### PR TITLE
use JSON API to open JSONRoot directly from Open key

### DIFF
--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -240,8 +240,11 @@ int Document_LoadSchemaFieldJson(Document *doc, RedisSearchCtx *sctx, RedisModul
   ctx = sctx->redisCtx;
   nitems = sctx->spec->numFields;
 
-  // Reuse the caller's already-open, pinned handle when provided instead of opening
-  // the same key a second time; a borrowed handle must not be closed below.
+  // Reuse the caller's already-open, pinned handle when provided (e.g. the async scan
+  // key callback) instead of opening the same key a second time; a borrowed handle must
+  // not be closed below. The handle stays open for the whole function: the RedisJSON root
+  // and every iterator derived from it are views into the value the key holds, so closing
+  // the key before the field loop finishes would leave them dangling.
   k = openKey ? openKey
               : RedisModule_OpenKey(sctx->redisCtx, doc->docKey, DOCUMENT_OPEN_KEY_INDEXING_FLAGS);
   if (!k) {
@@ -253,16 +256,9 @@ int Document_LoadSchemaFieldJson(Document *doc, RedisSearchCtx *sctx, RedisModul
     doc->docExpirationTime = GetKeyExpirationTime(k);
   }
 
-  if (!openKey) {
-    RedisModule_CloseKey(k);
-  }
-
-  if (openKey) {
-    //TODO: Analyze if we do not need to close key and we can always use this path
-    jsonRoot = japi->isJSON(openKey) ? (RedisJSON)RedisModule_ModuleTypeGetValue(openKey) : NULL;
-  } else {
-    jsonRoot = japi->openKeyWithFlags(ctx, doc->docKey, DOCUMENT_OPEN_KEY_QUERY_FLAGS);
-  }
+  // Fetch the JSON root straight off the open handle: RedisJSON validates it is a JSON
+  // module type and returns the root without opening the key a second time by name.
+  jsonRoot = japi->getJsonFromHandle(k);
   if (!jsonRoot) {
     QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Key does not exist or is not a json", ": %s", RedisModule_StringPtrLen(doc->docKey, NULL));
     goto done;
@@ -309,8 +305,14 @@ int Document_LoadSchemaFieldJson(Document *doc, RedisSearchCtx *sctx, RedisModul
   rv = REDISMODULE_OK;
 
 done:
+  // Free the iterator before closing the key: it is a view into the JSON value the key
+  // holds, so it must not outlive the handle.
   if (jsonIter) {
     japi->freeIter(jsonIter);
+  }
+  // Only close a handle we opened ourselves; a borrowed `openKey` is the caller's.
+  if (k && k != openKey) {
+    RedisModule_CloseKey(k);
   }
   return rv;
 }

--- a/src/json.h
+++ b/src/json.h
@@ -18,7 +18,7 @@ extern "C" {
 
 extern RedisJSONAPI *japi;
 extern int japi_ver;
-#define RedisJSONAPI_MIN_API_VER 7
+#define RedisJSONAPI_MIN_API_VER 8
 
 #define JSON_ROOT "$"
 

--- a/src/redisearch_rs/redis_json_api/src/lib.rs
+++ b/src/redisearch_rs/redis_json_api/src/lib.rs
@@ -26,8 +26,8 @@ pub use value::{JsonType, JsonValue, JsonValueRef};
 /// Minimum supported API version.
 pub const MIN_API_VERSION: i32 = ffi::RedisJSONAPI_MIN_API_VER as i32;
 
-/// Latest API version (V7).
-pub const LATEST_API_VERSION: i32 = 7;
+/// Latest API version (V8).
+pub const LATEST_API_VERSION: i32 = 8;
 
 /// The root JSON path.
 pub const JSON_ROOT: &CStr = c"$";
@@ -172,6 +172,38 @@ impl RedisJsonApi {
                 flags.bits() | redis_module::raw::REDISMODULE_READ as i32,
             )
         };
+
+        if ptr.is_null() {
+            None
+        } else {
+            Some(JsonValueRef { ptr, api: self })
+        }
+    }
+
+    /// Gets the JSON root from an already-open [`RedisModuleKey`] handle.
+    ///
+    /// Returns `None` if the key is `NULL`, is not a module type, or does not hold JSON.
+    /// The caller owns the key handle and must keep it open while the returned
+    /// [`JsonValueRef`] is in use.
+    ///
+    /// Only available with RedisJSON API v8 and later.
+    ///
+    /// # Safety
+    ///
+    /// 1. `redis_key` must be a valid, open `RedisModuleKey` handle (or NULL).
+    ///
+    /// [`RedisModuleKey`]: ffi::RedisModuleKey
+    pub unsafe fn open_from_handle(
+        &self,
+        redis_key: *mut ffi::RedisModuleKey,
+    ) -> Option<JsonValueRef<'_>> {
+        let vtable = self.vtable();
+        let get_json_from_handle = vtable
+            .getJsonFromHandle
+            .expect("RedisJSON API function `getJsonFromHandle` not available");
+
+        // Safety: ensured by caller (1.)
+        let ptr = unsafe { get_json_from_handle(redis_key) };
 
         if ptr.is_null() {
             None

--- a/src/redisearch_rs/redis_json_api/src/mock.rs
+++ b/src/redisearch_rs/redis_json_api/src/mock.rs
@@ -76,6 +76,7 @@ static VTABLE: ffi::RedisJSONAPI = ffi::RedisJSONAPI {
     nextKeyValue: Some(next_key_value),
     freeJson: Some(free_json),
     getArray: None,
+    getJsonFromHandle: None,
 };
 
 /// View a `RedisJSON` handle as the `serde_json::Value` node it points at.

--- a/src/rejson_api.h
+++ b/src/rejson_api.h
@@ -171,9 +171,17 @@ typedef struct RedisJSONAPI {
   // use the previous array API to get the values(e.g. getAt, etc.)
   const void* (*getArray)(RedisJSON json, size_t *len, JSONArrayType *type);
 
+  ////////////////
+  // V8 entries //
+  ////////////////
+  // Get a RedisJSON root from an already-open RedisModuleKey handle.
+  // Returns NULL if the key is NULL, is not a module type, or does not hold JSON.
+  // The caller owns the key handle and must keep it open while using the returned RedisJSON.
+  RedisJSON (*getJsonFromHandle)(RedisModuleKey *redis_key);
+
 } RedisJSONAPI;
 
-#define RedisJSONAPI_LATEST_API_VER 7
+#define RedisJSONAPI_LATEST_API_VER 8
 #ifdef __cplusplus
 }
 #endif

--- a/src/rlookup_load_document.c
+++ b/src/rlookup_load_document.c
@@ -178,8 +178,7 @@ int loadIndividualKeys(RLookup *it, RLookupRow *dst, RLookupLoadOptions *options
   const bool borrowedKey = options->openKey && (type == DocumentType_Hash || type == DocumentType_Json);
   if (borrowedKey) {
     if (type == DocumentType_Json) {
-      key = (japi && japi->isJSON(options->openKey)) ? RedisModule_ModuleTypeGetValue(options->openKey)
-                                                     : NULL;
+      key = japi ? (void *)japi->getJsonFromHandle(options->openKey) : NULL;
     } else {
       key = options->openKey;
     }


### PR DESCRIPTION
## Describe the changes in the pull request

Adopt the new RedisJSON `getJsonFromHandle` API (V8) to obtain a JSON root directly from an already-open `RedisModuleKey`, replacing the fragile `RedisModule_ModuleTypeGetValue(...)` cast and removing a redundant open-by-name during JSON indexing.

1. **Current:**
   - RediSearch pinned the RedisJSON shared API at V7 (`RedisJSONAPI_MIN_API_VER == RedisJSONAPI_LATEST_API_VER == 7`).
   - To read a JSON root from a *borrowed*, already-open key handle (the async-scan `key_cb` path), the code reached into RedisJSON internals via `japi->isJSON(k) ? (RedisJSON)RedisModule_ModuleTypeGetValue(k) : NULL`.
   - In the self-open path, `Document_LoadSchemaFieldJson` opened the key with `INDEXING_FLAGS` (to gate on existence/expiration and capture the TTL), **closed it**, and then reopened the *same key by name* via `japi->openKeyWithFlags(..., QUERY_FLAGS)` just to get the JSON root — two opens of the same key, with the handle closed before the root was fetched.

2. **Change:**
   - Bumped the RedisJSON API to **V8**: added the `getJsonFromHandle(RedisModuleKey *)` function pointer to `rejson_api.h`, raised `RedisJSONAPI_LATEST_API_VER` and `RedisJSONAPI_MIN_API_VER` to `8`.
   - Replaced both `RedisModule_ModuleTypeGetValue` workarounds (`document_basic.c`, `rlookup_load_document.c`) with `japi->getJsonFromHandle(...)`, which validates the handle is a JSON module type internally.
   - Refactored `Document_LoadSchemaFieldJson` to open the key **once** and fetch the root off that live handle with `getJsonFromHandle`, keeping it open until the field loop finishes (the root and its iterators are views into the value the key holds), then closing it at `done:` only when we opened it ourselves. This mirrors the sibling `Document_LoadSchemaFieldHash` and drops `openKeyWithFlags` from the indexing path.
   - Updated the Rust `redis_json_api` binding: bumped `LATEST_API_VERSION` to `8`, added a safe `open_from_handle()` wrapper, and added `getJsonFromHandle: None` to the test mock vtable (the bindgen struct regenerates from the header).

3. **Outcome:**
   - JSON indexing no longer opens the same key twice and no longer closes the handle before the JSON root is read, removing a redundant open-by-name and a needless close/reopen window.
   - RediSearch no longer depends on the `RedisModule_ModuleTypeGetValue` cast to interpret a RedisJSON value; the handle is validated by RedisJSON itself.
   - The self-opened JSON read now uses `INDEXING_FLAGS` (consistent with the Hash indexing path) instead of `QUERY_FLAGS`. This is a near-noop: lazily-expired keys are still rejected by the existing `INDEXING` existence gate before any read, and the async-scan path already read from a `RM_Scan`-pinned handle (never `QUERY_FLAGS`).

#### Which additional issues this PR fixes
1. MOD-... <!-- fill in the Jira ticket -->
2. Depends on RedisJSON/RedisJSON#1619 (the V8 `getJsonFromHandle` API) — must be merged/released before this can be built and tested green, otherwise `japi` stays `NULL` (JSON indexing disabled) because `MIN_API_VER` is now `8`.

#### Main objects this PR modified
1. `src/rejson_api.h` — new V8 `getJsonFromHandle` entry; `RedisJSONAPI_LATEST_API_VER` 7 → 8
2. `src/json.h` — `RedisJSONAPI_MIN_API_VER` 7 → 8
3. `src/document_basic.c` — `Document_LoadSchemaFieldJson`: single open + `getJsonFromHandle`, close-at-`done:`
4. `src/rlookup_load_document.c` — borrowed-handle JSON path uses `getJsonFromHandle`
5. `src/redisearch_rs/redis_json_api/{lib.rs,mock.rs}` — `LATEST_API_VERSION` bump, `open_from_handle()`, mock vtable field

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal integration change (RedisJSON API version bump + indexing-path refactor) with no user-visible behavior change.
