### PR TITLE
[MOD-14205] topk vector implementation: prepare profiling

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2954,7 +2954,6 @@ name = "top_k"
 version = "0.0.1"
 dependencies = [
  "build_utils",
- "ffi",
  "index_result",
  "index_spec",
  "inverted_index",

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -46,7 +46,7 @@ where
         inner: I,
         profile_children: Option<unsafe extern "C" fn(*mut QueryIterator) -> *mut QueryIterator>,
     ) -> *mut QueryIterator {
-        let mut wrapper = Box::new(Self {
+        let wrapper = Box::new(Self {
             header: QueryIterator {
                 type_: inner.type_(),
                 atEOF: inner.at_eof(),
@@ -63,14 +63,16 @@ where
             },
             inner,
         });
-        if let Some(current) = wrapper
-            .inner
-            .current()
-            .map(|c| c as *mut RSIndexResult as *mut ffi::RSIndexResult)
-        {
-            wrapper.header.current = current;
+        // Derive the self-referential `current` pointer only *after* the box is
+        // stable behind a raw pointer. `sync_current` reads `inner` and writes
+        // `header.current` through a single `&mut self`, so the borrow never
+        // escapes across `Box::into_raw`'s `Unique` retag (which would pop it).
+        let raw = Box::into_raw(wrapper);
+        // SAFETY: `raw` was just produced by `Box::into_raw`, so it is non-null,
+        unsafe {
+            (*raw).sync_current();
         }
-        Box::into_raw(wrapper) as *mut QueryIterator
+        raw as *mut QueryIterator
     }
 }
 

--- a/src/redisearch_rs/top_k/Cargo.toml
+++ b/src/redisearch_rs/top_k/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "top_k"
-version.workspace = true
 edition.workspace = true
 license-file.workspace = true
+name = "top_k"
 publish.workspace = true
+version.workspace = true
 
 [lib]
 bench = false
@@ -17,23 +17,22 @@ test-utils = []
 unittest = []
 
 [build-dependencies]
-build_utils = { path = "../build_utils" }
+build_utils = {path = "../build_utils"}
 
 [dependencies]
-ffi.workspace = true
-rqe_core.workspace = true
+index_result.workspace = true
+index_spec.workspace = true
 inverted_index.workspace = true
+rqe_core.workspace = true
 rqe_iterator_type.workspace = true
 rqe_iterators.workspace = true
 workspace_hack.workspace = true
-index_result.workspace = true
-index_spec.workspace = true
 
 [dev-dependencies]
-top_k = { path = ".", features = ["unittest", "test-utils"] }
 redis_mock.workspace = true
-rqe_iterators = { workspace = true, features = ["unittest"] }
+redisearch_rs = {path = "../c_entrypoint/redisearch_rs", features = [
+  "mock_allocator",
+]}
+rqe_iterators = {workspace = true, features = ["unittest"]}
 rqe_iterators_test_utils.workspace = true
-redisearch_rs = { path = "../c_entrypoint/redisearch_rs", features = [
-    "mock_allocator",
-] }
+top_k = {path = ".", features = ["unittest", "test-utils"]}

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -499,19 +499,7 @@ impl<'index, S: ScoreSource + 'index> rqe_iterators::interop::ProfileChildren<'i
             child: self
                 .child
                 .map(rqe_iterators::c2rust::CRQEIterator::into_profiled),
-            source: self.source,
-            mode: self.mode,
-            initial_mode: self.initial_mode,
-            heap: self.heap,
-            direct_batch: self.direct_batch,
-            k: self.k,
-            compare: self.compare,
-            phase: self.phase,
-            results: self.results,
-            yield_pos: self.yield_pos,
-            current: self.current,
-            last_doc_id: self.last_doc_id,
-            at_eof: self.at_eof,
+            ..self
         }
     }
 }

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -77,9 +77,13 @@ enum Phase {
 /// Implements the execution mode described in the design doc:
 /// [`Unfiltered`](TopKMode::Unfiltered), [`Batches`](TopKMode::Batches),
 /// and [`AdhocBF`](TopKMode::AdhocBF).
-pub struct TopKIterator<'index, S: ScoreSource> {
+pub struct TopKIterator<
+    'index,
+    S: ScoreSource,
+    C: RQEIterator<'index> + 'index = Box<dyn RQEIterator<'index> + 'index>,
+> {
     source: S,
-    child: Option<Box<dyn RQEIterator<'index> + 'index>>,
+    child: Option<C>,
     mode: TopKMode,
     /// Preserved so [`rewind`](Self::rewind) can restore the original mode.
     initial_mode: TopKMode,
@@ -98,33 +102,28 @@ pub struct TopKIterator<'index, S: ScoreSource> {
 }
 
 impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
-    /// Create a new [`TopKIterator`].
+    /// Create a new unfiltered [`TopKIterator`] (no child filter).
     ///
-    /// The execution mode is inferred from `child`:
-    /// - `None` → [`TopKMode::Unfiltered`]
-    /// - `Some(_)` → [`TopKMode::Batches`]
-    pub fn new(
-        source: S,
-        child: Option<Box<dyn RQEIterator<'index> + 'index>>,
-        k: NonZeroUsize,
-        compare: fn(f64, f64) -> Ordering,
-    ) -> Self {
-        let mode = if child.is_some() {
-            TopKMode::Batches
-        } else {
-            TopKMode::Unfiltered
-        };
-        Self::_new_with_mode(source, child, k, compare, mode)
+    /// Results are streamed directly from the source's batch — the heap is bypassed.
+    /// Use [`new`](Self::new) when a filter child is present.
+    pub fn new_unfiltered(source: S, k: NonZeroUsize, compare: fn(f64, f64) -> Ordering) -> Self {
+        Self::_new_with_mode(source, None, k, compare, TopKMode::Unfiltered)
+    }
+}
+
+impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKIterator<'index, S, C> {
+    /// Create a new [`TopKIterator`] with a filter child.
+    ///
+    /// The initial mode defaults to [`TopKMode::Batches`].
+    pub fn new(source: S, child: C, k: NonZeroUsize, compare: fn(f64, f64) -> Ordering) -> Self {
+        Self::_new_with_mode(source, Some(child), k, compare, TopKMode::Batches)
     }
 
     /// Create a new [`TopKIterator`] with an explicit initial mode.
-    ///
-    /// Useful for tests and for constructors that want to start in
-    /// [`AdhocBF`](TopKMode::AdhocBF) immediately.
     #[cfg(feature = "test-utils")]
     pub fn new_with_mode(
         source: S,
-        child: Option<Box<dyn RQEIterator<'index> + 'index>>,
+        child: Option<C>,
         k: NonZeroUsize,
         compare: fn(f64, f64) -> Ordering,
         mode: TopKMode,
@@ -135,7 +134,7 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
     /// Create a new [`TopKIterator`] with an explicit initial mode.
     fn _new_with_mode(
         source: S,
-        child: Option<Box<dyn RQEIterator<'index> + 'index>>,
+        child: Option<C>,
         k: NonZeroUsize,
         compare: fn(f64, f64) -> Ordering,
         mode: TopKMode,
@@ -171,6 +170,11 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
     /// Returns a mutable reference to the score source.
     pub fn source_mut(&mut self) -> &mut S {
         &mut self.source
+    }
+
+    /// Returns a reference to the filter child iterator, if present.
+    pub fn child(&self) -> Option<&C> {
+        self.child.as_ref()
     }
 
     /// Drive collection based on the current mode.
@@ -333,7 +337,9 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
     }
 }
 
-impl<'index, S: ScoreSource + 'index> RQEIterator<'index> for TopKIterator<'index, S> {
+impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> RQEIterator<'index>
+    for TopKIterator<'index, S, C>
+{
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
         self.current.as_mut()
@@ -428,8 +434,8 @@ impl<'index, S: ScoreSource + 'index> RQEIterator<'index> for TopKIterator<'inde
 /// Uses a merge-join (alternating `skip_to` calls) to find matching doc IDs.
 ///
 /// The child is **rewound** at the start of each call.
-fn intersect_batch_with_child<'index>(
-    child: &mut Box<dyn RQEIterator<'index> + 'index>,
+fn intersect_batch_with_child<'index, C: RQEIterator<'index>>(
+    child: &mut C,
     batch: &mut impl ScoreBatch,
     heap: &mut TopKHeap,
 ) -> Result<(), RQEIteratorError> {
@@ -483,4 +489,29 @@ fn intersect_batch_with_child<'index>(
         }
     }
     Ok(())
+}
+
+impl<'index, S: ScoreSource + 'index> rqe_iterators::interop::ProfileChildren<'index>
+    for TopKIterator<'index, S, rqe_iterators::c2rust::CRQEIterator>
+{
+    fn profile_children(self) -> Self {
+        TopKIterator {
+            child: self
+                .child
+                .map(rqe_iterators::c2rust::CRQEIterator::into_profiled),
+            source: self.source,
+            mode: self.mode,
+            initial_mode: self.initial_mode,
+            heap: self.heap,
+            direct_batch: self.direct_batch,
+            k: self.k,
+            compare: self.compare,
+            phase: self.phase,
+            results: self.results,
+            yield_pos: self.yield_pos,
+            current: self.current,
+            last_doc_id: self.last_doc_id,
+            at_eof: self.at_eof,
+        }
+    }
 }

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -158,6 +158,21 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
         }
     }
 
