### PR TITLE
[Iterator Revalidation][MOD-16971] Optional optimized

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -234,7 +234,7 @@ impl<'query> TypeErasedRQESuspendedIterator<'query> {
 /// Call it in a `const {}` block so the check runs at monomorphization: a
 /// mismatch fails to compile instead of causing undefined behaviour when the
 /// suspend/resume helpers reinterpret an allocation from `A` to `B`.
-const fn assert_layout_compatible<A, B>() {
+pub(crate) const fn assert_layout_compatible<A, B>() {
     assert!(
         std::mem::size_of::<A>() == std::mem::size_of::<B>(),
         "size mismatch across suspend/resume transition: active and suspended representations must have identical size"

--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -129,6 +129,16 @@ pub trait RQESuspendedIterator<'query> {
     ///   is unrecoverable. No active iterator is produced; the suspended
     ///   iterator is dropped.
     ///
+    /// # Implementer obligation
+    ///
+    /// A composite returning [`Moved`](ResumeOutcome::Moved) must leave the
+    /// resumed iterator so that [`current`](RQEIterator::current) answers
+    /// truthfully: `None` when the move landed past the last result. Reporting
+    /// it only through [`at_eof`](RQEIterator::at_eof) gives callers nothing
+    /// they can act on — it is a look-ahead, true on the last result too — and
+    /// the pre-suspend result the iterator would otherwise keep handing out is
+    /// exactly the stale position that made the resume necessary.
+    ///
     /// Resume re-reads/seeks the index to restore position (mirroring
     /// [`RQEIterator::revalidate`]), so it can fail with an
     /// [`RQEIteratorError`] (e.g. [`IoError`](RQEIteratorError::IoError) or

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -399,6 +399,12 @@ where
 {
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        // `at_eos` is set only by a read/skip that found no record, never while
+        // sitting on the last valid document, so honouring it here hides the stale
+        // leftover in `self.result` without hiding the final result.
+        if self.at_eos {
+            return None;
+        }
         Some(&mut self.result)
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -231,6 +231,16 @@ pub trait RQEIterator<'index> {
     /// Returns `false` if the iterator can yield more results.
     /// The iterator implementation must ensure that [`at_eof`](Self::at_eof) returns `true`
     /// when [`read`](Self::read) would return `Ok(None)`.
+    ///
+    /// # Contract
+    ///
+    /// This is a *look-ahead* — "the next `read` yields nothing" — and not a
+    /// has-current test. It is therefore already `true` while the iterator is
+    /// still positioned on its last result, so it cannot distinguish "on the
+    /// final document" from "positioned nowhere".
+    ///
+    /// [`current`](Self::current) is the has-current question, and is the one
+    /// to ask when recovering a position after a [`ResumeOutcome::Moved`].
     fn at_eof(&self) -> bool;
 
     /// Returns the [`IteratorType`] of this iterator.

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -161,6 +161,21 @@ pub trait RQEIterator<'index> {
     /// for later in time. The child iterator already has that result anyway,
     /// and it is this method which provides the ability to expose it (for later use).
     ///
+    /// # Contract
+    ///
+    /// This is a *has-current* oracle: `Some(&mut result)` while the iterator is
+    /// positioned on a result, `None` once a [`read`](Self::read) or
+    /// [`skip_to`](Self::skip_to) found nothing and left it positioned *past* its
+    /// last result. Never a stale result once exhausted — that is what lets
+    /// resume-path callers detect a move that landed at EOF.
+    ///
+    /// [`at_eof`](Self::at_eof) does not answer the same question: it is a
+    /// *look-ahead* ("the next [`read`](Self::read) returns `None`") which, for
+    /// some iterators, is already `true` while they still sit on their last
+    /// result. An iterator that clamps on its last result rather than advancing
+    /// past it therefore keeps returning `Some(last)` from here while reporting
+    /// [`at_eof`](Self::at_eof).
+    ///
     /// # Usage
     ///
     /// Calling this method before the first [`read`](Self::read) or [`skip_to`](Self::skip_to),

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -69,6 +69,21 @@ pub struct RawOptional<'query, Rf: Ref, I> {
     /// [`Optional::new`]. From that point onward all results will be virtual
     /// until `max_doc_id` is reached.
     child: OptionalChild<I>,
+
+    /// Whether the iterator has run *past* its last result, i.e. a
+    /// `read`/`skip_to` found nothing beyond [`Optional::max_doc_id`].
+    ///
+    /// Distinct from [`at_eof`](RQEIterator::at_eof), which is a look-ahead:
+    /// on reaching `max_doc_id` the iterator is `at_eof()` while still sitting
+    /// on that final result. This flag only flips once it has moved past it,
+    /// which is what makes [`current`](RQEIterator::current) a truthful
+    /// has-current oracle — and hence what lets a resume whose re-read hits EOF
+    /// report "no current" rather than the stale pre-suspend result.
+    ///
+    /// It cannot be folded into `result.doc_id`: that field *is*
+    /// [`last_doc_id`](RQEIterator::last_doc_id), so pushing it past
+    /// `max_doc_id` would misreport the position.
+    past_end: bool,
 }
 
 /// Child slot for [`RawOptional`].
@@ -140,6 +155,7 @@ const _: () = {
     assert!(offset_of!(A, weight) == offset_of!(S, weight));
     assert!(offset_of!(A, result) == offset_of!(S, result));
     assert!(offset_of!(A, child) == offset_of!(S, child));
+    assert!(offset_of!(A, past_end) == offset_of!(S, past_end));
     assert!(size_of::<A>() == size_of::<S>());
     assert!(align_of::<A>() == align_of::<S>());
 };
@@ -166,6 +182,7 @@ where
                 .field_mask(RS_FIELDMASK_ALL)
                 .build(),
             child: OptionalChild::Present(child),
+            past_end: false,
         }
     }
 
@@ -182,6 +199,9 @@ where
 {
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        if self.past_end {
+            return None;
+        }
         if let Some(child) = self.child.as_mut()
             && child.last_doc_id() == self.result.doc_id
             && let Some(child_result) = child.current()
@@ -194,6 +214,7 @@ where
 
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
         if self.at_eof() {
+            self.past_end = true;
             return Ok(None);
         }
 
@@ -238,6 +259,7 @@ where
 
         if doc_id > self.max_doc_id || self.at_eof() {
             self.result.doc_id = self.max_doc_id;
+            self.past_end = true;
             return Ok(None);
         }
 
@@ -299,6 +321,7 @@ where
     #[inline(always)]
     fn rewind(&mut self) {
         self.result.doc_id = 0;
+        self.past_end = false;
         if let Some(child) = self.child.as_mut() {
             child.rewind();
         }
@@ -486,6 +509,11 @@ where
         // Mirror `revalidate`: a child that aborted or moved forces a re-read
         // iff the previous result came from the child (its doc id matches the
         // aggregate's current doc id) rather than being a virtual sentinel.
+        //
+        // The re-read's outcome needs no inspection here: if it ran off the end
+        // it set `past_end`, so `current()` reports no current and the `Moved`
+        // below carries the same "nothing left" signal that `revalidate`'s
+        // `Moved { current: None }` did.
         let moved = if child_disturbed && last_child_doc_id == active.result.doc_id {
             active.read()?;
             true
@@ -517,6 +545,7 @@ impl<'index> crate::interop::ProfileChildren<'index>
             weight: self.weight,
             result: self.result,
             child: self.child.map(crate::c2rust::CRQEIterator::into_profiled),
+            past_end: self.past_end,
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -590,6 +590,13 @@ where
         // Success: disarm the guard and write the resumed children back into their
         // original slots (preserving their addresses — and `virt`'s, which never
         // moved), then reinterpret the reused allocation as the active form.
+        //
+        // Unlike `suspend_child_slot_in_place`/`resume_child_slot_in_place`, the
+        // window opened here needs no `AbortOnUnwind`: those helpers straddle a
+        // safe trait call that may panic, whereas everything between this
+        // `forget` and the two writes below is moves, pointer arithmetic and
+        // `const` assertions. None of it can unwind, so no unwind can observe the
+        // uninitialised slots.
         std::mem::forget(shell);
         // Statically enforce the size/alignment invariant the in-place writes
         // below rely on. `WildcardIterator` and the child are public safe traits,

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -75,7 +75,21 @@ pub struct RawOptionalOptimized<'query, Rf: Ref, W, I> {
     /// which is treated as virtual. Doc IDs start from 1, so 0 is a safe sentinel.
     last_doc_id: DocId,
     /// Whether the iterator has reached EOF.
+    ///
+    /// A *look-ahead*: [`settle_at`](OptionalOptimized::settle_at) sets it as
+    /// soon as the settled position reaches `max_doc_id`, while that position is
+    /// still the current result. It therefore cannot express "no current" — see
+    /// [`past_end`](Self::past_end).
     at_eof: bool,
+    /// Whether the iterator has run *past* its last result, i.e. a
+    /// `read`/`skip_to` found nothing.
+    ///
+    /// This is what makes [`current`](RQEIterator::current) a truthful
+    /// has-current oracle, and hence what lets a resume that lands off the end
+    /// report "no current" instead of the stale pre-suspend result. Kept
+    /// separate from `at_eof` because that one is already true on the last
+    /// valid result.
+    past_end: bool,
 }
 
 /// Alias for an [`Active`] [`RawOptionalOptimized`] — the only instantiation
@@ -99,6 +113,7 @@ const _: () = {
     assert!(offset_of!(A, child) == offset_of!(S, child));
     assert!(offset_of!(A, virt) == offset_of!(S, virt));
     assert!(offset_of!(A, max_doc_id) == offset_of!(S, max_doc_id));
+    assert!(offset_of!(A, past_end) == offset_of!(S, past_end));
     assert!(size_of::<A>() == size_of::<S>());
     assert!(align_of::<A>() == align_of::<S>());
 };
@@ -137,6 +152,7 @@ where
             weight,
             last_doc_id: 0,
             at_eof: false,
+            past_end: false,
         }
     }
 }
@@ -171,6 +187,7 @@ where
         }
 
         self.last_doc_id = doc_id;
+        self.past_end = false;
         // Look-ahead, so callers see true immediately after the last result.
         self.at_eof = doc_id >= self.max_doc_id;
 
