### PR TITLE
[Iterator Revalidation][MOD-16554] Simple leaves: Empty, IdList, Metric

### DIFF
--- a/src/redisearch_rs/headers/index_result_rs.h
+++ b/src/redisearch_rs/headers/index_result_rs.h
@@ -28,7 +28,7 @@ typedef struct RLookupKey RLookupKey;
 /**
  * A single metric: a borrowed key and a numeric value.
  */
-typedef struct RawMetricEntry {
+typedef struct MetricEntry {
   /**
    * Borrowed reference to the lookup key that identifies this metric,
    * or `None` when the metric has no associated key.
@@ -49,7 +49,7 @@ typedef struct RawMetricEntry {
    * The metric value (e.g. vector distance, score).
    */
   double value;
-} RawMetricEntry;
+} MetricEntry;
 
 /**
  * The [`Active`] instantiation of [`RawOffsetSlice`]: a borrowed view whose data
@@ -58,28 +58,23 @@ typedef struct RawMetricEntry {
 typedef struct RSOffsetVector RSOffsetSlice;
 
 /**
- * Lifetime-parameterised alias for [`RawMetricEntry`].
- */
-typedef struct RawMetricEntry MetricEntry;
-
-/**
  * A read-only, C-visible slice view over the entries of a [`MetricsVec`].
  *
  * Returned by [`MetricsVec::as_metrics_slice`] for zero-copy iteration
  * from C. The pointed-to data is valid as long as the originating
  * [`MetricsVec`] is not mutated or dropped.
  */
-typedef struct RawMetricsSlice {
+typedef struct MetricsSlice {
   /**
    * Pointer to the first [`MetricEntry`].  May be dangling (but not null)
    * when `len == 0`.
    */
-  const struct RawMetricEntry *data;
+  const struct MetricEntry *data;
   /**
    * Number of entries.
    */
   size_t len;
-} RawMetricsSlice;
+} MetricsSlice;
 
 #ifndef THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED
 #define THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED
@@ -91,15 +86,15 @@ typedef struct ThinVec_Box_RawIndexResult_Active__u16 {
 } ThinVec_Box_RawIndexResult_Active__u16;
 #endif /* THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED */
 
-#ifndef THINVEC_RAWMETRICENTRY__U64_DEFINED
-#define THINVEC_RAWMETRICENTRY__U64_DEFINED
+#ifndef THINVEC_METRICENTRY__U64_DEFINED
+#define THINVEC_METRICENTRY__U64_DEFINED
 /**
  * See the crate's top level documentation for a description of this type.
  */
-typedef struct ThinVec_RawMetricEntry__u64 {
+typedef struct ThinVec_MetricEntry__u64 {
   struct Header_u64 *ptr;
-} ThinVec_RawMetricEntry__u64;
-#endif /* THINVEC_RAWMETRICENTRY__U64_DEFINED */
+} ThinVec_MetricEntry__u64;
+#endif /* THINVEC_METRICENTRY__U64_DEFINED */
 
 /**
  * A dynamically-sized collection of [`MetricEntry`] values.
@@ -110,12 +105,7 @@ typedef struct ThinVec_RawMetricEntry__u64 {
  * `repr(transparent)` over `ThinVec` means this type is pointer-sized
  * and can be embedded directly in `repr(C)` structs.
  */
-typedef struct ThinVec_RawMetricEntry__u64 RawMetricsVec;
-
-/**
- * Lifetime-parameterised alias for [`RawMetricsVec`].
- */
-typedef RawMetricsVec MetricsVec;
+typedef struct ThinVec_MetricEntry__u64 MetricsVec;
 
 #ifndef THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED
 #define THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED
@@ -126,11 +116,6 @@ typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u16 {
   struct Header_u16 *ptr;
 } ThinVec_SharedPtr_Active__RawIndexResult_Active__u16;
 #endif /* THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED */
-
-/**
- * Lifetime-parameterised alias for [`RawMetricsSlice`].
- */
-typedef struct RawMetricsSlice MetricsSlice;
 
 #ifndef SHAREDPTR_ACTIVE__U8_DEFINED
 #define SHAREDPTR_ACTIVE__U8_DEFINED
