### PR TITLE
[MOD-14206] Top K Vector: FFI entrypoint

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1200,7 +1200,9 @@ dependencies = [
  "rqe_core",
  "rqe_iterator_type",
  "rqe_iterators",
+ "top_k",
  "trie_rs",
+ "vector_score_source",
  "workspace_hack",
 ]
 
@@ -3562,6 +3564,7 @@ dependencies = [
  "redisearch_rs",
  "rlookup",
  "rqe_core",
+ "rqe_iterator_type",
  "rqe_iterators",
  "rqe_iterators_test_utils",
  "top_k",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1216,7 +1216,9 @@ dependencies = [
  "rqe_core",
  "rqe_iterator_type",
  "rqe_iterators",
+ "top_k",
  "trie_rs",
+ "vector_score_source",
  "workspace_hack",
 ]
 
@@ -3631,6 +3633,7 @@ dependencies = [
  "redisearch_rs",
  "rlookup",
  "rqe_core",
+ "rqe_iterator_type",
  "rqe_iterators",
  "rqe_iterators_test_utils",
  "top_k",

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
@@ -35,6 +35,8 @@ query_types.workspace = true
 redis_reply.workspace = true
 rqe_iterator_type.workspace = true
 rqe_iterators.workspace = true
+top_k.workspace = true
 trie_rs.workspace = true
+vector_score_source.workspace = true
 workspace_hack.workspace = true
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
@@ -38,6 +38,8 @@ rlookup.workspace = true
 rqe_core.workspace = true
 rqe_iterator_type.workspace = true
 rqe_iterators.workspace = true
+top_k.workspace = true
 trie_rs.workspace = true
+vector_score_source.workspace = true
 workspace_hack.workspace = true
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/lib.rs
@@ -19,4 +19,5 @@ pub mod optional;
 pub mod profile;
 mod profile_print;
 pub mod union;
+pub mod vector_top_k;
 pub mod wildcard;

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/lib.rs
@@ -20,4 +20,5 @@ pub mod optional;
 pub mod profile;
 mod profile_print;
 pub mod union;
+pub mod vector_top_k;
 pub mod wildcard;

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/vector_top_k.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/vector_top_k.rs
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Rust implementation of the vector top-k iterator and its C accessor functions.
+//!
+//! This module provides [`NewVectorTopKIterator`] (a drop-in replacement for the
+//! C `NewHybridVectorIterator`) together with the accessor shims that C callers
+//! use for query-plan construction and profiling.
+
+use std::{
+    ffi::{c_char, c_void},
+    ptr::{self, NonNull},
+};
+
+use ffi::{
+    QueryIterator, RLookupKey, RLookupKeyHandle, RedisSearchCtx, VecSimIndex, VecSimQueryParams,
+    VecSimSearchMode_VECSIM_HYBRID_ADHOC_BF, VecSimSearchMode_VECSIM_HYBRID_BATCHES,
+    VecSimSearchMode_VECSIM_HYBRID_BATCHES_TO_ADHOC_BF, VecSimSearchMode_VECSIM_STANDARD_KNN,
+    timespec,
+};
+use field::FieldFilterContext;
+use rqe_iterators::{
+    ExpirationChecker, FieldExpirationChecker,
+    c2rust::CRQEIterator,
+    interop::{RQEIteratorWrapper, patch_vtable},
+};
+use top_k::TopKMode;
+use vector_score_source::{NewVectorTopK, VectorTopKIterator, new_vector_top_k};
+
+/// Construct a vector top-k iterator and expose it as a C [`QueryIterator`].
+///
+/// This call can reduce to an `Empty` iterator.
+///
+/// Pass `child = NULL` for a pure KNN query; pass a valid owning child iterator
+/// for a hybrid (filtered) query.
+///
+/// The `query_params` pointer is read once to copy the parameters into the
+/// iterator; it is not retained after this call.
+///
+/// `can_trim_deep_results` applies only to filtered queries: when `true`, the
+/// pipeline needs no rich results, so each match yields a metric-only result
+/// carrying just the vector score instead of a deep copy of the child's scoring
+/// subtree. It has no effect on a pure KNN query, which is metric-only anyway.
+///
+/// # Safety
+///
+/// 1. `index` is non-null and [valid], and outlives the returned iterator.
+/// 2. `query_vector` is [valid] for `vector_byte_len` bytes, and
+///    `vector_byte_len` equals the index's expected query-vector size.
+/// 3. `query_params` is non-null and [valid] for a [`VecSimQueryParams`].
+/// 4. `child`, when non-null, is a [valid], owning `QueryIterator *` with every
+///    callback populated.
+/// 5. `filter_ctx` is non-null and [valid] for a [`FieldFilterContext`] for the
+///    duration of this call.
+/// 6. `sctx` is non-null and [valid] for a [`RedisSearchCtx`] with a [valid]
+///    `spec`, both outliving the returned iterator.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn NewVectorTopKIterator(
+    index: *mut VecSimIndex,
+    query_vector: *const c_void,
+    vector_byte_len: usize,
+    query_params: *const VecSimQueryParams,
+    k: usize,
+    can_trim_deep_results: bool,
+    child: *mut QueryIterator,
+    timeout: timespec,
+    skip_timeout_checks: bool,
+    sctx: *mut RedisSearchCtx,
+    filter_ctx: *const FieldFilterContext,
+) -> *mut QueryIterator {
+    // SAFETY: guaranteed by 2.
+    let query_vector =
+        unsafe { std::slice::from_raw_parts(query_vector as *const u8, vector_byte_len).to_vec() };
+    // SAFETY: guaranteed by 3.
+    let query_params = unsafe { *query_params };
+
+    // Adopt the filter child as an owning Rust iterator. A null child means a pure KNN query.
+    // SAFETY: guaranteed by 4.
+    let child = NonNull::new(child).map(|c| unsafe { CRQEIterator::new(c) });
+
+    // SAFETY: guaranteed by 1.
+    let index = unsafe { NonNull::new_unchecked(index) };
+
+    // The accessor shims cast the returned handle back to the
+    // `FieldExpirationChecker` monomorphization, so this is the only checker the
+    // iterator may carry; a differently-typed checker would give those casts an
+    // incompatible layout. Requirements 5 and 6 guarantee both inputs are present.
+    debug_assert!(!sctx.is_null(), "sctx must be non-null");
+    debug_assert!(!filter_ctx.is_null(), "filter_ctx must be non-null");
+
+    // SAFETY: guaranteed by 6.
+    let sctx_nn = unsafe { NonNull::new_unchecked(sctx) };
+    // SAFETY: guaranteed by 5.
+    let filter_ctx_val = unsafe { *filter_ctx };
+    // Wide-schema flag is irrelevant here: the vector field expiration
+    // check uses `FieldMaskOrIndex::Index`, not the mask path.
+    // SAFETY: guaranteed by 6.
+    let checker = unsafe { FieldExpirationChecker::new(sctx_nn, filter_ctx_val, 0) };
+    // SAFETY: `index` and `query_vector` are guaranteed by 1 and 2.
+    let reduced = unsafe {
+        new_vector_top_k(
+            index,
+            query_vector,
+            query_params,
+            k,
+            timeout,
+            skip_timeout_checks,
+            can_trim_deep_results,
+            checker,
+            child,
+        )
+    };
+    box_reduced(reduced)
+}
+
+/// Box a [`NewVectorTopK`] into the C [`QueryIterator`] handle, clearing the
+/// root-only `SkipTo` vtable slot so the C highlighter falls back to sequential
+/// reads. Generic over the expiration checker to keep the boxing path
+/// independent of the checker strategy.
+fn box_reduced<'index, E: ExpirationChecker + 'index>(
+    reduced: NewVectorTopK<'index, E>,
+) -> *mut QueryIterator {
+    let clear_skip_to = |ptr| {
+        // SAFETY: `ptr` comes from `boxed_new`/`boxed_new_compound` below and has no
+        // other alias yet, satisfying 1 and 2.
+        unsafe { patch_vtable(ptr, |h| h.SkipTo = None) }
+    };
+    match reduced {
+        NewVectorTopK::ReducedEmpty => RQEIteratorWrapper::boxed_new(rqe_iterators::Empty),
+        NewVectorTopK::Unfiltered(it) => {
+            let ptr = RQEIteratorWrapper::boxed_new(it);
+            clear_skip_to(ptr);
+            ptr
+        }
+        NewVectorTopK::Filtered(it) => {
+            // `boxed_new_compound` registers the `ProfileChildren` callback so
+            // `FT.PROFILE` recurses into and counts the filter subtree.
+            let ptr = RQEIteratorWrapper::boxed_new_compound(it);
+            clear_skip_to(ptr);
+            ptr
+        }
+    }
+}
+
+/// Cast a `*mut QueryIterator` back to
+/// its full Rust wrapper so accessors can reach `VectorScoreSource`.
+///
+/// # Safety
+///
+/// `it` must be a [`VectorTopKIterator`] and remain valid.
+const unsafe fn wrapper_mut(
+    it: *mut QueryIterator,
+) -> &'static mut RQEIteratorWrapper<VectorTopKIterator<'static>> {
+    // SAFETY: `it` was created by `RQEIteratorWrapper::boxed_new` with inner type
+    // `VectorTopKIterator<'static>`, so the cast is valid per `mut_ref_from_header_ptr`'s contract.
+    unsafe { RQEIteratorWrapper::<VectorTopKIterator<'static>>::mut_ref_from_header_ptr(it) }
+}
+
+/// Cast a `*const QueryIterator` produced by [`NewVectorTopKIterator`] back to
+/// its full Rust wrapper (shared).
+///
+/// # Safety
+///
+/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+///    created by [`NewVectorTopKIterator`].
+const unsafe fn wrapper_ref(
+    it: *const QueryIterator,
+) -> &'static RQEIteratorWrapper<VectorTopKIterator<'static>> {
+    // SAFETY: same contract as `wrapper_mut`.
+    unsafe { RQEIteratorWrapper::<VectorTopKIterator<'static>>::ref_from_header_ptr(it) }
+}
+
+/// Return a mutable reference to the `RLookupKey *` stored inside this iterator.
+///
+/// The key is initially `NULL`; the metrics-loader result processor writes
+/// through this pointer to set the iterator's score-output key.
+///
+/// # Safety
+///
+/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+///    created by [`NewVectorTopKIterator`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn VectorTopK_GetOwnKeyRef(it: *mut QueryIterator) -> *mut *mut RLookupKey {
+    debug_assert!(!it.is_null());
+    // SAFETY: guaranteed by 1.
+    let wrapper = unsafe { wrapper_mut(it) };
+    // `own_key` boxes a `*mut RLookupKey<'static>`; return the address of the
+    // boxed slot (the pointee), not of the `Box` field, so the pointer handed to
+    // C stays valid across iterator moves (e.g. the `FT.PROFILE` rebox). The slot
+    // holds an `RLookupKey<'static>`, whose `#[repr(C)]` prefix is `ffi::RLookupKey`,
+    // so the pointer-to-pointer reinterprets to the C type the caller expects.
+    (&raw mut *wrapper.inner.source_mut().own_key).cast::<*mut RLookupKey>()
+}
+
+/// Set the [`RLookupKeyHandle`] back-reference on this iterator.
+///
+/// The handle is used to invalidate the key pointer when the iterator is freed.
+///
+/// # Safety
+///
+/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+///    created by [`NewVectorTopKIterator`].
+/// 2. `handle` is either null or a valid pointer to a [`RLookupKeyHandle`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn VectorTopK_SetKeyHandle(
+    it: *mut QueryIterator,
+    handle: *mut RLookupKeyHandle,
+) {
+    debug_assert!(!it.is_null());
+    // SAFETY: guaranteed by 1.
+    let wrapper = unsafe { wrapper_mut(it) };
+    wrapper.inner.source_mut().key_handle = handle;
+}
+
+/// Return a C string describing the search mode that was used (or is being used) for this query.
+///
+/// - [`Unfiltered`](TopKMode::Unfiltered) → `VECSIM_STANDARD_KNN`
+/// - [`Batches`](TopKMode::Batches) → `VECSIM_HYBRID_BATCHES`
+/// - [`AdhocBF`](TopKMode::AdhocBF) → `VECSIM_HYBRID_ADHOC_BF` or
+///   `VECSIM_HYBRID_BATCHES_TO_ADHOC_BF` (when the mode was switched mid-execution)
+///
+/// The returned pointer is a static, null-terminated C string. It is valid for
+/// the lifetime of the program and must not be freed by the caller.
+///
+/// # Safety
+///
+/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+///    created by [`NewVectorTopKIterator`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn VectorTopK_GetSearchModeString(it: *const QueryIterator) -> *const c_char {
+    debug_assert!(!it.is_null());
+    // SAFETY: guaranteed by 1.
+    let wrapper = unsafe { wrapper_ref(it) };
+    let mode = wrapper.inner.mode();
+    let switches = wrapper.inner.metrics().strategy_switches;
+    let mode = match mode {
+        TopKMode::Unfiltered => VecSimSearchMode_VECSIM_STANDARD_KNN,
+        TopKMode::Batches | TopKMode::ForcedBatches => VecSimSearchMode_VECSIM_HYBRID_BATCHES,
+        TopKMode::AdhocBF if switches > 0 => VecSimSearchMode_VECSIM_HYBRID_BATCHES_TO_ADHOC_BF,
+        TopKMode::AdhocBF => VecSimSearchMode_VECSIM_HYBRID_ADHOC_BF,
+    };
+    // SAFETY: `VecSimSearchMode` and `VecSearchMode` are distinct bindgen types generated from
+    // two C enums that are kept in sync (same underlying integer type, matching variant values).
+    unsafe { ffi::VecSimSearchMode_ToString(mode) }
+}
+
+/// Return `true` if the iterator is, or has ever been, in batches mode.
+///
+/// This includes queries that started as batches before switching to ad-hoc BF.
+///
+/// # Safety
+///
+/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+///    created by [`NewVectorTopKIterator`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn VectorTopK_IsBatchMode(it: *const QueryIterator) -> bool {
+    debug_assert!(!it.is_null());
+    // SAFETY: guaranteed by 1.
+    let wrapper = unsafe { wrapper_ref(it) };
+    let mode = wrapper.inner.mode();
+    let switches = wrapper.inner.metrics().strategy_switches;
+    matches!(mode, TopKMode::Batches | TopKMode::ForcedBatches)
+        || matches!(mode, TopKMode::AdhocBF if switches > 0)
+}
+
+/// Return the number of batch iterations performed so far (Batches mode only).
+///
+/// # Safety
+///
+/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+///    created by [`NewVectorTopKIterator`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn VectorTopK_GetNumIterations(it: *const QueryIterator) -> usize {
+    debug_assert!(!it.is_null());
+    // SAFETY: guaranteed by 1.
+    let wrapper = unsafe { wrapper_ref(it) };
+    wrapper.inner.source().num_iterations
+}
+
+/// Return the largest batch size used during Batches mode.
+///
+/// # Safety
+///
+/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+///    created by [`NewVectorTopKIterator`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn VectorTopK_GetMaxBatchSize(it: *const QueryIterator) -> usize {
+    debug_assert!(!it.is_null());
+    // SAFETY: guaranteed by 1.
+    let wrapper = unsafe { wrapper_ref(it) };
+    wrapper.inner.source().max_batch_size
+}
+
+/// Return the zero-based batch index at which the maximum batch size occurred.
+///
+/// # Safety
+///
+/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+///    created by [`NewVectorTopKIterator`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn VectorTopK_GetMaxBatchIteration(it: *const QueryIterator) -> usize {
+    debug_assert!(!it.is_null());
+    // SAFETY: guaranteed by 1.
+    let wrapper = unsafe { wrapper_ref(it) };
+    wrapper.inner.source().max_batch_iteration
+}
+
+/// Return the filter child iterator, or `NULL` for a pure KNN query.
+///
+/// The returned pointer is non-owning; its lifetime is that of `it`.
+///
+/// # Safety
+///
+/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+///    created by [`NewVectorTopKIterator`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn VectorTopK_GetChild(it: *const QueryIterator) -> *mut QueryIterator {
+    debug_assert!(!it.is_null());
+    // SAFETY: guaranteed by 1.
+    let wrapper = unsafe { wrapper_ref(it) };
+    wrapper.inner.child().map_or(ptr::null_mut(), |c| {
+        c.as_ref() as *const QueryIterator as *mut QueryIterator
+    })
+}

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/vector_top_k.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/vector_top_k.rs
@@ -9,19 +9,13 @@
 
 //! Rust implementation of the vector top-k iterator and its C accessor functions.
 //!
