### PR TITLE
[8.6-rse] Backport num_docs replace-stats fix (#9977)

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -220,10 +220,8 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
 
       bool failure = docId == 0;
 
-      // Gate on oldDocId, not oldLen: a vector/tag/numeric-only doc has no
-      // full-text tokens, so its length is 0 and gating on oldLen would miss
-      // those replaces and leak numDocuments. oldLen is still the right amount
-      // to subtract from totalDocsLen (subtracting 0 is a no-op).
+      // Gate on oldDocId, not oldLen: vector/tag/numeric-only docs have length 0,
+      // so oldLen > 0 would miss those replaces and leak numDocuments.
       if (oldDocId != 0) {
         // We deleted a document in the above call, update the stats accordingly
         RS_ASSERT(spec->stats.scoring.numDocuments > 0);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -220,22 +220,22 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
 
       bool failure = docId == 0;
 
-      // Gate on oldDocId, not oldLen: a vector/tag/numeric-only doc has length 0,
-      // so gating on oldLen would miss those replaces and leak numDocuments.
-      // Requires a successful write (on failure nothing was added or replaced);
-      // oldLen is still the right amount to subtract from totalDocsLen (0 is a no-op).
-      if (!failure && oldDocId != 0) {
-        // We replaced a document in the above call, update the stats accordingly
+      // Gate on oldDocId, not oldLen: a vector/tag/numeric-only doc has no
+      // full-text tokens, so its length is 0 and gating on oldLen would miss
+      // those replaces and leak numDocuments. oldLen is still the right amount
+      // to subtract from totalDocsLen (subtracting 0 is a no-op).
+      if (oldDocId != 0) {
+        // We deleted a document in the above call, update the stats accordingly
         RS_ASSERT(spec->stats.scoring.numDocuments > 0);
         spec->stats.scoring.numDocuments--;
         RS_ASSERT(spec->stats.scoring.totalDocsLen >= oldLen);
         spec->stats.scoring.totalDocsLen -= oldLen;
-        updated = true;
+        updated = docId != 0; // If docId is 0, the document was not added
       }
 
       // Vector indexes are cleaned explicitly and not managed by the disk layer or GC,
       // so they must be updated explicitly when a document is replaced.
-      if (!failure && oldDocId != 0 && (spec->flags & Index_HasVecSim)) {
+      if (oldDocId != 0 && (spec->flags & Index_HasVecSim)) {
         for (int i = 0; i < spec->numFields; ++i) {
           if (spec->fields[i].types == INDEXFLD_T_VECTOR) {
             VecSimIndex *vecsim = openVectorIndex(ctx->redisCtx, &spec->fields[i], DONT_CREATE_INDEX);
@@ -247,13 +247,17 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
 
       if (!failure) {
         cur->doc->docId = docId;
-        // Store docId in key metadata. The disk batch is already committed, so a
-        // failure here has no clean recovery and a stale mapping would corrupt
-        // the next update's replace stats; crash to restart from a clean state.
+        // Store docId in key metadata for fast lookup
         int rc = DocIdMeta_Set(ctx->redisCtx, cur->doc->docKey, spec->specId, docId);
-        RS_LOG_ASSERT_ALWAYS(rc == REDISMODULE_OK, "DocIdMeta_Set failed after a successful disk commit");
-        spec->stats.scoring.totalDocsLen += cur->fwIdx->totalFreq;
-        ++spec->stats.scoring.numDocuments;
+        failure = rc != REDISMODULE_OK;
+
+        if (failure) {
+          uint32_t docLen = 0;
+          SearchDisk_DeleteDocumentById(spec->diskSpec, docId, &docLen);
+        } else {
+          spec->stats.scoring.totalDocsLen += cur->fwIdx->totalFreq;
+          ++spec->stats.scoring.numDocuments;
+        }
       }
 
       if (failure) {

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -220,18 +220,22 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
 
       bool failure = docId == 0;
 
-      if (oldLen > 0) {
-        // We deleted a document in the above call, update the stats accordingly
+      // Gate on oldDocId, not oldLen: a vector/tag/numeric-only doc has length 0,
+      // so gating on oldLen would miss those replaces and leak numDocuments.
+      // Requires a successful write (on failure nothing was added or replaced);
+      // oldLen is still the right amount to subtract from totalDocsLen (0 is a no-op).
+      if (!failure && oldDocId != 0) {
+        // We replaced a document in the above call, update the stats accordingly
         RS_ASSERT(spec->stats.scoring.numDocuments > 0);
         spec->stats.scoring.numDocuments--;
         RS_ASSERT(spec->stats.scoring.totalDocsLen >= oldLen);
         spec->stats.scoring.totalDocsLen -= oldLen;
-        updated = docId != 0; // If docId is 0, the document was not added
+        updated = true;
       }
 
       // Vector indexes are cleaned explicitly and not managed by the disk layer or GC,
       // so they must be updated explicitly when a document is replaced.
-      if (oldDocId != 0 && (spec->flags & Index_HasVecSim)) {
+      if (!failure && oldDocId != 0 && (spec->flags & Index_HasVecSim)) {
         for (int i = 0; i < spec->numFields; ++i) {
           if (spec->fields[i].types == INDEXFLD_T_VECTOR) {
             VecSimIndex *vecsim = openVectorIndex(ctx->redisCtx, &spec->fields[i], DONT_CREATE_INDEX);
@@ -243,17 +247,13 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
 
       if (!failure) {
         cur->doc->docId = docId;
-        // Store docId in key metadata for fast lookup
+        // Store docId in key metadata. The disk batch is already committed, so a
+        // failure here has no clean recovery and a stale mapping would corrupt
+        // the next update's replace stats; crash to restart from a clean state.
         int rc = DocIdMeta_Set(ctx->redisCtx, cur->doc->docKey, spec->specId, docId);
-        failure = rc != REDISMODULE_OK;
-
-        if (failure) {
-          uint32_t docLen = 0;
-          SearchDisk_DeleteDocumentById(spec->diskSpec, docId, &docLen);
-        } else {
-          spec->stats.scoring.totalDocsLen += cur->fwIdx->totalFreq;
-          ++spec->stats.scoring.numDocuments;
-        }
+        RS_LOG_ASSERT_ALWAYS(rc == REDISMODULE_OK, "DocIdMeta_Set failed after a successful disk commit");
+        spec->stats.scoring.totalDocsLen += cur->fwIdx->totalFreq;
+        ++spec->stats.scoring.numDocuments;
       }
 
       if (failure) {

--- a/src/spec.c
+++ b/src/spec.c
@@ -3971,6 +3971,10 @@ void IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModul
       // Failed to delete
       return;
     }
+
+    // Delete the key-to-docId mapping now the doc is gone from disk, keeping
+    // DocIdMeta authoritative: an entry exists iff the doc is currently indexed.
+    DocIdMeta_Delete(ctx, key, spec->specId);
   } else {
     RSDocumentMetadata *md = DocTable_PopR(&spec->docs, key);
     if (!md) {

--- a/src/spec.h
+++ b/src/spec.h
@@ -548,11 +548,9 @@ StrongRef IndexSpec_ParseC(RedisModuleCtx *ctx, const char *name, const char **a
 
 FieldSpec *IndexSpec_CreateField(IndexSpec *sp, const char *name, const char *path);
 
-// Delete a document from the index by its key name.
-// In disk mode, looks up the docId via DocIdMeta_Get on the key, removes the
-// document from disk by that id, and deletes the DocIdMeta key-to-docId mapping
-// so it stays authoritative (an entry exists iff the doc is indexed). In memory
-// mode, pops the document metadata from the DocTable.
+// Delete a document from the index by its key name. Looks up the docId via
+// DocIdMeta_Get, removes the doc (from disk, or the DocTable in memory mode),
+// and deletes the DocIdMeta mapping so it stays authoritative.
 // Requires a RedisModuleCtx to access the key's metadata.
 // This function locks the spec for writing.
 int IndexSpec_DeleteDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key);

--- a/src/spec.h
+++ b/src/spec.h
@@ -549,8 +549,10 @@ StrongRef IndexSpec_ParseC(RedisModuleCtx *ctx, const char *name, const char **a
 FieldSpec *IndexSpec_CreateField(IndexSpec *sp, const char *name, const char *path);
 
 // Delete a document from the index by its key name.
-// Looks up the docId via DocIdMeta_Get on the key, then removes the document
-// from the DocTable and cleans up associated metadata (DocIdMeta_Delete).
+// In disk mode, looks up the docId via DocIdMeta_Get on the key, removes the
+// document from disk by that id, and deletes the DocIdMeta key-to-docId mapping
+// so it stays authoritative (an entry exists iff the doc is indexed). In memory
+// mode, pops the document metadata from the DocTable.
 // Requires a RedisModuleCtx to access the key's metadata.
 // This function locks the spec for writing.
 int IndexSpec_DeleteDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key);


### PR DESCRIPTION
## Backport of #9977 to `8.6-rse`

Adapts [#9977](https://github.com/RediSearch/RediSearch/pull/9977) ("Actual DocIDMeta Delete from Update path") to `8.6-rse`. The fix landed on `master` and was carried into `8.8-rse` and `8.10`, but **`8.6-rse` was skipped** — it still has the original buggy gate.

### The bug

In the disk indexing path (`doAssignIds`), the replaced-document stats decrement was gated on `oldLen > 0`:

```c
if (oldLen > 0) {
    spec->stats.scoring.numDocuments--;
    ...
}
```

`oldLen` is the replaced doc's `docLen` (== `fwIdx->totalFreq`, the full-text token count). A **vector/tag/numeric-only document has no full-text tokens**, so `oldLen == 0`. Replacing such a document (an `HSET` on an existing key) skipped the decrement while still doing `++numDocuments` for the new doc — leaking `numDocuments`. `FT.INFO num_docs` therefore grows on every same-key update.

This is the failure behind a disk vector-update flow test: after two `HSET`s on the same key, `num_docs` is `2` instead of `1`.

### The fix (mirrors #9977)

- **`indexer.c`** — gate the replace-stats decrement (and the GC `updated` signal) on `oldDocId != 0` instead of `oldLen > 0`. `oldLen` is still subtracted from `totalDocsLen` (subtracting 0 is a correct no-op).
- **`spec.c`** — delete the key→docId mapping in `IndexSpec_DeleteDoc_Unsafe` after a successful disk delete, so `DocIdMeta` stays authoritative and `oldDocId` is a reliable replace signal (a FILTER-dropped key no longer leaves a stale id pointing at a deleted docId). This is the half that makes gating on `oldDocId` safe.
- **`spec.h`** — update the `IndexSpec_DeleteDoc` doc comment.

### Why adapted rather than a clean cherry-pick

`8.6-rse` predates `master`'s `applyDocTable` refactor (and helpers like `removeOldDocStats` / `addNewDocStats` / `GCContext_OnWrite`), so a verbatim cherry-pick of #9977 conflicts hard in `indexer.c`. The `spec.c` / `spec.h` hunks came straight from the cherry-pick (clean auto-merge); only `indexer.c` was hand-adapted onto the existing `doAssignIds` structure. Behavior matches #9977.

🤖 Generated with [Claude Code](https://claude.com/claude-code)