### PR TITLE
[MOD-15032] Implement FT.HYBRID tail timeout for cluster mode

### DIFF
--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -1156,12 +1156,8 @@ void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     // RSGlobalConfig on this BG thread (races FT.CONFIG SET).
     applyCoordReqConfigTimeoutPolicy(hreq, CoordRequestCtx_GetTimeoutPolicy(reqCtx));
 
-    // The SEARCH/VSIM debug timeouts are applied on the shards (the subqueries
-    // run there), forwarded via the _FT.DEBUG-wrapped shard command. The tail
-    // (merge) pipeline runs only here on the coordinator, so its timeout can't
-    // be forwarded -- apply it directly to the coordinator's tail pipeline,
-    // which prepareForExecution has already built. Done after the policy re-pin
-    // so the injected processor sits on the final, dispatch-time pipeline.
+    // The tail (merge) pipeline runs on the coordinator, so its debug timeout
+    // can't be forwarded to the shards like SEARCH/VSIM are; apply it here.
     if (debugParams.tail_timeout_count > 0 && hreq->tailPipeline) {
       PipelineAddTimeoutAfterCount(&hreq->tailPipeline->qctx, hreq->sctx,
                                    debugParams.tail_timeout_count);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -697,10 +697,6 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
 
     // For debug commands, wrap the shard command with _FT.DEBUG prefix and
     // append the debug parameters so the shard-side debug handler can apply them.
-    // TIMEOUT_AFTER_N_TAIL is forwarded too but is a no-op on the shards: an
-    // internal shard command builds no tail pipeline, so applyHybridDebugTimeout
-    // skips it there. The tail timeout takes effect on the coordinator's tail
-    // pipeline (see DEBUG_RSExecDistHybrid).
     if (debugParams) {
       MRCommand_Insert(&xcmd, 0, "_FT.DEBUG", sizeof("_FT.DEBUG") - 1);
       // The _FT.DEBUG prefix shifts every existing argument by one; adjust the
@@ -1161,7 +1157,7 @@ void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     applyCoordReqConfigTimeoutPolicy(hreq, CoordRequestCtx_GetTimeoutPolicy(reqCtx));
 
     // The tail (merge) pipeline runs only on the coordinator, so the tail debug
-    // timeout takes effect here (the shards forward it but have no tail pipeline).
+    // timeout takes effect here.
     if (debugParams.tail_timeout_count > 0 && hreq->tailPipeline) {
       PipelineAddTimeoutAfterCount(&hreq->tailPipeline->qctx, hreq->sctx,
                                    debugParams.tail_timeout_count);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -1156,6 +1156,17 @@ void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     // RSGlobalConfig on this BG thread (races FT.CONFIG SET).
     applyCoordReqConfigTimeoutPolicy(hreq, CoordRequestCtx_GetTimeoutPolicy(reqCtx));
 
+    // The SEARCH/VSIM debug timeouts are applied on the shards (the subqueries
+    // run there), forwarded via the _FT.DEBUG-wrapped shard command. The tail
+    // (merge) pipeline runs only here on the coordinator, so its timeout can't
+    // be forwarded -- apply it directly to the coordinator's tail pipeline,
+    // which prepareForExecution has already built. Done after the policy re-pin
+    // so the injected processor sits on the final, dispatch-time pipeline.
+    if (debugParams.tail_timeout_count > 0 && hreq->tailPipeline) {
+      PipelineAddTimeoutAfterCount(&hreq->tailPipeline->qctx, hreq->sctx,
+                                   debugParams.tail_timeout_count);
+    }
+
     if (HybridRequest_prepareCursors(hreq, &status) != REDISMODULE_OK) {
         DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, hreq, &status);
         return;

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -601,16 +601,6 @@ static void applyCoordReqConfigTimeoutPolicy(HybridRequest *hreq, RSTimeoutPolic
     HybridRequest_SetSkipTimeoutChecks(hreq, !shouldCheckInPipelineTimeoutCoord(hreq));
 }
 
-// TIMEOUT_AFTER_N_TAIL targets the tail (merge) pipeline, which in cluster mode
-// runs only on the coordinator. It must not be forwarded to the shards: a shard
-// would apply it to its own pipeline, which is semantically wrong and leaks the
-// timeout processor when it fires (only SEARCH/VSIM timeouts belong on shards).
-static bool isTailTimeoutArg(RedisModuleString *arg) {
-  size_t n;
-  const char *s = RedisModule_StringPtrLen(arg, &n);
-  return n == sizeof("TIMEOUT_AFTER_N_TAIL") - 1 && !strncmp(s, "TIMEOUT_AFTER_N_TAIL", n);
-}
-
 static int HybridRequest_prepareForExecution(HybridRequest *hreq,
         RedisModuleCtx *ctx, RedisModuleString **argv, int argc, IndexSpec *sp,
         size_t numShards, QueryError *status,
@@ -707,36 +697,21 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
 
     // For debug commands, wrap the shard command with _FT.DEBUG prefix and
     // append the debug parameters so the shard-side debug handler can apply them.
-    // TIMEOUT_AFTER_N_TAIL is filtered out here (see isTailTimeoutArg) and applied
-    // on the coordinator instead, so only the SEARCH/VSIM timeouts reach the shards.
+    // TIMEOUT_AFTER_N_TAIL is forwarded too but is a no-op on the shards: an
+    // internal shard command builds no tail pipeline, so applyHybridDebugTimeout
+    // skips it there. The tail timeout takes effect on the coordinator's tail
+    // pipeline (see DEBUG_RSExecDistHybrid).
     if (debugParams) {
-      // Debug timeout params come in token+value pairs; count the forwarded ones.
-      unsigned long long nparams = debugParams->debug_params_count;
-      int fwdCount = 0;
-      for (unsigned long long i = 0; i + 1 < nparams; i += 2) {
-        if (!isTailTimeoutArg(debugParams->debug_argv[i])) fwdCount += 2;
-      }
-
-      // With only TIMEOUT_AFTER_N_TAIL set there is nothing for the shards to do;
-      // leave the plain command unwrapped (a DEBUG_PARAMS_COUNT of 0 is rejected).
-      if (fwdCount > 0) {
-        MRCommand_Insert(&xcmd, 0, "_FT.DEBUG", sizeof("_FT.DEBUG") - 1);
-        // The _FT.DEBUG prefix shifts every existing argument by one; adjust the
-        // saved K argument index so the SHARD_K_RATIO modifier rewrites the right
-        // slot.
-        if (hreq->kArgIndex >= 0) hreq->kArgIndex += 1;
-        for (unsigned long long i = 0; i + 1 < nparams; i += 2) {
-          if (isTailTimeoutArg(debugParams->debug_argv[i])) continue;
-          size_t n;
-          const char *tok = RedisModule_StringPtrLen(debugParams->debug_argv[i], &n);
-          MRCommand_Append(&xcmd, tok, n);
-          const char *val = RedisModule_StringPtrLen(debugParams->debug_argv[i + 1], &n);
-          MRCommand_Append(&xcmd, val, n);
-        }
-        MRCommand_Append(&xcmd, "DEBUG_PARAMS_COUNT", sizeof("DEBUG_PARAMS_COUNT") - 1);
-        char countBuf[16];
-        int countLen = snprintf(countBuf, sizeof(countBuf), "%d", fwdCount);
-        MRCommand_Append(&xcmd, countBuf, countLen);
+      MRCommand_Insert(&xcmd, 0, "_FT.DEBUG", sizeof("_FT.DEBUG") - 1);
+      // The _FT.DEBUG prefix shifts every existing argument by one; adjust the
+      // saved K argument index so the SHARD_K_RATIO modifier rewrites the right
+      // slot.
+      if (hreq->kArgIndex >= 0) hreq->kArgIndex += 1;
+      int debug_argv_count = (int)debugParams->debug_params_count + 2;
+      for (int i = 0; i < debug_argv_count; i++) {
+        size_t n;
+        const char *arg = RedisModule_StringPtrLen(debugParams->debug_argv[i], &n);
+        MRCommand_Append(&xcmd, arg, n);
       }
     }
 
@@ -1185,8 +1160,8 @@ void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     // RSGlobalConfig on this BG thread (races FT.CONFIG SET).
     applyCoordReqConfigTimeoutPolicy(hreq, CoordRequestCtx_GetTimeoutPolicy(reqCtx));
 
-    // The tail (merge) pipeline runs on the coordinator, so its debug timeout
-    // can't be forwarded to the shards like SEARCH/VSIM are; apply it here.
+    // The tail (merge) pipeline runs only on the coordinator, so the tail debug
+    // timeout takes effect here (the shards forward it but have no tail pipeline).
     if (debugParams.tail_timeout_count > 0 && hreq->tailPipeline) {
       PipelineAddTimeoutAfterCount(&hreq->tailPipeline->qctx, hreq->sctx,
                                    debugParams.tail_timeout_count);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -601,6 +601,16 @@ static void applyCoordReqConfigTimeoutPolicy(HybridRequest *hreq, RSTimeoutPolic
     HybridRequest_SetSkipTimeoutChecks(hreq, !shouldCheckInPipelineTimeoutCoord(hreq));
 }
 
+// TIMEOUT_AFTER_N_TAIL targets the tail (merge) pipeline, which in cluster mode
+// runs only on the coordinator. It must not be forwarded to the shards: a shard
+// would apply it to its own pipeline, which is semantically wrong and leaks the
+// timeout processor when it fires (only SEARCH/VSIM timeouts belong on shards).
+static bool isTailTimeoutArg(RedisModuleString *arg) {
+  size_t n;
+  const char *s = RedisModule_StringPtrLen(arg, &n);
+  return n == sizeof("TIMEOUT_AFTER_N_TAIL") - 1 && !strncmp(s, "TIMEOUT_AFTER_N_TAIL", n);
+}
+
 static int HybridRequest_prepareForExecution(HybridRequest *hreq,
         RedisModuleCtx *ctx, RedisModuleString **argv, int argc, IndexSpec *sp,
         size_t numShards, QueryError *status,
@@ -697,17 +707,36 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
 
     // For debug commands, wrap the shard command with _FT.DEBUG prefix and
     // append the debug parameters so the shard-side debug handler can apply them.
+    // TIMEOUT_AFTER_N_TAIL is filtered out here (see isTailTimeoutArg) and applied
+    // on the coordinator instead, so only the SEARCH/VSIM timeouts reach the shards.
     if (debugParams) {
-      MRCommand_Insert(&xcmd, 0, "_FT.DEBUG", sizeof("_FT.DEBUG") - 1);
-      // The _FT.DEBUG prefix shifts every existing argument by one; adjust the
-      // saved K argument index so the SHARD_K_RATIO modifier rewrites the right
-      // slot.
-      if (hreq->kArgIndex >= 0) hreq->kArgIndex += 1;
-      int debug_argv_count = (int)debugParams->debug_params_count + 2;
-      for (int i = 0; i < debug_argv_count; i++) {
-        size_t n;
-        const char *arg = RedisModule_StringPtrLen(debugParams->debug_argv[i], &n);
-        MRCommand_Append(&xcmd, arg, n);
+      // Debug timeout params come in token+value pairs; count the forwarded ones.
+      unsigned long long nparams = debugParams->debug_params_count;
+      int fwdCount = 0;
+      for (unsigned long long i = 0; i + 1 < nparams; i += 2) {
+        if (!isTailTimeoutArg(debugParams->debug_argv[i])) fwdCount += 2;
+      }
+
+      // With only TIMEOUT_AFTER_N_TAIL set there is nothing for the shards to do;
+      // leave the plain command unwrapped (a DEBUG_PARAMS_COUNT of 0 is rejected).
+      if (fwdCount > 0) {
+        MRCommand_Insert(&xcmd, 0, "_FT.DEBUG", sizeof("_FT.DEBUG") - 1);
+        // The _FT.DEBUG prefix shifts every existing argument by one; adjust the
+        // saved K argument index so the SHARD_K_RATIO modifier rewrites the right
+        // slot.
+        if (hreq->kArgIndex >= 0) hreq->kArgIndex += 1;
+        for (unsigned long long i = 0; i + 1 < nparams; i += 2) {
+          if (isTailTimeoutArg(debugParams->debug_argv[i])) continue;
+          size_t n;
+          const char *tok = RedisModule_StringPtrLen(debugParams->debug_argv[i], &n);
+          MRCommand_Append(&xcmd, tok, n);
+          const char *val = RedisModule_StringPtrLen(debugParams->debug_argv[i + 1], &n);
+          MRCommand_Append(&xcmd, val, n);
+        }
+        MRCommand_Append(&xcmd, "DEBUG_PARAMS_COUNT", sizeof("DEBUG_PARAMS_COUNT") - 1);
+        char countBuf[16];
+        int countLen = snprintf(countBuf, sizeof(countBuf), "%d", fwdCount);
+        MRCommand_Append(&xcmd, countBuf, countLen);
       }
     }
 

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -145,8 +145,11 @@ int applyHybridDebugTimeout(HybridRequest *hreq, const HybridDebugParams *params
     PipelineAddTimeoutAfterCount(AREQ_QueryProcessingCtx(vector_req), AREQ_SearchCtx(vector_req), params->vsim_timeout_count);
   }
 
-  // Apply timeout to tail pipeline
-  if (params->tail_timeout_count > 0 && hreq->tailPipeline) {
+  // Apply timeout to tail pipeline, but only when it was actually built. Internal
+  // shard commands (cluster) build just the depletion pipeline and leave the tail
+  // pipeline empty (endProc == NULL). PipelineAddTimeoutAfterCount can't link the
+  // processor into an empty chain, so it would leak it -- skip in that case.
+  if (params->tail_timeout_count > 0 && hreq->tailPipeline && hreq->tailPipeline->qctx.endProc) {
     PipelineAddTimeoutAfterCount(&hreq->tailPipeline->qctx, hreq->sctx, params->tail_timeout_count);
   }
 

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -145,10 +145,8 @@ int applyHybridDebugTimeout(HybridRequest *hreq, const HybridDebugParams *params
     PipelineAddTimeoutAfterCount(AREQ_QueryProcessingCtx(vector_req), AREQ_SearchCtx(vector_req), params->vsim_timeout_count);
   }
 
-  // Apply timeout to tail pipeline, but only when it was actually built. Internal
-  // shard commands (cluster) build just the depletion pipeline and leave the tail
-  // pipeline empty (endProc == NULL). PipelineAddTimeoutAfterCount can't link the
-  // processor into an empty chain, so it would leak it -- skip in that case.
+  // Apply timeout to the tail pipeline, but only when it was built: internal shard
+  // commands build only the depletion pipeline, leaving the tail empty (endProc NULL).
   if (params->tail_timeout_count > 0 && hreq->tailPipeline && hreq->tailPipeline->qctx.endProc) {
     PipelineAddTimeoutAfterCount(&hreq->tailPipeline->qctx, hreq->sctx, params->tail_timeout_count);
   }

--- a/tests/pytests/test_hybrid_timeout.py
+++ b/tests/pytests/test_hybrid_timeout.py
@@ -173,18 +173,14 @@ def test_debug_timeout_fail_both():
     setup_basic_index(env)
     env.expect('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector, 'TIMEOUT_AFTER_N_SEARCH', '1','TIMEOUT_AFTER_N_VSIM', '2', 'DEBUG_PARAMS_COUNT', '4').error().contains('SEARCH_TIMEOUT Timeout limit was reached')
 
-# Tail pipeline runs on the coordinator; debug timeout params aren't applied there in cluster.
-@skip(cluster=True)
 def test_debug_timeout_fail_tail():
     """Test FAIL policy with tail timeout using debug parameters"""
     env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT FAIL')
     setup_basic_index(env)
     env.expect('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector, 'TIMEOUT_AFTER_N_TAIL', '1', 'DEBUG_PARAMS_COUNT', '2').error().contains('SEARCH_TIMEOUT Timeout limit was reached')
 
-# Tail pipeline runs on the coordinator; debug timeout params aren't applied there in cluster.
-@skip(cluster=True)
 def test_debug_timeout_return_tail():
-    """Test FAIL policy with tail timeout using debug parameters"""
+    """Test RETURN policy with tail timeout using debug parameters"""
     env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT RETURN')
     setup_basic_index(env)
     response = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `_FT.DEBUG FT.HYBRID ... TIMEOUT_AFTER_N_TAIL <N>` forces a timeout after N results from the tail (merge) pipeline. In standalone the whole request runs locally, so `applyHybridDebugTimeout` injects the timeout processor into `hreq->tailPipeline`. In **cluster** mode the SEARCH/VSIM subqueries run on the shards (their debug timeouts are forwarded via the `_FT.DEBUG`-wrapped shard command), but the tail/merge runs only on the coordinator, where the tail timeout was never applied. The two tail-timeout tests were therefore skipped under cluster.
2. **Change:**
   - In `DEBUG_RSExecDistHybrid`, after the dispatch-time timeout policy is re-pinned, apply the tail timeout directly to the coordinator's already-built tail pipeline via `PipelineAddTimeoutAfterCount`, mirroring the standalone path. Gated on `tail_timeout_count > 0` to match standalone semantics (0 = no timeout).
   - Un-skip `test_debug_timeout_fail_tail` / `test_debug_timeout_return_tail` in cluster.
   - **Leak fix:** `applyHybridDebugTimeout` guarded the tail branch on `hreq->tailPipeline` (the pointer, always non-NULL) rather than on whether the tail pipeline was built. An internal shard command builds only the depletion pipeline, leaving the tail pipeline empty (`qctx.endProc == NULL`); `PipelineAddTimeoutAfterCount` then allocated the processor while `addResultProcessor` silently dropped it (its loop never runs on an empty chain), leaking 64 bytes per shard — caught by the cluster ASan CI once the tests were un-skipped. The guard now also requires `hreq->tailPipeline->qctx.endProc`, so the processor is only added when there is a chain to link it into. This fixes the leak for every caller, not just this path.
3. **Outcome:** `TIMEOUT_AFTER_N_TAIL` behaves identically in standalone and cluster — `ON_TIMEOUT FAIL` returns the `SEARCH_TIMEOUT Timeout limit was reached` error, and `ON_TIMEOUT RETURN` surfaces the `Timeout limit was reached (POST PROCESSING)` warning. The two previously-skipped tests are enabled and pass in both modes (30/30, standalone and 3-shard cluster), with no ASan leak.

#### Which additional issues this PR fixes
1. MOD-15032

#### Main objects this PR modified
1. `src/coord/hybrid/dist_hybrid.c` — `DEBUG_RSExecDistHybrid` (apply tail timeout on the coordinator)
2. `src/hybrid/hybrid_debug.c` — `applyHybridDebugTimeout` (skip tail timeout when the tail pipeline is unbuilt; fixes the leak)
3. `tests/pytests/test_hybrid_timeout.py` — un-skip `test_debug_timeout_fail_tail` / `test_debug_timeout_return_tail`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal-only change: it wires up an existing `_FT.DEBUG` testing knob in cluster mode (plus a memory-leak fix on that path) and enables tests. No user-facing command, behavior, or persistence change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)