### PR TITLE
[MOD-16703] Fix crash on FT.CURSOR READ after index drop (NULL spec ref in BlockedQueries cursor node)

### DIFF
--- a/src/info/info_redis/types/blocked_queries.c
+++ b/src/info/info_redis/types/blocked_queries.c
@@ -93,6 +93,10 @@ void BlockedQueries_RemoveQuery(BlockedQueryNode* blockedQueryNode) {
 }
 
 void BlockedQueries_RemoveCursor(BlockedCursorNode* blockedCursorNode) {
-  StrongRef_Release(blockedCursorNode->spec);
+  // The spec ref is legitimately empty when the promote in BlockedQueries_AddCursor failed
+  // (the index was dropped while the cursor was idle), so mirror its guard here.
+  if (blockedCursorNode->spec.rm) {
+    StrongRef_Release(blockedCursorNode->spec);
+  }
   dllist_delete(&blockedCursorNode->llnode);
 }

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -759,6 +759,25 @@ def test_cursor_commands_errors(env: Env):
     env.expect('FT.DROPINDEX', 'temp').ok()
     env.expect('_FT.CURSOR', 'PROFILE', 'temp', cid).error().contains('The index was dropped while the cursor was idle')
 
+@skip(cluster=True)
+def test_internal_cursor_read_after_drop_with_workers():
+    """Regression test for MOD-16703: an internal `_FT.CURSOR READ` on a cursor
+    whose index was dropped while it sat idle crashed the shard when the read
+    went through the blocked-client path (`BlockCursorClientWithTimeout`), which
+    is only taken when worker threads are enabled. The test runner forces
+    `WORKERS 0` (inline path), so enable workers explicitly here."""
+    env = Env(moduleArgs='WORKERS 1')
+    env.expect('DEBUG', 'MARK-INTERNAL-CLIENT').ok()
+    env.cmd('FT.CREATE', 'temp', 'SCHEMA', 't', 'TEXT')
+    # Two docs + COUNT 1 keep the cursor alive after the first read
+    env.cmd('HSET', 'doc1', 't', 'hello')
+    env.cmd('HSET', 'doc2', 't', 'world')
+    waitForIndex(env, 'temp')
+    _, cid = env.cmd('FT.AGGREGATE', 'temp', '*', 'WITHCURSOR', 'COUNT', '1')
+    env.assertNotEqual(cid, 0)
+    env.expect('FT.DROPINDEX', 'temp').ok()
+    env.expect('_FT.CURSOR', 'READ', 'temp', cid).error().contains('The index was dropped while the cursor was idle')
+
 @skip(cluster=False)
 def test_cursor_gc_edge_cases(env: Env):
     """


### PR DESCRIPTION

## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: `BlockedQueries_AddCursor` stores an empty `StrongRef` when `WeakRef_Promote(cursor->spec_ref)` fails — which legitimately happens when the index was dropped while the cursor sat idle (`if (spec.rm) { node->spec = WeakRef_Promote(spec); }` leaves `node->spec` zeroed on a failed promote too). `BlockedQueries_RemoveCursor` then releases it unconditionally: `StrongRef_Release(blockedCursorNode->spec)` → `RefManager_ReturnStrongReference(rm = NULL)` → SIGSEGV at `src/util/references.c:49` (verified gdb backtrace: blocked-client `free_privdata` callback → `BlockedQueries_RemoveCursor` → `StrongRef_Release` with `rm = 0x0`). Deterministic repro on a shard with worker threads enabled: `FT.CREATE temp SCHEMA t TEXT` → `FT.AGGREGATE temp '*' WITHCURSOR COUNT 1` → `FT.DROPINDEX temp` → `_FT.CURSOR READ temp <cid>` (internal client) → server crash.
2. Change: guard the release in `BlockedQueries_RemoveCursor` with `if (blockedCursorNode->spec.rm)`, mirroring the guard in `BlockedQueries_AddCursor`, plus a comment explaining the ref is legitimately empty when the promote failed. Also adds an MT-enabled regression test (`test_internal_cursor_read_after_drop_with_workers` in `tests/pytests/test_cursors.py`).
3. Outcome: `_FT.CURSOR READ` / `FT.CURSOR READ` on a cursor whose index was dropped returns the expected `The index was dropped while the cursor was idle` error instead of crashing the shard.

**`BlockedQueries_RemoveQuery` does NOT need the same guard**: `BlockQueryClientWithTimeout` receives a live `StrongRef` (spec existence is validated on the main thread in buildRequest) and `BlockedQueries_AddQuery` stores `StrongRef_Clone(spec)`, so a query node's ref can never be empty. Only the cursor path promotes a `WeakRef` that can fail.

**Introduced by**: MOD-14284 (PR #9289, merged 2026-04-29), which wired shard `FT.CURSOR READ` through `BlockCursorClientWithTimeout` — the only caller of `BlockedQueries_AddCursor`.

**Why CI never caught this**: the official pytest runner (`tests/pytests/runtests.sh`, used by `./build.sh RUN_PYTEST` and the CI workflows) always appends `WORKERS 0` to the module args, so `_FT.CURSOR READ` takes the inline (synchronous) path and `BlockCursorClientWithTimeout` is never reached. A bare RLTest invocation (no forced `WORKERS 0`) crashes deterministically in `test_cursors.py:test_cursor_commands_errors`. The new regression test creates its own env with `moduleArgs='WORKERS 1'` so the blocked-cursor path is exercised under CI's configuration as well; it was verified to crash the server on the unfixed build and pass on the fixed one.

**Affected versions**: master and 8.8 — 8.8 crash reproduced empirically on `origin/8.8` (c90df10bb) with the same test. 8.2/8.4/8.6 contain the code but `BlockCursorClientWithTimeout` has no callers there, so they are not affected. **A backport to 8.8 is required after this PR is merged** (not included here).

#### Which additional issues this PR fixes

1. MOD-16703

#### Main objects this PR modified

1. `BlockedQueries_RemoveCursor` (`src/info/info_redis/types/blocked_queries.c`)
2. `tests/pytests/test_cursors.py` (new regression test)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

🤖 Generated with [Claude Code](https://claude.com/claude-code)