@@ -214,6 +231,9 @@ where
 {
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        if self.past_end {
+            return None;
+        }
         if self.last_doc_id != 0
             && self.child.last_doc_id() == self.last_doc_id
             && let Some(result) = self.child.current()
@@ -226,6 +246,7 @@ where
 
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
         if self.at_eof {
+            self.past_end = true;
             return Ok(None);
         }
 
@@ -233,6 +254,7 @@ where
         let wcii_doc_id = match self.wcii.read()? {
             None => {
                 self.at_eof = true;
+                self.past_end = true;
                 return Ok(None);
             }
             Some(r) => r.doc_id,
@@ -241,6 +263,7 @@ where
         // wcii may jump past max_doc_id in a single step (e.g. sparse index).
         if wcii_doc_id > self.max_doc_id {
             self.at_eof = true;
+            self.past_end = true;
             return Ok(None);
         }
 
@@ -256,6 +279,7 @@ where
 
         if doc_id > self.max_doc_id || self.at_eof {
             self.at_eof = true;
+            self.past_end = true;
             return Ok(None);
         }
 
@@ -264,6 +288,7 @@ where
         let (found, effective_id) = match self.wcii.skip_to(doc_id)? {
             None => {
                 self.at_eof = true;
+                self.past_end = true;
                 return Ok(None);
             }
             Some(SkipToOutcome::Found(r)) => (true, r.doc_id),
@@ -273,6 +298,7 @@ where
         // wcii may jump past max_doc_id in a single step (e.g. sparse index).
         if effective_id > self.max_doc_id {
             self.at_eof = true;
+            self.past_end = true;
             return Ok(None);
         }
 
@@ -302,6 +328,7 @@ where
             RQEValidateStatus::Moved { current: Some(_) } => ValidateOutcome::Moved,
             RQEValidateStatus::Moved { current: None } => {
                 self.at_eof = true;
+                self.past_end = true;
                 return Ok(RQEValidateStatus::Moved { current: None });
             }
             RQEValidateStatus::Aborted => return Ok(RQEValidateStatus::Aborted),
@@ -344,6 +371,7 @@ where
                 // wcii may have moved past max_doc_id.
                 if wcii_doc_id > self.max_doc_id {
                     self.at_eof = true;
+                    self.past_end = true;
                     return Ok(RQEValidateStatus::Moved { current: None });
                 }
 
@@ -365,6 +393,7 @@ where
     fn rewind(&mut self) {
         self.last_doc_id = 0;
         self.at_eof = false;
+        self.past_end = false;
         self.virt.doc_id = 0;
         self.wcii.rewind();
         self.child.rewind();
@@ -499,10 +528,13 @@ where
             return Ok(ResumeOutcome::Aborted);
         }
 
-        // Capture pre-resume positions for the post-resume logic below (both reads
-        // happen before `self` is consumed by `Box::into_raw`). The `wcii` (base)
-        // child is genuinely a wildcard; its resumed type is a `WildcardIterator`.
-        let pre_wcii_last_doc_id = RQESuspendedIterator::last_doc_id(&self.wcii);
+        // Capture the child's pre-resume position: `current_was_virtual` below
+        // has to be judged against where the child was *before* it resumed, the
+        // way `revalidate` snapshots it before revalidating the child. The read
+        // happens before `self` is consumed by `Box::into_raw`.
+        //
+        // No such snapshot is needed for `wcii`: its resumed `current()` answers
+        // "did the move land anywhere" directly.
         let pre_child_last_doc_id = RQESuspendedIterator::last_doc_id(&self.child);
 
         let raw = Box::into_raw(self);
@@ -588,22 +620,23 @@ where
             Box::from_raw(raw.cast::<OptionalOptimized<'a, WS::Resumed<'a>, IS::Resumed<'a>>>())
         };
 
-        // Distinguish "wcii moved to a new valid position" from "wcii moved
-        // past all docs (no new current)". `ResumeOutcome::Moved` doesn't
-        // carry the {Some, None} distinction that legacy `revalidate` had, so
-        // we recover it by comparing wcii's pre/post `last_doc_id`: a true
-        // "Moved to EOF without a new doc" leaves the cached doc_id unchanged
-        // (the wcii has nothing new to surface). A "Moved to a new valid doc"
-        // advances the cached doc_id even if `at_eof` is now true (because
-        // that new doc is the LAST valid one).
-        if wcii_moved && active.wcii.at_eof() && active.wcii.last_doc_id() == pre_wcii_last_doc_id {
+        // Distinguish "wcii moved to a new valid position" from "wcii moved past
+        // all docs". `ResumeOutcome::Moved` carries no {Some, None}, so we ask
+        // the wildcard the has-current question directly.
+        //
+        // Comparing wcii's pre/post `last_doc_id` does *not* work: the
+        // inverted-index wildcards rewind before re-seeking
+        // (`RawInvIndIterator::resume_in_place`), so a move to EOF leaves the
+        // cached id at 0 — below the pre-resume value, not equal to it.
+        if wcii_moved && active.wcii.current().is_none() {
             active.at_eof = true;
+            active.past_end = true;
             return Ok(ResumeOutcome::Moved(active));
         }
         // NB: do NOT reset `at_eof` from `wcii.at_eof()` here. For an unchanged
         // wcii we keep the pre-suspend flag, so a bound-EOF from an earlier
-        // `skip_to(max_doc_id + 1)` survives resume; for a moved wcii it is set
-        // explicitly below from `wcii_doc_id >= max_doc_id`, matching `read`/`skip_to`.
+        // `skip_to(max_doc_id + 1)` survives resume; for a moved wcii `settle_at`
+        // sets it below, matching `read`/`skip_to`.
 
         let current_was_virtual =
             active.last_doc_id == 0 || pre_child_last_doc_id != active.last_doc_id;
@@ -624,6 +657,7 @@ where
         let wcii_doc_id = active.wcii.last_doc_id();
         if wcii_doc_id > active.max_doc_id {
             active.at_eof = true;
+            active.past_end = true;
             return Ok(ResumeOutcome::Moved(active));
         }
         // Settle exactly as `read`/`skip_to` do — including applying the optional
@@ -657,6 +691,7 @@ impl<'index, W: WildcardIterator<'index> + 'index> crate::interop::ProfileChildr
             virt: self.virt,
             last_doc_id: self.last_doc_id,
             at_eof: self.at_eof,
+            past_end: self.past_end,
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -489,12 +489,9 @@ where
         // `data` is `Rf`-parametrized, so `kind() == Virtual` is the whole
         // condition (`dmd`/`metrics` are not touched by the reinterpretation).
         // Checked safely via `&self`, before `Box::into_raw`, so a violation just
-        // drops `self`.
+        // drops `self`; we abort the resume rather than risk UB.
         if self.virt.kind() != RSResultKind::Virtual {
-            return Err(RQEIteratorError::IoError(std::io::Error::other(
-                "OptionalOptimized resume: virt is no longer a virtual sentinel; \
-                 its index-backed data cannot be re-validated",
-            )));
+            return Ok(ResumeOutcome::Aborted);
         }
 
         // Capture pre-resume positions for the post-resume logic below (both reads
@@ -527,10 +524,14 @@ where
         // there is no manual teardown and no uninitialised-slot window.
         let shell = FreeSuspendedShell { raw };
 
-        // Resume both children unconditionally (a `wcii` abort must not
-        // short-circuit the child — mirrors `revalidate`, which drove both). They
-        // are owned values, so `?` / early return drop them (and, via `shell`,
-        // `virt` + the allocation) with zero manual teardown.
+        // Resume both children up front. This differs from `revalidate`, which
+        // drives the child only *after* the `wcii` outcome and skips it entirely
+        // on a `wcii` abort or move-to-EOF; resuming both here keeps the
+        // move-out/write-back teardown uniform and is benign — a `wcii` abort
+        // still wins (its outcome is consumed first, below), and the child is
+        // simply dropped in that case. They are owned values, so `?` / early
+        // return drop them (and, via `shell`, `virt` + the allocation) with zero
+        // manual teardown.
         let wcii_out = Box::new(wcii).resume(guard);
         let child_out = Box::new(child).resume(guard);
 
@@ -553,6 +554,13 @@ where
         // original slots (preserving their addresses — and `virt`'s, which never
         // moved), then reinterpret the reused allocation as the active form.
         std::mem::forget(shell);
+        // Statically enforce the size/alignment invariant the in-place writes
+        // below rely on. `WildcardIterator` and the child are public safe traits,
+        // so a custom impl whose resumed type differs in layout would corrupt the
+        // slot; a mismatch fails to compile here, mirroring the guard inside
+        // `resume_child_slot_in_place`/`suspend_child_slot_in_place`.
+        const { crate::boxed::assert_layout_compatible::<WS, WS::Resumed<'a>>() };
+        const { crate::boxed::assert_layout_compatible::<MaybeEmpty<IS>, MaybeEmpty<IS::Resumed<'a>>>() };
         // SAFETY: the `wcii` slot is uninitialised; `&raw mut` forms a field
         // pointer to it.
         let wcii_slot = unsafe { &raw mut (*raw).wcii };
@@ -587,7 +595,10 @@ where
             active.at_eof = true;
             return Ok(ResumeOutcome::Moved(active));
         }
-        active.at_eof = active.wcii.at_eof();
+        // NB: do NOT reset `at_eof` from `wcii.at_eof()` here. For an unchanged
+        // wcii we keep the pre-suspend flag, so a bound-EOF from an earlier
+        // `skip_to(max_doc_id + 1)` survives resume; for a moved wcii it is set
+        // explicitly below from `wcii_doc_id >= max_doc_id`, matching `read`/`skip_to`.
 
         let current_was_virtual =
             active.last_doc_id == 0 || pre_child_last_doc_id != active.last_doc_id;
@@ -614,9 +625,24 @@ where
             active.child.skip_to(wcii_doc_id)?;
         }
         active.last_doc_id = wcii_doc_id;
-        active.at_eof |= wcii_doc_id >= active.max_doc_id;
+        // Match `read`/`skip_to`: EOF iff the new position reached the bound
+        // (absolute — not OR'd with the stale pre-suspend flag). `wcii_doc_id` is
+        // `<= max_doc_id` here (the `> max_doc_id` case returned above), so this is
+        // EOF only at exactly `max_doc_id`, leaving a valid in-bound hit visible.
+        active.at_eof = wcii_doc_id >= active.max_doc_id;
         if active.child.last_doc_id() != wcii_doc_id {
+            // Virtual hit: wcii has a doc ID but the child does not.
             active.virt.doc_id = wcii_doc_id;
+        } else {
+            // Real hit: apply the optional weight to the child result, mirroring
+            // `read`/`skip_to` — otherwise a moved-to real hit surfaces the child's
+            // unweighted score.
+            let weight = active.weight;
+            let result = active
+                .child
+                .current()
+                .expect("child has a result at wcii_doc_id");
+            result.weight = weight;
         }
         Ok(ResumeOutcome::Moved(active))
     }

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -141,6 +141,70 @@ where
     }
 }
 
+impl<'index, W, I> OptionalOptimized<'index, W, I>
+where
+    I: RQEIterator<'index>,
+{
+    /// Settle on `doc_id`, the position `wcii` has just landed on, and report
+    /// whether the child has a real hit there.
+    ///
+    /// Advances the child to catch up, records the new position, keeps `at_eof`
+    /// consistent, and prepares the result to hand out: the child's hit with
+    /// [`Self::weight`] applied when it has one at `doc_id`, otherwise the
+    /// virtual sentinel.
+    ///
+    /// Shared by `read`, `skip_to`, `revalidate` and the resume path so this
+    /// bookkeeping — in particular applying the optional weight — exists once
+    /// rather than in four copies that can drift apart.
+    ///
+    /// `doc_id` must already be within `max_doc_id`; every caller bound-checks
+    /// before settling.
+    fn settle_at(&mut self, doc_id: DocId) -> Result<bool, RQEIteratorError> {
+        debug_assert!(
+            doc_id <= self.max_doc_id,
+            "callers must bound-check against max_doc_id before settling",
+        );
+
+        // Advance the child to catch up with wcii.
+        if doc_id > self.child.last_doc_id() {
+            let _ = self.child.skip_to(doc_id)?;
+        }
+
+        self.last_doc_id = doc_id;
+        // Look-ahead, so callers see true immediately after the last result.
+        self.at_eof = doc_id >= self.max_doc_id;
+
+        let weight = self.weight;
+        // The `current()` guard mirrors `RQEIterator::current` so both agree on
+        // what a real hit is: a child may report a matching `last_doc_id` while
+        // having run past its own last result, in which case we fall back to the
+        // virtual sentinel rather than unwrapping a `None`.
+        if self.child.last_doc_id() == doc_id
+            && let Some(result) = self.child.current()
+        {
+            // Real hit: apply the optional weight.
+            result.weight = weight;
+            Ok(true)
+        } else {
+            // Virtual hit: wcii has a doc ID but the child does not.
+            self.virt.doc_id = doc_id;
+            Ok(false)
+        }
+    }
+
+    /// The result [`settle_at`](Self::settle_at) settled on, given the `is_real`
+    /// it returned.
+    fn settled_result(&mut self, is_real: bool) -> &mut RSIndexResult<'index> {
+        if is_real {
+            self.child
+                .current()
+                .expect("settle_at established a child result at this position")
+        } else {
+            &mut self.virt
+        }
+    }
+}
+
 impl<'index, W, I> RQEIterator<'index> for OptionalOptimized<'index, W, I>
 where
     // Only generic `RQEIterator` methods are called on the wildcard base here;
@@ -180,29 +244,8 @@ where
             return Ok(None);
         }
 
-        // Advance child to catch up with wcii.
-        if wcii_doc_id > self.child.last_doc_id() {
-            let _ = self.child.skip_to(wcii_doc_id)?;
-        }
-
-        self.last_doc_id = wcii_doc_id;
-        // Keep at_eof consistent so callers see true immediately after the last result.
-        self.at_eof = wcii_doc_id >= self.max_doc_id;
-
-        let weight = self.weight;
-        if self.child.last_doc_id() == wcii_doc_id {
-            // Real hit: child has a result at this position.
-            let result = self
-                .child
-                .current()
-                .expect("child has a result at wcii_doc_id");
-            result.weight = weight;
-            Ok(Some(result))
-        } else {
-            // Virtual hit: wcii has a doc ID but child does not.
-            self.virt.doc_id = wcii_doc_id;
-            Ok(Some(&mut self.virt))
-        }
+        let is_real = self.settle_at(wcii_doc_id)?;
+        Ok(Some(self.settled_result(is_real)))
     }
 
     fn skip_to(
@@ -233,37 +276,14 @@ where
             return Ok(None);
         }
 
-        // Advance child to effective_id if needed.
-        if effective_id > self.child.last_doc_id() {
-            let _ = self.child.skip_to(effective_id)?;
-        }
-
-        self.last_doc_id = effective_id;
-        // Keep at_eof consistent so callers see true immediately after the last result.
-        self.at_eof = effective_id >= self.max_doc_id;
-
-        let weight = self.weight;
-        if self.child.last_doc_id() == effective_id {
-            // Real hit — outcome (Found/NotFound) mirrors wcii.
-            let result = self
-                .child
-                .current()
-                .expect("child has a result at effective_id");
-            result.weight = weight;
-            if found {
-                Ok(Some(SkipToOutcome::Found(result)))
-            } else {
-                Ok(Some(SkipToOutcome::NotFound(result)))
-            }
+        let is_real = self.settle_at(effective_id)?;
+        let result = self.settled_result(is_real);
+        // Found/NotFound mirrors wcii, for real and virtual hits alike.
+        Ok(Some(if found {
+            SkipToOutcome::Found(result)
         } else {
-            // Virtual hit — outcome (Found/NotFound) mirrors wcii.
-            self.virt.doc_id = effective_id;
-            if found {
-                Ok(Some(SkipToOutcome::Found(&mut self.virt)))
-            } else {
-                Ok(Some(SkipToOutcome::NotFound(&mut self.virt)))
-            }
-        }
+            SkipToOutcome::NotFound(result)
+        }))
     }
 
     fn revalidate(
@@ -286,7 +306,8 @@ where
             }
             RQEValidateStatus::Aborted => return Ok(RQEValidateStatus::Aborted),
         };
-        self.at_eof = self.wcii.at_eof();
+        let wcii_at_eof = self.wcii.at_eof();
+        self.at_eof = wcii_at_eof;
 
         // `last_doc_id` is `None` in the initial/rewound state, which is always
         // virtual.
@@ -326,32 +347,16 @@ where
                     return Ok(RQEValidateStatus::Moved { current: None });
                 }
 
