### PR TITLE
[MOD-16724] inverted_index: remove the unused gc_marker

### DIFF
--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -499,38 +499,6 @@ pub unsafe extern "C" fn InvertedIndex_LastId(ii: *const InvertedIndex) -> DocId
     ii_dispatch!(ii, last_doc_id).unwrap_or(0)
 }
 
-/// Get the garbage collector marker of the inverted index. This is used by some C tests.
-///
-/// # Safety
-///
-/// The following invariant must be upheld when calling this function:
-/// - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn InvertedIndex_GcMarker(ii: *const InvertedIndex) -> u32 {
-    debug_assert!(!ii.is_null(), "ii must not be null");
-
-    // SAFETY: The caller must ensure that `ii` is a valid pointer to an `InvertedIndex`
-    let ii = unsafe { &*ii };
-
-    ii_dispatch!(ii, gc_marker)
-}
-
-/// Increment the garbage collector marker of the inverted index. This is used by some C tests.
-///
-/// # Safety
-///
-/// The following invariant must be upheld when calling this function:
-/// - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn InvertedIndex_GcMarkerInc(ii: *mut InvertedIndex) {
-    debug_assert!(!ii.is_null(), "ii must not be null");
-
-    // SAFETY: The caller must ensure that `ii` is a valid pointer to an `InvertedIndex`
-    let ii = unsafe { &*ii };
-
-    ii_dispatch!(ii, gc_marker_inc);
-}
-
 /// Scan the inverted index for garbage and write the GC delta to the provided writer. The function
 /// returns true if the scan was successful and false otherwise.
 ///

