### PR TITLE
[MOD-15870] Refresh cluster topology on cluster topology change events instead of polling

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -15,16 +15,16 @@ concurrency:
 
 jobs:
   # TODO: revert to calling task-get-latest-tag.yml once Redis 8.10 is released.
-  # Pinned to the head of redis/redis#15350 (not merged yet) because the module requires
-  # RedisModule_GetClusterNodeSlotRanges (MOD-15868) and RedisModuleEvent_ClusterTopologyChange
-  # (MOD-15870), neither of which is in any Redis release yet.
+  # Pinned to a redis/redis unstable commit (the redis/redis#15350 merge) because the module
+  # requires RedisModule_GetClusterNodeSlotRanges (MOD-15868) and
+  # RedisModuleEvent_ClusterTopologyChange (MOD-15870), neither of which is in any Redis release yet.
   get-latest-redis-tag:
     # uses: ./.github/workflows/task-get-latest-tag.yml
     # with:
     #   repo: redis/redis
     runs-on: ubuntu-slim
     outputs:
-      tag: e2d25443c2cd53b0564db395561f8d92bc916621
+      tag: 8897348030c20bcd26841bc7d3ec7227f8187aeb
     steps:
       - run: echo "Using pinned redis/redis unstable commit instead of the latest release tag"
 

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -15,15 +15,16 @@ concurrency:
 
 jobs:
   # TODO: revert to calling task-get-latest-tag.yml once Redis 8.10 is released.
-  # Pinned to a redis/redis unstable commit because the module requires
-  # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any Redis release yet.
+  # Pinned to the head of redis/redis#15350 (not merged yet) because the module requires
+  # RedisModule_GetClusterNodeSlotRanges (MOD-15868) and RedisModuleEvent_ClusterTopologyChange
+  # (MOD-15870), neither of which is in any Redis release yet.
   get-latest-redis-tag:
     # uses: ./.github/workflows/task-get-latest-tag.yml
     # with:
     #   repo: redis/redis
     runs-on: ubuntu-slim
     outputs:
-      tag: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
+      tag: e2d25443c2cd53b0564db395561f8d92bc916621
     steps:
       - run: echo "Using pinned redis/redis unstable commit instead of the latest release tag"
 

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -150,8 +150,9 @@ jobs:
           echo "Covered PRs: ${{ steps.check.outputs.covered-prs }}"
 
   # TODO: revert to calling task-get-latest-tag.yml once Redis 8.10 is released.
-  # Pinned to a redis/redis unstable commit because the module requires
-  # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any Redis release yet.
+  # Pinned to the head of redis/redis#15350 (not merged yet) because the module requires
+  # RedisModule_GetClusterNodeSlotRanges (MOD-15868) and RedisModuleEvent_ClusterTopologyChange
+  # (MOD-15870), neither of which is in any Redis release yet.
   get-latest-redis-tag:
     needs: should-run
     if: ${{ needs.should-run.outputs.run-validation == 'true' }}
@@ -160,7 +161,7 @@ jobs:
     #   repo: redis/redis
     runs-on: ubuntu-slim
     outputs:
-      tag: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
+      tag: e2d25443c2cd53b0564db395561f8d92bc916621
     steps:
       - run: echo "Using pinned redis/redis unstable commit instead of the latest release tag"
 

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -150,9 +150,9 @@ jobs:
           echo "Covered PRs: ${{ steps.check.outputs.covered-prs }}"
 
   # TODO: revert to calling task-get-latest-tag.yml once Redis 8.10 is released.
-  # Pinned to the head of redis/redis#15350 (not merged yet) because the module requires
-  # RedisModule_GetClusterNodeSlotRanges (MOD-15868) and RedisModuleEvent_ClusterTopologyChange
-  # (MOD-15870), neither of which is in any Redis release yet.
+  # Pinned to a redis/redis unstable commit (the redis/redis#15350 merge) because the module
+  # requires RedisModule_GetClusterNodeSlotRanges (MOD-15868) and
+  # RedisModuleEvent_ClusterTopologyChange (MOD-15870), neither of which is in any Redis release yet.
   get-latest-redis-tag:
     needs: should-run
     if: ${{ needs.should-run.outputs.run-validation == 'true' }}
