### PR TITLE
[Iterator Revalidation][MOD-16714] FFI-boundary enum dispatchers

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1470,6 +1470,7 @@ dependencies = [
  "redis_mock",
  "redis_reply",
  "redisearch_rs",
+ "ref_mode",
  "rqe_core",
  "rstest",
  "tracing",

--- a/src/redisearch_rs/inverted_index/src/reader/geo.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/geo.rs
@@ -124,7 +124,6 @@ unsafe impl<IR: SuspendableReader> SuspendableReader for FilterGeoReader<IR> {
 /// proof there).
 unsafe impl<RS: ResumableReader> ResumableReader for FilterGeoReader<RS>
 where
-    for<'a> Self: 'static,
     for<'a> FilterGeoReader<RS::Resumed<'a>>: IndexReader<'a>,
 {
     type Resumed<'a> = FilterGeoReader<RS::Resumed<'a>>;

--- a/src/redisearch_rs/inverted_index/src/reader/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/numeric.rs
@@ -147,7 +147,6 @@ unsafe impl<IR: SuspendableReader> SuspendableReader for FilterNumericReader<IR>
 /// proof there).
 unsafe impl<RS: ResumableReader> ResumableReader for FilterNumericReader<RS>
 where
-    for<'a> Self: 'static,
     for<'a> FilterNumericReader<RS::Resumed<'a>>: IndexReader<'a>,
 {
     type Resumed<'a> = FilterNumericReader<RS::Resumed<'a>>;

--- a/src/redisearch_rs/numeric_range_tree/Cargo.toml
+++ b/src/redisearch_rs/numeric_range_tree/Cargo.toml
@@ -28,6 +28,7 @@ rqe_core.workspace = true
 hyperloglog.workspace = true
 index_result.workspace = true
 inverted_index.workspace = true
+ref_mode.workspace = true
 redis_reply.workspace = true
 generational_slab.workspace = true
 tracing.workspace = true

--- a/src/redisearch_rs/numeric_range_tree/src/index.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/index.rs
@@ -15,10 +15,11 @@
 use ffi::IndexFlags_Index_StoreNumeric;
 use index_result::RSIndexResult;
 use inverted_index::{
-    EntriesTrackingIndex, IndexReader, IndexReaderCore, NumericReader,
+    EntriesTrackingIndex, IndexReader, NumericReader, RawIndexReaderCore,
     debug::Summary,
     numeric::{Numeric, NumericFloatCompression},
 };
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
 /// Enum to hold either compressed or uncompressed numeric index.
@@ -156,14 +157,60 @@ impl NumericIndex {
     }
 }
 
-/// Iterate over the entries stored in a numeric index.
+/// Iterate over the entries stored in a numeric index, parameterised over a
+/// [`Ref`] mode.
 ///
-/// This abstracts over whether the underlying index is compressed or uncompressed.
-pub enum NumericIndexReader<'a> {
+/// Abstracts over whether the underlying index is compressed or uncompressed.
+/// `RawNumericIndexReader<Active<'index>>` (aliased [`NumericIndexReader`]) and
+/// `RawNumericIndexReader<Suspended>` are layout-identical, so the owning
+/// `RawInvIndIterator` can suspend/resume by a same-allocation reinterpretation —
+/// the [`SuspendableReader`](inverted_index::SuspendableReader) /
+/// [`ResumableReader`](inverted_index::ResumableReader) contract. This holds
+/// because `Rf` flows only through the per-variant [`RawIndexReaderCore`]
+/// payloads, each itself layout-compatible (invariant 1 on that type). Enforced
+/// by the `const _` proof below.
+#[repr(C)]
+pub enum RawNumericIndexReader<Rf: Ref> {
     /// Reader over uncompressed entries.
-    Uncompressed(IndexReaderCore<'a, Numeric>),
+    Uncompressed(RawIndexReaderCore<Rf, Numeric>),
     /// Reader over compressed entries.
-    Compressed(IndexReaderCore<'a, NumericFloatCompression>),
+    Compressed(RawIndexReaderCore<Rf, NumericFloatCompression>),
+}
+
+/// Active-form alias of [`RawNumericIndexReader`] — the live numeric reader.
+pub type NumericIndexReader<'index> = RawNumericIndexReader<Active<'index>>;
+
+// Compile-time proof that the `Active` and `Suspended` instantiations of
+// `RawNumericIndexReader` are layout-identical. As an enum we assert size and
+// alignment equality; the per-variant `RawIndexReaderCore` payloads are
+// layout-compatible by their own invariant 1, so a divergence here is a build error.
+const _: () = {
+    use std::mem::{align_of, size_of};
+    type A = RawNumericIndexReader<Active<'static>>;
+    type S = RawNumericIndexReader<Suspended>;
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
+// SAFETY: `RawNumericIndexReader<Active>` and `<Suspended>` are layout-identical
+// (const proof above), as `SuspendableReader` requires.
+unsafe impl<'a> inverted_index::SuspendableReader for NumericIndexReader<'a> {
+    type Suspended = RawNumericIndexReader<Suspended>;
+}
+
+// SAFETY: layout-compatible for the same reason as the `SuspendableReader` impl above.
+unsafe impl inverted_index::ResumableReader for RawNumericIndexReader<Suspended> {
+    type Resumed<'a> = NumericIndexReader<'a>;
+
+    unsafe fn refresh_pointers(&mut self) -> inverted_index::RefreshOutcome {
+        match self {
+            // SAFETY: our caller upholds `ResumableReader::refresh_pointers`'s
+            // read-lock obligation, which we forward unchanged to the inner reader.
+            Self::Uncompressed(r) => unsafe { r.refresh_pointers() },
+            // SAFETY: as above.
+            Self::Compressed(r) => unsafe { r.refresh_pointers() },
+        }
+    }
 }
 
 /// Marker trait for readers producing numeric values.

--- a/src/redisearch_rs/numeric_range_tree/src/lib.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/lib.rs
@@ -77,7 +77,7 @@ mod tree;
 mod unique_id;
 
 pub use arena::NodeIndex;
-pub use index::{NumericIndex, NumericIndexReader};
+pub use index::{NumericIndex, NumericIndexReader, RawNumericIndexReader};
 pub use inverted_index::NumericFilter;
 pub use iter::{IndexedReversePreOrderDfsIterator, ReversePreOrderDfsIterator};
 pub use node::{InternalNode, LeafNode, NumericRangeNode};

--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -288,6 +288,99 @@ where
     std::mem::forget(bomb);
 }
 
+/// Outcome of [`resume_child_slot_in_place`], mirroring the recoverable
+/// discriminants of [`ResumeOutcome`] but *without* carrying the iterator —
+/// the resumed child is written back into the slot instead.
+pub(crate) enum ResumeSlotOutcome {
+    /// The child resumed at the same position; the slot now holds the active child.
+    Unchanged,
+    /// The child resumed but its position moved forward; the slot now holds the
+    /// active child.
+    Moved,
+    /// The child's state was unrecoverable. It was consumed and the slot is
+    /// **left uninitialised** — see the safety contract.
+    Aborted,
+}
+
+/// Resume a single child slot in place: read the suspended child out, drive its
+/// consuming [`RQESuspendedIterator::resume`] through the trait, and — on a
+/// recoverable outcome — write the resumed counterpart back into the **same
+/// slot**. This is the resume-direction mirror of
+/// [`suspend_child_slot_in_place`].
+///
+/// The inner iterator's own heap allocation is preserved by its `resume`, and
+/// the resumed value is written back to the same slot, so the *slot* address is
+/// stable. A caller that also reuses its own allocation (via
+/// `Box::into_raw`/`Box::from_raw`) therefore preserves every interior address
+/// across the suspend/resume cycle.
+///
+/// # Safety
+///
+/// * `slot` must point to a valid, exclusively-owned `S` value.
+/// * On [`Ok`](ResumeSlotOutcome::Unchanged)/[`Moved`](ResumeSlotOutcome::Moved)
+///   the slot's bytes are a valid `S::Resumed<'a>`; the caller must interpret
+///   the slot (and its container) as `S::Resumed<'a>` from this point on and not
+///   read it as `S` again.
+/// * On [`Aborted`](ResumeSlotOutcome::Aborted) or [`Err`] the child was consumed
+///   by its `resume` and the slot is **left uninitialised**; the caller must tear
+///   the container down WITHOUT dropping the slot.
+/// * `S` and `S::Resumed<'a>` must have the same size and alignment — guaranteed
+///   for all `RQEIteratorBoxed`/`RQESuspendedIterator` impls in this crate by
+///   their `#[repr(C)]` layouts.
+///
+/// Between the `ptr::read` and the matching `ptr::write` (or the caller's
+/// teardown) the slot is logically uninitialised. [`RQESuspendedIterator::resume`]
+/// is a safe trait method that may dispatch to arbitrary (including dyn)
+/// implementations and could panic; as in [`suspend_child_slot_in_place`], a
+/// panic is converted into a process abort rather than an unwind through the
+/// uninitialised slot.
+pub(crate) unsafe fn resume_child_slot_in_place<'query, 'a, S>(
+    slot: *mut S,
+    guard: &IndexSpecReadGuard<'a>,
+) -> Result<ResumeSlotOutcome, RQEIteratorError>
+where
+    S: RQESuspendedIterator<'query>,
+    'query: 'a,
+{
+    /// Aborts the process if dropped during unwinding through the
+    /// uninitialised-slot window. Disarmed with [`std::mem::forget`] once
+    /// `resume` has returned.
+    struct AbortOnUnwind;
+    impl Drop for AbortOnUnwind {
+        fn drop(&mut self) {
+            std::process::abort();
+        }
+    }
+
+    // SAFETY: caller guarantees `slot` is exclusively owned and points to a
+    // valid `S` value. `ptr::read` moves the value out; the slot bytes are
+    // typed-but-moved-from until the matching `ptr::write` (or teardown) below.
+    let suspended = unsafe { std::ptr::read(slot) };
+    // Armed across the uninitialised-slot window: if `resume` panics, drop
+    // aborts instead of unwinding through the moved-from slot.
+    let bomb = AbortOnUnwind;
+    let outcome = Box::new(suspended).resume(guard);
+    // `resume` returned normally (Ok/Aborted or Err) — the remaining steps below
+    // cannot panic, so disarm before we either write the slot back or hand an
+    // uninitialised slot to the caller for teardown.
+    std::mem::forget(bomb);
+
+    let (active, moved) = match outcome? {
+        ResumeOutcome::Aborted => return Ok(ResumeSlotOutcome::Aborted),
+        ResumeOutcome::Ok(active) => (active, false),
+        ResumeOutcome::Moved(active) => (active, true),
+    };
+    // SAFETY: `S` and `S::Resumed<'a>` share size and alignment (see contract
+    // above). The slot is uninitialised after the earlier `ptr::read`; writing a
+    // valid `S::Resumed<'a>` reinitialises it.
+    unsafe { std::ptr::write(slot as *mut S::Resumed<'a>, *active) };
+    Ok(if moved {
+        ResumeSlotOutcome::Moved
+    } else {
+        ResumeSlotOutcome::Unchanged
+    })
+}
+
 // --- Blanket bridges: concrete → dyn-safe -----------------------------------
 
 /// Bridge concrete active iterators into the dyn-safe sibling.

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -17,9 +17,9 @@ use ffi::{
 use rqe_core::DocId;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
-    interop::RQEIteratorWrapper, intersection::Intersection, profile_print,
-    profile_print::ProfilePrint,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome, interop::RQEIteratorWrapper,
+    intersection::Intersection, profile_print, profile_print::ProfilePrint,
 };
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
@@ -507,5 +507,65 @@ impl profile_print::ProfilePrint for CRQEIterator {
         // entry was set at construction time by RQEIteratorWrapper::boxed_new
         // or by the C iterator constructor.
         unsafe { call_print_profile(ptr, map, ctx) };
+    }
+}
+
+impl<'index> RQEIteratorBoxed<'index> for CRQEIterator {
+    /// `CRQEIterator` wraps an opaque C handle that owns its own validity
+    /// state. There is no Rust-side state to flip between modes; the
+    /// suspended counterpart is the same type.
+    type Suspended = CRQEIterator;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        self
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for CRQEIterator {
+    type Resumed<'a>
+        = CRQEIterator
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        spec: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Delegate validity recovery to the C-side `Revalidate` vtable
+        // entry. Whatever convention the C iterator uses to refresh stale
+        // pointers, restart cursors, etc. is its own concern — we just
+        // call its callback under the held read lock.
+        // SAFETY: invariant 3. of [`CRQEIterator::header`] guarantees the
+        // callback is non-null.
+        let callback = unsafe { self.Revalidate.unwrap_unchecked() };
+        // SAFETY: the handle is unique (consumed by value into `self`),
+        // the C-side callback is safe to call per invariant 4., and
+        // `spec.as_mut_ptr()` is valid for the duration of the call.
+        let status = unsafe { callback(self.header.as_ptr(), spec.as_mut_ptr()) };
+        // On `ABORTED` the C `Revalidate` leaves disposal to the owner (see
+        // the `revalidate` impl above); `self` is not moved into the outcome,
+        // so it drops here and its `Free` callback runs exactly once.
+        #[expect(non_upper_case_globals)]
+        Ok(match status {
+            ValidateStatus_VALIDATE_ABORTED => ResumeOutcome::Aborted,
+            ValidateStatus_VALIDATE_MOVED => ResumeOutcome::Moved(self),
+            ValidateStatus_VALIDATE_OK => ResumeOutcome::Ok(self),
+            _ => unreachable!("`Revalidate` returned an unexpected status, {status}"),
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.lastDocId
+    }
+
+    fn num_estimated(&self) -> usize {
+        // SAFETY: Safe thanks to invariant 3. of [`CRQEIterator::header`].
+        let callback = unsafe { self.NumEstimated.unwrap_unchecked() };
+        // SAFETY: the C code guarantees, by constructor, that callbacks can
+        // be called on types that implement its C iterator API.
+        unsafe { callback(self.header.as_ptr()) }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/src/intersection.rs
@@ -14,13 +14,14 @@
 //! - `in_order`: Require terms to appear in order
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 
 use index_result::{RSIndexResult, RawIndexResult};
 use index_spec::IndexSpecReadGuard;
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
 /// Yields documents appearing in ALL child iterators using a merge (AND) algorithm.
@@ -579,6 +580,157 @@ where
 
     fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
         1.0 / self.children.len().max(1) as f64
+    }
+}
+
+impl<'index, I> RQEIteratorBoxed<'index> for Intersection<'index, I>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawIntersection<'index, Suspended, I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Walk children: dispatch each child's `suspend` through the trait so
+        // dyn-erased `I` (e.g. [`TypeErasedRQEIterator`](crate::TypeErasedRQEIterator),
+        // whose active and suspended forms carry different vtables) correctly
+        // transitions. For concrete-typed `I` this is the same whole-box cast
+        // that the outer composite would otherwise have done, just per-child
+        // instead of per-composite. Either way the inner concrete iterator's
+        // heap address is preserved; only the wrapper bytes (which nothing
+        // external points at) are re-typed.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` and is exclusively owned for
+        // the rest of this function, so the children Vec field is reachable
+        // and not aliased.
+        let children: &mut Vec<I> = unsafe { &mut (*raw).children };
+        for slot in children.iter_mut() {
+            // SAFETY: `slot` is a valid `&mut I`; the function leaves it in
+            // a valid `I::Suspended` state.
+            unsafe { crate::boxed::suspend_child_slot_in_place(slot) };
+        }
+        // SAFETY: `RawIntersection` is `#[repr(C)]` over `Vec<I>` (now byte-
+        // rewritten as `Vec<I::Suspended>` contents — Vec metadata is
+        // identical) and `result: RawIndexResult<Rf>` (layout-compatible
+        // via `SharedPtr` transparency). The active aggregate's borrowed
+        // pointers into children's interiors are still valid because each
+        // child's inner concrete iterator heap was preserved by the
+        // per-child suspend above.
+        unsafe { Box::from_raw(raw as *mut RawIntersection<'index, Suspended, I::Suspended>) }
+    }
+}
+
+impl<'query, S> RQESuspendedIterator<'query> for RawIntersection<'query, Suspended, S>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = Intersection<'a, S::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let RawIntersection {
+            children,
+            last_doc_id,
+            num_expected,
+            is_eof,
+            max_slop,
+            in_order,
+            result,
+        } = *self;
+
+        // The suspended aggregate `result` holds borrowed pointers into the
+        // children we're about to consume. After the per-child `resume`
+        // calls below, those pointers would dangle: each child is consumed
+        // by value and produces a fresh Active value at a new address. We
+        // therefore extract the `weight` (a plain `f64`, no aliasing
+        // concerns), drop the suspended result, and build a fresh empty
+        // Active aggregate. It's repopulated at the end of this method
+        // from the resumed children's current positions.
+        let weight = result.weight;
+        let num_children = children.len();
+        drop(result);
+
+        // Resume each child, tracking aggregate position-shift signals. This
+        // mirrors `Intersection::revalidate`: any child aborting aborts the
+        // whole intersection immediately (an intersection missing a child
+        // yields nothing); otherwise stay at `last_doc_id` when no child
+        // moved, else advance to the new max child position to find the next
+        // common doc.
+        let mut any_moved = false;
+        let mut max_child_doc_id: DocId = 0;
+        let mut moved_to_eof = false;
+        let mut active_children: Vec<S::Resumed<'a>> = Vec::with_capacity(num_children);
+        for child in children {
+            match Box::new(child).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active_child) => active_children.push(*active_child),
+                ResumeOutcome::Moved(active_child) => {
+                    let active_child = *active_child;
+                    any_moved = true;
+                    if active_child.at_eof() {
+                        moved_to_eof = true;
+                    } else {
+                        max_child_doc_id = max_child_doc_id.max(active_child.last_doc_id());
+                    }
+                    active_children.push(active_child);
+                }
+            }
+        }
+
+        let result = RSIndexResult::build_intersect(num_children)
+            .weight(weight)
+            .build();
+
+        let mut active = Box::new(Intersection {
+            children: active_children,
+            last_doc_id,
+            num_expected,
+            is_eof,
+            max_slop,
+            in_order,
+            result,
+        });
+
+        // No child moved (or we're at EOF / before-first-read): the
+        // children are still at the same positions as before suspend, so
+        // the aggregate's `last_doc_id` is still valid. Repopulate the
+        // (now-empty) aggregate from each child's current result.
+        if !any_moved || active.is_eof || active.last_doc_id == 0 {
+            if active.last_doc_id > 0 && !active.is_eof {
+                active.build_aggregate_result(active.last_doc_id);
+            }
+            return Ok(ResumeOutcome::Ok(active));
+        }
+
+        // At least one child moved to EOF — the intersection can't continue.
+        if moved_to_eof {
+            active.is_eof = true;
+            return Ok(ResumeOutcome::Moved(active));
+        }
+
+        // Some children moved forward. Advance the intersection to the new
+        // max child position and find the next common doc from there.
+        // `Intersection::skip_to`'s internal `agree_on_doc_id` skips
+        // children already at the target (no `skip_to` precondition
+        // violation) and advances ones behind via their own `skip_to`.
+        let _ = active.skip_to(max_child_doc_id);
+        Ok(ResumeOutcome::Moved(active))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.last_doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.num_expected
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
@@ -9,7 +9,9 @@
 
 //! Supporting types for [`Missing`], [`Numeric`], [`Term`], and [`Wildcard`].
 
-mod core;
+// `pub(crate)` so the top-level `OptimizedWildcard` wrapper can name
+// `core::ResumeStatus` when driving its inline variants' in-place resume.
+pub(crate) mod core;
 mod geo;
 mod missing;
 mod numeric;
@@ -29,4 +31,4 @@ pub use numeric::{
 
 pub use tag::{Tag, TagLookup};
 pub use term::{Term, TermIndexReader, build_term_iterator};
-pub use wildcard::Wildcard;
+pub use wildcard::{RawWildcard, Wildcard};

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -26,7 +26,7 @@ use inverted_index::{
     FilterGeoReader, FilterNumericReader, IndexReader, NumericFilter, NumericReader,
     ResumableReader, SuspendableReader,
 };
-use numeric_range_tree::{NumericIndexReader, NumericRangeTree};
+use numeric_range_tree::{NumericIndexReader, NumericRangeTree, RawNumericIndexReader};
 use query_types::QueryNodeType;
 use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
@@ -749,4 +749,165 @@ pub unsafe fn build_numeric_filter_iterator(
     let iter =
         crate::union_opaque::build_union(children, true, min_union_iter_heap, node_type, 1.0);
     Some(iter)
+}
+
+/// [`Suspended`]-mode counterpart of [`NumericIteratorVariant`] used
+/// as its `RQEIteratorBoxed::Suspended` type. Each variant holds the
+/// `Suspended` form of the corresponding `Numeric` instantiation, retaining
+/// the `'query` lifetime so query-attached borrows stay valid across the
+/// suspend/resume cycle.
+pub enum NumericIteratorVariantSuspended<'query> {
+    /// Suspended counterpart of [`NumericIteratorVariant::Unfiltered`].
+    ///
+    /// The trailing `RA` type argument is the frozen **active** reader (see
+    /// [`RawInvIndIterator`]'s `RA`), matching what `Numeric::suspend` produces.
+    Unfiltered(
+        RawNumeric<
+            'query,
+            Suspended,
+            RawNumericIndexReader<Suspended>,
+            FieldExpirationChecker,
+            NumericIndexReader<'query>,
+        >,
+    ),
+    /// Suspended counterpart of [`NumericIteratorVariant::Filtered`].
+    Filtered(
+        RawNumeric<
+            'query,
+            Suspended,
+            FilterNumericReader<RawNumericIndexReader<Suspended>>,
+            FieldExpirationChecker,
+            FilterNumericReader<NumericIndexReader<'query>>,
+        >,
+    ),
+    /// Suspended counterpart of [`NumericIteratorVariant::Geo`].
+    Geo(
+        RawNumeric<
+            'query,
+            Suspended,
+            FilterGeoReader<RawNumericIndexReader<Suspended>>,
+            FieldExpirationChecker,
+            FilterGeoReader<NumericIndexReader<'query>>,
+        >,
+    ),
+}
+
+impl<'query> NumericIteratorVariantSuspended<'query> {
+    /// Mirror of [`NumericIteratorVariant::range_min`] on the suspended side.
+    pub const fn range_min(&self) -> f64 {
+        match self {
+            Self::Unfiltered(iter) => iter.range_min(),
+            Self::Filtered(iter) => iter.range_min(),
+            Self::Geo(iter) => iter.range_min(),
+        }
+    }
+
+    /// Mirror of [`NumericIteratorVariant::range_max`] on the suspended side.
+    pub const fn range_max(&self) -> f64 {
+        match self {
+            Self::Unfiltered(iter) => iter.range_max(),
+            Self::Filtered(iter) => iter.range_max(),
+            Self::Geo(iter) => iter.range_max(),
+        }
+    }
+
+    /// Mirror of [`NumericIteratorVariant::flags`] on the suspended side.
+    pub const fn flags(&self) -> ffi::IndexFlags {
+        match self {
+            Self::Unfiltered(iter) => iter.flags(),
+            Self::Filtered(iter) => iter.flags(),
+            Self::Geo(iter) => iter.flags(),
+        }
+    }
+}
+
+impl<'index> RQEIteratorBoxed<'index> for NumericIteratorVariant<'index> {
+    type Suspended = NumericIteratorVariantSuspended<'index>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        // Field-by-field dispatch: the enum tag's discriminant layout is
+        // unspecified across these two distinct enum types, so we can't
+        // whole-box-cast. Match arms call the inner `RawNumeric`'s
+        // `RQEIteratorBoxed::suspend` (disambiguated via UFCS so it isn't
+        // resolved against an inherent or auto-impl `suspend`) and re-wrap
+        // into the suspended enum.
+        match *self {
+            NumericIteratorVariant::Unfiltered(it) => {
+                let suspended = RQEIteratorBoxed::suspend(Box::new(it));
+                Box::new(NumericIteratorVariantSuspended::Unfiltered(*suspended))
+            }
+            NumericIteratorVariant::Filtered(it) => {
+                let suspended = RQEIteratorBoxed::suspend(Box::new(it));
+                Box::new(NumericIteratorVariantSuspended::Filtered(*suspended))
+            }
+            NumericIteratorVariant::Geo(it) => {
+                let suspended = RQEIteratorBoxed::suspend(Box::new(it));
+                Box::new(NumericIteratorVariantSuspended::Geo(*suspended))
+            }
+        }
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for NumericIteratorVariantSuspended<'query> {
+    type Resumed<'a>
+        = NumericIteratorVariant<'a>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Forward the inner variant's outcome: an aborted inner aborts the
+        // whole wrapper; otherwise reconstruct the concrete
+        // `NumericIteratorVariant` and preserve the `Ok`/`Moved` status.
+        let (variant, moved) = match *self {
+            NumericIteratorVariantSuspended::Unfiltered(it) => match Box::new(it).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (NumericIteratorVariant::Unfiltered(*active), false),
+                ResumeOutcome::Moved(active) => (NumericIteratorVariant::Unfiltered(*active), true),
+            },
+            NumericIteratorVariantSuspended::Filtered(it) => match Box::new(it).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (NumericIteratorVariant::Filtered(*active), false),
+                ResumeOutcome::Moved(active) => (NumericIteratorVariant::Filtered(*active), true),
+            },
+            NumericIteratorVariantSuspended::Geo(it) => match Box::new(it).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (NumericIteratorVariant::Geo(*active), false),
+                ResumeOutcome::Moved(active) => (NumericIteratorVariant::Geo(*active), true),
+            },
+        };
+        let active = Box::new(variant);
+        Ok(if moved {
+            ResumeOutcome::Moved(active)
+        } else {
+            ResumeOutcome::Ok(active)
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        match self {
+            NumericIteratorVariantSuspended::Unfiltered(it) => {
+                RQESuspendedIterator::last_doc_id(it)
+            }
+            NumericIteratorVariantSuspended::Filtered(it) => RQESuspendedIterator::last_doc_id(it),
+            NumericIteratorVariantSuspended::Geo(it) => RQESuspendedIterator::last_doc_id(it),
+        }
+    }
+
+    fn num_estimated(&self) -> usize {
+        match self {
+            NumericIteratorVariantSuspended::Unfiltered(it) => {
+                RQESuspendedIterator::num_estimated(it)
+            }
+            NumericIteratorVariantSuspended::Filtered(it) => {
+                RQESuspendedIterator::num_estimated(it)
+            }
+            NumericIteratorVariantSuspended::Geo(it) => RQESuspendedIterator::num_estimated(it),
+        }
+    }
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -10,8 +10,8 @@
 use std::{f64, ptr::NonNull};
 
 use crate::{
-    FieldExpirationChecker, IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus,
-    SkipToOutcome,
+    FieldExpirationChecker, IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError,
+    RQESuspendedIterator, RQEValidateStatus, ResumeOutcome, SkipToOutcome,
     c2rust::CRQEIterator,
     expiration_checker::{ExpirationChecker, NoOpChecker},
     profile_print::{ProfilePrint, ProfilePrintCtx, format_g},
@@ -24,13 +24,14 @@ use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use inverted_index::{
     FilterGeoReader, FilterNumericReader, IndexReader, NumericFilter, NumericReader,
+    ResumableReader, SuspendableReader,
 };
 use numeric_range_tree::{NumericIndexReader, NumericRangeTree};
 use query_types::QueryNodeType;
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
-use super::core::{InvIndIterator, RawInvIndIterator};
+use super::core::{InvIndIterator, RawInvIndIterator, ResumeStatus};
 
 /// An iterator over numeric inverted index entries, parameterised over a
 /// [`Ref`] mode. See [`Numeric`] for the [`Active`] instantiation that
@@ -44,8 +45,8 @@ use super::core::{InvIndIterator, RawInvIndIterator};
 /// * `R` - The type of the numeric reader.
 /// * `E` - The expiration checker type used to check for expired documents.
 #[repr(C)]
-pub struct RawNumeric<'query, Rf: Ref, R, E = NoOpChecker> {
-    it: RawInvIndIterator<'query, Rf, R, E>,
+pub struct RawNumeric<'query, Rf: Ref, R, E = NoOpChecker, RA = R> {
+    it: RawInvIndIterator<'query, Rf, R, E, RA>,
     /// The numeric range tree and its revision ID, used to detect changes during revalidation.
     range_tree_info: Option<RangeTreeInfo>,
     /// Minimum numeric range, only used in debug print.
@@ -56,7 +57,7 @@ pub struct RawNumeric<'query, Rf: Ref, R, E = NoOpChecker> {
 
 /// Alias for an [`Active`] [`RawNumeric`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
-pub type Numeric<'index, R, E = NoOpChecker> = RawNumeric<'index, Active<'index>, R, E>;
+pub type Numeric<'index, R, E = NoOpChecker> = RawNumeric<'index, Active<'index>, R, E, R>;
 
 /// Information about the numeric range tree backing a [`Numeric`] iterator.
 struct RangeTreeInfo {
@@ -65,6 +66,53 @@ struct RangeTreeInfo {
     /// The revision ID at the time the iterator was created.
     /// Used to detect if the tree has been modified.
     revision_id: u32,
+}
+
+impl<'query, Rf: Ref, R, E, RA> RawNumeric<'query, Rf, R, E, RA> {
+    /// Cached minimum numeric range (only used in debug print / FT.PROFILE).
+    pub const fn range_min(&self) -> f64 {
+        self.range_min
+    }
+
+    /// Cached maximum numeric range (only used in debug print / FT.PROFILE).
+    pub const fn range_max(&self) -> f64 {
+        self.range_max
+    }
+
+    /// Cached [`IndexFlags`] of the underlying inverted index — see
+    /// [`RawInvIndIterator::flags`].
+    pub const fn flags(&self) -> ffi::IndexFlags {
+        self.it.flags()
+    }
+
+    /// Check if the iterator should abort revalidation.
+    ///
+    /// The numeric range tree's revision id changes when the tree is
+    /// modified by GC (a node split or removal). The iterator's cached
+    /// `revision_id` snapshot is compared against the current value; if
+    /// they differ, the cursor is invalidated and the iterator must
+    /// [abort](RQEValidateStatus::Aborted).
+    ///
+    /// Reads only the range tree's `NonNull` pointer and `revision_id` (owned by
+    /// the spec, stable under the read lock); it materializes no `&'a`
+    /// reader/buffer borrow, so it is sound to call on the suspended form during
+    /// [`RQESuspendedIterator::resume`].
+    pub(crate) const fn should_abort(&self) -> bool {
+        // If there's no range tree, we can't check for changes
+        let Some(ref info) = self.range_tree_info else {
+            return false;
+        };
+
+        let current_revision_id = {
+            // SAFETY: Condition 2 of `Self::new` guarantees the tree
+            // remains valid for the iterator's lifetime.
+            let tree = unsafe { info.tree.as_ref() };
+            tree.revision_id()
+        };
+        // If the revision id changed the numeric tree was either completely deleted or a node was split or removed.
+        // The cursor is invalidated so we cannot revalidate the iterator.
+        current_revision_id != info.revision_id
+    }
 }
 
 impl<'index, R, E> Numeric<'index, R, E>
@@ -119,31 +167,6 @@ where
         }
     }
 
-    const fn should_abort(&self) -> bool {
-        // If there's no range tree, we can't check for changes
-        let Some(ref info) = self.range_tree_info else {
-            return false;
-        };
-
-        let current_revision_id = {
-            // SAFETY: Condition 2 of `Self::new` guarantees the tree
-            // remains valid for the iterator's lifetime.
-            let tree = unsafe { info.tree.as_ref() };
-            tree.revision_id()
-        };
-        // If the revision id changed the numeric tree was either completely deleted or a node was split or removed.
-        // The cursor is invalidated so we cannot revalidate the iterator.
-        current_revision_id != info.revision_id
-    }
-
-    pub const fn range_min(&self) -> f64 {
-        self.range_min
-    }
-
-    pub const fn range_max(&self) -> f64 {
-        self.range_max
-    }
-
     /// Get a reference to the underlying reader.
     ///
     /// This is used by FFI code to access the reader.
@@ -152,6 +175,85 @@ where
     }
 }
 
+impl<'index, R, E> RQEIteratorBoxed<'index> for Numeric<'index, R, E>
+where
+    R: NumericReader<'index> + SuspendableReader + 'index,
+    R::Suspended: ResumableReader,
+    for<'a> <R::Suspended as ResumableReader>::Resumed<'a>: NumericReader<'a>,
+    E: ExpirationChecker + 'static,
+{
+    // Reader weakens `R -> R::Suspended`; the frozen `RA = R` slot keeps the
+    // inner iterator's dispatch pointers unchanged across the cast.
+    type Suspended = RawNumeric<'index, Suspended, R::Suspended, E, R>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawNumeric` is `#[repr(C)]` over the inner
+        // `RawInvIndIterator`, layout-identical across modes by invariant 1 on
+        // [`RawInvIndIterator`]: `reader` weakens `R -> R::Suspended` while the
+        // frozen `RA = R` slot keeps the dispatch pointers unchanged. The
+        // remaining fields (`range_tree_info`, `range_min`, `range_max`) carry no
+        // `Rf`, so they survive the cast unchanged. `Box::from_raw` reuses the
+        // same heap allocation.
+        unsafe { Box::from_raw(raw as *mut RawNumeric<'index, Suspended, R::Suspended, E, R>) }
+    }
+}
+
+impl<'query, RS, E, RA> RQESuspendedIterator<'query> for RawNumeric<'query, Suspended, RS, E, RA>
+where
+    RS: ResumableReader,
+    for<'a> RS::Resumed<'a>: NumericReader<'a>,
+    E: ExpirationChecker + 'static,
+{
+    type Resumed<'a>
+        = Numeric<'a, RS::Resumed<'a>, E>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        mut self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Step 1: identity check on the suspended form. On abort we drop the
+        // suspended iterator without promoting it to Active — nothing is
+        // materialized.
+        if self.should_abort() {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        // Step 2: run the shared in-place resume transition on the inner core
+        // iterator (refresh pointers, reset stale offsets, promote the result,
+        // and re-seek if GC moved us). `guard` witnesses the read lock the
+        // refresh requires.
+        let status = self.it.resume_in_place(guard)?;
+
+        // Step 3: reinterpret the owning box's type. The heap address is
+        // preserved across the cast.
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawNumeric` is `#[repr(C)]` over the inner `RawInvIndIterator`
+        // (layout-identical across modes by invariant 1 on `RawInvIndIterator`)
+        // plus the `Rf`-free `range_tree_info`/`range_min`/`range_max` fields.
+        // `resume_in_place` left the inner iterator as a valid active iterator, so
+        // the whole `RawNumeric` is now a valid `Numeric<'a, RS::Resumed<'a>, E>`.
+        let active = unsafe { Box::from_raw(raw as *mut Numeric<'a, RS::Resumed<'a>, E>) };
+
+        Ok(match status {
+            ResumeStatus::Unchanged => ResumeOutcome::Ok(active),
+            ResumeStatus::Moved => ResumeOutcome::Moved(active),
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.it.last_doc_id_field()
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.it.num_estimated()
+    }
+}
 impl<'index, R, E> RQEIterator<'index> for Numeric<'index, R, E>
 where
     R: NumericReader<'index>,
@@ -434,12 +536,12 @@ impl<'index> NumericIteratorVariant<'index> {
         }
     }
 
-    /// Returns the flags from the underlying index reader.
-    pub fn flags(&self) -> IndexFlags {
+    /// Returns the cached flags of the underlying index reader.
+    pub const fn flags(&self) -> IndexFlags {
         match self {
-            Self::Unfiltered(iter) => iter.reader().flags(),
-            Self::Filtered(iter) => iter.reader().flags(),
-            Self::Geo(iter) => iter.reader().flags(),
+            Self::Unfiltered(iter) => iter.flags(),
+            Self::Filtered(iter) => iter.flags(),
+            Self::Geo(iter) => iter.flags(),
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
@@ -14,7 +14,8 @@ use index_spec::IndexSpecReadGuard;
 use rqe_core::DocId;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, empty::Empty,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome, empty::Empty,
 };
 
 /// An iterator that is either [`Empty`] or the provided [`RQEIterator`].
@@ -145,7 +146,9 @@ where
     #[inline(always)]
     fn num_estimated(&self) -> usize {
         match &self.0 {
-            MaybeEmptyOption::None(empty) => empty.num_estimated(),
+            // Disambiguated against `RQESuspendedIterator::num_estimated`
+            // (Empty's suspended counterpart is itself).
+            MaybeEmptyOption::None(empty) => RQEIterator::num_estimated(empty),
             MaybeEmptyOption::Some(it) => it.num_estimated(),
         }
     }
@@ -153,7 +156,9 @@ where
     #[inline(always)]
     fn last_doc_id(&self) -> DocId {
         match &self.0 {
-            MaybeEmptyOption::None(empty) => empty.last_doc_id(),
+            // Disambiguated against `RQESuspendedIterator::last_doc_id`
+            // (Empty's suspended counterpart is itself).
+            MaybeEmptyOption::None(empty) => RQEIterator::last_doc_id(empty),
             MaybeEmptyOption::Some(it) => it.last_doc_id(),
         }
     }
@@ -180,6 +185,94 @@ where
                 empty.intersection_sort_weight(prioritize_union_children)
             }
             MaybeEmptyOption::Some(it) => it.intersection_sort_weight(prioritize_union_children),
+        }
+    }
+}
+
+impl<'index, I> RQEIteratorBoxed<'index> for MaybeEmpty<I>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = MaybeEmpty<I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Walk the `Some(I)` arm if present — dispatches via the trait so
+        // dyn-erased `I` correctly transitions its vtable. The `None(Empty)`
+        // arm needs no suspend (Empty is a unit struct with no state).
+        //
+        // SAFETY: `raw` came from `Box::into_raw`, exclusively owned and
+        // valid, so the inner enum slot is reachable.
+        let inner: &mut MaybeEmptyOption<I> = unsafe { &mut (*raw).0 };
+        if let MaybeEmptyOption::Some(it) = inner {
+            // SAFETY: `it` is a valid `&mut I` aliased to nothing else;
+            // the function leaves the slot in a valid `I::Suspended` state.
+            unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut I) };
+        }
+        // SAFETY: `MaybeEmpty<I>` is `#[repr(C)]` over a `#[repr(C)]` enum
+        // `MaybeEmptyOption<I>` whose `Some` payload (now byte-rewritten as
+        // `I::Suspended`) is layout-compatible with the suspended form.
+        // `I` and `I::Suspended` share layout by the [`RQEIteratorBoxed`]
+        // contract.
+        unsafe { Box::from_raw(raw as *mut MaybeEmpty<I::Suspended>) }
+    }
+}
+
+impl<'query, S> RQESuspendedIterator<'query> for MaybeEmpty<S>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = MaybeEmpty<S::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        match (*self).0 {
+            MaybeEmptyOption::None(empty) => {
+                let active: Box<MaybeEmpty<S::Resumed<'a>>> =
+                    Box::new(MaybeEmpty(MaybeEmptyOption::None(empty)));
+                Ok(ResumeOutcome::Ok(active))
+            }
+            MaybeEmptyOption::Some(child) => {
+                // Forward the child's outcome: an aborted child aborts the
+                // whole wrapper (no active iterator produced); otherwise
+                // re-wrap the resumed child and preserve its `Ok`/`Moved`
+                // status.
+                let (active_child, moved) = match Box::new(child).resume(guard)? {
+                    ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                    ResumeOutcome::Ok(child) => (child, false),
+                    ResumeOutcome::Moved(child) => (child, true),
+                };
+                let active = Box::new(MaybeEmpty(MaybeEmptyOption::Some(*active_child)));
+                Ok(if moved {
+                    ResumeOutcome::Moved(active)
+                } else {
+                    ResumeOutcome::Ok(active)
+                })
+            }
+        }
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        match &self.0 {
+            MaybeEmptyOption::None(_) => 0,
+            MaybeEmptyOption::Some(child) => S::last_doc_id(child),
+        }
+    }
+
+    fn num_estimated(&self) -> usize {
+        match &self.0 {
+            // Empty is its own suspended counterpart; disambiguate against
+            // `RQEIterator::num_estimated`.
+            MaybeEmptyOption::None(empty) => RQESuspendedIterator::num_estimated(empty),
+            MaybeEmptyOption::Some(child) => S::num_estimated(child),
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -10,10 +10,11 @@
 //! Supporting types for [`Not`].
 
 use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
     maybe_empty::MaybeEmpty,
     profile_print::{ProfilePrint, ProfilePrintCtx},
     utils::TimeoutContext,
@@ -266,6 +267,87 @@ where
 
     fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
         1.0
+    }
+}
+
+impl<'index, I, TC> RQEIteratorBoxed<'index> for Not<'index, I, TC>
+where
+    I: RQEIteratorBoxed<'index>,
+    TC: TimeoutContext + 'index + 'static,
+{
+    type Suspended = RawNot<'index, Suspended, I::Suspended, TC>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawNot` is `#[repr(C)]`. The only `Rf`-dependent field
+        // is `result: RawIndexResult<Rf>`, layout-compatible across `Rf`
+        // via `SharedPtr` transparency. `MaybeEmpty<I>` and
+        // `MaybeEmpty<I::Suspended>` are layout-compatible by the
+        // [`RQEIteratorBoxed`] contract (see [`MaybeEmpty::suspend`]).
+        // Box::from_raw reuses the same heap allocation.
+        unsafe { Box::from_raw(raw as *mut RawNot<'index, Suspended, I::Suspended, TC>) }
+    }
+}
+
+impl<'query, S, TC> RQESuspendedIterator<'query> for RawNot<'query, Suspended, S, TC>
+where
+    S: RQESuspendedIterator<'query>,
+    TC: TimeoutContext + 'static,
+{
+    type Resumed<'a>
+        = Not<'a, S::Resumed<'a>, TC>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let RawNot {
+            child,
+            max_doc_id,
+            forced_eof,
+            result,
+            timeout_ctx,
+        } = *self;
+
+        // Mirror the existing `revalidate` semantics: if the child aborted,
+        // `NOT (aborted)` collapses to "NOT empty" — drop the child. A child
+        // move doesn't shift NOT's position because NOT keeps its own cursor,
+        // so resume always reports `Ok`.
+        let child: MaybeEmpty<S::Resumed<'a>> = match Box::new(child).resume(guard)? {
+            ResumeOutcome::Aborted => MaybeEmpty::new_empty(),
+            ResumeOutcome::Ok(active_child) | ResumeOutcome::Moved(active_child) => *active_child,
+        };
+
+        // SAFETY: `Not`'s `result` is a virtual sentinel built via
+        // `build_virt()` — its `data` is `RawResultData::Virtual` (carries
+        // no pointers), `dmd` is null at this iterator's construction, and
+        // `metrics` is empty. There are therefore no aliased pointers
+        // whose validity could be in question, so the `Active<'a>`
+        // re-typing is unconditionally sound.
+        let result = unsafe { result.into_active::<'a>() };
+
+        let active = Box::new(Not {
+            child,
+            max_doc_id,
+            forced_eof,
+            result,
+            timeout_ctx,
+        });
+        Ok(ResumeOutcome::Ok(active))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        // Mode-independent — mirrors the active `num_estimated`.
+        self.max_doc_id as usize
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -10,11 +10,11 @@
 //! Supporting types for [`NotOptimized`].
 
 use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
-    WildcardIterator,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome, WildcardIterator,
     maybe_empty::MaybeEmpty,
     profile_print::{ProfilePrint, ProfilePrintCtx},
     utils::TimeoutContext,
@@ -94,7 +94,16 @@ where
             timeout_ctx,
         }
     }
