### PR TITLE
[MOD-14206] topk vector iterator: ffi entrypoint prerequisites

### DIFF
--- a/src/redisearch_rs/top_k/src/heap.rs
+++ b/src/redisearch_rs/top_k/src/heap.rs
@@ -58,6 +58,15 @@ struct HeapEntry<'index> {
     compare: fn(f64, f64) -> Ordering,
 }
 
+impl<'index> From<HeapEntry<'index>> for HeapResult<'index> {
+    fn from(entry: HeapEntry<'index>) -> Self {
+        HeapResult {
+            scored: entry.result,
+            record: entry.record,
+        }
+    }
+}
+
 impl PartialEq for HeapEntry<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.cmp(other) == Ordering::Equal
@@ -218,10 +227,7 @@ impl<'index> TopKHeap<'index> {
     /// Unlike [`drain_sorted`](Self::drain_sorted) this borrows the heap, so the
     /// caller can rescore the drained entries and push them back.
     pub fn drain_unsorted(&mut self) -> impl Iterator<Item = HeapResult<'index>> + use<'index, '_> {
-        self.inner.drain().map(|e| HeapResult {
-            scored: e.result,
-            record: e.record,
-        })
+        self.inner.drain().map(HeapResult::from)
     }
 
     /// Drains all elements and returns them sorted best-first.
@@ -233,10 +239,7 @@ impl<'index> TopKHeap<'index> {
         self.inner
             .into_sorted_vec()
             .into_iter()
-            .map(|e| HeapResult {
-                scored: e.result,
-                record: e.record,
-            })
+            .map(HeapResult::from)
             .collect()
     }
 }

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -107,6 +107,11 @@ pub struct TopKIterator<
     direct_batch: Option<S::Batch>,
     k: NonZeroUsize,
     compare: fn(f64, f64) -> Ordering,
+    /// When `true`, filtered modes skip deep-copying the child's rich result
+    /// subtree and yield a metric-only result carrying just the source's score.
+    /// Set when the downstream pipeline needs no rich results (no relevance
+    /// scorer or highlighter that reads the child's term records).
+    can_trim_deep_results: bool,
     phase: Phase,
     /// Heap contents drained into score order for yielding. In filtered modes
     /// each entry carries the child's record captured at match time.
@@ -159,6 +164,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             direct_batch: None,
             k,
             compare,
+            can_trim_deep_results: false,
             phase: Phase::NotStarted,
             results: Vec::new(),
             yield_pos: 0,
@@ -167,6 +173,18 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             at_eof: false,
             metrics: TopKMetrics::default(),
         }
+    }
+
+    /// Set whether filtered modes may yield metric-only results.
+    ///
+    /// When `true`, the collection phase skips deep-copying each matching
+    /// child record and the yield phase builds a metric-only result via
+    /// [`ScoreSource::build_result`] instead of carrying the child's subtree.
+    /// Leave `false` (the default) whenever a downstream scorer or highlighter
+    /// reads the child's term records.
+    pub fn with_trim_deep_results(mut self, trim: bool) -> Self {
+        self.can_trim_deep_results = trim;
+        self
     }
 
     /// Returns the current execution mode.
@@ -189,7 +207,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
         self.child.as_ref()
     }
 
-    /// Returns a reference to the diagnostic counters accumulated so far.
+    /// Returns a reference to the metrics accumulated so far.
     pub const fn metrics(&self) -> &TopKMetrics {
         &self.metrics
     }
@@ -249,8 +267,15 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
 
             // Borrow-checker split: we can't hold `&mut self.child` and call
             // `self.heap.push` at the same time.  Pass fields explicitly.
+            let can_trim_deep_results = self.can_trim_deep_results;
             if let Some(child) = &mut self.child {
-                intersect_batch_with_child(child, &mut batch, &mut self.heap, &mut self.metrics)?;
+                intersect_batch_with_child(
+                    child,
+                    &mut batch,
+                    &mut self.heap,
+                    &mut self.metrics,
+                    can_trim_deep_results,
+                )?;
             }
             match self.source.batch_strategy(self.heap.len(), self.k.get()) {
                 BatchStrategy::Continue => continue,
@@ -297,6 +322,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
     /// wrap the adhoc code. This allows [`ScoreSource::lookup_score`]
     /// to reuse expensive resources.
     fn collect_adhoc(&mut self) -> Result<(), RQEIteratorError> {
+        let can_trim_deep_results = self.can_trim_deep_results;
         let child = self
             .child
             .as_mut()
@@ -315,10 +341,16 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             // VecSim distance lookup.
             scope.0.check_timeout()?;
             if let Some(score) = scope.0.lookup_score(doc_id) {
-                // Capture the child's record now, before the next `child.read()`
+                // Capture the child's data now, before the next `child.read()`
                 // reuses its storage, so the yield phase needn't re-walk the child.
-                let record = capture_child_record(result);
-                self.heap.push_with_record(doc_id, score, Some(record));
+                // When rich results can be trimmed, copy only the child's yielded
+                // metrics rather than its full scoring subtree.
+                let record = Some(if can_trim_deep_results {
+                    capture_child_metrics(result)
+                } else {
+                    capture_child_record(result)
+                });
+                self.heap.push_with_record(doc_id, score, record);
             }
         }
 
@@ -337,7 +369,10 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             let reranked = entries
                 .into_iter()
                 .zip(scored)
-                .map(|(entry, scored)| HeapResult { scored, record: entry.record });
+                .map(|(entry, scored)| HeapResult {
+                    scored,
+                    record: entry.record,
+                });
             self.heap.rebuild_from(reranked);
         }
 