-//! This module provides [`NewVectorTopKIterator`] (a drop-in replacement for the
-//! C `NewHybridVectorIterator`) together with the accessor shims that C callers
-//! use for query-plan construction and profiling.
+//! This module provides [`NewVectorTopKIterator`] together with the accessor
+//! shims that C callers use to bind the iterator's vector-score `RLookupKey`.
 
-use std::{
-    ffi::{c_char, c_void},
-    ptr::{self, NonNull},
-};
+use std::{ffi::c_void, ptr::NonNull};
 
 use ffi::{
     QueryIterator, RLookupKey, RLookupKeyHandle, RedisSearchCtx, VecSimIndex, VecSimQueryParams,
-    VecSimSearchMode_VECSIM_HYBRID_ADHOC_BF, VecSimSearchMode_VECSIM_HYBRID_BATCHES,
-    VecSimSearchMode_VECSIM_HYBRID_BATCHES_TO_ADHOC_BF, VecSimSearchMode_VECSIM_STANDARD_KNN,
     timespec,
 };
 use field::FieldFilterContext;
@@ -30,7 +24,6 @@ use rqe_iterators::{
     c2rust::CRQEIterator,
     interop::{RQEIteratorWrapper, patch_vtable},
 };
-use top_k::TopKMode;
 use vector_score_source::{NewVectorTopK, VectorTopKIterator, new_vector_top_k};
 
 /// Construct a vector top-k iterator and expose it as a C [`QueryIterator`].
