### PR TITLE
[MOD-14207] Topk: numeric score source: multiple batches

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1539,7 +1539,9 @@ version = "0.0.1"
 dependencies = [
  "build_utils",
  "index_result",
+ "inverted_index",
  "itertools 0.15.0",
+ "numeric_range_tree",
  "numeric_score_source",
  "redis_mock",
  "redisearch_rs",

--- a/src/redisearch_rs/numeric_score_source/Cargo.toml
+++ b/src/redisearch_rs/numeric_score_source/Cargo.toml
@@ -29,3 +29,4 @@ numeric_range_tree = {workspace = true, features = ["test-utils"]}
 numeric_score_source = {path = ".", features = ["unittest"]}
 redis_mock.workspace = true
 redisearch_rs = {workspace = true, features = ["mock_allocator"]}
+rqe_iterators = {workspace = true, features = ["unittest"]}

--- a/src/redisearch_rs/numeric_score_source/Cargo.toml
+++ b/src/redisearch_rs/numeric_score_source/Cargo.toml
@@ -11,18 +11,21 @@ version.workspace = true
 unittest = []
 
 [build-dependencies]
-build_utils = {path = "../build_utils"}
+build_utils.workspace = true
 
 [dependencies]
 index_result.workspace = true
+inverted_index.workspace = true
+numeric_range_tree.workspace = true
 rqe_core.workspace = true
 rqe_iterator_type.workspace = true
 rqe_iterators.workspace = true
-top_k = {path = "../top_k"}
+top_k.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]
 itertools.workspace = true
+numeric_range_tree = {workspace = true, features = ["test-utils"]}
 numeric_score_source = {path = ".", features = ["unittest"]}
 redis_mock.workspace = true
-redisearch_rs = {path = "../c_entrypoint/redisearch_rs", features = ["mock_allocator"]}
+redisearch_rs = {workspace = true, features = ["mock_allocator"]}

--- a/src/redisearch_rs/numeric_score_source/src/lib.rs
+++ b/src/redisearch_rs/numeric_score_source/src/lib.rs
@@ -15,6 +15,16 @@
 //! This crate provides [`NumericScoreSource`], a concrete [`top_k::ScoreSource`]
 //! that drives [`TopKIterator`] using a numeric field's values as scores.
 
+// Force-link the umbrella `redisearch_rs` crate so the `QueryError_*` (and other)
+// Rust FFI symbols that `libredisearch_c_bundle.a` calls back into are retained in the
+// lib unit-test binary, which links the C archive via the `unittest` feature.
+#[cfg(test)]
+extern crate redisearch_rs;
+// Stub the C symbols (e.g. OpenSSL) that the linked archive references but these
+// unit tests never exercise, so the binary links without pulling in those libs.
+#[cfg(test)]
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
 pub mod range_iterator;
 pub mod score_batch;
 pub mod source;

--- a/src/redisearch_rs/numeric_score_source/src/lib.rs
+++ b/src/redisearch_rs/numeric_score_source/src/lib.rs
@@ -15,22 +15,24 @@
 //! This crate provides [`NumericScoreSource`], a concrete [`top_k::ScoreSource`]
 //! that drives [`TopKIterator`] using a numeric field's values as scores.
 
+pub mod range_iterator;
 pub mod score_batch;
 pub mod source;
 
+pub use range_iterator::NumericRangeIterator;
 pub use score_batch::NumericScoreBatch;
-pub use source::{NumericRecords, NumericScoreSource};
+pub use source::NumericScoreSource;
 
 use std::{cmp::Ordering, num::NonZeroUsize};
 
 use rqe_iterators::RQEIterator;
 use top_k::{TopKIterator, TopKMode};
 
-/// A [`TopKIterator`] parameterised over [`NumericScoreSource`].
+/// A [`TopKIterator`] driven by a [`NumericScoreSource`].
 ///
 /// Construct one with [`new_numeric_top_k_unfiltered`] or
 /// [`new_numeric_top_k_filtered`].
-pub type NumericTopKIterator<'index, S> = TopKIterator<'index, NumericScoreSource<'index, S>>;
+pub type NumericTopKIterator<'index> = TopKIterator<'index, NumericScoreSource<'index>>;
 
 /// Pick the heap comparator for the query's sort direction.
 fn cmp_for(ascending: bool) -> fn(&f64, &f64) -> Ordering {
@@ -45,31 +47,31 @@ fn cmp_for(ascending: bool) -> fn(&f64, &f64) -> Ordering {
 ///
 /// Every record is fed through the heap, which retains the top `k` by numeric
 /// value: a numeric source has no native top-k, so the heap ([`TopKMode::Batches`]
-/// with no child) performs the selection. `ascending` selects the sort
-/// direction (`SORTBY field ASC`/`DESC`).
-pub fn new_numeric_top_k_unfiltered<'index, S: NumericRecords<'index> + 'index>(
-    source: NumericScoreSource<'index, S>,
+/// with no child) performs the selection. The sort direction is taken from the
+/// `source` (`SORTBY field ASC`/`DESC`).
+pub fn new_numeric_top_k_unfiltered<'index>(
+    source: NumericScoreSource<'index>,
     k: NonZeroUsize,
-    ascending: bool,
-) -> NumericTopKIterator<'index, S> {
-    TopKIterator::new_with_mode(source, None, k, cmp_for(ascending), TopKMode::Batches)
+) -> NumericTopKIterator<'index> {
+    let cmp = cmp_for(source.ascending());
+    TopKIterator::new_with_mode(source, None, k, cmp, TopKMode::Batches)
 }
 
 /// Construct a filtered [`NumericTopKIterator`] with a filter child.
 ///
 /// Uses [`TopKMode::Batches`]: the source's batch is intersected with the
 /// child filter, and the heap keeps the top `k` by numeric value.
-pub fn new_numeric_top_k_filtered<'index, S: NumericRecords<'index> + 'index>(
-    source: NumericScoreSource<'index, S>,
+pub fn new_numeric_top_k_filtered<'index>(
+    source: NumericScoreSource<'index>,
     child: impl RQEIterator<'index> + 'index,
     k: NonZeroUsize,
-    ascending: bool,
-) -> NumericTopKIterator<'index, S> {
+) -> NumericTopKIterator<'index> {
+    let cmp = cmp_for(source.ascending());
     TopKIterator::new_with_mode(
         source,
         Some(Box::new(child) as Box<dyn RQEIterator<'index> + 'index>),
         k,
-        cmp_for(ascending),
+        cmp,
         TopKMode::Batches,
     )
 }

--- a/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
+++ b/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
@@ -16,6 +16,8 @@
 //! Each chunk is materialized into a doc-id-ordered [`NumericScoreBatch`], so a
 //! batch is *value-bucketed across* the stream yet *doc-id-sorted within*.
 
+use std::collections::HashSet;
+
 use index_result::RSIndexResult;
 use inverted_index::{FilterNumericReader, IndexReader as _, NumericFilter};
 use numeric_range_tree::{NumericRange, NumericRangeTree};
@@ -33,6 +35,14 @@ pub struct NumericRangeIterator<'index> {
     pos: usize,
     /// Value predicate applied to each record as a batch is materialized.
     filter: NumericFilter,
+    /// Doc ids already handed out by an earlier batch or window.
+    ///
+    /// A multivalue field indexes one entry per value, so a doc's values can
+    /// fall in different range chunks and be split across `next_n` batches — or
+    /// even across expanded windows. Ranges are strictly value-ordered and
+    /// disjoint, so a doc's first emission is on its best value; later, worse
+    /// occurrences are dropped to keep it scored exactly once.
+    emitted: HashSet<DocId>,
 }
 
 impl<'index> NumericRangeIterator<'index> {
@@ -44,15 +54,27 @@ impl<'index> NumericRangeIterator<'index> {
             ranges: tree.find(filter),
             pos: 0,
             filter: *filter,
+            emitted: HashSet::new(),
         }
     }
 
     /// Re-resolve the (typically expanded) `filter` and restart from the first
     /// matching range.
+    ///
+    /// The emitted-doc set is kept: expansion moves to a strictly worse,
+    /// disjoint value window, so a doc already scored on a better value must
+    /// stay suppressed. Use [`forget_emitted`](Self::forget_emitted) to reset it
+    /// when restarting the whole query.
     pub fn refind(&mut self, filter: &NumericFilter) {
         self.ranges = self.tree.find(filter);
         self.pos = 0;
         self.filter = *filter;
+    }
+
+    /// Drop the record of already-emitted doc ids, so a full rewind can score
+    /// every doc afresh.
+    pub fn forget_emitted(&mut self) {
+        self.emitted.clear();
     }
 
     /// Sum of `num_docs` across every range in the current window.
@@ -78,7 +100,7 @@ impl<'index> NumericRangeIterator<'index> {
             return Ok(None);
         }
         let end = (self.pos + n.max(1)).min(self.ranges.len());
-        let batch = merge_ranges(&self.ranges[self.pos..end], self.filter)?;
+        let batch = merge_ranges(&self.ranges[self.pos..end], self.filter, &mut self.emitted)?;
         self.pos = end;
         Ok(Some(batch))
     }
@@ -94,18 +116,23 @@ impl<'index> NumericRangeIterator<'index> {
 /// [`NumericScoreBatch`] requires for its `skip_to` `partition_point`.
 ///
 /// A multivalue field indexes one entry per value, so a doc id can occur several
-/// times with different scores. Such runs are coalesced to a single entry
-/// carrying the doc's best score for the sort direction — the value that decides
-/// its rank in a top-k over this batch's ranges.
+/// times with different scores. Occurrences within this batch's ranges are
+/// coalesced to a single entry carrying the doc's best score for the sort
+/// direction; occurrences already handed out by an earlier batch (tracked in
+/// `emitted`) are dropped, since their better value was scored there.
 fn merge_ranges(
     ranges: &[&NumericRange],
     filter: NumericFilter,
+    emitted: &mut HashSet<DocId>,
 ) -> std::io::Result<NumericScoreBatch> {
     let mut items: Vec<(DocId, f64)> = Vec::new();
     let mut record = RSIndexResult::build_numeric(0.0).build();
     for range in ranges {
         let mut reader = FilterNumericReader::new(filter, range.reader());
         while reader.next_record(&mut record)? {
+            if emitted.contains(&record.doc_id) {
+                continue;
+            }
             let score = record
                 .as_numeric()
                 .expect("numeric range yields numeric records");
@@ -114,6 +141,7 @@ fn merge_ranges(
     }
     items.sort_unstable_by_key(|(doc_id, _)| *doc_id);
     coalesce_by_doc_id(&mut items, filter.ascending);
+    emitted.extend(items.iter().map(|(doc_id, _)| *doc_id));
     Ok(NumericScoreBatch::new(items))
 }
 
@@ -155,16 +183,44 @@ mod tests {
             .collect()
     }
 
-    /// Drain every window into the `(doc_id, score)` pairs it yields.
-    fn drain_pairs(tree: &NumericRangeTree, filter: &NumericFilter) -> Vec<(DocId, f64)> {
+    /// Drain every window into the `(doc_id, score)` pairs it yields, taking
+    /// `per_batch` ranges at a time so tests can force multi-batch behavior.
+    fn drain_pairs_in_chunks(
+        tree: &NumericRangeTree,
+        filter: &NumericFilter,
+        per_batch: usize,
+    ) -> Vec<(DocId, f64)> {
         let mut it = NumericRangeIterator::new(tree, filter);
         let mut pairs = Vec::new();
-        while let Some(mut batch) = it.next_n(8).unwrap() {
+        while let Some(mut batch) = it.next_n(per_batch).unwrap() {
             while let Some(pair) = batch.next() {
                 pairs.push(pair);
             }
         }
         pairs
+    }
+
+    /// Drain every window into the `(doc_id, score)` pairs it yields.
+    fn drain_pairs(tree: &NumericRangeTree, filter: &NumericFilter) -> Vec<(DocId, f64)> {
+        drain_pairs_in_chunks(tree, filter, 8)
+    }
+
+    /// Build a two-leaf tree, then index `doc_id` as a multivalue doc with one
+    /// value in each leaf so its occurrences span a range (and hence batch)
+    /// boundary.
+    fn tree_with_multivalue_doc_spanning_two_ranges(doc_id: DocId) -> NumericRangeTree {
+        let mut tree = NumericRangeTree::new(false);
+        // Enough distinct values to force a split into two value-disjoint leaves.
+        for value in 1..=20u64 {
+            tree.add(value, value as f64, false, 0);
+        }
+        assert!(
+            tree.find(&NumericFilter::default()).len() >= 2,
+            "expected a split"
+        );
+        tree.add(doc_id, 1.0, true, 0);
+        tree.add(doc_id, 20.0, true, 0);
+        tree
     }
 
     #[test]
@@ -240,6 +296,50 @@ mod tests {
             pairs,
             [(1, 90.0)],
             "descending keeps the doc's largest value"
+        );
+    }
+
+    #[test]
+    fn multivalue_doc_spanning_batches_is_scored_once_on_its_best_value() {
+        let doc = 1000;
+        let tree = tree_with_multivalue_doc_spanning_two_ranges(doc);
+
+        // One range per batch: the doc's two values land in different batches,
+        // which per-batch coalescing alone cannot reconcile.
+        let pairs = drain_pairs_in_chunks(&tree, &NumericFilter::default(), 1);
+
+        let occurrences: Vec<f64> = pairs
+            .iter()
+            .filter(|(id, _)| *id == doc)
+            .map(|(_, score)| *score)
+            .collect();
+        assert_eq!(
+            occurrences,
+            [1.0],
+            "ascending must emit the doc once, on its smallest value"
+        );
+    }
+
+    #[test]
+    fn multivalue_doc_spanning_batches_is_scored_once_descending() {
+        let doc = 1000;
+        let tree = tree_with_multivalue_doc_spanning_two_ranges(doc);
+        let filter = NumericFilter {
+            ascending: false,
+            ..NumericFilter::default()
+        };
+
+        let pairs = drain_pairs_in_chunks(&tree, &filter, 1);
+
+        let occurrences: Vec<f64> = pairs
+            .iter()
+            .filter(|(id, _)| *id == doc)
+            .map(|(_, score)| *score)
+            .collect();
+        assert_eq!(
+            occurrences,
+            [20.0],
+            "descending must emit the doc once, on its largest value"
         );
     }
 }

--- a/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
+++ b/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
@@ -85,13 +85,18 @@ impl<'index> NumericRangeIterator<'index> {
 }
 
 /// Read each range's records that satisfy `filter` into a single
-/// `(doc_id, score)` vector sorted strictly ascending by doc id.
+/// `(doc_id, score)` vector, one strictly-increasing entry per doc id.
 ///
 /// A range read through [`FilterNumericReader`] yields only records whose value
 /// lies in the filter's window, since the tree's buckets are coarser than the
 /// window. Ranges overlap in doc-id space, so reading them back-to-back yields
-/// interleaved ids; the sort restores the strictly-increasing order that
+/// interleaved ids; the sort restores the increasing order that
 /// [`NumericScoreBatch`] requires for its `skip_to` `partition_point`.
+///
+/// A multivalue field indexes one entry per value, so a doc id can occur several
+/// times with different scores. Such runs are coalesced to a single entry
+/// carrying the doc's best score for the sort direction — the value that decides
+/// its rank in a top-k over this batch's ranges.
 fn merge_ranges(ranges: &[&NumericRange], filter: NumericFilter) -> NumericScoreBatch {
     let mut items: Vec<(DocId, f64)> = Vec::new();
     let mut record = RSIndexResult::build_numeric(0.0).build();
@@ -105,27 +110,58 @@ fn merge_ranges(ranges: &[&NumericRange], filter: NumericFilter) -> NumericScore
         }
     }
     items.sort_unstable_by_key(|(doc_id, _)| *doc_id);
+    coalesce_by_doc_id(&mut items, filter.ascending);
     NumericScoreBatch::new(items)
+}
+
+/// Collapse each run of equal doc ids in a doc-id-sorted `items` to one entry,
+/// keeping the best score for the sort direction: the smallest when `ascending`,
+/// the largest otherwise.
+fn coalesce_by_doc_id(items: &mut Vec<(DocId, f64)>, ascending: bool) {
+    items.dedup_by(|dropped, kept| {
+        if dropped.0 != kept.0 {
+            return false;
+        }
+        // `dedup_by` retains `kept`, so fold the better score into it.
+        let dropped_is_better = if ascending {
+            dropped.1 < kept.1
+        } else {
+            dropped.1 > kept.1
+        };
+        if dropped_is_better {
+            kept.1 = dropped.1;
+        }
+        true
+    });
 }
 
 #[cfg(test)]
 mod tests {
     use inverted_index::NumericFilter;
     use numeric_range_tree::NumericRangeTree;
+    use rqe_core::DocId;
     use top_k::ScoreBatch;
 
     use super::NumericRangeIterator;
 
     /// Drain every window into the list of scores it yields.
     fn drain_scores(tree: &NumericRangeTree, filter: &NumericFilter) -> Vec<f64> {
+        drain_pairs(tree, filter)
+            .into_iter()
+            .map(|(_id, score)| score)
+            .collect()
+    }
+
+    /// Drain every window into the `(doc_id, score)` pairs it yields.
+    fn drain_pairs(tree: &NumericRangeTree, filter: &NumericFilter) -> Vec<(DocId, f64)> {
         let mut it = NumericRangeIterator::new(tree, filter);
-        let mut scores = Vec::new();
+        let mut pairs = Vec::new();
         while let Some(mut batch) = it.next_n(8) {
-            while let Some((_doc_id, score)) = batch.next() {
-                scores.push(score);
+            while let Some(pair) = batch.next() {
+                pairs.push(pair);
             }
         }
-        scores
+        pairs
     }
 
     #[test]
@@ -167,5 +203,40 @@ mod tests {
 
         assert!(scores.iter().all(|&s| s > 10.0 && s < 20.0));
         assert!(!scores.contains(&10.0) && !scores.contains(&20.0));
+    }
+
+    #[test]
+    fn multivalue_doc_is_coalesced_to_its_best_ascending_value() {
+        // `is_multivalued` lets a doc id repeat with several values, as a
+        // multivalue field does.
+        let mut tree = NumericRangeTree::new(false);
+        tree.add(1, 90.0, true, 0);
+        tree.add(1, 5.0, true, 0);
+        tree.add(2, 40.0, false, 0);
+
+        let pairs = drain_pairs(&tree, &NumericFilter::default());
+
+        let ids: Vec<DocId> = pairs.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids, [1, 2], "each doc id appears exactly once");
+        assert_eq!(pairs[0].1, 5.0, "ascending keeps the doc's smallest value");
+    }
+
+    #[test]
+    fn multivalue_doc_is_coalesced_to_its_best_descending_value() {
+        let mut tree = NumericRangeTree::new(false);
+        tree.add(1, 90.0, true, 0);
+        tree.add(1, 5.0, true, 0);
+
+        let filter = NumericFilter {
+            ascending: false,
+            ..NumericFilter::default()
+        };
+        let pairs = drain_pairs(&tree, &filter);
+
+        assert_eq!(
+            pairs,
+            [(1, 90.0)],
+            "descending keeps the doc's largest value"
+        );
     }
 }

--- a/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
+++ b/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
@@ -70,17 +70,17 @@ impl<'index> NumericRangeIterator<'index> {
     }
 
     /// Materialize the next `n` value-ordered ranges into one doc-id-ordered
-    /// batch, or `None` once the window is exhausted.
+    /// batch, or `Ok(None)` once the window is exhausted.
     ///
     /// `n` is clamped to at least `1`.
-    pub fn next_n(&mut self, n: usize) -> Option<NumericScoreBatch> {
+    pub fn next_n(&mut self, n: usize) -> std::io::Result<Option<NumericScoreBatch>> {
         if self.pos >= self.ranges.len() {
-            return None;
+            return Ok(None);
         }
         let end = (self.pos + n.max(1)).min(self.ranges.len());
-        let batch = merge_ranges(&self.ranges[self.pos..end], self.filter);
+        let batch = merge_ranges(&self.ranges[self.pos..end], self.filter)?;
         self.pos = end;
-        Some(batch)
+        Ok(Some(batch))
     }
 }
 
@@ -97,12 +97,15 @@ impl<'index> NumericRangeIterator<'index> {
 /// times with different scores. Such runs are coalesced to a single entry
 /// carrying the doc's best score for the sort direction — the value that decides
 /// its rank in a top-k over this batch's ranges.
-fn merge_ranges(ranges: &[&NumericRange], filter: NumericFilter) -> NumericScoreBatch {
+fn merge_ranges(
+    ranges: &[&NumericRange],
+    filter: NumericFilter,
+) -> std::io::Result<NumericScoreBatch> {
     let mut items: Vec<(DocId, f64)> = Vec::new();
     let mut record = RSIndexResult::build_numeric(0.0).build();
     for range in ranges {
         let mut reader = FilterNumericReader::new(filter, range.reader());
-        while reader.next_record(&mut record).unwrap_or(false) {
+        while reader.next_record(&mut record)? {
             let score = record
                 .as_numeric()
                 .expect("numeric range yields numeric records");
@@ -111,7 +114,7 @@ fn merge_ranges(ranges: &[&NumericRange], filter: NumericFilter) -> NumericScore
     }
     items.sort_unstable_by_key(|(doc_id, _)| *doc_id);
     coalesce_by_doc_id(&mut items, filter.ascending);
-    NumericScoreBatch::new(items)
+    Ok(NumericScoreBatch::new(items))
 }
 
 /// Collapse each run of equal doc ids in a doc-id-sorted `items` to one entry,
@@ -156,7 +159,7 @@ mod tests {
     fn drain_pairs(tree: &NumericRangeTree, filter: &NumericFilter) -> Vec<(DocId, f64)> {
         let mut it = NumericRangeIterator::new(tree, filter);
         let mut pairs = Vec::new();
-        while let Some(mut batch) = it.next_n(8) {
+        while let Some(mut batch) = it.next_n(8).unwrap() {
             while let Some(pair) = batch.next() {
                 pairs.push(pair);
             }

--- a/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
+++ b/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
@@ -17,7 +17,7 @@
 //! batch is *value-bucketed across* the stream yet *doc-id-sorted within*.
 
 use index_result::RSIndexResult;
-use inverted_index::{IndexReader as _, NumericFilter};
+use inverted_index::{FilterNumericReader, IndexReader as _, NumericFilter};
 use numeric_range_tree::{NumericRange, NumericRangeTree};
 use rqe_core::DocId;
 
@@ -31,6 +31,8 @@ pub struct NumericRangeIterator<'index> {
     ranges: Vec<&'index NumericRange>,
     /// Index of the next range to hand out.
     pos: usize,
+    /// Value predicate applied to each record as a batch is materialized.
+    filter: NumericFilter,
 }
 
 impl<'index> NumericRangeIterator<'index> {
@@ -41,6 +43,7 @@ impl<'index> NumericRangeIterator<'index> {
             tree,
             ranges: tree.find(filter),
             pos: 0,
+            filter: *filter,
         }
     }
 
@@ -49,6 +52,7 @@ impl<'index> NumericRangeIterator<'index> {
     pub fn refind(&mut self, filter: &NumericFilter) {
         self.ranges = self.tree.find(filter);
         self.pos = 0;
+        self.filter = *filter;
     }
 
     /// Sum of `num_docs` across every range in the current window.
@@ -74,23 +78,25 @@ impl<'index> NumericRangeIterator<'index> {
             return None;
         }
         let end = (self.pos + n.max(1)).min(self.ranges.len());
-        let batch = merge_ranges(&self.ranges[self.pos..end]);
+        let batch = merge_ranges(&self.ranges[self.pos..end], self.filter);
         self.pos = end;
         Some(batch)
     }
 }
 
-/// Read every record of each range into a single `(doc_id, score)` vector
-/// sorted strictly ascending by doc id.
+/// Read each range's records that satisfy `filter` into a single
+/// `(doc_id, score)` vector sorted strictly ascending by doc id.
 ///
-/// Ranges overlap in doc-id space, so reading them back-to-back yields
+/// A range read through [`FilterNumericReader`] yields only records whose value
+/// lies in the filter's window, since the tree's buckets are coarser than the
+/// window. Ranges overlap in doc-id space, so reading them back-to-back yields
 /// interleaved ids; the sort restores the strictly-increasing order that
 /// [`NumericScoreBatch`] requires for its `skip_to` `partition_point`.
-fn merge_ranges(ranges: &[&NumericRange]) -> NumericScoreBatch {
+fn merge_ranges(ranges: &[&NumericRange], filter: NumericFilter) -> NumericScoreBatch {
     let mut items: Vec<(DocId, f64)> = Vec::new();
     let mut record = RSIndexResult::build_numeric(0.0).build();
     for range in ranges {
-        let mut reader = range.reader();
+        let mut reader = FilterNumericReader::new(filter, range.reader());
         while reader.next_record(&mut record).unwrap_or(false) {
             let score = record
                 .as_numeric()
@@ -100,4 +106,66 @@ fn merge_ranges(ranges: &[&NumericRange]) -> NumericScoreBatch {
     }
     items.sort_unstable_by_key(|(doc_id, _)| *doc_id);
     NumericScoreBatch::new(items)
+}
+
+#[cfg(test)]
+mod tests {
+    use inverted_index::NumericFilter;
+    use numeric_range_tree::NumericRangeTree;
+    use top_k::ScoreBatch;
+
+    use super::NumericRangeIterator;
+
+    /// Drain every window into the list of scores it yields.
+    fn drain_scores(tree: &NumericRangeTree, filter: &NumericFilter) -> Vec<f64> {
+        let mut it = NumericRangeIterator::new(tree, filter);
+        let mut scores = Vec::new();
+        while let Some(mut batch) = it.next_n(8) {
+            while let Some((_doc_id, score)) = batch.next() {
+                scores.push(score);
+            }
+        }
+        scores
+    }
+
+    #[test]
+    fn next_n_drops_records_outside_the_value_window() {
+        let mut tree = NumericRangeTree::new(false);
+        for id in 0..30u64 {
+            tree.add(id, id as f64, false, 0);
+        }
+        let filter = NumericFilter {
+            min: 10.0,
+            max: 20.0,
+            ..NumericFilter::default()
+        };
+
+        let scores = drain_scores(&tree, &filter);
+
+        assert!(
+            scores.iter().all(|&s| (10.0..=20.0).contains(&s)),
+            "leaked out-of-range values: {scores:?}"
+        );
+        assert!(scores.contains(&10.0) && scores.contains(&20.0));
+    }
+
+    #[test]
+    fn next_n_honors_exclusive_endpoints() {
+        let mut tree = NumericRangeTree::new(false);
+        for id in 0..30u64 {
+            tree.add(id, id as f64, false, 0);
+        }
+        let filter = NumericFilter {
+            min: 10.0,
+            max: 20.0,
+            min_inclusive: false,
+            max_inclusive: false,
+            ..NumericFilter::default()
+        };
+
+        let scores = drain_scores(&tree, &filter);
+
+        assert!(scores.iter().all(|&s| s > 10.0 && s < 20.0));
+        assert!(!scores.contains(&10.0) && !scores.contains(&20.0));
+    }
 }

--- a/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
+++ b/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Value-ordered iteration over a numeric range tree.
+//!
+//! [`NumericRangeIterator`] turns a [`NumericRangeTree`] into a stream of
+//! score brackets: it asks the tree for the ranges matching a filter window —
+//! already ordered best-score-first per the filter's `ascending` flag — and
+//! hands them out in fixed-size chunks via [`next_n`](NumericRangeIterator::next_n).
+//! Each chunk is materialized into a doc-id-ordered [`NumericScoreBatch`], so a
+//! batch is *value-bucketed across* the stream yet *doc-id-sorted within*.
+
+use index_result::RSIndexResult;
+use inverted_index::{IndexReader as _, NumericFilter};
+use numeric_range_tree::{NumericRange, NumericRangeTree};
+use rqe_core::DocId;
+
+use crate::score_batch::NumericScoreBatch;
+
+/// Streams a numeric tree's ranges in value order, windowed by the filter's
+/// `offset`/`limit` and chunked by [`next_n`](Self::next_n).
+pub struct NumericRangeIterator<'index> {
+    tree: &'index NumericRangeTree,
+    /// Ranges matching the current filter window, best-score-first.
+    ranges: Vec<&'index NumericRange>,
+    /// Index of the next range to hand out.
+    pos: usize,
+}
+
+impl<'index> NumericRangeIterator<'index> {
+    /// Resolve `filter` against `tree` and prepare to stream the matching
+    /// ranges best-score-first.
+    pub fn new(tree: &'index NumericRangeTree, filter: &NumericFilter) -> Self {
+        Self {
+            tree,
+            ranges: tree.find(filter),
+            pos: 0,
+        }
+    }
+
+    /// Re-resolve the (typically expanded) `filter` and restart from the first
+    /// matching range.
+    pub fn refind(&mut self, filter: &NumericFilter) {
+        self.ranges = self.tree.find(filter);
+        self.pos = 0;
+    }
+
+    /// Sum of `num_docs` across every range in the current window.
+    ///
+    /// Used as the per-window document estimate, both for the source's
+    /// `num_estimated` and to advance the filter `offset` past a consumed
+    /// window on retry.
+    pub fn total_docs_estimate(&self) -> usize {
+        self.ranges.iter().map(|r| r.num_docs() as usize).sum()
+    }
+
+    /// Whether every range of the current window has been handed out.
+    pub fn is_exhausted(&self) -> bool {
+        self.pos >= self.ranges.len()
+    }
+
+    /// Materialize the next `n` value-ordered ranges into one doc-id-ordered
+    /// batch, or `None` once the window is exhausted.
+    ///
+    /// `n` is clamped to at least `1`.
+    pub fn next_n(&mut self, n: usize) -> Option<NumericScoreBatch> {
+        if self.pos >= self.ranges.len() {
+            return None;
+        }
+        let end = (self.pos + n.max(1)).min(self.ranges.len());
+        let batch = merge_ranges(&self.ranges[self.pos..end]);
+        self.pos = end;
+        Some(batch)
+    }
+}
+
+/// Read every record of each range into a single `(doc_id, score)` vector
+/// sorted strictly ascending by doc id.
+///
+/// Ranges overlap in doc-id space, so reading them back-to-back yields
+/// interleaved ids; the sort restores the strictly-increasing order that
+/// [`NumericScoreBatch`] requires for its `skip_to` `partition_point`.
+fn merge_ranges(ranges: &[&NumericRange]) -> NumericScoreBatch {
+    let mut items: Vec<(DocId, f64)> = Vec::new();
+    let mut record = RSIndexResult::build_numeric(0.0).build();
+    for range in ranges {
+        let mut reader = range.reader();
+        while reader.next_record(&mut record).unwrap_or(false) {
+            let score = record
+                .as_numeric()
+                .expect("numeric range yields numeric records");
+            items.push((record.doc_id, score));
+        }
+    }
+    items.sort_unstable_by_key(|(doc_id, _)| *doc_id);
+    NumericScoreBatch::new(items)
+}

--- a/src/redisearch_rs/numeric_score_source/src/score_batch.rs
+++ b/src/redisearch_rs/numeric_score_source/src/score_batch.rs
@@ -14,8 +14,8 @@ use top_k::ScoreBatch;
 
 /// A [`ScoreBatch`] backed by a doc-id-ordered `Vec<(DocId, f64)>`.
 ///
-/// Doc IDs must be strictly increasing — the numeric index reader yields them
-/// in ascending order; this is asserted in debug builds.
+/// Doc IDs must be strictly increasing, so [`skip_to`](ScoreBatch::skip_to) can
+/// `partition_point`; this is asserted in debug builds.
 pub struct NumericScoreBatch {
     items: Vec<(DocId, f64)>,
     pos: usize,

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -88,7 +88,8 @@ pub struct NumericScoreSource<'index> {
     num_estimated: usize,
     /// Whether the filtered expand-and-retry path is active.
     retry_enabled: bool,
-    /// Total documents in the index, used to bound and cap window expansion.
+    /// Total documents in the index, the selectivity denominator that sizes
+    /// each retry window's estimated limit.
     num_docs: usize,
     /// Filter child's selectivity estimate, used to size the next window.
     child_estimate: usize,
@@ -212,9 +213,9 @@ impl<'index> NumericScoreSource<'index> {
         if !self.retry_enabled || self.num_iterations >= MAX_ITERATIONS {
             return false;
         }
-        // `limit == 0` is unbounded, and `limit >= num_docs` already reads the
-        // whole index: in both cases there is nothing left to expand into.
-        if self.filter.limit == 0 || self.filter.limit >= self.num_docs {
+        // A `limit == 0` window is unbounded and has already read every remaining
+        // range, so there is nothing left to expand into.
+        if self.filter.limit == 0 {
             return false;
         }
 
@@ -222,9 +223,9 @@ impl<'index> NumericScoreSource<'index> {
         let success_ratio = self.success_ratio(heap_count);
 
         if success_ratio < MIN_SUCCESS_RATIO || self.num_iterations + 1 >= MAX_ITERATIONS {
-            // Hits are too sparse, or this is the last allowed retry: stop
-            // estimating and read every remaining document.
-            self.filter.limit = self.num_docs;
+            // Hits are too sparse, or this is the last allowed retry: drop the
+            // window limit so the retry reads every remaining range.
+            self.filter.limit = 0;
         } else {
             let results_missing = k.saturating_sub(heap_count);
             let estimate = estimate_limit(self.num_docs, self.child_estimate, results_missing);
@@ -232,9 +233,16 @@ impl<'index> NumericScoreSource<'index> {
             self.filter.limit = self.last_limit_estimate.max(1);
         }
 
+        self.ranges.refind(&self.filter);
+
+        // The advanced window resolved to no ranges: the tree is exhausted, so
+        // report no expansion rather than a spurious empty one.
+        if self.ranges.is_exhausted() {
+            return false;
+        }
+
         self.num_iterations += 1;
         self.heap_old_size = heap_count;
-        self.ranges.refind(&self.filter);
         true
     }
 }

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -55,10 +55,13 @@ const MIN_SUCCESS_RATIO: f64 = 0.01;
 ///
 /// With a filter child, the initial window may be too small to fill the heap.
 /// When a window is drained with `heap_count < k`,
-/// [`batch_strategy`](ScoreSource::batch_strategy) expands the window
-/// (`offset`/`limit`) and returns [`BatchStrategy::SwitchToBatches`] so the
-/// surrounding iterator re-collects against the larger window. The unfiltered
-/// path reads an unbounded window and never retries.
+/// [`batch_strategy`](ScoreSource::batch_strategy) advances `offset`/`limit` to
+/// the next disjoint window and returns [`BatchStrategy::ExpandWindow`]. The
+/// windows are disjoint in value space, so the heap keeps accumulating the
+/// global top `k` across them. The unfiltered path reads an unbounded window and
+/// never retries.
+///
+/// [`BatchStrategy::ExpandWindow`]: top_k::BatchStrategy::ExpandWindow
 ///
 /// [`TopKIterator`]: top_k::TopKIterator
 ///
@@ -73,6 +76,9 @@ pub struct NumericScoreSource<'index> {
     /// Filter driving [`find`](NumericRangeTree::find); its `offset`/`limit`
     /// window is mutated in place by the retry expansion.
     filter: NumericFilter,
+    /// Initial `offset`/`limit` of `filter`, restored by [`rewind`](ScoreSource::rewind).
+    initial_offset: usize,
+    initial_limit: usize,
     /// Sort direction (`SORTBY field ASC`/`DESC`), also written into `filter`.
     ascending: bool,
     /// Number of value-ordered ranges materialized per batch. Always `>= 1`.
@@ -97,8 +103,11 @@ pub struct NumericScoreSource<'index> {
 }
 
 impl<'index> NumericScoreSource<'index> {
-    /// Build an unfiltered source: an unbounded value-ordered window with no
-    /// retry. `LIMIT k` is served by the heap plus the early `Stop`.
+    /// Build a source for the unfiltered case (no filter child): an unbounded
+    /// value-ordered window with no retry. `filter` is the numeric range over
+    /// the sort field that picks which ranges to read; its `offset`/`limit`
+    /// window is ignored here, since `LIMIT k` is served by the heap plus the
+    /// early `Stop`.
     pub fn unfiltered(
         tree: &'index NumericRangeTree,
         filter: NumericFilter,
@@ -160,6 +169,8 @@ impl<'index> NumericScoreSource<'index> {
         Self {
             ranges,
             last_limit_estimate: filter.limit,
+            initial_offset: filter.offset,
+            initial_limit: filter.limit,
             filter,
             ascending,
             range_batch_size: range_batch_size.max(1),
@@ -188,11 +199,15 @@ impl<'index> NumericScoreSource<'index> {
         collected as f64 / self.last_limit_estimate as f64
     }
 
-    /// Advance the filter window past the drained one and size the next.
+    /// Advance the window past the drained one, size the next, and re-resolve
+    /// the range stream onto it.
     ///
-    /// Returns `true` if the window was expanded (so the caller should
-    /// `SwitchToBatches`), `false` if no expansion is possible (already
-    /// unbounded, out of retries, or retry disabled).
+    /// Returns `true` if a new (disjoint) window was resolved, so the caller can
+    /// return [`BatchStrategy::ExpandWindow`]; `false` if no expansion is
+    /// possible (already unbounded, out of retries, or retry disabled), leaving
+    /// the window untouched.
+    ///
+    /// [`BatchStrategy::ExpandWindow`]: top_k::BatchStrategy::ExpandWindow
     fn expand_window(&mut self, heap_count: usize, k: usize) -> bool {
         if !self.retry_enabled || self.num_iterations >= MAX_ITERATIONS {
             return false;
@@ -219,6 +234,7 @@ impl<'index> NumericScoreSource<'index> {
 
         self.num_iterations += 1;
         self.heap_old_size = heap_count;
+        self.ranges.refind(&self.filter);
         true
     }
 }
@@ -231,8 +247,9 @@ impl<'index> ScoreSource for NumericScoreSource<'index> {
     }
 
     fn lookup_score(&mut self, _doc_id: DocId) -> Option<f64> {
-        // Adhoc-BF is not used by the numeric path.
-        None
+        // The numeric path never returns `SwitchToAdhoc`, so Adhoc-BF is never
+        // entered and this is unreachable.
+        unimplemented!("numeric top-k does not use Adhoc-BF")
     }
 
     fn num_estimated(&self) -> usize {
@@ -240,9 +257,14 @@ impl<'index> ScoreSource for NumericScoreSource<'index> {
     }
 
     fn rewind(&mut self) {
-        // Re-resolve whatever window the filter currently holds: the original
-        // one for an outer rewind, or the expanded one set by `expand_window`
-        // just before a `SwitchToBatches`.
+        // Full reset to the initial window. The expand-and-retry path resolves
+        // its own windows inside `expand_window`, so this is only reached for an
+        // outer rewind that restarts the whole query.
+        self.filter.offset = self.initial_offset;
+        self.filter.limit = self.initial_limit;
+        self.last_limit_estimate = self.initial_limit;
+        self.num_iterations = 0;
+        self.heap_old_size = 0;
         self.ranges.refind(&self.filter);
     }
 
@@ -263,10 +285,11 @@ impl<'index> ScoreSource for NumericScoreSource<'index> {
         if !self.ranges.is_exhausted() {
             return BatchStrategy::Continue;
         }
-        // Window drained with the heap still short of k: expand and retry if we
-        // can, otherwise `Continue` so `next_batch` reports EOF and finalizes.
+        // Window drained with the heap still short of k: advance to the next
+        // disjoint window if we can, otherwise `Continue` so `next_batch`
+        // reports EOF and finalizes.
         if self.expand_window(heap_count, k) {
-            BatchStrategy::SwitchToBatches
+            BatchStrategy::ExpandWindow
         } else {
             BatchStrategy::Continue
         }

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -273,6 +273,7 @@ impl<'index> ScoreSource for NumericScoreSource<'index> {
         self.last_limit_estimate = self.initial_limit;
         self.num_iterations = 0;
         self.heap_old_size = 0;
+        self.ranges.forget_emitted();
         self.ranges.refind(&self.filter);
     }
 

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -48,6 +48,15 @@ unsafe impl<'index, R, E> NumericRecords<'index> for Numeric<'index, R, E> where
 {
 }
 
+/// Default per-batch record cap for [`next_batch`](ScoreSource::next_batch).
+///
+/// At 16 bytes per `(DocId, f64)` pair this caps a batch at ~64 KiB. It is large
+/// enough to amortize the per-batch child rewind in `intersect_batch_with_child`
+/// (the child is rewound and merge-joined once per batch) yet small enough that a
+/// filtered top-k query over a huge numeric field no longer allocates one entry
+/// per record.
+const MATERIALIZE_BATCH_SIZE: usize = 4096;
+
 /// Scores each document by a numeric field, for top-k queries like
 /// `SORTBY <numeric field>`.
 ///
@@ -55,9 +64,20 @@ unsafe impl<'index, R, E> NumericRecords<'index> for Numeric<'index, R, E> where
 /// iterator, so taking the top `k` here means taking the `k` highest values of
 /// that field.
 ///
-/// [`next_batch`](ScoreSource::next_batch) reads the whole source into one
-/// batch, ordered by doc id; the surrounding [`TopKIterator`] then picks the top
-/// `k` with its heap.
+/// The wrapped source yields records in doc-id order, not score order, so the
+/// surrounding [`TopKIterator`] does the top-k selection with its heap. To keep
+/// peak memory bounded, [`next_batch`](ScoreSource::next_batch) drains the source
+/// in chunks of at most `batch_size` records rather than materializing the whole
+/// index at once; the iterator pushes each chunk through the heap (intersecting
+/// with the filter child first, when present) and keeps the running top `k`.
+///
+/// Both the filtered and unfiltered numeric top-k iterators run in
+/// [`TopKMode::Batches`], so every query path flows through
+/// [`next_batch`](ScoreSource::next_batch) and the heap — there is no
+/// heap-bypassing single-batch path here, and bounded batches keep memory
+/// bounded in both cases.
+///
+/// [`TopKMode::Batches`]: top_k::TopKMode::Batches
 ///
 /// Adhoc-BF strategy has not been implemented
 ///
@@ -72,9 +92,9 @@ unsafe impl<'index, R, E> NumericRecords<'index> for Numeric<'index, R, E> where
 pub struct NumericScoreSource<'index, S: NumericRecords<'index>> {
     /// Numeric iterator whose per-document value is used as the score.
     source: S,
-    /// Whether [`next_batch`](ScoreSource::next_batch) has already emitted its
-    /// single batch. Reset by [`rewind`](ScoreSource::rewind).
-    drained: bool,
+    /// Maximum number of records [`next_batch`](ScoreSource::next_batch) reads
+    /// into a single batch. Always `>= 1`.
+    batch_size: usize,
     /// Upper-bound result estimate captured at construction, so it stays stable
     /// after the source is drained.
     num_estimated: usize,
@@ -82,28 +102,34 @@ pub struct NumericScoreSource<'index, S: NumericRecords<'index>> {
 }
 
 impl<'index, S: NumericRecords<'index>> NumericScoreSource<'index, S> {
-    /// Wrap a numeric `source` iterator as a score source.
+    /// Wrap a numeric `source` iterator as a score source, using the default
+    /// `MATERIALIZE_BATCH_SIZE` per-batch cap.
     pub fn new(source: S) -> Self {
+        Self::with_batch_size(source, MATERIALIZE_BATCH_SIZE)
+    }
+
+    /// Like [`new`](Self::new) but with an explicit per-batch record cap, so
+    /// callers (chiefly tests) can force multi-batch behavior on small inputs.
+    /// `batch_size` is clamped to at least `1`.
+    pub fn with_batch_size(source: S, batch_size: usize) -> Self {
         let num_estimated = source.num_estimated();
         Self {
             source,
-            drained: false,
+            batch_size: batch_size.max(1),
             num_estimated,
             _index: PhantomData,
         }
     }
-}
 
-impl<'index, S: NumericRecords<'index>> ScoreSource for NumericScoreSource<'index, S> {
-    type Batch = NumericScoreBatch;
-
-    fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
-        if self.drained {
-            return Ok(None);
-        }
-
-        let mut items = Vec::new();
-        while let Some(result) = self.source.read()? {
+    /// Drain up to [`batch_size`](Self::batch_size) records from the source into a
+    /// doc-id-ordered batch, so a top-k query never materializes the whole numeric
+    /// index at once. Returns `Ok(None)` once the source is exhausted.
+    fn read_batch(&mut self) -> Result<Option<NumericScoreBatch>, RQEIteratorError> {
+        let mut items = Vec::with_capacity(self.batch_size.min(self.num_estimated));
+        while items.len() < self.batch_size {
+            let Some(result) = self.source.read()? else {
+                break;
+            };
             debug_assert!(
                 matches!(result.kind(), RSResultKind::Numeric | RSResultKind::Metric),
                 "NumericScoreSource: wrapped iterator yielded a non-numeric record ({})",
@@ -114,12 +140,19 @@ impl<'index, S: NumericRecords<'index>> ScoreSource for NumericScoreSource<'inde
             let score = unsafe { result.as_numeric_unchecked() };
             items.push((result.doc_id, score));
         }
-        self.drained = true;
 
         if items.is_empty() {
             return Ok(None);
         }
         Ok(Some(NumericScoreBatch::new(items)))
+    }
+}
+
+impl<'index, S: NumericRecords<'index>> ScoreSource for NumericScoreSource<'index, S> {
+    type Batch = NumericScoreBatch;
+
+    fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
+        self.read_batch()
     }
 
     fn lookup_score(&mut self, _doc_id: DocId) -> Option<f64> {
@@ -133,7 +166,6 @@ impl<'index, S: NumericRecords<'index>> ScoreSource for NumericScoreSource<'inde
 
     fn rewind(&mut self) {
         self.source.rewind();
-        self.drained = false;
     }
 
     fn build_result<'r>(&self, doc_id: DocId, score: f64) -> RSIndexResult<'r>
@@ -143,12 +175,15 @@ impl<'index, S: NumericRecords<'index>> ScoreSource for NumericScoreSource<'inde
         RSIndexResult::build_numeric(score).doc_id(doc_id).build()
     }
 
-    fn batch_strategy(&mut self, heap_count: usize, k: usize) -> BatchStrategy {
-        if heap_count >= k {
-            BatchStrategy::Stop
-        } else {
-            BatchStrategy::Continue
-        }
+    fn batch_strategy(&mut self, _heap_count: usize, _k: usize) -> BatchStrategy {
+        // Records arrive in doc-id order, so a batch is an arbitrary doc-id slice,
+        // not a score bracket: a higher score may still appear in a later batch.
+        // The heap can therefore only know the true top-k once every record has
+        // been offered, so always keep pulling until the source reaches EOF
+        // (`next_batch` returns `Ok(None)`). Unlike the vector source — whose
+        // batches are successive score brackets — we must never `Stop` early on a
+        // full heap, or we would drop higher-scored documents from later batches.
+        BatchStrategy::Continue
     }
 
     fn iterator_type(&self) -> IteratorType {

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -243,7 +243,7 @@ impl<'index> ScoreSource for NumericScoreSource<'index> {
     type Batch = NumericScoreBatch;
 
     fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
-        Ok(self.ranges.next_n(self.range_batch_size))
+        Ok(self.ranges.next_n(self.range_batch_size)?)
     }
 
     fn lookup_score(&mut self, _doc_id: DocId) -> Option<f64> {

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -7,152 +7,227 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! [`NumericScoreSource`] — [`ScoreSource`] implementation backed by a numeric
-//! [`RQEIterator`].
+//! [`NumericScoreSource`] — a [`ScoreSource`] that scores documents by a
+//! numeric field, reading the field's value-ordered ranges directly from a
+//! [`NumericRangeTree`].
 
-use std::marker::PhantomData;
-
-use index_result::{RSIndexResult, RSResultKind};
+use index_result::RSIndexResult;
+use inverted_index::NumericFilter;
+use numeric_range_tree::NumericRangeTree;
 use rqe_core::DocId;
 use rqe_iterator_type::IteratorType;
-use rqe_iterators::{RQEIterator, RQEIteratorError, inverted_index::Numeric, metric::Metric};
+use rqe_iterators::RQEIteratorError;
 use top_k::{BatchStrategy, ScoreSource};
 
+use crate::range_iterator::NumericRangeIterator;
 use crate::score_batch::NumericScoreBatch;
 
-/// An [`RQEIterator`] whose records are guaranteed to be numeric.
+/// Default number of value-ordered ranges materialized into a single batch.
 ///
-/// [`NumericScoreSource`] is generic over its source iterator, but reads each
-/// record's score via [`as_numeric_unchecked`](RSIndexResult::as_numeric_unchecked),
-/// which is undefined behavior on a non-numeric record. This trait restricts the
-/// source to iterators that uphold that guarantee.
+/// Larger batches amortize the per-batch child rewind in the surrounding
+/// [`TopKIterator`]'s `intersect_batch_with_child`; smaller batches tighten the
+/// early-`Stop` granularity, since a batch boundary is also a score-bracket
+/// boundary. Callers (chiefly tests) override it to force multi-batch behavior.
 ///
-/// # Safety
-///
-/// Implementers must guarantee that every record produced by
-/// [`read`](RQEIterator::read) is numeric — its [`kind`](RSIndexResult::kind) is
-/// either [`RSResultKind::Numeric`] or [`RSResultKind::Metric`].
-pub unsafe trait NumericRecords<'index>: RQEIterator<'index> {}
+/// [`TopKIterator`]: top_k::TopKIterator
+const DEFAULT_RANGE_BATCH_SIZE: usize = 8;
 
-// SAFETY: every record is built via `RSIndexResult::build_metric`, so its kind is
-// always `Metric`.
-unsafe impl<'index, const SORTED_BY_ID: bool> NumericRecords<'index>
-    for Metric<'index, SORTED_BY_ID>
-{
-}
+/// Maximum number of expand-and-retry iterations before the next retry reads
+/// every remaining document.
+const MAX_ITERATIONS: usize = 3;
 
-// SAFETY: the wrapped reader decodes into a result seeded with
-// `RSIndexResult::build_numeric`, so its kind is always `Numeric`.
-unsafe impl<'index, R, E> NumericRecords<'index> for Numeric<'index, R, E> where
-    Self: RQEIterator<'index>
-{
-}
-
-/// Default per-batch record cap for [`next_batch`](ScoreSource::next_batch).
-///
-/// At 16 bytes per `(DocId, f64)` pair this caps a batch at ~64 KiB. It is large
-/// enough to amortize the per-batch child rewind in `intersect_batch_with_child`
-/// (the child is rewound and merge-joined once per batch) yet small enough that a
-/// filtered top-k query over a huge numeric field no longer allocates one entry
-/// per record.
-const MATERIALIZE_BATCH_SIZE: usize = 4096;
+/// Below this hit ratio for a consumed window, the next retry abandons
+/// estimation and reads every remaining document.
+const MIN_SUCCESS_RATIO: f64 = 0.01;
 
 /// Scores each document by a numeric field, for top-k queries like
 /// `SORTBY <numeric field>`.
 ///
-/// A document's score is the numeric value read from the wrapped `source`
-/// iterator, so taking the top `k` here means taking the `k` highest values of
-/// that field.
+/// A document's score is its value in the numeric field. The source asks the
+/// [`NumericRangeTree`] for the field's ranges in score order (per `ascending`),
+/// windowed by the filter's `offset`/`limit`, and hands them to the surrounding
+/// [`TopKIterator`] as doc-id-ordered batches. Because batches arrive
+/// best-score-first, a full heap (`heap_count >= k`) means no later batch can
+/// improve the result, so [`batch_strategy`](ScoreSource::batch_strategy) can
+/// `Stop` early — the value-ordering is what makes that sound.
 ///
-/// The wrapped source yields records in doc-id order, not score order, so the
-/// surrounding [`TopKIterator`] does the top-k selection with its heap. To keep
-/// peak memory bounded, [`next_batch`](ScoreSource::next_batch) drains the source
-/// in chunks of at most `batch_size` records rather than materializing the whole
-/// index at once; the iterator pushes each chunk through the heap (intersecting
-/// with the filter child first, when present) and keeps the running top `k`.
+/// # Filtered retry
 ///
-/// Both the filtered and unfiltered numeric top-k iterators run in
-/// [`TopKMode::Batches`], so every query path flows through
-/// [`next_batch`](ScoreSource::next_batch) and the heap — there is no
-/// heap-bypassing single-batch path here, and bounded batches keep memory
-/// bounded in both cases.
+/// With a filter child, the initial window may be too small to fill the heap.
+/// When a window is drained with `heap_count < k`,
+/// [`batch_strategy`](ScoreSource::batch_strategy) expands the window
+/// (`offset`/`limit`) and returns [`BatchStrategy::SwitchToBatches`] so the
+/// surrounding iterator re-collects against the larger window. The unfiltered
+/// path reads an unbounded window and never retries.
 ///
-/// [`TopKMode::Batches`]: top_k::TopKMode::Batches
-///
-/// Adhoc-BF strategy has not been implemented
+/// [`TopKIterator`]: top_k::TopKIterator
 ///
 /// Not implemented yet:
-/// - TODO: MOD-14207 Proper batching logic through numeric filter
 /// - TODO: MOD-14945 Timeout handling
 /// - TODO: MOD-14946 Profile metrics
 /// - TODO: MOD-14947 Parity tests
 /// - TODO: MOD-14948 Performance validation
-///
-/// [`TopKIterator`]: top_k::TopKIterator
-pub struct NumericScoreSource<'index, S: NumericRecords<'index>> {
-    /// Numeric iterator whose per-document value is used as the score.
-    source: S,
-    /// Maximum number of records [`next_batch`](ScoreSource::next_batch) reads
-    /// into a single batch. Always `>= 1`.
-    batch_size: usize,
-    /// Upper-bound result estimate captured at construction, so it stays stable
-    /// after the source is drained.
+pub struct NumericScoreSource<'index> {
+    /// Value-ordered range stream over the numeric index.
+    ranges: NumericRangeIterator<'index>,
+    /// Filter driving [`find`](NumericRangeTree::find); its `offset`/`limit`
+    /// window is mutated in place by the retry expansion.
+    filter: NumericFilter,
+    /// Sort direction (`SORTBY field ASC`/`DESC`), also written into `filter`.
+    ascending: bool,
+    /// Number of value-ordered ranges materialized per batch. Always `>= 1`.
+    range_batch_size: usize,
+    /// Window document estimate captured at construction, kept stable after the
+    /// window is drained or expanded.
     num_estimated: usize,
-    _index: PhantomData<&'index ()>,
+    /// Whether the filtered expand-and-retry path is active.
+    retry_enabled: bool,
+    /// Total documents in the index, used to bound and cap window expansion.
+    num_docs: usize,
+    /// Filter child's selectivity estimate, used to size the next window.
+    child_estimate: usize,
+    /// Limit of the window currently being consumed, the denominator of the
+    /// success ratio.
+    last_limit_estimate: usize,
+    /// Heap count at the start of the current window, the baseline for counting
+    /// hits collected from it.
+    heap_old_size: usize,
+    /// Number of expand-and-retry iterations performed so far.
+    num_iterations: usize,
 }
 
-impl<'index, S: NumericRecords<'index>> NumericScoreSource<'index, S> {
-    /// Wrap a numeric `source` iterator as a score source, using the default
-    /// `MATERIALIZE_BATCH_SIZE` per-batch cap.
-    pub fn new(source: S) -> Self {
-        Self::with_batch_size(source, MATERIALIZE_BATCH_SIZE)
+impl<'index> NumericScoreSource<'index> {
+    /// Build an unfiltered source: an unbounded value-ordered window with no
+    /// retry. `LIMIT k` is served by the heap plus the early `Stop`.
+    pub fn unfiltered(
+        tree: &'index NumericRangeTree,
+        filter: NumericFilter,
+        ascending: bool,
+    ) -> Self {
+        Self::with_range_batch_size(tree, filter, ascending, DEFAULT_RANGE_BATCH_SIZE)
     }
 
-    /// Like [`new`](Self::new) but with an explicit per-batch record cap, so
-    /// callers (chiefly tests) can force multi-batch behavior on small inputs.
-    /// `batch_size` is clamped to at least `1`.
-    pub fn with_batch_size(source: S, batch_size: usize) -> Self {
-        let num_estimated = source.num_estimated();
+    /// Like [`unfiltered`](Self::unfiltered) but with an explicit per-batch range
+    /// count, so tests can force multi-batch behavior on small inputs.
+    pub fn with_range_batch_size(
+        tree: &'index NumericRangeTree,
+        mut filter: NumericFilter,
+        ascending: bool,
+        range_batch_size: usize,
+    ) -> Self {
+        filter.ascending = ascending;
+        filter.limit = 0;
+        filter.offset = 0;
+        Self::build(tree, filter, ascending, range_batch_size, 0, 0, false)
+    }
+
+    /// Build a filtered source with the expand-and-retry path enabled.
+    ///
+    /// `num_docs` is the total document count and `child_estimate` the filter
+    /// child's selectivity estimate; both size the retry windows. `filter.limit`
+    /// is the initial window size.
+    pub fn filtered(
+        tree: &'index NumericRangeTree,
+        mut filter: NumericFilter,
+        ascending: bool,
+        range_batch_size: usize,
+        num_docs: usize,
+        child_estimate: usize,
+    ) -> Self {
+        filter.ascending = ascending;
+        Self::build(
+            tree,
+            filter,
+            ascending,
+            range_batch_size,
+            num_docs,
+            child_estimate,
+            true,
+        )
+    }
+
+    fn build(
+        tree: &'index NumericRangeTree,
+        filter: NumericFilter,
+        ascending: bool,
+        range_batch_size: usize,
+        num_docs: usize,
+        child_estimate: usize,
+        retry_enabled: bool,
+    ) -> Self {
+        let ranges = NumericRangeIterator::new(tree, &filter);
+        let num_estimated = ranges.total_docs_estimate();
         Self {
-            source,
-            batch_size: batch_size.max(1),
+            ranges,
+            last_limit_estimate: filter.limit,
+            filter,
+            ascending,
+            range_batch_size: range_batch_size.max(1),
             num_estimated,
-            _index: PhantomData,
+            retry_enabled,
+            num_docs,
+            child_estimate,
+            heap_old_size: 0,
+            num_iterations: 0,
         }
     }
 
-    /// Drain up to [`batch_size`](Self::batch_size) records from the source into a
-    /// doc-id-ordered batch, so a top-k query never materializes the whole numeric
-    /// index at once. Returns `Ok(None)` once the source is exhausted.
-    fn read_batch(&mut self) -> Result<Option<NumericScoreBatch>, RQEIteratorError> {
-        let mut items = Vec::with_capacity(self.batch_size.min(self.num_estimated));
-        while items.len() < self.batch_size {
-            let Some(result) = self.source.read()? else {
-                break;
-            };
-            debug_assert!(
-                matches!(result.kind(), RSResultKind::Numeric | RSResultKind::Metric),
-                "NumericScoreSource: wrapped iterator yielded a non-numeric record ({})",
-                result.kind()
-            );
-            // SAFETY: the `S: NumericRecords` bound guarantees every record read
-            // from `source` is numeric.
-            let score = unsafe { result.as_numeric_unchecked() };
-            items.push((result.doc_id, score));
+    /// Sort direction the source reads in, for the heap comparator.
+    pub fn ascending(&self) -> bool {
+        self.ascending
+    }
+
+    /// Hit ratio of the window just consumed: results collected from it over the
+    /// window's limit. Returns `0.0` when the limit is `0`, guarding the
+    /// division.
+    fn success_ratio(&self, heap_count: usize) -> f64 {
+        if self.last_limit_estimate == 0 {
+            return 0.0;
+        }
+        let collected = heap_count.saturating_sub(self.heap_old_size);
+        collected as f64 / self.last_limit_estimate as f64
+    }
+
+    /// Advance the filter window past the drained one and size the next.
+    ///
+    /// Returns `true` if the window was expanded (so the caller should
+    /// `SwitchToBatches`), `false` if no expansion is possible (already
+    /// unbounded, out of retries, or retry disabled).
+    fn expand_window(&mut self, heap_count: usize, k: usize) -> bool {
+        if !self.retry_enabled || self.num_iterations >= MAX_ITERATIONS {
+            return false;
+        }
+        // `limit == 0` is unbounded, and `limit >= num_docs` already reads the
+        // whole index: in both cases there is nothing left to expand into.
+        if self.filter.limit == 0 || self.filter.limit >= self.num_docs {
+            return false;
         }
 
-        if items.is_empty() {
-            return Ok(None);
+        self.filter.offset += self.ranges.total_docs_estimate();
+        let success_ratio = self.success_ratio(heap_count);
+
+        if success_ratio < MIN_SUCCESS_RATIO || self.num_iterations + 1 >= MAX_ITERATIONS {
+            // Hits are too sparse, or this is the last allowed retry: stop
+            // estimating and read every remaining document.
+            self.filter.limit = self.num_docs;
+        } else {
+            let results_missing = k.saturating_sub(heap_count);
+            let estimate = estimate_limit(self.num_docs, self.child_estimate, results_missing);
+            self.last_limit_estimate = ((estimate as f64) * success_ratio) as usize;
+            self.filter.limit = self.last_limit_estimate.max(1);
         }
-        Ok(Some(NumericScoreBatch::new(items)))
+
+        self.num_iterations += 1;
+        self.heap_old_size = heap_count;
+        true
     }
 }
 
-impl<'index, S: NumericRecords<'index>> ScoreSource for NumericScoreSource<'index, S> {
+impl<'index> ScoreSource for NumericScoreSource<'index> {
     type Batch = NumericScoreBatch;
 
     fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
-        self.read_batch()
+        Ok(self.ranges.next_n(self.range_batch_size))
     }
 
     fn lookup_score(&mut self, _doc_id: DocId) -> Option<f64> {
@@ -165,7 +240,10 @@ impl<'index, S: NumericRecords<'index>> ScoreSource for NumericScoreSource<'inde
     }
 
     fn rewind(&mut self) {
-        self.source.rewind();
+        // Re-resolve whatever window the filter currently holds: the original
+        // one for an outer rewind, or the expanded one set by `expand_window`
+        // just before a `SwitchToBatches`.
+        self.ranges.refind(&self.filter);
     }
 
     fn build_result<'r>(&self, doc_id: DocId, score: f64) -> RSIndexResult<'r>
@@ -175,15 +253,23 @@ impl<'index, S: NumericRecords<'index>> ScoreSource for NumericScoreSource<'inde
         RSIndexResult::build_numeric(score).doc_id(doc_id).build()
     }
 
-    fn batch_strategy(&mut self, _heap_count: usize, _k: usize) -> BatchStrategy {
-        // Records arrive in doc-id order, so a batch is an arbitrary doc-id slice,
-        // not a score bracket: a higher score may still appear in a later batch.
-        // The heap can therefore only know the true top-k once every record has
-        // been offered, so always keep pulling until the source reaches EOF
-        // (`next_batch` returns `Ok(None)`). Unlike the vector source — whose
-        // batches are successive score brackets — we must never `Stop` early on a
-        // full heap, or we would drop higher-scored documents from later batches.
-        BatchStrategy::Continue
+    fn batch_strategy(&mut self, heap_count: usize, k: usize) -> BatchStrategy {
+        // Batches arrive best-score-first, so a full heap can never be improved
+        // by a later (worse-scored) batch.
+        if heap_count >= k {
+            return BatchStrategy::Stop;
+        }
+        // More ranges remain in this window: keep draining before deciding.
+        if !self.ranges.is_exhausted() {
+            return BatchStrategy::Continue;
+        }
+        // Window drained with the heap still short of k: expand and retry if we
+        // can, otherwise `Continue` so `next_batch` reports EOF and finalizes.
+        if self.expand_window(heap_count, k) {
+            BatchStrategy::SwitchToBatches
+        } else {
+            BatchStrategy::Continue
+        }
     }
 
     fn iterator_type(&self) -> IteratorType {
@@ -202,4 +288,16 @@ impl<'index, S: NumericRecords<'index>> ScoreSource for NumericScoreSource<'inde
     {
         // TODO: MOD-14946
     }
+}
+
+/// Estimate the window limit needed to collect `limit` more results, given the
+/// child's selectivity (`estimate`/`num_docs`).
+///
+/// Returns `0` when `num_docs` or `estimate` is `0`, guarding the division.
+fn estimate_limit(num_docs: usize, estimate: usize, limit: usize) -> usize {
+    if num_docs == 0 || estimate == 0 {
+        return 0;
+    }
+    let ratio = estimate as f64 / num_docs as f64;
+    (limit as f64 / ratio) as usize + 1
 }

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -318,7 +318,17 @@ impl<'index> ScoreSource for NumericScoreSource<'index> {
     where
         Self: 'r,
     {
-        // TODO: MOD-14946
+        // Unused: the numeric field value is the ordering key and is carried by
+        // the source-built result ([`yields_child_record`] is `false`), so the
+        // iterator never takes the child-record yield path that would call this.
+        // TODO: Production metric-key wiring is tracked by MOD-14946.
+    }
+
+    fn yields_child_record(&self) -> bool {
+        // Numeric `SORTBY` orders purely by the field value the source supplies,
+        // with no relevance scoring, so yield the source-built numeric result
+        // rather than the child's record.
+        false
     }
 }
 

--- a/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
@@ -211,3 +211,61 @@ fn rewind_restarts_iteration() {
     let second = drain_all(&mut source);
     assert_eq!(first, second);
 }
+
+#[test]
+fn filtered_retry_keeps_high_match_across_windows() {
+    // Multi-leaf tree, doc_id == value == i. DESC, k=2, and the child matches the
+    // highest- and lowest-valued docs, which fall in different value-windows. The
+    // high match (doc 20) is collected in the first window; it must survive the
+    // expansion that reaches the low match (doc 1), so the heap accumulates
+    // across windows rather than restarting on each retry.
+    let tree = build_tree(20, false, 0);
+    assert!(tree.num_leaves() > 1, "fixture must split into many ranges");
+
+    let mut filter = full_range();
+    filter.limit = 1;
+    let source = NumericScoreSource::filtered(&tree, filter, false, 1, 20, 2);
+    let mut it = new_numeric_top_k_filtered(
+        source,
+        IdList::<true>::new(vec![1u64, 20u64]),
+        NonZeroUsize::new(2).unwrap(),
+    );
+
+    let mut got = Vec::new();
+    while let Some(result) = it.read().unwrap() {
+        got.push((result.doc_id, result.as_numeric().expect("numeric result")));
+    }
+    assert_eq!(got, vec![(20, 20.0), (1, 1.0)]);
+}
+
+#[test]
+fn filtered_rewind_after_expansion_repeats_results() {
+    // Driving to completion forces at least one window expansion; an outer rewind
+    // must reset to the initial window and reproduce the same results.
+    let tree = build_tree(20, false, 0);
+    let child = vec![1u64, 20u64];
+
+    let mut filter = full_range();
+    filter.limit = 1;
+    let source = NumericScoreSource::filtered(&tree, filter, false, 1, 20, 2);
+    let mut it = new_numeric_top_k_filtered(
+        source,
+        IdList::<true>::new(child),
+        NonZeroUsize::new(2).unwrap(),
+    );
+
+    let mut first = Vec::new();
+    while let Some(result) = it.read().unwrap() {
+        first.push((result.doc_id, result.as_numeric().expect("numeric result")));
+    }
+
+    it.rewind();
+
+    let mut second = Vec::new();
+    while let Some(result) = it.read().unwrap() {
+        second.push((result.doc_id, result.as_numeric().expect("numeric result")));
+    }
+
+    assert_eq!(first, second);
+    assert_eq!(first, vec![(20, 20.0), (1, 1.0)]);
+}

--- a/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
@@ -193,6 +193,46 @@ fn filtered_retry_expands_window_to_reach_low_scored_match() {
 }
 
 #[test]
+fn filtered_retry_reaches_match_past_multivalue_inflated_ranges() {
+    // Numeric top-k over a multivalue field keeps a low-valued match when a
+    // selective filter forces the window to expand into low ranges.
+    //
+    // A multivalue field indexes one entry per value, so the per-range count
+    // `find` totals over a window exceeds the unique document count. Four filler
+    // docs interleave values across the whole high span, landing each in every
+    // high leaf; the summed count runs well past the five unique docs. DESC,
+    // k=1, and the only child match sits alone in the lowest leaf.
+    let mut tree = NumericRangeTree::new(false);
+    for d in 1..=4u64 {
+        for j in 0..100u64 {
+            tree.add(d, 1000.0 + (j as f64) * 100.0 + (d as f64), true, 0);
+        }
+    }
+    let match_id = 99999u64;
+    tree.add(match_id, 0.5, false, 0);
+    assert!(
+        tree.num_leaves() >= 3,
+        "fixture needs several high leaves to inflate the per-range total"
+    );
+
+    let num_docs = 5; // docs 1..=4 plus the match doc
+    let mut filter = full_range();
+    filter.limit = 1;
+    let source = NumericScoreSource::filtered(&tree, filter, false, 1, num_docs, 1);
+    let mut it = new_numeric_top_k_filtered(
+        source,
+        IdList::<true>::new(vec![match_id]),
+        NonZeroUsize::new(1).unwrap(),
+    );
+
+    let mut got = Vec::new();
+    while let Some(result) = it.read().unwrap() {
+        got.push((result.doc_id, result.as_numeric().expect("numeric result")));
+    }
+    assert_eq!(got, vec![(match_id, 0.5)]);
+}
+
+#[test]
 fn rewind_restarts_iteration() {
     let tree = build_tree(20, false, 0);
     let mut source = NumericScoreSource::with_range_batch_size(&tree, full_range(), false, 1);

--- a/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
@@ -7,36 +7,43 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Tests for [`NumericScoreSource`], driven by a `MetricSortedById`
-//! source (a pure-Rust numeric-valued iterator).
+//! Tests for [`NumericScoreSource`], driven by real [`NumericRangeTree`]
+//! fixtures.
 
 use std::{iter, num::NonZeroUsize};
 
-use itertools::Itertools;
+use inverted_index::NumericFilter;
+use numeric_range_tree::NumericRangeTree;
+use numeric_range_tree::test_utils::build_tree;
 use numeric_score_source::{
     NumericScoreSource, new_numeric_top_k_filtered, new_numeric_top_k_unfiltered,
 };
 use rqe_core::DocId;
-use rqe_iterators::metric::MetricSortedById;
 use rqe_iterators::{IdList, RQEIterator};
 use top_k::{ScoreBatch, ScoreSource};
 
-/// Wrap `(doc_id, score)` pairs (ascending by id) as a `NumericScoreSource`.
-fn source(pairs: &[(DocId, f64)]) -> NumericScoreSource<'static, MetricSortedById<'static>> {
-    let ids = pairs.iter().map(|(id, _)| *id).collect::<Vec<_>>();
-    let scores = pairs.iter().map(|(_, s)| *s).collect::<Vec<_>>();
-    NumericScoreSource::new(MetricSortedById::new(ids, scores))
+/// Build a numeric tree from `(doc_id, value)` pairs (added in the given order).
+///
+/// Few distinct values stay a single leaf; use [`build_tree`] for a multi-leaf
+/// tree with `doc_id == value == i`.
+fn tree_from(pairs: &[(u64, f64)]) -> NumericRangeTree {
+    let mut tree = NumericRangeTree::new(false);
+    for &(id, value) in pairs {
+        tree.add(id, value, false, 0);
+    }
+    tree
 }
 
-/// Like [`source`] but with an explicit per-batch cap, to exercise multi-batch
-/// behavior on small inputs.
-fn source_with_batch_size(
-    pairs: &[(DocId, f64)],
-    batch_size: usize,
-) -> NumericScoreSource<'static, MetricSortedById<'static>> {
-    let ids = pairs.iter().map(|(id, _)| *id).collect::<Vec<_>>();
-    let scores = pairs.iter().map(|(_, s)| *s).collect::<Vec<_>>();
-    NumericScoreSource::with_batch_size(MetricSortedById::new(ids, scores), batch_size)
+/// Whole-field filter: matches every value, ascending.
+///
+/// `NumericFilter::default()` bounds the window at `0.0..f64::MAX`, which drops
+/// negatives and `+inf`; the `±inf` bounds here match the true whole-field span.
+fn full_range() -> NumericFilter {
+    NumericFilter {
+        min: f64::NEG_INFINITY,
+        max: f64::INFINITY,
+        ..NumericFilter::default()
+    }
 }
 
 /// Drain a batch into a `Vec`.
@@ -44,119 +51,54 @@ fn drain<B: ScoreBatch>(mut batch: B) -> Vec<(DocId, f64)> {
     iter::from_fn(|| batch.next()).collect()
 }
 
->>>>>>> conflict 1 of 1 ends
-#[test]
-fn next_batch_yields_every_record_in_doc_id_order() {
-    let mut src = source(&[(1, 3.0), (2, 1.0), (3, 2.0)]);
-    let mut batch = src.next_batch().unwrap().expect("a batch");
-    assert_eq!(
-        iter::from_fn(|| batch.next()).collect_vec(),
-        vec![(1, 3.0), (2, 1.0), (3, 2.0)]
-    );
-}
-
-#[test]
-fn empty_source_yields_no_batch() {
-    let mut src = source(&[]);
-    assert!(src.next_batch().unwrap().is_none());
-}
-
-#[test]
-fn next_batch_splits_into_bounded_batches() {
-    // batch_size 2 over 5 records: bounded batches in doc-id order, every record
-    // appearing once across batches, none larger than the cap, then EOF.
-    let mut src = source_with_batch_size(&[(1, 9.0), (2, 8.0), (3, 7.0), (4, 6.0), (5, 5.0)], 2);
-
-    let mut batches = Vec::new();
-    while let Some(batch) = src.next_batch().unwrap() {
-        let drained = drain(batch);
-        assert!(drained.len() <= 2, "batch exceeded the cap: {drained:?}");
-        batches.push(drained);
-    }
-
-    // Two full batches plus a trailing partial one.
-    assert_eq!(
-        batches,
-        vec![
-            vec![(1, 9.0), (2, 8.0)],
-            vec![(3, 7.0), (4, 6.0)],
-            vec![(5, 5.0)]
-        ]
-    );
-    // Source is exhausted: a further read stays empty without a rewind.
-    assert!(src.next_batch().unwrap().is_none());
-}
-
-/// Drive a filtered top-k iterator to exhaustion, collecting yielded
-/// `(doc_id, score)` pairs. The child filter passes exactly `child_ids`.
-fn run_filtered(
-    pairs: &[(DocId, f64)],
-    child_ids: Vec<DocId>,
-    batch_size: usize,
-    k: usize,
-    ascending: bool,
-) -> Vec<(DocId, f64)> {
-    let mut it = new_numeric_top_k_filtered(
-        source_with_batch_size(pairs, batch_size),
-        IdList::<true>::new(child_ids),
-        NonZeroUsize::new(k).unwrap(),
-        ascending,
-    );
+/// Drive an unfiltered top-k iterator to exhaustion, collecting the yielded
+/// `(doc_id, score)` pairs.
+fn run_unfiltered(pairs: &[(u64, f64)], k: usize, ascending: bool) -> Vec<(DocId, f64)> {
+    let tree = tree_from(pairs);
+    let source = NumericScoreSource::unfiltered(&tree, full_range(), ascending);
+    let mut it = new_numeric_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
     let mut got = Vec::new();
     while let Some(result) = it.read().unwrap() {
-        // SAFETY: the numeric source builds every result with `build_numeric`,
-        // so each yielded record is numeric.
-        let score = unsafe { result.as_numeric_unchecked() };
-        got.push((result.doc_id, score));
+        got.push((result.doc_id, result.as_numeric().expect("numeric result")));
     }
     got
 }
 
-#[test]
-fn filtered_top_k_finds_high_score_beyond_first_batch() {
-    // Regression test for bounded batches: the best-scoring match (doc 4, the
-    // second batch with batch_size 2) must win even though an earlier batch
-    // already filled the heap to k. A premature `Stop` on a full heap would
-    // wrongly return doc 2 from the first batch.
-    let pairs = [(1, 1.0), (2, 2.0), (3, 3.0), (4, 100.0), (5, 5.0)];
-    let got = run_filtered(&pairs, vec![2, 4], 2, 1, false);
-    assert_eq!(got, vec![(4, 100.0)]);
-}
-
-#[test]
-fn source_emits_one_batch_then_rewinds() {
-    let mut src = source(&[(1, 1.0), (2, 2.0)]);
-    assert!(src.next_batch().unwrap().is_some());
-    // Single-batch source: a second read without rewinding is empty.
-    assert!(src.next_batch().unwrap().is_none());
-
-    src.rewind();
-    let mut batch = src.next_batch().unwrap().expect("a batch after rewind");
-    assert_eq!(
-        iter::from_fn(|| batch.next()).collect_vec(),
-        vec![(1, 1.0), (2, 2.0)]
+/// Drive a filtered top-k iterator to exhaustion. The child filter passes
+/// exactly `child_ids`.
+fn run_filtered(
+    pairs: &[(u64, f64)],
+    child_ids: Vec<DocId>,
+    range_batch_size: usize,
+    k: usize,
+    ascending: bool,
+) -> Vec<(DocId, f64)> {
+    let tree = tree_from(pairs);
+    let child_estimate = child_ids.len();
+    let source = NumericScoreSource::filtered(
+        &tree,
+        full_range(),
+        ascending,
+        range_batch_size,
+        pairs.len(),
+        child_estimate,
     );
-}
-
-/// Drive an unfiltered top-k iterator to exhaustion, collecting the yielded
-/// `(doc_id, score)` pairs.
-fn run_unfiltered(pairs: &[(DocId, f64)], k: usize, ascending: bool) -> Vec<(DocId, f64)> {
-    let mut it =
-        new_numeric_top_k_unfiltered(source(pairs), NonZeroUsize::new(k).unwrap(), ascending);
+    let mut it = new_numeric_top_k_filtered(
+        source,
+        IdList::<true>::new(child_ids),
+        NonZeroUsize::new(k).unwrap(),
+    );
     let mut got = Vec::new();
     while let Some(result) = it.read().unwrap() {
-        // SAFETY: the numeric source builds every result with `build_numeric`,
-        // so each yielded record is numeric.
-        let score = unsafe { result.as_numeric_unchecked() };
-        got.push((result.doc_id, score));
+        got.push((result.doc_id, result.as_numeric().expect("numeric result")));
     }
     got
 }
 
 #[test]
 fn unfiltered_caps_at_k_descending() {
-    // More records than k: LIMIT k must return the k highest values (DESC),
-    // not every record in doc-id order. Yields best-first.
+    // More records than k: LIMIT k returns the k highest values (DESC),
+    // best-first.
     let got = run_unfiltered(
         &[(1, 5.0), (2, 1.0), (3, 4.0), (4, 2.0), (5, 3.0)],
         3,
@@ -173,7 +115,99 @@ fn unfiltered_caps_at_k_ascending() {
 }
 
 #[test]
+fn unfiltered_includes_negative_values() {
+    // A whole-field sort must score values below zero; the `0.0..f64::MAX`
+    // default bounds would drop them before the heap.
+    let got = run_unfiltered(&[(1, -5.0), (2, 2.0), (3, -1.0), (4, 0.0)], 4, true);
+    assert_eq!(got, vec![(1, -5.0), (3, -1.0), (4, 0.0), (2, 2.0)]);
+}
+
+#[test]
 fn unfiltered_fewer_than_k_yields_all() {
     let got = run_unfiltered(&[(1, 3.0), (2, 1.0)], 5, false);
     assert_eq!(got, vec![(1, 3.0), (2, 1.0)]);
+}
+
+#[test]
+fn empty_source_yields_no_batch() {
+    let tree = tree_from(&[]);
+    let mut source = NumericScoreSource::unfiltered(&tree, full_range(), false);
+    assert!(source.next_batch().unwrap().is_none());
+}
+
+#[test]
+fn filtered_top_k_finds_high_score_among_matches() {
+    // The best-scoring match (doc 4) must win even though lower-scored docs also
+    // pass the filter. A premature stop would wrongly return doc 2.
+    let pairs = [(1, 1.0), (2, 2.0), (3, 3.0), (4, 100.0), (5, 5.0)];
+    let got = run_filtered(&pairs, vec![2, 4], 1, 1, false);
+    assert_eq!(got, vec![(4, 100.0)]);
+}
+
+#[test]
+fn next_batch_yields_ranges_best_score_first_descending() {
+    // 20 distinct values produce a multi-leaf tree; doc_id == value == i.
+    let tree = build_tree(20, false, 0);
+    assert!(tree.num_leaves() > 1, "fixture must split into many ranges");
+
+    // One range per batch, descending: each batch's scores must all be >= the
+    // next batch's, and be doc-id-sorted within the batch.
+    let mut source = NumericScoreSource::with_range_batch_size(&tree, full_range(), false, 1);
+    let b1 = drain(source.next_batch().unwrap().expect("first batch"));
+    let b2 = drain(source.next_batch().unwrap().expect("second batch"));
+
+    let min1 = b1.iter().map(|&(_, s)| s).fold(f64::MAX, f64::min);
+    let max2 = b2.iter().map(|&(_, s)| s).fold(f64::MIN, f64::max);
+    assert!(
+        min1 >= max2,
+        "DESC: batch1 scores must all be >= batch2 scores"
+    );
+    assert!(
+        b1.windows(2).all(|w| w[0].0 < w[1].0),
+        "doc ids within a batch must be strictly increasing"
+    );
+}
+
+#[test]
+fn filtered_retry_expands_window_to_reach_low_scored_match() {
+    // Multi-leaf tree, doc_id == value == i. DESC, k=1, and the child matches
+    // only the lowest-valued doc — which sits in the last (worst-scored) range.
+    // A tiny initial window can't reach it, so the source must expand and retry.
+    let tree = build_tree(20, false, 0);
+    assert!(tree.num_leaves() > 1, "fixture must split into many ranges");
+
+    let mut filter = full_range();
+    filter.limit = 1;
+    let source = NumericScoreSource::filtered(&tree, filter, false, 1, 20, 1);
+    let mut it = new_numeric_top_k_filtered(
+        source,
+        IdList::<true>::new(vec![1u64]),
+        NonZeroUsize::new(1).unwrap(),
+    );
+
+    let mut got = Vec::new();
+    while let Some(result) = it.read().unwrap() {
+        got.push((result.doc_id, result.as_numeric().expect("numeric result")));
+    }
+    assert_eq!(got, vec![(1, 1.0)]);
+}
+
+#[test]
+fn rewind_restarts_iteration() {
+    let tree = build_tree(20, false, 0);
+    let mut source = NumericScoreSource::with_range_batch_size(&tree, full_range(), false, 1);
+
+    let drain_all = |source: &mut NumericScoreSource| {
+        let mut all = Vec::new();
+        while let Some(batch) = source.next_batch().unwrap() {
+            all.extend(drain(batch));
+        }
+        all
+    };
+
+    let first = drain_all(&mut source);
+    assert!(!first.is_empty());
+    source.rewind();
+    let second = drain_all(&mut source);
+    assert_eq!(first, second);
 }

--- a/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
@@ -13,10 +13,12 @@
 use std::{iter, num::NonZeroUsize};
 
 use itertools::Itertools;
-use numeric_score_source::{NumericScoreSource, new_numeric_top_k_unfiltered};
+use numeric_score_source::{
+    NumericScoreSource, new_numeric_top_k_filtered, new_numeric_top_k_unfiltered,
+};
 use rqe_core::DocId;
-use rqe_iterators::RQEIterator;
 use rqe_iterators::metric::MetricSortedById;
+use rqe_iterators::{IdList, RQEIterator};
 use top_k::{ScoreBatch, ScoreSource};
 
 /// Wrap `(doc_id, score)` pairs (ascending by id) as a `NumericScoreSource`.
@@ -26,6 +28,23 @@ fn source(pairs: &[(DocId, f64)]) -> NumericScoreSource<'static, MetricSortedByI
     NumericScoreSource::new(MetricSortedById::new(ids, scores))
 }
 
+/// Like [`source`] but with an explicit per-batch cap, to exercise multi-batch
+/// behavior on small inputs.
+fn source_with_batch_size(
+    pairs: &[(DocId, f64)],
+    batch_size: usize,
+) -> NumericScoreSource<'static, MetricSortedById<'static>> {
+    let ids = pairs.iter().map(|(id, _)| *id).collect::<Vec<_>>();
+    let scores = pairs.iter().map(|(_, s)| *s).collect::<Vec<_>>();
+    NumericScoreSource::with_batch_size(MetricSortedById::new(ids, scores), batch_size)
+}
+
+/// Drain a batch into a `Vec`.
+fn drain<B: ScoreBatch>(mut batch: B) -> Vec<(DocId, f64)> {
+    iter::from_fn(|| batch.next()).collect()
+}
+
+>>>>>>> conflict 1 of 1 ends
 #[test]
 fn next_batch_yields_every_record_in_doc_id_order() {
     let mut src = source(&[(1, 3.0), (2, 1.0), (3, 2.0)]);
@@ -40,6 +59,68 @@ fn next_batch_yields_every_record_in_doc_id_order() {
 fn empty_source_yields_no_batch() {
     let mut src = source(&[]);
     assert!(src.next_batch().unwrap().is_none());
+}
+
+#[test]
+fn next_batch_splits_into_bounded_batches() {
+    // batch_size 2 over 5 records: bounded batches in doc-id order, every record
+    // appearing once across batches, none larger than the cap, then EOF.
+    let mut src = source_with_batch_size(&[(1, 9.0), (2, 8.0), (3, 7.0), (4, 6.0), (5, 5.0)], 2);
+
+    let mut batches = Vec::new();
+    while let Some(batch) = src.next_batch().unwrap() {
+        let drained = drain(batch);
+        assert!(drained.len() <= 2, "batch exceeded the cap: {drained:?}");
+        batches.push(drained);
+    }
+
+    // Two full batches plus a trailing partial one.
+    assert_eq!(
+        batches,
+        vec![
+            vec![(1, 9.0), (2, 8.0)],
+            vec![(3, 7.0), (4, 6.0)],
+            vec![(5, 5.0)]
+        ]
+    );
+    // Source is exhausted: a further read stays empty without a rewind.
+    assert!(src.next_batch().unwrap().is_none());
+}
+
+/// Drive a filtered top-k iterator to exhaustion, collecting yielded
+/// `(doc_id, score)` pairs. The child filter passes exactly `child_ids`.
+fn run_filtered(
+    pairs: &[(DocId, f64)],
+    child_ids: Vec<DocId>,
+    batch_size: usize,
+    k: usize,
+    ascending: bool,
+) -> Vec<(DocId, f64)> {
+    let mut it = new_numeric_top_k_filtered(
+        source_with_batch_size(pairs, batch_size),
+        IdList::<true>::new(child_ids),
+        NonZeroUsize::new(k).unwrap(),
+        ascending,
+    );
+    let mut got = Vec::new();
+    while let Some(result) = it.read().unwrap() {
+        // SAFETY: the numeric source builds every result with `build_numeric`,
+        // so each yielded record is numeric.
+        let score = unsafe { result.as_numeric_unchecked() };
+        got.push((result.doc_id, score));
+    }
+    got
+}
+
+#[test]
+fn filtered_top_k_finds_high_score_beyond_first_batch() {
+    // Regression test for bounded batches: the best-scoring match (doc 4, the
+    // second batch with batch_size 2) must win even though an earlier batch
+    // already filled the heap to k. A premature `Stop` on a full heap would
+    // wrongly return doc 2 from the first batch.
+    let pairs = [(1, 1.0), (2, 2.0), (3, 3.0), (4, 100.0), (5, 5.0)];
+    let got = run_filtered(&pairs, vec![2, 4], 2, 1, false);
+    assert_eq!(got, vec![(4, 100.0)]);
 }
 
 #[test]

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -442,8 +442,9 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             // Poll once per step, before yielding or skipping an entry.
             self.source.check_timeout()?;
 
-            // Filtered mode: yield the stored child record so BM25 inputs survive.
-            if self.child.is_some() {
+            // Filtered mode: yield the stored child record so BM25 inputs survive,
+            // unless the source builds its own result (e.g. numeric `SORTBY`).
+            if self.child.is_some() && self.source.yields_child_record() {
                 let Some(mut record) = record else {
                     // A filtered-mode entry must always carry its captured record;
                     // a missing one would indicate a collection-side bug. Treat as
@@ -460,7 +461,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
                 return Ok(self.current.as_mut());
             }
 
-            // Unfiltered fallback (no child): build a fresh result from the source.
+            // No child record to yield: build a fresh result from the source.
             let result = self.source.build_result(doc_id, score);
             if self.source.is_expired(&result) {
                 continue;

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -300,13 +300,11 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
                     self.collect_adhoc()?;
                     return Ok(());
                 }
-                BatchStrategy::SwitchToBatches => {
+                BatchStrategy::ExpandWindow => {
                     self.metrics.strategy_switches += 1;
-                    // Clear the heap: the source restarts with new parameters
-                    // (e.g. expanded numeric range) and will re-emit previously
-                    // collected docs. Keeping stale entries would cause duplicates.
-                    *self.heap = TopKHeap::new(self.k, self.compare);
-                    self.source.rewind();
+                    // The source already re-resolved itself to the next disjoint
+                    // window, so the heap stays valid and keeps accumulating.
+                    // Only the child is rewound for re-intersection.
                     if let Some(child) = &mut self.child {
                         child.rewind();
                     }

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -247,4 +247,8 @@ impl ScoreSource for MockScoreSource {
         Self: 'r,
     {
     }
+
+    fn yields_child_record(&self) -> bool {
+        true
+    }
 }

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -49,11 +49,14 @@ pub enum BatchStrategy {
     /// The iterator will rewind the child and start calling
     /// [`ScoreSource::lookup_score`] for each document the child yields.
     SwitchToAdhoc,
-    /// Restart batch collection (e.g. after the source has expanded its range).
+    /// Advance to the next, disjoint window of the source.
     ///
-    /// The iterator rewinds both the source and the child, then re-enters
-    /// Batches mode from the beginning.
-    SwitchToBatches,
+    /// The source has already re-resolved itself to a new window whose
+    /// documents do not overlap any previously emitted window, so the running
+    /// heap stays valid and keeps accumulating the global top `k`. The iterator
+    /// rewinds **only the child** and keeps collecting; it does **not** clear
+    /// the heap or rewind the source.
+    ExpandWindow,
     /// Collection is complete — stop and yield whatever is in the heap.
     Stop,
 }

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -208,7 +208,8 @@ pub trait ScoreSource {
     /// [`AdhocBF`](crate::TopKMode::AdhocBF)) the iterator yields the **child's**
     /// `RSIndexResult` directly so its scoring inputs (frequency, field mask,
     /// term records) are preserved, and calls
-    /// [`attach_score_metric`](Self::attach_score_metric) instead.
+    /// [`attach_score_metric`](Self::attach_score_metric) instead — unless the
+    /// source opts out via [`yields_child_record`](Self::yields_child_record).
     ///
     /// [`TopKIterator`]: crate::TopKIterator
     fn build_result<'r>(&self, doc_id: DocId, score: f64) -> RSIndexResult<'r>
@@ -231,6 +232,17 @@ pub trait ScoreSource {
     fn attach_score_metric<'r>(&self, _result: &mut RSIndexResult<'r>, _score: f64)
     where
         Self: 'r;
+
+    /// Whether the filtered yield path should hand back the child's captured
+    /// `RSIndexResult` (with [`attach_score_metric`](Self::attach_score_metric)
+    /// applied) rather than a source-built one.
+    ///
+    /// `true` preserves the child's scoring inputs for relevance scoring — the
+    /// hybrid/vector case. A source whose score *is* the ordering key and needs
+    /// no child scoring inputs (e.g. a numeric `SORTBY`) returns `false`, so the
+    /// iterator yields [`build_result`](Self::build_result) even when a filter
+    /// child is present.
+    fn yields_child_record(&self) -> bool;
 
     /// Called after each batch (Batches mode only) to decide how collection
     /// should proceed.

--- a/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
+++ b/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
@@ -77,6 +77,10 @@ impl ScoreSource for CallCountingScoreSource {
     {
     }
 
+    fn yields_child_record(&self) -> bool {
+        true
+    }
+
     fn batch_strategy(&mut self, _: usize, _: usize) -> BatchStrategy {
         BatchStrategy::Continue
     }

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -59,6 +59,10 @@ impl ScoreSource for TimingOutSource {
     {
     }
 
+    fn yields_child_record(&self) -> bool {
+        true
+    }
+
     fn batch_strategy(&mut self, _: usize, _: usize) -> BatchStrategy {
         BatchStrategy::Continue
     }
@@ -526,6 +530,10 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
         {
         }
 
+        fn yields_child_record(&self) -> bool {
+            true
+        }
+
         fn batch_strategy(&mut self, _heap_count: usize, _k: usize) -> BatchStrategy {
             BatchStrategy::Continue
         }
@@ -748,6 +756,9 @@ fn adhoc_timeout_propagated() {
         where
             Self: 'r,
         {
+        }
+        fn yields_child_record(&self) -> bool {
+            true
         }
         fn batch_strategy(&mut self, _: usize, _: usize) -> BatchStrategy {
             BatchStrategy::Continue

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -596,20 +596,23 @@ fn strategy_switch_to_adhoc() {
 }
 
 #[test]
-fn strategy_switch_to_batches_rewinds() {
-    // Call 0 → SwitchToBatches (rewinds source+child, restarts loop).
-    // Call 1 → Stop (to exit on the second pass).
+fn strategy_expand_window_preserves_heap() {
+    // Two disjoint windows; the match from the first window (doc 1) must survive
+    // into the result after the second window is collected. A cleared heap would
+    // drop it and yield only [2].
+    // Call 0 → ExpandWindow (advance to the next window, keep the heap).
+    // Call 1 → Stop.
     let call_count = std::cell::Cell::new(0u32);
     let strategy = move |_: usize, _: usize| {
         let n = call_count.get();
         call_count.set(n + 1);
         if n == 0 {
-            BatchStrategy::SwitchToBatches
+            BatchStrategy::ExpandWindow
         } else {
             BatchStrategy::Stop
         }
     };
-    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], strategy);
+    let source = MockScoreSource::new(vec![vec![(1, 1.0)], vec![(2, 2.0)]], vec![], strategy);
     let mut it = TopKIterator::new(
         source,
         make_child(vec![1, 2]),

--- a/src/redisearch_rs/vector_score_source/Cargo.toml
+++ b/src/redisearch_rs/vector_score_source/Cargo.toml
@@ -16,9 +16,9 @@ build_utils = {path = "../build_utils"}
 [dependencies]
 ffi.workspace = true
 index_result.workspace = true
-rqe_core.workspace = true
 redis_reply.workspace = true
 rlookup.workspace = true
+rqe_core.workspace = true
 rqe_iterators.workspace = true
 top_k = {path = "../top_k"}
 tracing.workspace = true

--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -476,6 +476,13 @@ impl<'index, E: ExpirationChecker> ScoreSource for VectorScoreSource<'index, E> 
         }
     }
 
+    fn yields_child_record(&self) -> bool {
+        // A hybrid query scores relevance from the child's term records, so the
+        // child's result is what must reach the scorer; the vector distance
+        // rides along as a metric entry.
+        true
+    }
+
     fn iterator_type(&self) -> rqe_iterators::IteratorType {
         // TODO: MOD-14206: Rename.
         rqe_iterators::IteratorType::Hybrid


### PR DESCRIPTION
- builds on top of https://github.com/RediSearch/RediSearch/pull/10230/
- Next: https://github.com/RediSearch/RediSearch/pull/10467

## What changed

### From design

- The original design of `DESIGN_TOP_K.md` planned a `CollectionStrategy::SwitchToBatches` for the expanding window ("rewind") mechanism, this PR introduces this concept as `BatchStrategy::ExpandWindow`.

### From existing code

`NumericScoreSource` used to push every record of a numeric field through the top-k heap in whatever order it read them. Now it reads the values in score order, straight from the `NumericRangeTree` (through the new `NumericRangeIterator`), and hands them to the heap in small batches. Best scores arrive first, so the moment the heap holds k results the source stops — the rest of the index is never touched.

Two shapes, depending on whether the query has a filter:

- No filter — e.g. `FT.SEARCH books * SORTBY price LIMIT 0 10`. The source walks the tree's ranges in value order through NumericRangeIterator and pushes each batch straight into the heap. There is no child to match against, so nothing is intersected; the heap alone keeps the top k.

- With a filter — e.g. `FT.SEARCH books "@genre:{sci-fi}" SORTBY price LIMIT 0 10`. Each batch is intersected with the filter child before it reaches the heap. One batch covers one window of values; if too few docs in it match the filter to fill the heap, the source moves on to the next window and keeps going. Windows don't overlap in value space, so the heap still ends up with the true top k across all of them (`ExpandWindow`).

## Note on the C behavior

This follows the C `OptimizerIterator`. One difference: in the no-filter case C still runs a wildcard child and intersects every result against it, while here the no-filter path drops the child and reads ranges from `NumericRangeIterator` directly. A wildcard keeps every document, so skipping it changes nothing in the output — it just avoids a pass that always says yes.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
