### PR TITLE
[MOD-16908] topk: numeric source implementation (single batch)

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1518,7 +1518,11 @@ dependencies = [
 name = "numeric_score_source"
 version = "0.0.1"
 dependencies = [
+ "build_utils",
  "index_result",
+ "numeric_score_source",
+ "redis_mock",
+ "redisearch_rs",
  "rqe_core",
  "rqe_iterator_type",
  "rqe_iterators",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1515,6 +1515,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "numeric_score_source"
+version = "0.0.1"
+dependencies = [
+ "index_result",
+ "rqe_core",
+ "rqe_iterator_type",
+ "rqe_iterators",
+ "top_k",
+ "workspace_hack",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1520,6 +1520,7 @@ version = "0.0.1"
 dependencies = [
  "build_utils",
  "index_result",
+ "itertools 0.15.0",
  "numeric_score_source",
  "redis_mock",
  "redisearch_rs",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "top_k_bencher",
     "vector_score_source",
     "vector_score_source_bencher",
+    "numeric_score_source",
     "trie_rs",
     "ttl_table",
     "utf8parse",
@@ -128,6 +129,7 @@ index_result = { path = "./index_result" }
 index_spec_cache = { path = "./c_wrappers/index_spec_cache" }
 inverted_index = { path = "./inverted_index" }
 numeric_range_tree = { path = "./numeric_range_tree" }
+numeric_score_source = { path = "./numeric_score_source" }
 redis_reply = { path = "./redis_reply" }
 qint = { path = "./qint" }
 query = { path = "./c_wrappers/query" }

--- a/src/redisearch_rs/numeric_score_source/Cargo.toml
+++ b/src/redisearch_rs/numeric_score_source/Cargo.toml
@@ -5,6 +5,14 @@ name = "numeric_score_source"
 publish.workspace = true
 version.workspace = true
 
+[features]
+# Links C static libraries at test time (see build.rs).
+# https://github.com/rust-lang/cargo/issues/4789#issuecomment-2308131243
+unittest = []
+
+[build-dependencies]
+build_utils = {path = "../build_utils"}
+
 [dependencies]
 index_result.workspace = true
 rqe_core.workspace = true
@@ -12,3 +20,8 @@ rqe_iterator_type.workspace = true
 rqe_iterators.workspace = true
 top_k = {path = "../top_k"}
 workspace_hack.workspace = true
+
+[dev-dependencies]
+redis_mock.workspace = true
+redisearch_rs = {path = "../c_entrypoint/redisearch_rs", features = ["mock_allocator"]}
+numeric_score_source = {path = ".", features = ["unittest"]}

--- a/src/redisearch_rs/numeric_score_source/Cargo.toml
+++ b/src/redisearch_rs/numeric_score_source/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+edition.workspace = true
+license-file.workspace = true
+name = "numeric_score_source"
+publish.workspace = true
+version.workspace = true
+
+[dependencies]
+index_result.workspace = true
+rqe_core.workspace = true
+rqe_iterator_type.workspace = true
+rqe_iterators.workspace = true
+top_k = {path = "../top_k"}
+workspace_hack.workspace = true

--- a/src/redisearch_rs/numeric_score_source/Cargo.toml
+++ b/src/redisearch_rs/numeric_score_source/Cargo.toml
@@ -22,6 +22,7 @@ top_k = {path = "../top_k"}
 workspace_hack.workspace = true
 
 [dev-dependencies]
+itertools.workspace = true
+numeric_score_source = {path = ".", features = ["unittest"]}
 redis_mock.workspace = true
 redisearch_rs = {path = "../c_entrypoint/redisearch_rs", features = ["mock_allocator"]}
-numeric_score_source = {path = ".", features = ["unittest"]}

--- a/src/redisearch_rs/numeric_score_source/build.rs
+++ b/src/redisearch_rs/numeric_score_source/build.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+fn main() {
+    #[cfg(feature = "unittest")]
+    build_utils::bind_foreign_c_symbols();
+}

--- a/src/redisearch_rs/numeric_score_source/src/lib.rs
+++ b/src/redisearch_rs/numeric_score_source/src/lib.rs
@@ -49,15 +49,16 @@ fn cmp_for(ascending: bool) -> fn(f64, f64) -> Ordering {
 
 /// Construct an unfiltered [`NumericTopKIterator`] (no filter child).
 ///
-/// Results are streamed directly from the source's single batch without a
-/// heap, via the [`TopKMode::Unfiltered`] path. `ascending` selects the sort
+/// Every record is fed through the heap, which retains the top `k` by numeric
+/// value: a numeric source has no native top-k, so the heap ([`TopKMode::Batches`]
+/// with no child) performs the selection. `ascending` selects the sort
 /// direction (`SORTBY field ASC`/`DESC`).
 pub fn new_numeric_top_k_unfiltered<'index, S: RQEIterator<'index> + 'index>(
     source: NumericScoreSource<'index, S>,
     k: NonZeroUsize,
     ascending: bool,
 ) -> NumericTopKIterator<'index, S> {
-    TopKIterator::new_with_mode(source, None, k, cmp_for(ascending), TopKMode::Unfiltered)
+    TopKIterator::new_with_mode(source, None, k, cmp_for(ascending), TopKMode::Batches)
 }
 
 /// Construct a filtered [`NumericTopKIterator`] with a filter child.

--- a/src/redisearch_rs/numeric_score_source/src/lib.rs
+++ b/src/redisearch_rs/numeric_score_source/src/lib.rs
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Numeric-field-backed [`top_k::ScoreSource`] and [`NumericTopKIterator`] for
+//! top-k optimizer queries.
+//!
+//! # Overview
+//!
+//! This crate provides [`NumericScoreSource`], a concrete [`top_k::ScoreSource`]
+//! that drives [`TopKIterator`] using a numeric field's values as scores.
+
+pub mod score_batch;
+pub mod source;
+
+pub use score_batch::NumericScoreBatch;
+pub use source::NumericScoreSource;
+
+use std::{cmp::Ordering, num::NonZeroUsize};
+
+use rqe_iterators::RQEIterator;
+use top_k::{TopKIterator, TopKMode};
+
+/// A [`TopKIterator`] parameterised over [`NumericScoreSource`].
+///
+/// Construct one with [`new_numeric_top_k_unfiltered`] or
+/// [`new_numeric_top_k_filtered`].
+pub type NumericTopKIterator<'index, S> = TopKIterator<'index, NumericScoreSource<'index, S>>;
+
+/// Ascending comparator — lower numeric value is "better" (`SORTBY field ASC`).
+fn asc_cmp(a: f64, b: f64) -> Ordering {
+    a.partial_cmp(&b).unwrap_or(Ordering::Equal)
+}
+
+/// Descending comparator — higher numeric value is "better" (`SORTBY field DESC`).
+fn desc_cmp(a: f64, b: f64) -> Ordering {
+    asc_cmp(a, b).reverse()
+}
+
+/// Pick the heap comparator for the query's sort direction.
+fn cmp_for(ascending: bool) -> fn(f64, f64) -> Ordering {
+    if ascending { asc_cmp } else { desc_cmp }
+}
+
+/// Construct an unfiltered [`NumericTopKIterator`] (no filter child).
+///
+/// Results are streamed directly from the source's single batch without a
+/// heap, via the [`TopKMode::Unfiltered`] path. `ascending` selects the sort
+/// direction (`SORTBY field ASC`/`DESC`).
+pub fn new_numeric_top_k_unfiltered<'index, S: RQEIterator<'index> + 'index>(
+    source: NumericScoreSource<'index, S>,
+    k: NonZeroUsize,
+    ascending: bool,
+) -> NumericTopKIterator<'index, S> {
+    TopKIterator::new_with_mode(source, None, k, cmp_for(ascending), TopKMode::Unfiltered)
+}
+
+/// Construct a filtered [`NumericTopKIterator`] with a filter child.
+///
+/// Uses [`TopKMode::Batches`]: the source's batch is intersected with the
+/// child filter, and the heap keeps the top `k` by numeric value.
+pub fn new_numeric_top_k_filtered<'index, S: RQEIterator<'index> + 'index>(
+    source: NumericScoreSource<'index, S>,
+    child: impl RQEIterator<'index> + 'index,
+    k: NonZeroUsize,
+    ascending: bool,
+) -> NumericTopKIterator<'index, S> {
+    TopKIterator::new_with_mode(
+        source,
+        Some(Box::new(child) as Box<dyn RQEIterator<'index> + 'index>),
+        k,
+        cmp_for(ascending),
+        TopKMode::Batches,
+    )
+}

