### PR TITLE
[MOD-16604] Test aggregate config defaults are disk only

### DIFF
--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -272,6 +272,27 @@ def test_flex_gc_config_defaults_and_set(env):
 
 
 @skip(cluster=True)
+@with_simulate_in_flex(True)
+def test_flex_aggregate_config_defaults_are_disk_only(env):
+    """Simulated Flex validates disk syntax but does not lower aggregate caps."""
+    env.expect('CONFIG', 'GET', 'search-max-aggregate-results') \
+        .equal(['search-max-aggregate-results', str(1 << 31)])
+    env.expect('CONFIG', 'GET', 'search-max-aggregate-groups') \
+        .equal(['search-max-aggregate-groups', '1000000'])
+    env.expect(config_cmd(), 'GET', 'MAXAGGREGATERESULTS') \
+        .equal([['MAXAGGREGATERESULTS', 'unlimited']])
+    env.expect(config_cmd(), 'GET', 'MAX_AGGREGATE_GROUPS') \
+        .equal([['MAX_AGGREGATE_GROUPS', '1000000']])
+
+    env.expect(config_cmd(), 'SET', 'MAXAGGREGATERESULTS', '1000000').ok()
+    env.expect(config_cmd(), 'SET', 'MAX_AGGREGATE_GROUPS', '100000').ok()
+    env.expect('CONFIG', 'GET', 'search-max-aggregate-results') \
+        .equal(['search-max-aggregate-results', '1000000'])
+    env.expect('CONFIG', 'GET', 'search-max-aggregate-groups') \
+        .equal(['search-max-aggregate-groups', '100000'])
+
+
+@skip(cluster=True)
 @with_simulate_in_flex(
     True,
     module_args='FORK_GC_RUN_INTERVAL 60 FORK_GC_CLEAN_THRESHOLD 500',


### PR DESCRIPTION
## Describe the changes in the pull request

Current: aggregate config caps are registered with lowered defaults only when real disk mode is enabled, but simulated Flex validation did not have explicit regression coverage for keeping the standard defaults.

Change: Add a Python validation test that checks `_SIMULATE_IN_FLEX` keeps the regular aggregate config defaults for both Redis `CONFIG GET` and `_FT.CONFIG GET`, and still allows explicit overrides.

Outcome: Protects the disk-only default behavior for aggregate configs from regressing into simulated Flex validation mode.

#### Which additional issues this PR fixes
1. MOD-16604
2. N/A

#### Main objects this PR modified
1. `tests/pytests/test_flex_validation.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  