### PR TITLE
[MOD-16883] Support borrowed open_key handle in Rust load path

### DIFF
--- a/src/redisearch_rs/redis_json_api/src/mock.rs
+++ b/src/redisearch_rs/redis_json_api/src/mock.rs
@@ -76,7 +76,7 @@ static VTABLE: ffi::RedisJSONAPI = ffi::RedisJSONAPI {
     nextKeyValue: Some(next_key_value),
     freeJson: Some(free_json),
     getArray: None,
-    getJsonFromHandle: None,
+    getJsonFromHandle: Some(get_json_from_handle),
 };
 
 /// View a `RedisJSON` handle as the `serde_json::Value` node it points at.
@@ -156,6 +156,23 @@ unsafe extern "C" fn open_key_with_flags(
 ) -> ffi::RedisJSON {
     // Safety: ensured by caller (1.)
     let state = unsafe { &*ctx.cast::<MockState>() };
+    match &state.doc {
+        Some(value) => ptr::from_ref(value).cast(),
+        None => ptr::null(),
+    }
+}
+
+/// Resolve an already-open key handle to the mock document's JSON root. The mock
+/// represents the handle by the same [`MockState`] pointer as the context.
+///
+/// # Safety
+///
+/// 1. `key` must be a [valid], non-null pointer to a mock context created by this module.
+///
+/// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+unsafe extern "C" fn get_json_from_handle(key: *mut ffi::RedisModuleKey) -> ffi::RedisJSON {
+    // Safety: ensured by caller (1.)
+    let state = unsafe { &*key.cast::<MockState>() };
     match &state.doc {
         Some(value) => ptr::from_ref(value).cast(),
         None => ptr::null(),

--- a/src/redisearch_rs/rlookup/src/load_document/hash.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/hash.rs
@@ -16,6 +16,7 @@ use redis_module::RedisString;
 use redis_module::key::RedisKey;
 use redis_module::{KeyType, ScanKeyCursor};
 use std::ffi::CStr;
+use std::mem::ManuallyDrop;
 use std::ptr::{self, NonNull};
 use std::slice;
 use value::{SharedValue, Value};
@@ -26,10 +27,27 @@ pub struct HashDocumentFormat {
     force_string: bool,
 }
 
+/// An open hash key handle, either owned or borrowed.
+#[derive(Debug)]
+enum HashKey {
+    Owned(RedisKey),
+    /// `ManuallyDrop` keeps [`RedisKey`]'s destructor from closing a handle we borrow.
+    Borrowed(ManuallyDrop<RedisKey>),
+}
+
+impl HashKey {
+    fn get(&self) -> &RedisKey {
+        match self {
+            Self::Owned(k) => k,
+            Self::Borrowed(k) => k,
+        }
+    }
+}
+
 /// Represents an open hash document ready to load values from.
 #[derive(Debug)]
 pub struct HashFieldLoader<'a> {
-    key: RedisKey,
+    key: HashKey,
     key_name: &'a RedisString,
 }
 
@@ -76,7 +94,37 @@ impl DocumentFormat for HashDocumentFormat {
             HashOpenError::WrongType => LoadFieldError::WrongKeyType,
         })?;
 
-        Ok(HashFieldLoader { key, key_name })
+        Ok(HashFieldLoader {
+            key: HashKey::Owned(key),
+            key_name,
+        })
+    }
+
+    fn borrow<'key>(
+        &'key self,
+        open_key: &'key ffi::RedisModuleKey,
+        key_name: &'key RedisString,
+    ) -> Result<Self::FieldLoader<'key>, LoadFieldError> {
+        // Safety: the `&'key` reference guarantees `open_key` is valid for `'key`, and the
+        // returned loader is bounded by `'key`. `ManuallyDrop` (see `HashKey::Borrowed`) keeps
+        // us from closing a handle we do not own.
+        let key = unsafe {
+            RedisKey::from_raw_parts(
+                self.ctx.cast().as_ptr(),
+                ptr::from_ref(open_key).cast_mut().cast(),
+            )
+        };
+
+        debug_assert_eq!(
+            key.key_type(),
+            KeyType::Hash,
+            "borrowed handle must reference a hash key"
+        );
+
+        Ok(HashFieldLoader {
+            key: HashKey::Borrowed(ManuallyDrop::new(key)),
+            key_name,
+        })
     }
 
     fn load_all(
@@ -150,7 +198,7 @@ impl FieldLoader for HashFieldLoader<'_> {
             None => return Ok(()),
         };
 
