### PR TITLE
[MOD-16085] Retain live references to non-index resources when suspending iterators

### DIFF
--- a/src/redisearch_rs/headers/index_result_rs.h
+++ b/src/redisearch_rs/headers/index_result_rs.h
@@ -26,10 +26,60 @@ typedef struct RSQueryTerm RSQueryTerm;
 typedef struct RLookupKey RLookupKey;
 
 /**
+ * A single metric: a borrowed key and a numeric value.
+ */
+typedef struct RawMetricEntry {
+  /**
+   * Borrowed reference to the lookup key that identifies this metric,
+   * or `None` when the metric has no associated key.
+   *
+   * The key always lives under the `'query` lifetime: it belongs to the
+   * query pipeline (the `RLookupKey`), not to the inverted index, so it is
+   * never weakened by the `Active`/`Suspended` ref-mode transitions —
+   * unlike the index-backed pointers of a result, it stays a genuine
+   * `&'query` borrow across the whole suspend/resume cycle. That is why it
+   * is modelled as a plain reference rather than a ref-mode-parametrised
+   * `SharedPtr`.
+   *
+   * Stored as `Option<&'query RLookupKey>` so "no key" is `None`; the
+   * `NonNull` niche of `&T` keeps the C ABI as a nullable `RLookupKey *`.
+   */
+  const RLookupKey *key;
+  /**
+   * The metric value (e.g. vector distance, score).
+   */
+  double value;
+} RawMetricEntry;
+
+/**
  * The [`Active`] instantiation of [`RawOffsetSlice`]: a borrowed view whose data
  * pointer is a live `&'a [u8]`.
  */
 typedef struct RSOffsetVector RSOffsetSlice;
+
+/**
+ * Lifetime-parameterised alias for [`RawMetricEntry`].
+ */
+typedef struct RawMetricEntry MetricEntry;
+
+/**
+ * A read-only, C-visible slice view over the entries of a [`MetricsVec`].
+ *
+ * Returned by [`MetricsVec::as_metrics_slice`] for zero-copy iteration
+ * from C. The pointed-to data is valid as long as the originating
+ * [`MetricsVec`] is not mutated or dropped.
+ */
+typedef struct RawMetricsSlice {
+  /**
+   * Pointer to the first [`MetricEntry`].  May be dangling (but not null)
+   * when `len == 0`.
+   */
+  const struct RawMetricEntry *data;
+  /**
+   * Number of entries.
+   */
+  size_t len;
+} RawMetricsSlice;
 
 #ifndef THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED
 #define THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED
@@ -41,18 +91,16 @@ typedef struct ThinVec_Box_RawIndexResult_Active__u16 {
 } ThinVec_Box_RawIndexResult_Active__u16;
 #endif /* THINVEC_BOX_RAWINDEXRESULT_ACTIVE__U16_DEFINED */
 
-#ifndef THINVEC_RAWMETRICENTRY_ACTIVE__U64_DEFINED
-#define THINVEC_RAWMETRICENTRY_ACTIVE__U64_DEFINED
+#ifndef THINVEC_RAWMETRICENTRY__U64_DEFINED
+#define THINVEC_RAWMETRICENTRY__U64_DEFINED
 /**
  * See the crate's top level documentation for a description of this type.
  */
-typedef struct ThinVec_RawMetricEntry_Active__u64 {
+typedef struct ThinVec_RawMetricEntry__u64 {
   struct Header_u64 *ptr;
-} ThinVec_RawMetricEntry_Active__u64;
-#endif /* THINVEC_RAWMETRICENTRY_ACTIVE__U64_DEFINED */
+} ThinVec_RawMetricEntry__u64;
+#endif /* THINVEC_RAWMETRICENTRY__U64_DEFINED */
 
-#ifndef RAWMETRICSVEC_ACTIVE_DEFINED
-#define RAWMETRICSVEC_ACTIVE_DEFINED
 /**
  * A dynamically-sized collection of [`MetricEntry`] values.
  *
@@ -62,13 +110,12 @@ typedef struct ThinVec_RawMetricEntry_Active__u64 {
  * `repr(transparent)` over `ThinVec` means this type is pointer-sized
  * and can be embedded directly in `repr(C)` structs.
  */
-typedef struct ThinVec_RawMetricEntry_Active__u64 RawMetricsVec_Active;
-#endif /* RAWMETRICSVEC_ACTIVE_DEFINED */
+typedef struct ThinVec_RawMetricEntry__u64 RawMetricsVec;
 
 /**
- * The [`Active`] instantiation of [`RawMetricsVec`].
+ * Lifetime-parameterised alias for [`RawMetricsVec`].
  */
-typedef RawMetricsVec_Active MetricsVec;
+typedef RawMetricsVec MetricsVec;
 
 #ifndef THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED
 #define THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED
@@ -80,94 +127,10 @@ typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u16 {
 } ThinVec_SharedPtr_Active__RawIndexResult_Active__u16;
 #endif /* THINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE__U16_DEFINED */
 
-#ifndef SHAREDPTR_ACTIVE__RLOOKUPKEY_DEFINED
-#define SHAREDPTR_ACTIVE__RLOOKUPKEY_DEFINED
 /**
- * A pointer to `T` whose validity semantics depend on the [`Ref`] mode `Rf`.
- *
- * Internally this is a [`NonNull<T>`]. The `Rf` type parameter controls
- * which constructors and methods are available:
- *
- * - [`Active<'a>`]: built from a reference via
- *   [`SharedPtr::<Active>::from_ref`], with safe access via
- *   [`SharedPtr::get`].
- * - [`Suspended`]: built from a raw [`NonNull<T>`] via
- *   [`SharedPtr::<Suspended>::from_non_null`]; inert (no safe access).
- *   Upgrade to [`Active`] with the unsafe
- *   [`SharedPtr::<Suspended>::into_active`] once validity is
- *   re-established.
- *
- * `SharedPtr` only ever exposes shared (immutable) access to its
- * referent; there is no mutable counterpart.
- *
- * `#[repr(transparent)]` ensures `SharedPtr<Rf, T>` has the same layout
- * as `NonNull<T>` regardless of `Rf`, enabling zero-cost transmutation
- * between `Active` and `Suspended` instantiations of containing
- * `#[repr(C)]` structs. The `NonNull<T>` niche makes
- * `Option<SharedPtr<Rf, T>>` pointer-sized as well.
+ * Lifetime-parameterised alias for [`RawMetricsSlice`].
  */
-typedef RLookupKey *SharedPtr_Active__RLookupKey;
-#endif /* SHAREDPTR_ACTIVE__RLOOKUPKEY_DEFINED */
-
-#ifndef RAWMETRICENTRY_ACTIVE_DEFINED
-#define RAWMETRICENTRY_ACTIVE_DEFINED
-/**
- * A single metric: a borrowed key and a numeric value.
- *
- * The `R: Ref` parameter controls how the key reference is stored:
- * in [`Active<'a>`] mode it is a valid `&'a RLookupKey`, in
- * [`ref_mode::Suspended`] mode it is an inert raw pointer.
- *
- * `key` is `Option<SharedPtr<R, RLookupKey>>` so "no key" is encoded as
- * `None`. `SharedPtr` wraps `NonNull` so the niche optimization keeps the C
- * ABI as a nullable `RLookupKey *`.
- */
-typedef struct RawMetricEntry_Active {
-  /**
-   * Borrowed reference to the lookup key that identifies this metric,
-   * or `None` when the metric has no associated key.
-   */
-  SharedPtr_Active__RLookupKey key;
-  /**
-   * The metric value (e.g. vector distance, score).
-   */
-  double value;
-} RawMetricEntry_Active;
-#endif /* RAWMETRICENTRY_ACTIVE_DEFINED */
-
-/**
- * The [`Active`] instantiation of [`RawMetricEntry`].
- */
-typedef struct RawMetricEntry_Active MetricEntry;
-
-#ifndef SHAREDPTR_ACTIVE__RSQUERYTERM_DEFINED
-#define SHAREDPTR_ACTIVE__RSQUERYTERM_DEFINED
-/**
- * A pointer to `T` whose validity semantics depend on the [`Ref`] mode `Rf`.
- *
- * Internally this is a [`NonNull<T>`]. The `Rf` type parameter controls
- * which constructors and methods are available:
- *
- * - [`Active<'a>`]: built from a reference via
- *   [`SharedPtr::<Active>::from_ref`], with safe access via
- *   [`SharedPtr::get`].
- * - [`Suspended`]: built from a raw [`NonNull<T>`] via
- *   [`SharedPtr::<Suspended>::from_non_null`]; inert (no safe access).
- *   Upgrade to [`Active`] with the unsafe
- *   [`SharedPtr::<Suspended>::into_active`] once validity is
- *   re-established.
- *
- * `SharedPtr` only ever exposes shared (immutable) access to its
- * referent; there is no mutable counterpart.
- *
- * `#[repr(transparent)]` ensures `SharedPtr<Rf, T>` has the same layout
- * as `NonNull<T>` regardless of `Rf`, enabling zero-cost transmutation
- * between `Active` and `Suspended` instantiations of containing
- * `#[repr(C)]` structs. The `NonNull<T>` niche makes
- * `Option<SharedPtr<Rf, T>>` pointer-sized as well.
- */
-typedef struct RSQueryTerm *SharedPtr_Active__RSQueryTerm;
-#endif /* SHAREDPTR_ACTIVE__RSQUERYTERM_DEFINED */
+typedef struct RawMetricsSlice MetricsSlice;
 
 #ifndef SHAREDPTR_ACTIVE__U8_DEFINED
 #define SHAREDPTR_ACTIVE__U8_DEFINED
