### PR TITLE
[8.8] Use relaxed memory ordering for the request timedOut signal flag (#9749)

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -29,10 +29,14 @@
 #ifdef __cplusplus
 #include <atomic>
 #define RS_Atomic(T) std::atomic<T>
+#define RS_AtomicLoadRelaxed(p)     ((p)->load(std::memory_order_relaxed))
+#define RS_AtomicStoreRelaxed(p, v) ((p)->store((v), std::memory_order_relaxed))
 extern "C" {
 #else
 #define RS_Atomic(T) _Atomic(T)
 #include <stdatomic.h>
+#define RS_AtomicLoadRelaxed(p)     atomic_load_explicit((p), memory_order_relaxed)
+#define RS_AtomicStoreRelaxed(p, v) atomic_store_explicit((p), (v), memory_order_relaxed)
 #endif
 
 #define DEFAULT_LIMIT 10
@@ -631,8 +635,12 @@ void SetSearchCtx(RedisSearchCtx *sctx, const AREQ *req);
 // Allows calling parseProfileArgs from reply_empty.c
 int parseProfileArgs(RedisModuleString **argv, int argc, AREQ *r);
 
-bool AREQ_TimedOut(AREQ *req);
-void AREQ_SetTimedOut(AREQ *req);
+static inline bool AREQ_TimedOut(AREQ *req) {
+  return RS_AtomicLoadRelaxed(&req->syncCtx.timedOut);
+}
+static inline void AREQ_SetTimedOut(AREQ *req) {
+  RS_AtomicStoreRelaxed(&req->syncCtx.timedOut, true);
+}
 #ifdef ENABLE_ASSERT
 // SyncPointStopFn predicate adapter for AREQ_TimedOut. Pass the AREQ as `arg`
 // to SyncPoint_WaitUntil to release the wait when the request is timed out.
@@ -642,7 +650,9 @@ bool areq_timed_out(void *arg);
 /* True when this AREQ uses the BG-thread / timeout-callback claim handshake
  * around AggregateResults (TryClaim/Signal/Wait). Currently set only on the
  * coordinator AREQ under RETURN-STRICT; all other paths skip the protocol. */
-bool AREQ_RequiresThreadsSyncResults(const AREQ *req);
+static inline bool AREQ_RequiresThreadsSyncResults(const AREQ *req) {
+  return req->syncCtx.requiresAggregateResultsSync;
+}
 
 /* TryClaim: atomic CAS on `aggregatingResults`; winner runs AggregateResults.
  * Signal: called by winner at completion. Wait: called by loser, blocks until Signal.

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -29,14 +29,13 @@
 #ifdef __cplusplus
 #include <atomic>
 #define RS_Atomic(T) std::atomic<T>
-#define RS_AtomicLoadRelaxed(p)     ((p)->load(std::memory_order_relaxed))
-#define RS_AtomicStoreRelaxed(p, v) ((p)->store((v), std::memory_order_relaxed))
+#define RS_AtomicBoolLoadRelaxed(p)     (((std::atomic<bool> *)(p))->load(std::memory_order_relaxed))
+#define RS_AtomicBoolStoreRelaxed(p, v) (((std::atomic<bool> *)(p))->store((v), std::memory_order_relaxed))
 extern "C" {
 #else
 #define RS_Atomic(T) _Atomic(T)
-#include <stdatomic.h>
-#define RS_AtomicLoadRelaxed(p)     atomic_load_explicit((p), memory_order_relaxed)
-#define RS_AtomicStoreRelaxed(p, v) atomic_store_explicit((p), (v), memory_order_relaxed)
+#define RS_AtomicBoolLoadRelaxed(p)     __atomic_load_n((bool *)(p), __ATOMIC_RELAXED)
+#define RS_AtomicBoolStoreRelaxed(p, v) __atomic_store_n((bool *)(p), (v), __ATOMIC_RELAXED)
 #endif
 
 #define DEFAULT_LIMIT 10
@@ -636,10 +635,10 @@ void SetSearchCtx(RedisSearchCtx *sctx, const AREQ *req);
 int parseProfileArgs(RedisModuleString **argv, int argc, AREQ *r);
 
 static inline bool AREQ_TimedOut(AREQ *req) {
-  return RS_AtomicLoadRelaxed(&req->syncCtx.timedOut);
+  return RS_AtomicBoolLoadRelaxed(&req->syncCtx.timedOut);
 }
 static inline void AREQ_SetTimedOut(AREQ *req) {
-  RS_AtomicStoreRelaxed(&req->syncCtx.timedOut, true);
+  RS_AtomicBoolStoreRelaxed(&req->syncCtx.timedOut, true);
 }
 #ifdef ENABLE_ASSERT
 // SyncPointStopFn predicate adapter for AREQ_TimedOut. Pass the AREQ as `arg`

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1102,21 +1102,10 @@ AREQ *AREQ_New(void) {
   return req;
 }
 
-bool AREQ_TimedOut(AREQ *req) {
-  return atomic_load_explicit(&req->syncCtx.timedOut, memory_order_acquire);
-}
-
-void AREQ_SetTimedOut(AREQ *req) {
-  atomic_store_explicit(&req->syncCtx.timedOut, true, memory_order_release);
-}
-
-bool AREQ_RequiresThreadsSyncResults(const AREQ *req) {
-  return req->syncCtx.requiresAggregateResultsSync;
-}
-
 bool AREQ_TryClaimAggregateResults(AREQ *req) {
   bool expected = false;
-  return atomic_compare_exchange_strong(&req->syncCtx.aggregatingResults, &expected, true);
+  return atomic_compare_exchange_strong_explicit(&req->syncCtx.aggregatingResults, &expected, true,
+                                                 memory_order_relaxed, memory_order_relaxed);
 }
 
 void AREQ_SignalAggregateResultsComplete(AREQ *req) {
@@ -1135,7 +1124,7 @@ void AREQ_WaitForAggregateResultsComplete(AREQ *req) {
 }
 
 void AREQ_ResetAggregateResultsClaim(AREQ *req) {
-  atomic_store_explicit(&req->syncCtx.aggregatingResults, false, memory_order_release);
+  RS_AtomicStoreRelaxed(&req->syncCtx.aggregatingResults, false);
   pthread_mutex_lock(&req->syncCtx.aggregateResultsLock);
   req->syncCtx.aggregateResultsDone = false;
   pthread_mutex_unlock(&req->syncCtx.aggregateResultsLock);

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1124,7 +1124,7 @@ void AREQ_WaitForAggregateResultsComplete(AREQ *req) {
 }
 
 void AREQ_ResetAggregateResultsClaim(AREQ *req) {
-  RS_AtomicStoreRelaxed(&req->syncCtx.aggregatingResults, false);
+  RS_AtomicBoolStoreRelaxed(&req->syncCtx.aggregatingResults, false);
   pthread_mutex_lock(&req->syncCtx.aggregateResultsLock);
   req->syncCtx.aggregateResultsDone = false;
   pthread_mutex_unlock(&req->syncCtx.aggregateResultsLock);

--- a/src/coord/coord_request_ctx.c
+++ b/src/coord/coord_request_ctx.c
@@ -104,7 +104,7 @@ void *CoordRequestCtx_GetRequest(CoordRequestCtx *ctx) {
 }
 
 void CoordRequestCtx_SetTimedOut(CoordRequestCtx *ctx) {
-  RS_AtomicStoreRelaxed(&ctx->timedOut, true);
+  RS_AtomicBoolStoreRelaxed(&ctx->timedOut, true);
   // Also propagate to the underlying request if set
   if (ctx->type == COMMAND_HYBRID) {
     if (ctx->hreq) HybridRequest_SetTimedOut(ctx->hreq);

--- a/src/coord/coord_request_ctx.c
+++ b/src/coord/coord_request_ctx.c
@@ -103,12 +103,8 @@ void *CoordRequestCtx_GetRequest(CoordRequestCtx *ctx) {
   }
 }
 
-bool CoordRequestCtx_TimedOut(CoordRequestCtx *ctx) {
-  return atomic_load_explicit(&ctx->timedOut, memory_order_acquire);
-}
-
 void CoordRequestCtx_SetTimedOut(CoordRequestCtx *ctx) {
-  atomic_store_explicit(&ctx->timedOut, true, memory_order_release);
+  RS_AtomicStoreRelaxed(&ctx->timedOut, true);
   // Also propagate to the underlying request if set
   if (ctx->type == COMMAND_HYBRID) {
     if (ctx->hreq) HybridRequest_SetTimedOut(ctx->hreq);

--- a/src/coord/coord_request_ctx.h
+++ b/src/coord/coord_request_ctx.h
@@ -89,7 +89,7 @@ void *CoordRequestCtx_GetRequest(CoordRequestCtx *ctx);
  * Check if the coordinator request has timed out.
  */
 static inline bool CoordRequestCtx_TimedOut(CoordRequestCtx *ctx) {
-  return RS_AtomicLoadRelaxed(&ctx->timedOut);
+  return RS_AtomicBoolLoadRelaxed(&ctx->timedOut);
 }
 
 /**

--- a/src/coord/coord_request_ctx.h
+++ b/src/coord/coord_request_ctx.h
@@ -88,7 +88,9 @@ void *CoordRequestCtx_GetRequest(CoordRequestCtx *ctx);
 /**
  * Check if the coordinator request has timed out.
  */
-bool CoordRequestCtx_TimedOut(CoordRequestCtx *ctx);
+static inline bool CoordRequestCtx_TimedOut(CoordRequestCtx *ctx) {
+  return RS_AtomicLoadRelaxed(&ctx->timedOut);
+}
 
 /**
  * Set the timeout flag on the coordinator request context.

--- a/src/coord/rmr/chan.c
+++ b/src/coord/rmr/chan.c
@@ -168,7 +168,7 @@ void *MRChannel_PopWithTimeout(MRChannel *chan, const struct timespec *abstimeMo
   pthread_mutex_lock(&chan->lock);
   while (!chan->size) {
     // Sticky abort flipped by another thread (e.g. timeout callback + MRChannel_WakeAbort).
-    if (abortFlag && atomic_load_explicit(abortFlag, memory_order_acquire)) goto aborted;
+    if (abortFlag && atomic_load_explicit(abortFlag, memory_order_relaxed)) goto aborted;
     // One-shot unblock via MRChannel_Unblock; reset for the next pop.
     if (!chan->wait) { chan->wait = true; goto aborted; }
     // Park until pushed/broadcast/deadline. Re-checks all conditions on wake.

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -254,14 +254,6 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
     return hybridReq;
 }
 
-bool HybridRequest_TimedOut(HybridRequest *req) {
-  return atomic_load_explicit(&req->syncCtx.timedOut, memory_order_acquire);
-}
-
-void HybridRequest_SetTimedOut(HybridRequest *req) {
-  atomic_store_explicit(&req->syncCtx.timedOut, true, memory_order_release);
-}
-
 void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, RedisModuleString **argv, int argc) {
   // skip command and index name
   const int step = argc > 2 ? 2 : argc;

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -81,10 +81,10 @@ typedef struct HybridRequest {
 
 // Timeout helper functions for HybridRequest (mirrors AREQ pattern)
 static inline bool HybridRequest_TimedOut(HybridRequest *req) {
-  return RS_AtomicLoadRelaxed(&req->syncCtx.timedOut);
+  return RS_AtomicBoolLoadRelaxed(&req->syncCtx.timedOut);
 }
 static inline void HybridRequest_SetTimedOut(HybridRequest *req) {
-  RS_AtomicStoreRelaxed(&req->syncCtx.timedOut, true);
+  RS_AtomicBoolStoreRelaxed(&req->syncCtx.timedOut, true);
 }
 
 // Cursor mutex wrappers for synchronizing cursor creation with timeout callback

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -80,8 +80,12 @@ typedef struct HybridRequest {
 } HybridRequest;
 
 // Timeout helper functions for HybridRequest (mirrors AREQ pattern)
-bool HybridRequest_TimedOut(HybridRequest *req);
-void HybridRequest_SetTimedOut(HybridRequest *req);
+static inline bool HybridRequest_TimedOut(HybridRequest *req) {
+  return RS_AtomicLoadRelaxed(&req->syncCtx.timedOut);
+}
+static inline void HybridRequest_SetTimedOut(HybridRequest *req) {
+  RS_AtomicStoreRelaxed(&req->syncCtx.timedOut, true);
+}
 
 // Cursor mutex wrappers for synchronizing cursor creation with timeout callback
 static inline void HybridRequest_LockCursors(HybridRequest *req) {


### PR DESCRIPTION
## Describe the changes in the pull request

Backport of #9749 and its follow-up fix #9845 to the `8.8` branch.

1. **Current:** The request `timedOut` signal flag and the aggregate-claim CAS use `memory_order_acquire`/`release` (and the default seq_cst CAS). The timeout-flag accessors are out-of-line functions, and `aggregate.h` pulls in `<stdatomic.h>`.
2. **Change:**
   - Relax the `timedOut` flag accessors and the aggregate-claim CAS to `memory_order_relaxed` (publication still happens through the `aggregateResultsLock`/`aggregateResultsCond` pair).
   - Inline the trivial timeout-flag accessors (`AREQ_TimedOut`/`AREQ_SetTimedOut`, `HybridRequest_TimedOut`/`SetTimedOut`, `CoordRequestCtx_TimedOut`) so the compiler can fold the atomic load into polling loops.
   - Replace `<stdatomic.h>` with the `__atomic_*_n` compiler builtins via the `RS_AtomicBool{Load,Store}Relaxed` macros (#9845), avoiding libclang/bindgen issues during FFI generation.
3. **Outcome:** Lower per-poll overhead on the timeout hot path (notably ARM64/PowerPC) with no behavior change.

#### Which additional issues this PR fixes
1. Backport of #9749
2. Backport of #9845

#### Main objects this PR modified
1. `src/aggregate/aggregate.h`, `src/aggregate/aggregate_request.c`
2. `src/coord/coord_request_ctx.{c,h}`, `src/coord/rmr/chan.c`
3. `src/hybrid/hybrid_request.{c,h}`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Performance improvement: relaxed memory ordering for the request timeout signal flag reduces per-poll overhead on the timeout hot path.

---
Co-authored by [Augment Code](https://www.augmentcode.com/?utm_source=github&utm_medium=pr&utm_campaign=backport)
