### PR TITLE
RED-207724 [asm] Pipeline test corpus population to fix macOS x86 timeouts

### DIFF
--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -364,7 +364,9 @@ def create_and_populate_index(env: Env, index_name: str, n_docs: int):
     # Set random seed for reproducible vectors
     np.random.seed(42)
 
+    HSET_BATCH = 1000
     with env.getClusterConnectionIfNeeded() as con:
+        pipe = con.pipeline(transaction=False)
         for i in range(n_docs):
             # Generate a 10-dimensional vector with more variation to avoid same scores
             vector = np.array([
@@ -380,7 +382,7 @@ def create_and_populate_index(env: Env, index_name: str, n_docs: int):
             text_content = f"document {i} content {' '.join(random_words)} data"
             tag_value = "even" if i % 2 == 0 else "odd"
             # force each document to a different slot
-            con.execute_command('HSET', f'doc-{i}:{{{i % CLUSTER_SLOTS}}}',
+            pipe.execute_command('HSET', f'doc-{i}:{{{i % CLUSTER_SLOTS}}}',
                               'n', i,
                               'text', text_content,
                               'tag', tag_value,
@@ -388,6 +390,9 @@ def create_and_populate_index(env: Env, index_name: str, n_docs: int):
                               'update_counter', 0,
                               'timestamp', int(time.time() * 1000),
                               'extra_data', f'initial_{i}')
+            if (i + 1) % HSET_BATCH == 0:
+                pipe.execute()
+        pipe.execute()
 
 def wait_for_migration_complete(env, dest_shard, source_shard, timeout=200, query_during_migration=None):
     """Helper to wait for slot migration to complete with retry on failure
@@ -950,12 +955,17 @@ def test_migrate_no_indexes():
 
     # Add documents without creating any index
     n_docs = 5 * CLUSTER_SLOTS
+    HSET_BATCH = 1000
     with env.getClusterConnectionIfNeeded() as con:
+        pipe = con.pipeline(transaction=False)
         for i in range(n_docs):
-            con.execute_command('HSET', f'doc-{i}:{{{i % CLUSTER_SLOTS}}}',
+            pipe.execute_command('HSET', f'doc-{i}:{{{i % CLUSTER_SLOTS}}}',
                               'n', i,
                               'text', f'document {i} content data',
                               'tag', 'even' if i % 2 == 0 else 'odd')
+            if (i + 1) % HSET_BATCH == 0:
+                pipe.execute()
+        pipe.execute()
 
     shard1, shard2 = env.getConnection(1), env.getConnection(2)
 
@@ -1088,12 +1098,17 @@ def test_hybrid_cursor_after_add_shard_migration():
                'embedding', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2').ok()
 
     # Populate docs - they will be spread across both shards via cluster hashing
+    HSET_BATCH = 1000
     with env.getClusterConnectionIfNeeded() as con:
+        pipe = con.pipeline(transaction=False)
         for i in range(n_docs):
             vector = np.array([float(i), float(i % 10)], dtype=np.float32)
-            con.execute_command('HSET', f'doc:{i}:{{{i % CLUSTER_SLOTS}}}',
+            pipe.execute_command('HSET', f'doc:{i}:{{{i % CLUSTER_SLOTS}}}',
                               'description', f'running shoes item {i}',
                               'embedding', vector.tobytes())
+            if (i + 1) % HSET_BATCH == 0:
+                pipe.execute()
+        pipe.execute()
 
     shard1 = env.getConnection(1)
 


### PR DESCRIPTION
Batch the ASM test corpus population through a cluster pipeline so setup no longer does ~82k sequential round-trips per test, which is what times out the slow macOS 26 x86_64 CI runner.

- [ ] This PR requires release notes
- [x] This PR does not require release notes

## Changes
- `create_and_populate_index`: send the `HSET`s via `con.pipeline(transaction=False)`, flushing every 1000 commands, instead of one round-trip per document.
- No change to the generated data, insertion order, or slot layout - only how the commands are transmitted.

## Why
- Each of ~40 test variants populates `5 * CLUSTER_SLOTS` (~82k) docs one `HSET` at a time. On fast platforms the per-RTT cost is negligible; on the underpowered/scarce macOS x86_64 hosted runner it dominates and blows the per-test timeout (and, on 2026-07-08, the 120-min coordinator cap). Every other platform passes.

## Test plan
- Run `tests/pytests/test_asm.py` in cluster mode (`min_shards>=2`) on Linux and macOS; confirm all `import_slot_range` / `add_shard_and_migrate` variants pass.
- Compare wall-clock of the coordinator flow-test lane before/after on the macOS x86_64 leg.

Follow-up levers tracked in RED-207724 (not in this PR): raise `WITHCURSOR COUNT` from 10, and reassess the `5 * CLUSTER_SLOTS` corpus size.