### PR TITLE
[MOD-16897] Add deadline-aware early stop to TermSuffixIndex wildcard scan

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2943,6 +2943,7 @@ name = "term_suffix_index"
 version = "0.0.1"
 dependencies = [
  "ffi",
+ "itertools 0.15.0",
  "proptest",
  "rqe_wildcard",
  "rstest",

--- a/src/redisearch_rs/c_entrypoint/term_suffix_index_ffi/src/iter_callback.rs
+++ b/src/redisearch_rs/c_entrypoint/term_suffix_index_ffi/src/iter_callback.rs
@@ -132,9 +132,16 @@ pub unsafe extern "C" fn TermSuffixIndex_IterateSuffix(
 /// byte); a term may be reported more than once. Iteration stops early
 /// when the callback returns a non-zero value.
 ///
+/// When `should_stop` is non-NULL it is polled periodically while the
+/// candidate set is scanned; once it returns `true` the scan is abandoned
+/// and only the terms gathered so far are reported. This bounds the
+/// expensive scan by a caller-owned deadline, which the per-term callback
+/// alone cannot do because matches are gathered before any callback fires.
+/// Pass NULL to scan without a deadline.
+///
 /// Returns 0 when the pattern has no literal token that can anchor the
 /// search; the caller must then fall back to a full scan. Returns 1
-/// otherwise, even when no term matched.
+/// otherwise, even when no term matched or the scan stopped early.
 ///
 /// # Safety
 ///
@@ -146,6 +153,8 @@ pub unsafe extern "C" fn TermSuffixIndex_IterateSuffix(
 /// 2. `pattern` must point to a [valid] byte sequence of length `len`.
 /// 3. `cb` must not modify or free `tsi`, nor retain the term
 ///    pointer beyond the call.
+/// 4. If `should_stop` is non-NULL it must be safe to call with `stop_ctx`
+///    for the duration of this call, and must not modify or free `tsi`.
 ///
 /// # Panics
 ///
@@ -159,6 +168,8 @@ pub unsafe extern "C" fn TermSuffixIndex_IterateWildcard(
     len: usize,
     cb: TermSuffixIterateCallback,
     ctx: *mut c_void,
+    should_stop: TermSuffixShouldStop,
+    stop_ctx: *mut c_void,
 ) -> c_int {
     debug_assert!(!tsi.is_null(), "tsi cannot be NULL");
     debug_assert!(!pattern.is_null(), "pattern cannot be NULL");
@@ -170,7 +181,9 @@ pub unsafe extern "C" fn TermSuffixIndex_IterateWildcard(
     let bytes = unsafe { slice::from_raw_parts(pattern.cast::<u8>(), len) };
 
     let pattern = str::from_utf8(bytes).expect("pattern must be valid UTF-8");
-    let Some(matches) = index.iter_wildcard(pattern) else {
+    // Safety: ensured by caller (4.)
+    let should_stop = || should_stop.is_some_and(|f| unsafe { f(stop_ctx) });
+    let Some(matches) = index.iter_wildcard(pattern, should_stop) else {
         return 0;
     };
     for term in matches {
@@ -208,3 +221,10 @@ pub type TermSuffixIterateCallback = Option<
         payload: *mut c_void,
     ) -> c_int,
 >;
+
+/// Stop predicate polled while a wildcard scan walks its candidates.
+///
+/// `ctx` is the `stop_ctx` passed to the iterate function. Return `true`
+/// to abandon the scan (e.g. once a deadline has passed); the caller owns
+/// the decision and any clock it consults. A NULL predicate never stops.
+pub type TermSuffixShouldStop = Option<unsafe extern "C" fn(ctx: *mut c_void) -> bool>;

--- a/src/redisearch_rs/c_entrypoint/term_suffix_index_ffi/tests/term_suffix_index.rs
+++ b/src/redisearch_rs/c_entrypoint/term_suffix_index_ffi/tests/term_suffix_index.rs
@@ -211,6 +211,8 @@ fn collect_wildcard(t: *mut TermSuffixIndex, pattern: &str) -> (c_int, HashSet<S
             pattern.len(),
             Some(collect_cb),
             (&raw mut yielded).cast(),
+            None,
+            std::ptr::null_mut(),
         )
     };
     (rc, yielded)

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -497,6 +497,12 @@ const HEADERS: &[HeaderAllowlist] = &[
         vars: &[],
     },
     HeaderAllowlist {
+        path: "src/util/timeout.h",
+        fns: &[],
+        types: &[],
+        vars: &["TIMEOUT_COUNTER_LIMIT"],
+    },
+    HeaderAllowlist {
         path: "src/wildcard/wildcard.h",
         fns: &["Wildcard_RemoveEscape"],
         types: &[],

--- a/src/redisearch_rs/headers/term_suffix_index_ffi.h
+++ b/src/redisearch_rs/headers/term_suffix_index_ffi.h
@@ -33,6 +33,15 @@ typedef struct TermSuffixIndexIterator TermSuffixIndexIterator;
  */
 typedef int (*TermSuffixIterateCallback)(const char *term, size_t len, void *ctx, void *payload);
 
+/**
+ * Stop predicate polled while a wildcard scan walks its candidates.
+ *
+ * `ctx` is the `stop_ctx` passed to the iterate function. Return `true`
+ * to abandon the scan (e.g. once a deadline has passed); the caller owns
+ * the decision and any clock it consults. A NULL predicate never stops.
+ */
+typedef bool (*TermSuffixShouldStop)(void *ctx);
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -246,9 +255,16 @@ size_t TermSuffixIndex_MemUsage(const struct TermSuffixIndex *tsi);
  * byte); a term may be reported more than once. Iteration stops early
  * when the callback returns a non-zero value.
  *
+ * When `should_stop` is non-NULL it is polled periodically while the
+ * candidate set is scanned; once it returns `true` the scan is abandoned
+ * and only the terms gathered so far are reported. This bounds the
+ * expensive scan by a caller-owned deadline, which the per-term callback
+ * alone cannot do because matches are gathered before any callback fires.
+ * Pass NULL to scan without a deadline.
+ *
  * Returns 0 when the pattern has no literal token that can anchor the
  * search; the caller must then fall back to a full scan. Returns 1
- * otherwise, even when no term matched.
+ * otherwise, even when no term matched or the scan stopped early.
  *
  * # Safety
  *
@@ -260,6 +276,8 @@ size_t TermSuffixIndex_MemUsage(const struct TermSuffixIndex *tsi);
  * 2. `pattern` must point to a [valid] byte sequence of length `len`.
  * 3. `cb` must not modify or free `tsi`, nor retain the term
  *    pointer beyond the call.
+ * 4. If `should_stop` is non-NULL it must be safe to call with `stop_ctx`
+ *    for the duration of this call, and must not modify or free `tsi`.
  *
  * # Panics
  *
@@ -267,7 +285,7 @@ size_t TermSuffixIndex_MemUsage(const struct TermSuffixIndex *tsi);
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-int TermSuffixIndex_IterateWildcard(const struct TermSuffixIndex *tsi, const char *pattern, size_t len, TermSuffixIterateCallback cb, void *ctx);
+int TermSuffixIndex_IterateWildcard(const struct TermSuffixIndex *tsi, const char *pattern, size_t len, TermSuffixIterateCallback cb, void *ctx, TermSuffixShouldStop should_stop, void *stop_ctx);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/term_suffix_index/Cargo.toml
+++ b/src/redisearch_rs/term_suffix_index/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 ffi.workspace = true
+itertools.workspace = true
 rqe_wildcard.workspace = true
 string_utils.workspace = true
 trie_rs.workspace = true

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -32,6 +32,7 @@
 
 mod term_refs;
 
+use itertools::Itertools;
 use std::{
     fmt::{self, Debug},
     sync::Arc,
@@ -46,6 +47,15 @@ use trie_rs::str_trie_map::StrTrieMap;
 /// scans a whole subtree instead of a single exact entry, so they
 /// must out-length an exact token by this many codepoints to win.
 const STARRED_ANCHOR_PENALTY: i32 = ffi::SUFFIX_STARRED_ANCHOR_PENALTY as i32;
+
+/// Poll the caller's stop predicate once per this many candidates examined
+/// during a wildcard scan, amortizing the cost of the check over a run of
+/// work. Scans shorter than one window never poll and always complete.
+pub const TIMEOUT_COUNTER_LIMIT: u32 = ffi::TIMEOUT_COUNTER_LIMIT;
+const _: () = assert!(
+    TIMEOUT_COUNTER_LIMIT > 0,
+    "the poll window divides the candidate count"
+);
 
 /// Longest addable term, in bytes, after lowercasing. The underlying
 /// trie stores node labels with `u16` lengths, so a longer key cannot
@@ -190,7 +200,17 @@ impl TermSuffixIndex {
     /// match `entré`. This is not an approximation introduced here — it is the
     /// engine's pre-existing `?` behavior, which we deliberately reuse rather
     /// than diverge from with a second, codepoint-aware matcher.
-    pub fn iter_wildcard(&self, pattern: &str) -> Option<impl Iterator<Item = Arc<str>>> {
+    ///
+    /// `should_stop` is polled once per [`TIMEOUT_COUNTER_LIMIT`] candidates
+    /// examined; when it returns `true` the scan is abandoned early, yielding
+    /// the matches found so far rather than the full set. This lets a caller
+    /// bound the scan by a deadline without consulting the clock on every
+    /// candidate. Pass `|| false` to always scan to completion.
+    pub fn iter_wildcard(
+        &self,
+        pattern: &str,
+        mut should_stop: impl FnMut() -> bool,
+    ) -> Option<impl Iterator<Item = Arc<str>>> {
         let lowered = unicode_tolower_cow(pattern);
         let (token, followed_by_star) = Self::choose_token(&lowered)?;
 
@@ -206,13 +226,18 @@ impl TermSuffixIndex {
         };
 
         let wildcard = WildcardPattern::parse(lowered.as_bytes());
-        let matches: Vec<Arc<str>> = subtree
+        let limit = TIMEOUT_COUNTER_LIMIT as usize;
+        let matches = subtree
             .into_iter()
             .flatten()
             .chain(exact)
-            .flat_map(|data| data.terms().cloned())
+            .flat_map(|data| data.terms())
+            .enumerate()
+            .take_while(|&(i, _)| !((i + 1).is_multiple_of(limit) && should_stop()))
+            .map(|(_, term)| term)
             .filter(|term| wildcard.matches(term.as_bytes()) == MatchOutcome::Match)
-            .collect();
+            .cloned()
+            .collect_vec();
         Some(matches.into_iter())
     }
 

--- a/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
@@ -334,20 +334,19 @@ fn iter_wildcard_does_not_poll_within_the_first_window() {
 fn iter_wildcard_abandons_scan_once_stop_fires() {
     // More candidates than one window: the first poll fires mid-scan, so
     // an always-stop request abandons it with only a prefix of the matches.
-    let large = (0..TIMEOUT_COUNTER_LIMIT * 5 / 2)
+    // Sized one window past the polling boundary to stay fast under Miri.
+    let large = (0..TIMEOUT_COUNTER_LIMIT + 50)
         .map(|i| format!("cat{i:03}"))
         .collect::<Vec<_>>();
     let sut = build_index(&large);
 
     let stopped = collect_set(sut.iter_wildcard("cat*", || true).expect("'cat' anchors"));
-    let full = collect_set(sut.iter_wildcard("cat*", || false).expect("'cat' anchors"));
 
-    assert_eq!(full.len(), large.len(), "never stopping yields every match");
     assert!(
-        !stopped.is_empty() && stopped.len() < full.len(),
+        !stopped.is_empty() && stopped.len() < large.len(),
         "always stopping abandons the scan partway: {} of {}",
         stopped.len(),
-        full.len()
+        large.len()
     );
 }
 

--- a/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
@@ -11,7 +11,7 @@
 
 use std::collections::HashSet;
 
-use term_suffix_index::TermSuffixIndex;
+use term_suffix_index::{TIMEOUT_COUNTER_LIMIT, TermSuffixIndex};
 
 #[test]
 fn add_promotes_existing_suffix_only_node_to_full_term() {
@@ -197,7 +197,10 @@ fn iter_wildcard_end_token_uses_suffix_semantics() {
         .collect::<Vec<_>>();
     let sut = build_index(&corpus);
 
-    let actual = collect_set(sut.iter_wildcard("*cat").expect("'cat' is anchorable"));
+    let actual = collect_set(
+        sut.iter_wildcard("*cat", || false)
+            .expect("'cat' is anchorable"),
+    );
 
     let expected = HashSet::from(["concat".to_string(), "scat".to_string(), "cat".to_string()]);
     assert_eq!(actual, expected);
@@ -212,7 +215,7 @@ fn iter_wildcard_middle_tokens_anchor_on_best_literal() {
     let sut = build_index(&corpus);
 
     let actual = collect_set(
-        sut.iter_wildcard("ab*cd")
+        sut.iter_wildcard("ab*cd", || false)
             .expect("'ab' and 'cd' are anchorable"),
     );
 
@@ -228,7 +231,10 @@ fn iter_wildcard_multibyte_anchor_matches() {
         .collect::<Vec<_>>();
     let sut = build_index(&corpus);
 
-    let actual = collect_set(sut.iter_wildcard("*本語").expect("two codepoints anchor"));
+    let actual = collect_set(
+        sut.iter_wildcard("*本語", || false)
+            .expect("two codepoints anchor"),
+    );
 
     let expected = HashSet::from(["日本語".to_string(), "本語".to_string()]);
     assert_eq!(actual, expected);
@@ -246,7 +252,10 @@ fn iter_wildcard_question_mark_is_byte_wise_for_multibyte() {
         .collect::<Vec<_>>();
     let sut = build_index(&corpus);
 
-    let actual = collect_set(sut.iter_wildcard("ab*c?").expect("'ab' is anchorable"));
+    let actual = collect_set(
+        sut.iter_wildcard("ab*c?", || false)
+            .expect("'ab' is anchorable"),
+    );
 
     // The ASCII-tailed term matches; the `é`-tailed one is missed.
     assert_eq!(actual, HashSet::from(["abxcd".to_string()]));
@@ -263,7 +272,10 @@ fn iter_wildcard_question_mark_outside_anchor_is_honored() {
     // The `?b` token cannot anchor (contains `?`), so `cd` is chosen;
     // the full-pattern filter must still enforce that `?` consumes
     // exactly one character.
-    let actual = collect_set(sut.iter_wildcard("?b*cd").expect("'cd' is anchorable"));
+    let actual = collect_set(
+        sut.iter_wildcard("?b*cd", || false)
+            .expect("'cd' is anchorable"),
+    );
 
     let expected = HashSet::from(["abcd".to_string(), "zbxcd".to_string()]);
     assert_eq!(actual, expected);
@@ -277,7 +289,10 @@ fn iter_wildcard_trailing_star_uses_contains_semantics() {
         .collect::<Vec<_>>();
     let sut = build_index(&corpus);
 
-    let actual = collect_set(sut.iter_wildcard("*cat*").expect("'cat' is anchorable"));
+    let actual = collect_set(
+        sut.iter_wildcard("*cat*", || false)
+            .expect("'cat' is anchorable"),
+    );
 
     let expected = HashSet::from(["scatter".to_string(), "category".to_string()]);
     assert_eq!(actual, expected);
@@ -291,10 +306,49 @@ fn iter_wildcard_without_anchorable_token_reports_none() {
     // lookup. (Single-char tokens can, now that the floor is gone.)
     for pattern in ["*", "a?c", "??*", ""] {
         assert!(
-            sut.iter_wildcard(pattern).is_none(),
+            sut.iter_wildcard(pattern, || false).is_none(),
             "pattern={pattern:?} must request the fallback scan"
         );
     }
+}
+
+#[test]
+fn iter_wildcard_does_not_poll_within_the_first_window() {
+    // Fewer candidates than one polling window: the predicate is never
+    // consulted, so even an always-stop request yields every match.
+    let small = (0..TIMEOUT_COUNTER_LIMIT / 2)
+        .map(|i| format!("cat{i:03}"))
+        .collect::<Vec<_>>();
+    let sut = build_index(&small);
+
+    let actual = collect_set(sut.iter_wildcard("cat*", || true).expect("'cat' anchors"));
+
+    assert_eq!(
+        actual.len(),
+        small.len(),
+        "no candidate within the first window triggers a poll"
+    );
+}
+
+#[test]
+fn iter_wildcard_abandons_scan_once_stop_fires() {
+    // More candidates than one window: the first poll fires mid-scan, so
+    // an always-stop request abandons it with only a prefix of the matches.
+    let large = (0..TIMEOUT_COUNTER_LIMIT * 5 / 2)
+        .map(|i| format!("cat{i:03}"))
+        .collect::<Vec<_>>();
+    let sut = build_index(&large);
+
+    let stopped = collect_set(sut.iter_wildcard("cat*", || true).expect("'cat' anchors"));
+    let full = collect_set(sut.iter_wildcard("cat*", || false).expect("'cat' anchors"));
+
+    assert_eq!(full.len(), large.len(), "never stopping yields every match");
+    assert!(
+        !stopped.is_empty() && stopped.len() < full.len(),
+        "always stopping abandons the scan partway: {} of {}",
+        stopped.len(),
+        full.len()
+    );
 }
 
 #[test]
@@ -361,7 +415,10 @@ fn iter_wildcard_is_case_insensitive() {
 
     // An uppercased pattern is lowercased before matching the
     // (lowercased) stored terms.
-    let actual = collect_set(sut.iter_wildcard("*CAT").expect("'cat' is anchorable"));
+    let actual = collect_set(
+        sut.iter_wildcard("*CAT", || false)
+            .expect("'cat' is anchorable"),
+    );
 
     let expected = HashSet::from(["concat".to_string(), "scat".to_string(), "cat".to_string()]);
     assert_eq!(actual, expected);
@@ -451,7 +508,7 @@ mod fuzz {
             // `None` requests the fallback scan — out of scope here. The
             // oracle uses the same byte-wise matcher iter_wildcard does, so
             // this pins the anchor-selection logic, not the matcher itself.
-            if let Some(matches) = sut.iter_wildcard(&pattern) {
+            if let Some(matches) = sut.iter_wildcard(&pattern, || false) {
                 let parsed = WildcardPattern::parse(pattern.as_bytes());
                 let expected = corpus
                     .iter()

--- a/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
@@ -313,6 +313,7 @@ fn iter_wildcard_without_anchorable_token_reports_none() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Too slow to run under miri")]
 fn iter_wildcard_does_not_poll_within_the_first_window() {
     // Fewer candidates than one polling window: the predicate is never
     // consulted, so even an always-stop request yields every match.
@@ -331,10 +332,10 @@ fn iter_wildcard_does_not_poll_within_the_first_window() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Too slow to run under miri")]
 fn iter_wildcard_abandons_scan_once_stop_fires() {
     // More candidates than one window: the first poll fires mid-scan, so
     // an always-stop request abandons it with only a prefix of the matches.
-    // Sized one window past the polling boundary to stay fast under Miri.
     let large = (0..TIMEOUT_COUNTER_LIMIT + 50)
         .map(|i| format!("cat{i:03}"))
         .collect::<Vec<_>>();


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `TermSuffixIndex_IterateWildcard` gathers all matches before any callback fires, so the per-term callback's non-zero return cannot bound the candidate scan — the expensive part runs to completion regardless. The C original (`Suffix_IterateWildcard`) threads a timeout into the trie traversal and aborts mid-scan.
2. Change: The inner `iter_wildcard` now takes a mandatory `should_stop` closure, polled once per `TIMEOUT_COUNTER_LIMIT` candidates; when it fires, the scan is abandoned and the matches found so far are returned. Deadline-free callers pass `|| false`. The FFI gains `should_stop`/`stop_ctx` parameters; a NULL predicate scans without a deadline. The clock and mock policy stay entirely on the C side, keeping the inner crate time-agnostic. The poll cadence is bound to C's `TIMEOUT_COUNTER_LIMIT` via the ffi crate's bindgen allowlist of `src/util/timeout.h`, and the constant is `pub` so integration tests derive their corpus sizes from it.
3. Outcome: The Rust wildcard suffix scan can honor the query deadline mid-scan, matching the C trie traversal it replaces. Wiring the predicate into query execution lands with the query.c integration.

#### Which additional issues this PR fixes
1. MOD-16185

#### Main objects this PR modified
1. `TermSuffixIndex::iter_wildcard` (term_suffix_index crate) — mandatory stop predicate, amortized polling
2. `TermSuffixIndex_IterateWildcard` (term_suffix_index_ffi) — `should_stop`/`stop_ctx` params, NULL decoded at the boundary
3. `ffi/build.rs` — bindgen allowlist for `TIMEOUT_COUNTER_LIMIT`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