@@ -177,31 +170,6 @@ unsafe fn wrapper_mut(
     unsafe { RQEIteratorWrapper::<VectorTopKIterator<'static>>::mut_ref_from_header_ptr(iter) }
 }
 
-/// Cast a `*const QueryIterator` produced by [`NewVectorTopKIterator`] back to
-/// its full Rust wrapper (shared).
-///
-/// # Safety
-///
-/// 1. `iter` is non-null, [valid], and was returned by [`NewVectorTopKIterator`]
-///    for a query that did not reduce to `Empty`, so its `type_` is
-///    [`IteratorType::Hybrid`].
-/// 2. No mutable reference to the wrapper is live for the duration of the
-///    returned borrow.
-/// 3. The `index` and `sctx` given to that [`NewVectorTopKIterator`] call are
-///    still alive.
-///
-/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
-unsafe fn wrapper_ref(
-    iter: *const QueryIterator,
-) -> &'static RQEIteratorWrapper<VectorTopKIterator<'static>> {
-    // SAFETY: guaranteed by 1.
-    debug_assert!(matches!(unsafe { (*iter).type_ }, IteratorType::Hybrid));
-    // SAFETY: 1 pins the inner type — `NewVectorTopKIterator` boxes only
-    // `VectorTopKIterator` with a `FieldExpirationChecker` — and 2 keeps the shared
-    // borrow unaliased; 3 makes the `'static` inner lifetime sound.
-    unsafe { RQEIteratorWrapper::<VectorTopKIterator<'static>>::ref_from_header_ptr(iter) }
-}
-
 /// Return a mutable reference to the `RLookupKey *` stored inside this iterator.
 ///
 /// The key is initially `NULL`; the metrics-loader result processor writes
@@ -242,114 +210,4 @@ pub unsafe extern "C" fn VectorTopK_SetKeyHandle(
     // SAFETY: guaranteed by 1.
     let wrapper = unsafe { wrapper_mut(it) };
     wrapper.inner.source_mut().key_handle = handle;
-}
-
-/// Return a C string describing the search mode that was used (or is being used) for this query.
-///
-/// - [`Unfiltered`](TopKMode::Unfiltered) → `VECSIM_STANDARD_KNN`
-/// - [`Batches`](TopKMode::Batches) → `VECSIM_HYBRID_BATCHES`
-/// - [`AdhocBF`](TopKMode::AdhocBF) → `VECSIM_HYBRID_ADHOC_BF` or
-///   `VECSIM_HYBRID_BATCHES_TO_ADHOC_BF` (when the mode was switched mid-execution)
-///
-/// The returned pointer is a static, null-terminated C string. It is valid for
-/// the lifetime of the program and must not be freed by the caller.
-///
-/// # Safety
-///
-/// 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
-///    to `Empty`, whose `index` and `sctx` are still alive.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn VectorTopK_GetSearchModeString(it: *const QueryIterator) -> *const c_char {
-    debug_assert!(!it.is_null());
-    // SAFETY: guaranteed by 1.
-    let wrapper = unsafe { wrapper_ref(it) };
-    let mode = wrapper.inner.mode();
-    let switches = wrapper.inner.metrics().strategy_switches;
-    let mode = match mode {
-        TopKMode::Unfiltered => VecSimSearchMode_VECSIM_STANDARD_KNN,
-        TopKMode::Batches | TopKMode::ForcedBatches => VecSimSearchMode_VECSIM_HYBRID_BATCHES,
-        TopKMode::AdhocBF if switches > 0 => VecSimSearchMode_VECSIM_HYBRID_BATCHES_TO_ADHOC_BF,
-        TopKMode::AdhocBF => VecSimSearchMode_VECSIM_HYBRID_ADHOC_BF,
-    };
-    // SAFETY: the call is sound for any `mode`; `mode` is initialized with ffi-driven constants.
-    unsafe { ffi::VecSimSearchMode_ToString(mode) }
-}
-
-/// Return `true` if the iterator is, or has ever been, in batches mode.
-///
-/// This includes queries that started as batches before switching to ad-hoc BF.
-///
-/// # Safety
-///
-/// 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
-///    to `Empty`, whose `index` and `sctx` are still alive.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn VectorTopK_IsBatchMode(it: *const QueryIterator) -> bool {
-    debug_assert!(!it.is_null());
-    // SAFETY: guaranteed by 1.
-    let wrapper = unsafe { wrapper_ref(it) };
-    let mode = wrapper.inner.mode();
-    let switches = wrapper.inner.metrics().strategy_switches;
-    matches!(mode, TopKMode::Batches | TopKMode::ForcedBatches)
-        || matches!(mode, TopKMode::AdhocBF if switches > 0)
-}
-
-/// Return the number of batch iterations performed so far (Batches mode only).
-///
-/// # Safety
-///
-/// 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
-///    to `Empty`, whose `index` and `sctx` are still alive.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn VectorTopK_GetNumIterations(it: *const QueryIterator) -> usize {
-    debug_assert!(!it.is_null());
-    // SAFETY: guaranteed by 1.
-    let wrapper = unsafe { wrapper_ref(it) };
-    wrapper.inner.source().num_iterations
-}
-
-/// Return the maximum batch size used during Batches mode.
-///
-/// # Safety
-///
-/// 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
-///    to `Empty`, whose `index` and `sctx` are still alive.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn VectorTopK_GetMaxBatchSize(it: *const QueryIterator) -> usize {
-    debug_assert!(!it.is_null());
-    // SAFETY: guaranteed by 1.
-    let wrapper = unsafe { wrapper_ref(it) };
-    wrapper.inner.source().max_batch_size
-}
-
-/// Return the zero-based batch index at which the maximum batch size occurred.
-///
-/// # Safety
-///
-/// 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
-///    to `Empty`, whose `index` and `sctx` are still alive.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn VectorTopK_GetMaxBatchIteration(it: *const QueryIterator) -> usize {
-    debug_assert!(!it.is_null());
-    // SAFETY: guaranteed by 1.
-    let wrapper = unsafe { wrapper_ref(it) };
-    wrapper.inner.source().max_batch_iteration
-}
-
-/// Return the filter child iterator, or `NULL` for a pure KNN query.
-///
-/// The returned pointer is non-owning; its lifetime is that of `it`.
-///
-/// # Safety
-///
-/// 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
-///    to `Empty`, whose `index` and `sctx` are still alive.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn VectorTopK_GetChild(it: *const QueryIterator) -> *mut QueryIterator {
-    debug_assert!(!it.is_null());
-    // SAFETY: guaranteed by 1.
-    let wrapper = unsafe { wrapper_ref(it) };
-    wrapper.inner.child().map_or(ptr::null_mut(), |c| {
-        c.as_ref() as *const QueryIterator as *mut QueryIterator
-    })
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/vector_top_k.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/vector_top_k.rs
@@ -26,7 +26,7 @@ use ffi::{
 };
 use field::FieldFilterContext;
 use rqe_iterators::{
-    ExpirationChecker, FieldExpirationChecker,
+    ExpirationChecker, FieldExpirationChecker, IteratorType,
     c2rust::CRQEIterator,
     interop::{RQEIteratorWrapper, patch_vtable},
 };
@@ -35,7 +35,9 @@ use vector_score_source::{NewVectorTopK, VectorTopKIterator, new_vector_top_k};
 
 /// Construct a vector top-k iterator and expose it as a C [`QueryIterator`].
 ///
-/// This call can reduce to an `Empty` iterator.
+/// This call can reduce to an `Empty` iterator, whose `type_` is
+/// [`IteratorType::Empty`] rather than [`IteratorType::Hybrid`]. The `VectorTopK_*`
+/// accessors below must not be called on such a handle.
 ///
 /// Pass `child = NULL` for a pure KNN query; pass a valid owning child iterator
 /// for a hybrid (filtered) query.
