### PR TITLE
[8.6-rse][MOD-16523][MOD-16145] FT.HYBRID: bound the cursor-setup wait with a deadline

### DIFF
--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -717,7 +717,9 @@ static int HybridRequest_executePlan(HybridRequest *hreq, struct ConcurrentCmdCt
     cmd->coordStartTime = hreq->profileClocks.coordStartTime;
 
     const RSOomPolicy oomPolicy = hreq->reqConfig.oomPolicy;
-    if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, hreq->tailPipeline->qctx.err, oomPolicy)) {
+    const struct timespec *deadline =
+        hreq->sctx ? (const struct timespec *)&hreq->sctx->time.timeout : NULL;
+    if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, hreq->tailPipeline->qctx.err, oomPolicy, deadline)) {
         // Handle error
         StrongRef_Release(searchMappingsRef);
         StrongRef_Release(vsimMappingsRef);

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -22,11 +22,6 @@ typedef struct {
     StrongRef searchMappings;
     StrongRef vsimMappings;
     arrayof(QueryError) errors;
-    size_t responseCount;
-    pthread_mutex_t *mutex;           // Mutex for array access and completion tracking
-    pthread_cond_t *completionCond;   // Condition variable for completion signaling
-    int numShards;                    // Total number of expected shards
-    bool initialized;                 // Whether numShards has been set by the IO thread
 } processCursorMappingCallbackContext;
 
 void CursorMapping_Release(CursorMapping *mapping) {
@@ -169,9 +164,6 @@ static void processCursorMappingCallback(MRIteratorCallbackCtx *ctx, MRReply *re
     MRCommand *cmd = MRIteratorCallback_GetCommand(ctx);
 
     const int replyType = MRReply_Type(rep);
-    pthread_mutex_lock(cb_ctx->mutex);
-    // add under a lock, allows the coordinator to know when all responses have arrived
-    cb_ctx->responseCount++;
     if (replyType == MR_REPLY_ERROR) {
         processHybridError(cb_ctx, rep);
     } else if (replyType == MR_REPLY_MAP) {
@@ -184,109 +176,75 @@ static void processCursorMappingCallback(MRIteratorCallbackCtx *ctx, MRReply *re
         processHybridUnknownReplyType(cb_ctx, replyType);
     }
 
-    // we must notify the coordinator a response has arrived, even if it's an error
-    pthread_cond_signal(cb_ctx->completionCond);
-    pthread_mutex_unlock(cb_ctx->mutex);
-
     MRIteratorCallback_Done(ctx, 0);
     MRReply_Free(rep);
 }
 
-// No-reply error callback: bumps responseCount and records a communication
-// error so the wait loop below (which keys completion off responseCount, not
-// iterator depletion) unblocks instead of hanging.
+// No-reply error callback: records a communication error. Completion is driven by
+// the iterator's channel (every callback decrements inProcess), so the wait below
+// unblocks once all callbacks have run regardless of this error.
 static void processCursorMappingErrorCallback(MRIteratorCallbackCtx *ctx) {
     processCursorMappingCallbackContext *cb_ctx = (processCursorMappingCallbackContext *)MRIteratorCallback_GetPrivateData(ctx);
     RS_ASSERT(cb_ctx);
 
-    pthread_mutex_lock(cb_ctx->mutex);
-    cb_ctx->responseCount++;
     QueryError error = QueryError_Default();
     QueryError_SetCode(&error, QUERY_ERROR_CODE_GENERIC);
     // Shared with the MR iterator no-reply path (pre-fanout connection-validation failure).
     QueryError_SetDetail(&error, CLUSTER_QUERY_ERROR);
     cb_ctx->errors = array_ensure_append_1(cb_ctx->errors, error);
-    pthread_cond_signal(cb_ctx->completionCond);
-    pthread_mutex_unlock(cb_ctx->mutex);
 }
 
-// Init callback for the private data, so that numShards is set to the actual number of shards in the cluster, and the expected responses.
-static void processCursorMappingInit(void *privateData, MRIterator *it) {
+// Iterator destructor: frees the callback context once the iterator is released.
+static void freeCursorMappingCtx(void *privateData) {
     processCursorMappingCallbackContext *ctx = (processCursorMappingCallbackContext *)privateData;
-    int actualNumShards = (int)MRIterator_GetNumShards(it);
-    pthread_mutex_lock(ctx->mutex);
-    ctx->numShards = actualNumShards;
-    ctx->initialized = true;
-    ctx->errors = array_new(QueryError, actualNumShards);
-    // Signal so the coordinator can re-check the wait condition.
-    pthread_cond_signal(ctx->completionCond);
-    pthread_mutex_unlock(ctx->mutex);
-}
-
-static inline void cleanupCtx(processCursorMappingCallbackContext *ctx) {
-    pthread_mutex_destroy(ctx->mutex);
-    pthread_cond_destroy(ctx->completionCond);
-    rm_free(ctx->mutex);
-    rm_free(ctx->completionCond);
     StrongRef_Release(ctx->searchMappings);
     StrongRef_Release(ctx->vsimMappings);
     array_free_ex(ctx->errors, QueryError_ClearError((QueryError*)ptr));
     rm_free(ctx);
 }
 
-bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsRef, StrongRef vsimMappingsRef, QueryError *status, const RSOomPolicy oomPolicy) {
+bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsRef, StrongRef vsimMappingsRef, QueryError *status, const RSOomPolicy oomPolicy, const struct timespec *deadline) {
     CursorMappings *searchMappings = StrongRef_Get(searchMappingsRef);
     CursorMappings *vsimMappings = StrongRef_Get(vsimMappingsRef);
     RS_ASSERT(array_len(searchMappings->mappings) == 0 && array_len(vsimMappings->mappings) == 0);
 
-    // Allocate callback context on heap (since MR_IterateWithPrivateData is asynchronous)
+    // Heap-allocated because the iterator runs asynchronously; freed by
+    // freeCursorMappingCtx (the iterator's destructor).
     processCursorMappingCallbackContext *ctx = rm_malloc(sizeof(processCursorMappingCallbackContext));
-
-    // Initialize synchronization primitives on heap
-    ctx->mutex = rm_malloc(sizeof(pthread_mutex_t));
-    ctx->completionCond = rm_malloc(sizeof(pthread_cond_t));
-    pthread_mutex_init(ctx->mutex, NULL);
-    pthread_cond_init(ctx->completionCond, NULL);
-
-    // Setup callback context
     *ctx = (processCursorMappingCallbackContext) {
         .searchMappings = StrongRef_Clone(searchMappingsRef),
         .vsimMappings = StrongRef_Clone(vsimMappingsRef),
-        .errors = NULL,
-        .responseCount = 0,
-        .mutex = ctx->mutex,
-        .completionCond = ctx->completionCond,
-        .numShards = 0,
-        .initialized = false
+        .errors = array_new(QueryError, 0),
       };
 
-    // Start iteration (ctx is cleaned up manually in cleanupCtx, no destructor needed)
-    // processCursorMappingInit is called from iterStartCb to update ctx->numShards
-    // with the actual shard count from the live topology, preventing use-after-free
-    // when topology changes during shard migration.
     MRIterator *it = MR_IterateWithPrivateData(cmd, &(MRIteratorConfig){
         .successCB = processCursorMappingCallback,
         .errorCB = processCursorMappingErrorCallback,
         .cbPrivateData = ctx,
-        .cbPrivateDataInit = processCursorMappingInit,
+        .cbPrivateDataDestructor = freeCursorMappingCtx,
         .iterStartCb = iterStartCb,
     });
     if (!it) {
         // Cleanup on error
         QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_GENERIC, "Failed to communicate with shards");
-        cleanupCtx(ctx);
+        freeCursorMappingCtx(ctx);
         return false;
     }
-    // Wait for all callbacks to complete
-    pthread_mutex_lock(ctx->mutex);
-    // Wait until either:
-    // 1. Normal completion: IO thread initialized numShards and all responses arrived
-    // 2. Early failure: We got a response before initialization (e.g., connection validation failed)
-    //    In this case, responseCount > 0 but initialized is false - we should unblock.
-    while (ctx->responseCount == 0 || (ctx->initialized && ctx->responseCount < ctx->numShards)) {
-        pthread_cond_wait(ctx->completionCond, ctx->mutex);
+
+    // Wait on the iterator's channel, bounded by the request deadline.
+    bool timedOut = false;
+    MRReply *r = MRIterator_NextWithTimeout(it, deadline, &timedOut);
+    RS_ASSERT(r == NULL);  // the callbacks never AddReply; a non-NULL reply is a bug
+
+    if (timedOut) {
+        QueryError_SetCode(status, QUERY_ERROR_CODE_TIMED_OUT);
+        MRIterator_Release(it);
+        return false;
     }
-    pthread_mutex_unlock(ctx->mutex);
+
+    // Normal completion: inProcess hit 0, so every callback has run.
+    RS_ASSERT(array_len(searchMappings->mappings) == array_len(vsimMappings->mappings));
+
     bool success = true;
     if (array_len(ctx->errors)) {
         for (size_t i = 0; i < array_len(ctx->errors); i++) {
@@ -300,9 +258,7 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
             }
         }
     }
-    // Cleanup
     MRIterator_Release(it);
-    cleanupCtx(ctx);
 
     return success;
 }

--- a/src/coord/hybrid/hybrid_cursor_mappings.h
+++ b/src/coord/hybrid/hybrid_cursor_mappings.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <time.h>
+
 #include "rmr/rmr.h"
 #include "util/references.h"
 #include "../../config.h"
@@ -46,9 +48,11 @@ typedef struct QueryError QueryError;
  * @param vsimMappings Empty array to populate with vector similarity cursor mappings
  * @param status QueryError pointer to store warning/error information
  * @param oomPolicy OOM policy to determine error handling behavior
+ * @param deadline Absolute (monotonic) time after which the cursor-setup wait gives up and
+ *                 reports a timeout, or NULL to wait without a deadline (e.g. timeout disabled)
  * @return true if processing completed (even with warnings), false on fatal errors; status will contain error/warning information
  */
-bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappings, StrongRef vsimMappings, QueryError *status, RSOomPolicy oomPolicy);
+bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappings, StrongRef vsimMappings, QueryError *status, RSOomPolicy oomPolicy, const struct timespec *deadline);
 
 /**
  * Release resources associated with a cursor mapping

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -633,9 +633,9 @@ struct MRIterator {
   size_t len;
 };
 
-// No-reply termination path: invoke the caller's optional errorCB (notify-only)
-// before the iterator's MRIteratorCallback_Done. Without this hook callers that
-// wait on a private counter (e.g. ProcessHybridCursorMappings) would hang.
+// No-reply termination path: invoke the caller's optional errorCB (notify-only) so
+// it can record the communication error, then run MRIteratorCallback_Done to advance
+// the iterator's completion countdown like any other terminated shard.
 static void mrIteratorCallback_Error(MRIteratorCallbackCtx *ctx) {
   if (ctx->it->ctx.errorCB) {
     ctx->it->ctx.errorCB(ctx);

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -377,6 +377,14 @@ void HREQ_ReplyOrStoreError(HybridRequest *hreq, RedisModuleCtx *ctx, QueryError
     QueryError_CloneFrom(status, &hreq->storedReplyState.err);
     // Clear the original to avoid leaking heap-allocated strings.
     QueryError_ClearError(status);
+  } else if (!ShouldReplyWithError(QueryError_GetCode(status),
+                                   hreq->reqConfig.timeoutPolicy, IsProfile(hreq))) {
+    // A timeout under a non-fail policy must not surface as an error: reply an
+    // empty result set carrying the timeout warning instead (e.g. a cursor-setup
+    // timeout, where no mappings were established).
+    common_hybrid_query_reply_empty(ctx, QueryError_GetCode(status),
+                                    IsInternal(hreq), IsProfile(hreq));
+    QueryError_ClearError(status);
   } else {
     QueryError_ReplyAndClear(ctx, status);
   }
@@ -503,6 +511,11 @@ void sendChunk_ReplyOnly_HybridEmptyResults(RedisModule_Reply *reply, QueryError
         RedisModule_Reply_Array(reply);
         // This function is called by Coordinator or SA
         RedisModule_Reply_SimpleString(reply, QUERY_WOOM_COORD);
+        RedisModule_Reply_ArrayEnd(reply);
+    } else if (QueryError_GetCode(err) == QUERY_ERROR_CODE_TIMED_OUT) {
+        QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_TIMED_OUT, 1, COORD_ERR_WARN);
+        RedisModule_Reply_Array(reply);
+        RedisModule_Reply_SimpleString(reply, QueryWarning_Strwarning(QUERY_WARNING_CODE_TIMED_OUT));
         RedisModule_Reply_ArrayEnd(reply);
     } else {
         RedisModule_Reply_EmptyArray(reply);

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -111,6 +111,40 @@ def getConnectionByEnv(env):
         conn = env.getConnection()
     return conn
 
+
+# --- Coordinator / cluster timeout test helpers ---
+
+def pid_cmd(conn):
+    """Get the process ID of a Redis connection."""
+    return conn.execute_command('info', 'server')['process_id']
+
+
+def non_coord_shard_conns(env):
+    """Return shard connections whose process id differs from the coordinator's."""
+    coord_pid = pid_cmd(env.con)
+    conns = []
+    for shardId in range(1, env.shardsCount + 1):
+        conn = env.getConnection(shardId)
+        if pid_cmd(conn) != coord_pid:
+            conns.append(conn)
+    return conns
+
+
+def split_shards_pick_one_paused(env):
+    """Pick one non-coordinator shard to designate as paused and split the rest.
+
+    Returns ``(all_shard_conns, paused_conn, paused_pid, responsive_conns)``.
+    Asserts that at least one non-coordinator shard exists.
+    """
+    all_shard_conns = [env.getConnection(i) for i in range(1, env.shardsCount + 1)]
+    non_coord_conns = non_coord_shard_conns(env)
+    env.assertGreater(len(non_coord_conns), 0,
+                      message="Test requires at least one non-coordinator shard")
+    paused_conn = non_coord_conns[0]
+    paused_pid = pid_cmd(paused_conn)
+    responsive_conns = [c for c in all_shard_conns if pid_cmd(c) != paused_pid]
+    return all_shard_conns, paused_conn, paused_pid, responsive_conns
+
 def waitForIndex(env, idx = 'idx'):
     waitForRdbSaveToFinish(env)
     while True:

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -114,6 +114,15 @@ def getConnectionByEnv(env):
 
 # --- Coordinator / cluster timeout test helpers ---
 
+ON_TIMEOUT_CONFIG = 'search-on-timeout'
+
+
+def assert_timeout_warning(env, res, message=''):
+    warnings = res.get('warning', res.get('warnings', []))
+    env.assertTrue(warnings, message=message + " expected timeout warning")
+    env.assertContains('Timeout', warnings[0], message=message + " expected timeout warning")
+
+
 def pid_cmd(conn):
     """Get the process ID of a Redis connection."""
     return conn.execute_command('info', 'server')['process_id']

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -362,8 +362,8 @@ def test_queries_fail_on_all_shards_unreachable(env: Env):
     must be routed through the user callback so that:
     - FT.SEARCH: The reducer receives the error and returns it to the client
     - FT.AGGREGATE: The error is pushed to the channel and consumed by rpnetNext
-    - FT.HYBRID: The processCursorMappingCallback increments responseCount and signals
-      the condition variable, allowing ProcessHybridCursorMappings to unblock
+    - FT.HYBRID: The no-reply errorCB records the error and the iterator's completion
+      countdown unblocks ProcessHybridCursorMappings' channel wait
     """
     # Create an index and add data before breaking topology
     env.expect('FT.CREATE', 'idx', 'SCHEMA',

--- a/tests/pytests/test_hybrid_dist.py
+++ b/tests/pytests/test_hybrid_dist.py
@@ -73,7 +73,7 @@ def test_dist_hybrid_index_drop_after_sctx_allocation(env):
 @require_enable_assert
 def test_dist_hybrid_shard_dispatch_failure_does_not_hang(env):
     """A no-reply shard dispatch failure must surface as an error
-    rather than hanging FT.HYBRID on ProcessHybridCursorMappings' completionCond.
+    rather than hanging FT.HYBRID on the cursor-setup wait.
     FT.DEBUG SEND_ERROR forces the next MRCluster_SendCommand to return REDIS_ERR."""
     conn, query_vec, doc_vec = _setup_hybrid_index(env)
     for i in range(10):

--- a/tests/pytests/test_hybrid_timeout.py
+++ b/tests/pytests/test_hybrid_timeout.py
@@ -1,6 +1,7 @@
 from RLTest import Env
 from includes import *
 from common import *
+import psutil
 
 # Test data with deterministic vectors
 test_data = {
@@ -224,3 +225,62 @@ def test_tail_property_not_loaded_warning_coordinator():
         warnings = []
     env.assertTrue(any('__score' in w for w in warnings),
                    message=f"Expected warning about __score, got: {warnings}")
+
+
+@skip(cluster=False)
+def test_timeout_setup_phase_hybrid():
+    """FT.HYBRID cursor-setup timeout: one shard suspended, the in-band deadline fires.
+
+    Suspending a non-coordinator shard parks the coordinator in
+    ProcessHybridCursorMappings' cursor-mapping wait on a connected-but-silent shard.
+    The per-query TIMEOUT bounds that wait, so the command returns a timeout error at
+    the deadline instead of hanging.
+    """
+    # WORKERS 1 dispatches the query to a BG thread so the cursor-setup wait is
+    # reachable; cluster mode gives us a non-coordinator shard to suspend.
+    env = Env(moduleArgs='WORKERS 1', protocol=3)
+    for i in range(1, env.shardsCount + 1):
+        verify_shard_init(env.getConnection(i))
+    conn = getConnectionByEnv(env)
+
+    env.expect(
+        'FT.CREATE', 'hybrid_idx', 'PREFIX', '1', 'hybrid_doc', 'SCHEMA',
+        'name', 'TEXT',
+        'embedding', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2'
+    ).ok()
+    for i in range(100):
+        vec = np.array([float(i), float(i)], dtype=np.float32).tobytes()
+        conn.execute_command('HSET', f'hybrid_doc{i}', 'name', f'hello{i}', 'embedding', vec)
+    query_vec = np.array([0.0, 0.0], dtype=np.float32).tobytes()
+    env.expect(
+        'FT.HYBRID', 'hybrid_idx', 'SEARCH', '*', 'VSIM', '@embedding', '$BLOB',
+        'PARAMS', '2', 'BLOB', query_vec
+    ).noError()
+
+    _, _, paused_pid, _ = split_shards_pick_one_paused(env)
+    shard_to_pause_p = psutil.Process(paused_pid)
+
+    # A finite per-query TIMEOUT arms the coordinator's cursor-setup deadline.
+    query_args = [
+        'FT.HYBRID', 'hybrid_idx',
+        'SEARCH', '*',
+        'VSIM', '@embedding', '$BLOB',
+        'PARAMS', '2', 'BLOB', query_vec,
+        'TIMEOUT', '200',
+    ]
+
+    shard_to_pause_p.suspend()
+    try:
+        wait_for_condition(
+            lambda: (shard_to_pause_p.status() == psutil.STATUS_STOPPED,
+                     {'status': shard_to_pause_p.status()}),
+            'Timeout while waiting for shard to pause'
+        )
+
+        # The deadline fires in the setup wait; the wait is bounded so the command
+        # returns a timeout error rather than hanging (a hang would trip the harness).
+        env.expect(*query_args).error().contains('Timeout')
+    finally:
+        # Resume so the shard drains the queued _FT.HYBRID / CURSOR DEL and frees
+        # its cursors before later tests run.
+        shard_to_pause_p.resume()

--- a/tests/pytests/test_hybrid_timeout.py
+++ b/tests/pytests/test_hybrid_timeout.py
@@ -229,12 +229,15 @@ def test_tail_property_not_loaded_warning_coordinator():
 
 @skip(cluster=False)
 def test_timeout_setup_phase_hybrid():
-    """FT.HYBRID cursor-setup timeout: one shard suspended, the in-band deadline fires.
+    """FT.HYBRID cursor-setup timeout with one shard suspended, both policies.
 
     Suspending a non-coordinator shard parks the coordinator in
     ProcessHybridCursorMappings' cursor-mapping wait on a connected-but-silent shard.
-    The per-query TIMEOUT bounds that wait, so the command returns a timeout error at
-    the deadline instead of hanging.
+    The per-query TIMEOUT bounds that wait, so instead of hanging the command resolves
+    at the deadline per policy:
+      - FAIL   -> a timeout error.
+      - RETURN -> an empty result set carrying the timeout warning (no cursor mappings
+                  were established, so there is nothing to return).
     """
     # WORKERS 1 dispatches the query to a BG thread so the cursor-setup wait is
     # reachable; cluster mode gives us a non-coordinator shard to suspend.
@@ -257,9 +260,6 @@ def test_timeout_setup_phase_hybrid():
         'PARAMS', '2', 'BLOB', query_vec
     ).noError()
 
-    _, _, paused_pid, _ = split_shards_pick_one_paused(env)
-    shard_to_pause_p = psutil.Process(paused_pid)
-
     # A finite per-query TIMEOUT arms the coordinator's cursor-setup deadline.
     query_args = [
         'FT.HYBRID', 'hybrid_idx',
@@ -269,6 +269,10 @@ def test_timeout_setup_phase_hybrid():
         'TIMEOUT', '200',
     ]
 
+    prev_policy = env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
+    _, _, paused_pid, _ = split_shards_pick_one_paused(env)
+    shard_to_pause_p = psutil.Process(paused_pid)
+
     shard_to_pause_p.suspend()
     try:
         wait_for_condition(
@@ -277,10 +281,17 @@ def test_timeout_setup_phase_hybrid():
             'Timeout while waiting for shard to pause'
         )
 
-        # The deadline fires in the setup wait; the wait is bounded so the command
-        # returns a timeout error rather than hanging (a hang would trip the harness).
+        # FAIL policy: the bounded setup wait surfaces a timeout error.
+        env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'fail')
         env.expect(*query_args).error().contains('Timeout')
+
+        # RETURN policy: empty result set + timeout warning instead of an error.
+        env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return')
+        res = env.cmd(*query_args)
+        env.assertEqual(res['total_results'], 0, message=f"expected 0 results, got {res}")
+        assert_timeout_warning(env, res, message="RETURN-policy setup-phase timeout")
     finally:
         # Resume so the shard drains the queued _FT.HYBRID / CURSOR DEL and frees
         # its cursors before later tests run.
         shard_to_pause_p.resume()
+        env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, prev_policy)


### PR DESCRIPTION
## Backport

Backports a scoped slice of **#10110** (`[MOD-16145] FT.HYBRID: bound the cursor-setup wait with a channel timeout`, merged to `master`) to `8.6-rse`. Sibling of #10197 (8.4) and #10199 (8.6) — same approach.

`8.6-rse` is a parallel branch (not descended from 8.6), but for this code it is in the same architectural state: `ProcessHybridCursorMappings` is still the old mutex/cond version and the `RequestSyncCtx` framework #10110 builds on does not exist. So this is a **manual port**, not a cherry-pick — adapted to 8.6-rse's shape (the `QUERY_ERROR_CODE_*` error-code names, same as 8.6).

### What this takes from #10110
- Replaces the bespoke `mutex` + `cond` + `responseCount`/`numShards`/`initialized` **unbounded `pthread_cond_wait`** with a channel pop bounded by the request deadline: `MRIterator_NextWithTimeout(it, deadline, &timedOut)`.
- Completion is driven by the iterator's `inProcess` countdown reaching 0 (fires on success **and** disconnect), so a non-responding/disconnected shard during cursor setup no longer hangs the coordinator.
- Lock-free hybrid callbacks; ctx teardown moved into the iterator's `cbPrivateDataDestructor` (`freeCursorMappingCtx`). Bespoke mutex/cond/counters deleted.
- The deadline comes from `hreq->sctx->time.timeout` (a disabled timeout maps to a far-future deadline → effectively unbounded, but no spurious-wakeup footgun).

### What this deliberately does NOT take (absent on 8.6-rse)
- **`RequestSyncCtx` abort-channel registration** (`RequestSyncCtx_RegisterAbortWakeChannel` / `WakeAbortChannel`, 4-arg `MRIterator_NextWithTimeout`, `MRIterator_GetChannel`). 8.6-rse only has the 3-arg sync variant, which is exactly what the in-band deadline needs.
- **Main-thread blocked-client timeout callbacks** (`DistHybridTimeout{Fail,ReturnStrict}Callback`, `wakeHybridAbortChannels`).
- **Policy-aware empty+warning reply** (`HREQ_ReplyOrStoreError`).

### Behavior delta vs master
- A setup-phase deadline timeout replies a **timeout error** under all policies (master replies empty+warning under RETURN/RETURN-STRICT). No cursor mappings exist yet at setup, so there is nothing to return regardless.
- RETURN-STRICT / disabled-timeout retains the (now far-future-bounded) wait — only the finite-`TIMEOUT` case is bounded by the in-band deadline. This is the intended limit of the sync-timeout slice.

### Tests
- Ports the in-band-deadline setup-phase test as `test_timeout_setup_phase_hybrid` (`test_hybrid_timeout.py`): suspends a non-coordinator shard so the setup wait stalls, asserts a timeout error at the deadline.
- Adds shared shard-picking helpers (`pid_cmd`, `non_coord_shard_conns`, `split_shards_pick_one_paused`) to `common.py`.
- The two `CLIENT UNBLOCK` setup-phase tests from #10110 are **not** ported (they exercise the blocked-client mechanism excluded above).
- Note: full build + Python run was not possible on the author's macOS box (pre-existing geometry/`fmt`/`toml++` dep build breakage on that toolchain, unrelated to this change). The byte-identical-logic 8.4 port (#10197) passed `clang -fsyntax-only`; relying on CI for the Linux build/test.

#### Release Notes
- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: distributed `FT.HYBRID` no longer hangs when a shard fails to respond or disconnects during cursor setup; it returns at the query timeout with a timeout error.

[MOD-16145]: https://redislabs.atlassian.net/browse/MOD-16145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