-                if wcii_doc_id > self.child.last_doc_id() {
-                    let _ = self.child.skip_to(wcii_doc_id)?;
-                }
-
-                self.last_doc_id = wcii_doc_id;
-                // Keep at_eof consistent so callers see true immediately after the last result.
-                self.at_eof |= wcii_doc_id >= self.max_doc_id;
-
-                let weight = self.weight;
-                if self.child.last_doc_id() == wcii_doc_id {
-                    // Real hit at the new wcii position.
-                    let result = self
-                        .child
-                        .current()
-                        .expect("child has a result at wcii_doc_id");
-                    result.weight = weight;
-                    Ok(RQEValidateStatus::Moved {
-                        current: Some(result),
-                    })
-                } else {
-                    // Virtual hit at the new wcii position.
-                    self.virt.doc_id = wcii_doc_id;
-                    Ok(RQEValidateStatus::Moved {
-                        current: Some(&mut self.virt),
-                    })
-                }
+                let is_real = self.settle_at(wcii_doc_id)?;
+                // `settle_at` sets `at_eof` from the `max_doc_id` bound alone.
+                // Unlike `read`/`skip_to`/resume, `revalidate` also keeps the
+                // wildcard's own EOF (captured at step 1, above) — an exhausted
+                // wcii means the next `read` yields nothing regardless of the
+                // bound.
+                self.at_eof |= wcii_at_eof;
+                Ok(RQEValidateStatus::Moved {
+                    current: Some(self.settled_result(is_real)),
+                })
             }
         }
     }
@@ -621,29 +626,12 @@ where
             active.at_eof = true;
             return Ok(ResumeOutcome::Moved(active));
         }
-        if wcii_doc_id > active.child.last_doc_id() {
-            active.child.skip_to(wcii_doc_id)?;
-        }
-        active.last_doc_id = wcii_doc_id;
-        // Match `read`/`skip_to`: EOF iff the new position reached the bound
-        // (absolute — not OR'd with the stale pre-suspend flag). `wcii_doc_id` is
-        // `<= max_doc_id` here (the `> max_doc_id` case returned above), so this is
-        // EOF only at exactly `max_doc_id`, leaving a valid in-bound hit visible.
-        active.at_eof = wcii_doc_id >= active.max_doc_id;
-        if active.child.last_doc_id() != wcii_doc_id {
-            // Virtual hit: wcii has a doc ID but the child does not.
-            active.virt.doc_id = wcii_doc_id;
-        } else {
-            // Real hit: apply the optional weight to the child result, mirroring
-            // `read`/`skip_to` — otherwise a moved-to real hit surfaces the child's
-            // unweighted score.
-            let weight = active.weight;
-            let result = active
-                .child
-                .current()
-                .expect("child has a result at wcii_doc_id");
-            result.weight = weight;
-        }
+        // Settle exactly as `read`/`skip_to` do — including applying the optional
+        // weight to a moved-to real hit, which this path used to omit. `at_eof`
+        // comes from the `max_doc_id` bound alone (absolute, not OR'd with the
+        // stale pre-suspend flag); `wcii_doc_id <= max_doc_id` here, so it is EOF
+        // only at exactly the bound, leaving a valid in-bound hit visible.
+        let _ = active.settle_at(wcii_doc_id)?;
         Ok(ResumeOutcome::Moved(active))
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -14,11 +14,13 @@
 //! `spec.existingDocs` to visit only real document IDs, yielding real or virtual
 //! results accordingly.
 
