### PR TITLE
[8.6-rse] Use relaxed memory ordering for the request timedOut signal flag (#9749)

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -29,10 +29,14 @@
 #ifdef __cplusplus
 #include <atomic>
 #define RS_Atomic(T) std::atomic<T>
+#define RS_AtomicBoolLoadRelaxed(p)     (((std::atomic<bool> *)(p))->load(std::memory_order_relaxed))
+#define RS_AtomicBoolStoreRelaxed(p, v) (((std::atomic<bool> *)(p))->store((v), std::memory_order_relaxed))
 extern "C" {
 #else
 #define RS_Atomic(T) _Atomic(T)
 #include <stdatomic.h>
+#define RS_AtomicBoolLoadRelaxed(p)     __atomic_load_n((bool *)(p), __ATOMIC_RELAXED)
+#define RS_AtomicBoolStoreRelaxed(p, v) __atomic_store_n((bool *)(p), (v), __ATOMIC_RELAXED)
 #endif
 
 #define DEFAULT_LIMIT 10
@@ -586,8 +590,12 @@ void SetSearchCtx(RedisSearchCtx *sctx, const AREQ *req);
 // Allows calling parseProfileArgs from reply_empty.c
 int parseProfileArgs(RedisModuleString **argv, int argc, AREQ *r);
 
-bool AREQ_TimedOut(AREQ *req);
-void AREQ_SetTimedOut(AREQ *req);
+static inline bool AREQ_TimedOut(AREQ *req) {
+  return RS_AtomicBoolLoadRelaxed(&req->syncCtx.timedOut);
+}
+static inline void AREQ_SetTimedOut(AREQ *req) {
+  RS_AtomicBoolStoreRelaxed(&req->syncCtx.timedOut, true);
+}
 
 static inline bool AREQ_ShouldCheckTimeout(AREQ *req) {
   return !req->skipTimeoutChecks;

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1078,16 +1078,6 @@ AREQ *AREQ_New(void) {
   return req;
 }
 
-bool AREQ_TimedOut(AREQ *req) {
-  return atomic_load_explicit(&req->syncCtx.timedOut, memory_order_acquire);
-}
-
-void AREQ_SetTimedOut(AREQ *req) {
-  atomic_store_explicit(&req->syncCtx.timedOut, true, memory_order_release);
-}
-
-
-
 int parseAggPlan(ParseAggPlanContext *papCtx, ArgsCursor *ac, bool isDiskIndex, QueryError *status) {
   while (!AC_IsAtEnd(ac)) {
     int rv = handleCommonArgs(papCtx, ac, status);

--- a/src/coord/coord_request_ctx.c
+++ b/src/coord/coord_request_ctx.c
@@ -76,12 +76,8 @@ void *CoordRequestCtx_GetRequest(CoordRequestCtx *ctx) {
   return ctx->type == COMMAND_HYBRID ? (void *)ctx->hreq : (void *)ctx->areq;
 }
 
-bool CoordRequestCtx_TimedOut(CoordRequestCtx *ctx) {
-  return atomic_load_explicit(&ctx->timedOut, memory_order_acquire);
-}
-
 void CoordRequestCtx_SetTimedOut(CoordRequestCtx *ctx) {
-  atomic_store_explicit(&ctx->timedOut, true, memory_order_release);
+  RS_AtomicBoolStoreRelaxed(&ctx->timedOut, true);
   // Also propagate to the underlying request if set
   if (ctx->type == COMMAND_HYBRID) {
     if (ctx->hreq) HybridRequest_SetTimedOut(ctx->hreq);

--- a/src/coord/coord_request_ctx.h
+++ b/src/coord/coord_request_ctx.h
@@ -88,7 +88,9 @@ void *CoordRequestCtx_GetRequest(CoordRequestCtx *ctx);
 /**
  * Check if the coordinator request has timed out.
  */
-bool CoordRequestCtx_TimedOut(CoordRequestCtx *ctx);
+static inline bool CoordRequestCtx_TimedOut(CoordRequestCtx *ctx) {
+  return RS_AtomicBoolLoadRelaxed(&ctx->timedOut);
+}
 
 /**
  * Set the timeout flag on the coordinator request context.

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -252,14 +252,6 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
     return hybridReq;
 }
 
-bool HybridRequest_TimedOut(HybridRequest *req) {
-  return atomic_load_explicit(&req->syncCtx.timedOut, memory_order_acquire);
-}
-
-void HybridRequest_SetTimedOut(HybridRequest *req) {
-  atomic_store_explicit(&req->syncCtx.timedOut, true, memory_order_release);
-}
-
 void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, RedisModuleString **argv, int argc) {
   // skip command and index name
   const int step = argc > 2 ? 2 : argc;

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -53,8 +53,12 @@ typedef struct HybridRequest {
 } HybridRequest;
 
 // Timeout helper functions for HybridRequest (mirrors AREQ pattern)
-bool HybridRequest_TimedOut(HybridRequest *req);
-void HybridRequest_SetTimedOut(HybridRequest *req);
+static inline bool HybridRequest_TimedOut(HybridRequest *req) {
+  return RS_AtomicBoolLoadRelaxed(&req->syncCtx.timedOut);
+}
+static inline void HybridRequest_SetTimedOut(HybridRequest *req) {
+  RS_AtomicBoolStoreRelaxed(&req->syncCtx.timedOut, true);
+}
 
 static inline bool HybridRequest_ShouldCheckTimeout(HybridRequest *req) {
   return !req->skipTimeoutChecks;


### PR DESCRIPTION
## Describe the changes in the pull request

Partial backport of #9749 ("Use relaxed memory ordering for the request `timedOut` signal flag") to `8.6-rse`.

The high-frequency `timedOut` polling flag for `AREQ`, `HybridRequest`, and `CoordRequestCtx` is now read/written with **relaxed** memory ordering. The accessors are inlined into the headers (`aggregate.h`, `hybrid_request.h`, `coord_request_ctx.h`) using two new helper macros, `RS_AtomicBoolLoadRelaxed` / `RS_AtomicBoolStoreRelaxed`, that compile under both C (`__atomic_*` builtins) and C++ (`std::atomic` methods).

### Why this is a *partial* backport

- **`<stdatomic.h>` is intentionally retained** in `aggregate.h` (the one deliberate deviation from #9845). On `8.6-rse` many translation units — `disk_gc.c`, `result_processor.c`, `debug_commands.c`, `fork_gc.c`, `rpnet.c`, `rmr.c`, `circular_buffer.c` — depend on it transitively for library-form atomics (`atomic_fetch_add`, `atomic_exchange`, `atomic_init`, …). Removing it would break those TUs, so the FFI-oriented `<stdatomic.h>` → builtins migration from #9845 is **not** applied here.
- The `chan.c` abort-flag relaxed-load hunk and the `RETURN-STRICT` claim-reset logic from the source PRs **do not exist** on `8.6-rse` (`MRChannel_PopWithTimeout` has a different signature with no `abortFlag`), so those hunks are omitted.

Net effect: the timeout-flag relaxation — the user-visible performance optimization — is backported; the FFI-only header refactor and the diverged infrastructure hunks are not applicable.

### Source PRs

- #9749 — relax memory ordering for the `timedOut` flag (backported here, adapted)
- #9845 — replace `<stdatomic.h>` with compiler builtins (**not** backported; see above)

## Which issues does this pull request fix or reference?

Backport of #9749 / #9845 to `8.6-rse`.

## How was the change tested?

Not built/tested locally per request; relying on CI.

---

- [ ] This PR requires release notes
- [x] This PR does not require release notes
