### PR TITLE
topk: skip timeout-check FFI cost when disabled

### DIFF
--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -482,6 +482,11 @@ impl<'index, E: ExpirationChecker> ScoreSource for VectorScoreSource<'index, E> 
     }
 
     fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+        // `u32::MAX` is the sentinel for "timeout checks disabled": the deadline
+        // is never consulted, so reporting "not timed out" is unconditional.
+        if self.timeout_ctx.counter == u32::MAX {
+            return Ok(());
+        }
         // SAFETY: `as_mut()` gives a valid, exclusive borrow for the call; the
         // source is single-threaded so no other access to the aliased raw
         // pointer in `query_params.timeoutCtx` is live during the call. The


### PR DESCRIPTION
| benchmark | before | noise re-run | after 1 | after 2 |
|---|---:|---:|---:|---:|
| adhoc/rust n=10k  k=10  | 2.097 | 2.110 | 2.106 | 2.159 |
| adhoc/rust n=10k  k=100 | 25.35 | 25.01 | 24.92 | 24.75 |
| adhoc/rust n=100k k=10  | 2.309 | 2.324 | 2.289 | 2.297 |
| adhoc/rust n=100k k=100 | 25.59 | 26.11 | 25.95 | 25.76 |

Change vs the `before` baseline (criterion point estimate):

| benchmark | **noise floor** (same code) | after 1 | after 2 |
|---|---:|---:|---:|
| adhoc/rust n=10k  k=10  | +0.37% | +0.08% | **+2.03%** |
| adhoc/rust n=10k  k=100 | −1.42% | −1.75% | −2.32% |
| adhoc/rust n=100k k=10  | +1.39% | −0.61% | −0.23% |
| adhoc/rust n=100k k=100 | +1.97% | +1.67% | +0.71% |

updated benchmarks ; let's not merge it for now and focus on other improvements.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
