### PR TITLE
[MOD-16150] inverted_index: fold pending into sealed on insert

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -37,8 +37,10 @@ static void writeIndexEntry(IndexSpec *spec, InvertedIndex *idx, ForwardIndexEnt
 
   // Update index statistics:
 
-  // Number of additional bytes
+  // Number of additional bytes (mem_freed is non-zero when the write also folded
+  // pending blocks into sealed, collapsing per-block Arc headers).
   spec->stats.invertedSize += r.mem_growth;
+  spec->stats.invertedSize -= r.mem_freed;
   IndexStats_BlockCountAdd(&spec->stats, r.blocks_added);
   // Number of records
   spec->stats.numRecords++;
@@ -607,6 +609,7 @@ static void writeMissingFieldDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx,
                          .metrics = MetricsVec_New()};
     AddRecordOutcome r = InvertedIndex_WriteEntryGeneric(iiMissingDocs, &rec);
     aCtx->spec->stats.invertedSize += r.mem_growth;
+    aCtx->spec->stats.invertedSize -= r.mem_freed;
     IndexStats_BlockCountAdd(&aCtx->spec->stats, r.blocks_added);
   }
   dictReleaseIterator(iter);
@@ -630,6 +633,7 @@ static void writeExistingDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {
                        .metrics = MetricsVec_New()};
   AddRecordOutcome r = InvertedIndex_WriteEntryGeneric(sctx->spec->existingDocs, &rec);
   aCtx->spec->stats.invertedSize += r.mem_growth;
+  aCtx->spec->stats.invertedSize -= r.mem_freed;
   IndexStats_BlockCountAdd(&aCtx->spec->stats, r.blocks_added);
 }
 

--- a/src/redisearch_rs/headers/inverted_index.h
+++ b/src/redisearch_rs/headers/inverted_index.h
@@ -37,6 +37,14 @@ typedef struct InvertedIndexSnapshot InvertedIndexSnapshot;
 typedef struct InvertedIndexGcDelta InvertedIndexGcDelta;
 
 /**
+ * An opaque inverted index structure. The actual implementation is determined at runtime based on
+ * the index flags provided when creating the index. This allows us to have a single interface for
+ * all index types while still being able to optimize the storage and performance for each index
+ * type.
+ */
+typedef struct InvertedIndex InvertedIndex;
+
+/**
  * Each `IndexBlock` contains a set of entries for a specific range of document IDs. The entries
  * are ordered by document ID, so the first entry in the block has the lowest document ID, and the
  * last entry has the highest document ID. The block also contains a buffer that is used to
@@ -44,14 +52,6 @@ typedef struct InvertedIndexGcDelta InvertedIndexGcDelta;
  * added to the block.
  */
 typedef struct IndexBlock IndexBlock;
