### PR TITLE
[MOD-14806]: Refactor COLLECT storage: split by SORTBY axis and defer sort-key write

### DIFF
--- a/src/redisearch_rs/reducers/src/collect/heap.rs
+++ b/src/redisearch_rs/reducers/src/collect/heap.rs
@@ -48,11 +48,6 @@ impl<D: Ord> RankingKey<D> {
     }
 
     /// The sort-key snapshot, in `SORTBY` order (an absent key is `None`).
-    ///
-    /// The heap keeps these for ranking only, but
-    /// [`HeapStorage`][super::storage::HeapStorage] also exposes them at drain
-    /// time so the remote reducer can re-attach the sort columns it deferred
-    /// during projection.
     pub fn sort_vals(&self) -> &[Option<SharedValue>] {
         &self.sort_vals
     }

--- a/src/redisearch_rs/reducers/src/collect/heap.rs
+++ b/src/redisearch_rs/reducers/src/collect/heap.rs
@@ -46,6 +46,16 @@ impl<D: Ord> EntryKey<D> {
             doc_id,
         }
     }
+
+    /// The sort-key snapshot, in `SORTBY` order (an absent key is `None`).
+    ///
+    /// The heap keeps these for ranking only, but
+    /// [`HeapStorage`][super::storage::HeapStorage] also exposes them at drain
+    /// time so the remote reducer can re-attach the sort columns it deferred
+    /// during projection.
+    pub fn sort_vals(&self) -> &[Option<SharedValue>] {
+        &self.sort_vals
+    }
 }
 
 impl<D: Ord> PartialEq for EntryKey<D> {
@@ -88,9 +98,9 @@ impl<D: Ord> Ord for EntryKey<D> {
 
 /// Heap slot: the comparator key alongside the projected payload.
 ///
-/// `T` is the per-row payload the consumer (`Storage::Heap`) yields at
-/// finalize. Comparing only reads `key`, so the choice of `T` does not
-/// affect ranking.
+/// `T` is the per-row payload the consumer
+/// ([`HeapStorage`][super::storage::HeapStorage]) yields at finalize. Comparing
+/// only reads `key`, so the choice of `T` does not affect ranking.
 pub struct HeapEntry<D: Ord, T> {
     key: EntryKey<D>,
     projected: T,
@@ -112,6 +122,15 @@ impl<D: Ord, T> HeapEntry<D, T> {
     /// Return the projected payload.
     pub fn into_projected(self) -> T {
         self.projected
+    }
+
+    /// Split into the ranking key and the projected payload.
+    ///
+    /// Unlike [`Self::into_projected`], this keeps the [`EntryKey`] so a
+    /// consumer can read its [`EntryKey::sort_vals`] — needed by the remote
+    /// reducer's deferred sort-key merge.
+    pub fn into_parts(self) -> (EntryKey<D>, T) {
+        (self.key, self.projected)
     }
 }
 

--- a/src/redisearch_rs/reducers/src/collect/heap.rs
+++ b/src/redisearch_rs/reducers/src/collect/heap.rs
@@ -11,13 +11,13 @@
 //! top-K path.
 //!
 //! Wraps an `Ord`-driven [`MinMaxHeap`][min_max_heap::MinMaxHeap] over
-//! [`HeapEntry<D, T>`], where the comparator only reads the [`EntryKey`] half. The
+//! [`HeapEntry<D, T>`], where the comparator only reads the [`RankingKey`] half. The
 //! split lets the heap defer payload projection until a candidate's survival is
 //! confirmed.
 //!
 //! ## Deferred projection
 //!
-//! [`EntryKey`] owns a *snapshot* of the sort-key values, severed from the
+//! [`RankingKey`] owns a *snapshot* of the sort-key values, severed from the
 //! reused upstream [`RLookupRow`][rlookup::RLookupRow] buffer. The payload
 //! `T` is materialised by the caller only after the candidate has beaten the
 //! current worst — see [`super::storage`].
@@ -32,13 +32,13 @@ use value::comparison::cmp_fields;
 ///
 /// Bit `i` of `sort_asc_map` (LSB-first) selects ASC for the `i`-th key
 /// (set) or DESC (clear), matching `SORTASCMAP_GETASC` / `cmp_fields`.
-pub struct EntryKey<D: Ord> {
+pub struct RankingKey<D: Ord> {
     sort_vals: Box<[Option<SharedValue>]>,
     sort_asc_map: u64,
     doc_id: D,
 }
 
-impl<D: Ord> EntryKey<D> {
+impl<D: Ord> RankingKey<D> {
     pub const fn new(sort_vals: Box<[Option<SharedValue>]>, sort_asc_map: u64, doc_id: D) -> Self {
         Self {
             sort_vals,
@@ -58,26 +58,26 @@ impl<D: Ord> EntryKey<D> {
     }
 }
 
-impl<D: Ord> PartialEq for EntryKey<D> {
+impl<D: Ord> PartialEq for RankingKey<D> {
     fn eq(&self, other: &Self) -> bool {
         self.cmp(other) == Ordering::Equal
     }
 }
 
-impl<D: Ord> Eq for EntryKey<D> {}
+impl<D: Ord> Eq for RankingKey<D> {}
 
-impl<D: Ord> PartialOrd for EntryKey<D> {
+impl<D: Ord> PartialOrd for RankingKey<D> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<D: Ord> Ord for EntryKey<D> {
+impl<D: Ord> Ord for RankingKey<D> {
     fn cmp(&self, other: &Self) -> Ordering {
         debug_assert_eq!(
             self.sort_vals.len(),
             other.sort_vals.len(),
-            "EntryKey sort_vals length mismatch"
+            "RankingKey sort_vals length mismatch"
         );
         let pairs = self
             .sort_vals
@@ -102,16 +102,16 @@ impl<D: Ord> Ord for EntryKey<D> {
 /// ([`HeapStorage`][super::storage::HeapStorage]) yields at finalize. Comparing
 /// only reads `key`, so the choice of `T` does not affect ranking.
 pub struct HeapEntry<D: Ord, T> {
-    key: EntryKey<D>,
+    key: RankingKey<D>,
     projected: T,
 }
 
 impl<D: Ord, T> HeapEntry<D, T> {
-    pub const fn new(key: EntryKey<D>, projected: T) -> Self {
+    pub const fn new(key: RankingKey<D>, projected: T) -> Self {
         Self { key, projected }
     }
 
-    pub const fn key(&self) -> &EntryKey<D> {
+    pub const fn key(&self) -> &RankingKey<D> {
         &self.key
     }
 
@@ -126,10 +126,10 @@ impl<D: Ord, T> HeapEntry<D, T> {
 
     /// Split into the ranking key and the projected payload.
     ///
-    /// Unlike [`Self::into_projected`], this keeps the [`EntryKey`] so a
-    /// consumer can read its [`EntryKey::sort_vals`] — needed by the remote
+    /// Unlike [`Self::into_projected`], this keeps the [`RankingKey`] so a
+    /// consumer can read its [`RankingKey::sort_vals`] — needed by the remote
     /// reducer's deferred sort-key merge.
-    pub fn into_parts(self) -> (EntryKey<D>, T) {
+    pub fn into_parts(self) -> (RankingKey<D>, T) {
         (self.key, self.projected)
     }
 }

--- a/src/redisearch_rs/reducers/src/collect/local.rs
+++ b/src/redisearch_rs/reducers/src/collect/local.rs
@@ -230,7 +230,8 @@ impl LocalCollectCtx {
     }
 
     /// Deserialize the shard payload carried by `row` into [`RLookupRow`]s,
-    /// honouring `LIMIT` via [`Storage::insert_entry`].
+    /// dispatching each item to the array or heap arm of [`Storage`] under the
+    /// configured `LIMIT`.
     pub fn add(&mut self, r: &LocalCollectReducer, row: &RLookupRow) {
         let Some(Value::Array(items)) = row.get(r.input_key).map(|p| &**p) else {
             tracing_assert::debug_assert_warn!(
@@ -248,11 +249,14 @@ impl LocalCollectCtx {
                 );
                 continue;
             }
-            self.storage.insert_entry(
-                || snapshot_sort_keys(r.fields.sort_key_names(), item),
-                (),
-                || r.fields.prepare_row(item, &mut self.lookup),
-            );
+            match &mut self.storage {
+                Storage::Array(a) => a.push(|| r.fields.prepare_row(item, &mut self.lookup)),
+                Storage::Heap(h) => h.consider(
+                    snapshot_sort_keys(r.fields.sort_key_names(), item),
+                    (),
+                    || r.fields.prepare_row(item, &mut self.lookup),
+                ),
+            }
         }
     }
 

--- a/src/redisearch_rs/reducers/src/collect/local.rs
+++ b/src/redisearch_rs/reducers/src/collect/local.rs
@@ -32,7 +32,7 @@ use rlookup::{RLookup, RLookupKey, RLookupKeyFlag, RLookupRow};
 use value::{SharedValue, Value};
 
 use crate::Reducer;
-use crate::collect::storage::Storage;
+use crate::collect::storage::{ProjectedRow, Storage};
 
 /// Look up `name` in a shard-payload item (`Map` or flat `Array`).
 ///
@@ -250,11 +250,13 @@ impl LocalCollectCtx {
                 continue;
             }
             match &mut self.storage {
-                Storage::Array(a) => a.push(|| r.fields.prepare_row(item, &mut self.lookup)),
+                Storage::Array(a) => {
+                    a.push(|| ProjectedRow::new(r.fields.prepare_row(item, &mut self.lookup)))
+                }
                 Storage::Heap(h) => h.consider(
                     snapshot_sort_keys(r.fields.sort_key_names(), item),
                     (),
-                    || r.fields.prepare_row(item, &mut self.lookup),
+                    || ProjectedRow::new(r.fields.prepare_row(item, &mut self.lookup)),
                 ),
             }
         }
@@ -276,7 +278,8 @@ impl LocalCollectCtx {
             .map(|k| (k, SharedValue::new_string(k.name().to_bytes().to_vec())))
             .collect();
 
-        SharedValue::new_array(self.storage.drain().map(|row| {
+        SharedValue::new_array(self.storage.drain().map(|projected| {
+            let row = projected.row();
             SharedValue::new_map(
                 template
                     .iter()

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -27,11 +27,9 @@ use crate::collect::storage::{ProjectedRow, Storage};
 
 /// Field-selection state: `FIELDS *` vs explicit list.
 ///
-/// Sort keys live in both variants and feed the heap comparator. In
-/// [`Fields::Specific`] mode they are *not* projected per row: the shard path
-/// re-attaches them at finalize from the ranking-key snapshot (see
-/// [`Fields::deferred_sort_keys`]), so a stored row never duplicates the sort
-/// values already held in the ranking key.
+/// Sort keys live in both variants and feed the heap comparator;
+/// [`Fields::deferred_sort_keys`] covers how [`Fields::Specific`] keeps them out
+/// of the per-row projection.
 enum Fields<'a> {
     /// `FIELDS *` mode. Non-[`RLookupKeyFlag::Hidden`] keys in `src_lookup`
     /// are emitted; the lookup is re-walked per call so an upstream
@@ -55,9 +53,9 @@ impl<'a> Fields<'a> {
         }
     }
 
-    /// Keys to project per row in [`RemoteCollectCtx::add`]:
-    /// [`Fields::Specific`] projects only its explicit `field_keys` (the SORTBY
-    /// columns are deferred — see [`Fields::deferred_sort_keys`]).
+    /// Keys to project per row in [`RemoteCollectCtx::add`]. [`Fields::Specific`]
+    /// projects only `field_keys`; its sort columns are deferred (see
+    /// [`Fields::deferred_sort_keys`]).
     fn get_keys_add(&self) -> impl Iterator<Item = &'a RLookupKey<'a>> + '_ {
         match self {
             Self::All { src_lookup, .. } => Either::Left(
@@ -288,13 +286,9 @@ impl RemoteCollectCtx {
     /// [`LocalCollectCtx::finalize`][crate::collect::local::LocalCollectCtx::finalize]
     /// reconstructs the client-facing result from the emitted payload.
     ///
-    /// On the shard (`is_internal`) heap path the coordinator re-sorts, so the
-    /// SORTBY columns that [`Fields::get_keys_add`] dropped are merged back here
-    /// from each entry's ranking-key snapshot
-    /// ([`RankingKey::sort_vals`][super::heap::RankingKey::sort_vals]). This stays in
-    /// lockstep with [`Fields::build_template`], which adds those same columns to
-    /// the template under the same `is_internal` condition. The client-facing
-    /// path emits only the requested fields and merges nothing.
+    /// On the shard (`is_internal`) heap path the [`Fields::deferred_sort_keys`]
+    /// are merged back into each row from its ranking-key snapshot, matching the
+    /// `is_internal` columns [`Fields::build_template`] adds.
     pub fn finalize(&mut self, r: &RemoteCollectReducer<'_>) -> SharedValue {
         let template = r.fields.build_template(r.is_internal);
         let to_map = |row: &RLookupRow<'static>| {
@@ -314,8 +308,8 @@ impl RemoteCollectCtx {
             Storage::Array(a) => Either::Left(a.drain().map(|projected| to_map(projected.row()))),
             Storage::Heap(h) => Either::Right(h.drain().map(|entry| {
                 let (ranking_key, projected) = entry.into_parts();
-                // Leave the projected-only representation to build the wire row:
-                // projected fields plus the deferred sort columns.
+                // Start from the projected fields, then add the deferred sort
+                // columns to form the wire row.
                 let mut row = projected.into_row();
                 // `sort_extras` and the snapshot share SORTBY order, so the
                 // zip pairs each key with its value; a value overlapping a

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -23,7 +23,7 @@ use rlookup::{RLookup, RLookupKey, RLookupKeyFlag, RLookupRow};
 use value::SharedValue;
 
 use crate::Reducer;
-use crate::collect::storage::Storage;
+use crate::collect::storage::{ProjectedRow, Storage};
 
 /// Field-selection state: `FIELDS *` vs explicit list.
 ///
@@ -267,7 +267,7 @@ impl RemoteCollectCtx {
                     dst.write_key(key, v.clone());
                 }
             }
-            dst
+            ProjectedRow::new(dst)
         };
         match &mut self.storage {
             Storage::Array(a) => a.push(project),
@@ -311,9 +311,12 @@ impl RemoteCollectCtx {
             &[]
         };
         let rows = match &mut self.storage {
-            Storage::Array(a) => Either::Left(a.drain().map(|row| to_map(&row))),
+            Storage::Array(a) => Either::Left(a.drain().map(|projected| to_map(projected.row()))),
             Storage::Heap(h) => Either::Right(h.drain().map(|entry| {
-                let (ranking_key, mut row) = entry.into_parts();
+                let (ranking_key, projected) = entry.into_parts();
+                // Leave the projected-only representation to build the wire row:
+                // projected fields plus the deferred sort columns.
+                let mut row = projected.into_row();
                 // `sort_extras` and the snapshot share SORTBY order, so the
                 // zip pairs each key with its value; a value overlapping a
                 // projected field rewrites the same `dstidx` idempotently.

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -55,11 +55,9 @@ impl<'a> Fields<'a> {
         }
     }
 
-    /// Keys to project per row in [`RemoteCollectCtx::add`].
-    ///
-    /// [`Fields::Specific`] projects only its explicit `field_keys`; the SORTBY
-    /// columns are deferred (see [`Fields::deferred_sort_keys`]) so a stored row
-    /// never duplicates the sort values already held in the ranking key.
+    /// Keys to project per row in [`RemoteCollectCtx::add`]:
+    /// [`Fields::Specific`] projects only its explicit `field_keys` (the SORTBY
+    /// columns are deferred — see [`Fields::deferred_sort_keys`]).
     fn get_keys_add(&self) -> impl Iterator<Item = &'a RLookupKey<'a>> + '_ {
         match self {
             Self::All { src_lookup, .. } => Either::Left(

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -27,8 +27,11 @@ use crate::collect::storage::Storage;
 
 /// Field-selection state: `FIELDS *` vs explicit list.
 ///
-/// Sort keys live in both variants; they feed the heap comparator and, in
-/// [`Fields::Specific`] mode, append to the per-row projection.
+/// Sort keys live in both variants and feed the heap comparator. In
+/// [`Fields::Specific`] mode they are *not* projected per row: the shard path
+/// re-attaches them at finalize from the ranking-key snapshot (see
+/// [`Fields::deferred_sort_keys`]), so a stored row never duplicates the sort
+/// values already held in the ranking key.
 enum Fields<'a> {
     /// `FIELDS *` mode. Non-[`RLookupKeyFlag::Hidden`] keys in `src_lookup`
     /// are emitted; the lookup is re-walked per call so an upstream
@@ -53,6 +56,10 @@ impl<'a> Fields<'a> {
     }
 
     /// Keys to project per row in [`RemoteCollectCtx::add`].
+    ///
+    /// [`Fields::Specific`] projects only its explicit `field_keys`; the SORTBY
+    /// columns are deferred (see [`Fields::deferred_sort_keys`]) so a stored row
+    /// never duplicates the sort values already held in the ranking key.
     fn get_keys_add(&self) -> impl Iterator<Item = &'a RLookupKey<'a>> + '_ {
         match self {
             Self::All { src_lookup, .. } => Either::Left(
@@ -60,10 +67,22 @@ impl<'a> Fields<'a> {
                     .iter()
                     .filter(|k| !k.flags.contains(RLookupKeyFlag::Hidden)),
             ),
-            Self::Specific {
-                field_keys,
-                sort_keys,
-            } => Either::Right(field_keys.iter().copied().chain(sort_keys.iter().copied())),
+            Self::Specific { field_keys, .. } => Either::Right(field_keys.iter().copied()),
+        }
+    }
+
+    /// SORTBY keys to re-merge into each heap row at finalize, on the shard
+    /// (`is_internal`) path.
+    ///
+    /// Only [`Fields::Specific`] defers them: [`Fields::get_keys_add`] drops the
+    /// sort columns from the per-row projection, but the coordinator's re-sort
+    /// still needs them, so the shard path writes them back from the
+    /// ranking-key snapshot. [`Fields::All`] already projects every non-hidden
+    /// field, so it has nothing to defer.
+    fn deferred_sort_keys(&self) -> &[&'a RLookupKey<'a>] {
+        match self {
+            Self::Specific { sort_keys, .. } => sort_keys,
+            Self::All { .. } => &[],
         }
     }
 
@@ -231,25 +250,18 @@ impl RemoteCollectCtx {
         }
     }
 
-    /// Project the source row's field values into a stored [`RLookupRow`]
-    /// and snapshot the sort-key values for the heap comparator.
+    /// Project the source row's field values into a stored [`RLookupRow`].
     ///
-    /// The array path ignores the snapshot closure entirely. The heap path
-    /// uses the snapshot to drive comparisons, dropping doomed candidates
-    /// without paying the row-projection cost.
+    /// Dispatches on the storage family: the array path simply buffers the row,
+    /// while the heap path additionally snapshots the sort-key values to drive
+    /// the comparator, dropping doomed candidates before paying the
+    /// row-projection cost. The snapshot is built only on the heap path.
     pub fn add(
         &mut self,
         r: &RemoteCollectReducer<'_>,
         row: &RLookupRow<'_>,
         doc_id: ffi::t_docId,
     ) {
-        let sort_vals = || -> Box<[Option<SharedValue>]> {
-            r.fields
-                .sort_keys()
-                .iter()
-                .map(|key| row.get(key).cloned())
-                .collect()
-        };
         let project = || {
             let mut dst = RLookupRow::new();
             for key in r.fields.get_keys_add() {
@@ -259,22 +271,62 @@ impl RemoteCollectCtx {
             }
             dst
         };
-        self.storage.insert_entry(sort_vals, doc_id, project);
+        match &mut self.storage {
+            Storage::Array(a) => a.push(project),
+            Storage::Heap(h) => {
+                let sort_vals = r
+                    .fields
+                    .sort_keys()
+                    .iter()
+                    .map(|key| row.get(key).cloned())
+                    .collect();
+                h.consider(sort_vals, doc_id, project);
+            }
+        }
     }
 
     /// Serialize the buffered rows into an array of maps. Keys absent from a
     /// row are omitted; on the cluster path
     /// [`LocalCollectCtx::finalize`][crate::collect::local::LocalCollectCtx::finalize]
     /// reconstructs the client-facing result from the emitted payload.
+    ///
+    /// On the shard (`is_internal`) heap path the coordinator re-sorts, so the
+    /// SORTBY columns that [`Fields::get_keys_add`] dropped are merged back here
+    /// from each entry's ranking-key snapshot
+    /// ([`EntryKey::sort_vals`][super::heap::EntryKey::sort_vals]). This stays in
+    /// lockstep with [`Fields::build_template`], which adds those same columns to
+    /// the template under the same `is_internal` condition. The client-facing
+    /// path emits only the requested fields and merges nothing.
     pub fn finalize(&mut self, r: &RemoteCollectReducer<'_>) -> SharedValue {
-        let rows = self.storage.drain();
         let template = r.fields.build_template(r.is_internal);
-        SharedValue::new_array(rows.map(|row| {
-            let entries: Vec<_> = template
-                .iter()
-                .filter_map(|(key, name)| row.get(key).map(|v| (name.clone(), v.clone())))
-                .collect();
-            SharedValue::new_map(entries)
-        }))
+        let to_map = |row: &RLookupRow<'static>| {
+            SharedValue::new_map(
+                template
+                    .iter()
+                    .filter_map(|(key, name)| row.get(key).map(|v| (name.clone(), v.clone())))
+                    .collect::<Vec<_>>(),
+            )
+        };
+        let sort_extras: &[&RLookupKey] = if r.is_internal {
+            r.fields.deferred_sort_keys()
+        } else {
+            &[]
+        };
+        let rows = match &mut self.storage {
+            Storage::Array(a) => Either::Left(a.drain().map(|row| to_map(&row))),
+            Storage::Heap(h) => Either::Right(h.drain().map(|entry| {
+                let (ranking_key, mut row) = entry.into_parts();
+                // `sort_extras` and the snapshot share SORTBY order, so the
+                // zip pairs each key with its value; a value overlapping a
+                // projected field rewrites the same `dstidx` idempotently.
+                for (sort_key, val) in sort_extras.iter().zip(ranking_key.sort_vals()) {
+                    if let Some(val) = val {
+                        row.write_key(sort_key, val.clone());
+                    }
+                }
+                to_map(&row)
+            })),
+        };
+        SharedValue::new_array(rows)
     }
 }

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -27,9 +27,11 @@ use crate::collect::storage::{ProjectedRow, Storage};
 
 /// Field-selection state: `FIELDS *` vs explicit list.
 ///
-/// Sort keys live in both variants and feed the heap comparator;
-/// [`Fields::deferred_sort_keys`] covers how [`Fields::Specific`] keeps them out
-/// of the per-row projection.
+/// Sort keys feed the heap comparator in both variants. [`Fields::Specific`]
+/// deliberately excludes them from the per-row projection and merges them back at
+/// finalize (see [`Fields::build_template`]); [`Fields::All`] carries them only
+/// because they are non-hidden lookup fields it already projects, not by any
+/// special handling.
 enum Fields<'a> {
     /// `FIELDS *` mode. Non-[`RLookupKeyFlag::Hidden`] keys in `src_lookup`
     /// are emitted; the lookup is re-walked per call so an upstream
@@ -54,8 +56,8 @@ impl<'a> Fields<'a> {
     }
 
     /// Keys to project per row in [`RemoteCollectCtx::add`]. [`Fields::Specific`]
-    /// projects only `field_keys`; its sort columns are deferred (see
-    /// [`Fields::deferred_sort_keys`]).
+    /// projects only `field_keys`; its sort columns are merged back at finalize
+    /// (see [`Fields::build_template`]).
     fn get_keys_add(&self) -> impl Iterator<Item = &'a RLookupKey<'a>> + '_ {
         match self {
             Self::All { src_lookup, .. } => Either::Left(
@@ -67,42 +69,41 @@ impl<'a> Fields<'a> {
         }
     }
 
-    /// SORTBY keys to re-merge into each heap row at finalize, on the shard
-    /// (`is_internal`) path.
+    /// The `(key→name template, sort keys to merge)` pair for
+    /// [`RemoteCollectCtx::finalize`].
     ///
-    /// Only [`Fields::Specific`] defers them: [`Fields::get_keys_add`] drops the
-    /// sort columns from the per-row projection, but the coordinator's re-sort
-    /// still needs them, so the shard path writes them back from the
-    /// ranking-key snapshot. [`Fields::All`] already projects every non-hidden
-    /// field, so it has nothing to defer.
-    fn deferred_sort_keys(&self) -> &[&'a RLookupKey<'a>] {
-        match self {
-            Self::Specific { sort_keys, .. } => sort_keys,
-            Self::All { .. } => &[],
-        }
-    }
-
-    /// Key→name template for [`RemoteCollectCtx::finalize`].
-    ///
-    /// `include_sort_extras` extends the [`Fields::Specific`] projection
-    /// with sort keys (shard path: `true`; client-facing: `false`).
-    fn build_template(&self, include_sort_extras: bool) -> Vec<(&'a RLookupKey<'a>, SharedValue)> {
-        let keys: Vec<&RLookupKey<'a>> = match self {
-            Self::All { src_lookup, .. } => src_lookup
-                .iter()
-                .filter(|k| !k.flags.contains(RLookupKeyFlag::Hidden))
-                .collect(),
+    /// When `include_sort_extras` (the shard path), the [`Fields::Specific`]
+    /// template gains its SORTBY keys and they are returned as the merge set so
+    /// `finalize` re-attaches them from the ranking-key snapshot; otherwise the
+    /// merge set is empty. [`Fields::All`] already projects every field.
+    fn build_template(
+        &self,
+        include_sort_extras: bool,
+    ) -> (
+        Vec<(&'a RLookupKey<'a>, SharedValue)>,
+        &[&'a RLookupKey<'a>],
+    ) {
+        let (keys, sort_extras): (Vec<&RLookupKey<'a>>, &[&RLookupKey<'a>]) = match self {
+            Self::All { src_lookup, .. } => (
+                src_lookup
+                    .iter()
+                    .filter(|k| !k.flags.contains(RLookupKeyFlag::Hidden))
+                    .collect(),
+                &[],
+            ),
             Self::Specific {
                 field_keys,
                 sort_keys,
             } => {
                 let extras: &[&RLookupKey<'a>] = if include_sort_extras { sort_keys } else { &[] };
-                dedup_by_dstidx(field_keys, extras)
+                (dedup_by_dstidx(field_keys, extras), extras)
             }
         };
-        keys.into_iter()
+        let template = keys
+            .into_iter()
             .map(|k| (k, SharedValue::new_string(k.name().to_bytes().to_vec())))
-            .collect()
+            .collect();
+        (template, sort_extras)
     }
 }
 
@@ -286,11 +287,11 @@ impl RemoteCollectCtx {
     /// [`LocalCollectCtx::finalize`][crate::collect::local::LocalCollectCtx::finalize]
     /// reconstructs the client-facing result from the emitted payload.
     ///
-    /// On the shard (`is_internal`) heap path the [`Fields::deferred_sort_keys`]
-    /// are merged back into each row from its ranking-key snapshot, matching the
-    /// `is_internal` columns [`Fields::build_template`] adds.
+    /// On the shard (`is_internal`) heap path the SORTBY columns are re-attached
+    /// from each entry's ranking-key snapshot; the client path emits only the
+    /// requested fields.
     pub fn finalize(&mut self, r: &RemoteCollectReducer<'_>) -> SharedValue {
-        let template = r.fields.build_template(r.is_internal);
+        let (template, sort_extras) = r.fields.build_template(r.is_internal);
         let to_map = |row: &RLookupRow<'static>| {
             SharedValue::new_map(
                 template
@@ -299,24 +300,16 @@ impl RemoteCollectCtx {
                     .collect::<Vec<_>>(),
             )
         };
-        let sort_extras: &[&RLookupKey] = if r.is_internal {
-            r.fields.deferred_sort_keys()
-        } else {
-            &[]
-        };
         let rows = match &mut self.storage {
             Storage::Array(a) => Either::Left(a.drain().map(|projected| to_map(projected.row()))),
             Storage::Heap(h) => Either::Right(h.drain().map(|entry| {
                 let (ranking_key, projected) = entry.into_parts();
-                // Start from the projected fields, then add the deferred sort
-                // columns to form the wire row.
                 let mut row = projected.into_row();
-                // `sort_extras` and the snapshot share SORTBY order, so the
-                // zip pairs each key with its value; a value overlapping a
-                // projected field rewrites the same `dstidx` idempotently.
-                for (sort_key, val) in sort_extras.iter().zip(ranking_key.sort_vals()) {
+                // `sort_extras` (names) and the snapshot (values) share SORTBY
+                // order, so the i-th key takes the i-th value.
+                for (key, val) in sort_extras.iter().zip(ranking_key.sort_vals()) {
                     if let Some(val) = val {
-                        row.write_key(sort_key, val.clone());
+                        row.write_key(key, val.clone());
                     }
                 }
                 to_map(&row)

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -291,7 +291,7 @@ impl RemoteCollectCtx {
     /// On the shard (`is_internal`) heap path the coordinator re-sorts, so the
     /// SORTBY columns that [`Fields::get_keys_add`] dropped are merged back here
     /// from each entry's ranking-key snapshot
-    /// ([`EntryKey::sort_vals`][super::heap::EntryKey::sort_vals]). This stays in
+    /// ([`RankingKey::sort_vals`][super::heap::RankingKey::sort_vals]). This stays in
     /// lockstep with [`Fields::build_template`], which adds those same columns to
     /// the template under the same `is_internal` condition. The client-facing
     /// path emits only the requested fields and merges nothing.

--- a/src/redisearch_rs/reducers/src/collect/storage.rs
+++ b/src/redisearch_rs/reducers/src/collect/storage.rs
@@ -20,7 +20,7 @@ use min_max_heap::MinMaxHeap;
 use rlookup::RLookupRow;
 use value::SharedValue;
 
-use super::heap::{EntryKey, HeapEntry};
+use super::heap::{HeapEntry, RankingKey};
 
 /// Default count for `SORTBY` results when no explicit `LIMIT` is provided,
 /// matching the C implementation's `DEFAULT_LIMIT`.
@@ -121,9 +121,9 @@ impl ArrayStorage {
 
 /// Top-K storage for the `SORTBY` path.
 ///
-/// Keeps the best `offset + count` candidates under the [`EntryKey`]
+/// Keeps the best `offset + count` candidates under the [`RankingKey`]
 /// comparator, draining best→worst. Unlike [`ArrayStorage`], it owns the sort
-/// context: each candidate's sort-key snapshot lives in its [`EntryKey`] (which
+/// context: each candidate's sort-key snapshot lives in its [`RankingKey`] (which
 /// doubles as the cap-check key), so the projected row never has to carry it.
 pub struct HeapStorage<D: Ord> {
     heap: MinMaxHeap<HeapEntry<D, RLookupRow<'static>>>,
@@ -146,10 +146,10 @@ impl<D: Ord> HeapStorage<D> {
     /// Offer a candidate to the bounded top-K.
     ///
     /// `sort_vals` is the candidate's sort-key snapshot; it forms the ranking
-    /// [`EntryKey`] and is compared against the current worst survivor *before*
+    /// [`RankingKey`] and is compared against the current worst survivor *before*
     /// `project` runs, so `project` is invoked only for a candidate that is
     /// actually retained. `doc_id` breaks ties when the sort keys compare equal
-    /// (see [`EntryKey`]).
+    /// (see [`RankingKey`]).
     pub fn consider(
         &mut self,
         sort_vals: Box<[Option<SharedValue>]>,
@@ -160,7 +160,7 @@ impl<D: Ord> HeapStorage<D> {
         if max_size == 0 {
             return;
         }
-        let cand_key = EntryKey::new(sort_vals, self.sort_asc_map, doc_id);
+        let cand_key = RankingKey::new(sort_vals, self.sort_asc_map, doc_id);
         if self.heap.len() < max_size {
             self.heap.push(HeapEntry::new(cand_key, project()));
         } else {
@@ -177,9 +177,9 @@ impl<D: Ord> HeapStorage<D> {
     /// Drain the retained entries best→worst, sliced as
     /// `skip(offset).take(count)`.
     ///
-    /// Each [`HeapEntry`] still pairs the row with its ranking [`EntryKey`]:
+    /// Each [`HeapEntry`] still pairs the row with its ranking [`RankingKey`]:
     /// callers that only need rows map with [`HeapEntry::into_projected`], while
-    /// the remote reducer reads [`EntryKey::sort_vals`] (via
+    /// the remote reducer reads [`RankingKey::sort_vals`] (via
     /// [`HeapEntry::into_parts`]) to rebuild the wire row.
     pub fn drain(&mut self) -> impl ExactSizeIterator<Item = HeapEntry<D, RLookupRow<'static>>> {
         std::mem::take(&mut self.heap)

--- a/src/redisearch_rs/reducers/src/collect/storage.rs
+++ b/src/redisearch_rs/reducers/src/collect/storage.rs
@@ -176,16 +176,15 @@ impl<D: Ord> HeapStorage<D> {
         project: impl FnOnce() -> ProjectedRow,
     ) {
         let max_size = self.offset.saturating_add(self.count);
-        if max_size == 0 {
-            return;
-        }
+        // `LIMIT count` is parse-validated `>= 1`, so a zero cap never reaches here.
+        debug_assert!(max_size > 0, "heap storage built with a zero cap");
         let cand_key = RankingKey::new(sort_vals, self.sort_asc_map, doc_id);
         if self.heap.len() < max_size {
             self.heap.push(HeapEntry::new(cand_key, project()));
         } else {
             // `peek_min` is the worst survivor under the "best = max"
-            // convention (see [`super::heap`]); the unwrap is sound because a
-            // full heap with `max_size > 0` is non-empty.
+            // convention (see [`super::heap`]); a full heap is non-empty per the
+            // `max_size > 0` assertion above, so the unwrap holds.
             let worst = self.heap.peek_min().expect("heap at cap is non-empty");
             if cand_key > *worst.key() {
                 self.heap.push_pop_min(HeapEntry::new(cand_key, project()));

--- a/src/redisearch_rs/reducers/src/collect/storage.rs
+++ b/src/redisearch_rs/reducers/src/collect/storage.rs
@@ -192,14 +192,10 @@ impl<D: Ord> HeapStorage<D> {
         }
     }
 
-    /// Drain the retained entries best→worst, sliced as
-    /// `skip(offset).take(count)`.
+    /// Drain the retained entries best→worst, sliced as `skip(offset).take(count)`.
     ///
-    /// Each [`HeapEntry`] still pairs the [`ProjectedRow`] with its
-    /// [`RankingKey`]: callers that only need the value map with
-    /// [`HeapEntry::into_projected`], while the remote reducer reads
-    /// [`RankingKey::sort_vals`] (via [`HeapEntry::into_parts`]) to rebuild the
-    /// wire row.
+    /// Yields whole [`HeapEntry`]s, not just the [`ProjectedRow`], so the remote
+    /// reducer can read each [`RankingKey`] to rebuild the wire row.
     pub fn drain(&mut self) -> impl ExactSizeIterator<Item = HeapEntry<D, ProjectedRow>> {
         std::mem::take(&mut self.heap)
             .into_vec_desc()

--- a/src/redisearch_rs/reducers/src/collect/storage.rs
+++ b/src/redisearch_rs/reducers/src/collect/storage.rs
@@ -32,14 +32,9 @@ pub const DEFAULT_LIMIT: u64 = 10;
 /// number of rows we will retain.
 const INITIAL_CAPACITY_CAP: usize = 16_384;
 
-/// The *value* held by the storage: the projected (collected) fields, in a type
-/// distinct from the [`RankingKey`] so the two storage axes stay explicit. The
-/// ranking key decides order; the `ProjectedRow` is the content — hence the unit
-/// any content-based identity would key on.
-///
-/// Naming the role does not prove the row holds *only* projected fields; that is
-/// upheld by the `project` closure each reducer passes to [`ArrayStorage::push`]
-/// / [`HeapStorage::consider`].
+/// The *value* held by the storage: the projected (collected) fields, kept in a
+/// type distinct from [`RankingKey`] so that order (the ranking key) and content
+/// (this row) stay explicit.
 pub struct ProjectedRow(RLookupRow<'static>);
 
 impl ProjectedRow {
@@ -89,16 +84,12 @@ impl<D: Ord> Storage<D> {
         }
     }
 
-    /// Drain the retained values, sliced as `skip(offset).take(count)`.
+    /// Drain the retained values, sliced as `skip(offset).take(count)`: the array
+    /// arm in insertion order, the heap arm best→worst.
     ///
-    /// - **Array arm** yields values in insertion order.
-    /// - **Heap arm** yields values best→worst (matching the SORTBY result order).
-    ///
-    /// The heap arm discards each entry's [`RankingKey`]
-    /// ([`HeapEntry::into_projected`]) because the client-facing local reducer
-    /// never re-emits the sort columns. The remote reducer, which *does* re-emit
-    /// them on the shard path, drains [`HeapStorage`] directly instead — see
-    /// [`RemoteCollectCtx::finalize`][super::remote::RemoteCollectCtx::finalize].
+    /// The heap arm discards each entry's [`RankingKey`], which suits the
+    /// client-facing local reducer. The remote reducer, which re-emits the sort
+    /// columns on the shard path, drains [`HeapStorage`] directly instead.
     pub fn drain(&mut self) -> impl ExactSizeIterator<Item = ProjectedRow> {
         match self {
             Self::Array(a) => Either::Left(a.drain()),

--- a/src/redisearch_rs/reducers/src/collect/storage.rs
+++ b/src/redisearch_rs/reducers/src/collect/storage.rs
@@ -7,17 +7,20 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Bounded storage shared by the COLLECT reducer variants. Two modes:
+//! Bounded storage shared by the COLLECT reducer variants, split by the
+//! `SORTBY` axis into two family types:
 //!
-//! - [`Storage::Array`] — preserves arrival order under an `offset + count`
-//!   cap and drops excess inserts in O(1) without paying any projection
-//!   cost. Suitable when ranking is not needed.
-//! - [`Storage::Heap`] — retains the top-`(offset + count)` survivors under
-//!   a comparator driven by `sort_asc_map`, wrapping the [`MinMaxHeap`]
-//!   primitive defined in [`super::heap`] and draining best→worst.
-//!   Suitable when a ranked top-K is needed.
-
-use std::marker::PhantomData;
+//! - [`ArrayStorage`] — preserves arrival order under an `offset + count` cap
+//!   and drops excess inserts in O(1) without paying any projection cost. Used
+//!   when ranking is not needed (no `SORTBY`).
+//! - [`HeapStorage`] — retains the top-`(offset + count)` survivors under a
+//!   comparator driven by `sort_asc_map`, wrapping the [`MinMaxHeap`] primitive
+//!   from [`super::heap`] and draining best→worst. Used for the ranked
+//!   `COLLECT … SORTBY [LIMIT]` path.
+//!
+//! [`Storage`] is a thin enum that selects one family; the reducer dispatches
+//! array-vs-heap once, in its `add` method, so only the heap path ever builds a
+//! sort-key snapshot.
 
 use itertools::Either;
 use min_max_heap::MinMaxHeap;
@@ -36,23 +39,20 @@ pub const DEFAULT_LIMIT: u64 = 10;
 /// number of rows we will retain.
 const INITIAL_CAPACITY_CAP: usize = 16_384;
 
+/// Bounded COLLECT storage, selecting one family type by the `SORTBY` axis.
+///
+/// `D` is the doc-id tie-breaker carried by [`HeapStorage`]; the array path
+/// never ranks, so [`ArrayStorage`] is free of it.
 pub enum Storage<D: Ord> {
-    Array {
-        buf: Vec<RLookupRow<'static>>,
-        offset: usize,
-        count: usize,
-        _marker: PhantomData<D>,
-    },
-    Heap {
-        heap: MinMaxHeap<HeapEntry<D, RLookupRow<'static>>>,
-        sort_asc_map: u64,
-        offset: usize,
-        count: usize,
-    },
+    Array(ArrayStorage),
+    Heap(HeapStorage<D>),
 }
 
 impl<D: Ord> Storage<D> {
-    /// Resolve `(offset, count)` and pre-size the buffer/heap.
+    /// Select the family by `sortby` and resolve `(offset, count)`.
+    ///
+    /// Without an explicit `LIMIT`, the array path falls back to the global
+    /// `maxAggregateResults` and the heap path to [`DEFAULT_LIMIT`].
     pub fn new(sortby: bool, limit: Option<(u64, u64)>, sort_asc_map: u64) -> Self {
         let (offset, count) = match (sortby, limit) {
             (_, Some((o, c))) => (o as usize, c as usize),
@@ -62,121 +62,137 @@ impl<D: Ord> Storage<D> {
             (false, None) => (0, unsafe { ffi::RSGlobalConfig.maxAggregateResults }),
             (true, None) => (0, DEFAULT_LIMIT as usize),
         };
-        let initial_capacity = offset.saturating_add(count).min(INITIAL_CAPACITY_CAP);
         if sortby {
-            Self::Heap {
-                heap: MinMaxHeap::with_capacity(initial_capacity),
-                sort_asc_map,
-                offset,
-                count,
-            }
+            Self::Heap(HeapStorage::new(sort_asc_map, offset, count))
         } else {
-            Self::Array {
-                buf: Vec::with_capacity(initial_capacity),
-                offset,
-                count,
-                _marker: PhantomData,
-            }
+            Self::Array(ArrayStorage::new(offset, count))
         }
     }
 
-    /// Insert an entry under the cap. Two-phase to preserve the
-    /// deferred-projection invariant:
+    /// Drain the retained rows, sliced as `skip(offset).take(count)`.
     ///
-    /// - `sort_vals` is invoked only on the heap path (the array path
-    ///   ignores it).
-    /// - `project` is invoked only when the entry will actually be
-    ///   retained (i.e. on the heap path, only when the candidate beats
-    ///   the current worst).
+    /// - **Array arm** yields rows in insertion order.
+    /// - **Heap arm** yields rows best→worst (matching the SORTBY result order).
     ///
-    /// Returns `true` if the entry was buffered, `false` if it was dropped.
-    ///
-    /// `doc_id` is only consulted on the heap path, where it acts as a
-    /// deterministic tie-breaker when sort keys compare equal. Callers
-    /// that don't need tie-breaking instantiate `Storage<()>` and pass
-    /// `()` here — `()`'s `Ord` impl makes the fallback a no-op.
-    pub fn insert_entry<S, P>(&mut self, sort_vals: S, doc_id: D, project: P) -> bool
-    where
-        S: FnOnce() -> Box<[Option<SharedValue>]>,
-        P: FnOnce() -> RLookupRow<'static>,
-    {
-        match self {
-            Self::Array {
-                buf, offset, count, ..
-            } => {
-                let max_size = offset.saturating_add(*count);
-                if buf.len() < max_size {
-                    buf.push(project());
-                    true
-                } else {
-                    false
-                }
-            }
-            Self::Heap {
-                heap,
-                sort_asc_map,
-                offset,
-                count,
-            } => {
-                let max_size = offset.saturating_add(*count);
-                let make_key = |sort_vals: S| EntryKey::new(sort_vals(), *sort_asc_map, doc_id);
-                if max_size == 0 {
-                    return false;
-                }
-                if heap.len() < max_size {
-                    let key = make_key(sort_vals);
-                    heap.push(HeapEntry::new(key, project()));
-                    true
-                } else {
-                    let cand_key = make_key(sort_vals);
-                    // `peek_min` returns the worst surviving candidate
-                    // under the "best = max" convention (see `heap`).
-                    // The unwrap is sound: `cap > 0` implies the heap is
-                    // non-empty once we've reached the cap.
-                    let worst = heap.peek_min().expect("heap at cap is non-empty");
-                    if cand_key > *worst.key() {
-                        heap.push_pop_min(HeapEntry::new(cand_key, project()));
-                        true
-                    } else {
-                        false
-                    }
-                }
-            }
-        }
-    }
-
-    /// Drain buffered rows, sliced as `skip(offset).take(count)`.
-    ///
-    /// - **Array path** yields rows in insertion order.
-    /// - **Heap path** yields rows best→worst (matching the SORTBY result
-    ///   order).
+    /// The heap arm discards each entry's sort-key snapshot
+    /// ([`HeapEntry::into_projected`]) because the client-facing local reducer
+    /// never re-emits the sort columns. The remote reducer, which *does* re-emit
+    /// them on the shard path, drains [`HeapStorage`] directly instead — see
+    /// [`RemoteCollectCtx::finalize`][super::remote::RemoteCollectCtx::finalize].
     pub fn drain(&mut self) -> impl ExactSizeIterator<Item = RLookupRow<'static>> {
-        // Sentinel left in place of `*self`. Empty Array, no allocation.
-        let taken = std::mem::replace(
-            self,
-            Self::Array {
-                buf: Vec::new(),
-                offset: 0,
-                count: 0,
-                _marker: PhantomData,
-            },
-        );
-        match taken {
-            Self::Array {
-                buf, offset, count, ..
-            } => Either::Left(buf.into_iter().skip(offset).take(count)),
-            Self::Heap {
-                heap,
-                offset,
-                count,
-                ..
-            } => Either::Right(
-                heap.into_vec_desc()
-                    .into_iter()
-                    .skip(offset)
-                    .take(count)
-                    .map(HeapEntry::into_projected),
-            ),
+        match self {
+            Self::Array(a) => Either::Left(a.drain()),
+            Self::Heap(h) => Either::Right(h.drain().map(HeapEntry::into_projected)),
         }
+    }
+}
+
+/// Arrival-ordered storage for the non-`SORTBY` path.
+///
+/// Holds at most `offset + count` rows and drops the rest without projecting
+/// them. Has no sort context at all.
+pub struct ArrayStorage {
+    buf: Vec<RLookupRow<'static>>,
+    offset: usize,
+    count: usize,
+}
+
+impl ArrayStorage {
+    fn new(offset: usize, count: usize) -> Self {
+        let initial_capacity = offset.saturating_add(count).min(INITIAL_CAPACITY_CAP);
+        Self {
+            buf: Vec::with_capacity(initial_capacity),
+            offset,
+            count,
+        }
+    }
+
+    /// Buffer one more row, dropping it once the `offset + count` cap is
+    /// reached. `project` runs only for a retained row, so a dropped row pays
+    /// no projection cost.
+    pub fn push(&mut self, project: impl FnOnce() -> RLookupRow<'static>) {
+        if self.buf.len() < self.offset.saturating_add(self.count) {
+            self.buf.push(project());
+        }
+    }
+
+    /// Drain the buffered rows in insertion order, sliced as
+    /// `skip(offset).take(count)`.
+    pub fn drain(&mut self) -> impl ExactSizeIterator<Item = RLookupRow<'static>> {
+        std::mem::take(&mut self.buf)
+            .into_iter()
+            .skip(self.offset)
+            .take(self.count)
+    }
+}
+
+/// Top-K storage for the `SORTBY` path.
+///
+/// Keeps the best `offset + count` candidates under the [`EntryKey`]
+/// comparator, draining best→worst. Unlike [`ArrayStorage`], it owns the sort
+/// context: each candidate's sort-key snapshot lives in its [`EntryKey`] (which
+/// doubles as the cap-check key), so the projected row never has to carry it.
+pub struct HeapStorage<D: Ord> {
+    heap: MinMaxHeap<HeapEntry<D, RLookupRow<'static>>>,
+    sort_asc_map: u64,
+    offset: usize,
+    count: usize,
+}
+
+impl<D: Ord> HeapStorage<D> {
+    fn new(sort_asc_map: u64, offset: usize, count: usize) -> Self {
+        let initial_capacity = offset.saturating_add(count).min(INITIAL_CAPACITY_CAP);
+        Self {
+            heap: MinMaxHeap::with_capacity(initial_capacity),
+            sort_asc_map,
+            offset,
+            count,
+        }
+    }
+
+    /// Offer a candidate to the bounded top-K.
+    ///
+    /// `sort_vals` is the candidate's sort-key snapshot; it forms the ranking
+    /// [`EntryKey`] and is compared against the current worst survivor *before*
+    /// `project` runs, so `project` is invoked only for a candidate that is
+    /// actually retained. `doc_id` breaks ties when the sort keys compare equal
+    /// (see [`EntryKey`]).
+    pub fn consider(
+        &mut self,
+        sort_vals: Box<[Option<SharedValue>]>,
+        doc_id: D,
+        project: impl FnOnce() -> RLookupRow<'static>,
+    ) {
+        let max_size = self.offset.saturating_add(self.count);
+        if max_size == 0 {
+            return;
+        }
+        let cand_key = EntryKey::new(sort_vals, self.sort_asc_map, doc_id);
+        if self.heap.len() < max_size {
+            self.heap.push(HeapEntry::new(cand_key, project()));
+        } else {
+            // `peek_min` is the worst survivor under the "best = max"
+            // convention (see [`super::heap`]); the unwrap is sound because a
+            // full heap with `max_size > 0` is non-empty.
+            let worst = self.heap.peek_min().expect("heap at cap is non-empty");
+            if cand_key > *worst.key() {
+                self.heap.push_pop_min(HeapEntry::new(cand_key, project()));
+            }
+        }
+    }
+
+    /// Drain the retained entries best→worst, sliced as
+    /// `skip(offset).take(count)`.
+    ///
+    /// Each [`HeapEntry`] still pairs the row with its ranking [`EntryKey`]:
+    /// callers that only need rows map with [`HeapEntry::into_projected`], while
+    /// the remote reducer reads [`EntryKey::sort_vals`] (via
+    /// [`HeapEntry::into_parts`]) to rebuild the wire row.
+    pub fn drain(&mut self) -> impl ExactSizeIterator<Item = HeapEntry<D, RLookupRow<'static>>> {
+        std::mem::take(&mut self.heap)
+            .into_vec_desc()
+            .into_iter()
+            .skip(self.offset)
+            .take(self.count)
     }
 }

--- a/src/redisearch_rs/reducers/src/collect/storage.rs
+++ b/src/redisearch_rs/reducers/src/collect/storage.rs
@@ -8,15 +8,8 @@
 */
 
 //! Bounded storage shared by the COLLECT reducer variants, split by the
-//! `SORTBY` axis into two family types:
-//!
-//! - [`ArrayStorage`] — preserves arrival order under an `offset + count` cap
-//!   and drops excess inserts in O(1) without paying any projection cost. Used
-//!   when ranking is not needed (no `SORTBY`).
-//! - [`HeapStorage`] — retains the top-`(offset + count)` survivors under a
-//!   comparator driven by `sort_asc_map`, wrapping the [`MinMaxHeap`] primitive
-//!   from [`super::heap`] and draining best→worst. Used for the ranked
-//!   `COLLECT … SORTBY [LIMIT]` path.
+//! `SORTBY` axis into two family types: [`ArrayStorage`] for the unranked path
+//! and [`HeapStorage`] for the ranked `COLLECT … SORTBY [LIMIT]` path.
 //!
 //! [`Storage`] is a thin enum that selects one family; the reducer dispatches
 //! array-vs-heap once, in its `add` method, so only the heap path ever builds a

--- a/src/redisearch_rs/reducers/src/collect/storage.rs
+++ b/src/redisearch_rs/reducers/src/collect/storage.rs
@@ -32,6 +32,33 @@ pub const DEFAULT_LIMIT: u64 = 10;
 /// number of rows we will retain.
 const INITIAL_CAPACITY_CAP: usize = 16_384;
 
+/// The *value* held by the storage: the projected (collected) fields, in a type
+/// distinct from the [`RankingKey`] so the two storage axes stay explicit. The
+/// ranking key decides order; the `ProjectedRow` is the content — hence the unit
+/// any content-based identity would key on.
+///
+/// Naming the role does not prove the row holds *only* projected fields; that is
+/// upheld by the `project` closure each reducer passes to [`ArrayStorage::push`]
+/// / [`HeapStorage::consider`].
+pub struct ProjectedRow(RLookupRow<'static>);
+
+impl ProjectedRow {
+    /// Wrap a freshly projected row.
+    pub const fn new(row: RLookupRow<'static>) -> Self {
+        Self(row)
+    }
+
+    /// Borrow the fields, e.g. to serialize the output map.
+    pub const fn row(&self) -> &RLookupRow<'static> {
+        &self.0
+    }
+
+    /// Consume the wrapper, returning the inner row.
+    pub fn into_row(self) -> RLookupRow<'static> {
+        self.0
+    }
+}
+
 /// Bounded COLLECT storage, selecting one family type by the `SORTBY` axis.
 ///
 /// `D` is the doc-id tie-breaker carried by [`HeapStorage`]; the array path
@@ -62,17 +89,17 @@ impl<D: Ord> Storage<D> {
         }
     }
 
-    /// Drain the retained rows, sliced as `skip(offset).take(count)`.
+    /// Drain the retained values, sliced as `skip(offset).take(count)`.
     ///
-    /// - **Array arm** yields rows in insertion order.
-    /// - **Heap arm** yields rows best→worst (matching the SORTBY result order).
+    /// - **Array arm** yields values in insertion order.
+    /// - **Heap arm** yields values best→worst (matching the SORTBY result order).
     ///
-    /// The heap arm discards each entry's sort-key snapshot
+    /// The heap arm discards each entry's [`RankingKey`]
     /// ([`HeapEntry::into_projected`]) because the client-facing local reducer
     /// never re-emits the sort columns. The remote reducer, which *does* re-emit
     /// them on the shard path, drains [`HeapStorage`] directly instead — see
     /// [`RemoteCollectCtx::finalize`][super::remote::RemoteCollectCtx::finalize].
-    pub fn drain(&mut self) -> impl ExactSizeIterator<Item = RLookupRow<'static>> {
+    pub fn drain(&mut self) -> impl ExactSizeIterator<Item = ProjectedRow> {
         match self {
             Self::Array(a) => Either::Left(a.drain()),
             Self::Heap(h) => Either::Right(h.drain().map(HeapEntry::into_projected)),
@@ -82,10 +109,10 @@ impl<D: Ord> Storage<D> {
 
 /// Arrival-ordered storage for the non-`SORTBY` path.
 ///
-/// Holds at most `offset + count` rows and drops the rest without projecting
-/// them. Has no sort context at all.
+/// Holds at most `offset + count` [`ProjectedRow`]s and drops the rest without
+/// projecting them. Has no sort context at all.
 pub struct ArrayStorage {
-    buf: Vec<RLookupRow<'static>>,
+    buf: Vec<ProjectedRow>,
     offset: usize,
     count: usize,
 }
@@ -103,7 +130,7 @@ impl ArrayStorage {
     /// Buffer one more row, dropping it once the `offset + count` cap is
     /// reached. `project` runs only for a retained row, so a dropped row pays
     /// no projection cost.
-    pub fn push(&mut self, project: impl FnOnce() -> RLookupRow<'static>) {
+    pub fn push(&mut self, project: impl FnOnce() -> ProjectedRow) {
         if self.buf.len() < self.offset.saturating_add(self.count) {
             self.buf.push(project());
         }
@@ -111,7 +138,7 @@ impl ArrayStorage {
 
     /// Drain the buffered rows in insertion order, sliced as
     /// `skip(offset).take(count)`.
-    pub fn drain(&mut self) -> impl ExactSizeIterator<Item = RLookupRow<'static>> {
+    pub fn drain(&mut self) -> impl ExactSizeIterator<Item = ProjectedRow> {
         std::mem::take(&mut self.buf)
             .into_iter()
             .skip(self.offset)
@@ -124,9 +151,10 @@ impl ArrayStorage {
 /// Keeps the best `offset + count` candidates under the [`RankingKey`]
 /// comparator, draining best→worst. Unlike [`ArrayStorage`], it owns the sort
 /// context: each candidate's sort-key snapshot lives in its [`RankingKey`] (which
-/// doubles as the cap-check key), so the projected row never has to carry it.
+/// doubles as the cap-check key), so the paired [`ProjectedRow`] never has to
+/// carry it.
 pub struct HeapStorage<D: Ord> {
-    heap: MinMaxHeap<HeapEntry<D, RLookupRow<'static>>>,
+    heap: MinMaxHeap<HeapEntry<D, ProjectedRow>>,
     sort_asc_map: u64,
     offset: usize,
     count: usize,
@@ -154,7 +182,7 @@ impl<D: Ord> HeapStorage<D> {
         &mut self,
         sort_vals: Box<[Option<SharedValue>]>,
         doc_id: D,
-        project: impl FnOnce() -> RLookupRow<'static>,
+        project: impl FnOnce() -> ProjectedRow,
     ) {
         let max_size = self.offset.saturating_add(self.count);
         if max_size == 0 {
@@ -177,11 +205,12 @@ impl<D: Ord> HeapStorage<D> {
     /// Drain the retained entries best→worst, sliced as
     /// `skip(offset).take(count)`.
     ///
-    /// Each [`HeapEntry`] still pairs the row with its ranking [`RankingKey`]:
-    /// callers that only need rows map with [`HeapEntry::into_projected`], while
-    /// the remote reducer reads [`RankingKey::sort_vals`] (via
-    /// [`HeapEntry::into_parts`]) to rebuild the wire row.
-    pub fn drain(&mut self) -> impl ExactSizeIterator<Item = HeapEntry<D, RLookupRow<'static>>> {
+    /// Each [`HeapEntry`] still pairs the [`ProjectedRow`] with its
+    /// [`RankingKey`]: callers that only need the value map with
+    /// [`HeapEntry::into_projected`], while the remote reducer reads
+    /// [`RankingKey::sort_vals`] (via [`HeapEntry::into_parts`]) to rebuild the
+    /// wire row.
+    pub fn drain(&mut self) -> impl ExactSizeIterator<Item = HeapEntry<D, ProjectedRow>> {
         std::mem::take(&mut self.heap)
             .into_vec_desc()
             .into_iter()

--- a/src/redisearch_rs/reducers/tests/heap.rs
+++ b/src/redisearch_rs/reducers/tests/heap.rs
@@ -164,7 +164,7 @@ fn min_max_heap_top_k_under_asc() {
 }
 
 #[test]
-fn entry_key_compares_doc_id_only_after_sort_values_tie() {
+fn ranking_key_compares_doc_id_only_after_sort_values_tie() {
     let primary = Some(SharedValue::new_num(1.0));
     let a = RankingKey::new(Box::new([primary.clone()]), asc(0), 10u64);
     let b = RankingKey::new(Box::new([primary]), asc(0), 20u64);

--- a/src/redisearch_rs/reducers/tests/heap.rs
+++ b/src/redisearch_rs/reducers/tests/heap.rs
@@ -13,15 +13,15 @@
 extern crate redisearch_rs;
 
 use min_max_heap::MinMaxHeap;
-use reducers::collect::heap::{EntryKey, HeapEntry};
+use reducers::collect::heap::{HeapEntry, RankingKey};
 use std::cmp::Ordering;
 use value::SharedValue;
 
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
-/// Builds an [`EntryKey`] from `f64`s — `f64::NAN` projects to `None` so tests
+/// Builds an [`RankingKey`] from `f64`s — `f64::NAN` projects to `None` so tests
 /// can exercise the missing-worst policy.
-fn key(vals: &[f64], asc: u64) -> EntryKey<()> {
+fn key(vals: &[f64], asc: u64) -> RankingKey<()> {
     let snapshot: Box<[Option<SharedValue>]> = vals
         .iter()
         .map(|v| {
@@ -32,7 +32,7 @@ fn key(vals: &[f64], asc: u64) -> EntryKey<()> {
             }
         })
         .collect();
-    EntryKey::new(snapshot, asc, ())
+    RankingKey::new(snapshot, asc, ())
 }
 
 /// Bit `i` ASC.
@@ -166,8 +166,8 @@ fn min_max_heap_top_k_under_asc() {
 #[test]
 fn entry_key_compares_doc_id_only_after_sort_values_tie() {
     let primary = Some(SharedValue::new_num(1.0));
-    let a = EntryKey::new(Box::new([primary.clone()]), asc(0), 10u64);
-    let b = EntryKey::new(Box::new([primary]), asc(0), 20u64);
+    let a = RankingKey::new(Box::new([primary.clone()]), asc(0), 10u64);
+    let b = RankingKey::new(Box::new([primary]), asc(0), 20u64);
     // Sort values tie -> smaller doc id is "better".
     assert_eq!(a.cmp(&b), Ordering::Greater);
     assert_eq!(b.cmp(&a), Ordering::Less);
@@ -175,8 +175,8 @@ fn entry_key_compares_doc_id_only_after_sort_values_tie() {
 
 #[test]
 fn entry_key_sort_values_take_precedence_over_doc_id() {
-    let a = EntryKey::new(Box::new([Some(SharedValue::new_num(1.0))]), asc(0), 20u64);
-    let b = EntryKey::new(Box::new([Some(SharedValue::new_num(2.0))]), asc(0), 10u64);
+    let a = RankingKey::new(Box::new([Some(SharedValue::new_num(1.0))]), asc(0), 20u64);
+    let b = RankingKey::new(Box::new([Some(SharedValue::new_num(2.0))]), asc(0), 10u64);
     // Sort value wins first; doc id is only a tie-breaker.
     assert_eq!(a.cmp(&b), Ordering::Greater);
     assert_eq!(b.cmp(&a), Ordering::Less);

--- a/src/redisearch_rs/reducers/tests/heap.rs
+++ b/src/redisearch_rs/reducers/tests/heap.rs
@@ -174,7 +174,7 @@ fn ranking_key_compares_doc_id_only_after_sort_values_tie() {
 }
 
 #[test]
-fn entry_key_sort_values_take_precedence_over_doc_id() {
+fn ranking_key_sort_values_take_precedence_over_doc_id() {
     let a = RankingKey::new(Box::new([Some(SharedValue::new_num(1.0))]), asc(0), 20u64);
     let b = RankingKey::new(Box::new([Some(SharedValue::new_num(2.0))]), asc(0), 10u64);
     // Sort value wins first; doc id is only a tie-breaker.

--- a/src/redisearch_rs/reducers/tests/storage.rs
+++ b/src/redisearch_rs/reducers/tests/storage.rs
@@ -7,12 +7,13 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Unit tests for the bounded [`Storage`] shared by the COLLECT reducer
-//! variants.
+//! Unit tests for the bounded COLLECT storage families ([`ArrayStorage`] and
+//! [`HeapStorage`]) selected by [`Storage`].
 
 extern crate redisearch_rs;
 
-use reducers::collect::storage::{DEFAULT_LIMIT, Storage};
+use reducers::collect::heap::HeapEntry;
+use reducers::collect::storage::{ArrayStorage, DEFAULT_LIMIT, HeapStorage, Storage};
 use rlookup::{RLookupKey, RLookupKeyFlags, RLookupRow};
 use value::SharedValue;
 
@@ -55,25 +56,43 @@ fn drained_nums(key: &RLookupKey<'_>, drained: &[RLookupRow<'_>]) -> Vec<f64> {
         .collect()
 }
 
+/// Unwrap the array family from a [`Storage`] built with `sortby = false`.
+fn as_array(storage: &mut Storage<()>) -> &mut ArrayStorage {
+    match storage {
+        Storage::Array(a) => a,
+        Storage::Heap(_) => panic!("expected ArrayStorage"),
+    }
+}
+
+/// Unwrap the heap family from a [`Storage`] built with `sortby = true`.
+fn as_heap(storage: &mut Storage<()>) -> &mut HeapStorage<()> {
+    match storage {
+        Storage::Heap(h) => h,
+        Storage::Array(_) => panic!("expected HeapStorage"),
+    }
+}
+
 #[test]
-fn insert_entry_array_caps_at_cap_in_insertion_order() {
+fn array_push_caps_at_cap_in_insertion_order() {
     let key = make_key();
     let mut s = Storage::new(false, Some((0, 3)), 0);
+    let a = as_array(&mut s);
     for i in 0..5 {
-        s.insert_entry(|| sort_vals(i as f64), (), || row(&key, i as f64));
+        a.push(|| row(&key, i as f64));
     }
-    let drained: Vec<_> = s.drain().collect();
+    let drained: Vec<_> = a.drain().collect();
     assert_eq!(drained.len(), 3);
     assert_eq!(drained_nums(&key, &drained), vec![0.0, 1.0, 2.0]);
 }
 
 #[test]
-fn insert_entry_array_drops_excess_without_calling_project() {
+fn array_push_drops_excess_without_calling_project() {
     let key = make_key();
     let mut counter = 0;
     let mut s = Storage::new(false, Some((0, 2)), 0);
+    let a = as_array(&mut s);
     for v in [1.0_f64, 2.0, 3.0, 4.0] {
-        s.insert_entry(|| sort_vals(v), (), counting_project(&mut counter, &key, v));
+        a.push(counting_project(&mut counter, &key, v));
     }
     assert_eq!(
         counter, 2,
@@ -82,42 +101,45 @@ fn insert_entry_array_drops_excess_without_calling_project() {
 }
 
 #[test]
-fn insert_entry_heap_keeps_top_k_under_asc() {
+fn heap_consider_keeps_top_k_under_asc() {
     let key = make_key();
     let mut s = Storage::new(true, Some((0, 3)), SORT_ASC);
+    let h = as_heap(&mut s);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        s.insert_entry(|| sort_vals(i), (), || row(&key, i));
+        h.consider(sort_vals(i), (), || row(&key, i));
     }
-    let drained: Vec<_> = s.drain().collect();
+    let drained: Vec<_> = h.drain().map(HeapEntry::into_projected).collect();
     // ASC: smallest is best; heap drains best→worst.
     assert_eq!(drained_nums(&key, &drained), vec![0.0, 1.0, 2.0]);
 }
 
 #[test]
-fn insert_entry_heap_keeps_top_k_under_desc() {
+fn heap_consider_keeps_top_k_under_desc() {
     let key = make_key();
     let mut s = Storage::new(true, Some((0, 3)), SORT_DESC);
+    let h = as_heap(&mut s);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        s.insert_entry(|| sort_vals(i), (), || row(&key, i));
+        h.consider(sort_vals(i), (), || row(&key, i));
     }
-    let drained: Vec<_> = s.drain().collect();
+    let drained: Vec<_> = h.drain().map(HeapEntry::into_projected).collect();
     // DESC: largest is best; heap drains best→worst.
     assert_eq!(drained_nums(&key, &drained), vec![5.0, 4.0, 3.0]);
 }
 
 #[test]
-fn insert_entry_heap_skips_project_for_doomed_candidates() {
+fn heap_consider_skips_project_for_doomed_candidates() {
     let key = make_key();
     let mut counter = 0;
     let mut s = Storage::new(true, Some((0, 2)), SORT_ASC);
+    let h = as_heap(&mut s);
     // Fill with the two best candidates first.
     for v in [0.0_f64, 1.0] {
-        s.insert_entry(|| sort_vals(v), (), counting_project(&mut counter, &key, v));
+        h.consider(sort_vals(v), (), counting_project(&mut counter, &key, v));
     }
     // Each subsequent candidate is worse than the worst survivor (1.0)
     // under ASC, so `project` must not run.
     for v in [2.0_f64, 3.0, 4.0] {
-        s.insert_entry(|| sort_vals(v), (), counting_project(&mut counter, &key, v));
+        h.consider(sort_vals(v), (), counting_project(&mut counter, &key, v));
     }
     assert_eq!(
         counter, 2,
@@ -126,14 +148,15 @@ fn insert_entry_heap_skips_project_for_doomed_candidates() {
 }
 
 #[test]
-fn insert_entry_heap_invokes_project_on_eviction() {
+fn heap_consider_invokes_project_on_eviction() {
     let key = make_key();
     let mut counter = 0;
     let mut s = Storage::new(true, Some((0, 2)), SORT_ASC);
+    let h = as_heap(&mut s);
     // Each insert is strictly better than the current worst, so every
     // candidate must be projected.
     for v in [5.0_f64, 3.0, 1.0] {
-        s.insert_entry(|| sort_vals(v), (), counting_project(&mut counter, &key, v));
+        h.consider(sort_vals(v), (), counting_project(&mut counter, &key, v));
     }
     assert_eq!(counter, 3);
 }
@@ -142,10 +165,11 @@ fn insert_entry_heap_invokes_project_on_eviction() {
 fn drain_array_applies_skip_take() {
     let key = make_key();
     let mut s = Storage::new(false, Some((1, 2)), 0);
+    let a = as_array(&mut s);
     for i in 0..5 {
-        s.insert_entry(|| sort_vals(i as f64), (), || row(&key, i as f64));
+        a.push(|| row(&key, i as f64));
     }
-    let drained: Vec<_> = s.drain().collect();
+    let drained: Vec<_> = a.drain().collect();
     assert_eq!(drained_nums(&key, &drained), vec![1.0, 2.0]);
 }
 
@@ -153,21 +177,64 @@ fn drain_array_applies_skip_take() {
 fn drain_heap_applies_skip_take_after_best_first_order() {
     let key = make_key();
     let mut s = Storage::new(true, Some((1, 2)), SORT_ASC);
+    let h = as_heap(&mut s);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        s.insert_entry(|| sort_vals(i), (), || row(&key, i));
+        h.consider(sort_vals(i), (), || row(&key, i));
     }
     // Top-3 under ASC = [0, 1, 2] best→worst; offset 1, count 2 → [1, 2].
-    let drained: Vec<_> = s.drain().collect();
+    let drained: Vec<_> = h.drain().map(HeapEntry::into_projected).collect();
     assert_eq!(drained_nums(&key, &drained), vec![1.0, 2.0]);
 }
 
 #[test]
-fn insert_entry_heap_uses_default_limit_when_no_explicit_limit() {
+fn heap_uses_default_limit_when_no_explicit_limit() {
     let key = make_key();
     let mut s = Storage::new(true, None, SORT_ASC);
+    let h = as_heap(&mut s);
     for i in 0..(DEFAULT_LIMIT as usize + 5) {
-        s.insert_entry(|| sort_vals(i as f64), (), || row(&key, i as f64));
+        h.consider(sort_vals(i as f64), (), || row(&key, i as f64));
+    }
+    let drained: Vec<_> = h.drain().map(HeapEntry::into_projected).collect();
+    assert_eq!(drained.len(), DEFAULT_LIMIT as usize);
+}
+
+#[test]
+fn storage_drain_heap_yields_rows_best_first() {
+    // The `Storage::drain` convenience discards each entry's sort snapshot and
+    // yields rows best→worst, which is all the client-facing local reducer
+    // needs.
+    let key = make_key();
+    let mut s = Storage::new(true, Some((0, 3)), SORT_ASC);
+    {
+        let h = as_heap(&mut s);
+        for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
+            h.consider(sort_vals(i), (), || row(&key, i));
+        }
     }
     let drained: Vec<_> = s.drain().collect();
-    assert_eq!(drained.len(), DEFAULT_LIMIT as usize);
+    assert_eq!(drained_nums(&key, &drained), vec![0.0, 1.0, 2.0]);
+}
+
+#[test]
+fn heap_drain_entries_expose_sort_vals_in_best_first_order() {
+    // The heap-family drain keeps each row's ranking key so the remote reducer
+    // can re-attach the deferred SORTBY columns (see `HeapEntry::into_parts`).
+    let key = make_key();
+    let mut s = Storage::new(true, Some((0, 3)), SORT_ASC);
+    let h = as_heap(&mut s);
+    for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
+        h.consider(sort_vals(i), (), || row(&key, i));
+    }
+    let snapshots: Vec<f64> = h
+        .drain()
+        .map(|entry| {
+            let (ranking_key, _row) = entry.into_parts();
+            ranking_key.sort_vals()[0]
+                .as_ref()
+                .and_then(|v| v.as_num())
+                .expect("sort snapshot present")
+        })
+        .collect();
+    // Best→worst under ASC = smallest sort values first.
+    assert_eq!(snapshots, vec![0.0, 1.0, 2.0]);
 }

--- a/src/redisearch_rs/reducers/tests/storage.rs
+++ b/src/redisearch_rs/reducers/tests/storage.rs
@@ -13,7 +13,7 @@
 extern crate redisearch_rs;
 
 use reducers::collect::heap::HeapEntry;
-use reducers::collect::storage::{ArrayStorage, DEFAULT_LIMIT, HeapStorage, Storage};
+use reducers::collect::storage::{ArrayStorage, DEFAULT_LIMIT, HeapStorage, ProjectedRow, Storage};
 use rlookup::{RLookupKey, RLookupKeyFlags, RLookupRow};
 use value::SharedValue;
 
@@ -31,10 +31,12 @@ fn sort_vals(v: f64) -> Box<[Option<SharedValue>]> {
     vec![Some(SharedValue::new_num(v))].into_boxed_slice()
 }
 
-fn row(key: &RLookupKey<'_>, v: f64) -> RLookupRow<'static> {
+/// A one-field [`ProjectedRow`] tagged with `v`, as a reducer's `project`
+/// closure would produce.
+fn projected(key: &RLookupKey<'_>, v: f64) -> ProjectedRow {
     let mut r = RLookupRow::new();
     r.write_key(key, SharedValue::new_num(v));
-    r
+    ProjectedRow::new(r)
 }
 
 /// `project` closure that increments `counter` on each call.
@@ -42,17 +44,23 @@ fn counting_project<'a>(
     counter: &'a mut usize,
     key: &'a RLookupKey<'_>,
     tag: f64,
-) -> impl FnOnce() -> RLookupRow<'static> + 'a {
+) -> impl FnOnce() -> ProjectedRow + 'a {
     move || {
         *counter += 1;
-        row(key, tag)
+        projected(key, tag)
     }
 }
 
-fn drained_nums(key: &RLookupKey<'_>, drained: &[RLookupRow<'_>]) -> Vec<f64> {
+fn drained_nums(key: &RLookupKey<'_>, drained: &[ProjectedRow]) -> Vec<f64> {
     drained
         .iter()
-        .map(|r| r.get(key).expect("row missing key").as_num().expect("num"))
+        .map(|pr| {
+            pr.row()
+                .get(key)
+                .expect("row missing key")
+                .as_num()
+                .expect("num")
+        })
         .collect()
 }
 
@@ -78,7 +86,7 @@ fn array_push_caps_at_cap_in_insertion_order() {
     let mut s = Storage::new(false, Some((0, 3)), 0);
     let a = as_array(&mut s);
     for i in 0..5 {
-        a.push(|| row(&key, i as f64));
+        a.push(|| projected(&key, i as f64));
     }
     let drained: Vec<_> = a.drain().collect();
     assert_eq!(drained.len(), 3);
@@ -106,7 +114,7 @@ fn heap_consider_keeps_top_k_under_asc() {
     let mut s = Storage::new(true, Some((0, 3)), SORT_ASC);
     let h = as_heap(&mut s);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        h.consider(sort_vals(i), (), || row(&key, i));
+        h.consider(sort_vals(i), (), || projected(&key, i));
     }
     let drained: Vec<_> = h.drain().map(HeapEntry::into_projected).collect();
     // ASC: smallest is best; heap drains best→worst.
@@ -119,7 +127,7 @@ fn heap_consider_keeps_top_k_under_desc() {
     let mut s = Storage::new(true, Some((0, 3)), SORT_DESC);
     let h = as_heap(&mut s);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        h.consider(sort_vals(i), (), || row(&key, i));
+        h.consider(sort_vals(i), (), || projected(&key, i));
     }
     let drained: Vec<_> = h.drain().map(HeapEntry::into_projected).collect();
     // DESC: largest is best; heap drains best→worst.
@@ -167,7 +175,7 @@ fn drain_array_applies_skip_take() {
     let mut s = Storage::new(false, Some((1, 2)), 0);
     let a = as_array(&mut s);
     for i in 0..5 {
-        a.push(|| row(&key, i as f64));
+        a.push(|| projected(&key, i as f64));
     }
     let drained: Vec<_> = a.drain().collect();
     assert_eq!(drained_nums(&key, &drained), vec![1.0, 2.0]);
@@ -179,7 +187,7 @@ fn drain_heap_applies_skip_take_after_best_first_order() {
     let mut s = Storage::new(true, Some((1, 2)), SORT_ASC);
     let h = as_heap(&mut s);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        h.consider(sort_vals(i), (), || row(&key, i));
+        h.consider(sort_vals(i), (), || projected(&key, i));
     }
     // Top-3 under ASC = [0, 1, 2] best→worst; offset 1, count 2 → [1, 2].
     let drained: Vec<_> = h.drain().map(HeapEntry::into_projected).collect();
@@ -192,7 +200,7 @@ fn heap_uses_default_limit_when_no_explicit_limit() {
     let mut s = Storage::new(true, None, SORT_ASC);
     let h = as_heap(&mut s);
     for i in 0..(DEFAULT_LIMIT as usize + 5) {
-        h.consider(sort_vals(i as f64), (), || row(&key, i as f64));
+        h.consider(sort_vals(i as f64), (), || projected(&key, i as f64));
     }
     let drained: Vec<_> = h.drain().map(HeapEntry::into_projected).collect();
     assert_eq!(drained.len(), DEFAULT_LIMIT as usize);
@@ -200,15 +208,15 @@ fn heap_uses_default_limit_when_no_explicit_limit() {
 
 #[test]
 fn storage_drain_heap_yields_rows_best_first() {
-    // The `Storage::drain` convenience discards each entry's sort snapshot and
-    // yields rows best→worst, which is all the client-facing local reducer
+    // The `Storage::drain` convenience discards each entry's ranking key and
+    // yields values best→worst, which is all the client-facing local reducer
     // needs.
     let key = make_key();
     let mut s = Storage::new(true, Some((0, 3)), SORT_ASC);
     {
         let h = as_heap(&mut s);
         for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-            h.consider(sort_vals(i), (), || row(&key, i));
+            h.consider(sort_vals(i), (), || projected(&key, i));
         }
     }
     let drained: Vec<_> = s.drain().collect();
@@ -217,18 +225,18 @@ fn storage_drain_heap_yields_rows_best_first() {
 
 #[test]
 fn heap_drain_entries_expose_sort_vals_in_best_first_order() {
-    // The heap-family drain keeps each row's ranking key so the remote reducer
+    // The heap-family drain keeps each value's ranking key so the remote reducer
     // can re-attach the deferred SORTBY columns (see `HeapEntry::into_parts`).
     let key = make_key();
     let mut s = Storage::new(true, Some((0, 3)), SORT_ASC);
     let h = as_heap(&mut s);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        h.consider(sort_vals(i), (), || row(&key, i));
+        h.consider(sort_vals(i), (), || projected(&key, i));
     }
     let snapshots: Vec<f64> = h
         .drain()
         .map(|entry| {
-            let (ranking_key, _row) = entry.into_parts();
+            let (ranking_key, _value) = entry.into_parts();
             ranking_key.sort_vals()[0]
                 .as_ref()
                 .and_then(|v| v.as_num())


### PR DESCRIPTION
## Describe the changes in the pull request

Reshapes the COLLECT storage layer to make its two axes — ranking and content — explicit in the types. Pure refactor — **no behavior or wire-format change**.

**Before.** Storage was a single `Storage<D>` enum (`Array` / `Heap`) with one `insert_entry` method that carried sort context into both arms — including the array path, which never ranks. On the heap path the sort values were written *into the stored row* (for the coordinator re-sort) **and** kept in the ranking key, i.e. stored twice. The ordering key was named `EntryKey`, and the stored payload was a bare `RLookupRow`, so "what ranks" vs "what's collected" was only a convention.

**After.**
- **Split storage by the `SORTBY` axis** into two family types behind a thin enum: `ArrayStorage` (`push`, no sort context) and `HeapStorage<D>` (`consider`, owns the sort context). Each reducer dispatches array-vs-heap once, in `add`, so only the heap path builds a sort-key snapshot.
- **Defer the sort-key write to `finalize`.** The stored heap row holds only the projected fields; the SORTBY columns the coordinator re-sort needs are merged back at `finalize` from the ranking-key snapshot. No more double-stored sort values.
- **Make the two axes explicit in the types.** `EntryKey` → `RankingKey` (the key entries are *ranked* by; avoids confusion with the field-level `sort_keys` / `sort_key_names`), and the stored payload is wrapped in a `ProjectedRow` newtype (the *value* / collected content). Storage now reads as `(RankingKey, ProjectedRow)`: order is decided solely by the ranking key.

**Outcome.** A cleaner storage layer with no duplicated sort values on the heap path and a smaller projected row. The payload the coordinator receives is **identical** — just reconstructed at `finalize` instead of during ingestion.

#### Which additional issues this PR fixes

_None._

#### Main objects this PR modified

1. `reducers::collect::storage` — `Storage<D>` thin enum over new `ArrayStorage` / `HeapStorage<D>` family types; new `ProjectedRow` value newtype.
2. `reducers::collect::heap` — `RankingKey` (renamed from `EntryKey`) with a `sort_vals` accessor; `HeapEntry::into_parts`.
3. `reducers::collect::remote` — array-vs-heap dispatch in `add`; `build_template` returns the sort columns to re-attach, merged back in `finalize`.
4. `reducers::collect::local` — array-vs-heap dispatch in `add`.
5. `reducers/tests/storage.rs` — storage-layer unit tests rewritten for the family-type / `ProjectedRow` API.
6. `reducers/tests/heap.rs` — `EntryKey` → `RankingKey` rename in the heap tests.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal-only refactor; no user-visible behavior or wire-format change.

## Verification

- `cargo nextest run -p reducers` — **53/53 pass**. The behavioral `collect` / `sortby` / `local` / `remote` integration tests pass **unchanged** (behavior-preserving); only the impl-specific storage-layer unit tests were rewritten.
- `cargo clippy -p reducers --all-targets -- -D warnings` — clean.
- `RUSTDOCFLAGS="-Dwarnings" cargo doc -p reducers --no-deps --document-private-items` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
