### PR TITLE
[Iterator Revalidation][MOD-16901] Inverted-index leaves: Term/Tag/Missing/Wildcard

### DIFF
--- a/src/redisearch_rs/index_result/src/term_record.rs
+++ b/src/redisearch_rs/index_result/src/term_record.rs
@@ -113,6 +113,15 @@ impl<'query, R: Ref> RawTermRecord<'query, R> {
     pub const fn is_copy(&self) -> bool {
         matches!(self, Self::Owned { .. } | Self::FullyOwned { .. })
     }
+
+    /// Get a reference to the query term of this term record, if one is set.
+    pub fn query_term(&self) -> Option<&RSQueryTerm> {
+        match self {
+            Self::Borrowed { term, .. } => term.as_deref(),
+            Self::Owned { term, .. } => *term,
+            Self::FullyOwned { term, .. } => term.as_deref(),
+        }
+    }
 }
 
 impl<'a> RSTermRecord<'a> {
@@ -130,15 +139,6 @@ impl<'a> RSTermRecord<'a> {
             Self::Borrowed { offsets, .. } => offsets.as_bytes(),
             Self::Owned { offsets, .. } => offsets.as_bytes(),
             Self::FullyOwned { offsets, .. } => offsets.as_bytes(),
-        }
-    }
-
-    /// Get a reference to the query term of this term record, if one is set.
-    pub fn query_term(&self) -> Option<&RSQueryTerm> {
-        match self {
-            Self::Borrowed { term, .. } => term.as_deref(),
-            Self::Owned { term, .. } => *term,
-            Self::FullyOwned { term, .. } => term.as_deref(),
         }
     }
 

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -27,8 +27,8 @@ pub use gc::{GcApplyInfo, GcScanDelta, RepairContext};
 
 // Re-export reader types.
 pub use reader::{
-    IndexReader, IndexReaderCore, NumericFilter, NumericReader, RawIndexReaderCore, RefreshOutcome,
-    ResumableReader, SuspendableReader, TermReader,
+    IndexReader, IndexReaderCore, NumericFilter, NumericReader, PointsToOpaqueIndex,
+    RawIndexReaderCore, RefreshOutcome, ResumableReader, SuspendableReader, TermReader,
 };
 
 // Re-export filter types.

--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -12,7 +12,8 @@ use std::{io::Cursor, marker::PhantomData, ptr::NonNull, sync::atomic};
 use ref_mode::{Active, Ref, SharedPtr, Suspended};
 
 use super::{
-    IndexReader, NumericReader, RefreshOutcome, ResumableReader, SuspendableReader, TermReader,
+    IndexReader, NumericReader, PointsToOpaqueIndex, RefreshOutcome, ResumableReader,
+    SuspendableReader, TermReader,
 };
 use crate::{
     DecodedBy, Decoder, Encoder, HasInnerIndex, InvertedIndex, NumericDecoder, TermDecoder,
@@ -210,9 +211,13 @@ impl<'index, E: DecodedBy<Decoder = D> + 'index, D: Decoder + NumericDecoder> Nu
 {
 }
 
-/// Automatically implemented if the IndexReaderCore uses a TermDecoder.
-impl<'index, E: DecodedBy<Decoder = D> + OpaqueEncoding + 'index, D: Decoder + TermDecoder>
-    TermReader<'index> for RawIndexReaderCore<Active<'index>, E>
+/// Resolve an opaque [`InvertedIndex`](crate::opaque::InvertedIndex) and compare
+/// it against this reader's own `ii` pointer, via
+/// [`E::from_opaque`](crate::DecodedBy) and
+/// [`points_to_ii`](RawIndexReaderCore::points_to_ii). Implemented for every `Rf`
+/// so leaves (`Term`) can call it from their suspended-side `should_abort` checks.
+impl<Rf: Ref, E: DecodedBy<Decoder = D> + OpaqueEncoding, D: Decoder + TermDecoder>
+    PointsToOpaqueIndex for RawIndexReaderCore<Rf, E>
 where
     E::Storage: HasInnerIndex<E>,
 {
@@ -221,6 +226,15 @@ where
         let ii = storage.inner_index();
         self.points_to_ii(ii)
     }
+}
+
+/// Automatically implemented if the IndexReaderCore uses a TermDecoder.
+/// The [`PointsToOpaqueIndex`] supertrait is satisfied via the impl above.
+impl<'index, E: DecodedBy<Decoder = D> + OpaqueEncoding + 'index, D: Decoder + TermDecoder>
+    TermReader<'index> for RawIndexReaderCore<Active<'index>, E>
+where
+    E::Storage: HasInnerIndex<E>,
+{
 }
 
 impl<'index, E: DecodedBy<Decoder = D> + 'index, D: Decoder> IndexReader<'index>

--- a/src/redisearch_rs/inverted_index/src/reader/field_mask.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/field_mask.rs
@@ -8,7 +8,8 @@
 */
 
 use super::{
-    IndexReader, IndexReaderCore, RefreshOutcome, ResumableReader, SuspendableReader, TermReader,
+    IndexReader, IndexReaderCore, PointsToOpaqueIndex, RefreshOutcome, ResumableReader,
+    SuspendableReader, TermReader,
 };
 use crate::{
     DecodedBy, Decoder, HasInnerIndex, InvertedIndex, TermDecoder, opaque::OpaqueEncoding,
@@ -177,13 +178,20 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> FilterMaskReader<IndexReader
     }
 }
 
+/// Forwards the opaque-index check to the inner reader. Covers both the
+/// [`Active`](ref_mode::Active) and [`Suspended`](ref_mode::Suspended) inner
+/// reader forms.
+impl<IR: PointsToOpaqueIndex> PointsToOpaqueIndex for FilterMaskReader<IR> {
+    fn points_to_the_same_opaque_index(&self, opaque: &crate::opaque::InvertedIndex) -> bool {
+        self.inner.points_to_the_same_opaque_index(opaque)
+    }
+}
+
 /// Automatically implemented if the IndexReaderCore uses a TermDecoder.
+/// The [`PointsToOpaqueIndex`] supertrait is satisfied via the impl above.
 impl<'index, E: DecodedBy<Decoder = D> + OpaqueEncoding + 'index, D: Decoder + TermDecoder>
     TermReader<'index> for FilterMaskReader<IndexReaderCore<'index, E>>
 where
     E::Storage: HasInnerIndex<E>,
 {
-    fn points_to_the_same_opaque_index(&self, opaque: &crate::opaque::InvertedIndex) -> bool {
-        self.inner.points_to_the_same_opaque_index(opaque)
-    }
 }

--- a/src/redisearch_rs/inverted_index/src/reader/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/mod.rs
@@ -182,12 +182,22 @@ pub unsafe trait ResumableReader: 'static {
 /// Marker trait for readers producing numeric values.
 pub trait NumericReader<'index>: IndexReader<'index> {}
 
-/// Trait for readers producing term values.
-pub trait TermReader<'index>: IndexReader<'index> {
+/// Check whether a reader is linked to the same
+/// [`InvertedIndex`](crate::opaque::InvertedIndex) as an externally-held
+/// opaque pointer.
+///
+/// Extracted from [`TermReader`] so it can be implemented for both the
+/// [`Active`](ref_mode::Active) and [`Suspended`](ref_mode::Suspended) reader
+/// forms; leaves (`Term`, FFI enums) call it from their suspended-side
+/// `should_abort` checks during `RQESuspendedIterator::resume`.
+pub trait PointsToOpaqueIndex {
     /// Check if this reader's underlying index points to the same one
     /// contained in the given opaque [`InvertedIndex`](crate::opaque::InvertedIndex).
     fn points_to_the_same_opaque_index(&self, opaque: &crate::opaque::InvertedIndex) -> bool;
 }
+
+/// Trait for readers producing term values.
+pub trait TermReader<'index>: IndexReader<'index> + PointsToOpaqueIndex {}
 
 /// Filter to apply when reading from an index. Entries which don't match the filter will not be
 /// returned by the reader.

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -479,6 +479,19 @@ where
 }
 // ---- Suspend / Resume ------------------------------------------------------
 
+/// Outcome of an in-place suspended→active resume
+/// ([`resume_in_place`](RawInvIndIterator::resume_in_place)).
+///
+/// Reports whether the iterator's position is unchanged or whether a re-seek
+/// after a GC/relocation moved it past the previous document.
+pub(crate) enum ResumeStatus {
+    /// The iterator resumed at the same position it held before suspending.
+    Unchanged,
+    /// GC or a block relocation invalidated the cached offset; the re-seek
+    /// landed the iterator on a different (later) document, or off the end.
+    Moved,
+}
+
 impl<'query, RS, E, RA> RawInvIndIterator<'query, Suspended, RS, E, RA>
 where
     RS: ResumableReader,
@@ -507,6 +520,108 @@ where
         // an `IndexSpecReadGuard`). `ResumableReader::refresh_pointers` requires
         // exactly that lock while it dereferences the reader's raw index pointer.
         unsafe { self.reader.refresh_pointers() }
