### PR TITLE
CI: fix flaky-DB reporting on macOS (pip/python3 interpreter mismatch)

### DIFF
--- a/.github/actions/flaky-build-testfile/action.yml
+++ b/.github/actions/flaky-build-testfile/action.yml
@@ -64,7 +64,13 @@ runs:
         python-version: "3.x"
 
     - shell: bash -l -eo pipefail {0}
-      run: pip install 'redis>=6,<7'
+      # Install via `python3 -m pip` (not bare `pip`): on the macOS runners the
+      # `bash -l` login shell re-runs path_helper/Homebrew profile setup, which
+      # can leave bare `pip` and bare `python3` resolving to different
+      # interpreters. `redis` would then land in one interpreter's site-packages
+      # while `python3 flaky_db.py` runs under another, failing with
+      # `ModuleNotFoundError: redis`. Pinning the interpreter keeps them in sync.
+      run: python3 -m pip install 'redis>=6,<7'
 
     - name: Fetch flaky skip list
       shell: bash -l -eo pipefail {0}

--- a/.github/actions/flaky-record-results/action.yml
+++ b/.github/actions/flaky-record-results/action.yml
@@ -64,7 +64,13 @@ runs:
 
     - name: Install dependencies
       shell: bash -l -eo pipefail {0}
-      run: pip install 'redis>=6,<7'
+      # Install via `python3 -m pip` (not bare `pip`): on the macOS runners the
+      # `bash -l` login shell re-runs path_helper/Homebrew profile setup, which
+      # can leave bare `pip` and bare `python3` resolving to different
+      # interpreters. `redis` would then land in one interpreter's site-packages
+      # while `python3 flaky_db.py` runs under another, failing with
+      # `ModuleNotFoundError: redis`. Pinning the interpreter keeps them in sync.
+      run: python3 -m pip install 'redis>=6,<7'
 
     - name: Record results
       shell: bash -l -eo pipefail {0}


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: The flaky-DB composite actions (`flaky-record-results`, `flaky-build-testfile`) install the `redis` Python client with a bare `pip install 'redis>=6,<7'`, then run `.github/scripts/flaky_db.py` with bare `python3`. On the macOS runners the `bash -l` login shell re-runs `path_helper`/Homebrew profile setup, which can leave bare `pip` and bare `python3` resolving to **different** interpreters. `redis` lands in one interpreter's site-packages while the script runs under another, failing with `ModuleNotFoundError: redis`.
2. **Change**: Install via `python3 -m pip install` so the package targets exactly the interpreter that later runs the script.
3. **Outcome**: macOS test failures are recorded to the flaky DB again. No-op behavior change on Linux/container runners.

This was surfaced by the post-merge selected-platform validation for #10159: the macOS 26 ARM64 `flaky-record-results` step logged `pip` installing `redis 6.4.0` but `python3 flaky_db.py` then failed with `ModuleNotFoundError: redis` for both standalone and coordinator reporting (the step is `continue-on-error`, so failures were silently dropped rather than recorded).

#### Which additional issues this PR fixes

_None known._

#### Main objects this PR modified
1. `.github/actions/flaky-record-results/action.yml`
2. `.github/actions/flaky-build-testfile/action.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)