### PR TITLE
Widen nextest leak-timeout to 500ms

### DIFF
--- a/src/redisearch_rs/.config/nextest.toml
+++ b/src/redisearch_rs/.config/nextest.toml
@@ -1,5 +1,6 @@
 [profile.default]
 slow-timeout = { period = "2s", terminate-after = 8 }
+leak-timeout = "500ms"
 fail-fast = false
 
 [profile.default-miri]


### PR DESCRIPTION
Default 100ms false-flags fast tests as leaky under parallel load when CPU-bound fuzz tests saturate the cores, delaying nextest's pipe-EOF observation. Tests spawn no children, so there is no real leak; 500ms clears the noise while still catching a genuinely leaked pipe.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
