### PR TITLE
[MOD-16423] Document priority-queue MPL-2.0 license

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,11 @@
+# Third-Party Notices
+
+This file records package-specific third-party license usage that must be
+reflected in release dependency and SBOM inventories. RediSearch's Rust
+workspace license policy is enforced by `cargo deny check licenses` using
+`src/redisearch_rs/deny.toml`.
+
+| Package | Version | License | Use |
+| --- | --- | --- | --- |
+| `cbindgen` | `0.28.0`, `0.29.2` | `MPL-2.0` | Generates C and C++ headers from Rust FFI crates in release branches that still use cbindgen. |
+| `priority-queue` | `2.7.0` | `MPL-2.0` | Provides the double-ended priority queue used by `COLLECT DISTINCT` to deduplicate by projected value while retaining the best `SORTBY` representative. |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -7,5 +7,4 @@ workspace license policy is enforced by `cargo deny check licenses` using
 
 | Package | Version | License | Use |
 | --- | --- | --- | --- |
-| `cbindgen` | `0.28.0`, `0.29.2` | `MPL-2.0` | Generates C and C++ headers from Rust FFI crates in release branches that still use cbindgen. |
 | `priority-queue` | `2.7.0` | `MPL-2.0` | Provides the double-ended priority queue used by `COLLECT DISTINCT` to deduplicate by projected value while retaining the best `SORTBY` representative. |

--- a/src/redisearch_rs/deny.toml
+++ b/src/redisearch_rs/deny.toml
@@ -15,6 +15,9 @@ Since there are no known vulnerabilities (nor ways to remove it), it's safe to a
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
 # List of explicitly allowed licenses
+# Package-specific MPL-2.0 usage that must be reflected in release dependency
+# and SBOM inventories is documented in the repository-level
+# THIRD_PARTY_NOTICES.md.
 allow = [
     # OSI-approved licenses
     "MIT",


### PR DESCRIPTION
## Describe the changes in the pull request

Current: The MPL-2.0 usage of `priority-queue` is called out in Jira/review context for the COLLECT DISTINCT work, but the repository does not have a repository-level third-party notice entry for it.

Change: Add `THIRD_PARTY_NOTICES.md` documenting `priority-queue` with license `MPL-2.0`, and point the Rust `deny.toml` license policy at the repository-level notice.

Outcome: The master branch tracks the dependency/license metadata for the planned COLLECT DISTINCT dependency. `cbindgen` is not used on current `master`; it should be added only in backport PRs for release branches that still use `cbindgen`.

#### Which additional issues this PR fixes
1. MOD-16423

#### Main objects this PR modified
1. `THIRD_PARTY_NOTICES.md`
2. `src/redisearch_rs/deny.toml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
