### PR TITLE
[8.10] build(deps): update anyhow to 1.0.103 (RUSTSEC-2026-0190)

### DIFF
--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -48,7 +48,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
-          persist-credentials: false
       - name: Fix HOME Directory
         if: ${{ needs.build-image.outputs.succeeded == 'true' }}
         shell: bash

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          persist-credentials: false
       - name: Fix HOME Directory
         if: ${{ needs.build-image.outputs.succeeded == 'true' }}
         shell: bash

--- a/scripts/cargo_deny_advisory_gate.py
+++ b/scripts/cargo_deny_advisory_gate.py
@@ -84,10 +84,13 @@ def print_findings(title: str, findings: set[tuple[str, str, str]]) -> None:
         print(f"  - {advisory_id}: {crate}{f' {version}' if version else ''}")
 
 
-def fail_if_unparsed(rc: int, findings: set[tuple[str, str, str]], label: str) -> None:
+def fail_if_unparsed(rc: int, findings: set[tuple[str, str, str]], label: str, output: Path) -> None:
     if rc != 0 and not findings:
         print(f"cargo deny failed for {label}, but no advisory findings could be parsed.")
         print("Failing conservatively so CI does not hide a tool or configuration error.")
+        print(f"----- cargo deny output ({output}) -----")
+        print(output.read_text(encoding="utf-8", errors="replace"), end="")
+        print("----- end cargo deny output -----")
         sys.exit(rc)
 
 
@@ -115,7 +118,7 @@ def main() -> int:
 
     head_rc = cargo_deny(Path.cwd(), head_out, args.manifest_path)
     head_findings = parse_findings(head_out)
-    fail_if_unparsed(head_rc, head_findings, "current checkout")
+    fail_if_unparsed(head_rc, head_findings, "current checkout", head_out)
 
     if not args.compare_to_base:
         print_findings("Current advisory findings:", head_findings)
@@ -135,7 +138,7 @@ def main() -> int:
         base_out = out_dir / "cargo-deny-advisories-base.jsonl"
         base_rc = cargo_deny(worktree, base_out, args.manifest_path)
         base_findings = parse_findings(base_out)
-        fail_if_unparsed(base_rc, base_findings, "base checkout")
+        fail_if_unparsed(base_rc, base_findings, "base checkout", base_out)
     finally:
         subprocess.run(["git", "worktree", "remove", "--force", str(worktree)], check=False)
         shutil.rmtree(worktree, ignore_errors=True)

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The `lint / Linting` job fails at the cargo-deny advisory gate. The gate only printed "cargo deny failed for current checkout, but no advisory findings could be parsed", hiding the cause (it redirects cargo-deny's output into a temp `.jsonl` that was never printed). The real cause: **`anyhow` 1.0.102 is flagged by `RUSTSEC-2026-0190`** (unsoundness in `Error::downcast_mut`, published 2026-06-25), pulled in via the dev-tool crates `ffi_geiger` and `safety_report`. This is a pre-existing dependency on 8.10 that started failing once the advisory DB refreshed — unrelated to any specific PR.
2. **Change:**
   - `src/redisearch_rs/Cargo.lock`: update `anyhow` 1.0.102 → 1.0.103 (the fixed version per the advisory).
   - `scripts/cargo_deny_advisory_gate.py`: print the captured cargo-deny output on the "fail conservatively" path, so future gate failures are diagnosable instead of blind (this is what surfaced the cause here).
3. **Outcome:** `cargo deny check advisories` passes; the lint job is unblocked.

#### Follow-ups (not in this PR)
- The gate's `parse_findings` cannot parse cargo-deny's findings (stdout+stderr are merged, corrupting the JSONL), so the intended `--compare-to-base` "only fail on *new* advisories" logic never runs — it always falls back to failing conservatively. Worth fixing separately.
- `anyhow` should be bumped on `master` too.

#### Main objects this PR modified
1. `src/redisearch_rs/Cargo.lock`
2. `scripts/cargo_deny_advisory_gate.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)