### PR TITLE
Top K : support batched top k without filter.

### DIFF
--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -41,7 +41,12 @@ pub enum TopKMode {
     /// lost.
     Unfiltered,
     /// Fetch score-ordered batches from the source and intersect each one
-    /// with the child filter iterator.
+    /// with the child filter iterator, keeping the top `k` in the heap.
+    ///
+    /// With no child filter every source record is a candidate: the whole
+    /// batch is fed through the heap, which still retains the top `k`. This is
+    /// the mode for a source that has no native top-k and must rely on the heap
+    /// for selection (e.g. a numeric `SORTBY` with no query filter).
     ///
     /// The source's [`ScoreSource::batch_strategy`] may return
     /// [`BatchStrategy::SwitchToAdhoc`] mid-run to switch to
@@ -211,6 +216,12 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             // `self.heap.push` at the same time.  Pass fields explicitly.
             if let Some(child) = &mut self.child {
                 intersect_batch_with_child(child, &mut batch, &mut self.heap)?;
+            } else {
+                // No filter child: every source record is a candidate, so feed
+                // the whole batch through the heap, which retains the top k.
+                while let Some((doc_id, score)) = batch.next() {
+                    self.heap.push(doc_id, score);
+                }
             }
             match self.source.batch_strategy(self.heap.len(), self.k.get()) {
                 BatchStrategy::Continue => continue,
@@ -219,6 +230,11 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
                     if self.mode == TopKMode::ForcedBatches {
                         // Honour the forced-batches contract: never switch
                         // mid-run.
+                        continue;
+                    }
+                    if self.child.is_none() {
+                        // Adhoc-BF requires a child filter iterator:
+                        // ignore the strategy switch.
                         continue;
                     }
                     self.mode = TopKMode::AdhocBF;

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -262,6 +262,49 @@ fn batches_multiple_batches() {
     assert_eq!(doc_ids, vec![3, 4, 1]);
 }
 
+/// Build a no-child Batches iterator, exercising the heap-driven top-k path a
+/// numeric `SORTBY` with no query filter uses.
+fn batches_no_child(
+    batches: Vec<Vec<(DocId, f64)>>,
+    k: usize,
+) -> TopKIterator<'static, MockScoreSource, Box<dyn RQEIterator<'static>>> {
+    let source = MockScoreSource::new(batches, vec![], |_, _| BatchStrategy::Continue);
+    TopKIterator::new_with_mode(
+        source,
+        None,
+        NonZeroUsize::new(k).unwrap(),
+        asc,
+        TopKMode::Batches,
+    )
+}
+
+#[test]
+fn batches_no_child_keeps_top_k() {
+    // The heap must retain the three lowest by score and yield them best-first,
+    // not stream all five in doc-id order.
+    let mut it = batches_no_child(
+        vec![vec![(1, 5.0), (2, 1.0), (3, 4.0), (4, 2.0), (5, 3.0)]],
+        3,
+    );
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids, vec![2, 4, 5]);
+}
+
+#[test]
+fn batches_no_child_fewer_than_k_yields_all() {
+    let mut it = batches_no_child(vec![vec![(1, 3.0), (2, 1.0)]], 5);
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids, vec![2, 1]);
+}
+
+#[test]
+fn batches_no_child_spans_multiple_batches() {
+    // Top-k selection must consider every batch, not just the first.
+    let mut it = batches_no_child(vec![vec![(1, 9.0), (2, 1.0)], vec![(3, 2.0), (4, 8.0)]], 2);
+    let doc_ids: Vec<_> = std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect();
+    assert_eq!(doc_ids, vec![2, 3]);
+}
+
 #[test]
 fn batches_expired_doc_shrinks_results_without_refill() {
     // Doc 1 expires after collection. It still fills the heap to k=2 during


### PR DESCRIPTION
vector score source was driving the implementation of top k, its different modes are:
- "unfiltered": no filter child iterator means we can defer the iteration **completely** to vecsim accelerated library, which provides a top k api, so we bypass completely our top k heap.
- "Batches": a filter child means we can't use the vecsim api directly, so we use vecsim in batches, then use out heap to consolidate the result.
- an adhoc for heuristics, not relevant here.

We implemented batches, assuming it would always be filtered, which is true, for vector source, but **NOT** for numeric, as we don't have any api to consult and give us top k results.

So this PR adds support for unfiltered batch, by feeding the batch into the heap.

We may want to rename the `Unfiltered` strategy to `UnfilteredDirect` or something, but this will create a lot of conflicts I'd like to avoid currently, happy to tackle those later when things settle down.

- Next: https://github.com/RediSearch/RediSearch/pull/10230

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