-use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use index_result::{RSIndexResult, RSResultKind, RawIndexResult};
+use ref_mode::{Active, Ref, Suspended};
 
 use crate::{
-    RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator, RQEValidateStatus,
+    ResumeOutcome, SkipToOutcome,
+    boxed::suspend_child_slot_in_place,
     maybe_empty::MaybeEmpty,
     profile_print::{ProfilePrint, ProfilePrintCtx},
     wildcard::WildcardIterator,
@@ -40,6 +42,19 @@ use rqe_core::{DocId, RS_FIELDMASK_ALL};
 /// This avoids scanning doc IDs 1..=maxDocId sequentially. When the index is
 /// sparse (few documents relative to `maxDocId`), the optimized variant is
 /// significantly faster.
+///
+/// # Invariants
+///
+/// 1. **Layout compatibility across modes.** `RawOptionalOptimized` is
+///    `#[repr(C)]` and its only `Rf`-dependent field is
+///    `virt: RawIndexResult<Rf>`, which is layout-compatible across `Rf`
+///    (proven in `index_result`). Given that the wildcard base `W`/`W::Suspended`
+///    and the child `I`/`I::Suspended` are layout-compatible (the
+///    [`RQEIteratorBoxed`] contract — the latter through the `#[repr(C)]`
+///    [`MaybeEmpty`] slot), the `Active` and `Suspended` instantiations are
+///    layout-identical. This is what lets
+///    [`suspend`](RQEIteratorBoxed::suspend) reinterpret the owning `Box` in
+///    place.
 #[repr(C)]
 pub struct RawOptionalOptimized<'query, Rf: Ref, W, I> {
     /// Wildcard iterator over `spec.existingDocs` — the authoritative source of doc IDs.
@@ -66,6 +81,27 @@ pub struct RawOptionalOptimized<'query, Rf: Ref, W, I> {
 /// Alias for an [`Active`] [`RawOptionalOptimized`] — the only instantiation
 /// with an [`RQEIterator`] impl today.
 pub type OptionalOptimized<'index, W, I> = RawOptionalOptimized<'index, Active<'index>, W, I>;
+
+// Compile-time proof of invariant 1 on `RawOptionalOptimized`: for representative
+// concrete `wcii`/`child` types, the `Active` and `Suspended` instantiations are
+// layout-identical. The `wcii`/`child` slots' own compatibility is their invariant
+// 1 (enforced generically by `suspend_child_slot_in_place`); `virt` is
+// layout-compatible across `Rf` (proven in `index_result`); the wrapper adds only
+// `Rf`-free scalar fields.
+const _: () = {
+    use crate::Wildcard;
+    use std::mem::{align_of, offset_of, size_of};
+    type AChild = Wildcard<'static>;
+    type SChild = <Wildcard<'static> as RQEIteratorBoxed<'static>>::Suspended;
+    type A = RawOptionalOptimized<'static, Active<'static>, AChild, AChild>;
+    type S = RawOptionalOptimized<'static, Suspended, SChild, SChild>;
+    assert!(offset_of!(A, wcii) == offset_of!(S, wcii));
+    assert!(offset_of!(A, child) == offset_of!(S, child));
+    assert!(offset_of!(A, virt) == offset_of!(S, virt));
+    assert!(offset_of!(A, max_doc_id) == offset_of!(S, max_doc_id));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
 
 impl<'index, W, I> OptionalOptimized<'index, W, I>
 where
@@ -107,7 +143,9 @@ where
 
 impl<'index, W, I> RQEIterator<'index> for OptionalOptimized<'index, W, I>
 where
-    W: WildcardIterator<'index>,
+    // Only generic `RQEIterator` methods are called on the wildcard base here;
+    // the `WildcardIterator` marker is enforced at construction (see `new`).
+    W: RQEIterator<'index>,
     I: RQEIterator<'index>,
 {
     #[inline(always)]
@@ -348,6 +386,248 @@ where
 
     fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
         1.0
+    }
+}
+
+impl<'index, W, I> RQEIteratorBoxed<'index> for OptionalOptimized<'index, W, I>
+where
+    // Marker enforced at construction (`new`), not on the suspend/resume path —
+    // the suspend/resume impls only move the wildcard child through the box
+    // cast, so `W: RQEIteratorBoxed` suffices. This drops the recursive
+    // `for<'a> …: WildcardIterator + RQEIteratorBoxed<Suspended = …>` HRTB,
+    // which is otherwise unsatisfiable once `'query` narrows on resume.
+    W: RQEIteratorBoxed<'index>,
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawOptionalOptimized<'index, Suspended, W::Suspended, I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Dispatch each sub-iterator's own `suspend` in place. A whole-box cast
+        // alone is *not* enough: for a type-erased `wcii`/`child` the active and
+        // suspended forms carry different `dyn` vtables, so the transition must be
+        // dispatched through the child's own `suspend` (a no-op cast for concrete
+        // children, a vtable swap for erased ones). `child` is a `MaybeEmpty<I>`,
+        // itself an `RQEIteratorBoxed` that walks its own `Some(I)` arm.
+
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned, initialised,
+        // exclusively owned); `&raw mut` forms a field pointer to `wcii`.
+        let wcii = unsafe { &raw mut (*raw).wcii };
+        // SAFETY: `wcii` points at a valid, owned `W`; the helper dispatches its
+        // `suspend` and reinitialises the slot as a valid `W::Suspended`.
+        unsafe { suspend_child_slot_in_place(wcii) };
+        // SAFETY: `&raw mut` forms a field pointer to `child`.
+        let child = unsafe { &raw mut (*raw).child };
+        // SAFETY: `child` points at a valid, owned `MaybeEmpty<I>`; the helper
+        // dispatches its `suspend` and reinitialises the slot as a valid
+        // `MaybeEmpty<I::Suspended>`.
+        unsafe { suspend_child_slot_in_place(child) };
+        // SAFETY: both sub-iterators now hold their `Suspended` forms; `virt` is
+        // `Rf`-dependent but layout-compatible across `Rf`, and the remaining
+        // fields are `Rf`-free. So the allocation is a valid
+        // `RawOptionalOptimized<Suspended, W::Suspended, I::Suspended>` —
+        // layout-identical to the active form by invariant 1 (const proof above),
+        // with the child slots' size/alignment matches enforced by
+        // `suspend_child_slot_in_place`. `Box::from_raw` reuses the allocation.
+        unsafe {
+            Box::from_raw(
+                raw as *mut RawOptionalOptimized<'index, Suspended, W::Suspended, I::Suspended>,
+            )
+        }
+    }
+}
+
+/// RAII guard used by [`RawOptionalOptimized`]'s `resume` while its two child
+/// slots are moved out into owned locals. It owns the leftover shell: on drop
+/// (an early return or a panic) it drops the still-suspended `virt` and frees the
+/// allocation — it never touches the moved-out `wcii`/`child` slots, so its
+/// behaviour is independent of how far the resume got. It is disarmed with
+/// [`std::mem::forget`] once the resumed children are written back.
+struct FreeSuspendedShell<'q, WS, IS> {
+    raw: *mut RawOptionalOptimized<'q, Suspended, WS, IS>,
+}
+
+impl<'q, WS, IS> Drop for FreeSuspendedShell<'q, WS, IS> {
+    fn drop(&mut self) {
+        // SAFETY: `raw` is a valid, exclusively-owned allocation; `&raw mut`
+        // forms a field pointer to the still-suspended `virt`.
+        let virt = unsafe { &raw mut (*self.raw).virt };
+        // SAFETY: `virt` is a valid, owned suspended result; drop it in place.
+        unsafe { std::ptr::drop_in_place(virt) };
+        // SAFETY: `raw` was allocated by `Box` with exactly this layout; the
+        // `wcii`/`child` slots are moved-from and must not be dropped. Free it.
+        unsafe {
+            std::alloc::dealloc(
+                self.raw.cast::<u8>(),
+                std::alloc::Layout::new::<RawOptionalOptimized<'q, Suspended, WS, IS>>(),
+            )
+        };
+    }
+}
+
+impl<'query, WS, IS> RQESuspendedIterator<'query>
+    for RawOptionalOptimized<'query, Suspended, WS, IS>
+where
+    WS: RQESuspendedIterator<'query>,
+    IS: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = OptionalOptimized<'a, WS::Resumed<'a>, IS::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // `virt` must still be a virtual sentinel. It is handed out mutably via
+        // `current()`/`read()`/`skip_to`, and on resume its `Suspended → Active`
+        // reinterpretation would assert index borrows we cannot re-validate. Only
+        // `data` is `Rf`-parametrized, so `kind() == Virtual` is the whole
+        // condition (`dmd`/`metrics` are not touched by the reinterpretation).
+        // Checked safely via `&self`, before `Box::into_raw`, so a violation just
+        // drops `self`.
+        if self.virt.kind() != RSResultKind::Virtual {
+            return Err(RQEIteratorError::IoError(std::io::Error::other(
+                "OptionalOptimized resume: virt is no longer a virtual sentinel; \
+                 its index-backed data cannot be re-validated",
+            )));
+        }
+
+        // Capture pre-resume positions for the post-resume logic below (both reads
+        // happen before `self` is consumed by `Box::into_raw`). The `wcii` (base)
+        // child is genuinely a wildcard; its resumed type is a `WildcardIterator`.
+        let pre_wcii_last_doc_id = RQESuspendedIterator::last_doc_id(&self.wcii);
+        let pre_child_last_doc_id = RQESuspendedIterator::last_doc_id(&self.child);
+
+        let raw = Box::into_raw(self);
+
+        // Move both children out into owned locals; their slots become
+        // uninitialised. `virt` stays in place (it must keep its address — it is
+        // handed out via `current()`/`read()`/`skip_to`), as do the `Rf`-free
+        // scalar fields.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned, initialised,
+        // exclusively owned); `&raw const` forms a field pointer to `wcii`.
+        let wcii_ptr = unsafe { &raw const (*raw).wcii };
+        // SAFETY: move the owned suspended `wcii` out exactly once.
+        let wcii = unsafe { std::ptr::read(wcii_ptr) };
+        // SAFETY: field pointer to `child`.
+        let child_ptr = unsafe { &raw const (*raw).child };
+        // SAFETY: move the owned suspended `child` out exactly once.
+        let child = unsafe { std::ptr::read(child_ptr) };
+
+        // From here until success, `raw` is a shell whose child slots are
+        // moved-out. This guard frees it — dropping the still-suspended `virt` and
+        // the allocation, but never the moved-out slots — on any early return or
+        // panic. The `wcii`/`child` locals clean themselves up via ownership, so
+        // there is no manual teardown and no uninitialised-slot window.
+        let shell = FreeSuspendedShell { raw };
+
+        // Resume both children unconditionally (a `wcii` abort must not
+        // short-circuit the child — mirrors `revalidate`, which drove both). They
+        // are owned values, so `?` / early return drop them (and, via `shell`,
+        // `virt` + the allocation) with zero manual teardown.
+        let wcii_out = Box::new(wcii).resume(guard);
+        let child_out = Box::new(child).resume(guard);
+
+        // `wcii` is the base: if it is unrecoverable there is nothing to
+        // enumerate, so the whole iterator aborts.
+        let (wcii, wcii_moved) = match wcii_out? {
+            ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+            ResumeOutcome::Ok(w) => (w, false),
+            ResumeOutcome::Moved(w) => (w, true),
+        };
+        // An aborted query child is replaced by `Empty` (mirroring `revalidate`'s
+        // `take_iterator`) and treated as "moved".
+        let (child, child_moved_or_aborted) = match child_out? {
+            ResumeOutcome::Aborted => (Box::new(MaybeEmpty::new_empty()), true),
+            ResumeOutcome::Ok(c) => (c, false),
+            ResumeOutcome::Moved(c) => (c, true),
+        };
+
+        // Success: disarm the guard and write the resumed children back into their
+        // original slots (preserving their addresses — and `virt`'s, which never
+        // moved), then reinterpret the reused allocation as the active form.
+        std::mem::forget(shell);
+        // SAFETY: the `wcii` slot is uninitialised; `&raw mut` forms a field
+        // pointer to it.
+        let wcii_slot = unsafe { &raw mut (*raw).wcii };
+        // SAFETY: write the resumed `wcii` back at the same offset, as its
+        // resumed type.
+        unsafe { std::ptr::write(wcii_slot.cast::<WS::Resumed<'a>>(), *wcii) };
+        // SAFETY: `&raw mut` forms a field pointer to the uninitialised `child`
+        // slot.
+        let child_slot = unsafe { &raw mut (*raw).child };
+        // SAFETY: write the resumed `child` back at the same offset.
+        unsafe { std::ptr::write(child_slot.cast::<MaybeEmpty<IS::Resumed<'a>>>(), *child) };
+
+        // SAFETY: both slots now hold their resumed forms and `virt` is a valid
+        // (pointerless) virtual sentinel (checked above), so the allocation is a
+        // valid `OptionalOptimized<'a, …>` — layout-identical to the suspended
+        // form by invariant 1 on `RawOptionalOptimized` (const proof above), with
+        // `virt` re-typing `Suspended → Active` soundly. `Box::from_raw` reuses
+        // the same allocation.
+        let mut active = unsafe {
+            Box::from_raw(raw.cast::<OptionalOptimized<'a, WS::Resumed<'a>, IS::Resumed<'a>>>())
+        };
+
+        // Distinguish "wcii moved to a new valid position" from "wcii moved
+        // past all docs (no new current)". `ResumeOutcome::Moved` doesn't
+        // carry the {Some, None} distinction that legacy `revalidate` had, so
+        // we recover it by comparing wcii's pre/post `last_doc_id`: a true
+        // "Moved to EOF without a new doc" leaves the cached doc_id unchanged
+        // (the wcii has nothing new to surface). A "Moved to a new valid doc"
+        // advances the cached doc_id even if `at_eof` is now true (because
+        // that new doc is the LAST valid one).
+        if wcii_moved && active.wcii.at_eof() && active.wcii.last_doc_id() == pre_wcii_last_doc_id {
+            active.at_eof = true;
+            return Ok(ResumeOutcome::Moved(active));
+        }
+        active.at_eof = active.wcii.at_eof();
+
+        let current_was_virtual =
+            active.last_doc_id == 0 || pre_child_last_doc_id != active.last_doc_id;
+
+        if !wcii_moved {
+            // wcii stayed at the same position.
+            if !child_moved_or_aborted || current_was_virtual {
+                // Child is still valid, or the current result was virtual — no change.
+                return Ok(ResumeOutcome::Ok(active));
+            }
+            // Child moved or aborted while the current was a real result:
+            // advance to the next valid state.
+            active.read()?;
+            return Ok(ResumeOutcome::Moved(active));
+        }
+
+        // wcii moved to a new valid position; update the child accordingly.
+        let wcii_doc_id = active.wcii.last_doc_id();
+        if wcii_doc_id > active.max_doc_id {
+            active.at_eof = true;
+            return Ok(ResumeOutcome::Moved(active));
+        }
+        if wcii_doc_id > active.child.last_doc_id() {
+            active.child.skip_to(wcii_doc_id)?;
+        }
+        active.last_doc_id = wcii_doc_id;
+        active.at_eof |= wcii_doc_id >= active.max_doc_id;
+        if active.child.last_doc_id() != wcii_doc_id {
+            active.virt.doc_id = wcii_doc_id;
+        }
+        Ok(ResumeOutcome::Moved(active))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.last_doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        // Mirrors the active `num_estimated`, which delegates to the wildcard base.
+        self.wcii.num_estimated()
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/resume_outcome.rs
+++ b/src/redisearch_rs/rqe_iterators/src/resume_outcome.rs
@@ -28,11 +28,11 @@ pub enum ResumeOutcome<I> {
     /// Resumed, but the position moved forward (the previous `last_doc_id` was
     /// deleted or otherwise no longer present).
     ///
-    /// The move may have landed on a live document or run off the end. Check
-    /// `at_eof()` first: if it is not at EOF, `current()` holds the new
-    /// position; if it is at EOF, `current()` is meaningless — like the real
-    /// iterators, it keeps returning `Some` even past the end, so it must not
-    /// be trusted once `at_eof()` is true.
+    /// The move may have landed on a live document or run off the end;
+    /// [`current`](crate::RQEIterator::current) on the returned iterator tells
+    /// the two apart, `Some` being the new position and `None` a move past the
+    /// last result. Not [`at_eof`](crate::RQEIterator::at_eof), which answers a
+    /// different question — see its contract.
     Moved(I),
     /// Unrecoverable: no active iterator is produced and the suspended iterator
     /// was dropped.

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -201,6 +201,17 @@ impl<'index> WildcardIterator<'index> for crate::c2rust::CRQEIterator {}
 
 impl<'index> WildcardIterator<'index> for Box<dyn WildcardIterator<'index> + 'index> {}
 
+/// A [`TypeErasedRQEIterator`](crate::TypeErasedRQEIterator) may wrap a wildcard
+/// iterator, but — as with [`CRQEIterator`](crate::c2rust::CRQEIterator) — that
+/// cannot be verified statically once the concrete type is erased.
+///
+/// The caller is responsible for only using this impl when the erased iterator
+/// really is a wildcard. It exists so composites that take a wildcard base (e.g.
+/// [`OptionalOptimized`](crate::optional_optimized::OptionalOptimized)) can hold
+/// a type-erased one, which is what the suspend/resume path needs in order to
+/// dispatch the base's own `suspend`/`resume` through its vtable.
+impl<'index> WildcardIterator<'index> for crate::TypeErasedRQEIterator<'index> {}
+
 /// The result of [`new_wildcard_iterator`], representing the different kinds of
 /// wildcard iterators that can be created depending on the index configuration.
 pub enum NewWildcardIterator<'index> {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/current_contract.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/current_contract.rs
@@ -62,6 +62,17 @@ fn optional_upholds_current_contract() {
     assert_eq!(assert_current_contract(&mut it), [1, 2, 3, 4, 5]);
 }
 
+#[test]
+fn optional_optimized_upholds_current_contract() {
+    let mut it = rqe_iterators::optional_optimized::OptionalOptimized::new(
+        utils::Mock::new([1u64, 2, 3, 4, 5]),
+        utils::Mock::new([2u64, 4]),
+        5,
+        2.0,
+    );
+    assert_eq!(assert_current_contract(&mut it), [1, 2, 3, 4, 5]);
+}
+
 // ---------------------------------------------------------------------------
 // Not yet conforming
 //
@@ -100,14 +111,3 @@ fn not_upholds_current_contract() {
     assert_eq!(assert_current_contract(&mut it), [1, 3, 5]);
 }
 
-#[test]
-#[ignore = "fixed in a following change"]
-fn optional_optimized_upholds_current_contract() {
-    let mut it = rqe_iterators::optional_optimized::OptionalOptimized::new(
-        utils::Mock::new([1u64, 2, 3, 4, 5]),
-        utils::Mock::new([2u64, 4]),
-        5,
-        2.0,
-    );
-    assert_eq!(assert_current_contract(&mut it), [1, 2, 3, 4, 5]);
-}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/current_contract.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/current_contract.rs
@@ -55,6 +55,13 @@ fn empty_upholds_current_contract() {
     assert!(assert_current_contract(&mut it).is_empty());
 }
 
+#[test]
+fn optional_upholds_current_contract() {
+    // Yields every id in 1..=5, real at 2 and 4, virtual elsewhere.
+    let mut it = rqe_iterators::optional::Optional::new(5, 2.0, utils::Mock::new([2u64, 4]));
+    assert_eq!(assert_current_contract(&mut it), [1, 2, 3, 4, 5]);
+}
+
 // ---------------------------------------------------------------------------
 // Not yet conforming
 //
@@ -91,14 +98,6 @@ fn not_upholds_current_contract() {
     let mut it =
         rqe_iterators::not::Not::new(utils::Mock::new([2u64, 4]), 5, 1.0, NoTimeoutChecker);
     assert_eq!(assert_current_contract(&mut it), [1, 3, 5]);
-}
-
-#[test]
-#[ignore = "fixed in the following change"]
-fn optional_upholds_current_contract() {
-    // Yields every id in 1..=5, real at 2 and 4, virtual elsewhere.
-    let mut it = rqe_iterators::optional::Optional::new(5, 2.0, utils::Mock::new([2u64, 4]));
-    assert_eq!(assert_current_contract(&mut it), [1, 2, 3, 4, 5]);
 }
 
 #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/current_contract.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/current_contract.rs
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Cross-iterator conformance tests for the [`RQEIterator::current`]
+//! has-current contract.
+//!
+//! Every iterator that participates in suspend/resume must report `None` from
+//! `current()` once it has run past its last result — that is the signal a
+//! composite parent uses to tell "moved to a new document" from "moved off the
+//! end" when its child resumes (see `ResumeOutcome::Moved`). An iterator that
+//! keeps handing out its last result silently collapses those two cases into
+//! the first, reinstating exactly the stale position the resume was meant to
+//! repair.
+//!
+//! Per-iterator suites test behaviour; this file tests that they all agree on
+//! the shared contract. Iterators that do not yet uphold it are listed here as
+//! `#[ignore]`d tests rather than omitted, so the gap stays visible.
+//!
+//! [`RQEIterator::current`]: rqe_iterators::RQEIterator::current
+
+use rqe_core::DocId;
+use rqe_iterators::{Empty, IdList};
+use rqe_iterators_test_utils::assert_current_contract;
+use timeout::NoTimeoutChecker;
+
+use crate::utils;
+
+const DOCS: [DocId; 5] = [10, 20, 30, 50, 80];
+
+// ---------------------------------------------------------------------------
+// Conforming
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mock_upholds_current_contract() {
+    let mut it = utils::Mock::new(DOCS);
+    assert_eq!(assert_current_contract(&mut it), DOCS);
+}
+
+#[test]
+fn mock_vec_upholds_current_contract() {
+    let mut it = utils::MockVec::new(DOCS.to_vec());
+    assert_eq!(assert_current_contract(&mut it), DOCS);
+}
+
+#[test]
+fn empty_upholds_current_contract() {
+    let mut it = Empty;
+    assert!(assert_current_contract(&mut it).is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Not yet conforming
+//
+// Each keeps returning its last result after `read()` has returned `None`, so a
+// parent asking "did my child move to a new doc, or off the end?" is told "new
+// doc" either way.
+//
+// `Wildcard` and `IdList` already implement `RQEIteratorBoxed`, so that is
+// reachable from a resume today. `Not` does not yet — for it this is a latent
+// violation, which becomes reachable when it is migrated.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "Wildcard::current() clamps on its last result; needs a past-the-end \
+            state like the inverted-index iterators have"]
+fn wildcard_upholds_current_contract() {
+    let mut it = rqe_iterators::Wildcard::new(5, 1.0);
+    assert_eq!(assert_current_contract(&mut it), [1, 2, 3, 4, 5]);
+}
+
+#[test]
+#[ignore = "IdList::current() clamps on its last result; `offset` could encode \
+            past-the-end the way the mocks' `next_index` does"]
+fn id_list_upholds_current_contract() {
+    let mut it: IdList<'_, true> = IdList::new(DOCS.to_vec());
+    assert_eq!(assert_current_contract(&mut it), DOCS);
+}
+
+#[test]
+#[ignore = "Not::current() clamps on its last result; latent until Not is \
+            migrated to RQEIteratorBoxed"]
+fn not_upholds_current_contract() {
+    // `Not` over [2, 4] within 1..=5 yields the complement.
+    let mut it =
+        rqe_iterators::not::Not::new(utils::Mock::new([2u64, 4]), 5, 1.0, NoTimeoutChecker);
+    assert_eq!(assert_current_contract(&mut it), [1, 3, 5]);
+}
+
+#[test]
+#[ignore = "fixed in the following change"]
+fn optional_upholds_current_contract() {
+    // Yields every id in 1..=5, real at 2 and 4, virtual elsewhere.
+    let mut it = rqe_iterators::optional::Optional::new(5, 2.0, utils::Mock::new([2u64, 4]));
+    assert_eq!(assert_current_contract(&mut it), [1, 2, 3, 4, 5]);
+}
+
+#[test]
+#[ignore = "fixed in a following change"]
+fn optional_optimized_upholds_current_contract() {
+    let mut it = rqe_iterators::optional_optimized::OptionalOptimized::new(
+        utils::Mock::new([1u64, 2, 3, 4, 5]),
+        utils::Mock::new([2u64, 4]),
+        5,
+        2.0,
+    );
+    assert_eq!(assert_current_contract(&mut it), [1, 2, 3, 4, 5]);
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/current_contract.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/current_contract.rs
@@ -110,4 +110,3 @@ fn not_upholds_current_contract() {
         rqe_iterators::not::Not::new(utils::Mock::new([2u64, 4]), 5, 1.0, NoTimeoutChecker);
     assert_eq!(assert_current_contract(&mut it), [1, 3, 5]);
 }
-

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -150,8 +150,16 @@ impl<E: Encoder> BaseTest<E> {
             i += 1;
         }
 
-        // Test reading after skipping to the last id
+        // Sitting on the last result: these iterators only flip `at_eof` once a
+        // read runs past it, so the two states are observable separately here.
+        let last_id = *self.doc_ids.last().unwrap();
+        assert_eq!(it.current().unwrap().doc_id, last_id);
+        assert!(!it.at_eof());
+
         assert!(matches!(it.read(), Ok(None)));
+        assert!(it.current().is_none());
+        assert!(it.at_eof());
+
         let last_doc_id = it.last_doc_id();
         assert!(matches!(it.skip_to(last_doc_id + 1), Ok(None)));
         assert!(it.at_eof());
@@ -179,9 +187,10 @@ impl<E: Encoder> BaseTest<E> {
         assert!(!it.at_eof());
         let res = it.skip_to(self.doc_ids.last().unwrap() + 1);
         assert!(matches!(res, Ok(None)));
-        // we just rewound
+        // The skip found no record, so the iterator is left unpositioned and
+        // `last_doc_id` keeps the value `rewind` gave it.
         assert_eq!(it.last_doc_id(), 0);
-        assert_eq!(it.current().unwrap().doc_id, 0);
+        assert!(it.current().is_none());
         assert!(it.at_eof());
     }
 }
@@ -797,12 +806,12 @@ pub mod via_resume {
         assert_eq!(it.current().unwrap().doc_id, last_doc_id);
 
         test.remove_document(ii, last_doc_id);
-        // The move ran off the end: the iterator is at EOF. In the resume model
-        // EOF is observed via `at_eof()` / `read()`, not `current()` (which,
-        // like the real iterators, keeps returning the last record).
+        // The move runs off the end, which `current()` reports on its own — no
+        // `at_eof()` pre-check needed to interpret it.
         let mut it = revalidate_via_resume(it, &guard)
             .expect("resume should not fail in this test")
             .expect_moved();
+        assert!(it.current().is_none());
         assert!(it.at_eof());
         assert!(it.read().expect("read should not fail").is_none());
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/main.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/main.rs
@@ -33,6 +33,7 @@ use rstest_reuse::template;
 fn id_cases(#[case] case: &[u64]) {}
 
 mod c2rust;
+mod current_contract;
 mod deferred;
 mod empty;
 #[cfg(not(miri))]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -1330,6 +1330,50 @@ mod via_resume {
         );
     }
 
+    /// A resume whose re-read runs off the end must report `Moved` with **no
+    /// current** — not the stale pre-suspend result.
+    ///
+    /// `ResumeOutcome::Moved` carries no `Option`, so the caller recovers the
+    /// new position from `current()`. The legacy `revalidate` forwarded
+    /// `read()` straight into `Moved { current }` and so surfaced EOF as
+    /// `current: None`; the resume path discarded the re-read's outcome, which
+    /// left `current()` handing back the very position the resume was repairing.
+    #[test]
+    fn resume_reread_to_eof_reports_no_current() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // `max_doc_id` of 1 with a child hit at doc 1: after reading it the
+        // iterator sits on its final result, so the resume's re-read finds
+        // nothing.
+        let child = Mock::new([1]);
+        child
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        let mut optional = Box::new(Optional::new(1, WEIGHT, child));
+
+        let hit = optional.read().unwrap().unwrap();
+        assert_eq!(hit.doc_id, 1);
+        assert_eq!(hit.weight, WEIGHT, "doc 1 is a real child hit");
+        assert!(optional.at_eof(), "doc 1 is the bound");
+        assert!(
+            optional.current().is_some(),
+            "at_eof() is a look-ahead: doc 1 is still the current result",
+        );
+
+        let mut active = match optional
+            .suspend()
+            .resume(&mock_ctx.spec_read())
+            .expect("resume failed")
+        {
+            ResumeOutcome::Moved(it) => it,
+            ResumeOutcome::Ok(_) => panic!("expected Moved, got Ok"),
+            ResumeOutcome::Aborted => panic!("expected Moved, got Aborted"),
+        };
+        assert!(
+            active.current().is_none(),
+            "the re-read ran off the end, so the moved iterator has no current",
+        );
+    }
+
     /// `Present` child that moves during resume, forcing a re-read whose own
     /// `read` then fails: the error propagates out of `Optional::resume`.
     #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -904,6 +904,8 @@ mod optional_iterator_non_sequential_reads {
 
     struct ReadStepIterator<'index, const N: usize> {
         read_steps: [DocId; N],
+        /// Index of the next step to serve, [`utils::past_end_cursor`] once a
+        /// `read`/`skip_to` ran past the last one.
         read_step: usize,
         result: index_result::RSIndexResult<'index>,
     }
@@ -920,6 +922,9 @@ mod optional_iterator_non_sequential_reads {
 
     impl<'index, const N: usize> RQEIterator<'index> for ReadStepIterator<'index, N> {
         fn current(&mut self) -> Option<&mut index_result::RSIndexResult<'index>> {
+            if self.read_step == utils::past_end_cursor(N) {
+                return None;
+            }
             Some(&mut self.result)
         }
 
@@ -928,6 +933,7 @@ mod optional_iterator_non_sequential_reads {
         ) -> Result<Option<&mut index_result::RSIndexResult<'index>>, rqe_iterators::RQEIteratorError>
         {
             if self.at_eof() {
+                self.read_step = utils::past_end_cursor(N);
                 return Ok(None);
             }
 
@@ -946,7 +952,10 @@ mod optional_iterator_non_sequential_reads {
             }
 
             match self.result.doc_id.cmp(&doc_id) {
-                std::cmp::Ordering::Less => Ok(None),
+                std::cmp::Ordering::Less => {
+                    self.read_step = utils::past_end_cursor(N);
+                    Ok(None)
+                }
                 std::cmp::Ordering::Equal => Ok(Some(SkipToOutcome::Found(&mut self.result))),
                 std::cmp::Ordering::Greater => Ok(Some(SkipToOutcome::NotFound(&mut self.result))),
             }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -1488,3 +1488,148 @@ mod via_resume_semantics {
         );
     }
 }
+
+/// Resume paths that the rest of the suite cannot distinguish from a passing
+/// case: the `max_doc_id` boundary, a type-erased wildcard slot, a second cycle
+/// after the child aborted, and the hand-rolled teardown guard.
+mod via_resume_coverage {
+    use super::*;
+    use rqe_iterators::{RQEIteratorBoxed, RQESuspendedIterator};
+
+    const WEIGHT: f64 = 2.0;
+
+    /// A wcii that moves to exactly `max_doc_id` still has a valid current
+    /// result there, even though `at_eof()` is true.
+    ///
+    /// `at_eof` is a look-ahead — `settle_at` raises it the moment the position
+    /// reaches the bound, while that position is the current result. A caller
+    /// reading `Moved` + `at_eof()` as "nothing left" would skip the last
+    /// document of the range; `current()` is what actually answers.
+    #[test]
+    fn resume_moved_to_exactly_max_doc_id_keeps_the_hit() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        // max_doc_id == 20, and the move lands exactly on it, with a child hit.
+        let wcii = utils::Mock::new([5u64, 20]);
+        let mut wcii_data = wcii.data();
+        let child = utils::Mock::new([5u64, 20]);
+        let mut it = Box::new(OptionalOptimized::new(wcii, child, 20, WEIGHT));
+
+        let r = it.read().expect("read").expect("result");
+        assert_eq!(r.doc_id, 5);
+
+        wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+        let mut active = match it.suspend().resume(&guard).expect("resume failed") {
+            ResumeOutcome::Moved(a) => a,
+            ResumeOutcome::Ok(_) => panic!("expected Moved, got Ok"),
+            ResumeOutcome::Aborted => panic!("expected Moved, got Aborted"),
+        };
+
+        assert!(
+            active.at_eof(),
+            "look-ahead: doc 20 is the bound, so the next read yields nothing",
+        );
+        let cur = active
+            .current()
+            .expect("doc 20 is a valid current result despite at_eof()");
+        assert_eq!(cur.doc_id, 20);
+        assert_eq!(cur.weight, WEIGHT, "a real hit carries the optional weight");
+    }
+
+    /// A *type-erased wildcard* must survive the cycle.
+    ///
+    /// `suspend` dispatches both slots through `suspend_child_slot_in_place`
+    /// precisely because an erased slot's active and suspended forms carry
+    /// different vtables. Only the child slot was covered; a byte cast of the
+    /// wildcard slot would mis-dispatch on resume.
+    #[test]
+    fn resume_with_type_erased_wcii_survives() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let wcii = TypeErasedRQEIterator::new(Box::new(utils::Mock::new([1u64, 2, 3])));
+        let child = utils::Mock::new([2u64]);
+        let mut it = Box::new(OptionalOptimized::new(wcii, child, 100, WEIGHT));
+
+        let r = it.read().expect("read").expect("result");
+        assert_eq!(r.doc_id, 1);
+
+        let mut active = match it.suspend().resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(a) | ResumeOutcome::Moved(a) => a,
+            ResumeOutcome::Aborted => panic!("default mocks should not abort"),
+        };
+        // The erased wildcard still drives the iteration after the round trip.
+        let r = active.read().expect("read after resume").expect("result");
+        assert_eq!(r.doc_id, 2);
+        assert_eq!(r.weight, WEIGHT, "doc 2 is a real child hit");
+    }
+
+    /// Resuming a second time, with the child already replaced by `Empty`.
+    ///
+    /// The first resume aborts the child and installs `MaybeEmpty`'s `None`
+    /// arm; the second then has to suspend and resume *that* arm. Every other
+    /// test stops after one cycle, so the empty-child arm was never carried
+    /// through one.
+    #[test]
+    fn resume_twice_after_child_abort_stays_virtual() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let wcii = utils::Mock::new([5u64, 20, 50]);
+        let child = utils::Mock::new([5u64, 20]);
+        let mut child_data = child.data();
+        let mut it = Box::new(OptionalOptimized::new(wcii, child, 100, WEIGHT));
+
+        let r = it.read().expect("read").expect("result");
+        assert_eq!(r.doc_id, 5);
+        assert_eq!(r.weight, WEIGHT, "doc 5 is a real child hit");
+
+        // First cycle: the child aborts and is replaced by `Empty`.
+        child_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
+        let guard = mock_ctx.spec_read();
+        let active = match it.suspend().resume(&guard).expect("first resume failed") {
+            ResumeOutcome::Ok(a) | ResumeOutcome::Moved(a) => a,
+            ResumeOutcome::Aborted => panic!("an aborted child must not abort the whole iterator"),
+        };
+        assert!(active.child().is_none(), "child replaced by Empty");
+
+        // Second cycle: suspend/resume the `None` arm.
+        let mut active = match active
+            .suspend()
+            .resume(&guard)
+            .expect("second resume failed")
+        {
+            ResumeOutcome::Ok(a) | ResumeOutcome::Moved(a) => a,
+            ResumeOutcome::Aborted => panic!("an empty child must not abort the resume"),
+        };
+        assert!(active.child().is_none(), "still Empty after a second cycle");
+
+        // Still usable, and now purely virtual.
+        let r = active.read().expect("read after resume").expect("result");
+        assert_eq!(r.weight, 0., "the child is gone, so every hit is virtual");
+    }
+
+    /// An error from the wildcard's own `resume` propagates, exercising the
+    /// teardown guard.
+    ///
+    /// This is the early-return path where `FreeSuspendedShell` has to drop the
+    /// still-suspended `virt` and free the shell by hand, without touching the
+    /// moved-out child slots. Nothing else in the suite reaches it, so the
+    /// hand-rolled `dealloc` went unverified — including under miri.
+    #[test]
+    fn resume_wcii_error_propagates_and_frees_the_shell() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let wcii = utils::Mock::new([5u64, 20]);
+        let mut wcii_data = wcii.data();
+        let child = utils::Mock::new([5u64]);
+        let mut it = Box::new(OptionalOptimized::new(wcii, child, 100, WEIGHT));
+
+        let r = it.read().expect("read").expect("result");
+        assert_eq!(r.doc_id, 5);
+
+        wcii_data.set_error_on_resume(Some(utils::MockIteratorError::TimeoutError(None)));
+        let result = it.suspend().resume(&guard);
+        assert!(
+            matches!(result, Err(rqe_iterators::RQEIteratorError::TimedOut)),
+            "a wildcard resume failure must propagate out of OptionalOptimized::resume",
+        );
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -1306,3 +1306,141 @@ mod via_resume_address {
         );
     }
 }
