### PR TITLE
[MOD-16175] Mark non-cacheable commands with dont_cache

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -292,7 +292,10 @@
       }
     ],
     "since": "1.0.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.INFO": {
     "summary": "Returns information and statistics on the index",
@@ -305,7 +308,10 @@
       }
     ],
     "since": "1.0.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.EXPLAIN": {
     "summary": "Returns the execution plan for a complex query",
@@ -331,7 +337,10 @@
       }
     ],
     "since": "1.0.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.EXPLAINCLI": {
     "summary": "Returns the execution plan for a complex query",
@@ -357,7 +366,10 @@
       }
     ],
     "since": "1.0.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.ALTER": {
     "summary": "Adds a new field to the index",
@@ -397,7 +409,10 @@
       }
     ],
     "since": "1.0.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.DROPINDEX": {
     "summary": "Deletes the index",
@@ -422,7 +437,10 @@
       }
     ],
     "since": "2.0.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.ALIASADD": {
     "summary": "Adds an alias to the index",
@@ -439,7 +457,10 @@
       }
     ],
     "since": "1.0.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.ALIASUPDATE": {
     "summary": "Adds or updates an alias to the index",
@@ -456,7 +477,10 @@
       }
     ],
     "since": "1.0.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.ALIASDEL": {
     "summary": "Deletes an alias from the index",
@@ -468,7 +492,10 @@
       }
     ],
     "since": "1.0.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.ALIASLIST": {
     "summary": "Lists all aliases for the index",
@@ -481,7 +508,10 @@
       }
     ],
     "since": "8.10.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.TAGVALS": {
     "summary": "Returns the distinct tags indexed in a Tag field",
@@ -498,7 +528,10 @@
       }
     ],
     "since": "1.0.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.SUGADD": {
     "summary": "Adds a suggestion string to an auto-complete suggestion dictionary",
@@ -542,7 +575,10 @@
       }
     ],
     "since": "1.0.0",
-    "group": "suggestion"
+    "group": "suggestion",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.SUGGET": {
     "summary": "Gets completion suggestions for a prefix",
@@ -606,7 +642,10 @@
       }
     ],
     "since": "1.0.0",
-    "group": "suggestion"
+    "group": "suggestion",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.SUGLEN": {
     "summary": "Gets the size of an auto-complete suggestion dictionary",
@@ -647,7 +686,10 @@
       }
     ],
     "since": "1.2.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.SYNDUMP": {
     "summary": "Dumps the contents of a synonym group",
@@ -660,7 +702,10 @@
       }
     ],
     "since": "1.2.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.SPELLCHECK": {
     "summary": "Performs spelling correction on a query, returning suggestions for misspelled terms",
@@ -726,7 +771,10 @@
       }
     ],
     "since": "1.4.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.DICTADD": {
     "summary": "Adds terms to a dictionary",
@@ -743,7 +791,10 @@
       }
     ],
     "since": "1.4.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.DICTDEL": {
     "summary": "Deletes terms from a dictionary",
@@ -760,7 +811,10 @@
       }
     ],
     "since": "1.4.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.DICTDUMP": {
     "summary": "Dumps all terms in the given dictionary",
@@ -772,13 +826,19 @@
       }
     ],
     "since": "1.4.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT._LIST": {
     "summary": "Returns a list of all existing indexes",
     "complexity": "O(1)",
     "since": "2.0.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.CONFIG SET": {
     "summary": "Sets runtime configuration options",
@@ -796,7 +856,10 @@
       }
     ],
     "since": "1.0.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.CONFIG GET": {
     "summary": "Retrieves runtime configuration options",
@@ -810,7 +873,10 @@
       }
     ],
     "since": "1.0.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.CONFIG HELP": {
     "summary": "Help description of runtime configuration options",
@@ -824,7 +890,10 @@
       }
     ],
     "since": "1.0.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.SEARCH": {
     "summary": "Searches the index with a textual query, returning either documents or just ids",
@@ -1264,7 +1333,10 @@
       }
     ],
     "since": "1.0.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.AGGREGATE": {
     "summary": "Run a search query on an index and perform aggregate transformations on the results",
@@ -2050,7 +2122,10 @@
       }
     ],
     "since": "1.1.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.PROFILE": {
     "summary": "Performs a `FT.SEARCH`, `FT.AGGREGATE`, or `FT.HYBRID` command and collects performance information",
@@ -2101,7 +2176,10 @@
       }
     ],
     "since": "2.2.0",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   },
   "FT.CURSOR READ": {
     "summary": "Reads from a cursor",
@@ -2124,7 +2202,8 @@
       }
     ],
     "command_tips": [
-      "REQUEST_POLICY:SPECIAL"
+      "REQUEST_POLICY:SPECIAL",
+      "DONT_CACHE"
     ],
     "since": "1.1.0",
     "group": "search"
