### PR TITLE
Add unicode_tolower_cow to string_utils + microbench

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2748,6 +2748,7 @@ name = "string_utils"
 version = "0.0.1"
 dependencies = [
  "build_utils",
+ "criterion",
  "ffi",
  "proptest",
  "redis_mock",

--- a/src/redisearch_rs/string_utils/Cargo.toml
+++ b/src/redisearch_rs/string_utils/Cargo.toml
@@ -4,6 +4,8 @@ version.workspace = true
 edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
+
+[lib]
 # Disable the default libtest bench harness so criterion can parse its own args.
 # See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 bench = false

--- a/src/redisearch_rs/string_utils/Cargo.toml
+++ b/src/redisearch_rs/string_utils/Cargo.toml
@@ -6,7 +6,6 @@ license-file.workspace = true
 publish.workspace = true
 
 [lib]
-# Disable the default libtest bench harness so criterion can parse its own args.
 # See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 bench = false
 

--- a/src/redisearch_rs/string_utils/Cargo.toml
+++ b/src/redisearch_rs/string_utils/Cargo.toml
@@ -4,6 +4,13 @@ version.workspace = true
 edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
+# Disable the default libtest bench harness so criterion can parse its own args.
+# See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false
+
+[[bench]]
+name = "unicode-tolower-bench"
+harness = false
 
 [features]
 # feature enabled when building tests so they can link the C code in build.rs
@@ -19,6 +26,7 @@ thiserror.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]
+criterion = { workspace = true }
 proptest = { workspace = true, features = ["std"] }
 redis_mock.workspace = true
 redisearch_rs = { workspace = true, features = ["mock_allocator"] }

