### PR TITLE
[MOD-15868] Build pinned Redis for CI benchmarks until 8.10 is released

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -47,6 +47,10 @@ on:
         type: string
         default: ""
         description: "Branch to use as the comparison baseline. Empty falls back to the PR base branch."
+      redis_ref:
+        type: string
+        default: ""
+        description: "Optional redis/redis git ref (sha/branch/tag). When set, redis-server is built from this ref on the runner and passed to `redisbench-admin run-remote --redis-server-binary`, which copies it to the remote DB hosts instead of using their preinstalled redis. Empty keeps the tool's default."
 
 jobs:
   benchmark-steps:
@@ -137,6 +141,24 @@ jobs:
           BINROOT: ${{ format('{0}/bin/linux-{1}-release', github.workspace, inputs.arch == 'aarch64' && 'aarch64' || 'x64') }}
         run: ./tests/deps/setup_rejson.sh
 
+      # Temporary until Redis 8.10 is GA and becomes the default redis on the
+      # benchmark DB hosts: the module on master needs a newer redis-server than
+      # the one preinstalled there, so when redis_ref is set we build redis on
+      # this runner (same arch/OS as the flow-build-benchmark-binary runner that
+      # built redisearch.so, so ABI assumptions are identical) and let
+      # redisbench-admin copy it to the remote DB hosts. The action exports the
+      # REDIS_SERVER env var pointing at the built binary.
+      - name: Build custom redis-server from redis/redis@${{ inputs.redis_ref }}
+        if: steps.benchmark-filter.outputs.skip != 'true' && inputs.redis_ref != ''
+        uses: ./.github/actions/build-redis
+        with:
+          ref: ${{ inputs.redis_ref }}
+          # The DB hosts may not ship the runner's libssl, and benchmarks don't
+          # use TLS: build without it so the copied binary needs no extra
+          # shared libraries on the remote side.
+          build_tls: 'false'
+          cache_platform_id: ${{ inputs.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+
       - name: Run CI benchmarks on aws for envs ${{ inputs.allowed_envs }}
         if: steps.benchmark-filter.outputs.skip != 'true'
         timeout-minutes: 360 # timeout for the step
@@ -193,6 +215,7 @@ jobs:
               --github_org "$GITHUB_ORG_NAME" \
               --module_path "../../$REJSON_MODULE_PATH" \
               --required-module ReJSON \
+              ${REDIS_SERVER:+--redis-server-binary "$REDIS_SERVER"} \
               --github_sha "$GITHUB_SHA_RESOLVED" \
               --github_branch "$GITHUB_BRANCH_NAME" \
               --architecture "$ARCH" \

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -141,13 +141,13 @@ jobs:
           BINROOT: ${{ format('{0}/bin/linux-{1}-release', github.workspace, inputs.arch == 'aarch64' && 'aarch64' || 'x64') }}
         run: ./tests/deps/setup_rejson.sh
 
-      # Temporary until Redis 8.10 is GA and becomes the default redis on the
-      # benchmark DB hosts: the module on master needs a newer redis-server than
-      # the one preinstalled there, so when redis_ref is set we build redis on
-      # this runner (same arch/OS as the flow-build-benchmark-binary runner that
-      # built redisearch.so, so ABI assumptions are identical) and let
-      # redisbench-admin copy it to the remote DB hosts. The action exports the
-      # REDIS_SERVER env var pointing at the built binary.
+      # When redis_ref is set, build redis at that ref on this runner (same
+      # arch/OS as the flow-build-benchmark-binary runner that built
+      # redisearch.so, so ABI assumptions are identical) and let
+      # redisbench-admin copy it to the remote DB hosts instead of using their
+      # preinstalled redis-server. Useful whenever the module requires a redis
+      # newer than the DB hosts' default. The action exports the REDIS_SERVER
+      # env var pointing at the built binary.
       - name: Build custom redis-server from redis/redis@${{ inputs.redis_ref }}
         if: steps.benchmark-filter.outputs.skip != 'true' && inputs.redis_ref != ''
         uses: ./.github/actions/build-redis
@@ -194,6 +194,11 @@ jobs:
           ALLOWED_ENVS: ${{ inputs.allowed_envs }}
           ALLOWED_SETUPS: ${{ inputs.allowed_setups }}
           ARCH: ${{ inputs.arch }}
+          # Path of the redis-server built by the build-redis step above (which
+          # exports REDIS_SERVER). Empty when redis_ref is empty, so the
+          # --redis-server-binary flag below is omitted and the DB hosts'
+          # preinstalled redis is used.
+          CUSTOM_REDIS_SERVER: ${{ inputs.redis_ref != '' && env.REDIS_SERVER || '' }}
           GITHUB_ACTOR_NAME: ${{ github.triggering_actor }}
           GITHUB_REPO_NAME: ${{ github.event.repository.name }}
           GITHUB_ORG_NAME: ${{ github.repository_owner }}
@@ -215,7 +220,7 @@ jobs:
               --github_org "$GITHUB_ORG_NAME" \
               --module_path "../../$REJSON_MODULE_PATH" \
               --required-module ReJSON \
-              ${REDIS_SERVER:+--redis-server-binary "$REDIS_SERVER"} \
+              ${CUSTOM_REDIS_SERVER:+--redis-server-binary "$CUSTOM_REDIS_SERVER"} \
               --github_sha "$GITHUB_SHA_RESOLVED" \
               --github_branch "$GITHUB_BRANCH_NAME" \
               --architecture "$ARCH" \

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -25,6 +25,12 @@ on:
         type: string
         default: ""
         description: "Branch to use as the comparison baseline. Empty falls back to the PR base branch."
+      redis_ref:
+        type: string
+        # Keep in sync with the pinned redis/redis commit the test CI uses
+        # (get-latest-redis-tag in event-pull_request.yml / event-merge-to-queue.yml).
+        default: "3869512c920d4e865b54384bce5fcb6a4e06ae0d"
+        description: "redis/redis git ref (sha/branch/tag) to build and run the benchmarks against, instead of the redis preinstalled on the DB hosts. Empty uses the preinstalled default. TODO: reset the default to '' once Redis 8.10 is GA and becomes the DB hosts' default."
   workflow_call:
     inputs:
       extended:
@@ -45,6 +51,12 @@ on:
         type: string
         default: ""
         description: "Branch to use as the comparison baseline. Empty falls back to the PR base branch."
+      redis_ref:
+        type: string
+        # Keep in sync with the pinned redis/redis commit the test CI uses
+        # (get-latest-redis-tag in event-pull_request.yml / event-merge-to-queue.yml).
+        default: "3869512c920d4e865b54384bce5fcb6a4e06ae0d"
+        description: "redis/redis git ref (sha/branch/tag) to build and run the benchmarks against, instead of the redis preinstalled on the DB hosts. Empty uses the preinstalled default. TODO: reset the default to '' once Redis 8.10 is GA and becomes the DB hosts' default."
 
 jobs:
   # Build RediSearch ONCE per-arch. Every benchmark job below downloads the
@@ -86,6 +98,7 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
       base_branch: ${{ inputs.base_branch }}
+      redis_ref: ${{ inputs.redis_ref }}
 
   # aarch64 sibling of benchmark-search-oss-standalone. Targets the
   # oss-standalone-redisearch-m7-aarch64 terraform dir (m7g.8xlarge DB +
@@ -111,6 +124,7 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-aarch64-${{ github.run_id }}-${{ github.run_attempt }}
       base_branch: ${{ inputs.base_branch }}
+      redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-search-oss-standalone-threads-6:
     # TODO: Temporarily disabled - Redis becomes unavailable after ~3 hours of data loading.
@@ -131,6 +145,7 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
       base_branch: ${{ inputs.base_branch }}
+      redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-vecsim-oss-standalone:
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone' }}
@@ -150,6 +165,7 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
       base_branch: ${{ inputs.base_branch }}
+      redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-vecsim-oss-standalone-threads-6:
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone-threads-6' }}
@@ -169,6 +185,7 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
       base_branch: ${{ inputs.base_branch }}
+      redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-search-oss-cluster-02-primaries:
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-02-primaries' }}
@@ -188,6 +205,7 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
       base_branch: ${{ inputs.base_branch }}
+      redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-search-oss-cluster-04-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-04-primaries') }}
@@ -207,6 +225,7 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
       base_branch: ${{ inputs.base_branch }}
+      redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-search-oss-cluster-04-primaries-threads-6:
     # TODO: Temporarily disabled - Redis becomes unavailable after ~3 hours of data loading.
@@ -227,6 +246,7 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
       base_branch: ${{ inputs.base_branch }}
+      redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-search-oss-cluster-08-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-08-primaries') }}
@@ -246,6 +266,7 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
       base_branch: ${{ inputs.base_branch }}
+      redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8:
     if: ${{ inputs.allowed_setup == 'oss-cluster-08-primaries-250gb-threads-8' }}
@@ -259,6 +280,7 @@ jobs:
       allowed_setups: oss-cluster-08-primaries-250gb-threads-8
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
       base_branch: ${{ inputs.base_branch }}
+      redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-search-oss-cluster-16-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-16-primaries') }}
@@ -278,6 +300,7 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
       base_branch: ${{ inputs.base_branch }}
+      redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-search-oss-cluster-20-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-20-primaries') }}
@@ -297,6 +320,7 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
       base_branch: ${{ inputs.base_branch }}
+      redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-search-oss-cluster-24-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-24-primaries') }}
@@ -316,6 +340,7 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
       base_branch: ${{ inputs.base_branch }}
+      redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-hybrid-oss-standalone:
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone' }}
@@ -335,6 +360,7 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
       binary_artifact_name: redisearch-bin-${{ github.run_id }}-${{ github.run_attempt }}
       base_branch: ${{ inputs.base_branch }}
+      redis_ref: ${{ inputs.redis_ref }}
 
   triage-benchmark-failures:
     needs:

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -27,10 +27,12 @@ on:
         description: "Branch to use as the comparison baseline. Empty falls back to the PR base branch."
       redis_ref:
         type: string
-        # Keep in sync with the pinned redis/redis commit the test CI uses
-        # (get-latest-redis-tag in event-pull_request.yml / event-merge-to-queue.yml).
+        # TEMPORARY default, reset to "" once Redis 8.10 is GA and becomes the
+        # DB hosts' default: pinned to the same redis/redis commit the test CI
+        # uses (get-latest-redis-tag in event-pull_request.yml /
+        # event-merge-to-queue.yml) — keep in sync.
         default: "3869512c920d4e865b54384bce5fcb6a4e06ae0d"
-        description: "redis/redis git ref (sha/branch/tag) to build and run the benchmarks against, instead of the redis preinstalled on the DB hosts. Empty uses the preinstalled default. TODO: reset the default to '' once Redis 8.10 is GA and becomes the DB hosts' default."
+        description: "redis/redis git ref (sha/branch/tag) to build and run the benchmarks against, instead of the redis preinstalled on the DB hosts. Empty uses the preinstalled default."
   workflow_call:
     inputs:
       extended:
@@ -53,10 +55,12 @@ on:
         description: "Branch to use as the comparison baseline. Empty falls back to the PR base branch."
       redis_ref:
         type: string
-        # Keep in sync with the pinned redis/redis commit the test CI uses
-        # (get-latest-redis-tag in event-pull_request.yml / event-merge-to-queue.yml).
+        # TEMPORARY default, reset to "" once Redis 8.10 is GA and becomes the
+        # DB hosts' default: pinned to the same redis/redis commit the test CI
+        # uses (get-latest-redis-tag in event-pull_request.yml /
+        # event-merge-to-queue.yml) — keep in sync.
         default: "3869512c920d4e865b54384bce5fcb6a4e06ae0d"
-        description: "redis/redis git ref (sha/branch/tag) to build and run the benchmarks against, instead of the redis preinstalled on the DB hosts. Empty uses the preinstalled default. TODO: reset the default to '' once Redis 8.10 is GA and becomes the DB hosts' default."
+        description: "redis/redis git ref (sha/branch/tag) to build and run the benchmarks against, instead of the redis preinstalled on the DB hosts. Empty uses the preinstalled default."
 
 jobs:
   # Build RediSearch ONCE per-arch. Every benchmark job below downloads the


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: CI benchmarks are broken — the module on master requires `RedisModule_GetClusterNodeSlotRanges` (MOD-15868), which is not in any released Redis, so the redis-server preinstalled on the benchmark DB hosts fails to load `redisearch.so`.
2. Change: `benchmark-flow.yml` gains an optional `redis_ref` input. When set, the runner builds redis/redis at that ref via the cached `build-redis` composite action (TLS off, so the copied binary needs no extra shared libraries on the DB hosts) and passes the resulting binary to `redisbench-admin run-remote --redis-server-binary`, which copies it to the remote DB hosts and uses it for both standalone and cluster topologies. `benchmark-runner.yml` threads `redis_ref` into every benchmark job and defaults it to the same pinned redis/redis unstable commit the test CI uses (`get-latest-redis-tag` in `event-pull_request.yml` / `event-merge-to-queue.yml`), so all callers (PR label trigger, weekly, push-to-integ, periodic MS MARCO) are fixed without changes. An empty `redis_ref` keeps the tool's preinstalled default.
3. Outcome: CI benchmarks run against a redis build the module can load. Once Redis 8.10 is GA and becomes the DB hosts' default, reverting is just resetting the two `redis_ref` defaults to `''` (TODO comments in place).

#### Which additional issues this PR fixes
1. MOD-15868

#### Main objects this PR modified
1. `.github/workflows/benchmark-flow.yml` — optional `redis_ref` input, cached redis build step, conditional `--redis-server-binary` flag
2. `.github/workflows/benchmark-runner.yml` — `redis_ref` input (dispatch + call) defaulting to the pinned test-CI redis commit, threaded to all benchmark jobs

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)