@@ -2144,7 +2223,8 @@
       }
     ],
     "command_tips": [
-      "REQUEST_POLICY:SPECIAL"
+      "REQUEST_POLICY:SPECIAL",
+      "DONT_CACHE"
     ],
     "since": "1.1.0",
     "group": "search"
@@ -3147,6 +3227,9 @@
       }
     ],
     "since": "8.4.4",
-    "group": "search"
+    "group": "search",
+    "command_tips": [
+      "DONT_CACHE"
+    ]
   }
 }

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -306,6 +306,7 @@ int SetFtCreateInfo(RedisModuleCommand *cmd) {
     },
     .arity = -5,
     .since = "1.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -326,6 +327,7 @@ int SetFtInfoInfo(RedisModuleCommand *cmd) {
     },
     .arity = 2,
     .since = "1.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -359,6 +361,7 @@ int SetFtExplainInfo(RedisModuleCommand *cmd) {
     },
     .arity = -3,
     .since = "1.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -392,6 +395,7 @@ int SetFtExplaincliInfo(RedisModuleCommand *cmd) {
     },
     .arity = -3,
     .since = "1.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -439,6 +443,7 @@ int SetFtAlterInfo(RedisModuleCommand *cmd) {
     },
     .arity = -6,
     .since = "1.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -472,6 +477,7 @@ int SetFtDropindexInfo(RedisModuleCommand *cmd) {
     },
     .arity = -2,
     .since = "2.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -496,6 +502,7 @@ int SetFtAliasaddInfo(RedisModuleCommand *cmd) {
     },
     .arity = 3,
     .since = "1.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -520,6 +527,7 @@ int SetFtAliasupdateInfo(RedisModuleCommand *cmd) {
     },
     .arity = 3,
     .since = "1.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -539,6 +547,7 @@ int SetFtAliasdelInfo(RedisModuleCommand *cmd) {
     },
     .arity = 2,
     .since = "1.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -559,6 +568,7 @@ int SetFtAliaslistInfo(RedisModuleCommand *cmd) {
     },
     .arity = 2,
     .since = "8.10.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -583,6 +593,7 @@ int SetFtTagvalsInfo(RedisModuleCommand *cmd) {
     },
     .arity = 3,
     .since = "1.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -633,6 +644,7 @@ int SetFtSugaddInfo(RedisModuleCommand *cmd) {
     },
     .arity = -4,
     .since = "1.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -709,6 +721,7 @@ int SetFtSugdelInfo(RedisModuleCommand *cmd) {
     },
     .arity = 3,
     .since = "1.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -764,6 +777,7 @@ int SetFtSynupdateInfo(RedisModuleCommand *cmd) {
     },
     .arity = -4,
     .since = "1.2.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -784,6 +798,7 @@ int SetFtSyndumpInfo(RedisModuleCommand *cmd) {
     },
     .arity = 2,
     .since = "1.2.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -858,6 +873,7 @@ int SetFtSpellcheckInfo(RedisModuleCommand *cmd) {
     },
     .arity = -3,
     .since = "1.4.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -882,6 +898,7 @@ int SetFtDictaddInfo(RedisModuleCommand *cmd) {
     },
     .arity = -3,
     .since = "1.4.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -906,6 +923,7 @@ int SetFtDictdelInfo(RedisModuleCommand *cmd) {
     },
     .arity = -3,
     .since = "1.4.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -925,6 +943,7 @@ int SetFtDictdumpInfo(RedisModuleCommand *cmd) {
     },
     .arity = 2,
     .since = "1.4.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -936,6 +955,7 @@ int SetFt_ListInfo(RedisModuleCommand *cmd) {
     .summary = "Returns a list of all existing indexes",
     .complexity = "O(1)",
     .since = "2.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -959,6 +979,7 @@ int SetFtConfigSetInfo(RedisModuleCommand *cmd) {
     },
     .arity = -3,
     .since = "1.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -978,6 +999,7 @@ int SetFtConfigGetInfo(RedisModuleCommand *cmd) {
     },
     .arity = -3,
     .since = "1.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -997,6 +1019,7 @@ int SetFtConfigHelpInfo(RedisModuleCommand *cmd) {
     },
     .arity = -3,
     .since = "1.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -1457,6 +1480,7 @@ int SetFtSearchInfo(RedisModuleCommand *cmd) {
     },
     .arity = -3,
     .since = "1.0.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -2295,6 +2319,7 @@ int SetFtAggregateInfo(RedisModuleCommand *cmd) {
     },
     .arity = -3,
     .since = "1.1.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -2354,6 +2379,7 @@ int SetFtProfileInfo(RedisModuleCommand *cmd) {
     },
     .arity = -5,
     .since = "2.2.0",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }
@@ -2383,7 +2409,7 @@ int SetFtCursorReadInfo(RedisModuleCommand *cmd) {
       {0}
     },
     .arity = -4,
-    .tips = "request_policy:special",
+    .tips = "request_policy:special dont_cache",
     .since = "1.1.0",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
@@ -2408,7 +2434,7 @@ int SetFtCursorDelInfo(RedisModuleCommand *cmd) {
       {0}
     },
     .arity = -4,
-    .tips = "request_policy:special",
+    .tips = "request_policy:special dont_cache",
     .since = "1.1.0",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
@@ -3474,6 +3500,7 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
     },
     .arity = -7,
     .since = "8.4.4",
+    .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -1401,6 +1401,14 @@ typedef union {
   SubscribeSubCommands subscribeSubCommands;
 } MutuallyExclusiveCommandCallbacks;
 
+static int SetDontCacheInfo(RedisModuleCommand *cmd) {
+  const RedisModuleCommandInfo info = {
+    .version = REDISMODULE_COMMAND_INFO_VERSION,
+    .tips = "dont_cache",
+  };
+  return RedisModule_SetCommandInfo(cmd, &info);
+}
+
 typedef struct {
   const char *name;
   const char *flags;
@@ -1835,11 +1843,11 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx) {
     // read only commands
     DEFINE_COMMAND(RS_INFO_CMD,      IndexInfoCommand,         "readonly"                , NULL,                      NONE,                  "",                     true,             indexOnlyCmdArgs, true),
     DEFINE_COMMAND(RS_SEARCH_CMD,    RSSearchCommand,          "readonly"                , SetFtSearchInfo,           SET_COMMAND_INFO,      "",                     true,             indexOnlyCmdArgs, true),
-    DEFINE_COMMAND(RS_GET_CMD,       DiskDisabledCmd(GetSingleDocumentCommand), "readonly"                , NULL,                      NONE,                  "read",                 true,             indexDocCmdArgs,  false),
+    DEFINE_COMMAND(RS_GET_CMD,       DiskDisabledCmd(GetSingleDocumentCommand), "readonly"                , SetDontCacheInfo,          SET_COMMAND_INFO,      "read",                 true,             indexDocCmdArgs,  false),
     DEFINE_COMMAND(RS_HYBRID_CMD,    DiskDisabledCmd(RSShardedHybridCommand),   "readonly"                , SetFtHybridInfo,           SET_COMMAND_INFO,      "",                     true,             indexOnlyCmdArgs, true),
     DEFINE_COMMAND(RS_AGGREGATE_CMD, DiskDisabledCmd(RSAggregateCommand),       "readonly"                , SetFtAggregateInfo,        SET_COMMAND_INFO,      "read",                 true,             indexOnlyCmdArgs, true),
     DEFINE_COMMAND(RS_PROFILE_CMD,   RSProfileCommand,         "readonly"                , SetFtProfileInfo,          SET_COMMAND_INFO,      "read",                 true,             indexOnlyCmdArgs, true),
-    DEFINE_COMMAND(RS_MGET_CMD,      DiskDisabledCmd(GetDocumentsCommand),      "readonly"                , NULL,                      NONE,                  "read",                 true,             indexOnlyCmdArgs, true),
+    DEFINE_COMMAND(RS_MGET_CMD,      DiskDisabledCmd(GetDocumentsCommand),      "readonly"                , SetDontCacheInfo,          SET_COMMAND_INFO,      "read",                 true,             indexOnlyCmdArgs, true),
     DEFINE_COMMAND(RS_TAGVALS_CMD,   DiskDisabledCmd(TagValsCommand),           "readonly"                , SetFtTagvalsInfo,          SET_COMMAND_INFO,      "read slow dangerous",  true,             indexOnlyCmdArgs, true),
     DEFINE_COMMAND(RS_CURSOR_CMD,    NULL,                     "readonly"                , RegisterCursorCommands,    SUBSCRIBE_SUBCOMMANDS, "read",                 true,             indexOnlyCmdArgs, true),
     DEFINE_COMMAND(RS_DEBUG,         NULL,                     RS_READ_ONLY_FLAGS_DEFAULT, RegisterAllDebugCommands,  SUBSCRIBE_SUBCOMMANDS, "admin slow dangerous",                true,             indexOnlyCmdArgs, false),
@@ -4966,7 +4974,7 @@ RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   }
   // Deprecated commands. Grouped here for easy tracking
   SearchCommand deprecatedCommands[] = {
-    DEFINE_COMMAND("FT.MGET",           SafeCmd(DiskDisabledCmd(MGetCommandHandler)),    "readonly", NULL,             NONE,             "read",           true, noKeyArgs, false),
+    DEFINE_COMMAND("FT.MGET",           SafeCmd(DiskDisabledCmd(MGetCommandHandler)),    "readonly", SetDontCacheInfo, SET_COMMAND_INFO, "read",           true, noKeyArgs, false),
     DEFINE_COMMAND("FT.TAGVALS",        SafeCmd(DiskDisabledCmd(TagValsCommandHandler)), "readonly", SetFtTagvalsInfo, SET_COMMAND_INFO, "read slow dangerous", true, noKeyArgs, false)
   };
   if (CreateSearchCommands(ctx, deprecatedCommands, sizeof(deprecatedCommands) / sizeof(SearchCommand)) != REDISMODULE_OK) {

--- a/src/module.c
+++ b/src/module.c
@@ -1841,7 +1841,7 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx) {
     DEFINE_COMMAND(RS_INDEX_LIST_CMD, IndexList,              "readonly",       SetFt_ListInfo,      SET_COMMAND_INFO, "slow admin", true, indexOnlyCmdArgs, false),
     DEFINE_COMMAND(RS_SYNADD_CMD,     DiskDisabledCmd(SynAddCommand),          "write deny-oom", NULL,                NONE,             "",           true, indexOnlyCmdArgs, false),
     // read only commands
-    DEFINE_COMMAND(RS_INFO_CMD,      IndexInfoCommand,         "readonly"                , NULL,                      NONE,                  "",                     true,             indexOnlyCmdArgs, true),
+    DEFINE_COMMAND(RS_INFO_CMD,      IndexInfoCommand,         "readonly"                , SetDontCacheInfo,          SET_COMMAND_INFO,      "",                     true,             indexOnlyCmdArgs, true),
     DEFINE_COMMAND(RS_SEARCH_CMD,    RSSearchCommand,          "readonly"                , SetFtSearchInfo,           SET_COMMAND_INFO,      "",                     true,             indexOnlyCmdArgs, true),
     DEFINE_COMMAND(RS_GET_CMD,       DiskDisabledCmd(GetSingleDocumentCommand), "readonly"                , SetDontCacheInfo,          SET_COMMAND_INFO,      "read",                 true,             indexDocCmdArgs,  false),
     DEFINE_COMMAND(RS_HYBRID_CMD,    DiskDisabledCmd(RSShardedHybridCommand),   "readonly"                , SetFtHybridInfo,           SET_COMMAND_INFO,      "",                     true,             indexOnlyCmdArgs, true),
@@ -4041,10 +4041,10 @@ static int RegisterCursorCommands(RedisModuleCtx* ctx, RedisModuleCommand *curso
      .setCommandInfo = SetFtCursorDelInfo, .position = keys},
     {.name = "PROFILE", .fullName = RS_CURSOR_CMD "|PROFILE", .flags = "readonly",
      .handler = DiskDisabledCmd(RSCursorProfileCommand),
-     .setCommandInfo = NULL, .position = keys},
+     .setCommandInfo = SetDontCacheInfo, .position = keys},
     {.name = "GC",      .fullName = RS_CURSOR_CMD "|GC",      .flags = "readonly",
      .handler = DiskDisabledCmd(RSCursorGCCommand),
-     .setCommandInfo = NULL, .position = keys}
+     .setCommandInfo = SetDontCacheInfo, .position = keys}
     };
 
   return CreateSubCommands(ctx, cursorCommand, subcommands, sizeof(subcommands) / sizeof(SubCommand));
