### PR TITLE
trie_rs: place Default/Debug impls after inherent impl and tidy imports

### DIFF
--- a/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
@@ -24,18 +24,6 @@ pub struct StrTrieMap<Data> {
     inner: TrieMap<Data>,
 }
 
-impl<Data> Default for StrTrieMap<Data> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<Data: fmt::Debug> fmt::Debug for StrTrieMap<Data> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)
-    }
-}
-
 impl<Data> StrTrieMap<Data> {
     /// Create a new (empty) [`StrTrieMap`]. See [`TrieMap::new`].
     pub const fn new() -> Self {
@@ -146,5 +134,17 @@ impl<Data> StrTrieMap<Data> {
         todo!("UTF-8 wildcard iteration over StrTrieMap not yet implemented");
         #[expect(unreachable_code)]
         std::iter::empty()
+    }
+}
+
+impl<Data> Default for StrTrieMap<Data> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Data: fmt::Debug> fmt::Debug for StrTrieMap<Data> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
     }
 }

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
@@ -7,11 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::fmt;
+pub mod iter;
 
 use crate::TrieMap;
-
-pub mod iter;
+use std::fmt;
 
 /// UTF-8 keyed view over [`TrieMap`].
 ///
@@ -28,6 +27,12 @@ pub struct StrTrieMap<Data> {
 impl<Data> Default for StrTrieMap<Data> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<Data: fmt::Debug> fmt::Debug for StrTrieMap<Data> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
     }
 }
 
@@ -141,11 +146,5 @@ impl<Data> StrTrieMap<Data> {
         todo!("UTF-8 wildcard iteration over StrTrieMap not yet implemented");
         #[expect(unreachable_code)]
         std::iter::empty()
-    }
-}
-
-impl<Data: fmt::Debug> fmt::Debug for StrTrieMap<Data> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)
     }
 }

--- a/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
@@ -35,21 +35,6 @@ pub struct TrieMap<Data> {
     memory_usage: usize,
 }
 
-impl<Data> Default for TrieMap<Data> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<Data: fmt::Debug> fmt::Debug for TrieMap<Data> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.root {
-            Some(r) => r.fmt(f),
-            None => f.write_str("(empty)"),
-        }
-    }
-}
-
 impl<Data> TrieMap<Data> {
     /// Create a new (empty) [`TrieMap`].
     ///
@@ -284,6 +269,21 @@ impl<Data> TrieMap<Data> {
         match self.find_root_for_prefix(prefix) {
             Some((root, _)) => Values::new(Some(root)),
             None => Values::new(None),
+        }
+    }
+}
+
+impl<Data> Default for TrieMap<Data> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Data: fmt::Debug> fmt::Debug for TrieMap<Data> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.root {
+            Some(r) => r.fmt(f),
+            None => f.write_str("(empty)"),
         }
     }
 }

--- a/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
@@ -13,8 +13,6 @@ pub mod iter;
 mod node;
 mod utils;
 
-use rqe_wildcard::WildcardPattern;
-
 use crate::trie_map::{
     iter::{
         ContainsIter, IntoValues, Iter, LendingIter, PrefixesIter, RangeFilter, RangeIter, Values,
@@ -23,6 +21,7 @@ use crate::trie_map::{
     node::Node,
     utils::strip_prefix,
 };
+use rqe_wildcard::WildcardPattern;
 use std::fmt;
 
 #[derive(Clone, PartialEq, Eq)]
@@ -39,6 +38,15 @@ pub struct TrieMap<Data> {
 impl<Data> Default for TrieMap<Data> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<Data: fmt::Debug> fmt::Debug for TrieMap<Data> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.root {
+            Some(r) => r.fmt(f),
+            None => f.write_str("(empty)"),
+        }
     }
 }
 
@@ -276,15 +284,6 @@ impl<Data> TrieMap<Data> {
         match self.find_root_for_prefix(prefix) {
             Some((root, _)) => Values::new(Some(root)),
             None => Values::new(None),
-        }
-    }
-}
-
-impl<Data: std::fmt::Debug> std::fmt::Debug for TrieMap<Data> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.root {
-            Some(r) => r.fmt(f),
-            None => f.write_str("(empty)"),
         }
     }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

Pure cosmetic cleanup of `trie_rs` — no behavior change.

1. **Current:** In both `TrieMap` and `StrTrieMap` the trait impls were placed inconsistently: `Default` sat *before* the inherent `impl Type { ... }` block while `Debug` sat at the bottom of the file, far from it. Imports were also interleaved with `pub mod` declarations, and `TrieMap`'s `Debug` redundantly fully-qualified `std::fmt::Debug` despite `use std::fmt`.
2. **Change:** Moved both `Default` and `Debug` to sit together *after* the inherent `impl` block (`Default` first), matching the codebase-majority convention of inherent methods first, trait impls after. Regrouped imports and dropped the redundant `std::fmt::` qualifier.
3. **Outcome:** The two types now follow the prevailing placement convention and keep their trait impls colocated; no functional difference.

#### Which additional issues this PR fixes

_None._

#### Main objects this PR modified

1. `src/redisearch_rs/trie_rs/src/trie_map/mod.rs`
2. `src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
