### PR TITLE
[MOD-14870] qast: handle QN_PHRASE in Rust

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -937,38 +937,6 @@ static QueryIterator *Query_EvalFuzzyNode(QueryEvalCtx *q, QueryNode *qn) {
                               TRIE_MATCH_EDIT_DISTANCE, &qn->opts);
 }
 
-static QueryIterator *Query_EvalPhraseNode(QueryEvalCtx *q, QueryNode *qn) {
-  QueryPhraseNode *node = &qn->pn;
-  // an intersect stage with one child is the same as the child, so we just
-  // return it
-  if (QueryNode_NumChildren(qn) == 1) {
-    qn->children[0]->opts.fieldMask &= qn->opts.fieldMask;
-    return Query_EvalNode_Rs(q, qn->children[0]);
-  }
-
-  // recursively eval the children
-  QueryIterator **iters = rm_calloc(QueryNode_NumChildren(qn), sizeof(QueryIterator *));
-  for (size_t ii = 0; ii < QueryNode_NumChildren(qn); ++ii) {
-    qn->children[ii]->opts.fieldMask &= qn->opts.fieldMask;
-    iters[ii] = Query_EvalNode_Rs(q, qn->children[ii]);
-  }
-  QueryIterator *ret;
-
-  if (node->exact) {
-    ret = NewIntersectionIterator(iters, QueryNode_NumChildren(qn), 0, true, qn->opts.weight);
-  } else {
-    // Let the query node override the slop/order parameters
-    int slop = qn->opts.maxSlop;
-    if (slop == -1) slop = q->opts->slop;
-
-    // Let the query node override the inorder of the whole query
-    bool inOrder = (q->opts->flags & Search_InOrder) || qn->opts.inOrder;
-
-    ret = NewIntersectionIterator(iters, QueryNode_NumChildren(qn), slop, inOrder, qn->opts.weight);
-  }
-  return ret;
-}
-
 // Probe the Blocked Client Timeout flag for a query iterator. Called from
 // Rust via a direct `extern "C"` declaration when a NOT iterator is wired
 // to an AREQ; the sync point makes the check deterministically pauseable
