### PR TITLE
[MOD-15895] Organize RediSearch module config

### DIFF
--- a/module.conf
+++ b/module.conf
@@ -1,10 +1,5 @@
 ############################## QUERY ENGINE CONFIG ############################
 
-# Keep numeric ranges in numeric tree parent nodes of leafs for `x` generations.
-# numeric, valid range: [0, 2], default: 0
-#
-# search-_numeric-ranges-parents 0
-
 # The number of iterations to run while performing background indexing
 # before we call usleep(1) (sleep for 1 micro-second) and make sure that we
 # allow redis to process other commands.
@@ -77,7 +72,7 @@
 
 # Number of worker threads to use for background tasks when the server is
 # in an operation event.
-# numeric, valid range: [1, 16], default: 4
+# numeric, valid range: [0, 16], default: 4
 #
 # search-min-operation-workers 4
 
@@ -153,36 +148,20 @@
 #
 # search-friso-ini ""
 
-# Action to perform when search timeout is exceeded (choose RETURN or FAIL).
-# enum, valid values: ["return", "fail"], default: "return"
+# Default scorer to use for scoring documents.
+# string, default: "BM25STD"
+#
+# search-default-scorer "BM25STD"
+
+# Action to perform when search timeout is exceeded.
+# enum, valid values: ["return", "fail", "return-strict"], default: "return"
 #
 # search-on-timeout return
 
-# Determine whether some index resources are free on a second thread.
-# bool, default: yes
+# Action to perform when an out-of-memory state is encountered.
+# enum, valid values: ["return", "fail", "ignore"], default: "return"
 #
-# search-_free-resource-on-thread yes
-
-# Enable legacy compression of double to float.
-# bool, default: no
-#
-# search-_numeric-compress no
-
-# Disable print of time for ft.profile. For testing only.
-# bool, default: yes
-#
-# search-_print-profile-clock yes
-
-# Intersection iterator orders the children iterators by their relative estimated
-# number of results in ascending order, so that if we see first iterators with
-# a lower count of results we will skip a larger number of results, which
-# translates into faster iteration. If this flag is set, we use this
-# optimization in a way where union iterators are being factorize by the number
-# of their own children, so that we sort by the number of children times the
-# overall estimated number of results instead.
-# bool, default: no
-#
-# search-_prioritize-intersect-union-children no
+# search-on-oom return
 
 # Set to run without memory pools.
 # bool, default: no
@@ -204,10 +183,20 @@
 #
 # search-raw-docid-encoding no
 
+# Enable unstable features.
+# bool, default: no
+#
+# search-enable-unstable-features no
+
 # Number of search threads in the coordinator thread pool.
 # numeric, valid range: [1, LLONG_MAX], default: 20
 #
 # search-threads 20
+
+# Number of I/O threads in the coordinator.
+# numeric, valid range: [1, 256], default: 1
+#
+# search-io-threads 1
 
 # Timeout for topology validation (in milliseconds). After this timeout,
 # any pending requests will be processed, even if the topology is not fully connected.
@@ -215,10 +204,22 @@
 #
 # search-topology-validation-timeout 30000
 
+# Maximum number of replies to accumulate before triggering `_FT.CURSOR READ`
+# on the shards.
+# numeric, valid range: [1, LLONG_MAX], default: 1
+#
+# search-cursor-reply-threshold 1
+
+# Number of connections to each shard in the cluster. If set to 0, the number
+# of connections is set to `search-workers` + 1.
+# numeric, valid range: [0, UINT32_MAX], default: 0
+#
+# search-conn-per-shard 0
+
 # Per-attempt timeout for inter-shard connection setup (in milliseconds). Bounds
 # the TCP+TLS handshake so a blackholed SYN does not stall a connection
 # indefinitely. 0 disables the timeout.
-# numeric, valid range: [0, LLONG_MAX], default: 10000
+# numeric, valid range: [0, INT_MAX], default: 10000
 #
 # search-connect-timeout 10000
 
@@ -246,3 +247,87 @@
 # bool, default: yes
 #
 # search-monitor-expiration yes