+}
 
+impl<'index, W, I, TC> NotOptimized<'index, W, I, TC>
+where
+    // Helpers below only call generic `RQEIterator` methods on the wildcard
+    // base, so they don't need the `WildcardIterator` marker (enforced in `new`).
+    W: RQEIterator<'index>,
+    I: RQEIterator<'index>,
+    TC: TimeoutContext,
+{
     /// Wrapper around [`TimeoutContext::check_timeout`].
     #[inline(always)]
     fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
@@ -183,7 +192,8 @@ where
 
 impl<'index, W, I, TC> RQEIterator<'index> for NotOptimized<'index, W, I, TC>
 where
-    W: WildcardIterator<'index>,
+    // Marker enforced at construction (`new`); only generic methods used here.
+    W: RQEIterator<'index>,
     I: RQEIterator<'index>,
     TC: TimeoutContext,
 {
@@ -345,6 +355,128 @@ where
 
     fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
         1.0
+    }
+}
+
+impl<'index, W, I, TC> RQEIteratorBoxed<'index> for NotOptimized<'index, W, I, TC>
+where
+    // Marker enforced at construction (`new`), not on the suspend/resume path.
+    W: RQEIteratorBoxed<'index>,
+    I: RQEIteratorBoxed<'index>,
+    TC: TimeoutContext + 'index + 'static,
+{
+    type Suspended = RawNotOptimized<'index, Suspended, W::Suspended, I::Suspended, TC>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawNotOptimized` is `#[repr(C)]`. The only `Rf`-dependent
+        // field is `result: RawIndexResult<Rf>` (layout-compatible via
+        // `SharedPtr` transparency). `W`/`I` are layout-compatible with
+        // `W::Suspended`/`I::Suspended` by the [`RQEIteratorBoxed`]
+        // contract; `MaybeEmpty<I>` likewise (see [`MaybeEmpty::suspend`]).
+        // Box::from_raw reuses the same heap allocation.
+        unsafe {
+            Box::from_raw(
+                raw as *mut RawNotOptimized<'index, Suspended, W::Suspended, I::Suspended, TC>,
+            )
+        }
+    }
+}
+
+impl<'query, WS, IS, TC> RQESuspendedIterator<'query>
+    for RawNotOptimized<'query, Suspended, WS, IS, TC>
+where
+    WS: RQESuspendedIterator<'query>,
+    IS: RQESuspendedIterator<'query>,
+    TC: TimeoutContext + 'static,
+{
+    type Resumed<'a>
+        = NotOptimized<'a, WS::Resumed<'a>, IS::Resumed<'a>, TC>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let RawNotOptimized {
+            wcii,
+            child,
+            max_doc_id,
+            forced_eof,
+            result,
+            timeout_ctx,
+        } = *self;
+
+        // Resume both children unconditionally, mirroring the legacy path.
+        let wcii_outcome = Box::new(wcii).resume(guard)?;
+        let child_outcome = Box::new(child).resume(guard)?;
+
+        // An aborted query child collapses to `Empty` (mirroring the legacy
+        // behaviour); a moved child doesn't shift NOT's cursor.
+        let child: MaybeEmpty<IS::Resumed<'a>> = match child_outcome {
+            ResumeOutcome::Aborted => MaybeEmpty::new_empty(),
+            ResumeOutcome::Ok(c) | ResumeOutcome::Moved(c) => *c,
+        };
+
+        // If `wcii` aborted we cannot rebuild — there is no base to enumerate
+        // the complement over — so the whole iterator aborts. The `wcii` is
+        // genuinely a wildcard; its concrete resumed type `WS::Resumed<'a>` is
+        // statically a `WildcardIterator`.
+        let (wcii, wcii_moved) = match wcii_outcome {
+            ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+            ResumeOutcome::Ok(w) => (*w, false),
+            ResumeOutcome::Moved(w) => (*w, true),
+        };
+
+        // SAFETY: `NotOptimized`'s `result` is a virtual sentinel built via
+        // `build_virt()` — no aliased pointers to validate. The `Active<'a>`
+        // re-typing is unconditionally sound.
+        let result = unsafe { result.into_active::<'a>() };
+
+        let mut active = Box::new(NotOptimized {
+            wcii,
+            child,
+            max_doc_id,
+            forced_eof,
+            result,
+            timeout_ctx,
+        });
+
+        if wcii_moved {
+            active.forced_eof = active.wcii.at_eof();
+            let mut have_valid_pos = !active.forced_eof;
+            if have_valid_pos {
+                active.result.doc_id = active.wcii.last_doc_id();
+                if active.child.last_doc_id() < active.result.doc_id {
+                    let _ = active.child.skip_to(active.result.doc_id);
+                }
+                if active.child.last_doc_id() == active.result.doc_id {
+                    if let Ok(found) = active.read_inner() {
+                        have_valid_pos = found;
+                    } else {
+                        active.forced_eof = false;
+                        have_valid_pos = false;
+                    }
+                }
+            }
+            let _ = have_valid_pos;
+            return Ok(ResumeOutcome::Moved(active));
+        }
+
+        Ok(ResumeOutcome::Ok(active))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        // Mirrors the active `num_estimated`, which delegates to the wildcard base.
+        self.wcii.num_estimated()
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -10,11 +10,12 @@
 //! Supporting types for [`Optional`].
 
 use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use std::cmp;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 use index_spec::IndexSpecReadGuard;
@@ -26,6 +27,18 @@ use rqe_core::{DocId, RS_FIELDMASK_ALL};
 ///
 /// Parameterised over a [`Ref`] mode — see [`Optional`] for the [`Active`]
 /// instantiation that implements [`RQEIterator`].
+///
+/// # Invariants
+///
+/// 1. **Layout compatibility across modes.** `RawOptional` is `#[repr(C)]` and
+///    its only `Rf`-dependent field is `result: RawIndexResult<Rf>`, which is
+///    layout-compatible across `Rf` (proven in `index_result`). Given that the
+///    child `I` and its `I::Suspended` are layout-compatible (the
+///    [`RQEIteratorBoxed`] contract, preserved through the `#[repr(C)]`
+///    [`OptionalChild`] slot), the `Active` and `Suspended` instantiations are
+///    layout-identical. This is what lets
+///    [`suspend`](RQEIteratorBoxed::suspend) reinterpret the owning `Box` in
+///    place.
 #[repr(C)]
 pub struct RawOptional<'query, Rf: Ref, I> {
     /// Inclusive upper bound on document identifiers to iterate over.
@@ -293,6 +306,106 @@ where
     }
 }
 
+impl<'index, I> RQEIteratorBoxed<'index> for Optional<'index, I>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawOptional<'index, Suspended, I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawOptional` is `#[repr(C)]`. The only `Rf`-dependent
+        // field is `result: RawIndexResult<Rf>`, layout-compatible across
+        // `Rf` via `SharedPtr` transparency. `Option<I>` ↔ `Option<I::Suspended>`
+        // are layout-compatible by the [`RQEIteratorBoxed`] contract.
+        // Box::from_raw reuses the same heap allocation.
+        unsafe { Box::from_raw(raw as *mut RawOptional<'index, Suspended, I::Suspended>) }
+    }
+}
+
+impl<'query, S> RQESuspendedIterator<'query> for RawOptional<'query, Suspended, S>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = Optional<'a, S::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let RawOptional {
+            max_doc_id,
+            weight,
+            result,
+            child,
+        } = *self;
+
+        // Resume the child first (if present) so we never construct the
+        // active `Optional<'a, …>` with a still-suspended `child` field.
+        // Track whether the child aborted or moved to mirror `revalidate`;
+        // an aborted child is dropped (`Gone`), leaving us fully virtual.
+        let (child, child_disturbed, last_child_doc_id) = match child {
+            OptionalChild::Gone => (OptionalChild::Gone, false, 0),
+            OptionalChild::Present(c) => {
+                let last = S::last_doc_id(&c);
+                match Box::new(c).resume(guard)? {
+                    ResumeOutcome::Aborted => (OptionalChild::Gone, true, last),
+                    ResumeOutcome::Ok(active_child) => {
+                        (OptionalChild::Present(*active_child), false, last)
+                    }
+                    ResumeOutcome::Moved(active_child) => {
+                        (OptionalChild::Present(*active_child), true, last)
+                    }
+                }
+            }
+        };
+
+        // SAFETY: `Optional`'s `result` is a virtual sentinel built via
+        // `build_virt()` — its `data` is `RawResultData::Virtual` (carries no
+        // pointers), `dmd` is null at this iterator's construction, and
+        // `metrics` is empty. There are therefore no aliased pointers whose
+        // validity could be in question, so the `Active<'a>` re-typing is
+        // unconditionally sound.
+        let result = unsafe { result.into_active::<'a>() };
+
+        let mut active = Box::new(Optional {
+            max_doc_id,
+            weight,
+            result,
+            child,
+        });
+
+        // Mirror `revalidate`: a child that aborted or moved forces a re-read
+        // iff the previous result came from the child (its doc id matches the
+        // aggregate's current doc id) rather than being a virtual sentinel.
+        let moved = if child_disturbed && last_child_doc_id == active.result.doc_id {
+            active.read()?;
+            true
+        } else {
+            false
+        };
+
+        Ok(if moved {
+            ResumeOutcome::Moved(active)
+        } else {
+            ResumeOutcome::Ok(active)
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.max_doc_id as usize
+    }
+}
 impl<'index> crate::interop::ProfileChildren<'index>
     for Optional<'index, crate::c2rust::CRQEIterator>
 {

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -15,10 +15,11 @@
 //! results accordingly.
 
 use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 
 use crate::{
-    RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator, RQEValidateStatus,
+    ResumeOutcome, SkipToOutcome,
     maybe_empty::MaybeEmpty,
     profile_print::{ProfilePrint, ProfilePrintCtx},
     wildcard::WildcardIterator,
@@ -40,6 +41,19 @@ use rqe_core::{DocId, RS_FIELDMASK_ALL};
 /// This avoids scanning doc IDs 1..=maxDocId sequentially. When the index is
 /// sparse (few documents relative to `maxDocId`), the optimized variant is
 /// significantly faster.
+///
+/// # Invariants
+///
+/// 1. **Layout compatibility across modes.** `RawOptionalOptimized` is
+///    `#[repr(C)]` and its only `Rf`-dependent field is
+///    `virt: RawIndexResult<Rf>`, which is layout-compatible across `Rf`
+///    (proven in `index_result`). Given that the wildcard base `W`/`W::Suspended`
+///    and the child `I`/`I::Suspended` are layout-compatible (the
+///    [`RQEIteratorBoxed`] contract — the latter through the `#[repr(C)]`
+///    [`MaybeEmpty`] slot), the `Active` and `Suspended` instantiations are
+///    layout-identical. This is what lets
+///    [`suspend`](RQEIteratorBoxed::suspend) reinterpret the owning `Box` in
+///    place.
 #[repr(C)]
 pub struct RawOptionalOptimized<'query, Rf: Ref, W, I> {
     /// Wildcard iterator over `spec.existingDocs` — the authoritative source of doc IDs.
@@ -107,7 +121,9 @@ where
 
 impl<'index, W, I> RQEIterator<'index> for OptionalOptimized<'index, W, I>
 where
-    W: WildcardIterator<'index>,
+    // Only generic `RQEIterator` methods are called on the wildcard base here;
+    // the `WildcardIterator` marker is enforced at construction (see `new`).
+    W: RQEIterator<'index>,
     I: RQEIterator<'index>,
 {
     #[inline(always)]
@@ -348,6 +364,165 @@ where
 
     fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
         1.0
+    }
+}
+
+impl<'index, W, I> RQEIteratorBoxed<'index> for OptionalOptimized<'index, W, I>
+where
+    // Marker enforced at construction (`new`), not on the suspend/resume path —
+    // the suspend/resume impls only move the wildcard child through the box
+    // cast, so `W: RQEIteratorBoxed` suffices. This drops the recursive
+    // `for<'a> …: WildcardIterator + RQEIteratorBoxed<Suspended = …>` HRTB,
+    // which is otherwise unsatisfiable once `'query` narrows on resume.
+    W: RQEIteratorBoxed<'index>,
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawOptionalOptimized<'index, Suspended, W::Suspended, I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawOptionalOptimized` is `#[repr(C)]`. The only
+        // `Rf`-dependent field is `virt: RawIndexResult<Rf>`, layout-
+        // compatible across `Rf` via `SharedPtr` transparency. `W`/`I` are
+        // layout-compatible with `W::Suspended`/`I::Suspended` by the
+        // [`RQEIteratorBoxed`] contract, and `MaybeEmpty<I>` likewise
+        // (see [`MaybeEmpty::suspend`]). Box::from_raw reuses the same
+        // heap allocation.
+        unsafe {
+            Box::from_raw(
+                raw as *mut RawOptionalOptimized<'index, Suspended, W::Suspended, I::Suspended>,
+            )
+        }
+    }
+}
+
+impl<'query, WS, IS> RQESuspendedIterator<'query>
+    for RawOptionalOptimized<'query, Suspended, WS, IS>
+where
+    WS: RQESuspendedIterator<'query>,
+    IS: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = OptionalOptimized<'a, WS::Resumed<'a>, IS::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let RawOptionalOptimized {
+            wcii,
+            child,
+            virt,
+            max_doc_id,
+            weight,
+            last_doc_id,
+            at_eof,
+        } = *self;
+
+        // Resume both children unconditionally, mirroring the legacy path
+        // (which drove `resume` on both before inspecting either outcome).
+        // The `wcii` (base) child is genuinely a wildcard; its concrete
+        // resumed type `WS::Resumed<'a>` is statically a `WildcardIterator`.
+        let pre_wcii_last_doc_id = RQESuspendedIterator::last_doc_id(&wcii);
+        let wcii_outcome = Box::new(wcii).resume(guard)?;
+        let pre_child_last_doc_id = RQESuspendedIterator::last_doc_id(&child);
+        let child_outcome = Box::new(child).resume(guard)?;
+
+        // If `wcii` aborted we cannot rebuild — there is no base to enumerate
+        // doc ids — so the whole iterator aborts, dropping the just-resumed
+        // child.
+        let (wcii, wcii_moved) = match wcii_outcome {
+            ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+            ResumeOutcome::Ok(w) => (*w, false),
+            ResumeOutcome::Moved(w) => (*w, true),
+        };
+
+        // An aborted query child is replaced by `Empty` (mirroring
+        // `revalidate`'s `take_iterator`) and treated as "moved": its state
+        // changed, so downstream must re-evaluate.
+        let (child, child_moved_or_aborted): (MaybeEmpty<IS::Resumed<'a>>, bool) =
+            match child_outcome {
+                ResumeOutcome::Aborted => (MaybeEmpty::new_empty(), true),
+                ResumeOutcome::Ok(c) => (*c, false),
+                ResumeOutcome::Moved(c) => (*c, true),
+            };
+
+        // SAFETY: `OptionalOptimized`'s `virt` is a virtual sentinel built via
+        // `build_virt()` — its `data` is `RawResultData::Virtual` (carries no
+        // pointers), `dmd` is null at this iterator's construction, and
+        // `metrics` is empty. There are therefore no aliased pointers whose
+        // validity could be in question, so the `Active<'a>` re-typing is
+        // unconditionally sound.
+        let virt = unsafe { virt.into_active::<'a>() };
+
+        let mut active = Box::new(OptionalOptimized {
+            wcii,
+            child,
+            virt,
+            max_doc_id,
+            weight,
+            last_doc_id,
+            at_eof,
+        });
+
+        // Distinguish "wcii moved to a new valid position" from "wcii moved
+        // past all docs (no new current)". `ResumeOutcome::Moved` doesn't
+        // carry the {Some, None} distinction that legacy `revalidate` had, so
+        // we recover it by comparing wcii's pre/post `last_doc_id`: a true
+        // "Moved to EOF without a new doc" leaves the cached doc_id unchanged
+        // (the wcii has nothing new to surface). A "Moved to a new valid doc"
+        // advances the cached doc_id even if `at_eof` is now true (because
+        // that new doc is the LAST valid one).
+        if wcii_moved && active.wcii.at_eof() && active.wcii.last_doc_id() == pre_wcii_last_doc_id {
+            active.at_eof = true;
+            return Ok(ResumeOutcome::Moved(active));
+        }
+        active.at_eof = active.wcii.at_eof();
+
+        let current_was_virtual =
+            active.last_doc_id == 0 || pre_child_last_doc_id != active.last_doc_id;
+
+        if !wcii_moved {
+            // wcii stayed at the same position.
+            if !child_moved_or_aborted || current_was_virtual {
+                // Child is still valid, or the current result was virtual — no change.
+                return Ok(ResumeOutcome::Ok(active));
+            }
+            // Child moved or aborted while the current was a real result:
+            // advance to the next valid state.
+            active.read()?;
+            return Ok(ResumeOutcome::Moved(active));
+        }
+
+        // wcii moved to a new valid position; update the child accordingly.
+        let wcii_doc_id = active.wcii.last_doc_id();
+        if wcii_doc_id > active.max_doc_id {
+            active.at_eof = true;
+            return Ok(ResumeOutcome::Moved(active));
+        }
+        if wcii_doc_id > active.child.last_doc_id() {
+            active.child.skip_to(wcii_doc_id)?;
+        }
+        active.last_doc_id = wcii_doc_id;
+        active.at_eof |= wcii_doc_id >= active.max_doc_id;
+        if active.child.last_doc_id() != wcii_doc_id {
+            active.virt.doc_id = wcii_doc_id;
+        }
+        Ok(ResumeOutcome::Moved(active))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.last_doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        // Mirrors the active `num_estimated`, which delegates to the wildcard base.
+        self.wcii.num_estimated()
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/src/profile.rs
@@ -15,10 +15,14 @@
 
 use std::time::{Duration, Instant};
 
-use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+    boxed::{ResumeSlotOutcome, resume_child_slot_in_place},
+};
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
 /// Profile counters collected during query execution.
@@ -59,6 +63,16 @@ impl ProfileCounters {
 ///
 /// The collected metrics can be accessed via [`Profile::counters()`] and
 /// [`Profile::wall_time_ns()`].
+///
+/// # Invariants
+///
+/// 1. **Layout compatibility across modes.** `RawProfile` is `#[repr(C)]` and
+///    carries no `Rf`-dependent field other than the zero-sized
+///    `_marker: PhantomData<Rf>`, so its `Active` and `Suspended`
+///    instantiations are layout-identical given that the child `I` and its
+///    `I::Suspended` are (the [`RQEIteratorBoxed`] contract). This is what lets
+///    [`suspend`](RQEIteratorBoxed::suspend) reinterpret the owning `Box` in
+///    place.
 #[repr(C)]
 pub struct RawProfile<Rf: Ref, I> {
     child: I,
@@ -182,5 +196,123 @@ where
         let counters = self.counters();
         let mut child_ctx = ctx.with_counters(counters, self.wall_time_ns());
         self.child().print_profile(map, &mut child_ctx);
+    }
+}
+
+impl<'index, I> RQEIteratorBoxed<'index> for Profile<'index, I>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawProfile<Suspended, I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawProfile` is `#[repr(C)]`. The `Rf`-dependent field is
+        // only `_marker: PhantomData<Rf>` (zero-sized). `child: I` and the
+        // suspended counterpart's `child: I::Suspended` are layout-
+        // compatible by the [`RQEIteratorBoxed`] contract. `counters` and
+        // `wall_time` carry no `Rf`. Box::from_raw reuses the same heap
+        // allocation, so the box address is preserved.
+        unsafe { Box::from_raw(raw as *mut RawProfile<Suspended, I::Suspended>) }
+    }
+}
+
+/// Free a [`RawProfile`] allocation whose `child` slot has already been consumed
+/// (moved-from) by an aborted/failed child resume, without running the child's
+/// drop glue.
+///
+/// # Safety
+///
+/// * `raw` came from `Box::into_raw` and is still exclusively owned by the caller.
+/// * `(*raw).child` is moved-from (uninitialised) and must NOT be dropped.
+/// * No other reference to the allocation exists.
+unsafe fn dealloc_after_child_gone<S>(raw: *mut RawProfile<Suspended, S>) {
+    // SAFETY: `raw` is valid; `&raw mut` forms a field pointer without a reference.
+    let counters = unsafe { &raw mut (*raw).counters };
+    // SAFETY: `counters` is still a valid, owned value; drop it in place.
+    unsafe { std::ptr::drop_in_place(counters) };
+    // SAFETY: `raw` is valid; `&raw mut` forms a field pointer without a reference.
+    let wall_time = unsafe { &raw mut (*raw).wall_time };
+    // SAFETY: `wall_time` is still a valid, owned value; drop it in place.
+    unsafe { std::ptr::drop_in_place(wall_time) };
+    // `_marker` is a ZST with no drop glue.
+    // SAFETY: `raw` was allocated by `Box` with exactly this layout; the `child`
+    // slot is moved-from so it is not dropped. Frees the allocation.
+    unsafe {
+        std::alloc::dealloc(
+            raw.cast::<u8>(),
+            std::alloc::Layout::new::<RawProfile<Suspended, S>>(),
+        )
+    };
+}
+
+impl<'query, S> RQESuspendedIterator<'query> for RawProfile<Suspended, S>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = Profile<'a, S::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Resume the child in place and reuse this box's allocation, mirroring
+        // `RawInvIndIterator::resume`. Profile delegates `current()` — and hence
+        // the FFI wrapper's cached `header.current` pointer — into the child's
+        // storage, so the box (and the child slot inside it) must keep its
+        // address across the cycle; rebuilding via `Box::new` would dangle that
+        // pointer. Profile owns no aggregate result and simply mirrors the
+        // child's `Ok`/`Moved`/`Aborted` outcome.
+        let raw = Box::into_raw(self);
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+        // initialised, exclusively owned). `&raw mut` forms a field pointer to
+        // the `child` slot without creating a reference.
+        let child_slot = unsafe { &raw mut (*raw).child };
+        // SAFETY: `child_slot` points at the valid, exclusively-owned suspended
+        // child. On `Unchanged`/`Moved` the helper reinitialises the slot as
+        // `S::Resumed<'a>`; on `Aborted`/`Err` the child is consumed and the slot
+        // is left uninitialised (handled by the teardown arms below).
+        match unsafe { resume_child_slot_in_place(child_slot, guard) } {
+            Ok(outcome @ (ResumeSlotOutcome::Unchanged | ResumeSlotOutcome::Moved)) => {
+                // SAFETY: the child slot now holds a valid `S::Resumed<'a>`, and
+                // every other field is `Rf`-independent, so the allocation is a
+                // valid `Profile<'a, S::Resumed<'a>>` — layout-identical to the
+                // suspended form (invariant 1: `RawProfile` is `#[repr(C)]`).
+                // `Box::from_raw` reuses the same allocation, preserving the box
+                // and child-slot addresses.
+                let active = unsafe { Box::from_raw(raw.cast::<Profile<'a, S::Resumed<'a>>>()) };
+                Ok(if matches!(outcome, ResumeSlotOutcome::Moved) {
+                    ResumeOutcome::Moved(active)
+                } else {
+                    ResumeOutcome::Ok(active)
+                })
+            }
+            Ok(ResumeSlotOutcome::Aborted) => {
+                // SAFETY: the child was consumed by its `resume` (slot
+                // uninitialised); free the reused allocation without dropping the
+                // moved-from child.
+                unsafe { dealloc_after_child_gone(raw) };
+                Ok(ResumeOutcome::Aborted)
+            }
+            Err(e) => {
+                // SAFETY: as the `Aborted` arm — the child is gone, tear the rest down.
+                unsafe { dealloc_after_child_gone(raw) };
+                Err(e)
+            }
+        }
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        S::last_doc_id(&self.child)
+    }
+
+    fn num_estimated(&self) -> usize {
+        S::num_estimated(&self.child)
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -10,10 +10,13 @@
 //! Flat array variant of the union iterator with O(n) min-finding.
 
 use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
-use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+};
 use index_spec::IndexSpecReadGuard;
 
 /// A child iterator paired with its original insertion index.
