### PR TITLE
[MOD-16418] Trie - use unicode_tolower_cow in SpellcheckDictionary

### DIFF
--- a/src/redisearch_rs/spellcheck_dictionary/src/lib.rs
+++ b/src/redisearch_rs/spellcheck_dictionary/src/lib.rs
@@ -9,7 +9,7 @@
 
 use std::fmt::{self, Debug};
 
-use string_utils::{unicode_tolower, unicode_tolower_capped};
+use string_utils::{unicode_tolower_capped, unicode_tolower_cow};
 use trie_rs::str_trie_map::StrTrieMap;
 
 /// Maximum query length, in Unicode codepoints, that the dictionary will match
@@ -88,7 +88,7 @@ impl SpellCheckDictionary {
         };
         self.trie
             .iter()
-            .any(|(key, _)| unicode_tolower(&key) == needle)
+            .any(|(key, _)| *unicode_tolower_cow(&key) == *needle)
     }
 
     /// Find stored terms within Levenshtein edit distance `max_dist`
@@ -100,7 +100,7 @@ impl SpellCheckDictionary {
         let needle = unicode_tolower_capped(term, TRIE_MAX_PREFIX);
         needle.into_iter().flat_map(move |needle| {
             self.trie.iter().filter_map(move |(key, _)| {
-                let dist = strsim::levenshtein(&unicode_tolower(&key), &needle) as u32;
+                let dist = strsim::levenshtein(&unicode_tolower_cow(&key), &needle) as u32;
                 (dist <= max_dist).then_some(key)
             })
         })
@@ -112,6 +112,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
     use std::collections::BTreeSet;
+    use string_utils::unicode_tolower;
 
     #[rstest]
     #[case(&["Hello"], "Hello", true)]


### PR DESCRIPTION
Use `unicode_tolower_cow` in `SpellcheckDictionary` for decreased number of allocations and increased performance.

Builds on top of 
- https://github.com/RediSearch/RediSearch/pull/10315

which introduces this function for the purpose of using it here.

## Performance report

(macOS, ARM, non-LTO)

```
  Lowercase corpus (cow borrows — expected win)

  ┌───────────┬────────┬────────┬──────┬────────┬───────────┐
  │ Benchmark │ Before │ After  │ Unit │   Δ    │           │
  ├───────────┼────────┼────────┼──────┼────────┼───────────┤
  │ Contains  │ 2.881  │ 1.785  │ ms   │ −38.6% │ ✅ faster │
  ├───────────┼────────┼────────┼──────┼────────┼───────────┤
  │ Fuzzy     │ 12.707 │ 10.514 │ ms   │ −17.3% │ ✅ faster │
  └───────────┴────────┴────────┴──────┴────────┴───────────┘

  Mixed-case corpus control (cow forced to allocate — expected flat)

  ┌───────────┬────────┬────────┬──────┬───────┬──────┐
  │ Benchmark │ Before │ After  │ Unit │   Δ   │      │
  ├───────────┼────────┼────────┼──────┼───────┼──────┤
  │ Contains  │ 2.904  │ 2.947  │ ms   │ +1.5% │ flat │
  ├───────────┼────────┼────────┼──────┼───────┼──────┤
  │ Fuzzy     │ 12.847 │ 13.122 │ ms   │ +2.1% │ flat │
  └───────────┴────────┴────────┴──────┴───────┴──────┘
```

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