+
+# Percentage of available memory to use for the disk write buffer.
+# numeric, valid range: [0, 100], default: 20
+#
+# search-disk-buffer-percentage 20
+
+# >>> BEGIN redis-gen-conf:private >>>
+# Internal/advanced RediSearch configuration parameters — intentionally NOT exported to
+# redis-gen.conf by `make sync-redis-conf`. Set via CLI override or by
+# editing this module.conf directly when running redis-server against it.
+# See the Redis repo's modules/sync-redis-conf.mk for the marker contract.
+
+# Keep numeric ranges in numeric tree parent nodes of leafs for `x` generations.
+# numeric, valid range: [0, 2], default: 0
+#
+# search-_numeric-ranges-parents 0
+
+# Memory limit threshold for background indexing, as a percentage.
+# numeric, valid range: [0, 100], default: 100
+#
+# search-_bg-index-mem-pct-thr 100
+
+# Time to pause background indexing after an out-of-memory condition.
+# numeric, valid range: [0, UINT32_MAX], default: 0
+#
+# search-_bg-index-oom-pause-time 0
+
+# Minimum delay before trimming can run, in milliseconds.
+# numeric, valid range: [1, UINT32_MAX], default: 2000
+#
+# search-_min-trim-delay-ms 2000
+
+# Maximum delay before trimming can run, in milliseconds.
+# numeric, valid range: [1, UINT32_MAX], default: 5000
+#
+# search-_max-trim-delay-ms 5000
+
+# Delay between trimming state checks, in milliseconds.
+# numeric, valid range: [1, UINT32_MAX], default: 100
+#
+# search-_trimming-state-check-delay-ms 100
+
+# Determine whether some index resources are freed on a second thread.
+# bool, default: yes
+#
+# search-_free-resource-on-thread yes
+
+# Enable legacy compression of double to float.
+# bool, default: no
+#
+# search-_numeric-compress no
+
+# Disable print of time for ft.profile. For testing only.
+# bool, default: yes
+#
+# search-_print-profile-clock yes
+
+# Intersection iterator orders the children iterators by their relative estimated
+# number of results in ascending order, so that if we see first iterators with
+# a lower count of results we will skip a larger number of results, which
+# translates into faster iteration. If this flag is set, we use this
+# optimization in a way where union iterators are being factorized by the number
+# of their own children, so that we sort by the number of children times the
+# overall estimated number of results instead.
+# bool, default: no
+#
+# search-_prioritize-intersect-union-children no
+
+# Simulate working under Flex conditions. For testing only. Immutable.
+# bool, default: no
+#
+# search-_simulate-in-flex no
+
+# Emit FT.INFO fields even when no indexes exist.
+# bool, default: no
+#
+# search-_info-on-zero-indexes no
+
+# Fall back to the main thread when a block client is unavailable.
+# bool, default: yes
+#
+# search-_fallback-to-main-thread-when-block-client-unavailable yes
+
+# <<< END redis-gen-conf:private <<<

--- a/module.conf
+++ b/module.conf
@@ -253,7 +253,7 @@
 #
 # search-disk-buffer-percentage 20
 
-# >>> BEGIN redis-gen-conf:private >>>
+# >>> BEGIN redis-gen-conf:private <<<
 # Internal/advanced RediSearch configuration parameters — intentionally NOT exported to
 # redis-gen.conf by `make sync-redis-conf`. Set via CLI override or by
 # editing this module.conf directly when running redis-server against it.

--- a/module.conf
+++ b/module.conf
@@ -248,16 +248,16 @@
 #
 # search-monitor-expiration yes
 
-# Percentage of available memory to use for the disk write buffer.
-# numeric, valid range: [0, 100], default: 20
-#
-# search-disk-buffer-percentage 20
-
 # >>> BEGIN redis-gen-conf:private <<<
 # Internal/advanced RediSearch configuration parameters — intentionally NOT exported to
 # redis-gen.conf by `make sync-redis-conf`. Set via CLI override or by
 # editing this module.conf directly when running redis-server against it.
 # See the Redis repo's modules/sync-redis-conf.mk for the marker contract.
+
+# Percentage of available memory to use for the disk write buffer.
+# numeric, valid range: [0, 100], default: 20
+#
+# search-disk-buffer-percentage 20
 
 # Keep numeric ranges in numeric tree parent nodes of leafs for `x` generations.
 # numeric, valid range: [0, 2], default: 0


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `module.conf` was missing several public `search.*` module config entries, and some internal `search-_...` entries were mixed into the public section.
2. Change: Added the missing public config entries and moved all `search-_...` internal configs under the `redis-gen-conf:private` marker block used by Redis sync flow.
3. Outcome: `module.conf` documents the full RediSearch config surface while allowing Redis generated config sync to exclude internal configs.

#### Which additional issues this PR fixes
1. MOD-15895

#### Main objects this PR modified
1. `module.conf`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

No code changes. Runtime behavior is unchanged.
