### PR TITLE
[Iterator Revalidation][MOD-16715] TopK: suspend/resume + drop Box<dyn> child

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3067,11 +3067,13 @@ name = "top_k"
 version = "0.0.1"
 dependencies = [
  "build_utils",
+ "ffi",
  "index_result",
  "index_spec",
  "inverted_index",
  "redis_mock",
  "redisearch_rs",
+ "ref_mode",
  "rqe_core",
  "rqe_iterator_type",
  "rqe_iterators",

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -197,10 +197,29 @@ pub trait RQEIterator<'index> {
     ///
     /// The caller must hold the spec read lock, represented by [`IndexSpecReadGuard`].
     /// The lock ensures the spec remains valid and unchanged during this call.
+    ///
+    /// # Migration to suspend/resume
+    ///
+    /// This method is being phased out in favour of the
+    /// [`RQEIteratorBoxed::suspend`] +
+    /// [`RQESuspendedIterator::resume`] cycle,
+    /// which is the canonical path used by the FFI wrapper (see
+    /// `rqe_iterators::interop::revalidate`). The default implementation panics
+    /// so that any production call site that still goes through `revalidate`
+    /// surfaces loudly — production code should not be calling this. Tests are
+    /// migrating to `suspend`/`resume` iterator-by-iterator; once no iterator
+    /// overrides this method, it can be removed from the trait entirely.
     fn revalidate(
         &mut self,
-        spec: &IndexSpecReadGuard,
-    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError>;
+        _spec: &IndexSpecReadGuard,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        unreachable!(
+            "RQEIterator::revalidate is being phased out; the suspend/resume path \
+             (RQEIteratorBoxed::suspend + RQESuspendedIterator::resume) is canonical. \
+             Each iterator's revalidate override is removed in its own revision once \
+             its tests have migrated."
+        )
+    }
 
     /// Rewind the iterator to the beginning and reset its properties.
     fn rewind(&mut self);

--- a/src/redisearch_rs/top_k/Cargo.toml
+++ b/src/redisearch_rs/top_k/Cargo.toml
@@ -20,12 +20,14 @@ unittest = []
 build_utils = {path = "../build_utils"}
 
 [dependencies]
+ffi.workspace = true
 index_result.workspace = true
 index_spec.workspace = true
 inverted_index.workspace = true
 rqe_core.workspace = true
 rqe_iterator_type.workspace = true
 rqe_iterators.workspace = true
+ref_mode.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -9,13 +9,17 @@
 
 //! [`TopKIterator`] — the generic top-k state machine.
 
-use std::{cmp::Ordering, num::NonZeroUsize};
+use std::{cmp::Ordering, marker::PhantomData, num::NonZeroUsize};
 
-use index_result::RSIndexResult;
+use index_result::{RSIndexResult, RawIndexResult};
 use index_spec::IndexSpecReadGuard;
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 use rqe_iterator_type::IteratorType;
-use rqe_iterators::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use rqe_iterators::{
+    RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator, RQEValidateStatus,
+    ResumeOutcome, SkipToOutcome,
+};
 
 use crate::{
     heap::{ScoredResult, TopKHeap},
@@ -28,6 +32,7 @@ use crate::{
 /// and may be switched mid-execution when the source decides a different
 /// strategy is more efficient.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum TopKMode {
     /// No child filter — stream directly from the source's single batch.
     /// The heap is bypassed entirely.
@@ -60,6 +65,7 @@ pub enum TopKMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 enum Phase {
     /// Collection has not started; the first call to [`read`](TopKIterator::read)
     /// will trigger it.
@@ -72,23 +78,41 @@ enum Phase {
     YieldingDirect,
 }
 
-/// A generic top-k iterator parameterized over a [`ScoreSource`].
+/// A generic top-k iterator parameterized over a [`ScoreSource`] and a child
+/// [`RQEIterator`].
 ///
-/// Implements the execution mode described in the design doc:
+/// Implements the execution modes described in the design doc:
 /// [`Unfiltered`](TopKMode::Unfiltered), [`Batches`](TopKMode::Batches),
 /// and [`AdhocBF`](TopKMode::AdhocBF).
-pub struct TopKIterator<
-    'index,
+///
+/// Parameterised over a [`Ref`] mode — see [`TopKIterator`] for the [`Active`]
+/// instantiation that implements [`RQEIterator`].
+///
+/// # Layout
+///
+/// The struct is `#[repr(C)]` so that [`Active`] and [`Suspended`]
+/// instantiations are layout-compatible: `result: RawIndexResult<Rf>` differs
+/// only in the validity of internal [`SharedPtr`](ref_mode::SharedPtr) fields
+/// (transparent over `Rf`), and the child field varies via `I` vs
+/// `I::Suspended` (layout-compatible by the [`RQEIteratorBoxed`] contract).
+/// `S` is identical across modes because [`ScoreSource`] is unparameterized.
+#[repr(C)]
+pub struct RawTopK<'index, Rf: Ref, S, I>
+where
     S: ScoreSource,
-    C: RQEIterator<'index> + 'index = Box<dyn RQEIterator<'index> + 'index>,
-> {
+{
     source: S,
-    child: Option<C>,
+    child: Option<I>,
     mode: TopKMode,
-    /// Preserved so [`rewind`](Self::rewind) can restore the original mode.
+    /// Preserved so [`rewind`](RQEIterator::rewind) can restore the original mode.
     initial_mode: TopKMode,
     heap: TopKHeap,
     /// Holds the in-progress batch for the Unfiltered path.
+    ///
+    /// Dropped on [`suspend`](RQEIteratorBoxed::suspend) and re-acquired on the
+    /// next [`read`](RQEIterator::read) after [`resume`](RQESuspendedIterator::resume),
+    /// since the batch cursor may carry references that are only valid while
+    /// the spec read lock is held.
     direct_batch: Option<S::Batch>,
     k: NonZeroUsize,
     compare: fn(f64, f64) -> Ordering,
@@ -96,12 +120,25 @@ pub struct TopKIterator<
     /// Heap contents drained into score order for yielding.
     results: Vec<ScoredResult>,
     yield_pos: usize,
-    current: Option<RSIndexResult<'index>>,
+    /// Currently-held result. Valid iff `has_current` is `true`.
+    result: RawIndexResult<'index, Rf>,
+    /// Discriminant for `result`: matches the legacy `current: Option<…>`
+    /// shape — `false` before the first read and after EOF.
+    has_current: bool,
     last_doc_id: DocId,
     at_eof: bool,
+    _marker: PhantomData<&'index ()>,
 }
 
-impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
+/// Alias for an [`Active`] [`RawTopK`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
+pub type TopKIterator<'index, S, I = Box<dyn RQEIterator<'index> + 'index>> =
+    RawTopK<'index, Active<'index>, S, I>;
+
+impl<'index, S> TopKIterator<'index, S, Box<dyn RQEIterator<'index> + 'index>>
+where
+    S: ScoreSource + 'index,
+{
     /// Create a new unfiltered [`TopKIterator`] (no child filter).
     ///
     /// Results are streamed directly from the source's batch — the heap is bypassed.
@@ -111,18 +148,33 @@ impl<'index, S: ScoreSource + 'index> TopKIterator<'index, S> {
     }
 }
 
-impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKIterator<'index, S, C> {
+impl<'index, S, I> TopKIterator<'index, S, I>
+where
+    S: ScoreSource + 'index,
+    I: RQEIterator<'index> + 'index,
+{
     /// Create a new [`TopKIterator`] with a filter child.
     ///
     /// The initial mode defaults to [`TopKMode::Batches`].
-    pub fn new(source: S, child: C, k: NonZeroUsize, compare: fn(f64, f64) -> Ordering) -> Self {
-        Self::new_with_mode(source, Some(child), k, compare, TopKMode::Batches)
+    pub fn new(source: S, child: I, k: NonZeroUsize, compare: fn(f64, f64) -> Ordering) -> Self {
+        Self::_new_with_mode(source, Some(child), k, compare, TopKMode::Batches)
     }
 
     /// Create a new [`TopKIterator`] with an explicit initial mode.
     pub fn new_with_mode(
         source: S,
-        child: Option<C>,
+        child: Option<I>,
+        k: NonZeroUsize,
+        compare: fn(f64, f64) -> Ordering,
+        mode: TopKMode,
+    ) -> Self {
+        Self::_new_with_mode(source, child, k, compare, mode)
+    }
+
+    /// Create a new [`TopKIterator`] with an explicit initial mode.
+    fn _new_with_mode(
+        source: S,
+        child: Option<I>,
         k: NonZeroUsize,
         compare: fn(f64, f64) -> Ordering,
         mode: TopKMode,
@@ -139,9 +191,11 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             phase: Phase::NotStarted,
             results: Vec::new(),
             yield_pos: 0,
-            current: None,
+            result: RawIndexResult::build_virt().build(),
+            has_current: false,
             last_doc_id: 0,
             at_eof: false,
+            _marker: PhantomData,
         }
     }
 
@@ -161,7 +215,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
     }
 
     /// Returns a reference to the filter child iterator, if present.
-    pub fn child(&self) -> Option<&C> {
+    pub fn child(&self) -> Option<&I> {
         self.child.as_ref()
     }
 
@@ -325,12 +379,13 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
                         continue;
                     }
                     self.last_doc_id = doc_id;
-                    self.current = Some(result);
-                    return Ok(self.current.as_mut());
+                    self.result = result;
+                    self.has_current = true;
+                    return Ok(Some(&mut self.result));
                 }
                 None => {
                     self.at_eof = true;
-                    self.current = None;
+                    self.has_current = false;
                     return Ok(None);
                 }
             }
@@ -364,20 +419,27 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
                         continue;
                     }
                     self.last_doc_id = doc_id;
-                    self.current = Some(result);
-                    return Ok(self.current.as_mut());
+                    self.result = result;
+                    self.has_current = true;
+                    return Ok(Some(&mut self.result));
                 }
             }
         }
     }
 }
 
-impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> RQEIterator<'index>
-    for TopKIterator<'index, S, C>
+impl<'index, S, I> RQEIterator<'index> for TopKIterator<'index, S, I>
+where
+    S: ScoreSource + 'index,
+    I: RQEIterator<'index> + 'index,
 {
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
-        self.current.as_mut()
+        if self.has_current {
+            Some(&mut self.result)
+        } else {
+            None
+        }
     }
 
     #[inline(always)]
@@ -436,7 +498,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> RQEIterat
         self.direct_batch = None;
         self.results.clear();
         self.yield_pos = 0;
-        self.current = None;
+        self.has_current = false;
         self.last_doc_id = 0;
         self.at_eof = false;
         self.phase = Phase::NotStarted;
@@ -546,6 +608,141 @@ impl<'a, S: ScoreSource> AdhocScope<'a, S> {
 impl<S: ScoreSource> Drop for AdhocScope<'_, S> {
     fn drop(&mut self) {
         self.0.end_adhoc();
+    }
+}
+
+impl<'index, S, I> RQEIteratorBoxed<'index> for TopKIterator<'index, S, I>
+where
+    S: ScoreSource + 'static,
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawTopK<'static, Suspended, S, I::Suspended>;
+
+    fn suspend(mut self: Box<Self>) -> Box<Self::Suspended> {
+        // Drop the in-flight batch and reset phase BEFORE the type cast.
+        // A `ScoreSource::Batch` may borrow from the source's live state; any
+        // such borrow is invalid once the spec read lock is released. We pay
+        // for a fresh `collect()` on resume — see [`prepare_unfiltered_direct`].
+        self.direct_batch = None;
+        self.phase = Phase::NotStarted;
+
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawTopK` is `#[repr(C)]`. The only `Rf`-dependent field is
+        // `result: RawIndexResult<Rf>`, layout-compatible across `Rf` via
+        // [`SharedPtr`](ref_mode::SharedPtr) transparency. `Option<I>` and
+        // `Option<I::Suspended>` are layout-compatible by the
+        // [`RQEIteratorBoxed`] contract. `S` is unchanged because
+        // [`ScoreSource`] is unparameterized over `Rf`. `Box::from_raw` reuses
+        // the same heap allocation.
+        unsafe { Box::from_raw(raw as *mut RawTopK<'static, Suspended, S, I::Suspended>) }
+    }
+}
+
+impl<'query, S, IS> RQESuspendedIterator<'query> for RawTopK<'static, Suspended, S, IS>
+where
+    S: ScoreSource + 'static,
+    IS: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = RawTopK<'a, Active<'a>, S, IS::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let RawTopK {
+            source,
+            child,
+            mode,
+            initial_mode,
+            heap,
+            direct_batch,
+            k,
+            compare,
+            phase,
+            results,
+            yield_pos,
+            result,
+            has_current,
+            last_doc_id,
+            at_eof,
+            _marker,
+        } = *self;
+
+        // `suspend` always resets these — assert as an internal invariant.
+        debug_assert!(
+            direct_batch.is_none(),
+            "direct_batch must be dropped on suspend"
+        );
+        debug_assert!(
+            matches!(phase, Phase::NotStarted),
+            "phase must be NotStarted on suspend"
+        );
+
+        // Resume the child first (if present) so we never construct the
+        // active iterator with a still-suspended `child` field. A child that
+        // aborts collapses the whole TopK (an aborted filter leaves nothing
+        // recoverable), mirroring the legacy path where an aborted child
+        // status propagated as the aggregate's status.
+        let (child, child_moved) = match child {
+            None => (None, false),
+            Some(c) => match Box::new(c).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active_child) => (Some(*active_child), false),
+                ResumeOutcome::Moved(active_child) => (Some(*active_child), true),
+            },
+        };
+
+        // SAFETY: `result` was last populated via `ScoreSource::build_result`
+        // (owned/virtual), which carries no `'index`-bound borrows. Re-typing
+        // the held result as `Active<'a>` is therefore unconditionally sound;
+        // the lifetime is purely advisory at this point.
+        let result = unsafe { result.into_active::<'a>() };
+
+        let active = Box::new(RawTopK {
+            source,
+            child,
+            mode,
+            initial_mode,
+            heap,
+            direct_batch: None,
+            k,
+            compare,
+            phase: Phase::NotStarted,
+            results,
+            yield_pos,
+            result,
+            has_current,
+            last_doc_id,
+            at_eof,
+            _marker: PhantomData,
+        });
+
+        // If we had a yielded result before suspend, the iterator's position
+        // can only "move" because the batch is regenerated on the next read.
+        // Surface that as MOVED so callers re-query `current()` / `read()`;
+        // otherwise mirror the child's outcome.
+        let moved = has_current || last_doc_id > 0 || child_moved;
+        Ok(if moved {
+            ResumeOutcome::Moved(active)
+        } else {
+            ResumeOutcome::Ok(active)
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.last_doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        // Mode-independent — mirrors the active `num_estimated`; `k` and
+        // `source` carry no `Rf`-bound state.
+        self.k.get().min(self.source.num_estimated())
     }
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

Port `top_k::TopKIterator` onto the new suspend/resume trait machinery:
the iterator is parametrised by `Rf: Ref`, its child field moves from
`Option<Box<dyn RQEIterator>>` to `Option<I>` where `I: RQEIterator`,
and it gains the `suspend` + `resume` pair following the same pattern
every leaf and composite iterator now uses.

Also lands the back-compat shim that lets the legacy
`RQEIterator::revalidate` surface coexist with the new protocol for
the rest of this stack: a `revalidate` default impl that panics on
call. The legacy method is fully removed in PR #10268 (delete-legacy).

#### Main objects this PR modified
- `TopKIterator` → `RawTopK<Rf: Ref, S, I>` parametrised + Suspended pair
- `RQEIterator::revalidate`: panicking default impl (back-compat shim)

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

Final slice of the C-split. Stacked on #10273.
