### PR TITLE
[MOD-16846] test_asm: scale ASM slot-migration corpus down on Intel macOS CI

### DIFF
--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -8,6 +8,7 @@ import numpy as np
 import threading
 import time
 import os
+import platform
 import signal
 import psutil
 import subprocess
@@ -15,6 +16,11 @@ import subprocess
 # Total number of hash slots in a Redis Cluster (CRC16(key) % 16384).
 # This is a fixed, protocol-level constant defined by the Redis Cluster specification.
 CLUSTER_SLOTS = 2**14
+
+# Doc count for the slot-migration tests. The Intel (x86_64) macOS CI runners are
+# emulated and far slower; shrink the corpus there to avoid per-test timeouts
+# (still >= 1 doc/slot, and the @n:[69 1420] match set is unchanged).
+ASM_N_DOCS = CLUSTER_SLOTS if (OS == 'macos' and platform.machine() == 'x86_64') else 5 * CLUSTER_SLOTS
 
 # Random words for generating more diverse text content
 RANDOM_WORDS = [
@@ -442,7 +448,7 @@ def wait_for_migration_complete(env, dest_shard, source_shard, timeout=200, quer
 cluster_node_timeout = 60_000 # in milliseconds (1 minute)
 
 def import_slot_range_sanity_test(env: Env, query_type: str = 'FT.SEARCH'):
-    n_docs = 5 * CLUSTER_SLOTS
+    n_docs = ASM_N_DOCS
     create_and_populate_index(env, 'idx', n_docs)
 
     shard1, shard2 = env.getConnection(1), env.getConnection(2)
@@ -502,7 +508,7 @@ def parallel_update_worker(env, n_docs, stop_event):
             time.sleep(0.1)
 
 def import_slot_range_test(env: Env, query_type: str = 'FT.SEARCH', parallel_updates: bool = False):
-    n_docs = 5 * CLUSTER_SLOTS
+    n_docs = ASM_N_DOCS
     create_and_populate_index(env, 'idx', n_docs)
 
     if query_type == 'FT.SEARCH':
@@ -684,7 +690,7 @@ def test_ft_hybrid_import_slot_range_sanity_BG():
 
 def add_shard_and_migrate_test(env: Env, query_type: str = 'FT.SEARCH'):
     initial_shards_count = env.shardsCount
-    n_docs = 5 * CLUSTER_SLOTS
+    n_docs = ASM_N_DOCS
     create_and_populate_index(env, 'idx', n_docs)
 
     shard1 = env.getConnection(1)
@@ -949,7 +955,7 @@ def test_migrate_no_indexes():
         shard.execute_command('CONFIG', 'SET', 'search-_min-trim-delay-ms', 1000000)
 
     # Add documents without creating any index
-    n_docs = 5 * CLUSTER_SLOTS
+    n_docs = ASM_N_DOCS
     with env.getClusterConnectionIfNeeded() as con:
         for i in range(n_docs):
             con.execute_command('HSET', f'doc-{i}:{{{i % CLUSTER_SLOTS}}}',


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The cluster-only ASM slot-migration tests in `tests/pytests/test_asm.py` populate `5 * CLUSTER_SLOTS` (~82k) documents across a 3-shard cluster, perform a live `CLUSTER MIGRATION IMPORT` of a middle slot range, and run full-scan `FT.AGGREGATE`/`WITHCURSOR` queries during migration. On the emulated/underpowered **macOS 26 x86_64** GitHub runner these are the heaviest tests in the suite and exceed the per-test timeout. In the 2026-07-11 nightly ([run 29167293534](https://github.com/RediSearch/RediSearch/actions/runs/29167293534/job/86582545011)) 8 of them timed out in the coordinator lane; on 2026-07-08 the whole "Flow tests (coordinator)" step hit the 120-minute cap. Every other platform — including **macOS 26 aarch64**, macOS 15, macOS 14, and all Linux — passes. This platform gates the merge queue and periodic validation (`architecture: all`), not just nightly.

2. **Change:** Introduce `ASM_N_DOCS`, which drops the corpus to `CLUSTER_SLOTS` (16384) **only on Intel macOS** (`OS == 'macos' and platform.machine() == 'x86_64'`) and stays at `5 * CLUSTER_SLOTS` on every other platform. The four heavy helpers (`import_slot_range_sanity_test`, `import_slot_range_test`, `add_shard_and_migrate_test`, `test_migrate_no_indexes`) use it.

3. **Outcome:** The Intel-macOS runs shrink 5× and fit within the timeout, while full coverage is retained everywhere else. `CLUSTER_SLOTS` docs still puts one doc in every slot (so migration always moves data), and the `@n:[69 1420]` query match set (1352 docs) is unchanged — assertions are unaffected. The only absolute assertion (`test_migrate_no_indexes`: `migration_time < 300s`) only gets easier.

#### Which additional issues this PR fixes
1. MOD-16846

#### Main objects this PR modified
1. `tests/pytests/test_asm.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Test-only change to CI reliability; no user-facing impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
