### PR TITLE
[Iterator Revalidation][MOD-16713] Union family

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
@@ -9,7 +9,9 @@
 
 //! Supporting types for [`Missing`], [`Numeric`], [`Term`], and [`Wildcard`].
 
-mod core;
+// `pub(crate)` so the top-level `OptimizedWildcard` wrapper can name
+// `core::ResumeStatus` when driving its inline variants' in-place resume.
+pub(crate) mod core;
 mod geo;
 mod missing;
 mod numeric;
@@ -29,4 +31,4 @@ pub use numeric::{
 
 pub use tag::{Tag, TagLookup};
 pub use term::{Term, TermIndexReader, build_term_iterator};
-pub use wildcard::Wildcard;
+pub use wildcard::{RawWildcard, Wildcard};

--- a/src/redisearch_rs/rqe_iterators/src/union.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union.rs
@@ -22,6 +22,32 @@ pub use crate::union_flat::UnionFlat;
 pub use crate::union_heap::UnionHeap;
 pub use crate::union_trimmed::UnionTrimmed;
 
+/// Where settling left a union, after its children moved underneath it.
+///
+/// Returned by both variants' `settle_after_children_changed`, which is the single
+/// decision point shared by the legacy [`RQEIterator::revalidate`] and the
+/// `Box<Self>` [`resume`](crate::RQESuspendedIterator::resume) path. Each caller maps
+/// these onto its own outcome type, so the two cannot drift apart:
+///
+/// | `SettleOutcome` | `RQEValidateStatus`         | `ResumeOutcome` |
+/// |-----------------|-----------------------------|-----------------|
+/// | `Unchanged`     | `Ok`                        | `Ok`            |
+/// | `Moved`         | `Moved { current: Some(_) }`| `Moved`         |
+/// | `Eof`           | `Moved { current: None }`   | `Moved`         |
+///
+/// [`RQEIterator::revalidate`]: crate::RQEIterator::revalidate
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SettleOutcome {
+    /// The union is still on the document it was on, and that document is still backed
+    /// by an active child.
+    Unchanged,
+    /// The union advanced, and its result describes the new position.
+    Moved,
+    /// The union ran out of documents while settling; it is now at EOF and has no
+    /// current result.
+    Eof,
+}
+
 // ============================================================================
 // Type aliases for convenient access
 // ============================================================================

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -10,10 +10,15 @@
 //! Flat array variant of the union iterator with O(n) min-finding.
 
 use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
-use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::union::SettleOutcome;
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+    boxed::{ResumeSlotOutcome, rederive_aggregate_entries, resume_child_slot_in_place},
+};
 use index_spec::IndexSpecReadGuard;
 
 /// A child iterator paired with its original insertion index.
@@ -89,6 +94,79 @@ pub struct RawUnionFlat<'query, Rf: Ref, I, const QUICK_EXIT: bool> {
 /// [`RQEIterator`] impl today.
 pub type UnionFlat<'index, I, const QUICK_EXIT: bool> =
     RawUnionFlat<'index, Active<'index>, I, QUICK_EXIT>;
+
+// Compile-time proof of invariant 1 on `RawUnionFlat`: for a representative
+// concrete child, the `Active` and `Suspended` instantiations are
+// layout-identical. The child elements' own compatibility is their invariant 1
+// (enforced generically by the slot helpers), carried through the `#[repr(C)]`
+// `IndexedChild`; `result` is layout-compatible across `Rf` (proven in
+// `index_result`); the remaining fields are `Rf`-free. `QUICK_EXIT` never
+// affects layout.
+const _: () = {
+    use crate::Wildcard;
+    use std::mem::{align_of, offset_of, size_of};
+    type AChild = Wildcard<'static>;
+    type SChild = <Wildcard<'static> as RQEIteratorBoxed<'static>>::Suspended;
+    type A = RawUnionFlat<'static, Active<'static>, AChild, false>;
+    type S = RawUnionFlat<'static, Suspended, SChild, false>;
+    assert!(offset_of!(A, children) == offset_of!(S, children));
+    assert!(offset_of!(A, num_active) == offset_of!(S, num_active));
+    assert!(offset_of!(A, num_estimated) == offset_of!(S, num_estimated));
+    assert!(offset_of!(A, is_eof) == offset_of!(S, is_eof));
+    assert!(offset_of!(A, result) == offset_of!(S, result));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
+/// Frees a suspended [`RawUnionFlat`]'s reused allocation after the in-place
+/// resume consumed the child at `consumed`: drops the compacted resumed prefix
+/// `children[..kept]` in place and the still-suspended tail past `consumed`,
+/// skips the holes in between (moved-from or consumed), empties the `Vec` so it
+/// frees only its buffer, then drops the box (freeing the still-suspended
+/// `result` and the allocation).
+///
+/// # Safety
+///
+/// * `raw` must be exclusively owned and have come from `Box::into_raw`.
+/// * `children[..kept]` must hold valid `IndexedChild<S::Resumed<'a>>` values,
+///   `children[kept..=consumed]` must be moved-from or consumed (they are not
+///   touched), and `children[consumed + 1..]` must hold valid `IndexedChild<S>`
+///   values — the exact state the in-place resume loop leaves behind when the
+///   slot helper reports `Err` for element `consumed`.
+unsafe fn free_after_consumed_child<'query, 'a, S, const QUICK_EXIT: bool>(
+    raw: *mut RawUnionFlat<'query, Suspended, S, QUICK_EXIT>,
+    kept: usize,
+    consumed: usize,
+) where
+    S: RQESuspendedIterator<'query>,
+    'query: 'a,
+{
+    // SAFETY: `raw` is exclusively owned (caller contract); the borrow is used
+    // only to reach the buffer pointer, the length, and `set_len`.
+    let children: &mut Vec<IndexedChild<S>> = unsafe { &mut (*raw).children };
+    let len = children.len();
+    let base = children.as_mut_ptr();
+    for i in 0..kept {
+        // SAFETY: `i` is in bounds of the children buffer.
+        let slot = unsafe { base.add(i) };
+        // SAFETY: the slot holds a valid resumed child (caller contract); drop
+        // it through the resumed type (same size/alignment, enforced by the
+        // slot helper's const guard).
+        unsafe { std::ptr::drop_in_place(slot.cast::<IndexedChild<S::Resumed<'a>>>()) };
+    }
+    for i in (consumed + 1)..len {
+        // SAFETY: `i` is in bounds of the children buffer.
+        let slot = unsafe { base.add(i) };
+        // SAFETY: the slot still holds a valid suspended child.
+        unsafe { std::ptr::drop_in_place(slot) };
+    }
+    // SAFETY: every element was dropped, moved, or consumed; zeroing the length
+    // keeps the `Vec` from dropping them again — it frees only its buffer.
+    unsafe { children.set_len(0) };
+    // SAFETY: `raw` is a well-formed suspended union again (empty children,
+    // still-suspended `result`, `Rf`-free scalars); reclaim and drop it.
+    drop(unsafe { Box::from_raw(raw) });
+}
 
 // Methods used in both modes.
 impl<'index, I, const QUICK_EXIT: bool> UnionFlat<'index, I, QUICK_EXIT>
@@ -167,6 +245,183 @@ where
     pub fn into_trimmed(self, limit: usize, asc: bool) -> Option<super::UnionTrimmed<'index, I>> {
         let children: Vec<I> = self.children.into_iter().map(|c| c.inner).collect();
         (children.len() >= 3).then(|| super::UnionTrimmed::new(children, limit, asc))
+    }
+
+    /// Settles the union's position after its children have moved, and reports where
+    /// that leaves it.
+    ///
+    /// The single place that decides a union's post-change position, shared by
+    /// [`RQEIterator::revalidate`] and
+    /// [`RQESuspendedIterator::resume`] so the two
+    /// cannot drift apart — the legacy and the `Box<Self>` path must make the same
+    /// re-seek and moved-versus-unchanged decisions, and a divergence between them is a
+    /// bug. Each caller re-admits every child first (`num_active = children.len()`):
+    /// a child revalidation can bring a parked child back into play, and the scan
+    /// below re-drops the ones that are still exhausted.
+    ///
+    /// `original_last_doc_id` is the position the union held before the children moved.
+    fn settle_after_children_changed(
+        &mut self,
+        original_last_doc_id: DocId,
+    ) -> Result<SettleOutcome, RQEIteratorError> {
+        // Only a child that has run past its last result is dropped: one that has
+        // merely returned its final document still owes it, and dropping it would
+        // lose that document — or report EOF for the whole union, if it was the
+        // last active child.
+        let mut min_doc_id: DocId = DocId::MAX;
+        let mut min_child_idx: usize = 0;
+        let mut i = 0;
+        while i < self.num_active {
+            let child = &self.children[i];
+            if child.at_eof() {
+                self.swap_remove_child(i);
+                // Don't increment i - check the swapped-in child
+            } else {
+                let child_doc_id = child.last_doc_id();
+                if child_doc_id < min_doc_id {
+                    min_doc_id = child_doc_id;
+                    min_child_idx = i;
+                }
+                i += 1;
+            }
+        }
+
+        // Every remaining child is at EOF.
+        if self.num_active == 0 {
+            self.is_eof = true;
+            return Ok(SettleOutcome::Eof);
+        }
+
+        // A minimum *behind* the union is not a position to move to — adopting it
+        // would replay documents, because a reported move has the caller emit
+        // `current` in place of a read and the read after that resumes from there.
+        // `iterator_api.h` says `VALIDATE_MOVED` means the position moved
+        // *forward*, and `Not::revalidate` asserts that of its child — which is
+        // where a `QUICK_EXIT` union usually sits.
+        //
+        // Both modes can see one. With `QUICK_EXIT` it is the mode's own early
+        // return: `skip_to_quick` stops on the first exact match, so a later
+        // sibling keeps an earlier round's id, or answers 0 having never been read
+        // at all. Without it there is exactly one way: a child that ran out and was
+        // dropped can *resurrect* during a revalidation — an inverted-index leaf
+        // rewinds and re-seeks the position it held, and rewinding clears the
+        // past-the-end state — so the re-admission above put it back far behind a
+        // union that carried on without it.
+        if min_doc_id < original_last_doc_id {
+            // A child still sitting on the union's document backs the position as
+            // it stands: republish from it (the result holds raw pointers into
+            // children that may have moved or been dropped) and report no change,
+            // with no reads spent. `min_child_idx` cannot serve — that is the
+            // lagging child just rejected. Quick mode only: its laggers are
+            // ordinary state for the next `read`/`skip_to` to seek past, while a
+            // full union must catch them up below either way —
+            // `advance_and_find_min` relies on no active child sitting behind the
+            // union.
+            if QUICK_EXIT
+                && let Some(idx) = self.children[..self.num_active]
+                    .iter()
+                    .position(|c| c.last_doc_id() == original_last_doc_id)
+            {
+                self.quick_set_from_child(idx);
+
+                debug_assert_eq!(
+                    self.last_doc_id(),
+                    original_last_doc_id,
+                    "staying put must leave the position untouched",
+                );
+
+                return Ok(SettleOutcome::Unchanged);
+            }
+
+            // Nothing already sits on the union's document, but a lagging child
+            // may still *hold* it: `skip_to_quick`'s early return strands a
+            // sibling without consuming its position. The union may not step over
+            // the document before asking — under a `NOT`, its position is not a
+            // delivered result but the next id the `NOT` has yet to exclude, and
+            // stepping over it would let that document into the result set. So
+            // every lagger is seeked to the abandoned position itself, not past
+            // it.
+            //
+            // These reads cannot be avoided. An `Err` here reaches the caller as
+            // `VALIDATE_ABORTED`, freeing the iterator and substituting an empty
+            // one — blunt, but better than handing out a position no child backs.
+            let mut i = 0;
+            while i < self.num_active {
+                if self.children[i].last_doc_id() >= original_last_doc_id {
+                    i += 1;
+                    continue;
+                }
+                match self.children[i].skip_to(original_last_doc_id)? {
+                    Some(SkipToOutcome::Found(_)) => {
+                        if QUICK_EXIT {
+                            // Still matched after all: the union stays on it,
+                            // backed by this child; remaining laggers wait for the
+                            // next call.
+                            self.quick_set_from_child(i);
+
+                            debug_assert_eq!(
+                                self.last_doc_id(),
+                                original_last_doc_id,
+                                "staying put must leave the position untouched",
+                            );
+
+                            return Ok(SettleOutcome::Unchanged);
+                        }
+                        i += 1;
+                    }
+                    Some(SkipToOutcome::NotFound(_)) => {
+                        i += 1;
+                    }
+                    None => {
+                        // The seek exhausted the child. Don't increment i — the
+                        // swapped-in element needs to be checked.
+                        self.swap_remove_child(i);
+                    }
+                }
+            }
+
+            // Seeking the laggers forward can run the union out of documents.
+            if self.num_active == 0 {
+                self.is_eof = true;
+                return Ok(SettleOutcome::Eof);
+            }
+
+            // Every active child now sits at or past the abandoned position, so
+            // the minimum is a position again: equal to it when children still
+            // match the document (full mode only — quick mode returned above),
+            // later otherwise.
+            min_doc_id = DocId::MAX;
+            for (i, child) in self.children[..self.num_active].iter().enumerate() {
+                let child_doc_id = child.last_doc_id();
+                if child_doc_id < min_doc_id {
+                    min_doc_id = child_doc_id;
+                    min_child_idx = i;
+                }
+            }
+
+            debug_assert!(
+                min_doc_id >= original_last_doc_id,
+                "every lagging child was just seeked to the union's position",
+            );
+        }
+
+        // Rebuild result at the new minimum doc_id
+        if QUICK_EXIT {
+            self.quick_set_from_child(min_child_idx);
+        } else {
+            self.build_aggregate_result(min_doc_id);
+        }
+
+        if self.last_doc_id() == original_last_doc_id {
+            return Ok(SettleOutcome::Unchanged);
+        }
+
+        debug_assert!(
+            self.last_doc_id() > original_last_doc_id,
+            "a reported move must be forward",
+        );
+
+        Ok(SettleOutcome::Moved)
     }
 
     /// Swap-removes an exhausted child at `idx` by swapping it with the last active child.
@@ -637,167 +892,19 @@ where
             return Ok(RQEValidateStatus::Ok);
         }
 
-        // Sync num_active and find minimum doc_id.
-        // Use swap_remove_child to move EOF children out of the active region.
+        // Re-admit every child, including any parked past `num_active`: their own
+        // revalidation may have brought them back into play.
         self.num_active = self.children.len();
 
-        // Only a child that has run past its last result is dropped: one that has
-        // merely returned its final document still owes it, and dropping it would
-        // lose that document — or report EOF for the whole union, if it was the
-        // last active child.
-        let mut min_doc_id: DocId = DocId::MAX;
-        let mut min_child_idx: usize = 0;
-        let mut i = 0;
-        while i < self.num_active {
-            let child = &self.children[i];
-            if child.at_eof() {
-                self.swap_remove_child(i);
-                // Don't increment i - check the swapped-in child
-            } else {
-                let child_doc_id = child.last_doc_id();
-                if child_doc_id < min_doc_id {
-                    min_doc_id = child_doc_id;
-                    min_child_idx = i;
-                }
-                i += 1;
-            }
-        }
-
-        // Check if all remaining children are at EOF
-        if self.num_active == 0 {
-            self.is_eof = true;
-            return Ok(RQEValidateStatus::Moved { current: None });
-        }
-
-        // A minimum *behind* the union is not a position to move to — adopting it
-        // would replay documents, because `VALIDATE_MOVED` has the caller emit
-        // `current` in place of a read and the read after that resumes from there.
-        // `iterator_api.h` says `VALIDATE_MOVED` means the position moved *forward*,
-        // and `Not::revalidate` asserts that of its child — which is where a
-        // `QUICK_EXIT` union usually sits.
-        //
-        // Both modes can see one. With `QUICK_EXIT` it is the mode's own early
-        // return: `skip_to_quick` stops on the first exact match, so a later sibling
-        // keeps an earlier round's id, or answers 0 having never been read at all.
-        // Without it there is exactly one way: a child that ran out and was dropped
-        // can *resurrect* during the revalidation above — an inverted-index leaf
-        // rewinds and re-seeks the position it held, and rewinding clears the
-        // past-the-end state — so it re-enters the active set far behind a union
-        // that carried on without it.
-        if min_doc_id < original_last_doc_id {
-            // A child still sitting on the union's document backs the position as it
-            // stands: republish from it (the result holds raw pointers into children
-            // that may have moved or been dropped) and report `Ok`, with no reads
-            // spent. `min_child_idx` cannot serve — that is the lagging child just
-            // rejected. Quick mode only: its laggers are ordinary state for the next
-            // `read`/`skip_to` to seek past, while a full union must catch them up
-            // below either way — `advance_and_find_min` relies on no active child
-            // sitting behind the union.
-            if QUICK_EXIT
-                && let Some(idx) = self.children[..self.num_active]
-                    .iter()
-                    .position(|c| c.last_doc_id() == original_last_doc_id)
-            {
-                self.quick_set_from_child(idx);
-
-                debug_assert_eq!(
-                    self.last_doc_id(),
-                    original_last_doc_id,
-                    "staying put must leave the position untouched",
-                );
-
-                return Ok(RQEValidateStatus::Ok);
-            }
-
-            // Nothing already sits on the union's document, but a lagging child may
-            // still *hold* it: `skip_to_quick`'s early return strands a sibling
-            // without consuming its position. The union may not step over the
-            // document before asking — under a `NOT`, its position is not a
-            // delivered result but the next id the `NOT` has yet to exclude, and
-            // stepping over it would let that document into the result set. So every
-            // lagger is seeked to the abandoned position itself, not past it.
-            //
-            // These reads cannot be avoided. An `Err` here reaches the caller as
-            // `VALIDATE_ABORTED`, freeing the iterator and substituting an empty one
-            // — blunt, but better than handing out a position no child backs.
-            let mut i = 0;
-            while i < self.num_active {
-                if self.children[i].last_doc_id() >= original_last_doc_id {
-                    i += 1;
-                    continue;
-                }
-                match self.children[i].skip_to(original_last_doc_id)? {
-                    Some(SkipToOutcome::Found(_)) => {
-                        if QUICK_EXIT {
-                            // Still matched after all: the union stays on it, backed
-                            // by this child; remaining laggers wait for the next call.
-                            self.quick_set_from_child(i);
-
-                            debug_assert_eq!(
-                                self.last_doc_id(),
-                                original_last_doc_id,
-                                "staying put must leave the position untouched",
-                            );
-
-                            return Ok(RQEValidateStatus::Ok);
-                        }
-                        i += 1;
-                    }
-                    Some(SkipToOutcome::NotFound(_)) => {
-                        i += 1;
-                    }
-                    None => {
-                        // The seek exhausted the child. Don't increment i — the
-                        // swapped-in element needs to be checked.
-                        self.swap_remove_child(i);
-                    }
-                }
-            }
-
-            // Seeking the laggers forward can run the union out of documents.
-            if self.num_active == 0 {
-                self.is_eof = true;
-                return Ok(RQEValidateStatus::Moved { current: None });
-            }
-
-            // Every active child now sits at or past the abandoned position, so the
-            // minimum is a position again: equal to it when children still match the
-            // document (full mode only — quick mode returned above), later otherwise.
-            min_doc_id = DocId::MAX;
-            for (i, child) in self.children[..self.num_active].iter().enumerate() {
-                let child_doc_id = child.last_doc_id();
-                if child_doc_id < min_doc_id {
-                    min_doc_id = child_doc_id;
-                    min_child_idx = i;
-                }
-            }
-
-            debug_assert!(
-                min_doc_id >= original_last_doc_id,
-                "every lagging child was just seeked to the union's position",
-            );
-        }
-
-        // Rebuild result at the new minimum doc_id
-        if QUICK_EXIT {
-            self.quick_set_from_child(min_child_idx);
-        } else {
-            self.build_aggregate_result(min_doc_id);
-        }
-
-        // Return MOVED only if lastDocId changed
-        if self.last_doc_id() == original_last_doc_id {
-            return Ok(RQEValidateStatus::Ok);
-        }
-
-        debug_assert!(
-            self.last_doc_id() > original_last_doc_id,
-            "a reported move must be forward",
-        );
-
-        Ok(RQEValidateStatus::Moved {
-            current: Some(&mut self.result),
-        })
+        Ok(
+            match self.settle_after_children_changed(original_last_doc_id)? {
+                SettleOutcome::Unchanged => RQEValidateStatus::Ok,
+                SettleOutcome::Moved => RQEValidateStatus::Moved {
+                    current: Some(&mut self.result),
+                },
+                SettleOutcome::Eof => RQEValidateStatus::Moved { current: None },
+            },
+        )
     }
 
     #[inline(always)]
@@ -811,6 +918,253 @@ where
         } else {
             1.0
         }