@@ -410,12 +445,29 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             // Poll once per step, before yielding or skipping an entry.
             self.source.check_timeout()?;
 
-            // Filtered mode: yield the stored child record so BM25 inputs survive.
+            // Filtered mode carries the child's captured data. Without trimming,
+            // the stored record is the child's full subtree, kept so BM25 inputs
+            // survive; when trimming it holds only the child's yielded metrics.
             if self.child.is_some() {
+                if self.can_trim_deep_results {
+                    // Build a metric-only result, then fold in the child's
+                    // yielded metrics (explicit output/sort fields) captured at
+                    // match time.
+                    let mut result = self.source.build_result(doc_id, score);
+                    if self.source.is_expired(&result) {
+                        continue;
+                    }
+                    self.last_doc_id = doc_id;
+                    if let Some(mut record) = record {
+                        result.metrics_mut().concat(record.metrics_mut());
+                    }
+                    self.current = Some(result);
+                    return Ok(self.current.as_mut());
+                }
                 let Some(mut record) = record else {
-                    // A filtered-mode entry must always carry its captured record;
-                    // a missing one would indicate a collection-side bug. Treat as
-                    // EOF rather than panicking.
+                    // A rich filtered-mode entry must always carry its captured
+                    // record; a missing one would indicate a collection-side bug.
+                    // Treat as EOF rather than panicking.
                     self.at_eof = true;
                     return Ok(None);
                 };
@@ -428,7 +480,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
                 return Ok(self.current.as_mut());
             }
 
-            // Unfiltered fallback (no child): build a fresh result from the source.
+            // Unfiltered: build a fresh metric-only result from the source.
             let result = self.source.build_result(doc_id, score);
             if self.source.is_expired(&result) {
                 continue;
@@ -565,6 +617,22 @@ fn capture_child_record<'index>(record: &RSIndexResult<'index>) -> RSIndexResult
     unsafe { std::mem::transmute::<RSIndexResult<'_>, RSIndexResult<'index>>(owned) }
 }
 
+/// Capture only the child's yielded metrics (e.g. `AS`-yielded vector
+/// distances) into a fresh metric-only result.
+///
+/// Used on the trim path, where the child's deep scoring subtree is skipped but
+/// its yielded metrics remain explicit output/sort fields that must still be
+/// carried. Cloning copies each metric entry by value; the `RLookupKey`s they
+/// reference are owned by the query and stay valid for `'index`, so the copy
+/// outlives subsequent child reads.
+fn capture_child_metrics<'index>(record: &RSIndexResult<'index>) -> RSIndexResult<'index> {
+    let mut owned = RSIndexResult::build_metric(0.0)
+        .doc_id(record.doc_id)
+        .build();
+    owned.metrics = record.metrics.clone();
+    owned
+}
+
 /// Intersect one score-ordered batch with a child filter iterator,
 /// pushing matches into `heap`.
 ///
