### PR TITLE
RLookup - change C-unwind to C

### DIFF
--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
@@ -132,7 +132,7 @@ pub unsafe extern "C" fn RLookupRow_Reset(row: Option<NonNull<OpaqueRLookupRow>>
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn RLookupRow_MoveFieldsFrom(
+pub unsafe extern "C" fn RLookupRow_MoveFieldsFrom(
     lookup: *const RLookup,
     src_row: Option<NonNull<OpaqueRLookupRow>>,
     dst_row: Option<NonNull<OpaqueRLookupRow>>,
@@ -284,7 +284,7 @@ pub unsafe extern "C" fn RLookupRow_WriteByNameOwned<'a>(
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn RLookupRow_WriteFieldsFrom<'a>(
+pub unsafe extern "C" fn RLookupRow_WriteFieldsFrom<'a>(
     src_row: *const OpaqueRLookupRow,
     src_lookup: *const RLookup<'a>,
     dst_row: Option<NonNull<OpaqueRLookupRow>>,


### PR DESCRIPTION
Two "C-unwind" got left behind in RLookup, probably from testing. Calling them from C could result in UB, so changing them to just "C" like all other FFI functions.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