@@ -4063,7 +4063,7 @@ static int RegisterCoordCursorCommands(RedisModuleCtx* ctx, RedisModuleCommand *
      .setCommandInfo = SetFtCursorDelInfo, .position = keys},
     {.name = "GC",      .fullName = "FT.CURSOR|GC",      .flags = "readonly",
      .handler = SafeCmd(DiskDisabledCmd(CursorGCCommand)),
-     .setCommandInfo = NULL, .position = keys}
+     .setCommandInfo = SetDontCacheInfo, .position = keys}
     };
   return CreateSubCommands(ctx, cursorCommand, subcommands, sizeof(subcommands) / sizeof(SubCommand));
 }
@@ -4965,9 +4965,9 @@ RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   // cluster set commands
   SearchCommand clusterSetCommands[] = {
-    DEFINE_COMMAND(REDISEARCH_MODULE_NAME ".CLUSTERSET",     SafeCmd(SetClusterCommand),     IsEnterprise() ? "readonly allow-loading deny-script " CMD_PROXY_FILTERED : "readonly allow-loading deny-script", NULL, NONE, "", true, noKeyArgs, false),
-    DEFINE_COMMAND(REDISEARCH_MODULE_NAME ".CLUSTERREFRESH", SafeCmd(RefreshClusterCommand), IsEnterprise() ? "readonly deny-script " CMD_PROXY_FILTERED               : "readonly deny-script",               NULL, NONE, "", true, noKeyArgs, false),
-    DEFINE_COMMAND(REDISEARCH_MODULE_NAME ".CLUSTERINFO",    SafeCmd(ClusterInfoCommand),    IsEnterprise() ? "readonly allow-loading deny-script " CMD_PROXY_FILTERED : "readonly allow-loading deny-script", NULL, NONE, "", true, noKeyArgs, false),
+    DEFINE_COMMAND(REDISEARCH_MODULE_NAME ".CLUSTERSET",     SafeCmd(SetClusterCommand),     IsEnterprise() ? "readonly allow-loading deny-script " CMD_PROXY_FILTERED : "readonly allow-loading deny-script", SetDontCacheInfo, SET_COMMAND_INFO, "", true, noKeyArgs, false),
+    DEFINE_COMMAND(REDISEARCH_MODULE_NAME ".CLUSTERREFRESH", SafeCmd(RefreshClusterCommand), IsEnterprise() ? "readonly deny-script " CMD_PROXY_FILTERED               : "readonly deny-script",               SetDontCacheInfo, SET_COMMAND_INFO, "", true, noKeyArgs, false),
+    DEFINE_COMMAND(REDISEARCH_MODULE_NAME ".CLUSTERINFO",    SafeCmd(ClusterInfoCommand),    IsEnterprise() ? "readonly allow-loading deny-script " CMD_PROXY_FILTERED : "readonly allow-loading deny-script", SetDontCacheInfo, SET_COMMAND_INFO, "", true, noKeyArgs, false),
   };
   if (CreateSearchCommands(ctx, clusterSetCommands, sizeof(clusterSetCommands) / sizeof(SearchCommand)) != REDISMODULE_OK) {
     return REDISMODULE_ERR;

--- a/tests/pytests/test_command_info.py
+++ b/tests/pytests/test_command_info.py
@@ -423,7 +423,7 @@ def test_command_info_tips_field():
 
 """Test commands.json DONT_CACHE policy for CSC cacheability."""
 def test_command_info_cacheability_tips_policy():
-    env = Env()
+    env = Env(protocol=3)
     try:
         commands_json = _load_command_expectations()
     except Exception as e:
@@ -444,6 +444,22 @@ def test_command_info_cacheability_tips_policy():
                     message=f"Commands expected without {_DONT_CACHE_TIP} must not have it: {unexpected_dont_cache}")
     env.assertEqual(missing_dont_cache, [],
                     message=f"Non-cacheable commands must have {_DONT_CACHE_TIP}: {missing_dont_cache}")
