### PR TITLE
[MOD-1487] qast: handle QN_UNION in Rust

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -1064,26 +1064,6 @@ static QueryIterator *Query_EvalVectorNode(QueryEvalCtx *q, QueryNode *qn) {
   return it;
 }
 
-static QueryIterator *Query_EvalUnionNode(QueryEvalCtx *q, QueryNode *qn) {
-  RS_LOG_ASSERT(qn->type == QN_UNION, "query node type should be union")
-  // Parsers and expanders always create unions with 2+ children.
-  RS_ASSERT(QueryNode_NumChildren(qn) > 1);
-
-  // recursively eval the children
-  QueryIterator **iters = rm_malloc(QueryNode_NumChildren(qn) * sizeof(QueryIterator *));
-  for (size_t i = 0; i < QueryNode_NumChildren(qn); ++i) {
-    qn->children[i]->opts.fieldMask &= qn->opts.fieldMask;
-    iters[i] = Query_EvalNode_Rs(q, qn->children[i]);
-  }
-
-  // We want to get results with all the matching children (`quickExit == false`), unless:
-  // 1. We are a `Not` sub-tree, so we only care about the set of IDs
-  // 2. The node's weight is 0, which means the sub-tree is not relevant for scoring.
-  bool quickExit = q->inNotSubTree || qn->opts.weight == 0;
-  QueryIterator *ret = NewUnionIterator(iters, QueryNode_NumChildren(qn), quickExit, qn->opts.weight, QN_UNION, NULL, q->config);
-  return ret;
-}
-
 /**
  * Converts a given string to lowercase and handles escape sequences.
  *
@@ -1425,12 +1405,11 @@ QueryIterator *Query_EvalNode(QueryEvalCtx *q, QueryNode *n) {
     case QN_OPTIONAL:
     case QN_NOT:
     case QN_PHRASE:
+    case QN_UNION:
       // These node types have been ported to Rust.
       return Query_EvalNode_Rs(q, n);
     case QN_TOKEN:
       return Query_EvalTokenNode(q, n);
-    case QN_UNION:
-      return Query_EvalUnionNode(q, n);
     case QN_TAG:
       return Query_EvalTagNode(q, n);
     case QN_PREFIX:

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn NewGeoRangeIterator(
         })
         .collect();
 
-    // SAFETY: `q_str` is null and `QueryNodeType::Geo` is union-compatible,
+    // SAFETY: `q_str` is `None` and `QueryNodeType::Geo` is union-compatible,
     // satisfying the requirements of `build_union`.
     unsafe {
         build_union(
@@ -84,7 +84,7 @@ pub unsafe extern "C" fn NewGeoRangeIterator(
             true,
             min_union_iter_heap,
             QueryNodeType::Geo,
-            ptr::null(),
+            None,
             1.0,
         )
     }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
@@ -14,6 +14,7 @@ use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use query_node_type::QueryNodeType;
 use rqe_iterators::{
     IteratorsConfig, c2rust::CRQEIterator, interop::RQEIteratorWrapper, new_geo_range_iterator,
+    union_opaque::build_union,
 };
 
 use crate::inverted_index::numeric::NumericIterator;
@@ -75,12 +76,16 @@ pub unsafe extern "C" fn NewGeoRangeIterator(
         })
         .collect();
 
-    crate::union::build_union_from_children(
-        children,
-        true,
-        min_union_iter_heap,
-        QueryNodeType::Geo,
-        ptr::null(),
-        1.0,
-    )
+    // SAFETY: `q_str` is null and `QueryNodeType::Geo` is union-compatible,
+    // satisfying the requirements of `build_union`.
+    unsafe {
+        build_union(
+            children,
+            true,
+            min_union_iter_heap,
+            QueryNodeType::Geo,
+            ptr::null(),
+            1.0,
+        )
+    }
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
@@ -76,8 +76,7 @@ pub unsafe extern "C" fn NewGeoRangeIterator(
         })
         .collect();
 
-    // SAFETY: `q_str` is `None` and `QueryNodeType::Geo` is union-compatible,
-    // satisfying the requirements of `build_union`.
+    // SAFETY: `q_str` is `None`, satisfying the requirements of `build_union`.
     unsafe {
         build_union(
             children,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -16,7 +16,7 @@ use query_node_type::QueryNodeType;
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::{
     IteratorsConfig, NumericIteratorVariant, c2rust::CRQEIterator, interop::RQEIteratorWrapper,
-    open_numeric_or_geo_index, profile_print,
+    open_numeric_or_geo_index, profile_print, union_opaque::build_union,
 };
 
 /// Wrapper around [`NumericIteratorVariant`].
@@ -198,14 +198,18 @@ pub unsafe extern "C" fn NewNumericFilterIterator(
         })
         .collect();
 
-    crate::union::build_union_from_children(
-        children,
-        true,
-        min_union_iter_heap,
-        node_type,
-        ptr::null(),
-        1.0,
-    )
+    // SAFETY: `q_str` is null and `node_type` is `Numeric` or `Geo`, both
+    // union-compatible, satisfying the requirements of `build_union`.
+    unsafe {
+        build_union(
+            children,
+            true,
+            min_union_iter_heap,
+            node_type,
+            ptr::null(),
+            1.0,
+        )
+    }
 }
 
 impl profile_print::ProfilePrint for NumericIterator<'_> {

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -198,18 +198,9 @@ pub unsafe extern "C" fn NewNumericFilterIterator(
         })
         .collect();
 
-    // SAFETY: `q_str` is null and `node_type` is `Numeric` or `Geo`, both
+    // SAFETY: `q_str` is `None` and `node_type` is `Numeric` or `Geo`, both
     // union-compatible, satisfying the requirements of `build_union`.
-    unsafe {
-        build_union(
-            children,
-            true,
-            min_union_iter_heap,
-            node_type,
-            ptr::null(),
-            1.0,
-        )
-    }
+    unsafe { build_union(children, true, min_union_iter_heap, node_type, None, 1.0) }
 }
 
 impl profile_print::ProfilePrint for NumericIterator<'_> {

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -198,8 +198,7 @@ pub unsafe extern "C" fn NewNumericFilterIterator(
         })
         .collect();
 
-    // SAFETY: `q_str` is `None` and `node_type` is `Numeric` or `Geo`, both
-    // union-compatible, satisfying the requirements of `build_union`.
+    // SAFETY: `q_str` is `None`, satisfying the requirements of `build_union`.
     unsafe { build_union(children, true, min_union_iter_heap, node_type, None, 1.0) }
 }
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
@@ -9,7 +9,10 @@
 
 //! FFI bridge for the Rust union iterators.
 
-use std::{ffi::c_char, ptr::NonNull};
+use std::{
+    ffi::{CStr, c_char},
+    ptr::NonNull,
+};
 
 use ffi::{QueryIterator, QueryNodeType};
 
@@ -96,8 +99,16 @@ pub unsafe extern "C" fn NewUnionIterator(
     // SAFETY: its was allocated via rm_malloc per the function's safety contract (1).
     unsafe { free_iterators_array(its) };
 
-    // SAFETY: by contract (5), `q_str` is null or a valid NUL-terminated C
-    // string that outlives the returned iterator, and `type_` is union-compatible.
+    let q_str = if q_str.is_null() {
+        None
+    } else {
+        // SAFETY: by contract (5), a non-null `q_str` is a valid, NUL-terminated
+        // C string that outlives the returned iterator.
+        Some(unsafe { CStr::from_ptr(q_str) })
+    };
+
+    // SAFETY: by contract (5), `q_str` outlives the returned iterator and
+    // `type_` is union-compatible.
     unsafe {
         build_union(
             children,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
@@ -64,8 +64,7 @@ unsafe fn free_iterators_array(its: *mut *mut QueryIterator) {
 /// 3. Null entries in `its` are treated as empty iterators.
 /// 4. `config` must be a valid non-null pointer to an [`IteratorsConfig`].
 /// 5. `q_str` must be null or a valid, NUL-terminated C string that outlives
-///    the returned iterator, and `type_` must be a union-compatible query node
-///    type — the requirements of [`build_union`].
+///    the returned iterator — the requirement of [`build_union`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewUnionIterator(
     its: *mut *mut QueryIterator,
@@ -107,8 +106,7 @@ pub unsafe extern "C" fn NewUnionIterator(
         Some(unsafe { CStr::from_ptr(q_str) })
     };
 
-    // SAFETY: by contract (5), `q_str` outlives the returned iterator and
-    // `type_` is union-compatible.
+    // SAFETY: by contract (5), `q_str` outlives the returned iterator.
     unsafe {
         build_union(
             children,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
@@ -13,11 +13,12 @@ use std::{ffi::c_char, ptr::NonNull};
 
 use ffi::{QueryIterator, QueryNodeType};
 
-use crate::profile::Profile_AddIters;
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::{
-    IteratorsConfig, RQEIterator, UnionVariant, c2rust::CRQEIterator, interop::RQEIteratorWrapper,
-    union_opaque::UnionOpaque, union_reducer::new_union_iterator,
+    IteratorsConfig, RQEIterator,
+    c2rust::CRQEIterator,
+    interop::RQEIteratorWrapper,
+    union_opaque::{UnionOpaque, build_union},
 };
 
 /// Concrete [`RQEIteratorWrapper`] used to expose a [`UnionOpaque`] to C.
@@ -28,32 +29,6 @@ use rqe_iterators::{
 /// via [`RQEIteratorWrapper::ref_from_header_ptr`] /
 /// [`RQEIteratorWrapper::mut_ref_from_header_ptr`].
 type UnionWrapper<'index> = RQEIteratorWrapper<UnionOpaque<'index, CRQEIterator>>;
-
-/// `ProfileChildren` callback for union iterators.
-///
-/// Profiles each child in-place via [`Profile_AddIters`].
-/// Returns the same pointer (mutation is in-place).
-///
-/// # Safety
-///
-/// `base` must be a valid, owning pointer to a `UnionWrapper` created via
-/// [`NewUnionIterator`].
-unsafe extern "C" fn union_profile_children(base: *mut QueryIterator) -> *mut QueryIterator {
-    debug_assert!(!base.is_null());
-    // SAFETY: caller guarantees `base` is valid and points to a union wrapper.
-    let wrapper = unsafe { UnionWrapper::mut_ref_from_header_ptr(base) };
-    for child in wrapper.inner.children_mut() {
-        // SAFETY: CRQEIterator is #[repr(transparent)] over NonNull<QueryIterator>,
-        // which is layout-compatible with *mut QueryIterator (same size/alignment).
-        // The cast to *mut *mut QueryIterator is therefore valid for in-place mutation.
-        // `Profile_AddIters` writes back a valid, non-null `QueryIterator*`,
-        // preserving the `NonNull` invariant.
-        let slot = child as *mut CRQEIterator as *mut *mut QueryIterator;
-        // SAFETY: `Profile_AddIters` is a valid function pointer.
-        unsafe { Profile_AddIters(slot) };
-    }
-    base
-}
 
 // ============================================================================
 // FFI: Constructor
@@ -71,66 +46,6 @@ unsafe fn free_iterators_array(its: *mut *mut QueryIterator) {
     unsafe { free_fn(its.cast::<std::ffi::c_void>()) };
 }
 
-/// Build a union iterator from a `Vec` of already-owned [`CRQEIterator`] children.
-///
-/// Applies the same reduction and variant-selection logic as [`NewUnionIterator`]:
-/// empty children are removed, a single surviving child is returned directly, and
-/// multiple children are placed in a flat or heap union depending on
-/// `min_union_iter_heap`.
-///
-/// Intended for internal Rust callers that create their own boxed iterators and
-/// want to combine them into a union without going through the C ABI.
-pub(crate) fn build_union_from_children(
-    children: Vec<CRQEIterator>,
-    quick_exit: bool,
-    min_union_iter_heap: usize,
-    type_: QueryNodeType,
-    q_str: *const c_char,
-    weight: f64,
-) -> *mut QueryIterator {
-    use rqe_iterators::union_reducer::NewUnionIterator as NewUI;
-    match new_union_iterator(children, quick_exit, min_union_iter_heap) {
-        NewUI::ReducedEmpty(empty) => RQEIteratorWrapper::boxed_new(empty),
-        NewUI::ReducedSingle(child) => child.into_raw().as_ptr(),
-        NewUI::Flat(flat) => {
-            let mut dispatch = UnionOpaque {
-                variant: UnionVariant::FlatFull(flat),
-                query_node_type: type_,
-                query_string: q_str,
-            };
-            dispatch.set_result_weight(weight);
-            RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children))
-        }
-        NewUI::FlatQuick(flat) => {
-            let mut dispatch = UnionOpaque {
-                variant: UnionVariant::FlatQuick(flat),
-                query_node_type: type_,
-                query_string: q_str,
-            };
-            dispatch.set_result_weight(weight);
-            RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children))
-        }
-        NewUI::Heap(heap) => {
-            let mut dispatch = UnionOpaque {
-                variant: UnionVariant::HeapFull(heap),
-                query_node_type: type_,
-                query_string: q_str,
-            };
-            dispatch.set_result_weight(weight);
-            RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children))
-        }
-        NewUI::HeapQuick(heap) => {
-            let mut dispatch = UnionOpaque {
-                variant: UnionVariant::HeapQuick(heap),
-                query_node_type: type_,
-                query_string: q_str,
-            };
-            dispatch.set_result_weight(weight);
-            RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children))
-        }
-    }
-}
-
 /// Creates a new union iterator, applying reduction rules and choosing between
 /// flat and heap variants based on the number of children.
 ///
@@ -145,6 +60,9 @@ pub(crate) fn build_union_from_children(
 ///    callbacks are set.
 /// 3. Null entries in `its` are treated as empty iterators.
 /// 4. `config` must be a valid non-null pointer to an [`IteratorsConfig`].
+/// 5. `q_str` must be null or a valid, NUL-terminated C string that outlives
+///    the returned iterator, and `type_` must be a union-compatible query node
+///    type — the requirements of [`build_union`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewUnionIterator(
     its: *mut *mut QueryIterator,
@@ -178,14 +96,18 @@ pub unsafe extern "C" fn NewUnionIterator(
     // SAFETY: its was allocated via rm_malloc per the function's safety contract (1).
     unsafe { free_iterators_array(its) };
 
-    build_union_from_children(
-        children,
-        quick_exit,
-        min_union_iter_heap,
-        type_,
-        q_str,
-        weight,
-    )
+    // SAFETY: by contract (5), `q_str` is null or a valid NUL-terminated C
+    // string that outlives the returned iterator, and `type_` is union-compatible.
+    unsafe {
+        build_union(
+            children,
+            quick_exit,
+            min_union_iter_heap,
+            type_,
+            q_str,
+            weight,
+        )
+    }
 }
 
 // ============================================================================

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -349,6 +349,27 @@ QueryIterator *NewIntersectionIterator(QueryIterator * *its, size_t num, int32_t
 QueryIterator *NewMetricIteratorSortedByScore(t_docId *ids, double *metric_list, size_t num, enum MetricType type_);
 
 /**
+ * Creates a new union iterator, applying reduction rules and choosing between
+ * flat and heap variants based on the number of children.
+ *
+ * Takes ownership of both the `its` array and all child iterators it contains.
+ *
+ * # Safety
+ *
+ * 1. `its` must be a valid non-null pointer to an array of `num`
+ *    `QueryIterator*` values, allocated with the Redis allocator (`rm_malloc`).
+ *    Ownership is transferred to this function.
+ * 2. Every non-null pointer in `its` must be a valid `QueryIterator` whose
+ *    callbacks are set.
+ * 3. Null entries in `its` are treated as empty iterators.
+ * 4. `config` must be a valid non-null pointer to an [`IteratorsConfig`].
+ * 5. `q_str` must be null or a valid, NUL-terminated C string that outlives
+ *    the returned iterator, and `type_` must be a union-compatible query node
+ *    type — the requirements of [`build_union`].
+ */
+QueryIterator *NewUnionIterator(QueryIterator * *its, int32_t num, bool quick_exit, double weight, QueryNodeType type_, const char *q_str, const struct IteratorsConfig *config);
+
+/**
  * Creates a new wildcard iterator from a query evaluation context.
  *
  * There are three possible code paths:
@@ -442,6 +463,17 @@ NumericRangeTree *openNumericOrGeoIndex(IndexSpec *spec, FieldSpec *fs, bool cre
  * 3. `key_handle` is either a null pointer or a valid non-null pointer to a [`RLookupKeyHandle`] instance.
  */
 void SetMetricRLookupHandle(QueryIterator *header, RLookupKeyHandle *key_handle);