@@ -1456,12 +1424,11 @@ QueryIterator *Query_EvalNode(QueryEvalCtx *q, QueryNode *n) {
     case QN_MISSING:
     case QN_OPTIONAL:
     case QN_NOT:
+    case QN_PHRASE:
       // These node types have been ported to Rust.
       return Query_EvalNode_Rs(q, n);
     case QN_TOKEN:
       return Query_EvalTokenNode(q, n);
-    case QN_PHRASE:
-      return Query_EvalPhraseNode(q, n);
     case QN_UNION:
       return Query_EvalUnionNode(q, n);
     case QN_TAG:

--- a/src/redisearch_rs/c_wrappers/query/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/lib.rs
@@ -13,7 +13,7 @@ mod query_eval_ctx;
 mod query_node_ref;
 
 pub use query_eval_ctx::QueryEvalContext;
-pub use query_node_ref::{QueryNode, QueryNodeRef, WildcardMode};
+pub use query_node_ref::{QueryNode, QueryNodeMut, QueryNodeRef, WildcardMode};
 
 /// Test-only mocks for the query wrapper types, shared with the `query_eval`
 /// crate's evaluation-dispatcher tests.

--- a/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
@@ -104,6 +104,19 @@ impl QueryEvalContext {
         unsafe { &*self.as_ref().opts }
     }
 
+    /// The query-wide default slop (max term distance) for phrase matching.
+    ///
+    /// A node may override this; a value of `-1` means no phrase constraint.
+    pub const fn slop(&self) -> i32 {
+        self.opts().slop
+    }
+
+    /// Whether the query-wide `INORDER` flag (`Search_InOrder`) is set, forcing
+    /// phrase terms to match in order regardless of per-node options.
+    pub const fn search_in_order(&self) -> bool {
+        self.opts().flags & ffi::RSSearchFlags_Search_InOrder != 0
+    }
+
     /// The [`query_error::QueryError`] accumulator for reporting evaluation
     /// errors and warnings (e.g. max-prefix-expansion limits).
     ///

--- a/src/redisearch_rs/c_wrappers/query/src/query_node_ref.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_node_ref.rs
@@ -9,11 +9,16 @@
 
 //! Safe wrapper around [`ffi::RSQueryNode`].
 
-use std::{ffi::c_char, ops::Bound, ptr::NonNull};
+use std::{
+    ffi::c_char,
+    marker::PhantomData,
+    ops::{Bound, Deref},
+    ptr::NonNull,
+};
 
 use inverted_index::NumericFilter;
 use query_node_type::{QueryNodeOptions, QueryNodeType};
-use rqe_core::DocId;
+use rqe_core::{DocId, FieldMask};
 
 /// The wildcard expansion mode for a [`QueryNode::Prefix`] node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -137,11 +142,18 @@ pub enum QueryNode<'a> {
 /// and provides typed accessors for each union variant, gated by the node
 /// type.
 ///
+/// All accessors here are read-only. Mutation goes through an exclusive
+/// [`QueryNodeMut`], obtained via [`as_mut`](Self::as_mut).
+///
 /// # Ownership
 ///
 /// `QueryNodeRef` does **not** own the node — it is a borrowed view.
 /// The underlying [`ffi::RSQueryNode`] (and its children) are owned by the
 /// C `QueryAST` and freed when the AST is dropped.
+///
+/// `#[repr(transparent)]` so a [`QueryNodeMut`] (also transparent over the same
+/// pointer) can expose itself as a `&QueryNodeRef` via [`AsRef`].
+#[repr(transparent)]
 pub struct QueryNodeRef(NonNull<ffi::RSQueryNode>);
 
 impl QueryNodeRef {
@@ -160,7 +172,7 @@ impl QueryNodeRef {
     }
 
     /// Shared reference to the underlying [`ffi::RSQueryNode`].
-    const fn as_ref(&self) -> &ffi::RSQueryNode {
+    const fn as_ffi_ref(&self) -> &ffi::RSQueryNode {
         // SAFETY: invariant (1) of `new`.
         unsafe { self.0.as_ref() }
     }
@@ -172,24 +184,42 @@ impl QueryNodeRef {
 
     /// The discriminant that selects which union variant is active.
     pub const fn node_type(&self) -> QueryNodeType {
-        self.as_ref().type_
+        self.as_ffi_ref().type_
     }
 
     /// The shared options header (field mask, weight, slop, flags, …).
     pub const fn opts(&self) -> &QueryNodeOptions {
-        &self.as_ref().opts
+        &self.as_ffi_ref().opts
+    }
+
+    /// Upgrade this shared view into an exclusive [`QueryNodeMut`] over the same
+    /// node subtree, enabling in-place mutation.
+    ///
+    /// # Safety
+    ///
+    /// The caller must have **exclusive** access to this node and all of its
+    /// descendants for the lifetime of the returned [`QueryNodeMut`]: while that
+    /// wrapper — or any [`QueryNodeMut`] reborrowed from it via
+    /// [`child_mut`](QueryNodeMut::child_mut) — is live, no other
+    /// [`QueryNodeRef`]/[`QueryNodeMut`] wrapping a node in this subtree may be
+    /// used, and no reference obtained from one (e.g. via [`opts`](Self::opts))
+    /// may be live. This cannot be enforced by the borrow checker because
+    /// wrappers to the same node can be minted from safe code (e.g.
+    /// [`child`](Self::child)); upholding it is the caller's responsibility.
+    ///
+    /// This is the single point where exclusivity is asserted. Given it, every
+    /// write through the returned [`QueryNodeMut`] is safe: its `&mut`-based API
+    /// and reborrowing [`child_mut`](QueryNodeMut::child_mut) keep each
+    /// individual mutation statically free of aliasing.
+    pub const unsafe fn as_mut(&self) -> QueryNodeMut<'_> {
+        QueryNodeMut(self.0, PhantomData)
     }
 
     /// The number of child nodes.
     ///
     /// Returns 0 when the `children` pointer is null (leaf nodes).
     pub fn num_children(&self) -> usize {
-        let children = self.as_ref().children;
-        if children.is_null() {
-            return 0;
-        }
-        // SAFETY: `children` is a non-null `array_*`-managed pointer.
-        unsafe { ffi::array_len_func(children.cast()) as usize }
+        children_len(self.as_ffi_ref())
     }
 
     /// Return the child at `index` as a new [`QueryNodeRef`].
@@ -198,21 +228,10 @@ impl QueryNodeRef {
     ///
     /// Panics if `index >= self.num_children()`.
     pub fn child(&self, index: usize) -> QueryNodeRef {
-        let n = self.num_children();
-        assert!(index < n, "index {index} out of bounds (num_children: {n})");
-        let children = self.as_ref().children;
-        // SAFETY: `children` is non-null (num_children > 0) and `index <
-        // num_children`, so `add` stays within the `array_*` allocation.
-        let slot = unsafe { children.add(index) };
-        // SAFETY: the slot is within bounds; dereference yields a valid
-        // child pointer.
-        let child_ptr = unsafe { *slot };
-        // SAFETY: all children in the AST are valid, non-null nodes
-        // (invariant 1 of `new`).
-        let child_nn = unsafe { NonNull::new_unchecked(child_ptr) };
-        // SAFETY: invariant (1) of `new` — child nodes in the AST are
-        // properly initialised.
-        unsafe { QueryNodeRef::new(child_nn) }
+        // SAFETY: `child_ptr` yields a valid, non-null child node pointer, and
+        // having (at least) shared access to this node we also have shared
+        // access to its children — invariants (1) and (2) of `new`.
+        unsafe { QueryNodeRef::new(child_ptr(self.as_ffi_ref(), index)) }
     }
 
     /// Iterator over all children as [`QueryNodeRef`]s.
@@ -222,7 +241,7 @@ impl QueryNodeRef {
 
     /// Convert the C tagged union into a [`QueryNode`] enum.
     pub fn as_enum(&self) -> QueryNode<'_> {
-        let inner = self.as_ref();
+        let inner = self.as_ffi_ref();
         // Each arm has its own `unsafe` block so that every union access
         // is individually justified, satisfying `multiple_unsafe_ops_per_block`.
         //
@@ -365,6 +384,125 @@ impl QueryNodeRef {
             }
         }
     }
+}
+
+/// Exclusive, mutable view of a [`ffi::RSQueryNode`] subtree.
+///
+/// Obtained from [`QueryNodeRef::as_mut`], whose `unsafe` contract establishes
+/// exclusive access to the node and its descendants. Given that invariant, the
+/// mutating API here is **safe**: [`and_field_mask`](Self::and_field_mask) takes
+/// `&mut self`, and [`child_mut`](Self::child_mut) reborrows `&mut self`, so the
+/// borrow checker guarantees that while a child view is live the parent (and any
+/// sibling view) cannot be read or mutated — no two live wrappers ever alias the
+/// same node. The exclusivity asserted once at [`as_mut`](QueryNodeRef::as_mut)
+/// thus propagates down the subtree without any further `unsafe`.
+///
+/// The lifetime `'node` ties the view to the originating [`QueryNodeRef`] so it
+/// cannot outlive the borrowed node.
+///
+/// Read-only access goes through [`Deref`]: all of [`QueryNodeRef`]'s shared
+/// accessors (`opts`, `num_children`, …) are reachable on a [`QueryNodeMut`]
+/// without re-implementation.
+///
+/// `#[repr(transparent)]` over the node pointer (the [`PhantomData`] is a ZST),
+/// matching [`QueryNodeRef`]'s layout so the [`Deref`] view can reinterpret a
+/// `&QueryNodeMut` as a borrowed `&QueryNodeRef`.
+#[repr(transparent)]
+pub struct QueryNodeMut<'node>(
+    NonNull<ffi::RSQueryNode>,
+    PhantomData<&'node mut ffi::RSQueryNode>,
+);
+
+impl QueryNodeMut<'_> {
+    /// Intersect `mask` into this node's [field mask](QueryNodeOptions::field_mask).
+    pub fn and_field_mask(&mut self, mask: FieldMask) {
+        // `&mut self` plus the exclusive-access invariant of
+        // [`QueryNodeRef::as_mut`] guarantee no other wrapper or reference
+        // aliases this node, so the read-modify-write below cannot race or
+        // alias a live reference.
+        //
+        // SAFETY: the node is valid, so a raw pointer to its `opts` field is in
+        // bounds; the update goes through the raw pointer without forming an
+        // intermediate reference.
+        let opts = unsafe { &raw mut (*self.0.as_ptr()).opts };
+        // SAFETY: as above — `opts` points to a valid, exclusively-owned
+        // `QueryNodeOptions`.
+        unsafe { (*opts).field_mask &= mask };
+    }
+
+    /// Reborrow the child at `index` as an exclusive [`QueryNodeMut`].
+    ///
+    /// The returned view borrows `*self`, so the parent cannot be read or
+    /// mutated while it is live. Exclusivity therefore propagates down the
+    /// subtree by construction — no further `unsafe` assertion is required.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index >= self.num_children()`.
+    pub fn child_mut(&mut self, index: usize) -> QueryNodeMut<'_> {
+        // The returned view's lifetime is tied to `&mut self` by the signature,
+        // so the parent stays exclusively borrowed while the child is live even
+        // though `child_ptr` itself only reads.
+        QueryNodeMut(child_ptr(self.as_ref().as_ffi_ref(), index), PhantomData)
+    }
+}
+
+impl Deref for QueryNodeMut<'_> {
+    type Target = QueryNodeRef;
+
+    /// A shared [`QueryNodeRef`] view of this node, for handing to read-only
+    /// evaluation once any mutation through this view is complete. Every
+    /// shared-view method of [`QueryNodeRef`] (e.g.
+    /// [`opts`](QueryNodeRef::opts), [`num_children`](QueryNodeRef::num_children))
+    /// is therefore reachable on a [`QueryNodeMut`] without re-implementation.
+    ///
+    /// The returned reference borrows `*self`, so a read view (or anything
+    /// derived from it, e.g. via [`opts`](QueryNodeRef::opts)) cannot be held
+    /// across — and therefore cannot alias — a mutation through this
+    /// [`QueryNodeMut`]: while the `&QueryNodeRef` is live, `self` is
+    /// shared-borrowed and the `&mut self` methods are unreachable.
+    fn deref(&self) -> &QueryNodeRef {
+        // SAFETY: `QueryNodeMut` and `QueryNodeRef` are both
+        // `#[repr(transparent)]` over `NonNull<ffi::RSQueryNode>`, so they share
+        // an identical layout and a `&QueryNodeMut` can be reinterpreted as a
+        // `&QueryNodeRef`. The shared borrow of `self` is carried into the
+        // returned reference's lifetime.
+        unsafe { &*(self as *const Self as *const QueryNodeRef) }
+    }
+}
+
+impl AsRef<QueryNodeRef> for QueryNodeMut<'_> {
+    fn as_ref(&self) -> &QueryNodeRef {
+        self
+    }
+}
+
+/// The number of children of `node` (0 when the `children` pointer is null).
+fn children_len(node: &ffi::RSQueryNode) -> usize {
+    let children = node.children;
+    if children.is_null() {
+        return 0;
+    }
+    // SAFETY: `children` is a non-null `array_*`-managed pointer.
+    unsafe { ffi::array_len_func(children.cast()) as usize }
+}
+
+/// Pointer to `node`'s child at `index`.
+///
+/// # Panics
+///
+/// Panics if `index >= children_len(node)`.
+fn child_ptr(node: &ffi::RSQueryNode, index: usize) -> NonNull<ffi::RSQueryNode> {
+    let n = children_len(node);
+    assert!(index < n, "index {index} out of bounds (num_children: {n})");
+    // SAFETY: `children` is non-null (`n > 0`) and `index < n`, so `add` stays
+    // within the `array_*` allocation.
+    let slot = unsafe { node.children.add(index) };
+    // SAFETY: the slot is within bounds; dereference yields a valid child
+    // pointer.
+    let child = unsafe { *slot };
+    // SAFETY: all children in the AST are valid, non-null nodes.
+    unsafe { NonNull::new_unchecked(child) }
 }
 
 const fn char_ptr_to_bound(ptr: *mut c_char, inclusive: bool) -> Bound<*const c_char> {

--- a/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
@@ -277,3 +277,52 @@ fn as_enum_all_payload_variants() {
         assert!(matches, "unexpected variant for {ty}");
     }
 }
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (array_new_sz)")]
+fn query_node_mut_narrows_child_field_masks() {
+    // A phrase node with mask 0b0110 and two children with broader masks.
+    // Narrowing each child against the parent intersects the masks in place,
+    // and `as_ref` still exposes the child for read-only evaluation.
+    let mut child1 = MockQueryNode::new(QueryNodeType::Token);
+    child1.opts_mut().field_mask = 0b1111;
+    let mut child2 = MockQueryNode::new(QueryNodeType::Numeric);
+    child2.opts_mut().field_mask = 0b1010;
+
+    let mut parent = MockQueryNode::new(QueryNodeType::Phrase);
+    parent.opts_mut().field_mask = 0b0110;
+    parent.set_children(&[child1.as_ptr(), child2.as_ptr()]);
+
+    let node = unsafe { QueryNodeRef::new(parent.as_non_null()) };
+    // SAFETY: `node` is the sole wrapper to this subtree for the duration of
+    // the test; no other wrapper or derived reference is live.
+    let mut node = unsafe { node.as_mut() };
+    assert_eq!(node.num_children(), 2);
+    let mask = node.opts().field_mask;
+
+    {
+        let mut c0 = node.child_mut(0);
+        c0.and_field_mask(mask);
+        assert_eq!(c0.opts().field_mask, 0b0110); // 0b1111 & 0b0110
+        assert_eq!(c0.as_ref().node_type(), QueryNodeType::Token);
+    }
+    {
+        let mut c1 = node.child_mut(1);
+        c1.and_field_mask(mask);
+        assert_eq!(c1.opts().field_mask, 0b0010); // 0b1010 & 0b0110
+        assert_eq!(c1.as_ref().node_type(), QueryNodeType::Numeric);
+    }
+
+    // The parent's own mask is untouched.
+    assert_eq!(node.opts().field_mask, 0b0110);
+}
+
+#[test]
+#[should_panic(expected = "out of bounds")]
+fn query_node_mut_child_out_of_bounds_panics() {
+    let mock = MockQueryNode::new(QueryNodeType::Wildcard);
+    let node = unsafe { QueryNodeRef::new(mock.as_non_null()) };
+    // SAFETY: sole wrapper to a leaf node; no other wrapper or reference live.
+    let mut node = unsafe { node.as_mut() };
+    let _ = node.child_mut(0);
+}

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -346,6 +346,12 @@ const HEADERS: &[HeaderAllowlist] = &[
         vars: &[],
     },
     HeaderAllowlist {
+        path: "src/search_options.h",
+        fns: &[],
+        types: &["RSSearchFlags"],
+        vars: &[],
+    },
+    HeaderAllowlist {
         path: "src/spec.h",
         fns: &[
             "IndexSpec_AcquireWriteLock",

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -21,6 +21,7 @@ use rqe_iterators::{
     c2rust::CRQEIterator,
     id_list::IdListSorted,
     interop::RQEIteratorWrapper,
+    intersection::{Intersection, NewIntersectionIterator, new_intersection_iterator},
     inverted_index::new_missing_iterator,
     not_reducer::{NewNotIterator, new_not_iterator},
     optional_reducer::{NewOptionalIterator, new_optional_iterator},
@@ -161,6 +162,7 @@ pub fn eval_node<'index>(
         QueryNode::Missing { field } => eval_missing(ctx, field).map(Evaluated::RustLeaf),
         QueryNode::Optional => Some(eval_optional(ctx, node)),
         QueryNode::Not => Some(eval_not(ctx, node)),
+        QueryNode::Phrase { exact } => eval_phrase(ctx, node, exact),
         // Node types not yet ported to Rust are delegated back to the C
         // dispatcher.
         _ => eval_node_c(ctx, node),
@@ -449,4 +451,90 @@ fn eval_not<'index>(ctx: &'index mut QueryEvalContext, node: &QueryNodeRef) -> E
                 .expect("not iterator must not be null"),
         ),
     }
