### PR TITLE
[MOD-15868] Avoid CLUSTER SHARDS in SEARCH.CLUSTERREFRESH

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -43,7 +43,10 @@ jobs:
     with:
       platform: 'macos-26,alpine:3.23,intel'
       architecture: all
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      # TODO: revert to `${{ needs.get-latest-redis-tag.outputs.tag }}` once Redis 8.10 is
+      # released. Pinned to a redis/redis unstable commit because the module requires
+      # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any release yet.
+      redis-ref: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
       options: skip-tests,fail-fast
       rejson-branch: master
 
@@ -60,7 +63,10 @@ jobs:
     with:
       platform: ubuntu:noble
       architecture: x86_64
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      # TODO: revert to `${{ needs.get-latest-redis-tag.outputs.tag }}` once Redis 8.10 is
+      # released. Pinned to a redis/redis unstable commit because the module requires
+      # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any release yet.
+      redis-ref: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
       job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
       options: unit-tests,coordinator,standalone,rejson,fail-fast
       separate-coordinator-job: true

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -18,6 +18,9 @@ jobs:
   # Pinned to a redis/redis unstable commit because the module requires
   # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any Redis release yet.
   get-latest-redis-tag:
+    # uses: ./.github/workflows/task-get-latest-tag.yml
+    # with:
+    #   repo: redis/redis
     runs-on: ubuntu-slim
     outputs:
       tag: 3869512c920d4e865b54384bce5fcb6a4e06ae0d

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -14,10 +14,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # TODO: revert to calling task-get-latest-tag.yml once Redis 8.10 is released.
+  # Pinned to a redis/redis unstable commit because the module requires
+  # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any Redis release yet.
   get-latest-redis-tag:
-    uses: ./.github/workflows/task-get-latest-tag.yml
-    with:
-      repo: redis/redis
+    runs-on: ubuntu-slim
+    outputs:
+      tag: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
+    steps:
+      - run: echo "Using pinned redis/redis unstable commit instead of the latest release tag"
 
   lint:
     permissions:
@@ -43,10 +48,7 @@ jobs:
     with:
       platform: 'macos-26,alpine:3.23,intel'
       architecture: all
-      # TODO: revert to `${{ needs.get-latest-redis-tag.outputs.tag }}` once Redis 8.10 is
-      # released. Pinned to a redis/redis unstable commit because the module requires
-      # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any release yet.
-      redis-ref: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       options: skip-tests,fail-fast
       rejson-branch: master
 
@@ -63,10 +65,7 @@ jobs:
     with:
       platform: ubuntu:noble
       architecture: x86_64
-      # TODO: revert to `${{ needs.get-latest-redis-tag.outputs.tag }}` once Redis 8.10 is
-      # released. Pinned to a redis/redis unstable commit because the module requires
-      # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any release yet.
-      redis-ref: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
       options: unit-tests,coordinator,standalone,rejson,fail-fast
       separate-coordinator-job: true

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -155,6 +155,9 @@ jobs:
   get-latest-redis-tag:
     needs: should-run
     if: ${{ needs.should-run.outputs.run-validation == 'true' }}
+    # uses: ./.github/workflows/task-get-latest-tag.yml
+    # with:
+    #   repo: redis/redis
     runs-on: ubuntu-slim
     outputs:
       tag: 3869512c920d4e865b54384bce5fcb6a4e06ae0d

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -169,7 +169,10 @@ jobs:
     with:
       platform: 'ubuntu:noble,macos-26,alpine:3.23,intel'
       architecture: all
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      # TODO: revert to `${{ needs.get-latest-redis-tag.outputs.tag }}` once Redis 8.10 is
+      # released. Pinned to a redis/redis unstable commit because the module requires
+      # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any release yet.
+      redis-ref: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
       job-test-config: '{"test": "", "coverage": "", "sanitize": ""}'
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,sanitize' }}
       rejson-branch: master

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -149,12 +149,17 @@ jobs:
         run: |
           echo "Covered PRs: ${{ steps.check.outputs.covered-prs }}"
 
+  # TODO: revert to calling task-get-latest-tag.yml once Redis 8.10 is released.
+  # Pinned to a redis/redis unstable commit because the module requires
+  # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any Redis release yet.
   get-latest-redis-tag:
     needs: should-run
     if: ${{ needs.should-run.outputs.run-validation == 'true' }}
-    uses: ./.github/workflows/task-get-latest-tag.yml
-    with:
-      repo: redis/redis
+    runs-on: ubuntu-slim
+    outputs:
+      tag: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
+    steps:
+      - run: echo "Using pinned redis/redis unstable commit instead of the latest release tag"
 
   test-selected-platforms:
     needs: [should-run, get-latest-redis-tag]