--- a/src/redisearch_rs/numeric_score_source/src/lib.rs
+++ b/src/redisearch_rs/numeric_score_source/src/lib.rs
@@ -19,7 +19,7 @@ pub mod score_batch;
 pub mod source;
 
 pub use score_batch::NumericScoreBatch;
-pub use source::NumericScoreSource;
+pub use source::{NumericRecords, NumericScoreSource};
 
 use std::{cmp::Ordering, num::NonZeroUsize};
 
@@ -47,7 +47,7 @@ fn cmp_for(ascending: bool) -> fn(&f64, &f64) -> Ordering {
 /// value: a numeric source has no native top-k, so the heap ([`TopKMode::Batches`]
 /// with no child) performs the selection. `ascending` selects the sort
 /// direction (`SORTBY field ASC`/`DESC`).
-pub fn new_numeric_top_k_unfiltered<'index, S: RQEIterator<'index> + 'index>(
+pub fn new_numeric_top_k_unfiltered<'index, S: NumericRecords<'index> + 'index>(
     source: NumericScoreSource<'index, S>,
     k: NonZeroUsize,
     ascending: bool,
@@ -59,7 +59,7 @@ pub fn new_numeric_top_k_unfiltered<'index, S: RQEIterator<'index> + 'index>(
 ///
 /// Uses [`TopKMode::Batches`]: the source's batch is intersected with the
 /// child filter, and the heap keeps the top `k` by numeric value.
-pub fn new_numeric_top_k_filtered<'index, S: RQEIterator<'index> + 'index>(
+pub fn new_numeric_top_k_filtered<'index, S: NumericRecords<'index> + 'index>(
     source: NumericScoreSource<'index, S>,
     child: impl RQEIterator<'index> + 'index,
     k: NonZeroUsize,

--- a/src/redisearch_rs/numeric_score_source/src/lib.rs
+++ b/src/redisearch_rs/numeric_score_source/src/lib.rs
@@ -32,19 +32,13 @@ use top_k::{TopKIterator, TopKMode};
 /// [`new_numeric_top_k_filtered`].
 pub type NumericTopKIterator<'index, S> = TopKIterator<'index, NumericScoreSource<'index, S>>;
 
-/// Ascending comparator — lower numeric value is "better" (`SORTBY field ASC`).
-fn asc_cmp(a: f64, b: f64) -> Ordering {
-    a.partial_cmp(&b).unwrap_or(Ordering::Equal)
-}
-
-/// Descending comparator — higher numeric value is "better" (`SORTBY field DESC`).
-fn desc_cmp(a: f64, b: f64) -> Ordering {
-    asc_cmp(a, b).reverse()
-}
-
 /// Pick the heap comparator for the query's sort direction.
-fn cmp_for(ascending: bool) -> fn(f64, f64) -> Ordering {
-    if ascending { asc_cmp } else { desc_cmp }
+fn cmp_for(ascending: bool) -> fn(&f64, &f64) -> Ordering {
+    if ascending {
+        f64::total_cmp
+    } else {
+        |a, b| b.total_cmp(a)
+    }
 }
 
 /// Construct an unfiltered [`NumericTopKIterator`] (no filter child).

--- a/src/redisearch_rs/numeric_score_source/src/score_batch.rs
+++ b/src/redisearch_rs/numeric_score_source/src/score_batch.rs
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! [`NumericScoreBatch`] — a [`ScoreBatch`] over a drained numeric iterator.
+
+use rqe_core::DocId;
+use top_k::ScoreBatch;
+
+/// A [`ScoreBatch`] backed by a doc-id-ordered `Vec<(DocId, f64)>`.
+///
+/// Doc IDs must be strictly increasing — the numeric index reader yields them
+/// in ascending order; this is asserted in debug builds.
+pub struct NumericScoreBatch {
+    items: Vec<(DocId, f64)>,
+    pos: usize,
+}
+
+impl NumericScoreBatch {
+    /// Create a batch from `(doc_id, score)` pairs sorted strictly ascending by
+    /// `doc_id`.
+    pub(crate) fn new(items: Vec<(DocId, f64)>) -> Self {
+        debug_assert!(
+            items.windows(2).all(|w| w[0].0 < w[1].0),
+            "NumericScoreBatch: doc IDs must be strictly increasing"
+        );
+        Self { items, pos: 0 }
+    }
+}
+
+impl ScoreBatch for NumericScoreBatch {
+    fn next(&mut self) -> Option<(DocId, f64)> {
+        let item = self.items.get(self.pos).copied();
+        if item.is_some() {
+            self.pos += 1;
+        }
+        item
+    }
+
+    fn skip_to(&mut self, target: DocId) -> Option<(DocId, f64)> {
+        self.pos += self.items[self.pos..].partition_point(|(id, _)| *id < target);
+        self.next()
+    }
+}

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! [`NumericScoreSource`] — [`ScoreSource`] implementation backed by a numeric
+//! [`RQEIterator`].
+
+use std::marker::PhantomData;
+
+use index_result::{RSIndexResult, RSResultKind};
+use rqe_core::DocId;
+use rqe_iterator_type::IteratorType;
+use rqe_iterators::{RQEIterator, RQEIteratorError};
+use top_k::{BatchStrategy, ScoreSource};
+
+use crate::score_batch::NumericScoreBatch;
+
+/// Scores each document by a numeric field, for top-k queries like
+/// `SORTBY <numeric field>`.
+///
+/// A document's score is the numeric value read from the wrapped `source`
+/// iterator, so taking the top `k` here means taking the `k` highest values of
+/// that field.
+///
+/// [`next_batch`](ScoreSource::next_batch) reads the whole source into one
+/// batch, ordered by doc id; the surrounding [`TopKIterator`] then picks the top
+/// `k` with its heap.
+///
+/// Adhoc-BF strategy has not been implemented
+///
+/// Not implemented yet:
+/// - TODO: MOD-14945 Timeout handling
+/// - TODO: MOD-14946 Profile metrics
+/// - TODO: MOD-14947 Parity tests
+/// - TODO: MOD-14948 Performance validation
+///
+/// [`TopKIterator`]: top_k::TopKIterator
+pub struct NumericScoreSource<'index, S: RQEIterator<'index>> {
+    /// Numeric iterator whose per-document value is used as the score.
+    source: S,
+    /// Whether [`next_batch`](ScoreSource::next_batch) has already emitted its
+    /// single batch. Reset by [`rewind`](ScoreSource::rewind).
+    drained: bool,
+    /// Upper-bound result estimate captured at construction, so it stays stable
+    /// after the source is drained.
+    num_estimated: usize,
+    _index: PhantomData<&'index ()>,
+}
+
+impl<'index, S: RQEIterator<'index>> NumericScoreSource<'index, S> {
+    /// Wrap a numeric `source` iterator as a score source.
+    pub fn new(source: S) -> Self {
+        let num_estimated = source.num_estimated();
+        Self {
+            source,
+            drained: false,
+            num_estimated,
+            _index: PhantomData,
+        }
+    }
+}
+
+impl<'index, S: RQEIterator<'index>> ScoreSource for NumericScoreSource<'index, S> {
+    type Batch = NumericScoreBatch;
+
+    fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
+        if self.drained {
+            return Ok(None);
+        }
+
+        let mut items = Vec::new();
+        while let Some(result) = self.source.read()? {
+            debug_assert!(
+                matches!(result.kind(), RSResultKind::Numeric | RSResultKind::Metric),
+                "NumericScoreSource: wrapped iterator yielded a non-numeric record ({})",
+                result.kind()
+            );
+            // SAFETY: the wrapped iterator is a numeric index iterator, whose
+            // records are always numeric (asserted above in debug builds).
+            let score = unsafe { result.as_numeric_unchecked() };
+            items.push((result.doc_id, score));
+        }
+        self.drained = true;
+
+        if items.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(NumericScoreBatch::new(items)))
+    }
+
+    fn lookup_score(&mut self, _doc_id: DocId) -> Option<f64> {
+        // Adhoc-BF is not used by the numeric path.
+        None
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.num_estimated
+    }
+
+    fn rewind(&mut self) {
+        self.source.rewind();
+        self.drained = false;
+    }
+
+    fn build_result<'r>(&self, doc_id: DocId, score: f64) -> RSIndexResult<'r>
+    where
+        Self: 'r,
+    {
+        RSIndexResult::build_numeric(score).doc_id(doc_id).build()
+    }
+
+    fn batch_strategy(&mut self, heap_count: usize, k: usize) -> BatchStrategy {
+        if heap_count >= k {
+            BatchStrategy::Stop
+        } else {
+            BatchStrategy::Continue
+        }
+    }
+
+    fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+        // TODO: MOD-14945: Timeout handling is deferred to a later iteration.
+        Ok(())
+    }
+
+    fn iterator_type(&self) -> IteratorType {
+        IteratorType::Optimus
+    }
+
+    fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+        // TODO: MOD-14945 — real timeout handling. The numeric source never
+        // times out yet.
+        Ok(())
+    }
+}

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -34,6 +34,7 @@ use crate::score_batch::NumericScoreBatch;
 /// Adhoc-BF strategy has not been implemented
 ///
 /// Not implemented yet:
+/// - TODO: MOD-14207 Proper batching logic through numeric filter
 /// - TODO: MOD-14945 Timeout handling
 /// - TODO: MOD-14946 Profile metrics
 /// - TODO: MOD-14947 Parity tests
@@ -120,11 +121,6 @@ impl<'index, S: RQEIterator<'index>> ScoreSource for NumericScoreSource<'index, 
         } else {
             BatchStrategy::Continue
         }
-    }
-
-    fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
-        // TODO: MOD-14945: Timeout handling is deferred to a later iteration.
-        Ok(())
     }
 
     fn iterator_type(&self) -> IteratorType {

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -15,10 +15,38 @@ use std::marker::PhantomData;
 use index_result::{RSIndexResult, RSResultKind};
 use rqe_core::DocId;
 use rqe_iterator_type::IteratorType;
-use rqe_iterators::{RQEIterator, RQEIteratorError};
+use rqe_iterators::{RQEIterator, RQEIteratorError, inverted_index::Numeric, metric::Metric};
 use top_k::{BatchStrategy, ScoreSource};
 
 use crate::score_batch::NumericScoreBatch;
+
+/// An [`RQEIterator`] whose records are guaranteed to be numeric.
+///
+/// [`NumericScoreSource`] is generic over its source iterator, but reads each
+/// record's score via [`as_numeric_unchecked`](RSIndexResult::as_numeric_unchecked),
+/// which is undefined behavior on a non-numeric record. This trait restricts the
+/// source to iterators that uphold that guarantee.
+///
+/// # Safety
+///
+/// Implementers must guarantee that every record produced by
+/// [`read`](RQEIterator::read) is numeric — its [`kind`](RSIndexResult::kind) is
+/// either [`RSResultKind::Numeric`] or [`RSResultKind::Metric`].
+pub unsafe trait NumericRecords<'index>: RQEIterator<'index> {}
+
+// SAFETY: every record is built via `RSIndexResult::build_metric`, so its kind is
+// always `Metric`.
+unsafe impl<'index, const SORTED_BY_ID: bool> NumericRecords<'index>
+    for Metric<'index, SORTED_BY_ID>
+{
+}
+
+// SAFETY: the wrapped reader decodes into a result seeded with
+// `RSIndexResult::build_numeric`, so its kind is always `Numeric`.
+unsafe impl<'index, R, E> NumericRecords<'index> for Numeric<'index, R, E> where
+    Self: RQEIterator<'index>
+{
+}
 
 /// Scores each document by a numeric field, for top-k queries like
 /// `SORTBY <numeric field>`.
@@ -41,7 +69,7 @@ use crate::score_batch::NumericScoreBatch;
 /// - TODO: MOD-14948 Performance validation
 ///
 /// [`TopKIterator`]: top_k::TopKIterator
-pub struct NumericScoreSource<'index, S: RQEIterator<'index>> {
+pub struct NumericScoreSource<'index, S: NumericRecords<'index>> {
     /// Numeric iterator whose per-document value is used as the score.
     source: S,
     /// Whether [`next_batch`](ScoreSource::next_batch) has already emitted its
@@ -53,7 +81,7 @@ pub struct NumericScoreSource<'index, S: RQEIterator<'index>> {
     _index: PhantomData<&'index ()>,
 }
 
-impl<'index, S: RQEIterator<'index>> NumericScoreSource<'index, S> {
+impl<'index, S: NumericRecords<'index>> NumericScoreSource<'index, S> {
     /// Wrap a numeric `source` iterator as a score source.
     pub fn new(source: S) -> Self {
         let num_estimated = source.num_estimated();
@@ -66,7 +94,7 @@ impl<'index, S: RQEIterator<'index>> NumericScoreSource<'index, S> {
     }
 }
 
-impl<'index, S: RQEIterator<'index>> ScoreSource for NumericScoreSource<'index, S> {
+impl<'index, S: NumericRecords<'index>> ScoreSource for NumericScoreSource<'index, S> {
     type Batch = NumericScoreBatch;
 
     fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
@@ -81,8 +109,8 @@ impl<'index, S: RQEIterator<'index>> ScoreSource for NumericScoreSource<'index, 
                 "NumericScoreSource: wrapped iterator yielded a non-numeric record ({})",
                 result.kind()
             );
-            // SAFETY: the wrapped iterator is a numeric index iterator, whose
-            // records are always numeric (asserted above in debug builds).
+            // SAFETY: the `S: NumericRecords` bound guarantees every record read
+            // from `source` is numeric.
             let score = unsafe { result.as_numeric_unchecked() };
             items.push((result.doc_id, score));
         }