+}
+
+/// `QN_PHRASE` — an ordered/unordered conjunction of child terms.
+///
+/// A single-child phrase is equivalent to the child itself, so the child is
+/// returned directly (after narrowing its field mask). Otherwise the children
+/// are evaluated and combined with an [`Intersection`], honoring the phrase's
+/// slop/in-order constraints (exact phrases force slop `0`, in order).
+///
+/// Each child's field mask is first intersected with the phrase node's own
+/// mask, so a child only matches the fields shared with the phrase.
+///
+/// * `exact` — whether this is an exact (quoted) phrase. When `true`, the
+///   terms must be adjacent and in order: slop is forced to `0` and in-order
+///   matching is required, ignoring the per-node and query-wide slop/in-order
+///   settings. When `false`, the slop and in-order constraints are resolved
+///   from the node's own options, falling back to the query-wide defaults.
+fn eval_phrase<'index>(
+    ctx: &'index mut QueryEvalContext,
+    node: &QueryNodeRef,
+    exact: bool,
+) -> Option<Evaluated<'index>> {
+    // Query evaluation is single-threaded and walks each AST node exactly once,
+    // top-down, so we hold exclusive access to this phrase node and its
+    // descendants for the duration of the call: no other wrapper into this
+    // subtree, and no reference derived from one, is live here.
+    //
+    // SAFETY: that exclusive-access precondition is exactly what `as_mut`
+    // requires. It is asserted once, here; every field-mask write below then
+    // goes through the exclusive `QueryNodeMut` and is statically alias-free.
+    let mut node = unsafe { node.as_mut() };
+
+    let num_children = node.num_children();
+    let node_mask = node.opts().field_mask;
+    // SAFETY: `RSGlobalConfig` is the process-wide config instance, read-only here.
+    let prioritize_union_children = unsafe { ffi::RSGlobalConfig.prioritizeIntersectUnionChildren };
+
+    // A single-child intersection is just the child; return it directly.
+    if num_children == 1 {
+        let mut child = node.child_mut(0);
+        child.and_field_mask(node_mask);
+        return eval_node(ctx, child.as_ref());
+    }
+
+    let weight = node.opts().weight;
+
+    let (max_slop, in_order) = if exact {
+        // An exact (quoted) phrase requires adjacent, in-order terms.
+        (Some(0), true)
+    } else {
+        // The node may override the query-wide slop; -1 means "use the default".
+        let slop = match node.opts().max_slop {
+            -1 => ctx.slop(),
+            s => s,
+        };
+        let in_order = ctx.search_in_order() || node.opts().in_order != 0;
+        let max_slop = if slop < 0 { None } else { Some(slop as u32) };
+        (max_slop, in_order)
+    };
+
+    // Recursively evaluate every child, narrowing its field mask first.
+    let mut children = Vec::with_capacity(num_children);
+    for i in 0..num_children {
+        let mut child = node.child_mut(i);
+        child.and_field_mask(node_mask);
+        children.push(eval_child_iterator(ctx, child.as_ref()));
+    }
+
+    let result_ptr = match new_intersection_iterator(children) {
+        NewIntersectionIterator::Empty => return Some(Evaluated::RustLeaf(Box::new(Empty))),
+        NewIntersectionIterator::Single(child) => child.into_raw().as_ptr(),
+        NewIntersectionIterator::Proceed(cs) => {
+            let intersection = Intersection::new_with_slop_order(
+                cs,
+                weight,
+                prioritize_union_children,
+                max_slop,
+                in_order,
+            );
+            RQEIteratorWrapper::boxed_new_compound(intersection)
+        }
+    };
+
+    Some(Evaluated::RustCompound(
+        NonNull::new(result_ptr).expect("phrase iterator must not be null"),
+    ))
 }

