### PR TITLE
[MOD-16734] inverted_index: store sealed blocks in a single Arc<[IndexBlock]> allocation

### DIFF
--- a/src/redisearch_rs/inverted_index/src/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/gc.rs
@@ -9,14 +9,13 @@
 
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::{marker::PhantomData, sync::Arc};
+use std::{marker::PhantomData, mem::MaybeUninit, sync::Arc};
 
-use crate::{BlockCapacity, DecodedBy, Decoder, Encoder, IndexBlock, InvertedIndex, empty_sealed};
+use crate::{DecodedBy, Decoder, Encoder, IndexBlock, InvertedIndex, empty_sealed};
 use ffi::IndexFlags_Index_DocIdsOnly;
 use index_result::RSIndexResult;
 use rqe_core::DocId;
 use smallvec::SmallVec;
-use thin_vec::ThinVec;
 
 /// Process-wide cumulative count of index blocks deep-cloned by GC because a live
 /// reader snapshot pinned them (copy-on-write). Stays `0` whenever no snapshot is
@@ -361,13 +360,12 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
             return info;
         }
 
-        // Count survivors up front so the new `sealed` ThinVec is allocated to fit
-        // exactly (no slack) and built straight into the `Arc` — no intermediate `Vec`,
-        // no final block-buffer copy. `deltas` is sorted ascending and every remaining
-        // entry targets a live block (the one possibly-stale trailing delta was dropped
-        // by the last-block-changed check above); a Delete removes one block and a
-        // Replace swaps one block for its shrunk replacements. The `< blocks_before`
-        // guard ignores any delta that would land past the current tail (never applied).
+        // Count survivors up front so the new `sealed` region is allocated to fit exactly
+        // (no slack). `deltas` is sorted ascending and every remaining entry targets a
+        // live block (the one possibly-stale trailing delta was dropped by the
+        // last-block-changed check above); a Delete removes one block and a Replace swaps
+        // one block for its shrunk replacements. The `< blocks_before` guard ignores any
+        // delta that would land past the current tail (never applied).
         let mut n_survivors: usize = blocks_before;
         for d in &deltas {
             if d.index >= blocks_before {
@@ -379,25 +377,37 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
             }
         }
 
-        // Build the compacted region straight into the `sealed` ThinVec, sized to fit
-        // exactly. Blocks flow in logical sealed → pending → in_progress order; a delta
-        // at logical index N is matched against the Nth block consumed. `trailing` holds
-        // the most recent survivor — the next survivor displaces it into `sealed`, so
-        // whatever remains after the pass is the tail block and becomes `in_progress`.
-        // A block is only *materialized* (moved or cloned) when it survives — a Delete
-        // reads only its entry-count / size for accounting, so a deleted block that a
-        // snapshot pins is never cloned.
-        let mut new_sealed: ThinVec<IndexBlock, BlockCapacity> =
-            ThinVec::with_capacity(n_survivors.saturating_sub(1));
+        // Build the compacted `sealed` region in a *single* allocation. `Arc::new_uninit_slice`
+        // lays out the refcount header immediately followed by the `[IndexBlock]` slice, and
+        // survivors are written straight into it — no intermediate `Vec`/`ThinVec` and no
+        // second buffer copy that `Arc::new(vec)` would incur. Blocks flow in logical
+        // sealed → pending → in_progress order; a delta at logical index N is matched
+        // against the Nth block consumed. `trailing` holds the most recent survivor — the
+        // next survivor displaces it into `sealed`, so whatever remains after the pass is
+        // the tail block and becomes `in_progress`. A block is only *materialized* (moved
+        // or cloned) when it survives — a Delete reads only its entry-count / size for
+        // accounting, so a deleted block that a snapshot pins is never cloned.
+        //
+        // Exactly `n_survivors - 1` blocks go to `sealed` (the trailing survivor becomes
+        // `in_progress`), so allocate that many uninitialized slots and fill `0..write_idx`.
+        let sealed_len = n_survivors.saturating_sub(1);
+        let mut new_sealed: Arc<[MaybeUninit<IndexBlock>]> = Arc::new_uninit_slice(sealed_len);
+        // Uniquely owned right after allocation — no snapshot can share it yet — so
+        // `get_mut` is guaranteed `Some`; hold the slot slice for the fill below.
+        let sealed_slots =
+            Arc::get_mut(&mut new_sealed).expect("freshly allocated Arc is uniquely owned");
+        let mut write_idx: usize = 0;
         let mut trailing: Option<IndexBlock> = None;
         let mut deltas_iter = deltas.into_iter().peekable();
         let mut block_index: usize = 0;
 
