### PR TITLE
inverted_index: lock-free reads flag + snapshot COW benchmarks (experimental)

### DIFF
--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -231,12 +231,27 @@ jobs:
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8:
-    if: ${{ inputs.allowed_setup == 'oss-cluster-08-primaries-250gb-threads-8' }}
+    if: ${{ inputs.allowed_setup == 'oss-cluster-08-primaries-250gb-threads-8' && (inputs.benchmark_filter == '' || startsWith(inputs.benchmark_filter, 'search-msmarco')) }}
     needs: build-redisearch
     uses: ./.github/workflows/benchmark-flow.yml
     secrets: inherit
     with:
       benchmark_glob: "search-msmarco*.yml"
+      benchmark_filter: ${{ inputs.benchmark_filter }}
+      allowed_envs: oss-cluster
+      allowed_setups: oss-cluster-08-primaries-250gb-threads-8
+      binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
+
+  # Copy-on-write / lock-free-read stress benchmarks. Share the worker-provisioned
+  # 250gb-threads-8 setup with the msmarco job (both trigger on the same allowed_setup)
+  # but select a disjoint glob, so a benchmark_filter targets exactly one job.
+  benchmark-cow-oss-cluster-08-primaries-250gb-threads-8:
+    if: ${{ inputs.allowed_setup == 'oss-cluster-08-primaries-250gb-threads-8' && (inputs.benchmark_filter == '' || startsWith(inputs.benchmark_filter, 'search-cow')) }}
+    needs: build-redisearch
+    uses: ./.github/workflows/benchmark-flow.yml
+    secrets: inherit
+    with:
+      benchmark_glob: "search-cow*.yml"
       benchmark_filter: ${{ inputs.benchmark_filter }}
       allowed_envs: oss-cluster
       allowed_setups: oss-cluster-08-primaries-250gb-threads-8

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1325,9 +1325,10 @@ void AREQ_Execute_Callback(blockedClientReqCtx *BCRctx) {
   }
 
 #ifdef ENABLE_ASSERT
-  // Sync point (debug): pause after iterators are created and snapshot is established.
-  // For disk indexes, the lock is already released at this point.
-  // For RAM indexes, the lock is still held.
+  // Sync point (debug): pause after iterators are created and the snapshot is
+  // established. The lock is already released here for disk indexes and for RAM cursor
+  // queries under _LOCK_FREE_READS (see shouldReleaseSpecAfterSnapshot); otherwise it
+  // is still held.
   SyncPoint_Wait(SYNC_POINT_AFTER_ITERATOR_CREATE);
 #endif
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1248,6 +1248,27 @@ void AREQ_ReplyOrStoreError(AREQ *req, RedisModuleCtx *ctx, QueryError *status) 
   }
 }
 