+
+/// Resume-path correctness: the outcome must match what `read`/`skip_to` produce
+/// for the same positions — the optional weight on a moved real hit, and `at_eof`
+/// keyed on the `max_doc_id` bound rather than the wildcard's own `at_eof()`.
+mod via_resume_semantics {
+    use super::*;
+    use rqe_iterators::{RQEIteratorBoxed, RQESuspendedIterator};
+
+    const WEIGHT: f64 = 2.0;
+
+    /// A moved wcii that lands on a doc the child also matches must return that
+    /// hit with the optional weight applied (mirrors `read`/`skip_to`), and must
+    /// NOT report EOF for a valid in-bound doc even though the wildcard itself is
+    /// now `at_eof()`. (Codex T3 + T13/T16.)
+    #[test]
+    fn resume_moved_real_hit_applies_weight_and_is_not_eof() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        // wcii `[5, 20]`, child `[5, 20]`, max_doc_id 100: after reading doc 5,
+        // a moved resume advances wcii to its last doc 20 (`wcii.at_eof()` now
+        // true) which the child also matches.
+        let wcii = utils::Mock::new([5u64, 20]);
+        let mut wcii_data = wcii.data();
+        let child = utils::Mock::new([5u64, 20]);
+        let mut it = Box::new(OptionalOptimized::new(wcii, child, 100, WEIGHT));
+
+        let r = it.read().expect("read").expect("result");
+        assert_eq!(r.doc_id, 5);
+
+        wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+        let mut active = match it.suspend().resume(&guard).expect("resume failed") {
+            ResumeOutcome::Moved(a) => a,
+            ResumeOutcome::Ok(_) => panic!("expected Moved, got Ok"),
+            ResumeOutcome::Aborted => panic!("expected Moved, got Aborted"),
+        };
+        assert!(
+            !active.at_eof(),
+            "doc 20 < max_doc_id is a valid current, not EOF, even though wcii.at_eof()"
+        );
+        let cur = active.current().expect("current after moved resume");
+        assert_eq!(cur.doc_id, 20);
+        assert_eq!(
+            cur.weight, WEIGHT,
+            "moved real hit must carry the optional weight"
+        );
+    }
+
+    /// A moved wcii that lands on a valid in-bound doc the child does NOT match
+    /// returns a virtual hit at that doc (zero weight) and is not EOF, again even
+    /// though the wildcard is exhausted. (Codex T13/T16, virtual case.)
+    #[test]
+    fn resume_moved_virtual_hit_at_last_doc_is_not_eof() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        // wcii `[5, 20]`, child `[5, 25]`: after doc 5, wcii moves to 20; the
+        // child has no match at 20 (its next is 25) → virtual hit.
+        let wcii = utils::Mock::new([5u64, 20]);
+        let mut wcii_data = wcii.data();
+        let child = utils::Mock::new([5u64, 25]);
+        let mut it = Box::new(OptionalOptimized::new(wcii, child, 100, WEIGHT));
+
+        let r = it.read().expect("read").expect("result");
+        assert_eq!(r.doc_id, 5);
+
+        wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+        let mut active = match it.suspend().resume(&guard).expect("resume failed") {
+            ResumeOutcome::Moved(a) => a,
+            ResumeOutcome::Ok(_) => panic!("expected Moved, got Ok"),
+            ResumeOutcome::Aborted => panic!("expected Moved, got Aborted"),
+        };
+        assert!(
+            !active.at_eof(),
+            "doc 20 < max_doc_id is a valid current, not EOF"
+        );
+        let cur = active.current().expect("current after moved resume");
+        assert_eq!(cur.doc_id, 20);
+        assert_eq!(cur.weight, 0., "virtual hit carries zero weight");
+    }
+
+    /// An `OptionalOptimized` already exhausted by its own bound (via
+    /// `skip_to(max_doc_id + 1)`, which sets `at_eof` without advancing wcii) must
+    /// keep that EOF across a resume where the wildcard is unchanged — the resume
+    /// must not reset `at_eof` from the still-live `wcii.at_eof()`. (Codex T12.)
+    #[test]
+    fn resume_preserves_bound_eof_when_wcii_unchanged() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        // wcii still has docs (so `wcii.at_eof()` is false), but the iterator is
+        // driven past its own bound.
+        let wcii = utils::Mock::new([5u64, 20, 50]);
+        let child = utils::Mock::new([5u64]);
+        let mut it = Box::new(OptionalOptimized::new(wcii, child, 100, WEIGHT));
+
+        // Exhaust by bound without advancing wcii.
+        assert!(it.skip_to(101).expect("skip_to").is_none());
+        assert!(it.at_eof());
+
+        // wcii resumes unchanged (default Ok); EOF must survive.
+        let active = match it.suspend().resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(a) => a,
+            ResumeOutcome::Moved(_) => panic!("expected Ok (unchanged wcii), got Moved"),
+            ResumeOutcome::Aborted => panic!("expected Ok, got Aborted"),
+        };
+        assert!(
+            active.at_eof(),
+            "bound-EOF must survive resume; must not be reset from wcii.at_eof()"
+        );
+    }
+
+    /// If the virtual sentinel is no longer virtual — a consumer replaced it with
+    /// index-backed data via the mutable `current()`/`read()`/`skip_to` handout —
+    /// resume cannot re-validate it, so it aborts the whole iterator (returns
+    /// `Aborted`, not an error), mirroring `Optional::resume`.
+    #[test]
+    fn resume_aborts_when_virt_no_longer_virtual() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        // child has no match at doc 5 → the first read yields the virtual sentinel.
+        let wcii = utils::Mock::new([5u64]);
+        let child = utils::Mock::new([10u64]);
+        let mut it = Box::new(OptionalOptimized::new(wcii, child, 100, WEIGHT));
+
+        let r = it.read().expect("read").expect("result");
+        assert_eq!(r.doc_id, 5);
+        assert_eq!(r.kind(), RSResultKind::Virtual);
+        // Simulate a consumer swapping the sentinel for a real, index-backed result.
+        *r = RSIndexResult::build_numeric(1.0).build();
+
+        let outcome = it
+            .suspend()
+            .resume(&guard)
+            .expect("resume must not surface an error");
+        assert!(
+            matches!(outcome, ResumeOutcome::Aborted),
+            "a non-virtual sentinel must abort the resume",
+        );
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -12,9 +12,10 @@ use index_result::{RSIndexResult, RSResultKind};
 use inverted_index::{InvertedIndex, doc_ids_only::DocIdsOnly};
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 use rqe_iterators::{
-    RQEIterator, RQEValidateStatus, SkipToOutcome, empty::Empty, inverted_index::Wildcard,
-    optional_optimized::OptionalOptimized,
+    RQEIterator, RQEValidateStatus, ResumeOutcome, SkipToOutcome, TypeErasedRQEIterator,
+    empty::Empty, inverted_index::Wildcard, optional_optimized::OptionalOptimized,
 };