@@ -169,10 +174,7 @@ jobs:
     with:
       platform: 'ubuntu:noble,macos-26,alpine:3.23,intel'
       architecture: all
-      # TODO: revert to `${{ needs.get-latest-redis-tag.outputs.tag }}` once Redis 8.10 is
-      # released. Pinned to a redis/redis unstable commit because the module requires
-      # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any release yet.
-      redis-ref: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "", "coverage": "", "sanitize": ""}'
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,sanitize' }}
       rejson-branch: master

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -69,7 +69,10 @@ jobs:
     with:
       platform: ubuntu:latest
       architecture: x86_64
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      # TODO: revert to `${{ needs.get-latest-redis-tag.outputs.tag }}` once Redis 8.10 is
+      # released. Pinned to a redis/redis unstable commit because the module requires
+      # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any release yet.
+      redis-ref: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
       test-config: QUICK=1
       coordinator: ${{ matrix.test-mode != 'standalone' }}
       standalone: ${{ matrix.test-mode != 'coordinator' }}

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -11,10 +11,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # TODO: revert to calling task-get-latest-tag.yml once Redis 8.10 is released.
+  # Pinned to a redis/redis unstable commit because the module requires
+  # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any Redis release yet.
   get-latest-redis-tag:
-    uses: ./.github/workflows/task-get-latest-tag.yml
-    with:
-      repo: redis/redis
+    runs-on: ubuntu-slim
+    outputs:
+      tag: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
+    steps:
+      - run: echo "Using pinned redis/redis unstable commit instead of the latest release tag"
 
   check-what-changed:
     uses: ./.github/workflows/task-check-changes.yml
@@ -69,10 +74,7 @@ jobs:
     with:
       platform: ubuntu:latest
       architecture: x86_64
-      # TODO: revert to `${{ needs.get-latest-redis-tag.outputs.tag }}` once Redis 8.10 is
-      # released. Pinned to a redis/redis unstable commit because the module requires
-      # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any release yet.
-      redis-ref: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       test-config: QUICK=1
       coordinator: ${{ matrix.test-mode != 'standalone' }}
       standalone: ${{ matrix.test-mode != 'coordinator' }}

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -15,6 +15,9 @@ jobs:
   # Pinned to a redis/redis unstable commit because the module requires
   # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any Redis release yet.
   get-latest-redis-tag:
+    # uses: ./.github/workflows/task-get-latest-tag.yml
+    # with:
+    #   repo: redis/redis
     runs-on: ubuntu-slim
     outputs:
       tag: 3869512c920d4e865b54384bce5fcb6a4e06ae0d

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           # TAG=$(curl -sL --retry 5 https://api.github.com/repos/redis/redis/releases/latest | jq -er '.tag_name') && \
           # echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "tag=3cd464263b03b425ffae2e23db24df3dc9346871" >> $GITHUB_OUTPUT
+          echo "tag=3869512c920d4e865b54384bce5fcb6a4e06ae0d" >> $GITHUB_OUTPUT
       - name: Generate Beta Version unique identifier
         id: beta-version
         run: |

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -71,7 +71,7 @@ on:
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable", or a commit sha)'
         type: string
-        default: 3cd464263b03b425ffae2e23db24df3dc9346871
+        default: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
       rejson-branch:
         type: string
         default: master

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -21,7 +21,7 @@ on:
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable")'
         type: string
-        default: 3cd464263b03b425ffae2e23db24df3dc9346871
+        default: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
       test-config:
         description: 'Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")'
         required: true

--- a/pack/ramp-community.yml
+++ b/pack/ramp-community.yml
@@ -7,7 +7,10 @@ homepage: http://redisearch.io
 license:  Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
 compatible_redis_version: "99.99"
-min_redis_version: "8.0"
+# Minimal Redis (engine) version. 8.9.80 is the 8.10 pre-release line, the first with
+# RedisModule_GetClusterNodeSlotRanges (MOD-15868). TODO: set to "8.10" once released.
+min_redis_version: "8.9.80"
+# Minimal Redis Enterprise (cluster) version - independent of the engine version above.
 min_redis_pack_version: "8.0"
 config_command: "_FT.CONFIG SET"
 capabilities:

--- a/pack/ramp-community.yml
+++ b/pack/ramp-community.yml
@@ -7,10 +7,7 @@ homepage: http://redisearch.io
 license:  Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
 compatible_redis_version: "99.99"
