### PR TITLE
[8.10] [MOD-16613] bump anyhow to 1.0.103 (RUSTSEC-2026-0190)

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The `lint / Linting` cargo-deny advisory gate fails on 8.10 because `anyhow` 1.0.102 is flagged by **RUSTSEC-2026-0190** (unsoundness in `anyhow::Error::downcast_mut`), pulled in via the dev-tool crates `ffi_geiger`/`safety_report`. It was fixed on master by #10297 (anyhow → 1.0.103) but never backported.
2. **Change:** Bump `anyhow` 1.0.102 → 1.0.103 in `src/redisearch_rs/Cargo.lock` (the fixed version per the advisory).
3. **Outcome:** `cargo deny check advisories` passes on 8.10; lint is unblocked. (Verified on an earlier branch: the `lint / Linting` job went green with this bump.)

Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0190 (no CVE assigned).
Jira: MOD-16613

#### Main objects this PR modified
1. `src/redisearch_rs/Cargo.lock`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)