### PR TITLE
rqe_iterators_bencher: remove intersection C benches

### DIFF
--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/intersection.rs
@@ -20,7 +20,7 @@ use criterion::{
 };
 use ffi::{
     IndexFlags, IndexFlags_Index_StoreByteOffsets, IndexFlags_Index_StoreFieldFlags,
-    IndexFlags_Index_StoreFreqs, IndexFlags_Index_StoreTermOffsets, IteratorStatus_ITERATOR_OK,
+    IndexFlags_Index_StoreFreqs, IndexFlags_Index_StoreTermOffsets,
 };
 use index_result::{RSIndexResult, RSOffsetSlice};
 use inverted_index::{InvertedIndex, full::Full};
@@ -29,8 +29,6 @@ use rqe_iterators::{
     Intersection, NoOpChecker, RQEIterator, id_list::IdListSorted, inverted_index::Term,
 };
 use rqe_iterators_test_utils::MockContext;
-
-use crate::ffi::{self, InvertedIndex as CInvertedIndex};
 
 #[derive(Default)]
 pub struct Bencher;
@@ -161,19 +159,6 @@ fn make_rust_indexes(first_pos: u8, second_pos: u8) -> (InvertedIndex<Full>, Inv
     (first, second)
 }
 
-/// Build two C `InvertedIndex` instances.
-///
-/// `first_pos` and `second_pos` are the (constant) positions used for every document.
-fn make_c_indexes(first_pos: u8, second_pos: u8) -> (CInvertedIndex, CInvertedIndex) {
-    let first = CInvertedIndex::new(FLAGS);
-    let second = CInvertedIndex::new(FLAGS);
-    for doc_id in 1..=NUM_DOCS {
-        first.write_term_entry(doc_id, 1, 1, None, &[first_pos]);
-        second.write_term_entry(doc_id, 1, 1, None, &[second_pos]);
-    }
-    (first, second)
-}
-
 impl Bencher {
     const MEASUREMENT_TIME: Duration = Duration::from_millis(3000);
     const WARMUP_TIME: Duration = Duration::from_millis(200);
@@ -257,28 +242,6 @@ impl Bencher {
         first_pos: u8,
         second_pos: u8,
     ) {
-        let (first_c, second_c) = make_c_indexes(first_pos, second_pos);
-
-        group.bench_function("C", |b| {
-            b.iter_batched_ref(
-                || {
-                    ffi::QueryIterator::new_intersection_from_term_its(
-                        first_c.iterator_term(),
-                        second_c.iterator_term(),
-                        max_slop.map_or(-1, |v| v as i32),
-                        in_order,
-                    )
-                },
-                |it| {
-                    while it.read() == IteratorStatus_ITERATOR_OK {
-                        black_box(it.current());
-                    }
-                    it.free();
-                },
-                criterion::BatchSize::SmallInput,
-            );
-        });
-
         let (first_rust, second_rust) = make_rust_indexes(first_pos, second_pos);
         let mock_ctx = MockContext::new(NUM_DOCS, NUM_DOCS as usize);
 

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -15,7 +15,7 @@ pub use ffi::{
 };
 use index_result::{RSIndexResult, RSQueryTerm};
 use iterators_ffi::intersection::NewIntersectionIterator;
-use rqe_core::{DocId, RS_FIELDMASK_ALL};
+use rqe_core::DocId;
 use std::{ffi::c_void, ptr};
 
 /// Simple wrapper around the C `QueryIterator` type.
@@ -76,20 +76,6 @@ impl QueryIterator {
             *children_ptr.add(1) = child2.into_raw();
         }
         Self(unsafe { NewIntersectionIterator(children_ptr, 2, max_slop, in_order, 1.0) })
-    }
-
-    #[inline(always)]
-    pub unsafe fn new_term(ii: *mut ffi::InvertedIndex, sctx: *const ffi::RedisSearchCtx) -> Self {
-        let term = Box::into_raw(RSQueryTerm::new("term", 1, 0));
-        Self(unsafe {
-            iterators_ffi::inverted_index::NewInvIndIterator_TermQuery(
-                ii.cast_const(),
-                sctx,
-                field::FieldMaskOrIndex::Mask(RS_FIELDMASK_ALL),
-                term,
-                1.0,
-            )
-        })
     }
 
     /// Creates a new intersection iterator from child ID list iterators.
@@ -271,10 +257,5 @@ impl InvertedIndex {
                 &record as *const _ as *mut _,
             );
         }
-    }
-
-    #[inline(always)]
-    pub fn iterator_term(&self) -> QueryIterator {
-        unsafe { QueryIterator::new_term(self.ii, self.sctx) }
     }
 }


### PR DESCRIPTION
The C version has been removed. The iterator is all in Rust now.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