+    /// Returns the current execution mode.
+    pub fn mode(&self) -> TopKMode {
+        self.mode
+    }
+
+    /// Returns a shared reference to the score source.
+    pub fn source(&self) -> &S {
+        &self.source
+    }
+
+    /// Returns a mutable reference to the score source.
+    pub fn source_mut(&mut self) -> &mut S {
+        &mut self.source
+    }
+
     /// Drive collection based on the current mode.
     fn collect(&mut self) -> Result<(), RQEIteratorError> {
         self.phase = Phase::Collecting;

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -95,7 +95,7 @@ impl ScoreSource for TimingOutSource {
         Err(RQEIteratorError::TimedOut)
     }
 
-    fn lookup_score(&mut self, _: ffi::t_docId) -> Option<f64> {
+    fn lookup_score(&mut self, _: DocId) -> Option<f64> {
         None
     }
 
@@ -132,9 +132,10 @@ fn make_child<'a>(ids: Vec<DocId>) -> Box<dyn RQEIterator<'a> + 'a> {
     Box::new(IdList::<true>::new(ids))
 }
 
-/// Wrap an [`IdList`] in a [`CRQEIterator`] so the typed-child `TopKIterator`
-/// variant (which supports [`ProfileChildren`]) can be exercised in tests.
-fn make_crqe_child(ids: Vec<ffi::t_docId>) -> CRQEIterator {
+/// Build an [`IdList`] from `ids` and wrap it in a [`CRQEIterator`] so the
+/// typed-child `TopKIterator` variant (which supports [`ProfileChildren`]) can
+/// be exercised in tests.
+fn make_crqe_child(ids: Vec<DocId>) -> CRQEIterator {
     let it = IdList::<true>::new(ids);
     let ptr = RQEIteratorWrapper::boxed_new(it);
     // SAFETY: `boxed_new` returns a non-null `Box::into_raw` pointer.

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -410,7 +410,7 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
             RSIndexResult::build_virt().doc_id(doc_id).build()
         }
 
-        fn batch_strategy(&mut self, _: usize, _: usize) -> BatchStrategy {
+        fn batch_strategy(&mut self, _heap_count: usize, _k: usize) -> BatchStrategy {
             BatchStrategy::Continue
         }
 

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -15,7 +15,12 @@ use rqe_core::DocId;
 
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use rqe_iterators::{IdList, RQEIterator, RQEIteratorError};
+use rqe_iterator_type::IteratorType;
+use rqe_iterators::{
+    IdList, RQEIterator, RQEIteratorError,
+    c2rust::CRQEIterator,
+    interop::{ProfileChildren, RQEIteratorWrapper},
+};
 use top_k::{
     BatchStrategy, ScoreSource, TopKIterator, TopKMode, mock::MockScoreBatch, mock::MockScoreSource,
 };
@@ -127,6 +132,18 @@ fn make_child<'a>(ids: Vec<DocId>) -> Box<dyn RQEIterator<'a> + 'a> {
     Box::new(IdList::<true>::new(ids))
 }
 
+/// Wrap an [`IdList`] in a [`CRQEIterator`] so the typed-child `TopKIterator`
+/// variant (which supports [`ProfileChildren`]) can be exercised in tests.
+fn make_crqe_child(ids: Vec<ffi::t_docId>) -> CRQEIterator {
+    let it = IdList::<true>::new(ids);
+    let ptr = RQEIteratorWrapper::boxed_new(it);
+    // SAFETY: `boxed_new` returns a non-null `Box::into_raw` pointer.
+    let ptr = unsafe { std::ptr::NonNull::new_unchecked(ptr) };
+    // SAFETY: `ptr` is a valid, owning, non-null `QueryIterator` pointer produced
+    // by `RQEIteratorWrapper::boxed_new`, satisfying all `CRQEIterator::new` preconditions.
+    unsafe { CRQEIterator::new(ptr) }
+}
+
 // ── State machine ─────────────────────────────────────────────────────────────
 
 #[test]
@@ -134,7 +151,7 @@ fn read_triggers_collection_on_first_call() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
         BatchStrategy::Continue
     });
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new_unfiltered(source, NonZeroUsize::new(5).unwrap(), asc);
 
     assert!(!it.at_eof());
     let result = it.read().unwrap().expect("should have a result");
