### PR TITLE
SearchEnterpriseIterators: use Rust types directly

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -25,7 +25,7 @@ use ref_mode::{Active, Ref};
 use rqe_core::{DocId, FieldIndex};
 use thiserror::Error;
 
-use ::inverted_index::FieldMask;
+use ::inverted_index::{FieldMask, NumericFilter};
 use index_result::{RSIndexResult, RawIndexResult};
 pub use query_error::QueryError;
 use query_term::RSQueryTerm;
@@ -366,8 +366,8 @@ pub trait SearchEnterpriseIterators: Send + Sync {
     fn new_numeric_on_disk<'index>(
         &self,
         index: &'index mut ffi::RedisSearchDiskIndexSpec,
-        filter: &ffi::NumericFilter,
-        field_index: ffi::t_fieldIndex,
+        filter: &NumericFilter,
+        field_index: FieldIndex,
         snapshot: NonNull<ffi::RedisSearchDiskSnapshot>,
     ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>>;
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_enterprise_iterators.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_enterprise_iterators.rs
@@ -14,6 +14,7 @@
 //! test suite to exercise code paths that depend on [`SEARCH_ENTERPRISE_ITERATORS`]
 //! without requiring the actual enterprise implementation.
 
+use inverted_index::NumericFilter;
 use rqe_core::{DocId, FieldIndex};
 use rqe_iterators::{
     QueryError, RQEIteratorPrintable, SEARCH_ENTERPRISE_ITERATORS, SearchEnterpriseIterators,
@@ -87,8 +88,8 @@ impl SearchEnterpriseIterators for MockEnterpriseIterators {
     fn new_numeric_on_disk<'index>(
         &self,
         _index: &'index mut ffi::RedisSearchDiskIndexSpec,
-        _filter: &ffi::NumericFilter,
-        _field_index: ffi::t_fieldIndex,
+        _filter: &NumericFilter,
+        _field_index: FieldIndex,
         _snapshot: std::ptr::NonNull<ffi::RedisSearchDiskSnapshot>,
     ) -> Result<Box<dyn RQEIteratorPrintable<'index> + 'index>, Box<dyn std::error::Error>> {
         unimplemented!("MockEnterpriseIterators::new_numeric_on_disk not used in these tests")


### PR DESCRIPTION
No point using pure Rust types through ffi.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
