### PR TITLE
[MOD-14212] topk: capture child record only when the heap retains it

### DIFF
--- a/src/redisearch_rs/top_k/src/heap.rs
+++ b/src/redisearch_rs/top_k/src/heap.rs
@@ -175,13 +175,31 @@ impl<'index> TopKHeap<'index> {
         score: f64,
         record: Option<RSIndexResult<'index>>,
     ) -> bool {
-        let entry = HeapEntry {
+        self.push_with_record_lazy(doc_id, score, move || record)
+    }
+
+    /// Like [`push_with_record`](Self::push_with_record), but the record is
+    /// produced by `make_record` only when the element is actually retained.
+    ///
+    /// Use this when building the record is expensive (e.g. a deep copy): the
+    /// closure is not called for an element the heap discards, so a rejected
+    /// candidate costs only the score comparison.
+    pub fn push_with_record_lazy(
+        &mut self,
+        doc_id: DocId,
+        score: f64,
+        make_record: impl FnOnce() -> Option<RSIndexResult<'index>>,
+    ) -> bool {
+        // The record never participates in ordering, so a record-less probe
+        // decides retention; the record is attached only on the accept branches.
+        let mut entry = HeapEntry {
             result: ScoredResult { doc_id, score },
-            record,
+            record: None,
             compare: self.compare,
         };
 
         if !self.is_full() {
+            entry.record = make_record();
             self.inner.push(entry);
             true
         }
@@ -192,6 +210,7 @@ impl<'index> TopKHeap<'index> {
         else if let Some(mut worst) = self.inner.peek_mut()
             && entry < *worst
         {
+            entry.record = make_record();
             *worst = entry;
             true
         } else {

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -344,10 +344,12 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             // VecSim distance lookup.
             scope.0.check_timeout()?;
             if let Some(score) = scope.0.lookup_score(doc_id) {
-                // Capture the child's record now, before the next `child.read()`
-                // reuses its storage, so the yield phase needn't re-walk the child.
-                let record = capture_child_record(result);
-                self.heap.push_with_record(doc_id, score, Some(record));
+                // Capture the child's record only if the heap retains this entry,
+                // before the next `child.read()` reuses its storage, so the yield
+                // phase needn't re-walk the child. A discarded candidate skips the
+                // copy entirely.
+                self.heap
+                    .push_with_record_lazy(doc_id, score, || Some(capture_child_record(result)));
             }
         }
 
@@ -626,10 +628,12 @@ fn intersect_batch_with_child<'index, C: RQEIterator<'index>>(
         metrics.total_comparisons += 1;
         match batch_doc.cmp(&child_doc) {
             Ordering::Equal => {
-                // Capture the matching child record before advancing past it,
-                // so the yield phase can return it without re-reading the child.
-                let record = child.current().map(|r| capture_child_record(r));
-                heap.push_with_record(batch_doc, batch_score, record);
+                // Capture the matching child record only if the heap retains it,
+                // before advancing past it, so the yield phase can return it
+                // without re-reading the child. A discarded match skips the copy.
+                heap.push_with_record_lazy(batch_doc, batch_score, || {
+                    child.current().map(|r| capture_child_record(r))
+                });
                 // Advance the batch first; only read the child when another
                 // batch doc remains. Reading the child past an exhausted batch
                 // is needless work that inflates its profile counters and could


### PR DESCRIPTION
| benchmark | before | after | change |
|---|---:|---:|---:|
| batches_50pct_overlap/10000 | 123.9 µs | 110.9 µs | **−10.1%** |
| batches_0pct_overlap/10000  | 221.5 µs | 222.6 µs | +0.5% |
| adhoc / k=10 n_child=50000  | 1.027 ms | 608.2 µs | **−40.8%** |
| adhoc / k=10 n_child=99900  | 2.042 ms | 1.204 ms | **−41.0%** |
| batches / k=10 n_child=100  | 276.3 µs | 258.9 µs | **−5.6%** |
| batches / k=10 n_child=50000 | 1.505 ms | 1.396 ms | **−7.2%** |
| batches / k=10 n_child=99900 | 1.424 ms | 501.8 µs | **−68.1%** |


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