@@ -624,6 +627,192 @@ where
         } else {
             1.0
         }
+    }
+}
+
+impl<'index, I, const QUICK_EXIT: bool> RQEIteratorBoxed<'index>
+    for UnionFlat<'index, I, QUICK_EXIT>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawUnionFlat<'index, Suspended, I::Suspended, QUICK_EXIT>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Walk children: dispatch each child's `suspend` through the trait
+        // so dyn-erased `I` (e.g. [`TypeErasedRQEIterator`](crate::TypeErasedRQEIterator))
+        // correctly transitions its vtable. For concrete-typed `I` this is
+        // the same whole-box cast that would otherwise happen at the outer
+        // level, just per-child.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` and is exclusively owned
+        // for the rest of this function, so the children Vec is reachable
+        // and unaliased.
+        let children: &mut Vec<IndexedChild<I>> = unsafe { &mut (*raw).children };
+        for child in children.iter_mut() {
+            // SAFETY: `child.inner` is a valid `I` accessed via a fresh
+            // `&mut`; the function leaves the slot in a valid
+            // `I::Suspended` state.
+            unsafe { crate::boxed::suspend_child_slot_in_place(&mut child.inner) };
+        }
+        // SAFETY: `RawUnionFlat` is `#[repr(C)]` over `Vec<IndexedChild<I>>`
+        // (now byte-rewritten with `I::Suspended` payloads) and
+        // `result: RawIndexResult<Rf>` (layout-compatible via `SharedPtr`).
+        unsafe {
+            Box::from_raw(raw as *mut RawUnionFlat<'index, Suspended, I::Suspended, QUICK_EXIT>)
+        }
+    }
+}
+
+impl<'query, S, const QUICK_EXIT: bool> RQESuspendedIterator<'query>
+    for RawUnionFlat<'query, Suspended, S, QUICK_EXIT>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = UnionFlat<'a, S::Resumed<'a>, QUICK_EXIT>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let RawUnionFlat {
+            children,
+            num_active,
+            num_estimated,
+            is_eof,
+            result,
+        } = *self;
+
+        // Read plain-data fields off the suspended aggregate before
+        // discarding it — the suspended aggregate's borrowed children
+        // pointers would dangle after we consume the children by value.
+        let saved_weight = result.weight;
+        let saved_last_doc_id = result.doc_id;
+        drop(result);
+
+        // `swap_remove_child` keeps EOF children in the Vec at indices
+        // `[num_active..]` so [`rewind`](RQEIterator::rewind) can sort them
+        // back into the active set. Resume must preserve that split: the
+        // tail children stay in their resumed-active form so they survive
+        // a future rewind, but they don't count toward `num_active` (their
+        // last_doc_id would otherwise be picked up as a spurious min and
+        // yielded again after the live children exhaust).
+        //
+        // Track changes the same way as in the non-rewind case: a MOVED or
+        // ABORTED child means the cached aggregate position may no longer
+        // be the union's actual min, so we re-find min below.
+        let mut any_change = false;
+        let mut live: Vec<IndexedChild<S::Resumed<'a>>> = Vec::with_capacity(num_active);
+        let mut dead: Vec<IndexedChild<S::Resumed<'a>>> =
+            Vec::with_capacity(children.len().saturating_sub(num_active));
+        for (
+            i,
+            IndexedChild {
+                original_index,
+                inner,
+            },
+        ) in children.into_iter().enumerate()
+        {
+            let active_inner = match Box::new(inner).resume(guard)? {
+                ResumeOutcome::Aborted => {
+                    any_change = true;
+                    continue;
+                }
+                ResumeOutcome::Moved(active_inner) => {
+                    any_change = true;
+                    *active_inner
+                }
+                ResumeOutcome::Ok(active_inner) => *active_inner,
+            };
+            let resumed = IndexedChild {
+                original_index,
+                inner: active_inner,
+            };
+            if i < num_active {
+                live.push(resumed);
+            } else {
+                dead.push(resumed);
+            }
+        }
+        let num_children = live.len();
+        let mut active_children = live;
+        active_children.extend(dead);
+        let result = RSIndexResult::build_union(num_children)
+            .weight(saved_weight)
+            .build();
+
+        let mut active: Box<UnionFlat<'a, S::Resumed<'a>, QUICK_EXIT>> = Box::new(UnionFlat {
+            children: active_children,
+            num_active: num_children,
+            num_estimated,
+            is_eof,
+            result,
+        });
+
+        if active.is_eof || saved_last_doc_id == 0 {
+            return Ok(ResumeOutcome::Ok(active));
+        }
+
+        // `num_children == 0` here means every previously-live child
+        // ABORTED during resume (children that reached EOF naturally went
+        // into `dead` and don't count toward `num_children`). The union
+        // has no recoverable state.
+        if num_children == 0 {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        if !any_change {
+            // All children resumed Ok with state preserved; rebuild the
+            // aggregate at `saved_last_doc_id` so subsequent reads pick up
+            // from the same logical position. Don't proactively trim
+            // at_eof children — the next read will surface them.
+            active.build_aggregate_result(saved_last_doc_id);
+            return Ok(ResumeOutcome::Ok(active));
+        }
+
+        // Some child moved or aborted: re-discover the new minimum doc_id
+        // among survivors, dropping any that hit EOF.
+        let mut min_doc_id: DocId = DocId::MAX;
+        let mut i = 0;
+        while i < active.num_active {
+            let child = &active.children[i].inner;
+            if child.at_eof() {
+                active.swap_remove_child(i);
+                continue;
+            }
+            let child_doc_id = child.last_doc_id();
+            if child_doc_id < min_doc_id {
+                min_doc_id = child_doc_id;
+            }
+            i += 1;
+        }
+
+        if active.num_active == 0 {
+            active.is_eof = true;
+            return Ok(ResumeOutcome::Moved(active));
+        }
+
+        active.build_aggregate_result(min_doc_id);
+
+        if min_doc_id == saved_last_doc_id {
+            Ok(ResumeOutcome::Ok(active))
+        } else {
+            Ok(ResumeOutcome::Moved(active))
+        }
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.num_estimated
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -10,11 +10,14 @@
 //! Heap variant of the union iterator with O(log n) min-finding.
 
 use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
 use crate::utils::DocIdMinHeap;
-use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+};
 use index_spec::IndexSpecReadGuard;
 
 /// Yields documents appearing in ANY child iterator using a binary heap.
@@ -502,6 +505,180 @@ where
         } else {
             1.0
         }