@@ -596,7 +581,7 @@ typedef struct RawIndexResult_Active {
    * Backed by [`ThinVec`](thin_vec::ThinVec) — pointer-sized, no
    * allocation when empty.
    */
-  RawMetricsVec metrics;
+  MetricsVec metrics;
   /**
    * Relative weight for scoring calculations. This is derived from the result's iterator weight
    */

--- a/src/redisearch_rs/headers/metrics_ffi.h
+++ b/src/redisearch_rs/headers/metrics_ffi.h
@@ -77,7 +77,7 @@ void IndexResult_ResetAggregate(RSIndexResult *r);
  * 2. The returned slice borrows from the `MetricsVec`; the caller must
  *    not mutate or free the `MetricsVec` while the slice is in use.
  */
-MetricsSlice MetricsVec_AsSlice(const MetricsVec *metrics);
+struct MetricsSlice MetricsVec_AsSlice(const MetricsVec *metrics);
 
 /**
  * Finds the first metric whose key matches `key` (pointer equality) and

--- a/src/redisearch_rs/index_result/src/core/mod.rs
+++ b/src/redisearch_rs/index_result/src/core/mod.rs
@@ -439,6 +439,8 @@ impl<'a> RSIndexResult<'a> {
     pub const unsafe fn into_suspended_in_place(
         slot: *mut Self,
     ) -> *mut RawIndexResult<'a, Suspended> {
+        debug_assert!(!slot.is_null());
+
         // SAFETY: `slot` is valid for reads and aligned (caller contract); `read`
         // moves the value out without dropping, leaving the slot logically uninit
         // until the `write` below re-initializes it.
@@ -538,6 +540,8 @@ impl<'query> RawIndexResult<'query, Suspended> {
     where
         'query: 'a,
     {
+        debug_assert!(!slot.is_null());
+
         // SAFETY: `slot` is valid for reads and aligned (caller contract); `read`
         // moves the value out without dropping, leaving the slot logically uninit
         // until the `write` below re-initializes it.

--- a/src/redisearch_rs/index_result/src/core/mod.rs
+++ b/src/redisearch_rs/index_result/src/core/mod.rs
@@ -13,7 +13,7 @@ use std::ptr;
 
 use super::aggregate::RawAggregateResult;
 use super::kind::RSResultKind;
-use super::metrics::{MetricsVec, RawMetricsVec};
+use super::metrics::MetricsVec;
 use super::offsets::{RSOffsetVector, RawOffsetSlice};
 use super::result_data::RawResultData;
 use super::term_record::RawTermRecord;
@@ -166,7 +166,7 @@ impl<'query, R: Ref> RawIndexResultBuilder<'query, R> {
             field_mask: self.field_mask,
             freq: self.freq,
             data: self.data,
-            metrics: RawMetricsVec::new(),
+            metrics: MetricsVec::new(),
             weight: self.weight,
         }
     }
@@ -276,7 +276,7 @@ impl<'query, R: Ref> RawTermResultBuilder<'query, R> {
             field_mask: self.field_mask,
             freq: self.freq,
             data,
-            metrics: RawMetricsVec::new(),
+            metrics: MetricsVec::new(),
             weight: self.weight,
         }
     }
@@ -312,7 +312,7 @@ pub struct RawIndexResult<'query, R: Ref> {
     ///
     /// Backed by [`ThinVec`](thin_vec::ThinVec) — pointer-sized, no
     /// allocation when empty.
-    pub metrics: RawMetricsVec<'query>,
+    pub metrics: MetricsVec<'query>,
 
     /// Relative weight for scoring calculations. This is derived from the result's iterator weight
     pub weight: f64,
@@ -359,7 +359,7 @@ const _: () = {
     // The only `R`-dependent field is `data`; check its two instantiations
     // have identical size. The `metrics` field no longer depends on `R` (its
     // `RLookupKey` lives under `'query`, never weakened), so it is the same
-    // `RawMetricsVec<'static>` type on both sides — nothing to assert there.
+    // `MetricsVec<'static>` type on both sides — nothing to assert there.
     assert!(
         size_of::<RawResultData<'static, Active<'static>>>()
             == size_of::<RawResultData<'static, Suspended>>()
@@ -861,12 +861,12 @@ impl<'query, R: Ref> RawIndexResult<'query, R> {
     }
 
     /// Returns a mutable reference to the metrics collection.
-    pub const fn metrics_mut(&mut self) -> &mut RawMetricsVec<'query> {
+    pub const fn metrics_mut(&mut self) -> &mut MetricsVec<'query> {
         &mut self.metrics
     }
 
     /// Returns a reference to the metrics collection.
-    pub const fn metrics_ref(&self) -> &RawMetricsVec<'query> {
+    pub const fn metrics_ref(&self) -> &MetricsVec<'query> {
         &self.metrics
     }
 

--- a/src/redisearch_rs/index_result/src/core/mod.rs
+++ b/src/redisearch_rs/index_result/src/core/mod.rs
@@ -418,6 +418,41 @@ impl<'a> RSIndexResult<'a> {
         // logically-moved bytes.
         unsafe { std::mem::transmute(self) }
     }
+
+    /// Convert the active result at `slot` into its suspended form in place,
+    /// reusing the same slot so the surrounding allocation is never moved.
+    ///
+    /// This is the inverse of [`RawIndexResult::into_active_in_place`]. Because
+    /// [`into_suspended`](Self::into_suspended) only *loosens* validity, this
+    /// conversion has no lifetime or pointee precondition — the only obligations
+    /// are the raw-pointer ones below.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that:
+    ///
+    /// 1. `slot` is non-null, aligned, and points to an initialized
+    ///    `RSIndexResult<'a>`.
+    /// 2. `slot` must be unaliased for the duration of the call: no other
+    ///    reference or pointer may be used to access the slot while this runs,
+    ///    since the value is moved out and written back through `slot` alone.
+    pub const unsafe fn into_suspended_in_place(
+        slot: *mut Self,
+    ) -> *mut RawIndexResult<'a, Suspended> {
+        // SAFETY: `slot` is valid for reads and aligned (caller contract); `read`
+        // moves the value out without dropping, leaving the slot logically uninit
+        // until the `write` below re-initializes it.
+        let active = unsafe { slot.read() };
+        // Safe widening conversion — consumes the moved-out value.
+        let suspended = active.into_suspended();
+        let slot = slot.cast::<RawIndexResult<'a, Suspended>>();
+        // SAFETY: `slot` is valid for writes and aligned; `Active<'a>` and
+        // `Suspended` are layout-identical, so `Suspended` fits the slot exactly.
+        // `write` does not drop the old bits — correct, `read` already moved them
+        // out. Net drops across this fn: zero.
+        unsafe { slot.write(suspended) };
+        slot
+    }
 }
 
 impl<'query> RawIndexResult<'query, Suspended> {
@@ -428,6 +463,10 @@ impl<'query> RawIndexResult<'query, Suspended> {
     /// this is the inverse direction. Promoting `Suspended` to `Active<'a>`
     /// narrows validity (asserting that every index-backed pointer inside this
     /// result is dereferenceable for `'a`), so the call is `unsafe`.
+    ///
+    /// # Invariants
+    ///
+    /// `into_active` never panics.
     ///
     /// # Safety
     ///
@@ -479,6 +518,39 @@ impl<'query> RawIndexResult<'query, Suspended> {
         // valid for `'a` thanks to the `'query: 'a` bound. `transmute` moves
         // `self`, so no destructor runs on the logically-moved bytes.
         unsafe { std::mem::transmute(self) }
+    }
+
+    /// Convert the suspended result at `slot` into its active form in place,
+    /// reusing the same slot so the surrounding allocation is never moved.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that:
+    ///
+    /// 1. `slot` is non-null, aligned, and points to an initialized
+    ///    `RawIndexResult<Suspended>`.
+    /// 2. `slot` must be unaliased for the duration of the call: no other
+    ///    reference or pointer may be used to access the slot while this runs,
+    ///    since the value is moved out and written back through `slot` alone.
+    /// 3. The safety preconditions of [`RawIndexResult::into_active`] must hold
+    ///    for the chosen lifetime `'a`.
+    pub const unsafe fn into_active_in_place<'a>(slot: *mut Self) -> *mut RSIndexResult<'a>
+    where
+        'query: 'a,
+    {
+        // SAFETY: `slot` is valid for reads and aligned (caller contract); `read`
+        // moves the value out without dropping, leaving the slot logically uninit
+        // until the `write` below re-initializes it.
+        let suspended = unsafe { slot.read() };
+        // SAFETY: `into_active`'s preconditions for `'a` are guaranteed by our
+        // caller (forwarded via this fn's `# Safety`); consumes the moved-out value.
+        let active: RSIndexResult<'a> = unsafe { suspended.into_active() };
+        let slot = slot.cast::<RSIndexResult<'a>>();
+        // SAFETY: `slot` is valid for writes and aligned; sizes/aligns asserted equal
+        // above, so `Active<'a>` fits the slot exactly. `write` does not drop the old
+        // bits — correct, `read` already moved them out. Net drops across this fn: zero.
+        unsafe { slot.write(active) };
+        slot
     }
 }
 

--- a/src/redisearch_rs/index_result/src/lib.rs
+++ b/src/redisearch_rs/index_result/src/lib.rs
@@ -23,9 +23,7 @@ pub use self::core::{
 };
 pub use aggregate::{RSAggregateResult, RSAggregateResultIter, RawAggregateResult};
 pub use kind::{RSResultKind, RSResultKindMask};
-pub use metrics::{
-    MetricEntry, MetricsSlice, MetricsVec, RawMetricEntry, RawMetricsSlice, RawMetricsVec,
-};
+pub use metrics::{MetricEntry, MetricsSlice, MetricsVec};
 pub use offsets::{RSOffsetSlice, RSOffsetVector, RawOffsetSlice};
 pub use result_data::{RSResultData, RawResultData};
 pub use term_record::{RSTermRecord, RawTermRecord};

--- a/src/redisearch_rs/index_result/src/metrics.rs
+++ b/src/redisearch_rs/index_result/src/metrics.rs
@@ -22,7 +22,8 @@ use thin_vec::ThinVec;
 /// A single metric: a borrowed key and a numeric value.
 #[derive(Debug)]
 #[repr(C)]
-pub struct RawMetricEntry<'query> {
+#[cheadergen::config(export)]
+pub struct MetricEntry<'query> {
     /// Borrowed reference to the lookup key that identifies this metric,
     /// or `None` when the metric has no associated key.
     ///
@@ -42,13 +43,9 @@ pub struct RawMetricEntry<'query> {
     pub value: f64,
 }
 
-/// Lifetime-parameterised alias for [`RawMetricEntry`].
-#[cheadergen::config(export)]
-pub type MetricEntry<'a> = RawMetricEntry<'a>;
+impl Copy for MetricEntry<'_> {}
 
-impl Copy for RawMetricEntry<'_> {}
-
-impl Clone for RawMetricEntry<'_> {
+impl Clone for MetricEntry<'_> {
     fn clone(&self) -> Self {
         *self
     }
@@ -74,7 +71,7 @@ impl<'a> MetricEntry<'a> {
     }
 }
 
-impl RawMetricEntry<'_> {
+impl MetricEntry<'_> {
     /// Returns the metric value.
     pub const fn value(&self) -> f64 {
         self.value
@@ -113,14 +110,12 @@ impl<'a> PartialEq for MetricEntry<'a> {
 /// and can be embedded directly in `repr(C)` structs.
 #[derive(Debug)]
 #[repr(transparent)]
-pub struct RawMetricsVec<'query> {
-    inner: ThinVec<RawMetricEntry<'query>>,
+#[cheadergen::config(export)]
+pub struct MetricsVec<'query> {
+    inner: ThinVec<MetricEntry<'query>>,
 }
 
-/// Lifetime-parameterised alias for [`RawMetricsVec`].
-pub type MetricsVec<'a> = RawMetricsVec<'a>;
-
-impl Clone for RawMetricsVec<'_> {
+impl Clone for MetricsVec<'_> {
     fn clone(&self) -> Self {
         let Self { inner } = self;
         Self {
@@ -143,19 +138,17 @@ impl<'a> PartialEq for MetricsVec<'a> {
 /// from C. The pointed-to data is valid as long as the originating
 /// [`MetricsVec`] is not mutated or dropped.
 #[repr(C)]
-pub struct RawMetricsSlice<'query> {
+#[cheadergen::config(export)]
+pub struct MetricsSlice<'query> {
     /// Pointer to the first [`MetricEntry`].  May be dangling (but not null)
     /// when `len == 0`.
-    pub data: *const RawMetricEntry<'query>,
+    pub data: *const MetricEntry<'query>,
 
     /// Number of entries.
     pub len: usize,
 }
 
-/// Lifetime-parameterised alias for [`RawMetricsSlice`].
-pub type MetricsSlice<'a> = RawMetricsSlice<'a>;
-
-impl<'query> RawMetricsVec<'query> {
+impl<'query> MetricsVec<'query> {
     /// Creates an empty metrics collection. Does not allocate.
     pub const fn new() -> Self {
         Self {
@@ -184,9 +177,9 @@ impl<'query> RawMetricsVec<'query> {
     }
 
     /// Returns a C-compatible slice view for zero-copy iteration.
-    pub fn as_metrics_slice(&self) -> RawMetricsSlice<'query> {
+    pub fn as_metrics_slice(&self) -> MetricsSlice<'query> {
         let slice = self.inner.as_slice();
-        RawMetricsSlice {
+        MetricsSlice {
             data: slice.as_ptr(),
             len: slice.len(),
         }
@@ -194,24 +187,24 @@ impl<'query> RawMetricsVec<'query> {
 
     /// Returns a reference to the entry at `index`, or `None` if out of
     /// bounds.
-    pub fn get(&self, index: usize) -> Option<&RawMetricEntry<'query>> {
+    pub fn get(&self, index: usize) -> Option<&MetricEntry<'query>> {
         self.inner.as_slice().get(index)
     }
 
     /// Returns a mutable reference to the entry at `index`, or `None` if
     /// out of bounds.
-    pub fn get_mut(&mut self, index: usize) -> Option<&mut RawMetricEntry<'query>> {
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut MetricEntry<'query>> {
         self.inner.as_mut_slice().get_mut(index)
     }
 
     /// Returns an iterator over the entries.
-    pub fn iter(&self) -> impl Iterator<Item = &RawMetricEntry<'query>> {
+    pub fn iter(&self) -> impl Iterator<Item = &MetricEntry<'query>> {
         self.inner.as_slice().iter()
     }
 
     /// Finds the first entry whose key matches `key` (pointer equality)
     /// and returns a mutable reference to it.
-    pub fn find_by_key_mut(&mut self, key: &RLookupKey) -> Option<&mut RawMetricEntry<'query>> {
+    pub fn find_by_key_mut(&mut self, key: &RLookupKey) -> Option<&mut MetricEntry<'query>> {
         let needle = key as *const RLookupKey;
         self.inner
             .as_mut_slice()
@@ -232,7 +225,7 @@ impl<'a> MetricsVec<'a> {
     }
 }
 
-impl Default for RawMetricsVec<'_> {
+impl Default for MetricsVec<'_> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -154,9 +154,7 @@ pub trait RQESuspendedIterator<'query> {
     /// is acceptable — the underlying invariant is that the FFI consumer
     /// uses it for display only. Default returns 0 for iterators that do
     /// not maintain a cached estimate.
-    fn num_estimated(&self) -> usize {
-        0
-    }
+    fn num_estimated(&self) -> usize;
 }
 
 /// Dyn-safe sibling of [`RQEIteratorBoxed`].

--- a/src/redisearch_rs/rqe_iterators/src/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/empty.rs
@@ -14,7 +14,8 @@ use index_spec::IndexSpecReadGuard;
 use rqe_core::DocId;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 
@@ -87,5 +88,36 @@ impl<'index> RQEIterator<'index> for Empty {
 impl ProfilePrint for Empty {
     fn print_profile(&self, map: &mut redis_reply::MapBuilder<'_>, ctx: &mut ProfilePrintCtx<'_>) {
         ctx.print_leaf(c"EMPTY", map);
+    }
+}
+
+impl<'index> RQEIteratorBoxed<'index> for Empty {
+    /// `Empty` has no `Rf`-dependent state, so its Suspended counterpart is
+    /// itself.
+    type Suspended = Empty;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        self
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for Empty {
+    type Resumed<'index>
+        = Empty
+    where
+        'query: 'index;
+
+    fn resume<'index>(
+        self: Box<Self>,
+        _guard: &IndexSpecReadGuard<'index>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'index>>>, RQEIteratorError>
+    where
+        'query: 'index,
+    {
+        Ok(ResumeOutcome::Ok(self))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        0
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/empty.rs
@@ -120,4 +120,8 @@ impl<'query> RQESuspendedIterator<'query> for Empty {
     fn last_doc_id(&self) -> DocId {
         0
     }
+
+    fn num_estimated(&self) -> usize {
+        0
+    }
 }

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -9,7 +9,7 @@
 
 //! Supporting types for [`IdList`].
 
-use index_result::{RSIndexResult, RawIndexResult};
+use index_result::{RSIndexResult, RSResultKind, RawIndexResult};
 use index_spec::IndexSpecReadGuard;
 use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
@@ -42,12 +42,35 @@ pub struct RawIdList<'query, Rf: Ref, const SORTED: bool> {
     /// When `offset` is equal to the length of `ids`, the iterator is at EOF.
     offset: usize,
     /// A reusable result object to avoid allocations on each [`read`](RQEIterator::read) call.
+    ///
+    /// # Invariant
+    ///
+    /// `result`'s kind is either virtual or metric.
     result: RawIndexResult<'query, Rf>,
 }
 
 /// Alias for an [`Active`] [`RawIdList`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
 pub type IdList<'index, const SORTED: bool> = RawIdList<'index, Active<'index>, SORTED>;
+/// Alias for a [`Suspended`] [`RawIdList`].
+pub type SuspendedIdList<'query, const SORTED: bool> = RawIdList<'query, Suspended, SORTED>;
+
+// Compile-time proof that the `IdList` and its suspended counterpart are layout-identical.
+const _: () = {
+    use std::mem::offset_of;
+
+    const SORTED: bool = true;
+    type A<'a> = IdList<'a, SORTED>;
+    type S<'a> = SuspendedIdList<'a, SORTED>;
+
+    // Every field starts at the same offset.
+    assert!(offset_of!(A, ids) == offset_of!(S, ids));
+    assert!(offset_of!(A, offset) == offset_of!(S, offset));
+    assert!(offset_of!(A, result) == offset_of!(S, result));
+
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
 
 impl<'index, const SORTED: bool> IdList<'index, SORTED> {
     /// Creates a new ID list iterator.
@@ -71,6 +94,13 @@ impl<'index, const SORTED: bool> IdList<'index, SORTED> {
     /// Same as [`IdList::new`] but with a custom [`RSIndexResult`],
     /// useful when wrapping this iterator and requiring a non-virtual result.
     pub fn with_result(ids: impl Into<OwnedSlice<DocId>>, result: RSIndexResult<'index>) -> Self {
+        let kind = result.kind();
+        if kind != RSResultKind::Virtual && kind != RSResultKind::Metric {
+            panic!(
+                "IdList iterators can only work with virtual and metric result kinds. {kind} is not supported.",
+            );
+        }
+
         let ids = ids.into();
 
         if SORTED {
@@ -101,6 +131,13 @@ impl<'index, const SORTED: bool> IdList<'index, SORTED> {
         }
         self.ids = ids;
         self.offset = 0;
+    }
+}
+
+impl<'query, Rf: Ref, const SORTED: bool> RawIdList<'query, Rf, SORTED> {
+    #[inline(always)]
+    pub(super) fn _num_estimated(&self) -> usize {
+        self.ids.len()
     }
 }
 
@@ -256,7 +293,7 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for IdList<'index, SO
 
     #[inline(always)]
     fn num_estimated(&self) -> usize {
-        self.ids.len()
+        self._num_estimated()
     }
 
     #[inline(always)]
@@ -311,23 +348,112 @@ impl<'query, Rf: Ref, const SORTED: bool> RawIdList<'query, Rf, SORTED> {
     }
 }
 
-impl<'index, const SORTED: bool> RQEIteratorBoxed<'index> for IdList<'index, SORTED> {
-    type Suspended = RawIdList<'index, Suspended, SORTED>;
+impl<'query, const SORTED: bool> SuspendedIdList<'query, SORTED> {
+    /// Resume the suspended id list at `slot` in place.
+    ///
+    /// On success returns `Ok(ptr)`, the same slot reinterpreted as the active
+    /// [`IdList`]. If the stored result kind is neither metric nor virtual it logs
+    /// a warning and returns `Err(ptr)` — the same slot, **left untouched and
+    /// still a valid [`SuspendedIdList`]**. Constructors enforce the kind
+    /// invariant, but it can be violated at runtime because
+    /// [`read`](RQEIterator::read)/[`current`](RQEIterator::current) hand out
+    /// `&mut RSIndexResult`, letting a caller overwrite the result with another
+    /// kind before suspension.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that:
+    ///
+    /// 1. `slot` is non-null, aligned, and points to an initialized
+    ///    `SuspendedIdList<'query, SORTED>`.
+    /// 2. `slot` is unaliased for the duration of the call.
+    ///
+    /// The returned pointer aliases `slot`. In the `Ok` case every field is valid
+    /// at the active type for `'a`; in the `Err` case the slot is byte-for-byte
+    /// unchanged and remains a valid `SuspendedIdList<'query, SORTED>`.
+    pub(crate) unsafe fn resume_in_place<'a>(
+        slot: *mut Self,
+    ) -> Result<*mut IdList<'a, SORTED>, *mut Self>
+    where
+        'query: 'a,
+    {
+        // SAFETY: `slot` is non-null, aligned, initialized, and unaliased (caller
+        // contracts 1 & 2), so a shared read of the result kind is sound.
+        let kind = unsafe { (*slot).result.kind() };
+        if kind != RSResultKind::Metric && kind != RSResultKind::Virtual {
+            tracing::warn!(
+                "An internal invariant has been violated. A suspended id list is storing a {kind} \
+                 result instead of the expected metric/virtual kind"
+            );
+            // The slot has not been touched, so it is still a valid `SuspendedIdList`.
+            return Err(slot);
+        }
 
-    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
-        let raw = Box::into_raw(self);
-        // SAFETY: `RawIdList` is `#[repr(C)]`. The only `Rf`-dependent field
-        // is `result: RawIndexResult<'index, Rf>`, layout-compatible across `Rf` via
-        // `SharedPtr` transparency. The other fields (`ids: OwnedSlice<...>`,
-        // `offset: usize`) carry no `Rf`. Suspend preserves `'query` and only
-        // widens `Rf` (`Active<'index>` -> `Suspended`), so casting the box's heap
-        // pointer to the suspended counterpart is sound and preserves the box's
-        // heap allocation.
-        unsafe { Box::from_raw(raw as *mut RawIdList<'index, Suspended, SORTED>) }
+        // SAFETY: `slot` is non-null, aligned, and points to an initialized
+        // `RawIdList<'query, Suspended, SORTED>` (caller contract 1). `&raw mut` forms a
+        // field pointer without creating a reference, leaving `slot`'s provenance
+        // over the whole allocation intact for the cast below.
+        let result_slot = unsafe { &raw mut (*slot).result };
+        // SAFETY: all preconditions of `into_active_in_place` are met:
+        // 1. `result_slot` points at an initialized `RawIndexResult<'query, Suspended>`.
+        // 2. `result_slot` is not aliased (caller contract 2).
+        // 3. `into_active`'s preconditions hold trivially: thanks to the runtime kind check above,
+        //    the result is virtual or metric. Those variants own their data.
+        //    So conditions (1)–(4) range over no pointers and hold for any `'a`; the
+        //    `'query: 'a` bound covers any retained query-pipeline pointers.
+        unsafe { RawIndexResult::<'query, Suspended>::into_active_in_place::<'a>(result_slot) };
+        Ok(slot.cast::<IdList<'a, SORTED>>())
     }
 }
 
-impl<'query, const SORTED: bool> RQESuspendedIterator<'query> for RawIdList<'query, Suspended, SORTED> {
+impl<'index, const SORTED: bool> IdList<'index, SORTED> {
+    /// Suspend the active id list at `slot` in place, converting its `result`
+    /// field to its [`Suspended`] form without moving the allocation. Returns the
+    /// same slot reinterpreted as the [`SuspendedIdList`].
+    ///
+    /// Splitting this out (rather than a whole-struct pointer cast) lets the
+    /// wrapping iterators ([`Metric`](crate::metric::Metric), the lazy variants)
+    /// recurse through the canonical [`RSIndexResult::into_suspended`] conversion
+    /// for the `result` field, and keeps the allocation stable.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that:
+    ///
+    /// 1. `slot` is non-null, aligned, and points to an initialized
+    ///    `IdList<'index, SORTED>`.
+    /// 2. `slot` is unaliased for the duration of the call.
+    pub(crate) unsafe fn suspend_in_place(slot: *mut Self) -> *mut SuspendedIdList<'index, SORTED> {
+        // SAFETY: `slot` is non-null, aligned, and initialized (caller contract 1).
+        // `&raw mut` forms a field pointer without creating a reference, leaving
+        // `slot`'s provenance over the whole allocation intact for the cast below.
+        let result_slot = unsafe { &raw mut (*slot).result };
+        // SAFETY: `into_suspended_in_place`'s contract is met — `result_slot` points at
+        // an initialized `RSIndexResult<'index>` and is not aliased (caller contracts
+        // 1 and 2). Suspending is a safe widening conversion with no further precondition.
+        unsafe { RawIndexResult::<Active<'index>>::into_suspended_in_place(result_slot) };
+
+        slot.cast::<SuspendedIdList<'index, SORTED>>()
+    }
+}
+
+impl<'index, const SORTED: bool> RQEIteratorBoxed<'index> for IdList<'index, SORTED> {
+    type Suspended = SuspendedIdList<'index, SORTED>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let active: *mut Self = Box::into_raw(self);
+
+        // SAFETY: `suspend_in_place`'s contract is met — `active` is non-null, aligned, and
+        // initialized (it just came from a `Box`), and unaliased (this function owns `self`).
+        let suspended_ptr = unsafe { IdList::<'index, SORTED>::suspend_in_place(active) };
+
+        // SAFETY: `suspended_ptr` reuses the same allocation from `Box::into_raw` above, so the
+        // address is unchanged and every field is now valid at the suspended type.
+        unsafe { Box::from_raw(suspended_ptr) }
+    }
+}
+
+impl<'query, const SORTED: bool> RQESuspendedIterator<'query> for SuspendedIdList<'query, SORTED> {
     type Resumed<'index>
         = IdList<'index, SORTED>
     where
@@ -340,15 +466,25 @@ impl<'query, const SORTED: bool> RQESuspendedIterator<'query> for RawIdList<'que
     where
         'query: 'index,
     {
-        let raw = Box::into_raw(self);
-        // SAFETY: layout-compatible — see `suspend`. `IdList` owns its data
-        // entirely (the `OwnedSlice<DocId>`) and the virtual `result` has
-        // no aliased pointers, so promoting back to `Active<'index>` is
-        // unconditionally sound (the `'query: 'index` bound keeps any retained
-        // query-pipeline pointers valid). Box::from_raw reuses the same heap
-        // allocation as suspend's Box::into_raw.
-        let active = unsafe { Box::from_raw(raw as *mut IdList<'index, SORTED>) };
-        Ok(ResumeOutcome::Ok(active))
+        let suspended: *mut Self = Box::into_raw(self);
+
+        // SAFETY: `resume_in_place`'s contract is met:
+        // 1. `suspended` is non-null, aligned, and initialized — it just came from a `Box`.
+        // 2. `suspended` is not aliased, since this function has ownership of `self`.
+        match unsafe { SuspendedIdList::<'query, SORTED>::resume_in_place::<'index>(suspended) } {
+            Ok(active_ptr) => {
+                // SAFETY: `active_ptr` reuses the same allocation from `Box::into_raw` above, so
+                // the address is unchanged and every field is now valid at the active type for
+                // `'index`.
+                Ok(ResumeOutcome::Ok(unsafe { Box::from_raw(active_ptr) }))
+            }
+            Err(suspended_ptr) => {
+                // SAFETY: `suspended_ptr` is the same allocation, left untouched and still a valid
+                // `SuspendedIdList`. Reclaim ownership so it is dropped.
+                drop(unsafe { Box::from_raw(suspended_ptr) });
+                Ok(ResumeOutcome::Aborted)
+            }
+        }
     }
 
     fn last_doc_id(&self) -> DocId {

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -11,12 +11,13 @@
 
 use index_result::{RSIndexResult, RawIndexResult};
 use index_spec::IndexSpecReadGuard;
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 use std::cmp::Ordering;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
     profile_print::{ProfilePrint, ProfilePrintCtx},
     utils::OwnedSlice,
 };
@@ -297,5 +298,60 @@ impl<const SORTED: bool> ProfilePrint for IdList<'_, SORTED> {
         } else {
             ctx.print_leaf(c"ID-LIST-UNSORTED", map);
         }
+    }
+}
+
+impl<'query, Rf: Ref, const SORTED: bool> RawIdList<'query, Rf, SORTED> {
+    /// Read `result.doc_id` without exposing the private `result` field to
+    /// other modules. Used by [`Metric`](crate::metric::Metric)'s
+    /// [`RQESuspendedIterator`] impl, which can't reach into the inner
+    /// `RawIdList` directly.
+    pub(crate) const fn suspended_result_doc_id(s: &Self) -> DocId {
+        s.result.doc_id
+    }
+}
+
+impl<'index, const SORTED: bool> RQEIteratorBoxed<'index> for IdList<'index, SORTED> {
+    type Suspended = RawIdList<'index, Suspended, SORTED>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawIdList` is `#[repr(C)]`. The only `Rf`-dependent field
+        // is `result: RawIndexResult<'index, Rf>`, layout-compatible across `Rf` via
+        // `SharedPtr` transparency. The other fields (`ids: OwnedSlice<...>`,
+        // `offset: usize`) carry no `Rf`. Suspend preserves `'query` and only
+        // widens `Rf` (`Active<'index>` -> `Suspended`), so casting the box's heap
+        // pointer to the suspended counterpart is sound and preserves the box's
+        // heap allocation.
+        unsafe { Box::from_raw(raw as *mut RawIdList<'index, Suspended, SORTED>) }
+    }
+}
+
+impl<'query, const SORTED: bool> RQESuspendedIterator<'query> for RawIdList<'query, Suspended, SORTED> {
+    type Resumed<'index>
+        = IdList<'index, SORTED>
+    where
+        'query: 'index;
+
+    fn resume<'index>(
+        self: Box<Self>,
+        _guard: &IndexSpecReadGuard<'index>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'index>>>, RQEIteratorError>
+    where
+        'query: 'index,
+    {
+        let raw = Box::into_raw(self);
+        // SAFETY: layout-compatible — see `suspend`. `IdList` owns its data
+        // entirely (the `OwnedSlice<DocId>`) and the virtual `result` has
+        // no aliased pointers, so promoting back to `Active<'index>` is
+        // unconditionally sound (the `'query: 'index` bound keeps any retained
+        // query-pipeline pointers valid). Box::from_raw reuses the same heap
+        // allocation as suspend's Box::into_raw.
+        let active = unsafe { Box::from_raw(raw as *mut IdList<'index, SORTED>) };
+        Ok(ResumeOutcome::Ok(active))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        Self::suspended_result_doc_id(self)
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -490,4 +490,8 @@ impl<'query, const SORTED: bool> RQESuspendedIterator<'query> for SuspendedIdLis
     fn last_doc_id(&self) -> DocId {
         Self::suspended_result_doc_id(self)
     }
+
+    fn num_estimated(&self) -> usize {
+        self._num_estimated()
+    }
 }

--- a/src/redisearch_rs/rqe_iterators/src/id_list_lazy.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list_lazy.rs
@@ -49,7 +49,10 @@ pub struct RawIdListLazy<'query, Rf: Ref, const SORTED: bool> {
     num_estimated_hint: usize,
 }
 
+/// Alias for an [`Active`] [`RawIdListLazy`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
 pub type IdListLazy<'index, const SORTED: bool> = RawIdListLazy<'index, Active<'index>, SORTED>;
+/// Alias for a [`Suspended`] [`RawIdListLazy`].
 pub type SuspendedIdListLazy<'query, const SORTED: bool> = RawIdListLazy<'query, Suspended, SORTED>;
 
 // Compile-time proof that the `IdListLazy` and its suspended counterpart are layout-identical.

--- a/src/redisearch_rs/rqe_iterators/src/id_list_lazy.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list_lazy.rs
@@ -11,12 +11,14 @@
 
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
+use ref_mode::Suspended;
 use rqe_core::DocId;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
     deferred::{ProducedResults, Producer},
-    id_list::IdList,
+    id_list::{IdList, RawIdList},
     profile_print::{ProfilePrint, ProfilePrintCtx},
     utils::OwnedSlice,
 };
@@ -28,6 +30,11 @@ use crate::{
 ///
 /// Once produced it delegates entirely to the wrapped [`IdList`], so it reports the same
 /// [`IteratorType`] and is interchangeable with an eagerly-built one.
+///
+/// `#[repr(C)]` so it is layout-compatible with its suspended counterpart
+/// [`IdListLazySuspended`], enabling the allocation-preserving whole-struct cast
+/// in [`RQEIteratorBoxed::suspend`].
+#[repr(C)]
 pub struct IdListLazy<'index, const SORTED: bool> {
     /// The wrapped ID list, empty until [`producer`](Self::producer) runs.
     inner: IdList<'index, SORTED>,
@@ -143,5 +150,75 @@ impl<'index, const SORTED: bool> RQEIterator<'index> for IdListLazy<'index, SORT
 impl<const SORTED: bool> ProfilePrint for IdListLazy<'_, SORTED> {
     fn print_profile(&self, map: &mut redis_reply::MapBuilder<'_>, ctx: &mut ProfilePrintCtx<'_>) {
         self.inner.print_profile(map, ctx);
+    }
+}
+
+/// Suspended counterpart of [`IdListLazy`], used as its
+/// [`RQEIteratorBoxed::Suspended`] type.
+///
+/// Layout-compatible with [`IdListLazy`] — both are `#[repr(C)]` with the same
+/// field order. The only differing field is the inner list: the active
+/// `RawIdList<Active, _>` is layout-compatible with `RawIdList<Suspended, _>`
+/// (see [`IdList`]'s [`RQEIteratorBoxed::suspend`]). The `producer`,
+/// `produced`, and `num_estimated_hint` fields are identical — in particular the
+/// producer is `Producer<'static>` on both sides (it captures only raw C pointers
+/// and C function pointers, never Rust references — see the
+/// `NewLazyVectorRangeIterator` FFI constructor), so the whole-struct cast touches
+/// no lifetime.
+#[repr(C)]
+pub struct IdListLazySuspended<'query, const SORTED: bool> {
+    inner: RawIdList<'query, Suspended, SORTED>,
+    producer: Producer<'static>,
+    produced: bool,
+    num_estimated_hint: usize,
+}
+
+impl<'index, const SORTED: bool> RQEIteratorBoxed<'index> for IdListLazy<'index, SORTED> {
+    type Suspended = IdListLazySuspended<'index, SORTED>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `IdListLazy` and `IdListLazySuspended` are both `#[repr(C)]` with
+        // identical field layout: the inner `RawIdList<Active, _>` is layout-compatible
+        // with `RawIdList<Suspended, _>` (see `IdList::suspend`), the `producer` field is
+        // `Producer<'static>` on both sides, and `produced`/`num_estimated_hint` carry no
+        // lifetime. Casting the box's heap pointer preserves the allocation, so any
+        // interior pointers into the inner list's result stay valid across the
+        // suspend/resume cycle.
+        unsafe { Box::from_raw(raw as *mut IdListLazySuspended<'index, SORTED>) }
+    }
+}
+
+impl<'query, const SORTED: bool> RQESuspendedIterator<'query> for IdListLazySuspended<'query, SORTED> {
+    type Resumed<'index>
+        = IdListLazy<'index, SORTED>
+    where
+        'query: 'index;
+
+    fn resume<'index>(
+        self: Box<Self>,
+        _guard: &IndexSpecReadGuard<'index>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'index>>>, RQEIteratorError>
+    where
+        'query: 'index,
+    {
+        let raw = Box::into_raw(self);
+        // SAFETY: layout-compatible — see `suspend`. The inner list owns all its data
+        // (the `OwnedSlice<DocId>`) and the virtual result has no aliased pointers, so
+        // promoting it back to `Active<'index>` is unconditionally sound (`'query: 'index`
+        // keeps any retained query-pipeline pointers valid). `Box::from_raw` reuses the
+        // same heap allocation as `suspend`'s `Box::into_raw`.
+        let active = unsafe { Box::from_raw(raw as *mut IdListLazy<'index, SORTED>) };
+        Ok(ResumeOutcome::Ok(active))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        RawIdList::<'query, Suspended, SORTED>::suspended_result_doc_id(&self.inner)
+    }
+
+    fn num_estimated(&self) -> usize {
+        // Snapshot from construction; the real count is only known once the producer
+        // has run. Acceptable for the FFI display-only consumer.
+        self.num_estimated_hint
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/id_list_lazy.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list_lazy.rs
@@ -11,14 +11,14 @@
 
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use ref_mode::Suspended;
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    IdList, IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
     RQEValidateStatus, ResumeOutcome, SkipToOutcome,
     deferred::{ProducedResults, Producer},
-    id_list::{IdList, RawIdList},
+    id_list::{RawIdList, SuspendedIdList},
     profile_print::{ProfilePrint, ProfilePrintCtx},
     utils::OwnedSlice,
 };
@@ -31,20 +31,16 @@ use crate::{
 /// Once produced it delegates entirely to the wrapped [`IdList`], so it reports the same
 /// [`IteratorType`] and is interchangeable with an eagerly-built one.
 ///
-/// `#[repr(C)]` so it is layout-compatible with its suspended counterpart
-/// [`IdListLazySuspended`], enabling the allocation-preserving whole-struct cast
+/// `#[repr(C)]` so the active/suspended versions are layout-compatible, enabling the
+/// allocation-preserving whole-struct cast
 /// in [`RQEIteratorBoxed::suspend`].
 #[repr(C)]
-pub struct IdListLazy<'index, const SORTED: bool> {
+pub struct RawIdListLazy<'query, Rf: Ref, const SORTED: bool> {
     /// The wrapped ID list, empty until [`producer`](Self::producer) runs.
-    inner: IdList<'index, SORTED>,
+    inner: RawIdList<'query, Rf, SORTED>,
     /// The deferred producer. Run once on the first read/skip_to (guarded by
     /// [`produced`](Self::produced)) but **retained** so any state it owns lives as long as this
     /// iterator (see [`Producer`]).
-    ///
-    /// `'static` rather than `'index`: the deferred producer captures only raw C pointers and C
-    /// function pointers (never Rust references — see the `NewLazyVectorRangeIterator` FFI
-    /// constructor), so it borrows nothing tied to `'index`.
     producer: Producer<'static>,
     /// Whether [`producer`](Self::producer) has already run.
     produced: bool,
@@ -52,6 +48,27 @@ pub struct IdListLazy<'index, const SORTED: bool> {
     /// unknown until it runs).
     num_estimated_hint: usize,
 }
+
+pub type IdListLazy<'index, const SORTED: bool> = RawIdListLazy<'index, Active<'index>, SORTED>;
+pub type SuspendedIdListLazy<'query, const SORTED: bool> = RawIdListLazy<'query, Suspended, SORTED>;
+
+// Compile-time proof that the `IdListLazy` and its suspended counterpart are layout-identical.
+const _: () = {
+    use std::mem::offset_of;
+
+    const SORTED: bool = true;
+    type A<'a> = IdListLazy<'a, SORTED>;
+    type S<'a> = SuspendedIdListLazy<'a, SORTED>;
+
+    // Every field starts at the same offset.
+    assert!(offset_of!(A, inner) == offset_of!(S, inner));
+    assert!(offset_of!(A, producer) == offset_of!(S, producer));
+    assert!(offset_of!(A, produced) == offset_of!(S, produced));
+    assert!(offset_of!(A, num_estimated_hint) == offset_of!(S, num_estimated_hint));
+
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
 
 impl<'index, const SORTED: bool> IdListLazy<'index, SORTED> {
     /// Create a lazy ID list. `result` is the reusable result object the inner list yields,
@@ -83,6 +100,17 @@ impl<'index, const SORTED: bool> IdListLazy<'index, SORTED> {
     }
 }
 
+impl<'query, Rf: Ref, const SORTED: bool> RawIdListLazy<'query, Rf, SORTED> {
+    #[inline(always)]
+    fn _num_estimated(&self) -> usize {
+        if self.produced {
+            self.inner._num_estimated()
+        } else {
+            self.num_estimated_hint
+        }
+    }
+}
+
 impl<'index, const SORTED: bool> RQEIterator<'index> for IdListLazy<'index, SORTED> {
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
@@ -109,11 +137,7 @@ impl<'index, const SORTED: bool> RQEIterator<'index> for IdListLazy<'index, SORT
 
     #[inline(always)]
     fn num_estimated(&self) -> usize {
-        if self.produced {
-            self.inner.num_estimated()
-        } else {
-            self.num_estimated_hint
-        }
+        self._num_estimated()
     }
 
     #[inline(always)]
@@ -141,6 +165,7 @@ impl<'index, const SORTED: bool> RQEIterator<'index> for IdListLazy<'index, SORT
         self.inner.type_()
     }
 
+    #[inline(always)]
     fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
         self.inner
             .intersection_sort_weight(prioritize_union_children)
@@ -153,43 +178,33 @@ impl<const SORTED: bool> ProfilePrint for IdListLazy<'_, SORTED> {
     }
 }
 
-/// Suspended counterpart of [`IdListLazy`], used as its
-/// [`RQEIteratorBoxed::Suspended`] type.
-///
-/// Layout-compatible with [`IdListLazy`] — both are `#[repr(C)]` with the same
-/// field order. The only differing field is the inner list: the active
-/// `RawIdList<Active, _>` is layout-compatible with `RawIdList<Suspended, _>`
-/// (see [`IdList`]'s [`RQEIteratorBoxed::suspend`]). The `producer`,
-/// `produced`, and `num_estimated_hint` fields are identical — in particular the
-/// producer is `Producer<'static>` on both sides (it captures only raw C pointers
-/// and C function pointers, never Rust references — see the
-/// `NewLazyVectorRangeIterator` FFI constructor), so the whole-struct cast touches
-/// no lifetime.
-#[repr(C)]
-pub struct IdListLazySuspended<'query, const SORTED: bool> {
-    inner: RawIdList<'query, Suspended, SORTED>,
-    producer: Producer<'static>,
-    produced: bool,
-    num_estimated_hint: usize,
-}
-
 impl<'index, const SORTED: bool> RQEIteratorBoxed<'index> for IdListLazy<'index, SORTED> {
-    type Suspended = IdListLazySuspended<'index, SORTED>;
+    type Suspended = SuspendedIdListLazy<'index, SORTED>;
 
     fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
-        let raw = Box::into_raw(self);
-        // SAFETY: `IdListLazy` and `IdListLazySuspended` are both `#[repr(C)]` with
-        // identical field layout: the inner `RawIdList<Active, _>` is layout-compatible
-        // with `RawIdList<Suspended, _>` (see `IdList::suspend`), the `producer` field is
-        // `Producer<'static>` on both sides, and `produced`/`num_estimated_hint` carry no
-        // lifetime. Casting the box's heap pointer preserves the allocation, so any
-        // interior pointers into the inner list's result stay valid across the
-        // suspend/resume cycle.
-        unsafe { Box::from_raw(raw as *mut IdListLazySuspended<'index, SORTED>) }
+        let active = Box::into_raw(self);
+
+        // Suspend the wrapped id list in place, leaving the outer
+        // allocation (and the `Rf`-independent `producer`) untouched.
+        //
+        // SAFETY: `&raw mut` forms a field pointer without creating a reference,
+        // preserving `active`'s provenance over the whole allocation for the outer
+        // cast below.
+        let inner_slot = unsafe { &raw mut (*active).inner };
+        // SAFETY: `suspend_in_place`'s contract is met — `inner_slot` is initialized and
+        // unaliased (this function owns `self`). Suspending is a safe widening conversion.
+        unsafe { IdList::<'index, SORTED>::suspend_in_place(inner_slot) };
+
+        // SAFETY: `IdListLazy` and `SuspendedIdListLazy` are both `#[repr(C)]` with identical
+        // field layout. `Box::from_raw` reuses the same heap allocation as `Box::into_raw`,
+        // so the address is unchanged.
+        unsafe { Box::from_raw(active.cast::<SuspendedIdListLazy<'index, SORTED>>()) }
     }
 }
 
-impl<'query, const SORTED: bool> RQESuspendedIterator<'query> for IdListLazySuspended<'query, SORTED> {
+impl<'query, const SORTED: bool> RQESuspendedIterator<'query>
+    for SuspendedIdListLazy<'query, SORTED>
+{
     type Resumed<'index>
         = IdListLazy<'index, SORTED>
     where
@@ -202,14 +217,38 @@ impl<'query, const SORTED: bool> RQESuspendedIterator<'query> for IdListLazySusp
     where
         'query: 'index,
     {
-        let raw = Box::into_raw(self);
-        // SAFETY: layout-compatible — see `suspend`. The inner list owns all its data
-        // (the `OwnedSlice<DocId>`) and the virtual result has no aliased pointers, so
-        // promoting it back to `Active<'index>` is unconditionally sound (`'query: 'index`
-        // keeps any retained query-pipeline pointers valid). `Box::from_raw` reuses the
-        // same heap allocation as `suspend`'s `Box::into_raw`.
-        let active = unsafe { Box::from_raw(raw as *mut IdListLazy<'index, SORTED>) };
-        Ok(ResumeOutcome::Ok(active))
+        let suspended = Box::into_raw(self);
+
+        // Promote the wrapped id list's `result` field in place, leaving the outer
+        // allocation (and the `Rf`-independent `producer`) untouched.
+        //
+        // SAFETY: `&raw mut` forms a field pointer without creating a reference,
+        // preserving `suspended`'s provenance over the whole allocation for the
+        // outer cast below.
+        let inner_slot = unsafe { &raw mut (*suspended).inner };
+        // SAFETY: `resume_in_place`'s contract is met — `inner_slot` is initialized and
+        // unaliased (this function owns `self`). We reclaim the outer allocation via `suspended`
+        // in either branch, so the inner pointer it returns is not needed.
+        match unsafe { SuspendedIdList::<'query, SORTED>::resume_in_place::<'index>(inner_slot) } {
+            Ok(_) => {
+                // SAFETY: layout-compatible — see `suspend`. `inner`'s `result` is now valid at
+                // the active type for `'index`; the remaining fields carry no `Rf`. `Box::from_raw`
+                // reuses the same heap allocation as `suspend`'s `Box::into_raw`, so the address
+                // is unchanged.
+                let active =
+                    unsafe { Box::from_raw(suspended.cast::<IdListLazy<'index, SORTED>>()) };
+                Ok(ResumeOutcome::Ok(active))
+            }
+            Err(_) => {
+                // `resume_in_place` left the inner id list untouched (the stored result kind was
+                // neither metric nor virtual), so the outer allocation is still a valid
+                // `SuspendedIdListLazy`.
+                // SAFETY: `suspended` came from `Box::into_raw` above and was not mutated; reclaim
+                // ownership so it is dropped.
+                drop(unsafe { Box::from_raw(suspended) });
+                Ok(ResumeOutcome::Aborted)
+            }
+        }
     }
 
     fn last_doc_id(&self) -> DocId {
@@ -217,8 +256,6 @@ impl<'query, const SORTED: bool> RQESuspendedIterator<'query> for IdListLazySusp
     }
 
     fn num_estimated(&self) -> usize {
-        // Snapshot from construction; the real count is only known once the producer
-        // has run. Acceptable for the FFI display-only consumer.
-        self.num_estimated_hint
+        self._num_estimated()
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -72,12 +72,15 @@ pub use empty::Empty;
 pub use expiration_checker::{ExpirationChecker, FieldExpirationChecker, NoOpChecker};
 pub use geo_shape::{GeoShape, MemTracker, NoTracker};
 pub use id_list::IdList;
+pub use id_list_lazy::IdListLazy;
 pub use intersection::{Intersection, NewIntersectionIterator, new_intersection_iterator};
 pub use inverted_index::{
     GeoRangeError, InvalidGeoInput, Missing, Numeric, NumericIteratorVariant, Tag, Term,
     build_geo_numeric_filters, build_geo_range_iterator, build_numeric_filter_iterator,
     extract_geo_unit_factor, new_geo_range_iterator, open_numeric_or_geo_index,
 };
+pub use metric::Metric;
+pub use metric_lazy::MetricLazy;
 pub use resume_outcome::ResumeOutcome;
 pub use rqe_iterator_type::IteratorType;
 pub use union::{

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -12,7 +12,7 @@
 use crate::{
     IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
     RQEValidateStatus, ResumeOutcome, SkipToOutcome,
-    id_list::{IdList, RawIdList},
+    id_list::{IdList, RawIdList, SuspendedIdList},
     profile_print::{ProfilePrint, ProfilePrintCtx},
     utils::OwnedSlice,
 };
@@ -61,9 +61,38 @@ pub struct RawMetric<'query, Rf: Ref, const SORTED_BY_ID: bool> {
     key_handle: *mut RLookupKeyHandle,
 }
 
+// Compile-time proof that the `Metric` and its suspended counterpart are layout-identical.
+const _: () = {
+    use std::mem::offset_of;
+
+    const SORTED_BY_ID: bool = true;
+    type A<'a> = Metric<'a, SORTED_BY_ID>;
+    type S<'a> = RawMetric<'a, Suspended, SORTED_BY_ID>;
+
+    // Every field starts at the same offset.
+    assert!(offset_of!(A, base) == offset_of!(S, base));
+    assert!(offset_of!(A, metric_data) == offset_of!(S, metric_data));
+    assert!(offset_of!(A, type_) == offset_of!(S, type_));
+    assert!(offset_of!(A, own_key) == offset_of!(S, own_key));
+    assert!(offset_of!(A, key_handle) == offset_of!(S, key_handle));
+
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
 /// Alias for an [`Active`] [`RawMetric`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
 pub type Metric<'index, const SORTED_BY_ID: bool> = RawMetric<'index, Active<'index>, SORTED_BY_ID>;
+/// Alias for a [`Suspended`] [`RawMetric`].
+pub type SuspendedMetric<'query, const SORTED_BY_ID: bool> =
+    RawMetric<'query, Suspended, SORTED_BY_ID>;
+
+impl<'query, Rf: Ref, const SORTED_BY_ID: bool> RawMetric<'query, Rf, SORTED_BY_ID> {
+    #[inline(always)]
+    pub(super) fn _num_estimated(&self) -> usize {
+        self.base._num_estimated()
+    }
+}
 
 impl<'query, Rf: Ref, const SORTED_BY_ID: bool> Drop for RawMetric<'query, Rf, SORTED_BY_ID> {
     fn drop(&mut self) {
@@ -210,7 +239,7 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for Metric<'index, SO
     #[inline(always)]
     // This should always return total results from the iterator, even after some yields.
     fn num_estimated(&self) -> usize {
-        self.base.num_estimated()
+        self._num_estimated()
     }
 
     #[inline(always)]
@@ -273,34 +302,100 @@ impl<const SORTED_BY_ID: bool> ProfilePrint for Metric<'_, SORTED_BY_ID> {
 impl<'query, const SORTED_BY_ID: bool> RawMetric<'query, Suspended, SORTED_BY_ID> {
     /// Read the suspended iterator's `doc_id` without exposing the private
     /// `base` field to other modules. Used by
-    /// [`MetricLazySuspended`](crate::metric_lazy::MetricLazySuspended)'s
+    /// [`SuspendedMetricLazy`](crate::metric_lazy::SuspendedMetricLazy)'s
     /// [`RQESuspendedIterator`] impl, which can't reach into the inner
     /// `RawMetric` directly.
-    pub(crate) fn suspended_result_doc_id(&self) -> DocId {
+    pub(crate) const fn suspended_result_doc_id(&self) -> DocId {
         RawIdList::<'query, Suspended, SORTED_BY_ID>::suspended_result_doc_id(&self.base)
     }
 }
 
+impl<'index, const SORTED_BY_ID: bool> Metric<'index, SORTED_BY_ID> {
+    /// Suspend the active metric at `slot` in place.
+    /// Returns the same slot reinterpreted as the suspended `RawMetric`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that:
+    ///
+    /// 1. `slot` is non-null, aligned, and points to an initialized
+    ///    `Metric<'index, SORTED_BY_ID>`.
+    /// 2. `slot` is unaliased for the duration of the call.
+    pub(crate) unsafe fn suspend_in_place(
+        slot: *mut Self,
+    ) -> *mut SuspendedMetric<'index, SORTED_BY_ID> {
+        // SAFETY: `slot` is non-null, aligned, and initialized (caller contract 1).
+        // `&raw mut` forms a field pointer without creating a reference, leaving
+        // `slot`'s provenance over the whole allocation intact for the cast below.
+        let base_slot = unsafe { &raw mut (*slot).base };
+        // SAFETY: `IdList::suspend_in_place`'s contract is met — `base_slot` is
+        // initialized and unaliased (caller contracts 1 and 2).
+        unsafe { IdList::<'index, SORTED_BY_ID>::suspend_in_place(base_slot) };
+
+        slot.cast::<SuspendedMetric<'index, SORTED_BY_ID>>()
+    }
+}
+
 impl<'index, const SORTED_BY_ID: bool> RQEIteratorBoxed<'index> for Metric<'index, SORTED_BY_ID> {
-    type Suspended = RawMetric<'index, Suspended, SORTED_BY_ID>;
+    type Suspended = SuspendedMetric<'index, SORTED_BY_ID>;
 
     fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
-        let raw = Box::into_raw(self);
-        // SAFETY: `RawMetric` is `#[repr(C)]`. The only `Rf`-dependent field
-        // is the inner `RawIdList<'index, Rf, SORTED_BY_ID>`, layout-compatible
-        // across `Rf` (its only `Rf` field is `result: RawIndexResult<'index, Rf>`,
-        // backed by `SharedPtr` transparency). The remaining fields
-        // (`metric_data`, `type_`, `own_key`, `key_handle`) carry no `Rf`.
-        // Suspend preserves `'query` and only widens `Rf`, so casting the box's
-        // heap pointer is sound and preserves the heap allocation; the active
-        // `Drop` impl (`key_handle` nullification) does not run on these bytes —
-        // ownership of the allocation transfers to the suspended box.
-        unsafe { Box::from_raw(raw as *mut RawMetric<'index, Suspended, SORTED_BY_ID>) }
+        let active: *mut Self = Box::into_raw(self);
+
+        // SAFETY: `suspend_in_place`'s contract is met — `active` is non-null, aligned, and
+        // initialized (it just came from a `Box`), and unaliased (this function owns `self`).
+        let suspended_ptr = unsafe { Metric::<'index, SORTED_BY_ID>::suspend_in_place(active) };
+
+        // SAFETY: `suspended_ptr` reuses the same allocation from `Box::into_raw` above, so the
+        // address is unchanged and every field is now valid at the suspended type.
+        unsafe { Box::from_raw(suspended_ptr) }
+    }
+}
+
+impl<'query, const SORTED_BY_ID: bool> SuspendedMetric<'query, SORTED_BY_ID> {
+    /// Resume the suspended metric at `slot` in place, promoting its wrapped
+    /// [`base`](Self::base) id list to `Active<'a>` without moving the allocation.
+    ///
+    /// On success returns `Ok(ptr)`, the same slot reinterpreted as the active
+    /// [`Metric`]. If the stored result kind is neither metric nor virtual it
+    /// returns `Err(ptr)` — the same slot, **left untouched and still a valid
+    /// [`SuspendedMetric`]** — with a warning logged by the wrapped id list; see
+    /// [`SuspendedIdList::resume_in_place`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that:
+    ///
+    /// 1. `slot` is non-null, aligned, and points to an initialized
+    ///    `RawMetric<'query, Suspended, SORTED_BY_ID>`.
+    /// 2. `slot` is unaliased for the duration of the call.
+    ///
+    /// The returned pointer aliases `slot`. In the `Ok` case every field is valid
+    /// at the active type for `'a`; in the `Err` case the slot is byte-for-byte
+    /// unchanged and remains a valid `SuspendedMetric<'query, SORTED_BY_ID>`.
+    pub(crate) unsafe fn resume_in_place<'a>(
+        slot: *mut Self,
+    ) -> Result<*mut Metric<'a, SORTED_BY_ID>, *mut Self>
+    where
+        'query: 'a,
+    {
+        // SAFETY: `slot` is non-null, aligned, and initialized (caller contract 1).
+        // `&raw mut` forms a field pointer without creating a reference, leaving
+        // `slot`'s provenance over the whole allocation intact for the casts below.
+        let base_slot = unsafe { &raw mut (*slot).base };
+        // SAFETY: `SuspendedIdList::resume_in_place`'s contract is met — `base_slot`
+        // is initialized and unaliased (caller contracts 1 and 2).
+        match unsafe { SuspendedIdList::<'query, SORTED_BY_ID>::resume_in_place::<'a>(base_slot) } {
+            // The base id list was resumed in place; the rest of the metric carries no `Rf`.
+            Ok(_) => Ok(slot.cast::<Metric<'a, SORTED_BY_ID>>()),
+            // The base — and therefore the whole metric slot — was left untouched.
+            Err(_) => Err(slot),
+        }
     }
 }
 
 impl<'query, const SORTED_BY_ID: bool> RQESuspendedIterator<'query>
-    for RawMetric<'query, Suspended, SORTED_BY_ID>
+    for SuspendedMetric<'query, SORTED_BY_ID>
 {
     type Resumed<'index>
         = Metric<'index, SORTED_BY_ID>
@@ -314,18 +409,34 @@ impl<'query, const SORTED_BY_ID: bool> RQESuspendedIterator<'query>
     where
         'query: 'index,
     {
-        let raw = Box::into_raw(self);
-        // SAFETY: layout-compatible — see `suspend`. `Metric` owns all its
-        // pointee data (the `OwnedSlice` and the inner `IdList`'s
-        // `OwnedSlice`); the virtual `result` has no aliased pointers, so
-        // promotion back to `Active<'index>` is unconditionally sound (the
-        // `'query: 'index` bound keeps any retained query-pipeline pointers
-        // valid) and re-uses the same heap allocation.
-        let active = unsafe { Box::from_raw(raw as *mut Metric<'index, SORTED_BY_ID>) };
-        Ok(ResumeOutcome::Ok(active))
+        let suspended: *mut Self = Box::into_raw(self);
+
+        // SAFETY: `resume_in_place`'s contract is met:
+        // 1. `suspended` is non-null, aligned, and initialized — it just came from a `Box`.
+        // 2. `suspended` is not aliased, since this function has ownership of `self`.
+        match unsafe {
+            SuspendedMetric::<'query, SORTED_BY_ID>::resume_in_place::<'index>(suspended)
+        } {
+            Ok(active_ptr) => {
+                // SAFETY: `active_ptr` reuses the same allocation from `Box::into_raw` above, so
+                // the address is unchanged and every field is now valid at the active type for
+                // `'index`.
+                Ok(ResumeOutcome::Ok(unsafe { Box::from_raw(active_ptr) }))
+            }
+            Err(suspended_ptr) => {
+                // SAFETY: `suspended_ptr` is the same allocation, left untouched and still a valid
+                // `SuspendedMetric`. Reclaim ownership so it is dropped.
+                drop(unsafe { Box::from_raw(suspended_ptr) });
+                Ok(ResumeOutcome::Aborted)
+            }
+        }
     }
 
     fn last_doc_id(&self) -> DocId {
         self.suspended_result_doc_id()
+    }
+
+    fn num_estimated(&self) -> usize {
+        self._num_estimated()
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -10,7 +10,8 @@
 //! Supporting types for [`Metric`].
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
     id_list::{IdList, RawIdList},
     profile_print::{ProfilePrint, ProfilePrintCtx},
     utils::OwnedSlice,
@@ -18,7 +19,7 @@ use crate::{
 use ffi::{RLookupKey, RLookupKeyHandle};
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
 /// The different types of metrics.
@@ -266,5 +267,65 @@ impl<const SORTED_BY_ID: bool> ProfilePrint for Metric<'_, SORTED_BY_ID> {
         if matches!(metric_type, MetricType::VectorDistance) {
             map.kv_simple_string(c"Vector search mode", c"RANGE_QUERY");
         }
+    }
+}
+
+impl<'query, const SORTED_BY_ID: bool> RawMetric<'query, Suspended, SORTED_BY_ID> {
+    /// Read the suspended iterator's `doc_id` without exposing the private
+    /// `base` field to other modules. Used by
+    /// [`MetricLazySuspended`](crate::metric_lazy::MetricLazySuspended)'s
+    /// [`RQESuspendedIterator`] impl, which can't reach into the inner
+    /// `RawMetric` directly.
+    pub(crate) fn suspended_result_doc_id(&self) -> DocId {
+        RawIdList::<'query, Suspended, SORTED_BY_ID>::suspended_result_doc_id(&self.base)
+    }
+}
+
+impl<'index, const SORTED_BY_ID: bool> RQEIteratorBoxed<'index> for Metric<'index, SORTED_BY_ID> {
+    type Suspended = RawMetric<'index, Suspended, SORTED_BY_ID>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawMetric` is `#[repr(C)]`. The only `Rf`-dependent field
+        // is the inner `RawIdList<'index, Rf, SORTED_BY_ID>`, layout-compatible
+        // across `Rf` (its only `Rf` field is `result: RawIndexResult<'index, Rf>`,
+        // backed by `SharedPtr` transparency). The remaining fields
+        // (`metric_data`, `type_`, `own_key`, `key_handle`) carry no `Rf`.
+        // Suspend preserves `'query` and only widens `Rf`, so casting the box's
+        // heap pointer is sound and preserves the heap allocation; the active
+        // `Drop` impl (`key_handle` nullification) does not run on these bytes —
+        // ownership of the allocation transfers to the suspended box.
+        unsafe { Box::from_raw(raw as *mut RawMetric<'index, Suspended, SORTED_BY_ID>) }
+    }
+}
+
+impl<'query, const SORTED_BY_ID: bool> RQESuspendedIterator<'query>
+    for RawMetric<'query, Suspended, SORTED_BY_ID>
+{
+    type Resumed<'index>
+        = Metric<'index, SORTED_BY_ID>
+    where
+        'query: 'index;
+
+    fn resume<'index>(
+        self: Box<Self>,
+        _guard: &IndexSpecReadGuard<'index>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'index>>>, RQEIteratorError>
+    where
+        'query: 'index,
+    {
+        let raw = Box::into_raw(self);
+        // SAFETY: layout-compatible — see `suspend`. `Metric` owns all its
+        // pointee data (the `OwnedSlice` and the inner `IdList`'s
+        // `OwnedSlice`); the virtual `result` has no aliased pointers, so
+        // promotion back to `Active<'index>` is unconditionally sound (the
+        // `'query: 'index` bound keeps any retained query-pipeline pointers
+        // valid) and re-uses the same heap allocation.
+        let active = unsafe { Box::from_raw(raw as *mut Metric<'index, SORTED_BY_ID>) };
+        Ok(ResumeOutcome::Ok(active))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.suspended_result_doc_id()
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/metric_lazy.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric_lazy.rs
@@ -54,7 +54,11 @@ pub struct RawMetricLazy<'query, Rf: Ref, const SORTED_BY_ID: bool> {
     num_estimated_hint: usize,
 }
 
+/// Alias for an [`Active`] [`RawMetricLazy`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
 pub type MetricLazy<'index, const SORTED: bool> = RawMetricLazy<'index, Active<'index>, SORTED>;
+/// Alias for an [`Active`] [`RawMetricLazy`] — the only instantiation with an
+/// [`RQEIterator`] impl today.
 pub type SuspendedMetricLazy<'query, const SORTED: bool> = RawMetricLazy<'query, Suspended, SORTED>;
 
 // Compile-time proof that the `MetricLazy` and its suspended counterpart are layout-identical.

--- a/src/redisearch_rs/rqe_iterators/src/metric_lazy.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric_lazy.rs
@@ -9,19 +9,18 @@
 
 //! Supporting types for [`MetricLazy`].
 
+use crate::{
+    IteratorType, Metric, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+    deferred::{ProducedResults, Producer},
+    metric::{MetricType, RawMetric, SuspendedMetric},
+    profile_print::{ProfilePrint, ProfilePrintCtx},
+};
 use ffi::{RLookupKey, RLookupKeyHandle};
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use ref_mode::Suspended;
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
-
-use crate::{
-    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
-    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
-    deferred::{ProducedResults, Producer},
-    metric::{Metric, MetricType, RawMetric},
-    profile_print::{ProfilePrint, ProfilePrintCtx},
-};
 
 /// A lazily-populated metric iterator sorted by document id.
 pub type MetricLazySortedById<'index> = MetricLazy<'index, true>;
@@ -39,25 +38,42 @@ pub type MetricLazySortedByScore<'index> = MetricLazy<'index, false>;
 /// metric value is yielded against the same key.
 ///
 /// `#[repr(C)]` so it is layout-compatible with its suspended counterpart
-/// [`MetricLazySuspended`], enabling the allocation-preserving whole-struct
+/// [`SuspendedMetricLazy`], enabling the allocation-preserving whole-struct
 /// cast in [`RQEIteratorBoxed::suspend`].
 #[repr(C)]
-pub struct MetricLazy<'index, const SORTED_BY_ID: bool> {
+pub struct RawMetricLazy<'query, Rf: Ref, const SORTED_BY_ID: bool> {
     /// The wrapped metric iterator, empty until [`producer`](Self::producer) runs.
-    inner: Metric<'index, SORTED_BY_ID>,
+    inner: RawMetric<'query, Rf, SORTED_BY_ID>,
     /// The deferred producer. Run once on the first read/skip_to (guarded by
     /// [`produced`](Self::produced)) but **retained** so any state it owns lives as long as this
     /// iterator (see [`Producer`]).
-    ///
-    /// `'static` rather than `'index`: the deferred producer captures only raw C pointers and C
-    /// function pointers (never Rust references — see the `NewLazyVectorRangeIterator` FFI
-    /// constructor), so it borrows nothing tied to `'index`.
     producer: Producer<'static>,
     /// Whether [`producer`](Self::producer) has already run.
     produced: bool,
     /// Upper-bound estimate reported while the producer is still pending.
     num_estimated_hint: usize,
 }
+
+pub type MetricLazy<'index, const SORTED: bool> = RawMetricLazy<'index, Active<'index>, SORTED>;
+pub type SuspendedMetricLazy<'query, const SORTED: bool> = RawMetricLazy<'query, Suspended, SORTED>;
+
+// Compile-time proof that the `MetricLazy` and its suspended counterpart are layout-identical.
+const _: () = {
+    use std::mem::offset_of;
+
+    const SORTED: bool = true;
+    type A<'a> = MetricLazy<'a, SORTED>;
+    type S<'a> = SuspendedMetricLazy<'a, SORTED>;
+
+    // Every field starts at the same offset.
+    assert!(offset_of!(A, inner) == offset_of!(S, inner));
+    assert!(offset_of!(A, producer) == offset_of!(S, producer));
+    assert!(offset_of!(A, produced) == offset_of!(S, produced));
+    assert!(offset_of!(A, num_estimated_hint) == offset_of!(S, num_estimated_hint));
+
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
 
 impl<'index, const SORTED_BY_ID: bool> MetricLazy<'index, SORTED_BY_ID> {
     /// Create a lazy metric iterator. `num_estimated_hint` is the estimate reported until the
@@ -105,6 +121,17 @@ impl<'index, const SORTED_BY_ID: bool> MetricLazy<'index, SORTED_BY_ID> {
     }
 }
 
+impl<'query, Rf: Ref, const SORTED_BY_ID: bool> RawMetricLazy<'query, Rf, SORTED_BY_ID> {
+    #[inline(always)]
+    fn _num_estimated(&self) -> usize {
+        if self.produced {
+            self.inner._num_estimated()
+        } else {
+            self.num_estimated_hint
+        }
+    }
+}
+
 impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for MetricLazy<'index, SORTED_BY_ID> {
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
@@ -131,11 +158,7 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for MetricLazy<'index
 
     #[inline(always)]
     fn num_estimated(&self) -> usize {
-        if self.produced {
-            self.inner.num_estimated()
-        } else {
-            self.num_estimated_hint
-        }
+        self._num_estimated()
     }
 
     #[inline(always)]
@@ -179,45 +202,35 @@ impl<const SORTED_BY_ID: bool> ProfilePrint for MetricLazy<'_, SORTED_BY_ID> {
     }
 }
 
-/// Suspended counterpart of [`MetricLazy`], used as its
-/// [`RQEIteratorBoxed::Suspended`] type.
-///
-/// Layout-compatible with [`MetricLazy`] — both are `#[repr(C)]` with the same
-/// field order. The only differing field is the inner iterator: the active
-/// `RawMetric<Active, _>` is layout-compatible with `RawMetric<Suspended, _>`
-/// (see [`Metric`]'s [`RQEIteratorBoxed::suspend`]). The `producer`, `produced`,
-/// and `num_estimated_hint` fields are identical — in particular the producer is
-/// `Producer<'static>` on both sides (it captures only raw C pointers and C
-/// function pointers, never Rust references — see the `NewLazyVectorRangeIterator`
-/// FFI constructor), so the whole-struct cast touches no lifetime.
-#[repr(C)]
-pub struct MetricLazySuspended<'query, const SORTED_BY_ID: bool> {
-    inner: RawMetric<'query, Suspended, SORTED_BY_ID>,
-    producer: Producer<'static>,
-    produced: bool,
-    num_estimated_hint: usize,
-}
-
-impl<'index, const SORTED_BY_ID: bool> RQEIteratorBoxed<'index> for MetricLazy<'index, SORTED_BY_ID> {
-    type Suspended = MetricLazySuspended<'index, SORTED_BY_ID>;
+impl<'index, const SORTED_BY_ID: bool> RQEIteratorBoxed<'index>
+    for MetricLazy<'index, SORTED_BY_ID>
+{
+    type Suspended = SuspendedMetricLazy<'index, SORTED_BY_ID>;
 
     fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
-        let raw = Box::into_raw(self);
-        // SAFETY: `MetricLazy` and `MetricLazySuspended` are both `#[repr(C)]`
-        // with identical field layout: the inner `RawMetric<Active, _>` is
-        // layout-compatible with `RawMetric<Suspended, _>` (see `Metric::suspend`),
-        // the `producer` field is `Producer<'static>` on both sides, and
-        // `produced`/`num_estimated_hint` carry no lifetime. Casting the box's heap
-        // pointer preserves the allocation, so any interior pointers into the inner
-        // metric's result stay valid across the suspend/resume cycle. The active
-        // `Drop` impl (`key_handle` nullification) does not run on these bytes —
-        // ownership of the allocation transfers to the suspended box.
-        unsafe { Box::from_raw(raw as *mut MetricLazySuspended<'index, SORTED_BY_ID>) }
+        let active = Box::into_raw(self);
+
+        // Suspend the wrapped metric's base id list `result` field in place, leaving the
+        // outer allocation (and the `Rf`-independent `producer`) untouched.
+        //
+        // SAFETY: `&raw mut` forms a field pointer without creating a reference,
+        // preserving `active`'s provenance over the whole allocation for the outer
+        // cast below.
+        let inner_slot = unsafe { &raw mut (*active).inner };
+        // SAFETY: `suspend_in_place`'s contract is met — `inner_slot` is initialized and
+        // unaliased (this function owns `self`). Suspending is a safe widening conversion.
+        let _ = unsafe { Metric::<'index, SORTED_BY_ID>::suspend_in_place(inner_slot) };
+
+        // SAFETY: `MetricLazy` and `SuspendedMetricLazy` are both `#[repr(C)]` with identical
+        // field layout: `inner` is now the suspended metric, `producer` is `Producer<'static>` in
+        // both variants, and `produced`/`num_estimated_hint` carry no lifetime. `Box::from_raw`
+        // reuses the same heap allocation as `Box::into_raw`, so the address is unchanged.
+        unsafe { Box::from_raw(active.cast::<SuspendedMetricLazy<'index, SORTED_BY_ID>>()) }
     }
 }
 
 impl<'query, const SORTED_BY_ID: bool> RQESuspendedIterator<'query>
-    for MetricLazySuspended<'query, SORTED_BY_ID>
+    for SuspendedMetricLazy<'query, SORTED_BY_ID>
 {
     type Resumed<'index>
         = MetricLazy<'index, SORTED_BY_ID>
@@ -231,24 +244,48 @@ impl<'query, const SORTED_BY_ID: bool> RQESuspendedIterator<'query>
     where
         'query: 'index,
     {
-        let raw = Box::into_raw(self);
-        // SAFETY: layout-compatible — see `suspend`. The inner metric owns all its
-        // pointee data (the `OwnedSlice`s), and the virtual result has no aliased
-        // pointers, so promoting it back to `Active<'index>` is unconditionally sound
-        // (the `'query: 'index` bound keeps any retained query-pipeline pointers valid).
-        // `Box::from_raw` reuses the same heap allocation as `suspend`'s
-        // `Box::into_raw`.
-        let active = unsafe { Box::from_raw(raw as *mut MetricLazy<'index, SORTED_BY_ID>) };
-        Ok(ResumeOutcome::Ok(active))
+        let suspended = Box::into_raw(self);
+
+        // Promote the wrapped metric's base id list `result` field in place, leaving the
+        // outer allocation (and the `Rf`-independent `producer`) untouched.
+        //
+        // SAFETY: `&raw mut` forms a field pointer without creating a reference,
+        // preserving `suspended`'s provenance over the whole allocation for the
+        // outer cast below.
+        let inner_slot = unsafe { &raw mut (*suspended).inner };
+        // SAFETY: `resume_in_place`'s contract is met — `inner_slot` is initialized and
+        // unaliased (this function owns `self`). We reclaim the outer allocation via `suspended`
+        // in either branch, so the inner pointer it returns is not needed.
+        match unsafe {
+            SuspendedMetric::<'query, SORTED_BY_ID>::resume_in_place::<'index>(inner_slot)
+        } {
+            Ok(_) => {
+                // SAFETY: layout-compatible — see `suspend`. `inner`'s base `result` is now valid
+                // at the active type for `'index`; the remaining fields carry no `Rf`.
+                // `Box::from_raw` reuses the same heap allocation as `suspend`'s `Box::into_raw`,
+                // so the address is unchanged.
+                let active =
+                    unsafe { Box::from_raw(suspended.cast::<MetricLazy<'index, SORTED_BY_ID>>()) };
+                Ok(ResumeOutcome::Ok(active))
+            }
+            Err(_) => {
+                // `resume_in_place` left the inner metric untouched (the stored result kind was
+                // neither metric nor virtual), so the outer allocation is still a valid
+                // `SuspendedMetricLazy`.
+                // SAFETY: `suspended` came from `Box::into_raw` above and was not mutated; reclaim
+                // ownership so it is dropped.
+                drop(unsafe { Box::from_raw(suspended) });
+                Ok(ResumeOutcome::Aborted)
+            }
+        }
     }
 
+    #[inline(always)]
     fn last_doc_id(&self) -> DocId {
-        self.inner.suspended_result_doc_id()
+        self.inner.last_doc_id()
     }
 
     fn num_estimated(&self) -> usize {
-        // Snapshot from construction; the real count is only known once the
-        // producer has run. Acceptable for the FFI display-only consumer.
-        self.num_estimated_hint
+        self._num_estimated()
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/metric_lazy.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric_lazy.rs
@@ -12,12 +12,14 @@
 use ffi::{RLookupKey, RLookupKeyHandle};
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
+use ref_mode::Suspended;
 use rqe_core::DocId;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
     deferred::{ProducedResults, Producer},
-    metric::{Metric, MetricType},
+    metric::{Metric, MetricType, RawMetric},
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 
@@ -35,6 +37,11 @@ pub type MetricLazySortedByScore<'index> = MetricLazy<'index, false>;
 /// caller wires via [`set_handle`](Self::set_handle)/[`key_mut_ref`](Self::key_mut_ref)) before
 /// the producer ever runs. Once produced it delegates entirely to the inner [`Metric`], so the
 /// metric value is yielded against the same key.
+///
+/// `#[repr(C)]` so it is layout-compatible with its suspended counterpart
+/// [`MetricLazySuspended`], enabling the allocation-preserving whole-struct
+/// cast in [`RQEIteratorBoxed::suspend`].
+#[repr(C)]
 pub struct MetricLazy<'index, const SORTED_BY_ID: bool> {
     /// The wrapped metric iterator, empty until [`producer`](Self::producer) runs.
     inner: Metric<'index, SORTED_BY_ID>,
@@ -169,5 +176,79 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index> for MetricLazy<'index
 impl<const SORTED_BY_ID: bool> ProfilePrint for MetricLazy<'_, SORTED_BY_ID> {
     fn print_profile(&self, map: &mut redis_reply::MapBuilder<'_>, ctx: &mut ProfilePrintCtx<'_>) {
         self.inner.print_profile(map, ctx);
+    }
+}
+
+/// Suspended counterpart of [`MetricLazy`], used as its
+/// [`RQEIteratorBoxed::Suspended`] type.
+///
+/// Layout-compatible with [`MetricLazy`] — both are `#[repr(C)]` with the same
+/// field order. The only differing field is the inner iterator: the active
+/// `RawMetric<Active, _>` is layout-compatible with `RawMetric<Suspended, _>`
+/// (see [`Metric`]'s [`RQEIteratorBoxed::suspend`]). The `producer`, `produced`,
+/// and `num_estimated_hint` fields are identical — in particular the producer is
+/// `Producer<'static>` on both sides (it captures only raw C pointers and C
+/// function pointers, never Rust references — see the `NewLazyVectorRangeIterator`
+/// FFI constructor), so the whole-struct cast touches no lifetime.
+#[repr(C)]
+pub struct MetricLazySuspended<'query, const SORTED_BY_ID: bool> {
+    inner: RawMetric<'query, Suspended, SORTED_BY_ID>,
+    producer: Producer<'static>,
+    produced: bool,
+    num_estimated_hint: usize,
+}
+
+impl<'index, const SORTED_BY_ID: bool> RQEIteratorBoxed<'index> for MetricLazy<'index, SORTED_BY_ID> {
+    type Suspended = MetricLazySuspended<'index, SORTED_BY_ID>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `MetricLazy` and `MetricLazySuspended` are both `#[repr(C)]`
+        // with identical field layout: the inner `RawMetric<Active, _>` is
+        // layout-compatible with `RawMetric<Suspended, _>` (see `Metric::suspend`),
+        // the `producer` field is `Producer<'static>` on both sides, and
+        // `produced`/`num_estimated_hint` carry no lifetime. Casting the box's heap
+        // pointer preserves the allocation, so any interior pointers into the inner
+        // metric's result stay valid across the suspend/resume cycle. The active
+        // `Drop` impl (`key_handle` nullification) does not run on these bytes —
+        // ownership of the allocation transfers to the suspended box.
+        unsafe { Box::from_raw(raw as *mut MetricLazySuspended<'index, SORTED_BY_ID>) }
+    }
+}
+
+impl<'query, const SORTED_BY_ID: bool> RQESuspendedIterator<'query>
+    for MetricLazySuspended<'query, SORTED_BY_ID>
+{
+    type Resumed<'index>
+        = MetricLazy<'index, SORTED_BY_ID>
+    where
+        'query: 'index;
+
+    fn resume<'index>(
+        self: Box<Self>,
+        _guard: &IndexSpecReadGuard<'index>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'index>>>, RQEIteratorError>
+    where
+        'query: 'index,
+    {
+        let raw = Box::into_raw(self);
+        // SAFETY: layout-compatible — see `suspend`. The inner metric owns all its
+        // pointee data (the `OwnedSlice`s), and the virtual result has no aliased
+        // pointers, so promoting it back to `Active<'index>` is unconditionally sound
+        // (the `'query: 'index` bound keeps any retained query-pipeline pointers valid).
+        // `Box::from_raw` reuses the same heap allocation as `suspend`'s
+        // `Box::into_raw`.
+        let active = unsafe { Box::from_raw(raw as *mut MetricLazy<'index, SORTED_BY_ID>) };
+        Ok(ResumeOutcome::Ok(active))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.inner.suspended_result_doc_id()
+    }
+
+    fn num_estimated(&self) -> usize {
+        // Snapshot from construction; the real count is only known once the
+        // producer has run. Acceptable for the FFI display-only consumer.
+        self.num_estimated_hint
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/deferred.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/deferred.rs
@@ -224,7 +224,12 @@ mod suspend_resume {
         let mock_ctx = MockContext::new(0, 0);
         let calls = Rc::new(Cell::new(0));
         let mut it = MetricLazySortedById::new(
-            producer(vec![2, 5, 8], Some(vec![0.2, 0.5, 0.8]), false, calls.clone()),
+            producer(
+                vec![2, 5, 8],
+                Some(vec![0.2, 0.5, 0.8]),
+                false,
+                calls.clone(),
+            ),
             42,
             MetricType::VectorDistance,
         );

--- a/src/redisearch_rs/rqe_iterators/tests/integration/deferred.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/deferred.rs
@@ -73,6 +73,69 @@ fn id_list_is_not_produced_until_first_read() {
     assert_eq!(calls.get(), 1);
 }
 
+/// Suspend/resume round-trips for the lazy ID list. These exercise the
+/// `RQEIteratorBoxed`/`RQESuspendedIterator` impls (whose suspended form erases
+/// the retained producer's lifetime to `'static` and restores it on resume) via
+/// the dyn path used by the production FFI wrapper.
+mod id_list_suspend_resume {
+    use super::*;
+    use rqe_iterators::TypeErasedRQEIterator;
+    use rqe_iterators_test_utils::{MockContext, ResumeOutcomeExt, revalidate_via_resume};
+
+    #[test]
+    fn survives_suspend_resume_after_production() {
+        let mock_ctx = MockContext::new(0, 0);
+        let calls = Rc::new(Cell::new(0));
+        let mut it = IdListLazy::<true>::new(
+            producer(vec![1, 4, 9], None, false, calls.clone()),
+            100,
+            index_result::RSIndexResult::build_virt().build(),
+        );
+        // Produce and consume the first result.
+        assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
+        assert_eq!(calls.get(), 1);
+
+        // Suspend + resume across a (mock) lock release/reacquire cycle.
+        let mut it = revalidate_via_resume(
+            TypeErasedRQEIterator::new(Box::new(it)),
+            &mock_ctx.spec_read(),
+        )
+        .expect("resume should not fail")
+        .expect_ok();
+
+        // The retained producer is not re-run; the remaining data survives at the
+        // preserved position.
+        assert_eq!(it.read().unwrap().unwrap().doc_id, 4);
+        assert_eq!(it.read().unwrap().unwrap().doc_id, 9);
+        assert!(matches!(it.read(), Ok(None)));
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn suspend_resume_before_production_keeps_deferral() {
+        let mock_ctx = MockContext::new(0, 0);
+        let calls = Rc::new(Cell::new(0));
+        let it = IdListLazy::<true>::new(
+            producer(vec![7, 8], None, false, calls.clone()),
+            5,
+            index_result::RSIndexResult::build_virt().build(),
+        );
+
+        // Suspend/resume before any read leaves production deferred.
+        let mut it = revalidate_via_resume(
+            TypeErasedRQEIterator::new(Box::new(it)),
+            &mock_ctx.spec_read(),
+        )
+        .expect("resume should not fail")
+        .expect_ok();
+        assert_eq!(calls.get(), 0);
+
+        // The producer still runs on the first read after resume.
+        assert_eq!(it.read().unwrap().unwrap().doc_id, 7);
+        assert_eq!(calls.get(), 1);
+    }
+}
+
 #[test]
 fn metric_produces_ids_and_metrics_on_first_read() {
     let calls = Rc::new(Cell::new(0));

--- a/src/redisearch_rs/rqe_iterators/tests/integration/deferred.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/deferred.rs
@@ -209,3 +209,66 @@ fn skip_to_triggers_production() {
         other => panic!("expected Found(6), got {other:?}"),
     }
 }
+
+/// Suspend/resume round-trips for the lazy iterators. These exercise the
+/// `RQEIteratorBoxed`/`RQESuspendedIterator` impls (whose suspended forms erase
+/// the retained producer's lifetime to `'static` and restore it on resume) via
+/// the dyn path used by the production FFI wrapper.
+mod suspend_resume {
+    use super::*;
+    use rqe_iterators::TypeErasedRQEIterator;
+    use rqe_iterators_test_utils::{MockContext, ResumeOutcomeExt, revalidate_via_resume};
+
+    #[test]
+    fn lazy_metric_survives_suspend_resume_after_production() {
+        let mock_ctx = MockContext::new(0, 0);
+        let calls = Rc::new(Cell::new(0));
+        let mut it = MetricLazySortedById::new(
+            producer(vec![2, 5, 8], Some(vec![0.2, 0.5, 0.8]), false, calls.clone()),
+            42,
+            MetricType::VectorDistance,
+        );
+        // Produce and consume the first result.
+        assert_eq!(it.read().unwrap().unwrap().doc_id, 2);
+        assert_eq!(calls.get(), 1);
+
+        // Suspend + resume across a (mock) lock release/reacquire cycle.
+        let mut it = revalidate_via_resume(
+            TypeErasedRQEIterator::new(Box::new(it)),
+            &mock_ctx.spec_read(),
+        )
+        .expect("resume should not fail")
+        .expect_ok();
+
+        // The retained producer is not re-run; the remaining data survives at the
+        // preserved position.
+        assert_eq!(it.read().unwrap().unwrap().doc_id, 5);
+        assert_eq!(it.read().unwrap().unwrap().doc_id, 8);
+        assert!(matches!(it.read(), Ok(None)));
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn lazy_metric_suspend_resume_before_production_keeps_deferral() {
+        let mock_ctx = MockContext::new(0, 0);
+        let calls = Rc::new(Cell::new(0));
+        let it = MetricLazySortedById::new(
+            producer(vec![1, 2], Some(vec![0.1, 0.2]), false, calls.clone()),
+            9,
+            MetricType::VectorDistance,
+        );
+
+        // Suspend/resume before any read leaves production deferred.
+        let mut it = revalidate_via_resume(
+            TypeErasedRQEIterator::new(Box::new(it)),
+            &mock_ctx.spec_read(),
+        )
+        .expect("resume should not fail")
+        .expect_ok();
+        assert_eq!(calls.get(), 0);
+
+        // The producer still runs on the first read after resume.
+        assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
+        assert_eq!(calls.get(), 1);
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/empty.rs
@@ -72,3 +72,18 @@ fn revalidate() {
         .expect("revalidate failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 }
+
+mod via_resume {
+    use super::*;
+    use rqe_iterators::TypeErasedRQEIterator;
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    #[test]
+    fn revalidate() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let it: Box<Empty> = Box::new(Empty::default());
+        revalidate_via_resume(TypeErasedRQEIterator::new(it), &mock_ctx.spec_read())
+            .expect("resume should not fail")
+            .expect_ok();
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
@@ -238,3 +238,18 @@ fn revalidate() {
         .expect("revalidate failed");
     assert_eq!(status, RQEValidateStatus::Ok);
 }
+
+mod via_resume {
+    use super::*;
+    use rqe_iterators::TypeErasedRQEIterator;
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    #[test]
+    fn revalidate() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let it = Box::new(IdListSorted::new(vec![1, 2, 3]));
+        revalidate_via_resume(TypeErasedRQEIterator::new(it), &mock_ctx.spec_read())
+            .expect("resume should not fail")
+            .expect_ok();
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
@@ -288,6 +288,22 @@ fn revalidate() {
     assert_eq!(status, RQEValidateStatus::Ok);
 }
 
+mod via_resume {
+    use super::*;
+    use rqe_iterators::TypeErasedRQEIterator;
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    #[test]
+    fn revalidate() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let metric_data = vec![0.1, 0.2, 0.3];
+        let it = Box::new(MetricSortedById::new(vec![1, 2, 3], metric_data));
+        revalidate_via_resume(TypeErasedRQEIterator::new(it), &mock_ctx.spec_read())
+            .expect("resume should not fail")
+            .expect_ok();
+    }
+}
+
 #[test]
 fn metric_type_returns_vector_distance() {
     let it = MetricSortedById::new(vec![1], vec![0.5]);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
@@ -290,6 +290,7 @@ fn revalidate() {
 
 mod via_resume {
     use super::*;
+    use ffi::RLookupKeyHandle;
     use rqe_iterators::TypeErasedRQEIterator;
     use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
 
@@ -297,10 +298,22 @@ mod via_resume {
     fn revalidate() {
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let metric_data = vec![0.1, 0.2, 0.3];
-        let it = Box::new(MetricSortedById::new(vec![1, 2, 3], metric_data));
-        revalidate_via_resume(TypeErasedRQEIterator::new(it), &mock_ctx.spec_read())
-            .expect("resume should not fail")
-            .expect_ok();
+        let mut handle = RLookupKeyHandle {
+            key_ptr: std::ptr::null_mut(),
+            is_valid: true,
+        };
+        let mut it = MetricSortedById::new(vec![1, 2, 3], metric_data);
+        // SAFETY: handle_ptr points to a valid, stack-allocated RLookupKeyHandle.
+        unsafe { it.set_handle(&raw mut handle) };
+
+        let _it = revalidate_via_resume(
+            TypeErasedRQEIterator::new(Box::new(it)),
+            &mock_ctx.spec_read(),
+        )
+        .expect("resume should not fail")
+        .expect_ok();
+
+        assert!(handle.is_valid);
     }
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

Implement `RQEIteratorBoxed` + `RQESuspendedIterator` for the self-contained leaf iterators that don't touch the
inverted-index reader: `Empty`, `IdList`, `Metric`, `IdListLazy` and `MetricLazy`.

Related changes:
- Added `into_active_in_place` and `into_suspended_in_place` convenience methods on `RSIndexResult` and its suspended counterparts. We'll use them a lot later on.
- Moved `*Lazy` iterators to separate modules.
- Changed the lifetime of `Producer` for both lazy iterators to `'static`, since that's the only one that's used in practice.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

Stacked on #10270.