+    }
+}
+
+impl<'index, I, const QUICK_EXIT: bool> RQEIteratorBoxed<'index>
+    for UnionFlat<'index, I, QUICK_EXIT>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawUnionFlat<'index, Suspended, I::Suspended, QUICK_EXIT>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Walk children: dispatch each child's `suspend` through the trait
+        // so dyn-erased `I` (e.g. [`TypeErasedRQEIterator`](crate::TypeErasedRQEIterator))
+        // correctly transitions its vtable. For concrete-typed `I` this is
+        // the same whole-box cast that would otherwise happen at the outer
+        // level, just per-child.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` and is exclusively owned
+        // for the rest of this function, so the children Vec is reachable
+        // and unaliased.
+        let children: &mut Vec<IndexedChild<I>> = unsafe { &mut (*raw).children };
+        for child in children.iter_mut() {
+            // SAFETY: `child.inner` is a valid `I` accessed via a fresh
+            // `&mut`; the function leaves the slot in a valid
+            // `I::Suspended` state.
+            unsafe { crate::boxed::suspend_child_slot_in_place(&mut child.inner) };
+        }
+        // SAFETY: `RawUnionFlat` is `#[repr(C)]` over `Vec<IndexedChild<I>>`
+        // (now byte-rewritten with `I::Suspended` payloads) and
+        // `result: RawIndexResult<Rf>` (layout-compatible via `SharedPtr`).
+        unsafe {
+            Box::from_raw(raw as *mut RawUnionFlat<'index, Suspended, I::Suspended, QUICK_EXIT>)
+        }
+    }
+}
+
+impl<'query, S, const QUICK_EXIT: bool> RQESuspendedIterator<'query>
+    for RawUnionFlat<'query, Suspended, S, QUICK_EXIT>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = UnionFlat<'a, S::Resumed<'a>, QUICK_EXIT>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // The pre-resume position, read off the suspended form. Unlike
+        // `revalidate` there is no is-EOF return before the walk: the suspended
+        // children must be transitioned regardless of the outcome.
+        let original_last_doc_id = self.result.doc_id;
+
+        let raw = Box::into_raw(self);
+
+        // Resume every child *in place* — including the exhausted tail past
+        // `num_active`: a leaf can resurrect (its revalidation rewinds and
+        // re-seeks, clearing the past-the-end state), and `revalidate` re-admits
+        // such a child through the settle below, so resume must too. Aborted
+        // children are removed, like `revalidate`'s aborted children: survivors
+        // are compacted down over the holes.
+        //
+        // The compaction preserves the survivors' relative order where
+        // `revalidate` uses `swap_remove`, which pulls the last child into the
+        // hole instead. The surviving *set* is the same and `original_index`
+        // keeps each child identifiable, so the two orders differ only in the
+        // shared settle's tie-breaks between children sitting on the *same*
+        // document (`min_child_idx` takes the first, and `QUICK_EXIT`'s
+        // `position(..)` likewise): the union's document sequence is identical
+        // either way, only which of several equally-matching children backs a
+        // `QUICK_EXIT` payload can differ. Matching `swap_remove` here would mean
+        // pulling still-suspended children out of the tail and re-entering slots
+        // the walk has already transitioned, so the buffer would no longer be a
+        // resumed prefix followed by a suspended suffix — the split
+        // `free_after_consumed_child` relies on to tear the allocation down.
+        // Compacting is the deliberate choice.
+        //
+        // Whatever the walk does to the children, the suspended aggregate's
+        // entries are re-derived from the survivors before the cast — the one
+        // step that turns pointers whose addresses happen to have survived into
+        // usable references. An abort is where the addresses stop surviving too:
+        // the aborted child's result is freed outright, and the compaction
+        // relocates every survivor behind it, so for a concrete (non-boxed) child
+        // the result moves as well. Both show up there as an entry no live child
+        // answers for, and clear the aggregate rather than re-narrow it.
+        //
+        // A panic between slot transitions leaks the allocation (memory-safe);
+        // the slot helper guards its own moved-out window.
+        let (base, len) = {
+            // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+            // initialised, exclusively owned); the borrow is used only to reach
+            // the buffer pointer and length.
+            let children: &mut Vec<IndexedChild<S>> = unsafe { &mut (*raw).children };
+            (children.as_mut_ptr(), children.len())
+        };
+        let mut any_change = false;
+        let mut kept = 0usize;
+        for i in 0..len {
+            // SAFETY: `i` is in bounds of the children buffer.
+            let elem = unsafe { base.add(i) };
+            // SAFETY: `elem` holds a valid `IndexedChild`; `&raw mut` forms a
+            // pointer to its `inner` slot.
+            let inner = unsafe { &raw mut (*elem).inner };
+            // SAFETY: `inner` holds a valid, owned `S`; the helper rewrites it as
+            // a valid `S::Resumed<'a>` on `Unchanged`/`Moved`, and consumes it on
+            // `Aborted`/`Err`.
+            match unsafe { resume_child_slot_in_place(inner, guard) } {
+                Ok(outcome) => {
+                    match outcome {
+                        ResumeSlotOutcome::Unchanged => {}
+                        ResumeSlotOutcome::Moved => any_change = true,
+                        ResumeSlotOutcome::Aborted => {
+                            // Dropped from the union, as `revalidate` drops an
+                            // aborted child; the hole is compacted over by later
+                            // survivors.
+                            any_change = true;
+                            continue;
+                        }
+                    }
+                    if kept < i {
+                        // SAFETY: `kept < i < len`, both in bounds.
+                        let dst = unsafe { base.add(kept) };
+                        // SAFETY: slot `kept` was vacated (its element moved left
+                        // or was consumed) and `elem` holds a resumed child, so
+                        // this is a single-element move between disjoint,
+                        // in-bounds slots. `copy_nonoverlapping` is a move — the
+                        // source is treated as vacated from here on.
+                        unsafe {
+                            std::ptr::copy_nonoverlapping(
+                                elem.cast::<IndexedChild<S::Resumed<'a>>>().cast_const(),
+                                dst.cast::<IndexedChild<S::Resumed<'a>>>(),
+                                1,
+                            )
+                        };
+                    }
+                    kept += 1;
+                }
+                Err(e) => {
+                    // SAFETY: `children[..kept]` holds compacted resumed
+                    // survivors, `children[kept..=i]` holes or the consumed
+                    // element, `children[i + 1..]` still-suspended children — the
+                    // exact state the teardown documents; `raw` is exclusively
+                    // owned.
+                    unsafe { free_after_consumed_child::<S, QUICK_EXIT>(raw, kept, i) };
+                    return Err(e);
+                }
+            }
+        }
+        // SAFETY: `raw` is exclusively owned; the borrow is confined to this
+        // statement.
+        let children = unsafe { &mut (*raw).children };
+        // SAFETY: `children[..kept]` holds the compacted, initialised survivors
+        // and everything past it is vacated, so shrinking to `kept` describes
+        // exactly the live elements; `set_len` never drops, so the vacated tail
+        // is left alone. The stale `num_active` is clamped right after the cast
+        // below.
+        unsafe { children.set_len(kept) };
+
+        // Every survivor now sits in the compacted prefix in its resumed form, so
+        // the aggregate can be re-derived from them — the step that makes its
+        // entries usable again, rather than merely re-narrowed, and the last one
+        // before the cast. All `kept` of them are offered, including any parked
+        // past `num_active`, because an entry can point at any child the
+        // aggregate was built from.
+        {
+            // SAFETY: `base` addresses the `kept` compacted survivors, each a
+            // valid `IndexedChild<S::Resumed<'a>>` — same size and alignment as
+            // the `IndexedChild<S>` the buffer was allocated for, by `#[repr(C)]`
+            // over a child slot whose halves the slot helper statically enforces
+            // — and `raw` is exclusively owned, so the slice is unaliased.
+            let children = unsafe {
+                std::slice::from_raw_parts_mut(base.cast::<IndexedChild<S::Resumed<'a>>>(), kept)
+            };
+            // SAFETY: `raw` is exclusively owned and `result` is a valid
+            // suspended result in a field disjoint from the children buffer; the
+            // borrow is confined to this block.
+            let result = unsafe { &mut (*raw).result };
+            rederive_aggregate_entries(result, children.iter_mut().map(|c| &mut c.inner));
+        }
+
+        // SAFETY: every surviving child slot holds its resumed form inside the
+        // `Vec`'s untouched buffer, and the aggregate's entries have just been
+        // re-derived from those survivors (or cleared, if any of them could not
+        // be), so no entry is re-narrowed onto a freed, relocated, or merely
+        // retagged result; the remaining fields are `Rf`-free. Layout-identical
+        // to the suspended form by invariant 1 on `RawUnionFlat` (const proof
+        // above). `Box::from_raw` reuses the same allocation, so the FFI's cached
+        // `header.current` and any parent's pointer into `result` stay valid
+        // across the cycle.
+        let mut active =
+            unsafe { Box::from_raw(raw.cast::<UnionFlat<'a, S::Resumed<'a>, QUICK_EXIT>>()) };
+        // Aborted children shrank the vec; the active region cannot outgrow it.
+        active.num_active = active.num_active.min(active.children.len());
+
+        // From here on, mirror `revalidate` decision for decision — including
+        // the order the two questions are asked in. An already-finished union
+        // stays finished, whatever its children now report: `revalidate` returns
+        // before it looks at a single one, so asking "did they all abort?" first
+        // would tear down a spent union that `revalidate` leaves alone. Its
+        // position is preserved (`result.doc_id` rode along in the cast), exactly
+        // as `revalidate` leaves it. The children were still transitioned above —
+        // the one structural difference from `revalidate`, which never touches
+        // them.
+        if active.is_eof {
+            return Ok(ResumeOutcome::Ok(active));
+        }
+
+        // All children aborted → the union aborts (a union of nothing is
+        // nothing). `revalidate` also sets `is_eof` before reporting `Aborted`;
+        // here the box is dropped instead of handed back, so the flag has no
+        // observer.
+        if active.children.is_empty() {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        // Nothing moved or aborted: the children still sit on the positions the
+        // aggregate describes, so it stands as-is.
+        if !any_change {
+            return Ok(ResumeOutcome::Ok(active));
+        }
+
+        // Re-admit every child, including any parked past `num_active`: their own
+        // resume may have brought them back into play. The settle re-drops the
+        // still-exhausted ones and re-derives the union's position.
+        active.num_active = active.children.len();
+        Ok(
+            match active.settle_after_children_changed(original_last_doc_id)? {
+                SettleOutcome::Unchanged => ResumeOutcome::Ok(active),
+                // Both leave the union somewhere other than where it was; `Eof` has
+                // already set `is_eof`, so the caller sees no current either way.
+                SettleOutcome::Moved | SettleOutcome::Eof => ResumeOutcome::Moved(active),
+            },
+        )
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.num_estimated
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -10,10 +10,14 @@
 //! Flat array variant of the union iterator with O(n) min-finding.
 
 use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
-use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::union::SettleOutcome;
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+};
 use index_spec::IndexSpecReadGuard;
 
 /// A child iterator paired with its original insertion index.
@@ -167,6 +171,159 @@ where
     pub fn into_trimmed(self, limit: usize, asc: bool) -> Option<super::UnionTrimmed<'index, I>> {
         let children: Vec<I> = self.children.into_iter().map(|c| c.inner).collect();
         (children.len() >= 3).then(|| super::UnionTrimmed::new(children, limit, asc))
+    }
+
+    /// Settles the union's position after its children have moved, and reports where
+    /// that leaves it.
+    ///
+    /// The single place that decides a union's post-change position, shared by
+    /// [`RQEIterator::revalidate`] and
+    /// [`RQESuspendedIterator::resume`](crate::RQESuspendedIterator::resume) so the two
+    /// cannot drift apart — the legacy and the `Box<Self>` path must make the same
+    /// re-seek and moved-versus-unchanged decisions, and a divergence between them is a
+    /// bug. Each caller sets `num_active` first, because they disagree on it
+    /// legitimately: `revalidate` re-admits every child, while `resume` must keep the
+    /// live/dead split it rebuilt (a dead child's `last_doc_id` would otherwise be
+    /// picked up as a spurious minimum and yielded again).
+    ///
+    /// `original_last_doc_id` is the position the union held before the children moved.
+    fn settle_after_children_changed(
+        &mut self,
+        original_last_doc_id: DocId,
+    ) -> Result<SettleOutcome, RQEIteratorError> {
+        // Only a child that has run past its last result is dropped: one that has
+        // merely returned its final document still owes it, and dropping it would
+        // lose that document — or report EOF for the whole union, if it was the
+        // last active child.
+        let mut min_doc_id: DocId = DocId::MAX;
+        let mut min_child_idx: usize = 0;
+        let mut i = 0;
+        while i < self.num_active {
+            let child = &self.children[i];
+            if child.at_eof() {
+                self.swap_remove_child(i);
+                // Don't increment i - check the swapped-in child
+            } else {
+                let child_doc_id = child.last_doc_id();
+                if child_doc_id < min_doc_id {
+                    min_doc_id = child_doc_id;
+                    min_child_idx = i;
+                }
+                i += 1;
+            }
+        }
+
+        // Every remaining child is at EOF.
+        if self.num_active == 0 {
+            self.is_eof = true;
+            return Ok(SettleOutcome::Eof);
+        }
+
+        // Without `QUICK_EXIT` no child can fall behind the union: every active child
+        // is advanced on every `read`/`skip_to`, and a child's own `revalidate` may only
+        // move it forward — one that has run past its end reports no `current` and was
+        // dropped by the scan above. So the minimum is at worst *equal* to the current
+        // position, which is simply a child still sitting on the document it supplied.
+        debug_assert!(
+            QUICK_EXIT || min_doc_id >= original_last_doc_id,
+            "a full union's child cannot fall behind it: {min_doc_id} < {original_last_doc_id}",
+        );
+
+        // With `QUICK_EXIT` it can: `skip_to_quick` returns on the first exact match, so
+        // a later sibling keeps an earlier round's id, or answers 0 having never been
+        // read at all. Such a minimum is not a position to move to — adopting it would
+        // replay documents, because a reported move has the caller emit `current` in
+        // place of a read and the read after that resumes from there. `iterator_api.h`
+        // says `VALIDATE_MOVED` means the position moved *forward*, and
+        // `Not::revalidate` asserts that of its child — which is where a `QUICK_EXIT`
+        // union usually sits.
+        //
+        // `QUICK_EXIT` is a const generic, so a full union compiles this away entirely
+        // rather than paying for a comparison that its invariant already rules out.
+        if QUICK_EXIT && min_doc_id < original_last_doc_id {
+            // The result has to be republished either way, because it holds raw pointers
+            // into the children's own results: one that moved leaves it describing
+            // another document, and one that aborted was dropped above and leaves it
+            // dangling. What it can be republished *from* decides the outcome.
+            if self.republish_at(original_last_doc_id) {
+                // Still backed, so the union has not moved and its current stands.
+                debug_assert_eq!(
+                    self.last_doc_id(),
+                    original_last_doc_id,
+                    "staying put must leave the position untouched",
+                );
+
+                return Ok(SettleOutcome::Unchanged);
+            }
+
+            // Nothing is left on the union's document: the child that supplied it has
+            // moved on too. Reporting no change would promise a `current` that no child
+            // backs.
+            //
+            // So the union advances instead, which is what it would have done on the next
+            // read anyway — `read_quick` targets `last_doc_id() + 1` and seeks every
+            // lagging child past it, including the one whose position was rejected here.
+            // Skipping over the abandoned document costs nothing: it has already been
+            // delivered, and a quick union never promised to aggregate every child that
+            // holds it, so no contribution is dropped by leaving it behind.
+            //
+            // This is the one place settling reads. An `Err` here reaches the caller as
+            // `VALIDATE_ABORTED`, which frees the iterator and substitutes an empty one —
+            // the failure is reported, if bluntly, which beats publishing a result that
+            // describes nothing.
+            return Ok(if self.read_quick()?.is_some() {
+                SettleOutcome::Moved
+            } else {
+                // Seeking past the abandoned position ran the union out of documents.
+                SettleOutcome::Eof
+            });
+        }
+
+        // Rebuild result at the new minimum doc_id
+        if QUICK_EXIT {
+            self.quick_set_from_child(min_child_idx);
+        } else {
+            self.build_aggregate_result(min_doc_id);
+        }
+
+        if self.last_doc_id() == original_last_doc_id {
+            return Ok(SettleOutcome::Unchanged);
+        }
+
+        debug_assert!(
+            self.last_doc_id() > original_last_doc_id,
+            "a reported move must be forward",
+        );
+
+        Ok(SettleOutcome::Moved)
+    }
+
+    /// Republishes the result at `doc_id`, returning whether any active child backs it.
+    ///
+    /// From a *single* child in `QUICK_EXIT` mode — the full aggregate is what that mode
+    /// exists to avoid — and from every child holding `doc_id` otherwise.
+    ///
+    /// Full mode always answers `true`: its children never fall behind, so the only
+    /// position it is ever asked to republish is one a child still holds.
+    fn republish_at(&mut self, doc_id: DocId) -> bool {
+        if QUICK_EXIT {
+            // The minimum's index cannot serve here: that is the lagging child whose
+            // position was rejected. Every child in the active region has a `current`
+            // (the scan dropped the rest), so finding one by position is enough.
+            match self.children[..self.num_active]
+                .iter()
+                .position(|c| c.last_doc_id() == doc_id)
+            {
+                Some(idx) => {
+                    self.quick_set_from_child(idx);
+                    true
+                }
+                None => false,
+            }
+        } else {
+            self.build_aggregate_result(doc_id);
+            true
+        }
     }
 
     /// Swap-removes an exhausted child at `idx` by swapping it with the last active child.
@@ -643,130 +800,19 @@ where
             return Ok(RQEValidateStatus::Ok);
         }
 
-        // Sync num_active and find minimum doc_id.
-        // Use swap_remove_child to move EOF children out of the active region.
+        // Re-admit every child, including any parked past `num_active`: their own
+        // revalidation may have brought them back into play.
         self.num_active = self.children.len();
 
-        // Only a child that has run past its last result is dropped: one that has
-        // merely returned its final document still owes it, and dropping it would
-        // lose that document — or report EOF for the whole union, if it was the
-        // last active child.
-        let mut min_doc_id: DocId = DocId::MAX;
-        let mut min_child_idx: usize = 0;
-        let mut i = 0;
-        while i < self.num_active {
-            let child = &self.children[i];
-            if child.at_eof() {
-                self.swap_remove_child(i);
-                // Don't increment i - check the swapped-in child
-            } else {
-                let child_doc_id = child.last_doc_id();
-                if child_doc_id < min_doc_id {
-                    min_doc_id = child_doc_id;
-                    min_child_idx = i;
-                }
-                i += 1;
-            }
-        }
-
-        // Check if all remaining children are at EOF
-        if self.num_active == 0 {
-            self.is_eof = true;
-            return Ok(RQEValidateStatus::Moved { current: None });
-        }
-
-        // Without `QUICK_EXIT` no child can fall behind the union: every active child
-        // is advanced on every `read`/`skip_to`, and a child's own `revalidate` may only
-        // move it forward — one that has run past its end reports no `current` and was
-        // dropped by the scan above. So the minimum is at worst *equal* to the current
-        // position, which is simply a child still sitting on the document it supplied.
-        debug_assert!(
-            QUICK_EXIT || min_doc_id >= original_last_doc_id,
-            "a full union's child cannot fall behind it: {min_doc_id} < {original_last_doc_id}",
-        );
-
-        // With `QUICK_EXIT` it can: `skip_to_quick` returns on the first exact match, so
-        // a later sibling keeps an earlier round's id, or answers 0 having never been
-        // read at all. Such a minimum is not a position to move to — adopting it would
-        // replay documents, because `VALIDATE_MOVED` has the caller emit `current` in
-        // place of a read and the read after that resumes from there. `iterator_api.h`
-        // says `VALIDATE_MOVED` means the position moved *forward*, and
-        // `Not::revalidate` asserts that of its child — which is where a `QUICK_EXIT`
-        // union usually sits.
-        //
-        // `QUICK_EXIT` is a const generic, so a full union compiles this away entirely
-        // rather than paying for a comparison that its invariant already rules out.
-        if QUICK_EXIT && min_doc_id < original_last_doc_id {
-            // The result has to be republished either way, because it holds raw pointers
-            // into the children's own results: one that moved leaves it describing
-            // another document, and one that aborted was dropped above and leaves it
-            // dangling. What it can be republished *from* decides the outcome.
-            //
-            // From a *single* child, as everywhere else in this mode — the full aggregate
-            // is what `QUICK_EXIT` exists to avoid. `min_child_idx` cannot serve: that is
-            // the lagging child just rejected, sitting at `min_doc_id`. So the child
-            // still on the current position is looked up instead. Every child in the
-            // active region has a `current` (the scan above dropped the rest), so finding
-            // one by position is enough.
-            if let Some(idx) = self.children[..self.num_active]
-                .iter()
-                .position(|c| c.last_doc_id() == original_last_doc_id)
-            {
-                // Still backed, so the union has not moved and its current stands.
-                self.quick_set_from_child(idx);
-
-                debug_assert_eq!(
-                    self.last_doc_id(),
-                    original_last_doc_id,
-                    "staying put must leave the position untouched",
-                );
-
-                return Ok(RQEValidateStatus::Ok);
-            }
-
-            // Nothing is left on the union's document: the child that supplied it has
-            // moved on too. Reporting `Ok` would promise a `current` that no child backs.
-            //
-            // So the union advances instead, which is what it would have done on the next
-            // read anyway — `read_quick` targets `last_doc_id() + 1` and seeks every
-            // lagging child past it, including the one whose position was rejected here.
-            // Skipping over the abandoned document costs nothing: it has already been
-            // delivered, and a quick union never promised to aggregate every child that
-            // holds it, so no contribution is dropped by leaving it behind.
-            //
-            // This is the one place a `QUICK_EXIT` revalidation reads. An `Err` here
-            // reaches the caller as `VALIDATE_ABORTED`, which frees the iterator and
-            // substitutes an empty one — the failure is reported, if bluntly, which beats
-            // publishing a result that describes nothing.
-            return match self.read_quick()? {
-                Some(result) => Ok(RQEValidateStatus::Moved {
-                    current: Some(result),
-                }),
-                // Seeking past the abandoned position ran the union out of documents.
-                None => Ok(RQEValidateStatus::Moved { current: None }),
-            };
-        }
-
-        // Rebuild result at the new minimum doc_id
-        if QUICK_EXIT {
-            self.quick_set_from_child(min_child_idx);
-        } else {
-            self.build_aggregate_result(min_doc_id);
-        }
-
-        // Return MOVED only if lastDocId changed
-        if self.last_doc_id() == original_last_doc_id {
-            return Ok(RQEValidateStatus::Ok);
-        }
-
-        debug_assert!(
-            self.last_doc_id() > original_last_doc_id,
-            "a reported move must be forward",
-        );
-
-        Ok(RQEValidateStatus::Moved {
-            current: Some(&mut self.result),
-        })
+        Ok(
+            match self.settle_after_children_changed(original_last_doc_id)? {
+                SettleOutcome::Unchanged => RQEValidateStatus::Ok,
+                SettleOutcome::Moved => RQEValidateStatus::Moved {
+                    current: Some(&mut self.result),
+                },
+                SettleOutcome::Eof => RQEValidateStatus::Moved { current: None },
+            },
+        )
     }
 
     #[inline(always)]
@@ -780,6 +826,166 @@ where
         } else {
             1.0
         }
+    }
+}
+
+impl<'index, I, const QUICK_EXIT: bool> RQEIteratorBoxed<'index>
+    for UnionFlat<'index, I, QUICK_EXIT>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawUnionFlat<'index, Suspended, I::Suspended, QUICK_EXIT>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Walk children: dispatch each child's `suspend` through the trait
+        // so dyn-erased `I` (e.g. [`TypeErasedRQEIterator`](crate::TypeErasedRQEIterator))
+        // correctly transitions its vtable. For concrete-typed `I` this is
+        // the same whole-box cast that would otherwise happen at the outer
+        // level, just per-child.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` and is exclusively owned
+        // for the rest of this function, so the children Vec is reachable
+        // and unaliased.
+        let children: &mut Vec<IndexedChild<I>> = unsafe { &mut (*raw).children };
+        for child in children.iter_mut() {
+            // SAFETY: `child.inner` is a valid `I` accessed via a fresh
+            // `&mut`; the function leaves the slot in a valid
+            // `I::Suspended` state.
+            unsafe { crate::boxed::suspend_child_slot_in_place(&mut child.inner) };
+        }
+        // SAFETY: `RawUnionFlat` is `#[repr(C)]` over `Vec<IndexedChild<I>>`
+        // (now byte-rewritten with `I::Suspended` payloads) and
+        // `result: RawIndexResult<Rf>` (layout-compatible via `SharedPtr`).
+        unsafe {
+            Box::from_raw(raw as *mut RawUnionFlat<'index, Suspended, I::Suspended, QUICK_EXIT>)
+        }
+    }
+}
+
+impl<'query, S, const QUICK_EXIT: bool> RQESuspendedIterator<'query>
+    for RawUnionFlat<'query, Suspended, S, QUICK_EXIT>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = UnionFlat<'a, S::Resumed<'a>, QUICK_EXIT>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let RawUnionFlat {
+            children,
+            num_active,
+            num_estimated,
+            is_eof,
+            result,
+        } = *self;
+
+        // Read plain-data fields off the suspended aggregate before
+        // discarding it — the suspended aggregate's borrowed children
+        // pointers would dangle after we consume the children by value.
+        let saved_weight = result.weight;
+        let saved_last_doc_id = result.doc_id;
+        drop(result);
+
+        // `swap_remove_child` keeps EOF children in the Vec at indices
+        // `[num_active..]` so [`rewind`](RQEIterator::rewind) can sort them
+        // back into the active set. Resume must preserve that split: the
+        // tail children stay in their resumed-active form so they survive
+        // a future rewind, but they don't count toward `num_active` (their
+        // last_doc_id would otherwise be picked up as a spurious min and
+        // yielded again after the live children exhaust).
+        //
+        // No need to track whether any child moved: settling below re-finds the minimum
+        // unconditionally, and reports `Unchanged` when it turns out to be where the
+        // union already was.
+        let mut live: Vec<IndexedChild<S::Resumed<'a>>> = Vec::with_capacity(num_active);
+        let mut dead: Vec<IndexedChild<S::Resumed<'a>>> =
+            Vec::with_capacity(children.len().saturating_sub(num_active));
+        for (
+            i,
+            IndexedChild {
+                original_index,
+                inner,
+            },
+        ) in children.into_iter().enumerate()
+        {
+            let active_inner = match Box::new(inner).resume(guard)? {
+                ResumeOutcome::Aborted => continue,
+                ResumeOutcome::Moved(active_inner) | ResumeOutcome::Ok(active_inner) => {
+                    *active_inner
+                }
+            };
+            let resumed = IndexedChild {
+                original_index,
+                inner: active_inner,
+            };
+            if i < num_active {
+                live.push(resumed);
+            } else {
+                dead.push(resumed);
+            }
+        }
+        let num_children = live.len();
+        let mut active_children = live;
+        active_children.extend(dead);
+        let result = RSIndexResult::build_union(num_children)
+            .weight(saved_weight)
+            .build();
+
+        let mut active: Box<UnionFlat<'a, S::Resumed<'a>, QUICK_EXIT>> = Box::new(UnionFlat {
+            children: active_children,
+            num_active: num_children,
+            num_estimated,
+            is_eof,
+            result,
+        });
+
+        if active.is_eof || saved_last_doc_id == 0 {
+            return Ok(ResumeOutcome::Ok(active));
+        }
+
+        // `num_children == 0` here means every previously-live child
+        // ABORTED during resume (children that reached EOF naturally went
+        // into `dead` and don't count toward `num_children`). The union
+        // has no recoverable state.
+        if num_children == 0 {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        // The result was rebuilt from scratch above, so it has to be repopulated whether
+        // or not a child moved — which is why this settles unconditionally rather than
+        // short-circuiting on `any_change` the way `revalidate` can. With nothing moved
+        // the recomputed minimum *is* `saved_last_doc_id`, so settling reports
+        // `Unchanged`, and the special case would only be a second copy of logic that
+        // has to agree with the shared one.
+        //
+        // `num_active` was set to the live count above and must stay that way: the dead
+        // tail is kept for a later `rewind`, and re-admitting it here would let a dead
+        // child's position become a spurious minimum.
+        Ok(
+            match active.settle_after_children_changed(saved_last_doc_id)? {
+                SettleOutcome::Unchanged => ResumeOutcome::Ok(active),
+                // Both leave the union somewhere other than where it was; `Eof` has
+                // already set `is_eof`, so the caller sees no current either way.
+                SettleOutcome::Moved | SettleOutcome::Eof => ResumeOutcome::Moved(active),
+            },
+        )
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.num_estimated
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -10,11 +10,16 @@
 //! Heap variant of the union iterator with O(log n) min-finding.
 
 use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
+use crate::union::SettleOutcome;
 use crate::utils::DocIdMinHeap;
-use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+    boxed::{ResumeSlotOutcome, rederive_aggregate_entries, resume_child_slot_in_place},
+};
 use index_spec::IndexSpecReadGuard;
 
 /// Yields documents appearing in ANY child iterator using a binary heap.
@@ -58,6 +63,79 @@ pub struct RawUnionHeap<'query, Rf: Ref, I, const QUICK_EXIT: bool> {
 /// [`RQEIterator`] impl today.
 pub type UnionHeap<'index, I, const QUICK_EXIT: bool> =
     RawUnionHeap<'index, Active<'index>, I, QUICK_EXIT>;
