### PR TITLE
[MOD-14209] TopK: Revalidation + Timeout Correctness Pass (Vector)

### DIFF
--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -158,6 +158,12 @@ static void alternatingIterate(HybridIterator *hr, VecSimQueryReply_Iterator *ve
 // Need the redirection so tests can pass a mock function to test timeout behavior.
 int (*vecsimTimeoutCallback)(TimeoutCtx *ctx) = TimedOut_WithCtx;
 
+// Non-inline wrapper called from Rust's VectorScoreSource::adhoc_strategy so the
+// test-mockable vecsimTimeoutCallback indirection is honored on the adhoc-BF path.
+int RS_VecSimCheckTimeout(TimeoutCtx *ctx) {
+  return vecsimTimeoutCallback(ctx);
+}
+
 // Updates both locations where scores are stored:
 // 1. IndexResult numeric value (used by VECTOR_SCORE macro for heap ordering)
 // 2. metrics array entry (used downstream for $score in queries)

--- a/src/iterators/hybrid_reader.h
+++ b/src/iterators/hybrid_reader.h
@@ -63,6 +63,10 @@ extern "C" {
 
 QueryIterator *NewHybridVectorIterator(HybridIteratorParams hParams, QueryError *status);
 
+// Routes the Rust adhoc-BF scan through the swappable `vecsimTimeoutCallback`
+// so FT.DEBUG VECSIM_MOCK_TIMEOUT can override its timeout behavior.
+int RS_VecSimCheckTimeout(TimeoutCtx *ctx);
+
 RLookupKey    **HybridIterator_GetOwnKeyRef(QueryIterator *it);
 void            HybridIterator_SetKeyHandle(QueryIterator *it, struct RLookupKeyHandle *h);
 

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3452,6 +3452,7 @@ dependencies = [
  "redisearch_rs",
  "rqe_core",
  "rqe_iterators",
+ "rqe_iterators_test_utils",
  "top_k",
  "tracing",
  "vecsim",

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -177,6 +177,7 @@ const HEADERS: &[HeaderAllowlist] = &[
             "HybridIterator_GetNumIterations",
             "HybridIterator_GetSearchModeString",
             "HybridIterator_IsBatchMode",
+            "RS_VecSimCheckTimeout",
         ],
         // `vector_score_source` owns a `TimeoutCtx` (an absolute `timespec`
         // deadline) handed to VecSim. Exposed via this already-included header

--- a/src/redisearch_rs/field/src/lib.rs
+++ b/src/redisearch_rs/field/src/lib.rs
@@ -51,7 +51,7 @@ impl FieldExpirationPredicate {
 }
 
 /// Field filter context used when querying fields.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C)]
 #[cheadergen::config(export)]
 pub struct FieldFilterContext {

--- a/src/redisearch_rs/rqe_iterators/src/expiration_checker.rs
+++ b/src/redisearch_rs/rqe_iterators/src/expiration_checker.rs
@@ -54,6 +54,7 @@ impl ExpirationChecker for NoOpChecker {
 /// Field-level expiration checker using TTL table.
 ///
 /// This checker uses the in-memory TTL table to determine if a document's field has expired.
+#[derive(Clone, Copy)]
 pub struct FieldExpirationChecker {
     /// The search context used to check for expiration.
     sctx: NonNull<RedisSearchCtx>,

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -187,7 +187,6 @@ impl<E: Encoder> BaseTest<E> {
 }
 
 /// ---------- Expiration Tests ----------
-
 pub use rqe_iterators_test_utils::MockExpirationChecker;
 
 /// The type of index used in the expiration test.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -16,7 +16,7 @@ use index_result::{RSIndexResult, RSResultKind};
 use inverted_index::{DecodedBy, Encoder, InvertedIndex, test_utils::TermRecordCompare};
 use numeric_range_tree::NumericIndex;
 use rqe_core::{DocId, FieldMask};
-use rqe_iterators::{ExpirationChecker, RQEIterator, RQEValidateStatus, SkipToOutcome};
+use rqe_iterators::{RQEIterator, RQEValidateStatus, SkipToOutcome};
 use rqe_iterators_test_utils::MockContext;
 use std::collections::HashSet;
 
@@ -188,35 +188,7 @@ impl<E: Encoder> BaseTest<E> {
 
 /// ---------- Expiration Tests ----------
 
-/// A mock expiration checker for testing.
-///
-/// This allows testing expiration logic without requiring TTL tables.
-/// The `ExpirationTest` will mark documents as expired in this mock checker
-/// instead of in the TTL tables.
-#[derive(Debug, Clone)]
-pub struct MockExpirationChecker {
-    expired_docs: HashSet<DocId>,
-}
-
-impl MockExpirationChecker {
-    pub fn new(expired_docs: HashSet<DocId>) -> Self {
-        Self { expired_docs }
-    }
-
-    pub fn mark_expired(&mut self, doc_id: DocId) {
-        self.expired_docs.insert(doc_id);
-    }
-}
-
-impl ExpirationChecker for MockExpirationChecker {
-    fn has_expiration(&self) -> bool {
-        !self.expired_docs.is_empty()
-    }
-
-    fn is_expired(&self, result: &RSIndexResult) -> bool {
-        self.expired_docs.contains(&result.doc_id)
-    }
-}
+pub use rqe_iterators_test_utils::MockExpirationChecker;
 
 /// The type of index used in the expiration test.
 enum ExpirationIndexType {

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/lib.rs
@@ -15,12 +15,14 @@
 #[expect(clippy::undocumented_unsafe_blocks)]
 #[expect(clippy::multiple_unsafe_ops_per_block)]
 pub mod mock_context;
+pub mod mock_expiration;
 #[expect(clippy::undocumented_unsafe_blocks)]
 #[expect(clippy::multiple_unsafe_ops_per_block)]
 pub mod test_context;
 
 use index_spec::IndexSpecReadGuard;
 pub use mock_context::MockContext;
+pub use mock_expiration::MockExpirationChecker;
 use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator, TypeErasedRQESuspendedIterator};
 pub use test_context::{GlobalGuard, TestContext};
 

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/mock_expiration.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/mock_expiration.rs
@@ -15,7 +15,7 @@ use index_result::RSIndexResult;
 use rqe_core::DocId;
 use rqe_iterators::ExpirationChecker;
 
-/// A mock expiration checker that flags a fixed set of doc ids as expired.
+/// A mock expiration checker that marks a fixed set of doc ids as expired.
 ///
 /// This lets a consumer of [`ExpirationChecker`] exercise its own skip-on-expired
 /// logic without standing up a real TTL table and search context.
@@ -30,7 +30,7 @@ impl MockExpirationChecker {
         Self { expired_docs }
     }
 
-    /// Flag an additional doc id as expired.
+    /// Mark an additional doc id as expired.
     pub fn mark_expired(&mut self, doc_id: DocId) {
         self.expired_docs.insert(doc_id);
     }

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/mock_expiration.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/mock_expiration.rs
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! A mock [`ExpirationChecker`] for testing expiration handling without TTL tables.
+
+use std::collections::HashSet;
+
+use index_result::RSIndexResult;
+use rqe_core::DocId;
+use rqe_iterators::ExpirationChecker;
+
+/// A mock expiration checker that flags a fixed set of doc ids as expired.
+///
+/// This lets a consumer of [`ExpirationChecker`] exercise its own skip-on-expired
+/// logic without standing up a real TTL table and search context.
+#[derive(Debug, Clone, Default)]
+pub struct MockExpirationChecker {
+    expired_docs: HashSet<DocId>,
+}
+
+impl MockExpirationChecker {
+    /// Create a checker that reports the given doc ids as expired.
+    pub const fn new(expired_docs: HashSet<DocId>) -> Self {
+        Self { expired_docs }
+    }
+
+    /// Flag an additional doc id as expired.
+    pub fn mark_expired(&mut self, doc_id: DocId) {
+        self.expired_docs.insert(doc_id);
+    }
+}
+
+impl ExpirationChecker for MockExpirationChecker {
+    fn has_expiration(&self) -> bool {
+        !self.expired_docs.is_empty()
+    }
+
+    fn is_expired(&self, result: &RSIndexResult) -> bool {
+        self.expired_docs.contains(&result.doc_id)
+    }
+}

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -313,18 +313,19 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
     ) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
         loop {
             let item = self.direct_batch.as_mut().and_then(S::Batch::next);
-            let expired = item.is_some_and(|(doc_id, _)| self.source.is_expired(doc_id));
 
             // Poll once per step, after classifying the entry and before yielding
             // it — gates valid results, EOF, and expired skips alike.
             self.source.check_timeout()?;
 
             match item {
-                Some(_) if expired => continue,
                 Some((doc_id, score)) => {
                     let result = self.source.build_result(doc_id, score);
-                    self.current = Some(result);
+                    if self.source.is_expired(&result) {
+                        continue;
+                    }
                     self.last_doc_id = doc_id;
+                    self.current = Some(result);
                     return Ok(self.current.as_mut());
                 }
                 None => {
@@ -348,23 +349,22 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
         loop {
             let entry = self.results.get(self.yield_pos).copied();
             self.yield_pos += 1;
-            let expired =
-                entry.is_some_and(|ScoredResult { doc_id, .. }| self.source.is_expired(doc_id));
 
             // Poll once per step, after classifying the entry and before yielding
             // it — gates valid results, EOF, and expired skips alike.
             self.source.check_timeout()?;
-
             match entry {
                 None => {
                     self.at_eof = true;
                     return Ok(None);
                 }
-                Some(_) if expired => continue,
                 Some(ScoredResult { doc_id, score }) => {
                     let result = self.source.build_result(doc_id, score);
-                    self.current = Some(result);
+                    if self.source.is_expired(&result) {
+                        continue;
+                    }
                     self.last_doc_id = doc_id;
+                    self.current = Some(result);
                     return Ok(self.current.as_mut());
                 }
             }

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -272,11 +272,15 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             if let Some(score) = scope.0.lookup_score(doc_id) {
                 self.heap.push(doc_id, score);
             }
+            if scope.0.adhoc_check_timeout() {
+                return Err(RQEIteratorError::TimedOut);
+            }
         }
 
         // Reached only on a clean scan exit (EOF or `Stop`); a timed-out scan
-        // propagates via `?` above and never gets here. Rerank while `scope` is
-        // alive, so the source's scan resources are still held.
+        // propagates via `?` or an `AdhocStrategy::TimedOut` return above and
+        // never gets here. Rerank while `scope` is alive, so the source's scan
+        // resources are still held.
         if scope.0.should_rerank() && !self.heap.is_empty() {
             let mut entries: Vec<_> = self.heap.drain_unsorted().collect();
             scope.0.rerank(&mut entries);

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -269,10 +269,12 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             };
             let doc_id = result.doc_id;
 
+            // Poll before the lookup so an expired deadline skips the expensive
+            // VecSim distance lookup.
+            scope.0.check_timeout()?;
             if let Some(score) = scope.0.lookup_score(doc_id) {
                 self.heap.push(doc_id, score);
             }
-            scope.0.check_timeout()?;
         }
 
         // Reached only on a clean scan exit (EOF or `Stop`); a timed-out scan
@@ -311,14 +313,14 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
     ) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
         loop {
             let item = self.direct_batch.as_mut().and_then(S::Batch::next);
+            let expired = item.is_some_and(|(doc_id, _)| self.source.is_expired(doc_id));
+
+            // Poll once per step, after classifying the entry and before yielding
+            // it — gates valid results, EOF, and expired skips alike.
+            self.source.check_timeout()?;
 
             match item {
-                Some((doc_id, _)) if self.source.is_expired(doc_id) => {
-                    // Poll the deadline so a long run of expired docs cannot
-                    // drain the batch past the timeout.
-                    self.source.check_timeout()?;
-                    continue;
-                }
+                Some(_) if expired => continue,
                 Some((doc_id, score)) => {
                     let result = self.source.build_result(doc_id, score);
                     self.current = Some(result);
@@ -344,22 +346,28 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
         &mut self,
     ) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
         loop {
-            if self.yield_pos >= self.results.len() {
-                self.at_eof = true;
-                return Ok(None);
-            }
-            let ScoredResult { doc_id, score } = self.results[self.yield_pos];
+            let entry = self.results.get(self.yield_pos).copied();
             self.yield_pos += 1;
-            if self.source.is_expired(doc_id) {
-                // Poll the deadline so a long run of expired docs cannot
-                // drain the heap past the timeout.
-                self.source.check_timeout()?;
-                continue;
+            let expired =
+                entry.is_some_and(|ScoredResult { doc_id, .. }| self.source.is_expired(doc_id));
+
+            // Poll once per step, after classifying the entry and before yielding
+            // it — gates valid results, EOF, and expired skips alike.
+            self.source.check_timeout()?;
+
+            match entry {
+                None => {
+                    self.at_eof = true;
+                    return Ok(None);
+                }
+                Some(_) if expired => continue,
+                Some(ScoredResult { doc_id, score }) => {
+                    let result = self.source.build_result(doc_id, score);
+                    self.current = Some(result);
+                    self.last_doc_id = doc_id;
+                    return Ok(self.current.as_mut());
+                }
             }
-            let result = self.source.build_result(doc_id, score);
-            self.current = Some(result);
-            self.last_doc_id = doc_id;
-            return Ok(self.current.as_mut());
         }
     }
 }

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -302,40 +302,58 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
     }
 
     /// Yield the next result from the unfiltered direct batch.
+    ///
+    /// Results whose document expired ([`ScoreSource::is_expired`]) are dropped
+    /// without replacement: the batch holds at most k entries, so skipping
+    /// shrinks the yielded count.
     fn advance_unfiltered_direct(
         &mut self,
     ) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
-        let item = self.direct_batch.as_mut().and_then(S::Batch::next);
+        loop {
+            let item = self.direct_batch.as_mut().and_then(S::Batch::next);
 
-        match item {
-            Some((doc_id, score)) => {
-                let result = self.source.build_result(doc_id, score);
-                self.current = Some(result);
-                self.last_doc_id = doc_id;
-                Ok(self.current.as_mut())
-            }
-            None => {
-                self.at_eof = true;
-                self.current = None;
-                Ok(None)
+            match item {
+                Some((doc_id, _)) if self.source.is_expired(doc_id) => continue,
+                Some((doc_id, score)) => {
+                    let result = self.source.build_result(doc_id, score);
+                    self.current = Some(result);
+                    self.last_doc_id = doc_id;
+                    return Ok(self.current.as_mut());
+                }
+                None => {
+                    self.at_eof = true;
+                    self.current = None;
+                    return Ok(None);
+                }
             }
         }
     }
 
     /// Yield the next result from the pre-sorted `results` vec.
+    ///
+    /// Results whose document expired ([`ScoreSource::is_expired`]) since
+    /// collection are dropped without replacement, mirroring the C
+    /// `HybridIterator`'s pop-time expiration check: expired docs occupied
+    /// their top-k slots during collection, so they shrink the yielded count
+    /// rather than being refilled from lower-scored candidates.
     fn advance_from_results(
         &mut self,
     ) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
-        if self.yield_pos >= self.results.len() {
-            self.at_eof = true;
-            return Ok(None);
+        loop {
+            if self.yield_pos >= self.results.len() {
+                self.at_eof = true;
+                return Ok(None);
+            }
+            let ScoredResult { doc_id, score } = self.results[self.yield_pos];
+            self.yield_pos += 1;
+            if self.source.is_expired(doc_id) {
+                continue;
+            }
+            let result = self.source.build_result(doc_id, score);
+            self.current = Some(result);
+            self.last_doc_id = doc_id;
+            return Ok(self.current.as_mut());
         }
-        let ScoredResult { doc_id, score } = self.results[self.yield_pos];
-        self.yield_pos += 1;
-        let result = self.source.build_result(doc_id, score);
-        self.current = Some(result);
-        self.last_doc_id = doc_id;
-        Ok(self.current.as_mut())
     }
 }
 

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -403,8 +403,13 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> RQEIterat
         &mut self,
         spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        // Only a child abort aborts us. Results come from our own score-ordered
+        // buffer, so a moved child does not move our cursor: collapse it to Ok.
         if let Some(child) = &mut self.child {
-            return child.revalidate(spec);
+            match child.revalidate(spec)? {
+                RQEValidateStatus::Aborted => return Ok(RQEValidateStatus::Aborted),
+                RQEValidateStatus::Ok | RQEValidateStatus::Moved { .. } => {}
+            }
         }
         Ok(RQEValidateStatus::Ok)
     }

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -272,15 +272,11 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             if let Some(score) = scope.0.lookup_score(doc_id) {
                 self.heap.push(doc_id, score);
             }
-            if scope.0.adhoc_check_timeout() {
-                return Err(RQEIteratorError::TimedOut);
-            }
+            scope.0.check_timeout()?;
         }
 
         // Reached only on a clean scan exit (EOF or `Stop`); a timed-out scan
-        // propagates via `?` or an `AdhocStrategy::TimedOut` return above and
-        // never gets here. Rerank while `scope` is alive, so the source's scan
-        // resources are still held.
+        // propagates earlier.
         if scope.0.should_rerank() && !self.heap.is_empty() {
             let mut entries: Vec<_> = self.heap.drain_unsorted().collect();
             scope.0.rerank(&mut entries);
@@ -317,7 +313,12 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             let item = self.direct_batch.as_mut().and_then(S::Batch::next);
 
             match item {
-                Some((doc_id, _)) if self.source.is_expired(doc_id) => continue,
+                Some((doc_id, _)) if self.source.is_expired(doc_id) => {
+                    // Poll the deadline so a long run of expired docs cannot
+                    // drain the batch past the timeout.
+                    self.source.check_timeout()?;
+                    continue;
+                }
                 Some((doc_id, score)) => {
                     let result = self.source.build_result(doc_id, score);
                     self.current = Some(result);
@@ -336,10 +337,9 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
     /// Yield the next result from the pre-sorted `results` vec.
     ///
     /// Results whose document expired ([`ScoreSource::is_expired`]) since
-    /// collection are dropped without replacement, mirroring the C
-    /// `HybridIterator`'s pop-time expiration check: expired docs occupied
-    /// their top-k slots during collection, so they shrink the yielded count
-    /// rather than being refilled from lower-scored candidates.
+    /// collection are dropped without replacement: they occupied their top-k
+    /// slots during collection, so they shrink the yielded count rather than
+    /// being refilled from lower-scored candidates.
     fn advance_from_results(
         &mut self,
     ) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
@@ -351,6 +351,9 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             let ScoredResult { doc_id, score } = self.results[self.yield_pos];
             self.yield_pos += 1;
             if self.source.is_expired(doc_id) {
+                // Poll the deadline so a long run of expired docs cannot
+                // drain the heap past the timeout.
+                self.source.check_timeout()?;
                 continue;
             }
             let result = self.source.build_result(doc_id, score);

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -183,6 +183,10 @@ impl ScoreSource for MockScoreSource {
         (self.batch_strategy)(heap_count, k)
     }
 
+    fn adhoc_check_timeout(&mut self) -> bool {
+        return false;
+    }
+
     fn should_rerank(&self) -> bool {
         self.rerank_scores.is_some()
     }

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -174,8 +174,8 @@ impl ScoreSource for MockScoreSource {
         self.scores.get(&doc_id).copied()
     }
 
-    fn is_expired(&self, doc_id: DocId) -> bool {
-        self.expired.contains(&doc_id)
+    fn is_expired(&self, result: &RSIndexResult) -> bool {
+        self.expired.contains(&result.doc_id)
     }
 
     fn num_estimated(&self) -> usize {

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -90,6 +90,11 @@ pub struct MockScoreSource {
     rerank_scores: Option<HashMap<DocId, f64>>,
     /// Doc ids reported expired by [`ScoreSource::is_expired`]. Empty by default.
     expired: HashSet<DocId>,
+    /// Number of [`ScoreSource::check_timeout`] calls after which it starts
+    /// reporting a fired deadline. `None` (default) never times out.
+    timeout_after_n_checks: Option<usize>,
+    /// Count of [`ScoreSource::check_timeout`] calls so far.
+    n_timeout_checks: usize,
 }
 
 impl MockScoreSource {
@@ -116,6 +121,8 @@ impl MockScoreSource {
             num_estimated,
             rerank_scores: None,
             expired: HashSet::new(),
+            timeout_after_n_checks: None,
+            n_timeout_checks: 0,
         }
     }
 
@@ -137,6 +144,13 @@ impl MockScoreSource {
     /// Report the given doc ids as expired from [`ScoreSource::is_expired`].
     pub fn with_expired(mut self, docs: impl IntoIterator<Item = DocId>) -> Self {
         self.expired = docs.into_iter().collect();
+        self
+    }
+
+    /// Make [`ScoreSource::check_timeout`] report a fired deadline from its
+    /// `n`-th call onward (1-based).
+    pub fn with_timeout_after(mut self, n: usize) -> Self {
+        self.timeout_after_n_checks = Some(n);
         self
     }
 }
@@ -183,8 +197,15 @@ impl ScoreSource for MockScoreSource {
         (self.batch_strategy)(heap_count, k)
     }
 
-    fn adhoc_check_timeout(&mut self) -> bool {
-        return false;
+    fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+        self.n_timeout_checks += 1;
+        if self
+            .timeout_after_n_checks
+            .is_some_and(|n| self.n_timeout_checks >= n)
+        {
+            return Err(RQEIteratorError::TimedOut);
+        }
+        Ok(())
     }
 
     fn should_rerank(&self) -> bool {

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -12,7 +12,7 @@
 //!
 //! Gated behind the `test-utils` feature.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use index_result::RSIndexResult;
 use rqe_core::DocId;
@@ -88,6 +88,8 @@ pub struct MockScoreSource {
     /// reranking (the default); `Some` map rescores any retained doc it
     /// contains and leaves the rest untouched.
     rerank_scores: Option<HashMap<DocId, f64>>,
+    /// Doc ids reported expired by [`ScoreSource::is_expired`]. Empty by default.
+    expired: HashSet<DocId>,
 }
 
 impl MockScoreSource {
@@ -113,6 +115,7 @@ impl MockScoreSource {
             batch_strategy: Box::new(batch_strategy),
             num_estimated,
             rerank_scores: None,
+            expired: HashSet::new(),
         }
     }
 
@@ -128,6 +131,12 @@ impl MockScoreSource {
     /// of labels with no exact distance.
     pub fn with_rerank(mut self, scores: Vec<(DocId, f64)>) -> Self {
         self.rerank_scores = Some(scores.into_iter().collect());
+        self
+    }
+
+    /// Report the given doc ids as expired from [`ScoreSource::is_expired`].
+    pub fn with_expired(mut self, docs: impl IntoIterator<Item = DocId>) -> Self {
+        self.expired = docs.into_iter().collect();
         self
     }
 }
@@ -149,6 +158,10 @@ impl ScoreSource for MockScoreSource {
 
     fn lookup_score(&mut self, doc_id: DocId) -> Option<f64> {
         self.scores.get(&doc_id).copied()
+    }
+
+    fn is_expired(&self, doc_id: DocId) -> bool {
+        self.expired.contains(&doc_id)
     }
 
     fn num_estimated(&self) -> usize {

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -118,13 +118,13 @@ pub trait ScoreSource {
     /// Used in Adhoc-BF mode where the child iterator drives traversal.
     fn lookup_score(&mut self, doc_id: DocId) -> Option<f64>;
 
-    /// Whether `doc_id` is no longer valid and must not be surfaced
+    /// Whether `result` is no longer valid and must not be surfaced
     /// (e.g. its field has expired).
     ///
-    /// Queried per result as it is about to be yielded, so the answer must
-    /// reflect the document's current state rather than state captured during
+    /// Queried on the result about to be yielded, so the answer must reflect
+    /// the document's current state rather than state captured during
     /// collection. The default never expires.
-    fn is_expired(&self, _doc_id: DocId) -> bool {
+    fn is_expired(&self, _result: &RSIndexResult) -> bool {
         false
     }
 

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -118,16 +118,12 @@ pub trait ScoreSource {
     /// Used in Adhoc-BF mode where the child iterator drives traversal.
     fn lookup_score(&mut self, doc_id: DocId) -> Option<f64>;
 
-    /// Whether `doc_id` must be dropped at yield time (e.g. its field expired).
+    /// Whether `doc_id` is no longer valid and must not be surfaced
+    /// (e.g. its field has expired).
     ///
-    /// [`TopKIterator`] consults this for each result it is about to yield,
-    /// after collection has finished. A `true` answer drops the result without
-    /// replacement: the document still occupied its top-k slot during
-    /// collection, so expiration reduces the number of yielded results rather
-    /// than letting lower-scored candidates take its place. The default never
-    /// expires.
-    ///
-    /// [`TopKIterator`]: crate::TopKIterator
+    /// Queried per result as it is about to be yielded, so the answer must
+    /// reflect the document's current state rather than state captured during
+    /// collection. The default never expires.
     fn is_expired(&self, _doc_id: DocId) -> bool {
         false
     }
@@ -221,9 +217,9 @@ pub trait ScoreSource {
     /// - `k` — the target number of results.
     fn batch_strategy(&mut self, heap_count: usize, k: usize) -> BatchStrategy;
 
-    /// Checked only in Adhoc-BF mode, returns `true` if the iteration needs to abort
-    /// completely due to a timeout.
-    fn adhoc_check_timeout(&mut self) -> bool;
+    /// Poll the query deadline, returning [`RQEIteratorError::TimedOut`] once
+    /// it has been reached.
+    fn check_timeout(&mut self) -> Result<(), RQEIteratorError>;
 
     /// The [`IteratorType`] that the wrapping [`TopKIterator`] should report.
     ///

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -118,6 +118,20 @@ pub trait ScoreSource {
     /// Used in Adhoc-BF mode where the child iterator drives traversal.
     fn lookup_score(&mut self, doc_id: DocId) -> Option<f64>;
 
+    /// Whether `doc_id` must be dropped at yield time (e.g. its field expired).
+    ///
+    /// [`TopKIterator`] consults this for each result it is about to yield,
+    /// after collection has finished. A `true` answer drops the result without
+    /// replacement: the document still occupied its top-k slot during
+    /// collection, so expiration reduces the number of yielded results rather
+    /// than letting lower-scored candidates take its place. The default never
+    /// expires.
+    ///
+    /// [`TopKIterator`]: crate::TopKIterator
+    fn is_expired(&self, _doc_id: DocId) -> bool {
+        false
+    }
+
     /// Called at the start of an adhoc scan, before any
     /// [`lookup_score`](Self::lookup_score) call in that scan.
     ///

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -221,6 +221,10 @@ pub trait ScoreSource {
     /// - `k` — the target number of results.
     fn batch_strategy(&mut self, heap_count: usize, k: usize) -> BatchStrategy;
 
+    /// Checked only in Adhoc-BF mode, returns `true` if the iteration needs to abort
+    /// completely due to a timeout.
+    fn adhoc_check_timeout(&mut self) -> bool;
+
     /// The [`IteratorType`] that the wrapping [`TopKIterator`] should report.
     ///
     /// [`TopKIterator`]: crate::TopKIterator

--- a/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
+++ b/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
@@ -75,6 +75,10 @@ impl ScoreSource for CallCountingScoreSource {
         BatchStrategy::Continue
     }
 
+    fn adhoc_check_timeout(&mut self) -> bool {
+        false
+    }
+
     fn begin_adhoc(&mut self) {
         self.begin_calls += 1;
     }

--- a/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
+++ b/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
@@ -75,8 +75,8 @@ impl ScoreSource for CallCountingScoreSource {
         BatchStrategy::Continue
     }
 
-    fn adhoc_check_timeout(&mut self) -> bool {
-        false
+    fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+        Ok(())
     }
 
     fn begin_adhoc(&mut self) {

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -14,7 +14,6 @@ use std::{cmp::Ordering, num::NonZeroUsize};
 use rqe_core::DocId;
 
 use index_result::RSIndexResult;
-use index_spec::IndexSpecReadGuard;
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::{
     IdList, RQEIterator, RQEIteratorError, c2rust::CRQEIterator, interop::ProfileChildren,
@@ -24,62 +23,6 @@ use top_k::{
 };
 
 // ── Error path stubs ─────────────────────────────────────────────────────────────
-
-/// Child iterator whose `revalidate` unconditionally returns `Aborted`.
-///
-/// The `Ok` delegation path is covered by [`rqe_iterators::Empty`], which
-/// already returns `Ok` from `revalidate`.  This stub only exists for the
-/// case that cannot be expressed with any existing public iterator type.
-struct AbortOnRevalidate;
-
-impl<'index> rqe_iterators::RQEIterator<'index> for AbortOnRevalidate {
-    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
-        None
-    }
-
-    fn read(
-        &mut self,
-    ) -> Result<Option<&mut RSIndexResult<'index>>, rqe_iterators::RQEIteratorError> {
-        Ok(None)
-    }
-
-    fn skip_to(
-        &mut self,
-        _doc_id: DocId,
-    ) -> Result<Option<rqe_iterators::SkipToOutcome<'_, 'index>>, rqe_iterators::RQEIteratorError>
-    {
-        unimplemented!()
-    }
-
-    fn revalidate(
-        &mut self,
-        _spec: &IndexSpecReadGuard,
-    ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        Ok(rqe_iterators::RQEValidateStatus::Aborted)
-    }
-
-    fn rewind(&mut self) {}
-
-    fn num_estimated(&self) -> usize {
-        0
-    }
-
-    fn last_doc_id(&self) -> DocId {
-        0
-    }
-
-    fn at_eof(&self) -> bool {
-        true
-    }
-
-    fn type_(&self) -> rqe_iterator_type::IteratorType {
-        rqe_iterator_type::IteratorType::Mock
-    }
-
-    fn intersection_sort_weight(&self, _: bool) -> f64 {
-        1.0
-    }
-}
 
 /// [`ScoreSource`] whose [`ScoreSource::next_batch`] unconditionally returns [`RQEIteratorError::TimedOut`].
 ///
@@ -238,39 +181,7 @@ fn unfiltered_empty_source_is_immediate_eof() {
     assert!(it.at_eof());
 }
 
-// ── Revalidation ──────────────────────────────────────────────────────────────
-
-#[test]
-fn revalidate_without_child_returns_ok() {
-    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
-    let mut it = TopKIterator::new_unfiltered(source, NonZeroUsize::new(5).unwrap(), asc);
-    let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
-    assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
-}
-
-#[test]
-fn revalidate_with_child_delegates_ok() {
-    // rqe_iterators::Empty::revalidate returns Ok, so it is the natural stand-in
-    // for any child iterator that leaves the parent in a valid state.
-    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
-    let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(rqe_iterators::Empty::default());
-    let mut it = TopKIterator::new(source, child, NonZeroUsize::new(5).unwrap(), asc);
-    let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
-
-    assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
-}
-
-#[test]
-fn revalidate_with_child_delegates_aborted() {
-    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
-    let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(AbortOnRevalidate);
-    let mut it = TopKIterator::new(source, child, NonZeroUsize::new(5).unwrap(), asc);
-    let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
-    assert_eq!(status, rqe_iterators::RQEValidateStatus::Aborted);
-}
+// ── Timeout ─────────────────────────────────────────────────────────────────
 
 #[test]
 fn unfiltered_timeout_propagated() {

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -308,7 +308,7 @@ fn unfiltered_expired_docs_dropped_at_yield() {
 #[test]
 fn unfiltered_timeout_polled_while_skipping_expired() {
     // A run of expired docs at the front of the direct batch must not drain past
-    // the deadline: the timeout poll on the expired-skip path fires and surfaces
+    // the deadline: the per-step poll fires on the expired skip and surfaces
     // TimedOut instead of skipping ahead to the live doc 3.
     let source = MockScoreSource::new(vec![vec![(1, 0.1), (2, 0.2), (3, 0.3)]], vec![], |_, _| {
         BatchStrategy::Continue
@@ -322,8 +322,8 @@ fn unfiltered_timeout_polled_while_skipping_expired() {
 #[test]
 fn yield_timeout_polled_while_skipping_expired() {
     // Collected top-k results that expired must not drain past the deadline at
-    // yield time: the poll fires and surfaces TimedOut instead of skipping ahead
-    // to the live doc 3.
+    // yield time: the per-step poll fires on the expired skip and surfaces
+    // TimedOut instead of skipping ahead to the live doc 3.
     let source = MockScoreSource::new(vec![vec![(1, 0.1), (2, 0.2), (3, 0.3)]], vec![], |_, _| {
         BatchStrategy::Stop
     })
@@ -335,6 +335,38 @@ fn yield_timeout_polled_while_skipping_expired() {
         NonZeroUsize::new(3).unwrap(),
         asc,
     );
+    assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
+}
+
+#[test]
+fn unfiltered_timeout_polled_before_yielding_valid() {
+    // No docs expire, so the deadline is never reached via an expired skip. It
+    // must still stop yielding: the first read returns a live doc, the second
+    // trips the per-step poll instead of streaming the rest of the batch.
+    let source = MockScoreSource::new(vec![vec![(1, 0.1), (2, 0.2), (3, 0.3)]], vec![], |_, _| {
+        BatchStrategy::Continue
+    })
+    .with_timeout_after(2);
+    let mut it = TopKIterator::new_unfiltered(source, NonZeroUsize::new(3).unwrap(), asc);
+    assert_eq!(it.read().unwrap().map(|r| r.doc_id), Some(1));
+    assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
+}
+
+#[test]
+fn yield_timeout_polled_before_yielding_valid() {
+    // Same guarantee on the heap-backed yield path: with no expired docs, the
+    // deadline still halts yielding after the first live result.
+    let source = MockScoreSource::new(vec![vec![(1, 0.1), (2, 0.2), (3, 0.3)]], vec![], |_, _| {
+        BatchStrategy::Stop
+    })
+    .with_timeout_after(2);
+    let mut it = TopKIterator::new(
+        source,
+        make_child(vec![1, 2, 3]),
+        NonZeroUsize::new(3).unwrap(),
+        asc,
+    );
+    assert_eq!(it.read().unwrap().map(|r| r.doc_id), Some(1));
     assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
 }
 

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -114,6 +114,10 @@ impl ScoreSource for TimingOutSource {
         BatchStrategy::Continue
     }
 
+    fn adhoc_check_timeout(&mut self) -> bool {
+        false
+    }
+
     fn iterator_type(&self) -> rqe_iterator_type::IteratorType {
         rqe_iterator_type::IteratorType::Mock
     }
@@ -468,6 +472,10 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
             BatchStrategy::Continue
         }
 
+        fn adhoc_check_timeout(&mut self) -> bool {
+            false
+        }
+
         fn iterator_type(&self) -> rqe_iterator_type::IteratorType {
             rqe_iterator_type::IteratorType::Mock
         }
@@ -644,6 +652,57 @@ fn adhoc_empty_child_is_eof() {
     );
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
+}
+
+/// An adhoc scan that hits the query deadline mid-walk must abort with
+/// [`RQEIteratorError::TimedOut`], not return a truncated top-k.
+#[test]
+fn adhoc_timeout_propagated() {
+    // Returns `TimedOut` from the second `adhoc_strategy` call, simulating the
+    // deadline firing after one document has been scored.
+    struct TimingOutAdhocSource {
+        adhoc_calls: u32,
+    }
+    impl ScoreSource for TimingOutAdhocSource {
+        type Batch = MockScoreBatch;
+        fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
+            Ok(None)
+        }
+        fn lookup_score(&mut self, _: DocId) -> Option<f64> {
+            Some(1.0)
+        }
+        fn num_estimated(&self) -> usize {
+            0
+        }
+        fn rewind(&mut self) {
+            self.adhoc_calls = 0;
+        }
+        fn build_result<'r>(&self, doc_id: DocId, _: f64) -> RSIndexResult<'r>
+        where
+            Self: 'r,
+        {
+            RSIndexResult::build_virt().doc_id(doc_id).build()
+        }
+        fn batch_strategy(&mut self, _: usize, _: usize) -> BatchStrategy {
+            BatchStrategy::Continue
+        }
+        fn adhoc_check_timeout(&mut self) -> bool {
+            self.adhoc_calls += 1;
+            if self.adhoc_calls >= 2 { true } else { false }
+        }
+        fn iterator_type(&self) -> IteratorType {
+            IteratorType::Mock
+        }
+    }
+
+    let mut it = TopKIterator::new_with_mode(
+        TimingOutAdhocSource { adhoc_calls: 0 },
+        Some(make_child(vec![1, 2, 3, 4, 5])),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+        TopKMode::AdhocBF,
+    );
+    assert!(matches!(it.read().unwrap_err(), RQEIteratorError::TimedOut));
 }
 
 // ── ProfileChildren ───────────────────────────────────────────────────────────

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -348,6 +348,49 @@ fn batches_multiple_batches() {
 }
 
 #[test]
+fn batches_expired_doc_shrinks_results_without_refill() {
+    // Doc 1 expires after collection. It still fills the heap to k=2 during
+    // batch 1 (so the strategy sees a full heap and stops — batch 2's better
+    // candidate 3 is never pulled), and is dropped only at yield. Expiration
+    // must shrink the result count, not refill from candidate 3.
+    let source = MockScoreSource::new(
+        vec![vec![(1, 1.0), (2, 2.0)], vec![(3, 0.5)]],
+        vec![],
+        |count, k| {
+            if count >= k {
+                BatchStrategy::Stop
+            } else {
+                BatchStrategy::Continue
+            }
+        },
+    )
+    .with_expired([1]);
+    let mut it = TopKIterator::new(
+        source,
+        make_child(vec![1, 2, 3]),
+        NonZeroUsize::new(2).unwrap(),
+        asc,
+    );
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids, vec![2]);
+    assert!(it.at_eof());
+}
+
+#[test]
+fn unfiltered_expired_docs_dropped_at_yield() {
+    // The single direct batch is the complete result set; expired entries are
+    // skipped while streaming, shrinking the yielded count.
+    let source = MockScoreSource::new(vec![vec![(1, 0.1), (2, 0.2), (3, 0.3)]], vec![], |_, _| {
+        BatchStrategy::Continue
+    })
+    .with_expired([1, 3]);
+    let mut it = TopKIterator::new_unfiltered(source, NonZeroUsize::new(3).unwrap(), asc);
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids, vec![2]);
+    assert!(it.at_eof());
+}
+
+#[test]
 fn strategy_stop_stops_after_first_batch() {
     let source = MockScoreSource::new(
         vec![
@@ -565,6 +608,28 @@ fn adhoc_child_eof_returns_what_was_found() {
     );
     let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(doc_ids, vec![1, 2]);
+}
+
+#[test]
+fn adhoc_expired_doc_shrinks_results_without_refill() {
+    // k=2; the best two scores are docs 1 (0.1) and 2 (0.2), so doc 3 (0.3)
+    // never enters the heap. Doc 1 expires after collection: it is dropped at
+    // yield without refilling from doc 3, mirroring the C HybridIterator's
+    // pop-time check.
+    let source = MockScoreSource::new(vec![], vec![(1, 0.1), (2, 0.2), (3, 0.3)], |_, _| {
+        BatchStrategy::Continue
+    })
+    .with_expired([1]);
+    let mut it = TopKIterator::new_with_mode(
+        source,
+        Some(make_child(vec![1, 2, 3])),
+        NonZeroUsize::new(2).unwrap(),
+        asc,
+        TopKMode::AdhocBF,
+    );
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids, vec![2]);
+    assert!(it.at_eof());
 }
 
 #[test]

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -57,8 +57,8 @@ impl ScoreSource for TimingOutSource {
         BatchStrategy::Continue
     }
 
-    fn adhoc_check_timeout(&mut self) -> bool {
-        false
+    fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+        Ok(())
     }
 
     fn iterator_type(&self) -> rqe_iterator_type::IteratorType {
@@ -306,6 +306,39 @@ fn unfiltered_expired_docs_dropped_at_yield() {
 }
 
 #[test]
+fn unfiltered_timeout_polled_while_skipping_expired() {
+    // A run of expired docs at the front of the direct batch must not drain past
+    // the deadline: the timeout poll on the expired-skip path fires and surfaces
+    // TimedOut instead of skipping ahead to the live doc 3.
+    let source = MockScoreSource::new(vec![vec![(1, 0.1), (2, 0.2), (3, 0.3)]], vec![], |_, _| {
+        BatchStrategy::Continue
+    })
+    .with_expired([1, 2])
+    .with_timeout_after(1);
+    let mut it = TopKIterator::new_unfiltered(source, NonZeroUsize::new(3).unwrap(), asc);
+    assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
+}
+
+#[test]
+fn yield_timeout_polled_while_skipping_expired() {
+    // Collected top-k results that expired must not drain past the deadline at
+    // yield time: the poll fires and surfaces TimedOut instead of skipping ahead
+    // to the live doc 3.
+    let source = MockScoreSource::new(vec![vec![(1, 0.1), (2, 0.2), (3, 0.3)]], vec![], |_, _| {
+        BatchStrategy::Stop
+    })
+    .with_expired([1, 2])
+    .with_timeout_after(1);
+    let mut it = TopKIterator::new(
+        source,
+        make_child(vec![1, 2, 3]),
+        NonZeroUsize::new(3).unwrap(),
+        asc,
+    );
+    assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
+}
+
+#[test]
 fn strategy_stop_stops_after_first_batch() {
     let source = MockScoreSource::new(
         vec![
@@ -383,8 +416,8 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
             BatchStrategy::Continue
         }
 
-        fn adhoc_check_timeout(&mut self) -> bool {
-            false
+        fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+            Ok(())
         }
 
         fn iterator_type(&self) -> rqe_iterator_type::IteratorType {
@@ -597,9 +630,13 @@ fn adhoc_timeout_propagated() {
         fn batch_strategy(&mut self, _: usize, _: usize) -> BatchStrategy {
             BatchStrategy::Continue
         }
-        fn adhoc_check_timeout(&mut self) -> bool {
+        fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
             self.adhoc_calls += 1;
-            if self.adhoc_calls >= 2 { true } else { false }
+            if self.adhoc_calls >= 2 {
+                Err(RQEIteratorError::TimedOut)
+            } else {
+                Ok(())
+            }
         }
         fn iterator_type(&self) -> IteratorType {
             IteratorType::Mock

--- a/src/redisearch_rs/top_k/tests/integration/main.rs
+++ b/src/redisearch_rs/top_k/tests/integration/main.rs
@@ -14,3 +14,4 @@ extern crate redisearch_rs;
 
 mod adhoc_lifecycle;
 mod iterator;
+mod revalidation;

--- a/src/redisearch_rs/top_k/tests/integration/revalidation.rs
+++ b/src/redisearch_rs/top_k/tests/integration/revalidation.rs
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Integration tests for [`TopKIterator::revalidate`].
+
+use std::{cmp::Ordering, num::NonZeroUsize};
+
+use index_result::RSIndexResult;
+use index_spec::IndexSpecReadGuard;
+use rqe_core::DocId;
+use rqe_iterators::{RQEIterator, RQEValidateStatus};
+use top_k::{BatchStrategy, TopKIterator, mock::MockScoreSource};
+
+/// Ascending comparator: lower score is better (e.g. vector distance).
+fn asc(a: f64, b: f64) -> Ordering {
+    a.partial_cmp(&b).unwrap_or(Ordering::Equal)
+}
+
+/// Child iterator whose `revalidate` unconditionally returns `Aborted`.
+///
+/// The `Ok` delegation path is covered by [`rqe_iterators::Empty`], which
+/// already returns `Ok` from `revalidate`.  This stub only exists for the
+/// case that cannot be expressed with any existing public iterator type.
+struct AbortOnRevalidate;
+
+impl<'index> RQEIterator<'index> for AbortOnRevalidate {
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        None
+    }
+
+    fn read(
+        &mut self,
+    ) -> Result<Option<&mut RSIndexResult<'index>>, rqe_iterators::RQEIteratorError> {
+        Ok(None)
+    }
+
+    fn skip_to(
+        &mut self,
+        _doc_id: DocId,
+    ) -> Result<Option<rqe_iterators::SkipToOutcome<'_, 'index>>, rqe_iterators::RQEIteratorError>
+    {
+        unimplemented!()
+    }
+
+    fn revalidate(
+        &mut self,
+        _spec: &IndexSpecReadGuard,
+    ) -> Result<RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
+        Ok(RQEValidateStatus::Aborted)
+    }
+
+    fn rewind(&mut self) {}
+
+    fn num_estimated(&self) -> usize {
+        0
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        0
+    }
+
+    fn at_eof(&self) -> bool {
+        true
+    }
+
+    fn type_(&self) -> rqe_iterator_type::IteratorType {
+        rqe_iterator_type::IteratorType::Mock
+    }
+
+    fn intersection_sort_weight(&self, _: bool) -> f64 {
+        1.0
+    }
+}
+
+/// Child iterator whose `revalidate` reports `Moved` to a new current document.
+///
+/// Used to verify the parent collapses a moved child to `Ok` rather than
+/// surfacing the child's reposition as its own.
+struct MovedOnRevalidate<'index> {
+    current: RSIndexResult<'index>,
+}
+
+impl<'index> MovedOnRevalidate<'index> {
+    fn new() -> Self {
+        Self {
+            current: RSIndexResult::build_virt().doc_id(7).build(),
+        }
+    }
+}
+
+impl<'index> RQEIterator<'index> for MovedOnRevalidate<'index> {
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        None
+    }
+
+    fn read(
+        &mut self,
+    ) -> Result<Option<&mut RSIndexResult<'index>>, rqe_iterators::RQEIteratorError> {
+        Ok(None)
+    }
+
+    fn skip_to(
+        &mut self,
+        _doc_id: DocId,
+    ) -> Result<Option<rqe_iterators::SkipToOutcome<'_, 'index>>, rqe_iterators::RQEIteratorError>
+    {
+        unimplemented!()
+    }
+
+    fn revalidate(
+        &mut self,
+        _spec: &IndexSpecReadGuard,
+    ) -> Result<RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
+        Ok(RQEValidateStatus::Moved {
+            current: Some(&mut self.current),
+        })
+    }
+
+    fn rewind(&mut self) {}
+
+    fn num_estimated(&self) -> usize {
+        0
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        7
+    }
+
+    fn at_eof(&self) -> bool {
+        false
+    }
+
+    fn type_(&self) -> rqe_iterator_type::IteratorType {
+        rqe_iterator_type::IteratorType::Mock
+    }
+
+    fn intersection_sort_weight(&self, _: bool) -> f64 {
+        1.0
+    }
+}
+
+#[test]
+fn without_child_returns_ok() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
+    let mut it = TopKIterator::new_unfiltered(source, NonZeroUsize::new(5).unwrap(), asc);
+    let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
+    assert_eq!(status, RQEValidateStatus::Ok);
+}
+
+#[test]
+fn with_child_delegates_ok() {
+    // rqe_iterators::Empty::revalidate returns Ok, so it is the natural stand-in
+    // for any child iterator that leaves the parent in a valid state.
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
+    let child: Box<dyn RQEIterator<'_>> = Box::new(rqe_iterators::Empty::default());
+    let mut it = TopKIterator::new(source, child, NonZeroUsize::new(5).unwrap(), asc);
+    let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
+    assert_eq!(status, RQEValidateStatus::Ok);
+}
+
+#[test]
+fn with_child_delegates_aborted() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
+    let child: Box<dyn RQEIterator<'_>> = Box::new(AbortOnRevalidate);
+    let mut it = TopKIterator::new(source, child, NonZeroUsize::new(5).unwrap(), asc);
+    let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
+    assert_eq!(status, RQEValidateStatus::Aborted);
+}
+
+#[test]
+fn moved_child_collapses_to_ok() {
+    // We yield from our own score-ordered buffer, so a child that repositions
+    // does not move our cursor: the parent must report Ok, not Moved.
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
+    let child: Box<dyn RQEIterator<'_>> = Box::new(MovedOnRevalidate::new());
+    let mut it = TopKIterator::new(source, child, NonZeroUsize::new(5).unwrap(), asc);
+    let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
+    assert_eq!(status, RQEValidateStatus::Ok);
+}

--- a/src/redisearch_rs/vector_score_source/Cargo.toml
+++ b/src/redisearch_rs/vector_score_source/Cargo.toml
@@ -30,4 +30,5 @@ redisearch_rs = {path = "../c_entrypoint/redisearch_rs", features = [
 ]}
 rqe_core.workspace = true
 rqe_iterators = {workspace = true, features = ["unittest"]}
+rqe_iterators_test_utils.workspace = true
 vector_score_source = {path = ".", features = ["unittest"]}

--- a/src/redisearch_rs/vector_score_source/src/lib.rs
+++ b/src/redisearch_rs/vector_score_source/src/lib.rs
@@ -35,14 +35,18 @@ pub use source::VectorScoreSource;
 use std::{cmp::Ordering, num::NonZeroUsize};
 
 use ffi::{VecSearchMode_HYBRID_ADHOC_BF, VecSearchMode_HYBRID_BATCHES};
-use rqe_iterators::RQEIterator;
+use rqe_iterators::{ExpirationChecker, FieldExpirationChecker, RQEIterator};
 use top_k::{TopKIterator, TopKMode};
 
 /// A [`TopKIterator`] parameterised over [`VectorScoreSource`].
 ///
 /// Use [`new_vector_top_k_unfiltered`] or [`new_vector_top_k_filtered`]
 /// to construct one; these constructors encode the mode-selection logic.
-pub type VectorTopKIterator<'index> = TopKIterator<'index, VectorScoreSource<'index>>;
+///
+/// `E` is the [`ExpirationChecker`] strategy, defaulting to the production
+/// [`FieldExpirationChecker`].
+pub type VectorTopKIterator<'index, E = FieldExpirationChecker> =
+    TopKIterator<'index, VectorScoreSource<'index, E>>;
 
 /// Ascending comparator — lower distance score is better (vector L2/IP/Cosine).
 fn asc_cmp(a: f64, b: f64) -> Ordering {
@@ -53,10 +57,10 @@ fn asc_cmp(a: f64, b: f64) -> Ordering {
 ///
 /// Results are streamed directly from the VecSim batch without a heap,
 /// using the [`TopKMode::Unfiltered`] path.
-pub fn new_vector_top_k_unfiltered<'index>(
-    source: VectorScoreSource<'index>,
+pub fn new_vector_top_k_unfiltered<'index, E: ExpirationChecker + 'index>(
+    source: VectorScoreSource<'index, E>,
     k: NonZeroUsize,
-) -> VectorTopKIterator<'index> {
+) -> VectorTopKIterator<'index, E> {
     TopKIterator::new_with_mode(source, None, k, asc_cmp, TopKMode::Unfiltered)
 }
 
@@ -75,11 +79,11 @@ pub fn new_vector_top_k_unfiltered<'index>(
 /// [`VectorScoreSource::requested_search_mode`]: source::VectorScoreSource::requested_search_mode
 /// [`VecSimIndex_PreferAdHocSearch`]: ffi::VecSimIndex_PreferAdHocSearch
 /// [`BatchStrategy::SwitchToAdhoc`]: top_k::BatchStrategy::SwitchToAdhoc
-pub fn new_vector_top_k_filtered<'index>(
-    source: VectorScoreSource<'index>,
+pub fn new_vector_top_k_filtered<'index, E: ExpirationChecker + 'index>(
+    source: VectorScoreSource<'index, E>,
     child: impl RQEIterator<'index> + 'index,
     k: NonZeroUsize,
-) -> VectorTopKIterator<'index> {
+) -> VectorTopKIterator<'index, E> {
     new_vector_top_k_filtered_boxed(source, Box::new(child), k)
 }
 
@@ -91,11 +95,11 @@ pub fn new_vector_top_k_filtered<'index>(
 /// Delegates mode selection to source.
 ///
 /// [`VecSimIndex_PreferAdHocSearch`]: ffi::VecSimIndex_PreferAdHocSearch
-pub fn new_vector_top_k_filtered_boxed<'index>(
-    source: VectorScoreSource<'index>,
+pub fn new_vector_top_k_filtered_boxed<'index, E: ExpirationChecker + 'index>(
+    source: VectorScoreSource<'index, E>,
     child: Box<dyn RQEIterator<'index> + 'index>,
     k: NonZeroUsize,
-) -> VectorTopKIterator<'index> {
+) -> VectorTopKIterator<'index, E> {
     // The user pinned a policy via HYBRID_POLICY: honor it verbatim. HYBRID_BATCHES
     // also suppresses the mid-run switch to adhoc — the C reader's
     // `reviewHybridSearchPolicy` returns false for it — which is exactly what

--- a/src/redisearch_rs/vector_score_source/src/score_batch.rs
+++ b/src/redisearch_rs/vector_score_source/src/score_batch.rs
@@ -14,6 +14,10 @@ use top_k::ScoreBatch;
 use vecsim::ReplyResults;
 
 /// Adapts [`ReplyResults`] to the [`ScoreBatch`] interface.
+///
+/// The batch yields every reply entry, expired documents included; expiration
+/// is checked at yield time by the wrapping iterator (see
+/// [`VectorScoreSource::is_expired`](crate::VectorScoreSource)).
 pub struct VecSimScoreBatch {
     results: ReplyResults,
 }
@@ -26,7 +30,7 @@ impl VecSimScoreBatch {
 
 impl ScoreBatch for VecSimScoreBatch {
     fn next(&mut self) -> Option<(DocId, f64)> {
-        Iterator::next(&mut self.results)
+        self.results.next()
     }
 
     fn skip_to(&mut self, target: DocId) -> Option<(DocId, f64)> {

--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -12,8 +12,8 @@
 use std::{ffi::c_void, num::NonZeroUsize, ptr::NonNull};
 
 use ffi::{
-    TimeoutCtx, VecSearchMode, VecSearchMode_HYBRID_BATCHES, VecSimIndex, VecSimQueryParams,
-    timespec,
+    RS_VecSimCheckTimeout, TimeoutCtx, VecSearchMode, VecSearchMode_HYBRID_BATCHES, VecSimIndex,
+    VecSimQueryParams, timespec,
 };
 use index_result::RSIndexResult;
 use rqe_core::DocId;
@@ -404,6 +404,15 @@ impl<'index, E: ExpirationChecker> ScoreSource for VectorScoreSource<'index, E> 
     fn iterator_type(&self) -> rqe_iterators::IteratorType {
         // TODO: MOD-14206: Rename.
         rqe_iterators::IteratorType::Hybrid
+    }
+
+    fn adhoc_check_timeout(&mut self) -> bool {
+        // SAFETY: `as_mut()` gives a valid, exclusive borrow for the call; the
+        // source is single-threaded so the aliased raw pointer in
+        // `query_params.timeoutCtx` is idle. The callee reads the deadline and
+        // bumps the counter without retaining the pointer.
+        let timeout = unsafe { RS_VecSimCheckTimeout(self.timeout_ctx.as_mut()) };
+        timeout != 0
     }
 
     fn batch_strategy(&mut self, heap_count: usize, k: usize) -> BatchStrategy {

--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -104,7 +104,7 @@ pub struct VectorScoreSource<'index, E: ExpirationChecker = FieldExpirationCheck
 // thread). The `index` pointer is non-owning; everything else is owned and
 // managed by the struct itself (timeout_ctx, batch_iter). It is the caller's
 // responsibility to ensure the index outlives the iterator.
-unsafe impl<E: ExpirationChecker> Send for VectorScoreSource<'_, E> {}
+unsafe impl<E: ExpirationChecker + Send> Send for VectorScoreSource<'_, E> {}
 
 impl<'index, E: ExpirationChecker> VectorScoreSource<'index, E> {
     /// Create a new `VectorScoreSource`.
@@ -406,13 +406,16 @@ impl<'index, E: ExpirationChecker> ScoreSource for VectorScoreSource<'index, E> 
         rqe_iterators::IteratorType::Hybrid
     }
 
-    fn adhoc_check_timeout(&mut self) -> bool {
+    fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
         // SAFETY: `as_mut()` gives a valid, exclusive borrow for the call; the
         // source is single-threaded so the aliased raw pointer in
         // `query_params.timeoutCtx` is idle. The callee reads the deadline and
         // bumps the counter without retaining the pointer.
         let timeout = unsafe { RS_VecSimCheckTimeout(self.timeout_ctx.as_mut()) };
-        timeout != 0
+        if timeout != 0 {
+            return Err(RQEIteratorError::TimedOut);
+        }
+        Ok(())
     }
 
     fn batch_strategy(&mut self, heap_count: usize, k: usize) -> BatchStrategy {

--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -408,9 +408,10 @@ impl<'index, E: ExpirationChecker> ScoreSource for VectorScoreSource<'index, E> 
 
     fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
         // SAFETY: `as_mut()` gives a valid, exclusive borrow for the call; the
-        // source is single-threaded so the aliased raw pointer in
-        // `query_params.timeoutCtx` is idle. The callee reads the deadline and
-        // bumps the counter without retaining the pointer.
+        // source is single-threaded so no other access to the aliased raw
+        // pointer in `query_params.timeoutCtx` is live during the call. The
+        // callee reads the deadline and bumps the counter without retaining the
+        // pointer.
         let timeout = unsafe { RS_VecSimCheckTimeout(self.timeout_ctx.as_mut()) };
         if timeout != 0 {
             return Err(RQEIteratorError::TimedOut);

--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -17,7 +17,7 @@ use ffi::{
 };
 use index_result::RSIndexResult;
 use rqe_core::DocId;
-use rqe_iterators::RQEIteratorError;
+use rqe_iterators::{ExpirationChecker, FieldExpirationChecker, RQEIteratorError};
 use top_k::{BatchStrategy, ScoreSource, ScoredResult};
 use vecsim::{
     AdhocBfCtx, BatchIterator, IndexRef, QueryError, QueryVector, ReplyOrder, SharedLockGuard,
@@ -50,7 +50,7 @@ enum AdhocPathState<'index> {
 ///
 /// - RAM uses the unsafe RAM distance lookup under shared locks
 /// - Disk uses a preprocessed [`AdhocBfCtx`] per scan.
-pub struct VectorScoreSource<'index> {
+pub struct VectorScoreSource<'index, E: ExpirationChecker = FieldExpirationChecker> {
     /// Non-owning reference to the VecSim index.
     ///
     /// `'index` reflects the [`VectorScoreSource::new`] safety contract: the C
@@ -94,15 +94,19 @@ pub struct VectorScoreSource<'index> {
     child_num_estimated: usize,
     /// `k - heap_count`, updated by `batch_strategy`. Reset on rewind.
     k_remaining: usize,
+
+    /// Optional field-expiration filter for the vector field, consulted at
+    /// yield time via [`ScoreSource::is_expired`].
+    expiration: Option<E>,
 }
 
 // SAFETY: VectorScoreSource is used from a single thread (the query execution
 // thread). The `index` pointer is non-owning; everything else is owned and
 // managed by the struct itself (timeout_ctx, batch_iter). It is the caller's
 // responsibility to ensure the index outlives the iterator.
-unsafe impl Send for VectorScoreSource<'_> {}
+unsafe impl<E: ExpirationChecker> Send for VectorScoreSource<'_, E> {}
 
-impl<'index> VectorScoreSource<'index> {
+impl<'index, E: ExpirationChecker> VectorScoreSource<'index, E> {
     /// Create a new `VectorScoreSource`.
     ///
     /// `timeout` is the query deadline as an absolute `timespec`.
@@ -127,6 +131,7 @@ impl<'index> VectorScoreSource<'index> {
         skip_timeout_checks: bool,
         child_num_estimated: usize,
         fixed_batch_size: usize,
+        expiration: Option<E>,
     ) -> Self {
         // SAFETY: caller-upheld: `index` is valid for the struct's lifetime.
         let index = unsafe { IndexRef::from_raw(index) };
@@ -161,6 +166,7 @@ impl<'index> VectorScoreSource<'index> {
             child_num_estimated,
             initial_child_num_estimated: child_num_estimated,
             k_remaining: k,
+            expiration,
         }
     }
 
@@ -205,9 +211,8 @@ impl<'index> VectorScoreSource<'index> {
     }
 }
 
-impl<'index> ScoreSource for VectorScoreSource<'index> {
+impl<'index, E: ExpirationChecker> ScoreSource for VectorScoreSource<'index, E> {
     type Batch = VecSimScoreBatch;
-
     fn all_results_unfiltered_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
         // Single-shot top-k query for the unfiltered path; called exactly once
         // per evaluation by `prepare_unfiltered_direct`.
@@ -285,6 +290,17 @@ impl<'index> ScoreSource for VectorScoreSource<'index> {
             AdhocPathState::Disk { ctx: Some(ctx) } => ctx.get_distance_from(doc_id),
             AdhocPathState::Disk { ctx: None } => None,
         }
+    }
+
+    fn is_expired(&self, doc_id: DocId) -> bool {
+        let Some(checker) = self.expiration.as_ref() else {
+            return false;
+        };
+        if !checker.has_expiration() {
+            return false;
+        }
+        let probe = RSIndexResult::build_virt().doc_id(doc_id).build();
+        checker.is_expired(&probe)
     }
 
     fn begin_adhoc(&mut self) {

--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -17,7 +17,7 @@ use ffi::{
 };
 use index_result::RSIndexResult;
 use rqe_core::DocId;
-use rqe_iterators::{ExpirationChecker, FieldExpirationChecker, RQEIteratorError};
+use rqe_iterators::{ExpirationChecker, RQEIteratorError};
 use top_k::{BatchStrategy, ScoreSource, ScoredResult};
 use vecsim::{
     AdhocBfCtx, BatchIterator, IndexRef, QueryError, QueryVector, ReplyOrder, SharedLockGuard,
@@ -50,7 +50,7 @@ enum AdhocPathState<'index> {
 ///
 /// - RAM uses the unsafe RAM distance lookup under shared locks
 /// - Disk uses a preprocessed [`AdhocBfCtx`] per scan.
-pub struct VectorScoreSource<'index, E: ExpirationChecker = FieldExpirationChecker> {
+pub struct VectorScoreSource<'index, E: ExpirationChecker> {
     /// Non-owning reference to the VecSim index.
     ///
     /// `'index` reflects the [`VectorScoreSource::new`] safety contract: the C
@@ -95,9 +95,9 @@ pub struct VectorScoreSource<'index, E: ExpirationChecker = FieldExpirationCheck
     /// `k - heap_count`, updated by `batch_strategy`. Reset on rewind.
     k_remaining: usize,
 
-    /// Optional field-expiration filter for the vector field, consulted at
-    /// yield time via [`ScoreSource::is_expired`].
-    expiration: Option<E>,
+    /// Field-expiration filter for the vector field, consulted at yield time
+    /// via [`ScoreSource::is_expired`]. Use [`NoOpChecker`](rqe_iterators::NoOpChecker) to disable.
+    expiration: E,
 }
 
 // SAFETY: VectorScoreSource is used from a single thread (the query execution
@@ -131,7 +131,7 @@ impl<'index, E: ExpirationChecker> VectorScoreSource<'index, E> {
         skip_timeout_checks: bool,
         child_num_estimated: usize,
         fixed_batch_size: usize,
-        expiration: Option<E>,
+        expiration: E,
     ) -> Self {
         // SAFETY: caller-upheld: `index` is valid for the struct's lifetime.
         let index = unsafe { IndexRef::from_raw(index) };
@@ -292,15 +292,8 @@ impl<'index, E: ExpirationChecker> ScoreSource for VectorScoreSource<'index, E> 
         }
     }
 
-    fn is_expired(&self, doc_id: DocId) -> bool {
-        let Some(checker) = self.expiration.as_ref() else {
-            return false;
-        };
-        if !checker.has_expiration() {
-            return false;
-        }
-        let probe = RSIndexResult::build_virt().doc_id(doc_id).build();
-        checker.is_expired(&probe)
+    fn is_expired(&self, result: &RSIndexResult) -> bool {
+        self.expiration.has_expiration() && self.expiration.is_expired(result)
     }
 
     fn begin_adhoc(&mut self) {
@@ -479,6 +472,7 @@ mod tests {
     use std::ptr::NonNull;
 
     use ffi::{VecSimIndex, VecSimIndex_Free};
+    use rqe_iterators::NoOpChecker;
     use top_k::ScoreSource;
 
     use super::refine_child_estimated;
@@ -516,7 +510,7 @@ mod tests {
         index: NonNull<VecSimIndex>,
         k: usize,
         child_est: usize,
-    ) -> VectorScoreSource<'static> {
+    ) -> VectorScoreSource<'static, NoOpChecker> {
         // SAFETY: caller upholds the `index` lifetime contract.
         unsafe { make_source(index, uniform_blob(0.0, 1), 0, k, child_est) }
     }

--- a/src/redisearch_rs/vector_score_source/src/test_utils.rs
+++ b/src/redisearch_rs/vector_score_source/src/test_utils.rs
@@ -21,7 +21,7 @@ use ffi::{
     VecSimIndex_New, VecSimMetric, VecSimMetric_VecSimMetric_Cosine, VecSimMetric_VecSimMetric_L2,
     VecSimParams, VecSimQueryParams, VecSimType_VecSimType_FLOAT32, t_docId,
 };
-use rqe_iterators::{IdList, RQEIterator};
+use rqe_iterators::{ExpirationChecker, FieldExpirationChecker, IdList, RQEIterator};
 
 use crate::VectorScoreSource;
 
@@ -113,8 +113,7 @@ fn new_index(
     params: &VecSimParams,
     fill: impl FnOnce(&mut dyn FnMut(t_docId, &[f32])),
 ) -> NonNull<VecSimIndex> {
-    // SAFETY: `params` is fully initialised; `VecSimIndex_New` copies what it
-    // needs and returns an owned index handle.
+    // SAFETY: `params` is fully initialised.
     let index = unsafe { VecSimIndex_New(params) };
     let index = NonNull::new(index).expect("VecSimIndex_New returned null");
 
@@ -166,6 +165,62 @@ pub unsafe fn make_source_with_mode(
     k: usize,
     child_est: usize,
 ) -> VectorScoreSource<'static> {
+    // SAFETY: caller guarantees `index` outlives the returned source.
+    unsafe {
+        make_source_inner(
+            index,
+            query,
+            ef,
+            search_mode,
+            k,
+            child_est,
+            None::<FieldExpirationChecker>,
+        )
+    }
+}
+
+/// [`make_source`] with an optional field-`expiration` filter, consulted at
+/// yield time. `EMPTY_MODE` lets VecSim pick the search strategy.
+///
+/// # Safety
+///
+/// `index` must outlive the returned source (and any iterator built from it).
+pub unsafe fn make_source_with_expiration<E: ExpirationChecker>(
+    index: NonNull<VecSimIndex>,
+    query: Vec<u8>,
+    ef: usize,
+    k: usize,
+    child_est: usize,
+    expiration: Option<E>,
+) -> VectorScoreSource<'static, E> {
+    // SAFETY: caller guarantees `index` outlives the returned source.
+    unsafe {
+        make_source_inner(
+            index,
+            query,
+            ef,
+            VecSearchMode_EMPTY_MODE,
+            k,
+            child_est,
+            expiration,
+        )
+    }
+}
+
+/// Shared builder behind the `make_source*` fixtures.
+///
+/// # Safety
+///
+/// `index` must outlive the returned source (and any iterator built from it).
+unsafe fn make_source_inner<E: ExpirationChecker>(
+    index: NonNull<VecSimIndex>,
+    query: Vec<u8>,
+    ef: usize,
+    search_mode: VecSearchMode,
+    k: usize,
+    child_est: usize,
+    expiration: Option<E>,
+) -> VectorScoreSource<'static, E> {
     // SAFETY: zeroed is a valid bit pattern for this config; we then set only
     // the fields VecSim reads.
     let mut query_params: VecSimQueryParams = unsafe { std::mem::zeroed() };
@@ -185,6 +240,7 @@ pub unsafe fn make_source_with_mode(
             true,
             child_est,
             0,
+            expiration,
         )
     }
 }

--- a/src/redisearch_rs/vector_score_source/src/test_utils.rs
+++ b/src/redisearch_rs/vector_score_source/src/test_utils.rs
@@ -165,7 +165,8 @@ pub unsafe fn make_source_with_mode(
     k: usize,
     child_est: usize,
 ) -> VectorScoreSource<'static> {
-    // SAFETY: caller guarantees `index` outlives the returned source.
+    // SAFETY: forwarded to `make_source_inner`; caller upholds this fn's
+    // `# Safety` 1 and 2.
     unsafe {
         make_source_inner(
             index,
@@ -184,7 +185,10 @@ pub unsafe fn make_source_with_mode(
 ///
 /// # Safety
 ///
-/// `index` must outlive the returned source (and any iterator built from it).
+/// 1. `index` must outlive the returned source (and any iterator built from it).
+/// 2. `query` must match `index`'s type and dimension, the layout VecSim reads
+///    in full on every query path; a shorter blob is read out of bounds. Use
+///    [`uniform_blob`]/[`blob`] sized to the index `dim`.
 pub unsafe fn make_source_with_expiration<E: ExpirationChecker>(
     index: NonNull<VecSimIndex>,
     query: Vec<u8>,
@@ -193,7 +197,8 @@ pub unsafe fn make_source_with_expiration<E: ExpirationChecker>(
     child_est: usize,
     expiration: Option<E>,
 ) -> VectorScoreSource<'static, E> {
-    // SAFETY: caller guarantees `index` outlives the returned source.
+    // SAFETY: forwarded to `make_source_inner`; caller upholds this fn's
+    // `# Safety` 1 and 2.
     unsafe {
         make_source_inner(
             index,
@@ -211,7 +216,10 @@ pub unsafe fn make_source_with_expiration<E: ExpirationChecker>(
 ///
 /// # Safety
 ///
-/// `index` must outlive the returned source (and any iterator built from it).
+/// 1. `index` must outlive the returned source (and any iterator built from it).
+/// 2. `query` must match `index`'s type and dimension, the layout VecSim reads
+///    in full on every query path; a shorter blob is read out of bounds. Use
+///    [`uniform_blob`]/[`blob`] sized to the index `dim`.
 unsafe fn make_source_inner<E: ExpirationChecker>(
     index: NonNull<VecSimIndex>,
     query: Vec<u8>,

--- a/src/redisearch_rs/vector_score_source/src/test_utils.rs
+++ b/src/redisearch_rs/vector_score_source/src/test_utils.rs
@@ -21,7 +21,7 @@ use ffi::{
     VecSimIndex_New, VecSimMetric, VecSimMetric_VecSimMetric_Cosine, VecSimMetric_VecSimMetric_L2,
     VecSimParams, VecSimQueryParams, VecSimType_VecSimType_FLOAT32, t_docId,
 };
-use rqe_iterators::{ExpirationChecker, FieldExpirationChecker, IdList, RQEIterator};
+use rqe_iterators::{ExpirationChecker, IdList, NoOpChecker, RQEIterator};
 
 use crate::VectorScoreSource;
 
@@ -144,7 +144,7 @@ pub unsafe fn make_source(
     ef: usize,
     k: usize,
     child_est: usize,
-) -> VectorScoreSource<'static> {
+) -> VectorScoreSource<'static, NoOpChecker> {
     // SAFETY: forwarded to `make_source_with_mode`, same contract.
     unsafe { make_source_with_mode(index, query, ef, VecSearchMode_EMPTY_MODE, k, child_est) }
 }
@@ -164,20 +164,10 @@ pub unsafe fn make_source_with_mode(
     search_mode: VecSearchMode,
     k: usize,
     child_est: usize,
-) -> VectorScoreSource<'static> {
+) -> VectorScoreSource<'static, NoOpChecker> {
     // SAFETY: forwarded to `make_source_inner`; caller upholds this fn's
     // `# Safety` 1 and 2.
-    unsafe {
-        make_source_inner(
-            index,
-            query,
-            ef,
-            search_mode,
-            k,
-            child_est,
-            None::<FieldExpirationChecker>,
-        )
-    }
+    unsafe { make_source_inner(index, query, ef, search_mode, k, child_est, NoOpChecker) }
 }
 
 /// [`make_source`] with an optional field-`expiration` filter, consulted at
@@ -195,7 +185,7 @@ pub unsafe fn make_source_with_expiration<E: ExpirationChecker>(
     ef: usize,
     k: usize,
     child_est: usize,
-    expiration: Option<E>,
+    expiration: E,
 ) -> VectorScoreSource<'static, E> {
     // SAFETY: forwarded to `make_source_inner`; caller upholds this fn's
     // `# Safety` 1 and 2.
@@ -227,7 +217,7 @@ unsafe fn make_source_inner<E: ExpirationChecker>(
     search_mode: VecSearchMode,
     k: usize,
     child_est: usize,
-    expiration: Option<E>,
+    expiration: E,
 ) -> VectorScoreSource<'static, E> {
     // SAFETY: zeroed is a valid bit pattern for this config; we then set only
     // the fields VecSim reads.

--- a/src/redisearch_rs/vector_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source.rs
@@ -91,13 +91,13 @@ fn unfiltered_returns_top_k_nearest_by_score() {
     let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
 
     // The unfiltered path streams VecSim's reply ordered by score, so the k
-    // nearest neighbours come out best-first: id 100 (distance 0) down to 91.
+    // nearest neighbours come out best-first.
     let ids = collect_ids(&mut it);
     assert_eq!(ids, (91..=100).rev().collect::<Vec<_>>());
     assert!(it.at_eof());
 
     drop(it);
-    // Stest_utilsve references to the index remain.
+    // SAFETY: no live references to the index remain.
     unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
@@ -115,8 +115,8 @@ fn unfiltered_results_are_metric_kind_with_exact_distance() {
     // Estimate is capped at k (k < index size here).
     assert_eq!(it.num_estimated(), k);
 
-    // Unfiltered streams by score, so ids 100..=91 come out best-first. Each
-    // result is a Metric carrying the exact squared-L2 distance DIM*(n-id)^2.
+    // Unfiltered streams by score, so results come out best-first. Each result
+    // is a Metric carrying the exact squared-L2 distance DIM*(n-id)^2.
     let mut expected_id = n as t_docId;
     while let Some(res) = it.read().unwrap() {
         assert_eq!(res.kind(), RSResultKind::Metric);
@@ -220,7 +220,7 @@ fn filtered_batches_partial_child_intersects() {
     );
 
     // Only multiples of `step` pass the filter; best-first gives the top-k of
-    // those: 100, 96, 92, ... 64.
+    // those.
     let ids = collect_ids(&mut it);
     let expected: Vec<t_docId> = (0..k).map(|c| (n - step * c) as t_docId).collect();
     assert_eq!(ids, expected);
@@ -267,8 +267,8 @@ fn filtered_adhoc_drops_nan_distance_docs() {
 
     // The adhoc-BF path looks up a distance per child id. Ids that were never
     // added to the vector index have no label, so VecSim returns NaN — the
-    // source must drop them. Mixing real ids (91..=100) with phantom ids
-    // (> n) exercises that filter against a real index, no mock needed.
+    // source must drop them. Mixing real ids with phantom ids (> n) exercises
+    // that filter against a real index, no mock needed.
     let real: Vec<t_docId> = (91..=100).collect();
     let phantom: Vec<t_docId> = vec![201, 202, 203];
     let mut child_ids = real.clone();
@@ -369,14 +369,14 @@ fn unfiltered_skips_expired_docs() {
     let k = 10;
     let index = build_hnsw_index(n);
 
-    // Mark the two nearest neighbours (ids 100, 99) expired.
+    // Mark the two nearest neighbours expired.
     let checker = MockExpirationChecker::new(HashSet::from([100, 99]));
     // SAFETY: index outlives the iterator (freed at end of scope).
     let source = unsafe { make_source_with_expiration(index, n, k, n, Some(checker)) };
     let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
 
-    // Top-k by score is ids 100..=91; the two expired nearest neighbours are
-    // dropped without refill, leaving 98..=91.
+    // The two expired nearest neighbours are
+    // dropped without refill.
     let ids = collect_ids(&mut it);
     assert_eq!(ids, (91..=98).rev().collect::<Vec<_>>());
 
@@ -392,9 +392,10 @@ fn filtered_batches_drops_expired_without_refill() {
     let k = 3;
     let index = build_hnsw_index(n);
 
-    // Child filter passes 90..=100, so the best k are [100, 99, 98]. Doc 100
-    // is expired: it still occupies its heap slot during collection (stopping
-    // batch refill), and is dropped at yield — leaving [99, 98], not [99, 98, 97].
+    // Child filter passes the candidates, so the best k are the closest
+    // neighbours. The nearest is expired: it still occupies its heap slot during
+    // collection (stopping batch refill), and is dropped at yield — leaving the
+    // count short, not refilled from the next-best doc.
     let child_ids: Vec<t_docId> = (90..=100).collect();
     let checker = MockExpirationChecker::new(HashSet::from([100]));
     // SAFETY: index outlives the iterator (freed at end of scope).
@@ -424,9 +425,9 @@ fn filtered_adhoc_drops_expired_without_refill() {
     let k = 3;
     let index = build_hnsw_index(n);
 
-    // Same shape as the batches test, on the adhoc-BF path: expired doc 100
+    // Same shape as the batches test, on the adhoc-BF path: the expired nearest
     // claims a heap slot during the child scan and is dropped at yield, so the
-    // count shrinks instead of refilling from doc 97.
+    // count shrinks instead of refilling from the next-best doc.
     let child_ids: Vec<t_docId> = (90..=100).collect();
     let checker = MockExpirationChecker::new(HashSet::from([100]));
     // SAFETY: index outlives the iterator (freed at end of scope).

--- a/src/redisearch_rs/vector_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source.rs
@@ -18,9 +18,12 @@
 
 use std::{num::NonZeroUsize, ptr::NonNull};
 
+use std::collections::HashSet;
+
 use ffi::{VecSimIndex, VecSimIndex_Free, t_docId};
 use index_result::RSResultKind;
-use rqe_iterators::RQEIterator;
+use rqe_iterators::{ExpirationChecker, FieldExpirationChecker, RQEIterator};
+use rqe_iterators_test_utils::MockExpirationChecker;
 use top_k::{TopKIterator, TopKMode};
 use vector_score_source::test_utils::{self, asc, collect_ids, make_child, uniform_blob};
 use vector_score_source::{
@@ -46,8 +49,34 @@ unsafe fn make_source(
     k: usize,
     child_est: usize,
 ) -> VectorScoreSource<'static> {
+    // SAFETY: caller-upheld `index` lifetime; no expiration filter.
+    unsafe { make_source_with_expiration(index, n, k, child_est, None::<FieldExpirationChecker>) }
+}
+
+/// Same as [`make_source`], but installs an optional field-expiration filter,
+/// consulted at yield time.
+///
+/// # Safety
+///
+/// `index` must outlive the returned source (and any iterator built from it).
+unsafe fn make_source_with_expiration<E: ExpirationChecker>(
+    index: NonNull<VecSimIndex>,
+    n: usize,
+    k: usize,
+    child_est: usize,
+    expiration: Option<E>,
+) -> VectorScoreSource<'static, E> {
     // SAFETY: caller upholds the `index` lifetime contract.
-    unsafe { test_utils::make_source(index, uniform_blob(n as f32, DIM), n, k, child_est) }
+    unsafe {
+        test_utils::make_source_with_expiration(
+            index,
+            uniform_blob(n as f32, DIM),
+            n,
+            k,
+            child_est,
+            expiration,
+        )
+    }
 }
 
 #[test]
@@ -327,6 +356,93 @@ fn disjoint_child_yields_nothing() {
 
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
+
+    drop(it);
+    // SAFETY: no live references to the index remain.
+    unsafe { VecSimIndex_Free(index.as_ptr()) };
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
+fn unfiltered_skips_expired_docs() {
+    let n = 100;
+    let k = 10;
+    let index = build_hnsw_index(n);
+
+    // Mark the two nearest neighbours (ids 100, 99) expired.
+    let checker = MockExpirationChecker::new(HashSet::from([100, 99]));
+    // SAFETY: index outlives the iterator (freed at end of scope).
+    let source = unsafe { make_source_with_expiration(index, n, k, n, Some(checker)) };
+    let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
+
+    // Top-k by score is ids 100..=91; the two expired nearest neighbours are
+    // dropped without refill, leaving 98..=91.
+    let ids = collect_ids(&mut it);
+    assert_eq!(ids, (91..=98).rev().collect::<Vec<_>>());
+
+    drop(it);
+    // SAFETY: no live references to the index remain.
+    unsafe { VecSimIndex_Free(index.as_ptr()) };
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
+fn filtered_batches_drops_expired_without_refill() {
+    let n = 100;
+    let k = 3;
+    let index = build_hnsw_index(n);
+
+    // Child filter passes 90..=100, so the best k are [100, 99, 98]. Doc 100
+    // is expired: it still occupies its heap slot during collection (stopping
+    // batch refill), and is dropped at yield — leaving [99, 98], not [99, 98, 97].
+    let child_ids: Vec<t_docId> = (90..=100).collect();
+    let checker = MockExpirationChecker::new(HashSet::from([100]));
+    // SAFETY: index outlives the iterator (freed at end of scope).
+    let source =
+        unsafe { make_source_with_expiration(index, n, k, child_ids.len(), Some(checker)) };
+    let child = make_child(child_ids);
+    let mut it = TopKIterator::new_with_mode(
+        source,
+        Some(child),
+        NonZeroUsize::new(k).unwrap(),
+        asc,
+        TopKMode::ForcedBatches,
+    );
+
+    let ids = collect_ids(&mut it);
+    assert_eq!(ids, vec![99, 98]);
+
+    drop(it);
+    // SAFETY: no live references to the index remain.
+    unsafe { VecSimIndex_Free(index.as_ptr()) };
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
+fn filtered_adhoc_drops_expired_without_refill() {
+    let n = 100;
+    let k = 3;
+    let index = build_hnsw_index(n);
+
+    // Same shape as the batches test, on the adhoc-BF path: expired doc 100
+    // claims a heap slot during the child scan and is dropped at yield, so the
+    // count shrinks instead of refilling from doc 97.
+    let child_ids: Vec<t_docId> = (90..=100).collect();
+    let checker = MockExpirationChecker::new(HashSet::from([100]));
+    // SAFETY: index outlives the iterator (freed at end of scope).
+    let source =
+        unsafe { make_source_with_expiration(index, n, k, child_ids.len(), Some(checker)) };
+    let child = make_child(child_ids);
+    let mut it = TopKIterator::new_with_mode(
+        source,
+        Some(child),
+        NonZeroUsize::new(k).unwrap(),
+        asc,
+        TopKMode::AdhocBF,
+    );
+
+    let ids = collect_ids(&mut it);
+    assert_eq!(ids, vec![99, 98]);
 
     drop(it);
     // SAFETY: no live references to the index remain.

--- a/src/redisearch_rs/vector_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source.rs
@@ -22,7 +22,7 @@ use std::collections::HashSet;
 
 use ffi::{VecSimIndex, VecSimIndex_Free, t_docId};
 use index_result::RSResultKind;
-use rqe_iterators::{ExpirationChecker, FieldExpirationChecker, RQEIterator};
+use rqe_iterators::{ExpirationChecker, NoOpChecker, RQEIterator};
 use rqe_iterators_test_utils::MockExpirationChecker;
 use top_k::{TopKIterator, TopKMode};
 use vector_score_source::test_utils::{self, asc, collect_ids, make_child, uniform_blob};
@@ -48,13 +48,13 @@ unsafe fn make_source(
     n: usize,
     k: usize,
     child_est: usize,
-) -> VectorScoreSource<'static> {
+) -> VectorScoreSource<'static, NoOpChecker> {
     // SAFETY: caller-upheld `index` lifetime; no expiration filter.
-    unsafe { make_source_with_expiration(index, n, k, child_est, None::<FieldExpirationChecker>) }
+    unsafe { make_source_with_expiration(index, n, k, child_est, NoOpChecker) }
 }
 
-/// Same as [`make_source`], but installs an optional field-expiration filter,
-/// consulted at yield time.
+/// Same as [`make_source`], but installs a field-expiration filter, consulted
+/// at yield time.
 ///
 /// # Safety
 ///
@@ -64,7 +64,7 @@ unsafe fn make_source_with_expiration<E: ExpirationChecker>(
     n: usize,
     k: usize,
     child_est: usize,
-    expiration: Option<E>,
+    expiration: E,
 ) -> VectorScoreSource<'static, E> {
     // SAFETY: caller upholds the `index` lifetime contract.
     unsafe {
@@ -372,7 +372,7 @@ fn unfiltered_skips_expired_docs() {
     // Mark the two nearest neighbours expired.
     let checker = MockExpirationChecker::new(HashSet::from([100, 99]));
     // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source_with_expiration(index, n, k, n, Some(checker)) };
+    let source = unsafe { make_source_with_expiration(index, n, k, n, checker) };
     let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
 
     // The two expired nearest neighbours are
@@ -399,8 +399,7 @@ fn filtered_batches_drops_expired_without_refill() {
     let child_ids: Vec<t_docId> = (90..=100).collect();
     let checker = MockExpirationChecker::new(HashSet::from([100]));
     // SAFETY: index outlives the iterator (freed at end of scope).
-    let source =
-        unsafe { make_source_with_expiration(index, n, k, child_ids.len(), Some(checker)) };
+    let source = unsafe { make_source_with_expiration(index, n, k, child_ids.len(), checker) };
     let child = make_child(child_ids);
     let mut it = TopKIterator::new_with_mode(
         source,
@@ -431,8 +430,7 @@ fn filtered_adhoc_drops_expired_without_refill() {
     let child_ids: Vec<t_docId> = (90..=100).collect();
     let checker = MockExpirationChecker::new(HashSet::from([100]));
     // SAFETY: index outlives the iterator (freed at end of scope).
-    let source =
-        unsafe { make_source_with_expiration(index, n, k, child_ids.len(), Some(checker)) };
+    let source = unsafe { make_source_with_expiration(index, n, k, child_ids.len(), checker) };
     let child = make_child(child_ids);
     let mut it = TopKIterator::new_with_mode(
         source,


### PR DESCRIPTION
- Builds on top of https://github.com/RediSearch/RediSearch/pull/9905
- next: https://github.com/RediSearch/RediSearch/pull/9906

This PR:
- Adds a basic implementation of a timeout for TopK, on each read step.
- Adds expiration checker
  - Brings `MockExpirationChecker` to the shared rqe_iterators_test_utils
- tests

Supporting `AnyTimeoutContext` is a bit complex because vecsim needs a timeoutctx which is not provided by the trait, decided out of scope as not critical.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