@@ -161,7 +161,7 @@ jobs:
     #   repo: redis/redis
     runs-on: ubuntu-slim
     outputs:
-      tag: e2d25443c2cd53b0564db395561f8d92bc916621
+      tag: 8897348030c20bcd26841bc7d3ec7227f8187aeb
     steps:
       - run: echo "Using pinned redis/redis unstable commit instead of the latest release tag"
 

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -12,15 +12,16 @@ concurrency:
 
 jobs:
   # TODO: revert to calling task-get-latest-tag.yml once Redis 8.10 is released.
-  # Pinned to a redis/redis unstable commit because the module requires
-  # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any Redis release yet.
+  # Pinned to the head of redis/redis#15350 (not merged yet) because the module requires
+  # RedisModule_GetClusterNodeSlotRanges (MOD-15868) and RedisModuleEvent_ClusterTopologyChange
+  # (MOD-15870), neither of which is in any Redis release yet.
   get-latest-redis-tag:
     # uses: ./.github/workflows/task-get-latest-tag.yml
     # with:
     #   repo: redis/redis
     runs-on: ubuntu-slim
     outputs:
-      tag: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
+      tag: e2d25443c2cd53b0564db395561f8d92bc916621
     steps:
       - run: echo "Using pinned redis/redis unstable commit instead of the latest release tag"
 

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -12,16 +12,16 @@ concurrency:
 
 jobs:
   # TODO: revert to calling task-get-latest-tag.yml once Redis 8.10 is released.
-  # Pinned to the head of redis/redis#15350 (not merged yet) because the module requires
-  # RedisModule_GetClusterNodeSlotRanges (MOD-15868) and RedisModuleEvent_ClusterTopologyChange
-  # (MOD-15870), neither of which is in any Redis release yet.
+  # Pinned to a redis/redis unstable commit (the redis/redis#15350 merge) because the module
+  # requires RedisModule_GetClusterNodeSlotRanges (MOD-15868) and
+  # RedisModuleEvent_ClusterTopologyChange (MOD-15870), neither of which is in any Redis release yet.
   get-latest-redis-tag:
     # uses: ./.github/workflows/task-get-latest-tag.yml
     # with:
     #   repo: redis/redis
     runs-on: ubuntu-slim
     outputs:
-      tag: e2d25443c2cd53b0564db395561f8d92bc916621
+      tag: 8897348030c20bcd26841bc7d3ec7227f8187aeb
     steps:
       - run: echo "Using pinned redis/redis unstable commit instead of the latest release tag"
 

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           # TAG=$(curl -sL --retry 5 https://api.github.com/repos/redis/redis/releases/latest | jq -er '.tag_name') && \
           # echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "tag=e2d25443c2cd53b0564db395561f8d92bc916621" >> $GITHUB_OUTPUT
+          echo "tag=8897348030c20bcd26841bc7d3ec7227f8187aeb" >> $GITHUB_OUTPUT
       - name: Generate Beta Version unique identifier
         id: beta-version
         run: |

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           # TAG=$(curl -sL --retry 5 https://api.github.com/repos/redis/redis/releases/latest | jq -er '.tag_name') && \
           # echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "tag=3869512c920d4e865b54384bce5fcb6a4e06ae0d" >> $GITHUB_OUTPUT
+          echo "tag=e2d25443c2cd53b0564db395561f8d92bc916621" >> $GITHUB_OUTPUT
       - name: Generate Beta Version unique identifier
         id: beta-version
         run: |

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -71,7 +71,7 @@ on:
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable", or a commit sha)'
         type: string
-        default: e2d25443c2cd53b0564db395561f8d92bc916621
+        default: 8897348030c20bcd26841bc7d3ec7227f8187aeb
       rejson-branch:
         type: string
         default: master

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -71,7 +71,7 @@ on:
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable", or a commit sha)'
         type: string
-        default: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
+        default: e2d25443c2cd53b0564db395561f8d92bc916621
       rejson-branch:
         type: string
         default: master

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -21,7 +21,7 @@ on:
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable")'
         type: string
-        default: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
+        default: e2d25443c2cd53b0564db395561f8d92bc916621
       test-config:
         description: 'Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")'
         required: true

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -21,7 +21,7 @@ on:
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable")'
         type: string
