### PR TITLE
refactor term iterator helpers

### DIFF
--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -236,9 +236,8 @@ InvertedIndex *Redis_OpenInvertedIndex(IndexSpec *spec, const char *term, size_t
   return idx;
 }
 
-QueryIterator *Redis_OpenReader(const RedisSearchCtx *ctx, RSToken *tok, int tok_id, DocTable *dt,
-                                t_fieldMask fieldMask, double weight) {
-
+InvertedIndex *Redis_OpenReaderIndex(const RedisSearchCtx *ctx, const RSToken *tok,
+                                     t_fieldMask fieldMask) {
   CharBuf termKey = {.buf = tok->str, .len = tok->len};
 
   InvertedIndex *idx = openIndexKeysDict(ctx->spec, &termKey, false, NULL);
@@ -249,6 +248,17 @@ QueryIterator *Redis_OpenReader(const RedisSearchCtx *ctx, RSToken *tok, int tok
   if (!InvertedIndex_NumDocs(idx) ||
       (Index_StoreFieldMask(ctx->spec) && !(InvertedIndex_FieldMask(idx) & fieldMask))) {
     // empty index! or index does not have results from requested field.
+    return NULL;
+  }
+
+  return idx;
+}
+
+QueryIterator *Redis_OpenReader(const RedisSearchCtx *ctx, RSToken *tok, int tok_id, DocTable *dt,
+                                t_fieldMask fieldMask, double weight) {
+
+  InvertedIndex *idx = Redis_OpenReaderIndex(ctx, tok, fieldMask);
+  if (!idx) {
     return NULL;
   }
 

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -21,6 +21,13 @@ typedef struct InvertedIndex InvertedIndex;
 extern "C" {
 #endif
 
+/* Open and validate the inverted index backing a specific term, honoring the
+ * requested field mask. Returns NULL when the term has no inverted index, the
+ * index is empty, or it holds no results for the requested field(s).
+ */
+InvertedIndex *Redis_OpenReaderIndex(const RedisSearchCtx *ctx, const RSToken *tok,
+                                     t_fieldMask fieldMask);
+
 /* Open an inverted index reader on a redis DMA string, for a specific term.
  * If singleWordMode is set to 1, we do not load the skip index, only the score index
  */

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/term.rs
@@ -9,119 +9,10 @@
 
 use std::ptr::NonNull;
 
-use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
-use index_result::{RSIndexResult, RSQueryTerm};
-use inverted_index::{
-    FilterMaskReader, IndexReader, IndexReaderCore, TermReader, doc_ids_only::DocIdsOnly,
-    fields_offsets, fields_only, freqs_fields, freqs_offsets, freqs_only, full, offsets_only,
-    raw_doc_ids_only::RawDocIdsOnly,
-};
-use rqe_core::{DocId, RS_FIELDMASK_ALL};
+use field::FieldMaskOrIndex;
+use index_result::RSQueryTerm;
 use rqe_iterators::interop::RQEIteratorWrapper;
-use rqe_iterators::{FieldExpirationChecker, inverted_index::Term};
-
-/// Wrapper around different term reader types to avoid generics in FFI code.
-///
-/// Handles all term-compatible encoding types. Types with field mask tracking use
-/// [`FilterMaskReader`] to filter records by field mask, while types without field
-/// mask data use the bare [`IndexReaderCore`].
-pub(super) enum TermIndexReader<'index> {
-    // FieldMaskTrackingIndex types (with FilterMaskReader)
-    Full(FilterMaskReader<IndexReaderCore<'index, full::Full>>),
-    FullWide(FilterMaskReader<IndexReaderCore<'index, full::FullWide>>),
-    FreqsFields(FilterMaskReader<IndexReaderCore<'index, freqs_fields::FreqsFields>>),
-    FreqsFieldsWide(FilterMaskReader<IndexReaderCore<'index, freqs_fields::FreqsFieldsWide>>),
-    FieldsOnly(FilterMaskReader<IndexReaderCore<'index, fields_only::FieldsOnly>>),
-    FieldsOnlyWide(FilterMaskReader<IndexReaderCore<'index, fields_only::FieldsOnlyWide>>),
-    FieldsOffsets(FilterMaskReader<IndexReaderCore<'index, fields_offsets::FieldsOffsets>>),
-    FieldsOffsetsWide(FilterMaskReader<IndexReaderCore<'index, fields_offsets::FieldsOffsetsWide>>),
-    // InvertedIndexInner types (without FilterMaskReader)
-    FreqsOnly(IndexReaderCore<'index, freqs_only::FreqsOnly>),
-    OffsetsOnly(IndexReaderCore<'index, offsets_only::OffsetsOnly>),
-    FreqsOffsets(IndexReaderCore<'index, freqs_offsets::FreqsOffsets>),
-    DocIdsOnly(IndexReaderCore<'index, DocIdsOnly>),
-    RawDocIdsOnly(IndexReaderCore<'index, RawDocIdsOnly>),
-}
-
-macro_rules! term_ir_dispatch {
-    ($self:expr, $method:ident $(, $args:expr)*) => {
-        match $self {
-            TermIndexReader::Full(r) => r.$method($($args),*),
-            TermIndexReader::FullWide(r) => r.$method($($args),*),
-            TermIndexReader::FreqsFields(r) => r.$method($($args),*),
-            TermIndexReader::FreqsFieldsWide(r) => r.$method($($args),*),
-            TermIndexReader::FieldsOnly(r) => r.$method($($args),*),
-            TermIndexReader::FieldsOnlyWide(r) => r.$method($($args),*),
-            TermIndexReader::FieldsOffsets(r) => r.$method($($args),*),
-            TermIndexReader::FieldsOffsetsWide(r) => r.$method($($args),*),
-            TermIndexReader::FreqsOnly(r) => r.$method($($args),*),
-            TermIndexReader::OffsetsOnly(r) => r.$method($($args),*),
-            TermIndexReader::FreqsOffsets(r) => r.$method($($args),*),
-            TermIndexReader::DocIdsOnly(r) => r.$method($($args),*),
-            TermIndexReader::RawDocIdsOnly(r) => r.$method($($args),*),
-        }
-    };
-}
-
-impl<'index> IndexReader<'index> for TermIndexReader<'index> {
-    #[inline(always)]
-    fn next_record(&mut self, result: &mut RSIndexResult<'index>) -> std::io::Result<bool> {
-        term_ir_dispatch!(self, next_record, result)
-    }
-
-    #[inline(always)]
-    fn seek_record(
-        &mut self,
-        doc_id: DocId,
-        result: &mut RSIndexResult<'index>,
-    ) -> std::io::Result<bool> {
-        term_ir_dispatch!(self, seek_record, doc_id, result)
-    }
-
-    #[inline(always)]
-    fn skip_to(&mut self, doc_id: DocId) -> bool {
-        term_ir_dispatch!(self, skip_to, doc_id)
-    }
-
-    #[inline(always)]
-    fn reset(&mut self) {
-        term_ir_dispatch!(self, reset)
-    }
-
-    #[inline(always)]
-    fn unique_docs(&self) -> u64 {
-        term_ir_dispatch!(self, unique_docs)
-    }
-
-    #[inline(always)]
-    fn has_duplicates(&self) -> bool {
-        term_ir_dispatch!(self, has_duplicates)
-    }
-
-    #[inline(always)]
-    fn flags(&self) -> ffi::IndexFlags {
-        term_ir_dispatch!(self, flags)
-    }
-
-    #[inline(always)]
-    fn needs_revalidation(&self) -> bool {
-        term_ir_dispatch!(self, needs_revalidation)
-    }
-
-    #[inline(always)]
-    fn refresh_buffer_pointers(&mut self) {
-        term_ir_dispatch!(self, refresh_buffer_pointers)
-    }
-}
-
-impl<'index> TermReader<'index> for TermIndexReader<'index> {
-    fn points_to_the_same_opaque_index(
-        &self,
-        opaque: &inverted_index::opaque::InvertedIndex,
-    ) -> bool {
-        term_ir_dispatch!(self, points_to_the_same_opaque_index, opaque)
-    }
-}
+use rqe_iterators::inverted_index::build_term_iterator;
 
 /// Creates a new term inverted index iterator for querying term fields.
 ///
@@ -161,83 +52,17 @@ pub unsafe extern "C" fn NewInvIndIterator_TermQuery(
     debug_assert!(!sctx.is_null(), "sctx must not be null");
     debug_assert!(!term.is_null(), "term must not be null");
 
-    let idx_ffi: *const inverted_index_ffi::InvertedIndex = idx.cast();
-    // SAFETY: 1. guarantees idx is valid and non-null
-    let ii_ref = unsafe { &*idx_ffi };
-
-    // Determine the field mask for reader filtering.
-    // If a mask is given, filter by that mask. Otherwise, use ALL (index fields are filtered
-    // differently via the expiration checker).
-    let mask = match field_mask_or_index {
-        FieldMaskOrIndex::Mask(m) => m,
-        FieldMaskOrIndex::Index(_) => RS_FIELDMASK_ALL,
-    };
-
-    // Create the appropriate reader based on the encoding type
-    let reader = match ii_ref {
-        inverted_index_ffi::InvertedIndex::Full(ii) => TermIndexReader::Full(ii.reader(mask)),
-        inverted_index_ffi::InvertedIndex::FullWide(ii) => {
-            TermIndexReader::FullWide(ii.reader(mask))
-        }
-        inverted_index_ffi::InvertedIndex::FreqsFields(ii) => {
-            TermIndexReader::FreqsFields(ii.reader(mask))
-        }
-        inverted_index_ffi::InvertedIndex::FreqsFieldsWide(ii) => {
-            TermIndexReader::FreqsFieldsWide(ii.reader(mask))
-        }
-        inverted_index_ffi::InvertedIndex::FieldsOnly(ii) => {
-            TermIndexReader::FieldsOnly(ii.reader(mask))
-        }
-        inverted_index_ffi::InvertedIndex::FieldsOnlyWide(ii) => {
-            TermIndexReader::FieldsOnlyWide(ii.reader(mask))
-        }
-        inverted_index_ffi::InvertedIndex::FieldsOffsets(ii) => {
-            TermIndexReader::FieldsOffsets(ii.reader(mask))
-        }
-        inverted_index_ffi::InvertedIndex::FieldsOffsetsWide(ii) => {
-            TermIndexReader::FieldsOffsetsWide(ii.reader(mask))
-        }
-        inverted_index_ffi::InvertedIndex::FreqsOnly(ii) => TermIndexReader::FreqsOnly(ii.reader()),
-        inverted_index_ffi::InvertedIndex::OffsetsOnly(ii) => {
-            TermIndexReader::OffsetsOnly(ii.reader())
-        }
-        inverted_index_ffi::InvertedIndex::FreqsOffsets(ii) => {
-            TermIndexReader::FreqsOffsets(ii.reader())
-        }
-        inverted_index_ffi::InvertedIndex::DocIdsOnly(ii) => {
-            TermIndexReader::DocIdsOnly(ii.reader())
-        }
-        inverted_index_ffi::InvertedIndex::RawDocIdsOnly(ii) => {
-            TermIndexReader::RawDocIdsOnly(ii.reader())
-        }
-        inverted_index_ffi::InvertedIndex::Numeric(_)
-        | inverted_index_ffi::InvertedIndex::NumericFloatCompression(_) => panic!(
-            "Unsupported inverted index type for term query (numeric indices are not supported)",
-        ),
-    };
-
-    // SAFETY: 3.
+    // SAFETY: 3. guarantees `sctx` is valid and non-null.
     let sctx = unsafe { NonNull::new_unchecked(sctx as *mut _) };
 
-    // SAFETY: 5. guarantees term is a heap-allocated RSQueryTerm
+    // SAFETY: 5. guarantees `term` is a heap-allocated `RSQueryTerm`; ownership
+    // is transferred to the iterator.
     let term = unsafe { Box::from_raw(term) };
 
-    // SAFETY: The caller guarantees `sctx` points to a valid `RedisSearchCtx`
-    // with a valid `spec`, both remaining valid for the iterator's lifetime.
-    let expiration_checker = unsafe {
-        FieldExpirationChecker::new(
-            sctx,
-            FieldFilterContext {
-                field: field_mask_or_index,
-                predicate: FieldExpirationPredicate::Default,
-            },
-            reader.flags(),
-        )
-    };
-
-    // SAFETY: All preconditions for `Term::new` are upheld by this function's
-    // own safety contract (valid reader, valid sctx, valid term).
-    let iterator = unsafe { Term::new(reader, sctx, term, weight, expiration_checker) };
+    // SAFETY: this function's preconditions map directly onto
+    // `build_term_iterator`'s: (1)/(2) for `idx`, (3)/(4) for `sctx`, (5) for
+    // `term`.
+    let iterator = unsafe { build_term_iterator(idx, sctx, field_mask_or_index, term, weight) };
 
     RQEIteratorWrapper::boxed_new(iterator)
 }

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -308,6 +308,36 @@ QueryIterator *NewInvIndIterator_MissingQuery(const InvertedIndex *idx, const Re
 QueryIterator *NewUnsortedIdListIterator(t_docId *ids, uint64_t num, double weight);
 
 /**
+ * Creates a new term inverted index iterator for querying term fields.
+ *
+ * # Parameters
+ *
+ * * `idx` - Pointer to the inverted index to query.
+ * * `sctx` - Pointer to the Redis search context.
+ * * `field_mask_or_index` - Field mask or field index to filter on.
+ * * `term` - Pointer to the query term. Ownership is transferred to the iterator.
+ * * `weight` - Weight to apply to the term results.
+ *
+ * # Returns
+ *
+ * A pointer to a `QueryIterator` that can be used from C code.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ *
+ * 1. `idx` must be a valid pointer to a term `InvertedIndex` and cannot be NULL.
+ * 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
+ *    mechanism detects when the index has been replaced via `Redis_OpenInvertedIndex()`
+ *    pointer comparison.
+ * 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
+ * 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
+ * 5. `term` must be a valid pointer to a heap-allocated `RSQueryTerm` (e.g. created by
+ *    `NewQueryTerm`) and cannot be NULL. Ownership is transferred to the iterator.
+ */
+QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, union FieldMaskOrIndex field_mask_or_index, struct RSQueryTerm *term, double weight);
+
+/**
  * Add profile iterators to all nodes in the iterator tree.
  *
  * Wraps the root as a [`CRQEIterator`], calls
@@ -600,36 +630,6 @@ void Profile_PrintIterators(RedisModuleCtx *ctx, const QueryIterator *root, bool
  *    `NewQueryTerm`) and cannot be NULL. Ownership is transferred to the iterator.
  */
 QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagIndex *tag_idx, const RedisSearchCtx *sctx, union FieldMaskOrIndex field_mask_or_index, struct RSQueryTerm *term, double weight);
-
-/**
- * Creates a new term inverted index iterator for querying term fields.
- *
- * # Parameters
- *
- * * `idx` - Pointer to the inverted index to query.
- * * `sctx` - Pointer to the Redis search context.
- * * `field_mask_or_index` - Field mask or field index to filter on.
- * * `term` - Pointer to the query term. Ownership is transferred to the iterator.
- * * `weight` - Weight to apply to the term results.
- *
- * # Returns
- *
- * A pointer to a `QueryIterator` that can be used from C code.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- *
- * 1. `idx` must be a valid pointer to a term `InvertedIndex` and cannot be NULL.
- * 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
- *    mechanism detects when the index has been replaced via `Redis_OpenInvertedIndex()`
- *    pointer comparison.
- * 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
- * 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
- * 5. `term` must be a valid pointer to a heap-allocated `RSQueryTerm` (e.g. created by
- *    `NewQueryTerm`) and cannot be NULL. Ownership is transferred to the iterator.
- */
-QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, union FieldMaskOrIndex field_mask_or_index, struct RSQueryTerm *term, double weight);
 
 /**
  * Creates a new wildcard inverted index iterator for querying all existing documents.

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
@@ -27,5 +27,5 @@ pub use numeric::{
     Numeric, NumericIteratorVariant, build_numeric_filter_iterator, open_numeric_or_geo_index,
 };
 pub use tag::Tag;
-pub use term::Term;
+pub use term::{Term, TermIndexReader, build_term_iterator};
 pub use wildcard::Wildcard;

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -10,15 +10,21 @@
 use std::ptr::NonNull;
 
 use ffi::RedisSearchCtx;
+use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use index_result::{RSIndexResult, RSOffsetSlice};
 use index_spec::IndexSpecReadGuard;
-use inverted_index::TermReader;
+use inverted_index::{
+    FilterMaskReader, IndexReader, IndexReaderCore, TermReader, doc_ids_only::DocIdsOnly,
+    fields_offsets, fields_only, freqs_fields, freqs_offsets, freqs_only, full, offsets_only,
+    opaque::InvertedIndex, raw_doc_ids_only::RawDocIdsOnly,
+};
 use query_term::RSQueryTerm;
 use ref_mode::{Active, Ref};
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    FieldExpirationChecker, IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus,
+    SkipToOutcome,
     expiration_checker::ExpirationChecker,
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
@@ -245,4 +251,186 @@ where
         ctx.print_optional_counters(map);
         map.kv_long_long(c"Estimated number of matches", self.num_estimated() as i64);
     }
+}
+
+/// A reader over any term-compatible inverted index encoding, erasing the
+/// encoding type behind a single enum so callers don't need to be generic over
+/// it.
+///
+/// Encodings that track a field mask filter their records through a
+/// [`FilterMaskReader`]; encodings without field-mask data use the bare
+/// [`IndexReaderCore`].
+pub enum TermIndexReader<'index> {
+    // Field-mask-tracking encodings (filtered through `FilterMaskReader`).
+    Full(FilterMaskReader<IndexReaderCore<'index, full::Full>>),
+    FullWide(FilterMaskReader<IndexReaderCore<'index, full::FullWide>>),
+    FreqsFields(FilterMaskReader<IndexReaderCore<'index, freqs_fields::FreqsFields>>),
+    FreqsFieldsWide(FilterMaskReader<IndexReaderCore<'index, freqs_fields::FreqsFieldsWide>>),
+    FieldsOnly(FilterMaskReader<IndexReaderCore<'index, fields_only::FieldsOnly>>),
+    FieldsOnlyWide(FilterMaskReader<IndexReaderCore<'index, fields_only::FieldsOnlyWide>>),
+    FieldsOffsets(FilterMaskReader<IndexReaderCore<'index, fields_offsets::FieldsOffsets>>),
+    FieldsOffsetsWide(FilterMaskReader<IndexReaderCore<'index, fields_offsets::FieldsOffsetsWide>>),
+    // Encodings without field-mask data (no `FilterMaskReader`).
+    FreqsOnly(IndexReaderCore<'index, freqs_only::FreqsOnly>),
+    OffsetsOnly(IndexReaderCore<'index, offsets_only::OffsetsOnly>),
+    FreqsOffsets(IndexReaderCore<'index, freqs_offsets::FreqsOffsets>),
+    DocIdsOnly(IndexReaderCore<'index, DocIdsOnly>),
+    RawDocIdsOnly(IndexReaderCore<'index, RawDocIdsOnly>),
+}
+
+macro_rules! term_ir_dispatch {
+    ($self:expr, $method:ident $(, $args:expr)*) => {
+        match $self {
+            TermIndexReader::Full(r) => r.$method($($args),*),
+            TermIndexReader::FullWide(r) => r.$method($($args),*),
+            TermIndexReader::FreqsFields(r) => r.$method($($args),*),
+            TermIndexReader::FreqsFieldsWide(r) => r.$method($($args),*),
+            TermIndexReader::FieldsOnly(r) => r.$method($($args),*),
+            TermIndexReader::FieldsOnlyWide(r) => r.$method($($args),*),
+            TermIndexReader::FieldsOffsets(r) => r.$method($($args),*),
+            TermIndexReader::FieldsOffsetsWide(r) => r.$method($($args),*),
+            TermIndexReader::FreqsOnly(r) => r.$method($($args),*),
+            TermIndexReader::OffsetsOnly(r) => r.$method($($args),*),
+            TermIndexReader::FreqsOffsets(r) => r.$method($($args),*),
+            TermIndexReader::DocIdsOnly(r) => r.$method($($args),*),
+            TermIndexReader::RawDocIdsOnly(r) => r.$method($($args),*),
+        }
+    };
+}
+
+impl<'index> IndexReader<'index> for TermIndexReader<'index> {
+    #[inline(always)]
+    fn next_record(&mut self, result: &mut RSIndexResult<'index>) -> std::io::Result<bool> {
+        term_ir_dispatch!(self, next_record, result)
+    }
+
+    #[inline(always)]
+    fn seek_record(
+        &mut self,
+        doc_id: DocId,
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<bool> {
+        term_ir_dispatch!(self, seek_record, doc_id, result)
+    }
+
+    #[inline(always)]
+    fn skip_to(&mut self, doc_id: DocId) -> bool {
+        term_ir_dispatch!(self, skip_to, doc_id)
+    }
+
+    #[inline(always)]
+    fn reset(&mut self) {
+        term_ir_dispatch!(self, reset)
+    }
+
+    #[inline(always)]
+    fn unique_docs(&self) -> u64 {
+        term_ir_dispatch!(self, unique_docs)
+    }
+
+    #[inline(always)]
+    fn has_duplicates(&self) -> bool {
+        term_ir_dispatch!(self, has_duplicates)
+    }
+
+    #[inline(always)]
+    fn flags(&self) -> ffi::IndexFlags {
+        term_ir_dispatch!(self, flags)
+    }
+
+    #[inline(always)]
+    fn needs_revalidation(&self) -> bool {
+        term_ir_dispatch!(self, needs_revalidation)
+    }
+
+    #[inline(always)]
+    fn refresh_buffer_pointers(&mut self) {
+        term_ir_dispatch!(self, refresh_buffer_pointers)
+    }
+}
+
+impl<'index> TermReader<'index> for TermIndexReader<'index> {
+    fn points_to_the_same_opaque_index(
+        &self,
+        opaque: &inverted_index::opaque::InvertedIndex,
+    ) -> bool {
+        term_ir_dispatch!(self, points_to_the_same_opaque_index, opaque)
+    }
+}
+
+/// Build a term-query iterator over an in-memory inverted index.
+///
+/// Selects the reader for `idx`'s encoding, filters it by `field_mask_or_index`
+/// (a field mask reads only matching fields; a field index reads all fields and
+/// filters via the expiration checker), and returns a [`Term`] iterator that
+/// yields one entry per document containing `term`. `term`'s IDF scores are
+/// (re)computed from the opened index inside [`Term::new`].
+///
+/// # Safety
+///
+/// 1. `idx` must be a valid, non-null pointer to a term [`InvertedIndex`],
+///    remaining valid — and stable between [`revalidate`](RQEIterator::revalidate)
+///    calls — for `'index`. (Revalidation detects a GC replacement by comparing
+///    the index pointer looked up via `Redis_OpenInvertedIndex`.)
+/// 2. `sctx` and `sctx.spec` must be valid and remain valid for `'index`.
+/// 3. `term` is a heap-allocated [`RSQueryTerm`] whose ownership is transferred
+///    to the returned iterator.
+///
+/// # Panics
+///
+/// Panics if `idx` is a numeric index, which has no term reader.
+pub unsafe fn build_term_iterator<'index>(
+    idx: *const ffi::InvertedIndex,
+    sctx: NonNull<RedisSearchCtx>,
+    field_mask_or_index: FieldMaskOrIndex,
+    term: Box<RSQueryTerm>,
+    weight: f64,
+) -> Term<'index, TermIndexReader<'index>, FieldExpirationChecker> {
+    debug_assert!(!idx.is_null(), "idx must not be null");
+
+    let idx_ptr: *const InvertedIndex = idx.cast();
+    // SAFETY: precondition (1) — `idx` is a valid, non-null `InvertedIndex`.
+    let idx = unsafe { &*idx_ptr };
+
+    // A field mask reads only its fields; a field index reads all fields (index
+    // filtering happens later, via the expiration checker).
+    let mask = match field_mask_or_index {
+        FieldMaskOrIndex::Mask(m) => m,
+        FieldMaskOrIndex::Index(_) => RS_FIELDMASK_ALL,
+    };
+
+    let reader = match idx {
+        InvertedIndex::Full(ii) => TermIndexReader::Full(ii.reader(mask)),
+        InvertedIndex::FullWide(ii) => TermIndexReader::FullWide(ii.reader(mask)),
+        InvertedIndex::FreqsFields(ii) => TermIndexReader::FreqsFields(ii.reader(mask)),
+        InvertedIndex::FreqsFieldsWide(ii) => TermIndexReader::FreqsFieldsWide(ii.reader(mask)),
+        InvertedIndex::FieldsOnly(ii) => TermIndexReader::FieldsOnly(ii.reader(mask)),
+        InvertedIndex::FieldsOnlyWide(ii) => TermIndexReader::FieldsOnlyWide(ii.reader(mask)),
+        InvertedIndex::FieldsOffsets(ii) => TermIndexReader::FieldsOffsets(ii.reader(mask)),
+        InvertedIndex::FieldsOffsetsWide(ii) => TermIndexReader::FieldsOffsetsWide(ii.reader(mask)),
+        InvertedIndex::FreqsOnly(ii) => TermIndexReader::FreqsOnly(ii.reader()),
+        InvertedIndex::OffsetsOnly(ii) => TermIndexReader::OffsetsOnly(ii.reader()),
+        InvertedIndex::FreqsOffsets(ii) => TermIndexReader::FreqsOffsets(ii.reader()),
+        InvertedIndex::DocIdsOnly(ii) => TermIndexReader::DocIdsOnly(ii.reader()),
+        InvertedIndex::RawDocIdsOnly(ii) => TermIndexReader::RawDocIdsOnly(ii.reader()),
+        InvertedIndex::Numeric(_) | InvertedIndex::NumericFloatCompression(_) => {
+            panic!("numeric inverted indices have no term reader")
+        }
+    };
+
+    // SAFETY: precondition (2) — `sctx`/`sctx.spec` are valid for `'index`.
+    let expiration_checker = unsafe {
+        FieldExpirationChecker::new(
+            sctx,
+            FieldFilterContext {
+                field: field_mask_or_index,
+                predicate: FieldExpirationPredicate::Default,
+            },
+            reader.flags(),
+        )
+    };
+
+    // SAFETY: `reader` was just built from the valid `idx`; preconditions (2)/(3)
+    // uphold the remaining `Term::new` requirements (valid `sctx`, owned `term`).
+    unsafe { Term::new(reader, sctx, term, weight, expiration_checker) }
 }

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -75,8 +75,9 @@ pub use id_list::IdList;
 pub use intersection::{Intersection, NewIntersectionIterator, new_intersection_iterator};
 pub use inverted_index::{
     GeoRangeError, InvalidGeoInput, Missing, Numeric, NumericIteratorVariant, Tag, Term,
-    build_geo_numeric_filters, build_geo_range_iterator, build_numeric_filter_iterator,
-    extract_geo_unit_factor, new_geo_range_iterator, open_numeric_or_geo_index,
+    TermIndexReader, build_geo_numeric_filters, build_geo_range_iterator,
+    build_numeric_filter_iterator, build_term_iterator, extract_geo_unit_factor,
+    new_geo_range_iterator, open_numeric_or_geo_index,
 };
 pub use resume_outcome::ResumeOutcome;
 pub use rqe_iterator_type::IteratorType;


### PR DESCRIPTION
- Based on top of https://github.com/RediSearch/RediSearch/pull/10412

Couple of refactoring which will allow `eval.rs` to create the term iterator itself:
- add `build_term_iterator` and move it out of the `ffi` crate.
- factor out `Redis_OpenReaderIndex` which is the only `ffi` code we'll need to crate the iterator.

No semantic change.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