+
+/**
+ * Trims a union iterator for the LIMIT optimizer, then switches to unsorted
+ * sequential read mode.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid non-null pointer to a non-reduced union iterator
+ *    created via [`NewUnionIterator`].
+ */
+void TrimUnionIterator(QueryIterator *it, size_t limit, bool asc);
 
 /**
  * Append a new child iterator to the intersection.
@@ -571,24 +603,6 @@ QueryIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const struct 
 QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagIndex *tag_idx, const RedisSearchCtx *sctx, union FieldMaskOrIndex field_mask_or_index, struct RSQueryTerm *term, double weight);
 
 /**
- * Creates a new union iterator, applying reduction rules and choosing between
- * flat and heap variants based on the number of children.
- *
- * Takes ownership of both the `its` array and all child iterators it contains.
- *
- * # Safety
- *
- * 1. `its` must be a valid non-null pointer to an array of `num`
- *    `QueryIterator*` values, allocated with the Redis allocator (`rm_malloc`).
- *    Ownership is transferred to this function.
- * 2. Every non-null pointer in `its` must be a valid `QueryIterator` whose
- *    callbacks are set.
- * 3. Null entries in `its` are treated as empty iterators.
- * 4. `config` must be a valid non-null pointer to an [`IteratorsConfig`].
- */
-QueryIterator *NewUnionIterator(QueryIterator * *its, int32_t num, bool quick_exit, double weight, QueryNodeType type_, const char *q_str, const struct IteratorsConfig *config);
-
-/**
  * Creates a new term inverted index iterator for querying term fields.
  *
  * # Parameters
@@ -653,17 +667,6 @@ QueryIterator *NewInvIndIterator_WildcardQuery(const InvertedIndex *idx, const R
  * 2. `header` was built via [`NewMetricIteratorSortedByScore`] or [`NewMetricIteratorSortedById`].
  */
 RLookupKey * *GetMetricOwnKeyRef(QueryIterator *header);
