### PR TITLE
Cache RedisJSON builds across CI jobs

### DIFF
--- a/.github/actions/build-rejson/action.yml
+++ b/.github/actions/build-rejson/action.yml
@@ -1,0 +1,128 @@
+name: Build RedisJSON (cached)
+description: |
+  Build RedisJSON and cache rejson.so, keyed on (resolved RedisJSON SHA,
+  platform, arch, sanitizer, coverage, pinned nightly toolchain). On a cache hit
+  the binary is restored; on a miss it is built and saved.
+
+  On completion $GITHUB_WORKSPACE/bin/rejson.so exists (built or restored) and
+  REJSON_PATH is exported to $GITHUB_ENV pointing at it, so later steps in the
+  job (flow tests, flaky-test enumeration) reuse it via setup_rejson.sh and skip
+  their own clone+build.
+inputs:
+  rejson-branch:
+    description: "RedisJSON git ref to build (branch, tag, or 40-char SHA)"
+    required: true
+  san:
+    description: "Sanitizer (empty or 'address')"
+    required: false
+    default: ""
+  cov:
+    description: "Coverage build (1) or not (0)"
+    required: false
+    default: "0"
+  cache_platform_id:
+    description: "Opaque identifier for the binary-compatible platform (container image or runner env)"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve RedisJSON SHA
+      id: resolve
+      shell: bash
+      env:
+        REJSON_REF: ${{ inputs.rejson-branch }}
+      run: |
+        if [[ "$REJSON_REF" =~ ^[0-9a-f]{40}$ ]]; then
+          SHA="$REJSON_REF"
+        else
+          SHA=$(git ls-remote https://github.com/RedisJSON/RedisJSON.git "$REJSON_REF" \
+                | awk 'NR==1 {print $1}')
+        fi
+        if [[ -z "$SHA" ]]; then
+          echo "Failed to resolve RedisJSON ref '$REJSON_REF' to a commit SHA" >&2
+          exit 1
+        fi
+        echo "Resolved $REJSON_REF -> $SHA"
+        echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+        # Absolute, in-container workspace path for the cached binary. Captured
+        # here from $GITHUB_WORKSPACE (the path the build runs in) rather than
+        # the github.workspace context, which resolves to the runner host path
+        # and is unreachable inside container jobs.
+        echo "binpath=$GITHUB_WORKSPACE/bin/rejson.so" >> "$GITHUB_OUTPUT"
+
+    - name: Compute cache key
+      id: key
+      shell: bash
+      env:
+        SHA: ${{ steps.resolve.outputs.sha }}
+        PLATFORM_ID: ${{ inputs.cache_platform_id }}
+        ARCH: ${{ runner.arch }}
+        SAN: ${{ inputs.san }}
+        COV: ${{ inputs.cov }}
+      run: |
+        SAN_LABEL="${SAN:-none}"
+        COV_LABEL="${COV:-0}"
+        # RedisJSON is compiled with the pinned nightly toolchain
+        # (setup_rejson.sh exports RUST_GOOD_NIGHTLY from .rust-nightly), so the
+        # toolchain is a build input: a nightly bump must invalidate the cached
+        # binary even when the RedisJSON SHA is unchanged.
+        NIGHTLY=$(tr -d '[:space:]' < "$GITHUB_WORKSPACE/.rust-nightly")
+        NIGHTLY_SAFE=$(echo "$NIGHTLY" | sed 's#[^A-Za-z0-9_.-]#-#g')
+        # Sanitize platform id for use in a cache key.
+        PLATFORM_SAFE=$(echo "$PLATFORM_ID" | sed 's#[^A-Za-z0-9_.-]#-#g')
+        KEY="rejson-${SHA}-${PLATFORM_SAFE}-${ARCH}-san_${SAN_LABEL}-cov_${COV_LABEL}-rust_${NIGHTLY_SAFE}"
+        echo "key=$KEY" >> "$GITHUB_OUTPUT"
+        echo "Cache key: $KEY"
+
+    - name: Restore cached RedisJSON
+      id: cache-restore
+      uses: actions/cache/restore@v5
+      with:
+        path: ${{ steps.resolve.outputs.binpath }}
+        key: ${{ steps.key.outputs.key }}
+
+    - name: Build RedisJSON (cache miss)
+      if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
+      # Login shell so the python venv created by install_python_deps.sh
+      # (activated via ~/.bash_profile) is on PATH — RedisJSON's readies-based
+      # Makefile needs python3.
+      shell: bash -leo pipefail {0}
+      env:
+        SAN: ${{ inputs.san }}
+        # Build the resolved SHA (not the moving branch ref) so the produced
+        # binary always matches the cache key.
+        REJSON_BRANCH: ${{ steps.resolve.outputs.sha }}
+      run: |
+        set -euo pipefail
+        # This action is the producer of bin/rejson.so. If the caller exports
+        # REJSON_PATH (e.g. job-level, so consumer steps reuse the binary),
+        # setup_rejson.sh would short-circuit and skip the build — so clear it
+        # here to force an actual build.
+        unset REJSON_PATH
+        # Build into scratch space so RedisJSON's own build tree (cargo target
+        # dir, object files) never enters the artifact — we copy out only the .so.
+        export ROOT="$GITHUB_WORKSPACE"
+        export BINROOT="$RUNNER_TEMP/rejson-build"
+        mkdir -p "$BINROOT"
+        mkdir -p "$GITHUB_WORKSPACE/bin"
+        source "$GITHUB_WORKSPACE/tests/deps/setup_rejson.sh"
+        cp "$JSON_BIN_PATH" "$GITHUB_WORKSPACE/bin/rejson.so"
+        ls -lh "$GITHUB_WORKSPACE/bin/rejson.so"
+
+    - name: Save RedisJSON to cache
+      if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ steps.resolve.outputs.binpath }}
+        key: ${{ steps.key.outputs.key }}
+
+    - name: Expose RedisJSON via REJSON_PATH
+      shell: bash
+      # Hand the absolute, container-correct path to downstream consumers (flow
+      # tests, flaky-test enumeration) so setup_rejson.sh reuses this binary
+      # instead of cloning + building. Runs on both cache hit and miss. Uses
+      # $GITHUB_WORKSPACE (the in-container workspace), not the github.workspace
+      # context (the runner host path, unreachable in container jobs).
+      run: |
+        echo "REJSON_PATH=$GITHUB_WORKSPACE/bin/rejson.so" >> "$GITHUB_ENV"

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -353,6 +353,20 @@ jobs:
           coverage: ${{ inputs.coverage }}
           cache_platform_id: ${{ needs.get-config.outputs.container || needs.get-config.outputs.env }}
 
