### PR TITLE
CI: fix post-merge triage missing real failures (focused-log collection + truncation)

### DIFF
--- a/.github/actions/ci-failure-context/action.yml
+++ b/.github/actions/ci-failure-context/action.yml
@@ -18,6 +18,35 @@ inputs:
     description: Directory to write failed-logs.txt and download artifacts into.
     required: false
     default: '.'
+  highlight-patterns:
+    description: >
+      Newline-separated extended-regex (`grep -E`) patterns. Every matching line
+      of the assembled log is extracted *before* the tail-cap and prepended under
+      a `KEY FAILURE LINES` banner, so a root cause buried mid-log (e.g. a Python
+      traceback or an RLTest `[FAIL]` summary far above the tail) survives
+      truncation. The default targets common RediSearch CI failure signatures;
+      pass an empty string to disable.
+    required: false
+    default: |
+      Traceback \(most recent call last\):
+      [A-Za-z_.]*(Error|Exception):
+      AssertionError
+      \[(FAIL|ERROR)\]
+      \(FAIL\):
+      [1-9][0-9]* tests failed
+      Total Tests Failed: [1-9]
+      tests? failed, code:
+      ##\[error\]
+      Segmentation fault
+      SUMMARY: .*Sanitizer
+      panicked at
+      RDB CHECKSUM ERROR
+  max-key-lines:
+    description: >
+      Cap on the number of extracted highlight lines (deduplicated, in log order)
+      prepended to the file. Bounds token spend when a pattern is noisy.
+    required: false
+    default: '150'
 
 outputs:
   failed-jobs:
@@ -119,6 +148,8 @@ runs:
         GH_TOKEN: ${{ github.token }}
         ARTIFACT_PATTERN: ${{ inputs.artifact-pattern }}
         MAX_BYTES: ${{ inputs.max-bytes }}
+        HIGHLIGHT_PATTERNS: ${{ inputs.highlight-patterns }}
+        MAX_KEY_LINES: ${{ inputs.max-key-lines }}
       run: |
         set +e
         # Higher-priority focused "Failed Test Logs *" artifacts (per-test
@@ -162,6 +193,35 @@ runs:
           echo "No Failed Test Logs artifacts found."
         fi
 
+        # Extract high-signal lines from the *whole* assembled log before the
+        # tail-cap below, so a root cause buried mid-log (e.g. a Python traceback
+        # or an RLTest [FAIL] summary far above the surviving tail) is preserved.
+        # The banner is prepended *after* the cap so it always survives — a job
+        # log can run to several MB and the decisive line is often nowhere near
+        # the last MAX_BYTES.
+        KEY_FILE=""
+        if [ -n "$HIGHLIGHT_PATTERNS" ]; then
+          PAT_FILE="$(mktemp)"
+          printf '%s\n' "$HIGHLIGHT_PATTERNS" | grep -v '^[[:space:]]*$' > "$PAT_FILE"
+          KEY_FILE="$(mktemp)"
+          # -n: keep line numbers for locatability; cut: bound pathological long
+          # lines; awk: dedupe preserving order after stripping the line-number
+          # prefix and GH-Actions/Python-logger timestamps, so a message repeated
+          # on many lines collapses to one entry; head: bound total volume.
+          grep -nE -f "$PAT_FILE" failed-logs.txt 2>/dev/null \
+            | cut -c1-500 \
+            | awk '{
+                key = $0
+                sub(/^[0-9]+:/, "", key)
+                gsub(/[0-9]+-[0-9]+-[0-9]+T[0-9:.]+Z/, "", key)
+                gsub(/[0-9]+-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+,[0-9]+/, "", key)
+                if (!seen[key]++) print
+              }' \
+            | head -n "$MAX_KEY_LINES" > "$KEY_FILE"
+          rm -f "$PAT_FILE"
+          [ -s "$KEY_FILE" ] || { rm -f "$KEY_FILE"; KEY_FILE=""; }
+        fi
+
         # Cap to MAX_BYTES to bound Codex token spend. Focused logs are
         # appended last, so they survive truncation; the per-job logs
         # written by fetch-failed-run-logs absorb it.