+// True when the spec read lock can be dropped right after iterator creation, letting
+// the main thread write and GC run while the query iterates:
+//   - disk indexes always snapshot (diskSnapshot != NULL), so they always release; and
+//   - RAM indexes now snapshot their inverted-index blocks too, so under the
+//     experimental _LOCK_FREE_READS flag we release here as well, scoped to cursor
+//     queries — the well-tested cursor-resume path and where a long-held read lock
+//     actually blocks writers (scope only; not a safety requirement).
+// Releasing is safe even with a loader: the lock only guarded the index iteration,
+// which is now covered by the snapshot. The per-result dmd is borrowed (refcounted)
+// and owned by the SearchResult, so it and its sorting vector outlive the unlock; and a
+// loader reads the document from the keyspace under the GIL. The result processor
+// re-acquires the lock per read for the dmd doc-table lookup and releases it per result
+// — see rpQueryItNext / handleSpecLockAndRevalidate.
+static bool shouldReleaseSpecAfterSnapshot(const RedisSearchCtx *sctx, const AREQ *req) {
+  if (sctx->diskSnapshot) {
+    return true;
+  }
+  return RSGlobalConfig.requestConfigParams.lockFreeReads &&
+         (AREQ_RequestFlags(req) & QEXEC_F_IS_CURSOR);
+}
+
 void AREQ_Execute_Callback(blockedClientReqCtx *BCRctx) {
   AREQ *req = blockedClientReqCtx_getRequest(BCRctx);
 
@@ -1297,14 +1318,9 @@ void AREQ_Execute_Callback(blockedClientReqCtx *BCRctx) {
     goto error;
   }
 
-  // For disk indexes, release the spec lock immediately after iterator creation.
-  // This is fine, since the disk iterators use snapshots. This allows the main
-  // thread to write while the query iterates over disk data. `diskSnapshot` is
-  // guaranteed non-NULL here for disk-backed indexes — `prepareExecutionPlan`
-  // bails out if SearchDisk_CreateSnapshot fails — so this check distinguishes
-  // disk indexes (snapshot present, can unlock) from RAM-only ones (keep lock).
-  // NOTE: Revisit as more index types are supported.
-  if (sctx->diskSnapshot) {
+  // Drop the spec read lock now that the iterators (and their snapshots) exist, when
+  // the pipeline can iterate safely without it — see shouldReleaseSpecAfterSnapshot.
+  if (shouldReleaseSpecAfterSnapshot(sctx, req)) {
     RedisSearchCtx_UnlockSpec(sctx);
   }
 
@@ -1908,14 +1924,9 @@ static int buildPipelineAndExecute(AREQ *r, RedisModuleCtx *ctx, QueryError *sta
       return REDISMODULE_ERR;
     }
 
-    // For disk indexes, release the spec lock immediately after iterator creation.
-    // This is fine, since the disk iterators use snapshots. This allows the main
-    // thread to write while the query iterates over disk data. `diskSnapshot` is
-    // guaranteed non-NULL here for disk-backed indexes — `prepareExecutionPlan`
-    // bails out if SearchDisk_CreateSnapshot fails — so this check distinguishes
-    // disk indexes (snapshot present, can unlock) from RAM-only ones (keep lock).
-    // NOTE: Revisit as more index types are supported.
-    if (sctx->diskSnapshot) {
+    // Drop the spec read lock now that the iterators (and their snapshots) exist, when
+    // the pipeline can iterate safely without it — see shouldReleaseSpecAfterSnapshot.
+    if (shouldReleaseSpecAfterSnapshot(sctx, r)) {
       RedisSearchCtx_UnlockSpec(sctx);
     }
 

--- a/src/config.c
+++ b/src/config.c
@@ -60,6 +60,7 @@ configPair_t __configPairs[] = {
   {"_NUMERIC_COMPRESS",               "search-_numeric-compress"},
   {"_NUMERIC_RANGES_PARENTS",         "search-_numeric-ranges-parents"},
   {"_PRINT_PROFILE_CLOCK",            "search-_print-profile-clock"},
+  {"_LOCK_FREE_READS",                "search-_lock-free-reads"},
   {"_PRIORITIZE_INTERSECT_UNION_CHILDREN", "search-_prioritize-intersect-union-children"},
   {"_BG_INDEX_MEM_PCT_THR",           "search-_bg-index-mem-pct-thr"},
   {"BG_INDEX_SLEEP_GAP",              "search-bg-index-sleep-gap"},
@@ -1080,6 +1081,10 @@ CONFIG_BOOLEAN_GETTER(getFreeResourcesThread, freeResourcesThread, 0)
 CONFIG_BOOLEAN_SETTER(setPrintProfileClock, requestConfigParams.printProfileClock)
 CONFIG_BOOLEAN_GETTER(getPrintProfileClock, requestConfigParams.printProfileClock, 0)
 
+// _LOCK_FREE_READS
+CONFIG_BOOLEAN_SETTER(setLockFreeReads, requestConfigParams.lockFreeReads)
+CONFIG_BOOLEAN_GETTER(getLockFreeReads, requestConfigParams.lockFreeReads, 0)
+
 // RAW_DOCID_ENCODING
 CONFIG_BOOLEAN_SETTER(setRawDocIDEncoding, invertedIndexRawDocidEncoding)
 CONFIG_BOOLEAN_GETTER(getRawDocIDEncoding, invertedIndexRawDocidEncoding, 0)
@@ -1726,6 +1731,11 @@ RSConfigOptions RSGlobalConfigOptions = {
          .helpText = "Disable print of time for ft.profile. For testing only.",
          .setValue = setPrintProfileClock,
          .getValue = getPrintProfileClock},
+        {.name = "_LOCK_FREE_READS",
+         .helpText = "Experimental: release the spec read lock per result during query "
+                     "iteration (lock-free-read snapshot path). For benchmarking only.",
+         .setValue = setLockFreeReads,
+         .getValue = getLockFreeReads},
         {.name = "RAW_DOCID_ENCODING",
          .helpText = "Disable compression for DocID inverted index. Boost CPU performance.",
          .setValue = setRawDocIDEncoding,
@@ -2488,6 +2498,15 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
       REDISMODULE_CONFIG_UNPREFIXED,
       get_bool_config, set_bool_config, NULL,
       (void *)&(RSGlobalConfig.requestConfigParams.printProfileClock)
+    )
+  )
+
+  RM_TRY(
+    RedisModule_RegisterBoolConfig(
+      ctx, "search-_lock-free-reads", 0,
+      REDISMODULE_CONFIG_UNPREFIXED,
+      get_bool_config, set_bool_config, NULL,
+      (void *)&(RSGlobalConfig.requestConfigParams.lockFreeReads)
     )
   )
 

--- a/src/config.c
+++ b/src/config.c
@@ -61,6 +61,7 @@ configPair_t __configPairs[] = {
   {"_NUMERIC_RANGES_PARENTS",         "search-_numeric-ranges-parents"},
   {"_PRINT_PROFILE_CLOCK",            "search-_print-profile-clock"},
   {"_LOCK_FREE_READS",                "search-_lock-free-reads"},
+  {"_LOCK_FREE_READS_BATCH_SIZE",     "search-_lock-free-reads-batch-size"},
   {"_PRIORITIZE_INTERSECT_UNION_CHILDREN", "search-_prioritize-intersect-union-children"},
   {"_BG_INDEX_MEM_PCT_THR",           "search-_bg-index-mem-pct-thr"},
   {"BG_INDEX_SLEEP_GAP",              "search-bg-index-sleep-gap"},
@@ -1085,6 +1086,19 @@ CONFIG_BOOLEAN_GETTER(getPrintProfileClock, requestConfigParams.printProfileCloc
 CONFIG_BOOLEAN_SETTER(setLockFreeReads, requestConfigParams.lockFreeReads)
 CONFIG_BOOLEAN_GETTER(getLockFreeReads, requestConfigParams.lockFreeReads, 0)
 
+// _LOCK_FREE_READS_BATCH_SIZE
+CONFIG_SETTER(setLockFreeReadsBatchSize) {
+  unsigned int batchSize;
+  int acrc = AC_GetUnsigned(ac, &batchSize, AC_F_GE1);
+  CHECK_RETURN_PARSE_ERROR(acrc);
+  config->requestConfigParams.lockFreeReadsBatchSize = batchSize;
+  return REDISMODULE_OK;
+}
+CONFIG_GETTER(getLockFreeReadsBatchSize) {
+  sds ss = sdsempty();
+  return sdscatprintf(ss, "%u", config->requestConfigParams.lockFreeReadsBatchSize);
+}
+
 // RAW_DOCID_ENCODING
 CONFIG_BOOLEAN_SETTER(setRawDocIDEncoding, invertedIndexRawDocidEncoding)
 CONFIG_BOOLEAN_GETTER(getRawDocIDEncoding, invertedIndexRawDocidEncoding, 0)
@@ -1736,6 +1750,12 @@ RSConfigOptions RSGlobalConfigOptions = {
                      "iteration (lock-free-read snapshot path). For benchmarking only.",
          .setValue = setLockFreeReads,
          .getValue = getLockFreeReads},
+        {.name = "_LOCK_FREE_READS_BATCH_SIZE",
+         .helpText = "Experimental: results served per spec-read-lock acquisition under "
+                     "lock-free reads (amortizes the per-result lock + revalidate). "
+                     "For benchmarking only.",
+         .setValue = setLockFreeReadsBatchSize,
+         .getValue = getLockFreeReadsBatchSize},
         {.name = "RAW_DOCID_ENCODING",
          .helpText = "Disable compression for DocID inverted index. Boost CPU performance.",
          .setValue = setRawDocIDEncoding,
@@ -2507,6 +2527,15 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
       REDISMODULE_CONFIG_UNPREFIXED,
       get_bool_config, set_bool_config, NULL,
       (void *)&(RSGlobalConfig.requestConfigParams.lockFreeReads)
+    )
+  )
+
+  RM_TRY(
+    RedisModule_RegisterNumericConfig(
+      ctx, "search-_lock-free-reads-batch-size", 100,
+      REDISMODULE_CONFIG_UNPREFIXED, 1, UINT32_MAX,
+      get_uint_numeric_config, set_uint_numeric_config, NULL,
+      (void *)&(RSGlobalConfig.requestConfigParams.lockFreeReadsBatchSize)
     )
   )
 

--- a/src/config.h
+++ b/src/config.h
@@ -102,6 +102,10 @@ typedef struct {
   RSTimeoutPolicy timeoutPolicy;
   // reply with time on profile
   bool printProfileClock;
+  // Experimental: release the spec read lock per result during query iteration
+  // (lock-free-read snapshot path). Off by default; for benchmarking the COW
+  // snapshot work. See docs/design/snapshot-cow-benchmark-plan.md.
+  bool lockFreeReads;
   // BM25STD.TANH factor
   unsigned int BM25STD_TanhFactor;
   // OOM policy
@@ -416,6 +420,7 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
     .numericCompress = false,                                                  \
     .numericTreeMaxDepthRange = 0,                                             \
     .requestConfigParams.printProfileClock = 1,                                \
+    .requestConfigParams.lockFreeReads = false,                                \
     .invertedIndexRawDocidEncoding = false,                                    \
     .gcConfigParams.gcSettings.forkGCCleanNumericEmptyNodes = true,            \
     .freeResourcesThread = true,                                               \

--- a/src/config.h
+++ b/src/config.h
@@ -106,6 +106,10 @@ typedef struct {
   // (lock-free-read snapshot path). Off by default; for benchmarking the COW
   // snapshot work. See docs/design/snapshot-cow-benchmark-plan.md.
   bool lockFreeReads;
+  // Lock-free reads: number of results served under a single spec-read-lock acquisition
+  // before releasing (amortizes the per-result lock acquire/release and iterator
+  // Revalidate). Only consulted when lockFreeReads is on; 1 == release per result.
+  uint32_t lockFreeReadsBatchSize;
   // BM25STD.TANH factor
   unsigned int BM25STD_TanhFactor;
   // OOM policy
@@ -421,6 +425,7 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
     .numericTreeMaxDepthRange = 0,                                             \
     .requestConfigParams.printProfileClock = 1,                                \
     .requestConfigParams.lockFreeReads = false,                                \
+    .requestConfigParams.lockFreeReadsBatchSize = 100,                         \
     .invertedIndexRawDocidEncoding = false,                                    \
     .gcConfigParams.gcSettings.forkGCCleanNumericEmptyNodes = true,            \
     .freeResourcesThread = true,                                               \

--- a/src/redisearch_rs/inverted_index_bencher/Cargo.toml
+++ b/src/redisearch_rs/inverted_index_bencher/Cargo.toml
@@ -24,6 +24,21 @@ harness = false
 name = "add_record"
 harness = false
 
+[[bench]]
+name = "reader_iteration"
+harness = false
+
+[[bench]]
+name = "revalidation_churn"
+harness = false
+
+[[bench]]
+name = "snapshot_cow"
+harness = false
+
+[[example]]
+name = "snapshot_cow_memory"
+
 [dependencies]
 buffer.workspace = true
 criterion.workspace = true

--- a/src/redisearch_rs/inverted_index_bencher/benches/reader_iteration.rs
+++ b/src/redisearch_rs/inverted_index_bencher/benches/reader_iteration.rs
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Regression bench for the reader traversal hot path — full forward scan of an
+//! [`InvertedIndex`] via [`IndexReader::next_record`].
+//!
+//! Runs identically on `master` (flat `blocks: ThinVec` walk) and on the snapshot
+//! branch (where `reader()` captures a point-in-time snapshot — `Arc` clone of
+//! `sealed` + shallow clone of `pending` + deep copy of the `in_progress` tail —
+//! then walks it lock-free). Comparing the two branches with `--save-baseline` /
+//! `--baseline` isolates the per-reader snapshot-capture cost plus any traversal
+//! regression from the extra region indirection.
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use ffi::IndexFlags_Index_DocIdsOnly;
+use index_result::RSIndexResult;
+use inverted_index::{IndexReader, InvertedIndex, doc_ids_only::DocIdsOnly};
+
+const RECORD_COUNTS: [u64; 3] = [1_000, 10_000, 100_000];
+
+fn bench_reader_iteration(c: &mut Criterion) {
+    let mut group = c.benchmark_group("reader_iteration");
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_millis(800));
+
+    for n in RECORD_COUNTS {
+        // Build the index once — reading does not mutate it, so it is reused across
+        // measured iterations.
+        let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+        for doc_id in 0..n {
+            let record = RSIndexResult::build_term().doc_id(doc_id).build();
+            ii.add_record(&record).unwrap();
+        }
+
+        group.bench_function(BenchmarkId::new("DocIdsOnly", n), |b| {
+            b.iter(|| {
+                let mut reader = ii.reader();
+                let mut result = RSIndexResult::build_virt().build();
+                let mut count = 0u64;
+                while reader.next_record(&mut result).unwrap() {
+                    count += 1;
+                }
+                black_box(count);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_reader_iteration);
+criterion_main!(benches);

--- a/src/redisearch_rs/inverted_index_bencher/benches/revalidation_churn.rs
+++ b/src/redisearch_rs/inverted_index_bencher/benches/revalidation_churn.rs
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Micro-bench for the reader revalidation hot path — the cost the `_LOCK_FREE_READS`
+//! regression fix targets.
+//!
+//! Lock-free reads release the spec lock per result; on resume the reader asks
+//! [`IndexReader::needs_revalidation`] whether its snapshot is still current. Under a
+//! concurrent writer, the pre-fix check treated every append as invalidating, so each
+//! resumed read did a full `reset()` (re-snapshot from the start) plus a `seek_record`
+//! to reposition — turning a linear scan into roughly O(N · seek). The fix keys
+//! revalidation off the `sealed` `Arc`'s pointer identity, so appends no longer force a
+//! rewind and a resumed read is a plain forward step.
+//!
+//! The two functions bracket that difference on a single, static index (no real writer
+//! needed — we just drive the two revalidation outcomes directly):
+//!
+//! - `no_rewind` — the post-fix path: pay the (cheap) `needs_revalidation` check per
+//!   result, then step forward.
+//! - `rewind_each_result` — the pre-fix path under churn: `reset()` + `seek_record` on
+//!   every result.
+//!
+//! The gap between them is the per-result rewind + re-seek overhead the fix removes.
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use ffi::IndexFlags_Index_DocIdsOnly;
+use index_result::RSIndexResult;
+use inverted_index::{IndexReader, InvertedIndex, doc_ids_only::DocIdsOnly};
+use rqe_core::DocId;
+
+const RECORD_COUNTS: [DocId; 2] = [10_000, 100_000];
+
+/// Build an index with contiguous doc IDs `1..=n`, so `seek_record(k)` lands exactly on
+/// the k-th record — letting the rewind path resume with a simple counter.
+fn build_index(n: DocId) -> InvertedIndex<DocIdsOnly> {
+    let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+    for doc_id in 1..=n {
+        let record = RSIndexResult::build_term().doc_id(doc_id).build();
+        ii.add_record(&record).unwrap();
+    }
+    ii
+}
+
+fn bench_revalidation_churn(c: &mut Criterion) {
+    let mut group = c.benchmark_group("revalidation_churn");
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_millis(1500));
+
+    for n in RECORD_COUNTS {
+        // Reading never mutates the index, so build it once and reuse it.
+        let ii = build_index(n);
+
+        // Post-fix: `needs_revalidation` is false under appends, so the resumed read is a
+        // plain forward step. We still call it every result to include its cost.
+        group.bench_function(BenchmarkId::new("no_rewind", n), |b| {
+            b.iter(|| {
+                let mut reader = ii.reader();
+                let mut result = RSIndexResult::build_virt().build();
+                let mut count = 0u64;
+                loop {
+                    black_box(reader.needs_revalidation());
+                    if !reader.next_record(&mut result).unwrap() {
+                        break;
+                    }
+                    count += 1;
+                }
+                black_box(count);
+            });
+        });
+
+        // Pre-fix under churn: revalidation fired on every result, forcing a re-snapshot
+        // from the start plus a `seek_record` to reposition at the next doc.
+        group.bench_function(BenchmarkId::new("rewind_each_result", n), |b| {
+            b.iter(|| {
+                let mut reader = ii.reader();
+                let mut result = RSIndexResult::build_virt().build();
+                let mut count: DocId = 0;
+                loop {
+                    reader.reset();
+                    if !reader.seek_record(count + 1, &mut result).unwrap() {
+                        break;
+                    }
+                    count += 1;
+                }
+                black_box(count);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_revalidation_churn);
+criterion_main!(benches);

--- a/src/redisearch_rs/inverted_index_bencher/benches/snapshot_cow.rs
+++ b/src/redisearch_rs/inverted_index_bencher/benches/snapshot_cow.rs
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Timing benches for the copy-on-write snapshot mechanism (feature-branch only —
+//! master has no snapshot API to compare against; master's snapshot cost is zero
+//! because it holds the read lock instead of copying).
+//!
+//! Two components, per `docs/design/snapshot-cow-benchmark-plan.md`:
+//!
+//! - **C1 — per-snapshot reader copy.** [`InvertedIndex::snapshot`] = `Arc::clone`
+//!   of `sealed` + shallow `Vec` clone of `pending` + deep copy of the `in_progress`
+//!   tail block. Paid by every reader at construction/revalidation.
+//! - **C2 — GC copy-of-pinned-blocks.** When `apply_gc` rebuilds `sealed` while
+//!   snapshots are live, each block a snapshot pins (refcount > 1) is deep-cloned
+//!   via `Arc::try_unwrap(..).unwrap_or_else(clone)` instead of moved. We vary the
+//!   number of held snapshots {0, 1, 8}; the delta over the 0-held baseline is the
+//!   COW cost. Byte-level cost is reported by the `snapshot_cow_memory` example.
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use ffi::IndexFlags_Index_DocIdsOnly;
+use index_result::RSIndexResult;
+use inverted_index::{InvertedIndex, numeric::Numeric};
+
+const RECORD_COUNTS: [u64; 2] = [10_000, 100_000];
+const PINNED_SNAPSHOTS: [usize; 3] = [0, 1, 8];
+
+/// Delete the oldest 30% of documents — produces GC work spread across early blocks.
+fn doc_exist(doc_id: u64, total: u64) -> bool {
+    doc_id >= (total * 30 / 100)
+}
+
+fn build_index(n: u64) -> InvertedIndex<Numeric> {
+    let mut ii = InvertedIndex::<Numeric>::new(IndexFlags_Index_DocIdsOnly);
+    for doc_id in 0..n {
+        ii.add_record(
+            &RSIndexResult::build_numeric(doc_id as f64 / 10.0)
+                .doc_id(doc_id)
+                .build(),
+        )
+        .unwrap();
+    }
+    ii
+}
+
+/// C1: cost of capturing a snapshot over an index of `n` records.
+fn bench_snapshot_capture(c: &mut Criterion) {
+    let mut group = c.benchmark_group("snapshot_capture");
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_millis(800));
+
+    for n in RECORD_COUNTS {
+        let ii = build_index(n);
+        group.bench_function(BenchmarkId::from_parameter(n), |b| {
+            b.iter(|| {
+                // Arc clone of sealed + Vec clone of pending + deep copy of in_progress.
+                black_box(ii.snapshot());
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// C2: cost of `apply_gc` while `k` snapshots pin the index's blocks. `k = 0` is the
+/// baseline (blocks moved); `k > 0` forces the `Arc::try_unwrap -> clone` COW path.
+fn bench_gc_apply_with_pinned(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gc_apply_pinned");
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_millis(800));
+
+    for n in RECORD_COUNTS {
+        for k in PINNED_SNAPSHOTS {
+            group.bench_function(BenchmarkId::new(format!("records_{n}"), k), |b| {
+                b.iter_batched(
+                    || {
+                        let ii = build_index(n);
+                        let delta = ii
+                            .scan_gc(
+                                |d| doc_exist(d, n),
+                                None::<fn(&RSIndexResult, &inverted_index::RepairContext<'_>)>,
+                            )
+                            .unwrap()
+                            .unwrap();
+                        // Hold `k` snapshots so their pinned blocks cannot be moved
+                        // (refcount > 1) and must be deep-cloned by apply_gc.
+                        let snaps: Vec<_> = (0..k).map(|_| ii.snapshot()).collect();
+                        (ii, delta, snaps)
+                    },
+                    |(mut ii, delta, snaps)| {
+                        let info = ii.apply_gc(delta);
+                        // Keep the snapshots alive across apply_gc.
+                        black_box(&snaps);
+                        black_box(info);
+                    },
+                    BatchSize::SmallInput,
+                );
+            });
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_snapshot_capture, bench_gc_apply_with_pinned);
+criterion_main!(benches);

--- a/src/redisearch_rs/inverted_index_bencher/examples/snapshot_cow_memory.rs
+++ b/src/redisearch_rs/inverted_index_bencher/examples/snapshot_cow_memory.rs
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Byte-level memory report for the copy-on-write snapshot mechanism (feature branch).
+//!
+//! Answers the "memory cost of static copy-on-write" question directly, in bytes,
+//! via a counting global allocator plus the index's own `GcApplyInfo` accounting.
+//! See `docs/design/snapshot-cow-benchmark-plan.md`:
+//!
+//! - **C1 — per-snapshot reader copy:** heap bytes allocated by one `snapshot()`
+//!   (deep copy of the `in_progress` tail buffer + shallow `pending` Vec clone;
+//!   `sealed` is a refcount bump = 0 bytes).
+//! - **C2 — GC copy-of-pinned-blocks:** extra bytes `apply_gc` allocates when `k`
+//!   snapshots pin the blocks (deep-cloned) vs the `k = 0` baseline (blocks moved).
+//! - **C3 — retention amplification:** heap outstanding while the snapshots are held
+//!   across the GC cycle vs after they are dropped (old blocks that cannot be freed).
+//!
+//! Run: `cargo run --release --example snapshot_cow_memory -p inverted_index_bencher`
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use ffi::IndexFlags_Index_DocIdsOnly;
+use index_result::RSIndexResult;
+use inverted_index::{InvertedIndex, numeric::Numeric};
+
+// -- Counting global allocator -------------------------------------------------
+
+static ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+static FREED: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+// SAFETY: forwards every call to the system allocator unchanged, only adding
+// relaxed counter updates; the returned pointers and layouts are exactly those
+// System produces, so all GlobalAlloc invariants are preserved.
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATED.fetch_add(layout.size(), Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        FREED.fetch_add(layout.size(), Ordering::Relaxed);
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        ALLOCATED.fetch_add(layout.size(), Ordering::Relaxed);
+        unsafe { System.alloc_zeroed(layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if new_size >= layout.size() {
+            ALLOCATED.fetch_add(new_size - layout.size(), Ordering::Relaxed);
+        } else {
+            FREED.fetch_add(layout.size() - new_size, Ordering::Relaxed);
+        }
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+/// Net heap bytes currently outstanding (allocated minus freed).
+fn outstanding() -> isize {
+    ALLOCATED.load(Ordering::Relaxed) as isize - FREED.load(Ordering::Relaxed) as isize
+}
+
+/// Cumulative heap bytes allocated so far.
+fn allocated() -> usize {
+    ALLOCATED.load(Ordering::Relaxed)
+}
+
+// -- Fixtures ------------------------------------------------------------------
+
+const RECORD_COUNTS: [u64; 2] = [10_000, 100_000];
+const PINNED: usize = 8;
+
+fn doc_exist(doc_id: u64, total: u64) -> bool {
+    doc_id >= (total * 30 / 100)
+}
+
+fn build_index(n: u64) -> InvertedIndex<Numeric> {
+    let mut ii = InvertedIndex::<Numeric>::new(IndexFlags_Index_DocIdsOnly);
+    for doc_id in 0..n {
+        ii.add_record(
+            &RSIndexResult::build_numeric(doc_id as f64 / 10.0)
+                .doc_id(doc_id)
+                .build(),
+        )
+        .unwrap();
+    }
+    ii
+}
+
+fn scan(ii: &InvertedIndex<Numeric>, n: u64) -> inverted_index::GcScanDelta {
+    ii.scan_gc(
+        |d| doc_exist(d, n),
+        None::<fn(&RSIndexResult, &inverted_index::RepairContext<'_>)>,
+    )
+    .unwrap()
+    .unwrap()
+}
+
+// -- Report --------------------------------------------------------------------
+
+fn main() {
+    println!(
+        "{:>9} | {:>14} | {:>14} | {:>16} | {:>16} | {:>14}",
+        "records", "index_bytes", "C1_snapshot", "C2_gc_move(k=0)", "C2_gc_cow(k=8)", "C3_retained"
+    );
+    println!("{}", "-".repeat(100));
+
+    for n in RECORD_COUNTS {
+        let ii = build_index(n);
+        let index_bytes = ii.memory_usage();
+
+        // C1: heap bytes one snapshot allocates (in_progress deep copy + pending Vec).
+        let before = outstanding();
+        let snap = ii.snapshot();
+        let c1 = outstanding() - before;
+        drop(snap);
+
+        // C2 baseline: apply_gc with no live snapshots — surviving blocks are moved,
+        // not cloned. Measured as heap allocated during apply_gc (allocator ground
+        // truth — the index's own `GcApplyInfo.bytes_allocated` does not count the
+        // COW block clones, so it reads 0 here and understates C2).
+        let mut ii0 = build_index(n);
+        let d0 = scan(&ii0, n);
+        let a0 = allocated();
+        ii0.apply_gc(d0);
+        let gc_move = allocated() - a0;
+
+        // C2 COW: apply_gc while PINNED snapshots pin the blocks — forces deep clone.
+        let mut iik = build_index(n);
+        let dk = scan(&iik, n);
+        let before_gc = outstanding();
+        let snaps: Vec<_> = (0..PINNED).map(|_| iik.snapshot()).collect();
+        let ak = allocated();
+        iik.apply_gc(dk);
+        let gc_cow = allocated() - ak;
+        // C3: heap still outstanding while the snapshots pin the superseded blocks.
+        let retained_held = outstanding() - before_gc;
+        drop(snaps);
+        // After dropping the snapshots, the superseded blocks are freed; the delta
+        // between held and dropped is the retention amplification.
+        let retained_dropped = outstanding() - before_gc;
+        let c3 = retained_held - retained_dropped;
+
+        println!(
+            "{:>9} | {:>14} | {:>14} | {:>16} | {:>16} | {:>14}",
+            n, index_bytes, c1, gc_move, gc_cow, c3
+        );
+    }
+
+    println!(
+        "\nC1 = per-reader snapshot copy · C2 = GC block-clone cost (k=8 pins vs k=0) \
+         · C3 = bytes pinned alive by 8 held snapshots across a GC cycle"
+    );
+}

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -66,6 +66,13 @@ typedef struct {
   uint32_t keySpaceVersion;                     // version of the Keyspace slot ranges used for filtering
   const RedisModuleSlotRangeArray *querySlots;  // Query slots info, may be used for filtering
 
+  // Lock-free reads batching: hold the spec read lock across a batch of results instead
+  // of re-acquiring it per result, amortizing the lock acquire/release and the per-result
+  // iterator Revalidate. Released every `lockFreeReadsBatchSize` results, and
+  // force-released at the cursor chunk boundary (runCursor) and on EOF/timeout.
+  bool heldBatchLock;       // we currently hold the spec read lock for the active batch
+  uint32_t readsSinceLock;  // results produced since this batch acquired the lock
+
   // Async disk I/O state (only used when async disk I/O is enabled)
   IndexResultAsyncReadState async;
 #ifdef ENABLE_ASSERT
@@ -237,9 +244,8 @@ static inline void SearchResult_BufferIndexResult(ResultProcessor *rp, SearchRes
  *    consistency for disk reads without needing to hold the lock.
  * 3. This avoids blocking the main thread during disk IO operations.
  */
-static bool handleSpecLockAndRevalidate(RPQueryIterator *self, bool *acquiredLock) {
+static bool handleSpecLockAndRevalidate(RPQueryIterator *self) {
   RedisSearchCtx *sctx = self->sctx;
-  if (acquiredLock) *acquiredLock = false;
 
   // For disk indexes, return immediately, since we don't need to acquire the
   // lock, nor to revalidate the iterators.
@@ -249,12 +255,19 @@ static bool handleSpecLockAndRevalidate(RPQueryIterator *self, bool *acquiredLoc
 
   QueryIterator *it = self->iterator;
 
+  // Lock already held: either a non-lock-free query holding it for the whole run, or a
+  // lock-free batch we acquired on a previous result. Either way, don't re-acquire or
+  // re-revalidate — while the read lock is held GC cannot run, so the snapshot the
+  // iterators captured stays valid across the batch.
   if (sctx->flags != RS_CTX_UNSET) {
     return false;
   }
 
   RedisSearchCtx_LockSpecRead(sctx);
-  if (acquiredLock) *acquiredLock = true;
+  // Start of a (possibly single-result) lock-free batch: we now hold the read lock and
+  // will release it after `lockFreeReadsBatchSize` results (see rpQueryItNext).
+  self->heldBatchLock = true;
+  self->readsSinceLock = 0;
 
   ValidateStatus rc = it->Revalidate(it, sctx->spec);
 
@@ -276,8 +289,7 @@ static int rpQueryItNext(ResultProcessor *base, SearchResult *res) {
   IndexSpec* spec = sctx->spec;
   const RSDocumentMetadata *dmd;
   // Handle spec lock and revalidation
-  bool acquiredLock = false;
-  bool needToValidateCurrent = handleSpecLockAndRevalidate(self, &acquiredLock);
+  bool needToValidateCurrent = handleSpecLockAndRevalidate(self);
 
   // Always update it after revalidation as iterator may have been replaced
   it = self->iterator;
@@ -326,14 +338,21 @@ static int rpQueryItNext(ResultProcessor *base, SearchResult *res) {
     }
 
     setSearchResult(base, res, it->current, dmd);
-    // Lock-free-read path (experimental, off by default): if this call acquired the
-    // spec read lock, release it now that Read + dmd retrieval are done, so writers
-    // and GC can interleave before the next round. Only release what we acquired —
-    // the disk path never locks, and an already-held outer lock is not ours to drop.
-    // The reader keeps its own immutable snapshot, so its iterator state survives the
-    // release window; the buffered SearchResult already outlives it->current today.
-    if (acquiredLock && RSGlobalConfig.requestConfigParams.lockFreeReads) {
-      RedisSearchCtx_UnlockSpec(sctx);
+    // Lock-free-read path (experimental, off by default): we hold the spec read lock for
+    // a batch of results (acquired by handleSpecLockAndRevalidate at the batch start).
+    // Release it every `lockFreeReadsBatchSize` results so writers and GC can interleave,
+    // then the next result re-acquires + revalidates once for the new batch. Batching
+    // amortizes both the lock acquire/release and the per-result iterator Revalidate.
+    // Correctness: while the lock is held GC cannot run, so the iterators' snapshot stays
+    // valid mid-batch; the reader keeps its own immutable snapshot and the buffered
+    // SearchResult outlives it->current. A partial batch is force-released at the cursor
+    // chunk boundary (runCursor) and on EOF/timeout (UnlockSpec_and_ReturnRPResult).
+    if (self->heldBatchLock && RSGlobalConfig.requestConfigParams.lockFreeReads) {
+      if (++self->readsSinceLock >= RSGlobalConfig.requestConfigParams.lockFreeReadsBatchSize) {
+        RedisSearchCtx_UnlockSpec(sctx);
+        self->heldBatchLock = false;
+        self->readsSinceLock = 0;
+      }
     }
     return RS_RESULT_OK;
   }
@@ -348,7 +367,7 @@ static int rpQueryItNext_AsyncDisk(ResultProcessor *base, SearchResult *res) {
   // Handle spec lock and revalidation
   // no need store the return value since validate current result is not needed for async disk path
   // (disk path never acquires the spec lock, so no acquisition to track)
-  handleSpecLockAndRevalidate(self, NULL);
+  handleSpecLockAndRevalidate(self);
 
   // Always update it after revalidation as iterator may have been replaced
   it = self->iterator;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -237,8 +237,9 @@ static inline void SearchResult_BufferIndexResult(ResultProcessor *rp, SearchRes
  *    consistency for disk reads without needing to hold the lock.
  * 3. This avoids blocking the main thread during disk IO operations.
  */
-static bool handleSpecLockAndRevalidate(RPQueryIterator *self) {
+static bool handleSpecLockAndRevalidate(RPQueryIterator *self, bool *acquiredLock) {
   RedisSearchCtx *sctx = self->sctx;
+  if (acquiredLock) *acquiredLock = false;
 
   // For disk indexes, return immediately, since we don't need to acquire the
   // lock, nor to revalidate the iterators.
@@ -253,6 +254,7 @@ static bool handleSpecLockAndRevalidate(RPQueryIterator *self) {
   }
 
   RedisSearchCtx_LockSpecRead(sctx);
+  if (acquiredLock) *acquiredLock = true;
 
   ValidateStatus rc = it->Revalidate(it, sctx->spec);
 
@@ -274,7 +276,8 @@ static int rpQueryItNext(ResultProcessor *base, SearchResult *res) {
   IndexSpec* spec = sctx->spec;
   const RSDocumentMetadata *dmd;
   // Handle spec lock and revalidation
-  bool needToValidateCurrent = handleSpecLockAndRevalidate(self);
+  bool acquiredLock = false;
+  bool needToValidateCurrent = handleSpecLockAndRevalidate(self, &acquiredLock);
 
   // Always update it after revalidation as iterator may have been replaced
   it = self->iterator;
@@ -323,6 +326,15 @@ static int rpQueryItNext(ResultProcessor *base, SearchResult *res) {
     }
 
     setSearchResult(base, res, it->current, dmd);
+    // Lock-free-read path (experimental, off by default): if this call acquired the
+    // spec read lock, release it now that Read + dmd retrieval are done, so writers
+    // and GC can interleave before the next round. Only release what we acquired —
+    // the disk path never locks, and an already-held outer lock is not ours to drop.
+    // The reader keeps its own immutable snapshot, so its iterator state survives the
+    // release window; the buffered SearchResult already outlives it->current today.
+    if (acquiredLock && RSGlobalConfig.requestConfigParams.lockFreeReads) {
+      RedisSearchCtx_UnlockSpec(sctx);
+    }
     return RS_RESULT_OK;
   }
 }
@@ -335,7 +347,8 @@ static int rpQueryItNext_AsyncDisk(ResultProcessor *base, SearchResult *res) {
 
   // Handle spec lock and revalidation
   // no need store the return value since validate current result is not needed for async disk path
-  handleSpecLockAndRevalidate(self);
+  // (disk path never acquires the spec lock, so no acquisition to track)
+  handleSpecLockAndRevalidate(self, NULL);
 
   // Always update it after revalidation as iterator may have been replaced
   it = self->iterator;

--- a/tests/benchmarks/search-cow-mixed-5200K-union-lockfree-b500.yml
+++ b/tests/benchmarks/search-cow-mixed-5200K-union-lockfree-b500.yml
@@ -1,0 +1,62 @@
+version: 0.5
+name: "search-cow-mixed-5200K-union-lockfree-b500"
+description: |
+  As search-cow-mixed-5200K-union-lockfree (_LOCK_FREE_READS on), but with the spec
+  read lock released once per 500 results instead of the default 100
+  (_LOCK_FREE_READS_BATCH_SIZE 500). Sweep point to see whether a larger batch pushes
+  throughput past the flag-off / master baseline or starts starving the concurrent
+  writers (write latency up). Compare against the batch=100 (default) lockfree run and
+  the flag-off / master baselines.
+
+  See search-cow-mixed-5200K-union.yml for the full design rationale (real-key HSET
+  churn coupled to a bounded marker-term aggregate read, WORKERS>0 for lock
+  contention).
+
+metadata:
+  component: "search"
+  dataset: "5200K-docs-union-iterators"
+  doc_count: 5204050
+  query_type: "mixed"
+  # Keep free of parentheses and other punctuation beyond space, '/', '+', '-' — see
+  # the note in search-cow-mixed-5200K-union-lockfree.yml (RedisTimeSeries label parse).
+  use_case: "Concurrent read/write with lock-free reads batch 500 + snapshot COW"
+
+timeout_seconds: 3600
+
+setups:
+  - oss-cluster-08-primaries-250gb-threads-8
+
+dbconfig:
+  - dataset_name: "5200K-docs-union-iterators.idx10-cow-mixed-lockfree-b500"
+  # As the lockfree variant, plus _LOCK_FREE_READS_BATCH_SIZE 500 so the read lock is
+  # released every 500 results. Applied at module load on every primary.
+  - module-configuration-parameters:
+      redisearch:
+        WORKERS: 8
+        MIN_OPERATION_WORKERS: 8
+        FORK_GC_RUN_INTERVAL: 1
+        FORK_GC_CLEAN_THRESHOLD: 1
+        _LOCK_FREE_READS: "true"
+        _LOCK_FREE_READS_BATCH_SIZE: 500
+      module-oss:
+        WORKERS: 8
+        MIN_OPERATION_WORKERS: 8
+        FORK_GC_RUN_INTERVAL: 1
+        FORK_GC_CLEAN_THRESHOLD: 1
+        _LOCK_FREE_READS: "true"
+        _LOCK_FREE_READS_BATCH_SIZE: 500
+  - init_commands:
+    - '"FT.CREATE" "idx10" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
+  - dataset_load_timeout_secs: 600
+  - check:
+      keyspacelen: 5204050
+
+clientconfig:
+  benchmark_type: "mixed"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 8 -t 4 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'HSET __key__ field2 zzqbench' --command-ratio 1 --command 'FT.AGGREGATE idx10 @field2:zzqbench GROUPBY 0 REDUCE COUNT 0 AS n' --command-ratio 1"

--- a/tests/benchmarks/search-cow-mixed-5200K-union-lockfree.yml
+++ b/tests/benchmarks/search-cow-mixed-5200K-union-lockfree.yml
@@ -1,0 +1,69 @@
+version: 0.5
+name: "search-cow-mixed-5200K-union-lockfree"
+description: |
+  Feature-branch variant of search-cow-mixed-5200K-union with _LOCK_FREE_READS
+  ENABLED (search-_lock-free-reads true): query iteration releases the spec read lock
+  per result (reading from the owned snapshot) instead of holding it for the whole
+  scan. Because the reads are aggregate scans that hold the shard-side snapshot for
+  their full duration, releasing the lock is what lets the concurrent HSET writers
+  make progress instead of blocking on the reader — so this variant exposes the
+  concurrency win. Compare against:
+    - master (search-cow-mixed-5200K-union on a master build) → lock held for the
+      whole scan → writers blocked. Baseline.
+    - feature flag-off (search-cow-mixed-5200K-union on this build) → snapshot capture
+      (C1) + COW cost (C2/C3) but WITHOUT the lock-free benefit (worst case).
+
+  See search-cow-mixed-5200K-union.yml for the full design rationale (real-key HSET
+  churn coupled to a bounded marker-term aggregate read, WORKERS>0 for lock
+  contention).
+
+metadata:
+  component: "search"
+  dataset: "5200K-docs-union-iterators"
+  doc_count: 5204050
+  query_type: "mixed"
+  # NOTE: keep this free of parentheses and other punctuation beyond space, '/', '+',
+  # '-'. redisbench-admin turns `use_case` into a RedisTimeSeries label value, and
+  # RedisTimeSeries rejected the parenthesised form with "TSDB: Couldn't parse LABELS",
+  # failing the whole run at result-upload time (the benchmark itself had succeeded).
+  use_case: "Concurrent read/write with lock-free reads enabled + snapshot COW"
+
+timeout_seconds: 3600
+
+setups:
+  - oss-cluster-08-primaries-250gb-threads-8
+
+dbconfig:
+  - dataset_name: "5200K-docs-union-iterators.idx10-cow-mixed-lockfree"
+  # As search-cow-mixed-5200K-union, plus _LOCK_FREE_READS true so query iteration
+  # releases the spec read lock per result. Applied at module load on every primary
+  # (a runtime CONFIG SET is node-local in a cluster and would leave 7/8 primaries
+  # lock-based, defeating the comparison).
+  - module-configuration-parameters:
+      redisearch:
+        WORKERS: 8
+        MIN_OPERATION_WORKERS: 8
+        FORK_GC_RUN_INTERVAL: 1
+        FORK_GC_CLEAN_THRESHOLD: 1
+        _LOCK_FREE_READS: "true"
+      module-oss:
+        WORKERS: 8
+        MIN_OPERATION_WORKERS: 8
+        FORK_GC_RUN_INTERVAL: 1
+        FORK_GC_CLEAN_THRESHOLD: 1
+        _LOCK_FREE_READS: "true"
+  - init_commands:
+    - '"FT.CREATE" "idx10" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
+  - dataset_load_timeout_secs: 600
+  - check:
+      keyspacelen: 5204050
+
+clientconfig:
+  benchmark_type: "mixed"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 8 -t 4 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'HSET __key__ field2 zzqbench' --command-ratio 1 --command 'FT.AGGREGATE idx10 @field2:zzqbench GROUPBY 0 REDUCE COUNT 0 AS n' --command-ratio 1"

--- a/tests/benchmarks/search-cow-mixed-5200K-union.yml
+++ b/tests/benchmarks/search-cow-mixed-5200K-union.yml
@@ -1,0 +1,76 @@
+version: 0.5
+name: "search-cow-mixed-5200K-union"
+description: |
+  Copy-on-write / lock-free-read STRESS benchmark: concurrent read+write on the
+  inverted-index snapshot path. Compares master (spec read lock held for the whole
+  query) against the snapshot branch (lock released per result); this file is the
+  flag-OFF variant, search-cow-mixed-5200K-union-lockfree.yml enables it.
+
+  Why this dataset: 5200K-docs-union-iterators keys documents as idx10:<N> (numeric),
+  so memtier's __key__ (idx10:1..100000) reproduces REAL loaded keys. Every write is
+  therefore an UPDATE of a pre-existing document, which reindexes it (DocTable_PopR
+  deletes the old doc-id, a new one is assigned — no unchanged-skip, see
+  src/indexer.c makeDocumentId) and turns the old posting entry into GC garbage from
+  the very first write. That avoids the "must first insert N docs before any churn"
+  fragility you get when writes create brand-new keys (as they would on MS MARCO,
+  whose keys are string doc-ids memtier cannot reproduce).
+
+  Coupling reads to writes: writes set field2 to a synthetic marker ("zzqbench") on a
+  bounded 100k-key hot set; reads COUNT that marker. Using a term present in no loaded
+  document bounds each scan to the hot set (so a common word's millions of matches
+  can't swamp the writers) while guaranteeing the reader scans exactly the posting
+  list the writers are churning — the only arrangement that exercises COW. In an OSS
+  cluster the coordinator drives each shard with FT.AGGREGATE ... WITHCURSOR (see
+  src/coord/dist_aggregate.c), so the shard-side iterator holds its snapshot for the
+  scan; a low fork-GC interval + clean threshold reclaim the superseded blocks while a
+  reader holds them (deep-copied on the snapshot branch → the C2/C3 cost).
+
+  WORKERS>0 is essential: with WORKERS=0 Redis is single-threaded and there is no
+  read/write lock contention for _LOCK_FREE_READS to relieve. The -250gb-threads-8
+  setup provisions 8 workers per primary + the cpus to run them; we also set WORKERS
+  explicitly so the run does not depend on setup defaults.
+
+metadata:
+  component: "search"
+  dataset: "5200K-docs-union-iterators"
+  doc_count: 5204050
+  query_type: "mixed"
+  use_case: "Concurrent read/write lock contention + snapshot COW cost"
+
+timeout_seconds: 3600
+
+setups:
+  - oss-cluster-08-primaries-250gb-threads-8
+
+dbconfig:
+  - dataset_name: "5200K-docs-union-iterators.idx10-cow-mixed"
+  # Applied at module load on EVERY cluster primary. WORKERS>0 enables worker-thread
+  # query execution (the read lock is taken there); the low fork-GC interval + clean
+  # threshold keep GC reclaiming superseded blocks during the run. A runtime CONFIG
+  # SET would only reach the single node it hits in a cluster, so it must go here.
+  - module-configuration-parameters:
+      redisearch:
+        WORKERS: 8
+        MIN_OPERATION_WORKERS: 8
+        FORK_GC_RUN_INTERVAL: 1
+        FORK_GC_CLEAN_THRESHOLD: 1
+      module-oss:
+        WORKERS: 8
+        MIN_OPERATION_WORKERS: 8
+        FORK_GC_RUN_INTERVAL: 1
+        FORK_GC_CLEAN_THRESHOLD: 1
+  - init_commands:
+    - '"FT.CREATE" "idx10" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
+  - dataset_load_timeout_secs: 600
+  - check:
+      keyspacelen: 5204050
+
+clientconfig:
+  benchmark_type: "mixed"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 8 -t 4 --hide-histogram --key-prefix 'idx10:' --key-minimum 1 --key-maximum 100000 --command 'HSET __key__ field2 zzqbench' --command-ratio 1 --command 'FT.AGGREGATE idx10 @field2:zzqbench GROUPBY 0 REDUCE COUNT 0 AS n' --command-ratio 1"

--- a/tests/pytests/test_lock_free_reads.py
+++ b/tests/pytests/test_lock_free_reads.py
@@ -27,7 +27,7 @@ def _run_query_store_result(conn, cmd, result_list):
 
 def test_lock_free_reads_writer_progresses_while_cursor_held():
     # WORKERS 1 so the aggregate runs on a worker thread, leaving the main thread free to
-    # service SYNC_POINT / FT.ALTER while the query is parked.
+    # service SYNC_POINT / the concurrent write while the query is parked.
     env = Env(moduleArgs='WORKERS 1 _LOCK_FREE_READS true DEFAULT_DIALECT 2')
     skipIfNoEnableAssert(env)
 
@@ -36,6 +36,9 @@ def test_lock_free_reads_writer_progresses_while_cursor_held():
     num_docs = 200
     for i in range(num_docs):
         conn.execute_command('HSET', f'doc:{i}', 'body', 'term')
+    # HSET indexing is synchronous (Document_AddToIndexes runs inline in the keyspace
+    # notification), so all num_docs are indexed once this loop returns and the cursor's
+    # snapshot below captures exactly them.
 
     sp = 'AfterIteratorCreate'
     # Control connection: drives the sync point and issues the concurrent writer. Kept
@@ -61,11 +64,16 @@ def test_lock_free_reads_writer_progresses_while_cursor_held():
             lambda: (ctl.execute_command(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sp) == 1, {}),
             'Timeout waiting for the cursor query to reach AfterIteratorCreate')
 
-        # The query is holding a cursor mid-execution. FT.ALTER needs the spec WRITE lock;
-        # with _LOCK_FREE_READS the read lock is already released, so this returns
-        # immediately. If the lock were still held this would block the (single) main
-        # thread and the test would deadlock — a regression here fails as a timeout.
-        env.assertEqual(conn.execute_command('FT.ALTER', 'idx', 'SCHEMA', 'ADD', 'body2', 'TEXT'), 'OK')
+        # The query is holding a cursor mid-execution. Add a NEW matching doc: indexing
+        # runs inline in the keyspace notification and needs the spec WRITE lock. With
+        # _LOCK_FREE_READS the read lock is already released, so the HSET completes
+        # immediately; if the lock were still held the (single) main thread would block
+        # and the test would deadlock — a regression here surfaces as a timeout.
+        # (We use an append rather than FT.ALTER: an append only extends the live index
+        # beyond the snapshot, so the reader's point-in-time view is unaffected and the
+        # count stays deterministic. FT.ALTER concurrently mutates the index the reader is
+        # scanning, which makes the counted total racy — see git history.)
+        env.assertEqual(conn.execute_command('HSET', f'doc:{num_docs}', 'body', 'term'), 1)
 
         # ...and the reader is still parked: the writer made progress *while* the cursor
         # was held, which is only possible because the read lock was released.
@@ -76,8 +84,11 @@ def test_lock_free_reads_writer_progresses_while_cursor_held():
         t.join(timeout=30)
         env.assertFalse(t.is_alive(), message='cursor query did not finish after SIGNAL')
 
-        # The query must have completed successfully (snapshot stayed valid across the
-        # release + the concurrent schema change), counting every matching doc.
+        # The cursor's snapshot is point-in-time (taken before the HSET), so the newly
+        # added matching doc must NOT be counted — appends are absorbed by the COW
+        # snapshot (append-immunity). The count is therefore exactly the original set,
+        # deterministically. A count of num_docs+1 would mean the reader re-snapshotted
+        # and saw the concurrent append; anything less means it dropped snapshot results.
         env.assertEqual(len(query_result), 1)
         res = query_result[0]
         env.assertFalse(isinstance(res, Exception), message=f'query failed: {res}')

--- a/tests/pytests/test_lock_free_reads.py
+++ b/tests/pytests/test_lock_free_reads.py
@@ -1,0 +1,86 @@
+"""
+Tests for the experimental `_LOCK_FREE_READS` request config.
+
+With `_LOCK_FREE_READS` enabled, a RAM cursor query releases the spec read lock right
+after it takes its inverted-index snapshot (see `shouldReleaseSpecAfterSnapshot` in
+`aggregate/aggregate_exec.c`). Because the reader then iterates from its own immutable
+snapshot, a concurrent writer that needs the spec *write* lock can make progress while
+the query is still holding a cursor mid-execution. Without the flag the query keeps the
+read lock for its whole execution and such a writer blocks until the query finishes.
+
+The test is made deterministic with the `AfterIteratorCreate` sync point, which fires
+just after the snapshot is established (and, under the flag, just after the read lock is
+released). Sync points only exist in `ENABLE_ASSERT` builds, so the test skips otherwise.
+"""
+
+from common import *
+import threading
+
+
+def _run_query_store_result(conn, cmd, result_list):
+    """Execute a command on `conn` and stash the reply (or exception) for the caller."""
+    try:
+        result_list.append(conn.execute_command(*cmd))
+    except Exception as e:
+        result_list.append(e)
+
+
+def test_lock_free_reads_writer_progresses_while_cursor_held():
+    # WORKERS 1 so the aggregate runs on a worker thread, leaving the main thread free to
+    # service SYNC_POINT / FT.ALTER while the query is parked.
+    env = Env(moduleArgs='WORKERS 1 _LOCK_FREE_READS true DEFAULT_DIALECT 2')
+    skipIfNoEnableAssert(env)
+
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'body', 'TEXT').ok()
+    num_docs = 200
+    for i in range(num_docs):
+        conn.execute_command('HSET', f'doc:{i}', 'body', 'term')
+
+    sp = 'AfterIteratorCreate'
+    # Control connection: drives the sync point and issues the concurrent writer. Kept
+    # separate from the reader connection (which will block at the sync point).
+    ctl = env.getConnection()
+    ctl.execute_command(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+    ctl.execute_command(debug_cmd(), 'SYNC_POINT', 'ARM', sp)
+
+    try:
+        # Start a cursor aggregate on a background thread; it parks at AfterIteratorCreate
+        # (snapshot taken, read lock released because _LOCK_FREE_READS + cursor).
+        reader_conn = env.getConnection()
+        query_result = []
+        cmd = ['FT.AGGREGATE', 'idx', 'term',
+               'GROUPBY', 0, 'REDUCE', 'COUNT', 0, 'AS', 'n',
+               'WITHCURSOR', 'COUNT', 1000]
+        t = threading.Thread(target=_run_query_store_result,
+                             args=(reader_conn, cmd, query_result), daemon=True)
+        t.start()
+
+        # Deterministically wait until the reader is parked at the sync point.
+        wait_for_condition(
+            lambda: (ctl.execute_command(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sp) == 1, {}),
+            'Timeout waiting for the cursor query to reach AfterIteratorCreate')
+
+        # The query is holding a cursor mid-execution. FT.ALTER needs the spec WRITE lock;
+        # with _LOCK_FREE_READS the read lock is already released, so this returns
+        # immediately. If the lock were still held this would block the (single) main
+        # thread and the test would deadlock — a regression here fails as a timeout.
+        env.assertEqual(conn.execute_command('FT.ALTER', 'idx', 'SCHEMA', 'ADD', 'body2', 'TEXT'), 'OK')
+
+        # ...and the reader is still parked: the writer made progress *while* the cursor
+        # was held, which is only possible because the read lock was released.
+        env.assertEqual(ctl.execute_command(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sp), 1)
+
+        # Release the reader and let it complete.
+        ctl.execute_command(debug_cmd(), 'SYNC_POINT', 'SIGNAL', sp)
+        t.join(timeout=30)
+        env.assertFalse(t.is_alive(), message='cursor query did not finish after SIGNAL')
+
+        # The query must have completed successfully (snapshot stayed valid across the
+        # release + the concurrent schema change), counting every matching doc.
+        env.assertEqual(len(query_result), 1)
+        res = query_result[0]
+        env.assertFalse(isinstance(res, Exception), message=f'query failed: {res}')
+        env.assertContains(str(num_docs), str(res))
+    finally:
+        ctl.execute_command(debug_cmd(), 'SYNC_POINT', 'CLEAR')


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The snapshot/COW work was developed alongside an experimental `_LOCK_FREE_READS` config flag (release the spec read lock per result) and a set of snapshot-COW benchmarks. These were interleaved into the functional history.
2. **Change:** Collect all of that — the `_LOCK_FREE_READS` flag plumbing (`config`, `result_processor`, `aggregate_exec`), its pytest, the `inverted_index_bencher` harnesses (reader-iteration / snapshot_cow / revalidation_churn), and the 5200K real-key COW-mixed CI benchmark configs — onto this single experimental top branch, stacked above the three functional PRs.
3. **Outcome:** The undecided lock-free-reads flag and all benchmark churn are isolated at the top of the stack, so the decision to keep or drop the flag does not block the functional PRs below.

**Experimental / undecided** — opened as a draft. The lock-free-reads flag is not yet a committed feature.

#### Which additional issues this PR fixes
_None — no Jira ticket by request._

#### Main objects this PR modified
1. `src/config.{c,h}`, `src/result_processor.c`, `src/aggregate/aggregate_exec.c` — `_LOCK_FREE_READS` flag
2. `src/redisearch_rs/inverted_index_bencher/` — bench harnesses + examples
3. `tests/benchmarks/*.yml`, `.github/workflows/benchmark-runner.yml` — COW-mixed benchmark configs

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

_(Adds an internal `_LOCK_FREE_READS` config flag, disabled by default.)_

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

**Stacked PR (draft, experimental).** Base = `jk-ii-drop-gc-marker`. Top of the follow-up stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