@@ -146,7 +163,7 @@ fn rewind_resets_to_not_started() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
         BatchStrategy::Continue
     });
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new_unfiltered(source, NonZeroUsize::new(5).unwrap(), asc);
     it.read().unwrap();
     it.read().unwrap();
     let eof = it.read().unwrap();
@@ -166,7 +183,7 @@ fn rewind_resets_to_not_started() {
 #[test]
 fn eof_set_after_results_exhausted() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new_unfiltered(source, NonZeroUsize::new(5).unwrap(), asc);
     it.read().unwrap();
     let eof = it.read().unwrap();
     assert!(eof.is_none());
@@ -178,7 +195,7 @@ fn last_doc_id_starts_at_zero_tracks_reads_and_resets_on_rewind() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
         BatchStrategy::Continue
     });
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new_unfiltered(source, NonZeroUsize::new(5).unwrap(), asc);
 
     assert_eq!(it.last_doc_id(), 0);
 
@@ -197,7 +214,7 @@ fn num_estimated_capped_at_k() {
         BatchStrategy::Continue
     })
     .with_num_estimated(100);
-    let it = TopKIterator::new(source, None, NonZeroUsize::new(3).unwrap(), asc);
+    let it = TopKIterator::new_unfiltered(source, NonZeroUsize::new(3).unwrap(), asc);
 
     assert_eq!(it.num_estimated(), 3);
 }