-
-/**
- * Trims a union iterator for the LIMIT optimizer, then switches to unsorted
- * sequential read mode.
- *
- * # Safety
- *
- * 1. `it` must be a valid non-null pointer to a non-reduced union iterator
- *    created via [`NewUnionIterator`].
- */
-void TrimUnionIterator(QueryIterator *it, size_t limit, bool asc);
 
 /**
  * Creates a NOT iterator, choosing between non-optimized and optimized based

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -364,8 +364,7 @@ QueryIterator *NewMetricIteratorSortedByScore(t_docId *ids, double *metric_list,
  * 3. Null entries in `its` are treated as empty iterators.
  * 4. `config` must be a valid non-null pointer to an [`IteratorsConfig`].
  * 5. `q_str` must be null or a valid, NUL-terminated C string that outlives
- *    the returned iterator, and `type_` must be a union-compatible query node
- *    type — the requirements of [`build_union`].
+ *    the returned iterator — the requirement of [`build_union`].
  */
 QueryIterator *NewUnionIterator(QueryIterator * *its, int32_t num, bool quick_exit, double weight, QueryNodeType type_, const char *q_str, const struct IteratorsConfig *config);
 

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -465,17 +465,6 @@ NumericRangeTree *openNumericOrGeoIndex(IndexSpec *spec, FieldSpec *fs, bool cre
 void SetMetricRLookupHandle(QueryIterator *header, RLookupKeyHandle *key_handle);
 
 /**
- * Trims a union iterator for the LIMIT optimizer, then switches to unsorted
- * sequential read mode.
- *
- * # Safety
- *
- * 1. `it` must be a valid non-null pointer to a non-reduced union iterator
- *    created via [`NewUnionIterator`].
- */
-void TrimUnionIterator(QueryIterator *it, size_t limit, bool asc);
-
-/**
  * Append a new child iterator to the intersection.
  *
  * Transfers ownership of `child` to the intersection. Updates the estimated result count
@@ -514,6 +503,17 @@ void AddIntersectionIteratorChild(QueryIterator *header, QueryIterator *child);
  * 3. `ctx` must remain valid until the iterator is freed; ownership transfers to the iterator.
  */
 QueryIterator *NewLazyVectorRangeIterator(ProduceResultsFn produce, FreeProducerCtxFn free_ctx, void *ctx, bool yields_metric, bool sorted_by_id, size_t num_estimated, enum MetricType type_);
+
+/**
+ * Trims a union iterator for the LIMIT optimizer, then switches to unsorted
+ * sequential read mode.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid non-null pointer to a non-reduced union iterator
+ *    created via [`NewUnionIterator`].
+ */
+void TrimUnionIterator(QueryIterator *it, size_t limit, bool asc);
 
 /**
  * Print iterator profile tree as a Redis reply.

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -573,12 +573,13 @@ fn eval_union<'index>(ctx: &'index mut QueryEvalContext, node: &QueryNodeRef) ->
     // exactly once, top-down, so we hold exclusive access to this node and its
     // subtree for the duration of the call — exactly what `as_mut` requires.
     let mut node = unsafe { node.as_mut() };
-    let mut children = Vec::with_capacity(num_children);
-    for i in 0..num_children {
-        let mut child = node.child_mut(i);
-        child.and_field_mask(node_mask);
-        children.push(eval_child_iterator(ctx, child.as_ref()));
-    }
+    let children: Vec<CRQEIterator> = (0..num_children)
+        .map(|i| {
+            let mut child = node.child_mut(i);
+            child.and_field_mask(node_mask);
+            eval_child_iterator(ctx, child.as_ref())
+        })
+        .collect();
 
     // SAFETY: `q_str` is `None`, satisfying the requirements of `build_union`.
     let result_ptr = unsafe {

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -580,9 +580,7 @@ fn eval_union<'index>(ctx: &'index mut QueryEvalContext, node: &QueryNodeRef) ->
         children.push(eval_child_iterator(ctx, child.as_ref()));
     }
 
-    // SAFETY: `q_str` is `None`, and `node_type` is the type of a `QN_UNION`
-    // node (`QueryNodeType::Union`), which is union-compatible — satisfying the
-    // requirements of `build_union`.
+    // SAFETY: `q_str` is `None`, satisfying the requirements of `build_union`.
     let result_ptr = unsafe {
         build_union(
             children,

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -580,8 +580,8 @@ fn eval_union<'index>(ctx: &'index mut QueryEvalContext, node: &QueryNodeRef) ->
         children.push(eval_child_iterator(ctx, child.as_ref()));
     }
 
-    // SAFETY: `q_str` is null, and `node_type` is the type of a `QN_UNION` node
-    // (`QueryNodeType::Union`), which is union-compatible — satisfying the
+    // SAFETY: `q_str` is `None`, and `node_type` is the type of a `QN_UNION`
+    // node (`QueryNodeType::Union`), which is union-compatible — satisfying the
     // requirements of `build_union`.
     let result_ptr = unsafe {
         build_union(
@@ -589,7 +589,7 @@ fn eval_union<'index>(ctx: &'index mut QueryEvalContext, node: &QueryNodeRef) ->
             quick_exit,
             min_union_iter_heap,
             node_type,
-            std::ptr::null(),
+            None,
             weight,
         )
     };

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -25,6 +25,7 @@ use rqe_iterators::{
     inverted_index::new_missing_iterator,
     not_reducer::{NewNotIterator, new_not_iterator},
     optional_reducer::{NewOptionalIterator, new_optional_iterator},
+    union_opaque::build_union,
 };
 
 use crate::{QueryEvalContext, QueryNode, QueryNodeRef};
@@ -163,6 +164,7 @@ pub fn eval_node<'index>(
         QueryNode::Optional => Some(eval_optional(ctx, node)),
         QueryNode::Not => Some(eval_not(ctx, node)),
         QueryNode::Phrase { exact } => eval_phrase(ctx, node, exact),
+        QueryNode::Union => Some(eval_union(ctx, node)),
         // Node types not yet ported to Rust are delegated back to the C
         // dispatcher.
         _ => eval_node_c(ctx, node),
@@ -537,4 +539,60 @@ fn eval_phrase<'index>(
     Some(Evaluated::RustCompound(
         NonNull::new(result_ptr).expect("phrase iterator must not be null"),
     ))
+}
+
+/// `QN_UNION` — a logical OR over its children (matches any document matched by
+/// at least one child).
+///
+/// The children are evaluated and combined with the Rust union iterator. Each
+/// child's field mask is first intersected with the union node's own mask, and
+/// `quick_exit` is enabled when the union only needs the matching id set rather
+/// than per-child scores — i.e. inside a `NOT` subtree or when the node's weight
+/// is zero.
+fn eval_union<'index>(ctx: &'index mut QueryEvalContext, node: &QueryNodeRef) -> Evaluated<'index> {
+    // Parsers and expanders always create unions with 2+ children.
+    debug_assert!(
+        node.num_children() > 1,
+        "a union node must have more than one child"
+    );
+
+    let num_children = node.num_children();
+    let node_mask = node.opts().field_mask;
+    let weight = node.opts().weight;
+    let node_type = node.node_type();
+
+    // We want results from every matching child (`quick_exit == false`) unless
+    // either (1) we are inside a `NOT` subtree, where only the id set matters,
+    // or (2) the node's weight is zero, so its subtree is irrelevant to scoring.
+    let quick_exit = ctx.in_not_sub_tree() || weight == 0.0;
+    let min_union_iter_heap = ctx.config().min_union_iter_heap as usize;
+
+    // Recursively evaluate every child, narrowing its field mask first.
+    //
+    // SAFETY: query evaluation is single-threaded and walks each AST node
+    // exactly once, top-down, so we hold exclusive access to this node and its
+    // subtree for the duration of the call — exactly what `as_mut` requires.
+    let mut node = unsafe { node.as_mut() };
+    let mut children = Vec::with_capacity(num_children);
+    for i in 0..num_children {
+        let mut child = node.child_mut(i);
+        child.and_field_mask(node_mask);
+        children.push(eval_child_iterator(ctx, child.as_ref()));
+    }
+
+    // SAFETY: `q_str` is null, and `node_type` is the type of a `QN_UNION` node
+    // (`QueryNodeType::Union`), which is union-compatible — satisfying the
+    // requirements of `build_union`.
+    let result_ptr = unsafe {
+        build_union(
+            children,
+            quick_exit,
+            min_union_iter_heap,
+            node_type,
+            std::ptr::null(),
+            weight,
+        )
+    };
+
+    Evaluated::RustCompound(NonNull::new(result_ptr).expect("union iterator must not be null"))
 }

--- a/src/redisearch_rs/query_eval/tests/integration/main.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/main.rs
@@ -18,5 +18,6 @@ mod null;
 mod optional;
 mod phrase;
 mod qast_iterate;
+mod union;
 mod util;
 mod wildcard;

--- a/src/redisearch_rs/query_eval/tests/integration/union.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/union.rs
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! QN_UNION → Union
+
+use query_eval::{QueryEvalContext, QueryNodeRef, eval};
+use query_node_type::QueryNodeType;
+use rqe_iterators::{IteratorType, RQEIterator};
+
+use query::mock::{MockQueryEvalCtx, MockQueryNode};
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (array_new_sz)")]
+fn eval_union_merges_children() {
+    // A union of two wildcard children matches every document in the index.
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    mock_ctx.set_max_doc_id(3);
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+    let mut c1 = MockQueryNode::new(QueryNodeType::Wildcard);
+    c1.opts_mut().weight = 1.0;
+    let mut c2 = MockQueryNode::new(QueryNodeType::Wildcard);
+    c2.opts_mut().weight = 1.0;
+    let mut union = MockQueryNode::new(QueryNodeType::Union);
+    union.opts_mut().weight = 1.0;
+    union.set_children(&[c1.as_ptr(), c2.as_ptr()]);
+    let node = unsafe { QueryNodeRef::new(union.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node)
+        .expect("should not be None")
+        .into_boxed();
+
+    assert_eq!(it.type_(), IteratorType::Union);
+    for expected in [1, 2, 3] {
+        let r = it.read().unwrap().expect("should have a result");
+        assert_eq!(r.doc_id, expected);
+    }
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (array_new_sz)")]
+fn eval_union_zero_weight_takes_quick_exit() {
+    // A zero-weight union only needs the matching id set, so `quick_exit` is
+    // enabled. In quick-exit mode the reducer shortcircuits a wildcard child:
+    // the union of two wildcards collapses to a single wildcard (unlike the
+    // full `Union` built when `quick_exit` is false).
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    mock_ctx.set_max_doc_id(3);
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+
+    let mut c1 = MockQueryNode::new(QueryNodeType::Wildcard);
+    c1.opts_mut().weight = 1.0;
+    let mut c2 = MockQueryNode::new(QueryNodeType::Wildcard);
+    c2.opts_mut().weight = 1.0;
+    let mut union = MockQueryNode::new(QueryNodeType::Union);
+    // Zero weight drives `quick_exit = true`.
+    union.opts_mut().weight = 0.0;
+    union.set_children(&[c1.as_ptr(), c2.as_ptr()]);
+    let node = unsafe { QueryNodeRef::new(union.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node)
+        .expect("should not be None")
+        .into_boxed();
+
+    // Quick-exit collapsed the union to a single wildcard child.
+    assert_eq!(it.type_(), IteratorType::Wildcard);
+    for expected in [1, 2, 3] {
+        let r = it.read().unwrap().expect("should have a result");
+        assert_eq!(r.doc_id, expected);
+    }
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (array_new_sz)")]
+fn eval_union_in_not_subtree_takes_quick_exit() {
+    // Inside a `NOT` subtree only the matching id set matters, so `quick_exit`
+    // is enabled via the `in_not_sub_tree` disjunct even though the node's weight is
+    // non-zero. As above, quick-exit mode collapses the union of two wildcards to
+    // a single wildcard child.
+    let mut mock_ctx = MockQueryEvalCtx::new();
+    mock_ctx.set_max_doc_id(3);
+    let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
+    // Drive `quick_exit` through `ctx.in_not_sub_tree()` rather than a zero weight.
+    ctx.set_in_not_sub_tree(true);
+
+    let mut c1 = MockQueryNode::new(QueryNodeType::Wildcard);
+    c1.opts_mut().weight = 1.0;
+    let mut c2 = MockQueryNode::new(QueryNodeType::Wildcard);
+    c2.opts_mut().weight = 1.0;
+    let mut union = MockQueryNode::new(QueryNodeType::Union);
+    // Non-zero weight, so only the `in_not_sub_tree` disjunct can enable quick-exit.
+    union.opts_mut().weight = 1.0;
+    union.set_children(&[c1.as_ptr(), c2.as_ptr()]);
+    let node = unsafe { QueryNodeRef::new(union.as_non_null()) };
+
+    let mut it = eval::eval_node(&mut ctx, &node)
+        .expect("should not be None")
+        .into_boxed();
+
+    // Quick-exit collapsed the union to a single wildcard child.
+    assert_eq!(it.type_(), IteratorType::Wildcard);
+    for expected in [1, 2, 3] {
+        let r = it.read().unwrap().expect("should have a result");
+        assert_eq!(r.doc_id, expected);
+    }
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+// ---------------------------------------------------------------------------
+// QN_UNION → Union over multiple real children with distinct id sets.
+//
+// Exercising the merge/dedup needs children resolving to overlapping-but-
+// distinct documents, which requires the full-FFI `TestContext`.
+// ---------------------------------------------------------------------------
+
+// Disabled under Miri: `TestContext` and SDS creation call into the C library,
+// which Miri cannot execute.
+#[cfg(not(miri))]
+mod union {
+    use ffi::IndexFlags_Index_StoreFreqs;
+    use rqe_iterators::IteratorsConfig;
+    use rqe_iterators_test_utils::{GlobalGuard, TestContext};
+
+    use super::*;
+
+    fn new_sds(s: &str) -> ffi::sds {
+        // SAFETY: `s` points to `s.len()` valid bytes; `sdsnewlen` copies them
+        // into a freshly allocated SDS string.
+        unsafe { ffi::sdsnewlen(s.as_ptr().cast(), s.len()) }
+    }
+
+    #[test]
+    fn eval_union_merges_distinct_children() {
+        let _guard = GlobalGuard::default();
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        let id_a = context.add_document("doc_a");
+        let id_b = context.add_document("doc_b");
+        let id_c = context.add_document("doc_c");
+        assert_eq!((id_a, id_b, id_c), (1, 2, 3));
+
+        // The union path reads `config.min_union_iter_heap`, which the zero-init
+        // `QueryEvalCtx` leaves NULL; provide a real config.
+        let qctx = context.qctx();
+        let mut cfg = IteratorsConfig {
+            max_prefix_expansions: 200,
+            min_term_prefix: 2,
+            min_stem_length: 4,
+            min_union_iter_heap: 20,
+        };
+        // SAFETY: `qctx` is a valid, exclusively-owned `QueryEvalCtx`; `cfg`
+        // outlives `ctx` below and has the same layout as the C config.
+        unsafe { (*qctx.as_ptr()).config = (&mut cfg as *mut IteratorsConfig).cast() };
+        let mut ctx = unsafe { QueryEvalContext::new(qctx) };
+
+        // child 1 matches {doc_a, doc_b}; child 2 matches {doc_b, doc_c}; the
+        // union is {doc_a, doc_b, doc_c}.
+        let keys1: Vec<ffi::sds> = vec![new_sds("doc_a"), new_sds("doc_b")];
+        let keys2: Vec<ffi::sds> = vec![new_sds("doc_b"), new_sds("doc_c")];
+        let mut c1 = MockQueryNode::new(QueryNodeType::Ids);
+        c1.set_ids(keys1.as_ptr(), std::ptr::null_mut(), keys1.len());
+        let mut c2 = MockQueryNode::new(QueryNodeType::Ids);
+        c2.set_ids(keys2.as_ptr(), std::ptr::null_mut(), keys2.len());
+
+        let mut union = MockQueryNode::new(QueryNodeType::Union);
+        union.opts_mut().weight = 1.0;
+        union.set_children(&[c1.as_ptr(), c2.as_ptr()]);
+        let node = unsafe { QueryNodeRef::new(union.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node)
+            .expect("should not be None")
+            .into_boxed();
+
+        assert_eq!(it.type_(), IteratorType::Union);
+        for expected in [1, 2, 3] {
+            let r = it.read().unwrap().expect("should have a result");
+            assert_eq!(r.doc_id, expected);
+        }
+        assert!(matches!(it.read(), Ok(None)));
+
+        for key in keys1.into_iter().chain(keys2) {
+            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
+            unsafe { ffi::sdsfree(key) };
+        }
+    }
+
+    #[test]
+    fn eval_union_none_child_dropped() {
+        let _guard = GlobalGuard::default();
+        // A union child that evaluates to `None` (a QN_MISSING node for a field
+        // with no missing values) yields a NULL child pointer, which the
+        // multi-child path substitutes with a freshly built `Empty` iterator.
+        // The union reducer then strips that empty child, leaving the single
+        // real child — so the union collapses to it.
+        let context = TestContext::term(IndexFlags_Index_StoreFreqs, std::iter::empty(), false);
+
+        let id_a = context.add_document("doc_a");
+        let id_b = context.add_document("doc_b");
+        assert_eq!((id_a, id_b), (1, 2));
+
+        // The union path reads `config.min_union_iter_heap`, which the zero-init
+        // `QueryEvalCtx` leaves NULL; provide a real config.
+        let qctx = context.qctx();
+        let mut cfg = IteratorsConfig {
+            max_prefix_expansions: 200,
+            min_term_prefix: 2,
+            min_stem_length: 4,
+            min_union_iter_heap: 20,
+        };
+        // SAFETY: `qctx` is a valid, exclusively-owned `QueryEvalCtx`; `cfg`
+        // outlives `ctx` below and has the same layout as the C config.
+        unsafe { (*qctx.as_ptr()).config = (&mut cfg as *mut IteratorsConfig).cast() };
+        let mut ctx = unsafe { QueryEvalContext::new(qctx) };
+
+        // child 1: QN_MISSING for a field with no missing values → None.
+        let mut missing_child = MockQueryNode::new(QueryNodeType::Missing);
+        missing_child.set_missing_field(context.field_spec());
+        // child 2: QN_IDS resolving to a real document.
+        let keys: Vec<ffi::sds> = vec![new_sds("doc_a")];
+        let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
+        ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
+
+        let mut union = MockQueryNode::new(QueryNodeType::Union);
+        union.opts_mut().weight = 1.0;
+        union.set_children(&[missing_child.as_ptr(), ids_child.as_ptr()]);
+        let node = unsafe { QueryNodeRef::new(union.as_non_null()) };
+
+        let mut it = eval::eval_node(&mut ctx, &node)
+            .expect("a multi-child union always yields an iterator")
+            .into_boxed();
+
+        // The empty child was dropped, leaving the single QN_IDS child, to which
+        // the union collapses.
+        assert_eq!(it.type_(), IteratorType::IdListSorted);
+        let r = it.read().unwrap().expect("should have a result");
+        assert_eq!(r.doc_id, 1);
+        assert!(matches!(it.read(), Ok(None)));
+
+        for key in keys {
+            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
+            unsafe { ffi::sdsfree(key) };
+        }
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -174,6 +174,17 @@ impl CRQEIterator {
         let self_ = ManuallyDrop::new(self);
         self_.header
     }
+
+    /// Return the raw pointer to the underlying [`QueryIterator`] without
+    /// consuming `self`.
+    ///
+    /// Unlike [`Self::into_raw`], `self` retains ownership: the returned pointer
+    /// aliases the one owned by `self`, so it must not be freed while `self` is
+    /// still live, nor used to construct a second owning [`CRQEIterator`] unless
+    /// ownership is first relinquished (e.g. by overwriting `self` in place).
+    pub const fn as_raw(&self) -> NonNull<QueryIterator> {
+        self.header
+    }
 }
 
 impl<'index> RQEIterator<'index> for CRQEIterator {

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -371,44 +371,20 @@ pub unsafe fn build_union(
 ) -> *mut QueryIterator {
     use crate::union_reducer::{NewUnionIterator, new_union_iterator};
 
-    match new_union_iterator(children, quick_exit, min_union_iter_heap) {
-        NewUnionIterator::ReducedEmpty(empty) => RQEIteratorWrapper::boxed_new(empty),
-        NewUnionIterator::ReducedSingle(child) => child.into_raw().as_ptr(),
-        NewUnionIterator::Flat(flat) => {
-            let mut dispatch = UnionOpaque {
-                variant: UnionVariant::FlatFull(flat),
-                query_node_type: type_,
-                query_string: q_str,
-            };
-            dispatch.set_result_weight(weight);
-            RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children))
-        }
-        NewUnionIterator::FlatQuick(flat) => {
-            let mut dispatch = UnionOpaque {
-                variant: UnionVariant::FlatQuick(flat),
-                query_node_type: type_,
-                query_string: q_str,
-            };
-            dispatch.set_result_weight(weight);
-            RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children))
-        }
-        NewUnionIterator::Heap(heap) => {
-            let mut dispatch = UnionOpaque {
-                variant: UnionVariant::HeapFull(heap),
-                query_node_type: type_,
-                query_string: q_str,
-            };
-            dispatch.set_result_weight(weight);
-            RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children))
-        }
-        NewUnionIterator::HeapQuick(heap) => {
-            let mut dispatch = UnionOpaque {
-                variant: UnionVariant::HeapQuick(heap),
-                query_node_type: type_,
-                query_string: q_str,
-            };
-            dispatch.set_result_weight(weight);
-            RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children))
-        }
-    }
+    let variant = match new_union_iterator(children, quick_exit, min_union_iter_heap) {
+        NewUnionIterator::ReducedEmpty(empty) => return RQEIteratorWrapper::boxed_new(empty),
+        NewUnionIterator::ReducedSingle(child) => return child.into_raw().as_ptr(),
+        NewUnionIterator::Flat(flat) => UnionVariant::FlatFull(flat),
+        NewUnionIterator::FlatQuick(flat) => UnionVariant::FlatQuick(flat),
+        NewUnionIterator::Heap(heap) => UnionVariant::HeapFull(heap),
+        NewUnionIterator::HeapQuick(heap) => UnionVariant::HeapQuick(heap),
+    };
+
+    let mut dispatch = UnionOpaque {
+        variant,
+        query_node_type: type_,
+        query_string: q_str,
+    };
+    dispatch.set_result_weight(weight);
+    RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children))
 }

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -346,18 +346,12 @@ unsafe extern "C" fn union_profile_children(base: *mut QueryIterator) -> *mut Qu
 ///
 /// # Safety
 ///
-/// The caller must uphold the following:
-///
-/// 1. `q_str`, when [`Some`], must stay live and unchanged for as long as the
-///    returned iterator exists. The borrow is stored in the [`UnionOpaque`] and
-///    read back when the C-driven profiler prints the iterator, but its
-///    `'index` lifetime is erased once the iterator is leaked to a raw
-///    `*mut QueryIterator`, so the borrow checker cannot enforce this — the
-///    caller must guarantee the string outlives the returned iterator.
-/// 2. `type_` is one of the union-compatible query node types understood by the
-///    profile printer (`Geo`, `Tag`, `Union`, `Fuzzy`, `Prefix`, `Numeric`,
-///    `LexRange`, `WildcardQuery`); any other discriminant aborts profile
-///    printing via an `unreachable!`.
+/// `q_str`, when [`Some`], must stay live and unchanged for as long as the
+/// returned iterator exists. The borrow is stored in the [`UnionOpaque`] and
+/// read back when the C-driven profiler prints the iterator, but its
+/// `'index` lifetime is erased once the iterator is leaked to a raw
+/// `*mut QueryIterator`, so the borrow checker cannot enforce this — the
+/// caller must guarantee the string outlives the returned iterator.
 pub unsafe fn build_union(
     children: Vec<CRQEIterator>,
     quick_exit: bool,

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -21,7 +21,7 @@
 //! and call methods such as [`UnionOpaque::num_children_active`] directly,
 //! without going through a C FFI trampoline.
 
-use std::{ffi::CStr, ptr::NonNull};
+use std::ffi::CStr;
 
 use ffi::{QueryIterator, QueryNodeType};
 use index_result::RSIndexResult;
@@ -312,17 +312,16 @@ unsafe extern "C" fn union_profile_children(base: *mut QueryIterator) -> *mut Qu
     // SAFETY: caller guarantees `base` is valid and points to a union wrapper.
     let wrapper = unsafe { UnionWrapper::mut_ref_from_header_ptr(base) };
     for child in wrapper.inner.children_mut() {
+        // Read the child's owning pointer without consuming the slot; ownership
+        // is moved out here and handed back in place below.
+        let it = child.as_raw();
+        // SAFETY: `it` is a valid, uniquely-owned C iterator; it is consumed
+        // here and replaced below, so it is neither leaked nor double-freed.
+        let profiled = unsafe { CRQEIterator::new(it) }.into_profiled();
         // `CRQEIterator` is `#[repr(transparent)]` over `NonNull<QueryIterator>`,
         // so a `&mut CRQEIterator` can be viewed as a `*mut *mut QueryIterator`
         // slot for in-place replacement.
         let slot = child as *mut CRQEIterator as *mut *mut QueryIterator;
-        // SAFETY: `slot` is a valid pointer to the child's owning iterator slot.
-        let raw = unsafe { *slot };
-        // SAFETY: the child slot holds a valid, non-null `QueryIterator`.
-        let it = unsafe { NonNull::new_unchecked(raw) };
-        // SAFETY: `it` is a valid, uniquely-owned C iterator; it is consumed
-        // here and replaced below, so it is neither leaked nor double-freed.
-        let profiled = unsafe { CRQEIterator::new(it) }.into_profiled();
         // SAFETY: `slot` is a valid, writable pointer; store the profiled
         // iterator back in place.
         unsafe { *slot = profiled.into_raw().as_ptr() };

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -21,7 +21,7 @@
 //! and call methods such as [`UnionOpaque::num_children_active`] directly,
 //! without going through a C FFI trampoline.
 
-use std::{ffi::c_char, ptr::NonNull};
+use std::{ffi::CStr, ptr::NonNull};
 
 use ffi::{QueryIterator, QueryNodeType};
 use index_result::RSIndexResult;
@@ -118,14 +118,15 @@ macro_rules! delegate_variant_ref_mut {
 pub struct RawUnionOpaque<Rf: Ref, I> {
     pub variant: RawUnionVariant<Rf, I>,
     pub query_node_type: QueryNodeType,
-    /// Non-owning pointer to a C string describing the query (e.g. the search
-    /// term). May be null.
+    /// Borrowed C string describing the query (e.g. the search term), or
+    /// [`None`] when the union has no associated query string.
     ///
-    /// The pointee is owned by the query AST and must outlive this iterator.
-    /// In practice the AST is freed only after the entire query execution
-    /// pipeline — including all iterators — has been torn down, so the
-    /// pointer remains valid for the lifetime of this struct.
-    pub query_string: *const c_char,
+    /// The string is owned by the query AST, not the index; the `'index`
+    /// lifetime is reused here because both the index and the AST outlive the
+    /// iterator. In practice the AST is freed only after the entire query
+    /// execution pipeline — including all iterators — has been torn down, so
+    /// the borrow remains valid for the lifetime of this struct.
+    pub query_string: Option<&'index CStr>,
 }
 
 /// Alias for an [`Active`] [`RawUnionOpaque`] — the only instantiation
@@ -231,8 +232,6 @@ where
     I: RQEIterator<'index> + ProfilePrint,
 {
     fn print_profile(&self, map: &mut redis_reply::MapBuilder<'_>, ctx: &mut ProfilePrintCtx<'_>) {
-        use std::ffi::CStr;
-
         let node_type = self.query_node_type;
         // Union, Geo, and LexRange always print full children even in
         // limited mode — these types have few enough children that
@@ -257,20 +256,19 @@ where
             _ => unreachable!("Invalid type for union"),
         };
 
-        let q_str_ptr = self.query_string;
-        if q_str_ptr.is_null() {
-            let value = std::ffi::CString::new(type_str).unwrap();
-            map.kv_simple_string(c"Query type", &value);
-        } else {
-            // SAFETY: q_str_ptr is a valid null-terminated C string (checked
-            // non-null). The pointee is owned by the query AST and outlives
-            // this iterator.
-            let q_str_rust = unsafe { CStr::from_ptr(q_str_ptr) }.to_string_lossy();
-            let formatted = format!("{type_str} - {q_str_rust}");
-            // Use string_buffer (bulk string) instead of simple_string: the
-            // query string may contain \r\n which is invalid in RESP Simple
-            // Strings.
-            map.kv_string_buffer(c"Query type", formatted.as_bytes());
+        match self.query_string {
+            None => {
+                let value = std::ffi::CString::new(type_str).unwrap();
+                map.kv_simple_string(c"Query type", &value);
+            }
+            Some(q_str) => {
+                let q_str_rust = q_str.to_string_lossy();
+                let formatted = format!("{type_str} - {q_str_rust}");
+                // Use string_buffer (bulk string) instead of simple_string: the
+                // query string may contain \r\n which is invalid in RESP Simple
+                // Strings.
+                map.kv_string_buffer(c"Query type", formatted.as_bytes());
+            }
         }
 
         ctx.print_optional_counters(map);
@@ -348,15 +346,14 @@ unsafe extern "C" fn union_profile_children(base: *mut QueryIterator) -> *mut Qu
 ///
 /// # Safety
 ///
-/// The caller must uphold the following for the lifetime of the returned
-/// iterator (the value is stored verbatim in the [`UnionOpaque`] and read back
-/// only when the C-driven profiler prints the iterator):
+/// The caller must uphold the following:
 ///
-/// 1. `q_str` is either null or a valid, NUL-terminated C string that stays
-///    live and unchanged for as long as the returned iterator exists. It is
-///    dereferenced via [`CStr::from_ptr`](std::ffi::CStr::from_ptr) during
-///    profile printing; a dangling, freed, or non-NUL-terminated non-null
-///    pointer is undefined behavior.
+/// 1. `q_str`, when [`Some`], must stay live and unchanged for as long as the
+///    returned iterator exists. The borrow is stored in the [`UnionOpaque`] and
+///    read back when the C-driven profiler prints the iterator, but its
+///    `'index` lifetime is erased once the iterator is leaked to a raw
+///    `*mut QueryIterator`, so the borrow checker cannot enforce this — the
+///    caller must guarantee the string outlives the returned iterator.
 /// 2. `type_` is one of the union-compatible query node types understood by the
 ///    profile printer (`Geo`, `Tag`, `Union`, `Fuzzy`, `Prefix`, `Numeric`,
 ///    `LexRange`, `WildcardQuery`); any other discriminant aborts profile
@@ -366,7 +363,7 @@ pub unsafe fn build_union(
     quick_exit: bool,
     min_union_iter_heap: usize,
     type_: QueryNodeType,
-    q_str: *const c_char,
+    q_str: Option<&CStr>,
     weight: f64,
 ) -> *mut QueryIterator {
     use crate::union_reducer::{NewUnionIterator, new_union_iterator};

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -25,7 +25,7 @@ use std::ffi::CStr;
 
 use ffi::{QueryIterator, QueryNodeType};
 use index_result::RSIndexResult;
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, SharedPtr};
 use rqe_core::DocId;
 
 use crate::{
@@ -121,12 +121,12 @@ pub struct RawUnionOpaque<Rf: Ref, I> {
     /// Borrowed C string describing the query (e.g. the search term), or
     /// [`None`] when the union has no associated query string.
     ///
-    /// The string is owned by the query AST, not the index; the `'index`
-    /// lifetime is reused here because both the index and the AST outlive the
-    /// iterator. In practice the AST is freed only after the entire query
+    /// The string is owned by the query AST, not the index; its validity is
+    /// tied to the [`Ref`] mode `Rf`, since both the index and the AST outlive
+    /// the iterator. In practice the AST is freed only after the entire query
     /// execution pipeline — including all iterators — has been torn down, so
     /// the borrow remains valid for the lifetime of this struct.
-    pub query_string: Option<&'index CStr>,
+    pub query_string: Option<SharedPtr<Rf, CStr>>,
 }
 
 /// Alias for an [`Active`] [`RawUnionOpaque`] — the only instantiation
@@ -262,7 +262,7 @@ where
                 map.kv_simple_string(c"Query type", &value);
             }
             Some(q_str) => {
-                let q_str_rust = q_str.to_string_lossy();
+                let q_str_rust = q_str.get().to_string_lossy();
                 let formatted = format!("{type_str} - {q_str_rust}");
                 // Use string_buffer (bulk string) instead of simple_string: the
                 // query string may contain \r\n which is invalid in RESP Simple
@@ -373,7 +373,7 @@ pub unsafe fn build_union(
     let mut dispatch = UnionOpaque {
         variant,
         query_node_type: type_,
-        query_string: q_str,
+        query_string: q_str.map(SharedPtr::from_ref),
     };
     dispatch.set_result_weight(weight);
     RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children))

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -10,7 +10,7 @@
 //! Dynamic dispatch wrapper over the concrete union variants.
 //!
 //! [`UnionOpaque`] is the type that sits behind every
-//! [`RQEIteratorWrapper`](crate::interop::RQEIteratorWrapper) produced by the
+//! [`RQEIteratorWrapper`] produced by the
 //! FFI `NewUnionIterator` constructor. It holds one of the five concrete
 //! union variants and forwards every [`RQEIterator`] call via match dispatch.
 //!
@@ -21,15 +21,17 @@
 //! and call methods such as [`UnionOpaque::num_children_active`] directly,
 //! without going through a C FFI trampoline.
 
-use std::ffi::c_char;
+use std::{ffi::c_char, ptr::NonNull};
 
-use ffi::QueryNodeType;
+use ffi::{QueryIterator, QueryNodeType};
 use index_result::RSIndexResult;
 use ref_mode::{Active, Ref};
 use rqe_core::DocId;
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, UnionFullFlat,
+    c2rust::CRQEIterator,
+    interop::RQEIteratorWrapper,
     profile_print::{ProfilePrint, ProfilePrintCtx},
     union_flat::RawUnionFlat,
     union_heap::RawUnionHeap,
@@ -288,6 +290,125 @@ where
             let msg = format!("The number of iterators in the union is {num_children}");
             let msg_cstr = std::ffi::CString::new(msg).unwrap();
             map.kv_simple_string(c"Child iterators", &msg_cstr);
+        }
+    }
+}
+
+/// Concrete [`RQEIteratorWrapper`] used to expose a [`UnionOpaque`] to C.
+type UnionWrapper<'index> = RQEIteratorWrapper<UnionOpaque<'index, CRQEIterator>>;
+
+/// `ProfileChildren` callback for union iterators.
+///
+/// Profiles each child in-place via
+/// [`CRQEIterator::into_profiled`](crate::c2rust::CRQEIterator::into_profiled),
+/// preserving the `UnionOpaque<CRQEIterator>` type so the C-side optimizer and
+/// profiler keep seeing the same layout. Returns the same pointer (mutation is
+/// in-place).
+///
+/// # Safety
+///
+/// `base` must be a valid, owning pointer to a `UnionWrapper` created via
+/// [`build_union`].
+unsafe extern "C" fn union_profile_children(base: *mut QueryIterator) -> *mut QueryIterator {
+    debug_assert!(!base.is_null());
+    // SAFETY: caller guarantees `base` is valid and points to a union wrapper.
+    let wrapper = unsafe { UnionWrapper::mut_ref_from_header_ptr(base) };
+    for child in wrapper.inner.children_mut() {
+        // `CRQEIterator` is `#[repr(transparent)]` over `NonNull<QueryIterator>`,
+        // so a `&mut CRQEIterator` can be viewed as a `*mut *mut QueryIterator`
+        // slot for in-place replacement.
+        let slot = child as *mut CRQEIterator as *mut *mut QueryIterator;
+        // SAFETY: `slot` is a valid pointer to the child's owning iterator slot.
+        let raw = unsafe { *slot };
+        // SAFETY: the child slot holds a valid, non-null `QueryIterator`.
+        let it = unsafe { NonNull::new_unchecked(raw) };
+        // SAFETY: `it` is a valid, uniquely-owned C iterator; it is consumed
+        // here and replaced below, so it is neither leaked nor double-freed.
+        let profiled = unsafe { CRQEIterator::new(it) }.into_profiled();
+        // SAFETY: `slot` is a valid, writable pointer; store the profiled
+        // iterator back in place.
+        unsafe { *slot = profiled.into_raw().as_ptr() };
+    }
+    base
+}
+
+/// Build a union iterator from a `Vec` of already-owned [`CRQEIterator`]
+/// children, returning a C-ABI [`QueryIterator`] pointer.
+///
+/// Applies the union reduction and variant-selection logic of
+/// [`new_union_iterator`](crate::union_reducer::new_union_iterator): empty
+/// children are removed, a single surviving child
+/// is returned directly, and multiple children are placed in a flat or heap
+/// union depending on `min_union_iter_heap`. The resulting wrapper carries the
+/// [`union_profile_children`] callback so the still-C-driven profiler can
+/// recurse into the children.
+///
+/// Shared by the FFI `NewUnionIterator` constructor and the Rust `query_eval`
+/// dispatcher so both build the identical C-boundary shape.
+///
+/// # Safety
+///
+/// The caller must uphold the following for the lifetime of the returned
+/// iterator (the value is stored verbatim in the [`UnionOpaque`] and read back
+/// only when the C-driven profiler prints the iterator):
+///
+/// 1. `q_str` is either null or a valid, NUL-terminated C string that stays
+///    live and unchanged for as long as the returned iterator exists. It is
+///    dereferenced via [`CStr::from_ptr`](std::ffi::CStr::from_ptr) during
+///    profile printing; a dangling, freed, or non-NUL-terminated non-null
+///    pointer is undefined behavior.
+/// 2. `type_` is one of the union-compatible query node types understood by the
+///    profile printer (`Geo`, `Tag`, `Union`, `Fuzzy`, `Prefix`, `Numeric`,
+///    `LexRange`, `WildcardQuery`); any other discriminant aborts profile
+///    printing via an `unreachable!`.
+pub unsafe fn build_union(
+    children: Vec<CRQEIterator>,
+    quick_exit: bool,
+    min_union_iter_heap: usize,
+    type_: QueryNodeType,
+    q_str: *const c_char,
+    weight: f64,
+) -> *mut QueryIterator {
+    use crate::union_reducer::{NewUnionIterator, new_union_iterator};
+
+    match new_union_iterator(children, quick_exit, min_union_iter_heap) {
+        NewUnionIterator::ReducedEmpty(empty) => RQEIteratorWrapper::boxed_new(empty),
+        NewUnionIterator::ReducedSingle(child) => child.into_raw().as_ptr(),
+        NewUnionIterator::Flat(flat) => {
+            let mut dispatch = UnionOpaque {
+                variant: UnionVariant::FlatFull(flat),
+                query_node_type: type_,
+                query_string: q_str,
+            };
+            dispatch.set_result_weight(weight);
+            RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children))
+        }
+        NewUnionIterator::FlatQuick(flat) => {
+            let mut dispatch = UnionOpaque {
+                variant: UnionVariant::FlatQuick(flat),
+                query_node_type: type_,
+                query_string: q_str,
+            };
+            dispatch.set_result_weight(weight);
+            RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children))
+        }
+        NewUnionIterator::Heap(heap) => {
+            let mut dispatch = UnionOpaque {
+                variant: UnionVariant::HeapFull(heap),
+                query_node_type: type_,
+                query_string: q_str,
+            };
+            dispatch.set_result_weight(weight);
+            RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children))
+        }
+        NewUnionIterator::HeapQuick(heap) => {
+            let mut dispatch = UnionOpaque {
+                variant: UnionVariant::HeapQuick(heap),
+                query_node_type: type_,
+                query_string: q_str,
+            };
+            dispatch.set_result_weight(weight);
+            RQEIteratorWrapper::boxed_new_inner(dispatch, Some(union_profile_children))
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
@@ -322,6 +322,7 @@ fn union_limited_lexrange_prints_full() {
 #[test]
 fn union_with_query_string() {
     use ffi::QueryNodeType;
+    use ref_mode::SharedPtr;
     use rqe_iterators::union_opaque::{UnionOpaque, UnionVariant};
 
     let mut replier = init();
@@ -331,7 +332,7 @@ fn union_with_query_string() {
     let iter = UnionOpaque {
         variant: UnionVariant::FlatFull(flat),
         query_node_type: QueryNodeType::Prefix,
-        query_string: Some(query_str.as_c_str()),
+        query_string: Some(SharedPtr::from_ref(query_str.as_c_str())),
     };
     let reply = print(&mut replier, &iter, false);
     insta::assert_debug_snapshot!(reply);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
@@ -246,7 +246,7 @@ fn union_full_print() {
     let iter = UnionOpaque {
         variant: UnionVariant::FlatFull(flat),
         query_node_type: QueryNodeType::Union,
-        query_string: std::ptr::null(),
+        query_string: None,
     };
     let reply = print(&mut replier, &iter, false);
     insta::assert_debug_snapshot!(reply);
@@ -267,7 +267,7 @@ fn union_limited_non_union_type() {
     let iter = UnionOpaque {
         variant: UnionVariant::FlatFull(flat),
         query_node_type: QueryNodeType::Tag,
-        query_string: std::ptr::null(),
+        query_string: None,
     };
     let reply = capture_single_reply(|| {
         let mut ctx = ProfilePrintCtx::new(true, false);
@@ -288,7 +288,7 @@ fn union_limited_geo_prints_full() {
     let iter = UnionOpaque {
         variant: UnionVariant::FlatFull(flat),
         query_node_type: QueryNodeType::Geo,
-        query_string: std::ptr::null(),
+        query_string: None,
     };
     let reply = capture_single_reply(|| {
         let mut ctx = ProfilePrintCtx::new(true, false);
@@ -309,7 +309,7 @@ fn union_limited_lexrange_prints_full() {
     let iter = UnionOpaque {
         variant: UnionVariant::FlatFull(flat),
         query_node_type: QueryNodeType::LexRange,
-        query_string: std::ptr::null(),
+        query_string: None,
     };
     let reply = capture_single_reply(|| {
         let mut ctx = ProfilePrintCtx::new(true, false);
@@ -331,7 +331,7 @@ fn union_with_query_string() {
     let iter = UnionOpaque {
         variant: UnionVariant::FlatFull(flat),
         query_node_type: QueryNodeType::Prefix,
-        query_string: query_str.as_ptr(),
+        query_string: Some(query_str.as_c_str()),
     };
     let reply = print(&mut replier, &iter, false);
     insta::assert_debug_snapshot!(reply);


### PR DESCRIPTION
- Based on top of https://github.com/RediSearch/RediSearch/pull/10314


Port the `QN_UNION` evaluation from C to the Rust.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