+      # Build RedisJSON once and cache it, restoring on subsequent runs with the
+      # same key. Produces bin/rejson.so and exports REJSON_PATH, which the
+      # flow-test and flaky-test-enumeration steps reuse instead of rebuilding.
+      # Gated on a flow-test consumer (standalone/coordinator) so unit-test-only
+      # runs don't build RedisJSON they never use.
+      - name: Build RedisJSON (cached)
+        if: ${{ !inputs.skip-tests && inputs.rejson && (inputs.standalone || inputs.coordinator) }}
+        uses: ./.github/actions/build-rejson
+        with:
+          rejson-branch: ${{ inputs.rejson-branch }}
+          san: ${{ inputs.san }}
+          cov: ${{ inputs.coverage && '1' || '0' }}
+          cache_platform_id: ${{ needs.get-config.outputs.container || needs.get-config.outputs.env }}
+
       - name: Set Artifact Names
         # Artifact names have to be unique, so we base them on the environment.
         # We also remove invalid characters from the name.

--- a/tests/deps/setup_rejson.sh
+++ b/tests/deps/setup_rejson.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 
-# Function to run a command, and only if it fails, print stdout and stderr and then exit
+# Function to run a command, and only if it fails, print stdout and stderr and then exit.
+# The `|| status=$?` keeps this working when the caller has `set -e`: a bare
+# `output=$(...)` assignment would abort the script on a non-zero substitution
+# before we could print the captured output, hiding the failure.
 run_command() {
-  output=$(eval "$@" 2>&1)
-  status=$?
-  if [ $status -ne 0 ]; then
+  local output status=0
+  output=$(eval "$@" 2>&1) || status=$?
+  if [ "$status" -ne 0 ]; then
     echo "$output"
-    exit $status
+    exit "$status"
   fi
 }
 