@@ -211,7 +228,7 @@ fn unfiltered_yields_batch_in_source_order() {
     let source = MockScoreSource::new(vec![vec![(1, 0.9), (2, 0.5), (3, 0.1)]], vec![], |_, _| {
         BatchStrategy::Continue
     });
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(10).unwrap(), asc);
+    let mut it = TopKIterator::new_unfiltered(source, NonZeroUsize::new(10).unwrap(), asc);
     let ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
     assert_eq!(ids, vec![1, 2, 3]);
 }
@@ -219,7 +236,7 @@ fn unfiltered_yields_batch_in_source_order() {
 #[test]
 fn unfiltered_empty_source_is_immediate_eof() {
     let source = MockScoreSource::new(vec![], vec![], |_, _| BatchStrategy::Continue);
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new_unfiltered(source, NonZeroUsize::new(5).unwrap(), asc);
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
 }
@@ -230,7 +247,7 @@ fn unfiltered_empty_source_is_immediate_eof() {
 fn revalidate_without_child_returns_ok() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
-    let mut it = TopKIterator::new(source, None, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new_unfiltered(source, NonZeroUsize::new(5).unwrap(), asc);
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
 }
@@ -242,8 +259,9 @@ fn revalidate_with_child_delegates_ok() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
     let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(rqe_iterators::Empty::default());
-    let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new(source, child, NonZeroUsize::new(5).unwrap(), asc);
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
+
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Ok);
 }
 
