### PR TITLE
Block NUMERIC field creation for disk (Flex) indexes

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -1285,6 +1285,7 @@ static int parseFieldSpec(ArgsCursor *ac, IndexSpec *sp, StrongRef sp_ref, Field
     // Skip SORTABLE and NOINDEX options
     return 1;
   } else if (AC_AdvanceIfMatch(ac, SPEC_NUMERIC_STR)) {  // numeric field
+    if (!SearchDisk_MarkUnsupportedFieldIfDiskEnabled(SPEC_NUMERIC_STR, fs, status)) goto error;
     fs->types |= INDEXFLD_T_NUMERIC;
     if (AC_AdvanceIfMatch(ac, SPEC_INDEXMISSING_STR)) {
       fs->options |= FieldSpec_IndexMissing;
@@ -1442,8 +1443,8 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
 
     if (isSpecOnDiskForValidation(sp))
     {
-      if (!FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && !FIELD_IS(fs, INDEXFLD_T_VECTOR) && !FIELD_IS(fs, INDEXFLD_T_TAG) && !FIELD_IS(fs, INDEXFLD_T_NUMERIC)) {
-        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Disk index does not support non-TEXT/VECTOR/TAG/NUMERIC fields");
+      if (!FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && !FIELD_IS(fs, INDEXFLD_T_VECTOR) && !FIELD_IS(fs, INDEXFLD_T_TAG)) {
+        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Disk index does not support non-TEXT/VECTOR/TAG fields");
         goto reset;
       }
       if (fs->options & FieldSpec_NotIndexable) {

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -48,6 +48,8 @@ def test_invalid_field_type(env):
         .error().contains('GEO fields are not supported in Flex indexes')
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA', 'field', 'GEOSHAPE') \
         .error().contains('GEOSHAPE fields are not supported in Flex indexes')
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA', 'field', 'NUMERIC') \
+        .error().contains('NUMERIC fields are not supported in Flex indexes')
 
 
 @skip(cluster=True)


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `FT.CREATE` on a disk (Flex) index accepts NUMERIC fields, but the disk numeric index does not yet survive replication and hot restart — the RAM-resident routing/split metadata (BucketMap) is not coherently snapshotted with the SpeedB disk half.
2. Change: Reject NUMERIC fields at schema-parse time when disk validation is enabled, using the same mechanism (and error shape) as the existing GEO/GEOSHAPE rejection: `NUMERIC fields are not supported in Flex indexes`. NUMERIC is also removed from the disk-supported types in the schema catch-all validation.
3. Outcome: Creating a Flex index with a NUMERIC field now fails with a clear error instead of producing an index that cannot replicate or hot-restart correctly. The block is temporary until the numeric replication/hot-restart work lands.

#### Which additional issues this PR fixes
N/A

#### Main objects this PR modified
1. `parseFieldSpec` (`src/spec.c`) — NUMERIC branch now calls `SearchDisk_MarkUnsupportedFieldIfDiskEnabled`
2. `IndexSpec_AddFieldsInternal` (`src/spec.c`) — disk catch-all no longer lists NUMERIC as supported
3. `tests/pytests/test_flex_validation.py` — `test_invalid_field_type` covers NUMERIC

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
