### PR TITLE
Fix include paths for coverage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -322,7 +322,7 @@ prepare_coverage_capture() {
   lcov --zerocounters      --directory $BINROOT --base-directory $ROOT
   lcov --capture --initial --directory $BINROOT --base-directory $ROOT -o $BINROOT/base.info \
     --ignore-errors inconsistent,corrupt,mismatch \
-    --exclude '*/_deps/*'
+    --include "$ROOT/deps/thpool/*" --include "$ROOT/src/*"
   end_group
 }
 
@@ -344,7 +344,7 @@ capture_coverage() {
   # cover lcov versions that classify the same disagreement under that name.
   lcov --capture --directory $BINROOT --base-directory $ROOT -o $BINROOT/test.info \
     --ignore-errors inconsistent,corrupt,mismatch \
-    --exclude '*/_deps/*'
+    --include "$ROOT/deps/thpool/*" --include "$ROOT/src/*"
 
   # Accumulate results with the baseline captured before the test
   lcov --add-tracefile $BINROOT/base.info --add-tracefile $BINROOT/test.info -o $BINROOT/full.info \


### PR DESCRIPTION

## Describe the changes in the pull request

**Current.** The lcov coverage flow in `build.sh` runs in two steps:

1. *Capture* (`prepare_coverage_capture` + `capture_coverage`) gathered **all** gcov data, excluding only `*/_deps/*` — CMake's FetchContent build tree.
2. *Report* (`capture_coverage`, via `lcov --extract`) is generated **only** for `$ROOT/src/*` and `$ROOT/deps/thpool/*`.

Because the capture exclude dropped just `_deps/`, other vendored sources under `$ROOT` (the generated Snowball stemmers, VectorSimilarity C++) were still captured — and under LCOV 2.x they trigger fatal `source`/`format` errors that abort the coverage step. That data never reached the report anyway, since the downstream `--extract` discards everything outside `src/*` and `deps/thpool/*`.

**Change.** Capture only the two paths the report already scopes to, by replacing `--exclude '*/_deps/*'` with `--include "$ROOT/src/*" --include "$ROOT/deps/thpool/*"` in both capture calls. Because the capture set now matches the downstream `--extract`, **the report output is unchanged** — we simply stop capturing vendored data that was being thrown away. `_deps/` stays excluded (it is outside both paths), and the `inconsistent`/`corrupt`/`mismatch` demotions are kept for code we still measure (templated C++ such as `src/geometry/rtree.hpp`, and threaded code under `src` and `deps/thpool/`).
                                                                                
**Outcome.** Coverage capture is robust against LCOV 2.x on the CI image — the step no longer aborts on vendored-dep gcov data — and the reported set is identical to before.
                                                                                
#### Main objects this PR modified
1. `build.sh` — `prepare_coverage_capture`, `capture_coverage`                 

#### Mark if applicable                                                        

- [ ] This PR introduces API changes                                           
- [ ] This PR introduces serialization changes
                                                                                
#### Release Notes
                                                                                
- [ ] This PR requires release notes
- [x] This PR does not require release notes
