### PR TITLE
[MOD-16023] ForkGC: Missing docs - child part

### DIFF
--- a/src/fork_gc/missing_docs.c
+++ b/src/fork_gc/missing_docs.c
@@ -12,33 +12,6 @@
 #include "rmutil/rm_assert.h"
 #include "obfuscation/hidden.h"
 
-void FGC_childCollectMissingDocs(ForkGC *gc, RedisSearchCtx *sctx) {
-  IndexSpec *spec = sctx->spec;
-
-  dictIterator* iter = dictGetIterator(spec->missingFieldDict);
-  dictEntry* entry = NULL;
-  while ((entry = dictNext(iter))) {
-    const HiddenString *hiddenFieldName = dictGetKey(entry);
-    InvertedIndex *idx = dictGetVal(entry);
-    if(idx) {
-      size_t length;
-      const char* fieldName = HiddenString_GetUnsafe(hiddenFieldName, &length);
-      struct iovec iov = {.iov_base = (void *)fieldName, length};
-
-      CTX_II_GC_Callback cbCtx = { .gc = gc, .hdrarg = &iov };
-      II_GCCallback cb = { .ctx = &cbCtx, .call = sendHeaderString };
-
-      II_GCWriter wr = { .ctx = gc, .write = pipe_write_cb };
-
-      InvertedIndex_GcDelta_Scan(&wr, sctx, idx, &cb);
-    }
-  }
-  dictReleaseIterator(iter);
-
-  // we are done with missing field docs inverted indexes
-  FGC_sendTerminator(gc);
-}
-
 FGCError FGC_parentHandleMissingDocs(ForkGC *gc) {
   FGCError status = FGC_COLLECTED;
   size_t fieldNameLen = 0;

--- a/src/fork_gc/pipe.h
+++ b/src/fork_gc/pipe.h
@@ -72,9 +72,6 @@ FGCError FGC_parentHandleNumeric(ForkGC *gc);
 void FGC_childCollectTags(ForkGC *gc, RedisSearchCtx *sctx);
 FGCError FGC_parentHandleTags(ForkGC *gc);
 
-void FGC_childCollectMissingDocs(ForkGC *gc, RedisSearchCtx *sctx);
 FGCError FGC_parentHandleMissingDocs(ForkGC *gc);
-
-FGCError FGC_parentHandleExistingDocs(ForkGC *gc);
 
 #endif /* FORK_GC_PIPE_H_ */

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -492,6 +492,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dict"
+version = "0.0.1"
+dependencies = [
+ "ffi",
+ "hidden_string",
+ "workspace_hack",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,9 +1061,11 @@ dependencies = [
 name = "index_spec"
 version = "0.0.1"
 dependencies = [
+ "dict",
  "document",
  "ffi",
  "field_spec",
+ "hidden_string",
  "inverted_index",
  "pretty_assertions",
  "redis_mock",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -718,13 +718,18 @@ dependencies = [
 name = "fork_gc"
 version = "0.0.1"
 dependencies = [
+ "build_utils",
+ "dict",
  "ffi",
+ "fork_gc",
  "index_result",
  "index_spec",
  "inverted_index",
  "libc",
  "nix",
  "redis-module",
+ "redis_mock",
+ "redisearch_rs",
  "rmp-serde",
  "rqe_core",
  "serde",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -497,6 +497,7 @@ version = "0.0.1"
 dependencies = [
  "ffi",
  "hidden_string",
+ "inverted_index",
  "workspace_hack",
 ]
 
@@ -722,6 +723,7 @@ dependencies = [
  "dict",
  "ffi",
  "fork_gc",
+ "hidden_string",
  "index_result",
  "index_spec",
  "inverted_index",
@@ -1070,7 +1072,6 @@ dependencies = [
  "document",
  "ffi",
  "field_spec",
- "hidden_string",
  "inverted_index",
  "pretty_assertions",
  "redis_mock",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -111,6 +111,7 @@ build_utils = { path = "./build_utils" }
 c_ffi_utils = { path = "./c_entrypoint/c_ffi_utils" }
 c_trie = { path = "./c_wrappers/c_trie" }
 document = { path = "./document" }
+dict = { path = "./c_wrappers/dict" }
 document_metadata = { path = "./c_wrappers/document_metadata" }
 ffi = { path = "./ffi", default-features = false }
 field = { path = "./field" }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/lib.rs
@@ -26,6 +26,7 @@ use tracing::Level;
 use tracing_log_error::log_error;
 
 mod existing_docs;
+mod missing_docs;
 mod util;
 
 /// Status code returned by Fork GC parent-side pipe-receive operations.

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
@@ -26,7 +26,8 @@ use index_spec::IndexSpecReadGuard;
 ///
 /// 1. `gc` must point to a valid [`ffi::ForkGC`].
 /// 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`].
-/// 3. `sctx.spec.missingFieldDict` must be a non-null, valid dict pointer.
+/// 3. `sctx.spec` must be a non-null pointer to a valid [`ffi::IndexSpec`].
+/// 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_childCollectMissingDocs(
     gc: *mut ffi::ForkGC,
@@ -34,15 +35,14 @@ pub unsafe extern "C" fn FGC_childCollectMissingDocs(
 ) {
     // SAFETY: caller guarantees (1).
     let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
-
-    // SAFETY: caller guarantees (2); sctx is a valid non-null pointer.
+    // SAFETY: caller guarantees (2).
     let spec_ptr = unsafe { (*sctx).spec };
-    // SAFETY: caller guarantees (2); sctx.spec is a valid non-null IndexSpec.
+    // SAFETY: caller guarantees (3).
     let spec = unsafe { &*spec_ptr };
 
-    // SAFETY: We don't actually hold a read lock, but when the Fork GC code runs it holds the Redis GIL
-    // (so no other thread would be touching any shared Redis state), then forks and the child has
-    // only one thread with exclusive access to the index spec.
+    // SAFETY: caller guarantees (4). We don't actually hold a read lock, but when the Fork GC code
+    // runs it holds the Redis GIL (so no other thread would be touching any shared Redis state),
+    // then forks and the child has only one thread with exclusive access to the index spec.
     let guard = unsafe { IndexSpecReadGuard::from_locked(spec) };
 
     collect_missing_docs(&mut fgc.writer(), &guard).unwrap_or_exit();

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
@@ -15,15 +15,18 @@ use index_spec::IndexSpecReadGuard;
 ///
 /// Iterates the `missingFieldDict`, and for each entry with a non-null
 /// `InvertedIndex` calls `scan_gc` which sends the field name header
-/// followed by the serialised GC delta.  Sends a terminator once all
+/// followed by the serialised GC delta. Sends a terminator once all
 /// entries are processed.
+///
+/// # Panic
+///
+/// Panics if `pipe_write_fd` on `gc` is an invalid or closed writable file descriptor.
 ///
 /// # Safety
 ///
-/// 1. `gc` must point to a valid [`ffi::ForkGC`] whose `pipe_write_fd` is an open,
-///    writable file descriptor.
-/// 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`] whose `spec` field is
-///    a non-null `IndexSpec` with a populated `missingFieldDict`.
+/// 1. `gc` must point to a valid [`ffi::ForkGC`].
+/// 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`].
+/// 3. `sctx.spec.missingFieldDict` must be a non-null, valid dict pointer.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_childCollectMissingDocs(
     gc: *mut ffi::ForkGC,

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use fork_gc::{ForkGC, io_result_ext::IoResultExt, missing_docs::collect_missing_docs};
+use index_spec::IndexSpecReadGuard;
+
+/// Collect GC delta data for every entry in the spec's `missingFieldDict` and
+/// send it to the parent process over the pipe.
+///
+/// Iterates the `missingFieldDict`, and for each entry with a non-null
+/// `InvertedIndex` calls `scan_gc` which sends the field name header
+/// followed by the serialised GC delta.  Sends a terminator once all
+/// entries are processed.
+///
+/// # Safety
+///
+/// 1. `gc` must point to a valid [`ffi::ForkGC`] whose `pipe_write_fd` is an open,
+///    writable file descriptor.
+/// 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`] whose `spec` field is
+///    a non-null `IndexSpec` with a populated `missingFieldDict`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn FGC_childCollectMissingDocs(
+    gc: *mut ffi::ForkGC,
+    sctx: *mut ffi::RedisSearchCtx,
+) {
+    // SAFETY: caller guarantees (1).
+    let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
+
+    // SAFETY: caller guarantees (2); sctx is a valid non-null pointer.
+    let spec_ptr = unsafe { (*sctx).spec };
+    // SAFETY: caller guarantees (2); sctx.spec is a valid non-null IndexSpec.
+    let spec = unsafe { &*spec_ptr };
+
+    // SAFETY: We don't actually hold a read lock, but when the Fork GC code runs it holds the Redis GIL
+    // (so no other thread would be touching any shared Redis state), then forks and the child has
+    // only one thread with exclusive access to the index spec.
+    let guard = unsafe { IndexSpecReadGuard::from_locked(spec) };
+
+    collect_missing_docs(&mut fgc.writer(), &guard).unwrap_or_exit();
+}

--- a/src/redisearch_rs/c_wrappers/dict/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/dict/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "dict"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+ffi.workspace = true
+hidden_string.workspace = true
+workspace_hack.workspace = true

--- a/src/redisearch_rs/c_wrappers/dict/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/dict/Cargo.toml
@@ -11,4 +11,5 @@ workspace = true
 [dependencies]
 ffi.workspace = true
 hidden_string.workspace = true
+inverted_index.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/c_wrappers/dict/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/dict/src/lib.rs
@@ -15,6 +15,7 @@ use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 
 use hidden_string::HiddenStringRef;
+use inverted_index::opaque::InvertedIndex;
 
 /// Bidirectional conversion between a Rust type and the raw `*mut c_void`
 /// pointer stored in a dict entry.
@@ -50,14 +51,22 @@ pub unsafe trait DictValue<'a>: Sized + Copy + 'a {
 // SAFETY: pointer casts are always layout-compatible; the caller is responsible
 // for ensuring the pointer actually addresses a T.
 unsafe impl<'a, T: 'a> DictValue<'a> for *mut T {
-    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self { ptr.cast() }
-    fn into_dict_ptr(self) -> *mut c_void { self.cast() }
+    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self {
+        ptr.cast()
+    }
+    fn into_dict_ptr(self) -> *mut c_void {
+        self.cast()
+    }
 }
 
 // SAFETY: same as *mut T; const-ness is a Rust concept, not a C one.
 unsafe impl<'a, T: 'a> DictValue<'a> for *const T {
-    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self { ptr.cast() }
-    fn into_dict_ptr(self) -> *mut c_void { self.cast_mut().cast() }
+    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self {
+        ptr.cast()
+    }
+    fn into_dict_ptr(self) -> *mut c_void {
+        self.cast_mut().cast()
+    }
 }
 
 // SAFETY: The dict stores *mut HiddenString pointers as *mut c_void.
@@ -68,7 +77,9 @@ unsafe impl<'a> DictValue<'a> for HiddenStringRef<'a> {
         // SAFETY: caller guarantees ptr is a valid *mut HiddenString for 'a.
         unsafe { HiddenStringRef::from_raw(ptr.cast::<ffi::HiddenString>()) }
     }
-    fn into_dict_ptr(self) -> *mut c_void { self.as_ptr().cast() }
+    fn into_dict_ptr(self) -> *mut c_void {
+        self.as_ptr().cast()
+    }
 }
 
 // SAFETY: null pointer → None (absence of a value); non-null *mut c_void →
@@ -76,7 +87,11 @@ unsafe impl<'a> DictValue<'a> for HiddenStringRef<'a> {
 unsafe impl<'a, T: 'a> DictValue<'a> for Option<&'a T> {
     unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self {
         // SAFETY: caller guarantees non-null ptr is a valid *const T for 'a.
-        if ptr.is_null() { None } else { Some(unsafe { &*ptr.cast::<T>() }) }
+        if ptr.is_null() {
+            None
+        } else {
+            Some(unsafe { &*ptr.cast::<T>() })
+        }
     }
     fn into_dict_ptr(self) -> *mut c_void {
         match self {
@@ -86,42 +101,75 @@ unsafe impl<'a, T: 'a> DictValue<'a> for Option<&'a T> {
     }
 }
 
+/// Describes the key type, value type, and underlying C [`ffi::dictType`] for
+/// a particular dict configuration.
+///
+/// Implemented by marker types (e.g. `MissingFieldDictType`) that bind a
+/// specific `ffi::dictType` to typed `K` and `V` parameters. This allows
+/// [`OwnedDict<DT>`] to call [`create`](OwnedDict::create) without a caller-
+/// supplied `dictType` pointer, and ensures that the dict's hash/compare/dup/
+/// destructor callbacks are always consistent with the key and value types.
+///
+/// # Safety
+///
+/// Implementors must ensure that [`as_ptr`](Self::as_ptr) returns a pointer to
+/// a valid, live `ffi::dictType` whose callbacks are consistent with `K` and
+/// `V`: e.g. if `K::into_dict_ptr` returns a pointer to a temporary, the
+/// dictType's `keyDup` must copy it before the caller is allowed to free the
+/// original.
+pub unsafe trait DictType {
+    type K<'a>: DictValue<'a>;
+    type V<'a>: DictValue<'a>;
+
+    /// Return a pointer to the static C `dictType` for this configuration.
+    fn as_ptr() -> *mut ffi::dictType;
+}
+
+/// [`DictType`] marker for the spec's `missingFieldDict`.
+///
+/// Keys are [`HiddenStringRef`] (field names); values are
+/// `Option<&InvertedIndex>` (the per-field missing-doc inverted index, or
+/// `None` when the field has no such index). The underlying C dictType is
+/// `dictTypeHeapHiddenStrings`, which copies keys on insertion via `keyDup`
+/// and does not free values on removal.
+pub struct MissingFieldDictType;
+
+// SAFETY: dictTypeHeapHiddenStrings is a valid static ffi::dictType whose
+// callbacks are compatible with HiddenStringRef keys and Option<&InvertedIndex>
+// values: keyDup copies the HiddenString so callers may free the original after
+// insert; valDestructor is null so callers retain ownership of InvertedIndex.
+unsafe impl DictType for MissingFieldDictType {
+    type K<'a> = HiddenStringRef<'a>;
+    type V<'a> = Option<&'a InvertedIndex>;
+
+    fn as_ptr() -> *mut ffi::dictType {
+        unsafe { std::ptr::addr_of_mut!(ffi::dictTypeHeapHiddenStrings) }
+    }
+}
 
 /// A safe wrapper around a C [`ffi::dict`].
 ///
-/// `K` and `V` are the types returned by [`DictEntry::key`] and
-/// [`DictEntry::val`]; both default to `*mut c_void` for untyped access.
-/// Specifying concrete types eliminates manual casts at call sites and — for
-/// wrapper types such as [`HiddenStringRef`] — the manual construction call:
+/// `DT` is a [`DictType`] marker that fixes the key type ([`DictType::K`]),
+/// value type ([`DictType::V`]), and the underlying C `dictType` callbacks.
 ///
-/// ```text
-/// // typed key, untyped value
-/// let d: &Dict<HiddenStringRef<'_>, *mut c_void> = spec.missing_field_dict();
-/// for entry in d.iter() {
-///     let name: HiddenStringRef<'_> = entry.key(); // no cast, no from_raw
-///     let idx:  *mut c_void         = entry.val();
-/// }
-/// ```
-///
-/// Obtained from a raw `*const`/`*mut ffi::dict` via [`Dict::from_raw`] or
-/// [`Dict::from_raw_mut`].
+/// Obtained from a raw `*const`/`*mut ffi::dict` via [`Dict::from_raw`] /
+/// [`Dict::from_raw_mut`]. For an owned dict that is released on drop, use
+/// [`OwnedDict`].
 #[repr(transparent)]
-pub struct Dict<K = *mut c_void, V = *mut c_void> {
+pub struct Dict<DT: DictType> {
     inner: ffi::dict,
-    _phantom: PhantomData<(K, V)>,
+    _phantom: PhantomData<DT>,
 }
 
-impl<K, V> Dict<K, V> {
+impl<DT: DictType> Dict<DT> {
     /// Borrow a [`Dict`] from a raw const pointer.
     ///
     /// # Safety
     ///
-    /// `ptr` must be a valid, non-null pointer to an `ffi::dict` that is
-    /// properly initialised and remains live for the returned lifetime `'a`.
-    /// The caller must also ensure that the dict's keys and values are
-    /// actually of types `K` and `V`.
+    /// `ptr` must be a valid, non-null pointer to an `ffi::dict` created with
+    /// the `ffi::dictType` described by `DT`, and must remain live for `'a`.
     pub const unsafe fn from_raw<'a>(ptr: *const ffi::dict) -> &'a Self {
-        // SAFETY: #[repr(transparent)] guarantees identical layout for any K, V.
+        // SAFETY: #[repr(transparent)] guarantees identical layout.
         // Validity and liveness are the caller's responsibility.
         unsafe { ptr.cast::<Self>().as_ref().unwrap() }
     }
@@ -130,13 +178,11 @@ impl<K, V> Dict<K, V> {
     ///
     /// # Safety
     ///
-    /// `ptr` must be a valid, non-null pointer to an `ffi::dict` that is
-    /// properly initialised and remains live for the returned lifetime `'a`,
-    /// with no other aliasing references for the duration.  The caller must
-    /// also ensure that the dict's keys and values are actually of types `K`
-    /// and `V`.
+    /// `ptr` must be a valid, non-null pointer to an `ffi::dict` created with
+    /// the `ffi::dictType` described by `DT`, must remain live for `'a`, and
+    /// must have no other aliasing references for the duration.
     pub const unsafe fn from_raw_mut<'a>(ptr: *mut ffi::dict) -> &'a mut Self {
-        // SAFETY: #[repr(transparent)] guarantees identical layout for any K, V.
+        // SAFETY: #[repr(transparent)] guarantees identical layout.
         // Validity, liveness, and exclusivity are the caller's responsibility.
         unsafe { ptr.cast::<Self>().as_mut().unwrap() }
     }
@@ -155,11 +201,7 @@ impl<K, V> Dict<K, V> {
     ///
     /// Returns `true` when the entry was added, `false` when the key already
     /// existed (the existing entry is not updated).
-    pub fn insert<'b>(&mut self, key: K, val: V) -> bool
-    where
-        K: DictValue<'b>,
-        V: DictValue<'b>,
-    {
+    pub fn insert<'b>(&mut self, key: DT::K<'b>, val: DT::V<'b>) -> bool {
         // SAFETY: self points to a valid dict; key and val lifetimes are managed
         // by the dictType's dup/destructor callbacks.
         unsafe { ffi::RS_dictAdd(self.as_mut_ptr(), key.into_dict_ptr(), val.into_dict_ptr()) == 0 }
@@ -173,11 +215,7 @@ impl<K, V> Dict<K, V> {
     ///
     /// The iterator holds a C-side iterator object and releases it on drop,
     /// so it is safe to abandon iteration early.
-    pub fn iter<'a>(&'a self) -> DictIterator<'a, K, V>
-    where
-        K: DictValue<'a>,
-        V: DictValue<'a>,
-    {
+    pub fn iter(&self) -> DictIterator<'_, DT> {
         // SAFETY: `self.inner` is a valid dict (invariant upheld by construction).
         // RS_dictGetIterator does not modify the dict; the cast from *const to
         // *mut is sound because the C function only reads the dict to initialise
@@ -188,33 +226,24 @@ impl<K, V> Dict<K, V> {
 
 /// An owned [`Dict`] that calls `RS_dictRelease` on drop.
 ///
-/// Obtained via [`OwnedDict::create`]. Derefs to [`Dict<K, V>`] so all
+/// Obtained via [`OwnedDict::create`]. Derefs to [`Dict<DT>`] so all
 /// [`Dict`] methods — including [`iter`](Dict::iter) and
 /// [`insert`](Dict::insert) — are available on `&OwnedDict` and
 /// `&mut OwnedDict` respectively.
-///
-/// The `valDestructor` of the supplied [`ffi::dictType`] determines whether
-/// values are freed on drop; callers that need to free values themselves must
-/// use a type with a null `valDestructor`.
-pub struct OwnedDict<K = *mut c_void, V = *mut c_void> {
+pub struct OwnedDict<DT: DictType> {
     ptr: NonNull<ffi::dict>,
-    _phantom: PhantomData<(K, V)>,
+    _phantom: PhantomData<DT>,
 }
 
-impl<K, V> OwnedDict<K, V> {
-    /// Allocate a new C dict with the given type descriptor.
+impl<DT: DictType> OwnedDict<DT> {
+    /// Allocate a new C dict for the configuration described by `DT`.
     ///
-    /// # Safety
-    ///
-    /// `dict_type` must point to a valid, live [`ffi::dictType`] that remains
-    /// live for the lifetime of the returned dict. The dictType's callbacks
-    /// (hash, compare, dup, destructor) must be consistent with how `K` and
-    /// `V` values will be inserted and read back: e.g. if `K::into_dict_ptr`
-    /// returns a pointer to a temporary, the dictType's `keyDup` must copy it.
-    pub unsafe fn create(dict_type: *mut ffi::dictType) -> Self {
-        // SAFETY: dict_type is valid per the caller's contract; null privdata
-        // is always accepted by RS_dictCreate.
-        let ptr = unsafe { ffi::RS_dictCreate(dict_type, std::ptr::null_mut()) };
+    /// The dictType pointer and the guarantee that its callbacks are compatible
+    /// with `DT::K` and `DT::V` are encoded in the `unsafe impl DictType`.
+    pub fn create() -> Self {
+        // SAFETY: DT::as_ptr() is guaranteed by the unsafe DictType impl to
+        // return a valid, compatible ffi::dictType*.
+        let ptr = unsafe { ffi::RS_dictCreate(DT::as_ptr(), std::ptr::null_mut()) };
         Self {
             ptr: NonNull::new(ptr).expect("RS_dictCreate returned null"),
             _phantom: PhantomData,
@@ -227,25 +256,25 @@ impl<K, V> OwnedDict<K, V> {
     }
 }
 
-impl<K, V> Deref for OwnedDict<K, V> {
-    type Target = Dict<K, V>;
+impl<DT: DictType> Deref for OwnedDict<DT> {
+    type Target = Dict<DT>;
 
-    fn deref(&self) -> &Dict<K, V> {
+    fn deref(&self) -> &Dict<DT> {
         // SAFETY: self.ptr is a valid, non-null dict alive for the lifetime of
         // this OwnedDict.
         unsafe { Dict::from_raw(self.ptr.as_ptr()) }
     }
 }
 
-impl<K, V> DerefMut for OwnedDict<K, V> {
-    fn deref_mut(&mut self) -> &mut Dict<K, V> {
+impl<DT: DictType> DerefMut for OwnedDict<DT> {
+    fn deref_mut(&mut self) -> &mut Dict<DT> {
         // SAFETY: self.ptr is a valid, non-null dict alive for the lifetime of
         // this OwnedDict, and we hold exclusive access via &mut self.
         unsafe { Dict::from_raw_mut(self.ptr.as_ptr()) }
     }
 }
 
-impl<K, V> Drop for OwnedDict<K, V> {
+impl<DT: DictType> Drop for OwnedDict<DT> {
     fn drop(&mut self) {
         // SAFETY: self.ptr was obtained from RS_dictCreate and has not been
         // released yet.
@@ -255,42 +284,33 @@ impl<K, V> Drop for OwnedDict<K, V> {
 
 /// A single entry in a [`Dict`], yielded by [`DictIterator`].
 ///
-/// `'a` is the lifetime of the underlying dict data; `K` and `V` are the
-/// types returned by [`key`](Self::key) and [`val`](Self::val).
-pub struct DictEntry<'a, K = *mut c_void, V = *mut c_void> {
+/// `'a` is the lifetime of the underlying dict data.
+pub struct DictEntry<'a, DT: DictType> {
     entry: *mut ffi::dictEntry,
-    _phantom: PhantomData<(&'a (), K, V)>,
+    _phantom: PhantomData<(&'a (), DT)>,
 }
 
-impl<'a, K, V> DictEntry<'a, K, V> {
+impl<'a, DT: DictType> DictEntry<'a, DT> {
     const fn new(entry: *mut ffi::dictEntry) -> Self {
-        Self { entry, _phantom: PhantomData }
+        Self {
+            entry,
+            _phantom: PhantomData,
+        }
     }
-}
 
-impl<'a, K: DictValue<'a>, V: DictValue<'a>> DictEntry<'a, K, V> {
     /// Return the key of this entry.
-    ///
-    /// Corresponds to the C macro `dictGetKey(entry)` (`entry->key`),
-    /// converted to `K` via [`DictValue`].
-    pub fn key(&self) -> K {
-        // SAFETY: self.entry is a valid non-null dictEntry* (invariant of DictEntry).
+    pub fn key(&self) -> DT::K<'a> {
+        // SAFETY: self.entry is a valid non-null dictEntry*.
         let ptr = unsafe { (*self.entry).key };
-        // SAFETY: the caller selected K to match the actual key type stored in this dict.
-        unsafe { K::from_dict_ptr(ptr) }
+        unsafe { <DT::K<'a> as DictValue<'a>>::from_dict_ptr(ptr) }
     }
 
     /// Return the value of this entry.
-    ///
-    /// Corresponds to the C macro `dictGetVal(entry)` (`entry->v.val`),
-    /// converted to `V` via [`DictValue`].
-    pub fn val(&self) -> V {
+    pub fn val(&self) -> DT::V<'a> {
         // SAFETY: self.entry is a valid non-null dictEntry*.
         let v = unsafe { &(*self.entry).v };
-        // SAFETY: the dict value union variant is a pointer-sized void pointer.
         let ptr = unsafe { v.val };
-        // SAFETY: the caller selected V to match the actual value type stored in this dict.
-        unsafe { V::from_dict_ptr(ptr) }
+        unsafe { <DT::V<'a> as DictValue<'a>>::from_dict_ptr(ptr) }
     }
 }
 
@@ -300,39 +320,45 @@ impl<'a, K: DictValue<'a>, V: DictValue<'a>> DictEntry<'a, K, V> {
 /// [`ffi::RS_dictGetIterator`] / [`ffi::RS_dictNext`] /
 /// [`ffi::RS_dictReleaseIterator`] and releases the underlying C iterator on
 /// drop.
-pub struct DictIterator<'a, K = *mut c_void, V = *mut c_void> {
+pub struct DictIterator<'a, DT: DictType> {
     iter: *mut ffi::dictIterator,
-    _phantom: PhantomData<(&'a (), K, V)>,
+    _phantom: PhantomData<(&'a (), DT)>,
 }
 
-impl<'a, K, V> DictIterator<'a, K, V> {
+impl<'a, DT: DictType> DictIterator<'a, DT> {
     /// Create an iterator directly from a raw `dict*`.
     ///
     /// Prefer [`Dict::iter`] when a [`Dict`] reference is available.
     ///
     /// # Safety
     ///
-    /// `dict` must be a valid, non-null `dict*` whose keys and values are
-    /// of types `K` and `V`, and that remains live for `'a`.
+    /// `dict` must be a valid, non-null `dict*` consistent with the key and
+    /// value types of `DT`, and must remain live for `'a`.
     pub unsafe fn new(dict: *mut ffi::dict) -> Self {
         // SAFETY: caller guarantees dict is valid and non-null.
         let iter = unsafe { ffi::RS_dictGetIterator(dict) };
-        Self { iter, _phantom: PhantomData }
+        Self {
+            iter,
+            _phantom: PhantomData,
+        }
     }
 }
 
-impl<'a, K: DictValue<'a>, V: DictValue<'a>> Iterator for DictIterator<'a, K, V> {
-    type Item = DictEntry<'a, K, V>;
+impl<'a, DT: DictType> Iterator for DictIterator<'a, DT> {
+    type Item = DictEntry<'a, DT>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // SAFETY: self.iter is a valid iterator obtained during construction
-        // and not yet released.
+        // SAFETY: self.iter is a valid iterator obtained during construction.
         let entry = unsafe { ffi::RS_dictNext(self.iter) };
-        if entry.is_null() { None } else { Some(DictEntry::new(entry)) }
+        if entry.is_null() {
+            None
+        } else {
+            Some(DictEntry::new(entry))
+        }
     }
 }
 
-impl<K, V> Drop for DictIterator<'_, K, V> {
+impl<DT: DictType> Drop for DictIterator<'_, DT> {
     fn drop(&mut self) {
         // SAFETY: self.iter is a valid iterator obtained during construction.
         unsafe { ffi::RS_dictReleaseIterator(self.iter) };

--- a/src/redisearch_rs/c_wrappers/dict/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/dict/src/lib.rs
@@ -18,20 +18,42 @@ use hidden_string::HiddenStringRef;
 use inverted_index::opaque::InvertedIndex;
 
 /// Describes a `Dict` type defined by a `ffi::dictType` with conversion
-/// functions to and from keys and values.
+/// functions for keys and values.
+///
+/// Two separate value types model the ownership split between insertion and
+/// iteration:
+///
+/// - [`InsertV`](Self::InsertV) — what the caller passes on insertion. Must
+///   match the ownership contract of the dict's `valDestructor`: for owning
+///   dicts (e.g. `InvIndFreeCb`) this should be an owned type such as
+///   `Box<V>`; for non-owning dicts it can be a raw pointer or reference.
+/// - [`IterV`](Self::IterV) — what is yielded during iteration. Always a
+///   borrow from the dict for the dict-borrow lifetime `'a`.
 ///
 /// # Safety
 ///
 /// Implementers must ensure that:
-/// - [`as_ptr`](Self::as_ptr) returns a pointer to a valid, live `ffi::dictType`
-///   whose callbacks are consistent with `K` and `V`.
-/// - [`key_from_ptr`](Self::key_from_ptr) and [`val_from_ptr`](Self::val_from_ptr)
-///   correctly reconstruct the key/value from the raw pointer stored by the dict.
-/// - [`key_into_ptr`](Self::key_into_ptr) and [`val_into_ptr`](Self::val_into_ptr)
-///   produce pointers that are handled correctly by the `dictType`.
+/// - [`as_ptr`](Self::as_ptr) returns a pointer to a valid, live
+///   `ffi::dictType` whose callbacks are consistent with `K`, `InsertV`, and
+///   `IterV`.
+/// - [`key_from_ptr`](Self::key_from_ptr) correctly reconstructs a key from
+///   the raw pointer stored by the dict.
+/// - [`key_into_ptr`](Self::key_into_ptr) produces a pointer the `dictType`
+///   can manage (e.g. copy via `keyDup`).
+/// - [`insert_val_into_ptr`](Self::insert_val_into_ptr) converts the owned
+///   insert value to the raw pointer stored by the dict. Ownership semantics
+///   must match the `valDestructor` in the `dictType`.
+/// - [`iter_val_from_ptr`](Self::iter_val_from_ptr) correctly borrows the
+///   value stored at `ptr` for lifetime `'a`.
 pub unsafe trait DictType {
-    type K<'a>: Sized + Copy + 'a;
-    type V<'a>: Sized + Copy + 'a;
+    type K<'a>;
+    /// Owned value type for insertion. When `valDestructor` is set, this
+    /// should be an owned type (e.g. `Box<V>`) whose memory the dict will
+    /// free on removal.
+    type InsertV;
+    /// Borrowed value type yielded during iteration. `'a` is the dict-borrow
+    /// lifetime.
+    type IterV<'a>;
 
     /// Return a pointer to the static C `dictType` for this configuration.
     fn as_ptr() -> *mut ffi::dictType;
@@ -46,33 +68,39 @@ pub unsafe trait DictType {
     /// Convert a key to the raw pointer to be passed to the dict.
     fn key_into_ptr<'a>(key: Self::K<'a>) -> *mut c_void;
 
-    /// Reconstruct a value from the raw pointer stored in a dict entry.
+    /// Convert an owned insert value to the raw pointer stored by the dict.
+    ///
+    /// For owning dicts this must consume or leak the value so the
+    /// `valDestructor` can free it later.
+    fn insert_val_into_ptr(val: Self::InsertV) -> *mut c_void;
+
+    /// Reconstruct a borrowed value from the raw pointer stored in a dict entry.
     ///
     /// # Safety
     ///
-    /// `ptr` must be a valid pointer consistent with `V`, valid for `'a`.
-    unsafe fn val_from_ptr<'a>(ptr: *mut c_void) -> Self::V<'a>;
-
-    /// Convert a value to the raw pointer to be passed to the dict.
-    fn val_into_ptr<'a>(val: Self::V<'a>) -> *mut c_void;
+    /// `ptr` must be a valid pointer to a value consistent with `IterV`, valid
+    /// for `'a`.
+    unsafe fn iter_val_from_ptr<'a>(ptr: *mut c_void) -> Self::IterV<'a>;
 }
 
 /// [`DictType`] marker for the spec's `missingFieldDict`.
 pub struct MissingFieldDictType;
 
 // SAFETY:
-// - dictTypeHeapHiddenStrings is a valid static ffi::dictType whose callbacks
-//   are compatible with HiddenStringRef keys and Option<&InvertedIndex> values.
+// - missingFieldDictType is a valid static ffi::dictType whose callbacks are
+//   compatible with HiddenStringRef keys and Box<InvertedIndex> values.
 // - keyDup copies the HiddenString so callers may free the original after insert.
-// - valDestructor is null so callers retain ownership of InvertedIndex.
-// - The key/value conversions round-trip through *mut HiddenString and
-//   *mut InvertedIndex respectively, consistent with how the C dict stores them.
+// - valDestructor is InvIndFreeCb → InvertedIndex_Free, which calls
+//   drop(Box::from_raw(ptr)); insert_val_into_ptr calls Box::into_raw,
+//   transferring ownership to the dict.
+// - iter_val_from_ptr borrows the stored pointer as Option<&InvertedIndex>.
 unsafe impl DictType for MissingFieldDictType {
     type K<'a> = HiddenStringRef<'a>;
-    type V<'a> = Option<&'a InvertedIndex>;
+    type InsertV = Box<InvertedIndex>;
+    type IterV<'a> = Option<&'a InvertedIndex>;
 
     fn as_ptr() -> *mut ffi::dictType {
-        std::ptr::addr_of_mut!(ffi::dictTypeHeapHiddenStrings)
+        std::ptr::addr_of_mut!(ffi::missingFieldDictType)
     }
 
     unsafe fn key_from_ptr<'a>(ptr: *mut c_void) -> Self::K<'a> {
@@ -84,48 +112,39 @@ unsafe impl DictType for MissingFieldDictType {
         key.as_ptr().cast()
     }
 
-    unsafe fn val_from_ptr<'a>(ptr: *mut c_void) -> Self::V<'a> {
-        // SAFETY: caller guarantees non-null ptr is a valid *mut InvertedIndex
-        // for 'a; null represents None (no missing-doc index for this field).
-        NonNull::new(ptr.cast::<InvertedIndex>()).map(|p| unsafe { p.as_ref() })
+    fn insert_val_into_ptr(val: Self::InsertV) -> *mut c_void {
+        Box::into_raw(val).cast()
     }
 
-    fn val_into_ptr<'a>(val: Self::V<'a>) -> *mut c_void {
-        match val {
-            None => std::ptr::null_mut(),
-            Some(r) => std::ptr::from_ref(r).cast_mut().cast(),
-        }
+    unsafe fn iter_val_from_ptr<'a>(ptr: *mut c_void) -> Self::IterV<'a> {
+        // SAFETY: caller guarantees non-null ptr is a valid *mut InvertedIndex
+        // for 'a; null represents None.
+        NonNull::new(ptr.cast::<InvertedIndex>()).map(|p| unsafe { p.as_ref() })
     }
 }
 
 /// A safe wrapper around a C [`ffi::dict`].
 ///
 /// `DT` is a [`DictType`] marker that fixes the key type ([`DictType::K`]),
-/// value type ([`DictType::V`]), pointer conversions, and the underlying C
-/// `dictType` callbacks.
-///
-/// `'val` is the minimum lifetime of values stored in this dict. All values
-/// passed to [`Dict::insert`] must be valid for at least `'val`, which the
-/// compiler enforces. This prevents dangling references when values are read
-/// back via [`Dict::iter`].
+/// insert value type ([`DictType::InsertV`]), iteration value type
+/// ([`DictType::IterV`]), and the underlying C `dictType` callbacks.
 ///
 /// Obtained from a raw `*const`/`*mut ffi::dict` via [`Dict::from_raw`] /
 /// [`Dict::from_raw_mut`]. For an owned dict that is released on drop, use
 /// [`OwnedDict`].
 #[repr(transparent)]
-pub struct Dict<'val, DT: DictType> {
+pub struct Dict<DT: DictType> {
     inner: ffi::dict,
-    _phantom: PhantomData<(DT, DT::V<'val>)>,
+    _phantom: PhantomData<DT>,
 }
 
-impl<'val, DT: DictType> Dict<'val, DT> {
+impl<DT: DictType> Dict<DT> {
     /// Borrow a [`Dict`] from a raw const pointer.
     ///
     /// # Safety
     ///
     /// `ptr` must be a valid, non-null pointer to an `ffi::dict` created with
     /// the `ffi::dictType` described by `DT`, and must remain live for `'a`.
-    /// `'val` must not outlive the lifetimes of any values stored in the dict.
     pub const unsafe fn from_raw<'a>(ptr: *const ffi::dict) -> &'a Self {
         // SAFETY: #[repr(transparent)] guarantees identical layout.
         // Validity and liveness are the caller's responsibility.
@@ -137,9 +156,8 @@ impl<'val, DT: DictType> Dict<'val, DT> {
     /// # Safety
     ///
     /// `ptr` must be a valid, non-null pointer to an `ffi::dict` created with
-    /// the `ffi::dictType` described by `DT`, must remain live for `'a`, must
-    /// have no other aliasing references for the duration, and `'val` must not
-    /// outlive the lifetimes of any values stored in the dict.
+    /// the `ffi::dictType` described by `DT`, must remain live for `'a`, and
+    /// must have no other aliasing references for the duration.
     pub const unsafe fn from_raw_mut<'a>(ptr: *mut ffi::dict) -> &'a mut Self {
         // SAFETY: #[repr(transparent)] guarantees identical layout.
         // Validity, liveness, and exclusivity are the caller's responsibility.
@@ -156,31 +174,32 @@ impl<'val, DT: DictType> Dict<'val, DT> {
         &raw mut self.inner
     }
 
-    /// Insert a typed key–value pair into this dict.
+    /// Insert a key–value pair into this dict.
     ///
     /// Returns `true` when the entry was added, `false` when the key already
     /// existed (the existing entry is not updated).
     ///
     /// The key lifetime is unconstrained because the underlying `dictType` is
     /// required (by the [`DictType`] safety contract) to copy keys on insertion.
-    /// The value must be valid for `'val` — the dict's value lifetime — so that
-    /// values read back via [`Dict::iter`] are never dangling.
-    pub fn insert(&mut self, key: DT::K<'_>, val: DT::V<'val>) -> bool {
+    ///
+    /// `val` is `DT::InsertV`: for owning dicts this is an owned type (e.g.
+    /// `Box<V>`) whose memory the dict takes responsibility for freeing.
+    pub fn insert(&mut self, key: DT::K<'_>, val: DT::InsertV) -> bool {
         // SAFETY: self points to a valid dict; key is copied by the dictType's
-        // keyDup; val lifetime is enforced to be 'val by the type signature.
+        // keyDup; insert_val_into_ptr transfers ownership of val to the dict.
         unsafe {
             ffi::RS_dictAdd(
                 self.as_mut_ptr(),
                 DT::key_into_ptr(key),
-                DT::val_into_ptr(val),
+                DT::insert_val_into_ptr(val),
             ) == 0
         }
     }
 
     /// Iterate over all entries in this dict.
     ///
-    /// Each entry is yielded as a [`DictEntry`] whose [`DictEntry::key`] and
-    /// [`DictEntry::val`] return the typed key and value directly.
+    /// Each entry is yielded as a [`DictEntryRef`] whose [`DictEntryRef::key`] and
+    /// [`DictEntryRef::val`] return the typed key and value directly.
     ///
     /// The iterator holds a C-side iterator object and releases it on drop,
     /// so it is safe to abandon iteration early.
@@ -195,19 +214,16 @@ impl<'val, DT: DictType> Dict<'val, DT> {
 
 /// An owned [`Dict`] that calls `RS_dictRelease` on drop.
 ///
-/// `'val` is the minimum lifetime of values stored in this dict; see
-/// [`Dict`] for details.
-///
-/// Obtained via [`OwnedDict::create`]. Derefs to [`Dict<'val, DT>`] so all
+/// Obtained via [`OwnedDict::create`]. Derefs to [`Dict<DT>`] so all
 /// [`Dict`] methods — including [`iter`](Dict::iter) and
 /// [`insert`](Dict::insert) — are available on `&OwnedDict` and
 /// `&mut OwnedDict` respectively.
-pub struct OwnedDict<'val, DT: DictType> {
+pub struct OwnedDict<DT: DictType> {
     ptr: NonNull<ffi::dict>,
-    _phantom: PhantomData<(DT, DT::V<'val>)>,
+    _phantom: PhantomData<DT>,
 }
 
-impl<'val, DT: DictType> OwnedDict<'val, DT> {
+impl<DT: DictType> OwnedDict<DT> {
     /// Allocate a new C dict for the configuration described by `DT`.
     pub fn create() -> Self {
         // SAFETY: DT::as_ptr() is guaranteed by the unsafe DictType impl to
@@ -219,32 +235,31 @@ impl<'val, DT: DictType> OwnedDict<'val, DT> {
         }
     }
 
-    /// Return the raw dict pointer for use in FFI calls that take `*mut ffi::dict`.
-    pub const fn as_ptr(&self) -> *mut ffi::dict {
+    /// Return a raw mutable pointer to the underlying [`ffi::dict`].
+    pub const fn as_mut_ptr(&self) -> *mut ffi::dict {
         self.ptr.as_ptr()
     }
 }
 
-impl<'val, DT: DictType> Deref for OwnedDict<'val, DT> {
-    type Target = Dict<'val, DT>;
+impl<DT: DictType> Deref for OwnedDict<DT> {
+    type Target = Dict<DT>;
 
-    fn deref(&self) -> &Dict<'val, DT> {
+    fn deref(&self) -> &Dict<DT> {
         // SAFETY: self.ptr is a valid, non-null dict alive for the lifetime of
-        // this OwnedDict. 'val matches the OwnedDict's own 'val invariant.
+        // this OwnedDict.
         unsafe { Dict::from_raw(self.ptr.as_ptr()) }
     }
 }
 
-impl<'val, DT: DictType> DerefMut for OwnedDict<'val, DT> {
-    fn deref_mut(&mut self) -> &mut Dict<'val, DT> {
+impl<DT: DictType> DerefMut for OwnedDict<DT> {
+    fn deref_mut(&mut self) -> &mut Dict<DT> {
         // SAFETY: self.ptr is a valid, non-null dict alive for the lifetime of
         // this OwnedDict, and we hold exclusive access via &mut self.
-        // 'val matches the OwnedDict's own 'val invariant.
         unsafe { Dict::from_raw_mut(self.ptr.as_ptr()) }
     }
 }
 
-impl<'val, DT: DictType> Drop for OwnedDict<'val, DT> {
+impl<DT: DictType> Drop for OwnedDict<DT> {
     fn drop(&mut self) {
         // SAFETY: self.ptr was obtained from RS_dictCreate and has not been
         // released yet.
@@ -270,7 +285,7 @@ impl<'a, DT: DictType> DictIterator<'a, DT> {
     ///
     /// `dict` must be a valid, non-null `dict*` consistent with the key and
     /// value types of `DT`, and must remain live for `'a`.
-    pub unsafe fn new(dict: *mut ffi::dict) -> Self {
+    unsafe fn new(dict: *mut ffi::dict) -> Self {
         // SAFETY: caller guarantees dict is valid and non-null.
         let iter = unsafe { ffi::RS_dictGetIterator(dict) };
         Self {
@@ -281,7 +296,7 @@ impl<'a, DT: DictType> DictIterator<'a, DT> {
 }
 
 impl<'a, DT: DictType> Iterator for DictIterator<'a, DT> {
-    type Item = DictEntry<'a, DT>;
+    type Item = DictEntryRef<'a, DT>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // SAFETY: self.iter is a valid iterator obtained during construction.
@@ -291,7 +306,7 @@ impl<'a, DT: DictType> Iterator for DictIterator<'a, DT> {
         } else {
             // SAFETY: RS_dictNext returns a valid, non-null dictEntry* consistent
             // with DT, and it remains valid for 'a (the dict borrow lifetime).
-            Some(unsafe { DictEntry::new(entry) })
+            Some(unsafe { DictEntryRef::new(entry) })
         }
     }
 }
@@ -306,19 +321,19 @@ impl<DT: DictType> Drop for DictIterator<'_, DT> {
 /// A single entry in a [`Dict`], yielded by [`DictIterator`].
 ///
 /// `'a` is the lifetime of the underlying dict data.
-pub struct DictEntry<'a, DT: DictType> {
+pub struct DictEntryRef<'a, DT: DictType> {
     entry: *mut ffi::dictEntry,
     _phantom: PhantomData<(&'a (), DT)>,
 }
 
-impl<'a, DT: DictType> DictEntry<'a, DT> {
-    /// Wrap a raw `dictEntry*` as a [`DictEntry`].
+impl<'a, DT: DictType> DictEntryRef<'a, DT> {
+    /// Wrap a raw `dictEntry*` as a [`DictEntryRef`].
     ///
     /// # Safety
     ///
     /// `entry` must be a valid, non-null pointer to a `dictEntry` whose key
     /// and value are consistent with `DT`, and must remain valid for `'a`.
-    const unsafe fn new(entry: *mut ffi::dictEntry) -> Self {
+    unsafe fn new(entry: *mut ffi::dictEntry) -> Self {
         Self {
             entry,
             _phantom: PhantomData,
@@ -333,13 +348,12 @@ impl<'a, DT: DictType> DictEntry<'a, DT> {
         unsafe { DT::key_from_ptr(ptr) }
     }
 
-    /// Return the value of this entry.
-    pub fn val(&self) -> DT::V<'a> {
+    /// Return the value of this entry as a borrow from the dict.
+    pub fn val(&self) -> DT::IterV<'a> {
         // SAFETY: self.entry is a valid non-null dictEntry*.
-        let v = unsafe { &(*self.entry).v };
-        // SAFETY: v.val is the value pointer of a valid dictEntry, consistent with DT::V.
-        let ptr = unsafe { v.val };
-        // SAFETY: ptr is the value of a valid dictEntry, consistent with DT::V.
-        unsafe { DT::val_from_ptr(ptr) }
+        let ptr = unsafe { (*self.entry).v.val };
+        // SAFETY: ptr is the value of a valid dictEntry, consistent with
+        // DT::IterV, and valid for 'a (the dict-borrow lifetime).
+        unsafe { DT::iter_val_from_ptr(ptr) }
     }
 }

--- a/src/redisearch_rs/c_wrappers/dict/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/dict/src/lib.rs
@@ -30,7 +30,7 @@ use inverted_index::opaque::InvertedIndex;
 ///
 /// # Safety
 ///
-/// Implementors must ensure that the `*mut c_void` passed to `from_dict_ptr`
+/// Implementers must ensure that the `*mut c_void` passed to `from_dict_ptr`
 /// genuinely points to a value of the type that `Self` represents. Whether
 /// `into_dict_ptr` is safe to call depends on the [`ffi::dictType`] the dict
 /// was created with — the dictType's callbacks determine how the pointer is
@@ -112,7 +112,7 @@ unsafe impl<'a, T: 'a> DictValue<'a> for Option<&'a T> {
 ///
 /// # Safety
 ///
-/// Implementors must ensure that [`as_ptr`](Self::as_ptr) returns a pointer to
+/// Implementers must ensure that [`as_ptr`](Self::as_ptr) returns a pointer to
 /// a valid, live `ffi::dictType` whose callbacks are consistent with `K` and
 /// `V`: e.g. if `K::into_dict_ptr` returns a pointer to a temporary, the
 /// dictType's `keyDup` must copy it before the caller is allowed to free the
@@ -143,7 +143,7 @@ unsafe impl DictType for MissingFieldDictType {
     type V<'a> = Option<&'a InvertedIndex>;
 
     fn as_ptr() -> *mut ffi::dictType {
-        unsafe { std::ptr::addr_of_mut!(ffi::dictTypeHeapHiddenStrings) }
+        std::ptr::addr_of_mut!(ffi::dictTypeHeapHiddenStrings)
     }
 }
 

--- a/src/redisearch_rs/c_wrappers/dict/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/dict/src/lib.rs
@@ -11,26 +11,30 @@
 
 use std::ffi::c_void;
 use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+use std::ptr::NonNull;
 
 use hidden_string::HiddenStringRef;
 
-/// Conversion from the raw `*mut c_void` pointer stored in a dict entry.
+/// Bidirectional conversion between a Rust type and the raw `*mut c_void`
+/// pointer stored in a dict entry.
 ///
-/// The lifetime `'a` ties the returned value to the lifetime of the dict's
-/// underlying data, enabling types like [`HiddenStringRef<'a>`] that borrow
-/// from the dict to be returned directly from [`DictEntry::key`] and
-/// [`DictEntry::val`].
+/// The lifetime `'a` ties the output of [`from_dict_ptr`](Self::from_dict_ptr)
+/// to the lifetime of the underlying dict data, enabling borrowed types like
+/// [`HiddenStringRef<'a>`] to be returned directly from
+/// [`DictEntry::key`] and [`DictEntry::val`].
 ///
-/// Blanket implementations are provided for `*mut T` and `*const T`; both
-/// perform a pointer cast and are valid for any lifetime.  [`HiddenStringRef`]
-/// is implemented as a zero-cost wrapper construction.
+/// The same type is used for both reading (via [`Dict::iter`]) and writing
+/// (via [`Dict::insert`]).
 ///
 /// # Safety
 ///
-/// Implementors must ensure that the `*mut c_void` passed to
-/// [`from_dict_ptr`](Self::from_dict_ptr) genuinely points to a value of
-/// the type that `Self` represents.
-pub unsafe trait FromDictPtr<'a>: Sized + Copy + 'a {
+/// Implementors must ensure that the `*mut c_void` passed to `from_dict_ptr`
+/// genuinely points to a value of the type that `Self` represents. Whether
+/// `into_dict_ptr` is safe to call depends on the [`ffi::dictType`] the dict
+/// was created with — the dictType's callbacks determine how the pointer is
+/// used after insertion.
+pub unsafe trait DictValue<'a>: Sized + Copy + 'a {
     /// Convert a raw dict entry pointer to `Self`.
     ///
     /// # Safety
@@ -38,40 +42,47 @@ pub unsafe trait FromDictPtr<'a>: Sized + Copy + 'a {
     /// `ptr` must point to a valid value of the type that `Self` represents,
     /// and must remain valid for at least `'a`.
     unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self;
+
+    /// Convert `self` into a raw dict entry pointer.
+    fn into_dict_ptr(self) -> *mut c_void;
 }
 
-// SAFETY: A pointer cast from *mut c_void to *mut T is always layout-compatible.
-// The caller is responsible for ensuring the pointer actually addresses a T.
-unsafe impl<'a, T: 'a> FromDictPtr<'a> for *mut T {
-    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self {
-        ptr.cast()
-    }
+// SAFETY: pointer casts are always layout-compatible; the caller is responsible
+// for ensuring the pointer actually addresses a T.
+unsafe impl<'a, T: 'a> DictValue<'a> for *mut T {
+    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self { ptr.cast() }
+    fn into_dict_ptr(self) -> *mut c_void { self.cast() }
 }
 
-// SAFETY: A pointer cast from *mut c_void to *const T is always layout-compatible.
-// The caller is responsible for ensuring the pointer actually addresses a T.
-unsafe impl<'a, T: 'a> FromDictPtr<'a> for *const T {
-    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self {
-        ptr.cast()
-    }
+// SAFETY: same as *mut T; const-ness is a Rust concept, not a C one.
+unsafe impl<'a, T: 'a> DictValue<'a> for *const T {
+    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self { ptr.cast() }
+    fn into_dict_ptr(self) -> *mut c_void { self.cast_mut().cast() }
 }
 
-// SAFETY: The dict stores *const HiddenString pointers as *mut c_void.
+// SAFETY: The dict stores *mut HiddenString pointers as *mut c_void.
 // Casting back and wrapping in HiddenStringRef is sound when the caller
 // guarantees the pointer is a valid, non-null HiddenString that lives for 'a.
-unsafe impl<'a> FromDictPtr<'a> for HiddenStringRef<'a> {
+unsafe impl<'a> DictValue<'a> for HiddenStringRef<'a> {
     unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self {
-        // SAFETY: caller guarantees ptr is a valid *const HiddenString for 'a.
+        // SAFETY: caller guarantees ptr is a valid *mut HiddenString for 'a.
         unsafe { HiddenStringRef::from_raw(ptr.cast::<ffi::HiddenString>()) }
     }
+    fn into_dict_ptr(self) -> *mut c_void { self.as_ptr().cast() }
 }
 
-// SAFETY: null pointer → None; non-null *mut c_void → Some(&T).
-// The caller must ensure non-null pointers address a valid T that lives for 'a.
-unsafe impl<'a, T: 'a> FromDictPtr<'a> for Option<&'a T> {
+// SAFETY: null pointer → None (absence of a value); non-null *mut c_void →
+// Some(&T). The caller must ensure non-null pointers address a valid T for 'a.
+unsafe impl<'a, T: 'a> DictValue<'a> for Option<&'a T> {
     unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self {
         // SAFETY: caller guarantees non-null ptr is a valid *const T for 'a.
         if ptr.is_null() { None } else { Some(unsafe { &*ptr.cast::<T>() }) }
+    }
+    fn into_dict_ptr(self) -> *mut c_void {
+        match self {
+            None => std::ptr::null_mut(),
+            Some(r) => (r as *const T).cast_mut().cast(),
+        }
     }
 }
 
@@ -140,6 +151,20 @@ impl<K, V> Dict<K, V> {
         &raw mut self.inner
     }
 
+    /// Insert a typed key–value pair into this dict.
+    ///
+    /// Returns `true` when the entry was added, `false` when the key already
+    /// existed (the existing entry is not updated).
+    pub fn insert<'b>(&mut self, key: K, val: V) -> bool
+    where
+        K: DictValue<'b>,
+        V: DictValue<'b>,
+    {
+        // SAFETY: self points to a valid dict; key and val lifetimes are managed
+        // by the dictType's dup/destructor callbacks.
+        unsafe { ffi::RS_dictAdd(self.as_mut_ptr(), key.into_dict_ptr(), val.into_dict_ptr()) == 0 }
+    }
+
     /// Iterate over all entries in this dict.
     ///
     /// Each entry is yielded as a [`DictEntry`] whose [`DictEntry::key`] and
@@ -150,14 +175,81 @@ impl<K, V> Dict<K, V> {
     /// so it is safe to abandon iteration early.
     pub fn iter<'a>(&'a self) -> DictIterator<'a, K, V>
     where
-        K: FromDictPtr<'a>,
-        V: FromDictPtr<'a>,
+        K: DictValue<'a>,
+        V: DictValue<'a>,
     {
         // SAFETY: `self.inner` is a valid dict (invariant upheld by construction).
         // RS_dictGetIterator does not modify the dict; the cast from *const to
         // *mut is sound because the C function only reads the dict to initialise
         // the iterator's internal fingerprint.
         unsafe { DictIterator::new(self.as_ptr().cast_mut()) }
+    }
+}
+
+/// An owned [`Dict`] that calls `RS_dictRelease` on drop.
+///
+/// Obtained via [`OwnedDict::create`]. Derefs to [`Dict<K, V>`] so all
+/// [`Dict`] methods — including [`iter`](Dict::iter) and
+/// [`insert`](Dict::insert) — are available on `&OwnedDict` and
+/// `&mut OwnedDict` respectively.
+///
+/// The `valDestructor` of the supplied [`ffi::dictType`] determines whether
+/// values are freed on drop; callers that need to free values themselves must
+/// use a type with a null `valDestructor`.
+pub struct OwnedDict<K = *mut c_void, V = *mut c_void> {
+    ptr: NonNull<ffi::dict>,
+    _phantom: PhantomData<(K, V)>,
+}
+
+impl<K, V> OwnedDict<K, V> {
+    /// Allocate a new C dict with the given type descriptor.
+    ///
+    /// # Safety
+    ///
+    /// `dict_type` must point to a valid, live [`ffi::dictType`] that remains
+    /// live for the lifetime of the returned dict. The dictType's callbacks
+    /// (hash, compare, dup, destructor) must be consistent with how `K` and
+    /// `V` values will be inserted and read back: e.g. if `K::into_dict_ptr`
+    /// returns a pointer to a temporary, the dictType's `keyDup` must copy it.
+    pub unsafe fn create(dict_type: *mut ffi::dictType) -> Self {
+        // SAFETY: dict_type is valid per the caller's contract; null privdata
+        // is always accepted by RS_dictCreate.
+        let ptr = unsafe { ffi::RS_dictCreate(dict_type, std::ptr::null_mut()) };
+        Self {
+            ptr: NonNull::new(ptr).expect("RS_dictCreate returned null"),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Return the raw dict pointer for use in FFI calls that take `*mut ffi::dict`.
+    pub fn as_ptr(&self) -> *mut ffi::dict {
+        self.ptr.as_ptr()
+    }
+}
+
+impl<K, V> Deref for OwnedDict<K, V> {
+    type Target = Dict<K, V>;
+
+    fn deref(&self) -> &Dict<K, V> {
+        // SAFETY: self.ptr is a valid, non-null dict alive for the lifetime of
+        // this OwnedDict.
+        unsafe { Dict::from_raw(self.ptr.as_ptr()) }
+    }
+}
+
+impl<K, V> DerefMut for OwnedDict<K, V> {
+    fn deref_mut(&mut self) -> &mut Dict<K, V> {
+        // SAFETY: self.ptr is a valid, non-null dict alive for the lifetime of
+        // this OwnedDict, and we hold exclusive access via &mut self.
+        unsafe { Dict::from_raw_mut(self.ptr.as_ptr()) }
+    }
+}
+
+impl<K, V> Drop for OwnedDict<K, V> {
+    fn drop(&mut self) {
+        // SAFETY: self.ptr was obtained from RS_dictCreate and has not been
+        // released yet.
+        unsafe { ffi::RS_dictRelease(self.ptr.as_ptr()) };
     }
 }
 
@@ -176,11 +268,11 @@ impl<'a, K, V> DictEntry<'a, K, V> {
     }
 }
 
-impl<'a, K: FromDictPtr<'a>, V: FromDictPtr<'a>> DictEntry<'a, K, V> {
+impl<'a, K: DictValue<'a>, V: DictValue<'a>> DictEntry<'a, K, V> {
     /// Return the key of this entry.
     ///
     /// Corresponds to the C macro `dictGetKey(entry)` (`entry->key`),
-    /// converted to `K` via [`FromDictPtr`].
+    /// converted to `K` via [`DictValue`].
     pub fn key(&self) -> K {
         // SAFETY: self.entry is a valid non-null dictEntry* (invariant of DictEntry).
         let ptr = unsafe { (*self.entry).key };
@@ -191,7 +283,7 @@ impl<'a, K: FromDictPtr<'a>, V: FromDictPtr<'a>> DictEntry<'a, K, V> {
     /// Return the value of this entry.
     ///
     /// Corresponds to the C macro `dictGetVal(entry)` (`entry->v.val`),
-    /// converted to `V` via [`FromDictPtr`].
+    /// converted to `V` via [`DictValue`].
     pub fn val(&self) -> V {
         // SAFETY: self.entry is a valid non-null dictEntry*.
         let v = unsafe { &(*self.entry).v };
@@ -229,7 +321,7 @@ impl<'a, K, V> DictIterator<'a, K, V> {
     }
 }
 
-impl<'a, K: FromDictPtr<'a>, V: FromDictPtr<'a>> Iterator for DictIterator<'a, K, V> {
+impl<'a, K: DictValue<'a>, V: DictValue<'a>> Iterator for DictIterator<'a, K, V> {
     type Item = DictEntry<'a, K, V>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/redisearch_rs/c_wrappers/dict/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/dict/src/lib.rs
@@ -86,17 +86,13 @@ unsafe impl<'a> DictValue<'a> for HiddenStringRef<'a> {
 // Some(&T). The caller must ensure non-null pointers address a valid T for 'a.
 unsafe impl<'a, T: 'a> DictValue<'a> for Option<&'a T> {
     unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self {
-        // SAFETY: caller guarantees non-null ptr is a valid *const T for 'a.
-        if ptr.is_null() {
-            None
-        } else {
-            Some(unsafe { &*ptr.cast::<T>() })
-        }
+        // SAFETY: ptr is non-null and valid for 'a per the trait contract.
+        std::ptr::NonNull::new(ptr.cast::<T>()).map(|p| unsafe { p.as_ref() })
     }
     fn into_dict_ptr(self) -> *mut c_void {
         match self {
             None => std::ptr::null_mut(),
-            Some(r) => (r as *const T).cast_mut().cast(),
+            Some(r) => std::ptr::from_ref(r).cast_mut().cast(),
         }
     }
 }
@@ -251,7 +247,7 @@ impl<DT: DictType> OwnedDict<DT> {
     }
 
     /// Return the raw dict pointer for use in FFI calls that take `*mut ffi::dict`.
-    pub fn as_ptr(&self) -> *mut ffi::dict {
+    pub const fn as_ptr(&self) -> *mut ffi::dict {
         self.ptr.as_ptr()
     }
 }
@@ -302,6 +298,7 @@ impl<'a, DT: DictType> DictEntry<'a, DT> {
     pub fn key(&self) -> DT::K<'a> {
         // SAFETY: self.entry is a valid non-null dictEntry*.
         let ptr = unsafe { (*self.entry).key };
+        // SAFETY: ptr is the key of a valid dictEntry, consistent with DT::K.
         unsafe { <DT::K<'a> as DictValue<'a>>::from_dict_ptr(ptr) }
     }
 
@@ -309,7 +306,9 @@ impl<'a, DT: DictType> DictEntry<'a, DT> {
     pub fn val(&self) -> DT::V<'a> {
         // SAFETY: self.entry is a valid non-null dictEntry*.
         let v = unsafe { &(*self.entry).v };
+        // SAFETY: v.val is the value pointer of a valid dictEntry, consistent with DT::V.
         let ptr = unsafe { v.val };
+        // SAFETY: ptr is a valid value pointer consistent with DT::V.
         unsafe { <DT::V<'a> as DictValue<'a>>::from_dict_ptr(ptr) }
     }
 }

--- a/src/redisearch_rs/c_wrappers/dict/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/dict/src/lib.rs
@@ -46,6 +46,8 @@ use inverted_index::opaque::InvertedIndex;
 /// - [`iter_val_from_ptr`](Self::iter_val_from_ptr) correctly borrows the
 ///   value stored at `ptr` for lifetime `'a`.
 pub unsafe trait DictType {
+    /// Key type used for insertion and returned during iteration. `'a` is the
+    /// dict-borrow lifetime, tying iterated keys to the underlying dict storage.
     type K<'a>;
     /// Owned value type for insertion. When `valDestructor` is set, this
     /// should be an owned type (e.g. `Box<V>`) whose memory the dict will
@@ -58,6 +60,9 @@ pub unsafe trait DictType {
     /// Return a pointer to the static C `dictType` for this configuration.
     fn as_ptr() -> *mut ffi::dictType;
 
+    /// Convert a key to the raw pointer to be passed to the dict.
+    fn key_into_ptr<'a>(key: Self::K<'a>) -> *mut c_void;
+
     /// Reconstruct a key from the raw pointer stored in a dict entry.
     ///
     /// # Safety
@@ -65,21 +70,14 @@ pub unsafe trait DictType {
     /// `ptr` must be a valid pointer to a key consistent with `K`, valid for `'a`.
     unsafe fn key_from_ptr<'a>(ptr: *mut c_void) -> Self::K<'a>;
 
-    /// Convert a key to the raw pointer to be passed to the dict.
-    fn key_into_ptr<'a>(key: Self::K<'a>) -> *mut c_void;
-
-    /// Convert an owned insert value to the raw pointer stored by the dict.
-    ///
-    /// For owning dicts this must consume or leak the value so the
-    /// `valDestructor` can free it later.
+    /// Convert an owned insert value to the raw pointer to be stored by the dict.
     fn insert_val_into_ptr(val: Self::InsertV) -> *mut c_void;
 
     /// Reconstruct a borrowed value from the raw pointer stored in a dict entry.
     ///
     /// # Safety
     ///
-    /// `ptr` must be a valid pointer to a value consistent with `IterV`, valid
-    /// for `'a`.
+    /// `ptr` must be a valid pointer to a value consistent with `IterV`, valid for `'a`.
     unsafe fn iter_val_from_ptr<'a>(ptr: *mut c_void) -> Self::IterV<'a>;
 }
 
@@ -97,10 +95,14 @@ pub struct MissingFieldDictType;
 unsafe impl DictType for MissingFieldDictType {
     type K<'a> = HiddenStringRef<'a>;
     type InsertV = Box<InvertedIndex>;
-    type IterV<'a> = Option<&'a InvertedIndex>;
+    type IterV<'a> = &'a InvertedIndex;
 
     fn as_ptr() -> *mut ffi::dictType {
         std::ptr::addr_of_mut!(ffi::missingFieldDictType)
+    }
+
+    fn key_into_ptr<'a>(key: Self::K<'a>) -> *mut c_void {
+        key.as_ptr().cast()
     }
 
     unsafe fn key_from_ptr<'a>(ptr: *mut c_void) -> Self::K<'a> {
@@ -108,18 +110,13 @@ unsafe impl DictType for MissingFieldDictType {
         unsafe { HiddenStringRef::from_raw(ptr.cast::<ffi::HiddenString>()) }
     }
 
-    fn key_into_ptr<'a>(key: Self::K<'a>) -> *mut c_void {
-        key.as_ptr().cast()
-    }
-
     fn insert_val_into_ptr(val: Self::InsertV) -> *mut c_void {
         Box::into_raw(val).cast()
     }
 
     unsafe fn iter_val_from_ptr<'a>(ptr: *mut c_void) -> Self::IterV<'a> {
-        // SAFETY: caller guarantees non-null ptr is a valid *mut InvertedIndex
-        // for 'a; null represents None.
-        NonNull::new(ptr.cast::<InvertedIndex>()).map(|p| unsafe { p.as_ref() })
+        // SAFETY: caller guarantees ptr is a valid, non-null *mut InvertedIndex for 'a.
+        unsafe { &*ptr.cast::<InvertedIndex>() }
     }
 }
 
@@ -176,24 +173,32 @@ impl<DT: DictType> Dict<DT> {
 
     /// Insert a key–value pair into this dict.
     ///
-    /// Returns `true` when the entry was added, `false` when the key already
-    /// existed (the existing entry is not updated).
+    /// Returns `Ok(())` when the entry was added. Returns `Err(val)` when the
+    /// key already existed — ownership of `val` is returned to the caller.
     ///
-    /// The key lifetime is unconstrained because the underlying `dictType` is
-    /// required (by the [`DictType`] safety contract) to copy keys on insertion.
-    ///
-    /// `val` is `DT::InsertV`: for owning dicts this is an owned type (e.g.
-    /// `Box<V>`) whose memory the dict takes responsibility for freeing.
-    pub fn insert(&mut self, key: DT::K<'_>, val: DT::InsertV) -> bool {
-        // SAFETY: self points to a valid dict; key is copied by the dictType's
-        // keyDup; insert_val_into_ptr transfers ownership of val to the dict.
-        unsafe {
-            ffi::RS_dictAdd(
+    /// The key is only borrowed for the duration of this call; `RS_dictAddRaw`
+    /// copies it via `keyDup` if a new entry is allocated.
+    pub fn try_insert(&mut self, key: DT::K<'_>, val: DT::InsertV) -> Result<(), DT::InsertV> {
+        // SAFETY: self points to a valid dict; key is valid for the lookup;
+        // RS_dictAddRaw copies the key via keyDup if it allocates a new entry.
+        // Passing null for the `existing` out-param: the C function checks for
+        // null before writing, and we only need the return value here.
+        let new_entry = unsafe {
+            ffi::RS_dictAddRaw(
                 self.as_mut_ptr(),
                 DT::key_into_ptr(key),
-                DT::insert_val_into_ptr(val),
-            ) == 0
+                std::ptr::null_mut(),
+            )
+        };
+        if new_entry.is_null() {
+            // Key already existed; val was never consumed.
+            return Err(val);
         }
+        // New entry allocated; set the value. Ownership passes to the dict.
+        // SAFETY: new_entry is valid and non-null (returned by RS_dictAddRaw above).
+        let entry = unsafe { &mut *new_entry };
+        entry.v.val = DT::insert_val_into_ptr(val);
+        Ok(())
     }
 
     /// Iterate over all entries in this dict.
@@ -216,8 +221,11 @@ impl<DT: DictType> Dict<DT> {
 ///
 /// Obtained via [`OwnedDict::create`]. Derefs to [`Dict<DT>`] so all
 /// [`Dict`] methods — including [`iter`](Dict::iter) and
-/// [`insert`](Dict::insert) — are available on `&OwnedDict` and
+/// [`try_insert`](Dict::try_insert) — are available on `&OwnedDict` and
 /// `&mut OwnedDict` respectively.
+///
+/// For a non-owning wrapper around an existing C dict pointer, use [`Dict`]
+/// directly via [`Dict::from_raw`] or [`Dict::from_raw_mut`].
 pub struct OwnedDict<DT: DictType> {
     ptr: NonNull<ffi::dict>,
     _phantom: PhantomData<DT>,
@@ -269,22 +277,23 @@ impl<DT: DictType> Drop for OwnedDict<DT> {
 
 /// An iterator over the entries of a [`Dict`].
 ///
-/// `'a` is the lifetime of the underlying dict data.  Wraps
-/// [`ffi::RS_dictGetIterator`] / [`ffi::RS_dictNext`] /
+/// `'dict` is the lifetime of the underlying dict data.
+///
+/// Wraps [`ffi::RS_dictGetIterator`] / [`ffi::RS_dictNext`] /
 /// [`ffi::RS_dictReleaseIterator`] and releases the underlying C iterator on
 /// drop.
-pub struct DictIterator<'a, DT: DictType> {
+pub struct DictIterator<'dict, DT: DictType> {
     iter: *mut ffi::dictIterator,
-    _phantom: PhantomData<(&'a (), DT)>,
+    _phantom: PhantomData<(&'dict (), DT)>,
 }
 
-impl<'a, DT: DictType> DictIterator<'a, DT> {
+impl<'dict, DT: DictType> DictIterator<'dict, DT> {
     /// Create an iterator directly from a raw `dict*`.
     ///
     /// # Safety
     ///
-    /// `dict` must be a valid, non-null `dict*` consistent with the key and
-    /// value types of `DT`, and must remain live for `'a`.
+    /// - `dict` must be a valid, non-null `dict*` consistent with the key and
+    ///   value types of `DT`, and must remain live for `'dict`.
     unsafe fn new(dict: *mut ffi::dict) -> Self {
         // SAFETY: caller guarantees dict is valid and non-null.
         let iter = unsafe { ffi::RS_dictGetIterator(dict) };
@@ -295,8 +304,8 @@ impl<'a, DT: DictType> DictIterator<'a, DT> {
     }
 }
 
-impl<'a, DT: DictType> Iterator for DictIterator<'a, DT> {
-    type Item = DictEntryRef<'a, DT>;
+impl<'dict, DT: DictType> Iterator for DictIterator<'dict, DT> {
+    type Item = DictEntryRef<'dict, DT>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // SAFETY: self.iter is a valid iterator obtained during construction.
@@ -305,7 +314,7 @@ impl<'a, DT: DictType> Iterator for DictIterator<'a, DT> {
             None
         } else {
             // SAFETY: RS_dictNext returns a valid, non-null dictEntry* consistent
-            // with DT, and it remains valid for 'a (the dict borrow lifetime).
+            // with DT, and it remains valid for 'dict (the dict borrow lifetime).
             Some(unsafe { DictEntryRef::new(entry) })
         }
     }
@@ -320,20 +329,20 @@ impl<DT: DictType> Drop for DictIterator<'_, DT> {
 
 /// A single entry in a [`Dict`], yielded by [`DictIterator`].
 ///
-/// `'a` is the lifetime of the underlying dict data.
-pub struct DictEntryRef<'a, DT: DictType> {
+/// `'dict` is the lifetime of the underlying dict data.
+pub struct DictEntryRef<'dict, DT: DictType> {
     entry: *mut ffi::dictEntry,
-    _phantom: PhantomData<(&'a (), DT)>,
+    _phantom: PhantomData<(&'dict (), DT)>,
 }
 
-impl<'a, DT: DictType> DictEntryRef<'a, DT> {
+impl<'dict, DT: DictType> DictEntryRef<'dict, DT> {
     /// Wrap a raw `dictEntry*` as a [`DictEntryRef`].
     ///
     /// # Safety
     ///
-    /// `entry` must be a valid, non-null pointer to a `dictEntry` whose key
-    /// and value are consistent with `DT`, and must remain valid for `'a`.
-    unsafe fn new(entry: *mut ffi::dictEntry) -> Self {
+    /// - `entry` must be a valid, non-null pointer to a `dictEntry` whose key
+    ///   and value are consistent with `DT`, and must remain valid for `'dict`.
+    const unsafe fn new(entry: *mut ffi::dictEntry) -> Self {
         Self {
             entry,
             _phantom: PhantomData,
@@ -341,19 +350,25 @@ impl<'a, DT: DictType> DictEntryRef<'a, DT> {
     }
 
     /// Return the key of this entry.
-    pub fn key(&self) -> DT::K<'a> {
+    pub fn key(&self) -> DT::K<'dict> {
         // SAFETY: self.entry is a valid non-null dictEntry*.
         let ptr = unsafe { (*self.entry).key };
-        // SAFETY: ptr is the key of a valid dictEntry, consistent with DT::K.
+        // SAFETY: ptr is the key of a valid dictEntry, consistent with DT::K,
+        // and valid for 'dict (the dict-borrow lifetime). No mutable aliasing:
+        // DictEntryRef<'dict> is only produced by DictIterator<'dict>, which is
+        // created via &Dict — a shared borrow that excludes any &mut Dict.
         unsafe { DT::key_from_ptr(ptr) }
     }
 
     /// Return the value of this entry as a borrow from the dict.
-    pub fn val(&self) -> DT::IterV<'a> {
+    pub fn val(&self) -> DT::IterV<'dict> {
         // SAFETY: self.entry is a valid non-null dictEntry*.
-        let ptr = unsafe { (*self.entry).v.val };
+        let entry = unsafe { &*self.entry };
+        // SAFETY: v.val is the pointer-sized value field of the dictEntry union.
+        let ptr = unsafe { entry.v.val };
         // SAFETY: ptr is the value of a valid dictEntry, consistent with
-        // DT::IterV, and valid for 'a (the dict-borrow lifetime).
+        // DT::IterV, and valid for 'dict (the dict-borrow lifetime). No mutable
+        // aliasing: same argument as key() above.
         unsafe { DT::iter_val_from_ptr(ptr) }
     }
 }

--- a/src/redisearch_rs/c_wrappers/dict/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/dict/src/lib.rs
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Safe wrappers around the C [`ffi::dict`] type.
+
+use std::ffi::c_void;
+use std::marker::PhantomData;
+
+use hidden_string::HiddenStringRef;
+
+/// Conversion from the raw `*mut c_void` pointer stored in a dict entry.
+///
+/// The lifetime `'a` ties the returned value to the lifetime of the dict's
+/// underlying data, enabling types like [`HiddenStringRef<'a>`] that borrow
+/// from the dict to be returned directly from [`DictEntry::key`] and
+/// [`DictEntry::val`].
+///
+/// Blanket implementations are provided for `*mut T` and `*const T`; both
+/// perform a pointer cast and are valid for any lifetime.  [`HiddenStringRef`]
+/// is implemented as a zero-cost wrapper construction.
+///
+/// # Safety
+///
+/// Implementors must ensure that the `*mut c_void` passed to
+/// [`from_dict_ptr`](Self::from_dict_ptr) genuinely points to a value of
+/// the type that `Self` represents.
+pub unsafe trait FromDictPtr<'a>: Sized + Copy + 'a {
+    /// Convert a raw dict entry pointer to `Self`.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point to a valid value of the type that `Self` represents,
+    /// and must remain valid for at least `'a`.
+    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self;
+}
+
+// SAFETY: A pointer cast from *mut c_void to *mut T is always layout-compatible.
+// The caller is responsible for ensuring the pointer actually addresses a T.
+unsafe impl<'a, T: 'a> FromDictPtr<'a> for *mut T {
+    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self {
+        ptr.cast()
+    }
+}
+
+// SAFETY: A pointer cast from *mut c_void to *const T is always layout-compatible.
+// The caller is responsible for ensuring the pointer actually addresses a T.
+unsafe impl<'a, T: 'a> FromDictPtr<'a> for *const T {
+    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self {
+        ptr.cast()
+    }
+}
+
+// SAFETY: The dict stores *const HiddenString pointers as *mut c_void.
+// Casting back and wrapping in HiddenStringRef is sound when the caller
+// guarantees the pointer is a valid, non-null HiddenString that lives for 'a.
+unsafe impl<'a> FromDictPtr<'a> for HiddenStringRef<'a> {
+    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self {
+        // SAFETY: caller guarantees ptr is a valid *const HiddenString for 'a.
+        unsafe { HiddenStringRef::from_raw(ptr.cast::<ffi::HiddenString>()) }
+    }
+}
+
+// SAFETY: null pointer → None; non-null *mut c_void → Some(&T).
+// The caller must ensure non-null pointers address a valid T that lives for 'a.
+unsafe impl<'a, T: 'a> FromDictPtr<'a> for Option<&'a T> {
+    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self {
+        // SAFETY: caller guarantees non-null ptr is a valid *const T for 'a.
+        if ptr.is_null() { None } else { Some(unsafe { &*ptr.cast::<T>() }) }
+    }
+}
+
+
+/// A safe wrapper around a C [`ffi::dict`].
+///
+/// `K` and `V` are the types returned by [`DictEntry::key`] and
+/// [`DictEntry::val`]; both default to `*mut c_void` for untyped access.
+/// Specifying concrete types eliminates manual casts at call sites and — for
+/// wrapper types such as [`HiddenStringRef`] — the manual construction call:
+///
+/// ```text
+/// // typed key, untyped value
+/// let d: &Dict<HiddenStringRef<'_>, *mut c_void> = spec.missing_field_dict();
+/// for entry in d.iter() {
+///     let name: HiddenStringRef<'_> = entry.key(); // no cast, no from_raw
+///     let idx:  *mut c_void         = entry.val();
+/// }
+/// ```
+///
+/// Obtained from a raw `*const`/`*mut ffi::dict` via [`Dict::from_raw`] or
+/// [`Dict::from_raw_mut`].
+#[repr(transparent)]
+pub struct Dict<K = *mut c_void, V = *mut c_void> {
+    inner: ffi::dict,
+    _phantom: PhantomData<(K, V)>,
+}
+
+impl<K, V> Dict<K, V> {
+    /// Borrow a [`Dict`] from a raw const pointer.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be a valid, non-null pointer to an `ffi::dict` that is
+    /// properly initialised and remains live for the returned lifetime `'a`.
+    /// The caller must also ensure that the dict's keys and values are
+    /// actually of types `K` and `V`.
+    pub const unsafe fn from_raw<'a>(ptr: *const ffi::dict) -> &'a Self {
+        // SAFETY: #[repr(transparent)] guarantees identical layout for any K, V.
+        // Validity and liveness are the caller's responsibility.
+        unsafe { ptr.cast::<Self>().as_ref().unwrap() }
+    }
+
+    /// Borrow a [`Dict`] mutably from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be a valid, non-null pointer to an `ffi::dict` that is
+    /// properly initialised and remains live for the returned lifetime `'a`,
+    /// with no other aliasing references for the duration.  The caller must
+    /// also ensure that the dict's keys and values are actually of types `K`
+    /// and `V`.
+    pub const unsafe fn from_raw_mut<'a>(ptr: *mut ffi::dict) -> &'a mut Self {
+        // SAFETY: #[repr(transparent)] guarantees identical layout for any K, V.
+        // Validity, liveness, and exclusivity are the caller's responsibility.
+        unsafe { ptr.cast::<Self>().as_mut().unwrap() }
+    }
+
+    /// Return a raw const pointer to the underlying [`ffi::dict`].
+    pub const fn as_ptr(&self) -> *const ffi::dict {
+        &raw const self.inner
+    }
+
+    /// Return a raw mutable pointer to the underlying [`ffi::dict`].
+    pub const fn as_mut_ptr(&mut self) -> *mut ffi::dict {
+        &raw mut self.inner
+    }
+
+    /// Iterate over all entries in this dict.
+    ///
+    /// Each entry is yielded as a [`DictEntry`] whose [`DictEntry::key`] and
+    /// [`DictEntry::val`] return the typed key and value directly — no manual
+    /// casts or wrapper constructions required.
+    ///
+    /// The iterator holds a C-side iterator object and releases it on drop,
+    /// so it is safe to abandon iteration early.
+    pub fn iter<'a>(&'a self) -> DictIterator<'a, K, V>
+    where
+        K: FromDictPtr<'a>,
+        V: FromDictPtr<'a>,
+    {
+        // SAFETY: `self.inner` is a valid dict (invariant upheld by construction).
+        // RS_dictGetIterator does not modify the dict; the cast from *const to
+        // *mut is sound because the C function only reads the dict to initialise
+        // the iterator's internal fingerprint.
+        unsafe { DictIterator::new(self.as_ptr().cast_mut()) }
+    }
+}
+
+/// A single entry in a [`Dict`], yielded by [`DictIterator`].
+///
+/// `'a` is the lifetime of the underlying dict data; `K` and `V` are the
+/// types returned by [`key`](Self::key) and [`val`](Self::val).
+pub struct DictEntry<'a, K = *mut c_void, V = *mut c_void> {
+    entry: *mut ffi::dictEntry,
+    _phantom: PhantomData<(&'a (), K, V)>,
+}
+
+impl<'a, K, V> DictEntry<'a, K, V> {
+    const fn new(entry: *mut ffi::dictEntry) -> Self {
+        Self { entry, _phantom: PhantomData }
+    }
+}
+
+impl<'a, K: FromDictPtr<'a>, V: FromDictPtr<'a>> DictEntry<'a, K, V> {
+    /// Return the key of this entry.
+    ///
+    /// Corresponds to the C macro `dictGetKey(entry)` (`entry->key`),
+    /// converted to `K` via [`FromDictPtr`].
+    pub fn key(&self) -> K {
+        // SAFETY: self.entry is a valid non-null dictEntry* (invariant of DictEntry).
+        let ptr = unsafe { (*self.entry).key };
+        // SAFETY: the caller selected K to match the actual key type stored in this dict.
+        unsafe { K::from_dict_ptr(ptr) }
+    }
+
+    /// Return the value of this entry.
+    ///
+    /// Corresponds to the C macro `dictGetVal(entry)` (`entry->v.val`),
+    /// converted to `V` via [`FromDictPtr`].
+    pub fn val(&self) -> V {
+        // SAFETY: self.entry is a valid non-null dictEntry*.
+        let v = unsafe { &(*self.entry).v };
+        // SAFETY: the dict value union variant is a pointer-sized void pointer.
+        let ptr = unsafe { v.val };
+        // SAFETY: the caller selected V to match the actual value type stored in this dict.
+        unsafe { V::from_dict_ptr(ptr) }
+    }
+}
+
+/// An iterator over the entries of a C [`ffi::dict`].
+///
+/// `'a` is the lifetime of the underlying dict data.  Wraps
+/// [`ffi::RS_dictGetIterator`] / [`ffi::RS_dictNext`] /
+/// [`ffi::RS_dictReleaseIterator`] and releases the underlying C iterator on
+/// drop.
+pub struct DictIterator<'a, K = *mut c_void, V = *mut c_void> {
+    iter: *mut ffi::dictIterator,
+    _phantom: PhantomData<(&'a (), K, V)>,
+}
+
+impl<'a, K, V> DictIterator<'a, K, V> {
+    /// Create an iterator directly from a raw `dict*`.
+    ///
+    /// Prefer [`Dict::iter`] when a [`Dict`] reference is available.
+    ///
+    /// # Safety
+    ///
+    /// `dict` must be a valid, non-null `dict*` whose keys and values are
+    /// of types `K` and `V`, and that remains live for `'a`.
+    pub unsafe fn new(dict: *mut ffi::dict) -> Self {
+        // SAFETY: caller guarantees dict is valid and non-null.
+        let iter = unsafe { ffi::RS_dictGetIterator(dict) };
+        Self { iter, _phantom: PhantomData }
+    }
+}
+
+impl<'a, K: FromDictPtr<'a>, V: FromDictPtr<'a>> Iterator for DictIterator<'a, K, V> {
+    type Item = DictEntry<'a, K, V>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // SAFETY: self.iter is a valid iterator obtained during construction
+        // and not yet released.
+        let entry = unsafe { ffi::RS_dictNext(self.iter) };
+        if entry.is_null() { None } else { Some(DictEntry::new(entry)) }
+    }
+}
+
+impl<K, V> Drop for DictIterator<'_, K, V> {
+    fn drop(&mut self) {
+        // SAFETY: self.iter is a valid iterator obtained during construction.
+        unsafe { ffi::RS_dictReleaseIterator(self.iter) };
+    }
+}

--- a/src/redisearch_rs/c_wrappers/dict/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/dict/src/lib.rs
@@ -17,123 +17,56 @@ use std::ptr::NonNull;
 use hidden_string::HiddenStringRef;
 use inverted_index::opaque::InvertedIndex;
 
-/// Bidirectional conversion between a Rust type and the raw `*mut c_void`
-/// pointer stored in a dict entry.
-///
-/// The lifetime `'a` ties the output of [`from_dict_ptr`](Self::from_dict_ptr)
-/// to the lifetime of the underlying dict data, enabling borrowed types like
-/// [`HiddenStringRef<'a>`] to be returned directly from
-/// [`DictEntry::key`] and [`DictEntry::val`].
-///
-/// The same type is used for both reading (via [`Dict::iter`]) and writing
-/// (via [`Dict::insert`]).
+/// Describes a `Dict` type defined by a `ffi::dictType` with conversion
+/// functions to and from keys and values.
 ///
 /// # Safety
 ///
-/// Implementers must ensure that the `*mut c_void` passed to `from_dict_ptr`
-/// genuinely points to a value of the type that `Self` represents. Whether
-/// `into_dict_ptr` is safe to call depends on the [`ffi::dictType`] the dict
-/// was created with — the dictType's callbacks determine how the pointer is
-/// used after insertion.
-pub unsafe trait DictValue<'a>: Sized + Copy + 'a {
-    /// Convert a raw dict entry pointer to `Self`.
-    ///
-    /// # Safety
-    ///
-    /// `ptr` must point to a valid value of the type that `Self` represents,
-    /// and must remain valid for at least `'a`.
-    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self;
-
-    /// Convert `self` into a raw dict entry pointer.
-    fn into_dict_ptr(self) -> *mut c_void;
-}
-
-// SAFETY: pointer casts are always layout-compatible; the caller is responsible
-// for ensuring the pointer actually addresses a T.
-unsafe impl<'a, T: 'a> DictValue<'a> for *mut T {
-    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self {
-        ptr.cast()
-    }
-    fn into_dict_ptr(self) -> *mut c_void {
-        self.cast()
-    }
-}
-
-// SAFETY: same as *mut T; const-ness is a Rust concept, not a C one.
-unsafe impl<'a, T: 'a> DictValue<'a> for *const T {
-    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self {
-        ptr.cast()
-    }
-    fn into_dict_ptr(self) -> *mut c_void {
-        self.cast_mut().cast()
-    }
-}
-
-// SAFETY: The dict stores *mut HiddenString pointers as *mut c_void.
-// Casting back and wrapping in HiddenStringRef is sound when the caller
-// guarantees the pointer is a valid, non-null HiddenString that lives for 'a.
-unsafe impl<'a> DictValue<'a> for HiddenStringRef<'a> {
-    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self {
-        // SAFETY: caller guarantees ptr is a valid *mut HiddenString for 'a.
-        unsafe { HiddenStringRef::from_raw(ptr.cast::<ffi::HiddenString>()) }
-    }
-    fn into_dict_ptr(self) -> *mut c_void {
-        self.as_ptr().cast()
-    }
-}
-
-// SAFETY: null pointer → None (absence of a value); non-null *mut c_void →
-// Some(&T). The caller must ensure non-null pointers address a valid T for 'a.
-unsafe impl<'a, T: 'a> DictValue<'a> for Option<&'a T> {
-    unsafe fn from_dict_ptr(ptr: *mut c_void) -> Self {
-        // SAFETY: ptr is non-null and valid for 'a per the trait contract.
-        std::ptr::NonNull::new(ptr.cast::<T>()).map(|p| unsafe { p.as_ref() })
-    }
-    fn into_dict_ptr(self) -> *mut c_void {
-        match self {
-            None => std::ptr::null_mut(),
-            Some(r) => std::ptr::from_ref(r).cast_mut().cast(),
-        }
-    }
-}
-
-/// Describes the key type, value type, and underlying C [`ffi::dictType`] for
-/// a particular dict configuration.
-///
-/// Implemented by marker types (e.g. `MissingFieldDictType`) that bind a
-/// specific `ffi::dictType` to typed `K` and `V` parameters. This allows
-/// [`OwnedDict<DT>`] to call [`create`](OwnedDict::create) without a caller-
-/// supplied `dictType` pointer, and ensures that the dict's hash/compare/dup/
-/// destructor callbacks are always consistent with the key and value types.
-///
-/// # Safety
-///
-/// Implementers must ensure that [`as_ptr`](Self::as_ptr) returns a pointer to
-/// a valid, live `ffi::dictType` whose callbacks are consistent with `K` and
-/// `V`: e.g. if `K::into_dict_ptr` returns a pointer to a temporary, the
-/// dictType's `keyDup` must copy it before the caller is allowed to free the
-/// original.
+/// Implementers must ensure that:
+/// - [`as_ptr`](Self::as_ptr) returns a pointer to a valid, live `ffi::dictType`
+///   whose callbacks are consistent with `K` and `V`.
+/// - [`key_from_ptr`](Self::key_from_ptr) and [`val_from_ptr`](Self::val_from_ptr)
+///   correctly reconstruct the key/value from the raw pointer stored by the dict.
+/// - [`key_into_ptr`](Self::key_into_ptr) and [`val_into_ptr`](Self::val_into_ptr)
+///   produce pointers that are handled correctly by the `dictType`.
 pub unsafe trait DictType {
-    type K<'a>: DictValue<'a>;
-    type V<'a>: DictValue<'a>;
+    type K<'a>: Sized + Copy + 'a;
+    type V<'a>: Sized + Copy + 'a;
 
     /// Return a pointer to the static C `dictType` for this configuration.
     fn as_ptr() -> *mut ffi::dictType;
+
+    /// Reconstruct a key from the raw pointer stored in a dict entry.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be a valid pointer to a key consistent with `K`, valid for `'a`.
+    unsafe fn key_from_ptr<'a>(ptr: *mut c_void) -> Self::K<'a>;
+
+    /// Convert a key to the raw pointer to be passed to the dict.
+    fn key_into_ptr<'a>(key: Self::K<'a>) -> *mut c_void;
+
+    /// Reconstruct a value from the raw pointer stored in a dict entry.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be a valid pointer consistent with `V`, valid for `'a`.
+    unsafe fn val_from_ptr<'a>(ptr: *mut c_void) -> Self::V<'a>;
+
+    /// Convert a value to the raw pointer to be passed to the dict.
+    fn val_into_ptr<'a>(val: Self::V<'a>) -> *mut c_void;
 }
 
 /// [`DictType`] marker for the spec's `missingFieldDict`.
-///
-/// Keys are [`HiddenStringRef`] (field names); values are
-/// `Option<&InvertedIndex>` (the per-field missing-doc inverted index, or
-/// `None` when the field has no such index). The underlying C dictType is
-/// `dictTypeHeapHiddenStrings`, which copies keys on insertion via `keyDup`
-/// and does not free values on removal.
 pub struct MissingFieldDictType;
 
-// SAFETY: dictTypeHeapHiddenStrings is a valid static ffi::dictType whose
-// callbacks are compatible with HiddenStringRef keys and Option<&InvertedIndex>
-// values: keyDup copies the HiddenString so callers may free the original after
-// insert; valDestructor is null so callers retain ownership of InvertedIndex.
+// SAFETY:
+// - dictTypeHeapHiddenStrings is a valid static ffi::dictType whose callbacks
+//   are compatible with HiddenStringRef keys and Option<&InvertedIndex> values.
+// - keyDup copies the HiddenString so callers may free the original after insert.
+// - valDestructor is null so callers retain ownership of InvertedIndex.
+// - The key/value conversions round-trip through *mut HiddenString and
+//   *mut InvertedIndex respectively, consistent with how the C dict stores them.
 unsafe impl DictType for MissingFieldDictType {
     type K<'a> = HiddenStringRef<'a>;
     type V<'a> = Option<&'a InvertedIndex>;
@@ -141,29 +74,58 @@ unsafe impl DictType for MissingFieldDictType {
     fn as_ptr() -> *mut ffi::dictType {
         std::ptr::addr_of_mut!(ffi::dictTypeHeapHiddenStrings)
     }
+
+    unsafe fn key_from_ptr<'a>(ptr: *mut c_void) -> Self::K<'a> {
+        // SAFETY: caller guarantees ptr is a valid *mut HiddenString for 'a.
+        unsafe { HiddenStringRef::from_raw(ptr.cast::<ffi::HiddenString>()) }
+    }
+
+    fn key_into_ptr<'a>(key: Self::K<'a>) -> *mut c_void {
+        key.as_ptr().cast()
+    }
+
+    unsafe fn val_from_ptr<'a>(ptr: *mut c_void) -> Self::V<'a> {
+        // SAFETY: caller guarantees non-null ptr is a valid *mut InvertedIndex
+        // for 'a; null represents None (no missing-doc index for this field).
+        NonNull::new(ptr.cast::<InvertedIndex>()).map(|p| unsafe { p.as_ref() })
+    }
+
+    fn val_into_ptr<'a>(val: Self::V<'a>) -> *mut c_void {
+        match val {
+            None => std::ptr::null_mut(),
+            Some(r) => std::ptr::from_ref(r).cast_mut().cast(),
+        }
+    }
 }
 
 /// A safe wrapper around a C [`ffi::dict`].
 ///
 /// `DT` is a [`DictType`] marker that fixes the key type ([`DictType::K`]),
-/// value type ([`DictType::V`]), and the underlying C `dictType` callbacks.
+/// value type ([`DictType::V`]), pointer conversions, and the underlying C
+/// `dictType` callbacks.
+///
+/// `'val` is the minimum lifetime of values stored in this dict. All values
+/// passed to [`Dict::insert`] must be valid for at least `'val`, which the
+/// compiler enforces. This prevents dangling references when values are read
+/// back via [`Dict::iter`].
 ///
 /// Obtained from a raw `*const`/`*mut ffi::dict` via [`Dict::from_raw`] /
 /// [`Dict::from_raw_mut`]. For an owned dict that is released on drop, use
 /// [`OwnedDict`].
 #[repr(transparent)]
-pub struct Dict<DT: DictType> {
+pub struct Dict<'val, DT: DictType> {
     inner: ffi::dict,
-    _phantom: PhantomData<DT>,
+    _phantom: PhantomData<(DT, DT::V<'val>)>,
 }
 
-impl<DT: DictType> Dict<DT> {
+impl<'val, DT: DictType> Dict<'val, DT> {
     /// Borrow a [`Dict`] from a raw const pointer.
     ///
     /// # Safety
     ///
     /// `ptr` must be a valid, non-null pointer to an `ffi::dict` created with
     /// the `ffi::dictType` described by `DT`, and must remain live for `'a`.
+    /// `'val` must not outlive the lifetimes of any values stored in the dict.
     pub const unsafe fn from_raw<'a>(ptr: *const ffi::dict) -> &'a Self {
         // SAFETY: #[repr(transparent)] guarantees identical layout.
         // Validity and liveness are the caller's responsibility.
@@ -175,8 +137,9 @@ impl<DT: DictType> Dict<DT> {
     /// # Safety
     ///
     /// `ptr` must be a valid, non-null pointer to an `ffi::dict` created with
-    /// the `ffi::dictType` described by `DT`, must remain live for `'a`, and
-    /// must have no other aliasing references for the duration.
+    /// the `ffi::dictType` described by `DT`, must remain live for `'a`, must
+    /// have no other aliasing references for the duration, and `'val` must not
+    /// outlive the lifetimes of any values stored in the dict.
     pub const unsafe fn from_raw_mut<'a>(ptr: *mut ffi::dict) -> &'a mut Self {
         // SAFETY: #[repr(transparent)] guarantees identical layout.
         // Validity, liveness, and exclusivity are the caller's responsibility.
@@ -197,17 +160,27 @@ impl<DT: DictType> Dict<DT> {
     ///
     /// Returns `true` when the entry was added, `false` when the key already
     /// existed (the existing entry is not updated).
-    pub fn insert<'b>(&mut self, key: DT::K<'b>, val: DT::V<'b>) -> bool {
-        // SAFETY: self points to a valid dict; key and val lifetimes are managed
-        // by the dictType's dup/destructor callbacks.
-        unsafe { ffi::RS_dictAdd(self.as_mut_ptr(), key.into_dict_ptr(), val.into_dict_ptr()) == 0 }
+    ///
+    /// The key lifetime is unconstrained because the underlying `dictType` is
+    /// required (by the [`DictType`] safety contract) to copy keys on insertion.
+    /// The value must be valid for `'val` — the dict's value lifetime — so that
+    /// values read back via [`Dict::iter`] are never dangling.
+    pub fn insert(&mut self, key: DT::K<'_>, val: DT::V<'val>) -> bool {
+        // SAFETY: self points to a valid dict; key is copied by the dictType's
+        // keyDup; val lifetime is enforced to be 'val by the type signature.
+        unsafe {
+            ffi::RS_dictAdd(
+                self.as_mut_ptr(),
+                DT::key_into_ptr(key),
+                DT::val_into_ptr(val),
+            ) == 0
+        }
     }
 
     /// Iterate over all entries in this dict.
     ///
     /// Each entry is yielded as a [`DictEntry`] whose [`DictEntry::key`] and
-    /// [`DictEntry::val`] return the typed key and value directly — no manual
-    /// casts or wrapper constructions required.
+    /// [`DictEntry::val`] return the typed key and value directly.
     ///
     /// The iterator holds a C-side iterator object and releases it on drop,
     /// so it is safe to abandon iteration early.
@@ -222,20 +195,20 @@ impl<DT: DictType> Dict<DT> {
 
 /// An owned [`Dict`] that calls `RS_dictRelease` on drop.
 ///
-/// Obtained via [`OwnedDict::create`]. Derefs to [`Dict<DT>`] so all
+/// `'val` is the minimum lifetime of values stored in this dict; see
+/// [`Dict`] for details.
+///
+/// Obtained via [`OwnedDict::create`]. Derefs to [`Dict<'val, DT>`] so all
 /// [`Dict`] methods — including [`iter`](Dict::iter) and
 /// [`insert`](Dict::insert) — are available on `&OwnedDict` and
 /// `&mut OwnedDict` respectively.
-pub struct OwnedDict<DT: DictType> {
+pub struct OwnedDict<'val, DT: DictType> {
     ptr: NonNull<ffi::dict>,
-    _phantom: PhantomData<DT>,
+    _phantom: PhantomData<(DT, DT::V<'val>)>,
 }
 
-impl<DT: DictType> OwnedDict<DT> {
+impl<'val, DT: DictType> OwnedDict<'val, DT> {
     /// Allocate a new C dict for the configuration described by `DT`.
-    ///
-    /// The dictType pointer and the guarantee that its callbacks are compatible
-    /// with `DT::K` and `DT::V` are encoded in the `unsafe impl DictType`.
     pub fn create() -> Self {
         // SAFETY: DT::as_ptr() is guaranteed by the unsafe DictType impl to
         // return a valid, compatible ffi::dictType*.
@@ -252,25 +225,26 @@ impl<DT: DictType> OwnedDict<DT> {
     }
 }
 
-impl<DT: DictType> Deref for OwnedDict<DT> {
-    type Target = Dict<DT>;
+impl<'val, DT: DictType> Deref for OwnedDict<'val, DT> {
+    type Target = Dict<'val, DT>;
 
-    fn deref(&self) -> &Dict<DT> {
+    fn deref(&self) -> &Dict<'val, DT> {
         // SAFETY: self.ptr is a valid, non-null dict alive for the lifetime of
-        // this OwnedDict.
+        // this OwnedDict. 'val matches the OwnedDict's own 'val invariant.
         unsafe { Dict::from_raw(self.ptr.as_ptr()) }
     }
 }
 
-impl<DT: DictType> DerefMut for OwnedDict<DT> {
-    fn deref_mut(&mut self) -> &mut Dict<DT> {
+impl<'val, DT: DictType> DerefMut for OwnedDict<'val, DT> {
+    fn deref_mut(&mut self) -> &mut Dict<'val, DT> {
         // SAFETY: self.ptr is a valid, non-null dict alive for the lifetime of
         // this OwnedDict, and we hold exclusive access via &mut self.
+        // 'val matches the OwnedDict's own 'val invariant.
         unsafe { Dict::from_raw_mut(self.ptr.as_ptr()) }
     }
 }
 
-impl<DT: DictType> Drop for OwnedDict<DT> {
+impl<'val, DT: DictType> Drop for OwnedDict<'val, DT> {
     fn drop(&mut self) {
         // SAFETY: self.ptr was obtained from RS_dictCreate and has not been
         // released yet.
@@ -278,42 +252,7 @@ impl<DT: DictType> Drop for OwnedDict<DT> {
     }
 }
 
-/// A single entry in a [`Dict`], yielded by [`DictIterator`].
-///
-/// `'a` is the lifetime of the underlying dict data.
-pub struct DictEntry<'a, DT: DictType> {
-    entry: *mut ffi::dictEntry,
-    _phantom: PhantomData<(&'a (), DT)>,
-}
-
-impl<'a, DT: DictType> DictEntry<'a, DT> {
-    const fn new(entry: *mut ffi::dictEntry) -> Self {
-        Self {
-            entry,
-            _phantom: PhantomData,
-        }
-    }
-
-    /// Return the key of this entry.
-    pub fn key(&self) -> DT::K<'a> {
-        // SAFETY: self.entry is a valid non-null dictEntry*.
-        let ptr = unsafe { (*self.entry).key };
-        // SAFETY: ptr is the key of a valid dictEntry, consistent with DT::K.
-        unsafe { <DT::K<'a> as DictValue<'a>>::from_dict_ptr(ptr) }
-    }
-
-    /// Return the value of this entry.
-    pub fn val(&self) -> DT::V<'a> {
-        // SAFETY: self.entry is a valid non-null dictEntry*.
-        let v = unsafe { &(*self.entry).v };
-        // SAFETY: v.val is the value pointer of a valid dictEntry, consistent with DT::V.
-        let ptr = unsafe { v.val };
-        // SAFETY: ptr is a valid value pointer consistent with DT::V.
-        unsafe { <DT::V<'a> as DictValue<'a>>::from_dict_ptr(ptr) }
-    }
-}
-
-/// An iterator over the entries of a C [`ffi::dict`].
+/// An iterator over the entries of a [`Dict`].
 ///
 /// `'a` is the lifetime of the underlying dict data.  Wraps
 /// [`ffi::RS_dictGetIterator`] / [`ffi::RS_dictNext`] /
@@ -326,8 +265,6 @@ pub struct DictIterator<'a, DT: DictType> {
 
 impl<'a, DT: DictType> DictIterator<'a, DT> {
     /// Create an iterator directly from a raw `dict*`.
-    ///
-    /// Prefer [`Dict::iter`] when a [`Dict`] reference is available.
     ///
     /// # Safety
     ///
@@ -352,7 +289,9 @@ impl<'a, DT: DictType> Iterator for DictIterator<'a, DT> {
         if entry.is_null() {
             None
         } else {
-            Some(DictEntry::new(entry))
+            // SAFETY: RS_dictNext returns a valid, non-null dictEntry* consistent
+            // with DT, and it remains valid for 'a (the dict borrow lifetime).
+            Some(unsafe { DictEntry::new(entry) })
         }
     }
 }
@@ -361,5 +300,46 @@ impl<DT: DictType> Drop for DictIterator<'_, DT> {
     fn drop(&mut self) {
         // SAFETY: self.iter is a valid iterator obtained during construction.
         unsafe { ffi::RS_dictReleaseIterator(self.iter) };
+    }
+}
+
+/// A single entry in a [`Dict`], yielded by [`DictIterator`].
+///
+/// `'a` is the lifetime of the underlying dict data.
+pub struct DictEntry<'a, DT: DictType> {
+    entry: *mut ffi::dictEntry,
+    _phantom: PhantomData<(&'a (), DT)>,
+}
+
+impl<'a, DT: DictType> DictEntry<'a, DT> {
+    /// Wrap a raw `dictEntry*` as a [`DictEntry`].
+    ///
+    /// # Safety
+    ///
+    /// `entry` must be a valid, non-null pointer to a `dictEntry` whose key
+    /// and value are consistent with `DT`, and must remain valid for `'a`.
+    const unsafe fn new(entry: *mut ffi::dictEntry) -> Self {
+        Self {
+            entry,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Return the key of this entry.
+    pub fn key(&self) -> DT::K<'a> {
+        // SAFETY: self.entry is a valid non-null dictEntry*.
+        let ptr = unsafe { (*self.entry).key };
+        // SAFETY: ptr is the key of a valid dictEntry, consistent with DT::K.
+        unsafe { DT::key_from_ptr(ptr) }
+    }
+
+    /// Return the value of this entry.
+    pub fn val(&self) -> DT::V<'a> {
+        // SAFETY: self.entry is a valid non-null dictEntry*.
+        let v = unsafe { &(*self.entry).v };
+        // SAFETY: v.val is the value pointer of a valid dictEntry, consistent with DT::V.
+        let ptr = unsafe { v.val };
+        // SAFETY: ptr is the value of a valid dictEntry, consistent with DT::V.
+        unsafe { DT::val_from_ptr(ptr) }
     }
 }

--- a/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
@@ -41,6 +41,11 @@ impl<'a> HiddenStringRef<'a> {
         )
     }
 
+    /// Return the raw pointer to the underlying [`ffi::HiddenString`].
+    pub fn as_ptr(self) -> *mut ffi::HiddenString {
+        self.0.as_ptr()
+    }
+
     /// Get the secret (aka. "unsafe" in C land) value from the underlying [`ffi::HiddenString`].
     ///
     /// This is safe **only if** the C function returns a pointer that stays valid

--- a/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
@@ -42,7 +42,7 @@ impl<'a> HiddenStringRef<'a> {
     }
 
     /// Return the raw pointer to the underlying [`ffi::HiddenString`].
-    pub fn as_ptr(self) -> *mut ffi::HiddenString {
+    pub const fn as_ptr(self) -> *mut ffi::HiddenString {
         self.0.as_ptr()
     }
 

--- a/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
@@ -42,7 +42,7 @@ impl<'a> HiddenStringRef<'a> {
     }
 
     /// Return the raw pointer to the underlying [`ffi::HiddenString`].
-    pub const fn as_ptr(self) -> *mut ffi::HiddenString {
+    pub const fn as_ptr(&self) -> *mut ffi::HiddenString {
         self.0.as_ptr()
     }
 

--- a/src/redisearch_rs/c_wrappers/index_spec/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/index_spec/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 dict.workspace = true
 ffi.workspace = true
 field_spec.workspace = true
-hidden_string.workspace = true
 inverted_index.workspace = true
 rqe_core.workspace = true
 schema_rule.workspace = true

--- a/src/redisearch_rs/c_wrappers/index_spec/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/index_spec/Cargo.toml
@@ -9,8 +9,10 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+dict.workspace = true
 ffi.workspace = true
 field_spec.workspace = true
+hidden_string.workspace = true
 inverted_index.workspace = true
 rqe_core.workspace = true
 schema_rule.workspace = true

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -17,9 +17,8 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-use dict::Dict;
+use dict::{Dict, MissingFieldDictType};
 use field_spec::FieldSpec;
-use hidden_string::HiddenStringRef;
 use inverted_index::opaque::InvertedIndex;
 use schema_rule::SchemaRule;
 
@@ -298,17 +297,18 @@ impl<'lock> IndexSpecReadGuard<'lock> {
         })
     }
 
-    /// Return the dict of inverted indexes for fields that are missing from a document.
+    /// Return the spec's `missingFieldDict` as a typed [`Dict`].
     ///
-    /// Keys are [`HiddenStringRef`] wrappers; values are `Option<&InvertedIndex>`,
-    /// where `None` indicates the field has no recorded missing-doc index.
-    pub fn missing_field_dict2(&self) -> &Dict<HiddenStringRef<'_>, Option<&'_ InvertedIndex>> {
+    /// Keys are field names ([`HiddenStringRef`]); values are the per-field
+    /// missing-doc inverted index (`None` when no such index exists).
+    pub fn missing_field_dict2(&self) -> &Dict<MissingFieldDictType> {
         debug_assert!(
             !self.0.missingFieldDict.is_null(),
             "missingFieldDict must not be null"
         );
-        // SAFETY: missingFieldDict is a valid non-null dict* for a properly
-        // initialised IndexSpec (invariant upheld by construction).
+        // SAFETY: missingFieldDict is a valid non-null dict* created with
+        // dictTypeHeapHiddenStrings (MissingFieldDictType::as_ptr()), so
+        // interpreting it as Dict<MissingFieldDictType> is sound.
         unsafe { Dict::from_raw(self.0.missingFieldDict) }
     }
 

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -298,9 +298,6 @@ impl<'lock> IndexSpecReadGuard<'lock> {
     }
 
     /// Return the spec's `missingFieldDict` as a typed [`Dict`].
-    ///
-    /// Keys are field names ([`HiddenStringRef`]); values are the per-field
-    /// missing-doc inverted index (`None` when no such index exists).
     pub fn missing_field_dict(&self) -> &Dict<MissingFieldDictType> {
         debug_assert!(
             !self.0.missingFieldDict.is_null(),

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -298,7 +298,7 @@ impl<'lock> IndexSpecReadGuard<'lock> {
     }
 
     /// Return the spec's `missingFieldDict` as a typed [`Dict`].
-    pub fn missing_field_dict<'a>(&'a self) -> &'a Dict<'a, MissingFieldDictType> {
+    pub fn missing_field_dict(&self) -> &Dict<MissingFieldDictType> {
         debug_assert!(
             !self.0.missingFieldDict.is_null(),
             "missingFieldDict must not be null"

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -17,7 +17,9 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
+use dict::Dict;
 use field_spec::FieldSpec;
+use hidden_string::HiddenStringRef;
 use inverted_index::opaque::InvertedIndex;
 use schema_rule::SchemaRule;
 
@@ -294,6 +296,20 @@ impl<'lock> IndexSpecReadGuard<'lock> {
             // SAFETY: existingDocs is a valid, non-null pointer to an opaque InvertedIndex.
             unsafe { existing_docs.cast::<InvertedIndex>().as_ref() }
         })
+    }
+
+    /// Return the dict of inverted indexes for fields that are missing from a document.
+    ///
+    /// Keys are [`HiddenStringRef`] wrappers; values are `Option<&InvertedIndex>`,
+    /// where `None` indicates the field has no recorded missing-doc index.
+    pub fn missing_field_dict2(&self) -> &Dict<HiddenStringRef<'_>, Option<&'_ InvertedIndex>> {
+        debug_assert!(
+            !self.0.missingFieldDict.is_null(),
+            "missingFieldDict must not be null"
+        );
+        // SAFETY: missingFieldDict is a valid non-null dict* for a properly
+        // initialised IndexSpec (invariant upheld by construction).
+        unsafe { Dict::from_raw(self.0.missingFieldDict) }
     }
 
     /// Returns whether the keys dictionary is available.

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -298,7 +298,7 @@ impl<'lock> IndexSpecReadGuard<'lock> {
     }
 
     /// Return the spec's `missingFieldDict` as a typed [`Dict`].
-    pub fn missing_field_dict(&self) -> &Dict<MissingFieldDictType> {
+    pub fn missing_field_dict<'a>(&'a self) -> &'a Dict<'a, MissingFieldDictType> {
         debug_assert!(
             !self.0.missingFieldDict.is_null(),
             "missingFieldDict must not be null"

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -301,7 +301,7 @@ impl<'lock> IndexSpecReadGuard<'lock> {
     ///
     /// Keys are field names ([`HiddenStringRef`]); values are the per-field
     /// missing-doc inverted index (`None` when no such index exists).
-    pub fn missing_field_dict2(&self) -> &Dict<MissingFieldDictType> {
+    pub fn missing_field_dict(&self) -> &Dict<MissingFieldDictType> {
         debug_assert!(
             !self.0.missingFieldDict.is_null(),
             "missingFieldDict must not be null"
@@ -339,7 +339,7 @@ impl<'lock> IndexSpecReadGuard<'lock> {
     /// Returns a pointer to the missing field dictionary.
     ///
     /// This dictionary maps field names to their missing-value inverted indexes.
-    pub const fn missing_field_dict(&self) -> *mut ffi::dict {
+    pub const fn missing_field_dict_ptr(&self) -> *mut ffi::dict {
         self.0.missingFieldDict
     }
 

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -487,10 +487,14 @@ const HEADERS: &[HeaderAllowlist] = &[
     HeaderAllowlist {
         path: "src/util/dict/dict.h",
         fns: &[
+            "dictIterator",
             "RS_dictAdd",
             "RS_dictDelete",
             "RS_dictFetchValue",
+            "RS_dictGetIterator",
+            "RS_dictNext",
             "RS_dictRelease",
+            "RS_dictReleaseIterator",
         ],
         types: &[],
         vars: &[],

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -489,6 +489,7 @@ const HEADERS: &[HeaderAllowlist] = &[
         fns: &[
             "dictIterator",
             "RS_dictAdd",
+            "RS_dictCreate",
             "RS_dictDelete",
             "RS_dictFetchValue",
             "RS_dictGetIterator",
@@ -496,8 +497,8 @@ const HEADERS: &[HeaderAllowlist] = &[
             "RS_dictRelease",
             "RS_dictReleaseIterator",
         ],
-        types: &[],
-        vars: &[],
+        types: &["dictType"],
+        vars: &["dictTypeHeapHiddenStrings"],
     },
     HeaderAllowlist {
         path: "src/util/references.h",

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -434,7 +434,7 @@ const HEADERS: &[HeaderAllowlist] = &[
             "IndexSpecRef_Release",
         ],
         types: &[],
-        vars: &["isCrdt"],
+        vars: &["isCrdt", "missingFieldDictType"],
     },
     HeaderAllowlist {
         path: "src/stopwords.h",

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -489,6 +489,7 @@ const HEADERS: &[HeaderAllowlist] = &[
         fns: &[
             "dictIterator",
             "RS_dictAdd",
+            "RS_dictAddRaw",
             "RS_dictCreate",
             "RS_dictDelete",
             "RS_dictFetchValue",

--- a/src/redisearch_rs/fork_gc/Cargo.toml
+++ b/src/redisearch_rs/fork_gc/Cargo.toml
@@ -31,6 +31,7 @@ workspace_hack.workspace = true
 [dev-dependencies]
 dict = { workspace = true }
 ffi = { workspace = true }
+hidden_string = { workspace = true }
 index_result = { workspace = true }
 inverted_index = { workspace = true, features = ["test_utils"] }
 rqe_core = { workspace = true }

--- a/src/redisearch_rs/fork_gc/Cargo.toml
+++ b/src/redisearch_rs/fork_gc/Cargo.toml
@@ -10,8 +10,6 @@ test = false
 doctest = false
 
 [features]
-# Activated by the self dev-dependency below so that build.rs links the C
-# library when compiling tests. See https://github.com/rust-lang/cargo/issues/4789
 unittest = []
 
 [build-dependencies]
@@ -21,11 +19,11 @@ build_utils = { path = "../build_utils" }
 workspace = true
 
 [dependencies]
-ffi = { workspace = true }
-inverted_index = { workspace = true }
-libc = { workspace = true }
-nix = { workspace = true }
-redis-module = { workspace = true }
+ffi.workspace = true
+inverted_index.workspace = true
+libc.workspace = true
+nix.workspace = true
+redis-module.workspace = true
 rmp-serde.workspace = true
 index_spec.workspace = true
 serde.workspace = true
@@ -33,14 +31,13 @@ tracing.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]
-dict = { workspace = true }
-ffi = { workspace = true }
-hidden_string = { workspace = true }
-index_result = { workspace = true }
+dict.workspace = true
+ffi.workspace = true
+hidden_string.workspace = true
+index_result.workspace = true
 inverted_index = { workspace = true, features = ["test_utils"] }
 rqe_core = { workspace = true }
 # Self-dependency activates the `unittest` feature so build.rs links the C library.
 fork_gc = { path = ".", features = ["unittest"] }
-# Provides FFI symbol guards and the mock Redis allocator.
 redisearch_rs = { path = "../c_entrypoint/redisearch_rs", features = ["mock_allocator"] }
-redis_mock = { workspace = true }
+redis_mock.workspace = true

--- a/src/redisearch_rs/fork_gc/Cargo.toml
+++ b/src/redisearch_rs/fork_gc/Cargo.toml
@@ -5,6 +5,14 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[features]
+# Activated by the self dev-dependency below so that build.rs links the C
+# library when compiling tests. See https://github.com/rust-lang/cargo/issues/4789
+unittest = []
+
+[build-dependencies]
+build_utils = { path = "../build_utils" }
+
 [lints]
 workspace = true
 
@@ -21,7 +29,13 @@ tracing.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]
+dict = { workspace = true }
 ffi = { workspace = true }
 index_result = { workspace = true }
 inverted_index = { workspace = true, features = ["test_utils"] }
 rqe_core = { workspace = true }
+# Self-dependency activates the `unittest` feature so build.rs links the C library.
+fork_gc = { path = ".", features = ["unittest"] }
+# Provides FFI symbol guards and the mock Redis allocator.
+redisearch_rs = { path = "../c_entrypoint/redisearch_rs", features = ["mock_allocator"] }
+redis_mock = { workspace = true }

--- a/src/redisearch_rs/fork_gc/Cargo.toml
+++ b/src/redisearch_rs/fork_gc/Cargo.toml
@@ -5,6 +5,10 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+test = false
+doctest = false
+
 [features]
 # Activated by the self dev-dependency below so that build.rs links the C
 # library when compiling tests. See https://github.com/rust-lang/cargo/issues/4789

--- a/src/redisearch_rs/fork_gc/build.rs
+++ b/src/redisearch_rs/fork_gc/build.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+fn main() {
+    #[cfg(feature = "unittest")]
+    build_utils::bind_foreign_c_symbols();
+}

--- a/src/redisearch_rs/fork_gc/src/lib.rs
+++ b/src/redisearch_rs/fork_gc/src/lib.rs
@@ -19,6 +19,7 @@ pub mod existing_docs;
 pub mod fork_gc;
 pub mod frame;
 pub mod io_result_ext;
+pub mod missing_docs;
 pub mod util;
 
 pub use fork_gc::ForkGC;

--- a/src/redisearch_rs/fork_gc/src/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/src/missing_docs.rs
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Child-side GC collection for the `missingFieldDict` inverted indexes.
+
+use std::io::{self, Write};
+
+use index_spec::IndexSpecReadGuard;
+use serde::Serialize as _;
+
+use crate::Frame;
+
+/// Collect GC deltas for every entry in the spec's `missingFieldDict` and write
+/// them to the parent process.
+///
+/// Iterates the dict and, for each entry with a non-null inverted index,
+/// attempts a GC scan. When a scan produces a delta the field-name header
+/// followed by the serialised [`GcScanDelta`] is written. Entries that produce
+/// no delta or fail the scan are skipped. A terminator is written once all
+/// entries are processed.
+///
+/// Scan errors are silently ignored (same block is retried on the next GC
+/// cycle). Write errors are surfaced to the caller so they can terminate the
+/// child process.
+///
+/// [`GcScanDelta`]: inverted_index::GcScanDelta
+pub fn collect_missing_docs(writer: &mut impl Write, spec: &IndexSpecReadGuard) -> io::Result<()> {
+    let doc_exists = |id| spec.doc_exists(id);
+
+    for entry in spec.missing_field_dict2().iter() {
+        let Some(ii) = entry.val() else { continue };
+
+        let Ok(Some(deltas)) = ii.scan_gc(doc_exists) else {
+            continue;
+        };
+
+        let field_name = entry.key().into_secret_value();
+        Frame::data(field_name.to_bytes()).encode(writer)?;
+        deltas
+            .serialize(&mut rmp_serde::Serializer::new(&mut *writer))
+            .map_err(io::Error::other)?;
+    }
+
+    Frame::Terminator.encode(writer)
+}

--- a/src/redisearch_rs/fork_gc/src/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/src/missing_docs.rs
@@ -33,7 +33,7 @@ use crate::Frame;
 pub fn collect_missing_docs(writer: &mut impl Write, spec: &IndexSpecReadGuard) -> io::Result<()> {
     let doc_exists = |id| spec.doc_exists(id);
 
-    for entry in spec.missing_field_dict2().iter() {
+    for entry in spec.missing_field_dict().iter() {
         let Some(ii) = entry.val() else { continue };
 
         let Ok(Some(deltas)) = ii.scan_gc(doc_exists) else {

--- a/src/redisearch_rs/fork_gc/src/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/src/missing_docs.rs
@@ -34,9 +34,7 @@ pub fn collect_missing_docs(writer: &mut impl Write, spec: &IndexSpecReadGuard) 
     let doc_exists = |id| spec.doc_exists(id);
 
     for entry in spec.missing_field_dict().iter() {
-        let Some(ii) = entry.val() else { continue };
-
-        let Ok(Some(deltas)) = ii.scan_gc(doc_exists) else {
+        let Ok(Some(deltas)) = entry.val().scan_gc(doc_exists) else {
             continue;
         };
 

--- a/src/redisearch_rs/fork_gc/tests/existing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/existing_docs.rs
@@ -22,6 +22,8 @@ use inverted_index::opaque::InvertedIndex as OpaqueInvertedIndex;
 use inverted_index::{GcScanDelta, InvertedIndex, doc_ids_only::DocIdsOnly};
 use serde::Serialize as _;
 
+// Link both Rust-provided and C-provided symbols
+extern crate redisearch_rs;
 // Provide Redis allocator shims so the C dict functions can allocate memory.
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 

--- a/src/redisearch_rs/fork_gc/tests/existing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/existing_docs.rs
@@ -81,6 +81,7 @@ fn empty_existing_docs_writes_only_terminator() {
 /// (stub returns false), `scan_gc` produces a delta. The output is an Empty
 /// frame, the serialised [`GcScanDelta`], then a Terminator.
 #[test]
+#[cfg_attr(miri, ignore = "calls FFI function `DocTable_Exists`")]
 fn existing_docs_with_deleted_entries_writes_delta() {
     let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
     ii.add_record(&RSIndexResult::build_virt().doc_id(1).build())
@@ -154,6 +155,7 @@ fn apply_returns_err_when_existing_docs_absent() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "calls FFI function `DocTable_Exists`")]
 fn roundtrip_all_docs_deleted_clears_index() {
     let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
     ii.add_record(&RSIndexResult::build_virt().doc_id(1).build())

--- a/src/redisearch_rs/fork_gc/tests/existing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/existing_docs.rs
@@ -22,14 +22,6 @@ use inverted_index::opaque::InvertedIndex as OpaqueInvertedIndex;
 use inverted_index::{GcScanDelta, InvertedIndex, doc_ids_only::DocIdsOnly};
 use serde::Serialize as _;
 
-// `collect_existing_docs` calls `spec.doc_exists()`, which calls `DocTable_Exists`
-// from the C library. That symbol is unavailable in pure-Rust test binaries, so we
-// provide a stub that always returns `false` (every doc treated as absent).
-#[unsafe(no_mangle)]
-unsafe extern "C" fn DocTable_Exists(_: *const ffi::DocTable, _: rqe_core::DocId) -> bool {
-    false
-}
-
 fn make_spec(existing_docs: *mut ffi::InvertedIndex) -> ffi::IndexSpec {
     // SAFETY: zeroed IndexSpec is valid for read-only access; existingDocs is
     // either null or a caller-managed pointer that outlives this struct.

--- a/src/redisearch_rs/fork_gc/tests/existing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/existing_docs.rs
@@ -22,6 +22,9 @@ use inverted_index::opaque::InvertedIndex as OpaqueInvertedIndex;
 use inverted_index::{GcScanDelta, InvertedIndex, doc_ids_only::DocIdsOnly};
 use serde::Serialize as _;
 
+// Provide Redis allocator shims so the C dict functions can allocate memory.
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
 fn make_spec(existing_docs: *mut ffi::InvertedIndex) -> ffi::IndexSpec {
     // SAFETY: zeroed IndexSpec is valid for read-only access; existingDocs is
     // either null or a caller-managed pointer that outlives this struct.

--- a/src/redisearch_rs/fork_gc/tests/fork_gc.rs
+++ b/src/redisearch_rs/fork_gc/tests/fork_gc.rs
@@ -19,6 +19,11 @@ use std::{
     time::Duration,
 };
 
+// Link both Rust-provided and C-provided symbols
+extern crate redisearch_rs;
+// Provide Redis allocator shims so the C dict functions can allocate memory.
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
 /// Construct a zeroed [`ffi::ForkGC`] backed by a real pipe pair.
 ///
 /// Returns the raw struct together with the [`io::PipeReader`] and

--- a/src/redisearch_rs/fork_gc/tests/frame.rs
+++ b/src/redisearch_rs/fork_gc/tests/frame.rs
@@ -10,6 +10,11 @@
 use fork_gc::Frame;
 use std::io::{self, Cursor};
 
+// Link both Rust-provided and C-provided symbols
+extern crate redisearch_rs;
+// Provide Redis allocator shims so the C dict functions can allocate memory.
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
 #[test]
 fn read_returns_data_frame_for_length_prefixed_payload() {
     let mut bytes = Vec::new();

--- a/src/redisearch_rs/fork_gc/tests/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/missing_docs.rs
@@ -26,13 +26,14 @@ redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
 /// Add one entry to `dict` keyed by `field_name`, with value `ii`.
 ///
-/// `MissingFieldDictType` uses `dictTypeHeapHiddenStrings`, which copies the
-/// key via `keyDup`, so the temporary `HiddenString` can be freed immediately
-/// after insertion.
-fn add_entry<'a>(
-    dict: &mut OwnedDict<'a, MissingFieldDictType>,
+/// `MissingFieldDictType` uses `missingFieldDictType`, which copies the key via
+/// `keyDup` and owns the value via `valDestructor` (→ `InvertedIndex_Free`).
+/// The temporary `HiddenString` key is freed immediately after insertion;
+/// ownership of `ii` is transferred to the dict.
+fn add_entry(
+    dict: &mut OwnedDict<MissingFieldDictType>,
     field_name: &[u8],
-    ii: Option<&'a OpaqueInvertedIndex>,
+    ii: Box<OpaqueInvertedIndex>,
 ) {
     // SAFETY: NewHiddenString copies `field_name`; the dict's keyDup copies
     // the HiddenString itself, so we free the original immediately after insert.
@@ -45,13 +46,13 @@ fn add_entry<'a>(
 fn make_spec(dict: &OwnedDict<MissingFieldDictType>) -> ffi::IndexSpec {
     // SAFETY: zeroed IndexSpec is valid for read-only field access through the guard.
     let mut spec: ffi::IndexSpec = unsafe { mem::zeroed() };
-    spec.missingFieldDict = dict.as_ptr();
+    spec.missingFieldDict = dict.as_mut_ptr();
     spec
 }
 
 /// When the dict has no entries, only a Terminator is written.
 #[test]
-#[cfg_attr(miri, ignore = "accesses extern static `dictTypeHeapHiddenStrings`")]
+#[cfg_attr(miri, ignore = "accesses extern static `missingFieldDictType`")]
 fn empty_dict_writes_only_terminator() {
     let dict = OwnedDict::create();
     let spec = make_spec(&dict);
@@ -67,36 +68,16 @@ fn empty_dict_writes_only_terminator() {
     ));
 }
 
-/// Entries whose value is `None` (no inverted index) are skipped silently.
-#[test]
-#[cfg_attr(miri, ignore = "accesses extern static `dictTypeHeapHiddenStrings`")]
-fn null_value_entry_is_skipped() {
-    let mut dict = OwnedDict::create();
-    add_entry(&mut dict, b"no_index_field", None);
-    let spec = make_spec(&dict);
-    let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
-
-    let mut buf = Vec::new();
-    collect_missing_docs(&mut buf, &*guard).unwrap();
-
-    let mut cursor = Cursor::new(&buf);
-    assert!(matches!(
-        Frame::decode(&mut cursor).unwrap(),
-        Frame::Terminator
-    ));
-}
-
 /// An entry whose inverted index is empty produces no delta, so it is skipped.
 #[test]
-#[cfg_attr(miri, ignore = "accesses extern static `dictTypeHeapHiddenStrings`")]
+#[cfg_attr(miri, ignore = "accesses extern static `missingFieldDictType`")]
 fn empty_inverted_index_is_skipped() {
     let ii = Box::new(OpaqueInvertedIndex::DocIdsOnly(
         InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
     ));
-    let ii_ptr = Box::into_raw(ii);
 
     let mut dict = OwnedDict::create();
-    add_entry(&mut dict, b"empty_field", Some(unsafe { &*ii_ptr }));
+    add_entry(&mut dict, b"empty_field", ii);
     let spec = make_spec(&dict);
     let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
 
@@ -108,9 +89,6 @@ fn empty_inverted_index_is_skipped() {
         Frame::decode(&mut cursor).unwrap(),
         Frame::Terminator
     ));
-
-    // SAFETY: dict does not free values; ii_ptr was created via Box::into_raw.
-    unsafe { drop(Box::from_raw(ii_ptr)) };
 }
 
 /// When an entry has docs absent from the DocTable, `scan_gc` produces a delta.
@@ -120,7 +98,7 @@ fn empty_inverted_index_is_skipped() {
 /// The spec's `DocTable` is zeroed, so `DocTable_Exists` returns `false` for
 /// every doc ID — every recorded doc is treated as deleted.
 #[test]
-#[cfg_attr(miri, ignore = "accesses extern static `dictTypeHeapHiddenStrings`")]
+#[cfg_attr(miri, ignore = "accesses extern static `missingFieldDictType`")]
 fn entry_with_deleted_docs_writes_delta_frame() {
     let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
     ii.add_record(&RSIndexResult::build_virt().doc_id(1).build())
@@ -128,10 +106,9 @@ fn entry_with_deleted_docs_writes_delta_frame() {
     ii.add_record(&RSIndexResult::build_virt().doc_id(2).build())
         .unwrap();
     let ii = Box::new(OpaqueInvertedIndex::DocIdsOnly(ii));
-    let ii_ptr = Box::into_raw(ii);
 
     let mut dict = OwnedDict::create();
-    add_entry(&mut dict, b"age", Some(unsafe { &*ii_ptr }));
+    add_entry(&mut dict, b"age", ii);
     let spec = make_spec(&dict);
     let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
 
@@ -152,29 +129,23 @@ fn entry_with_deleted_docs_writes_delta_frame() {
         Frame::decode(&mut cursor).unwrap(),
         Frame::Terminator
     ));
-
-    // SAFETY: dict does not free values; ii_ptr was created via Box::into_raw.
-    unsafe { drop(Box::from_raw(ii_ptr)) };
 }
 
 /// Multiple entries each produce their own Data frame + delta, followed by a
 /// single Terminator.
 #[test]
-#[cfg_attr(miri, ignore = "accesses extern static `dictTypeHeapHiddenStrings`")]
+#[cfg_attr(miri, ignore = "accesses extern static `missingFieldDictType`")]
 fn multiple_entries_write_multiple_delta_frames() {
     let make_ii = |doc_id| {
         let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
         ii.add_record(&RSIndexResult::build_virt().doc_id(doc_id).build())
             .unwrap();
-        Box::into_raw(Box::new(OpaqueInvertedIndex::DocIdsOnly(ii)))
+        Box::new(OpaqueInvertedIndex::DocIdsOnly(ii))
     };
 
-    let ii_a = make_ii(1);
-    let ii_b = make_ii(2);
-
     let mut dict = OwnedDict::create();
-    add_entry(&mut dict, b"field_a", Some(unsafe { &*ii_a }));
-    add_entry(&mut dict, b"field_b", Some(unsafe { &*ii_b }));
+    add_entry(&mut dict, b"field_a", make_ii(1));
+    add_entry(&mut dict, b"field_b", make_ii(2));
     let spec = make_spec(&dict);
     let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
 
@@ -200,10 +171,4 @@ fn multiple_entries_write_multiple_delta_frames() {
         Frame::decode(&mut cursor).unwrap(),
         Frame::Terminator
     ));
-
-    // SAFETY: dict does not free values; both ii pointers were created via Box::into_raw.
-    unsafe {
-        drop(Box::from_raw(ii_a));
-        drop(Box::from_raw(ii_b));
-    }
 }

--- a/src/redisearch_rs/fork_gc/tests/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/missing_docs.rs
@@ -51,6 +51,7 @@ fn make_spec(dict: &OwnedDict<MissingFieldDictType>) -> ffi::IndexSpec {
 
 /// When the dict has no entries, only a Terminator is written.
 #[test]
+#[cfg_attr(miri, ignore = "accesses extern static `dictTypeHeapHiddenStrings`")]
 fn empty_dict_writes_only_terminator() {
     let dict = OwnedDict::create();
     let spec = make_spec(&dict);
@@ -68,6 +69,7 @@ fn empty_dict_writes_only_terminator() {
 
 /// Entries whose value is `None` (no inverted index) are skipped silently.
 #[test]
+#[cfg_attr(miri, ignore = "accesses extern static `dictTypeHeapHiddenStrings`")]
 fn null_value_entry_is_skipped() {
     let mut dict = OwnedDict::create();
     add_entry(&mut dict, b"no_index_field", None);
@@ -86,6 +88,7 @@ fn null_value_entry_is_skipped() {
 
 /// An entry whose inverted index is empty produces no delta, so it is skipped.
 #[test]
+#[cfg_attr(miri, ignore = "accesses extern static `dictTypeHeapHiddenStrings`")]
 fn empty_inverted_index_is_skipped() {
     let ii = Box::new(OpaqueInvertedIndex::DocIdsOnly(
         InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
@@ -117,6 +120,7 @@ fn empty_inverted_index_is_skipped() {
 /// The spec's `DocTable` is zeroed, so `DocTable_Exists` returns `false` for
 /// every doc ID — every recorded doc is treated as deleted.
 #[test]
+#[cfg_attr(miri, ignore = "accesses extern static `dictTypeHeapHiddenStrings`")]
 fn entry_with_deleted_docs_writes_delta_frame() {
     let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
     ii.add_record(&RSIndexResult::build_virt().doc_id(1).build())
@@ -156,6 +160,7 @@ fn entry_with_deleted_docs_writes_delta_frame() {
 /// Multiple entries each produce their own Data frame + delta, followed by a
 /// single Terminator.
 #[test]
+#[cfg_attr(miri, ignore = "accesses extern static `dictTypeHeapHiddenStrings`")]
 fn multiple_entries_write_multiple_delta_frames() {
     let make_ii = |doc_id| {
         let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);

--- a/src/redisearch_rs/fork_gc/tests/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/missing_docs.rs
@@ -19,6 +19,8 @@ use index_spec::IndexSpecReadGuard;
 use inverted_index::opaque::InvertedIndex as OpaqueInvertedIndex;
 use inverted_index::{GcScanDelta, InvertedIndex, doc_ids_only::DocIdsOnly};
 
+// Link both Rust-provided and C-provided symbols
+extern crate redisearch_rs;
 // Provide Redis allocator shims so the C dict functions can allocate memory.
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 

--- a/src/redisearch_rs/fork_gc/tests/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/missing_docs.rs
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::{io::Cursor, mem, ptr};
+
+use dict::OwnedDict;
+use ffi::IndexFlags_Index_DocIdsOnly;
+use fork_gc::{Frame, missing_docs::collect_missing_docs};
+use index_result::RSIndexResult;
+use index_spec::IndexSpecReadGuard;
+use inverted_index::opaque::InvertedIndex as OpaqueInvertedIndex;
+use inverted_index::{GcScanDelta, InvertedIndex, doc_ids_only::DocIdsOnly};
+use serde::Serialize as _;
+
+// Provide Redis allocator shims so the C dict functions can allocate memory.
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+/// Create an [`OwnedDict`] using `dictTypeHeapHiddenStrings` — the same key
+/// type as a real `missingFieldDict`. The dict is released automatically when
+/// it goes out of scope. Values are NOT freed on drop because
+/// `dictTypeHeapHiddenStrings.valDestructor` is null.
+fn make_dict() -> OwnedDict {
+    // SAFETY: dictTypeHeapHiddenStrings is a valid static dictType.
+    unsafe { OwnedDict::create(ptr::addr_of_mut!(ffi::dictTypeHeapHiddenStrings)) }
+}
+
+/// Add one entry to `dict` keyed by `field_name`, with value `ii`.
+///
+/// `dictTypeHeapHiddenStrings` duplicates the key internally (via `keyDup`),
+/// so the temporary `HiddenString` is freed immediately after insertion.
+fn add_entry(dict: &mut OwnedDict, field_name: &[u8], ii: *mut std::ffi::c_void) {
+    // SAFETY: NewHiddenString copies `field_name` into a heap allocation; the
+    // dict's keyDup makes its own copy, so we free the original immediately.
+    let hs = unsafe { ffi::NewHiddenString(field_name.as_ptr().cast(), field_name.len(), false) };
+    dict.insert(hs.cast(), ii);
+    unsafe { ffi::HiddenString_Free(hs, false) };
+}
+
+fn make_spec(dict: &OwnedDict) -> ffi::IndexSpec {
+    // SAFETY: zeroed IndexSpec is valid for read-only field access through the guard.
+    let mut spec: ffi::IndexSpec = unsafe { mem::zeroed() };
+    spec.missingFieldDict = dict.as_ptr();
+    spec
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// When the dict has no entries, only a Terminator is written.
+#[test]
+fn empty_dict_writes_only_terminator() {
+    let dict = make_dict();
+    let spec = make_spec(&dict);
+    // SAFETY: spec borrows dict, which lives for the duration of this test.
+    let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
+
+    let mut buf = Vec::new();
+    collect_missing_docs(&mut buf, &*guard).unwrap();
+
+    let mut cursor = Cursor::new(&buf);
+    assert!(matches!(
+        Frame::decode(&mut cursor).unwrap(),
+        Frame::Terminator
+    ));
+}
+
+/// Entries whose value is null (no inverted index) are skipped silently.
+#[test]
+fn null_value_entry_is_skipped() {
+    let mut dict = make_dict();
+    add_entry(&mut dict, b"no_index_field", ptr::null_mut());
+    let spec = make_spec(&dict);
+    // SAFETY: spec borrows dict, which lives for the duration of this test.
+    let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
+
+    let mut buf = Vec::new();
+    collect_missing_docs(&mut buf, &*guard).unwrap();
+
+    let mut cursor = Cursor::new(&buf);
+    assert!(matches!(
+        Frame::decode(&mut cursor).unwrap(),
+        Frame::Terminator
+    ));
+}
+
+/// An entry whose inverted index is empty produces no delta, so it is skipped.
+#[test]
+fn empty_inverted_index_is_skipped() {
+    let ii = Box::new(OpaqueInvertedIndex::DocIdsOnly(
+        InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
+    ));
+    let ii_ptr = Box::into_raw(ii);
+
+    let mut dict = make_dict();
+    add_entry(&mut dict, b"empty_field", ii_ptr.cast());
+    let spec = make_spec(&dict);
+    // SAFETY: spec borrows dict; ii_ptr is valid for the duration of this test.
+    let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
+
+    let mut buf = Vec::new();
+    collect_missing_docs(&mut buf, &*guard).unwrap();
+
+    let mut cursor = Cursor::new(&buf);
+    assert!(matches!(
+        Frame::decode(&mut cursor).unwrap(),
+        Frame::Terminator
+    ));
+
+    // SAFETY: dict does not free values; ii_ptr was created via Box::into_raw.
+    unsafe { drop(Box::from_raw(ii_ptr)) };
+}
+
+/// When an entry has docs absent from the DocTable, `scan_gc` produces a delta.
+/// The output is a Data frame carrying the field name, the serialised
+/// [`GcScanDelta`], then a Terminator.
+///
+/// The spec's `DocTable` is zeroed, so `DocTable_Exists` returns `false` for
+/// every doc ID — every recorded doc is treated as deleted.
+#[test]
+fn entry_with_deleted_docs_writes_delta_frame() {
+    let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+    ii.add_record(&RSIndexResult::build_virt().doc_id(1).build())
+        .unwrap();
+    ii.add_record(&RSIndexResult::build_virt().doc_id(2).build())
+        .unwrap();
+    let ii = Box::new(OpaqueInvertedIndex::DocIdsOnly(ii));
+    let ii_ptr = Box::into_raw(ii);
+
+    let mut dict = make_dict();
+    add_entry(&mut dict, b"age", ii_ptr.cast());
+    let spec = make_spec(&dict);
+    // SAFETY: spec borrows dict; ii_ptr is valid for the duration of this test.
+    let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
+
+    let mut buf = Vec::new();
+    collect_missing_docs(&mut buf, &*guard).unwrap();
+
+    let mut cursor = Cursor::new(&buf);
+
+    let frame = Frame::decode(&mut cursor).unwrap();
+    let Frame::Data(name) = frame else {
+        panic!("expected Data frame, got {frame:?}");
+    };
+    assert_eq!(&*name, b"age");
+
+    let _delta: GcScanDelta = rmp_serde::from_read(&mut cursor).unwrap();
+
+    assert!(matches!(
+        Frame::decode(&mut cursor).unwrap(),
+        Frame::Terminator
+    ));
+
+    // SAFETY: dict does not free values; ii_ptr was created via Box::into_raw.
+    unsafe { drop(Box::from_raw(ii_ptr)) };
+}
+
+/// Multiple entries each produce their own Data frame + delta, followed by a
+/// single Terminator.
+#[test]
+fn multiple_entries_write_multiple_delta_frames() {
+    let make_ii = |doc_id| {
+        let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+        ii.add_record(&RSIndexResult::build_virt().doc_id(doc_id).build())
+            .unwrap();
+        Box::into_raw(Box::new(OpaqueInvertedIndex::DocIdsOnly(ii)))
+    };
+
+    let ii_a = make_ii(1);
+    let ii_b = make_ii(2);
+
+    let mut dict = make_dict();
+    add_entry(&mut dict, b"field_a", ii_a.cast());
+    add_entry(&mut dict, b"field_b", ii_b.cast());
+    let spec = make_spec(&dict);
+    // SAFETY: spec borrows dict; both ii pointers are valid for the duration of this test.
+    let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
+
+    let mut buf = Vec::new();
+    collect_missing_docs(&mut buf, &*guard).unwrap();
+
+    let mut cursor = Cursor::new(&buf);
+    let mut field_names_seen = Vec::new();
+    loop {
+        match Frame::decode(&mut cursor).unwrap() {
+            Frame::Terminator => break,
+            Frame::Data(name) => {
+                field_names_seen.push(name.into_inner().into_vec());
+                let _delta: GcScanDelta = rmp_serde::from_read(&mut cursor).unwrap();
+            }
+            Frame::Empty => panic!("unexpected Empty frame"),
+        }
+    }
+
+    field_names_seen.sort();
+    assert_eq!(field_names_seen, [b"field_a".to_vec(), b"field_b".to_vec()]);
+
+    // SAFETY: dict does not free values; both ii pointers were created via Box::into_raw.
+    unsafe {
+        drop(Box::from_raw(ii_a));
+        drop(Box::from_raw(ii_b));
+    }
+}
+
+/// A roundtrip test: the wire output of `collect_missing_docs` can be decoded
+/// frame-by-frame as the parent side would.
+#[test]
+fn roundtrip_protocol_is_decodable() {
+    let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+    ii.add_record(&RSIndexResult::build_virt().doc_id(5).build())
+        .unwrap();
+    let ii = Box::new(OpaqueInvertedIndex::DocIdsOnly(ii));
+    let ii_ptr = Box::into_raw(ii);
+
+    let mut dict = make_dict();
+    add_entry(&mut dict, b"title", ii_ptr.cast());
+    let spec = make_spec(&dict);
+    // SAFETY: spec borrows dict; ii_ptr is valid for the duration of this test.
+    let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
+
+    let mut buf = Vec::new();
+    collect_missing_docs(&mut buf, &*guard).unwrap();
+
+    let mut cursor = Cursor::new(&buf);
+    let mut entries_received = 0usize;
+    loop {
+        match Frame::decode(&mut cursor).unwrap() {
+            Frame::Terminator => break,
+            Frame::Data(name) => {
+                assert_eq!(&*name, b"title");
+                let delta: GcScanDelta = rmp_serde::from_read(&mut cursor).unwrap();
+                assert_eq!(delta.last_block_idx(), 0);
+                entries_received += 1;
+            }
+            Frame::Empty => panic!("unexpected Empty frame"),
+        }
+    }
+    assert_eq!(entries_received, 1);
+
+    // SAFETY: dict does not free values; ii_ptr was created via Box::into_raw.
+    unsafe { drop(Box::from_raw(ii_ptr)) };
+}
+
+/// Verify the serialised bytes written after a Data frame are a valid
+/// msgpack-encoded [`GcScanDelta`] that round-trips cleanly.
+#[test]
+fn delta_frame_serialisation_roundtrips_via_msgpack() {
+    let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+    ii.add_record(&RSIndexResult::build_virt().doc_id(3).build())
+        .unwrap();
+    let ii = Box::new(OpaqueInvertedIndex::DocIdsOnly(ii));
+    let ii_ptr = Box::into_raw(ii);
+
+    let mut dict = make_dict();
+    add_entry(&mut dict, b"score", ii_ptr.cast());
+    let spec = make_spec(&dict);
+    // SAFETY: spec borrows dict; ii_ptr is valid for the duration of this test.
+    let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
+
+    let mut buf = Vec::new();
+    collect_missing_docs(&mut buf, &*guard).unwrap();
+
+    let mut cursor = Cursor::new(&buf);
+    let Frame::Data(_) = Frame::decode(&mut cursor).unwrap() else {
+        panic!("expected Data frame");
+    };
+    let delta: GcScanDelta = rmp_serde::from_read(&mut cursor).unwrap();
+
+    let mut re_encoded = Vec::new();
+    delta
+        .serialize(&mut rmp_serde::Serializer::new(&mut re_encoded))
+        .unwrap();
+
+    let frame_end = cursor.position() as usize;
+    let frame_start = size_of::<usize>() + b"score".len();
+    assert_eq!(&buf[frame_start..frame_end], re_encoded.as_slice());
+
+    // SAFETY: dict does not free values; ii_ptr was created via Box::into_raw.
+    unsafe { drop(Box::from_raw(ii_ptr)) };
+}

--- a/src/redisearch_rs/fork_gc/tests/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/missing_docs.rs
@@ -7,11 +7,13 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::{io::Cursor, mem, ptr};
+use std::{io::Cursor, mem};
 
+use dict::MissingFieldDictType;
 use dict::OwnedDict;
 use ffi::IndexFlags_Index_DocIdsOnly;
 use fork_gc::{Frame, missing_docs::collect_missing_docs};
+use hidden_string::HiddenStringRef;
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use inverted_index::opaque::InvertedIndex as OpaqueInvertedIndex;
@@ -23,28 +25,29 @@ redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
 // ── Test helpers ─────────────────────────────────────────────────────────────
 
-/// Create an [`OwnedDict`] using `dictTypeHeapHiddenStrings` — the same key
-/// type as a real `missingFieldDict`. The dict is released automatically when
-/// it goes out of scope. Values are NOT freed on drop because
-/// `dictTypeHeapHiddenStrings.valDestructor` is null.
-fn make_dict() -> OwnedDict {
-    // SAFETY: dictTypeHeapHiddenStrings is a valid static dictType.
-    unsafe { OwnedDict::create(ptr::addr_of_mut!(ffi::dictTypeHeapHiddenStrings)) }
+fn make_dict() -> OwnedDict<MissingFieldDictType> {
+    OwnedDict::create()
 }
 
 /// Add one entry to `dict` keyed by `field_name`, with value `ii`.
 ///
-/// `dictTypeHeapHiddenStrings` duplicates the key internally (via `keyDup`),
-/// so the temporary `HiddenString` is freed immediately after insertion.
-fn add_entry(dict: &mut OwnedDict, field_name: &[u8], ii: *mut std::ffi::c_void) {
-    // SAFETY: NewHiddenString copies `field_name` into a heap allocation; the
-    // dict's keyDup makes its own copy, so we free the original immediately.
+/// `MissingFieldDictType` uses `dictTypeHeapHiddenStrings`, which copies the
+/// key via `keyDup`, so the temporary `HiddenString` can be freed immediately
+/// after insertion.
+fn add_entry(
+    dict: &mut OwnedDict<MissingFieldDictType>,
+    field_name: &[u8],
+    ii: Option<&OpaqueInvertedIndex>,
+) {
+    // SAFETY: NewHiddenString copies `field_name`; the dict's keyDup copies
+    // the HiddenString itself, so we free the original immediately after insert.
     let hs = unsafe { ffi::NewHiddenString(field_name.as_ptr().cast(), field_name.len(), false) };
-    dict.insert(hs.cast(), ii);
+    let hs_ref = unsafe { HiddenStringRef::from_raw(hs) };
+    dict.insert(hs_ref, ii);
     unsafe { ffi::HiddenString_Free(hs, false) };
 }
 
-fn make_spec(dict: &OwnedDict) -> ffi::IndexSpec {
+fn make_spec(dict: &OwnedDict<MissingFieldDictType>) -> ffi::IndexSpec {
     // SAFETY: zeroed IndexSpec is valid for read-only field access through the guard.
     let mut spec: ffi::IndexSpec = unsafe { mem::zeroed() };
     spec.missingFieldDict = dict.as_ptr();
@@ -58,7 +61,6 @@ fn make_spec(dict: &OwnedDict) -> ffi::IndexSpec {
 fn empty_dict_writes_only_terminator() {
     let dict = make_dict();
     let spec = make_spec(&dict);
-    // SAFETY: spec borrows dict, which lives for the duration of this test.
     let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
 
     let mut buf = Vec::new();
@@ -71,13 +73,12 @@ fn empty_dict_writes_only_terminator() {
     ));
 }
 
-/// Entries whose value is null (no inverted index) are skipped silently.
+/// Entries whose value is `None` (no inverted index) are skipped silently.
 #[test]
 fn null_value_entry_is_skipped() {
     let mut dict = make_dict();
-    add_entry(&mut dict, b"no_index_field", ptr::null_mut());
+    add_entry(&mut dict, b"no_index_field", None);
     let spec = make_spec(&dict);
-    // SAFETY: spec borrows dict, which lives for the duration of this test.
     let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
 
     let mut buf = Vec::new();
@@ -99,9 +100,8 @@ fn empty_inverted_index_is_skipped() {
     let ii_ptr = Box::into_raw(ii);
 
     let mut dict = make_dict();
-    add_entry(&mut dict, b"empty_field", ii_ptr.cast());
+    add_entry(&mut dict, b"empty_field", Some(unsafe { &*ii_ptr }));
     let spec = make_spec(&dict);
-    // SAFETY: spec borrows dict; ii_ptr is valid for the duration of this test.
     let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
 
     let mut buf = Vec::new();
@@ -134,9 +134,8 @@ fn entry_with_deleted_docs_writes_delta_frame() {
     let ii_ptr = Box::into_raw(ii);
 
     let mut dict = make_dict();
-    add_entry(&mut dict, b"age", ii_ptr.cast());
+    add_entry(&mut dict, b"age", Some(unsafe { &*ii_ptr }));
     let spec = make_spec(&dict);
-    // SAFETY: spec borrows dict; ii_ptr is valid for the duration of this test.
     let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
 
     let mut buf = Vec::new();
@@ -176,10 +175,9 @@ fn multiple_entries_write_multiple_delta_frames() {
     let ii_b = make_ii(2);
 
     let mut dict = make_dict();
-    add_entry(&mut dict, b"field_a", ii_a.cast());
-    add_entry(&mut dict, b"field_b", ii_b.cast());
+    add_entry(&mut dict, b"field_a", Some(unsafe { &*ii_a }));
+    add_entry(&mut dict, b"field_b", Some(unsafe { &*ii_b }));
     let spec = make_spec(&dict);
-    // SAFETY: spec borrows dict; both ii pointers are valid for the duration of this test.
     let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
 
     let mut buf = Vec::new();
@@ -219,9 +217,8 @@ fn roundtrip_protocol_is_decodable() {
     let ii_ptr = Box::into_raw(ii);
 
     let mut dict = make_dict();
-    add_entry(&mut dict, b"title", ii_ptr.cast());
+    add_entry(&mut dict, b"title", Some(unsafe { &*ii_ptr }));
     let spec = make_spec(&dict);
-    // SAFETY: spec borrows dict; ii_ptr is valid for the duration of this test.
     let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
 
     let mut buf = Vec::new();
@@ -258,9 +255,8 @@ fn delta_frame_serialisation_roundtrips_via_msgpack() {
     let ii_ptr = Box::into_raw(ii);
 
     let mut dict = make_dict();
-    add_entry(&mut dict, b"score", ii_ptr.cast());
+    add_entry(&mut dict, b"score", Some(unsafe { &*ii_ptr }));
     let spec = make_spec(&dict);
-    // SAFETY: spec borrows dict; ii_ptr is valid for the duration of this test.
     let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
 
     let mut buf = Vec::new();

--- a/src/redisearch_rs/fork_gc/tests/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/missing_docs.rs
@@ -39,7 +39,7 @@ fn add_entry(
     // the HiddenString itself, so we free the original immediately after insert.
     let hs = unsafe { ffi::NewHiddenString(field_name.as_ptr().cast(), field_name.len(), false) };
     let hs_ref = unsafe { HiddenStringRef::from_raw(hs) };
-    dict.insert(hs_ref, ii);
+    dict.try_insert(hs_ref, ii).unwrap();
     unsafe { ffi::HiddenString_Free(hs, false) };
 }
 
@@ -66,6 +66,7 @@ fn empty_dict_writes_only_terminator() {
         Frame::decode(&mut cursor).unwrap(),
         Frame::Terminator
     ));
+    assert_eq!(cursor.position(), buf.len() as u64);
 }
 
 /// An entry whose inverted index is empty produces no delta, so it is skipped.
@@ -89,6 +90,7 @@ fn empty_inverted_index_is_skipped() {
         Frame::decode(&mut cursor).unwrap(),
         Frame::Terminator
     ));
+    assert_eq!(cursor.position(), buf.len() as u64);
 }
 
 /// When an entry has docs absent from the DocTable, `scan_gc` produces a delta.
@@ -129,6 +131,7 @@ fn entry_with_deleted_docs_writes_delta_frame() {
         Frame::decode(&mut cursor).unwrap(),
         Frame::Terminator
     ));
+    assert_eq!(cursor.position(), buf.len() as u64);
 }
 
 /// Multiple entries each produce their own Data frame + delta, followed by a
@@ -165,10 +168,12 @@ fn multiple_entries_write_multiple_delta_frames() {
     let _: GcScanDelta = rmp_serde::from_read(&mut cursor).unwrap();
 
     let mut names = [name1.into_inner().into_vec(), name2.into_inner().into_vec()];
-    names.sort();
+    names.sort(); // Frames can come in any order because dict iteration order is undefined.
+
     assert_eq!(names, [b"field_a".to_vec(), b"field_b".to_vec()]);
     assert!(matches!(
         Frame::decode(&mut cursor).unwrap(),
         Frame::Terminator
     ));
+    assert_eq!(cursor.position(), buf.len() as u64);
 }

--- a/src/redisearch_rs/fork_gc/tests/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/missing_docs.rs
@@ -18,16 +18,9 @@ use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use inverted_index::opaque::InvertedIndex as OpaqueInvertedIndex;
 use inverted_index::{GcScanDelta, InvertedIndex, doc_ids_only::DocIdsOnly};
-use serde::Serialize as _;
 
 // Provide Redis allocator shims so the C dict functions can allocate memory.
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
-
-// ── Test helpers ─────────────────────────────────────────────────────────────
-
-fn make_dict() -> OwnedDict<MissingFieldDictType> {
-    OwnedDict::create()
-}
 
 /// Add one entry to `dict` keyed by `field_name`, with value `ii`.
 ///
@@ -54,12 +47,10 @@ fn make_spec(dict: &OwnedDict<MissingFieldDictType>) -> ffi::IndexSpec {
     spec
 }
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
-
 /// When the dict has no entries, only a Terminator is written.
 #[test]
 fn empty_dict_writes_only_terminator() {
-    let dict = make_dict();
+    let dict = OwnedDict::create();
     let spec = make_spec(&dict);
     let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
 
@@ -76,7 +67,7 @@ fn empty_dict_writes_only_terminator() {
 /// Entries whose value is `None` (no inverted index) are skipped silently.
 #[test]
 fn null_value_entry_is_skipped() {
-    let mut dict = make_dict();
+    let mut dict = OwnedDict::create();
     add_entry(&mut dict, b"no_index_field", None);
     let spec = make_spec(&dict);
     let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
@@ -99,7 +90,7 @@ fn empty_inverted_index_is_skipped() {
     ));
     let ii_ptr = Box::into_raw(ii);
 
-    let mut dict = make_dict();
+    let mut dict = OwnedDict::create();
     add_entry(&mut dict, b"empty_field", Some(unsafe { &*ii_ptr }));
     let spec = make_spec(&dict);
     let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
@@ -133,7 +124,7 @@ fn entry_with_deleted_docs_writes_delta_frame() {
     let ii = Box::new(OpaqueInvertedIndex::DocIdsOnly(ii));
     let ii_ptr = Box::into_raw(ii);
 
-    let mut dict = make_dict();
+    let mut dict = OwnedDict::create();
     add_entry(&mut dict, b"age", Some(unsafe { &*ii_ptr }));
     let spec = make_spec(&dict);
     let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
@@ -174,7 +165,7 @@ fn multiple_entries_write_multiple_delta_frames() {
     let ii_a = make_ii(1);
     let ii_b = make_ii(2);
 
-    let mut dict = make_dict();
+    let mut dict = OwnedDict::create();
     add_entry(&mut dict, b"field_a", Some(unsafe { &*ii_a }));
     add_entry(&mut dict, b"field_b", Some(unsafe { &*ii_b }));
     let spec = make_spec(&dict);
@@ -184,99 +175,28 @@ fn multiple_entries_write_multiple_delta_frames() {
     collect_missing_docs(&mut buf, &*guard).unwrap();
 
     let mut cursor = Cursor::new(&buf);
-    let mut field_names_seen = Vec::new();
-    loop {
-        match Frame::decode(&mut cursor).unwrap() {
-            Frame::Terminator => break,
-            Frame::Data(name) => {
-                field_names_seen.push(name.into_inner().into_vec());
-                let _delta: GcScanDelta = rmp_serde::from_read(&mut cursor).unwrap();
-            }
-            Frame::Empty => panic!("unexpected Empty frame"),
-        }
-    }
 
-    field_names_seen.sort();
-    assert_eq!(field_names_seen, [b"field_a".to_vec(), b"field_b".to_vec()]);
+    let Frame::Data(name1) = Frame::decode(&mut cursor).unwrap() else {
+        panic!("expected first Data frame");
+    };
+    let _: GcScanDelta = rmp_serde::from_read(&mut cursor).unwrap();
+
+    let Frame::Data(name2) = Frame::decode(&mut cursor).unwrap() else {
+        panic!("expected second Data frame");
+    };
+    let _: GcScanDelta = rmp_serde::from_read(&mut cursor).unwrap();
+
+    let mut names = [name1.into_inner().into_vec(), name2.into_inner().into_vec()];
+    names.sort();
+    assert_eq!(names, [b"field_a".to_vec(), b"field_b".to_vec()]);
+    assert!(matches!(
+        Frame::decode(&mut cursor).unwrap(),
+        Frame::Terminator
+    ));
 
     // SAFETY: dict does not free values; both ii pointers were created via Box::into_raw.
     unsafe {
         drop(Box::from_raw(ii_a));
         drop(Box::from_raw(ii_b));
     }
-}
-
-/// A roundtrip test: the wire output of `collect_missing_docs` can be decoded
-/// frame-by-frame as the parent side would.
-#[test]
-fn roundtrip_protocol_is_decodable() {
-    let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
-    ii.add_record(&RSIndexResult::build_virt().doc_id(5).build())
-        .unwrap();
-    let ii = Box::new(OpaqueInvertedIndex::DocIdsOnly(ii));
-    let ii_ptr = Box::into_raw(ii);
-
-    let mut dict = make_dict();
-    add_entry(&mut dict, b"title", Some(unsafe { &*ii_ptr }));
-    let spec = make_spec(&dict);
-    let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
-
-    let mut buf = Vec::new();
-    collect_missing_docs(&mut buf, &*guard).unwrap();
-
-    let mut cursor = Cursor::new(&buf);
-    let mut entries_received = 0usize;
-    loop {
-        match Frame::decode(&mut cursor).unwrap() {
-            Frame::Terminator => break,
-            Frame::Data(name) => {
-                assert_eq!(&*name, b"title");
-                let delta: GcScanDelta = rmp_serde::from_read(&mut cursor).unwrap();
-                assert_eq!(delta.last_block_idx(), 0);
-                entries_received += 1;
-            }
-            Frame::Empty => panic!("unexpected Empty frame"),
-        }
-    }
-    assert_eq!(entries_received, 1);
-
-    // SAFETY: dict does not free values; ii_ptr was created via Box::into_raw.
-    unsafe { drop(Box::from_raw(ii_ptr)) };
-}
-
-/// Verify the serialised bytes written after a Data frame are a valid
-/// msgpack-encoded [`GcScanDelta`] that round-trips cleanly.
-#[test]
-fn delta_frame_serialisation_roundtrips_via_msgpack() {
-    let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
-    ii.add_record(&RSIndexResult::build_virt().doc_id(3).build())
-        .unwrap();
-    let ii = Box::new(OpaqueInvertedIndex::DocIdsOnly(ii));
-    let ii_ptr = Box::into_raw(ii);
-
-    let mut dict = make_dict();
-    add_entry(&mut dict, b"score", Some(unsafe { &*ii_ptr }));
-    let spec = make_spec(&dict);
-    let guard = unsafe { IndexSpecReadGuard::from_locked(&spec) };
-
-    let mut buf = Vec::new();
-    collect_missing_docs(&mut buf, &*guard).unwrap();
-
-    let mut cursor = Cursor::new(&buf);
-    let Frame::Data(_) = Frame::decode(&mut cursor).unwrap() else {
-        panic!("expected Data frame");
-    };
-    let delta: GcScanDelta = rmp_serde::from_read(&mut cursor).unwrap();
-
-    let mut re_encoded = Vec::new();
-    delta
-        .serialize(&mut rmp_serde::Serializer::new(&mut re_encoded))
-        .unwrap();
-
-    let frame_end = cursor.position() as usize;
-    let frame_start = size_of::<usize>() + b"score".len();
-    assert_eq!(&buf[frame_start..frame_end], re_encoded.as_slice());
-
-    // SAFETY: dict does not free values; ii_ptr was created via Box::into_raw.
-    unsafe { drop(Box::from_raw(ii_ptr)) };
 }

--- a/src/redisearch_rs/fork_gc/tests/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/missing_docs.rs
@@ -29,10 +29,10 @@ redis_mock::mock_or_stub_missing_redis_c_symbols!();
 /// `MissingFieldDictType` uses `dictTypeHeapHiddenStrings`, which copies the
 /// key via `keyDup`, so the temporary `HiddenString` can be freed immediately
 /// after insertion.
-fn add_entry(
-    dict: &mut OwnedDict<MissingFieldDictType>,
+fn add_entry<'a>(
+    dict: &mut OwnedDict<'a, MissingFieldDictType>,
     field_name: &[u8],
-    ii: Option<&OpaqueInvertedIndex>,
+    ii: Option<&'a OpaqueInvertedIndex>,
 ) {
     // SAFETY: NewHiddenString copies `field_name`; the dict's keyDup copies
     // the HiddenString itself, so we free the original immediately after insert.

--- a/src/redisearch_rs/fork_gc/tests/util.rs
+++ b/src/redisearch_rs/fork_gc/tests/util.rs
@@ -18,6 +18,11 @@ use std::{
     time::Duration,
 };
 
+// Link both Rust-provided and C-provided symbols
+extern crate redisearch_rs;
+// Provide Redis allocator shims so the C dict functions can allocate memory.
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
 #[test]
 fn reads_available_data() {
     let (mut reader, mut writer) = io::pipe().unwrap();

--- a/src/redisearch_rs/headers/fork_gc_ffi.h
+++ b/src/redisearch_rs/headers/fork_gc_ffi.h
@@ -57,7 +57,8 @@ extern "C" {
  *
  * 1. `gc` must point to a valid [`ffi::ForkGC`].
  * 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`].
- * 3. `sctx.spec.missingFieldDict` must be a non-null, valid dict pointer.
+ * 3. `sctx.spec` must be a non-null pointer to a valid [`ffi::IndexSpec`].
+ * 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
  */
 void FGC_childCollectMissingDocs(ForkGC *gc, RedisSearchCtx *sctx);
 

--- a/src/redisearch_rs/headers/fork_gc_ffi.h
+++ b/src/redisearch_rs/headers/fork_gc_ffi.h
@@ -46,15 +46,18 @@ extern "C" {
  *
  * Iterates the `missingFieldDict`, and for each entry with a non-null
  * `InvertedIndex` calls `scan_gc` which sends the field name header
- * followed by the serialised GC delta.  Sends a terminator once all
+ * followed by the serialised GC delta. Sends a terminator once all
  * entries are processed.
+ *
+ * # Panic
+ *
+ * Panics if `pipe_write_fd` on `gc` is an invalid or closed writable file descriptor.
  *
  * # Safety
  *
- * 1. `gc` must point to a valid [`ffi::ForkGC`] whose `pipe_write_fd` is an open,
- *    writable file descriptor.
- * 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`] whose `spec` field is
- *    a non-null `IndexSpec` with a populated `missingFieldDict`.
+ * 1. `gc` must point to a valid [`ffi::ForkGC`].
+ * 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`].
+ * 3. `sctx.spec.missingFieldDict` must be a non-null, valid dict pointer.
  */
 void FGC_childCollectMissingDocs(ForkGC *gc, RedisSearchCtx *sctx);
 

--- a/src/redisearch_rs/headers/fork_gc_ffi.h
+++ b/src/redisearch_rs/headers/fork_gc_ffi.h
@@ -41,6 +41,24 @@ extern "C" {
 #endif // __cplusplus
 
 /**
+ * Collect GC delta data for every entry in the spec's `missingFieldDict` and
+ * send it to the parent process over the pipe.
+ *
+ * Iterates the `missingFieldDict`, and for each entry with a non-null
+ * `InvertedIndex` calls `scan_gc` which sends the field name header
+ * followed by the serialised GC delta.  Sends a terminator once all
+ * entries are processed.
+ *
+ * # Safety
+ *
+ * 1. `gc` must point to a valid [`ffi::ForkGC`] whose `pipe_write_fd` is an open,
+ *    writable file descriptor.
+ * 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`] whose `spec` field is
+ *    a non-null `IndexSpec` with a populated `missingFieldDict`.
+ */
+void FGC_childCollectMissingDocs(ForkGC *gc, RedisSearchCtx *sctx);
+
+/**
  * Collect GC delta data for the spec's `existingDocs` inverted index and
  * send it to the parent process over the pipe.
  *

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -110,8 +110,8 @@ where
     ///    variant matches `E`.
     fn should_abort(&self, spec: &IndexSpecReadGuard) -> bool {
         debug_assert!(
-            !spec.missing_field_dict().is_null(),
-            "spec.missing_field_dict() must be non-null",
+            !spec.missing_field_dict_ptr().is_null(),
+            "spec.missing_field_dict_ptr() must be non-null",
         );
 
         // SAFETY: field_index is a valid index into spec.fields (guaranteed by constructor pre-conditions).
@@ -119,8 +119,9 @@ where
         // SAFETY: the pointer is valid per the above.
         let field = unsafe { &*field_ptr };
         // SAFETY: The dict is non-null and valid (guaranteed by constructor pre-conditions).
-        let missing_ii_ptr =
-            unsafe { ffi::RS_dictFetchValue(spec.missing_field_dict(), field.fieldName as *mut _) };
+        let missing_ii_ptr = unsafe {
+            ffi::RS_dictFetchValue(spec.missing_field_dict_ptr(), field.fieldName as *mut _)
+        };
 
         if missing_ii_ptr.is_null() {
             // The inverted index was removed from the dict (garbage collected).

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -178,7 +178,7 @@ mod not_miri {
         // Note: the iterator's reader holds a (now-dangling) pointer to the
         // original II, but `should_abort` only compares pointers via
         // `is_index` without dereferencing it, so this is safe.
-        let dict = test.test.context.spec_read().missing_field_dict();
+        let dict = test.test.context.spec_read().missing_field_dict_ptr();
         unsafe {
             ffi::RS_dictDelete(dict, field_name as *mut _);
             let rc = ffi::RS_dictAdd(dict, field_name as *mut _, new_ii as *mut _);
@@ -224,7 +224,7 @@ mod not_miri {
         // by deleting the dict entry. `dictDelete` calls the value destructor
         // which frees the inverted index.
         let field_name = test.test.context.field_spec().fieldName;
-        let dict = test.test.context.spec_read().missing_field_dict();
+        let dict = test.test.context.spec_read().missing_field_dict_ptr();
         unsafe {
             ffi::RS_dictDelete(dict, field_name as *mut _);
         }
@@ -308,7 +308,7 @@ mod not_miri {
                 )));
             let field_name = test.test.context.field_spec().fieldName;
 
-            let dict = test.test.context.spec_read().missing_field_dict();
+            let dict = test.test.context.spec_read().missing_field_dict_ptr();
             unsafe {
                 ffi::RS_dictDelete(dict, field_name as *mut _);
                 let rc = ffi::RS_dictAdd(dict, field_name as *mut _, new_ii as *mut _);
@@ -349,7 +349,7 @@ mod not_miri {
             // Simulate the garbage collector removing the missing-field index
             // by deleting the dict entry.
             let field_name = test.test.context.field_spec().fieldName;
-            let dict = test.test.context.spec_read().missing_field_dict();
+            let dict = test.test.context.spec_read().missing_field_dict_ptr();
             unsafe {
                 ffi::RS_dictDelete(dict, field_name as *mut _);
             }

--- a/src/spec.c
+++ b/src/spec.c
@@ -2292,7 +2292,7 @@ static dictType invIdxDictType = {
   .valDestructor = InvIndFreeCb,
 };
 
-static dictType missingFieldDictType = {
+dictType missingFieldDictType = {
         .hashFunction = hiddenNameHashFunction,
         .keyDup = hiddenNameKeyDup,
         .valDup = NULL,

--- a/src/spec.h
+++ b/src/spec.h
@@ -593,6 +593,9 @@ RedisModuleString *IndexSpec_LegacyGetFormattedKey(IndexSpec *sp, const FieldSpe
  */
 void IndexSpec_MakeKeyless(IndexSpec *sp);
 
+/* The dictType used for IndexSpec.missingFieldDict: HiddenString keys, InvertedIndex* values. */
+extern dictType missingFieldDictType;
+
 /**
  * Exposing all the fields of the index to INFO command.
  * @param ctx - the redis module info context


### PR DESCRIPTION
## Describe the changes in the pull request

- Ports `FGC_childCollectMissingDocs` from C to Rust using a similar setup as `collect_existing_docs`.
- Also adds a typed safe wrapper around the C dict implementation needed for `collect_missing_docs`.
  I've already went through a few iterations on the design. I think it's not yet right, but it's good enough for this iteration. The relation of a `DictType` to it's value should maybe be a bit more flexible, but I'm not yet sure as I don't have a complete picture of the c dict type yet.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes