### PR TITLE
[MOD-15734] COLLECT SORTBY: reject losers by borrow, skip the per-row snapshot

### DIFF
--- a/src/redisearch_rs/reducers/src/collect/local.rs
+++ b/src/redisearch_rs/reducers/src/collect/local.rs
@@ -110,17 +110,6 @@ impl Fields {
     }
 }
 
-/// Snapshot sort-key values for ranking comparison, preserving absent keys as
-/// `None` so [`cmp_fields`][value::comparison::cmp_fields] can apply its
-/// missing-worst policy.
-fn snapshot_sort_keys(sort_key_names: &[CString], item: &Value) -> Box<[Option<SharedValue>]> {
-    debug_assert!(matches!(item, Value::Map(_) | Value::Array(_)));
-    sort_key_names
-        .iter()
-        .map(|name| get_field(item, name.to_bytes()).cloned())
-        .collect()
-}
-
 /// Materialize `(k, v)` as a typed [`RLookupRow`] entry.
 ///
 /// Terminates the wire-side `BString → CString` check; a non-string or
@@ -256,11 +245,17 @@ impl LocalCollectCtx {
             match &mut self.storage {
                 Storage::Unranked(unranked) => unranked
                     .push(|| ProjectedRow::new(r.fields.prepare_row(item, &mut self.lookup))),
-                Storage::Ranked(ranked) => ranked.consider(
-                    snapshot_sort_keys(r.fields.sort_key_names(), item),
-                    (),
-                    || ProjectedRow::new(r.fields.prepare_row(item, &mut self.lookup)),
-                ),
+                Storage::Ranked(ranked) => {
+                    let item = &**item;
+                    let sort_vals = r
+                        .fields
+                        .sort_key_names()
+                        .iter()
+                        .map(|name| get_field(item, name.to_bytes()));
+                    ranked.consider(sort_vals, (), || {
+                        ProjectedRow::new(r.fields.prepare_row(item, &mut self.lookup))
+                    })
+                }
             }
         }
     }

--- a/src/redisearch_rs/reducers/src/collect/ranking.rs
+++ b/src/redisearch_rs/reducers/src/collect/ranking.rs
@@ -20,8 +20,25 @@
 //!
 
 use std::cmp::Ordering;
-use value::SharedValue;
 use value::comparison::cmp_fields;
+use value::{SharedValue, Value};
+
+/// Shared by [`RankingKey`]'s `Ord` and the borrowed [`RankingKey::ranks_below`]
+/// so the two can't diverge.
+///
+/// `cmp_fields` returns [`Ordering::Greater`] for the better side ("best = max",
+/// as in C's `SearchResult_CmpByFields` / `RPSorter`); ties break on a smaller
+/// doc id ranking higher, hence the reversed doc-id compare.
+fn cmp_ranking<'a, 'b, D: Ord>(
+    a_vals: impl IntoIterator<Item = Option<&'a Value>>,
+    a_doc: &D,
+    b_vals: impl IntoIterator<Item = Option<&'b Value>>,
+    b_doc: &D,
+    sort_asc_map: u64,
+) -> Ordering {
+    let pairs = a_vals.into_iter().zip(b_vals);
+    cmp_fields(pairs, sort_asc_map, None).then_with(|| a_doc.cmp(b_doc).reverse())
+}
 
 /// Sort-key snapshot plus the ASC/DESC bitmap, owning everything the
 /// comparator is allowed to read.
@@ -48,6 +65,24 @@ impl<D: Ord> RankingKey<D> {
     pub fn into_sort_vals(self) -> Box<[Option<SharedValue>]> {
         self.sort_vals
     }
+
+    /// Whether `self` (a survivor) ranks strictly below `cand_sort_vals` — i.e.
+    /// the candidate beats it and should evict it. Matches the [`Ord`] impl
+    /// (both via [`cmp_ranking`]) but reads the candidate by borrow, so a loser
+    /// is rejected without materialising its owned key.
+    pub fn ranks_below<'a>(
+        &self,
+        cand_sort_vals: impl IntoIterator<Item = Option<&'a SharedValue>>,
+        cand_doc_id: &D,
+    ) -> bool {
+        cmp_ranking(
+            self.sort_vals.iter().map(Option::as_deref),
+            &self.doc_id,
+            cand_sort_vals.into_iter().map(|v| v.map(|sv| &**sv)),
+            cand_doc_id,
+            self.sort_asc_map,
+        ) == Ordering::Less
+    }
 }
 
 impl<D: Ord> PartialEq for RankingKey<D> {
@@ -71,20 +106,13 @@ impl<D: Ord> Ord for RankingKey<D> {
             other.sort_vals.len(),
             "RankingKey sort_vals length mismatch"
         );
-        let pairs = self
-            .sort_vals
-            .iter()
-            .zip(other.sort_vals.iter())
-            .map(|(a, b)| (a.as_deref(), b.as_deref()));
-        // Direct delegation: `cmp_fields` already returns
-        // `Ordering::Greater` for the "better" side, matching the
-        // "best = max" convention in `SearchResult_CmpByFields` and the
-        // C `RPSorter`'s `mmh_pop_max` consumer.
-        //
-        // On a tie, break by doc id. Reversing the comparison makes a
-        // smaller doc id "stronger" (greater), so ranking prefers it.
-        cmp_fields(pairs, self.sort_asc_map, None)
-            .then_with(|| self.doc_id.cmp(&other.doc_id).reverse())
+        cmp_ranking(
+            self.sort_vals.iter().map(Option::as_deref),
+            &self.doc_id,
+            other.sort_vals.iter().map(Option::as_deref),
+            &other.doc_id,
+            self.sort_asc_map,
+        )
     }
 }
 

