### PR TITLE
[MOD-16518] Avoid eager query dumps for blocked search clients

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1869,7 +1869,6 @@ static int buildPipelineAndExecute(AREQ *r, RedisModuleCtx *ctx, QueryError *sta
     AREQ_IncrRef(r);
     blockClientCtx.freePrivData = BlockClient_FreeAREQ;
     blockClientCtx.privdata = r;
-    blockClientCtx.ast = &r->ast;
     RSTimeoutPolicy policy = r->reqConfig.timeoutPolicy;
 
     // Determine timeout and reply callbacks based on policy.
@@ -2323,9 +2322,7 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 
   if (RunInThread(ctx) && !upstreamBC) {
     // Shard/standalone path: block and dispatch to worker. Non-RETURN policies arm
-    // the blocked-client timer with reply/timeout callbacks;
-    // BlockCursorClientWithTimeout requires cursor->execState != NULL (it dereferences it
-    // for the AST).
+    // the blocked-client timer with reply/timeout callbacks.
     RS_ASSERT(cursor->execState != NULL);
     BlockClientCtx blockClientCtx = {0};
     if (cursor->queryTimeoutPolicy != TimeoutPolicy_Return) {

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -1001,7 +1001,6 @@ static int HybridRequest_BuildPipelineAndExecute(StrongRef hybrid_ref, HybridPip
 
     BlockClientCtx blockClientCtx = {0};
 
-    blockClientCtx.ast = &hreq->requests[0]->ast;
     blockClientCtx.privdata = hreq;
     HybridRequest_IncrRef(hreq);
     blockClientCtx.freePrivData = HybridRequest_DecrRefWrapper;

--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -45,8 +45,9 @@ RedisModuleBlockedClient *BlockQueryClientWithTimeout(RedisModuleCtx *ctx, Stron
   // privdata ownership: shared between blockedClientReqCtx (background thread) and BlockedQueryNode (timeout callback, reply callback).
   // Take a reference for the timeout callback access via node->privdata.
   // This reference is released in FreeQueryNode via the freePrivData callback after timeout/reply callback completes.
-  BlockedQueryNode *node = BlockedQueries_AddQuery(blockedQueries, spec_ref, blockClientCtx->ast, blockClientCtx->privdata,
-                                                    blockClientCtx->freePrivData);
+  BlockedQueryNode *node = BlockedQueries_AddQuery(blockedQueries, spec_ref,
+                                                   blockClientCtx->privdata,
+                                                   blockClientCtx->freePrivData);
 
   // Prepare context for the worker thread
   // Since we are still in the main thread, and we already validated the
@@ -71,8 +72,8 @@ RedisModuleBlockedClient *BlockCursorClientWithTimeout(RedisModuleCtx *ctx, Curs
   // privdata is shared between the worker and BlockedCursorNode (timeout/reply
   // callbacks). Caller takes the extra ref (e.g. AREQ_IncrRef on FAIL);
   // FreeCursorNode releases it via freePrivData.
-  BlockedCursorNode *node = BlockedQueries_AddCursor(blockedQueries, cursor->spec_ref, cursor->id,
-                                                     &cursor->execState->ast, count,
+  BlockedCursorNode *node = BlockedQueries_AddCursor(blockedQueries, cursor->spec_ref,
+                                                     cursor->id, count,
                                                      blockClientCtx->privdata,
                                                      blockClientCtx->freePrivData);
 

--- a/src/info/info_redis/block_client.h
+++ b/src/info/info_redis/block_client.h
@@ -31,7 +31,6 @@ typedef struct BlockClientCtx{
   BlockedClientTimeoutCB timeoutCallback;
   BlockedClientFreePrivDataCB freePrivData;
   rs_wall_clock_ms_t timeoutMS;
-  QueryAST *ast;
 } BlockClientCtx;
 
 RedisModuleBlockedClient* BlockQueryClientWithTimeout(RedisModuleCtx *ctx, StrongRef spec, BlockClientCtx *blockClientCtx);

--- a/src/info/info_redis/threads/main_thread.c
+++ b/src/info/info_redis/threads/main_thread.c
@@ -11,6 +11,7 @@
 #include "main_thread.h"
 #include "rmalloc.h"
 
+#include <assert.h>
 #ifdef __linux__
 #include <sys/syscall.h>
 #include <unistd.h>

--- a/src/info/info_redis/types/blocked_queries.c
+++ b/src/info/info_redis/types/blocked_queries.c
@@ -7,9 +7,12 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 #include "info/info_redis/types/blocked_queries.h"
+#include "config.h"
+#include "rmalloc.h"
 #include "rmutil/rm_assert.h"
 #include "redismodule.h"
 #include "rmutil/rm_assert.h"
+#include "spec.h"
 #include <inttypes.h>
 
 BlockedQueries *BlockedQueries_Init() {
@@ -26,8 +29,8 @@ static size_t PrintActiveQueries(BlockedQueries *blockedQueries) {
     IndexSpec *sp = StrongRef_Get(at->spec);
     ++count; // increment regardless if sp is valid, the fact we have a valid node is problematic
     const char *indexName = sp ? IndexSpec_FormatName(sp, RSGlobalConfig.hideUserDataFromLog) : "n/a";
-    const char *query = at->query && !RSGlobalConfig.hideUserDataFromLog ? at->query : "n/a";
-    RedisModule_Log(NULL, "warning", "Active query on index %s, query: %s, started at %ld", indexName, query, at->start);
+    RedisModule_Log(NULL, "warning", "Active query on index %s, started at %ld", indexName,
+                    at->start);
   }
   return count;
 }
@@ -39,8 +42,8 @@ static size_t PrintActiveCursors(BlockedQueries *blockedQueries) {
     IndexSpec *sp = StrongRef_Get(at->spec);
     ++count; // increment regardless if sp is valid, the fact we have a valid node is problematic
     const char *indexName = sp ? IndexSpec_FormatName(sp, RSGlobalConfig.hideUserDataFromLog) : "n/a";
-    const char *query = at->query && !RSGlobalConfig.hideUserDataFromLog ? at->query : "n/a";
-    RedisModule_Log(NULL, "warning", "Active cursor %" PRIu64 ", on index %s, query: %s, started at %ld", at->cursorId, indexName, query, at->start);
+    RedisModule_Log(NULL, "warning", "Active cursor %" PRIu64 ", on index %s, started at %ld",
+                    at->cursorId, indexName, at->start);
   }
   return count;
 }
@@ -54,29 +57,25 @@ void BlockedQueries_Free(BlockedQueries *blockedQueries) {
   rm_free(blockedQueries);
 }
 
-BlockedQueryNode* BlockedQueries_AddQuery(BlockedQueries* blockedQueries, StrongRef spec, QueryAST* ast,
+BlockedQueryNode* BlockedQueries_AddQuery(BlockedQueries* blockedQueries, StrongRef spec,
                                           void *privdata, BlockedQueryNode_FreePrivData freePrivData) {
   BlockedQueryNode* blockedQueryNode = rm_calloc(1, sizeof(BlockedQueryNode));
   blockedQueryNode->spec = StrongRef_Clone(spec);
   blockedQueryNode->start = time(NULL);
-  blockedQueryNode->query = QAST_DumpExplain(ast, StrongRef_Get(spec));
   blockedQueryNode->privdata = privdata;
   blockedQueryNode->freePrivData = freePrivData;
   dllist_prepend(&blockedQueries->queries, &blockedQueryNode->llnode);
   return blockedQueryNode;
 }
 
-BlockedCursorNode* BlockedQueries_AddCursor(BlockedQueries* blockedQueries, WeakRef spec, uint64_t cursorId, QueryAST* ast, size_t count,
+BlockedCursorNode* BlockedQueries_AddCursor(BlockedQueries* blockedQueries, WeakRef spec,
+                                            uint64_t cursorId, size_t count,
                                             void *privdata, BlockedQueryNode_FreePrivData freePrivData) {
   BlockedCursorNode* blockedCursorNode = rm_calloc(1, sizeof(BlockedCursorNode));
   if (spec.rm) {
     // we don't want cursors to block index deletion, so we don't take a strong ref
     // not entirely sure we clean cursors on index drop, so better be safe than sorry
     blockedCursorNode->spec = WeakRef_Promote(spec);
-    IndexSpec *sp = StrongRef_Get(blockedCursorNode->spec);
-    if (sp) {
-      blockedCursorNode->query = QAST_DumpExplain(ast, sp);
-    }
   }
   blockedCursorNode->cursorId = cursorId;
   blockedCursorNode->count = count;
@@ -90,16 +89,10 @@ BlockedCursorNode* BlockedQueries_AddCursor(BlockedQueries* blockedQueries, Weak
 void BlockedQueries_RemoveQuery(BlockedQueryNode* blockedQueryNode) {
   // Main thread manages the lifetime of specs, so spec must be valid
   StrongRef_Release(blockedQueryNode->spec);
-  if (blockedQueryNode->query) {
-    rm_free(blockedQueryNode->query);
-  }
   dllist_delete(&blockedQueryNode->llnode);
 }
 
 void BlockedQueries_RemoveCursor(BlockedCursorNode* blockedCursorNode) {
   StrongRef_Release(blockedCursorNode->spec);
-  if (blockedCursorNode->query) {
-    rm_free(blockedCursorNode->query);
-  }
   dllist_delete(&blockedCursorNode->llnode);
 }

--- a/src/info/info_redis/types/blocked_queries.h
+++ b/src/info/info_redis/types/blocked_queries.h
@@ -9,10 +9,10 @@
 #pragma once
 
 #include <pthread.h>
+#include <stdint.h>
 
 #include "util/dllist.h"
 #include "util/references.h"
-#include "query.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,15 +25,13 @@ typedef void (*BlockedQueryNode_FreePrivData)(void *privdata);
  * @brief Represents all the active queries.
  *
  * This structure is used to store information about an active query, including
- * the query itself, and a strong reference to the `IndexSpec`
- * associated with the query. Since we use the StrongRef, we know that we can
- * safely access the `IndexSpec` upon crashing.
+ * a strong reference to the `IndexSpec` associated with the query. Since we use
+ * the StrongRef, we know that we can safely access the `IndexSpec` upon crashing.
  */
 typedef struct {
   DLLIST_node llnode; // Node in the doubly-linked list
   StrongRef spec;     // IndexSpec strong ref
   time_t start;       // Time node was added into list
-  char *query;        // The query
   void *privdata;     // Non-owning. Must remain valid until UnblockClient is called.
   BlockedQueryNode_FreePrivData freePrivData; // Optional callback to free privdata
 } BlockedQueryNode;
@@ -44,7 +42,6 @@ typedef struct {
   uint64_t cursorId;  // cursor id
   size_t count;       // cursor count
   time_t start;       // Time node was added into list
-  char *query;        // The query that created the cursor
   void *privdata;     // Non-owning. Must remain valid until UnblockClient is called.
   BlockedQueryNode_FreePrivData freePrivData; // Optional callback to free privdata
 } BlockedCursorNode;
@@ -76,9 +73,10 @@ BlockedQueries* BlockedQueries_Init();
  */
 void BlockedQueries_Free(BlockedQueries*);
 
-BlockedQueryNode* BlockedQueries_AddQuery(BlockedQueries* list, StrongRef spec, QueryAST* ast,
+BlockedQueryNode* BlockedQueries_AddQuery(BlockedQueries* list, StrongRef spec,
                                           void *privdata, BlockedQueryNode_FreePrivData freePrivData);
-BlockedCursorNode* BlockedQueries_AddCursor(BlockedQueries* list, WeakRef spec, uint64_t cursorId, QueryAST* ast, size_t count,
+BlockedCursorNode* BlockedQueries_AddCursor(BlockedQueries* list, WeakRef spec, uint64_t cursorId,
+                                            size_t count,
                                             void *privdata, BlockedQueryNode_FreePrivData freePrivData);
 void BlockedQueries_RemoveQuery(BlockedQueryNode* node);
 void BlockedQueries_RemoveCursor(BlockedCursorNode* node);


### PR DESCRIPTION
## Describe the changes in the pull request

Current: Background `FT.SEARCH`, `FT.AGGREGATE`, cursor, and hybrid execution registered blocked clients with a preformatted query dump, even though the blocked-query info path does not emit that dump.

Change: Remove the stored query dump from blocked query/cursor bookkeeping, drop the `BlockClientCtx` AST plumbing used only for that dump, and add direct includes that were previously hidden behind `query.h`.

Outcome: Multithreaded search requests no longer pay `QAST_DumpExplain` / `QueryNode_DumpSds` cost while registering blocked clients.

#### Which additional issues this PR fixes
1. MOD-16518
2. Fixes #10250

#### Main objects this PR modified
1. `src/info/info_redis/types/blocked_queries.*`
2. `src/info/info_redis/block_client.*`
3. `src/aggregate/aggregate_exec.c`
4. `src/hybrid/hybrid_exec.c`
5. `src/info/info_redis/threads/main_thread.c`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Validation:

- `./build.sh DEBUG=1`