### PR TITLE
[MOD-16185] Trie - drop the MIN_SUFFIX floor in the Rust term_suffix_index port

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2867,7 +2867,6 @@ dependencies = [
 name = "term_suffix_index"
 version = "0.0.1"
 dependencies = [
- "ffi",
  "proptest",
  "trie_rs",
  "workspace_hack",

--- a/src/redisearch_rs/term_suffix_index/Cargo.toml
+++ b/src/redisearch_rs/term_suffix_index/Cargo.toml
@@ -9,7 +9,6 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-ffi.workspace = true
 trie_rs.workspace = true
 workspace_hack.workspace = true
 

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -22,10 +22,6 @@
 //! trie for the needle surfaces every member containing it.
 //! [`TermSuffixIndex::iter_contains`] is the prefix lookup;
 //! [`TermSuffixIndex::iter_suffix`] is the exact lookup.
-//!
-//! Every non-empty member is stored along with all of its proper
-//! suffixes down to the final codepoint, so even a single-codepoint
-//! needle resolves directly against the structure.
 
 mod term_refs;
 

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -23,8 +23,9 @@
 //! [`TermSuffixIndex::iter_contains`] is the prefix lookup;
 //! [`TermSuffixIndex::iter_suffix`] is the exact lookup.
 //!
-//! Suffixes shorter than [`MIN_SUFFIX`] codepoints aren't indexed —
-//! trades index size for a minimum supported needle length.
+//! Every non-empty member is stored along with all of its proper
+//! suffixes down to the final codepoint, so even a single-codepoint
+//! needle resolves directly against the structure.
 
 mod term_refs;
 
@@ -32,12 +33,6 @@ use std::rc::Rc;
 
 use term_refs::{Outcome, TermRefs};
 use trie_rs::str_trie_map::StrTrieMap;
-
-// TODO(MOD-16185): the C suffix DS dropped its MIN_SUFFIX floor (#9945), so the
-// constant no longer exists in `src/suffix.h`. This Rust port isn't wired into
-// production yet, so it keeps the old floor hardcoded for now; remove it (and
-// the gating logic and assertions below) in the MOD-16185 follow-up.
-const MIN_SUFFIX: usize = 2;
 
 pub struct TermSuffixIndex {
     inner: StrTrieMap<TermRefs>,
@@ -61,9 +56,10 @@ impl TermSuffixIndex {
     }
 
     pub fn add(&mut self, term: &str) {
-        if term.is_empty() {
-            return;
-        }
+        debug_assert!(
+            !term.is_empty(),
+            "empty term is a caller-level mistake; callers gate empty values out before indexing",
+        );
 
         if self.inner.get(term).is_some_and(TermRefs::has_full_term) {
             return;
@@ -82,9 +78,10 @@ impl TermSuffixIndex {
     }
 
     pub fn remove(&mut self, term: &str) {
-        if term.is_empty() {
-            return;
-        }
+        debug_assert!(
+            !term.is_empty(),
+            "empty term is a caller-level mistake; callers gate empty values out before indexing",
+        );
 
         if let Some(data) = self.inner.get_mut(term)
             && data.has_full_term()
@@ -102,29 +99,18 @@ impl TermSuffixIndex {
         }
     }
 
+    /// Every proper suffix of `term`, longest first, down to its final
+    /// codepoint. Empty for a single-codepoint `term`.
     fn suffixes_of(term: &str) -> impl Iterator<Item = &str> {
-        let total_chars = term.chars().count();
         term.char_indices()
-            .enumerate()
             .skip(1)
-            .take_while(move |(char_idx, _)| total_chars - char_idx >= MIN_SUFFIX)
-            .map(|(_, (byte_idx, _))| &term[byte_idx..])
+            .map(|(byte_idx, _)| &term[byte_idx..])
     }
 
     /// Yield every indexed term containing `needle`, in unspecified
     /// order. Empty `needle` yields nothing. A term may be yielded
     /// more than once; dedupe by [`Rc::as_ptr`] if needed.
-    ///
-    /// Non-empty `needle` must span at least [`MIN_SUFFIX`] codepoints.
-    /// Shorter needles silently yield a subset of matching terms,
-    /// since suffixes below the threshold aren't indexed; debug
-    /// builds assert this. Production callers filter upstream via
-    /// the query engine's `minTermPrefix` gate.
     pub fn iter_contains(&self, needle: &str) -> impl Iterator<Item = Rc<str>> {
-        debug_assert!(
-            needle.is_empty() || needle.chars().count() >= MIN_SUFFIX,
-            "needle must span at least {MIN_SUFFIX} codepoints; caller must filter shorter needles (production gate: minTermPrefix)",
-        );
         (!needle.is_empty())
             .then_some(needle)
             .into_iter()
@@ -136,17 +122,7 @@ impl TermSuffixIndex {
     /// order. Empty `needle` yields nothing.
     ///
     /// Each matching term is yielded exactly once.
-    ///
-    /// Non-empty `needle` must span at least [`MIN_SUFFIX`] codepoints.
-    /// Shorter needles silently yield a subset of matching terms,
-    /// since suffixes below the threshold aren't indexed; debug
-    /// builds assert this. Production callers filter upstream via
-    /// the query engine's `minTermPrefix` gate.
     pub fn iter_suffix(&self, needle: &str) -> impl Iterator<Item = Rc<str>> {
-        debug_assert!(
-            needle.is_empty() || needle.chars().count() >= MIN_SUFFIX,
-            "needle must span at least {MIN_SUFFIX} codepoints; caller must filter shorter needles (production gate: minTermPrefix)",
-        );
         (!needle.is_empty())
             .then_some(needle)
             .into_iter()

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -89,8 +89,6 @@ impl TermSuffixIndex {
         }
     }
 
-    /// Every proper suffix of `term`, longest first, down to its final
-    /// codepoint. Empty for a single-codepoint `term`.
     fn suffixes_of(term: &str) -> impl Iterator<Item = &str> {
         term.char_indices()
             .skip(1)

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -56,10 +56,7 @@ impl TermSuffixIndex {
     }
 
     pub fn add(&mut self, term: &str) {
-        debug_assert!(
-            !term.is_empty(),
-            "empty term is a caller-level mistake; callers gate empty values out before indexing",
-        );
+        debug_assert!(!term.is_empty(), "term must not be empty");
 
         if self.inner.get(term).is_some_and(TermRefs::has_full_term) {
             return;
@@ -78,10 +75,7 @@ impl TermSuffixIndex {
     }
 
     pub fn remove(&mut self, term: &str) {
-        debug_assert!(
-            !term.is_empty(),
-            "empty term is a caller-level mistake; callers gate empty values out before indexing",
-        );
+        debug_assert!(!term.is_empty(), "term must not be empty");
 
         if let Some(data) = self.inner.get_mut(term)
             && data.has_full_term()

--- a/src/redisearch_rs/term_suffix_index/src/term_refs.rs
+++ b/src/redisearch_rs/term_suffix_index/src/term_refs.rs
@@ -24,10 +24,9 @@
 use std::rc::Rc;
 
 /// `Rc<str>` shares one heap allocation across all of a term's
-/// trie entries — one full-term entry plus up to
-/// `N - `[`MIN_SUFFIX`](super::MIN_SUFFIX) proper-suffix entries —
-/// keeping per-term memory `O(N)` instead of `O(N²)`. Bytes drop
-/// with the last reference.
+/// trie entries — one full-term entry plus its `N - 1` proper-suffix
+/// entries — keeping per-term memory `O(N)` instead of `O(N²)`.
+/// Bytes drop with the last reference.
 pub(super) struct TermRefs {
     full_term: Option<Rc<str>>,
     longer_terms: Vec<Rc<str>>,

--- a/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
@@ -119,8 +119,8 @@ fn add_promotes_existing_suffix_only_node_to_full_term() {
 
 #[test]
 fn length_one_proper_suffix_is_indexed() {
-    // No MIN_SUFFIX floor: "ab" stores its trailing length-1 suffix "b"
-    // as a back-reference, so a 1-char suffix or contains query reaches it.
+    // "ab" stores its trailing length-1 suffix "b" as a back-reference,
+    // so a 1-char suffix or contains query reaches it.
     let mut sut = TermSuffixIndex::new();
     sut.add("ab");
 
@@ -141,7 +141,7 @@ fn multibyte_utf8_suffix_slicing_is_codepoint_aware() {
     }
 
     assert!(collect_set(sut.iter_suffix("fé")).contains("café"));
-    // The length-1 suffix "é" is indexed now that the floor is gone.
+    // The length-1 suffix "é" is indexed too.
     assert!(collect_set(sut.iter_suffix("é")).contains("café"));
     // "本語" is a two-codepoint suffix of "日本語" — should be present ...
     assert!(collect_set(sut.iter_suffix("本語")).contains("日本語"));

--- a/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
@@ -118,31 +118,35 @@ fn add_promotes_existing_suffix_only_node_to_full_term() {
 }
 
 #[test]
-fn min_suffix_boundary_two_chars_no_proper_suffix() {
+fn length_one_proper_suffix_is_indexed() {
+    // No MIN_SUFFIX floor: "ab" stores its trailing length-1 suffix "b"
+    // as a back-reference, so a 1-char suffix or contains query reaches it.
     let mut sut = TermSuffixIndex::new();
     sut.add("ab");
 
-    let actual_exact = collect_set(sut.iter_suffix("ab"));
-
-    let expected_exact = HashSet::from(["ab".to_string()]);
-    assert_eq!(actual_exact, expected_exact);
+    assert_eq!(collect_set(sut.iter_suffix("ab")), HashSet::from(["ab".to_string()]));
+    assert!(collect_set(sut.iter_suffix("b")).contains("ab"));
+    assert!(collect_set(sut.iter_contains("a")).contains("ab"));
 }
 
 #[test]
-fn multibyte_utf8_min_suffix_is_codepoint_aware() {
-    // Codepoint-aware suffix slicing: "café" has 4 codepoints, so the
-    // length-2 suffix "fé" is indexed but length-1 "é" is not. A
-    // byte-stride port would either panic (`&term[3..]` splits the
-    // first byte of "é") or insert a malformed key — neither should
-    // happen here.
+fn multibyte_utf8_suffix_slicing_is_codepoint_aware() {
+    // Codepoint-aware suffix slicing: "café" has 4 codepoints, so every
+    // proper suffix down to the length-1 "é" is indexed. A byte-stride
+    // port would either panic (`&term[3..]` splits the first byte of
+    // "é") or insert a malformed key — neither should happen here.
     let mut sut = TermSuffixIndex::new();
     for t in ["café", "naïve", "日本語", "🦀rust"] {
         sut.add(t);
     }
 
     assert!(collect_set(sut.iter_suffix("fé")).contains("café"));
-    // "本語" is a two-codepoint suffix of "日本語" — should be present.
+    // The length-1 suffix "é" is indexed now that the floor is gone.
+    assert!(collect_set(sut.iter_suffix("é")).contains("café"));
+    // "本語" is a two-codepoint suffix of "日本語" — should be present ...
     assert!(collect_set(sut.iter_suffix("本語")).contains("日本語"));
+    // ... as is its length-1 tail "語".
+    assert!(collect_set(sut.iter_suffix("語")).contains("日本語"));
 
     for t in ["café", "naïve", "日本語", "🦀rust"] {
         sut.remove(t);
@@ -211,7 +215,7 @@ mod fuzz {
         #[test]
         fn iter_contains_matches_substring_oracle(
             corpus in proptest::collection::vec(term_strategy(), 1..=20),
-            needle in "[a-z]{2,4}",
+            needle in "[a-z]{1,4}",
         ) {
             let sut = build_index(&corpus);
             let expected = corpus
@@ -228,7 +232,7 @@ mod fuzz {
         #[test]
         fn iter_suffix_matches_ends_with_oracle(
             corpus in proptest::collection::vec(term_strategy(), 1..=20),
-            needle in "[a-z]{2,4}",
+            needle in "[a-z]{1,4}",
         ) {
             let sut = build_index(&corpus);
             let expected = corpus
@@ -259,7 +263,7 @@ mod fuzz {
             }
 
             // Every needle of length up to 4 yields zero hits.
-            for sample in ["ab", "abc", "abcd"] {
+            for sample in ["a", "ab", "abc", "abcd"] {
                 prop_assert_eq!(sut.iter_contains(sample).count(), 0,
                     "stale entries for needle={:?} corpus={:?}", sample, corpus);
                 prop_assert_eq!(sut.iter_suffix(sample).count(), 0,
@@ -273,7 +277,7 @@ mod fuzz {
                 (any::<bool>(), "[a-z]{1,6}"),
                 1..=30,
             ),
-            needle in "[a-z]{2,3}",
+            needle in "[a-z]{1,3}",
         ) {
             let mut sut = TermSuffixIndex::new();
             let mut alive = HashSet::new();

--- a/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
@@ -124,7 +124,10 @@ fn length_one_proper_suffix_is_indexed() {
     let mut sut = TermSuffixIndex::new();
     sut.add("ab");
 
-    assert_eq!(collect_set(sut.iter_suffix("ab")), HashSet::from(["ab".to_string()]));
+    assert_eq!(
+        collect_set(sut.iter_suffix("ab")),
+        HashSet::from(["ab".to_string()])
+    );
     assert!(collect_set(sut.iter_suffix("b")).contains("ab"));
     assert!(collect_set(sut.iter_contains("a")).contains("ab"));
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: The `term_suffix_index` crate hardcodes `const MIN_SUFFIX = 2`, gating 1-codepoint sub-suffixes out of the structure and rejecting short needles. This was a stopgap left by #9945, which dropped the same floor on the C side (`src/suffix.h`) but kept the Rust port frozen behind a `TODO(MOD-16185)` because the const it imported (`ffi::MIN_SUFFIX`) was being removed.
2. **Change**: Remove the floor in the Rust port to match the C suffix DS — store every non-empty member along with all of its proper suffixes down to the final codepoint, and accept single-codepoint needles. Replace the silent empty-string early returns in `add`/`remove` with `debug_assert!`, matching C's `RS_LOG_ASSERT` on the four mutators (the query path keeps tolerating an empty needle, as C does). Drop the now-dead `ffi` dependency (it only existed for `ffi::MIN_SUFFIX`).
3. **Outcome**: The Rust port is behavior-faithful to the post-#9945 C suffix DS. `cargo nextest -p term_suffix_index`, clippy, and `cargo doc -D warnings` are all green.

#### Which additional issues this PR fixes
1. MOD-16185
2. Follow-up to #9945

#### Main objects this PR modified
1. `term_suffix_index::TermSuffixIndex` — `suffixes_of`, `add`, `remove`, `iter_contains`, `iter_suffix`
2. `term_suffix_index::term_refs` — doc fix
3. `term_suffix_index/Cargo.toml` — dropped dead `ffi` dependency

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
