### PR TITLE
[MOD-16881] Fix flaky test_vecsim_info_stats_marked_deleted on OSS cluster

### DIFF
--- a/tests/pytests/test_info.py
+++ b/tests/pytests/test_info.py
@@ -232,8 +232,11 @@ def test_vecsim_info_stats_marked_deleted():
   data_type = 'FLOAT16'
   env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'vector', 'VECTOR', 'HNSW', 6, 'DIM', 6, 'TYPE', 'float16', 'DISTANCE_METRIC', 'L2').ok()
   load_vectors_to_redis(env, 1000, 0, vec_size, data_type)
-  env.expect(debug_cmd(), 'WORKERS', 'DRAIN').ok() # wait for HNSW graph construction to finish
-  env.expect(debug_cmd(), 'WORKERS', 'PAUSE').ok() # pause to prevent repair jobs on the graph
+  # Run the worker-pool sync on every shard: in cluster mode the docs (and the GC below) are
+  # spread across all shards, so draining/pausing only the default shard leaves the other shards'
+  # repair jobs racing the GC, which flakily leaves vectors marked-deleted (MOD-16881).
+  verify_command_OK_on_all_shards(env, debug_cmd(), 'WORKERS', 'DRAIN') # wait for HNSW graph construction to finish
+  verify_command_OK_on_all_shards(env, debug_cmd(), 'WORKERS', 'PAUSE') # pause to prevent repair jobs on the graph
 
   # Set the GC clean threshold to 0
   run_command_on_all_shards(env, config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0')
@@ -246,9 +249,9 @@ def test_vecsim_info_stats_marked_deleted():
   info = index_info(env, 'idx')
   env.assertTrue("field statistics" in info)
   env.assertEqual(info["field statistics"][0]["marked_deleted"], docs_to_delete)
-  env.expect(debug_cmd(), 'WORKERS', 'resume').ok()
+  verify_command_OK_on_all_shards(env, debug_cmd(), 'WORKERS', 'resume')
   # Wait for all repair jobs to be finish, then run GC to remove the deleted vectors.
-  env.expect(debug_cmd(), 'WORKERS', 'DRAIN').ok()
+  verify_command_OK_on_all_shards(env, debug_cmd(), 'WORKERS', 'DRAIN')
   res = run_command_on_all_shards(env, debug_cmd(), 'GC_FORCEINVOKE', 'idx', '100000')
   env.assertTrue(all([r == 'DONE' for r in res]))
   info = index_info(env, 'idx')


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `test_info:test_vecsim_info_stats_marked_deleted` synchronizes the worker thread pool with `env.expect(FT.DEBUG, 'WORKERS', DRAIN/PAUSE/resume)`. `FT.DEBUG WORKERS` is a **node-local** command, so those calls only reach the default shard — but the 500 `DEL`s and the final `GC_FORCEINVOKE` (via `run_command_on_all_shards`) span **all** shards.
2. **Change:** Run the `DRAIN`/`PAUSE`/`resume` on every shard via `verify_command_OK_on_all_shards`, so the "repairs complete before GC" barrier holds cluster-wide.
3. **Outcome:** The final `marked_deleted == 0` assertion is now deterministic in cluster mode. Standalone is unaffected (single shard).

### Why it was flaky

In tiered HNSW a deleted vector stays counted as `marked_deleted` until GC runs a *swap job* for it, and a swap job becomes ready only after all its *repair jobs* complete (`hnsw_tiered.h`: `atomicDecreasePendingJobsNum() == 0 → readySwapJobs++`); `GC_FORCEINVOKE` runs only *ready* swap jobs. Reaching `marked_deleted == 0` therefore requires every shard's repair jobs to finish before that shard's GC runs. Draining only the default shard leaves the other shards' repairs racing the GC.

Observed in the master Periodic Master Validation coverage lane (`330 == 0` at `test_info.py:255`): 500 deletes / 3 shards ≈ 167 each, only the drained shard's ~170 were cleaned, `500 − 170 = 330` remained.

- Failing run: https://github.com/RediSearch/RediSearch/actions/runs/29252306703/job/86823872556

### Verification

Ran the fixed test 6× in OSS-cluster mode (3 shards) locally — all green; server logs confirm the drain now executes on all three shard masters.

#### Which additional issues this PR fixes
1. MOD-16881

#### Main objects this PR modified
1. `tests/pytests/test_info.py` — `test_vecsim_info_stats_marked_deleted`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Test-only change (fixes a flaky test); no user-facing impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)