+    }
+
+    /// Perform the full suspended→active resume transition **in place**.
+    ///
+    /// Refreshes the reader's pointers, resets any stale borrowed offsets,
+    /// promotes the `Rf`-carrying `result` field to its active form, and — if
+    /// GC or a block relocation invalidated the cached offset — rewinds and
+    /// re-seeks to the last document the iterator returned. On return, `self`'s
+    /// storage is a valid `InvIndIterator<'a, RS::Resumed<'a>, E>` at the same
+    /// address; the caller only has to reinterpret the owning `Box`'s type,
+    /// which is a layout-identical no-op cast (invariant 1, const proof above).
+    ///
+    /// This is the single shared resume path for the bare-core iterator and for
+    /// every leaf wrapper (`Term`/`Tag`/`Missing`/`Wildcard`/`Numeric`), so the
+    /// borrowed-data transition lives in exactly one place.
+    ///
+    /// # Precondition
+    ///
+    /// Like [`RQESuspendedIterator::resume`], this refreshes the reader pointers
+    /// without an index-identity check of its own. It assumes the caller has
+    /// already established that the underlying inverted index is still live
+    /// (leaf wrappers run their `should_abort` check first).
+    pub(crate) fn resume_in_place<'a>(
+        &mut self,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeStatus, RQEIteratorError>
+    where
+        'query: 'a,
+        RS::Resumed<'a>: IndexReader<'a>,
+    {
+        // We use the last doc id yielded by the iterator, rather than the reader state,
+        // since the reader initializes its own field to the first block's first_doc_id
+        // before any result has been returned, so if GC or a moved block buffer occurs
+        // while a freshly-created iterator is suspended, resume would reseek to that first
+        // doc and report Ok, causing the next read() to skip the first result.
+        let last_doc_id = self.last_doc_id;
+
+        // Step 1: refresh reader pointers *on the suspended form*. This never
+        // materializes a `&'a` borrow of any potentially-dangling field — the
+        // Suspended → Active reinterpretation happens afterwards, only once every
+        // `Rf`-dependent field is valid. Passing `guard` proves the spec read
+        // lock is held for the pointer refresh.
+        let outcome = self.refresh_pointers(guard);
+
+        // Whatever offsets we borrowed from the index may be stale. To make
+        // promotion from suspended to active safe, we unset them while still
+        // suspended, before any active reference to `result` can be formed.
+        if outcome == RefreshOutcome::NeedsReseek
+            && let Some(term) = self.result.as_term_mut()
+        {
+            match term {
+                RawTermRecord::Borrowed { offsets, .. } => {
+                    *offsets = RawOffsetSlice::empty();
+                }
+                RawTermRecord::Owned { .. } | RawTermRecord::FullyOwned { .. } => {
+                    // These variants own their offsets, so no issues.
+                }
+            }
+        }
+
+        // Step 2: convert the `Rf`-carrying `result` field Suspended → Active in
+        // place, then reinterpret the rest of the struct by reborrowing `self`'s
+        // storage as the active iterator. The heap allocation is untouched, so
+        // external pointers into this iterator's interior stay valid.
+        //
+        // `&raw mut` forms a field pointer without creating a reference, leaving
+        // provenance over the whole allocation intact for the reborrow below.
+        let result_slot = &raw mut self.result;
+        // SAFETY: `into_active_in_place`'s preconditions for `'a` hold — the
+        // caller's read lock (witnessed by `guard`) plus the `refresh_pointers`
+        // call above ensure every index-backed pointer inside `result` is
+        // dereferenceable for `'a`; `result_slot` is initialized and unaliased.
+        unsafe { RawIndexResult::<'query, Suspended>::into_active_in_place::<'a>(result_slot) };
+        // SAFETY: `result` is now the active form; the remaining `Rf`-dependent
+        // fields (`reader`, the `fn` pointers) are layout-identical across modes
+        // by invariant 1 on `RawInvIndIterator` (const proof above) given
+        // invariant 1 on the reader `RS`. Reborrowing the same storage as the
+        // active iterator is therefore sound, and no `&mut self` borrow outlives
+        // this reborrow (we never touch `self` again).
+        let active: &mut InvIndIterator<'a, RS::Resumed<'a>, E> =
+            unsafe { &mut *(self as *mut Self).cast() };
+
+        // Step 3: if GC ran while we were suspended, the cached block offset is
+        // stale even though the buffer pointer was refreshed. Rewind and re-seek
+        // to the last doc id.
+        match outcome {
+            RefreshOutcome::Ok => Ok(ResumeStatus::Unchanged),
+            RefreshOutcome::NeedsReseek => {
+                active.rewind();
+
+                if last_doc_id == 0 {
+                    // We hadn't returned anything yet, so there's nothing to
+                    // re-seek; a fresh `read()` will produce the right next doc.
+                    return Ok(ResumeStatus::Unchanged);
+                }
+
+                Ok(match active.skip_to(last_doc_id)? {
+                    Some(SkipToOutcome::Found(_)) => ResumeStatus::Unchanged,
+                    Some(SkipToOutcome::NotFound(_)) | None => ResumeStatus::Moved,
+                })
+            }
+        }
     }
 }
 
@@ -564,14 +679,26 @@ where
 
     /// # Precondition
     ///
-    /// This core resume refreshes the reader's pointers (dereferencing the
-    /// stored index pointer via [`refresh_pointers`](RawInvIndIterator::refresh_pointers))
-    /// without performing an index-identity check of its own. It assumes the
-    /// caller — a leaf wrapper's `resume` (`Term`/`Tag`/`Missing`/`Wildcard`/
-    /// `Numeric`), which runs its `should_abort` identity check *first* — has
-    /// already established that the underlying inverted index is still live
-    /// (not freed or replaced by GC while suspended). The bare-core iterator is
-    /// not resumed directly in production.
+    /// This core resume refreshes the reader's pointers (via
+    /// [`resume_in_place`](RawInvIndIterator::resume_in_place)) without
+    /// performing an index-identity check of its own. It assumes the caller — a
+    /// leaf wrapper's `resume` (`Term`/`Tag`/`Missing`/`Wildcard`/`Numeric`),
+    /// which runs its `should_abort` identity check *first* — has already
+    /// established that the underlying inverted index is still live (not freed
+    /// or replaced by GC while suspended).
+    ///
+    /// The liveness check is deliberately **not** performed here: it is
+    /// leaf-specific (each leaf locates its index differently — `Term` via
+    /// `keysDict`, `Tag` via the tag `TrieMap`, `Missing` via `missingFieldDict`,
+    /// `Wildcard` via `existingDocs`), so it cannot be expressed generically at
+    /// this layer. Consequently, resuming the *bare* core iterator directly —
+    /// i.e. an [`InvIndIterator`] not wrapped by one of those leaves — after the
+    /// index was fully GC'd or replaced while suspended would let
+    /// `resume_in_place` dereference the stale saved index pointer. That path is
+    /// never exercised in production: every core iterator is owned by a leaf
+    /// wrapper whose `resume` gates on `should_abort` before delegating here. If
+    /// a future caller resumes the bare core directly, it must first prove the
+    /// index identity itself.
     fn resume<'a>(
         mut self: Box<Self>,
         guard: &IndexSpecReadGuard<'a>,
