### PR TITLE
[8.4][MOD-16523][MOD-16145] FT.HYBRID: bound the cursor-setup wait with a deadline

### DIFF
--- a/src/aggregate/reply_empty.c
+++ b/src/aggregate/reply_empty.c
@@ -104,7 +104,52 @@ int coord_aggregate_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **a
     return ret;
 }
 
-int common_hybrid_query_reply_empty(RedisModuleCtx *ctx, QueryErrorCode errCode, bool internal, bool isProfile) {
+// Shard->coord internal empty reply; cursor ids of 0 signal the shard error.
+static void build_hybrid_empty_internal_reply(RedisModule_Reply *reply, QueryError *status, bool isProfile) {
+    RedisModule_Reply_Map(reply); // outer/root {}
+
+    if (isProfile) {
+        Profile_PrepareMapForReply(reply); // opens "Results" map
+    }
+
+    RedisModule_ReplyKV_LongLong(reply, "SEARCH", 0);
+    RedisModule_ReplyKV_LongLong(reply, "VSIM", 0);
+    RedisModule_ReplyKV_Array(reply, "warnings"); // warnings []
+    if (QueryError_HasQueryOOMWarning(status)) {
+        QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_OUT_OF_MEMORY_SHARD, 1, SHARD_ERR_WARN);
+        RedisModule_Reply_SimpleString(reply, QueryError_Strerror(QUERY_EOOM));
+    }
+    RedisModule_Reply_ArrayEnd(reply); // ~warnings
+
+    if (isProfile) {
+        RedisModule_Reply_MapEnd(reply); // close "Results" map
+        Profile_PrintInFormat(reply, NULL, NULL, NULL, NULL);
+    }
+
+    RedisModule_Reply_MapEnd(reply); // close outer / root map
+}
+
+// Client-facing empty hybrid reply.
+static void build_hybrid_empty_client_reply(RedisModule_Reply *reply, QueryError *status, bool isProfile) {
+    if (isProfile) {
+        // Outer profile map: "Results" (filled below) + "Profile".
+        RedisModule_Reply_Map(reply); // outer {}
+        if (reply->resp3) {
+            RedisModule_Reply_SimpleString(reply, "Results"); // key
+        }
+    }
+
+    sendChunk_ReplyOnly_HybridEmptyResults(reply, status);
+
+    if (isProfile) {
+        Profile_PrintInFormat(reply, NULL, NULL, NULL, NULL);
+        RedisModule_Reply_MapEnd(reply); // close outer map
+    }
+}
+
+// Fill a caller-owned reply with an empty hybrid result for errCode. The caller
+// manages the reply lifecycle; the ctx wrapper below is for when there's no reply yet.
+void common_hybrid_query_reply_empty_into(RedisModule_Reply *reply, QueryErrorCode errCode, bool internal, bool isProfile) {
 
     QueryError status = QueryError_Default();
     QueryError_SetError(&status, errCode, NULL);
@@ -113,60 +158,19 @@ int common_hybrid_query_reply_empty(RedisModuleCtx *ctx, QueryErrorCode errCode,
         QueryError_SetQueryOOMWarning(&status);
     }
 
-    // If internal - reply cursor information from shards to coord.
-    // Shards notify error by setting cursor id to 0
     if (internal) {
-        RedisModule_Reply _coordInfoReply = RedisModule_NewReply(ctx), *coordInfoReply = &_coordInfoReply;
-
-        RedisModule_Reply_Map(coordInfoReply); // outer/root {}
-
-        if (isProfile) {
-            // Profile wrapping: open an outer map, then nest "Results" and "Profile"
-            // inside it, consistent with search/aggregate profile reply structure.
-            Profile_PrepareMapForReply(coordInfoReply); // opens "Results" map
-        }
-
-        RedisModule_ReplyKV_LongLong(coordInfoReply, "SEARCH", 0);
-        RedisModule_ReplyKV_LongLong(coordInfoReply, "VSIM", 0);
-        RedisModule_ReplyKV_Array(coordInfoReply,"warnings"); // warnings []
-        if (QueryError_HasQueryOOMWarning(&status)) {
-            QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_OUT_OF_MEMORY_SHARD, 1, SHARD_ERR_WARN);
-            RedisModule_Reply_SimpleString(coordInfoReply, QueryError_Strerror(QUERY_EOOM));
-        }
-        RedisModule_Reply_ArrayEnd(coordInfoReply); // ~warnings
-
-        if (isProfile) {
-            RedisModule_Reply_MapEnd(coordInfoReply); // close "Results" map
-            Profile_PrintInFormat(coordInfoReply, NULL, NULL, NULL, NULL);
-        }
-
-        RedisModule_Reply_MapEnd(coordInfoReply); // close outer / root map
-        RedisModule_EndReply(coordInfoReply);
-        QueryError_ClearError(&status);
-        return REDISMODULE_OK;
+        build_hybrid_empty_internal_reply(reply, &status, isProfile);
+    } else {
+        build_hybrid_empty_client_reply(reply, &status, isProfile);
     }
 
