### PR TITLE
redis_json_api: ExactIterator impl for KeyValues iter

### DIFF
--- a/src/redisearch_rs/redis_json_api/src/key_values.rs
+++ b/src/redisearch_rs/redis_json_api/src/key_values.rs
@@ -14,19 +14,22 @@ use std::{ffi::c_void, ptr::NonNull};
 
 // An iterators over key value pairs if the json value is an object
 pub struct KeyValuesIterator<'a> {
-    pub(crate) ptr: NonNull<c_void>,
+    ptr: NonNull<c_void>,
     // Get the next key-value pair
     // The caller gains ownership of `key_name`
     // The caller must pass 'ptr' which was allocated with allocJson
-    pub(crate) next: unsafe extern "C" fn(
+    next: unsafe extern "C" fn(
         iter: ffi::JSONKeyValuesIterator,
         key_name: *mut *mut ffi::RedisModuleString,
         ptr: ffi::RedisJSONPtr,
     ) -> i32,
     // Free the iterator
-    pub(crate) free: unsafe extern "C" fn(ptr: ffi::JSONKeyValuesIterator),
-    pub(crate) ctx: *mut ffi::RedisModuleCtx,
-    pub(crate) api: &'a RedisJsonApi,
+    free: unsafe extern "C" fn(ptr: ffi::JSONKeyValuesIterator),
+    ctx: *mut ffi::RedisModuleCtx,
+    api: &'a RedisJsonApi,
+    // Remaining items. Probed at construction from the source object via
+    // `getLen`.
+    remaining: usize,
 }
 
 impl Drop for KeyValuesIterator<'_> {
@@ -41,6 +44,8 @@ impl<'a> KeyValuesIterator<'a> {
     ///
     /// Only available with RedisJSON API v4 and later.
     ///
+    /// `len` is the number of key-value pairs the iterator will yield.
+    ///
     /// # Safety
     ///
     /// 1. `ctx` must be a valid Redis module context.
@@ -49,6 +54,7 @@ impl<'a> KeyValuesIterator<'a> {
         ptr: NonNull<c_void>,
         ctx: *mut ffi::RedisModuleCtx,
         api: &'a RedisJsonApi,
+        len: usize,
     ) -> Self {
         let vtable = api.vtable();
         let next = vtable
@@ -64,6 +70,7 @@ impl<'a> KeyValuesIterator<'a> {
             free,
             ctx,
             api,
+            remaining: len,
         }
     }
 }
@@ -83,10 +90,18 @@ impl<'a> Iterator for KeyValuesIterator<'a> {
 
         if status == ffi::REDISMODULE_OK as i32 {
             let key = RedisString::from_redis_module_string(self.ctx.cast(), key.cast());
+            self.remaining = self.remaining.saturating_sub(1);
             Some((key, value))
         } else {
             debug_assert!(key.is_null());
+            self.remaining = 0;
             None
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
 }
+
+impl ExactSizeIterator for KeyValuesIterator<'_> {}

--- a/src/redisearch_rs/redis_json_api/src/value.rs
+++ b/src/redisearch_rs/redis_json_api/src/value.rs
@@ -263,8 +263,10 @@ impl<'a> JsonValueRef<'a> {
         // TODO this should have been a mutable pointer (we mutate the underlying iterator in subsequent calls after all)
         let ptr = NonNull::new(ptr.cast_mut())?;
 
+        let len = self.len().unwrap_or(0);
+
         // Safety: (1.): ensured by caller. (2.): we obtained this pointer from `getKeyValues`.
-        Some(unsafe { KeyValuesIterator::from_non_null(ptr, ctx, self.api) })
+        Some(unsafe { KeyValuesIterator::from_non_null(ptr, ctx, self.api, len) })
     }
 
     /// Returns an iterator over values matched by `path`.


### PR DESCRIPTION
Implements `ExactIterator` for `KeyValues` so that we can collect it into a `Box` instead of having to collect it into a `Vec` first and then convert to a `Box`. This also makes collecting the iterator more efficient in general. The exact size is known, it's just a question of propagating that info into the trait implementation.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