+
+// Compile-time proof of invariant 1 on `RawUnionHeap`: for a representative
+// concrete child, the `Active` and `Suspended` instantiations are
+// layout-identical. The child elements' own compatibility is their invariant 1
+// (enforced generically by the slot helpers); `result` is layout-compatible
+// across `Rf` (proven in `index_result`); `heap` and the remaining fields are
+// `Rf`-free. `QUICK_EXIT` never affects layout.
+const _: () = {
+    use crate::Wildcard;
+    use std::mem::{align_of, offset_of, size_of};
+    type AChild = Wildcard<'static>;
+    type SChild = <Wildcard<'static> as RQEIteratorBoxed<'static>>::Suspended;
+    type A = RawUnionHeap<'static, Active<'static>, AChild, false>;
+    type S = RawUnionHeap<'static, Suspended, SChild, false>;
+    assert!(offset_of!(A, children) == offset_of!(S, children));
+    assert!(offset_of!(A, num_estimated) == offset_of!(S, num_estimated));
+    assert!(offset_of!(A, num_active) == offset_of!(S, num_active));
+    assert!(offset_of!(A, is_eof) == offset_of!(S, is_eof));
+    assert!(offset_of!(A, result) == offset_of!(S, result));
+    assert!(offset_of!(A, heap) == offset_of!(S, heap));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
+/// Frees a suspended [`RawUnionHeap`]'s reused allocation after the in-place
+/// resume consumed the child at `consumed`: drops the compacted resumed prefix
+/// `children[..kept]` in place and the still-suspended tail past `consumed`,
+/// skips the holes in between (moved-from or consumed), empties the `Vec` so it
+/// frees only its buffer, then drops the box (freeing the still-suspended
+/// `result`, the heap, and the allocation).
+///
+/// # Safety
+///
+/// * `raw` must be exclusively owned and have come from `Box::into_raw`.
+/// * `children[..kept]` must hold valid `S::Resumed<'a>` values,
+///   `children[kept..=consumed]` must be moved-from or consumed (they are not
+///   touched), and `children[consumed + 1..]` must hold valid `S` values — the
+///   exact state the in-place resume loop leaves behind when the slot helper
+///   reports `Err` for element `consumed`.
+unsafe fn free_after_consumed_child<'query, 'a, S, const QUICK_EXIT: bool>(
+    raw: *mut RawUnionHeap<'query, Suspended, S, QUICK_EXIT>,
+    kept: usize,
+    consumed: usize,
+) where
+    S: RQESuspendedIterator<'query>,
+    'query: 'a,
+{
+    // SAFETY: `raw` is exclusively owned (caller contract); the borrow is used
+    // only to reach the buffer pointer, the length, and `set_len`.
+    let children: &mut Vec<S> = unsafe { &mut (*raw).children };
+    let len = children.len();
+    let base = children.as_mut_ptr();
+    for i in 0..kept {
+        // SAFETY: `i` is in bounds of the children buffer.
+        let slot = unsafe { base.add(i) };
+        // SAFETY: the slot holds a valid resumed child (caller contract); drop
+        // it through the resumed type (same size/alignment, enforced by the
+        // slot helper's const guard).
+        unsafe { std::ptr::drop_in_place(slot.cast::<S::Resumed<'a>>()) };
+    }
+    for i in (consumed + 1)..len {
+        // SAFETY: `i` is in bounds of the children buffer.
+        let slot = unsafe { base.add(i) };
+        // SAFETY: the slot still holds a valid suspended child.
+        unsafe { std::ptr::drop_in_place(slot) };
+    }
+    // SAFETY: every element was dropped, moved, or consumed; zeroing the length
+    // keeps the `Vec` from dropping them again — it frees only its buffer.
+    unsafe { children.set_len(0) };
+    // SAFETY: `raw` is a well-formed suspended union again (empty children,
+    // still-suspended `result`, `Rf`-free scalars and heap); reclaim and drop it.
+    drop(unsafe { Box::from_raw(raw) });
+}
 
 // Methods used in both modes.
 impl<'index, I, const QUICK_EXIT: bool> UnionHeap<'index, I, QUICK_EXIT>
@@ -140,6 +218,138 @@ where
                 self.heap.push(child.last_doc_id(), idx);
             }
         }
+    }
+
+    /// Settles the union's position after its children have moved, and reports where
+    /// that leaves it.
+    ///
+    /// The single place that decides a union's post-change position, shared by
+    /// [`RQEIterator::revalidate`] and
+    /// [`RQESuspendedIterator::resume`] so the two
+    /// cannot drift apart — the legacy and the `Box<Self>` path must make the same
+    /// re-seek and moved-versus-unchanged decisions, and a divergence between them is a
+    /// bug. Each caller rebuilds the heap and sets `num_active` first, re-admitting
+    /// every child: a child revalidation can bring a parked child back into play,
+    /// and `rebuild_heap` leaves out the ones that are still exhausted.
+    ///
+    /// `original_last_doc_id` is the position the union held before the children moved.
+    fn settle_after_children_changed(
+        &mut self,
+        original_last_doc_id: DocId,
+    ) -> Result<SettleOutcome, RQEIteratorError> {
+        let Some(mut min) = self.heap.peek() else {
+            self.is_eof = true;
+            return Ok(SettleOutcome::Eof);
+        };
+
+        // A minimum *behind* the union is not a position to move to — adopting it
+        // would replay documents, because a reported move has the caller emit
+        // `current` in place of a read and the read after that resumes from there.
+        // `iterator_api.h` says `VALIDATE_MOVED` means the position moved
+        // *forward*, and `Not::revalidate` asserts that of its child — which is
+        // where a `QUICK_EXIT` union usually sits.
+        //
+        // Both modes can see one. With `QUICK_EXIT` it is the mode's own early
+        // return: `rebuild_heap` keys on `last_doc_id()`, which answers 0 for a
+        // child that has never been read and an earlier round's id for one that
+        // `advance_lagging_children` left in the heap when it returned on an exact
+        // match. Without it there is exactly one way: a child that ran out and was
+        // dropped can *resurrect* during a revalidation — an inverted-index leaf
+        // rewinds and re-seeks the position it held, and rewinding clears the
+        // past-the-end state — so `rebuild_heap` re-admits it far behind a union
+        // that carried on without it.
+        if min.doc_id < original_last_doc_id {
+            // A child still sitting on the union's document backs the position as
+            // it stands: republish from it (the result holds raw pointers into
+            // children that may have moved or been dropped) and report no change,
+            // with no reads spent. `min.child_idx` cannot serve — that is the
+            // lagging child just rejected. Quick mode only: its laggers are
+            // ordinary state for the next `read`/`skip_to` to seek past, while a
+            // full union must catch them up below either way —
+            // `advance_matching_children` and `build_aggregate_result` rely on
+            // the root not sitting behind the union.
+            if QUICK_EXIT
+                && let Some(idx) = self
+                    .children
+                    .iter()
+                    .position(|c| !c.at_eof() && c.last_doc_id() == original_last_doc_id)
+            {
+                self.quick_set_from_child(idx);
+
+                debug_assert_eq!(
+                    self.last_doc_id(),
+                    original_last_doc_id,
+                    "staying put must leave the position untouched",
+                );
+
+                return Ok(SettleOutcome::Unchanged);
+            }
+
+            // Nothing already sits on the union's document, but a lagging child
+            // may still *hold* it: the early return that stranded it never
+            // consumed its position. The union may not step over the document
+            // before asking — under a `NOT`, its position is not a delivered
+            // result but the next id the `NOT` has yet to exclude, and stepping
+            // over it would let that document into the result set. So the laggers
+            // are seeked to the abandoned position itself, not past it — which is
+            // exactly `advance_lagging_children`, down to quick mode's early
+            // return on the child that lands there.
+            //
+            // These reads cannot be avoided. An `Err` here reaches the caller as
+            // `VALIDATE_ABORTED`, freeing the iterator and substituting an empty
+            // one — blunt, but better than handing out a position no child backs.
+            let early_match = self.advance_lagging_children(original_last_doc_id)?;
+            if QUICK_EXIT && early_match != usize::MAX {
+                // Still matched after all: the union stays on it, backed by this
+                // child; remaining laggers wait for the next call.
+                self.quick_set_from_child(early_match);
+
+                debug_assert_eq!(
+                    self.last_doc_id(),
+                    original_last_doc_id,
+                    "staying put must leave the position untouched",
+                );
+
+                return Ok(SettleOutcome::Unchanged);
+            }
+
+            min = match self.heap.peek() {
+                Some(min) => min,
+                // Seeking the laggers forward ran the union out of documents.
+                None => {
+                    self.is_eof = true;
+                    return Ok(SettleOutcome::Eof);
+                }
+            };
+
+            // Every child left in the heap now sits at or past the abandoned
+            // position, so the root is a position again: equal to it when
+            // children still match the document (full mode only — quick mode
+            // returned above), later otherwise.
+            debug_assert!(
+                min.doc_id >= original_last_doc_id,
+                "every lagging child was just seeked to the union's position",
+            );
+        }
+
+        let min_doc_id = min.doc_id;
+        let min_child_idx = min.child_idx;
+        if QUICK_EXIT {
+            self.quick_set_from_child(min_child_idx);
+        } else {
+            self.build_aggregate_result(min_doc_id);
+        }
+
+        if self.last_doc_id() == original_last_doc_id {
+            return Ok(SettleOutcome::Unchanged);
+        }
+
+        debug_assert!(
+            self.last_doc_id() > original_last_doc_id,
+            "a reported move must be forward",
+        );
+
+        Ok(SettleOutcome::Moved)
     }
 
     /// Advances all lagging children in the heap to at least `doc_id`.
@@ -555,119 +765,15 @@ where
         self.rebuild_heap();
         self.num_active = self.heap.len();
 
-        let Some(mut min) = self.heap.peek() else {
-            self.is_eof = true;
-            return Ok(RQEValidateStatus::Moved { current: None });
-        };
-
-        // A minimum *behind* the union is not a position to move to — adopting it
-        // would replay documents, because `VALIDATE_MOVED` has the caller emit
-        // `current` in place of a read and the read after that resumes from there.
-        // `iterator_api.h` says `VALIDATE_MOVED` means the position moved *forward*,
-        // and `Not::revalidate` asserts that of its child — which is where a
-        // `QUICK_EXIT` union usually sits.
-        //
-        // Both modes can see one. With `QUICK_EXIT` it is the mode's own early
-        // return: `rebuild_heap` keys on `last_doc_id()`, which answers 0 for a child
-        // that has never been read and an earlier round's id for one that
-        // `advance_lagging_children` left in the heap when it returned on an exact
-        // match. Without it there is exactly one way: a child that ran out and was
-        // dropped can *resurrect* during the revalidation above — an inverted-index
-        // leaf rewinds and re-seeks the position it held, and rewinding clears the
-        // past-the-end state — so `rebuild_heap` re-admits it far behind a union that
-        // carried on without it.
-        if min.doc_id < original_last_doc_id {
-            // A child still sitting on the union's document backs the position as it
-            // stands: republish from it (the result holds raw pointers into children
-            // that may have moved or been dropped) and report `Ok`, with no reads
-            // spent. `min.child_idx` cannot serve — that is the lagging child just
-            // rejected. Quick mode only: its laggers are ordinary state for the next
-            // `read`/`skip_to` to seek past, while a full union must catch them up
-            // below either way — `advance_matching_children` and
-            // `build_aggregate_result` rely on the root not sitting behind the union.
-            if QUICK_EXIT
-                && let Some(idx) = self
-                    .children
-                    .iter()
-                    .position(|c| !c.at_eof() && c.last_doc_id() == original_last_doc_id)
-            {
-                self.quick_set_from_child(idx);
-
-                debug_assert_eq!(
-                    self.last_doc_id(),
-                    original_last_doc_id,
-                    "staying put must leave the position untouched",
-                );
-
-                return Ok(RQEValidateStatus::Ok);
-            }
-
-            // Nothing already sits on the union's document, but a lagging child may
-            // still *hold* it: the early return that stranded it never consumed its
-            // position. The union may not step over the document before asking —
-            // under a `NOT`, its position is not a delivered result but the next id
-            // the `NOT` has yet to exclude, and stepping over it would let that
-            // document into the result set. So the laggers are seeked to the
-            // abandoned position itself, not past it — which is exactly
-            // `advance_lagging_children`, down to quick mode's early return on the
-            // child that lands there.
-            //
-            // These reads cannot be avoided. An `Err` here reaches the caller as
-            // `VALIDATE_ABORTED`, freeing the iterator and substituting an empty one
-            // — blunt, but better than handing out a position no child backs.
-            let early_match = self.advance_lagging_children(original_last_doc_id)?;
-            if QUICK_EXIT && early_match != usize::MAX {
-                // Still matched after all: the union stays on it, backed by this
-                // child; remaining laggers wait for the next call.
-                self.quick_set_from_child(early_match);
-
-                debug_assert_eq!(
-                    self.last_doc_id(),
-                    original_last_doc_id,
-                    "staying put must leave the position untouched",
-                );
-
-                return Ok(RQEValidateStatus::Ok);
-            }
-
-            min = match self.heap.peek() {
-                Some(min) => min,
-                // Seeking the laggers forward ran the union out of documents.
-                None => {
-                    self.is_eof = true;
-                    return Ok(RQEValidateStatus::Moved { current: None });
-                }
-            };
-
-            // Every child left in the heap now sits at or past the abandoned
-            // position, so the root is a position again: equal to it when children
-            // still match the document (full mode only — quick mode returned above),
-            // later otherwise.
-            debug_assert!(
-                min.doc_id >= original_last_doc_id,
-                "every lagging child was just seeked to the union's position",
-            );
-        }
-
-        if QUICK_EXIT {
-            self.quick_set_from_child(min.child_idx);
-        } else {
-            self.build_aggregate_result(min.doc_id);
-        }
-
-        // Return MOVED only if lastDocId changed
-        if self.last_doc_id() == original_last_doc_id {
-            return Ok(RQEValidateStatus::Ok);
-        }
-
-        debug_assert!(
-            self.last_doc_id() > original_last_doc_id,
-            "a reported move must be forward",
-        );
-
-        Ok(RQEValidateStatus::Moved {
-            current: Some(&mut self.result),
-        })
+        Ok(
+            match self.settle_after_children_changed(original_last_doc_id)? {
+                SettleOutcome::Unchanged => RQEValidateStatus::Ok,
+                SettleOutcome::Moved => RQEValidateStatus::Moved {
+                    current: Some(&mut self.result),
+                },
+                SettleOutcome::Eof => RQEValidateStatus::Moved { current: None },
+            },
+        )
     }
 
     #[inline(always)]
@@ -681,6 +787,240 @@ where
         } else {
             1.0
         }
+    }
+}
+
+impl<'index, I, const QUICK_EXIT: bool> RQEIteratorBoxed<'index>
+    for UnionHeap<'index, I, QUICK_EXIT>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawUnionHeap<'index, Suspended, I::Suspended, QUICK_EXIT>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Walk children: dispatch each child's `suspend` through the trait
+        // so dyn-erased `I` correctly transitions its vtable. See
+        // [`crate::boxed::suspend_child_slot_in_place`] for the rationale.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` and is exclusively owned
+        // for the rest of this function, so the children Vec is reachable
+        // and unaliased.
+        let children: &mut Vec<I> = unsafe { &mut (*raw).children };
+        for child in children.iter_mut() {
+            // SAFETY: `child` is a valid `&mut I` aliased to nothing else;
+            // the function leaves the slot in a valid `I::Suspended` state.
+            unsafe { crate::boxed::suspend_child_slot_in_place(child) };
+        }
+        // SAFETY: `RawUnionHeap` is `#[repr(C)]` over `Vec<I>` (now byte-
+        // rewritten as `Vec<I::Suspended>` contents), `result:
+        // RawIndexResult<Rf>` (layout-compatible via `SharedPtr`), and
+        // a heap of plain doc-ids/indices (no `Rf` in its types).
+        unsafe {
+            Box::from_raw(raw as *mut RawUnionHeap<'index, Suspended, I::Suspended, QUICK_EXIT>)
+        }
+    }
+}
+
+impl<'query, S, const QUICK_EXIT: bool> RQESuspendedIterator<'query>
+    for RawUnionHeap<'query, Suspended, S, QUICK_EXIT>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = UnionHeap<'a, S::Resumed<'a>, QUICK_EXIT>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // The pre-resume position, read off the suspended form. Unlike
+        // `revalidate` there is no is-EOF return before the walk: the suspended
+        // children must be transitioned regardless of the outcome.
+        let original_last_doc_id = self.result.doc_id;
+
+        let raw = Box::into_raw(self);
+
+        // Resume every child *in place* — including the exhausted tail past
+        // `num_active`: a leaf can resurrect (its revalidation rewinds and
+        // re-seeks, clearing the past-the-end state), and `revalidate` re-admits
+        // such a child through `rebuild_heap` + the settle below, so resume must
+        // too. Aborted children are removed, mirroring `revalidate`'s
+        // swap_remove: survivors are compacted down over the holes.
+        //
+        // Whatever the walk does to the children, the suspended aggregate's
+        // entries are re-derived from the survivors before the cast — the one
+        // step that turns pointers whose addresses happen to have survived into
+        // usable references. An abort is where the addresses stop surviving too:
+        // the aborted child's result is freed outright, and the compaction
+        // relocates every survivor behind it, so for a concrete (non-boxed)
+        // child the result moves as well. Both show up there as an entry no live
+        // child answers for, and clear the aggregate rather than re-narrow it.
+        //
+        // A panic between slot transitions leaks the allocation (memory-safe);
+        // the slot helper guards its own moved-out window.
+        let (base, len) = {
+            // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+            // initialised, exclusively owned); the borrow is used only to reach
+            // the buffer pointer and length.
+            let children: &mut Vec<S> = unsafe { &mut (*raw).children };
+            (children.as_mut_ptr(), children.len())
+        };
+        let mut any_change = false;
+        let mut kept = 0usize;
+        for i in 0..len {
+            // SAFETY: `i` is in bounds of the children buffer.
+            let elem = unsafe { base.add(i) };
+            // SAFETY: `elem` holds a valid, owned `S`; the helper rewrites it as
+            // a valid `S::Resumed<'a>` on `Unchanged`/`Moved`, and consumes it
+            // on `Aborted`/`Err`.
+            match unsafe { resume_child_slot_in_place(elem, guard) } {
+                Ok(outcome) => {
+                    match outcome {
+                        ResumeSlotOutcome::Unchanged => {}
+                        ResumeSlotOutcome::Moved => any_change = true,
+                        ResumeSlotOutcome::Aborted => {
+                            // Dropped from the union, like `revalidate`'s
+                            // swap_remove of an aborted child; the hole is
+                            // compacted over by later survivors.
+                            any_change = true;
+                            continue;
+                        }
+                    }
+                    if kept < i {
+                        // SAFETY: slot `kept` was vacated (its element moved left
+                        // or was consumed); move the resumed element `i` into it.
+                        // `copy_nonoverlapping` is a move — the source is treated
+                        // as vacated from here on.
+                        // SAFETY: `kept < i < len`, both in bounds.
+                        let dst = unsafe { base.add(kept) };
+                        // SAFETY: single-element move between disjoint,
+                        // in-bounds slots.
+                        unsafe {
+                            std::ptr::copy_nonoverlapping(
+                                elem.cast::<S::Resumed<'a>>().cast_const(),
+                                dst.cast::<S::Resumed<'a>>(),
+                                1,
+                            )
+                        };
+                    }
+                    kept += 1;
+                }
+                Err(e) => {
+                    // SAFETY: `children[..kept]` holds compacted resumed
+                    // survivors, `children[kept..=i]` holes or the consumed
+                    // element, `children[i + 1..]` still-suspended children — the
+                    // exact state the teardown documents; `raw` is exclusively
+                    // owned.
+                    unsafe { free_after_consumed_child::<S, QUICK_EXIT>(raw, kept, i) };
+                    return Err(e);
+                }
+            }
+        }
+        // SAFETY: `children[..kept]` holds the compacted survivors; everything
+        // past it is vacated. `set_len` never drops, so shrinking to the
+        // survivors is sound. The stale `num_active` is clamped right after the
+        // cast below.
+        // SAFETY: `raw` is exclusively owned; the borrow is confined to this
+        // statement.
+        let children = unsafe { &mut (*raw).children };
+        // SAFETY: the first `kept` elements are initialised; `set_len` never
+        // drops.
+        unsafe { children.set_len(kept) };
+
+        // Every survivor now sits in the compacted prefix in its resumed form,
+        // so the aggregate can be re-derived from them — the step that makes its
+        // entries usable again, rather than merely re-narrowed, and the last one
+        // before the cast. All `kept` of them are offered, including the ones
+        // the heap left out as exhausted, because an entry can point at any
+        // child the aggregate was built from.
+        {
+            // SAFETY: `base` addresses the `kept` compacted survivors, each a
+            // valid `S::Resumed<'a>` — same size and alignment as the `S` the
+            // buffer was allocated for, statically enforced by
+            // `resume_child_slot_in_place` — and `raw` is exclusively owned, so
+            // the slice is unaliased.
+            let children =
+                unsafe { std::slice::from_raw_parts_mut(base.cast::<S::Resumed<'a>>(), kept) };
+            // SAFETY: `raw` is exclusively owned and `result` is a valid
+            // suspended result in a field disjoint from the children buffer; the
+            // borrow is confined to this block.
+            let result = unsafe { &mut (*raw).result };
+            rederive_aggregate_entries(result, children);
+        }
+
+        // SAFETY: every surviving child slot holds its resumed form inside the
+        // `Vec`'s buffer, and the aggregate's entries have just been re-derived
+        // from those survivors (or cleared, if any of them could not be), so no
+        // entry is re-narrowed onto a freed, relocated, or merely retagged
+        // result; `heap` and the remaining fields are `Rf`-free. Layout-identical
+        // to the suspended form by invariant 1 on `RawUnionHeap` (const proof
+        // above). `Box::from_raw` reuses the same allocation, so the FFI's cached
+        // `header.current` and any parent's pointer into `result` stay valid
+        // across the cycle.
+        let mut active =
+            unsafe { Box::from_raw(raw.cast::<UnionHeap<'a, S::Resumed<'a>, QUICK_EXIT>>()) };
+        // Aborted children shrank the vec; the active region cannot outgrow it.
+        // (The heap can hold stale entries after a compaction, but every path
+        // below that reads it either rebuilds it first or is gated on `is_eof`,
+        // and `rewind` clears it.)
+        active.num_active = active.num_active.min(active.children.len());
+
+        // From here on, mirror `revalidate` decision for decision — including
+        // the order the two questions are asked in. An already-finished union
+        // stays finished, whatever its children now report: `revalidate` returns
+        // before it looks at a single one, so asking "did they all abort?" first
+        // would tear down a spent union that `revalidate` leaves alone, and
+        // would answer `Aborted` for a union built with no children at all —
+        // a supported construction that starts at EOF. Its position is
+        // preserved (`result.doc_id` rode along in the cast), exactly as
+        // `revalidate` leaves it. The children were still transitioned above —
+        // the one structural difference from `revalidate`, which never touches
+        // them.
+        if active.is_eof {
+            return Ok(ResumeOutcome::Ok(active));
+        }
+
+        // All children aborted → the union aborts (a union of nothing is
+        // nothing). `revalidate` also sets `is_eof` before reporting `Aborted`;
+        // here the box is dropped instead of handed back, so the flag has no
+        // observer.
+        if active.children.is_empty() {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        // Nothing moved or aborted: the children still sit on the positions the
+        // aggregate and the heap describe, so both stand as-is.
+        if !any_change {
+            return Ok(ResumeOutcome::Ok(active));
+        }
+
+        // Re-admit every child, including any parked past `num_active`: their own
+        // resume may have brought them back into play. `rebuild_heap` leaves the
+        // still-exhausted ones out, and the settle re-derives the position.
+        active.rebuild_heap();
+        active.num_active = active.heap.len();
+        Ok(
+            match active.settle_after_children_changed(original_last_doc_id)? {
+                SettleOutcome::Unchanged => ResumeOutcome::Ok(active),
+                // Both leave the union somewhere other than where it was; `Eof` has
+                // already set `is_eof`, so the caller sees no current either way.
+                SettleOutcome::Moved | SettleOutcome::Eof => ResumeOutcome::Moved(active),
+            },
+        )
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.num_estimated
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -10,11 +10,15 @@
 //! Heap variant of the union iterator with O(log n) min-finding.
 
 use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
+use crate::union::SettleOutcome;
 use crate::utils::DocIdMinHeap;
-use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+};
 use index_spec::IndexSpecReadGuard;
 
 /// Yields documents appearing in ANY child iterator using a binary heap.
@@ -139,6 +143,124 @@ where
             if !child.at_eof() {
                 self.heap.push(child.last_doc_id(), idx);
             }
+        }
+    }
+
+    /// Settles the union's position after its children have moved, and reports where
+    /// that leaves it.
+    ///
+    /// The single place that decides a union's post-change position, shared by
+    /// [`RQEIterator::revalidate`] and
+    /// [`RQESuspendedIterator::resume`](crate::RQESuspendedIterator::resume) so the two
+    /// cannot drift apart — the legacy and the `Box<Self>` path must make the same
+    /// re-seek and moved-versus-unchanged decisions, and a divergence between them is a
+    /// bug. Each caller rebuilds the heap and sets `num_active` first.
+    ///
+    /// `original_last_doc_id` is the position the union held before the children moved.
+    fn settle_after_children_changed(
+        &mut self,
+        original_last_doc_id: DocId,
+    ) -> Result<SettleOutcome, RQEIteratorError> {
+        let Some(min) = self.heap.peek() else {
+            self.is_eof = true;
+            return Ok(SettleOutcome::Eof);
+        };
+
+        // Without `QUICK_EXIT` no child can fall behind the union: every child in the
+        // heap is advanced on every `read`/`skip_to`, and a child's own `revalidate` may
+        // only move it forward — one that has run past its end reports no `current` and
+        // is left out by `rebuild_heap`. So the minimum is at worst *equal* to the
+        // current position, which is simply a child still sitting on the document it
+        // supplied.
+        debug_assert!(
+            QUICK_EXIT || min.doc_id >= original_last_doc_id,
+            "a full union's child cannot fall behind it: {} < {original_last_doc_id}",
+            min.doc_id,
+        );
+
+        // With `QUICK_EXIT` it can: `rebuild_heap` keys on `last_doc_id()`, which answers
+        // 0 for a child that has never been read and an earlier round's id for one that
+        // `advance_lagging_children` left in the heap when it returned on an exact match.
+        // Such a minimum is not a position to move to — adopting it would replay
+        // documents, because a reported move has the caller emit `current` in place of a
+        // read and the read after that resumes from there.
+        //
+        // `QUICK_EXIT` is a const generic, so a full union compiles this away entirely
+        // rather than paying for a comparison that its invariant already rules out.
+        if QUICK_EXIT && min.doc_id < original_last_doc_id {
+            // The result has to be republished either way, because it holds raw pointers
+            // into the children's own results: one that moved leaves it describing
+            // another document, and one that aborted was dropped above and leaves it
+            // dangling. What it can be republished *from* decides the outcome.
+            if self.republish_at(original_last_doc_id) {
+                debug_assert_eq!(
+                    self.last_doc_id(),
+                    original_last_doc_id,
+                    "staying put must leave the position untouched",
+                );
+
+                return Ok(SettleOutcome::Unchanged);
+            }
+
+            // Nothing is left on the union's document: the child that supplied it has
+            // moved on too. Reporting no change would promise a `current` that no child
+            // backs, so the union advances instead — which is what the following read
+            // would have done anyway. Skipping over the abandoned document costs
+            // nothing: it has already been delivered, and a quick union never promised
+            // to aggregate every child that holds it.
+            return Ok(if self.read_quick()?.is_some() {
+                SettleOutcome::Moved
+            } else {
+                SettleOutcome::Eof
+            });
+        }
+
+        let min_doc_id = min.doc_id;
+        let min_child_idx = min.child_idx;
+        if QUICK_EXIT {
+            self.quick_set_from_child(min_child_idx);
+        } else {
+            self.build_aggregate_result(min_doc_id);
+        }
+
+        if self.last_doc_id() == original_last_doc_id {
+            return Ok(SettleOutcome::Unchanged);
+        }
+
+        debug_assert!(
+            self.last_doc_id() > original_last_doc_id,
+            "a reported move must be forward",
+        );
+
+        Ok(SettleOutcome::Moved)
+    }
+
+    /// Republishes the result at `doc_id`, returning whether any child backs it.
+    ///
+    /// From a *single* child in `QUICK_EXIT` mode — the full aggregate is what that mode
+    /// exists to avoid — and by descending the heap otherwise.
+    ///
+    /// Full mode always answers `true`: its children never fall behind, so the only
+    /// position it is ever asked to republish is the heap's own minimum.
+    fn republish_at(&mut self, doc_id: DocId) -> bool {
+        if QUICK_EXIT {
+            // The minimum's index cannot serve here: that is the lagging child whose
+            // position was rejected. A child the heap left out holds nothing to
+            // contribute, so `at_eof` filters it.
+            match self
+                .children
+                .iter()
+                .position(|c| !c.at_eof() && c.last_doc_id() == doc_id)
+            {
+                Some(idx) => {
+                    self.quick_set_from_child(idx);
+                    true
+                }
+                None => false,
+            }
+        } else {
+            self.build_aggregate_result(doc_id);
+            true
         }
     }
 