--- a/src/redisearch_rs/reducers/src/collect/remote.rs
+++ b/src/redisearch_rs/reducers/src/collect/remote.rs
@@ -275,12 +275,7 @@ impl RemoteCollectCtx {
         match &mut self.storage {
             Storage::Unranked(unranked) => unranked.push(project),
             Storage::Ranked(ranked) => {
-                let sort_vals = r
-                    .fields
-                    .sort_keys()
-                    .iter()
-                    .map(|key| row.get(key).cloned())
-                    .collect();
+                let sort_vals = r.fields.sort_keys().iter().map(|key| row.get(key));
                 ranked.consider(sort_vals, doc_id, project);
             }
         }

--- a/src/redisearch_rs/reducers/src/collect/storage.rs
+++ b/src/redisearch_rs/reducers/src/collect/storage.rs
@@ -252,30 +252,52 @@ impl<D: Ord> RankedStorage<D> {
     }
 
     /// `doc_id` breaks ties when sort keys compare equal (see [`RankingKey`]).
-    pub fn consider(
+    /// `sort_vals` must be cheap to clone: it is cloned once per candidate to
+    /// rank it by borrow before any value is materialised.
+    pub fn consider<'a>(
         &mut self,
-        sort_vals: Box<[Option<SharedValue>]>,
+        sort_vals: impl Iterator<Item = Option<&'a SharedValue>> + Clone,
         doc_id: D,
         project: impl FnOnce() -> ProjectedRow,
     ) {
         let max_size = self.max_size();
         // `LIMIT count` is parse-validated `>= 1`, so `offset + count` never reaches zero here.
         debug_assert!(max_size > 0, "ranked storage built with a zero cap");
-        let cand_key = RankingKey::new(sort_vals, self.sort_asc_map(), doc_id);
+        let sort_asc_map = self.sort_asc_map();
         match self {
             Self::Plain { heap, .. } => {
                 if heap.len() < max_size {
+                    let cand_key = RankingKey::new(
+                        sort_vals.map(|v| v.cloned()).collect(),
+                        sort_asc_map,
+                        doc_id,
+                    );
                     heap.push(RankedEntry::new(cand_key, project()));
                 } else {
                     // `peek_min` is the worst survivor (best = max, see
                     // `super::ranking`); a full heap with `max_size > 0` is non-empty.
                     let worst = heap.peek_min().expect("heap at cap is non-empty");
-                    if cand_key > *worst.key() {
+                    // Rank by borrow before cloning: a loser — the steady state for
+                    // a large stream with small K — pays only the comparison, no
+                    // snapshot allocation or `Arc` traffic.
+                    if worst.key().ranks_below(sort_vals.clone(), &doc_id) {
+                        let cand_key = RankingKey::new(
+                            sort_vals.map(|v| v.cloned()).collect(),
+                            sort_asc_map,
+                            doc_id,
+                        );
                         heap.push_pop_min(RankedEntry::new(cand_key, project()));
                     }
                 }
             }
             Self::Distinct { pq, .. } => {
+                // The queue is keyed on the projected row, so both the key and the
+                // row are always materialised — nothing to defer here.
+                let cand_key = RankingKey::new(
+                    sort_vals.map(|v| v.cloned()).collect(),
+                    sort_asc_map,
+                    doc_id,
+                );
                 let row = project();
                 // Priority is `Reverse<RankingKey>`, so `push_decrease` keeps the
                 // better (higher) `RankingKey` per identity, and the queue's max —

--- a/src/redisearch_rs/reducers/tests/storage.rs
+++ b/src/redisearch_rs/reducers/tests/storage.rs
@@ -36,6 +36,12 @@ fn sort_vals(v: f64) -> Box<[Option<SharedValue>]> {
     vec![Some(SharedValue::new_num(v))].into_boxed_slice()
 }
 
+/// Adapt an owned snapshot into the borrowed, cloneable iterator `consider`
+/// takes; production passes borrows straight from the row / shard payload.
+fn refs(vals: &[Option<SharedValue>]) -> impl Iterator<Item = Option<&SharedValue>> + Clone {
+    vals.iter().map(Option::as_ref)
+}
+
 /// A one-field [`ProjectedRow`] tagged with `v`, as a reducer's `project`
 /// closure would produce.
 fn projected(key: &RLookupKey<'_>, v: f64) -> ProjectedRow {
@@ -123,7 +129,7 @@ fn heap_consider_keeps_top_k_under_asc() {
     let mut s = Storage::new(true, false, Some((0, 3)), SORT_ASC);
     let h = as_ranked(&mut s);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        h.consider(sort_vals(i), (), || projected(&key, i));
+        h.consider(refs(&sort_vals(i)), (), || projected(&key, i));
     }
     let drained: Vec<_> = h.drain().collect();
     // ASC: smallest is best; heap drains best→worst.
@@ -136,7 +142,7 @@ fn heap_consider_keeps_top_k_under_desc() {
     let mut s = Storage::new(true, false, Some((0, 3)), SORT_DESC);
     let h = as_ranked(&mut s);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        h.consider(sort_vals(i), (), || projected(&key, i));
+        h.consider(refs(&sort_vals(i)), (), || projected(&key, i));
     }
     let drained: Vec<_> = h.drain().collect();
     // DESC: largest is best; heap drains best→worst.
@@ -151,16 +157,25 @@ fn heap_consider_skips_project_for_doomed_candidates() {
     let h = as_ranked(&mut s);
     // Fill with the two best candidates first.
     for v in [0.0_f64, 1.0] {
-        h.consider(sort_vals(v), (), counting_project(&mut counter, &key, v));
+        h.consider(
+            refs(&sort_vals(v)),
+            (),
+            counting_project(&mut counter, &key, v),
+        );
     }
-    // Each subsequent candidate is worse than the worst survivor (1.0)
-    // under ASC, so `project` must not run.
+    // Each subsequent candidate is worse than the worst survivor (1.0) under
+    // ASC. `project` and the sort-value snapshot are co-gated on winning the
+    // borrow comparison, so neither must run for a doomed candidate.
     for v in [2.0_f64, 3.0, 4.0] {
-        h.consider(sort_vals(v), (), counting_project(&mut counter, &key, v));
+        h.consider(
+            refs(&sort_vals(v)),
+            (),
+            counting_project(&mut counter, &key, v),
+        );
     }
     assert_eq!(
         counter, 2,
-        "`project` must not run for candidates worse than the heap's worst"
+        "`project` (and the snapshot clone) must not run for candidates worse than the worst"
     );
 }
 
@@ -173,7 +188,11 @@ fn heap_consider_invokes_project_on_eviction() {
     // Each insert is strictly better than the current worst, so every
     // candidate must be projected.
     for v in [5.0_f64, 3.0, 1.0] {
-        h.consider(sort_vals(v), (), counting_project(&mut counter, &key, v));
+        h.consider(
+            refs(&sort_vals(v)),
+            (),
+            counting_project(&mut counter, &key, v),
+        );
     }
     assert_eq!(counter, 3);
 }
@@ -196,7 +215,7 @@ fn drain_heap_applies_skip_take_after_best_first_order() {
     let mut s = Storage::new(true, false, Some((1, 2)), SORT_ASC);
     let h = as_ranked(&mut s);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        h.consider(sort_vals(i), (), || projected(&key, i));
+        h.consider(refs(&sort_vals(i)), (), || projected(&key, i));
     }
     // Top-3 under ASC = [0, 1, 2] best→worst; offset 1, count 2 → [1, 2].
     let drained: Vec<_> = h.drain().collect();
@@ -209,7 +228,7 @@ fn heap_uses_default_limit_when_no_explicit_limit() {
     let mut s = Storage::new(true, false, None, SORT_ASC);
     let h = as_ranked(&mut s);
     for i in 0..(DEFAULT_LIMIT as usize + 5) {
-        h.consider(sort_vals(i as f64), (), || projected(&key, i as f64));
+        h.consider(refs(&sort_vals(i as f64)), (), || projected(&key, i as f64));
     }
     let drained: Vec<_> = h.drain().collect();
     assert_eq!(drained.len(), DEFAULT_LIMIT as usize);
@@ -357,7 +376,7 @@ fn heap_drain_with_sort_vals_exposes_snapshot_in_best_first_order() {
     let mut s = Storage::new(true, false, Some((0, 3)), SORT_ASC);
     let h = as_ranked(&mut s);
     for i in [4.0_f64, 1.0, 5.0, 2.0, 0.0, 3.0] {
-        h.consider(sort_vals(i), (), || projected(&key, i));
+        h.consider(refs(&sort_vals(i)), (), || projected(&key, i));
     }
     let snapshots: Vec<f64> = h
         .drain_with_sort_vals()
@@ -429,7 +448,7 @@ fn distinct_heap_dedups_keeping_best_ranked() {
     // rank 4.
     let inserts = [(1.0_f64, 1.0_f64), (2.0, 2.0), (1.0, 5.0), (2.0, 4.0)];
     for (v, rank) in inserts {
-        d.consider(sort_vals(rank), (), || projected(&key, v));
+        d.consider(refs(&sort_vals(rank)), (), || projected(&key, v));
     }
     let drained: Vec<_> = d.drain().collect();
     // Two distinct identities survive; drained best→worst by the kept rank
@@ -447,7 +466,7 @@ fn distinct_heap_stays_bounded_on_insert() {
     // rank (DESC ⇒ largest), bounded on insert rather than at drain.
     for v in 0..20_u32 {
         let v = v as f64;
-        d.consider(sort_vals(v), (), || projected(&key, v));
+        d.consider(refs(&sort_vals(v)), (), || projected(&key, v));
     }
     let drained: Vec<_> = d.drain().collect();
     assert_eq!(drained.len(), cap);
@@ -469,7 +488,7 @@ fn distinct_heap_duplicates_do_not_consume_capacity() {
         (2.0, 4.0),
         (1.0, 9.0),
     ] {
-        d.consider(sort_vals(rank), (), || projected(&key, v));
+        d.consider(refs(&sort_vals(rank)), (), || projected(&key, v));
     }
     let drained: Vec<_> = d.drain().collect();
     // Both identities survive; v=1 kept rank 9, v=2 kept rank 4 → DESC order.

--- a/src/redisearch_rs/value/src/comparison.rs
+++ b/src/redisearch_rs/value/src/comparison.rs
@@ -86,8 +86,8 @@ pub fn compare_on_equality_only(v1: &Value, v2: &Value) -> bool {
 /// Callers are responsible for any docid tiebreak when this function returns
 /// [`Ordering::Equal`].
 #[inline]
-pub fn cmp_fields<'a>(
-    pairs: impl IntoIterator<Item = (Option<&'a Value>, Option<&'a Value>)>,
+pub fn cmp_fields<'a, 'b>(
+    pairs: impl IntoIterator<Item = (Option<&'a Value>, Option<&'b Value>)>,
     ascend_map: u64,
     mut qerr: Option<&mut QueryError>,
 ) -> Ordering {


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: On the shard-side ranked, non-DISTINCT `COLLECT … SORTBY` path, `RemoteCollectReducer::add` cloned each candidate's SORTBY values into an owned `Box<[Option<SharedValue>]>` (one allocation + an `Arc` increment per value) *before* checking whether the candidate could beat the worst survivor of a full top-K heap. Once the heap is full — the steady state for a large stream with small `K` — most candidates lose, so that allocation + `Arc` traffic was thrown away every row.
2. **Change**: `RankedStorage::consider` now takes the candidate's borrowed SORTBY values as a cheap, cloneable iterator. It ranks the candidate against the worst survivor *by borrow* (`RankingKey::ranks_below`) and materialises the owned snapshot only when the candidate wins. A single `cmp_ranking` helper backs both the owned `Ord` impl and the borrowed comparison so the two can't drift. `cmp_fields` is widened to two independent borrow lifetimes (a strict, backward-compatible change). The DISTINCT arm is untouched (its queue is keyed on the projected row, so it must materialise regardless).
3. **Outcome**: A losing candidate pays only the comparison — no snapshot allocation, no `Arc` traffic, no projection. No behavior change.

#### Performance

Measured in a (separate, not-included) micro-benchmark isolating the reducer's `add → finalize` cycle: the reject-heavy/shuffled cases improve ~80% (≈5–7×) *of that stage*; the eviction-heavy guard case regresses ~1–3% (the added on-win lookup). In absolute terms the saving is ~20 ns/row, so end-to-end FT.AGGREGATE impact is small — bounded by row production (iterators, RLookup, result processors) dominating per-row cost — and only on high-cardinality `COLLECT … SORTBY … LIMIT 0 <smallK>` queries.

#### Which additional issues this PR fixes
1. MOD-15734

#### Main objects this PR modified
1. `RankedStorage::consider` / `RankingKey::ranks_below` / `cmp_ranking` (`reducers::collect`)
2. `value::comparison::cmp_fields` (lifetime widening)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal reducer optimisation with no behavior change; end-to-end user impact is negligible.