@@ -170,5 +230,17 @@ runs:
           printf '[truncated to last %d bytes]\n' "$MAX_BYTES" > failed-logs.txt
           cat failed-logs.txt.tmp >> failed-logs.txt
           rm failed-logs.txt.tmp
+        fi
+
+        if [ -n "$KEY_FILE" ]; then
+          {
+            printf '##[group]KEY FAILURE LINES (grepped from full pre-truncation log; line numbers included)\n'
+            cat "$KEY_FILE"
+            printf '##[endgroup]\n'
+            printf -- '--- assembled job + focused-test logs follow (may be tail-truncated) ---\n'
+          } > failed-logs.txt.tmp
+          cat failed-logs.txt >> failed-logs.txt.tmp
+          mv failed-logs.txt.tmp failed-logs.txt
+          rm -f "$KEY_FILE"
         fi
         exit 0

--- a/.github/codex/prompts/post-merge-triage.md
+++ b/.github/codex/prompts/post-merge-triage.md
@@ -21,8 +21,14 @@ tests that actually failed) or a job/step name (fallback when no per-test logs
 were available — e.g. build-only failures). If the file is missing, empty, or
 unreadable, output one line saying so and stop.
 
+If a `KEY FAILURE LINES` section is present at the top of the file, it holds the
+highest-signal lines (tracebacks, `[FAIL]`/error markers, failed-test counts)
+grepped from the full log before truncation. Start there: the rest of the file
+may be tail-truncated and a passing summary near the tail can be misleading, so
+do not conclude "no failures" from the tail alone when these lines disagree.
+
 If a `failed-tests-*.txt` file is bundled inside the input, it contains the
-RLTest list of failed tests in `test_file.py:test_name` form — use it as the
+RLTest list of failed tests in `test_file:test_name` form — use it as the
 authoritative list of distinct failures.
 
 ## Task

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -593,14 +593,21 @@ jobs:
         # part of the filename. So we key the glob on `<file>_<class-or-func>`,
         # dropping any `.method` suffix from the failed id — otherwise the glob can
         # never match and the focused bundle silently misses the real failure.
+        #
+        # Mirror the "Upload Artifacts" guard: with fail-fast disabled the test
+        # steps are continue-on-error, so a unit-test-only failure never trips
+        # `failure()` here and we must check the step outcomes explicitly —
+        # otherwise no focused bundle is produced for unit-test-only failures.
         if: >
           failure() || (
+            (steps.rust_unit_tests_miri.outcome == 'failure') ||
+            steps.rust_unit_tests.outcome == 'failure' ||
+            steps.c_unit_tests.outcome == 'failure' ||
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
           )
         env:
           C_UNIT_TESTS_OUTCOME: ${{ steps.c_unit_tests.outcome }}
-          RUST_UNIT_TESTS_OUTCOME: ${{ steps.rust_unit_tests.outcome }}
         run: |
           set +e
           DEST="failed-test-logs"
@@ -630,12 +637,15 @@ jobs:
           copy_for_failed_list ".failed_coordinator.txt"
 
           # The C/C++ CTest summary logs (rstest*.log) are only relevant when the
-          # unit tests themselves failed. Including them unconditionally is
+          # C/C++ unit tests themselves failed. Including them unconditionally is
           # misleading for flow-test failures: they report "100% tests passed" and,
           # when no per-test flow logs match, become the *only* content the triage
-          # sees — making a real failure look like a clean run. Gate on an actual
-          # unit-test failure.
-          if [ "$C_UNIT_TESTS_OUTCOME" = "failure" ] || [ "$RUST_UNIT_TESTS_OUTCOME" = "failure" ]; then
+          # sees — making a real failure look like a clean run. Gate strictly on a
+          # C/C++ unit-test failure: a Rust-only failure leaves these CTest logs
+          # passing, so copying them would recreate the same misleading artifact
+          # (the real Rust failure lives in the job log, surfaced via the triage
+          # KEY FAILURE LINES extraction instead).
+          if [ "$C_UNIT_TESTS_OUTCOME" = "failure" ]; then
             find tests -path '*/logs/rstest*.log' -type f 2>/dev/null | while read -r log; do
               mkdir -p "$DEST/$(dirname "$log")"
               cp "$log" "$DEST/$log"
