### PR TITLE
[MOD-16584] Stop requiring uv for macOS builds

### DIFF
--- a/.install/verify_build_deps_macos.sh
+++ b/.install/verify_build_deps_macos.sh
@@ -26,10 +26,9 @@ should_check_cheadergen() {
 # Dependencies
 # ============================================
 # Define dependencies and their corresponding check methods
-mac_os_deps=("make" "uv" "python3" "cmake" "cargo" "clang" "openssl" "brew")
+mac_os_deps=("make" "python3" "cmake" "cargo" "clang" "openssl" "brew")
 mac_os_deps_types=(
     "check_command" # Check for "make"
-    "check_command" # Check for "uv"
     "check_command" # Check for "python3"
     "check_command" # Check for "cmake"
     "check_command" # Check for "cargo"


### PR DESCRIPTION
## Describe the changes in the pull request

Current: The macOS build dependency checker requires `uv`, even though `uv` is only needed for RediSearch Python test/dev setup and not for compiling the module. With dependency-check failures now blocking builds, this can break Homebrew/macOS build flows that do not install test-only tooling.

Change: Remove `uv` from `.install/verify_build_deps_macos.sh` so the macOS verifier matches the build-only dependency set used by the Linux verifier.

Outcome: Homebrew/macOS package builds can run the build dependency check without installing `uv`. Test/dev flows still install and use `uv` through the existing Python test setup scripts.

#### Which additional issues this PR fixes
1. MOD-16584

#### Main objects this PR modified
1. `.install/verify_build_deps_macos.sh`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Release note: macOS build dependency verification no longer requires the `uv` Python test tool to build RediSearch.

Validation:
- `bash -n .install/verify_build_deps_macos.sh`
- `git diff --check origin/master..HEAD`