-    RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
-
-    if (isProfile) {
-        // Profile wrapping: open outer map containing "Results" and "Profile" sections.
-        // sendChunk_ReplyOnly_HybridEmptyResults opens/closes its own map, so we use it
-        // directly as the value of the "Results" key.
-        RedisModule_Reply_Map(reply); // outer {}
-        if (reply->resp3) {
-            RedisModule_Reply_SimpleString(reply, "Results"); // key
-        }
-    }
-
-    sendChunk_ReplyOnly_HybridEmptyResults(reply, &status);
-
-    if (isProfile) {
-        Profile_PrintInFormat(reply, NULL, NULL, NULL, NULL);
-        RedisModule_Reply_MapEnd(reply); // close outer map
-    }
-
-    RedisModule_EndReply(reply);
     QueryError_ClearError(&status);
+}
+
+int common_hybrid_query_reply_empty(RedisModuleCtx *ctx, QueryErrorCode errCode, bool internal, bool isProfile) {
+    RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
+    common_hybrid_query_reply_empty_into(reply, errCode, internal, isProfile);
+    RedisModule_EndReply(reply);
     return REDISMODULE_OK;
 }
 

--- a/src/aggregate/reply_empty.h
+++ b/src/aggregate/reply_empty.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include "redismodule.h"
+#include "reply.h"
 #include "query_error.h"
 
 // Coordinator empty reply for FT.SEARCH commands.
@@ -28,6 +29,9 @@ int coord_aggregate_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **a
 // Creates QueryError with OOM/timeout warning and uses sendChunk_ReplyOnly_HybridEmptyResults.
 // When isProfile is true, wraps the reply with profile structure.
 int common_hybrid_query_reply_empty(RedisModuleCtx *ctx, QueryErrorCode errCode, bool internal, bool isProfile);