-        // Add a survivor to the compacted region via the trailing slot.
+        // Add a survivor to the compacted region via the trailing slot: the displaced
+        // previous survivor is written into the next uninitialized `sealed` slot.
         macro_rules! keep_survivor {
             ($block:expr) => {{
                 if let Some(prev) = trailing.replace($block) {
-                    new_sealed.push(prev);
+                    sealed_slots[write_idx].write(prev);
+                    write_idx += 1;
                 }
             }};
         }
@@ -420,7 +430,8 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
                             } => {
                                 info.entries_removed += $num_entries;
                                 info.bytes_freed += $mem_usage;
-                                self.n_unique_docs -= n_unique_docs_removed;
+                                self.n_unique_docs =
+                                    self.n_unique_docs.saturating_sub(n_unique_docs_removed);
                             }
                             RepairType::Replace {
                                 blocks,
@@ -428,7 +439,8 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
                             } => {
                                 info.entries_removed += $num_entries;
                                 info.bytes_freed += $mem_usage;
-                                self.n_unique_docs -= n_unique_docs_removed;
+                                self.n_unique_docs =
+                                    self.n_unique_docs.saturating_sub(n_unique_docs_removed);
                                 for b in blocks {
                                     // Replace can only shrink — new block entries are always
                                     // a subset of the old. saturating_sub guards against a
@@ -449,23 +461,29 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
         }
 
         // `sealed`: when no reader snapshot pins the region (the common case) move each
-        // block out by value — no buffer copy. When a live snapshot still shares it we
-        // must deep-copy the survivors it holds (copy-on-write); a deleted block is only
-        // read for accounting, never cloned.
-        let old_sealed = std::mem::replace(&mut self.sealed, empty_sealed());
-        match Arc::try_unwrap(old_sealed) {
-            Ok(sealed_vec) => {
-                for b in sealed_vec.into_iter() {
+        // block out by value via a placeholder swap — no buffer copy. When a live
+        // snapshot still shares it we must deep-copy the survivors it holds
+        // (copy-on-write); a deleted block is only read for accounting, never cloned.
+        // (`Arc<[IndexBlock]>` can't be `try_unwrap`'d — the slice is unsized — so take
+        // ownership per block instead: `get_mut` proves uniqueness, then swap each block
+        // out for a trivial empty placeholder.)
+        let mut old_sealed = std::mem::replace(&mut self.sealed, empty_sealed());
+        match Arc::get_mut(&mut old_sealed) {
+            Some(blocks) => {
+                for slot in blocks.iter_mut() {
+                    // Move the block out; the emptied placeholder is dropped with
+                    // `old_sealed` at end of scope (trivial — its buffer is empty).
+                    let b = std::mem::replace(slot, IndexBlock::new(0));
                     let (ne, mu) = (b.num_entries as usize, b.mem_usage());
                     apply_delta_or_keep!(ne, mu, { keep_survivor!(b) });
                 }
             }
-            Err(shared) => {
+            None => {
                 // A live snapshot pins the whole region, so every block must be
                 // deep-copied out (the reader keeps reading the originals). Clone up
                 // front — matching the pre-existing behavior — then apply deltas to the
                 // owned copy.
-                for b in shared.iter() {
+                for b in old_sealed.iter() {
                     COW_CLONED_BLOCKS.fetch_add(1, Ordering::Relaxed);
                     COW_CLONED_BYTES.fetch_add(b.mem_usage() as u64, Ordering::Relaxed);
                     let owned = b.clone();
@@ -474,6 +492,7 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
                 }
             }
         }
+        drop(old_sealed);
         // `pending`: each block is its own `Arc`. Only survivors are materialized via
         // `unwrap_or_cow` (move when unique, clone when a snapshot pins that block); a
         // deleted pending block is read through the `Arc` and dropped without cloning.
@@ -497,19 +516,27 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
         // Whatever remains in `trailing` is the tail block → new `in_progress`.
         let new_in_progress = trailing;
         debug_assert_eq!(
-            new_sealed.len() + usize::from(new_in_progress.is_some()),
+            write_idx, sealed_len,
+            "must have filled exactly the pre-counted sealed slots"
+        );
+        debug_assert_eq!(
+            write_idx + usize::from(new_in_progress.is_some()),
             n_survivors,
             "survivor pre-count must match the blocks actually kept"
         );
 
-        let blocks_after = new_sealed.len() + usize::from(new_in_progress.is_some());
+        let blocks_after = write_idx + usize::from(new_in_progress.is_some());
 
-        // Point at the shared empty region rather than allocating an Arc for an empty
-        // ThinVec when GC compacted everything away (or into in_progress).
-        self.sealed = if new_sealed.is_empty() {
+        // Point at the shared empty region rather than keeping a zero-length `Arc`
+        // allocation when GC compacted everything away (or into in_progress).
+        self.sealed = if sealed_len == 0 {
             empty_sealed()
         } else {
-            Arc::new(new_sealed)
+            // SAFETY: the fill loop wrote exactly `sealed_len` blocks into slots
+            // `0..sealed_len` (asserted by `write_idx == sealed_len` above), so every
+            // element of the slice is initialized. `new_sealed` is still uniquely owned
+            // (no snapshot taken since allocation), so promoting it is sound.
+            unsafe { new_sealed.assume_init() }
         };
         // pending was drained via std::mem::take above; leave it empty.
         self.in_progress = new_in_progress;
@@ -518,9 +545,9 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
 
         // Reconcile the per-block accounting with the actual memory delta. The
         // compaction frees the old pending Vec heap, drops Arc<IndexBlock> wrappers
-        // for both deleted *and* surviving blocks, and rebuilds the sealed ThinVec —
-        // none of which is captured by per-block bytes_freed/bytes_allocated. Charge
-        // the residual to whichever side moved.
+        // for both deleted *and* surviving blocks, and reallocates the sealed
+        // `Arc<[IndexBlock]>` — none of which is captured by per-block
+        // bytes_freed/bytes_allocated. Charge the residual to whichever side moved.
         let mem_after = self.memory_usage();
         let net_delta = mem_after as i64 - mem_before as i64;
         let block_level_delta = info.bytes_allocated as i64 - info.bytes_freed as i64;

--- a/src/redisearch_rs/inverted_index/src/index/core.rs
+++ b/src/redisearch_rs/inverted_index/src/index/core.rs
@@ -30,15 +30,14 @@ use thin_vec::ThinVec;
 
 /// Shared, immutable empty `sealed` region. Every index with nothing sealed yet — the
 /// common case for small / single-block terms — points its `sealed` `Arc` here instead of
-/// allocating its own refcount box, saving ~24 bytes per index across the many inverted
-/// indexes a keyspace holds. `sealed` is only ever replaced wholesale (never mutated in
-/// place), so sharing one empty instance is safe; GC/`add_record` swap in a fresh `Arc`
-/// the moment they actually seal a block.
-static EMPTY_SEALED: LazyLock<Arc<ThinVec<IndexBlock, BlockCapacity>>> =
-    LazyLock::new(|| Arc::new(ThinVec::new()));
+/// allocating its own refcount box, saving a per-index heap allocation across the many
+/// inverted indexes a keyspace holds. `sealed` is only ever replaced wholesale (never
+/// mutated in place), so sharing one empty instance is safe; GC/`add_record` swap in a
+/// fresh `Arc` the moment they actually seal a block.
+static EMPTY_SEALED: LazyLock<Arc<[IndexBlock]>> = LazyLock::new(|| Arc::from([]));
 
 /// An `Arc::clone` of the shared empty `sealed` region — see [`EMPTY_SEALED`].
-pub(crate) fn empty_sealed() -> Arc<ThinVec<IndexBlock, BlockCapacity>> {
+pub(crate) fn empty_sealed() -> Arc<[IndexBlock]> {
     Arc::clone(&EMPTY_SEALED)
 }
 
@@ -46,7 +45,8 @@ pub(crate) fn empty_sealed() -> Arc<ThinVec<IndexBlock, BlockCapacity>> {
 /// used to efficiently search for documents that contain specific terms.
 ///
 /// Block storage is split across three direct fields:
-/// - [`Self::sealed`] — compacted blocks owned via [`Arc`]; only GC writes here.
+/// - [`Self::sealed`] — compacted blocks owned via a single [`Arc<[IndexBlock]>`]; only
+///   GC writes here.
 /// - [`Self::pending`] — full-but-not-yet-compacted blocks added by `add_record`'s
 ///   roll-over path. Each block is wrapped in an [`Arc`] so the snapshot's shallow Vec
 ///   clone shares the underlying data with the index.
@@ -57,9 +57,11 @@ pub(crate) fn empty_sealed() -> Arc<ThinVec<IndexBlock, BlockCapacity>> {
 /// [`Self::snapshot`].
 #[derive(Debug)]
 pub struct InvertedIndex<E> {
-    /// Compacted, immutable blocks. GC's `apply_gc` replaces this [`Arc`] under
+    /// Compacted, immutable blocks stored inline in a single `Arc` allocation
+    /// ([`Arc<[IndexBlock]>`] — refcount header immediately followed by the block slice,
+    /// no separate backing buffer). GC's `apply_gc` replaces this [`Arc`] under
     /// `&mut self`; readers' snapshots share the same allocation via refcount clone.
-    pub(crate) sealed: Arc<ThinVec<IndexBlock, BlockCapacity>>,
+    pub(crate) sealed: Arc<[IndexBlock]>,
 
     /// Full-but-not-yet-compacted blocks, in insertion order. `add_record` pushes the
     /// `in_progress` block here as an [`Arc`] when it fills up; GC drains this into
@@ -254,22 +256,23 @@ impl<E: Encoder> InvertedIndex<E> {
 
     /// The memory size of the index in bytes.
     ///
-    /// Counts every heap allocation reachable from `self`: the [`Arc<ThinVec>`] for
-    /// `sealed` (header + ThinVec stack + heap if it has one), the heap of the directly-
-    /// owned `pending: Vec<Arc<IndexBlock>>` plus each `Arc<IndexBlock>`'s allocation,
-    /// and every block's `buffer` capacity. `in_progress` is owned directly on the
-    /// struct, so its `IndexBlock` is already in `size_of::<Self>()`; only the
+    /// Counts every heap allocation reachable from `self`: the single [`Arc<[IndexBlock]>`]
+    /// allocation for `sealed` (refcount header + the inline block slice), the heap of the
+    /// directly-owned `pending: Vec<Arc<IndexBlock>>` plus each `Arc<IndexBlock>`'s
+    /// allocation, and every block's `buffer` capacity. `in_progress` is owned directly on
+    /// the struct, so its `IndexBlock` is already in `size_of::<Self>()`; only the
     /// heap-allocated `buffer` capacity is added below.
     pub fn memory_usage(&self) -> usize {
-        // `size_of::<Self>` covers the direct fields: the `Arc<ThinVec>` pointer, the
-        // `ThinVec<Arc<IndexBlock>>` pointer, the `Option<IndexBlock>`, the atomics and
-        // PhantomData. Heap-allocated portions are added below.
+        // `size_of::<Self>` covers the direct fields: the `Arc<[IndexBlock]>` fat pointer
+        // (data ptr + len), the `ThinVec<Arc<IndexBlock>>` pointer, the
+        // `Option<IndexBlock>`, the counters/flags, unique_id and PhantomData.
+        // Heap-allocated portions are added below.
         let stack = std::mem::size_of::<Self>();
 
-        // `sealed: Arc<ThinVec<IndexBlock, BlockCapacity>>`.
-        let sealed_arc =
-            ARC_HEADER_BYTES + std::mem::size_of::<ThinVec<IndexBlock, BlockCapacity>>();
-        let sealed_thinvec_heap = self.sealed.mem_usage();
+        // `sealed: Arc<[IndexBlock]>` — one allocation holding the refcount header
+        // immediately followed by the `[IndexBlock]` slice (no separate ThinVec buffer or
+        // header). The empty shared singleton has `len == 0`, so this is just the header.
+        let sealed_arc = ARC_HEADER_BYTES + self.sealed.len() * IndexBlock::STACK_SIZE;
         let sealed_buffers: usize = self.sealed.iter().map(|b| b.buffer.capacity()).sum();
 
         // `pending: ThinVec<Arc<IndexBlock>, BlockCapacity>` — direct field. `mem_usage()`
@@ -290,13 +293,7 @@ impl<E: Encoder> InvertedIndex<E> {
             .map(|b| b.buffer.capacity())
             .unwrap_or(0);
 
-        stack
-            + sealed_arc
-            + sealed_thinvec_heap
-            + sealed_buffers
-            + pending_vec_heap
-            + pending_blocks
-            + in_progress_buffer
+        stack + sealed_arc + sealed_buffers + pending_vec_heap + pending_blocks + in_progress_buffer
     }
 
     /// Add a new record to the index. Returns an [`AddRecordOutcome`] reporting how many bytes
@@ -543,14 +540,14 @@ impl<E: Encoder> InvertedIndex<E> {
     /// extract its blocks into an owned form. Tries to avoid cloning by `Arc::try_unwrap` —
     /// since the consumer owns the index, the Arcs are usually unique.
     pub(crate) fn into_blocks_owned(self) -> Vec<IndexBlock> {
-        let sealed = match Arc::try_unwrap(self.sealed) {
-            Ok(tv) => tv,
-            Err(arc) => (*arc).clone(),
-        };
         let mut out: Vec<IndexBlock> = Vec::with_capacity(
-            sealed.len() + self.pending.len() + usize::from(self.in_progress.is_some()),
+            self.sealed.len() + self.pending.len() + usize::from(self.in_progress.is_some()),
         );
-        out.extend(sealed);
+        // `sealed: Arc<[IndexBlock]>` — you can't move blocks out of a shared slice, so
+        // clone each. In practice `sealed` is empty here (the only caller builds a
+        // throwaway index via `add_record`, whose blocks all live in `pending` /
+        // `in_progress`), so this clones nothing.
+        out.extend(self.sealed.iter().cloned());
         for arc_block in self.pending {
             out.push(Arc::try_unwrap(arc_block).unwrap_or_else(|arc| (*arc).clone()));
         }

--- a/src/redisearch_rs/inverted_index/src/index/snapshot.rs
+++ b/src/redisearch_rs/inverted_index/src/index/snapshot.rs
@@ -49,7 +49,7 @@ use crate::BlockCapacity;
 /// lock is released the snapshot is fully owned and can be walked without coordination.
 #[derive(Debug)]
 pub struct InvertedIndexSnapshot {
-    sealed: Arc<ThinVec<IndexBlock, BlockCapacity>>,
+    sealed: Arc<[IndexBlock]>,
     pending: ThinVec<Arc<IndexBlock>, BlockCapacity>,
     in_progress: Option<IndexBlock>,
 }
@@ -59,7 +59,7 @@ impl InvertedIndexSnapshot {
     /// Caller is responsible for capturing all three under the same spec-read-lock
     /// acquisition.
     pub(crate) const fn new(
-        sealed: Arc<ThinVec<IndexBlock, BlockCapacity>>,
+        sealed: Arc<[IndexBlock]>,
         pending: ThinVec<Arc<IndexBlock>, BlockCapacity>,
         in_progress: Option<IndexBlock>,
     ) -> Self {
@@ -76,7 +76,7 @@ impl InvertedIndexSnapshot {
     /// [`InvertedIndex::sealed`](super::core::InvertedIndex), so a reader whose captured
     /// `sealed` still points at the index's current `sealed` has not been invalidated by a
     /// compaction. See [`needs_revalidation`](crate::reader::core).
-    pub(crate) const fn sealed_arc(&self) -> &Arc<ThinVec<IndexBlock, BlockCapacity>> {
+    pub(crate) const fn sealed_arc(&self) -> &Arc<[IndexBlock]> {
         &self.sealed
     }
 

--- a/src/redisearch_rs/inverted_index/src/tests/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/gc.rs
@@ -466,20 +466,19 @@ fn ii_apply_gc() {
 
     assert_eq!(ii.gc_marker(), 1);
 
-    // POST-GC layout:
-    //   - 3 sealed blocks live in a `ThinVec<IndexBlock>` (capacity = 3 here):
+    // POST-GC layout (sealed is a single `Arc<[IndexBlock]>` allocation — the refcount
+    // header is already part of the 104-byte empty overhead):
+    //   - 3 sealed blocks inline in the Arc allocation (no ThinVec header):
     //       Replace_block_for_1 (cap=8),
-    //       survivor_of_block_2 (cap=8, preserved by Arc::try_unwrap — the survivor's
-    //       Arc is uniquely owned at compaction time, so its original buffer Vec is
-    //       moved out without cloning),
+    //       survivor_of_block_2 (cap=8, moved out of its uniquely-owned sealed slot
+    //       without cloning its buffer),
     //       Replace_block_for_3a (cap=8).
     //   - 1 in_progress block, owned directly on the struct: Replace_block_for_3b
     //     (cap=8). Its IndexBlock stack bytes are in the 104-byte overhead already.
     //   - pending is empty (drained, no heap allocation).
     assert_eq!(
         ii.memory_usage(),
-        104 // empty InvertedIndex overhead
-        + 8 // sealed ThinVec heap header (4-byte length + 4-byte capacity)
+        104 // empty InvertedIndex overhead (88 stack + 16 sealed Arc header)
         + IndexBlock::STACK_SIZE * 3 // sealed slots (in-line IndexBlocks)
         + 8 + 8 + 8 // sealed buffer capacities
         + 8 // in_progress buffer capacity (block itself is in the 104 overhead)
@@ -520,9 +519,11 @@ fn ii_apply_gc() {
         GcApplyInfo {
             // Per-block frees (184) plus the container-level overhead released during
             // compaction (Arc<IndexBlock> wrappers around pending blocks, pending ThinVec
-            // heap incl. its header, ThinVec rebuild) — reconciled to match memory_usage()
-            // delta.
-            bytes_freed: 264,
+            // heap incl. its header, sealed region reallocated as a single
+            // `Arc<[IndexBlock]>`) — reconciled to match memory_usage() delta. 8 bytes more
+            // than the ThinVec-backed sealed: the compacted region no longer carries a
+            // ThinVec header.
+            bytes_freed: 272,
             // The third and fifth block was split making 168 new bytes
             bytes_allocated: 168,
             entries_removed: 5,

--- a/src/redisearch_rs/inverted_index/src/tests/index.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/index.rs
@@ -31,10 +31,11 @@ use super::Dummy;
 #[test]
 fn memory_usage() {
     let mut ii = InvertedIndex::<Dummy>::new(IndexFlags_Index_DocIdsOnly);
-    // Empty index: stack (80 = sealed Arc ptr 8 + pending ThinVec ptr 8 + Option<IndexBlock>
-    // 48 + n_unique_docs 4 + flags 4 + gc_marker 4 + unique_id 4 + alignment) plus the
-    // empty `sealed` Arc allocation (16 Arc header + 8 ThinVec stack rep = 24). pending
-    // and in_progress have no heap allocation when empty.
+    // Empty index: stack (88 = sealed Arc<[IndexBlock]> fat ptr 16 + pending ThinVec ptr 8
+    // + Option<IndexBlock> 48 + n_unique_docs 4 + flags 4 + gc_marker 4 + unique_id 4) plus
+    // the empty `sealed` Arc allocation (16 Arc header, 0 blocks). pending and in_progress
+    // have no heap allocation when empty. (88 + 16 = 104, unchanged from the ThinVec-backed
+    // sealed: the +8 fat pointer offsets the -8 ThinVec header that moved into the Arc.)
     let empty_size = 104;
 
     assert_eq!(ii.memory_usage(), empty_size);


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `sealed` is stored as `Arc<ThinVec<IndexBlock>>` — two heap allocations (the `Arc` refcount box holding a `ThinVec` pointer, plus the `ThinVec`'s own len/cap header + block buffer) and two pointer indirections to reach a block.
2. **Change:** Store `sealed` as a single `Arc<[IndexBlock]>` — the refcount header sits immediately in front of the inline block slice. `apply_gc` builds the compacted region straight into an `Arc::new_uninit_slice(n_survivors - 1)` and `assume_init`s it (no intermediate `Vec`/`ThinVec`, no second buffer copy). The unique-owner fast path moves survivor blocks out via a placeholder swap; the snapshot-pinned path deep-copies as before. Also hardens `apply_gc` to use `saturating_sub` for `n_unique_docs`, removing a corrupt-delta underflow.
3. **Outcome:** One allocation instead of two, one fewer indirection, and 8 fewer bytes of per-index heap overhead. Empty `memory_usage` is unchanged (104): the +8 fat pointer offsets the −8 `ThinVec` header now folded into the `Arc` allocation.

#### Which additional issues this PR fixes
MOD-16734

#### Main objects this PR modified
1. `inverted_index/src/index/core.rs` — `sealed: Arc<[IndexBlock]>`, `memory_usage`, `into_blocks_owned`
2. `inverted_index/src/gc.rs` — `Arc::new_uninit_slice` compaction, `saturating_sub` hardening
3. `inverted_index/src/index/snapshot.rs` — `sealed` type

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

**Stacked PR.** Base = `jk-ii-apply-gc` (the apply_gc mechanism PR). 168 `inverted_index` tests pass; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)