@@ -576,6 +644,7 @@ fn intersect_batch_with_child<'index, C: RQEIterator<'index>>(
     batch: &mut impl ScoreBatch,
     heap: &mut TopKHeap<'index>,
     metrics: &mut TopKMetrics,
+    can_trim_deep_results: bool,
 ) -> Result<(), RQEIteratorError> {
     child.rewind();
 
@@ -592,20 +661,37 @@ fn intersect_batch_with_child<'index, C: RQEIterator<'index>>(
         metrics.total_comparisons += 1;
         match batch_doc.cmp(&child_doc) {
             Ordering::Equal => {
-                // Capture the matching child record before advancing past it,
-                // so the yield phase can return it without re-reading the child.
-                let record = child.current().map(|r| capture_child_record(r));
+                // Capture the matching child data before advancing past it, so
+                // the yield phase can return it without re-reading the child.
+                // When rich results can be trimmed, copy only the child's yielded
+                // metrics rather than its full scoring subtree.
+                let record = child.current().map(|r| {
+                    if can_trim_deep_results {
+                        capture_child_metrics(r)
+                    } else {
+                        capture_child_record(r)
+                    }
+                });
                 heap.push_with_record(batch_doc, batch_score, record);
-                // Advance the batch first; only read the child when another
-                // batch doc remains. Reading the child past an exhausted batch
-                // is needless work that inflates its profile counters and could
-                // turn a completed batch into a spurious TimedOut.
-                let Some((d, s)) = batch.next() else { break };
-                batch_doc = d;
-                batch_score = s;
-                match child.read()?.map(|r| r.doc_id) {
-                    Some(doc_id) => child_doc = doc_id,
-                    None => break,
+                // Advance both iterators once per match, then stop if either is
+                // exhausted — keeping the child's profiled read count in step
+                // with the C hybrid reader.
+                //
+                // TODO: skip this child read when the batch is already exhausted.
+                // It is redundant work (no batch doc remains to match) and
+                // re-reading a completed batch's child can surface a spurious
+                // TimedOut. Deferred because it lowers the child's profiled read
+                // count, so it must land together with updated FT.PROFILE
+                // expectations (see tests/pytests/test_profile.py).
+                let child_next = child.read()?.map(|r| r.doc_id);
+                let batch_next = batch.next();
+                match (batch_next, child_next) {
+                    (Some((d, s)), Some(doc_id)) => {
+                        batch_doc = d;
+                        batch_score = s;
+                        child_doc = doc_id;
+                    }
+                    _ => break,
                 }
             }
             Ordering::Less => {

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -205,6 +205,12 @@ impl ScoreSource for MockScoreSource {
         RSIndexResult::build_virt().doc_id(doc_id).build()
     }
 
+    fn attach_score_metric<'r>(&self, _result: &mut RSIndexResult<'r>, _score: f64)
+    where
+        Self: 'r,
+    {
+    }
+
     fn batch_strategy(&mut self, heap_count: usize, k: usize) -> BatchStrategy {
         (self.batch_strategy)(heap_count, k)
     }

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -230,9 +230,7 @@ pub trait ScoreSource {
     /// [`TopKIterator`]: crate::TopKIterator
     fn attach_score_metric<'r>(&self, _result: &mut RSIndexResult<'r>, _score: f64)
     where
-        Self: 'r,
-    {
-    }
+        Self: 'r;
 
     /// Called after each batch (Batches mode only) to decide how collection
     /// should proceed.

--- a/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
+++ b/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
@@ -71,6 +71,12 @@ impl ScoreSource for CallCountingScoreSource {
         RSIndexResult::build_virt().doc_id(doc_id).build()
     }
 
+    fn attach_score_metric<'r>(&self, _result: &mut RSIndexResult<'r>, _score: f64)
+    where
+        Self: 'r,
+    {
+    }
+
     fn batch_strategy(&mut self, _: usize, _: usize) -> BatchStrategy {
         BatchStrategy::Continue
     }

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -55,6 +55,12 @@ impl ScoreSource for TimingOutSource {
         RSIndexResult::build_virt().doc_id(doc_id).build()
     }
 
+    fn attach_score_metric<'r>(&self, _result: &mut RSIndexResult<'r>, _score: f64)
+    where
+        Self: 'r,
+    {
+    }
+
     fn batch_strategy(&mut self, _: usize, _: usize) -> BatchStrategy {
         BatchStrategy::Continue
     }
@@ -482,6 +488,12 @@ fn rewind_after_mid_collect_error_does_not_retain_stale_heap() {
             RSIndexResult::build_virt().doc_id(doc_id).build()
         }
 
+        fn attach_score_metric<'r>(&self, _result: &mut RSIndexResult<'r>, _score: f64)
+        where
+            Self: 'r,
+        {
+        }
+
         fn batch_strategy(&mut self, _heap_count: usize, _k: usize) -> BatchStrategy {
             BatchStrategy::Continue
         }
@@ -697,6 +709,11 @@ fn adhoc_timeout_propagated() {
         {
             RSIndexResult::build_virt().doc_id(doc_id).build()
         }
+        fn attach_score_metric<'r>(&self, _result: &mut RSIndexResult<'r>, _score: f64)
+        where
+            Self: 'r,
+        {
+        }
         fn batch_strategy(&mut self, _: usize, _: usize) -> BatchStrategy {
             BatchStrategy::Continue
         }
@@ -820,4 +837,116 @@ fn batches_preserves_child_scoring_fields() {
         "child's scoring fields (freq, field_mask) were dropped — \
           got {emitted:?}; the BM25-becomes-0 bug from MOD-8142"
     );
+}
+
+/// The dual of [`batches_preserves_child_scoring_fields`]: when the pipeline can
+/// trim deep results, the child's scoring subtree is never captured, so each
+/// match yields the source's metric-only result (default freq/field_mask) rather
+/// than the child's rich record.
+#[test]
+fn batches_trim_deep_results_yields_metric_only() {
+    use index_result::RSIndexResult;
+    use rqe_iterators::IdList;
+
+    let child_result = RSIndexResult::build_virt()
+        .frequency(7)
+        .field_mask(0xABC)
+        .build();
+    let child = IdList::<true>::with_result(vec![1, 2], child_result);
+
+    let source = MockScoreSource::new(vec![vec![(1, 0.9), (2, 0.5)]], vec![], |_, _| {
+        BatchStrategy::Continue
+    });
+
+    let mut it = TopKIterator::new(
+        source,
+        Box::new(child) as Box<dyn RQEIterator<'_> + '_>,
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    )
+    .with_trim_deep_results(true);
+
+    let mut emitted = Vec::new();
+    while let Some(r) = it.read().unwrap() {
+        emitted.push((r.doc_id, r.freq, r.field_mask));
+    }
+
+    // Same doc ids and best-first order as the rich path, but the child's
+    // freq/field_mask are absent — the yielded record is the source's
+    // metric-only result.
+    assert_eq!(emitted, vec![(2, 0, 0), (1, 0, 0)]);
+}
+
+/// Adhoc-BF counterpart of [`batches_trim_deep_results_yields_metric_only`]:
+/// the child-driven scan also skips capturing the rich record when results are
+/// trimmed.
+#[test]
+fn adhoc_trim_deep_results_yields_metric_only() {
+    use index_result::RSIndexResult;
+    use rqe_iterators::IdList;
+
+    let child_result = RSIndexResult::build_virt()
+        .frequency(7)
+        .field_mask(0xABC)
+        .build();
+    let child = IdList::<true>::with_result(vec![1, 2], child_result);
+
+    let source = MockScoreSource::new(vec![], vec![(1, 0.9), (2, 0.5)], |_, _| {
+        BatchStrategy::Continue
+    });
+
+    let mut it = TopKIterator::new_with_mode(
+        source,
+        Some(Box::new(child) as Box<dyn RQEIterator<'_> + '_>),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+        TopKMode::AdhocBF,
+    )
+    .with_trim_deep_results(true);
+
+    let mut emitted = Vec::new();
+    while let Some(r) = it.read().unwrap() {
+        emitted.push((r.doc_id, r.freq, r.field_mask));
+    }
+
+    assert_eq!(emitted, vec![(2, 0, 0), (1, 0, 0)]);
+}
+
+/// Trimming skips the child's scoring subtree but must still carry its yielded
+/// metrics (e.g. `AS`-yielded vector distances), which are explicit output/sort
+/// fields rather than part of the rich subtree.
+#[test]
+fn batches_trim_deep_results_preserves_child_metrics() {
+    use index_result::RSIndexResult;
+    use rqe_iterators::IdList;
+
+    // Child result with rich scoring fields *and* a yielded metric.
+    let mut child_result = RSIndexResult::build_virt()
+        .frequency(7)
+        .field_mask(0xABC)
+        .build();
+    child_result.metrics_mut().push_without_key(42.0);
+    let child = IdList::<true>::with_result(vec![1, 2], child_result);
+
+    let source = MockScoreSource::new(vec![vec![(1, 0.9), (2, 0.5)]], vec![], |_, _| {
+        BatchStrategy::Continue
+    });
+
+    let mut it = TopKIterator::new(
+        source,
+        Box::new(child) as Box<dyn RQEIterator<'_> + '_>,
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    )
+    .with_trim_deep_results(true);
+
+    let mut emitted = Vec::new();
+    while let Some(r) = it.read().unwrap() {
+        let metric = r.metrics_ref().get(0).map(|m| m.value());
+        emitted.push((r.doc_id, r.freq, r.field_mask, metric));
+    }
+
+    // Rich subtree is trimmed (freq/field_mask are the source's defaults), but
+    // the child's yielded metric rides along on every result.
+    assert_eq!(emitted, vec![(2, 0, 0, Some(42.0)), (1, 0, 0, Some(42.0))]);
 }

--- a/src/redisearch_rs/vector_score_source/src/lib.rs
+++ b/src/redisearch_rs/vector_score_source/src/lib.rs
@@ -24,11 +24,13 @@ extern crate redisearch_rs;
 #[cfg(test)]
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
+pub mod reducer;
 pub mod score_batch;
 pub mod source;
 #[cfg(feature = "unittest")]
 pub mod test_utils;
 
+pub use reducer::{NewVectorTopK, new_vector_top_k};
 use rqe_iterators::c2rust::CRQEIterator;
 use rqe_iterators::profile_print::ProfilePrint;
 pub use score_batch::VecSimScoreBatch;
@@ -105,6 +107,10 @@ pub fn new_vector_top_k_unfiltered<'index, E: ExpirationChecker + 'index>(
 ///
 /// Delegates mode selection to source.
 ///
+/// When `can_trim_deep_results` is `true`, the pipeline needs no rich results,
+/// so matches yield a metric-only result carrying just the vector score instead
+/// of the child's deep-copied scoring subtree.
+///
 /// [`VectorScoreSource::requested_search_mode`]: source::VectorScoreSource::requested_search_mode
 /// [`VecSimIndex_PreferAdHocSearch`]: ffi::VecSimIndex_PreferAdHocSearch
 /// [`BatchStrategy::SwitchToAdhoc`]: top_k::BatchStrategy::SwitchToAdhoc
@@ -112,6 +118,7 @@ pub fn new_vector_top_k_filtered<'index, E, C>(
     source: VectorScoreSource<'index, E>,
     child: C,
     k: NonZeroUsize,
+    can_trim_deep_results: bool,
 ) -> TopKIterator<'index, VectorScoreSource<'index, E>, C>
 where
     E: ExpirationChecker + 'index,
@@ -136,6 +143,7 @@ where
         }
     };
     TopKIterator::new_with_mode(source, Some(child), k, asc_cmp, mode)
+        .with_trim_deep_results(can_trim_deep_results)
 }
 
 impl<E: ExpirationChecker> TopKSourceProfile for VectorScoreSource<'_, E> {

--- a/src/redisearch_rs/vector_score_source/src/reducer.rs
+++ b/src/redisearch_rs/vector_score_source/src/reducer.rs
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Child short-circuit reduction and construction dispatch for vector top-k,
+//! keeping this decision logic out of the FFI boundary.
+
+use std::{num::NonZeroUsize, ptr::NonNull};
+
+use ffi::{IteratorType, VecSearchMode_STANDARD_KNN, VecSimIndex, VecSimQueryParams, timespec};
+use rqe_iterators::{ExpirationChecker, RQEIterator, c2rust::CRQEIterator};
+use top_k::TopKIterator;
+
+use crate::{
+    VectorScoreSource, VectorTopKIterator, new_vector_top_k_filtered, new_vector_top_k_unfiltered,
+};
+
+/// Outcome of reducing a filter child before constructing the iterator.
+enum VectorChildReduction<C> {
+    /// The child can never yield a match, so the whole query is empty.
+    Empty,
+    /// There is no filter (no child, or a wildcard that matches everything):
+    /// run as a pure KNN query.
+    Unfiltered,
+    /// A real filter child to intersect the KNN results against.
+    Filtered(C),
+}
+
+/// Classify a filter child into the reduction that applies to it.
+///
+/// A reduced-away child is dropped, freeing the underlying iterator.
+fn vector_child_reducer<'index, C>(child: Option<C>) -> VectorChildReduction<C>
+where
+    C: RQEIterator<'index> + 'index,
+{
+    let Some(child) = child else {
+        return VectorChildReduction::Unfiltered;
+    };
+    match child.type_() {
+        IteratorType::Empty => VectorChildReduction::Empty,
+        IteratorType::Wildcard | IteratorType::InvIdxWildcard => VectorChildReduction::Unfiltered,
+        _ => VectorChildReduction::Filtered(child),
+    }
+}
+
+/// Result of [`new_vector_top_k`]: the iterator to expose, already reduced to
+/// the right variant.
+pub enum NewVectorTopK<'index, E: ExpirationChecker> {
+    /// The query yields nothing (empty child, or `k == 0`).
+    ReducedEmpty,
+    /// Pure KNN, no filter child.
+    Unfiltered(VectorTopKIterator<'index, E>),
+    /// Hybrid KNN intersected with a filter child.
+    Filtered(TopKIterator<'index, VectorScoreSource<'index, E>, CRQEIterator>),
+}
+
+/// Build the vector top-k iterator for the given query, applying the child
+/// reduction and choosing the unfiltered or filtered construction accordingly.
+///
+/// # Safety
+///
+/// - `index` must be valid for `'index`, which outlives the returned iterator.
+/// - `query_vector` must satisfy the [`VectorScoreSource`] query-vector length
+///   invariant for `index`.
+#[expect(clippy::too_many_arguments)]
+pub unsafe fn new_vector_top_k<'index, E>(
+    index: NonNull<VecSimIndex>,
+    query_vector: Vec<u8>,
+    query_params: VecSimQueryParams,
+    k: usize,
+    timeout: timespec,
+    skip_timeout_checks: bool,
+    can_trim_deep_results: bool,
+    expiration: E,
+    child: Option<CRQEIterator>,
+) -> NewVectorTopK<'index, E>
+where
+    E: ExpirationChecker + 'index,
+{
+    let Some(k) = NonZeroUsize::new(k) else {
+        return NewVectorTopK::ReducedEmpty;
+    };
+
+    match vector_child_reducer(child) {
+        VectorChildReduction::Empty => NewVectorTopK::ReducedEmpty,
+        VectorChildReduction::Unfiltered => {
+            // A caller-supplied hybrid policy must not reach the single-shot KNN call.
+            let query_params = VecSimQueryParams {
+                searchMode: VecSearchMode_STANDARD_KNN,
+                ..query_params
+            };
+            // SAFETY: `index` validity and the query-vector length invariant are
+            // guaranteed by this function's contract.
+            let source = unsafe {
+                VectorScoreSource::new(
+                    index,
+                    query_vector,
+                    query_params,
+                    k.get(),
+                    timeout,
+                    skip_timeout_checks,
+                    0, // no child
+                    0, // dynamic batch size
+                    expiration,
+                )
+            };
+            NewVectorTopK::Unfiltered(new_vector_top_k_unfiltered(source, k))
+        }
+        VectorChildReduction::Filtered(child) => {
+            let child_est = child.num_estimated();
+            // SAFETY: `index` validity and the query-vector length invariant are
+            // guaranteed by this function's contract.
+            let source = unsafe {
+                VectorScoreSource::new(
+                    index,
+                    query_vector,
+                    query_params,
+                    k.get(),
+                    timeout,
+                    skip_timeout_checks,
+                    child_est,
+                    // Honor an explicit `BATCH_SIZE` (0 means dynamic).
+                    query_params.batchSize,
+                    expiration,
+                )
+            };
+            NewVectorTopK::Filtered(new_vector_top_k_filtered(
+                source,
+                child,
+                k,
+                can_trim_deep_results,
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rqe_iterators::{Empty, IdList, Wildcard};
+
+    use super::{VectorChildReduction, vector_child_reducer};
+
+    #[test]
+    fn no_child_is_unfiltered() {
+        let reduction = vector_child_reducer(None::<Empty>);
+        assert!(matches!(reduction, VectorChildReduction::Unfiltered));
+    }
+
+    #[test]
+    fn empty_child_reduces_to_empty() {
+        let reduction = vector_child_reducer(Some(Empty));
+        assert!(matches!(reduction, VectorChildReduction::Empty));
+    }
+
+    #[test]
+    fn wildcard_child_is_unfiltered() {
+        let reduction = vector_child_reducer(Some(Wildcard::new(10, 1.0)));
+        assert!(matches!(reduction, VectorChildReduction::Unfiltered));
+    }
+
+    #[test]
+    fn real_child_is_kept_as_filter() {
+        let child = IdList::<true>::new(vec![1, 2, 3]);
+        let reduction = vector_child_reducer(Some(child));
+        assert!(matches!(reduction, VectorChildReduction::Filtered(_)));
+    }
+}

--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -16,8 +16,8 @@ use std::{
 };
 
 use ffi::{
-    QueryIterator, RS_VecSimCheckTimeout, TimeoutCtx, VecSearchMode, VecSearchMode_HYBRID_BATCHES,
-    VecSimIndex, VecSimQueryParams, timespec,
+    RLookupKeyHandle, RS_VecSimCheckTimeout, TimeoutCtx, VecSearchMode,
+    VecSearchMode_HYBRID_BATCHES, VecSimIndex, VecSimQueryParams, timespec,
 };
 use index_result::RSIndexResult;
 use rlookup::RLookupKey;
@@ -99,8 +99,6 @@ pub struct VectorScoreSource<'index, E: ExpirationChecker> {
     /// Highest `num_iterations` value observed so far. Reset on rewind. Read
     /// by the profile printer.
     pub max_batch_iteration: usize,
-    /// Raw child iterator handle exposed to the C profile printer.
-    pub child_raw: *mut QueryIterator,
     /// Rolling estimate of how many child docs pass the filter; seeded from
     /// [`initial_child_num_estimated`](Self::initial_child_num_estimated) and
     /// refined each batch. Reset on rewind.
@@ -118,8 +116,27 @@ pub struct VectorScoreSource<'index, E: ExpirationChecker> {
     /// leaves this clear so a retry re-issues it. Reset by `rewind`.
     unfiltered_consumed: bool,
 
-    /// Score key for this iterator's metric output; set by the metrics loader.
-    pub own_key: *mut RLookupKey<'index>
+    /// Score key for this iterator's metric output. The C metrics loader writes
+    /// through the address returned by the own-key accessor. Boxed so that
+    /// address stays stable across iterator moves (e.g. the rebox performed
+    /// during `FT.PROFILE`), keeping the C-side key handle valid. Holds a null
+    /// pointer until the loader sets it.
+    pub own_key: Box<*mut RLookupKey<'index>>,
+    /// Back-reference to the handle that points to [`own_key`](Self::own_key).
+    /// Set by the C side alongside `own_key`; null until then.
+    pub key_handle: *mut RLookupKeyHandle,
+}
+
+impl<E: ExpirationChecker> Drop for VectorScoreSource<'_, E> {
+    fn drop(&mut self) {
+        if !self.key_handle.is_null() {
+            // SAFETY: key_handle is non-null only when VectorTopK_SetKeyHandle
+            // stored a valid, live RLookupKeyHandle pointer here.
+            unsafe {
+                (*self.key_handle).is_valid = false;
+            }
+        }
+    }
 }
 
 // SAFETY: VectorScoreSource is used from a single thread (the query execution
@@ -187,13 +204,13 @@ impl<'index, E: ExpirationChecker> VectorScoreSource<'index, E> {
             num_iterations: 0,
             max_batch_size: 0,
             max_batch_iteration: 0,
-            child_raw: ptr::null_mut(),
             child_num_estimated,
             initial_child_num_estimated: child_num_estimated,
             k_remaining: k,
             expiration,
             unfiltered_consumed: false,
-            own_key: ptr::null_mut(),
+            own_key: Box::new(ptr::null_mut()),
+            key_handle: ptr::null_mut(),
         }
     }
 
@@ -442,11 +459,11 @@ impl<'index, E: ExpirationChecker> ScoreSource for VectorScoreSource<'index, E> 
         Self: 'r,
     {
         let mut result = RSIndexResult::build_metric(score).doc_id(doc_id).build();
-        if !self.own_key.is_null() {
+        if !(*self.own_key).is_null() {
             // SAFETY: when non-null, `own_key` points to a live `RLookupKey` that the query
             // set up before reading any results and keeps alive for at least `'r`. The cast
             // is valid because `RLookupKey<'idx>` starts with a `#[repr(C)]` `ffi::RLookupKey`.
-            let key: &'r ffi::RLookupKey = unsafe { &*(self.own_key as *const ffi::RLookupKey) };
+            let key: &'r ffi::RLookupKey = unsafe { &*(*self.own_key as *const ffi::RLookupKey) };
             result.metrics.push_with_key(key, score);
         }
         result
@@ -456,13 +473,13 @@ impl<'index, E: ExpirationChecker> ScoreSource for VectorScoreSource<'index, E> 
     where
         Self: 'r,
     {
-        if self.own_key.is_null() {
+        if (*self.own_key).is_null() {
             return;
         }
         // SAFETY: `own_key` is set by `getAdditionalMetricsRP` in pipeline_construction.c
         // before any reads occur, and the key lives in the query's RLookup structure for
         // at least `'index` (the query lifetime).
-        let key: &'r ffi::RLookupKey = unsafe { &*(self.own_key as *const ffi::RLookupKey) };
+        let key: &'r ffi::RLookupKey = unsafe { &*(*self.own_key as *const ffi::RLookupKey) };
 
         // The child reuses one storage slot across yields, so an entry from a
         // previous yield may already exist for our key. Update in place when

--- a/src/redisearch_rs/vector_score_source/tests/integration/policy.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/policy.rs
@@ -41,6 +41,7 @@ fn explicit_adhoc_policy() {
         source,
         make_child(vec![1, 2, 3]),
         NonZeroUsize::new(3).unwrap(),
+        false,
     );
     assert_eq!(it.mode(), TopKMode::AdhocBF);
 
@@ -68,6 +69,7 @@ fn explicit_batches_policy() {
         source,
         make_child(vec![1, 2, 3]),
         NonZeroUsize::new(3).unwrap(),
+        false,
     );
     assert_eq!(it.mode(), TopKMode::ForcedBatches);
 
@@ -97,6 +99,7 @@ fn unset_policy_uses_heuristic() {
         source,
         make_child(vec![1, 2, 3]),
         NonZeroUsize::new(3).unwrap(),
+        false,
     );
     assert!(
         matches!(it.mode(), TopKMode::Batches | TopKMode::AdhocBF),

--- a/src/redisearch_rs/vector_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source.rs
@@ -20,11 +20,11 @@ use std::{num::NonZeroUsize, ptr::NonNull};
 
 use std::collections::HashSet;
 
-use ffi::{VecSimIndex, VecSimIndex_Free, t_docId};
-use index_result::RSResultKind;
+use ffi::{RLookupKey, VecSimIndex, VecSimIndex_Free, t_docId};
+use index_result::{RSIndexResult, RSResultKind};
 use rqe_iterators::{ExpirationChecker, NoOpChecker, RQEIterator};
 use rqe_iterators_test_utils::MockExpirationChecker;
-use top_k::{TopKIterator, TopKMode};
+use top_k::{ScoreSource, TopKIterator, TopKMode};
 use vector_score_source::test_utils::{self, asc, collect_ids, make_child, uniform_blob};
 use vector_score_source::{
     VectorScoreSource, new_vector_top_k_filtered, new_vector_top_k_unfiltered,
@@ -182,7 +182,7 @@ fn filtered_full_child_yields_best_first() {
     let child = make_child((1..=n as t_docId).collect());
     // Public constructor auto-selects batches vs adhoc; either way the heap is
     // drained best-first, so ordering is deterministic.
-    let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap());
+    let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap(), false);
 
     // Best (lowest distance) first → highest ids first.
     let ids = collect_ids(&mut it);
@@ -458,6 +458,98 @@ fn index_size_reflects_added_vectors() {
     let source = unsafe { make_source(index, n, 10, n) };
     assert_eq!(source.index_size(), n);
 
+    drop(source);
+    // SAFETY: no live references to the index remain.
+    unsafe { VecSimIndex_Free(index.as_ptr()) };
+}
+
+/// A zero-filled lookup key. The metrics channel only compares the key's
+/// address, so the fields are never read.
+fn make_key() -> RLookupKey {
+    // SAFETY: `RLookupKey` is plain data whose all-zero state (null pointers,
+    // zero indices) is valid and never dereferenced by the metrics code.
+    unsafe { std::mem::zeroed() }
+}
+
+/// The first yield on fresh storage: with no entry yet under the source's
+/// output key, the score is appended without disturbing metrics the child
+/// attached under other keys.
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
+fn attach_score_metric_appends_when_absent() {
+    // Arrange: a keyed source and a result holding only the child's own metric.
+    let index = build_hnsw_index(3);
+    // SAFETY: index outlives the source (freed at end of scope).
+    let mut source = unsafe { make_source(index, 3, 3, 3) };
+    let mut own = make_key();
+    *source.own_key = (&mut own as *mut RLookupKey).cast();
+
+    let foreign = make_key();
+    let mut result = RSIndexResult::build_virt().doc_id(1).build();
+    result.metrics.push_with_key(&foreign, 7.0);
+
+    // Act.
+    source.attach_score_metric(&mut result, 42.0);
+
+    // Assert: appended alongside the untouched foreign metric.
+    assert_eq!(result.metrics.len(), 2);
+    assert_eq!(result.metrics.find_by_key_mut(&own).unwrap().value(), 42.0);
+    assert_eq!(
+        result.metrics.find_by_key_mut(&foreign).unwrap().value(),
+        7.0
+    );
+
+    drop(result);
+    drop(source);
+    // SAFETY: no live references to the index remain.
+    unsafe { VecSimIndex_Free(index.as_ptr()) };
+}
+
+/// Repeated yields reuse one child storage slot, so the source overwrites its
+/// own score entry in place rather than appending — otherwise a stale score
+/// from an earlier document would leak onto a later one.
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
+fn attach_score_metric_overwrites_in_place() {
+    // Arrange: a result already carrying a stale score under our key, as if left
+    // by a previous yield on the same storage.
+    let index = build_hnsw_index(3);
+    // SAFETY: index outlives the source (freed at end of scope).
+    let mut source = unsafe { make_source(index, 3, 3, 3) };
+    let mut own = make_key();
+    *source.own_key = (&mut own as *mut RLookupKey).cast();
+
+    let mut result = RSIndexResult::build_virt().doc_id(1).build();
+    result.metrics.push_with_key(&own, 1.0);
+
+    // Act.
+    source.attach_score_metric(&mut result, 99.0);
+
+    // Assert: updated in place, not duplicated.
+    assert_eq!(result.metrics.len(), 1);
+    assert_eq!(result.metrics.find_by_key_mut(&own).unwrap().value(), 99.0);
+
+    drop(result);
+    drop(source);
+    // SAFETY: no live references to the index remain.
+    unsafe { VecSimIndex_Free(index.as_ptr()) };
+}
+
+/// With no output key wired up (the metrics loader never ran), attaching a
+/// score must be a no-op rather than pushing a keyless entry.
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
+fn attach_score_metric_without_key_is_noop() {
+    let index = build_hnsw_index(3);
+    // SAFETY: index outlives the source (freed at end of scope).
+    let source = unsafe { make_source(index, 3, 3, 3) };
+    assert!(source.own_key.is_null(), "no key wired by default");
+
+    let mut result = RSIndexResult::build_virt().doc_id(1).build();
+    source.attach_score_metric(&mut result, 42.0);
+    assert_eq!(result.metrics.len(), 0, "no key means no metric attached");
+
+    drop(result);
     drop(source);
     // SAFETY: no live references to the index remain.
     unsafe { VecSimIndex_Free(index.as_ptr()) };

--- a/src/redisearch_rs/vector_score_source/tests/integration/source_pytest_parity.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source_pytest_parity.rs
@@ -63,7 +63,7 @@ fn flat_filtered_full_child_yields_best_first() {
     // SAFETY: index outlives the iterator (freed at end of scope).
     let source = unsafe { make_source(index, uniform_blob(n as f32, dim), n, k, n) };
     let child = make_child((1..=n as DocId).collect());
-    let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap());
+    let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap(), false);
 
     assert_eq!(collect_ids(&mut it), (91..=100).rev().collect::<Vec<_>>());
 
@@ -86,7 +86,7 @@ fn cosine_metric_filtered_top_k_are_highest_ids() {
     // SAFETY: index outlives the iterator (freed at end of scope).
     let source = unsafe { make_source(index, uniform_blob(1.0, dim), n, k, n) };
     let child = make_child((1..=n as DocId).collect());
-    let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap());
+    let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap(), false);
 
     let ids = collect_ids(&mut it);
     assert_eq!(ids.first().copied(), Some(n as DocId));
@@ -116,7 +116,7 @@ fn middle_query_orders_by_distance_then_lower_id() {
     // SAFETY: index outlives the iterator (freed at end of scope).
     let source = unsafe { make_source(index, uniform_blob(mid as f32, dim), n, k, n) };
     let child = make_child((1..=n as DocId).collect());
-    let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap());
+    let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap(), false);
 
     let mut expected = vec![mid];
     for d in 1..=4 {
@@ -166,7 +166,7 @@ fn dim1_filtered_subset_knn_top3() {
     // SAFETY: index outlives the iterator (freed at end of scope).
     let source = unsafe { make_source(index, uniform_blob(0.0, dim), n, k, child_ids.len()) };
     let child = make_child(child_ids);
-    let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap());
+    let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap(), false);
 
     assert_eq!(collect_ids(&mut it), vec![6, 7, 8]);
 


### PR DESCRIPTION
- based on https://github.com/RediSearch/RediSearch/pull/10221
- next: https://github.com/RediSearch/RediSearch/pull/10222

Groundwork extracted from the FFI-entrypoint work so the actual FFI PR stays
small and focused.

- **ffi**: expose the `VecSimSearchMode` constants so the top-k iterator can
  report its search strategy back to C.
- **top_k**: honor `canTrimDeepResults` — skip deep child-record copies when the
  pipeline needs only the metric score.
- **vector_score_source**: move the child empty/wildcard reduction into the Rust
  core, add the `key_handle` back-reference field + `Drop` that invalidates it,
  and reset `searchMode` to `STANDARD_KNN` on the unfiltered path.
- **rqe_iterators**: add `patch_vtable`, a small escape hatch for
  post-construction vtable overrides ; more of a defensive requirement, more info at https://github.com/RediSearch/RediSearch/pull/9479

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
