### PR TITLE
[8.6] [MOD-16745] Fix FT.INFO num_records for multi-value TAG fields

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -758,8 +758,8 @@ FIELD_BULK_INDEXER(tagIndexer) {
 
   size_t numRecords = 0;
   ctx->spec->stats.invertedSize +=
-      TagIndex_Index_(tidx, (const char **)fdata->tags, array_len(fdata->tags),
-                      aCtx->doc->docId, &numRecords);
+      TagIndex_Index(tidx, (const char **)fdata->tags, array_len(fdata->tags),
+                     aCtx->doc->docId, &numRecords);
   ctx->spec->stats.numRecords += numRecords;
   return 0;
 }

--- a/src/document.c
+++ b/src/document.c
@@ -756,9 +756,11 @@ FIELD_BULK_INDEXER(tagIndexer) {
     tidx->suffix = NewTrieMap();
   }
 
+  size_t numRecords;
   ctx->spec->stats.invertedSize +=
-      TagIndex_Index(tidx, (const char **)fdata->tags, array_len(fdata->tags), aCtx->doc->docId);
-  ctx->spec->stats.numRecords++;
+      TagIndex_IndexWithRecords(tidx, (const char **)fdata->tags, array_len(fdata->tags),
+                                aCtx->doc->docId, &numRecords);
+  ctx->spec->stats.numRecords += numRecords;
   return 0;
 }
 

--- a/src/document.c
+++ b/src/document.c
@@ -756,11 +756,8 @@ FIELD_BULK_INDEXER(tagIndexer) {
     tidx->suffix = NewTrieMap();
   }
 
-  size_t numRecords;
-  ctx->spec->stats.invertedSize +=
-      TagIndex_IndexWithRecords(tidx, (const char **)fdata->tags, array_len(fdata->tags),
-                                aCtx->doc->docId, &numRecords);
-  ctx->spec->stats.numRecords += numRecords;
+  TagIndex_Index(tidx, (const char **)fdata->tags, array_len(fdata->tags), aCtx->doc->docId,
+                 &ctx->spec->stats);
   return 0;
 }
 

--- a/src/document.c
+++ b/src/document.c
@@ -756,8 +756,11 @@ FIELD_BULK_INDEXER(tagIndexer) {
     tidx->suffix = NewTrieMap();
   }
 
-  TagIndex_Index(tidx, (const char **)fdata->tags, array_len(fdata->tags), aCtx->doc->docId,
-                 &ctx->spec->stats);
+  size_t numRecords = 0;
+  ctx->spec->stats.invertedSize +=
+      TagIndex_Index_(tidx, (const char **)fdata->tags, array_len(fdata->tags),
+                      aCtx->doc->docId, &numRecords);
+  ctx->spec->stats.numRecords += numRecords;
   return 0;
 }
 

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -214,21 +214,36 @@ static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, 
 }
 
 /* Index a vector of pre-processed tags for a docId */
-void TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docId,
-                    IndexStats *stats) {
-  if (!values) return;
-  size_t numRecords = 0;
+size_t TagIndex_Index_(TagIndex *idx, const char **values, size_t n, t_docId docId,
+                       size_t *numRecords) {
+  if (!values) {
+    if (numRecords) {
+      *numRecords = 0;
+    }
+    return 0;
+  }
+
+  size_t ret = 0;
+  size_t records = 0;
   for (size_t ii = 0; ii < n; ++ii) {
     const char *tok = values[ii];
     if (tok) {
-      stats->invertedSize += tagIndex_Put(idx, tok, strlen(tok), docId, &numRecords);
+      ret += tagIndex_Put(idx, tok, strlen(tok), docId, &records);
 
       if (idx->suffix && (*tok != '\0')) { // add to suffix TrieMap
         addSuffixTrieMap(idx->suffix, tok, strlen(tok));
       }
     }
   }
-  stats->numRecords += numRecords;
+
+  if (numRecords) {
+    *numRecords = records;
+  }
+  return ret;
+}
+
+size_t TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docId) {
+  return TagIndex_Index_(idx, values, n, docId, NULL);
 }
 
 static QueryIterator *TagIndex_GetReader(const TagIndex *idx, const RedisSearchCtx *sctx, InvertedIndex *iv,

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -214,8 +214,8 @@ static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, 
 }
 
 /* Index a vector of pre-processed tags for a docId */