+
+// Variant for callers that already own a RedisModule_Reply (they must EndReply it).
+void common_hybrid_query_reply_empty_into(RedisModule_Reply *reply, QueryErrorCode errCode, bool internal, bool isProfile);
 
 // Single-shard empty reply for SEARCH and AGGREGATE commands.
 // Handles both RESP2 and RESP3 with command-appropriate formatting.

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -700,7 +700,13 @@ static int HybridRequest_executePlan(HybridRequest *hreq, struct ConcurrentCmdCt
     MRCommand *cmd = &searchRPNet->cmd;
 
     const RSOomPolicy oomPolicy = hreq->reqConfig.oomPolicy;
-    if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, hreq->tailPipeline->qctx.err, oomPolicy)) {
+    // Bound the cursor-setup wait by the request deadline so a non-responding shard
+    // times out instead of hanging the coordinator. time.timeout is populated by
+    // SearchCtx_UpdateTime during prepare (a disabled timeout becomes a far-future
+    // deadline, so the wait is effectively unbounded but never spurious).
+    const struct timespec *deadline =
+        hreq->sctx ? (const struct timespec *)&hreq->sctx->time.timeout : NULL;
+    if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, hreq->tailPipeline->qctx.err, oomPolicy, deadline)) {
         // Handle error
         StrongRef_Release(searchMappingsRef);
         StrongRef_Release(vsimMappingsRef);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -757,7 +757,7 @@ static void DistHybridCleanups(RedisModuleCtx *ctx,
 
     if (hreq && QueryError_GetCode(status) == QUERY_ETIMEDOUT &&
         hreq->reqConfig.timeoutPolicy != TimeoutPolicy_Fail) {
-        // A cursor-setup timeout under RETURN / RETURN-STRICT must not surface as an
+        // A cursor-setup timeout under RETURN must not surface as an
         // error: no cursor mappings were established, so reply an empty result set
         // carrying the timeout warning (and the FT.PROFILE envelope when applicable),
         // matching the read-phase RETURN behavior.

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -700,10 +700,6 @@ static int HybridRequest_executePlan(HybridRequest *hreq, struct ConcurrentCmdCt
     MRCommand *cmd = &searchRPNet->cmd;
 
     const RSOomPolicy oomPolicy = hreq->reqConfig.oomPolicy;
-    // Bound the cursor-setup wait by the request deadline so a non-responding shard
-    // times out instead of hanging the coordinator. time.timeout is populated by
-    // SearchCtx_UpdateTime during prepare (a disabled timeout becomes a far-future
-    // deadline, so the wait is effectively unbounded but never spurious).
     const struct timespec *deadline =
         hreq->sctx ? (const struct timespec *)&hreq->sctx->time.timeout : NULL;
     if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, hreq->tailPipeline->qctx.err, oomPolicy, deadline)) {

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -759,7 +759,21 @@ static void DistHybridCleanups(RedisModuleCtx *ctx,
         // A cursor-setup timeout under RETURN / RETURN-STRICT must not surface as an
         // error: no cursor mappings were established, so reply an empty result set
         // carrying the timeout warning, matching the read-phase RETURN behavior.
+        // Preserve the FT.PROFILE Results/Profile envelope for profile requests,
+        // mirroring common_hybrid_query_reply_empty (we write into the already-open
+        // reply rather than open a second one).
+        const bool isProfile = hreq->tailPipeline->qctx.isProfile;
+        if (isProfile) {
+            RedisModule_Reply_Map(reply); // outer {}
+            if (reply->resp3) {
+                RedisModule_Reply_SimpleString(reply, "Results"); // key
+            }
+        }
         sendChunk_ReplyOnly_HybridEmptyResults(reply, status);
+        if (isProfile) {
+            Profile_PrintInFormat(reply, NULL, NULL, NULL, NULL);
+            RedisModule_Reply_MapEnd(reply); // close outer map
+        }
         QueryError_ClearError(status);
     } else {
         QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(status), 1, COORD_ERR_WARN);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -754,9 +754,17 @@ static void DistHybridCleanups(RedisModuleCtx *ctx,
 
     RS_ASSERT(QueryError_HasError(status));
 
-    QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(status), 1, COORD_ERR_WARN);
-
-    QueryError_ReplyAndClear(ctx, status);
+    if (hreq && QueryError_GetCode(status) == QUERY_ETIMEDOUT &&
+        hreq->reqConfig.timeoutPolicy != TimeoutPolicy_Fail) {
+        // A cursor-setup timeout under RETURN / RETURN-STRICT must not surface as an
+        // error: no cursor mappings were established, so reply an empty result set
+        // carrying the timeout warning, matching the read-phase RETURN behavior.
+        sendChunk_ReplyOnly_HybridEmptyResults(reply, status);
+        QueryError_ClearError(status);
+    } else {
+        QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(status), 1, COORD_ERR_WARN);
+        QueryError_ReplyAndClear(ctx, status);
+    }
     WeakRef_Release(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
     if (sp) {
         IndexSpecRef_Release(*strong_ref);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -10,6 +10,7 @@
 #include "dist_hybrid.h"
 #include "hybrid/hybrid_request.h"
 #include "hybrid/hybrid_exec.h"
+#include "aggregate/reply_empty.h"
 #include "hybrid/dist_hybrid_plan.h"
 #include "hybrid/parse_hybrid.h"
 #include "dist_plan.h"
@@ -758,22 +759,10 @@ static void DistHybridCleanups(RedisModuleCtx *ctx,
         hreq->reqConfig.timeoutPolicy != TimeoutPolicy_Fail) {
         // A cursor-setup timeout under RETURN / RETURN-STRICT must not surface as an
         // error: no cursor mappings were established, so reply an empty result set
-        // carrying the timeout warning, matching the read-phase RETURN behavior.
-        // Preserve the FT.PROFILE Results/Profile envelope for profile requests,
-        // mirroring common_hybrid_query_reply_empty (we write into the already-open
-        // reply rather than open a second one).
-        const bool isProfile = hreq->tailPipeline->qctx.isProfile;
-        if (isProfile) {
-            RedisModule_Reply_Map(reply); // outer {}
-            if (reply->resp3) {
-                RedisModule_Reply_SimpleString(reply, "Results"); // key
-            }
-        }
-        sendChunk_ReplyOnly_HybridEmptyResults(reply, status);
-        if (isProfile) {
-            Profile_PrintInFormat(reply, NULL, NULL, NULL, NULL);
-            RedisModule_Reply_MapEnd(reply); // close outer map
-        }
+        // carrying the timeout warning (and the FT.PROFILE envelope when applicable),
+        // matching the read-phase RETURN behavior.
+        common_hybrid_query_reply_empty(ctx, QUERY_ETIMEDOUT, false,
+                                        hreq->tailPipeline->qctx.isProfile);
         QueryError_ClearError(status);
     } else {
         QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(status), 1, COORD_ERR_WARN);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -761,8 +761,8 @@ static void DistHybridCleanups(RedisModuleCtx *ctx,
         // error: no cursor mappings were established, so reply an empty result set
         // carrying the timeout warning (and the FT.PROFILE envelope when applicable),
         // matching the read-phase RETURN behavior.
-        common_hybrid_query_reply_empty(ctx, QUERY_ETIMEDOUT, false,
-                                        hreq->tailPipeline->qctx.isProfile);
+        common_hybrid_query_reply_empty_into(reply, QUERY_ETIMEDOUT, false,
+                                             hreq->tailPipeline->qctx.isProfile);
         QueryError_ClearError(status);
     } else {
         QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(status), 1, COORD_ERR_WARN);

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -225,10 +225,7 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
         return false;
     }
 
-    // Wait on the iterator's channel, bounded by the request deadline. Completion is
-    // driven by the inProcess countdown reaching 0 (every callback decrements it), so a
-    // non-responding shard times out instead of hanging. `deadline` is NULL when timeout
-    // checking is disabled, in which case the pop waits without a deadline.
+    // Wait on the iterator's channel, bounded by the request deadline.
     bool timedOut = false;
     MRReply *r = MRIterator_NextWithTimeout(it, deadline, &timedOut);
     RS_ASSERT(r == NULL);  // the callbacks never AddReply; a non-NULL reply is a bug

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -207,7 +207,6 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     *ctx = (processCursorMappingCallbackContext) {
         .searchMappings = StrongRef_Clone(searchMappingsRef),
         .vsimMappings = StrongRef_Clone(vsimMappingsRef),
-        // Allocated up front (race-free: built on the coord thread before IO launches).
         .errors = array_new(QueryError, 0),
       };
 
@@ -252,7 +251,6 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
             }
         }
     }
