### PR TITLE
[MOD-16767] Fix cluster FT.SEARCH LIMIT result window

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3175,7 +3175,7 @@ static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) 
 
     RedisModule_ReplyKV_Array(reply, "results"); // >results
 
-    for (int i = 0; i < qlen && i < num; ++i) {
+    for (size_t i = req->offset; i < qlen && i < num; ++i) {
       RedisModule_Reply_Map(reply); // >> result
         searchResult *res = results[i];
 

--- a/src/module.c
+++ b/src/module.c
@@ -3108,9 +3108,8 @@ static void knnPostProcess(searchReducerCtx *rCtx) {
 static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) {
   searchRequestCtx *req = rCtx->searchCtx;
 
-  size_t replyOffset = rCtx->searchCtx->offset;
-  size_t replyEnd = replyOffset + rCtx->searchCtx->limit;
-  replyEnd = MIN(replyEnd, (size_t)req->requestedResultsCount);
+  // Number of results to actually return
+  size_t num = req->requestedResultsCount;
 
   size_t qlen = heap_count(rCtx->pq);
   size_t pos = qlen;
@@ -3176,7 +3175,7 @@ static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) 
 
     RedisModule_ReplyKV_Array(reply, "results"); // >results
 
-    for (size_t i = rCtx->searchCtx->offset; i < qlen && i < replyEnd; ++i) {
+    for (size_t i = rCtx->searchCtx->offset; i < qlen && i < num; ++i) {
       RedisModule_Reply_Map(reply); // >> result
         searchResult *res = results[i];
 
@@ -3224,7 +3223,7 @@ static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) 
   {
     RedisModule_Reply_LongLong(reply, rCtx->totalReplies);
 
-    for (pos = rCtx->searchCtx->offset; pos < qlen && pos < replyEnd; pos++) {
+    for (pos = rCtx->searchCtx->offset; pos < qlen && pos < num; pos++) {
       searchResult *res = results[pos];
       RedisModule_Reply_StringBuffer(reply, res->id, res->idLen);
       if (req->withScores) {

--- a/src/module.c
+++ b/src/module.c
@@ -3109,7 +3109,7 @@ static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) 
   searchRequestCtx *req = rCtx->searchCtx;
 
   // Number of results to actually return
-  size_t num = req->requestedResultsCount;
+  size_t num = req->offset + req->limit;
 
   size_t qlen = heap_count(rCtx->pq);
   size_t pos = qlen;

--- a/src/module.c
+++ b/src/module.c
@@ -3110,6 +3110,7 @@ static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) 
 
   size_t replyOffset = rCtx->searchCtx->offset;
   size_t replyEnd = replyOffset + rCtx->searchCtx->limit;
+  replyEnd = MIN(replyEnd, (size_t)req->requestedResultsCount);
 
   size_t qlen = heap_count(rCtx->pq);
   size_t pos = qlen;

--- a/src/module.c
+++ b/src/module.c
@@ -3108,8 +3108,8 @@ static void knnPostProcess(searchReducerCtx *rCtx) {
 static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) {
   searchRequestCtx *req = rCtx->searchCtx;
 
-  // Number of results to actually return
-  size_t num = req->requestedResultsCount;
+  size_t replyOffset = rCtx->searchCtx->offset;
+  size_t replyEnd = replyOffset + rCtx->searchCtx->limit;
 
   size_t qlen = heap_count(rCtx->pq);
   size_t pos = qlen;
@@ -3175,7 +3175,7 @@ static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) 
 
     RedisModule_ReplyKV_Array(reply, "results"); // >results
 
-    for (size_t i = req->offset; i < qlen && i < num; ++i) {
+    for (size_t i = rCtx->searchCtx->offset; i < qlen && i < replyEnd; ++i) {
       RedisModule_Reply_Map(reply); // >> result
         searchResult *res = results[i];
 
@@ -3223,7 +3223,7 @@ static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) 
   {
     RedisModule_Reply_LongLong(reply, rCtx->totalReplies);
 
-    for (pos = rCtx->searchCtx->offset; pos < qlen && pos < num; pos++) {
+    for (pos = rCtx->searchCtx->offset; pos < qlen && pos < replyEnd; pos++) {
       searchResult *res = results[pos];
       RedisModule_Reply_StringBuffer(reply, res->id, res->idLen);
       if (req->withScores) {

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -116,6 +116,8 @@ def test_search():
 @skip(redis_less_than="7.0.0")
 def test_search_sortby_limit_offset():
     env = Env(protocol=3)
+    if not env.isCluster():
+        env.skip()
     conn = getConnectionByEnv(env)
 
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'count', 'NUMERIC', 'SORTABLE')
@@ -130,6 +132,8 @@ def test_search_sortby_limit_offset():
 @skip(redis_less_than="7.0.0")
 def test_search_knn_limit_count():
     env = Env(protocol=3, moduleArgs='DEFAULT_DIALECT 2')
+    if not env.isCluster():
+        env.skip()
     conn = getConnectionByEnv(env)
 
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'FLAT', '6',

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -114,6 +114,20 @@ def test_search():
     env.expect('FT.search', 'idx1', "*", 'SCORER', 'TFIDF').equal(exp)
 
 @skip(redis_less_than="7.0.0")
+def test_search_sortby_limit_offset():
+    env = Env(protocol=3)
+    conn = getConnectionByEnv(env)
+
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'count', 'NUMERIC', 'SORTABLE')
+    for i in range(30):
+        conn.execute_command('HSET', f'cdoc{{{i}}}', 'count', i)
+    waitForIndex(env, 'idx')
+
+    res = env.cmd('FT.SEARCH', 'idx', '*', 'SORTBY', 'count', 'ASC', 'LIMIT', '20', '10', 'NOCONTENT')
+    ids = [row['id'] for row in res['results']]
+    env.assertEqual(ids, [f'cdoc{{{i}}}' for i in range(20, 30)])
+
+@skip(redis_less_than="7.0.0")
 def test_search_timeout():
     num_range = 1000
     env = Env(protocol=3, moduleArgs=f'DEFAULT_DIALECT 2 MAXPREFIXEXPANSIONS {num_range} TIMEOUT 1')

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -113,11 +113,9 @@ def test_search():
     }
     env.expect('FT.search', 'idx1', "*", 'SCORER', 'TFIDF').equal(exp)
 
-@skip(redis_less_than="7.0.0")
+@skip(cluster=False, redis_less_than="7.0.0")
 def test_search_sortby_limit_offset():
     env = Env(protocol=3)
-    if not env.isCluster():
-        env.skip()
     conn = getConnectionByEnv(env)
 
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'count', 'NUMERIC', 'SORTABLE')
@@ -128,25 +126,6 @@ def test_search_sortby_limit_offset():
     res = env.cmd('FT.SEARCH', 'idx', '*', 'SORTBY', 'count', 'ASC', 'LIMIT', '20', '10', 'NOCONTENT')
     ids = [row['id'] for row in res['results']]
     env.assertEqual(ids, [f'cdoc{{{i}}}' for i in range(20, 30)])
-
-@skip(redis_less_than="7.0.0")
-def test_search_knn_limit_count():
-    env = Env(protocol=3, moduleArgs='DEFAULT_DIALECT 2')
-    if not env.isCluster():
-        env.skip()
-    conn = getConnectionByEnv(env)
-
-    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'FLAT', '6',
-            'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2')
-    for i in range(30):
-        conn.execute_command('HSET', f'vdoc{{{i}}}', 'v',
-                             np.array([float(i), 0.0], dtype=np.float32).tobytes())
-    waitForIndex(env, 'idx')
-
-    res = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 20 @v $B]', 'PARAMS', '2', 'B',
-                  np.array([0.0, 0.0], dtype=np.float32).tobytes(), 'LIMIT', '0', '10',
-                  'NOCONTENT')
-    env.assertEqual(len(res['results']), 10)
 
 @skip(redis_less_than="7.0.0")
 def test_search_timeout():

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -128,6 +128,23 @@ def test_search_sortby_limit_offset():
     env.assertEqual(ids, [f'cdoc{{{i}}}' for i in range(20, 30)])
 
 @skip(redis_less_than="7.0.0")
+def test_search_knn_limit_count():
+    env = Env(protocol=3, moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'FLAT', '6',
+            'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2')
+    for i in range(30):
+        conn.execute_command('HSET', f'vdoc{{{i}}}', 'v',
+                             np.array([float(i), 0.0], dtype=np.float32).tobytes())
+    waitForIndex(env, 'idx')
+
+    res = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 20 @v $B]', 'PARAMS', '2', 'B',
+                  np.array([0.0, 0.0], dtype=np.float32).tobytes(), 'LIMIT', '0', '10',
+                  'NOCONTENT')
+    env.assertEqual(len(res['results']), 10)
+
+@skip(redis_less_than="7.0.0")
 def test_search_timeout():
     num_range = 1000
     env = Env(protocol=3, moduleArgs=f'DEFAULT_DIALECT 2 MAXPREFIXEXPANSIONS {num_range} TIMEOUT 1')

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -127,6 +127,43 @@ def test_search_sortby_limit_offset():
     ids = [row['id'] for row in res['results']]
     env.assertEqual(ids, [f'cdoc{{{i}}}' for i in range(20, 30)])
 
+def _search_knn_limit_offset(protocol):
+    env = Env(protocol=protocol, moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'FLAT', '6',
+            'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2')
+    for i in range(30):
+        conn.execute_command('HSET', f'vdoc{{{i:02d}}}', 'v',
+                             np.array([float(i), 0.0], dtype=np.float32).tobytes())
+    waitForIndex(env, 'idx')
+
+    blob = np.array([0.0, 0.0], dtype=np.float32).tobytes()
+
+    res = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 20 @v $B]', 'PARAMS', '2', 'B', blob,
+                  'LIMIT', '0', '10', 'NOCONTENT', 'DIALECT', '2')
+    if protocol == 3:
+        ids = [row['id'] for row in res['results']]
+    else:
+        ids = res[1:]
+    env.assertEqual(ids, [f'vdoc{{{i:02d}}}' for i in range(10)])
+
+    res = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 20 @v $B]', 'PARAMS', '2', 'B', blob,
+                  'LIMIT', '10', '10', 'NOCONTENT', 'DIALECT', '2')
+    if protocol == 3:
+        ids = [row['id'] for row in res['results']]
+    else:
+        ids = res[1:]
+    env.assertEqual(ids, [f'vdoc{{{i:02d}}}' for i in range(10, 20)])
+
+@skip(cluster=False, redis_less_than="7.0.0")
+def test_search_knn_limit_offset_resp2():
+    _search_knn_limit_offset(protocol=2)
+
+@skip(cluster=False, redis_less_than="7.0.0")
+def test_search_knn_limit_offset_resp3():
+    _search_knn_limit_offset(protocol=3)
+
 @skip(redis_less_than="7.0.0")
 def test_search_timeout():
     num_range = 1000