--- a/src/redisearch_rs/numeric_score_source/tests/integration/main.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/main.rs
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+// Provide stubs for C symbols that the linked C archive references but that
+// these tests never exercise (Redis module API surface).
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+extern crate redisearch_rs;
+
+mod source;

--- a/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Tests for [`NumericScoreSource`], driven by a `MetricSortedById`
+//! source (a pure-Rust numeric-valued iterator).
+
+use std::num::NonZeroUsize;
+
+use numeric_score_source::{NumericScoreSource, new_numeric_top_k_unfiltered};
+use rqe_core::DocId;
+use rqe_iterators::RQEIterator;
+use rqe_iterators::metric::MetricSortedById;
+use top_k::{ScoreBatch, ScoreSource};
+
+/// Wrap `(doc_id, score)` pairs (ascending by id) as a `NumericScoreSource`.
+fn source(pairs: &[(DocId, f64)]) -> NumericScoreSource<'static, MetricSortedById<'static>> {
+    let ids = pairs.iter().map(|(id, _)| *id).collect::<Vec<_>>();
+    let scores = pairs.iter().map(|(_, s)| *s).collect::<Vec<_>>();
+    NumericScoreSource::new(MetricSortedById::new(ids, scores))
+}
+
+/// Drain a batch into a `Vec`.
+fn drain<B: ScoreBatch>(mut batch: B) -> Vec<(DocId, f64)> {
+    let mut got = Vec::new();
+    while let Some(pair) = batch.next() {
+        got.push(pair);
+    }
+    got
+}
+
+#[test]
+fn next_batch_yields_every_record_in_doc_id_order() {
+    let mut src = source(&[(1, 3.0), (2, 1.0), (3, 2.0)]);
+    let batch = src.next_batch().unwrap().expect("a batch");
+    assert_eq!(drain(batch), vec![(1, 3.0), (2, 1.0), (3, 2.0)]);
+}
+
+#[test]
+fn empty_source_yields_no_batch() {
+    let mut src = source(&[]);
+    assert!(src.next_batch().unwrap().is_none());
+}
+
+#[test]
+fn source_emits_one_batch_then_rewinds() {
+    let mut src = source(&[(1, 1.0), (2, 2.0)]);
+    assert!(src.next_batch().unwrap().is_some());
+    // Single-batch source: a second read without rewinding is empty.
+    assert!(src.next_batch().unwrap().is_none());
+
+    src.rewind();
+    let batch = src.next_batch().unwrap().expect("a batch after rewind");
+    assert_eq!(drain(batch), vec![(1, 1.0), (2, 2.0)]);
+}
+
+/// Drive an unfiltered top-k iterator to exhaustion, collecting the yielded
+/// `(doc_id, score)` pairs.
+fn run_unfiltered(pairs: &[(DocId, f64)], k: usize, ascending: bool) -> Vec<(DocId, f64)> {
+    let mut it =
+        new_numeric_top_k_unfiltered(source(pairs), NonZeroUsize::new(k).unwrap(), ascending);
+    let mut got = Vec::new();
+    while let Some(result) = it.read().unwrap() {
+        // SAFETY: the numeric source builds every result with `build_numeric`,
+        // so each yielded record is numeric.
+        let score = unsafe { result.as_numeric_unchecked() };
+        got.push((result.doc_id, score));
+    }
+    got
+}
+
+#[test]
+fn unfiltered_caps_at_k_descending() {
+    // More records than k: LIMIT k must return the k highest values (DESC),
+    // not every record in doc-id order. Yields best-first.
+    let got = run_unfiltered(
+        &[(1, 5.0), (2, 1.0), (3, 4.0), (4, 2.0), (5, 3.0)],
+        3,
+        false,
+    );
+    assert_eq!(got, vec![(1, 5.0), (3, 4.0), (5, 3.0)]);
+}
+
+#[test]
+fn unfiltered_caps_at_k_ascending() {
+    // Same records, ASC: the k lowest values, best-first.
+    let got = run_unfiltered(&[(1, 5.0), (2, 1.0), (3, 4.0), (4, 2.0), (5, 3.0)], 3, true);
+    assert_eq!(got, vec![(2, 1.0), (4, 2.0), (5, 3.0)]);
+}
+
+#[test]
+fn unfiltered_fewer_than_k_yields_all() {
+    let got = run_unfiltered(&[(1, 3.0), (2, 1.0)], 5, false);
+    assert_eq!(got, vec![(1, 3.0), (2, 1.0)]);
+}