+
+    conn = env.getConnection()
+    runtime_dont_cache = []
+
+    for cmd_name in _COMMANDS_WITHOUT_DONT_CACHE:
+        info = conn.execute_command("COMMAND", "INFO", cmd_name)
+        if not info or not isinstance(info, dict) or cmd_name not in info:
+            runtime_dont_cache.append(f"{cmd_name}: No command info returned")
+            continue
+
+        tips = _tolower_list(info[cmd_name].get('tips', []))
+        if _DONT_CACHE_TIP in tips:
+            runtime_dont_cache.append(cmd_name)
+
+    env.assertEqual(runtime_dont_cache, [],
+                    message=f"Commands expected without {_DONT_CACHE_TIP} expose it in COMMAND INFO: {runtime_dont_cache}")
 
 """Test the structure of command info for specific well-known commands."""
 def test_specific_command_docs_structure():

--- a/tests/pytests/test_command_info.py
+++ b/tests/pytests/test_command_info.py
@@ -4,6 +4,7 @@ import os
 
 _DONT_CACHE_TIP = 'dont_cache'
 _COMMANDS_WITHOUT_DONT_CACHE = {'FT.SUGGET', 'FT.SUGLEN'}
+_LEGACY_COMMANDS_WITH_DONT_CACHE = {'FT.GET', 'FT.MGET'}
 
 def _load_command_expectations():
     """Load and parse the command info expectations file."""
