### PR TITLE
rqe_iterators: add patch_vtable for post-construction vtable overrides

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -464,8 +464,16 @@ impl CRQEIterator {
             "Attempted to double-profile an iterator"
         );
         let profiled = self.profile_children();
+        let had_no_skip_to = profiled.SkipTo.is_none();
         let profile_wrapper = crate::profile::Profile::new(profiled);
-        CRQEIterator::from_rust_leaf(profile_wrapper)
+        let result = CRQEIterator::from_rust_leaf(profile_wrapper);
+        if had_no_skip_to {
+            // Preserve a root-only iterator's cleared `SkipTo` (top_k is the only
+            // user today) across the outer `Profile` rebox.
+            // SAFETY: `result` was just constructed above and has no other alias yet.
+            unsafe { crate::interop::patch_vtable(result.as_raw().as_ptr(), |h| h.SkipTo = None) };
+        }
+        result
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -355,6 +355,13 @@ extern "C" fn rust_profile_children<'index, I: ProfileChildren<'index> + Profile
 ) -> *mut QueryIterator {
     debug_assert!(!base.is_null());
     debug_assert!(base.is_aligned());
+    // SAFETY:
+    // 1. As a header-stored callback (invariant 1. in [`RQEIteratorWrapper`]),
+    //    `base` is a non-null, aligned, live header, uniquely owned until it is
+    //    consumed into the `Box` below.
+    // 2. `SkipTo` is `Copy`, so reading it through a shared reference leaves
+    //    `base` intact for that `Box::from_raw`.
+    let had_no_skip_to = unsafe { (*base).SkipTo.is_none() };
     // SAFETY: Callbacks are guaranteed to get a header pointer created by
     // `RQEIteratorWrapper::boxed_new_compound`, which uses `Box::into_raw`.
     let it = unsafe { Box::from_raw(base as *mut RQEIteratorWrapper<I>) };
@@ -362,7 +369,14 @@ extern "C" fn rust_profile_children<'index, I: ProfileChildren<'index> + Profile
     // Re-wrap with `boxed_new_inner` instead of `boxed_new_compound`: profiling is
     // a one-shot pass, so the result's children are already profiled and the
     // `ProfileChildren` callback would never be called again.
-    RQEIteratorWrapper::boxed_new_inner(profiled, None)
+    let ptr = RQEIteratorWrapper::boxed_new_inner(profiled, None);
+    if had_no_skip_to {
+        // Preserve a root-only iterator's cleared `SkipTo` (top_k is the only
+        // user today) across this rebox.
+        // SAFETY: `ptr` was just produced above and has no other alias yet.
+        unsafe { patch_vtable(ptr, |h| h.SkipTo = None) };
+    }
+    ptr
 }
 
 extern "C" fn free_iterator<'index, I: RQEIterator<'index> + 'index>(base: *mut QueryIterator) {

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -400,3 +400,19 @@ unsafe extern "C" fn print_profile<'index, I: ProfilePrint + RQEIterator<'index>
     let ctx = unsafe { &mut *(ctx as *mut crate::profile_print::ProfilePrintCtx<'_>) };
     wrapper.inner.print_profile(map, ctx);
 }
+
+/// Apply a post-construction mutation to the vtable of a freshly-boxed iterator.
+///
+/// This is an escape hatch for clearing or overriding vtable entries that
+/// `boxed_new` / `boxed_new_compound` set unconditionally. The closure receives
+/// a mutable reference to the [`QueryIterator`] header and may set any field.
+///
+/// # Safety
+///
+/// 1. `ptr` is a valid, non-null `*mut QueryIterator` produced by a
+///    [`RQEIteratorWrapper`] constructor in this module.
+/// 2. No other alias to `ptr` is live for the duration of `f`.
+pub unsafe fn patch_vtable(ptr: *mut QueryIterator, f: impl FnOnce(&mut QueryIterator)) {
+    // SAFETY: upheld by the caller
+    unsafe { f(&mut *ptr) }
+}


### PR DESCRIPTION
- I split https://github.com/RediSearch/RediSearch/pull/10324 into several PRs, this is one of them
- Based on https://github.com/RediSearch/RediSearch/pull/10221
- **rqe_iterators**: add `patch_vtable`, a small escape hatch for
  post-construction vtable overrides ; more of a defensive requirement, more info at https://github.com/RediSearch/RediSearch/pull/9479


This change is purely "defensive", but seeing the complexity of the code, I'd better be secure than sorry.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