@@ -561,101 +683,15 @@ where
         self.rebuild_heap();
         self.num_active = self.heap.len();
 
-        let Some(min) = self.heap.peek() else {
-            self.is_eof = true;
-            return Ok(RQEValidateStatus::Moved { current: None });
-        };
-
-        // Without `QUICK_EXIT` no child can fall behind the union: every child in the
-        // heap is advanced on every `read`/`skip_to`, and a child's own `revalidate` may
-        // only move it forward — one that has run past its end reports no `current` and
-        // is left out by `rebuild_heap`. So the minimum is at worst *equal* to the
-        // current position, which is simply a child still sitting on the document it
-        // supplied.
-        debug_assert!(
-            QUICK_EXIT || min.doc_id >= original_last_doc_id,
-            "a full union's child cannot fall behind it: {} < {original_last_doc_id}",
-            min.doc_id,
-        );
-
-        // With `QUICK_EXIT` it can: `rebuild_heap` keys on `last_doc_id()`, which answers
-        // 0 for a child that has never been read and an earlier round's id for one that
-        // `advance_lagging_children` left in the heap when it returned on an exact match.
-        // Such a minimum is not a position to move to — adopting it would replay
-        // documents, because `VALIDATE_MOVED` has the caller emit `current` in place of a
-        // read and the read after that resumes from there. `iterator_api.h` says
-        // `VALIDATE_MOVED` means the position moved *forward*, and `Not::revalidate`
-        // asserts that of its child — which is where a `QUICK_EXIT` union usually sits.
-        //
-        // The result has to be republished either way, because it holds raw pointers into
-        // the children's own results — one that moved leaves it describing another
-        // document, and one that aborted was dropped above and leaves it dangling. What
-        // it can be republished *from* decides the outcome. From a single child, as
-        // everywhere else in this mode: `min.child_idx` cannot serve, being the lagging
-        // child just rejected, so the one still on the current position is looked up.
-        //
-        // `QUICK_EXIT` is a const generic, so a full union compiles this away entirely
-        // rather than paying for a comparison that its invariant already rules out.
-        if QUICK_EXIT && min.doc_id < original_last_doc_id {
-            if let Some(idx) = self
-                .children
-                .iter()
-                .position(|c| !c.at_eof() && c.last_doc_id() == original_last_doc_id)
-            {
-                // Still backed, so the union has not moved and its current stands.
-                self.quick_set_from_child(idx);
-
-                debug_assert_eq!(
-                    self.last_doc_id(),
-                    original_last_doc_id,
-                    "staying put must leave the position untouched",
-                );
-
-                return Ok(RQEValidateStatus::Ok);
-            }
-
-            // Nothing is left on the union's document: the child that supplied it has
-            // moved on too. Reporting `Ok` would promise a `current` that no child backs.
-            //
-            // So the union advances instead, which is what it would have done on the next
-            // read anyway — `read_quick` targets `last_doc_id() + 1` and seeks every
-            // lagging child past it, including the one whose position was rejected here.
-            // Skipping over the abandoned document costs nothing: it has already been
-            // delivered, and a quick union never promised to aggregate every child that
-            // holds it, so no contribution is dropped by leaving it behind.
-            //
-            // This is the one place a `QUICK_EXIT` revalidation reads. An `Err` here
-            // reaches the caller as `VALIDATE_ABORTED`, which frees the iterator and
-            // substitutes an empty one — the failure is reported, if bluntly, which beats
-            // publishing a result that describes nothing.
-            return match self.read_quick()? {
-                Some(result) => Ok(RQEValidateStatus::Moved {
-                    current: Some(result),
-                }),
-                // Seeking past the abandoned position ran the union out of documents.
-                None => Ok(RQEValidateStatus::Moved { current: None }),
-            };
-        }
-
-        if QUICK_EXIT {
-            self.quick_set_from_child(min.child_idx);
-        } else {
-            self.build_aggregate_result(min.doc_id);
-        }
-
-        // Return MOVED only if lastDocId changed
-        if self.last_doc_id() == original_last_doc_id {
-            return Ok(RQEValidateStatus::Ok);
-        }
-
-        debug_assert!(
-            self.last_doc_id() > original_last_doc_id,
-            "a reported move must be forward",
-        );
-
-        Ok(RQEValidateStatus::Moved {
-            current: Some(&mut self.result),
-        })
+        Ok(
+            match self.settle_after_children_changed(original_last_doc_id)? {
+                SettleOutcome::Unchanged => RQEValidateStatus::Ok,
+                SettleOutcome::Moved => RQEValidateStatus::Moved {
+                    current: Some(&mut self.result),
+                },
+                SettleOutcome::Eof => RQEValidateStatus::Moved { current: None },
+            },
+        )
     }
 
     #[inline(always)]
@@ -669,6 +705,152 @@ where
         } else {
             1.0
         }
+    }
+}
+
+impl<'index, I, const QUICK_EXIT: bool> RQEIteratorBoxed<'index>
+    for UnionHeap<'index, I, QUICK_EXIT>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawUnionHeap<'index, Suspended, I::Suspended, QUICK_EXIT>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Walk children: dispatch each child's `suspend` through the trait
+        // so dyn-erased `I` correctly transitions its vtable. See
+        // [`crate::boxed::suspend_child_slot_in_place`] for the rationale.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` and is exclusively owned
+        // for the rest of this function, so the children Vec is reachable
+        // and unaliased.
+        let children: &mut Vec<I> = unsafe { &mut (*raw).children };
+        for child in children.iter_mut() {
+            // SAFETY: `child` is a valid `&mut I` aliased to nothing else;
+            // the function leaves the slot in a valid `I::Suspended` state.
+            unsafe { crate::boxed::suspend_child_slot_in_place(child) };
+        }
+        // SAFETY: `RawUnionHeap` is `#[repr(C)]` over `Vec<I>` (now byte-
+        // rewritten as `Vec<I::Suspended>` contents), `result:
+        // RawIndexResult<Rf>` (layout-compatible via `SharedPtr`), and
+        // a heap of plain doc-ids/indices (no `Rf` in its types).
+        unsafe {
+            Box::from_raw(raw as *mut RawUnionHeap<'index, Suspended, I::Suspended, QUICK_EXIT>)
+        }
+    }
+}
+
+impl<'query, S, const QUICK_EXIT: bool> RQESuspendedIterator<'query>
+    for RawUnionHeap<'query, Suspended, S, QUICK_EXIT>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = UnionHeap<'a, S::Resumed<'a>, QUICK_EXIT>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let RawUnionHeap {
+            children,
+            num_estimated,
+            num_active,
+            is_eof,
+            result,
+            heap: _,
+        } = *self;
+
+        let saved_weight = result.weight;
+        let saved_last_doc_id = result.doc_id;
+        drop(result);
+
+        // `swap_remove_child` keeps EOF children in the Vec at indices
+        // `[num_active..]` so [`rewind`](RQEIterator::rewind) can restore
+        // them to active. Resume must preserve that split: tail children
+        // stay in their resumed-active form so a future rewind picks them
+        // up, but they don't count toward `num_active` (their last_doc_id
+        // would otherwise be re-inserted into the heap and yielded again
+        // after the live children exhaust).
+        // No need to track whether any child moved: settling below re-finds the minimum
+        // unconditionally, and reports `Unchanged` when it turns out to be where the
+        // union already was.
+        let mut live: Vec<S::Resumed<'a>> = Vec::with_capacity(num_active);
+        let mut dead: Vec<S::Resumed<'a>> =
+            Vec::with_capacity(children.len().saturating_sub(num_active));
+        for (i, inner) in children.into_iter().enumerate() {
+            let active_inner = match Box::new(inner).resume(guard)? {
+                ResumeOutcome::Aborted => continue,
+                ResumeOutcome::Moved(active_inner) | ResumeOutcome::Ok(active_inner) => {
+                    *active_inner
+                }
+            };
+            if i < num_active {
+                live.push(active_inner);
+            } else {
+                dead.push(active_inner);
+            }
+        }
+        let num_children = live.len();
+        let mut active_children = live;
+        active_children.extend(dead);
+        let result = RSIndexResult::build_union(num_children)
+            .weight(saved_weight)
+            .build();
+
+        let mut active: Box<UnionHeap<'a, S::Resumed<'a>, QUICK_EXIT>> = Box::new(UnionHeap {
+            children: active_children,
+            num_estimated,
+            num_active: num_children,
+            is_eof,
+            result,
+            heap: DocIdMinHeap::with_capacity(num_children),
+        });
+
+        if active.is_eof || saved_last_doc_id == 0 {
+            return Ok(ResumeOutcome::Ok(active));
+        }
+
+        if num_children == 0 {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        // The heap was emptied with the suspended form, so it has to be rebuilt whether
+        // or not a child moved — which is why this settles unconditionally rather than
+        // short-circuiting on `any_change` the way `revalidate` can. With nothing moved
+        // the recomputed minimum *is* `saved_last_doc_id`, so settling reports
+        // `Unchanged`, and the special case would only be a second copy of logic that
+        // has to agree with the shared one.
+        let mut num_active = 0usize;
+        for (idx, child) in active.children.iter().enumerate() {
+            if !child.at_eof() {
+                active.heap.push(child.last_doc_id(), idx);
+                num_active += 1;
+            }
+        }
+        active.num_active = num_active;
+
+        Ok(
+            match active.settle_after_children_changed(saved_last_doc_id)? {
+                SettleOutcome::Unchanged => ResumeOutcome::Ok(active),
+                // Both leave the union somewhere other than where it was; `Eof` has
+                // already set `is_eof`, so the caller sees no current either way.
+                SettleOutcome::Moved | SettleOutcome::Eof => ResumeOutcome::Moved(active),
+            },
+        )
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.num_estimated
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -27,11 +27,12 @@ use std::ptr::NonNull;
 use ffi::QueryIterator;
 use index_result::RSIndexResult;
 use query_types::QueryNodeType;
-use ref_mode::{Active, Ref, SharedPtr};
+use ref_mode::{Active, Ref, SharedPtr, Suspended};
 use rqe_core::DocId;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, UnionFullFlat,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome, UnionFullFlat,
     c2rust::CRQEIterator,
     interop::RQEIteratorWrapper,
     profile_print::{ProfilePrint, ProfilePrintCtx},
@@ -441,4 +442,177 @@ unsafe fn build_union_with_q_str_opt(
     let ptr = RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children));
     // SAFETY: `boxed_new_inner` uses `Box::into_raw`, which is guaranteed non-null.
     unsafe { NonNull::new_unchecked(ptr) }
+}
+
+impl<'index, I> RQEIteratorBoxed<'index> for UnionOpaque<'index, I>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawUnionOpaque<'index, Suspended, I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Per-variant dispatch: each inner Union variant (`UnionFlat`,
+        // `UnionHeap`, `UnionTrimmed`) walks its own children during
+        // `suspend`, correctly transitioning dyn-erased `I` via the vtable.
+        // A whole-box cast at this level alone would skip those per-variant
+        // walks and leave inner children's vtables stale.
+        //
+        // SAFETY: `raw` came from `Box::into_raw`, exclusively owned and
+        // valid, so the variant field is reachable.
+        let variant_slot = unsafe { std::ptr::addr_of_mut!((*raw).variant) };
+        // SAFETY: `variant_slot` is a valid `*mut UnionVariant<...>`;
+        // `ptr::read` moves the value out, leaving the slot logically
+        // uninitialized until the matching `ptr::write` below.
+        let active_variant = unsafe { std::ptr::read(variant_slot) };
+        // The inner variant's own `RQEIteratorBoxed::suspend` impl walks
+        // its children and produces the suspended form. Per-variant
+        // dispatch ensures dyn-erased `I` correctly transitions its vtable;
+        // a whole-box cast at this outer level alone would skip those walks.
+        let suspended_variant = match active_variant {
+            UnionVariant::FlatFull(it) => RawUnionVariant::FlatFull(*Box::new(it).suspend()),
+            UnionVariant::FlatQuick(it) => RawUnionVariant::FlatQuick(*Box::new(it).suspend()),
+            UnionVariant::HeapFull(it) => RawUnionVariant::HeapFull(*Box::new(it).suspend()),
+            UnionVariant::HeapQuick(it) => RawUnionVariant::HeapQuick(*Box::new(it).suspend()),
+            UnionVariant::Trimmed(it) => RawUnionVariant::Trimmed(*Box::new(it).suspend()),
+        };
+        // SAFETY: `variant_slot` has the same size and alignment as the
+        // suspended variant (both via `#[repr(C, u8)]` over layout-compatible
+        // payloads). Writing reinitialises the slot moved-from above.
+        unsafe {
+            std::ptr::write(
+                variant_slot as *mut RawUnionVariant<'index, Suspended, I::Suspended>,
+                suspended_variant,
+            );
+        }
+        // SAFETY: `RawUnionOpaque` is `#[repr(C)]` over `variant`
+        // (now byte-rewritten as Suspended form via the per-variant
+        // dispatch above), `query_node_type`, and `query_string`.
+        unsafe { Box::from_raw(raw as *mut RawUnionOpaque<'index, Suspended, I::Suspended>) }
+    }
+}
+
+impl<'query, S> RQESuspendedIterator<'query> for RawUnionOpaque<'query, Suspended, S>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = UnionOpaque<'a, S::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let RawUnionOpaque {
+            variant,
+            query_node_type,
+            query_string,
+        } = *self;
+
+        // Per-variant dispatch — `RawUnionVariant` itself doesn't impl
+        // RQESuspendedIterator, so we match here and forward each arm to
+        // the concrete variant's resume, reconstructing the concrete
+        // `UnionVariant`. The wrapper mirrors its single child's outcome: an
+        // aborted child aborts the whole opaque union; otherwise the
+        // `Ok`/`Moved` status is preserved.
+        let (variant, moved) = match variant {
+            RawUnionVariant::FlatFull(it) => match Box::new(it).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (UnionVariant::FlatFull(*active), false),
+                ResumeOutcome::Moved(active) => (UnionVariant::FlatFull(*active), true),
+            },
+            RawUnionVariant::FlatQuick(it) => match Box::new(it).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (UnionVariant::FlatQuick(*active), false),
+                ResumeOutcome::Moved(active) => (UnionVariant::FlatQuick(*active), true),
+            },
+            RawUnionVariant::HeapFull(it) => match Box::new(it).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (UnionVariant::HeapFull(*active), false),
+                ResumeOutcome::Moved(active) => (UnionVariant::HeapFull(*active), true),
+            },
+            RawUnionVariant::HeapQuick(it) => match Box::new(it).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (UnionVariant::HeapQuick(*active), false),
+                ResumeOutcome::Moved(active) => (UnionVariant::HeapQuick(*active), true),
+            },
+            RawUnionVariant::Trimmed(it) => match Box::new(it).resume(guard)? {
+                // In practice this branch is unreachable — trimmed unions
+                // are not subject to GC. `UnionTrimmed::resume` panics if
+                // reached.
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (UnionVariant::Trimmed(*active), false),
+                ResumeOutcome::Moved(active) => (UnionVariant::Trimmed(*active), true),
+            },
+        };
+
+        let active = Box::new(UnionOpaque {
+            variant,
+            query_node_type,
+            // Promote the query-string borrow from the suspended to the active
+            // ref-mode. `query_string` borrows the query AST (not the index),
+            // which outlives the iterator, so this is sound.
+            query_string: query_string.map(|sp| {
+                // SAFETY: `SharedPtr<Rf, CStr>` is `#[repr(transparent)]` over
+                // `NonNull<CStr>`, so the two ref-mode instantiations share a
+                // layout; the pointee (an AST-owned C string) stays valid for
+                // `'a` under the caller's read lock witnessed by `guard`.
+                unsafe {
+                    core::mem::transmute::<SharedPtr<Suspended, CStr>, SharedPtr<Active<'a>, CStr>>(
+                        sp,
+                    )
+                }
+            }),
+        });
+        Ok(if moved {
+            ResumeOutcome::Moved(active)
+        } else {
+            ResumeOutcome::Ok(active)
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        match &self.variant {
+            RawUnionVariant::FlatFull(it) => {
+                <RawUnionFlat<'query, Suspended, S, false> as RQESuspendedIterator<'query>>::last_doc_id(it)
+            }
+            RawUnionVariant::FlatQuick(it) => {
+                <RawUnionFlat<'query, Suspended, S, true> as RQESuspendedIterator<'query>>::last_doc_id(it)
+            }
+            RawUnionVariant::HeapFull(it) => {
+                <RawUnionHeap<'query, Suspended, S, false> as RQESuspendedIterator<'query>>::last_doc_id(it)
+            }
+            RawUnionVariant::HeapQuick(it) => {
+                <RawUnionHeap<'query, Suspended, S, true> as RQESuspendedIterator<'query>>::last_doc_id(it)
+            }
+            RawUnionVariant::Trimmed(it) => {
+                <RawUnionTrimmed<'query, Suspended, S> as RQESuspendedIterator<'query>>::last_doc_id(it)
+            }
+        }
+    }
+
+    fn num_estimated(&self) -> usize {
+        match &self.variant {
+            RawUnionVariant::FlatFull(it) => {
+                <RawUnionFlat<'query, Suspended, S, false> as RQESuspendedIterator<'query>>::num_estimated(it)
+            }
+            RawUnionVariant::FlatQuick(it) => {
+                <RawUnionFlat<'query, Suspended, S, true> as RQESuspendedIterator<'query>>::num_estimated(it)
+            }
+            RawUnionVariant::HeapFull(it) => {
+                <RawUnionHeap<'query, Suspended, S, false> as RQESuspendedIterator<'query>>::num_estimated(it)
+            }
+            RawUnionVariant::HeapQuick(it) => {
+                <RawUnionHeap<'query, Suspended, S, true> as RQESuspendedIterator<'query>>::num_estimated(it)
+            }
+            RawUnionVariant::Trimmed(it) => {
+                <RawUnionTrimmed<'query, Suspended, S> as RQESuspendedIterator<'query>>::num_estimated(it)
+            }
+        }
+    }
 }

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -27,11 +27,12 @@ use std::ptr::NonNull;
 use ffi::QueryIterator;
 use index_result::RSIndexResult;
 use query_types::QueryNodeType;
-use ref_mode::{Active, Ref, SharedPtr};
+use ref_mode::{Active, Ref, SharedPtr, Suspended};
 use rqe_core::DocId;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, UnionFullFlat,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome, UnionFullFlat,
     c2rust::CRQEIterator,
     interop::RQEIteratorWrapper,
     profile_print::{ProfilePrint, ProfilePrintCtx},
@@ -56,6 +57,28 @@ pub enum RawUnionVariant<'query, Rf: Ref, I> {
 /// Alias for an [`Active`] [`RawUnionVariant`] — the only instantiation
 /// with a callable surface today.
 pub type UnionVariant<'index, I> = RawUnionVariant<'index, Active<'index>, I>;