@@ -269,10 +232,16 @@ typedef struct RawTermRecord_Active_Owned_Body {
    * The term that brought up this record.
    *
    * It borrows the term from another record. `None` encodes "no
-   * term"; thanks to `NonNull`'s niche, `Option<SharedPtr<R, RSQueryTerm>>`
+   * term"; thanks to the `NonNull` niche of `&T`, `Option<&'query RSQueryTerm>`
    * has the same C ABI as a nullable `*const RSQueryTerm`.
+   *
+   * The borrowed query term belongs to the query pipeline, so it lives
+   * under the `'query` lifetime and is never weakened by the
+   * `Active`/`Suspended` ref-mode transitions — it stays a genuine
+   * `&'query` borrow, so it is modelled as a plain reference rather than
+   * a ref-mode-parametrised `SharedPtr`.
    */
-  SharedPtr_Active__RSQueryTerm term;
+  const struct RSQueryTerm *term;
   /**
    * The encoded offsets in which the term appeared in the document
    *
@@ -313,33 +282,6 @@ typedef union RawTermRecord_Active {
  * The [`Active`] instantiation of [`RawTermRecord`].
  */
 typedef union RawTermRecord_Active RSTermRecord;
-
-#ifndef RAWMETRICSSLICE_ACTIVE_DEFINED
-#define RAWMETRICSSLICE_ACTIVE_DEFINED
-/**
- * A read-only, C-visible slice view over the entries of a [`MetricsVec`].
- *
- * Returned by [`MetricsVec::as_metrics_slice`] for zero-copy iteration
- * from C. The pointed-to data is valid as long as the originating
- * [`MetricsVec`] is not mutated or dropped.
- */
-typedef struct RawMetricsSlice_Active {
-  /**
-   * Pointer to the first [`MetricEntry`].  May be dangling (but not null)
-   * when `len == 0`.
-   */
-  const struct RawMetricEntry_Active *data;
-  /**
-   * Number of entries.
-   */
-  size_t len;
-} RawMetricsSlice_Active;
-#endif /* RAWMETRICSSLICE_ACTIVE_DEFINED */
-
-/**
- * The [`Active`] instantiation of [`RawMetricsSlice`].
- */
-typedef struct RawMetricsSlice_Active MetricsSlice;
 
 #ifndef SMALLTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED
 #define SMALLTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED
@@ -654,7 +596,7 @@ typedef struct RawIndexResult_Active {
    * Backed by [`ThinVec`](thin_vec::ThinVec) — pointer-sized, no
    * allocation when empty.
    */
-  RawMetricsVec_Active metrics;
+  RawMetricsVec metrics;
   /**
    * Relative weight for scoring calculations. This is derived from the result's iterator weight
    */

--- a/src/redisearch_rs/index_result/src/aggregate.rs
+++ b/src/redisearch_rs/index_result/src/aggregate.rs
@@ -22,7 +22,7 @@ use super::kind::RSResultKindMask;
 #[cheadergen::config(prefix_with_name)]
 #[derive(Debug)]
 #[repr(u8)]
-pub enum RawAggregateResult<R: Ref> {
+pub enum RawAggregateResult<'query, R: Ref> {
     Borrowed {
         /// The records making up this aggregate result
         ///
@@ -34,7 +34,7 @@ pub enum RawAggregateResult<R: Ref> {
         /// Each child is stored as a [`SharedPtr<R, RawIndexResult<R>>`]. In [`Active`] mode this is
         /// equivalent to a `&'a RSIndexResult<'a>`; in [`ref_mode::Suspended`] mode it is
         /// an inert raw pointer that survives lock release/reacquire cycles.
-        records: SmallThinVec<SharedPtr<R, RawIndexResult<R>>>,
+        records: SmallThinVec<SharedPtr<R, RawIndexResult<'query, R>>>,
 
         /// A map of the aggregate kind of the underlying records
         kind_mask: RSResultKindMask,
@@ -45,7 +45,7 @@ pub enum RawAggregateResult<R: Ref> {
         /// The `RawAggregateResult` is part of a union in [`super::result_data::RawResultData`], so it needs to have a
         /// known size. The std `Vec` won't have this since it is not `#[repr(C)]`, so we use our
         /// own `ThinVec` type which is `#[repr(C)]` and has a known size instead.
-        records: SmallThinVec<Box<RawIndexResult<R>>>,
+        records: SmallThinVec<Box<RawIndexResult<'query, R>>>,
 
         /// A map of the aggregate kind of the underlying records
         kind_mask: RSResultKindMask,
@@ -54,7 +54,7 @@ pub enum RawAggregateResult<R: Ref> {
 
 /// The [`Active`] instantiation of [`RawAggregateResult`].
 #[cheadergen::config(export)]
-pub type RSAggregateResult<'a> = RawAggregateResult<Active<'a>>;
+pub type RSAggregateResult<'a> = RawAggregateResult<'a, Active<'a>>;
 
 // Compile-time proof that the `Active` and `Suspended` instantiations of
 // `RawAggregateResult` are layout-identical. Only `size_of`/`align_of` are
@@ -66,8 +66,8 @@ pub type RSAggregateResult<'a> = RawAggregateResult<Active<'a>>;
 const _: () = {
     use ref_mode::Suspended;
     use std::mem::{align_of, size_of};
-    type A = RawAggregateResult<Active<'static>>;
-    type S = RawAggregateResult<Suspended>;
+    type A = RawAggregateResult<'static, Active<'static>>;
+    type S = RawAggregateResult<'static, Suspended>;
     assert!(size_of::<A>() == size_of::<S>());
     assert!(align_of::<A>() == align_of::<S>());
 };
@@ -107,7 +107,7 @@ impl<'a> PartialEq for RSAggregateResult<'a> {
     }
 }
 
-impl<R: Ref> RawAggregateResult<R> {
+impl<'query, R: Ref> RawAggregateResult<'query, R> {
     /// Create a new empty aggregate result (of the borrowed kind) with the given capacity
     pub fn borrowed_with_capacity(cap: usize) -> Self {
         Self::Borrowed {

--- a/src/redisearch_rs/index_result/src/core/mod.rs
+++ b/src/redisearch_rs/index_result/src/core/mod.rs
@@ -19,7 +19,7 @@ use super::result_data::RawResultData;
 use super::term_record::RawTermRecord;
 use ffi::RSDocumentMetadata;
 use query_term::RSQueryTerm;
-use ref_mode::{Active, Ref, SharedPtr, Suspended};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::{DocId, FieldMask, RS_FIELDMASK_ALL};
 
 /// Builder for creating [`RawIndexResult`] instances.
@@ -28,11 +28,11 @@ use rqe_core::{DocId, FieldMask, RS_FIELDMASK_ALL};
 /// [`RSResultKind::Term`] kind, [`RawIndexResult::build_term`] returns a
 /// specialized [`RawTermResultBuilder`] with additional setters for
 /// term-specific fields.
-pub struct RawIndexResultBuilder<R: Ref> {
+pub struct RawIndexResultBuilder<'query, R: Ref> {
     doc_id: DocId,
     field_mask: FieldMask,
     freq: u32,
-    data: RawResultData<R>,
+    data: RawResultData<'query, R>,
     weight: f64,
 }
 
@@ -42,22 +42,22 @@ pub struct RawIndexResultBuilder<R: Ref> {
 /// Created via [`RawIndexResult::build_term`]. Use [`Self::borrowed_record`]
 /// or [`Self::owned_record`] to set the term record data before calling
 /// [`Self::build`].
-pub struct RawTermResultBuilder<R: Ref> {
+pub struct RawTermResultBuilder<'query, R: Ref> {
     doc_id: DocId,
     field_mask: FieldMask,
     freq: u32,
     weight: f64,
-    record: TermBuilderRecord<R>,
+    record: TermBuilderRecord<'query, R>,
 }
 
 /// Internal enum holding the term record data for the builder.
-enum TermBuilderRecord<R: Ref> {
+enum TermBuilderRecord<'query, R: Ref> {
     Borrowed {
         term: Option<Box<RSQueryTerm>>,
         offsets: RawOffsetSlice<R>,
     },
     Owned {
-        term: Option<SharedPtr<R, RSQueryTerm>>,
+        term: Option<&'query RSQueryTerm>,
         offsets: RSOffsetVector,
     },
     FullyOwned {
@@ -66,7 +66,7 @@ enum TermBuilderRecord<R: Ref> {
     },
 }
 
-impl<R: Ref> RawIndexResultBuilder<R> {
+impl<'query, R: Ref> RawIndexResultBuilder<'query, R> {
     /// Set the document ID of this record
     pub const fn doc_id(mut self, doc_id: DocId) -> Self {
         self.doc_id = doc_id;
@@ -159,7 +159,7 @@ impl<R: Ref> RawIndexResultBuilder<R> {
 
     /// Build the final [`RawIndexResult`]
     #[inline]
-    pub fn build(self) -> RawIndexResult<R> {
+    pub fn build(self) -> RawIndexResult<'query, R> {
         RawIndexResult {
             doc_id: self.doc_id,
             dmd: ptr::null(),
@@ -172,7 +172,7 @@ impl<R: Ref> RawIndexResultBuilder<R> {
     }
 }
 
-impl<R: Ref> RawTermResultBuilder<R> {
+impl<'query, R: Ref> RawTermResultBuilder<'query, R> {
     /// Create a new term result builder
     const fn new() -> Self {
         Self {
@@ -231,7 +231,7 @@ impl<R: Ref> RawTermResultBuilder<R> {
     #[inline]
     pub fn owned_record(
         mut self,
-        term: Option<SharedPtr<R, RSQueryTerm>>,
+        term: Option<&'query RSQueryTerm>,
         offsets: RSOffsetVector,
     ) -> Self {
         self.record = TermBuilderRecord::Owned { term, offsets };
@@ -258,7 +258,7 @@ impl<R: Ref> RawTermResultBuilder<R> {
 
     /// Build the final [`RawIndexResult`]
     #[inline]
-    pub fn build(self) -> RawIndexResult<R> {
+    pub fn build(self) -> RawIndexResult<'query, R> {
         let data = match self.record {
             TermBuilderRecord::Borrowed { term, offsets } => {
                 RawResultData::Term(RawTermRecord::Borrowed { term, offsets })
@@ -292,7 +292,7 @@ impl<R: Ref> RawTermResultBuilder<R> {
 #[cheadergen::config(rename_all = "camelCase")]
 #[derive(Debug)]
 #[repr(C)]
-pub struct RawIndexResult<R: Ref> {
+pub struct RawIndexResult<'query, R: Ref> {
     /// The document ID of the result
     pub doc_id: DocId,
 
@@ -306,13 +306,13 @@ pub struct RawIndexResult<R: Ref> {
     pub freq: u32,
 
     /// The actual data of the result
-    pub(super) data: RawResultData<R>,
+    pub(super) data: RawResultData<'query, R>,
 
     /// Holds an array of metrics yielded by the different iterators in the AST.
     ///
     /// Backed by [`ThinVec`](thin_vec::ThinVec) — pointer-sized, no
     /// allocation when empty.
-    pub metrics: RawMetricsVec<R>,
+    pub metrics: RawMetricsVec<'query>,
 
     /// Relative weight for scoring calculations. This is derived from the result's iterator weight
     pub weight: f64,
@@ -323,7 +323,14 @@ pub struct RawIndexResult<R: Ref> {
 /// This is the only mode that crosses the C boundary today; the suspended
 /// counterpart is forthcoming.
 #[cheadergen::config(export)]
-pub type RSIndexResult<'a> = RawIndexResult<Active<'a>>;
+pub type RSIndexResult<'a> = RawIndexResult<'a, Active<'a>>;
+
+/// The [`Suspended`] instantiation of [`RawIndexResult`].
+///
+/// A result whose index-backed pointers have been weakened to inert raw
+/// pointers, so it can survive inverted-index lock release/reacquire cycles.
+/// Its query-pipeline pointers still live under `'query`.
+pub type SuspendedIndexResult<'query> = RawIndexResult<'query, Suspended>;
 
 // Compile-time proof that the [`Active`] and [`Suspended`] instantiations of
 // [`RawIndexResult`] are layout-identical, which is what makes the
@@ -337,8 +344,8 @@ pub type RSIndexResult<'a> = RawIndexResult<Active<'a>>;
 const _: () = {
     use std::mem::{align_of, offset_of, size_of};
 
-    type A = RawIndexResult<Active<'static>>;
-    type S = RawIndexResult<Suspended>;
+    type A = RawIndexResult<'static, Active<'static>>;
+    type S = RawIndexResult<'static, Suspended>;
 
     // Every field starts at the same offset.
     assert!(offset_of!(A, doc_id) == offset_of!(S, doc_id));
@@ -349,10 +356,14 @@ const _: () = {
     assert!(offset_of!(A, metrics) == offset_of!(S, metrics));
     assert!(offset_of!(A, weight) == offset_of!(S, weight));
 
-    // The two `R`-dependent field types have identical size (the non-`R`
-    // fields are the same type on both sides, so only these can differ).
-    assert!(size_of::<RawResultData<Active<'static>>>() == size_of::<RawResultData<Suspended>>());
-    assert!(size_of::<RawMetricsVec<Active<'static>>>() == size_of::<RawMetricsVec<Suspended>>());
+    // The only `R`-dependent field is `data`; check its two instantiations
+    // have identical size. The `metrics` field no longer depends on `R` (its
+    // `RLookupKey` lives under `'query`, never weakened), so it is the same
+    // `RawMetricsVec<'static>` type on both sides — nothing to assert there.
+    assert!(
+        size_of::<RawResultData<'static, Active<'static>>>()
+            == size_of::<RawResultData<'static, Suspended>>()
+    );
 
     // Whole-struct backstop: equal total size + alignment.
     assert!(size_of::<A>() == size_of::<S>());
@@ -397,43 +408,49 @@ impl<'a> Default for RSIndexResult<'a> {
 
 impl<'a> RSIndexResult<'a> {
     /// Convert this active result into its [`Suspended`] counterpart.
-    pub const fn into_suspended(self) -> RawIndexResult<Suspended> {
-        // SAFETY: `RawIndexResult<Active<'a>>` and `RawIndexResult<Suspended>`
+    pub const fn into_suspended(self) -> RawIndexResult<'a, Suspended> {
+        // SAFETY: `RawIndexResult<'a, Active<'a>>` and `RawIndexResult<'a, Suspended>`
         // are layout-identical (enforced by the `const _` assertion block above).
         // Going Active -> Suspended is a widening transition: it only loosens
-        // validity invariants (`'a`-bound references become inert raw pointers),
-        // so it is sound. `transmute` moves `self`, so no destructor runs on the
+        // validity invariants (the index-backed `'a`-bound references become inert
+        // raw pointers; the `'query`-bound query pointers are unchanged), so it is
+        // sound. `transmute` moves `self`, so no destructor runs on the
         // logically-moved bytes.
         unsafe { std::mem::transmute(self) }
     }
 }
 
-impl RawIndexResult<Suspended> {
+impl<'query> RawIndexResult<'query, Suspended> {
     /// Convert this suspended result back to an [`Active`] counterpart
     /// covering lifetime `'a`.
     ///
     /// Layout-compatibility is the same as for [`RSIndexResult::into_suspended`];
     /// this is the inverse direction. Promoting `Suspended` to `Active<'a>`
-    /// narrows validity (asserting that every pointer inside this result is
-    /// dereferenceable for `'a`), so the call is `unsafe`.
+    /// narrows validity (asserting that every index-backed pointer inside this
+    /// result is dereferenceable for `'a`), so the call is `unsafe`.
     ///
     /// # Safety
     ///
-    /// The caller must guarantee that all of the following hold for the entire
-    /// chosen lifetime `'a`:
+    /// This promotion only re-validates the **index-backed** pointers — the
+    /// ones that were weakened when the result was suspended. The caller must
+    /// guarantee that all of the following hold for the entire chosen lifetime
+    /// `'a`:
     ///
-    /// 1. Every single-value pointer — the document metadata ([`Self::dmd`])
-    ///    and each [`SharedPtr`] pointee (e.g. a metric's `RLookupKey`, a term
-    ///    record's borrowed query term) — is valid for reads of its pointee
-    ///    type.
-    /// 2. Every slice-backed pointer is valid for reads of its **entire stored
-    ///    length**, with provenance covering the whole region — e.g. a term
-    ///    record's offset slice ([`RawOffsetSlice`]), whose `*const u8` must
-    ///    cover all `len` bytes.
+    /// 1. The document metadata pointer ([`Self::dmd`]) is valid for reads (or
+    ///    null).
+    /// 2. Every index-backed slice pointer is valid for reads of its **entire
+    ///    stored length**, with provenance covering the whole region — namely a
+    ///    term record's offset slice ([`RawOffsetSlice`]), whose `*const u8`
+    ///    must cover all `len` bytes.
     /// 3. No concurrent writer aliases any pointer covered by (1) or (2).
-    /// 4. Conditions (1)–(3) hold recursively for every child result reachable
-    ///    through aggregate records (the [`SharedPtr`]/`Box` entries of a
-    ///    union / intersection / hybrid-metric result).
+    /// 4. Every aggregate child pointer is itself valid for reads for `'a`: the
+    ///    [`SharedPtr`](ref_mode::SharedPtr)/`Box` entry for each child of a
+    ///    union / intersection / hybrid-metric result. The `SharedPtr` children
+    ///    are index-mode and were weakened to raw pointers on suspension, so a
+    ///    safe `RawAggregateResult::get` dereferences them; the caller must
+    ///    ensure the child allocation was neither moved nor freed while
+    ///    suspended before it is reached.
+    /// 5. Conditions (1)–(4) hold recursively for every such child result.
     ///
     /// Typically the caller upholds these by holding the inverted-index read
     /// lock for the whole of `'a`, so that neither GC nor a writer can free or
@@ -445,49 +462,59 @@ impl RawIndexResult<Suspended> {
     /// call such as `RSOffsetSlice::as_bytes` (or anything built on it) would
     /// then read invalid memory — undefined behaviour reached through entirely
     /// safe code.
-    pub const unsafe fn into_active<'a>(self) -> RSIndexResult<'a> {
+    ///
+    /// The **query-pipeline** pointers — the `RLookupKey` in [`Self::metrics`]
+    /// and a term record's borrowed query term — are *not* part of this
+    /// obligation. They live under `'query`, were never weakened by
+    /// suspension, and the `'query: 'a` bound guarantees they remain valid for
+    /// all of `'a` independently of any lock.
+    pub const unsafe fn into_active<'a>(self) -> RawIndexResult<'a, Active<'a>>
+    where
+        'query: 'a,
+    {
         // SAFETY: layout-identical (see the `const _` assertion block above).
-        // Narrowing the validity from raw-pointer to `&'a`-style references
-        // is sound under the caller's contract documented on this method.
-        // `transmute` moves `self`, so no destructor runs on the logically-moved
-        // bytes.
+        // Narrowing the validity of the index-backed pointers from raw-pointer
+        // to `&'a`-style references is sound under the caller's contract
+        // documented on this method; the query-pipeline pointers are already
+        // valid for `'a` thanks to the `'query: 'a` bound. `transmute` moves
+        // `self`, so no destructor runs on the logically-moved bytes.
         unsafe { std::mem::transmute(self) }
     }
 }
 
-impl<R: Ref> RawIndexResult<R> {
+impl<'query, R: Ref> RawIndexResult<'query, R> {
     /// Create a builder for a virtual index result
-    pub const fn build_virt() -> RawIndexResultBuilder<R> {
+    pub const fn build_virt() -> RawIndexResultBuilder<'query, R> {
         RawIndexResultBuilder::virt()
     }
 
     /// Create a builder for a numeric index result with the given number
-    pub const fn build_numeric(num: f64) -> RawIndexResultBuilder<R> {
+    pub const fn build_numeric(num: f64) -> RawIndexResultBuilder<'query, R> {
         RawIndexResultBuilder::numeric(num)
     }
 
     /// Create a builder for a metric index result with the given number
-    pub const fn build_metric(num: f64) -> RawIndexResultBuilder<R> {
+    pub const fn build_metric(num: f64) -> RawIndexResultBuilder<'query, R> {
         RawIndexResultBuilder::metric(num)
     }
 
     /// Create a builder for an intersection index result with the given capacity
-    pub fn build_intersect(cap: usize) -> RawIndexResultBuilder<R> {
+    pub fn build_intersect(cap: usize) -> RawIndexResultBuilder<'query, R> {
         RawIndexResultBuilder::intersect(cap)
     }
 
     /// Create a builder for a union index result with the given capacity
-    pub fn build_union(cap: usize) -> RawIndexResultBuilder<R> {
+    pub fn build_union(cap: usize) -> RawIndexResultBuilder<'query, R> {
         RawIndexResultBuilder::union(cap)
     }
 
     /// Create a builder for a hybrid metric index result
-    pub fn build_hybrid_metric() -> RawIndexResultBuilder<R> {
+    pub fn build_hybrid_metric() -> RawIndexResultBuilder<'query, R> {
         RawIndexResultBuilder::hybrid_metric()
     }
 
     /// Create a specialized builder for a term index result
-    pub const fn build_term() -> RawTermResultBuilder<R> {
+    pub const fn build_term() -> RawTermResultBuilder<'query, R> {
         RawTermResultBuilder::new()
     }
 
@@ -602,7 +629,7 @@ impl<R: Ref> RawIndexResult<R> {
     /// # Safety
     ///
     /// 1. `Self::is_term()` must return `true` for `self`.
-    pub unsafe fn as_term_unchecked_mut(&mut self) -> &mut RawTermRecord<R> {
+    pub unsafe fn as_term_unchecked_mut(&mut self) -> &mut RawTermRecord<'query, R> {
         debug_assert!(
             self.is_term(),
             "Invariant violation: `as_term_unchecked_mut` was invoked on a non-term `RawIndexResult` \
@@ -626,7 +653,7 @@ impl<R: Ref> RawIndexResult<R> {
 
     /// Get this record as a term record if possible. If the record is not term, returns
     /// `None`.
-    pub const fn as_term(&self) -> Option<&RawTermRecord<R>> {
+    pub const fn as_term(&self) -> Option<&RawTermRecord<'query, R>> {
         match &self.data {
             RawResultData::Term(term) => Some(term),
             RawResultData::Union(_)
@@ -640,7 +667,7 @@ impl<R: Ref> RawIndexResult<R> {
 
     /// Get this record as a mutable term record if possible. If the record is not term, returns
     /// `None`.
-    pub const fn as_term_mut(&mut self) -> Option<&mut RawTermRecord<R>> {
+    pub const fn as_term_mut(&mut self) -> Option<&mut RawTermRecord<'query, R>> {
         match &mut self.data {
             RawResultData::Term(term) => Some(term),
             RawResultData::Union(_)
@@ -658,7 +685,7 @@ impl<R: Ref> RawIndexResult<R> {
     /// # Safety
     ///
     /// 1. `Self::is_aggregate` must return `true` for `self`.
-    pub unsafe fn as_aggregate_unchecked(&self) -> Option<&RawAggregateResult<R>> {
+    pub unsafe fn as_aggregate_unchecked(&self) -> Option<&RawAggregateResult<'query, R>> {
         debug_assert!(
             self.is_aggregate(),
             "Invariant violation: `as_aggregate_unchecked` was invoked on an `IndexResult` \
@@ -682,7 +709,7 @@ impl<R: Ref> RawIndexResult<R> {
 
     /// Get this record as an aggregate result if possible. If the record is not an aggregate,
     /// returns `None`.
-    pub const fn as_aggregate(&self) -> Option<&RawAggregateResult<R>> {
+    pub const fn as_aggregate(&self) -> Option<&RawAggregateResult<'query, R>> {
         match &self.data {
             RawResultData::Union(agg)
             | RawResultData::Intersection(agg)
@@ -696,7 +723,7 @@ impl<R: Ref> RawIndexResult<R> {
 
     /// Get this record as a mutable aggregate result if possible. If the record is not an
     /// aggregate, returns `None`.
-    pub const fn as_aggregate_mut(&mut self) -> Option<&mut RawAggregateResult<R>> {
+    pub const fn as_aggregate_mut(&mut self) -> Option<&mut RawAggregateResult<'query, R>> {
         match &mut self.data {
             RawResultData::Union(agg)
             | RawResultData::Intersection(agg)
@@ -714,7 +741,9 @@ impl<R: Ref> RawIndexResult<R> {
     /// # Safety
     ///
     /// 1. `Self::is_aggregate` must return `true` for `self`.
-    pub unsafe fn as_aggregate_mut_unchecked(&mut self) -> Option<&mut RawAggregateResult<R>> {
+    pub unsafe fn as_aggregate_mut_unchecked(
+        &mut self,
+    ) -> Option<&mut RawAggregateResult<'query, R>> {
         debug_assert!(
             self.is_aggregate(),
             "Invariant violation: `as_aggregate_mut_unchecked` was invoked on an `IndexResult` \
@@ -760,12 +789,12 @@ impl<R: Ref> RawIndexResult<R> {
     }
 
     /// Returns a mutable reference to the metrics collection.
-    pub const fn metrics_mut(&mut self) -> &mut RawMetricsVec<R> {
+    pub const fn metrics_mut(&mut self) -> &mut RawMetricsVec<'query> {
         &mut self.metrics
     }
 
     /// Returns a reference to the metrics collection.
-    pub const fn metrics_ref(&self) -> &RawMetricsVec<R> {
+    pub const fn metrics_ref(&self) -> &RawMetricsVec<'query> {
         &self.metrics
     }
 

--- a/src/redisearch_rs/index_result/src/lib.rs
+++ b/src/redisearch_rs/index_result/src/lib.rs
@@ -17,7 +17,10 @@ mod term_record;
 
 pub use query_term::RSQueryTerm;
 
-pub use self::core::{RSIndexResult, RawIndexResult, RawIndexResultBuilder, RawTermResultBuilder};
+pub use self::core::{
+    RSIndexResult, RawIndexResult, RawIndexResultBuilder, RawTermResultBuilder,
+    SuspendedIndexResult,
+};
 pub use aggregate::{RSAggregateResult, RSAggregateResultIter, RawAggregateResult};
 pub use kind::{RSResultKind, RSResultKindMask};
 pub use metrics::{

--- a/src/redisearch_rs/index_result/src/metrics.rs
+++ b/src/redisearch_rs/index_result/src/metrics.rs
@@ -16,55 +16,39 @@
 //! `MetricsVec` is `repr(transparent)` and can be embedded directly in
 //! `repr(C)` structs like [`super::RSIndexResult`].
 use ffi::RLookupKey;
-use ref_mode::{Active, Ref, SharedPtr};
 use std::ptr;
 use thin_vec::ThinVec;
 
 /// A single metric: a borrowed key and a numeric value.
-///
-/// The `R: Ref` parameter controls how the key reference is stored:
-/// in [`Active<'a>`] mode it is a valid `&'a RLookupKey`, in
-/// [`ref_mode::Suspended`] mode it is an inert raw pointer.
-///
-/// `key` is `Option<SharedPtr<R, RLookupKey>>` so "no key" is encoded as
-/// `None`. `SharedPtr` wraps `NonNull` so the niche optimization keeps the C
-/// ABI as a nullable `RLookupKey *`.
 #[derive(Debug)]
 #[repr(C)]
-pub struct RawMetricEntry<R: Ref> {
+pub struct RawMetricEntry<'query> {
     /// Borrowed reference to the lookup key that identifies this metric,
     /// or `None` when the metric has no associated key.
-    pub key: Option<SharedPtr<R, RLookupKey>>,
+    ///
+    /// The key always lives under the `'query` lifetime: it belongs to the
+    /// query pipeline (the `RLookupKey`), not to the inverted index, so it is
+    /// never weakened by the `Active`/`Suspended` ref-mode transitions —
+    /// unlike the index-backed pointers of a result, it stays a genuine
+    /// `&'query` borrow across the whole suspend/resume cycle. That is why it
+    /// is modelled as a plain reference rather than a ref-mode-parametrised
+    /// `SharedPtr`.
+    ///
+    /// Stored as `Option<&'query RLookupKey>` so "no key" is `None`; the
+    /// `NonNull` niche of `&T` keeps the C ABI as a nullable `RLookupKey *`.
+    pub key: Option<&'query RLookupKey>,
 
     /// The metric value (e.g. vector distance, score).
     pub value: f64,
 }
 
-/// The [`Active`] instantiation of [`RawMetricEntry`].
+/// Lifetime-parameterised alias for [`RawMetricEntry`].
 #[cheadergen::config(export)]
-pub type MetricEntry<'a> = RawMetricEntry<Active<'a>>;
+pub type MetricEntry<'a> = RawMetricEntry<'a>;
 
-// Compile-time proof that the `Active` and `Suspended` instantiations of
-// `RawMetricEntry` are layout-identical. `R` enters only through the
-// `#[repr(transparent)]` `SharedPtr<R, RLookupKey>` in `key`. Entries live
-// behind the `RawMetricsVec` allocation, so they are read as the `Suspended`
-// type through that pointer after an active/suspended `transmute` — hence they
-// need the same guarantee. Part of the recursive net backing the conversions
-// on `RawIndexResult` (see `core/mod.rs`).
-const _: () = {
-    use ref_mode::Suspended;
-    use std::mem::{align_of, offset_of, size_of};
-    type A = RawMetricEntry<Active<'static>>;
-    type S = RawMetricEntry<Suspended>;
-    assert!(offset_of!(A, key) == offset_of!(S, key));
-    assert!(offset_of!(A, value) == offset_of!(S, value));
-    assert!(size_of::<A>() == size_of::<S>());
-    assert!(align_of::<A>() == align_of::<S>());
-};
+impl Copy for RawMetricEntry<'_> {}
 
-impl<R: Ref> Copy for RawMetricEntry<R> {}
-
-impl<R: Ref> Clone for RawMetricEntry<R> {
+impl Clone for RawMetricEntry<'_> {
     fn clone(&self) -> Self {
         *self
     }
@@ -74,7 +58,7 @@ impl<'a> MetricEntry<'a> {
     /// Creates a metric entry with an associated key.
     pub const fn with_key(key: &'a RLookupKey, value: f64) -> Self {
         Self {
-            key: Some(SharedPtr::from_ref(key)),
+            key: Some(key),
             value,
         }
     }
@@ -86,14 +70,11 @@ impl<'a> MetricEntry<'a> {
 
     /// Returns the key reference, or `None` if the metric has no key.
     pub const fn key(&self) -> Option<&'a RLookupKey> {
-        match self.key {
-            Some(k) => Some(k.get()),
-            None => None,
-        }
+        self.key
     }
 }
 
-impl<R: Ref> RawMetricEntry<R> {
+impl RawMetricEntry<'_> {
     /// Returns the metric value.
     pub const fn value(&self) -> f64 {
         self.value
@@ -117,8 +98,8 @@ impl<'a> PartialEq for MetricEntry<'a> {
             key: o_key,
             value: o_value,
         } = other;
-        let lhs = key.map_or(ptr::null(), |p| p.as_raw());
-        let rhs = o_key.map_or(ptr::null(), |p| p.as_raw());
+        let lhs = key.map_or(ptr::null(), |k| k as *const RLookupKey);
+        let rhs = o_key.map_or(ptr::null(), |k| k as *const RLookupKey);
         ptr::eq(lhs, rhs) && value == o_value
     }
 }
@@ -132,30 +113,14 @@ impl<'a> PartialEq for MetricEntry<'a> {
 /// and can be embedded directly in `repr(C)` structs.
 #[derive(Debug)]
 #[repr(transparent)]
-pub struct RawMetricsVec<R: Ref> {
-    inner: ThinVec<RawMetricEntry<R>>,
+pub struct RawMetricsVec<'query> {
+    inner: ThinVec<RawMetricEntry<'query>>,
 }
 
-/// The [`Active`] instantiation of [`RawMetricsVec`].
-pub type MetricsVec<'a> = RawMetricsVec<Active<'a>>;
+/// Lifetime-parameterised alias for [`RawMetricsVec`].
+pub type MetricsVec<'a> = RawMetricsVec<'a>;
 
-// Compile-time proof that the `Active` and `Suspended` instantiations of
-// `RawMetricsVec` are layout-identical. The type is `#[repr(transparent)]` over
-// a single `ThinVec` pointer, so `R` only affects the element type behind the
-// allocation (guarded by the `RawMetricEntry` block above); the inline layout
-// is a bare pointer either way. Part of the recursive net backing the
-// conversions on `RawIndexResult` (see `core/mod.rs`).
-const _: () = {
-    use ref_mode::Suspended;
-    use std::mem::{align_of, offset_of, size_of};
-    type A = RawMetricsVec<Active<'static>>;
-    type S = RawMetricsVec<Suspended>;
-    assert!(offset_of!(A, inner) == offset_of!(S, inner));
-    assert!(size_of::<A>() == size_of::<S>());
-    assert!(align_of::<A>() == align_of::<S>());
-};
-
-impl<R: Ref> Clone for RawMetricsVec<R> {
+impl Clone for RawMetricsVec<'_> {
     fn clone(&self) -> Self {
         let Self { inner } = self;
         Self {
@@ -178,19 +143,19 @@ impl<'a> PartialEq for MetricsVec<'a> {
 /// from C. The pointed-to data is valid as long as the originating
 /// [`MetricsVec`] is not mutated or dropped.
 #[repr(C)]
-pub struct RawMetricsSlice<R: Ref> {
+pub struct RawMetricsSlice<'query> {
     /// Pointer to the first [`MetricEntry`].  May be dangling (but not null)
     /// when `len == 0`.
-    pub data: *const RawMetricEntry<R>,
+    pub data: *const RawMetricEntry<'query>,
 
     /// Number of entries.
     pub len: usize,
 }
 
-/// The [`Active`] instantiation of [`RawMetricsSlice`].
-pub type MetricsSlice<'a> = RawMetricsSlice<Active<'a>>;
+/// Lifetime-parameterised alias for [`RawMetricsSlice`].
+pub type MetricsSlice<'a> = RawMetricsSlice<'a>;
 
-impl<R: Ref> RawMetricsVec<R> {
+impl<'query> RawMetricsVec<'query> {
     /// Creates an empty metrics collection. Does not allocate.
     pub const fn new() -> Self {
         Self {
@@ -219,7 +184,7 @@ impl<R: Ref> RawMetricsVec<R> {
     }
 
     /// Returns a C-compatible slice view for zero-copy iteration.
-    pub fn as_metrics_slice(&self) -> RawMetricsSlice<R> {
+    pub fn as_metrics_slice(&self) -> RawMetricsSlice<'query> {
         let slice = self.inner.as_slice();
         RawMetricsSlice {
             data: slice.as_ptr(),
@@ -229,29 +194,29 @@ impl<R: Ref> RawMetricsVec<R> {
 
     /// Returns a reference to the entry at `index`, or `None` if out of
     /// bounds.
-    pub fn get(&self, index: usize) -> Option<&RawMetricEntry<R>> {
+    pub fn get(&self, index: usize) -> Option<&RawMetricEntry<'query>> {
         self.inner.as_slice().get(index)
     }
 
     /// Returns a mutable reference to the entry at `index`, or `None` if
     /// out of bounds.
-    pub fn get_mut(&mut self, index: usize) -> Option<&mut RawMetricEntry<R>> {
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut RawMetricEntry<'query>> {
         self.inner.as_mut_slice().get_mut(index)
     }
 
     /// Returns an iterator over the entries.
-    pub fn iter(&self) -> impl Iterator<Item = &RawMetricEntry<R>> {
+    pub fn iter(&self) -> impl Iterator<Item = &RawMetricEntry<'query>> {
         self.inner.as_slice().iter()
     }
 
     /// Finds the first entry whose key matches `key` (pointer equality)
     /// and returns a mutable reference to it.
-    pub fn find_by_key_mut(&mut self, key: &RLookupKey) -> Option<&mut RawMetricEntry<R>> {
+    pub fn find_by_key_mut(&mut self, key: &RLookupKey) -> Option<&mut RawMetricEntry<'query>> {
         let needle = key as *const RLookupKey;
         self.inner
             .as_mut_slice()
             .iter_mut()
-            .find(|e| e.key.is_some_and(|p| ptr::eq(p.as_raw(), needle)))
+            .find(|e| e.key.is_some_and(|k| ptr::eq(k, needle)))
     }
 }
 
@@ -267,7 +232,7 @@ impl<'a> MetricsVec<'a> {
     }
 }
 
-impl<R: Ref> Default for RawMetricsVec<R> {
+impl Default for RawMetricsVec<'_> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/redisearch_rs/index_result/src/result_data.rs
+++ b/src/redisearch_rs/index_result/src/result_data.rs
@@ -23,19 +23,19 @@ use super::term_record::RawTermRecord;
 #[cheadergen::config(prefix_with_name)]
 #[derive(Debug)]
 #[repr(u8)]
-pub enum RawResultData<R: Ref> {
-    Union(RawAggregateResult<R>) = 1,
-    Intersection(RawAggregateResult<R>) = 2,
-    Term(RawTermRecord<R>) = 4,
+pub enum RawResultData<'query, R: Ref> {
+    Union(RawAggregateResult<'query, R>) = 1,
+    Intersection(RawAggregateResult<'query, R>) = 2,
+    Term(RawTermRecord<'query, R>) = 4,
     Virtual = 8,
     Numeric(f64) = 16,
     Metric(f64) = 32,
-    HybridMetric(RawAggregateResult<R>) = 64,
+    HybridMetric(RawAggregateResult<'query, R>) = 64,
 }
 
 /// The [`Active`] instantiation of [`RawResultData`].
 #[cheadergen::config(export)]
-pub type RSResultData<'a> = RawResultData<Active<'a>>;
+pub type RSResultData<'a> = RawResultData<'a, Active<'a>>;
 
 // Compile-time proof that the `Active` and `Suspended` instantiations of
 // `RawResultData` are layout-identical. Only `size_of`/`align_of` are checked:
@@ -47,8 +47,8 @@ pub type RSResultData<'a> = RawResultData<Active<'a>>;
 const _: () = {
     use ref_mode::Suspended;
     use std::mem::{align_of, size_of};
-    type A = RawResultData<Active<'static>>;
-    type S = RawResultData<Suspended>;
+    type A = RawResultData<'static, Active<'static>>;
+    type S = RawResultData<'static, Suspended>;
     assert!(size_of::<A>() == size_of::<S>());
     assert!(align_of::<A>() == align_of::<S>());
 };
@@ -68,7 +68,7 @@ impl<'a> PartialEq for RSResultData<'a> {
     }
 }
 
-impl<R: Ref> RawResultData<R> {
+impl<'query, R: Ref> RawResultData<'query, R> {
     pub const fn kind(&self) -> RSResultKind {
         match self {
             Self::Union(_) => RSResultKind::Union,

--- a/src/redisearch_rs/index_result/src/term_record.rs
+++ b/src/redisearch_rs/index_result/src/term_record.rs
@@ -8,7 +8,7 @@
 */
 
 use query_term::RSQueryTerm;
-use ref_mode::{Active, Ref, SharedPtr};
+use ref_mode::{Active, Ref};
 
 use super::offsets::{RSOffsetSlice, RSOffsetVector, RawOffsetSlice};
 
@@ -16,7 +16,7 @@ use super::offsets::{RSOffsetSlice, RSOffsetVector, RawOffsetSlice};
 #[cheadergen::config(prefix_with_name)]
 #[derive(Debug)]
 #[repr(u8)]
-pub enum RawTermRecord<R: Ref> {
+pub enum RawTermRecord<'query, R: Ref> {
     Borrowed {
         /// The term that brought up this record.
         ///
@@ -37,9 +37,15 @@ pub enum RawTermRecord<R: Ref> {
         /// The term that brought up this record.
         ///
         /// It borrows the term from another record. `None` encodes "no
-        /// term"; thanks to `NonNull`'s niche, `Option<SharedPtr<R, RSQueryTerm>>`
+        /// term"; thanks to the `NonNull` niche of `&T`, `Option<&'query RSQueryTerm>`
         /// has the same C ABI as a nullable `*const RSQueryTerm`.
-        term: Option<SharedPtr<R, RSQueryTerm>>,
+        ///
+        /// The borrowed query term belongs to the query pipeline, so it lives
+        /// under the `'query` lifetime and is never weakened by the
+        /// `Active`/`Suspended` ref-mode transitions — it stays a genuine
+        /// `&'query` borrow, so it is modelled as a plain reference rather than
+        /// a ref-mode-parametrised `SharedPtr`.
+        term: Option<&'query RSQueryTerm>,
 
         /// The encoded offsets in which the term appeared in the document
         ///
@@ -65,7 +71,7 @@ pub enum RawTermRecord<R: Ref> {
 
 /// The [`Active`] instantiation of [`RawTermRecord`].
 #[cheadergen::config(export)]
-pub type RSTermRecord<'a> = RawTermRecord<Active<'a>>;
+pub type RSTermRecord<'a> = RawTermRecord<'a, Active<'a>>;
 
 // Compile-time proof that the `Active` and `Suspended` instantiations of
 // `RawTermRecord` are layout-identical. Only `size_of`/`align_of` are checked:
@@ -77,16 +83,15 @@ pub type RSTermRecord<'a> = RawTermRecord<Active<'a>>;
 const _: () = {
     use ref_mode::Suspended;
     use std::mem::{align_of, size_of};
-    type A = RawTermRecord<Active<'static>>;
-    type S = RawTermRecord<Suspended>;
+    type A = RawTermRecord<'static, Active<'static>>;
+    type S = RawTermRecord<'static, Suspended>;
     assert!(size_of::<A>() == size_of::<S>());
     assert!(align_of::<A>() == align_of::<S>());
 };
 
-// Manual (rather than derived) because the `Owned` variant stores
-// `Option<SharedPtr<R, RSQueryTerm>>`, which only implements `PartialEq` in
-// `Active` mode. Compares the dereferenced query term and the byte view of
-// the offsets so equality is well-defined across variants.
+// Manual (rather than derived) so equality is well-defined across the three
+// variants (which store the term and offsets differently): compares the
+// dereferenced query term and the byte view of the offsets.
 impl<'a> PartialEq for RSTermRecord<'a> {
     fn eq(&self, other: &Self) -> bool {
         self.query_term() == other.query_term() && self.offsets() == other.offsets()
@@ -95,7 +100,7 @@ impl<'a> PartialEq for RSTermRecord<'a> {
 
 impl<'a> Eq for RSTermRecord<'a> {}
 
-impl<R: Ref> RawTermRecord<R> {
+impl<'query, R: Ref> RawTermRecord<'query, R> {
     /// Create a new term record without term pointer and offsets.
     pub const fn new() -> Self {
         Self::Borrowed {
@@ -132,14 +137,14 @@ impl<'a> RSTermRecord<'a> {
     pub fn query_term(&self) -> Option<&RSQueryTerm> {
         match self {
             Self::Borrowed { term, .. } => term.as_deref(),
-            Self::Owned { term, .. } => term.map(|p| p.get()),
+            Self::Owned { term, .. } => *term,
             Self::FullyOwned { term, .. } => term.as_deref(),
         }
     }
 
     /// Create an owned copy of this term record, allocating new memory for the offsets, but reusing the term.
     pub fn to_owned(&'a self) -> RSTermRecord<'a> {
-        let term = self.query_term().map(SharedPtr::from_ref);
+        let term = self.query_term();
         Self::Owned {
             term,
             offsets: match self {
@@ -204,7 +209,7 @@ impl<'a> RSTermRecord<'a> {
     }
 }
 
-impl<R: Ref> Default for RawTermRecord<R> {
+impl<'query, R: Ref> Default for RawTermRecord<'query, R> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -76,9 +76,12 @@ use crate::{
 /// what lets the [`RQEDynIterator`] sibling exist as a free blanket impl.
 pub trait RQEIteratorBoxed<'index>: RQEIterator<'index> + 'index {
     /// The suspended counterpart of this iterator. Carries no live
-    /// references into the index and can therefore be held across a lock
-    /// release/reacquire cycle.
-    type Suspended: RQESuspendedIterator + 'static;
+    /// references into the *index* (those are weakened to raw pointers on
+    /// suspend), but may still borrow query-pipeline data for `'index` — see
+    /// the `'query` parameter on [`RQESuspendedIterator`]. It can therefore be
+    /// held across a lock release/reacquire cycle: the index pointers are
+    /// re-validated on resume, while the query-pipeline borrows stay live.
+    type Suspended: RQESuspendedIterator<'index> + 'index;
 
     /// Transition to the suspended state.
     fn suspend(self: Box<Self>) -> Box<Self::Suspended>;
@@ -87,14 +90,28 @@ pub trait RQEIteratorBoxed<'index>: RQEIterator<'index> + 'index {
 /// Concrete-typed suspended iterator trait — counterpart of
 /// [`RQEIteratorBoxed`].
 ///
-/// Implementers are typically the `Raw…<Suspended, …>` instantiations of
-/// the same `#[repr(C)]` struct used in active mode. The `'static` bound
-/// reflects the absence of live index references: a suspended iterator
-/// can be held across a lock release.
-pub trait RQESuspendedIterator: 'static {
+/// Implementers are typically the `Raw…<Suspended, 'query>` instantiations of
+/// the same `#[repr(C)]` struct used in active mode.
+///
+/// The `'query` parameter is the lifetime of the **query-pipeline** data the
+/// iterator borrows — e.g. the `RLookupKey` a metric result yields against, or
+/// a term record's borrowed query term. Unlike index-derived pointers (which
+/// are weakened to raw pointers on suspend and re-validated via the spec guard
+/// on resume), query-pipeline data is *not* invalidated by concurrent index
+/// mutation, so it stays a live borrow across the whole suspend/resume cycle.
+/// That is why this trait carries `'query` instead of a `'static` bound: a
+/// suspended iterator holds no live *index* references, but may still borrow
+/// query-pipeline data for `'query`.
+pub trait RQESuspendedIterator<'query> {
     /// The active counterpart this iterator resumes into, parameterised by
-    /// the lifetime of the held read guard.
-    type Resumed<'index>: RQEIteratorBoxed<'index>;
+    /// the lifetime of the freshly re-acquired read guard.
+    ///
+    /// `'query: 'index` is required because the retained query-pipeline
+    /// borrows must outlive the (shorter) guard window the iterator is
+    /// resumed into.
+    type Resumed<'index>: RQEIteratorBoxed<'index>
+    where
+        'query: 'index;
 
     /// Resume from the suspended state, re-acquiring references into the
     /// index and re-validating the iterator's state against any changes
@@ -120,7 +137,9 @@ pub trait RQESuspendedIterator: 'static {
     fn resume<'index>(
         self: Box<Self>,
         guard: &IndexSpecReadGuard<'index>,
-    ) -> Result<ResumeOutcome<Box<Self::Resumed<'index>>>, RQEIteratorError>;
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'index>>>, RQEIteratorError>
+    where
+        'query: 'index;
 
     /// Read the cached `last_doc_id` from the suspended state without
     /// resuming. Composite iterators use this during resume to compare
@@ -147,7 +166,7 @@ pub trait RQESuspendedIterator: 'static {
 /// produces it for every concrete iterator.
 pub trait RQEDynIterator<'index>: RQEIterator<'index> + 'index {
     /// Type-erased counterpart of [`RQEIteratorBoxed::suspend`].
-    fn suspend(self: Box<Self>) -> TypeErasedRQESuspendedIterator;
+    fn suspend(self: Box<Self>) -> TypeErasedRQESuspendedIterator<'index>;
 }
 
 /// Dyn-safe sibling of [`RQESuspendedIterator`].
@@ -155,12 +174,14 @@ pub trait RQEDynIterator<'index>: RQEIterator<'index> + 'index {
 /// As with [`RQEDynIterator`], implementers don't write this directly — the
 /// blanket bridge below produces it from any
 /// `T: RQESuspendedIterator`.
-pub trait RQEDynSuspendedIterator: 'static {
+pub trait RQEDynSuspendedIterator<'query> {
     /// Type-erased counterpart of [`RQESuspendedIterator::resume`].
     fn resume<'index>(
         self: Box<Self>,
         guard: &IndexSpecReadGuard<'index>,
-    ) -> Result<ResumeOutcome<TypeErasedRQEIterator<'index>>, RQEIteratorError>;
+    ) -> Result<ResumeOutcome<TypeErasedRQEIterator<'index>>, RQEIteratorError>
+    where
+        'query: 'index;
 
     fn last_doc_id(&self) -> t_docId;
 
@@ -178,10 +199,13 @@ pub struct TypeErasedRQEIterator<'index>(pub Box<dyn RQEDynIterator<'index> + 'i
 
 /// Type-erased, suspended iterator.
 ///
-/// Newtype around `Box<dyn RQEDynSuspendedIterator>`. Mirrors
-/// [`TypeErasedRQEIterator`] in the suspended state.
+/// Newtype around `Box<dyn RQEDynSuspendedIterator<'query> + 'query>`. Mirrors
+/// [`TypeErasedRQEIterator`] in the suspended state. Carries the `'query`
+/// lifetime of the borrowed query-pipeline data (see [`RQESuspendedIterator`]).
 #[repr(transparent)]
-pub struct TypeErasedRQESuspendedIterator(pub Box<dyn RQEDynSuspendedIterator>);
+pub struct TypeErasedRQESuspendedIterator<'query>(
+    pub Box<dyn RQEDynSuspendedIterator<'query> + 'query>,
+);
 
 impl<'index> TypeErasedRQEIterator<'index> {
     /// Wrap a concrete iterator into the type-erased wrapper.
@@ -190,10 +214,10 @@ impl<'index> TypeErasedRQEIterator<'index> {
     }
 }
 
-impl TypeErasedRQESuspendedIterator {
+impl<'query> TypeErasedRQESuspendedIterator<'query> {
     /// Wrap a concrete suspended iterator into the type-erased wrapper.
-    pub fn new<S: RQESuspendedIterator>(iter: Box<S>) -> Self {
-        Self(iter as Box<dyn RQEDynSuspendedIterator>)
+    pub fn new<S: RQESuspendedIterator<'query> + 'query>(iter: Box<S>) -> Self {
+        Self(iter as Box<dyn RQEDynSuspendedIterator<'query> + 'query>)
     }
 }
 
@@ -275,39 +299,46 @@ where
 /// concrete iterator already implements.
 impl<'index, T: RQEIteratorBoxed<'index> + 'index> RQEDynIterator<'index> for T {
     #[inline(always)]
-    fn suspend(self: Box<Self>) -> TypeErasedRQESuspendedIterator {
+    fn suspend(self: Box<Self>) -> TypeErasedRQESuspendedIterator<'index> {
         let suspended = <T as RQEIteratorBoxed<'index>>::suspend(self);
-        TypeErasedRQESuspendedIterator(suspended as Box<dyn RQEDynSuspendedIterator>)
+        TypeErasedRQESuspendedIterator(
+            suspended as Box<dyn RQEDynSuspendedIterator<'index> + 'index>,
+        )
     }
 }
 
 /// Bridge concrete suspended iterators into the dyn-safe sibling.
-impl<S: RQESuspendedIterator> RQEDynSuspendedIterator for S {
+impl<'query, S: RQESuspendedIterator<'query> + 'query> RQEDynSuspendedIterator<'query> for S {
     #[inline(always)]
     fn resume<'index>(
         self: Box<Self>,
         guard: &IndexSpecReadGuard<'index>,
-    ) -> Result<ResumeOutcome<TypeErasedRQEIterator<'index>>, RQEIteratorError> {
+    ) -> Result<ResumeOutcome<TypeErasedRQEIterator<'index>>, RQEIteratorError>
+    where
+        'query: 'index,
+    {
         // This bridge is the *only* place the resumed iterator is type-erased:
         // the concrete impl hands back its `Box<Self::Resumed>`, which we wrap
         // into a `TypeErasedRQEIterator`. `Aborted` carries nothing, so it maps
         // straight through. (The already-erased forwarding impl on
         // `TypeErasedRQESuspendedIterator` deliberately double-boxes; see there.)
-        Ok(match <S as RQESuspendedIterator>::resume(self, guard)? {
-            ResumeOutcome::Ok(it) => ResumeOutcome::Ok(TypeErasedRQEIterator::new(it)),
-            ResumeOutcome::Moved(it) => ResumeOutcome::Moved(TypeErasedRQEIterator::new(it)),
-            ResumeOutcome::Aborted => ResumeOutcome::Aborted,
-        })
+        Ok(
+            match <S as RQESuspendedIterator<'query>>::resume(self, guard)? {
+                ResumeOutcome::Ok(it) => ResumeOutcome::Ok(TypeErasedRQEIterator::new(it)),
+                ResumeOutcome::Moved(it) => ResumeOutcome::Moved(TypeErasedRQEIterator::new(it)),
+                ResumeOutcome::Aborted => ResumeOutcome::Aborted,
+            },
+        )
     }
 
     #[inline(always)]
     fn last_doc_id(&self) -> t_docId {
-        <S as RQESuspendedIterator>::last_doc_id(self)
+        <S as RQESuspendedIterator<'query>>::last_doc_id(self)
     }
 
     #[inline(always)]
     fn num_estimated(&self) -> usize {
-        <S as RQESuspendedIterator>::num_estimated(self)
+        <S as RQESuspendedIterator<'query>>::num_estimated(self)
     }
 }
 
@@ -383,7 +414,7 @@ impl<'index> RQEIterator<'index> for TypeErasedRQEIterator<'index> {
 /// participates in the new suspend/resume surface (its `Suspended`
 /// counterpart is [`TypeErasedRQESuspendedIterator`]).
 impl<'index> RQEIteratorBoxed<'index> for TypeErasedRQEIterator<'index> {
-    type Suspended = TypeErasedRQESuspendedIterator;
+    type Suspended = TypeErasedRQESuspendedIterator<'index>;
 
     #[inline(always)]
     fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
@@ -394,14 +425,20 @@ impl<'index> RQEIteratorBoxed<'index> for TypeErasedRQEIterator<'index> {
 
 /// Forwarding [`RQESuspendedIterator`] impl on [`TypeErasedRQESuspendedIterator`]
 /// so the dyn-erased pair behaves like any other concrete iterator pair.
-impl RQESuspendedIterator for TypeErasedRQESuspendedIterator {
-    type Resumed<'index> = TypeErasedRQEIterator<'index>;
+impl<'query> RQESuspendedIterator<'query> for TypeErasedRQESuspendedIterator<'query> {
+    type Resumed<'index>
+        = TypeErasedRQEIterator<'index>
+    where
+        'query: 'index;
 
     #[inline(always)]
     fn resume<'index>(
         self: Box<Self>,
         guard: &IndexSpecReadGuard<'index>,
-    ) -> Result<ResumeOutcome<Box<TypeErasedRQEIterator<'index>>>, RQEIteratorError> {
+    ) -> Result<ResumeOutcome<Box<TypeErasedRQEIterator<'index>>>, RQEIteratorError>
+    where
+        'query: 'index,
+    {
         let TypeErasedRQESuspendedIterator(inner) = *self;
         // `Self::Resumed` is the already-erased `TypeErasedRQEIterator`, so the
         // concrete `ResumeOutcome<Box<Self::Resumed>>` shape forces a

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -34,7 +34,7 @@ pub type IdListUnsorted<'index> = IdList<'index, false>;
 /// instantiation that implements [`RQEIterator`]. The struct owns its data
 /// (the list of document IDs); the only `Rf`-dependent field is `result`.
 #[repr(C)]
-pub struct RawIdList<Rf: Ref, const SORTED: bool> {
+pub struct RawIdList<'query, Rf: Ref, const SORTED: bool> {
     /// The list of document IDs to iterate over.
     /// There must be no duplicates. The list must be sorted if `SORTED` is set to `true`.
     ids: OwnedSlice<DocId>,
@@ -42,12 +42,12 @@ pub struct RawIdList<Rf: Ref, const SORTED: bool> {
     /// When `offset` is equal to the length of `ids`, the iterator is at EOF.
     offset: usize,
     /// A reusable result object to avoid allocations on each [`read`](RQEIterator::read) call.
-    result: RawIndexResult<Rf>,
+    result: RawIndexResult<'query, Rf>,
 }
 
 /// Alias for an [`Active`] [`RawIdList`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
-pub type IdList<'index, const SORTED: bool> = RawIdList<Active<'index>, SORTED>;
+pub type IdList<'index, const SORTED: bool> = RawIdList<'index, Active<'index>, SORTED>;
 
 impl<'index, const SORTED: bool> IdList<'index, SORTED> {
     /// Creates a new ID list iterator.

--- a/src/redisearch_rs/rqe_iterators/src/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/src/intersection.rs
@@ -39,7 +39,7 @@ use rqe_core::DocId;
 ///   validation entirely.
 /// - `in_order`: When `true`, terms must appear in the same order as the child iterators.
 #[repr(C)]
-pub struct RawIntersection<Rf: Ref, I> {
+pub struct RawIntersection<'query, Rf: Ref, I> {
     /// Child iterators, sorted by estimated count (smallest first) unless `in_order` is set.
     children: Vec<I>,
     /// Last doc_id successfully found in ALL children (returned by [`last_doc_id()`](Self::last_doc_id)).
@@ -52,12 +52,12 @@ pub struct RawIntersection<Rf: Ref, I> {
     /// When `true`, terms must appear in the same order as the child iterators.
     in_order: bool,
     /// Aggregate result combining children's results, reused to avoid allocations.
-    result: RawIndexResult<Rf>,
+    result: RawIndexResult<'query, Rf>,
 }
 
 /// Alias for an [`Active`] [`RawIntersection`] — the only instantiation
 /// with an [`RQEIterator`] impl today.
-pub type Intersection<'index, I> = RawIntersection<Active<'index>, I>;
+pub type Intersection<'index, I> = RawIntersection<'index, Active<'index>, I>;
 
 /// Result of attempting to get all children to agree on a target document ID.
 enum AgreeResult {

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -39,7 +39,7 @@ use crate::{
 /// * `R` - The reader type used to read the inverted index.
 /// * `E` - The expiration checker type used to check for expired documents.
 #[repr(C)]
-pub struct RawInvIndIterator<Rf: Ref, R, E = NoOpChecker> {
+pub struct RawInvIndIterator<'query, Rf: Ref, R, E = NoOpChecker> {
     /// The reader used to iterate over the inverted index.
     pub(super) reader: R,
     /// if we reached the end of the index.
@@ -47,7 +47,7 @@ pub struct RawInvIndIterator<Rf: Ref, R, E = NoOpChecker> {
     /// the last document ID read by the iterator.
     last_doc_id: DocId,
     /// A reusable result object to avoid allocations on each `read` call.
-    pub(super) result: RawIndexResult<Rf>,
+    pub(super) result: RawIndexResult<'query, Rf>,
 
     /// The expiration checker used to determine if documents are expired.
     expiration_checker: E,
@@ -55,7 +55,7 @@ pub struct RawInvIndIterator<Rf: Ref, R, E = NoOpChecker> {
     /// The implementation of the [`read`](RQEIterator::read) method.
     /// Using dynamic dispatch so we can pick the right version during the
     /// iterator construction saving to re-do the checks each time [`read()`](RQEIterator::read) is called.
-    read_impl: fn(&mut Self) -> Result<Option<&mut RawIndexResult<Rf>>, RQEIteratorError>,
+    read_impl: fn(&mut Self) -> Result<Option<&mut RawIndexResult<'query, Rf>>, RQEIteratorError>,
     /// The implementation of the [`skip_to`](RQEIterator::skip_to) method.
     #[expect(
         clippy::type_complexity,
@@ -63,12 +63,13 @@ pub struct RawInvIndIterator<Rf: Ref, R, E = NoOpChecker> {
                   would hide the Rf dependency that drives transmute soundness across modes."
     )]
     skip_to_impl:
-        fn(&mut Self, DocId) -> Result<Option<SkipToOutcomeRaw<'_, Rf>>, RQEIteratorError>,
+        fn(&mut Self, DocId) -> Result<Option<SkipToOutcomeRaw<'_, 'query, Rf>>, RQEIteratorError>,
 }
 
 /// Alias for an [`Active`] [`RawInvIndIterator`] — the only instantiation
 /// with an [`RQEIterator`] impl today.
-pub type InvIndIterator<'index, R, E = NoOpChecker> = RawInvIndIterator<Active<'index>, R, E>;
+pub type InvIndIterator<'index, R, E = NoOpChecker> =
+    RawInvIndIterator<'index, Active<'index>, R, E>;
 
 impl<'index, R, E> InvIndIterator<'index, R, E>
 where

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/missing.rs
@@ -50,8 +50,8 @@ use super::{InvIndIterator, core::RawInvIndIterator};
 /// * `E` - The encoding type for the inverted index. Its decoder must implement [`DocIdsDecoder`].
 /// * `C` - The expiration checker type.
 #[repr(C)]
-pub struct RawMissing<Rf: Ref, E: DecodedBy, C = crate::expiration_checker::NoOpChecker> {
-    it: RawInvIndIterator<Rf, RawIndexReaderCore<Rf, E>, C>,
+pub struct RawMissing<'query, Rf: Ref, E: DecodedBy, C = crate::expiration_checker::NoOpChecker> {
+    it: RawInvIndIterator<'query, Rf, RawIndexReaderCore<Rf, E>, C>,
     field_index: FieldIndex,
     /// Owned copy of the field name, extracted from the spec at construction
     /// time. Owning the string means the iterator no longer borrows from
@@ -63,7 +63,7 @@ pub struct RawMissing<Rf: Ref, E: DecodedBy, C = crate::expiration_checker::NoOp
 /// Alias for an [`Active`] [`RawMissing`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
 pub type Missing<'index, E, C = crate::expiration_checker::NoOpChecker> =
-    RawMissing<Active<'index>, E, C>;
+    RawMissing<'index, Active<'index>, E, C>;
 
 impl<'index, E, C> Missing<'index, E, C>
 where

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -44,8 +44,8 @@ use super::core::{InvIndIterator, RawInvIndIterator};
 /// * `R` - The type of the numeric reader.
 /// * `E` - The expiration checker type used to check for expired documents.
 #[repr(C)]
-pub struct RawNumeric<Rf: Ref, R, E = NoOpChecker> {
-    it: RawInvIndIterator<Rf, R, E>,
+pub struct RawNumeric<'query, Rf: Ref, R, E = NoOpChecker> {
+    it: RawInvIndIterator<'query, Rf, R, E>,
     /// The numeric range tree and its revision ID, used to detect changes during revalidation.
     range_tree_info: Option<RangeTreeInfo>,
     /// Minimum numeric range, only used in debug print.
@@ -56,7 +56,7 @@ pub struct RawNumeric<Rf: Ref, R, E = NoOpChecker> {
 
 /// Alias for an [`Active`] [`RawNumeric`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
-pub type Numeric<'index, R, E = NoOpChecker> = RawNumeric<Active<'index>, R, E>;
+pub type Numeric<'index, R, E = NoOpChecker> = RawNumeric<'index, Active<'index>, R, E>;
 
 /// Information about the numeric range tree backing a [`Numeric`] iterator.
 struct RangeTreeInfo {

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -45,14 +45,15 @@ use super::{InvIndIterator, core::RawInvIndIterator};
 /// * `E` - The encoding type for the inverted index. Its decoder must implement [`DocIdsDecoder`].
 /// * `C` - The expiration checker type.
 #[repr(C)]
-pub struct RawTag<Rf: Ref, E, C = crate::expiration_checker::NoOpChecker> {
-    it: RawInvIndIterator<Rf, RawIndexReaderCore<Rf, E>, C>,
+pub struct RawTag<'query, Rf: Ref, E, C = crate::expiration_checker::NoOpChecker> {
+    it: RawInvIndIterator<'query, Rf, RawIndexReaderCore<Rf, E>, C>,
     tag_index: NonNull<TagIndex>,
 }
 
 /// Alias for an [`Active`] [`RawTag`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
-pub type Tag<'index, E, C = crate::expiration_checker::NoOpChecker> = RawTag<Active<'index>, E, C>;
+pub type Tag<'index, E, C = crate::expiration_checker::NoOpChecker> =
+    RawTag<'index, Active<'index>, E, C>;
 
 impl<'index, E, C> Tag<'index, E, C>
 where

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -35,14 +35,14 @@ use super::core::{InvIndIterator, RawInvIndIterator};
 /// * `R` - The reader type used to read the inverted index.
 /// * `E` - The expiration checker type used to check for expired documents.
 #[repr(C)]
-pub struct RawTerm<Rf: Ref, R, E = crate::expiration_checker::NoOpChecker> {
-    it: RawInvIndIterator<Rf, R, E>,
+pub struct RawTerm<'query, Rf: Ref, R, E = crate::expiration_checker::NoOpChecker> {
+    it: RawInvIndIterator<'query, Rf, R, E>,
 }
 
 /// Alias for an [`Active`] [`RawTerm`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
 pub type Term<'index, R, E = crate::expiration_checker::NoOpChecker> =
-    RawTerm<Active<'index>, R, E>;
+    RawTerm<'index, Active<'index>, R, E>;
 
 impl<'index, R, E> Term<'index, R, E>
 where

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
@@ -41,13 +41,13 @@ use rqe_core::RS_FIELDMASK_ALL;
 /// * `Rf` - The [`Ref`] mode (see [`RawInvIndIterator`] for details).
 /// * `E` - The encoding type for the inverted index. Its decoder must implement [`DocIdsDecoder`].
 #[repr(C)]
-pub struct RawWildcard<Rf: Ref, E: DecodedBy> {
-    it: RawInvIndIterator<Rf, RawIndexReaderCore<Rf, E>>,
+pub struct RawWildcard<'query, Rf: Ref, E: DecodedBy> {
+    it: RawInvIndIterator<'query, Rf, RawIndexReaderCore<Rf, E>>,
 }
 
 /// Alias for an [`Active`] [`RawWildcard`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
-pub type Wildcard<'index, E> = RawWildcard<Active<'index>, E>;
+pub type Wildcard<'index, E> = RawWildcard<'index, Active<'index>, E>;
 
 impl<'index, E> Wildcard<'index, E>
 where

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -87,20 +87,20 @@ pub use wildcard::{NewWildcardIterator, Wildcard, WildcardIterator};
 
 #[derive(Debug)]
 /// The outcome of [`RQEIterator::skip_to`], generic over the [`Ref`] mode.
-pub enum SkipToOutcomeRaw<'iterator, Rf: Ref> {
+pub enum SkipToOutcomeRaw<'iterator, 'query, Rf: Ref> {
     /// The iterator has a valid entry for the requested `doc_id`.
-    Found(&'iterator mut RawIndexResult<Rf>),
+    Found(&'iterator mut RawIndexResult<'query, Rf>),
 
     /// The iterator doesn't have an entry for the requested `doc_id`, but there are entries with an id greater than the requested one.
-    NotFound(&'iterator mut RawIndexResult<Rf>),
+    NotFound(&'iterator mut RawIndexResult<'query, Rf>),
 }
 
 /// Manual `PartialEq` impl with a transitive bound on
-/// `RawIndexResult<Rf>: PartialEq` — only [`Active`] satisfies this
+/// `RawIndexResult<'query, Rf>: PartialEq` — only [`Active`] satisfies this
 /// (see [`ref_mode`]).
-impl<'iterator, Rf: Ref> PartialEq for SkipToOutcomeRaw<'iterator, Rf>
+impl<'iterator, 'query, Rf: Ref> PartialEq for SkipToOutcomeRaw<'iterator, 'query, Rf>
 where
-    RawIndexResult<Rf>: PartialEq,
+    RawIndexResult<'query, Rf>: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -117,7 +117,7 @@ where
 /// [`SkipToOutcomeRaw`] exists so the iterator structs can store function
 /// pointers whose signatures are uniform across `Active`/`Suspended`
 /// instantiations.
-pub type SkipToOutcome<'iterator, 'index> = SkipToOutcomeRaw<'iterator, Active<'index>>;
+pub type SkipToOutcome<'iterator, 'index> = SkipToOutcomeRaw<'iterator, 'index, Active<'index>>;
 
 #[derive(Debug, Error)]
 /// An iterator failure indications

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -47,8 +47,8 @@ pub type MetricSortedByScore<'index> = Metric<'index, false>;
 /// the wrapped `RawIdList` (whose `result` field is `Rf`-typed); the metric
 /// data is owned and has no `Rf` dependency.
 #[repr(C)]
-pub struct RawMetric<Rf: Ref, const SORTED_BY_ID: bool> {
-    base: RawIdList<Rf, SORTED_BY_ID>,
+pub struct RawMetric<'query, Rf: Ref, const SORTED_BY_ID: bool> {
+    base: RawIdList<'query, Rf, SORTED_BY_ID>,
     metric_data: OwnedSlice<f64>,
     type_: MetricType,
     own_key: *mut RLookupKey,
@@ -63,9 +63,9 @@ pub struct RawMetric<Rf: Ref, const SORTED_BY_ID: bool> {
 
 /// Alias for an [`Active`] [`RawMetric`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
-pub type Metric<'index, const SORTED_BY_ID: bool> = RawMetric<Active<'index>, SORTED_BY_ID>;
+pub type Metric<'index, const SORTED_BY_ID: bool> = RawMetric<'index, Active<'index>, SORTED_BY_ID>;
 
-impl<Rf: Ref, const SORTED_BY_ID: bool> Drop for RawMetric<Rf, SORTED_BY_ID> {
+impl<'query, Rf: Ref, const SORTED_BY_ID: bool> Drop for RawMetric<'query, Rf, SORTED_BY_ID> {
     fn drop(&mut self) {
         if !self.key_handle.is_null() {
             // Safety: thanks to [`Self::key_handle`]'s invariant, we can safely

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -36,7 +36,7 @@ use rqe_core::{DocId, RS_FIELDMASK_ALL};
 /// * `TC` - The [`TimeoutContext`] implementation. The variant is chosen at
 ///   construction time and monomorphized into the hot path.
 #[repr(C)]
-pub struct RawNot<Rf: Ref, I, TC> {
+pub struct RawNot<'query, Rf: Ref, I, TC> {
     /// The child iterator whose results are negated.
     child: MaybeEmpty<I>,
     /// The maximum document ID to iterate up to (inclusive).
@@ -46,7 +46,7 @@ pub struct RawNot<Rf: Ref, I, TC> {
     /// and reset to `false` at [`RQEIterator::rewind`].
     forced_eof: bool,
     /// A reusable result object to avoid allocations on each [`read`](RQEIterator::read) call.
-    result: RawIndexResult<Rf>,
+    result: RawIndexResult<'query, Rf>,
     /// Tracks the execution deadline for this iterator. Pass
     /// [`NoTimeout`](crate::utils::NoTimeout) to opt out of timeout checks
     /// entirely; monomorphization collapses the no-op context to dead code.
@@ -58,7 +58,7 @@ pub struct RawNot<Rf: Ref, I, TC> {
 
 /// Alias for an [`Active`] [`RawNot`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
-pub type Not<'index, I, TC> = RawNot<Active<'index>, I, TC>;
+pub type Not<'index, I, TC> = RawNot<'index, Active<'index>, I, TC>;
 
 impl<'index, I, TC> Not<'index, I, TC>
 where

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -45,7 +45,7 @@ use rqe_core::{DocId, RS_FIELDMASK_ALL};
 /// * `TC` - The [`TimeoutContext`] implementation. Chosen at construction
 ///   time and monomorphized into the hot path.
 #[repr(C)]
-pub struct RawNotOptimized<Rf: Ref, W, I, TC> {
+pub struct RawNotOptimized<'query, Rf: Ref, W, I, TC> {
     /// The wildcard iterator over all existing documents.
     wcii: W,
     /// The child iterator whose results are negated.
@@ -55,7 +55,7 @@ pub struct RawNotOptimized<Rf: Ref, W, I, TC> {
     /// Sticky EOF flag, set when iteration completes.
     forced_eof: bool,
     /// A reusable result object to avoid allocations on each [`read`](RQEIterator::read) call.
-    result: RawIndexResult<Rf>,
+    result: RawIndexResult<'query, Rf>,
     /// Tracks the execution deadline for this iterator. Pass
     /// [`NoTimeout`](crate::utils::NoTimeout) to opt out of timeout checks
     /// entirely; monomorphization collapses the no-op context to dead code.
@@ -64,7 +64,7 @@ pub struct RawNotOptimized<Rf: Ref, W, I, TC> {
 
 /// Alias for an [`Active`] [`RawNotOptimized`] — the only instantiation
 /// with an [`RQEIterator`] impl today.
-pub type NotOptimized<'index, W, I, TC> = RawNotOptimized<Active<'index>, W, I, TC>;
+pub type NotOptimized<'index, W, I, TC> = RawNotOptimized<'index, Active<'index>, W, I, TC>;
 
 impl<'index, W, I, TC> NotOptimized<'index, W, I, TC>
 where

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -27,7 +27,7 @@ use rqe_core::{DocId, RS_FIELDMASK_ALL};
 /// Parameterised over a [`Ref`] mode — see [`Optional`] for the [`Active`]
 /// instantiation that implements [`RQEIterator`].
 #[repr(C)]
-pub struct RawOptional<Rf: Ref, I> {
+pub struct RawOptional<'query, Rf: Ref, I> {
     /// Inclusive upper bound on document identifiers to iterate over.
     /// Reads from the [`Optional::child`] beyond this bound are ignored.
     /// If the [`Optional::child`] ends before this bound, this [`Optional`] iterator yields virtual
@@ -43,7 +43,7 @@ pub struct RawOptional<Rf: Ref, I> {
     ///
     /// Only for actual virtual results do we return a reference to it in
     /// functions such as Read/SkipTo.
-    result: RawIndexResult<Rf>,
+    result: RawIndexResult<'query, Rf>,
 
     /// The child [`RQEIterator`] provided at construction time.
     /// It is used while it can still produce results. Once exhausted,
@@ -106,7 +106,7 @@ impl<I> OptionalChild<I> {
 
 /// Alias for an [`Active`] [`RawOptional`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
-pub type Optional<'index, I> = RawOptional<Active<'index>, I>;
+pub type Optional<'index, I> = RawOptional<'index, Active<'index>, I>;
 
 impl<'index, I> Optional<'index, I>
 where

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -41,7 +41,7 @@ use rqe_core::{DocId, RS_FIELDMASK_ALL};
 /// sparse (few documents relative to `maxDocId`), the optimized variant is
 /// significantly faster.
 #[repr(C)]
-pub struct RawOptionalOptimized<Rf: Ref, W, I> {
+pub struct RawOptionalOptimized<'query, Rf: Ref, W, I> {
     /// Wildcard iterator over `spec.existingDocs` — the authoritative source of doc IDs.
     wcii: W,
     /// Query child — provides real hits at positions where it has a match.
@@ -49,7 +49,7 @@ pub struct RawOptionalOptimized<Rf: Ref, W, I> {
     /// when it is aborted during [`RQEIterator::revalidate`].
     child: MaybeEmpty<I>,
     /// Virtual result returned when `wcii` has a doc but `child` does not.
-    virt: RawIndexResult<Rf>,
+    virt: RawIndexResult<'query, Rf>,
     /// Inclusive upper bound (matches C `maxDocId`).
     max_doc_id: DocId,
     /// Weight applied to real results from `child`.
@@ -65,7 +65,7 @@ pub struct RawOptionalOptimized<Rf: Ref, W, I> {
 
 /// Alias for an [`Active`] [`RawOptionalOptimized`] — the only instantiation
 /// with an [`RQEIterator`] impl today.
-pub type OptionalOptimized<'index, W, I> = RawOptionalOptimized<Active<'index>, W, I>;
+pub type OptionalOptimized<'index, W, I> = RawOptionalOptimized<'index, Active<'index>, W, I>;
 
 impl<'index, W, I> OptionalOptimized<'index, W, I>
 where

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -71,7 +71,7 @@ impl<I> std::ops::DerefMut for IndexedChild<I> {
 /// - `QUICK_EXIT`: If `true`, returns immediately after finding any matching child.
 ///   If `false`, aggregates results from all children with the minimum doc_id.
 #[repr(C)]
-pub struct RawUnionFlat<Rf: Ref, I, const QUICK_EXIT: bool> {
+pub struct RawUnionFlat<'query, Rf: Ref, I, const QUICK_EXIT: bool> {
     /// Child iterators. Active children are in `children[..num_active]`,
     /// exhausted children are moved to the end and not removed so we can rewind the iterator.
     children: Vec<IndexedChild<I>>,
@@ -82,12 +82,13 @@ pub struct RawUnionFlat<Rf: Ref, I, const QUICK_EXIT: bool> {
     /// Whether the iterator has reached EOF (all children exhausted).
     is_eof: bool,
     /// Aggregate result combining children's results, reused to avoid allocations.
-    result: RawIndexResult<Rf>,
+    result: RawIndexResult<'query, Rf>,
 }
 
 /// Alias for an [`Active`] [`RawUnionFlat`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
-pub type UnionFlat<'index, I, const QUICK_EXIT: bool> = RawUnionFlat<Active<'index>, I, QUICK_EXIT>;
+pub type UnionFlat<'index, I, const QUICK_EXIT: bool> =
+    RawUnionFlat<'index, Active<'index>, I, QUICK_EXIT>;
 
 impl<'index, I, const QUICK_EXIT: bool> UnionFlat<'index, I, QUICK_EXIT>
 where

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -38,7 +38,7 @@ use index_spec::IndexSpecReadGuard;
 /// - `QUICK_EXIT`: If `true`, returns immediately after finding any matching child.
 ///   If `false`, aggregates results from all children with the minimum doc_id.
 #[repr(C)]
-pub struct RawUnionHeap<Rf: Ref, I, const QUICK_EXIT: bool> {
+pub struct RawUnionHeap<'query, Rf: Ref, I, const QUICK_EXIT: bool> {
     children: Vec<I>,
     num_estimated: usize,
     /// Number of children that have not yet reached EOF.
@@ -49,14 +49,15 @@ pub struct RawUnionHeap<Rf: Ref, I, const QUICK_EXIT: bool> {
     num_active: usize,
     is_eof: bool,
     /// Reused across calls to avoid allocations.
-    result: RawIndexResult<Rf>,
+    result: RawIndexResult<'query, Rf>,
     /// Min-heap of `(doc_id, child_index)`.
     heap: DocIdMinHeap,
 }
 
 /// Alias for an [`Active`] [`RawUnionHeap`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
-pub type UnionHeap<'index, I, const QUICK_EXIT: bool> = RawUnionHeap<Active<'index>, I, QUICK_EXIT>;
+pub type UnionHeap<'index, I, const QUICK_EXIT: bool> =
+    RawUnionHeap<'index, Active<'index>, I, QUICK_EXIT>;
 
 impl<'index, I, const QUICK_EXIT: bool> UnionHeap<'index, I, QUICK_EXIT>
 where

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -43,17 +43,17 @@ use index_spec::IndexSpecReadGuard;
 /// Enum holding all possible union iterator variants, parameterised over a
 /// [`Ref`] mode. See [`UnionVariant`] for the [`Active`] instantiation.
 #[repr(C)]
-pub enum RawUnionVariant<Rf: Ref, I> {
-    FlatFull(RawUnionFlat<Rf, I, false>),
-    FlatQuick(RawUnionFlat<Rf, I, true>),
-    HeapFull(RawUnionHeap<Rf, I, false>),
-    HeapQuick(RawUnionHeap<Rf, I, true>),
-    Trimmed(RawUnionTrimmed<Rf, I>),
+pub enum RawUnionVariant<'query, Rf: Ref, I> {
+    FlatFull(RawUnionFlat<'query, Rf, I, false>),
+    FlatQuick(RawUnionFlat<'query, Rf, I, true>),
+    HeapFull(RawUnionHeap<'query, Rf, I, false>),
+    HeapQuick(RawUnionHeap<'query, Rf, I, true>),
+    Trimmed(RawUnionTrimmed<'query, Rf, I>),
 }
 
 /// Alias for an [`Active`] [`RawUnionVariant`] — the only instantiation
 /// with a callable surface today.
-pub type UnionVariant<'index, I> = RawUnionVariant<Active<'index>, I>;
+pub type UnionVariant<'index, I> = RawUnionVariant<'index, Active<'index>, I>;
 
 impl<'index, I: RQEIterator<'index>> UnionVariant<'index, I> {
     /// Converts this variant in place to [`UnionVariant::Trimmed`], switching
@@ -115,8 +115,8 @@ macro_rules! delegate_variant_ref_mut {
 /// Parameterised over a [`Ref`] mode — see [`UnionOpaque`] for the
 /// [`Active`] instantiation that implements [`RQEIterator`].
 #[repr(C)]
-pub struct RawUnionOpaque<Rf: Ref, I> {
-    pub variant: RawUnionVariant<Rf, I>,
+pub struct RawUnionOpaque<'query, Rf: Ref, I> {
+    pub variant: RawUnionVariant<'query, Rf, I>,
     pub query_node_type: QueryNodeType,
     /// Borrowed C string describing the query (e.g. the search term), or
     /// [`None`] when the union has no associated query string.
@@ -131,7 +131,7 @@ pub struct RawUnionOpaque<Rf: Ref, I> {
 
 /// Alias for an [`Active`] [`RawUnionOpaque`] — the only instantiation
 /// with an [`RQEIterator`] impl today.
-pub type UnionOpaque<'index, I> = RawUnionOpaque<Active<'index>, I>;
+pub type UnionOpaque<'index, I> = RawUnionOpaque<'index, Active<'index>, I>;
 
 impl<'index, I: RQEIterator<'index>> UnionOpaque<'index, I> {
     /// Set the weight on the union's aggregate result.

--- a/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
@@ -78,7 +78,7 @@ use index_spec::IndexSpecReadGuard;
 /// - `Rf`: The [`Ref`] mode.
 /// - `I`: The child iterator type, must implement [`RQEIterator`].
 #[repr(C)]
-pub struct RawUnionTrimmed<Rf: Ref, I> {
+pub struct RawUnionTrimmed<'query, Rf: Ref, I> {
     /// All child iterators. The cursor only visits children in the trimmed
     /// window `[trim_start..trim_end)`. Children outside the window are kept
     /// alive (not dropped) so that profile display can query them by index.
@@ -97,12 +97,12 @@ pub struct RawUnionTrimmed<Rf: Ref, I> {
     /// Whether all children in the active window have been exhausted.
     is_eof: bool,
     /// Aggregate result combining children's results, reused to avoid allocations.
-    result: RawIndexResult<Rf>,
+    result: RawIndexResult<'query, Rf>,
 }
 
 /// Alias for an [`Active`] [`RawUnionTrimmed`] — the only instantiation
 /// with an [`RQEIterator`] impl today.
-pub type UnionTrimmed<'index, I> = RawUnionTrimmed<Active<'index>, I>;
+pub type UnionTrimmed<'index, I> = RawUnionTrimmed<'index, Active<'index>, I>;
 
 impl<'index, I> UnionTrimmed<'index, I>
 where

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -34,17 +34,17 @@ use crate::{IteratorType, QueryError, RQEIteratorPrintable};
 /// references into the index (it's a pure counter); the only `Rf`-dependent
 /// field is `result`.
 #[repr(C)]
-pub struct RawWildcard<Rf: Ref> {
+pub struct RawWildcard<'query, Rf: Ref> {
     // Supposed to be the max id in the index
     top_id: DocId,
 
     /// A reusable result object to avoid allocations on each `read` call.
-    result: RawIndexResult<Rf>,
+    result: RawIndexResult<'query, Rf>,
 }
 
 /// Alias for an [`Active`] [`RawWildcard`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
-pub type Wildcard<'index> = RawWildcard<Active<'index>>;
+pub type Wildcard<'index> = RawWildcard<'index, Active<'index>>;
 
 impl Wildcard<'_> {
     pub fn new(top_id: DocId, weight: f64) -> Self {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -517,13 +517,18 @@ impl<'index, const N: usize> rqe_iterators::RQEIteratorBoxed<'index> for Mock<'i
     }
 }
 
-impl<const N: usize> rqe_iterators::RQESuspendedIterator for MockSuspended<N> {
-    type Resumed<'a> = Mock<'a, N>;
+impl<'query, const N: usize> rqe_iterators::RQESuspendedIterator<'query> for MockSuspended<N> {
+    type Resumed<'a>
+        = Mock<'a, N>
+    where
+        'query: 'a;
 
     fn resume<'a>(
         mut self: Box<Self>,
         _guard: &index_spec::IndexSpecReadGuard<'a>,
     ) -> Result<rqe_iterators::ResumeOutcome<Box<Mock<'a, N>>>, rqe_iterators::RQEIteratorError>
+    where
+        'query: 'a,
     {
         // Honour the [`MockRevalidateResult`] configured on the mock's
         // [`MockData`] — mirrors what `Mock::revalidate` does on the legacy
@@ -800,13 +805,18 @@ impl<'index> rqe_iterators::RQEIteratorBoxed<'index> for MockVec<'index> {
     }
 }
 
-impl rqe_iterators::RQESuspendedIterator for MockVecSuspended {
-    type Resumed<'a> = MockVec<'a>;
+impl<'query> rqe_iterators::RQESuspendedIterator<'query> for MockVecSuspended {
+    type Resumed<'a>
+        = MockVec<'a>
+    where
+        'query: 'a;
 
     fn resume<'a>(
         mut self: Box<Self>,
         _guard: &index_spec::IndexSpecReadGuard<'a>,
     ) -> Result<rqe_iterators::ResumeOutcome<Box<MockVec<'a>>>, rqe_iterators::RQEIteratorError>
+    where
+        'query: 'a,
     {
         // Honour the [`MockRevalidateResult`] configured on the mock's
         // [`MockData`] — mirrors what `MockVec::revalidate` does on the legacy


### PR DESCRIPTION
## Describe the changes in the pull request

Split query-pipeline borrows (RLookupKey in metrics, borrowed query term in term records) out from the Active/Suspended ref-mode and onto a separate 'query lifetime parameter on RawIndexResult and friends. Suspending flips only the ref-mode (Active<'index> -> Suspended); 'query survives, so the suspended iterator is no longer forced to be 'static. 

Resume re-justifies only the index pointers via the spec guard; the RLookupKey/query-term are never weakened.

The need for this change became evident while reviewing `SAFETY` comments in #10274.

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
