### PR TITLE
Drop phantom 'req lifetime from AnyTimeoutContext / TimeoutContextBlockedClient

### DIFF
--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -24,9 +24,9 @@ use rqe_iterators::{
     },
 };
 
-type NotFfi<'index> = Not<'index, CRQEIterator, AnyTimeoutContext<'index>>;
+type NotFfi<'index> = Not<'index, CRQEIterator, AnyTimeoutContext>;
 type NotOptimizedFfi<'index> =
-    NotOptimized<'index, NewWildcardIterator<'index>, CRQEIterator, AnyTimeoutContext<'index>>;
+    NotOptimized<'index, NewWildcardIterator<'index>, CRQEIterator, AnyTimeoutContext>;
 
 /// Enum holding both NOT iterator variants with concrete [`CRQEIterator`] child.
 ///
@@ -169,12 +169,12 @@ impl<'index> rqe_iterators::interop::ProfileChildren<'index> for NotIteratorEnum
 /// Caller must guarantee `q` and `q.sctx` are valid (FFI preconditions
 /// 3 and 4 of [`NewNotIterator()`]). When `bc_timeout_areq` is non-null, it
 /// must uphold the [`TimeoutContextBlockedClient::new`] safety contract for
-/// the lifetime of the returned context.
-unsafe fn build_timeout_context<'req>(
+/// as long as the returned context (and any iterator built from it) is used.
+unsafe fn build_timeout_context(
     timeout: timespec,
     bc_timeout_areq: *mut AREQ,
     q: NonNull<ffi::QueryEvalCtx>,
-) -> AnyTimeoutContext<'req> {
+) -> AnyTimeoutContext {
     match NonNull::new(bc_timeout_areq) {
         Some(areq) => {
             // SAFETY: caller guarantees `areq` upholds the

--- a/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
@@ -222,20 +222,35 @@ impl QueryEvalContext {
     /// flag. Otherwise the Clock Based Timeout (or [`NoTimeout`], when timeout
     /// checks are skipped or no deadline is set) is derived from `sctx.time`.
     ///
-    /// The returned [`AnyTimeoutContext`] borrows `self`: its `'_` lifetime ties
-    /// it (and any iterator built from it) to this wrapper, so it cannot outlive
-    /// the context.
+    /// The returned [`AnyTimeoutContext`] is `'static`: when a Blocked Client
+    /// Timeout is wired in it holds the `AREQ` as a raw pointer, not a borrow, so
+    /// the type system no longer ties it to the request. That validity is now a
+    /// runtime precondition (see below), which is why this method is `unsafe`.
+    ///
+    /// # Safety
+    ///
+    /// The returned context, and any iterator built from it, must not be used
+    /// after the `AREQ` behind `bcTimeoutAreq` is freed.
+    ///
+    /// A Blocked Client Timeout context holds that `AREQ` as a raw pointer with
+    /// no lifetime, so nothing enforces the precondition at compile time:
+    /// probing the context calls [`AREQ_CheckTimedOut`](ffi::AREQ_CheckTimedOut)
+    /// on the stored pointer. For a [`QueryEvalContext`] built through
+    /// [`new`](Self::new), invariant (2) already guarantees `bcTimeoutAreq`
+    /// outlives every timeout context and iterator derived from it, so the
+    /// caller discharges the precondition simply by not retaining the returned
+    /// context beyond the current query. See [`TimeoutContextBlockedClient::new`].
     ///
     /// [`NoTimeout`]: rqe_iterators::utils::NoTimeout
-    pub fn build_timeout_context(&self) -> AnyTimeoutContext<'_> {
+    pub unsafe fn build_timeout_context(&self) -> AnyTimeoutContext {
         match NonNull::new(self.as_ref().bcTimeoutAreq) {
             Some(areq) => {
                 // SAFETY: invariant (2) of `new` guarantees a non-null
                 // `bcTimeoutAreq` points to a valid `AREQ` that outlives every
-                // iterator built from this context. The returned context borrows
-                // `self`, so its lifetime cannot exceed that of `self` (and hence
-                // of the `AREQ`), satisfying the `TimeoutContextBlockedClient::new`
-                // contract that `'req` not outlive the request.
+                // iterator built from this context; this method's own safety
+                // contract requires the caller not to use the returned context
+                // past that window — together they satisfy the
+                // `TimeoutContextBlockedClient::new` contract.
                 let timeout = unsafe { TimeoutContextBlockedClient::new(areq) };
                 AnyTimeoutContext::BlockedClient(timeout)
             }

--- a/src/redisearch_rs/c_wrappers/query/tests/integration/query_eval_ctx/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/tests/integration/query_eval_ctx/mod.rs
@@ -132,10 +132,10 @@ fn build_timeout_context_without_blocked_client_uses_sctx() {
     let mut mock = MockQueryEvalCtx::new();
     let ctx = unsafe { QueryEvalContext::new(mock.as_non_null()) };
 
-    assert!(matches!(
-        ctx.build_timeout_context(),
-        AnyTimeoutContext::Clock(_)
-    ));
+    // SAFETY: `mock` (and its AREQ, if any) outlives the returned context, which
+    // is dropped at the end of the assertion — never used past the AREQ.
+    let timeout = unsafe { ctx.build_timeout_context() };
+    assert!(matches!(timeout, AnyTimeoutContext::Clock(_)));
 }
 
 #[test]
@@ -146,8 +146,8 @@ fn build_timeout_context_prefers_blocked_client_when_wired() {
     mock.enable_blocked_client_timeout();
     let ctx = unsafe { QueryEvalContext::new(mock.as_non_null()) };
 
-    assert!(matches!(
-        ctx.build_timeout_context(),
-        AnyTimeoutContext::BlockedClient(_)
-    ));
+    // SAFETY: `mock`'s AREQ outlives the returned context, which is dropped at
+    // the end of the assertion — never used past the AREQ.
+    let timeout = unsafe { ctx.build_timeout_context() };
+    assert!(matches!(timeout, AnyTimeoutContext::BlockedClient(_)));
 }

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -422,6 +422,12 @@ fn eval_not<'index>(ctx: &'index mut QueryEvalContext, node: &QueryNodeRef) -> E
     let child = eval_child_iterator(ctx, &child_node);
     ctx.set_in_not_sub_tree(prev_in_not_sub_tree);
 
+    // SAFETY: invariant (2) of `QueryEvalContext::new` guarantees `bcTimeoutAreq`
+    // outlives every timeout context derived from `ctx`, and the returned context
+    // is handed straight to `new_not_iterator` below (never retained past this
+    // query), so it cannot be used after the `AREQ` is freed.
+    let timeout_ctx = unsafe { ctx.build_timeout_context() };
+
     // SAFETY: the preconditions of `new_not_iterator` map to
     // `QueryEvalContext::new` invariants:
     // 1. `query` is a valid, non-null `QueryEvalCtx` — invariant (1).
@@ -437,7 +443,7 @@ fn eval_not<'index>(ctx: &'index mut QueryEvalContext, node: &QueryNodeRef) -> E
             child,
             ctx.max_doc_id(),
             node.opts().weight,
-            ctx.build_timeout_context(),
+            timeout_ctx,
             ctx.as_non_null(),
         )
     };

--- a/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
@@ -8,7 +8,6 @@
 */
 
 use std::{
-    marker::PhantomData,
     ptr::NonNull,
     time::{Duration, Instant},
 };
@@ -118,39 +117,35 @@ impl TimeoutContext for TimeoutContextClock {
 /// in the same order of magnitude as a counter bump, and avoiding the
 /// counter keeps the hot path branch-free.
 ///
-/// The `'req` lifetime tracks the borrow of the [`AREQ`] this context probes,
-/// so the type system prevents the context (and any iterator holding it) from
-/// outliving the request.
-pub struct TimeoutContextBlockedClient<'req> {
+/// The [`AREQ`] is held as a raw [`NonNull`] pointer with no lifetime: like the
+/// rest of the query-iterator tree (see the "phantom `'index`" note on
+/// `RQEIteratorWrapper`), the context does not model the borrow in the type
+/// system. Keeping the request valid for as long as the context is used is a
+/// runtime invariant the caller upholds, documented on [`new`](Self::new).
+pub struct TimeoutContextBlockedClient {
     /// [`AREQ`] pointer forwarded verbatim to [`AREQ_CheckTimedOut`].
     areq: NonNull<AREQ>,
-    /// Ties the context to the borrow of the [`AREQ`] it points at.
-    _areq: PhantomData<&'req AREQ>,
 }
 
-impl<'req> TimeoutContextBlockedClient<'req> {
+impl TimeoutContextBlockedClient {
     /// Build a new context wrapping `areq`.
     ///
     /// # Safety
     ///
     /// * `areq` must point to a valid [`AREQ`] (as defined in
-    ///   `src/aggregate/aggregate.h`) for the whole of `'req`.
-    /// * The caller must pick `'req` so that it does not outlive the [`AREQ`];
-    ///   since `'req` is otherwise unconstrained by the arguments, it is the
-    ///   caller's responsibility to bound it (e.g. by tying the returned
-    ///   context to a borrow that the request outlives).
+    ///   `src/aggregate/aggregate.h`) for as long as this context (and any
+    ///   iterator holding it) is used. The pointer is stored without a
+    ///   lifetime, so the caller is fully responsible for not using the context
+    ///   past the [`AREQ`]'s lifetime.
     /// * The `RequestSyncCtx::timedOut` flag inside the [`AREQ`] must be safe
     ///   to read with relaxed semantics from any thread.
     #[inline(always)]
     pub const unsafe fn new(areq: NonNull<AREQ>) -> Self {
-        Self {
-            areq,
-            _areq: PhantomData,
-        }
+        Self { areq }
     }
 }
 
-impl TimeoutContext for TimeoutContextBlockedClient<'_> {
+impl TimeoutContext for TimeoutContextBlockedClient {
     /// Probe the AREQ timed-out flag via [`AREQ_CheckTimedOut`] and translate
     /// its `bool` reply into the iterator-level [`Result`].
     #[inline(always)]
@@ -192,19 +187,21 @@ impl TimeoutContext for NoTimeout {
 ///
 /// [`check_timeout`]: TimeoutContext::check_timeout
 ///
-/// The `'req` lifetime is carried by the [`BlockedClient`](Self::BlockedClient)
-/// variant (the other two borrow nothing) and ties the context to the [`AREQ`]
-/// it probes, so it cannot outlive the request.
-pub enum AnyTimeoutContext<'req> {
+/// The [`BlockedClient`](Self::BlockedClient) variant holds its [`AREQ`] as a
+/// raw pointer with no lifetime (see [`TimeoutContextBlockedClient`]); the other
+/// two borrow nothing. The type is therefore `'static`, and keeping the request
+/// alive while the context is used is a runtime invariant its constructor
+/// documents.
+pub enum AnyTimeoutContext {
     /// No timeout source: every probe is a no-op.
     NoTimeout(NoTimeout),
     /// Clock Based Timeout: amortized clock check.
     Clock(TimeoutContextClock),
     /// Blocked Client Timeout: relaxed atomic load against the AREQ flag.
-    BlockedClient(TimeoutContextBlockedClient<'req>),
+    BlockedClient(TimeoutContextBlockedClient),
 }
 
-impl<'req> AnyTimeoutContext<'req> {
+impl AnyTimeoutContext {
     /// Builds the timeout context from a search context's time settings.
     ///
     /// `skipTimeoutChecks` (or the absence of a deadline) opts out of timeout
@@ -224,7 +221,7 @@ impl<'req> AnyTimeoutContext<'req> {
     }
 }
 
-impl TimeoutContext for AnyTimeoutContext<'_> {
+impl TimeoutContext for AnyTimeoutContext {
     #[inline(always)]
     fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
         match self {


### PR DESCRIPTION
## Describe the changes in the pull request

It causes issues when implementing sound iterator revalidation, since we can't hold lifetimes in suspended variants.
The machinery may be later generalized to support it, but for now it's easier to just drop it.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
