### PR TITLE
benchmark-flow: add label to override base branch

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -215,10 +215,17 @@ jobs:
         # block instead of an empty table, and the cross-arch section
         # auto-suppresses. The last-to-finish upsert wins -- same behavior
         # as today, but with the richer multi-arch body.
+        #
+        # The baseline branch is normally the PR's base branch, but adding the
+        # 'bench:vs-master' label forces the comparison against master
+        # instead. This is for stacked PRs: when a PR is based on another PR's
+        # branch, the default base-branch comparison only shows the delta of
+        # this PR on top of its parent. Baselining against master instead shows
+        # the cumulative performance impact of the whole stack.
         run: redisbench-admin compare
               --defaults_filename ./tests/benchmarks/defaults.yml
               --comparison-branch ${{ github.event.pull_request.head.ref || github.ref_name }}
-              --baseline-branch ${{ github.event.pull_request.base.ref }}
+              --baseline-branch ${{ contains(github.event.pull_request.labels.*.name, 'bench:vs-master') && 'master' || github.event.pull_request.base.ref }}
               --architectures x86_64,aarch64
               --auto-approve
               --pull-request ${{ github.event.number }}

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -43,6 +43,10 @@ on:
         type: string
         default: x86_64
         description: "CPU arch the built .so targets. Passed to `redisbench-admin run-remote --architecture <arch>` so terraform picks the matching oss-standalone-redisearch-m7[-aarch64] dir. Valid: `x86_64` | `aarch64`."
+      base_branch:
+        type: string
+        default: ""
+        description: "Branch to use as the comparison baseline. Empty falls back to the PR base branch."
 
 jobs:
   benchmark-steps:
@@ -216,16 +220,17 @@ jobs:
         # auto-suppresses. The last-to-finish upsert wins -- same behavior
         # as today, but with the richer multi-arch body.
         #
-        # The baseline branch is normally the PR's base branch, but adding the
-        # 'bench:vs-master' label forces the comparison against master
-        # instead. This is for stacked PRs: when a PR is based on another PR's
-        # branch, the default base-branch comparison only shows the delta of
-        # this PR on top of its parent. Baselining against master instead shows
-        # the cumulative performance impact of the whole stack.
+        # The baseline branch is decided by the caller (benchmark-trigger.yml):
+        # normally the PR base branch, or master when the 'bench:vs-master'
+        # label is set. This is for stacked PRs: when a PR is based on another
+        # PR's branch, the default base-branch comparison only shows the delta
+        # of this PR on top of its parent. Baselining against master instead
+        # shows the cumulative performance impact of the whole stack. Fall back
+        # to the PR base branch when no baseline is passed (e.g. workflow_dispatch).
         run: redisbench-admin compare
               --defaults_filename ./tests/benchmarks/defaults.yml
               --comparison-branch ${{ github.event.pull_request.head.ref || github.ref_name }}
-              --baseline-branch ${{ contains(github.event.pull_request.labels.*.name, 'bench:vs-master') && 'master' || github.event.pull_request.base.ref }}
+              --baseline-branch ${{ inputs.base_branch || github.event.pull_request.base.ref }}
               --architectures x86_64,aarch64
               --auto-approve
               --pull-request ${{ github.event.number }}

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -21,6 +21,10 @@ on:
         type: string
         default: master
         description: "branch to use for rejson"
+      base_branch:
+        type: string
+        default: ""
+        description: "Branch to use as the comparison baseline. Empty falls back to the PR base branch."
   workflow_call:
     inputs:
       extended:
@@ -37,6 +41,10 @@ on:
         type: boolean
         default: false
         description: "if true, will notify failure on slack"
+      base_branch:
+        type: string
+        default: ""
+        description: "Branch to use as the comparison baseline. Empty falls back to the PR base branch."
 
 jobs:
   # Build RediSearch ONCE per-arch. Every benchmark job below downloads the
@@ -77,6 +85,7 @@ jobs:
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+      base_branch: ${{ inputs.base_branch }}
 
   # aarch64 sibling of benchmark-search-oss-standalone. Targets the
   # oss-standalone-redisearch-m7-aarch64 terraform dir (m7g.8xlarge DB +
@@ -101,6 +110,7 @@ jobs:
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-aarch64-${{ github.run_id }}-${{ github.run_attempt }}
+      base_branch: ${{ inputs.base_branch }}
 
   benchmark-search-oss-standalone-threads-6:
     # TODO: Temporarily disabled - Redis becomes unavailable after ~3 hours of data loading.
