### PR TITLE
[MOD-16628] CI: make Ubuntu Focal build resilient to launchpad.net outages

### DIFF
--- a/.install/ubuntu_20.04.sh
+++ b/.install/ubuntu_20.04.sh
@@ -4,10 +4,8 @@ export DEBIAN_FRONTEND=noninteractive
 MODE=$1 # whether to install using sudo or not
 source "$(dirname "${BASH_SOURCE[0]}")/apt_get_cmd.sh"
 
-# Add a Launchpad PPA without the `ppa:` shortcut, which imports the key via the
-# launchpad.net web frontend - flaky from CI runners and the cause of focal build
-# failures. Resolve the fingerprint via api.launchpad.net, fetch the key from the
-# keyserver, and add a plain `deb` line (key fetched before the source is trusted).
+# Add the PPA manually instead of via the `ppa:` shortcut, which relies on
+# launchpad.net - intermittently unreachable from CI runners. See MOD-XXXXX.
 add_launchpad_ppa() {
     local owner="$1" name="$2"
     local codename keyring fp

--- a/.install/ubuntu_20.04.sh
+++ b/.install/ubuntu_20.04.sh
@@ -4,22 +4,10 @@ export DEBIAN_FRONTEND=noninteractive
 MODE=$1 # whether to install using sudo or not
 source "$(dirname "${BASH_SOURCE[0]}")/apt_get_cmd.sh"
 
-# Add a Launchpad PPA without add-apt-repository's `ppa:` shortcut.
-#
-# The `ppa:owner/name` shortcut resolves the PPA through the launchpad.net web
-# frontend and imports its signing key from there. That host is intermittently
-# unreachable from CI runners (TCP connections to it hang/time out), which makes
-# the focal container build fail with "retrieving gpg key timed out" /
-# "NO_PUBKEY" / "user or team does not exist" - all symptoms of the same failed
-# launchpad.net call.
-#
-# Instead we avoid launchpad.net entirely and use only its reachable
-# infrastructure: look up the signing-key fingerprint via the API host
-# (api.launchpad.net), fetch the *public* signing key from the Ubuntu keyserver,
-# then add the PPA as a plain `deb` line (no `ppa:` resolution). Packages still
-# come from the reachable ppa.launchpad.net. The key is fetched before the source
-# line is trusted, so a failed fetch never leaves a half-configured, unsigned
-# source behind (which would otherwise poison retries).
+# Add a Launchpad PPA without the `ppa:` shortcut, which imports the key via the
+# launchpad.net web frontend - flaky from CI runners and the cause of focal build
+# failures. Resolve the fingerprint via api.launchpad.net, fetch the key from the
+# keyserver, and add a plain `deb` line (key fetched before the source is trusted).
 add_launchpad_ppa() {
     local owner="$1" name="$2"
     local codename keyring fp
@@ -39,8 +27,6 @@ add_launchpad_ppa() {
         "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x${fp}" \
         | $MODE gpg --dearmor --yes -o "$keyring"
 
-    # `deb` line (not `ppa:`) => add-apt-repository just writes the source, with
-    # no launchpad.net lookup. The key is already trusted via signed-by.
     $MODE add-apt-repository -y \
         "deb [signed-by=${keyring}] http://ppa.launchpad.net/${owner}/${name}/ubuntu ${codename} main"
 }
@@ -48,8 +34,7 @@ add_launchpad_ppa() {
 apt_get_cmd "$MODE" update -qq
 apt_get_cmd "$MODE" upgrade -yqq
 
-# Provides add-apt-repository (software-properties-common) plus curl/gnupg used
-# by add_launchpad_ppa below.
+# software-properties-common provides add-apt-repository; curl/gnupg used by add_launchpad_ppa
 apt_get_cmd "$MODE" install -yqq software-properties-common curl gnupg
 
 add_launchpad_ppa ubuntu-toolchain-r test

--- a/.install/ubuntu_20.04.sh
+++ b/.install/ubuntu_20.04.sh
@@ -4,14 +4,56 @@ export DEBIAN_FRONTEND=noninteractive
 MODE=$1 # whether to install using sudo or not
 source "$(dirname "${BASH_SOURCE[0]}")/apt_get_cmd.sh"
 
+# Add a Launchpad PPA without add-apt-repository's `ppa:` shortcut.
+#
+# The `ppa:owner/name` shortcut resolves the PPA through the launchpad.net web
+# frontend and imports its signing key from there. That host is intermittently
+# unreachable from CI runners (TCP connections to it hang/time out), which makes
+# the focal container build fail with "retrieving gpg key timed out" /
+# "NO_PUBKEY" / "user or team does not exist" - all symptoms of the same failed
+# launchpad.net call.
+#
+# Instead we avoid launchpad.net entirely and use only its reachable
+# infrastructure: look up the signing-key fingerprint via the API host
+# (api.launchpad.net), fetch the *public* signing key from the Ubuntu keyserver,
+# then add the PPA as a plain `deb` line (no `ppa:` resolution). Packages still
+# come from the reachable ppa.launchpad.net. The key is fetched before the source
+# line is trusted, so a failed fetch never leaves a half-configured, unsigned
+# source behind (which would otherwise poison retries).
+add_launchpad_ppa() {
+    local owner="$1" name="$2"
+    local codename keyring fp
+    codename="$(. /etc/os-release && echo "$VERSION_CODENAME")"
+    keyring="/etc/apt/keyrings/${owner}-${name}.gpg"
+
+    fp="$(curl -fsSL --retry 5 --retry-delay 5 --retry-connrefused \
+        "https://api.launchpad.net/devel/~${owner}/+archive/ubuntu/${name}" \
+        | grep -o '"signing_key_fingerprint":[[:space:]]*"[^"]*"' | cut -d'"' -f4)"
+    if [ -z "$fp" ]; then
+        echo "ERROR: could not resolve signing key fingerprint for ppa:${owner}/${name}" >&2
+        return 1
+    fi
+
+    $MODE install -d -m 0755 /etc/apt/keyrings
+    curl -fsSL --retry 5 --retry-delay 5 --retry-connrefused \
+        "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x${fp}" \
+        | $MODE gpg --dearmor --yes -o "$keyring"
+
+    # `deb` line (not `ppa:`) => add-apt-repository just writes the source, with
+    # no launchpad.net lookup. The key is already trusted via signed-by.
+    $MODE add-apt-repository -y \
+        "deb [signed-by=${keyring}] http://ppa.launchpad.net/${owner}/${name}/ubuntu ${codename} main"
+}
+
 apt_get_cmd "$MODE" update -qq
 apt_get_cmd "$MODE" upgrade -yqq
 
-# Provides the add-apt-repository command
-apt_get_cmd "$MODE" install -yqq software-properties-common
+# Provides add-apt-repository (software-properties-common) plus curl/gnupg used
+# by add_launchpad_ppa below.
+apt_get_cmd "$MODE" install -yqq software-properties-common curl gnupg
 
-$MODE add-apt-repository ppa:ubuntu-toolchain-r/test -y
-$MODE add-apt-repository ppa:deadsnakes/ppa -y
+add_launchpad_ppa ubuntu-toolchain-r test
+add_launchpad_ppa deadsnakes ppa
 
 apt_get_cmd "$MODE" install -yqq wget make clang-format gcc lcov git openssl libssl-dev \
     unzip rsync build-essential gcc-11 g++-11 curl libclang-dev gdb

--- a/.install/ubuntu_20.04.sh
+++ b/.install/ubuntu_20.04.sh
@@ -25,18 +25,21 @@ add_launchpad_ppa() {
         "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x${fp}" \
         | $MODE gpg --dearmor --yes -o "$keyring"
 
-    $MODE add-apt-repository -y \
-        "deb [signed-by=${keyring}] http://ppa.launchpad.net/${owner}/${name}/ubuntu ${codename} main"
+    # Write the source directly: focal's add-apt-repository can't parse a one-line
+    # entry with [signed-by=...] options.
+    echo "deb [signed-by=${keyring}] http://ppa.launchpad.net/${owner}/${name}/ubuntu ${codename} main" \
+        | $MODE tee "/etc/apt/sources.list.d/${owner}-${name}.list" > /dev/null
 }
 
 apt_get_cmd "$MODE" update -qq
 apt_get_cmd "$MODE" upgrade -yqq
 
-# software-properties-common provides add-apt-repository; curl/gnupg used by add_launchpad_ppa
+# curl/gnupg for add_launchpad_ppa; software-properties-common for install_llvm.sh
 apt_get_cmd "$MODE" install -yqq software-properties-common curl gnupg
 
 add_launchpad_ppa ubuntu-toolchain-r test
 add_launchpad_ppa deadsnakes ppa
+apt_get_cmd "$MODE" update -qq
 
 apt_get_cmd "$MODE" install -yqq wget make clang-format gcc lcov git openssl libssl-dev \
     unzip rsync build-essential gcc-11 g++-11 curl libclang-dev gdb


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The Ubuntu Focal install script installs gcc-11 (and newer Python) by adding two PPAs with the `add-apt-repository ppa:...` shortcut — `ppa:ubuntu-toolchain-r/test` and `ppa:deadsnakes/ppa`. That shortcut resolves the PPA and imports its signing key through the **launchpad.net web frontend**, which is intermittently unreachable from CI runners (TCP connections hang/time out). When it's down, the focal `build-image` job fails with `retrieving gpg key timed out` / `NO_PUBKEY` / `'~ubuntu-toolchain-r' user or team does not exist` — all symptoms of the same failed `launchpad.net` call — and blocks the merge queue. Focal is the only platform affected, because it's the only one that needs a PPA for its compiler (newer Ubuntus ship gcc-11+ natively; non-Ubuntu distros use their own repos).

2. **Change:** Add each PPA without the `ppa:` shortcut, avoiding `launchpad.net` entirely and using only its **reachable** infrastructure:
   - resolve the signing-key fingerprint via `api.launchpad.net` (a separate, reachable host),
   - fetch the **public** signing key from `keyserver.ubuntu.com`,
   - add the PPA as a plain `deb [signed-by=…]` line (no `ppa:` resolution).

   Packages still come from the reachable `ppa.launchpad.net`. The key is fetched *before* the source line is trusted, so a failed fetch can't leave a half-configured, unsigned source behind (which previously poisoned `retry.sh` retries). Network calls use `curl --retry` for transient blips.

3. **Outcome:** The focal container build no longer depends on the flaky `launchpad.net` frontend, so it stops failing/blocking the merge queue, while still installing the exact same gcc-11 toolchain.

#### Which additional issues this PR fixes
1. N/A (no Jira ticket)

#### Main objects this PR modified
1. `.install/ubuntu_20.04.sh` — new `add_launchpad_ppa` helper; replaces the two `add-apt-repository ppa:` calls.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

### Notes for reviewers
- The fingerprints resolved at build time are `C8EC952E2A0E1FBDC5090F6A2C277A0A352154E5` (toolchain-r) and `F23C5A6CF475977595C89F51BA6932366A755776` (deadsnakes); both are **public** signing keys (not secrets/tokens). Verified reachable: `api.launchpad.net`, `keyserver.ubuntu.com`, and `ppa.launchpad.net` all respond in ~0.2s while `launchpad.net` times out.
- **Not testable locally** (no focal container runtime available here) — the authoritative check is the `ubuntu:focal … / build-image` CI job, which should go from red → green.
- **Backport:** the same `add-apt-repository ppa:` pattern is latent on `8.4`, `8.6`, `8.8`, `8.10`, and `9.6` (identical `.install/ubuntu_20.04.sh`). This should be backported to the active release branches — `8.8` is the one currently hitting it in the merge queue.
- `.install/ubuntu_18.04.sh` has the same pattern but bionic is not in the CI matrix, so it's left unchanged.