+
+// Compile-time proof of invariant 1 on `RawUnionVariant`: for a representative
+// concrete child, the `Active` and `Suspended` instantiations are
+// layout-identical. Each variant's payload carries its own invariant 1, and the
+// per-payload halves are statically enforced by `suspend_child_slot_in_place` /
+// `resume_child_slot_in_place`, which is what `RawUnionOpaque`'s transitions
+// drive them through; `#[repr(C)]` then puts every payload at the same offset
+// under the same tag in both modes. What is asserted here is the whole-enum
+// consequence the outer whole-box cast rests on.
+//
+// There is no per-variant `offset_of!`: naming an enum variant's field in
+// `offset_of!` is still unstable.
+const _: () = {
+    use crate::Wildcard;
+    use std::mem::{align_of, size_of};
+    type AChild = Wildcard<'static>;
+    type SChild = <Wildcard<'static> as RQEIteratorBoxed<'static>>::Suspended;
+    type A = RawUnionVariant<'static, Active<'static>, AChild>;
+    type S = RawUnionVariant<'static, Suspended, SChild>;
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
 
 impl<'index, I: RQEIterator<'index>> UnionVariant<'index, I> {
     /// Converts this variant in place to [`UnionVariant::Trimmed`], switching
@@ -134,6 +157,32 @@ pub struct RawUnionOpaque<'query, Rf: Ref, I> {
 /// Alias for an [`Active`] [`RawUnionOpaque`] — the only instantiation
 /// with an [`RQEIterator`] impl today.
 pub type UnionOpaque<'index, I> = RawUnionOpaque<'index, Active<'index>, I>;
+
+// Compile-time proof of invariant 1 on `RawUnionOpaque`: for a representative
+// concrete child, the `Active` and `Suspended` instantiations are
+// layout-identical. Three separate operations rest on it — the `ptr::write` of
+// the suspended variant into a slot sized for the active one, the whole-box
+// cast in either direction, and the `std::alloc::dealloc` on the abort/error
+// path, which frees with `Layout::new::<Self>()` an allocation that was made
+// for the active form.
+//
+// `variant` carries its own invariant 1 (proof above); `query_node_type` is
+// `Rf`-free; `query_string` is an `Option<SharedPtr<Rf, CStr>>`, and `SharedPtr`
+// is `#[repr(transparent)]` over `NonNull`, so the niche the `Option` folds into
+// is the same in both modes.
+const _: () = {
+    use crate::Wildcard;
+    use std::mem::{align_of, offset_of, size_of};
+    type AChild = Wildcard<'static>;
+    type SChild = <Wildcard<'static> as RQEIteratorBoxed<'static>>::Suspended;
+    type A = RawUnionOpaque<'static, Active<'static>, AChild>;
+    type S = RawUnionOpaque<'static, Suspended, SChild>;
+    assert!(offset_of!(A, variant) == offset_of!(S, variant));
+    assert!(offset_of!(A, query_node_type) == offset_of!(S, query_node_type));
+    assert!(offset_of!(A, query_string) == offset_of!(S, query_string));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
 
 impl<'index, I: RQEIterator<'index>> UnionOpaque<'index, I> {
     /// Set the weight on the union's aggregate result.
@@ -441,4 +490,213 @@ unsafe fn build_union_with_q_str_opt(
     let ptr = RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children));
     // SAFETY: `boxed_new_inner` uses `Box::into_raw`, which is guaranteed non-null.
     unsafe { NonNull::new_unchecked(ptr) }
+}
+
+impl<'index, I> RQEIteratorBoxed<'index> for UnionOpaque<'index, I>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawUnionOpaque<'index, Suspended, I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+
+        // Per-variant in-place dispatch, mirroring `resume` below:
+        // `RawUnionVariant` itself doesn't implement `RQEIteratorBoxed`, so we
+        // match here and drive each payload through the slot helper. Each inner
+        // union walks its own children during `suspend`, which is what
+        // transitions a dyn-erased `I`'s vtable; a whole-box cast at this level
+        // alone would skip those walks and leave the children's vtables stale.
+        // Routing through the helper is also what supplies the per-payload
+        // `assert_layout_compatible` guard and the abort-on-unwind cover for the
+        // moved-out window. The tag is left untouched, and both instantiations
+        // declare their variants in the same order, so the cast below lands on
+        // the same one.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+        // initialised, exclusively owned); the `&mut` borrow is confined to the
+        // match, and each payload is a valid, exclusively-owned value that the
+        // helper leaves as its suspended counterpart at the same address.
+        match unsafe { &mut (*raw).variant } {
+            UnionVariant::FlatFull(it) => {
+                // SAFETY: `it` is the valid, exclusively-owned payload.
+                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+            }
+            UnionVariant::FlatQuick(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+            }
+            UnionVariant::HeapFull(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+            }
+            UnionVariant::HeapQuick(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+            }
+            UnionVariant::Trimmed(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+            }
+        }
+
+        // SAFETY: the variant now holds its suspended form at the same offset
+        // under the same tag, and the remaining fields are either `Rf`-free
+        // (`query_node_type`) or a borrow of the query AST rather than the index
+        // (`query_string`), which the `Active → Suspended` re-typing only
+        // weakens. Layout-identical to the suspended form by invariant 1 on
+        // `RawUnionOpaque` (const proof above). `Box::from_raw` reuses the same
+        // allocation, so the box and every interior address survive the cycle.
+        unsafe { Box::from_raw(raw as *mut RawUnionOpaque<'index, Suspended, I::Suspended>) }
+    }
+}
+
+impl<'query, S> RQESuspendedIterator<'query> for RawUnionOpaque<'query, Suspended, S>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = UnionOpaque<'a, S::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let raw = Box::into_raw(self);
+
+        // Per-variant in-place dispatch — `RawUnionVariant` itself doesn't impl
+        // `RQESuspendedIterator`, so we match here and drive each payload's
+        // resume through the slot helper. `RawUnionVariant` is a single
+        // `#[repr(C)]` enum parametrized by the ref-mode, so the tag encoding is
+        // identical across modes and only the payload bytes change — the
+        // whole-box cast below lands on the same variant.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+        // initialised, exclusively owned); the `&mut` borrow is confined to the
+        // match. On `Unchanged`/`Moved` the helper rewrites the payload as its
+        // resumed form; on `Aborted`/`Err` it consumes the payload, leaving it
+        // uninitialised (handled below).
+        let outcome = match unsafe { &mut (*raw).variant } {
+            RawUnionVariant::FlatFull(it) => {
+                // SAFETY: `it` is the valid, exclusively-owned payload.
+                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, guard) }
+            }
+            RawUnionVariant::FlatQuick(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, guard) }
+            }
+            RawUnionVariant::HeapFull(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, guard) }
+            }
+            RawUnionVariant::HeapQuick(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, guard) }
+            }
+            RawUnionVariant::Trimmed(_) => {
+                // Unreachable for the reason spelled out in `RawUnionTrimmed`'s
+                // own `resume`: trimmed unions are only built for
+                // `Q_OPT_PARTIAL_RANGE`, whose pipeline never revalidates.
+                //
+                // Panicking here rather than dispatching the payload through
+                // `resume_child_slot_in_place` is deliberate: the helper arms an
+                // `AbortOnUnwind` across the dispatched `resume`, so going
+                // through it would turn this panic into a `std::process::abort()`
+                // while the legacy `revalidate` path — which delegates to
+                // `UnionTrimmed::revalidate`'s twin `unreachable!` — unwinds. The
+                // two paths must agree on the failure mode.
+                unreachable!(
+                    "resume is not supported on UnionTrimmed — trimmed unions are not subject to GC"
+                );
+            }
+        };
+
+        // Free the reused allocation when the payload was consumed: only the tag
+        // and the `Rf`-free/pointer fields remain live, none of which need
+        // dropping (`query_string` is a borrowed `SharedPtr`), so the raw
+        // allocation is deallocated directly.
+        let free_shell = |raw: *mut Self| {
+            // SAFETY: the allocation was made for the *active* form, whose size
+            // and alignment match `Self`'s by invariant 1 on `RawUnionOpaque`
+            // (const proof above), so `Layout::new::<Self>()` is the layout it
+            // was allocated with; the consumed payload must not be dropped, and
+            // the remaining fields have no drop glue.
+            unsafe { std::alloc::dealloc(raw.cast::<u8>(), std::alloc::Layout::new::<Self>()) };
+        };
+
+        match outcome {
+            Ok(
+                slot_outcome @ (crate::boxed::ResumeSlotOutcome::Unchanged
+                | crate::boxed::ResumeSlotOutcome::Moved),
+            ) => {
+                // SAFETY: the payload holds its resumed form at the same offset
+                // and the tag is unchanged; `query_string` is a
+                // `#[repr(transparent)]` `SharedPtr` over `NonNull<CStr>`
+                // borrowing the query AST (not the index), which outlives the
+                // iterator, so its `Suspended → Active<'a>` re-typing is sound;
+                // `query_node_type` is `Rf`-free. `Box::from_raw` reuses the
+                // same allocation, so the box address — and the FFI's cached
+                // `header.current` into the payload's result — stay valid.
+                let active =
+                    unsafe { Box::from_raw(raw.cast::<UnionOpaque<'a, S::Resumed<'a>>>()) };
+                Ok(match slot_outcome {
+                    crate::boxed::ResumeSlotOutcome::Unchanged => ResumeOutcome::Ok(active),
+                    _ => ResumeOutcome::Moved(active),
+                })
+            }
+            Ok(crate::boxed::ResumeSlotOutcome::Aborted) => {
+                free_shell(raw);
+                Ok(ResumeOutcome::Aborted)
+            }
+            Err(e) => {
+                free_shell(raw);
+                Err(e)
+            }
+        }
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        match &self.variant {
+            RawUnionVariant::FlatFull(it) => {
+                <RawUnionFlat<'query, Suspended, S, false> as RQESuspendedIterator<'query>>::last_doc_id(it)
+            }
+            RawUnionVariant::FlatQuick(it) => {
+                <RawUnionFlat<'query, Suspended, S, true> as RQESuspendedIterator<'query>>::last_doc_id(it)
+            }
+            RawUnionVariant::HeapFull(it) => {
+                <RawUnionHeap<'query, Suspended, S, false> as RQESuspendedIterator<'query>>::last_doc_id(it)
+            }
+            RawUnionVariant::HeapQuick(it) => {
+                <RawUnionHeap<'query, Suspended, S, true> as RQESuspendedIterator<'query>>::last_doc_id(it)
+            }
+            RawUnionVariant::Trimmed(it) => {
+                <RawUnionTrimmed<'query, Suspended, S> as RQESuspendedIterator<'query>>::last_doc_id(it)
+            }
+        }
+    }
+
+    fn num_estimated(&self) -> usize {
+        match &self.variant {
+            RawUnionVariant::FlatFull(it) => {
+                <RawUnionFlat<'query, Suspended, S, false> as RQESuspendedIterator<'query>>::num_estimated(it)
+            }
+            RawUnionVariant::FlatQuick(it) => {
+                <RawUnionFlat<'query, Suspended, S, true> as RQESuspendedIterator<'query>>::num_estimated(it)
+            }
+            RawUnionVariant::HeapFull(it) => {
+                <RawUnionHeap<'query, Suspended, S, false> as RQESuspendedIterator<'query>>::num_estimated(it)
+            }
+            RawUnionVariant::HeapQuick(it) => {
+                <RawUnionHeap<'query, Suspended, S, true> as RQESuspendedIterator<'query>>::num_estimated(it)
+            }
+            RawUnionVariant::Trimmed(it) => {
+                <RawUnionTrimmed<'query, Suspended, S> as RQESuspendedIterator<'query>>::num_estimated(it)
+            }
+        }
+    }
 }

--- a/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
@@ -46,10 +46,13 @@
 //! accessible even though they are inactive.
 
 use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
-use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+};
 use index_spec::IndexSpecReadGuard;
 
 /// Union iterator that drains children sequentially in reverse order.
@@ -332,5 +335,65 @@ where
         } else {
             1.0
         }
+    }
+}
+
+impl<'index, I> RQEIteratorBoxed<'index> for UnionTrimmed<'index, I>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawUnionTrimmed<'index, Suspended, I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Walk children — see [`crate::boxed::suspend_child_slot_in_place`].
+        // SAFETY: `raw` came from `Box::into_raw`, exclusively owned and
+        // valid, so the children Vec is reachable and unaliased.
+        let children: &mut Vec<I> = unsafe { &mut (*raw).children };
+        for child in children.iter_mut() {
+            // SAFETY: `child` is a valid `&mut I` aliased to nothing else;
+            // the function leaves the slot in a valid `I::Suspended` state.
+            unsafe { crate::boxed::suspend_child_slot_in_place(child) };
+        }
+        // SAFETY: `RawUnionTrimmed` is `#[repr(C)]` over `Vec<I>` (now
+        // byte-rewritten as `Vec<I::Suspended>` contents) and
+        // `result: RawIndexResult<Rf>` (layout-compatible via `SharedPtr`).
+        unsafe { Box::from_raw(raw as *mut RawUnionTrimmed<'index, Suspended, I::Suspended>) }
+    }
+}
+
+impl<'query, S> RQESuspendedIterator<'query> for RawUnionTrimmed<'query, Suspended, S>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = UnionTrimmed<'a, S::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        _guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Trimmed unions are not subject to GC — they're only constructed
+        // for `Q_OPT_PARTIAL_RANGE` (numeric SORTBY), whose result-processor
+        // pipeline drains every upstream result inside a single locked
+        // `sendChunk` call, so the FFI `Revalidate` path never reaches a
+        // trimmed union. See the parallel `unreachable!` in
+        // `RQEIterator::revalidate` for the full justification.
+        unreachable!(
+            "resume is not supported on UnionTrimmed — trimmed unions are not subject to GC"
+        );
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.num_estimated
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
@@ -46,10 +46,13 @@
 //! accessible even though they are inactive.
 
 use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
-use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+};
 use index_spec::IndexSpecReadGuard;
 
 /// Union iterator that drains children sequentially in reverse order.
@@ -72,6 +75,8 @@ use index_spec::IndexSpecReadGuard;
 /// - [`revalidate`](RQEIterator::revalidate): trimmed unions run in a
 ///   single, short-lived read path that does not interleave with GC cycles,
 ///   so revalidation should never be needed.
+/// - [`resume`](RQESuspendedIterator::resume): the suspend/resume successor
+///   of `revalidate`, unreachable for the same reason.
 ///
 /// # Type Parameters
 ///
@@ -103,6 +108,29 @@ pub struct RawUnionTrimmed<'query, Rf: Ref, I> {
 /// Alias for an [`Active`] [`RawUnionTrimmed`] — the only instantiation
 /// with an [`RQEIterator`] impl today.
 pub type UnionTrimmed<'index, I> = RawUnionTrimmed<'index, Active<'index>, I>;
+
+// Compile-time proof of invariant 1 on `RawUnionTrimmed`: for a representative
+// concrete child, the `Active` and `Suspended` instantiations are
+// layout-identical. The child elements' own compatibility is their invariant 1
+// (enforced generically by the slot helper); `result` is layout-compatible
+// across `Rf` (proven in `index_result`); the remaining fields are `Rf`-free.
+const _: () = {
+    use crate::Wildcard;
+    use std::mem::{align_of, offset_of, size_of};
+    type AChild = Wildcard<'static>;
+    type SChild = <Wildcard<'static> as RQEIteratorBoxed<'static>>::Suspended;
+    type A = RawUnionTrimmed<'static, Active<'static>, AChild>;
+    type S = RawUnionTrimmed<'static, Suspended, SChild>;
+    assert!(offset_of!(A, children) == offset_of!(S, children));
+    assert!(offset_of!(A, trim_start) == offset_of!(S, trim_start));
+    assert!(offset_of!(A, trim_end) == offset_of!(S, trim_end));
+    assert!(offset_of!(A, num_estimated) == offset_of!(S, num_estimated));
+    assert!(offset_of!(A, cursor) == offset_of!(S, cursor));
+    assert!(offset_of!(A, is_eof) == offset_of!(S, is_eof));
+    assert!(offset_of!(A, result) == offset_of!(S, result));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
 
 impl<'index, I> UnionTrimmed<'index, I>
 where
@@ -332,5 +360,80 @@ where
         } else {
             1.0
         }
