### PR TITLE
MOD-16435 redis_json_api: lending iterator for ResultsIter

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1994,6 +1994,7 @@ name = "redis_json_api"
 version = "0.0.1"
 dependencies = [
  "ffi",
+ "lending-iterator",
  "redis-module",
  "thiserror",
  "workspace_hack",

--- a/src/redisearch_rs/redis_json_api/Cargo.toml
+++ b/src/redisearch_rs/redis_json_api/Cargo.toml
@@ -12,6 +12,7 @@ doctest = false
 ffi.workspace = true
 thiserror.workspace = true
 workspace_hack.workspace = true
+lending-iterator.workspace = true
 
 [target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
 # Statically link to the libclang on aarch64-unknown-linux-musl,

--- a/src/redisearch_rs/redis_json_api/src/results.rs
+++ b/src/redisearch_rs/redis_json_api/src/results.rs
@@ -9,6 +9,7 @@
 
 use super::RedisJsonApi;
 use crate::{JsonValueRef, SerializeError};
+use lending_iterator::prelude::*;
 use redis_module::RedisString;
 use std::ffi::c_void;
 use std::ptr::NonNull;
@@ -115,11 +116,17 @@ impl<'a> ResultsIter<'a> {
             Err(SerializeError)
         }
     }
+}
 
-    /// Returns the next value in the iterator.
-    ///
-    /// Returns `None` when all values have been consumed.
-    pub fn next(&self) -> Option<JsonValueRef<'_>> {
+// Why do we need a crate? Well: <https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats>
+#[gat]
+impl<'a> LendingIterator for ResultsIter<'a> {
+    type Item<'next>
+    where
+        Self: 'next,
+    = JsonValueRef<'next>;
+
+    fn next(&mut self) -> Option<Self::Item<'_>> {
         // Safety: `ptr` is valid by construction.
         let raw = unsafe { (self.next)(self.ptr.as_ptr()) };
 


### PR DESCRIPTION
implements `LendingIterator` from the `lending-iterator` crate for `ResultsIter` instead of having a "hand-rolled" `next` method. This allows us to actually consume the type like an iterator downstream.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
