### PR TITLE
[MOD-16794] FT.HYBRID: COMMAND DOCS now documents the VSIM FILTER POLICY/BATCH_SIZE clause on the correct argument

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2394,18 +2394,24 @@
                     "token": "ADHOC"
                   },
                   {
-                    "name": "batches",
-                    "type": "pure-token",
-                    "token": "BATCHES"
+                    "name": "batches_policy",
+                    "type": "block",
+                    "arguments": [
+                      {
+                        "name": "batches",
+                        "type": "pure-token",
+                        "token": "BATCHES"
+                      },
+                      {
+                        "name": "batch_size_value",
+                        "type": "integer",
+                        "token": "BATCH_SIZE",
+                        "optional": true,
+                        "since": "8.4.3"
+                      }
+                    ]
                   }
                 ]
-              },
-              {
-                "name": "batch_size_value",
-                "type": "integer",
-                "token": "BATCH_SIZE",
-                "optional": true,
-                "since": "8.4.3"
               }
             ]
           }

--- a/commands.json
+++ b/commands.json
@@ -2367,10 +2367,47 @@
           },
           {
             "name": "filter",
-            "type": "string",
+            "type": "block",
+            "optional": true,
             "token": "FILTER",
-            "expression": true,
-            "optional": true
+            "arguments": [
+              {
+                "name": "count",
+                "type": "integer",
+                "since": "8.4.3"
+              },
+              {
+                "name": "filter_expression",
+                "type": "string",
+                "expression": true
+              },
+              {
+                "name": "policy",
+                "type": "oneof",
+                "optional": true,
+                "token": "POLICY",
+                "since": "8.4.3",
+                "arguments": [
+                  {
+                    "name": "adhoc",
+                    "type": "pure-token",
+                    "token": "ADHOC"
+                  },
+                  {
+                    "name": "batches",
+                    "type": "pure-token",
+                    "token": "BATCHES"
+                  }
+                ]
+              },
+              {
+                "name": "batch_size_value",
+                "type": "integer",
+                "token": "BATCH_SIZE",
+                "optional": true,
+                "since": "8.4.3"
+              }
+            ]
           }
         ]
       },
@@ -3204,47 +3241,19 @@
       },
       {
         "name": "filter",
-        "type": "block",
+        "type": "string",
         "optional": true,
-        "token": "FILTER",
-        "arguments": [
-          {
-            "name": "count",
-            "type": "integer"
-          },
-          {
-            "name": "filter_expression",
-            "type": "string",
-            "expression": true
-          },
-          {
-            "name": "policy",
-            "type": "oneof",
-            "optional": true,
-            "arguments": [
-              {
-                "name": "adhoc",
-                "type": "pure-token",
-                "token": "ADHOC"
-              },
-              {
-                "name": "batches",
-                "type": "pure-token",
-                "token": "BATCHES"
-              }
-            ],
-            "token": "POLICY"
-          },
-          {
-            "name": "batch_size_value",
-            "type": "integer",
-            "token": "BATCH_SIZE",
-            "optional": true
-          }
-        ]
+        "expression": true,
+        "token": "FILTER"
       }
     ],
-    "since": "8.4.4",
+    "since": "8.4.0",
+    "history": [
+      [
+        "8.4.3",
+        "Added `count`, `POLICY` and `BATCH_SIZE` arguments to the `VSIM` `FILTER` clause"
+      ]
+    ],
     "group": "search",
     "command_tips": [
       "DONT_CACHE"

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -2586,8 +2586,47 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
           {
             .name = "filter",
             .token = "FILTER",
-            .type = REDISMODULE_ARG_TYPE_STRING,
+            .type = REDISMODULE_ARG_TYPE_BLOCK,
             .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+            .subargs = (RedisModuleCommandArg[]){
+              {
+                .name = "count",
+                .since = "8.4.3",
+                .type = REDISMODULE_ARG_TYPE_INTEGER,
+              },
+              {
+                .name = "filter_expression",
+                .type = REDISMODULE_ARG_TYPE_STRING,
+              },
+              {
+                .name = "policy",
+                .token = "POLICY",
+                .since = "8.4.3",
+                .type = REDISMODULE_ARG_TYPE_ONEOF,
+                .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                .subargs = (RedisModuleCommandArg[]){
+                  {
+                    .name = "adhoc",
+                    .token = "ADHOC",
+                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                  },
+                  {
+                    .name = "batches",
+                    .token = "BATCHES",
+                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                  },
+                  {0}
+                },
+              },
+              {
+                .name = "batch_size_value",
+                .token = "BATCH_SIZE",
+                .since = "8.4.3",
+                .type = REDISMODULE_ARG_TYPE_INTEGER,
+                .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+              },
+              {0}
+            },
           },
           {0}
         },
@@ -3475,49 +3514,17 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
       {
         .name = "filter",
         .token = "FILTER",
-        .type = REDISMODULE_ARG_TYPE_BLOCK,
+        .type = REDISMODULE_ARG_TYPE_STRING,
         .flags = REDISMODULE_CMD_ARG_OPTIONAL,
-        .subargs = (RedisModuleCommandArg[]){
-          {
-            .name = "count",
-            .type = REDISMODULE_ARG_TYPE_INTEGER,
-          },
-          {
-            .name = "filter_expression",
-            .type = REDISMODULE_ARG_TYPE_STRING,
-          },
-          {
-            .name = "policy",
-            .token = "POLICY",
-            .type = REDISMODULE_ARG_TYPE_ONEOF,
-            .flags = REDISMODULE_CMD_ARG_OPTIONAL,
-            .subargs = (RedisModuleCommandArg[]){
-              {
-                .name = "adhoc",
-                .token = "ADHOC",
-                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-              },
-              {
-                .name = "batches",
-                .token = "BATCHES",
-                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
-              },
-              {0}
-            },
-          },
-          {
-            .name = "batch_size_value",
-            .token = "BATCH_SIZE",
-            .type = REDISMODULE_ARG_TYPE_INTEGER,
-            .flags = REDISMODULE_CMD_ARG_OPTIONAL,
-          },
-          {0}
-        },
       },
       {0}
     },
     .arity = -7,
