### PR TITLE
top_k: honor canTrimDeepResults, skip deep child-record copies

### DIFF
--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -114,6 +114,11 @@ pub struct TopKIterator<
     direct_batch: Option<S::Batch>,
     k: NonZeroUsize,
     compare: fn(&f64, &f64) -> Ordering,
+    /// When `true`, filtered modes skip deep-copying the child's rich result
+    /// subtree and yield a metric-only result carrying just the source's score.
+    /// Set when the downstream pipeline needs no rich results (no relevance
+    /// scorer or highlighter that reads the child's term records).
+    can_trim_deep_results: bool,
     phase: Phase,
     /// Heap contents drained into score order for yielding. In filtered modes
     /// each entry carries the child's record captured at match time.
@@ -177,6 +182,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             direct_batch: None,
             k,
             compare,
+            can_trim_deep_results: false,
             phase: Phase::NotStarted,
             results: ManuallyDrop::new(Vec::new()),
             yield_pos: 0,
@@ -185,6 +191,18 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             at_eof: false,
             metrics: TopKMetrics::default(),
         }
+    }
+
+    /// Set whether filtered modes may yield metric-only results.
+    ///
+    /// When `true`, the collection phase skips deep-copying each matching
+    /// child record and the yield phase builds a metric-only result via
+    /// [`ScoreSource::build_result`] instead of carrying the child's subtree.
+    /// Leave `false` (the default) whenever a downstream scorer or highlighter
+    /// reads the child's term records.
+    pub fn with_trim_deep_results(mut self, trim: bool) -> Self {
+        self.can_trim_deep_results = trim;
+        self
     }
 
     /// Returns the current execution mode.
@@ -207,7 +225,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
         self.child.as_ref()
     }
 
-    /// Returns a reference to the diagnostic counters accumulated so far.
+    /// Returns a reference to the metrics accumulated so far.
     pub const fn metrics(&self) -> &TopKMetrics {
         &self.metrics
     }
@@ -267,8 +285,15 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
 
             // Borrow-checker split: we can't hold `&mut self.child` and call
             // `self.heap.push` at the same time.  Pass fields explicitly.
+            let can_trim_deep_results = self.can_trim_deep_results;
             if let Some(child) = &mut self.child {
-                intersect_batch_with_child(child, &mut batch, &mut self.heap, &mut self.metrics)?;
+                intersect_batch_with_child(
+                    child,
+                    &mut batch,
+                    &mut self.heap,
+                    &mut self.metrics,
+                    can_trim_deep_results,
+                )?;
             } else {
                 // No filter child: every source batch record is a candidate, so feed
                 // the whole batch through the heap, which retains the top k.
@@ -324,6 +349,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
     /// wrap the adhoc code. This allows [`ScoreSource::lookup_score`]
     /// to reuse expensive resources.
     fn collect_adhoc(&mut self) -> Result<(), RQEIteratorError> {
+        let can_trim_deep_results = self.can_trim_deep_results;
         let child = self
             .child
             .as_mut()
@@ -342,12 +368,18 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             // VecSim distance lookup.
             scope.0.check_timeout()?;
             if let Some(score) = scope.0.lookup_score(doc_id) {
-                // Capture the child's record only if the heap retains this entry,
+                // Capture the child's data only if the heap retains this entry,
                 // before the next `child.read()` reuses its storage, so the yield
                 // phase needn't re-walk the child. A discarded candidate skips the
-                // copy entirely.
-                self.heap
-                    .push_with_record_lazy(doc_id, score, || Some(capture_child_record(result)));
+                // copy entirely. When rich results can be trimmed, copy only the
+                // child's yielded metrics rather than its full scoring subtree.
+                self.heap.push_with_record_lazy(doc_id, score, || {
+                    Some(if can_trim_deep_results {
+                        capture_child_metrics(result)
+                    } else {
+                        capture_child_record(result)
+                    })
+                });
             }
         }
 
@@ -444,13 +476,31 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             // Poll once per step, before yielding or skipping an entry.
             self.source.check_timeout()?;
 
-            // Filtered mode: yield the stored child record so BM25 inputs survive,
-            // unless the source builds its own result (e.g. numeric `SORTBY`).
+            // Filtered mode carries the child's captured data. Without trimming,
+            // the stored record is the child's full subtree, kept so BM25 inputs
+            // survive; when trimming it holds only the child's yielded metrics.
+            // A source that builds its own result (e.g. numeric `SORTBY`) opts out
+            // and takes the source-built path below.
             if self.child.is_some() && self.source.yields_child_record() {
+                if self.can_trim_deep_results {
+                    // Build a metric-only result, then fold in the child's
+                    // yielded metrics (explicit output/sort fields) captured at
+                    // match time.
+                    let mut result = self.source.build_result(doc_id, score);
+                    if self.source.is_expired(&result) {
+                        continue;
+                    }
+                    self.last_doc_id = doc_id;
+                    if let Some(mut record) = record {
+                        result.metrics_mut().concat(record.metrics_mut());
+                    }
+                    *self.current = Some(result);
+                    return Ok(self.current.as_mut());
+                }
                 let Some(mut record) = record else {
-                    // A filtered-mode entry must always carry its captured record;
-                    // a missing one would indicate a collection-side bug. Treat as
-                    // EOF rather than panicking.
+                    // A rich filtered-mode entry must always carry its captured
+                    // record; a missing one would indicate a collection-side bug.
+                    // Treat as EOF rather than panicking.
                     self.at_eof = true;
                     return Ok(None);
                 };
@@ -600,6 +650,22 @@ fn capture_child_record<'index>(record: &RSIndexResult<'index>) -> RSIndexResult
     unsafe { std::mem::transmute::<RSIndexResult<'_>, RSIndexResult<'index>>(owned) }
 }
 