--- a/src/redisearch_rs/headers/inverted_index_ffi.h
+++ b/src/redisearch_rs/headers/inverted_index_ffi.h
@@ -286,26 +286,6 @@ const struct IndexBlock *InvertedIndexSnapshot_BlockRef(const struct InvertedInd
 t_docId InvertedIndex_LastId(const struct InvertedIndex *ii);
 
 /**
- * Get the garbage collector marker of the inverted index. This is used by some C tests.
- *
- * # Safety
- *
- * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
- */
-uint32_t InvertedIndex_GcMarker(const struct InvertedIndex *ii);
-
-/**
- * Increment the garbage collector marker of the inverted index. This is used by some C tests.
- *
- * # Safety
- *
- * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
- */
-void InvertedIndex_GcMarkerInc(struct InvertedIndex *ii);
-
-/**
  * Scan the inverted index for garbage and write the GC delta to the provided writer. The function
  * returns true if the scan was successful and false otherwise.
  *

--- a/src/redisearch_rs/inverted_index/src/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/gc.rs
@@ -558,8 +558,6 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
             info.bytes_freed += (-residual) as usize;
         }
 
-        self.gc_marker_inc();
-
         info
     }
 }

--- a/src/redisearch_rs/inverted_index/src/index/core.rs
+++ b/src/redisearch_rs/inverted_index/src/index/core.rs
@@ -21,10 +21,7 @@ use rqe_core::DocId;
 use serde::{Deserialize, Serialize};
 use std::{
     marker::PhantomData,
-    sync::{
-        Arc, LazyLock,
-        atomic::{self, AtomicU32},
-    },
+    sync::{Arc, LazyLock},
 };
 use thin_vec::ThinVec;
 
@@ -82,10 +79,6 @@ pub struct InvertedIndex<E> {
     /// The flags of this index. This is used to determine the type of index and how it should be
     /// handled.
     pub(crate) flags: IndexFlags,
-
-    /// A marker used by the garbage collector to determine if the index has been modified since
-    /// the last GC pass. This is used to reset a reader if the index has been modified.
-    pub(crate) gc_marker: AtomicU32,
 
     /// A unique identifier for this index instance, assigned at construction time from a global
     /// monotonic counter. Used together with pointer comparison to detect the ABA problem: when
@@ -212,7 +205,6 @@ impl<E: Encoder> InvertedIndex<E> {
             in_progress: None,
             n_unique_docs: 0,
             flags,
-            gc_marker: AtomicU32::new(0),
             unique_id: IndexUniqueId::next(),
             _encoder: Default::default(),
         }
@@ -248,7 +240,6 @@ impl<E: Encoder> InvertedIndex<E> {
             in_progress,
             n_unique_docs,
             flags,
-            gc_marker: AtomicU32::new(0),
             unique_id: IndexUniqueId::next(),
             _encoder: Default::default(),
         }
@@ -504,16 +495,6 @@ impl<E: Encoder> InvertedIndex<E> {
             self.pending.clone(),
             self.in_progress.clone(),
         )
-    }
-
-    /// Get the current GC marker of this index. This is only used by the some C tests.
-    pub fn gc_marker(&self) -> u32 {
-        self.gc_marker.load(atomic::Ordering::Relaxed)
-    }
-
-    /// Increment the GC marker of this index. This is only used by the some C tests.
-    pub fn gc_marker_inc(&self) {
-        self.gc_marker.fetch_add(1, atomic::Ordering::Relaxed);
     }
 
     /// Returns the unique identifier for this index instance. This ID is assigned once at

--- a/src/redisearch_rs/inverted_index/src/index/with_entries.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_entries.rs
@@ -105,16 +105,6 @@ impl<E: Encoder> EntriesTrackingIndex<E> {
         self.index.snapshot()
     }
 
-    /// Get the current GC marker of this index. This is only used by the some C tests.
-    pub fn gc_marker(&self) -> u32 {
-        self.index.gc_marker()
-    }
-
-    /// Increment the GC marker of this index. This is only used by the some C tests.
-    pub fn gc_marker_inc(&self) {
-        self.index.gc_marker_inc();
-    }
-
     /// Get a reference to the inner inverted index.
     pub const fn inner(&self) -> &InvertedIndex<E> {
         &self.index

--- a/src/redisearch_rs/inverted_index/src/index/with_mask.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_mask.rs
@@ -98,16 +98,6 @@ impl<E: Encoder> FieldMaskTrackingIndex<E> {
         self.index.snapshot()
     }
 
-    /// Get the current GC marker of this index. This is only used by the some C tests.
-    pub fn gc_marker(&self) -> u32 {
-        self.index.gc_marker()
-    }
-
-    /// Increment the GC marker of this index. This is only used by the some C tests.
-    pub fn gc_marker_inc(&self) {
-        self.index.gc_marker_inc();
-    }
-
     /// Get a reference to the inner inverted index.
     pub const fn inner(&self) -> &InvertedIndex<E> {
         &self.index

--- a/src/redisearch_rs/inverted_index/src/tests/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/gc.rs
@@ -460,11 +460,7 @@ fn ii_apply_gc() {
         deltas: gc_result,
     };
 
-    assert_eq!(ii.gc_marker(), 0);
-
     let apply_info = ii.apply_gc(delta);
-
-    assert_eq!(ii.gc_marker(), 1);
 
     // POST-GC layout (sealed is a single `Arc<[IndexBlock]>` allocation — the refcount
     // header is already part of the 104-byte empty overhead):
@@ -594,11 +590,7 @@ fn ii_apply_gc_last_block_updated() {
         deltas: gc_result,
     };
 
-    assert_eq!(ii.gc_marker(), 0);
-
     let apply_info = ii.apply_gc(delta);
-
-    assert_eq!(ii.gc_marker(), 1);
 
     // POST-GC: block 0 deleted, block 1 (in_progress) survives unchanged (last-block
     // delta dropped because num_entries grew since the scan). The surviving block
@@ -965,11 +957,8 @@ fn ii_apply_gc_entries_tracking_index() {
         expected_delta
     );
 
-    assert_eq!(ii.gc_marker(), 0);
-
     let apply_info = ii.apply_gc(expected_delta);
 
-    assert_eq!(ii.gc_marker(), 1);
     assert_eq!(ii.number_of_entries(), 2);
     assert_eq!(ii.unique_docs(), 1);
     assert_eq!(repaired, vec![15, 15]);

--- a/src/redisearch_rs/inverted_index/src/tests/index.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/index.rs
@@ -32,7 +32,7 @@ use super::Dummy;
 fn memory_usage() {
     let mut ii = InvertedIndex::<Dummy>::new(IndexFlags_Index_DocIdsOnly);
     // Empty index: stack (88 = sealed Arc<[IndexBlock]> fat ptr 16 + pending ThinVec ptr 8
-    // + Option<IndexBlock> 48 + n_unique_docs 4 + flags 4 + gc_marker 4 + unique_id 4) plus
+    // + Option<IndexBlock> 48 + n_unique_docs 4 + flags 4 + unique_id 4 + alignment) plus
     // the empty `sealed` Arc allocation (16 Arc header, 0 blocks). pending and in_progress
     // have no heap allocation when empty. (88 + 16 = 104, unchanged from the ThinVec-backed
     // sealed: the +8 fat pointer offsets the -8 ThinVec header that moved into the Arc.)


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `InvertedIndex` carries a `gc_marker: AtomicU32` (with `gc_marker`/`gc_marker_inc` accessors and the `InvertedIndex_GcMarker[Inc]` FFI + header decls). It was the old reader-revalidation mechanism.
2. **Change:** Remove `gc_marker` entirely — the field, the accessors, the FFI functions, the C header declarations, and the test asserts that only observed the counter.
3. **Outcome:** Dead code removed. Reader revalidation now keys off `Arc::ptr_eq` of the snapshot's `sealed` region (introduced in the apply_gc mechanism PR), so nothing reads `gc_marker` anymore, and there are no remaining C callers.

#### Which additional issues this PR fixes
MOD-16724

#### Main objects this PR modified
1. `inverted_index/src/index/core.rs` — drop the field + accessors
2. `c_entrypoint/inverted_index_ffi/src/lib.rs`, `headers/inverted_index_ffi.h` — drop `InvertedIndex_GcMarker[Inc]`
3. `inverted_index/src/index/{with_mask,with_entries}.rs`, tests — drop delegations/asserts

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

_(Removes the internal `InvertedIndex_GcMarker` / `InvertedIndex_GcMarkerInc` FFI functions, which have no C callers.)_

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

**Stacked PR.** Base = `jk-ii-arc-slice`. Depends on the apply_gc mechanism PR's Arc-identity revalidation (that is what makes `gc_marker` removable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)