### PR TITLE
[MOD-15868] Restore module supportedVersion to 8.4.0

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1299,8 +1299,8 @@ int RegisterRestoreIfNxCommands(RedisModuleCtx *ctx, RedisModuleCommand *restore
 
 Version supportedVersion = {
     .majorVersion = 8,
-    .minorVersion = 9,
-    .patchVersion = 80,
+    .minorVersion = 4,
+    .patchVersion = 0,
 };
 
 static void GetRedisVersion(RedisModuleCtx *ctx) {


### PR DESCRIPTION
Reverts only the `supportedVersion` bump from #10380 (MOD-15868).

That change raised the module's minimum supported Redis version to `8.9.80` for the new `RedisModule_GetClusterNodeSlotRanges` topology API used in `SEARCH.CLUSTERREFRESH`. That API only exists in the unreleased Redis 8.10 line, so the floor currently blocks the module from loading on every released Redis (latest is 8.8.0) and on the Enterprise/RoR runtimes pinned below 8.10 — an OSS/Enterprise minimum-version mismatch.

This restores `supportedVersion` to `8.4.0`. The new topology API is only exercised on coordinator/cluster paths, not on standalone module load, so lowering the version gate is safe. The OSS 8.10 version branch should re-bump this floor when 8.10 is released.

Scope: exactly the two-line `supportedVersion` revert in `src/module.c` — the topology-parser code, CI Redis pins, and RAMP `min_redis_version` changes from #10380 are intentionally left in place.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes