### PR TITLE
skills: add run-macro-benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ compile_commands.json
 # (modules/common.mk) to indicate the upstream source is ready to build.
 # Not tracked by redisearch upstream.
 /.prepared
+# Per-run memtier_benchmark result files dropped in the repo root by
+# `redisbench-admin run-local` (named <setup>-<timestamp>--<test>.json).
+oss-*--*.json

--- a/.skills/run-macro-benchmarks/SKILL.md
+++ b/.skills/run-macro-benchmarks/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: run-macro-benchmarks
+description: Run a RediSearch end-to-end macro benchmark from tests/benchmarks/*.yml via redisbench-admin. Use this when you want to measure whole-module performance (throughput/latency) against a real redis-server, not micro Rust or C++ benchmarks.
+---
+
+# Run Macro Benchmark Skill
+
+Run a RediSearch end-to-end macro benchmark (a `tests/benchmarks/*.yml` config) against
+a real `redis-server` using `redisbench-admin run-local`.
+
+For Rust micro-benchmarks (Criterion), use `/run-rust-benchmarks` instead.
+
+## Arguments
+- No arguments: List the available benchmarks in `tests/benchmarks/` and ask which to run.
+- `<benchmark>`: Run the given benchmark. Accepts the bare name
+  (e.g. `search-expire-doc-json-10-milliseconds`), the file name with extension
+  (e.g. `search-expire-doc-json-10-milliseconds.yml`), or the full path
+  (e.g. `tests/benchmarks/search-expire-doc-json-10-milliseconds.yml`).
+
+Arguments provided: `$ARGUMENTS`
+
+## Prerequisites
+
+Confirm these before running (do not re-install if already present):
+
+1. **The modules are built.** There must be a *release* `redisearch.so` and a *release*
+   `rejson.so` under `bin/`. Filter to the `*-release/*` build flavor — a workspace can also
+   hold a `linux-x64-debug` (DEBUG=1) or coverage build, and benchmarking the wrong binary
+   silently reports numbers for it:
+   ```bash
+   find "$(pwd)/bin" -name redisearch.so -path '*-release/*'
+   find "$(pwd)/bin" -name rejson.so -path '*-release/*'
+   ```
+   Each must resolve to exactly one path. If either yields more than one candidate, stop and
+   ask the user which build to benchmark rather than guessing (the run command below aborts
+   on ambiguity). If `redisearch.so` is missing, build with `./build.sh` (or invoke `/build`). If
+   `rejson.so` is missing, build it with `./tests/deps/setup_rejson.sh`. RedisJSON is always
+   loaded (like CI) so JSON benchmarks work; without it their dataset load fails with
+   `unknown command 'JSON.SET'` and the run aborts on a keyspace check.
+2. **`redis-server`, `memtier_benchmark`, and `ftsb_redisearch` are on `$PATH`** — some
+   benchmarks need `memtier_benchmark` and/or `ftsb_redisearch`. See `developer.md`.
+3. **Python benchmark deps are installed** into the project virtualenv:
+   ```bash
+   uv pip install -r ./tests/benchmarks/requirements.txt
+   ```
+4. **Port 6379 is free.** `run-local` starts its own `redis-server` on 6379. If another
+   `redis-server` is already listening there, redisbench-admin's server fails to bind
+   (`Address already in use`) and aborts, but the benchmark then **silently loads into the
+   stale server** — which usually lacks the right modules — and fails a keyspace check with
+   `0 != <expected>` keys. Check first:
+   ```bash
+   ss -ltn | grep -q ':6379 ' && echo "PORT 6379 BUSY" || echo "port 6379 free"
+   ```
+   If busy, do NOT kill it yourself — it may be a workload the user cares about. Report it
+   and ask the user to stop it (e.g. `redis-cli -p 6379 shutdown nosave`, or by typing
+   `! redis-cli -p 6379 shutdown nosave` in the prompt).
+
+## Instructions
+
+1. Resolve the benchmark argument to a `tests/benchmarks/<benchmark>.yml` path. If no
+   argument was given, list `tests/benchmarks/*.yml` and ask the user which to run.
+2. Run the benchmark with he following commands. Capture output to a log per the
+   "Running Expensive Commands" guidance in `CLAUDE.md`:
+   ```bash
+   set -o pipefail
+
+   # Resolve exactly one *release* module; refuse to guess (a debug/coverage build
+   # under bin/ would otherwise be benchmarked and mislabelled as release numbers).
+   resolve_release_module() {
+       local name=$1 matches n
+       matches=$(find "$(pwd)/bin" -name "$name" -path '*-release/*')
+       n=$(printf '%s' "$matches" | grep -c .)
+       if [ "$n" -ne 1 ]; then
+           echo "ERROR: expected exactly one release $name under bin/, found $n:" >&2
+           printf '  %s\n' $matches >&2
+           return 1
+       fi
+       printf '%s\n' "$matches"
+   }
+   REDISEARCH_SO=$(resolve_release_module redisearch.so) || exit 1
+   REJSON_SO=$(resolve_release_module rejson.so) || exit 1
+
+   LOG=$(mktemp /tmp/macrobench.XXXXXX.log)
+   echo "Log: $LOG"
+   uv run redisbench-admin run-local \
+       --module_path "$REDISEARCH_SO" \
+       --required-module search \
+       --module_path "$REJSON_SO" \
+       --required-module ReJSON \
+       --allowed-setups oss-standalone \
+       --allowed-envs oss-standalone \
+       --test tests/benchmarks/<benchmark>.yml \
+       2>&1 | tee "$LOG" | tail -40
+   ```
+3. **Run the benchmark only once.** If the output is truncated or you need a specific
+   number, `grep`/`rg` the saved `$LOG` — do not re-run the benchmark to see more output.
+4. Do NOT run the benchmark concurrently with any `./build.sh`, `make`, or `cargo`
+   command — they contend on the shared Cargo build directory and running redis instances,
+   and concurrency skews benchmark timings.
+5. When the run completes, summarize the key results (throughput ops/sec, latency
+   percentiles) from the output. If the user is comparing against another build, ask
+   whether they want a copyable markdown table for a PR description.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,10 @@ Invoke [/port-c-module](.skills/port-c-module/SKILL.md) to plan the porting of a
 Invoke [/write-rust-tests](.skills/write-rust-tests/SKILL.md) to add tests to Rust code.
 Invoke [/rust-review](.skills/rust-review/SKILL.md) to review Rust code changes.
 
+### Benchmarking
+Invoke [/run-macro-benchmarks](.skills/run-macro-benchmarks/SKILL.md) to run an end-to-end macro benchmark (`tests/benchmarks/*.yml`) against a real redis-server.
+Invoke [/run-rust-benchmarks](.skills/run-rust-benchmarks/SKILL.md) to run Rust micro-benchmarks and compare performance with the C implementation.
+
 ### General
 Invoke [/report-flaky-test](.skills/report-flaky-test/SKILL.md) to report a flaky CI test to Jira or update an existing flaky-test ticket.
 Invoke [/investigate-flaky-test](.skills/investigate-flaky-test/SKILL.md) to investigate a flaky-test report and propose an evidence-backed fix.


### PR DESCRIPTION
New skill to run macro benchmarks.

Adding the generated bench output files to `gitignore`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
