### PR TITLE
[MOD-14988] TagIndex crate scaffolding

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2883,6 +2883,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tag_index"
+version = "0.0.1"
+dependencies = [
+ "ffi",
+ "index_result",
+ "inverted_index",
+ "proptest",
+ "thin_vec",
+ "trie_rs",
+ "workspace_hack",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2886,6 +2886,7 @@ dependencies = [
 name = "tag_index"
 version = "0.0.1"
 dependencies = [
+ "ffi",
  "inverted_index",
  "thin_vec",
  "trie_rs",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2886,10 +2886,7 @@ dependencies = [
 name = "tag_index"
 version = "0.0.1"
 dependencies = [
- "ffi",
- "index_result",
  "inverted_index",
- "proptest",
  "thin_vec",
  "trie_rs",
  "workspace_hack",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2886,8 +2886,12 @@ dependencies = [
 name = "tag_index"
 version = "0.0.1"
 dependencies = [
+ "build_utils",
  "ffi",
  "inverted_index",
+ "redis_mock",
+ "redisearch_rs",
+ "tag_index",
  "thin_vec",
  "trie_rs",
  "workspace_hack",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "sorting_vector",
     "spellcheck_dictionary",
     "string_utils",
+    "tag_index",
     "term_suffix_index",
     "tools/license_header_linter",
     "tools/ffi_geiger",

--- a/src/redisearch_rs/tag_index/Cargo.toml
+++ b/src/redisearch_rs/tag_index/Cargo.toml
@@ -9,12 +9,7 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-ffi.workspace = true
-index_result.workspace = true
 inverted_index.workspace = true
 thin_vec.workspace = true
 trie_rs.workspace = true
 workspace_hack.workspace = true
-
-[dev-dependencies]
-proptest = { workspace = true, features = ["std"] }

--- a/src/redisearch_rs/tag_index/Cargo.toml
+++ b/src/redisearch_rs/tag_index/Cargo.toml
@@ -5,8 +5,16 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[features]
+# Enabled when building tests so `build.rs` links the C code (`libredisearch_all`).
+# See https://github.com/rust-lang/cargo/issues/4789#issuecomment-2308131243
+unittest = []
+
 [lints]
 workspace = true
+
+[build-dependencies]
+build_utils.workspace = true
 
 [dependencies]
 ffi.workspace = true
@@ -14,3 +22,12 @@ inverted_index.workspace = true
 thin_vec.workspace = true
 trie_rs.workspace = true
 workspace_hack.workspace = true
+
+[dev-dependencies]
+tag_index = { path = ".", features = ["unittest"] }
+redis_mock.workspace = true
+
+# Crate required to invoke C symbols: its `#[used]` symbol table keeps the Rust FFI
+# functions (e.g. `IndexResult_Free`, `IsWildcardIterator`) that the linked C code
+# calls back into, so they aren't stripped from the test binary.
+redisearch_rs = { path = "../c_entrypoint/redisearch_rs", features = ["mock_allocator"] }

--- a/src/redisearch_rs/tag_index/Cargo.toml
+++ b/src/redisearch_rs/tag_index/Cargo.toml
@@ -9,6 +9,7 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+ffi.workspace = true
 inverted_index.workspace = true
 thin_vec.workspace = true
 trie_rs.workspace = true

--- a/src/redisearch_rs/tag_index/Cargo.toml
+++ b/src/redisearch_rs/tag_index/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tag_index"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+ffi.workspace = true
+index_result.workspace = true
+inverted_index.workspace = true
+thin_vec.workspace = true
+trie_rs.workspace = true
+workspace_hack.workspace = true
+
+[dev-dependencies]
+proptest = { workspace = true, features = ["std"] }

--- a/src/redisearch_rs/tag_index/build.rs
+++ b/src/redisearch_rs/tag_index/build.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+fn main() {
+    #[cfg(feature = "unittest")]
+    build_utils::bind_foreign_c_symbols();
+}

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -110,6 +110,17 @@
 
 mod suffix;
 
+// Force-link the umbrella `redisearch_rs` crate so its `#[used]` symbol table keeps the
+// Rust FFI functions that the linked C code (`libredisearch_all`) calls back into, and
+// stub any remaining Redis module C symbols the tests pull in. Without the `extern crate`
+// reference the umbrella rlib is dropped as unused and those symbols go undefined at link
+// time. Mirrors `numeric_range_tree`/`query_eval`/`top_k`.
+#[cfg(test)]
+extern crate redisearch_rs;
+
+#[cfg(test)]
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
 use std::ptr::NonNull;
 
 use ffi::{RedisSearchDiskIndexSpec, t_fieldIndex};

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Rust port of the TAG index (`src/tag_index.c`), memory mode.
+//!
+//! A [`TagIndex`] maps every tag value of one TAG field to the postings list
+//! (an [`InvertedIndex`] of document ids) of the documents carrying it, plus
+//! an optional [`TagSuffixIndex`] powering `WITHSUFFIXTRIE` queries.
+//!
+//! Tag values are raw byte strings: separator splitting, whitespace trimming
+//! and case folding happen upstream (C's `TagIndex_Preprocess`), exactly as
+//! in the C module. Disk mode (`diskSpec`) stays on the C side for now — it
+//! is a thin dispatcher to `SearchDisk_*` and carries no data-structure
+//! logic to port.
+//!
+//! This change introduces only the data structures; the methods, examples and
+//! tests follow in a later change, so every field is temporarily unread.
+#![expect(dead_code, reason = "read by methods added in the follow-up change")]
+
+pub mod suffix;
+
+use index_result::RSIndexResult;
+use inverted_index::{IndexReaderCore, InvertedIndex, doc_ids_only::DocIdsOnly};
+pub use suffix::TagSuffixIndex;
+use trie_rs::TrieMap;
+
+/// See the [crate documentation](self) for an overview.
+pub struct TagIndex {
+    unique_id: u32,
+
+    /// tag value → postings. Tag postings only need document ids, so the
+    /// inverted indexes always use the [`DocIdsOnly`] encoding, like C's
+    /// `NewInvertedIndex(Index_DocIdsOnly)`.
+    values: TrieMap<InvertedIndex<DocIdsOnly>>,
+
+    /// Suffix index, present only for fields created `WITHSUFFIXTRIE`.
+    suffix: Option<TagSuffixIndex>,
+
+    /// Documents indexed so far (C: `stats->numRecords`).
+    num_records: usize,
+
+    /// Total heap held by the postings (C: `stats->invertedSize`).
+    inverted_size: usize,
+}
+
+/// Sequential reader over one tag's postings; yields document ids in
+/// increasing order. Obtained from [`TagIndex::open_reader`].
+pub struct TagReader<'index> {
+    inner: IndexReaderCore<'index, DocIdsOnly>,
+    /// Scratch record the underlying reader decodes into.
+    result: RSIndexResult<'index>,
+}

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -7,52 +7,110 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Rust port of the TAG index (`src/tag_index.c`), memory mode.
+//! [`TagIndex`] is an index that indexes textual tags for documents. The "Disk mode"
+//! (`diskSpec`) is forwarded to another implementation.
 //!
-//! A [`TagIndex`] maps every tag value of one TAG field to the postings list
-//! (an [`InvertedIndex`] of document ids) of the documents carrying it, plus
-//! an optional [`TagSuffixIndex`] powering `WITHSUFFIXTRIE` queries.
+//! [`TagIndex`] uses the same indexes as the full text but in a simpler manner. In fact:
 //!
-//! Tag values are raw byte strings: separator splitting, whitespace trimming
-//! and case folding happen upstream (C's `TagIndex_Preprocess`), exactly as
-//! in the C module. Disk mode (`diskSpec`) stays on the C side for now — it
-//! is a thin dispatcher to `SearchDisk_*` and carries no data-structure
-//! logic to port.
+//! 1. An entire tag index resides in a single redis key, and doesn't have a key per term
 //!
-//! This change introduces only the data structures; the methods, examples and
-//! tests follow in a later change, so every field is temporarily unread.
+//! 2. We do not perform stemming on tags
+//!
+//! 3. The tokenization is simpler: The user can determine a separator (default to comma `,`),
+//!    and we do whitespace trimming at the end of tags. Thus, tags can contain spaces (in the middle),
+//!    punctuation marks, accents, etc. The only two transformations we perform are
+//!    lower-casing (not unicode sensitive as of now), and whitespace trimming.
+//!
+//! 4. Tags cannot be found from a general full-text search. i.e. if a document has a field called "tags"
+//!    with the values "foo" and "bar", searching for "foo" or "bar" without a special
+//!    tag modifier (see below) will not return the document.
+//!
+//! 5. The index is much simpler and more compressed: We do not store frequencies, offset vectors of field flags.
+//!    The index contains only document ids encoded as delta. This means that an entry in a tag index is usually one or two bytes long.
+//!    This makes them very memory efficient and fast.
+//!
+//!
+//! ## Creating a tag field
+//!
+//! Tag fields can be added to the schema in `FT.CREATE` with the following syntax:
+//! ```text
+//! FT.CREATE ... SCHEMA ... {field_name} TAG [SEPARATOR {sep}]
+//! ```
+//! `SEPARATOR` defaults to a comma (`,`), and can be any printable ascii character.  For example:
+//! ```text
+//! FT.CREATE idx SCHEMA tags TAG SEPARATOR ";"
+//! ```
+//!
+//! An unlimited number of tag fields can be created per document, as long as the overall number of
+//! fields is under 1024.
+//!
+//! ### With suffix
+//!
+//! [`TagIndex`] supports also suffix search if enabled during the creation as follow:
+//! ```text
+//! FT.CREATE idx SCHEMA tags TAG WITHSUFFIXTRIE
+//! ```
+//! In this case, also the suffix queries use index.
+//!
+//! NB: the suffix queries work even without `WITHSUFFIXTRIE`, but they will fallback to a brute force search.
+//!
+//! ## Querying Tag Fields
+//!
+//! As mentioned above, just searching for a tag without any modifiers will not retrieve documents
+//! containing it.
+//! The syntax for matching tags in a query is as follows (the curly braces are part of the syntax in
+//! this case):
+//! ```text
+//! @<field_name>:{ <tag> | <tag> | ...}
+//! ```
+//!  e.g.
+//! ```text
+//! @tags:{hello world | foo bar}
+//! ```
+//!  **IMPORTANT**: When specifying multiple tags in the same tag clause, the semantic meaning is a
+//!    **UNION** of the documents containing any of the tags (as in an SQL `WHERE IN` clause).
+//!    If you need to intersect tags, you should repeat several tag clauses.
+//!    For example:
+//! ```text
+//! FT.SEARCH idx "@tags:{hello | world}"
+//! ```
+//! Will return documents containing either hello or world (or both). But:
+//! ```text
+//! FT.SEARCH idx "@tags:{hello} @tags:{world}"
+//! ```
+//! Will return documents containing **both tags**.
+//!
+//! Notice that since tags can contain spaces (the separator by default is a comma), so can tags in
+//! the query.
+//!
+//! However, if a tag contains stopwords (for example, the tag `to be or not to be` will cause a
+//! syntax error),
+//! you can alternatively escape the spaces inside the tags to avoid syntax errors. In redis-cli and
+//! some clients, a second escaping is needed:
+//!
+//! ```text
+//! 127.0.0.1:6379> FT.SEARCH idx "@tags:{to\\ be\\ or\\ not\\ to\\ be}"
+//! ```
+//!
+
+// Temporary
 #![expect(dead_code, reason = "read by methods added in the follow-up change")]
 
-pub mod suffix;
+mod suffix;
 
-use index_result::RSIndexResult;
-use inverted_index::{IndexReaderCore, InvertedIndex, doc_ids_only::DocIdsOnly};
+use inverted_index::{InvertedIndex, doc_ids_only::DocIdsOnly};
 pub use suffix::TagSuffixIndex;
 use trie_rs::TrieMap;
 
 /// See the [crate documentation](self) for an overview.
 pub struct TagIndex {
+    /// Unique id generated at creation time.
     unique_id: u32,
 
     /// tag value → postings. Tag postings only need document ids, so the
-    /// inverted indexes always use the [`DocIdsOnly`] encoding, like C's
-    /// `NewInvertedIndex(Index_DocIdsOnly)`.
+    /// inverted indexes always use the [`DocIdsOnly`] encoding.
     values: TrieMap<InvertedIndex<DocIdsOnly>>,
 
     /// Suffix index, present only for fields created `WITHSUFFIXTRIE`.
     suffix: Option<TagSuffixIndex>,
-
-    /// Documents indexed so far (C: `stats->numRecords`).
-    num_records: usize,
-
-    /// Total heap held by the postings (C: `stats->invertedSize`).
-    inverted_size: usize,
-}
-
-/// Sequential reader over one tag's postings; yields document ids in
-/// increasing order. Obtained from [`TagIndex::open_reader`].
-pub struct TagReader<'index> {
-    inner: IndexReaderCore<'index, DocIdsOnly>,
-    /// Scratch record the underlying reader decodes into.
-    result: RSIndexResult<'index>,
 }

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -98,19 +98,37 @@
 
 mod suffix;
 
+use std::ptr::NonNull;
+
+use ffi::{RedisSearchDiskIndexSpec, t_fieldIndex};
 use inverted_index::{InvertedIndex, doc_ids_only::DocIdsOnly};
 pub use suffix::TagSuffixIndex;
 use trie_rs::TrieMap;
+
+enum TagIndexMode {
+    InMemory {
+        /// tag value → postings. Tag postings only need document ids, so the
+        /// inverted indexes always use the [`DocIdsOnly`] encoding.
+        values: TrieMap<InvertedIndex<DocIdsOnly>>,
+    },
+    Disk {
+        /// tag value → (). Is it used only to know whether a tag is there
+        values: TrieMap<()>,
+        /// Field id
+        field_id: t_fieldIndex,
+        /// Disk Index spec
+        disk_index_spec: NonNull<RedisSearchDiskIndexSpec>,
+    },
+}
 
 /// See the [crate documentation](self) for an overview.
 pub struct TagIndex {
     /// Unique id generated at creation time.
     unique_id: u32,
 
-    /// tag value → postings. Tag postings only need document ids, so the
-    /// inverted indexes always use the [`DocIdsOnly`] encoding.
-    values: TrieMap<InvertedIndex<DocIdsOnly>>,
-
     /// Suffix index, present only for fields created `WITHSUFFIXTRIE`.
     suffix: Option<TagSuffixIndex>,
+
+    /// The mode: in memory / disk
+    mode: TagIndexMode,
 }

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -44,15 +44,27 @@
 //! An unlimited number of tag fields can be created per document, as long as the overall number of
 //! fields is under 1024.
 //!
-//! ### With suffix
+//! ### Suffix and contains matching
 //!
-//! [`TagIndex`] supports also suffix search if enabled during the creation as follow:
+//! By default a tag query matches a tag either exactly (`@tags:{foo}`) or by
+//! prefix (`@tags:{foo*}`, every tag starting with `foo`). Two more wildcard
+//! forms are supported:
+//!
+//! - **Suffix** — `@tags:{*foo}` matches every tag that *ends* with `foo`.
+//! - **Contains** (infix) — `@tags:{*foo*}` matches every tag that *contains* `foo`.
+//!
+//! A trie resolves a prefix quickly by walking down to the prefix node, but it
+//! cannot do the same for a suffix or an infix without scanning every tag. To
+//! make those queries efficient, the field can be created with a *suffix trie*:
 //! ```text
 //! FT.CREATE idx SCHEMA tags TAG WITHSUFFIXTRIE
 //! ```
-//! In this case, also the suffix queries use index.
+//! The suffix trie indexes *every suffix* of each tag, so a `*foo` / `*foo*`
+//! query becomes a plain prefix lookup on the suffix trie (see
+//! [`TagSuffixIndex`]).
 //!
-//! NB: the suffix queries work even without `WITHSUFFIXTRIE`, but they will fallback to a brute force search.
+//! NB: suffix and contains queries also work without `WITHSUFFIXTRIE`, but they
+//! fall back to a brute-force scan of the whole tag trie.
 //!
 //! ## Querying Tag Fields
 //!

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -128,14 +128,16 @@ use inverted_index::{InvertedIndex, doc_ids_only::DocIdsOnly};
 pub use suffix::TagSuffixIndex;
 use trie_rs::TrieMap;
 
+/// Identifies the way the data is stored
 enum TagIndexMode {
+    /// If the postings (doc_ids) are kept in memory
     InMemory {
-        /// tag value → postings. Tag postings only need document ids, so the
-        /// inverted indexes always use the [`DocIdsOnly`] encoding.
+        /// tag value → document ids.
         values: TrieMap<InvertedIndex<DocIdsOnly>>,
     },
+    /// If the postings (doc_ids) are kept on disk
     Disk {
-        /// tag value → (). Is it used only to know whether a tag is there
+        /// tag value → (). It is used only to know whether a tag is there
         values: TrieMap<()>,
         /// Field id
         field_id: t_fieldIndex,

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -57,10 +57,6 @@ impl OwnedTerm {
     /// # Safety
     /// 1. term is NULL terminated and cannot contain NULL inside
     /// 2. term is not empty (it contains at least the null)
-    ///
-    /// # Panics
-    /// - the method panics if the tag key (the `term` excluding its trailing
-    ///   NUL) is longer than [`u16::MAX`] bytes.
     unsafe fn new(term: &[u8]) -> Self {
         #[cfg(debug_assertions)]
         {
@@ -71,11 +67,6 @@ impl OwnedTerm {
                 "term should be NULL terminated"
             );
         }
-
-        // Only the content (excluding the trailing NUL) must fit in `tm_len_t`
-        // (`u16`); the allocation still includes the NUL, so a maximum-size
-        // 65_535-byte key is stored as a 65_536-byte buffer.
-        u16::try_from(term.len() - 1).expect("caller rejects terms longer than u16::MAX");
 
         let size = term.len();
         let layout = tag_term_layout(size);
@@ -165,39 +156,18 @@ mod tests {
     }
 
     #[test]
-    fn empty_term() {
+    fn empty_term_is_fine() {
         let term = unsafe { OwnedTerm::new(b"\0") };
         // SAFETY: `term` is live and built by `OwnedTerm::new`.
         assert_eq!(unsafe { read_back(&term) }, b"\0");
     }
 
     #[test]
-    fn larger_term() {
+    fn larger_term_is_fine() {
         let mut expected = vec![0xABu8; 300];
         expected.push(0);
         let term = unsafe { OwnedTerm::new(&expected) };
         // SAFETY: `term` is live and built by `OwnedTerm::new`.
         assert_eq!(unsafe { read_back(&term) }, expected);
-    }
-
-    #[test]
-    fn max_len_term() {
-        // A key of exactly `u16::MAX` content bytes (plus its NUL) is the
-        // largest `tm_len_t` key and must be accepted, not rejected.
-        let mut expected = vec![0xABu8; u16::MAX as usize];
-        expected.push(0);
-        let term = unsafe { OwnedTerm::new(&expected) };
-        // SAFETY: `term` is live and built by `OwnedTerm::new`.
-        assert_eq!(unsafe { read_back(&term) }, expected);
-    }
-
-    #[test]
-    #[should_panic(expected = "caller rejects terms longer than u16::MAX")]
-    fn too_long_panics() {
-        // The panic fires at `u16::try_from` before any allocation happens.
-        // The content (excluding the trailing NUL) exceeds `u16::MAX`.
-        let mut term = vec![1u8; u16::MAX as usize + 1];
-        term.push(0);
-        let _ = unsafe { OwnedTerm::new(&term) };
     }
 }

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -31,16 +31,77 @@
 //! - the remaining bytes as the string
 //!
 
-use std::ptr::NonNull;
+use std::{
+    alloc::{Layout, alloc, dealloc, handle_alloc_error},
+    ptr::NonNull,
+};
 
 use thin_vec::{AlignedU32, ThinVec};
 use trie_rs::TrieMap;
+
+/// [`OwnedTerm`] header length
+const TERM_LEN_PREFIX: usize = size_of::<u16>();
+
+/// Layout of a tag term allocation: length prefix followed by the term bytes,
+/// aligned for the `u16` prefix.
+fn tag_term_layout(len: usize) -> Layout {
+    let align = align_of::<u16>();
+    let size = TERM_LEN_PREFIX + len;
+
+    // `align` is not 0 and power of two
+    // `size` is less than isize::MAX
+    Layout::from_size_align(size, align)
+        .expect("tag term length is bounded by u16::MAX, far below Layout's limits")
+}
 
 /// Owning handle to a tag term allocation.
 ///
 /// Dropping it frees the allocation.
 #[derive(Debug)]
 struct OwnedTerm(NonNull<u8>);
+
+impl OwnedTerm {
+    /// Copy `term` into a fresh length-prefixed allocation.
+    ///
+    /// # Panics
+    /// - the method panics if the `term` is longer than [`u16::MAX`] bytes.
+    fn new(term: &[u8]) -> Self {
+        let len = u16::try_from(term.len()).expect("caller rejects terms longer than u16::MAX");
+
+        let layout = tag_term_layout(len as usize);
+
+        // SAFETY: `layout` has non-zero size (the prefix alone is 2 bytes).
+        let ptr = unsafe { alloc(layout) };
+        let Some(ptr) = NonNull::new(ptr) else {
+            handle_alloc_error(layout);
+        };
+
+        // SAFETY: the allocation is at least `TERM_LEN_PREFIX` bytes and
+        // aligned for u16, so the prefix write is in bounds.
+        unsafe { ptr.cast::<u16>().write(len) };
+
+        // SAFETY: ptr + TERM_LEN_PREFIX is still in bounds.
+        let dst = unsafe { ptr.as_ptr().add(TERM_LEN_PREFIX) };
+
+        // SAFETY: source and destination are valid for `term.len()` bytes
+        // and cannot overlap because `dst` is a freshly allocated block.
+        unsafe { std::ptr::copy_nonoverlapping(term.as_ptr(), dst, term.len()) };
+
+        Self(ptr)
+    }
+}
+
+impl Drop for OwnedTerm {
+    fn drop(&mut self) {
+        // SAFETY: the allocation is alive (ownership is unique and this is
+        // the owner's drop) and its length prefix was initialized by
+        // `OwnedTerm::new`.
+        let len = usize::from(unsafe { self.0.cast::<u16>().read() });
+        // SAFETY: `self.0` came from `OwnedTerm::new` with exactly this
+        // layout, and this is the only deallocation.
+        unsafe { dealloc(self.0.as_ptr(), tag_term_layout(len)) };
+    }
+}
 
 /// Weak, thin (8-byte) pointer to a term allocation.
 ///
@@ -62,4 +123,54 @@ struct SuffixData {
 pub struct TagSuffixIndex {
     /// The suffix entries
     entries: TrieMap<SuffixData>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Read back the bytes stored in an [`OwnedTerm`], mirroring its in-memory
+    /// format (`u16` length prefix at offset 0, then the term bytes).
+    ///
+    /// # Safety
+    /// `t` must be a live [`OwnedTerm`] produced by [`OwnedTerm::new`].
+    unsafe fn read_back(t: &OwnedTerm) -> Vec<u8> {
+        // SAFETY: the prefix was initialized by `OwnedTerm::new`.
+        let len = usize::from(unsafe { t.0.cast::<u16>().read() });
+        // SAFETY: `ptr + TERM_LEN_PREFIX` is in bounds and holds `len` bytes.
+        let src = unsafe { t.0.as_ptr().add(TERM_LEN_PREFIX) };
+        // SAFETY: `src` is valid for `len` initialized bytes.
+        unsafe { std::slice::from_raw_parts(src, len) }.to_vec()
+    }
+
+    #[test]
+    fn roundtrip() {
+        let term = OwnedTerm::new(b"hello");
+        // SAFETY: `term` is live and built by `OwnedTerm::new`.
+        assert_eq!(unsafe { read_back(&term) }, b"hello");
+        // `term` drops here; miri checks the alloc/dealloc layout match.
+    }
+
+    #[test]
+    fn empty_term() {
+        let term = OwnedTerm::new(b"");
+        // SAFETY: `term` is live and built by `OwnedTerm::new`.
+        assert_eq!(unsafe { read_back(&term) }, b"");
+    }
+
+    #[test]
+    fn larger_term() {
+        let expected = vec![0xABu8; 300];
+        let term = OwnedTerm::new(&expected);
+        // SAFETY: `term` is live and built by `OwnedTerm::new`.
+        assert_eq!(unsafe { read_back(&term) }, expected);
+    }
+
+    #[test]
+    #[should_panic(expected = "caller rejects terms longer than u16::MAX")]
+    fn too_long_panics() {
+        // The panic fires at `u16::try_from` before any allocation happens.
+        let term = vec![0u8; u16::MAX as usize + 1];
+        let _ = OwnedTerm::new(&term);
+    }
 }

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -59,7 +59,8 @@ impl OwnedTerm {
     /// 2. term is not empty (it contains at least the null)
     ///
     /// # Panics
-    /// - the method panics if the `term` is longer than [`u16::MAX`] bytes.
+    /// - the method panics if the tag key (the `term` excluding its trailing
+    ///   NUL) is longer than [`u16::MAX`] bytes.
     unsafe fn new(term: &[u8]) -> Self {
         #[cfg(debug_assertions)]
         {
@@ -71,9 +72,13 @@ impl OwnedTerm {
             );
         }
 
-        let len = u16::try_from(term.len()).expect("caller rejects terms longer than u16::MAX");
+        // Only the content (excluding the trailing NUL) must fit in `tm_len_t`
+        // (`u16`); the allocation still includes the NUL, so a maximum-size
+        // 65_535-byte key is stored as a 65_536-byte buffer.
+        u16::try_from(term.len() - 1).expect("caller rejects terms longer than u16::MAX");
 
-        let layout = tag_term_layout(len as usize);
+        let size = term.len();
+        let layout = tag_term_layout(size);
 
         // SAFETY: `layout` has non-zero size (guarantee 2)
         let ptr = unsafe { alloc(layout) };
@@ -83,7 +88,7 @@ impl OwnedTerm {
 
         // SAFETY: source and destination are valid for `term.len()` bytes
         // and cannot overlap because `dst` is a freshly allocated block.
-        unsafe { std::ptr::copy_nonoverlapping(term.as_ptr(), ptr.as_ptr(), len as usize) };
+        unsafe { std::ptr::copy_nonoverlapping(term.as_ptr(), ptr.as_ptr(), size) };
 
         Self(ptr)
     }
@@ -176,9 +181,21 @@ mod tests {
     }
 
     #[test]
+    fn max_len_term() {
+        // A key of exactly `u16::MAX` content bytes (plus its NUL) is the
+        // largest `tm_len_t` key and must be accepted, not rejected.
+        let mut expected = vec![0xABu8; u16::MAX as usize];
+        expected.push(0);
+        let term = unsafe { OwnedTerm::new(&expected) };
+        // SAFETY: `term` is live and built by `OwnedTerm::new`.
+        assert_eq!(unsafe { read_back(&term) }, expected);
+    }
+
+    #[test]
     #[should_panic(expected = "caller rejects terms longer than u16::MAX")]
     fn too_long_panics() {
         // The panic fires at `u16::try_from` before any allocation happens.
+        // The content (excluding the trailing NUL) exceeds `u16::MAX`.
         let mut term = vec![1u8; u16::MAX as usize + 1];
         term.push(0);
         let _ = unsafe { OwnedTerm::new(&term) };

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! A byte-string set supporting substring and ends-with queries against its
+//! members, backing the `WITHSUFFIXTRIE` option on TAG fields.
+//!
+//! This is the Rust counterpart of the `TrieMap`-flavored suffix structure in
+//! `src/suffix.c` (`addSuffixTrieMap`, `deleteSuffixTrieMap`,
+//! `GetList_SuffixTrieMap`). Members are raw byte strings: tag values are
+//! already normalized upstream (case folding, separator trimming), so this
+//! structure applies no normalization of its own, and suffixes are taken at
+//! every *byte* offset — exactly like the C `TrieMap` variant, and unlike the
+//! rune-based `Trie` variant used for TEXT fields.
+//!
+//! # Why a suffix trie answers substring queries
+//!
+//! Every substring of a string is a prefix of some suffix of that string. So
+//! indexing all suffixes of every member and prefix-searching for the needle
+//! surfaces every member containing it. [`TagSuffixIndex::iter_contains`] is
+//! the prefix lookup; [`TagSuffixIndex::iter_suffix`] is the exact lookup.
+//!
+//! # Memory model
+//!
+//! For a member of `N` bytes, `N` trie entries reference it (the member's own
+//! entry plus its `N - 1` proper suffixes). Like the C implementation, one
+//! heap copy of the term is made and every entry's back-reference array holds
+//! a weak pointer to it ([`TermPtr`], 8 bytes); the member's own entry
+//! additionally holds the owning handle ([`OwnedTerm`], C's non-`NULL`
+//! `term` field), and [`TagSuffixIndex::remove`] strips all back-references
+//! before freeing the copy. [`ThinVec`] keeps the back-reference array at
+//! 8 bytes inline, so [`SuffixData`] is 16 bytes, matching C's `suffixData`.
+//!
+//! The term's length is stored as a [2-byte prefix](TERM_LEN_PREFIX) inside
+//! the allocation itself, so a back-reference stays a thin 8-byte pointer and
+//! resolving a match costs a single dependent load, as in C. An earlier
+//! design kept the memory fully safe by storing terms in an arena and using
+//! 4-byte ids as back-references, but resolving an id costs an extra random
+//! load through the arena table, which benchmarked at ~2x the per-match cost
+//! of the C implementation on exact-suffix gets.
+//!
+//! # Safety invariant
+//!
+//! All `unsafe` in this module rests on one invariant, the same one the C
+//! code relies on: *a [`TermPtr`] stored in some entry's back-reference array
+//! always points into an allocation owned by the [`OwnedTerm`] of the
+//! member's own entry, and every back-reference is removed before that owner
+//! is dropped.* [`TagSuffixIndex::add`] establishes it, [`TagSuffixIndex::remove`]
+//! preserves it by walking every suffix of the removed member (dropping the
+//! owner only afterwards), and dropping the whole index tears everything
+//! down together.
+#![allow(rustdoc::private_intra_doc_links)]
+
+use std::ptr::NonNull;
+
+use thin_vec::{AlignedU32, ThinVec};
+use trie_rs::TrieMap;
+
+/// Weak, thin (8-byte) pointer to a term allocation. The pointee is owned by
+/// the [`OwnedTerm`] of the member's own trie entry; see the
+/// [safety invariant](self#safety-invariant). Compared by address: every
+/// member has exactly one allocation, so pointer equality is term identity
+/// (C compares the bytes instead; the identity is the same).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TermPtr(NonNull<u8>);
+
+/// Owning handle to a term allocation; the Rust counterpart of C's
+/// `suffixData::term` field. Dropping it frees the allocation — the
+/// [safety invariant](self#safety-invariant) demands all [`TermPtr`]
+/// back-references are gone by then.
+#[derive(Debug)]
+struct OwnedTerm(NonNull<u8>);
+
+/// Payload of one trie entry.
+///
+/// A key `K` can play two independent roles at once: `K` may itself be a
+/// member of the set, and `K` may be a suffix (proper or not) of one or more
+/// members. Mirrors C's `suffixData { char *term; arrayof(char *) array; }`
+/// at the same 16-byte size — see the [memory model](self#memory-model).
+#[derive(Debug, Default)]
+struct SuffixData {
+    /// `Some` iff this entry's key is itself a member: the owning handle of
+    /// that member's term allocation. The C equivalent is a non-`NULL`
+    /// `term` marking ownership of the heap copy.
+    full_term: Option<OwnedTerm>,
+    /// Every member this entry's key is a suffix of — including the key
+    /// itself when [`Self::full_term`] is set, exactly like C's `array`.
+    /// The 32-bit capacity type shrinks the heap header to 8 bytes — the
+    /// same as C's `array_hdr_t` — and still bounds an entry's
+    /// back-references far above the number of representable members.
+    /// [`AlignedU32`] rather than `u32`: its empty-header singleton is
+    /// 8-byte aligned, letting `ThinVec` elide the empty-singleton
+    /// alignment guard for the 8-byte-aligned [`TermPtr`] element type —
+    /// the capacity type the crate intends for such elements. Same header
+    /// bytes and heap layout as `u32`; benchmarked
+    /// performance-indistinguishable from it.
+    refs: ThinVec<TermPtr, AlignedU32>,
+}
+
+/// See the [module documentation](self) for the data structure and its
+/// C counterpart.
+#[derive(Debug, Default)]
+pub struct TagSuffixIndex {
+    entries: TrieMap<SuffixData>,
+    /// Number of member terms.
+    n_terms: usize,
+    /// Total bytes of live term allocations, for [`Self::mem_usage`].
+    term_bytes: usize,
+}
+
+/// Iterator over the member terms recorded in one entry's back-reference
+/// array; returned by [`TagSuffixIndex::iter_suffix`]. A plain slice walk
+/// resolving each thin pointer, so a match costs one dependent load — the
+/// same access pattern as iterating C's `char *` arrays.
+pub struct Matches<'idx> {
+    refs: std::slice::Iter<'idx, TermPtr>,
+}

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -26,10 +26,6 @@
 //! - for each suffix:
 //!   - insert borrowed term under the suffix key
 //!
-//! [`OwnedTerm`] uses:
-//! - the first two bytes (the size of u16) as header to store the string length
-//! - the remaining bytes as the string
-//!
 
 use std::{
     alloc::{Layout, alloc, dealloc, handle_alloc_error},
@@ -39,14 +35,9 @@ use std::{
 use thin_vec::{AlignedU32, ThinVec};
 use trie_rs::TrieMap;
 
-/// [`OwnedTerm`] header length
-const TERM_LEN_PREFIX: usize = size_of::<u16>();
-
-/// Layout of a tag term allocation: length prefix followed by the term bytes,
-/// aligned for the `u16` prefix.
-fn tag_term_layout(len: usize) -> Layout {
+/// Layout of a tag term allocation.
+fn tag_term_layout(size: usize) -> Layout {
     let align = align_of::<u16>();
-    let size = TERM_LEN_PREFIX + len;
 
     // `align` is not 0 and power of two
     // `size` is less than isize::MAX
@@ -61,42 +52,61 @@ fn tag_term_layout(len: usize) -> Layout {
 struct OwnedTerm(NonNull<u8>);
 
 impl OwnedTerm {
-    /// Copy `term` into a fresh length-prefixed allocation.
+    /// Copy `term` into a fresh allocation.
+    ///
+    /// # Safety
+    /// 1. term is NULL terminated and cannot contain NULL inside
+    /// 2. term is not empty (it contains at least the null)
     ///
     /// # Panics
     /// - the method panics if the `term` is longer than [`u16::MAX`] bytes.
-    fn new(term: &[u8]) -> Self {
+    unsafe fn new(term: &[u8]) -> Self {
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(!term.is_empty(), "term shouldn't be empty");
+            debug_assert_eq!(
+                *term.last().expect("term shouldn't be empty"),
+                0,
+                "term should be NULL terminated"
+            );
+        }
+
         let len = u16::try_from(term.len()).expect("caller rejects terms longer than u16::MAX");
 
         let layout = tag_term_layout(len as usize);
 
-        // SAFETY: `layout` has non-zero size (the prefix alone is 2 bytes).
+        // SAFETY: `layout` has non-zero size (guarantee 2)
         let ptr = unsafe { alloc(layout) };
         let Some(ptr) = NonNull::new(ptr) else {
             handle_alloc_error(layout);
         };
 
-        // SAFETY: the allocation is at least `TERM_LEN_PREFIX` bytes and
-        // aligned for u16, so the prefix write is in bounds.
-        unsafe { ptr.cast::<u16>().write(len) };
-
-        // SAFETY: ptr + TERM_LEN_PREFIX is still in bounds.
-        let dst = unsafe { ptr.as_ptr().add(TERM_LEN_PREFIX) };
-
         // SAFETY: source and destination are valid for `term.len()` bytes
         // and cannot overlap because `dst` is a freshly allocated block.
-        unsafe { std::ptr::copy_nonoverlapping(term.as_ptr(), dst, term.len()) };
+        unsafe { std::ptr::copy_nonoverlapping(term.as_ptr(), ptr.as_ptr(), len as usize) };
 
         Self(ptr)
+    }
+
+    /// Full allocation size in bytes (term bytes + the trailing NUL).
+    ///
+    /// # Safety
+    /// `self` is built by [`OwnedTerm::new`]
+    const unsafe fn alloc_size(&self) -> usize {
+        // This cast doesn't change size, we care about only the NULL
+        let ptr = self.0.as_ptr().cast::<std::ffi::c_char>().cast_const();
+        // SAFETY: guarantee 1 of [`OwnedTerm::new`]
+        unsafe { std::ffi::CStr::from_ptr(ptr) }
+            .to_bytes_with_nul()
+            .len()
     }
 }
 
 impl Drop for OwnedTerm {
     fn drop(&mut self) {
-        // SAFETY: the allocation is alive (ownership is unique and this is
-        // the owner's drop) and its length prefix was initialized by
-        // `OwnedTerm::new`.
-        let len = usize::from(unsafe { self.0.cast::<u16>().read() });
+        // SAFETY: `self` is allocated using new method.
+        let len = unsafe { self.alloc_size() };
+
         // SAFETY: `self.0` came from `OwnedTerm::new` with exactly this
         // layout, and this is the only deallocation.
         unsafe { dealloc(self.0.as_ptr(), tag_term_layout(len)) };
@@ -129,39 +139,38 @@ pub struct TagSuffixIndex {
 mod tests {
     use super::*;
 
-    /// Read back the bytes stored in an [`OwnedTerm`], mirroring its in-memory
-    /// format (`u16` length prefix at offset 0, then the term bytes).
+    /// Read back the bytes stored in an [`OwnedTerm`].
     ///
     /// # Safety
     /// `t` must be a live [`OwnedTerm`] produced by [`OwnedTerm::new`].
     unsafe fn read_back(t: &OwnedTerm) -> Vec<u8> {
-        // SAFETY: the prefix was initialized by `OwnedTerm::new`.
-        let len = usize::from(unsafe { t.0.cast::<u16>().read() });
-        // SAFETY: `ptr + TERM_LEN_PREFIX` is in bounds and holds `len` bytes.
-        let src = unsafe { t.0.as_ptr().add(TERM_LEN_PREFIX) };
+        // SAFETY: guaranteed by Safety rule
+        let len = unsafe { t.alloc_size() };
+
         // SAFETY: `src` is valid for `len` initialized bytes.
-        unsafe { std::slice::from_raw_parts(src, len) }.to_vec()
+        unsafe { std::slice::from_raw_parts(t.0.as_ptr(), len) }.to_vec()
     }
 
     #[test]
     fn roundtrip() {
-        let term = OwnedTerm::new(b"hello");
+        let term = unsafe { OwnedTerm::new(b"hello\0") };
         // SAFETY: `term` is live and built by `OwnedTerm::new`.
-        assert_eq!(unsafe { read_back(&term) }, b"hello");
+        assert_eq!(unsafe { read_back(&term) }, b"hello\0");
         // `term` drops here; miri checks the alloc/dealloc layout match.
     }
 
     #[test]
     fn empty_term() {
-        let term = OwnedTerm::new(b"");
+        let term = unsafe { OwnedTerm::new(b"\0") };
         // SAFETY: `term` is live and built by `OwnedTerm::new`.
-        assert_eq!(unsafe { read_back(&term) }, b"");
+        assert_eq!(unsafe { read_back(&term) }, b"\0");
     }
 
     #[test]
     fn larger_term() {
-        let expected = vec![0xABu8; 300];
-        let term = OwnedTerm::new(&expected);
+        let mut expected = vec![0xABu8; 300];
+        expected.push(0);
+        let term = unsafe { OwnedTerm::new(&expected) };
         // SAFETY: `term` is live and built by `OwnedTerm::new`.
         assert_eq!(unsafe { read_back(&term) }, expected);
     }
@@ -170,7 +179,8 @@ mod tests {
     #[should_panic(expected = "caller rejects terms longer than u16::MAX")]
     fn too_long_panics() {
         // The panic fires at `u16::try_from` before any allocation happens.
-        let term = vec![0u8; u16::MAX as usize + 1];
-        let _ = OwnedTerm::new(&term);
+        let mut term = vec![1u8; u16::MAX as usize + 1];
+        term.push(0);
+        let _ = unsafe { OwnedTerm::new(&term) };
     }
 }

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -7,116 +7,59 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! A byte-string set supporting substring and ends-with queries against its
-//! members, backing the `WITHSUFFIXTRIE` option on TAG fields.
+//! [`TagSuffixIndex`] is created when `WITHSUFFIXTRIE` option is given.
 //!
-//! This is the Rust counterpart of the `TrieMap`-flavored suffix structure in
-//! `src/suffix.c` (`addSuffixTrieMap`, `deleteSuffixTrieMap`,
-//! `GetList_SuffixTrieMap`). Members are raw byte strings: tag values are
-//! already normalized upstream (case folding, separator trimming), so this
-//! structure applies no normalization of its own, and suffixes are taken at
-//! every *byte* offset — exactly like the C `TrieMap` variant, and unlike the
-//! rune-based `Trie` variant used for TEXT fields.
-//!
-//! # Why a suffix trie answers substring queries
-//!
-//! Every substring of a string is a prefix of some suffix of that string. So
-//! indexing all suffixes of every member and prefix-searching for the needle
-//! surfaces every member containing it. [`TagSuffixIndex::iter_contains`] is
-//! the prefix lookup; [`TagSuffixIndex::iter_suffix`] is the exact lookup.
+//! For each tags, [`TagSuffixIndex`] stores all the suffixes as key.
 //!
 //! # Memory model
 //!
-//! For a member of `N` bytes, `N` trie entries reference it (the member's own
-//! entry plus its `N - 1` proper suffixes). Like the C implementation, one
-//! heap copy of the term is made and every entry's back-reference array holds
-//! a weak pointer to it ([`TermPtr`], 8 bytes); the member's own entry
-//! additionally holds the owning handle ([`OwnedTerm`], C's non-`NULL`
-//! `term` field), and [`TagSuffixIndex::remove`] strips all back-references
-//! before freeing the copy. [`ThinVec`] keeps the back-reference array at
-//! 8 bytes inline, so [`SuffixData`] is 16 bytes, matching C's `suffixData`.
+//! The values of this index are [`SuffixData`] which stores:
+//! - owned term (one occurrence)
+//! - borrowed term (N occurrence, one for each suffix)
 //!
-//! The term's length is stored as a [2-byte prefix](TERM_LEN_PREFIX) inside
-//! the allocation itself, so a back-reference stays a thin 8-byte pointer and
-//! resolving a match costs a single dependent load, as in C. An earlier
-//! design kept the memory fully safe by storing terms in an arena and using
-//! 4-byte ids as back-references, but resolving an id costs an extra random
-//! load through the arena table, which benchmarked at ~2x the per-match cost
-//! of the C implementation on exact-suffix gets.
+//! [`OwnedTerm`] holds the owned memory, while [`TermPtr`] points to the owned memory.
+//! [`OwnedTerm`] frees the memory on drop, [`TermPtr`] doesn't.
+//! Adding and removing items from this trie require order-aware operations.
 //!
-//! # Safety invariant
+//! For instance, during the insertion:
+//! - insert owned term under tag key
+//! - for each suffix:
+//!   - insert borrowed term under the suffix key
 //!
-//! All `unsafe` in this module rests on one invariant, the same one the C
-//! code relies on: *a [`TermPtr`] stored in some entry's back-reference array
-//! always points into an allocation owned by the [`OwnedTerm`] of the
-//! member's own entry, and every back-reference is removed before that owner
-//! is dropped.* [`TagSuffixIndex::add`] establishes it, [`TagSuffixIndex::remove`]
-//! preserves it by walking every suffix of the removed member (dropping the
-//! owner only afterwards), and dropping the whole index tears everything
-//! down together.
-#![allow(rustdoc::private_intra_doc_links)]
+//! [`OwnedTerm`] uses:
+//! - the first two bytes (the size of u16) as header to store the string length
+//! - the remaining bytes as the string
+//!
 
 use std::ptr::NonNull;
 
 use thin_vec::{AlignedU32, ThinVec};
 use trie_rs::TrieMap;
 
-/// Weak, thin (8-byte) pointer to a term allocation. The pointee is owned by
-/// the [`OwnedTerm`] of the member's own trie entry; see the
-/// [safety invariant](self#safety-invariant). Compared by address: every
-/// member has exactly one allocation, so pointer equality is term identity
-/// (C compares the bytes instead; the identity is the same).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct TermPtr(NonNull<u8>);
-
-/// Owning handle to a term allocation; the Rust counterpart of C's
-/// `suffixData::term` field. Dropping it frees the allocation — the
-/// [safety invariant](self#safety-invariant) demands all [`TermPtr`]
-/// back-references are gone by then.
+/// Owning handle to a tag term allocation.
+///
+/// Dropping it frees the allocation.
 #[derive(Debug)]
 struct OwnedTerm(NonNull<u8>);
 
-/// Payload of one trie entry.
+/// Weak, thin (8-byte) pointer to a term allocation.
 ///
-/// A key `K` can play two independent roles at once: `K` may itself be a
-/// member of the set, and `K` may be a suffix (proper or not) of one or more
-/// members. Mirrors C's `suffixData { char *term; arrayof(char *) array; }`
-/// at the same 16-byte size — see the [memory model](self#memory-model).
+/// The pointee is owned by the [`OwnedTerm`] of the member's own trie entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TermPtr(NonNull<u8>);
+
+/// Payload of one trie entry.
 #[derive(Debug, Default)]
 struct SuffixData {
     /// `Some` iff this entry's key is itself a member: the owning handle of
-    /// that member's term allocation. The C equivalent is a non-`NULL`
-    /// `term` marking ownership of the heap copy.
+    /// that member's tag term allocation.
     full_term: Option<OwnedTerm>,
-    /// Every member this entry's key is a suffix of — including the key
-    /// itself when [`Self::full_term`] is set, exactly like C's `array`.
-    /// The 32-bit capacity type shrinks the heap header to 8 bytes — the
-    /// same as C's `array_hdr_t` — and still bounds an entry's
-    /// back-references far above the number of representable members.
-    /// [`AlignedU32`] rather than `u32`: its empty-header singleton is
-    /// 8-byte aligned, letting `ThinVec` elide the empty-singleton
-    /// alignment guard for the 8-byte-aligned [`TermPtr`] element type —
-    /// the capacity type the crate intends for such elements. Same header
-    /// bytes and heap layout as `u32`; benchmarked
-    /// performance-indistinguishable from it.
+    /// Every member this entry's key is a suffix of.
     refs: ThinVec<TermPtr, AlignedU32>,
 }
 
-/// See the [module documentation](self) for the data structure and its
-/// C counterpart.
 #[derive(Debug, Default)]
 pub struct TagSuffixIndex {
+    /// The suffix entries
     entries: TrieMap<SuffixData>,
-    /// Number of member terms.
-    n_terms: usize,
-    /// Total bytes of live term allocations, for [`Self::mem_usage`].
-    term_bytes: usize,
-}
-
-/// Iterator over the member terms recorded in one entry's back-reference
-/// array; returned by [`TagSuffixIndex::iter_suffix`]. A plain slice walk
-/// resolving each thin pointer, so a match costs one dependent load — the
-/// same access pattern as iterating C's `char *` arrays.
-pub struct Matches<'idx> {
-    refs: std::slice::Iter<'idx, TermPtr>,
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: The tag index is implemented entirely in C (`src/tag_index.c`).
2. **Change**: Introduce a new `tag_index` Rust crate under `src/redisearch_rs/` and register it
   in the workspace. This first step lands only the data-structure definitions and their
   documentation:
   - `TagIndex` — a `TrieMap` from tag value to a doc-ids-only `InvertedIndex`, plus a unique id
     and an optional suffix index (present for `WITHSUFFIXTRIE` fields).
   - `TagSuffixIndex` and its memory model (`OwnedTerm`, `TermPtr`, `SuffixData`) for
     suffix-trie search.
   - Crate-level docs describing tag tokenization, `FT.CREATE ... TAG` schema, and
     `@field:{...}` query semantics.
   *NB* No methods are implemented yet — they arrive in a follow-up PR — so the crate temporarily
   carries `#![expect(dead_code)]`.
3. **Outcome**: The `tag_index` crate builds. No runtime behavior changes.

#### Which additional issues this PR fixes

#### Main objects this PR modified

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization change

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