--- a/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
@@ -26,11 +26,6 @@ fn source(pairs: &[(DocId, f64)]) -> NumericScoreSource<'static, MetricSortedByI
     NumericScoreSource::new(MetricSortedById::new(ids, scores))
 }
 
-/// Drain a batch into a `Vec`.
-fn drain<B: ScoreBatch>(mut batch: B) -> Vec<(DocId, f64)> {
-    iter::from_fn(|| batch.next()).collect()
-}
-
 #[test]
 fn next_batch_yields_every_record_in_doc_id_order() {
     let mut src = source(&[(1, 3.0), (2, 1.0), (3, 2.0)]);

--- a/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
@@ -10,8 +10,9 @@
 //! Tests for [`NumericScoreSource`], driven by a `MetricSortedById`
 //! source (a pure-Rust numeric-valued iterator).
 
-use std::num::NonZeroUsize;
+use std::{iter, num::NonZeroUsize};
 
+use itertools::Itertools;
 use numeric_score_source::{NumericScoreSource, new_numeric_top_k_unfiltered};
 use rqe_core::DocId;
 use rqe_iterators::RQEIterator;
@@ -27,18 +28,17 @@ fn source(pairs: &[(DocId, f64)]) -> NumericScoreSource<'static, MetricSortedByI
 
 /// Drain a batch into a `Vec`.
 fn drain<B: ScoreBatch>(mut batch: B) -> Vec<(DocId, f64)> {
-    let mut got = Vec::new();
-    while let Some(pair) = batch.next() {
-        got.push(pair);
-    }
-    got
+    iter::from_fn(|| batch.next()).collect()
 }
 
 #[test]
 fn next_batch_yields_every_record_in_doc_id_order() {
     let mut src = source(&[(1, 3.0), (2, 1.0), (3, 2.0)]);
-    let batch = src.next_batch().unwrap().expect("a batch");
-    assert_eq!(drain(batch), vec![(1, 3.0), (2, 1.0), (3, 2.0)]);
+    let mut batch = src.next_batch().unwrap().expect("a batch");
+    assert_eq!(
+        iter::from_fn(|| batch.next()).collect_vec(),
+        vec![(1, 3.0), (2, 1.0), (3, 2.0)]
+    );
 }
 
 #[test]
@@ -55,8 +55,11 @@ fn source_emits_one_batch_then_rewinds() {
     assert!(src.next_batch().unwrap().is_none());
 
     src.rewind();
-    let batch = src.next_batch().unwrap().expect("a batch after rewind");
-    assert_eq!(drain(batch), vec![(1, 1.0), (2, 2.0)]);
+    let mut batch = src.next_batch().unwrap().expect("a batch after rewind");
+    assert_eq!(
+        iter::from_fn(|| batch.next()).collect_vec(),
+        vec![(1, 1.0), (2, 2.0)]
+    );
 }
 
 /// Drive an unfiltered top-k iterator to exhaustion, collecting the yielded

--- a/src/redisearch_rs/top_k/src/heap.rs
+++ b/src/redisearch_rs/top_k/src/heap.rs
@@ -37,7 +37,7 @@ pub struct ScoredResult {
 struct HeapEntry {
     result: ScoredResult,
     /// Cached comparison function so [`Ord`] can be implemented without extra state.
-    compare: fn(f64, f64) -> Ordering,
+    compare: fn(&f64, &f64) -> Ordering,
 }
 
 impl PartialEq for HeapEntry {
@@ -58,7 +58,7 @@ impl Ord for HeapEntry {
     fn cmp(&self, other: &Self) -> Ordering {
         // We want the worst element at the top of the heap so eviction is O(log k).
         // `compare(self, other) == Greater` means self is worse.
-        let score_ord = (self.compare)(self.result.score, other.result.score);
+        let score_ord = (self.compare)(&self.result.score, &other.result.score);
         match score_ord {
             Ordering::Less => Ordering::Less,
             Ordering::Greater => Ordering::Greater,
@@ -88,13 +88,13 @@ impl Ord for HeapEntry {
 pub struct TopKHeap {
     inner: BinaryHeap<HeapEntry>,
     capacity: usize,
-    compare: fn(f64, f64) -> Ordering,
+    compare: fn(&f64, &f64) -> Ordering,
 }
 
 impl TopKHeap {
     /// Creates a new heap that holds at most `capacity` elements,
     /// using the supplied `compare` function to determine score order.
-    pub fn new(capacity: NonZeroUsize, compare: fn(f64, f64) -> Ordering) -> Self {
+    pub fn new(capacity: NonZeroUsize, compare: fn(&f64, &f64) -> Ordering) -> Self {
         let capacity = capacity.into();
         Self {
             inner: BinaryHeap::with_capacity(capacity),
@@ -206,13 +206,13 @@ mod tests {
     }
 
     /// Ascending comparator: lower score is better (e.g. vector distance).
-    fn asc(a: f64, b: f64) -> Ordering {
-        a.partial_cmp(&b).unwrap_or(Ordering::Equal)
+    fn asc(a: &f64, b: &f64) -> Ordering {
+        a.total_cmp(b)
     }
 
     /// Descending comparator: higher score is better (e.g. numeric SORTBY).
-    fn desc(a: f64, b: f64) -> Ordering {
-        b.partial_cmp(&a).unwrap_or(Ordering::Equal)
+    fn desc(a: &f64, b: &f64) -> Ordering {
+        b.total_cmp(&a)
     }
 
     #[test]

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -217,7 +217,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             if let Some(child) = &mut self.child {
                 intersect_batch_with_child(child, &mut batch, &mut self.heap)?;
             } else {
-                // No filter child: every source record is a candidate, so feed
+                // No filter child: every source batch record is a candidate, so feed
                 // the whole batch through the heap, which retains the top k.
                 while let Some((doc_id, score)) = batch.next() {
                     self.heap.push(doc_id, score);

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -96,7 +96,7 @@ pub struct TopKIterator<
     /// Holds the in-progress batch for the Unfiltered path.
     direct_batch: Option<S::Batch>,
     k: NonZeroUsize,
-    compare: fn(f64, f64) -> Ordering,
+    compare: fn(&f64, &f64) -> Ordering,
     phase: Phase,
     /// Heap contents drained into score order for yielding.
     results: Vec<ScoredResult>,
@@ -111,7 +111,7 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
     ///
     /// Results are streamed directly from the source's batch — the heap is bypassed.
     /// Use [`new`](Self::new) when a filter child is present.
-    pub fn new_unfiltered(source: S, k: NonZeroUsize, compare: fn(f64, f64) -> Ordering) -> Self {
+    pub fn new_unfiltered(source: S, k: NonZeroUsize, compare: fn(&f64, &f64) -> Ordering) -> Self {
         Self::new_with_mode(source, None, k, compare, TopKMode::Unfiltered)
     }
 }
@@ -120,7 +120,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
     /// Create a new [`TopKIterator`] with a filter child.
     ///
     /// The initial mode defaults to [`TopKMode::Batches`].
-    pub fn new(source: S, child: C, k: NonZeroUsize, compare: fn(f64, f64) -> Ordering) -> Self {
+    pub fn new(source: S, child: C, k: NonZeroUsize, compare: fn(&f64, &f64) -> Ordering) -> Self {
         Self::new_with_mode(source, Some(child), k, compare, TopKMode::Batches)
     }
 
@@ -129,7 +129,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
         source: S,
         child: Option<C>,
         k: NonZeroUsize,
-        compare: fn(f64, f64) -> Ordering,
+        compare: fn(&f64, &f64) -> Ordering,
         mode: TopKMode,
     ) -> Self {
         Self {

--- a/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
+++ b/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
@@ -23,7 +23,7 @@ use top_k::{
     mock::MockScoreSource,
 };
 
-fn asc(a: f64, b: f64) -> Ordering {
+fn asc(a: &f64, b: &f64) -> Ordering {
     a.partial_cmp(&b).unwrap_or(Ordering::Equal)
 }
 

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -69,8 +69,8 @@ impl ScoreSource for TimingOutSource {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /// Ascending comparator: lower score is better (e.g. vector distance).
-fn asc(a: f64, b: f64) -> Ordering {
-    a.partial_cmp(&b).unwrap_or(Ordering::Equal)
+fn asc(a: &f64, b: &f64) -> Ordering {
+    a.total_cmp(&b)
 }
 
 fn make_child<'a>(ids: Vec<DocId>) -> Box<dyn RQEIterator<'a> + 'a> {

--- a/src/redisearch_rs/top_k/tests/integration/revalidation.rs
+++ b/src/redisearch_rs/top_k/tests/integration/revalidation.rs
@@ -18,8 +18,8 @@ use rqe_iterators::{RQEIterator, RQEValidateStatus};
 use top_k::{BatchStrategy, TopKIterator, mock::MockScoreSource};
 
 /// Ascending comparator: lower score is better (e.g. vector distance).
-fn asc(a: f64, b: f64) -> Ordering {
-    a.partial_cmp(&b).unwrap_or(Ordering::Equal)
+const fn asc() -> fn(a: &f64, b: &f64) -> Ordering {
+    f64::total_cmp
 }
 
 /// Child iterator whose `revalidate` unconditionally returns `Aborted`.
@@ -149,7 +149,7 @@ impl<'index> RQEIterator<'index> for MovedOnRevalidate<'index> {
 fn without_child_returns_ok() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
-    let mut it = TopKIterator::new_unfiltered(source, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new_unfiltered(source, NonZeroUsize::new(5).unwrap(), asc());
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, RQEValidateStatus::Ok);
 }
@@ -161,7 +161,7 @@ fn with_child_delegates_ok() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
     let child: Box<dyn RQEIterator<'_>> = Box::new(rqe_iterators::Empty::default());
-    let mut it = TopKIterator::new(source, child, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new(source, child, NonZeroUsize::new(5).unwrap(), asc());
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, RQEValidateStatus::Ok);
 }
@@ -171,7 +171,7 @@ fn with_child_delegates_aborted() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
     let child: Box<dyn RQEIterator<'_>> = Box::new(AbortOnRevalidate);
-    let mut it = TopKIterator::new(source, child, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new(source, child, NonZeroUsize::new(5).unwrap(), asc());
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, RQEValidateStatus::Aborted);
 }
@@ -183,7 +183,7 @@ fn moved_child_collapses_to_ok() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let source = MockScoreSource::new(vec![vec![(1, 1.0)]], vec![], |_, _| BatchStrategy::Continue);
     let child: Box<dyn RQEIterator<'_>> = Box::new(MovedOnRevalidate::new());
-    let mut it = TopKIterator::new(source, child, NonZeroUsize::new(5).unwrap(), asc);
+    let mut it = TopKIterator::new(source, child, NonZeroUsize::new(5).unwrap(), asc());
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, RQEValidateStatus::Ok);
 }

--- a/src/redisearch_rs/vector_score_source/src/lib.rs
+++ b/src/redisearch_rs/vector_score_source/src/lib.rs
@@ -49,8 +49,8 @@ pub type VectorTopKIterator<'index, E = FieldExpirationChecker> =
     TopKIterator<'index, VectorScoreSource<'index, E>>;
 
 /// Ascending comparator — lower distance score is better (vector L2/IP/Cosine).
-fn asc_cmp(a: f64, b: f64) -> Ordering {
-    a.partial_cmp(&b).unwrap_or(Ordering::Equal)
+const fn asc() -> fn(a: &f64, b: &f64) -> Ordering {
+    f64::total_cmp
 }
 
 /// Construct a pure KNN [`VectorTopKIterator`] (no filter child).
@@ -61,7 +61,7 @@ pub fn new_vector_top_k_unfiltered<'index, E: ExpirationChecker + 'index>(
     source: VectorScoreSource<'index, E>,
     k: NonZeroUsize,
 ) -> VectorTopKIterator<'index, E> {
-    TopKIterator::new_with_mode(source, None, k, asc_cmp, TopKMode::Unfiltered)
+    TopKIterator::new_with_mode(source, None, k, asc(), TopKMode::Unfiltered)
 }
 
 /// Construct a hybrid [`VectorTopKIterator`] with a filter child.
@@ -118,5 +118,5 @@ pub fn new_vector_top_k_filtered_boxed<'index, E: ExpirationChecker + 'index>(
             TopKMode::Batches
         }
     };
-    TopKIterator::new_with_mode(source, Some(child), k, asc_cmp, mode)
+    TopKIterator::new_with_mode(source, Some(child), k, asc(), mode)
 }

--- a/src/redisearch_rs/vector_score_source/src/test_utils.rs
+++ b/src/redisearch_rs/vector_score_source/src/test_utils.rs
@@ -26,8 +26,8 @@ use rqe_iterators::{ExpirationChecker, IdList, NoOpChecker, RQEIterator};
 use crate::VectorScoreSource;
 
 /// Ascending comparator: lower distance score is better.
-pub fn asc(a: f64, b: f64) -> Ordering {
-    a.partial_cmp(&b).unwrap_or(Ordering::Equal)
+pub const fn asc() -> fn(a: &f64, b: &f64) -> Ordering {
+    f64::total_cmp
 }
 
 /// Native-endian f32 byte blob of `values`, as VecSim expects.

--- a/src/redisearch_rs/vector_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source.rs
@@ -154,7 +154,7 @@ fn first_result_after_rewind_is_best() {
         source,
         Some(child),
         NonZeroUsize::new(k).unwrap(),
-        asc,
+        asc(),
         TopKMode::Batches,
     );
 
@@ -215,7 +215,7 @@ fn filtered_batches_partial_child_intersects() {
         source,
         Some(make_child(child_ids)),
         NonZeroUsize::new(k).unwrap(),
-        asc,
+        asc(),
         TopKMode::Batches,
     );
 
@@ -246,7 +246,7 @@ fn filtered_adhoc_matches_batches() {
         source,
         Some(child),
         NonZeroUsize::new(k).unwrap(),
-        asc,
+        asc(),
         TopKMode::AdhocBF,
     );
 
@@ -284,7 +284,7 @@ fn filtered_adhoc_drops_nan_distance_docs() {
         source,
         Some(make_child(child_ids)),
         NonZeroUsize::new(k).unwrap(),
-        asc,
+        asc(),
         TopKMode::AdhocBF,
     );
 
@@ -316,7 +316,7 @@ fn rewind_replays_same_results() {
         source,
         Some(child),
         NonZeroUsize::new(k).unwrap(),
-        asc,
+        asc(),
         TopKMode::Batches,
     );
 
@@ -350,7 +350,7 @@ fn disjoint_child_yields_nothing() {
         source,
         Some(child),
         NonZeroUsize::new(k).unwrap(),
-        asc,
+        asc(),
         TopKMode::Batches,
     );
 
@@ -405,7 +405,7 @@ fn filtered_batches_drops_expired_without_refill() {
         source,
         Some(child),
         NonZeroUsize::new(k).unwrap(),
-        asc,
+        asc(),
         TopKMode::ForcedBatches,
     );
 
@@ -436,7 +436,7 @@ fn filtered_adhoc_drops_expired_without_refill() {
         source,
         Some(child),
         NonZeroUsize::new(k).unwrap(),
-        asc,
+        asc(),
         TopKMode::AdhocBF,
     );
 

--- a/src/redisearch_rs/vector_score_source/tests/integration/source_pytest_parity.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source_pytest_parity.rs
@@ -193,7 +193,7 @@ fn batches_switch_to_adhoc_yields_no_duplicates() {
         source,
         Some(make_child(child_ids)),
         NonZeroUsize::new(k).unwrap(),
-        asc,
+        asc(),
         TopKMode::Batches,
     );
 
@@ -248,7 +248,7 @@ fn numeric_like_subset_batches_matches_adhoc() {
             source,
             Some(make_child(child_ids.clone())),
             NonZeroUsize::new(k).unwrap(),
-            asc,
+            asc(),
             mode,
         );
 

--- a/src/redisearch_rs/vector_score_source/tests/vecsim_timeout.rs
+++ b/src/redisearch_rs/vector_score_source/tests/vecsim_timeout.rs
@@ -131,7 +131,7 @@ fn batches_propagates_timeout() {
         source,
         Some(make_child((1..=n as DocId).collect())),
         NonZeroUsize::new(k).unwrap(),
-        asc,
+        asc(),
         TopKMode::Batches,
     );
 


### PR DESCRIPTION
Foundation work to have a minimal implementation of numeric source implementation.


Not implemented yet:
- TODO: Proper batching logic through numeric filter
  - Next: https://github.com/RediSearch/RediSearch/pull/10316
- TODO: MOD-14945 Timeout handling
- TODO: MOD-14946 Profile metrics
- TODO: MOD-14947 Parity tests
- TODO: MOD-14948 Performance validation



I'll look into making this PR less reliant on the whole top k stack

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
