### PR TITLE
[MOD-16745] Fix FT.INFO num_records for multi-value TAG fields

### DIFF
--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -24,6 +24,7 @@
 #include "query_term_ffi.h"
 #include "search_disk.h"
 #include "spec.h"
+#include <string.h>
 
 extern RedisModuleCtx *RSDummyContext;
 
@@ -160,6 +161,21 @@ static int tokenizeTagString(const char *str, const FieldSpec *fs, char ***resAr
   return REDISMODULE_OK;
 }
 
+static void TagIndex_DeduplicatePreprocessedData(char **tags) {
+  for (uint32_t ii = 0; ii < array_len(tags); ++ii) {
+    if (!tags[ii]) continue;
+
+    for (uint32_t jj = ii + 1; jj < array_len(tags);) {
+      if (tags[jj] && strcmp(tags[ii], tags[jj]) == 0) {
+        rm_free(tags[jj]);
+        tags = array_del(tags, jj);
+      } else {
+        ++jj;
+      }
+    }
+  }
+}
+
 int TagIndex_Preprocess(const FieldSpec *fs, const DocumentField *data, FieldIndexerData *fdata) {
   arrayof(char*) arr = array_new(char *, 4);
   const char *str;
@@ -188,6 +204,7 @@ int TagIndex_Preprocess(const FieldSpec *fs, const DocumentField *data, FieldInd
     RS_ABORT("nope")
     break;
   }
+  TagIndex_DeduplicatePreprocessedData(arr);
   fdata->tags = arr;
   return ret;
 }
