### PR TITLE
Mod 14988 add tests

### DIFF
--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -187,3 +187,154 @@ TEST_F(TagIndexTest, testSepStringIndexEmpty) {
   ASSERT_FALSE(token);
   free(orig);
 }
+
+TEST_F(TagIndexTest, testTokenizeViaPreprocess) {
+  // --- normal separator, case-insensitive (ASCII, in-place lowercase) ---
+  {
+    FieldSpec fs = makeTagFieldSpec(',', (TagFieldFlags)0, (FieldSpecOptions)0);
+    DocumentField df{};
+    df.unionType = FLD_VAR_T_CSTR;
+    df.strval = (char *)"Hello,World";
+    df.strlen = strlen(df.strval);
+    FieldIndexerData fdata{};
+    int ret = TagIndex_Preprocess(&fs, &df, &fdata);
+    ASSERT_EQ(ret, 1);
+    ASSERT_EQ(array_len(fdata.tags), 2u);
+    ASSERT_STREQ(fdata.tags[0], "hello");
+    ASSERT_STREQ(fdata.tags[1], "world");
+    TagIndex_FreePreprocessedData(fdata.tags);
+  }
+
+  // --- normal separator, case-insensitive, lowercase needs MORE bytes ---
+  // 'İ' (U+0130, 2 bytes) lowercases to 'i' + combining dot above (3 bytes),
+  // so unicode_tolower returns a freshly allocated longer buffer.
+  {
+    FieldSpec fs = makeTagFieldSpec(',', (TagFieldFlags)0, (FieldSpecOptions)0);
+    DocumentField df{};
+    df.unionType = FLD_VAR_T_CSTR;
+    df.strval = (char *)"İSTANBUL";
+    df.strlen = strlen(df.strval);
+    FieldIndexerData fdata{};
+    TagIndex_Preprocess(&fs, &df, &fdata);
+    ASSERT_EQ(array_len(fdata.tags), 1u);
+    ASSERT_STREQ(fdata.tags[0], "i̇stanbul");
+    TagIndex_FreePreprocessedData(fdata.tags);
+  }
+
+  // --- normal separator, case-sensitive (no lowercasing) ---
+  {
+    FieldSpec fs = makeTagFieldSpec(',', TagField_CaseSensitive, (FieldSpecOptions)0);
+    DocumentField df{};
+    df.unionType = FLD_VAR_T_CSTR;
+    df.strval = (char *)"Hello,World";
+    df.strlen = strlen(df.strval);
+    FieldIndexerData fdata{};
+    TagIndex_Preprocess(&fs, &df, &fdata);
+    ASSERT_EQ(array_len(fdata.tags), 2u);
+    ASSERT_STREQ(fdata.tags[0], "Hello");
+    ASSERT_STREQ(fdata.tags[1], "World");
+    TagIndex_FreePreprocessedData(fdata.tags);
+  }
+
+  // --- JSON default separator: the whole string is a single token ---
+  {
+    // case-insensitive, ASCII -> lowercased in place
+    FieldSpec fs =
+        makeTagFieldSpec(TAG_FIELD_DEFAULT_JSON_SEP, (TagFieldFlags)0, (FieldSpecOptions)0);
+    DocumentField df{};
+    df.unionType = FLD_VAR_T_CSTR;
+    df.strval = (char *)"Hello, World";
+    df.strlen = strlen(df.strval);
+    FieldIndexerData fdata{};
+    TagIndex_Preprocess(&fs, &df, &fdata);
+    ASSERT_EQ(array_len(fdata.tags), 1u);
+    ASSERT_STREQ(fdata.tags[0], "hello, world");
+    TagIndex_FreePreprocessedData(fdata.tags);
+  }
+  {
+    // case-insensitive, longer-output realloc branch
+    FieldSpec fs =
+        makeTagFieldSpec(TAG_FIELD_DEFAULT_JSON_SEP, (TagFieldFlags)0, (FieldSpecOptions)0);
+    DocumentField df{};
+    df.unionType = FLD_VAR_T_CSTR;
+    df.strval = (char *)"İSTANBUL";
+    df.strlen = strlen(df.strval);
+    FieldIndexerData fdata{};
+    TagIndex_Preprocess(&fs, &df, &fdata);
+    ASSERT_EQ(array_len(fdata.tags), 1u);
+    ASSERT_STREQ(fdata.tags[0], "i̇stanbul");
+    TagIndex_FreePreprocessedData(fdata.tags);
+  }
+  {
+    // case-sensitive: tolower block skipped entirely
+    FieldSpec fs =
+        makeTagFieldSpec(TAG_FIELD_DEFAULT_JSON_SEP, TagField_CaseSensitive, (FieldSpecOptions)0);
+    DocumentField df{};
+    df.unionType = FLD_VAR_T_CSTR;
+    df.strval = (char *)"Hello, World";
+    df.strlen = strlen(df.strval);
+    FieldIndexerData fdata{};
+    TagIndex_Preprocess(&fs, &df, &fdata);
+    ASSERT_EQ(array_len(fdata.tags), 1u);
+    ASSERT_STREQ(fdata.tags[0], "Hello, World");
+    TagIndex_FreePreprocessedData(fdata.tags);
+  }
+
+  // --- index-empty: empty input and trailing-separator input both add "" ---
+  {
+    FieldSpec fs = makeTagFieldSpec(',', (TagFieldFlags)0, FieldSpec_IndexEmpty);
+    DocumentField df{};
+    df.unionType = FLD_VAR_T_CSTR;
+    df.strval = (char *)"";
+    df.strlen = 0;
+    FieldIndexerData fdata{};
+    TagIndex_Preprocess(&fs, &df, &fdata);
+    ASSERT_EQ(array_len(fdata.tags), 1u);
+    ASSERT_STREQ(fdata.tags[0], "");
+    TagIndex_FreePreprocessedData(fdata.tags);
+  }
+  {
+    FieldSpec fs = makeTagFieldSpec(',', (TagFieldFlags)0, FieldSpec_IndexEmpty);
+    DocumentField df{};
+    df.unionType = FLD_VAR_T_CSTR;
+    df.strval = (char *)"foo,";
+    df.strlen = strlen(df.strval);
+    FieldIndexerData fdata{};
+    TagIndex_Preprocess(&fs, &df, &fdata);
+    ASSERT_EQ(array_len(fdata.tags), 2u);
+    ASSERT_STREQ(fdata.tags[0], "foo");
+    ASSERT_STREQ(fdata.tags[1], "");
+    TagIndex_FreePreprocessedData(fdata.tags);
+  }
+
+  // --- FLD_VAR_T_ARRAY: each element is tokenized independently ---
+  {
+    FieldSpec fs = makeTagFieldSpec(',', (TagFieldFlags)0, (FieldSpecOptions)0);
+    DocumentField df{};
+    df.unionType = FLD_VAR_T_ARRAY;
+    const char *vals[] = {"red,green", "blue"};
+    df.multiVal = (char **)vals;
+    df.arrayLen = 2;
+    FieldIndexerData fdata{};
+    int ret = TagIndex_Preprocess(&fs, &df, &fdata);
+    ASSERT_EQ(ret, 1);
+    ASSERT_EQ(array_len(fdata.tags), 3u);
+    ASSERT_STREQ(fdata.tags[0], "red");
+    ASSERT_STREQ(fdata.tags[1], "green");
+    ASSERT_STREQ(fdata.tags[2], "blue");
+    TagIndex_FreePreprocessedData(fdata.tags);
+  }
+
+  // --- FLD_VAR_T_NULL: nothing to index, isNull is set, returns 0 ---
+  {
+    FieldSpec fs = makeTagFieldSpec(',', (TagFieldFlags)0, (FieldSpecOptions)0);
+    DocumentField df{};
+    df.unionType = FLD_VAR_T_NULL;
+    FieldIndexerData fdata{};
+    int ret = TagIndex_Preprocess(&fs, &df, &fdata);
+    ASSERT_EQ(ret, 0);
+    ASSERT_EQ(fdata.isNull, 1);
+    ASSERT_EQ(array_len(fdata.tags), 0u);
+    TagIndex_FreePreprocessedData(fdata.tags);
+  }
+}

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -104,8 +104,7 @@ TEST_F(TagIndexTest, testCreate) {
   ASSERT_EQ(expectedTotalSZ + last_block_size, stats.invertedSize);
 
   MockQueryEvalCtx mockQctx(N, N);
-  QueryIterator *it =
-      TagIndex_OpenReader(idx, &mockQctx.sctx, "hello", 5, 1, RS_INVALID_FIELD_INDEX, NULL);
+  QueryIterator *it = TagIndex_OpenReader(idx, &mockQctx.sctx, "hello", 5, 1, RS_INVALID_FIELD_INDEX, NULL);
   ASSERT_TRUE(it != NULL);
   t_docId n = 1;
 
@@ -300,7 +299,7 @@ TEST_F(TagIndexTest, testOpenReaderEdgeCases) {
 
   // Absent tag -> NULL reader
   {
-    TagIndex *idx = NewTagIndex(NULL, 0);
+    TagIndex *idx = NewTagIndex(NULL, 0, false);
     const char *v[] = {"hello"};
     IndexStats stats = {0};
     TagIndex_Index(NULL, idx, NULL, &v[0], 1, 1, &stats);
@@ -312,7 +311,7 @@ TEST_F(TagIndexTest, testOpenReaderEdgeCases) {
 }
 
 TEST_F(TagIndexTest, testGetIteratorFromTrieMapValueNull) {
-  TagIndex *idx = NewTagIndex(NULL, 0);
+  TagIndex *idx = NewTagIndex(NULL, 0, false);
   const char *v[] = {"hello"};
   IndexStats stats = {0};
   TagIndex_Index(NULL, idx, NULL, &v[0], 1, 1, &stats);
@@ -335,7 +334,7 @@ TEST_F(TagIndexTest, testGetIteratorFromTrieMapValueNull) {
 }
 
 TEST_F(TagIndexTest, testCommitAndOverheadWithSuffix) {
-  TagIndex *idx = NewTagIndex(NULL, 0);
+  TagIndex *idx = NewTagIndex(NULL, 0, false);
   idx->suffix = NewTrieMap();
 
   const char *v[] = {"hello", "world"};

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -383,3 +383,28 @@ TEST_F(TagIndexTest, testGetIteratorFromTrieMapValueNull) {
   ASSERT_TRUE(itNull == NULL);
   TagIndex_Free(idx);
 }
+
+TEST_F(TagIndexTest, testCommitAndOverheadWithSuffix) {
+  TagIndex *idx = NewTagIndex(NULL, 0);
+  idx->suffix = NewTrieMap();
+
+  const char *v[] = {"hello", "world"};
+  IndexStats stats = {0};
+  TagIndex_Commit(idx, &v[0], 1, &stats);
+  ASSERT_EQ(stats.numRecords, 1u);
+
+  // Overhead with a live index that has a populated suffix trie.
+  FieldSpec fs{};
+  fs.types = INDEXFLD_T_TAG;
+  fs.tagOpts.tagIndex = idx;
+  size_t overhead = TagIndex_GetOverhead(&fs);
+  ASSERT_GT(overhead, 0u);
+
+  TagIndex_Free(idx);
+
+  // No tag index -> zero overhead.
+  FieldSpec emptyFs{};
+  emptyFs.types = INDEXFLD_T_TAG;
+  emptyFs.tagOpts.tagIndex = NULL;
+  ASSERT_EQ(TagIndex_GetOverhead(&emptyFs), 0u);
+}

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -338,3 +338,25 @@ TEST_F(TagIndexTest, testTokenizeViaPreprocess) {
     TagIndex_FreePreprocessedData(fdata.tags);
   }
 }
+
+TEST_F(TagIndexTest, testOpenReaderEdgeCases) {
+  MockQueryEvalCtx mockQctx(1, 1);
+
+  // NULL index -> NULL reader
+  {
+    ASSERT_TRUE(
+        TagIndex_OpenReader(NULL, &mockQctx.sctx, "x", 1, 1, RS_INVALID_FIELD_INDEX, NULL) == NULL);
+  }
+
+  // Absent tag -> NULL reader
+  {
+    TagIndex *idx = NewTagIndex(NULL, 0);
+    const char *v[] = {"hello"};
+    IndexStats stats = {0};
+    TagIndex_Index(NULL, idx, NULL, &v[0], 1, 1, &stats);
+
+    ASSERT_TRUE(TagIndex_OpenReader(idx, &mockQctx.sctx, "missing", 7, 1, RS_INVALID_FIELD_INDEX,
+                                    NULL) == NULL);
+    TagIndex_Free(idx);
+  }
+}

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -5,10 +5,14 @@
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
  * GNU Affero General Public License v3 (AGPLv3).
-*/
+ */
 
 #include "tag_index.h"
 #include "triemap_ffi.h"
+#include "field_spec.h"
+#include "document.h"
+#include "indexer.h"
+#include "util/arr.h"
 #include "gtest/gtest.h"
 #include "index_utils.h"
 
@@ -16,6 +20,19 @@
 #include <string>
 
 class TagIndexTest : public ::testing::Test {};
+
+// Build a minimal stack FieldSpec for a TAG field. `tokenizeTagString` /
+// `TagIndex_Preprocess` only read `tagOpts.tagSep`, `tagOpts.tagFlags` and
+// `options` (via FieldSpec_IndexesEmpty), so no full IndexSpec is required.
+static FieldSpec makeTagFieldSpec(char sep, TagFieldFlags flags, FieldSpecOptions options) {
+  FieldSpec fs{};
+  fs.types = INDEXFLD_T_TAG;
+  fs.options = options;
+  fs.tagOpts.tagFlags = flags;
+  fs.tagOpts.tagSep = sep;
+  fs.tagOpts.tagIndex = NULL;
+  return fs;
+}
 
 TEST_F(TagIndexTest, testCreate) {
   TagIndex *idx = NewTagIndex(NULL, 0, false);
@@ -63,7 +80,8 @@ TEST_F(TagIndexTest, testCreate) {
   ASSERT_EQ(expectedTotalSZ + last_block_size, stats.invertedSize);
 
   MockQueryEvalCtx mockQctx(N, N);
-  QueryIterator *it = TagIndex_OpenReader(idx, &mockQctx.sctx, "hello", 5, 1, RS_INVALID_FIELD_INDEX, NULL);
+  QueryIterator *it =
+      TagIndex_OpenReader(idx, &mockQctx.sctx, "hello", 5, 1, RS_INVALID_FIELD_INDEX, NULL);
   ASSERT_TRUE(it != NULL);
   t_docId n = 1;
 
@@ -91,7 +109,8 @@ TEST_F(TagIndexTest, testSkipToLastId) {
   IndexStats stats = {0};
   TagIndex_Index(NULL, idx, NULL, &v[0], v.size(), docId, &stats);
   MockQueryEvalCtx mockQctx(1, 1);
-  QueryIterator *it = TagIndex_OpenReader(idx, &mockQctx.sctx, "hello", 5, 1, RS_INVALID_FIELD_INDEX, NULL);
+  QueryIterator *it =
+      TagIndex_OpenReader(idx, &mockQctx.sctx, "hello", 5, 1, RS_INVALID_FIELD_INDEX, NULL);
   IteratorStatus rc = it->Read(it);
   ASSERT_EQ(rc, ITERATOR_OK);
   ASSERT_EQ(it->lastDocId, docId);

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -162,3 +162,28 @@ TEST_F(TagIndexTest, testSepString) {
 
   TEST_MY_SEP(' ', "   foo    bar   ")
 }
+
+TEST_F(TagIndexTest, testSepStringIndexEmpty) {
+  char *orig, *s, *token;
+  size_t tokenLen;
+
+  // Leading space then a separator -> an empty value is returned, then the
+  // following non-empty token.
+  orig = s = strdup(" ,foo");
+  token = TagIndex_SepString(',', &s, &tokenLen, true);
+  EXPECT_STREQ(token, "");
+  token = TagIndex_SepString(',', &s, &tokenLen, true);
+  EXPECT_STREQ(token, "foo");
+  ASSERT_EQ(tokenLen, 3);
+  token = TagIndex_SepString(',', &s, &tokenLen, true);
+  ASSERT_FALSE(token);
+  free(orig);
+
+  // Leading spaces then end-of-string -> one empty value, then NULL.
+  orig = s = strdup("   ");
+  token = TagIndex_SepString(',', &s, &tokenLen, true);
+  EXPECT_STREQ(token, "");
+  token = TagIndex_SepString(',', &s, &tokenLen, true);
+  ASSERT_FALSE(token);
+  free(orig);
+}

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -34,6 +34,30 @@ static FieldSpec makeTagFieldSpec(char sep, TagFieldFlags flags, FieldSpecOption
   return fs;
 }
 
+// Run TagIndex_Preprocess and assert the returned status and tag list.
+static void checkPreprocess(const FieldSpec &fs, const DocumentField &df, int expectedRet,
+                            const char *const *expected, size_t nExpected) {
+  FieldIndexerData fdata{};
+  int ret = TagIndex_Preprocess(&fs, &df, &fdata);
+  EXPECT_EQ(ret, expectedRet);
+  ASSERT_EQ(array_len(fdata.tags), nExpected);
+  for (size_t i = 0; i < nExpected; i++) {
+    EXPECT_STREQ(fdata.tags[i], expected[i]);
+  }
+  TagIndex_FreePreprocessedData(fdata.tags);
+}
+
+// Tokenize a single C-string TAG value and assert the resulting tags.
+static void checkPreprocessCStr(char sep, TagFieldFlags flags, FieldSpecOptions options,
+                                const char *value, const char *const *expected, size_t nExpected) {
+  FieldSpec fs = makeTagFieldSpec(sep, flags, options);
+  DocumentField df{};
+  df.unionType = FLD_VAR_T_CSTR;
+  df.strval = (char *)value;
+  df.strlen = strlen(value);
+  checkPreprocess(fs, df, /*expectedRet=*/1, expected, nExpected);
+}
+
 TEST_F(TagIndexTest, testCreate) {
   TagIndex *idx = NewTagIndex(NULL, 0, false);
   ASSERT_FALSE(idx == NULL);
@@ -191,120 +215,52 @@ TEST_F(TagIndexTest, testSepStringIndexEmpty) {
 TEST_F(TagIndexTest, testTokenizeViaPreprocess) {
   // --- normal separator, case-insensitive (ASCII, in-place lowercase) ---
   {
-    FieldSpec fs = makeTagFieldSpec(',', (TagFieldFlags)0, (FieldSpecOptions)0);
-    DocumentField df{};
-    df.unionType = FLD_VAR_T_CSTR;
-    df.strval = (char *)"Hello,World";
-    df.strlen = strlen(df.strval);
-    FieldIndexerData fdata{};
-    int ret = TagIndex_Preprocess(&fs, &df, &fdata);
-    ASSERT_EQ(ret, 1);
-    ASSERT_EQ(array_len(fdata.tags), 2u);
-    ASSERT_STREQ(fdata.tags[0], "hello");
-    ASSERT_STREQ(fdata.tags[1], "world");
-    TagIndex_FreePreprocessedData(fdata.tags);
+    const char *e[] = {"hello", "world"};
+    checkPreprocessCStr(',', (TagFieldFlags)0, (FieldSpecOptions)0, "Hello,World", e, 2);
   }
 
   // --- normal separator, case-insensitive, lowercase needs MORE bytes ---
   // 'İ' (U+0130, 2 bytes) lowercases to 'i' + combining dot above (3 bytes),
   // so unicode_tolower returns a freshly allocated longer buffer.
   {
-    FieldSpec fs = makeTagFieldSpec(',', (TagFieldFlags)0, (FieldSpecOptions)0);
-    DocumentField df{};
-    df.unionType = FLD_VAR_T_CSTR;
-    df.strval = (char *)"İSTANBUL";
-    df.strlen = strlen(df.strval);
-    FieldIndexerData fdata{};
-    TagIndex_Preprocess(&fs, &df, &fdata);
-    ASSERT_EQ(array_len(fdata.tags), 1u);
-    ASSERT_STREQ(fdata.tags[0], "i̇stanbul");
-    TagIndex_FreePreprocessedData(fdata.tags);
+    const char *e[] = {"i̇stanbul"};
+    checkPreprocessCStr(',', (TagFieldFlags)0, (FieldSpecOptions)0, "İSTANBUL", e, 1);
   }
 
   // --- normal separator, case-sensitive (no lowercasing) ---
   {
-    FieldSpec fs = makeTagFieldSpec(',', TagField_CaseSensitive, (FieldSpecOptions)0);
-    DocumentField df{};
-    df.unionType = FLD_VAR_T_CSTR;
-    df.strval = (char *)"Hello,World";
-    df.strlen = strlen(df.strval);
-    FieldIndexerData fdata{};
-    TagIndex_Preprocess(&fs, &df, &fdata);
-    ASSERT_EQ(array_len(fdata.tags), 2u);
-    ASSERT_STREQ(fdata.tags[0], "Hello");
-    ASSERT_STREQ(fdata.tags[1], "World");
-    TagIndex_FreePreprocessedData(fdata.tags);
+    const char *e[] = {"Hello", "World"};
+    checkPreprocessCStr(',', TagField_CaseSensitive, (FieldSpecOptions)0, "Hello,World", e, 2);
   }
 
   // --- JSON default separator: the whole string is a single token ---
   {
     // case-insensitive, ASCII -> lowercased in place
-    FieldSpec fs =
-        makeTagFieldSpec(TAG_FIELD_DEFAULT_JSON_SEP, (TagFieldFlags)0, (FieldSpecOptions)0);
-    DocumentField df{};
-    df.unionType = FLD_VAR_T_CSTR;
-    df.strval = (char *)"Hello, World";
-    df.strlen = strlen(df.strval);
-    FieldIndexerData fdata{};
-    TagIndex_Preprocess(&fs, &df, &fdata);
-    ASSERT_EQ(array_len(fdata.tags), 1u);
-    ASSERT_STREQ(fdata.tags[0], "hello, world");
-    TagIndex_FreePreprocessedData(fdata.tags);
+    const char *e[] = {"hello, world"};
+    checkPreprocessCStr(TAG_FIELD_DEFAULT_JSON_SEP, (TagFieldFlags)0, (FieldSpecOptions)0,
+                        "Hello, World", e, 1);
   }
   {
     // case-insensitive, longer-output realloc branch
-    FieldSpec fs =
-        makeTagFieldSpec(TAG_FIELD_DEFAULT_JSON_SEP, (TagFieldFlags)0, (FieldSpecOptions)0);
-    DocumentField df{};
-    df.unionType = FLD_VAR_T_CSTR;
-    df.strval = (char *)"İSTANBUL";
-    df.strlen = strlen(df.strval);
-    FieldIndexerData fdata{};
-    TagIndex_Preprocess(&fs, &df, &fdata);
-    ASSERT_EQ(array_len(fdata.tags), 1u);
-    ASSERT_STREQ(fdata.tags[0], "i̇stanbul");
-    TagIndex_FreePreprocessedData(fdata.tags);
+    const char *e[] = {"i̇stanbul"};
+    checkPreprocessCStr(TAG_FIELD_DEFAULT_JSON_SEP, (TagFieldFlags)0, (FieldSpecOptions)0,
+                        "İSTANBUL", e, 1);
   }
   {
     // case-sensitive: tolower block skipped entirely
-    FieldSpec fs =
-        makeTagFieldSpec(TAG_FIELD_DEFAULT_JSON_SEP, TagField_CaseSensitive, (FieldSpecOptions)0);
-    DocumentField df{};
-    df.unionType = FLD_VAR_T_CSTR;
-    df.strval = (char *)"Hello, World";
-    df.strlen = strlen(df.strval);
-    FieldIndexerData fdata{};
-    TagIndex_Preprocess(&fs, &df, &fdata);
-    ASSERT_EQ(array_len(fdata.tags), 1u);
-    ASSERT_STREQ(fdata.tags[0], "Hello, World");
-    TagIndex_FreePreprocessedData(fdata.tags);
+    const char *e[] = {"Hello, World"};
+    checkPreprocessCStr(TAG_FIELD_DEFAULT_JSON_SEP, TagField_CaseSensitive, (FieldSpecOptions)0,
+                        "Hello, World", e, 1);
   }
 
   // --- index-empty: empty input and trailing-separator input both add "" ---
   {
-    FieldSpec fs = makeTagFieldSpec(',', (TagFieldFlags)0, FieldSpec_IndexEmpty);
-    DocumentField df{};
-    df.unionType = FLD_VAR_T_CSTR;
-    df.strval = (char *)"";
-    df.strlen = 0;
-    FieldIndexerData fdata{};
-    TagIndex_Preprocess(&fs, &df, &fdata);
-    ASSERT_EQ(array_len(fdata.tags), 1u);
-    ASSERT_STREQ(fdata.tags[0], "");
-    TagIndex_FreePreprocessedData(fdata.tags);
+    const char *e[] = {""};
+    checkPreprocessCStr(',', (TagFieldFlags)0, FieldSpec_IndexEmpty, "", e, 1);
   }
   {
-    FieldSpec fs = makeTagFieldSpec(',', (TagFieldFlags)0, FieldSpec_IndexEmpty);
-    DocumentField df{};
-    df.unionType = FLD_VAR_T_CSTR;
-    df.strval = (char *)"foo,";
-    df.strlen = strlen(df.strval);
-    FieldIndexerData fdata{};
-    TagIndex_Preprocess(&fs, &df, &fdata);
-    ASSERT_EQ(array_len(fdata.tags), 2u);
-    ASSERT_STREQ(fdata.tags[0], "foo");
-    ASSERT_STREQ(fdata.tags[1], "");
-    TagIndex_FreePreprocessedData(fdata.tags);
+    const char *e[] = {"foo", ""};
+    checkPreprocessCStr(',', (TagFieldFlags)0, FieldSpec_IndexEmpty, "foo,", e, 2);
   }
 
   // --- FLD_VAR_T_ARRAY: each element is tokenized independently ---
@@ -315,14 +271,8 @@ TEST_F(TagIndexTest, testTokenizeViaPreprocess) {
     const char *vals[] = {"red,green", "blue"};
     df.multiVal = (char **)vals;
     df.arrayLen = 2;
-    FieldIndexerData fdata{};
-    int ret = TagIndex_Preprocess(&fs, &df, &fdata);
-    ASSERT_EQ(ret, 1);
-    ASSERT_EQ(array_len(fdata.tags), 3u);
-    ASSERT_STREQ(fdata.tags[0], "red");
-    ASSERT_STREQ(fdata.tags[1], "green");
-    ASSERT_STREQ(fdata.tags[2], "blue");
-    TagIndex_FreePreprocessedData(fdata.tags);
+    const char *e[] = {"red", "green", "blue"};
+    checkPreprocess(fs, df, /*expectedRet=*/1, e, 3);
   }
 
   // --- FLD_VAR_T_NULL: nothing to index, isNull is set, returns 0 ---

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -360,3 +360,26 @@ TEST_F(TagIndexTest, testOpenReaderEdgeCases) {
     TagIndex_Free(idx);
   }
 }
+
+TEST_F(TagIndexTest, testGetIteratorFromTrieMapValueNull) {
+  TagIndex *idx = NewTagIndex(NULL, 0);
+  const char *v[] = {"hello"};
+  IndexStats stats = {0};
+  TagIndex_Index(NULL, idx, NULL, &v[0], 1, 1, &stats);
+
+  size_t sz = 0;
+  InvertedIndex *iv = TagIndex_OpenIndex(idx, "hello", 5, /*create_if_missing=*/false, &sz);
+  ASSERT_TRUE(iv != NULL && iv != TRIEMAP_NOTFOUND);
+
+  MockQueryEvalCtx mockQctx(1, 1);
+  QueryIterator *it = TagIndex_GetIteratorFromTrieMapValue(idx, &mockQctx.sctx, "hello", 5, iv, 1,
+                                                           RS_INVALID_FIELD_INDEX, NULL);
+  ASSERT_TRUE(it != NULL);
+  it->Free(it);
+
+  // NULL inverted-index pointer -> NULL iterator
+  QueryIterator *itNull = TagIndex_GetIteratorFromTrieMapValue(
+      idx, &mockQctx.sctx, "hello", 5, NULL, 1, RS_INVALID_FIELD_INDEX, NULL);
+  ASSERT_TRUE(itNull == NULL);
+  TagIndex_Free(idx);
+}

--- a/tests/pytests/test_json_multi_tag.py
+++ b/tests/pytests/test_json_multi_tag.py
@@ -321,3 +321,21 @@ def testMultiTagReturnBWC(env):
     checkMultiTagReturn(env, [res1, res2, res3, res2], True, True, False)
     env.flush()
     checkMultiTagReturn(env, [res1, res2, res3, res2], True, True, True)
+
+@skip(no_json=True)
+def testMultiTagJsonCaseInsensitiveMultibyte(env):
+    """A JSON TAG field uses the default JSON separator, so the whole value is a
+    single token. Case-insensitive normalization of a multibyte value whose
+    lowercase form is LONGER in UTF-8 (Turkish İ, U+0130 -> 'i' + combining dot
+    above) exercises the realloc path of the JSON tokenizer branch."""
+    conn = getConnectionByEnv(env)
+    value = 'İSTANBUL'  # 9 UTF-8 bytes; lowercases to 10 bytes
+    conn.execute_command('JSON.SET', 'doc:1', '$', json.dumps({'city': value}))
+    env.expect('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.city', 'AS', 'city', 'TAG').ok()
+
+    for _ in env.reloadingIterator():
+        waitForIndex(env, 'idx')
+        # Both the original (uppercase) and lowercase forms normalize identically
+        # and match the indexed document.
+        env.expect('FT.SEARCH', 'idx', '@city:{%s}' % value.lower(), 'NOCONTENT').equal([1, 'doc:1'])
+        env.expect('FT.SEARCH', 'idx', '@city:{%s}' % value, 'NOCONTENT').equal([1, 'doc:1'])

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -1117,3 +1117,27 @@ def testTagWildcardMaxExpansionsBruteForce():
 
     # Restore default
     run_command_on_all_shards(env, config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '200')
+
+@skip(cluster=True)
+def testTagSuffixTrieInfoOverhead(env):
+    """FT.INFO on a populated WITHSUFFIXTRIE tag field walks the suffix trie when
+    accounting for index overhead (covers the suffix branch of
+    TagIndex_GetOverhead). Also exercises a contains query against the suffix
+    trie."""
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG', 'WITHSUFFIXTRIE').ok()
+
+    conn.execute_command('HSET', 'doc1', 't', 'hello')
+    conn.execute_command('HSET', 'doc2', 't', 'jello')
+    conn.execute_command('HSET', 'doc3', 't', 'world')
+
+    for _ in env.reloadingIterator():
+        waitForIndex(env, 'idx')
+        # FT.INFO triggers the per-field overhead computation over the suffix trie.
+        info = index_info(env, 'idx')
+        env.assertEqual(info['num_docs'], 3)
+
+        # Contains query resolved through the suffix trie (both end with "llo").
+        res = env.cmd('FT.SEARCH', 'idx', '@t:{*llo}', 'NOCONTENT')
+        env.assertEqual(res[0], 2)  # hello, jello
+        env.assertEqual(py2sorted(res[1:]), ['doc1', 'doc2'])


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: The current test suite doesn't cover some branches in src/tag_index.c (the tag-string tokenizer, the JSON/case-insensitive normalization paths, the open-reader edge cases, and the suffix-trie overhead accounting)
2. Change: Add C++ unit tests and Python end-to-end tests that exercise these previously-uncovered branches. No production code is changed.
3. Outcome: The tag index's tokenization, normalization, reader, and overhead-accounting paths are now covered, guarding against regressions.

#### Which additional issues this PR fixes

#### Main objects this PR modified

1. tests/cpptests/test_cpp_tagindex.cpp
2. tests/pytests/test_tags.py
3. tests/pytests/test_json_multi_tag.py

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