-size_t TagIndex_Index_(TagIndex *idx, const char **values, size_t n, t_docId docId,
-                       size_t *numRecords) {
+size_t TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docId,
+                      size_t *numRecords) {
   if (!values) {
     if (numRecords) {
       *numRecords = 0;
@@ -240,10 +240,6 @@ size_t TagIndex_Index_(TagIndex *idx, const char **values, size_t n, t_docId doc
     *numRecords = records;
   }
   return ret;
-}
-
-size_t TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docId) {
-  return TagIndex_Index_(idx, values, n, docId, NULL);
 }
 
 static QueryIterator *TagIndex_GetReader(const TagIndex *idx, const RedisSearchCtx *sctx, InvertedIndex *iv,

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -200,28 +200,43 @@ struct InvertedIndex *TagIndex_OpenIndex(const TagIndex *idx, const char *value,
 // Encode a single docId into a specific tag value
 // Returns the number of bytes occupied by the encoded entry plus the size of
 // the inverted index (if a new inverted index was created)
-static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, t_docId docId) {
+static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, t_docId docId,
+                                  size_t *numRecords) {
   size_t sz;
   RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0};
   InvertedIndex *iv = TagIndex_OpenIndex(idx, value, len, CREATE_INDEX, &sz);
-  return InvertedIndex_WriteEntryGeneric(iv, &rec) + sz;
+  uint32_t numDocs = InvertedIndex_NumDocs(iv);
+  size_t written = InvertedIndex_WriteEntryGeneric(iv, &rec);
+  if (InvertedIndex_NumDocs(iv) > numDocs) {
+    (*numRecords)++;
+  }
+  return written + sz;
 }
 
 /* Index a vector of pre-processed tags for a docId */
-size_t TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docId) {
+size_t TagIndex_IndexWithRecords(TagIndex *idx, const char **values, size_t n, t_docId docId,
+                                 size_t *numRecords) {
   if (!values) return 0;
   size_t ret = 0;
+  size_t records = 0;
   for (size_t ii = 0; ii < n; ++ii) {
     const char *tok = values[ii];
     if (tok) {
-      ret += tagIndex_Put(idx, tok, strlen(tok), docId);
+      ret += tagIndex_Put(idx, tok, strlen(tok), docId, &records);
 
       if (idx->suffix && (*tok != '\0')) { // add to suffix TrieMap
         addSuffixTrieMap(idx->suffix, tok, strlen(tok));
       }
     }
   }
+  if (numRecords) {
+    *numRecords = records;
+  }
   return ret;
+}
+
+size_t TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docId) {
+  return TagIndex_IndexWithRecords(idx, values, n, docId, NULL);
 }
 
 static QueryIterator *TagIndex_GetReader(const TagIndex *idx, const RedisSearchCtx *sctx, InvertedIndex *iv,

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -214,29 +214,21 @@ static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, 
 }
 
 /* Index a vector of pre-processed tags for a docId */
-size_t TagIndex_IndexWithRecords(TagIndex *idx, const char **values, size_t n, t_docId docId,
-                                 size_t *numRecords) {
-  if (!values) return 0;
-  size_t ret = 0;
-  size_t records = 0;
+void TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docId,
+                    IndexStats *stats) {
+  if (!values) return;
+  size_t numRecords = 0;
   for (size_t ii = 0; ii < n; ++ii) {
     const char *tok = values[ii];
     if (tok) {
-      ret += tagIndex_Put(idx, tok, strlen(tok), docId, &records);
+      stats->invertedSize += tagIndex_Put(idx, tok, strlen(tok), docId, &numRecords);
 
       if (idx->suffix && (*tok != '\0')) { // add to suffix TrieMap
         addSuffixTrieMap(idx->suffix, tok, strlen(tok));
       }
     }
   }
-  if (numRecords) {
-    *numRecords = records;
-  }
-  return ret;
-}
-
-size_t TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docId) {
-  return TagIndex_IndexWithRecords(idx, values, n, docId, NULL);
+  stats->numRecords += numRecords;
 }
 
 static QueryIterator *TagIndex_GetReader(const TagIndex *idx, const RedisSearchCtx *sctx, InvertedIndex *iv,

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -128,6 +128,10 @@ static inline void TagIndex_FreePreprocessedData(char **s) {
 /* Index a vector of pre-processed tags for a docId */
 size_t TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docId);
 
+/* Index tags and return the number of accepted postings through numRecords. */
+size_t TagIndex_IndexWithRecords(TagIndex *idx, const char **values, size_t n, t_docId docId,
+                                 size_t *numRecords);
+
 /* Open an index reader to iterate a tag index for a specific tag. Used at query evaluation time.
  * Returns NULL if there is no such tag in the index */
 QueryIterator *TagIndex_OpenReader(TagIndex *idx, const RedisSearchCtx *sctx, const char *value, size_t len,

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -125,12 +125,9 @@ static inline void TagIndex_FreePreprocessedData(char **s) {
   array_free(s);
 }
 
-/* Index a vector of pre-processed tags for a docId. */
-size_t TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docId);
-
 /* Index tags and return the number of accepted postings through numRecords. */
-size_t TagIndex_Index_(TagIndex *idx, const char **values, size_t n, t_docId docId,
-                       size_t *numRecords);
+size_t TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docId,
+                      size_t *numRecords);
 
 /* Open an index reader to iterate a tag index for a specific tag. Used at query evaluation time.
  * Returns NULL if there is no such tag in the index */

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -125,12 +125,8 @@ static inline void TagIndex_FreePreprocessedData(char **s) {
   array_free(s);
 }
 
