### PR TITLE
Fix gbench "built as DEBUG" warning printed in release builds

### DIFF
--- a/tests/cpptests/micro-benchmarks/CMakeLists.txt
+++ b/tests/cpptests/micro-benchmarks/CMakeLists.txt
@@ -33,6 +33,11 @@ target_compile_options(benchmark PRIVATE
 target_compile_options(benchmark_main PRIVATE
   $<$<CXX_COMPILER_ID:Clang>:-Wno-unknown-warning-option -Wno-c2y-extensions>)
 
+# Our RelWithDebInfo flags drop CMake's default -DNDEBUG. Restore it in non-Debug configs so
+# gbench's NDEBUG-based debug-build detection reflects the actual build type.
+target_compile_definitions(benchmark PRIVATE $<$<NOT:$<CONFIG:Debug>>:NDEBUG>)
+target_compile_definitions(benchmark_main PRIVATE $<$<NOT:$<CONFIG:Debug>>:NDEBUG>)
+
 file(GLOB BENCHMARK_ITER_SOURCES "benchmark_*_iterator.cpp")
 foreach(benchmark_file ${BENCHMARK_ITER_SOURCES})
   get_filename_component(benchmark_name ${benchmark_file} NAME_WE)


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Our custom `CMAKE_C(XX)_FLAGS_RELWITHDEBINFO` (`-O3`) replace CMake's defaults, dropping the default `-DNDEBUG`. Google Benchmark detects debug builds via `#ifndef NDEBUG` in its own translation units, so every release-mode micro-benchmark run prints `***WARNING*** Library was built as DEBUG. Timings may be affected.` even though the build is optimized.
2. Change: Define `NDEBUG` on the gbench targets (`benchmark`, `benchmark_main`) only, guarded with `$<$<NOT:$<CONFIG:Debug>>:NDEBUG>` so Debug builds keep the warning.
3. Outcome: Release benchmark runs no longer print the false warning; Debug builds (`./build.sh DEBUG=1`) still print it, where it is accurate. Verified both configs locally on macOS.

#### Which additional issues this PR fixes

#### Main objects this PR modified
1. `tests/cpptests/micro-benchmarks/CMakeLists.txt`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FifezD343HMtFGLo3S7Cye
