### PR TITLE
[MOD-16667] thpool: don't run verify_init barrier from a worker thread

### DIFF
--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -119,7 +119,7 @@ typedef struct redisearch_thpool_t {
  * within thread_do. NULL on any non-worker thread (e.g. the main thread).
  * Used to detect re-entrant job submission: a worker submitting jobs to its
  * OWN pool must not run the verify_init all-threads barrier, because the
- * submitting worker cannot also arrive at that barrier -> deadlock (MOD-14296). */
+ * submitting worker cannot also arrive at that barrier -> deadlock. */
 static __thread redisearch_thpool_t *g_thpool_self = NULL;
 
 
@@ -447,13 +447,13 @@ static void redisearch_thpool_push_chain_verify_init_threads(
   thpool_priority priority) {
   redisearch_thpool_push_chain(thpool_p, f_newjob_p, l_newjob_p, n, priority);
 
-  /* MOD-14296: never run verify_init from within one of this pool's own worker
-   * threads. verify_init coordinates every live worker through a barrier; the
-   * submitting worker is one of them but is stuck here initiating the barrier,
-   * so it can never be reached -> the pool (and any load-time drain waiting on
-   * it) deadlocks. The pool is already running (the caller is a live worker),
-   * so the jobs just pushed will be drained by the running workers; spawning or
-   * reviving threads is only ever required from a non-worker (main) thread. */
+  /* Never run verify_init from within one of this pool's own worker threads.
+   * verify_init coordinates every live worker through a barrier; the submitting
+   * worker is one of them but is stuck here initiating the barrier, so it can
+   * never be reached. The pool is already running (the caller is a live
+   * worker), so the jobs just pushed will be drained by the running workers;
+   * spawning or reviving threads is only ever required from a non-worker
+   * thread. */
   if (g_thpool_self == thpool_p) {
     return;
   }

--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -115,6 +115,13 @@ typedef struct redisearch_thpool_t {
                                                 '-<thread id>'*/
 } redisearch_thpool_t;
 
+/* Set (for its whole lifetime) to the pool a worker thread belongs to, from
+ * within thread_do. NULL on any non-worker thread (e.g. the main thread).
+ * Used to detect re-entrant job submission: a worker submitting jobs to its
+ * OWN pool must not run the verify_init all-threads barrier, because the
+ * submitting worker cannot also arrive at that barrier -> deadlock (MOD-14296). */
+static __thread redisearch_thpool_t *g_thpool_self = NULL;
+
 
 /* ========================== PROTOTYPES ============================ */
 
@@ -440,6 +447,17 @@ static void redisearch_thpool_push_chain_verify_init_threads(
   thpool_priority priority) {
   redisearch_thpool_push_chain(thpool_p, f_newjob_p, l_newjob_p, n, priority);
 
+  /* MOD-14296: never run verify_init from within one of this pool's own worker
+   * threads. verify_init coordinates every live worker through a barrier; the
+   * submitting worker is one of them but is stuck here initiating the barrier,
+   * so it can never be reached -> the pool (and any load-time drain waiting on
+   * it) deadlocks. The pool is already running (the caller is a live worker),
+   * so the jobs just pushed will be drained by the running workers; spawning or
+   * reviving threads is only ever required from a non-worker (main) thread. */
+  if (g_thpool_self == thpool_p) {
+    return;
+  }
+
   /* Initialize threads if needed */
   redisearch_thpool_verify_init(thpool_p);
 }
@@ -645,6 +663,10 @@ static int thread_init(redisearch_thpool_t *thpool_p, volatile bool *started) {
 static void *thread_do(void *p) {
   struct thread_do_args *args = (struct thread_do_args *)p;
   redisearch_thpool_t *thpool_p = args->thpool_p;
+
+  /* Remember which pool this worker serves, so job submissions made from within
+   * a job it runs can skip the verify_init barrier (see g_thpool_self). */
+  g_thpool_self = thpool_p;
 
   /* Set thread name for profiling and debugging */
   char thread_name[16] = {0};

--- a/tests/cpptests/test_cpp_thpool.cpp
+++ b/tests/cpptests/test_cpp_thpool.cpp
@@ -96,6 +96,11 @@ void sleep_job_us(void *p) {
     std::this_thread::sleep_for(std::chrono::microseconds(*time_us));
 };
 
+void incrementAtomicSize(void *p) {
+    volatile std::atomic<size_t> *value = (volatile std::atomic<size_t> *)p;
+    ++(*value);
+}
+
 struct test_struct {
     std::chrono::time_point<std::chrono::high_resolution_clock> *arr; // Pointer to the array of timestamps
     int index;                                                        // Index of the timestamp in the array
@@ -583,6 +588,69 @@ TEST_P(PriorityThpoolTestRuntimeConfig, TestSetToZeroWhileTerminateWhenEmpty) {
         stats = redisearch_thpool_get_stats(this->pool);
     }
     ASSERT_EQ(stats.total_jobs_done, total_jobs_pushed);
+    ASSERT_EQ(stats.total_pending_jobs, 0);
+}
+
+TEST_P(PriorityThpoolTestRuntimeConfig, TestWorkerCanAddJobsWhileTerminateWhenEmpty) {
+    typedef struct {
+        redisearch_thpool_t *pool;
+        volatile std::atomic<bool> &submitted;
+        volatile std::atomic<bool> &release;
+        volatile std::atomic<size_t> &executed;
+    } SubmitFromWorkerCtx;
+
+    auto submitFromWorkerFunc = [](void *p) {
+        SubmitFromWorkerCtx *ctx = (SubmitFromWorkerCtx *)p;
+        while (redisearch_thpool_is_initialized(ctx->pool)) {
+            usleep(1);
+        }
+
+        redisearch_thpool_work_t jobs[] = {
+            {incrementAtomicSize, (void *)&ctx->executed},
+            {incrementAtomicSize, (void *)&ctx->executed},
+            {incrementAtomicSize, (void *)&ctx->executed},
+        };
+        ASSERT_EQ(redisearch_thpool_add_n_work(ctx->pool, jobs, 3, THPOOL_PRIORITY_HIGH), 0);
+        ctx->submitted = true;
+
+        while (ctx->release) {
+            usleep(1);
+        }
+    };
+
+    auto waitForReleaseFunc = [](void *p) {
+        volatile std::atomic<bool> *release = (volatile std::atomic<bool> *)p;
+        while (*release) {
+            usleep(1);
+        }
+    };
+
+    volatile std::atomic<bool> submitted{false};
+    volatile std::atomic<bool> release{true};
+    volatile std::atomic<size_t> executed{0};
+    SubmitFromWorkerCtx ctx = {this->pool, submitted, release, executed};
+
+    redisearch_thpool_add_work(this->pool, submitFromWorkerFunc, &ctx, THPOOL_PRIORITY_HIGH);
+    redisearch_thpool_add_work(this->pool, waitForReleaseFunc, (void *)&release, THPOOL_PRIORITY_HIGH);
+    jobs_pull_wait(this->pool, 2);
+
+    redisearch_thpool_schedule_config_reduce_threads_job(this->pool, redisearch_thpool_get_num_threads(this->pool), true);
+    ASSERT_FALSE(redisearch_thpool_is_initialized(this->pool));
+    ASSERT_EQ(redisearch_thpool_get_num_threads(this->pool), 0);
+
+    while (!submitted) {
+        usleep(1);
+    }
+
+    release = false;
+    redisearch_thpool_wait(this->pool);
+
+    while (redisearch_thpool_get_stats(this->pool).num_threads_alive) {
+        usleep(1);
+    }
+
+    thpool_stats stats = redisearch_thpool_get_stats(this->pool);
+    ASSERT_EQ(executed, 3);
     ASSERT_EQ(stats.total_pending_jobs, 0);
 }
 


### PR DESCRIPTION
## Problem

A worker thread that submits jobs to its **own** pool can deadlock the pool.

`redisearch_thpool_add_work` / `add_n_work` funnel through
`redisearch_thpool_push_chain_verify_init_threads`, which — after enqueuing —
calls `redisearch_thpool_verify_init`. When the pool is not in `INITIALIZED`
state, `verify_init` coordinates **every live worker** through a
`pthread_barrier` (each worker runs an `admin_job_change_state` job that waits
on the barrier, while the caller waits in `barrier_wait_and_destroy`).

If the caller is itself one of the pool's worker threads, it is stuck in
`verify_init` instead of servicing the barrier, so the barrier can never reach
its count — the pool deadlocks permanently, and anything waiting on the pool
(e.g. a `redisearch_thpool_wait` drain) hangs forever.

This was hit by the tiered disk-HNSW `completeLoad` path on hot-restart /
SST-replica reopen: a `delete-init` job runs on a worker, derives repair jobs,
and submits them via `add_n_work` while the pool is mid-resize during the load
event (not `INITIALIZED`) → re-entrant `verify_init` → deadlock. The
load-completion drain (`workersThreadPool_OnEventEnd(true)`) then never returns,
so the server never finishes loading and never accepts connections.
(RediSearchEnterprise MOD-14296.)

Backtrace of the stuck worker:
```
barrier_wait_and_destroy            thpool/barrier.c:28
redisearch_thpool_verify_init       thpool/thpool.c:292
..._push_chain_verify_init_threads  thpool/thpool.c:444
redisearch_thpool_add_n_work        thpool/thpool.c:399
ThreadPoolAPI_SubmitIndexJobs       util/threadpool_api.c:50
... TieredHNSWDiskIndex::submitRepairsForDelete / executeDeleteInitJob ...
thread_do                           thpool/thpool.c:693   <- it's a pool worker
```
(3 sibling workers were parked in `pthread_barrier_wait` via `admin_job_change_state`.)

## Fix

Track the owning pool per worker thread in a thread-local (`g_thpool_self`, set
in `thread_do`). In `push_chain_verify_init_threads`, **skip `verify_init` when
a worker submits to its own pool**: the pool is already running (the caller is a
live worker), the enqueued jobs are drained by the running workers, and
spawning/reviving threads only ever needs to happen from a non-worker thread.

## Testing

Verified on RediSearchEnterprise aarch64 CI (async I/O), which reproduces the
hang: the tombstone hot-restart + worker-drain [JSON] flow hung 3/3 stress runs
before this change (gdb: 3 workers in `pthread_barrier_wait` + main thread in
the load drain), and 61/61 stress iterations clean after it.

- [ ] This PR requires release notes
- [x] This PR does not require release notes
