### PR TITLE
[MOD-16581] Fix: FT.HYBRID tail matched_terms() returned NULL without scores

### DIFF
--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -195,6 +195,11 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *score
     QITR_PushRP(&req->tailPipeline->qctx, merger);
     // Build the aggregation part of the tail pipeline for final result processing
     // This handles sorting, filtering, field loading, and output formatting of merged results
+    // Skip the index-result copy unless the tail needs it. The tail misses this baseline
+    // by skipping Pipeline_BuildQueryPart; BuildAggregationPart flips it back on as needed.
+    req->tailPipeline->qctx.skipIndexResultDeepCopy =
+        !QEFlags_RequireIndexResultsDownstream(params->aggregationParams.common.reqflags);
+
     uint32_t stateFlags = 0;
     int rc = Pipeline_BuildAggregationPart(req->tailPipeline, &params->aggregationParams, &stateFlags, status);
 

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -197,6 +197,18 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *score
     // This handles sorting, filtering, field loading, and output formatting of merged results
     uint32_t stateFlags = 0;
     int rc = Pipeline_BuildAggregationPart(req->tailPipeline, &params->aggregationParams, &stateFlags, status);
+
+    // The tail's matched_terms()/highlighting reads each row's RSIndexResult, but the
+    // per-subquery depleters were built earlier with their own skipIndexResultDeepCopy
+    // decision and would drop the borrow before the merged row reaches the tail. The
+    // flag is read at execution time, so forcing the subqueries to preserve the borrow
+    // now reaches those depleters. Only ever force the copy on, never off, so a subquery
+    // that independently needs the index result downstream is left untouched.
+    if (rc == REDISMODULE_OK && !req->tailPipeline->qctx.skipIndexResultDeepCopy) {
+      for (size_t i = 0; i < req->nrequests; i++) {
+        req->requests[i]->pipeline.qctx.skipIndexResultDeepCopy = false;
+      }
+    }
     return rc;
 }
 

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -711,3 +711,39 @@ TEST_F(HybridRequestParseTest, testKeyCorrespondenceBetweenSearchAndTailPipeline
     }
   }
 }
+
+// A tail with no index-result reader lets every subquery depleter drop the borrow.
+TEST_F(HybridRequestParseTest, testHybridSkipIndexResultDeepCopyWhenTailHasNoReader) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", "test_skip_copy_no_reader",
+                      "SEARCH", "machine",
+                      "VSIM", "@vector_field", "$BLOB",
+                      "LOAD", "1", "@title",
+                      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+
+  HYBRID_TEST_SETUP("test_skip_copy_no_reader", args);
+
+  EXPECT_TRUE(hybridReq->tailPipeline->qctx.skipIndexResultDeepCopy)
+    << "Tail without matched_terms()/highlight should skip the index-result copy";
+  for (size_t i = 0; i < hybridReq->nrequests; i++) {
+    EXPECT_TRUE(hybridReq->requests[i]->pipeline.qctx.skipIndexResultDeepCopy)
+      << "Subquery " << i << " should not be forced to preserve the index result";
+  }
+}
+
+// A tail matched_terms() must force every subquery depleter to preserve the borrow.
+TEST_F(HybridRequestParseTest, testHybridForceIndexResultDeepCopyWhenTailReadsIt) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", "test_force_copy_matched_terms",
+                      "SEARCH", "machine",
+                      "VSIM", "@vector_field", "$BLOB",
+                      "APPLY", "matched_terms()", "AS", "terms",
+                      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+
+  HYBRID_TEST_SETUP("test_force_copy_matched_terms", args);
+
+  EXPECT_FALSE(hybridReq->tailPipeline->qctx.skipIndexResultDeepCopy)
+    << "Tail with matched_terms() must preserve the index result";
+  for (size_t i = 0; i < hybridReq->nrequests; i++) {
+    EXPECT_FALSE(hybridReq->requests[i]->pipeline.qctx.skipIndexResultDeepCopy)
+      << "Subquery " << i << " must preserve the index result for the tail's matched_terms()";
+  }
+}

--- a/tests/pytests/test_hybrid_apply_filter.py
+++ b/tests/pytests/test_hybrid_apply_filter.py
@@ -111,3 +111,35 @@ def test_hybrid_bad_apply():
     env.expect('FT.HYBRID', 'idx', 'SEARCH', search_query, 'VSIM' ,'@embedding', '$BLOB',\
         'COMBINE', 'RRF', '4', 'CONSTANT', '60', 'WINDOW', '10',
          'APPLY', 'whoami', 'PARAMS', '2', 'BLOB', query_vector).error().contains("Unknown symbol 'whoami'")
+
+
+def test_hybrid_apply_matched_terms_without_scores():
+    """matched_terms() in the tail must work even when scores aren't requested.
+
+    The per-subquery depleters must preserve each row's index result so the tail
+    APPLY can read it; without the fix they drop it and every row yields None.
+    """
+    env = Env()
+    setup_basic_index(env)
+    query_vector = np.array([0, 0]).astype(np.float32).tobytes()
+
+    def run_matched_terms(*extra_search_args):
+        response = env.cmd('FT.HYBRID', 'idx',
+            'SEARCH', 'shoes', *extra_search_args,
+            'VSIM', '@embedding', '$BLOB', 'COMBINE', 'RRF', '2', 'CONSTANT', '60',
+            'LOAD', '1', '@__key', 'APPLY', 'matched_terms()', 'AS', 'terms',
+            'PARAMS', '2', 'BLOB', query_vector)
+        results, _ = get_results_from_hybrid_response(response)
+        return {key: row.get('terms') for key, row in results.items()}
+
+    terms = run_matched_terms()
+    # Docs whose text matches "shoes" expose the matched (stemmed) terms.
+    for key in ('doc:1', 'doc:2', 'doc:4'):
+        env.assertIsNotNone(terms[key], message=key)
+        env.assertContains('shoes', terms[key], message=key)
+    # "running gear" matches only the vector subquery, so it has no matched terms.
+    env.assertIsNone(terms['doc:3'])
+
+    # Requesting a score must not change the matched_terms() output: the no-score
+    # path now agrees with the path that already preserved the index result.
+    env.assertEqual(run_matched_terms('YIELD_SCORE_AS', 's_score'), terms)