@@ -655,8 +665,13 @@ jobs:
           exit 0
 
       - name: Upload Failed-Only Test Logs
+        # Keep this guard in lockstep with "Collect failed-test-only logs" above,
+        # otherwise the bundle is built but never uploaded (or vice versa).
         if: >
           failure() || (
+            (steps.rust_unit_tests_miri.outcome == 'failure') ||
+            steps.rust_unit_tests.outcome == 'failure' ||
+            steps.c_unit_tests.outcome == 'failure' ||
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
           )

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -584,14 +584,23 @@ jobs:
       - name: Collect failed-test-only logs
         # Build a focused log bundle containing only logs for tests that actually
         # failed, so downstream tools (e.g. Codex triage) get high-signal input.
-        # Driven by RLTest's FAILEDFILE output (test ids in `test_file.py:test_name`
-        # form). RLTest log filenames embed the test id as `..._<file>_<test>_...`,
-        # so we convert each failed id to a glob and copy matching files.
+        # Driven by RLTest's FAILEDFILE output (test ids in `test_file:test_name`
+        # form, e.g. `test_foo:TestBar.test_baz` for class-based tests).
+        #
+        # RLTest creates one Env — and one set of redis logs — per test *class*
+        # (or per module-level function), not per method, and names the files
+        # `<uuid>.<role>-<file>_<class-or-func>-<env>.log`; the method name is NOT
+        # part of the filename. So we key the glob on `<file>_<class-or-func>`,
+        # dropping any `.method` suffix from the failed id — otherwise the glob can
+        # never match and the focused bundle silently misses the real failure.
         if: >
           failure() || (
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
           )
+        env:
+          C_UNIT_TESTS_OUTCOME: ${{ steps.c_unit_tests.outcome }}
+          RUST_UNIT_TESTS_OUTCOME: ${{ steps.rust_unit_tests.outcome }}
         run: |
           set +e
           DEST="failed-test-logs"
@@ -605,7 +614,10 @@ jobs:
               local file_part="${test_id%%:*}"
               local test_part="${test_id#*:}"
               local file_no_py="${file_part%.py}"
-              local pattern="*-${file_no_py}_${test_part}-*.log*"
+              # Log files are named per class/function, not per method: turn
+              # `Class.method` into `Class` (a bare function name is unchanged).
+              local class_part="${test_part%%.*}"
+              local pattern="*-${file_no_py}_${class_part}-*.log*"
               find tests -path '*/logs/*' -name "$pattern" -type f 2>/dev/null | \
                 while read -r log; do
                   mkdir -p "$DEST/$(dirname "$log")"
@@ -617,17 +629,26 @@ jobs:
           copy_for_failed_list ".failed_standalone.txt"
           copy_for_failed_list ".failed_coordinator.txt"
 
-          # Always include the run-level RLTest summary log if present — it gives
-          # session-level context that complements per-test logs.
-          find tests -path '*/logs/rstest*.log' -type f 2>/dev/null | while read -r log; do
-            mkdir -p "$DEST/$(dirname "$log")"
-            cp "$log" "$DEST/$log"
-          done
+          # The C/C++ CTest summary logs (rstest*.log) are only relevant when the
+          # unit tests themselves failed. Including them unconditionally is
+          # misleading for flow-test failures: they report "100% tests passed" and,
+          # when no per-test flow logs match, become the *only* content the triage
+          # sees — making a real failure look like a clean run. Gate on an actual
+          # unit-test failure.
+          if [ "$C_UNIT_TESTS_OUTCOME" = "failure" ] || [ "$RUST_UNIT_TESTS_OUTCOME" = "failure" ]; then
+            find tests -path '*/logs/rstest*.log' -type f 2>/dev/null | while read -r log; do
+              mkdir -p "$DEST/$(dirname "$log")"
+              cp "$log" "$DEST/$log"
+            done
+          fi
 