-        default: e2d25443c2cd53b0564db395561f8d92bc916621
+        default: 8897348030c20bcd26841bc7d3ec7227f8187aeb
       test-config:
         description: 'Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")'
         required: true

--- a/src/coord/rmr/redis_cluster.c
+++ b/src/coord/rmr/redis_cluster.c
@@ -12,6 +12,8 @@
 #include "rmr.h"
 #include "module.h"
 
+#include <stdbool.h>
+
 void UpdateTopology(RedisModuleCtx *ctx) {
   uint32_t my_shard_idx = UINT32_MAX;
   MRClusterTopology *topo = MRClusterTopology_FromAPI(ctx, NULL, 0, &my_shard_idx);
@@ -42,28 +44,30 @@ void UpdateTopology(RedisModuleCtx *ctx) {
   }
 }
 
-#define REFRESH_PERIOD 1000 // 1 second
-RedisModuleTimerID topologyRefreshTimer = 0;
+// True while the topology updater is active: refreshing the topology on every cluster topology
+// change event. Only set on an OSS cluster; may be cleared temporarily by the debug commands.
+static bool topologyUpdaterRunning = false;
 
-static void UpdateTopology_Periodic(RedisModuleCtx *ctx, void *p) {
-  REDISMODULE_NOT_USED(p);
-  topologyRefreshTimer = RedisModule_CreateTimer(ctx, REFRESH_PERIOD, UpdateTopology_Periodic, NULL);
+void RedisTopologyUpdater_OnTopologyChanged(RedisModuleCtx *ctx) {
+  if (!topologyUpdaterRunning) return;  // Paused, or not an OSS cluster
   UpdateTopology(ctx);
 }
 
-void RedisTopologyUpdater_StopAndRescheduleImmediately(RedisModuleCtx *ctx) {
-  RedisModule_StopTimer(ctx, topologyRefreshTimer, NULL);
-  topologyRefreshTimer = RedisModule_CreateTimer(ctx, 0, UpdateTopology_Periodic, NULL);
-}
-
 int InitRedisTopologyUpdater(RedisModuleCtx *ctx) {
-  if (topologyRefreshTimer || clusterConfig.type != ClusterType_RedisOSS) return REDISMODULE_ERR;
-  topologyRefreshTimer = RedisModule_CreateTimer(ctx, REFRESH_PERIOD, UpdateTopology_Periodic, NULL);
+  if (topologyUpdaterRunning || clusterConfig.type != ClusterType_RedisOSS) return REDISMODULE_ERR;
+  topologyUpdaterRunning = true;
+  // The topology change event only fires on changes, so fetch the current topology ourselves.
+  // This may fail if the cluster is not ready yet (e.g. at server startup); the events fired
+  // while the cluster forms will trigger the next refresh.
+  UpdateTopology(ctx);
   return REDISMODULE_OK;
 }
 
 int StopRedisTopologyUpdater(RedisModuleCtx *ctx) {
-  int rc = RedisModule_StopTimer(ctx, topologyRefreshTimer, NULL);
-  topologyRefreshTimer = 0;
-  return rc; // OK if we stopped the timer, ERR if it was already stopped (or never started - enterprise)
+  REDISMODULE_NOT_USED(ctx);
+  if (!topologyUpdaterRunning) {
+    return REDISMODULE_ERR;  // Already stopped (or never started - enterprise)
+  }
+  topologyUpdaterRunning = false;
+  return REDISMODULE_OK;
 }

--- a/src/coord/rmr/redis_cluster.h
+++ b/src/coord/rmr/redis_cluster.h
@@ -17,4 +17,6 @@ struct RedisModuleCtx;
 void UpdateTopology(struct RedisModuleCtx *ctx);
 int InitRedisTopologyUpdater(struct RedisModuleCtx *ctx);
 int StopRedisTopologyUpdater(RedisModuleCtx *ctx);
-void RedisTopologyUpdater_StopAndRescheduleImmediately(struct RedisModuleCtx *ctx);
+// Called on a cluster topology change event. Refreshes the topology unless the updater
+// is paused (or was never started).
+void RedisTopologyUpdater_OnTopologyChanged(struct RedisModuleCtx *ctx);

--- a/src/module.c
+++ b/src/module.c
@@ -4745,24 +4745,6 @@ static int initSearchCluster(RedisModuleCtx *ctx, RedisModuleString **argv, int 
                   "Cluster configuration: AUTO partitions, type: %d, coordinator timeout: %dms",
                   clusterConfig.type, clusterConfig.timeoutMS);
 
-  if (clusterConfig.type == ClusterType_RedisOSS) {
-    if (isClusterEnabled) {
-      // Init the topology updater cron loop.
-      InitRedisTopologyUpdater(ctx);
-    } else {
-      // We are not in cluster mode. No need to init the topology updater cron loop.
-      // Set the number of shards to 1 to indicate the topology is "set"
-      NumShards = 1;
-      // Setting all slots for the case where we send/test internal commands directly from client (potentially with _SLOTS_INFO)
-      RedisModuleSlotRangeArray *all_slots = rm_malloc(SlotRangeArray_SizeOf(1));
-      all_slots->num_ranges = 1;
-      all_slots->ranges[0].start = 0;
-      all_slots->ranges[0].end = 16383;
-      ASM_StateMachine_SetLocalSlots(all_slots);
-      rm_free(all_slots);
-    }
-  }
-
   size_t num_connections_per_shard;
   if (clusterConfig.connPerShard) {
     num_connections_per_shard = clusterConfig.connPerShard;
@@ -4776,6 +4758,22 @@ static int initSearchCluster(RedisModuleCtx *ctx, RedisModuleString **argv, int 
 
   MR_Init(num_io_threads, conn_pool_size, clusterConfig.timeoutMS);
   MR_InitLocalNodeId();
+
+  if (clusterConfig.type == ClusterType_RedisOSS) {
+    if (isClusterEnabled) {
+      // Start the topology updater and fetch the initial topology. Must come after MR_Init
+      // and MR_InitLocalNodeId, as the initial fetch feeds the topology into the MR layer.
+      InitRedisTopologyUpdater(ctx);
+    } else {
+      // We are not in cluster mode. No need to init the topology updater.
+      // Set the number of shards to 1 to indicate the topology is "set"
+      NumShards = 1;
+      // Setting all slots for the case where we send/test internal commands directly from client
+      // (potentially with _SLOTS_INFO)
+      static const RedisModuleSlotRangeArray all_slots = {1, {{0, 16383}}};
+      ASM_StateMachine_SetLocalSlots(&all_slots);
+    }
+  }
 
   return REDISMODULE_OK;
 }

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -523,9 +523,6 @@ void ClusterSlotMigrationEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64
       // Since importing is done in a part-time job while redis is running other commands, we notify
       // the thread pool to no longer receive new jobs, and terminate the threads ONCE ALL PENDING JOBS ARE DONE.
       workersThreadPool_OnEventEnd(false);
-      if (!IsEnterprise() && subevent == REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_IMPORT_COMPLETED) {
-        RedisTopologyUpdater_StopAndRescheduleImmediately(ctx);
-      }
       break;
 
     // case REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_MIGRATE_STARTED:
@@ -559,9 +556,6 @@ void ClusterSlotMigrationEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64
       trimmingDelayCtx.enableTrimmingTimerId = RedisModule_CreateTimer(ctx, RSGlobalConfig.maxTrimDelayMS, enableTrimmingCallback, NULL);
       trimmingDelayCtx.checkTrimmingStateTimerIdScheduled = true;
       trimmingDelayCtx.enableTrimmingTimerIdScheduled = true;
-      if (!IsEnterprise()) {
-        RedisTopologyUpdater_StopAndRescheduleImmediately(ctx);
-      }
       break;
 
     case REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_MIGRATE_MODULE_PROPAGATE:
@@ -604,6 +598,15 @@ void ClusterSlotMigrationTrimEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, ui
 
     // case REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_BACKGROUND:
   }
+}
+
+static void ClusterTopologyChangeEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent,
+                                       void *data) {
+  REDISMODULE_NOT_USED(eid);
+  REDISMODULE_NOT_USED(subevent);
+  RedisModuleClusterTopologyChangeInfo *info = data;
+  RedisModule_Log(ctx, "verbose", "Got cluster topology change event (change flags: 0x%llx)", (unsigned long long)info->change_flags);
+  RedisTopologyUpdater_OnTopologyChanged(ctx);
 }
 
 static void ServerReadyEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data) {
@@ -951,6 +954,12 @@ void Initialize_ServerEventNotifications(RedisModuleCtx *ctx) {
   RedisModule_Log(ctx, "notice", "Subscribe to cluster slot migration events");
   RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_ClusterSlotMigration, ClusterSlotMigrationEvent);
   RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_ClusterSlotMigrationTrim, ClusterSlotMigrationTrimEvent);