-
-/**
- * An opaque inverted index structure. The actual implementation is determined at runtime based on
- * the index flags provided when creating the index. This allows us to have a single interface for
- * all index types while still being able to optimize the storage and performance for each index
- * type.
- */
-typedef struct InvertedIndex InvertedIndex;
 
 /**
  * Summary information about an inverted index containing all key metrics
@@ -156,13 +156,22 @@ typedef union IndexDecoderCtx {
 } IndexDecoderCtx;
 
 /**
- * Outcome of [`InvertedIndex::add_record`]: how the index grew during the write.
+ * Outcome of [`InvertedIndex::add_record`]: how the index's memory changed during the
+ * write. The net memory delta is `mem_growth - mem_freed`; callers maintaining a running
+ * size stat (e.g. `spec->stats.invertedSize`) must apply both.
  */
 typedef struct AddRecordOutcome {
   /**
-   * Number of bytes the inverted index's memory usage grew by.
+   * Number of bytes the inverted index's memory usage grew by (buffer growth + any
+   * `Arc<IndexBlock>` / pending-slot allocation from a roll-over).
    */
   uint32_t mem_growth;
+  /**
+   * Number of bytes freed if this write also folded `pending` into `sealed`
+   * (see [`InvertedIndex::fold_pending_into_sealed`]): the collapsed per-block `Arc`
+   * refcount headers + the drained `pending` Vec heap. `0` when no fold occurred.
+   */
+  uint32_t mem_freed;
   /**
    * Number of new index blocks this write created.
    */

--- a/src/redisearch_rs/inverted_index/src/index/core.rs
+++ b/src/redisearch_rs/inverted_index/src/index/core.rs
@@ -21,6 +21,7 @@ use rqe_core::DocId;
 use serde::{Deserialize, Serialize};
 use std::{
     marker::PhantomData,
+    mem::MaybeUninit,
     sync::{Arc, LazyLock},
 };
 use thin_vec::ThinVec;
@@ -90,12 +91,19 @@ pub struct InvertedIndex<E> {
     pub(crate) _encoder: PhantomData<E>,
 }
 
-/// Outcome of [`InvertedIndex::add_record`]: how the index grew during the write.
+/// Outcome of [`InvertedIndex::add_record`]: how the index's memory changed during the
+/// write. The net memory delta is `mem_growth - mem_freed`; callers maintaining a running
+/// size stat (e.g. `spec->stats.invertedSize`) must apply both.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 #[repr(C)]
 pub struct AddRecordOutcome {
-    /// Number of bytes the inverted index's memory usage grew by.
+    /// Number of bytes the inverted index's memory usage grew by (buffer growth + any
+    /// `Arc<IndexBlock>` / pending-slot allocation from a roll-over).
     pub mem_growth: u32,
+    /// Number of bytes freed if this write also folded `pending` into `sealed`
+    /// (see [`InvertedIndex::fold_pending_into_sealed`]): the collapsed per-block `Arc`
+    /// refcount headers + the drained `pending` Vec heap. `0` when no fold occurred.
+    pub mem_freed: u32,
     /// Number of new index blocks this write created.
     pub blocks_added: u32,
 }
@@ -134,6 +142,13 @@ pub(crate) const ARC_HEADER_BYTES: usize = std::mem::size_of::<usize>() * 2;
 /// that's tracked separately because `Vec::push` grows by amortized capacity, not
 /// one slot at a time. See [`InvertedIndex::add_record`].
 pub(crate) const PER_ROLLOVER_HEAP_BYTES: usize = IndexBlock::STACK_SIZE + ARC_HEADER_BYTES;
+
+/// Floor on `pending.len()` before the write path will fold `pending`→`sealed` (see
+/// [`InvertedIndex::maybe_fold_pending`]). Combined with the geometric "fold once pending
+/// has grown to at least `sealed.len()`" rule, this keeps small indexes from paying a
+/// fold and bounds total fold work across a load to O(n) (`sealed` roughly doubles each
+/// fold: 64 → 128 → 256 → …).
+const FOLD_MIN_PENDING_BLOCKS: usize = 64;
 
 impl IndexBlock {
     pub(crate) const STACK_SIZE: usize = std::mem::size_of::<Self>();
@@ -418,14 +433,103 @@ impl<E: Encoder> InvertedIndex<E> {
             self.flags |= IndexFlags_Index_HasMultiValue;
         }
 
+        // Fold accumulated `pending` blocks into the contiguous `sealed` region once they
+        // are worth compacting. Without this, a pure-insert index (no deletes/updates)
+        // never triggers fork-GC — its `deletedOrUpdatedDocsFromLastRun` stays 0 — so all
+        // its blocks live forever as scattered `Arc<IndexBlock>` in `pending`, which reads
+        // with worse locality (and more per-snapshot refcount work) than master's single
+        // contiguous vector. Only checked on a rollover (when `pending` actually grew).
+        //
+        // The fold reallocates `sealed` and moves M+N block structs, so it must stay on a
+        // geometric schedule (amortized O(n)) regardless of snapshots. But the per-block
+        // *COW clone* only fires when a live snapshot pins the region; with no snapshot
+        // (`strong_count == 1`) the fold is all cheap moves, so we fold more eagerly — at ¼
+        // of `sealed` rather than 1× — to keep `pending` small (better read locality)
+        // without paying the copy cost. Still geometric (~1.25× growth), so still O(n).
+        let mut mem_freed: usize = 0;
+        let unpinned = Arc::strong_count(&self.sealed) == 1;
+        let ratio_reached = if unpinned {
+            self.pending.len() >= self.sealed.len() >> 2
+        } else {
+            self.pending.len() >= self.sealed.len()
+        };
+        if rollovers_into_pending > 0
+            && self.pending.len() >= FOLD_MIN_PENDING_BLOCKS
+            && ratio_reached
+        {
+            mem_freed = self.fold_pending_into_sealed();
+        }
+
         debug_assert!(
             mem_growth <= u32::MAX as usize,
             "AddRecordOutcome::mem_growth overflowed u32 ({mem_growth} bytes in one add)"
         );
         Ok(AddRecordOutcome {
             mem_growth: mem_growth as u32,
+            mem_freed: mem_freed as u32,
             blocks_added,
         })
+    }
+
+    /// Fold every `pending` block into a fresh contiguous `sealed` [`Arc<[IndexBlock]>`],
+    /// leaving `in_progress` (the single active tail) untouched. No-op when `pending` is
+    /// empty. Blocks are moved out of their old allocations when no reader snapshot pins
+    /// them, and deep-copied (copy-on-write) when one does — mirroring `apply_gc`.
+    ///
+    /// Replaces `self.sealed` with a new `Arc`, so readers detect the change via
+    /// `Arc::ptr_eq` and revalidate. Callers must invoke this rarely (geometric schedule —
+    /// see [`FOLD_MIN_PENDING_BLOCKS`]) so concurrent readers aren't forced to re-seek on
+    /// every write.
+    /// Returns the number of bytes freed by the fold (0 if it was a no-op): the M per-block
+    /// `Arc` refcount headers that collapse into the single `sealed` `Arc`, plus the drained
+    /// `pending` Vec heap. The blocks' stack bytes and buffer capacities are unchanged —
+    /// they move from `pending` into `sealed`, not freed — so this is the exact
+    /// `memory_usage()` decrease.
+    fn fold_pending_into_sealed(&mut self) -> usize {
+        if self.pending.is_empty() {
+            return 0;
+        }
+        let freed = self.pending.len() * ARC_HEADER_BYTES + self.pending.mem_usage();
+        let new_len = self.sealed.len() + self.pending.len();
+        let mut new_sealed: Arc<[MaybeUninit<IndexBlock>]> = Arc::new_uninit_slice(new_len);
+        // Uniquely owned right after allocation — `get_mut` is `Some`.
+        let slots = Arc::get_mut(&mut new_sealed).expect("freshly allocated Arc is uniquely owned");
+        let mut write_idx = 0usize;
+
+        // `sealed`: move each block out via a placeholder swap when unpinned; deep-copy
+        // when a live reader snapshot still shares the region (`Arc<[IndexBlock]>` can't be
+        // `try_unwrap`'d, so `get_mut` gates the move).
+        let mut old_sealed = std::mem::replace(&mut self.sealed, empty_sealed());
+        match Arc::get_mut(&mut old_sealed) {
+            Some(blocks) => {
+                for slot in blocks.iter_mut() {
+                    slots[write_idx].write(std::mem::replace(slot, IndexBlock::new(0)));
+                    write_idx += 1;
+                }
+            }
+            None => {
+                for b in old_sealed.iter() {
+                    slots[write_idx].write(b.clone());
+                    write_idx += 1;
+                }
+            }
+        }
+        drop(old_sealed);
+
+        // `pending`: each block is its own `Arc` — move it out when unique, clone when a
+        // snapshot pins it.
+        for arc in std::mem::take(&mut self.pending) {
+            let block = Arc::try_unwrap(arc).unwrap_or_else(|shared| (*shared).clone());
+            slots[write_idx].write(block);
+            write_idx += 1;
+        }
+
+        debug_assert_eq!(write_idx, new_len, "must fill exactly new_len sealed slots");
+        // SAFETY: the loops wrote exactly `new_len` initialized blocks into slots
+        // `0..new_len`, and `new_sealed` is still uniquely owned (no snapshot taken since
+        // allocation), so promoting the uninit slice is sound.
+        self.sealed = unsafe { new_sealed.assume_init() };
+        freed
     }
 
     /// Returns the last document ID in the index, if any.

--- a/src/redisearch_rs/inverted_index/src/tests/index.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/index.rs
@@ -90,6 +90,57 @@ fn mem_growth_matches_memory_usage_across_rollovers() {
     }
 }
 
