### PR TITLE
[MOD-16428] Capture warmup FT.HYBRID error in RESP2 timeout test setup

### DIFF
--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -4894,12 +4894,20 @@ class TestCoordinatorTimeoutReturnStrictResp2:
 
         # Warmup hybrid query and store the query vector for tests.
         self.hybrid_query_vec = np.array([0.0, 0.0], dtype=np.float32).tobytes()
-        self.env.expect(
-            'FT.HYBRID', 'hybrid_idx',
-            'SEARCH', '*',
-            'VSIM', '@embedding', '$BLOB',
-            'PARAMS', '2', 'BLOB', self.hybrid_query_vec
-        ).noError()
+        try:
+            warmup_res = self.env.cmd(
+                'FT.HYBRID', 'hybrid_idx',
+                'SEARCH', '*',
+                'VSIM', '@embedding', '$BLOB',
+                'PARAMS', '2', 'BLOB', self.hybrid_query_vec)
+        except Exception as e:
+            # MOD-16428: surface the actual reply for the macOS x86_64 flake,
+            # whose error string is otherwise absent from the server logs.
+            self.env.assertTrue(
+                False, message=f"warmup FT.HYBRID raised {type(e).__name__}: {e!r}")
+            raise
+        self.env.assertNotEqual(
+            warmup_res, None, message=f"warmup FT.HYBRID empty reply: {warmup_res!r}")
 
     def test_return_strict_timeout_at_claim_sync_point_profile_hybrid_resp2(self):
         """RESP2 FT.PROFILE HYBRID early-timeout preserves the profile envelope.


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The warmup `FT.HYBRID` in `TestCoordinatorTimeoutReturnStrictResp2.__init__` uses a bare `.noError()`. When it fails, RLTest reports only `True == False` and discards the actual reply, and the error string is also absent from the server logs — making the macOS x86_64 flake (MOD-16428) undiagnosable from CI artifacts.
2. **Change:** Replace the bare `.noError()` with a `try/except` around `self.env.cmd(...)` that asserts with the actual reply / exception `repr` in the failure message. `self.env.cmd` preserves the original single-shard coordinator dispatch (the `RedisCluster` client from `getConnectionByEnv` cannot route the keyless `FT.HYBRID`).
3. **Outcome:** The next occurrence of the flake will print the exact error string in the assertion message, enabling root-cause analysis. The happy path is unchanged (verified locally: the test class passes).

#### Which additional issues this PR fixes
1. MOD-16428

#### Main objects this PR modified
1. `tests/pytests/test_blocked_client_timeout.py` — `TestCoordinatorTimeoutReturnStrictResp2.__init__` warmup

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Test-only diagnostic change; no user-facing impact.

---
Co-authored by [Augment Code](https://www.augmentcode.com/?utm_source=github&utm_medium=pr&utm_campaign=redisearch)
