### PR TITLE
[MOD-16185] Trie - use unicode_tolower_cow in TermSuffixIndex

### DIFF
--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -18,7 +18,7 @@
 //! # Case-insensitivity
 //!
 //! Every term and query is lowercased on the way in via
-//! [`unicode_tolower`], so stored terms and matches are always in
+//! [`unicode_tolower_cow`], so stored terms and matches are always in
 //! lowercase form and lookups are case-insensitive. Callers pass terms
 //! verbatim; the index owns normalization.
 //!
@@ -38,7 +38,7 @@ use std::{
 };
 
 use rqe_wildcard::{MatchOutcome, WildcardPattern};
-use string_utils::unicode_tolower;
+use string_utils::unicode_tolower_cow;
 use term_refs::{Outcome, TermRefs};
 use trie_rs::str_trie_map::StrTrieMap;
 
@@ -80,8 +80,8 @@ impl TermSuffixIndex {
             return;
         }
 
-        let lowered = unicode_tolower(term);
-        let term = lowered.as_str();
+        let lowered = unicode_tolower_cow(term);
+        let term: &str = &lowered;
 
         if self.inner.get(term).is_some_and(TermRefs::has_full_term) {
             return;
@@ -107,8 +107,8 @@ impl TermSuffixIndex {
             return;
         }
 
-        let lowered = unicode_tolower(term);
-        let term = lowered.as_str();
+        let lowered = unicode_tolower_cow(term);
+        let term: &str = &lowered;
 
         if let Some(data) = self.inner.get_mut(term)
             && data.has_full_term()
@@ -143,7 +143,7 @@ impl TermSuffixIndex {
     /// `needle` yields nothing. A term may be yielded more than once
     /// (once per matching suffix entry).
     pub fn iter_contains(&self, needle: &str) -> impl Iterator<Item = &str> {
-        let lowered = unicode_tolower(needle);
+        let lowered = unicode_tolower_cow(needle);
         self.inner
             .prefixed_iter(&lowered)
             .flat_map(|(_, data)| data.terms().map(|term| &**term))
@@ -153,7 +153,7 @@ impl TermSuffixIndex {
     /// Matching is [case-insensitive](crate#case-insensitivity). Empty
     /// `needle` yields nothing.
     pub fn iter_suffix(&self, needle: &str) -> impl Iterator<Item = &str> {
-        let lowered = unicode_tolower(needle);
+        let lowered = unicode_tolower_cow(needle);
         let data = if lowered.is_empty() {
             None
         } else {
@@ -180,7 +180,7 @@ impl TermSuffixIndex {
     /// engine's pre-existing `?` behavior, which we deliberately reuse rather
     /// than diverge from with a second, codepoint-aware matcher.
     pub fn iter_wildcard(&self, pattern: &str) -> Option<impl Iterator<Item = Rc<str>>> {
-        let lowered = unicode_tolower(pattern);
+        let lowered = unicode_tolower_cow(pattern);
         let (token, followed_by_star) = Self::choose_token(&lowered)?;
 
         // A token followed by `*` can sit anywhere inside a match,


### PR DESCRIPTION
Use `unicode_tolower_cow` in `TermSuffixIndex` for decreased number of allocations and increased performance.

Builds on top of 
- https://github.com/RediSearch/RediSearch/pull/10315

which introduces this function for the purpose of using it here.

## Performance report

(macOS, ARM, non-LTO)

```
  Lowercase corpus (cow borrows — expected win)

  ┌───────────┬────────┬────────┬──────┬────────┬───────────┐
  │ Benchmark │ Before │ After  │ Unit │   Δ    │           │
  ├───────────┼────────┼────────┼──────┼────────┼───────────┤
  │ Suffix    │  1.141 │  0.803 │ µs   │ −29.6% │ ✅ faster │
  ├───────────┼────────┼────────┼──────┼────────┼───────────┤
  │ Insert    │  4.903 │  4.727 │ ms   │  −3.6% │ noise     │
  ├───────────┼────────┼────────┼──────┼────────┼───────────┤
  │ Delete    │  7.692 │  7.423 │ ms   │  −3.5% │ noise     │
  ├───────────┼────────┼────────┼──────┼────────┼───────────┤
  │ Contains  │ 24.655 │ 24.770 │ µs   │  +0.5% │ noise     │
  ├───────────┼────────┼────────┼──────┼────────┼───────────┤
  │ Wildcard  │ 43.560 │ 43.574 │ µs   │  +0.0% │ noise     │
  ├───────────┼────────┼────────┼──────┼────────┼───────────┤
  │ DumpAll   │ 1355.9 │ 1389.8 │ µs   │  +2.5% │ noise     │
  └───────────┴────────┴────────┴──────┴────────┴───────────┘

  Mixed-case control (cow forced to allocate — expected flat)

  ┌───────────┬────────┬────────┬──────┬───────┬──────┐
  │ Benchmark │ Before │ After  │ Unit │   Δ   │      │
  ├───────────┼────────┼────────┼──────┼───────┼──────┤
  │ Suffix    │  1.138 │  1.157 │ µs   │ +1.7% │ flat │
  ├───────────┼────────┼────────┼──────┼───────┼──────┤
  │ Insert    │  4.938 │  4.979 │ ms   │ +0.8% │ flat │
  ├───────────┼────────┼────────┼──────┼───────┼──────┤
  │ Contains  │ 25.482 │ 25.550 │ µs   │ +0.3% │ flat │
  ├───────────┼────────┼────────┼──────┼───────┼──────┤
  │ Delete    │  7.741 │  7.749 │ ms   │ +0.1% │ flat │
  ├───────────┼────────┼────────┼──────┼───────┼──────┤
  │ Wildcard  │ 44.004 │ 43.638 │ µs   │ −0.8% │ flat │
  └───────────┴────────┴────────┴──────┴───────┴──────┘
```

~There are no benchmarks for `SpellcheckDictionary` yet. Just did the same change there as it _probably makes sense there too_.~

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