+use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
 
 use crate::utils;
 
@@ -938,5 +939,370 @@ mod optional_optimized_iterator_revalidate_tests {
         // Can still read after revalidation.
         let r = it.read().expect("read after revalidate").expect("result");
         assert!(r.doc_id > 20);
+    }
+
+    mod via_resume {
+        use super::*;
+
+        #[cfg(not(miri))]
+        mod with_inverted_wildcard {
+            use super::*;
+            use inverted_index::opaque::OpaqueEncoding;
+            use rqe_iterators::inverted_index::Wildcard;
+            use rqe_iterators_test_utils::{GlobalGuard, TestContext};
+
+            fn setup<'index>(
+                test_ctx: &'index TestContext,
+            ) -> (
+                OptionalOptimized<
+                    'index,
+                    Wildcard<'index, DocIdsOnly>,
+                    utils::Mock<'index, NUM_DOCS>,
+                >,
+                utils::MockData,
+            ) {
+                let ii = DocIdsOnly::from_opaque(test_ctx.wildcard_inverted_index());
+                let wcii = Wildcard::new(ii.reader(), 0.);
+                let child = utils::Mock::new(CHILD_DOCS);
+                let data = child.data();
+                let it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+                (it, data)
+            }
+
+            #[test]
+            fn test_revalidate_ok() {
+                let _guard = GlobalGuard::default();
+                let test_ctx = TestContext::wildcard(1..=MAX_DOC_ID);
+                let (mut it, mut data) = setup(&test_ctx);
+
+                data.set_revalidate_result(utils::MockRevalidateResult::Ok);
+
+                let _ = it.read().expect("read").expect("result");
+                let _ = it.read().expect("read").expect("result");
+
+                let guard = test_ctx.spec_read();
+                let mut it =
+                    revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                        .expect("resume failed")
+                        .expect_ok();
+                assert_eq!(data.revalidate_count(), 1);
+
+                let _ = it.read().expect("read after revalidate").expect("result");
+            }
+
+            #[test]
+            fn test_revalidate_child_aborted() {
+                let _guard = GlobalGuard::default();
+                let test_ctx = TestContext::wildcard(1..=MAX_DOC_ID);
+                let (mut it, mut data) = setup(&test_ctx);
+
+                data.set_revalidate_result(utils::MockRevalidateResult::Abort);
+
+                let r = it.read().expect("read").expect("result");
+                assert_eq!(r.doc_id, 1);
+
+                let guard = test_ctx.spec_read();
+                // Child aborted while on a virtual result → Ok (no state change needed).
+                let mut it =
+                    revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                        .expect("resume failed")
+                        .expect_ok();
+                // The resumed iterator is type-erased and no longer exposes the
+                // concrete `child()` accessor; the virtual read below (weight 0)
+                // confirms the child was dropped and we fell back to virtual.
+                assert_eq!(data.revalidate_count(), 1);
+
+                let r = it.read().expect("read").expect("result");
+                assert_eq!(r.weight, 0.);
+            }
+
+            #[test]
+            fn test_revalidate_child_moved_on_real() {
+                let _guard = GlobalGuard::default();
+                let test_ctx = TestContext::wildcard(1..=MAX_DOC_ID);
+                let (mut it, mut data) = setup(&test_ctx);
+
+                match it.skip_to(10).expect("no error") {
+                    Some(SkipToOutcome::Found(r)) => assert_eq!(r.doc_id, 10),
+                    other => panic!("unexpected: {other:?}"),
+                }
+
+                data.set_revalidate_result(utils::MockRevalidateResult::Move);
+                let guard = test_ctx.spec_read();
+                revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                    .expect("resume failed")
+                    .expect_moved();
+                assert_eq!(data.revalidate_count(), 1);
+            }
+
+            #[test]
+            fn test_revalidate_child_moved_on_virtual() {
+                let _guard = GlobalGuard::default();
+                let test_ctx = TestContext::wildcard(1..=MAX_DOC_ID);
+                let (mut it, mut data) = setup(&test_ctx);
+
+                match it.skip_to(15).expect("no error") {
+                    Some(SkipToOutcome::Found(r)) => assert_eq!(r.doc_id, 15),
+                    other => panic!("unexpected: {other:?}"),
+                }
+
+                data.set_revalidate_result(utils::MockRevalidateResult::Move);
+                let guard = test_ctx.spec_read();
+                // Child moved while on a virtual result → Ok
+                revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                    .expect("resume failed")
+                    .expect_ok();
+                assert_eq!(data.revalidate_count(), 1);
+            }
+        }
+
+        #[test]
+        fn test_revalidate_wcii_aborted() {
+            const WCII_DOCS: usize = 10;
+            let wcii_docs: [DocId; WCII_DOCS] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+            let wcii = utils::Mock::new(wcii_docs);
+            let mut wcii_data = wcii.data();
+            let child = utils::Mock::new(CHILD_DOCS);
+            let mut it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+
+            let _ = it.read().expect("read").expect("result");
+
+            wcii_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let guard = mock_ctx.spec_read();
+            let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+        }
+
+        #[test]
+        fn test_revalidate_wcii_moved_real_hit() {
+            let wcii = utils::Mock::new([5u64, 20]);
+            let mut wcii_data = wcii.data();
+            let child = utils::Mock::new([5u64, 20]);
+            let mut it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+
+            let r = it.read().expect("read").expect("result");
+            assert_eq!(r.doc_id, 5);
+
+            wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let guard = mock_ctx.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            let r = it.current().expect("current");
+            assert_eq!(r.doc_id, 20);
+            assert_eq!(r.weight, WEIGHT);
+            assert_eq!(it.last_doc_id(), 20);
+        }
+
+        #[test]
+        fn test_revalidate_wcii_moved_virtual_hit() {
+            let wcii = utils::Mock::new([5u64, 20]);
+            let mut wcii_data = wcii.data();
+            let child = utils::Mock::new([5u64, 25]);
+            let mut it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+
+            let r = it.read().expect("read").expect("result");
+            assert_eq!(r.doc_id, 5);
+
+            wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let guard = mock_ctx.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            let r = it.current().expect("current");
+            assert_eq!(r.doc_id, 20);
+            assert_eq!(r.weight, 0.);
+            assert_eq!(it.last_doc_id(), 20);
+        }
+
+        #[test]
+        fn test_revalidate_wcii_moved_past_max_doc_id() {
+            let wcii = utils::Mock::new([5u64, 150]);
+            let mut wcii_data = wcii.data();
+            let child = utils::Mock::new(CHILD_DOCS);
+            let mut it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+
+            let r = it.read().expect("read").expect("result");
+            assert_eq!(r.doc_id, 5);
+
+            wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let guard = mock_ctx.spec_read();
+            let it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            assert!(it.at_eof());
+        }
+
+        /// Regression: wcii moves to its own EOF (single-doc Mock at EOF returns
+        /// "Moved without new doc"). Optional must propagate that as Moved + EOF.
+        #[test]
+        fn test_revalidate_wcii_moved_to_eof() {
+            let wcii = utils::Mock::new([5u64]);
+            let mut wcii_data = wcii.data();
+            let child = utils::Mock::new([5u64]);
+            let mut it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+
+            let r = it.read().expect("read").expect("result");
+            assert_eq!(r.doc_id, 5);
+
+            wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let guard = mock_ctx.spec_read();
+            let it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            assert!(it.at_eof(), "iterator must be at EOF");
+            assert_eq!(wcii_data.revalidate_count(), 1);
+        }
+
+        #[test]
+        fn test_revalidate_child_aborted_wcii_moved() {
+            let wcii = utils::Mock::new([5u64, 20]);
+            let mut wcii_data = wcii.data();
+            let child = utils::Mock::new([5u64, 35]);
+            let mut child_data = child.data();
+            let mut it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+
+            let r = it.read().expect("read").expect("result");
+            assert_eq!(r.doc_id, 5);
+
+            wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+            child_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
+
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let guard = mock_ctx.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            let r = it.current().expect("current");
+            assert_eq!(r.doc_id, 20);
+            assert_eq!(r.weight, 0.);
+            // The resumed iterator is type-erased and no longer exposes the
+            // concrete `child()` accessor; the virtual result above (weight 0)
+            // confirms the aborted child was replaced by `Empty`.
+            assert_eq!(wcii_data.revalidate_count(), 1);
+            assert_eq!(child_data.revalidate_count(), 1);
+        }
+
+        #[test]
+        fn test_revalidate_child_moved_wcii_aborted() {
+            let wcii = utils::Mock::new([5u64, 20]);
+            let mut wcii_data = wcii.data();
+            let child = utils::Mock::new([5u64, 35]);
+            let mut child_data = child.data();
+            let mut it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+
+            let r = it.read().expect("read").expect("result");
+            assert_eq!(r.doc_id, 5);
+
+            wcii_data.set_revalidate_result(utils::MockRevalidateResult::Abort);
+            child_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let guard = mock_ctx.spec_read();
+            let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+            assert_eq!(wcii_data.revalidate_count(), 1);
+            // Both children are resumed in the new path (resume drives both unconditionally);
+            // the suspend->resume cycle returns Aborted but doesn't short-circuit child.
+            assert_eq!(child_data.revalidate_count(), 1);
+        }
+
+        #[test]
+        fn test_revalidate_child_moved_wcii_moved() {
+            let wcii = utils::Mock::new([5u64, 20, 35]);
+            let mut wcii_data = wcii.data();
+            let child = utils::Mock::new([5u64, 25, 35]);
+            let mut child_data = child.data();
+            let mut it = OptionalOptimized::new(wcii, child, MAX_DOC_ID, WEIGHT);
+
+            let r = it.read().expect("read").expect("result");
+            assert_eq!(r.doc_id, 5);
+
+            wcii_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+            child_data.set_revalidate_result(utils::MockRevalidateResult::Move);
+
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let guard = mock_ctx.spec_read();
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                .expect("resume failed")
+                .expect_moved();
+            let r = it.current().expect("current");
+            assert_eq!(r.doc_id, 20);
+            assert_eq!(r.weight, 0.);
+            assert_eq!(it.last_doc_id(), 20);
+            assert_eq!(wcii_data.revalidate_count(), 1);
+            assert_eq!(child_data.revalidate_count(), 1);
+
+            let r = it.read().expect("read after revalidate").expect("result");
+            assert!(r.doc_id > 20);
+        }
+    }
+}
+
+mod via_resume_address {
+    use super::*;
+    use rqe_iterators::{RQEIteratorBoxed, RQESuspendedIterator};
+
+    /// Regression: both `suspend` and `resume` must **reuse the allocation**.
+    /// `OptionalOptimized` hands out `&mut self.virt` from
+    /// `current()`/`read()`/`skip_to`, so the FFI's cached `header.current` points
+    /// into the box; the previous `resume` rebuilt via `Box::new`, which moved
+    /// `virt` (and the two inline sub-iterators) and dangled it.
+    #[test]
+    fn resume_preserves_box_address() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let wcii = utils::Mock::new([1u64, 2, 3]);
+        let child = utils::Mock::new([2u64]);
+        let mut it = Box::new(OptionalOptimized::new(wcii, child, 100, 2.0));
+        let _ = it.read().expect("read").expect("result");
+        let addr_before = &*it as *const _ as usize;
+
+        let suspended = it.suspend();
+        assert_eq!(
+            &*suspended as *const _ as usize, addr_before,
+            "suspend must reuse the allocation"
+        );
+
+        let active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(a) | ResumeOutcome::Moved(a) => a,
+            ResumeOutcome::Aborted => panic!("default mocks should not abort"),
+        };
+        assert_eq!(
+            &*active as *const _ as usize, addr_before,
+            "resume must reuse the allocation (OptionalOptimized hands out &mut self.virt)"
+        );
+    }
+
+    /// Regression: `suspend` must dispatch the child's own `suspend` (not
+    /// byte-cast it). With a *type-erased* child, a byte cast would keep the
+    /// child's active `dyn` vtable under a suspended type, so `resume` would
+    /// mis-dispatch and the child would be lost (dropped to `Empty`). A surviving
+    /// `Present` child is the discriminating signal.
+    #[test]
+    fn resume_with_type_erased_child_survives() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let wcii = utils::Mock::new([1u64, 2, 3]);
+        let child = TypeErasedRQEIterator::new(Box::new(utils::Mock::new([2u64])));
+        let mut it = Box::new(OptionalOptimized::new(wcii, child, 100, 2.0));
+        let _ = it.read().expect("read").expect("result");
+
+        let suspended = it.suspend();
+        let active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(a) | ResumeOutcome::Moved(a) => a,
+            ResumeOutcome::Aborted => panic!("default mocks should not abort"),
+        };
+        assert!(
+            active.child().is_some(),
+            "type-erased child must survive suspend/resume (not be dropped to Empty)"
+        );
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional_optimized.rs
@@ -1316,6 +1316,50 @@ mod via_resume_semantics {
 
     const WEIGHT: f64 = 2.0;
 
+    /// Regression: a wildcard that resumes by re-seeking *past* the end must be
+    /// recognised as having no current, not settled onto doc 0.
+    ///
+    /// `resume` used to recover "moved to a new doc" vs "moved off the end" by
+    /// comparing the wildcard's pre- and post-resume `last_doc_id`, expecting
+    /// EOF to leave it unchanged. The inverted-index wildcards rewind before
+    /// re-seeking (`RawInvIndIterator::resume_in_place`), so a GC that removes
+    /// the current doc and everything after it returns EOF with `last_doc_id()`
+    /// reset to 0 — never equal to the pre-resume value. The comparison missed
+    /// it, fell through to the moved-to-a-valid-doc path with `wcii_doc_id == 0`
+    /// and produced a virtual result for the non-existent doc 0, reported as
+    /// `Moved` with `at_eof()` false.
+    #[test]
+    fn resume_wcii_reseeking_past_end_reports_no_current() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        // The wildcard still has ids after 5, so nothing about its *contents*
+        // signals EOF — only the rewind-then-miss resume does.
+        let wcii = utils::Mock::new([5u64, 20, 50]);
+        let mut wcii_data = wcii.data();
+        let child = utils::Mock::new([5u64]);
+        let mut it = Box::new(OptionalOptimized::new(wcii, child, 100, WEIGHT));
+
+        let r = it.read().expect("read").expect("result");
+        assert_eq!(r.doc_id, 5);
+
+        wcii_data.set_resume_reseeks_past_end(true);
+        let mut active = match it.suspend().resume(&guard).expect("resume failed") {
+            ResumeOutcome::Moved(a) => a,
+            ResumeOutcome::Ok(_) => panic!("expected Moved, got Ok"),
+            ResumeOutcome::Aborted => panic!("expected Moved, got Aborted"),
+        };
+
+        assert!(
+            active.current().is_none(),
+            "the wildcard re-seeked past its end, so there is no current result",
+        );
+        assert!(active.at_eof(), "and the iterator is exhausted");
+        assert!(
+            active.read().expect("read after resume").is_none(),
+            "nothing left to read",
+        );
+    }
+
     /// A moved wcii that lands on a doc the child also matches must return that
     /// hit with the optional weight applied (mirrors `read`/`skip_to`), and must
     /// NOT report EOF for a valid in-bound doc even though the wildcard itself is

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -140,7 +140,30 @@ impl MockData {
             resume_error: None,
             delays: Vec::new(),
             force_read_none: false,
+            resume_reseeks_past_end: false,
         })))