@@ -242,7 +259,7 @@ static void TagIndex_WritePostings(TagIndex *idx, const char **values, size_t n,
  *     `TagIndex_WritePostings`, so the trie insert is skipped to preserve
  *     them.
  *
- * Both modes populate `idx->suffix` and bump `stats->numRecords` once per tag posting.
+ * Both modes populate `idx->suffix` and bump `stats->numRecords` once per unique tag posting.
  * Infallible. */
 void TagIndex_Commit(TagIndex *idx, const char **values, size_t n, IndexStats *stats) {
   if (!values) return;

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -242,12 +242,15 @@ static void TagIndex_WritePostings(TagIndex *idx, const char **values, size_t n,
  *     `TagIndex_WritePostings`, so the trie insert is skipped to preserve
  *     them.
  *
- * Both modes populate `idx->suffix` and bump `stats->numRecords`. Infallible. */
+ * Both modes populate `idx->suffix` and bump `stats->numRecords` once per tag posting.
+ * Infallible. */
 void TagIndex_Commit(TagIndex *idx, const char **values, size_t n, IndexStats *stats) {
   if (!values) return;
+  size_t numRecords = 0;
   for (size_t ii = 0; ii < n; ++ii) {
     const char *tok = values[ii];
     if (!tok) continue;
+    numRecords++;
     size_t len = strlen(tok);
     if (idx->diskSpec) {
       TrieMap_Add(idx->values, tok, len, NULL, NULL);
@@ -256,7 +259,7 @@ void TagIndex_Commit(TagIndex *idx, const char **values, size_t n, IndexStats *s
       addSuffixTrieMap(idx->suffix, tok, len);
     }
   }
-  stats->numRecords++;
+  stats->numRecords += numRecords;
 }
 
 /* Phase 1 (index) for a vector of pre-processed tags. Writes the per-tag

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -24,7 +24,6 @@
 #include "query_term_ffi.h"
 #include "search_disk.h"
 #include "spec.h"
-#include <string.h>
 
 extern RedisModuleCtx *RSDummyContext;
 
@@ -161,21 +160,6 @@ static int tokenizeTagString(const char *str, const FieldSpec *fs, char ***resAr
   return REDISMODULE_OK;
 }
 
-static void TagIndex_DeduplicatePreprocessedData(char **tags) {
-  for (uint32_t ii = 0; ii < array_len(tags); ++ii) {
-    if (!tags[ii]) continue;
-
-    for (uint32_t jj = ii + 1; jj < array_len(tags);) {
-      if (tags[jj] && strcmp(tags[ii], tags[jj]) == 0) {
-        rm_free(tags[jj]);
-        tags = array_del(tags, jj);
-      } else {
-        ++jj;
-      }
-    }
-  }
-}
-
 int TagIndex_Preprocess(const FieldSpec *fs, const DocumentField *data, FieldIndexerData *fdata) {
   arrayof(char*) arr = array_new(char *, 4);
   const char *str;
@@ -204,7 +188,6 @@ int TagIndex_Preprocess(const FieldSpec *fs, const DocumentField *data, FieldInd
     RS_ABORT("nope")
     break;
   }
-  TagIndex_DeduplicatePreprocessedData(arr);
   fdata->tags = arr;
   return ret;
 }
@@ -226,12 +209,16 @@ struct InvertedIndex *TagIndex_OpenIndex(const TagIndex *idx, const char *value,
 // Returns the number of bytes occupied by the encoded entry plus the size of
 // the inverted index (if a new inverted index was created)
 static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, t_docId docId,
-                                  IndexStats *stats) {
+                                  IndexStats *stats, size_t *numRecords) {
   size_t sz;
   RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0,
                        .metrics = MetricsVec_New()};
   InvertedIndex *iv = TagIndex_OpenIndex(idx, value, len, CREATE_INDEX, &sz);
+  uint32_t numDocs = InvertedIndex_NumDocs(iv);
   AddRecordOutcome r = InvertedIndex_WriteEntryGeneric(iv, &rec);
+  if (InvertedIndex_NumDocs(iv) > numDocs) {
+    (*numRecords)++;
+  }
   IndexStats_BlockCountAdd(stats, r.blocks_added);
   return r.mem_growth + sz;
 }
@@ -242,12 +229,14 @@ static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, 
 static void TagIndex_WritePostings(TagIndex *idx, const char **values, size_t n,
                                      t_docId docId, IndexStats *stats) {
   if (!values) return;
+  size_t numRecords = 0;
   for (size_t ii = 0; ii < n; ++ii) {
     const char *tok = values[ii];
     if (tok) {
-      stats->invertedSize += tagIndex_Put(idx, tok, strlen(tok), docId, stats);
+      stats->invertedSize += tagIndex_Put(idx, tok, strlen(tok), docId, stats, &numRecords);
     }
   }
+  stats->numRecords += numRecords;
 }
 
 /* Apply the in-memory tag-trie updates for a vector of tag tokens (Phase 3).
@@ -259,7 +248,8 @@ static void TagIndex_WritePostings(TagIndex *idx, const char **values, size_t n,
  *     `TagIndex_WritePostings`, so the trie insert is skipped to preserve
  *     them.
  *
- * Both modes populate `idx->suffix` and bump `stats->numRecords` once per unique tag posting.
+ * Both modes populate `idx->suffix`; memory mode already bumped `stats->numRecords`
+ * for the actual postings written by `TagIndex_WritePostings`.
  * Infallible. */
 void TagIndex_Commit(TagIndex *idx, const char **values, size_t n, IndexStats *stats) {
   if (!values) return;
@@ -276,7 +266,9 @@ void TagIndex_Commit(TagIndex *idx, const char **values, size_t n, IndexStats *s
       addSuffixTrieMap(idx->suffix, tok, len);
     }
   }
-  stats->numRecords += numRecords;
+  if (idx->diskSpec) {
+    stats->numRecords += numRecords;
+  }
 }
 
 /* Phase 1 (index) for a vector of pre-processed tags. Writes the per-tag

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -248,8 +248,11 @@ static void TagIndex_WritePostings(TagIndex *idx, const char **values, size_t n,
  *     `TagIndex_WritePostings`, so the trie insert is skipped to preserve
  *     them.
  *
- * Both modes populate `idx->suffix`; memory mode already bumped `stats->numRecords`
- * for the actual postings written by `TagIndex_WritePostings`.
+ * Record accounting follows the phase that writes the posting:
+ *   - Memory mode writes postings inline in `TagIndex_WritePostings` and counts
+ *     only records accepted by the inverted index.
+ *   - Disk mode reaches this function after the batch commit, so committed tag
+ *     values are counted here while applying the matching in-memory metadata.
  * Infallible. */
 void TagIndex_Commit(TagIndex *idx, const char **values, size_t n, IndexStats *stats) {
   if (!values) return;

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -192,7 +192,6 @@ arrayof(char *)
                                       struct timespec timeout, long long maxPrefixExpansions, bool skipTimeoutChecks);
 
 /* Preprocess a document tag field, split the content in data into fdata `tags` array
-   and remove duplicate normalized tags for this document.
    Return 0 if there's no content to index in the field (its value is NULL), 1 otherwise
  */
 int TagIndex_Preprocess(const FieldSpec *fs, const DocumentField *data, FieldIndexerData *fdata);
@@ -225,7 +224,8 @@ bool TagIndex_Index(RedisModuleCtx *ctx, TagIndex *idx, SearchDiskWriteBatchHand
  * postings have already been written, so the trie insert is skipped (existing
  * `InvertedIndex*` values are preserved).
  *
- * Both modes populate `idx->suffix` and bump `stats->numRecords` once per unique tag posting. */
+ * Both modes populate `idx->suffix`; memory mode already bumped `stats->numRecords`
+ * for the actual postings written by `TagIndex_Index`. */
 void TagIndex_Commit(TagIndex *idx, const char **values, size_t n, IndexStats *stats);
 
 /* Open an index reader to iterate a tag index for a specific tag. Used at query evaluation time.

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -192,6 +192,7 @@ arrayof(char *)
                                       struct timespec timeout, long long maxPrefixExpansions, bool skipTimeoutChecks);
 
 /* Preprocess a document tag field, split the content in data into fdata `tags` array
+   and remove duplicate normalized tags for this document.
    Return 0 if there's no content to index in the field (its value is NULL), 1 otherwise
  */
 int TagIndex_Preprocess(const FieldSpec *fs, const DocumentField *data, FieldIndexerData *fdata);
@@ -224,7 +225,7 @@ bool TagIndex_Index(RedisModuleCtx *ctx, TagIndex *idx, SearchDiskWriteBatchHand
  * postings have already been written, so the trie insert is skipped (existing
  * `InvertedIndex*` values are preserved).
  *
- * Both modes populate `idx->suffix` and bump `stats->numRecords`. */
+ * Both modes populate `idx->suffix` and bump `stats->numRecords` once per unique tag posting. */
 void TagIndex_Commit(TagIndex *idx, const char **values, size_t n, IndexStats *stats);
 
 /* Open an index reader to iterate a tag index for a specific tag. Used at query evaluation time.

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -224,8 +224,9 @@ bool TagIndex_Index(RedisModuleCtx *ctx, TagIndex *idx, SearchDiskWriteBatchHand
  * postings have already been written, so the trie insert is skipped (existing
  * `InvertedIndex*` values are preserved).
  *
- * Both modes populate `idx->suffix`; memory mode already bumped `stats->numRecords`
- * for the actual postings written by `TagIndex_Index`. */
+ * Record accounting follows the posting write: memory mode accounts accepted
+ * postings in `TagIndex_Index`, and disk mode accounts after the batch commit
+ * in `TagIndex_Commit`. */
 void TagIndex_Commit(TagIndex *idx, const char **values, size_t n, IndexStats *stats);
 
 /* Open an index reader to iterate a tag index for a specific tag. Used at query evaluation time.

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -72,12 +72,15 @@ TEST_F(TagIndexTest, testCreate) {
   for (d = 1; d <= N; d++) {
     TagIndex_Index(NULL, idx, NULL, &v[0], v.size(), d, &stats);
     const size_t sz = stats.invertedSize;
+    const size_t numRecords = stats.numRecords;
     // make sure repeating push of the same vector doesn't get indexed
     TagIndex_Index(NULL, idx, NULL, &v[0], v.size(), d, &stats);
     ASSERT_EQ(sz, stats.invertedSize);
+    ASSERT_EQ(numRecords, stats.numRecords);
   }
 
   ASSERT_EQ(v.size(), TagIndex_NUniqueValues(idx));
+  ASSERT_EQ(N * v.size(), stats.numRecords);
 
   // expectedTotalSZ should include the memory occupied by the inverted index
   // structure and its blocks.
@@ -102,6 +105,7 @@ TEST_F(TagIndexTest, testCreate) {
   // And after the first insert the buffer capacity is 1 byte
   size_t last_block_size = 24 + 8 + 48 + 1;
   ASSERT_EQ(expectedTotalSZ + last_block_size, stats.invertedSize);
+  ASSERT_EQ(N * v.size() + v2.size(), stats.numRecords);
 
   MockQueryEvalCtx mockQctx(N, N);
   QueryIterator *it = TagIndex_OpenReader(idx, &mockQctx.sctx, "hello", 5, 1, RS_INVALID_FIELD_INDEX, NULL);
@@ -121,6 +125,20 @@ TEST_F(TagIndexTest, testCreate) {
   //        TimeSampler_IterationMS(&ts) * 1000000);
   ASSERT_EQ(N + 1, n);
   it->Free(it);
+  TagIndex_Free(idx);
+}
+
+TEST_F(TagIndexTest, testDuplicateTagValuesCountOnce) {
+  TagIndex *idx = NewTagIndex(NULL, 0, false);
+  const char *v[] = {"foo", "foo", "bar"};
+  IndexStats stats = {0};
+
+  TagIndex_Index(NULL, idx, NULL, &v[0], 3, 1, &stats);
+  TagIndex_Commit(idx, &v[0], 3, &stats);
+
+  ASSERT_EQ(2u, stats.numRecords);
+  ASSERT_EQ(2u, TagIndex_NUniqueValues(idx));
+
   TagIndex_Free(idx);
 }
 
@@ -217,10 +235,6 @@ TEST_F(TagIndexTest, testTokenizeViaPreprocess) {
     const char *e[] = {"hello", "world"};
     checkPreprocessCStr(',', (TagFieldFlags)0, (FieldSpecOptions)0, "Hello,World", e, 2);
   }
-  {
-    const char *e[] = {"foo", "bar", "baz"};
-    checkPreprocessCStr(',', (TagFieldFlags)0, (FieldSpecOptions)0, "Foo,foo,BAR,bar,baz", e, 3);
-  }
 
   // --- normal separator, case-insensitive, lowercase needs MORE bytes ---
   // 'İ' (U+0130, 2 bytes) lowercases to 'i' + combining dot above (3 bytes),
@@ -274,16 +288,6 @@ TEST_F(TagIndexTest, testTokenizeViaPreprocess) {
     const char *vals[] = {"red,green", "blue"};
     df.multiVal = (char **)vals;
     df.arrayLen = 2;
-    const char *e[] = {"red", "green", "blue"};
-    checkPreprocess(fs, df, /*expectedRet=*/1, e, 3);
-  }
-  {
-    FieldSpec fs = makeTagFieldSpec(',', (TagFieldFlags)0, (FieldSpecOptions)0);
-    DocumentField df{};
-    df.unionType = FLD_VAR_T_ARRAY;
-    const char *vals[] = {"red,green", "RED,blue", "green"};
-    df.multiVal = (char **)vals;
-    df.arrayLen = 3;
     const char *e[] = {"red", "green", "blue"};
     checkPreprocess(fs, df, /*expectedRet=*/1, e, 3);
   }
@@ -354,7 +358,7 @@ TEST_F(TagIndexTest, testCommitAndOverheadWithSuffix) {
   const char *v[] = {"hello", "world"};
   IndexStats stats = {0};
   TagIndex_Commit(idx, &v[0], 1, &stats);
-  ASSERT_EQ(stats.numRecords, 1u);
+  ASSERT_EQ(stats.numRecords, 0u);
 
   // Overhead with a live index that has a populated suffix trie.
   FieldSpec fs{};

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -217,6 +217,10 @@ TEST_F(TagIndexTest, testTokenizeViaPreprocess) {
     const char *e[] = {"hello", "world"};
     checkPreprocessCStr(',', (TagFieldFlags)0, (FieldSpecOptions)0, "Hello,World", e, 2);
   }
+  {
+    const char *e[] = {"foo", "bar", "baz"};
+    checkPreprocessCStr(',', (TagFieldFlags)0, (FieldSpecOptions)0, "Foo,foo,BAR,bar,baz", e, 3);
+  }
 
   // --- normal separator, case-insensitive, lowercase needs MORE bytes ---
   // 'İ' (U+0130, 2 bytes) lowercases to 'i' + combining dot above (3 bytes),
@@ -270,6 +274,16 @@ TEST_F(TagIndexTest, testTokenizeViaPreprocess) {
     const char *vals[] = {"red,green", "blue"};
     df.multiVal = (char **)vals;
     df.arrayLen = 2;
+    const char *e[] = {"red", "green", "blue"};
+    checkPreprocess(fs, df, /*expectedRet=*/1, e, 3);
+  }
+  {
+    FieldSpec fs = makeTagFieldSpec(',', (TagFieldFlags)0, (FieldSpecOptions)0);
+    DocumentField df{};
+    df.unionType = FLD_VAR_T_ARRAY;
+    const char *vals[] = {"red,green", "RED,blue", "green"};
+    df.multiVal = (char **)vals;
+    df.arrayLen = 3;
     const char *e[] = {"red", "green", "blue"};
     checkPreprocess(fs, df, /*expectedRet=*/1, e, 3);
   }

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -223,7 +223,9 @@ def testTagMultiValueNumRecordsAfterGC(env):
                't', 'TAG', 'SEPARATOR', ',').ok()
 
     def tags_value(doc_id, offset):
-        return ','.join(f'tag{doc_id + offset + tag_id}' for tag_id in range(tags_per_doc))
+        tags = [f'tag{doc_id + offset + tag_id}' for tag_id in range(tags_per_doc)]
+        tags.append(tags[0].upper())
+        return ','.join(tags)
 
     for doc_id in range(n_docs):
         conn.execute_command('HSET', f'doc:{doc_id}', 't', tags_value(doc_id, 0))

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -213,6 +213,37 @@ def testTagIndex_OnReopen(env:Env): # issue MOD-8011
     # Read from the cursor, should not crash
     env.expect('FT.CURSOR', 'READ', 'idx', cursor).noError().equal([ANY, 0]) # cursor is done
 
+@skip(cluster=True)
+def testTagMultiValueNumRecordsAfterGC(env):
+    n_docs = 100
+    tags_per_doc = 5
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'doc:', 'SCHEMA',
+               't', 'TAG', 'SEPARATOR', ',').ok()
+
+    def tags_value(doc_id, offset):
+        return ','.join(f'tag{doc_id + offset + tag_id}' for tag_id in range(tags_per_doc))
+
+    for doc_id in range(n_docs):
+        conn.execute_command('HSET', f'doc:{doc_id}', 't', tags_value(doc_id, 0))
+
+    waitForIndex(env, 'idx')
+    forceInvokeGC(env, 'idx')
+    info = index_info(env, 'idx')
+    env.assertEqual(n_docs, int(info['num_docs']))
+    env.assertEqual(n_docs * tags_per_doc, int(info['num_records']))
+
+    for doc_id in range(n_docs):
+        conn.execute_command('HSET', f'doc:{doc_id}', 't', tags_value(doc_id, n_docs * tags_per_doc))
+
+    waitForIndex(env, 'idx')
+    forceInvokeGC(env, 'idx')
+    info = index_info(env, 'idx')
+    env.assertEqual(n_docs, int(info['num_docs']))
+    env.assertEqual(n_docs * tags_per_doc, int(info['num_records']))
+    env.assertEqual(tags_per_doc, int(float(info['records_per_doc_avg'])))
+
 def testTagCaseSensitive(env):
     conn = getConnectionByEnv(env)
 


### PR DESCRIPTION
## Describe the changes in the pull request

Current: Multi-value TAG fields write one posting per tag value, but `numRecords` was incremented once per field. When GC later removed stale postings per tag value, `FT.INFO num_records` could underflow and make derived averages nonsensical.

Change: Count TAG records once per committed tag posting, matching the postings written by `TagIndex_Index` and later collected by GC. Add a regression test that overwrites multi-value TAG documents, forces GC, and validates `FT.INFO` stats.

Outcome: `FT.INFO num_records` and `records_per_doc_avg` remain correct for multi-value TAG fields after updates and GC.

#### Which additional issues this PR fixes
1. MOD-16745

#### Main objects this PR modified
1. `src/tag_index.c`
2. `tests/pytests/test_tags.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Tests:
`UV_CACHE_DIR=/tmp/uv-cache ASAN_OPTIONS=detect_leaks=0 LSAN_OPTIONS=detect_leaks=0 MODULE=/home/omer-lerman/Code/RediSearch/bin/linux-x64-release/search-community/redisearch.so BINROOT=/home/omer-lerman/Code/RediSearch/bin/linux-x64-release FULL_VARIANT=search-community BINDIR=/home/omer-lerman/Code/RediSearch/bin/linux-x64-release/search-community REDIS_SERVER=/usr/local/bin/redis-server REJSON=0 PARALLEL=0 LOG_LEVEL=debug REDIS_STANDALONE=1 SA=1 TEST=test_tags.py:testTagMultiValueNumRecordsAfterGC ./tests/pytests/runtests.sh`