### PR DESCRIPTION
## Describe the changes in the pull request

Current:
- In RESP3 cluster mode, `FT.SEARCH ... LIMIT <offset> <count>` can return `offset + count` results instead of applying the final coordinator offset.
- In cluster mode, KNN search can return `K` results instead of the requested LIMIT count when `K > count`, for example `*=>[KNN 20 @v $B] LIMIT 0 10` returning 20 rows. This affects both RESP2 and RESP3.

Change:
- Start the RESP3 distributed search reply loop at the request offset, matching the existing RESP2 path.
- Bound final coordinator replies by the original client LIMIT window (`offset + count`) instead of the internal shard collection window.
- Keep `requestedResultsCount` available for shard fanout/merge, including KNN where the coordinator may need to collect up to `K` candidates before slicing the final reply.
- Add cluster regressions for:
  - RESP3 `FT.SEARCH ... SORTBY ... LIMIT 20 10`
  - RESP2/RESP3 `FT.SEARCH ... KNN 20 ... LIMIT 0 10`
  - RESP2/RESP3 `FT.SEARCH ... KNN 20 ... LIMIT 10 10`

Outcome:
- RESP3 cluster search now returns only the requested result window.
- Cluster KNN search now returns the requested LIMIT page even when KNN internally collects a larger candidate set.

#### Which additional issues this PR fixes
1. MOD-16767
2. #10369

#### Version / history notes

I did not find an 8.4-specific source change that introduced the RESP3 offset behavior. The same vulnerable RESP3 coordinator loop exists in `v8.2.13` and `origin/8.2`, so the issue appears to be latent before 8.4.

The broken RESP3 result serialization loop was introduced by the RESP3 support PR:
https://github.com/RediSearch/RediSearch/pull/3574

The same logic was later moved from the coordinator module source into the unified module build path by:
https://github.com/RediSearch/RediSearch/pull/4935

The KNN over-return case is caused by reusing `requestedResultsCount` for both shard collection and final reply serialization. KNN intentionally expands `requestedResultsCount` to at least `K` so the coordinator can merge enough candidates, but the final reply still needs to be sliced by the original client LIMIT window.

#### Main objects this PR modified
1. `src/module.c`
2. `tests/pytests/test_resp3.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Fixes cluster `FT.SEARCH` returning too many rows when applying `LIMIT`, including RESP3 non-zero offsets and KNN queries where `K` is larger than the requested LIMIT count.
