### PR TITLE
[MOD-15997] Reject DIALECT 4 and WITHOUTCOUNT on disk indexes

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -670,6 +670,11 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
       }
       optimization_specified = true;
     } else if (AC_AdvanceIfMatch(ac, "WITHOUTCOUNT")) {
+      // WITHOUTCOUNT enables the query optimizer (QEXEC_OPTIMIZE), which is unsupported
+      // on disk indexes (it relies on RAM-only structures). Reject rather than silently degrade.
+      if (!SearchDisk_MarkUnsupportedArgumentIfDiskEnabled("WITHOUTCOUNT", status)) {
+        return REDISMODULE_ERR;
+      }
       AREQ_AddRequestFlags(req, QEXEC_OPTIMIZE);
       if (IsAggregate(req)) {
         AREQ_RemoveRequestFlags(req, QEXEC_F_HAS_WITHCOUNT);
@@ -714,6 +719,15 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
     }
   }
 
+  // DIALECT 4 enables the query optimizer (QEXEC_OPTIMIZE) by default. The optimizer
+  // relies on RAM-only structures (DocTable / NumericRangeTree) that disk specs don't
+  // populate, so it is unsupported on disk. Reject rather than silently degrade.
+  if (isDiskIndex && req->reqConfig.dialectVersion >= 4) {
+    if (!SearchDisk_MarkUnsupportedArgumentIfDiskEnabled("DIALECT 4", status)) {
+      return REDISMODULE_ERR;
+    }
+  }
+
   // In dialect 2, we require a non empty numeric filter
   if (req->reqConfig.dialectVersion >= 2 && hasEmptyFilterValue){
       QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Numeric/Geo filter value/s cannot be empty");
@@ -722,16 +736,8 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
 
   if (!optimization_specified && req->reqConfig.dialectVersion >= 4) {
     // If optimize was not enabled/disabled explicitly, enable it by default starting with dialect 4
+    // (disk indexes reject dialect 4 above, so this is only reached for RAM specs).
     AREQ_AddRequestFlags(req, QEXEC_OPTIMIZE);
-  }
-
-  // QEXEC_OPTIMIZE can be set either by the dialect-4 default above or by an
-  // explicit WITHOUTCOUNT token earlier in this function. Either way, the
-  // QOptimizer pipeline reads from the RAM DocTable / NumericRangeTree, which
-  // aren't populated on disk specs. Force-disable so QOptimizer_Iterators is
-  // never entered for disk specs (it asserts the same).
-  if (isDiskIndex) {
-    AREQ_RemoveRequestFlags(req, QEXEC_OPTIMIZE);
   }
 
   QEFlags reqFlags = AREQ_RequestFlags(req);

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -719,15 +719,6 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
     }
   }
 
-  // DIALECT 4 enables the query optimizer (QEXEC_OPTIMIZE) by default. The optimizer
-  // relies on RAM-only structures (DocTable / NumericRangeTree) that disk specs don't
-  // populate, so it is unsupported on disk. Reject rather than silently degrade.
-  if (isDiskIndex && req->reqConfig.dialectVersion >= 4) {
-    if (!SearchDisk_MarkUnsupportedArgumentIfDiskEnabled("DIALECT 4", status)) {
-      return REDISMODULE_ERR;
-    }
-  }
-
   // In dialect 2, we require a non empty numeric filter
   if (req->reqConfig.dialectVersion >= 2 && hasEmptyFilterValue){
       QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Numeric/Geo filter value/s cannot be empty");
@@ -735,8 +726,9 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
   }
 
   if (!optimization_specified && req->reqConfig.dialectVersion >= 4) {
-    // If optimize was not enabled/disabled explicitly, enable it by default starting with dialect 4
-    // (disk indexes reject dialect 4 above, so this is only reached for RAM specs).
+    // If optimize was not enabled/disabled explicitly, enable it by default starting with dialect 4.
+    // Disk specs reject dialect 4 after parseAggPlan (once the dialect is final), so the optimizer
+    // is never actually run for them.
     AREQ_AddRequestFlags(req, QEXEC_OPTIMIZE);
   }
 