@@ -16,6 +19,12 @@ ROOT=${ROOT:=$CURR_DIR}  # unless ROOT is set, assume it is the current director
 BINROOT=${BINROOT:=${ROOT}/bin/linux-x64-release}
 
 JSON_BRANCH=${REJSON_BRANCH:-master}
+# Optional path to a prebuilt rejson.so. When non-empty, the build below is
+# skipped and this binary is reused (consumer jobs set it); empty means build
+# from source. Declared with a default so callers that source this under
+# `set -u` without setting it (e.g. the producer build job) don't trip on an
+# unbound variable.
+REJSON_PATH=${REJSON_PATH:-}
 JSON_REPO_URL="https://github.com/RedisJSON/RedisJSON.git"
 TEST_DEPS_DIR="${ROOT}/tests/deps"
 JSON_MODULE_DIR="${TEST_DEPS_DIR}/RedisJSON"


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** Flow-test jobs clone and build RedisJSON from source inside `make pytest` (via `tests/deps/setup_rejson.sh`). Every matrix variant and every re-run rebuilds the same `rejson.so` from scratch — there is no caching.
2. **Change:** Add a reusable composite action (`.github/actions/build-rejson`, mirroring `build-redis`) that builds RedisJSON once per `(resolved SHA, platform, arch, sanitizer, coverage, pinned nightly)` tuple and restores `rejson.so` from the GitHub Actions cache on subsequent runs with the same key. Wire it into `task-test.yml`: a "Build RedisJSON (cached)" step produces `bin/rejson.so` before the test steps and exports `REJSON_PATH` (via `$GITHUB_ENV`) so every consumer in the job — the flow tests **and** the flaky-test enumeration — reuses the binary instead of rebuilding. `setup_rejson.sh` is hardened to honor a prebuilt `REJSON_PATH` (skip clone+build), declare `REJSON_PATH` with a default so it is `set -u` safe, and make `run_command` `set -e` safe.
3. **Outcome:** RedisJSON is built at most once per job (both flow-test steps share the binary) and the cache deduplicates work across re-runs and warm-cache jobs. Coverage is part of the cache key, so a coverage run and a non-coverage run never read each other's entry.

Notes:
- **Container-correct paths:** the cache `path:` and the exported `REJSON_PATH` are both derived from `$GITHUB_WORKSPACE` (the in-container workspace), not the `${{ github.workspace }}` context (which is the runner *host* path, unreachable inside container jobs). This matches how `build-redis` handles the same problem.
- The action clears `REJSON_PATH` internally before building, so the value handed to *consumers* can never short-circuit the *producer*. The build step is gated on a flow-test consumer (`standalone || coordinator`) so unit-only runs don't build RedisJSON they never use.
- **Cold-cache caveat:** the cache does not serialize concurrent jobs. Since PRs run standalone and coordinator as separate parallel jobs, on a cold cache each may build RedisJSON before either saves; warm runs reuse it. True "build once per fan-out" needs a dedicated producer job + artifact — that is the build/test-split work, tracked separately.
- The `build-rejson` action and `setup_rejson.sh` hardening are reused as-is by that upcoming split; only the `task-test.yml` wiring here is superseded by it.

#### Which additional issues this PR fixes

_None._

#### Main objects this PR modified

1. `.github/actions/build-rejson/action.yml` (new composite action)
2. `.github/workflows/task-test.yml` (cached build step; exports `REJSON_PATH`)
3. `tests/deps/setup_rejson.sh`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)