### PR TITLE
[MOD-16660] FT.PROFILE ON_TIMEOUT FAIL: report pre-execution timeout as Warning, not error

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1428,7 +1428,10 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
     }
   }
 
-  if (AREQ_ShouldCheckTimeout(req) && req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail) {
+  // FT.PROFILE reports a timeout as a Warning, not an error, so skip the
+  // pre-execution hard-fail and let it proceed to execution like the RETURN path.
+  if (AREQ_ShouldCheckTimeout(req) && req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail &&
+      !IsProfile(req)) {
     TimedOut_WithStatus(&sctx->time.timeout, status);
   }
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1428,13 +1428,10 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
     }
   }
 
-  // A query-build timeout under FAIL policy hard-fails a normal query. FT.PROFILE
-  // must report the timeout as a Warning instead: record it right here (so it is
-  // surfaced regardless of any later timeout check) and mark the request timed out
-  // so the pipeline no-ops rather than erroring, leaving the profile to be returned.
   if (AREQ_ShouldCheckTimeout(req) && req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail &&
       TimedOut(&sctx->time.timeout) == TIMED_OUT) {
     if (IsProfile(req)) {
+      // FT.PROFILE reports a timeout as a Warning, not an error.
       ProfileWarnings_Add(&req->profileCtx.warnings, PROFILE_WARNING_TYPE_TIMEOUT);
       AREQ_SetTimedOut(req);
     } else {

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1428,11 +1428,18 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
     }
   }
 
-  // FT.PROFILE reports a timeout as a Warning, not an error, so skip the
-  // pre-execution hard-fail and let it proceed to execution like the RETURN path.
+  // A query-build timeout under FAIL policy hard-fails a normal query. FT.PROFILE
+  // must report the timeout as a Warning instead: record it right here (so it is
+  // surfaced regardless of any later timeout check) and mark the request timed out
+  // so the pipeline no-ops rather than erroring, leaving the profile to be returned.
   if (AREQ_ShouldCheckTimeout(req) && req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail &&
-      !IsProfile(req)) {
-    TimedOut_WithStatus(&sctx->time.timeout, status);
+      TimedOut(&sctx->time.timeout) == TIMED_OUT) {
+    if (IsProfile(req)) {
+      ProfileWarnings_Add(&req->profileCtx.warnings, PROFILE_WARNING_TYPE_TIMEOUT);
+      AREQ_SetTimedOut(req);
+    } else {
+      QueryError_SetCode(status, QUERY_ERROR_CODE_TIMED_OUT);
+    }
   }
 
   if (QueryError_HasError(status)) {

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1428,15 +1428,11 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
     }
   }
 