@@ -1289,6 +1281,14 @@ int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int a
   };
   if (parseAggPlan(&papCtx, &ac, isDiskIndex, status) != REDISMODULE_OK) {
     goto error;
+  }
+
+  // DIALECT 4 enables the query optimizer (QEXEC_OPTIMIZE), which is unsupported
+  // on disk.
+  if (isDiskIndex && req->reqConfig.dialectVersion >= 4) {
+    if (!SearchDisk_MarkUnsupportedArgumentIfDiskEnabled("DIALECT 4", status)) {
+      goto error;
+    }
   }
 
   // Cap the per-query timeout to _MAX_FOREGROUND_TIMEOUT_LIMIT when workers

--- a/src/query_optimizer.c
+++ b/src/query_optimizer.c
@@ -231,7 +231,7 @@ int QOptimizer_Iterators(AREQ *req, QOptimizer *opt, QueryError *status) {
   QueryIterator *root = req->rootiter;
 
   // OptimizerIterator and the Q_OPT_UNDECIDED numeric fallback both rely on
-  // the RAM DocTable / NumericRangeTree. parseQueryArgs rejects the queries that
+  // the RAM DocTable / NumericRangeTree. AREQ_Compile rejects the queries that
   // would set QEXEC_OPTIMIZE on disk specs (DIALECT 4 and WITHOUTCOUNT), so this
   // function should never be entered for them.
   RS_ASSERT(!spec->diskSpec);

--- a/src/query_optimizer.c
+++ b/src/query_optimizer.c
@@ -231,8 +231,9 @@ int QOptimizer_Iterators(AREQ *req, QOptimizer *opt, QueryError *status) {
   QueryIterator *root = req->rootiter;
 
   // OptimizerIterator and the Q_OPT_UNDECIDED numeric fallback both rely on
-  // the RAM DocTable / NumericRangeTree. parseQueryArgs clears QEXEC_OPTIMIZE
-  // for disk specs, so this function should never be entered for them.
+  // the RAM DocTable / NumericRangeTree. parseQueryArgs rejects the queries that
+  // would set QEXEC_OPTIMIZE on disk specs (DIALECT 4 and WITHOUTCOUNT), so this
+  // function should never be entered for them.
   RS_ASSERT(!spec->diskSpec);
 
   switch (opt->type) {

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -696,6 +696,56 @@ def test_flex_blocks_summarize_argument(env):
 
 @skip(cluster=True)
 @with_simulate_in_flex(True)
+def test_flex_blocks_dialect_4(env):
+    """Test that DIALECT 4 is blocked in Redis Flex while dialects 1-3 work.
+
+    DIALECT 4 enables the query optimizer (QEXEC_OPTIMIZE) by default, which
+    relies on RAM-only structures (DocTable / NumericRangeTree) that disk specs
+    do not populate, so it is unsupported on disk (MOD-15997).
+    """
+    _create_flex_search(env)
+
+    # Dialects 1-3 still return the document on a disk index.
+    for dialect in (1, 2, 3):
+        env.expect('FT.SEARCH', 'idx', 'hello', 'NOCONTENT', 'DIALECT', str(dialect)) \
+            .equal([1, 'doc:1'])
+
+    # DIALECT 4 is rejected.
+    env.expect('FT.SEARCH', 'idx', 'hello', 'NOCONTENT', 'DIALECT', '4') \
+        .error().contains('DIALECT 4 is not supported in Redis Flex')
+
+
+@skip(cluster=True)
+@with_simulate_in_flex(True)
+def test_flex_blocks_withoutcount_argument(env):
+    """Test that WITHOUTCOUNT is blocked in Redis Flex.
+
+    WITHOUTCOUNT explicitly enables the query optimizer (QEXEC_OPTIMIZE), which
+    is unsupported on disk for the same reason as DIALECT 4 (MOD-15997).
+    """
+    _create_flex_search(env)
+
+    env.expect('FT.SEARCH', 'idx', 'hello', 'NOCONTENT', 'WITHOUTCOUNT') \
+        .error().contains('WITHOUTCOUNT is not supported in Redis Flex')
+
+
+@skip(cluster=True)
+@with_simulate_in_flex(True)
+def test_flex_blocks_configured_default_dialect_4(env):
+    """Test that a configured default of DIALECT 4 is also blocked in Redis Flex.
+
+    When the query omits an explicit DIALECT it inherits search-default-dialect,
+    so a default of 4 must be rejected too (MOD-15997).
+    """
+    _create_flex_search(env)
+
+    env.expect('CONFIG', 'SET', 'search-default-dialect', '4').ok()
+    env.expect('FT.SEARCH', 'idx', 'hello', 'NOCONTENT') \
+        .error().contains('DIALECT 4 is not supported in Redis Flex')
+
+
+@skip(cluster=True)
+@with_simulate_in_flex(True)
 def test_flex_blocks_sortby_on_non_vector_fields(env):
     """Test that SORTBY on non-vector-score fields is blocked in Redis Flex"""
     _create_flex_search(env)


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** On disk (Redis Flex) indexes, `DIALECT 4` (which enables the query optimizer `QEXEC_OPTIMIZE` by default) and an explicit `WITHOUTCOUNT` token both turn on the optimizer. The optimizer reads RAM-only structures (the in-memory `DocTable` / `NumericRangeTree`) that disk specs never populate, so it is buggy/unsupported there. Today the optimize flag is *silently stripped* for disk specs in `parseQueryArgs`.
2. **Change:** Reject these queries at parse time with a clear `"… is not supported in Redis Flex"` error, reusing `SearchDisk_MarkUnsupportedArgumentIfDiskEnabled` — the same mechanism already used for `SLOP`, `INORDER`, and `HIGHLIGHT`.
   - `WITHOUTCOUNT` is rejected in `parseQueryArgs` (it cannot appear after an aggregate-only token).
   - `DIALECT 4` is rejected in `AREQ_Compile`, *after* `parseAggPlan`, where the dialect version is final. Validating there catches it regardless of argument position — e.g. `... GROUPBY ... DIALECT 4`, where `parseQueryArgs` stops at the first aggregate-only token and never sees the dialect.
   - The now-dead `if (isDiskIndex) AREQ_RemoveRequestFlags(req, QEXEC_OPTIMIZE)` strip in `parseQueryArgs` is removed, since neither set-site can fire on disk anymore.
3. **Outcome:** Users get an explicit, actionable error instead of silently degraded behavior, and `QOptimizer_Iterators` (which asserts `!spec->diskSpec`) can never be reached on disk.

#### Which additional issues this PR fixes
1. MOD-15997

#### Main objects this PR modified
1. `src/aggregate/aggregate_request.c` — `parseQueryArgs`: reject `WITHOUTCOUNT` and remove the silent optimize-flag strip; `AREQ_Compile`: reject `DIALECT 4` after `parseAggPlan`.
2. `src/query_optimizer.c` — update the stale comment above `RS_ASSERT(!spec->diskSpec)`.
3. `tests/pytests/test_flex_validation.py` — validation tests under the `_SIMULATE_IN_FLEX` flag, alongside the other Redis Flex argument-blocking tests: `DIALECT 4` rejected (dialects 1-3 still return results), `WITHOUTCOUNT` rejected, and a configured `search-default-dialect` of 4 (no explicit dialect on the query) rejected. `FT.AGGREGATE` rejection on disk is already covered by `test_flex_blocks_aggregate_and_hybrid_commands`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
