### PR TITLE
[MOD-16428] Create indexes before populating them in RESP2 timeout test

### DIFF
--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -4830,9 +4830,6 @@ class TestCoordinatorTimeoutReturnStrictResp2:
 
         self.env.expect('FT.CREATE', 'idx', 'PREFIX', '1', 'doc',
                         'SCHEMA', 'name', 'TEXT').ok()
-        for i in range(self.n_docs):
-            conn.execute_command('HSET', f'doc{i}', 'name', f'hello{i}')
-
         # Index with a vector field for FT.HYBRID tests (different prefix).
         self.env.expect(
             'FT.CREATE', 'hybrid_idx', 'PREFIX', '1', 'hybrid_doc', 'SCHEMA',
@@ -4840,11 +4837,14 @@ class TestCoordinatorTimeoutReturnStrictResp2:
             'embedding', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2',
             'DISTANCE_METRIC', 'L2'
         ).ok()
+
         for i in range(self.n_docs):
+            conn.execute_command('HSET', f'doc{i}', 'name', f'hello{i}')
+
             vec = np.array([float(i), float(i)], dtype=np.float32).tobytes()
             conn.execute_command('HSET', f'hybrid_doc{i}', 'name', f'hello{i}',
                                  'embedding', vec)
-        
+
         # Warmup hybrid query and store the query vector for tests.
         self.hybrid_query_vec = np.array([0.0, 0.0], dtype=np.float32).tobytes()
         try:

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -4827,13 +4827,15 @@ class TestCoordinatorTimeoutReturnStrictResp2:
             verify_shard_init(self.env.getConnection(i))
 
         conn = getConnectionByEnv(self.env)
-        self.env.expect('FT.CREATE', 'idx', 'PREFIX', '1', 'doc',
-                        'SCHEMA', 'name', 'TEXT').ok()
+
         for i in range(self.n_docs):
             conn.execute_command('HSET', f'doc{i}', 'name', f'hello{i}')
             vec = np.array([float(i), float(i)], dtype=np.float32).tobytes()
             conn.execute_command('HSET', f'hybrid_doc{i}', 'name', f'hello{i}',
                                  'embedding', vec)
+        
+        self.env.expect('FT.CREATE', 'idx', 'PREFIX', '1', 'doc',
+                        'SCHEMA', 'name', 'TEXT').ok()
         
         # Index with a vector field for FT.HYBRID tests (different prefix).
         self.env.expect(

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -4831,7 +4831,10 @@ class TestCoordinatorTimeoutReturnStrictResp2:
                         'SCHEMA', 'name', 'TEXT').ok()
         for i in range(self.n_docs):
             conn.execute_command('HSET', f'doc{i}', 'name', f'hello{i}')
-
+            vec = np.array([float(i), float(i)], dtype=np.float32).tobytes()
+            conn.execute_command('HSET', f'hybrid_doc{i}', 'name', f'hello{i}',
+                                 'embedding', vec)
+        
         # Index with a vector field for FT.HYBRID tests (different prefix).
         self.env.expect(
             'FT.CREATE', 'hybrid_idx', 'PREFIX', '1', 'hybrid_doc', 'SCHEMA',
@@ -4839,16 +4842,6 @@ class TestCoordinatorTimeoutReturnStrictResp2:
             'embedding', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2',
             'DISTANCE_METRIC', 'L2'
         ).ok()
-        for i in range(self.n_docs):
-            vec = np.array([float(i), float(i)], dtype=np.float32).tobytes()
-            conn.execute_command('HSET', f'hybrid_doc{i}', 'name', f'hello{i}',
-                                 'embedding', vec)
-
-        # Wait for background indexing of the docs just written to settle before
-        # the warmup FT.HYBRID. The hybrid background depleter (RP_SAFE_DEPLETER)
-        # try-locks the index; if indexing still holds the write lock the warmup
-        # fails with SEARCH_SAFE_DEPLETER_FAILURE (MOD-16428).
-        waitForIndex(self.env, 'hybrid_idx')
 
         # Warmup hybrid query and store the query vector for tests.
         self.hybrid_query_vec = np.array([0.0, 0.0], dtype=np.float32).tobytes()

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -4828,15 +4828,11 @@ class TestCoordinatorTimeoutReturnStrictResp2:
 
         conn = getConnectionByEnv(self.env)
 
-        for i in range(self.n_docs):
-            conn.execute_command('HSET', f'doc{i}', 'name', f'hello{i}')
-            vec = np.array([float(i), float(i)], dtype=np.float32).tobytes()
-            conn.execute_command('HSET', f'hybrid_doc{i}', 'name', f'hello{i}',
-                                 'embedding', vec)
-        
         self.env.expect('FT.CREATE', 'idx', 'PREFIX', '1', 'doc',
                         'SCHEMA', 'name', 'TEXT').ok()
-        
+        for i in range(self.n_docs):
+            conn.execute_command('HSET', f'doc{i}', 'name', f'hello{i}')
+
         # Index with a vector field for FT.HYBRID tests (different prefix).
         self.env.expect(
             'FT.CREATE', 'hybrid_idx', 'PREFIX', '1', 'hybrid_doc', 'SCHEMA',
@@ -4844,7 +4840,11 @@ class TestCoordinatorTimeoutReturnStrictResp2:
             'embedding', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2',
             'DISTANCE_METRIC', 'L2'
         ).ok()
-
+        for i in range(self.n_docs):
+            vec = np.array([float(i), float(i)], dtype=np.float32).tobytes()
+            conn.execute_command('HSET', f'hybrid_doc{i}', 'name', f'hello{i}',
+                                 'embedding', vec)
+        
         # Warmup hybrid query and store the query vector for tests.
         self.hybrid_query_vec = np.array([0.0, 0.0], dtype=np.float32).tobytes()
         try:

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -4844,6 +4844,12 @@ class TestCoordinatorTimeoutReturnStrictResp2:
             conn.execute_command('HSET', f'hybrid_doc{i}', 'name', f'hello{i}',
                                  'embedding', vec)
 
+        # Wait for background indexing of the docs just written to settle before
+        # the warmup FT.HYBRID. The hybrid background depleter (RP_SAFE_DEPLETER)
+        # try-locks the index; if indexing still holds the write lock the warmup
+        # fails with SEARCH_SAFE_DEPLETER_FAILURE (MOD-16428).
+        waitForIndex(self.env, 'hybrid_idx')
+
         # Warmup hybrid query and store the query vector for tests.
         self.hybrid_query_vec = np.array([0.0, 0.0], dtype=np.float32).tobytes()
         try:


### PR DESCRIPTION
## Describe the changes in the pull request

`TestCoordinatorTimeoutReturnStrictResp2.__init__` fires the warmup `FT.HYBRID` immediately after `HSET`-ing 100 `hybrid_doc` hashes, with no wait for background indexing to settle. Under `WORKERS 1` the background index scan still holds the index write lock when the hybrid background depleter (`RP_SAFE_DEPLETER`) try-locks it, so the warmup intermittently fails in `create_instance()` (before any test body) with `SEARCH_SAFE_DEPLETER_FAILURE Failed to acquire index lock for background depletion`, erroring the whole class.

Create indexes before populating them in RESP2 timeout test, avoiding the background processing.

Failing CI run that surfaced this: https://github.com/RediSearch/RediSearch/actions/runs/28005745983/job/82887524322

#### Which additional issues this PR fixes
1. MOD-16428

#### Main objects this PR modified
1. `tests/pytests/test_blocked_client_timeout.py` — `TestCoordinatorTimeoutReturnStrictResp2.__init__`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes