### PR TITLE
[8.0] ci: raise flow-test timeout to 120 minutes

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -40,7 +40,10 @@ on:
         description: 'Branch to use when building RedisJSON for tests'
       test-timeout:
         type: number
-        default: 50
+        # Per-step (standalone/coordinator) flow-test budget. The full multi-config
+        # suite does not fit in 50 min on the 2-vCPU aarch64 and the slow macOS
+        # runners, causing merge-queue timeouts. Matches 8.2+ (see #9101).
+        default: 120
 
 env:
   REJSON: ${{ inputs.rejson && 1 || 0 }}  # convert the boolean input to numeric


### PR DESCRIPTION
**Describe the changes in the pull request**

1. **Current state:** on the `8.0` branch, each flow-test step (`Flow tests (standalone)` and `Flow tests (coordinator)`) is given a 50-minute budget via `task-test.yml`'s `test-timeout` input (default `50`). On the 2-vCPU aarch64 runner (`ubuntu24-arm64-2-8`, 2 parallel test processes) and the slow macOS runners, the full multi-config pytest suite runs ~2x slower than on x86_64 (4 processes) and does **not** finish in 50 minutes, so the step is killed. The abrupt kill leaves orphaned redis processes, which then make the subsequent coordinator step's cluster setup fail (`slot already busy` / connection refused). This makes the `8.0` merge queue red on aarch64 + macOS for any PR (e.g. #10360), while all x86_64 platforms pass.

2. **The change:** raise the default `test-timeout` from `50` to `120` minutes, matching `8.2`+ (which fixed the same problem in #9101). No workflow overrides this input, so the merge-queue, nightly and PR flows all pick up the new value.

3. **Outcome:** the multi-config suite completes on the slower aarch64/macOS runners, and the coordinator step starts from a clean environment. `8.0`'s merge queue matches the behavior already shipping on `8.2`/`8.4`.

Note: `8.0` is not migrated to the newer `test-matrix` CI (that is a separate, larger effort). This is the minimal, targeted fix — a backport of the `8.2` timeout bump (#9101) adapted to `8.0`'s current workflow.

**Which issues this PR fixes**
1. Unblocks #10360 (backport of #10251 / MOD-16507 to `8.0`), which is currently blocked by aarch64/macOS merge-queue timeouts unrelated to its code.
2. Backport of the timeout bump from #9101.

**Main objects this PR modified**
1. `.github/workflows/task-test.yml` — `test-timeout` default `50` → `120`.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes