### PR TITLE
Move scorer logic to Rust

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -521,45 +521,6 @@ static void QueryNode_Expand(RSQueryTokenExpander expander, RSQueryExpanderCtx *
   }
 }
 
-/**
- * @brief Check if a scorer uses GetSlop (term proximity) for scoring
- *
- * Scorers that use GetSlop need offset data to calculate term proximity.
- * Default to true for unknown/custom scorers for safety.
- */
-static bool scorerNeedsOffsets(const char *scorerName) {
-  if (!scorerName) {
-    scorerName = RSGlobalConfig.defaultScorer;
-  }
-  // Scorers that do NOT need offsets (don't use GetSlop)
-  if (!strcmp(scorerName, BM25_STD_SCORER_NAME) ||
-      !strcmp(scorerName, BM25_STD_NORMALIZED_TANH_SCORER_NAME) ||
-      !strcmp(scorerName, BM25_STD_NORMALIZED_MAX_SCORER_NAME) ||
-      !strcmp(scorerName, DISMAX_SCORER_NAME) ||
-      !strcmp(scorerName, DOCSCORE_SCORER) ||
-      !strcmp(scorerName, HAMMINGDISTANCE_SCORER)) {
-    return false;
-  }
-  // TFIDF, TFIDF.DOCNORM, BM25 (legacy), and custom scorers need offsets
-  return true;
-}
-
-/**
- * @brief Check if a query needs offset data
- *
- * Offsets are needed if:
- * 1. The query has phrase/slop constraints (maxSlop >= 0 or inOrder)
- * 2. The scorer uses GetSlop for proximity-based scoring
- */
-static bool queryNeedsOffsets(const char *scorerName, const QueryNodeOptions *opts) {
-  // Check if query has phrase/slop constraints that require offsets for filtering
-  if (opts && (opts->maxSlop >= 0 || opts->inOrder)) {
-    return true;
-  }
-  // Check if scorer uses GetSlop for proximity-based scoring
-  return scorerNeedsOffsets(scorerName);
-}
-
 QueryIterator *Query_EvalTokenNode(QueryEvalCtx *q, QueryNode *qn) {
   RS_LOG_ASSERT(qn->type == QN_TOKEN, "query node type should be token")
 

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1804,6 +1804,8 @@ dependencies = [
  "cheadergen",
  "enumflags2",
  "rqe_core",
+ "strum",
+ "thiserror",
  "workspace_hack",
 ]
 

--- a/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
@@ -10,13 +10,20 @@
 //! C-callable bindings for the Rust query-evaluation dispatcher
 //! ([`query_eval::eval`]).
 
-use std::ptr::NonNull;
+use std::{
+    ffi::{CStr, c_char},
+    ptr::NonNull,
+};
 
 use ffi::{
-    AREQ, QueryAST, QueryError, QueryEvalCtx, QueryIterator, RSQueryNode, RSSearchOptions,
-    RedisSearchCtx,
+    AREQ, QueryAST, QueryError, QueryEvalCtx, QueryIterator, QueryNodeOptions, RSQueryNode,
+    RSSearchOptions, RedisSearchCtx,
 };
-use query_eval::{QueryEvalContext, QueryNodeRef, eval, eval::Config};
+use query_eval::{
+    QueryEvalContext, QueryNodeRef, eval,
+    eval::Config,
+    scorers::{BuiltInScorer, slop_forces_offsets},
+};
 
 /// Snapshot the evaluator's configuration from the process-wide
 /// [`ffi::RSGlobalConfig`].
@@ -37,6 +44,79 @@ fn eval_config() -> Config {
         numeric_compress,
         prioritize_intersect_union_children,
     }
+}
+
+/// Resolve a C scorer name to a built-in [`BuiltInScorer`], applying the configured
+/// default when `scorer_name` is null.
+///
+/// Returns [`None`] when the resolved name is unset or not a built-in name (a
+/// custom scorer) — cases the caller treats conservatively (as needing term
+/// offsets).
+///
+/// # Safety
+///
+/// `scorer_name` must be null or a valid NUL-terminated C string.
+unsafe fn resolve_scorer(scorer_name: *const c_char) -> Option<BuiltInScorer> {
+    // A null scorer name means "use the configured default scorer".
+    let name = if scorer_name.is_null() {
+        // SAFETY: `RSGlobalConfig` is the process-wide config, read-only here;
+        // `defaultScorer` is a `Copy` pointer read directly out of the static.
+        unsafe { ffi::RSGlobalConfig.defaultScorer }
+    } else {
+        scorer_name
+    };
+
+    NonNull::new(name.cast_mut()).and_then(|ptr| {
+        // SAFETY: `name` is non-null here and points to a valid NUL-terminated C
+        // string: either `scorer_name` (by this function's contract) or, in the
+        // default branch, `RSGlobalConfig.defaultScorer`, which the config layer
+        // guarantees is a valid NUL-terminated C string.
+        BuiltInScorer::from_c_str(unsafe { CStr::from_ptr(ptr.as_ptr()) })
+    })
+}
+
+/// Whether the scorer named `scorer_name` needs term offset data.
+///
+/// A null `scorer_name` falls back to the configured default scorer
+/// ([`ffi::RSGlobalConfig`]'s `defaultScorer`), and a custom or
+/// otherwise unrecognised name conservatively needs offsets.
+///
+/// # Safety
+///
+/// `scorer_name` must be null or a valid NUL-terminated C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn scorerNeedsOffsets(scorer_name: *const c_char) -> bool {
+    // SAFETY: `scorer_name` upholds this function's contract (null or a valid
+    // NUL-terminated C string).
+    let scorer = unsafe { resolve_scorer(scorer_name) };
+    scorer.is_none_or(BuiltInScorer::needs_offsets)
+}
+
+/// Whether a query node needs term offset data.
+///
+/// # Safety
+///
+/// `scorer_name` must be null or a valid NUL-terminated C string; `opts` must be
+/// null or point to a valid [`QueryNodeOptions`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn queryNeedsOffsets(
+    scorer_name: *const c_char,
+    opts: *const QueryNodeOptions,
+) -> bool {
+    // A phrase/slop constraint forces offsets regardless of the scorer, so check
+    // it first and return before resolving the scorer — which would otherwise
+    // read the process-wide default scorer needlessly. A null `opts` carries no
+    // such constraint.
+    // SAFETY: `opts` is null or a valid `QueryNodeOptions` (this function's contract).
+    if let Some(opts) = unsafe { opts.as_ref() }
+        && slop_forces_offsets(opts.max_slop, opts.in_order)
+    {
+        return true;
+    }
+    // No phrase/slop constraint: the scorer alone decides.
+    // SAFETY: `scorer_name` upholds this function's contract (null or a valid
+    // NUL-terminated C string).
+    unsafe { scorerNeedsOffsets(scorer_name) }
 }
 
 /// Evaluate a single query AST node, producing the corresponding

--- a/src/redisearch_rs/c_wrappers/query/src/mock/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/mock/query_eval_ctx.rs
@@ -159,6 +159,10 @@ impl MockQueryEvalCtx {
         self.doc_table
     }
 
+    pub fn opts_ptr(&self) -> *mut ffi::RSSearchOptions {
+        self.opts
+    }
+
     pub fn set_max_doc_id(&mut self, max_doc_id: rqe_core::DocId) {
         // SAFETY: `self.doc_table` is a valid, exclusively-owned allocation.
         unsafe { (*self.doc_table).maxDocId = max_doc_id }

--- a/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
@@ -9,7 +9,7 @@
 
 //! Safe wrapper around [`ffi::QueryEvalCtx`].
 
-use std::ptr::NonNull;
+use std::{ffi::CStr, ptr::NonNull};
 
 use query_flags::QEFlags;
 use rlookup::MetricRequest;
@@ -20,6 +20,8 @@ use rqe_iterators::{
     utils::{AnyTimeoutContext, TimeoutContextBlockedClient},
 };
 use search_disk::SearchDiskHandle;
+
+use query_types::scorers::{BuiltInScorer, RequestedScorer};
 
 /// Safe wrapper around [`ffi::QueryEvalCtx`].
 ///
@@ -60,6 +62,10 @@ impl QueryEvalContext {
     ///    context, but for the lifetime of every timeout context and iterator
     ///    derived from it (e.g. via
     ///    [`build_timeout_context`](QueryEvalContext::build_timeout_context)).
+    ///    The `opts.scorerName` pointer may be null (no scorer requested); when
+    ///    non-null it must point to a valid NUL-terminated C string that stays
+    ///    valid for at least the lifetime of the returned context (read by
+    ///    [`scorer`](QueryEvalContext::scorer)).
     /// 3. The caller must have exclusive access to the pointer for the
     ///    lifetime of the returned [`QueryEvalContext`].
     ///
@@ -115,6 +121,29 @@ impl QueryEvalContext {
     /// phrase terms to match in order regardless of per-node options.
     pub const fn search_in_order(&self) -> bool {
         self.opts().flags & ffi::RSSearchFlags_Search_InOrder != 0
+    }
+
+    /// The scorer this query requested, as a [`RequestedScorer`].
+    ///
+    /// This reports only the query's own choice; it does **not** apply any
+    /// default. A null scorer name is [`Unset`](RequestedScorer::Unset); a
+    /// set name resolves to [`BuiltIn`](RequestedScorer::BuiltIn) when it
+    /// matches a built-in, otherwise [`Custom`](RequestedScorer::Custom)
+    /// carrying the requested name. The caller decides the fallback for each
+    /// variant.
+    pub fn scorer(&self) -> RequestedScorer<'_> {
+        let Some(ptr) = NonNull::new(self.opts().scorerName.cast_mut()) else {
+            return RequestedScorer::Unset;
+        };
+        // SAFETY: invariant (2) of `new` guarantees `opts` is valid and that its
+        // `scorerName`, non-null here, points to a valid NUL-terminated C string
+        // that stays valid for at least the lifetime of the returned context, and
+        // thus of `&self` — which bounds the returned `RequestedScorer`'s borrow.
+        let name = unsafe { CStr::from_ptr(ptr.as_ptr()) };
+        match BuiltInScorer::from_c_str(name) {
+            Some(scorer) => RequestedScorer::BuiltIn(scorer),
+            None => RequestedScorer::Custom(name),
+        }
     }
 
     /// The [`query_error::QueryError`] accumulator for reporting evaluation

--- a/src/redisearch_rs/c_wrappers/query/tests/integration/query_eval_ctx/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/tests/integration/query_eval_ctx/mod.rs
@@ -9,6 +9,7 @@
 
 use query::{QueryEvalContext, mock::MockQueryEvalCtx};
 use query_flags::QEFlag;
+use query_types::scorers::{BuiltInScorer, RequestedScorer};
 use rqe_iterators::utils::AnyTimeoutContext;
 
 #[test]
@@ -150,4 +151,45 @@ fn build_timeout_context_prefers_blocked_client_when_wired() {
     // the end of the assertion — never used past the AREQ.
     let timeout = unsafe { ctx.build_timeout_context() };
     assert!(matches!(timeout, AnyTimeoutContext::BlockedClient(_)));
+}
+
+/// Build a context whose query scorer name is `name`, keeping the backing
+/// [`CString`] alive for the returned context.
+fn ctx_with_scorer_name(mock: &mut MockQueryEvalCtx, name: &std::ffi::CStr) -> QueryEvalContext {
+    // SAFETY: `mock.opts_ptr()` is a valid, exclusively-owned `RSSearchOptions`;
+    // `name` outlives the returned context.
+    unsafe { (*mock.opts_ptr()).scorerName = name.as_ptr() };
+    unsafe { QueryEvalContext::new(mock.as_non_null()) }
+}
+
+#[test]
+fn scorer_unset_query_is_unset() {
+    // The mock zero-inits `opts`, so `scorerName` is null: the query requested
+    // no scorer, so `scorer()` reports `Unset` and leaves the fallback to the
+    // caller.
+    let mut mock = MockQueryEvalCtx::new();
+    // SAFETY: the mock is a valid, exclusively-owned `QueryEvalCtx`.
+    let ctx = unsafe { QueryEvalContext::new(mock.as_non_null()) };
+    assert_eq!(ctx.scorer(), RequestedScorer::Unset);
+}
+
+#[test]
+fn scorer_builtin_query_resolves_to_that_scorer() {
+    let name = std::ffi::CString::new("BM25STD").unwrap();
+    let mut mock = MockQueryEvalCtx::new();
+    let ctx = ctx_with_scorer_name(&mut mock, &name);
+    assert_eq!(
+        ctx.scorer(),
+        RequestedScorer::BuiltIn(BuiltInScorer::Bm25Std)
+    );
+}
+
+#[test]
+fn scorer_custom_query_is_custom() {
+    // A set-but-custom query scorer is not one of the built-ins, so it resolves
+    // to `Custom` (distinct from an unset scorer).
+    let name = std::ffi::CString::new("MY_CUSTOM_SCORER").unwrap();
+    let mut mock = MockQueryEvalCtx::new();
+    let ctx = ctx_with_scorer_name(&mut mock, &name);
+    assert_eq!(ctx.scorer(), RequestedScorer::Custom(name.as_c_str()));
 }

--- a/src/redisearch_rs/headers/query_eval_ffi.h
+++ b/src/redisearch_rs/headers/query_eval_ffi.h
@@ -22,11 +22,40 @@ typedef struct RSQueryNode RSQueryNode;
 typedef struct AREQ AREQ;
 
 
+/**
+ * Various modifiers and options that can apply to the entire query or any
+ * sub-query of it.
+ */
+typedef struct QueryNodeOptions QueryNodeOptions;
+
 typedef struct QueryError QueryError;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
+
+/**
+ * Whether the scorer named `scorer_name` needs term offset data.
+ *
+ * A null `scorer_name` falls back to the configured default scorer
+ * ([`ffi::RSGlobalConfig`]'s `defaultScorer`), and a custom or
+ * otherwise unrecognised name conservatively needs offsets.
+ *
+ * # Safety
+ *
+ * `scorer_name` must be null or a valid NUL-terminated C string.
+ */
+bool scorerNeedsOffsets(const char *scorer_name);
+
+/**
+ * Whether a query node needs term offset data.
+ *
+ * # Safety
+ *
+ * `scorer_name` must be null or a valid NUL-terminated C string; `opts` must be
+ * null or point to a valid [`QueryNodeOptions`].
+ */
+bool queryNeedsOffsets(const char *scorer_name, const struct QueryNodeOptions *opts);
 
 /**
  * Evaluate a single query AST node, producing the corresponding

--- a/src/redisearch_rs/headers/query_types.h
+++ b/src/redisearch_rs/headers/query_types.h
@@ -506,19 +506,14 @@ typedef struct QueryNodeOptions {
 #define DEFAULT_EXPANDER_NAME "DEFAULT"
 
 /**
- * TF-IDF scorer (`TFIDF`). Uses term proximity, so it needs term offsets.
- */
-#define TFIDF_SCORER_NAME "TFIDF"
-
-/**
  * Phonetic-matching query expander (`PHONETIC`).
  */
 #define PHONETIC_EXPENDER_NAME "PHONETIC"
 
 /**
- * Document-normalized TF-IDF scorer (`TFIDF.DOCNORM`).
+ * TF-IDF scorer (`TFIDF`). Uses term proximity, so it needs term offsets.
  */
-#define TFIDF_DOCNORM_SCORER_NAME "TFIDF.DOCNORM"
+#define TFIDF_SCORER_NAME "TFIDF"
 
 /**
  * Synonym-expansion query expander (`SYNONYM`).
@@ -526,14 +521,19 @@ typedef struct QueryNodeOptions {
 #define SYNONYMS_EXPENDER_NAME "SYNONYM"
 
 /**
- * Disjunction-max scorer (`DISMAX`).
+ * Document-normalized TF-IDF scorer (`TFIDF.DOCNORM`).
  */
-#define DISMAX_SCORER_NAME "DISMAX"
+#define TFIDF_DOCNORM_SCORER_NAME "TFIDF.DOCNORM"
 
 /**
  * Stemming query expander (`SBSTEM`).
  */
 #define STEMMER_EXPENDER_NAME "SBSTEM"
+
+/**
+ * Disjunction-max scorer (`DISMAX`).
+ */
+#define DISMAX_SCORER_NAME "DISMAX"
 
 /**
  * Legacy BM25 scorer (`BM25`).

--- a/src/redisearch_rs/query_types/Cargo.toml
+++ b/src/redisearch_rs/query_types/Cargo.toml
@@ -12,4 +12,6 @@ workspace = true
 cheadergen.workspace = true
 enumflags2.workspace = true
 rqe_core.workspace = true
+strum.workspace = true
+thiserror.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/query_types/src/scorers.rs
+++ b/src/redisearch_rs/query_types/src/scorers.rs
@@ -138,6 +138,17 @@ impl BuiltInScorer {
     }
 }
 
+/// Whether a node's phrase/slop options force term offsets on their own,
+/// regardless of the scorer.
+///
+/// A phrase/slop constraint — a non-negative `max_slop` or an `in_order`
+/// requirement — needs offsets to filter matches by term position. When this
+/// returns `false` the options impose no such requirement and the scorer alone
+/// decides (see [`BuiltInScorer::needs_offsets`]).
+pub const fn slop_forces_offsets(max_slop: i32, in_order: i32) -> bool {
+    max_slop >= 0 || in_order != 0
+}
+
 /// The scorer a query requested, before any default is applied.
 ///
 /// This reports the query's stated intent as-is; it never substitutes a

--- a/src/redisearch_rs/query_types/src/scorers.rs
+++ b/src/redisearch_rs/query_types/src/scorers.rs
@@ -7,7 +7,11 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Canonical names of the built-in scorers.
+//! Canonical names of the built-in scorers, and the [`BuiltInScorer`] enum over them.
+
+use std::ffi::CStr;
+
+use strum::VariantArray;
 
 /// TF-IDF scorer (`TFIDF`). Uses term proximity, so it needs term offsets.
 #[cheadergen::config(export)]
@@ -52,3 +56,121 @@ pub const HAMMINGDISTANCE_SCORER: &str = "HAMMING";
 /// string constants.
 #[cheadergen::config(export)]
 pub const DEFAULT_SCORER_NAME: &str = "BM25STD";
+
+/// A built-in scorer, identified by its canonical name.
+///
+/// Parse a name into a [`BuiltInScorer`] with [`str::parse`]/[`FromStr`]; a name that
+/// is not one of the built-ins (a custom scorer) yields [`UnknownScorer`].
+///
+/// The [`Default`] is [`Bm25Std`](BuiltInScorer::Bm25Std), the scorer applied when a
+/// query requests none (see [`DEFAULT_SCORER_NAME`]).
+///
+/// [`FromStr`]: std::str::FromStr
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, VariantArray)]
+pub enum BuiltInScorer {
+    /// TF-IDF ([`TFIDF_SCORER_NAME`]).
+    TfIdf,
+    /// Document-normalized TF-IDF ([`TFIDF_DOCNORM_SCORER_NAME`]).
+    TfIdfDocNorm,
+    /// Legacy BM25 ([`BM25_SCORER_NAME`]).
+    Bm25,
+    /// Disjunction-max ([`DISMAX_SCORER_NAME`]).
+    DisMax,
+    /// Standard BM25 ([`BM25_STD_SCORER_NAME`]). The default scorer.
+    #[default]
+    Bm25Std,
+    /// Standard BM25 with tanh normalization ([`BM25_STD_NORMALIZED_TANH_SCORER_NAME`]).
+    Bm25StdTanh,
+    /// Standard BM25 with max normalization ([`BM25_STD_NORMALIZED_MAX_SCORER_NAME`]).
+    Bm25StdNorm,
+    /// Document score ([`DOCSCORE_SCORER`]).
+    DocScore,
+    /// Hamming distance ([`HAMMINGDISTANCE_SCORER`]).
+    Hamming,
+}
+
+impl BuiltInScorer {
+    /// Resolve a scorer from its raw name bytes, or [`None`] for a name that is
+    /// not one of the built-ins.
+    fn from_name_bytes(bytes: &[u8]) -> Option<BuiltInScorer> {
+        BuiltInScorer::VARIANTS
+            .iter()
+            .copied()
+            .find(|scorer| scorer.name().as_bytes() == bytes)
+    }
+
+    /// Resolve a scorer from a NUL-terminated C string.
+    pub fn from_c_str(name: &CStr) -> Option<BuiltInScorer> {
+        BuiltInScorer::from_name_bytes(name.to_bytes())
+    }
+
+    /// The scorer's canonical name.
+    pub const fn name(self) -> &'static str {
+        match self {
+            BuiltInScorer::TfIdf => TFIDF_SCORER_NAME,
+            BuiltInScorer::TfIdfDocNorm => TFIDF_DOCNORM_SCORER_NAME,
+            BuiltInScorer::Bm25 => BM25_SCORER_NAME,
+            BuiltInScorer::DisMax => DISMAX_SCORER_NAME,
+            BuiltInScorer::Bm25Std => BM25_STD_SCORER_NAME,
+            BuiltInScorer::Bm25StdTanh => BM25_STD_NORMALIZED_TANH_SCORER_NAME,
+            BuiltInScorer::Bm25StdNorm => BM25_STD_NORMALIZED_MAX_SCORER_NAME,
+            BuiltInScorer::DocScore => DOCSCORE_SCORER,
+            BuiltInScorer::Hamming => HAMMINGDISTANCE_SCORER,
+        }
+    }
+
+    /// Whether this scorer needs term offset data.
+    ///
+    /// The BM25STD family, [`DisMax`](BuiltInScorer::DisMax),
+    /// [`DocScore`](BuiltInScorer::DocScore) and [`Hamming`](BuiltInScorer::Hamming) score
+    /// without term proximity, so they don't need offsets. TF-IDF (both
+    /// variants) and legacy [`Bm25`](BuiltInScorer::Bm25) use proximity scoring and do.
+    pub const fn needs_offsets(self) -> bool {
+        match self {
+            BuiltInScorer::Bm25Std
+            | BuiltInScorer::Bm25StdTanh
+            | BuiltInScorer::Bm25StdNorm
+            | BuiltInScorer::DisMax
+            | BuiltInScorer::DocScore
+            | BuiltInScorer::Hamming => false,
+            BuiltInScorer::TfIdf | BuiltInScorer::TfIdfDocNorm | BuiltInScorer::Bm25 => true,
+        }
+    }
+}
+
+/// The scorer a query requested, before any default is applied.
+///
+/// This reports the query's stated intent as-is; it never substitutes a
+/// default. The [`Custom`](RequestedScorer::Custom) name borrows from the
+/// source that produced it (typically the query's search options).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestedScorer<'name> {
+    /// The query set no scorer of its own. The caller applies its own default.
+    Unset,
+    /// The query set a name that is not one of the built-ins (a custom scorer),
+    /// carried here as its raw NUL-terminated name. It cannot be resolved to a
+    /// [`BuiltInScorer`], so the caller should handle it conservatively (e.g. as
+    /// needing term offsets) or look it up among the registered extension
+    /// scorers by name.
+    Custom(&'name CStr),
+    /// The query set a recognized built-in [`BuiltInScorer`].
+    BuiltIn(BuiltInScorer),
+}
+
+/// Error returned by [`BuiltInScorer::from_str`](std::str::FromStr::from_str) when the
+/// name is not one of the built-in scorers.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("unknown scorer name: {name:?}")]
+pub struct UnknownScorer {
+    /// The unrecognized scorer name that was requested.
+    pub name: String,
+}
+
+impl std::str::FromStr for BuiltInScorer {
+    type Err = UnknownScorer;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        BuiltInScorer::from_name_bytes(s.as_bytes())
+            .ok_or_else(|| UnknownScorer { name: s.to_owned() })
+    }
+}

--- a/src/redisearch_rs/query_types/tests/integration/main.rs
+++ b/src/redisearch_rs/query_types/tests/integration/main.rs
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+mod scorers;

--- a/src/redisearch_rs/query_types/tests/integration/scorers.rs
+++ b/src/redisearch_rs/query_types/tests/integration/scorers.rs
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Tests for the public [`BuiltInScorer`] API.
+
+use std::ffi::CString;
+
+use query_types::scorers::{DEFAULT_SCORER_NAME, Scorer, UnknownScorer};
+use strum::VariantArray;
+
+#[test]
+fn default_is_bm25_std() {
+    assert_eq!(BuiltInScorer::default(), BuiltInScorer::Bm25Std);
+    assert_eq!(BuiltInScorer::default().name(), DEFAULT_SCORER_NAME);
+}
+
+#[test]
+fn from_str_round_trips_every_scorer() {
+    for &scorer in BuiltInScorer::VARIANTS {
+        assert_eq!(scorer.name().parse::<BuiltInScorer>(), Ok(scorer));
+    }
+}
+
+#[test]
+fn from_str_rejects_unknown_names() {
+    // The rejected name is captured in the error so it can be logged.
+    for name in ["", "MY_CUSTOM_SCORER", /* case-sensitive: */ "tfidf"] {
+        assert_eq!(
+            name.parse::<BuiltInScorer>(),
+            Err(UnknownScorer { name: name.into() })
+        );
+    }
+    // The captured name surfaces in the error message.
+    let err = "MY_CUSTOM_SCORER".parse::<BuiltInScorer>().unwrap_err();
+    assert!(err.to_string().contains("MY_CUSTOM_SCORER"));
+}
+
+#[test]
+fn from_c_str_matches_from_str() {
+    // Built-in names round-trip through the C-string path too.
+    for &scorer in BuiltInScorer::VARIANTS {
+        let c_name = CString::new(scorer.name()).unwrap();
+        assert_eq!(BuiltInScorer::from_c_str(&c_name), Some(scorer));
+    }
+
+    // Custom and non-UTF-8 names are not built-ins, so they yield `None`.
+    let custom = CString::new("MY_CUSTOM_SCORER").unwrap();
+    assert_eq!(BuiltInScorer::from_c_str(&custom), None);
+    let non_utf8 = CString::new([0xFF, 0xFE]).unwrap();
+    assert_eq!(BuiltInScorer::from_c_str(&non_utf8), None);
+}
+
+#[test]
+fn proximity_scorers_need_offsets() {
+    for scorer in [
+        BuiltInScorer::TfIdf,
+        BuiltInScorer::TfIdfDocNorm,
+        BuiltInScorer::Bm25,
+    ] {
+        assert!(scorer.needs_offsets(), "{scorer:?} should need offsets");
+    }
+}
+
+#[test]
+fn non_proximity_scorers_skip_offsets() {
+    for scorer in [
+        BuiltInScorer::DisMax,
+        BuiltInScorer::DocScore,
+        BuiltInScorer::Hamming,
+        BuiltInScorer::Bm25Std,
+        BuiltInScorer::Bm25StdTanh,
+        BuiltInScorer::Bm25StdNorm,
+    ] {
+        assert!(!scorer.needs_offsets(), "{scorer:?} should skip offsets");
+    }
+}