@@ -252,14 +270,14 @@ fn revalidate_with_child_delegates_aborted() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
     let child: Box<dyn rqe_iterators::RQEIterator<'_>> = Box::new(AbortOnRevalidate);
-    let mut it = TopKIterator::new(source, Some(child), NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new(source, child, NonZeroUsize::new(5).unwrap(), asc);
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, rqe_iterators::RQEValidateStatus::Aborted);
 }
 
 #[test]
 fn unfiltered_timeout_propagated() {
-    let mut it = TopKIterator::new(TimingOutSource, None, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new_unfiltered(TimingOutSource, NonZeroUsize::new(5).unwrap(), asc);
     assert!(matches!(
         it.read().unwrap_err(),
         rqe_iterators::RQEIteratorError::TimedOut
@@ -279,7 +297,7 @@ fn batches_overlap_intersection() {
     );
     let mut it = TopKIterator::new(
         source,
-        Some(make_child(vec![1, 3, 5])),
+        make_child(vec![1, 3, 5]),
         NonZeroUsize::new(10).unwrap(),
         asc,
     );
@@ -294,7 +312,7 @@ fn batches_disjoint_yields_nothing() {
     });
     let mut it = TopKIterator::new(
         source,
-        Some(make_child(vec![10, 20])),
+        make_child(vec![10, 20]),
         NonZeroUsize::new(10).unwrap(),
         asc,
     );
@@ -309,7 +327,7 @@ fn batches_empty_child_yields_nothing() {
     });
     let mut it = TopKIterator::new(
         source,
-        Some(make_child(vec![])),
+        make_child(vec![]),
         NonZeroUsize::new(10).unwrap(),
         asc,
     );
@@ -328,7 +346,7 @@ fn batches_multiple_batches() {
     );
     let mut it = TopKIterator::new(
         source,
-        Some(make_child(vec![1, 3, 4])),
+        make_child(vec![1, 3, 4]),
         NonZeroUsize::new(10).unwrap(),
         asc,
     );
@@ -349,7 +367,7 @@ fn strategy_stop_stops_after_first_batch() {
     );
     let mut it = TopKIterator::new(
         source,
-        Some(make_child(vec![1, 2, 3, 4])),
+        make_child(vec![1, 2, 3, 4]),
         NonZeroUsize::new(10).unwrap(),
         asc,
     );
@@ -425,7 +443,7 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
     };
     let mut it = TopKIterator::new(
         source,
-        Some(make_child(vec![1, 3])),
+        make_child(vec![1, 3]),
         NonZeroUsize::new(10).unwrap(),
         asc,
     );
@@ -466,7 +484,7 @@ fn strategy_switch_to_adhoc() {
     );
     let mut it = TopKIterator::new(
         source,
-        Some(make_child(vec![1, 2, 3])),
+        make_child(vec![1, 2, 3]),
         NonZeroUsize::new(10).unwrap(),
         asc,
     );
@@ -492,7 +510,7 @@ fn strategy_switch_to_batches_rewinds() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], strategy);
     let mut it = TopKIterator::new(
         source,
-        Some(make_child(vec![1, 2])),
+        make_child(vec![1, 2]),
         NonZeroUsize::new(10).unwrap(),
         asc,
     );