-/* Index a vector of pre-processed tags for a docId */
-size_t TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docId);
-
-/* Index tags and return the number of accepted postings through numRecords. */
-size_t TagIndex_IndexWithRecords(TagIndex *idx, const char **values, size_t n, t_docId docId,
-                                 size_t *numRecords);
+/* Index a vector of pre-processed tags for a docId and update the index statistics. */
+void TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docId, IndexStats *stats);
 
 /* Open an index reader to iterate a tag index for a specific tag. Used at query evaluation time.
  * Returns NULL if there is no such tag in the index */

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -125,8 +125,12 @@ static inline void TagIndex_FreePreprocessedData(char **s) {
   array_free(s);
 }
 
-/* Index a vector of pre-processed tags for a docId and update the index statistics. */
-void TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docId, IndexStats *stats);
+/* Index a vector of pre-processed tags for a docId. */
+size_t TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docId);
+
+/* Index tags and return the number of accepted postings through numRecords. */
+size_t TagIndex_Index_(TagIndex *idx, const char **values, size_t n, t_docId docId,
+                       size_t *numRecords);
 
 /* Open an index reader to iterate a tag index for a specific tag. Used at query evaluation time.
  * Returns NULL if there is no such tag in the index */

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -98,6 +98,19 @@ TEST_F(TagIndexTest, testSkipToLastId) {
   TagIndex_Free(idx);
 }
 