@@ -579,87 +706,26 @@ where
     where
         'query: 'a,
     {
-        // If there has been a GC cycle on this key while we were suspended, the offset might not be valid
-        // anymore. This means that we need to seek the last docId we were at.
-        let last_doc_id = self.last_doc_id();
+        // Do the whole borrowed-data transition in place on the boxed value.
+        let status = self.resume_in_place(guard)?;
 
-        // Step 1: refresh reader pointers *on the suspended form*. This
-        // never materializes a `&'a` borrow of any potentially-dangling
-        // field — the `Box<Suspended>` → `Box<Active<'a>>` conversion happens
-        // afterwards, only once every `Rf`-dependent field is valid. Passing
-        // `guard` proves the spec read lock is held for the pointer refresh.
-        let outcome = self.refresh_pointers(guard);
+        // Reinterpret the owning box's type. The heap allocation is preserved,
+        // so external pointers into this iterator's interior (composite
+        // aggregate results) stay valid across the cycle.
+        //
+        // SAFETY: `resume_in_place` left `self`'s storage as a valid
+        // `InvIndIterator<'a, RS::Resumed<'a>, E>` (layout-identical to
+        // `Self` by invariant 1 on `RawInvIndIterator`, const proof above).
+        // `Box::from_raw` reuses the same allocation, so the box address is
+        // preserved.
+        let active = unsafe {
+            Box::from_raw(Box::into_raw(self).cast::<InvIndIterator<'a, RS::Resumed<'a>, E>>())
+        };
 
-        // Whatever offsets we borrowed from the index may be stale.
-        // To make promotion from suspended to active safe, we unset them.
-        if outcome == RefreshOutcome::NeedsReseek
-            && let Some(term) = self.result.as_term_mut()
-        {
-            match term {
-                RawTermRecord::Borrowed { offsets, .. } => {
-                    *offsets = RawOffsetSlice::empty();
-                }
-                RawTermRecord::Owned { .. } | RawTermRecord::FullyOwned { .. } => {
-                    // These variants own their offsets, so no issues.
-                }
-            }
-        }
-
-        // Step 2: convert Suspended → Active in place. The heap allocation is
-        // preserved, so external pointers into this iterator's interior
-        // (composite aggregate results) stay valid across the cycle.
-        let suspended: *mut Self = Box::into_raw(self);
-
-        // SAFETY: `suspended` just came from a `Box`, so it is non-null, aligned,
-        // initialized, and unaliased (we own it). `&raw mut` forms a field
-        // pointer without creating a reference, leaving provenance over the
-        // whole allocation intact for the cast below.
-        let result_slot = unsafe { &raw mut (*suspended).result };
-        // SAFETY: `into_active_in_place`'s preconditions for `'a` hold — the
-        // caller's read lock (witnessed by `_guard`) plus the `refresh_pointers`
-        // call above ensure every index-backed pointer inside `result` is
-        // dereferenceable for `'a`; `result_slot` is initialized and unaliased.
-        // Converting the `Rf`-carrying `result` field through the canonical
-        // in-place conversion keeps the borrowed-data transition explicit.
-        unsafe { RawIndexResult::<'query, Suspended>::into_active_in_place::<'a>(result_slot) };
-
-        // SAFETY: `result` is now the active form; the only other `Rf`-dependent
-        // field, `reader`, is reinterpreted `RS -> RS::Resumed<'a>` — sound by
-        // invariant 1 on `RawInvIndIterator` (const proof above) given invariant 1
-        // on the reader `RS`. The `read_impl`/`skip_to_impl` fn-pointer fields are
-        // frozen at the active reader `RA`; the cast changes that slot only by
-        // lifetime (`RA` -> `RS::Resumed<'a>`, the same reader type modulo
-        // lifetime, which is erased in codegen), never across the Active/Suspended
-        // boundary or a genuinely different reader type. `Box::from_raw` reuses the
-        // same allocation, so the box address is preserved.
-        let mut active =
-            unsafe { Box::from_raw(suspended.cast::<InvIndIterator<'a, RS::Resumed<'a>, E>>()) };
-
-        // Step 3: if GC ran while we were suspended, the cached block
-        // offset is stale even though the buffer pointer was refreshed.
-        // Rewind and re-seek to the last doc id.
-        match outcome {
-            RefreshOutcome::Ok => Ok(ResumeOutcome::Ok(active)),
-            // We use the last doc id yielded by the iterator, rather than the reader state,
-            // since the reader initializes this field to the first block's first_doc_id
-            // before any result has been returned, so if GC or a moved block buffer occurs
-            // while a freshly-created iterator is suspended, resume will reseek to that first doc
-            // and report Ok, causing the next read() to skip the first result.
-            RefreshOutcome::NeedsReseek => {
-                active.rewind();
-
-                if last_doc_id == 0 {
-                    // We hadn't returned anything yet, so there's nothing to
-                    // re-seek; a fresh `read()` will produce the right next doc.
-                    return Ok(ResumeOutcome::Ok(active));
-                }
-
-                match active.skip_to(last_doc_id)? {
-                    Some(SkipToOutcome::Found(_)) => Ok(ResumeOutcome::Ok(active)),
-                    Some(SkipToOutcome::NotFound(_)) | None => Ok(ResumeOutcome::Moved(active)),
-                }
-            }
-        }
+        Ok(match status {
+            ResumeStatus::Unchanged => ResumeOutcome::Ok(active),
+            ResumeStatus::Moved => ResumeOutcome::Moved(active),
+        })
     }
 
     fn last_doc_id(&self) -> DocId {

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -19,18 +19,19 @@ use inverted_index::{
     DecodedBy, DocIdsDecoder, IndexReader, IndexReaderCore, RawIndexReaderCore,
     opaque::OpaqueEncoding,
 };
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::{DocId, FieldIndex, RS_FIELDMASK_ALL};
 
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 
 use crate::{
-    ExpirationChecker, FieldExpirationChecker, IteratorType, RQEIterator, RQEIteratorError,
-    RQEIteratorPrintable, RQEValidateStatus, SkipToOutcome,
+    ExpirationChecker, FieldExpirationChecker, IteratorType, RQEIterator, RQEIteratorBoxed,
+    RQEIteratorError, RQEIteratorPrintable, RQESuspendedIterator, RQEValidateStatus, ResumeOutcome,
+    SkipToOutcome,
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 
-use super::{InvIndIterator, core::RawInvIndIterator};
+use super::{InvIndIterator, core::RawInvIndIterator, core::ResumeStatus};
 
 /// An iterator over documents that are missing a specific field, parameterised
 /// over a [`Ref`] mode. See [`Missing`] for the [`Active`] instantiation that
@@ -50,8 +51,16 @@ use super::{InvIndIterator, core::RawInvIndIterator};
 /// * `E` - The encoding type for the inverted index. Its decoder must implement [`DocIdsDecoder`].
 /// * `C` - The expiration checker type.
 #[repr(C)]
-pub struct RawMissing<'query, Rf: Ref, E: DecodedBy, C = crate::expiration_checker::NoOpChecker> {
-    it: RawInvIndIterator<'query, Rf, RawIndexReaderCore<Rf, E>, C>,
+pub struct RawMissing<
+    'query,
+    Rf: Ref,
+    E: DecodedBy,
+    C = crate::expiration_checker::NoOpChecker,
+    // Frozen active reader for the inner iterator's dispatch pointers; hardcoded
+    // to the `Active` reader regardless of `Rf` (see `RawInvIndIterator`'s `RA`).
+    RA = RawIndexReaderCore<Active<'query>, E>,
+> {
+    it: RawInvIndIterator<'query, Rf, RawIndexReaderCore<Rf, E>, C, RA>,
     field_index: FieldIndex,
     /// Owned copy of the field name, extracted from the spec at construction
     /// time. Owning the string means the iterator no longer borrows from
@@ -64,6 +73,67 @@ pub struct RawMissing<'query, Rf: Ref, E: DecodedBy, C = crate::expiration_check
 /// [`RQEIterator`] impl today.
 pub type Missing<'index, E, C = crate::expiration_checker::NoOpChecker> =
     RawMissing<'index, Active<'index>, E, C>;
+
+impl<'query, Rf: Ref, E: DecodedBy, C, RA> RawMissing<'query, Rf, E, C, RA> {
+    /// Cached [`IndexFlags`](ffi::IndexFlags) of the underlying inverted index — see
+    /// [`RawInvIndIterator::flags`].
+    pub const fn flags(&self) -> ffi::IndexFlags {
+        self.it.flags()
+    }
+
+    /// Get the field name tracked by this missing-field iterator.
+    /// The field name is stored as an owned [`CString`].
+    pub fn field_name(&self) -> (*const c_char, usize) {
+        (self.field_name.as_ptr(), self.field_name.as_bytes().len())
+    }
+}
+
+impl<'query, Rf: Ref, E, C, RA> RawMissing<'query, Rf, E, C, RA>
+where
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+    <E as DecodedBy>::Decoder: DocIdsDecoder,
+{
+    /// Check if the iterator should abort revalidation.
+    ///
+    /// The garbage collector may remove all documents from the
+    /// missing-field inverted index or replace it with a new allocation.
+    /// In both cases the reader's pointer is stale and the iterator
+    /// must [abort](RQEValidateStatus::Aborted).
+    ///
+    /// # Safety
+    ///
+    /// 1. `self.field_index` must be a valid index into `spec.fields`.
+    /// 2. `spec.missingFieldDict` must be a non-null, valid dict pointer.
+    /// 3. The entry in `missingFieldDict` for `spec.fields[field_index].fieldName`,
+    ///    when non-null, must point to an opaque
+    ///    [`InvertedIndex`](inverted_index::opaque::InvertedIndex) whose encoding
+    ///    variant matches `E`.
+    fn should_abort(&self, spec: &IndexSpecReadGuard) -> bool {
+        debug_assert!(
+            !spec.missing_field_dict().is_null(),
+            "spec.missing_field_dict() must be non-null",
+        );
+
+        // SAFETY: field_index is a valid index into spec.fields (guaranteed by constructor pre-conditions).
+        let field_ptr = unsafe { spec.fields_ptr().offset(self.field_index as isize) };
+        // SAFETY: the pointer is valid per the above.
+        let field = unsafe { &*field_ptr };
+        // SAFETY: The dict is non-null and valid (guaranteed by constructor pre-conditions).
+        let missing_ii_ptr =
+            unsafe { ffi::RS_dictFetchValue(spec.missing_field_dict(), field.fieldName as *mut _) };
+
+        if missing_ii_ptr.is_null() {
+            // The inverted index was removed from the dict (garbage collected).
+            return true;
+        }
+
+        let missing_ii = missing_ii_ptr.cast::<inverted_index::opaque::InvertedIndex>();
+        // SAFETY: 3. guarantees the encoding variant matches E.
+        let ii = E::from_opaque(unsafe { &*missing_ii });
+
+        !self.it.reader.points_to_ii(ii)
+    }
+}
 
 impl<'index, E, C> Missing<'index, E, C>
 where
@@ -134,55 +204,9 @@ where
         }
     }
 
-    /// Check if the iterator should abort revalidation.
-    ///
-    /// The garbage collector may remove all documents from the missing-field
-    /// inverted index or replace it with a new allocation. In both cases the
-    /// reader's pointer is stale and the iterator must
-    /// [abort](RQEValidateStatus::Aborted).
-    ///
-    /// # Safety
-    ///
-    /// 1. `self.field_index` must be a valid index into `spec.fields`.
-    /// 2. `spec.missingFieldDict` must be a non-null, valid dict pointer.
-    /// 3. The entry in `missingFieldDict` for `spec.fields[field_index].fieldName`,
-    ///    when non-null, must point to an opaque
-    ///    [`InvertedIndex`](inverted_index::opaque::InvertedIndex) whose encoding
-    ///    variant matches `E`.
-    fn should_abort(&self, spec: &IndexSpecReadGuard) -> bool {
-        debug_assert!(
-            !spec.missing_field_dict().is_null(),
-            "spec.missing_field_dict() must be non-null",
-        );
-
-        // SAFETY: field_index is a valid index into spec.fields (guaranteed by constructor pre-conditions).
-        let field_ptr = unsafe { spec.fields_ptr().offset(self.field_index as isize) };
-        // SAFETY: the pointer is valid per the above.
-        let field = unsafe { &*field_ptr };
-        // SAFETY: The dict is non-null and valid (guaranteed by constructor pre-conditions).
-        let missing_ii_ptr =
-            unsafe { ffi::RS_dictFetchValue(spec.missing_field_dict(), field.fieldName as *mut _) };
-
-        if missing_ii_ptr.is_null() {
-            // The inverted index was removed from the dict (garbage collected).
-            return true;
-        }
-
-        let missing_ii = missing_ii_ptr.cast::<inverted_index::opaque::InvertedIndex>();
-        // SAFETY: 3. guarantees the encoding variant matches E.
-        let ii = E::from_opaque(unsafe { &*missing_ii });
-
-        !self.it.reader.points_to_ii(ii)
-    }
-
     /// Get a reference to the underlying reader.
     pub const fn reader(&self) -> &IndexReaderCore<'index, E> {
         &self.it.reader
-    }
-
-    /// Get the field name tracked by this missing-field iterator.
-    pub fn field_name(&self) -> (*const c_char, usize) {
-        (self.field_name.as_ptr(), self.field_name.as_bytes().len())
     }
 }
 
@@ -316,5 +340,81 @@ pub unsafe fn new_missing_iterator<'index>(
             "Missing iterator requires a DocIdsOnly or RawDocIdsOnly inverted index, got: {:?}",
             std::mem::discriminant(ii)
         ),