@@ -120,6 +130,7 @@ jobs:
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+      base_branch: ${{ inputs.base_branch }}
 
   benchmark-vecsim-oss-standalone:
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone' }}
@@ -138,6 +149,7 @@ jobs:
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+      base_branch: ${{ inputs.base_branch }}
 
   benchmark-vecsim-oss-standalone-threads-6:
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone-threads-6' }}
@@ -156,6 +168,7 @@ jobs:
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+      base_branch: ${{ inputs.base_branch }}
 
   benchmark-search-oss-cluster-02-primaries:
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-02-primaries' }}
@@ -174,6 +187,7 @@ jobs:
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+      base_branch: ${{ inputs.base_branch }}
 
   benchmark-search-oss-cluster-04-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-04-primaries') }}
@@ -192,6 +206,7 @@ jobs:
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+      base_branch: ${{ inputs.base_branch }}
 
   benchmark-search-oss-cluster-04-primaries-threads-6:
     # TODO: Temporarily disabled - Redis becomes unavailable after ~3 hours of data loading.
@@ -211,6 +226,7 @@ jobs:
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+      base_branch: ${{ inputs.base_branch }}
 
   benchmark-search-oss-cluster-08-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-08-primaries') }}
@@ -229,6 +245,7 @@ jobs:
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+      base_branch: ${{ inputs.base_branch }}
 
   benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8:
     if: ${{ inputs.allowed_setup == 'oss-cluster-08-primaries-250gb-threads-8' }}
@@ -241,6 +258,7 @@ jobs:
       allowed_envs: oss-cluster
       allowed_setups: oss-cluster-08-primaries-250gb-threads-8
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+      base_branch: ${{ inputs.base_branch }}
 
   benchmark-search-oss-cluster-16-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-16-primaries') }}
@@ -259,6 +277,7 @@ jobs:
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+      base_branch: ${{ inputs.base_branch }}
 
   benchmark-search-oss-cluster-20-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-20-primaries') }}
@@ -277,6 +296,7 @@ jobs:
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+      base_branch: ${{ inputs.base_branch }}
 
   benchmark-search-oss-cluster-24-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-24-primaries') }}
@@ -295,6 +315,7 @@ jobs:
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+      base_branch: ${{ inputs.base_branch }}
 
   benchmark-hybrid-oss-standalone:
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone' }}
@@ -313,6 +334,7 @@ jobs:
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+      base_branch: ${{ inputs.base_branch }}
 
   triage-benchmark-failures:
     needs:

--- a/.github/workflows/benchmark-trigger.yml
+++ b/.github/workflows/benchmark-trigger.yml
@@ -30,6 +30,10 @@ jobs:
       id-token: write # OIDC role assumption for sccache S3 (used inside flow-build-benchmark-binary.yml)
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit
+    with:
+      # Baseline against master when the 'bench:vs-master' label is set (for
+      # stacked PRs), otherwise against the PR base branch.
+      base_branch: ${{ contains(github.event.pull_request.labels.*.name, 'bench:vs-master') && 'master' || github.event.pull_request.base.ref }}
 
   msmarco-benchmark:
     name: Trigger MS MARCO Benchmark
@@ -56,6 +60,9 @@ jobs:
     secrets: inherit
     with:
       allowed_setup: oss-cluster-08-primaries-250gb-threads-8
+      # Baseline against master when the 'bench:vs-master' label is set (for
+      # stacked PRs), otherwise against the PR base branch.
+      base_branch: ${{ contains(github.event.pull_request.labels.*.name, 'bench:vs-master') && 'master' || github.event.pull_request.base.ref }}
 
   rust-micro-benchmarks:
     name: Trigger Rust Micro Benchmarks

--- a/.github/workflows/benchmark-trigger.yml
+++ b/.github/workflows/benchmark-trigger.yml
@@ -16,6 +16,10 @@ jobs:
       ) || (
         contains(fromJson('["opened", "reopened", "synchronize"]'), github.event.action) &&
         contains(github.event.pull_request.labels.*.name, 'action:run-benchmark')
+      ) || (
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'bench:vs-master' &&
+        contains(github.event.pull_request.labels.*.name, 'action:run-benchmark')
       )
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.number }}-benchmark
@@ -35,6 +39,10 @@ jobs:
         github.event.label.name == 'action:run-msmarco-benchmark'
       ) || (
         contains(fromJson('["opened", "reopened", "synchronize"]'), github.event.action) &&
+        contains(github.event.pull_request.labels.*.name, 'action:run-msmarco-benchmark')
+      ) || (
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'bench:vs-master' &&
         contains(github.event.pull_request.labels.*.name, 'action:run-msmarco-benchmark')
       )
     concurrency:
