### PR TITLE
MOD-16433 redis_json_api: test mock implementation

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1996,6 +1996,7 @@ dependencies = [
  "ffi",
  "lending-iterator",
  "redis-module",
+ "serde_json",
  "thiserror",
  "workspace_hack",
 ]
@@ -2610,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -196,6 +196,7 @@ rand = "0.10.1"
 rmp-serde = "1.3.1"
 rustc-hash = "2.1.1"
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.150"
 smallvec = "1.15.1"
 strsim = "0.11.1"
 strum = { version = "0.27.2", features = ["derive"] }

--- a/src/redisearch_rs/redis_json_api/Cargo.toml
+++ b/src/redisearch_rs/redis_json_api/Cargo.toml
@@ -13,6 +13,7 @@ ffi.workspace = true
 thiserror.workspace = true
 workspace_hack.workspace = true
 lending-iterator.workspace = true
+serde_json = { workspace = true, optional = true }
 
 [target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
 # Statically link to the libclang on aarch64-unknown-linux-musl,
@@ -25,6 +26,9 @@ default-features = false
 [target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
 workspace = true
 default-features = true
+
+[features]
+test-mock = ["dep:serde_json"]
 
 [lints]
 workspace = true

--- a/src/redisearch_rs/redis_json_api/src/lib.rs
+++ b/src/redisearch_rs/redis_json_api/src/lib.rs
@@ -8,6 +8,8 @@
 */
 
 mod key_values;
+#[cfg(feature = "test-mock")]
+pub mod mock;
 mod path;
 mod results;
 mod value;
@@ -69,6 +71,12 @@ impl RedisJsonApi {
         }
 
         Some(Self { vtable })
+    }
+
+    /// Construct an API handle from a caller-provided vtable.
+    #[cfg(feature = "test-mock")]
+    pub const fn from_vtable(vtable: &'static RedisJsonApiVTable) -> Self {
+        Self { vtable }
     }
 
     /// Returns the current API version.

--- a/src/redisearch_rs/redis_json_api/src/mock.rs
+++ b/src/redisearch_rs/redis_json_api/src/mock.rs
@@ -1,0 +1,476 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! An in-memory implementation of the RedisJSON module API, for use in tests.
+
+use crate::RedisJsonApi;
+use std::cell::RefCell;
+use std::ffi::{CStr, c_char, c_int, c_longlong, c_void};
+use std::ptr::{self, NonNull};
+
+/// Per-invocation mock state, owned by the [`with_json_api`] stack frame.
+struct MockState {
+    /// The document `openKeyWithFlags` resolves to. `None` models a missing key.
+    doc: Option<serde_json::Value>,
+    /// Keeps serialized buffers (`getJSON` / `getJSONFromIter`) alive for the
+    /// lifetime of the mock: `redis_mock`'s `RedisModule_CreateString` stores
+    /// the pointer rather than copying, so the bytes must outlive the string.
+    strings: RefCell<Vec<Box<[u8]>>>,
+}
+
+/// Run `f` with a [`RedisJsonApi`] backed by an in-memory `doc`.
+///
+/// `doc` is the value `openKeyWithFlags` resolves to; pass `None` to model a
+/// missing key. The returned context pointer must be handed to whatever opens
+/// the document (e.g. `JsonFormat::new(ctx, &api, api_version)`); it is a
+/// disguised pointer to the mock state and is only valid for the duration of
+/// `f`.
+pub fn with_json_api<R>(
+    doc: Option<serde_json::Value>,
+    f: impl FnOnce(RedisJsonApi, NonNull<ffi::RedisModuleCtx>) -> R,
+) -> R {
+    let state = MockState {
+        doc,
+        strings: RefCell::new(Vec::new()),
+    };
+    // Derive the handle from a shared reference: we never form `&mut state`
+    // afterwards, and all interior mutation goes through `RefCell`.
+    let ctx = NonNull::from(&state).cast::<ffi::RedisModuleCtx>();
+    let api = RedisJsonApi::from_vtable(&VTABLE);
+
+    f(api, ctx)
+}
+
+static VTABLE: ffi::RedisJSONAPI = ffi::RedisJSONAPI {
+    openKey: None,
+    openKeyFromStr: None,
+    get: Some(get),
+    next: Some(next),
+    len: Some(len),
+    freeIter: Some(free_iter),
+    getLen: Some(get_len),
+    getType: Some(get_type),
+    getInt: Some(get_int),
+    getDouble: Some(get_double),
+    getBoolean: Some(get_boolean),
+    getString: Some(get_string),
+    getJSON: Some(get_json),
+    isJSON: None,
+    pathParse: None,
+    pathFree: None,
+    pathIsSingle: None,
+    pathHasDefinedOrder: None,
+    getJSONFromIter: Some(get_json_from_iter),
+    resetIter: Some(reset_iter),
+    getKeyValues: Some(get_key_values),
+    freeKeyValuesIter: Some(free_key_values_iter),
+    openKeyWithFlags: Some(open_key_with_flags),
+    allocJson: Some(alloc_json),
+    getAt: Some(get_at),
+    nextKeyValue: Some(next_key_value),
+    freeJson: Some(free_json),
+    getArray: None,
+};
+
+/// View a `RedisJSON` handle as the `serde_json::Value` node it points at.
+///
+/// # Safety
+///
+/// 1. `ctx` must be a valid, non-null pointer to a mock context created by this module
+const unsafe fn node<'a>(json: ffi::RedisJSON) -> &'a serde_json::Value {
+    // Safety: ensured by caller (1.)
+    unsafe { &*json.cast::<serde_json::Value>() }
+}
+
+/// Create a `RedisModuleString` over `bytes`, keeping the buffer alive in the
+/// mock's string arena.
+fn arena_string(state: &MockState, bytes: Vec<u8>) -> *mut ffi::RedisModuleString {
+    let buf = bytes.into_boxed_slice();
+    let ptr = buf.as_ptr();
+    let len = buf.len();
+    state.strings.borrow_mut().push(buf);
+    module_string(ptr, len)
+}
+
+/// Mint a `RedisModuleString` over `len` bytes at `ptr`, which the caller must
+/// keep alive (the mock `RedisModule_CreateString` stores the pointer).
+fn module_string(ptr: *const u8, len: usize) -> *mut ffi::RedisModuleString {
+    // SAFETY: initialized by `redis_mock::init_redis_module_mock`.
+    let create = unsafe { redis_module::raw::RedisModule_CreateString }
+        .expect("RedisModule_CreateString not initialized — call init_redis_module_mock()");
+    // SAFETY: the mock ignores `ctx`; `ptr`/`len` describe a caller-owned buffer.
+    let s = unsafe { create(ptr::null_mut(), ptr.cast::<c_char>(), len) };
+    s.cast()
+}
+
+/// Evaluate the minimal JSONPath subset the loader uses against `root`.
+fn eval_path(root: &serde_json::Value, path: &str) -> Vec<*const serde_json::Value> {
+    let Some(rest) = path.strip_prefix('$') else {
+        panic!("mock: unsupported JSON path `{path}` (must start with `$`)");
+    };
+    if rest.is_empty() {
+        return vec![ptr::from_ref(root)];
+    }
+    if rest == "[*]" {
+        return match root {
+            serde_json::Value::Array(a) => a.iter().map(ptr::from_ref).collect(),
+            _ => Vec::new(),
+        };
+    }
+    // A plain `$.key`: a present key matches, an absent key (or non-object root)
+    // is a missing field. Anything carrying further path syntax is a multi-level
+    // or wildcard path this mock does not model.
+    if let Some(key) = rest.strip_prefix('.')
+        && !key.contains(|c| matches!(c, '.' | '[' | ']' | '*'))
+    {
+        return match root {
+            serde_json::Value::Object(m) => m.get(key).map(ptr::from_ref).into_iter().collect(),
+            _ => Vec::new(),
+        };
+    }
+    panic!("mock: unsupported JSON path `{path}`");
+}
+
+/// # Safety
+///
+/// 1. `ctx` must be a valid, non-null pointer to a mock context created by this module
+unsafe extern "C-unwind" fn open_key_with_flags(
+    ctx: *mut ffi::RedisModuleCtx,
+    _key_name: *mut ffi::RedisModuleString,
+    _flags: c_int,
+) -> ffi::RedisJSON {
+    // Safety: ensured by caller (1.)
+    let state = unsafe { &*ctx.cast::<MockState>() };
+    match &state.doc {
+        Some(value) => ptr::from_ref(value).cast(),
+        None => ptr::null(),
+    }
+}
+
+/// Boxed state behind a `JSONResultsIterator`.
+struct Results {
+    items: Vec<*const serde_json::Value>,
+    pos: usize,
+}
+
+/// # Safety
+///
+/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module
+/// 2. `path` must be a valid, non-null pointer to a null-terminated c string.
+unsafe extern "C-unwind" fn get(
+    json: ffi::RedisJSON,
+    path: *const c_char,
+) -> ffi::JSONResultsIterator {
+    // SAFETY: ensured by caller (2.)
+    let Ok(path) = unsafe { CStr::from_ptr(path) }.to_str() else {
+        return ptr::null();
+    };
+    // SAFETY: ensured by caller (1.)
+    let items = eval_path(unsafe { node(json) }, path);
+    if items.is_empty() {
+        // A null iterator signals "no match"; the wrapper maps it to absence.
+        return ptr::null();
+    }
+    Box::into_raw(Box::new(Results { items, pos: 0 })).cast()
+}
+
+/// # Safety
+///
+/// 1. `iter` must be a valid, non-null pointer to a results iterator created by this module
+unsafe extern "C-unwind" fn next(iter: ffi::JSONResultsIterator) -> ffi::RedisJSON {
+    // Safety: ensured by caller (1.)
+    let it = unsafe { &mut *iter.cast::<Results>().cast_mut() };
+    match it.items.get(it.pos) {
+        Some(&node) => {
+            it.pos += 1;
+            node.cast()
+        }
+        None => ptr::null(),
+    }
+}
+
+/// # Safety
+///
+/// 1. `iter` must be a valid, non-null pointer to a results iterator created by this module
+const unsafe extern "C-unwind" fn len(iter: ffi::JSONResultsIterator) -> usize {
+    // Safety: ensured by caller (1.)
+    unsafe { &*iter.cast::<Results>() }.items.len()
+}
+
+/// # Safety
+///
+/// 1. `iter` must be a valid, non-null pointer to a results iterator created by this module
+unsafe extern "C-unwind" fn reset_iter(iter: ffi::JSONResultsIterator) {
+    // Safety: ensured by caller (1.)
+    unsafe { &mut *iter.cast::<Results>().cast_mut() }.pos = 0;
+}
+
+/// # Safety
+///
+/// 1. `iter` must be a valid, non-null pointer to a results iterator created by this module.
+/// 2. this function must be called exactly once, for a given `ptr`.
+unsafe extern "C-unwind" fn free_iter(iter: ffi::JSONResultsIterator) {
+    // Safety: ensured by caller (1., 2.)
+    drop(unsafe { Box::from_raw(iter.cast::<Results>().cast_mut()) });
+}
+
+/// # Safety
+///
+/// 1. `iter` must be a valid, non-null pointer to a results iterator created by this module
+/// 2. `ctx` must be a valid, non-null pointer to a mock context created by this module.
+/// 4. `str` must be a valid, non-null pointer to a `*mut RedisModuleString`.
+unsafe extern "C-unwind" fn get_json_from_iter(
+    iter: ffi::JSONResultsIterator,
+    ctx: *mut ffi::RedisModuleCtx,
+    str: *mut *mut ffi::RedisModuleString,
+) -> c_int {
+    // Safety: ensured by caller (1.)
+    let it = unsafe { &*iter.cast::<Results>() };
+    // Safety: ensured by caller (2.)
+    let state = unsafe { &*ctx.cast::<MockState>() };
+
+    // RedisJSON's `getJSONFromIter` always wraps matches in a JSON array, even
+    // when there is exactly one match.
+    let arr = it
+        .items
+        .iter()
+        // Safety: `with_json_api` ensures everything within its scope has the same lifetime.
+        // therefore it is safe to dereference the item here: the iterator cannot ordinarily outlive it.
+        .map(|p| unsafe { (**p).clone() })
+        .collect();
+    let text = serde_json::to_string(&serde_json::Value::Array(arr)).unwrap();
+
+    let s = arena_string(state, text.into_bytes());
+
+    // Safety: ensured by caller (3.)
+    unsafe { *str = s };
+
+    ffi::REDISMODULE_OK as i32
+}
+
+/// # Safety
+///
+/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module
+unsafe extern "C-unwind" fn get_type(json: ffi::RedisJSON) -> ffi::JSONType {
+    // SAFETY: ensured by caller (1.)
+    match unsafe { node(json) } {
+        serde_json::Value::String(_) => ffi::JSONType_JSONType_String,
+        serde_json::Value::Number(n) if n.is_f64() => ffi::JSONType_JSONType_Double,
+        serde_json::Value::Number(_) => ffi::JSONType_JSONType_Int,
+        serde_json::Value::Bool(_) => ffi::JSONType_JSONType_Bool,
+        serde_json::Value::Object(_) => ffi::JSONType_JSONType_Object,
+        serde_json::Value::Array(_) => ffi::JSONType_JSONType_Array,
+        serde_json::Value::Null => ffi::JSONType_JSONType_Null,
+    }
+}
+
+/// # Safety
+///
+/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module
+/// 2. `count` must be a valid, non-null pointer to a `usize`.
+unsafe extern "C-unwind" fn get_len(json: ffi::RedisJSON, count: *mut usize) -> c_int {
+    // Safety: ensured by caller (1.)
+    let value = match unsafe { node(json) } {
+        serde_json::Value::Object(m) => m.len(),
+        serde_json::Value::Array(a) => a.len(),
+        _ => return ffi::REDISMODULE_ERR as i32,
+    };
+
+    // Safety: ensured by caller (2.)
+    unsafe { *count = value };
+
+    ffi::REDISMODULE_OK as i32
+}
+
+/// # Safety
+///
+/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module
+/// 2. `integer` must be a valid, non-null pointer to a `c_longlong`.
+unsafe extern "C-unwind" fn get_int(json: ffi::RedisJSON, integer: *mut c_longlong) -> c_int {
+    // Safety: ensured by caller (1.)
+    let Some(i) = unsafe { node(json) }.as_i64() else {
+        return ffi::REDISMODULE_ERR as i32;
+    };
+
+    // Safety: ensured by caller (2.)
+    unsafe { *integer = i };
+
+    ffi::REDISMODULE_OK as i32
+}
+
+/// # Safety
+///
+/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module
+/// 2. `dbl` must be a valid, non-null pointer to a `f64`.
+unsafe extern "C-unwind" fn get_double(json: ffi::RedisJSON, dbl: *mut f64) -> c_int {
+    // Safety: ensured by caller (1.)
+    let Some(d) = unsafe { node(json) }.as_f64() else {
+        return ffi::REDISMODULE_ERR as i32;
+    };
+
+    // Safety: ensured by caller (2.)
+    unsafe { *dbl = d };
+
+    ffi::REDISMODULE_OK as i32
+}
+
+/// # Safety
+///
+/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module
+/// 2. `boolean` must be a valid, non-null pointer to a `c_int`.
+unsafe extern "C-unwind" fn get_boolean(json: ffi::RedisJSON, boolean: *mut c_int) -> c_int {
+    // Safety: ensured by caller (1.)
+    let Some(b) = unsafe { node(json) }.as_bool() else {
+        return ffi::REDISMODULE_ERR as i32;
+    };
+
+    // Safety: ensured by caller (2.)
+    unsafe { *boolean = c_int::from(b) };
+
+    ffi::REDISMODULE_OK as i32
+}
+
+/// # Safety
+///
+/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module
+/// 2. `str` must be a valid, non-null pointer to a `*const c_char`.
+/// 3. `len` must be a valid, non-null pointer to a `usize`.
+unsafe extern "C-unwind" fn get_string(
+    json: ffi::RedisJSON,
+    str: *mut *const c_char,
+    len: *mut usize,
+) -> c_int {
+    // Safety: ensured by caller (1.)
+    let Some(s) = unsafe { node(json) }.as_str() else {
+        return ffi::REDISMODULE_ERR as i32;
+    };
+
+    // The bytes live in the document, valid for the mock's lifetime.
+    // Safety: ensured by caller (2.)
+    unsafe { *str = s.as_ptr().cast::<c_char>() };
+
+    // Safety: ensured by caller (3.)
+    unsafe { *len = s.len() };
+
+    ffi::REDISMODULE_OK as i32
+}
+
+/// # Safety
+///
+/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module.
+/// 2. `ctx` must be a valid, non-null pointer to a mock context created by this module.
+/// 3. `str` must be a valid pointer to a `*mut RedisModuleString`.
+unsafe extern "C-unwind" fn get_json(
+    json: ffi::RedisJSON,
+    ctx: *mut ffi::RedisModuleCtx,
+    str: *mut *mut ffi::RedisModuleString,
+) -> c_int {
+    // Safety: ensured by caller (1.)
+    let state = unsafe { ctx.cast::<MockState>().as_ref().unwrap() };
+    // Safety: ensured by caller (2.)
+    let text = serde_json::to_string(unsafe { node(json) }).unwrap();
+
+    let s = arena_string(state, text.into_bytes());
+
+    // Safety: ensured by caller (3.)
+    unsafe { *str = s };
+
+    ffi::REDISMODULE_OK as i32
+}
+
+/// # Safety
+///
+/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module.
+/// 2. `ptr` must be a valid, non_null pointer to a mock JSON object created by this module.
+unsafe extern "C-unwind" fn get_at(
+    json: ffi::RedisJSON,
+    index: usize,
+    ptr: ffi::RedisJSONPtr,
+) -> c_int {
+    // Safety: ensured by caller (1.)
+    let Some(elem) = unsafe { node(json) }.as_array().and_then(|a| a.get(index)) else {
+        return ffi::REDISMODULE_ERR as i32;
+    };
+
+    // Safety: ensured by caller (2.)
+    unsafe { *ptr = ptr::from_ref(elem).cast() };
+
+    ffi::REDISMODULE_OK as i32
+}
+
+/// Boxed state behind a `JSONKeyValuesIterator`. Key pointers reference the
+/// document's own key strings (kept alive by the [`MockState`]).
+struct KeyValues {
+    entries: Vec<(*const c_char, usize, *const serde_json::Value)>,
+    pos: usize,
+}
+
+/// # Safety
+///
+/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module.
+unsafe extern "C-unwind" fn get_key_values(json: ffi::RedisJSON) -> ffi::JSONKeyValuesIterator {
+    // Safety: ensured by caller (1.)
+    let serde_json::Value::Object(map) = (unsafe { node(json) }) else {
+        return ptr::null();
+    };
+    let entries = map
+        .iter()
+        .map(|(k, v)| (k.as_ptr().cast::<c_char>(), k.len(), ptr::from_ref(v)))
+        .collect();
+    Box::into_raw(Box::new(KeyValues { entries, pos: 0 })).cast()
+}
+
+/// # Safety
+///
+/// 1. `iter` must be a valid, non-null pointer to a mock key-values iterator created by this module.
+/// 2. `key_name` must be a valid, non-null pointer to a `*mut RedisModuleString`.
+/// 3. `ptr` must be a valid, non-null pointer to a JSON object created by this module.
+unsafe extern "C-unwind" fn next_key_value(
+    iter: ffi::JSONKeyValuesIterator,
+    key_name: *mut *mut ffi::RedisModuleString,
+    ptr: ffi::RedisJSONPtr,
+) -> c_int {
+    // Safety: ensured by caller (1.)
+    let it = unsafe { &mut *iter.cast::<KeyValues>().cast_mut() };
+    let Some(&(key_ptr, key_len, value)) = it.entries.get(it.pos) else {
+        return ffi::REDISMODULE_ERR as i32;
+    };
+    it.pos += 1;
+
+    let key = module_string(key_ptr.cast::<u8>(), key_len);
+
+    // Safety: ensured by caller (2.)
+    unsafe { *key_name = key };
+
+    // Safety: ensured by caller (3.)
+    unsafe { *ptr = value.cast() };
+
+    ffi::REDISMODULE_OK as i32
+}
+
+/// # Safety
+///
+/// 1. `iter` must be a valid, non-null pointer to a mock key-values iterator created by this module.
+unsafe extern "C-unwind" fn free_key_values_iter(iter: ffi::JSONKeyValuesIterator) {
+    // Safety: ensured by caller (1.)
+    drop(unsafe { Box::from_raw(iter.cast::<KeyValues>().cast_mut()) });
+}
+
+extern "C-unwind" fn alloc_json() -> ffi::RedisJSONPtr {
+    Box::into_raw(Box::new(ptr::null::<c_void>()))
+}
+
+/// # Safety
+///
+/// 1. `ptr` must be a valid, non-null pointer to a mock JSON object created by this module.
+/// 2. this function must be called exactly once, for a given `ptr`.
+unsafe extern "C-unwind" fn free_json(ptr: ffi::RedisJSONPtr) {
+    // Safety: ensured by caller (1., 2.)
+    drop(unsafe { Box::from_raw(ptr) });
+}

--- a/src/redisearch_rs/redis_json_api/src/mock.rs
+++ b/src/redisearch_rs/redis_json_api/src/mock.rs
@@ -16,7 +16,7 @@ use std::ptr::{self, NonNull};
 
 /// Per-invocation mock state, owned by the [`with_json_api`] stack frame.
 struct MockState {
-    /// The document `openKeyWithFlags` resolves to. `None` models a missing key.
+    /// The document `openKeyWithFlags` resolves to. `None` models a missing document.
     doc: Option<serde_json::Value>,
     /// Keeps serialized buffers (`getJSON` / `getJSONFromIter`) alive for the
     /// lifetime of the mock: `redis_mock`'s `RedisModule_CreateString` stores
@@ -27,7 +27,7 @@ struct MockState {
 /// Run `f` with a [`RedisJsonApi`] backed by an in-memory `doc`.
 ///
 /// `doc` is the value `openKeyWithFlags` resolves to; pass `None` to model a
-/// missing key. The returned context pointer must be handed to whatever opens
+/// missing document. The returned context pointer must be handed to whatever opens
 /// the document (e.g. `JsonFormat::new(ctx, &api, api_version)`); it is a
 /// disguised pointer to the mock state and is only valid for the duration of
 /// `f`.
@@ -82,7 +82,9 @@ static VTABLE: ffi::RedisJSONAPI = ffi::RedisJSONAPI {
 ///
 /// # Safety
 ///
-/// 1. `ctx` must be a valid, non-null pointer to a mock context created by this module
+/// 1. `json` must be a [valid], non-null pointer to a mock JSON value created by this module
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 const unsafe fn node<'a>(json: ffi::RedisJSON) -> &'a serde_json::Value {
     // Safety: ensured by caller (1.)
     unsafe { &*json.cast::<serde_json::Value>() }
@@ -111,18 +113,21 @@ fn module_string(ptr: *const u8, len: usize) -> *mut ffi::RedisModuleString {
 
 /// Evaluate the minimal JSONPath subset the loader uses against `root`.
 fn eval_path(root: &serde_json::Value, path: &str) -> Vec<*const serde_json::Value> {
-    let Some(rest) = path.strip_prefix('$') else {
-        panic!("mock: unsupported JSON path `{path}` (must start with `$`)");
-    };
+    let rest = path
+        .strip_prefix('$')
+        .expect("mock: unsupported JSON path `{path}` (must start with `$`)");
+
     if rest.is_empty() {
         return vec![ptr::from_ref(root)];
     }
+
     if rest == "[*]" {
         return match root {
             serde_json::Value::Array(a) => a.iter().map(ptr::from_ref).collect(),
             _ => Vec::new(),
         };
     }
+
     // A plain `$.key`: a present key matches, an absent key (or non-object root)
     // is a missing field. Anything carrying further path syntax is a multi-level
     // or wildcard path this mock does not model.
@@ -134,13 +139,16 @@ fn eval_path(root: &serde_json::Value, path: &str) -> Vec<*const serde_json::Val
             _ => Vec::new(),
         };
     }
-    panic!("mock: unsupported JSON path `{path}`");
+
+    unimplemented!("mock: unsupported JSON path `{path}`");
 }
 
 /// # Safety
 ///
-/// 1. `ctx` must be a valid, non-null pointer to a mock context created by this module
-unsafe extern "C-unwind" fn open_key_with_flags(
+/// 1. `ctx` must be a [valid], non-null pointer to a mock context created by this module.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn open_key_with_flags(
     ctx: *mut ffi::RedisModuleCtx,
     _key_name: *mut ffi::RedisModuleString,
     _flags: c_int,
@@ -153,7 +161,6 @@ unsafe extern "C-unwind" fn open_key_with_flags(
     }
 }
 
-/// Boxed state behind a `JSONResultsIterator`.
 struct Results {
     items: Vec<*const serde_json::Value>,
     pos: usize,
@@ -161,18 +168,18 @@ struct Results {
 
 /// # Safety
 ///
-/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module
-/// 2. `path` must be a valid, non-null pointer to a null-terminated c string.
-unsafe extern "C-unwind" fn get(
-    json: ffi::RedisJSON,
-    path: *const c_char,
-) -> ffi::JSONResultsIterator {
+/// 1. `json` must be a [valid], non-null pointer to a mock JSON object created by this module.
+/// 2. `path` must be a [valid], non-null pointer to a null-terminated c string.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn get(json: ffi::RedisJSON, path: *const c_char) -> ffi::JSONResultsIterator {
     // SAFETY: ensured by caller (2.)
     let Ok(path) = unsafe { CStr::from_ptr(path) }.to_str() else {
         return ptr::null();
     };
     // SAFETY: ensured by caller (1.)
-    let items = eval_path(unsafe { node(json) }, path);
+    let json = unsafe { node(json) };
+    let items = eval_path(json, path);
     if items.is_empty() {
         // A null iterator signals "no match"; the wrapper maps it to absence.
         return ptr::null();
@@ -182,8 +189,10 @@ unsafe extern "C-unwind" fn get(
 
 /// # Safety
 ///
-/// 1. `iter` must be a valid, non-null pointer to a results iterator created by this module
-unsafe extern "C-unwind" fn next(iter: ffi::JSONResultsIterator) -> ffi::RedisJSON {
+/// 1. `iter` must be a [valid], non-null pointer to a results iterator created by this module.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn next(iter: ffi::JSONResultsIterator) -> ffi::RedisJSON {
     // Safety: ensured by caller (1.)
     let it = unsafe { &mut *iter.cast::<Results>().cast_mut() };
     match it.items.get(it.pos) {
@@ -197,35 +206,43 @@ unsafe extern "C-unwind" fn next(iter: ffi::JSONResultsIterator) -> ffi::RedisJS
 
 /// # Safety
 ///
-/// 1. `iter` must be a valid, non-null pointer to a results iterator created by this module
-const unsafe extern "C-unwind" fn len(iter: ffi::JSONResultsIterator) -> usize {
+/// 1. `iter` must be a [valid], non-null pointer to a results iterator created by this module.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+const unsafe extern "C" fn len(iter: ffi::JSONResultsIterator) -> usize {
     // Safety: ensured by caller (1.)
     unsafe { &*iter.cast::<Results>() }.items.len()
 }
 
 /// # Safety
 ///
-/// 1. `iter` must be a valid, non-null pointer to a results iterator created by this module
-unsafe extern "C-unwind" fn reset_iter(iter: ffi::JSONResultsIterator) {
+/// 1. `iter` must be a [valid], non-null pointer to a results iterator created by this module.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn reset_iter(iter: ffi::JSONResultsIterator) {
     // Safety: ensured by caller (1.)
     unsafe { &mut *iter.cast::<Results>().cast_mut() }.pos = 0;
 }
 
 /// # Safety
 ///
-/// 1. `iter` must be a valid, non-null pointer to a results iterator created by this module.
+/// 1. `iter` must be a [valid], non-null pointer to a results iterator created by this module.
 /// 2. this function must be called exactly once, for a given `ptr`.
-unsafe extern "C-unwind" fn free_iter(iter: ffi::JSONResultsIterator) {
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn free_iter(iter: ffi::JSONResultsIterator) {
     // Safety: ensured by caller (1., 2.)
     drop(unsafe { Box::from_raw(iter.cast::<Results>().cast_mut()) });
 }
 
 /// # Safety
 ///
-/// 1. `iter` must be a valid, non-null pointer to a results iterator created by this module
-/// 2. `ctx` must be a valid, non-null pointer to a mock context created by this module.
-/// 4. `str` must be a valid, non-null pointer to a `*mut RedisModuleString`.
-unsafe extern "C-unwind" fn get_json_from_iter(
+/// 1. `iter` must be a [valid], non-null pointer to a results iterator created by this module.
+/// 2. `ctx` must be a [valid], non-null pointer to a mock context created by this module.
+/// 3. `str` must be a [valid], non-null pointer to a `*mut RedisModuleString`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn get_json_from_iter(
     iter: ffi::JSONResultsIterator,
     ctx: *mut ffi::RedisModuleCtx,
     str: *mut *mut ffi::RedisModuleString,
@@ -256,8 +273,10 @@ unsafe extern "C-unwind" fn get_json_from_iter(
 
 /// # Safety
 ///
-/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module
-unsafe extern "C-unwind" fn get_type(json: ffi::RedisJSON) -> ffi::JSONType {
+/// 1. `json` must be a [valid], non-null pointer to a mock JSON object created by this module.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn get_type(json: ffi::RedisJSON) -> ffi::JSONType {
     // SAFETY: ensured by caller (1.)
     match unsafe { node(json) } {
         serde_json::Value::String(_) => ffi::JSONType_JSONType_String,
@@ -272,9 +291,11 @@ unsafe extern "C-unwind" fn get_type(json: ffi::RedisJSON) -> ffi::JSONType {
 
 /// # Safety
 ///
-/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module
-/// 2. `count` must be a valid, non-null pointer to a `usize`.
-unsafe extern "C-unwind" fn get_len(json: ffi::RedisJSON, count: *mut usize) -> c_int {
+/// 1. `json` must be a [valid], non-null pointer to a mock JSON object created by this module.
+/// 2. `count` must be a [valid], non-null pointer to a `usize`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn get_len(json: ffi::RedisJSON, count: *mut usize) -> c_int {
     // Safety: ensured by caller (1.)
     let value = match unsafe { node(json) } {
         serde_json::Value::Object(m) => m.len(),
@@ -290,9 +311,11 @@ unsafe extern "C-unwind" fn get_len(json: ffi::RedisJSON, count: *mut usize) -> 
 
 /// # Safety
 ///
-/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module
-/// 2. `integer` must be a valid, non-null pointer to a `c_longlong`.
-unsafe extern "C-unwind" fn get_int(json: ffi::RedisJSON, integer: *mut c_longlong) -> c_int {
+/// 1. `json` must be a [valid], non-null pointer to a mock JSON object created by this module.
+/// 2. `integer` must be a [valid], non-null pointer to a `c_longlong`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn get_int(json: ffi::RedisJSON, integer: *mut c_longlong) -> c_int {
     // Safety: ensured by caller (1.)
     let Some(i) = unsafe { node(json) }.as_i64() else {
         return ffi::REDISMODULE_ERR as i32;
@@ -306,9 +329,11 @@ unsafe extern "C-unwind" fn get_int(json: ffi::RedisJSON, integer: *mut c_longlo
 
 /// # Safety
 ///
-/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module
-/// 2. `dbl` must be a valid, non-null pointer to a `f64`.
-unsafe extern "C-unwind" fn get_double(json: ffi::RedisJSON, dbl: *mut f64) -> c_int {
+/// 1. `json` must be a [valid], non-null pointer to a mock JSON object created by this module.
+/// 2. `dbl` must be a [valid], non-null pointer to a `f64`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn get_double(json: ffi::RedisJSON, dbl: *mut f64) -> c_int {
     // Safety: ensured by caller (1.)
     let Some(d) = unsafe { node(json) }.as_f64() else {
         return ffi::REDISMODULE_ERR as i32;
@@ -322,9 +347,11 @@ unsafe extern "C-unwind" fn get_double(json: ffi::RedisJSON, dbl: *mut f64) -> c
 
 /// # Safety
 ///
-/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module
-/// 2. `boolean` must be a valid, non-null pointer to a `c_int`.
-unsafe extern "C-unwind" fn get_boolean(json: ffi::RedisJSON, boolean: *mut c_int) -> c_int {
+/// 1. `json` must be a [valid], non-null pointer to a mock JSON object created by this module.
+/// 2. `boolean` must be a [valid], non-null pointer to a `c_int`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn get_boolean(json: ffi::RedisJSON, boolean: *mut c_int) -> c_int {
     // Safety: ensured by caller (1.)
     let Some(b) = unsafe { node(json) }.as_bool() else {
         return ffi::REDISMODULE_ERR as i32;
@@ -338,10 +365,12 @@ unsafe extern "C-unwind" fn get_boolean(json: ffi::RedisJSON, boolean: *mut c_in
 
 /// # Safety
 ///
-/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module
-/// 2. `str` must be a valid, non-null pointer to a `*const c_char`.
-/// 3. `len` must be a valid, non-null pointer to a `usize`.
-unsafe extern "C-unwind" fn get_string(
+/// 1. `json` must be a [valid], non-null pointer to a mock JSON object created by this module.
+/// 2. `str` must be a [valid], non-null pointer to a `*const c_char`.
+/// 3. `len` must be a [valid], non-null pointer to a `usize`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn get_string(
     json: ffi::RedisJSON,
     str: *mut *const c_char,
     len: *mut usize,
@@ -363,10 +392,12 @@ unsafe extern "C-unwind" fn get_string(
 
 /// # Safety
 ///
-/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module.
-/// 2. `ctx` must be a valid, non-null pointer to a mock context created by this module.
-/// 3. `str` must be a valid pointer to a `*mut RedisModuleString`.
-unsafe extern "C-unwind" fn get_json(
+/// 1. `json` must be a [valid], non-null pointer to a mock JSON object created by this module.
+/// 2. `ctx` must be a [valid], non-null pointer to a mock context created by this module.
+/// 3. `str` must be a [valid] pointer to a `*mut RedisModuleString`.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn get_json(
     json: ffi::RedisJSON,
     ctx: *mut ffi::RedisModuleCtx,
     str: *mut *mut ffi::RedisModuleString,
@@ -386,13 +417,11 @@ unsafe extern "C-unwind" fn get_json(
 
 /// # Safety
 ///
-/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module.
-/// 2. `ptr` must be a valid, non_null pointer to a mock JSON object created by this module.
-unsafe extern "C-unwind" fn get_at(
-    json: ffi::RedisJSON,
-    index: usize,
-    ptr: ffi::RedisJSONPtr,
-) -> c_int {
+/// 1. `json` must be a [valid], non-null pointer to a mock JSON object created by this module.
+/// 2. `ptr` must be a [valid], non_null pointer to a mock JSON object created by this module.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn get_at(json: ffi::RedisJSON, index: usize, ptr: ffi::RedisJSONPtr) -> c_int {
     // Safety: ensured by caller (1.)
     let Some(elem) = unsafe { node(json) }.as_array().and_then(|a| a.get(index)) else {
         return ffi::REDISMODULE_ERR as i32;
@@ -404,8 +433,6 @@ unsafe extern "C-unwind" fn get_at(
     ffi::REDISMODULE_OK as i32
 }
 
-/// Boxed state behind a `JSONKeyValuesIterator`. Key pointers reference the
-/// document's own key strings (kept alive by the [`MockState`]).
 struct KeyValues {
     entries: Vec<(*const c_char, usize, *const serde_json::Value)>,
     pos: usize,
@@ -413,8 +440,10 @@ struct KeyValues {
 
 /// # Safety
 ///
-/// 1. `json` must be a valid, non-null pointer to a mock JSON object created by this module.
-unsafe extern "C-unwind" fn get_key_values(json: ffi::RedisJSON) -> ffi::JSONKeyValuesIterator {
+/// 1. `json` must be a [valid], non-null pointer to a mock JSON object created by this module.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn get_key_values(json: ffi::RedisJSON) -> ffi::JSONKeyValuesIterator {
     // Safety: ensured by caller (1.)
     let serde_json::Value::Object(map) = (unsafe { node(json) }) else {
         return ptr::null();
@@ -428,10 +457,12 @@ unsafe extern "C-unwind" fn get_key_values(json: ffi::RedisJSON) -> ffi::JSONKey
 
 /// # Safety
 ///
-/// 1. `iter` must be a valid, non-null pointer to a mock key-values iterator created by this module.
-/// 2. `key_name` must be a valid, non-null pointer to a `*mut RedisModuleString`.
-/// 3. `ptr` must be a valid, non-null pointer to a JSON object created by this module.
-unsafe extern "C-unwind" fn next_key_value(
+/// 1. `iter` must be a [valid], non-null pointer to a mock key-values iterator created by this module.
+/// 2. `key_name` must be a [valid], non-null pointer to a `*mut RedisModuleString`.
+/// 3. `ptr` must be a [valid], non-null pointer to a JSON object created by this module.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn next_key_value(
     iter: ffi::JSONKeyValuesIterator,
     key_name: *mut *mut ffi::RedisModuleString,
     ptr: ffi::RedisJSONPtr,
@@ -456,21 +487,25 @@ unsafe extern "C-unwind" fn next_key_value(
 
 /// # Safety
 ///
-/// 1. `iter` must be a valid, non-null pointer to a mock key-values iterator created by this module.
-unsafe extern "C-unwind" fn free_key_values_iter(iter: ffi::JSONKeyValuesIterator) {
+/// 1. `iter` must be a [valid], non-null pointer to a mock key-values iterator created by this module.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn free_key_values_iter(iter: ffi::JSONKeyValuesIterator) {
     // Safety: ensured by caller (1.)
     drop(unsafe { Box::from_raw(iter.cast::<KeyValues>().cast_mut()) });
 }
 
-extern "C-unwind" fn alloc_json() -> ffi::RedisJSONPtr {
+extern "C" fn alloc_json() -> ffi::RedisJSONPtr {
     Box::into_raw(Box::new(ptr::null::<c_void>()))
 }
 
 /// # Safety
 ///
-/// 1. `ptr` must be a valid, non-null pointer to a mock JSON object created by this module.
+/// 1. `ptr` must be a [valid], non-null pointer to a mock JSON object created by this module.
 /// 2. this function must be called exactly once, for a given `ptr`.
-unsafe extern "C-unwind" fn free_json(ptr: ffi::RedisJSONPtr) {
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn free_json(ptr: ffi::RedisJSONPtr) {
     // Safety: ensured by caller (1., 2.)
     drop(unsafe { Box::from_raw(ptr) });
 }


### PR DESCRIPTION
This PR adds a mock implementation of the `RedisJsonApi` for testing purposes to the `redis_json_api` crate behind the `test-mock` feature.
 
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
