### PR TITLE
MOD-16644: Use redis/redis for Redis build sanity workflow

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -50,9 +50,8 @@ jobs:
     with:
       platform: all,ubuntu:latest
       architecture: all
-      # TODO: Switch to redis/redis after https://github.com/redis/redis/pull/15253 lands.
-      redis-repository: TalBarYakar/redis
-      redis-ref: tal.ba/feat/add_redis_docker_files
+      redis-repository: redis/redis
+      redis-ref: unstable
       redisearch-repository: ${{ github.repository }}
       redisearch-ref: ${{ github.sha }}
 

--- a/.github/workflows/flow-redis-build-sanity.yml
+++ b/.github/workflows/flow-redis-build-sanity.yml
@@ -12,12 +12,11 @@ on:
       redis-repository:
         description: 'Redis repository to use for the modernized build flow'
         type: string
-        # TODO: Switch to redis/redis after https://github.com/redis/redis/pull/15253 lands.
-        default: TalBarYakar/redis
+        default: redis/redis
       redis-ref:
         description: 'Redis ref containing modules-update/bootstrap/build/run'
         type: string
-        default: tal.ba/feat/add_redis_docker_files
+        default: unstable
       redisearch-repository:
         description: 'RediSearch repository to inject into Redis modules.yaml. Defaults to this repository.'
         type: string
@@ -47,12 +46,11 @@ on:
       redis-repository:
         description: 'Redis repository to use for the modernized build flow'
         type: string
-        # TODO: Switch to redis/redis after https://github.com/redis/redis/pull/15253 lands.
-        default: TalBarYakar/redis
+        default: redis/redis
       redis-ref:
         description: 'Redis ref containing modules-update/bootstrap/build/run'
         type: string
-        default: tal.ba/feat/add_redis_docker_files
+        default: unstable
       redisearch-repository:
         description: 'RediSearch repository to inject into Redis modules.yaml. Empty means this repository.'
         type: string


### PR DESCRIPTION
## Describe the changes in the pull request

Current: the Redis build-sanity workflow was still wired to Tal's temporary Redis fork/branch while redis/redis#15253 was pending.

Change: point the nightly build-sanity job and workflow defaults at `redis/redis` on `unstable`.

Outcome: nightly Redis build-sanity runs against the upstream Redis modules modernization flow now that it has landed.

#### Which additional issues this PR fixes
1. RED-191626
2. RED-191854

#### Main objects this PR modified
1. GitHub Actions Redis build-sanity workflows

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