+    }
+}
+
+impl<'index, I> RQEIteratorBoxed<'index> for UnionTrimmed<'index, I>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawUnionTrimmed<'index, Suspended, I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Walk children — see [`crate::boxed::suspend_child_slot_in_place`].
+        // SAFETY: `raw` came from `Box::into_raw`, exclusively owned and
+        // valid, so the children Vec is reachable and unaliased.
+        let children: &mut Vec<I> = unsafe { &mut (*raw).children };
+        for child in children.iter_mut() {
+            // SAFETY: `child` is a valid `&mut I` aliased to nothing else;
+            // the function leaves the slot in a valid `I::Suspended` state.
+            unsafe { crate::boxed::suspend_child_slot_in_place(child) };
+        }
+        // SAFETY: every child slot now holds its suspended form at its original
+        // address, so the aggregate's entries — pointers into those slots'
+        // result objects — still refer to live objects; the remaining fields
+        // are `Rf`-free. Layout-identical to the active form by invariant 1 on
+        // `RawUnionTrimmed` (const proof above), whose child-slot half — the
+        // `I`/`I::Suspended` size and alignment match — is statically enforced
+        // by `suspend_child_slot_in_place`. `Box::from_raw` reuses the same
+        // allocation, so the box and every interior address survive the cycle.
+        unsafe { Box::from_raw(raw as *mut RawUnionTrimmed<'index, Suspended, I::Suspended>) }
+    }
+}
+
+impl<'query, S> RQESuspendedIterator<'query> for RawUnionTrimmed<'query, Suspended, S>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = UnionTrimmed<'a, S::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        _guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Trimmed unions are not subject to GC — they're only constructed
+        // for `Q_OPT_PARTIAL_RANGE` (numeric SORTBY), whose result-processor
+        // pipeline drains every upstream result inside a single locked
+        // `sendChunk` call, so the FFI `Revalidate` path never reaches a
+        // trimmed union. See the parallel `unreachable!` in
+        // `RQEIterator::revalidate` for the full justification.
+        //
+        // This is a design constraint, not a gap to be filled later: a trimmed
+        // union yields documents out of doc-id order and its `skip_to` panics,
+        // so there is no way to re-derive a position after the children move.
+        //
+        // Failure mode note: reached directly, this unwinds like the legacy
+        // `revalidate`. Reached as a *child slot* of another composite, it goes
+        // through `crate::boxed::resume_child_slot_in_place`, which arms an
+        // `AbortOnUnwind` across the dispatched `resume` — so the panic
+        // escalates to `std::process::abort()` instead.
+        unreachable!(
+            "resume is not supported on UnionTrimmed — trimmed unions are not subject to GC"
+        );
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.num_estimated
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -19,6 +19,7 @@ use ref_mode::{Active, Ref, Suspended};
 
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
+use crate::inverted_index::core::ResumeStatus;
 use crate::{
     Empty, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
     RQEValidateStatus, ResumeOutcome, SEARCH_ENTERPRISE_ITERATORS, SkipToOutcome,
@@ -353,6 +354,96 @@ impl crate::profile_print::ProfilePrint for OptimizedWildcard<'_> {
         match self {
             Self::DocIdsOnly(it) => it.print_profile(map, ctx),
             Self::RawDocIdsOnly(it) => it.print_profile(map, ctx),
+        }
+    }
+}
+
+/// [`Suspended`]-mode counterpart of [`OptimizedWildcard`] used as its
+/// `RQEIteratorBoxed::Suspended` type. Each variant holds the `Suspended`
+/// form of the corresponding inverted-index wildcard reader, retaining the
+/// `'query` lifetime so query-attached borrows stay valid across the
+/// suspend/resume cycle.
+///
+/// `#[repr(C, u8)]` matches [`OptimizedWildcard`]'s layout.
+#[repr(C, u8)]
+pub enum OptimizedWildcardSuspended<'query> {
+    /// Suspended counterpart of [`OptimizedWildcard::DocIdsOnly`].
+    DocIdsOnly(crate::inverted_index::RawWildcard<'query, Suspended, DocIdsOnly>),
+    /// Suspended counterpart of [`OptimizedWildcard::RawDocIdsOnly`].
+    RawDocIdsOnly(crate::inverted_index::RawWildcard<'query, Suspended, RawDocIdsOnly>),
+}
+
+impl<'index> RQEIteratorBoxed<'index> for OptimizedWildcard<'index> {
+    type Suspended = OptimizedWildcardSuspended<'index>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: both enums are `#[repr(C, u8)]`; corresponding variants
+        // hold `RawWildcard<'index, Active<'index>, E>` / `RawWildcard<'index,
+        // Suspended, E>`, which are layout-compatible by the [`RQEIteratorBoxed`]
+        // contract on `inverted_index::Wildcard`. Box::from_raw reuses the
+        // heap allocation.
+        unsafe { Box::from_raw(raw as *mut OptimizedWildcardSuspended<'index>) }
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for OptimizedWildcardSuspended<'query> {
+    type Resumed<'a>
+        = OptimizedWildcard<'a>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        mut self: Box<Self>,
+        spec: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Step 1: per-variant identity check + the shared in-place resume
+        // transition on the inner inverted-index wildcard, still on the
+        // suspended form. Preserves the heap allocation across the cycle so
+        // external borrows into the iterator's interior (FFI wrapper's
+        // `header.current`) stay valid.
+        let status = match &mut *self {
+            OptimizedWildcardSuspended::DocIdsOnly(w) => {
+                if w.should_abort(spec) {
+                    return Ok(ResumeOutcome::Aborted);
+                }
+                w.it.resume_in_place(spec)?
+            }
+            OptimizedWildcardSuspended::RawDocIdsOnly(w) => {
+                if w.should_abort(spec) {
+                    return Ok(ResumeOutcome::Aborted);
+                }
+                w.it.resume_in_place(spec)?
+            }
+        };
+
+        // Step 2: whole-box cast to the active form.
+        let raw = Box::into_raw(self);
+        // SAFETY: layout-compatible — see `suspend`.
+        let active = unsafe { Box::from_raw(raw as *mut OptimizedWildcard<'a>) };
+
+        Ok(match status {
+            ResumeStatus::Unchanged => ResumeOutcome::Ok(active),
+            ResumeStatus::Moved => ResumeOutcome::Moved(active),
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        match self {
+            OptimizedWildcardSuspended::DocIdsOnly(it) => RQESuspendedIterator::last_doc_id(it),
+            OptimizedWildcardSuspended::RawDocIdsOnly(it) => RQESuspendedIterator::last_doc_id(it),
+        }
+    }
+
+    fn num_estimated(&self) -> usize {
+        match self {
+            OptimizedWildcardSuspended::DocIdsOnly(it) => RQESuspendedIterator::num_estimated(it),
+            OptimizedWildcardSuspended::RawDocIdsOnly(it) => {
+                RQESuspendedIterator::num_estimated(it)
+            }
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -19,6 +19,7 @@ use ref_mode::{Active, Ref, Suspended};
 
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
+use crate::inverted_index::core::ResumeStatus;
 use crate::{
     Empty, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
     RQEValidateStatus, ResumeOutcome, SEARCH_ENTERPRISE_ITERATORS, SkipToOutcome,
@@ -289,6 +290,16 @@ pub enum NewWildcardIterator<'index> {
 ///
 /// The encoding may be either [`DocIdsOnly`] or [`RawDocIdsOnly`], depending on
 /// the index configuration.
+///
+/// `#[repr(C, u8)]` is load-bearing, not decorative: [`suspend`](RQEIteratorBoxed::suspend)
+/// and [`OptimizedWildcardSuspended::resume`](RQESuspendedIterator::resume)
+/// reinterpret the owning `Box` between this enum and
+/// [`OptimizedWildcardSuspended`], which is only sound if the two agree on the
+/// tag encoding *and* the payload offsets. Under the default `repr(Rust)` both
+/// are unspecified — the tag may be niche-encoded into one of the payload's
+/// [`NonNull`] fields, and the two enums are free to choose differently — so
+/// the attribute must be present on both. The proof below pins the result down.
+#[repr(C, u8)]
 pub enum OptimizedWildcard<'index> {
     /// Optimized wildcard with [`DocIdsOnly`] encoding.
     DocIdsOnly(crate::inverted_index::Wildcard<'index, DocIdsOnly>),
@@ -367,6 +378,130 @@ impl crate::profile_print::ProfilePrint for OptimizedWildcard<'_> {
         match self {
             Self::DocIdsOnly(it) => it.print_profile(map, ctx),
             Self::RawDocIdsOnly(it) => it.print_profile(map, ctx),
+        }
+    }
+}
+
+/// [`Suspended`]-mode counterpart of [`OptimizedWildcard`] used as its
+/// `RQEIteratorBoxed::Suspended` type. Each variant holds the `Suspended`
+/// form of the corresponding inverted-index wildcard reader, retaining the
+/// `'query` lifetime so query-attached borrows stay valid across the
+/// suspend/resume cycle.
+///
+/// Both this enum and [`OptimizedWildcard`] are `#[repr(C, u8)]`, which is what
+/// makes the whole-box reinterpretation between them well-defined — see
+/// [`OptimizedWildcard`] for why the attribute is required on the pair.
+#[repr(C, u8)]
+pub enum OptimizedWildcardSuspended<'query> {
+    /// Suspended counterpart of [`OptimizedWildcard::DocIdsOnly`].
+    DocIdsOnly(crate::inverted_index::RawWildcard<'query, Suspended, DocIdsOnly>),
+    /// Suspended counterpart of [`OptimizedWildcard::RawDocIdsOnly`].
+    RawDocIdsOnly(crate::inverted_index::RawWildcard<'query, Suspended, RawDocIdsOnly>),
+}
+
+// Compile-time proof of invariant 1 on the `OptimizedWildcard` /
+// `OptimizedWildcardSuspended` pair, which the whole-box casts in `suspend` and
+// `resume` rely on. Per-variant payload equality plus the shared `#[repr(C, u8)]`
+// is what fixes the tag encoding and the payload offsets; the enum-level
+// size/align asserts pin the resulting layout — and, because the box is freed
+// through the *other* type, the deallocation layout too.
+//
+// Unlike the struct proofs elsewhere in the crate there is no per-field
+// `offset_of!`: naming an enum variant's field in `offset_of!` is still
+// unstable. A module-level `const _` is evaluated even though neither type is
+// ever instantiated here, which a `const {}` inside a generic function would
+// not be.
+const _: () = {
+    use std::mem::{align_of, size_of};
+    type ADocIds<'a> = crate::inverted_index::Wildcard<'a, DocIdsOnly>;
+    type SDocIds<'a> = crate::inverted_index::RawWildcard<'a, Suspended, DocIdsOnly>;
+    type ARawDocIds<'a> = crate::inverted_index::Wildcard<'a, RawDocIdsOnly>;
+    type SRawDocIds<'a> = crate::inverted_index::RawWildcard<'a, Suspended, RawDocIdsOnly>;
+    assert!(size_of::<ADocIds<'static>>() == size_of::<SDocIds<'static>>());
+    assert!(align_of::<ADocIds<'static>>() == align_of::<SDocIds<'static>>());
+    assert!(size_of::<ARawDocIds<'static>>() == size_of::<SRawDocIds<'static>>());
+    assert!(align_of::<ARawDocIds<'static>>() == align_of::<SRawDocIds<'static>>());
+    assert!(
+        size_of::<OptimizedWildcard<'static>>() == size_of::<OptimizedWildcardSuspended<'static>>()
+    );
+    assert!(
+        align_of::<OptimizedWildcard<'static>>()
+            == align_of::<OptimizedWildcardSuspended<'static>>()
+    );
+};
+
+impl<'index> RQEIteratorBoxed<'index> for OptimizedWildcard<'index> {
+    type Suspended = OptimizedWildcardSuspended<'index>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: layout-identical by invariant 1 on the
+        // `OptimizedWildcard`/`OptimizedWildcardSuspended` pair (const proof
+        // above): both enums are `#[repr(C, u8)]` and corresponding variants
+        // hold the `Active`/`Suspended` instantiations of the same
+        // `inverted_index::RawWildcard`. `Box::from_raw` reuses the same heap
+        // allocation.
+        unsafe { Box::from_raw(raw as *mut OptimizedWildcardSuspended<'index>) }
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for OptimizedWildcardSuspended<'query> {
+    type Resumed<'a>
+        = OptimizedWildcard<'a>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        mut self: Box<Self>,
+        spec: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Step 1: per-variant identity check + the shared in-place resume
+        // transition on the inner inverted-index wildcard, still on the
+        // suspended form. Preserves the heap allocation across the cycle so
+        // external borrows into the iterator's interior (FFI wrapper's
+        // `header.current`) stay valid.
+        let status = match &mut *self {
+            OptimizedWildcardSuspended::DocIdsOnly(w) => {
+                if w.should_abort(spec) {
+                    return Ok(ResumeOutcome::Aborted);
+                }
+                w.it.resume_in_place(spec)?
+            }
+            OptimizedWildcardSuspended::RawDocIdsOnly(w) => {
+                if w.should_abort(spec) {
+                    return Ok(ResumeOutcome::Aborted);
+                }
+                w.it.resume_in_place(spec)?
+            }
+        };
+
+        // Step 2: whole-box cast to the active form.
+        let raw = Box::into_raw(self);
+        // SAFETY: layout-compatible — see `suspend`.
+        let active = unsafe { Box::from_raw(raw as *mut OptimizedWildcard<'a>) };
+
+        Ok(match status {
+            ResumeStatus::Unchanged => ResumeOutcome::Ok(active),
+            ResumeStatus::Moved => ResumeOutcome::Moved(active),
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        match self {
+            OptimizedWildcardSuspended::DocIdsOnly(it) => RQESuspendedIterator::last_doc_id(it),
+            OptimizedWildcardSuspended::RawDocIdsOnly(it) => RQESuspendedIterator::last_doc_id(it),
+        }
+    }
+
+    fn num_estimated(&self) -> usize {
+        match self {
+            OptimizedWildcardSuspended::DocIdsOnly(it) => RQESuspendedIterator::num_estimated(it),
+            OptimizedWildcardSuspended::RawDocIdsOnly(it) => {
+                RQESuspendedIterator::num_estimated(it)
+            }
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/main.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/main.rs
@@ -61,6 +61,7 @@ mod timeout_context;
 mod union_common;
 mod union_flat;
 mod union_heap;
+mod union_opaque;
 mod union_reducer;
 mod union_trimmed;
 mod wildcard;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_flat.rs
@@ -215,3 +215,220 @@ fn revalidate_with_an_unread_sibling_does_not_move_the_union_backwards() {
         "the unread sibling's 15 is still owed and must not be skipped: {seen:?}",
     );
 }
+
+mod via_resume {
+    use crate::utils::{Mock, MockRevalidateResult};
+    use rqe_iterators::{RQEIterator, ResumeOutcome, TypeErasedRQEIterator, UnionFullFlat};
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 15);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 20);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_moved() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        // After Move, children advance — last_doc_id should reflect new min.
+        assert!(union.last_doc_id() > 10);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_single_child_aborts() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        // One child aborted, the other survives — union continues (Ok or Moved).
+        let mut union =
+            match revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+                .expect("resume failed")
+            {
+                ResumeOutcome::Ok(it) | ResumeOutcome::Moved(it) => it,
+                ResumeOutcome::Aborted => {
+                    panic!("Expected MOVED or OK when one child aborts, got Aborted")
+                }
+            };
+        // Reads from the surviving child should continue.
+        let r = union.read().unwrap().unwrap();
+        assert!(r.doc_id >= 15);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_all_children_abort() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed");
+        assert!(matches!(outcome, ResumeOutcome::Aborted));
+    }
+
+    /// Phase 3.15 regression: when no child moved, the aggregate must be
+    /// rebuilt at `saved_last_doc_id` so subsequent reads continue from the
+    /// same logical position.
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_minimum_unchanged_returns_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 3> = Mock::new([10, 30, 50]);
+        let child1: Mock<'_, 3> = Mock::new([10, 40, 60]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        // Union must continue producing the remaining children's docs.
+        let r = union.read().unwrap().unwrap();
+        assert!(r.doc_id > 10, "expected next doc_id > 10, got {}", r.doc_id);
+    }
+
+    /// Phase 5b.5 regression: an EOF child swap-removed into the dead tail must
+    /// NOT be re-included as a live child by resume — that would yield its
+    /// already-read max doc_id forever.
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_swap_removed_dead_tail_not_yielded_again() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // Child 0 has a small doc set; child 1 has more docs.
+        // Read past child 0's EOF so it's swap-removed into the dead tail.
+        let child0: Mock<'_, 2> = Mock::new([10, 20]);
+        let child1: Mock<'_, 5> = Mock::new([5, 15, 25, 35, 45]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        // Drain child0: 5 (c1), 10 (c0), 15 (c1), 20 (c0) — c0 now at EOF and
+        // gets swap_remove_child'd next time `read()` advances past 20.
+        let mut docs = Vec::new();
+        for _ in 0..4 {
+            docs.push(union.read().unwrap().unwrap().doc_id);
+        }
+        assert_eq!(docs, [5, 10, 15, 20]);
+        // The next read trims child0 to the dead tail.
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 25);
+
+        // Now resume: child0 is in the dead tail. It must NOT re-emerge as live.
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        // Continue reading: must surface the rest of child1 and never repeat 20.
+        let remaining: Vec<_> =
+            std::iter::from_fn(|| union.read().unwrap().map(|r| r.doc_id)).collect();
+        assert_eq!(remaining, [35, 45]);
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_flat.rs
@@ -220,3 +220,804 @@ fn revalidate_with_an_unread_sibling_does_not_move_the_union_backwards() {
         "the unread sibling's 15 is still owed and must not be skipped: {seen:?}",
     );
 }
+
+mod via_resume {
+    use crate::utils::{Mock, MockIteratorError, MockRevalidateResult};
+    use rqe_core::DocId;
+    use rqe_iterators::{
+        RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator, RQEValidateStatus,
+        ResumeOutcome, TypeErasedRQEIterator, UnionFlat, UnionFullFlat, UnionQuickFlat,
+    };
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    /// Read `it` to completion, collecting the doc ids it yields.
+    fn drain<'index>(it: &mut impl RQEIterator<'index>) -> Vec<DocId> {
+        let mut seen = Vec::new();
+        while let Some(doc) = it.read().expect("read failed") {
+            seen.push(doc.doc_id);
+        }
+        seen
+    }
+
+    /// Wrap three mocks as the type-erased children a composite really holds:
+    /// their active and suspended forms carry different vtables, which a
+    /// concrete-child test cannot exercise.
+    fn boxed_children<'spec, const N0: usize, const N1: usize, const N2: usize>(
+        c0: Mock<'spec, N0>,
+        c1: Mock<'spec, N1>,
+        c2: Mock<'spec, N2>,
+    ) -> Vec<TypeErasedRQEIterator<'spec>> {
+        vec![
+            TypeErasedRQEIterator::new(Box::new(c0)),
+            TypeErasedRQEIterator::new(Box::new(c1)),
+            TypeErasedRQEIterator::new(Box::new(c2)),
+        ]
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 15);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 20);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_moved() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        // After Move, children advance — last_doc_id should reflect new min.
+        assert!(union.last_doc_id() > 10);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_single_child_aborts() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        // One child aborted, the other survives — the union carries on from the
+        // survivor's position. Asserting the exact sequence, rather than just
+        // "the next id is not behind us", is what distinguishes a correctly
+        // repartitioned union from one that resurrects the aborted child: the
+        // latter would hand back 20, 30, 40, 50 interleaved with the survivor's.
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert_eq!(
+            union.last_doc_id(),
+            15,
+            "the union settles on the surviving child's document",
+        );
+        assert_eq!(drain(&mut union), [25, 35, 45, 55]);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_all_children_abort() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed");
+        assert!(matches!(outcome, ResumeOutcome::Aborted));
+    }
+
+    /// Phase 3.15 regression: when no child moved, the aggregate must be
+    /// rebuilt at `saved_last_doc_id` so subsequent reads continue from the
+    /// same logical position.
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_minimum_unchanged_returns_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 3> = Mock::new([10, 30, 50]);
+        let child1: Mock<'_, 3> = Mock::new([10, 40, 60]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        // Union must continue producing the remaining children's docs.
+        let r = union.read().unwrap().unwrap();
+        assert!(r.doc_id > 10, "expected next doc_id > 10, got {}", r.doc_id);
+    }
+
+    /// `resume` hands the aggregate back across the cycle rather than rebuilding
+    /// it, so every entry must still *reach* its child afterwards. Every other
+    /// `Ok`-path test reads first, which resets and rebuilds the aggregate, so a
+    /// broken entry would be overwritten before anything read it. Dereference
+    /// every entry here instead, in the window between the resume and the next
+    /// read — the window a scorer walking `current()` occupies in production.
+    ///
+    /// Run under miri this is also the regression test for the entries'
+    /// *provenance*, which is the half a plain read cannot see: the addresses
+    /// survive a child's transition on their own, the borrows they were derived
+    /// from do not, and only `resume`'s re-derivation of the entries makes them
+    /// usable rather than merely well-addressed. The twin of
+    /// `intersection::via_resume::resume_ok_leaves_the_aggregate_pointing_at_live_children`,
+    /// for a full union — where the aggregate carries one entry per child sitting
+    /// on the document rather than one per child.
+    #[test]
+    fn resume_ok_leaves_the_aggregate_pointing_at_live_children() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // All three children start on 10, so all three back the aggregate.
+        let child0: Mock<'_, 3> = Mock::new([10, 40, 70]);
+        let child1: Mock<'_, 3> = Mock::new([10, 50, 80]);
+        let child2: Mock<'_, 3> = Mock::new([10, 60, 90]);
+        // Nothing moves, so `resume` carries the aggregate across untouched —
+        // the case its liveness obligation rests on entirely.
+        for data in [child0.data(), child1.data(), child2.data()].iter_mut() {
+            data.set_revalidate_result(MockRevalidateResult::Ok);
+        }
+
+        let mut union = UnionFullFlat::new(boxed_children(child0, child1, child2));
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let current = union
+            .current()
+            .expect("an unchanged union is still positioned");
+        assert_eq!(current.doc_id, 10);
+        let aggregate = current
+            .as_aggregate()
+            .expect("a full union publishes an aggregate result");
+        assert_eq!(aggregate.len(), 3, "one entry per child on the document");
+        for i in 0..aggregate.len() {
+            let entry = aggregate.get(i).expect("index below len");
+            assert_eq!(
+                entry.doc_id, 10,
+                "entry {i} must still reach its child's live result",
+            );
+        }
+
+        // Only now let a read rebuild the aggregate from scratch.
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 40);
+    }
+
+    /// Phase 5b.5 regression: an EOF child swap-removed into the dead tail must
+    /// NOT be re-included as a live child by resume — that would yield its
+    /// already-read max doc_id forever.
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_swap_removed_dead_tail_not_yielded_again() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // Child 0 has a small doc set; child 1 has more docs.
+        // Read past child 0's EOF so it's swap-removed into the dead tail.
+        let child0: Mock<'_, 2> = Mock::new([10, 20]);
+        let child1: Mock<'_, 5> = Mock::new([5, 15, 25, 35, 45]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        // Drain child0: 5 (c1), 10 (c0), 15 (c1), 20 (c0) — c0 now at EOF and
+        // gets swap_remove_child'd next time `read()` advances past 20.
+        let mut docs = Vec::new();
+        for _ in 0..4 {
+            docs.push(union.read().unwrap().unwrap().doc_id);
+        }
+        assert_eq!(docs, [5, 10, 15, 20]);
+        // The next read trims child0 to the dead tail.
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 25);
+
+        // Now resume: child0 is in the dead tail. It must NOT re-emerge as live.
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        // Continue reading: must surface the rest of child1 and never repeat 20.
+        let remaining: Vec<_> =
+            std::iter::from_fn(|| union.read().unwrap().map(|r| r.doc_id)).collect();
+        assert_eq!(remaining, [35, 45]);
+    }
+
+    /// The suspend/resume cycle must reuse the allocation: the FFI wrapper and
+    /// delegating parents cache raw pointers into the iterator's storage, and a
+    /// rebuilt box would dangle them.
+    #[test]
+    fn resume_preserves_box_address() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let children = vec![Mock::new([10u64, 30]), Mock::new([20u64, 40])];
+        let mut union = Box::new(UnionFullFlat::new(children));
+        let r = union.read().expect("read failed").expect("expected doc");
+        assert_eq!(r.doc_id, 10);
+        let addr_before = &*union as *const _ as usize;
+
+        let suspended = union.suspend();
+        assert_eq!(
+            &*suspended as *const _ as usize, addr_before,
+            "suspend must reuse the allocation",
+        );
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(a) => a,
+            ResumeOutcome::Moved(_) => panic!("expected Ok, got Moved"),
+            ResumeOutcome::Aborted => panic!("expected Ok, got Aborted"),
+        };
+        assert_eq!(
+            &*active as *const _ as usize, addr_before,
+            "resume must reuse the allocation",
+        );
+
+        let r = active.read().expect("read failed").expect("expected doc");
+        assert_eq!(r.doc_id, 20, "the union carries on where it was");
+    }
+
+    /// A finished union is finished whatever its children now say:
+    /// `revalidate` tests `is_eof` before it looks at a single child, so it
+    /// reports `Ok` without asking them. `resume` has to transition the
+    /// children regardless, but must still reach the same verdict — asking
+    /// "did every child abort?" first turns a no-op revalidation of a
+    /// spent union into a tear-down of the whole subtree.
+    #[test]
+    fn resume_of_a_finished_union_whose_children_all_abort_is_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 2> = Mock::new([10, 30]);
+        let child1: Mock<'_, 2> = Mock::new([20, 40]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+        let seen: Vec<_> = std::iter::from_fn(|| union.read().unwrap().map(|r| r.doc_id)).collect();
+        assert_eq!(seen, [10, 20, 30, 40]);
+        assert!(union.at_eof());
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+        assert!(union.at_eof());
+        assert!(matches!(union.read(), Ok(None)));
+    }
+
+    /// A union over no children at all is a supported construction — it
+    /// starts at EOF — and `revalidate` reports `Ok` for it. `resume` must
+    /// not mistake "no children" for "every child aborted".
+    #[test]
+    fn resume_of_an_empty_union_is_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let union = UnionFullFlat::new(Vec::<TypeErasedRQEIterator<'_>>::new());
+        assert!(union.at_eof());
+
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+        assert!(union.at_eof());
+        assert!(matches!(union.read(), Ok(None)));
+    }
+
+    /// A child whose resume *fails* takes the union down the
+    /// `free_after_consumed_child` teardown, the most delicate unsafe in this
+    /// file: it drops the compacted resumed prefix, leaves the consumed slot
+    /// alone, and drops the still-suspended tail. Get the `kept`/`consumed`
+    /// boundary wrong and it is a double free or a leak, both of which miri
+    /// sees through the mocks' reference-counted state.
+    ///
+    /// This is the plain shape: no child aborted first, so `kept == consumed`
+    /// and the buffer is a resumed prefix followed directly by a suspended
+    /// tail.
+    #[test]
+    fn resume_child_error_frees_a_shell_with_a_suspended_tail() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child0: Mock<'_, 3> = Mock::new([10, 40, 70]);
+        let child1: Mock<'_, 3> = Mock::new([20, 50, 80]);
+        let child2: Mock<'_, 3> = Mock::new([30, 60, 90]);
+        child1
+            .data()
+            .set_error_on_resume(Some(MockIteratorError::TimeoutError(None)));
+
+        let mut union = UnionFullFlat::new(boxed_children(child0, child1, child2));
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        match revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard) {
+            Err(e) => assert!(matches!(e, RQEIteratorError::TimedOut)),
+            Ok(_) => panic!("the failing child's error must reach the caller"),
+        }
+    }
+
+    /// The same teardown, but with a hole in the middle: child 0 aborts before
+    /// child 2 fails, so the survivor is compacted down to slot 0 and `kept`
+    /// (1) trails `consumed` (2). Slot 1 is then a vacated hole that the
+    /// teardown must skip — the clause the plain shape never reaches.
+    #[test]
+    fn resume_child_error_frees_a_shell_with_a_hole_in_it() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child0: Mock<'_, 3> = Mock::new([10, 40, 70]);
+        let child1: Mock<'_, 3> = Mock::new([20, 50, 80]);
+        let child2: Mock<'_, 3> = Mock::new([30, 60, 90]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child2
+            .data()
+            .set_error_on_resume(Some(MockIteratorError::TimeoutError(None)));
+
+        let mut union = UnionFullFlat::new(boxed_children(child0, child1, child2));
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        match revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard) {
+            Err(e) => assert!(matches!(e, RQEIteratorError::TimedOut)),
+            Ok(_) => panic!("the failing child's error must reach the caller"),
+        }
+    }
+
+    /// The abort path — `copy_nonoverlapping` compacting survivors down over
+    /// the hole, `set_len` shrinking the vector, and the whole-box cast that
+    /// must not re-narrow the aggregate onto the child it just freed — with
+    /// **concrete** children, so miri can see all of it.
+    ///
+    /// Concrete children are also what makes the relocation half of that
+    /// hazard real: an `IndexedChild<Mock<..>>` lives inline in the vector's
+    /// buffer, so compaction moves the survivor's result object to a new
+    /// address, where a boxed child's would have stayed put.
+    #[test]
+    fn resume_compacts_over_an_aborted_concrete_child() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child0 = Mock::new([10u64, 40, 70]);
+        let child1 = Mock::new([20u64, 50, 80]);
+        let child2 = Mock::new([30u64, 60, 90]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+
+        let mut union = Box::new(UnionFullFlat::new(vec![child0, child1, child2]));
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        let mut active = match union.suspend().resume(&guard).expect("resume failed") {
+            ResumeOutcome::Moved(a) => a,
+            ResumeOutcome::Ok(_) => panic!("expected Moved, got Ok"),
+            ResumeOutcome::Aborted => panic!("expected Moved, got Aborted"),
+        };
+        assert_eq!(
+            active.num_children_total(),
+            2,
+            "the aborted child is gone from the vector",
+        );
+        assert_eq!(active.last_doc_id(), 20);
+        assert_eq!(
+            drain(&mut *active),
+            [30, 50, 60, 80, 90],
+            "nothing of the aborted child's may survive in the sequence",
+        );
+    }
+
+    /// A middle child aborting drags the *dead tail* into the active region:
+    /// child 2 is parked past `num_active` when the abort of child 1 compacts
+    /// child 2 down into slot 1, which the re-admission then treats as live.
+    /// The settle has to re-park it. If it does not, the exhausted child's last
+    /// document becomes the union's minimum and is handed out again — the
+    /// `num_active`-invariant bug class.
+    #[test]
+    fn resume_reparks_a_dead_tail_pulled_forward_by_a_middle_abort() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child0: Mock<'_, 3> = Mock::new([10, 40, 70]);
+        let child1: Mock<'_, 3> = Mock::new([20, 50, 80]);
+        let child2: Mock<'_, 1> = Mock::new([30]);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+
+        let mut union = UnionFullFlat::new(boxed_children(child0, child1, child2));
+        let seen: Vec<_> = (0..4)
+            .map(|_| union.read().unwrap().unwrap().doc_id)
+            .collect();
+        assert_eq!(
+            seen,
+            [10, 20, 30, 40],
+            "reading past 30 parks child2 in the dead tail",
+        );
+
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+        assert_eq!(
+            union.last_doc_id(),
+            40,
+            "the surviving child still backs the union's position",
+        );
+        assert_eq!(
+            drain(&mut union),
+            [70],
+            "child2's 30 was already delivered and must not come back",
+        );
+    }
+
+    /// A child re-admitted *behind* the union is the shape the settle's
+    /// `min_doc_id < original_last_doc_id` block exists for: the union may not
+    /// adopt a minimum it has already passed, so every lagger is seeked up to
+    /// the abandoned position instead.
+    ///
+    /// The legacy twin
+    /// (`revalidate_resurrected_child_does_not_drag_a_full_union_backwards`)
+    /// gets there with [`MockData::set_revalidate_reseeks_to`], which only the
+    /// legacy `revalidate` honours. The suspended mock has no equivalent, so
+    /// the lagger is produced the other way the union parks a child without
+    /// exhausting it: a `read` that answers `None` while the child still holds
+    /// documents, which leaves its position untouched.
+    ///
+    /// [`MockData::set_revalidate_reseeks_to`]: crate::utils::MockData::set_revalidate_reseeks_to
+    #[test]
+    fn resume_does_not_let_a_re_admitted_lagger_drag_the_union_backwards() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child0: Mock<'_, 3> = Mock::new([10, 30, 40]);
+        let child1: Mock<'_, 3> = Mock::new([20, 100, 200]);
+        let mut data0 = child0.data();
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        // child0 answers `None` while still sitting on 10, so the union parks it
+        // in the dead tail with a live, lagging position.
+        data0.set_force_read_none(true);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 20);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 100);
+
+        // child1 has to move, or resume returns before the parked child is ever
+        // re-admitted.
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert_eq!(
+            union.last_doc_id(),
+            200,
+            "the union must not fall back onto a document it already delivered",
+        );
+        assert_eq!(
+            drain(&mut union),
+            [],
+            "the lagger held nothing at or past 100, so it is dropped for good",
+        );
+    }
+
+    // =========================================================================
+    // `UnionQuickFlat` coverage: `QUICK_EXIT = true` is a separate
+    // monomorphization with its own settle branches, and every test above uses
+    // `UnionFullFlat`.
+    // =========================================================================
+
+    #[test]
+    fn quick_revalidate_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionQuickFlat::new(children);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+        assert_eq!(union.last_doc_id(), 10);
+        assert_eq!(drain(&mut union), [15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    }
+
+    #[test]
+    fn quick_revalidate_moved() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionQuickFlat::new(children);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert_eq!(union.last_doc_id(), 20);
+        assert_eq!(drain(&mut union), [25, 30, 35, 40, 45, 50, 55]);
+    }
+
+    /// A quick union losing a child exercises the compaction and the
+    /// `quick_set_from_child` republish that a full union never reaches.
+    #[test]
+    fn quick_revalidate_single_child_aborts() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionQuickFlat::new(children);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert_eq!(union.last_doc_id(), 15);
+        assert_eq!(drain(&mut union), [25, 35, 45, 55]);
+    }
+
+    // =========================================================================
+    // Differential: the legacy `revalidate` and the new `resume` are two
+    // spellings of one transition and must not drift.
+    // =========================================================================
+
+    /// The outcome shape the legacy and resume paths share.
+    #[derive(Debug, PartialEq, Eq)]
+    enum Outcome {
+        Ok,
+        Moved,
+        Aborted,
+        Failed,
+    }
+
+    /// Drive `build()` through the legacy `revalidate` and through
+    /// `suspend`/`resume`, and require both to agree on the outcome *and* on
+    /// everything read afterwards. `what` names the scenario in the failure.
+    #[track_caller]
+    fn assert_paths_agree<'index, const QUICK_EXIT: bool>(
+        what: &str,
+        guard: &index_spec::IndexSpecReadGuard<'index>,
+        build: impl Fn() -> Box<UnionFlat<'index, TypeErasedRQEIterator<'index>, QUICK_EXIT>>,
+    ) {
+        let mut legacy = build();
+        let legacy_outcome = match legacy.revalidate(guard) {
+            Ok(RQEValidateStatus::Ok) => Outcome::Ok,
+            Ok(RQEValidateStatus::Moved { .. }) => Outcome::Moved,
+            Ok(RQEValidateStatus::Aborted) => Outcome::Aborted,
+            Err(_) => Outcome::Failed,
+        };
+        // An aborted or failed iterator is dropped rather than used, so there is
+        // nothing left to read on either path.
+        let legacy_tail = match legacy_outcome {
+            Outcome::Ok | Outcome::Moved => drain(&mut *legacy),
+            Outcome::Aborted | Outcome::Failed => Vec::new(),
+        };
+
+        let (resumed_outcome, resumed_tail) = match build().suspend().resume(guard) {
+            Ok(ResumeOutcome::Ok(mut it)) => (Outcome::Ok, drain(&mut *it)),
+            Ok(ResumeOutcome::Moved(mut it)) => (Outcome::Moved, drain(&mut *it)),
+            Ok(ResumeOutcome::Aborted) => (Outcome::Aborted, Vec::new()),
+            Err(_) => (Outcome::Failed, Vec::new()),
+        };
+
+        assert_eq!(
+            legacy_outcome, resumed_outcome,
+            "{what}: the two paths disagree on the outcome",
+        );
+        assert_eq!(
+            legacy_tail, resumed_tail,
+            "{what}: the two paths disagree on what is read afterwards",
+        );
+    }
+
+    /// Every child outcome at every position, for both modes. The position
+    /// matters because the abort/error teardown splits the child list at the
+    /// failing index, and the mode matters because `QUICK_EXIT` takes settle
+    /// branches the full union cannot reach.
+    #[test]
+    fn revalidate_and_resume_agree_on_every_child_outcome() {
+        let outcomes = [
+            MockRevalidateResult::Ok,
+            MockRevalidateResult::Move,
+            MockRevalidateResult::Abort,
+            MockRevalidateResult::TimedOut,
+        ];
+        for position in 0..3 {
+            for outcome in outcomes {
+                let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+                let guard = mock_ctx.spec_read();
+                let build = || {
+                    let child0: Mock<'_, 4> = Mock::new([10, 20, 40, 70]);
+                    let child1: Mock<'_, 4> = Mock::new([10, 30, 50, 80]);
+                    let child2: Mock<'_, 4> = Mock::new([10, 35, 60, 90]);
+                    for (i, data) in [child0.data(), child1.data(), child2.data()]
+                        .iter_mut()
+                        .enumerate()
+                    {
+                        data.set_revalidate_result(if i == position {
+                            outcome
+                        } else {
+                            MockRevalidateResult::Ok
+                        });
+                    }
+                    (child0, child1, child2)
+                };
+                let what = format!("child {position} reports {outcome:?}");
+                assert_paths_agree(&format!("full: {what}"), &guard, || {
+                    let (c0, c1, c2) = build();
+                    let mut it = Box::new(UnionFullFlat::new(boxed_children(c0, c1, c2)));
+                    assert_eq!(it.read().expect("read failed").expect("doc").doc_id, 10);
+                    it
+                });
+                assert_paths_agree(&format!("quick: {what}"), &guard, || {
+                    let (c0, c1, c2) = build();
+                    let mut it = Box::new(UnionQuickFlat::new(boxed_children(c0, c1, c2)));
+                    assert_eq!(it.read().expect("read failed").expect("doc").doc_id, 10);
+                    it
+                });
+            }
+        }
+    }
+
+    /// The two exits `revalidate` reaches *before* it looks at any child, and
+    /// which `resume` has to reproduce even though it must transition the
+    /// children regardless: a union that has already finished, and a union that
+    /// never had a child to begin with.
+    #[test]
+    fn revalidate_and_resume_agree_on_a_spent_or_empty_union() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+
+        for outcome in [MockRevalidateResult::Ok, MockRevalidateResult::Abort] {
+            assert_paths_agree(
+                &format!("full, spent, children {outcome:?}"),
+                &guard,
+                || {
+                    let child0: Mock<'_, 2> = Mock::new([10, 30]);
+                    let child1: Mock<'_, 2> = Mock::new([20, 40]);
+                    for data in [child0.data(), child1.data()].iter_mut() {
+                        data.set_revalidate_result(outcome);
+                    }
+                    let mut it = Box::new(UnionFullFlat::new(vec![
+                        TypeErasedRQEIterator::new(Box::new(child0)),
+                        TypeErasedRQEIterator::new(Box::new(child1)),
+                    ]));
+                    assert_eq!(drain(&mut *it), [10, 20, 30, 40]);
+                    it
+                },
+            );
+        }
+
+        assert_paths_agree("full, empty", &guard, || {
+            Box::new(UnionFullFlat::new(Vec::new()))
+        });
+        assert_paths_agree("quick, empty", &guard, || {
+            Box::new(UnionQuickFlat::new(Vec::new()))
+        });
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_heap.rs
@@ -278,3 +278,762 @@ fn union_full_heap_upholds_current_contract() {
     assert_eq!(assert_current_contract(&mut it), [1, 2, 3, 4]);
     assert_current_contract_via_skip_to(&mut it, 5);
 }