+    }
+}
+
+impl<'index, I, const QUICK_EXIT: bool> RQEIteratorBoxed<'index>
+    for UnionHeap<'index, I, QUICK_EXIT>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawUnionHeap<'index, Suspended, I::Suspended, QUICK_EXIT>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Walk children: dispatch each child's `suspend` through the trait
+        // so dyn-erased `I` correctly transitions its vtable. See
+        // [`crate::boxed::suspend_child_slot_in_place`] for the rationale.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` and is exclusively owned
+        // for the rest of this function, so the children Vec is reachable
+        // and unaliased.
+        let children: &mut Vec<I> = unsafe { &mut (*raw).children };
+        for child in children.iter_mut() {
+            // SAFETY: `child` is a valid `&mut I` aliased to nothing else;
+            // the function leaves the slot in a valid `I::Suspended` state.
+            unsafe { crate::boxed::suspend_child_slot_in_place(child) };
+        }
+        // SAFETY: `RawUnionHeap` is `#[repr(C)]` over `Vec<I>` (now byte-
+        // rewritten as `Vec<I::Suspended>` contents), `result:
+        // RawIndexResult<Rf>` (layout-compatible via `SharedPtr`), and
+        // a heap of plain doc-ids/indices (no `Rf` in its types).
+        unsafe {
+            Box::from_raw(raw as *mut RawUnionHeap<'index, Suspended, I::Suspended, QUICK_EXIT>)
+        }
+    }
+}
+
+impl<'query, S, const QUICK_EXIT: bool> RQESuspendedIterator<'query>
+    for RawUnionHeap<'query, Suspended, S, QUICK_EXIT>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = UnionHeap<'a, S::Resumed<'a>, QUICK_EXIT>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let RawUnionHeap {
+            children,
+            num_estimated,
+            num_active,
+            is_eof,
+            result,
+            heap: _,
+        } = *self;
+
+        let saved_weight = result.weight;
+        let saved_last_doc_id = result.doc_id;
+        drop(result);
+
+        // `swap_remove_child` keeps EOF children in the Vec at indices
+        // `[num_active..]` so [`rewind`](RQEIterator::rewind) can restore
+        // them to active. Resume must preserve that split: tail children
+        // stay in their resumed-active form so a future rewind picks them
+        // up, but they don't count toward `num_active` (their last_doc_id
+        // would otherwise be re-inserted into the heap and yielded again
+        // after the live children exhaust).
+        let mut any_change = false;
+        let mut live: Vec<S::Resumed<'a>> = Vec::with_capacity(num_active);
+        let mut dead: Vec<S::Resumed<'a>> =
+            Vec::with_capacity(children.len().saturating_sub(num_active));
+        for (i, inner) in children.into_iter().enumerate() {
+            let active_inner = match Box::new(inner).resume(guard)? {
+                ResumeOutcome::Aborted => {
+                    any_change = true;
+                    continue;
+                }
+                ResumeOutcome::Moved(active_inner) => {
+                    any_change = true;
+                    *active_inner
+                }
+                ResumeOutcome::Ok(active_inner) => *active_inner,
+            };
+            if i < num_active {
+                live.push(active_inner);
+            } else {
+                dead.push(active_inner);
+            }
+        }
+        let num_children = live.len();
+        let mut active_children = live;
+        active_children.extend(dead);
+        let result = RSIndexResult::build_union(num_children)
+            .weight(saved_weight)
+            .build();
+
+        let mut active: Box<UnionHeap<'a, S::Resumed<'a>, QUICK_EXIT>> = Box::new(UnionHeap {
+            children: active_children,
+            num_estimated,
+            num_active: num_children,
+            is_eof,
+            result,
+            heap: DocIdMinHeap::with_capacity(num_children),
+        });
+
+        if active.is_eof || saved_last_doc_id == 0 {
+            return Ok(ResumeOutcome::Ok(active));
+        }
+
+        if num_children == 0 {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        if !any_change {
+            // Children's positions are unchanged. Rebuild the heap from
+            // their current positions so subsequent reads have a valid
+            // structure, then build the aggregate at saved_last_doc_id —
+            // exhausted children get discovered naturally on the next
+            // read, matching legacy revalidate's early-return.
+            for (idx, child) in active.children.iter().enumerate() {
+                if !child.at_eof() {
+                    active.heap.push(child.last_doc_id(), idx);
+                }
+            }
+            active.build_aggregate_result(saved_last_doc_id);
+            return Ok(ResumeOutcome::Ok(active));
+        }
+
+        // Some child moved or aborted: rebuild the heap from survivors,
+        // dropping those at EOF. The new minimum is the heap root.
+        let mut num_active = 0usize;
+        for (idx, child) in active.children.iter().enumerate() {
+            if !child.at_eof() {
+                active.heap.push(child.last_doc_id(), idx);
+                num_active += 1;
+            }
+        }
+        active.num_active = num_active;
+
+        if num_active == 0 {
+            active.is_eof = true;
+            return Ok(ResumeOutcome::Moved(active));
+        }
+
+        let min_entry = active
+            .heap
+            .peek()
+            .expect("heap is non-empty after num_active check");
+        let min_doc_id = min_entry.doc_id;
+
+        if QUICK_EXIT {
+            active.quick_set_from_child(min_entry.child_idx);
+        } else {
+            active.build_aggregate_result(min_doc_id);
+        }
+
+        if min_doc_id == saved_last_doc_id {
+            Ok(ResumeOutcome::Ok(active))
+        } else {
+            Ok(ResumeOutcome::Moved(active))
+        }
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.num_estimated
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -27,11 +27,12 @@ use std::ptr::NonNull;
 use ffi::QueryIterator;
 use index_result::RSIndexResult;
 use query_types::QueryNodeType;
-use ref_mode::{Active, Ref, SharedPtr};
+use ref_mode::{Active, Ref, SharedPtr, Suspended};
 use rqe_core::DocId;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, UnionFullFlat,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome, UnionFullFlat,
     c2rust::CRQEIterator,
     interop::RQEIteratorWrapper,
     profile_print::{ProfilePrint, ProfilePrintCtx},
@@ -441,4 +442,177 @@ unsafe fn build_union_with_q_str_opt(
     let ptr = RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children));
     // SAFETY: `boxed_new_inner` uses `Box::into_raw`, which is guaranteed non-null.
     unsafe { NonNull::new_unchecked(ptr) }
+}
+
+impl<'index, I> RQEIteratorBoxed<'index> for UnionOpaque<'index, I>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawUnionOpaque<'index, Suspended, I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Per-variant dispatch: each inner Union variant (`UnionFlat`,
+        // `UnionHeap`, `UnionTrimmed`) walks its own children during
+        // `suspend`, correctly transitioning dyn-erased `I` via the vtable.
+        // A whole-box cast at this level alone would skip those per-variant
+        // walks and leave inner children's vtables stale.
+        //
+        // SAFETY: `raw` came from `Box::into_raw`, exclusively owned and
+        // valid, so the variant field is reachable.
+        let variant_slot = unsafe { std::ptr::addr_of_mut!((*raw).variant) };
+        // SAFETY: `variant_slot` is a valid `*mut UnionVariant<...>`;
+        // `ptr::read` moves the value out, leaving the slot logically
+        // uninitialized until the matching `ptr::write` below.
+        let active_variant = unsafe { std::ptr::read(variant_slot) };
+        // The inner variant's own `RQEIteratorBoxed::suspend` impl walks
+        // its children and produces the suspended form. Per-variant
+        // dispatch ensures dyn-erased `I` correctly transitions its vtable;
+        // a whole-box cast at this outer level alone would skip those walks.
+        let suspended_variant = match active_variant {
+            UnionVariant::FlatFull(it) => RawUnionVariant::FlatFull(*Box::new(it).suspend()),
+            UnionVariant::FlatQuick(it) => RawUnionVariant::FlatQuick(*Box::new(it).suspend()),
+            UnionVariant::HeapFull(it) => RawUnionVariant::HeapFull(*Box::new(it).suspend()),
+            UnionVariant::HeapQuick(it) => RawUnionVariant::HeapQuick(*Box::new(it).suspend()),
+            UnionVariant::Trimmed(it) => RawUnionVariant::Trimmed(*Box::new(it).suspend()),
+        };
+        // SAFETY: `variant_slot` has the same size and alignment as the
+        // suspended variant (both via `#[repr(C, u8)]` over layout-compatible
+        // payloads). Writing reinitialises the slot moved-from above.
+        unsafe {
+            std::ptr::write(
+                variant_slot as *mut RawUnionVariant<'index, Suspended, I::Suspended>,
+                suspended_variant,
+            );
+        }
+        // SAFETY: `RawUnionOpaque` is `#[repr(C)]` over `variant`
+        // (now byte-rewritten as Suspended form via the per-variant
+        // dispatch above), `query_node_type`, and `query_string`.
+        unsafe { Box::from_raw(raw as *mut RawUnionOpaque<'index, Suspended, I::Suspended>) }
+    }
+}
+
+impl<'query, S> RQESuspendedIterator<'query> for RawUnionOpaque<'query, Suspended, S>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = UnionOpaque<'a, S::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let RawUnionOpaque {
+            variant,
+            query_node_type,
+            query_string,
+        } = *self;
+
+        // Per-variant dispatch — `RawUnionVariant` itself doesn't impl
+        // RQESuspendedIterator, so we match here and forward each arm to
+        // the concrete variant's resume, reconstructing the concrete
+        // `UnionVariant`. The wrapper mirrors its single child's outcome: an
+        // aborted child aborts the whole opaque union; otherwise the
+        // `Ok`/`Moved` status is preserved.
+        let (variant, moved) = match variant {
+            RawUnionVariant::FlatFull(it) => match Box::new(it).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (UnionVariant::FlatFull(*active), false),
+                ResumeOutcome::Moved(active) => (UnionVariant::FlatFull(*active), true),
+            },
+            RawUnionVariant::FlatQuick(it) => match Box::new(it).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (UnionVariant::FlatQuick(*active), false),
+                ResumeOutcome::Moved(active) => (UnionVariant::FlatQuick(*active), true),
+            },
+            RawUnionVariant::HeapFull(it) => match Box::new(it).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (UnionVariant::HeapFull(*active), false),
+                ResumeOutcome::Moved(active) => (UnionVariant::HeapFull(*active), true),
+            },
+            RawUnionVariant::HeapQuick(it) => match Box::new(it).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (UnionVariant::HeapQuick(*active), false),
+                ResumeOutcome::Moved(active) => (UnionVariant::HeapQuick(*active), true),
+            },
+            RawUnionVariant::Trimmed(it) => match Box::new(it).resume(guard)? {
+                // In practice this branch is unreachable — trimmed unions
+                // are not subject to GC. `UnionTrimmed::resume` panics if
+                // reached.
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (UnionVariant::Trimmed(*active), false),
+                ResumeOutcome::Moved(active) => (UnionVariant::Trimmed(*active), true),
+            },
+        };
+
+        let active = Box::new(UnionOpaque {
+            variant,
+            query_node_type,
+            // Promote the query-string borrow from the suspended to the active
+            // ref-mode. `query_string` borrows the query AST (not the index),
+            // which outlives the iterator, so this is sound.
+            query_string: query_string.map(|sp| {
+                // SAFETY: `SharedPtr<Rf, CStr>` is `#[repr(transparent)]` over
+                // `NonNull<CStr>`, so the two ref-mode instantiations share a
+                // layout; the pointee (an AST-owned C string) stays valid for
+                // `'a` under the caller's read lock witnessed by `guard`.
+                unsafe {
+                    core::mem::transmute::<SharedPtr<Suspended, CStr>, SharedPtr<Active<'a>, CStr>>(
+                        sp,
+                    )
+                }
+            }),
+        });
+        Ok(if moved {
+            ResumeOutcome::Moved(active)
+        } else {
+            ResumeOutcome::Ok(active)
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        match &self.variant {
+            RawUnionVariant::FlatFull(it) => {
+                <RawUnionFlat<'query, Suspended, S, false> as RQESuspendedIterator<'query>>::last_doc_id(it)
+            }
+            RawUnionVariant::FlatQuick(it) => {
+                <RawUnionFlat<'query, Suspended, S, true> as RQESuspendedIterator<'query>>::last_doc_id(it)
+            }
+            RawUnionVariant::HeapFull(it) => {
+                <RawUnionHeap<'query, Suspended, S, false> as RQESuspendedIterator<'query>>::last_doc_id(it)
+            }
+            RawUnionVariant::HeapQuick(it) => {
+                <RawUnionHeap<'query, Suspended, S, true> as RQESuspendedIterator<'query>>::last_doc_id(it)
+            }
+            RawUnionVariant::Trimmed(it) => {
+                <RawUnionTrimmed<'query, Suspended, S> as RQESuspendedIterator<'query>>::last_doc_id(it)
+            }
+        }
+    }
+
+    fn num_estimated(&self) -> usize {
+        match &self.variant {
+            RawUnionVariant::FlatFull(it) => {
+                <RawUnionFlat<'query, Suspended, S, false> as RQESuspendedIterator<'query>>::num_estimated(it)
+            }
+            RawUnionVariant::FlatQuick(it) => {
+                <RawUnionFlat<'query, Suspended, S, true> as RQESuspendedIterator<'query>>::num_estimated(it)
+            }
+            RawUnionVariant::HeapFull(it) => {
+                <RawUnionHeap<'query, Suspended, S, false> as RQESuspendedIterator<'query>>::num_estimated(it)
+            }
+            RawUnionVariant::HeapQuick(it) => {
+                <RawUnionHeap<'query, Suspended, S, true> as RQESuspendedIterator<'query>>::num_estimated(it)
+            }
+            RawUnionVariant::Trimmed(it) => {
+                <RawUnionTrimmed<'query, Suspended, S> as RQESuspendedIterator<'query>>::num_estimated(it)
+            }
+        }
+    }
 }

--- a/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
@@ -46,10 +46,13 @@
 //! accessible even though they are inactive.
 
 use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
-use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+};
 use index_spec::IndexSpecReadGuard;
 
 /// Union iterator that drains children sequentially in reverse order.
@@ -332,5 +335,65 @@ where
         } else {
             1.0
         }
