### PR TITLE
ttl_table_bencher: add missing `const`

### DIFF
--- a/src/redisearch_rs/ttl_table_bencher/src/lib.rs
+++ b/src/redisearch_rs/ttl_table_bencher/src/lib.rs
@@ -253,7 +253,10 @@ impl PickRandom {
         self.0.sample(rng)
     }
 
-    fn iter<'s, 'rand, R: RngExt>(&'s self, rng: &'rand mut R) -> PickRandomIter<'s, 'rand, R> {
+    const fn iter<'s, 'rand, R: RngExt>(
+        &'s self,
+        rng: &'rand mut R,
+    ) -> PickRandomIter<'s, 'rand, R> {
         PickRandomIter(self, rng)
     }
 }


### PR DESCRIPTION
Fix running clippy manually in redisearch_rs.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