@@ -90,6 +98,13 @@ jobs:
       ) || (
         contains(fromJson('["opened", "reopened", "synchronize"]'), github.event.action) &&
         contains(github.event.pull_request.labels.*.name, 'action:run-c-micro-benchmark')
+      ) || (
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'bench:vs-master' &&
+        (
+          contains(github.event.pull_request.labels.*.name, 'action:run-micro-benchmark') ||
+          contains(github.event.pull_request.labels.*.name, 'action:run-c-micro-benchmark')
+        )
       )
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.number }}-micro-benchmark

--- a/.github/workflows/benchmark-trigger.yml
+++ b/.github/workflows/benchmark-trigger.yml
@@ -114,3 +114,7 @@ jobs:
       id-token: write # OIDC role assumption for sccache S3 (used inside flow-micro-benchmarks-runner.yml)
     uses: ./.github/workflows/flow-micro-benchmarks.yml
     secrets: inherit
+    with:
+      # Baseline against master when the 'bench:vs-master' label is set (for
+      # stacked PRs), otherwise against the PR base branch.
+      base_branch: ${{ contains(github.event.pull_request.labels.*.name, 'bench:vs-master') && 'master' || github.event.pull_request.base.ref }}

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -94,10 +94,15 @@ jobs:
           sudo apt install python3-pip -y
           pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.14
       - name: Compare benchmark results
+        # The baseline branch is normally the PR's base branch, but adding the
+        # 'bench:vs-master' label forces the comparison against master instead,
+        # so a stacked PR shows the cumulative impact of the whole stack rather
+        # than just the delta on top of its parent. Kept in sync with the macro
+        # benchmark flow in benchmark-flow.yml.
         run: |
           redisbench-admin compare \
           --comparison-branch ${{ github.event.pull_request.head.ref || github.ref_name }} \
-          --baseline-branch ${{ github.event.pull_request.base.ref }} \
+          --baseline-branch ${{ contains(github.event.pull_request.labels.*.name, 'bench:vs-master') && 'master' || github.event.pull_request.base.ref }} \
           --auto-approve \
           --pull-request ${{ github.event.number }} \
           --redistimeseries_host ${{ secrets.PERFORMANCE_RTS_HOST }} \

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: 'all'
         description: 'Run only on specific architecture'
+      base_branch:
+        type: string
+        required: false
+        default: ''
+        description: 'Branch to use as the comparison baseline. Empty falls back to the PR base branch.'
   workflow_dispatch:
     inputs:
       architecture:
@@ -94,15 +99,14 @@ jobs:
           sudo apt install python3-pip -y
           pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.14
       - name: Compare benchmark results
-        # The baseline branch is normally the PR's base branch, but adding the
-        # 'bench:vs-master' label forces the comparison against master instead,
-        # so a stacked PR shows the cumulative impact of the whole stack rather
-        # than just the delta on top of its parent. Kept in sync with the macro
-        # benchmark flow in benchmark-flow.yml.
+        # The baseline branch is decided by the caller (benchmark-trigger.yml):
+        # normally the PR base branch, or master when the 'bench:vs-master'
+        # label is set. Fall back to the PR base branch when no baseline is
+        # passed (e.g. workflow_dispatch runs).
         run: |
           redisbench-admin compare \
           --comparison-branch ${{ github.event.pull_request.head.ref || github.ref_name }} \
-          --baseline-branch ${{ contains(github.event.pull_request.labels.*.name, 'bench:vs-master') && 'master' || github.event.pull_request.base.ref }} \
+          --baseline-branch ${{ inputs.base_branch || github.event.pull_request.base.ref }} \
           --auto-approve \
           --pull-request ${{ github.event.number }} \
           --redistimeseries_host ${{ secrets.PERFORMANCE_RTS_HOST }} \


### PR DESCRIPTION
When stacking PRs we usually want to compare performance against master rather than the PR base.
The `bench:vs-master` label can now be set for this use case.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
