### PR TITLE
[MOD-14988] Use accessors to avoid explosing fields - part 2

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -869,7 +869,7 @@ DEBUG_COMMAND(DumpSuffix) {
       RedisModule_ReplyWithEmptyArray(sctx->redisCtx);
       goto end;
     }
-    if (!idx->suffix) {
+    if (!TagIndex_HasSuffix(idx)) {
       RedisModule_ReplyWithError(sctx->redisCtx, "tag field does have suffix trie");
       goto end;
     }

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -869,7 +869,9 @@ DEBUG_COMMAND(DumpSuffix) {
       RedisModule_ReplyWithEmptyArray(sctx->redisCtx);
       goto end;
     }
-    if (!TagIndex_HasSuffix(idx)) {
+
+    TrieMapIterator *it = TagIndex_IterateSuffix(idx);
+    if (!it) {
       RedisModule_ReplyWithError(sctx->redisCtx, "tag field does have suffix trie");
       goto end;
     }
@@ -877,7 +879,6 @@ DEBUG_COMMAND(DumpSuffix) {
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
     long resultSize = 0;
 
-    TrieMapIterator *it = TrieMap_Iterate(idx->suffix);
     char *str;
     tm_len_t len;
     void *value;

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -794,7 +794,7 @@ DEBUG_COMMAND(DumpTagIndex) {
   }
 
   // Debug dump not supported for disk-mode tag indexes (TrieMap contains NULL sentinels)
-  if (tagIndex->diskSpec) {
+  if (TagIndex_HasDiskSpec(tagIndex)) {
     RedisModule_ReplyWithError(sctx->redisCtx, "DUMP_TAGIDX not supported for disk-mode indexes");
     goto end;
   }
@@ -1417,7 +1417,7 @@ DEBUG_COMMAND(InfoTagIndex) {
   }
 
   // Debug info not supported for disk-mode tag indexes (TrieMap contains NULL sentinels)
-  if (idx->diskSpec) {
+  if (TagIndex_HasDiskSpec(idx)) {
     RedisModule_ReplyWithError(sctx->redisCtx, "INFO_TAGIDX not supported for disk-mode indexes");
     goto end;
   }

--- a/src/document.c
+++ b/src/document.c
@@ -822,14 +822,11 @@ FIELD_PREPROCESSOR(tagPreprocessor) {
 }
 
 FIELD_BULK_INDEXER(tagIndexer) {
-  TagIndex *tidx = TagIndex_Ensure(&ctx->spec->fields[fs->index], ctx->spec->diskSpec);
+  bool withSuffix = FieldSpec_HasSuffixTrie(fs);
+  TagIndex *tidx = TagIndex_Ensure(&ctx->spec->fields[fs->index], ctx->spec->diskSpec, withSuffix);
   if (!tidx) {
     QueryError_SetError(status, QUERY_ERROR_CODE_GENERIC, "Could not open tag index for indexing");
     return -1;
-  }
-
-  if (FieldSpec_HasSuffixTrie(fs) && !TagIndex_HasSuffix(tidx)) {
-    tidx->suffix = NewTrieMap();
   }
 
   if (!TagIndex_Index(ctx->redisCtx, tidx, aCtx->disk.batch,

--- a/src/document.c
+++ b/src/document.c
@@ -828,7 +828,7 @@ FIELD_BULK_INDEXER(tagIndexer) {
     return -1;
   }
 
-  if (FieldSpec_HasSuffixTrie(fs) && !tidx->suffix) {
+  if (FieldSpec_HasSuffixTrie(fs) && !TagIndex_HasSuffix(tidx)) {
     tidx->suffix = NewTrieMap();
   }
 

--- a/src/document.c
+++ b/src/document.c
@@ -829,9 +829,8 @@ FIELD_BULK_INDEXER(tagIndexer) {
     return -1;
   }
 
-  if (!TagIndex_Index(ctx->redisCtx, tidx, aCtx->disk.batch,
-                      (const char **)fdata->tags, array_len(fdata->tags),
-                      aCtx->doc->docId, &ctx->spec->stats)) {
+  if (!TagIndex_Index(ctx->redisCtx, tidx, aCtx->disk.batch, (const char **)fdata->tags,
+                      array_len(fdata->tags), aCtx->doc->docId, &ctx->spec->stats)) {
     QueryError_SetError(status, QUERY_ERROR_CODE_GENERIC, "Tag indexing failed");
     return -1;
   }

--- a/src/fork_gc/tags.c
+++ b/src/fork_gc/tags.c
@@ -170,7 +170,7 @@ FGCError FGC_parentHandleTags(ForkGC *gc) {
 
       // Empty values (INDEXEMPTY) are never inserted into the suffix triemap, so skip the delete.
       if (TagIndex_HasSuffix(tagIdx) && tagValLen) {
-        deleteSuffixTrieMap(tagIdx->suffix, tagVal, tagValLen);
+        TagIndex_DeleteTagSuffix(tagIdx, tagVal, tagValLen);
       }
     }
 

--- a/src/fork_gc/tags.c
+++ b/src/fork_gc/tags.c
@@ -169,7 +169,7 @@ FGCError FGC_parentHandleTags(ForkGC *gc) {
       TagIndex_DeleteTagValue(tagIdx, tagVal, tagValLen);
 
       // Empty values (INDEXEMPTY) are never inserted into the suffix triemap, so skip the delete.
-      if (tagIdx->suffix && tagValLen) {
+      if (TagIndex_HasSuffix(tagIdx) && tagValLen) {
         deleteSuffixTrieMap(tagIdx->suffix, tagVal, tagValLen);
       }
     }

--- a/src/query.c
+++ b/src/query.c
@@ -1218,7 +1218,7 @@ static QueryIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
     TrieMapIterator_Free(it);
   } else {  // TAG field has suffix triemap
     arrayof(char **) arr =
-        TagIndex_SuffixTrieMap(idx, tok->str, tok->len, qn->pfx.prefix, q->sctx->time.timeout,
+        TagIndex_GetSuffixMatches(idx, tok->str, tok->len, qn->pfx.prefix, q->sctx->time.timeout,
                                q->sctx->time.skipTimeoutChecks);
     if (!arr) {
       rm_free(its);
@@ -1268,7 +1268,7 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
   bool fallbackBruteForce = false;
   if (TagIndex_HasSuffix(idx)) {
     // with suffix
-    arrayof(char *) arr = TagIndex_SuffixTrieMap_Wildcard(
+    arrayof(char *) arr = TagIndex_GetSuffixWildcardMatches(
         idx, tok->str, tok->len, q->sctx->time.timeout, q->config->maxPrefixExpansions,
         q->sctx->time.skipTimeoutChecks);
     if (!arr) {

--- a/src/query.c
+++ b/src/query.c
@@ -1216,9 +1216,10 @@ static QueryIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
     }
 
     TrieMapIterator_Free(it);
-  } else {    // TAG field has suffix triemap
-    arrayof(char**) arr = TagIndex_SuffixTrieMap(idx, tok->str, tok->len,
-                                                qn->pfx.prefix, q->sctx->time.timeout, q->sctx->time.skipTimeoutChecks);
+  } else {  // TAG field has suffix triemap
+    arrayof(char **) arr =
+        TagIndex_SuffixTrieMap(idx, tok->str, tok->len, qn->pfx.prefix, q->sctx->time.timeout,
+                               q->sctx->time.skipTimeoutChecks);
     if (!arr) {
       rm_free(its);
       return NULL;
@@ -1267,8 +1268,9 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
   bool fallbackBruteForce = false;
   if (TagIndex_HasSuffix(idx)) {
     // with suffix
-    arrayof(char*) arr = TagIndex_SuffixTrieMap_Wildcard(idx, tok->str, tok->len,
-                                                        q->sctx->time.timeout, q->config->maxPrefixExpansions, q->sctx->time.skipTimeoutChecks);
+    arrayof(char *) arr = TagIndex_SuffixTrieMap_Wildcard(
+        idx, tok->str, tok->len, q->sctx->time.timeout, q->config->maxPrefixExpansions,
+        q->sctx->time.skipTimeoutChecks);
     if (!arr) {
       // No matching terms
       rm_free(its);

--- a/src/query.c
+++ b/src/query.c
@@ -1267,7 +1267,7 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
   bool fallbackBruteForce = false;
   if (TagIndex_HasSuffix(idx)) {
     // with suffix
-    arrayof(char*) arr = GetList_SuffixTrieMap_Wildcard(idx->suffix, tok->str, tok->len,
+    arrayof(char*) arr = TagIndex_SuffixTrieMap_Wildcard(idx, tok->str, tok->len,
                                                         q->sctx->time.timeout, q->config->maxPrefixExpansions, q->sctx->time.skipTimeoutChecks);
     if (!arr) {
       // No matching terms

--- a/src/query.c
+++ b/src/query.c
@@ -1265,7 +1265,7 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
   QueryIterator **its = rm_malloc(itsCap * sizeof(*its));
 
   bool fallbackBruteForce = false;
-  if (idx->suffix) {
+  if (TagIndex_HasSuffix(idx)) {
     // with suffix
     arrayof(char*) arr = GetList_SuffixTrieMap_Wildcard(idx->suffix, tok->str, tok->len,
                                                         q->sctx->time.timeout, q->config->maxPrefixExpansions, q->sctx->time.skipTimeoutChecks);
@@ -1296,7 +1296,7 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
     }
   }
 
-  if (!idx->suffix || fallbackBruteForce) {
+  if (!TagIndex_HasSuffix(idx) || fallbackBruteForce) {
     // brute force wildcard query
     TrieMapIterator *it =
         TagIndex_IterateValuesWithFilter(idx, tok->str, tok->len, TAG_WILDCARD_MODE);

--- a/src/query.c
+++ b/src/query.c
@@ -1217,7 +1217,7 @@ static QueryIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
 
     TrieMapIterator_Free(it);
   } else {    // TAG field has suffix triemap
-    arrayof(char**) arr = GetList_SuffixTrieMap(idx->suffix, tok->str, tok->len,
+    arrayof(char**) arr = TagIndex_SuffixTrieMap(idx, tok->str, tok->len,
                                                 qn->pfx.prefix, q->sctx->time.timeout, q->sctx->time.skipTimeoutChecks);
     if (!arr) {
       rm_free(its);

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -584,7 +584,8 @@ impl TestContext {
             ptr::NonNull::new(fs as _).expect("FieldSpec should not be null");
 
         // Create TagIndex via the C API (uses Redis allocator for proper cleanup)
-        let tag_index_raw = unsafe { ffi::TagIndex_Ensure(field_spec.as_ptr(), ptr::null_mut()) };
+        let tag_index_raw =
+            unsafe { ffi::TagIndex_Ensure(field_spec.as_ptr(), ptr::null_mut(), false) };
         let tag_index = ptr::NonNull::new(tag_index_raw).expect("TagIndex should not be null");
 
         // Create the tag inverted index for "test_tag" via TagIndex_OpenIndex

--- a/src/spec.c
+++ b/src/spec.c
@@ -2864,7 +2864,7 @@ static void IndexSpec_EnsureTagDiskIndexes(IndexSpec *sp) {
   for (int i = 0; i < sp->numFields; i++) {
     FieldSpec *fs = &sp->fields[i];
     if (!FIELD_IS(fs, INDEXFLD_T_TAG)) continue;
-    TagIndex_Ensure(fs, sp->diskSpec);
+    TagIndex_Ensure(fs, sp->diskSpec, false);
   }
 }
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -2864,7 +2864,7 @@ static void IndexSpec_EnsureTagDiskIndexes(IndexSpec *sp) {
   for (int i = 0; i < sp->numFields; i++) {
     FieldSpec *fs = &sp->fields[i];
     if (!FIELD_IS(fs, INDEXFLD_T_TAG)) continue;
-    TagIndex_Ensure(fs, sp->diskSpec, false);
+    TagIndex_Ensure(fs, sp->diskSpec, FieldSpec_HasSuffixTrie(fs));
   }
 }
 

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -370,6 +370,10 @@ void TagIndex_IterateRangeValues(const TagIndex *idx, const char *min, int minle
                        ctx);
 }
 
+TrieMapIterator *TagIndex_IterateSuffix(TagIndex *idx) {
+  return idx->suffix ? TrieMap_Iterate(idx->suffix) : NULL;
+}
+
 /* Serialize all the tags in the index to the redis client */
 void TagIndex_SerializeValues(TagIndex *idx, RedisModuleCtx *ctx) {
   TrieMapIterator *it = TagIndex_IterateValues(idx);

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -359,6 +359,10 @@ int TagIndex_DeleteTagValue(TagIndex *idx, const char *tagVal, size_t tagValLen)
   return TrieMap_Delete(idx->values, tagVal, tagValLen, (void (*)(void *))InvertedIndex_Free);
 }
 
+void TagIndex_DeleteTagSuffix(TagIndex *idx, const char *tagVal, size_t tagValLen) {
+  deleteSuffixTrieMap(idx->suffix, tagVal, tagValLen);
+}
+
 TrieMapIterator *TagIndex_IterateValuesWithFilter(TagIndex *idx, const char *tagVal,
                                                  size_t tagValLen, tag_iter_mode mode) {
   return TrieMap_IterateWithFilter(idx->values, tagVal, tagValLen, (tm_iter_mode)mode);

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -32,11 +32,11 @@ static uint32_t tagUniqueId = 0;
 // Tags are limited to 4096 each
 #define MAX_TAG_LEN 0x1000
 /* See tag_index.h for documentation  */
-TagIndex *NewTagIndex(RedisSearchDiskIndexSpec *diskSpec, t_fieldIndex fieldIndex) {
+TagIndex *NewTagIndex(RedisSearchDiskIndexSpec *diskSpec, t_fieldIndex fieldIndex, bool withSuffix) {
   TagIndex *idx = rm_new(TagIndex);
   idx->values = NewTrieMap();
   idx->uniqueId = tagUniqueId++;
-  idx->suffix = NULL;
+  idx->suffix = withSuffix ? NewTrieMap() : NULL;
   idx->diskSpec = diskSpec;
   idx->fieldIndex = fieldIndex;
   return idx;
@@ -334,10 +334,10 @@ TagIndex *TagIndex_Open(const FieldSpec *spec) {
 }
 
 /* Open the tag index, creating it if it doesn't exist. */
-TagIndex *TagIndex_Ensure(FieldSpec *spec, RedisSearchDiskIndexSpec *diskSpec) {
+TagIndex *TagIndex_Ensure(FieldSpec *spec, RedisSearchDiskIndexSpec *diskSpec, bool withSuffix) {
   RS_ASSERT(FIELD_IS(spec, INDEXFLD_T_TAG));
   if (!spec->tagOpts.tagIndex) {
-    spec->tagOpts.tagIndex = NewTagIndex(diskSpec, spec->index);
+    spec->tagOpts.tagIndex = NewTagIndex(diskSpec, spec->index, withSuffix);
   }
   return spec->tagOpts.tagIndex;
 }

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -380,6 +380,11 @@ arrayof(char**) TagIndex_SuffixTrieMap(const TagIndex *idx, const char *str, uin
   return idx->suffix ? GetList_SuffixTrieMap(idx->suffix) : NULL;
 }
 
+arrayof(char**) TagIndex_SuffixTrieMap_Wildcard(const TagIndex *idx, const char *str, uint32_t len,
+                                        bool prefix, struct timespec timeout, bool skipTimeoutChecks) {
+  return idx->suffix ? GetList_SuffixTrieMap_Wildcard(idx->suffix) : NULL;
+}
+
 /* Serialize all the tags in the index to the redis client */
 void TagIndex_SerializeValues(TagIndex *idx, RedisModuleCtx *ctx) {
   TrieMapIterator *it = TagIndex_IterateValues(idx);

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -347,6 +347,14 @@ uint32_t TagIndex_GetId(const TagIndex *idx) {
   return idx->uniqueId;
 }
 
+bool TagIndex_HasSuffix(const TagIndex *idx) {
+  return idx->suffix != NULL;
+}
+
+bool TagIndex_HasDiskSpec(const TagIndex *idx) {
+  return idx->diskSpec != NULL;
+}
+
 TrieMapIterator *TagIndex_IterateValues(const TagIndex *idx) {
   return TrieMap_Iterate(idx->values);
 }

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -371,21 +371,21 @@ void TagIndex_IterateRangeValues(const TagIndex *idx, const char *min, int minle
                        ctx);
 }
 
-TrieMapIterator *TagIndex_IterateSuffix(TagIndex *idx) {
+TrieMapIterator *TagIndex_IterateSuffix(const TagIndex *idx) {
   return idx->suffix ? TrieMap_Iterate(idx->suffix) : NULL;
 }
 
 /* Return a list of list of terms which match the suffix or contains term or NULL */
 arrayof(char **)
-    TagIndex_SuffixTrieMap(const TagIndex *idx, const char *str, uint32_t len, bool prefix,
+    TagIndex_GetSuffixMatches(const TagIndex *idx, const char *str, uint32_t len, bool prefix,
                            struct timespec timeout, bool skipTimeoutChecks) {
-  return idx->suffix ? GetList_SuffixTrieMap(idx->suffix) : NULL;
+  return idx->suffix ? GetList_SuffixTrieMap(idx->suffix, str, len, prefix, timeout, skipTimeoutChecks) : NULL;
 }
 
-arrayof(char **)
-    TagIndex_SuffixTrieMap_Wildcard(const TagIndex *idx, const char *str, uint32_t len, bool prefix,
-                                    struct timespec timeout, bool skipTimeoutChecks) {
-  return idx->suffix ? GetList_SuffixTrieMap_Wildcard(idx->suffix) : NULL;
+arrayof(char *)
+    TagIndex_GetSuffixWildcardMatches(const TagIndex *idx, const char *pattern, uint32_t len,
+                                               struct timespec timeout, long long maxPrefixExpansions, bool skipTimeoutChecks) {
+  return idx->suffix ? GetList_SuffixTrieMap_Wildcard(idx->suffix, pattern, len, timeout, maxPrefixExpansions, skipTimeoutChecks) : NULL;
 }
 
 /* Serialize all the tags in the index to the redis client */

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -32,7 +32,8 @@ static uint32_t tagUniqueId = 0;
 // Tags are limited to 4096 each
 #define MAX_TAG_LEN 0x1000
 /* See tag_index.h for documentation  */
-TagIndex *NewTagIndex(RedisSearchDiskIndexSpec *diskSpec, t_fieldIndex fieldIndex, bool withSuffix) {
+TagIndex *NewTagIndex(RedisSearchDiskIndexSpec *diskSpec, t_fieldIndex fieldIndex,
+                      bool withSuffix) {
   TagIndex *idx = rm_new(TagIndex);
   idx->values = NewTrieMap();
   idx->uniqueId = tagUniqueId++;
@@ -375,13 +376,15 @@ TrieMapIterator *TagIndex_IterateSuffix(TagIndex *idx) {
 }
 
 /* Return a list of list of terms which match the suffix or contains term or NULL */
-arrayof(char**) TagIndex_SuffixTrieMap(const TagIndex *idx, const char *str, uint32_t len,
-                                        bool prefix, struct timespec timeout, bool skipTimeoutChecks) {
+arrayof(char **)
+    TagIndex_SuffixTrieMap(const TagIndex *idx, const char *str, uint32_t len, bool prefix,
+                           struct timespec timeout, bool skipTimeoutChecks) {
   return idx->suffix ? GetList_SuffixTrieMap(idx->suffix) : NULL;
 }
 
-arrayof(char**) TagIndex_SuffixTrieMap_Wildcard(const TagIndex *idx, const char *str, uint32_t len,
-                                        bool prefix, struct timespec timeout, bool skipTimeoutChecks) {
+arrayof(char **)
+    TagIndex_SuffixTrieMap_Wildcard(const TagIndex *idx, const char *str, uint32_t len, bool prefix,
+                                    struct timespec timeout, bool skipTimeoutChecks) {
   return idx->suffix ? GetList_SuffixTrieMap_Wildcard(idx->suffix) : NULL;
 }
 

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -374,6 +374,12 @@ TrieMapIterator *TagIndex_IterateSuffix(TagIndex *idx) {
   return idx->suffix ? TrieMap_Iterate(idx->suffix) : NULL;
 }
 
+/* Return a list of list of terms which match the suffix or contains term or NULL */
+arrayof(char**) TagIndex_SuffixTrieMap(const TagIndex *idx, const char *str, uint32_t len,
+                                        bool prefix, struct timespec timeout, bool skipTimeoutChecks) {
+  return idx->suffix ? GetList_SuffixTrieMap(idx->suffix) : NULL;
+}
+
 /* Serialize all the tags in the index to the redis client */
 void TagIndex_SerializeValues(TagIndex *idx, RedisModuleCtx *ctx) {
   TrieMapIterator *it = TagIndex_IterateValues(idx);

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -130,14 +130,10 @@ char *TagIndex_SepString(char sep, char **s, size_t *toklen, bool indexEmpty);
 uint32_t TagIndex_GetId(const TagIndex *idx);
 
 /* Return 1 if TagIndex supports suffix searches */
-static inline bool TagIndex_HasSuffix(const TagIndex *idx) {
-  return idx->suffix != NULL;
-}
+bool TagIndex_HasSuffix(const TagIndex *idx);
 
 /* Return 1 if TagIndex supports disk searches */
-static inline bool TagIndex_HasDiskSpec(const TagIndex *idx) {
-  return idx->diskSpec != NULL;
-}
+bool TagIndex_HasDiskSpec(const TagIndex *idx);
 
 /* Return an iterator over the TagIndex values */
 TrieMapIterator *TagIndex_IterateValues(const TagIndex *idx);

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -181,14 +181,14 @@ TrieMapIterator *TagIndex_IterateSuffix(const TagIndex *idx);
 
 /* Return a list of list of terms which match the suffix or contains term or NULL */
 arrayof(char **)
-    TagIndex_SuffixTrieMap(const TagIndex *idx, const char *str, uint32_t len, bool prefix,
+    TagIndex_GetSuffixMatches(const TagIndex *idx, const char *str, uint32_t len, bool prefix,
                            struct timespec timeout, bool skipTimeoutChecks);
 
 /* Return a list of terms which match the wildcard pattern or NULL
  * If pattern does not match using suffix trie, return 0xBAAAAAAD */
-arrayof(char **)
-    TagIndex_SuffixTrieMap_Wildcard(const TagIndex *idx, const char *str, uint32_t len, bool prefix,
-                                    struct timespec timeout, bool skipTimeoutChecks);
+arrayof(char *)
+    TagIndex_GetSuffixWildcardMatches(const TagIndex *idx, const char *pattern, uint32_t len,
+                                      struct timespec timeout, long long maxPrefixExpansions, bool skipTimeoutChecks);
 
 /* Preprocess a document tag field, split the content in data into fdata `tags` array
    Return 0 if there's no content to index in the field (its value is NULL), 1 otherwise

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -134,6 +134,11 @@ static inline bool TagIndex_HasSuffix(const TagIndex *idx) {
   return idx->suffix != NULL;
 }
 
+/* Return 1 if TagIndex supports suffix searches */
+static inline bool TagIndex_HasDiskSpec(const TagIndex *idx) {
+  return idx->diskSpec != NULL;
+}
+
 /* Return an iterator over the TagIndex values */
 TrieMapIterator *TagIndex_IterateValues(const TagIndex *idx);
 

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -134,7 +134,7 @@ static inline bool TagIndex_HasSuffix(const TagIndex *idx) {
   return idx->suffix != NULL;
 }
 
-/* Return 1 if TagIndex supports suffix searches */
+/* Return 1 if TagIndex supports disk searches */
 static inline bool TagIndex_HasDiskSpec(const TagIndex *idx) {
   return idx->diskSpec != NULL;
 }
@@ -150,6 +150,11 @@ size_t TagIndex_NUniqueValues(const TagIndex *idx);
  * See [`TrieMap_Delete`] for more details.
  */
 int TagIndex_DeleteTagValue(TagIndex *idx, const char *tagVal, size_t tagValLen);
+
+/**
+ * Remove the given suffix.
+ */
+void TagIndex_DeleteTagSuffix(TagIndex *idx, const char *tagVal, size_t tagValLen);
 
 // must match `tm_iter_mode` defined in triemap_ffi.h
 typedef enum tag_iter_mode {

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -118,8 +118,9 @@ typedef struct TagIndex {
 /* Create a new tag index
  * @param diskSpec NULL for memory mode, non-NULL for disk mode
  * @param fieldIndex Field index for disk API calls
+ * @param withSuffix Let TagIndex support suffix searches
  */
-TagIndex *NewTagIndex(RedisSearchDiskIndexSpec *diskSpec, t_fieldIndex fieldIndex);
+TagIndex *NewTagIndex(RedisSearchDiskIndexSpec *diskSpec, t_fieldIndex fieldIndex, bool withSuffix);
 
 void TagIndex_Free(TagIndex *index);
 
@@ -229,8 +230,9 @@ TagIndex *TagIndex_Open(const FieldSpec *spec);
 /* Open the tag index, creating it if it doesn't exist.
  * @param spec Field spec for the tag field
  * @param diskSpec NULL for memory mode, non-NULL for disk mode
+ * @param withSuffix Let TagIndex support suffix searches
  */
-TagIndex *TagIndex_Ensure(FieldSpec *spec, RedisSearchDiskIndexSpec *diskSpec);
+TagIndex *TagIndex_Ensure(FieldSpec *spec, RedisSearchDiskIndexSpec *diskSpec, bool withSuffix);
 
 /* Find and index containing value, if the index is not found and create == 1,
  * a new index is created.

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -178,6 +178,11 @@ TrieMapIterator *TagIndex_IterateSuffix(const TagIndex *idx);
 arrayof(char**) TagIndex_SuffixTrieMap(const TagIndex *idx, const char *str, uint32_t len,
                                         bool prefix, struct timespec timeout, bool skipTimeoutChecks);
 
+/* Return a list of terms which match the wildcard pattern or NULL
+ * If pattern does not match using suffix trie, return 0xBAAAAAAD */
+arrayof(char**) TagIndex_SuffixTrieMap_Wildcard(const TagIndex *idx, const char *str, uint32_t len,
+                                        bool prefix, struct timespec timeout, bool skipTimeoutChecks);
+
 /* Preprocess a document tag field, split the content in data into fdata `tags` array
    Return 0 if there's no content to index in the field (its value is NULL), 1 otherwise
  */

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -174,6 +174,10 @@ void TagIndex_IterateRangeValues(const TagIndex *idx, const char *min, int minle
 /* Return an iterator over the TagIndex suffix or null */
 TrieMapIterator *TagIndex_IterateSuffix(const TagIndex *idx);
 
+/* Return a list of list of terms which match the suffix or contains term or NULL */
+arrayof(char**) TagIndex_SuffixTrieMap(const TagIndex *idx, const char *str, uint32_t len,
+                                        bool prefix, struct timespec timeout, bool skipTimeoutChecks);
+
 /* Preprocess a document tag field, split the content in data into fdata `tags` array
    Return 0 if there's no content to index in the field (its value is NULL), 1 otherwise
  */

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -180,13 +180,15 @@ void TagIndex_IterateRangeValues(const TagIndex *idx, const char *min, int minle
 TrieMapIterator *TagIndex_IterateSuffix(const TagIndex *idx);
 
 /* Return a list of list of terms which match the suffix or contains term or NULL */
-arrayof(char**) TagIndex_SuffixTrieMap(const TagIndex *idx, const char *str, uint32_t len,
-                                        bool prefix, struct timespec timeout, bool skipTimeoutChecks);
+arrayof(char **)
+    TagIndex_SuffixTrieMap(const TagIndex *idx, const char *str, uint32_t len, bool prefix,
+                           struct timespec timeout, bool skipTimeoutChecks);
 
 /* Return a list of terms which match the wildcard pattern or NULL
  * If pattern does not match using suffix trie, return 0xBAAAAAAD */
-arrayof(char**) TagIndex_SuffixTrieMap_Wildcard(const TagIndex *idx, const char *str, uint32_t len,
-                                        bool prefix, struct timespec timeout, bool skipTimeoutChecks);
+arrayof(char **)
+    TagIndex_SuffixTrieMap_Wildcard(const TagIndex *idx, const char *str, uint32_t len, bool prefix,
+                                    struct timespec timeout, bool skipTimeoutChecks);
 
 /* Preprocess a document tag field, split the content in data into fdata `tags` array
    Return 0 if there's no content to index in the field (its value is NULL), 1 otherwise
@@ -255,7 +257,7 @@ TagIndex *TagIndex_Ensure(FieldSpec *spec, RedisSearchDiskIndexSpec *diskSpec, b
  * a new index is created.
  * If a new index was created, the size of the new index is returned in *sz,
  * otherwise *sz is set to 0
-*/
+ */
 struct InvertedIndex *TagIndex_OpenIndex(const TagIndex *idx, const char *value,
                                          size_t len, int create_if_missing, size_t *sz);
 

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -128,6 +128,11 @@ char *TagIndex_SepString(char sep, char **s, size_t *toklen, bool indexEmpty);
 /* Return the unique id generated in `NewTagIndex` */
 uint32_t TagIndex_GetId(const TagIndex *idx);
 
+/* Return 1 if TagIndex supports suffix searches */
+static inline bool TagIndex_HasSuffix(const TagIndex *idx) {
+  return idx->suffix != NULL;
+}
+
 /* Return an iterator over the TagIndex values */
 TrieMapIterator *TagIndex_IterateValues(const TagIndex *idx);
 

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -171,6 +171,9 @@ void TagIndex_IterateRangeValues(const TagIndex *idx, const char *min, int minle
                                  const char *max, int maxlen, bool includeMax,
                                  TrieMapRangeCallback callback, void *ctx);
 
+/* Return an iterator over the TagIndex suffix or null */
+TrieMapIterator *TagIndex_IterateSuffix(const TagIndex *idx);
+
 /* Preprocess a document tag field, split the content in data into fdata `tags` array
    Return 0 if there's no content to index in the field (its value is NULL), 1 otherwise
  */

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -94,7 +94,7 @@ class FGCTest : public ::testing::Test {
 static InvertedIndex *getTagInvidx(RedisSearchCtx *sctx, const char *field,
                                    const char *value) {
   const FieldSpec *fs = IndexSpec_GetFieldWithLength(sctx->spec, "f1", strlen("f1"));
-  auto tix = TagIndex_Ensure(const_cast<FieldSpec *>(fs), NULL);
+  auto tix = TagIndex_Ensure(const_cast<FieldSpec *>(fs), NULL, false);
   size_t sz;
   auto iv = TagIndex_OpenIndex(tix, "hello", strlen("hello"), CREATE_INDEX, &sz);
   sctx->spec->stats.invertedSize += sz;

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -18,7 +18,7 @@
 class TagIndexTest : public ::testing::Test {};
 
 TEST_F(TagIndexTest, testCreate) {
-  TagIndex *idx = NewTagIndex(NULL, 0);
+  TagIndex *idx = NewTagIndex(NULL, 0, false);
   ASSERT_FALSE(idx == NULL);
   // ASSERT_STRING_EQ(idx->)
   const size_t N = 100000;
@@ -84,7 +84,7 @@ TEST_F(TagIndexTest, testCreate) {
 }
 
 TEST_F(TagIndexTest, testSkipToLastId) {
-  TagIndex *idx = NewTagIndex(NULL, 0);
+  TagIndex *idx = NewTagIndex(NULL, 0, false);
   ASSERT_FALSE(idx == NULL);
   std::vector<const char *> v{"hello"};
   t_docId docId = 1;


### PR DESCRIPTION
## Describe the changes in the pull request

This is part 2 of an ongoing effort to prevent callers from directly accessing TagIndex internals (idx->suffix, idx->diskSpec) by encapsulating those fields behind accessor functions. (see https://github.com/RediSearch/RediSearch/pull/10253)

1. Current: Code C code touches TagIndex fields, reading/creating `idx->suffix` and checking `idx->diskSpec`.
2. Change:
  - Added accessors so callers no longer reach into the struct: `TagIndex_HasSuffix`, `TagIndex_HasDiskSpec`, `TagIndex_IterateSuffix`, `TagIndex_SuffixTrieMap`, and `TagIndex_SuffixTrieMap_Wildcard`.
  - Moved suffix-trie creation inside TagIndex construction: `NewTagIndex` / `TagIndex_Ensure` now take a bool withSuffix parameter and allocate the suffix TrieMap themselves.
  - Replaced direct field accesses at all call sites with the new accessors.
3. Outcome: TagIndex's suffix/diskSpec fields are now accessed through a stable API surface, making the type easier to evolve (e.g. for the disk-spec work) without touching every caller. No behavior change.

#### Which additional issues this PR fixes

#### Main objects this PR modified

1. `src/tag_index.c` / `src/tag_index.h`: new accessors and the new parameter `withSuffix` on `NewTagIndex`/`TagIndex_Ensure`
2. `src/document.c`, `src/query.c`, `src/fork_gc/tsrc/spec.c`: use accessors / new signature
3. `tests/cpptests/test_cpp_tagindex.cpp`, `tests/cpptests/test_cpp_forkgc.cpp`, `rqe_iterators_test_utils/src/test_context.rs`: updated call sites

#### Mark if applicable

- [ ] This PR introduces API changes  (internal C API: NewTagIndex / TagIndex_Ensure signatures)
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