@@ -568,4 +586,53 @@ fn adhoc_empty_child_is_eof() {
     );
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
+}
+
+// ── ProfileChildren ───────────────────────────────────────────────────────────
+
+#[test]
+fn profile_children_wraps_child_in_profile_node() {
+    // Verify that `profile_children()` wraps the filter child in a Profile
+    // iterator without changing the results produced by the TopKIterator.
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0), (3, 0.5)]], vec![], |_, _| {
+        BatchStrategy::Continue
+    });
+    let child = make_crqe_child(vec![1, 2, 3]);
+    let it = TopKIterator::new(source, child, NonZeroUsize::new(10).unwrap(), asc);
+
+    let mut profiled = it.profile_children();
+
+    // Child must now be a Profile wrapper.
+    assert_eq!(
+        profiled.child().map(|c| c.type_),
+        Some(IteratorType::Profile),
+        "filter child should be wrapped in a Profile node after profile_children()"
+    );
+
+    // Results must be unchanged: all three docs, sorted best-first (asc).
+    let doc_ids: Vec<_> =
+        std::iter::from_fn(|| profiled.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids, vec![3, 1, 2]);
+}
+
+#[test]
+fn profile_children_with_no_child_is_identity() {
+    // Unfiltered path: profile_children() is a no-op on the child (there is none).
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
+        BatchStrategy::Continue
+    });
+    let it = TopKIterator::<_, CRQEIterator>::new_with_mode(
+        source,
+        None,
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+        TopKMode::Unfiltered,
+    );
+
+    let mut profiled = it.profile_children();
+
+    assert!(profiled.child().is_none());
+    let doc_ids: Vec<_> =
+        std::iter::from_fn(|| profiled.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids, vec![1, 2]);
 }

--- a/src/redisearch_rs/top_k_bencher/benches/top_k.rs
+++ b/src/redisearch_rs/top_k_bencher/benches/top_k.rs
@@ -130,12 +130,12 @@ fn bench_intersection_overlap(c: &mut Criterion) {
                     let source = MockScoreSource::new(vec![batch.clone()], vec![], |_, _| {
                         BatchStrategy::Continue
                     });
-                    let child: Box<dyn RQEIterator> =
+                    let child: Box<_> =
                         Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
                     (source, child)
                 },
                 |(source, child)| {
-                    let mut it = TopKIterator::new(source, Some(child), k, asc);
+                    let mut it = TopKIterator::new(source, child, k, asc);
                     while black_box(it.read()).unwrap().is_some() {}
                 },
                 BatchSize::SmallInput,
@@ -159,12 +159,12 @@ fn bench_intersection_disjoint(c: &mut Criterion) {
                     let source = MockScoreSource::new(vec![batch.clone()], vec![], |_, _| {
                         BatchStrategy::Continue
                     });
-                    let child: Box<dyn RQEIterator> =
+                    let child: Box<_> =
                         Box::new(rqe_iterators::IdList::<true>::new(child_ids.clone()));
                     (source, child)
                 },
                 |(source, child)| {
-                    let mut it = TopKIterator::new(source, Some(child), k, asc);
+                    let mut it = TopKIterator::new(source, child, k, asc);
                     while black_box(it.read()).unwrap().is_some() {}
                 },
                 BatchSize::SmallInput,


### PR DESCRIPTION
Several improvements in this PR:

- an API improvement we discussed: making an **unfiltered** top k iterator can be explicit because we have no children (filter), so the API translates to that. It helps with simplifying calls to "filtered" API, avoiding an Option wrapper.
- aligns iterator with a generic over iterator language type (works over C or Rust filter iterator)
  - let's challenge pure Rust filter iterator child when all iterators are in Rust, for simplicity.
- Some getters added to `TopKIterator`, not really used right now, but will serve when migrating from C.

- next: https://github.com/RediSearch/RediSearch/pull/9590

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
