### PR TITLE
[MOD-16185] Trie - term_suffix_index - wildcard, ends-with, and case-insensitive lookups

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2867,7 +2867,6 @@ dependencies = [
 name = "term_suffix_index"
 version = "0.0.1"
 dependencies = [
- "ffi",
  "proptest",
  "rqe_wildcard",
  "rstest",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2868,6 +2868,8 @@ name = "term_suffix_index"
 version = "0.0.1"
 dependencies = [
  "proptest",
+ "rqe_wildcard",
+ "rstest",
  "trie_rs",
  "workspace_hack",
 ]

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2867,9 +2867,11 @@ dependencies = [
 name = "term_suffix_index"
 version = "0.0.1"
 dependencies = [
+ "ffi",
  "proptest",
  "rqe_wildcard",
  "rstest",
+ "string_utils",
  "trie_rs",
  "workspace_hack",
 ]

--- a/src/redisearch_rs/term_suffix_index/Cargo.toml
+++ b/src/redisearch_rs/term_suffix_index/Cargo.toml
@@ -9,7 +9,6 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-ffi.workspace = true
 rqe_wildcard.workspace = true
 string_utils.workspace = true
 trie_rs.workspace = true

--- a/src/redisearch_rs/term_suffix_index/Cargo.toml
+++ b/src/redisearch_rs/term_suffix_index/Cargo.toml
@@ -9,7 +9,9 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+ffi.workspace = true
 rqe_wildcard.workspace = true
+string_utils.workspace = true
 trie_rs.workspace = true
 workspace_hack.workspace = true
 

--- a/src/redisearch_rs/term_suffix_index/Cargo.toml
+++ b/src/redisearch_rs/term_suffix_index/Cargo.toml
@@ -9,8 +9,10 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+rqe_wildcard.workspace = true
 trie_rs.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]
 proptest = { workspace = true, features = ["std"] }
+rstest.workspace = true

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -30,8 +30,14 @@ use std::{
     rc::Rc,
 };
 
+use rqe_wildcard::{MatchOutcome, WildcardPattern};
 use term_refs::{Outcome, TermRefs};
 use trie_rs::str_trie_map::StrTrieMap;
+
+/// Score handicap for anchor tokens followed by `*`: matching them
+/// scans a whole subtree instead of a single exact entry, so they
+/// must out-length an exact token by this many codepoints to win.
+const STARRED_ANCHOR_PENALTY: i32 = 5;
 
 #[derive(Default)]
 pub struct TermSuffixIndex {
@@ -123,5 +129,89 @@ impl TermSuffixIndex {
             .into_iter()
             .flat_map(|n| self.inner.get(n))
             .flat_map(|data| data.terms().cloned())
+    }
+
+    /// Iterate over the members matching the glob `pattern`, where `*` matches
+    /// any run of characters and `?` any single byte. Returns `None` when no
+    /// token in the pattern can seed the search (every token is empty or
+    /// contains `?`). A term may be yielded more than once (once per matching
+    /// suffix entry).
+    pub fn iter_wildcard(&self, pattern: &str) -> Option<impl Iterator<Item = Rc<str>>> {
+        let (token, followed_by_star) = choose_token(pattern)?;
+
+        // A token followed by `*` can sit anywhere inside a match,
+        // so every suffix entry starting with it is a candidate. A
+        // token at the very end of the pattern must terminate the
+        // match, so only terms ending with it — exactly its own
+        // suffix entry — qualify.
+        let (subtree, exact) = if followed_by_star {
+            (
+                Some(self.inner.prefixed_iter(token).map(|(_, data)| data)),
+                None,
+            )
+        } else {
+            (None, self.inner.get(token))
+        };
+
+        // Byte-wise wildcard match against the established matcher. `?`
+        // therefore matches a single *byte*, not a codepoint, so multibyte
+        // terms are matched only approximately — acceptable here, and it
+        // avoids carrying a codepoint-aware matcher of our own.
+        let wildcard = WildcardPattern::parse(pattern.as_bytes());
+        let matches: Vec<Rc<str>> = subtree
+            .into_iter()
+            .flatten()
+            .chain(exact)
+            .flat_map(|data| data.terms().cloned())
+            .filter(|term| wildcard.matches(term.as_bytes()) == MatchOutcome::Match)
+            .collect();
+        Some(matches.into_iter())
+    }
+}
+
+/// Returns the anchor token to look up for a wildcard `pattern`
+/// (e.g. `"ab*cd"`), paired with whether a `*` follows it.
+///
+/// The anchor is the `*`-separated token expected to narrow the
+/// candidate set the most. Returns [`None`] if no token is
+/// eligible, i.e. every token is empty (a bare `*`) or contains
+/// `?` or `\`.
+fn choose_token(pattern: &str) -> Option<(&str, bool)> {
+    pattern
+        .split_inclusive('*')
+        .map(|token| match token.strip_suffix('*') {
+            Some(stripped) => (stripped, true),
+            None => (token, false),
+        })
+        .filter(|(token, _)| !token.is_empty() && !token.contains(['?', '\\']))
+        .max_by_key(|&(token, followed_by_star)| {
+            token.chars().count() as i32
+                - if followed_by_star {
+                    STARRED_ANCHOR_PENALTY
+                } else {
+                    0
+                }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    /// Anchor choice affects performance, never the result set, so
+    /// no test going through the public API can observe it; the
+    /// scoring rules are pinned against the private heuristic.
+    #[rstest]
+    #[case::score_tie_prefers_later_token("ab*cd*", Some(("cd", true)))]
+    #[case::starred_anchor_penalty_outweighs_small_length_lead("abcdef*gh", Some(("gh", false)))]
+    #[case::length_lead_above_starred_anchor_penalty_wins("abcdefgh*ij", Some(("abcdefgh", true)))]
+    #[case::single_char_tokens_are_eligible("a*b", Some(("b", false)))]
+    #[case::all_empty_tokens_ineligible("*", None)]
+    #[case::tokens_with_question_mark_or_backslash_ineligible("a?cd*\\ab*ef", Some(("ef", false)))]
+    #[case::length_counts_codepoints_not_bytes("日本語*ab", Some(("ab", false)))]
+    fn choose_token_test(#[case] pattern: &str, #[case] expected: Option<(&str, bool)>) {
+        assert_eq!(choose_token(pattern), expected);
     }
 }

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -15,6 +15,11 @@
 //! by the tokenizer. The structure itself is content-agnostic — any
 //! `&str` will do.
 //!
+//! Every term and query is lowercased on the way in via
+//! [`unicode_tolower`], so stored terms and matches are always in
+//! lowercase form and lookups are case-insensitive. Callers pass terms
+//! verbatim; the index owns normalization.
+//!
 //! # Why a suffix trie answers substring queries
 //!
 //! Every substring of a string is a prefix of *some* suffix of that
@@ -31,6 +36,7 @@ use std::{
 };
 
 use rqe_wildcard::{MatchOutcome, WildcardPattern};
+use string_utils::unicode_tolower;
 use term_refs::{Outcome, TermRefs};
 use trie_rs::str_trie_map::StrTrieMap;
 
@@ -64,8 +70,15 @@ impl TermSuffixIndex {
         self.inner.mem_usage()
     }
 
+    /// Add a term to the set, registering it under its own key and every
+    /// queryable suffix. Lowercased on entry; re-adding an existing term, or
+    /// adding an empty one, is a no-op.
     pub fn add(&mut self, term: &str) {
-        debug_assert!(!term.is_empty(), "term must not be empty");
+        let lowered = unicode_tolower(term);
+        let term = lowered.as_str();
+        if term.is_empty() {
+            return;
+        }
 
         if self.inner.get(term).is_some_and(TermRefs::has_full_term) {
             return;
@@ -83,8 +96,15 @@ impl TermSuffixIndex {
         }
     }
 
+    /// Remove a term from the set, evicting its own key and any suffix entries
+    /// it was the last referrer to. Lowercased on entry; removing an absent or
+    /// empty term is a no-op.
     pub fn remove(&mut self, term: &str) {
-        debug_assert!(!term.is_empty(), "term must not be empty");
+        let lowered = unicode_tolower(term);
+        let term = lowered.as_str();
+        if term.is_empty() {
+            return;
+        }
 
         if let Some(data) = self.inner.get_mut(term)
             && data.has_full_term()
@@ -108,36 +128,39 @@ impl TermSuffixIndex {
             .map(|(byte_idx, _)| &term[byte_idx..])
     }
 
-    /// Yield every indexed term containing `needle`, in unspecified
-    /// order. Empty `needle` yields nothing. A term may be yielded
-    /// more than once; dedupe by [`Rc::as_ptr`] if needed.
-    pub fn iter_contains(&self, needle: &str) -> impl Iterator<Item = Rc<str>> {
-        (!needle.is_empty())
-            .then_some(needle)
-            .into_iter()
-            .flat_map(|n| self.inner.prefixed_iter(n))
-            .flat_map(|(_key, data)| data.terms().cloned())
+    /// Iterate over the members that contain `needle` as a substring.
+    /// Lowercased on entry, so matching is case-insensitive. Empty
+    /// `needle` yields nothing. A term may be yielded more than once
+    /// (once per matching suffix entry).
+    pub fn iter_contains(&self, needle: &str) -> impl Iterator<Item = &str> {
+        let lowered = unicode_tolower(needle);
+        self.inner
+            .prefixed_iter(&lowered)
+            .flat_map(|(_, data)| data.terms().map(|term| &**term))
     }
 
-    /// Yield every indexed term that ends with `needle`, in unspecified
-    /// order. Empty `needle` yields nothing.
-    ///
-    /// Each matching term is yielded exactly once.
-    pub fn iter_suffix(&self, needle: &str) -> impl Iterator<Item = Rc<str>> {
-        (!needle.is_empty())
-            .then_some(needle)
-            .into_iter()
-            .flat_map(|n| self.inner.get(n))
-            .flat_map(|data| data.terms().cloned())
+    /// Iterate over the members that end with `needle`.
+    /// Lowercased on entry, so matching is case-insensitive. Empty
+    /// `needle` yields nothing.
+    pub fn iter_suffix(&self, needle: &str) -> impl Iterator<Item = &str> {
+        let lowered = unicode_tolower(needle);
+        let data = if lowered.is_empty() {
+            None
+        } else {
+            self.inner.get(&lowered)
+        };
+        data.into_iter()
+            .flat_map(|data| data.terms().map(|term| &**term))
     }
 
     /// Iterate over the members matching the glob `pattern`, where `*` matches
-    /// any run of characters and `?` any single byte. Returns `None` when no
-    /// token in the pattern can seed the search (every token is empty or
-    /// contains `?`). A term may be yielded more than once (once per matching
-    /// suffix entry).
+    /// any run of characters and `?` any single byte. Lowercased on entry, so
+    /// matching is case-insensitive. Returns `None` when no token in the
+    /// pattern can seed the search (every token is empty or contains `?`).
+    /// A term may be yielded more than once (once per matching suffix entry).
     pub fn iter_wildcard(&self, pattern: &str) -> Option<impl Iterator<Item = Rc<str>>> {
-        let (token, followed_by_star) = choose_token(pattern)?;
+        let lowered = unicode_tolower(pattern);
+        let (token, followed_by_star) = choose_token(&lowered)?;
 
         // A token followed by `*` can sit anywhere inside a match,
         // so every suffix entry starting with it is a candidate. A
@@ -157,7 +180,7 @@ impl TermSuffixIndex {
         // therefore matches a single *byte*, not a codepoint, so multibyte
         // terms are matched only approximately — acceptable here, and it
         // avoids carrying a codepoint-aware matcher of our own.
-        let wildcard = WildcardPattern::parse(pattern.as_bytes());
+        let wildcard = WildcardPattern::parse(lowered.as_bytes());
         let matches: Vec<Rc<str>> = subtree
             .into_iter()
             .flatten()

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -158,6 +158,16 @@ impl TermSuffixIndex {
     /// matching is case-insensitive. Returns `None` when no token in the
     /// pattern can seed the search (every token is empty or contains `?`).
     /// A term may be yielded more than once (once per matching suffix entry).
+    ///
+    /// `?` matches a single *byte*, not a codepoint. The final filter runs
+    /// [`WildcardPattern`] over the raw UTF-8, and that matcher advances one
+    /// byte per `?` — it is the same byte-granular matcher the wider query
+    /// engine uses for wildcard search (the Rust counterpart of C's
+    /// `Wildcard_MatchChar`). So against a multibyte term, `?` lines up with a
+    /// single byte of a codepoint, not the whole character: `caf?` will not
+    /// match `café`. This is not an approximation introduced here — it is the
+    /// engine's pre-existing `?` behavior, which we deliberately reuse rather
+    /// than diverge from with a second, codepoint-aware matcher.
     pub fn iter_wildcard(&self, pattern: &str) -> Option<impl Iterator<Item = Rc<str>>> {
         let lowered = unicode_tolower(pattern);
         let (token, followed_by_star) = choose_token(&lowered)?;

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -74,11 +74,12 @@ impl TermSuffixIndex {
     /// queryable suffix. Lowercased on entry; re-adding an existing term, or
     /// adding an empty one, is a no-op.
     pub fn add(&mut self, term: &str) {
-        let lowered = unicode_tolower(term);
-        let term = lowered.as_str();
         if term.is_empty() {
             return;
         }
+
+        let lowered = unicode_tolower(term);
+        let term = lowered.as_str();
 
         if self.inner.get(term).is_some_and(TermRefs::has_full_term) {
             return;
@@ -100,11 +101,12 @@ impl TermSuffixIndex {
     /// it was the last referrer to. Lowercased on entry; removing an absent or
     /// empty term is a no-op.
     pub fn remove(&mut self, term: &str) {
-        let lowered = unicode_tolower(term);
-        let term = lowered.as_str();
         if term.is_empty() {
             return;
         }
+
+        let lowered = unicode_tolower(term);
+        let term = lowered.as_str();
 
         if let Some(data) = self.inner.get_mut(term)
             && data.has_full_term()

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -166,8 +166,8 @@ impl TermSuffixIndex {
     /// byte per `?` — it is the same byte-granular matcher the wider query
     /// engine uses for wildcard search (the Rust counterpart of C's
     /// `Wildcard_MatchChar`). So against a multibyte term, `?` lines up with a
-    /// single byte of a codepoint, not the whole character: `caf?` will not
-    /// match `café`. This is not an approximation introduced here — it is the
+    /// single byte of a codepoint, not the whole character: `entr?` will not
+    /// match `entré`. This is not an approximation introduced here — it is the
     /// engine's pre-existing `?` behavior, which we deliberately reuse rather
     /// than diverge from with a second, codepoint-aware matcher.
     pub fn iter_wildcard(&self, pattern: &str) -> Option<impl Iterator<Item = Rc<str>>> {

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -25,30 +25,37 @@
 
 mod term_refs;
 
-use std::rc::Rc;
+use std::{
+    fmt::{self, Debug},
+    rc::Rc,
+};
 
 use term_refs::{Outcome, TermRefs};
 use trie_rs::str_trie_map::StrTrieMap;
 
+#[derive(Default)]
 pub struct TermSuffixIndex {
     inner: StrTrieMap<TermRefs>,
 }
 
-impl Default for TermSuffixIndex {
-    fn default() -> Self {
-        Self::new()
+impl Debug for TermSuffixIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
     }
 }
 
 impl TermSuffixIndex {
+    /// Create a new, empty index.
     pub const fn new() -> Self {
         Self {
             inner: StrTrieMap::new(),
         }
     }
 
-    pub fn mem_usage(&self) -> usize {
-        todo!("FT.INFO memory accounting for the suffix index")
+    /// Estimated heap memory currently held by this index. Mirrors the cached
+    /// counter on the underlying [`StrTrieMap`] — O(1). See [`StrTrieMap::mem_usage`].
+    pub const fn mem_usage(&self) -> usize {
+        self.inner.mem_usage()
     }
 
     pub fn add(&mut self, term: &str) {

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -188,10 +188,6 @@ impl TermSuffixIndex {
             (None, self.inner.get(token))
         };
 
-        // Byte-wise wildcard match against the established matcher. `?`
-        // therefore matches a single *byte*, not a codepoint, so multibyte
-        // terms are matched only approximately — acceptable here, and it
-        // avoids carrying a codepoint-aware matcher of our own.
         let wildcard = WildcardPattern::parse(lowered.as_bytes());
         let matches: Vec<Rc<str>> = subtree
             .into_iter()

--- a/src/redisearch_rs/term_suffix_index/src/term_refs.rs
+++ b/src/redisearch_rs/term_suffix_index/src/term_refs.rs
@@ -27,6 +27,7 @@ use std::rc::Rc;
 /// trie entries — one full-term entry plus its `N - 1` proper-suffix
 /// entries — keeping per-term memory `O(N)` instead of `O(N²)`.
 /// Bytes drop with the last reference.
+#[derive(Debug, Default)]
 pub(super) struct TermRefs {
     full_term: Option<Rc<str>>,
     longer_terms: Vec<Rc<str>>,

--- a/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
@@ -9,68 +9,34 @@
 
 //! Property tests for [`TermSuffixIndex`].
 
-use std::{collections::HashSet, rc::Rc};
+use std::collections::HashSet;
 
 use term_suffix_index::TermSuffixIndex;
 
-fn build_index(corpus: &[String]) -> TermSuffixIndex {
+#[test]
+fn add_promotes_existing_suffix_only_node_to_full_term() {
+    // "longer" leaves "ger" as a suffix-only node; inserting "ger"
+    // must promote it.
     let mut sut = TermSuffixIndex::new();
-    for t in corpus {
-        sut.add(t);
-    }
-    sut
-}
+    sut.add("longer");
+    sut.add("ger");
 
-fn collect_set<I: Iterator<Item = Rc<str>>>(it: I) -> HashSet<String> {
-    it.map(|r| r.as_ref().to_string()).collect()
-}
+    let actual = collect_set(sut.iter_suffix("ger"));
 
-// --- Focused, hand-rolled cases ----------------------------------------
-
-#[test]
-fn iter_suffix_yields_terms_ending_with_needle() {
-    let corpus = ["cat", "catalog", "category", "concat", "scat", "scatter"]
-        .iter()
-        .map(|s| s.to_string())
-        .collect::<Vec<_>>();
-    let sut = build_index(&corpus);
-    let expected = ["cat", "concat", "scat"]
-        .iter()
-        .map(|s| s.to_string())
-        .collect::<HashSet<_>>();
-
-    let actual = collect_set(sut.iter_suffix("cat"));
-
-    assert_eq!(actual, expected, "iter_suffix('cat')");
+    let expected = HashSet::from(["longer".to_string(), "ger".to_string()]);
+    assert_eq!(actual, expected);
 }
 
 #[test]
-fn iter_contains_yields_terms_containing_needle() {
-    let corpus = ["cat", "catalog", "category", "concat", "scat", "scatter"]
-        .iter()
-        .map(|s| s.to_string())
-        .collect::<Vec<_>>();
-    let sut = build_index(&corpus);
-    let expected = corpus.iter().cloned().collect::<HashSet<_>>();
+fn add_same_term_twice_is_noop() {
+    let mut sut = TermSuffixIndex::new();
 
-    let actual = collect_set(sut.iter_contains("cat"));
+    sut.add("apple");
+    sut.add("apple");
+    let actual = sut.iter_contains("apple").collect::<Vec<_>>();
 
-    assert_eq!(actual, expected, "iter_contains('cat')");
-}
-
-#[test]
-fn empty_needle_yields_no_matches() {
-    let corpus = ["cat", "dog"]
-        .iter()
-        .map(|s| s.to_string())
-        .collect::<Vec<_>>();
-    let sut = build_index(&corpus);
-
-    let actual_suffix = sut.iter_suffix("").count();
-    let actual_contains = sut.iter_contains("").count();
-
-    assert_eq!(actual_suffix, 0);
-    assert_eq!(actual_contains, 0);
+    assert_eq!(actual.len(), 1, "apple inserted twice yields one hit");
+    assert_eq!(actual[0], "apple");
 }
 
 #[test]
@@ -92,48 +58,36 @@ fn add_then_remove_clears_the_index() {
 }
 
 #[test]
-fn add_same_term_twice_is_noop() {
-    let mut sut = TermSuffixIndex::new();
+fn iter_contains_yields_terms_containing_needle() {
+    let corpus = ["cat", "catalog", "category", "concat", "scat", "scatter"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+    let sut = build_index(&corpus);
+    let expected = corpus.iter().cloned().collect::<HashSet<_>>();
 
-    sut.add("apple");
-    sut.add("apple");
-    let actual = sut.iter_contains("apple").collect::<Vec<_>>();
+    let actual = collect_set(sut.iter_contains("cat"));
 
-    assert_eq!(actual.len(), 1, "apple inserted twice yields one hit");
-    assert_eq!(actual[0].as_ref(), "apple");
+    assert_eq!(actual, expected, "iter_contains('cat')");
 }
 
 #[test]
-fn add_promotes_existing_suffix_only_node_to_full_term() {
-    // "longer" leaves "ger" as a suffix-only node; inserting "ger"
-    // must promote it.
-    let mut sut = TermSuffixIndex::new();
-    sut.add("longer");
-    sut.add("ger");
+fn iter_suffix_and_iter_contains_empty_needle_yield_no_matches() {
+    let corpus = ["cat", "dog"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+    let sut = build_index(&corpus);
 
-    let actual = collect_set(sut.iter_suffix("ger"));
+    let actual_suffix = sut.iter_suffix("").count();
+    let actual_contains = sut.iter_contains("").count();
 
-    let expected = HashSet::from(["longer".to_string(), "ger".to_string()]);
-    assert_eq!(actual, expected);
+    assert_eq!(actual_suffix, 0);
+    assert_eq!(actual_contains, 0);
 }
 
 #[test]
-fn length_one_proper_suffix_is_indexed() {
-    // "ab" stores its trailing length-1 suffix "b" as a back-reference,
-    // so a 1-char suffix or contains query reaches it.
-    let mut sut = TermSuffixIndex::new();
-    sut.add("ab");
-
-    assert_eq!(
-        collect_set(sut.iter_suffix("ab")),
-        HashSet::from(["ab".to_string()])
-    );
-    assert!(collect_set(sut.iter_suffix("b")).contains("ab"));
-    assert!(collect_set(sut.iter_contains("a")).contains("ab"));
-}
-
-#[test]
-fn multibyte_utf8_suffix_slicing_is_codepoint_aware() {
+fn iter_suffix_multibyte_needle_is_codepoint_aware() {
     // Codepoint-aware suffix slicing: "café" has 4 codepoints, so every
     // proper suffix down to the length-1 "é" is indexed. A byte-stride
     // port would either panic (`&term[3..]` splits the first byte of
@@ -161,25 +115,18 @@ fn multibyte_utf8_suffix_slicing_is_codepoint_aware() {
 }
 
 #[test]
-fn remove_unknown_term_is_noop() {
+fn length_one_proper_suffix_is_indexed() {
+    // "ab" stores its trailing length-1 suffix "b" as a back-reference,
+    // so a 1-char suffix or contains query reaches it.
     let mut sut = TermSuffixIndex::new();
-    sut.add("present");
+    sut.add("ab");
 
-    sut.remove("absent");
-
-    assert!(collect_set(sut.iter_suffix("present")).contains("present"));
-}
-
-#[test]
-fn remove_suffix_only_entry_is_noop() {
-    // "ger" was never `add`ed, but it exists in the trie as a
-    // back-reference key for "longer". Remove must no-op gracefully.
-    let mut sut = TermSuffixIndex::new();
-    sut.add("longer");
-
-    sut.remove("ger");
-
-    assert!(collect_set(sut.iter_suffix("ger")).contains("longer"));
+    assert_eq!(
+        collect_set(sut.iter_suffix("ab")),
+        HashSet::from(["ab".to_string()])
+    );
+    assert!(collect_set(sut.iter_suffix("b")).contains("ab"));
+    assert!(collect_set(sut.iter_contains("a")).contains("ab"));
 }
 
 #[test]
@@ -190,13 +137,30 @@ fn iter_suffix_yields_one_hit_per_matching_term() {
 
     let actual = sut
         .iter_suffix("abc")
-        .map(|r| r.as_ref().to_string())
+        .map(str::to_string)
         .collect::<Vec<_>>();
 
     assert_eq!(actual.len(), 2, "each match yielded exactly once");
     let actual_set = actual.into_iter().collect::<HashSet<_>>();
     let expected = HashSet::from(["abc".to_string(), "xabc".to_string()]);
     assert_eq!(actual_set, expected);
+}
+
+#[test]
+fn iter_suffix_yields_terms_ending_with_needle() {
+    let corpus = ["cat", "catalog", "category", "concat", "scat", "scatter"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+    let sut = build_index(&corpus);
+    let expected = ["cat", "concat", "scat"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<HashSet<_>>();
+
+    let actual = collect_set(sut.iter_suffix("cat"));
+
+    assert_eq!(actual, expected, "iter_suffix('cat')");
 }
 
 #[test]
@@ -307,7 +271,98 @@ fn iter_wildcard_without_anchorable_token_reports_none() {
     }
 }
 
-// --- Proptest fuzz
+#[test]
+fn remove_suffix_only_entry_is_noop() {
+    // "ger" was never `add`ed, but it exists in the trie as a
+    // back-reference key for "longer". Remove must no-op gracefully.
+    let mut sut = TermSuffixIndex::new();
+    sut.add("longer");
+
+    sut.remove("ger");
+
+    assert!(collect_set(sut.iter_suffix("ger")).contains("longer"));
+}
+
+#[test]
+fn remove_unknown_term_is_noop() {
+    let mut sut = TermSuffixIndex::new();
+    sut.add("present");
+
+    sut.remove("absent");
+
+    assert!(collect_set(sut.iter_suffix("present")).contains("present"));
+}
+
+#[test]
+fn add_lowercases_terms_and_queries_are_case_insensitive() {
+    let mut sut = TermSuffixIndex::new();
+    sut.add("CataLog");
+
+    // The stored term is lowercased, so it is returned in lowercase
+    // regardless of the casing used on insertion.
+    let stored = collect_set(sut.iter_contains("cat"));
+    assert_eq!(stored, HashSet::from(["catalog".to_string()]));
+
+    // Queries are lowercased too, so any casing of the needle hits.
+    for needle in ["CAT", "Cat", "cAt"] {
+        assert_eq!(
+            collect_set(sut.iter_contains(needle)),
+            HashSet::from(["catalog".to_string()]),
+            "needle={needle}",
+        );
+    }
+}
+
+#[test]
+fn remove_is_case_insensitive() {
+    let mut sut = TermSuffixIndex::new();
+    sut.add("Banana");
+
+    // Removing with a different casing must clear the lowercased entry.
+    sut.remove("baNANa");
+
+    assert_eq!(sut.iter_contains("ana").count(), 0);
+    assert_eq!(sut.iter_suffix("nana").count(), 0);
+}
+
+#[test]
+fn iter_wildcard_is_case_insensitive() {
+    let corpus = ["Concat", "SCAT", "cat"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+    let sut = build_index(&corpus);
+
+    // An uppercased pattern is lowercased before matching the
+    // (lowercased) stored terms.
+    let actual = collect_set(sut.iter_wildcard("*CAT").expect("'cat' is anchorable"));
+
+    let expected = HashSet::from(["concat".to_string(), "scat".to_string(), "cat".to_string()]);
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn add_lowercases_per_codepoint_not_with_final_sigma() {
+    // Greek "ΟΔΟΣ" (street) ends in a capital sigma. `str::to_lowercase`
+    // would apply the word-final rule and yield "οδος" (final sigma ς),
+    // but the index uses per-codepoint lowering (matching the C
+    // `unicode_tolower`), so the trailing sigma stays σ: "οδοσ".
+    let mut sut = TermSuffixIndex::new();
+    sut.add("ΟΔΟΣ");
+
+    // Probe the stored member through a suffix query: "οσ" is a registered
+    // suffix only if the term was lowered per codepoint.
+    let members = collect_set(sut.iter_suffix("οσ"));
+    assert_eq!(
+        members,
+        HashSet::from(["οδοσ".to_string()]),
+        "expected per-codepoint lowering (οδοσ), got {members:?}",
+    );
+    assert!(
+        !members.iter().any(|m| m.contains('ς')),
+        "final-sigma ς must not appear, got {members:?}",
+    );
+}
 
 #[cfg(not(miri))]
 mod fuzz {
@@ -338,7 +393,7 @@ mod fuzz {
 
             let actual = collect_set(sut.iter_contains(&needle));
 
-            prop_assert_eq!(actual, expected, "needle={:?} corpus={:?}", needle, corpus);
+            prop_assert_eq!(&actual, &expected, "needle={:?} corpus={:?}", needle, corpus);
         }
 
         #[test]
@@ -386,31 +441,6 @@ mod fuzz {
         }
 
         #[test]
-        fn removing_all_added_terms_clears_the_index(
-            corpus in proptest::collection::vec(term_strategy(), 1..=10),
-        ) {
-            let mut sut = TermSuffixIndex::new();
-            for t in &corpus {
-                sut.add(t);
-            }
-
-            // Remove in reverse insertion order — exercises the
-            // suffix-promotion path inside the index more often than
-            // forward removal.
-            for t in corpus.iter().rev() {
-                sut.remove(t);
-            }
-
-            // Every needle of length up to 4 yields zero hits.
-            for sample in ["a", "ab", "abc", "abcd"] {
-                prop_assert_eq!(sut.iter_contains(sample).count(), 0,
-                    "stale entries for needle={:?} corpus={:?}", sample, corpus);
-                prop_assert_eq!(sut.iter_suffix(sample).count(), 0,
-                    "stale entries for needle={:?} corpus={:?}", sample, corpus);
-            }
-        }
-
-        #[test]
         fn mixed_add_remove_matches_hashset_oracle(
             ops in proptest::collection::vec(
                 (any::<bool>(), "[a-z]{1,6}"),
@@ -443,5 +473,46 @@ mod fuzz {
             prop_assert_eq!(actual_suffix, expected_suffix,
                 "iter_suffix needle={:?}", needle);
         }
+
+        #[test]
+        fn removing_all_added_terms_clears_the_index(
+            corpus in proptest::collection::vec(term_strategy(), 1..=10),
+        ) {
+            let mut sut = TermSuffixIndex::new();
+            for t in &corpus {
+                sut.add(t);
+            }
+
+            // Remove in reverse insertion order — exercises the
+            // suffix-promotion path inside the index more often than
+            // forward removal.
+            for t in corpus.iter().rev() {
+                sut.remove(t);
+            }
+
+            // Every needle of length up to 4 yields zero hits.
+            for sample in ["a", "ab", "abc", "abcd"] {
+                prop_assert_eq!(sut.iter_contains(sample).count(), 0,
+                    "stale entries for needle={:?} corpus={:?}", sample, corpus);
+                prop_assert_eq!(sut.iter_suffix(sample).count(), 0,
+                    "stale entries for needle={:?} corpus={:?}", sample, corpus);
+            }
+        }
     }
+}
+
+fn build_index(corpus: &[String]) -> TermSuffixIndex {
+    let mut sut = TermSuffixIndex::new();
+    for t in corpus {
+        sut.add(t);
+    }
+    sut
+}
+
+fn collect_set<I>(it: I) -> HashSet<String>
+where
+    I: Iterator,
+    I::Item: AsRef<str>,
+{
+    it.map(|r| r.as_ref().to_string()).collect()
 }

--- a/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
@@ -199,6 +199,114 @@ fn iter_suffix_yields_one_hit_per_matching_term() {
     assert_eq!(actual_set, expected);
 }
 
+#[test]
+fn iter_wildcard_end_token_uses_suffix_semantics() {
+    let corpus = ["concat", "scat", "catalog", "cat"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+    let sut = build_index(&corpus);
+
+    let actual = collect_set(sut.iter_wildcard("*cat").expect("'cat' is anchorable"));
+
+    let expected = HashSet::from(["concat".to_string(), "scat".to_string(), "cat".to_string()]);
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn iter_wildcard_middle_tokens_anchor_on_best_literal() {
+    let corpus = ["abide", "abcde", "abxxcd", "abandoned", "cdrom"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+    let sut = build_index(&corpus);
+
+    let actual = collect_set(
+        sut.iter_wildcard("ab*cd")
+            .expect("'ab' and 'cd' are anchorable"),
+    );
+
+    let expected = HashSet::from(["abxxcd".to_string()]);
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn iter_wildcard_multibyte_anchor_matches() {
+    let corpus = ["日本語", "日本酒", "本語"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+    let sut = build_index(&corpus);
+
+    let actual = collect_set(sut.iter_wildcard("*本語").expect("two codepoints anchor"));
+
+    let expected = HashSet::from(["日本語".to_string(), "本語".to_string()]);
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn iter_wildcard_question_mark_is_byte_wise_for_multibyte() {
+    // The matcher is byte-wise, so `?` consumes one *byte*, not one
+    // codepoint. `é` (U+00E9) is two UTF-8 bytes: `ab*c?` matches only its
+    // first byte, the second has nothing to pair with, and the term is
+    // dropped. This is the accepted approximation — an ASCII tail matches.
+    let corpus = ["abxc\u{e9}", "abxcd"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+    let sut = build_index(&corpus);
+
+    let actual = collect_set(sut.iter_wildcard("ab*c?").expect("'ab' is anchorable"));
+
+    // The ASCII-tailed term matches; the `é`-tailed one is missed.
+    assert_eq!(actual, HashSet::from(["abxcd".to_string()]));
+}
+
+#[test]
+fn iter_wildcard_question_mark_outside_anchor_is_honored() {
+    let corpus = ["abcd", "bcd", "zbxcd"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+    let sut = build_index(&corpus);
+
+    // The `?b` token cannot anchor (contains `?`), so `cd` is chosen;
+    // the full-pattern filter must still enforce that `?` consumes
+    // exactly one character.
+    let actual = collect_set(sut.iter_wildcard("?b*cd").expect("'cd' is anchorable"));
+
+    let expected = HashSet::from(["abcd".to_string(), "zbxcd".to_string()]);
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn iter_wildcard_trailing_star_uses_contains_semantics() {
+    let corpus = ["scatter", "category", "dog"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+    let sut = build_index(&corpus);
+
+    let actual = collect_set(sut.iter_wildcard("*cat*").expect("'cat' is anchorable"));
+
+    let expected = HashSet::from(["scatter".to_string(), "category".to_string()]);
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn iter_wildcard_without_anchorable_token_reports_none() {
+    let sut = build_index(&["abc".to_string()]);
+
+    // `?`-bearing tokens and bare stars cannot anchor a literal trie
+    // lookup. (Single-char tokens can, now that the floor is gone.)
+    for pattern in ["*", "a?c", "??*", ""] {
+        assert!(
+            sut.iter_wildcard(pattern).is_none(),
+            "pattern={pattern:?} must request the fallback scan"
+        );
+    }
+}
+
 // --- Proptest fuzz
 
 #[cfg(not(miri))]
@@ -208,8 +316,9 @@ mod fuzz {
     use super::*;
 
     /// Kept small so fuzz cases land in a regime where suffix collisions are common.
+    /// Includes `é` (multibyte) to exercise the index against non-ASCII terms.
     fn term_strategy() -> impl Strategy<Value = String> {
-        "[a-z]{1,8}"
+        "[a-zé]{1,8}"
     }
 
     proptest! {
@@ -247,6 +356,33 @@ mod fuzz {
             let actual = collect_set(sut.iter_suffix(&needle));
 
             prop_assert_eq!(actual, expected, "needle={:?} corpus={:?}", needle, corpus);
+        }
+
+        #[test]
+        fn iter_wildcard_matches_full_scan_oracle(
+            corpus in proptest::collection::vec(term_strategy(), 1..=20),
+            pattern in "[ab*?]{0,8}",
+        ) {
+            use rqe_wildcard::{MatchOutcome, WildcardPattern};
+
+            let sut = build_index(&corpus);
+
+            // `None` requests the fallback scan — out of scope here. The
+            // oracle uses the same byte-wise matcher iter_wildcard does, so
+            // this pins the anchor-selection logic, not the matcher itself.
+            if let Some(matches) = sut.iter_wildcard(&pattern) {
+                let parsed = WildcardPattern::parse(pattern.as_bytes());
+                let expected = corpus
+                    .iter()
+                    .filter(|t| parsed.matches(t.as_bytes()) == MatchOutcome::Match)
+                    .cloned()
+                    .collect::<HashSet<_>>();
+
+                let actual = collect_set(matches);
+
+                prop_assert_eq!(actual, expected,
+                    "pattern={:?} corpus={:?}", pattern, corpus);
+            }
         }
 
         #[test]

--- a/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
@@ -60,8 +60,8 @@ fn add_then_remove_clears_the_index() {
 #[test]
 fn iter_contains_yields_terms_containing_needle() {
     let corpus = ["cat", "catalog", "category", "concat", "scat", "scatter"]
-        .iter()
-        .map(|s| s.to_string())
+        .into_iter()
+        .map(String::from)
         .collect::<Vec<_>>();
     let sut = build_index(&corpus);
     let expected = corpus.iter().cloned().collect::<HashSet<_>>();
@@ -74,8 +74,8 @@ fn iter_contains_yields_terms_containing_needle() {
 #[test]
 fn iter_suffix_and_iter_contains_empty_needle_yield_no_matches() {
     let corpus = ["cat", "dog"]
-        .iter()
-        .map(|s| s.to_string())
+        .into_iter()
+        .map(String::from)
         .collect::<Vec<_>>();
     let sut = build_index(&corpus);
 
@@ -149,13 +149,13 @@ fn iter_suffix_yields_one_hit_per_matching_term() {
 #[test]
 fn iter_suffix_yields_terms_ending_with_needle() {
     let corpus = ["cat", "catalog", "category", "concat", "scat", "scatter"]
-        .iter()
-        .map(|s| s.to_string())
+        .into_iter()
+        .map(String::from)
         .collect::<Vec<_>>();
     let sut = build_index(&corpus);
     let expected = ["cat", "concat", "scat"]
-        .iter()
-        .map(|s| s.to_string())
+        .into_iter()
+        .map(String::from)
         .collect::<HashSet<_>>();
 
     let actual = collect_set(sut.iter_suffix("cat"));
@@ -166,8 +166,8 @@ fn iter_suffix_yields_terms_ending_with_needle() {
 #[test]
 fn iter_wildcard_end_token_uses_suffix_semantics() {
     let corpus = ["concat", "scat", "catalog", "cat"]
-        .iter()
-        .map(|s| s.to_string())
+        .into_iter()
+        .map(String::from)
         .collect::<Vec<_>>();
     let sut = build_index(&corpus);
 
@@ -180,8 +180,8 @@ fn iter_wildcard_end_token_uses_suffix_semantics() {
 #[test]
 fn iter_wildcard_middle_tokens_anchor_on_best_literal() {
     let corpus = ["abide", "abcde", "abxxcd", "abandoned", "cdrom"]
-        .iter()
-        .map(|s| s.to_string())
+        .into_iter()
+        .map(String::from)
         .collect::<Vec<_>>();
     let sut = build_index(&corpus);
 
@@ -197,8 +197,8 @@ fn iter_wildcard_middle_tokens_anchor_on_best_literal() {
 #[test]
 fn iter_wildcard_multibyte_anchor_matches() {
     let corpus = ["日本語", "日本酒", "本語"]
-        .iter()
-        .map(|s| s.to_string())
+        .into_iter()
+        .map(String::from)
         .collect::<Vec<_>>();
     let sut = build_index(&corpus);
 
@@ -215,8 +215,8 @@ fn iter_wildcard_question_mark_is_byte_wise_for_multibyte() {
     // first byte, the second has nothing to pair with, and the term is
     // dropped. This is the accepted approximation — an ASCII tail matches.
     let corpus = ["abxc\u{e9}", "abxcd"]
-        .iter()
-        .map(|s| s.to_string())
+        .into_iter()
+        .map(String::from)
         .collect::<Vec<_>>();
     let sut = build_index(&corpus);
 
@@ -229,8 +229,8 @@ fn iter_wildcard_question_mark_is_byte_wise_for_multibyte() {
 #[test]
 fn iter_wildcard_question_mark_outside_anchor_is_honored() {
     let corpus = ["abcd", "bcd", "zbxcd"]
-        .iter()
-        .map(|s| s.to_string())
+        .into_iter()
+        .map(String::from)
         .collect::<Vec<_>>();
     let sut = build_index(&corpus);
 
@@ -246,8 +246,8 @@ fn iter_wildcard_question_mark_outside_anchor_is_honored() {
 #[test]
 fn iter_wildcard_trailing_star_uses_contains_semantics() {
     let corpus = ["scatter", "category", "dog"]
-        .iter()
-        .map(|s| s.to_string())
+        .into_iter()
+        .map(String::from)
         .collect::<Vec<_>>();
     let sut = build_index(&corpus);
 
@@ -328,8 +328,8 @@ fn remove_is_case_insensitive() {
 #[test]
 fn iter_wildcard_is_case_insensitive() {
     let corpus = ["Concat", "SCAT", "cat"]
-        .iter()
-        .map(|s| s.to_string())
+        .into_iter()
+        .map(String::from)
         .collect::<Vec<_>>();
     let sut = build_index(&corpus);
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: The `term_suffix_index` crate (the in-progress Rust port of the C `WITHSUFFIXTRIE` suffix index) supported only substring (`iter_contains`) and exact ends-with (`iter_suffix`) lookups, matched case-sensitively, and left `mem_usage` as a `todo!()`. Callers were expected to fold case and dedupe upstream.
2. **Change**:
   - Add `iter_wildcard` — glob matching (`*` runs, `?` single byte) seeded by an anchor token chosen to minimize the candidate set, then filtered through the shared `rqe_wildcard` byte-wise matcher.
   - Lowercase every term and query internally via per-codepoint `unicode_tolower` (matching the C folding semantics, deliberately *not* `str::to_lowercase` so the Greek final-sigma rule does not apply). Lookups are now case-insensitive and the index owns normalization.
   - Implement `mem_usage` as an O(1) read of the underlying `StrTrieMap`'s cached counter (parity with the C suffix accounting, which likewise floors below the term-bytes payload).
   - Derive `Debug` / `Default`; drop the unused `keys` helper and the recursive-visitor path; route `contains`/`wildcard` through `prefixed_iter`.
   - Documentation: note that `iter_contains` / `iter_wildcard` may yield a term once per matching suffix entry; intra-doc-link cleanups.
3. **Outcome**: The crate now covers the three lookup shapes the C suffix index exposes (contains, ends-with, wildcard) with case-insensitive matching, backed by focused unit tests, multibyte/case-fold cases, and a full-scan property oracle for wildcard anchor selection.

#### Which additional issues this PR fixes
- None.

#### Main objects this PR modified
1. `term_suffix_index` crate — `TermSuffixIndex` (`add`, `remove`, `iter_contains`, `iter_suffix`, new `iter_wildcard`, `mem_usage`), private `choose_token` anchor heuristic, `TermRefs`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal-only: the crate is not yet wired into the C command path, so there is no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
