### PR TITLE
[MOD-16185] Trie - add TermSuffixIndex keys function

### DIFF
--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -130,6 +130,12 @@ impl TermSuffixIndex {
             .map(|(byte_idx, _)| &term[byte_idx..])
     }
 
+    /// Iterate over every key in the index — each member term plus every
+    /// indexed proper suffix — in lexicographical order.
+    pub fn keys(&self) -> impl Iterator<Item = String> + '_ {
+        self.inner.iter().map(|(key, _)| key)
+    }
+
     /// Iterate over the members that contain `needle` as a substring.
     /// Lowercased on entry, so matching is case-insensitive. Empty
     /// `needle` yields nothing. A term may be yielded more than once


### PR DESCRIPTION
Add `keys` function, will be used by `IterateAll`.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
