### PR TITLE
Update agent worktree location guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,7 +280,7 @@ branch for the task.
 Always use `-b` when creating a worktree — git forbids two worktrees on the same branch, so checking out `master` directly will fail when master is already the main checkout. Prefix the branch with your handle (e.g. `alice-`, `bob-`) to avoid collisions on the shared remote. Pass `--no-track` so the new branch does not inherit `origin/master` as its upstream — otherwise a later `git push --force` without an explicit target can try to force-push the feature branch onto master:
 
 ```bash
-git worktree add --no-track -b <your-handle>-<feature> .claude/worktrees/<your-handle>-<feature> origin/master
+git worktree add --no-track -b <your-handle>-<feature> .worktree/<your-handle>-<feature> origin/master
 ```
 
 To remove a worktree, use `git worktree remove --force <path>` (plain `remove` fails on initialized submodules).


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: Agent instructions tell contributors to create dedicated worktrees under `.claude/worktrees/`.
2. Change: Update the documented worktree example to use `.worktree/<your-handle>-<feature>`.
3. Outcome: New agent-created worktrees follow the repository-local `.worktree/` convention.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. `AGENTS.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