+
+  RedisModule_Log(ctx, "notice", "Subscribe to cluster topology change events");
+  if (RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_ClusterTopologyChange, ClusterTopologyChangeEvent) != REDISMODULE_OK) {
+    RedisModule_Log(ctx, "warning", "Cluster topology change event is not supported by the server. The cluster "
+                                    "topology will not be refreshed automatically");
+  }
   if (SearchDisk_IsEnabled()) {
     RedisModule_Log(ctx, "notice", "Subscribe to Server ready event");
     RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_ServerReady, ServerReadyEvent);

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -955,10 +955,15 @@ void Initialize_ServerEventNotifications(RedisModuleCtx *ctx) {
   RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_ClusterSlotMigration, ClusterSlotMigrationEvent);
   RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_ClusterSlotMigrationTrim, ClusterSlotMigrationTrimEvent);
 
-  RedisModule_Log(ctx, "notice", "Subscribe to cluster topology change events");
-  if (RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_ClusterTopologyChange, ClusterTopologyChangeEvent) != REDISMODULE_OK) {
-    RedisModule_Log(ctx, "warning", "Cluster topology change event is not supported by the server. The cluster "
-                                    "topology will not be refreshed automatically");
+  // Do not subscribe on Enterprise, even if the server supports the event: topology updates
+  // there are driven by `SEARCH.CLUSTERSET`, and we must not react to topology change events
+  // before the Enterprise flow fully supports it (e.g. connections auth).
+  if (!IsEnterprise()) {
+    RedisModule_Log(ctx, "notice", "Subscribe to cluster topology change events");
+    if (RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_ClusterTopologyChange, ClusterTopologyChangeEvent) != REDISMODULE_OK) {
+      RedisModule_Log(ctx, "warning", "Cluster topology change event is not supported by the server. The cluster "
+                                      "topology will not be refreshed automatically");
+    }
   }
   if (SearchDisk_IsEnabled()) {
     RedisModule_Log(ctx, "notice", "Subscribe to Server ready event");

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -598,7 +598,8 @@ typedef void (*RedisModuleEventLoopOneShotFunc)(void *user_data);
 #define REDISMODULE_EVENT_KEY 17
 #define REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION 18
 #define REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM 19
-#define _REDISMODULE_EVENT_NEXT 20 /* Next event flag, should be updated if a new event added. */
+#define REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE 20
+#define _REDISMODULE_EVENT_NEXT 21 /* Next event flag, should be updated if a new event added. */
 
 /* RL Extension: Use IDs >= 1000 to maintain ABI compatibility with OSS Redis */
 #define REDISMODULE_EVENT_SHARDING 1000
@@ -741,6 +742,10 @@ static const RedisModuleEvent
         REDISMODULE_EVENT_CLUSTER_SLOT_MIGRATION_TRIM,
         1
     },