@@ -464,6 +465,20 @@ def test_command_info_cacheability_tips_policy():
 
     env.assertEqual(runtime_dont_cache, [],
                     message=f"Commands expected without {_DONT_CACHE_TIP} expose it in COMMAND INFO: {runtime_dont_cache}")
+
+    missing_legacy_dont_cache = []
+    for cmd_name in _LEGACY_COMMANDS_WITH_DONT_CACHE:
+        info = conn.execute_command("COMMAND", "INFO", cmd_name)
+        if not info or not isinstance(info, dict) or cmd_name not in info:
+            missing_legacy_dont_cache.append(f"{cmd_name}: No command info returned")
+            continue
+
+        tips = _tolower_list(info[cmd_name].get('tips', []))
+        if _DONT_CACHE_TIP not in tips:
+            missing_legacy_dont_cache.append(cmd_name)
+
+    env.assertEqual(missing_legacy_dont_cache, [],
+                    message=f"Legacy commands expected with {_DONT_CACHE_TIP} do not expose it in COMMAND INFO: {missing_legacy_dont_cache}")
 
 """Test the structure of command info for specific well-known commands."""
 def test_specific_command_docs_structure():

--- a/tests/pytests/test_command_info.py
+++ b/tests/pytests/test_command_info.py
@@ -388,6 +388,10 @@ def test_command_info_tips_field():
     failed_tips = []
 
     for cmd_name, expected_data in commands_with_tips.items():
