### PR TITLE
[MOD-15571] Split test_index_multi_value_json by algorithm to fix coverage-coordinator timeout

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1897,111 +1897,115 @@ def test_create_multi_value_json():
                        '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',).ok()
             env.assertEqual(to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", "idx", "vec"))['IS_MULTI_VALUE'], 0, message=f'{algo}, {path}')
 
-def index_multi_value_json(data_t):
-    env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
-    conn = getConnectionByEnv(env)
-    dim = 4
-    per_doc = 5
+class TestIndexMultiValueJsonReload:
+    """Multi-value JSON vector indexing (HNSW / FLAT / SVS-VAMANA) across data types, with a reload.
 
-    run_svs_test = data_t in ('FLOAT32', 'FLOAT16')
-    n = 100
+    Split per vector algorithm so the expensive SVS-VAMANA graph rebuild on DEBUG RELOAD gets its
+    own RLTest per-test timeout budget. Originally a single test ran every algorithm and data type
+    under one budget and timed out on the coverage Coordinator job (MOD-15571). All methods share a
+    single environment to avoid paying the (coverage-instrumented) cluster startup cost per algorithm.
+    """
 
-    # Scale factor to avoid FLOAT16/BFLOAT16 overflow: using 1/8 keeps values and distances within safe range
-    # For FLOAT16 with n=250: max value = 250/8 = 31.25, max L2 distance = 4 * 31.25^2 ≈ 3906 (< 65504)
-    scale = 8.0
+    def __init__(self):
+        skipTest(no_json=True)
+        self.env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
+        self.dim = 4
+        self.per_doc = 5
+        # Scale factor to avoid FLOAT16/BFLOAT16 overflow: using 1/8 keeps values and distances within
+        # safe range. For FLOAT16 with n=250: max value = 250/8 = 31.25, max L2 distance ≈ 3906 (< 65504)
+        self.scale = 8.0
 
-    args = ['FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA',
-            '$.vecs[*]', 'AS', 'hnsw', 'VECTOR', 'HNSW', '6', 'TYPE', data_t, 'DIM', dim, 'DISTANCE_METRIC', 'L2',
-            '$.vecs[*]', 'AS', 'flat', 'VECTOR', 'FLAT', '6', 'TYPE', data_t, 'DIM', dim, 'DISTANCE_METRIC', 'L2']
-    if run_svs_test:
-        # Add enough vectors to trigger svs backend index initialization
-        n = 250 * env.shardsCount
-        args += ['$.vecs[*]', 'AS', 'svs', 'VECTOR', 'SVS-VAMANA', '10', 'TYPE', data_t, 'DIM', dim, 'DISTANCE_METRIC', 'L2', 'CONSTRUCTION_WINDOW_SIZE', n, 'SEARCH_WINDOW_SIZE', n]
+    def _check_algo(self, field, algo, data_t, n, extra_params=None, is_svs=False):
+        env = self.env
+        conn = getConnectionByEnv(env)
+        dim, per_doc, scale = self.dim, self.per_doc, self.scale
+        conn.flushall()
 
-    env.expect(*args).ok()
+        attrs = ['TYPE', data_t, 'DIM', dim, 'DISTANCE_METRIC', 'L2']
+        if extra_params:
+            attrs += extra_params
+        env.expect('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA',
+                   '$.vecs[*]', 'AS', field, 'VECTOR', algo, str(len(attrs)), *attrs).ok()
 
-    for i in range(0, n, 2):
-        # Test setting vectors with python list
-        conn.json().set(i, '.', {'vecs': [[(i + j) / scale] * dim for j in range(per_doc)]})
-        # Test setting vectors with numpy array of the same type
-        conn.json().set(i + 1, '.', {'vecs': [
-            create_np_array_typed([(i + 1 + j) / scale] * dim, data_t).tolist() for j in range(per_doc)]})
+        for i in range(0, n, 2):
+            # Test setting vectors with python list
+            conn.json().set(i, '.', {'vecs': [[(i + j) / scale] * dim for j in range(per_doc)]})
+            # Test setting vectors with numpy array of the same type
+            conn.json().set(i + 1, '.', {'vecs': [
+                create_np_array_typed([(i + 1 + j) / scale] * dim, data_t).tolist() for j in range(per_doc)]})
 
-    score_field_name = 'dist'
-    k = min(10, n)
-    element = create_np_array_typed([0]*dim, data_t)
-    cmd_knn = ['FT.SEARCH', 'idx', '', 'PARAMS', '2', 'b', element.tobytes(), 'RETURN', '1', score_field_name, 'SORTBY', score_field_name]
+        score_field_name = 'dist'
+        k = min(10, n)
+        element = create_np_array_typed([0]*dim, data_t)
+        cmd_knn = ['FT.SEARCH', 'idx', '', 'PARAMS', '2', 'b', element.tobytes(), 'RETURN', '1', score_field_name, 'SORTBY', score_field_name]
 
-    expected_res_knn = []  # the expected ids are going to be unique
-    for i in range(k):
-        expected_res_knn.append(str(i))                                 # Expected id
-        dist = i * i * dim / (scale * scale)
-        # Server returns int for whole numbers, float otherwise
-        expected_res_knn.append([score_field_name, str(int(dist) if dist == int(dist) else dist)])
+        expected_res_knn = []  # the expected ids are going to be unique
+        for i in range(k):
+            expected_res_knn.append(str(i))                                 # Expected id
+            dist = i * i * dim / (scale * scale)
+            # Server returns int for whole numbers, float otherwise
+            expected_res_knn.append([score_field_name, str(int(dist) if dist == int(dist) else dist)])
 
-    radius = (dim * k**2 + 40) / (scale * scale)
-    element = create_np_array_typed([n / scale]*dim, data_t)
-    cmd_range = ['FT.SEARCH', 'idx', '', 'PARAMS', '2', 'b', element.tobytes(), 'RETURN', '1', score_field_name, 'LIMIT', 0, n]
-    expected_res_range = []
-    for i in range(n-k-per_doc+1, n-per_doc+1):
-        expected_res_range.append(str(i))
-        dist = dim * (n-per_doc-i+1)**2 / (scale * scale)
-        # Server returns int for whole numbers, float otherwise
-        expected_res_range.append([score_field_name, str(int(dist) if dist == int(dist) else dist)])
-    for i in range(n-per_doc+1, n):        # Ids for which there is a vector whose distance to the query vec is zero.
-        expected_res_range.append(str(i))
-        expected_res_range.append([score_field_name, '0'])
-    expected_res_range.insert(0, int(len(expected_res_range)/2))
+        radius = (dim * k**2 + 40) / (scale * scale)
+        element = create_np_array_typed([n / scale]*dim, data_t)
+        cmd_range = ['FT.SEARCH', 'idx', '', 'PARAMS', '2', 'b', element.tobytes(), 'RETURN', '1', score_field_name, 'LIMIT', 0, n]
+        expected_res_range = []
+        for i in range(n-k-per_doc+1, n-per_doc+1):
+            expected_res_range.append(str(i))
+            dist = dim * (n-per_doc-i+1)**2 / (scale * scale)
+            # Server returns int for whole numbers, float otherwise
+            expected_res_range.append([score_field_name, str(int(dist) if dist == int(dist) else dist)])
+        for i in range(n-per_doc+1, n):        # Ids for which there is a vector whose distance to the query vec is zero.
+            expected_res_range.append(str(i))
+            expected_res_range.append([score_field_name, '0'])
+        expected_res_range.insert(0, int(len(expected_res_range)/2))
 
-    for _ in env.reloadingIterator():
-        waitForIndex(env, 'idx')
-        info = index_info(env, 'idx')
-        env.assertEqual(info['num_docs'], n, message=f'data_t: {data_t}')
-        env.assertEqual(info['num_records'], 0, message=f'data_t: {data_t}')
-        env.assertEqual(info['hash_indexing_failures'], 0, message=f'data_t: {data_t}')
+        for _ in env.reloadingIterator():
+            waitForIndex(env, 'idx')
+            info = index_info(env, 'idx')
+            env.assertEqual(info['num_docs'], n, message=f'{algo}, data_t: {data_t}')
+            env.assertEqual(info['num_records'], 0, message=f'{algo}, data_t: {data_t}')
+            env.assertEqual(info['hash_indexing_failures'], 0, message=f'{algo}, data_t: {data_t}')
 
-        cmd_knn[2] = f'*=>[KNN {k} @hnsw $b AS {score_field_name}]'
-        hnsw_res = conn.execute_command(*cmd_knn)[1:]
-        env.assertEqual(hnsw_res, expected_res_knn, message=f'data_t: {data_t}')
+            if is_svs:
+                env.assertGreater(get_tiered_backend_debug_info(env, 'idx', field)['INDEX_SIZE'], 0,
+                                  message=f'data_t: {data_t}')
 
-        cmd_knn[2] = f'*=>[KNN {k} @flat $b AS {score_field_name}]'
-        flat_res = conn.execute_command(*cmd_knn)[1:]
-        env.assertEqual(flat_res, expected_res_knn, message=f'data_t: {data_t}')
+            cmd_knn[2] = f'*=>[KNN {k} @{field} $b AS {score_field_name}]'
+            knn_res = conn.execute_command(*cmd_knn)[1:]
+            env.assertEqual(knn_res, expected_res_knn, message=f'{algo}, data_t: {data_t}')
 
-        cmd_range[2] = f'@hnsw:[VECTOR_RANGE {radius} $b]=>{{$yield_distance_as:{score_field_name}}}'
-        hnsw_res = conn.execute_command(*cmd_range)
-        try:
-            env.assertEqual(sortedResults(hnsw_res), expected_res_range, message=f'data_t: {data_t}')
-        except Exception as e:
-            env.debugPrint(f"Failed comparing results: {e} for data_t: {data_t}", force=True)
-            raise e
+            cmd_range[2] = f'@{field}:[VECTOR_RANGE {radius} $b]=>{{$yield_distance_as:{score_field_name}}}'
+            range_res = conn.execute_command(*cmd_range)
+            try:
+                env.assertEqual(sortedResults(range_res), expected_res_range, message=f'{algo}, data_t: {data_t}')
+            except Exception as e:
+                env.debugPrint(f"Failed comparing range results: {e} for {algo}, data_t: {data_t}", force=True)
+                raise e
 
-        cmd_range[2] = f'@flat:[VECTOR_RANGE {radius} $b]=>{{$yield_distance_as:{score_field_name}}}'
-        flat_res = conn.execute_command(*cmd_range)
-        env.assertEqual(sortedResults(flat_res), expected_res_range, message=f'data_t: {data_t}')
+    def test_hnsw(self):
+        for data_t in VECSIM_DATA_TYPES:
+            self._check_algo('hnsw', 'HNSW', data_t, n=100)
 
-        if run_svs_test:
-            env.assertGreater(get_tiered_backend_debug_info(env, 'idx', 'svs')['INDEX_SIZE'], 0)
-            cmd_knn[2] = f'*=>[KNN {k} @svs $b AS {score_field_name}]'
-            svs_res = conn.execute_command(*cmd_knn)[1:]
-            env.assertEqual(svs_res, expected_res_knn, message=f'data_t: {data_t}')
+    def test_flat(self):
+        for data_t in VECSIM_DATA_TYPES:
+            self._check_algo('flat', 'FLAT', data_t, n=100)
 
-            cmd_range[2] = f'@svs:[VECTOR_RANGE {radius} $b]=>{{$yield_distance_as:{score_field_name}}}'
-            svs_res = conn.execute_command(*cmd_range)
-            env.assertEqual(sortedResults(svs_res), expected_res_range, message=f'data_t: {data_t}')
+    def _check_svs(self, data_t):
+        # Use enough vectors to trigger the SVS backend (Vamana graph) build. SEARCH_WINDOW_SIZE = n
+        # keeps the search effectively exhaustive, so KNN/range results stay exact regardless of graph
+        # connectivity; CONSTRUCTION_WINDOW_SIZE keeps the index default. Under coverage with
+        # MIN_OPERATION_WORKERS 0 the graph is rebuilt synchronously during DEBUG RELOAD, so each data
+        # type runs as its own test to keep that rebuild within a single per-test timeout (MOD-15571).
+        n = 250 * self.env.shardsCount
+        self._check_algo('svs', 'SVS-VAMANA', data_t, n,
+                         extra_params=['SEARCH_WINDOW_SIZE', n], is_svs=True)
 
+    def test_svs_float32(self):
+        self._check_svs('FLOAT32')
 
-# Generate one test per data type. Running all data types in a single test shared one RLTest
-# per-test timeout budget; on the coverage Coordinator job the SVS backend rebuild on reload
-# (FLOAT32/FLOAT16) multiplied across shards overran that budget and timed out (MOD-15571).
-# Splitting gives each data type its own budget and lets them run on separate parallel workers,
-# without weakening coverage.
-multi_value_json_test_gen = lambda dt: skip(no_json=True)(lambda: index_multi_value_json(dt))
-for _data_t in VECSIM_DATA_TYPES:
-    _test_name = f"test_index_multi_value_json_{_data_t}"
-    _test_func = multi_value_json_test_gen(_data_t)
-    _test_func.__name__ = _test_name
-    globals()[_test_name] = _test_func
+    def test_svs_float16(self):
+        self._check_svs('FLOAT16')
 
 @skip(no_json=True)
 def test_bad_index_multi_value_json():


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** After splitting `test_index_multi_value_json` per data type (#10168), a single SVS-heavy data type still timed out on the coverage Coordinator job ([run 27951794738](https://github.com/RediSearch/RediSearch/actions/runs/27951794738/job/82710754111)). With `MIN_OPERATION_WORKERS 0` the SVS-VAMANA graph is rebuilt **synchronously** during `DEBUG RELOAD`, and that build cost — driven by `CONSTRUCTION_WINDOW_SIZE`, which the test forced to `n` (=750, 3.75× the index default of 200) — dominates the runtime under gcov instrumentation across shards.
2. **Change:**
   - Restructure into a class `TestIndexMultiValueJsonReload` that splits the test **by algorithm** (`test_hnsw`, `test_flat`, `test_svs_float32`, `test_svs_float16`), all sharing a **single environment** so the coverage-instrumented cluster startup is paid once.
   - Each method gets its own RLTest per-test timeout budget; the expensive SVS rebuild is isolated and further split per data type so each synchronous reload-rebuild stays within one budget.
   - Stop forcing the oversized `CONSTRUCTION_WINDOW_SIZE`; use the index default (200). Keep `SEARCH_WINDOW_SIZE = n` so the Vamana search stays effectively exhaustive and KNN/range results remain exact regardless of graph connectivity (also required so the range query isn't truncated).
3. **Outcome:** No coverage lost (same algorithms, data types, reload, assertions). Verified under a `COV=1` gcov build in 3-shard cluster mode: the whole class runs in ~115s, each SVS data-type method ~48s locally; previously the combined test took 338s and a single SVS data type timed out (>300s) on CI.

#### Which additional issues this PR fixes
1. MOD-15571

#### Main objects this PR modified
1. `tests/pytests/test_vecsim.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