+    RedisModuleEvent_ClusterTopologyChange = {
+        REDISMODULE_EVENT_CLUSTER_TOPOLOGY_CHANGE,
+        1
+    },
     RedisModuleEvent_SSTReplication = {
         REDISMODULE_EVENT_SST_REPLICATION,
         1
@@ -855,6 +860,9 @@ static const RedisModuleEvent
 #define REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_COMPLETED 1
 #define REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_BACKGROUND 2
 #define _REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_TRIM_NEXT 3
+
+/* RedisModuleEvent_ClusterTopologyChange has no meaningful subevent. */
+#define _REDISMODULE_SUBEVENT_CLUSTER_TOPOLOGY_CHANGE_NEXT 0
 
 /* RedisModuleClientInfo flags. */
 #define REDISMODULE_CLIENTINFO_FLAG_SSL (1<<0)
@@ -1019,6 +1027,26 @@ typedef struct RedisModuleClusterSlotMigrationTrimInfo {
 } RedisModuleClusterSlotMigrationTrimInfoV1;
 
 #define RedisModuleClusterSlotMigrationTrimInfo RedisModuleClusterSlotMigrationTrimInfoV1
+
+/* Reason flags reported in RedisModuleClusterTopologyChangeInfo.change_flags.
+ * More than one bit may be set when several changes were collapsed into a
+ * single (debounced) RedisModuleEvent_ClusterTopologyChange notification. */
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_SLOT  (1<<0) /* Slot ownership changed. */
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_ROLE  (1<<1) /* A node changed its primary/replica role. */
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_STATE (1<<2) /* The cluster OK/FAIL state changed. */
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_NODE  (1<<3) /* A node joined or left the cluster, or its address changed. */
+
+#define REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_INFO_VERSION 1
+
+typedef struct RedisModuleClusterTopologyChangeInfo {
+    uint64_t version;       /* Not used since this structure is never passed
+                               from the module to the core right now. Here
+                               for future compatibility. */
+    uint64_t change_flags;  /* Bitmask of REDISMODULE_CLUSTER_TOPOLOGY_CHANGE_FLAG_*
+                               reasons that contributed to this notification. */
+} RedisModuleClusterTopologyChangeInfoV1;
+
+#define RedisModuleClusterTopologyChangeInfo RedisModuleClusterTopologyChangeInfoV1
 
 typedef enum {
     REDISMODULE_ACL_LOG_AUTH = 0, /* Authentication failure */

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4445,9 +4445,7 @@ def test_cluster_set_myself_excluded(env: Env):
     ]
     env.expect('SEARCH.CLUSTERINFO').equal(expected)
 
-# TODO(MOD-15868): re-enable once https://redislabs.atlassian.net/browse/MOD-15868 is resolved
-@skip()
-#@skip(cluster=False) # this test is only relevant on cluster
+@skip(cluster=True) # only parsing errors are tested, no need for an actual cluster
 def test_cluster_set_errors(env: Env):
 
     # Check general values parsing
@@ -4459,12 +4457,17 @@ def test_cluster_set_errors(env: Env):
     env.expect('SEARCH.CLUSTERSET', 'HASHFUNC').error().contains('Missing value for HASHFUNC')
     env.expect('SEARCH.CLUSTERSET', 'NUMSLOTS').error().contains('Missing value for NUMSLOTS')
 
-    env.expect('SEARCH.CLUSTERSET', 'HASHFUNC', 'yes please').error().contains('Bad value for HASHFUNC: yes please')
-    env.expect('SEARCH.CLUSTERSET', 'RANGES', 'yes please').error().contains('Bad value for RANGES: yes please')
-    env.expect('SEARCH.CLUSTERSET', 'RANGES', '-1').error().contains('Bad value for RANGES: -1')
-    env.expect('SEARCH.CLUSTERSET', 'NUMSLOTS', 'yes please').error().contains('Bad value for NUMSLOTS: yes please')
-    env.expect('SEARCH.CLUSTERSET', 'NUMSLOTS', '0').error().contains('Bad value for NUMSLOTS: 0')
-    env.expect('SEARCH.CLUSTERSET', 'NUMSLOTS', '1000000').error().contains('Bad value for NUMSLOTS: 1000000')
+    # Any 3-argument invocation is dispatched to the short form (`SEARCH.CLUSTERSET AUTH <password>`)
+    env.expect('SEARCH.CLUSTERSET', 'HASHFUNC', 'yes please').error().contains('Expected `AUTH` but got `HASHFUNC`')
+    env.expect('SEARCH.CLUSTERSET', 'RANGES', '-1').error().contains('Expected `AUTH` but got `RANGES`')
+    env.expect('SEARCH.CLUSTERSET', 'NUMSLOTS', '0').error().contains('Expected `AUTH` but got `NUMSLOTS`')
+
+    env.expect('SEARCH.CLUSTERSET', 'MYID', '1', 'HASHFUNC', 'yes please').error().contains('Bad value for HASHFUNC: yes please')
+    env.expect('SEARCH.CLUSTERSET', 'MYID', '1', 'RANGES', 'yes please').error().contains('Bad value for RANGES: yes please')
+    env.expect('SEARCH.CLUSTERSET', 'MYID', '1', 'RANGES', '-1').error().contains('Bad value for RANGES: -1')
+    env.expect('SEARCH.CLUSTERSET', 'MYID', '1', 'NUMSLOTS', 'yes please').error().contains('Bad value for NUMSLOTS: yes please')
+    env.expect('SEARCH.CLUSTERSET', 'MYID', '1', 'NUMSLOTS', '0').error().contains('Bad value for NUMSLOTS: 0')
+    env.expect('SEARCH.CLUSTERSET', 'MYID', '1', 'NUMSLOTS', '1000000').error().contains('Bad value for NUMSLOTS: 1000000')
 
     # Check shard values parsing
     env.expect('SEARCH.CLUSTERSET', 'MYID', '1', 'RANGES', '1',


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: On an OSS cluster, the coordinator refreshes its cluster topology by polling `MRClusterTopology_FromAPI` on a 1-second timer, which is wasteful and lags behind actual topology changes. Additionally, `test_cluster_set_errors` has been unconditionally skipped since #10068, and ASM completion handlers force an extra topology refresh.
2. **Change**:
   - Subscribe to the new `RedisModuleEvent_ClusterTopologyChange` server event ([redis/redis#15350](https://github.com/redis/redis/pull/15350), definitions added to our `redismodule.h`) and refresh the topology when it fires. The subscription is registered in `notifications.c` alongside the other server events; `redis_cluster.c` is reduced to a running/paused flag (for the `PAUSE/RESUME_TOPOLOGY_UPDATER` debug commands) and a single initial fetch at startup, since the event only fires on changes. The periodic timer, and timers in general, are removed. If the server does not support the event, a warning is logged and the topology is only refreshed via `SEARCH.CLUSTERREFRESH`.
   - Remove the explicit topology refresh from the ASM `IMPORT_COMPLETED`/`MIGRATE_COMPLETED` handlers: the slot-ownership changes of a completed migration fire the topology change event on every node (participants synchronously in the same event-loop iteration, non-participants via gossip), so the refresh is event-driven there too.
   - Re-enable `test_cluster_set_errors` and update it to the current `SEARCH.CLUSTERSET` behavior (3-argument invocations dispatch to the `AUTH <password>` short form). The test now runs in standalone mode only, as it only exercises argument parsing. Long-form value validation coverage is preserved via `MYID`-prefixed invocations.
   - CI (separate commits): re-pin the redis ref to the redis/redis#15350 merge commit on unstable, which contains both the topology change event and `RedisModule_GetClusterNodeSlotRanges` (MOD-15868). Revert to `task-get-latest-tag.yml` once Redis 8.10 is released.
3. **Outcome**: OSS cluster topology is refreshed reactively on actual topology changes (reshards, failovers, node membership/address changes, cluster state transitions) with no periodic polling. Depends on redis/redis#15350, which is now merged into unstable (targeted for Redis 8.10).

#### Which additional issues this PR fixes
1. [MOD-15870](https://redislabs.atlassian.net/browse/MOD-15870)
2. Re-enables the test skipped in #10068 (MOD-15868 follow-up)

#### Main objects this PR modified
1. `src/coord/rmr/redis_cluster.c` — topology updater: event-driven, no timers
2. `src/notifications.c` — `ClusterTopologyChangeEvent` handler + subscription; ASM handlers no longer force a refresh
3. `src/module.c` — `initSearchCluster`: updater started after `MR_Init`/`MR_InitLocalNodeId` (initial fetch feeds the MR layer)
4. `src/redismodule.h` — `RedisModuleEvent_ClusterTopologyChange` definitions from redis/redis#15350
5. `tests/pytests/test.py` — `test_cluster_set_errors` re-enabled
6. `.github/workflows/*` — redis CI pin (separate commit)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

[MOD-15870]: https://redislabs.atlassian.net/browse/MOD-15870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
