### PR TITLE
[MOD-15148] Accept FLOAT16 for disk HNSW vector indexes

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -773,7 +773,8 @@ static int parseVectorField_hnsw(IndexSpec *sp, FieldSpec *fs, VecSimParams *par
 
   // Disk-mode validation: enforce mandatory parameters
   if (isSpecOnDiskForValidation(sp)) {
-    if (params->algoParams.hnswParams.type != VecSimType_FLOAT32) {
+    if (params->algoParams.hnswParams.type != VecSimType_FLOAT32 &&
+        params->algoParams.hnswParams.type != VecSimType_FLOAT16) {
       const char *typeName = VecSimType_ToString(params->algoParams.hnswParams.type);
       QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL,
         "Disk index does not support %s vector type", typeName);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1484,3 +1484,109 @@ TEST_F(IndexTest, testHybridIteratorReducerWithWildcardChild) {
   ASSERT_EQ(hi->searchMode, VECSIM_STANDARD_KNN);
   hybridIt->Free(hybridIt);
 }
+
+// Forces disk-mode validation on (SearchDisk_IsEnabledForValidation() reads
+// RSGlobalConfig.simulateInFlex) and restores the previous value on scope exit,
+// even if an ASSERT_* aborts the test body. (MOD-15148)
+struct SimulateInFlexGuard {
+  bool prev;
+  SimulateInFlexGuard() : prev(RSGlobalConfig.simulateInFlex) {
+    RSGlobalConfig.simulateInFlex = true;
+  }
+  ~SimulateInFlexGuard() {
+    RSGlobalConfig.simulateInFlex = prev;
+  }
+};
+
+// MOD-15148: disk HNSW validation accepts FLOAT16 alongside FLOAT32, and keeps
+// rejecting every other element type. All schemas carry ON HASH SKIPINITIALSCAN
+// because Flex specs require the SkipInitialScan flag (src/spec.c).
+TEST_F(IndexTest, testDiskHnswAcceptsFloat16) {
+  SimulateInFlexGuard flexGuard;
+  const size_t dim = 4;
+
+  // Positive: FLOAT16 disk HNSW parses, and the stored params carry the FP16
+  // type and the matching 2-byte blob size.
+  {
+    QueryError err = QueryError_Default();
+    const char *args[] = {
+        "ON",
+        "HASH",
+        "SKIPINITIALSCAN",
+        "SCHEMA",
+        "v",
+        "VECTOR",
+        "HNSW",
+        "14",
+        "TYPE",
+        "FLOAT16",
+        "DIM",
+        "4",
+        "DISTANCE_METRIC",
+        "L2",
+        "M",
+        "16",
+        "EF_CONSTRUCTION",
+        "200",
+        "EF_RUNTIME",
+        "10",
+        "RERANK",
+        "TRUE",
+    };
+    StrongRef ref =
+        IndexSpec_ParseC(NULL, "idx_fp16", args, sizeof(args) / sizeof(const char *), &err);
+    IndexSpec *s = (IndexSpec *)StrongRef_Get(ref);
+    ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
+    ASSERT_TRUE(s);
+
+    const FieldSpec *f = IndexSpec_GetFieldWithLength(s, "v", 1);
+    ASSERT_TRUE(f != NULL);
+    ASSERT_TRUE(FIELD_IS(f, INDEXFLD_T_VECTOR));
+    // HNSW is stored as a TIERED wrapper; the HNSW params live under primaryIndexParams.
+    ASSERT_EQ(f->vectorOpts.vecSimParams.algo, VecSimAlgo_TIERED);
+    VecSimParams *prim = f->vectorOpts.vecSimParams.algoParams.tieredParams.primaryIndexParams;
+    ASSERT_TRUE(prim != NULL);
+    ASSERT_EQ(prim->algo, VecSimAlgo_HNSWLIB);
+    ASSERT_EQ(prim->algoParams.hnswParams.type, VecSimType_FLOAT16);
+    ASSERT_EQ(f->vectorOpts.expBlobSize, (size_t)dim * 2);  // VecSimType_sizeof(FLOAT16) == 2
+
+    Indexes_RemoveSpecFromGlobals(ref, false);
+  }
+
+  // Negative: every other element type is still rejected on disk.
+  const char *unsupportedTypes[] = {"FLOAT64", "BFLOAT16", "INT8", "UINT8"};
+  for (const char *vecType : unsupportedTypes) {
+    QueryError err = QueryError_Default();
+    const char *args[] = {
+        "ON",
+        "HASH",
+        "SKIPINITIALSCAN",
+        "SCHEMA",
+        "v",
+        "VECTOR",
+        "HNSW",
+        "14",
+        "TYPE",
+        vecType,
+        "DIM",
+        "4",
+        "DISTANCE_METRIC",
+        "L2",
+        "M",
+        "16",
+        "EF_CONSTRUCTION",
+        "200",
+        "EF_RUNTIME",
+        "10",
+        "RERANK",
+        "TRUE",
+    };
+    StrongRef ref =
+        IndexSpec_ParseC(NULL, "idx_bad", args, sizeof(args) / sizeof(const char *), &err);
+    ASSERT_TRUE(QueryError_HasError(&err)) << "type " << vecType << " should be rejected";
+    ASSERT_EQ(nullptr, StrongRef_Get(ref));
+    ASSERT_NE(nullptr, strstr(QueryError_GetUserError(&err), "Disk index does not support"))
+        << "type " << vecType << " got: " << QueryError_GetUserError(&err);
+    QueryError_ClearError(&err);
+  }
+}

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -38,6 +38,7 @@ extern "C" {
 #include <stdio.h>
 #include <time.h>
 #include <float.h>
+#include <iterator>  // std::size
 #include <vector>
 #include <cstdint>
 #include <random>
@@ -1608,6 +1609,9 @@ TEST_F(IndexTest, testDiskHnswAcceptsFloat16) {
     };
     StrongRef ref =
         IndexSpec_ParseC(nullptr, "idx_bad", args, std::size(args), &err);
+    // Cleans up if a regression ever lets an unsupported type parse, so a failing
+    // assertion below cannot leak the created spec into later tests.
+    SpecCleanupGuard cleanup(ref);
     ASSERT_TRUE(QueryError_HasError(&err)) << "type " << vecType << " should be rejected";
     ASSERT_EQ(nullptr, StrongRef_Get(ref));
     ASSERT_NE(nullptr, strstr(QueryError_GetUserError(&err), "Disk index does not support"))

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1493,6 +1493,9 @@ struct SimulateInFlexGuard {
   SimulateInFlexGuard() : prev(RSGlobalConfig.simulateInFlex) {
     RSGlobalConfig.simulateInFlex = true;
   }
+  // Non-copyable/movable: a copy would restore the flag twice on scope exit.
+  SimulateInFlexGuard(const SimulateInFlexGuard &) = delete;
+  SimulateInFlexGuard &operator=(const SimulateInFlexGuard &) = delete;
   ~SimulateInFlexGuard() {
     RSGlobalConfig.simulateInFlex = prev;
   }
@@ -1509,6 +1512,10 @@ struct SpecCleanupGuard {
   StrongRef ref;
   explicit SpecCleanupGuard(StrongRef r) : ref(r) {
   }
+  // Non-copyable/movable: a copy would let two destructors each consume the same
+  // StrongRef, double-removing the spec (use-after-free).
+  SpecCleanupGuard(const SpecCleanupGuard &) = delete;
+  SpecCleanupGuard &operator=(const SpecCleanupGuard &) = delete;
   ~SpecCleanupGuard() {
     if (StrongRef_Get(ref)) {
       Indexes_RemoveSpecFromGlobals(ref, false);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1559,20 +1559,20 @@ TEST_F(IndexTest, testDiskHnswAcceptsFloat16) {
         "TRUE",
     };
     StrongRef ref =
-        IndexSpec_ParseC(NULL, "idx_fp16", args, sizeof(args) / sizeof(const char *), &err);
+        IndexSpec_ParseC(nullptr, "idx_fp16", args, std::size(args), &err);
     // Cleans up on scope exit even if an assertion below aborts the test.
     SpecCleanupGuard cleanup(ref);
-    IndexSpec *s = (IndexSpec *)StrongRef_Get(ref);
+    auto *s = (IndexSpec *)StrongRef_Get(ref);
     ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
     ASSERT_TRUE(s);
 
     const FieldSpec *f = IndexSpec_GetFieldWithLength(s, "v", 1);
-    ASSERT_TRUE(f != NULL);
+    ASSERT_TRUE(f != nullptr);
     ASSERT_TRUE(FIELD_IS(f, INDEXFLD_T_VECTOR));
     // HNSW is stored as a TIERED wrapper; the HNSW params live under primaryIndexParams.
     ASSERT_EQ(f->vectorOpts.vecSimParams.algo, VecSimAlgo_TIERED);
-    VecSimParams *prim = f->vectorOpts.vecSimParams.algoParams.tieredParams.primaryIndexParams;
-    ASSERT_TRUE(prim != NULL);
+    const VecSimParams *prim = f->vectorOpts.vecSimParams.algoParams.tieredParams.primaryIndexParams;
+    ASSERT_TRUE(prim != nullptr);
     ASSERT_EQ(prim->algo, VecSimAlgo_HNSWLIB);
     ASSERT_EQ(prim->algoParams.hnswParams.type, VecSimType_FLOAT16);
     ASSERT_EQ(f->vectorOpts.expBlobSize, (size_t)dim * 2);  // VecSimType_sizeof(FLOAT16) == 2
@@ -1607,7 +1607,7 @@ TEST_F(IndexTest, testDiskHnswAcceptsFloat16) {
         "TRUE",
     };
     StrongRef ref =
-        IndexSpec_ParseC(NULL, "idx_bad", args, sizeof(args) / sizeof(const char *), &err);
+        IndexSpec_ParseC(nullptr, "idx_bad", args, std::size(args), &err);
     ASSERT_TRUE(QueryError_HasError(&err)) << "type " << vecType << " should be rejected";
     ASSERT_EQ(nullptr, StrongRef_Get(ref));
     ASSERT_NE(nullptr, strstr(QueryError_GetUserError(&err), "Disk index does not support"))

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1498,6 +1498,20 @@ struct SimulateInFlexGuard {
   }
 };
 
+// Removes a parsed spec from the globals on scope exit, even if an ASSERT_*
+// aborts the test body before the explicit cleanup is reached. No-op when the
+// ref is already gone (parse failed, or it was released earlier). (MOD-15148)
+struct SpecCleanupGuard {
+  StrongRef ref;
+  explicit SpecCleanupGuard(StrongRef r) : ref(r) {
+  }
+  ~SpecCleanupGuard() {
+    if (StrongRef_Get(ref)) {
+      Indexes_RemoveSpecFromGlobals(ref, false);
+    }
+  }
+};
+
 // MOD-15148: disk HNSW validation accepts FLOAT16 alongside FLOAT32, and keeps
 // rejecting every other element type. All schemas carry ON HASH SKIPINITIALSCAN
 // because Flex specs require the SkipInitialScan flag (src/spec.c).
@@ -1535,6 +1549,8 @@ TEST_F(IndexTest, testDiskHnswAcceptsFloat16) {
     };
     StrongRef ref =
         IndexSpec_ParseC(NULL, "idx_fp16", args, sizeof(args) / sizeof(const char *), &err);
+    // Cleans up on scope exit even if an assertion below aborts the test.
+    SpecCleanupGuard cleanup(ref);
     IndexSpec *s = (IndexSpec *)StrongRef_Get(ref);
     ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
     ASSERT_TRUE(s);
@@ -1549,8 +1565,6 @@ TEST_F(IndexTest, testDiskHnswAcceptsFloat16) {
     ASSERT_EQ(prim->algo, VecSimAlgo_HNSWLIB);
     ASSERT_EQ(prim->algoParams.hnswParams.type, VecSimType_FLOAT16);
     ASSERT_EQ(f->vectorOpts.expBlobSize, (size_t)dim * 2);  // VecSimType_sizeof(FLOAT16) == 2
-
-    Indexes_RemoveSpecFromGlobals(ref, false);
   }
 
   // Negative: every other element type is still rejected on disk.

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1498,9 +1498,13 @@ struct SimulateInFlexGuard {
   }
 };
 
-// Removes a parsed spec from the globals on scope exit, even if an ASSERT_*
-// aborts the test body before the explicit cleanup is reached. No-op when the
-// ref is already gone (parse failed, or it was released earlier). (MOD-15148)
+// Consumes the parsed spec's StrongRef on scope exit (via
+// Indexes_RemoveSpecFromGlobals), so the spec/prefix globals are cleaned up even
+// if an ASSERT_* aborts the test body. The StrongRef_Get check skips removal
+// only when the parse failed (the ref carries no object). This guard must be the
+// sole owner of the ref: do NOT also call Indexes_RemoveSpecFromGlobals on the
+// same ref, since that consumes it and the StrongRef_Get here would then be a
+// use-after-free. (MOD-15148)
 struct SpecCleanupGuard {
   StrongRef ref;
   explicit SpecCleanupGuard(StrongRef r) : ref(r) {

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -478,7 +478,7 @@ def test_flex_disk_hnsw_float16(env):
     ).ok()
 
     # Unsupported element types are still rejected on disk.
-    for vec_type in ('FLOAT64', 'BFLOAT16'):
+    for vec_type in ('FLOAT64', 'BFLOAT16', 'INT8', 'UINT8'):
         env.expect(
             'FT.CREATE', f'idx_{vec_type.lower()}', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA',
             'v', 'VECTOR', 'HNSW', '14',

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -448,6 +448,51 @@ def test_flex_disk_hnsw_rerank_value(env):
 
 
 @skip(cluster=True)
+@with_simulate_in_flex(True)
+def test_flex_disk_hnsw_float16(env):
+    # MOD-15148: disk HNSW vector indexes accept FLOAT16 in addition to FLOAT32,
+    # while every other element type is still rejected. Creation only.
+    env.expect(
+        'FT.CREATE', 'idx_fp16', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA',
+        'v', 'VECTOR', 'HNSW', '14',
+        'TYPE', 'FLOAT16',
+        'DIM', '4',
+        'DISTANCE_METRIC', 'L2',
+        'M', '16',
+        'EF_CONSTRUCTION', '200',
+        'EF_RUNTIME', '10',
+        'RERANK', 'TRUE',
+    ).ok()
+
+    # FLOAT32 remains accepted (no regression).
+    env.expect(
+        'FT.CREATE', 'idx_fp32', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA',
+        'v', 'VECTOR', 'HNSW', '14',
+        'TYPE', 'FLOAT32',
+        'DIM', '4',
+        'DISTANCE_METRIC', 'L2',
+        'M', '16',
+        'EF_CONSTRUCTION', '200',
+        'EF_RUNTIME', '10',
+        'RERANK', 'TRUE',
+    ).ok()
+
+    # Unsupported element types are still rejected on disk.
+    for vec_type in ('FLOAT64', 'BFLOAT16'):
+        env.expect(
+            'FT.CREATE', f'idx_{vec_type.lower()}', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA',
+            'v', 'VECTOR', 'HNSW', '14',
+            'TYPE', vec_type,
+            'DIM', '4',
+            'DISTANCE_METRIC', 'L2',
+            'M', '16',
+            'EF_CONSTRUCTION', '200',
+            'EF_RUNTIME', '10',
+            'RERANK', 'TRUE',
+        ).error().contains('Disk index does not support')
+
+
+@skip(cluster=True)
 @with_simulate_in_flex(False)
 def test_ram_hnsw_rerank_rejected(env):
     # In RAM mode RERANK is a disk-only option and must be rejected outright,


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. **Current**: Disk-mode HNSW vector fields are rejected at `FT.CREATE` validation unless `TYPE FLOAT32` (single-type guard in `src/spec.c`), even though the disk backend now supports FP16.
2. **Change**: Relax that TYPE whitelist to accept `VecSimType_FLOAT16` alongside `VecSimType_FLOAT32`. Every other element type (`FLOAT64`, `BFLOAT16`, `INT8`, `UINT8`, ...) and every other disk restriction (HNSW-only, no MULTI, mandatory `M` / `EF_CONSTRUCTION` / `EF_RUNTIME` / `RERANK`) stay exactly as before. Blob sizing already uses `VecSimType_sizeof(type)`, so it needed no change.
3. **Outcome**: FP16 disk HNSW indexes pass RediSearch validation and forward their params unchanged to the disk backend; unsupported types still fail with a clear error; FP32 behavior is unchanged.

This only opens the RediSearch validation gate — the downstream FP16 disk construction and SQ8↔FP16 distance kernels already landed in MOD-15144 and MOD-15141.

#### Which additional issues this PR fixes
1. MOD-15148

#### Main objects this PR modified
1. `src/spec.c` — disk-mode HNSW TYPE guard (`parseVectorField_hnsw` disk validation block)
2. `tests/cpptests/test_cpp_index.cpp` — `IndexTest.testDiskHnswAcceptsFloat16`
3. `tests/pytests/test_flex_validation.py` — `test_flex_disk_hnsw_float16`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: `FT.CREATE` on a disk (Flex) index now accepts `TYPE FLOAT16` for HNSW vector fields, in addition to `FLOAT32`.

---

> **Note — backend support.** The full FP16 disk backend stack is already merged: SQ8↔FP16 distance kernels (MOD-15141), the vecsim_disk factory/type dispatch (MOD-15144), and the vecsim_disk RDB serializer with a V2 format + backward-compatible V1 reader (MOD-15145). So FP16 disk indexes both construct and persist (RDB/SST round-trip) on a backend built from those commits.
>
> The validation-only tests in this PR cannot exercise the backend ABI — under `simulateInFlex` the disk storage handle is NULL and the RAM path runs, so `VecSimDisk_CreateIndex` is never called. The real end-to-end proof (FP16 create + ingest + KNN + hot-restart SST round-trip) lives in the RediSearchDisk repo, run after a `deps/RediSearch` submodule bump to this commit.
>
> **Residual risk — cross-version skew, handled operationally (not by runtime code).** A per-`FT.CREATE` capability gate was considered and rejected: the disk backend exposes no "supports type T" query to gate on, and RediSearch core + vecsim_disk ship as a single co-built artifact, so a process can never pair the relaxed guard with an FP16-incapable backend. The only way to hit a mismatch is a deployment that pairs new core with an old backend, or replicates an FP16 index to a not-yet-upgraded node — handled by the standard upgrade barrier (finish upgrading before creating FP16 disk indexes) and called out in the release notes, not by a config flag that would disable FP16 disk by default for a state that cannot occur in a correct build.