--- a/src/redisearch_rs/query_types/tests/integration/scorers.rs
+++ b/src/redisearch_rs/query_types/tests/integration/scorers.rs
@@ -11,7 +11,9 @@
 
 use std::ffi::CString;
 
-use query_types::scorers::{DEFAULT_SCORER_NAME, Scorer, UnknownScorer};
+use query_types::scorers::{
+    BuiltInScorer, DEFAULT_SCORER_NAME, UnknownScorer, slop_forces_offsets,
+};
 use strum::VariantArray;
 
 #[test]
@@ -79,4 +81,21 @@ fn non_proximity_scorers_skip_offsets() {
     ] {
         assert!(!scorer.needs_offsets(), "{scorer:?} should skip offsets");
     }
+}
+
+#[test]
+fn slop_or_order_forces_offsets() {
+    // A non-negative `max_slop` or an `in_order` requirement forces offsets,
+    // regardless of the scorer.
+    assert!(slop_forces_offsets(0, 0));
+    assert!(slop_forces_offsets(5, 0));
+    assert!(slop_forces_offsets(-1, 1));
+    assert!(slop_forces_offsets(3, 0));
+}
+
+#[test]
+fn no_slop_or_order_does_not_force_offsets() {
+    // With no phrase/slop constraint (`max_slop < 0`, `in_order == 0`) the
+    // options impose nothing and the scorer alone decides.
+    assert!(!slop_forces_offsets(-1, 0));
 }


### PR DESCRIPTION
- Based on top of https://github.com/RediSearch/RediSearch/pull/10409

In order to ease the `QN_TOKEN` handling in Rust:

- add `Scorer` enum.
- move logic around scorers to Rust.

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