+        if env.isCluster() and cmd_name.startswith('FT.CONFIG'):
+            # We only register this command if we are not in a cluster mode.
+            continue
+
         cmd_upper = cmd_name.upper().replace(' ', '|')
         expected_tips = expected_data['command_tips']
 

--- a/tests/pytests/test_command_info.py
+++ b/tests/pytests/test_command_info.py
@@ -389,11 +389,12 @@ def test_command_info_tips_field():
     failed_tips = []
 
     for cmd_name, expected_data in commands_with_tips.items():
-        if env.isCluster() and cmd_name.startswith('FT.CONFIG'):
-            # We only register this command if we are not in a cluster mode.
-            continue
-
         cmd_upper = cmd_name.upper().replace(' ', '|')
+        if env.isCluster() and cmd_name.startswith('FT.CONFIG'):
+            # In cluster mode the coordinator does not register public FT.CONFIG,
+            # but the local _FT.CONFIG subcommands use the same command info.
+            cmd_upper = '_' + cmd_upper
+
         expected_tips = expected_data['command_tips']
 
         try:

--- a/tests/pytests/test_command_info.py
+++ b/tests/pytests/test_command_info.py
@@ -4,7 +4,16 @@ import os
 
 _DONT_CACHE_TIP = 'dont_cache'
 _COMMANDS_WITHOUT_DONT_CACHE = {'FT.SUGGET', 'FT.SUGLEN'}
-_LEGACY_COMMANDS_WITH_DONT_CACHE = {'FT.GET', 'FT.MGET'}
+_MANUAL_PUBLIC_COMMANDS_WITH_DONT_CACHE = {
+    'FT.GET',
+    'FT.MGET',
+    'FT.CURSOR|GC',
+}
+_CLUSTER_CONTROL_COMMANDS_WITH_DONT_CACHE = {
+    'SEARCH.CLUSTERSET',
+    'SEARCH.CLUSTERREFRESH',
+    'SEARCH.CLUSTERINFO',
+}
 
 def _load_command_expectations():
     """Load and parse the command info expectations file."""
@@ -28,6 +37,20 @@ def _lists_equal_insensitive(a, b):
 
 def _tolower_list(values):
     return [value.lower() for value in values]
+
+def _get_command_info(conn, cmd_name):
+    info = conn.execute_command("COMMAND", "INFO", cmd_name)
+    if not info or not isinstance(info, dict):
+        return None
+    if cmd_name in info:
+        return info[cmd_name]
+
+    cmd_name_lower = cmd_name.lower()
+    for returned_name, cmd_info in info.items():
+        if returned_name.lower() == cmd_name_lower:
+            return cmd_info
+
+    return None
 
 def _convert_flags_to_boolean_fields(flags_list):
     """
@@ -467,19 +490,23 @@ def test_command_info_cacheability_tips_policy():
     env.assertEqual(runtime_dont_cache, [],
                     message=f"Commands expected without {_DONT_CACHE_TIP} expose it in COMMAND INFO: {runtime_dont_cache}")
 
-    missing_legacy_dont_cache = []
-    for cmd_name in _LEGACY_COMMANDS_WITH_DONT_CACHE:
-        info = conn.execute_command("COMMAND", "INFO", cmd_name)
-        if not info or not isinstance(info, dict) or cmd_name not in info:
-            missing_legacy_dont_cache.append(f"{cmd_name}: No command info returned")
+    manual_commands_with_dont_cache = set(_MANUAL_PUBLIC_COMMANDS_WITH_DONT_CACHE)
+    if env.isCluster():
+        manual_commands_with_dont_cache.update(_CLUSTER_CONTROL_COMMANDS_WITH_DONT_CACHE)
+
+    missing_manual_dont_cache = []
+    for cmd_name in manual_commands_with_dont_cache:
+        info = _get_command_info(conn, cmd_name)
+        if not info:
+            missing_manual_dont_cache.append(f"{cmd_name}: No command info returned")
             continue
 
-        tips = _tolower_list(info[cmd_name].get('tips', []))
+        tips = _tolower_list(info.get('tips', []))
         if _DONT_CACHE_TIP not in tips:
-            missing_legacy_dont_cache.append(cmd_name)
+            missing_manual_dont_cache.append(cmd_name)
 
-    env.assertEqual(missing_legacy_dont_cache, [],
-                    message=f"Legacy commands expected with {_DONT_CACHE_TIP} do not expose it in COMMAND INFO: {missing_legacy_dont_cache}")
+    env.assertEqual(missing_manual_dont_cache, [],
+                    message=f"Manual commands expected with {_DONT_CACHE_TIP} do not expose it in COMMAND INFO: {missing_manual_dont_cache}")
 
 """Test the structure of command info for specific well-known commands."""
 def test_specific_command_docs_structure():

--- a/tests/pytests/test_command_info.py
+++ b/tests/pytests/test_command_info.py
@@ -2,6 +2,9 @@ from common import *
 import json
 import os
 
+_DONT_CACHE_TIP = 'dont_cache'
+_COMMANDS_WITHOUT_DONT_CACHE = {'FT.SUGGET', 'FT.SUGLEN'}
+
 def _load_command_expectations():
     """Load and parse the command info expectations file."""
     commands_json_path = os.path.join(os.path.dirname(__file__), '..', '..', 'commands.json')
@@ -21,6 +24,9 @@ def _lists_equal_insensitive(a, b):
     Returns True if they contain the same items (ignoring case and order).
     """
     return set(map(str.lower, a)) == set(map(str.lower, b))
