### PR TITLE
[MOD-16396] Fix coordinator crash under RESP2 FT.PROFILE HYBRID return-strict timeout

### DIFF
--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -215,11 +215,10 @@ static void startPipelineHybrid(HybridRequest *hreq, ResultProcessor *rp, Search
   SyncPoint_WaitUntil(SYNC_POINT_BEFORE_HYBRID_RESULTS_CLAIM, hreq_timeout_or_pending_spec_writers, hreq);
 #endif
 
-  // Bail if the RETURN-STRICT timeout callback already claimed (it replies)
-  // or if it signaled timeout in parallel after we won (it will reply with
-  // our stored zero-result state).
+  // Bail if the RETURN-STRICT timeout callback already owns the reply.
+  // The timeout check MUST come first so it short-circuits the CAS.
   if (HybridRequest_RequiresThreadsSyncResults(hreq) &&
-      (!HybridRequest_TryClaimAggregateResults(hreq) || HybridRequest_TimedOut(hreq))) {
+      (HybridRequest_TimedOut(hreq) || !HybridRequest_TryClaimAggregateResults(hreq))) {
     *rc = RS_RESULT_TIMEDOUT;
     return;
   }


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: In `startPipelineHybrid`, the background (BG) worker attempts the aggregate-results CAS (`HybridRequest_TryClaimAggregateResults`) *before* checking the timeout flag. Under the RETURN_STRICT timeout policy the BG worker can be released from the pre-claim sync point / channel wait precisely because the main-thread timeout callback set `timedOut`. It then wins the CAS and immediately bails with `RS_RESULT_TIMEDOUT` without running the pipeline. The timeout callback, having lost the CAS, serializes results from `RPNet` shard profiles that were never initialized. Under Linux ASAN this crashes the coordinator (`extractShardProfile` -> `printShardsHybridProfile` -> `serializeStoredResults_hybrid` -> `DistHybridTimeoutReturnStrictCallback`).
2. **Change**: Reorder the guard so the timeout check short-circuits the CAS (`HybridRequest_TimedOut(hreq) || !HybridRequest_TryClaimAggregateResults(hreq)`). A timed-out BG worker now cedes the claim instead of winning it, so the main-thread callback wins and replies with a safe empty result set. Reaching the CAS now implies `timedOut` was false, so a win always proceeds into the pipeline.
3. **Outcome**: The coordinator no longer dereferences uninitialized `MRReply` shard-profile data on the hybrid RETURN_STRICT timeout path; whoever wins the claim is always the party able to produce the reply.

#### Which additional issues this PR fixes
1. MOD-16396

#### Main objects this PR modified
1. `src/hybrid/hybrid_exec.c` (`startPipelineHybrid`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
