### PR TITLE
redis_json_api: use KeyFlags instead of u32 for open_key_with_flags

### DIFF
--- a/src/redisearch_rs/redis_json_api/src/lib.rs
+++ b/src/redisearch_rs/redis_json_api/src/lib.rs
@@ -13,7 +13,7 @@ mod results;
 mod value;
 
 use ffi::RedisJSONAPI as RedisJsonApiVTable;
-use redis_module::RedisString;
+use redis_module::{RedisString, key::KeyFlags};
 use std::{error::Error, ffi::CStr, fmt};
 
 pub use key_values::KeyValuesIterator;
@@ -149,7 +149,7 @@ impl RedisJsonApi {
         &self,
         ctx: *mut ffi::RedisModuleCtx,
         key_name: &RedisString,
-        flags: i32,
+        flags: KeyFlags,
     ) -> Option<JsonValueRef<'_>> {
         let vtable = self.vtable();
         let open_key_with_flags = vtable
@@ -157,7 +157,13 @@ impl RedisJsonApi {
             .expect("RedisJSON API function `openKeyWithFlags` not available");
 
         // Safety: ensured by caller (1.)
-        let ptr = unsafe { open_key_with_flags(ctx, key_name.inner.cast(), flags) };
+        let ptr = unsafe {
+            open_key_with_flags(
+                ctx,
+                key_name.inner.cast(),
+                flags.bits() | redis_module::raw::REDISMODULE_READ as i32,
+            )
+        };
 
         if ptr.is_null() {
             None


### PR DESCRIPTION
Use the proper, typed `KeyFlags` type as the argument to `open_key_with_flags` now that the variants we need have landed upstream.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