-# Minimal Redis (engine) version. 8.9.80 is the 8.10 pre-release line, the first with
-# RedisModule_GetClusterNodeSlotRanges (MOD-15868). TODO: set to "8.10" once released.
-min_redis_version: "8.9.80"
-# Minimal Redis Enterprise (cluster) version - independent of the engine version above.
+min_redis_version: "8.9"
 min_redis_pack_version: "8.0"
 config_command: "_FT.CONFIG SET"
 capabilities:

--- a/pack/ramp-community.yml
+++ b/pack/ramp-community.yml
@@ -7,8 +7,8 @@ homepage: http://redisearch.io
 license:  Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
 compatible_redis_version: "99.99"
-min_redis_version: "8.0"
-min_redis_pack_version: "8.0"
+min_redis_version: "8.10"
+min_redis_pack_version: "8.10"
 config_command: "_FT.CONFIG SET"
 capabilities:
     - types

--- a/pack/ramp-community.yml
+++ b/pack/ramp-community.yml
@@ -7,8 +7,8 @@ homepage: http://redisearch.io
 license:  Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
 compatible_redis_version: "99.99"
-min_redis_version: "8.10"
-min_redis_pack_version: "8.10"
+min_redis_version: "8.0"
+min_redis_pack_version: "8.0"
 config_command: "_FT.CONFIG SET"
 capabilities:
     - types

--- a/pack/ramp-enterprise.yml
+++ b/pack/ramp-enterprise.yml
@@ -7,7 +7,10 @@ homepage: 'http://redisearch.io'
 license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
 compatible_redis_version: "99.99"
-min_redis_version: "8.0"
+# Minimal Redis (engine) version. 8.9.80 is the 8.10 pre-release line, the first with
+# RedisModule_GetClusterNodeSlotRanges (MOD-15868). TODO: set to "8.10" once released.
+min_redis_version: "8.9.80"
+# Minimal Redis Enterprise (cluster) version - independent of the engine version above.
 min_redis_pack_version: "8.0"
 config_command: "_FT.CONFIG SET"
 capabilities:

--- a/pack/ramp-enterprise.yml
+++ b/pack/ramp-enterprise.yml
@@ -7,9 +7,9 @@ homepage: 'http://redisearch.io'
 license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
 compatible_redis_version: "99.99"
-# Minimal Redis (engine) version. 8.9.80 is the 8.10 pre-release line, the first with
+# Minimal Redis (engine) version. 8.9 is the 8.10 pre-release line, the first with
 # RedisModule_GetClusterNodeSlotRanges (MOD-15868). TODO: set to "8.10" once released.
-min_redis_version: "8.9.80"
+min_redis_version: "8.9"
 # Minimal Redis Enterprise (cluster) version - independent of the engine version above.
 min_redis_pack_version: "8.0"
 config_command: "_FT.CONFIG SET"

--- a/pack/ramp-enterprise.yml
+++ b/pack/ramp-enterprise.yml
@@ -7,8 +7,8 @@ homepage: 'http://redisearch.io'
 license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
 compatible_redis_version: "99.99"
-min_redis_version: "8.10"
-min_redis_pack_version: "8.10"
+min_redis_version: "8.0"
+min_redis_pack_version: "8.0"
 config_command: "_FT.CONFIG SET"
 capabilities:
     - types

--- a/pack/ramp-enterprise.yml
+++ b/pack/ramp-enterprise.yml
@@ -7,8 +7,8 @@ homepage: 'http://redisearch.io'
 license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
 compatible_redis_version: "99.99"
-min_redis_version: "8.0"
-min_redis_pack_version: "8.0"
+min_redis_version: "8.10"
+min_redis_pack_version: "8.10"
 config_command: "_FT.CONFIG SET"
 capabilities:
     - types