+
+mod via_resume {
+    use crate::utils::{Mock, MockIteratorError, MockRevalidateResult};
+    use rqe_core::DocId;
+    use rqe_iterators::{
+        RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator, RQEValidateStatus,
+        ResumeOutcome, TypeErasedRQEIterator, UnionFullHeap, UnionHeap, UnionQuickHeap,
+    };
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    /// Read `it` to completion, collecting the doc ids it yields.
+    fn drain<'index>(it: &mut impl RQEIterator<'index>) -> Vec<DocId> {
+        let mut seen = Vec::new();
+        while let Some(doc) = it.read().expect("read failed") {
+            seen.push(doc.doc_id);
+        }
+        seen
+    }
+
+    /// Wrap three mocks as the type-erased children a composite really holds:
+    /// their active and suspended forms carry different vtables, which a
+    /// concrete-child test cannot exercise.
+    fn boxed_children<'spec, const N0: usize, const N1: usize, const N2: usize>(
+        c0: Mock<'spec, N0>,
+        c1: Mock<'spec, N1>,
+        c2: Mock<'spec, N2>,
+    ) -> Vec<TypeErasedRQEIterator<'spec>> {
+        vec![
+            TypeErasedRQEIterator::new(Box::new(c0)),
+            TypeErasedRQEIterator::new(Box::new(c1)),
+            TypeErasedRQEIterator::new(Box::new(c2)),
+        ]
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 15);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 20);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_moved() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert!(union.last_doc_id() > 10);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_single_child_aborts() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union =
+            match revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+                .expect("resume failed")
+            {
+                ResumeOutcome::Ok(it) | ResumeOutcome::Moved(it) => it,
+                ResumeOutcome::Aborted => {
+                    panic!("Expected MOVED or OK when one child aborts, got Aborted")
+                }
+            };
+        let r = union.read().unwrap().unwrap();
+        assert!(r.doc_id >= 15);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_all_children_abort() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed");
+        assert!(matches!(outcome, ResumeOutcome::Aborted));
+    }
+
+    /// Phase 3.17 regression: when no child moved, rebuild aggregate at the
+    /// previous saved position (no skip_to shortcut).
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_minimum_unchanged_returns_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 3> = Mock::new([10, 30, 50]);
+        let child1: Mock<'_, 3> = Mock::new([10, 40, 60]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let r = union.read().unwrap().unwrap();
+        assert!(r.doc_id > 10, "expected next doc_id > 10, got {}", r.doc_id);
+    }
+
+    /// Phase 5b.5 regression: an EOF child dropped from the heap must NOT be
+    /// re-inserted into it by resume — it would yield its already-read max
+    /// doc_id forever.
+    ///
+    /// The *surviving* child has to move, or `any_change` stays false and
+    /// `resume` returns before `rebuild_heap` runs at all: the heap would then
+    /// be carried over untouched and the re-admission filter this test is about
+    /// (`rebuild_heap`'s `!child.at_eof()`) would never be reached.
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_swap_removed_dead_tail_not_yielded_again() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 2> = Mock::new([10, 20]);
+        let child1: Mock<'_, 5> = Mock::new([5, 15, 25, 35, 45]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let mut docs = Vec::new();
+        for _ in 0..4 {
+            docs.push(union.read().unwrap().unwrap().doc_id);
+        }
+        assert_eq!(docs, [5, 10, 15, 20]);
+        // The next read runs child0 past its last document, dropping it from
+        // the heap while it stays in the children vector.
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 25);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert_eq!(
+            union.last_doc_id(),
+            35,
+            "only the surviving child backs the union's new position",
+        );
+
+        let remaining: Vec<_> =
+            std::iter::from_fn(|| union.read().unwrap().map(|r| r.doc_id)).collect();
+        assert_eq!(remaining, [45], "child0's 20 must not come back");
+    }
+
+    /// The same dead-tail child, but *aborting*: the compaction that removes it
+    /// shifts the survivor down to slot 0, invalidating every `child_idx` the
+    /// heap still caches. Only the `rebuild_heap` that follows re-derives them,
+    /// so a resume that reused the carried-over heap would index a child that no
+    /// longer lives there.
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn resume_compacts_over_an_aborted_dead_tail_child() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 2> = Mock::new([10, 20]);
+        let child1: Mock<'_, 5> = Mock::new([5, 15, 25, 35, 45]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let mut docs = Vec::new();
+        for _ in 0..5 {
+            docs.push(union.read().unwrap().unwrap().doc_id);
+        }
+        assert_eq!(docs, [5, 10, 15, 20, 25]);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+        assert_eq!(
+            union.last_doc_id(),
+            25,
+            "the survivor still sits on the union's document",
+        );
+        assert_eq!(drain(&mut union), [35, 45]);
+    }
+
+    /// `resume` hands the aggregate back across the cycle rather than rebuilding
+    /// it, so every entry must still *reach* its child afterwards. Every other
+    /// `Ok`-path test reads first, which resets and rebuilds the aggregate, so a
+    /// broken entry would be overwritten before anything read it. Dereference
+    /// every entry here instead, in the window between the resume and the next
+    /// read — the window a scorer walking `current()` occupies in production.
+    ///
+    /// Run under miri this is also the regression test for the entries'
+    /// *provenance*, which is the half a plain read cannot see: the addresses
+    /// survive a child's transition on their own, the borrows they were derived
+    /// from do not, and only `resume`'s re-derivation of the entries makes them
+    /// usable rather than merely well-addressed. The twin of
+    /// `union_flat::via_resume::resume_ok_leaves_the_aggregate_pointing_at_live_children`.
+    #[test]
+    fn resume_ok_leaves_the_aggregate_pointing_at_live_children() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // All three children start on 10, so all three back the aggregate.
+        let child0: Mock<'_, 3> = Mock::new([10, 40, 70]);
+        let child1: Mock<'_, 3> = Mock::new([10, 50, 80]);
+        let child2: Mock<'_, 3> = Mock::new([10, 60, 90]);
+        // Nothing moves, so `resume` carries the aggregate across untouched —
+        // the case its liveness obligation rests on entirely.
+        for data in [child0.data(), child1.data(), child2.data()].iter_mut() {
+            data.set_revalidate_result(MockRevalidateResult::Ok);
+        }
+
+        let mut union = UnionFullHeap::new(boxed_children(child0, child1, child2));
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let current = union
+            .current()
+            .expect("an unchanged union is still positioned");
+        assert_eq!(current.doc_id, 10);
+        let aggregate = current
+            .as_aggregate()
+            .expect("a full union publishes an aggregate result");
+        assert_eq!(aggregate.len(), 3, "one entry per child on the document");
+        for i in 0..aggregate.len() {
+            let entry = aggregate.get(i).expect("index below len");
+            assert_eq!(
+                entry.doc_id, 10,
+                "entry {i} must still reach its child's live result",
+            );
+        }
+
+        // Only now let a read rebuild the aggregate from scratch.
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 40);
+    }
+
+    /// The suspend/resume cycle must reuse the allocation: the FFI wrapper and
+    /// delegating parents cache raw pointers into the iterator's storage, and a
+    /// rebuilt box would dangle them.
+    #[test]
+    fn resume_preserves_box_address() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let children = vec![Mock::new([10u64, 30]), Mock::new([20u64, 40])];
+        let mut union = Box::new(UnionFullHeap::new(children));
+        let r = union.read().expect("read failed").expect("expected doc");
+        assert_eq!(r.doc_id, 10);
+        let addr_before = &*union as *const _ as usize;
+
+        let suspended = union.suspend();
+        assert_eq!(
+            &*suspended as *const _ as usize, addr_before,
+            "suspend must reuse the allocation",
+        );
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(a) => a,
+            ResumeOutcome::Moved(_) => panic!("expected Ok, got Moved"),
+            ResumeOutcome::Aborted => panic!("expected Ok, got Aborted"),
+        };
+        assert_eq!(
+            &*active as *const _ as usize, addr_before,
+            "resume must reuse the allocation",
+        );
+
+        let r = active.read().expect("read failed").expect("expected doc");
+        assert_eq!(r.doc_id, 20, "the union carries on where it was");
+    }
+
+    /// A child whose resume *fails* takes the union down the
+    /// `free_after_consumed_child` teardown, the most delicate unsafe in this
+    /// file: it drops the compacted resumed prefix, leaves the consumed slot
+    /// alone, and drops the still-suspended tail. Get the `kept`/`consumed`
+    /// boundary wrong and it is a double free or a leak, both of which miri
+    /// sees through the mocks' reference-counted state.
+    ///
+    /// This is the plain shape: no child aborted first, so `kept == consumed`
+    /// and the buffer is a resumed prefix, the consumed slot, and a suspended
+    /// tail — all three regions at once.
+    #[test]
+    fn resume_child_error_frees_a_shell_with_a_suspended_tail() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child0: Mock<'_, 3> = Mock::new([10, 40, 70]);
+        let child1: Mock<'_, 3> = Mock::new([20, 50, 80]);
+        let child2: Mock<'_, 3> = Mock::new([30, 60, 90]);
+        child1
+            .data()
+            .set_error_on_resume(Some(MockIteratorError::TimeoutError(None)));
+
+        let mut union = UnionFullHeap::new(boxed_children(child0, child1, child2));
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        match revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard) {
+            Err(e) => assert!(matches!(e, RQEIteratorError::TimedOut)),
+            Ok(_) => panic!("the failing child's error must reach the caller"),
+        }
+    }
+
+    /// The same teardown, but with a hole in the middle: child 0 aborts before
+    /// child 2 fails, so the survivor is compacted down to slot 0 and `kept`
+    /// (1) trails `consumed` (2). Slot 1 is then a vacated hole that the
+    /// teardown must skip — the clause the plain shape never reaches.
+    #[test]
+    fn resume_child_error_frees_a_shell_with_a_hole_in_it() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child0: Mock<'_, 3> = Mock::new([10, 40, 70]);
+        let child1: Mock<'_, 3> = Mock::new([20, 50, 80]);
+        let child2: Mock<'_, 3> = Mock::new([30, 60, 90]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child2
+            .data()
+            .set_error_on_resume(Some(MockIteratorError::TimeoutError(None)));
+
+        let mut union = UnionFullHeap::new(boxed_children(child0, child1, child2));
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        match revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard) {
+            Err(e) => assert!(matches!(e, RQEIteratorError::TimedOut)),
+            Ok(_) => panic!("the failing child's error must reach the caller"),
+        }
+    }
+
+    /// A `Moved` that changes *which* child is the minimum, which is what makes
+    /// the post-resume `rebuild_heap` more than a formality. Both children
+    /// advance, but child 0 jumps past child 1: the root has to change hands, so
+    /// a re-sift that is merely partial or mis-ordered — not just an absent one —
+    /// surfaces as the wrong position.
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn resume_moved_resifts_the_heap_when_the_root_changes_child() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 2> = Mock::new([10, 100]);
+        let child1: Mock<'_, 2> = Mock::new([15, 20]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+        assert_eq!(
+            union.read().unwrap().unwrap().doc_id,
+            10,
+            "child 0 starts out as the root",
+        );
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert_eq!(
+            union.last_doc_id(),
+            20,
+            "child 1 is the minimum now that child 0 jumped to 100",
+        );
+        assert_eq!(drain(&mut union), [100]);
+    }
+
+    /// A finished union is finished whatever its children now say:
+    /// `revalidate` tests `is_eof` before it looks at a single child, so it
+    /// reports `Ok` without asking them. `resume` has to transition the
+    /// children regardless, but must still reach the same verdict — and hand
+    /// back the position it was spent on, since the aggregate it carries was
+    /// never rebuilt.
+    #[test]
+    fn resume_of_a_finished_union_is_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 2> = Mock::new([10, 30]);
+        let child1: Mock<'_, 2> = Mock::new([20, 40]);
+        for data in [child0.data(), child1.data()].iter_mut() {
+            data.set_revalidate_result(MockRevalidateResult::Move);
+        }
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+        assert_eq!(drain(&mut union), [10, 20, 30, 40]);
+        assert!(union.at_eof());
+        let spent_at = union.last_doc_id();
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+        assert!(union.at_eof());
+        assert!(union.current().is_none());
+        assert_eq!(
+            union.last_doc_id(),
+            spent_at,
+            "a spent union keeps the position it stopped on",
+        );
+        assert!(matches!(union.read(), Ok(None)));
+    }
+
+    /// A child re-admitted *behind* the union is the shape the settle's
+    /// `min.doc_id < original_last_doc_id` block exists for: the union may not
+    /// adopt a minimum it has already passed, so every lagger is seeked up to
+    /// the abandoned position instead.
+    ///
+    /// The legacy twin gets there with [`MockData::set_revalidate_reseeks_to`],
+    /// which only the legacy `revalidate` honours — [`MockSuspended::resume`]
+    /// never reads it, so the re-seek branch is unreachable from the resume
+    /// path. The lagger is produced the other way the union parks a child
+    /// without exhausting it instead: a `read` that answers `None` while the
+    /// child still holds documents, which leaves its position untouched.
+    ///
+    /// [`MockData::set_revalidate_reseeks_to`]: crate::utils::MockData::set_revalidate_reseeks_to
+    /// [`MockSuspended::resume`]: crate::utils::MockSuspended
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn resume_does_not_let_a_re_admitted_lagger_drag_the_union_backwards() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child0: Mock<'_, 3> = Mock::new([10, 30, 40]);
+        let child1: Mock<'_, 3> = Mock::new([20, 100, 200]);
+        let mut data0 = child0.data();
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        // child0 answers `None` while still sitting on 10, so the union drops it
+        // from the heap with a live, lagging position.
+        data0.set_force_read_none(true);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 20);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 100);
+
+        // child1 has to move, or resume returns before the parked child is ever
+        // re-admitted.
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert_eq!(
+            union.last_doc_id(),
+            200,
+            "the union must not fall back onto a document it already delivered",
+        );
+        assert_eq!(
+            drain(&mut union),
+            [],
+            "the lagger held nothing at or past 100, so it is dropped for good",
+        );
+    }
+
+    // =========================================================================
+    // `UnionQuickHeap` coverage: `QUICK_EXIT = true` is a separate
+    // monomorphization with its own settle branches, and every test above uses
+    // `UnionFullHeap`.
+    // =========================================================================
+
+    #[test]
+    fn quick_revalidate_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionQuickHeap::new(children);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+        assert_eq!(union.last_doc_id(), 10);
+        assert_eq!(drain(&mut union), [15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    }
+
+    #[test]
+    fn quick_revalidate_moved() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionQuickHeap::new(children);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert_eq!(union.last_doc_id(), 20);
+        assert_eq!(drain(&mut union), [25, 30, 35, 40, 45, 50, 55]);
+    }
+
+    // =========================================================================
+    // Differential: the legacy `revalidate` and the new `resume` are two
+    // spellings of one transition and must not drift.
+    // =========================================================================
+
+    /// The outcome shape the legacy and resume paths share.
+    #[derive(Debug, PartialEq, Eq)]
+    enum Outcome {
+        Ok,
+        Moved,
+        Aborted,
+        Failed,
+    }
+
+    /// Drive `build()` through the legacy `revalidate` and through
+    /// `suspend`/`resume`, and require both to agree on the outcome *and* on
+    /// everything read afterwards. `what` names the scenario in the failure.
+    #[track_caller]
+    fn assert_paths_agree<'index, const QUICK_EXIT: bool>(
+        what: &str,
+        guard: &index_spec::IndexSpecReadGuard<'index>,
+        build: impl Fn() -> Box<UnionHeap<'index, TypeErasedRQEIterator<'index>, QUICK_EXIT>>,
+    ) {
+        let mut legacy = build();
+        let legacy_outcome = match legacy.revalidate(guard) {
+            Ok(RQEValidateStatus::Ok) => Outcome::Ok,
+            Ok(RQEValidateStatus::Moved { .. }) => Outcome::Moved,
+            Ok(RQEValidateStatus::Aborted) => Outcome::Aborted,
+            Err(_) => Outcome::Failed,
+        };
+        // An aborted or failed iterator is dropped rather than used, so there is
+        // nothing left to read on either path.
+        let legacy_tail = match legacy_outcome {
+            Outcome::Ok | Outcome::Moved => drain(&mut *legacy),
+            Outcome::Aborted | Outcome::Failed => Vec::new(),
+        };
+
+        let (resumed_outcome, resumed_tail) = match build().suspend().resume(guard) {
+            Ok(ResumeOutcome::Ok(mut it)) => (Outcome::Ok, drain(&mut *it)),
+            Ok(ResumeOutcome::Moved(mut it)) => (Outcome::Moved, drain(&mut *it)),
+            Ok(ResumeOutcome::Aborted) => (Outcome::Aborted, Vec::new()),
+            Err(_) => (Outcome::Failed, Vec::new()),
+        };
+
+        assert_eq!(
+            legacy_outcome, resumed_outcome,
+            "{what}: the two paths disagree on the outcome",
+        );
+        assert_eq!(
+            legacy_tail, resumed_tail,
+            "{what}: the two paths disagree on what is read afterwards",
+        );
+    }
+
+    /// Every child outcome at every position, for both modes. The position
+    /// matters because the abort/error teardown splits the child list at the
+    /// failing index, and the mode matters because `QUICK_EXIT` takes settle
+    /// branches the full union cannot reach.
+    #[test]
+    fn revalidate_and_resume_agree_on_every_child_outcome() {
+        let outcomes = [
+            MockRevalidateResult::Ok,
+            MockRevalidateResult::Move,
+            MockRevalidateResult::Abort,
+            MockRevalidateResult::TimedOut,
+        ];
+        for position in 0..3 {
+            for outcome in outcomes {
+                let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+                let guard = mock_ctx.spec_read();
+                let build = || {
+                    let child0: Mock<'_, 4> = Mock::new([10, 20, 40, 70]);
+                    let child1: Mock<'_, 4> = Mock::new([10, 30, 50, 80]);
+                    let child2: Mock<'_, 4> = Mock::new([10, 35, 60, 90]);
+                    for (i, data) in [child0.data(), child1.data(), child2.data()]
+                        .iter_mut()
+                        .enumerate()
+                    {
+                        data.set_revalidate_result(if i == position {
+                            outcome
+                        } else {
+                            MockRevalidateResult::Ok
+                        });
+                    }
+                    (child0, child1, child2)
+                };
+                let what = format!("child {position} reports {outcome:?}");
+                assert_paths_agree(&format!("full: {what}"), &guard, || {
+                    let (c0, c1, c2) = build();
+                    let mut it = Box::new(UnionFullHeap::new(boxed_children(c0, c1, c2)));
+                    assert_eq!(it.read().expect("read failed").expect("doc").doc_id, 10);
+                    it
+                });
+                assert_paths_agree(&format!("quick: {what}"), &guard, || {
+                    let (c0, c1, c2) = build();
+                    let mut it = Box::new(UnionQuickHeap::new(boxed_children(c0, c1, c2)));
+                    assert_eq!(it.read().expect("read failed").expect("doc").doc_id, 10);
+                    it
+                });
+            }
+        }
+    }
+
+    /// The two exits `revalidate` reaches *before* it looks at any child, and
+    /// which `resume` has to reproduce even though it must transition the
+    /// children regardless: a union that has already finished, and a union that
+    /// never had a child to begin with.
+    #[test]
+    fn revalidate_and_resume_agree_on_a_spent_or_empty_union() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+
+        for outcome in [MockRevalidateResult::Ok, MockRevalidateResult::Abort] {
+            assert_paths_agree(
+                &format!("full, spent, children {outcome:?}"),
+                &guard,
+                || {
+                    let child0: Mock<'_, 2> = Mock::new([10, 30]);
+                    let child1: Mock<'_, 2> = Mock::new([20, 40]);
+                    for data in [child0.data(), child1.data()].iter_mut() {
+                        data.set_revalidate_result(outcome);
+                    }
+                    let mut it = Box::new(UnionFullHeap::new(vec![
+                        TypeErasedRQEIterator::new(Box::new(child0)),
+                        TypeErasedRQEIterator::new(Box::new(child1)),
+                    ]));
+                    assert_eq!(drain(&mut *it), [10, 20, 30, 40]);
+                    it
+                },
+            );
+        }
+
+        assert_paths_agree("full, empty", &guard, || {
+            Box::new(UnionFullHeap::new(Vec::new()))
+        });
+        assert_paths_agree("quick, empty", &guard, || {
+            Box::new(UnionQuickHeap::new(Vec::new()))
+        });
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_heap.rs
@@ -273,3 +273,207 @@ fn union_full_heap_upholds_current_contract() {
     assert_eq!(assert_current_contract(&mut it), [1, 2, 3, 4]);
     assert_current_contract_via_skip_to(&mut it, 5);
 }