-    // Cleanup (ctx is freed by freeCursorMappingCtx via the iterator destructor).
     MRIterator_Release(it);
 
     return success;

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -22,11 +22,6 @@ typedef struct {
     StrongRef searchMappings;
     StrongRef vsimMappings;
     arrayof(QueryError) errors;
-    size_t responseCount;
-    pthread_mutex_t *mutex;           // Mutex for array access and completion tracking
-    pthread_cond_t *completionCond;   // Condition variable for completion signaling
-    int numShards;                    // Total number of expected shards
-    bool initialized;                 // Whether numShards has been set by the IO thread
 } processCursorMappingCallbackContext;
 
 void CursorMapping_Release(CursorMapping *mapping) {
@@ -163,9 +158,6 @@ static void processCursorMappingCallback(MRIteratorCallbackCtx *ctx, MRReply *re
     MRCommand *cmd = MRIteratorCallback_GetCommand(ctx);
 
     const int replyType = MRReply_Type(rep);
-    pthread_mutex_lock(cb_ctx->mutex);
-    // add under a lock, allows the coordinator to know when all responses have arrived
-    cb_ctx->responseCount++;
     if (replyType == MR_REPLY_ERROR) {
         processHybridError(cb_ctx, rep);
     } else if (replyType == MR_REPLY_MAP) {
@@ -178,108 +170,78 @@ static void processCursorMappingCallback(MRIteratorCallbackCtx *ctx, MRReply *re
         processHybridUnknownReplyType(cb_ctx, replyType);
     }
 
-    // we must notify the coordinator a response has arrived, even if it's an error
-    pthread_cond_signal(cb_ctx->completionCond);
-    pthread_mutex_unlock(cb_ctx->mutex);
-
     MRIteratorCallback_Done(ctx, 0);
     MRReply_Free(rep);
 }
 
-// No-reply error callback: bumps responseCount and records a communication
-// error so the wait loop below (which keys completion off responseCount, not
-// iterator depletion) unblocks instead of hanging.
+// No-reply error callback: records a communication error. Completion is driven by
+// the iterator's channel (every callback decrements inProcess), so the wait below
+// unblocks once all callbacks have run regardless of this error.
 static void processCursorMappingErrorCallback(MRIteratorCallbackCtx *ctx) {
     processCursorMappingCallbackContext *cb_ctx = (processCursorMappingCallbackContext *)MRIteratorCallback_GetPrivateData(ctx);
     RS_ASSERT(cb_ctx);
 
-    pthread_mutex_lock(cb_ctx->mutex);
-    cb_ctx->responseCount++;
     QueryError error = QueryError_Default();
     // Shared with the MR iterator no-reply path (pre-fanout connection-validation failure).
     QueryError_SetError(&error, QUERY_EGENERIC, CLUSTER_QUERY_ERROR);
     cb_ctx->errors = array_ensure_append_1(cb_ctx->errors, error);
-    pthread_cond_signal(cb_ctx->completionCond);
-    pthread_mutex_unlock(cb_ctx->mutex);
 }
 
-// Init callback for the private data, so that numShards is set to the actual number of shards in the cluster, and the expected responses.
-static void processCursorMappingInit(void *privateData, MRIterator *it) {
+// Iterator destructor: frees the callback context once the iterator is released.
+static void freeCursorMappingCtx(void *privateData) {
     processCursorMappingCallbackContext *ctx = (processCursorMappingCallbackContext *)privateData;
-    int actualNumShards = (int)MRIterator_GetNumShards(it);
-    pthread_mutex_lock(ctx->mutex);
-    ctx->numShards = actualNumShards;
-    ctx->initialized = true;
-    ctx->errors = array_new(QueryError, actualNumShards);
-    // Signal so the coordinator can re-check the wait condition.
-    pthread_cond_signal(ctx->completionCond);
-    pthread_mutex_unlock(ctx->mutex);
-}
-
-static inline void cleanupCtx(processCursorMappingCallbackContext *ctx) {
-    pthread_mutex_destroy(ctx->mutex);
-    pthread_cond_destroy(ctx->completionCond);
-    rm_free(ctx->mutex);
-    rm_free(ctx->completionCond);
     StrongRef_Release(ctx->searchMappings);
     StrongRef_Release(ctx->vsimMappings);
     array_free_ex(ctx->errors, QueryError_ClearError((QueryError*)ptr));
     rm_free(ctx);
 }
 
-bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsRef, StrongRef vsimMappingsRef, QueryError *status, const RSOomPolicy oomPolicy) {
+bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsRef, StrongRef vsimMappingsRef, QueryError *status, const RSOomPolicy oomPolicy, const struct timespec *deadline) {
     CursorMappings *searchMappings = StrongRef_Get(searchMappingsRef);
     CursorMappings *vsimMappings = StrongRef_Get(vsimMappingsRef);
     RS_ASSERT(array_len(searchMappings->mappings) == 0 && array_len(vsimMappings->mappings) == 0);
 
-    // Allocate callback context on heap (since MR_IterateWithPrivateData is asynchronous)
+    // Heap-allocated because the iterator runs asynchronously; freed by
+    // freeCursorMappingCtx (the iterator's destructor).
     processCursorMappingCallbackContext *ctx = rm_malloc(sizeof(processCursorMappingCallbackContext));
-
-    // Initialize synchronization primitives on heap
-    ctx->mutex = rm_malloc(sizeof(pthread_mutex_t));
-    ctx->completionCond = rm_malloc(sizeof(pthread_cond_t));
-    pthread_mutex_init(ctx->mutex, NULL);
-    pthread_cond_init(ctx->completionCond, NULL);
-
-    // Setup callback context
     *ctx = (processCursorMappingCallbackContext) {
         .searchMappings = StrongRef_Clone(searchMappingsRef),
         .vsimMappings = StrongRef_Clone(vsimMappingsRef),
-        .errors = NULL,
-        .responseCount = 0,
-        .mutex = ctx->mutex,
-        .completionCond = ctx->completionCond,
-        .numShards = 0,
-        .initialized = false
+        // Allocated up front (race-free: built on the coord thread before IO launches).
+        .errors = array_new(QueryError, 0),
       };
 
-    // Start iteration (ctx is cleaned up manually in cleanupCtx, no destructor needed)
-    // processCursorMappingInit is called from iterStartCb to update ctx->numShards
-    // with the actual shard count from the live topology, preventing use-after-free
-    // when topology changes during shard migration.
     MRIterator *it = MR_IterateWithPrivateData(cmd, &(MRIteratorConfig){
         .successCB = processCursorMappingCallback,
         .errorCB = processCursorMappingErrorCallback,
         .cbPrivateData = ctx,
-        .cbPrivateDataInit = processCursorMappingInit,
+        .cbPrivateDataDestructor = freeCursorMappingCtx,
         .iterStartCb = iterStartCb,
     });
     if (!it) {
         // Cleanup on error
         QueryError_SetWithoutUserDataFmt(status, QUERY_EGENERIC, "Failed to communicate with shards");
-        cleanupCtx(ctx);
+        freeCursorMappingCtx(ctx);
         return false;
     }
-    // Wait for all callbacks to complete
-    pthread_mutex_lock(ctx->mutex);
-    // Wait until either:
-    // 1. Normal completion: IO thread initialized numShards and all responses arrived
-    // 2. Early failure: We got a response before initialization (e.g., connection validation failed)
-    //    In this case, responseCount > 0 but initialized is false - we should unblock.
-    while (ctx->responseCount == 0 || (ctx->initialized && ctx->responseCount < ctx->numShards)) {
-        pthread_cond_wait(ctx->completionCond, ctx->mutex);
+
+    // Wait on the iterator's channel, bounded by the request deadline. Completion is
+    // driven by the inProcess countdown reaching 0 (every callback decrements it), so a
+    // non-responding shard times out instead of hanging. `deadline` is NULL when timeout
+    // checking is disabled, in which case the pop waits without a deadline.
+    bool timedOut = false;
+    MRReply *r = MRIterator_NextWithTimeout(it, deadline, &timedOut);
+    RS_ASSERT(r == NULL);  // the callbacks never AddReply; a non-NULL reply is a bug
+
+    if (timedOut) {
+        QueryError_SetCode(status, QUERY_ETIMEDOUT);
+        MRIterator_Release(it);
+        return false;
     }
-    pthread_mutex_unlock(ctx->mutex);
+
+    // Normal completion: inProcess hit 0, so every callback has run.
+    RS_ASSERT(array_len(searchMappings->mappings) == array_len(vsimMappings->mappings));
+
     bool success = true;
     if (array_len(ctx->errors)) {
         for (size_t i = 0; i < array_len(ctx->errors); i++) {
@@ -293,9 +255,8 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
             }
         }
     }
-    // Cleanup
+    // Cleanup (ctx is freed by freeCursorMappingCtx via the iterator destructor).
     MRIterator_Release(it);
-    cleanupCtx(ctx);
 
     return success;
 }

--- a/src/coord/hybrid/hybrid_cursor_mappings.h
+++ b/src/coord/hybrid/hybrid_cursor_mappings.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <time.h>
+
 #include "rmr/rmr.h"
 #include "util/references.h"
 #include "../../config.h"
@@ -45,9 +47,11 @@ typedef struct QueryError QueryError;
  * @param vsimMappings Empty array to populate with vector similarity cursor mappings
  * @param status QueryError pointer to store warning/error information
  * @param oomPolicy OOM policy to determine error handling behavior
+ * @param deadline Absolute (monotonic) time after which the cursor-setup wait gives up and
+ *                 reports a timeout, or NULL to wait without a deadline (e.g. timeout disabled)
  * @return true if processing completed (even with warnings), false on fatal errors; status will contain error/warning information
  */
-bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappings, StrongRef vsimMappings, QueryError *status, RSOomPolicy oomPolicy);
+bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappings, StrongRef vsimMappings, QueryError *status, RSOomPolicy oomPolicy, const struct timespec *deadline);
 
 /**
  * Release resources associated with a cursor mapping

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -519,9 +519,9 @@ struct MRIterator {
   size_t len;
 };
 
-// No-reply termination path: invoke the caller's optional errorCB (notify-only)
-// before the iterator's MRIteratorCallback_Done. Without this hook callers that
-// wait on a private counter (e.g. ProcessHybridCursorMappings) would hang.
+// No-reply termination path: invoke the caller's optional errorCB (notify-only) so
+// it can record the communication error, then run MRIteratorCallback_Done to advance
+// the iterator's completion countdown like any other terminated shard.
 static void mrIteratorCallback_Error(MRIteratorCallbackCtx *ctx) {
   if (ctx->it->ctx.errorCB) {
     ctx->it->ctx.errorCB(ctx);

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -339,6 +339,11 @@ void sendChunk_ReplyOnly_HybridEmptyResults(RedisModule_Reply *reply, QueryError
         // This function is called by Coordinator or SA
         RedisModule_Reply_SimpleString(reply, QUERY_WOOM_COORD);
         RedisModule_Reply_ArrayEnd(reply);
+    } else if (QueryError_GetCode(err) == QUERY_ETIMEDOUT) {
+        QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_TIMED_OUT, 1, COORD_ERR_WARN);
+        RedisModule_Reply_Array(reply);
+        RedisModule_Reply_SimpleString(reply, QueryError_Strerror(QUERY_ETIMEDOUT));
+        RedisModule_Reply_ArrayEnd(reply);
     } else {
         RedisModule_Reply_EmptyArray(reply);
     }

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -111,6 +111,40 @@ def getConnectionByEnv(env):
         conn = env.getConnection()
     return conn
 
+
+# --- Coordinator / cluster timeout test helpers ---
+
+def pid_cmd(conn):
+    """Get the process ID of a Redis connection."""
+    return conn.execute_command('info', 'server')['process_id']
+
+
+def non_coord_shard_conns(env):
+    """Return shard connections whose process id differs from the coordinator's."""
+    coord_pid = pid_cmd(env.con)
+    conns = []
+    for shardId in range(1, env.shardsCount + 1):
+        conn = env.getConnection(shardId)
+        if pid_cmd(conn) != coord_pid:
+            conns.append(conn)
+    return conns
+
+
+def split_shards_pick_one_paused(env):
+    """Pick one non-coordinator shard to designate as paused and split the rest.
+
+    Returns ``(all_shard_conns, paused_conn, paused_pid, responsive_conns)``.
+    Asserts that at least one non-coordinator shard exists.
+    """
+    all_shard_conns = [env.getConnection(i) for i in range(1, env.shardsCount + 1)]
+    non_coord_conns = non_coord_shard_conns(env)
+    env.assertGreater(len(non_coord_conns), 0,
+                      message="Test requires at least one non-coordinator shard")
+    paused_conn = non_coord_conns[0]
+    paused_pid = pid_cmd(paused_conn)
+    responsive_conns = [c for c in all_shard_conns if pid_cmd(c) != paused_pid]
+    return all_shard_conns, paused_conn, paused_pid, responsive_conns
+
 def waitForIndex(env, idx = 'idx'):
     waitForRdbSaveToFinish(env)
     while True:

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -114,6 +114,15 @@ def getConnectionByEnv(env):
 
 # --- Coordinator / cluster timeout test helpers ---
 
+ON_TIMEOUT_CONFIG = 'search-on-timeout'
+
+
+def assert_timeout_warning(env, res, message=''):
+    warnings = res.get('warning', res.get('warnings', []))
+    env.assertTrue(warnings, message=message + " expected timeout warning")
+    env.assertContains('Timeout', warnings[0], message=message + " expected timeout warning")
+
+
 def pid_cmd(conn):
     """Get the process ID of a Redis connection."""
     return conn.execute_command('info', 'server')['process_id']

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -315,8 +315,8 @@ def test_queries_fail_on_all_shards_unreachable(env: Env):
     must be routed through the user callback so that:
     - FT.SEARCH: The reducer receives the error and returns it to the client
     - FT.AGGREGATE: The error is pushed to the channel and consumed by rpnetNext
-    - FT.HYBRID: The processCursorMappingCallback increments responseCount and signals
-      the condition variable, allowing ProcessHybridCursorMappings to unblock
+    - FT.HYBRID: The no-reply errorCB records the error and the iterator's completion
+      countdown unblocks ProcessHybridCursorMappings' channel wait
     """
     # Create an index and add data before breaking topology
     env.expect('FT.CREATE', 'idx', 'SCHEMA',

--- a/tests/pytests/test_hybrid_dist.py
+++ b/tests/pytests/test_hybrid_dist.py
@@ -22,7 +22,7 @@ def _setup_hybrid_index(env, dim=2):
 @require_enable_assert
 def test_dist_hybrid_shard_dispatch_failure_does_not_hang(env):
     """A no-reply shard dispatch failure must surface as an error
-    rather than hanging FT.HYBRID on ProcessHybridCursorMappings' completionCond.
+    rather than hanging FT.HYBRID on the cursor-setup wait.
     FT.DEBUG SEND_ERROR forces the next MRCluster_SendCommand to return REDIS_ERR."""
     conn, query_vec, doc_vec = _setup_hybrid_index(env)
     for i in range(10):

--- a/tests/pytests/test_hybrid_timeout.py
+++ b/tests/pytests/test_hybrid_timeout.py
@@ -195,12 +195,15 @@ def test_tail_property_not_loaded_error():
 
 @skip(cluster=False)
 def test_timeout_setup_phase_hybrid():
-    """FT.HYBRID cursor-setup timeout: one shard suspended, the in-band deadline fires.
+    """FT.HYBRID cursor-setup timeout with one shard suspended, both policies.
 
     Suspending a non-coordinator shard parks the coordinator in
     ProcessHybridCursorMappings' cursor-mapping wait on a connected-but-silent shard.
-    The per-query TIMEOUT bounds that wait, so the command returns a timeout error at
-    the deadline instead of hanging.
+    The per-query TIMEOUT bounds that wait, so instead of hanging the command resolves
+    at the deadline per policy:
+      - FAIL   -> a timeout error.
+      - RETURN -> an empty result set carrying the timeout warning (no cursor mappings
+                  were established, so there is nothing to return).
     """
     # WORKERS 1 dispatches the query to a BG thread so the cursor-setup wait is
     # reachable; cluster mode gives us a non-coordinator shard to suspend.
@@ -223,9 +226,6 @@ def test_timeout_setup_phase_hybrid():
         'PARAMS', '2', 'BLOB', query_vec
     ).noError()
 
-    _, _, paused_pid, _ = split_shards_pick_one_paused(env)
-    shard_to_pause_p = psutil.Process(paused_pid)
-
     # A finite per-query TIMEOUT arms the coordinator's cursor-setup deadline.
     query_args = [
         'FT.HYBRID', 'hybrid_idx',
@@ -235,6 +235,10 @@ def test_timeout_setup_phase_hybrid():
         'TIMEOUT', '200',
     ]
 
+    prev_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
+    _, _, paused_pid, _ = split_shards_pick_one_paused(env)
+    shard_to_pause_p = psutil.Process(paused_pid)
+
     shard_to_pause_p.suspend()
     try:
         wait_for_condition(
@@ -243,11 +247,18 @@ def test_timeout_setup_phase_hybrid():
             'Timeout while waiting for shard to pause'
         )
 
-        # The deadline fires in the setup wait; the wait is bounded so the command
-        # returns a timeout error rather than hanging (a hang would trip the harness).
+        # FAIL policy: the bounded setup wait surfaces a timeout error.
+        env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'fail')
         env.expect(*query_args).error().contains('Timeout')
+
+        # RETURN policy: empty result set + timeout warning instead of an error.
+        env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return')
+        res = env.cmd(*query_args)
+        env.assertEqual(res['total_results'], 0, message=f"expected 0 results, got {res}")
+        assert_timeout_warning(env, res, message="RETURN-policy setup-phase timeout")
     finally:
         # Resume so the shard drains the queued _FT.HYBRID / CURSOR DEL and frees
         # its cursors before later tests run.
         shard_to_pause_p.resume()
+        env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_policy)
 

--- a/tests/pytests/test_hybrid_timeout.py
+++ b/tests/pytests/test_hybrid_timeout.py
@@ -1,6 +1,7 @@
 from RLTest import Env
 from includes import *
 from common import *
+import psutil
 
 # Test data with deterministic vectors
 test_data = {
@@ -190,4 +191,63 @@ def test_tail_property_not_loaded_error():
                           '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', \
                           query_vector, 'LOAD', '1', '@__key', 'APPLY', '2*@__score',\
                           'AS', 'doubled_score').error().contains('Property `__score` not loaded nor in pipeline')
+
+
+@skip(cluster=False)
+def test_timeout_setup_phase_hybrid():
+    """FT.HYBRID cursor-setup timeout: one shard suspended, the in-band deadline fires.
+
+    Suspending a non-coordinator shard parks the coordinator in
+    ProcessHybridCursorMappings' cursor-mapping wait on a connected-but-silent shard.
+    The per-query TIMEOUT bounds that wait, so the command returns a timeout error at
+    the deadline instead of hanging.
+    """
+    # WORKERS 1 dispatches the query to a BG thread so the cursor-setup wait is
+    # reachable; cluster mode gives us a non-coordinator shard to suspend.
+    env = Env(moduleArgs='WORKERS 1', protocol=3)
+    for i in range(1, env.shardsCount + 1):
+        verify_shard_init(env.getConnection(i))
+    conn = getConnectionByEnv(env)
+
+    env.expect(
+        'FT.CREATE', 'hybrid_idx', 'PREFIX', '1', 'hybrid_doc', 'SCHEMA',
+        'name', 'TEXT',
+        'embedding', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2'
+    ).ok()
+    for i in range(100):
+        vec = np.array([float(i), float(i)], dtype=np.float32).tobytes()
+        conn.execute_command('HSET', f'hybrid_doc{i}', 'name', f'hello{i}', 'embedding', vec)
+    query_vec = np.array([0.0, 0.0], dtype=np.float32).tobytes()
+    env.expect(
+        'FT.HYBRID', 'hybrid_idx', 'SEARCH', '*', 'VSIM', '@embedding', '$BLOB',
+        'PARAMS', '2', 'BLOB', query_vec
+    ).noError()
+
+    _, _, paused_pid, _ = split_shards_pick_one_paused(env)
+    shard_to_pause_p = psutil.Process(paused_pid)
+
+    # A finite per-query TIMEOUT arms the coordinator's cursor-setup deadline.
+    query_args = [
+        'FT.HYBRID', 'hybrid_idx',
+        'SEARCH', '*',
+        'VSIM', '@embedding', '$BLOB',
+        'PARAMS', '2', 'BLOB', query_vec,
+        'TIMEOUT', '200',
+    ]
+
+    shard_to_pause_p.suspend()
+    try:
+        wait_for_condition(
+            lambda: (shard_to_pause_p.status() == psutil.STATUS_STOPPED,
+                     {'status': shard_to_pause_p.status()}),
+            'Timeout while waiting for shard to pause'
+        )
+
+        # The deadline fires in the setup wait; the wait is bounded so the command
+        # returns a timeout error rather than hanging (a hang would trip the harness).
+        env.expect(*query_args).error().contains('Timeout')
+    finally:
+        # Resume so the shard drains the queued _FT.HYBRID / CURSOR DEL and frees
+        # its cursors before later tests run.
+        shard_to_pause_p.resume()
 


### PR DESCRIPTION
## Backport

Backports a scoped slice of **#10110** (`[MOD-16145] FT.HYBRID: bound the cursor-setup wait with a channel timeout`, merged to `master`) to `8.4`.

8.4's `ProcessHybridCursorMappings` predates the knn/`SHARD_K_RATIO` and timeout-policy plumbing and the `RequestSyncCtx` framework that #10110 builds on, so this is a **manual port**, not a cherry-pick — the idea is adapted into 8.4's existing shape.

### What this takes from #10110
- Replaces the bespoke `mutex` + `cond` + `responseCount`/`numShards`/`initialized` **unbounded `pthread_cond_wait`** in `ProcessHybridCursorMappings` with a channel pop bounded by the request deadline: `MRIterator_NextWithTimeout(it, deadline, &timedOut)`.
- Completion is driven by the iterator's `inProcess` countdown reaching 0 (fires on success **and** disconnect), so a non-responding/disconnected shard during cursor setup no longer hangs the coordinator.
- Lock-free hybrid callbacks; ctx teardown moved into the iterator's `cbPrivateDataDestructor` (`freeCursorMappingCtx`). Bespoke mutex/cond/counters deleted.
- The deadline comes from `hreq->sctx->time.timeout` (a disabled timeout maps to a far-future deadline → effectively unbounded, but no spurious-wakeup footgun).

### What this deliberately does NOT take (absent on 8.4)
- **`RequestSyncCtx` abort-channel registration** (`RequestSyncCtx_RegisterAbortWakeChannel` / `WakeAbortChannel`, 4-arg `MRIterator_NextWithTimeout`, `MRIterator_GetChannel`). 8.4 only has the 3-arg sync variant, which is exactly what the in-band deadline needs.
- **Main-thread blocked-client timeout callbacks** (`DistHybridTimeout{Fail,ReturnStrict}Callback`, `wakeHybridAbortChannels`).
- **Policy-aware empty+warning reply** (`HREQ_ReplyOrStoreError`). 

### Behavior delta vs master
- A setup-phase deadline timeout replies a **timeout error** under all policies (master replies empty+warning under RETURN/RETURN-STRICT). No cursor mappings exist yet at setup, so there is nothing to return regardless.
- RETURN-STRICT / disabled-timeout retains the (now far-future-bounded) wait — only the finite-`TIMEOUT` case is bounded by the in-band deadline. This is the intended limit of the sync-timeout slice.

### Tests
- Ports the in-band-deadline setup-phase test as `test_timeout_setup_phase_hybrid` (`test_hybrid_timeout.py`): suspends a non-coordinator shard so the setup wait stalls, asserts a timeout error at the deadline.
- Adds shared shard-picking helpers (`pid_cmd`, `non_coord_shard_conns`, `split_shards_pick_one_paused`) to `common.py`.
- The two `CLIENT UNBLOCK` setup-phase tests from #10110 are **not** ported (they exercise the blocked-client mechanism excluded above).
- Note: full build + Python run was not possible on the author's macOS box (pre-existing geometry/`fmt`/`toml++` dep build breakage on that toolchain, unrelated to this change); `hybrid_cursor_mappings.c` passes `clang -fsyntax-only`. Relying on CI for the Linux build/test.

#### Release Notes
- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: distributed `FT.HYBRID` no longer hangs when a shard fails to respond or disconnects during cursor setup; it returns at the query timeout with a timeout error.

[MOD-16145]: https://redislabs.atlassian.net/browse/MOD-16145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