+    }
+}
+
+impl<'index, E, C> RQEIteratorBoxed<'index> for Missing<'index, E, C>
+where
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>> + 'static,
+    <E as DecodedBy>::Decoder: DocIdsDecoder,
+    C: ExpirationChecker + 'static,
+{
+    type Suspended = RawMissing<'index, Suspended, E, C>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawMissing` is a `#[repr(C)]` newtype whose only
+        // `Rf`-dependent field is the inner `RawInvIndIterator`, layout-identical
+        // across modes by invariant 1 on [`RawInvIndIterator`] (const proof
+        // there); `field_index` and `field_name` carry no `Rf`. `Box::from_raw`
+        // reuses the same heap allocation.
+        unsafe { Box::from_raw(raw as *mut RawMissing<'index, Suspended, E, C>) }
+    }
+}
+
+impl<'query, E, C, RA> RQESuspendedIterator<'query> for RawMissing<'query, Suspended, E, C, RA>
+where
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>> + 'static,
+    <E as DecodedBy>::Decoder: DocIdsDecoder,
+    C: ExpirationChecker + 'static,
+{
+    type Resumed<'a>
+        = Missing<'a, E, C>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        mut self: Box<Self>,
+        spec: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Step 1: identity check on the suspended form. On abort we drop the
+        // suspended iterator without promoting it to Active — nothing is
+        // materialized.
+        if self.should_abort(spec) {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        // Step 2: run the shared in-place resume transition on the inner
+        // core iterator (refresh pointers, reset stale offsets, promote the
+        // result, and re-seek if GC moved us). `spec` witnesses the read lock
+        // the refresh requires.
+        let status = self.it.resume_in_place(spec)?;
+
+        // Step 3: reinterpret the owning box's type. The heap address is
+        // preserved across the cast.
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawMissing` is a `#[repr(C)]` newtype whose only
+        // `Rf`-dependent field is the inner `RawInvIndIterator`, layout-identical
+        // across modes by invariant 1 on [`RawInvIndIterator`] (const proof
+        // there); `field_index` and `field_name` carry no `Rf`. `resume_in_place`
+        // left the inner iterator as a valid active iterator, so the whole
+        // `RawMissing` is now a valid `Missing<'a, E, C>`.
+        let active = unsafe { Box::from_raw(raw as *mut Missing<'a, E, C>) };
+
+        Ok(match status {
+            ResumeStatus::Unchanged => ResumeOutcome::Ok(active),
+            ResumeStatus::Moved => ResumeOutcome::Moved(active),
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.it.last_doc_id_field()
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.it.num_estimated()
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -12,18 +12,21 @@ use std::ptr::NonNull;
 use ffi::RedisSearchCtx;
 use index_result::{RSIndexResult, RSOffsetSlice};
 use index_spec::IndexSpecReadGuard;
-use inverted_index::{DecodedBy, DocIdsDecoder, IndexReader, IndexReaderCore, RawIndexReaderCore};
+use inverted_index::{
+    DecodedBy, DocIdsDecoder, IndexReader, IndexReaderCore, RawIndexReaderCore,
+    opaque::OpaqueEncoding,
+};
 use query_term::RSQueryTerm;
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 use crate::{
-    ExpirationChecker, IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus,
-    SkipToOutcome,
+    ExpirationChecker, IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError,
+    RQESuspendedIterator, RQEValidateStatus, ResumeOutcome, SkipToOutcome,
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 
-use super::{InvIndIterator, core::RawInvIndIterator};
+use super::{InvIndIterator, core::RawInvIndIterator, core::ResumeStatus};
 
 /// Resolves a tag value to the inverted index currently stored for it in a
 /// tag-index container.
@@ -59,6 +62,51 @@ pub struct RawTag<'query, Rf: Ref, E, L, C = crate::expiration_checker::NoOpChec
 /// [`RQEIterator`] impl today.
 pub type Tag<'index, E, L, C = crate::expiration_checker::NoOpChecker> =
     RawTag<'index, Active<'index>, E, L, C>;
+
+impl<'query, Rf: Ref, E, L, C> RawTag<'query, Rf, E, L, C> {
+    /// Cached [`IndexFlags`](ffi::IndexFlags) of the underlying inverted index — see
+    /// [`RawInvIndIterator::flags`].
+    pub const fn flags(&self) -> ffi::IndexFlags {
+        self.it.flags()
+    }
+}
+
+impl<'query, Rf: Ref, E, L, C> RawTag<'query, Rf, E, L, C>
+where
+    E: DecodedBy,
+    <E as DecodedBy>::Decoder: DocIdsDecoder,
+    L: TagLookup<E>,
+{
+    /// Check if the iterator should abort revalidation.
+    ///
+    /// The garbage collector may remove all documents from a tag value's
+    /// inverted index or replace it with a new allocation. In both cases the
+    /// reader's pointer is stale and the iterator must
+    /// [`abort`](RQEValidateStatus::Aborted).
+    ///
+    /// Defined on the `Rf`-generic [`RawTag`] so the suspended form can run it
+    /// from [`RQESuspendedIterator::resume`] before promoting to [`Active`].
+    fn should_abort(&self) -> bool {
+        let term = self
+            .it
+            .result
+            .as_term()
+            .expect("Tag iterator should always have a term result")
+            .query_term()
+            .expect("Tag iterator should always have a query term");
+
+        let term_bytes = term
+            .as_bytes()
+            .expect("Tag iterator query term should have a non-null string");
+
+        match self.lookup.find(term_bytes) {
+            // The inverted index was collected entirely by GC, or the
+            // value is a null sentinel (disk mode).
+            None => true,
+            Some(ii) => !self.it.reader.points_to_ii(ii),
+        }
+    }
+}
 
 impl<'index, E, L, C> Tag<'index, E, L, C>
 where
@@ -125,33 +173,6 @@ where
         Self {
             it: InvIndIterator::new(reader, result, expiration_checker),
             lookup,
-        }
-    }
-
-    /// Check if the iterator should abort revalidation.
-    ///
-    /// The garbage collector may remove all documents from a tag value's
-    /// inverted index or replace it with a new allocation. In both cases the
-    /// reader's pointer is stale and the iterator must
-    /// [`abort`](RQEValidateStatus::Aborted).
-    fn should_abort(&self) -> bool {
-        let term = self
-            .it
-            .result
-            .as_term()
-            .expect("Tag iterator should always have a term result")
-            .query_term()
-            .expect("Tag iterator should always have a query term");
-
-        let term_bytes = term
-            .as_bytes()
-            .expect("Tag iterator query term should have a non-null string");
-
-        match self.lookup.find(term_bytes) {
-            // The inverted index was collected entirely by GC, or the
-            // value is a null sentinel (disk mode).
-            None => true,
-            Some(ii) => !self.it.reader.points_to_ii(ii),
         }
     }
 
@@ -242,5 +263,86 @@ where
         }
         ctx.print_optional_counters(map);
         map.kv_long_long(c"Estimated number of matches", self.num_estimated() as i64);
+    }
+}
+
+impl<'index, E, L, C> RQEIteratorBoxed<'index> for Tag<'index, E, L, C>
+where
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>> + 'static,
+    <E as DecodedBy>::Decoder: DocIdsDecoder,
+    C: ExpirationChecker + 'static,
+    L: TagLookup<E> + 'static,
+{
+    // The inner reader is concretely `RawIndexReaderCore<Rf, E>`, so the core
+    // iterator's frozen `RA` slot defaults to the `Active` reader and stays
+    // identical across the cast while the inner reader weakens.
+    type Suspended = RawTag<'index, Suspended, E, L, C>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawTag` is a `#[repr(C)]` struct whose only `Rf`-dependent
+        // field is the inner `RawInvIndIterator`, layout-identical across modes
+        // by invariant 1 on [`RawInvIndIterator`] (const proof there); the
+        // `lookup` field carries no `Rf`. `Box::from_raw` reuses the same heap
+        // allocation.
+        unsafe { Box::from_raw(raw as *mut RawTag<'index, Suspended, E, L, C>) }
+    }
+}
+
+impl<'query, E, L, C> RQESuspendedIterator<'query> for RawTag<'query, Suspended, E, L, C>
+where
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>> + 'static,
+    <E as DecodedBy>::Decoder: DocIdsDecoder,
+    C: ExpirationChecker + 'static,
+    L: TagLookup<E> + 'static,
+{
+    type Resumed<'a>
+        = Tag<'a, E, L, C>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        mut self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Step 1: identity check on the suspended form. On abort we drop the
+        // suspended iterator without promoting it to Active — nothing is
+        // materialized.
+        if self.should_abort() {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        // Step 2: run the shared in-place resume transition on the inner
+        // core iterator (refresh pointers, reset stale offsets, promote the
+        // result, and re-seek if GC moved us). `guard` witnesses the read lock
+        // the refresh requires.
+        let status = self.it.resume_in_place(guard)?;
+
+        // Step 3: reinterpret the owning box's type. The heap address is
+        // preserved across the cast.
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawTag` is a `#[repr(C)]` struct whose only `Rf`-dependent
+        // field is the inner `RawInvIndIterator`, layout-identical across modes
+        // by invariant 1 on [`RawInvIndIterator`] (const proof there); the
+        // `lookup` field carries no `Rf`. `resume_in_place` left the inner
+        // iterator as a valid active iterator, so the whole `RawTag` is now a
+        // valid `Tag<'a, E, L, C>`.
+        let active = unsafe { Box::from_raw(raw as *mut Tag<'a, E, L, C>) };
+
+        Ok(match status {
+            ResumeStatus::Unchanged => ResumeOutcome::Ok(active),
+            ResumeStatus::Moved => ResumeOutcome::Moved(active),
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.it.last_doc_id_field()
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.it.num_estimated()
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -14,9 +14,9 @@ use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use index_result::{RSIndexResult, RSOffsetSlice};
 use index_spec::IndexSpecReadGuard;
 use inverted_index::{
-    FilterMaskReader, IndexReader, IndexReaderCore, TermReader, doc_ids_only::DocIdsOnly,
-    fields_offsets, fields_only, freqs_fields, freqs_offsets, freqs_only, full, offsets_only,
-    opaque::InvertedIndex, raw_doc_ids_only::RawDocIdsOnly,
+    FilterMaskReader, IndexReader, IndexReaderCore, PointsToOpaqueIndex, TermReader,
+    doc_ids_only::DocIdsOnly, fields_offsets, fields_only, freqs_fields, freqs_offsets, freqs_only,
+    full, offsets_only, opaque::InvertedIndex, raw_doc_ids_only::RawDocIdsOnly,
 };
 use query_term::RSQueryTerm;
 use ref_mode::{Active, Ref};
@@ -349,7 +349,7 @@ impl<'index> IndexReader<'index> for TermIndexReader<'index> {
     }
 }
 
-impl<'index> TermReader<'index> for TermIndexReader<'index> {
+impl PointsToOpaqueIndex for TermIndexReader<'_> {
     fn points_to_the_same_opaque_index(
         &self,
         opaque: &inverted_index::opaque::InvertedIndex,
@@ -357,6 +357,8 @@ impl<'index> TermReader<'index> for TermIndexReader<'index> {
         term_ir_dispatch!(self, points_to_the_same_opaque_index, opaque)
     }
 }
+
+impl<'index> TermReader<'index> for TermIndexReader<'index> {}
 
 /// Build a term-query iterator over an in-memory inverted index.
 ///

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -14,22 +14,23 @@ use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use index_result::{RSIndexResult, RSOffsetSlice};
 use index_spec::IndexSpecReadGuard;
 use inverted_index::{
-    FilterMaskReader, IndexReader, IndexReaderCore, PointsToOpaqueIndex, TermReader,
-    doc_ids_only::DocIdsOnly, fields_offsets, fields_only, freqs_fields, freqs_offsets, freqs_only,
-    full, offsets_only, opaque::InvertedIndex, raw_doc_ids_only::RawDocIdsOnly,
+    FilterMaskReader, IndexReader, PointsToOpaqueIndex, RawIndexReaderCore, RefreshOutcome,
+    ResumableReader, SuspendableReader, TermReader, doc_ids_only::DocIdsOnly, fields_offsets,
+    fields_only, freqs_fields, freqs_offsets, freqs_only, full, offsets_only,
+    opaque::InvertedIndex, raw_doc_ids_only::RawDocIdsOnly,
 };
 use query_term::RSQueryTerm;
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 use crate::{
-    FieldExpirationChecker, IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus,
-    SkipToOutcome,
+    FieldExpirationChecker, IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError,
+    RQESuspendedIterator, RQEValidateStatus, ResumeOutcome, SkipToOutcome,
     expiration_checker::ExpirationChecker,
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 
-use super::core::{InvIndIterator, RawInvIndIterator};
+use super::core::{InvIndIterator, RawInvIndIterator, ResumeStatus};
 
 /// An iterator over term inverted index entries, parameterised over a
 /// [`Ref`] mode. See [`Term`] for the [`Active`] instantiation that
@@ -41,14 +42,14 @@ use super::core::{InvIndIterator, RawInvIndIterator};
 /// * `R` - The reader type used to read the inverted index.
 /// * `E` - The expiration checker type used to check for expired documents.
 #[repr(C)]
-pub struct RawTerm<'query, Rf: Ref, R, E = crate::expiration_checker::NoOpChecker> {
-    it: RawInvIndIterator<'query, Rf, R, E>,
+pub struct RawTerm<'query, Rf: Ref, R, E = crate::expiration_checker::NoOpChecker, RA = R> {
+    it: RawInvIndIterator<'query, Rf, R, E, RA>,
 }
 
 /// Alias for an [`Active`] [`RawTerm`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
 pub type Term<'index, R, E = crate::expiration_checker::NoOpChecker> =
-    RawTerm<'index, Active<'index>, R, E>;
+    RawTerm<'index, Active<'index>, R, E, R>;
 
 impl<'index, R, E> Term<'index, R, E>
 where
@@ -104,7 +105,12 @@ where
     pub const fn reader(&self) -> &R {
         &self.it.reader
     }
+}
 
+impl<'query, Rf: Ref, R, E, RA> RawTerm<'query, Rf, R, E, RA>
+where
+    R: PointsToOpaqueIndex,
+{
     /// Check if the iterator should abort revalidation.
     ///
     /// The term's inverted index may have been garbage-collected and
@@ -255,45 +261,77 @@ where
 
 /// A reader over any term-compatible inverted index encoding, erasing the
 /// encoding type behind a single enum so callers don't need to be generic over
-/// it.
+/// it. Parameterised over a [`Ref`] mode `Rf`; see [`TermIndexReader`] for the
+/// [`Active`] instantiation (the live reader implementing [`IndexReader`]).
+/// `RawTermIndexReader<Suspended>` is its passive carrier across a lock
+/// release/reacquire cycle (implementing [`ResumableReader`]).
 ///
 /// Encodings that track a field mask filter their records through a
 /// [`FilterMaskReader`]; encodings without field-mask data use the bare
-/// [`IndexReaderCore`].
-pub enum TermIndexReader<'index> {
+/// [`RawIndexReaderCore`].
+///
+/// # Invariants
+///
+/// 1. **Layout compatibility across modes.** `RawTermIndexReader<Active<'index>>`
+///    and `RawTermIndexReader<Suspended>` are layout-identical, so the owning
+///    `RawInvIndIterator` can suspend/resume by a same-allocation reinterpretation
+///    — the [`SuspendableReader`]/[`ResumableReader`] contract. This holds because
+///    it is a single `#[repr(C)]` generic whose `Rf` flows only through the
+///    per-variant [`RawIndexReaderCore`]/[`FilterMaskReader`] payloads, each itself
+///    layout-compatible (invariant 1 on those types). Enforced by the `const _`
+///    proof below.
+#[repr(C)]
+pub enum RawTermIndexReader<Rf: Ref> {
     // Field-mask-tracking encodings (filtered through `FilterMaskReader`).
-    Full(FilterMaskReader<IndexReaderCore<'index, full::Full>>),
-    FullWide(FilterMaskReader<IndexReaderCore<'index, full::FullWide>>),
-    FreqsFields(FilterMaskReader<IndexReaderCore<'index, freqs_fields::FreqsFields>>),
-    FreqsFieldsWide(FilterMaskReader<IndexReaderCore<'index, freqs_fields::FreqsFieldsWide>>),
-    FieldsOnly(FilterMaskReader<IndexReaderCore<'index, fields_only::FieldsOnly>>),
-    FieldsOnlyWide(FilterMaskReader<IndexReaderCore<'index, fields_only::FieldsOnlyWide>>),
-    FieldsOffsets(FilterMaskReader<IndexReaderCore<'index, fields_offsets::FieldsOffsets>>),
-    FieldsOffsetsWide(FilterMaskReader<IndexReaderCore<'index, fields_offsets::FieldsOffsetsWide>>),
+    Full(FilterMaskReader<RawIndexReaderCore<Rf, full::Full>>),
+    FullWide(FilterMaskReader<RawIndexReaderCore<Rf, full::FullWide>>),
+    FreqsFields(FilterMaskReader<RawIndexReaderCore<Rf, freqs_fields::FreqsFields>>),
+    FreqsFieldsWide(FilterMaskReader<RawIndexReaderCore<Rf, freqs_fields::FreqsFieldsWide>>),
+    FieldsOnly(FilterMaskReader<RawIndexReaderCore<Rf, fields_only::FieldsOnly>>),
+    FieldsOnlyWide(FilterMaskReader<RawIndexReaderCore<Rf, fields_only::FieldsOnlyWide>>),
+    FieldsOffsets(FilterMaskReader<RawIndexReaderCore<Rf, fields_offsets::FieldsOffsets>>),
+    FieldsOffsetsWide(FilterMaskReader<RawIndexReaderCore<Rf, fields_offsets::FieldsOffsetsWide>>),
     // Encodings without field-mask data (no `FilterMaskReader`).
-    FreqsOnly(IndexReaderCore<'index, freqs_only::FreqsOnly>),
-    OffsetsOnly(IndexReaderCore<'index, offsets_only::OffsetsOnly>),
-    FreqsOffsets(IndexReaderCore<'index, freqs_offsets::FreqsOffsets>),
-    DocIdsOnly(IndexReaderCore<'index, DocIdsOnly>),
-    RawDocIdsOnly(IndexReaderCore<'index, RawDocIdsOnly>),
+    FreqsOnly(RawIndexReaderCore<Rf, freqs_only::FreqsOnly>),
+    OffsetsOnly(RawIndexReaderCore<Rf, offsets_only::OffsetsOnly>),
+    FreqsOffsets(RawIndexReaderCore<Rf, freqs_offsets::FreqsOffsets>),
+    DocIdsOnly(RawIndexReaderCore<Rf, DocIdsOnly>),
+    RawDocIdsOnly(RawIndexReaderCore<Rf, RawDocIdsOnly>),
 }
 
+/// Active-form alias of [`RawTermIndexReader`] — the live term reader.
+pub type TermIndexReader<'index> = RawTermIndexReader<Active<'index>>;
+
+// Compile-time proof of invariant 1 on `RawTermIndexReader`: its `Active` and
+// `Suspended` instantiations are layout-identical. As an enum we assert size and
+// alignment equality; the per-variant payloads are layout-compatible by their own
+// invariant 1, so a divergence here would be a build error.
+const _: () = {
+    use std::mem::{align_of, size_of};
+    type A = RawTermIndexReader<Active<'static>>;
+    type S = RawTermIndexReader<Suspended>;
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
+/// Dispatch a method call to the reader held by the current variant. Works for
+/// any `Rf` because every variant carries the same name across modes.
 macro_rules! term_ir_dispatch {
     ($self:expr, $method:ident $(, $args:expr)*) => {
         match $self {
-            TermIndexReader::Full(r) => r.$method($($args),*),
-            TermIndexReader::FullWide(r) => r.$method($($args),*),
-            TermIndexReader::FreqsFields(r) => r.$method($($args),*),
-            TermIndexReader::FreqsFieldsWide(r) => r.$method($($args),*),
-            TermIndexReader::FieldsOnly(r) => r.$method($($args),*),
-            TermIndexReader::FieldsOnlyWide(r) => r.$method($($args),*),
-            TermIndexReader::FieldsOffsets(r) => r.$method($($args),*),
-            TermIndexReader::FieldsOffsetsWide(r) => r.$method($($args),*),
-            TermIndexReader::FreqsOnly(r) => r.$method($($args),*),
-            TermIndexReader::OffsetsOnly(r) => r.$method($($args),*),
-            TermIndexReader::FreqsOffsets(r) => r.$method($($args),*),
-            TermIndexReader::DocIdsOnly(r) => r.$method($($args),*),
-            TermIndexReader::RawDocIdsOnly(r) => r.$method($($args),*),
+            RawTermIndexReader::Full(r) => r.$method($($args),*),
+            RawTermIndexReader::FullWide(r) => r.$method($($args),*),
+            RawTermIndexReader::FreqsFields(r) => r.$method($($args),*),
+            RawTermIndexReader::FreqsFieldsWide(r) => r.$method($($args),*),
+            RawTermIndexReader::FieldsOnly(r) => r.$method($($args),*),
+            RawTermIndexReader::FieldsOnlyWide(r) => r.$method($($args),*),
+            RawTermIndexReader::FieldsOffsets(r) => r.$method($($args),*),
+            RawTermIndexReader::FieldsOffsetsWide(r) => r.$method($($args),*),
+            RawTermIndexReader::FreqsOnly(r) => r.$method($($args),*),
+            RawTermIndexReader::OffsetsOnly(r) => r.$method($($args),*),
+            RawTermIndexReader::FreqsOffsets(r) => r.$method($($args),*),
+            RawTermIndexReader::DocIdsOnly(r) => r.$method($($args),*),
+            RawTermIndexReader::RawDocIdsOnly(r) => r.$method($($args),*),
         }
     };
 }
@@ -349,7 +387,10 @@ impl<'index> IndexReader<'index> for TermIndexReader<'index> {
     }
 }
 
-impl PointsToOpaqueIndex for TermIndexReader<'_> {
+/// Resolve an opaque index and compare it against the current variant's reader.
+/// Implemented for every `Rf` so it is callable from the suspended-side
+/// `should_abort` check as well as the active reader.
+impl<Rf: Ref> PointsToOpaqueIndex for RawTermIndexReader<Rf> {
     fn points_to_the_same_opaque_index(
         &self,
         opaque: &inverted_index::opaque::InvertedIndex,
@@ -359,6 +400,32 @@ impl PointsToOpaqueIndex for TermIndexReader<'_> {
 }
 
 impl<'index> TermReader<'index> for TermIndexReader<'index> {}
+
+/// `TermIndexReader<'index>` suspends to `RawTermIndexReader<Suspended>` — the
+/// same generic enum with the ref mode weakened.
+///
+/// SAFETY: layout compatibility is invariant 1 on [`RawTermIndexReader`] (const
+/// proof there).
+unsafe impl<'index> SuspendableReader for TermIndexReader<'index> {
+    type Suspended = RawTermIndexReader<Suspended>;
+}
+
+/// Inverse of the above: `RawTermIndexReader<Suspended>` resumes to
+/// `TermIndexReader<'a>` at any index lifetime `'a`. `refresh_pointers` forwards
+/// to the suspended reader held by the current variant.
+///
+/// SAFETY: layout compatibility is invariant 1 on [`RawTermIndexReader`] (const
+/// proof there).
+unsafe impl ResumableReader for RawTermIndexReader<Suspended> {
+    type Resumed<'a> = TermIndexReader<'a>;
+
+    unsafe fn refresh_pointers(&mut self) -> RefreshOutcome {
+        // SAFETY: our caller upholds `ResumableReader::refresh_pointers`'s
+        // no-concurrent-aliasing obligation, which we forward unchanged to the
+        // per-variant suspended reader.
+        unsafe { term_ir_dispatch!(self, refresh_pointers) }
+    }
+}
 
 /// Build a term-query iterator over an in-memory inverted index.
 ///
@@ -435,4 +502,84 @@ pub unsafe fn build_term_iterator<'index>(
     // SAFETY: `reader` was just built from the valid `idx`; preconditions (2)/(3)
     // uphold the remaining `Term::new` requirements (valid `sctx`, owned `term`).
     unsafe { Term::new(reader, sctx, term, weight, expiration_checker) }
+}
+
+impl<'index, R, E> RQEIteratorBoxed<'index> for Term<'index, R, E>
+where
+    R: TermReader<'index> + SuspendableReader + 'index,
+    R::Suspended: ResumableReader + PointsToOpaqueIndex,
+    for<'a> <R::Suspended as ResumableReader>::Resumed<'a>: TermReader<'a>,
+    E: ExpirationChecker + 'static,
+{
+    // Reader weakens `R -> R::Suspended`; the frozen `RA` slot stays `R` (the
+    // active reader) so the inner iterator's dispatch pointers are unchanged.
+    type Suspended = RawTerm<'index, Suspended, R::Suspended, E, R>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawTerm` is a `#[repr(C)]` newtype over the inner
+        // `RawInvIndIterator`, layout-identical across modes by invariant 1 on
+        // [`RawInvIndIterator`] (const proof there): `reader` weakens `R ->
+        // R::Suspended` (given the reader's own layout invariant) while the
+        // frozen `RA = R` slot keeps the dispatch pointers unchanged.
+        // `Box::from_raw` reuses the same heap allocation.
+        unsafe { Box::from_raw(raw as *mut RawTerm<'index, Suspended, R::Suspended, E, R>) }
+    }
+}
+
+impl<'query, RS, E, RA> RQESuspendedIterator<'query> for RawTerm<'query, Suspended, RS, E, RA>
+where
+    RS: ResumableReader + PointsToOpaqueIndex,
+    for<'a> RS::Resumed<'a>: TermReader<'a>,
+    E: ExpirationChecker + 'static,
+{
+    type Resumed<'a>
+        = Term<'a, RS::Resumed<'a>, E>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        mut self: Box<Self>,
+        spec: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Step 1: identity check on the suspended form. On abort we drop the
+        // suspended iterator without promoting it to Active — nothing is
+        // materialized.
+        if self.should_abort(spec) {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        // Step 2: run the shared in-place resume transition on the inner
+        // core iterator (refresh pointers, reset stale offsets, promote the
+        // result, and re-seek if GC moved us). `spec` witnesses the read lock
+        // the refresh requires.
+        let status = self.it.resume_in_place(spec)?;
+
+        // Step 3: reinterpret the owning box's type. The heap address is
+        // preserved across the cast.
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawTerm` is a `#[repr(C)]` newtype over the inner
+        // `RawInvIndIterator`, layout-identical across modes by invariant 1 on
+        // [`RawInvIndIterator`] (const proof there); `resume_in_place` left that
+        // field as a valid active iterator (reader promoted to `RS::Resumed<'a>`,
+        // dispatch pointers unchanged), so the whole `RawTerm` is now a valid
+        // `Term<'a, RS::Resumed<'a>, E>`.
+        let active = unsafe { Box::from_raw(raw as *mut Term<'a, RS::Resumed<'a>, E>) };
+
+        Ok(match status {
+            ResumeStatus::Unchanged => ResumeOutcome::Ok(active),
+            ResumeStatus::Moved => ResumeOutcome::Moved(active),
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.it.last_doc_id_field()
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.it.num_estimated()
+    }
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
@@ -12,16 +12,17 @@ use index_spec::IndexSpecReadGuard;
 use inverted_index::{
     DecodedBy, DocIdsDecoder, IndexReaderCore, RawIndexReaderCore, opaque::OpaqueEncoding,
 };
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
     expiration_checker::NoOpChecker,
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 
-use super::core::{InvIndIterator, RawInvIndIterator};
+use super::core::{InvIndIterator, RawInvIndIterator, ResumeStatus};
 use rqe_core::RS_FIELDMASK_ALL;
 
 /// An iterator over all existing documents in an index, parameterised over
@@ -41,13 +42,55 @@ use rqe_core::RS_FIELDMASK_ALL;
 /// * `Rf` - The [`Ref`] mode (see [`RawInvIndIterator`] for details).
 /// * `E` - The encoding type for the inverted index. Its decoder must implement [`DocIdsDecoder`].
 #[repr(C)]
-pub struct RawWildcard<'query, Rf: Ref, E: DecodedBy> {
-    it: RawInvIndIterator<'query, Rf, RawIndexReaderCore<Rf, E>>,
+pub struct RawWildcard<
+    'query,
+    Rf: Ref,
+    E: DecodedBy,
+    // Frozen active reader for the inner iterator's dispatch pointers; hardcoded
+    // to the `Active` reader regardless of `Rf` (see `RawInvIndIterator`'s `RA`).
+    RA = RawIndexReaderCore<Active<'query>, E>,
+> {
+    // `pub(crate)` so the top-level `OptimizedWildcard` wrapper can drive the
+    // inner iterator's `resume_in_place` on its inline variants.
+    pub(crate) it: RawInvIndIterator<'query, Rf, RawIndexReaderCore<Rf, E>, NoOpChecker, RA>,
 }
 
 /// Alias for an [`Active`] [`RawWildcard`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
 pub type Wildcard<'index, E> = RawWildcard<'index, Active<'index>, E>;
+
+impl<'query, Rf: Ref, E, RA> RawWildcard<'query, Rf, E, RA>
+where
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+    <E as DecodedBy>::Decoder: DocIdsDecoder,
+{
+    /// Check if the iterator should abort revalidation.
+    ///
+    /// The garbage collector may either null out `existingDocs` (after
+    /// collecting all documents) or replace it with a new allocation. In
+    /// both cases the reader's pointer is stale and the iterator must
+    /// [abort](RQEValidateStatus::Aborted).
+    ///
+    /// # Safety
+    ///
+    /// 1. `spec.existingDocs`, when non-null, must point to an opaque
+    ///    [`InvertedIndex`](inverted_index::InvertedIndex) whose encoding
+    ///    variant matches `E`.
+    ///
+    /// `pub(crate)` so the top-level `OptimizedWildcard` wrapper can run the
+    /// identity check on its inline inverted-index wildcard variants.
+    pub(crate) fn should_abort(&self, spec: &IndexSpecReadGuard) -> bool {
+        // the garbage collector may set existing_docs to NULL after garbage collecting all documents
+        let Some(existing_docs) = spec.existing_docs() else {
+            return true;
+        };
+
+        // SAFETY: The encoding variant matches E (structural invariant).
+        let ii = E::from_opaque(existing_docs);
+
+        !self.it.reader.points_to_ii(ii)
+    }
+}
 
 impl<'index, E> Wildcard<'index, E>
 where
@@ -69,30 +112,6 @@ where
             // Wildcard iterator does not support expiration check
             it: InvIndIterator::new(reader, result, NoOpChecker),
         }
-    }
-
-    /// Check if the iterator should abort revalidation.
-    ///
-    /// The garbage collector may either null out `existingDocs` (after
-    /// collecting all documents) or replace it with a new allocation. In
-    /// both cases the reader's pointer is stale and the iterator must
-    /// [abort](RQEValidateStatus::Aborted).
-    ///
-    /// # Safety
-    ///
-    /// 1. `spec.existingDocs`, when non-null, must point to an opaque
-    ///    [`InvertedIndex`](inverted_index::InvertedIndex) whose encoding
-    ///    variant matches `E`.
-    fn should_abort(&self, spec: &IndexSpecReadGuard) -> bool {
-        // the garbage collector may set existing_docs to NULL after garbage collecting all documents
-        let Some(existing_docs) = spec.existing_docs() else {
-            return true;
-        };
-
-        // SAFETY: The encoding variant matches E (structural invariant).
-        let ii = E::from_opaque(existing_docs);
-
-        !self.it.reader.points_to_ii(ii)
     }
 
     /// Get a reference to the underlying reader.
@@ -171,5 +190,77 @@ where
 impl<E: DecodedBy> ProfilePrint for Wildcard<'_, E> {
     fn print_profile(&self, map: &mut redis_reply::MapBuilder<'_>, ctx: &mut ProfilePrintCtx<'_>) {
         ctx.print_leaf(c"WILDCARD", map);
+    }
+}
+
+impl<'index, E> RQEIteratorBoxed<'index> for Wildcard<'index, E>
+where
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>> + 'static,
+    <E as DecodedBy>::Decoder: DocIdsDecoder,
+{
+    type Suspended = RawWildcard<'index, Suspended, E>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawWildcard` is a `#[repr(C)]` newtype whose only
+        // `Rf`-dependent field is the inner `RawInvIndIterator`, layout-identical
+        // across modes by invariant 1 on [`RawInvIndIterator`] (const proof
+        // there). `Box::from_raw` reuses the same heap allocation.
+        unsafe { Box::from_raw(raw as *mut RawWildcard<'index, Suspended, E>) }
+    }
+}
+
+impl<'query, E, RA> RQESuspendedIterator<'query> for RawWildcard<'query, Suspended, E, RA>
+where
+    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>> + 'static,
+    <E as DecodedBy>::Decoder: DocIdsDecoder,
+{
+    type Resumed<'a>
+        = Wildcard<'a, E>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        mut self: Box<Self>,
+        spec: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Step 1: identity check on the suspended form. On abort we drop the
+        // suspended iterator without promoting it to Active — nothing is
+        // materialized.
+        if self.should_abort(spec) {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        // Step 2: run the shared in-place resume transition on the inner
+        // core iterator (refresh pointers, reset stale offsets, promote the
+        // result, and re-seek if GC moved us). `spec` witnesses the read lock
+        // the refresh requires.
+        let status = self.it.resume_in_place(spec)?;
+
+        // Step 3: reinterpret the owning box's type. The heap address is
+        // preserved across the cast.
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawWildcard` is a `#[repr(C)]` newtype whose only
+        // `Rf`-dependent field is the inner `RawInvIndIterator`, layout-identical
+        // across modes by invariant 1 on [`RawInvIndIterator`] (const proof
+        // there). `resume_in_place` left the inner iterator as a valid active
+        // iterator, so the whole `RawWildcard` is now a valid `Wildcard<'a, E>`.
+        let active = unsafe { Box::from_raw(raw as *mut Wildcard<'a, E>) };
+
+        Ok(match status {
+            ResumeStatus::Unchanged => ResumeOutcome::Ok(active),
+            ResumeStatus::Moved => ResumeOutcome::Moved(active),
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.it.last_doc_id_field()
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.it.num_estimated()
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -263,4 +263,101 @@ mod not_miri {
         assert_eq!(field_name.to_bytes().len(), field_name_len);
         assert_eq!(field_name.to_bytes(), b"text_field");
     }
+
+    mod via_resume {
+        use super::*;
+        use crate::inverted_index::utils::via_resume::{
+            revalidate_after_document_deleted, revalidate_at_eof, revalidate_basic,
+        };
+        use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator};
+        use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+        #[test]
+        fn missing_revalidate_basic() {
+            let test = MissingRevalidateTest::new(10);
+            let it = test.create_iterator();
+            revalidate_basic(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn missing_revalidate_at_eof() {
+            let test = MissingRevalidateTest::new(10);
+            let it = test.create_iterator();
+            revalidate_at_eof(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn missing_revalidate_after_index_disappears() {
+            let test = MissingRevalidateTest::new(10);
+            let it = Box::new(test.create_iterator());
+            // Verify the iterator works normally and read at least one document
+            let guard = test.test.context.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+                .expect("resume should not fail in this test")
+                .expect_ok();
+            assert!(it.read().expect("failed to read").is_some());
+            let it = revalidate_via_resume(it, &guard)
+                .expect("resume should not fail in this test")
+                .expect_ok();
+
+            // Simulate the missing-field inverted index being garbage collected and
+            // recreated by replacing the dict entry with a new inverted index.
+            let new_ii =
+                Box::into_raw(Box::new(inverted_index::opaque::InvertedIndex::DocIdsOnly(
+                    inverted_index::InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
+                )));
+            let field_name = test.test.context.field_spec().fieldName;
+
+            let dict = test.test.context.spec_read().missing_field_dict();
+            unsafe {
+                ffi::RS_dictDelete(dict, field_name as *mut _);
+                let rc = ffi::RS_dictAdd(dict, field_name as *mut _, new_ii as *mut _);
+                assert_eq!(rc, 0, "dictAdd failed");
+            }
+
+            // Revalidate should return Aborted because the missing II no longer
+            // points to the same index the reader was created from.
+            let outcome =
+                revalidate_via_resume(it, &guard).expect("resume should not fail in this test");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+        }
+
+        #[test]
+        fn missing_revalidate_after_document_deleted() {
+            let test = MissingRevalidateTest::new(10);
+            let it = test.create_iterator();
+            let ii = DocIdsOnly::from_mut_opaque(test.test.context.missing_inverted_index());
+
+            revalidate_after_document_deleted(&test.test, Box::new(it), ii);
+        }
+
+        /// Test that revalidation returns `Aborted` when the missing-field inverted
+        /// index is removed from the dict (entry deleted), simulating the garbage
+        /// collector removing all documents.
+        #[test]
+        fn missing_revalidate_after_dict_entry_removed() {
+            let test = MissingRevalidateTest::new(10);
+            let mut it = Box::new(test.create_iterator());
+
+            // Read at least one document so the iterator has a position.
+            assert!(it.read().expect("failed to read").is_some());
+            let guard = test.test.context.spec_read();
+            let it = revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+                .expect("resume should not fail in this test")
+                .expect_ok();
+
+            // Simulate the garbage collector removing the missing-field index
+            // by deleting the dict entry.
+            let field_name = test.test.context.field_spec().fieldName;
+            let dict = test.test.context.spec_read().missing_field_dict();
+            unsafe {
+                ffi::RS_dictDelete(dict, field_name as *mut _);
+            }
+
+            // `should_abort` sees NULL from `dictFetchValue` and returns true.
+            let outcome =
+                revalidate_via_resume(it, &guard).expect("resume should not fail in this test");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+        }
+    }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -290,4 +290,126 @@ mod not_miri {
         let ii = DocIdsOnly::from_opaque(test.test.context.tag_inverted_index());
         assert!(reader.points_to_ii(ii));
     }
+
+    mod via_resume {
+        use super::*;
+        use crate::inverted_index::utils::via_resume::{
+            revalidate_after_document_deleted, revalidate_at_eof, revalidate_basic,
+        };
+        use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator};
+        use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+        #[test]
+        fn tag_revalidate_basic() {
+            let test = TagRevalidateTest::new(10);
+            let it = test.create_iterator();
+            revalidate_basic(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn tag_revalidate_at_eof() {
+            let test = TagRevalidateTest::new(10);
+            let it = test.create_iterator();
+            revalidate_at_eof(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn tag_revalidate_after_index_disappears() {
+            let test = TagRevalidateTest::new(10);
+            let it = Box::new(test.create_iterator());
+
+            // Verify the iterator works normally and read at least one document
+            let guard = test.test.context.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+                .expect("resume should not fail in this test")
+                .expect_ok();
+            assert!(it.read().expect("failed to read").is_some());
+            let it = revalidate_via_resume(it, &guard)
+                .expect("resume should not fail in this test")
+                .expect_ok();
+
+            // Simulate the tag's inverted index being garbage collected and
+            // recreated by replacing the TrieMap entry with a new inverted index.
+            let new_ii =
+                Box::into_raw(Box::new(inverted_index::opaque::InvertedIndex::DocIdsOnly(
+                    inverted_index::InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
+                )));
+
+            // Save the old II pointer so we can free it after the test.
+            let old_ii: *mut inverted_index::opaque::InvertedIndex =
+                (test.test.context.tag_inverted_index()
+                    as *mut inverted_index::opaque::InvertedIndex)
+                    .cast();
+
+            let tag_index = test.test.context.tag_index();
+
+            // Delete the old entry then add the new one.
+            // SAFETY: `tag_index` is valid (created by `TagIndex_Ensure`), `values`
+            // is a valid TrieMap.
+            let trie = unsafe { &mut *tag_index.as_ref().values.cast::<trie_rs::TrieMapOpaque>() };
+            let old_val = trie.remove(b"test_tag");
+            assert!(old_val.is_some(), "test_tag should exist in the TrieMap");
+            let prev = trie.insert(b"test_tag", new_ii as *mut c_void);
+            assert!(prev.is_none(), "insert should return None for new entry");
+
+            // Revalidate should return Aborted because the tag II no longer
+            // points to the same index the reader was created from.
+            let outcome =
+                revalidate_via_resume(it, &guard).expect("resume should not fail in this test");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+
+            // SAFETY: `old_ii` was allocated by `NewInvertedIndex_Ex` (via `Box::new`)
+            // and has not been freed. We are the sole owner after removing it from the TrieMap.
+            unsafe { drop(Box::from_raw(old_ii)) };
+        }
+
+        #[test]
+        fn tag_revalidate_after_document_deleted() {
+            let test = TagRevalidateTest::new(10);
+            let it = test.create_iterator();
+            let ii = DocIdsOnly::from_mut_opaque(test.test.context.tag_inverted_index());
+
+            revalidate_after_document_deleted(&test.test, Box::new(it), ii);
+        }
+
+        /// Test that revalidation returns `Aborted` when the tag value is removed
+        /// from the TagIndex's TrieMap, simulating the garbage collector removing
+        /// all documents for this tag.
+        #[test]
+        fn tag_revalidate_after_triemap_entry_removed() {
+            let test = TagRevalidateTest::new(10);
+            let mut it = Box::new(test.create_iterator());
+
+            // Read at least one document so the iterator has a position.
+            assert!(it.read().expect("failed to read").is_some());
+            let guard = test.test.context.spec_read();
+            let it = revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+                .expect("resume should not fail in this test")
+                .expect_ok();
+
+            // Save the old II pointer so we can free it after the test.
+            let old_ii: *mut inverted_index::opaque::InvertedIndex =
+                (test.test.context.tag_inverted_index()
+                    as *mut inverted_index::opaque::InvertedIndex)
+                    .cast();
+
+            // Simulate the garbage collector removing the tag's inverted index
+            // by deleting the TrieMap entry.
+            let tag_index = test.test.context.tag_index();
+            // SAFETY: `tag_index` is valid (created by `TagIndex_Ensure`), `values`
+            // is a valid TrieMap.
+            let trie = unsafe { &mut *tag_index.as_ref().values.cast::<trie_rs::TrieMapOpaque>() };
+            let old_val = trie.remove(b"test_tag");
+            assert!(old_val.is_some(), "test_tag should exist in the TrieMap");
+
+            // `should_abort` sees the tag value is missing and returns true.
+            let outcome =
+                revalidate_via_resume(it, &guard).expect("resume should not fail in this test");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+
+            // SAFETY: `old_ii` was allocated by `NewInvertedIndex_Ex` (via `Box::new`)
+            // and has not been freed. We are the sole owner after removing it from the TrieMap.
+            unsafe { drop(Box::from_raw(old_ii)) };
+        }
+    }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -441,4 +441,157 @@ mod not_miri {
 
         test.test.revalidate_after_document_deleted(&mut it, ii);
     }
+
+    mod via_resume {
+        use super::*;
+        use crate::inverted_index::utils::via_resume::{
+            revalidate_after_document_deleted, revalidate_at_eof, revalidate_basic,
+        };
+        use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator};
+        use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+        #[test]
+        fn term_revalidate_basic() {
+            let test = TermRevalidateTest::new(10);
+            let it = test.create_iterator();
+            revalidate_basic(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn term_revalidate_at_eof() {
+            let test = TermRevalidateTest::new(10);
+            let it = test.create_iterator();
+            revalidate_at_eof(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn term_revalidate_after_index_disappears() {
+            let test = TermRevalidateTest::new(10);
+            let guard = test.test.context.spec_read();
+
+            // First, verify the iterator works normally through a resume cycle.
+            let it = Box::new(test.create_iterator());
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+                .expect("resume should not fail in this test")
+                .expect_ok();
+            assert!(it.read().expect("failed to read").is_some());
+            revalidate_via_resume(it, &guard)
+                .expect("resume should not fail in this test")
+                .expect_ok();
+
+            // Now simulate the term's inverted index being garbage collected and
+            // replaced: build a fresh iterator and swap its stored index pointer to
+            // a different (dummy) index. Redis_OpenInvertedIndex still returns the
+            // original, so the pointer comparison fails and resume must abort.
+            //
+            // (Unlike the `revalidate` path, `resume` consumes the iterator and
+            // erases its concrete type, so the swap is performed on a fresh
+            // concrete iterator before the single aborting resume rather than
+            // between resumes of the same iterator.)
+            let mut it = Box::new(test.create_iterator());
+            let flags = test.test.context.term_inverted_index().flags();
+            let dummy_ptr = Box::into_raw(Box::new(inverted_index::InvertedIndex::<
+                inverted_index::full::Full,
+            >::new(flags)));
+            // SAFETY: `dummy_ptr` was just allocated and is valid.
+            let mut dummy_ref: &inverted_index::InvertedIndex<inverted_index::full::Full> =
+                unsafe { &*dummy_ptr };
+            it.swap_index(&mut dummy_ref);
+
+            let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+                .expect("resume should not fail in this test");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+
+            // The aborting resume consumed and dropped the iterator; its reader
+            // held a non-owning pointer to the dummy index, so the dummy is still
+            // leaked. Free it.
+            // SAFETY: `dummy_ptr` was allocated via `Box::into_raw` and not freed.
+            drop(unsafe { Box::from_raw(dummy_ptr) });
+        }
+
+        #[test]
+        fn term_revalidate_after_index_gc_collected() {
+            let test = TermRevalidateTest::new(10);
+
+            // Build the iterator with a query term that does not exist in keysDict.
+            // This simulates the GC having collected the entire inverted index for
+            // that term: Redis_OpenInvertedIndex will return null when should_abort
+            // tries to look it up.
+            let field_mask = test.test.context.text_field_bit();
+            let reader = test.test.context.term_inverted_index().reader(field_mask);
+            let gc_collected_term = RSQueryTerm::new("gc_collected", 1, 0);
+            // SAFETY: reader and sctx are valid pointers from the test context.
+            let mut it = Box::new(unsafe {
+                Term::new(
+                    reader,
+                    test.test.context.sctx,
+                    gc_collected_term,
+                    1.0,
+                    NoOpChecker,
+                )
+            });
+
+            // The reader still works because it reads from the actual inverted
+            // index — only the query term stored in the result differs.
+            assert!(it.read().expect("failed to read").is_some());
+
+            // Revalidation calls should_abort which looks up "gc_collected" in
+            // keysDict. The term is not there so Redis_OpenInvertedIndex returns
+            // null, triggering the abort path.
+            let guard = test.test.context.spec_read();
+            let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+                .expect("resume should not fail in this test");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+        }
+
+        #[test]
+        fn term_revalidate_after_document_deleted() {
+            let test = TermRevalidateTest::new(10);
+            let it = test.create_iterator();
+            let ii = {
+                use inverted_index::{full::Full, opaque::OpaqueEncoding};
+                Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut()
+            };
+
+            revalidate_after_document_deleted(&test.test, Box::new(it), ii);
+        }
+
+        /// Regression test for the "skip the first result" bug.
+        ///
+        /// A freshly-created iterator that is suspended *before any `read()`*
+        /// and then hit by a GC cycle (`NeedsReseek`) must still return its
+        /// first document on the first post-resume `read()`. The shared
+        /// `resume_in_place` re-seeks to the iterator's own `last_doc_id` (which
+        /// is 0 until the first read), not the reader's block-initialized
+        /// `first_doc_id`, so it must skip the re-seek entirely and leave the
+        /// iterator positioned at the start.
+        #[test]
+        fn term_resume_before_first_read_keeps_first_doc() {
+            let test = TermRevalidateTest::new(10);
+            let it = Box::new(test.create_iterator());
+            let ii = {
+                use inverted_index::{full::Full, opaque::OpaqueEncoding};
+                Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut()
+            };
+
+            // Bump the GC marker *without reading the iterator first* by deleting
+            // a document that sits after the first one. This forces resume down
+            // the `NeedsReseek` branch while the iterator's `last_doc_id` is
+            // still 0, and leaves `doc_ids[0]` as the first live document.
+            let first = test.test.doc_ids[0];
+            test.test.remove_document(ii, test.test.doc_ids[5]);
+
+            let guard = test.test.context.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+                .expect("resume should not fail in this test")
+                .expect_ok();
+
+            // The first document must not be skipped.
+            let doc = it
+                .read()
+                .expect("failed to read")
+                .expect("should not be at EOF");
+            assert_eq!(doc.doc_id, first, "resume must not skip the first result");
+        }
+    }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -229,4 +229,113 @@ mod not_miri {
         let ii = DocIdsOnly::from_opaque(test.test.context.wildcard_inverted_index());
         assert!(reader.points_to_ii(ii));
     }
+
+    mod via_resume {
+        use super::*;
+        use crate::inverted_index::utils::via_resume::{
+            revalidate_after_document_deleted, revalidate_at_eof, revalidate_basic,
+        };
+        use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator};
+        use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+        #[test]
+        fn wildcard_revalidate_basic() {
+            let test = WildcardRevalidateTest::new(10);
+            let it = test.create_iterator();
+            revalidate_basic(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn wildcard_revalidate_at_eof() {
+            let test = WildcardRevalidateTest::new(10);
+            let it = test.create_iterator();
+            revalidate_at_eof(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn wildcard_revalidate_after_index_disappears() {
+            let test = WildcardRevalidateTest::new(10);
+            let it = Box::new(test.create_iterator());
+
+            // Verify the iterator works normally and read at least one document
+            let guard = test.test.context.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+                .expect("resume should not fail in this test")
+                .expect_ok();
+            assert!(it.read().expect("failed to read").is_some());
+            let it = revalidate_via_resume(it, &guard)
+                .expect("resume should not fail in this test")
+                .expect_ok();
+
+            // Simulate existingDocs being garbage collected and recreated by
+            // pointing spec.existingDocs to a different inverted index.
+            let new_ii =
+                Box::into_raw(Box::new(inverted_index::opaque::InvertedIndex::DocIdsOnly(
+                    inverted_index::InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
+                )));
+            let old_existing_docs = test.test.context.spec_read().existing_docs_ptr();
+            test.test
+                .context
+                .spec_write()
+                .set_existing_docs_ptr(new_ii.cast());
+
+            // Revalidate should return Aborted because existingDocs no longer
+            // points to the same index the reader was created from.
+            let outcome =
+                revalidate_via_resume(it, &guard).expect("resume should not fail in this test");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+
+            // Restore original existingDocs and free the temporary index for
+            // proper cleanup.
+            test.test
+                .context
+                .spec_write()
+                .set_existing_docs_ptr(old_existing_docs);
+            unsafe {
+                drop(Box::from_raw(new_ii));
+            }
+        }
+
+        #[test]
+        fn wildcard_revalidate_after_document_deleted() {
+            let test = WildcardRevalidateTest::new(10);
+            let it = test.create_iterator();
+            let ii = DocIdsOnly::from_mut_opaque(test.test.context.wildcard_inverted_index());
+
+            revalidate_after_document_deleted(&test.test, Box::new(it), ii);
+        }
+
+        /// Test that revalidation returns `Aborted` when `existingDocs` is set to
+        /// NULL, simulating the garbage collector removing all documents.
+        #[test]
+        fn wildcard_revalidate_after_existing_docs_nulled() {
+            let test = WildcardRevalidateTest::new(10);
+            let mut it = Box::new(test.create_iterator());
+
+            // Read at least one document so the iterator has a position.
+            assert!(it.read().expect("failed to read").is_some());
+            let guard = test.test.context.spec_read();
+            let it = revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+                .expect("resume should not fail in this test")
+                .expect_ok();
+
+            // Simulate the garbage collector setting existingDocs to NULL after
+            // collecting all documents.
+            let old_existing_docs = test.test.context.spec_read().existing_docs_ptr();
+            test.test
+                .context
+                .spec_write()
+                .set_existing_docs_ptr(std::ptr::null_mut());
+
+            let outcome =
+                revalidate_via_resume(it, &guard).expect("resume should not fail in this test");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+
+            // Restore for proper cleanup.
+            test.test
+                .context
+                .spec_write()
+                .set_existing_docs_ptr(old_existing_docs);
+        }
+    }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

Implement `RQEIteratorBoxed` + `RQESuspendedIterator` for the four
inverted-index leaf iterators — `Term`, `Tag`, `Missing`, and
`inverted_index::Wildcard` — on top of the shared `RawInvIndIterator`
core introduced in the base PR.

Each leaf's suspend reduces to a pointer cast that re-types the core;
resume drives the core's resume and re-wraps the result. Sibling resume
tests land with each iterator (one commit per type).

#### Main objects this PR modified
- `Term`, `Tag`, `Missing`, `inverted_index::Wildcard`

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

Stacked on #10450.