+  // FT.PROFILE's reply is produced by sendChunk, which reports a timeout as a
+  // Warning rather than an error; skip the hard-fail here and let it handle it.
   if (AREQ_ShouldCheckTimeout(req) && req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail &&
-      TimedOut(&sctx->time.timeout) == TIMED_OUT) {
-    if (IsProfile(req)) {
-      // FT.PROFILE reports a timeout as a Warning, not an error.
-      ProfileWarnings_Add(&req->profileCtx.warnings, PROFILE_WARNING_TYPE_TIMEOUT);
-      AREQ_SetTimedOut(req);
-    } else {
-      QueryError_SetCode(status, QUERY_ERROR_CODE_TIMED_OUT);
-    }
+      !IsProfile(req)) {
+    TimedOut_WithStatus(&sctx->time.timeout, status);
   }
 
   if (QueryError_HasError(status)) {

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -613,6 +613,41 @@ def testFailOnTimeout_strict():
   # error becomes a warning for the `FT.PROFILE` command.
   TimeoutWarningInProfile(Env(moduleArgs="ON_TIMEOUT FAIL"))
 
+@skip(cluster=True)
+def testProfileTimeoutDuringQueryBuild():
+  """
+  `FT.PROFILE` under `ON_TIMEOUT FAIL` must report a timeout as a `Warning`, not
+  as an error.
+
+  The `testFailOnTimeout_*` tests above check this with a wildcard and are flaky:
+  whether the 1ms budget is crossed while building the iterator tree or while
+  executing it is a timing race, and only the build-phase case regressed. This
+  test removes the race by forcing the build phase to overrun the budget.
+  """
+  env = Env(moduleArgs="ON_TIMEOUT FAIL WORKERS 0")
+  conn = getConnectionByEnv(env)
+
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+  # Let single-character prefixes expand without bound, so the union below covers
+  # every indexed term.
+  env.expect(config_cmd(), 'SET', 'MINPREFIX', '1').ok()
+  env.expect(config_cmd(), 'SET', 'MAXEXPANSIONS', '1000000').ok()
+
+  num_docs = 10000
+  for i in range(num_docs):
+    conn.execute_command('HSET', f'doc{i}', 't', str(i))
+
+  # Matches every indexed term, so building the iterator tree costs ~num_docs
+  # term iterators -- enough to overrun the 1ms budget before execution starts.
+  heavy_query = '|'.join(f'{d}*' for d in range(10))
+
+  env.expect(
+    'FT.PROFILE', 'idx', 'SEARCH', 'QUERY', heavy_query, 'DIALECT', '2',
+    'LIMIT', '0', str(num_docs), 'TIMEOUT', '1'
+  ).noError(
+    message="FT.PROFILE hard-failed on a pre-execution timeout instead of embedding a Warning"
+  ).apply(str).contains('Timeout limit was reached')
+
 def TimedoutTest_resp3(env):
   """Tests that the `Timedout` value of the profile response is correct"""
 

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -617,12 +617,9 @@ def testFailOnTimeout_strict():
 def testProfileTimeoutDuringQueryBuild():
   """
   `FT.PROFILE` under `ON_TIMEOUT FAIL` must report a timeout as a `Warning`, not
-  as an error.
-
-  The `testFailOnTimeout_*` tests above check this with a wildcard and are flaky:
-  whether the 1ms budget is crossed while building the iterator tree or while
-  executing it is a timing race, and only the build-phase case regressed. This
-  test removes the race by forcing the build phase to overrun the budget.
+  an error. The large term expansion forces the timeout to hit during query
+  build -- the case that regressed and made the wildcard `testFailOnTimeout_*`
+  tests above flaky.
   """
   env = Env(moduleArgs="ON_TIMEOUT FAIL WORKERS 0")
   conn = getConnectionByEnv(env)


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. **Current:** Under `ON_TIMEOUT FAIL`, if a query timeout is detected *before* execution begins — while the iterator tree is built in `prepareExecutionPlan` — the request hard-fails with a raw `SEARCH_TIMEOUT Timeout limit was reached` error. For `FT.PROFILE` this is wrong: that pre-execution error path is not profile-aware, so the profile command errors out instead of embedding the timeout as a `Warning`. Whether the (tiny) timeout budget is crossed during query build vs. during execution is a timing race, which makes `test_profile:testFailOnTimeout_strict` flaky on loaded machines.
2. **Change:** Skip the pre-execution hard-fail timeout check for `FT.PROFILE` requests (add `!IsProfile(req)` to the `TimeoutPolicy_Fail` guard in `prepareExecutionPlan`), so a timed-out profile proceeds to execution like the `RETURN` path and surfaces the timeout as a `Warning`.
3. **Outcome:** `FT.PROFILE` under `ON_TIMEOUT FAIL` reports a timeout as a `Warning` regardless of whether it is detected during query build or execution — matching the `RETURN` behavior and the documented contract. Non-profile `FT.SEARCH`/`FT.AGGREGATE` still error on timeout as before.

#### Which additional issues this PR fixes
1. MOD-16660
2. #10190 (related: FT.INFO field statistics / disk metrics work — context only)

#### Main objects this PR modified
1. `src/aggregate/aggregate_exec.c` — `prepareExecutionPlan`
2. `tests/pytests/test_profile.py` — new deterministic regression test `testProfileTimeoutDuringQueryBuild`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

`FT.PROFILE` with `ON_TIMEOUT FAIL` now reports a query timeout as a `Warning` in the profile output instead of failing the whole command with a `SEARCH_TIMEOUT` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
