### PR TITLE
[MOD-16860] Fix flaky test_disk_vector_range_query_concurrent_writes (HNSW recall over duplicate corpus)

### DIFF
--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -692,8 +692,9 @@ def test_disk_vector_range_query_concurrent_writes(env: Env):
 
     def writer():
         # Dedicated connection (never shares a socket with the querier). Out-of-radius
-        # vectors are distinct: identical duplicates make the in-radius cluster unreachable
-        # to HNSW at EF_RUNTIME 64 and flake the final recall check (MOD-16860).
+        # vectors are distinct: a large corpus of identical vectors forms a dense HNSW
+        # component the greedy search can't cross out of, so range/KNN recall of the
+        # in-radius cluster can drop to zero (approximate-search artifact). See MOD-16860.
         try:
             wconn = env.getConnection()
             i = 0

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -682,7 +682,6 @@ def test_disk_vector_range_query_concurrent_writes(env: Env):
     # A small set of in-radius docs (few enough that HNSW reliably recalls them all).
     base_docs = {f'base:{i}' for i in range(5)}
     in_radius = create_np_array_typed([1.0, 1.0], 'FLOAT32').tobytes()
-    far_away = create_np_array_typed([1000.0, 1000.0], 'FLOAT32').tobytes()
     for doc_id in base_docs:
         env.cmd('HSET', doc_id, 'v', in_radius)
     waitForIndex(env, 'idx')
@@ -692,12 +691,14 @@ def test_disk_vector_range_query_concurrent_writes(env: Env):
     stop = threading.Event()
 
     def writer():
-        # Stream out-of-radius inserts on a dedicated connection so the writer never
-        # shares a socket with the querying thread.
+        # Dedicated connection (never shares a socket with the querier). Out-of-radius
+        # vectors are distinct: identical duplicates make the in-radius cluster unreachable
+        # to HNSW at EF_RUNTIME 64 and flake the final recall check (MOD-16860).
         try:
             wconn = env.getConnection()
             i = 0
             while not stop.is_set():
+                far_away = create_np_array_typed([1000.0 + i, 1000.0], 'FLOAT32').tobytes()
                 wconn.execute_command('HSET', f'extra:{i}', 'v', far_away)
                 i += 1
         except Exception as e:  # noqa: BLE001 - surface to the asserting thread


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `test_disk_vector_range_query_concurrent_writes` streams ~2000 *identical* out-of-radius vectors at `[1000,1000]`. Those duplicates form a dense HNSW clique disconnected from the `[1,1]` in-radius cluster; at the default `EF_RUNTIME=64` the greedy search can't navigate from the far clique to the base island, so the final *quiescent* `VECTOR_RANGE` recall assertion intermittently returns empty (`set() == {'base:0'..'base:4'}`, `test_flex_validation.py:735`). The base vectors are never lost — a full-index scan / `EF_RUNTIME>=1024` finds all 5, and KNN misses them too, so it is an approximate-search reachability artifact, not data loss or a concurrency bug.
2. **Change:** insert *distinct* out-of-radius vectors (`[1000.0 + i, 1000.0]`) so the graph stays navigable and the final exact-recall assertion is deterministic. The concurrent-phase no-leak / existence checks are unchanged (the vectors are still well outside the radius).
3. **Outcome:** the flake is eliminated. Validated locally on a faithful debug build: **0 failures over 270 repro rounds** (120 amplified + 150 single-writer), versus ~12–100% with the identical-vector corpus.

#### Which additional issues this PR fixes
1. MOD-16860
2. #10246 (follow-up to the MOD-16437 feature that introduced this test)

#### Main objects this PR modified
1. `tests/pytests/test_flex_validation.py` — the `writer()` in `test_disk_vector_range_query_concurrent_writes`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Test-only change (fixes a flaky test); no user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
