### PR TITLE
[Iterator Revalidation][MOD-16543] Introduce Box<Self>-based suspend/resume trait machinery

### DIFF
--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -566,7 +566,7 @@ int SetFtAliaslistInfo(RedisModuleCommand *cmd) {
       },
       {0}
     },
-    .arity = 2,
+    .arity = -2,
     .since = "8.10.0",
     .tips = "dont_cache",
   };

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -566,7 +566,7 @@ int SetFtAliaslistInfo(RedisModuleCommand *cmd) {
       },
       {0}
     },
-    .arity = -2,
+    .arity = 2,
     .since = "8.10.0",
     .tips = "dont_cache",
   };

--- a/src/redisearch_rs/headers/index_result_rs.h
+++ b/src/redisearch_rs/headers/index_result_rs.h
@@ -31,28 +31,6 @@ typedef struct RLookupKey RLookupKey;
  */
 typedef struct RSOffsetVector RSOffsetSlice;
 
-#ifndef RAWMETRICSSLICE_ACTIVE_DEFINED
-#define RAWMETRICSSLICE_ACTIVE_DEFINED
-/**
- * A read-only, C-visible slice view over the entries of a [`MetricsVec`].
- *
- * Returned by [`MetricsVec::as_metrics_slice`] for zero-copy iteration
- * from C. The pointed-to data is valid as long as the originating
- * [`MetricsVec`] is not mutated or dropped.
- */
-typedef struct RawMetricsSlice_Active {
-  /**
-   * Pointer to the first [`MetricEntry`].  May be dangling (but not null)
-   * when `len == 0`.
-   */
-  const struct RawMetricEntry_Active *data;
-  /**
-   * Number of entries.
-   */
-  size_t len;
-} RawMetricsSlice_Active;
-#endif /* RAWMETRICSSLICE_ACTIVE_DEFINED */
-
 #ifndef THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED
 #define THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED
 /**
@@ -101,11 +79,6 @@ typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u16 {
   struct Header_u16 *ptr;
 } ThinVec_SharedPtr_Active__RawIndexResult_Active__u16;
 #endif /* THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED */
-
-/**
- * The [`Active`] instantiation of [`RawMetricsSlice`].
- */
-typedef struct RawMetricsSlice_Active MetricsSlice;
 
 #ifndef SHAREDPTR_ACTIVE__RLOOKUPKEY_DEFINED
 #define SHAREDPTR_ACTIVE__RLOOKUPKEY_DEFINED
@@ -340,6 +313,33 @@ typedef union RawTermRecord_Active {
  * The [`Active`] instantiation of [`RawTermRecord`].
  */
 typedef union RawTermRecord_Active RSTermRecord;
+
+#ifndef RAWMETRICSSLICE_ACTIVE_DEFINED
+#define RAWMETRICSSLICE_ACTIVE_DEFINED
+/**
+ * A read-only, C-visible slice view over the entries of a [`MetricsVec`].
+ *
+ * Returned by [`MetricsVec::as_metrics_slice`] for zero-copy iteration
+ * from C. The pointed-to data is valid as long as the originating
+ * [`MetricsVec`] is not mutated or dropped.
+ */
+typedef struct RawMetricsSlice_Active {
+  /**
+   * Pointer to the first [`MetricEntry`].  May be dangling (but not null)
+   * when `len == 0`.
+   */
+  const struct RawMetricEntry_Active *data;
+  /**
+   * Number of entries.
+   */
+  size_t len;
+} RawMetricsSlice_Active;
+#endif /* RAWMETRICSSLICE_ACTIVE_DEFINED */
+
+/**
+ * The [`Active`] instantiation of [`RawMetricsSlice`].
+ */
+typedef struct RawMetricsSlice_Active MetricsSlice;
 
 #ifndef SMALLTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED
 #define SMALLTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED

--- a/src/redisearch_rs/headers/inverted_index.h
+++ b/src/redisearch_rs/headers/inverted_index.h
@@ -116,6 +116,35 @@ typedef struct AddRecordOutcome {
 } AddRecordOutcome;
 
 /**
+ * Information about the result of applying a garbage collection scan to the index
+ */
+typedef struct II_GCScanStats {
+  /**
+   * The number of bytes that were freed
+   */
+  size_t bytes_freed;
+  /**
+   * The number of bytes that were allocated
+   */
+  size_t bytes_allocated;
+  /**
+   * The number of entries that were removed from the index including duplicates
+   */
+  size_t entries_removed;
+  /**
+   * Net change in the index's block count for this apply. Positive when blocks were added
+   * (e.g. a `Replace` repair adding more blocks than it removed), negative when removed.
+   * Callers maintaining per-spec totals should add this signed value to their counter.
+   */
+  int64_t block_count_delta;
+  /**
+   * Whether or not we ignored the last block in the index, since it changed
+   * compared to the time we performed the scan
+   */
+  bool ignored_last_block;
+} II_GCScanStats;
+
+/**
  * Filter to apply when reading from an index. Entries which don't match the filter will not be
  * returned by the reader.
  */
@@ -152,32 +181,3 @@ typedef union IndexDecoderCtx {
     const struct NumericFilter *numeric;
   };
 } IndexDecoderCtx;
-
-/**
- * Information about the result of applying a garbage collection scan to the index
- */
-typedef struct II_GCScanStats {
-  /**
-   * The number of bytes that were freed
-   */
-  size_t bytes_freed;
-  /**
-   * The number of bytes that were allocated
-   */
-  size_t bytes_allocated;
-  /**
-   * The number of entries that were removed from the index including duplicates
-   */
-  size_t entries_removed;
-  /**
-   * Net change in the index's block count for this apply. Positive when blocks were added
-   * (e.g. a `Replace` repair adding more blocks than it removed), negative when removed.
-   * Callers maintaining per-spec totals should add this signed value to their counter.
-   */
-  int64_t block_count_delta;
-  /**
-   * Whether or not we ignored the last block in the index, since it changed
-   * compared to the time we performed the scan
-   */
-  bool ignored_last_block;
-} II_GCScanStats;

