### PR TITLE
fix: make tarball-installed LLVM usable from fresh shells (bootstrap → `make build LTO=1`)

### DIFF
--- a/.install/alpine_linux_3.sh
+++ b/.install/alpine_linux_3.sh
@@ -28,15 +28,24 @@ source "$(dirname "${BASH_SOURCE[0]}")/install_llvm.sh" $MODE
 
 # Static LLVM/clang libraries for bindgen-static mode (redis-module musl target
 # in document_metadata uses bindgen-static, which links clang-sys statically).
+# compiler-rt: the python test venv builds its sdist-only deps with clang
+# (see test_deps/install_python_deps.sh), whose baked-in --rtlib=compiler-rt
+# needs the runtime present.
 LLVM_VER=$(ls /usr/lib/ | grep -oE 'llvm[0-9]+' | sort -V | tail -1 | tr -d 'llvm')
-$MODE apk add --no-cache llvm${LLVM_VER}-static ncurses-static zlib-static zstd-static
+$MODE apk add --no-cache llvm${LLVM_VER}-static ncurses-static zlib-static zstd-static compiler-rt
 
 # Alpine ships component .a files but no combined libLLVM-<ver>.a.
 # clang-sys emits cargo:rustc-link-lib=LLVM-<ver> which the linker resolves to
-# libLLVM-<ver>.a. Create a thin archive that references the component files.
+# libLLVM-<ver>.a. GNU ar's thin-archive mode (`ar rcT`) flattens the nested
+# component archives into member headers ld.lld cannot parse ("could not get
+# the buffer for a child of the archive"), so provide a GROUP() linker script
+# instead — both ld.lld and GNU ld accept a text script in place of an
+# archive, and it costs no disk space.
 if [ ! -e /usr/lib/llvm${LLVM_VER}/lib/libLLVM-${LLVM_VER}.a ]; then
-    # shellcheck disable=SC2046
-    $MODE ar rcT /usr/lib/llvm${LLVM_VER}/lib/libLLVM-${LLVM_VER}.a \
-        /usr/lib/llvm${LLVM_VER}/lib/libLLVM*.a \
-        /usr/lib/libzstd.a
+    # Expand the glob before tee creates the output file, so the combined
+    # archive never lists itself.
+    # shellcheck disable=SC2086
+    LLVM_COMPONENT_LIBS=$(echo /usr/lib/llvm${LLVM_VER}/lib/libLLVM*.a /usr/lib/libzstd.a)
+    echo "GROUP( ${LLVM_COMPONENT_LIBS} )" \
+        | $MODE tee /usr/lib/llvm${LLVM_VER}/lib/libLLVM-${LLVM_VER}.a > /dev/null
 fi

--- a/.install/install_llvm.sh
+++ b/.install/install_llvm.sh
@@ -54,7 +54,32 @@ install_from_tarball() {
     rm -rf "$tmpdir"
 
     export_path_gha
+    link_tools_for_fresh_shells
     echo ">>> LLVM ${LLVM_FULL_VER} installed to ${INSTALL_DIR}"
+}
+
+# Fresh-shell usability for the tarball install: export_path_gha only covers
+# GitHub Actions steps (via $GITHUB_PATH/$GITHUB_ENV) and the shell that ran
+# this script. A user following the manual flow — `make bootstrap` now,
+# `make build LTO=1` from a later shell — has no ${INSTALL_DIR}/bin on PATH,
+# so build.sh cannot find clang-${LLVM_VER} and LTO refuses to enable. The
+# package-manager install paths don't have this problem (they land versioned
+# binaries in /usr/bin), so mirror that: symlink the tools build.sh looks up
+# — and llvm-config, through which bindgen's clang-sys locates libclang
+# (`llvm-config --libdir`) without needing a persisted LIBCLANG_PATH — into
+# /usr/local/bin, which is on the default PATH of every supported distro.
+# Same pattern rocky_linux_8.sh uses for its gcc-toolset shims.
+link_tools_for_fresh_shells() {
+    local bindir="${INSTALL_DIR}/bin"
+    local tool target
+    for tool in "clang-${LLVM_VER}" "clang++-${LLVM_VER}" "lld-${LLVM_VER}" ld.lld llvm-config; do
+        # The tarball ships some of these only under their unversioned
+        # names; resolve to whichever exists.
+        target="${bindir}/${tool}"
+        [[ -e "$target" ]] || target="${bindir}/${tool%-${LLVM_VER}}"
+        [[ -e "$target" ]] || continue
+        $MODE ln -sf "$target" "/usr/local/bin/${tool}" || true
+    done
 }
 
 # Wire up $INSTALL_DIR/bin for GitHub Actions and the current shell.

--- a/.install/install_llvm.sh
+++ b/.install/install_llvm.sh
@@ -71,7 +71,14 @@ install_from_tarball() {
 # Same pattern rocky_linux_8.sh uses for its gcc-toolset shims.
 link_tools_for_fresh_shells() {
     local bindir="${INSTALL_DIR}/bin"
+    local destdir="/usr/local/bin"
     local tool target
+
+    if ! $MODE mkdir -p "$destdir"; then
+        echo "ERROR: cannot create ${destdir}; rerun with sudo or add ${bindir} to PATH manually" >&2
+        return 1
+    fi
+
     # ld.lld-${LLVM_VER} matters beyond fresh shells: once lld-${LLVM_VER} is
     # on PATH, build.sh links with -fuse-ld=lld-${LLVM_VER}, and clang
     # resolves that name by looking for an executable literally called
@@ -82,8 +89,15 @@ link_tools_for_fresh_shells() {
         # names; resolve to whichever exists.
         target="${bindir}/${tool}"
         [[ -e "$target" ]] || target="${bindir}/${tool%-${LLVM_VER}}"
-        [[ -e "$target" ]] || continue
-        $MODE ln -sf "$target" "/usr/local/bin/${tool}" || true
+        if [[ ! -e "$target" ]]; then
+            echo "ERROR: expected LLVM tool '${tool}' not found under ${bindir}" >&2
+            return 1
+        fi
+
+        if ! $MODE ln -sf "$target" "${destdir}/${tool}"; then
+            echo "ERROR: failed to link ${destdir}/${tool} -> ${target}" >&2
+            return 1
+        fi
     done
 }
 

--- a/.install/install_llvm.sh
+++ b/.install/install_llvm.sh
@@ -72,7 +72,12 @@ install_from_tarball() {
 link_tools_for_fresh_shells() {
     local bindir="${INSTALL_DIR}/bin"
     local tool target
-    for tool in "clang-${LLVM_VER}" "clang++-${LLVM_VER}" "lld-${LLVM_VER}" ld.lld llvm-config; do
+    # ld.lld-${LLVM_VER} matters beyond fresh shells: once lld-${LLVM_VER} is
+    # on PATH, build.sh links with -fuse-ld=lld-${LLVM_VER}, and clang
+    # resolves that name by looking for an executable literally called
+    # ld.lld-${LLVM_VER} — distro packages ship one, the tarball only ships
+    # unversioned ld.lld.
+    for tool in "clang-${LLVM_VER}" "clang++-${LLVM_VER}" "lld-${LLVM_VER}" "ld.lld-${LLVM_VER}" ld.lld llvm-config; do
         # The tarball ships some of these only under their unversioned
         # names; resolve to whichever exists.
         target="${bindir}/${tool}"
@@ -168,8 +173,12 @@ install_llvm() {
         apt_get_cmd "$MODE" update -qq
 
         # 1) Try native distro packages first (e.g. Ubuntu 26.04 ships clang-21).
+        # llvm-${LLVM_VER} supplies llvm-ar/llvm-ranlib, which CMake's IPO
+        # (LTO) archive rules need; with --no-install-recommends
+        # clang-${LLVM_VER} doesn't pull it in.
         if apt_get_cmd "$MODE" install -y --no-install-recommends \
-                "clang-${LLVM_VER}" "lld-${LLVM_VER}" "libclang-${LLVM_VER}-dev" 2>/dev/null; then
+                "clang-${LLVM_VER}" "lld-${LLVM_VER}" "libclang-${LLVM_VER}-dev" \
+                "llvm-${LLVM_VER}" 2>/dev/null; then
             echo ">>> Installed clang-${LLVM_VER} from native apt repos"
         else
             # 2) Fall back to apt.llvm.org third-party repo.

--- a/.install/microsoft_azure_linux_3.0.sh
+++ b/.install/microsoft_azure_linux_3.0.sh
@@ -2,7 +2,21 @@
 MODE=$1 # whether to install using sudo or not
 set -eo pipefail
 
-$MODE tdnf install -yq build-essential ca-certificates gdb git libxcrypt-devel openssl-devel rsync tar unzip wget which xz
+# tdnf intermittently fails on Azure Linux mirrors with
+# "TDNFVerifySignature 2004" / "Failed to synchronize cache". Retry, and
+# within each attempt fall back to skipping the repo-metadata GPG plugin
+# (per-package GPG checks still apply).
+tdnf_install() {
+    local i
+    for i in 1 2 3; do
+        $MODE tdnf install -y "$@" && return 0
+        $MODE tdnf --disableplugin=tdnfrepogpgcheck install -y "$@" && return 0
+        [ "$i" -lt 3 ] && sleep 10
+    done
+    return 1
+}
+
+tdnf_install -q build-essential ca-certificates gdb git libxcrypt-devel openssl-devel rsync tar unzip wget which xz
 
 # Install LLVM for LTO
 source "$(dirname "${BASH_SOURCE[0]}")/install_llvm.sh" $MODE
@@ -11,5 +25,5 @@ source "$(dirname "${BASH_SOURCE[0]}")/install_llvm.sh" $MODE
 # source, since it only started providing wheels for aarch64
 # in version 6.w.z.
 if [ "$(uname -m)" = "aarch64" ]; then
-    $MODE tdnf install -y python3-devel
+    tdnf_install python3-devel
 fi

--- a/.install/rocky_linux_8.sh
+++ b/.install/rocky_linux_8.sh
@@ -17,7 +17,7 @@ $MODE dnf install epel-release -yqq
 $MODE dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ \
     gcc-toolset-13-libatomic-devel make wget git openssl openssl-devel \
     bzip2-devel libffi-devel zlib-devel tar xz which rsync \
-    clang curl clang-devel gdb --nobest --skip-broken
+    clang curl clang-devel lld gdb --nobest --skip-broken
 
 # We need Python headers to build psutil@5.x.y from
 # source, since it only started providing wheels for aarch64

--- a/build.sh
+++ b/build.sh
@@ -374,6 +374,21 @@ prepare_cmake_arguments() {
   # Initialize with base arguments
   CMAKE_BASIC_ARGS="-DCOORD_TYPE=$COORD"
 
+  # A reused build directory keeps the LTO configuration it was created with:
+  # the CMake cache retains CMAKE_INTERPROCEDURAL_OPTIMIZATION=true and the
+  # static libraries already built from it contain LLVM bitcode, which
+  # non-LTO consumers reject at link time (the Rust test binaries linking
+  # libredisearch_all.a through the default cc/bfd linker fail with
+  # "file format not recognized"). Inherit LTO from the cache so a re-drive
+  # without the LTO argument (e.g. `make test` after an LTO `make build`)
+  # keeps the matching clang/lld toolchain. FORCE wipes the directory in
+  # run_cmake(), so a forced clean build is exempt.
+  if [[ "$LTO" != "1" && "$FORCE" != "1" && -f "$BINDIR/CMakeCache.txt" ]] && \
+      grep -qE '^CMAKE_INTERPROCEDURAL_OPTIMIZATION:[^=]*=(true|TRUE|ON|1)$' "$BINDIR/CMakeCache.txt"; then
+    echo "Reusing LTO-configured build directory: enabling LTO"
+    LTO=1
+  fi
+
   if [[ "$LTO" == "1" ]]; then
     # LTO is only supported on Linux
     if [[ "$OS_NAME" != "linux" ]]; then
@@ -528,8 +543,13 @@ prepare_cmake_arguments() {
     # Pass LTO C/CXX flags to CMake via CFLAGS/CXXFLAGS env vars so CMake picks them
     # up without word-splitting issues.
     # Note: we assume there are no spaces in system C++ include paths.
-    export CFLAGS="${CFLAGS:+${CFLAGS} }${GCC_COMMON_FLAGS}"
-    export CXXFLAGS="${CXXFLAGS:+${CXXFLAGS} }${GCC_COMMON_FLAGS}${GCC_CXX_FLAGS:+ ${GCC_CXX_FLAGS}}"
+    # The environment may carry GCC-only -W options (e.g. CI exports
+    # -Wno-error=maybe-uninitialized for the gcc-built redis core). This
+    # branch always compiles with clang, which flags those as
+    # -Wunknown-warning-option — a hard error in vendored targets that add
+    # -Werror (e.g. VectorSimilarity spaces). Silence that diagnostic.
+    export CFLAGS="${CFLAGS:+${CFLAGS} }-Wno-unknown-warning-option ${GCC_COMMON_FLAGS}"
+    export CXXFLAGS="${CXXFLAGS:+${CXXFLAGS} }-Wno-unknown-warning-option ${GCC_COMMON_FLAGS}${GCC_CXX_FLAGS:+ ${GCC_CXX_FLAGS}}"
     # Export CC/CXX so that Rust's cc crate also uses clang, matching the
     # clang-specific flags in CFLAGS/CXXFLAGS (e.g. --gcc-install-dir).
     export CC="$C_COMPILER"


### PR DESCRIPTION
Companion to #10372 (same theme: `make bootstrap` should fully provision what the documented flows need).

## Problem

`install_llvm.sh`'s package-manager paths (apt / apt.llvm.org / apk / dnf) land versioned binaries in `/usr/bin`, so after `make bootstrap` a later shell can run `make build LTO=1` and `build.sh` finds `clang-21`/`lld-21`. The tarball fallback (Azure Linux, Mariner, any distro without matching packages) unpacks to `/usr/local/llvm` and wires PATH only via `$GITHUB_PATH`/the current shell - so outside GitHub Actions, a fresh shell can't see the toolchain: LTO refuses to enable (`Please either: 1. Install clang-21 ...`) even though bootstrap just installed it, and bindgen has no libclang.

## Fix

After extracting the tarball, symlink the tools `build.sh` looks up (`clang-21`, `clang++-21`, `lld-21`, `ld.lld-21`, `ld.lld`) and `llvm-config` - through which bindgen's clang-sys resolves libclang (`llvm-config --libdir`), so no persisted `LIBCLANG_PATH` is needed - into `/usr/local/bin` (default PATH everywhere). This mirrors what the package paths already provide, and the same pattern `rocky_linux_8.sh` uses for its gcc-toolset shims.

The follow-up commit also fixes the related LTO bootstrap issues found while validating the Redis bundled-modules flow: native apt installs `llvm-21` for CMake IPO archive tools, Alpine uses a `GROUP()` linker script for static LLVM libs, Azure Linux retries flaky `tdnf` metadata fetches, Rocky 8 installs `lld`, and `build.sh` keeps LTO enabled when reusing an LTO-configured build directory.

## Verified

Clean `mcr.microsoft.com/azurelinux/base/core:3.0` container -> `./install_llvm.sh` -> then a deliberately clean shell (`env -i PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`):

```console
/usr/local/bin/clang-21
clang version 21.1.8
/usr/local/bin/lld-21
/usr/local/bin/ld.lld
/usr/local/bin/clang++-21
$ llvm-config --libdir
/usr/local/llvm/lib   (contains libclang.so, libclang.so.21.1)
```

The broader LTO validation is for supported Linux targets where RediSearch/Redis build sanity enables LTO. macOS and explicitly non-LTO rows remain outside this claim.

Context: found while wiring the redis/redis bundled-modules flow ([redis/redis#15253](https://github.com/redis/redis/pull/15253)), whose docs currently tell users bootstrap can't provision the LTO toolchain.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Generated with [Claude Code](https://claude.com/claude-code)