-        let val = if let Some(val) = self.key.hash_get(path.to_bytes())? {
+        let val = if let Some(val) = self.key.get().hash_get(path.to_bytes())? {
             let coerce = if kk.flags.contains(RLookupKeyFlag::Numeric) {
                 HashCoerceType::Double
             } else {

--- a/src/redisearch_rs/rlookup/src/load_document/json.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/json.rs
@@ -18,7 +18,7 @@ use lending_iterator::LendingIterator;
 use redis_json_api::{JsonType, JsonValueRef, RedisJsonApi, SerializeError};
 use redis_module::RedisString;
 use std::ffi::CStr;
-use std::ptr::NonNull;
+use std::ptr::{self, NonNull};
 use value::SharedValue;
 
 const JSON_ROOT: &CStr = c"$";
@@ -72,6 +72,26 @@ impl DocumentFormat for JsonDocumentFormat<'_> {
         key_name: &'key RedisString,
     ) -> Result<Self::FieldLoader<'key>, LoadFieldError> {
         let value = self.open_key(key_name).ok_or(LoadFieldError::KeyNotFound)?;
+
+        Ok(JsonFieldLoader {
+            ctx: self.ctx,
+            value,
+            key_name,
+            api_version: self.api_version,
+        })
+    }
+
+    fn borrow<'key>(
+        &'key self,
+        open_key: &'key ffi::RedisModuleKey,
+        key_name: &'key RedisString,
+    ) -> Result<Self::FieldLoader<'key>, LoadFieldError> {
+        // Safety: the `&'key` reference guarantees `open_key` is valid for `'key`.
+        let value = unsafe {
+            self.japi
+                .open_from_handle(ptr::from_ref(open_key).cast_mut().cast())
+        }
+        .ok_or(LoadFieldError::KeyNotFound)?;
 
         Ok(JsonFieldLoader {
             ctx: self.ctx,

--- a/src/redisearch_rs/rlookup/src/load_document/mod.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/mod.rs
@@ -112,6 +112,13 @@ pub trait DocumentFormat {
         key_name: &'key RedisString,
     ) -> Result<Self::FieldLoader<'key>, LoadFieldError>;
 
+    /// Like [`open`](Self::open), but over an already-open handle the caller owns.
+    fn borrow<'key>(
+        &'key self,
+        open_key: &'key ffi::RedisModuleKey,
+        key_name: &'key RedisString,
+    ) -> Result<Self::FieldLoader<'key>, LoadFieldError>;
+
     /// Bulk-load all fields at once (HGETALL / JSON root scan).
     ///
     /// This is an alternative to `open` + per-field `load_field`, used when
@@ -176,6 +183,7 @@ impl<'env, 'a, F: DocumentFormat> DocumentLoader<'env, 'a, F> {
             &self.dmd.key_name(Some(self.ctx)),
             keys,
             self.force_load,
+            None,
         )
     }
 
@@ -200,12 +208,15 @@ impl<'env, 'a, F: DocumentFormat> DocumentLoader<'env, 'a, F> {
 /// Mirrors the C `loadIndividualKeys` pattern: open the key handle once
 /// (lazily, on first field that actually needs loading) and reuse it
 /// across all field loads. The key is closed when dropped at function end.
+///
+/// `open_key`, when `Some`, is reused instead of opening `key_name` by name.
 pub(crate) fn load_specific_keys<'a, F, I>(
     format: &F,
     dst_row: &mut RLookupRow,
     key_name: &RedisString,
     keys_to_load: I,
     force_load: bool,
+    open_key: Option<&ffi::RedisModuleKey>,
 ) -> Result<(), LoadFieldError>
 where
     F: DocumentFormat,
@@ -222,7 +233,11 @@ where
         let d = match &doc {
             Some(d) => d,
             None => {
-                doc = Some(format.open(key_name)?);
+                let loader = match open_key {
+                    Some(open_key) => format.borrow(open_key, key_name)?,
+                    None => format.open(key_name)?,
+                };
+                doc = Some(loader);
                 doc.as_ref().unwrap()
             }
         };