@@ -155,12 +157,23 @@ fn box_reduced<'index, E: ExpirationChecker + 'index>(
 ///
 /// # Safety
 ///
-/// `iter` must be a [`VectorTopKIterator`] and remain valid.
-const unsafe fn wrapper_mut(
+/// 1. `iter` is non-null, [valid], and was returned by [`NewVectorTopKIterator`]
+///    for a query that did not reduce to `Empty`, so its `type_` is
+///    [`IteratorType::Hybrid`].
+/// 2. No other reference to the wrapper is live for the duration of the returned
+///    borrow.
+/// 3. The `index` and `sctx` given to that [`NewVectorTopKIterator`] call are
+///    still alive.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe fn wrapper_mut(
     iter: *mut QueryIterator,
 ) -> &'static mut RQEIteratorWrapper<VectorTopKIterator<'static>> {
-    // SAFETY: `iter` was created by `RQEIteratorWrapper::boxed_new` with inner type
-    // `VectorTopKIterator<'static>`, so the cast is valid per `mut_ref_from_header_ptr`'s contract.
+    // SAFETY: guaranteed by 1.
+    debug_assert!(matches!(unsafe { (*iter).type_ }, IteratorType::Hybrid));
+    // SAFETY: 1 pins the inner type ; `NewVectorTopKIterator` boxes only
+    // `VectorTopKIterator` with a `FieldExpirationChecker` ; 2 gives the unique
+    // handle ; 3 makes the `'static` inner lifetime sound.
     unsafe { RQEIteratorWrapper::<VectorTopKIterator<'static>>::mut_ref_from_header_ptr(iter) }
 }
 
@@ -169,13 +182,23 @@ const unsafe fn wrapper_mut(
 ///
 /// # Safety
 ///
-/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
-///    created by [`NewVectorTopKIterator`].
-const unsafe fn wrapper_ref(
+/// 1. `iter` is non-null, [valid], and was returned by [`NewVectorTopKIterator`]
+///    for a query that did not reduce to `Empty`, so its `type_` is
+///    [`IteratorType::Hybrid`].
+/// 2. No mutable reference to the wrapper is live for the duration of the
+///    returned borrow.
+/// 3. The `index` and `sctx` given to that [`NewVectorTopKIterator`] call are
+///    still alive.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe fn wrapper_ref(
     iter: *const QueryIterator,
 ) -> &'static RQEIteratorWrapper<VectorTopKIterator<'static>> {
-    // SAFETY: `iter` was created by `RQEIteratorWrapper::boxed_new` with inner type
-    // `VectorTopKIterator<'static>`, so the cast is valid per `ref_from_header_ptr`'s contract.
+    // SAFETY: guaranteed by 1.
+    debug_assert!(matches!(unsafe { (*iter).type_ }, IteratorType::Hybrid));
+    // SAFETY: 1 pins the inner type — `NewVectorTopKIterator` boxes only
+    // `VectorTopKIterator` with a `FieldExpirationChecker` — and 2 keeps the shared
+    // borrow unaliased; 3 makes the `'static` inner lifetime sound.
     unsafe { RQEIteratorWrapper::<VectorTopKIterator<'static>>::ref_from_header_ptr(iter) }
 }
 
@@ -186,8 +209,8 @@ const unsafe fn wrapper_ref(
 ///
 /// # Safety
 ///
-/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
-///    created by [`NewVectorTopKIterator`].
+/// 1. `it` is a non-null, unaliased handle from [`NewVectorTopKIterator`] that did
+///    not reduce to `Empty`, whose `index` and `sctx` are still alive.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn VectorTopK_GetOwnKeyRef(it: *mut QueryIterator) -> *mut *mut RLookupKey {
     debug_assert!(!it.is_null());
@@ -207,8 +230,8 @@ pub unsafe extern "C" fn VectorTopK_GetOwnKeyRef(it: *mut QueryIterator) -> *mut
 ///
 /// # Safety
 ///
-/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
-///    created by [`NewVectorTopKIterator`].
+/// 1. `it` is a non-null, unaliased handle from [`NewVectorTopKIterator`] that did
+///    not reduce to `Empty`, whose `index` and `sctx` are still alive.
 /// 2. `handle` is either null or a valid pointer to a [`RLookupKeyHandle`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn VectorTopK_SetKeyHandle(
@@ -233,8 +256,8 @@ pub unsafe extern "C" fn VectorTopK_SetKeyHandle(
 ///
 /// # Safety
 ///
-/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
-///    created by [`NewVectorTopKIterator`].
+/// 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
+///    to `Empty`, whose `index` and `sctx` are still alive.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn VectorTopK_GetSearchModeString(it: *const QueryIterator) -> *const c_char {
     debug_assert!(!it.is_null());
@@ -248,8 +271,7 @@ pub unsafe extern "C" fn VectorTopK_GetSearchModeString(it: *const QueryIterator
         TopKMode::AdhocBF if switches > 0 => VecSimSearchMode_VECSIM_HYBRID_BATCHES_TO_ADHOC_BF,
         TopKMode::AdhocBF => VecSimSearchMode_VECSIM_HYBRID_ADHOC_BF,
     };
-    // SAFETY: `VecSimSearchMode` and `VecSearchMode` are distinct bindgen types generated from
-    // two C enums that are kept in sync (same underlying integer type, matching variant values).
+    // SAFETY: the call is sound for any `mode`; `mode` is initialized with ffi-driven constants.
     unsafe { ffi::VecSimSearchMode_ToString(mode) }
 }
 
@@ -259,8 +281,8 @@ pub unsafe extern "C" fn VectorTopK_GetSearchModeString(it: *const QueryIterator
 ///
 /// # Safety
 ///
-/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
-///    created by [`NewVectorTopKIterator`].
+/// 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
+///    to `Empty`, whose `index` and `sctx` are still alive.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn VectorTopK_IsBatchMode(it: *const QueryIterator) -> bool {
     debug_assert!(!it.is_null());
@@ -276,8 +298,8 @@ pub unsafe extern "C" fn VectorTopK_IsBatchMode(it: *const QueryIterator) -> boo
 ///
 /// # Safety
 ///
-/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
-///    created by [`NewVectorTopKIterator`].
+/// 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
+///    to `Empty`, whose `index` and `sctx` are still alive.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn VectorTopK_GetNumIterations(it: *const QueryIterator) -> usize {
     debug_assert!(!it.is_null());
@@ -290,8 +312,8 @@ pub unsafe extern "C" fn VectorTopK_GetNumIterations(it: *const QueryIterator) -
 ///
 /// # Safety
 ///
-/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
-///    created by [`NewVectorTopKIterator`].
+/// 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
+///    to `Empty`, whose `index` and `sctx` are still alive.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn VectorTopK_GetMaxBatchSize(it: *const QueryIterator) -> usize {
     debug_assert!(!it.is_null());
@@ -304,8 +326,8 @@ pub unsafe extern "C" fn VectorTopK_GetMaxBatchSize(it: *const QueryIterator) ->
 ///
 /// # Safety
 ///
-/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
-///    created by [`NewVectorTopKIterator`].
+/// 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
+///    to `Empty`, whose `index` and `sctx` are still alive.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn VectorTopK_GetMaxBatchIteration(it: *const QueryIterator) -> usize {
     debug_assert!(!it.is_null());
@@ -320,8 +342,8 @@ pub unsafe extern "C" fn VectorTopK_GetMaxBatchIteration(it: *const QueryIterato
 ///
 /// # Safety
 ///
-/// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
-///    created by [`NewVectorTopKIterator`].
+/// 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
+///    to `Empty`, whose `index` and `sctx` are still alive.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn VectorTopK_GetChild(it: *const QueryIterator) -> *mut QueryIterator {
     debug_assert!(!it.is_null());

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/vector_top_k.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/vector_top_k.rs
@@ -155,13 +155,13 @@ fn box_reduced<'index, E: ExpirationChecker + 'index>(
 ///
 /// # Safety
 ///
-/// `it` must be a [`VectorTopKIterator`] and remain valid.
+/// `iter` must be a [`VectorTopKIterator`] and remain valid.
 const unsafe fn wrapper_mut(
-    it: *mut QueryIterator,
+    iter: *mut QueryIterator,
 ) -> &'static mut RQEIteratorWrapper<VectorTopKIterator<'static>> {
-    // SAFETY: `it` was created by `RQEIteratorWrapper::boxed_new` with inner type
+    // SAFETY: `iter` was created by `RQEIteratorWrapper::boxed_new` with inner type
     // `VectorTopKIterator<'static>`, so the cast is valid per `mut_ref_from_header_ptr`'s contract.
-    unsafe { RQEIteratorWrapper::<VectorTopKIterator<'static>>::mut_ref_from_header_ptr(it) }
+    unsafe { RQEIteratorWrapper::<VectorTopKIterator<'static>>::mut_ref_from_header_ptr(iter) }
 }
 
 /// Cast a `*const QueryIterator` produced by [`NewVectorTopKIterator`] back to
@@ -172,10 +172,11 @@ const unsafe fn wrapper_mut(
 /// 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
 ///    created by [`NewVectorTopKIterator`].
 const unsafe fn wrapper_ref(
-    it: *const QueryIterator,
+    iter: *const QueryIterator,
 ) -> &'static RQEIteratorWrapper<VectorTopKIterator<'static>> {
-    // SAFETY: same contract as `wrapper_mut`.
-    unsafe { RQEIteratorWrapper::<VectorTopKIterator<'static>>::ref_from_header_ptr(it) }
+    // SAFETY: `iter` was created by `RQEIteratorWrapper::boxed_new` with inner type
+    // `VectorTopKIterator<'static>`, so the cast is valid per `ref_from_header_ptr`'s contract.
+    unsafe { RQEIteratorWrapper::<VectorTopKIterator<'static>>::ref_from_header_ptr(iter) }
 }
 
 /// Return a mutable reference to the `RLookupKey *` stored inside this iterator.
@@ -285,7 +286,7 @@ pub unsafe extern "C" fn VectorTopK_GetNumIterations(it: *const QueryIterator) -
     wrapper.inner.source().num_iterations
 }
 
-/// Return the largest batch size used during Batches mode.
+/// Return the maximum batch size used during Batches mode.
 ///
 /// # Safety
 ///

--- a/src/redisearch_rs/cheadergen.toml
+++ b/src/redisearch_rs/cheadergen.toml
@@ -109,7 +109,7 @@ inline static struct InvertedIndex *NewInvertedIndex(IndexFlags flags, size_t *m
 """
 
 [header.iterators_ffi]
-includes = ["redisearch.h", "<time.h>", "iterators/iterator_api.h", "tag_index.h", "query.h"]
+includes = ["redisearch.h", "<time.h>", "iterators/iterator_api.h", "tag_index.h", "query.h", "VecSim/vec_sim.h"]
 after_includes = """
 // In C, timespec is a struct tag, not a typedef. Rust's libc::timespec maps to
 // the bare name, so we introduce a typedef to make it valid C.

--- a/src/redisearch_rs/cheadergen.toml
+++ b/src/redisearch_rs/cheadergen.toml
@@ -110,7 +110,7 @@ inline static struct InvertedIndex *NewInvertedIndex(IndexFlags flags, size_t *m
 """
 
 [header.iterators_ffi]
-includes = ["redisearch.h", "<time.h>", "iterators/iterator_api.h", "tag_index.h", "query.h"]
+includes = ["redisearch.h", "<time.h>", "iterators/iterator_api.h", "tag_index.h", "query.h", "VecSim/vec_sim.h"]
 after_includes = """
 // In C, timespec is a struct tag, not a typedef. Rust's libc::timespec maps to
 // the bare name, so we introduce a typedef to make it valid C.

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -12,6 +12,7 @@
 #include "iterators/iterator_api.h"
 #include "tag_index.h"
 #include "query.h"
+#include "VecSim/vec_sim.h"
 #include "field.h"
 #include "query_types.h"
 #include "rqe_core.h"
@@ -413,6 +414,39 @@ QueryIterator *NewIntersectionIterator(QueryIterator * *its, size_t num, int32_t
 QueryIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const struct NumericFilter *flt, FieldType _for_type, const struct IteratorsConfig *config, const struct FieldFilterContext *filter_ctx);
 
 /**
+ * Construct a vector top-k iterator and expose it as a C [`QueryIterator`].
+ *
+ * This call can reduce to an `Empty` iterator.
+ *
+ * Pass `child = NULL` for a pure KNN query; pass a valid owning child iterator
+ * for a hybrid (filtered) query.
+ *
+ * The `query_params` pointer is read once to copy the parameters into the
+ * iterator; it is not retained after this call.
+ *
+ * `can_trim_deep_results` applies only to filtered queries: when `true`, the
+ * pipeline needs no rich results, so each match yields a metric-only result
+ * carrying just the vector score instead of a deep copy of the child's scoring
+ * subtree. It has no effect on a pure KNN query, which is metric-only anyway.
+ *
+ * # Safety
+ *
+ * 1. `index` is non-null and [valid], and outlives the returned iterator.
+ * 2. `query_vector` is [valid] for `vector_byte_len` bytes, and
+ *    `vector_byte_len` equals the index's expected query-vector size.
+ * 3. `query_params` is non-null and [valid] for a [`VecSimQueryParams`].
+ * 4. `child`, when non-null, is a [valid], owning `QueryIterator *` with every
+ *    callback populated.
+ * 5. `filter_ctx` is non-null and [valid] for a [`FieldFilterContext`] for the
+ *    duration of this call.
+ * 6. `sctx` is non-null and [valid] for a [`RedisSearchCtx`] with a [valid]
+ *    `spec`, both outliving the returned iterator.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+QueryIterator *NewVectorTopKIterator(VecSimIndex *index, const void *query_vector, size_t vector_byte_len, const VecSimQueryParams *query_params, size_t k, bool can_trim_deep_results, QueryIterator *child, timespec timeout, bool skip_timeout_checks, RedisSearchCtx *sctx, const struct FieldFilterContext *filter_ctx);
+
+/**
  * Creates a new union iterator, applying reduction rules and choosing between
  * flat and heap variants based on the number of children.
  *
@@ -632,6 +666,19 @@ QueryIterator *NewInvIndIterator_WildcardQuery(const InvertedIndex *idx, const R
 RLookupKey * *GetMetricOwnKeyRef(QueryIterator *header);
 
 /**
+ * Return a mutable reference to the `RLookupKey *` stored inside this iterator.
+ *
+ * The key is initially `NULL`; the metrics-loader result processor writes
+ * through this pointer to set the iterator's score-output key.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+ *    created by [`NewVectorTopKIterator`].
+ */
+RLookupKey * *VectorTopK_GetOwnKeyRef(QueryIterator *it);
+
+/**
  * Creates a new tag inverted index iterator.
  *
  * # Parameters
@@ -669,6 +716,19 @@ RLookupKey * *GetMetricOwnKeyRef(QueryIterator *header);
 QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagIndex *tag_idx, const RedisSearchCtx *sctx, union FieldMaskOrIndex field_mask_or_index, struct RSQueryTerm *term, double weight);
 
 /**
+ * Set the [`RLookupKeyHandle`] back-reference on this iterator.
+ *
+ * The handle is used to invalidate the key pointer when the iterator is freed.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+ *    created by [`NewVectorTopKIterator`].
+ * 2. `handle` is either null or a valid pointer to a [`RLookupKeyHandle`].
+ */
+void VectorTopK_SetKeyHandle(QueryIterator *it, RLookupKeyHandle *handle);
+
+/**
  * Creates a NOT iterator, choosing between non-optimized and optimized based
  * on the query evaluation context.
  *
@@ -702,6 +762,78 @@ QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagInd
  *    valid for the lifetime of the returned iterator.
  */
 QueryIterator *NewNotIterator(QueryIterator *child, t_docId max_doc_id, double weight, timespec timeout, AREQ *bc_timeout_areq, QueryEvalCtx *q);
+
+/**
+ * Return a C string describing the search mode that was used (or is being used) for this query.
+ *
+ * - [`Unfiltered`](TopKMode::Unfiltered) → `VECSIM_STANDARD_KNN`
+ * - [`Batches`](TopKMode::Batches) → `VECSIM_HYBRID_BATCHES`
+ * - [`AdhocBF`](TopKMode::AdhocBF) → `VECSIM_HYBRID_ADHOC_BF` or
+ *   `VECSIM_HYBRID_BATCHES_TO_ADHOC_BF` (when the mode was switched mid-execution)
+ *
+ * The returned pointer is a static, null-terminated C string. It is valid for
+ * the lifetime of the program and must not be freed by the caller.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+ *    created by [`NewVectorTopKIterator`].
+ */
+const char *VectorTopK_GetSearchModeString(const QueryIterator *it);
+
+/**
+ * Return `true` if the iterator is, or has ever been, in batches mode.
+ *
+ * This includes queries that started as batches before switching to ad-hoc BF.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+ *    created by [`NewVectorTopKIterator`].
+ */
+bool VectorTopK_IsBatchMode(const QueryIterator *it);
+
+/**
+ * Return the number of batch iterations performed so far (Batches mode only).
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+ *    created by [`NewVectorTopKIterator`].
+ */
+size_t VectorTopK_GetNumIterations(const QueryIterator *it);
+
+/**
+ * Return the largest batch size used during Batches mode.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+ *    created by [`NewVectorTopKIterator`].
+ */
+size_t VectorTopK_GetMaxBatchSize(const QueryIterator *it);
+
+/**
+ * Return the zero-based batch index at which the maximum batch size occurred.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+ *    created by [`NewVectorTopKIterator`].
+ */
+size_t VectorTopK_GetMaxBatchIteration(const QueryIterator *it);
+
+/**
+ * Return the filter child iterator, or `NULL` for a pure KNN query.
+ *
+ * The returned pointer is non-owning; its lifetime is that of `it`.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+ *    created by [`NewVectorTopKIterator`].
+ */
+QueryIterator *VectorTopK_GetChild(const QueryIterator *it);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -12,6 +12,7 @@
 #include "iterators/iterator_api.h"
 #include "tag_index.h"
 #include "query.h"
+#include "VecSim/vec_sim.h"
 #include "field.h"
 #include "query_types.h"
 #include "rqe_core.h"
@@ -606,6 +607,39 @@ QueryIterator *NewUnionIterator(QueryIterator * *its, int32_t num, bool quick_ex
 QueryIterator *NewUnsortedIdListIterator(t_docId *ids, uint64_t num, double weight);
 
 /**
+ * Construct a vector top-k iterator and expose it as a C [`QueryIterator`].
+ *
+ * This call can reduce to an `Empty` iterator.
+ *
+ * Pass `child = NULL` for a pure KNN query; pass a valid owning child iterator
+ * for a hybrid (filtered) query.
+ *
+ * The `query_params` pointer is read once to copy the parameters into the
+ * iterator; it is not retained after this call.
+ *
+ * `can_trim_deep_results` applies only to filtered queries: when `true`, the
+ * pipeline needs no rich results, so each match yields a metric-only result
+ * carrying just the vector score instead of a deep copy of the child's scoring
+ * subtree. It has no effect on a pure KNN query, which is metric-only anyway.
+ *
+ * # Safety
+ *
+ * 1. `index` is non-null and [valid], and outlives the returned iterator.
+ * 2. `query_vector` is [valid] for `vector_byte_len` bytes, and
+ *    `vector_byte_len` equals the index's expected query-vector size.
+ * 3. `query_params` is non-null and [valid] for a [`VecSimQueryParams`].
+ * 4. `child`, when non-null, is a [valid], owning `QueryIterator *` with every
+ *    callback populated.
+ * 5. `filter_ctx` is non-null and [valid] for a [`FieldFilterContext`] for the
+ *    duration of this call.
+ * 6. `sctx` is non-null and [valid] for a [`RedisSearchCtx`] with a [valid]
+ *    `spec`, both outliving the returned iterator.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+QueryIterator *NewVectorTopKIterator(VecSimIndex *index, const void *query_vector, size_t vector_byte_len, const VecSimQueryParams *query_params, size_t k, bool can_trim_deep_results, QueryIterator *child, timespec timeout, bool skip_timeout_checks, RedisSearchCtx *sctx, const struct FieldFilterContext *filter_ctx);
+
+/**
  * Creates a new wildcard iterator from a query evaluation context.
  *
  * There are three possible code paths:
@@ -741,6 +775,104 @@ void SetMetricRLookupHandle(QueryIterator *header, struct RLookupKeyHandle *key_
  *    created via [`NewUnionIterator`].
  */
 void TrimUnionIterator(QueryIterator *it, size_t limit, bool asc);
+
+/**
+ * Return the filter child iterator, or `NULL` for a pure KNN query.
+ *
+ * The returned pointer is non-owning; its lifetime is that of `it`.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+ *    created by [`NewVectorTopKIterator`].
+ */
+QueryIterator *VectorTopK_GetChild(const QueryIterator *it);
+
+/**
+ * Return the zero-based batch index at which the maximum batch size occurred.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+ *    created by [`NewVectorTopKIterator`].
+ */
+size_t VectorTopK_GetMaxBatchIteration(const QueryIterator *it);
+
+/**
+ * Return the largest batch size used during Batches mode.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+ *    created by [`NewVectorTopKIterator`].
+ */
+size_t VectorTopK_GetMaxBatchSize(const QueryIterator *it);
+
+/**
+ * Return the number of batch iterations performed so far (Batches mode only).
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+ *    created by [`NewVectorTopKIterator`].
+ */
+size_t VectorTopK_GetNumIterations(const QueryIterator *it);
+
+/**
+ * Return a mutable reference to the `RLookupKey *` stored inside this iterator.
+ *
+ * The key is initially `NULL`; the metrics-loader result processor writes
+ * through this pointer to set the iterator's score-output key.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+ *    created by [`NewVectorTopKIterator`].
+ */
+RLookupKey * *VectorTopK_GetOwnKeyRef(QueryIterator *it);
+
+/**
+ * Return a C string describing the search mode that was used (or is being used) for this query.
+ *
+ * - [`Unfiltered`](TopKMode::Unfiltered) → `VECSIM_STANDARD_KNN`
+ * - [`Batches`](TopKMode::Batches) → `VECSIM_HYBRID_BATCHES`
+ * - [`AdhocBF`](TopKMode::AdhocBF) → `VECSIM_HYBRID_ADHOC_BF` or
+ *   `VECSIM_HYBRID_BATCHES_TO_ADHOC_BF` (when the mode was switched mid-execution)
+ *
+ * The returned pointer is a static, null-terminated C string. It is valid for
+ * the lifetime of the program and must not be freed by the caller.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+ *    created by [`NewVectorTopKIterator`].
+ */
+const char *VectorTopK_GetSearchModeString(const QueryIterator *it);
+
+/**
+ * Return `true` if the iterator is, or has ever been, in batches mode.
+ *
+ * This includes queries that started as batches before switching to ad-hoc BF.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+ *    created by [`NewVectorTopKIterator`].
+ */
+bool VectorTopK_IsBatchMode(const QueryIterator *it);
+
+/**
+ * Set the [`RLookupKeyHandle`] back-reference on this iterator.
+ *
+ * The handle is used to invalidate the key pointer when the iterator is freed.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
+ *    created by [`NewVectorTopKIterator`].
+ * 2. `handle` is either null or a valid pointer to a [`RLookupKeyHandle`].
+ */
+void VectorTopK_SetKeyHandle(QueryIterator *it, RLookupKeyHandle *handle);
 
 /**
  *

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -779,48 +779,6 @@ void SetMetricRLookupHandle(QueryIterator *header, struct RLookupKeyHandle *key_
 void TrimUnionIterator(QueryIterator *it, size_t limit, bool asc);
 
 /**
- * Return the filter child iterator, or `NULL` for a pure KNN query.
- *
- * The returned pointer is non-owning; its lifetime is that of `it`.
- *
- * # Safety
- *
- * 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
- *    to `Empty`, whose `index` and `sctx` are still alive.
- */
-QueryIterator *VectorTopK_GetChild(const QueryIterator *it);
-
-/**
- * Return the zero-based batch index at which the maximum batch size occurred.
- *
- * # Safety
- *
- * 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
- *    to `Empty`, whose `index` and `sctx` are still alive.
- */
-size_t VectorTopK_GetMaxBatchIteration(const QueryIterator *it);
-
-/**
- * Return the maximum batch size used during Batches mode.
- *
- * # Safety
- *
- * 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
- *    to `Empty`, whose `index` and `sctx` are still alive.
- */
-size_t VectorTopK_GetMaxBatchSize(const QueryIterator *it);
-
-/**
- * Return the number of batch iterations performed so far (Batches mode only).
- *
- * # Safety
- *
- * 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
- *    to `Empty`, whose `index` and `sctx` are still alive.
- */
-size_t VectorTopK_GetNumIterations(const QueryIterator *it);
-
-/**
  * Return a mutable reference to the `RLookupKey *` stored inside this iterator.
  *
  * The key is initially `NULL`; the metrics-loader result processor writes
@@ -832,36 +790,6 @@ size_t VectorTopK_GetNumIterations(const QueryIterator *it);
  *    not reduce to `Empty`, whose `index` and `sctx` are still alive.
  */
 RLookupKey * *VectorTopK_GetOwnKeyRef(QueryIterator *it);
-
-/**
- * Return a C string describing the search mode that was used (or is being used) for this query.
- *
- * - [`Unfiltered`](TopKMode::Unfiltered) → `VECSIM_STANDARD_KNN`
- * - [`Batches`](TopKMode::Batches) → `VECSIM_HYBRID_BATCHES`
- * - [`AdhocBF`](TopKMode::AdhocBF) → `VECSIM_HYBRID_ADHOC_BF` or
- *   `VECSIM_HYBRID_BATCHES_TO_ADHOC_BF` (when the mode was switched mid-execution)
- *
- * The returned pointer is a static, null-terminated C string. It is valid for
- * the lifetime of the program and must not be freed by the caller.
- *
- * # Safety
- *
- * 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
- *    to `Empty`, whose `index` and `sctx` are still alive.
- */
-const char *VectorTopK_GetSearchModeString(const QueryIterator *it);
-
-/**
- * Return `true` if the iterator is, or has ever been, in batches mode.
- *
- * This includes queries that started as batches before switching to ad-hoc BF.
- *
- * # Safety
- *
- * 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
- *    to `Empty`, whose `index` and `sctx` are still alive.
- */
-bool VectorTopK_IsBatchMode(const QueryIterator *it);
 
 /**
  * Set the [`RLookupKeyHandle`] back-reference on this iterator.

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -609,7 +609,9 @@ QueryIterator *NewUnsortedIdListIterator(t_docId *ids, uint64_t num, double weig
 /**
  * Construct a vector top-k iterator and expose it as a C [`QueryIterator`].
  *
- * This call can reduce to an `Empty` iterator.
+ * This call can reduce to an `Empty` iterator, whose `type_` is
+ * [`IteratorType::Empty`] rather than [`IteratorType::Hybrid`]. The `VectorTopK_*`
+ * accessors below must not be called on such a handle.
  *
  * Pass `child = NULL` for a pure KNN query; pass a valid owning child iterator
  * for a hybrid (filtered) query.
@@ -783,8 +785,8 @@ void TrimUnionIterator(QueryIterator *it, size_t limit, bool asc);
  *
  * # Safety
  *
- * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
- *    created by [`NewVectorTopKIterator`].
+ * 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
+ *    to `Empty`, whose `index` and `sctx` are still alive.
  */
 QueryIterator *VectorTopK_GetChild(const QueryIterator *it);
 
@@ -793,18 +795,18 @@ QueryIterator *VectorTopK_GetChild(const QueryIterator *it);
  *
  * # Safety
  *
- * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
- *    created by [`NewVectorTopKIterator`].
+ * 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
+ *    to `Empty`, whose `index` and `sctx` are still alive.
  */
 size_t VectorTopK_GetMaxBatchIteration(const QueryIterator *it);
 
 /**
- * Return the largest batch size used during Batches mode.
+ * Return the maximum batch size used during Batches mode.
  *
  * # Safety
  *
- * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
- *    created by [`NewVectorTopKIterator`].
+ * 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
+ *    to `Empty`, whose `index` and `sctx` are still alive.
  */
 size_t VectorTopK_GetMaxBatchSize(const QueryIterator *it);
 
@@ -813,8 +815,8 @@ size_t VectorTopK_GetMaxBatchSize(const QueryIterator *it);
  *
  * # Safety
  *
- * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
- *    created by [`NewVectorTopKIterator`].
+ * 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
+ *    to `Empty`, whose `index` and `sctx` are still alive.
  */
 size_t VectorTopK_GetNumIterations(const QueryIterator *it);
 
@@ -826,8 +828,8 @@ size_t VectorTopK_GetNumIterations(const QueryIterator *it);
  *
  * # Safety
  *
- * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
- *    created by [`NewVectorTopKIterator`].
+ * 1. `it` is a non-null, unaliased handle from [`NewVectorTopKIterator`] that did
+ *    not reduce to `Empty`, whose `index` and `sctx` are still alive.
  */
 RLookupKey * *VectorTopK_GetOwnKeyRef(QueryIterator *it);
 
@@ -844,8 +846,8 @@ RLookupKey * *VectorTopK_GetOwnKeyRef(QueryIterator *it);
  *
  * # Safety
  *
- * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
- *    created by [`NewVectorTopKIterator`].
+ * 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
+ *    to `Empty`, whose `index` and `sctx` are still alive.
  */
 const char *VectorTopK_GetSearchModeString(const QueryIterator *it);
 
@@ -856,8 +858,8 @@ const char *VectorTopK_GetSearchModeString(const QueryIterator *it);
  *
  * # Safety
  *
- * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
- *    created by [`NewVectorTopKIterator`].
+ * 1. `it` is a non-null handle from [`NewVectorTopKIterator`] that did not reduce
+ *    to `Empty`, whose `index` and `sctx` are still alive.
  */
 bool VectorTopK_IsBatchMode(const QueryIterator *it);
 
@@ -868,8 +870,8 @@ bool VectorTopK_IsBatchMode(const QueryIterator *it);
  *
  * # Safety
  *
- * 1. `it` must be a valid, non-null pointer to a [`VectorTopKIterator`] that was
- *    created by [`NewVectorTopKIterator`].
+ * 1. `it` is a non-null, unaliased handle from [`NewVectorTopKIterator`] that did
+ *    not reduce to `Empty`, whose `index` and `sctx` are still alive.
  * 2. `handle` is either null or a valid pointer to a [`RLookupKeyHandle`].
  */
 void VectorTopK_SetKeyHandle(QueryIterator *it, RLookupKeyHandle *handle);

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -483,17 +483,18 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             // and takes the source-built path below.
             if self.child.is_some() && self.source.yields_child_record() {
                 if self.can_trim_deep_results {
-                    // Build a metric-only result, then fold in the child's
-                    // yielded metrics (explicit output/sort fields) captured at
-                    // match time.
-                    let mut result = self.source.build_result(doc_id, score);
+                    // Carry the child's captured metrics and attach our score
+                    // last, so a lookup key shared with the child (e.g. nested
+                    // KNN reusing an `AS` alias) keeps the outer vector score.
+                    let mut result = match record {
+                        Some(record) => record,
+                        None => self.source.build_result(doc_id, score),
+                    };
                     if self.source.is_expired(&result) {
                         continue;
                     }
                     self.last_doc_id = doc_id;
-                    if let Some(mut record) = record {
-                        result.metrics_mut().concat(record.metrics_mut());
-                    }
+                    self.source.attach_score_metric(&mut result, score);
                     *self.current = Some(result);
                     return Ok(self.current.as_mut());
                 }

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -11,7 +11,7 @@
 
 use std::{cmp::Ordering, num::NonZeroUsize};
 
-use rqe_core::DocId;
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 use index_result::RSIndexResult;
 use rqe_iterator_type::IteratorType;
@@ -887,8 +887,8 @@ fn batches_preserves_child_scoring_fields() {
 
 /// The dual of [`batches_preserves_child_scoring_fields`]: when the pipeline can
 /// trim deep results, the child's scoring subtree is never captured, so each
-/// match yields the source's metric-only result (default freq/field_mask) rather
-/// than the child's rich record.
+/// match yields a metric-only result carrying the `build_metric` defaults
+/// (freq 0, [`RS_FIELDMASK_ALL`]) rather than the child's rich record.
 #[test]
 fn batches_trim_deep_results_yields_metric_only() {
     use index_result::RSIndexResult;
@@ -918,9 +918,12 @@ fn batches_trim_deep_results_yields_metric_only() {
     }
 
     // Same doc ids and best-first order as the rich path, but the child's
-    // freq/field_mask are absent — the yielded record is the source's
-    // metric-only result.
-    assert_eq!(emitted, vec![(2, 0, 0), (1, 0, 0)]);
+    // freq/field_mask are dropped — the yielded record carries the metric-only
+    // defaults instead.
+    assert_eq!(
+        emitted,
+        vec![(2, 0, RS_FIELDMASK_ALL), (1, 0, RS_FIELDMASK_ALL)]
+    );
 }
 
 /// Adhoc-BF counterpart of [`batches_trim_deep_results_yields_metric_only`]:
@@ -955,7 +958,10 @@ fn adhoc_trim_deep_results_yields_metric_only() {
         emitted.push((r.doc_id, r.freq, r.field_mask));
     }
 
-    assert_eq!(emitted, vec![(2, 0, 0), (1, 0, 0)]);
+    assert_eq!(
+        emitted,
+        vec![(2, 0, RS_FIELDMASK_ALL), (1, 0, RS_FIELDMASK_ALL)]
+    );
 }
 
 /// Trimming skips the child's scoring subtree but must still carry its yielded
@@ -992,7 +998,13 @@ fn batches_trim_deep_results_preserves_child_metrics() {
         emitted.push((r.doc_id, r.freq, r.field_mask, metric));
     }
 
-    // Rich subtree is trimmed (freq/field_mask are the source's defaults), but
-    // the child's yielded metric rides along on every result.
-    assert_eq!(emitted, vec![(2, 0, 0, Some(42.0)), (1, 0, 0, Some(42.0))]);
+    // Rich subtree is trimmed (freq/field_mask carry the metric-only defaults),
+    // but the child's yielded metric rides along on every result.
+    assert_eq!(
+        emitted,
+        vec![
+            (2, 0, RS_FIELDMASK_ALL, Some(42.0)),
+            (1, 0, RS_FIELDMASK_ALL, Some(42.0))
+        ]
+    );
 }

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -11,7 +11,7 @@
 
 use std::num::NonZeroUsize;
 
-use rqe_core::{DocId, RS_FIELDMASK_ALL};
+use rqe_core::{DocId, FieldMask, RS_FIELDMASK_ALL};
 
 use index_result::RSIndexResult;
 use rqe_iterator_type::IteratorType;
@@ -83,6 +83,26 @@ impl ScoreSource for TimingOutSource {
 /// Ascending comparator: lower score is better (e.g. vector distance).
 fn make_child<'a>(ids: Vec<DocId>) -> Box<dyn RQEIterator<'a> + 'a> {
     Box::new(IdList::<true>::new(ids))
+}
+
+/// A child result carrying the scoring inputs a text match contributes —
+/// frequency and field mask — set to values [`RSIndexResult::build_metric`]
+/// never produces, so [`drain_scoring_fields`] can tell the two records apart.
+fn scoring_child_result<'a>() -> RSIndexResult<'a> {
+    RSIndexResult::build_virt()
+        .frequency(7)
+        .field_mask(0xABC)
+        .build()
+}
+
+/// Read `it` to EOF, keeping the fields that tell a propagated child record
+/// apart from a metric-only one.
+fn drain_scoring_fields<'a>(it: &mut impl RQEIterator<'a>) -> Vec<(DocId, u32, FieldMask)> {
+    let mut emitted = Vec::new();
+    while let Some(r) = it.read().unwrap() {
+        emitted.push((r.doc_id, r.freq, r.field_mask));
+    }
+    emitted
 }
 
 /// Build an [`IdList`] from `ids` and wrap it in a [`CRQEIterator`] so the
@@ -924,27 +944,16 @@ fn profile_children_with_no_child_is_identity() {
     assert_eq!(doc_ids, vec![1, 2]);
 }
 
+/// Without trimming, the Batches path yields the child's own record, so a
+/// BM25/TFIDF score computed from it is the child's, not zero.
+///
 /// Regression test for MOD-8142 (Python: `test_mod_8142` in
 /// `tests/pytests/test_issues.py`).
-///
-/// A KNN search with `WITHSCORES` returned a score of `0`: the Batches path
-/// carried only `(doc_id, score)` through the heap, so the child's scoring
-/// inputs (`freq`, `field_mask`, term records) that BM25/TFIDF need were lost.
-///
-/// Reproduced without Redis: a child result with non-default scoring fields
-/// must still carry them after passing through `TopKIterator`.
 #[test]
 fn batches_preserves_child_scoring_fields() {
-    use index_result::RSIndexResult;
     use rqe_iterators::IdList;
 
-    // Build a child whose result carries the scoring-relevant fields a
-    // text query would produce (analogous to BM25 inputs from "city").
-    let child_result = RSIndexResult::build_virt()
-        .frequency(7)
-        .field_mask(0xABC)
-        .build();
-    let child = IdList::<true>::with_result(vec![1, 2], child_result);
+    let child = IdList::<true>::with_result(vec![1, 2], scoring_child_result());
 
     // Source emits a single batch containing both doc IDs (analogous to
     // the KNN batch returned by VecSim).
@@ -959,35 +968,22 @@ fn batches_preserves_child_scoring_fields() {
         Ascending,
     ));
 
-    let mut emitted = Vec::new();
-    while let Some(r) = it.read().unwrap() {
-        emitted.push((r.doc_id, r.freq, r.field_mask));
-    }
+    let emitted = drain_scoring_fields(&mut it);
 
-    // Best-first ASC order; each result should still carry the child's
-    // scoring fields rather than a freshly rebuilt record.
-    assert_eq!(
-        emitted,
-        vec![(2, 7, 0xABC), (1, 7, 0xABC)],
-        "child's scoring fields (freq, field_mask) were dropped — \
-          got {emitted:?}; the BM25-becomes-0 bug from MOD-8142"
-    );
+    // Best-first ASC order, each result carrying the child's scoring fields
+    // rather than a freshly rebuilt record.
+    assert_eq!(emitted, vec![(2, 7, 0xABC), (1, 7, 0xABC)]);
 }
 
-/// The dual of [`batches_preserves_child_scoring_fields`]: when the pipeline can
-/// trim deep results, the child's scoring subtree is never captured, so each
+/// Same setup as [`batches_preserves_child_scoring_fields`], with deep-result
+/// trimming enabled: the child's scoring subtree is never captured, so each
 /// match yields a metric-only result carrying the `build_metric` defaults
 /// (freq 0, [`RS_FIELDMASK_ALL`]) rather than the child's rich record.
 #[test]
 fn batches_trim_deep_results_yields_metric_only() {
-    use index_result::RSIndexResult;
     use rqe_iterators::IdList;
 
-    let child_result = RSIndexResult::build_virt()
-        .frequency(7)
-        .field_mask(0xABC)
-        .build();
-    let child = IdList::<true>::with_result(vec![1, 2], child_result);
+    let child = IdList::<true>::with_result(vec![1, 2], scoring_child_result());
 
     let source = MockScoreSource::new(vec![vec![(1, 0.9), (2, 0.5)]], vec![], |_, _| {
         BatchStrategy::Continue
@@ -1001,10 +997,7 @@ fn batches_trim_deep_results_yields_metric_only() {
     )
     .with_trim_deep_results(true);
 
-    let mut emitted = Vec::new();
-    while let Some(r) = it.read().unwrap() {
-        emitted.push((r.doc_id, r.freq, r.field_mask));
-    }
+    let emitted = drain_scoring_fields(&mut it);
 
     // Same doc ids and best-first order as the rich path, but the child's
     // freq/field_mask are dropped — the yielded record carries the metric-only
@@ -1020,14 +1013,9 @@ fn batches_trim_deep_results_yields_metric_only() {
 /// trimmed.
 #[test]
 fn adhoc_trim_deep_results_yields_metric_only() {
-    use index_result::RSIndexResult;
     use rqe_iterators::IdList;
 
-    let child_result = RSIndexResult::build_virt()
-        .frequency(7)
-        .field_mask(0xABC)
-        .build();
-    let child = IdList::<true>::with_result(vec![1, 2], child_result);
+    let child = IdList::<true>::with_result(vec![1, 2], scoring_child_result());
 
     let source = MockScoreSource::new(vec![], vec![(1, 0.9), (2, 0.5)], |_, _| {
         BatchStrategy::Continue
@@ -1042,10 +1030,7 @@ fn adhoc_trim_deep_results_yields_metric_only() {
     )
     .with_trim_deep_results(true);
 
-    let mut emitted = Vec::new();
-    while let Some(r) = it.read().unwrap() {
-        emitted.push((r.doc_id, r.freq, r.field_mask));
-    }
+    let emitted = drain_scoring_fields(&mut it);
 
     assert_eq!(
         emitted,
@@ -1058,14 +1043,10 @@ fn adhoc_trim_deep_results_yields_metric_only() {
 /// fields rather than part of the rich subtree.
 #[test]
 fn batches_trim_deep_results_preserves_child_metrics() {
-    use index_result::RSIndexResult;
     use rqe_iterators::IdList;
 
-    // Child result with rich scoring fields *and* a yielded metric.
-    let mut child_result = RSIndexResult::build_virt()
-        .frequency(7)
-        .field_mask(0xABC)
-        .build();
+    // The scoring child, plus a yielded metric on top.
+    let mut child_result = scoring_child_result();
     child_result.metrics_mut().push_without_key(42.0);
     let child = IdList::<true>::with_result(vec![1, 2], child_result);
 

--- a/src/redisearch_rs/vector_score_source/Cargo.toml
+++ b/src/redisearch_rs/vector_score_source/Cargo.toml
@@ -19,6 +19,7 @@ index_result.workspace = true
 redis_reply.workspace = true
 rlookup.workspace = true
 rqe_core.workspace = true
+rqe_iterator_type.workspace = true
 rqe_iterators.workspace = true
 top_k = {path = "../top_k"}
 tracing.workspace = true

--- a/src/redisearch_rs/vector_score_source/src/lib.rs
+++ b/src/redisearch_rs/vector_score_source/src/lib.rs
@@ -50,6 +50,8 @@ use top_k::{TopKIterator, TopKMode, TopKSourceProfile};
 
 /// A [`TopKIterator`] parameterised over [`VectorScoreSource`].
 ///
+/// Its type is [`rqe_iterators::IteratorType::Hybrid`].
+///
 /// Use [`new_vector_top_k_unfiltered`] or [`new_vector_top_k_filtered`]
 /// to construct one; these constructors encode the mode-selection logic.
 ///

--- a/src/redisearch_rs/vector_score_source/src/lib.rs
+++ b/src/redisearch_rs/vector_score_source/src/lib.rs
@@ -50,6 +50,8 @@ use top_k::{Ascending, TopKIterator, TopKMode, TopKSourceProfile};
 
 /// A [`TopKIterator`] parameterised over [`VectorScoreSource`].
 ///
+/// Its type is [`rqe_iterators::IteratorType::Hybrid`].
+///
 /// Use [`new_vector_top_k_unfiltered`] or [`new_vector_top_k_filtered`]
 /// to construct one; these constructors encode the mode-selection logic.
 ///

--- a/src/redisearch_rs/vector_score_source/src/reducer.rs
+++ b/src/redisearch_rs/vector_score_source/src/reducer.rs
@@ -13,7 +13,8 @@
 use std::{num::NonZeroUsize, ptr::NonNull};
 
 use ffi::{VecSearchMode_STANDARD_KNN, VecSimIndex, VecSimQueryParams, timespec};
-use rqe_iterators::{ExpirationChecker, IteratorType, RQEIterator, c2rust::CRQEIterator};
+use rqe_iterator_type::IteratorType;
+use rqe_iterators::{ExpirationChecker, RQEIterator, c2rust::CRQEIterator};
 use top_k::TopKIterator;
 
 use crate::{

--- a/src/redisearch_rs/vector_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source.rs
@@ -16,9 +16,7 @@
 //! neighbours are simply the highest ids — making every expected ordering
 //! trivially predictable.
 
-use std::num::NonZeroUsize;
-
-use std::collections::HashSet;
+use std::{collections::HashSet, num::NonZeroUsize, ptr};
 
 use ffi::{RLookupKey, t_docId};
 use index_result::{RSIndexResult, RSResultKind};
@@ -381,10 +379,16 @@ fn index_size_reflects_added_vectors() {
 
 /// A zero-filled lookup key. The metrics channel only compares the key's
 /// address, so the fields are never read.
-fn make_key() -> RLookupKey {
-    // SAFETY: `RLookupKey` is plain data whose all-zero state (null pointers,
-    // zero indices) is valid and never dereferenced by the metrics code.
-    unsafe { std::mem::zeroed() }
+const fn make_key() -> RLookupKey {
+    RLookupKey {
+        dstidx: 0,
+        svidx: 0,
+        flags: 0,
+        path: ptr::null(),
+        name: ptr::null(),
+        name_len: 0,
+        next: ptr::null_mut(),
+    }
 }
 
 /// The first yield on fresh storage: with no entry yet under the source's


### PR DESCRIPTION
- builds on top of 
  - https://github.com/RediSearch/RediSearch/pull/10341
  - https://github.com/RediSearch/RediSearch/pull/10342
  - https://github.com/RediSearch/RediSearch/pull/10343
- next: https://github.com/RediSearch/RediSearch/pull/9480


This PR adds entrypoints to create Vector Top K iterators: `NewVectorTopKIterator` ; this doesn't reuse the exact name of `NewHybridVectorIterator` to avoid duplicate symbols errors, and we also want to move away from the "hybrid" naming, so we can consider this as a first "visible" (internal API-wise, still not yet used in production) step towards renaming.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
