### PR TITLE
rqe_iterators_test_utils: free IndexError global key at exit

### DIFF
--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -153,6 +153,12 @@ const HEADERS: &[HeaderAllowlist] = &[
         vars: &["specDict_g", "specIdDict_g"],
     },
     HeaderAllowlist {
+        path: "src/info/index_error.h",
+        fns: &["IndexError_GlobalCleanup"],
+        types: &[],
+        vars: &[],
+    },
+    HeaderAllowlist {
         path: "src/iterators/hybrid_reader.h",
         fns: &[
             "HybridIterator_GetChild",

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -1056,6 +1056,18 @@ impl Default for GlobalGuard {
                     // DefaultStopWordList is allocated when calling IndexSpec_ParseC()
                     ffi::StopWordList_FreeGlobals();
                 }
+
+                // NA_rstr (the IndexError default key) is lazily allocated the
+                // first time a spec's IndexError is initialized.
+                //
+                // SAFETY: `IndexError_GlobalCleanup` takes no arguments and
+                // internally null-checks `NA_rstr`, so it is sound to call whether
+                // or not a spec was ever created, and is idempotent. It runs at
+                // process exit, after every `TestContext` has been dropped, so
+                // nothing else references the string.
+                unsafe {
+                    ffi::IndexError_GlobalCleanup();
+                }
             }
 
             unsafe {


### PR DESCRIPTION
The test harness leaks a 32-byte block: NA_rstr, the process-global "N/A" default key that IndexError_Init lazily allocates on the first spec creation and that only IndexError_GlobalCleanup frees. The GlobalGuard atexit hook releases the other C global singletons (specDict_g, SchemaPrefixes_g, DefaultStopWordList, ...) but never called IndexError_GlobalCleanup, so valgrind flagged the string as leaked once per test binary.

Expose IndexError_GlobalCleanup through the ffi crate and call it from the GlobalGuard atexit cleanup alongside the existing global frees.

Fix leak detected by valrind when running query_eval tests.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