+    }
+
+    /// Make `resume` reproduce an inverted-index re-seek that runs off the end.
+    ///
+    /// A plain [`MockRevalidateResult::Move`] models a resume that lands on a
+    /// later document. The real inverted-index iterators have a second, quite
+    /// different `Moved` shape that no mock could express: when GC invalidates
+    /// the cached block offset, `RawInvIndIterator::resume_in_place` *rewinds*
+    /// and then re-seeks to the last doc id. If that seek finds nothing, the
+    /// iterator ends up at EOF with `last_doc_id()` reset to `0` — its
+    /// pre-suspend position is gone rather than advanced.
+    ///
+    /// That matters because a composite cannot recognise this case by comparing
+    /// the child's pre- and post-resume `last_doc_id`: the cached id went
+    /// backwards, not forwards. Only [`RQEIterator::current`] returning `None`
+    /// identifies it.
+    ///
+    /// When set, `resume` ignores the configured [`MockRevalidateResult`] and
+    /// reports `Moved` with the iterator rewound and past its end.
+    pub fn set_resume_reseeks_past_end(&mut self, reseeks_past_end: bool) -> &mut Self {
+        self.0.borrow_mut().resume_reseeks_past_end = reseeks_past_end;
+        self
     }
 
     /// Configure the result that [`Mock::revalidate`] will report.
@@ -237,6 +260,9 @@ struct MockDataInternal {
     /// If true, the next call to `read()` will return `None` even if not at EOF.
     /// Simulates Inverted Index iterators that discover EOF only when `read()` is called.
     force_read_none: bool,
+    /// If true, `resume` rewinds and reports `Moved` past the end — see
+    /// [`MockData::set_resume_reseeks_past_end`].
+    resume_reseeks_past_end: bool,
 }
 
 impl MockDataInternal {
@@ -565,16 +591,32 @@ impl<'query, const N: usize> rqe_iterators::RQESuspendedIterator<'query> for Moc
         // [`MockData`] — mirrors what `Mock::revalidate` does on the legacy
         // path, so tests driving suspend/resume see the same per-mock
         // outcomes as before.
-        let (revalidate_result, resume_error) = {
+        let (revalidate_result, resume_error, reseeks_past_end) = {
             let mut data = self.data.0.borrow_mut();
             data.validation_count += 1;
-            (data.revalidate_result, data.resume_error)
+            (
+                data.revalidate_result,
+                data.resume_error,
+                data.resume_reseeks_past_end,
+            )
         };
         // Injected resume failure (see `MockData::set_error_on_resume`): drop the
         // suspended mock and surface the error, mirroring a real child whose
         // revalidation-via-resume fails.
         if let Some(err) = resume_error {
             return Err(err.into_rqe_iterator_error());
+        }
+        if reseeks_past_end {
+            // Reproduce `RawInvIndIterator::resume_in_place` on a GC-invalidated
+            // offset whose re-seek finds nothing: rewind, then end up at EOF with
+            // the cached doc id reset to 0 rather than advanced. See
+            // `MockData::set_resume_reseeks_past_end`.
+            self.result.doc_id = 0;
+            self.next_index = N + 1;
+            let raw = Box::into_raw(self);
+            // SAFETY: layout-identical (see [`Mock::suspend`]).
+            let active = unsafe { Box::from_raw(raw as *mut Mock<'a, N>) };
+            return Ok(rqe_iterators::ResumeOutcome::Moved(active));
         }
         let moved = match revalidate_result {
             MockRevalidateResult::Ok => false,

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -11,6 +11,8 @@ use std::{cell::RefCell, rc::Rc, time::Duration};
 
 use index_result::{RSIndexResult, RSOffsetSlice};
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
+
+use super::past_end_cursor;
 use rqe_iterators::{IteratorType, RQEIterator, WildcardIterator};
 
 /// Test iterator used in unit tests that expect an [`RQEIterator`]
@@ -63,6 +65,8 @@ pub struct Mock<'index, const N: usize> {
     /// single-byte LEB128 varint encoding, so the byte can be passed directly to
     /// [`RSOffsetSlice::from_slice`] without a separate encoding step.
     positions: Option<[u8; N]>,
+    /// Index of the next document to serve, [`past_end_cursor`] once a
+    /// `read`/`skip_to` ran past the last one.
     next_index: usize,
     data: MockData,
 }
@@ -333,6 +337,9 @@ impl<'index, const N: usize> Mock<'index, N> {
 
 impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        if self.next_index == past_end_cursor(N) {
+            return None;
+        }
         Some(&mut self.result)
     }
 
@@ -346,6 +353,8 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
             // Check if we should force return None (simulating misbehaving iterator)
             if data.force_read_none {
                 data.force_read_none = false; // Clear after one use
+                // Deliberately not recorded as past the end: only the `None` is
+                // fabricated, the mock still has documents to serve.
                 return Ok(None);
             }
 
@@ -353,6 +362,7 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
                 return if let Some(err) = data.error_at_done {
                     Err(err.into_rqe_iterator_error())
                 } else {
+                    self.next_index = past_end_cursor(N);
                     Ok(None)
                 };
             }
@@ -394,6 +404,7 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
             return if let Some(err) = data.error_at_done {
                 Err(err.into_rqe_iterator_error())
             } else {
+                self.next_index = past_end_cursor(N);
                 Ok(None)
             };
         }
@@ -429,13 +440,17 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
             MockRevalidateResult::Ok => rqe_iterators::RQEValidateStatus::Ok,
             MockRevalidateResult::Abort => rqe_iterators::RQEValidateStatus::Aborted,
             MockRevalidateResult::Move => {
-                rqe_iterators::RQEValidateStatus::Moved {
-                    current: (self.next_index < N).then(|| {
-                        // Simulate a move by incrementing nextIndex
-                        self.set_result(self.next_index);
-                        self.next_index += 1;
-                        &mut self.result
-                    }),
+                if self.next_index < N {
+                    // Simulate a move by incrementing nextIndex
+                    self.set_result(self.next_index);
+                    self.next_index += 1;
+                    rqe_iterators::RQEValidateStatus::Moved {
+                        current: Some(&mut self.result),
+                    }
+                } else {
+                    // The move ran off the end, leaving the iterator unpositioned.
+                    self.next_index = past_end_cursor(N);
+                    rqe_iterators::RQEValidateStatus::Moved { current: None }
                 }
             }
         })
@@ -584,6 +599,10 @@ impl<'query, const N: usize> rqe_iterators::RQESuspendedIterator<'query> for Moc
                         self.result.doc_id = doc_id;
                     }
                     self.next_index += 1;