+/// Capture only the child's yielded metrics (e.g. `AS`-yielded vector
+/// distances) into a fresh metric-only result.
+///
+/// Used on the trim path, where the child's deep scoring subtree is skipped but
+/// its yielded metrics remain explicit output/sort fields that must still be
+/// carried. Cloning copies each metric entry by value; the `RLookupKey`s they
+/// reference are owned by the query and stay valid for `'index`, so the copy
+/// outlives subsequent child reads.
+fn capture_child_metrics<'index>(record: &RSIndexResult<'index>) -> RSIndexResult<'index> {
+    let mut owned = RSIndexResult::build_metric(0.0)
+        .doc_id(record.doc_id)
+        .build();
+    owned.metrics = record.metrics.clone();
+    owned
+}
+
 /// Intersect one score-ordered batch with a child filter iterator,
 /// pushing matches into `heap`.
 ///
@@ -611,6 +677,7 @@ fn intersect_batch_with_child<'index, C: RQEIterator<'index>>(
     batch: &mut impl ScoreBatch,
     heap: &mut TopKHeap<'index>,
     metrics: &mut TopKMetrics,
+    can_trim_deep_results: bool,
 ) -> Result<(), RQEIteratorError> {
     child.rewind();
 
@@ -627,11 +694,19 @@ fn intersect_batch_with_child<'index, C: RQEIterator<'index>>(
         metrics.total_comparisons += 1;
         match batch_doc.cmp(&child_doc) {
             Ordering::Equal => {
-                // Capture the matching child record only if the heap retains it,
+                // Capture the matching child data only if the heap retains it,
                 // before advancing past it, so the yield phase can return it
                 // without re-reading the child. A discarded match skips the copy.
+                // When rich results can be trimmed, copy only the child's yielded
+                // metrics rather than its full scoring subtree.
                 heap.push_with_record_lazy(batch_doc, batch_score, || {
-                    child.current().map(|r| capture_child_record(r))
+                    child.current().map(|r| {
+                        if can_trim_deep_results {
+                            capture_child_metrics(r)
+                        } else {
+                            capture_child_record(r)
+                        }
+                    })
                 });
                 // Advance the batch first; only read the child when another
                 // batch doc remains. Reading the child past an exhausted batch

--- a/src/redisearch_rs/top_k/src/mock.rs
+++ b/src/redisearch_rs/top_k/src/mock.rs
@@ -205,6 +205,12 @@ impl ScoreSource for MockScoreSource {
         RSIndexResult::build_virt().doc_id(doc_id).build()
     }
 
+    fn attach_score_metric<'r>(&self, _result: &mut RSIndexResult<'r>, _score: f64)
+    where
+        Self: 'r,
+    {
+    }
+
     fn batch_strategy(&mut self, heap_count: usize, k: usize) -> BatchStrategy {
         (self.batch_strategy)(heap_count, k)
     }
@@ -240,12 +246,6 @@ impl ScoreSource for MockScoreSource {
 
     fn iterator_type(&self) -> rqe_iterator_type::IteratorType {
         rqe_iterator_type::IteratorType::Mock
-    }
-
-    fn attach_score_metric<'r>(&self, _result: &mut RSIndexResult<'r>, _score: f64)
-    where
-        Self: 'r,
-    {
     }
 
     fn yields_child_record(&self) -> bool {

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -884,3 +884,115 @@ fn batches_preserves_child_scoring_fields() {
           got {emitted:?}; the BM25-becomes-0 bug from MOD-8142"
     );
 }
+
+/// The dual of [`batches_preserves_child_scoring_fields`]: when the pipeline can
+/// trim deep results, the child's scoring subtree is never captured, so each
+/// match yields the source's metric-only result (default freq/field_mask) rather
+/// than the child's rich record.
+#[test]
+fn batches_trim_deep_results_yields_metric_only() {
+    use index_result::RSIndexResult;
+    use rqe_iterators::IdList;
+
+    let child_result = RSIndexResult::build_virt()
+        .frequency(7)
+        .field_mask(0xABC)
+        .build();
+    let child = IdList::<true>::with_result(vec![1, 2], child_result);
+
+    let source = MockScoreSource::new(vec![vec![(1, 0.9), (2, 0.5)]], vec![], |_, _| {
+        BatchStrategy::Continue
+    });
+
+    let mut it = TopKIterator::new(
+        source,
+        Box::new(child) as Box<dyn RQEIterator<'_> + '_>,
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    )
+    .with_trim_deep_results(true);
+
+    let mut emitted = Vec::new();
+    while let Some(r) = it.read().unwrap() {
+        emitted.push((r.doc_id, r.freq, r.field_mask));
+    }
+
+    // Same doc ids and best-first order as the rich path, but the child's
+    // freq/field_mask are absent — the yielded record is the source's
+    // metric-only result.
+    assert_eq!(emitted, vec![(2, 0, 0), (1, 0, 0)]);
+}
+
+/// Adhoc-BF counterpart of [`batches_trim_deep_results_yields_metric_only`]:
+/// the child-driven scan also skips capturing the rich record when results are
+/// trimmed.
+#[test]
+fn adhoc_trim_deep_results_yields_metric_only() {
+    use index_result::RSIndexResult;
+    use rqe_iterators::IdList;
+
+    let child_result = RSIndexResult::build_virt()
+        .frequency(7)
+        .field_mask(0xABC)
+        .build();
+    let child = IdList::<true>::with_result(vec![1, 2], child_result);
+
+    let source = MockScoreSource::new(vec![], vec![(1, 0.9), (2, 0.5)], |_, _| {
+        BatchStrategy::Continue
+    });
+
+    let mut it = TopKIterator::new_with_mode(
+        source,
+        Some(Box::new(child) as Box<dyn RQEIterator<'_> + '_>),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+        TopKMode::AdhocBF,
+    )
+    .with_trim_deep_results(true);
+
+    let mut emitted = Vec::new();
+    while let Some(r) = it.read().unwrap() {
+        emitted.push((r.doc_id, r.freq, r.field_mask));
+    }
+
+    assert_eq!(emitted, vec![(2, 0, 0), (1, 0, 0)]);
+}
+
+/// Trimming skips the child's scoring subtree but must still carry its yielded
+/// metrics (e.g. `AS`-yielded vector distances), which are explicit output/sort
+/// fields rather than part of the rich subtree.
+#[test]
+fn batches_trim_deep_results_preserves_child_metrics() {
+    use index_result::RSIndexResult;
+    use rqe_iterators::IdList;
+
+    // Child result with rich scoring fields *and* a yielded metric.
+    let mut child_result = RSIndexResult::build_virt()
+        .frequency(7)
+        .field_mask(0xABC)
+        .build();
+    child_result.metrics_mut().push_without_key(42.0);
+    let child = IdList::<true>::with_result(vec![1, 2], child_result);
+
+    let source = MockScoreSource::new(vec![vec![(1, 0.9), (2, 0.5)]], vec![], |_, _| {
+        BatchStrategy::Continue
+    });
+
+    let mut it = TopKIterator::new(
+        source,
+        Box::new(child) as Box<dyn RQEIterator<'_> + '_>,
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    )
+    .with_trim_deep_results(true);
+
+    let mut emitted = Vec::new();
+    while let Some(r) = it.read().unwrap() {
+        let metric = r.metrics_ref().get(0).map(|m| m.value());
+        emitted.push((r.doc_id, r.freq, r.field_mask, metric));
+    }
+
+    // Rich subtree is trimmed (freq/field_mask are the source's defaults), but
+    // the child's yielded metric rides along on every result.
+    assert_eq!(emitted, vec![(2, 0, 0, Some(42.0)), (1, 0, 0, Some(42.0))]);
+}


### PR DESCRIPTION
- I split https://github.com/RediSearch/RediSearch/pull/10324 into several PRs, this is one of them
- Based on https://github.com/RediSearch/RediSearch/pull/10221
- **top_k**: honor `canTrimDeepResults` — skip deep child-record copies when the
  pipeline needs only the metric score.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
