### PR TITLE
TermSuffixIndex - introduce PrefixedValues iterator

### DIFF
--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -137,8 +137,8 @@ impl TermSuffixIndex {
     pub fn iter_contains(&self, needle: &str) -> impl Iterator<Item = &str> {
         let lowered = unicode_tolower(needle);
         self.inner
-            .prefixed_iter(&lowered)
-            .flat_map(|(_, data)| data.terms().map(|term| &**term))
+            .prefixed_values(&lowered)
+            .flat_map(|data| data.terms().map(|term| &**term))
     }
 
     /// Iterate over the members that end with `needle`.
@@ -180,10 +180,7 @@ impl TermSuffixIndex {
         // match, so only terms ending with it — exactly its own
         // suffix entry — qualify.
         let (subtree, exact) = if followed_by_star {
-            (
-                Some(self.inner.prefixed_iter(token).map(|(_, data)| data)),
-                None,
-            )
+            (Some(self.inner.prefixed_values(token)), None)
         } else {
             (None, self.inner.get(token))
         };

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/mod.rs
@@ -11,12 +11,14 @@
 
 mod contains;
 mod prefixed;
+mod prefixed_values;
 mod range;
 mod suffixed;
 mod unfiltered;
 
 pub use contains::ContainsIter;
 pub use prefixed::PrefixedIter;
+pub use prefixed_values::PrefixedValues;
 pub use range::{RangeBoundary, RangeFilter, RangeIter};
 pub use suffixed::SuffixedIter;
 pub use unfiltered::Iter;

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/prefixed_values.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/prefixed_values.rs
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use crate::{TrieMap, iter::Values};
+
+/// Prefix-filtered value iterator over a [`StrTrieMap`](crate::str_trie_map::StrTrieMap),
+/// in lexicographical key order.
+///
+/// Empty `prefix` yields zero matches — differs from
+/// [`TrieMap::prefixed_values`] which yields every entry on `&[]`. The
+/// short-circuit is encoded by delegating to an empty inner iterator.
+///
+/// See [`crate::iter::Values`] for the underlying traversal.
+pub struct PrefixedValues<'tm, Data: 'tm>(Values<'tm, Data>);
+
+impl<'tm, Data: 'tm> PrefixedValues<'tm, Data> {
+    pub(crate) fn new(trie: &'tm TrieMap<Data>, prefix: &str) -> Self {
+        if prefix.is_empty() {
+            Self(Values::new(None))
+        } else {
+            Self(trie.prefixed_values(prefix.as_bytes()))
+        }
+    }
+}
+
+impl<'tm, Data: 'tm> Iterator for PrefixedValues<'tm, Data> {
+    type Item = &'tm Data;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
@@ -99,6 +99,17 @@ impl<Data> StrTrieMap<Data> {
         iter::PrefixedIter::new(&self.inner, prefix)
     }
 
+    /// Yield a reference to the value of every entry whose key starts with
+    /// `prefix`, in lexicographical order. See [`TrieMap::prefixed_values`].
+    ///
+    /// Byte-prefix matching is codepoint-safe because UTF-8 codepoint
+    /// boundaries align with byte boundaries. Empty `prefix` yields zero
+    /// matches (this differs from the inner method, which would yield all
+    /// entries).
+    pub fn prefixed_values(&self, prefix: &str) -> iter::PrefixedValues<'_, Data> {
+        iter::PrefixedValues::new(&self.inner, prefix)
+    }
+
     /// Yield every entry whose key ends with `suffix`. Filters by byte
     /// `ends_with` — correct because UTF-8 is self-synchronizing (a
     /// multibyte sequence cannot be a suffix of another codepoint). Empty


### PR DESCRIPTION
`TermSuffixIndex` - introduce and use the `PrefixedValues` iterator for increased performance (no allocation of _keys_ that are not returned anyway).

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
