### PR TITLE
build_utils: re-evaluate BINDIR-derived link path when BINDIR changes

### DIFF
--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -90,7 +90,16 @@ pub fn force_link_time_symbol_resolution() {
 /// When the top-level build coordinator sets `BINDIR`, that value is used
 /// directly. Otherwise we fall back to the conventional release layout
 /// derived from the git root.
+///
+/// The chosen directory is baked into the `-L` link-search flags this crate
+/// emits, so it must be re-evaluated whenever `BINDIR` changes. Without the
+/// `rerun-if-env-changed` below, Cargo would replay a build script's cached
+/// directives — e.g. a release-layout `-L` captured during a `BINDIR`-less
+/// `cargo` invocation — into a later debug build, letting a stale
+/// `bin/<...>-release/.../libredisearch_all.a` shadow the correct one and
+/// fail the final link with undefined symbols.
 fn bin_root() -> PathBuf {
+    println!("cargo::rerun-if-env-changed=BINDIR");
     if let Ok(bin_root) = std::env::var("BINDIR") {
         // The directory changes depending on a variety of factors: target architecture, target OS,
         // optimization level, coverage, etc.

--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -92,12 +92,9 @@ pub fn force_link_time_symbol_resolution() {
 /// derived from the git root.
 ///
 /// The chosen directory is baked into the `-L` link-search flags this crate
-/// emits, so it must be re-evaluated whenever `BINDIR` changes. Without the
-/// `rerun-if-env-changed` below, Cargo would replay a build script's cached
-/// directives — e.g. a release-layout `-L` captured during a `BINDIR`-less
-/// `cargo` invocation — into a later debug build, letting a stale
-/// `bin/<...>-release/.../libredisearch_all.a` shadow the correct one and
-/// fail the final link with undefined symbols.
+/// emits, so the `rerun-if-env-changed` below re-evaluates it whenever
+/// `BINDIR` changes — otherwise Cargo replays a stale cached `-L` (e.g. a
+/// release path captured during a `BINDIR`-less run) into a later build.
 fn bin_root() -> PathBuf {
     println!("cargo::rerun-if-env-changed=BINDIR");
     if let Ok(bin_root) = std::env::var("BINDIR") {


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `bin_root()` in `build_utils` derives the `-L` link-search directory for `libredisearch_all.a` from the `BINDIR` env var (falling back to the release layout when unset). Build scripts never declared `BINDIR` as a rerun trigger. Cargo caches a build script's emitted directives and replays them until a `rerun-if-*` trigger fires, so a release-layout `-L` captured during a `BINDIR`-less `cargo` invocation lingered in the debug build tree's cached output.
2. **Change:** Emit `cargo::rerun-if-env-changed=BINDIR` from `bin_root()` so the script re-evaluates the link path whenever `BINDIR` changes (including unset→set and release↔debug).
3. **Outcome:** A later debug build no longer replays a stale release `-L`. This removes the failure mode where a stale `bin/<...>-release/.../libredisearch_all.a` from a previous branch shadows the correct debug lib and breaks the final link with undefined symbols (e.g. `_TermSuffixIndex_Iterate*` referenced from a stale `query.c.o`).

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `src/redisearch_rs/build_utils/src/lib.rs` — `bin_root()`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