+                } else {
+                    // The move ran off the end, leaving the resumed iterator
+                    // unpositioned.
+                    self.next_index = past_end_cursor(N);
                 }
                 true
             }
@@ -622,6 +641,8 @@ impl<'query, const N: usize> rqe_iterators::RQESuspendedIterator<'query> for Moc
 pub struct MockVec<'index> {
     result: RSIndexResult<'index>,
     doc_ids: Vec<DocId>,
+    /// Index of the next document to serve, [`past_end_cursor`] once a
+    /// `read`/`skip_to` ran past the last one.
     next_index: usize,
     data: MockData,
 }
@@ -651,6 +672,9 @@ impl<'index> MockVec<'index> {
 
 impl<'index> RQEIterator<'index> for MockVec<'index> {
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        if self.next_index == past_end_cursor(self.doc_ids.len()) {
+            return None;
+        }
         Some(&mut self.result)
     }
 
@@ -670,6 +694,7 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
                 return if let Some(err) = data.error_at_done {
                     Err(err.into_rqe_iterator_error())
                 } else {
+                    self.next_index = past_end_cursor(self.doc_ids.len());
                     Ok(None)
                 };
             }
@@ -708,6 +733,7 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
             return if let Some(err) = data.error_at_done {
                 Err(err.into_rqe_iterator_error())
             } else {
+                self.next_index = past_end_cursor(n);
                 Ok(None)
             };
         }
@@ -743,13 +769,19 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
         Ok(match revalidate_result {
             MockRevalidateResult::Ok => rqe_iterators::RQEValidateStatus::Ok,
             MockRevalidateResult::Abort => rqe_iterators::RQEValidateStatus::Aborted,
-            MockRevalidateResult::Move => rqe_iterators::RQEValidateStatus::Moved {
-                current: (self.next_index < n).then(|| {
+            MockRevalidateResult::Move => {
+                if self.next_index < n {
                     self.result.doc_id = self.doc_ids[self.next_index];
                     self.next_index += 1;
-                    &mut self.result
-                }),
-            },
+                    rqe_iterators::RQEValidateStatus::Moved {
+                        current: Some(&mut self.result),
+                    }
+                } else {
+                    // The move ran off the end, leaving the iterator unpositioned.
+                    self.next_index = past_end_cursor(n);
+                    rqe_iterators::RQEValidateStatus::Moved { current: None }
+                }
+            }
         })
     }
 
@@ -864,6 +896,10 @@ impl<'query> rqe_iterators::RQESuspendedIterator<'query> for MockVecSuspended {
                     // offsets), so setting `doc_id` alone is sufficient.
                     self.result.doc_id = self.doc_ids[self.next_index];
                     self.next_index += 1;
+                } else {
+                    // The move ran off the end, leaving the resumed iterator
+                    // unpositioned.
+                    self.next_index = past_end_cursor(self.doc_ids.len());
                 }
                 true
             }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
@@ -24,6 +24,8 @@ use rqe_iterators::{IteratorType, RQEIterator, RQEIteratorError, SkipToOutcome};
 /// `RSIndexResult::field_mask`.
 pub(crate) struct FieldMaskMock {
     doc_ids: Vec<u64>,
+    /// Index of the next document to serve, [`past_end_cursor`] once we ran past
+    /// the last one.
     next: usize,
     result: RSIndexResult<'static>,
     mask: inverted_index::FieldMask,
@@ -42,11 +44,15 @@ impl FieldMaskMock {
 
 impl RQEIterator<'static> for FieldMaskMock {
     fn current(&mut self) -> Option<&mut RSIndexResult<'static>> {
+        if self.next == past_end_cursor(self.doc_ids.len()) {
+            return None;
+        }
         Some(&mut self.result)
     }
 
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'static>>, RQEIteratorError> {
         if self.next >= self.doc_ids.len() {
+            self.next = past_end_cursor(self.doc_ids.len());
             return Ok(None);
         }
         self.result.doc_id = self.doc_ids[self.next];
@@ -63,6 +69,7 @@ impl RQEIterator<'static> for FieldMaskMock {
             self.next += 1;
         }
         if self.next >= self.doc_ids.len() {
+            self.next = past_end_cursor(self.doc_ids.len());
             return Ok(None);
         }
         self.result.doc_id = self.doc_ids[self.next];
@@ -110,6 +117,17 @@ impl RQEIterator<'static> for FieldMaskMock {
 
 use rqe_core::DocId;
 use std::collections::BTreeSet;
+
+/// The cursor value the mock iterators in these tests use to record that a
+/// `read`/`skip_to` ran past their last document, given the number of documents
+/// they hold.
+///
+/// A cursor equal to `len` cannot express it: that is also the state while still
+/// sitting on the last document, and [`RQEIterator::current`] has to tell the two
+/// apart (it is `Some` on the last document, `None` past it).
+pub(crate) fn past_end_cursor(len: usize) -> usize {
+    len + 1
+}
 
 /// Drain all documents from an iterator and return their doc_ids.
 pub(crate) fn drain_doc_ids<'index, I: RQEIterator<'index>>(it: &mut I) -> Vec<DocId> {

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/lib.rs
@@ -23,8 +23,104 @@ pub mod test_context;
 use index_spec::IndexSpecReadGuard;
 pub use mock_context::MockContext;
 pub use mock_expiration::MockExpirationChecker;
-use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator, TypeErasedRQESuspendedIterator};
+use rqe_core::DocId;
+use rqe_iterators::{
+    RQEIterator, ResumeOutcome, TypeErasedRQEIterator, TypeErasedRQESuspendedIterator,
+};
 pub use test_context::{GlobalGuard, TestContext};
+
+/// Drive `it` from its current position to exhaustion, asserting that it
+/// upholds the [`current`](RQEIterator::current) has-current contract.
+///
+/// The contract is what makes [`ResumeOutcome::Moved`] actionable: a composite
+/// recovers "moved to a new document" vs. "moved off the end" by asking its
+/// child for a current result. A child that keeps handing out its last result
+/// after exhaustion silently turns the second case into the first, which is
+/// exactly the stale-position bug the suspend/resume machinery exists to avoid.
+///
+/// Asserted, in order:
+///
+/// 1. after each successful `read`, `current()` is `Some` and agrees with both
+///    the returned result's `doc_id` and [`last_doc_id`](RQEIterator::last_doc_id);
+/// 2. once `read` returns `Ok(None)`, [`at_eof`](RQEIterator::at_eof) is `true`
+///    and `current()` is `None`;
+/// 3. the iterator stays exhausted, and keeps reporting no current;
+/// 4. after [`rewind`](RQEIterator::rewind) the iterator replays the identical
+///    doc-id sequence — which also proves the exhausted state is cleared rather
+///    than latched.
+///
+/// Returns the doc ids yielded, so callers can additionally assert on them.
+///
+/// Note that `at_eof()` is deliberately *not* asserted to be `false` while
+/// results remain: it is a look-ahead and is allowed to go `true` while the
+/// iterator still sits on its last result.
+///
+/// # Panics
+///
+/// Panics on the first contract violation, or if `it` errors while draining.
+/// Not suitable for iterators that panic on `rewind` (e.g. `UnionTrimmed`).
+#[track_caller]
+pub fn assert_current_contract<'index, I: RQEIterator<'index>>(it: &mut I) -> Vec<DocId> {
+    let first_pass = drain_checking_current(it, "first pass");
+
+    it.rewind();
+    let second_pass = drain_checking_current(it, "after rewind");
+    assert_eq!(
+        first_pass, second_pass,
+        "rewind must replay the same doc ids; a latched exhausted-state \
+         truncates the second pass",
+    );
+
+    first_pass
+}
+
+/// Drain `it`, asserting the has-current contract at every step. `phase` names
+/// the pass in assertion messages.
+#[track_caller]
+fn drain_checking_current<'index, I: RQEIterator<'index>>(it: &mut I, phase: &str) -> Vec<DocId> {
+    let mut doc_ids = Vec::new();
+
+    while let Some(result) = it.read().expect("read must not fail while draining") {
+        let doc_id = result.doc_id;
+        doc_ids.push(doc_id);
+
+        assert_eq!(
+            it.last_doc_id(),
+            doc_id,
+            "{phase}: last_doc_id() must track the result just returned by read()",
+        );
+        let current = it.current().unwrap_or_else(|| {
+            panic!("{phase}: current() must be Some right after a successful read of doc {doc_id}")
+        });
+        assert_eq!(
+            current.doc_id, doc_id,
+            "{phase}: current() must return the result read() just yielded",
+        );
+    }
+
+    assert!(
+        it.at_eof(),
+        "{phase}: at_eof() must be true once read() has returned None",
+    );
+    assert!(
+        it.current().is_none(),
+        "{phase}: current() must be None once the iterator has run past its \
+         last result — it must not keep returning the stale last result",
+    );
+
+    assert!(
+        it.read()
+            .expect("read must not fail once exhausted")
+            .is_none(),
+        "{phase}: an exhausted iterator must keep returning None",
+    );
+    assert!(
+        it.current().is_none(),
+        "{phase}: current() must stay None once exhausted",
+    );
+
+    doc_ids
+}
 
 /// Drive a suspend/resume cycle on `it` under the given lock guard.
 ///

--- a/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
+++ b/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
@@ -146,7 +146,12 @@ impl<'index> ErrOnSecondRead<'index> {
 
 impl<'index> RQEIterator<'index> for ErrOnSecondRead<'index> {
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
-        None
+        // Later reads fail rather than report depletion, so this stub never
+        // advances past its single document once it has been read.
+        if self.n == 0 {
+            return None;
+        }
+        Some(&mut self.result)
     }
 
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {

--- a/src/redisearch_rs/top_k/tests/integration/revalidation.rs
+++ b/src/redisearch_rs/top_k/tests/integration/revalidation.rs
@@ -84,24 +84,33 @@ impl<'index> RQEIterator<'index> for AbortOnRevalidate {
 /// surfacing the child's reposition as its own.
 struct MovedOnRevalidate<'index> {
     current: RSIndexResult<'index>,
+    /// Set once [`RQEIterator::read`] reported depletion, after which
+    /// [`RQEIterator::current`] no longer advertises a position.
+    at_eos: bool,
 }
 
 impl<'index> MovedOnRevalidate<'index> {
     fn new() -> Self {
         Self {
             current: RSIndexResult::build_virt().doc_id(7).build(),
+            at_eos: false,
         }
     }
 }
 
 impl<'index> RQEIterator<'index> for MovedOnRevalidate<'index> {
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
-        None
+        // Sits on the document its `revalidate` reports as the moved-to position.
+        if self.at_eos {
+            return None;
+        }
+        Some(&mut self.current)
     }
 
     fn read(
         &mut self,
     ) -> Result<Option<&mut RSIndexResult<'index>>, rqe_iterators::RQEIteratorError> {
+        self.at_eos = true;
         Ok(None)
     }
 
@@ -133,7 +142,9 @@ impl<'index> RQEIterator<'index> for MovedOnRevalidate<'index> {
     }
 
     fn at_eof(&self) -> bool {
-        false
+        // The next `read` does report depletion, even while `current` still
+        // reports a position.
+        true
     }
 
     fn type_(&self) -> rqe_iterator_type::IteratorType {


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `OptionalOptimized` (the wildcard-driven optimized optional
   iterator: a wildcard base `wcii` over `spec.existingDocs`, a `MaybeEmpty`
   query `child`, and a virtual sentinel `virt`) implements only the legacy
   `RQEIterator::revalidate`; it has no `Box<Self>`-based suspend/resume.
2. **Change:** Implement `RQEIteratorBoxed` + `RQESuspendedIterator` for
   `OptionalOptimized`. `suspend` dispatches both sub-iterators' own `suspend`
   (correct for type-erased children) and reuses the allocation. `resume` moves
   both children out into owned locals, resumes them (an aborted `wcii` aborts
   the whole iterator; an aborted `child` becomes `Empty`), and writes the
   resumed children back into their original slots — reusing the allocation so
   the `virt` sentinel handed out via `current()`/`read()`/`skip_to` (and the
   FFI's cached `header.current`) keeps its address. A small RAII guard frees the
   shell on any early return/panic, so there is no manual teardown. `virt` is
   validated to still be a virtual sentinel (`kind() == Virtual`) before the
   `Suspended → Active` reinterpretation. Adds a `const _` invariant-1 layout
   proof.
3. **Outcome:** `OptionalOptimized` can be suspended/resumed soundly, including
   over type-erased children, with stable addresses across the cycle.

Stacked on #10619 (`[Iterator Revalidation] MaybeEmpty`) and targets
`iter-reval-C3a-maybe-empty`. Reviewed against
`docs/rqe-iterator-suspend-resume.md`.

#### Which additional issues this PR fixes

Part of the Iterator Revalidation epic. Stacked on #10619.

#### Main objects this PR modified

1. `OptionalOptimized` / `RawOptionalOptimized`
   (`rqe_iterators/src/optional_optimized.rs`) — new `RQEIteratorBoxed` /
   `RQESuspendedIterator` impls + `const _` invariant proof.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal-only: the suspend/resume surface is not yet wired into production; no
user-facing behavior changes.
