### PR TITLE
[Iterator Revalidation][MOD-16712] Wildcard, FilterReader, Numeric

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1488,6 +1488,7 @@ dependencies = [
  "redis_mock",
  "redis_reply",
  "redisearch_rs",
+ "ref_mode",
  "rqe_core",
  "rstest",
  "tracing",

--- a/src/redisearch_rs/inverted_index/src/reader/geo.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/geo.rs
@@ -124,7 +124,6 @@ unsafe impl<IR: SuspendableReader> SuspendableReader for FilterGeoReader<IR> {
 /// proof there).
 unsafe impl<RS: ResumableReader> ResumableReader for FilterGeoReader<RS>
 where
-    for<'a> Self: 'static,
     for<'a> FilterGeoReader<RS::Resumed<'a>>: IndexReader<'a>,
 {
     type Resumed<'a> = FilterGeoReader<RS::Resumed<'a>>;

--- a/src/redisearch_rs/inverted_index/src/reader/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/numeric.rs
@@ -147,7 +147,6 @@ unsafe impl<IR: SuspendableReader> SuspendableReader for FilterNumericReader<IR>
 /// proof there).
 unsafe impl<RS: ResumableReader> ResumableReader for FilterNumericReader<RS>
 where
-    for<'a> Self: 'static,
     for<'a> FilterNumericReader<RS::Resumed<'a>>: IndexReader<'a>,
 {
     type Resumed<'a> = FilterNumericReader<RS::Resumed<'a>>;

--- a/src/redisearch_rs/numeric_range_tree/Cargo.toml
+++ b/src/redisearch_rs/numeric_range_tree/Cargo.toml
@@ -28,6 +28,7 @@ rqe_core.workspace = true
 hyperloglog.workspace = true
 index_result.workspace = true
 inverted_index.workspace = true
+ref_mode.workspace = true
 redis_reply.workspace = true
 generational_slab.workspace = true
 tracing.workspace = true

--- a/src/redisearch_rs/numeric_range_tree/src/index.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/index.rs
@@ -15,10 +15,11 @@
 use ffi::IndexFlags_Index_StoreNumeric;
 use index_result::RSIndexResult;
 use inverted_index::{
-    EntriesTrackingIndex, IndexReader, IndexReaderCore, NumericReader,
+    EntriesTrackingIndex, IndexReader, NumericReader, RawIndexReaderCore,
     debug::Summary,
     numeric::{Numeric, NumericFloatCompression},
 };
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
 /// Enum to hold either compressed or uncompressed numeric index.
@@ -156,14 +157,60 @@ impl NumericIndex {
     }
 }
 
-/// Iterate over the entries stored in a numeric index.
+/// Iterate over the entries stored in a numeric index, parameterised over a
+/// [`Ref`] mode.
 ///
-/// This abstracts over whether the underlying index is compressed or uncompressed.
-pub enum NumericIndexReader<'a> {
+/// Abstracts over whether the underlying index is compressed or uncompressed.
+/// `RawNumericIndexReader<Active<'index>>` (aliased [`NumericIndexReader`]) and
+/// `RawNumericIndexReader<Suspended>` are layout-identical, so the owning
+/// `RawInvIndIterator` can suspend/resume by a same-allocation reinterpretation —
+/// the [`SuspendableReader`](inverted_index::SuspendableReader) /
+/// [`ResumableReader`](inverted_index::ResumableReader) contract. This holds
+/// because `Rf` flows only through the per-variant [`RawIndexReaderCore`]
+/// payloads, each itself layout-compatible (invariant 1 on that type). Enforced
+/// by the `const _` proof below.
+#[repr(C)]
+pub enum RawNumericIndexReader<Rf: Ref> {
     /// Reader over uncompressed entries.
-    Uncompressed(IndexReaderCore<'a, Numeric>),
+    Uncompressed(RawIndexReaderCore<Rf, Numeric>),
     /// Reader over compressed entries.
-    Compressed(IndexReaderCore<'a, NumericFloatCompression>),
+    Compressed(RawIndexReaderCore<Rf, NumericFloatCompression>),
+}
+
+/// Active-form alias of [`RawNumericIndexReader`] — the live numeric reader.
+pub type NumericIndexReader<'index> = RawNumericIndexReader<Active<'index>>;
+
+// Compile-time proof that the `Active` and `Suspended` instantiations of
+// `RawNumericIndexReader` are layout-identical. As an enum we assert size and
+// alignment equality; the per-variant `RawIndexReaderCore` payloads are
+// layout-compatible by their own invariant 1, so a divergence here is a build error.
+const _: () = {
+    use std::mem::{align_of, size_of};
+    type A = RawNumericIndexReader<Active<'static>>;
+    type S = RawNumericIndexReader<Suspended>;
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
+// SAFETY: `RawNumericIndexReader<Active>` and `<Suspended>` are layout-identical
+// (const proof above), as `SuspendableReader` requires.
+unsafe impl<'a> inverted_index::SuspendableReader for NumericIndexReader<'a> {
+    type Suspended = RawNumericIndexReader<Suspended>;
+}
+
+// SAFETY: layout-compatible for the same reason as the `SuspendableReader` impl above.
+unsafe impl inverted_index::ResumableReader for RawNumericIndexReader<Suspended> {
+    type Resumed<'a> = NumericIndexReader<'a>;
+
+    unsafe fn refresh_pointers(&mut self) -> inverted_index::RefreshOutcome {
+        match self {
+            // SAFETY: our caller upholds `ResumableReader::refresh_pointers`'s
+            // read-lock obligation, which we forward unchanged to the inner reader.
+            Self::Uncompressed(r) => unsafe { r.refresh_pointers() },
+            // SAFETY: as above.
+            Self::Compressed(r) => unsafe { r.refresh_pointers() },
+        }
+    }
 }
 
 /// Marker trait for readers producing numeric values.

--- a/src/redisearch_rs/numeric_range_tree/src/lib.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/lib.rs
@@ -77,7 +77,7 @@ mod tree;
 mod unique_id;
 
 pub use arena::NodeIndex;
-pub use index::{NumericIndex, NumericIndexReader};
+pub use index::{NumericIndex, NumericIndexReader, RawNumericIndexReader};
 pub use inverted_index::NumericFilter;
 pub use iter::{IndexedReversePreOrderDfsIterator, ReversePreOrderDfsIterator};
 pub use node::{InternalNode, LeafNode, NumericRangeNode};

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -10,8 +10,8 @@
 use std::{f64, ptr::NonNull};
 
 use crate::{
-    FieldExpirationChecker, IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus,
-    SkipToOutcome,
+    FieldExpirationChecker, IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError,
+    RQESuspendedIterator, RQEValidateStatus, ResumeOutcome, SkipToOutcome,
     c2rust::CRQEIterator,
     expiration_checker::{ExpirationChecker, NoOpChecker},
     profile_print::{ProfilePrint, ProfilePrintCtx, format_g},
@@ -24,13 +24,14 @@ use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use inverted_index::{
     FilterGeoReader, FilterNumericReader, IndexReader, NumericFilter, NumericReader,
+    ResumableReader, SuspendableReader,
 };
 use numeric_range_tree::{NumericIndexReader, NumericRangeTree};
 use query_types::QueryNodeType;
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
-use super::core::{InvIndIterator, RawInvIndIterator};
+use super::core::{InvIndIterator, RawInvIndIterator, ResumeStatus};
 
 /// An iterator over numeric inverted index entries, parameterised over a
 /// [`Ref`] mode. See [`Numeric`] for the [`Active`] instantiation that
@@ -44,8 +45,8 @@ use super::core::{InvIndIterator, RawInvIndIterator};
 /// * `R` - The type of the numeric reader.
 /// * `E` - The expiration checker type used to check for expired documents.
 #[repr(C)]
-pub struct RawNumeric<'query, Rf: Ref, R, E = NoOpChecker> {
-    it: RawInvIndIterator<'query, Rf, R, E>,
+pub struct RawNumeric<'query, Rf: Ref, R, E = NoOpChecker, RA = R> {
+    it: RawInvIndIterator<'query, Rf, R, E, RA>,
     /// The numeric range tree and its revision ID, used to detect changes during revalidation.
     range_tree_info: Option<RangeTreeInfo>,
     /// Minimum numeric range, only used in debug print.
@@ -56,7 +57,7 @@ pub struct RawNumeric<'query, Rf: Ref, R, E = NoOpChecker> {
 
 /// Alias for an [`Active`] [`RawNumeric`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
-pub type Numeric<'index, R, E = NoOpChecker> = RawNumeric<'index, Active<'index>, R, E>;
+pub type Numeric<'index, R, E = NoOpChecker> = RawNumeric<'index, Active<'index>, R, E, R>;
 
 /// Information about the numeric range tree backing a [`Numeric`] iterator.
 struct RangeTreeInfo {
@@ -65,6 +66,53 @@ struct RangeTreeInfo {
     /// The revision ID at the time the iterator was created.
     /// Used to detect if the tree has been modified.
     revision_id: u32,
+}
+
+impl<'query, Rf: Ref, R, E, RA> RawNumeric<'query, Rf, R, E, RA> {
+    /// Cached minimum numeric range (only used in debug print / FT.PROFILE).
+    pub const fn range_min(&self) -> f64 {
+        self.range_min
+    }
+
+    /// Cached maximum numeric range (only used in debug print / FT.PROFILE).
+    pub const fn range_max(&self) -> f64 {
+        self.range_max
+    }
+
+    /// Cached [`IndexFlags`] of the underlying inverted index — see
+    /// [`RawInvIndIterator::flags`].
+    pub const fn flags(&self) -> ffi::IndexFlags {
+        self.it.flags()
+    }
+
+    /// Check if the iterator should abort revalidation.
+    ///
+    /// The numeric range tree's revision id changes when the tree is
+    /// modified by GC (a node split or removal). The iterator's cached
+    /// `revision_id` snapshot is compared against the current value; if
+    /// they differ, the cursor is invalidated and the iterator must
+    /// [abort](RQEValidateStatus::Aborted).
+    ///
+    /// Reads only the range tree's `NonNull` pointer and `revision_id` (owned by
+    /// the spec, stable under the read lock); it materializes no `&'a`
+    /// reader/buffer borrow, so it is sound to call on the suspended form during
+    /// [`RQESuspendedIterator::resume`].
+    pub(crate) const fn should_abort(&self) -> bool {
+        // If there's no range tree, we can't check for changes
+        let Some(ref info) = self.range_tree_info else {
+            return false;
+        };
+
+        let current_revision_id = {
+            // SAFETY: Condition 2 of `Self::new` guarantees the tree
+            // remains valid for the iterator's lifetime.
+            let tree = unsafe { info.tree.as_ref() };
+            tree.revision_id()
+        };
+        // If the revision id changed the numeric tree was either completely deleted or a node was split or removed.
+        // The cursor is invalidated so we cannot revalidate the iterator.
+        current_revision_id != info.revision_id
+    }
 }
 
 impl<'index, R, E> Numeric<'index, R, E>
@@ -119,31 +167,6 @@ where
         }
     }
 
-    const fn should_abort(&self) -> bool {
-        // If there's no range tree, we can't check for changes
-        let Some(ref info) = self.range_tree_info else {
-            return false;
-        };
-
-        let current_revision_id = {
-            // SAFETY: Condition 2 of `Self::new` guarantees the tree
-            // remains valid for the iterator's lifetime.
-            let tree = unsafe { info.tree.as_ref() };
-            tree.revision_id()
-        };
-        // If the revision id changed the numeric tree was either completely deleted or a node was split or removed.
-        // The cursor is invalidated so we cannot revalidate the iterator.
-        current_revision_id != info.revision_id
-    }
-
-    pub const fn range_min(&self) -> f64 {
-        self.range_min
-    }
-
-    pub const fn range_max(&self) -> f64 {
-        self.range_max
-    }
-
     /// Get a reference to the underlying reader.
     ///
     /// This is used by FFI code to access the reader.
@@ -152,6 +175,85 @@ where
     }
 }
 
+impl<'index, R, E> RQEIteratorBoxed<'index> for Numeric<'index, R, E>
+where
+    R: NumericReader<'index> + SuspendableReader + 'index,
+    R::Suspended: ResumableReader,
+    for<'a> <R::Suspended as ResumableReader>::Resumed<'a>: NumericReader<'a>,
+    E: ExpirationChecker + 'static,
+{
+    // Reader weakens `R -> R::Suspended`; the frozen `RA = R` slot keeps the
+    // inner iterator's dispatch pointers unchanged across the cast.
+    type Suspended = RawNumeric<'index, Suspended, R::Suspended, E, R>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawNumeric` is `#[repr(C)]` over the inner
+        // `RawInvIndIterator`, layout-identical across modes by invariant 1 on
+        // [`RawInvIndIterator`]: `reader` weakens `R -> R::Suspended` while the
+        // frozen `RA = R` slot keeps the dispatch pointers unchanged. The
+        // remaining fields (`range_tree_info`, `range_min`, `range_max`) carry no
+        // `Rf`, so they survive the cast unchanged. `Box::from_raw` reuses the
+        // same heap allocation.
+        unsafe { Box::from_raw(raw as *mut RawNumeric<'index, Suspended, R::Suspended, E, R>) }
+    }
+}
+
+impl<'query, RS, E, RA> RQESuspendedIterator<'query> for RawNumeric<'query, Suspended, RS, E, RA>
+where
+    RS: ResumableReader,
+    for<'a> RS::Resumed<'a>: NumericReader<'a>,
+    E: ExpirationChecker + 'static,
+{
+    type Resumed<'a>
+        = Numeric<'a, RS::Resumed<'a>, E>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        mut self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Step 1: identity check on the suspended form. On abort we drop the
+        // suspended iterator without promoting it to Active — nothing is
+        // materialized.
+        if self.should_abort() {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        // Step 2: run the shared in-place resume transition on the inner core
+        // iterator (refresh pointers, reset stale offsets, promote the result,
+        // and re-seek if GC moved us). `guard` witnesses the read lock the
+        // refresh requires.
+        let status = self.it.resume_in_place(guard)?;
+
+        // Step 3: reinterpret the owning box's type. The heap address is
+        // preserved across the cast.
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawNumeric` is `#[repr(C)]` over the inner `RawInvIndIterator`
+        // (layout-identical across modes by invariant 1 on `RawInvIndIterator`)
+        // plus the `Rf`-free `range_tree_info`/`range_min`/`range_max` fields.
+        // `resume_in_place` left the inner iterator as a valid active iterator, so
+        // the whole `RawNumeric` is now a valid `Numeric<'a, RS::Resumed<'a>, E>`.
+        let active = unsafe { Box::from_raw(raw as *mut Numeric<'a, RS::Resumed<'a>, E>) };
+
+        Ok(match status {
+            ResumeStatus::Unchanged => ResumeOutcome::Ok(active),
+            ResumeStatus::Moved => ResumeOutcome::Moved(active),
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.it.last_doc_id_field()
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.it.num_estimated()
+    }
+}
 impl<'index, R, E> RQEIterator<'index> for Numeric<'index, R, E>
 where
     R: NumericReader<'index>,
@@ -434,12 +536,12 @@ impl<'index> NumericIteratorVariant<'index> {
         }
     }
 
-    /// Returns the flags from the underlying index reader.
-    pub fn flags(&self) -> IndexFlags {
+    /// Returns the cached flags of the underlying index reader.
+    pub const fn flags(&self) -> IndexFlags {
         match self {
-            Self::Unfiltered(iter) => iter.reader().flags(),
-            Self::Filtered(iter) => iter.reader().flags(),
-            Self::Geo(iter) => iter.reader().flags(),
+            Self::Unfiltered(iter) => iter.flags(),
+            Self::Filtered(iter) => iter.flags(),
+            Self::Geo(iter) => iter.flags(),
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -15,13 +15,13 @@ use index_result::{RSIndexResult, RawIndexResult};
 use index_spec::IndexSpecReadGuard;
 use inverted_index::codec::{doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly};
 use inverted_index::{DocIdsDecoder, opaque};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 use crate::{
-    Empty, RQEIterator, RQEIteratorError, RQEValidateStatus, SEARCH_ENTERPRISE_ITERATORS,
-    SkipToOutcome,
+    Empty, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SEARCH_ENTERPRISE_ITERATORS, SkipToOutcome,
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 use crate::{IteratorType, QueryError, RQEIteratorPrintable};
@@ -127,6 +127,49 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
     }
 }
 
+impl<'index> RQEIteratorBoxed<'index> for Wildcard<'index> {
+    type Suspended = RawWildcard<'index, Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawWildcard` is `#[repr(C)]` with the only `Rf`-dependent
+        // field being `result: RawIndexResult<Rf>`, layout-compatible across
+        // `Rf` (see [`crate::inverted_index::Wildcard::suspend`] for the
+        // same argument). Box::from_raw reuses the same heap allocation.
+        unsafe { Box::from_raw(raw as *mut RawWildcard<'index, Suspended>) }
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for RawWildcard<'query, Suspended> {
+    type Resumed<'a>
+        = Wildcard<'a>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        _guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let raw = Box::into_raw(self);
+        // SAFETY: layout-compatible — see `suspend`. The top-level wildcard
+        // owns no references into the index (it's just a counter), so there
+        // is no state to refresh.
+        let active = unsafe { Box::from_raw(raw as *mut Wildcard<'a>) };
+        Ok(ResumeOutcome::Ok(active))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        // Mode-independent — mirrors the active `num_estimated`.
+        self.top_id as usize
+    }
+}
 /// A marker trait for iterators that match all documents.
 pub trait WildcardIterator<'index>: RQEIterator<'index> {}
 
@@ -291,11 +334,25 @@ impl<'index> RQEIterator<'index> for NewWildcardIterator<'index> {
     }
 
     fn num_estimated(&self) -> usize {
-        delegate_wildcard_iterator!(self, num_estimated)
+        // Disambiguated against `RQESuspendedIterator::num_estimated` for the
+        // `Empty` variant (whose Suspended counterpart is `Empty` itself).
+        match self {
+            Self::NotOptimized(it) => RQEIterator::num_estimated(it),
+            Self::Optimized(it) => RQEIterator::num_estimated(it),
+            Self::Empty(it) => RQEIterator::num_estimated(it),
+            Self::Disk(it) => RQEIterator::num_estimated(it),
+        }
     }
 
     fn last_doc_id(&self) -> DocId {
-        delegate_wildcard_iterator!(self, last_doc_id)
+        // Disambiguated against `RQESuspendedIterator::last_doc_id` for the
+        // `Empty` variant (whose Suspended counterpart is `Empty` itself).
+        match self {
+            Self::NotOptimized(it) => RQEIterator::last_doc_id(it),
+            Self::Optimized(it) => RQEIterator::last_doc_id(it),
+            Self::Empty(it) => RQEIterator::last_doc_id(it),
+            Self::Disk(it) => RQEIterator::last_doc_id(it),
+        }
     }
 
     fn at_eof(&self) -> bool {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -415,6 +415,38 @@ fn numeric_no_range_tree_revalidate() {
     assert_eq!(status, RQEValidateStatus::Ok);
 }
 
+/// Resume sibling of [`numeric_no_range_tree_revalidate`]: with no range tree,
+/// `should_abort` returns false, so a suspend/resume cycle promotes the iterator
+/// back to `Active` (`Ok`) and the position is preserved.
+#[test]
+fn numeric_no_range_tree_resume() {
+    use rqe_iterators::TypeErasedRQEIterator;
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let mut ii =
+        InvertedIndex::<inverted_index::numeric::Numeric>::new(IndexFlags_Index_StoreNumeric);
+    let _ = ii.add_record(&RSIndexResult::build_numeric(1.0).doc_id(1).build());
+    let _ = ii.add_record(&RSIndexResult::build_numeric(2.0).doc_id(3).build());
+
+    // Build without a range tree — should_abort will return false.
+    let it = NumericBuilder::new(ii.reader()).build();
+
+    let guard = mock_ctx.spec_read();
+    let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+        .expect("resume should not fail in this test")
+        .expect_ok();
+
+    // The first doc is still available after resume (no range tree ⇒ no abort).
+    let record = it.read().expect("read failed").expect("expected a result");
+    assert_eq!(record.doc_id, 1);
+
+    // A second resume also succeeds.
+    revalidate_via_resume(it, &guard)
+        .expect("resume should not fail in this test")
+        .expect_ok();
+}
+
 /// A [`GeoFilter`] with a non-null address so `is_numeric_filter()` returns `false`.
 /// `fieldSpec` and `numericFilters` are null — tests using this stub must not
 /// reach code paths that dereference those pointers.
@@ -1101,5 +1133,69 @@ mod not_miri {
 
         test.test
             .revalidate_numeric_after_document_deleted(&mut it, ii);
+    }
+
+    /// Resume-flavored siblings of the `revalidate` tests above: the same
+    /// scenarios driven through a suspend/resume cycle
+    /// ([`revalidate_via_resume`]) rather than in-place [`RQEIterator::revalidate`].
+    mod via_resume {
+        use super::*;
+        use crate::inverted_index::utils::via_resume::{
+            revalidate_at_eof, revalidate_basic, revalidate_numeric_after_document_deleted,
+        };
+        use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator};
+        use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+        #[test]
+        fn numeric_revalidate_basic() {
+            let test = NumericRevalidateTest::new(10);
+            let it = test.create_iterator();
+            revalidate_basic(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn numeric_revalidate_at_eof() {
+            let test = NumericRevalidateTest::new(10);
+            let it = test.create_iterator();
+            revalidate_at_eof(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn numeric_revalidate_after_document_deleted() {
+            let test = NumericRevalidateTest::new(10);
+            let it = test.create_iterator();
+            let ii = test.test.context.numeric_inverted_index();
+            revalidate_numeric_after_document_deleted(&test.test, Box::new(it), ii);
+        }
+
+        /// Resume sibling of [`numeric_revalidate_after_index_disappears`]: a
+        /// range-tree revision bump while suspended (simulating a GC node
+        /// split/removal) must abort the resume, since the cached revision id no
+        /// longer matches.
+        #[test]
+        fn numeric_revalidate_after_range_tree_modified() {
+            let test = NumericRevalidateTest::new(10);
+            let it = Box::new(test.create_iterator());
+            let guard = test.test.context.spec_read();
+
+            // A clean resume cycle works before any modification; read one doc so
+            // the iterator holds a non-trivial position.
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+                .expect("resume should not fail in this test")
+                .expect_ok();
+            assert!(it.read().expect("failed to read").is_some());
+
+            // Bump the range tree's revision id (interior mutability via raw
+            // pointer, so it does not conflict with the read guard).
+            {
+                let rt = test.test.context.numeric_range_tree_mut();
+                rt.increment_revision();
+            }
+
+            // The cached revision no longer matches, so resume must abort.
+            let outcome =
+                revalidate_via_resume(it, &guard).expect("resume should not fail in this test");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+        }
     }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

The last leaf iterators that didn't fit the simple-leaves or
inverted-index-leaves families, plus the reader plumbing they need:

- `Wildcard` (top-level): the range iterator that walks `1..max_doc_id`,
  unrelated to `inverted_index::Wildcard`.
- `FilterReader`: drops the redundant `for<'a> Self: 'static` bounds on the
  `ResumableReader` impls for `FilterNumericReader` / `FilterGeoReader`
  (already implied by `ResumableReader: 'static`). Cleanup prerequisite for
  `Numeric`'s suspend/resume.
- `NumericIndexReader`: adds the suspended counterpart
  `NumericIndexReaderSuspended` plus the `SuspendableReader` / `ResumableReader`
  impls, so `Numeric` can be suspended/resumed at its production reader type.
- `Numeric`: the numeric-range iterator, suspend/resume via the shared
  `RawInvIndIterator` core (introduced in the previous PR), with `via_resume`
  integration tests (basic, at-eof, document-deleted/Moved, range-tree-modified
  abort, and no-range-tree).

#### Main objects this PR modified
- Top-level `Wildcard`
- `FilterReader` (redundant `'static` bound cleanup)
- `NumericIndexReader` (`SuspendableReader`/`ResumableReader` + `NumericIndexReaderSuspended`)
- `Numeric` (+ suspend/resume tests)

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

Stacked on #10275.