--- a/src/redisearch_rs/index_result/src/aggregate.rs
+++ b/src/redisearch_rs/index_result/src/aggregate.rs
@@ -56,6 +56,22 @@ pub enum RawAggregateResult<R: Ref> {
 #[cheadergen::config(export)]
 pub type RSAggregateResult<'a> = RawAggregateResult<Active<'a>>;
 
+// Compile-time proof that the `Active` and `Suspended` instantiations of
+// `RawAggregateResult` are layout-identical. Only `size_of`/`align_of` are
+// checked: `offset_of!` cannot address `#[repr(u8)]` enum variant fields. Each
+// variant stores its children behind a `SmallThinVec` pointer, so the inline
+// layout is pointer-sized regardless of `R`; the child `RawIndexResult<R>`
+// read through that pointer is guarded by the `core/mod.rs` block. Part of the
+// recursive net backing the conversions on `RawIndexResult`.
+const _: () = {
+    use ref_mode::Suspended;
+    use std::mem::{align_of, size_of};
+    type A = RawAggregateResult<Active<'static>>;
+    type S = RawAggregateResult<Suspended>;
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
 // Manual (rather than derived) because the `Borrowed` variant stores
 // `SharedPtr<R, RawIndexResult<R>>`, which only implements `PartialEq` in `Active`
 // mode. Restricted to the `Active` alias accordingly.

--- a/src/redisearch_rs/index_result/src/core/mod.rs
+++ b/src/redisearch_rs/index_result/src/core/mod.rs
@@ -19,7 +19,7 @@ use super::result_data::RawResultData;
 use super::term_record::RawTermRecord;
 use ffi::RSDocumentMetadata;
 use query_term::RSQueryTerm;
-use ref_mode::{Active, Ref, SharedPtr};
+use ref_mode::{Active, Ref, SharedPtr, Suspended};
 use rqe_core::{DocId, FieldMask, RS_FIELDMASK_ALL};
 
 /// Builder for creating [`RawIndexResult`] instances.
@@ -358,6 +358,55 @@ impl<'a> PartialEq for RSIndexResult<'a> {
 impl<'a> Default for RSIndexResult<'a> {
     fn default() -> Self {
         Self::build_virt().build()
+    }
+}
+
+impl<'a> RSIndexResult<'a> {
+    /// Convert this active result into its [`Suspended`] counterpart.
+    ///
+    /// `RawIndexResult<Rf>` is layout-compatible across `Rf` instantiations
+    /// because every `Rf`-dependent field threads through [`SharedPtr<Rf,
+    /// T>`](ref_mode::SharedPtr), which is `#[repr(transparent)]` over
+    /// `NonNull<T>`. Going from `Active<'a>` to [`Suspended`] is a widening
+    /// transition (it loosens validity invariants — `'a`-bound references
+    /// become inert raw pointers), so this method is safe.
+    pub const fn into_suspended(self) -> RawIndexResult<Suspended> {
+        let md = std::mem::ManuallyDrop::new(self);
+        // SAFETY: layout-compatible via SharedPtr transparency; widening
+        // transition is sound. `ManuallyDrop` prevents the active
+        // destructor from running on bytes that have been logically moved.
+        unsafe { std::mem::transmute_copy(&md) }
+    }
+}
+
+impl RawIndexResult<Suspended> {
+    /// Convert this suspended result back to an [`Active`] counterpart
+    /// covering lifetime `'a`.
+    ///
+    /// Layout-compatibility is the same as for [`RSIndexResult::into_suspended`];
+    /// this is the inverse direction. Promoting `Suspended` to `Active<'a>`
+    /// narrows validity (asserting that every pointer inside this result is
+    /// dereferenceable for `'a`), so the call is `unsafe`.
+    ///
+    /// # Safety
+    ///
+    /// For the entire chosen lifetime `'a`, every pointer carried inside
+    /// this result (the inverted-index pointers behind any
+    /// [`SharedPtr`] fields, plus the document-metadata pointer in
+    /// [`Self::dmd`]) must be:
+    ///
+    /// - valid for reads of the type it would point to in active mode, and
+    /// - unaliased by any concurrent writer.
+    ///
+    /// How those invariants are upheld is the caller's concern — typically
+    /// by holding an appropriate read lock on the owning data structure, but
+    /// this method makes no specific lock assumption.
+    pub const unsafe fn into_active<'a>(self) -> RSIndexResult<'a> {
+        let md = std::mem::ManuallyDrop::new(self);
+        // SAFETY: layout-compatible — see `RSIndexResult::into_suspended`.
+        // Narrowing the validity from raw-pointer to `&'a`-style references
+        // is sound under the caller's contract documented on this method.
+        unsafe { std::mem::transmute_copy(&md) }
     }
 }
 

--- a/src/redisearch_rs/index_result/src/core/mod.rs
+++ b/src/redisearch_rs/index_result/src/core/mod.rs
@@ -325,6 +325,40 @@ pub struct RawIndexResult<R: Ref> {
 #[cheadergen::config(export)]
 pub type RSIndexResult<'a> = RawIndexResult<Active<'a>>;
 
+// Compile-time proof that the [`Active`] and [`Suspended`] instantiations of
+// [`RawIndexResult`] are layout-identical, which is what makes the
+// `transmute`-based [`RSIndexResult::into_suspended`] /
+// [`RawIndexResult::<Suspended>::into_active`] conversions sound.
+//
+// `RawIndexResult` is `#[repr(C)]`, so checking that every field shares an
+// identical offset and that each `R`-dependent field type shares an identical
+// size pins the layout down completely. If a future change makes the two
+// instantiations diverge, this block fails to compile.
+const _: () = {
+    use std::mem::{align_of, offset_of, size_of};
+
+    type A = RawIndexResult<Active<'static>>;
+    type S = RawIndexResult<Suspended>;
+
+    // Every field starts at the same offset.
+    assert!(offset_of!(A, doc_id) == offset_of!(S, doc_id));
+    assert!(offset_of!(A, dmd) == offset_of!(S, dmd));
+    assert!(offset_of!(A, field_mask) == offset_of!(S, field_mask));
+    assert!(offset_of!(A, freq) == offset_of!(S, freq));
+    assert!(offset_of!(A, data) == offset_of!(S, data));
+    assert!(offset_of!(A, metrics) == offset_of!(S, metrics));
+    assert!(offset_of!(A, weight) == offset_of!(S, weight));
+
+    // The two `R`-dependent field types have identical size (the non-`R`
+    // fields are the same type on both sides, so only these can differ).
+    assert!(size_of::<RawResultData<Active<'static>>>() == size_of::<RawResultData<Suspended>>());
+    assert!(size_of::<RawMetricsVec<Active<'static>>>() == size_of::<RawMetricsVec<Suspended>>());
+
+    // Whole-struct backstop: equal total size + alignment.
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
 impl<'a> PartialEq for RSIndexResult<'a> {
     fn eq(&self, other: &Self) -> bool {
         let Self {
@@ -363,19 +397,14 @@ impl<'a> Default for RSIndexResult<'a> {
 
 impl<'a> RSIndexResult<'a> {
     /// Convert this active result into its [`Suspended`] counterpart.
-    ///
-    /// `RawIndexResult<Rf>` is layout-compatible across `Rf` instantiations
-    /// because every `Rf`-dependent field threads through [`SharedPtr<Rf,
-    /// T>`](ref_mode::SharedPtr), which is `#[repr(transparent)]` over
-    /// `NonNull<T>`. Going from `Active<'a>` to [`Suspended`] is a widening
-    /// transition (it loosens validity invariants — `'a`-bound references
-    /// become inert raw pointers), so this method is safe.
     pub const fn into_suspended(self) -> RawIndexResult<Suspended> {
-        let md = std::mem::ManuallyDrop::new(self);
-        // SAFETY: layout-compatible via SharedPtr transparency; widening
-        // transition is sound. `ManuallyDrop` prevents the active
-        // destructor from running on bytes that have been logically moved.
-        unsafe { std::mem::transmute_copy(&md) }
+        // SAFETY: `RawIndexResult<Active<'a>>` and `RawIndexResult<Suspended>`
+        // are layout-identical (enforced by the `const _` assertion block above).
+        // Going Active -> Suspended is a widening transition: it only loosens
+        // validity invariants (`'a`-bound references become inert raw pointers),
+        // so it is sound. `transmute` moves `self`, so no destructor runs on the
+        // logically-moved bytes.
+        unsafe { std::mem::transmute(self) }
     }
 }
 
@@ -402,11 +431,12 @@ impl RawIndexResult<Suspended> {
     /// by holding an appropriate read lock on the owning data structure, but
     /// this method makes no specific lock assumption.
     pub const unsafe fn into_active<'a>(self) -> RSIndexResult<'a> {
-        let md = std::mem::ManuallyDrop::new(self);
-        // SAFETY: layout-compatible — see `RSIndexResult::into_suspended`.
+        // SAFETY: layout-identical (see the `const _` assertion block above).
         // Narrowing the validity from raw-pointer to `&'a`-style references
         // is sound under the caller's contract documented on this method.
-        unsafe { std::mem::transmute_copy(&md) }
+        // `transmute` moves `self`, so no destructor runs on the logically-moved
+        // bytes.
+        unsafe { std::mem::transmute(self) }
     }
 }
 

--- a/src/redisearch_rs/index_result/src/core/mod.rs
+++ b/src/redisearch_rs/index_result/src/core/mod.rs
@@ -419,17 +419,32 @@ impl RawIndexResult<Suspended> {
     ///
     /// # Safety
     ///
-    /// For the entire chosen lifetime `'a`, every pointer carried inside
-    /// this result (the inverted-index pointers behind any
-    /// [`SharedPtr`] fields, plus the document-metadata pointer in
-    /// [`Self::dmd`]) must be:
+    /// The caller must guarantee that all of the following hold for the entire
+    /// chosen lifetime `'a`:
     ///
-    /// - valid for reads of the type it would point to in active mode, and
-    /// - unaliased by any concurrent writer.
+    /// 1. Every single-value pointer — the document metadata ([`Self::dmd`])
+    ///    and each [`SharedPtr`] pointee (e.g. a metric's `RLookupKey`, a term
+    ///    record's borrowed query term) — is valid for reads of its pointee
+    ///    type.
+    /// 2. Every slice-backed pointer is valid for reads of its **entire stored
+    ///    length**, with provenance covering the whole region — e.g. a term
+    ///    record's offset slice ([`RawOffsetSlice`]), whose `*const u8` must
+    ///    cover all `len` bytes.
+    /// 3. No concurrent writer aliases any pointer covered by (1) or (2).
+    /// 4. Conditions (1)–(3) hold recursively for every child result reachable
+    ///    through aggregate records (the [`SharedPtr`]/`Box` entries of a
+    ///    union / intersection / hybrid-metric result).
     ///
-    /// How those invariants are upheld is the caller's concern — typically
-    /// by holding an appropriate read lock on the owning data structure, but
-    /// this method makes no specific lock assumption.
+    /// Typically the caller upholds these by holding the inverted-index read
+    /// lock for the whole of `'a`, so that neither GC nor a writer can free or
+    /// relocate a backing block; this method makes no specific lock assumption.
+    ///
+    /// Note that (2) is strictly stronger than per-pointee validity: a pointer
+    /// valid for a single `u8` does *not* satisfy it. If a GC cycle has freed
+    /// or relocated the backing block, the slice tail may be stale, and a safe
+    /// call such as `RSOffsetSlice::as_bytes` (or anything built on it) would
+    /// then read invalid memory — undefined behaviour reached through entirely
+    /// safe code.
     pub const unsafe fn into_active<'a>(self) -> RSIndexResult<'a> {
         // SAFETY: layout-identical (see the `const _` assertion block above).
         // Narrowing the validity from raw-pointer to `&'a`-style references

--- a/src/redisearch_rs/index_result/src/metrics.rs
+++ b/src/redisearch_rs/index_result/src/metrics.rs
@@ -44,6 +44,24 @@ pub struct RawMetricEntry<R: Ref> {
 #[cheadergen::config(export)]
 pub type MetricEntry<'a> = RawMetricEntry<Active<'a>>;
 
+// Compile-time proof that the `Active` and `Suspended` instantiations of
+// `RawMetricEntry` are layout-identical. `R` enters only through the
+// `#[repr(transparent)]` `SharedPtr<R, RLookupKey>` in `key`. Entries live
+// behind the `RawMetricsVec` allocation, so they are read as the `Suspended`
+// type through that pointer after an active/suspended `transmute` — hence they
+// need the same guarantee. Part of the recursive net backing the conversions
+// on `RawIndexResult` (see `core/mod.rs`).
+const _: () = {
+    use ref_mode::Suspended;
+    use std::mem::{align_of, offset_of, size_of};
+    type A = RawMetricEntry<Active<'static>>;
+    type S = RawMetricEntry<Suspended>;
+    assert!(offset_of!(A, key) == offset_of!(S, key));
+    assert!(offset_of!(A, value) == offset_of!(S, value));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
 impl<R: Ref> Copy for RawMetricEntry<R> {}
 
 impl<R: Ref> Clone for RawMetricEntry<R> {
@@ -120,6 +138,22 @@ pub struct RawMetricsVec<R: Ref> {
 
 /// The [`Active`] instantiation of [`RawMetricsVec`].
 pub type MetricsVec<'a> = RawMetricsVec<Active<'a>>;
+
+// Compile-time proof that the `Active` and `Suspended` instantiations of
+// `RawMetricsVec` are layout-identical. The type is `#[repr(transparent)]` over
+// a single `ThinVec` pointer, so `R` only affects the element type behind the
+// allocation (guarded by the `RawMetricEntry` block above); the inline layout
+// is a bare pointer either way. Part of the recursive net backing the
+// conversions on `RawIndexResult` (see `core/mod.rs`).
+const _: () = {
+    use ref_mode::Suspended;
+    use std::mem::{align_of, offset_of, size_of};
+    type A = RawMetricsVec<Active<'static>>;
+    type S = RawMetricsVec<Suspended>;
+    assert!(offset_of!(A, inner) == offset_of!(S, inner));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
 
 impl<R: Ref> Clone for RawMetricsVec<R> {
     fn clone(&self) -> Self {

--- a/src/redisearch_rs/index_result/src/offsets.rs
+++ b/src/redisearch_rs/index_result/src/offsets.rs
@@ -37,6 +37,23 @@ pub struct RawOffsetSlice<R: Ref> {
 #[cheadergen::config(export)]
 pub type RSOffsetSlice<'a> = RawOffsetSlice<Active<'a>>;
 
+// Compile-time proof that the `Active` and `Suspended` instantiations of
+// `RawOffsetSlice` are layout-identical. `R` enters only through the
+// `#[repr(transparent)]` `SharedPtr<R, u8>` in `data`, so the two layouts must
+// match; this block makes a future divergence a build failure. Part of the
+// recursive layout-compatibility net backing the `transmute`-based
+// active/suspended conversions on `RawIndexResult` (see `core/mod.rs`).
+const _: () = {
+    use ref_mode::Suspended;
+    use std::mem::{align_of, offset_of, size_of};
+    type A = RawOffsetSlice<Active<'static>>;
+    type S = RawOffsetSlice<Suspended>;
+    assert!(offset_of!(A, data) == offset_of!(S, data));
+    assert!(offset_of!(A, len) == offset_of!(S, len));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
 impl<R: Ref> Copy for RawOffsetSlice<R> {}
 
 impl<R: Ref> Clone for RawOffsetSlice<R> {

--- a/src/redisearch_rs/index_result/src/result_data.rs
+++ b/src/redisearch_rs/index_result/src/result_data.rs
@@ -37,6 +37,22 @@ pub enum RawResultData<R: Ref> {
 #[cheadergen::config(export)]
 pub type RSResultData<'a> = RawResultData<Active<'a>>;
 
+// Compile-time proof that the `Active` and `Suspended` instantiations of
+// `RawResultData` are layout-identical. Only `size_of`/`align_of` are checked:
+// `offset_of!` cannot address `#[repr(u8)]` enum variant fields. The variant
+// payloads that carry `R` are guarded one level deeper by the
+// `RawAggregateResult` (`aggregate.rs`) and `RawTermRecord` (`term_record.rs`)
+// blocks. Part of the recursive net backing the conversions on
+// `RawIndexResult` (see `core/mod.rs`).
+const _: () = {
+    use ref_mode::Suspended;
+    use std::mem::{align_of, size_of};
+    type A = RawResultData<Active<'static>>;
+    type S = RawResultData<Suspended>;
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
 impl<'a> PartialEq for RSResultData<'a> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {

--- a/src/redisearch_rs/index_result/src/term_record.rs
+++ b/src/redisearch_rs/index_result/src/term_record.rs
@@ -67,6 +67,22 @@ pub enum RawTermRecord<R: Ref> {
 #[cheadergen::config(export)]
 pub type RSTermRecord<'a> = RawTermRecord<Active<'a>>;
 
+// Compile-time proof that the `Active` and `Suspended` instantiations of
+// `RawTermRecord` are layout-identical. Only `size_of`/`align_of` are checked:
+// `offset_of!` cannot address `#[repr(u8)]` enum variant fields. The variant
+// payloads that carry `R` are guarded one level deeper — `RawOffsetSlice`
+// (`offsets.rs`) and `SharedPtr` (`ref_mode`) — so the internals this block
+// cannot see are still pinned. Part of the recursive net backing the
+// conversions on `RawIndexResult` (see `core/mod.rs`).
+const _: () = {
+    use ref_mode::Suspended;
+    use std::mem::{align_of, size_of};
+    type A = RawTermRecord<Active<'static>>;
+    type S = RawTermRecord<Suspended>;
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
 // Manual (rather than derived) because the `Owned` variant stores
 // `Option<SharedPtr<R, RSQueryTerm>>`, which only implements `PartialEq` in
 // `Active` mode. Compares the dereferenced query term and the byte view of

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -27,7 +27,8 @@ pub use gc::{GcApplyInfo, GcScanDelta, RepairContext};
 
 // Re-export reader types.
 pub use reader::{
-    IndexReader, IndexReaderCore, NumericFilter, NumericReader, RawIndexReaderCore, TermReader,
+    IndexReader, IndexReaderCore, NumericFilter, NumericReader, RawIndexReaderCore,
+    ResumableReader, SuspendableReader, TermReader,
 };
 
 // Re-export filter types.

--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -9,9 +9,9 @@
 
 use std::{io::Cursor, marker::PhantomData, sync::atomic};
 
-use ref_mode::{Active, Ref, SharedPtr};
+use ref_mode::{Active, Ref, SharedPtr, Suspended};
 
-use super::{IndexReader, NumericReader, TermReader};
+use super::{IndexReader, NumericReader, ResumableReader, SuspendableReader, TermReader};
 use crate::{
     DecodedBy, Decoder, Encoder, HasInnerIndex, InvertedIndex, NumericDecoder, TermDecoder,
     index::unique_id::IndexUniqueId, opaque::OpaqueEncoding,
@@ -27,7 +27,7 @@ use rqe_core::DocId;
 /// - With [`Active<'index>`], the pointers in this struct are real `&'index` references
 ///   into the index and the [`IndexReader`] trait is implemented — see
 ///   [`IndexReaderCore`] for that instantiation.
-/// - With [`Suspended`](ref_mode::Suspended), the pointers are inert raw
+/// - With [`Suspended`], the pointers are inert raw
 ///   pointers — the struct is a passive carrier across a lock release/reacquire
 ///   cycle. It will be re-promoted to [`Active`] under the read lock before any
 ///   reading happens.
@@ -41,7 +41,7 @@ pub struct RawIndexReaderCore<Rf: Ref, E> {
     pub(crate) ii: SharedPtr<Rf, InvertedIndex<E>>,
 
     /// The buffer of the current block. In [`Active`] mode this is a real
-    /// `&'index [u8]` into the block buffer; in [`Suspended`](ref_mode::Suspended)
+    /// `&'index [u8]` into the block buffer; in [`Suspended`]
     /// mode it is a raw pointer that may be stale and is refreshed when
     /// re-promoting to [`Active`].
     buf: SharedPtr<Rf, [u8]>,
@@ -75,6 +75,21 @@ pub struct RawIndexReaderCore<Rf: Ref, E> {
 /// Alias for an [`Active`] [`RawIndexReaderCore`] — the only instantiation
 /// that can actually read records from the underlying index.
 pub type IndexReaderCore<'index, E> = RawIndexReaderCore<Active<'index>, E>;
+
+/// `IndexReaderCore<Active<'a>, E>` suspends to `IndexReaderCore<Suspended, E>`.
+impl<'a, E> SuspendableReader for RawIndexReaderCore<Active<'a>, E> {
+    type Suspended = RawIndexReaderCore<Suspended, E>;
+}
+
+/// Inverse of the above: `RawIndexReaderCore<Suspended, E>` resumes to
+/// `IndexReaderCore<Active<'a>, E>` at any index lifetime `'a`.
+impl<E: 'static> ResumableReader for RawIndexReaderCore<Suspended, E>
+where
+    Self: IndexReader<'static>,
+    for<'a> RawIndexReaderCore<Active<'a>, E>: IndexReader<'a>,
+{
+    type Resumed<'a> = RawIndexReaderCore<Active<'a>, E>;
+}
 
 // Automatically implemented if the IndexReaderCore uses a NumericDecoder.
 impl<'index, E: DecodedBy<Decoder = D> + 'index, D: Decoder + NumericDecoder> NumericReader<'index>

--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -85,7 +85,6 @@ impl<'a, E> SuspendableReader for RawIndexReaderCore<Active<'a>, E> {
 /// `IndexReaderCore<Active<'a>, E>` at any index lifetime `'a`.
 impl<E: 'static> ResumableReader for RawIndexReaderCore<Suspended, E>
 where
-    Self: IndexReader<'static>,
     for<'a> RawIndexReaderCore<Active<'a>, E>: IndexReader<'a>,
 {
     type Resumed<'a> = RawIndexReaderCore<Active<'a>, E>;

--- a/src/redisearch_rs/inverted_index/src/reader/field_mask.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/field_mask.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use super::{IndexReader, IndexReaderCore, TermReader};
+use super::{IndexReader, IndexReaderCore, ResumableReader, SuspendableReader, TermReader};
 use crate::{
     DecodedBy, Decoder, HasInnerIndex, InvertedIndex, TermDecoder, opaque::OpaqueEncoding,
 };
@@ -36,6 +36,21 @@ impl<'index, IR: IndexReader<'index>> FilterMaskReader<IR> {
     pub const fn new(mask: FieldMask, inner: IR) -> Self {
         Self { mask, inner }
     }
+}
+
+/// `FilterMaskReader<IR>` suspends to `FilterMaskReader<IR::Suspended>`.
+impl<IR: SuspendableReader> SuspendableReader for FilterMaskReader<IR> {
+    type Suspended = FilterMaskReader<IR::Suspended>;
+}
+
+/// Inverse of the above: `FilterMaskReader<RS>` resumes to
+/// `FilterMaskReader<RS::Resumed<'a>>` for any `RS: ResumableReader`.
+impl<RS: ResumableReader> ResumableReader for FilterMaskReader<RS>
+where
+    for<'a> Self: 'static,
+    for<'a> FilterMaskReader<RS::Resumed<'a>>: IndexReader<'a>,
+{
+    type Resumed<'a> = FilterMaskReader<RS::Resumed<'a>>;
 }
 
 impl<'index, IR: IndexReader<'index>> IndexReader<'index> for FilterMaskReader<IR> {

--- a/src/redisearch_rs/inverted_index/src/reader/geo.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/geo.rs
@@ -7,7 +7,9 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use super::{IndexReader, IndexReaderCore, NumericFilter, NumericReader, SuspendableReader};
+use super::{
+    IndexReader, IndexReaderCore, NumericFilter, NumericReader, ResumableReader, SuspendableReader,
+};
 use crate::{DecodedBy, Decoder, InvertedIndex};
 use ffi::{GeoFilter, IndexFlags};
 use index_result::RSIndexResult;
@@ -84,6 +86,18 @@ impl<'index, IR: NumericReader<'index>> FilterGeoReader<IR> {
 /// only the inner reader switches modes.
 impl<IR: SuspendableReader> SuspendableReader for FilterGeoReader<IR> {
     type Suspended = FilterGeoReader<IR::Suspended>;
+}
+
+/// Inverse of the above: `FilterGeoReader<RS>` resumes to
+/// `FilterGeoReader<RS::Resumed<'a>>` for any `RS: ResumableReader`. The
+/// `IndexReader<'a>` bound requires `RS::Resumed<'a>: NumericReader<'a>`, which
+/// the resumed core reader provides.
+impl<RS: ResumableReader> ResumableReader for FilterGeoReader<RS>
+where
+    for<'a> Self: 'static,
+    for<'a> FilterGeoReader<RS::Resumed<'a>>: IndexReader<'a>,
+{
+    type Resumed<'a> = FilterGeoReader<RS::Resumed<'a>>;
 }
 
 impl<'index, E> FilterGeoReader<IndexReaderCore<'index, E>> {

--- a/src/redisearch_rs/inverted_index/src/reader/geo.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/geo.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use super::{IndexReader, IndexReaderCore, NumericFilter, NumericReader};
+use super::{IndexReader, IndexReaderCore, NumericFilter, NumericReader, SuspendableReader};
 use crate::{DecodedBy, Decoder, InvertedIndex};
 use ffi::{GeoFilter, IndexFlags};
 use index_result::RSIndexResult;
@@ -78,6 +78,12 @@ impl<'index, IR: NumericReader<'index>> FilterGeoReader<IR> {
             inner,
         }
     }
+}
+
+/// `FilterGeoReader<IR>` suspends to `FilterGeoReader<IR::Suspended>` —
+/// only the inner reader switches modes.
+impl<IR: SuspendableReader> SuspendableReader for FilterGeoReader<IR> {
+    type Suspended = FilterGeoReader<IR::Suspended>;
 }
 
 impl<'index, E> FilterGeoReader<IndexReaderCore<'index, E>> {

--- a/src/redisearch_rs/inverted_index/src/reader/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/mod.rs
@@ -60,6 +60,47 @@ pub trait IndexReader<'index> {
     fn refresh_buffer_pointers(&mut self);
 }
 
+/// Type-level mapping from an Active reader to its Suspended counterpart.
+///
+/// Each reader type that contains `Active<'a>` somewhere in its type
+/// parameters declares its matching `Suspended` shape via this trait. The
+/// suspended/resume work in `rqe_iterators` uses it to express the
+/// `Suspended` associated type of an iterator generically, e.g.
+/// `InvIndIterator<Active<'a>, R, E>` has
+/// `Suspended = InvIndIterator<Suspended, R::Suspended, E>` for any
+/// `R: SuspendableReader`.
+///
+/// This is purely a type-level helper — there is no runtime method. The
+/// trait is intentionally not bound by `IndexReader<'_>` so it can also be
+/// implemented for the `Suspended` instantiations themselves if needed by
+/// future work; for now only the `Active<'_>`-side impls are useful.
+pub trait SuspendableReader {
+    /// The matching reader type carrying [`ref_mode::Suspended`] instead of
+    /// [`ref_mode::Active`].
+    type Suspended;
+}
+
+/// Inverse of [`SuspendableReader`]: type-level mapping from a Suspended
+/// reader to its Active counterpart at a given index lifetime.
+///
+/// Together with [`SuspendableReader`], implementers of this trait form a
+/// bijection between Active and Suspended reader types — used by the
+/// `RQESuspendedIterator` impl on the suspended side of inverted-index
+/// iterators (in `rqe_iterators`) to express the [`Resumed`](Self::Resumed)
+/// associated type generically.
+///
+/// The `'static` bound reflects that a suspended reader carries no live
+/// references into the index. The trait is therefore implementable on
+/// reader types whose layout does not embed an `&'index …` reference;
+/// readers that borrow query-side resources (e.g.
+/// [`FilterNumericReader`] / [`FilterGeoReader`]'s borrowed filter) are
+/// covered separately under the wrapping iterator's own design.
+pub trait ResumableReader: 'static {
+    /// The matching active reader type, parameterised by the index
+    /// lifetime under which the suspended reader is being resumed.
+    type Resumed<'a>: IndexReader<'a> + SuspendableReader<Suspended = Self> + 'a;
+}
+
 /// Marker trait for readers producing numeric values.
 pub trait NumericReader<'index>: IndexReader<'index> {}
 

--- a/src/redisearch_rs/inverted_index/src/reader/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/mod.rs
@@ -62,18 +62,17 @@ pub trait IndexReader<'index> {
 
 /// Type-level mapping from an Active reader to its Suspended counterpart.
 ///
-/// Each reader type that contains `Active<'a>` somewhere in its type
+/// Each reader type that contains [`ref_mode::Active`] somewhere in its type
 /// parameters declares its matching `Suspended` shape via this trait. The
-/// suspended/resume work in `rqe_iterators` uses it to express the
-/// `Suspended` associated type of an iterator generically, e.g.
+/// suspend/resume work in `rqe_iterators` uses it to express the `Suspended`
+/// associated type of an iterator generically, e.g.
 /// `InvIndIterator<Active<'a>, R, E>` has
 /// `Suspended = InvIndIterator<Suspended, R::Suspended, E>` for any
 /// `R: SuspendableReader`.
 ///
-/// This is purely a type-level helper — there is no runtime method. The
-/// trait is intentionally not bound by `IndexReader<'_>` so it can also be
-/// implemented for the `Suspended` instantiations themselves if needed by
-/// future work; for now only the `Active<'_>`-side impls are useful.
+/// The actual transmute between the two layouts happens at the iterator
+/// level via the `Suspendable` trait (in the `rqe_iterators` crate) — this
+/// trait is purely a type-level helper with no runtime method.
 pub trait SuspendableReader {
     /// The matching reader type carrying [`ref_mode::Suspended`] instead of
     /// [`ref_mode::Active`].

--- a/src/redisearch_rs/inverted_index/src/reader/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/mod.rs
@@ -89,11 +89,7 @@ pub trait SuspendableReader {
 /// associated type generically.
 ///
 /// The `'static` bound reflects that a suspended reader carries no live
-/// references into the index. The trait is therefore implementable on
-/// reader types whose layout does not embed an `&'index …` reference;
-/// readers that borrow query-side resources (e.g.
-/// [`FilterNumericReader`] / [`FilterGeoReader`]'s borrowed filter) are
-/// covered separately under the wrapping iterator's own design.
+/// references into the index.
 pub trait ResumableReader: 'static {
     /// The matching active reader type, parameterised by the index
     /// lifetime under which the suspended reader is being resumed.

--- a/src/redisearch_rs/inverted_index/src/reader/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/numeric.rs
@@ -9,7 +9,7 @@
 
 use std::ffi::c_void;
 
-use super::{IndexReader, IndexReaderCore, NumericReader};
+use super::{IndexReader, IndexReaderCore, NumericReader, SuspendableReader};
 use crate::{DecodedBy, Decoder, InvertedIndex};
 use ffi::{FieldSpec, IndexFlags};
 use index_result::RSIndexResult;
@@ -103,6 +103,12 @@ impl<'index, IR: NumericReader<'index>> FilterNumericReader<IR> {
     pub const fn new(filter: NumericFilter, inner: IR) -> Self {
         Self { filter, inner }
     }
+}
+
+/// `FilterNumericReader<IR>` suspends to `FilterNumericReader<IR::Suspended>`
+/// — only the inner reader switches modes.
+impl<IR: SuspendableReader> SuspendableReader for FilterNumericReader<IR> {
+    type Suspended = FilterNumericReader<IR::Suspended>;
 }
 
 impl<'index, E> FilterNumericReader<IndexReaderCore<'index, E>> {

--- a/src/redisearch_rs/inverted_index/src/reader/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/numeric.rs
@@ -9,7 +9,7 @@
 
 use std::ffi::c_void;
 
-use super::{IndexReader, IndexReaderCore, NumericReader, SuspendableReader};
+use super::{IndexReader, IndexReaderCore, NumericReader, ResumableReader, SuspendableReader};
 use crate::{DecodedBy, Decoder, InvertedIndex};
 use ffi::{FieldSpec, IndexFlags};
 use index_result::RSIndexResult;
@@ -109,6 +109,18 @@ impl<'index, IR: NumericReader<'index>> FilterNumericReader<IR> {
 /// — only the inner reader switches modes.
 impl<IR: SuspendableReader> SuspendableReader for FilterNumericReader<IR> {
     type Suspended = FilterNumericReader<IR::Suspended>;
+}
+
+/// Inverse of the above: `FilterNumericReader<RS>` resumes to
+/// `FilterNumericReader<RS::Resumed<'a>>` for any `RS: ResumableReader`. The
+/// `IndexReader<'a>` bound requires `RS::Resumed<'a>: NumericReader<'a>`, which
+/// the resumed core reader provides.
+impl<RS: ResumableReader> ResumableReader for FilterNumericReader<RS>
+where
+    for<'a> Self: 'static,
+    for<'a> FilterNumericReader<RS::Resumed<'a>>: IndexReader<'a>,
+{
+    type Resumed<'a> = FilterNumericReader<RS::Resumed<'a>>;
 }
 
 impl<'index, E> FilterNumericReader<IndexReaderCore<'index, E>> {

--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -1,0 +1,390 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! `Box<Self>`-based suspend/resume trait scaffolding.
+//!
+//! This module introduces the suspend/resume trait hierarchy that will
+//! supersede the legacy
+//! [`RQEIterator::revalidate`] design:
+//!
+//! | Concept              | Concrete (type-state preserved)   | Dyn-safe sibling                |
+//! |----------------------|-----------------------------------|---------------------------------|
+//! | Active iterator      | [`RQEIteratorBoxed`]              | [`RQEDynIterator`]              |
+//! | Suspended iterator   | [`RQESuspendedIterator`]          | [`RQEDynSuspendedIterator`]     |
+//! | Erasure wrapper type | [`BoxedRQEIterator`]              | [`BoxedRQESuspendedIterator`]   |
+//!
+//! Implementors only need to provide the *concrete* traits
+//! ([`RQEIteratorBoxed`] / [`RQESuspendedIterator`]); blanket bridge impls
+//! produce the corresponding [`RQEDynIterator`] / [`RQEDynSuspendedIterator`]
+//! implementations automatically.
+//!
+//! The receiver shape (`self: Box<Self>`) is what unlocks object safety
+//! while still letting the suspend/resume body reinterpret the heap
+//! allocation byte-identically — see [`RQEIteratorBoxed::suspend`] for the
+//! intended idiom.
+//!
+//! # R1 + R2 transitional shape
+//!
+//! During R1 and R2 the new active-iterator trait is a **subtrait** of the
+//! legacy [`RQEIterator`]:
+//!
+//! ```text
+//! trait RQEIteratorBoxed<'a>: RQEIterator<'a> + 'a {
+//!     type Suspended: RQESuspendedIterator + 'static;
+//!     fn suspend(self: Box<Self>) -> Box<Self::Suspended>;
+//! }
+//! ```
+//!
+//! This means every iterator only needs to *add* `type Suspended` and
+//! `fn suspend` to migrate — the read/skip/rewind/etc. surface comes from
+//! the supertrait, and there is no method-name ambiguity at internal call
+//! sites that reach for `self.foo()`. The same goes for [`RQEDynIterator`]
+//! against the legacy trait on the dyn-erased side.
+//!
+//! In **R3** the legacy [`RQEIterator`] trait is
+//! deleted entirely; its method signatures (sans `revalidate`) are folded
+//! directly into [`RQEIteratorBoxed`] / [`RQEDynIterator`], and
+//! [`RQEIteratorBoxed`] is renamed back to `RQEIterator`. That matches the
+//! end-state design described in the plan.
+
+use ffi::{ValidateStatus, t_docId};
+use index_result::RSIndexResult;
+use index_spec::IndexSpecReadGuard;
+
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, c2rust,
+};
+
+/// Concrete-typed active iterator trait — the new shape of
+/// [`RQEIterator`].
+///
+/// Compared with the legacy trait it adds:
+///
+/// 1. [`suspend`](Self::suspend) consumes `self: Box<Self>` and returns
+///    `Box<Self::Suspended>`. The intended implementation is a pure pointer
+///    cast (`Box::from_raw(Box::into_raw(self) as *mut _)`) on `#[repr(C)]`,
+///    layout-compatible `Active`/`Suspended` counterparts. This preserves
+///    the box's heap address — composite aggregate
+///    [`RawIndexResult`](index_result::RawIndexResult) pointers into
+///    children's interiors stay valid across the suspend/resume cycle.
+///
+/// The [`Box<Self>`] receiver also makes this method object-safe, which is
+/// what lets the [`RQEDynIterator`] sibling exist as a free blanket impl.
+///
+/// During R1–R2 this trait is a **subtrait** of
+/// [`RQEIterator`] so that the read/skip/rewind surface
+/// is inherited without duplication. R3 folds those method signatures into
+/// this trait directly and renames it back to `RQEIterator`.
+pub trait RQEIteratorBoxed<'a>: RQEIterator<'a> + 'a {
+    /// The suspended counterpart of this iterator. Carries no live
+    /// references into the index and can therefore be held across a lock
+    /// release/reacquire cycle.
+    type Suspended: RQESuspendedIterator + 'static;
+
+    /// Transition to the suspended state.
+    ///
+    /// Implementations should perform a pure pointer cast of the box:
+    /// the active and suspended types are `#[repr(C)]` layout-compatible
+    /// over [`SharedPtr`](ref_mode::SharedPtr) (a `#[repr(transparent)]`
+    /// `NonNull`) fields, so the same heap allocation can be relabelled as
+    /// the suspended type without reallocation. Preserving the heap address
+    /// is what keeps composite aggregate-result pointers valid across the
+    /// cycle.
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended>;
+}
+
+/// Concrete-typed suspended iterator trait — counterpart of
+/// [`RQEIteratorBoxed`].
+///
+/// Implementors are typically the `Raw…<Suspended, …>` instantiations of
+/// the same `#[repr(C)]` struct used in active mode. The `'static` bound
+/// reflects the absence of live index references: a suspended iterator
+/// can be held across a lock release.
+pub trait RQESuspendedIterator: 'static {
+    /// The active counterpart this iterator resumes into, parameterised by
+    /// the lifetime of the held read guard.
+    type Resumed<'a>: RQEIteratorBoxed<'a>;
+
+    /// Resume from the suspended state, re-acquiring references into the
+    /// index and re-validating the iterator's state against any changes
+    /// that happened while the iterator was suspended.
+    ///
+    /// Returns the active iterator alongside a [`ValidateStatus`]:
+    ///
+    /// - [`VALIDATE_OK`](ffi::ValidateStatus_VALIDATE_OK) — the iterator is
+    ///   at the same position it was before suspend.
+    /// - [`VALIDATE_MOVED`](ffi::ValidateStatus_VALIDATE_MOVED) — the
+    ///   iterator's position moved forward (the previous `last_doc_id` was
+    ///   deleted or otherwise no longer present); callers should query
+    ///   [`current`](RQEIterator::current).
+    /// - [`VALIDATE_ABORTED`](ffi::ValidateStatus_VALIDATE_ABORTED) — the
+    ///   iterator's underlying state is unrecoverable; it should be
+    ///   dropped.
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &'a IndexSpecReadGuard<'a>,
+    ) -> (Box<Self::Resumed<'a>>, ValidateStatus);
+
+    /// Read the cached `last_doc_id` from the suspended state without
+    /// resuming. Composite iterators use this during resume to compare
+    /// their previous position against the child's pre-resume position.
+    fn last_doc_id(&self) -> t_docId;
+
+    /// Read the cached `num_estimated` from the suspended state without
+    /// resuming. Used by FFI introspection (`FT.PROFILE` printing) which
+    /// is called after the iterator has been suspended at the unlock site.
+    ///
+    /// The value is an estimate, so returning a snapshot from construction
+    /// is acceptable — the underlying invariant is that the FFI consumer
+    /// uses it for display only. Default returns 0 for iterators that do
+    /// not maintain a cached estimate.
+    fn num_estimated(&self) -> usize {
+        0
+    }
+}
+
+/// Dyn-safe sibling of [`RQEIteratorBoxed`].
+///
+/// During R1–R2 this trait is a **subtrait** of
+/// [`RQEIterator`] — the read/skip/rewind surface is
+/// reached via the supertrait, and only [`suspend`](Self::suspend) is new
+/// on top. R3 folds the legacy iter methods directly into this trait.
+///
+/// Implementors should not write this trait by hand; the blanket
+/// `impl<T: RQEIteratorBoxed<'a> + 'a> RQEDynIterator<'a> for T` below
+/// produces it for every concrete iterator.
+pub trait RQEDynIterator<'a>: RQEIterator<'a> + 'a {
+    /// Type-erased counterpart of [`RQEIteratorBoxed::suspend`].
+    fn suspend(self: Box<Self>) -> BoxedRQESuspendedIterator;
+}
+
+/// Dyn-safe sibling of [`RQESuspendedIterator`].
+///
+/// As with [`RQEDynIterator`], implementors don't write this directly — the
+/// blanket bridge below produces it from any
+/// `T: RQESuspendedIterator`.
+pub trait RQEDynSuspendedIterator: 'static {
+    /// Type-erased counterpart of [`RQESuspendedIterator::resume`].
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &'a IndexSpecReadGuard<'a>,
+    ) -> (BoxedRQEIterator<'a>, ValidateStatus);
+
+    fn last_doc_id(&self) -> t_docId;
+
+    fn num_estimated(&self) -> usize;
+}
+
+/// Type-erased, active iterator.
+///
+/// Newtype around `Box<dyn RQEDynIterator<'a> + 'a>`. The wrapper itself
+/// implements [`RQEIterator`] and [`RQEIteratorBoxed`] so composites can
+/// take it as their `I` parameter without knowing it's holding a trait
+/// object.
+#[repr(transparent)]
+pub struct BoxedRQEIterator<'a>(pub Box<dyn RQEDynIterator<'a> + 'a>);
+
+/// Type-erased, suspended iterator.
+///
+/// Newtype around `Box<dyn RQEDynSuspendedIterator>`. Mirrors
+/// [`BoxedRQEIterator`] in the suspended state.
+#[repr(transparent)]
+pub struct BoxedRQESuspendedIterator(pub Box<dyn RQEDynSuspendedIterator>);
+
+impl<'a> BoxedRQEIterator<'a> {
+    /// Wrap a concrete iterator into the type-erased wrapper.
+    pub fn new<I: RQEIteratorBoxed<'a> + 'a>(iter: Box<I>) -> Self {
+        Self(iter as Box<dyn RQEDynIterator<'a> + 'a>)
+    }
+}
+
+impl BoxedRQESuspendedIterator {
+    /// Wrap a concrete suspended iterator into the type-erased wrapper.
+    pub fn new<S: RQESuspendedIterator>(iter: Box<S>) -> Self {
+        Self(iter as Box<dyn RQEDynSuspendedIterator>)
+    }
+}
+
+/// Suspend a single child slot in place: read the value out, call its
+/// [`RQEIteratorBoxed::suspend`] through the trait, and write the suspended
+/// counterpart back into the same slot.
+///
+/// This is the composite-side primitive that lets `Vec<I>` storage hold
+/// children whose `I::Suspended` byte representation has different invariants
+/// from `I`'s — most importantly, dyn-erased children like [`BoxedRQEIterator`]
+/// whose active and suspended forms carry different vtables. The trait
+/// `suspend` call dispatches via the vtable for those, correctly transitioning
+/// the inner concrete iterator; for concrete-typed `I` (where `I` and
+/// `I::Suspended` are byte-layout-compatible by `#[repr(C)]`), the trait call
+/// is the same whole-box cast that the composite would have done at the outer
+/// level — just per-child instead of per-composite.
+///
+/// # Safety
+///
+/// * `slot` must point to a valid, exclusively-owned `I` value.
+/// * After this call, the slot's bytes are a valid `I::Suspended` value. The
+///   caller is responsible for ensuring the slot is *interpreted* as
+///   `I::Suspended` from this point on — typically by performing a whole-box
+///   cast on the containing composite (relabelling the Vec slot's static
+///   type) and not reading the slot as `I` again.
+/// * `I` and `I::Suspended` must have the same size and alignment — guaranteed
+///   for all `RQEIteratorBoxed` impls in this crate by their `#[repr(C)]`
+///   layouts over `SharedPtr`/fat-pointer fields.
+pub unsafe fn suspend_child_slot_in_place<'a, I>(slot: *mut I)
+where
+    I: RQEIteratorBoxed<'a> + 'a,
+{
+    // SAFETY: caller guarantees `slot` is exclusively owned and points to a
+    // valid `I` value. `ptr::read` moves the value out; the slot bytes are
+    // typed-but-moved-from until the matching `ptr::write` below.
+    let active = unsafe { std::ptr::read(slot) };
+    // Dispatches via the vtable for dyn-erased `I` (e.g. `BoxedRQEIterator`);
+    // a whole-box cast at the leaf level for concrete `I`. Either way the
+    // inner concrete iterator's heap allocation is preserved — only the
+    // outer wrapper bytes may differ (and the wrapper's address doesn't
+    // matter, see [`crate::interop::revalidate`] for the rationale).
+    let suspended = *<I as RQEIteratorBoxed<'a>>::suspend(Box::new(active));
+    // SAFETY: `I` and `I::Suspended` share size and alignment (see contract
+    // above). The slot is uninitialised after the earlier `ptr::read`;
+    // writing a valid `I::Suspended` reinitialises it.
+    unsafe { std::ptr::write(slot as *mut I::Suspended, suspended) };
+}
+
+// --- Blanket bridges: concrete → dyn-safe -----------------------------------
+
+/// Bridge concrete active iterators into the dyn-safe sibling.
+///
+/// Only `suspend` is bridged here — the read/skip surface is inherited from
+/// the legacy [`RQEIterator`] supertrait, which the
+/// concrete iterator already implements.
+impl<'a, T: RQEIteratorBoxed<'a> + 'a> RQEDynIterator<'a> for T {
+    fn suspend(self: Box<Self>) -> BoxedRQESuspendedIterator {
+        let suspended = <T as RQEIteratorBoxed<'a>>::suspend(self);
+        BoxedRQESuspendedIterator(suspended as Box<dyn RQEDynSuspendedIterator>)
+    }
+}
+
+/// Bridge concrete suspended iterators into the dyn-safe sibling.
+impl<S: RQESuspendedIterator> RQEDynSuspendedIterator for S {
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &'a IndexSpecReadGuard<'a>,
+    ) -> (BoxedRQEIterator<'a>, ValidateStatus) {
+        let (active, status) = <S as RQESuspendedIterator>::resume(self, guard);
+        (
+            BoxedRQEIterator(active as Box<dyn RQEDynIterator<'a> + 'a>),
+            status,
+        )
+    }
+
+    fn last_doc_id(&self) -> t_docId {
+        <S as RQESuspendedIterator>::last_doc_id(self)
+    }
+
+    fn num_estimated(&self) -> usize {
+        <S as RQESuspendedIterator>::num_estimated(self)
+    }
+}
+
+// --- Forwarding impls on the wrappers themselves ----------------------------
+
+/// Forwarding [`RQEIterator`] impl so [`BoxedRQEIterator`] can serve as the
+/// `I` type parameter of composite iterators (which bound on
+/// [`RQEIterator`] via the [`RQEIteratorBoxed`] supertrait).
+impl<'a> RQEIterator<'a> for BoxedRQEIterator<'a> {
+    fn current(&mut self) -> Option<&mut RSIndexResult<'a>> {
+        self.0.current()
+    }
+
+    fn read(&mut self) -> Result<Option<&mut RSIndexResult<'a>>, RQEIteratorError> {
+        self.0.read()
+    }
+
+    fn skip_to(
+        &mut self,
+        doc_id: t_docId,
+    ) -> Result<Option<SkipToOutcome<'_, 'a>>, RQEIteratorError> {
+        self.0.skip_to(doc_id)
+    }
+
+    fn revalidate(
+        &mut self,
+        spec: &IndexSpecReadGuard,
+    ) -> Result<RQEValidateStatus<'_, 'a>, RQEIteratorError> {
+        self.0.revalidate(spec)
+    }
+
+    fn rewind(&mut self) {
+        self.0.rewind()
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.0.num_estimated()
+    }
+
+    fn last_doc_id(&self) -> t_docId {
+        self.0.last_doc_id()
+    }
+
+    fn at_eof(&self) -> bool {
+        self.0.at_eof()
+    }
+
+    #[inline(always)]
+    fn type_(&self) -> IteratorType {
+        self.0.type_()
+    }
+
+    fn as_c_iterator(&self) -> Option<&c2rust::CRQEIterator> {
+        self.0.as_c_iterator()
+    }
+
+    fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
+        self.0.intersection_sort_weight(prioritize_union_children)
+    }
+}
+
+/// Forwarding [`RQEIteratorBoxed`] impl so [`BoxedRQEIterator`] also
+/// participates in the new suspend/resume surface (its `Suspended`
+/// counterpart is [`BoxedRQESuspendedIterator`]).
+impl<'a> RQEIteratorBoxed<'a> for BoxedRQEIterator<'a> {
+    type Suspended = BoxedRQESuspendedIterator;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let BoxedRQEIterator(inner) = *self;
+        Box::new(<dyn RQEDynIterator<'a> as RQEDynIterator<'a>>::suspend(
+            inner,
+        ))
+    }
+}
+
+/// Forwarding [`RQESuspendedIterator`] impl on [`BoxedRQESuspendedIterator`]
+/// so the dyn-erased pair behaves like any other concrete iterator pair.
+impl RQESuspendedIterator for BoxedRQESuspendedIterator {
+    type Resumed<'a> = BoxedRQEIterator<'a>;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &'a IndexSpecReadGuard<'a>,
+    ) -> (Box<Self::Resumed<'a>>, ValidateStatus) {
+        let BoxedRQESuspendedIterator(inner) = *self;
+        let (active, status) = <dyn RQEDynSuspendedIterator as RQEDynSuspendedIterator>::resume(
+            inner, guard,
+        );
+        (Box::new(active), status)
+    }
+
+    fn last_doc_id(&self) -> t_docId {
+        self.0.last_doc_id()
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.0.num_estimated()
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -274,6 +274,7 @@ where
 /// the legacy [`RQEIterator`] supertrait, which the
 /// concrete iterator already implements.
 impl<'index, T: RQEIteratorBoxed<'index> + 'index> RQEDynIterator<'index> for T {
+    #[inline(always)]
     fn suspend(self: Box<Self>) -> TypeErasedRQESuspendedIterator {
         let suspended = <T as RQEIteratorBoxed<'index>>::suspend(self);
         TypeErasedRQESuspendedIterator(suspended as Box<dyn RQEDynSuspendedIterator>)
@@ -282,6 +283,7 @@ impl<'index, T: RQEIteratorBoxed<'index> + 'index> RQEDynIterator<'index> for T 
 
 /// Bridge concrete suspended iterators into the dyn-safe sibling.
 impl<S: RQESuspendedIterator> RQEDynSuspendedIterator for S {
+    #[inline(always)]
     fn resume<'index>(
         self: Box<Self>,
         guard: &IndexSpecReadGuard<'index>,
@@ -298,10 +300,12 @@ impl<S: RQESuspendedIterator> RQEDynSuspendedIterator for S {
         })
     }
 
+    #[inline(always)]
     fn last_doc_id(&self) -> t_docId {
         <S as RQESuspendedIterator>::last_doc_id(self)
     }
 
+    #[inline(always)]
     fn num_estimated(&self) -> usize {
         <S as RQESuspendedIterator>::num_estimated(self)
     }
@@ -313,14 +317,17 @@ impl<S: RQESuspendedIterator> RQEDynSuspendedIterator for S {
 /// `I` type parameter of composite iterators (which bound on
 /// [`RQEIterator`] via the [`RQEIteratorBoxed`] supertrait).
 impl<'index> RQEIterator<'index> for TypeErasedRQEIterator<'index> {
+    #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
         self.0.current()
     }
 
+    #[inline(always)]
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
         self.0.read()
     }
 
+    #[inline(always)]
     fn skip_to(
         &mut self,
         doc_id: t_docId,
@@ -328,6 +335,7 @@ impl<'index> RQEIterator<'index> for TypeErasedRQEIterator<'index> {
         self.0.skip_to(doc_id)
     }
 
+    #[inline(always)]
     fn revalidate(
         &mut self,
         spec: &IndexSpecReadGuard,
@@ -335,18 +343,22 @@ impl<'index> RQEIterator<'index> for TypeErasedRQEIterator<'index> {
         self.0.revalidate(spec)
     }
 
+    #[inline(always)]
     fn rewind(&mut self) {
         self.0.rewind()
     }
 
+    #[inline(always)]
     fn num_estimated(&self) -> usize {
         self.0.num_estimated()
     }
 
+    #[inline(always)]
     fn last_doc_id(&self) -> t_docId {
         self.0.last_doc_id()
     }
 
+    #[inline(always)]
     fn at_eof(&self) -> bool {
         self.0.at_eof()
     }
@@ -356,10 +368,12 @@ impl<'index> RQEIterator<'index> for TypeErasedRQEIterator<'index> {
         self.0.type_()
     }
 
+    #[inline(always)]
     fn as_c_iterator(&self) -> Option<&c2rust::CRQEIterator> {
         self.0.as_c_iterator()
     }
 
+    #[inline(always)]
     fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
         self.0.intersection_sort_weight(prioritize_union_children)
     }
@@ -371,6 +385,7 @@ impl<'index> RQEIterator<'index> for TypeErasedRQEIterator<'index> {
 impl<'index> RQEIteratorBoxed<'index> for TypeErasedRQEIterator<'index> {
     type Suspended = TypeErasedRQESuspendedIterator;
 
+    #[inline(always)]
     fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
         let TypeErasedRQEIterator(inner) = *self;
         Box::new(<dyn RQEDynIterator<'index> as RQEDynIterator<'index>>::suspend(inner))
@@ -382,6 +397,7 @@ impl<'index> RQEIteratorBoxed<'index> for TypeErasedRQEIterator<'index> {
 impl RQESuspendedIterator for TypeErasedRQESuspendedIterator {
     type Resumed<'index> = TypeErasedRQEIterator<'index>;
 
+    #[inline(always)]
     fn resume<'index>(
         self: Box<Self>,
         guard: &IndexSpecReadGuard<'index>,
@@ -399,10 +415,12 @@ impl RQESuspendedIterator for TypeErasedRQESuspendedIterator {
         })
     }
 
+    #[inline(always)]
     fn last_doc_id(&self) -> t_docId {
         self.0.last_doc_id()
     }
 
+    #[inline(always)]
     fn num_estimated(&self) -> usize {
         self.0.num_estimated()
     }

--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -99,7 +99,7 @@ pub trait RQESuspendedIterator: 'static {
     /// index and re-validating the iterator's state against any changes
     /// that happened while the iterator was suspended.
     ///
-    /// Returns the active iterator alongside a [`ValidateStatus`]:
+    /// On success returns the active iterator alongside a [`ValidateStatus`]:
     ///
     /// - [`VALIDATE_OK`](ffi::ValidateStatus_VALIDATE_OK) — the iterator is
     ///   at the same position it was before suspend.
@@ -110,10 +110,16 @@ pub trait RQESuspendedIterator: 'static {
     /// - [`VALIDATE_ABORTED`](ffi::ValidateStatus_VALIDATE_ABORTED) — the
     ///   iterator's underlying state is unrecoverable; it should be
     ///   dropped.
+    ///
+    /// Resume re-reads/seeks the index to restore position (mirroring the
+    /// legacy [`RQEIterator::revalidate`]), so it can fail with an
+    /// [`RQEIteratorError`] (e.g. [`IoError`](RQEIteratorError::IoError) or
+    /// [`TimedOut`](RQEIteratorError::TimedOut)). On `Err` the suspended
+    /// iterator is consumed and dropped.
     fn resume<'a>(
         self: Box<Self>,
         guard: &'a IndexSpecReadGuard<'a>,
-    ) -> (Box<Self::Resumed<'a>>, ValidateStatus);
+    ) -> Result<(Box<Self::Resumed<'a>>, ValidateStatus), RQEIteratorError>;
 
     /// Read the cached `last_doc_id` from the suspended state without
     /// resuming. Composite iterators use this during resume to compare
@@ -153,7 +159,7 @@ pub trait RQEDynSuspendedIterator: 'static {
     fn resume<'a>(
         self: Box<Self>,
         guard: &'a IndexSpecReadGuard<'a>,
-    ) -> (BoxedRQEIterator<'a>, ValidateStatus);
+    ) -> Result<(BoxedRQEIterator<'a>, ValidateStatus), RQEIteratorError>;
 
     fn last_doc_id(&self) -> t_docId;
 
@@ -215,14 +221,35 @@ impl BoxedRQESuspendedIterator {
 /// * `I` and `I::Suspended` must have the same size and alignment — guaranteed
 ///   for all `RQEIteratorBoxed` impls in this crate by their `#[repr(C)]`
 ///   layouts over `SharedPtr`/fat-pointer fields.
+///
+/// Between the `ptr::read` and the matching `ptr::write` the slot is logically
+/// uninitialised while the caller (and any composite that owns it) still
+/// considers it live. `RQEIteratorBoxed::suspend` is a safe trait method that
+/// may dispatch to arbitrary (including dyn) implementations and could panic;
+/// if it did, unwinding past the uninitialised slot would let the owner drop a
+/// moved-from value (double drop). To keep the window sound, a panic from
+/// `suspend` is converted into a process abort rather than an unwind.
 pub unsafe fn suspend_child_slot_in_place<'a, I>(slot: *mut I)
 where
     I: RQEIteratorBoxed<'a> + 'a,
 {
+    /// Aborts the process if dropped during unwinding through the
+    /// uninitialised-slot window. Disarmed with [`std::mem::forget`] once the
+    /// slot has been reinitialised.
+    struct AbortOnUnwind;
+    impl Drop for AbortOnUnwind {
+        fn drop(&mut self) {
+            std::process::abort();
+        }
+    }
+
     // SAFETY: caller guarantees `slot` is exclusively owned and points to a
     // valid `I` value. `ptr::read` moves the value out; the slot bytes are
     // typed-but-moved-from until the matching `ptr::write` below.
     let active = unsafe { std::ptr::read(slot) };
+    // Armed across the uninitialised-slot window: if `suspend` panics, drop
+    // aborts instead of unwinding through the moved-from slot.
+    let bomb = AbortOnUnwind;
     // Dispatches via the vtable for dyn-erased `I` (e.g. `BoxedRQEIterator`);
     // a whole-box cast at the leaf level for concrete `I`. Either way the
     // inner concrete iterator's heap allocation is preserved — only the
@@ -233,6 +260,8 @@ where
     // above). The slot is uninitialised after the earlier `ptr::read`;
     // writing a valid `I::Suspended` reinitialises it.
     unsafe { std::ptr::write(slot as *mut I::Suspended, suspended) };
+    // Slot reinitialised — disarm the abort guard.
+    std::mem::forget(bomb);
 }
 
 // --- Blanket bridges: concrete → dyn-safe -----------------------------------
@@ -254,12 +283,12 @@ impl<S: RQESuspendedIterator> RQEDynSuspendedIterator for S {
     fn resume<'a>(
         self: Box<Self>,
         guard: &'a IndexSpecReadGuard<'a>,
-    ) -> (BoxedRQEIterator<'a>, ValidateStatus) {
-        let (active, status) = <S as RQESuspendedIterator>::resume(self, guard);
-        (
+    ) -> Result<(BoxedRQEIterator<'a>, ValidateStatus), RQEIteratorError> {
+        let (active, status) = <S as RQESuspendedIterator>::resume(self, guard)?;
+        Ok((
             BoxedRQEIterator(active as Box<dyn RQEDynIterator<'a> + 'a>),
             status,
-        )
+        ))
     }
 
     fn last_doc_id(&self) -> t_docId {
@@ -351,11 +380,11 @@ impl RQESuspendedIterator for BoxedRQESuspendedIterator {
     fn resume<'a>(
         self: Box<Self>,
         guard: &'a IndexSpecReadGuard<'a>,
-    ) -> (Box<Self::Resumed<'a>>, ValidateStatus) {
+    ) -> Result<(Box<Self::Resumed<'a>>, ValidateStatus), RQEIteratorError> {
         let BoxedRQESuspendedIterator(inner) = *self;
         let (active, status) =
-            <dyn RQEDynSuspendedIterator as RQEDynSuspendedIterator>::resume(inner, guard);
-        (Box::new(active), status)
+            <dyn RQEDynSuspendedIterator as RQEDynSuspendedIterator>::resume(inner, guard)?;
+        Ok((Box::new(active), status))
     }
 
     fn last_doc_id(&self) -> t_docId {

--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -119,7 +119,7 @@ pub trait RQESuspendedIterator: 'static {
     /// `Err` the suspended iterator is consumed and dropped.
     fn resume<'index>(
         self: Box<Self>,
-        guard: &'index IndexSpecReadGuard<'index>,
+        guard: &IndexSpecReadGuard<'index>,
     ) -> Result<ResumeOutcome<Box<Self::Resumed<'index>>>, RQEIteratorError>;
 
     /// Read the cached `last_doc_id` from the suspended state without
@@ -159,7 +159,7 @@ pub trait RQEDynSuspendedIterator: 'static {
     /// Type-erased counterpart of [`RQESuspendedIterator::resume`].
     fn resume<'index>(
         self: Box<Self>,
-        guard: &'index IndexSpecReadGuard<'index>,
+        guard: &IndexSpecReadGuard<'index>,
     ) -> Result<ResumeOutcome<TypeErasedRQEIterator<'index>>, RQEIteratorError>;
 
     fn last_doc_id(&self) -> t_docId;
@@ -284,7 +284,7 @@ impl<'index, T: RQEIteratorBoxed<'index> + 'index> RQEDynIterator<'index> for T 
 impl<S: RQESuspendedIterator> RQEDynSuspendedIterator for S {
     fn resume<'index>(
         self: Box<Self>,
-        guard: &'index IndexSpecReadGuard<'index>,
+        guard: &IndexSpecReadGuard<'index>,
     ) -> Result<ResumeOutcome<TypeErasedRQEIterator<'index>>, RQEIteratorError> {
         // This bridge is the *only* place the resumed iterator is type-erased:
         // the concrete impl hands back its `Box<Self::Resumed>`, which we wrap
@@ -384,7 +384,7 @@ impl RQESuspendedIterator for TypeErasedRQESuspendedIterator {
 
     fn resume<'index>(
         self: Box<Self>,
-        guard: &'index IndexSpecReadGuard<'index>,
+        guard: &IndexSpecReadGuard<'index>,
     ) -> Result<ResumeOutcome<Box<TypeErasedRQEIterator<'index>>>, RQEIteratorError> {
         let TypeErasedRQESuspendedIterator(inner) = *self;
         // `Self::Resumed` is the already-erased `TypeErasedRQEIterator`, so the

--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -19,7 +19,7 @@
 //! | Suspended iterator   | [`RQESuspendedIterator`]          | [`RQEDynSuspendedIterator`]     |
 //! | Erasure wrapper type | [`BoxedRQEIterator`]              | [`BoxedRQESuspendedIterator`]   |
 //!
-//! Implementors only need to provide the *concrete* traits
+//! Implementers only need to provide the *concrete* traits
 //! ([`RQEIteratorBoxed`] / [`RQESuspendedIterator`]); blanket bridge impls
 //! produce the corresponding [`RQEDynIterator`] / [`RQEDynSuspendedIterator`]
 //! implementations automatically.
@@ -52,12 +52,13 @@
 //! directly into [`RQEIteratorBoxed`] / [`RQEDynIterator`], and
 //! [`RQEIteratorBoxed`] will be renamed back to `RQEIterator`.
 
-use ffi::{ValidateStatus, t_docId};
+use ffi::t_docId;
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, c2rust,
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+    c2rust,
 };
 
 /// Concrete-typed active iterator trait — the new shape of
@@ -86,7 +87,7 @@ pub trait RQEIteratorBoxed<'a>: RQEIterator<'a> + 'a {
 /// Concrete-typed suspended iterator trait — counterpart of
 /// [`RQEIteratorBoxed`].
 ///
-/// Implementors are typically the `Raw…<Suspended, …>` instantiations of
+/// Implementers are typically the `Raw…<Suspended, …>` instantiations of
 /// the same `#[repr(C)]` struct used in active mode. The `'static` bound
 /// reflects the absence of live index references: a suspended iterator
 /// can be held across a lock release.
@@ -99,27 +100,27 @@ pub trait RQESuspendedIterator: 'static {
     /// index and re-validating the iterator's state against any changes
     /// that happened while the iterator was suspended.
     ///
-    /// On success returns the active iterator alongside a [`ValidateStatus`]:
+    /// Returns a [`ResumeOutcome`], mirroring the legacy
+    /// [`RQEIterator::revalidate`]'s [`RQEValidateStatus`]:
     ///
-    /// - [`VALIDATE_OK`](ffi::ValidateStatus_VALIDATE_OK) — the iterator is
-    ///   at the same position it was before suspend.
-    /// - [`VALIDATE_MOVED`](ffi::ValidateStatus_VALIDATE_MOVED) — the
-    ///   iterator's position moved forward (the previous `last_doc_id` was
-    ///   deleted or otherwise no longer present); callers should query
-    ///   [`current`](RQEIterator::current).
-    /// - [`VALIDATE_ABORTED`](ffi::ValidateStatus_VALIDATE_ABORTED) — the
-    ///   iterator's underlying state is unrecoverable; it should be
-    ///   dropped.
+    /// - [`Ok`](ResumeOutcome::Ok) — resumed at the same position.
+    /// - [`Moved`](ResumeOutcome::Moved) — resumed but the position moved
+    ///   forward (the previous `last_doc_id` was deleted or otherwise no
+    ///   longer present); query [`current`](RQEIterator::current) on the
+    ///   returned iterator.
+    /// - [`Aborted`](ResumeOutcome::Aborted) — the iterator's underlying state
+    ///   is unrecoverable. No active iterator is produced; the suspended
+    ///   iterator is dropped.
     ///
-    /// Resume re-reads/seeks the index to restore position (mirroring the
-    /// legacy [`RQEIterator::revalidate`]), so it can fail with an
+    /// Resume re-reads/seeks the index to restore position (mirroring
+    /// [`RQEIterator::revalidate`]), so it can fail with an
     /// [`RQEIteratorError`] (e.g. [`IoError`](RQEIteratorError::IoError) or
-    /// [`TimedOut`](RQEIteratorError::TimedOut)). On `Err` the suspended
-    /// iterator is consumed and dropped.
+    /// [`TimedOut`](RQEIteratorError::TimedOut)) — distinct from `Aborted`. On
+    /// `Err` the suspended iterator is consumed and dropped.
     fn resume<'a>(
         self: Box<Self>,
         guard: &'a IndexSpecReadGuard<'a>,
-    ) -> Result<(Box<Self::Resumed<'a>>, ValidateStatus), RQEIteratorError>;
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>;
 
     /// Read the cached `last_doc_id` from the suspended state without
     /// resuming. Composite iterators use this during resume to compare
@@ -151,7 +152,7 @@ pub trait RQEDynIterator<'a>: RQEIterator<'a> + 'a {
 
 /// Dyn-safe sibling of [`RQESuspendedIterator`].
 ///
-/// As with [`RQEDynIterator`], implementors don't write this directly — the
+/// As with [`RQEDynIterator`], implementers don't write this directly — the
 /// blanket bridge below produces it from any
 /// `T: RQESuspendedIterator`.
 pub trait RQEDynSuspendedIterator: 'static {
@@ -159,7 +160,7 @@ pub trait RQEDynSuspendedIterator: 'static {
     fn resume<'a>(
         self: Box<Self>,
         guard: &'a IndexSpecReadGuard<'a>,
-    ) -> Result<(BoxedRQEIterator<'a>, ValidateStatus), RQEIteratorError>;
+    ) -> Result<ResumeOutcome<BoxedRQEIterator<'a>>, RQEIteratorError>;
 
     fn last_doc_id(&self) -> t_docId;
 
@@ -283,12 +284,16 @@ impl<S: RQESuspendedIterator> RQEDynSuspendedIterator for S {
     fn resume<'a>(
         self: Box<Self>,
         guard: &'a IndexSpecReadGuard<'a>,
-    ) -> Result<(BoxedRQEIterator<'a>, ValidateStatus), RQEIteratorError> {
-        let (active, status) = <S as RQESuspendedIterator>::resume(self, guard)?;
-        Ok((
-            BoxedRQEIterator(active as Box<dyn RQEDynIterator<'a> + 'a>),
-            status,
-        ))
+    ) -> Result<ResumeOutcome<BoxedRQEIterator<'a>>, RQEIteratorError> {
+        // This bridge is the *only* place the resumed iterator is type-erased:
+        // the concrete impl hands back its `Box<Self::Resumed>`, which we wrap
+        // into a `BoxedRQEIterator`. `Aborted` carries nothing, so it maps
+        // straight through.
+        Ok(match <S as RQESuspendedIterator>::resume(self, guard)? {
+            ResumeOutcome::Ok(it) => ResumeOutcome::Ok(BoxedRQEIterator::new(it)),
+            ResumeOutcome::Moved(it) => ResumeOutcome::Moved(BoxedRQEIterator::new(it)),
+            ResumeOutcome::Aborted => ResumeOutcome::Aborted,
+        })
     }
 
     fn last_doc_id(&self) -> t_docId {
@@ -380,11 +385,15 @@ impl RQESuspendedIterator for BoxedRQESuspendedIterator {
     fn resume<'a>(
         self: Box<Self>,
         guard: &'a IndexSpecReadGuard<'a>,
-    ) -> Result<(Box<Self::Resumed<'a>>, ValidateStatus), RQEIteratorError> {
+    ) -> Result<ResumeOutcome<Box<BoxedRQEIterator<'a>>>, RQEIteratorError> {
         let BoxedRQESuspendedIterator(inner) = *self;
-        let (active, status) =
-            <dyn RQEDynSuspendedIterator as RQEDynSuspendedIterator>::resume(inner, guard)?;
-        Ok((Box::new(active), status))
+        // The inner dyn resume already yields a `BoxedRQEIterator`; box it to
+        // satisfy the concrete `ResumeOutcome<Box<Self::Resumed>>` shape.
+        Ok(match inner.resume(guard)? {
+            ResumeOutcome::Ok(it) => ResumeOutcome::Ok(Box::new(it)),
+            ResumeOutcome::Moved(it) => ResumeOutcome::Moved(Box::new(it)),
+            ResumeOutcome::Aborted => ResumeOutcome::Aborted,
+        })
     }
 
     fn last_doc_id(&self) -> t_docId {

--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -29,10 +29,10 @@
 //! allocation byte-identically — see [`RQEIteratorBoxed::suspend`] for the
 //! intended idiom.
 //!
-//! # R1 + R2 transitional shape
+//! # Transitional shape
 //!
-//! During R1 and R2 the new active-iterator trait is a **subtrait** of the
-//! legacy [`RQEIterator`]:
+//! During the first phrase of the revalidation work,
+//! the new `RQEIteratorBoxed` trait is a **subtrait** of the legacy [`RQEIterator`]:
 //!
 //! ```text
 //! trait RQEIteratorBoxed<'a>: RQEIterator<'a> + 'a {
@@ -47,11 +47,10 @@
 //! sites that reach for `self.foo()`. The same goes for [`RQEDynIterator`]
 //! against the legacy trait on the dyn-erased side.
 //!
-//! In **R3** the legacy [`RQEIterator`] trait is
-//! deleted entirely; its method signatures (sans `revalidate`) are folded
+//! In the second phase of the revalidation work, the legacy [`RQEIterator`] trait will be
+//! deleted entirely; its method signatures (sans `revalidate`) will be folded
 //! directly into [`RQEIteratorBoxed`] / [`RQEDynIterator`], and
-//! [`RQEIteratorBoxed`] is renamed back to `RQEIterator`. That matches the
-//! end-state design described in the plan.
+//! [`RQEIteratorBoxed`] will be renamed back to `RQEIterator`.
 
 use ffi::{ValidateStatus, t_docId};
 use index_result::RSIndexResult;
@@ -68,19 +67,12 @@ use crate::{
 ///
 /// 1. [`suspend`](Self::suspend) consumes `self: Box<Self>` and returns
 ///    `Box<Self::Suspended>`. The intended implementation is a pure pointer
-///    cast (`Box::from_raw(Box::into_raw(self) as *mut _)`) on `#[repr(C)]`,
-///    layout-compatible `Active`/`Suspended` counterparts. This preserves
-///    the box's heap address — composite aggregate
-///    [`RawIndexResult`](index_result::RawIndexResult) pointers into
-///    children's interiors stay valid across the suspend/resume cycle.
+///    cast layout-compatible `Active`/`Suspended` counterparts. This preserves
+///    the box's heap address across the suspend/resume cycle, which matters
+///    for iterators that give out raw pointers to (parts of their) internal state.
 ///
 /// The [`Box<Self>`] receiver also makes this method object-safe, which is
 /// what lets the [`RQEDynIterator`] sibling exist as a free blanket impl.
-///
-/// During R1–R2 this trait is a **subtrait** of
-/// [`RQEIterator`] so that the read/skip/rewind surface
-/// is inherited without duplication. R3 folds those method signatures into
-/// this trait directly and renames it back to `RQEIterator`.
 pub trait RQEIteratorBoxed<'a>: RQEIterator<'a> + 'a {
     /// The suspended counterpart of this iterator. Carries no live
     /// references into the index and can therefore be held across a lock
@@ -88,14 +80,6 @@ pub trait RQEIteratorBoxed<'a>: RQEIterator<'a> + 'a {
     type Suspended: RQESuspendedIterator + 'static;
 
     /// Transition to the suspended state.
-    ///
-    /// Implementations should perform a pure pointer cast of the box:
-    /// the active and suspended types are `#[repr(C)]` layout-compatible
-    /// over [`SharedPtr`](ref_mode::SharedPtr) (a `#[repr(transparent)]`
-    /// `NonNull`) fields, so the same heap allocation can be relabelled as
-    /// the suspended type without reallocation. Preserving the heap address
-    /// is what keeps composite aggregate-result pointers valid across the
-    /// cycle.
     fn suspend(self: Box<Self>) -> Box<Self::Suspended>;
 }
 
@@ -151,12 +135,7 @@ pub trait RQESuspendedIterator: 'static {
 
 /// Dyn-safe sibling of [`RQEIteratorBoxed`].
 ///
-/// During R1–R2 this trait is a **subtrait** of
-/// [`RQEIterator`] — the read/skip/rewind surface is
-/// reached via the supertrait, and only [`suspend`](Self::suspend) is new
-/// on top. R3 folds the legacy iter methods directly into this trait.
-///
-/// Implementors should not write this trait by hand; the blanket
+/// You shouldn't implement this trait by hand; the blanket
 /// `impl<T: RQEIteratorBoxed<'a> + 'a> RQEDynIterator<'a> for T` below
 /// produces it for every concrete iterator.
 pub trait RQEDynIterator<'a>: RQEIterator<'a> + 'a {
@@ -374,9 +353,8 @@ impl RQESuspendedIterator for BoxedRQESuspendedIterator {
         guard: &'a IndexSpecReadGuard<'a>,
     ) -> (Box<Self::Resumed<'a>>, ValidateStatus) {
         let BoxedRQESuspendedIterator(inner) = *self;
-        let (active, status) = <dyn RQEDynSuspendedIterator as RQEDynSuspendedIterator>::resume(
-            inner, guard,
-        );
+        let (active, status) =
+            <dyn RQEDynSuspendedIterator as RQEDynSuspendedIterator>::resume(inner, guard);
         (Box::new(active), status)
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -13,11 +13,11 @@
 //! supersede the legacy
 //! [`RQEIterator::revalidate`] design:
 //!
-//! | Concept              | Concrete (type-state preserved)   | Dyn-safe sibling                |
-//! |----------------------|-----------------------------------|---------------------------------|
-//! | Active iterator      | [`RQEIteratorBoxed`]              | [`RQEDynIterator`]              |
-//! | Suspended iterator   | [`RQESuspendedIterator`]          | [`RQEDynSuspendedIterator`]     |
-//! | Erasure wrapper type | [`BoxedRQEIterator`]              | [`BoxedRQESuspendedIterator`]   |
+//! | Concept              | Concrete (type-state preserved)   | Dyn-safe sibling                    |
+//! |----------------------|-----------------------------------|-------------------------------------|
+//! | Active iterator      | [`RQEIteratorBoxed`]              | [`RQEDynIterator`]                  |
+//! | Suspended iterator   | [`RQESuspendedIterator`]          | [`RQEDynSuspendedIterator`]         |
+//! | Erasure wrapper type | [`TypeErasedRQEIterator`]         | [`TypeErasedRQESuspendedIterator`]  |
 //!
 //! Implementers only need to provide the *concrete* traits
 //! ([`RQEIteratorBoxed`] / [`RQESuspendedIterator`]); blanket bridge impls
@@ -31,11 +31,11 @@
 //!
 //! # Transitional shape
 //!
-//! During the first phrase of the revalidation work,
+//! During the first phase of the revalidation work,
 //! the new `RQEIteratorBoxed` trait is a **subtrait** of the legacy [`RQEIterator`]:
 //!
 //! ```text
-//! trait RQEIteratorBoxed<'a>: RQEIterator<'a> + 'a {
+//! trait RQEIteratorBoxed<'index>: RQEIterator<'index> + 'index {
 //!     type Suspended: RQESuspendedIterator + 'static;
 //!     fn suspend(self: Box<Self>) -> Box<Self::Suspended>;
 //! }
@@ -74,7 +74,7 @@ use crate::{
 ///
 /// The [`Box<Self>`] receiver also makes this method object-safe, which is
 /// what lets the [`RQEDynIterator`] sibling exist as a free blanket impl.
-pub trait RQEIteratorBoxed<'a>: RQEIterator<'a> + 'a {
+pub trait RQEIteratorBoxed<'index>: RQEIterator<'index> + 'index {
     /// The suspended counterpart of this iterator. Carries no live
     /// references into the index and can therefore be held across a lock
     /// release/reacquire cycle.
@@ -94,7 +94,7 @@ pub trait RQEIteratorBoxed<'a>: RQEIterator<'a> + 'a {
 pub trait RQESuspendedIterator: 'static {
     /// The active counterpart this iterator resumes into, parameterised by
     /// the lifetime of the held read guard.
-    type Resumed<'a>: RQEIteratorBoxed<'a>;
+    type Resumed<'index>: RQEIteratorBoxed<'index>;
 
     /// Resume from the suspended state, re-acquiring references into the
     /// index and re-validating the iterator's state against any changes
@@ -117,10 +117,10 @@ pub trait RQESuspendedIterator: 'static {
     /// [`RQEIteratorError`] (e.g. [`IoError`](RQEIteratorError::IoError) or
     /// [`TimedOut`](RQEIteratorError::TimedOut)) — distinct from `Aborted`. On
     /// `Err` the suspended iterator is consumed and dropped.
-    fn resume<'a>(
+    fn resume<'index>(
         self: Box<Self>,
-        guard: &'a IndexSpecReadGuard<'a>,
-    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>;
+        guard: &'index IndexSpecReadGuard<'index>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'index>>>, RQEIteratorError>;
 
     /// Read the cached `last_doc_id` from the suspended state without
     /// resuming. Composite iterators use this during resume to compare
@@ -143,11 +143,11 @@ pub trait RQESuspendedIterator: 'static {
 /// Dyn-safe sibling of [`RQEIteratorBoxed`].
 ///
 /// You shouldn't implement this trait by hand; the blanket
-/// `impl<T: RQEIteratorBoxed<'a> + 'a> RQEDynIterator<'a> for T` below
+/// `impl<T: RQEIteratorBoxed<'index> + 'index> RQEDynIterator<'index> for T` below
 /// produces it for every concrete iterator.
-pub trait RQEDynIterator<'a>: RQEIterator<'a> + 'a {
+pub trait RQEDynIterator<'index>: RQEIterator<'index> + 'index {
     /// Type-erased counterpart of [`RQEIteratorBoxed::suspend`].
-    fn suspend(self: Box<Self>) -> BoxedRQESuspendedIterator;
+    fn suspend(self: Box<Self>) -> TypeErasedRQESuspendedIterator;
 }
 
 /// Dyn-safe sibling of [`RQESuspendedIterator`].
@@ -157,10 +157,10 @@ pub trait RQEDynIterator<'a>: RQEIterator<'a> + 'a {
 /// `T: RQESuspendedIterator`.
 pub trait RQEDynSuspendedIterator: 'static {
     /// Type-erased counterpart of [`RQESuspendedIterator::resume`].
-    fn resume<'a>(
+    fn resume<'index>(
         self: Box<Self>,
-        guard: &'a IndexSpecReadGuard<'a>,
-    ) -> Result<ResumeOutcome<BoxedRQEIterator<'a>>, RQEIteratorError>;
+        guard: &'index IndexSpecReadGuard<'index>,
+    ) -> Result<ResumeOutcome<TypeErasedRQEIterator<'index>>, RQEIteratorError>;
 
     fn last_doc_id(&self) -> t_docId;
 
@@ -169,28 +169,28 @@ pub trait RQEDynSuspendedIterator: 'static {
 
 /// Type-erased, active iterator.
 ///
-/// Newtype around `Box<dyn RQEDynIterator<'a> + 'a>`. The wrapper itself
+/// Newtype around `Box<dyn RQEDynIterator<'index> + 'index>`. The wrapper itself
 /// implements [`RQEIterator`] and [`RQEIteratorBoxed`] so composites can
 /// take it as their `I` parameter without knowing it's holding a trait
 /// object.
 #[repr(transparent)]
-pub struct BoxedRQEIterator<'a>(pub Box<dyn RQEDynIterator<'a> + 'a>);
+pub struct TypeErasedRQEIterator<'index>(pub Box<dyn RQEDynIterator<'index> + 'index>);
 
 /// Type-erased, suspended iterator.
 ///
 /// Newtype around `Box<dyn RQEDynSuspendedIterator>`. Mirrors
-/// [`BoxedRQEIterator`] in the suspended state.
+/// [`TypeErasedRQEIterator`] in the suspended state.
 #[repr(transparent)]
-pub struct BoxedRQESuspendedIterator(pub Box<dyn RQEDynSuspendedIterator>);
+pub struct TypeErasedRQESuspendedIterator(pub Box<dyn RQEDynSuspendedIterator>);
 
-impl<'a> BoxedRQEIterator<'a> {
+impl<'index> TypeErasedRQEIterator<'index> {
     /// Wrap a concrete iterator into the type-erased wrapper.
-    pub fn new<I: RQEIteratorBoxed<'a> + 'a>(iter: Box<I>) -> Self {
-        Self(iter as Box<dyn RQEDynIterator<'a> + 'a>)
+    pub fn new<I: RQEIteratorBoxed<'index> + 'index>(iter: Box<I>) -> Self {
+        Self(iter as Box<dyn RQEDynIterator<'index> + 'index>)
     }
 }
 
-impl BoxedRQESuspendedIterator {
+impl TypeErasedRQESuspendedIterator {
     /// Wrap a concrete suspended iterator into the type-erased wrapper.
     pub fn new<S: RQESuspendedIterator>(iter: Box<S>) -> Self {
         Self(iter as Box<dyn RQEDynSuspendedIterator>)
@@ -203,7 +203,7 @@ impl BoxedRQESuspendedIterator {
 ///
 /// This is the composite-side primitive that lets `Vec<I>` storage hold
 /// children whose `I::Suspended` byte representation has different invariants
-/// from `I`'s — most importantly, dyn-erased children like [`BoxedRQEIterator`]
+/// from `I`'s — most importantly, dyn-erased children like [`TypeErasedRQEIterator`]
 /// whose active and suspended forms carry different vtables. The trait
 /// `suspend` call dispatches via the vtable for those, correctly transitioning
 /// the inner concrete iterator; for concrete-typed `I` (where `I` and
@@ -230,9 +230,9 @@ impl BoxedRQESuspendedIterator {
 /// if it did, unwinding past the uninitialised slot would let the owner drop a
 /// moved-from value (double drop). To keep the window sound, a panic from
 /// `suspend` is converted into a process abort rather than an unwind.
-pub unsafe fn suspend_child_slot_in_place<'a, I>(slot: *mut I)
+pub unsafe fn suspend_child_slot_in_place<'index, I>(slot: *mut I)
 where
-    I: RQEIteratorBoxed<'a> + 'a,
+    I: RQEIteratorBoxed<'index> + 'index,
 {
     /// Aborts the process if dropped during unwinding through the
     /// uninitialised-slot window. Disarmed with [`std::mem::forget`] once the
@@ -251,12 +251,13 @@ where
     // Armed across the uninitialised-slot window: if `suspend` panics, drop
     // aborts instead of unwinding through the moved-from slot.
     let bomb = AbortOnUnwind;
-    // Dispatches via the vtable for dyn-erased `I` (e.g. `BoxedRQEIterator`);
-    // a whole-box cast at the leaf level for concrete `I`. Either way the
-    // inner concrete iterator's heap allocation is preserved — only the
-    // outer wrapper bytes may differ (and the wrapper's address doesn't
+    // Dispatches via:
+    // - the vtable for dyn-erased `I` (e.g. `TypeErasedRQEIterator`);
+    // - a transmute at the leaf level for concrete `I`.
+    // Either way the *inner* concrete iterator's heap allocation is preserved.
+    // Only the outer wrapper bytes may differ (and the wrapper's address doesn't
     // matter, see [`crate::interop::revalidate`] for the rationale).
-    let suspended = *<I as RQEIteratorBoxed<'a>>::suspend(Box::new(active));
+    let suspended = *<I as RQEIteratorBoxed<'index>>::suspend(Box::new(active));
     // SAFETY: `I` and `I::Suspended` share size and alignment (see contract
     // above). The slot is uninitialised after the earlier `ptr::read`;
     // writing a valid `I::Suspended` reinitialises it.
@@ -272,26 +273,27 @@ where
 /// Only `suspend` is bridged here — the read/skip surface is inherited from
 /// the legacy [`RQEIterator`] supertrait, which the
 /// concrete iterator already implements.
-impl<'a, T: RQEIteratorBoxed<'a> + 'a> RQEDynIterator<'a> for T {
-    fn suspend(self: Box<Self>) -> BoxedRQESuspendedIterator {
-        let suspended = <T as RQEIteratorBoxed<'a>>::suspend(self);
-        BoxedRQESuspendedIterator(suspended as Box<dyn RQEDynSuspendedIterator>)
+impl<'index, T: RQEIteratorBoxed<'index> + 'index> RQEDynIterator<'index> for T {
+    fn suspend(self: Box<Self>) -> TypeErasedRQESuspendedIterator {
+        let suspended = <T as RQEIteratorBoxed<'index>>::suspend(self);
+        TypeErasedRQESuspendedIterator(suspended as Box<dyn RQEDynSuspendedIterator>)
     }
 }
 
 /// Bridge concrete suspended iterators into the dyn-safe sibling.
 impl<S: RQESuspendedIterator> RQEDynSuspendedIterator for S {
-    fn resume<'a>(
+    fn resume<'index>(
         self: Box<Self>,
-        guard: &'a IndexSpecReadGuard<'a>,
-    ) -> Result<ResumeOutcome<BoxedRQEIterator<'a>>, RQEIteratorError> {
+        guard: &'index IndexSpecReadGuard<'index>,
+    ) -> Result<ResumeOutcome<TypeErasedRQEIterator<'index>>, RQEIteratorError> {
         // This bridge is the *only* place the resumed iterator is type-erased:
         // the concrete impl hands back its `Box<Self::Resumed>`, which we wrap
-        // into a `BoxedRQEIterator`. `Aborted` carries nothing, so it maps
-        // straight through.
+        // into a `TypeErasedRQEIterator`. `Aborted` carries nothing, so it maps
+        // straight through. (The already-erased forwarding impl on
+        // `TypeErasedRQESuspendedIterator` deliberately double-boxes; see there.)
         Ok(match <S as RQESuspendedIterator>::resume(self, guard)? {
-            ResumeOutcome::Ok(it) => ResumeOutcome::Ok(BoxedRQEIterator::new(it)),
-            ResumeOutcome::Moved(it) => ResumeOutcome::Moved(BoxedRQEIterator::new(it)),
+            ResumeOutcome::Ok(it) => ResumeOutcome::Ok(TypeErasedRQEIterator::new(it)),
+            ResumeOutcome::Moved(it) => ResumeOutcome::Moved(TypeErasedRQEIterator::new(it)),
             ResumeOutcome::Aborted => ResumeOutcome::Aborted,
         })
     }
@@ -307,29 +309,29 @@ impl<S: RQESuspendedIterator> RQEDynSuspendedIterator for S {
 
 // --- Forwarding impls on the wrappers themselves ----------------------------
 
-/// Forwarding [`RQEIterator`] impl so [`BoxedRQEIterator`] can serve as the
+/// Forwarding [`RQEIterator`] impl so [`TypeErasedRQEIterator`] can serve as the
 /// `I` type parameter of composite iterators (which bound on
 /// [`RQEIterator`] via the [`RQEIteratorBoxed`] supertrait).
-impl<'a> RQEIterator<'a> for BoxedRQEIterator<'a> {
-    fn current(&mut self) -> Option<&mut RSIndexResult<'a>> {
+impl<'index> RQEIterator<'index> for TypeErasedRQEIterator<'index> {
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
         self.0.current()
     }
 
-    fn read(&mut self) -> Result<Option<&mut RSIndexResult<'a>>, RQEIteratorError> {
+    fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
         self.0.read()
     }
 
     fn skip_to(
         &mut self,
         doc_id: t_docId,
-    ) -> Result<Option<SkipToOutcome<'_, 'a>>, RQEIteratorError> {
+    ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         self.0.skip_to(doc_id)
     }
 
     fn revalidate(
         &mut self,
         spec: &IndexSpecReadGuard,
-    ) -> Result<RQEValidateStatus<'_, 'a>, RQEIteratorError> {
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         self.0.revalidate(spec)
     }
 
@@ -363,32 +365,33 @@ impl<'a> RQEIterator<'a> for BoxedRQEIterator<'a> {
     }
 }
 
-/// Forwarding [`RQEIteratorBoxed`] impl so [`BoxedRQEIterator`] also
+/// Forwarding [`RQEIteratorBoxed`] impl so [`TypeErasedRQEIterator`] also
 /// participates in the new suspend/resume surface (its `Suspended`
-/// counterpart is [`BoxedRQESuspendedIterator`]).
-impl<'a> RQEIteratorBoxed<'a> for BoxedRQEIterator<'a> {
-    type Suspended = BoxedRQESuspendedIterator;
+/// counterpart is [`TypeErasedRQESuspendedIterator`]).
+impl<'index> RQEIteratorBoxed<'index> for TypeErasedRQEIterator<'index> {
+    type Suspended = TypeErasedRQESuspendedIterator;
 
     fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
-        let BoxedRQEIterator(inner) = *self;
-        Box::new(<dyn RQEDynIterator<'a> as RQEDynIterator<'a>>::suspend(
-            inner,
-        ))
+        let TypeErasedRQEIterator(inner) = *self;
+        Box::new(<dyn RQEDynIterator<'index> as RQEDynIterator<'index>>::suspend(inner))
     }
 }
 
-/// Forwarding [`RQESuspendedIterator`] impl on [`BoxedRQESuspendedIterator`]
+/// Forwarding [`RQESuspendedIterator`] impl on [`TypeErasedRQESuspendedIterator`]
 /// so the dyn-erased pair behaves like any other concrete iterator pair.
-impl RQESuspendedIterator for BoxedRQESuspendedIterator {
-    type Resumed<'a> = BoxedRQEIterator<'a>;
+impl RQESuspendedIterator for TypeErasedRQESuspendedIterator {
+    type Resumed<'index> = TypeErasedRQEIterator<'index>;
 
-    fn resume<'a>(
+    fn resume<'index>(
         self: Box<Self>,
-        guard: &'a IndexSpecReadGuard<'a>,
-    ) -> Result<ResumeOutcome<Box<BoxedRQEIterator<'a>>>, RQEIteratorError> {
-        let BoxedRQESuspendedIterator(inner) = *self;
-        // The inner dyn resume already yields a `BoxedRQEIterator`; box it to
-        // satisfy the concrete `ResumeOutcome<Box<Self::Resumed>>` shape.
+        guard: &'index IndexSpecReadGuard<'index>,
+    ) -> Result<ResumeOutcome<Box<TypeErasedRQEIterator<'index>>>, RQEIteratorError> {
+        let TypeErasedRQESuspendedIterator(inner) = *self;
+        // `Self::Resumed` is the already-erased `TypeErasedRQEIterator`, so the
+        // concrete `ResumeOutcome<Box<Self::Resumed>>` shape forces a
+        // (deliberate) double box here. This is a transient allocation only on
+        // the resume path for an erased composite child; the hot path resumes
+        // the concrete inner via the blanket bridge (single box).
         Ok(match inner.resume(guard)? {
             ResumeOutcome::Ok(it) => ResumeOutcome::Ok(Box::new(it)),
             ResumeOutcome::Moved(it) => ResumeOutcome::Moved(Box::new(it)),

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -62,8 +62,8 @@ pub mod utils;
 pub mod wildcard;
 
 pub use boxed::{
-    BoxedRQEIterator, BoxedRQESuspendedIterator, RQEDynIterator, RQEDynSuspendedIterator,
-    RQEIteratorBoxed, RQESuspendedIterator,
+    RQEDynIterator, RQEDynSuspendedIterator, RQEIteratorBoxed, RQESuspendedIterator,
+    TypeErasedRQEIterator, TypeErasedRQESuspendedIterator,
 };
 pub use config::IteratorsConfig;
 pub use empty::Empty;

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -30,6 +30,7 @@ use index_result::{RSIndexResult, RawIndexResult};
 pub use query_error::QueryError;
 use query_term::RSQueryTerm;
 
+pub mod boxed;
 pub mod c2rust;
 pub mod config;
 pub mod deferred;
@@ -60,6 +61,10 @@ mod union_trimmed;
 pub mod utils;
 pub mod wildcard;
 
+pub use boxed::{
+    BoxedRQEIterator, BoxedRQESuspendedIterator, RQEDynIterator, RQEDynSuspendedIterator,
+    RQEIteratorBoxed, RQESuspendedIterator,
+};
 pub use config::IteratorsConfig;
 pub use empty::Empty;
 pub use expiration_checker::{ExpirationChecker, FieldExpirationChecker, NoOpChecker};

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -50,6 +50,7 @@ pub mod optional_optimized;
 pub mod optional_reducer;
 pub mod profile;
 pub mod profile_print;
+pub mod resume_outcome;
 pub mod union;
 mod union_flat;
 mod union_heap;
@@ -70,6 +71,7 @@ pub use inverted_index::{
     build_geo_numeric_filters, extract_geo_unit_factor, new_geo_range_iterator,
     open_numeric_or_geo_index,
 };
+pub use resume_outcome::ResumeOutcome;
 pub use rqe_iterator_type::IteratorType;
 pub use union::{
     Union, UnionFlat, UnionFullFlat, UnionFullHeap, UnionHeap, UnionQuickFlat, UnionQuickHeap,

--- a/src/redisearch_rs/rqe_iterators/src/resume_outcome.rs
+++ b/src/redisearch_rs/rqe_iterators/src/resume_outcome.rs
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! The outcome shape returned when resuming a suspended iterator.
+
+/// Outcome of resuming a suspended iterator.
+///
+/// Mirrors the status returned by the legacy `RQEIterator::revalidate`, but
+/// *owns* the resumed iterator in its recoverable variants: resuming produces a
+/// brand-new active value (suspended and active are distinct types), so — unlike
+/// `revalidate`, which keeps the iterator in place — the outcome carries the
+/// resumed iterator rather than borrowing `current` from `self`. Callers query
+/// `current` on the returned iterator for the [`Moved`](ResumeOutcome::Moved)
+/// case.
+///
+/// Generic over the carried iterator `I` so the same shape serves both the
+/// concrete resume path (which carries `Box<Resumed>`) and the dyn-safe resume
+/// path (which carries a type-erased iterator).
+pub enum ResumeOutcome<I> {
+    /// Resumed at the same position.
+    Ok(I),
+    /// Resumed, but the position moved forward (the previous `last_doc_id` was
+    /// deleted or otherwise no longer present); query `current` on the iterator.
+    Moved(I),
+    /// Unrecoverable: no active iterator is produced and the suspended iterator
+    /// was dropped.
+    Aborted,
+}


### PR DESCRIPTION
## Describe the changes in the pull request

Lay down the trait machinery for the iterator suspend/resume protocol.
Introduces `RQEIteratorBoxed` (a `Box<Self>`-based pair of
`type Suspended` + `fn suspend(self: Box<Self>) -> Box<Self::Suspended>`)
alongside a dyn-safe sibling (`RQEDynIterator`) that preserves
object-safety where it's still needed, plus `BoxedRQE*` newtype
wrappers for type-erased uniformity inside composites.

Purely additive: no existing impls are wired up here. Each per-iterator
impl, and the production-side wiring, land in subsequent PRs.

#### Main objects this PR modified
- New traits in `rqe_iterators::boxed`: `RQEIteratorBoxed`,
  `RQESuspendedIterator`, `RQEDynIterator`, `RQEDynSuspendedIterator`
- New `SuspendableReader` / `ResumableReader` helpers in
  `inverted_index`
- New `RawIndexResult::{into_active, into_suspended}` lifetime-relabel
  helpers

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

Stacked on #10263.