### PR TITLE
[Iterator Revalidation][MOD-16542] Parametrize query iterators by Ref mode

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1109,6 +1109,7 @@ dependencies = [
  "qint",
  "query_term",
  "redis_reply",
+ "ref_mode",
  "rqe_core",
  "serde",
  "smallvec",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2284,6 +2284,7 @@ dependencies = [
  "redis_mock",
  "redis_reply",
  "redisearch_rs",
+ "ref_mode",
  "rqe_core",
  "rqe_iterator_type",
  "rqe_iterators",

--- a/src/redisearch_rs/inverted_index/Cargo.toml
+++ b/src/redisearch_rs/inverted_index/Cargo.toml
@@ -13,6 +13,7 @@ field.workspace = true
 rqe_core.workspace = true
 index_result.workspace = true
 query_term.workspace = true
+ref_mode.workspace = true
 thin_vec.workspace = true
 qint.workspace = true
 redis_reply.workspace = true

--- a/src/redisearch_rs/inverted_index/src/codec/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/fields_offsets.rs
@@ -83,6 +83,7 @@ impl Decoder for FieldsOffsets {
         RSIndexResult::build_term().build()
     }
 
+    #[inline(always)]
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
         mut base: DocId,
@@ -181,6 +182,7 @@ impl Decoder for FieldsOffsetsWide {
         RSIndexResult::build_term().build()
     }
 
+    #[inline(always)]
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
         mut base: DocId,

--- a/src/redisearch_rs/inverted_index/src/codec/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/fields_only.rs
@@ -64,6 +64,7 @@ impl Decoder for FieldsOnly {
         RSIndexResult::build_term().build()
     }
 
+    #[inline(always)]
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
         mut base: DocId,
@@ -136,6 +137,7 @@ impl Decoder for FieldsOnlyWide {
         RSIndexResult::build_term().build()
     }
 
+    #[inline(always)]
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
         mut base: DocId,

--- a/src/redisearch_rs/inverted_index/src/codec/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/freqs_fields.rs
@@ -66,6 +66,7 @@ impl Decoder for FreqsFields {
         RSIndexResult::build_term().build()
     }
 
+    #[inline(always)]
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
         mut base: DocId,
@@ -143,6 +144,7 @@ impl Decoder for FreqsFieldsWide {
         RSIndexResult::build_term().build()
     }
 
+    #[inline(always)]
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
         mut base: DocId,

--- a/src/redisearch_rs/inverted_index/src/codec/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/freqs_offsets.rs
@@ -66,6 +66,7 @@ impl Decoder for FreqsOffsets {
         RSIndexResult::build_term().build()
     }
 
+    #[inline(always)]
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
         mut base: DocId,

--- a/src/redisearch_rs/inverted_index/src/codec/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/freqs_only.rs
@@ -53,6 +53,7 @@ impl Decoder for FreqsOnly {
         RSIndexResult::build_virt().build()
     }
 
+    #[inline(always)]
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
         mut base: DocId,

--- a/src/redisearch_rs/inverted_index/src/codec/full.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/full.rs
@@ -139,6 +139,7 @@ impl Decoder for Full {
         RSIndexResult::build_term().build()
     }
 
+    #[inline(always)]
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
         mut base: DocId,
@@ -231,6 +232,7 @@ impl Decoder for FullWide {
         RSIndexResult::build_term().build()
     }
 
+    #[inline(always)]
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
         mut base: DocId,

--- a/src/redisearch_rs/inverted_index/src/codec/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/offsets_only.rs
@@ -66,6 +66,7 @@ impl Decoder for OffsetsOnly {
         RSIndexResult::build_term().build()
     }
 
+    #[inline(always)]
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
         mut base: DocId,

--- a/src/redisearch_rs/inverted_index/src/codec/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/raw_doc_ids_only.rs
@@ -60,6 +60,7 @@ impl Decoder for RawDocIdsOnly {
         block.first_doc_id
     }
 
+    #[inline(always)]
     fn seek<'index>(
         cursor: &mut Cursor<&'index [u8]>,
         base: DocId,

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -26,7 +26,9 @@ pub use index::*;
 pub use gc::{GcApplyInfo, GcScanDelta, RepairContext};
 
 // Re-export reader types.
-pub use reader::{IndexReader, IndexReaderCore, NumericFilter, NumericReader, TermReader};
+pub use reader::{
+    IndexReader, IndexReaderCore, NumericFilter, NumericReader, RawIndexReaderCore, TermReader,
+};
 
 // Re-export filter types.
 pub use reader::{FilterGeoReader, FilterMaskReader, FilterNumericReader, ReadFilter};

--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -7,7 +7,9 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::{io::Cursor, sync::atomic};
+use std::{io::Cursor, marker::PhantomData, sync::atomic};
+
+use ref_mode::{Active, Ref, SharedPtr};
 
 use super::{IndexReader, NumericReader, TermReader};
 use crate::{
@@ -18,13 +20,34 @@ use ffi::{IndexFlags, IndexFlags_Index_HasMultiValue};
 use index_result::RSIndexResult;
 use rqe_core::DocId;
 
-/// Reader that is able to read the records from an [`InvertedIndex`]
-pub struct IndexReaderCore<'index, E> {
+/// Reader that is able to read the records from an [`InvertedIndex`].
+///
+/// Parameterised over a [`Ref`] mode:
+///
+/// - With [`Active<'a>`], the pointers in this struct are real `&'a` references
+///   into the index and the [`IndexReader`] trait is implemented — see
+///   [`IndexReaderCore`] for that instantiation.
+/// - With [`Suspended`](ref_mode::Suspended), the pointers are inert raw
+///   pointers — the struct is a passive carrier across a lock release/reacquire
+///   cycle. It will be re-promoted to [`Active`] under the read lock before any
+///   reading happens.
+///
+/// Both instantiations have identical memory layout (`#[repr(C)]` +
+/// [`SharedPtr`] is `#[repr(transparent)]` over `NonNull`), so converting from
+/// `Active` to `Suspended` and back is a zero-cost transmute.
+#[repr(C)]
+pub struct RawIndexReaderCore<Rf: Ref, E> {
     /// The inverted index that is being read from.
-    pub(crate) ii: &'index InvertedIndex<E>,
+    pub(crate) ii: SharedPtr<Rf, InvertedIndex<E>>,
 
-    /// The current position in the block that is being read from.
-    current_buffer: Cursor<&'index [u8]>,
+    /// The buffer of the current block. In [`Active`] mode this is a real
+    /// `&'a [u8]` into the block buffer; in [`Suspended`](ref_mode::Suspended)
+    /// mode it is a raw pointer that may be stale and is refreshed when
+    /// re-promoting to [`Active`].
+    buf: SharedPtr<Rf, [u8]>,
+
+    /// The current read position into [`Self::buf`].
+    buf_pos: u64,
 
     /// The index of the current block in the `blocks` vector. This is used to keep track of
     /// which block we are currently reading from, especially when the current buffer is empty and we
@@ -44,17 +67,24 @@ pub struct IndexReaderCore<'index, E> {
     /// pointer comparison in [`Self::points_to_ii`] to detect the ABA problem: if the original
     /// index is freed and a new one is allocated at the same address, the unique IDs will differ.
     ii_unique_id: IndexUniqueId,
+
+    /// Keeps `E` in the type signature even though it only appears through `ii`.
+    _phantom: PhantomData<E>,
 }
 
+/// Alias for an [`Active`] [`RawIndexReaderCore`] — the only instantiation
+/// that can actually read records from the underlying index.
+pub type IndexReaderCore<'index, E> = RawIndexReaderCore<Active<'index>, E>;
+
 // Automatically implemented if the IndexReaderCore uses a NumericDecoder.
-impl<'index, E: DecodedBy<Decoder = D>, D: Decoder + NumericDecoder> NumericReader<'index>
-    for IndexReaderCore<'index, E>
+impl<'a, E: DecodedBy<Decoder = D> + 'a, D: Decoder + NumericDecoder> NumericReader<'a>
+    for RawIndexReaderCore<Active<'a>, E>
 {
 }
 
 /// Automatically implemented if the IndexReaderCore uses a TermDecoder.
-impl<'index, E: DecodedBy<Decoder = D> + OpaqueEncoding, D: Decoder + TermDecoder>
-    TermReader<'index> for IndexReaderCore<'index, E>
+impl<'a, E: DecodedBy<Decoder = D> + OpaqueEncoding + 'a, D: Decoder + TermDecoder> TermReader<'a>
+    for RawIndexReaderCore<Active<'a>, E>
 where
     E::Storage: HasInnerIndex<E>,
 {
@@ -65,14 +95,14 @@ where
     }
 }
 
-impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> IndexReader<'index>
-    for IndexReaderCore<'index, E>
+impl<'a, E: DecodedBy<Decoder = D> + 'a, D: Decoder> IndexReader<'a>
+    for RawIndexReaderCore<Active<'a>, E>
 {
     #[inline(always)]
-    fn next_record(&mut self, result: &mut RSIndexResult<'index>) -> std::io::Result<bool> {
+    fn next_record(&mut self, result: &mut RSIndexResult<'a>) -> std::io::Result<bool> {
         // Check if the current buffer is empty or the end of the buffer has been reached
-        if self.current_buffer.get_ref().len() as u64 <= self.current_buffer.position() {
-            if self.current_block_idx + 1 >= self.ii.blocks.len() {
+        if (self.buf.get().len() as u64) <= self.buf_pos {
+            if self.current_block_idx + 1 >= self.ii.get().blocks.len() {
                 // No more blocks to read from
                 return Ok(false);
             };
@@ -80,8 +110,12 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> IndexReader<'index>
             self.set_current_block(self.current_block_idx + 1);
         }
 
-        let base = D::base_id(&self.ii.blocks[self.current_block_idx], self.last_doc_id);
-        D::decode(&mut self.current_buffer, base, result)?;
+        let ii = self.ii.get();
+        let base = D::base_id(&ii.blocks[self.current_block_idx], self.last_doc_id);
+        let mut cursor = Cursor::new(self.buf.get());
+        cursor.set_position(self.buf_pos);
+        D::decode(&mut cursor, base, result)?;
+        self.buf_pos = cursor.position();
 
         self.last_doc_id = result.doc_id;
 
@@ -92,14 +126,18 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> IndexReader<'index>
     fn seek_record(
         &mut self,
         doc_id: DocId,
-        result: &mut RSIndexResult<'index>,
+        result: &mut RSIndexResult<'a>,
     ) -> std::io::Result<bool> {
         if !self.skip_to(doc_id) {
             return Ok(false);
         }
 
-        let base = D::base_id(&self.ii.blocks[self.current_block_idx], self.last_doc_id);
-        let success = D::seek(&mut self.current_buffer, base, doc_id, result)?;
+        let ii = self.ii.get();
+        let base = D::base_id(&ii.blocks[self.current_block_idx], self.last_doc_id);
+        let mut cursor = Cursor::new(self.buf.get());
+        cursor.set_position(self.buf_pos);
+        let success = D::seek(&mut cursor, base, doc_id, result)?;
+        self.buf_pos = cursor.position();
 
         if success {
             self.last_doc_id = result.doc_id;
@@ -109,18 +147,19 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> IndexReader<'index>
     }
 
     fn skip_to(&mut self, doc_id: DocId) -> bool {
-        if self.ii.blocks.is_empty() {
+        let ii = self.ii.get();
+        if ii.blocks.is_empty() {
             return false;
         }
 
-        if self.ii.blocks[self.current_block_idx].last_doc_id >= doc_id {
+        if ii.blocks[self.current_block_idx].last_doc_id >= doc_id {
             // We are already in the correct block
             return true;
         }
 
         // SAFETY: it is safe to unwrap because we checked that the blocks are not empty when
         // creating the reader.
-        if self.ii.blocks.last().unwrap().last_doc_id < doc_id {
+        if ii.blocks.last().unwrap().last_doc_id < doc_id {
             // The document ID is greater than the last document ID in the index
             return false;
         }
@@ -128,7 +167,7 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> IndexReader<'index>
         // Check if the very next block is correct before doing a binary search. This is a small
         // optimization for the common case where we are skipping to the next block.
         let search_start = self.current_block_idx + 1;
-        if let Some(next_block) = self.ii.blocks.get(search_start)
+        if let Some(next_block) = ii.blocks.get(search_start)
             && next_block.last_doc_id >= doc_id
         {
             self.set_current_block(search_start);
@@ -136,7 +175,7 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> IndexReader<'index>
         }
 
         // Binary search to find the correct block index
-        let relative_idx = self.ii.blocks[search_start..]
+        let relative_idx = ii.blocks[search_start..]
             .binary_search_by_key(&doc_id, |b| b.last_doc_id)
             .unwrap_or_else(|insertion_point| insertion_point);
 
@@ -146,65 +185,68 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> IndexReader<'index>
     }
 
     fn reset(&mut self) {
-        if !self.ii.blocks.is_empty() {
+        let ii = self.ii.get();
+        if !ii.blocks.is_empty() {
             self.set_current_block(0);
         } else {
-            self.current_buffer = Cursor::new(&[]);
+            self.buf = SharedPtr::from_ref(&[]);
+            self.buf_pos = 0;
             self.last_doc_id = 0;
         }
 
-        self.gc_marker = self.ii.gc_marker.load(atomic::Ordering::Relaxed);
+        self.gc_marker = self.ii.get().gc_marker.load(atomic::Ordering::Relaxed);
     }
 
     fn unique_docs(&self) -> u64 {
-        self.ii.unique_docs() as u64
+        self.ii.get().unique_docs() as u64
     }
 
     fn has_duplicates(&self) -> bool {
-        self.ii.flags() & IndexFlags_Index_HasMultiValue > 0
+        self.ii.get().flags() & IndexFlags_Index_HasMultiValue > 0
     }
 
     fn flags(&self) -> IndexFlags {
-        self.ii.flags()
+        self.ii.get().flags()
     }
 
     fn needs_revalidation(&self) -> bool {
-        self.gc_marker != self.ii.gc_marker.load(atomic::Ordering::Relaxed)
+        self.gc_marker != self.ii.get().gc_marker.load(atomic::Ordering::Relaxed)
     }
 
     fn refresh_buffer_pointers(&mut self) {
-        if !self.ii.blocks.is_empty() && self.current_block_idx < self.ii.blocks.len() {
-            let current_block = &self.ii.blocks[self.current_block_idx];
+        let ii = self.ii.get();
+        if !ii.blocks.is_empty() && self.current_block_idx < ii.blocks.len() {
+            let current_block = &ii.blocks[self.current_block_idx];
             // Update the cursor to point to the current position in the refreshed buffer
-            let position = self.current_buffer.position();
-            self.current_buffer = Cursor::new(&current_block.buffer);
-            self.current_buffer.set_position(position);
+            self.buf = SharedPtr::from_ref(current_block.buffer.as_slice());
         }
     }
 }
 
-impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> IndexReaderCore<'index, E> {
+impl<'a, E: DecodedBy<Decoder = D> + 'a, D: Decoder> RawIndexReaderCore<Active<'a>, E> {
     /// Create a new index reader that reads from the given [`InvertedIndex`].
     ///
     /// # Panic
     /// This function will panic if the inverted index is empty.
-    pub(crate) fn new(ii: &'index InvertedIndex<E>) -> Self {
-        let (current_buffer, last_doc_id) = if let Some(first_block) = ii.blocks.first() {
+    pub(crate) fn new(ii: &'a InvertedIndex<E>) -> Self {
+        let (buf, last_doc_id) = if let Some(first_block) = ii.blocks.first() {
             (
-                Cursor::new(first_block.buffer.as_ref()),
+                SharedPtr::from_ref(first_block.buffer.as_slice()),
                 first_block.first_doc_id,
             )
         } else {
-            (Cursor::new(&[] as &[u8]), 0)
+            (SharedPtr::from_ref(&[][..]), 0)
         };
 
         Self {
-            ii,
-            current_buffer,
+            ii: SharedPtr::from_ref(ii),
+            buf,
+            buf_pos: 0,
             current_block_idx: 0,
             last_doc_id,
             gc_marker: ii.gc_marker.load(atomic::Ordering::Relaxed),
             ii_unique_id: ii.unique_id(),
+            _phantom: PhantomData,
         }
     }
 
@@ -212,32 +254,33 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> IndexReaderCore<'index, E> {
     /// unique IDs. The dual check prevents the ABA problem: if the original index is freed and a
     /// new one is allocated at the same address, the unique IDs will differ.
     pub fn points_to_ii(&self, index: &InvertedIndex<E>) -> bool {
-        std::ptr::eq(self.ii, index) && self.ii_unique_id == index.unique_id()
+        std::ptr::eq(self.ii.as_raw(), index) && self.ii_unique_id == index.unique_id()
     }
 
     /// Swap the inverted index of the reader with the supplied index. This is only used by the C
     /// tests to trigger a revalidation.
-    pub const fn swap_index(&mut self, index: &mut &'index InvertedIndex<E>) {
-        std::mem::swap(&mut self.ii, index);
-        self.ii_unique_id = self.ii.unique_id();
+    pub const fn swap_index(&mut self, index: &mut &'a InvertedIndex<E>) {
+        let current = self.ii.get();
+        let new_ii = std::mem::replace(index, current);
+        self.ii = SharedPtr::from_ref(new_ii);
+        self.ii_unique_id = new_ii.unique_id();
     }
 
     /// Get the internal index of the reader. This is only used by some C tests.
     pub const fn internal_index(&self) -> &InvertedIndex<E> {
-        self.ii
+        self.ii.get()
     }
 
     /// Set the current active block to the given index
     fn set_current_block(&mut self, index: usize) {
-        debug_assert!(
-            index < self.ii.blocks.len(),
-            "block index should stay in bounds"
-        );
+        let ii = self.ii.get();
+        debug_assert!(index < ii.blocks.len(), "block index should stay in bounds");
 
         self.current_block_idx = index;
-        let current_block = &self.ii.blocks[self.current_block_idx];
+        let current_block = &ii.blocks[self.current_block_idx];
         self.last_doc_id = current_block.first_doc_id;
-        self.current_buffer = Cursor::new(&current_block.buffer);
+        self.buf = SharedPtr::from_ref(current_block.buffer.as_slice());
+        self.buf_pos = 0;
     }
 }
 

--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -24,7 +24,7 @@ use rqe_core::DocId;
 ///
 /// Parameterised over a [`Ref`] mode:
 ///
-/// - With [`Active<'a>`], the pointers in this struct are real `&'a` references
+/// - With [`Active<'index>`], the pointers in this struct are real `&'index` references
 ///   into the index and the [`IndexReader`] trait is implemented — see
 ///   [`IndexReaderCore`] for that instantiation.
 /// - With [`Suspended`](ref_mode::Suspended), the pointers are inert raw
@@ -41,7 +41,7 @@ pub struct RawIndexReaderCore<Rf: Ref, E> {
     pub(crate) ii: SharedPtr<Rf, InvertedIndex<E>>,
 
     /// The buffer of the current block. In [`Active`] mode this is a real
-    /// `&'a [u8]` into the block buffer; in [`Suspended`](ref_mode::Suspended)
+    /// `&'index [u8]` into the block buffer; in [`Suspended`](ref_mode::Suspended)
     /// mode it is a raw pointer that may be stale and is refreshed when
     /// re-promoting to [`Active`].
     buf: SharedPtr<Rf, [u8]>,
@@ -77,14 +77,14 @@ pub struct RawIndexReaderCore<Rf: Ref, E> {
 pub type IndexReaderCore<'index, E> = RawIndexReaderCore<Active<'index>, E>;
 
 // Automatically implemented if the IndexReaderCore uses a NumericDecoder.
-impl<'a, E: DecodedBy<Decoder = D> + 'a, D: Decoder + NumericDecoder> NumericReader<'a>
-    for RawIndexReaderCore<Active<'a>, E>
+impl<'index, E: DecodedBy<Decoder = D> + 'index, D: Decoder + NumericDecoder> NumericReader<'index>
+    for RawIndexReaderCore<Active<'index>, E>
 {
 }
 
 /// Automatically implemented if the IndexReaderCore uses a TermDecoder.
-impl<'a, E: DecodedBy<Decoder = D> + OpaqueEncoding + 'a, D: Decoder + TermDecoder> TermReader<'a>
-    for RawIndexReaderCore<Active<'a>, E>
+impl<'index, E: DecodedBy<Decoder = D> + OpaqueEncoding + 'index, D: Decoder + TermDecoder>
+    TermReader<'index> for RawIndexReaderCore<Active<'index>, E>
 where
     E::Storage: HasInnerIndex<E>,
 {
@@ -95,11 +95,11 @@ where
     }
 }
 
-impl<'a, E: DecodedBy<Decoder = D> + 'a, D: Decoder> IndexReader<'a>
-    for RawIndexReaderCore<Active<'a>, E>
+impl<'index, E: DecodedBy<Decoder = D> + 'index, D: Decoder> IndexReader<'index>
+    for RawIndexReaderCore<Active<'index>, E>
 {
     #[inline(always)]
-    fn next_record(&mut self, result: &mut RSIndexResult<'a>) -> std::io::Result<bool> {
+    fn next_record(&mut self, result: &mut RSIndexResult<'index>) -> std::io::Result<bool> {
         // Check if the current buffer is empty or the end of the buffer has been reached
         if (self.buf.get().len() as u64) <= self.buf_pos {
             if self.current_block_idx + 1 >= self.ii.get().blocks.len() {
@@ -126,7 +126,7 @@ impl<'a, E: DecodedBy<Decoder = D> + 'a, D: Decoder> IndexReader<'a>
     fn seek_record(
         &mut self,
         doc_id: DocId,
-        result: &mut RSIndexResult<'a>,
+        result: &mut RSIndexResult<'index>,
     ) -> std::io::Result<bool> {
         if !self.skip_to(doc_id) {
             return Ok(false);
@@ -223,12 +223,12 @@ impl<'a, E: DecodedBy<Decoder = D> + 'a, D: Decoder> IndexReader<'a>
     }
 }
 
-impl<'a, E: DecodedBy<Decoder = D> + 'a, D: Decoder> RawIndexReaderCore<Active<'a>, E> {
+impl<'index, E: DecodedBy<Decoder = D> + 'index, D: Decoder> RawIndexReaderCore<Active<'index>, E> {
     /// Create a new index reader that reads from the given [`InvertedIndex`].
     ///
     /// # Panic
     /// This function will panic if the inverted index is empty.
-    pub(crate) fn new(ii: &'a InvertedIndex<E>) -> Self {
+    pub(crate) fn new(ii: &'index InvertedIndex<E>) -> Self {
         let (buf, last_doc_id) = if let Some(first_block) = ii.blocks.first() {
             (
                 SharedPtr::from_ref(first_block.buffer.as_slice()),
@@ -259,7 +259,7 @@ impl<'a, E: DecodedBy<Decoder = D> + 'a, D: Decoder> RawIndexReaderCore<Active<'
 
     /// Swap the inverted index of the reader with the supplied index. This is only used by the C
     /// tests to trigger a revalidation.
-    pub const fn swap_index(&mut self, index: &mut &'a InvertedIndex<E>) {
+    pub const fn swap_index(&mut self, index: &mut &'index InvertedIndex<E>) {
         let current = self.ii.get();
         let new_ii = std::mem::replace(index, current);
         self.ii = SharedPtr::from_ref(new_ii);

--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -146,6 +146,7 @@ impl<'index, E: DecodedBy<Decoder = D> + 'index, D: Decoder> IndexReader<'index>
         Ok(success)
     }
 
+    #[inline(always)]
     fn skip_to(&mut self, doc_id: DocId) -> bool {
         let ii = self.ii.get();
         if ii.blocks.is_empty() {
@@ -272,6 +273,7 @@ impl<'index, E: DecodedBy<Decoder = D> + 'index, D: Decoder> RawIndexReaderCore<
     }
 
     /// Set the current active block to the given index
+    #[inline(always)]
     fn set_current_block(&mut self, index: usize) {
         let ii = self.ii.get();
         debug_assert!(index < ii.blocks.len(), "block index should stay in bounds");

--- a/src/redisearch_rs/inverted_index/src/reader/field_mask.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/field_mask.rs
@@ -18,6 +18,11 @@ use rqe_core::{DocId, FieldMask};
 /// A reader that filters out records that do not match a given field mask. It is used to
 /// filter records in an index based on their field mask, allowing only those that match the
 /// specified mask to be returned.
+///
+/// `#[repr(C)]` so that, once `IR` is layout-compatible across `Active`/`Suspended`
+/// instantiations of its inner [`RawIndexReaderCore`](crate::RawIndexReaderCore),
+/// the whole `FilterMaskReader` is too.
+#[repr(C)]
 pub struct FilterMaskReader<IR> {
     /// Mask which a record needs to match to be valid
     mask: FieldMask,
@@ -122,7 +127,7 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> FilterMaskReader<IndexReader
 }
 
 /// Automatically implemented if the IndexReaderCore uses a TermDecoder.
-impl<'index, E: DecodedBy<Decoder = D> + OpaqueEncoding, D: Decoder + TermDecoder>
+impl<'index, E: DecodedBy<Decoder = D> + OpaqueEncoding + 'index, D: Decoder + TermDecoder>
     TermReader<'index> for FilterMaskReader<IndexReaderCore<'index, E>>
 where
     E::Storage: HasInnerIndex<E>,

--- a/src/redisearch_rs/inverted_index/src/reader/geo.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/geo.rs
@@ -28,6 +28,11 @@ unsafe extern "C" {
 /// specified geo filter to be returned.
 ///
 /// This should only be wrapped around readers that return numeric records.
+///
+/// `#[repr(C)]` so that, once `IR` is layout-compatible across `Active`/`Suspended`
+/// instantiations of its inner [`RawIndexReaderCore`](crate::RawIndexReaderCore),
+/// the whole `FilterGeoReader` is too.
+#[repr(C)]
 pub struct FilterGeoReader<IR> {
     /// Numeric filter with a geo filter set to which a record needs to match to be valid.
     /// `filter.geo_filter` is rebound at construction to point at our owned

--- a/src/redisearch_rs/inverted_index/src/reader/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/mod.rs
@@ -16,7 +16,7 @@ use ffi::IndexFlags;
 use index_result::RSIndexResult;
 use rqe_core::{DocId, FieldMask};
 
-pub use self::core::*;
+pub use self::core::{IndexReaderCore, RawIndexReaderCore};
 pub use field_mask::FilterMaskReader;
 pub use geo::FilterGeoReader;
 pub use numeric::{FilterNumericReader, NumericFilter};

--- a/src/redisearch_rs/inverted_index/src/reader/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/numeric.rs
@@ -85,6 +85,11 @@ impl NumericFilter {
 /// specified filter to be returned.
 ///
 /// This should only be wrapped around readers that return numeric records.
+///
+/// `#[repr(C)]` so that, once `IR` is layout-compatible across `Active`/`Suspended`
+/// instantiations of its inner [`RawIndexReaderCore`](crate::RawIndexReaderCore),
+/// the whole `FilterNumericReader` is too.
+#[repr(C)]
 pub struct FilterNumericReader<IR> {
     /// The numeric filter that is used to filter the records.
     filter: NumericFilter,

--- a/src/redisearch_rs/rqe_iterators/Cargo.toml
+++ b/src/redisearch_rs/rqe_iterators/Cargo.toml
@@ -23,6 +23,7 @@ field.workspace = true
 idf.workspace = true
 index_result.workspace = true
 index_spec.workspace = true
+ref_mode.workspace = true
 inverted_index.workspace = true
 libc.workspace = true
 numeric_range_tree.workspace = true

--- a/src/redisearch_rs/rqe_iterators/src/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/empty.rs
@@ -21,7 +21,12 @@ use crate::{
 /// An iterator that yields no results.
 ///
 /// The [`Empty`] iterator is a sentinel iterator that represents an empty result set.
+///
+/// `#[repr(C)]` makes `Empty` trivially layout-compatible with itself across
+/// `Active`/`Suspended` instantiations of any containing iterator — it has no
+/// `Rf` fields of its own, so its Suspended counterpart is just `Empty` itself.
 #[derive(Default)]
+#[repr(C)]
 pub struct Empty;
 
 impl<'index> RQEIterator<'index> for Empty {

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -9,8 +9,9 @@
 
 //! Supporting types for [`IdList`].
 
-use index_result::RSIndexResult;
+use index_result::{RSIndexResult, RawIndexResult};
 use index_spec::IndexSpecReadGuard;
+use ref_mode::{Active, Ref};
 use rqe_core::DocId;
 use std::cmp::Ordering;
 
@@ -28,7 +29,12 @@ pub type IdListSorted<'index> = IdList<'index, true>;
 pub type IdListUnsorted<'index> = IdList<'index, false>;
 
 /// An iterator that yields results according to an IDs list given on construction.
-pub struct IdList<'index, const SORTED: bool> {
+///
+/// Parameterised over a [`Ref`] mode — see [`IdList`] for the [`Active`]
+/// instantiation that implements [`RQEIterator`]. The struct owns its data
+/// (the list of document IDs); the only `Rf`-dependent field is `result`.
+#[repr(C)]
+pub struct RawIdList<Rf: Ref, const SORTED: bool> {
     /// The list of document IDs to iterate over.
     /// There must be no duplicates. The list must be sorted if `SORTED` is set to `true`.
     ids: OwnedSlice<DocId>,
@@ -36,8 +42,12 @@ pub struct IdList<'index, const SORTED: bool> {
     /// When `offset` is equal to the length of `ids`, the iterator is at EOF.
     offset: usize,
     /// A reusable result object to avoid allocations on each [`read`](RQEIterator::read) call.
-    result: RSIndexResult<'index>,
+    result: RawIndexResult<Rf>,
 }
+
+/// Alias for an [`Active`] [`RawIdList`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
+pub type IdList<'index, const SORTED: bool> = RawIdList<Active<'index>, SORTED>;
 
 impl<'index, const SORTED: bool> IdList<'index, SORTED> {
     /// Creates a new ID list iterator.

--- a/src/redisearch_rs/rqe_iterators/src/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/src/intersection.rs
@@ -18,11 +18,17 @@ use crate::{
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 
-use index_result::RSIndexResult;
+use index_result::{RSIndexResult, RawIndexResult};
 use index_spec::IndexSpecReadGuard;
+use ref_mode::{Active, Ref};
 use rqe_core::DocId;
 
 /// Yields documents appearing in ALL child iterators using a merge (AND) algorithm.
+///
+/// Parameterised over a [`Ref`] mode — see [`Intersection`] for the
+/// [`Active`] instantiation that implements [`RQEIterator`]. `Vec<I>`'s
+/// representation is independent of `Rf`, so this struct is transmute-
+/// compatible across `Active`/`Suspended` instantiations provided `I` is.
 ///
 /// Children are sorted by estimated result count (smallest first) to minimize iterations,
 /// unless `in_order` is set (which preserves the original child order for positional checks).
@@ -32,7 +38,8 @@ use rqe_core::DocId;
 /// - `max_slop`: Maximum allowed slop (distance) between term positions. `None` disables proximity
 ///   validation entirely.
 /// - `in_order`: When `true`, terms must appear in the same order as the child iterators.
-pub struct Intersection<'index, I> {
+#[repr(C)]
+pub struct RawIntersection<Rf: Ref, I> {
     /// Child iterators, sorted by estimated count (smallest first) unless `in_order` is set.
     children: Vec<I>,
     /// Last doc_id successfully found in ALL children (returned by [`last_doc_id()`](Self::last_doc_id)).
@@ -45,8 +52,12 @@ pub struct Intersection<'index, I> {
     /// When `true`, terms must appear in the same order as the child iterators.
     in_order: bool,
     /// Aggregate result combining children's results, reused to avoid allocations.
-    result: RSIndexResult<'index>,
+    result: RawIndexResult<Rf>,
 }
+
+/// Alias for an [`Active`] [`RawIntersection`] — the only instantiation
+/// with an [`RQEIterator`] impl today.
+pub type Intersection<'index, I> = RawIntersection<Active<'index>, I>;
 
 /// Result of attempting to get all children to agree on a target document ID.
 enum AgreeResult {

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -7,26 +7,39 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use index_result::RSIndexResult;
+use index_result::{RSIndexResult, RawIndexResult};
 use index_spec::IndexSpecReadGuard;
 use inverted_index::IndexReader;
+use ref_mode::{Active, Ref};
 use rqe_core::DocId;
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    SkipToOutcomeRaw,
     expiration_checker::{ExpirationChecker, NoOpChecker},
 };
 
-/// A generic iterator over inverted index entries.
+/// A generic iterator over inverted index entries, parameterised over a
+/// [`Ref`] mode.
 ///
 /// This iterator is used to query an inverted index.
 ///
+/// Layout is fixed via `#[repr(C)]` so that the `Active`/`Suspended`
+/// instantiations are transmute-compatible: every `Rf`-dependent field —
+/// `result`, `read_impl`, `skip_to_impl` — has the same memory size and
+/// alignment regardless of the chosen mode, and `R` is expected to be
+/// `#[repr(C)]` with the same property. See [`InvIndIterator`] for the only
+/// instantiation that currently has an [`RQEIterator`] impl.
+///
 /// # Type Parameters
 ///
-/// * `'index` - The lifetime of the index being iterated over.
+/// * `Rf` - The [`Ref`] mode: [`Active<'a>`] gives the iterator working,
+///   readable references into the index; [`Suspended`](ref_mode::Suspended)
+///   produces a passive carrier with no callable surface.
 /// * `R` - The reader type used to read the inverted index.
 /// * `E` - The expiration checker type used to check for expired documents.
-pub struct InvIndIterator<'index, R, E = NoOpChecker> {
+#[repr(C)]
+pub struct RawInvIndIterator<Rf: Ref, R, E = NoOpChecker> {
     /// The reader used to iterate over the inverted index.
     pub(super) reader: R,
     /// if we reached the end of the index.
@@ -34,7 +47,7 @@ pub struct InvIndIterator<'index, R, E = NoOpChecker> {
     /// the last document ID read by the iterator.
     last_doc_id: DocId,
     /// A reusable result object to avoid allocations on each `read` call.
-    pub(super) result: RSIndexResult<'index>,
+    pub(super) result: RawIndexResult<Rf>,
 
     /// The expiration checker used to determine if documents are expired.
     expiration_checker: E,
@@ -42,11 +55,20 @@ pub struct InvIndIterator<'index, R, E = NoOpChecker> {
     /// The implementation of the [`read`](RQEIterator::read) method.
     /// Using dynamic dispatch so we can pick the right version during the
     /// iterator construction saving to re-do the checks each time [`read()`](RQEIterator::read) is called.
-    read_impl: fn(&mut Self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError>,
+    read_impl: fn(&mut Self) -> Result<Option<&mut RawIndexResult<Rf>>, RQEIteratorError>,
     /// The implementation of the [`skip_to`](RQEIterator::skip_to) method.
+    #[expect(
+        clippy::type_complexity,
+        reason = "Specialised fn pointer parameterised by Rf — extracting it to a type alias \
+                  would hide the Rf dependency that drives transmute soundness across modes."
+    )]
     skip_to_impl:
-        fn(&mut Self, DocId) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError>,
+        fn(&mut Self, DocId) -> Result<Option<SkipToOutcomeRaw<'_, Rf>>, RQEIteratorError>,
 }
+
+/// Alias for an [`Active`] [`RawInvIndIterator`] — the only instantiation
+/// with an [`RQEIterator`] impl today.
+pub type InvIndIterator<'index, R, E = NoOpChecker> = RawInvIndIterator<Active<'index>, R, E>;
 
 impl<'index, R, E> InvIndIterator<'index, R, E>
 where

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -56,7 +56,7 @@ pub struct Missing<'index, E: DecodedBy, C = crate::expiration_checker::NoOpChec
 
 impl<'index, E, C> Missing<'index, E, C>
 where
-    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>> + 'index,
     <E as DecodedBy>::Decoder: DocIdsDecoder,
     C: ExpirationChecker,
 {
@@ -177,7 +177,7 @@ where
 
 impl<'index, E, C> RQEIterator<'index> for Missing<'index, E, C>
 where
-    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>> + 'index,
     <E as DecodedBy>::Decoder: DocIdsDecoder,
     C: ExpirationChecker,
 {
@@ -246,7 +246,7 @@ where
 
 impl<'index, E, C> ProfilePrint for Missing<'index, E, C>
 where
-    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>> + 'index,
     <E as DecodedBy>::Decoder: DocIdsDecoder,
     C: ExpirationChecker,
 {

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -15,11 +15,14 @@ use std::{
 use ffi::RedisSearchCtx;
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use inverted_index::{DecodedBy, DocIdsDecoder, IndexReaderCore, opaque::OpaqueEncoding};
+use inverted_index::{
+    DecodedBy, DocIdsDecoder, IndexReader, IndexReaderCore, RawIndexReaderCore,
+    opaque::OpaqueEncoding,
+};
+use ref_mode::{Active, Ref};
 use rqe_core::{DocId, FieldIndex, RS_FIELDMASK_ALL};
 
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
-use inverted_index::IndexReader;
 
 use crate::{
     ExpirationChecker, FieldExpirationChecker, IteratorType, RQEIterator, RQEIteratorError,
@@ -27,9 +30,11 @@ use crate::{
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 
-use super::InvIndIterator;
+use super::{InvIndIterator, core::RawInvIndIterator};
 
-/// An iterator over documents that are missing a specific field.
+/// An iterator over documents that are missing a specific field, parameterised
+/// over a [`Ref`] mode. See [`Missing`] for the [`Active`] instantiation that
+/// implements [`RQEIterator`].
 ///
 /// Used for `ismissing(@field)` queries, where the goal is to match every
 /// document that does not have the specified field indexed. The set of such
@@ -41,11 +46,12 @@ use super::InvIndIterator;
 ///
 /// # Type Parameters
 ///
-/// * `'index` - The lifetime of the index being iterated over.
+/// * `Rf` - The [`Ref`] mode (see [`RawInvIndIterator`] for details).
 /// * `E` - The encoding type for the inverted index. Its decoder must implement [`DocIdsDecoder`].
 /// * `C` - The expiration checker type.
-pub struct Missing<'index, E: DecodedBy, C = crate::expiration_checker::NoOpChecker> {
-    it: InvIndIterator<'index, IndexReaderCore<'index, E>, C>,
+#[repr(C)]
+pub struct RawMissing<Rf: Ref, E: DecodedBy, C = crate::expiration_checker::NoOpChecker> {
+    it: RawInvIndIterator<Rf, RawIndexReaderCore<Rf, E>, C>,
     field_index: FieldIndex,
     /// Owned copy of the field name, extracted from the spec at construction
     /// time. Owning the string means the iterator no longer borrows from
@@ -53,6 +59,11 @@ pub struct Missing<'index, E: DecodedBy, C = crate::expiration_checker::NoOpChec
     /// construction time (not for the iterator's entire lifetime).
     field_name: CString,
 }
+
+/// Alias for an [`Active`] [`RawMissing`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
+pub type Missing<'index, E, C = crate::expiration_checker::NoOpChecker> =
+    RawMissing<Active<'index>, E, C>;
 
 impl<'index, E, C> Missing<'index, E, C>
 where

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -22,23 +22,25 @@ use inverted_index::{
     FilterGeoReader, FilterNumericReader, IndexReader, NumericFilter, NumericReader,
 };
 use numeric_range_tree::{NumericIndexReader, NumericRangeTree};
+use ref_mode::{Active, Ref};
 use rqe_core::DocId;
 
-use super::core::InvIndIterator;
+use super::core::{InvIndIterator, RawInvIndIterator};
 
-/// An iterator over numeric inverted index entries.
-///
-/// This iterator can be used to query a numeric inverted index.
+/// An iterator over numeric inverted index entries, parameterised over a
+/// [`Ref`] mode. See [`Numeric`] for the [`Active`] instantiation that
+/// implements [`RQEIterator`].
 ///
 /// The [`inverted_index::IndexReader`] API can be used to fully scan an inverted index.
 ///
 /// # Type Parameters
 ///
-/// * `'index` - The lifetime of the index being iterated over.
+/// * `Rf` - The [`Ref`] mode (see [`RawInvIndIterator`] for details).
 /// * `R` - The type of the numeric reader.
 /// * `E` - The expiration checker type used to check for expired documents.
-pub struct Numeric<'index, R, E = NoOpChecker> {
-    it: InvIndIterator<'index, R, E>,
+#[repr(C)]
+pub struct RawNumeric<Rf: Ref, R, E = NoOpChecker> {
+    it: RawInvIndIterator<Rf, R, E>,
     /// The numeric range tree and its revision ID, used to detect changes during revalidation.
     range_tree_info: Option<RangeTreeInfo>,
     /// Minimum numeric range, only used in debug print.
@@ -46,6 +48,10 @@ pub struct Numeric<'index, R, E = NoOpChecker> {
     /// Maximum numeric range, only used in debug print.
     range_max: f64,
 }
+
+/// Alias for an [`Active`] [`RawNumeric`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
+pub type Numeric<'index, R, E = NoOpChecker> = RawNumeric<Active<'index>, R, E>;
 
 /// Information about the numeric range tree backing a [`Numeric`] iterator.
 struct RangeTreeInfo {

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -13,9 +13,11 @@ use ffi::{RedisSearchCtx, TagIndex};
 use index_result::{RSIndexResult, RSOffsetSlice};
 use index_spec::IndexSpecReadGuard;
 use inverted_index::{
-    DecodedBy, DocIdsDecoder, IndexReader, IndexReaderCore, opaque::OpaqueEncoding,
+    DecodedBy, DocIdsDecoder, IndexReader, IndexReaderCore, RawIndexReaderCore,
+    opaque::OpaqueEncoding,
 };
 use query_term::RSQueryTerm;
+use ref_mode::{Active, Ref};
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 use crate::{
@@ -24,9 +26,11 @@ use crate::{
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 
-use super::InvIndIterator;
+use super::{InvIndIterator, core::RawInvIndIterator};
 
-/// An iterator over documents matching a specific tag value.
+/// An iterator over documents matching a specific tag value, parameterised
+/// over a [`Ref`] mode. See [`Tag`] for the [`Active`] instantiation that
+/// implements [`RQEIterator`].
 ///
 /// Used for tag queries where the goal is to match every document that has
 /// a specific tag value indexed.
@@ -37,13 +41,18 @@ use super::InvIndIterator;
 ///
 /// # Type Parameters
 ///
-/// * `'index` - The lifetime of the index being iterated over.
+/// * `Rf` - The [`Ref`] mode (see [`RawInvIndIterator`] for details).
 /// * `E` - The encoding type for the inverted index. Its decoder must implement [`DocIdsDecoder`].
 /// * `C` - The expiration checker type.
-pub struct Tag<'index, E, C = crate::expiration_checker::NoOpChecker> {
-    it: InvIndIterator<'index, IndexReaderCore<'index, E>, C>,
+#[repr(C)]
+pub struct RawTag<Rf: Ref, E, C = crate::expiration_checker::NoOpChecker> {
+    it: RawInvIndIterator<Rf, RawIndexReaderCore<Rf, E>, C>,
     tag_index: NonNull<TagIndex>,
 }
+
+/// Alias for an [`Active`] [`RawTag`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
+pub type Tag<'index, E, C = crate::expiration_checker::NoOpChecker> = RawTag<Active<'index>, E, C>;
 
 impl<'index, E, C> Tag<'index, E, C>
 where

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -47,7 +47,7 @@ pub struct Tag<'index, E, C = crate::expiration_checker::NoOpChecker> {
 
 impl<'index, E, C> Tag<'index, E, C>
 where
-    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>> + 'index,
     <E as DecodedBy>::Decoder: DocIdsDecoder,
     C: ExpirationChecker,
 {
@@ -178,7 +178,7 @@ where
 
 impl<'index, E, C> RQEIterator<'index> for Tag<'index, E, C>
 where
-    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>> + 'index,
     <E as DecodedBy>::Decoder: DocIdsDecoder,
     C: ExpirationChecker,
 {
@@ -245,7 +245,8 @@ where
 impl<'index, E, C> ProfilePrint for Tag<'index, E, C>
 where
     E: inverted_index::DecodedBy
-        + inverted_index::opaque::OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+        + inverted_index::opaque::OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>
+        + 'index,
     <E as inverted_index::DecodedBy>::Decoder: inverted_index::DocIdsDecoder,
     C: crate::expiration_checker::ExpirationChecker,
 {

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -14,6 +14,7 @@ use index_result::{RSIndexResult, RSOffsetSlice};
 use index_spec::IndexSpecReadGuard;
 use inverted_index::TermReader;
 use query_term::RSQueryTerm;
+use ref_mode::{Active, Ref};
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 use crate::{
@@ -22,20 +23,26 @@ use crate::{
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 
-use super::core::InvIndIterator;
+use super::core::{InvIndIterator, RawInvIndIterator};
 
-/// An iterator over term inverted index entries.
-///
-/// This iterator can be used to query a term inverted index.
+/// An iterator over term inverted index entries, parameterised over a
+/// [`Ref`] mode. See [`Term`] for the [`Active`] instantiation that
+/// implements [`RQEIterator`].
 ///
 /// # Type Parameters
 ///
-/// * `'index` - The lifetime of the index being iterated over.
+/// * `Rf` - The [`Ref`] mode (see [`RawInvIndIterator`] for details).
 /// * `R` - The reader type used to read the inverted index.
 /// * `E` - The expiration checker type used to check for expired documents.
-pub struct Term<'index, R, E = crate::expiration_checker::NoOpChecker> {
-    it: InvIndIterator<'index, R, E>,
+#[repr(C)]
+pub struct RawTerm<Rf: Ref, R, E = crate::expiration_checker::NoOpChecker> {
+    it: RawInvIndIterator<Rf, R, E>,
 }
+
+/// Alias for an [`Active`] [`RawTerm`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
+pub type Term<'index, R, E = crate::expiration_checker::NoOpChecker> =
+    RawTerm<Active<'index>, R, E>;
 
 impl<'index, R, E> Term<'index, R, E>
 where

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
@@ -41,7 +41,7 @@ pub struct Wildcard<'index, E: DecodedBy> {
 
 impl<'index, E> Wildcard<'index, E>
 where
-    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>> + 'index,
     <E as DecodedBy>::Decoder: DocIdsDecoder,
 {
     /// Create an iterator returning all documents from the `existingDocs`
@@ -93,7 +93,7 @@ where
 
 impl<'index, E> RQEIterator<'index> for Wildcard<'index, E>
 where
-    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>> + 'index,
     <E as DecodedBy>::Decoder: DocIdsDecoder,
 {
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
@@ -9,7 +9,10 @@
 
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use inverted_index::{DecodedBy, DocIdsDecoder, IndexReaderCore, opaque::OpaqueEncoding};
+use inverted_index::{
+    DecodedBy, DocIdsDecoder, IndexReaderCore, RawIndexReaderCore, opaque::OpaqueEncoding,
+};
+use ref_mode::{Active, Ref};
 use rqe_core::DocId;
 
 use crate::{
@@ -18,10 +21,12 @@ use crate::{
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 
-use super::core::InvIndIterator;
+use super::core::{InvIndIterator, RawInvIndIterator};
 use rqe_core::RS_FIELDMASK_ALL;
 
-/// An iterator over all existing documents in an index.
+/// An iterator over all existing documents in an index, parameterised over
+/// a [`Ref`] mode. See [`Wildcard`] for the [`Active`] instantiation that
+/// implements [`RQEIterator`].
 ///
 /// Used for wildcard queries (`*`), where the goal is to match every document
 /// rather than filtering by a specific term or numeric range. The set of
@@ -33,11 +38,16 @@ use rqe_core::RS_FIELDMASK_ALL;
 ///
 /// # Type Parameters
 ///
-/// * `'index` - The lifetime of the index being iterated over.
+/// * `Rf` - The [`Ref`] mode (see [`RawInvIndIterator`] for details).
 /// * `E` - The encoding type for the inverted index. Its decoder must implement [`DocIdsDecoder`].
-pub struct Wildcard<'index, E: DecodedBy> {
-    it: InvIndIterator<'index, IndexReaderCore<'index, E>>,
+#[repr(C)]
+pub struct RawWildcard<Rf: Ref, E: DecodedBy> {
+    it: RawInvIndIterator<Rf, RawIndexReaderCore<Rf, E>>,
 }
+
+/// Alias for an [`Active`] [`RawWildcard`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
+pub type Wildcard<'index, E> = RawWildcard<Active<'index>, E>;
 
 impl<'index, E> Wildcard<'index, E>
 where

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -21,11 +21,12 @@ use std::ptr::NonNull;
 use std::sync::OnceLock;
 
 use index_spec::IndexSpecReadGuard;
+use ref_mode::{Active, Ref};
 use rqe_core::{DocId, FieldIndex};
 use thiserror::Error;
 
 use ::inverted_index::FieldMask;
-use index_result::RSIndexResult;
+use index_result::{RSIndexResult, RawIndexResult};
 pub use query_error::QueryError;
 use query_term::RSQueryTerm;
 
@@ -77,15 +78,39 @@ pub use union::{
 pub use union_opaque::{UnionOpaque, UnionVariant};
 pub use wildcard::{NewWildcardIterator, Wildcard, WildcardIterator};
 
-#[derive(Debug, PartialEq)]
-/// The outcome of [`RQEIterator::skip_to`].
-pub enum SkipToOutcome<'iterator, 'index> {
+#[derive(Debug)]
+/// The outcome of [`RQEIterator::skip_to`], generic over the [`Ref`] mode.
+pub enum SkipToOutcomeRaw<'iterator, Rf: Ref> {
     /// The iterator has a valid entry for the requested `doc_id`.
-    Found(&'iterator mut RSIndexResult<'index>),
+    Found(&'iterator mut RawIndexResult<Rf>),
 
     /// The iterator doesn't have an entry for the requested `doc_id`, but there are entries with an id greater than the requested one.
-    NotFound(&'iterator mut RSIndexResult<'index>),
+    NotFound(&'iterator mut RawIndexResult<Rf>),
 }
+
+/// Manual `PartialEq` impl with a transitive bound on
+/// `RawIndexResult<Rf>: PartialEq` — only [`Active`] satisfies this
+/// (see [`ref_mode`]).
+impl<'iterator, Rf: Ref> PartialEq for SkipToOutcomeRaw<'iterator, Rf>
+where
+    RawIndexResult<Rf>: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Found(a), Self::Found(b)) => a == b,
+            (Self::NotFound(a), Self::NotFound(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+/// The outcome of [`RQEIterator::skip_to`] when the iterator holds [`Active`]
+/// references into the index. This is the only instantiation that's
+/// constructible from trait-impl code today; the more general
+/// [`SkipToOutcomeRaw`] exists so the iterator structs can store function
+/// pointers whose signatures are uniform across `Active`/`Suspended`
+/// instantiations.
+pub type SkipToOutcome<'iterator, 'index> = SkipToOutcomeRaw<'iterator, Active<'index>>;
 
 #[derive(Debug, Error)]
 /// An iterator failure indications

--- a/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
@@ -18,6 +18,11 @@ use crate::{
 };
 
 /// An iterator that is either [`Empty`] or the provided [`RQEIterator`].
+///
+/// `#[repr(C)]` so that `MaybeEmpty<I>` is layout-compatible with
+/// `MaybeEmpty<I::Suspended>` once the iterator's `Suspended` counterpart
+/// (added in the suspend/resume phase) lines up with `I`.
+#[repr(C)]
 pub struct MaybeEmpty<I>(MaybeEmptyOption<I>);
 
 impl<'index, I> MaybeEmpty<I>
@@ -75,6 +80,7 @@ where
     }
 }
 
+#[repr(C)]
 enum MaybeEmptyOption<I> {
     None(Empty),
     Some(I),

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -12,13 +12,14 @@
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
     deferred::{ProducedResults, Producer},
-    id_list::IdList,
+    id_list::{IdList, RawIdList},
     profile_print::{ProfilePrint, ProfilePrintCtx},
     utils::OwnedSlice,
 };
 use ffi::{RLookupKey, RLookupKeyHandle};
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
+use ref_mode::{Active, Ref};
 use rqe_core::DocId;
 
 /// The different types of metrics.
@@ -40,8 +41,14 @@ pub type MetricSortedByScore<'index> = Metric<'index, false>;
 /// An iterator that yields document ids alongside a metric value (e.g. a score or a distance).
 /// The iterator can be sorted by document id or by metric value,
 /// but the choice is made at compile time.
-pub struct Metric<'index, const SORTED_BY_ID: bool> {
-    base: IdList<'index, SORTED_BY_ID>,
+///
+/// Parameterised over a [`Ref`] mode — see [`Metric`] for the [`Active`]
+/// instantiation that implements [`RQEIterator`]. The `Rf` flows down into
+/// the wrapped `RawIdList` (whose `result` field is `Rf`-typed); the metric
+/// data is owned and has no `Rf` dependency.
+#[repr(C)]
+pub struct RawMetric<Rf: Ref, const SORTED_BY_ID: bool> {
+    base: RawIdList<Rf, SORTED_BY_ID>,
     metric_data: OwnedSlice<f64>,
     type_: MetricType,
     own_key: *mut RLookupKey,
@@ -54,7 +61,11 @@ pub struct Metric<'index, const SORTED_BY_ID: bool> {
     key_handle: *mut RLookupKeyHandle,
 }
 
-impl<'index, const SORTED_BY_ID: bool> Drop for Metric<'index, SORTED_BY_ID> {
+/// Alias for an [`Active`] [`RawMetric`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
+pub type Metric<'index, const SORTED_BY_ID: bool> = RawMetric<Active<'index>, SORTED_BY_ID>;
+
+impl<Rf: Ref, const SORTED_BY_ID: bool> Drop for RawMetric<Rf, SORTED_BY_ID> {
     fn drop(&mut self) {
         if !self.key_handle.is_null() {
             // Safety: thanks to [`Self::key_handle`]'s invariant, we can safely

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -9,7 +9,8 @@
 
 //! Supporting types for [`Not`].
 
-use index_result::RSIndexResult;
+use index_result::{RSIndexResult, RawIndexResult};
+use ref_mode::{Active, Ref};
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
@@ -22,16 +23,20 @@ use index_spec::IndexSpecReadGuard;
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 /// An iterator that negates the results of its child iterator.
 ///
+/// Parameterised over a [`Ref`] mode — see [`Not`] for the [`Active`]
+/// instantiation that implements [`RQEIterator`].
+///
 /// Yields all document IDs from 1 to `max_doc_id` (inclusive) that are **not**
 /// present in the child iterator.
 ///
 /// # Type parameters
 ///
-/// * `'index` - The lifetime of the index being iterated over.
+/// * `Rf` - The [`Ref`] mode.
 /// * `I` - The child iterator type whose results are negated.
 /// * `TC` - The [`TimeoutContext`] implementation. The variant is chosen at
 ///   construction time and monomorphized into the hot path.
-pub struct Not<'index, I, TC> {
+#[repr(C)]
+pub struct RawNot<Rf: Ref, I, TC> {
     /// The child iterator whose results are negated.
     child: MaybeEmpty<I>,
     /// The maximum document ID to iterate up to (inclusive).
@@ -41,7 +46,7 @@ pub struct Not<'index, I, TC> {
     /// and reset to `false` at [`RQEIterator::rewind`].
     forced_eof: bool,
     /// A reusable result object to avoid allocations on each [`read`](RQEIterator::read) call.
-    result: RSIndexResult<'index>,
+    result: RawIndexResult<Rf>,
     /// Tracks the execution deadline for this iterator. Pass
     /// [`NoTimeout`](crate::utils::NoTimeout) to opt out of timeout checks
     /// entirely; monomorphization collapses the no-op context to dead code.
@@ -50,6 +55,10 @@ pub struct Not<'index, I, TC> {
     /// reset upon rewinding.
     timeout_ctx: TC,
 }
+
+/// Alias for an [`Active`] [`RawNot`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
+pub type Not<'index, I, TC> = RawNot<Active<'index>, I, TC>;
 
 impl<'index, I, TC> Not<'index, I, TC>
 where

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -9,7 +9,8 @@
 
 //! Supporting types for [`NotOptimized`].
 
-use index_result::RSIndexResult;
+use index_result::{RSIndexResult, RawIndexResult};
+use ref_mode::{Active, Ref};
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
@@ -23,6 +24,9 @@ use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 /// An optimized NOT iterator that uses a wildcard inverted index iterator.
 ///
+/// Parameterised over a [`Ref`] mode — see [`NotOptimized`] for the [`Active`]
+/// instantiation that implements [`RQEIterator`].
+///
 /// Unlike [`Not`](super::not::Not) which iterates sequentially from 1 to
 /// `max_doc_id`, this variant uses a
 /// [wildcard iterator](crate::wildcard) that reads from the existing-documents inverted
@@ -35,12 +39,13 @@ use rqe_core::{DocId, RS_FIELDMASK_ALL};
 ///
 /// # Type Parameters
 ///
-/// * `'index` - The lifetime of the index being iterated over.
+/// * `Rf` - The [`Ref`] mode.
 /// * `W` - The wildcard iterator type, must implement [`WildcardIterator`].
 /// * `I` - The child iterator type whose results are negated.
 /// * `TC` - The [`TimeoutContext`] implementation. Chosen at construction
 ///   time and monomorphized into the hot path.
-pub struct NotOptimized<'index, W, I, TC> {
+#[repr(C)]
+pub struct RawNotOptimized<Rf: Ref, W, I, TC> {
     /// The wildcard iterator over all existing documents.
     wcii: W,
     /// The child iterator whose results are negated.
@@ -50,12 +55,16 @@ pub struct NotOptimized<'index, W, I, TC> {
     /// Sticky EOF flag, set when iteration completes.
     forced_eof: bool,
     /// A reusable result object to avoid allocations on each [`read`](RQEIterator::read) call.
-    result: RSIndexResult<'index>,
+    result: RawIndexResult<Rf>,
     /// Tracks the execution deadline for this iterator. Pass
     /// [`NoTimeout`](crate::utils::NoTimeout) to opt out of timeout checks
     /// entirely; monomorphization collapses the no-op context to dead code.
     timeout_ctx: TC,
 }
+
+/// Alias for an [`Active`] [`RawNotOptimized`] — the only instantiation
+/// with an [`RQEIterator`] impl today.
+pub type NotOptimized<'index, W, I, TC> = RawNotOptimized<Active<'index>, W, I, TC>;
 
 impl<'index, W, I, TC> NotOptimized<'index, W, I, TC>
 where

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -50,10 +50,58 @@ pub struct RawOptional<Rf: Ref, I> {
     /// the iterator yields virtual results until [`Optional::max_doc_id`] is reached.
     ///
     /// In case child aborts during [`RQEIterator::revalidate`],
-    /// this child is turned into [`None`], changed from the [`Some`] state it starts
-    /// at when creating using [`Optional::new`]. From that point onward all results
-    /// will be virtual until `max_doc_id` is reached.
-    child: Option<I>,
+    /// this child is turned into [`OptionalChild::Gone`], changed from the
+    /// [`OptionalChild::Present`] state it starts at when creating using
+    /// [`Optional::new`]. From that point onward all results will be virtual
+    /// until `max_doc_id` is reached.
+    child: OptionalChild<I>,
+}
+
+/// Child slot for [`RawOptional`].
+///
+/// `#[repr(C)]` so that `OptionalChild<I>` is layout-compatible with
+/// `OptionalChild<I::Suspended>` — a plain `Option<I>` is niche-dependent and
+/// not transmute-stable across the `I` → `I::Suspended` swap that the
+/// suspend/resume machinery relies on. Mirrors [`crate::maybe_empty`]'s
+/// `MaybeEmptyOption` for the same reason.
+#[repr(C)]
+enum OptionalChild<I> {
+    /// Child aborted during [`RQEIterator::revalidate`] (or otherwise gone):
+    /// only virtual results from here on.
+    Gone,
+    /// Child still producing results.
+    Present(I),
+}
+
+impl<I> OptionalChild<I> {
+    /// Shared reference to the child, if it is still present.
+    #[inline(always)]
+    const fn as_ref(&self) -> Option<&I> {
+        match self {
+            Self::Gone => None,
+            Self::Present(i) => Some(i),
+        }
+    }
+
+    /// Mutable reference to the child, if it is still present.
+    #[inline(always)]
+    const fn as_mut(&mut self) -> Option<&mut I> {
+        match self {
+            Self::Gone => None,
+            Self::Present(i) => Some(i),
+        }
+    }
+
+    /// Map the child (if present) into a new type, preserving the [`Gone`] state.
+    ///
+    /// [`Gone`]: OptionalChild::Gone
+    #[inline(always)]
+    fn map<J>(self, f: impl FnOnce(I) -> J) -> OptionalChild<J> {
+        match self {
+            Self::Gone => OptionalChild::Gone,
+            Self::Present(i) => OptionalChild::Present(f(i)),
+        }
+    }
 }
 
 /// Alias for an [`Active`] [`RawOptional`] — the only instantiation with an
@@ -81,7 +129,7 @@ where
                 .frequency(1)
                 .field_mask(RS_FIELDMASK_ALL)
                 .build(),
-            child: Some(child),
+            child: OptionalChild::Present(child),
         }
     }
 
@@ -182,7 +230,7 @@ where
         &mut self,
         spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        let Some(ref mut child) = self.child else {
+        let Some(child) = self.child.as_mut() else {
             return Ok(RQEValidateStatus::Ok);
         };
         let last_child_doc_id = child.last_doc_id();
@@ -192,7 +240,7 @@ where
             // Abort: Handle child validation results (but continue processing)
             status @ (RQEValidateStatus::Aborted | RQEValidateStatus::Moved { .. }) => {
                 if matches!(status, RQEValidateStatus::Aborted) {
-                    self.child = None; // Drop it so we become fully virtual until max is reached
+                    self.child = OptionalChild::Gone; // Drop it so we become fully virtual until max is reached
                 }
 
                 Ok(if last_child_doc_id != self.result.doc_id {

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -9,7 +9,8 @@
 
 //! Supporting types for [`Optional`].
 
-use index_result::RSIndexResult;
+use index_result::{RSIndexResult, RawIndexResult};
+use ref_mode::{Active, Ref};
 use std::cmp;
 
 use crate::{
@@ -22,7 +23,11 @@ use rqe_core::{DocId, RS_FIELDMASK_ALL};
 /// An iterator that emits a sequence of results with no gaps, up to a given document id.
 /// Results are pulled from an underlying [`RQEIterator`] instance. If there is no entry
 /// for a given document id, a virtual result is yielded in its place.
-pub struct Optional<'index, I> {
+///
+/// Parameterised over a [`Ref`] mode — see [`Optional`] for the [`Active`]
+/// instantiation that implements [`RQEIterator`].
+#[repr(C)]
+pub struct RawOptional<Rf: Ref, I> {
     /// Inclusive upper bound on document identifiers to iterate over.
     /// Reads from the [`Optional::child`] beyond this bound are ignored.
     /// If the [`Optional::child`] ends before this bound, this [`Optional`] iterator yields virtual
@@ -38,7 +43,7 @@ pub struct Optional<'index, I> {
     ///
     /// Only for actual virtual results do we return a reference to it in
     /// functions such as Read/SkipTo.
-    result: RSIndexResult<'index>,
+    result: RawIndexResult<Rf>,
 
     /// The child [`RQEIterator`] provided at construction time.
     /// It is used while it can still produce results. Once exhausted,
@@ -50,6 +55,10 @@ pub struct Optional<'index, I> {
     /// will be virtual until `max_doc_id` is reached.
     child: Option<I>,
 }
+
+/// Alias for an [`Active`] [`RawOptional`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
+pub type Optional<'index, I> = RawOptional<Active<'index>, I>;
 
 impl<'index, I> Optional<'index, I>
 where

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -14,7 +14,8 @@
 //! `spec.existingDocs` to visit only real document IDs, yielding real or virtual
 //! results accordingly.
 
-use index_result::RSIndexResult;
+use index_result::{RSIndexResult, RawIndexResult};
+use ref_mode::{Active, Ref};
 
 use crate::{
     RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
@@ -28,6 +29,9 @@ use rqe_core::{DocId, RS_FIELDMASK_ALL};
 /// An iterator that emits results for all document IDs present in the index,
 /// driven by a [wildcard iterator](crate::wildcard) over the existing-documents inverted index.
 ///
+/// Parameterised over a [`Ref`] mode — see [`OptionalOptimized`] for the
+/// [`Active`] instantiation that implements [`RQEIterator`].
+///
 /// For each doc ID that `wcii` yields:
 /// - If the query child also has a hit at that doc ID, a **real** result is
 ///   returned with [`OptionalOptimized::weight`] applied.
@@ -36,7 +40,8 @@ use rqe_core::{DocId, RS_FIELDMASK_ALL};
 /// This avoids scanning doc IDs 1..=maxDocId sequentially. When the index is
 /// sparse (few documents relative to `maxDocId`), the optimized variant is
 /// significantly faster.
-pub struct OptionalOptimized<'index, W, I> {
+#[repr(C)]
+pub struct RawOptionalOptimized<Rf: Ref, W, I> {
     /// Wildcard iterator over `spec.existingDocs` — the authoritative source of doc IDs.
     wcii: W,
     /// Query child — provides real hits at positions where it has a match.
@@ -44,7 +49,7 @@ pub struct OptionalOptimized<'index, W, I> {
     /// when it is aborted during [`RQEIterator::revalidate`].
     child: MaybeEmpty<I>,
     /// Virtual result returned when `wcii` has a doc but `child` does not.
-    virt: RSIndexResult<'index>,
+    virt: RawIndexResult<Rf>,
     /// Inclusive upper bound (matches C `maxDocId`).
     max_doc_id: DocId,
     /// Weight applied to real results from `child`.
@@ -57,6 +62,10 @@ pub struct OptionalOptimized<'index, W, I> {
     /// Whether the iterator has reached EOF.
     at_eof: bool,
 }
+
+/// Alias for an [`Active`] [`RawOptionalOptimized`] — the only instantiation
+/// with an [`RQEIterator`] impl today.
+pub type OptionalOptimized<'index, W, I> = RawOptionalOptimized<Active<'index>, W, I>;
 
 impl<'index, W, I> OptionalOptimized<'index, W, I>
 where

--- a/src/redisearch_rs/rqe_iterators/src/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/src/profile.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, Instant};
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
+use ref_mode::{Active, Ref};
 use rqe_core::DocId;
 
 /// Profile counters collected during query execution.
@@ -48,6 +49,9 @@ impl ProfileCounters {
 
 /// A wrapper iterator that collects profiling metrics from a child iterator.
 ///
+/// Parameterised over a [`Ref`] mode — see [`Profile`] for the [`Active`]
+/// instantiation that implements [`RQEIterator`].
+///
 /// This iterator delegates all operations to its inner child iterator while:
 /// - Tracking the number of [`read()`](RQEIterator::read) and [`skip_to()`](RQEIterator::skip_to) calls
 /// - Measuring wall-clock time spent in these operations
@@ -55,13 +59,18 @@ impl ProfileCounters {
 ///
 /// The collected metrics can be accessed via [`Profile::counters()`] and
 /// [`Profile::wall_time_ns()`].
-pub struct Profile<'index, I: RQEIterator<'index>> {
+#[repr(C)]
+pub struct RawProfile<Rf: Ref, I> {
     child: I,
     counters: ProfileCounters,
     /// Time spent in child iterator operations.
     wall_time: Duration,
-    _marker: std::marker::PhantomData<&'index ()>,
+    _marker: std::marker::PhantomData<Rf>,
 }
+
+/// Alias for an [`Active`] [`RawProfile`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
+pub type Profile<'index, I> = RawProfile<Active<'index>, I>;
 
 impl<'index, I: RQEIterator<'index>> Profile<'index, I> {
     /// Creates a new Profile iterator wrapping the given child iterator.

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -20,6 +20,13 @@ use index_spec::IndexSpecReadGuard;
 ///
 /// Tracks where the child was in the original `children` vector so that
 /// we can restore the original order.
+///
+/// `#[repr(C)]` so that the `Vec<IndexedChild<I>>` elements stay
+/// layout-compatible across the `I` → `I::Suspended` swap: a default-repr
+/// struct is free to reorder its fields differently per instantiation, which
+/// would corrupt elements when the union is transmuted between Active and
+/// Suspended modes.
+#[repr(C)]
 pub(crate) struct IndexedChild<I> {
     /// Position of this child in the original `children` vector passed to
     /// [`UnionFlat::new`].

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -9,7 +9,8 @@
 
 //! Flat array variant of the union iterator with O(n) min-finding.
 
-use index_result::RSIndexResult;
+use index_result::{RSIndexResult, RawIndexResult};
+use ref_mode::{Active, Ref};
 use rqe_core::DocId;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
@@ -44,6 +45,9 @@ impl<I> std::ops::DerefMut for IndexedChild<I> {
 
 /// Yields documents appearing in ANY child iterator using a flat array scan.
 ///
+/// Parameterised over a [`Ref`] mode — see [`UnionFlat`] for the [`Active`]
+/// instantiation that implements [`RQEIterator`].
+///
 /// Unlike [`crate::Intersection`] which requires documents to appear in ALL children,
 /// [`UnionFlat`] yields documents that appear in at least one child. When multiple children
 /// have the same document, their results are aggregated (unless `QUICK_EXIT` is `true`).
@@ -55,11 +59,12 @@ impl<I> std::ops::DerefMut for IndexedChild<I> {
 ///
 /// # Type Parameters
 ///
-/// - `'index`: Lifetime of the index data.
+/// - `Rf`: The [`Ref`] mode.
 /// - `I`: The child iterator type, must implement [`RQEIterator`].
 /// - `QUICK_EXIT`: If `true`, returns immediately after finding any matching child.
 ///   If `false`, aggregates results from all children with the minimum doc_id.
-pub struct UnionFlat<'index, I, const QUICK_EXIT: bool> {
+#[repr(C)]
+pub struct RawUnionFlat<Rf: Ref, I, const QUICK_EXIT: bool> {
     /// Child iterators. Active children are in `children[..num_active]`,
     /// exhausted children are moved to the end and not removed so we can rewind the iterator.
     children: Vec<IndexedChild<I>>,
@@ -70,8 +75,12 @@ pub struct UnionFlat<'index, I, const QUICK_EXIT: bool> {
     /// Whether the iterator has reached EOF (all children exhausted).
     is_eof: bool,
     /// Aggregate result combining children's results, reused to avoid allocations.
-    result: RSIndexResult<'index>,
+    result: RawIndexResult<Rf>,
 }
+
+/// Alias for an [`Active`] [`RawUnionFlat`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
+pub type UnionFlat<'index, I, const QUICK_EXIT: bool> = RawUnionFlat<Active<'index>, I, QUICK_EXIT>;
 
 impl<'index, I, const QUICK_EXIT: bool> UnionFlat<'index, I, QUICK_EXIT>
 where

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -9,7 +9,8 @@
 
 //! Heap variant of the union iterator with O(log n) min-finding.
 
-use index_result::RSIndexResult;
+use index_result::{RSIndexResult, RawIndexResult};
+use ref_mode::{Active, Ref};
 use rqe_core::DocId;
 
 use crate::utils::DocIdMinHeap;
@@ -17,6 +18,9 @@ use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, Skip
 use index_spec::IndexSpecReadGuard;
 
 /// Yields documents appearing in ANY child iterator using a binary heap.
+///
+/// Parameterised over a [`Ref`] mode — see [`UnionHeap`] for the [`Active`]
+/// instantiation that implements [`RQEIterator`].
 ///
 /// Unlike [`crate::Intersection`] which requires documents to appear in ALL children,
 /// `UnionHeap` yields documents that appear in at least one child. When multiple children
@@ -29,11 +33,12 @@ use index_spec::IndexSpecReadGuard;
 ///
 /// # Type Parameters
 ///
-/// - `'index`: Lifetime of the index data.
+/// - `Rf`: The [`Ref`] mode.
 /// - `I`: The child iterator type, must implement [`RQEIterator`].
 /// - `QUICK_EXIT`: If `true`, returns immediately after finding any matching child.
 ///   If `false`, aggregates results from all children with the minimum doc_id.
-pub struct UnionHeap<'index, I, const QUICK_EXIT: bool> {
+#[repr(C)]
+pub struct RawUnionHeap<Rf: Ref, I, const QUICK_EXIT: bool> {
     children: Vec<I>,
     num_estimated: usize,
     /// Number of children that have not yet reached EOF.
@@ -44,10 +49,14 @@ pub struct UnionHeap<'index, I, const QUICK_EXIT: bool> {
     num_active: usize,
     is_eof: bool,
     /// Reused across calls to avoid allocations.
-    result: RSIndexResult<'index>,
+    result: RawIndexResult<Rf>,
     /// Min-heap of `(doc_id, child_index)`.
     heap: DocIdMinHeap,
 }
+
+/// Alias for an [`Active`] [`RawUnionHeap`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
+pub type UnionHeap<'index, I, const QUICK_EXIT: bool> = RawUnionHeap<Active<'index>, I, QUICK_EXIT>;
 
 impl<'index, I, const QUICK_EXIT: bool> UnionHeap<'index, I, QUICK_EXIT>
 where

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -25,23 +25,33 @@ use std::ffi::c_char;
 
 use ffi::QueryNodeType;
 use index_result::RSIndexResult;
+use ref_mode::{Active, Ref};
 use rqe_core::DocId;
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, UnionFullFlat,
-    UnionFullHeap, UnionQuickFlat, UnionQuickHeap, UnionTrimmed,
     profile_print::{ProfilePrint, ProfilePrintCtx},
+    union_flat::RawUnionFlat,
+    union_heap::RawUnionHeap,
+    union_trimmed::RawUnionTrimmed,
 };
 
 use index_spec::IndexSpecReadGuard;
-/// Enum holding all possible union iterator variants.
-pub enum UnionVariant<'index, I> {
-    FlatFull(UnionFullFlat<'index, I>),
-    FlatQuick(UnionQuickFlat<'index, I>),
-    HeapFull(UnionFullHeap<'index, I>),
-    HeapQuick(UnionQuickHeap<'index, I>),
-    Trimmed(UnionTrimmed<'index, I>),
+
+/// Enum holding all possible union iterator variants, parameterised over a
+/// [`Ref`] mode. See [`UnionVariant`] for the [`Active`] instantiation.
+#[repr(C)]
+pub enum RawUnionVariant<Rf: Ref, I> {
+    FlatFull(RawUnionFlat<Rf, I, false>),
+    FlatQuick(RawUnionFlat<Rf, I, true>),
+    HeapFull(RawUnionHeap<Rf, I, false>),
+    HeapQuick(RawUnionHeap<Rf, I, true>),
+    Trimmed(RawUnionTrimmed<Rf, I>),
 }
+
+/// Alias for an [`Active`] [`RawUnionVariant`] — the only instantiation
+/// with a callable surface today.
+pub type UnionVariant<'index, I> = RawUnionVariant<Active<'index>, I>;
 
 impl<'index, I: RQEIterator<'index>> UnionVariant<'index, I> {
     /// Converts this variant in place to [`UnionVariant::Trimmed`], switching
@@ -99,8 +109,12 @@ macro_rules! delegate_variant_ref_mut {
 
 /// FFI-facing union iterator holding the Rust variant and C-visible metadata
 /// (query node type, query string) used by profile printing.
-pub struct UnionOpaque<'index, I> {
-    pub variant: UnionVariant<'index, I>,
+///
+/// Parameterised over a [`Ref`] mode — see [`UnionOpaque`] for the
+/// [`Active`] instantiation that implements [`RQEIterator`].
+#[repr(C)]
+pub struct RawUnionOpaque<Rf: Ref, I> {
+    pub variant: RawUnionVariant<Rf, I>,
     pub query_node_type: QueryNodeType,
     /// Non-owning pointer to a C string describing the query (e.g. the search
     /// term). May be null.
@@ -111,6 +125,10 @@ pub struct UnionOpaque<'index, I> {
     /// pointer remains valid for the lifetime of this struct.
     pub query_string: *const c_char,
 }
+
+/// Alias for an [`Active`] [`RawUnionOpaque`] — the only instantiation
+/// with an [`RQEIterator`] impl today.
+pub type UnionOpaque<'index, I> = RawUnionOpaque<Active<'index>, I>;
 
 impl<'index, I: RQEIterator<'index>> UnionOpaque<'index, I> {
     /// Set the weight on the union's aggregate result.

--- a/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
@@ -45,13 +45,17 @@
 //! via [`UnionTrimmed::child_at`], so trimmed-away children must remain
 //! accessible even though they are inactive.
 
-use index_result::RSIndexResult;
+use index_result::{RSIndexResult, RawIndexResult};
+use ref_mode::{Active, Ref};
 use rqe_core::DocId;
 
 use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 use index_spec::IndexSpecReadGuard;
 
 /// Union iterator that drains children sequentially in reverse order.
+///
+/// Parameterised over a [`Ref`] mode — see [`UnionTrimmed`] for the
+/// [`Active`] instantiation that implements [`RQEIterator`].
 ///
 /// Created by the query optimizer when a numeric-range union can be trimmed
 /// to satisfy a `LIMIT` clause. See the [module documentation](self) for
@@ -71,9 +75,10 @@ use index_spec::IndexSpecReadGuard;
 ///
 /// # Type Parameters
 ///
-/// - `'index`: Lifetime of the index data.
+/// - `Rf`: The [`Ref`] mode.
 /// - `I`: The child iterator type, must implement [`RQEIterator`].
-pub struct UnionTrimmed<'index, I> {
+#[repr(C)]
+pub struct RawUnionTrimmed<Rf: Ref, I> {
     /// All child iterators. The cursor only visits children in the trimmed
     /// window `[trim_start..trim_end)`. Children outside the window are kept
     /// alive (not dropped) so that profile display can query them by index.
@@ -92,8 +97,12 @@ pub struct UnionTrimmed<'index, I> {
     /// Whether all children in the active window have been exhausted.
     is_eof: bool,
     /// Aggregate result combining children's results, reused to avoid allocations.
-    result: RSIndexResult<'index>,
+    result: RawIndexResult<Rf>,
 }
+
+/// Alias for an [`Active`] [`RawUnionTrimmed`] — the only instantiation
+/// with an [`RQEIterator`] impl today.
+pub type UnionTrimmed<'index, I> = RawUnionTrimmed<Active<'index>, I>;
 
 impl<'index, I> UnionTrimmed<'index, I>
 where

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -126,7 +126,8 @@ impl<'index> WildcardIterator<'index> for Wildcard<'index> {}
 impl<'index, E> WildcardIterator<'index> for crate::inverted_index::Wildcard<'index, E>
 where
     E: inverted_index::DecodedBy
-        + inverted_index::opaque::OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+        + inverted_index::opaque::OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>
+        + 'index,
     <E as inverted_index::DecodedBy>::Decoder: DocIdsDecoder,
 {
 }

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -11,10 +11,11 @@
 
 use std::ptr::NonNull;
 
-use index_result::RSIndexResult;
+use index_result::{RSIndexResult, RawIndexResult};
 use index_spec::IndexSpecReadGuard;
 use inverted_index::codec::{doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly};
 use inverted_index::{DocIdsDecoder, opaque};
+use ref_mode::{Active, Ref};
 
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
@@ -25,15 +26,25 @@ use crate::{
 };
 use crate::{IteratorType, QueryError, RQEIteratorPrintable};
 
-/// An iterator that yields all ids within a given range, from 1 to max id (inclusive) in an index.
-#[derive(Default)]
-pub struct Wildcard<'index> {
+/// An iterator that yields all ids within a given range, from 1 to max id
+/// (inclusive) in an index.
+///
+/// Parameterised over a [`Ref`] mode — see [`Wildcard`] for the [`Active`]
+/// instantiation that implements [`RQEIterator`]. The struct owns no
+/// references into the index (it's a pure counter); the only `Rf`-dependent
+/// field is `result`.
+#[repr(C)]
+pub struct RawWildcard<Rf: Ref> {
     // Supposed to be the max id in the index
     top_id: DocId,
 
     /// A reusable result object to avoid allocations on each `read` call.
-    result: RSIndexResult<'index>,
+    result: RawIndexResult<Rf>,
 }
+
+/// Alias for an [`Active`] [`RawWildcard`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
+pub type Wildcard<'index> = RawWildcard<Active<'index>>;
 
 impl Wildcard<'_> {
     pub fn new(top_id: DocId, weight: f64) -> Self {

--- a/src/redisearch_rs/trie_rs/tests/proptest-regressions/iter/wildcard_automaton.txt
+++ b/src/redisearch_rs/trie_rs/tests/proptest-regressions/iter/wildcard_automaton.txt
@@ -1,8 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc a71ca1aa11dbdb258ec6d66239ffcca02201f1eb550fa17fb658d5601fdab8b1 # shrinks to keys = ["y"], prefix = "y", suffix = ""
-cc a64a6bd3014e5a14084310d95bd0c266b4c8d2b15841f8360c699c108d57c6a2 # shrinks to keys = ["aa"], pattern = "*"

--- a/src/redisearch_rs/trie_rs/tests/proptest-regressions/iter/wildcard_automaton.txt
+++ b/src/redisearch_rs/trie_rs/tests/proptest-regressions/iter/wildcard_automaton.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc a71ca1aa11dbdb258ec6d66239ffcca02201f1eb550fa17fb658d5601fdab8b1 # shrinks to keys = ["y"], prefix = "y", suffix = ""
+cc a64a6bd3014e5a14084310d95bd0c266b4c8d2b15841f8360c699c108d57c6a2 # shrinks to keys = ["aa"], pattern = "*"


### PR DESCRIPTION
## Describe the changes in the pull request

Continue the `RSIndexResult` Ref-mode parametrisation: every iterator
that holds a single `result: RSIndexResult<'index>` (or wraps one) is
rewritten as `Raw*<Rf: Ref, ...>` with the existing public name kept as
the `Active` alias. Each `Raw*` type gains `#[repr(C)]` so its Active
and Suspended instantiations are transmute-compatible — the layout
guarantee the upcoming iterator suspend/resume machinery relies on.

No iterator behaviour changes: every public type still resolves to its
Active instantiation. The Suspended counterparts ship dormant; later
PRs in this stack populate them.

#### Main objects this PR modified
- `Wildcard`, `IdList`, `Metric`, the Union family
- `Intersection`, `Not`, `Optional`, `Profile` (+ optimized variants)
- `Tag`, `Missing`, `Term`, `Numeric`, `InvIndIterator`, `IndexReaderCore`
- `Empty`, `MaybeEmpty<I>`: gain `#[repr(C)]` without taking an `Rf`
  parameter, for layout-compat as composite fields

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

Stacked on #9589.