### PR TITLE
[POC][draft] Conditional cdylib disk plugin — RediSearch side (decouple redisearch.so from libspeedb)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -264,6 +264,52 @@ list(REMOVE_DUPLICATES LIBS_TO_MERGE)
 list(REMOVE_DUPLICATES VISITED_TARGETS)
 message(STATUS "Static libraries for libredisearch_all.a: ${LIBS_TO_MERGE}")
 
+# Export the resolved VecSim / transitive archive set for the conditional disk
+# plugin's cdylib link (see redisearch_disk_plugin/build.rs).
+#
+# The plugin rebuilds the module as a cdylib that does NOT statically link the C
+# core, so it must link the SAME VecSim copy + transitive deps that
+# libredisearch_all.a uses, otherwise its VectorSimilarity objects leave spdlog /
+# fmt / SVS symbols undefined. The exact set is layout- and arch-dependent:
+#   - aarch64: VectorSimilarity, Spaces (+ no_optimization), cpu_features, and
+#     spdlog/fmt under _deps/{spdlog,fmt}-build/.
+#   - x86_64 (SVS): VectorSimilarity, Spaces (+ no_optimization), cpu_features,
+#     plus the precompiled SVS archives (fmt, spdlog, svs_static_library,
+#     svs_x86_objects) under _deps/svs-src/lib/ — a different layout entirely.
+# Rather than have build.rs guess these paths, resolve them here (CMake already
+# knows them) and hand the absolute paths to build.rs via a generated file.
+#
+# `file(GENERATE)` resolves the `$<TARGET_FILE:...>` generator expressions to the
+# real archive paths at build time. The SVS paths (when present) are already
+# absolute from the GLOB above.
+set(PLUGIN_VECSIM_ARCHIVES
+    "$<TARGET_FILE:VectorSimilarity>"
+    "$<TARGET_FILE:VectorSimilaritySpaces>"
+    "$<TARGET_FILE:VectorSimilaritySpaces_no_optimization>"
+    "$<TARGET_FILE:cpu_features>"
+)
+# spdlog/fmt live under _deps/{spdlog,fmt}-build/ when SVS is absent (aarch64); on
+# x86_64 they (and the SVS archives) come from _deps/svs-src/lib/ instead. Append
+# whichever set exists, plus the SVS-only archives when present. spdlog/fmt are
+# FetchContent-built (possibly in a non-local scope), so resolve them by GLOB on
+# their build dirs rather than `$<TARGET_FILE:...>` (which may not be visible
+# here). The `d` suffix appears in Debug builds (libspdlogd.a / libfmtd.a).
+if(EXISTS "${_svs_lib_dir}")
+    # x86_64 / SVS: fmt, spdlog, svs_static_library, svs_x86_objects (MKL already
+    # filtered out of _svs_static_libs above).
+    list(APPEND PLUGIN_VECSIM_ARCHIVES ${_svs_static_libs})
+else()
+    # aarch64 / no SVS: the FetchContent-built spdlog and fmt static archives.
+    file(GLOB _plugin_spdlog_a "${CMAKE_BINARY_DIR}/_deps/spdlog-build/libspdlog*.a")
+    file(GLOB _plugin_fmt_a "${CMAKE_BINARY_DIR}/_deps/fmt-build/libfmt*.a")
+    list(APPEND PLUGIN_VECSIM_ARCHIVES ${_plugin_spdlog_a} ${_plugin_fmt_a})
+endif()
+set(PLUGIN_VECSIM_ARCHIVES_FILE "${CMAKE_BINARY_DIR}/plugin_vecsim_archives.txt")
+string(REPLACE ";" "\n" _plugin_vecsim_archives_lines "${PLUGIN_VECSIM_ARCHIVES}")
+file(GENERATE OUTPUT "${PLUGIN_VECSIM_ARCHIVES_FILE}"
+     CONTENT "${_plugin_vecsim_archives_lines}\n")
+message(STATUS "Plugin VecSim archive list -> ${PLUGIN_VECSIM_ARCHIVES_FILE}")
+
 # Combine targets and library paths for DEPENDS
 set(MERGE_DEPENDS ${VISITED_TARGETS} ${LIBS_TO_MERGE})
 list(REMOVE_DUPLICATES MERGE_DEPENDS)

--- a/src/module.c
+++ b/src/module.c
@@ -4825,8 +4825,15 @@ static int RediSearch_InitModuleConfig(RedisModuleCtx *ctx, RedisModuleString **
   return REDISMODULE_OK;
 }
 
+// Renamed from `RedisModule_OnLoad`: when the module is delivered as a Rust
+// `cdylib` (conditional cdylib disk-plugin architecture), rustc's auto-generated
+// version script localizes every non-Rust-`#[no_mangle]` symbol, which would
+// hide the module entry from Redis' `dlsym(handle, "RedisModule_OnLoad")`. So a
+// thin Rust `#[no_mangle] RedisModule_OnLoad` shim (in the `redisearch_core`
+// crate) is the real exported entry and forwards here. The symbol stays
+// `visibility("default")` so the Rust shim can resolve it.
 int __attribute__((visibility("default")))
-RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+RediSearch_OnLoad_Impl(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   if (RedisModule_Init(ctx, REDISEARCH_MODULE_NAME, REDISEARCH_MODULE_VERSION,
                        REDISMODULE_APIVER_1) == REDISMODULE_ERR) {

--- a/src/module.c
+++ b/src/module.c
@@ -4832,6 +4832,19 @@ static int RediSearch_InitModuleConfig(RedisModuleCtx *ctx, RedisModuleString **
 // thin Rust `#[no_mangle] RedisModule_OnLoad` shim (in the `redisearch_core`
 // crate) is the real exported entry and forwards here. The symbol stays
 // `visibility("default")` so the Rust shim can resolve it.
+//
+// For the LEGACY build (the normal, self-contained C-linked `redisearch.so`,
+// CONDITIONAL_PLUGIN unset/0) there is no Rust shim, so the module must still
+// export `RedisModule_OnLoad` itself, or Redis' `dlsym` finds no entry point and
+// the module fails to load. A WEAK, default-visibility alias provides it: in the
+// legacy `.so` it is the (only) `RedisModule_OnLoad` Redis resolves; in the
+// cdylib build the Rust `#[no_mangle] RedisModule_OnLoad` is a STRONG definition
+// that overrides this weak alias (no duplicate-symbol error), and the weak alias
+// is excluded from the plugin export set (`collect_c_core_globals` keeps only
+// strong T/D/B/R symbols, never weak W).
+extern int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
+    __attribute__((visibility("default"), weak, alias("RediSearch_OnLoad_Impl")));
+
 int __attribute__((visibility("default")))
 RediSearch_OnLoad_Impl(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -32,6 +32,19 @@ members = [
     "rqe_core",
     "rqe_iterators",
     "rqe_iterators_bencher",
+    "search_shared",
+    "redisearch_core",
+    # NOTE: `redisearch_disk_plugin` is intentionally NOT listed here. It produces
+    # the dlopened disk plugin `redisearch_disk.so` and depends on the superrepo
+    # crate `redisearch_disk` via a path (`../../../../../redisearch_disk`) that
+    # exists ONLY in the RediSearchEnterprise superrepo, not in a bare OSS
+    # `deps/RediSearch` checkout. Listing it as a member would make `cargo metadata`
+    # / `cargo clippy --workspace` fail in OSS (member manifests load before
+    # `--exclude` applies). The superrepo build (`build.sh build_conditional_plugin`)
+    # injects it as a member at build time so it is compiled in the SAME workspace /
+    # feature-unification as `redisearch_core` — which is required for the single
+    # `search_shared` (and thin_vec / index_result monomorphization) SVH that the
+    # dlopen seam relies on. See REDISEARCH_PLUGIN_MEMBER handling in build.sh.
     "rqe_iterators_test_utils",
     "search_result",
     "slots_tracker",

--- a/src/redisearch_rs/redisearch_core/Cargo.toml
+++ b/src/redisearch_rs/redisearch_core/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "redisearch_core"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[lib]
+# The core Redis module `redisearch.so`. A `cdylib` so `rustc` is the final
+# linker and `-C prefer-dynamic` is honoured: it links the shared subgraph
+# dynamically (single instance, in libsearch_shared.so) + dynamic libstd, plus
+# the C core (libredisearch_all.a) statically. NO speedb / disk / vecsim.
+crate-type = ["cdylib"]
+test = false
+bench = false
+
+[dependencies]
+# Single shared instance of the subgraph (dylib, NEEDED at runtime).
+search_shared = { path = "../search_shared" }
+# The core Rust FFI hub: re-exports every `*_ffi` crate so their `extern "C"`
+# symbols (called by the C core in libredisearch_all.a) land in redisearch.so.
+redisearch_rs = { path = "../c_entrypoint/redisearch_rs" }
+
+[build-dependencies]
+build_utils = { path = "../build_utils" }

--- a/src/redisearch_rs/redisearch_core/build.rs
+++ b/src/redisearch_rs/redisearch_core/build.rs
@@ -1,0 +1,160 @@
+//! Link the C search core into `redisearch.so`.
+//!
+//! `rustc` is the final linker for this cdylib, so we attach the C-only combined
+//! archive (`libredisearch_all.a`), MKL, and OpenSSL here. The Rust `*_ffi`
+//! symbols this archive calls are provided by the `redisearch_rs` c_entrypoint
+//! dependency; the shared subgraph + libstd come dynamically from
+//! `libsearch_shared.so`. NO speedb / vecsim — those live in `redisearch_disk.so`.
+
+fn main() {
+    // This crate lives inside the `deps/RediSearch` submodule, so its git root is
+    // NOT the superrepo. The build harness passes BINDIR pointing at the CMake
+    // output dir (`<superrepo>/build/deps/RediSearch`); fall back to deriving it
+    // from the superrepo root only as a last resort. MKL lives at
+    // `<superrepo>/build/_deps/svs-src/lib`, so we also need the superrepo build dir.
+    let bin_dir = std::env::var("BINDIR").map(std::path::PathBuf::from).unwrap_or_else(|_| {
+        let root = build_utils::repository_root()
+            .expect("Could not find git root for static library linking");
+        // From deps/RediSearch up to the superrepo, then into build/deps/RediSearch.
+        root.join("..").join("..").join("build").join("deps").join("RediSearch")
+    });
+    // Superrepo build dir (parent-of-parent of bin_dir's `deps/RediSearch`).
+    let superrepo_build = bin_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_else(|| std::path::PathBuf::from("build"));
+
+    let linting_only = std::env::var("LINTING_ONLY").as_deref() == Ok("1");
+
+    // C-only combined RediSearch archive (whole-archive pull at final link).
+    let redisearch_all = match build_utils::link_redisearch_all(&bin_dir) {
+        Ok(path) => Some(path),
+        Err(e) if linting_only => {
+            println!("cargo::warning={e}");
+            None
+        }
+        Err(e) => panic!("{e}"),
+    };
+
+    // MKL is excluded from libredisearch_all.a; link it separately (SVS dep).
+    build_utils::link_mkl(&superrepo_build.join("_deps/svs-src/lib"));
+
+    // OpenSSL, used by the coordinator (rmr) inside the C core.
+    println!("cargo::rustc-link-lib=dylib=ssl");
+    println!("cargo::rustc-link-lib=dylib=crypto");
+
+    // The C core embeds C++ (VectorSimilarity, geometry), so it needs the C++
+    // runtime. A Rust cdylib does not pull libstdc++ automatically.
+    println!("cargo::rustc-link-lib=dylib=stdc++");
+
+    // The module entry `RedisModule_OnLoad` is provided by the Rust shim in
+    // `module_entry.rs` (a `#[no_mangle]` symbol that the cdylib version script
+    // DOES export); it forwards to the C core's `RediSearch_OnLoad_Impl`. Force
+    // that C implementation to be pulled from the archive (nothing else calls it).
+    println!("cargo::rustc-link-arg=-Wl,--undefined=RediSearch_OnLoad_Impl");
+
+    // On RoF the dlopened `redisearch_disk.so` resolves C-core symbols from this
+    // module via `RTLD_GLOBAL`, so the C-core globals must live in `redisearch.so`'s
+    // `.dynsym` (matching what the legacy C-linked `redisearch.so` exposed).
+    //
+    // This is harder than it looks. `rustc` emits an anonymous cdylib version script
+    // `{ global: <#[no_mangle] Rust syms>; local: *; }`. The `local: *` localizes
+    // every C-core / VecSim symbol, and empirically NEITHER `--export-dynamic`,
+    // `--export-dynamic-symbol`, `--dynamic-list` NOR `-u` can promote a symbol that
+    // a version script already marked local (verified with GNU ld 2.38 and LLD 21);
+    // and a second `--version-script` cannot be combined with `rustc`'s anonymous
+    // one ("anonymous version tag cannot be combined with other version tags").
+    //
+    // The robust mechanism is to inject the needed names into the `global:` section
+    // of `rustc`'s own version script at link time. A thin linker wrapper
+    // (`redisearch_core_linker.sh`, wired in by the superrepo `build.sh`) does this;
+    // here we (a) emit the list of symbols it must inject, and (b) force each to be
+    // pulled from the C archive and kept, so the name actually exists in the link.
+    //
+    // These symbols are genuinely shared: the plugin and core MUST operate on the
+    // SAME `IndexSpec` / `DocTable` / config instances, so they are exported from
+    // the single core copy rather than duplicated into the plugin.
+    println!("cargo::rustc-link-arg=-Wl,--export-dynamic");
+
+    const PLUGIN_EXPORTED_CORE_SYMBOLS: &[&str] = &[
+        // RediSearch C-core functions/globals the disk layer (redisearch_disk +
+        // vecsim_disk) references across the .so boundary, plus the C-core
+        // functions the shared dylib (`libsearch_shared.so`) references back into
+        // the core. Both consumers resolve these from `redisearch.so` at load time:
+        // the plugin via `RTLD_GLOBAL` at `dlopen`, the shared dylib via its
+        // `NEEDED redisearch.so`-equivalent load order (it is a `NEEDED` of
+        // `redisearch.so`, so the core's `.dynsym` must satisfy its undefined
+        // references). Every name here is otherwise localized by `rustc`'s cdylib
+        // `local: *` version script; the linker wrapper promotes exactly this set.
+        "AREQ_CheckTimedOut",
+        "Buffer_Grow",
+        "DMD_Free",
+        "DocTable_Exists",
+        "HiddenString_CompareC",
+        "HiddenString_GetUnsafe",
+        "HybridIterator_GetChild",
+        "HybridIterator_GetMaxBatchIteration",
+        "HybridIterator_GetMaxBatchSize",
+        "HybridIterator_GetNumIterations",
+        "HybridIterator_GetSearchModeString",
+        "HybridIterator_IsBatchMode",
+        "IndexSpecCache_Decref",
+        "Obfuscate_Number",
+        "Obfuscate_Text",
+        "OptimizerIterator_GetChild",
+        "OptimizerIterator_GetOptimizationType",
+        "RPProfile_IncrementCount",
+        "RSDummyContext",
+        "RSGlobalConfig",
+        "Redis_OpenInvertedIndex",
+        "SEDestroy",
+        "isWithinRadius",
+        "loadIndividualKeys",
+        "sdscatlen",
+        // C-core symbols referenced by `libsearch_shared.so` (the shared Rust
+        // subgraph: rqe_iterators / index_spec / ffi / ...). These are undefined
+        // (`U`) in the shared dylib and defined in the C core, so they must be
+        // exported from `redisearch.so` for the shared dylib's references to bind
+        // at module load. Without these, RoR module load fails to resolve them.
+        "IndexSpecRef_Promote",
+        "IndexSpecRef_Release",
+        "IndexSpec_AcquireWriteLock",
+        "IndexSpec_DecrementNumTerms",
+        "IndexSpec_DecrementTrieTermCount",
+        "IndexSpec_ReleaseWriteLock",
+        "NewNumericFilter",
+        "RS_dictFetchValue",
+        "StrongRef_Get",
+        "TimeToLiveTable_VerifyDocAndField",
+        "TimeToLiveTable_VerifyDocAndFieldMask",
+        "TimeToLiveTable_VerifyDocAndWideFieldMask",
+        "array_len_func",
+    ];
+
+    // Pull each symbol from the archive and keep it through GC, so the name is
+    // present in the link for the version-script `global:` injection to promote.
+    if redisearch_all.is_some() {
+        for sym in PLUGIN_EXPORTED_CORE_SYMBOLS {
+            println!("cargo::rustc-link-arg=-Wl,--undefined={sym}");
+        }
+    }
+
+    // Hand the symbol list to the linker wrapper via a file. The wrapper injects
+    // these names into `rustc`'s version-script `global:` section when it links
+    // `libredisearch_core.so`. `REDISEARCH_PLUGIN_EXPORTS_FILE` is set by the
+    // superrepo `build.sh`; when unset (e.g. a normal in-submodule `cargo build`)
+    // we skip — the C-only static link does not need the wrapper.
+    if let Ok(exports_file) = std::env::var("REDISEARCH_PLUGIN_EXPORTS_FILE") {
+        let body = PLUGIN_EXPORTED_CORE_SYMBOLS.join("\n");
+        if let Err(e) = std::fs::write(&exports_file, format!("{body}\n")) {
+            panic!("failed to write plugin exports file {exports_file}: {e}");
+        }
+        println!("cargo::rerun-if-env-changed=REDISEARCH_PLUGIN_EXPORTS_FILE");
+    }
+
+    if redisearch_all.is_some() {
+        // Link the C archive last so its symbols are preferred.
+        println!("cargo::rustc-link-arg=-lredisearch_all");
+    }
+}

--- a/src/redisearch_rs/redisearch_core/build.rs
+++ b/src/redisearch_rs/redisearch_core/build.rs
@@ -12,12 +12,18 @@ fn main() {
     // output dir (`<superrepo>/build/deps/RediSearch`); fall back to deriving it
     // from the superrepo root only as a last resort. MKL lives at
     // `<superrepo>/build/_deps/svs-src/lib`, so we also need the superrepo build dir.
-    let bin_dir = std::env::var("BINDIR").map(std::path::PathBuf::from).unwrap_or_else(|_| {
-        let root = build_utils::repository_root()
-            .expect("Could not find git root for static library linking");
-        // From deps/RediSearch up to the superrepo, then into build/deps/RediSearch.
-        root.join("..").join("..").join("build").join("deps").join("RediSearch")
-    });
+    let bin_dir = std::env::var("BINDIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            let root = build_utils::repository_root()
+                .expect("Could not find git root for static library linking");
+            // From deps/RediSearch up to the superrepo, then into build/deps/RediSearch.
+            root.join("..")
+                .join("..")
+                .join("build")
+                .join("deps")
+                .join("RediSearch")
+        });
     // Superrepo build dir (parent-of-parent of bin_dir's `deps/RediSearch`).
     let superrepo_build = bin_dir
         .parent()

--- a/src/redisearch_rs/redisearch_core/build.rs
+++ b/src/redisearch_rs/redisearch_core/build.rs
@@ -27,7 +27,8 @@ fn main() {
 
     let linting_only = std::env::var("LINTING_ONLY").as_deref() == Ok("1");
 
-    // C-only combined RediSearch archive (whole-archive pull at final link).
+    // C-only combined RediSearch archive (linked `static:-bundle`; the linker pulls
+    // only referenced objects, plus any forced via `--undefined` below).
     let redisearch_all = match build_utils::link_redisearch_all(&bin_dir) {
         Ok(path) => Some(path),
         Err(e) if linting_only => {
@@ -69,75 +70,39 @@ fn main() {
     // The robust mechanism is to inject the needed names into the `global:` section
     // of `rustc`'s own version script at link time. A thin linker wrapper
     // (`redisearch_core_linker.sh`, wired in by the superrepo `build.sh`) does this;
-    // here we (a) emit the list of symbols it must inject, and (b) force each to be
+    // here we (a) emit the list of symbols it must inject, and (b) ensure each is
     // pulled from the C archive and kept, so the name actually exists in the link.
+    //
+    // The export set is NOT hand-maintained. It is derived at build time from the
+    // C-only combined archive (`libredisearch_all.a`) itself: every globally-defined
+    // C-core symbol is exported. This way, any future disk/plugin or shared-dylib
+    // code that calls a new C-core function resolves at dlopen with ZERO linker-config
+    // edits — the symbol is already in the archive, so it is already exported. The
+    // alternative (a hand-enumerated list) silently broke `dlopen` whenever a new
+    // cross-`.so` call was added without updating the list.
     //
     // These symbols are genuinely shared: the plugin and core MUST operate on the
     // SAME `IndexSpec` / `DocTable` / config instances, so they are exported from
     // the single core copy rather than duplicated into the plugin.
     println!("cargo::rustc-link-arg=-Wl,--export-dynamic");
 
-    const PLUGIN_EXPORTED_CORE_SYMBOLS: &[&str] = &[
-        // RediSearch C-core functions/globals the disk layer (redisearch_disk +
-        // vecsim_disk) references across the .so boundary, plus the C-core
-        // functions the shared dylib (`libsearch_shared.so`) references back into
-        // the core. Both consumers resolve these from `redisearch.so` at load time:
-        // the plugin via `RTLD_GLOBAL` at `dlopen`, the shared dylib via its
-        // `NEEDED redisearch.so`-equivalent load order (it is a `NEEDED` of
-        // `redisearch.so`, so the core's `.dynsym` must satisfy its undefined
-        // references). Every name here is otherwise localized by `rustc`'s cdylib
-        // `local: *` version script; the linker wrapper promotes exactly this set.
-        "AREQ_CheckTimedOut",
-        "Buffer_Grow",
-        "DMD_Free",
-        "DocTable_Exists",
-        "HiddenString_CompareC",
-        "HiddenString_GetUnsafe",
-        "HybridIterator_GetChild",
-        "HybridIterator_GetMaxBatchIteration",
-        "HybridIterator_GetMaxBatchSize",
-        "HybridIterator_GetNumIterations",
-        "HybridIterator_GetSearchModeString",
-        "HybridIterator_IsBatchMode",
-        "IndexSpecCache_Decref",
-        "Obfuscate_Number",
-        "Obfuscate_Text",
-        "OptimizerIterator_GetChild",
-        "OptimizerIterator_GetOptimizationType",
-        "RPProfile_IncrementCount",
-        "RSDummyContext",
-        "RSGlobalConfig",
-        "Redis_OpenInvertedIndex",
-        "SEDestroy",
-        "isWithinRadius",
-        "loadIndividualKeys",
-        "sdscatlen",
-        // C-core symbols referenced by `libsearch_shared.so` (the shared Rust
-        // subgraph: rqe_iterators / index_spec / ffi / ...). These are undefined
-        // (`U`) in the shared dylib and defined in the C core, so they must be
-        // exported from `redisearch.so` for the shared dylib's references to bind
-        // at module load. Without these, RoR module load fails to resolve them.
-        "IndexSpecRef_Promote",
-        "IndexSpecRef_Release",
-        "IndexSpec_AcquireWriteLock",
-        "IndexSpec_DecrementNumTerms",
-        "IndexSpec_DecrementTrieTermCount",
-        "IndexSpec_ReleaseWriteLock",
-        "NewNumericFilter",
-        "RS_dictFetchValue",
-        "StrongRef_Get",
-        "TimeToLiveTable_VerifyDocAndField",
-        "TimeToLiveTable_VerifyDocAndFieldMask",
-        "TimeToLiveTable_VerifyDocAndWideFieldMask",
-        "array_len_func",
-    ];
-
-    // Pull each symbol from the archive and keep it through GC, so the name is
-    // present in the link for the version-script `global:` injection to promote.
-    if redisearch_all.is_some() {
-        for sym in PLUGIN_EXPORTED_CORE_SYMBOLS {
-            println!("cargo::rustc-link-arg=-Wl,--undefined={sym}");
+    // Derive the full set of C-core globals to export from the archive via `nm`.
+    let plugin_exported_core_symbols: Vec<String> = match &redisearch_all {
+        Some(archive) => {
+            println!("cargo::rerun-if-changed={}", archive.display());
+            collect_c_core_globals(archive)
         }
+        None => Vec::new(),
+    };
+
+    // Force every exported global to be pulled from the archive and kept through GC,
+    // so the name is present in the link for the version-script `global:` injection
+    // to promote. The archive is linked with `static:-bundle`, so the linker only
+    // pulls objects it sees a reference to; `--undefined` provides that reference for
+    // symbols the C core does not itself call (e.g. utility helpers only the plugin
+    // uses), making the blanket export complete and future-proof.
+    for sym in &plugin_exported_core_symbols {
+        println!("cargo::rustc-link-arg=-Wl,--undefined={sym}");
     }
 
     // Hand the symbol list to the linker wrapper via a file. The wrapper injects
@@ -146,7 +111,7 @@ fn main() {
     // superrepo `build.sh`; when unset (e.g. a normal in-submodule `cargo build`)
     // we skip — the C-only static link does not need the wrapper.
     if let Ok(exports_file) = std::env::var("REDISEARCH_PLUGIN_EXPORTS_FILE") {
-        let body = PLUGIN_EXPORTED_CORE_SYMBOLS.join("\n");
+        let body = plugin_exported_core_symbols.join("\n");
         if let Err(e) = std::fs::write(&exports_file, format!("{body}\n")) {
             panic!("failed to write plugin exports file {exports_file}: {e}");
         }
@@ -157,4 +122,57 @@ fn main() {
         // Link the C archive last so its symbols are preferred.
         println!("cargo::rustc-link-arg=-lredisearch_all");
     }
+}
+
+/// Extract every globally-defined C-core symbol from `libredisearch_all.a`.
+///
+/// Runs `nm -g --defined-only` on the combined C archive and keeps the **strong**
+/// defined globals — text (`T`), initialized/uninitialized data (`D`/`B`), and
+/// read-only data (`R`). These are the C-core API surface (functions and globals)
+/// that the dlopened plugin (`redisearch_disk.so`) and the shared dylib
+/// (`libsearch_shared.so`) resolve across the `.so` boundary.
+///
+/// Weak symbols (`W`/`V`) are deliberately excluded: in this archive they are
+/// overwhelmingly C++ template instantiations, inline functions, and vtables from
+/// the embedded C++ (VectorSimilarity, geometry). They are already merged at link
+/// time, are not part of the stable C-core ABI the plugin links against, and
+/// blanket-exporting ~75k of them would bloat the version script and risk ODR /
+/// interposition surprises across the boundary for no benefit. Every symbol the
+/// consumers actually need is a strong global.
+fn collect_c_core_globals(archive: &std::path::Path) -> Vec<String> {
+    let nm = std::env::var("NM").unwrap_or_else(|_| "nm".to_string());
+    let output = std::process::Command::new(&nm)
+        .args(["-g", "--defined-only"])
+        .arg(archive)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run `{nm}` on {}: {e}", archive.display()));
+    if !output.status.success() {
+        panic!(
+            "`{nm} -g --defined-only {}` failed: {}",
+            archive.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let mut symbols: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            // `nm` output for a defined global: "<addr> <type> <name>". Keep only
+            // strong defined types; skip undefined (`U`) and weak (`W`/`V`/`w`/`v`).
+            let mut fields = line.split_whitespace();
+            let _addr = fields.next()?;
+            let kind = fields.next()?;
+            let name = fields.next()?;
+            matches!(kind, "T" | "D" | "B" | "R").then(|| name.to_string())
+        })
+        .collect();
+    symbols.sort_unstable();
+    symbols.dedup();
+
+    assert!(
+        !symbols.is_empty(),
+        "no strong C-core globals found in {}; refusing to produce an empty export set",
+        archive.display()
+    );
+    symbols
 }

--- a/src/redisearch_rs/redisearch_core/src/disk_forwarder.rs
+++ b/src/redisearch_rs/redisearch_core/src/disk_forwarder.rs
@@ -7,6 +7,8 @@
 //! and resolve the plugin's distinct entry points `SearchDiskPlugin_*`.
 
 use std::ffi::{CStr, CString, c_char, c_int, c_void};
+#[cfg(debug_assertions)]
+use std::ffi::c_uint;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
@@ -51,6 +53,20 @@ type GetApiFn = unsafe extern "C" fn() -> *mut c_void;
 type SetApiFn = unsafe extern "C" fn();
 type InitRedisModuleApiFn = unsafe extern "C" fn(*const c_void);
 
+// Fork × compaction debug coordinator entry-point signatures. Debug builds only,
+// matching the `#[cfg(debug_assertions)]` exports in the plugin and the
+// `FT.DEBUG REPL_COMPACTION_COORDINATOR` call sites in the C core.
+#[cfg(debug_assertions)]
+type DebugCoordinatorArmPauseFn = unsafe extern "C" fn(c_int, bool);
+#[cfg(debug_assertions)]
+type DebugCoordinatorSetWakeFn = unsafe extern "C" fn(c_int, c_int);
+#[cfg(debug_assertions)]
+type DebugCoordinatorReleaseFn = unsafe extern "C" fn(c_int);
+#[cfg(debug_assertions)]
+type DebugCoordinatorReachedFn = unsafe extern "C" fn(c_int) -> c_uint;
+#[cfg(debug_assertions)]
+type DebugResetCompactionControllerFn = unsafe extern "C" fn();
+
 /// Log a `warning`-level diagnostic through the C core's `RedisModule_Log`, so disk
 /// seam failures are visible in the server log instead of silently swallowed.
 fn log_warning(msg: &str) {
@@ -94,6 +110,38 @@ struct PluginEntries {
     has_api: Option<HasApiFn>,
     get_api: Option<GetApiFn>,
     set_api: Option<SetApiFn>,
+    #[cfg(debug_assertions)]
+    debug_arm_pause: Option<DebugCoordinatorArmPauseFn>,
+    #[cfg(debug_assertions)]
+    debug_set_wake: Option<DebugCoordinatorSetWakeFn>,
+    #[cfg(debug_assertions)]
+    debug_release: Option<DebugCoordinatorReleaseFn>,
+    #[cfg(debug_assertions)]
+    debug_reached: Option<DebugCoordinatorReachedFn>,
+    #[cfg(debug_assertions)]
+    debug_reset: Option<DebugResetCompactionControllerFn>,
+}
+
+impl PluginEntries {
+    /// All-`None` value used as the error/early-return default before a
+    /// successful `dlopen` populates the real entry points.
+    const fn empty() -> Self {
+        PluginEntries {
+            has_api: None,
+            get_api: None,
+            set_api: None,
+            #[cfg(debug_assertions)]
+            debug_arm_pause: None,
+            #[cfg(debug_assertions)]
+            debug_set_wake: None,
+            #[cfg(debug_assertions)]
+            debug_release: None,
+            #[cfg(debug_assertions)]
+            debug_reached: None,
+            #[cfg(debug_assertions)]
+            debug_reset: None,
+        }
+    }
 }
 
 // SAFETY: function pointers into a dlopened-RTLD_GLOBAL library that is never
@@ -183,7 +231,7 @@ unsafe fn resolve(handle: *mut c_void, name: &str) -> *mut c_void {
 }
 
 fn load_plugin() -> PluginEntries {
-    let mut entries = PluginEntries { has_api: None, get_api: None, set_api: None };
+    let mut entries = PluginEntries::empty();
     let Some(path) = sibling_plugin_path() else {
         log_warning("could not locate sibling redisearch_disk.so (dladdr failed)");
         return entries;
@@ -243,6 +291,39 @@ fn load_plugin() -> PluginEntries {
             entries.set_api = Some(std::mem::transmute::<*mut c_void, SetApiFn>(sp));
         }
     }
+
+    // Resolve the fork × compaction debug coordinator entry points. Debug builds
+    // only; these back the `FT.DEBUG REPL_COMPACTION_COORDINATOR` subcommands.
+    #[cfg(debug_assertions)]
+    // SAFETY: handle is a valid dlopen handle; the resolved symbols have the
+    // declared `extern "C"` signatures matching the plugin's exports.
+    unsafe {
+        let ap = resolve(handle, "SearchDiskPlugin_DebugCoordinatorArmPause");
+        let sw = resolve(handle, "SearchDiskPlugin_DebugCoordinatorSetWake");
+        let rl = resolve(handle, "SearchDiskPlugin_DebugCoordinatorRelease");
+        let rc = resolve(handle, "SearchDiskPlugin_DebugCoordinatorReached");
+        let rs = resolve(handle, "SearchDiskPlugin_DebugResetCompactionController");
+        if !ap.is_null() {
+            entries.debug_arm_pause =
+                Some(std::mem::transmute::<*mut c_void, DebugCoordinatorArmPauseFn>(ap));
+        }
+        if !sw.is_null() {
+            entries.debug_set_wake =
+                Some(std::mem::transmute::<*mut c_void, DebugCoordinatorSetWakeFn>(sw));
+        }
+        if !rl.is_null() {
+            entries.debug_release =
+                Some(std::mem::transmute::<*mut c_void, DebugCoordinatorReleaseFn>(rl));
+        }
+        if !rc.is_null() {
+            entries.debug_reached =
+                Some(std::mem::transmute::<*mut c_void, DebugCoordinatorReachedFn>(rc));
+        }
+        if !rs.is_null() {
+            entries.debug_reset =
+                Some(std::mem::transmute::<*mut c_void, DebugResetCompactionControllerFn>(rs));
+        }
+    }
     entries
 }
 
@@ -276,6 +357,67 @@ pub extern "C" fn SearchDisk_GetAPI() -> *mut c_void {
 #[unsafe(no_mangle)]
 pub extern "C" fn SearchDisk_SetAPI() {
     if let Some(f) = plugin().set_api {
+        // SAFETY: resolved plugin entry with the declared signature.
+        unsafe { f() }
+    }
+}
+
+// --- Fork × compaction debug coordinator forwarders --------------------------
+//
+// Strong overrides of the weak C stubs in `search_disk.c`, mirroring the main
+// three above. Debug builds only (the C stubs and call sites in
+// `debug_commands.c` are themselves debug-only), so `FT.DEBUG
+// REPL_COMPACTION_COORDINATOR` reaches the plugin's real coordinator instead of
+// the no-op stubs. When the plugin is absent the entry is `None` and these
+// behave like the original weak no-op stubs.
+
+/// Strong override of the weak C stub. Arms a single-shot pause at `site`.
+#[cfg(debug_assertions)]
+#[unsafe(no_mangle)]
+pub extern "C" fn SearchDisk_DebugCoordinatorArmPause(site: c_int, armed: bool) {
+    if let Some(f) = plugin().debug_arm_pause {
+        // SAFETY: resolved plugin entry with the declared signature.
+        unsafe { f(site, armed) }
+    }
+}
+
+/// Strong override of the weak C stub. Configures a cross-wake link.
+#[cfg(debug_assertions)]
+#[unsafe(no_mangle)]
+pub extern "C" fn SearchDisk_DebugCoordinatorSetWake(trigger: c_int, target: c_int) {
+    if let Some(f) = plugin().debug_set_wake {
+        // SAFETY: resolved plugin entry with the declared signature.
+        unsafe { f(trigger, target) }
+    }
+}
+
+/// Strong override of the weak C stub. Releases a parked site.
+#[cfg(debug_assertions)]
+#[unsafe(no_mangle)]
+pub extern "C" fn SearchDisk_DebugCoordinatorRelease(site: c_int) {
+    if let Some(f) = plugin().debug_release {
+        // SAFETY: resolved plugin entry with the declared signature.
+        unsafe { f(site) }
+    }
+}
+
+/// Strong override of the weak C stub. Returns how many times `site` was
+/// reached, or 0 when the plugin is absent.
+#[cfg(debug_assertions)]
+#[unsafe(no_mangle)]
+pub extern "C" fn SearchDisk_DebugCoordinatorReached(site: c_int) -> c_uint {
+    match plugin().debug_reached {
+        // SAFETY: resolved plugin entry with the declared signature.
+        Some(f) => unsafe { f(site) },
+        None => 0,
+    }
+}
+
+/// Strong override of the weak C stub. Resets the compaction coordinator.
+#[cfg(debug_assertions)]
+#[unsafe(no_mangle)]
+pub extern "C" fn SearchDisk_DebugResetCompactionController() {
+    if let Some(f) = plugin().debug_reset {
         // SAFETY: resolved plugin entry with the declared signature.
         unsafe { f() }
     }

--- a/src/redisearch_rs/redisearch_core/src/disk_forwarder.rs
+++ b/src/redisearch_rs/redisearch_core/src/disk_forwarder.rs
@@ -1,0 +1,282 @@
+//! Strong forwarders for the disk-plugin seam (option a).
+//!
+//! These STRONG `SearchDisk_{HasAPI,GetAPI,SetAPI}` exports override the weak C
+//! stubs in `deps/RediSearch/src/search_disk.c` at link time, so the C core is
+//! UNCHANGED. On first use they locate the sibling `redisearch_disk.so` (next to
+//! this module on disk, found via `dladdr`), `dlopen` it `RTLD_NOW|RTLD_GLOBAL`,
+//! and resolve the plugin's distinct entry points `SearchDiskPlugin_*`.
+
+use std::ffi::{CStr, CString, c_char, c_int, c_void};
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+/// Type of the `RedisModule_Log` API entry. It is a function *pointer* C global,
+/// not a function, so it must be called through the pointer's value. We only ever
+/// pass the fixed `(ctx, level, fmt, one %s arg)` prefix, so a non-variadic 4-arg
+/// signature is ABI-compatible with the variadic C declaration for these calls.
+type RedisModuleLogFn =
+    unsafe extern "C" fn(*mut c_void, *const c_char, *const c_char, *const c_char);
+
+unsafe extern "C" {
+    fn dlopen(filename: *const c_char, flag: c_int) -> *mut c_void;
+    fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
+    fn dladdr(addr: *const c_void, info: *mut DlInfo) -> c_int;
+    fn dlerror() -> *mut c_char;
+    // `RedisModule_Log` is a function-pointer C global in `redisearch.so`, populated
+    // by Redis at `OnLoad`. Bind it as a `static` (a pointer variable), then call
+    // through its value — binding it as a `fn` would jump to the variable's address
+    // and crash. A null context logs without an associated command context.
+    static RedisModule_Log: Option<RedisModuleLogFn>;
+    // `RedisModule_GetApi` is the C core's API-bootstrap pointer (also a C-core
+    // global in `redisearch.so`, populated by Redis at `OnLoad`). Read its value to
+    // initialize the dlopened plugin's own `RedisModule_*` table. Resolves to the
+    // copy in this `.so` because the forwarder is linked with the C core.
+    static RedisModule_GetApi: *const c_void;
+}
+
+#[repr(C)]
+struct DlInfo {
+    dli_fname: *const c_char,
+    dli_fbase: *mut c_void,
+    dli_sname: *const c_char,
+    dli_saddr: *mut c_void,
+}
+
+const RTLD_NOW: c_int = 0x2;
+const RTLD_GLOBAL: c_int = 0x100;
+const RTLD_NOLOAD: c_int = 0x4;
+
+type HasApiFn = unsafe extern "C" fn() -> bool;
+type GetApiFn = unsafe extern "C" fn() -> *mut c_void;
+type SetApiFn = unsafe extern "C" fn();
+type InitRedisModuleApiFn = unsafe extern "C" fn(*const c_void);
+
+/// Log a `warning`-level diagnostic through the C core's `RedisModule_Log`, so disk
+/// seam failures are visible in the server log instead of silently swallowed.
+fn log_warning(msg: &str) {
+    // SAFETY: reading the C-core function-pointer global. `Option<fn>` is null when
+    // the API table is not yet populated, in which case we skip logging.
+    let Some(log) = (unsafe { RedisModule_Log }) else {
+        // Fallback so the diagnostic is never fully lost if the logger is unset.
+        eprintln!("Search Disk plugin: {msg}");
+        return;
+    };
+    let Ok(level) = CString::new("warning") else {
+        return;
+    };
+    // `%s` keeps the message a single, non-format-interpreted argument.
+    let Ok(fmt) = CString::new("Search Disk plugin: %s") else {
+        return;
+    };
+    let Ok(cmsg) = CString::new(msg) else {
+        return;
+    };
+    // SAFETY: `log` is the populated `RedisModule_Log` pointer; a null context is
+    // accepted (logs without a command context). The format string has exactly one
+    // `%s` matching the single C-string argument.
+    unsafe {
+        log(std::ptr::null_mut(), level.as_ptr(), fmt.as_ptr(), cmsg.as_ptr());
+    }
+}
+
+/// The current `dlerror()` text, or a placeholder when none is set.
+fn last_dlerror() -> String {
+    // SAFETY: `dlerror` returns either null or a valid C string owned by libdl.
+    let p = unsafe { dlerror() };
+    if p.is_null() {
+        return "(no dlerror)".to_string();
+    }
+    // SAFETY: non-null `dlerror` result is a valid NUL-terminated C string.
+    unsafe { CStr::from_ptr(p) }.to_string_lossy().into_owned()
+}
+
+struct PluginEntries {
+    has_api: Option<HasApiFn>,
+    get_api: Option<GetApiFn>,
+    set_api: Option<SetApiFn>,
+}
+
+// SAFETY: function pointers into a dlopened-RTLD_GLOBAL library that is never
+// unloaded for the process lifetime.
+unsafe impl Send for PluginEntries {}
+unsafe impl Sync for PluginEntries {}
+
+static PLUGIN: OnceLock<PluginEntries> = OnceLock::new();
+
+/// Marker so a function's own address can be passed to `dladdr`.
+extern "C" fn anchor() {}
+
+/// Filesystem path of `redisearch.so` (this object), discovered via `dladdr` on a
+/// local function address.
+fn self_path() -> Option<PathBuf> {
+    let mut info = DlInfo {
+        dli_fname: std::ptr::null(),
+        dli_fbase: std::ptr::null_mut(),
+        dli_sname: std::ptr::null(),
+        dli_saddr: std::ptr::null_mut(),
+    };
+    // SAFETY: `anchor` is a valid function address; `info` is a valid out-param.
+    let rc = unsafe { dladdr(anchor as *const c_void, &mut info) };
+    if rc == 0 || info.dli_fname.is_null() {
+        return None;
+    }
+    // SAFETY: dladdr populated dli_fname with a valid C string.
+    let self_path = unsafe { CStr::from_ptr(info.dli_fname) }.to_str().ok()?;
+    Some(PathBuf::from(self_path))
+}
+
+fn sibling_plugin_path() -> Option<PathBuf> {
+    let dir = self_path()?.parent()?.to_path_buf();
+    Some(dir.join("redisearch_disk.so"))
+}
+
+/// Promote `redisearch.so` (this object) into the global symbol scope.
+///
+/// Redis loads modules with `RTLD_LOCAL`, so this object's symbols — including the
+/// C-core globals the plugin needs at load time (`RSDummyContext`, the
+/// `PLUGIN_EXPORTED_CORE_SYMBOLS`, the C++ VecSim/iterator symbols) — are NOT in
+/// the global scope. Re-`dlopen`ing the already-loaded object with
+/// `RTLD_GLOBAL | RTLD_NOLOAD` adds its symbols to the global scope (a documented
+/// glibc behavior) WITHOUT reloading it. Without this, the subsequent
+/// `RTLD_NOW` plugin `dlopen` fails with `undefined symbol: RSDummyContext`.
+///
+/// Returns `true` on success.
+fn promote_self_global() -> bool {
+    let Some(path) = self_path() else {
+        log_warning("could not locate redisearch.so via dladdr to promote it global");
+        return false;
+    };
+    let Ok(cpath) = CString::new(path.to_string_lossy().as_bytes()) else {
+        return false;
+    };
+    let _ = last_dlerror();
+    // SAFETY: cpath is a valid C string; RTLD_NOLOAD only re-references an
+    // already-loaded object, promoting it to the global scope.
+    let h = unsafe { dlopen(cpath.as_ptr(), RTLD_NOW | RTLD_GLOBAL | RTLD_NOLOAD) };
+    if h.is_null() {
+        log_warning(&format!(
+            "failed to promote redisearch.so to global scope: {}",
+            last_dlerror()
+        ));
+        return false;
+    }
+    true
+}
+
+/// Resolve `name` in `handle`, logging a `dlerror` diagnostic on failure.
+///
+/// # Safety
+/// `handle` must be a live `dlopen` handle.
+unsafe fn resolve(handle: *mut c_void, name: &str) -> *mut c_void {
+    let Ok(cname) = CString::new(name) else {
+        return std::ptr::null_mut();
+    };
+    // Clear any stale error so `dlerror()` after `dlsym` reflects this lookup.
+    let _ = last_dlerror();
+    // SAFETY: `handle` is a live dlopen handle (caller contract); `cname` is a
+    // valid C string.
+    let sym = unsafe { dlsym(handle, cname.as_ptr()) };
+    if sym.is_null() {
+        log_warning(&format!("dlsym(\"{name}\") failed: {}", last_dlerror()));
+    }
+    sym
+}
+
+fn load_plugin() -> PluginEntries {
+    let mut entries = PluginEntries { has_api: None, get_api: None, set_api: None };
+    let Some(path) = sibling_plugin_path() else {
+        log_warning("could not locate sibling redisearch_disk.so (dladdr failed)");
+        return entries;
+    };
+    let Ok(cpath) = CString::new(path.to_string_lossy().as_bytes()) else {
+        return entries;
+    };
+    // Make this object's symbols (C-core globals like `RSDummyContext`, plus the
+    // C++ VecSim/iterator symbols the plugin links against) reachable from the
+    // plugin's `RTLD_NOW` resolution. Redis loaded us `RTLD_LOCAL`, so without this
+    // the plugin `dlopen` aborts with `undefined symbol: RSDummyContext`.
+    promote_self_global();
+    // Clear any stale error so a subsequent `dlerror()` reflects this `dlopen`.
+    let _ = last_dlerror();
+    // SAFETY: cpath is a valid C string.
+    let handle = unsafe { dlopen(cpath.as_ptr(), RTLD_NOW | RTLD_GLOBAL) };
+    if handle.is_null() {
+        log_warning(&format!(
+            "dlopen(\"{}\") failed: {}",
+            path.display(),
+            last_dlerror()
+        ));
+        return entries;
+    }
+
+    // Bootstrap the plugin's own `redis_module` API table BEFORE any plugin entry
+    // runs. The plugin has a separate, uninitialized copy of the `RedisModule_*`
+    // table; pass it the C core's already-populated `RedisModule_GetApi` pointer so
+    // it can query every symbol from Redis. Without this, the first plugin call that
+    // touches `RedisModule_*` (e.g. `RedisModule_BigWriteBufferBudgetInit` during
+    // disk open) would dereference a null pointer and abort.
+    // SAFETY: `handle` is a live dlopen handle.
+    let init_sym = unsafe { resolve(handle, "SearchDiskPlugin_InitRedisModuleAPI") };
+    if !init_sym.is_null() {
+        // SAFETY: `RedisModule_GetApi` is the C core's bootstrap pointer in this
+        // `.so`, populated by Redis at `OnLoad`. The resolved symbol has the
+        // declared `extern "C" fn(*const c_void)` signature.
+        unsafe {
+            let init = std::mem::transmute::<*mut c_void, InitRedisModuleApiFn>(init_sym);
+            init(RedisModule_GetApi);
+        }
+    }
+
+    // SAFETY: handle is a valid dlopen handle; the resolved symbols have the
+    // declared `extern "C"` signatures.
+    unsafe {
+        let hp = resolve(handle, "SearchDiskPlugin_HasAPI");
+        let gp = resolve(handle, "SearchDiskPlugin_GetAPI");
+        let sp = resolve(handle, "SearchDiskPlugin_SetAPI");
+        if !hp.is_null() {
+            entries.has_api = Some(std::mem::transmute::<*mut c_void, HasApiFn>(hp));
+        }
+        if !gp.is_null() {
+            entries.get_api = Some(std::mem::transmute::<*mut c_void, GetApiFn>(gp));
+        }
+        if !sp.is_null() {
+            entries.set_api = Some(std::mem::transmute::<*mut c_void, SetApiFn>(sp));
+        }
+    }
+    entries
+}
+
+fn plugin() -> &'static PluginEntries {
+    PLUGIN.get_or_init(load_plugin)
+}
+
+/// Strong override of the weak C stub. Returns true iff the plugin is present
+/// and reports its API available.
+#[unsafe(no_mangle)]
+pub extern "C" fn SearchDisk_HasAPI() -> bool {
+    match plugin().has_api {
+        // SAFETY: resolved plugin entry with the declared signature.
+        Some(f) => unsafe { f() },
+        None => false,
+    }
+}
+
+/// Strong override of the weak C stub. Returns the plugin's disk-API vtable.
+#[unsafe(no_mangle)]
+pub extern "C" fn SearchDisk_GetAPI() -> *mut c_void {
+    match plugin().get_api {
+        // SAFETY: resolved plugin entry with the declared signature.
+        Some(f) => unsafe { f() },
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// Strong override of the weak C stub. Installs the shared
+/// `SEARCH_ENTERPRISE_ITERATORS` via the plugin.
+#[unsafe(no_mangle)]
+pub extern "C" fn SearchDisk_SetAPI() {
+    if let Some(f) = plugin().set_api {
+        // SAFETY: resolved plugin entry with the declared signature.
+        unsafe { f() }
+    }
+}

--- a/src/redisearch_rs/redisearch_core/src/disk_forwarder.rs
+++ b/src/redisearch_rs/redisearch_core/src/disk_forwarder.rs
@@ -6,9 +6,9 @@
 //! this module on disk, found via `dladdr`), `dlopen` it `RTLD_NOW|RTLD_GLOBAL`,
 //! and resolve the plugin's distinct entry points `SearchDiskPlugin_*`.
 
-use std::ffi::{CStr, CString, c_char, c_int, c_void};
 #[cfg(debug_assertions)]
 use std::ffi::c_uint;
+use std::ffi::{CStr, CString, c_char, c_int, c_void};
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
@@ -91,7 +91,12 @@ fn log_warning(msg: &str) {
     // accepted (logs without a command context). The format string has exactly one
     // `%s` matching the single C-string argument.
     unsafe {
-        log(std::ptr::null_mut(), level.as_ptr(), fmt.as_ptr(), cmsg.as_ptr());
+        log(
+            std::ptr::null_mut(),
+            level.as_ptr(),
+            fmt.as_ptr(),
+            cmsg.as_ptr(),
+        );
     }
 }
 
@@ -320,8 +325,10 @@ fn load_plugin() -> PluginEntries {
                 Some(std::mem::transmute::<*mut c_void, DebugCoordinatorReachedFn>(rc));
         }
         if !rs.is_null() {
-            entries.debug_reset =
-                Some(std::mem::transmute::<*mut c_void, DebugResetCompactionControllerFn>(rs));
+            entries.debug_reset = Some(std::mem::transmute::<
+                *mut c_void,
+                DebugResetCompactionControllerFn,
+            >(rs));
         }
     }
     entries

--- a/src/redisearch_rs/redisearch_core/src/lib.rs
+++ b/src/redisearch_rs/redisearch_core/src/lib.rs
@@ -1,0 +1,21 @@
+//! `redisearch.so` — the core Redis module, built as a `cdylib` so that `rustc`
+//! is the final linker and `-C prefer-dynamic` is honoured.
+//!
+//! It links:
+//! - `libsearch_shared.so` (dynamically) — the single shared instance of the
+//!   subgraph (`rqe_iterators::SEARCH_ENTERPRISE_ITERATORS`, etc.).
+//! - dynamic `libstd` — one allocator / std across core and the disk plugin.
+//! - `libredisearch_all.a` (statically, via `build.rs`) — the C search core.
+//! - the `redisearch_rs` c_entrypoint hub — the `*_ffi` `extern "C"` symbols the
+//!   C core calls.
+//!
+//! It carries NO speedb / disk / vecsim code. On RoF it `dlopen`s the sibling
+//! `redisearch_disk.so` through the strong forwarders in [`disk_forwarder`].
+
+// Keep the shared umbrella dylib as a link edge (single-instance subgraph).
+use search_shared as _;
+// Keep the core FFI hub: forces the `*_ffi` extern "C" symbols into redisearch.so.
+use redisearch_rs as _;
+
+pub mod disk_forwarder;
+pub mod module_entry;

--- a/src/redisearch_rs/redisearch_core/src/module_entry.rs
+++ b/src/redisearch_rs/redisearch_core/src/module_entry.rs
@@ -1,0 +1,29 @@
+//! The module entry point exported by `redisearch.so`.
+//!
+//! Redis loads a module by `dlsym(handle, "RedisModule_OnLoad")`. A Rust
+//! `cdylib`'s auto-generated version script exports only Rust `#[no_mangle]`
+//! symbols and localizes everything else — so the C core's `RedisModule_OnLoad`
+//! (renamed to `RediSearch_OnLoad_Impl`) would be hidden. This Rust shim carries
+//! the exported `RedisModule_OnLoad` name and forwards to the C implementation.
+
+use std::ffi::{c_int, c_void};
+
+unsafe extern "C" {
+    /// The real module init in the C core (renamed from `RedisModule_OnLoad`).
+    fn RediSearch_OnLoad_Impl(ctx: *mut c_void, argv: *mut *mut c_void, argc: c_int) -> c_int;
+}
+
+/// `redisearch.so` module entry point. Forwards to the C core init.
+///
+/// # Safety
+/// Called by Redis with a valid module context and argument vector.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn RedisModule_OnLoad(
+    ctx: *mut c_void,
+    argv: *mut *mut c_void,
+    argc: c_int,
+) -> c_int {
+    // SAFETY: forwarding Redis' own arguments unchanged to the C implementation,
+    // which has the identical signature.
+    unsafe { RediSearch_OnLoad_Impl(ctx, argv, argc) }
+}

--- a/src/redisearch_rs/redisearch_core_linker.sh
+++ b/src/redisearch_rs/redisearch_core_linker.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2006-Present, Redis Ltd.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+# GNU Affero General Public License v3 (AGPLv3).
+#
+# Thin linker wrapper for the conditional disk-plugin build (LP1/LP2).
+#
+# `rustc` is the linker driver for the `redisearch_core` cdylib (`redisearch.so`).
+# For a cdylib it auto-generates an anonymous version script
+#   { global: <#[no_mangle] Rust syms>; local: *; };
+# whose `local: *` localizes every C-core / VecSim symbol. The dlopened plugin
+# `redisearch_disk.so` resolves a fixed set of C-core symbols from `redisearch.so`
+# via RTLD_GLOBAL, so those names MUST appear in `redisearch.so`'s `.dynsym`.
+#
+# Empirically (GNU ld 2.38, LLD 21) no linker flag promotes a symbol that the
+# version script marked local, and a second `--version-script` cannot be combined
+# with `rustc`'s anonymous one. The only robust fix is to inject the needed names
+# into the `global:` section of `rustc`'s own version script before the link.
+#
+# This wrapper does exactly that, and ONLY when it is producing
+# `libredisearch_core.so` (so the sibling `redisearch_disk_plugin` /
+# `search_shared` links are untouched). For everything else it is a transparent
+# pass-through to the real C compiler driver.
+#
+# Inputs (env):
+#   REAL_CC                       real cc driver to exec (default: "cc")
+#   REDISEARCH_PLUGIN_EXPORTS_FILE  newline-separated symbol names to inject
+set -euo pipefail
+
+real_cc="${REAL_CC:-cc}"
+exports_file="${REDISEARCH_PLUGIN_EXPORTS_FILE:-}"
+
+# Determine the link output and the rustc version-script path from argv.
+out=""
+version_script=""
+prev=""
+for a in "$@"; do
+  case "$prev" in
+    -o) out="$a" ;;
+  esac
+  case "$a" in
+    -o) ;; # handled via prev
+    -Wl,--version-script=*) version_script="${a#-Wl,--version-script=}" ;;
+    --version-script=*) version_script="${a#--version-script=}" ;;
+  esac
+  prev="$a"
+done
+
+# Only patch the redisearch_core cdylib link, and only if we have both a version
+# script and a non-empty symbol list. Otherwise pass through unchanged.
+if [[ "${out}" == *libredisearch_core.so ]] \
+   && [[ -n "${version_script}" && -f "${version_script}" ]] \
+   && [[ -n "${exports_file}" && -s "${exports_file}" ]]; then
+  patched="${version_script}.plugin_exports"
+  # Insert each symbol immediately after the `global:` line so it joins the
+  # exported set; the `local: *;` that follows no longer captures them.
+  {
+    awk '
+      /global:/ && !done {
+        print
+        while ((getline line < EXPORTS) > 0) {
+          if (line != "") printf "    %s;\n", line
+        }
+        close(EXPORTS)
+        done = 1
+        next
+      }
+      { print }
+    ' EXPORTS="${exports_file}" "${version_script}"
+  } > "${patched}"
+
+  # Rebuild argv with the patched version script substituted in place.
+  new_args=()
+  for a in "$@"; do
+    case "$a" in
+      -Wl,--version-script=*) new_args+=("-Wl,--version-script=${patched}") ;;
+      --version-script=*) new_args+=("--version-script=${patched}") ;;
+      *) new_args+=("$a") ;;
+    esac
+  done
+  exec "${real_cc}" "${new_args[@]}"
+fi
+
+exec "${real_cc}" "$@"

--- a/src/redisearch_rs/redisearch_disk_plugin/Cargo.lock
+++ b/src/redisearch_rs/redisearch_disk_plugin/Cargo.lock
@@ -18,19 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,40 +27,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloca"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
 name = "anstyle-query"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
-
-[[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
@@ -85,20 +45,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx"
-version = "0.6.0-rc2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fbdd65cc59dcc820bfb0fd01315963d4f9898bf3399a47134c9836698c47df"
-dependencies = [
- "num-traits 0.2.19",
- "paste",
-]
-
-[[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -114,12 +64,6 @@ dependencies = [
  "rustc-demangle",
  "windows-link",
 ]
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
@@ -138,8 +82,8 @@ dependencies = [
  "quote 1.0.45",
  "regex",
  "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.117",
+ "shlex 1.3.0",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -148,7 +92,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -158,8 +102,8 @@ dependencies = [
  "quote 1.0.45",
  "regex",
  "rustc-hash 2.1.2",
- "shlex",
- "syn 2.0.117",
+ "shlex 1.3.0",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -170,9 +114,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "buffer"
@@ -193,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecount"
@@ -216,12 +160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
 name = "bzip2-sys"
 version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,62 +177,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "c_trie"
-version = "0.0.1"
-dependencies = [
- "ffi",
- "strum",
- "workspace_hack",
-]
-
-[[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -313,61 +204,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "cheadergen"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b761058a928fa8f932d79ed1ad18b417ef2238a90f3a605cda6365b40c9658"
+checksum = "f53a323bcf01640850ec7cc849a052a98e9b23f08d003af1b7939bb33e58aa71"
 dependencies = [
  "cheadergen_macros",
 ]
 
 [[package]]
 name = "cheadergen_macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057f8322e701b896c5bbc5ac64aed5f17174a32e12ca8f34315a26ed8e83619a"
+checksum = "512458ff0d3b6b892724d6f8a0ffa191f579d3085fa8b31ff2eb5515c729ba53"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -382,31 +235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
-dependencies = [
- "clap_builder",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
-dependencies = [
- "anstyle",
- "clap_lex",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,79 +242,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "criterion"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
-dependencies = [
- "alloca",
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "itertools 0.13.0",
- "num-traits 0.2.19",
- "oorandom",
- "page_size",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
-dependencies = [
- "cast",
- "itertools 0.13.0",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
+ "windows-sys",
 ]
 
 [[package]]
@@ -494,33 +250,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "dashmap"
@@ -542,7 +271,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcc6bb0c903f3f815b48365bb9182092866f54a132d8ebe906f0b66952936e3"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "num-traits 0.2.19",
  "rustversion",
  "serde",
@@ -551,20 +280,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -626,7 +349,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -642,7 +365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -688,23 +411,10 @@ dependencies = [
  "build_utils",
  "cc",
  "document",
- "enumflags2",
  "query_node_type",
  "query_term",
  "rqe_core",
  "rqe_iterator_type",
- "workspace_hack",
-]
-
-[[package]]
-name = "ffi_geiger"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "cargo_metadata",
- "proc-macro2",
- "syn 2.0.117",
- "walkdir",
  "workspace_hack",
 ]
 
@@ -724,11 +434,7 @@ version = "0.0.1"
 dependencies = [
  "enumflags2",
  "ffi",
- "field_spec",
  "hidden_string",
- "pretty_assertions",
- "redis_mock",
- "redisearch_rs",
  "workspace_hack",
 ]
 
@@ -737,16 +443,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fnv"
@@ -765,17 +461,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "fork_gc"
 version = "0.0.1"
 dependencies = [
  "ffi",
- "index_result",
  "index_spec",
  "inverted_index",
  "libc",
@@ -801,39 +490,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs-err"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
 name = "generational_slab"
 version = "0.0.1"
 dependencies = [
@@ -845,7 +501,6 @@ name = "geo"
 version = "0.0.1"
 dependencies = [
  "decorum",
- "proptest",
  "thiserror",
  "workspace_hack",
 ]
@@ -889,16 +544,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -914,17 +567,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
-]
-
-[[package]]
 name = "hash32"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,15 +577,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -968,44 +601,19 @@ name = "hidden_string"
 version = "0.0.1"
 dependencies = [
  "ffi",
- "pretty_assertions",
- "redis_mock",
- "redisearch_rs",
  "workspace_hack",
 ]
-
-[[package]]
-name = "http"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
-dependencies = [
- "bytes",
- "itoa",
-]
-
-[[package]]
-name = "httparse"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyperloglog"
 version = "0.0.1"
 dependencies = [
- "ahash",
  "bytecount",
- "criterion",
  "fnv",
  "hash32",
- "insta",
- "proptest",
- "rustc-hash 2.1.2",
  "thiserror",
  "workspace_hack",
  "wyhash",
- "xxhash-rust",
 ]
 
 [[package]]
@@ -1097,17 +705,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idf"
 version = "0.0.1"
 dependencies = [
- "approx 0.6.0-rc2",
- "rstest",
  "workspace_hack",
 ]
 
@@ -1141,9 +741,6 @@ dependencies = [
  "ffi",
  "field_spec",
  "inverted_index",
- "pretty_assertions",
- "redis_mock",
- "redisearch_rs",
  "schema_rule",
  "workspace_hack",
 ]
@@ -1166,20 +763,19 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
  "regex",
  "similar",
+ "strip-ansi-escapes",
  "tempfile",
 ]
 
@@ -1192,8 +788,6 @@ dependencies = [
  "ffi",
  "field",
  "index_result",
- "pretty_assertions",
- "proptest",
  "qint",
  "query_term",
  "redis_reply",
@@ -1202,23 +796,6 @@ dependencies = [
  "smallvec",
  "thin_vec",
  "varint",
- "workspace_hack",
-]
-
-[[package]]
-name = "inverted_index_bencher"
-version = "0.0.1"
-dependencies = [
- "buffer",
- "criterion",
- "ffi",
- "index_result",
- "inverted_index",
- "itertools 0.14.0",
- "query_term",
- "redis-module",
- "redis_mock",
- "rqe_core",
  "workspace_hack",
 ]
 
@@ -1293,18 +870,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
-dependencies = [
- "cfg-if",
- "futures-util",
- "once_cell",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,12 +880,6 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lending-iterator"
@@ -1387,13 +946,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "license_header_linter"
-version = "0.0.1"
-dependencies = [
- "workspace_hack",
-]
-
-[[package]]
 name = "linkme"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,7 +962,7 @@ checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1436,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -1467,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "metrics_ffi"
@@ -1567,7 +1119,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1594,21 +1146,13 @@ version = "0.0.1"
 dependencies = [
  "build_utils",
  "cheadergen",
- "criterion",
  "ffi",
  "generational_slab",
  "hyperloglog",
  "index_result",
- "insta",
  "inverted_index",
- "numeric_range_tree",
- "pretty_assertions",
- "proptest",
- "redis_mock",
  "redis_reply",
- "redisearch_rs",
  "rqe_core",
- "rstest",
  "tracing",
  "workspace_hack",
 ]
@@ -1649,28 +1193,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
 name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits 0.2.19",
-]
-
-[[package]]
-name = "page_size"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -1709,12 +1237,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,7 +1253,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1745,34 +1267,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits 0.2.19",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
 
 [[package]]
 name = "polonius-the-crab"
@@ -1801,23 +1295,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_assertions"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
-dependencies = [
- "diff",
- "yansi",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1830,58 +1314,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
-dependencies = [
- "bitflags 2.11.1",
- "num-traits 0.2.19",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
- "rand_xorshift",
- "regex-syntax",
- "unarray",
-]
-
-[[package]]
-name = "proptest-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
-dependencies = [
- "proc-macro2",
- "quote 1.0.45",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "qint"
 version = "0.0.1"
 dependencies = [
- "criterion",
- "proptest",
- "proptest-derive",
- "rand 0.10.1",
- "workspace_hack",
-]
-
-[[package]]
-name = "query"
-version = "0.0.1"
-dependencies = [
- "build_utils",
- "ffi",
- "inverted_index",
- "query",
- "query_error",
- "query_flags",
- "query_node_type",
- "redis_mock",
- "redisearch_rs",
- "rlookup",
- "rqe_core",
- "rqe_iterators",
  "workspace_hack",
 ]
 
@@ -1902,29 +1337,6 @@ dependencies = [
  "c_ffi_utils",
  "query_error",
  "strum",
- "workspace_hack",
-]
-
-[[package]]
-name = "query_eval"
-version = "0.0.1"
-dependencies = [
- "build_utils",
- "ffi",
- "proptest",
- "query_eval",
- "redis_mock",
- "redisearch_rs",
- "thiserror",
- "workspace_hack",
-]
-
-[[package]]
-name = "query_flags"
-version = "0.0.1"
-dependencies = [
- "cheadergen",
- "enumflags2",
  "workspace_hack",
 ]
 
@@ -1983,58 +1395,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
-dependencies = [
- "chacha20",
- "getrandom 0.4.2",
- "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,47 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
 
 [[package]]
 name = "redis-module"
@@ -2094,7 +1416,7 @@ source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=f74ecbb
 dependencies = [
  "backtrace",
  "bindgen 0.72.1",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cc",
  "cfg-if",
  "enum-primitive-derive",
@@ -2130,16 +1452,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redis_json_api"
-version = "0.0.1"
-dependencies = [
- "ffi",
- "redis-module",
- "thiserror",
- "workspace_hack",
-]
-
-[[package]]
 name = "redis_mock"
 version = "0.0.1"
 dependencies = [
@@ -2155,19 +1467,7 @@ name = "redis_reply"
 version = "0.0.1"
 dependencies = [
  "ffi",
- "insta",
- "proptest",
- "redis_mock",
  "workspace_hack",
-]
-
-[[package]]
-name = "redisearch_core"
-version = "0.0.1"
-dependencies = [
- "build_utils",
- "redisearch_rs",
- "search_shared",
 ]
 
 [[package]]
@@ -2236,7 +1536,7 @@ dependencies = [
  "search_result_ffi",
  "slots_tracker_ffi",
  "sorting_vector_ffi",
- "syn 2.0.117",
+ "syn 2.0.118",
  "toml",
  "triemap_ffi",
  "types_ffi",
@@ -2252,7 +1552,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2265,9 +1565,6 @@ dependencies = [
  "itertools 0.14.0",
  "min-max-heap",
  "query_error",
- "redis_mock",
- "redisearch_rs",
- "reducers",
  "rlookup",
  "tracing",
  "tracing_assert",
@@ -2288,17 +1585,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref_mode"
-version = "0.0.1"
-dependencies = [
- "workspace_hack",
-]
-
-[[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2319,15 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "result_processor"
@@ -2337,9 +1621,6 @@ dependencies = [
  "ffi",
  "libc",
  "pin-project",
- "redis_mock",
- "redisearch_rs",
- "result_processor",
  "search_result",
  "workspace_hack",
 ]
@@ -2349,25 +1630,8 @@ name = "result_processor_ffi"
 version = "0.0.1"
 dependencies = [
  "ffi",
- "redis_mock",
- "redisearch_rs",
  "result_processor",
- "result_processor_ffi",
  "workspace_hack",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2387,13 +1651,9 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "pin-project",
- "pretty_assertions",
- "proptest",
  "query_error",
  "redis-module",
  "redis_mock",
- "redisearch_rs",
- "rlookup",
  "schema_rule",
  "sorting_vector",
  "strum",
@@ -2411,10 +1671,7 @@ dependencies = [
  "ffi",
  "libc",
  "query_error",
- "redis_mock",
- "redisearch_rs",
  "rlookup",
- "rlookup_ffi",
  "search_result",
  "sorting_vector",
  "value",
@@ -2479,85 +1736,28 @@ dependencies = [
 name = "rqe_iterators"
 version = "0.0.1"
 dependencies = [
- "approx 0.6.0-rc2",
  "build_utils",
  "cheadergen",
- "decorum",
  "ffi",
  "field",
  "geo",
  "idf",
  "index_result",
  "index_spec",
- "insta",
  "inverted_index",
  "libc",
  "numeric_range_tree",
- "pretty_assertions",
- "proptest",
  "query_error",
  "query_term",
- "query_term_ffi",
  "redis_mock",
  "redis_reply",
- "redisearch_rs",
  "rqe_core",
  "rqe_iterator_type",
- "rqe_iterators",
- "rqe_iterators_test_utils",
- "rstest",
- "rstest_reuse",
  "thiserror",
  "tracing",
  "trie_rs",
  "types_ffi",
  "value",
- "value_ffi",
- "varint_ffi",
- "workspace_hack",
-]
-
-[[package]]
-name = "rqe_iterators_bencher"
-version = "0.0.1"
-dependencies = [
- "bindgen 0.72.1",
- "build_utils",
- "criterion",
- "ffi",
- "field",
- "index_result",
- "inverted_index",
- "inverted_index_ffi",
- "iterators_ffi",
- "itertools 0.14.0",
- "query_term",
- "rand 0.10.1",
- "redis_mock",
- "redisearch_rs",
- "rqe_core",
- "rqe_iterators",
- "rqe_iterators_test_utils",
- "workspace_hack",
-]
-
-[[package]]
-name = "rqe_iterators_test_utils"
-version = "0.0.1"
-dependencies = [
- "ffi",
- "field",
- "index_result",
- "index_spec",
- "inverted_index",
- "inverted_index_ffi",
- "libc",
- "numeric_range_tree",
- "numeric_range_tree_ffi",
- "query_error",
- "redis_mock",
- "rqe_core",
- "rqe_iterators",
  "varint_ffi",
  "workspace_hack",
 ]
@@ -2567,72 +1767,8 @@ name = "rqe_wildcard"
 version = "0.0.1"
 dependencies = [
  "build_utils",
- "criterion",
- "ffi",
- "fnv_ffi",
- "fork_gc_ffi",
- "geo_ffi",
- "idf_ffi",
- "inverted_index_ffi",
- "iterators_ffi",
  "memchr",
- "metrics_ffi",
- "module_init_ffi",
- "numeric_range_tree_ffi",
- "proptest",
- "query_error_ffi",
- "query_term_ffi",
- "redis_mock",
- "reducers_ffi",
- "result_processor_ffi",
- "rlookup_ffi",
- "rqe_wildcard",
- "search_result_ffi",
- "slots_tracker_ffi",
- "sorting_vector_ffi",
- "triemap_ffi",
- "types_ffi",
- "value_ffi",
- "varint_ffi",
- "wildcard",
  "workspace_hack",
-]
-
-[[package]]
-name = "rstest"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
-dependencies = [
- "rstest_macros",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro2",
- "quote 1.0.45",
- "regex",
- "relative-path",
- "rustc_version",
- "syn 2.0.117",
- "unicode-ident",
-]
-
-[[package]]
-name = "rstest_reuse"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
-dependencies = [
- "quote 1.0.45",
- "rand 0.8.6",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2654,60 +1790,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
-dependencies = [
- "log",
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2715,24 +1807,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "safety_report"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "cargo_metadata",
- "proc-macro2",
- "syn 2.0.117",
- "walkdir",
- "workspace_hack",
-]
 
 [[package]]
 name = "same-file"
@@ -2748,9 +1822,6 @@ name = "schema_rule"
 version = "0.0.1"
 dependencies = [
  "ffi",
- "pretty_assertions",
- "redis_mock",
- "redisearch_rs",
  "workspace_hack",
 ]
 
@@ -2836,14 +1907,14 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2877,6 +1948,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,12 +1964,6 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-
-[[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slots_tracker"
@@ -2912,9 +1983,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -2926,9 +1997,6 @@ dependencies = [
  "build_utils",
  "ffi",
  "icu_casemap",
- "redis_mock",
- "redisearch_rs",
- "sorting_vector",
  "thin_vec",
  "value",
  "workspace_hack",
@@ -2964,6 +2032,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,14 +2071,8 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote 1.0.45",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -3011,7 +2082,7 @@ checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 dependencies = [
  "quote 0.3.15",
  "synom",
- "unicode-xid 0.0.4",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3027,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -3042,7 +2113,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 dependencies = [
- "unicode-xid 0.0.4",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3053,7 +2124,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3063,20 +2134,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "term_suffix_index"
-version = "0.0.1"
-dependencies = [
- "ffi",
- "proptest",
- "trie_rs",
- "workspace_hack",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3103,7 +2164,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3124,16 +2185,6 @@ dependencies = [
  "displaydoc",
  "serde_core",
  "zerovec",
-]
-
-[[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -3176,40 +2227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
-name = "top_k"
-version = "0.0.1"
-dependencies = [
- "build_utils",
- "ffi",
- "index_result",
- "index_spec",
- "inverted_index",
- "redis_mock",
- "redisearch_rs",
- "rqe_core",
- "rqe_iterator_type",
- "rqe_iterators",
- "rqe_iterators_test_utils",
- "top_k",
- "workspace_hack",
-]
-
-[[package]]
-name = "top_k_bencher"
-version = "0.0.1"
-dependencies = [
- "bindgen 0.72.1",
- "build_utils",
- "criterion",
- "rand 0.10.1",
- "redis_mock",
- "redisearch_rs",
- "rqe_iterators",
- "top_k",
- "workspace_hack",
-]
-
-[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,7 +2245,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3287,37 +2304,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "trie_bencher"
-version = "0.0.1"
-dependencies = [
- "crc32fast",
- "criterion",
- "csv",
- "ffi",
- "fs-err",
- "lending-iterator",
- "redis_mock",
- "rqe_wildcard",
- "trie_rs",
- "ureq",
- "workspace_hack",
-]
-
-[[package]]
 name = "trie_rs"
 version = "0.0.1"
 dependencies = [
  "cheadergen",
  "ffi",
- "fs-err",
- "insta",
  "lending-iterator",
  "libc",
  "memchr",
- "proptest",
- "proptest-derive",
  "rqe_wildcard",
- "trie_rs",
  "workspace_hack",
 ]
 
@@ -3347,52 +2342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ttl_table"
-version = "0.0.1"
-dependencies = [
- "ffi",
- "field",
- "libc",
- "rqe_core",
- "thin_vec",
- "ttl_table",
- "workspace_hack",
-]
-
-[[package]]
-name = "ttl_table_bencher"
-version = "0.0.1"
-dependencies = [
- "build_utils",
- "criterion",
- "ffi",
- "libc",
- "rand 0.10.1",
- "redis_mock",
- "redisearch_rs",
- "rqe_core",
- "thin_vec",
- "ttl_table",
- "workspace_hack",
-]
-
-[[package]]
-name = "ttl_table_ffi"
-version = "0.0.1"
-dependencies = [
- "cheadergen",
- "ffi",
- "field",
- "libc",
- "redis-module",
- "redis_mock",
- "rqe_core",
- "thin_vec",
- "ttl_table",
- "workspace_hack",
-]
-
-[[package]]
 name = "types_ffi"
 version = "0.0.1"
 dependencies = [
@@ -3401,12 +2350,6 @@ dependencies = [
  "inverted_index",
  "workspace_hack",
 ]
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -3419,12 +2362,6 @@ name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-tools"
@@ -3449,47 +2386,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c925fa852969cb33845bcb97736763d404ec5cd9210c58ebf3cefe39abbed80a"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
-dependencies = [
- "base64",
- "flate2",
- "log",
- "percent-encoding",
- "rustls",
- "rustls-pki-types",
- "ureq-proto",
- "utf8-zero",
- "webpki-roots",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
-dependencies = [
- "base64",
- "http",
- "httparse",
- "log",
-]
-
-[[package]]
-name = "utf8-zero"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3512,8 +2408,6 @@ dependencies = [
  "libc",
  "query_error",
  "redis-module",
- "redis_mock",
- "redisearch_rs",
  "thiserror",
  "tracing",
  "tracing_assert",
@@ -3530,7 +2424,6 @@ dependencies = [
  "fnv",
  "libc",
  "query_error",
- "redis_mock",
  "value",
  "workspace_hack",
 ]
@@ -3540,17 +2433,6 @@ name = "varint"
 version = "0.0.1"
 dependencies = [
  "cheadergen",
- "proptest",
- "proptest-derive",
- "workspace_hack",
-]
-
-[[package]]
-name = "varint_bencher"
-version = "0.0.1"
-dependencies = [
- "criterion",
- "varint",
  "workspace_hack",
 ]
 
@@ -3573,10 +2455,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
+name = "vte"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "walkdir"
@@ -3596,144 +2481,12 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
+ "wit-bindgen",
 ]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.121"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.121"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
-dependencies = [
- "quote 1.0.45",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.121"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
-dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote 1.0.45",
- "syn 2.0.117",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.121"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "wildcard"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b0540e91e49de3817c314da0dd3bc518093ceacc6ea5327cb0e1eb073e5189"
-dependencies = [
- "thiserror",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -3741,14 +2494,8 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -3758,85 +2505,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -3852,108 +2526,20 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote 1.0.45",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid 0.2.6",
- "wasmparser",
-]
 
 [[package]]
 name = "workspace_hack"
 version = "0.1.0"
 dependencies = [
  "bindgen 0.72.1",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "clang-sys",
  "either",
  "getrandom 0.2.17",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "insta",
  "itertools 0.13.0",
  "libc",
@@ -3976,7 +2562,7 @@ dependencies = [
  "serde_json",
  "stable_deref_trait",
  "syn 1.0.109",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tracing-core",
  "zerocopy",
 ]
@@ -3997,22 +2583,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "xxhash-rust"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4027,28 +2601,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4068,15 +2642,9 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
@@ -4110,7 +2678,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/src/redisearch_rs/redisearch_disk_plugin/Cargo.toml
+++ b/src/redisearch_rs/redisearch_disk_plugin/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "redisearch_disk_plugin"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[lib]
+# The dlopened disk plugin `redisearch_disk.so` (conditional cdylib architecture).
+# A `cdylib` so `rustc` is the final linker and honours `-C prefer-dynamic`: the
+# shared subgraph resolves to the single instance in `libsearch_shared.so`.
+#
+# This crate is a THIN shell that re-exports the superrepo `redisearch_disk`
+# package. Living inside the core Cargo workspace, it is compiled in the SAME
+# build graph as `redisearch_core`, so both link the EXACT SAME `search_shared`
+# (one Strict-Version-Hash). `redisearch_disk` is pulled into that graph as a
+# path dependency (not a workspace member — it sits above the workspace root and
+# the hierarchy rule forbids membership, but a member may still depend on it).
+crate-type = ["cdylib"]
+test = false
+bench = false
+
+[dependencies]
+# Link edge to the umbrella dylib so the shared subgraph resolves to the single
+# `libsearch_shared.so` instance under `-C prefer-dynamic`.
+search_shared = { path = "../search_shared" }
+# The superrepo disk layer (speedb + vecsim_disk + the `SearchDiskPlugin_*`
+# entry points). Path reaches up to `/work/redisearch_disk`.
+redisearch_disk = { path = "../../../../../redisearch_disk" }
+
+[build-dependencies]
+build_utils = { path = "../build_utils" }

--- a/src/redisearch_rs/redisearch_disk_plugin/build.rs
+++ b/src/redisearch_rs/redisearch_disk_plugin/build.rs
@@ -1,0 +1,181 @@
+//! Link configuration for the disk plugin cdylib `redisearch_disk.so`.
+//!
+//! `rustc` is the final linker for this cdylib. We must:
+//! - Keep the `SearchDiskPlugin_{Has,Get,Set}API` `#[no_mangle]` exports (defined
+//!   in the `redisearch_disk` rlib dependency) in the cdylib's dynamic symbol
+//!   table. Because nothing in *this* crate references them, the linker would
+//!   otherwise garbage-collect them; `-Wl,--undefined=NAME` pins each one.
+//! - Export the dynamic symbols so the dlopening core (`RTLD_GLOBAL`) and the
+//!   shared dylib can see them.
+//! - Link the VecSim archives (vecsim_disk + VectorSimilarity + transitive deps)
+//!   INTO this cdylib. The disk vector indexes the plugin owns are implemented in
+//!   `vecsim_disk` (C++) on top of `VectorSimilarity`; in `redisearch.so` those
+//!   symbols are localized by the cdylib version script (`local: *`) and so cannot
+//!   resolve from the core via `RTLD_GLOBAL`. They MUST be linked here, in the
+//!   *cdylib* crate: `cargo::rustc-link-arg` directives emitted by the
+//!   `redisearch_disk` rlib dependency do NOT propagate to this final link, so the
+//!   linking has to happen in this build script.
+//!
+//! The C-core archive / MKL are intentionally NOT linked (they resolve at `dlopen`
+//! time from `redisearch.so` via `RTLD_GLOBAL`); that part is handled by
+//! `redisearch_disk`'s own `build.rs`, gated on `REDISEARCH_DISK_PLUGIN=1`.
+
+use std::path::{Path, PathBuf};
+
+fn main() {
+    // Pin the plugin entry points so the linker keeps them in `.dynsym`.
+    for sym in [
+        "SearchDiskPlugin_HasAPI",
+        "SearchDiskPlugin_GetAPI",
+        "SearchDiskPlugin_SetAPI",
+        // Bootstrap entry for this `.so`'s own `redis_module` API table; the core
+        // forwarder resolves it via `dlsym` and calls it with the live
+        // `RedisModule_GetApi` pointer (see `redisearch_core::disk_forwarder`).
+        "SearchDiskPlugin_InitRedisModuleAPI",
+    ] {
+        println!("cargo::rustc-link-arg=-Wl,--undefined={sym}");
+    }
+
+    // Export the dynamic symbol table so the dlopening core and the shared dylib
+    // can resolve the plugin's exports at runtime.
+    println!("cargo::rustc-link-arg=-Wl,--export-dynamic");
+
+    // AArch64 outline-atomics helper(s). A C++ object in the disk layer (VecSim /
+    // SpeedB) emits a reference to `__aarch64_ldadd4_acq_rel`, which lives in the
+    // static `libgcc.a` but NOT the shared `libgcc_s.so.1`. By the time that
+    // reference is seen, the linker has already finished with libgcc, so the symbol
+    // is left undefined and the plugin `dlopen` aborts (`RTLD_NOW`) with
+    // `undefined symbol: __aarch64_ldadd4_acq_rel`. Pin the reference and append
+    // `-lgcc` so the helper is pulled from `libgcc.a` into this `.so`.
+    println!("cargo::rustc-link-arg=-Wl,--undefined=__aarch64_ldadd4_acq_rel");
+    println!("cargo::rustc-link-arg=-lgcc");
+
+    link_speedb_into_plugin();
+    link_vecsim_into_plugin();
+}
+
+/// Links SpeedB into the plugin cdylib as a `NEEDED` shared library.
+///
+/// The disk layer's storage engine is SpeedB (a RocksDB fork) shipped as
+/// `libspeedb.so.<major>.<minor>`. Its `rocksdb::*` C++ symbols are referenced
+/// from the `redisearch_disk` -> `speedb` (rust-speedb) rlib dependency, but the
+/// `cargo:rustc-link-lib=dylib=speedb` that `libspeedb-sys`'s build script emits
+/// does NOT carry the link-search path through to *this* final cdylib link (the
+/// same rlib-build-script-propagation gap that forces the VecSim archives to be
+/// linked here). Left unaddressed, `redisearch_disk.so` would carry ~127 undefined
+/// `rocksdb::*` symbols and NO `DT_NEEDED libspeedb`, relying on libspeedb having
+/// been preloaded into the global scope. Emitting the link here gives the plugin a
+/// real `DT_NEEDED libspeedb.so.*` (the library's SONAME), resolved at `dlopen`
+/// (on RoF) via the `$ORIGIN`/speedb rpath that `build.sh` stamps onto the staged
+/// artifact.
+///
+/// `redisearch.so` (the core module) does NOT link this — it has no disk code —
+/// so it remains free of any `libspeedb` dependency (the RoR requirement).
+///
+/// `build.sh` exports `SPEEDB_LIB_DIR` to the directory containing `libspeedb.so`.
+/// When it is unset (e.g. a plain in-submodule `cargo build`/`clippy` with no
+/// superrepo) we skip — the plugin is only ever produced by the superrepo build.
+fn link_speedb_into_plugin() {
+    println!("cargo::rerun-if-env-changed=SPEEDB_LIB_DIR");
+    let Ok(lib_dir) = std::env::var("SPEEDB_LIB_DIR") else {
+        return;
+    };
+    let lib_dir = PathBuf::from(lib_dir);
+    let lib_path = lib_dir.join("libspeedb.so");
+    if !std::fs::exists(&lib_path).unwrap_or(false) {
+        // No staged library to link against; leave the plugin as-is rather than
+        // failing the build (mirrors libspeedb-sys's tolerant behaviour).
+        println!("cargo::warning=SPEEDB_LIB_DIR set but {} not found", lib_path.display());
+        return;
+    }
+    println!("cargo::rerun-if-changed={}", lib_path.display());
+
+    // Record a `DT_NEEDED` for SpeedB. `-lspeedb` resolves `libspeedb.so` in
+    // `lib_dir`; the recorded NEEDED is the library's SONAME
+    // (`libspeedb.so.<major>.<minor>`). The plugin's ~127 undefined `rocksdb::*`
+    // references keep it from being dropped under the default `--as-needed`.
+    println!("cargo::rustc-link-search=native={}", lib_dir.display());
+    println!("cargo::rustc-link-arg=-L{}", lib_dir.display());
+    println!("cargo::rustc-link-arg=-lspeedb");
+    // Embed an rpath to the speedb directory so a `cargo`-only link (no `build.sh`
+    // rpath stamping) can still resolve it at runtime; `build.sh` additionally
+    // stamps `$ORIGIN:<speedb_dir>` over this for the staged artifact.
+    println!("cargo::rustc-link-arg=-Wl,-rpath,{}", lib_dir.display());
+}
+
+/// Links the disk vector index implementation and its VecSim dependencies into the
+/// plugin cdylib. The build coordinator (`build.sh`) sets `REDISEARCH_VECSIM_BUILD_DIR`
+/// to the CMake build directory that contains the archives; when it is unset (e.g. a
+/// plain in-submodule `cargo build`/`clippy` with no superrepo) we skip — the plugin
+/// is only ever produced by the superrepo build.
+fn link_vecsim_into_plugin() {
+    let Ok(build_dir) = std::env::var("REDISEARCH_VECSIM_BUILD_DIR") else {
+        println!("cargo::rerun-if-env-changed=REDISEARCH_VECSIM_BUILD_DIR");
+        return;
+    };
+    println!("cargo::rerun-if-env-changed=REDISEARCH_VECSIM_BUILD_DIR");
+    let build_dir = PathBuf::from(build_dir);
+    let vecsim_dir = build_dir.join("deps/RediSearch/src/VectorSimilarity/src/VecSim");
+    let spaces_dir = vecsim_dir.join("spaces");
+
+    // Resolve `lib<name>.a` from the first matching candidate (spdlog/fmt carry a
+    // `d` suffix in debug builds, none in release).
+    let resolve = |dir: &Path, candidates: &[&str]| -> PathBuf {
+        for name in candidates {
+            let p = dir.join(format!("lib{name}.a"));
+            if std::fs::exists(&p).unwrap_or(false) {
+                return p;
+            }
+        }
+        panic!(
+            "VecSim archive {} not found under {}",
+            candidates.join("/"),
+            dir.display()
+        );
+    };
+
+    // `vecsim_disk` is the plugin's payload (it owns disk vector indexes). Its
+    // `VecSimDisk_*` C API and C++ objects are referenced from the Rust crate only
+    // through FFI function pointers, which the linker cannot see as live when it
+    // scans the archive — so on-demand archive semantics leave them unpulled. Force
+    // the whole archive in.
+    let vecsim_disk_a = resolve(&build_dir.join("vecsim_disk"), &["vecsim_disk"]);
+    println!("cargo::rerun-if-changed={}", vecsim_disk_a.display());
+    println!("cargo::rustc-link-arg=-Wl,--whole-archive");
+    println!("cargo::rustc-link-arg={}", vecsim_disk_a.display());
+    println!("cargo::rustc-link-arg=-Wl,--no-whole-archive");
+
+    // The transitive VecSim libraries (the same set the CMake `vecsim_disk` target
+    // links via `PUBLIC VectorSimilarity`:
+    //   VectorSimilarity -> VectorSimilaritySpaces
+    //     -> VectorSimilaritySpaces_no_optimization + cpu_features
+    //   (VecSim logging) -> spdlog -> fmt)
+    // reference each other, so wrap them in a linker group for back-references. All
+    // archives are passed by ABSOLUTE PATH to avoid `-l`/search-path and
+    // `.so`-vs-`.a` ambiguities. The plugin's VecSim copy is pointed at Redis's
+    // allocator at init via `VecSim_SetMemoryFunctions` (see the
+    // `vecsim_set_memory_functions` helper in `redisearch_disk`).
+    let group_libs: [(PathBuf, &[&str]); 6] = [
+        (vecsim_dir.clone(), &["VectorSimilarity"]),
+        (spaces_dir.clone(), &["VectorSimilaritySpaces"]),
+        (spaces_dir.clone(), &["VectorSimilaritySpaces_no_optimization"]),
+        (build_dir.join("_deps/cpu_features-build"), &["cpu_features"]),
+        (build_dir.join("_deps/spdlog-build"), &["spdlog", "spdlogd"]),
+        (build_dir.join("_deps/fmt-build"), &["fmt", "fmtd"]),
+    ];
+    println!("cargo::rustc-link-arg=-Wl,--start-group");
+    for (dir, candidates) in &group_libs {
+        let path = resolve(dir, candidates);
+        println!("cargo::rustc-link-arg={}", path.display());
+        println!("cargo::rerun-if-changed={}", path.display());
+    }
+    println!("cargo::rustc-link-arg=-Wl,--end-group");
+
+    // The VecSim / vecsim_disk / spdlog / fmt C++ code needs the C++ runtime
+    // (`std::exception` typeinfo & vtables, `__dynamic_cast`, `__gxx_personality_v0`,
+    // `__once_proxy`, ...). The legacy static link gets this via
+    // `build_utils`'s C++ link step, which plugin mode skips, so add the C++ runtime
+    // as a `NEEDED` shared library here. Emitted after the archives so it resolves
+    // their references.
+    println!("cargo::rustc-link-arg=-lstdc++");
+}

--- a/src/redisearch_rs/redisearch_disk_plugin/build.rs
+++ b/src/redisearch_rs/redisearch_disk_plugin/build.rs
@@ -94,7 +94,10 @@ fn link_speedb_into_plugin() {
     if !std::fs::exists(&lib_path).unwrap_or(false) {
         // No staged library to link against; leave the plugin as-is rather than
         // failing the build (mirrors libspeedb-sys's tolerant behaviour).
-        println!("cargo::warning=SPEEDB_LIB_DIR set but {} not found", lib_path.display());
+        println!(
+            "cargo::warning=SPEEDB_LIB_DIR set but {} not found",
+            lib_path.display()
+        );
         return;
     }
     println!("cargo::rerun-if-changed={}", lib_path.display());
@@ -167,8 +170,14 @@ fn link_vecsim_into_plugin() {
     let group_libs: [(PathBuf, &[&str]); 6] = [
         (vecsim_dir.clone(), &["VectorSimilarity"]),
         (spaces_dir.clone(), &["VectorSimilaritySpaces"]),
-        (spaces_dir.clone(), &["VectorSimilaritySpaces_no_optimization"]),
-        (build_dir.join("_deps/cpu_features-build"), &["cpu_features"]),
+        (
+            spaces_dir.clone(),
+            &["VectorSimilaritySpaces_no_optimization"],
+        ),
+        (
+            build_dir.join("_deps/cpu_features-build"),
+            &["cpu_features"],
+        ),
         (build_dir.join("_deps/spdlog-build"), &["spdlog", "spdlogd"]),
         (build_dir.join("_deps/fmt-build"), &["fmt", "fmtd"]),
     ];

--- a/src/redisearch_rs/redisearch_disk_plugin/build.rs
+++ b/src/redisearch_rs/redisearch_disk_plugin/build.rs
@@ -120,6 +120,25 @@ fn link_speedb_into_plugin() {
 /// to the CMake build directory that contains the archives; when it is unset (e.g. a
 /// plain in-submodule `cargo build`/`clippy` with no superrepo) we skip — the plugin
 /// is only ever produced by the superrepo build.
+///
+/// The plugin must link the SAME VecSim copy + transitive deps that the C core's
+/// `libredisearch_all.a` links, otherwise its `VectorSimilarity` objects leave their
+/// `spdlog` / `fmt` / SVS symbols undefined. That transitive set is layout- and
+/// arch-dependent:
+///   - **aarch64** (no SVS): `VectorSimilarity`, `VectorSimilaritySpaces`
+///     (+ `_no_optimization`), `cpu_features`, and `spdlog` / `fmt` under
+///     `_deps/{spdlog,fmt}-build/` (the archives carry a `d` suffix in debug builds).
+///   - **x86_64** (SVS): the same VecSim/Spaces/cpu_features archives, but `spdlog`
+///     and `fmt` come precompiled under `_deps/svs-src/lib/` instead, PLUS the SVS
+///     archives `libsvs_static_library.a` and `libsvs_x86_objects.a` (which the C
+///     core also merges into `libredisearch_all.a`).
+///
+/// To stay layout-agnostic we do not hardcode a single directory per archive. The
+/// CMake build exports the already-resolved absolute paths to a file pointed at by
+/// `REDISEARCH_VECSIM_ARCHIVES` (see `deps/RediSearch/src/CMakeLists.txt`); when that
+/// file is present and non-empty we link exactly that set. Otherwise we fall back to
+/// searching the known candidate directories and globbing for the version-suffixed
+/// archives — including the SVS archives only when `_deps/svs-src/lib/` exists.
 fn link_vecsim_into_plugin() {
     let Ok(build_dir) = std::env::var("REDISEARCH_VECSIM_BUILD_DIR") else {
         println!("cargo::rerun-if-env-changed=REDISEARCH_VECSIM_BUILD_DIR");
@@ -127,63 +146,37 @@ fn link_vecsim_into_plugin() {
     };
     println!("cargo::rerun-if-env-changed=REDISEARCH_VECSIM_BUILD_DIR");
     let build_dir = PathBuf::from(build_dir);
-    let vecsim_dir = build_dir.join("deps/RediSearch/src/VectorSimilarity/src/VecSim");
-    let spaces_dir = vecsim_dir.join("spaces");
-
-    // Resolve `lib<name>.a` from the first matching candidate (spdlog/fmt carry a
-    // `d` suffix in debug builds, none in release).
-    let resolve = |dir: &Path, candidates: &[&str]| -> PathBuf {
-        for name in candidates {
-            let p = dir.join(format!("lib{name}.a"));
-            if std::fs::exists(&p).unwrap_or(false) {
-                return p;
-            }
-        }
-        panic!(
-            "VecSim archive {} not found under {}",
-            candidates.join("/"),
-            dir.display()
-        );
-    };
 
     // `vecsim_disk` is the plugin's payload (it owns disk vector indexes). Its
     // `VecSimDisk_*` C API and C++ objects are referenced from the Rust crate only
     // through FFI function pointers, which the linker cannot see as live when it
     // scans the archive — so on-demand archive semantics leave them unpulled. Force
     // the whole archive in.
-    let vecsim_disk_a = resolve(&build_dir.join("vecsim_disk"), &["vecsim_disk"]);
+    let vecsim_disk_a = build_dir.join("vecsim_disk/libvecsim_disk.a");
+    assert!(
+        std::fs::exists(&vecsim_disk_a).unwrap_or(false),
+        "plugin payload archive not found: {}",
+        vecsim_disk_a.display()
+    );
     println!("cargo::rerun-if-changed={}", vecsim_disk_a.display());
     println!("cargo::rustc-link-arg=-Wl,--whole-archive");
     println!("cargo::rustc-link-arg={}", vecsim_disk_a.display());
     println!("cargo::rustc-link-arg=-Wl,--no-whole-archive");
 
-    // The transitive VecSim libraries (the same set the CMake `vecsim_disk` target
-    // links via `PUBLIC VectorSimilarity`:
+    // The transitive VecSim libraries (the same set `libredisearch_all.a` merges via
+    // `vecsim_disk`'s `PUBLIC VectorSimilarity`:
     //   VectorSimilarity -> VectorSimilaritySpaces
     //     -> VectorSimilaritySpaces_no_optimization + cpu_features
-    //   (VecSim logging) -> spdlog -> fmt)
+    //   (VecSim logging) -> spdlog -> fmt   [+ SVS on x86_64])
     // reference each other, so wrap them in a linker group for back-references. All
     // archives are passed by ABSOLUTE PATH to avoid `-l`/search-path and
     // `.so`-vs-`.a` ambiguities. The plugin's VecSim copy is pointed at Redis's
     // allocator at init via `VecSim_SetMemoryFunctions` (see the
     // `vecsim_set_memory_functions` helper in `redisearch_disk`).
-    let group_libs: [(PathBuf, &[&str]); 6] = [
-        (vecsim_dir.clone(), &["VectorSimilarity"]),
-        (spaces_dir.clone(), &["VectorSimilaritySpaces"]),
-        (
-            spaces_dir.clone(),
-            &["VectorSimilaritySpaces_no_optimization"],
-        ),
-        (
-            build_dir.join("_deps/cpu_features-build"),
-            &["cpu_features"],
-        ),
-        (build_dir.join("_deps/spdlog-build"), &["spdlog", "spdlogd"]),
-        (build_dir.join("_deps/fmt-build"), &["fmt", "fmtd"]),
-    ];
+    let group_libs = vecsim_transitive_archives(&build_dir);
+
     println!("cargo::rustc-link-arg=-Wl,--start-group");
-    for (dir, candidates) in &group_libs {
-        let path = resolve(dir, candidates);
+    for path in &group_libs {
         println!("cargo::rustc-link-arg={}", path.display());
         println!("cargo::rerun-if-changed={}", path.display());
     }
@@ -196,4 +189,137 @@ fn link_vecsim_into_plugin() {
     // as a `NEEDED` shared library here. Emitted after the archives so it resolves
     // their references.
     println!("cargo::rustc-link-arg=-lstdc++");
+}
+
+/// Resolves the transitive VecSim archives the plugin must whole-link-group.
+///
+/// Prefers the explicit list CMake exports via `REDISEARCH_VECSIM_ARCHIVES` (a file
+/// of newline-separated absolute paths); that path is fully layout/arch-agnostic and
+/// already includes the SVS archives on x86_64. Falls back to searching the build
+/// tree when the env var is unset, the file is empty/missing, or the list is
+/// incomplete — the latter guards against the CMake export lagging (its spdlog/fmt
+/// paths are globbed at configure time and could be empty before those archives are
+/// built), which would otherwise silently drop them and break the link.
+fn vecsim_transitive_archives(build_dir: &Path) -> Vec<PathBuf> {
+    println!("cargo::rerun-if-env-changed=REDISEARCH_VECSIM_ARCHIVES");
+    if let Ok(list_file) = std::env::var("REDISEARCH_VECSIM_ARCHIVES") {
+        println!("cargo::rerun-if-changed={list_file}");
+        if let Ok(contents) = std::fs::read_to_string(&list_file) {
+            let archives: Vec<PathBuf> = contents
+                .lines()
+                .map(str::trim)
+                .filter(|l| !l.is_empty())
+                .map(PathBuf::from)
+                .filter(|p| std::fs::exists(p).unwrap_or(false))
+                .collect();
+
+            // Sanity-check completeness: VectorSimilarity links spdlog (which links
+            // fmt), so both MUST be in any valid set. If the exported list is missing
+            // either, treat it as stale and discover from the build tree instead.
+            let has = |needle: &str| {
+                archives.iter().any(|p| {
+                    p.file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|n| n.starts_with(&format!("lib{needle}")))
+                })
+            };
+            if has("spdlog") && has("fmt") {
+                return archives;
+            }
+            if !archives.is_empty() {
+                println!(
+                    "cargo::warning=REDISEARCH_VECSIM_ARCHIVES ({list_file}) is missing \
+                     spdlog/fmt; falling back to build-tree search"
+                );
+            }
+        }
+    }
+    discover_vecsim_transitive_archives(build_dir)
+}
+
+/// Fallback discovery of the transitive VecSim archives by searching the CMake build
+/// tree. Layout-agnostic: each archive is looked up across all known candidate
+/// directories and matched by glob so version/debug suffixes (`libspdlogd.a`,
+/// `libfmtd.a`) and the SVS layout (`_deps/svs-src/lib/`) are both handled.
+///
+/// `VectorSimilarity`, `VectorSimilaritySpaces`, `VectorSimilaritySpaces_no_optimization`,
+/// `cpu_features`, `spdlog` and `fmt` are MANDATORY and panic if not found. The SVS
+/// archives (`svs_static_library`, `svs_x86_objects`) are CONDITIONAL: present only on
+/// x86_64 (under `_deps/svs-src/lib/`) and silently skipped when absent (aarch64).
+fn discover_vecsim_transitive_archives(build_dir: &Path) -> Vec<PathBuf> {
+    let vecsim_dir = build_dir.join("deps/RediSearch/src/VectorSimilarity/src/VecSim");
+    let spaces_dir = vecsim_dir.join("spaces");
+    let cpu_features_dir = build_dir.join("_deps/cpu_features-build");
+    // On x86_64, VectorSimilarity is built WITH SVS: spdlog/fmt are the precompiled
+    // copies shipped under the SVS lib dir, alongside the SVS archives themselves.
+    let svs_lib_dir = build_dir.join("_deps/svs-src/lib");
+    let spdlog_dir = build_dir.join("_deps/spdlog-build");
+    let fmt_dir = build_dir.join("_deps/fmt-build");
+
+    let mut archives = Vec::new();
+
+    // Mandatory VecSim core archives (stable CMake target output locations).
+    for (dirs, stem) in [
+        (&[vecsim_dir.as_path()][..], "VectorSimilarity"),
+        (&[spaces_dir.as_path()][..], "VectorSimilaritySpaces"),
+        (
+            &[spaces_dir.as_path()][..],
+            "VectorSimilaritySpaces_no_optimization",
+        ),
+        (&[cpu_features_dir.as_path()][..], "cpu_features"),
+    ] {
+        archives.push(require_archive(dirs, stem));
+    }
+
+    // spdlog/fmt: `_deps/{spdlog,fmt}-build/` on aarch64, `_deps/svs-src/lib/` on
+    // x86_64. Search both; `find_archive` matches the optional debug `d` suffix.
+    archives.push(require_archive(
+        &[spdlog_dir.as_path(), svs_lib_dir.as_path()],
+        "spdlog",
+    ));
+    archives.push(require_archive(
+        &[fmt_dir.as_path(), svs_lib_dir.as_path()],
+        "fmt",
+    ));
+
+    // SVS archives: x86_64-only. Include when present, skip silently otherwise.
+    for stem in ["svs_static_library", "svs_x86_objects"] {
+        if let Some(p) = find_archive(&[svs_lib_dir.as_path()], stem) {
+            archives.push(p);
+        }
+    }
+
+    archives
+}
+
+/// Returns the archive for `stem` found across `dirs`, or `None` if absent.
+///
+/// Matches the release name `lib<stem>.a` and the debug name `lib<stem>d.a` (CMake's
+/// `CMAKE_DEBUG_POSTFIX` for spdlog/fmt) — and only those exact two forms. Matching a
+/// bare `lib<stem>*.a` glob would be ambiguous: `libVectorSimilaritySpaces.a` and
+/// `libVectorSimilaritySpaces_no_optimization.a` both start with the
+/// `VectorSimilaritySpaces` prefix, so a loose prefix match could pull the wrong
+/// archive. The release variant is preferred when both happen to exist.
+fn find_archive(dirs: &[&Path], stem: &str) -> Option<PathBuf> {
+    let candidates = [format!("lib{stem}.a"), format!("lib{stem}d.a")];
+    for dir in dirs {
+        for name in &candidates {
+            let p = dir.join(name);
+            if std::fs::exists(&p).unwrap_or(false) {
+                return Some(p);
+            }
+        }
+    }
+    None
+}
+
+/// Like [`find_archive`] but panics with the searched locations when not found.
+fn require_archive(dirs: &[&Path], stem: &str) -> PathBuf {
+    find_archive(dirs, stem).unwrap_or_else(|| {
+        let searched: Vec<String> = dirs.iter().map(|d| d.display().to_string()).collect();
+        panic!(
+            "VecSim archive lib{stem}*.a not found under any of: {}",
+            searched.join(", ")
+        );
+    })
 }

--- a/src/redisearch_rs/redisearch_disk_plugin/build.rs
+++ b/src/redisearch_rs/redisearch_disk_plugin/build.rs
@@ -47,8 +47,17 @@ fn main() {
     // is left undefined and the plugin `dlopen` aborts (`RTLD_NOW`) with
     // `undefined symbol: __aarch64_ldadd4_acq_rel`. Pin the reference and append
     // `-lgcc` so the helper is pulled from `libgcc.a` into this `.so`.
-    println!("cargo::rustc-link-arg=-Wl,--undefined=__aarch64_ldadd4_acq_rel");
-    println!("cargo::rustc-link-arg=-lgcc");
+    //
+    // These outline-atomics helpers exist ONLY on AArch64; on x86_64 (and other
+    // arches) the symbol does not exist, so pinning `--undefined=__aarch64_*` would
+    // leave an unsatisfiable reference and fail the link. Gate the pin on the build
+    // *target* arch via `CARGO_CFG_TARGET_ARCH` (set by cargo to the value of
+    // `cfg!(target_arch)`), so the same source builds on every arch.
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    if target_arch == "aarch64" {
+        println!("cargo::rustc-link-arg=-Wl,--undefined=__aarch64_ldadd4_acq_rel");
+        println!("cargo::rustc-link-arg=-lgcc");
+    }
 
     link_speedb_into_plugin();
     link_vecsim_into_plugin();

--- a/src/redisearch_rs/redisearch_disk_plugin/src/lib.rs
+++ b/src/redisearch_rs/redisearch_disk_plugin/src/lib.rs
@@ -1,0 +1,28 @@
+//! The dlopened disk plugin `redisearch_disk.so` (conditional cdylib architecture).
+//!
+//! `redisearch.so` (the [`redisearch_core`] cdylib) statically contains NO speedb /
+//! disk / vecsim code. On RoF it `dlopen`s this sibling `redisearch_disk.so` with
+//! `RTLD_NOW | RTLD_GLOBAL` and resolves the `SearchDiskPlugin_{Has,Get,Set}API`
+//! entry points (see `redisearch_core::disk_forwarder`).
+//!
+//! This crate is a thin shell:
+//! - It re-exports the superrepo `redisearch_disk` package, which defines the
+//!   `SearchDiskPlugin_*` entry points and the whole disk layer (speedb +
+//!   vecsim_disk).
+//! - It depends on `search_shared`, so under `-C prefer-dynamic` the shared
+//!   subgraph (`rqe_iterators::SEARCH_ENTERPRISE_ITERATORS`, allocator / `libstd`)
+//!   resolves to the single instance in `libsearch_shared.so` that `redisearch.so`
+//!   also binds — letting the plugin register disk iterators that the core's query
+//!   engine reads back across the `.so` boundary.
+//!
+//! Living inside the core Cargo workspace, it is compiled in the SAME build graph
+//! as `redisearch_core`, so both link the exact same `search_shared` (one SVH).
+
+// Force a link edge to the umbrella dylib so the shared subgraph binds the single
+// `libsearch_shared.so` instance under `-C prefer-dynamic`.
+use search_shared as _;
+
+// Pull in the disk layer. The `SearchDiskPlugin_{Has,Get,Set}API` `#[no_mangle]`
+// exports live in this crate; `build.rs` keeps them in the cdylib's dynamic symbol
+// table via `-Wl,--undefined=...`.
+use redisearch_disk as _;

--- a/src/redisearch_rs/search_shared/Cargo.toml
+++ b/src/redisearch_rs/search_shared/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "search_shared"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[lib]
+# `dylib`: the single shared instance (`libsearch_shared.so`) that the two
+#   cdylibs (`redisearch.so`, `redisearch_disk.so`) link under `-C prefer-dynamic`
+#   — one copy of process-global state (`rqe_iterators::SEARCH_ENTERPRISE_ITERATORS`,
+#   `inverted_index`'s id counter) and one allocator/`libstd`.
+# `rlib`: required so crates that still produce `rlib`/`staticlib` outputs (e.g.
+#   `redisearch_disk`'s retained static path, Rust unit tests) can depend on it.
+#   The cdylibs prefer the `dylib` form, so single-instance still holds for them.
+crate-type = ["dylib", "rlib"]
+
+[dependencies]
+# The shared subgraph roots. Their transitive in-repo deps are absorbed into
+# libsearch_shared.so, giving a single instance of every shared process-global.
+rqe_iterators.workspace = true
+inverted_index.workspace = true
+ffi.workspace = true
+query_term.workspace = true
+query_error.workspace = true
+index_result.workspace = true
+index_spec.workspace = true

--- a/src/redisearch_rs/search_shared/src/lib.rs
+++ b/src/redisearch_rs/search_shared/src/lib.rs
@@ -1,0 +1,59 @@
+//! Umbrella `dylib` crate aggregating the shared subgraph for the conditional
+//! cdylib disk-plugin architecture.
+//!
+//! By depending on the shared in-repo crates here and building this crate as a
+//! `dylib` (with `-C prefer-dynamic`), the transitive shared crates are linked
+//! statically *into* `libsearch_shared.so`. Downstream cdylibs (`redisearch.so`,
+//! `redisearch_disk.so`) that also depend on these crates and build
+//! `-C prefer-dynamic` resolve them to this single dynamic copy, giving one
+//! instance of every shared process-global (and one allocator / `libstd`).
+
+// Re-export so downstream crates can reach the shared globals through the
+// umbrella, and so the linker keeps the symbols.
+pub use ffi;
+pub use index_result;
+pub use index_spec;
+pub use inverted_index;
+pub use query_error;
+pub use query_term;
+pub use rqe_iterators;
+
+/// Reports whether the shared `rqe_iterators::SEARCH_ENTERPRISE_ITERATORS` is
+/// initialised, as observed *through this dylib* (`libsearch_shared.so`).
+///
+/// Returns `1` when the disk-iterators API has been installed, `0` otherwise.
+///
+/// This is the read side of the cross-`.so` interop proof: the dlopened disk
+/// plugin (`redisearch_disk.so`) installs the shared `SEARCH_ENTERPRISE_ITERATORS`
+/// via its `SearchDiskPlugin_SetAPI` entry point, and a C harness calls this
+/// function to confirm the write is visible to the single shared instance that
+/// `redisearch.so` also binds — proving SVH-matched runtime resolution.
+#[unsafe(no_mangle)]
+pub extern "C" fn SearchShared_IteratorsApiIsSet() -> std::ffi::c_int {
+    std::ffi::c_int::from(rqe_iterators::SEARCH_ENTERPRISE_ITERATORS.get().is_some())
+}
+
+/// A shared, allocation-free process global living in `libsearch_shared.so`,
+/// used purely to prove cross-`.so` shared-mutable-state visibility without
+/// depending on the Redis allocator (which is only initialised inside a live
+/// `redis-server`).
+///
+/// The dlopened disk plugin writes a sentinel here via
+/// [`SearchShared_InteropMarkerSet`] and a C harness reads it back via
+/// [`SearchShared_InteropMarkerGet`]; if the read observes the plugin's write,
+/// both `.so`s bind the single instance in `libsearch_shared.so`.
+static INTEROP_MARKER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Write side of the allocation-free interop marker. Stores `value` into the
+/// shared `INTEROP_MARKER` in `libsearch_shared.so`. See [`INTEROP_MARKER`].
+#[unsafe(no_mangle)]
+pub extern "C" fn SearchShared_InteropMarkerSet(value: u64) {
+    INTEROP_MARKER.store(value, std::sync::atomic::Ordering::SeqCst);
+}
+
+/// Read side of the allocation-free interop marker. Returns the current value of
+/// the shared `INTEROP_MARKER` in `libsearch_shared.so`. See [`INTEROP_MARKER`].
+#[unsafe(no_mangle)]
+pub extern "C" fn SearchShared_InteropMarkerGet() -> u64 {
+    INTEROP_MARKER.load(std::sync::atomic::Ordering::SeqCst)
+}


### PR DESCRIPTION
## Summary
- Add conditional cdylib disk plugin support so Redis module loading can avoid a hard libspeedb dependency.
- Preserve the legacy RedisModule_OnLoad export path and route disk debug symbols through the dynamic lookup path.
- Keep the user-visible WORKERS and MIN_OPERATION_WORKERS config maximum stable at 16 even when enterprise builds raise internal worker capacity.
- Refresh Cargo.lock after the dependency graph changes.

## Validation
- Not run in this pass; pushed the branch for CI.