+
+def _tolower_list(values):
+    return [value.lower() for value in values]
 
 def _convert_flags_to_boolean_fields(flags_list):
     """
@@ -414,6 +420,30 @@ def test_command_info_tips_field():
     # Strict assertion - all commands with tips should pass
     env.assertEqual(len(failed_tips), 0,
                    message=f"All commands with tips should have correct tips field. Failed: {failed_tips}")
+
+"""Test commands.json DONT_CACHE policy for CSC cacheability."""
+def test_command_info_cacheability_tips_policy():
+    env = Env()
+    try:
+        commands_json = _load_command_expectations()
+    except Exception as e:
+        env.fail(str(e))
+
+    unexpected_dont_cache = []
+    missing_dont_cache = []
+
+    for cmd_name, command_data in commands_json.items():
+        tips = _tolower_list(command_data.get('command_tips', []))
+        if cmd_name in _COMMANDS_WITHOUT_DONT_CACHE:
+            if _DONT_CACHE_TIP in tips:
+                unexpected_dont_cache.append(cmd_name)
+        elif _DONT_CACHE_TIP not in tips:
+            missing_dont_cache.append(cmd_name)
+
+    env.assertEqual(unexpected_dont_cache, [],
+                    message=f"Commands expected without {_DONT_CACHE_TIP} must not have it: {unexpected_dont_cache}")
+    env.assertEqual(missing_dont_cache, [],
+                    message=f"Non-cacheable commands must have {_DONT_CACHE_TIP}: {missing_dont_cache}")
 
 """Test the structure of command info for specific well-known commands."""
 def test_specific_command_docs_structure():


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: RediSearch command metadata does not explicitly mark commands that should be excluded from client-side caching.
2. Change: Add the `dont_cache` command tip to all RediSearch commands except `FT.SUGGET` and `FT.SUGLEN`, which qualify as cacheable. Regenerate command info from `commands.json`.
3. Outcome: Command metadata now explicitly blocks client-side caching for non-cacheable RediSearch commands, instead of relying on other metadata such as read-only flags or key information that may change independently.

#### Which additional issues this PR fixes
1. MOD-16175

#### Main objects this PR modified
1. `commands.json`
2. `src/command_info/command_info.c`
3. `tests/pytests/test_command_info.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Validation:

- `PYENV_VERSION=redisearch-test-env REDISEARCH_GENERATE_HEADERS=0 ./build.sh RUN_PYTEST TEST=test_command_info.py:test_command_info_cacheability_tips_policy`
- `PYENV_VERSION=redisearch-test-env REDISEARCH_GENERATE_HEADERS=0 ./build.sh RUN_PYTEST TEST=test_command_info.py:test_command_info_tips_field`
- `git diff --check`