--- a/src/redisearch_rs/query_eval/tests/integration/eval/mod.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/eval/mod.rs
@@ -343,6 +343,38 @@ fn eval_not_wildcard_child_reduces_to_empty() {
 }
 
 // ---------------------------------------------------------------------------
+// QN_PHRASE → Intersection (single child shortcut)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (array_new_sz)")]
+fn eval_phrase_single_child_returns_child() {
+    // An intersection of one child is equivalent to the child itself.
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    mock_ctx.set_max_doc_id(3);
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+    let mut wc_child = MockQueryNode::new(QueryNodeType::Wildcard);
+    wc_child.opts_mut().weight = 1.0;
+    let mut phrase = MockQueryNode::new(QueryNodeType::Phrase);
+    phrase.opts_mut().weight = 1.0;
+    phrase.set_children(&[wc_child.as_ptr()]);
+    let node = unsafe { QueryNodeRef::new(phrase.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node)
+        .expect("should not be None")
+        .into_boxed();
+
+    // The single child is returned directly, not wrapped in an intersection.
+    assert_eq!(it.type_(), IteratorType::Wildcard);
+    for expected in [1, 2, 3] {
+        let r = it.read().unwrap().expect("should have a result");
+        assert_eq!(r.doc_id, expected);
+    }
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+// ---------------------------------------------------------------------------
 // QN_MISSING → Missing inverted-index iterator
 //
 // These require a real `IndexSpec` with a populated `missingFieldDict`, which
@@ -431,6 +463,8 @@ mod missing {
 
 /// Create an SDS string from `s`. The caller owns the result and must free
 /// it with [`ffi::sdsfree`].
+// Disabled under Miri: SDS creation calls into the C library, which Miri
+// cannot execute.
 #[cfg(not(miri))]
 fn new_sds(s: &str) -> ffi::sds {
     // SAFETY: `s` points to `s.len()` valid bytes; `sdsnewlen` copies them
@@ -833,5 +867,394 @@ mod not {
             // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
             unsafe { ffi::sdsfree(key) };
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// QN_PHRASE → Intersection over multiple real children.
+//
+// The multi-child path needs children resolving to real documents. Two QN_IDS
+// children provide that; with the query-wide default slop (-1) the phrase is a
+// plain set intersection, requiring no positional offsets.
+// ---------------------------------------------------------------------------
+
+// Disabled under Miri: `TestContext` and SDS creation call into the C library,
+// which Miri cannot execute.
+#[cfg(not(miri))]
+mod phrase {
+    use ffi::IndexFlags_Index_StoreFreqs;
+    use rqe_iterators_test_utils::{GlobalGuard, TestContext};
+
+    use super::*;
+
+    fn new_sds(s: &str) -> ffi::sds {
+        // SAFETY: `s` points to `s.len()` valid bytes; `sdsnewlen` copies them
+        // into a freshly allocated SDS string.
+        unsafe { ffi::sdsnewlen(s.as_ptr().cast(), s.len()) }
+    }
+
+    #[test]
+    fn eval_phrase_intersects_children() {
+        let _guard = GlobalGuard::default();
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        let id_a = context.add_document("doc_a");
+        let id_b = context.add_document("doc_b");
+        let id_c = context.add_document("doc_c");
+        assert_eq!((id_a, id_b, id_c), (1, 2, 3));
+
+        // The phrase path reads `opts.slop`/`opts.flags`, which the zero-init
+        // `QueryEvalCtx` leaves NULL; provide a real options struct with the
+        // query-wide defaults (slop -1, no flags).
+        let qctx = context.qctx();
+        // SAFETY: `RSSearchOptions` is a plain C struct whose fields (integers,
+        // flags, and pointers) are all valid when zero-initialised.
+        let mut search_opts: ffi::RSSearchOptions = unsafe { std::mem::zeroed() };
+        search_opts.slop = -1;
+        // SAFETY: `qctx` is a valid, exclusively-owned `QueryEvalCtx`; `search_opts`
+        // outlives `ctx` below.
+        unsafe { (*qctx.as_ptr()).opts = &mut search_opts };
+        let mut ctx = unsafe { QueryEvalContext::new(qctx) };
+
+        // child 1 matches {doc_a, doc_b}; child 2 matches {doc_b, doc_c}; the
+        // intersection is {doc_b}.
+        let keys1: Vec<ffi::sds> = vec![new_sds("doc_a"), new_sds("doc_b")];
+        let keys2: Vec<ffi::sds> = vec![new_sds("doc_b"), new_sds("doc_c")];
+        let mut c1 = MockQueryNode::new(QueryNodeType::Ids);
+        c1.set_ids(keys1.as_ptr(), std::ptr::null_mut(), keys1.len());
+        let mut c2 = MockQueryNode::new(QueryNodeType::Ids);
+        c2.set_ids(keys2.as_ptr(), std::ptr::null_mut(), keys2.len());
+
+        let mut phrase = MockQueryNode::new(QueryNodeType::Phrase);
+        phrase.opts_mut().weight = 1.0;
+        // -1 → no slop constraint, i.e. a plain set intersection.
+        phrase.opts_mut().max_slop = -1;
+        phrase.set_children(&[c1.as_ptr(), c2.as_ptr()]);
+        let node = unsafe { QueryNodeRef::new(phrase.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node)
+            .expect("should not be None")
+            .into_boxed();
+
+        assert_eq!(it.type_(), IteratorType::Intersect);
+        let r = it.read().unwrap().expect("should have a result");
+        assert_eq!(r.doc_id, 2);
+        assert!(matches!(it.read(), Ok(None)));
+
+        for key in keys1.into_iter().chain(keys2) {
+            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
+            unsafe { ffi::sdsfree(key) };
+        }
+    }
+
+    #[test]
+    fn eval_phrase_in_order_flag_builds_intersection() {
+        // A non-exact phrase with the query-wide `INORDER` flag set must forward
+        // `in_order = true` into the constructed `Intersection`. Two real QN_IDS
+        // children (neither empty nor a wildcard) are not reducible, so the
+        // intersection is built (type `Intersect`); the IDS results carry no
+        // offsets for the in-order check to reject, so the shared id still passes.
+        let _guard = GlobalGuard::default();
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        let id_a = context.add_document("doc_a");
+        let id_b = context.add_document("doc_b");
+        let id_c = context.add_document("doc_c");
+        assert_eq!((id_a, id_b, id_c), (1, 2, 3));
+
+        // Query-wide defaults except for the `INORDER` flag, which forces
+        // `ctx.search_in_order()` to report `true`.
+        let qctx = context.qctx();
+        // SAFETY: `RSSearchOptions` is a plain C struct whose fields (integers,
+        // flags, and pointers) are all valid when zero-initialised.
+        let mut search_opts: ffi::RSSearchOptions = unsafe { std::mem::zeroed() };
+        search_opts.slop = -1;
+        search_opts.flags |= ffi::RSSearchFlags_Search_InOrder as u32;
+        // SAFETY: `qctx` is a valid, exclusively-owned `QueryEvalCtx`; `search_opts`
+        // outlives `ctx` below.
+        unsafe { (*qctx.as_ptr()).opts = &mut search_opts };
+        let mut ctx = unsafe { QueryEvalContext::new(qctx) };
+
+        // child 1 matches {doc_a, doc_b}; child 2 matches {doc_b, doc_c}; the
+        // intersection is {doc_b}.
+        let keys1: Vec<ffi::sds> = vec![new_sds("doc_a"), new_sds("doc_b")];
+        let keys2: Vec<ffi::sds> = vec![new_sds("doc_b"), new_sds("doc_c")];
+        let mut c1 = MockQueryNode::new(QueryNodeType::Ids);
+        c1.set_ids(keys1.as_ptr(), std::ptr::null_mut(), keys1.len());
+        let mut c2 = MockQueryNode::new(QueryNodeType::Ids);
+        c2.set_ids(keys2.as_ptr(), std::ptr::null_mut(), keys2.len());
+
+        let mut phrase = MockQueryNode::new(QueryNodeType::Phrase);
+        phrase.opts_mut().weight = 1.0;
+        // Non-exact, default slop: only the query-wide `INORDER` flag drives
+        // `in_order`.
+        phrase.opts_mut().max_slop = -1;
+        phrase.set_children(&[c1.as_ptr(), c2.as_ptr()]);
+        let node = unsafe { QueryNodeRef::new(phrase.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node)
+            .expect("should not be None")
+            .into_boxed();
+
+        assert_eq!(it.type_(), IteratorType::Intersect);
+        let r = it.read().unwrap().expect("should have a result");
+        assert_eq!(r.doc_id, 2);
+        assert!(matches!(it.read(), Ok(None)));
+
+        for key in keys1.into_iter().chain(keys2) {
+            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
+            unsafe { ffi::sdsfree(key) };
+        }
+    }
+
+    #[test]
+    fn eval_phrase_node_in_order_builds_intersection() {
+        // A non-exact phrase with the per-node `in_order` option set (query-wide
+        // `INORDER` flag clear) must still forward `in_order = true` into the
+        // constructed `Intersection`. This drives the `node.opts().in_order != 0`
+        // disjunct rather than `ctx.search_in_order()`. Two real QN_IDS children
+        // (neither empty nor a wildcard) are not reducible, so the intersection
+        // is built (type `Intersect`); the IDS results carry no offsets for the
+        // in-order check to reject, so the shared id still passes.
+        let _guard = GlobalGuard::default();
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        let id_a = context.add_document("doc_a");
+        let id_b = context.add_document("doc_b");
+        let id_c = context.add_document("doc_c");
+        assert_eq!((id_a, id_b, id_c), (1, 2, 3));
+
+        // Query-wide defaults with the `INORDER` flag clear, so only the per-node
+        // `in_order` option can drive in-order matching.
+        let qctx = context.qctx();
+        // SAFETY: `RSSearchOptions` is a plain C struct whose fields (integers,
+        // flags, and pointers) are all valid when zero-initialised.
+        let mut search_opts: ffi::RSSearchOptions = unsafe { std::mem::zeroed() };
+        search_opts.slop = -1;
+        // SAFETY: `qctx` is a valid, exclusively-owned `QueryEvalCtx`; `search_opts`
+        // outlives `ctx` below.
+        unsafe { (*qctx.as_ptr()).opts = &mut search_opts };
+        let mut ctx = unsafe { QueryEvalContext::new(qctx) };
+
+        // child 1 matches {doc_a, doc_b}; child 2 matches {doc_b, doc_c}; the
+        // intersection is {doc_b}.
+        let keys1: Vec<ffi::sds> = vec![new_sds("doc_a"), new_sds("doc_b")];
+        let keys2: Vec<ffi::sds> = vec![new_sds("doc_b"), new_sds("doc_c")];
+        let mut c1 = MockQueryNode::new(QueryNodeType::Ids);
+        c1.set_ids(keys1.as_ptr(), std::ptr::null_mut(), keys1.len());
+        let mut c2 = MockQueryNode::new(QueryNodeType::Ids);
+        c2.set_ids(keys2.as_ptr(), std::ptr::null_mut(), keys2.len());
+
+        let mut phrase = MockQueryNode::new(QueryNodeType::Phrase);
+        phrase.opts_mut().weight = 1.0;
+        // Non-exact, default slop, but the per-node `in_order` option is set.
+        phrase.opts_mut().max_slop = -1;
+        phrase.opts_mut().in_order = 1;
+        phrase.set_children(&[c1.as_ptr(), c2.as_ptr()]);
+        let node = unsafe { QueryNodeRef::new(phrase.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node)
+            .expect("should not be None")
+            .into_boxed();
+
+        assert_eq!(it.type_(), IteratorType::Intersect);
+        let r = it.read().unwrap().expect("should have a result");
+        assert_eq!(r.doc_id, 2);
+        assert!(matches!(it.read(), Ok(None)));
+
+        for key in keys1.into_iter().chain(keys2) {
+            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
+            unsafe { ffi::sdsfree(key) };
+        }
+    }
+
+    #[test]
+    fn eval_phrase_none_child_becomes_empty() {
+        let _guard = GlobalGuard::default();
+        // A phrase child that evaluates to `None` (a QN_MISSING node for a field
+        // with no missing values) yields a NULL child pointer, which the
+        // multi-child path substitutes with a freshly built `Empty` iterator.
+        // An empty child makes the whole intersection empty.
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        let id_a = context.add_document("doc_a");
+        let id_b = context.add_document("doc_b");
+        assert_eq!((id_a, id_b), (1, 2));
+
+        // The phrase path reads `opts.slop`/`opts.flags`, which the zero-init
+        // `QueryEvalCtx` leaves NULL; provide a real options struct with the
+        // query-wide defaults (slop -1, no flags).
+        let qctx = context.qctx();
+        // SAFETY: `RSSearchOptions` is a plain C struct whose fields (integers,
+        // flags, and pointers) are all valid when zero-initialised.
+        let mut search_opts: ffi::RSSearchOptions = unsafe { std::mem::zeroed() };
+        search_opts.slop = -1;
+        // SAFETY: `qctx` is a valid, exclusively-owned `QueryEvalCtx`; `search_opts`
+        // outlives `ctx` below.
+        unsafe { (*qctx.as_ptr()).opts = &mut search_opts };
+        let mut ctx = unsafe { QueryEvalContext::new(qctx) };
+
+        // child 1: QN_MISSING for a field with no missing values → None.
+        let mut missing_child = MockQueryNode::new(QueryNodeType::Missing);
+        missing_child.set_missing_field(context.field_spec());
+        // child 2: QN_IDS resolving to a real document.
+        let keys: Vec<ffi::sds> = vec![new_sds("doc_a")];
+        let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
+        ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
+
+        let mut phrase = MockQueryNode::new(QueryNodeType::Phrase);
+        phrase.opts_mut().weight = 1.0;
+        phrase.opts_mut().max_slop = -1;
+        phrase.set_children(&[missing_child.as_ptr(), ids_child.as_ptr()]);
+        let node = unsafe { QueryNodeRef::new(phrase.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node)
+            .expect("a multi-child phrase always yields an iterator")
+            .into_boxed();
+
+        assert_eq!(it.type_(), IteratorType::Empty);
+        assert!(matches!(it.read(), Ok(None)));
+        assert!(it.at_eof());
+
+        for key in keys {
+            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
+            unsafe { ffi::sdsfree(key) };
+        }
+    }
+
+    #[test]
+    fn eval_phrase_exact_builds_intersection() {
+        // An exact (quoted) phrase forces slop 0 / in-order, which `eval_phrase`
+        // must forward into a constructed `Intersection`. Two real QN_IDS
+        // children (neither empty nor a wildcard) are not reducible, so the
+        // reducer reaches its `Proceed` arm and `Intersection::new_with_slop_order`
+        // is invoked with `(Some(0), true)` — the only test that exercises that
+        // path. Both children resolve to the same document, so the intersection
+        // is built (type `Intersect`) and yields that shared id (the IDS results
+        // carry no offsets for the slop check to reject).
+        let _guard = GlobalGuard::default();
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        let id_a = context.add_document("doc_a");
+        let id_b = context.add_document("doc_b");
+        assert_eq!((id_a, id_b), (1, 2));
+
+        let qctx = context.qctx();
+        // SAFETY: `RSSearchOptions` is a plain C struct whose fields (integers,
+        // flags, and pointers) are all valid when zero-initialised.
+        let mut search_opts: ffi::RSSearchOptions = unsafe { std::mem::zeroed() };
+        search_opts.slop = -1;
+        // SAFETY: `qctx` is a valid, exclusively-owned `QueryEvalCtx`; `search_opts`
+        // outlives `ctx` below.
+        unsafe { (*qctx.as_ptr()).opts = &mut search_opts };
+        let mut ctx = unsafe { QueryEvalContext::new(qctx) };
+
+        // Both children resolve to the shared document `doc_b`.
+        let keys1: Vec<ffi::sds> = vec![new_sds("doc_b")];
+        let keys2: Vec<ffi::sds> = vec![new_sds("doc_b")];
+        let mut c1 = MockQueryNode::new(QueryNodeType::Ids);
+        c1.set_ids(keys1.as_ptr(), std::ptr::null_mut(), keys1.len());
+        let mut c2 = MockQueryNode::new(QueryNodeType::Ids);
+        c2.set_ids(keys2.as_ptr(), std::ptr::null_mut(), keys2.len());
+
+        let mut phrase = MockQueryNode::new(QueryNodeType::Phrase);
+        phrase.opts_mut().weight = 1.0;
+        // Exact phrase → `eval_phrase` resolves `(Some(0), true)`.
+        phrase.set_phrase_exact(1);
+        phrase.set_children(&[c1.as_ptr(), c2.as_ptr()]);
+        let node = unsafe { QueryNodeRef::new(phrase.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node)
+            .expect("should not be None")
+            .into_boxed();
+
+        // The exact params flowed into a real intersection (not a reduced leaf).
+        assert_eq!(it.type_(), IteratorType::Intersect);
+        let r = it.read().unwrap().expect("should have a result");
+        assert_eq!(r.doc_id, 2);
+        assert!(matches!(it.read(), Ok(None)));
+        assert!(it.at_eof());
+
+        for key in keys1.into_iter().chain(keys2) {
+            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
+            unsafe { ffi::sdsfree(key) };
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// QN_PHRASE reducer/slop paths that need no real index.
+//
+// These exercise the intersection-reducer shortcircuits (`Empty`, `Single`) and
+// the slop/in-order resolution, which depend only on the node options, the
+// lightweight `MockQueryEvalCtx`, and the process-wide `RSGlobalConfig`.
+// ---------------------------------------------------------------------------
+
+// Disabled under Miri: the multi-child path reads the C `RSGlobalConfig`
+// static, which Miri cannot access.
+#[cfg(not(miri))]
+mod phrase_reducer {
+    use super::*;
+
+    #[test]
+    fn eval_phrase_exact_with_empty_children_reduces_to_empty() {
+        // An exact (quoted) phrase forces slop 0, in order. With two QN_NULL
+        // children — both `Empty` iterators — the intersection reducer
+        // shortcircuits any empty child to an overall `Empty` result.
+        let mut mock_ctx = MockQueryEvalCtx::new();
+        let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+        let c1 = MockQueryNode::new(QueryNodeType::Null);
+        let c2 = MockQueryNode::new(QueryNodeType::Null);
+        let mut phrase = MockQueryNode::new(QueryNodeType::Phrase);
+        phrase.opts_mut().weight = 1.0;
+        phrase.set_phrase_exact(1);
+        phrase.set_children(&[c1.as_ptr(), c2.as_ptr()]);
+        let node = unsafe { QueryNodeRef::new(phrase.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node)
+            .expect("a multi-child phrase always yields an iterator")
+            .into_boxed();
+
+        assert_eq!(it.type_(), IteratorType::Empty);
+        assert!(matches!(it.read(), Ok(None)));
+        assert!(it.at_eof());
+    }
+
+    #[test]
+    fn eval_phrase_slop_all_wildcard_children_reduce_to_single() {
+        // A non-exact phrase with an explicit slop (>= 0) takes the
+        // node-slop-override branch (`Some(slop as u32)`), distinct from the
+        // default-slop (-1) path. Two wildcard children are all stripped by the
+        // reducer, leaving a single wildcard returned directly.
+        let mut mock_ctx = MockQueryEvalCtx::new();
+        mock_ctx.set_max_doc_id(3);
+        let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+        let mut c1 = MockQueryNode::new(QueryNodeType::Wildcard);
+        c1.opts_mut().weight = 1.0;
+        let mut c2 = MockQueryNode::new(QueryNodeType::Wildcard);
+        c2.opts_mut().weight = 1.0;
+        let mut phrase = MockQueryNode::new(QueryNodeType::Phrase);
+        phrase.opts_mut().weight = 1.0;
+        // A concrete, non-negative slop exercises the `s => s` arm and the
+        // `Some(slop as u32)` branch of the max-slop computation.
+        phrase.opts_mut().max_slop = 2;
+        phrase.set_children(&[c1.as_ptr(), c2.as_ptr()]);
+        let node = unsafe { QueryNodeRef::new(phrase.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node)
+            .expect("a multi-child phrase always yields an iterator")
+            .into_boxed();
+
+        // All children were wildcards, so the reducer returns the single
+        // remaining wildcard directly.
+        assert_eq!(it.type_(), IteratorType::Wildcard);
+        for expected in [1, 2, 3] {
+            let r = it.read().unwrap().expect("should have a result");
+            assert_eq!(r.doc_id, expected);
+        }
+        assert!(matches!(it.read(), Ok(None)));
+        assert!(it.at_eof());
     }
 }


### PR DESCRIPTION
- Based on top of https://github.com/RediSearch/RediSearch/pull/10149
- PR is using `master` as base so benchmarks are compared against it.
- You can just review the top commit directly.

Port the `QN_PHRASE` evaluation from C to the Rust.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