--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -559,12 +559,11 @@ static int checkTLS(RedisModuleString **client_key, RedisModuleString **client_c
   RedisModuleCtx *ctx = RSDummyContext;
   RedisModule_ThreadSafeContextLock(ctx);
 
-  // If `tls-cluster` is not set to `yes`, and `tls-port` is not set or zero,
-  // we do not connect to the other nodes with TLS. We always want to connect with TLS
-  // when the tls-port is set to a non-zero value, since this is the port we
-  // get from the proxy on Enterprise, and the preferred port on OSS (see RedisCluster_GetTopology).
+  // On OSS, the cluster topology module API returns the regular client port
+  // when `tls-cluster` is disabled, even if `tls-port` is also configured.
+  // Enterprise still uses the proxy port and should keep the tls-port fallback.
   if (!getRedisConfigBool(ctx, "tls-cluster", false)) {
-    if (getRedisConfigNumeric(ctx, "tls-port", 0) == 0) {
+    if (!IsEnterprise() || getRedisConfigNumeric(ctx, "tls-port", 0) == 0) {
       ret = 0;
       goto done;
     }

--- a/src/coord/rmr/redis_cluster.c
+++ b/src/coord/rmr/redis_cluster.c
@@ -21,6 +21,7 @@ void UpdateTopology(RedisModuleCtx *ctx) {
   }
 
   const RedisModuleSlotRangeArray *local_slots;
+  RedisModuleSlotRangeArray *local_slots_from_api = NULL;
   if (my_shard_idx != UINT32_MAX) {
     RS_ASSERT(my_shard_idx < topo->numShards);
     MR_SetLocalNodeId(topo->shards[my_shard_idx].node.id);
@@ -29,10 +30,14 @@ void UpdateTopology(RedisModuleCtx *ctx) {
     // Valid topology, but this node is not part of it (e.g. a replica or slot-less master).
     MR_SetLocalNodeId(RedisModule_GetMyClusterID());
     static const RedisModuleSlotRangeArray empty_slots = {0, {{0, 0}}};
-    local_slots = &empty_slots;
+    local_slots_from_api = RedisModule_ClusterGetLocalSlotRanges(ctx);
+    local_slots = local_slots_from_api ?: &empty_slots;
   }
 
   MR_UpdateTopology(topo, local_slots);
+  if (local_slots_from_api) {
+    RedisModule_ClusterFreeSlotRanges(ctx, local_slots_from_api);
+  }
 }
 
 #define REFRESH_PERIOD 1000 // 1 second

--- a/src/coord/rmr/redis_cluster.c
+++ b/src/coord/rmr/redis_cluster.c
@@ -11,241 +11,36 @@
 #include "redismodule.h"
 #include "rmr.h"
 #include "module.h"
-#include "util/strconv.h"
-#include "slot_ranges.h"
-
-#ifndef ENABLE_ASSERT
-#define ASSERT_KEY(reply, idx, expected)
-#else
-#define ASSERT_KEY(reply, idx, expected)                                        \
-  do {                                                                          \
-    RedisModuleCallReply *key = RedisModule_CallReplyArrayElement(reply, idx);  \
-    RS_ASSERT(RedisModule_CallReplyType(key) == REDISMODULE_REPLY_STRING);      \
-    size_t key_len;                                                             \
-    const char *key_str = RedisModule_CallReplyStringPtr(key, &key_len);        \
-    RS_ASSERT(STR_EQ(key_str, key_len, expected));                              \
-  } while (0)
-#endif
-
-static bool parseNode(RedisModuleCallReply *node, MRClusterNode *n) {
-  const size_t len = RedisModule_CallReplyLength(node);
-  RS_ASSERT(len % 2 == 0);
-  char *id = NULL;
-  char *host = NULL;
-  int port = 0; // Use 0 to indicate "not set"
-
-  for (size_t i = 0; i < len / 2; i++) {
-    size_t key_len, val_len;
-    RedisModuleCallReply *key = RedisModule_CallReplyArrayElement(node, i * 2);
-    const char *key_str = RedisModule_CallReplyStringPtr(key, &key_len);
-    RedisModuleCallReply *val = RedisModule_CallReplyArrayElement(node, i * 2 + 1);
-
-    if (STR_EQ(key_str, key_len, "id")) {
-      const char *val_str = RedisModule_CallReplyStringPtr(val, &val_len);
-      if (val_str && val_len == REDISMODULE_NODE_ID_LEN) {
-        id = rm_strndup(val_str, REDISMODULE_NODE_ID_LEN);
-      }
-    } else if (STR_EQ(key_str, key_len, "endpoint")) {
-      const char *val_str = RedisModule_CallReplyStringPtr(val, &val_len);
-      if (val_str && !STR_EQ(val_str, val_len, "") && !STR_EQ(val_str, val_len, "?")) {
-        host = rm_strndup(val_str, val_len);
-      }
-    } else if (STR_EQ(key_str, key_len, "tls-port")) {
-      int port_val = (int)RedisModule_CallReplyInteger(val);
-      if (port_val > 0) {
-        port = port_val; // Prefer tls-port if available (but only if valid)
-      }
-    } else if (STR_EQ(key_str, key_len, "port") && port == 0) {
-      int port_val = (int)RedisModule_CallReplyInteger(val);
-      if (port_val > 0) {
-        port = port_val; // Only set if tls-port wasn't set and port is valid
-      }
-    }
-  }
-  // Verify we have the required fields
-  if (id && host && port > 0) {
-    n->id = id;
-    n->endpoint.host = host;
-    n->endpoint.port = port;
-    return true;
-  }
-
-  // Invalid node. Cleanup and return `false`
-  rm_free(id);
-  rm_free(host);
-  return false;
-}
-
-static bool parseMasterNode(RedisModuleCallReply *nodes, MRClusterNode *n) {
-  const size_t numNodes = RedisModule_CallReplyLength(nodes);
-
-  for (size_t i = 0; i < numNodes; i++) {
-    RedisModuleCallReply *node = RedisModule_CallReplyArrayElement(nodes, i);
-    RS_ASSERT(RedisModule_CallReplyType(node) == REDISMODULE_REPLY_ARRAY);
-    size_t node_len = RedisModule_CallReplyLength(node);
-    RS_ASSERT(node_len % 2 == 0);
-
-    // Find the "role" key
-    size_t j = 0;
-    for (; j < node_len; j += 2) {
-      RedisModuleCallReply *key = RedisModule_CallReplyArrayElement(node, j);
-      RS_ASSERT(RedisModule_CallReplyType(key) == REDISMODULE_REPLY_STRING);
-      size_t key_len;
-      const char *key_str = RedisModule_CallReplyStringPtr(key, &key_len);
-      if (STR_EQ(key_str, key_len, "role")) {
-        break;
-      }
-    }
-    // Check if this is a master node
-    ASSERT_KEY(node, j, "role");
-    RedisModuleCallReply *val = RedisModule_CallReplyArrayElement(node, j + 1);
-    size_t val_len;
-    const char *val_str = RedisModule_CallReplyStringPtr(val, &val_len);
-    if (STR_EQ(val_str, val_len, "master")) {
-      if (parseNode(node, n)) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-static bool parseSlots(RedisModuleCallReply *slots, MRClusterShard *sh) {
-  size_t len = RedisModule_CallReplyLength(slots);
-  RS_ASSERT(len % 2 == 0);
-  if (!len) return false;
-  size_t buffer_size = SlotRangeArray_SizeOf(len / 2);
-  sh->slotRanges = rm_malloc(buffer_size);
-  sh->slotRanges->num_ranges = (int32_t)(len / 2);
-  for (size_t r = 0; r < sh->slotRanges->num_ranges; r++) {
-    sh->slotRanges->ranges[r].start = RedisModule_CallReplyInteger(RedisModule_CallReplyArrayElement(slots, r * 2));
-    sh->slotRanges->ranges[r].end = RedisModule_CallReplyInteger(RedisModule_CallReplyArrayElement(slots, r * 2 + 1));
-  }
-  return true;
-}
-
-static bool hasSlots(RedisModuleCallReply *shard) {
-  ASSERT_KEY(shard, 0, "slots");
-  RedisModuleCallReply *slots = RedisModule_CallReplyArrayElement(shard, 1);
-  RS_ASSERT(RedisModule_CallReplyType(slots) == REDISMODULE_REPLY_ARRAY);
-  return RedisModule_CallReplyLength(slots) > 0;
-}
-
-// Assumes auto memory was enabled on ctx
-static MRClusterTopology *RedisCluster_GetTopology(RedisModuleCtx *ctx) {
-
-  RedisModuleCallReply *cluster_shards = RedisModule_Call(ctx, "CLUSTER", "c", "SHARDS");
-  if (cluster_shards == NULL || RedisModule_CallReplyType(cluster_shards) != REDISMODULE_REPLY_ARRAY) {
-    RedisModule_Log(ctx, "warning", "Error calling CLUSTER SHARDS");
-    return NULL;
-  }
-  /*
-1) 1# "slots" =>
-      1) (integer) 0
-      2) (integer) 4095
-      3) (integer) 8192
-      4) (integer) 12287
-   2# "nodes" =>
-      1)  1# "id" => "e10b7051d6bf2d5febd39a2be297bbaea6084111"
-          2# "port" => (integer) 30001
-          3# "tls-port" => (integer) 40001
-          4# "ip" => "127.0.0.1"
-          5# "endpoint" => "localhost"
-          6# "role" => "master"
-      2)  1# "id" => "821d8ca00d7ccf931ed3ffc7e3db0599d2271abf"
-          2# "port" => (integer) 30004
-          3# "tls-port" => (integer) 40004
-          4# "ip" => "127.0.0.1"
-          5# "endpoint" => "localhost"
-          6# "role" => "replica"
-2) 1# "slots" =>
-      1) (integer) 4096
-      2) (integer) 8191
-      3) (integer) 12288
-      4) (integer) 16383
-   2# "nodes" =>
-      1)  1# "id" => "fd20502fe1b32fc32c15b69b0a9537551f162f1f"
-          2# "port" => (integer) 30003
-          3# "tls-port" => (integer) 40003
-          4# "ip" => "127.0.0.1"
-          5# "endpoint" => "localhost"
-          6# "role" => "master"
-      2)  1# "id" => "6daa25c08025a0c7e4cc0d1ab255949ce6cee902"
-          2# "port" => (integer) 30005
-          3# "tls-port" => (integer) 40005
-          4# "ip" => "127.0.0.1"
-          5# "endpoint" => "localhost"
-          6# "role" => "replica"
-  */
-
-  size_t numShards = RedisModule_CallReplyLength(cluster_shards);
-  if (numShards == 0 || (numShards == 1 && !hasSlots(RedisModule_CallReplyArrayElement(cluster_shards, 0)))) {
-    RedisModule_Log(ctx, "warning", "Got no valid shards in CLUSTER SHARDS");
-    return NULL;
-  }
-
-  MRClusterTopology *topo = rm_calloc(1, sizeof(MRClusterTopology));
-  topo->shards = rm_calloc(numShards, sizeof(MRClusterShard));
-
-  // Parse each shard, filter badly formatted or not ready shards
-  // A shard is valid if:
-  // 1. It has some slots associated with
-  // 2. It has a valid master node with a valid endpoint:
-  //    i. Valid node id
-  //   ii. Non-zero port
-  //  iii. Valid endpoint (not missing or a special invalid value)
-  for (size_t i = 0; i < numShards; i++) {
-    RedisModuleCallReply *currShard = RedisModule_CallReplyArrayElement(cluster_shards, i);
-    RS_ASSERT(RedisModule_CallReplyType(currShard) == REDISMODULE_REPLY_ARRAY);
-    RS_ASSERT(RedisModule_CallReplyLength(currShard) == 4); // We expect 4 elements: "slots", <array>, "nodes", <array>
-
-    // Handle slots
-    ASSERT_KEY(currShard, 0, "slots");
-    RedisModuleCallReply *slots = RedisModule_CallReplyArrayElement(currShard, 1);
-    if (!parseSlots(slots, &topo->shards[topo->numShards])) continue;
-
-    // Handle nodes
-    ASSERT_KEY(currShard, 2, "nodes");
-    RedisModuleCallReply *nodes = RedisModule_CallReplyArrayElement(currShard, 3);
-    RS_ASSERT(RedisModule_CallReplyType(nodes) == REDISMODULE_REPLY_ARRAY);
-    // parse and store the master
-    if (!parseMasterNode(nodes, &topo->shards[topo->numShards].node)) {
-      rm_free(topo->shards[topo->numShards].slotRanges);
-      continue;
-    }
-    // Successfully parsed this shard
-    topo->numShards++;
-  }
-
-  if (!topo->numShards) {
-    RedisModule_Log(ctx, "warning", "Got no valid shards in CLUSTER SHARDS");
-    rm_free(topo->shards);
-    rm_free(topo);
-    return NULL;
-  }
-
-  return topo;
-}
 
 void UpdateTopology(RedisModuleCtx *ctx) {
   RS_AutoMemory(ctx);
-  MRClusterTopology *topo = RedisCluster_GetTopology(ctx);
-  if (topo) { // if we didn't get a topology, do nothing. Log was already printed
-
-    // Store the local shard id
-    MR_SetLocalNodeId(RedisModule_GetMyClusterID());
-
-    // Pass the local slots info directly from the RedisModule API, as we enabled auto memory
-    MR_UpdateTopology(topo, RedisModule_ClusterGetLocalSlotRanges(ctx));
+  uint32_t my_shard_idx = UINT32_MAX;
+  MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, NULL, 0, &my_shard_idx);
+  if (!topo) {
+    // If we didn't get a topology, do nothing. MRClusterTopology_FromAPI logged the reason.
+    return;
   }
+
+  if (my_shard_idx != UINT32_MAX) {
+    RS_ASSERT(my_shard_idx < topo->numShards);
+    MR_SetLocalNodeId(topo->shards[my_shard_idx].node.id);
+    MR_UpdateTopology(topo, topo->shards[my_shard_idx].slotRanges);
+    return;
+  }
+
+  // Valid topology, but this node is not part of it (e.g. a replica or slot-less master).
+  MR_SetLocalNodeId(RedisModule_GetMyClusterID());
+  static const RedisModuleSlotRangeArray empty_slots = {0, {{0, 0}}};
+  MR_UpdateTopology(topo, &empty_slots);
 }
 
-#define REFRESH_PERIOD 1000 // 1 second
+#define REFRESH_PERIOD 1000  // 1 second
 RedisModuleTimerID topologyRefreshTimer = 0;
 
 static void UpdateTopology_Periodic(RedisModuleCtx *ctx, void *p) {
   REDISMODULE_NOT_USED(p);
-  topologyRefreshTimer = RedisModule_CreateTimer(ctx, REFRESH_PERIOD, UpdateTopology_Periodic, NULL);
+  topologyRefreshTimer =
+      RedisModule_CreateTimer(ctx, REFRESH_PERIOD, UpdateTopology_Periodic, NULL);
   UpdateTopology(ctx);
 }
 
@@ -256,12 +51,14 @@ void RedisTopologyUpdater_StopAndRescheduleImmediately(RedisModuleCtx *ctx) {
 
 int InitRedisTopologyUpdater(RedisModuleCtx *ctx) {
   if (topologyRefreshTimer || clusterConfig.type != ClusterType_RedisOSS) return REDISMODULE_ERR;
-  topologyRefreshTimer = RedisModule_CreateTimer(ctx, REFRESH_PERIOD, UpdateTopology_Periodic, NULL);
+  topologyRefreshTimer =
+      RedisModule_CreateTimer(ctx, REFRESH_PERIOD, UpdateTopology_Periodic, NULL);
   return REDISMODULE_OK;
 }
 
 int StopRedisTopologyUpdater(RedisModuleCtx *ctx) {
   int rc = RedisModule_StopTimer(ctx, topologyRefreshTimer, NULL);
   topologyRefreshTimer = 0;
-  return rc; // OK if we stopped the timer, ERR if it was already stopped (or never started - enterprise)
+  return rc;  // OK if we stopped the timer, ERR if it was already stopped (or never started -
+              // enterprise)
 }

--- a/src/coord/rmr/redis_cluster.c
+++ b/src/coord/rmr/redis_cluster.c
@@ -20,7 +20,8 @@ void UpdateTopology(RedisModuleCtx *ctx) {
     return;
   }
 
-  const RedisModuleSlotRangeArray *local_slots;
+  static const RedisModuleSlotRangeArray empty_slots = {0, {{0, 0}}};
+  const RedisModuleSlotRangeArray *local_slots = &empty_slots;
   RedisModuleSlotRangeArray *local_slots_from_api = NULL;
   if (my_shard_idx != UINT32_MAX) {
     RS_ASSERT(my_shard_idx < topo->numShards);
@@ -29,9 +30,10 @@ void UpdateTopology(RedisModuleCtx *ctx) {
   } else {
     // Valid topology, but this node is not part of it (e.g. a replica or slot-less master).
     MR_SetLocalNodeId(RedisModule_GetMyClusterID());
-    static const RedisModuleSlotRangeArray empty_slots = {0, {{0, 0}}};
     local_slots_from_api = RedisModule_ClusterGetLocalSlotRanges(ctx);
-    local_slots = local_slots_from_api ?: &empty_slots;
+    if (local_slots_from_api) {
+      local_slots = local_slots_from_api;
+    }
   }
 
   MR_UpdateTopology(topo, local_slots);

--- a/src/coord/rmr/redis_cluster.c
+++ b/src/coord/rmr/redis_cluster.c
@@ -21,26 +21,27 @@ void UpdateTopology(RedisModuleCtx *ctx) {
     return;
   }
 
+  const RedisModuleSlotRangeArray *local_slots;
   if (my_shard_idx != UINT32_MAX) {
     RS_ASSERT(my_shard_idx < topo->numShards);
     MR_SetLocalNodeId(topo->shards[my_shard_idx].node.id);
-    MR_UpdateTopology(topo, topo->shards[my_shard_idx].slotRanges);
-    return;
+    local_slots = topo->shards[my_shard_idx].slotRanges;
+  } else {
+    // Valid topology, but this node is not part of it (e.g. a replica or slot-less master).
+    MR_SetLocalNodeId(RedisModule_GetMyClusterID());
+    static const RedisModuleSlotRangeArray empty_slots = {0, {{0, 0}}};
+    local_slots = &empty_slots;
   }
 
-  // Valid topology, but this node is not part of it (e.g. a replica or slot-less master).
-  MR_SetLocalNodeId(RedisModule_GetMyClusterID());
-  static const RedisModuleSlotRangeArray empty_slots = {0, {{0, 0}}};
-  MR_UpdateTopology(topo, &empty_slots);
+  MR_UpdateTopology(topo, local_slots);
 }
 
-#define REFRESH_PERIOD 1000  // 1 second
+#define REFRESH_PERIOD 1000 // 1 second
 RedisModuleTimerID topologyRefreshTimer = 0;
 
 static void UpdateTopology_Periodic(RedisModuleCtx *ctx, void *p) {
   REDISMODULE_NOT_USED(p);
-  topologyRefreshTimer =
-      RedisModule_CreateTimer(ctx, REFRESH_PERIOD, UpdateTopology_Periodic, NULL);
+  topologyRefreshTimer = RedisModule_CreateTimer(ctx, REFRESH_PERIOD, UpdateTopology_Periodic, NULL);
   UpdateTopology(ctx);
 }
 
@@ -51,14 +52,12 @@ void RedisTopologyUpdater_StopAndRescheduleImmediately(RedisModuleCtx *ctx) {
 
 int InitRedisTopologyUpdater(RedisModuleCtx *ctx) {
   if (topologyRefreshTimer || clusterConfig.type != ClusterType_RedisOSS) return REDISMODULE_ERR;
-  topologyRefreshTimer =
-      RedisModule_CreateTimer(ctx, REFRESH_PERIOD, UpdateTopology_Periodic, NULL);
+  topologyRefreshTimer = RedisModule_CreateTimer(ctx, REFRESH_PERIOD, UpdateTopology_Periodic, NULL);
   return REDISMODULE_OK;
 }
 
 int StopRedisTopologyUpdater(RedisModuleCtx *ctx) {
   int rc = RedisModule_StopTimer(ctx, topologyRefreshTimer, NULL);
   topologyRefreshTimer = 0;
-  return rc;  // OK if we stopped the timer, ERR if it was already stopped (or never started -
-              // enterprise)
+  return rc; // OK if we stopped the timer, ERR if it was already stopped (or never started - enterprise)
 }

--- a/src/coord/rmr/redis_cluster.c
+++ b/src/coord/rmr/redis_cluster.c
@@ -13,7 +13,6 @@
 #include "module.h"
 
 void UpdateTopology(RedisModuleCtx *ctx) {
-  RS_AutoMemory(ctx);
   uint32_t my_shard_idx = UINT32_MAX;
   MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, NULL, 0, &my_shard_idx);
   if (!topo) {

--- a/src/module.c
+++ b/src/module.c
@@ -1299,8 +1299,8 @@ int RegisterRestoreIfNxCommands(RedisModuleCtx *ctx, RedisModuleCommand *restore
 
 Version supportedVersion = {
     .majorVersion = 8,
-    .minorVersion = 10,
-    .patchVersion = 0,
+    .minorVersion = 9,
+    .patchVersion = 80,
 };
 
 static void GetRedisVersion(RedisModuleCtx *ctx) {

--- a/src/module.c
+++ b/src/module.c
@@ -1299,7 +1299,7 @@ int RegisterRestoreIfNxCommands(RedisModuleCtx *ctx, RedisModuleCommand *restore
 
 Version supportedVersion = {
     .majorVersion = 8,
-    .minorVersion = 4,
+    .minorVersion = 10,
     .patchVersion = 0,
 };
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4702,14 +4702,14 @@ def test_dual_tls():
             env.assertContains('tls-port', node)
             env.assertNotEqual(node['port'], node['tls-port'], message=node)
 
-    # Verify we choose the tls-port when we have both
+    # Verify we choose the regular port when tls-cluster is disabled, even when tls-port exists.
     our_info = [to_dict(node) for node in to_dict(env.cmd('SEARCH.CLUSTERINFO'))['shards']]
     for node in our_info:
         env.assertContains(node['id'], node_to_info)
         redis_node = node_to_info[node['id']]
-        env.assertEqual(node['port'], redis_node['tls-port'])
+        env.assertEqual(node['port'], redis_node['port'])
 
-    # Verify we manage to create an index (connecting to all other nodes with tls)
+    # Verify we manage to create an index (connecting to all other nodes without TLS)
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
     for conn in env.getOSSMasterNodesConnectionList():
         env.assertEqual(conn.execute_command('FT._LIST'), ['idx'])


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: `SEARCH.CLUSTERREFRESH` refreshes Redis OSS cluster topology by issuing and parsing `CLUSTER SHARDS` directly.
2. Change: Route the refresh path through the shared `MRClusterTopology_FromAPI` parser and use the parsed local shard slots when updating coordinator topology.
3. Outcome: `SEARCH.CLUSTERREFRESH` no longer depends on `CLUSTER SHARDS` parsing and shares topology parsing behavior with the module API based path.

#### Which additional issues this PR fixes
1. MOD-15868

#### Main objects this PR modified
1. `src/coord/rmr/redis_cluster.c`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

#### Validation

- `./build.sh RUN_UNIT_TESTS TEST=rstest_coord` built unit test artifacts; the wrapper skipped direct test execution for this filter.
- `bin/linux-x64-release/search-community/tests/cpptests/coord_tests/rstest_coord --gtest_filter="ClusterTopologyFromAPITest.*"`
- `bin/linux-x64-release/search-community/tests/cpptests/coord_tests/rstest_coord`