### PR TITLE
[8.4] [MOD-16423] Document cbindgen MPL-2.0 license

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,10 @@
+# Third-Party Notices
+
+This file records package-specific third-party license usage that must be
+reflected in release dependency and SBOM inventories. RediSearch's Rust
+workspace license policy is enforced by `cargo deny check licenses` using
+`src/redisearch_rs/deny.toml`.
+
+| Package | Version | License | Use |
+| --- | --- | --- | --- |
+| `cbindgen` | `0.29.2` | `MPL-2.0` | Generates C headers from Rust FFI crates for the C integration layer. |

--- a/src/redisearch_rs/deny.toml
+++ b/src/redisearch_rs/deny.toml
@@ -15,6 +15,9 @@ Since there are no known vulnerabilities (nor ways to remove it), it's safe to a
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
 # List of explicitly allowed licenses
+# Package-specific MPL-2.0 usage that must be reflected in release dependency
+# and SBOM inventories is documented in the repository-level
+# THIRD_PARTY_NOTICES.md.
 allow = [
     # OSI-approved licenses
     "MIT",


### PR DESCRIPTION
## Describe the changes in the pull request

Current: This release branch uses `cbindgen` for Rust-to-C FFI header generation, but does not have a repository-level third-party notice for its MPL-2.0 license usage. This is a backport of #10213 from `master` for MOD-16423.

Change: Add `THIRD_PARTY_NOTICES.md` documenting `cbindgen 0.29.2` with license `MPL-2.0`, and point the Rust `deny.toml` license policy at the repository-level notice.

Outcome: The release branch tracks the dependency/license metadata for its actual MPL-2.0 Rust dependency.

#### Which additional issues this PR fixes
1. MOD-16423
2. Backport of #10213

#### Main objects this PR modified
1. `THIRD_PARTY_NOTICES.md`
2. `src/redisearch_rs/deny.toml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
