### PR TITLE
MOD-15859: disk geo: add IndexDiskAPI hooks

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -648,10 +648,7 @@ static int indexNumericOnDiskBatch(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx,
 FIELD_BULK_INDEXER(numericIndexer) {
   if (aCtx->disk.batch) {
     // The dispatcher in `IndexerBulkAdd` routes both IXFLDPOS_NUMERIC and
-    // IXFLDPOS_GEO through this indexer; only the numeric path rides the
-    // disk batch today.
-    RS_LOG_ASSERT_ALWAYS(!(fs->types & INDEXFLD_T_GEO),
-                         "disk-mode geo is not supported yet");
+    // IXFLDPOS_GEO through this indexer.
     return indexNumericOnDiskBatch(aCtx, ctx, fs, fdata, status);
   }
 
@@ -899,10 +896,10 @@ FIELD_BULK_APPLIER(numericApplier) {
 }
 
 FIELD_BULK_APPLIER(geoApplier) {
-  // TODO: when geo lands on the per-document disk write batch, move the
-  // numeric-tree mutation + stats deltas here. Today `numericIndexer` (which
-  // handles both numeric and geo) does the work inline and asserts disk-mode
-  // is disabled.
+  // Per-spec geo stats are bumped by `numericIndexer` in both modes (geo
+  // values are stored as geohash `f64`s in the numeric index, so the same
+  // code path applies). The applier only handles the global field-docs
+  // counter.
   (void)aCtx; (void)field; (void)fs; (void)fdata;
   FieldsGlobalStats_UpdateFieldDocsIndexed(INDEXFLD_T_GEO, 1);
 }

--- a/src/geo_index.c
+++ b/src/geo_index.c
@@ -19,6 +19,7 @@
 #include "query.h"
 #include "query_error_ffi.h"
 #include "redismodule.h"
+#include "iterators_ffi.h"
 
 static double extractUnitFactor(GeoDistance unit);
 
@@ -88,18 +89,13 @@ int GeoFilter_LegacyParse(LegacyGeoFilter *gf, ArgsCursor *ac, bool *hasEmptyFil
 }
 
 void GeoFilter_Free(GeoFilter *gf) {
+  // `numericFilters` is allocated in Rust (`build_geo_numeric_filters`), so it
+  // must be freed in Rust with the matching allocator; `GeoFilter_FreeNumericFilters`
+  // releases both the array and each per-range `NumericFilter` it owns.
   if (gf->numericFilters) {
-    for (int i = 0; i < GEO_RANGE_COUNT; ++i) {
-      if (gf->numericFilters[i])
-        NumericFilter_Free(gf->numericFilters[i]);
-    }
-    rm_free(gf->numericFilters);
+    GeoFilter_FreeNumericFilters(gf->numericFilters);
   }
   rm_free(gf);
-}
-
-NumericFilter **GeoFilter_AllocNumericFiltersArray(void) {
-  return rm_calloc(GEO_RANGE_COUNT, sizeof(NumericFilter *));
 }
 
 void LegacyGeoFilter_Free(LegacyGeoFilter *gf) {

--- a/src/geo_index.c
+++ b/src/geo_index.c
@@ -98,6 +98,10 @@ void GeoFilter_Free(GeoFilter *gf) {
   rm_free(gf);
 }
 
+NumericFilter **GeoFilter_AllocNumericFiltersArray(void) {
+  return rm_calloc(GEO_RANGE_COUNT, sizeof(NumericFilter *));
+}
+
 void LegacyGeoFilter_Free(LegacyGeoFilter *gf) {
   if (gf->field) {
     HiddenString_Free(gf->field, false);

--- a/src/geo_index.h
+++ b/src/geo_index.h
@@ -73,11 +73,6 @@ int GeoFilter_LegacyParse(LegacyGeoFilter *gf, ArgsCursor *ac, bool *hasEmptyFil
 void GeoFilter_Free(GeoFilter *gf);
 void LegacyGeoFilter_Free(LegacyGeoFilter *gf);
 
-/* Allocate the per-query `numericFilters` array for `GeoFilter` via
- * `rm_calloc`, so the array is freed symmetrically by `GeoFilter_Free`'s
- * `rm_free(gf->numericFilters)`. */
-NumericFilter **GeoFilter_AllocNumericFiltersArray(void);
-
 /*****************************************************************************/
 
 #define INVALID_GEOHASH -1.0

--- a/src/geo_index.h
+++ b/src/geo_index.h
@@ -73,6 +73,11 @@ int GeoFilter_LegacyParse(LegacyGeoFilter *gf, ArgsCursor *ac, bool *hasEmptyFil
 void GeoFilter_Free(GeoFilter *gf);
 void LegacyGeoFilter_Free(LegacyGeoFilter *gf);
 
+/* Allocate the per-query `numericFilters` array for `GeoFilter` via
+ * `rm_calloc`, so the array is freed symmetrically by `GeoFilter_Free`'s
+ * `rm_free(gf->numericFilters)`. */
+NumericFilter **GeoFilter_AllocNumericFiltersArray(void);
+
 /*****************************************************************************/
 
 #define INVALID_GEOHASH -1.0

--- a/src/info/field_spec_info.c
+++ b/src/info/field_spec_info.c
@@ -321,8 +321,9 @@ static void FieldSpecStats_PopulateDiskMetrics(FieldSpecStats *stats, const Inde
   if (FieldSpec_IsIndexableText(fs)) {
     stats->textDisk = SearchDisk_GetTextFieldMetrics(sp->diskSpec, fs->ftId);
   }
-  if (FIELD_IS(fs, INDEXFLD_T_TAG | INDEXFLD_T_NUMERIC)) {
-    // TAG/NUMERIC CFs are named by the numeric field index.
+  if (FIELD_IS(fs, INDEXFLD_T_TAG | INDEXFLD_T_NUMERIC | INDEXFLD_T_GEO)) {
+    // TAG/NUMERIC/GEO fields each own a CF keyed by the field index fs->index
+    // (tag_<i> / numeric_<i>); GEO reuses the numeric CF.
     stats->cfDisk = SearchDisk_GetCfFieldMetrics(sp->diskSpec, fs->index);
   } else if (FIELD_IS(fs, INDEXFLD_T_VECTOR)) {
     // Vector CFs are named `vector_<fieldName>`, so they are keyed by name.

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
@@ -10,7 +10,7 @@
 use std::ptr::{self, NonNull};
 
 use ffi::{GeoFilter, RSGlobalConfig};
-use rqe_iterators::{IteratorsConfig, build_geo_range_iterator};
+use rqe_iterators::{IteratorsConfig, build_geo_range_iterator, free_geo_numeric_filters};
 
 /// Creates an iterator over all geo-encoded index entries within the radius specified by `gf`.
 ///
@@ -47,4 +47,21 @@ pub unsafe extern "C" fn NewGeoRangeIterator(
     // SAFETY: preconditions 1–3 map directly to those of `build_geo_range_iterator`.
     unsafe { build_geo_range_iterator(sctx, geo, min_union_iter_heap, compress) }
         .map_or(ptr::null_mut(), NonNull::as_ptr)
+}
+
+/// Frees the `numericFilters` array that [`NewGeoRangeIterator`] populated on a
+/// `GeoFilter`, together with the per-range `NumericFilter`s it owns.
+///
+/// The array is allocated in Rust (`build_geo_numeric_filters` boxes it), so it
+/// must be released with the Rust allocator.
+///
+/// # Safety
+///
+/// `filters` must be NULL, or the array stored in `gf.numericFilters` by
+/// [`NewGeoRangeIterator`] (i.e. by `build_geo_numeric_filters`) and not yet
+/// freed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn GeoFilter_FreeNumericFilters(filters: *mut *mut ffi::NumericFilter) {
+    // SAFETY: the safety contract is forwarded to `free_geo_numeric_filters`.
+    unsafe { free_geo_numeric_filters(filters.cast()) };
 }

--- a/src/redisearch_rs/c_wrappers/search_disk/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/search_disk/src/lib.rs
@@ -89,6 +89,45 @@ impl SearchDiskHandle {
         api.new_numeric_on_disk(disk_spec, filter, field_index, snapshot)
     }
 
+    /// Build a geo-radius filter iterator backed by this on-disk index.
+    ///
+    /// Consumes the handle and delegates to the registered enterprise geo
+    /// iterator. Geo fields are stored geohash-encoded in the numeric column
+    /// family, so `gf` is decomposed into numeric range filters that are run
+    /// through the same disk machinery as [`new_numeric_iterator`], unioned,
+    /// and post-filtered by true great-circle distance.
+    ///
+    /// [`new_numeric_iterator`]: SearchDiskHandle::new_numeric_iterator
+    ///
+    /// # Safety
+    ///
+    /// 1. The wrapped disk index spec must remain valid for `'index`.
+    /// 2. [`SEARCH_ENTERPRISE_ITERATORS`] must be initialized (always the case
+    ///    when the spec is backed by a disk index).
+    /// 3. `snapshot` must be a
+    ///    [`RedisSearchDiskSnapshot`](ffi::RedisSearchDiskSnapshot) handle for
+    ///    this disk spec that remains valid for `'index`.
+    /// 4. There must be no other live reference to the wrapped spec for `'index`.
+    pub unsafe fn new_geo_iterator<'index>(
+        self,
+        gf: &'index mut ffi::GeoFilter,
+        field_index: ffi::t_fieldIndex,
+        snapshot: NonNull<ffi::RedisSearchDiskSnapshot>,
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>> {
+        // SAFETY: precondition (2) — a disk-backed spec always has the
+        // enterprise iterators registered.
+        let api = SEARCH_ENTERPRISE_ITERATORS
+            .get()
+            .expect("SEARCH_ENTERPRISE_ITERATORS not initialized");
+
+        // SAFETY: `new`'s invariant guarantees `self.0` points to a valid
+        // `RedisSearchDiskIndexSpec`; preconditions (1)/(4) uphold the `'index`
+        // lifetime and exclusive access of the returned reference.
+        let disk_spec = unsafe { &mut *self.0.as_ptr() };
+
+        api.new_geo_on_disk(disk_spec, gf, field_index, snapshot)
+    }
+
     /// Build a term iterator backed by this on-disk index.
     ///
     /// Consumes the handle and delegates to the registered enterprise term

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -148,11 +148,7 @@ const HEADERS: &[HeaderAllowlist] = &[
     },
     HeaderAllowlist {
         path: "src/geo_index.h",
-        fns: &[
-            "GeoFilter_Free",
-            "GeoFilter_Validate",
-            "NewGeoFilter",
-        ],
+        fns: &["GeoFilter_Free", "GeoFilter_Validate", "NewGeoFilter"],
         types: &[],
         vars: &[],
     },

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -148,7 +148,12 @@ const HEADERS: &[HeaderAllowlist] = &[
     },
     HeaderAllowlist {
         path: "src/geo_index.h",
-        fns: &["GeoFilter_Validate"],
+        fns: &[
+            "GeoFilter_AllocNumericFiltersArray",
+            "GeoFilter_Free",
+            "GeoFilter_Validate",
+            "NewGeoFilter",
+        ],
         types: &[],
         vars: &[],
     },

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -149,7 +149,6 @@ const HEADERS: &[HeaderAllowlist] = &[
     HeaderAllowlist {
         path: "src/geo_index.h",
         fns: &[
-            "GeoFilter_AllocNumericFiltersArray",
             "GeoFilter_Free",
             "GeoFilter_Validate",
             "NewGeoFilter",

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -388,6 +388,21 @@ QueryIterator *NewMetricIteratorSortedByScore(t_docId *ids, double *metric_list,
 QueryIterator *NewIntersectionIterator(QueryIterator * *its, size_t num, int32_t max_slop, bool in_order, double weight);
 
 /**
+ * Frees the `numericFilters` array that [`NewGeoRangeIterator`] populated on a
+ * `GeoFilter`, together with the per-range `NumericFilter`s it owns.
+ *
+ * The array is allocated in Rust (`build_geo_numeric_filters` boxes it), so it
+ * must be released with the Rust allocator.
+ *
+ * # Safety
+ *
+ * `filters` must be NULL, or the array stored in `gf.numericFilters` by
+ * [`NewGeoRangeIterator`] (i.e. by `build_geo_numeric_filters`) and not yet
+ * freed.
+ */
+void GeoFilter_FreeNumericFilters(NumericFilter * *filters);
+
+/**
  * Opens the numeric/geo index and creates an iterator over all matching sub-ranges.
  *
  * # Returns

--- a/src/redisearch_rs/query_eval/src/nodes/geo.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/geo.rs
@@ -11,16 +11,21 @@
 
 use std::ptr::NonNull;
 
+use query_error::QueryErrorCode;
 use rqe_iterators::build_geo_range_iterator;
+use search_disk::SearchDiskHandle;
 
 use crate::{Config, Evaluated, QueryEvalContext};
 
 /// `QN_GEO` — a geo-radius filter on a geo field.
 ///
-/// Validates the geo filter (reporting any error into the query's status), then
-/// builds a union over the matching geohash ranges via
-/// [`build_geo_range_iterator`]. Returns `None` — i.e. no iterator — when
-/// validation fails, the geo index does not exist yet, or no entries match.
+/// Validates the geo filter (reporting any error into the query's status). When
+/// the spec is backed by an on-disk index, delegates to the enterprise geo
+/// iterator via [`SearchDiskHandle::new_geo_iterator`]. Otherwise builds a union
+/// over the matching geohash ranges via [`build_geo_range_iterator`]. Returns
+/// `None` — i.e. no iterator — when validation fails, the geo index does not
+/// exist yet, no entries match, or the disk iterator could not be created (in
+/// which case the failure is reported via [`status`](QueryEvalContext::status)).
 pub(crate) fn eval<'index>(
     ctx: &'index mut QueryEvalContext,
     gf: *mut ffi::GeoFilter,
@@ -32,6 +37,39 @@ pub(crate) fn eval<'index>(
     // (`QueryEvalContext` invariant (2)).
     if unsafe { ffi::GeoFilter_Validate(gf, status) } == 0 {
         return None;
+    }
+
+    // Disk-index path: when the spec is backed by an on-disk index, delegate to
+    // the enterprise geo iterator instead of opening the in-memory range tree.
+    //
+    // SAFETY: `ctx.spec().diskSpec` is either null or a valid
+    // `RedisSearchDiskIndexSpec` that stays valid for `'index`
+    // (`QueryEvalContext` invariants 1/2). `SearchDiskHandle::new` yields `None`
+    // for the null (in-memory) case.
+    if let Some(disk) = unsafe { SearchDiskHandle::new(ctx.spec().diskSpec) } {
+        let snapshot = NonNull::new(ctx.sctx().diskSnapshot)
+            .expect("query.sctx.diskSnapshot is null for a disk-backed geo query");
+        // SAFETY: `gf` is valid and, during single-threaded evaluation,
+        // exclusively owned for `'index`, so a `&'index mut` is sound.
+        let gf_ref = unsafe { &mut *gf };
+        // SAFETY: a well-formed geo node has a valid, non-null `fieldSpec`, so
+        // reading its `index` is sound.
+        let field_index = unsafe { (*gf_ref.fieldSpec).index };
+        // SAFETY: the wrapped disk spec is valid for `'index` (`QueryEvalContext`
+        // invariants 1/2) and single-threaded query evaluation gives us the only
+        // live reference to it; the enterprise iterators are registered whenever
+        // a disk index is in use; `field_index` belongs to the geo node's field
+        // spec; `snapshot` is the disk snapshot taken at query start.
+        return match unsafe { disk.new_geo_iterator(gf_ref, field_index, snapshot) } {
+            Ok(it) => Some(Evaluated::RustLeaf(it)),
+            Err(err) => {
+                // Surface the failure via `status` so the query aborts with an
+                // error rather than silently returning empty results.
+                ctx.status()
+                    .set_error(QueryErrorCode::DiskIteratorCreation, &err.to_string());
+                None
+            }
+        };
     }
 
     let sctx = NonNull::from(ctx.sctx());

--- a/src/redisearch_rs/query_eval/tests/integration/geo.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/geo.rs
@@ -16,7 +16,6 @@
 //! the C library, which Miri cannot execute.
 #![cfg(not(miri))]
 
-use geo::GEO_RANGE_COUNT;
 use query::mock::MockQueryNode;
 use query_error::QueryErrorCode;
 use query_eval::{Config, EvalResult, QueryEvalContext, QueryNodeMut, eval_node};
@@ -94,34 +93,19 @@ impl GeoFixture {
 impl Drop for GeoFixture {
     fn drop(&mut self) {
         // A valid geo evaluation populates `gf.numericFilters` with a
-        // C-allocated (`GeoFilter_AllocNumericFiltersArray` / `rm_calloc`) array
-        // of `GEO_RANGE_COUNT` pointer slots, whose non-null entries are
-        // C-allocated (`NewNumericFilter`) `NumericFilter`s. This test binary
-        // uses distinct Rust and C allocators, so — unlike `GeoFilter_Free`,
-        // which releases everything through `rm_free` but also frees the `gf`
-        // struct itself (Rust-boxed here) — each piece must be reclaimed with the
-        // allocator that produced it: the entries with `NumericFilter_Free`, the
-        // array with the mock's C `free`. The `gf` box itself is released by the
-        // field drop below. Every evaluated iterator borrows the fixture and is
-        // dropped before this runs, so nothing still references the filters.
-        let array = self.gf.numericFilters as *mut *mut ffi::NumericFilter;
-        if !array.is_null() {
-            for i in 0..GEO_RANGE_COUNT {
-                // SAFETY: `array` has `GEO_RANGE_COUNT` pointer slots, so `i` is
-                // in bounds; the read yields a slot's (possibly null) entry.
-                let nf = unsafe { *array.add(i) };
-                if !nf.is_null() {
-                    // SAFETY: each non-null entry is a live, C-allocated
-                    // `NumericFilter` owned by `gf`, freed here exactly once.
-                    unsafe { ffi::NumericFilter_Free(nf) };
-                }
-            }
-            // SAFETY: `array` was allocated through the mock's C allocator
-            // (`GeoFilter_AllocNumericFiltersArray` → `rm_calloc` → `calloc_shim`),
-            // so releasing it with the matching `free_shim` balances that
-            // allocation exactly once.
-            redis_mock::allocator::free_shim(array.cast());
-        }
+        // Rust-allocated array (via `build_geo_numeric_filters`) whose non-null
+        // entries are C-allocated `NumericFilter`s. Release it through the same
+        // Rust helper `GeoFilter_Free` uses in production, so the array is
+        // reclaimed with the Rust allocator and each entry with
+        // `NumericFilter_Free`. Unlike `GeoFilter_Free`, we must *not* free `gf`
+        // itself — it is Rust-boxed here and released by the field drop below.
+        // Every evaluated iterator borrows the fixture and is dropped before this
+        // runs, so nothing still references the filters.
+        //
+        // SAFETY: `gf.numericFilters` is NULL or exactly what
+        // `build_geo_numeric_filters` stored, and no iterator references it any
+        // longer.
+        unsafe { rqe_iterators::free_geo_numeric_filters(self.gf.numericFilters.cast()) };
     }
 }
 

--- a/src/redisearch_rs/query_eval/tests/integration/geo.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/geo.rs
@@ -94,27 +94,33 @@ impl GeoFixture {
 impl Drop for GeoFixture {
     fn drop(&mut self) {
         // A valid geo evaluation populates `gf.numericFilters` with a
-        // Rust-allocated `[*mut NumericFilter; GEO_RANGE_COUNT]` array (via
-        // `Box::into_raw`) whose non-null entries are C-allocated (`rm_malloc`)
-        // `NumericFilter`s. This test binary uses distinct Rust and C allocators,
-        // so — unlike `GeoFilter_Free`, which releases both through `rm_free` —
-        // each must be reclaimed with the allocator that produced it: the array
-        // with `Box`, the entries with `NumericFilter_Free`. The `gf` box itself
-        // is released by the field drop below. Every evaluated iterator borrows
-        // the fixture and is dropped before this runs, so nothing still
-        // references the filters.
-        let array = self.gf.numericFilters as *mut [*mut ffi::NumericFilter; GEO_RANGE_COUNT];
+        // C-allocated (`GeoFilter_AllocNumericFiltersArray` / `rm_calloc`) array
+        // of `GEO_RANGE_COUNT` pointer slots, whose non-null entries are
+        // C-allocated (`NewNumericFilter`) `NumericFilter`s. This test binary
+        // uses distinct Rust and C allocators, so — unlike `GeoFilter_Free`,
+        // which releases everything through `rm_free` but also frees the `gf`
+        // struct itself (Rust-boxed here) — each piece must be reclaimed with the
+        // allocator that produced it: the entries with `NumericFilter_Free`, the
+        // array with the mock's C `free`. The `gf` box itself is released by the
+        // field drop below. Every evaluated iterator borrows the fixture and is
+        // dropped before this runs, so nothing still references the filters.
+        let array = self.gf.numericFilters as *mut *mut ffi::NumericFilter;
         if !array.is_null() {
-            // SAFETY: `array` is exactly what `build_geo_numeric_filters` produced
-            // with `Box::into_raw`; reclaiming it with `Box::from_raw` matches.
-            let array = unsafe { Box::from_raw(array) };
-            for &nf in array.iter() {
+            for i in 0..GEO_RANGE_COUNT {
+                // SAFETY: `array` has `GEO_RANGE_COUNT` pointer slots, so `i` is
+                // in bounds; the read yields a slot's (possibly null) entry.
+                let nf = unsafe { *array.add(i) };
                 if !nf.is_null() {
                     // SAFETY: each non-null entry is a live, C-allocated
                     // `NumericFilter` owned by `gf`, freed here exactly once.
                     unsafe { ffi::NumericFilter_Free(nf) };
                 }
             }
+            // SAFETY: `array` was allocated through the mock's C allocator
+            // (`GeoFilter_AllocNumericFiltersArray` → `rm_calloc` → `calloc_shim`),
+            // so releasing it with the matching `free_shim` balances that
+            // allocation exactly once.
+            redis_mock::allocator::free_shim(array.cast());
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/geo.rs
@@ -194,7 +194,7 @@ pub fn extract_geo_unit_factor(unit: GeoDistance) -> f64 {
 
 /// Build a geo-radius iterator over all geohash sub-ranges matching `gf`.
 ///
-/// A radius query maps to up to [`GEO_RANGE_COUNT`] contiguous geohash ranges;
+/// A radius query maps to up to `GEO_RANGE_COUNT` contiguous geohash ranges;
 /// each is queried via the field's numeric range tree (with per-record distance
 /// filtering) and the results are combined with [`build_union`].
 ///

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/geo.rs
@@ -60,7 +60,8 @@ pub enum GeoRangeError {
 ///
 /// 1. `gf.fieldSpec` must be a valid non-null pointer to a [`ffi::FieldSpec`], valid for `'index`.
 /// 2. `gf.numericFilters` must be NULL on entry; ownership of the allocated array is transferred
-///    to `*gf` and must be released by `GeoFilter_Free`.
+///    to `*gf` and must be released by `GeoFilter_Free` (which frees it through
+///    [`free_geo_numeric_filters`]).
 pub unsafe fn build_geo_numeric_filters<'index>(
     gf: &'index mut GeoFilter,
 ) -> Result<Vec<&'index NumericFilter>, InvalidGeoInput> {
@@ -72,16 +73,14 @@ pub unsafe fn build_geo_numeric_filters<'index>(
     let center = geo::hash::WGS84Coordinates::from_f64(gf.lon, gf.lat)?;
     let ranges = geo::calc_ranges(center, radius_meters);
 
-    // Allocate the `numericFilters` array via the C-side helper so the
-    // container is rm_calloc-backed, matching `GeoFilter_Free`'s
-    // `rm_free(gf->numericFilters)` cleanup.
-    //
-    // SAFETY: the helper just calls `rm_calloc(GEO_RANGE_COUNT, sizeof(*))`
-    // and returns the resulting pointer; on success the returned array is
-    // zero-initialised, so each per-cell slot starts as the null pointer
-    // the loop below expects.
-    let numeric_filters =
-        unsafe { ffi::GeoFilter_AllocNumericFiltersArray() } as *mut *mut NumericFilter;
+    // Allocate the `numericFilters` array in Rust and hand ownership to `*gf`.
+    // `GeoFilter_Free` releases it by calling back into Rust
+    // ([`free_geo_numeric_filters`], via the `iterators_ffi` wrapper), so the
+    // container is always reclaimed with the same Rust allocator that produced
+    // it.
+    let numeric_filters = Box::into_raw(Box::new(
+        [std::ptr::null_mut::<NumericFilter>(); geo::GEO_RANGE_COUNT],
+    ));
     // SAFETY: 2. guarantees gf.numericFilters is NULL and writable.
     gf.numericFilters = numeric_filters.cast();
 
@@ -102,16 +101,52 @@ pub unsafe fn build_geo_numeric_filters<'index>(
                 (gf as *const GeoFilter).cast(),
             )
         } as *mut NumericFilter;
-        // SAFETY: numeric_filters points at a freshly-allocated array of
-        // GEO_RANGE_COUNT pointer-sized slots (see the rm_calloc helper);
-        // `ii` is bounded by `ranges.iter()` which has the same length.
-        let slot = unsafe { numeric_filters.add(ii) };
-        // SAFETY: `slot` is a valid, aligned pointer into the array (see above).
-        unsafe { *slot = filt_ptr };
+        // SAFETY: numeric_filters is a valid array of [`geo::GEO_RANGE_COUNT`] elements;
+        // `ii` is bounded by `ranges.iter()`, which has the same length.
+        unsafe { (*numeric_filters)[ii] = filt_ptr };
         // SAFETY: filt_ptr is exclusively owned and lives for 'index (stored in gf).
         filters.push(unsafe { &*filt_ptr });
     }
     Ok(filters)
+}
+
+/// Frees the per-range `numericFilters` array that [`build_geo_numeric_filters`]
+/// stored on a [`GeoFilter`], together with every non-null [`NumericFilter`] it
+/// owns.
+///
+/// This is the deallocation counterpart of [`build_geo_numeric_filters`] and
+/// must stay in lockstep with it. Each piece is reclaimed with the allocator
+/// that produced it: the array container with the Rust allocator (`Box::from_raw`
+/// undoing the `Box::into_raw`) and each entry with `NumericFilter_Free` (the C
+/// allocator `NewNumericFilter` used). C's `GeoFilter_Free` calls this — through
+/// the `iterators_ffi` `GeoFilter_FreeNumericFilters` wrapper — instead of
+/// `rm_free`, so the container is freed with the right allocator in every binary.
+///
+/// Does nothing when `filters` is NULL.
+///
+/// # Safety
+///
+/// `filters` must be NULL, or the exact pointer [`build_geo_numeric_filters`]
+/// wrote into `gf.numericFilters` (a `Box::into_raw` of
+/// `[*mut NumericFilter; GEO_RANGE_COUNT]`), not yet freed. After this call that
+/// pointer is dangling and must not be used again.
+pub unsafe fn free_geo_numeric_filters(filters: *mut *mut NumericFilter) {
+    if filters.is_null() {
+        return;
+    }
+    // SAFETY: per the contract, `filters` is the `Box::into_raw` of a
+    // `[*mut NumericFilter; GEO_RANGE_COUNT]`, so reclaiming it with
+    // `Box::from_raw` matches the original allocation exactly.
+    let array =
+        unsafe { Box::from_raw(filters as *mut [*mut NumericFilter; geo::GEO_RANGE_COUNT]) };
+    for &filt_ptr in array.iter() {
+        if !filt_ptr.is_null() {
+            // SAFETY: each non-null entry is a live `NumericFilter` from
+            // `NewNumericFilter`, owned by `gf` and freed here exactly once.
+            unsafe { ffi::NumericFilter_Free(filt_ptr.cast()) };
+        }
+    }
+    // Dropping `array` releases the container via the Rust allocator.
 }
 
 /// Mapping to retrieve a [`NumericFilter`] for a vec of [`NumericIteratorVariant`]
@@ -121,7 +156,7 @@ type GeoFilterAndRangeIterator<'index> =
 /// Creates per-range iterators for all geo-encoded index entries within the radius in `gf`.
 ///
 /// Geo fields are stored as sorted numeric geohash values. The radius maps to up to
-/// `GEO_RANGE_COUNT` contiguous geohash ranges; each range is queried via the numeric range
+/// [`geo::GEO_RANGE_COUNT`] contiguous geohash ranges; each range is queried via the numeric range
 /// tree. Returns one `(filter, variants)` pair per non-trivial range so that callers can
 /// associate each [`NumericIteratorVariant`] with its [`NumericFilter`] (needed by C profiling;
 /// see the comment in `NewGeoRangeIterator`).
@@ -194,7 +229,7 @@ pub fn extract_geo_unit_factor(unit: GeoDistance) -> f64 {
 
 /// Build a geo-radius iterator over all geohash sub-ranges matching `gf`.
 ///
-/// A radius query maps to up to `GEO_RANGE_COUNT` contiguous geohash ranges;
+/// A radius query maps to up to [`geo::GEO_RANGE_COUNT`] contiguous geohash ranges;
 /// each is queried via the field's numeric range tree (with per-record distance
 /// filtering) and the results are combined with [`build_union`].
 ///

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/geo.rs
@@ -11,7 +11,7 @@ use std::ptr::NonNull;
 
 use ffi::{GeoDistance, GeoFilter, QueryIterator, RedisSearchCtx};
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
-use geo::{GEO_RANGE_COUNT, hash::InvalidWGS84Coordinates};
+use geo::hash::InvalidWGS84Coordinates;
 use inverted_index::NumericFilter;
 use query_types::QueryNodeType;
 
@@ -72,11 +72,16 @@ pub unsafe fn build_geo_numeric_filters<'index>(
     let center = geo::hash::WGS84Coordinates::from_f64(gf.lon, gf.lat)?;
     let ranges = geo::calc_ranges(center, radius_meters);
 
-    // Allocate the numericFilters array and hand ownership to *gf so that
-    // GeoFilter_Free → NumericFilter_Free → rm_free can clean up each entry.
-    let numeric_filters = Box::into_raw(Box::new(
-        [std::ptr::null_mut::<NumericFilter>(); GEO_RANGE_COUNT],
-    ));
+    // Allocate the `numericFilters` array via the C-side helper so the
+    // container is rm_calloc-backed, matching `GeoFilter_Free`'s
+    // `rm_free(gf->numericFilters)` cleanup.
+    //
+    // SAFETY: the helper just calls `rm_calloc(GEO_RANGE_COUNT, sizeof(*))`
+    // and returns the resulting pointer; on success the returned array is
+    // zero-initialised, so each per-cell slot starts as the null pointer
+    // the loop below expects.
+    let numeric_filters =
+        unsafe { ffi::GeoFilter_AllocNumericFiltersArray() } as *mut *mut NumericFilter;
     // SAFETY: 2. guarantees gf.numericFilters is NULL and writable.
     gf.numericFilters = numeric_filters.cast();
 
@@ -97,8 +102,12 @@ pub unsafe fn build_geo_numeric_filters<'index>(
                 (gf as *const GeoFilter).cast(),
             )
         } as *mut NumericFilter;
-        // SAFETY: numeric_filters is a valid array of GEO_RANGE_COUNT elements; ii is in bounds.
-        unsafe { (*numeric_filters)[ii] = filt_ptr };
+        // SAFETY: numeric_filters points at a freshly-allocated array of
+        // GEO_RANGE_COUNT pointer-sized slots (see the rm_calloc helper);
+        // `ii` is bounded by `ranges.iter()` which has the same length.
+        let slot = unsafe { numeric_filters.add(ii) };
+        // SAFETY: `slot` is a valid, aligned pointer into the array (see above).
+        unsafe { *slot = filt_ptr };
         // SAFETY: filt_ptr is exclusively owned and lives for 'index (stored in gf).
         filters.push(unsafe { &*filt_ptr });
     }
@@ -112,7 +121,7 @@ type GeoFilterAndRangeIterator<'index> =
 /// Creates per-range iterators for all geo-encoded index entries within the radius in `gf`.
 ///
 /// Geo fields are stored as sorted numeric geohash values. The radius maps to up to
-/// [`GEO_RANGE_COUNT`] contiguous geohash ranges; each range is queried via the numeric range
+/// `GEO_RANGE_COUNT` contiguous geohash ranges; each range is queried via the numeric range
 /// tree. Returns one `(filter, variants)` pair per non-trivial range so that callers can
 /// associate each [`NumericIteratorVariant`] with its [`NumericFilter`] (needed by C profiling;
 /// see the comment in `NewGeoRangeIterator`).

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
@@ -20,7 +20,7 @@ mod wildcard;
 pub use core::InvIndIterator;
 pub use geo::{
     GeoRangeError, InvalidGeoInput, build_geo_numeric_filters, build_geo_range_iterator,
-    extract_geo_unit_factor, new_geo_range_iterator,
+    extract_geo_unit_factor, free_geo_numeric_filters, new_geo_range_iterator,
 };
 pub use missing::{Missing, new_missing_iterator};
 pub use numeric::{

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -78,7 +78,7 @@ pub use inverted_index::{
     GeoRangeError, InvalidGeoInput, Missing, Numeric, NumericIteratorVariant, Tag, Term,
     TermIndexReader, build_geo_numeric_filters, build_geo_range_iterator,
     build_numeric_filter_iterator, build_term_iterator, extract_geo_unit_factor,
-    new_geo_range_iterator, open_numeric_or_geo_index,
+    free_geo_numeric_filters, new_geo_range_iterator, open_numeric_or_geo_index,
 };
 pub use metric::Metric;
 pub use metric_lazy::MetricLazy;
@@ -433,7 +433,7 @@ pub trait SearchEnterpriseIterators: Send + Sync {
     /// `gf` is mutated in place: [`build_geo_numeric_filters`] decomposes the
     /// circle into up to [`geo::GEO_RANGE_COUNT`] numeric range filters and
     /// stores them in `gf.numericFilters` (owned by `*gf`, freed by `GeoFilter_Free`).
-    ///  The disk path then runs each range through the numeric machinery and
+    /// The disk path then runs each range through the numeric machinery and
     /// post-filters survivors by true great-circle distance.
     fn new_geo_on_disk<'index>(
         &self,

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -425,4 +425,21 @@ pub trait SearchEnterpriseIterators: Send + Sync {
         field_index: FieldIndex,
         snapshot: NonNull<ffi::RedisSearchDiskSnapshot>,
     ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>>;
+
+    /// Iterate over the entries of the geo (numeric-encoded geohash) index at
+    /// the given field index whose `(lon, lat)` falls within the radius
+    /// described by `gf`.
+    ///
+    /// `gf` is mutated in place: [`build_geo_numeric_filters`] decomposes the
+    /// circle into up to [`geo::GEO_RANGE_COUNT`] numeric range filters and
+    /// stores them in `gf.numericFilters` (owned by `*gf`, freed by `GeoFilter_Free`).
+    ///  The disk path then runs each range through the numeric machinery and
+    /// post-filters survivors by true great-circle distance.
+    fn new_geo_on_disk<'index>(
+        &self,
+        index: &'index mut ffi::RedisSearchDiskIndexSpec,
+        gf: &'index mut ffi::GeoFilter,
+        field_index: ffi::t_fieldIndex,
+        snapshot: NonNull<ffi::RedisSearchDiskSnapshot>,
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>>;
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_enterprise_iterators.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_enterprise_iterators.rs
@@ -94,6 +94,16 @@ impl SearchEnterpriseIterators for MockEnterpriseIterators {
     ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>> {
         unimplemented!("MockEnterpriseIterators::new_numeric_on_disk not used in these tests")
     }
+
+    fn new_geo_on_disk<'index>(
+        &self,
+        _index: &'index mut ffi::RedisSearchDiskIndexSpec,
+        _gf: &'index mut ffi::GeoFilter,
+        _field_index: ffi::t_fieldIndex,
+        _snapshot: std::ptr::NonNull<ffi::RedisSearchDiskSnapshot>,
+    ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>> {
+        unimplemented!("MockEnterpriseIterators::new_geo_on_disk not used in these tests")
+    }
 }
 
 /// Initialize [`SEARCH_ENTERPRISE_ITERATORS`] with [`MockEnterpriseIterators`]

--- a/src/spec.c
+++ b/src/spec.c
@@ -1303,7 +1303,6 @@ static int parseFieldSpec(ArgsCursor *ac, IndexSpec *sp, StrongRef sp_ref, Field
       fs->options |= FieldSpec_IndexMissing;
     }
   } else if (AC_AdvanceIfMatch(ac, SPEC_GEO_STR)) {  // geo field
-    if (!SearchDisk_MarkUnsupportedFieldIfDiskEnabled(SPEC_GEO_STR, fs, status)) goto error;
     fs->types |= INDEXFLD_T_GEO;
     if (AC_AdvanceIfMatch(ac, SPEC_INDEXMISSING_STR)) {
       fs->options |= FieldSpec_IndexMissing;
@@ -1482,8 +1481,8 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
 
     if (isSpecOnDiskForValidation(sp))
     {
-      if (!FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && !FIELD_IS(fs, INDEXFLD_T_VECTOR) && !FIELD_IS(fs, INDEXFLD_T_TAG) && !FIELD_IS(fs, INDEXFLD_T_NUMERIC)) {
-        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Disk index does not support non-TEXT/VECTOR/TAG/NUMERIC fields");
+      if (!FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && !FIELD_IS(fs, INDEXFLD_T_VECTOR) && !FIELD_IS(fs, INDEXFLD_T_TAG) && !FIELD_IS(fs, INDEXFLD_T_NUMERIC) && !FIELD_IS(fs, INDEXFLD_T_GEO)) {
+        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Disk index does not support non-TEXT/VECTOR/TAG/NUMERIC/GEO fields");
         goto reset;
       }
       if (fs->options & FieldSpec_NotIndexable) {

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -44,8 +44,6 @@ def test_flex_max_index_limit(env):
 @with_simulate_in_flex(True)
 def test_invalid_field_type(env):
     """Test that creating an index with an invalid field type fails when search-_simulate-in-flex is true"""
-    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA', 'field', 'GEO') \
-        .error().contains('GEO fields are not supported in Flex indexes')
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA', 'field', 'GEOSHAPE') \
         .error().contains('GEOSHAPE fields are not supported in Flex indexes')
 


### PR DESCRIPTION
## Describe the changes in the pull request

Current: Disk-backed indexes support TEXT, VECTOR, TAG, and NUMERIC fields, but GEO fields are rejected at schema validation and geo queries always use the in-memory iterator path.

Change: Add the OSS-side disk GEO integration points used by Enterprise. The Rust RQE enterprise iterator boundary gains `new_geo_on_disk`, exposed to the query evaluator via `SearchDiskHandle::new_geo_iterator`; `eval_geo` routes GEO filters on disk-backed specs to it; and GEO fields are accepted by disk index schema validation, the numeric disk write batch, and disk field-stats reporting.

Outcome: Enterprise disk indexes can define GEO fields and execute GEO radius queries through the disk-backed iterator path. OSS gains only the integration hooks; it does not implement a standalone disk GEO backend.

#### Which additional issues this PR fixes
1. MOD-15859

#### Main objects this PR modified
1. Rust RQE iterator bridge: `SearchEnterpriseIterators::new_geo_on_disk`,
   `SearchDiskHandle::new_geo_iterator`
2. Query execution: `eval_geo` dispatches disk-backed GEO filters to the disk iterator
   instead of the in-memory union path
3. GEO schema/indexing flow: `spec.c` accepts GEO on disk specs, `document.c` lets geo
   values ride the numeric disk batch, `field_spec_info.c` reports GEO metrics from the
   numeric CF
4. GEO FFI bindings and `GeoFilter.numericFilters` ownership: new
   `GeoFilter_FreeNumericFilters` export so `GeoFilter_Free` releases the array with the
   allocator that produced it


#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