+TEST_F(TagIndexTest, testDuplicateTagValuesCountOnce) {
+  TagIndex *idx = NewTagIndex();
+  const char *v[] = {"foo", "foo", "bar"};
+  size_t numRecords;
+
+  TagIndex_IndexWithRecords(idx, &v[0], 3, 1, &numRecords);
+
+  ASSERT_EQ(2u, numRecords);
+  ASSERT_EQ(2u, TrieMap_NUniqueKeys(idx->values));
+
+  TagIndex_Free(idx);
+}
+
 #define TEST_MY_SEP(sep, str)                            \
   orig = s = strdup(str);                                \
   token = TagIndex_SepString(sep, &s, &tokenLen, false); \

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -25,20 +25,22 @@ TEST_F(TagIndexTest, testCreate) {
   // for (auto s : v) {
   //   printf("V[n]: %s\n", s);
   // }
-  IndexStats stats = {0};
+  size_t totalSZ = 0;
+  size_t totalRecords = 0;
   t_docId d;
   for (d = 1; d <= N; d++) {
-    TagIndex_Index(idx, &v[0], v.size(), d, &stats);
-    const size_t invertedSize = stats.invertedSize;
-    const size_t numRecords = stats.numRecords;
+    size_t numRecords = 0;
+    size_t sz = TagIndex_Index_(idx, &v[0], v.size(), d, &numRecords);
+    totalSZ += sz;
+    totalRecords += numRecords;
     // make sure repeating push of the same vector doesn't get indexed
-    TagIndex_Index(idx, &v[0], v.size(), d, &stats);
-    ASSERT_EQ(invertedSize, stats.invertedSize);
-    ASSERT_EQ(numRecords, stats.numRecords);
+    sz = TagIndex_Index_(idx, &v[0], v.size(), d, &numRecords);
+    ASSERT_EQ(0, sz);
+    ASSERT_EQ(0, numRecords);
   }
 
   ASSERT_EQ(v.size(), TrieMap_NUniqueKeys(idx->values));
-  ASSERT_EQ(N * v.size(), stats.numRecords);
+  ASSERT_EQ(N * v.size(), totalRecords);
 
   // expectedTotalSZ should include the memory occupied by the inverted index
   // structure and its blocks.
@@ -52,18 +54,20 @@ TEST_F(TagIndexTest, testCreate) {
 
   // Each index block is 48 bytes + its buffer capacity + the header of the block vector
   size_t expectedTotalSZ = v.size() * (iv_index_size + (8 + (buffer_cap + 48) * num_blocks));
-  ASSERT_EQ(expectedTotalSZ, stats.invertedSize);
+  ASSERT_EQ(expectedTotalSZ, totalSZ);
 
   // Add a new entry to and check the last block size
   std::vector<const char *> v2{"bye"};
-  TagIndex_Index(idx, &v2[0], v2.size(), ++d, &stats);
+  size_t numRecords = 0;
+  size_t sz = TagIndex_Index_(idx, &v2[0], v2.size(), ++d, &numRecords);
+  totalRecords += numRecords;
   // A base inverted index is 24 bytes
   // The header of the block vector is 8 bytes
   // An index block is 48 bytes
   // And after the first insert the buffer capacity is 1 byte
   size_t last_block_size = 24 + 8 + 48 + 1;
-  ASSERT_EQ(expectedTotalSZ + last_block_size, stats.invertedSize);
-  ASSERT_EQ(N * v.size() + v2.size(), stats.numRecords);
+  ASSERT_EQ(expectedTotalSZ + last_block_size, totalSZ + sz);
+  ASSERT_EQ(N * v.size() + v2.size(), totalRecords);
 
   QueryIterator *it = TagIndex_OpenReader(idx, NULL, "hello", 5, 1, RS_INVALID_FIELD_INDEX);
   ASSERT_TRUE(it != NULL);
@@ -90,8 +94,7 @@ TEST_F(TagIndexTest, testSkipToLastId) {
   ASSERT_FALSE(idx == NULL);
   std::vector<const char *> v{"hello"};
   t_docId docId = 1;
-  IndexStats stats = {0};
-  TagIndex_Index(idx, &v[0], v.size(), docId, &stats);
+  TagIndex_Index(idx, &v[0], v.size(), docId);
   QueryIterator *it = TagIndex_OpenReader(idx, NULL, "hello", 5, 1, RS_INVALID_FIELD_INDEX);
   IteratorStatus rc = it->Read(it);
   ASSERT_EQ(rc, ITERATOR_OK);
@@ -106,11 +109,11 @@ TEST_F(TagIndexTest, testSkipToLastId) {
 TEST_F(TagIndexTest, testDuplicateTagValuesCountOnce) {
   TagIndex *idx = NewTagIndex();
   const char *v[] = {"foo", "foo", "bar"};
-  IndexStats stats = {0};
+  size_t numRecords = 0;
 
-  TagIndex_Index(idx, &v[0], 3, 1, &stats);
+  TagIndex_Index_(idx, &v[0], 3, 1, &numRecords);
 
-  ASSERT_EQ(2u, stats.numRecords);
+  ASSERT_EQ(2u, numRecords);
   ASSERT_EQ(2u, TrieMap_NUniqueKeys(idx->values));
 
   TagIndex_Free(idx);

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -25,17 +25,20 @@ TEST_F(TagIndexTest, testCreate) {
   // for (auto s : v) {
   //   printf("V[n]: %s\n", s);
   // }
-  size_t totalSZ = 0;
+  IndexStats stats = {0};
   t_docId d;
   for (d = 1; d <= N; d++) {
-    size_t sz = TagIndex_Index(idx, &v[0], v.size(), d);
-    totalSZ += sz;
+    TagIndex_Index(idx, &v[0], v.size(), d, &stats);
+    const size_t invertedSize = stats.invertedSize;
+    const size_t numRecords = stats.numRecords;
     // make sure repeating push of the same vector doesn't get indexed
-    sz = TagIndex_Index(idx, &v[0], v.size(), d);
-    ASSERT_EQ(0, sz);
+    TagIndex_Index(idx, &v[0], v.size(), d, &stats);
+    ASSERT_EQ(invertedSize, stats.invertedSize);
+    ASSERT_EQ(numRecords, stats.numRecords);
   }
 
   ASSERT_EQ(v.size(), TrieMap_NUniqueKeys(idx->values));
+  ASSERT_EQ(N * v.size(), stats.numRecords);
 
   // expectedTotalSZ should include the memory occupied by the inverted index
   // structure and its blocks.
@@ -49,17 +52,18 @@ TEST_F(TagIndexTest, testCreate) {
 
   // Each index block is 48 bytes + its buffer capacity + the header of the block vector
   size_t expectedTotalSZ = v.size() * (iv_index_size + (8 + (buffer_cap + 48) * num_blocks));
-  ASSERT_EQ(expectedTotalSZ, totalSZ);
+  ASSERT_EQ(expectedTotalSZ, stats.invertedSize);
 
   // Add a new entry to and check the last block size
   std::vector<const char *> v2{"bye"};
-  size_t sz = TagIndex_Index(idx, &v2[0], v2.size(), ++d);
+  TagIndex_Index(idx, &v2[0], v2.size(), ++d, &stats);
   // A base inverted index is 24 bytes
   // The header of the block vector is 8 bytes
   // An index block is 48 bytes
   // And after the first insert the buffer capacity is 1 byte
   size_t last_block_size = 24 + 8 + 48 + 1;
-  ASSERT_EQ(expectedTotalSZ + last_block_size, totalSZ + sz);
+  ASSERT_EQ(expectedTotalSZ + last_block_size, stats.invertedSize);
+  ASSERT_EQ(N * v.size() + v2.size(), stats.numRecords);
 
   QueryIterator *it = TagIndex_OpenReader(idx, NULL, "hello", 5, 1, RS_INVALID_FIELD_INDEX);
   ASSERT_TRUE(it != NULL);
@@ -86,7 +90,8 @@ TEST_F(TagIndexTest, testSkipToLastId) {
   ASSERT_FALSE(idx == NULL);
   std::vector<const char *> v{"hello"};
   t_docId docId = 1;
-  TagIndex_Index(idx, &v[0], v.size(), docId);
+  IndexStats stats = {0};
+  TagIndex_Index(idx, &v[0], v.size(), docId, &stats);
   QueryIterator *it = TagIndex_OpenReader(idx, NULL, "hello", 5, 1, RS_INVALID_FIELD_INDEX);
   IteratorStatus rc = it->Read(it);
   ASSERT_EQ(rc, ITERATOR_OK);
@@ -101,11 +106,11 @@ TEST_F(TagIndexTest, testSkipToLastId) {
 TEST_F(TagIndexTest, testDuplicateTagValuesCountOnce) {
   TagIndex *idx = NewTagIndex();
   const char *v[] = {"foo", "foo", "bar"};
-  size_t numRecords;
+  IndexStats stats = {0};
 
-  TagIndex_IndexWithRecords(idx, &v[0], 3, 1, &numRecords);
+  TagIndex_Index(idx, &v[0], 3, 1, &stats);
 
-  ASSERT_EQ(2u, numRecords);
+  ASSERT_EQ(2u, stats.numRecords);
   ASSERT_EQ(2u, TrieMap_NUniqueKeys(idx->values));
 
   TagIndex_Free(idx);

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -30,11 +30,11 @@ TEST_F(TagIndexTest, testCreate) {
   t_docId d;
   for (d = 1; d <= N; d++) {
     size_t numRecords = 0;
-    size_t sz = TagIndex_Index_(idx, &v[0], v.size(), d, &numRecords);
+    size_t sz = TagIndex_Index(idx, &v[0], v.size(), d, &numRecords);
     totalSZ += sz;
     totalRecords += numRecords;
     // make sure repeating push of the same vector doesn't get indexed
-    sz = TagIndex_Index_(idx, &v[0], v.size(), d, &numRecords);
+    sz = TagIndex_Index(idx, &v[0], v.size(), d, &numRecords);
     ASSERT_EQ(0, sz);
     ASSERT_EQ(0, numRecords);
   }
@@ -59,7 +59,7 @@ TEST_F(TagIndexTest, testCreate) {
   // Add a new entry to and check the last block size
   std::vector<const char *> v2{"bye"};
   size_t numRecords = 0;
-  size_t sz = TagIndex_Index_(idx, &v2[0], v2.size(), ++d, &numRecords);
+  size_t sz = TagIndex_Index(idx, &v2[0], v2.size(), ++d, &numRecords);
   totalRecords += numRecords;
   // A base inverted index is 24 bytes
   // The header of the block vector is 8 bytes
@@ -94,7 +94,7 @@ TEST_F(TagIndexTest, testSkipToLastId) {
   ASSERT_FALSE(idx == NULL);
   std::vector<const char *> v{"hello"};
   t_docId docId = 1;
-  TagIndex_Index(idx, &v[0], v.size(), docId);
+  TagIndex_Index(idx, &v[0], v.size(), docId, NULL);
   QueryIterator *it = TagIndex_OpenReader(idx, NULL, "hello", 5, 1, RS_INVALID_FIELD_INDEX);
   IteratorStatus rc = it->Read(it);
   ASSERT_EQ(rc, ITERATOR_OK);
@@ -111,7 +111,7 @@ TEST_F(TagIndexTest, testDuplicateTagValuesCountOnce) {
   const char *v[] = {"foo", "foo", "bar"};
   size_t numRecords = 0;
 
-  TagIndex_Index_(idx, &v[0], 3, 1, &numRecords);
+  TagIndex_Index(idx, &v[0], 3, 1, &numRecords);
 
   ASSERT_EQ(2u, numRecords);
   ASSERT_EQ(2u, TrieMap_NUniqueKeys(idx->values));

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -193,6 +193,39 @@ def testTagIndex_OnReopen(env:Env): # issue MOD-8011
     # Read from the cursor, should not crash
     env.expect('FT.CURSOR', 'READ', 'idx', cursor).noError().equal([ANY, 0]) # cursor is done
 
+@skip(cluster=True)
+def testTagMultiValueNumRecordsAfterGC(env):
+    n_docs = 100
+    tags_per_doc = 5
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'doc:', 'SCHEMA',
+               't', 'TAG', 'SEPARATOR', ',').ok()
+
+    def tags_value(doc_id, offset):
+        tags = [f'tag{doc_id + offset + tag_id}' for tag_id in range(tags_per_doc)]
+        tags.append(tags[0].upper())
+        return ','.join(tags)
+
+    for doc_id in range(n_docs):
+        conn.execute_command('HSET', f'doc:{doc_id}', 't', tags_value(doc_id, 0))
+
+    waitForIndex(env, 'idx')
+    forceInvokeGC(env, 'idx')
+    info = index_info(env, 'idx')
+    env.assertEqual(n_docs, int(info['num_docs']))
+    env.assertEqual(n_docs * tags_per_doc, int(info['num_records']))
+
+    for doc_id in range(n_docs):
+        conn.execute_command('HSET', f'doc:{doc_id}', 't', tags_value(doc_id, n_docs * tags_per_doc))
+
+    waitForIndex(env, 'idx')
+    forceInvokeGC(env, 'idx')
+    info = index_info(env, 'idx')
+    env.assertEqual(n_docs, int(info['num_docs']))
+    env.assertEqual(n_docs * tags_per_doc, int(info['num_records']))
+    env.assertEqual(tags_per_doc, int(float(info['records_per_doc_avg'])))
+
 def testTagCaseSensitive(env):
     conn = getConnectionByEnv(env)
 


### PR DESCRIPTION
# Description
Backport of #10396 to `8.6`.

## Describe the changes in the pull request

Current:
- Multi-value TAG fields write one posting per tag value, but `numRecords` is incremented only once per field.
- When GC later removes stale postings per tag value, `FT.INFO num_records` can underflow and derived statistics such as `records_per_doc_avg` become incorrect.

Change:
- Count a TAG record only when the target inverted index accepts a new document posting.
- Report the number of accepted postings from `TagIndex_Index` alongside its existing memory-growth result, leaving `document.c` responsible for updating `IndexStats`.
- Avoid counting duplicate or case-equivalent TAG values more than once for the same document.
- Add C++ coverage for posting and duplicate accounting, plus a Python regression that overwrites multi-value TAG documents, forces GC, and validates `FT.INFO`.

Outcome:
- `FT.INFO num_records` and `records_per_doc_avg` remain correct for multi-value TAG fields after indexing, updates, and GC.

#### Which additional issues this PR fixes
1. MOD-16745

#### Main objects this PR modified
1. `src/tag_index.c`
2. `src/document.c`
3. `tests/cpptests/test_cpp_tagindex.cpp`
4. `tests/pytests/test_tags.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Fixes incorrect `FT.INFO num_records` and `records_per_doc_avg` values for multi-value TAG fields after document updates and garbage collection.

#### Tests

- `TagIndexTest.*`: 4/4 passed
- `test_tags:testTagMultiValueNumRecordsAfterGC`: passed