--- a/src/redisearch_rs/rlookup/tests/load_document_hash.rs
+++ b/src/redisearch_rs/rlookup/tests/load_document_hash.rs
@@ -375,3 +375,36 @@ fn load_all_coerces_numeric_keys_unless_force_string() {
         );
     })
 }
+
+/// `DocumentFormat::borrow` must not take ownership of the caller's key handle:
+/// dropping the loader must leave the handle open for the caller to close. This
+/// is the invariant that lets the AsyncScan `key_cb` reuse its pinned handle.
+#[test]
+#[cfg_attr(miri, ignore)] // can't call FFI function RedisModule_CreateString under miri
+fn borrow_does_not_close_caller_handle() {
+    redis_mock::init_redis_module_mock();
+
+    let key_name_bytes = CString::new("doc:1").unwrap();
+    with_ctx(KeyType::Hash, &[], |ctx| {
+        let format = HashDocumentFormat::new(ctx, false);
+        let key_name = make_redis_string(&key_name_bytes);
+
+        // Open a raw handle ourselves so we (not the loader) own it.
+        // Safety: the mock accepts any mode; `key_name.inner` is a mock string.
+        let raw_key = unsafe {
+            redis_module::raw::RedisModule_OpenKey.unwrap()(ctx.cast().as_ptr(), key_name.inner, 0)
+        };
+
+        {
+            // Safety: `raw_key` is a valid, open handle that outlives the loader.
+            let open_key = unsafe { raw_key.cast::<ffi::RedisModuleKey>().as_ref().unwrap() };
+            let _loader = format.borrow(open_key, &key_name).unwrap();
+            // `_loader` is dropped here; a borrowed handle must NOT be closed.
+        }
+
+        // We still own the handle, so we can close it exactly once. A double close
+        // (had `borrow` taken ownership) would abort the process.
+        // Safety: `raw_key` was opened above and has not been closed.
+        unsafe { redis_module::raw::RedisModule_CloseKey.unwrap()(raw_key) };
+    })
+}

--- a/src/redisearch_rs/rlookup/tests/load_document_json.rs
+++ b/src/redisearch_rs/rlookup/tests/load_document_json.rs
@@ -311,3 +311,39 @@ proptest! {
         assert_expanded_matches(&expanded[0], &value);
     }
 }
+
+/// The borrowed-handle path (`DocumentFormat::borrow`, used when a pinned key is
+/// delivered to an AsyncScan callback and is not addressable by name) must load a
+/// field identically to opening the key by name.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn borrow_loads_field_like_open() {
+    redis_mock::init_redis_module_mock();
+    with_json_api(Some(json!({ "name": "alice" })), |japi, ctx| {
+        let format = JsonDocumentFormat::new(ctx, &japi, PRE_MULTI);
+        let key_name = make_redis_string(c"doc:1");
+
+        let load = |via_borrow: bool| {
+            let mut rlookup = RLookup::new();
+            let key = rlookup
+                .get_key_load(c"$.name", c"$.name", RLookupKeyFlags::empty())
+                .unwrap();
+            let mut row = RLookupRow::new();
+            let loader = if via_borrow {
+                // The mock models the pinned handle by the context pointer.
+                // Safety: the mock resolves the handle to the document root.
+                let open_key = unsafe { ctx.cast::<ffi::RedisModuleKey>().as_ref() };
+                format.borrow(open_key, &key_name).unwrap()
+            } else {
+                format.open(&key_name).unwrap()
+            };
+            loader.load_field(key, &mut row).unwrap();
+            row.get(key).cloned()
+        };
+
+        let opened = load(false).expect("open should load the field");
+        let borrowed = load(true).expect("borrow should load the field");
+        assert_eq!(opened.as_str_bytes(), borrowed.as_str_bytes());
+        assert_eq!(borrowed.as_str_bytes(), Some(&b"alice"[..]));
+    });
+}


### PR DESCRIPTION
Ports the loadDocument relevant changes from https://github.com/RediSearch/RediSearch/pull/10080

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
