### PR TITLE
[MOD-14394] Bump requests to 2.31.0 in link-check requirements

### DIFF
--- a/scripts/requirements-linkcheck.txt
+++ b/scripts/requirements-linkcheck.txt
@@ -1,3 +1,3 @@
-requests>=2.28.0
+requests>=2.31.0
 beautifulsoup4>=4.11.0
 lxml>=4.9.0


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. **Current:** `scripts/requirements-linkcheck.txt` pins `requests>=2.28.0`. This range still permits the vulnerable `requests` 2.3.0–2.30.x versions affected by [CVE-2023-32681](https://github.com/psf/requests/security/advisories/GHSA-j8r2-6x86-q33q) — `requests` leaks the `Proxy-Authorization` header to the destination server when a request is redirected to an HTTPS endpoint.
2. **Change:** Raise the version floor to `requests>=2.31.0`, the release that contains the fix.
3. **Outcome:** The documentation link-checker (`scripts/check_links.py`, run in CI via `link-check.yml` and `event-weekly.yml`, and locally via `make check-links`) can no longer resolve a vulnerable `requests` version. This is CI/dev-tooling only — `requests` is never part of the shipped Redis module artifact.

#### Which additional issues this PR fixes
1. MOD-14394
2. #...

#### Main objects this PR modified
1. `scripts/requirements-linkcheck.txt`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal CI/dev-tooling change only (documentation link-checker dependency). No user-facing impact and no shipped-artifact change. The file exists only on `master`, so no backport is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)