### PR TITLE
[MOD-15571] Skip TestIndexMultiValueJsonReload under coverage until 2026-07-06

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1908,6 +1908,9 @@ class TestIndexMultiValueJsonReload:
 
     def __init__(self):
         skipTest(no_json=True)
+        # Flaky under coverage (MOD-15571); skip only on coverage runs until the date below.
+        if CODE_COVERAGE:
+            skipTestUntil("2026-07-06", reason="Flaky test under coverage, see MOD-15571")
         self.env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
         self.dim = 4
         self.per_doc = 5


### PR DESCRIPTION
## Summary

`TestIndexMultiValueJsonReload` (multi-value JSON vector indexing + reload across HNSW / FLAT / SVS-VAMANA float32/float16) was split per algorithm in #10168 and #10229 to fit within the coverage Coordinator per-test timeout. It is still flaky under coverage, so re-instate the coverage-only skip (originally added in #9575) and extend the date to **2026-07-06**.

## Change

In the class `__init__`, after the existing `skipTest(no_json=True)` guard:

```python
# Flaky under coverage (MOD-15571); skip only on coverage runs until the date below.
if CODE_COVERAGE:
    skipTestUntil("2026-07-06", reason="Flaky test under coverage, see MOD-15571")
```

Placing it in `__init__` skips all four split methods on coverage runs. Non-coverage runs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)