### PR TITLE
Change default query TIMEOUT to 5000ms and ON_TIMEOUT policy to fail for Flex (disk) indexes

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2479,7 +2479,7 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
   // Enum parameters
   RM_TRY(
     RedisModule_RegisterEnumConfig(
-      ctx, "search-on-timeout", TimeoutPolicy_Return,
+      ctx, "search-on-timeout", TimeoutPolicy_Fail,
       REDISMODULE_CONFIG_UNPREFIXED,
       on_timeout_vals, on_timeout_enums, 3,
       get_on_timeout, set_on_timeout, NULL,

--- a/src/config.c
+++ b/src/config.c
@@ -2314,7 +2314,8 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
 
   RM_TRY(
     RedisModule_RegisterNumericConfig(
-      ctx, "search-timeout", DEFAULT_QUERY_TIMEOUT_MS,
+      ctx, "search-timeout",
+      SearchDisk_IsEnabled() ? DEFAULT_QUERY_TIMEOUT_MS_FLEX : DEFAULT_QUERY_TIMEOUT_MS,
       REDISMODULE_CONFIG_UNPREFIXED, 1,
       LLONG_MAX, get_long_numeric_config, set_long_numeric_config, NULL,
       (void *)&(RSGlobalConfig.requestConfigParams.queryTimeoutMS)
@@ -2479,7 +2480,8 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
   // Enum parameters
   RM_TRY(
     RedisModule_RegisterEnumConfig(
-      ctx, "search-on-timeout", TimeoutPolicy_Fail,
+      ctx, "search-on-timeout",
+      SearchDisk_IsEnabled() ? DEFAULT_TIMEOUT_POLICY_FLEX : DEFAULT_TIMEOUT_POLICY,
       REDISMODULE_CONFIG_UNPREFIXED,
       on_timeout_vals, on_timeout_enums, 3,
       get_on_timeout, set_on_timeout, NULL,

--- a/src/config.h
+++ b/src/config.h
@@ -365,7 +365,7 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
 #define DEFAULT_MIN_TERM_PREFIX 2
 #define DEFAULT_MIN_STEM_LENGTH 4
 #define DEFAULT_MULTI_TEXT_SLOP 100
-#define DEFAULT_QUERY_TIMEOUT_MS 500
+#define DEFAULT_QUERY_TIMEOUT_MS 5000
 #define DEFAULT_MAX_FOREGROUND_TIMEOUT_LIMIT_MS 60000
 #define DEFAULT_UNION_ITERATOR_HEAP 20
 #define DEFAULT_VSS_MAX_RESIZE 0
@@ -407,7 +407,7 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
     .iteratorsConfigParams.minStemLength = DEFAULT_MIN_STEM_LENGTH,            \
     .iteratorsConfigParams.maxPrefixExpansions = DEFAULT_MAX_PREFIX_EXPANSIONS,\
     .requestConfigParams.queryTimeoutMS = DEFAULT_QUERY_TIMEOUT_MS,            \
-    .requestConfigParams.timeoutPolicy = TimeoutPolicy_Return,                 \
+    .requestConfigParams.timeoutPolicy = TimeoutPolicy_Fail,                   \
     .maxForegroundTimeoutLimitMS = DEFAULT_MAX_FOREGROUND_TIMEOUT_LIMIT_MS,    \
     .cursorReadSize = 1000,                                                    \
     .cursorMaxIdle = DEFAULT_MAX_CURSOR_IDLE,                                  \

--- a/src/config.h
+++ b/src/config.h
@@ -365,7 +365,13 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
 #define DEFAULT_MIN_TERM_PREFIX 2
 #define DEFAULT_MIN_STEM_LENGTH 4
 #define DEFAULT_MULTI_TEXT_SLOP 100
-#define DEFAULT_QUERY_TIMEOUT_MS 5000
+#define DEFAULT_QUERY_TIMEOUT_MS 500
+// Flex (disk-based indexes) defaults: disk queries are expected to take
+// longer, so they get a higher timeout, and time out with an error instead
+// of returning partial results.
+#define DEFAULT_QUERY_TIMEOUT_MS_FLEX 5000
+#define DEFAULT_TIMEOUT_POLICY TimeoutPolicy_Return
+#define DEFAULT_TIMEOUT_POLICY_FLEX TimeoutPolicy_Fail
 #define DEFAULT_MAX_FOREGROUND_TIMEOUT_LIMIT_MS 60000
 #define DEFAULT_UNION_ITERATOR_HEAP 20
 #define DEFAULT_VSS_MAX_RESIZE 0
@@ -407,7 +413,7 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
     .iteratorsConfigParams.minStemLength = DEFAULT_MIN_STEM_LENGTH,            \
     .iteratorsConfigParams.maxPrefixExpansions = DEFAULT_MAX_PREFIX_EXPANSIONS,\
     .requestConfigParams.queryTimeoutMS = DEFAULT_QUERY_TIMEOUT_MS,            \
-    .requestConfigParams.timeoutPolicy = TimeoutPolicy_Fail,                   \
+    .requestConfigParams.timeoutPolicy = DEFAULT_TIMEOUT_POLICY,               \
     .maxForegroundTimeoutLimitMS = DEFAULT_MAX_FOREGROUND_TIMEOUT_LIMIT_MS,    \
     .cursorReadSize = 1000,                                                    \
     .cursorMaxIdle = DEFAULT_MAX_CURSOR_IDLE,                                  \

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -17,6 +17,7 @@
 #include "hybrid/vector_query_utils.h"
 #include "spec.h"
 #include "search_ctx.h"
+#include "config.h"
 #include "rmalloc.h"
 // #include "index.h"
 #include "aggregate/aggregate.h"
@@ -167,8 +168,8 @@ TEST_F(ParseHybridTest, testBasicValidInput) {
   assertRRFScoringCtx(HYBRID_DEFAULT_RRF_CONSTANT, HYBRID_DEFAULT_WINDOW);
 
   // Verify timeout is set to default
-  ASSERT_EQ(result.search->reqConfig.queryTimeoutMS, 500);
-  ASSERT_EQ(result.vector->reqConfig.queryTimeoutMS, 500);
+  ASSERT_EQ(result.search->reqConfig.queryTimeoutMS, DEFAULT_QUERY_TIMEOUT_MS);
+  ASSERT_EQ(result.vector->reqConfig.queryTimeoutMS, DEFAULT_QUERY_TIMEOUT_MS);
 
   // Verify dialect is set to default
   ASSERT_EQ(result.search->reqConfig.dialectVersion, 2);
@@ -187,8 +188,8 @@ TEST_F(ParseHybridTest, testValidInputWithParams) {
   assertRRFScoringCtx(HYBRID_DEFAULT_RRF_CONSTANT, HYBRID_DEFAULT_WINDOW);
 
   // Verify timeout is set to default
-  ASSERT_EQ(result.search->reqConfig.queryTimeoutMS, 500);
-  ASSERT_EQ(result.vector->reqConfig.queryTimeoutMS, 500);
+  ASSERT_EQ(result.search->reqConfig.queryTimeoutMS, DEFAULT_QUERY_TIMEOUT_MS);
+  ASSERT_EQ(result.vector->reqConfig.queryTimeoutMS, DEFAULT_QUERY_TIMEOUT_MS);
 
   // Verify dialect is set to default
   ASSERT_EQ(result.search->reqConfig.dialectVersion, 2);

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -191,14 +191,14 @@ def testAllConfig(env):
     env.assertEqual(res_dict['MAXEXPANSIONS'][0], '200')
     env.assertEqual(res_dict['MAXPREFIXEXPANSIONS'][0], '200')
     env.assertEqual(res_dict['DEFAULT_SCORER'][0], 'BM25STD')
-    env.assertContains(res_dict['TIMEOUT'][0], ['500', '0'])
+    env.assertContains(res_dict['TIMEOUT'][0], ['5000', '0'])
     env.assertEqual(res_dict['WORKERS'][0], '0')
     env.assertEqual(res_dict['MIN_OPERATION_WORKERS'][0], '4')
     env.assertEqual(res_dict['TIERED_HNSW_BUFFER_LIMIT'][0], '1024')
     env.assertEqual(res_dict['PRIVILEGED_THREADS_NUM'][0], '1')
     env.assertEqual(res_dict['WORKERS_PRIORITY_BIAS_THRESHOLD'][0], '1')
     env.assertEqual(res_dict['FRISOINI'][0], None)
-    env.assertEqual(res_dict['ON_TIMEOUT'][0], 'return')
+    env.assertEqual(res_dict['ON_TIMEOUT'][0], 'fail')
     env.assertEqual(res_dict['GCSCANSIZE'][0], '100')
     env.assertEqual(res_dict['MIN_PHONETIC_TERM_LEN'][0], '3')
     env.assertEqual(res_dict['FORK_GC_RUN_INTERVAL'][0], '30')
@@ -578,7 +578,7 @@ numericConfigs = [
     ('search-min-stem-len', 'MINSTEMLEN', 4, 2, UINT32_MAX, False, False),
     ('search-multi-text-slop', 'MULTI_TEXT_SLOP', 100, 1, UINT32_MAX, True, False),
     ('search-tiered-hnsw-buffer-limit', 'TIERED_HNSW_BUFFER_LIMIT', 1024, 0, LLONG_MAX, True, False),
-    ('search-timeout', 'TIMEOUT', 500, 1, LLONG_MAX, False, False),
+    ('search-timeout', 'TIMEOUT', 5000, 1, LLONG_MAX, False, False),
     ('search-union-iterator-heap', 'UNION_ITERATOR_HEAP', 20, 1, UINT32_MAX, False, False),
     ('search-vss-max-resize', 'VSS_MAX_RESIZE', 0, 0, UINT32_MAX, False, False),
     ('search-workers', 'WORKERS', min(MAX_WORKER_THREADS, os.cpu_count()), 0, 16, False, False),
@@ -1169,7 +1169,7 @@ def testConfigAPIRunTimeEnumParams():
 
     # Test default value
     env.expect('CONFIG', 'GET', 'search-on-timeout')\
-        .equal(['search-on-timeout', 'return'])
+        .equal(['search-on-timeout', 'fail'])
 
     # Test search-on-timeout - valid values
     env.expect('CONFIG', 'SET', 'search-on-timeout', 'fail').equal('OK')

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -191,14 +191,14 @@ def testAllConfig(env):
     env.assertEqual(res_dict['MAXEXPANSIONS'][0], '200')
     env.assertEqual(res_dict['MAXPREFIXEXPANSIONS'][0], '200')
     env.assertEqual(res_dict['DEFAULT_SCORER'][0], 'BM25STD')
-    env.assertContains(res_dict['TIMEOUT'][0], ['5000', '0'])
+    env.assertContains(res_dict['TIMEOUT'][0], ['500', '0'])
     env.assertEqual(res_dict['WORKERS'][0], '0')
     env.assertEqual(res_dict['MIN_OPERATION_WORKERS'][0], '4')
     env.assertEqual(res_dict['TIERED_HNSW_BUFFER_LIMIT'][0], '1024')
     env.assertEqual(res_dict['PRIVILEGED_THREADS_NUM'][0], '1')
     env.assertEqual(res_dict['WORKERS_PRIORITY_BIAS_THRESHOLD'][0], '1')
     env.assertEqual(res_dict['FRISOINI'][0], None)
-    env.assertEqual(res_dict['ON_TIMEOUT'][0], 'fail')
+    env.assertEqual(res_dict['ON_TIMEOUT'][0], 'return')
     env.assertEqual(res_dict['GCSCANSIZE'][0], '100')
     env.assertEqual(res_dict['MIN_PHONETIC_TERM_LEN'][0], '3')
     env.assertEqual(res_dict['FORK_GC_RUN_INTERVAL'][0], '30')
@@ -578,7 +578,7 @@ numericConfigs = [
     ('search-min-stem-len', 'MINSTEMLEN', 4, 2, UINT32_MAX, False, False),
     ('search-multi-text-slop', 'MULTI_TEXT_SLOP', 100, 1, UINT32_MAX, True, False),
     ('search-tiered-hnsw-buffer-limit', 'TIERED_HNSW_BUFFER_LIMIT', 1024, 0, LLONG_MAX, True, False),
-    ('search-timeout', 'TIMEOUT', 5000, 1, LLONG_MAX, False, False),
+    ('search-timeout', 'TIMEOUT', 500, 1, LLONG_MAX, False, False),
     ('search-union-iterator-heap', 'UNION_ITERATOR_HEAP', 20, 1, UINT32_MAX, False, False),
     ('search-vss-max-resize', 'VSS_MAX_RESIZE', 0, 0, UINT32_MAX, False, False),
     ('search-workers', 'WORKERS', min(MAX_WORKER_THREADS, os.cpu_count()), 0, 16, False, False),
@@ -1169,7 +1169,7 @@ def testConfigAPIRunTimeEnumParams():
 
     # Test default value
     env.expect('CONFIG', 'GET', 'search-on-timeout')\
-        .equal(['search-on-timeout', 'fail'])
+        .equal(['search-on-timeout', 'return'])
 
     # Test search-on-timeout - valid values
     env.expect('CONFIG', 'SET', 'search-on-timeout', 'fail').equal('OK')


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: The default query timeout (`TIMEOUT` / `search-timeout`) is 500ms and the default timeout policy (`ON_TIMEOUT` / `search-on-timeout`) is `return` (return partial results on timeout), regardless of whether the deployment uses disk-based (Flex) indexes.
2. Change: In Flex mode (`SearchDisk_IsEnabled()`, i.e. `bigredis-enabled`), where every index is disk-based, the config defaults registered with Redis become `TIMEOUT 5000` and `ON_TIMEOUT fail`. Non-Flex deployments keep the existing 500ms / `return` defaults. Explicitly configured values (module ARGS, config file, `CONFIG SET`) still override the defaults as before.
3. Outcome: Disk-based queries, which are expected to take longer, get more time to complete by default — and when they do time out, users get an explicit error rather than silently-partial results. In-memory deployments are unaffected.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. `src/config.h`: new `DEFAULT_QUERY_TIMEOUT_MS_FLEX` (5000) and `DEFAULT_TIMEOUT_POLICY_FLEX` (`TimeoutPolicy_Fail`) alongside the existing defaults
2. `src/config.c` (`RegisterModuleConfig_Local`): `search-timeout` and `search-on-timeout` register Flex-conditional default values (Flex mode is determined before config registration in `RedisModule_OnLoad`)
3. `tests/cpptests/test_cpp_parse_hybrid.cpp`: assert the default timeout via `DEFAULT_QUERY_TIMEOUT_MS` instead of a hardcoded 500

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