+/// A write that folds `pending`→`sealed` reports the bytes it collapsed in `mem_freed`.
+/// The *net* `mem_growth - mem_freed` must still exactly track the `memory_usage()` change
+/// (a fold is a net decrease), so the C-side `spec->stats.invertedSize` accounting stays
+/// correct across folds — not just across plain rollovers.
+#[test]
+fn mem_accounting_matches_memory_usage_across_folds() {
+    /// Encoder that forces a rollover every 2 records, so folds trigger quickly.
+    #[derive(Clone)]
+    struct SmallBlocksDummy;
+
+    impl Encoder for SmallBlocksDummy {
+        type Delta = u32;
+        const RECOMMENDED_BLOCK_ENTRIES: u16 = 2;
+
+        fn encode<W: std::io::Write + std::io::Seek>(
+            mut writer: W,
+            _delta: Self::Delta,
+            _record: &RSIndexResult,
+        ) -> std::io::Result<usize> {
+            writer.write_all(&[1])?;
+            Ok(1)
+        }
+    }
+
+    let mut ii = InvertedIndex::<SmallBlocksDummy>::new(IndexFlags_Index_DocIdsOnly);
+    let mut folds = 0u32;
+    // ~500 records at 2/block => ~250 blocks => multiple geometric folds (at ~64, ~128 …).
+    for doc_id in 1..=500u64 {
+        let before = ii.memory_usage() as i64;
+        let outcome = ii
+            .add_record(&RSIndexResult::build_virt().doc_id(doc_id).build())
+            .unwrap();
+        let after = ii.memory_usage() as i64;
+        if outcome.mem_freed > 0 {
+            folds += 1;
+        }
+        assert_eq!(
+            after - before,
+            outcome.mem_growth as i64 - outcome.mem_freed as i64,
+            "doc_id={doc_id}: net (mem_growth {} - mem_freed {}) must equal memory_usage delta ({})",
+            outcome.mem_growth,
+            outcome.mem_freed,
+            after - before,
+        );
+    }
+    assert!(
+        folds >= 2,
+        "expected multiple pending->sealed folds over 500 records, observed {folds}"
+    );
+}
+
 #[test]
 fn adding_records() {
     let mut ii = InvertedIndex::<Dummy>::new(IndexFlags_Index_DocIdsOnly);

--- a/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
@@ -193,7 +193,7 @@ impl NumericRangeTree {
                     && let Some(range) = internal.range.as_mut()
                 {
                     let outcome = range.add_without_cardinality(doc_id, value);
-                    rv.size_delta += outcome.mem_growth as i64;
+                    rv.size_delta += outcome.mem_growth as i64 - outcome.mem_freed as i64;
                     rv.block_count_delta += outcome.blocks_added as i32;
                     rv.num_records_delta += 1;
                 }
@@ -231,7 +231,7 @@ impl NumericRangeTree {
 
                 let outcome = leaf.range.add(doc_id, value);
                 let mut rv = AddResult {
-                    size_delta: outcome.mem_growth as i64,
+                    size_delta: outcome.mem_growth as i64 - outcome.mem_freed as i64,
                     num_records_delta: 1,
                     changed: false,
                     num_ranges_delta: 0,
@@ -333,7 +333,7 @@ impl NumericRangeTree {
 
             if let Some(target_range) = nodes[target_idx].range_mut() {
                 let outcome = target_range.add(result.doc_id, entry_value);
-                rv.size_delta += outcome.mem_growth as i64;
+                rv.size_delta += outcome.mem_growth as i64 - outcome.mem_freed as i64;
                 rv.block_count_delta += outcome.blocks_added as i32;
             }
             rv.num_records_delta += 1;

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -215,6 +215,10 @@ static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, 
   InvertedIndex *iv = TagIndex_OpenIndex(idx, value, len, CREATE_INDEX, &sz);
   AddRecordOutcome r = InvertedIndex_WriteEntryGeneric(iv, &rec);
   IndexStats_BlockCountAdd(stats, r.blocks_added);
+  // The return only carries growth (added to invertedSize by the caller). If the write
+  // folded pending into sealed, apply the freed bytes here — invertedSize is the running
+  // spec total, always >= this index's freed bytes, so the unsigned subtraction is safe.
+  stats->invertedSize -= r.mem_freed;
   return r.mem_growth + sz;
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** a pure-insert index (no deletes/updates) never triggers fork-GC, so its blocks accumulate forever as scattered per-block `Arc<IndexBlock>` in `pending` — worse read locality and more per-snapshot refcount work than master's single contiguous `Vec`. This is a read regression on load-then-query workloads.
2. **Change:** on block roll-over, fold `pending` into the contiguous `sealed` `Arc<[IndexBlock]>` on a geometric schedule (amortized O(n)). The fold's only expensive step — the per-block copy-on-write clone — fires only when a live reader snapshot pins the region; when nothing pins it (`Arc::strong_count(&sealed) == 1`) the fold is all cheap moves, so it folds more eagerly (¼ of `sealed`) to keep `pending` small; conservative 1× while a snapshot is live. Freed bytes are threaded out via `AddRecordOutcome::mem_freed` so the indexer, tag index, and numeric range tree reconcile the net delta into `spec->stats.invertedSize`.
3. **Outcome:** recovers ~half the pure-insert read regression at zero measurable load-time cost, and reclaims ~half the snapshot's per-block memory tax.

## Numbers (q1 read-only, 5.2M docs, oss-standalone; medians)

| Variant | ops/sec | vs master |
| --- | --- | --- |
| master | 3.83 | — |
| feature, no fold | 3.38 | −13% |
| feature, with fold | 3.6–3.7 | −6% |

cow 50/50 mixed: no throughput penalty under sustained writes. Memory: snapshot inverted-index tax ~+4.5%, fold reclaims ~half (~0.2% of total server memory).

#### Which additional issues this PR fixes
MOD-16150

#### Main objects this PR modified
1. `inverted_index/src/index/core.rs` — `fold_pending_into_sealed`, snapshot-aware fold trigger, `AddRecordOutcome::mem_freed`
2. `indexer.c`, `tag_index.c`, `numeric_range_tree/src/tree/insert.rs` — reconcile `mem_freed` into the size stat
3. `headers/inverted_index.h` — regenerated (`AddRecordOutcome` gains `mem_freed`)
4. `inverted_index/src/tests/index.rs` — accounting-exactness test across folds

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

_(FFI: `AddRecordOutcome` gains a `mem_freed: u32` field — internal Rust↔C struct, no public command surface.)_

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

**Stacked PR.** Base = `jk-ii-block-cache`. Sibling of the experimental lock-free-reads PR (#10349) — decoupled: write-path change, does not depend on the lock-free result-processor work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)