### PR TITLE
[MOD-16514] validate native LLVM installs

### DIFF
--- a/.install/install_llvm.sh
+++ b/.install/install_llvm.sh
@@ -70,6 +70,26 @@ export_path_gha() {
     export LIBCLANG_PATH="${INSTALL_DIR}/lib"
 }
 
+llvm_major() {
+    "$1" --version 2>/dev/null | head -1 | sed -En 's/.*version ([0-9]+).*/\1/p'
+}
+
+accept_native_llvm() {
+    local clang_cmd="$1"
+    local lld_cmd="$2"
+
+    command -v "$clang_cmd" &>/dev/null || return 1
+    command -v "$lld_cmd" &>/dev/null || return 1
+
+    local actual
+    actual=$(llvm_major "$clang_cmd")
+    [[ "$actual" == "$LLVM_VER" ]] || return 1
+
+    # RHEL-family puts shared libs in /usr/lib64; expose for bindgen/clang-sys.
+    [[ -n "${GITHUB_ENV:-}" ]] && echo "LIBCLANG_PATH=/usr/lib64" >> "$GITHUB_ENV"
+    export LIBCLANG_PATH=/usr/lib64
+}
+
 # ---------------------------------------------------------------------------
 # Source the macOS profile updater if present.
 # ---------------------------------------------------------------------------
@@ -183,21 +203,17 @@ install_llvm() {
         # Try native distro packages first — they're built against the system
         # glibc/libstdc++ so no version-mismatch issues with the tarball.
         if $MODE dnf install -y --nobest --skip-broken \
-                "clang-${LLVM_VER}" "lld-${LLVM_VER}" "clang-devel-${LLVM_VER}" 2>/dev/null; then
+                "clang-${LLVM_VER}" "lld-${LLVM_VER}" "clang-devel-${LLVM_VER}" 2>/dev/null \
+                && accept_native_llvm "clang-${LLVM_VER}" "lld-${LLVM_VER}"; then
             echo ">>> Installed clang-${LLVM_VER} from native dnf repos"
-            # RHEL-family puts shared libs in /usr/lib64; expose for bindgen/clang-sys.
-            [[ -n "${GITHUB_ENV:-}" ]] && echo "LIBCLANG_PATH=/usr/lib64" >> "$GITHUB_ENV"
-            export LIBCLANG_PATH=/usr/lib64
-        elif $MODE dnf install -y --nobest --skip-broken clang lld clang-devel 2>/dev/null; then
+        elif $MODE dnf install -y --nobest --skip-broken clang lld clang-devel 2>/dev/null \
+                && accept_native_llvm clang lld; then
             echo ">>> Installed default clang from native dnf repos (may not be ${LLVM_VER})"
-            [[ -n "${GITHUB_ENV:-}" ]] && echo "LIBCLANG_PATH=/usr/lib64" >> "$GITHUB_ENV"
-            export LIBCLANG_PATH=/usr/lib64
-        elif $MODE yum install -y clang lld clang-devel 2>/dev/null; then
-            echo ">>> Installed clang from native yum repos (Amazon Linux 2)"
-            [[ -n "${GITHUB_ENV:-}" ]] && echo "LIBCLANG_PATH=/usr/lib64" >> "$GITHUB_ENV"
-            export LIBCLANG_PATH=/usr/lib64
+        elif $MODE yum install -y clang lld clang-devel 2>/dev/null \
+                && accept_native_llvm clang lld; then
+            echo ">>> Installed clang from native yum repos"
         else
-            echo ">>> Native packages not available — falling back to official tarball"
+            echo ">>> Native packages unavailable or wrong LLVM major — falling back to official tarball"
             install_from_tarball
         fi
         ;;


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: DNF/YUM-based platforms can report success for native LLVM package installation even when the requested versioned packages are unavailable or skipped.
2. Change: Validate that native `clang` and `lld` exist and that `clang` reports the expected LLVM major before accepting the native install path.
3. Outcome: Platforms such as Rocky Linux 10 and Amazon Linux 2023 fall back to the official LLVM tarball instead of later failing LTO builds without a usable matching clang.

#### Which additional issues this PR fixes
1. MOD-16514
2. Follow-up to #10340

#### Main objects this PR modified
1. `.install/install_llvm.sh`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Backports the urgent LLVM validation fix already applied to the 8.10 backport PR #10340.
