### PR TITLE
[MOD-14988] Use accessors to avoid exposing fields - part 1

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1398,7 +1398,7 @@ DEBUG_COMMAND(InfoTagIndex) {
 
   RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
   RedisModule_ReplyWithLiteral(ctx, "num_values");
-  RedisModule_ReplyWithLongLong(ctx, TrieMap_NUniqueKeys(idx->values));
+  RedisModule_ReplyWithLongLong(ctx, TagIndex_NUniqueValues(idx));
   nelem += 2;
 
   if (options.dumpIdEntries) {

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -774,7 +774,7 @@ DEBUG_COMMAND(DumpTagIndex) {
     goto end;
   }
 
-  iter = TrieMap_Iterate(tagIndex->values);
+  iter = TagIndex_IterateValues(tagIndex);
   RedisModule_ReplyWithArray(sctx->redisCtx, REDISMODULE_POSTPONED_ARRAY_LEN);
   while (TrieMapIterator_Next(iter, &tag, &len, (void **)&iv)) {
     RedisModule_ReplyWithArray(sctx->redisCtx, 2);
@@ -1410,7 +1410,7 @@ DEBUG_COMMAND(InfoTagIndex) {
   }
 
   limit = options.limit ? options.limit : 0;
-  iter = TrieMap_Iterate(idx->values);
+  iter = TagIndex_IterateValues(idx);
 
   nelem += 2;
   RedisModule_ReplyWithLiteral(ctx, "values");

--- a/src/fork_gc/tags.c
+++ b/src/fork_gc/tags.c
@@ -51,7 +51,7 @@ void FGC_childCollectTags(ForkGC *gc, RedisSearchCtx *sctx) {
       tagHeader header = {.field = HiddenString_GetUnsafe(tagFields[i]->fieldName, NULL),
                           .uniqueId = TagIndex_GetId(tagIdx)};
 
-      TrieMapIterator *iter = TrieMap_Iterate(tagIdx->values);
+      TrieMapIterator *iter = TagIndex_IterateValues(tagIdx);
       char *ptr;
       tm_len_t len;
       InvertedIndex *value;

--- a/src/fork_gc/tags.c
+++ b/src/fork_gc/tags.c
@@ -49,7 +49,7 @@ void FGC_childCollectTags(ForkGC *gc, RedisSearchCtx *sctx) {
       }
 
       tagHeader header = {.field = HiddenString_GetUnsafe(tagFields[i]->fieldName, NULL),
-                          .uniqueId = tagIdx->uniqueId};
+                          .uniqueId = TagIndex_GetId(tagIdx)};
 
       TrieMapIterator *iter = TrieMap_Iterate(tagIdx->values);
       char *ptr;
@@ -145,7 +145,7 @@ FGCError FGC_parentHandleTags(ForkGC *gc) {
     tagIdx = TagIndex_Open(fs);
     RS_LOG_ASSERT_FMT(tagIdx, "tag field '%.*s' was not opened", (int)fieldNameLen, fieldName);
 
-    if (tagIdx->uniqueId != tagUniqueId) {
+    if (TagIndex_GetId(tagIdx) != tagUniqueId) {
       status = FGC_CHILD_ERROR;
       goto loop_cleanup;
     }

--- a/src/fork_gc/tags.c
+++ b/src/fork_gc/tags.c
@@ -166,7 +166,7 @@ FGCError FGC_parentHandleTags(ForkGC *gc) {
       // index without spec context.
       info.bytes_freed += InvertedIndex_MemUsage(idx);
       IndexStats_BlockCountAdd(&sctx->spec->stats, -(int64_t)InvertedIndex_NumBlocks(idx));
-      TrieMap_Delete(tagIdx->values, tagVal, tagValLen, (void (*)(void *))InvertedIndex_Free);
+      TagIndex_DeleteTagValue(tagIdx, tagVal, tagValLen);
 
       // Empty values (INDEXEMPTY) are never inserted into the suffix triemap, so skip the delete.
       if (tagIdx->suffix && tagValLen) {

--- a/src/query.c
+++ b/src/query.c
@@ -1182,7 +1182,6 @@ void tag_strtolower(char **pstr, size_t *len, int caseSensitive) {
 
 static QueryIterator *Query_EvalTagLexRangeNode(QueryEvalCtx *q, TagIndex *idx, QueryNode *qn,
                                                 double weight, bool caseSensitive) {
-  TrieMap *t = idx->values;
   TrieCallbackCtx ctx = {.q = q, .opts = &qn->opts, .weight = weight, .tagIdx = idx};
 
   if(qn->lxrng.begin) {
@@ -1201,7 +1200,7 @@ static QueryIterator *Query_EvalTagLexRangeNode(QueryEvalCtx *q, TagIndex *idx, 
   const char *begin = qn->lxrng.begin, *end = qn->lxrng.end;
   int nbegin = begin ? strlen(begin) : -1, nend = end ? strlen(end) : -1;
 
-  TrieMap_IterateRange(t, begin, nbegin, qn->lxrng.includeBegin, end, nend, qn->lxrng.includeEnd,
+  TagIndex_IterateRangeValues(idx, begin, nbegin, qn->lxrng.includeBegin, end, nend, qn->lxrng.includeEnd,
                        tagRangeIterCb, &ctx);
 
   return NewUnionIterator(ctx.its, ctx.nits, true, qn->opts.weight, QN_LEXRANGE, NULL, q->config);

--- a/src/query.c
+++ b/src/query.c
@@ -1200,8 +1200,8 @@ static QueryIterator *Query_EvalTagLexRangeNode(QueryEvalCtx *q, TagIndex *idx, 
   const char *begin = qn->lxrng.begin, *end = qn->lxrng.end;
   int nbegin = begin ? strlen(begin) : -1, nend = end ? strlen(end) : -1;
 
-  TagIndex_IterateRangeValues(idx, begin, nbegin, qn->lxrng.includeBegin, end, nend, qn->lxrng.includeEnd,
-                       tagRangeIterCb, &ctx);
+  TagIndex_IterateRangeValues(idx, begin, nbegin, qn->lxrng.includeBegin, end, nend,
+                              qn->lxrng.includeEnd, tagRangeIterCb, &ctx);
 
   return NewUnionIterator(ctx.its, ctx.nits, true, qn->opts.weight, QN_LEXRANGE, NULL, q->config);
 }
@@ -1348,7 +1348,8 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
 
   if (!idx->suffix || fallbackBruteForce) {
     // brute force wildcard query
-    TrieMapIterator *it = TagIndex_IterateValueWithFilter(idx, tok->str, tok->len, TAG_WILDCARD_MODE);
+    TrieMapIterator *it =
+        TagIndex_IterateValueWithFilter(idx, tok->str, tok->len, TAG_WILDCARD_MODE);
     if (!q->sctx->time.skipTimeoutChecks) {
       TrieMapIterator_SetTimeout(it, q->sctx->time.timeout);
     }

--- a/src/query.c
+++ b/src/query.c
@@ -1185,10 +1185,6 @@ static QueryIterator *Query_EvalTagLexRangeNode(QueryEvalCtx *q, TagIndex *idx, 
   TrieMap *t = idx->values;
   TrieCallbackCtx ctx = {.q = q, .opts = &qn->opts, .weight = weight, .tagIdx = idx};
 
-  if (!t) {
-    return NULL;
-  }
-
   if(qn->lxrng.begin) {
     size_t beginLen = strlen(qn->lxrng.begin);
     tag_strtolower(&(qn->lxrng.begin), &beginLen, caseSensitive);
@@ -1225,7 +1221,7 @@ static QueryIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
   if (tok->len < q->config->minTermPrefix) {
     return NULL;
   }
-  if (!idx || !idx->values) return NULL;
+  if (!idx) return NULL;
 
   size_t itsSz = 0, itsCap = 8;
   QueryIterator **its = rm_calloc(itsCap, sizeof(*its));
@@ -1308,7 +1304,7 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
                      QueryNode *qn, double weight,
                      t_fieldIndex fieldIndex, bool caseSensitive) {
   RS_ASSERT(qn->type == QN_WILDCARD_QUERY);
-  if (!idx || !idx->values) return NULL;
+  if (!idx) return NULL;
 
   RSToken *tok = &qn->verb.tok;
 

--- a/src/query.c
+++ b/src/query.c
@@ -1227,15 +1227,15 @@ static QueryIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
   QueryIterator **its = rm_calloc(itsCap, sizeof(*its));
 
   if (!qn->pfx.suffix || !withSuffixTrie) {    // prefix query or no suffix triemap, use bruteforce
-    tm_iter_mode iter_mode = TM_PREFIX_MODE;
+    tag_iter_mode iter_mode = TAG_PREFIX_MODE;
     if (qn->pfx.suffix) {
       if (qn->pfx.prefix) { // contains mode
-        iter_mode = TM_CONTAINS_MODE;
+        iter_mode = TAG_CONTAINS_MODE;
       } else {
-        iter_mode = TM_SUFFIX_MODE;
+        iter_mode = TAG_SUFFIX_MODE;
       }
     }
-    TrieMapIterator *it = TrieMap_IterateWithFilter(idx->values, tok->str, tok->len, iter_mode);
+    TrieMapIterator *it = TagIndex_IterateValueWithFilter(idx, tok->str, tok->len, iter_mode);
     // TrieMap_IterateWithFilter only returns NULL on allocation failure
     RS_ASSERT(it);
     if (!q->sctx->time.skipTimeoutChecks) {
@@ -1349,7 +1349,7 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
 
   if (!idx->suffix || fallbackBruteForce) {
     // brute force wildcard query
-    TrieMapIterator *it = TrieMap_IterateWithFilter(idx->values, tok->str, tok->len, TM_WILDCARD_MODE);
+    TrieMapIterator *it = TagIndex_IterateValueWithFilter(idx, tok->str, tok->len, TAG_WILDCARD_MODE);
     if (!q->sctx->time.skipTimeoutChecks) {
       TrieMapIterator_SetTimeout(it, q->sctx->time.timeout);
     }

--- a/src/query.c
+++ b/src/query.c
@@ -1234,7 +1234,7 @@ static QueryIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
         iter_mode = TAG_SUFFIX_MODE;
       }
     }
-    TrieMapIterator *it = TagIndex_IterateValueWithFilter(idx, tok->str, tok->len, iter_mode);
+    TrieMapIterator *it = TagIndex_IterateValuesWithFilter(idx, tok->str, tok->len, iter_mode);
     // TrieMap_IterateWithFilter only returns NULL on allocation failure
     RS_ASSERT(it);
     if (!q->sctx->time.skipTimeoutChecks) {
@@ -1349,7 +1349,7 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
   if (!idx->suffix || fallbackBruteForce) {
     // brute force wildcard query
     TrieMapIterator *it =
-        TagIndex_IterateValueWithFilter(idx, tok->str, tok->len, TAG_WILDCARD_MODE);
+        TagIndex_IterateValuesWithFilter(idx, tok->str, tok->len, TAG_WILDCARD_MODE);
     if (!q->sctx->time.skipTimeoutChecks) {
       TrieMapIterator_SetTimeout(it, q->sctx->time.timeout);
     }

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -350,6 +350,10 @@ size_t TagIndex_NUniqueValues(const TagIndex *idx) {
   return TrieMap_NUniqueKeys(idx->values);
 }
 
+int TagIndex_DeleteTagValue(TagIndex *idx, const char *tagVal, size_t tagValLen) {
+  return TrieMap_Delete(idx->values, tagVal, tagValLen, (void (*)(void *))InvertedIndex_Free);
+}
+
 /* Serialize all the tags in the index to the redis client */
 void TagIndex_SerializeValues(TagIndex *idx, RedisModuleCtx *ctx) {
   TrieMapIterator *it = TagIndex_IterateValues(idx);

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -358,6 +358,21 @@ TrieMapIterator *TagIndex_IterateValueWithFilter(TagIndex *idx, const char *tagV
   return TrieMap_IterateWithFilter(idx->values, tagVal, tagValLen, (tm_iter_mode)mode);
 }
 
+void TagIndex_IterateRangeValues(
+  const TagIndex *idx,
+  const char *min,
+  int minlen,
+  bool includeMin,
+  const char *max,
+  int maxlen,
+  bool includeMax,
+  TrieMapRangeCallback callback,
+  void* ctx
+) {
+  TrieMap_IterateRange(idx->values, min, minlen, includeMin, max, maxlen, includeMax,
+                       callback, ctx);
+}
+
 /* Serialize all the tags in the index to the redis client */
 void TagIndex_SerializeValues(TagIndex *idx, RedisModuleCtx *ctx) {
   TrieMapIterator *it = TagIndex_IterateValues(idx);

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -344,7 +344,7 @@ TagIndex *TagIndex_Ensure(FieldSpec *spec, RedisSearchDiskIndexSpec *diskSpec) {
 
 /* Serialize all the tags in the index to the redis client */
 void TagIndex_SerializeValues(TagIndex *idx, RedisModuleCtx *ctx) {
-  TrieMapIterator *it = TrieMap_Iterate(idx->values);
+  TrieMapIterator *it = TagIndex_IterateValues(idx);
 
   char *str;
   tm_len_t slen;

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -354,6 +354,10 @@ int TagIndex_DeleteTagValue(TagIndex *idx, const char *tagVal, size_t tagValLen)
   return TrieMap_Delete(idx->values, tagVal, tagValLen, (void (*)(void *))InvertedIndex_Free);
 }
 
+TrieMapIterator *TagIndex_IterateValueWithFilter(TagIndex *idx, const char *tagVal, size_t tagValLen, tag_iter_mode mode) {
+  return TrieMap_IterateWithFilter(idx->values, tagVal, tagValLen, (tm_iter_mode)mode);
+}
+
 /* Serialize all the tags in the index to the redis client */
 void TagIndex_SerializeValues(TagIndex *idx, RedisModuleCtx *ctx) {
   TrieMapIterator *it = TagIndex_IterateValues(idx);

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -342,6 +342,10 @@ TagIndex *TagIndex_Ensure(FieldSpec *spec, RedisSearchDiskIndexSpec *diskSpec) {
   return spec->tagOpts.tagIndex;
 }
 
+TrieMapIterator *TagIndex_IterateValues(const TagIndex *idx) {
+  return TrieMap_Iterate(idx->values);
+}
+
 /* Serialize all the tags in the index to the redis client */
 void TagIndex_SerializeValues(TagIndex *idx, RedisModuleCtx *ctx) {
   TrieMapIterator *it = TagIndex_IterateValues(idx);

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -346,6 +346,10 @@ TrieMapIterator *TagIndex_IterateValues(const TagIndex *idx) {
   return TrieMap_Iterate(idx->values);
 }
 
+size_t TagIndex_NUniqueValues(const TagIndex *idx) {
+  return TrieMap_NUniqueKeys(idx->values);
+}
+
 /* Serialize all the tags in the index to the redis client */
 void TagIndex_SerializeValues(TagIndex *idx, RedisModuleCtx *ctx) {
   TrieMapIterator *it = TagIndex_IterateValues(idx);

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -342,6 +342,10 @@ TagIndex *TagIndex_Ensure(FieldSpec *spec, RedisSearchDiskIndexSpec *diskSpec) {
   return spec->tagOpts.tagIndex;
 }
 
+uint32_t TagIndex_GetId(const TagIndex *idx) {
+  return idx->uniqueId;
+}
+
 TrieMapIterator *TagIndex_IterateValues(const TagIndex *idx) {
   return TrieMap_Iterate(idx->values);
 }
@@ -354,7 +358,7 @@ int TagIndex_DeleteTagValue(TagIndex *idx, const char *tagVal, size_t tagValLen)
   return TrieMap_Delete(idx->values, tagVal, tagValLen, (void (*)(void *))InvertedIndex_Free);
 }
 
-TrieMapIterator *TagIndex_IterateValueWithFilter(TagIndex *idx, const char *tagVal,
+TrieMapIterator *TagIndex_IterateValuesWithFilter(TagIndex *idx, const char *tagVal,
                                                  size_t tagValLen, tag_iter_mode mode) {
   return TrieMap_IterateWithFilter(idx->values, tagVal, tagValLen, (tm_iter_mode)mode);
 }

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -354,23 +354,16 @@ int TagIndex_DeleteTagValue(TagIndex *idx, const char *tagVal, size_t tagValLen)
   return TrieMap_Delete(idx->values, tagVal, tagValLen, (void (*)(void *))InvertedIndex_Free);
 }
 
-TrieMapIterator *TagIndex_IterateValueWithFilter(TagIndex *idx, const char *tagVal, size_t tagValLen, tag_iter_mode mode) {
+TrieMapIterator *TagIndex_IterateValueWithFilter(TagIndex *idx, const char *tagVal,
+                                                 size_t tagValLen, tag_iter_mode mode) {
   return TrieMap_IterateWithFilter(idx->values, tagVal, tagValLen, (tm_iter_mode)mode);
 }
 
-void TagIndex_IterateRangeValues(
-  const TagIndex *idx,
-  const char *min,
-  int minlen,
-  bool includeMin,
-  const char *max,
-  int maxlen,
-  bool includeMax,
-  TrieMapRangeCallback callback,
-  void* ctx
-) {
-  TrieMap_IterateRange(idx->values, min, minlen, includeMin, max, maxlen, includeMax,
-                       callback, ctx);
+void TagIndex_IterateRangeValues(const TagIndex *idx, const char *min, int minlen, bool includeMin,
+                                 const char *max, int maxlen, bool includeMax,
+                                 TrieMapRangeCallback callback, void *ctx) {
+  TrieMap_IterateRange(idx->values, min, minlen, includeMin, max, maxlen, includeMax, callback,
+                       ctx);
 }
 
 /* Serialize all the tags in the index to the redis client */

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -136,6 +136,12 @@ TrieMapIterator *TagIndex_IterateValues(const TagIndex *idx);
 /* Return the number of unique values that the given `TagIndex` is holding */
 size_t TagIndex_NUniqueValues(const TagIndex *idx);
 
+/**
+ * Mark the tag value node as deleted.
+ * See [`TrieMap_Delete`] for more details.
+ */
+int TagIndex_DeleteTagValue(TagIndex *idx, const char *tagVal, size_t tagValLen);
+
 /* Preprocess a document tag field, split the content in data into fdata `tags` array
    Return 0 if there's no content to index in the field (its value is NULL), 1 otherwise
  */

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -123,6 +123,12 @@ void TagIndex_Free(TagIndex *index);
 
 char *TagIndex_SepString(char sep, char **s, size_t *toklen, bool indexEmpty);
 
+/* Return the unique id generated in `NewTagIndex`.
+ */
+static inline uint32_t TagIndex_GetId(const TagIndex *idx) {
+  return idx->uniqueId;
+}
+
 /* Preprocess a document tag field, split the content in data into fdata `tags` array
    Return 0 if there's no content to index in the field (its value is NULL), 1 otherwise
  */

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -133,6 +133,9 @@ static inline uint32_t TagIndex_GetId(const TagIndex *idx) {
 /* Return an iterator over the TagIndex values */
 TrieMapIterator *TagIndex_IterateValues(const TagIndex *idx);
 
+/* Return the number of unique values that the given `TagIndex` is holding */
+size_t TagIndex_NUniqueValues(const TagIndex *idx);
+
 /* Preprocess a document tag field, split the content in data into fdata `tags` array
    Return 0 if there's no content to index in the field (its value is NULL), 1 otherwise
  */

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -145,34 +145,28 @@ int TagIndex_DeleteTagValue(TagIndex *idx, const char *tagVal, size_t tagValLen)
 
 // must match `tm_iter_mode` defined in triemap_ffi.h
 typedef enum tag_iter_mode {
-    TAG_PREFIX_MODE = 0,
-    TAG_CONTAINS_MODE = 1,
-    TAG_SUFFIX_MODE = 2,
-    TAG_WILDCARD_MODE = 3,
+  TAG_PREFIX_MODE = 0,
+  TAG_CONTAINS_MODE = 1,
+  TAG_SUFFIX_MODE = 2,
+  TAG_WILDCARD_MODE = 3,
 } tag_iter_mode;
 
 /**
  * Iterate over the values that match the given predicate.
+ *
  * See [`TrieMap_IterateWithFilter`] for more details.
  */
-TrieMapIterator *TagIndex_IterateValueWithFilter(TagIndex *idx, const char *tagVal, size_t tagValLen, tag_iter_mode mode);
+TrieMapIterator *TagIndex_IterateValueWithFilter(TagIndex *idx, const char *tagVal,
+                                                 size_t tagValLen, tag_iter_mode mode);
 
 /**
  * Iterate the value tags within the specified key range.
- * 
+ *
  * See [`TrieMap_IterateRange`] for more details
  */
-void TagIndex_IterateRangeValues(
-  const TagIndex *idx, 
-  const char *min,
-  int minlen,
-  bool includeMin,
-  const char *max,
-  int maxlen,
-  bool includeMax,
-  TrieMapRangeCallback callback,
-  void* ctx
-);
+void TagIndex_IterateRangeValues(const TagIndex *idx, const char *min, int minlen, bool includeMin,
+                                 const char *max, int maxlen, bool includeMax,
+                                 TrieMapRangeCallback callback, void *ctx);
 
 /* Preprocess a document tag field, split the content in data into fdata `tags` array
    Return 0 if there's no content to index in the field (its value is NULL), 1 otherwise

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -125,11 +125,8 @@ void TagIndex_Free(TagIndex *index);
 
 char *TagIndex_SepString(char sep, char **s, size_t *toklen, bool indexEmpty);
 
-/* Return the unique id generated in `NewTagIndex`.
- */
-static inline uint32_t TagIndex_GetId(const TagIndex *idx) {
-  return idx->uniqueId;
-}
+/* Return the unique id generated in `NewTagIndex` */
+uint32_t TagIndex_GetId(const TagIndex *idx);
 
 /* Return an iterator over the TagIndex values */
 TrieMapIterator *TagIndex_IterateValues(const TagIndex *idx);
@@ -156,7 +153,7 @@ typedef enum tag_iter_mode {
  *
  * See [`TrieMap_IterateWithFilter`] for more details.
  */
-TrieMapIterator *TagIndex_IterateValueWithFilter(TagIndex *idx, const char *tagVal,
+TrieMapIterator *TagIndex_IterateValuesWithFilter(TagIndex *idx, const char *tagVal,
                                                  size_t tagValLen, tag_iter_mode mode);
 
 /**

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -16,6 +16,7 @@
 #include "vector_index.h"
 #include "indexer.h"
 #include "search_disk_api.h"
+#include "triemap_ffi.h"
 
 struct InvertedIndex;
 
@@ -127,6 +128,11 @@ char *TagIndex_SepString(char sep, char **s, size_t *toklen, bool indexEmpty);
  */
 static inline uint32_t TagIndex_GetId(const TagIndex *idx) {
   return idx->uniqueId;
+}
+
+/* Return an iterator over the TagIndex values */
+static inline TrieMapIterator* TagIndex_IterateValues(const TagIndex *idx) {
+  return TrieMap_Iterate(idx->values);
 }
 
 /* Preprocess a document tag field, split the content in data into fdata `tags` array

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -142,6 +142,20 @@ size_t TagIndex_NUniqueValues(const TagIndex *idx);
  */
 int TagIndex_DeleteTagValue(TagIndex *idx, const char *tagVal, size_t tagValLen);
 
+// must match `tm_iter_mode` defined in triemap_ffi.h
+typedef enum tag_iter_mode {
+    TAG_PREFIX_MODE = 0,
+    TAG_CONTAINS_MODE = 1,
+    TAG_SUFFIX_MODE = 2,
+    TAG_WILDCARD_MODE = 3,
+} tag_iter_mode;
+
+/**
+ * Iterate over the values that match the given predicate.
+ * See [`TrieMap_IterateWithFilter`] for more details.
+ */
+TrieMapIterator *TagIndex_IterateValueWithFilter(TagIndex *idx, const char *tagVal, size_t tagValLen, tag_iter_mode mode);
+
 /* Preprocess a document tag field, split the content in data into fdata `tags` array
    Return 0 if there's no content to index in the field (its value is NULL), 1 otherwise
  */

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -16,9 +16,9 @@
 #include "vector_index.h"
 #include "indexer.h"
 #include "search_disk_api.h"
-#include "triemap_ffi.h"
 
 struct InvertedIndex;
+typedef struct TrieMapIterator TrieMapIterator;
 
 #ifdef __cplusplus
 extern "C" {
@@ -131,9 +131,7 @@ static inline uint32_t TagIndex_GetId(const TagIndex *idx) {
 }
 
 /* Return an iterator over the TagIndex values */
-static inline TrieMapIterator* TagIndex_IterateValues(const TagIndex *idx) {
-  return TrieMap_Iterate(idx->values);
-}
+TrieMapIterator *TagIndex_IterateValues(const TagIndex *idx);
 
 /* Preprocess a document tag field, split the content in data into fdata `tags` array
    Return 0 if there's no content to index in the field (its value is NULL), 1 otherwise

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -19,6 +19,7 @@
 
 struct InvertedIndex;
 typedef struct TrieMapIterator TrieMapIterator;
+typedef void (*TrieMapRangeCallback)(const char *, size_t, void *, void *);
 
 #ifdef __cplusplus
 extern "C" {
@@ -155,6 +156,23 @@ typedef enum tag_iter_mode {
  * See [`TrieMap_IterateWithFilter`] for more details.
  */
 TrieMapIterator *TagIndex_IterateValueWithFilter(TagIndex *idx, const char *tagVal, size_t tagValLen, tag_iter_mode mode);
+
+/**
+ * Iterate the value tags within the specified key range.
+ * 
+ * See [`TrieMap_IterateRange`] for more details
+ */
+void TagIndex_IterateRangeValues(
+  const TagIndex *idx, 
+  const char *min,
+  int minlen,
+  bool includeMin,
+  const char *max,
+  int maxlen,
+  bool includeMax,
+  TrieMapRangeCallback callback,
+  void* ctx
+);
 
 /* Preprocess a document tag field, split the content in data into fdata `tags` array
    Return 0 if there's no content to index in the field (its value is NULL), 1 otherwise

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -36,7 +36,7 @@ TEST_F(TagIndexTest, testCreate) {
     ASSERT_EQ(sz, stats.invertedSize);
   }
 
-  ASSERT_EQ(v.size(), TrieMap_NUniqueKeys(idx->values));
+  ASSERT_EQ(v.size(), TagIndex_NUniqueValues(idx));
 
   // expectedTotalSZ should include the memory occupied by the inverted index
   // structure and its blocks.


### PR DESCRIPTION
## Describe the changes in the pull request

Introduce accessors to avoid access to `uniqueId` and `values` fields. 

1. Current: `TagIndex` internals are exposed, and the callers use them.
2. Change: Introduce accessor functions on TagIndex to reduce the used surface. This PR removes `uniqueId` and `values` direct access through:
  - `TagIndex_GetId` — returns uniqueId
  - `TagIndex_IterateValues` — iterate over all values
  - `TagIndex_NUniqueValues` — count unique values
  - `TagIndex_DeleteTagValue` — delete a tag value (frees the inverted index)
  - `TagIndex_IterateValueWithFilter` — filtered iteration, with a new tag_iter_mode enum mirroring tm_iter_mode so callers no longer reference the TrieMap enum directly
  - `TagIndex_IterateRangeValues` — range iteration
  Moreover:
  - `tag_index.h` now forward-declares TrieMapIterator and the TrieMapRangeCallback typedef.
  - The redundant null-checks on idx->values are dropped (the field is guaranteed non-NULL).
  - `tag_iter_mode` is temporarily introduced as a copy of `tm_iter_mode` to simplify the integration. It will remove at the end of the porting.
3. Outcome: `TagIndex`'s `values` and `uniqueId` fields are no longer accessed directly outside `tag_index.c`, reducing coupling to the struct layout and the `TrieMap` API.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes