### PR TITLE
Don't gitignore proptest regression seeds

### DIFF
--- a/src/redisearch_rs/.gitignore
+++ b/src/redisearch_rs/.gitignore
@@ -11,9 +11,6 @@
 
 .vscode
 
-# Regressions in `proptest` tests
-**/proptest-regressions/**
-
 # `insta` pending snapshots
 **/*.pending-snap
 **/*.snap.new


### PR DESCRIPTION
Rust proptest regression seeds should be checked in for more reliable repros of discovered bugs.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