+
+mod via_resume {
+    use crate::utils::{Mock, MockRevalidateResult};
+    use rqe_iterators::{RQEIterator, ResumeOutcome, TypeErasedRQEIterator, UnionFullHeap};
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 15);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 20);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_moved() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert!(union.last_doc_id() > 10);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_single_child_aborts() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union =
+            match revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+                .expect("resume failed")
+            {
+                ResumeOutcome::Ok(it) | ResumeOutcome::Moved(it) => it,
+                ResumeOutcome::Aborted => {
+                    panic!("Expected MOVED or OK when one child aborts, got Aborted")
+                }
+            };
+        let r = union.read().unwrap().unwrap();
+        assert!(r.doc_id >= 15);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_all_children_abort() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed");
+        assert!(matches!(outcome, ResumeOutcome::Aborted));
+    }
+
+    /// Phase 3.17 regression: when no child moved, rebuild aggregate at the
+    /// previous saved position (no skip_to shortcut).
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_minimum_unchanged_returns_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 3> = Mock::new([10, 30, 50]);
+        let child1: Mock<'_, 3> = Mock::new([10, 40, 60]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let r = union.read().unwrap().unwrap();
+        assert!(r.doc_id > 10, "expected next doc_id > 10, got {}", r.doc_id);
+    }
+
+    /// Phase 5b.5 regression: an EOF child swap-removed into the dead tail
+    /// must NOT be re-inserted into the heap by resume.
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_swap_removed_dead_tail_not_yielded_again() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 2> = Mock::new([10, 20]);
+        let child1: Mock<'_, 5> = Mock::new([5, 15, 25, 35, 45]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let mut docs = Vec::new();
+        for _ in 0..4 {
+            docs.push(union.read().unwrap().unwrap().doc_id);
+        }
+        assert_eq!(docs, [5, 10, 15, 20]);
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 25);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let remaining: Vec<_> =
+            std::iter::from_fn(|| union.read().unwrap().map(|r| r.doc_id)).collect();
+        assert_eq!(remaining, [35, 45]);
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_opaque.rs
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Tests for [`UnionOpaque`]'s suspend/resume surface.
+//!
+//! [`UnionOpaque`] has no read/skip behaviour of its own — it forwards
+//! everything to the variant it holds, and the variants are covered by
+//! `union_flat`, `union_heap` and `union_trimmed`. What *is* its own is the
+//! transition: a per-variant walk that rewrites the payload in place, followed
+//! by a whole-box cast, plus a bespoke `dealloc` for the case where the payload
+//! was consumed. Those are what these tests exercise.
+
+use std::ffi::CStr;
+
+use query_types::QueryNodeType;
+use ref_mode::SharedPtr;
+use rqe_iterators::{
+    RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator, ResumeOutcome,
+    TypeErasedRQEIterator, UnionFullFlat, UnionFullHeap, UnionOpaque, UnionQuickFlat,
+    UnionQuickHeap, UnionVariant,
+};
+use rqe_iterators_test_utils::{MockContext, ResumeOutcomeExt, revalidate_via_resume};
+
+use crate::utils::{Mock, MockIteratorError, MockRevalidateResult};
+
+/// Which concrete union sits inside the [`UnionOpaque`] under test.
+///
+/// The transition rewrites the payload **per variant**, so each arm carries its
+/// own layout obligation and covering one says nothing about the others.
+/// `Trimmed` is absent because its resume is `unreachable!` by design — trimmed
+/// unions are never revalidated — so there is no round trip to exercise.
+#[derive(Clone, Copy, Debug)]
+enum Which {
+    FlatFull,
+    FlatQuick,
+    HeapFull,
+    HeapQuick,
+}
+
+/// Wrap the mocks as the type-erased children a union really holds: their
+/// active and suspended forms carry different vtables, which a concrete-child
+/// test cannot exercise.
+fn erased<'spec, const N0: usize, const N1: usize>(
+    c0: Mock<'spec, N0>,
+    c1: Mock<'spec, N1>,
+) -> Vec<TypeErasedRQEIterator<'spec>> {
+    vec![
+        TypeErasedRQEIterator::new(Box::new(c0)),
+        TypeErasedRQEIterator::new(Box::new(c1)),
+    ]
+}
+
+fn variant_of<'spec>(
+    which: Which,
+    children: Vec<TypeErasedRQEIterator<'spec>>,
+) -> UnionVariant<'spec, TypeErasedRQEIterator<'spec>> {
+    match which {
+        Which::FlatFull => UnionVariant::FlatFull(UnionFullFlat::new(children)),
+        Which::FlatQuick => UnionVariant::FlatQuick(UnionQuickFlat::new(children)),
+        Which::HeapFull => UnionVariant::HeapFull(UnionFullHeap::new(children)),
+        Which::HeapQuick => UnionVariant::HeapQuick(UnionQuickHeap::new(children)),
+    }
+}
+
+fn opaque<'spec>(
+    variant: UnionVariant<'spec, TypeErasedRQEIterator<'spec>>,
+) -> UnionOpaque<'spec, TypeErasedRQEIterator<'spec>> {
+    UnionOpaque {
+        variant,
+        query_node_type: QueryNodeType::Union,
+        query_string: None,
+    }
+}
+
+/// A: the round trip, once per variant.
+///
+/// Guards the per-variant `ptr::write` of the suspended payload into a slot
+/// sized for the active one — an oversize write is a heap overflow, an
+/// undersize one leaves the tail of the slot holding stale active bytes that
+/// the resume then reads back as suspended state.
+#[rstest::rstest]
+#[case::flat_full(Which::FlatFull)]
+#[case::flat_quick(Which::FlatQuick)]
+#[case::heap_full(Which::HeapFull)]
+#[case::heap_quick(Which::HeapQuick)]
+fn resume_round_trip_per_variant(#[case] which: Which) {
+    let mock_ctx = MockContext::new(0, 0);
+    let child0: Mock<'_, 3> = Mock::new([10, 30, 50]);
+    let child1: Mock<'_, 3> = Mock::new([20, 40, 60]);
+
+    let mut union = opaque(variant_of(which, erased(child0, child1)));
+    assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+    let guard = mock_ctx.spec_read();
+    let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+        .expect("resume failed")
+        .expect_ok();
+
+    assert_eq!(
+        union.read().unwrap().unwrap().doc_id,
+        20,
+        "{which:?} must carry on where it was",
+    );
+}
+
+/// B: the allocation — and the payload's address inside it — survive the cycle.
+///
+/// The FFI wrapper caches a raw pointer into the payload's result object, so a
+/// transition that relocated either would dangle it. `suspend` in particular
+/// must rewrite the variant *in place* rather than moving it out to a temporary
+/// and back into a fresh box.
+#[test]
+fn resume_preserves_box_and_variant_addresses() {
+    let mock_ctx = MockContext::new(0, 0);
+    let guard = mock_ctx.spec_read();
+    let child0: Mock<'_, 2> = Mock::new([10, 30]);
+    let child1: Mock<'_, 2> = Mock::new([20, 40]);
+
+    let mut union = Box::new(opaque(UnionVariant::FlatFull(UnionFullFlat::new(erased(
+        child0, child1,
+    )))));
+    assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+    let box_addr = &*union as *const _ as usize;
+    let variant_addr = &union.variant as *const _ as usize;
+
+    let suspended = union.suspend();
+    assert_eq!(
+        &*suspended as *const _ as usize, box_addr,
+        "suspend must reuse the allocation",
+    );
+    assert_eq!(
+        &suspended.variant as *const _ as usize, variant_addr,
+        "suspend must rewrite the variant in place",
+    );
+
+    let mut active = match suspended.resume(&guard).expect("resume failed") {
+        ResumeOutcome::Ok(a) => a,
+        ResumeOutcome::Moved(_) => panic!("expected Ok, got Moved"),
+        ResumeOutcome::Aborted => panic!("expected Ok, got Aborted"),
+    };
+    assert_eq!(
+        &*active as *const _ as usize, box_addr,
+        "resume must reuse the allocation",
+    );
+    assert_eq!(
+        &active.variant as *const _ as usize, variant_addr,
+        "resume must rewrite the variant in place",
+    );
+
+    assert_eq!(active.read().unwrap().unwrap().doc_id, 20);
+}
+
+/// C1: every child aborting takes the payload down, which is the only path to
+/// the bespoke `free_shell` deallocation.
+///
+/// The payload was consumed by its own resume, so the shell must be freed
+/// *without* dropping it — with the layout the box was allocated with, which is
+/// the active form's. Under miri a mismatched layout or a double drop of the
+/// mocks' reference-counted state is caught here and nowhere else.
+#[test]
+fn resume_frees_the_shell_when_the_payload_aborts() {
+    let mock_ctx = MockContext::new(0, 0);
+    let child0: Mock<'_, 2> = Mock::new([10, 30]);
+    let child1: Mock<'_, 2> = Mock::new([20, 40]);
+    child0
+        .data()
+        .set_revalidate_result(MockRevalidateResult::Abort);
+    child1
+        .data()
+        .set_revalidate_result(MockRevalidateResult::Abort);
+
+    let mut union = opaque(UnionVariant::FlatFull(UnionFullFlat::new(erased(
+        child0, child1,
+    ))));
+    assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+    let guard = mock_ctx.spec_read();
+    let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+        .expect("resume must report the abort as an outcome, not an error");
+    assert!(matches!(outcome, ResumeOutcome::Aborted));
+}
+
+/// C2: the same teardown reached through the `Err` arm instead.
+///
+/// A failing child leaves the payload consumed exactly as an abort does, so the
+/// error path must free the shell the same way — and still surface the error.
+#[test]
+fn resume_frees_the_shell_when_the_payload_errors() {
+    let mock_ctx = MockContext::new(0, 0);
+    let child0: Mock<'_, 2> = Mock::new([10, 30]);
+    let child1: Mock<'_, 2> = Mock::new([20, 40]);
+    child1
+        .data()
+        .set_error_on_resume(Some(MockIteratorError::TimeoutError(None)));
+
+    let mut union = opaque(UnionVariant::FlatFull(UnionFullFlat::new(erased(
+        child0, child1,
+    ))));
+    assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+    let guard = mock_ctx.spec_read();
+    match revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard) {
+        Err(e) => assert!(matches!(e, RQEIteratorError::TimedOut)),
+        Ok(_) => panic!("the failing child's error must reach the caller"),
+    }
+}
+
+/// D: the suspended form's own surface — the accessors callers use *without*
+/// resuming, and the one `Rf`-parametrized field the transition re-types
+/// without validating anything.
+///
+/// `query_string` borrows the query AST rather than the index, which is why the
+/// suspend/resume cycle is allowed to hand it straight back; asserting the
+/// pointer is bit-for-bit the same is what pins that down, since a wrong
+/// payload offset would still produce a plausible-looking non-null pointer.
+#[test]
+fn suspended_accessors_and_query_string_survive_the_cycle() {
+    let mock_ctx = MockContext::new(0, 0);
+    let guard = mock_ctx.spec_read();
+    let q_str: &CStr = c"hello - world";
+    let child0: Mock<'_, 2> = Mock::new([10, 30]);
+    let child1: Mock<'_, 2> = Mock::new([20, 40]);
+
+    let mut union = Box::new(UnionOpaque {
+        variant: UnionVariant::HeapFull(UnionFullHeap::new(erased(child0, child1))),
+        query_node_type: QueryNodeType::Prefix,
+        query_string: Some(SharedPtr::from_ref(q_str)),
+    });
+    assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+    let num_estimated = RQEIterator::num_estimated(&*union);
+
+    let suspended = union.suspend();
+    assert_eq!(
+        RQESuspendedIterator::last_doc_id(&*suspended),
+        10,
+        "the suspended form reports the position without resuming",
+    );
+    assert_eq!(
+        RQESuspendedIterator::num_estimated(&*suspended),
+        num_estimated,
+    );
+    assert_eq!(
+        suspended
+            .query_string
+            .expect("the query string survives suspend")
+            .as_raw(),
+        std::ptr::from_ref(q_str),
+    );
+
+    let active = match suspended.resume(&guard).expect("resume failed") {
+        ResumeOutcome::Ok(a) => a,
+        ResumeOutcome::Moved(_) => panic!("expected Ok, got Moved"),
+        ResumeOutcome::Aborted => panic!("expected Ok, got Aborted"),
+    };
+    assert_eq!(
+        active
+            .query_string
+            .expect("the query string survives resume")
+            .as_raw(),
+        std::ptr::from_ref(q_str),
+    );
+    assert_eq!(active.query_node_type, QueryNodeType::Prefix);
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
@@ -467,3 +467,30 @@ fn into_trimmed_reuses_all_children() {
         "previously trimmed children are now active"
     );
 }
+
+mod via_resume {
+    use crate::utils::Mock;
+    use rqe_iterators::{TypeErasedRQEIterator, UnionTrimmed};
+    use rqe_iterators_test_utils::revalidate_via_resume;
+
+    /// Resume must panic on UnionTrimmed for the same reason `revalidate`
+    /// does: trimmed unions are constructed for the partial-range
+    /// optimization path which doesn't release the spec lock between reads.
+    #[test]
+    #[should_panic(expected = "resume is not supported on UnionTrimmed")]
+    fn resume_panics() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 1> = Mock::new([1]);
+        let child1: Mock<'_, 1> = Mock::new([2]);
+        let child2: Mock<'_, 1> = Mock::new([3]);
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+            TypeErasedRQEIterator::new(Box::new(child2)),
+        ];
+        let union = UnionTrimmed::new(children, usize::MAX, true);
+
+        let guard = mock_ctx.spec_read();
+        let _ = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard);
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
@@ -484,3 +484,118 @@ fn into_trimmed_reuses_all_children() {
         "previously trimmed children are now active"
     );
 }
+
+mod via_resume {
+    use crate::utils::Mock;
+    use rqe_core::DocId;
+    use rqe_iterators::{
+        RQEIterator, RQEIteratorBoxed, RQESuspendedIterator, TypeErasedRQEIterator, UnionTrimmed,
+    };
+    use rqe_iterators_test_utils::revalidate_via_resume;
+
+    /// Builds one type-erased single-document child per id. Erased children are
+    /// what production hands the union, and the only shape that can exhibit the
+    /// wrong-vtable bug `suspend_transitions_children_outside_the_active_window`
+    /// guards.
+    fn erased_children(doc_ids: &[DocId]) -> Vec<TypeErasedRQEIterator<'static>> {
+        doc_ids
+            .iter()
+            .map(|&doc_id| {
+                let child: Mock<'_, 1> = Mock::new([doc_id]);
+                TypeErasedRQEIterator::new(Box::new(child))
+            })
+            .collect()
+    }
+
+    /// Resume must panic on UnionTrimmed for the same reason `revalidate`
+    /// does: trimmed unions are constructed for the partial-range
+    /// optimization path which doesn't release the spec lock between reads.
+    #[test]
+    #[should_panic(expected = "resume is not supported on UnionTrimmed")]
+    fn resume_panics() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 1> = Mock::new([1]);
+        let child1: Mock<'_, 1> = Mock::new([2]);
+        let child2: Mock<'_, 1> = Mock::new([3]);
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+            TypeErasedRQEIterator::new(Box::new(child2)),
+        ];
+        let union = UnionTrimmed::new(children, usize::MAX, true);
+
+        let guard = mock_ctx.spec_read();
+        let _ = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard);
+    }
+
+    /// Guards a `dyn`-vtable type confusion on drop: `suspend` must transition
+    /// **every** child it owns, not only those inside the active window.
+    ///
+    /// Every other test in this file builds the union with `limit = usize::MAX`,
+    /// where the window spans all children — so none of them can tell the
+    /// correct loop apart from one narrowed to the active window. Under a limit
+    /// that actually trims, the narrowed loop would leave the trimmed-away
+    /// elements holding an active [`TypeErasedRQEIterator`] inside a `Vec` that
+    /// is then dropped as a vector of the suspended sibling: a different `dyn`
+    /// trait, hence a different vtable. Nothing observable happens until the
+    /// drop reads the wrong vtable, which is why this test earns its keep only
+    /// under Miri.
+    #[test]
+    fn suspend_transitions_children_outside_the_active_window() {
+        // Five children estimating one document each; `limit = 1` ascending
+        // keeps `children[0..3)`, leaving the last two owned but inactive.
+        let union = UnionTrimmed::new(erased_children(&[1, 2, 3, 4, 5]), 1, true);
+        assert_eq!(union.num_children_total(), 5);
+        assert_eq!(
+            union.num_children_active(),
+            3,
+            "the limit must actually trim, or this test degenerates into every other one"
+        );
+
+        let suspended = Box::new(union).suspend();
+        assert_eq!(
+            suspended.num_estimated(),
+            3,
+            "the suspended form still reports the active window's estimate"
+        );
+        drop(suspended);
+    }
+
+    /// Guards against `suspend` rebuilding the iterator's storage: the FFI
+    /// wrapper and delegating parents cache raw pointers into it, so a
+    /// `Box::new(RawUnionTrimmed { .. })` would dangle them while passing every
+    /// behavioural test. Only the suspend half is checkable here — see
+    /// [`resume_panics`].
+    #[test]
+    fn suspend_preserves_box_address() {
+        let union = Box::new(UnionTrimmed::new(
+            erased_children(&[1, 2, 3]),
+            usize::MAX,
+            true,
+        ));
+        let addr_before = &*union as *const _ as usize;
+
+        let suspended = union.suspend();
+        assert_eq!(
+            &*suspended as *const _ as usize, addr_before,
+            "suspend must reuse the allocation"
+        );
+    }
+
+    /// Guards the suspended accessors — besides `suspend` itself, the only new
+    /// code that ever executes, and the sole externally visible evidence that
+    /// the cursor and result state survived the whole-box cast. `union_opaque`
+    /// delegates its own suspended accessors straight to these, so a wrong field
+    /// here would surface only there.
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn suspended_last_doc_id_reports_the_pre_suspend_position() {
+        let mut union = UnionTrimmed::new(erased_children(&[1, 2, 3]), usize::MAX, true);
+        // Children are drained last to first, so the first read yields the
+        // last child's document.
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 3);
+
+        let suspended = Box::new(union).suspend();
+        assert_eq!(suspended.last_doc_id(), 3);
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/wildcard.rs
@@ -297,3 +297,283 @@ fn wildcard_upholds_current_contract() {
     assert_eq!(assert_current_contract(&mut it), [1, 2, 3, 4, 5]);
     assert_current_contract_via_skip_to(&mut it, 6);
 }
+
+/// Suspend/resume coverage for [`OptimizedWildcard`], the enum that stands in
+/// for the `existingDocs`-backed wildcard once the encoding is known.
+///
+/// [`OptimizedWildcard`] adds no behaviour of its own — every method forwards
+/// to the inverted-index wildcard inside, which `inverted_index::wildcard`
+/// already covers. What it adds is a whole-box reinterpretation between itself
+/// and [`OptimizedWildcardSuspended`], so these tests are about the enum's
+/// *layout* surviving the round trip, per variant.
+mod via_resume {
+    use ffi::IndexFlags_Index_DocIdsOnly;
+    use index_result::RSIndexResult;
+    use inverted_index::{
+        DecodedBy, Encoder, InvertedIndex, doc_ids_only::DocIdsOnly, opaque,
+        opaque::OpaqueEncoding, raw_doc_ids_only::RawDocIdsOnly,
+    };
+    use rqe_core::{DocId, RS_FIELDMASK_ALL};
+    use rqe_iterators::{
+        RQEIterator, RQEIteratorBoxed, RQESuspendedIterator, ResumeOutcome,
+        inverted_index::Wildcard as InvIdxWildcard,
+        wildcard::{OptimizedWildcard, OptimizedWildcardSuspended},
+    };
+    use rqe_iterators_test_utils::MockContext;
+
+    const DOC_IDS: [DocId; 5] = [1, 3, 5, 7, 9];
+
+    /// An `existingDocs` inverted index wired into a [`MockContext`]'s spec.
+    ///
+    /// The wiring is the point: resume opens with an identity check against
+    /// `spec.existingDocs`, so a fixture that leaves the spec's pointer null
+    /// (like `optional_optimized`'s `WildcardIndex`) can only ever produce
+    /// `Aborted`. The index is held behind a raw pointer so the spec's view of
+    /// it and the reader's view of it are derived from the same provenance.
+    struct ExistingDocs {
+        ctx: MockContext,
+        index: *mut opaque::InvertedIndex,
+    }
+
+    impl Drop for ExistingDocs {
+        fn drop(&mut self) {
+            self.ctx
+                .spec_write()
+                .set_existing_docs_ptr(std::ptr::null_mut());
+            // SAFETY: `index` came from `Box::into_raw` in `new` and every
+            // borrow handed out is tied to `&self`, so none outlives this.
+            unsafe { drop(Box::from_raw(self.index)) };
+        }
+    }
+
+    fn populate<E: Encoder>(ii: &mut InvertedIndex<E>) {
+        for doc_id in DOC_IDS {
+            let record = RSIndexResult::build_virt()
+                .doc_id(doc_id)
+                .field_mask(RS_FIELDMASK_ALL)
+                .frequency(1)
+                .build();
+            ii.add_record(&record).expect("failed to add record");
+        }
+    }
+
+    impl ExistingDocs {
+        fn new(index: opaque::InvertedIndex) -> Self {
+            let ctx = MockContext::new(0, 0);
+            let index = Box::into_raw(Box::new(index));
+            ctx.spec_write().set_existing_docs_ptr(index.cast());
+            Self { ctx, index }
+        }
+
+        fn doc_ids_only() -> Self {
+            let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+            populate(&mut ii);
+            Self::new(opaque::InvertedIndex::DocIdsOnly(ii))
+        }
+
+        fn raw_doc_ids_only() -> Self {
+            let mut ii = InvertedIndex::<RawDocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+            populate(&mut ii);
+            Self::new(opaque::InvertedIndex::RawDocIdsOnly(ii))
+        }
+
+        /// The typed index the spec's `existingDocs` points at.
+        fn typed<E>(&self) -> &InvertedIndex<E>
+        where
+            E: DecodedBy + OpaqueEncoding<Storage = InvertedIndex<E>>,
+        {
+            // SAFETY: `index` is a live, exclusively-owned allocation for as
+            // long as `self` is; the returned borrow is tied to `&self`.
+            E::from_opaque(unsafe { &*self.index })
+        }
+
+        /// Garbage-collect `doc_id` out of the index, the way the fork GC does.
+        ///
+        /// Takes `&self` so it can run while an iterator built from
+        /// [`typed`](Self::typed) is still alive — which is the whole point of
+        /// the scenario, and also why the caller has to be miri-ignored: the
+        /// exclusive access below overlaps a shared borrow that outlives it.
+        /// The existing `inverted_index::wildcard` revalidation tests take the
+        /// same shortcut for the same reason.
+        fn remove_document<E>(&self, doc_id: DocId)
+        where
+            E: Encoder + DecodedBy + OpaqueEncoding<Storage = InvertedIndex<E>>,
+        {
+            // SAFETY: `index` is a live, exclusively-owned allocation; see the
+            // aliasing caveat above for the borrow that overlaps this one.
+            let ii = E::from_mut_opaque(unsafe { &mut *self.index });
+            let delta = ii
+                .scan_gc(
+                    |d| d != doc_id,
+                    None::<fn(&RSIndexResult, &inverted_index::RepairContext<'_>)>,
+                )
+                .expect("scan GC failed")
+                .expect("no GC scan delta");
+            assert_eq!(ii.apply_gc(delta).entries_removed, 1);
+        }
+    }
+
+    /// E: the round trip, for both encodings.
+    ///
+    /// The `matches!` assertions are the interesting ones: they check that the
+    /// whole-box cast landed on the *same* variant, which is what a disagreeing
+    /// tag encoding between the two enums would break, and it can disagree per
+    /// variant — so covering only the first would prove little.
+    ///
+    /// It is worth being precise about what this does *not* establish. The
+    /// guarantee that the encodings agree comes from `#[repr(C, u8)]` on the
+    /// pair, not from here: with the attribute removed, `repr(Rust)` happens to
+    /// pick the same layout on the current toolchain and target, and this test
+    /// still passes (checked under miri). It is a regression test for the
+    /// *cast* — the addresses, the tag, and the position — and it will catch a
+    /// layout divergence if one ever materialises, but the attribute is what
+    /// stops one from materialising in the first place.
+    #[rstest::rstest]
+    #[case::doc_ids_only(false)]
+    #[case::raw_doc_ids_only(true)]
+    fn resume_round_trip_per_variant(#[case] raw: bool) {
+        let fixture = if raw {
+            ExistingDocs::raw_doc_ids_only()
+        } else {
+            ExistingDocs::doc_ids_only()
+        };
+        let guard = fixture.ctx.spec_read();
+        let mut it = Box::new(if raw {
+            OptimizedWildcard::RawDocIdsOnly(InvIdxWildcard::new(
+                fixture.typed::<RawDocIdsOnly>().reader(),
+                1.0,
+            ))
+        } else {
+            OptimizedWildcard::DocIdsOnly(InvIdxWildcard::new(
+                fixture.typed::<DocIdsOnly>().reader(),
+                1.0,
+            ))
+        });
+
+        assert_eq!(it.read().unwrap().unwrap().doc_id, DOC_IDS[0]);
+        let box_addr = &*it as *const _ as usize;
+
+        let suspended = it.suspend();
+        assert_eq!(
+            &*suspended as *const _ as usize, box_addr,
+            "suspend must reuse the allocation",
+        );
+        let tag_survived = if raw {
+            matches!(&*suspended, OptimizedWildcardSuspended::RawDocIdsOnly(_))
+        } else {
+            matches!(&*suspended, OptimizedWildcardSuspended::DocIdsOnly(_))
+        };
+        assert!(tag_survived, "suspend must land on the same variant");
+        assert_eq!(RQESuspendedIterator::last_doc_id(&*suspended), DOC_IDS[0]);
+
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(a) => a,
+            ResumeOutcome::Moved(_) => panic!("expected Ok, got Moved"),
+            ResumeOutcome::Aborted => panic!("expected Ok, got Aborted"),
+        };
+        assert_eq!(
+            &*active as *const _ as usize, box_addr,
+            "resume must reuse the allocation",
+        );
+        let tag_survived = if raw {
+            matches!(&*active, OptimizedWildcard::RawDocIdsOnly(_))
+        } else {
+            matches!(&*active, OptimizedWildcard::DocIdsOnly(_))
+        };
+        assert!(tag_survived, "resume must land on the same variant");
+        assert_eq!(active.read().unwrap().unwrap().doc_id, DOC_IDS[1]);
+    }
+
+    /// F1: the GC nulled `existingDocs` out from under the iterator.
+    #[test]
+    fn resume_aborts_when_existing_docs_is_nulled() {
+        let fixture = ExistingDocs::doc_ids_only();
+        let mut it = Box::new(OptimizedWildcard::DocIdsOnly(InvIdxWildcard::new(
+            fixture.typed::<DocIdsOnly>().reader(),
+            1.0,
+        )));
+        assert_eq!(it.read().unwrap().unwrap().doc_id, DOC_IDS[0]);
+
+        fixture
+            .ctx
+            .spec_write()
+            .set_existing_docs_ptr(std::ptr::null_mut());
+
+        // Taken after the write, as the production sequence does: the read lock
+        // is re-acquired once the GC's write lock has been released.
+        let guard = fixture.ctx.spec_read();
+        assert!(matches!(
+            it.suspend().resume(&guard).expect("resume failed"),
+            ResumeOutcome::Aborted
+        ));
+    }
+
+    /// F2: the GC replaced `existingDocs` with a fresh allocation, so the
+    /// reader's pointer is stale even though the spec's is not null.
+    #[test]
+    fn resume_aborts_when_existing_docs_is_replaced() {
+        let fixture = ExistingDocs::doc_ids_only();
+        let mut it = Box::new(OptimizedWildcard::DocIdsOnly(InvIdxWildcard::new(
+            fixture.typed::<DocIdsOnly>().reader(),
+            1.0,
+        )));
+        assert_eq!(it.read().unwrap().unwrap().doc_id, DOC_IDS[0]);
+
+        let replacement = Box::into_raw(Box::new(opaque::InvertedIndex::DocIdsOnly(
+            InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
+        )));
+        let original = fixture.ctx.spec_read().existing_docs_ptr();
+        fixture
+            .ctx
+            .spec_write()
+            .set_existing_docs_ptr(replacement.cast());
+
+        // Taken after the write — see `resume_aborts_when_existing_docs_is_nulled`.
+        let guard = fixture.ctx.spec_read();
+        assert!(matches!(
+            it.suspend().resume(&guard).expect("resume failed"),
+            ResumeOutcome::Aborted
+        ));
+
+        fixture.ctx.spec_write().set_existing_docs_ptr(original);
+        // SAFETY: `replacement` came from `Box::into_raw` and the spec no
+        // longer points at it.
+        unsafe { drop(Box::from_raw(replacement)) };
+    }
+
+    /// F3: the document the iterator sits on is collected while it is
+    /// suspended, so the resume re-seeks past it and reports `Moved`.
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "GC mutates the index through `&mut` while the reader's pointer into it is still live, which Stacked Borrows rejects"
+    )]
+    fn resume_reports_moved_when_the_current_document_is_collected() {
+        let fixture = ExistingDocs::doc_ids_only();
+        let mut it = Box::new(OptimizedWildcard::DocIdsOnly(InvIdxWildcard::new(
+            fixture.typed::<DocIdsOnly>().reader(),
+            1.0,
+        )));
+        assert_eq!(it.read().unwrap().unwrap().doc_id, DOC_IDS[0]);
+        assert_eq!(it.read().unwrap().unwrap().doc_id, DOC_IDS[1]);
+
+        let suspended = it.suspend();
+        fixture.remove_document::<DocIdsOnly>(DOC_IDS[1]);
+
+        let guard = fixture.ctx.spec_read();
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Moved(a) => a,
+            ResumeOutcome::Ok(_) => panic!("expected Moved, got Ok"),
+            ResumeOutcome::Aborted => panic!("expected Moved, got Aborted"),
+        };
+        assert_eq!(
+            active
+                .current()
+                .expect("a moved iterator answers `current`")
+                .doc_id,
+            DOC_IDS[2],
+            "the resume settles on the next surviving document",
+        );
+        assert_eq!(active.read().unwrap().unwrap().doc_id, DOC_IDS[3]);
+    }
+}


### PR DESCRIPTION
## Describe the changes in the pull request

Implement `RQEIteratorBoxed` + `RQESuspendedIterator` for the Union
family — the second multi-child composite group. Unlike Intersection,
Union emits the **disjunction** of its children, which makes the
suspend/resume cursor maintenance more delicate: each variant tracks
the "live" child set differently (heap, flat scan, trimmed window,
opaque dispatcher).

`resume` for every variant must preserve the live/dead partition so a
post-resume read doesn't yield stale doc IDs. One variant per commit.

#### Main objects this PR modified
- `UnionFlat`, `UnionHeap`, `UnionTrimmed`, `UnionOpaque`

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

Stacked on #10278.