-    .since = "8.4.4",
+    .since = "8.4.0",
+    .history = (RedisModuleCommandHistoryEntry[]){
+      {"8.4.3", "Added `count`, `POLICY` and `BATCH_SIZE` arguments to the `VSIM` `FILTER` clause"},
+      {0}
+    },
     .tips = "dont_cache",
   };
   return RedisModule_SetCommandInfo(cmd, &info);

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -2611,19 +2611,26 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
                     .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
                   },
                   {
-                    .name = "batches",
-                    .token = "BATCHES",
-                    .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                    .name = "batches_policy",
+                    .type = REDISMODULE_ARG_TYPE_BLOCK,
+                    .subargs = (RedisModuleCommandArg[]){
+                      {
+                        .name = "batches",
+                        .token = "BATCHES",
+                        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                      },
+                      {
+                        .name = "batch_size_value",
+                        .token = "BATCH_SIZE",
+                        .since = "8.4.3",
+                        .type = REDISMODULE_ARG_TYPE_INTEGER,
+                        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                      },
+                      {0}
+                    },
                   },
                   {0}
                 },
-              },
-              {
-                .name = "batch_size_value",
-                .token = "BATCH_SIZE",
-                .since = "8.4.3",
-                .type = REDISMODULE_ARG_TYPE_INTEGER,
-                .flags = REDISMODULE_CMD_ARG_OPTIONAL,
               },
               {0}
             },


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: MOD-12371 (#7638) added the VSIM `FILTER <count> "expr" [POLICY ADHOC|BATCHES] [BATCH_SIZE <n>]` clause and updated `commands.json`, but placed the `count`/`POLICY`/`BATCH_SIZE` expansion on the wrong FILTER node — the tail-pipeline `FILTER` (which only accepts a single expression, see `src/hybrid/parse/hybrid_optional_args.c`), while the VSIM clause `FILTER` (where these arguments are actually parsed, see `parseFilterClause` in `src/hybrid/parse_hybrid.c`) remained a plain string. It also set the command-level `since` to `8.4.4`, a version that was never released. Since `commands.json` is compiled into `command_info.c` and registered via `RM_SetCommandInfo`, `COMMAND DOCS FT.HYBRID` described both FILTERs incorrectly.
2. **Change**:
   - Moved the `count`/`POLICY`/`BATCH_SIZE` expansion into the VSIM clause `FILTER` block, with per-argument `since: 8.4.3` — the first released version containing the clause (8.4 backport #7730 shipped in v8.4.3; on the mainline it shipped in v8.6.0).
   - Scoped `BATCH_SIZE` under the `BATCHES` branch of the `POLICY` oneof — it is rejected under `ADHOC` (`SEARCH_ADHOC_BATCH_SIZE_IRRELEVANT`), so the grammar now only permits `BATCH_SIZE` together with `BATCHES`.
   - Restored the tail-pipeline `FILTER` to a plain expression argument.
   - Reverted the command-level `since` to `8.4.0` (FT.HYBRID's first release) and recorded the VSIM FILTER syntax change in a `history` entry.
   - Regenerated `src/command_info/command_info.c`.
3. **Outcome**: `COMMAND DOCS FT.HYBRID` documents the POLICY/BATCH_SIZE clause under the VSIM clause where it belongs, the tail FILTER matches its real syntax, and the version metadata points at releases that actually exist.

#### Which additional issues this PR fixes
1. MOD-16794

#### Main objects this PR modified
1. `commands.json` — FT.HYBRID entry
2. `src/command_info/command_info.c` — regenerated from the JSON

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Syntax diagrams (railroad, rendered from commands.json)

Generated with `cmd_tools.py railroad` from the [redis/docs](https://github.com/redis/docs) repo. Close-ups of the two affected regions:

### Before — VSIM clause: bare `FILTER filter`, missing the new arguments

<img width="2500" height="130" alt="image" src="https://github.com/user-attachments/assets/b80d6527-7e73-4bec-b60a-c6898fc732da" />

### Before — tail pipeline: `count`/`POLICY`/`BATCH_SIZE` wrongly attached to the aggregation-style FILTER

<img width="1300" height="130" alt="image" src="https://github.com/user-attachments/assets/ff1b574a-6f4e-41f3-b10f-1814137d9dc7" />

### After — VSIM clause: `FILTER count filter_expression [POLICY ADHOC | BATCHES [BATCH_SIZE n]]`, matching `parseFilterClause`

<img width="968" height="133" alt="image" src="https://github.com/user-attachments/assets/b123bffa-dcc0-4ea5-b3d2-aa8917714b03" />

### After — tail pipeline: back to plain `FILTER filter` expression

<img width="1300" height="130" alt="image" src="https://github.com/user-attachments/assets/4b6aa950-b63d-4e53-8007-23664f0289e8" />