-          # Stash the failed-test lists alongside the logs for downstream consumers.
-          for f in .failed_standalone.txt .failed_coordinator.txt; do
-            [ -f "$f" ] && cp "$f" "$DEST/$f"
-          done
+          # Stash the failed-test lists alongside the logs under non-hidden names.
+          # The triage prompt treats `failed-tests-*.txt` as the authoritative list
+          # of distinct failures; copying the source `.failed_*.txt` verbatim would
+          # both miss that naming convention and be silently dropped on upload,
+          # since actions/upload-artifact excludes hidden (dot-prefixed) files.
+          [ -f .failed_standalone.txt ] && cp .failed_standalone.txt "$DEST/failed-tests-standalone.txt"
+          [ -f .failed_coordinator.txt ] && cp .failed_coordinator.txt "$DEST/failed-tests-coordinator.txt"
 
           echo "Failed-test logs bundled:"
           find "$DEST" -type f | wc -l


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** When post-merge "selected-platform" validation fails, the focused failed-log bundle handed to Codex triage can contain only **passing** C/C++ CTest summaries, so triage reports "0 failures / needs-more-evidence" even when a flow test genuinely failed. This was observed on the `alpine:3.23 (x86_64)` job in [run 27774049608](https://github.com/RediSearch/RediSearch/actions/runs/27774049608/job/82182873138): a real coordinator RESP2 failure (`IndexError` in `test_blocked_client_timeout.py:4988`, `Total Tests Failed: 1`, `OSS cluster tests failed, code: 1`) was triaged as a clean run.

2. **Change:** Fix the failed-log collection so the real failure reaches triage. Four compounding bugs:
   - **Per-test log glob never matched class-based failures.** The glob keyed on `<file>_<Class.method>`, but RLTest creates one Env/log per test *class* and names files `<file>_<Class>` (the method is not in the filename). Now keys on `<file>_<class-or-func>` (drops the `.method` suffix). Verified against the incident's real filenames: old glob matched **0**, new matches the **3** correct shard logs, with no over-match of sibling classes.
   - **Failed-test lists were silently dropped on upload.** They were stashed as hidden `.failed_*.txt`, which `actions/upload-artifact` excludes. Now copied as non-hidden `failed-tests-{standalone,coordinator}.txt`, matching the name the triage prompt treats as authoritative.
   - **Passing CTest logs masqueraded as the failure.** `rstest*.log` was bundled unconditionally and, when nothing else matched, became the only content ("100% passed"). Now gated on an actual unit-test failure.
   - **Tail-cap discarded the mid-log root cause.** `ci-failure-context` tail-capped the assembled log to 200KB with no highlight extraction. Adds a default `KEY FAILURE LINES` extraction (tracebacks, `[FAIL]`/error markers, failed counts, sanitizer/crash) prepended after the cap so it always survives. Replayed on the incident log, it surfaces the `IndexError`, the RESP2 `(FAIL)` assertions, and `OSS cluster tests failed`.

3. **Outcome:** Post-merge (and nightly / PR-validation, which share `ci-failure-context`) triage now receives the failing test's per-test logs, the authoritative failed-test list, and a high-signal `KEY FAILURE LINES` banner — instead of a misleading passing summary.

#### Which additional issues this PR fixes
1. N/A (CI infrastructure)

#### Main objects this PR modified
1. `.github/workflows/task-test.yml` — "Collect failed-test-only logs" step (glob fix, non-hidden lists, gated CTest logs)
2. `.github/actions/ci-failure-context/action.yml` — KEY FAILURE LINES extraction before tail-cap
3. `.github/codex/prompts/post-merge-triage.md` — point the agent at the new banner; correct the test-id format note

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal CI-only change; no user-facing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