--- a/src/redisearch_rs/string_utils/benches/unicode-tolower-bench.rs
+++ b/src/redisearch_rs/string_utils/benches/unicode-tolower-bench.rs
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Compare the owned [`unicode_tolower`] against the borrowing
+//! [`unicode_tolower_cow`].
+//!
+//! The `Cow` variant only pays off when the input is already lowercase: it
+//! borrows and skips the allocation entirely. When a fold is required it does
+//! strictly more work (the `is_lowercase` scan *plus* the same fold+allocate),
+//! so the inputs are split along two axes — already-lowercase vs needs-fold,
+//! ASCII vs non-ASCII — to show both the win and the overhead.
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use string_utils::{unicode_tolower, unicode_tolower_cow};
+
+/// Representative inputs, one per (case, script) quadrant.
+const INPUTS: &[(&str, &str)] = &[
+    ("ascii_lower", "hello world this is a lowercase query term"),
+    ("ascii_mixed", "Hello World This Is A Mixed Case Query Term"),
+    // Cow worst case: the scan must walk the whole string before the trailing
+    // uppercase char forces a fold+allocate, so it pays scan cost on top of the
+    // owned path's work.
+    (
+        "ascii_late_upper",
+        "hello world this is a lowercase query terM",
+    ),
+    ("unicode_lower", "straße café naïve façade œuvre αβγδε"),
+    ("unicode_mixed", "Straße Café Naïve Façade Œuvre Αβγδε"),
+];
+
+fn bench_tolower(c: &mut Criterion) {
+    let mut group = c.benchmark_group("unicode_tolower");
+    for &(name, input) in INPUTS {
+        group.bench_with_input(BenchmarkId::new("owned", name), input, |b, s| {
+            b.iter(|| unicode_tolower(black_box(s)));
+        });
+        group.bench_with_input(BenchmarkId::new("cow", name), input, |b, s| {
+            b.iter(|| unicode_tolower_cow(black_box(s)));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_tolower);
+criterion_main!(benches);

--- a/src/redisearch_rs/string_utils/src/lib.rs
+++ b/src/redisearch_rs/string_utils/src/lib.rs
@@ -24,6 +24,20 @@ pub fn unicode_tolower(s: &str) -> String {
     s.chars().flat_map(char::to_lowercase).collect()
 }
 
+/// Convert a UTF-8 string to lowercase per-character, borrowing it unchanged
+/// when it is already lowercase.
+///
+/// Lowercases each [`char`] independently like [`unicode_tolower`], but
+/// allocates only when a character actually changes.
+pub fn unicode_tolower_cow(s: &str) -> Cow<'_, str> {
+    // `s` is already lowercase when folding every char leaves it unchanged.
+    if s.chars().all(|c| c.to_lowercase().eq([c])) {
+        Cow::Borrowed(s)
+    } else {
+        Cow::Owned(unicode_tolower(s))
+    }
+}
+
 /// Convert a UTF-8 string to lowercase per-character, without
 /// context-dependent casing rules.
 ///

--- a/src/redisearch_rs/string_utils/tests/integration/unicode_tolower.rs
+++ b/src/redisearch_rs/string_utils/tests/integration/unicode_tolower.rs
@@ -7,8 +7,9 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Verify that [`string_utils::unicode_tolower`] matches the FFI
-//! `unicode_tolower_fn` for all BMP codepoints.
+//! Verify that [`string_utils::unicode_tolower`] and
+//! [`string_utils::unicode_tolower_cow`] match the FFI `unicode_tolower_fn`
+//! for all BMP codepoints, and that the `Cow` variant borrows when possible.
 
 #[cfg(not(miri))]
 mod ffi_comparison {
@@ -49,13 +50,24 @@ mod ffi_comparison {
         }
     }
 
+    /// Assert that both the owned [`string_utils::unicode_tolower`] and the
+    /// borrowing [`string_utils::unicode_tolower_cow`] produce the same bytes
+    /// as the C oracle. Sharing the oracle here means every case below — and the
+    /// BMP proptest — exercises both Rust functions.
     fn assert_tolower_matches_c(s: &str) {
         let c_result = c_unicode_tolower(s);
+
         let rust_result = string_utils::unicode_tolower(s);
         assert_eq!(
             rust_result, c_result,
-            "mismatch for input {:?}: rust={:?}, c={:?}",
-            s, rust_result, c_result,
+            "unicode_tolower mismatch for {s:?}: rust={rust_result:?}, c={c_result:?}",
+        );
+
+        let cow_result = string_utils::unicode_tolower_cow(s);
+        assert_eq!(
+            cow_result.as_ref(),
+            c_result.as_str(),
+            "unicode_tolower_cow mismatch for {s:?}: cow={cow_result:?}, c={c_result:?}",
         );
     }
 
@@ -103,5 +115,26 @@ mod ffi_comparison {
         fn ffi_matches_rust(s in bmp_string()) {
             assert_tolower_matches_c(&s);
         }
+    }
+}
+
+/// The `Cow` variant must borrow when nothing changes and allocate only when a
+/// fold is required — the optimization the equivalence checks can't observe.
+mod cow_borrow_contract {
+    use std::borrow::Cow;
+    use string_utils::unicode_tolower_cow;
+
+    #[test]
+    fn borrows_when_already_lowercase() {
+        assert!(matches!(unicode_tolower_cow(""), Cow::Borrowed(_)));
+        assert!(matches!(unicode_tolower_cow("hello"), Cow::Borrowed(_)));
+        // ß is already lowercase; the non-ASCII path must borrow it too.
+        assert!(matches!(unicode_tolower_cow("straße"), Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn owns_when_fold_changes_input() {
+        assert!(matches!(unicode_tolower_cow("Hello"), Cow::Owned(_)));
+        assert!(matches!(unicode_tolower_cow("Σ"), Cow::Owned(_)));
     }
 }


### PR DESCRIPTION
Add `cow`-versions of function for potential performance increases.

Will be used in https://github.com/RediSearch/RediSearch/pull/10287.

Also adds a microbenchmark for comparing the two functions.

Results from a run on macOS/ARM:

```
  ┌─────────────────────────────────────┬─────────────────────────┬─────────────────────┬────────────────────┐
  │                Input                │ unicode_tolower (owned) │ unicode_tolower_cow │    Cow vs owned    │
  ├─────────────────────────────────────┼─────────────────────────┼─────────────────────┼────────────────────┤
  │ ascii_lower (already lc)            │                180.0 ns │             24.4 ns │ 7.4× faster        │
  ├─────────────────────────────────────┼─────────────────────────┼─────────────────────┼────────────────────┤
  │ unicode_lower (already lc)          │                213.0 ns │             66.6 ns │ 3.2× faster        │
  ├─────────────────────────────────────┼─────────────────────────┼─────────────────────┼────────────────────┤
  │ ascii_mixed (fold, early upper)     │                179.8 ns │            183.5 ns │ ~2% slower (noise) │
  ├─────────────────────────────────────┼─────────────────────────┼─────────────────────┼────────────────────┤
  │ unicode_mixed (fold, early upper)   │                225.4 ns │            223.8 ns │ tie                │
  ├─────────────────────────────────────┼─────────────────────────┼─────────────────────┼────────────────────┤
  │ ascii_late_upper (fold, worst case) │                180.9 ns │            199.1 ns │ ~10% slower        │
  └─────────────────────────────────────┴─────────────────────────┴─────────────────────┴────────────────────┘
```

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