+    }
+}
+
+impl<'index, I> RQEIteratorBoxed<'index> for UnionTrimmed<'index, I>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawUnionTrimmed<'index, Suspended, I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Walk children — see [`crate::boxed::suspend_child_slot_in_place`].
+        // SAFETY: `raw` came from `Box::into_raw`, exclusively owned and
+        // valid, so the children Vec is reachable and unaliased.
+        let children: &mut Vec<I> = unsafe { &mut (*raw).children };
+        for child in children.iter_mut() {
+            // SAFETY: `child` is a valid `&mut I` aliased to nothing else;
+            // the function leaves the slot in a valid `I::Suspended` state.
+            unsafe { crate::boxed::suspend_child_slot_in_place(child) };
+        }
+        // SAFETY: `RawUnionTrimmed` is `#[repr(C)]` over `Vec<I>` (now
+        // byte-rewritten as `Vec<I::Suspended>` contents) and
+        // `result: RawIndexResult<Rf>` (layout-compatible via `SharedPtr`).
+        unsafe { Box::from_raw(raw as *mut RawUnionTrimmed<'index, Suspended, I::Suspended>) }
+    }
+}
+
+impl<'query, S> RQESuspendedIterator<'query> for RawUnionTrimmed<'query, Suspended, S>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = UnionTrimmed<'a, S::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        _guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Trimmed unions are not subject to GC — they're only constructed
+        // for `Q_OPT_PARTIAL_RANGE` (numeric SORTBY), whose result-processor
+        // pipeline drains every upstream result inside a single locked
+        // `sendChunk` call, so the FFI `Revalidate` path never reaches a
+        // trimmed union. See the parallel `unreachable!` in
+        // `RQEIterator::revalidate` for the full justification.
+        unreachable!(
+            "resume is not supported on UnionTrimmed — trimmed unions are not subject to GC"
+        );
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.num_estimated
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -19,6 +19,7 @@ use ref_mode::{Active, Ref, Suspended};
 
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
+use crate::inverted_index::core::ResumeStatus;
 use crate::{
     Empty, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
     RQEValidateStatus, ResumeOutcome, SEARCH_ENTERPRISE_ITERATORS, SkipToOutcome,
@@ -296,6 +297,96 @@ impl crate::profile_print::ProfilePrint for OptimizedWildcard<'_> {
         match self {
             Self::DocIdsOnly(it) => it.print_profile(map, ctx),
             Self::RawDocIdsOnly(it) => it.print_profile(map, ctx),
+        }
+    }
+}
+
+/// [`Suspended`]-mode counterpart of [`OptimizedWildcard`] used as its
+/// `RQEIteratorBoxed::Suspended` type. Each variant holds the `Suspended`
+/// form of the corresponding inverted-index wildcard reader, retaining the
+/// `'query` lifetime so query-attached borrows stay valid across the
+/// suspend/resume cycle.
+///
+/// `#[repr(C, u8)]` matches [`OptimizedWildcard`]'s layout.
+#[repr(C, u8)]
+pub enum OptimizedWildcardSuspended<'query> {
+    /// Suspended counterpart of [`OptimizedWildcard::DocIdsOnly`].
+    DocIdsOnly(crate::inverted_index::RawWildcard<'query, Suspended, DocIdsOnly>),
+    /// Suspended counterpart of [`OptimizedWildcard::RawDocIdsOnly`].
+    RawDocIdsOnly(crate::inverted_index::RawWildcard<'query, Suspended, RawDocIdsOnly>),
+}
+
+impl<'index> RQEIteratorBoxed<'index> for OptimizedWildcard<'index> {
+    type Suspended = OptimizedWildcardSuspended<'index>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: both enums are `#[repr(C, u8)]`; corresponding variants
+        // hold `RawWildcard<'index, Active<'index>, E>` / `RawWildcard<'index,
+        // Suspended, E>`, which are layout-compatible by the [`RQEIteratorBoxed`]
+        // contract on `inverted_index::Wildcard`. Box::from_raw reuses the
+        // heap allocation.
+        unsafe { Box::from_raw(raw as *mut OptimizedWildcardSuspended<'index>) }
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for OptimizedWildcardSuspended<'query> {
+    type Resumed<'a>
+        = OptimizedWildcard<'a>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        mut self: Box<Self>,
+        spec: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Step 1: per-variant identity check + the shared in-place resume
+        // transition on the inner inverted-index wildcard, still on the
+        // suspended form. Preserves the heap allocation across the cycle so
+        // external borrows into the iterator's interior (FFI wrapper's
+        // `header.current`) stay valid.
+        let status = match &mut *self {
+            OptimizedWildcardSuspended::DocIdsOnly(w) => {
+                if w.should_abort(spec) {
+                    return Ok(ResumeOutcome::Aborted);
+                }
+                w.it.resume_in_place(spec)?
+            }
+            OptimizedWildcardSuspended::RawDocIdsOnly(w) => {
+                if w.should_abort(spec) {
+                    return Ok(ResumeOutcome::Aborted);
+                }
+                w.it.resume_in_place(spec)?
+            }
+        };
+
+        // Step 2: whole-box cast to the active form.
+        let raw = Box::into_raw(self);
+        // SAFETY: layout-compatible — see `suspend`.
+        let active = unsafe { Box::from_raw(raw as *mut OptimizedWildcard<'a>) };
+
+        Ok(match status {
+            ResumeStatus::Unchanged => ResumeOutcome::Ok(active),
+            ResumeStatus::Moved => ResumeOutcome::Moved(active),
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        match self {
+            OptimizedWildcardSuspended::DocIdsOnly(it) => RQESuspendedIterator::last_doc_id(it),
+            OptimizedWildcardSuspended::RawDocIdsOnly(it) => RQESuspendedIterator::last_doc_id(it),
+        }
+    }
+
+    fn num_estimated(&self) -> usize {
+        match self {
+            OptimizedWildcardSuspended::DocIdsOnly(it) => RQESuspendedIterator::num_estimated(it),
+            OptimizedWildcardSuspended::RawDocIdsOnly(it) => {
+                RQESuspendedIterator::num_estimated(it)
+            }
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -836,8 +836,7 @@ impl<'query> RQESuspendedIterator<'query> for DiskWildcardSuspended {
         // `'a`. Box::from_raw reuses the same heap allocation.
         let mut active = unsafe { Box::from_raw(raw as *mut DiskWildcardIterator<'a>) };
         // Drive validity recovery through the inner trait object's
-        // `revalidate` callback — the same path the legacy
-        // `Suspendable::resume` used. Reduce the borrowing `RQEValidateStatus`
+        // `revalidate` callback. Reduce the borrowing `RQEValidateStatus`
         // to a `Copy` status discriminant first so the mutable borrow of
         // `active` ends before we move it into the outcome; propagate a
         // revalidate error (e.g. timeout) rather than masking it.

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -15,13 +15,13 @@ use index_result::{RSIndexResult, RawIndexResult};
 use index_spec::IndexSpecReadGuard;
 use inverted_index::codec::{doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly};
 use inverted_index::{DocIdsDecoder, opaque};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 use crate::{
-    Empty, RQEIterator, RQEIteratorError, RQEValidateStatus, SEARCH_ENTERPRISE_ITERATORS,
-    SkipToOutcome,
+    Empty, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SEARCH_ENTERPRISE_ITERATORS, SkipToOutcome,
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 use crate::{IteratorType, QueryError, RQEIteratorPrintable};
@@ -127,6 +127,49 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
     }
 }
 
+impl<'index> RQEIteratorBoxed<'index> for Wildcard<'index> {
+    type Suspended = RawWildcard<'index, Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawWildcard` is `#[repr(C)]` with the only `Rf`-dependent
+        // field being `result: RawIndexResult<Rf>`, layout-compatible across
+        // `Rf` (see [`crate::inverted_index::Wildcard::suspend`] for the
+        // same argument). Box::from_raw reuses the same heap allocation.
+        unsafe { Box::from_raw(raw as *mut RawWildcard<'index, Suspended>) }
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for RawWildcard<'query, Suspended> {
+    type Resumed<'a>
+        = Wildcard<'a>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        _guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let raw = Box::into_raw(self);
+        // SAFETY: layout-compatible — see `suspend`. The top-level wildcard
+        // owns no references into the index (it's just a counter), so there
+        // is no state to refresh.
+        let active = unsafe { Box::from_raw(raw as *mut Wildcard<'a>) };
+        Ok(ResumeOutcome::Ok(active))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        // Mode-independent — mirrors the active `num_estimated`.
+        self.top_id as usize
+    }
+}
 /// A marker trait for iterators that match all documents.
 pub trait WildcardIterator<'index>: RQEIterator<'index> {}
 
@@ -291,11 +334,25 @@ impl<'index> RQEIterator<'index> for NewWildcardIterator<'index> {
     }
 
     fn num_estimated(&self) -> usize {
-        delegate_wildcard_iterator!(self, num_estimated)
+        // Disambiguated against `RQESuspendedIterator::num_estimated` for the
+        // `Empty` variant (whose Suspended counterpart is `Empty` itself).
+        match self {
+            Self::NotOptimized(it) => RQEIterator::num_estimated(it),
+            Self::Optimized(it) => RQEIterator::num_estimated(it),
+            Self::Empty(it) => RQEIterator::num_estimated(it),
+            Self::Disk(it) => RQEIterator::num_estimated(it),
+        }
     }
 
     fn last_doc_id(&self) -> DocId {
-        delegate_wildcard_iterator!(self, last_doc_id)
+        // Disambiguated against `RQESuspendedIterator::last_doc_id` for the
+        // `Empty` variant (whose Suspended counterpart is `Empty` itself).
+        match self {
+            Self::NotOptimized(it) => RQEIterator::last_doc_id(it),
+            Self::Optimized(it) => RQEIterator::last_doc_id(it),
+            Self::Empty(it) => RQEIterator::last_doc_id(it),
+            Self::Disk(it) => RQEIterator::last_doc_id(it),
+        }
     }
 
     fn at_eof(&self) -> bool {

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -469,6 +469,112 @@ impl<'index> RQEIterator<'index> for NewWildcardIterator<'index> {
 
 impl<'index> WildcardIterator<'index> for NewWildcardIterator<'index> {}
 
+/// [`Suspended`]-mode counterpart of [`NewWildcardIterator`] used as
+/// its `RQEIteratorBoxed::Suspended` type. Each variant holds the
+/// `Suspended` form of the corresponding active variant, retaining the
+/// `'query` lifetime so query-attached borrows stay valid across the
+/// suspend/resume cycle.
+pub enum NewWildcardSuspended<'query> {
+    /// Suspended counterpart of [`NewWildcardIterator::NotOptimized`].
+    NotOptimized(RawWildcard<'query, Suspended>),
+    /// Suspended counterpart of [`NewWildcardIterator::Optimized`].
+    Optimized(OptimizedWildcardSuspended<'query>),
+    /// Suspended counterpart of [`NewWildcardIterator::Empty`].
+    Empty(Empty),
+    /// Suspended counterpart of [`NewWildcardIterator::Disk`].
+    Disk(DiskWildcardSuspended),
+}
+
+impl<'index> RQEIteratorBoxed<'index> for NewWildcardIterator<'index> {
+    type Suspended = NewWildcardSuspended<'index>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        match *self {
+            NewWildcardIterator::NotOptimized(it) => {
+                let suspended = RQEIteratorBoxed::suspend(Box::new(it));
+                Box::new(NewWildcardSuspended::NotOptimized(*suspended))
+            }
+            NewWildcardIterator::Optimized(it) => {
+                let suspended = RQEIteratorBoxed::suspend(Box::new(it));
+                Box::new(NewWildcardSuspended::Optimized(*suspended))
+            }
+            NewWildcardIterator::Empty(it) => {
+                let suspended = RQEIteratorBoxed::suspend(Box::new(it));
+                Box::new(NewWildcardSuspended::Empty(*suspended))
+            }
+            NewWildcardIterator::Disk(it) => {
+                let suspended = RQEIteratorBoxed::suspend(Box::new(it));
+                Box::new(NewWildcardSuspended::Disk(*suspended))
+            }
+        }
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for NewWildcardSuspended<'query> {
+    type Resumed<'a>
+        = NewWildcardIterator<'a>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Forward the inner variant's outcome: an aborted inner aborts the
+        // whole wrapper; otherwise reconstruct the concrete
+        // `NewWildcardIterator` and preserve the `Ok`/`Moved` status.
+        let (variant, moved) = match *self {
+            NewWildcardSuspended::NotOptimized(it) => match Box::new(it).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (NewWildcardIterator::NotOptimized(*active), false),
+                ResumeOutcome::Moved(active) => (NewWildcardIterator::NotOptimized(*active), true),
+            },
+            NewWildcardSuspended::Optimized(it) => match Box::new(it).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (NewWildcardIterator::Optimized(*active), false),
+                ResumeOutcome::Moved(active) => (NewWildcardIterator::Optimized(*active), true),
+            },
+            NewWildcardSuspended::Empty(it) => match Box::new(it).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (NewWildcardIterator::Empty(*active), false),
+                ResumeOutcome::Moved(active) => (NewWildcardIterator::Empty(*active), true),
+            },
+            NewWildcardSuspended::Disk(it) => match Box::new(it).resume(guard)? {
+                ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+                ResumeOutcome::Ok(active) => (NewWildcardIterator::Disk(*active), false),
+                ResumeOutcome::Moved(active) => (NewWildcardIterator::Disk(*active), true),
+            },
+        };
+        let active = Box::new(variant);
+        Ok(if moved {
+            ResumeOutcome::Moved(active)
+        } else {
+            ResumeOutcome::Ok(active)
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        match self {
+            NewWildcardSuspended::NotOptimized(it) => RQESuspendedIterator::last_doc_id(it),
+            NewWildcardSuspended::Optimized(it) => RQESuspendedIterator::last_doc_id(it),
+            NewWildcardSuspended::Empty(it) => RQESuspendedIterator::last_doc_id(it),
+            NewWildcardSuspended::Disk(it) => RQESuspendedIterator::last_doc_id(it),
+        }
+    }
+
+    fn num_estimated(&self) -> usize {
+        match self {
+            NewWildcardSuspended::NotOptimized(it) => RQESuspendedIterator::num_estimated(it),
+            NewWildcardSuspended::Optimized(it) => RQESuspendedIterator::num_estimated(it),
+            NewWildcardSuspended::Empty(it) => RQESuspendedIterator::num_estimated(it),
+            NewWildcardSuspended::Disk(it) => RQESuspendedIterator::num_estimated(it),
+        }
+    }
+}
+
 /// Create a [`WildcardIterator`] for an index whose spec has
 /// [`SchemaRule`](ffi::SchemaRule)`.index_all` set.
 ///

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -679,3 +679,88 @@ impl ProfilePrint for NewWildcardIterator<'_> {
         }
     }
 }
+
+/// `'static`-typed counterpart of [`DiskWildcardIterator`] used as its
+/// `RQEIteratorBoxed::Suspended` type.
+///
+/// Wraps a `Box<dyn RQEIterator<'static> + 'static>` — the `'static`
+/// here is a **lifetime lie**: the actual borrowed lifetime is `'index`,
+/// inherited from the original [`DiskWildcardIterator`]. The lie is
+/// closed by the FFI-side discipline: while a `DiskWildcardSuspended`
+/// exists, no code dereferences the inner iterator. On [`resume`](RQESuspendedIterator::resume) the
+/// lifetime contracts back to the guard's lifetime `'a` (which the
+/// caller proves is still valid for the underlying index).
+#[repr(transparent)]
+pub struct DiskWildcardSuspended(pub(crate) Box<dyn RQEIterator<'static> + 'static>);
+
+impl<'index> RQEIteratorBoxed<'index> for DiskWildcardIterator<'index> {
+    type Suspended = DiskWildcardSuspended;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `DiskWildcardIterator<'index>` is `#[repr(transparent)]`
+        // over `Box<dyn RQEIterator<'index> + 'index>`, and
+        // `DiskWildcardSuspended` is `#[repr(transparent)]` over
+        // `Box<dyn RQEIterator<'static> + 'static>`. The two are byte-
+        // identical (a `Box` of a trait object is two pointers regardless
+        // of lifetime). Lifetime-extending the inner trait object from
+        // `'index` to `'static` is a lie that is closed at resume time;
+        // the suspended value is opaque (no read/skip path).
+        unsafe { Box::from_raw(raw as *mut DiskWildcardSuspended) }
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for DiskWildcardSuspended {
+    type Resumed<'a>
+        = DiskWildcardIterator<'a>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        spec: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let raw = Box::into_raw(self);
+        // SAFETY: contract the lifetime back from the suspended `'static`
+        // to the caller-provided `'a`. The caller's read lock on `spec`
+        // witnesses that the underlying index data is dereferenceable at
+        // `'a`. Box::from_raw reuses the same heap allocation.
+        let mut active = unsafe { Box::from_raw(raw as *mut DiskWildcardIterator<'a>) };
+        // Drive validity recovery through the inner trait object's
+        // `revalidate` callback — the same path the legacy
+        // `Suspendable::resume` used. Reduce the borrowing `RQEValidateStatus`
+        // to a `Copy` status discriminant first so the mutable borrow of
+        // `active` ends before we move it into the outcome; propagate a
+        // revalidate error (e.g. timeout) rather than masking it.
+        let status = match active.revalidate(spec)? {
+            RQEValidateStatus::Ok => ffi::ValidateStatus_VALIDATE_OK,
+            RQEValidateStatus::Moved { .. } => ffi::ValidateStatus_VALIDATE_MOVED,
+            RQEValidateStatus::Aborted => ffi::ValidateStatus_VALIDATE_ABORTED,
+        };
+        Ok(match status {
+            ffi::ValidateStatus_VALIDATE_OK => ResumeOutcome::Ok(active),
+            ffi::ValidateStatus_VALIDATE_MOVED => ResumeOutcome::Moved(active),
+            // `Aborted`: `active` is not moved into the outcome, so the inner
+            // trait object drops here.
+            _ => ResumeOutcome::Aborted,
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        // SAFETY: `last_doc_id` reads a cached primitive — it does not
+        // dereference any borrowed index pointer. Forwarding to the inner
+        // dyn's `RQEIterator::last_doc_id` is therefore sound despite the
+        // `'static` lifetime lie.
+        RQEIterator::last_doc_id(&*self.0)
+    }
+
+    fn num_estimated(&self) -> usize {
+        // `num_estimated` reads a cached count — it does not dereference any
+        // borrowed index pointer, so forwarding to the inner dyn is sound
+        // despite the `'static` lifetime lie.
+        RQEIterator::num_estimated(&*self.0)
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -556,9 +556,9 @@ fn many_children() {
 fn revalidate_ok() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     // Create mock children with const generic arrays
-    let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
-    let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
-    let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+    let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+    let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
 
     // Set all children to return OK on revalidate (default, but explicit)
     child0
@@ -599,9 +599,9 @@ fn revalidate_ok() {
 #[test]
 fn revalidate_aborted() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
-    let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
-    let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+    let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+    let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
 
     // Child 1 will abort
     child0
@@ -634,9 +634,9 @@ fn revalidate_aborted() {
 #[test]
 fn revalidate_moved() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
-    let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
-    let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+    let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+    let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
 
     // All children will move (advance by one document)
     child0
@@ -680,9 +680,9 @@ fn revalidate_moved() {
 #[test]
 fn revalidate_mixed_results() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
-    let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
-    let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+    let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+    let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
 
     // Mixed: OK, MOVED, OK
     child0
@@ -717,9 +717,9 @@ fn revalidate_mixed_results() {
 fn revalidate_after_eof() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     // Pre-set children to return MOVE on revalidate
-    let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
-    let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
-    let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+    let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+    let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
 
     child0
         .data()
@@ -766,10 +766,10 @@ fn revalidate_some_children_moved_to_eof() {
     // Child 0 and 2 have normal data, child 1 is small (only 2 elements: [10, 20])
     // When we read doc 10 and then call Move, child 1 moves to 20 and the next Move
     // would go to EOF
-    let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     // Child 1 has only doc 10 - after reading it, Move will result in EOF
-    let child1: Mock<'static, 1> = Mock::new([10]);
-    let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+    let child1: Mock<'_, 1> = Mock::new([10]);
+    let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
 
     // Child 0: OK, Child 1: moves (to EOF since only 1 element), Child 2: OK
     child0
@@ -932,9 +932,9 @@ fn overlapping_children_ids() {
 #[test]
 fn revalidate_before_read() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
-    let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
-    let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+    let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+    let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
 
     // All children return OK on revalidate
     child0
@@ -970,9 +970,9 @@ fn revalidate_before_read() {
 #[test]
 fn revalidate_move_before_read() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
-    let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
-    let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+    let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+    let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
 
     // All children will move
     child0
@@ -1105,9 +1105,9 @@ fn revalidate_moved_skip_to_returns_none() {
     // - child0 has no doc >= 18, so it goes EOF
     // - Result: None
 
-    let child0: Mock<'static, 2> = Mock::new([10, 15]);
-    let child1: Mock<'static, 2> = Mock::new([10, 18]);
-    let child2: Mock<'static, 2> = Mock::new([10, 22]);
+    let child0: Mock<'_, 2> = Mock::new([10, 15]);
+    let child1: Mock<'_, 2> = Mock::new([10, 18]);
+    let child2: Mock<'_, 2> = Mock::new([10, 22]);
 
     // All children will move
     child0
@@ -1154,6 +1154,293 @@ fn revalidate_moved_skip_to_returns_none() {
     assert!(matches!(ii.read(), Ok(None)));
 }
 
+mod via_resume {
+    use super::*;
+    use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator};
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    fn boxed_children<'spec, const N0: usize, const N1: usize, const N2: usize>(
+        c0: Mock<'spec, N0>,
+        c1: Mock<'spec, N1>,
+        c2: Mock<'spec, N2>,
+    ) -> Vec<TypeErasedRQEIterator<'spec>> {
+        vec![
+            TypeErasedRQEIterator::new(Box::new(c0)),
+            TypeErasedRQEIterator::new(Box::new(c1)),
+            TypeErasedRQEIterator::new(Box::new(c2)),
+        ]
+    }
+
+    #[test]
+    fn revalidate_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+        let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+        let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = boxed_children(child0, child1, child2);
+        let mut ii = Intersection::new(children, 1.0, false);
+
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 10);
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 20);
+
+        let guard = mock_ctx.spec_read();
+        let mut ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 30);
+    }
+
+    #[test]
+    fn revalidate_aborted() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+        let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+        let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = boxed_children(child0, child1, child2);
+        let mut ii = Intersection::new(children, 1.0, false);
+
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed");
+        assert!(matches!(outcome, ResumeOutcome::Aborted));
+    }
+
+    #[test]
+    fn revalidate_moved() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+        let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+        let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = boxed_children(child0, child1, child2);
+        let mut ii = Intersection::new(children, 1.0, false);
+
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert_eq!(ii.last_doc_id(), 20);
+    }
+
+    #[test]
+    fn revalidate_mixed_results() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+        let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+        let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = boxed_children(child0, child1, child2);
+        let mut ii = Intersection::new(children, 1.0, false);
+
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert_eq!(ii.last_doc_id(), 20);
+    }
+
+    #[test]
+    fn revalidate_after_eof() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+        let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+        let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = boxed_children(child0, child1, child2);
+        let mut ii = Intersection::new(children, 1.0, false);
+
+        while ii.read().expect("read").is_some() {}
+        assert!(ii.at_eof());
+
+        let guard = mock_ctx.spec_read();
+        let mut ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+        assert!(ii.at_eof());
+        assert!(matches!(ii.read(), Ok(None)));
+    }
+
+    #[test]
+    fn revalidate_some_children_moved_to_eof() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+        let child1: Mock<'_, 1> = Mock::new([10]);
+        let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = boxed_children(child0, child1, child2);
+        let mut ii = Intersection::new(children, 1.0, false);
+
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert!(ii.at_eof());
+        assert!(matches!(ii.read(), Ok(None)));
+    }
+
+    #[test]
+    fn revalidate_before_read() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+        let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+        let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = boxed_children(child0, child1, child2);
+        let ii = Intersection::new(children, 1.0, false);
+
+        let guard = mock_ctx.spec_read();
+        let mut ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 10);
+    }
+
+    #[test]
+    fn revalidate_move_before_read() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+        let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+        let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = boxed_children(child0, child1, child2);
+        let ii = Intersection::new(children, 1.0, false);
+
+        let guard = mock_ctx.spec_read();
+        let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed");
+        assert!(
+            matches!(outcome, ResumeOutcome::Ok(_) | ResumeOutcome::Moved(_)),
+            "Revalidate before read with Move should return OK or MOVED"
+        );
+    }
+
+    #[test]
+    fn revalidate_moved_skip_to_returns_none() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 2> = Mock::new([10, 15]);
+        let child1: Mock<'_, 2> = Mock::new([10, 18]);
+        let child2: Mock<'_, 2> = Mock::new([10, 22]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = boxed_children(child0, child1, child2);
+        let mut ii = Intersection::new(children, 1.0, false);
+
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 10);
+        assert!(!ii.at_eof());
+
+        let guard = mock_ctx.spec_read();
+        let mut ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert!(
+            ii.at_eof(),
+            "Intersection should be at EOF after no consensus"
+        );
+        assert!(matches!(ii.read(), Ok(None)));
+    }
+}
+
 // =============================================================================
 // Slop and InOrder tests
 // (Slop, InOrder, SlopAndOrder test cases)
@@ -1179,8 +1466,8 @@ mod slop_and_order {
         max_slop: Option<u32>,
         in_order: bool,
     ) -> Intersection<'static, Box<dyn RQEIterator<'static> + 'static>> {
-        let foo: Mock<'static, 4> = Mock::new_with_positions([1, 2, 3, 4], [1, 1, 2, 1]);
-        let bar: Mock<'static, 3> = Mock::new_with_positions([1, 3, 4], [2, 1, 3]);
+        let foo: Mock<'_, 4> = Mock::new_with_positions([1, 2, 3, 4], [1, 1, 2, 1]);
+        let bar: Mock<'_, 3> = Mock::new_with_positions([1, 3, 4], [2, 1, 3]);
         Intersection::new_with_slop_order(
             vec![Box::new(foo), Box::new(bar)],
             1.0,
@@ -1346,8 +1633,8 @@ mod slop_and_order {
     ///   bar@1 comes before foo@3; foo then tries doc 2, but bar has no doc ≥ 2 → EOF.
     #[test]
     fn relevancy_retry_hits_eof_in_second_consensus() {
-        let foo: Mock<'static, 2> = Mock::new_with_positions([1, 2], [3, 1]);
-        let bar: Mock<'static, 1> = Mock::new_with_positions([1], [1]);
+        let foo: Mock<'_, 2> = Mock::new_with_positions([1, 2], [3, 1]);
+        let bar: Mock<'_, 1> = Mock::new_with_positions([1], [1]);
         let mut ii = Intersection::new_with_slop_order(
             vec![
                 Box::new(foo) as Box<dyn RQEIterator<'static> + 'static>,

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -415,6 +415,38 @@ fn numeric_no_range_tree_revalidate() {
     assert_eq!(status, RQEValidateStatus::Ok);
 }
 
+/// Resume sibling of [`numeric_no_range_tree_revalidate`]: with no range tree,
+/// `should_abort` returns false, so a suspend/resume cycle promotes the iterator
+/// back to `Active` (`Ok`) and the position is preserved.
+#[test]
+fn numeric_no_range_tree_resume() {
+    use rqe_iterators::TypeErasedRQEIterator;
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let mut ii =
+        InvertedIndex::<inverted_index::numeric::Numeric>::new(IndexFlags_Index_StoreNumeric);
+    let _ = ii.add_record(&RSIndexResult::build_numeric(1.0).doc_id(1).build());
+    let _ = ii.add_record(&RSIndexResult::build_numeric(2.0).doc_id(3).build());
+
+    // Build without a range tree — should_abort will return false.
+    let it = NumericBuilder::new(ii.reader()).build();
+
+    let guard = mock_ctx.spec_read();
+    let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+        .expect("resume should not fail in this test")
+        .expect_ok();
+
+    // The first doc is still available after resume (no range tree ⇒ no abort).
+    let record = it.read().expect("read failed").expect("expected a result");
+    assert_eq!(record.doc_id, 1);
+
+    // A second resume also succeeds.
+    revalidate_via_resume(it, &guard)
+        .expect("resume should not fail in this test")
+        .expect_ok();
+}
+
 /// A [`GeoFilter`] with a non-null address so `is_numeric_filter()` returns `false`.
 /// `fieldSpec` and `numericFilters` are null — tests using this stub must not
 /// reach code paths that dereference those pointers.
@@ -1101,5 +1133,69 @@ mod not_miri {
 
         test.test
             .revalidate_numeric_after_document_deleted(&mut it, ii);
+    }
+
+    /// Resume-flavored siblings of the `revalidate` tests above: the same
+    /// scenarios driven through a suspend/resume cycle
+    /// ([`revalidate_via_resume`]) rather than in-place [`RQEIterator::revalidate`].
+    mod via_resume {
+        use super::*;
+        use crate::inverted_index::utils::via_resume::{
+            revalidate_at_eof, revalidate_basic, revalidate_numeric_after_document_deleted,
+        };
+        use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator};
+        use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+        #[test]
+        fn numeric_revalidate_basic() {
+            let test = NumericRevalidateTest::new(10);
+            let it = test.create_iterator();
+            revalidate_basic(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn numeric_revalidate_at_eof() {
+            let test = NumericRevalidateTest::new(10);
+            let it = test.create_iterator();
+            revalidate_at_eof(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn numeric_revalidate_after_document_deleted() {
+            let test = NumericRevalidateTest::new(10);
+            let it = test.create_iterator();
+            let ii = test.test.context.numeric_inverted_index();
+            revalidate_numeric_after_document_deleted(&test.test, Box::new(it), ii);
+        }
+
+        /// Resume sibling of [`numeric_revalidate_after_index_disappears`]: a
+        /// range-tree revision bump while suspended (simulating a GC node
+        /// split/removal) must abort the resume, since the cached revision id no
+        /// longer matches.
+        #[test]
+        fn numeric_revalidate_after_range_tree_modified() {
+            let test = NumericRevalidateTest::new(10);
+            let it = Box::new(test.create_iterator());
+            let guard = test.test.context.spec_read();
+
+            // A clean resume cycle works before any modification; read one doc so
+            // the iterator holds a non-trivial position.
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+                .expect("resume should not fail in this test")
+                .expect_ok();
+            assert!(it.read().expect("failed to read").is_some());
+
+            // Bump the range tree's revision id (interior mutability via raw
+            // pointer, so it does not conflict with the read guard).
+            {
+                let rt = test.test.context.numeric_range_tree_mut();
+                rt.increment_revision();
+            }
+
+            // The cached revision no longer matches, so resume must abort.
+            let outcome =
+                revalidate_via_resume(it, &guard).expect("resume should not fail in this test");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+        }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -9,12 +9,61 @@
 
 use rqe_core::DocId;
 use rqe_iterators::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome, TypeErasedRQEIterator,
     maybe_empty::MaybeEmpty,
 };
 
 #[derive(Default)]
+#[repr(C)]
 struct Infinite<'index>(index_result::RSIndexResult<'index>);
+
+/// Suspended counterpart of [`Infinite`]. The mock holds only owned data
+/// (no live index borrows), so the suspended form is byte-identical to the
+/// active form at any lifetime.
+#[repr(C)]
+struct InfiniteSuspended(index_result::RSIndexResult<'static>);
+
+impl<'index> RQEIteratorBoxed<'index> for Infinite<'index> {
+    type Suspended = InfiniteSuspended;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `Infinite<'index>` and `InfiniteSuspended` are both
+        // `#[repr(C)]` over `RSIndexResult`; the mock holds no live index
+        // borrows, so the lifetime parameter is phantom and the layouts
+        // are byte-identical. Box::from_raw reuses the same heap.
+        unsafe { Box::from_raw(raw as *mut InfiniteSuspended) }
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for InfiniteSuspended {
+    type Resumed<'a>
+        = Infinite<'a>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        _guard: &index_spec::IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let raw = Box::into_raw(self);
+        // SAFETY: layout-identical — see [`Infinite::suspend`].
+        let active = unsafe { Box::from_raw(raw as *mut Infinite<'a>) };
+        Ok(ResumeOutcome::Ok(active))
+    }
+
+    fn last_doc_id(&self) -> ffi::t_docId {
+        self.0.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        usize::MAX
+    }
+}
 
 impl<'index> RQEIterator<'index> for Infinite<'index> {
     fn current(&mut self) -> Option<&mut index_result::RSIndexResult<'index>> {
@@ -244,4 +293,31 @@ fn take_iterator_from_empty_returns_none() {
     // Still behaves as empty
     assert!(it.at_eof());
     assert!(matches!(it.read(), Ok(None)));
+}
+
+mod via_resume {
+    use super::*;
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    #[test]
+    fn revalidate_empty() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let it = Box::new(MaybeEmpty::<Infinite>::new_empty());
+        // Resuming an empty wrapper stays at the same (empty) position.
+        revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+            .expect("resume failed")
+            .expect_ok();
+    }
+
+    #[test]
+    fn revalidate_not_empty() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let it = Box::new(MaybeEmpty::new(Infinite::default()));
+        // The mock child resumes as `Ok`, so the wrapper does too.
+        revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+            .expect("resume failed")
+            .expect_ok();
+    }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -595,3 +595,124 @@ fn skip_to_timeout_via_timeout_ctx() {
     // that said... internal timeout context is _not_ reset,
     // so it is bound to timeout once you make the required amount of read/skip_to calls...
 }
+
+mod via_resume {
+    use super::*;
+    use rqe_iterators::TypeErasedRQEIterator;
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    #[test]
+    fn revalidate_child_ok_preserves_exclusions() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child = Mock::new([2, 4]);
+        let it = Not::new(child, 5, 1.0, NoTimeout);
+
+        let guard = mock_ctx.spec_read();
+        let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let mut seen = Vec::new();
+        while let Some(doc) = it.read().unwrap() {
+            seen.push(doc.doc_id);
+        }
+        assert_eq!(seen, vec![1, 3, 5]);
+    }
+
+    #[test]
+    fn revalidate_child_aborted_replaces_child_with_empty() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child = Mock::new([2, 4]);
+        let mut data = child.data();
+        data.set_revalidate_result(MockRevalidateResult::Abort);
+        let it = Not::new(child, 5, 1.0, NoTimeout);
+
+        let guard = mock_ctx.spec_read();
+        let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let mut seen = Vec::new();
+        while let Some(doc) = it.read().unwrap() {
+            seen.push(doc.doc_id);
+        }
+        assert_eq!(seen, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn revalidate_child_moved_on_fresh_iterator() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child = Mock::new([2, 4]);
+        let mut data = child.data();
+        data.set_revalidate_result(MockRevalidateResult::Move);
+        let it = Not::new(child, 5, 1.0, NoTimeout);
+
+        let guard = mock_ctx.spec_read();
+        let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let mut seen = Vec::new();
+        while let Some(doc) = it.read().unwrap() {
+            seen.push(doc.doc_id);
+        }
+        assert_eq!(seen, vec![1, 3, 5]);
+    }
+
+    #[test]
+    fn revalidate_child_moved_after_read_with_child_ahead() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child = Mock::new([5, 10]);
+        let mut data = child.data();
+        let mut it = Not::new(child, 15, 1.0, NoTimeout);
+
+        let doc = it.read().expect("read() failed").expect("expected doc");
+        assert_eq!(doc.doc_id, 1);
+        assert_eq!(it.last_doc_id(), 1);
+
+        data.set_revalidate_result(MockRevalidateResult::Move);
+        let guard = mock_ctx.spec_read();
+        let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let mut seen = vec![1];
+        while let Some(doc) = it.read().unwrap() {
+            seen.push(doc.doc_id);
+        }
+        assert_eq!(seen, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15]);
+    }
+
+    #[test]
+    fn revalidate_child_moved_after_skip_to_with_child_ahead() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child = Mock::new([8, 15]);
+        let mut data = child.data();
+        let mut it = Not::new(child, 20, 1.0, NoTimeout);
+
+        let outcome = it
+            .skip_to(3)
+            .expect("skip_to() failed")
+            .expect("expected outcome");
+        match outcome {
+            SkipToOutcome::Found(doc) => assert_eq!(doc.doc_id, 3),
+            _ => panic!("Expected Found outcome"),
+        }
+        assert_eq!(it.last_doc_id(), 3);
+
+        data.set_revalidate_result(MockRevalidateResult::Move);
+        let guard = mock_ctx.spec_read();
+        let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let mut seen = vec![3];
+        while let Some(doc) = it.read().unwrap() {
+            seen.push(doc.doc_id);
+        }
+        assert_eq!(
+            seen,
+            vec![3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18, 19, 20]
+        );
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -797,4 +797,196 @@ mod revalidate {
         );
         assert!(it.at_eof());
     }
+
+    mod via_resume {
+        use super::*;
+        use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator};
+        use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+        #[test]
+        fn revalidate_child_ok_wc_ok() {
+            let (_guard, context) = make_revalidate_context();
+            let (mut it, mut child_data) = create_not_optimized(&context);
+            child_data.set_revalidate_result(MockRevalidateResult::Ok);
+
+            it.read().unwrap().unwrap();
+            it.read().unwrap().unwrap();
+            let original = it.last_doc_id();
+
+            let guard = context.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_ok();
+            assert_eq!(child_data.revalidate_count(), 1);
+            assert_eq!(it.last_doc_id(), original);
+            it.read().unwrap().unwrap();
+        }
+
+        #[test]
+        fn revalidate_child_aborted_wc_ok() {
+            let (_guard, context) = make_revalidate_context();
+            let (mut it, mut child_data) = create_not_optimized(&context);
+            child_data.set_revalidate_result(MockRevalidateResult::Abort);
+
+            it.read().unwrap().unwrap();
+            let original = it.last_doc_id();
+
+            let guard = context.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_ok();
+            assert_eq!(it.last_doc_id(), original);
+            it.read().unwrap().unwrap();
+        }
+
+        #[test]
+        fn revalidate_child_moved_wc_ok() {
+            let (_guard, context) = make_revalidate_context();
+            let (mut it, mut child_data) = create_not_optimized(&context);
+            child_data.set_revalidate_result(MockRevalidateResult::Move);
+
+            it.read().unwrap().unwrap();
+            let original = it.last_doc_id();
+
+            let guard = context.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_ok();
+            assert_eq!(child_data.revalidate_count(), 1);
+            assert_eq!(it.last_doc_id(), original);
+            it.read().unwrap().unwrap();
+        }
+
+        #[test]
+        fn revalidate_wc_aborted() {
+            let (_guard, context) = make_revalidate_context();
+            let (mut it, _child_data) = create_not_optimized(&context);
+
+            it.read().unwrap().unwrap();
+
+            let new_ii =
+                Box::into_raw(Box::new(inverted_index::opaque::InvertedIndex::DocIdsOnly(
+                    InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
+                )));
+            let old_existing_docs = context.spec_read().existing_docs_ptr();
+            context.spec_write().set_existing_docs_ptr(new_ii.cast());
+
+            let guard = context.spec_read();
+            let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+
+            context
+                .spec_write()
+                .set_existing_docs_ptr(old_existing_docs);
+            // SAFETY: Dropping Box from raw pointer.
+            unsafe {
+                drop(Box::from_raw(new_ii));
+            }
+        }
+
+        #[test]
+        fn revalidate_child_ok_wc_moved() {
+            let (_guard, context) = make_revalidate_context();
+            let (mut it, mut child_data) = create_not_optimized(&context);
+            child_data.set_revalidate_result(MockRevalidateResult::Ok);
+
+            it.read().unwrap().unwrap();
+            let original = it.last_doc_id();
+            assert_eq!(original, 1);
+
+            gc_document(&context, 1);
+
+            let guard = context.spec_read();
+            let it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            assert!(it.last_doc_id() > original);
+        }
+
+        #[test]
+        fn revalidate_child_aborted_wc_moved() {
+            let (_guard, context) = make_revalidate_context();
+            let (mut it, mut child_data) = create_not_optimized(&context);
+            child_data.set_revalidate_result(MockRevalidateResult::Abort);
+
+            it.read().unwrap().unwrap();
+            let original = it.last_doc_id();
+            assert_eq!(original, 1);
+
+            gc_document(&context, 1);
+
+            let guard = context.spec_read();
+            let it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            assert!(it.last_doc_id() > original);
+        }
+
+        #[test]
+        fn revalidate_child_moved_wc_moved() {
+            let (_guard, context) = make_revalidate_context();
+            let (mut it, mut child_data) = create_not_optimized(&context);
+            child_data.set_revalidate_result(MockRevalidateResult::Move);
+
+            it.read().unwrap().unwrap();
+            let original = it.last_doc_id();
+            assert_eq!(original, 1);
+
+            gc_document(&context, 1);
+
+            let guard = context.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            assert!(it.last_doc_id() > original);
+            it.read().unwrap().unwrap();
+        }
+
+        #[test]
+        fn revalidate_wc_moves_to_same_id_as_child() {
+            let (_guard, context) = make_revalidate_context();
+            let (mut it, mut child_data) = create_not_optimized(&context);
+            child_data.set_revalidate_result(MockRevalidateResult::Ok);
+
+            it.read().unwrap().unwrap();
+            it.read().unwrap().unwrap();
+            assert_eq!(it.last_doc_id(), 5);
+
+            gc_document(&context, 5);
+
+            let guard = context.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            assert!(!it.at_eof());
+            assert_eq!(it.last_doc_id(), 15);
+            it.read().unwrap().unwrap();
+        }
+
+        #[test]
+        fn revalidate_wc_moved_to_eof() {
+            let (_guard, context) = (
+                GlobalGuard::default(),
+                TestContext::wildcard([1].iter().copied()),
+            );
+            let ii = DocIdsOnly::from_opaque(context.wildcard_inverted_index());
+            let wcii = rqe_iterators::inverted_index::Wildcard::new(ii.reader(), 1.0);
+            let child = Mock::<1>::new([100]);
+            let mut child_data = child.data();
+            child_data.set_revalidate_result(MockRevalidateResult::Ok);
+            let mut it = NotOptimized::new(wcii, child, 200, 1.0, NoTimeout);
+
+            let doc = it.read().unwrap().unwrap();
+            assert_eq!(doc.doc_id, 1);
+
+            gc_document(&context, 1);
+
+            let guard = context.spec_read();
+            let it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            assert!(it.at_eof());
+        }
+    }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -12,9 +12,10 @@ use index_result::{RSIndexResult, RSResultKind};
 use inverted_index::{InvertedIndex, doc_ids_only::DocIdsOnly};
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 use rqe_iterators::{
-    RQEIterator, RQEValidateStatus, SkipToOutcome, empty::Empty, inverted_index::Wildcard,
-    optional_optimized::OptionalOptimized,
+    RQEIterator, RQEValidateStatus, ResumeOutcome, SkipToOutcome, TypeErasedRQEIterator,
+    empty::Empty, inverted_index::Wildcard, optional_optimized::OptionalOptimized,
 };
+use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
 
 use crate::utils;
 
@@ -938,5 +939,309 @@ mod optional_optimized_iterator_revalidate_tests {
         // Can still read after revalidation.
         let r = it.read().expect("read after revalidate").expect("result");
         assert!(r.doc_id > 20);
+    }
+
+    mod via_resume {
+        use super::*;
+
+        #[cfg(not(miri))]
+        mod with_inverted_wildcard {
+            use super::*;
+            use inverted_index::opaque::OpaqueEncoding;
+            use rqe_iterators::inverted_index::Wildcard;
+            use rqe_iterators_test_utils::{GlobalGuard, TestContext};
+
+            fn setup<'index>(
+                test_ctx: &'index TestContext,
+            ) -> (
+                OptionalOptimized<
+                    'index,
+                    Wildcard<'index, DocIdsOnly>,
+                    utils::Mock<'index, NUM_DOCS>,
+                >,
+                utils::MockData,
+            ) {
+                let ii = DocIdsOnly::from_opaque(test_ctx.wildcard_inverted_index());
+                let wcii = Wildcard::new(ii.reader(), 0.);
+                let child = utils::Mock::new(CHILD_DOCS);
+                let data = child.data();
+                let it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+                (it, data)
+            }
+
+            #[test]
+            fn test_revalidate_ok() {
+                let _guard = GlobalGuard::default();
+                let test_ctx = TestContext::wildcard(1..=MAX_DOC_ID);
+                let (mut it, mut data) = setup(&test_ctx);
+
+                data.set_revalidate_result(utils::MockRevalidateResult::Ok);
+
+                let _ = it.read().expect("read").expect("result");
+                let _ = it.read().expect("read").expect("result");
+
+                let guard = test_ctx.spec_read();
+                let mut it =
+                    revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                        .expect("resume failed")
+                        .expect_ok();
+                assert_eq!(data.revalidate_count(), 1);
+
+                let _ = it.read().expect("read after revalidate").expect("result");
+            }
+
+            #[test]
+            fn test_revalidate_child_aborted() {
+                let _guard = GlobalGuard::default();
+                let test_ctx = TestContext::wildcard(1..=MAX_DOC_ID);
+                let (mut it, mut data) = setup(&test_ctx);
+
+                data.set_revalidate_result(utils::MockRevalidateResult::Abort);
+
+                let r = it.read().expect("read").expect("result");
+                assert_eq!(r.doc_id, 1);
+
+                let guard = test_ctx.spec_read();
+                // Child aborted while on a virtual result → Ok (no state change needed).
+                let mut it =
+                    revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                        .expect("resume failed")
+                        .expect_ok();
+                // The resumed iterator is type-erased and no longer exposes the
+                // concrete `child()` accessor; the virtual read below (weight 0)
+                // confirms the child was dropped and we fell back to virtual.
+                assert_eq!(data.revalidate_count(), 1);
+
+                let r = it.read().expect("read").expect("result");
+                assert_eq!(r.weight, 0.);
+            }
+
+            #[test]
+            fn test_revalidate_child_moved_on_real() {
+                let _guard = GlobalGuard::default();
+                let test_ctx = TestContext::wildcard(1..=MAX_DOC_ID);
+                let (mut it, mut data) = setup(&test_ctx);
+
+                match it.skip_to(10).expect("no error") {
+                    Some(SkipToOutcome::Found(r)) => assert_eq!(r.doc_id, 10),
+                    other => panic!("unexpected: {other:?}"),
+                }
+
+                data.set_revalidate_result(utils::MockRevalidateResult::Move);
+                let guard = test_ctx.spec_read();
+                revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                    .expect("resume failed")
+                    .expect_moved();
+                assert_eq!(data.revalidate_count(), 1);
+            }
+
+            #[test]
+            fn test_revalidate_child_moved_on_virtual() {
+                let _guard = GlobalGuard::default();
+                let test_ctx = TestContext::wildcard(1..=MAX_DOC_ID);
+                let (mut it, mut data) = setup(&test_ctx);
+
+                match it.skip_to(15).expect("no error") {
+                    Some(SkipToOutcome::Found(r)) => assert_eq!(r.doc_id, 15),
+                    other => panic!("unexpected: {other:?}"),
+                }
+
+                data.set_revalidate_result(utils::MockRevalidateResult::Move);
+                let guard = test_ctx.spec_read();
+                // Child moved while on a virtual result → Ok
+                revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                    .expect("resume failed")
+                    .expect_ok();
+                assert_eq!(data.revalidate_count(), 1);
+            }
+        }
+
+        #[test]
+        fn test_revalidate_wcii_aborted() {
+            const WCII_DOCS: usize = 10;
+            let wcii_docs: [DocId; WCII_DOCS] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+            let wcii = utils::Mock::new(wcii_docs);
+            let mut wcii_data = wcii.data();
+            let child = utils::Mock::new(CHILD_DOCS);
+            let mut it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+
+            let _ = it.read().expect("read").expect("result");
+
+            wcii_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let guard = mock_ctx.spec_read();
+            let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+        }
+
+        #[test]
+        fn test_revalidate_wcii_moved_real_hit() {
+            let wcii = utils::Mock::new([5u64, 20]);
+            let mut wcii_data = wcii.data();
+            let child = utils::Mock::new([5u64, 20]);
+            let mut it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+
+            let r = it.read().expect("read").expect("result");
+            assert_eq!(r.doc_id, 5);
+
+            wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let guard = mock_ctx.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            let r = it.current().expect("current");
+            assert_eq!(r.doc_id, 20);
+            assert_eq!(r.weight, WEIGHT);
+            assert_eq!(it.last_doc_id(), 20);
+        }
+
+        #[test]
+        fn test_revalidate_wcii_moved_virtual_hit() {
+            let wcii = utils::Mock::new([5u64, 20]);
+            let mut wcii_data = wcii.data();
+            let child = utils::Mock::new([5u64, 25]);
+            let mut it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+
+            let r = it.read().expect("read").expect("result");
+            assert_eq!(r.doc_id, 5);
+
+            wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let guard = mock_ctx.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            let r = it.current().expect("current");
+            assert_eq!(r.doc_id, 20);
+            assert_eq!(r.weight, 0.);
+            assert_eq!(it.last_doc_id(), 20);
+        }
+
+        #[test]
+        fn test_revalidate_wcii_moved_past_max_doc_id() {
+            let wcii = utils::Mock::new([5u64, 150]);
+            let mut wcii_data = wcii.data();
+            let child = utils::Mock::new(CHILD_DOCS);
+            let mut it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+
+            let r = it.read().expect("read").expect("result");
+            assert_eq!(r.doc_id, 5);
+
+            wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let guard = mock_ctx.spec_read();
+            let it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            assert!(it.at_eof());
+        }
+
+        /// Regression: wcii moves to its own EOF (single-doc Mock at EOF returns
+        /// "Moved without new doc"). Optional must propagate that as Moved + EOF.
+        #[test]
+        fn test_revalidate_wcii_moved_to_eof() {
+            let wcii = utils::Mock::new([5u64]);
+            let mut wcii_data = wcii.data();
+            let child = utils::Mock::new([5u64]);
+            let mut it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+
+            let r = it.read().expect("read").expect("result");
+            assert_eq!(r.doc_id, 5);
+
+            wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let guard = mock_ctx.spec_read();
+            let it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            assert!(it.at_eof(), "iterator must be at EOF");
+            assert_eq!(wcii_data.revalidate_count(), 1);
+        }
+
+        #[test]
+        fn test_revalidate_child_aborted_wcii_moved() {
+            let wcii = utils::Mock::new([5u64, 20]);
+            let mut wcii_data = wcii.data();
+            let child = utils::Mock::new([5u64, 35]);
+            let mut child_data = child.data();
+            let mut it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+
+            let r = it.read().expect("read").expect("result");
+            assert_eq!(r.doc_id, 5);
+
+            wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+            child_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
+
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let guard = mock_ctx.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            let r = it.current().expect("current");
+            assert_eq!(r.doc_id, 20);
+            assert_eq!(r.weight, 0.);
+            // The resumed iterator is type-erased and no longer exposes the
+            // concrete `child()` accessor; the virtual result above (weight 0)
+            // confirms the aborted child was replaced by `Empty`.
+            assert_eq!(wcii_data.revalidate_count(), 1);
+            assert_eq!(child_data.revalidate_count(), 1);
+        }
+
+        #[test]
+        fn test_revalidate_child_moved_wcii_aborted() {
+            let wcii = utils::Mock::new([5u64, 20]);
+            let mut wcii_data = wcii.data();
+            let child = utils::Mock::new([5u64, 35]);
+            let mut child_data = child.data();
+            let mut it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+
+            let r = it.read().expect("read").expect("result");
+            assert_eq!(r.doc_id, 5);
+
+            wcii_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
+            child_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let guard = mock_ctx.spec_read();
+            let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+            assert_eq!(wcii_data.revalidate_count(), 1);
+            // Both children are resumed in the new path (resume drives both unconditionally);
+            // the suspend->resume cycle returns Aborted but doesn't short-circuit child.
+            assert_eq!(child_data.revalidate_count(), 1);
+        }
+
+        #[test]
+        fn test_revalidate_child_moved_wcii_moved() {
+            let wcii = utils::Mock::new([5u64, 20, 35]);
+            let mut wcii_data = wcii.data();
+            let child = utils::Mock::new([5u64, 25, 35]);
+            let mut child_data = child.data();
+            let mut it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+
+            let r = it.read().expect("read").expect("result");
+            assert_eq!(r.doc_id, 5);
+
+            wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+            child_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let guard = mock_ctx.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            let r = it.current().expect("current");
+            assert_eq!(r.doc_id, 20);
+            assert_eq!(r.weight, 0.);
+            assert_eq!(it.last_doc_id(), 20);
+            assert_eq!(wcii_data.revalidate_count(), 1);
+            assert_eq!(child_data.revalidate_count(), 1);
+
+            let r = it.read().expect("read after revalidate").expect("result");
+            assert!(r.doc_id > 20);
+        }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
@@ -221,3 +221,67 @@ fn counters_default_is_zero() {
     let counters = ProfileCounters::default();
     assert_eq!(counters.num_reading_operations(), 0);
 }
+
+mod via_resume {
+    use super::*;
+    use rqe_iterators::TypeErasedRQEIterator;
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    #[test]
+    fn profile_revalidate() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child = Wildcard::new(10, 1.0);
+        let mut profile = Box::new(Profile::new(child));
+
+        let _ = profile.read(); // doc 1
+        let _ = profile.read(); // doc 2
+
+        // Resume (Wildcard returns OK)
+        let mut profile =
+            revalidate_via_resume(TypeErasedRQEIterator::new(profile), &mock_ctx.spec_read())
+                .expect("resume failed")
+                .expect_ok();
+
+        // Verify delegation still works
+        assert_eq!(profile.last_doc_id(), 2);
+        assert_eq!(profile.current().unwrap().doc_id, 2);
+    }
+
+    /// The FFI wrapper caches a raw pointer into the iterator (`header.current`),
+    /// so a suspend→resume cycle must reuse the same heap allocation rather than
+    /// reallocate. Exercise the concrete (non-type-erased) path and assert the
+    /// box address survives both transitions.
+    #[test]
+    fn profile_resume_preserves_box_address() {
+        use rqe_iterators::{RQEIteratorBoxed, RQESuspendedIterator, ResumeOutcome};
+
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child = Wildcard::new(10, 1.0);
+        let mut profile = Box::new(Profile::new(child));
+
+        let _ = profile.read(); // doc 1
+        let _ = profile.read(); // doc 2
+
+        let addr_before = &*profile as *const _ as usize;
+
+        let suspended = profile.suspend();
+        assert_eq!(
+            &*suspended as *const _ as usize, addr_before,
+            "suspend must reuse the allocation"
+        );
+
+        let active = match suspended
+            .resume(&mock_ctx.spec_read())
+            .expect("resume failed")
+        {
+            ResumeOutcome::Ok(it) | ResumeOutcome::Moved(it) => it,
+            ResumeOutcome::Aborted => panic!("wildcard child should not abort"),
+        };
+
+        assert_eq!(
+            &*active as *const _ as usize, addr_before,
+            "resume must reuse the same allocation (FFI caches a pointer into it)"
+        );
+        assert_eq!(active.last_doc_id(), 2);
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_flat.rs
@@ -133,3 +133,220 @@ fn into_trimmed_quick_flat_trims_asc() {
     // Active window [0..2), reads in reverse: child[1] then child[0].
     assert_eq!(docs, [3, 4, 1, 2]);
 }
+
+mod via_resume {
+    use crate::utils::{Mock, MockRevalidateResult};
+    use rqe_iterators::{RQEIterator, ResumeOutcome, TypeErasedRQEIterator, UnionFullFlat};
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 15);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 20);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_moved() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        // After Move, children advance — last_doc_id should reflect new min.
+        assert!(union.last_doc_id() > 10);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_single_child_aborts() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        // One child aborted, the other survives — union continues (Ok or Moved).
+        let mut union =
+            match revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+                .expect("resume failed")
+            {
+                ResumeOutcome::Ok(it) | ResumeOutcome::Moved(it) => it,
+                ResumeOutcome::Aborted => {
+                    panic!("Expected MOVED or OK when one child aborts, got Aborted")
+                }
+            };
+        // Reads from the surviving child should continue.
+        let r = union.read().unwrap().unwrap();
+        assert!(r.doc_id >= 15);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_all_children_abort() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed");
+        assert!(matches!(outcome, ResumeOutcome::Aborted));
+    }
+
+    /// Phase 3.15 regression: when no child moved, the aggregate must be
+    /// rebuilt at `saved_last_doc_id` so subsequent reads continue from the
+    /// same logical position.
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_minimum_unchanged_returns_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 3> = Mock::new([10, 30, 50]);
+        let child1: Mock<'_, 3> = Mock::new([10, 40, 60]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        // Union must continue producing the remaining children's docs.
+        let r = union.read().unwrap().unwrap();
+        assert!(r.doc_id > 10, "expected next doc_id > 10, got {}", r.doc_id);
+    }
+
+    /// Phase 5b.5 regression: an EOF child swap-removed into the dead tail must
+    /// NOT be re-included as a live child by resume — that would yield its
+    /// already-read max doc_id forever.
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_swap_removed_dead_tail_not_yielded_again() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // Child 0 has a small doc set; child 1 has more docs.
+        // Read past child 0's EOF so it's swap-removed into the dead tail.
+        let child0: Mock<'_, 2> = Mock::new([10, 20]);
+        let child1: Mock<'_, 5> = Mock::new([5, 15, 25, 35, 45]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        // Drain child0: 5 (c1), 10 (c0), 15 (c1), 20 (c0) — c0 now at EOF and
+        // gets swap_remove_child'd next time `read()` advances past 20.
+        let mut docs = Vec::new();
+        for _ in 0..4 {
+            docs.push(union.read().unwrap().unwrap().doc_id);
+        }
+        assert_eq!(docs, [5, 10, 15, 20]);
+        // The next read trims child0 to the dead tail.
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 25);
+
+        // Now resume: child0 is in the dead tail. It must NOT re-emerge as live.
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        // Continue reading: must surface the rest of child1 and never repeat 20.
+        let remaining: Vec<_> =
+            std::iter::from_fn(|| union.read().unwrap().map(|r| r.doc_id)).collect();
+        assert_eq!(remaining, [35, 45]);
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_heap.rs
@@ -137,3 +137,207 @@ fn into_trimmed_quick_heap_trims_desc() {
     // Active window [1..3), reads in reverse: child[2] then child[1].
     assert_eq!(docs, [5, 6, 3, 4]);
 }
+
+mod via_resume {
+    use crate::utils::{Mock, MockRevalidateResult};
+    use rqe_iterators::{RQEIterator, ResumeOutcome, TypeErasedRQEIterator, UnionFullHeap};
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 15);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 20);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_moved() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert!(union.last_doc_id() > 10);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_single_child_aborts() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union =
+            match revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+                .expect("resume failed")
+            {
+                ResumeOutcome::Ok(it) | ResumeOutcome::Moved(it) => it,
+                ResumeOutcome::Aborted => {
+                    panic!("Expected MOVED or OK when one child aborts, got Aborted")
+                }
+            };
+        let r = union.read().unwrap().unwrap();
+        assert!(r.doc_id >= 15);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_all_children_abort() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed");
+        assert!(matches!(outcome, ResumeOutcome::Aborted));
+    }
+
+    /// Phase 3.17 regression: when no child moved, rebuild aggregate at the
+    /// previous saved position (no skip_to shortcut).
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_minimum_unchanged_returns_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 3> = Mock::new([10, 30, 50]);
+        let child1: Mock<'_, 3> = Mock::new([10, 40, 60]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let r = union.read().unwrap().unwrap();
+        assert!(r.doc_id > 10, "expected next doc_id > 10, got {}", r.doc_id);
+    }
+
+    /// Phase 5b.5 regression: an EOF child swap-removed into the dead tail
+    /// must NOT be re-inserted into the heap by resume.
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_swap_removed_dead_tail_not_yielded_again() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 2> = Mock::new([10, 20]);
+        let child1: Mock<'_, 5> = Mock::new([5, 15, 25, 35, 45]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullHeap::new(children);
+
+        let mut docs = Vec::new();
+        for _ in 0..4 {
+            docs.push(union.read().unwrap().unwrap().doc_id);
+        }
+        assert_eq!(docs, [5, 10, 15, 20]);
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 25);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let remaining: Vec<_> =
+            std::iter::from_fn(|| union.read().unwrap().map(|r| r.doc_id)).collect();
+        assert_eq!(remaining, [35, 45]);
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
@@ -467,3 +467,30 @@ fn into_trimmed_reuses_all_children() {
         "previously trimmed children are now active"
     );
 }