--- a/tests/pytests/test_hybrid_apply_filter.py
+++ b/tests/pytests/test_hybrid_apply_filter.py
@@ -112,7 +112,8 @@ def test_hybrid_bad_apply():
         'COMBINE', 'RRF', '4', 'CONSTANT', '60', 'WINDOW', '10',
          'APPLY', 'whoami', 'PARAMS', '2', 'BLOB', query_vector).error().contains("Unknown symbol 'whoami'")
 
-
+# Skipped because it doesn't work in coordinator, see #10280 for more background.
+@skip(cluster=True)
 def test_hybrid_apply_matched_terms_without_scores():
     """matched_terms() in the tail must work even when scores aren't requested.
 


### PR DESCRIPTION
- I thought this bug went unnoticed with previous PR (https://github.com/RediSearch/RediSearch/pull/9479) because a matched term without score requested wasn't tested, so I looked into the root cause. Turns out this bug reproduced before.

In that case, the depleter read and respected the query index flag from the subquery when it transferred the buffered results.

So even though the tail pipeline detected matched terms and set the flag to attempt a deep copy, the index result was set to null before.

Now, in this PR, the sub query gets fed the correct flag at build time depending on the tail pipeline.

- Related: https://github.com/RediSearch/RediSearch/pull/10282 (I used that branch to validate that this Pr doesn't regress, and did a similar test to confirm it was present before my ownership change, too)

### Before

```mermaid
flowchart TB
    subgraph SUB["Per-subquery pipelines (built first, each its own qctx)"]
        direction LR
        subgraph S["SEARCH subquery · qctx A"]
            SR["reader → scorer"]
            SD["Depleter A"]
            SFLAG["skipIndexResultDeepCopy = true<br/>(no scores/highlight on subquery)"]
            SR --> SD
        end
        subgraph V["VSIM subquery · qctx B"]
            VR["vector reader"]
            VD["Depleter B"]
            VFLAG["skipIndexResultDeepCopy = true<br/>(no scores/highlight on subquery)"]
            VR --> VD
        end
    end

    MG["RPHybridMerger<br/>picks primary = first non-null<br/>= SEARCH branch (index 0)"]

    subgraph T["Tail pipeline · qctx C (built afterward)"]
        TFLAG["skipIndexResultDeepCopy = false<br/>(APPLY matched_terms detected)"]
        AP["APPLY matched_terms()"]
    end

    SD -- "obeys qctx A = true → DROPS index result" --> MG
    VD -- "obeys qctx B = true → DROPS index result" --> MG
    MG --> AP --> OUT
    AP -. "primary's index result = NULL" .-> BUG["terms = None ❌"]

    classDef bad fill:#fdd,stroke:#c00,color:#000;
    classDef good fill:#dfd,stroke:#0a0,color:#000;
    class SFLAG,VFLAG,BUG bad;
    class TFLAG good;
```

### After

```mermaid
flowchart TB
    subgraph T["Tail pipeline · qctx C — `skipIndexResultDeepCopy` flag decision"]
        SEED["SEED flag = !RequireIndexResultsDownstream(reqflags)<br/>(false on HIGHLIGHT/SCORE_AS)"]
        TFLAG["BuildAggregationPart flips flag → false<br/>matched_terms() in APPLY/FILTER"]
        SEED --> TFLAG
    end

    GATE{"tail flag == false?"}
    TFLAG --> GATE

FAST ~~~ PROP
    GATE -- "no · plain query" --> FAST["subquery flags stay true<br/>→ depleters DROP (fast path) ✅<br/>no over-copy"]
    GATE -- "yes · tail reads it" --> PROP["Propagation (this PR):<br/>set false on every subquery qctx"]

    subgraph SUB["Per-subquery pipelines (built first, each its own qctx)"]
        direction LR
        subgraph S["SEARCH subquery · qctx A"]
            SR["reader → scorer"]
            SD["Depleter A"]
            SFLAG["skipIndexResultDeepCopy<br/>false when tail needs it · true otherwise"]
            SR --> SD
        end
        subgraph V["VSIM subquery · qctx B"]
            VR["vector reader"]
            VD["Depleter B"]
            VFLAG["skipIndexResultDeepCopy<br/>false when tail needs it · true otherwise"]
            VR --> VD
        end
    end

    PROP -. "patches A & B (read at exec time)" .-> SFLAG & VFLAG

    SD -- "obeys qctx A → DEEP-COPIES when forced" --> MG
    VD -- "obeys qctx B → DEEP-COPIES when forced" --> MG
    MG["RPHybridMerger<br/>primary = first non-null = SEARCH (index 0)"]
    MG --> AP["APPLY matched_terms()"]
    AP --> OUT
    AP -. "primary carries its index result" .-> FIX["terms = [shoes, +shoe] ✅"]

    classDef good fill:#dfd,stroke:#0a0,color:#000;
    classDef neutral fill:#eef,stroke:#66c,color:#000;
    class SFLAG,VFLAG,FAST,FIX good;
    class SEED,TFLAG,GATE,PROP neutral;
```

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
