### PR TITLE
[2.10] [MOD-16767] Fix cluster FT.SEARCH LIMIT result window

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1164,7 +1164,7 @@ static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) 
   searchRequestCtx *req = rCtx->searchCtx;
 
   // Number of results to actually return
-  size_t num = req->requestedResultsCount;
+  size_t num = req->offset + req->limit;
 
   size_t qlen = heap_count(rCtx->pq);
   size_t pos = qlen;
@@ -1218,7 +1218,7 @@ static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) 
 
     RedisModule_ReplyKV_Array(reply, "results"); // >results
 
-    for (int i = 0; i < qlen && i < num; ++i) {
+    for (size_t i = rCtx->searchCtx->offset; i < qlen && i < num; ++i) {
       RedisModule_Reply_Map(reply); // >> result
         searchResult *res = results[i];
 

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -113,6 +113,57 @@ def test_search():
     }
     env.expect('FT.search', 'idx1', "*").equal(exp)
 
+@skip(cluster=False, redis_less_than="7.0.0")
+def test_search_sortby_limit_offset():
+    env = Env(protocol=3)
+    conn = getConnectionByEnv(env)
+
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'count', 'NUMERIC', 'SORTABLE')
+    for i in range(30):
+        conn.execute_command('HSET', f'cdoc{{{i}}}', 'count', i)
+    waitForIndex(env, 'idx')
+
+    res = env.cmd('FT.SEARCH', 'idx', '*', 'SORTBY', 'count', 'ASC', 'LIMIT', '20', '10', 'NOCONTENT')
+    ids = [row['id'] for row in res['results']]
+    env.assertEqual(ids, [f'cdoc{{{i}}}' for i in range(20, 30)])
+
+def _search_knn_limit_offset(protocol):
+    env = Env(protocol=protocol, moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'FLAT', '6',
+            'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2')
+    for i in range(30):
+        conn.execute_command('HSET', f'vdoc{{{i:02d}}}', 'v',
+                             np.array([float(i), 0.0], dtype=np.float32).tobytes())
+    waitForIndex(env, 'idx')
+
+    blob = np.array([0.0, 0.0], dtype=np.float32).tobytes()
+
+    res = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 20 @v $B]', 'PARAMS', '2', 'B', blob,
+                  'LIMIT', '0', '10', 'NOCONTENT', 'DIALECT', '2')
+    if protocol == 3:
+        ids = [row['id'] for row in res['results']]
+    else:
+        ids = res[1:]
+    env.assertEqual(ids, [f'vdoc{{{i:02d}}}' for i in range(10)])
+
+    res = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 20 @v $B]', 'PARAMS', '2', 'B', blob,
+                  'LIMIT', '10', '10', 'NOCONTENT', 'DIALECT', '2')
+    if protocol == 3:
+        ids = [row['id'] for row in res['results']]
+    else:
+        ids = res[1:]
+    env.assertEqual(ids, [f'vdoc{{{i:02d}}}' for i in range(10, 20)])
+
+@skip(cluster=False, redis_less_than="7.0.0")
+def test_search_knn_limit_offset_resp2():
+    _search_knn_limit_offset(protocol=2)
+
+@skip(cluster=False, redis_less_than="7.0.0")
+def test_search_knn_limit_offset_resp3():
+    _search_knn_limit_offset(protocol=3)
+
 @skip(redis_less_than="7.0.0")
 def test_search_timeout():
     num_range = 1000


### PR DESCRIPTION
Backport of #10394 to `2.10`.

## Original PR
https://github.com/RediSearch/RediSearch/pull/10394

## Changes from original
Manual backport. In `2.10`, the coordinator search reducer still lives in `coord/src/module.c`, so the final reply-window fix was applied there instead of `src/module.c`.

## Validation
- `./build.sh DEBUG=0`
- `./build.sh DEBUG=0 COORD=oss`
- `PYTHONPATH=/home/omer-lerman/Code/RediSearch/venv/lib/python3.12/site-packages ./build.sh RUN_PYTEST COORD=oss TEST=test_resp3.py:test_search_sortby_limit_offset`
- `PYTHONPATH=/home/omer-lerman/Code/RediSearch/venv/lib/python3.12/site-packages ./build.sh RUN_PYTEST COORD=oss TEST=test_resp3.py:test_search_knn_limit_offset_resp2`
- `PYTHONPATH=/home/omer-lerman/Code/RediSearch/venv/lib/python3.12/site-packages ./build.sh RUN_PYTEST COORD=oss TEST=test_resp3.py:test_search_knn_limit_offset_resp3`

## Release Notes
- [x] This PR requires release notes
- [ ] This PR does not require release notes

Fixes cluster `FT.SEARCH` returning too many rows when applying `LIMIT`, including RESP3 non-zero offsets and KNN queries where `K` is larger than the requested LIMIT count.