+
+mod via_resume {
+    use crate::utils::Mock;
+    use rqe_iterators::{TypeErasedRQEIterator, UnionTrimmed};
+    use rqe_iterators_test_utils::revalidate_via_resume;
+
+    /// Resume must panic on UnionTrimmed for the same reason `revalidate`
+    /// does: trimmed unions are constructed for the partial-range
+    /// optimization path which doesn't release the spec lock between reads.
+    #[test]
+    #[should_panic(expected = "resume is not supported on UnionTrimmed")]
+    fn resume_panics() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 1> = Mock::new([1]);
+        let child1: Mock<'_, 1> = Mock::new([2]);
+        let child2: Mock<'_, 1> = Mock::new([3]);
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+            TypeErasedRQEIterator::new(Box::new(child2)),
+        ];
+        let union = UnionTrimmed::new(children, usize::MAX, true);
+
+        let guard = mock_ctx.spec_read();
+        let _ = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard);
+    }
+}


### PR DESCRIPTION
## Describe the changes in the pull request

The remaining R2 surface: the FFI-boundary enum dispatchers that wrap
multiple concrete iterator instantiations behind a single type, and
the doc-comment cleanup that removes references to the now-obsolete
`Suspendable` trait.

Each enum forwards `suspend` / `resume` to its variants and pairs
them with a matching `Suspended` enum, so the production wiring in
PR D can address any iterator (Rust or C-backed) through a uniform
suspend interface.

#### Main objects this PR modified
- `NumericIteratorVariant` (Unfiltered / Filtered / Geo dispatcher)
- `CRQEIterator` (Rust wrapper around C-side `QueryIterator`)
- `DiskWildcardIterator` (on-disk wildcard variant)
- `NewWildcardIterator` (cross-tier wildcard dispatcher)
- Doc-comment cleanup: drop stale `Suspendable` references

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

Stacked on #10272.
