### PR TITLE
[Iterator Revalidation][MOD-16684] Inverted-index leaves: core (RawInvIndIterator)

### DIFF
--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -27,7 +27,7 @@ pub use gc::{GcApplyInfo, GcScanDelta, RepairContext};
 
 // Re-export reader types.
 pub use reader::{
-    IndexReader, IndexReaderCore, NumericFilter, NumericReader, RawIndexReaderCore,
+    IndexReader, IndexReaderCore, NumericFilter, NumericReader, RawIndexReaderCore, RefreshOutcome,
     ResumableReader, SuspendableReader, TermReader,
 };
 

--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -157,9 +157,7 @@ where
             // the offset is still valid. Leave `self.buf` as it is (its
             // value is about to be overwritten by `rewind` on the active
             // side) and report that a re-seek is needed.
-            return RefreshOutcome::NeedsReseek {
-                last_doc_id: self.last_doc_id,
-            };
+            return RefreshOutcome::NeedsReseek;
         }
 
         // SAFETY: as above — the contract excludes any concurrent aliasing
@@ -191,9 +189,7 @@ where
                 // offsets after resume. Force a re-seek so the active side rewinds
                 // and re-decodes the current document, rebuilding every borrowed
                 // slice against the live buffer.
-                return RefreshOutcome::NeedsReseek {
-                    last_doc_id: self.last_doc_id,
-                };
+                return RefreshOutcome::NeedsReseek;
             } else {
                 // Same base address: the allocation did not move (an in-place realloc
                 // preserves the bytes the offset slice borrows, and blocks only grow

--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -179,7 +179,12 @@ where
             if !std::ptr::eq(old_base, new_base) {
                 // The block buffer was reallocated to a different address by a
                 // non-GC operation (e.g. an append that outgrew its allocation)
-                // without bumping the GC marker. Refreshing only `self.buf` would
+                // without bumping the GC marker.
+                // Since GC has not run, the number of "old" blocks
+                // is the same and there is no risk of ABA confusion.
+                //
+                //
+                // Refreshing only `self.buf` would
                 // leave the iterator's cached `result` holding an `RSOffsetSlice`
                 // that still borrows the *old*, now-freed allocation — a
                 // use-after-free the moment a caller reads `current()` / iterates
@@ -189,14 +194,14 @@ where
                 return RefreshOutcome::NeedsReseek {
                     last_doc_id: self.last_doc_id,
                 };
+            } else {
+                // Same base address: the allocation did not move (an in-place realloc
+                // preserves the bytes the offset slice borrows, and blocks only grow
+                // by appending), so the cached result stays valid. Refresh the
+                // pointer's provenance to the live slice.
+                let new_buf: NonNull<[u8]> = NonNull::from(new_slice);
+                self.buf = SharedPtr::from_non_null(new_buf);
             }
-
-            // Same base address: the allocation did not move (an in-place realloc
-            // preserves the bytes the offset slice borrows, and blocks only grow
-            // by appending), so the cached result stays valid. Refresh the
-            // pointer's provenance to the live slice.
-            let new_buf: NonNull<[u8]> = NonNull::from(new_slice);
-            self.buf = SharedPtr::from_non_null(new_buf);
         }
 
         RefreshOutcome::Ok

--- a/src/redisearch_rs/inverted_index/src/reader/core.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/core.rs
@@ -7,11 +7,13 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::{io::Cursor, marker::PhantomData, sync::atomic};
+use std::{io::Cursor, marker::PhantomData, ptr::NonNull, sync::atomic};
 
 use ref_mode::{Active, Ref, SharedPtr, Suspended};
 
-use super::{IndexReader, NumericReader, ResumableReader, SuspendableReader, TermReader};
+use super::{
+    IndexReader, NumericReader, RefreshOutcome, ResumableReader, SuspendableReader, TermReader,
+};
 use crate::{
     DecodedBy, Decoder, Encoder, HasInnerIndex, InvertedIndex, NumericDecoder, TermDecoder,
     index::unique_id::IndexUniqueId, opaque::OpaqueEncoding,
@@ -32,9 +34,16 @@ use rqe_core::DocId;
 ///   cycle. It will be re-promoted to [`Active`] under the read lock before any
 ///   reading happens.
 ///
-/// Both instantiations have identical memory layout (`#[repr(C)]` +
-/// [`SharedPtr`] is `#[repr(transparent)]` over `NonNull`), so converting from
-/// `Active` to `Suspended` and back is a zero-cost transmute.
+/// # Invariants
+///
+/// 1. **Layout compatibility across modes.** The [`Active`] and [`Suspended`]
+///    instantiations are layout-identical — same size, alignment, and per-field
+///    offsets — so a `Box` of one may be reinterpreted as a `Box` of the other.
+///    This is what the [`SuspendableReader`]/[`ResumableReader`] contract this
+///    type satisfies requires. It holds because `Rf` flows only through the
+///    `#[repr(transparent)]`-over-`NonNull` [`SharedPtr`] fields (`ii`, `buf`)
+///    and the struct is `#[repr(C)]`. Mechanically enforced by the `const _`
+///    proof below.
 #[repr(C)]
 pub struct RawIndexReaderCore<Rf: Ref, E> {
     /// The inverted index that is being read from.
@@ -76,18 +85,122 @@ pub struct RawIndexReaderCore<Rf: Ref, E> {
 /// that can actually read records from the underlying index.
 pub type IndexReaderCore<'index, E> = RawIndexReaderCore<Active<'index>, E>;
 
+// Compile-time proof of invariant 1 on `RawIndexReaderCore`: its `Active` and
+// `Suspended` instantiations are layout-identical. `E` is fixed to a concrete
+// encoding — it does not participate in the `Rf`-dependent layout (it appears
+// only inside the `SharedPtr` pointee type and a `PhantomData`).
+const _: () = {
+    use std::mem::{align_of, offset_of, size_of};
+    type A = RawIndexReaderCore<Active<'static>, crate::codec::doc_ids_only::DocIdsOnly>;
+    type S = RawIndexReaderCore<Suspended, crate::codec::doc_ids_only::DocIdsOnly>;
+    assert!(offset_of!(A, ii) == offset_of!(S, ii));
+    assert!(offset_of!(A, buf) == offset_of!(S, buf));
+    assert!(offset_of!(A, buf_pos) == offset_of!(S, buf_pos));
+    assert!(offset_of!(A, current_block_idx) == offset_of!(S, current_block_idx));
+    assert!(offset_of!(A, last_doc_id) == offset_of!(S, last_doc_id));
+    assert!(offset_of!(A, gc_marker) == offset_of!(S, gc_marker));
+    assert!(offset_of!(A, ii_unique_id) == offset_of!(S, ii_unique_id));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
+impl<Rf: Ref, E: Encoder> RawIndexReaderCore<Rf, E> {
+    /// Check if this reader is reading from the given index by comparing both their pointers and
+    /// unique IDs. The dual check prevents the ABA problem: if the original index is freed and a
+    /// new one is allocated at the same address, the unique IDs will differ.
+    ///
+    /// Reads only the raw `ii` pointer and the cached `ii_unique_id` — it never
+    /// dereferences the index — so leaves (`Tag`, `Term`, …) can call it from
+    /// their suspended-side `should_abort` checks.
+    pub fn points_to_ii(&self, index: &InvertedIndex<E>) -> bool {
+        std::ptr::eq(self.ii.as_raw(), index) && self.ii_unique_id == index.unique_id()
+    }
+}
+
 /// `IndexReaderCore<Active<'a>, E>` suspends to `IndexReaderCore<Suspended, E>`.
-impl<'a, E> SuspendableReader for RawIndexReaderCore<Active<'a>, E> {
+///
+/// SAFETY: the layout compatibility this trait requires is invariant 1 on
+/// [`RawIndexReaderCore`], enforced by the `const _` proof there.
+unsafe impl<'a, E> SuspendableReader for RawIndexReaderCore<Active<'a>, E> {
     type Suspended = RawIndexReaderCore<Suspended, E>;
 }
 
 /// Inverse of the above: `RawIndexReaderCore<Suspended, E>` resumes to
 /// `IndexReaderCore<Active<'a>, E>` at any index lifetime `'a`.
-impl<E: 'static> ResumableReader for RawIndexReaderCore<Suspended, E>
+///
+/// SAFETY: layout compatibility is invariant 1 on [`RawIndexReaderCore`]
+/// (const proof there).
+unsafe impl<E: 'static> ResumableReader for RawIndexReaderCore<Suspended, E>
 where
     for<'a> RawIndexReaderCore<Active<'a>, E>: IndexReader<'a>,
 {
     type Resumed<'a> = RawIndexReaderCore<Active<'a>, E>;
+
+    unsafe fn refresh_pointers(&mut self) -> RefreshOutcome {
+        // The `InvertedIndex` that `self.ii` points to is owned by the spec; its
+        // address is stable for the spec's lifetime (GC mutates it in place
+        // rather than replacing the struct). We reach its fields through a raw
+        // pointer, borrowing a single field at a time, rather than forming a
+        // `&InvertedIndex` over the whole struct.
+        let ii = self.ii.as_raw();
+
+        // SAFETY: this fn's contract (see [`ResumableReader::refresh_pointers`])
+        // guarantees no concurrent writer/GC mutates or aliases the index for the
+        // call's duration, so reading the atomic `gc_marker` field is a
+        // data-race-free shared access; the borrow is scoped to that field and
+        // does not escape.
+        let current_gc = unsafe { (*ii).gc_marker.load(atomic::Ordering::Relaxed) };
+        if current_gc != self.gc_marker {
+            // GC ran while we were suspended. The cached block offset is
+            // stale; refreshing the buffer pointer alone would not be
+            // enough, and would in fact mislead the caller into thinking
+            // the offset is still valid. Leave `self.buf` as it is (its
+            // value is about to be overwritten by `rewind` on the active
+            // side) and report that a re-seek is needed.
+            return RefreshOutcome::NeedsReseek {
+                last_doc_id: self.last_doc_id,
+            };
+        }
+
+        // SAFETY: as above — the contract excludes any concurrent aliasing
+        // writer, so borrowing only the `blocks` field for the buffer refresh is
+        // sound.
+        let blocks = unsafe { &(*ii).blocks };
+        if !blocks.is_empty() && self.current_block_idx < blocks.len() {
+            let current_block = &blocks[self.current_block_idx];
+            let new_slice = current_block.buffer.as_slice();
+
+            // Compare the current block buffer's base address against the one we
+            // cached. Reading the address of `self.buf` does *not* dereference it
+            // — its pointee may be dangling; we only inspect the pointer value.
+            let old_base = self.buf.as_raw().cast::<u8>();
+            let new_base = new_slice.as_ptr();
+
+            if !std::ptr::eq(old_base, new_base) {
+                // The block buffer was reallocated to a different address by a
+                // non-GC operation (e.g. an append that outgrew its allocation)
+                // without bumping the GC marker. Refreshing only `self.buf` would
+                // leave the iterator's cached `result` holding an `RSOffsetSlice`
+                // that still borrows the *old*, now-freed allocation — a
+                // use-after-free the moment a caller reads `current()` / iterates
+                // offsets after resume. Force a re-seek so the active side rewinds
+                // and re-decodes the current document, rebuilding every borrowed
+                // slice against the live buffer.
+                return RefreshOutcome::NeedsReseek {
+                    last_doc_id: self.last_doc_id,
+                };
+            }
+
+            // Same base address: the allocation did not move (an in-place realloc
+            // preserves the bytes the offset slice borrows, and blocks only grow
+            // by appending), so the cached result stays valid. Refresh the
+            // pointer's provenance to the live slice.
+            let new_buf: NonNull<[u8]> = NonNull::from(new_slice);
+            self.buf = SharedPtr::from_non_null(new_buf);
+        }
+
+        RefreshOutcome::Ok
+    }
 }
 
 // Automatically implemented if the IndexReaderCore uses a NumericDecoder.
@@ -263,13 +376,6 @@ impl<'index, E: DecodedBy<Decoder = D> + 'index, D: Decoder> RawIndexReaderCore<
             ii_unique_id: ii.unique_id(),
             _phantom: PhantomData,
         }
-    }
-
-    /// Check if this reader is reading from the given index by comparing both their pointers and
-    /// unique IDs. The dual check prevents the ABA problem: if the original index is freed and a
-    /// new one is allocated at the same address, the unique IDs will differ.
-    pub fn points_to_ii(&self, index: &InvertedIndex<E>) -> bool {
-        std::ptr::eq(self.ii.as_raw(), index) && self.ii_unique_id == index.unique_id()
     }
 
     /// Swap the inverted index of the reader with the supplied index. This is only used by the C

--- a/src/redisearch_rs/inverted_index/src/reader/field_mask.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/field_mask.rs
@@ -7,7 +7,9 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use super::{IndexReader, IndexReaderCore, ResumableReader, SuspendableReader, TermReader};
+use super::{
+    IndexReader, IndexReaderCore, RefreshOutcome, ResumableReader, SuspendableReader, TermReader,
+};
 use crate::{
     DecodedBy, Decoder, HasInnerIndex, InvertedIndex, TermDecoder, opaque::OpaqueEncoding,
 };
@@ -19,9 +21,15 @@ use rqe_core::{DocId, FieldMask};
 /// filter records in an index based on their field mask, allowing only those that match the
 /// specified mask to be returned.
 ///
-/// `#[repr(C)]` so that, once `IR` is layout-compatible across `Active`/`Suspended`
-/// instantiations of its inner [`RawIndexReaderCore`](crate::RawIndexReaderCore),
-/// the whole `FilterMaskReader` is too.
+/// # Invariants
+///
+/// 1. **Layout compatibility across modes.** When the inner reader `IR` is
+///    layout-compatible with its suspended form (invariant 1 on
+///    [`RawIndexReaderCore`](crate::RawIndexReaderCore)), so is
+///    `FilterMaskReader<IR>`: it is `#[repr(C)]` and `IR` is its only
+///    mode-dependent field. This is the layout compatibility the
+///    [`SuspendableReader`]/[`ResumableReader`] contract requires. Enforced by
+///    the `const _` proof below.
 #[repr(C)]
 pub struct FilterMaskReader<IR> {
     /// Mask which a record needs to match to be valid
@@ -31,6 +39,22 @@ pub struct FilterMaskReader<IR> {
     inner: IR,
 }
 
+// Compile-time proof of invariant 1 on `FilterMaskReader`, for a representative
+// concrete inner reader. The inner reader's own layout compatibility is invariant
+// 1 on `RawIndexReaderCore`.
+const _: () = {
+    use crate::RawIndexReaderCore;
+    use crate::codec::doc_ids_only::DocIdsOnly;
+    use ref_mode::{Active, Suspended};
+    use std::mem::{align_of, offset_of, size_of};
+    type A = FilterMaskReader<RawIndexReaderCore<Active<'static>, DocIdsOnly>>;
+    type S = FilterMaskReader<RawIndexReaderCore<Suspended, DocIdsOnly>>;
+    assert!(offset_of!(A, mask) == offset_of!(S, mask));
+    assert!(offset_of!(A, inner) == offset_of!(S, inner));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
 impl<'index, IR: IndexReader<'index>> FilterMaskReader<IR> {
     /// Create a new filter mask reader with the given mask and inner iterator
     pub const fn new(mask: FieldMask, inner: IR) -> Self {
@@ -39,18 +63,30 @@ impl<'index, IR: IndexReader<'index>> FilterMaskReader<IR> {
 }
 
 /// `FilterMaskReader<IR>` suspends to `FilterMaskReader<IR::Suspended>`.
-impl<IR: SuspendableReader> SuspendableReader for FilterMaskReader<IR> {
+///
+/// SAFETY: layout compatibility is invariant 1 on [`FilterMaskReader`] (const
+/// proof there), given `IR`'s own layout compatibility.
+unsafe impl<IR: SuspendableReader> SuspendableReader for FilterMaskReader<IR> {
     type Suspended = FilterMaskReader<IR::Suspended>;
 }
 
 /// Inverse of the above: `FilterMaskReader<RS>` resumes to
 /// `FilterMaskReader<RS::Resumed<'a>>` for any `RS: ResumableReader`.
-impl<RS: ResumableReader> ResumableReader for FilterMaskReader<RS>
+///
+/// SAFETY: layout compatibility is invariant 1 on [`FilterMaskReader`] (const
+/// proof there).
+unsafe impl<RS: ResumableReader> ResumableReader for FilterMaskReader<RS>
 where
     for<'a> Self: 'static,
     for<'a> FilterMaskReader<RS::Resumed<'a>>: IndexReader<'a>,
 {
     type Resumed<'a> = FilterMaskReader<RS::Resumed<'a>>;
+
+    unsafe fn refresh_pointers(&mut self) -> RefreshOutcome {
+        // SAFETY: our caller upholds `ResumableReader::refresh_pointers`'s
+        // read-lock obligation, which we forward unchanged to the inner reader.
+        unsafe { self.inner.refresh_pointers() }
+    }
 }
 
 impl<'index, IR: IndexReader<'index>> IndexReader<'index> for FilterMaskReader<IR> {

--- a/src/redisearch_rs/inverted_index/src/reader/geo.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/geo.rs
@@ -8,7 +8,8 @@
 */
 
 use super::{
-    IndexReader, IndexReaderCore, NumericFilter, NumericReader, ResumableReader, SuspendableReader,
+    IndexReader, IndexReaderCore, NumericFilter, NumericReader, RefreshOutcome, ResumableReader,
+    SuspendableReader,
 };
 use crate::{DecodedBy, Decoder, InvertedIndex};
 use ffi::{GeoFilter, IndexFlags};
@@ -31,9 +32,15 @@ unsafe extern "C" {
 ///
 /// This should only be wrapped around readers that return numeric records.
 ///
-/// `#[repr(C)]` so that, once `IR` is layout-compatible across `Active`/`Suspended`
-/// instantiations of its inner [`RawIndexReaderCore`](crate::RawIndexReaderCore),
-/// the whole `FilterGeoReader` is too.
+/// # Invariants
+///
+/// 1. **Layout compatibility across modes.** When the inner reader `IR` is
+///    layout-compatible with its suspended form (invariant 1 on
+///    [`RawIndexReaderCore`](crate::RawIndexReaderCore)), so is
+///    `FilterGeoReader<IR>`: it is `#[repr(C)]` and `IR` is its only
+///    mode-dependent field (`filter`/`geo_filter` carry no `Rf`). This is the
+///    layout compatibility the [`SuspendableReader`]/[`ResumableReader`] contract
+///    requires. Enforced by the `const _` proof below.
 #[repr(C)]
 pub struct FilterGeoReader<IR> {
     /// Numeric filter with a geo filter set to which a record needs to match to be valid.
@@ -50,6 +57,23 @@ pub struct FilterGeoReader<IR> {
     /// The inner reader that will be used to read the records from the index.
     inner: IR,
 }
+
+// Compile-time proof of invariant 1 on `FilterGeoReader`, for a representative
+// concrete numeric-encoded inner reader. The inner reader's own layout
+// compatibility is invariant 1 on `RawIndexReaderCore`.
+const _: () = {
+    use crate::RawIndexReaderCore;
+    use crate::codec::numeric::Numeric;
+    use ref_mode::{Active, Suspended};
+    use std::mem::{align_of, offset_of, size_of};
+    type A = FilterGeoReader<RawIndexReaderCore<Active<'static>, Numeric>>;
+    type S = FilterGeoReader<RawIndexReaderCore<Suspended, Numeric>>;
+    assert!(offset_of!(A, filter) == offset_of!(S, filter));
+    assert!(offset_of!(A, geo_filter) == offset_of!(S, geo_filter));
+    assert!(offset_of!(A, inner) == offset_of!(S, inner));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
 
 impl<'index, IR: NumericReader<'index>> FilterGeoReader<IR> {
     /// Create a new filter geo reader with the given numeric filter and inner iterator
@@ -84,7 +108,10 @@ impl<'index, IR: NumericReader<'index>> FilterGeoReader<IR> {
 
 /// `FilterGeoReader<IR>` suspends to `FilterGeoReader<IR::Suspended>` —
 /// only the inner reader switches modes.
-impl<IR: SuspendableReader> SuspendableReader for FilterGeoReader<IR> {
+///
+/// SAFETY: layout compatibility is invariant 1 on [`FilterGeoReader`] (const
+/// proof there), given `IR`'s own layout compatibility.
+unsafe impl<IR: SuspendableReader> SuspendableReader for FilterGeoReader<IR> {
     type Suspended = FilterGeoReader<IR::Suspended>;
 }
 
@@ -92,12 +119,21 @@ impl<IR: SuspendableReader> SuspendableReader for FilterGeoReader<IR> {
 /// `FilterGeoReader<RS::Resumed<'a>>` for any `RS: ResumableReader`. The
 /// `IndexReader<'a>` bound requires `RS::Resumed<'a>: NumericReader<'a>`, which
 /// the resumed core reader provides.
-impl<RS: ResumableReader> ResumableReader for FilterGeoReader<RS>
+///
+/// SAFETY: layout compatibility is invariant 1 on [`FilterGeoReader`] (const
+/// proof there).
+unsafe impl<RS: ResumableReader> ResumableReader for FilterGeoReader<RS>
 where
     for<'a> Self: 'static,
     for<'a> FilterGeoReader<RS::Resumed<'a>>: IndexReader<'a>,
 {
     type Resumed<'a> = FilterGeoReader<RS::Resumed<'a>>;
+
+    unsafe fn refresh_pointers(&mut self) -> RefreshOutcome {
+        // SAFETY: our caller upholds `ResumableReader::refresh_pointers`'s
+        // read-lock obligation, which we forward unchanged to the inner reader.
+        unsafe { self.inner.refresh_pointers() }
+    }
 }
 
 impl<'index, E> FilterGeoReader<IndexReaderCore<'index, E>> {

--- a/src/redisearch_rs/inverted_index/src/reader/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/mod.rs
@@ -38,13 +38,10 @@ pub enum RefreshOutcome {
     /// allocation). Either way the cached block offset — and any
     /// `RSOffsetSlice` the iterator's result borrows from that buffer — is no
     /// longer valid. The caller must promote to Active, rewind, and re-seek to
-    /// `last_doc_id`, which re-decodes the current document and rebuilds every
-    /// borrowed slice against the live buffer.
-    NeedsReseek {
-        /// The last document ID the iterator returned before suspending.
-        /// Resume target for the active-side re-seek.
-        last_doc_id: DocId,
-    },
+    /// the last document it returned before suspending, which re-decodes the
+    /// current document and rebuilds every borrowed slice against the live
+    /// buffer.
+    NeedsReseek,
 }
 
 /// A reader is something which knows how to read / decode the records from an [`InvertedIndex`](crate::InvertedIndex).

--- a/src/redisearch_rs/inverted_index/src/reader/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/mod.rs
@@ -21,6 +21,32 @@ pub use field_mask::FilterMaskReader;
 pub use geo::FilterGeoReader;
 pub use numeric::{FilterNumericReader, NumericFilter};
 
+/// Outcome of [`ResumableReader::refresh_pointers`].
+///
+/// Communicates to the iterator's `resume` body whether the reader's
+/// cached buffer pointer was successfully refreshed in place, or whether
+/// a garbage-collection cycle invalidated the position and the iterator
+/// must rewind + re-seek after being promoted back to [`Active`](ref_mode::Active).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefreshOutcome {
+    /// The buffer pointer was refreshed without intervening GC. The
+    /// reader's position is still valid; the caller can cast Suspended →
+    /// Active and resume reading at the same offset.
+    Ok,
+    /// Either GC ran while suspended, or the current block buffer was
+    /// relocated by a non-GC reallocation (an append that outgrew its
+    /// allocation). Either way the cached block offset — and any
+    /// `RSOffsetSlice` the iterator's result borrows from that buffer — is no
+    /// longer valid. The caller must promote to Active, rewind, and re-seek to
+    /// `last_doc_id`, which re-decodes the current document and rebuilds every
+    /// borrowed slice against the live buffer.
+    NeedsReseek {
+        /// The last document ID the iterator returned before suspending.
+        /// Resume target for the active-side re-seek.
+        last_doc_id: DocId,
+    },
+}
+
 /// A reader is something which knows how to read / decode the records from an [`InvertedIndex`](crate::InvertedIndex).
 pub trait IndexReader<'index> {
     /// Read the next record from the index into `result`. If there are no more records to read,
@@ -70,10 +96,23 @@ pub trait IndexReader<'index> {
 /// `Suspended = InvIndIterator<Suspended, R::Suspended, E>` for any
 /// `R: SuspendableReader`.
 ///
-/// The actual transmute between the two layouts happens at the iterator
-/// level via the `Suspendable` trait (in the `rqe_iterators` crate) — this
-/// trait is purely a type-level helper with no runtime method.
-pub trait SuspendableReader {
+/// The whole-allocation reinterpretation between the two layouts happens at the
+/// iterator level (the inverted-index iterator's `suspend`/`resume` in the
+/// `rqe_iterators` crate); this trait is the type-level half of that mechanism.
+///
+/// # Safety
+///
+/// Implementers must guarantee that `Self` and [`Self::Suspended`] are
+/// **layout-compatible**: identical size and alignment, with every field at the
+/// same offset, so a `Box<Self>` may be reinterpreted as a `Box<Self::Suspended>`
+/// via a same-allocation pointer cast. The inverted-index iterator relies on this
+/// to move between [`Active`](ref_mode::Active) and [`Suspended`](ref_mode::Suspended)
+/// modes without reallocating (which would dangle external pointers into the
+/// iterator interior). The idiomatic way to satisfy this is to make both types
+/// the *same* `#[repr(C)]` generic differing only in the [`Ref`](ref_mode::Ref) mode, whose only
+/// mode-dependent fields are `#[repr(transparent)]`-over-`NonNull`
+/// [`SharedPtr`](ref_mode::SharedPtr)s — those have identical layout in every mode.
+pub unsafe trait SuspendableReader {
     /// The matching reader type carrying [`ref_mode::Suspended`] instead of
     /// [`ref_mode::Active`].
     type Suspended;
@@ -90,10 +129,57 @@ pub trait SuspendableReader {
 ///
 /// The `'static` bound reflects that a suspended reader carries no live
 /// references into the index.
-pub trait ResumableReader: 'static {
+///
+/// # Safety
+///
+/// Implementers must guarantee that `Self` and [`Self::Resumed`] (for every
+/// lifetime `'a`) are **layout-compatible** in the sense described on
+/// [`SuspendableReader`] — this is the inverse direction of the same
+/// same-allocation reinterpretation the iterator performs on resume.
+pub unsafe trait ResumableReader: 'static {
     /// The matching active reader type, parameterised by the index
     /// lifetime under which the suspended reader is being resumed.
     type Resumed<'a>: IndexReader<'a> + SuspendableReader<Suspended = Self> + 'a;
+
+    /// Refresh any reader-internal pointers that may have been invalidated
+    /// while suspended, *without* leaving the [`Suspended`](ref_mode::Suspended)
+    /// type-state.
+    ///
+    /// Returns whether the iterator's last-known position is still usable
+    /// after the refresh, or whether garbage collection ran and the caller
+    /// must rewind + re-seek after promoting back to [`Active`](ref_mode::Active).
+    ///
+    /// # Why this method exists on the suspended side
+    ///
+    /// The active form of a reader holds `SharedPtr<Active<'a>, [u8]>`
+    /// fields whose `'a` validity guarantee may have been broken by a GC
+    /// cycle that reallocated the underlying block buffer. Promoting
+    /// Suspended → Active *before* refreshing those pointers is a
+    /// validity hazard: any code path inside the refresh that materializes
+    /// a `&'a [u8]` borrow from the stale field (even through
+    /// [`SharedPtr::get`](ref_mode::SharedPtr::get)) is UB.
+    ///
+    /// Doing the refresh on the suspended form sidesteps this entirely:
+    /// `SharedPtr<Suspended, _>` exposes no safe deref, so the refresh
+    /// has to either write a fresh pointer directly or upgrade fields
+    /// one at a time under a documented invariant. Only after every
+    /// `Rf`-dependent field has been refreshed does the iterator perform
+    /// the whole-box `Box<Suspended> → Box<Active<'a>>` cast.
+    ///
+    /// # Safety
+    ///
+    /// For the duration of the call the caller must guarantee that no concurrent
+    /// writer or GC cycle mutates, relocates, or frees the pointed-to inverted
+    /// index — i.e. access to it is effectively unique (or shared read-only with
+    /// no aliasing writer). The implementation reads the index's GC marker and
+    /// block buffers through the reader's stored raw index pointer; a concurrent
+    /// mutation would be a data race. This trait does not depend on `index_spec`,
+    /// so the obligation is expressed as `unsafe` rather than by threading a guard
+    /// type. In practice the sole caller — `RQESuspendedIterator::resume` (in
+    /// `rqe_iterators`) — satisfies it by holding the [`IndexSpec`](ffi::IndexSpec)
+    /// read lock (witnessed by its `&IndexSpecReadGuard` parameter), which excludes
+    /// writers and GC for the duration of the call.
+    unsafe fn refresh_pointers(&mut self) -> RefreshOutcome;
 }
 
 /// Marker trait for readers producing numeric values.

--- a/src/redisearch_rs/inverted_index/src/reader/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/numeric.rs
@@ -9,7 +9,9 @@
 
 use std::ffi::c_void;
 
-use super::{IndexReader, IndexReaderCore, NumericReader, ResumableReader, SuspendableReader};
+use super::{
+    IndexReader, IndexReaderCore, NumericReader, RefreshOutcome, ResumableReader, SuspendableReader,
+};
 use crate::{DecodedBy, Decoder, InvertedIndex};
 use ffi::{FieldSpec, IndexFlags};
 use index_result::RSIndexResult;
@@ -86,9 +88,15 @@ impl NumericFilter {
 ///
 /// This should only be wrapped around readers that return numeric records.
 ///
-/// `#[repr(C)]` so that, once `IR` is layout-compatible across `Active`/`Suspended`
-/// instantiations of its inner [`RawIndexReaderCore`](crate::RawIndexReaderCore),
-/// the whole `FilterNumericReader` is too.
+/// # Invariants
+///
+/// 1. **Layout compatibility across modes.** When the inner reader `IR` is
+///    layout-compatible with its suspended form (invariant 1 on
+///    [`RawIndexReaderCore`](crate::RawIndexReaderCore)), so is
+///    `FilterNumericReader<IR>`: it is `#[repr(C)]` and `IR` is its only
+///    mode-dependent field. This is the layout compatibility the
+///    [`SuspendableReader`]/[`ResumableReader`] contract requires. Enforced by
+///    the `const _` proof below.
 #[repr(C)]
 pub struct FilterNumericReader<IR> {
     /// The numeric filter that is used to filter the records.
@@ -97,6 +105,22 @@ pub struct FilterNumericReader<IR> {
     /// The inner reader that will be used to read the records from the index.
     inner: IR,
 }
+
+// Compile-time proof of invariant 1 on `FilterNumericReader`, for a
+// representative concrete numeric-encoded inner reader. The inner reader's own
+// layout compatibility is invariant 1 on `RawIndexReaderCore`.
+const _: () = {
+    use crate::RawIndexReaderCore;
+    use crate::codec::numeric::Numeric;
+    use ref_mode::{Active, Suspended};
+    use std::mem::{align_of, offset_of, size_of};
+    type A = FilterNumericReader<RawIndexReaderCore<Active<'static>, Numeric>>;
+    type S = FilterNumericReader<RawIndexReaderCore<Suspended, Numeric>>;
+    assert!(offset_of!(A, filter) == offset_of!(S, filter));
+    assert!(offset_of!(A, inner) == offset_of!(S, inner));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
 
 impl<'index, IR: NumericReader<'index>> FilterNumericReader<IR> {
     /// Create a new filter numeric reader with the given filter and inner iterator.
@@ -107,7 +131,10 @@ impl<'index, IR: NumericReader<'index>> FilterNumericReader<IR> {
 
 /// `FilterNumericReader<IR>` suspends to `FilterNumericReader<IR::Suspended>`
 /// — only the inner reader switches modes.
-impl<IR: SuspendableReader> SuspendableReader for FilterNumericReader<IR> {
+///
+/// SAFETY: layout compatibility is invariant 1 on [`FilterNumericReader`] (const
+/// proof there), given `IR`'s own layout compatibility.
+unsafe impl<IR: SuspendableReader> SuspendableReader for FilterNumericReader<IR> {
     type Suspended = FilterNumericReader<IR::Suspended>;
 }
 
@@ -115,12 +142,21 @@ impl<IR: SuspendableReader> SuspendableReader for FilterNumericReader<IR> {
 /// `FilterNumericReader<RS::Resumed<'a>>` for any `RS: ResumableReader`. The
 /// `IndexReader<'a>` bound requires `RS::Resumed<'a>: NumericReader<'a>`, which
 /// the resumed core reader provides.
-impl<RS: ResumableReader> ResumableReader for FilterNumericReader<RS>
+///
+/// SAFETY: layout compatibility is invariant 1 on [`FilterNumericReader`] (const
+/// proof there).
+unsafe impl<RS: ResumableReader> ResumableReader for FilterNumericReader<RS>
 where
     for<'a> Self: 'static,
     for<'a> FilterNumericReader<RS::Resumed<'a>>: IndexReader<'a>,
 {
     type Resumed<'a> = FilterNumericReader<RS::Resumed<'a>>;
+
+    unsafe fn refresh_pointers(&mut self) -> RefreshOutcome {
+        // SAFETY: our caller upholds `ResumableReader::refresh_pointers`'s
+        // read-lock obligation, which we forward unchanged to the inner reader.
+        unsafe { self.inner.refresh_pointers() }
+    }
 }
 
 impl<'index, E> FilterNumericReader<IndexReaderCore<'index, E>> {

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -7,34 +7,46 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use ffi::{
+    IndexFlags, ValidateStatus, ValidateStatus_VALIDATE_ABORTED, ValidateStatus_VALIDATE_MOVED,
+    ValidateStatus_VALIDATE_OK,
+};
 use index_result::{RSIndexResult, RawIndexResult};
 use index_spec::IndexSpecReadGuard;
-use inverted_index::IndexReader;
-use ref_mode::{Active, Ref};
+use inverted_index::{IndexReader, RefreshOutcome, ResumableReader, SuspendableReader};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
-    SkipToOutcomeRaw,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome, SkipToOutcomeRaw,
     expiration_checker::{ExpirationChecker, NoOpChecker},
 };
 
 /// A generic iterator over inverted index entries, parameterised over a
 /// [`Ref`] mode.
 ///
-/// This iterator is used to query an inverted index.
+/// This iterator is used to query an inverted index. See [`InvIndIterator`] for
+/// the only instantiation that currently has an [`RQEIterator`] impl.
 ///
-/// Layout is fixed via `#[repr(C)]` so that the `Active`/`Suspended`
-/// instantiations are transmute-compatible: every `Rf`-dependent field —
-/// `result`, `read_impl`, `skip_to_impl` — has the same memory size and
-/// alignment regardless of the chosen mode, and `R` is expected to be
-/// `#[repr(C)]` with the same property. See [`InvIndIterator`] for the only
-/// instantiation that currently has an [`RQEIterator`] impl.
+/// # Invariants
+///
+/// 1. **Layout compatibility across modes.** For any reader `R` that is itself
+///    layout-compatible with its suspended form (invariant 1 on the reader
+///    types — e.g. [`RawIndexReaderCore`](inverted_index::RawIndexReaderCore)),
+///    the `Active` and `Suspended` instantiations of `RawInvIndIterator` are
+///    layout-identical, which is what lets `suspend`/`resume` reinterpret the
+///    `Box` in place. This holds because the struct is `#[repr(C)]` and every
+///    `Rf`-dependent field is layout-stable across modes: `result` is a
+///    [`RawIndexResult`] (proven layout-compatible
+///    in `index_result`), `reader: R` is covered by its own invariant, and the
+///    `read_impl`/`skip_to_impl` fields are `fn` pointers (pointer-sized in every
+///    mode). Enforced, for a representative reader, by the `const _` proof below.
 ///
 /// # Type Parameters
 ///
 /// * `Rf` - The [`Ref`] mode: [`Active<'a>`] gives the iterator working,
-///   readable references into the index; [`Suspended`](ref_mode::Suspended)
+///   readable references into the index; [`Suspended`]
 ///   produces a passive carrier with no callable surface.
 /// * `R` - The reader type used to read the inverted index.
 /// * `E` - The expiration checker type used to check for expired documents.
@@ -51,6 +63,22 @@ pub struct RawInvIndIterator<'query, Rf: Ref, R, E = NoOpChecker> {
 
     /// The expiration checker used to determine if documents are expired.
     expiration_checker: E,
+
+    /// Cached [`IndexFlags`] of the underlying inverted index, snapshotted at
+    /// construction time from `reader.flags()`. Kept here so FFI introspection
+    /// (e.g. `InvIndIterator_GetReaderFlags` during FT.PROFILE printing) can
+    /// read flags regardless of `Rf` — the live reader's `flags()` method is
+    /// only available in the [`Active`] instantiation, but the value itself
+    /// is immutable for the iterator's lifetime.
+    flags: IndexFlags,
+
+    /// Cached count of unique documents in the underlying index, snapshotted at
+    /// construction time from `reader.unique_docs()`. Kept here so introspection
+    /// (e.g. `FT.PROFILE` estimate printing) can read the estimate regardless of
+    /// `Rf` — the live reader's `unique_docs()` is only callable in the
+    /// [`Active`] instantiation, but the snapshot is a stable estimate that both
+    /// modes can report.
+    num_docs: u64,
 
     /// The implementation of the [`read`](RQEIterator::read) method.
     /// Using dynamic dispatch so we can pick the right version during the
@@ -70,6 +98,61 @@ pub struct RawInvIndIterator<'query, Rf: Ref, R, E = NoOpChecker> {
 /// with an [`RQEIterator`] impl today.
 pub type InvIndIterator<'index, R, E = NoOpChecker> =
     RawInvIndIterator<'index, Active<'index>, R, E>;
+
+// Compile-time proof of invariant 1 on `RawInvIndIterator`: for a representative
+// concrete reader, the `Active` and `Suspended` instantiations are
+// layout-identical. The reader's own layout compatibility is invariant 1 on
+// `RawIndexReaderCore`; the `result` field's is proven in `index_result`.
+const _: () = {
+    use inverted_index::{RawIndexReaderCore, doc_ids_only::DocIdsOnly};
+    use std::mem::{align_of, offset_of, size_of};
+    type A = InvIndIterator<'static, RawIndexReaderCore<Active<'static>, DocIdsOnly>, NoOpChecker>;
+    type S =
+        RawInvIndIterator<'static, Suspended, RawIndexReaderCore<Suspended, DocIdsOnly>, NoOpChecker>;
+    assert!(offset_of!(A, reader) == offset_of!(S, reader));
+    assert!(offset_of!(A, at_eos) == offset_of!(S, at_eos));
+    assert!(offset_of!(A, last_doc_id) == offset_of!(S, last_doc_id));
+    assert!(offset_of!(A, result) == offset_of!(S, result));
+    assert!(offset_of!(A, expiration_checker) == offset_of!(S, expiration_checker));
+    assert!(offset_of!(A, flags) == offset_of!(S, flags));
+    assert!(offset_of!(A, num_docs) == offset_of!(S, num_docs));
+    assert!(offset_of!(A, read_impl) == offset_of!(S, read_impl));
+    assert!(offset_of!(A, skip_to_impl) == offset_of!(S, skip_to_impl));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
+impl<'query, Rf: Ref, R, E> RawInvIndIterator<'query, Rf, R, E> {
+    /// Read the cached `last_doc_id` regardless of mode.
+    ///
+    /// `last_doc_id` is a plain `t_docId` field whose value survives the
+    /// suspend/resume transition unchanged. Composite iterators
+    /// (`Term`, `Numeric`, …, `Optional`, etc.) need this on the suspended
+    /// side to feed [`RQESuspendedIterator::last_doc_id`].
+    pub(crate) const fn last_doc_id_field(&self) -> DocId {
+        self.last_doc_id
+    }
+
+    /// Read the cached [`IndexFlags`] regardless of mode.
+    ///
+    /// Snapshotted at construction time from the reader's `flags()`. The
+    /// value is immutable for the iterator's lifetime; callers reading this
+    /// while suspended (e.g. FT.PROFILE introspection after the iterator has
+    /// transitioned to `Suspended`) get the same answer they would on
+    /// `Active`.
+    pub const fn flags(&self) -> IndexFlags {
+        self.flags
+    }
+
+    /// Read the cached unique-document count regardless of mode.
+    ///
+    /// Snapshotted at construction from `reader.unique_docs()`. Feeds
+    /// [`RQESuspendedIterator::num_estimated`] on the suspended side, where the
+    /// live reader is unavailable.
+    pub(crate) const fn num_docs_field(&self) -> u64 {
+        self.num_docs
+    }
+}
 
 impl<'index, R, E> InvIndIterator<'index, R, E>
 where
@@ -96,12 +179,17 @@ where
             Self::skip_to_default
         };
 
+        let flags = reader.flags();
+        let num_docs = reader.unique_docs();
+
         Self {
             reader,
             at_eos: false,
             last_doc_id: 0,
             result,
             expiration_checker,
+            flags,
+            num_docs,
             read_impl,
             skip_to_impl,
         }
@@ -358,5 +446,222 @@ where
 
     fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
         1.0
+    }
+}
+// ---- Suspend / Resume ------------------------------------------------------
+
+impl<'query, RS, E> RawInvIndIterator<'query, Suspended, RS, E>
+where
+    RS: ResumableReader,
+    E: ExpirationChecker + 'static,
+{
+    /// Refresh this iterator's reader-side pointers in place while still
+    /// in [`Suspended`] mode.
+    ///
+    /// Delegates to [`ResumableReader::refresh_pointers`] on the inner
+    /// reader. Returns whether the iterator's position is still usable as
+    /// a [`RefreshOutcome::Ok`], or whether the caller must rewind +
+    /// re-seek to `last_doc_id` after the cast to [`Active`]
+    /// ([`RefreshOutcome::NeedsReseek`]).
+    ///
+    /// # Why on the suspended form
+    ///
+    /// See [`ResumableReader::refresh_pointers`] for the full argument.
+    /// In short: doing the refresh on the suspended form avoids
+    /// materializing any `&'a` borrow of `self.reader.buf` before the
+    /// fresh pointer has been written — the `Box<Suspended>` →
+    /// `Box<Active<'a>>` cast happens only after every `Rf`-dependent
+    /// field is known to be valid.
+    pub(crate) fn refresh_pointers(&mut self, _guard: &IndexSpecReadGuard<'_>) -> RefreshOutcome {
+        // SAFETY: the caller proves the spec read lock is held by passing
+        // `_guard` — a witness that C holds the read lock (the only way to obtain
+        // an `IndexSpecReadGuard`). `ResumableReader::refresh_pointers` requires
+        // exactly that lock while it dereferences the reader's raw index pointer.
+        unsafe { self.reader.refresh_pointers() }
+    }
+}
+
+impl<'index, R, E> InvIndIterator<'index, R, E>
+where
+    R: IndexReader<'index>,
+    E: ExpirationChecker,
+{
+    /// Re-seek the iterator to its previous `last_doc_id` after a GC
+    /// cycle invalidated the cached block offset.
+    ///
+    /// Called from [`RQESuspendedIterator::resume`] on the active side,
+    /// after [`RawInvIndIterator::refresh_pointers`] reported
+    /// [`RefreshOutcome::NeedsReseek`]. Translates the
+    /// [`SkipToOutcome`] returned by [`skip_to`](Self::skip_to) into a
+    /// [`ValidateStatus`].
+    ///
+    /// The `last_doc_id` parameter is the value reported by
+    /// `refresh_pointers` (the reader's decoder base) and is ignored —
+    /// it can be non-zero on a freshly-constructed reader before any
+    /// reads happen, which would cause a spurious reseek. We use
+    /// [`Self::last_doc_id_field`] instead (the iterator's tracked
+    /// "position of the most recent read", 0 if no reads have happened).
+    ///
+    /// # Outcome mapping
+    ///
+    /// - [`SkipToOutcome::Found`] → `VALIDATE_OK` (same logical position).
+    /// - [`SkipToOutcome::NotFound`] or EOF → `VALIDATE_MOVED` (the
+    ///   previous `last_doc_id` no longer exists; the iterator has
+    ///   advanced past it).
+    /// - `skip_to` decode/I/O error → `VALIDATE_ABORTED`. A decode error means
+    ///   the re-seek hit a corrupted/malformed block, leaving the reader in a
+    ///   partially-updated state; rather than hand back a live iterator whose
+    ///   `current()` may be bogus, we abort (matching the legacy `revalidate`
+    ///   path, which propagated the error so the FFI wrapper aborts).
+    pub(crate) fn reseek_after_refresh(&mut self, _last_doc_id: DocId) -> ValidateStatus {
+        let target_doc_id = self.last_doc_id;
+        self.rewind();
+
+        if target_doc_id == 0 {
+            // We hadn't returned anything yet, so there's nothing to
+            // re-seek; a fresh `read()` will produce the right next doc.
+            return ValidateStatus_VALIDATE_OK;
+        }
+
+        match self.skip_to(target_doc_id) {
+            Ok(Some(SkipToOutcome::Found(_))) => ValidateStatus_VALIDATE_OK,
+            Ok(Some(SkipToOutcome::NotFound(_))) | Ok(None) => ValidateStatus_VALIDATE_MOVED,
+            Err(_) => ValidateStatus_VALIDATE_ABORTED,
+        }
+    }
+}
+
+impl<'index, R, E> RQEIteratorBoxed<'index> for InvIndIterator<'index, R, E>
+where
+    R: IndexReader<'index> + SuspendableReader + 'index,
+    R::Suspended: ResumableReader,
+    E: ExpirationChecker + 'static,
+{
+    type Suspended = RawInvIndIterator<'index, Suspended, R::Suspended, E>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        // Reuse the same allocation so external pointers into the iterator
+        // interior (composite aggregate results) stay valid across the cycle.
+        let active: *mut Self = Box::into_raw(self);
+
+        // SAFETY: `active` just came from a `Box`, so it is non-null, aligned,
+        // initialized, and unaliased (we own it). `&raw mut` forms a field
+        // pointer without creating a reference, leaving provenance over the
+        // whole allocation intact for the cast below.
+        let result_slot = unsafe { &raw mut (*active).result };
+        // SAFETY: `result_slot` points at an initialized `RSIndexResult<'index>`
+        // and is unaliased. Suspending only loosens validity, so there is no
+        // further precondition. Converting the `Rf`-carrying `result` field
+        // through the canonical in-place conversion — rather than folding it
+        // into the blanket struct reinterpretation below — keeps the
+        // borrowed-data transition explicit and auditable.
+        unsafe { RawIndexResult::<Active<'index>>::into_suspended_in_place(result_slot) };
+
+        // SAFETY: `result` is now the suspended form; the remaining `Rf`-dependent
+        // fields (`reader`, the `fn` pointers) are handled by reinterpreting the
+        // whole `#[repr(C)]` struct, which is sound by invariant 1 on
+        // `RawInvIndIterator` (const proof above) given invariant 1 on the reader
+        // `R`. `Box::from_raw` reuses the same allocation, so the box address is
+        // preserved.
+        unsafe {
+            Box::from_raw(active.cast::<RawInvIndIterator<'index, Suspended, R::Suspended, E>>())
+        }
+    }
+}
+
+impl<'query, RS, E> RQESuspendedIterator<'query> for RawInvIndIterator<'query, Suspended, RS, E>
+where
+    RS: ResumableReader,
+    E: ExpirationChecker + 'static,
+{
+    type Resumed<'a>
+        = InvIndIterator<'a, RS::Resumed<'a>, E>
+    where
+        'query: 'a;
+
+    /// # Precondition
+    ///
+    /// This core resume refreshes the reader's pointers (dereferencing the
+    /// stored index pointer via [`refresh_pointers`](RawInvIndIterator::refresh_pointers))
+    /// without performing an index-identity check of its own. It assumes the
+    /// caller — a leaf wrapper's `resume` (`Term`/`Tag`/`Missing`/`Wildcard`/
+    /// `Numeric`), which runs its `should_abort` identity check *first* — has
+    /// already established that the underlying inverted index is still live
+    /// (not freed or replaced by GC while suspended). The bare-core iterator is
+    /// not resumed directly in production.
+    fn resume<'a>(
+        mut self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Step 1: refresh reader pointers *on the suspended form*. This
+        // never materializes a `&'a` borrow of any potentially-dangling
+        // field — the `Box<Suspended>` → `Box<Active<'a>>` conversion happens
+        // afterwards, only once every `Rf`-dependent field is valid. Passing
+        // `guard` proves the spec read lock is held for the pointer refresh.
+        let outcome = self.refresh_pointers(guard);
+
+        // Step 2: convert Suspended → Active in place. The heap allocation is
+        // preserved, so external pointers into this iterator's interior
+        // (composite aggregate results) stay valid across the cycle.
+        let suspended: *mut Self = Box::into_raw(self);
+
+        // SAFETY: `suspended` just came from a `Box`, so it is non-null, aligned,
+        // initialized, and unaliased (we own it). `&raw mut` forms a field
+        // pointer without creating a reference, leaving provenance over the
+        // whole allocation intact for the cast below.
+        let result_slot = unsafe { &raw mut (*suspended).result };
+        // SAFETY: `into_active_in_place`'s preconditions for `'a` hold — the
+        // caller's read lock (witnessed by `_guard`) plus the `refresh_pointers`
+        // call above ensure every index-backed pointer inside `result` is
+        // dereferenceable for `'a`; `result_slot` is initialized and unaliased.
+        // Converting the `Rf`-carrying `result` field through the canonical
+        // in-place conversion keeps the borrowed-data transition explicit.
+        unsafe { RawIndexResult::<'query, Suspended>::into_active_in_place::<'a>(result_slot) };
+
+        // SAFETY: `result` is now the active form; the remaining `Rf`-dependent
+        // fields (`reader`, the `fn` pointers) are handled by reinterpreting the
+        // whole `#[repr(C)]` struct, which is sound by invariant 1 on
+        // `RawInvIndIterator` (const proof above) given invariant 1 on the reader
+        // `RS`. `Box::from_raw` reuses the same allocation, so the box address is
+        // preserved.
+        let mut active = unsafe {
+            Box::from_raw(suspended.cast::<InvIndIterator<'a, RS::Resumed<'a>, E>>())
+        };
+
+        // Step 3: if GC ran while we were suspended, the cached block
+        // offset is stale even though the buffer pointer was refreshed.
+        // Rewind and re-seek to the last doc id.
+        let status = match outcome {
+            RefreshOutcome::Ok => ValidateStatus_VALIDATE_OK,
+            RefreshOutcome::NeedsReseek { last_doc_id } => active.reseek_after_refresh(last_doc_id),
+        };
+
+        // Map the re-seek status to a resume outcome. A decode error during the
+        // re-seek yields `VALIDATE_ABORTED` (see `reseek_after_refresh`): the
+        // block is corrupted, so drop the active iterator rather than hand back a
+        // bogus `current()`.
+        Ok(if status == ValidateStatus_VALIDATE_ABORTED {
+            drop(active);
+            ResumeOutcome::Aborted
+        } else if status == ValidateStatus_VALIDATE_MOVED {
+            ResumeOutcome::Moved(active)
+        } else {
+            ResumeOutcome::Ok(active)
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.last_doc_id_field()
+    }
+
+    fn num_estimated(&self) -> usize {
+        // The live reader's `unique_docs()` is unavailable once weakened, so we
+        // return the snapshot cached at construction (see `num_docs`). This
+        // matches the active `num_estimated` and keeps FT.PROFILE introspection
+        // of a suspended iterator meaningful.
+        self.num_docs_field() as usize
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -7,11 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use ffi::{
-    IndexFlags, ValidateStatus, ValidateStatus_VALIDATE_ABORTED, ValidateStatus_VALIDATE_MOVED,
-    ValidateStatus_VALIDATE_OK,
-};
-use index_result::{RSIndexResult, RawIndexResult};
+use ffi::IndexFlags;
+use index_result::{RSIndexResult, RawIndexResult, RawOffsetSlice, RawTermRecord};
 use index_spec::IndexSpecReadGuard;
 use inverted_index::{IndexReader, RefreshOutcome, ResumableReader, SuspendableReader};
 use ref_mode::{Active, Ref, Suspended};
@@ -107,8 +104,12 @@ const _: () = {
     use inverted_index::{RawIndexReaderCore, doc_ids_only::DocIdsOnly};
     use std::mem::{align_of, offset_of, size_of};
     type A = InvIndIterator<'static, RawIndexReaderCore<Active<'static>, DocIdsOnly>, NoOpChecker>;
-    type S =
-        RawInvIndIterator<'static, Suspended, RawIndexReaderCore<Suspended, DocIdsOnly>, NoOpChecker>;
+    type S = RawInvIndIterator<
+        'static,
+        Suspended,
+        RawIndexReaderCore<Suspended, DocIdsOnly>,
+        NoOpChecker,
+    >;
     assert!(offset_of!(A, reader) == offset_of!(S, reader));
     assert!(offset_of!(A, at_eos) == offset_of!(S, at_eos));
     assert!(offset_of!(A, last_doc_id) == offset_of!(S, last_doc_id));
@@ -416,18 +417,18 @@ where
             return Ok(RQEValidateStatus::Ok);
         }
 
-        // if there has been a GC cycle on this key while we were asleep, the offset might not be valid
+        // If there has been a GC cycle on this key while we were suspended, the offset might not be valid
         // anymore. This means that we need to seek the last docId we were at
         let last_doc_id = self.last_doc_id();
-        // reset the state of the reader
+        // Reset the state of the reader
         self.rewind();
 
         if last_doc_id == 0 {
-            // Cannot skip to 0
+            // No need to skip if we're starting from the very beginning.
             return Ok(RQEValidateStatus::Ok);
         }
 
-        // try restoring the last docId
+        // Try jumping to the last docId
         let res = match self.skip_to(last_doc_id)? {
             Some(SkipToOutcome::Found(_)) => RQEValidateStatus::Ok,
             Some(SkipToOutcome::NotFound(doc)) => RQEValidateStatus::Moved { current: Some(doc) },
@@ -478,56 +479,6 @@ where
         // an `IndexSpecReadGuard`). `ResumableReader::refresh_pointers` requires
         // exactly that lock while it dereferences the reader's raw index pointer.
         unsafe { self.reader.refresh_pointers() }
-    }
-}
-
-impl<'index, R, E> InvIndIterator<'index, R, E>
-where
-    R: IndexReader<'index>,
-    E: ExpirationChecker,
-{
-    /// Re-seek the iterator to its previous `last_doc_id` after a GC
-    /// cycle invalidated the cached block offset.
-    ///
-    /// Called from [`RQESuspendedIterator::resume`] on the active side,
-    /// after [`RawInvIndIterator::refresh_pointers`] reported
-    /// [`RefreshOutcome::NeedsReseek`]. Translates the
-    /// [`SkipToOutcome`] returned by [`skip_to`](Self::skip_to) into a
-    /// [`ValidateStatus`].
-    ///
-    /// The `last_doc_id` parameter is the value reported by
-    /// `refresh_pointers` (the reader's decoder base) and is ignored —
-    /// it can be non-zero on a freshly-constructed reader before any
-    /// reads happen, which would cause a spurious reseek. We use
-    /// [`Self::last_doc_id_field`] instead (the iterator's tracked
-    /// "position of the most recent read", 0 if no reads have happened).
-    ///
-    /// # Outcome mapping
-    ///
-    /// - [`SkipToOutcome::Found`] → `VALIDATE_OK` (same logical position).
-    /// - [`SkipToOutcome::NotFound`] or EOF → `VALIDATE_MOVED` (the
-    ///   previous `last_doc_id` no longer exists; the iterator has
-    ///   advanced past it).
-    /// - `skip_to` decode/I/O error → `VALIDATE_ABORTED`. A decode error means
-    ///   the re-seek hit a corrupted/malformed block, leaving the reader in a
-    ///   partially-updated state; rather than hand back a live iterator whose
-    ///   `current()` may be bogus, we abort (matching the legacy `revalidate`
-    ///   path, which propagated the error so the FFI wrapper aborts).
-    pub(crate) fn reseek_after_refresh(&mut self, _last_doc_id: DocId) -> ValidateStatus {
-        let target_doc_id = self.last_doc_id;
-        self.rewind();
-
-        if target_doc_id == 0 {
-            // We hadn't returned anything yet, so there's nothing to
-            // re-seek; a fresh `read()` will produce the right next doc.
-            return ValidateStatus_VALIDATE_OK;
-        }
-
-        match self.skip_to(target_doc_id) {
-            Ok(Some(SkipToOutcome::Found(_))) => ValidateStatus_VALIDATE_OK,
-            Ok(Some(SkipToOutcome::NotFound(_))) | Ok(None) => ValidateStatus_VALIDATE_MOVED,
-            Err(_) => ValidateStatus_VALIDATE_ABORTED,
-        }
     }
 }
 
@@ -596,12 +547,31 @@ where
     where
         'query: 'a,
     {
+        // If there has been a GC cycle on this key while we were suspended, the offset might not be valid
+        // anymore. This means that we need to seek the last docId we were at.
+        let last_doc_id = self.last_doc_id();
+
         // Step 1: refresh reader pointers *on the suspended form*. This
         // never materializes a `&'a` borrow of any potentially-dangling
         // field — the `Box<Suspended>` → `Box<Active<'a>>` conversion happens
         // afterwards, only once every `Rf`-dependent field is valid. Passing
         // `guard` proves the spec read lock is held for the pointer refresh.
         let outcome = self.refresh_pointers(guard);
+
+        // Whatever offsets we borrowed from the index may be stale.
+        // To make promotion from suspended to active safe, we unset them.
+        if let RefreshOutcome::NeedsReseek { .. } = outcome
+            && let Some(term) = self.result.as_term_mut()
+        {
+            match term {
+                RawTermRecord::Borrowed { offsets, .. } => {
+                    *offsets = RawOffsetSlice::empty();
+                }
+                RawTermRecord::Owned { .. } | RawTermRecord::FullyOwned { .. } => {
+                    // These variants own their offsets, so no issues.
+                }
+            }
+        }
 
         // Step 2: convert Suspended → Active in place. The heap allocation is
         // preserved, so external pointers into this iterator's interior
@@ -627,30 +597,34 @@ where
         // `RawInvIndIterator` (const proof above) given invariant 1 on the reader
         // `RS`. `Box::from_raw` reuses the same allocation, so the box address is
         // preserved.
-        let mut active = unsafe {
-            Box::from_raw(suspended.cast::<InvIndIterator<'a, RS::Resumed<'a>, E>>())
-        };
+        let mut active =
+            unsafe { Box::from_raw(suspended.cast::<InvIndIterator<'a, RS::Resumed<'a>, E>>()) };
 
         // Step 3: if GC ran while we were suspended, the cached block
         // offset is stale even though the buffer pointer was refreshed.
         // Rewind and re-seek to the last doc id.
-        let status = match outcome {
-            RefreshOutcome::Ok => ValidateStatus_VALIDATE_OK,
-            RefreshOutcome::NeedsReseek { last_doc_id } => active.reseek_after_refresh(last_doc_id),
-        };
+        match outcome {
+            RefreshOutcome::Ok => Ok(ResumeOutcome::Ok(active)),
+            // We use the last doc id yielded by the iterator, rather than the reader state,
+            // since the reader initializes this field to the first block's first_doc_id
+            // before any result has been returned, so if GC or a moved block buffer occurs
+            // while a freshly-created iterator is suspended, resume will reseek to that first doc
+            // and report Ok, causing the next read() to skip the first result.
+            RefreshOutcome::NeedsReseek { .. } => {
+                active.rewind();
 
-        // Map the re-seek status to a resume outcome. A decode error during the
-        // re-seek yields `VALIDATE_ABORTED` (see `reseek_after_refresh`): the
-        // block is corrupted, so drop the active iterator rather than hand back a
-        // bogus `current()`.
-        Ok(if status == ValidateStatus_VALIDATE_ABORTED {
-            drop(active);
-            ResumeOutcome::Aborted
-        } else if status == ValidateStatus_VALIDATE_MOVED {
-            ResumeOutcome::Moved(active)
-        } else {
-            ResumeOutcome::Ok(active)
-        })
+                if last_doc_id == 0 {
+                    // We hadn't returned anything yet, so there's nothing to
+                    // re-seek; a fresh `read()` will produce the right next doc.
+                    return Ok(ResumeOutcome::Ok(active));
+                }
+
+                match active.skip_to(last_doc_id)? {
+                    Some(SkipToOutcome::Found(_)) => Ok(ResumeOutcome::Ok(active)),
+                    Some(SkipToOutcome::NotFound(_)) | None => Ok(ResumeOutcome::Moved(active)),
+                }
+            }
+        }
     }
 
     fn last_doc_id(&self) -> DocId {

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -16,7 +16,7 @@ use rqe_core::DocId;
 
 use crate::{
     IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
-    RQEValidateStatus, ResumeOutcome, SkipToOutcome, SkipToOutcomeRaw,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
     expiration_checker::{ExpirationChecker, NoOpChecker},
 };
 
@@ -35,20 +35,29 @@ use crate::{
 ///    layout-identical, which is what lets `suspend`/`resume` reinterpret the
 ///    `Box` in place. This holds because the struct is `#[repr(C)]` and every
 ///    `Rf`-dependent field is layout-stable across modes: `result` is a
-///    [`RawIndexResult`] (proven layout-compatible
-///    in `index_result`), `reader: R` is covered by its own invariant, and the
-///    `read_impl`/`skip_to_impl` fields are `fn` pointers (pointer-sized in every
-///    mode). Enforced, for a representative reader, by the `const _` proof below.
+///    [`RawIndexResult`] (proven layout-compatible in `index_result`) and
+///    `reader: R` is covered by its own invariant. The `read_impl`/`skip_to_impl`
+///    fn-pointer fields are frozen at the mode-independent reader parameter `RA`
+///    (see below), so they are the *same type* in every mode — the cast does not
+///    reinterpret them at all. Enforced, for a representative reader, by the
+///    `const _` proof below.
 ///
 /// # Type Parameters
 ///
 /// * `Rf` - The [`Ref`] mode: [`Active<'a>`] gives the iterator working,
 ///   readable references into the index; [`Suspended`]
 ///   produces a passive carrier with no callable surface.
-/// * `R` - The reader type used to read the inverted index.
+/// * `R` - The reader type used to read the inverted index. Weakens to
+///   `R::Suspended` when the iterator is suspended.
 /// * `E` - The expiration checker type used to check for expired documents.
+/// * `RA` - The **active** reader type the `read_impl`/`skip_to_impl` dispatch
+///   pointers are compiled for. Defaults to `R` (the active instantiation) and,
+///   unlike `R`, is **not** remapped on suspend — so those fn-pointer fields keep
+///   an identical type across the `Active`/`Suspended` cast. It only appears
+///   inside the `fn`-pointer field types (which take `&mut InvIndIterator`), so a
+///   suspended carrier cannot invoke them.
 #[repr(C)]
-pub struct RawInvIndIterator<'query, Rf: Ref, R, E = NoOpChecker> {
+pub struct RawInvIndIterator<'query, Rf: Ref, R, E = NoOpChecker, RA = R> {
     /// The reader used to iterate over the inverted index.
     pub(super) reader: R,
     /// if we reached the end of the index.
@@ -80,21 +89,36 @@ pub struct RawInvIndIterator<'query, Rf: Ref, R, E = NoOpChecker> {
     /// The implementation of the [`read`](RQEIterator::read) method.
     /// Using dynamic dispatch so we can pick the right version during the
     /// iterator construction saving to re-do the checks each time [`read()`](RQEIterator::read) is called.
-    read_impl: fn(&mut Self) -> Result<Option<&mut RawIndexResult<'query, Rf>>, RQEIteratorError>,
+    ///
+    /// Typed over the frozen active reader `RA` (not `Self`/`Rf`), so the field
+    /// keeps an identical type across the suspend/resume cast and can only be
+    /// invoked on the active form.
+    read_impl: ReadImpl<'query, RA, E>,
     /// The implementation of the [`skip_to`](RQEIterator::skip_to) method.
-    #[expect(
-        clippy::type_complexity,
-        reason = "Specialised fn pointer parameterised by Rf — extracting it to a type alias \
-                  would hide the Rf dependency that drives transmute soundness across modes."
-    )]
-    skip_to_impl:
-        fn(&mut Self, DocId) -> Result<Option<SkipToOutcomeRaw<'_, 'query, Rf>>, RQEIteratorError>,
+    /// Typed over the frozen active reader `RA` — see [`Self::read_impl`].
+    skip_to_impl: SkipToImpl<'query, RA, E>,
 }
+
+/// Dispatch pointer backing [`RQEIterator::read`], frozen at the active reader
+/// `RA` (see [`RawInvIndIterator`]'s type parameters) so it is layout-stable
+/// across the suspend/resume cast.
+type ReadImpl<'query, RA, E> =
+    for<'s> fn(
+        &'s mut InvIndIterator<'query, RA, E>,
+    ) -> Result<Option<&'s mut RSIndexResult<'query>>, RQEIteratorError>;
+
+/// Dispatch pointer backing [`RQEIterator::skip_to`], frozen at the active
+/// reader `RA` — see [`ReadImpl`].
+type SkipToImpl<'query, RA, E> =
+    for<'s> fn(
+        &'s mut InvIndIterator<'query, RA, E>,
+        DocId,
+    ) -> Result<Option<SkipToOutcome<'s, 'query>>, RQEIteratorError>;
 
 /// Alias for an [`Active`] [`RawInvIndIterator`] — the only instantiation
 /// with an [`RQEIterator`] impl today.
 pub type InvIndIterator<'index, R, E = NoOpChecker> =
-    RawInvIndIterator<'index, Active<'index>, R, E>;
+    RawInvIndIterator<'index, Active<'index>, R, E, R>;
 
 // Compile-time proof of invariant 1 on `RawInvIndIterator`: for a representative
 // concrete reader, the `Active` and `Suspended` instantiations are
@@ -104,11 +128,15 @@ const _: () = {
     use inverted_index::{RawIndexReaderCore, doc_ids_only::DocIdsOnly};
     use std::mem::{align_of, offset_of, size_of};
     type A = InvIndIterator<'static, RawIndexReaderCore<Active<'static>, DocIdsOnly>, NoOpChecker>;
+    // `S` mirrors the suspended form: the reader slot weakens to the `Suspended`
+    // reader, but the frozen `RA` slot stays the *active* reader (matching `A`),
+    // so `read_impl`/`skip_to_impl` are the same type in `A` and `S`.
     type S = RawInvIndIterator<
         'static,
         Suspended,
         RawIndexReaderCore<Suspended, DocIdsOnly>,
         NoOpChecker,
+        RawIndexReaderCore<Active<'static>, DocIdsOnly>,
     >;
     assert!(offset_of!(A, reader) == offset_of!(S, reader));
     assert!(offset_of!(A, at_eos) == offset_of!(S, at_eos));
@@ -123,7 +151,7 @@ const _: () = {
     assert!(align_of::<A>() == align_of::<S>());
 };
 
-impl<'query, Rf: Ref, R, E> RawInvIndIterator<'query, Rf, R, E> {
+impl<'query, Rf: Ref, R, E, RA> RawInvIndIterator<'query, Rf, R, E, RA> {
     /// Read the cached `last_doc_id` regardless of mode.
     ///
     /// `last_doc_id` is a plain `t_docId` field whose value survives the
@@ -451,7 +479,7 @@ where
 }
 // ---- Suspend / Resume ------------------------------------------------------
 
-impl<'query, RS, E> RawInvIndIterator<'query, Suspended, RS, E>
+impl<'query, RS, E, RA> RawInvIndIterator<'query, Suspended, RS, E, RA>
 where
     RS: ResumableReader,
     E: ExpirationChecker + 'static,
@@ -488,7 +516,9 @@ where
     R::Suspended: ResumableReader,
     E: ExpirationChecker + 'static,
 {
-    type Suspended = RawInvIndIterator<'index, Suspended, R::Suspended, E>;
+    // Reader weakens `R -> R::Suspended`, but the frozen `RA` slot stays `R` (the
+    // active reader), so `read_impl`/`skip_to_impl` keep an identical type.
+    type Suspended = RawInvIndIterator<'index, Suspended, R::Suspended, E, R>;
 
     fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
         // Reuse the same allocation so external pointers into the iterator
@@ -508,19 +538,21 @@ where
         // borrowed-data transition explicit and auditable.
         unsafe { RawIndexResult::<Active<'index>>::into_suspended_in_place(result_slot) };
 
-        // SAFETY: `result` is now the suspended form; the remaining `Rf`-dependent
-        // fields (`reader`, the `fn` pointers) are handled by reinterpreting the
-        // whole `#[repr(C)]` struct, which is sound by invariant 1 on
-        // `RawInvIndIterator` (const proof above) given invariant 1 on the reader
-        // `R`. `Box::from_raw` reuses the same allocation, so the box address is
+        // SAFETY: `result` is now the suspended form; the only other `Rf`-dependent
+        // field, `reader`, is reinterpreted `R -> R::Suspended` — sound by
+        // invariant 1 on `RawInvIndIterator` (const proof above) given invariant 1
+        // on the reader `R`. The `read_impl`/`skip_to_impl` fn-pointer fields are
+        // frozen at `RA = R` and so are *not* reinterpreted by this cast at all.
+        // `Box::from_raw` reuses the same allocation, so the box address is
         // preserved.
         unsafe {
-            Box::from_raw(active.cast::<RawInvIndIterator<'index, Suspended, R::Suspended, E>>())
+            Box::from_raw(active.cast::<RawInvIndIterator<'index, Suspended, R::Suspended, E, R>>())
         }
     }
 }
 
-impl<'query, RS, E> RQESuspendedIterator<'query> for RawInvIndIterator<'query, Suspended, RS, E>
+impl<'query, RS, E, RA> RQESuspendedIterator<'query>
+    for RawInvIndIterator<'query, Suspended, RS, E, RA>
 where
     RS: ResumableReader,
     E: ExpirationChecker + 'static,
@@ -591,12 +623,15 @@ where
         // in-place conversion keeps the borrowed-data transition explicit.
         unsafe { RawIndexResult::<'query, Suspended>::into_active_in_place::<'a>(result_slot) };
 
-        // SAFETY: `result` is now the active form; the remaining `Rf`-dependent
-        // fields (`reader`, the `fn` pointers) are handled by reinterpreting the
-        // whole `#[repr(C)]` struct, which is sound by invariant 1 on
-        // `RawInvIndIterator` (const proof above) given invariant 1 on the reader
-        // `RS`. `Box::from_raw` reuses the same allocation, so the box address is
-        // preserved.
+        // SAFETY: `result` is now the active form; the only other `Rf`-dependent
+        // field, `reader`, is reinterpreted `RS -> RS::Resumed<'a>` — sound by
+        // invariant 1 on `RawInvIndIterator` (const proof above) given invariant 1
+        // on the reader `RS`. The `read_impl`/`skip_to_impl` fn-pointer fields are
+        // frozen at the active reader `RA`; the cast changes that slot only by
+        // lifetime (`RA` -> `RS::Resumed<'a>`, the same reader type modulo
+        // lifetime, which is erased in codegen), never across the Active/Suspended
+        // boundary or a genuinely different reader type. `Box::from_raw` reuses the
+        // same allocation, so the box address is preserved.
         let mut active =
             unsafe { Box::from_raw(suspended.cast::<InvIndIterator<'a, RS::Resumed<'a>, E>>()) };
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -560,7 +560,7 @@ where
 
         // Whatever offsets we borrowed from the index may be stale.
         // To make promotion from suspended to active safe, we unset them.
-        if let RefreshOutcome::NeedsReseek { .. } = outcome
+        if outcome == RefreshOutcome::NeedsReseek
             && let Some(term) = self.result.as_term_mut()
         {
             match term {
@@ -610,7 +610,7 @@ where
             // before any result has been returned, so if GC or a moved block buffer occurs
             // while a freshly-created iterator is suspended, resume will reseek to that first doc
             // and report Ok, causing the next read() to skip the first result.
-            RefreshOutcome::NeedsReseek { .. } => {
+            RefreshOutcome::NeedsReseek => {
                 active.rewind();
 
                 if last_doc_id == 0 {


### PR DESCRIPTION
## Describe the changes in the pull request

Introduce the shared inverted-index leaf core for iterator revalidation:
`RawInvIndIterator` gains its `RQEIteratorBoxed` + `RQESuspendedIterator`
implementation (the suspend/resume mechanism), along with the reader-layer
refresh plumbing it relies on.

This is the foundation the four leaf iterators (Term, Tag, Missing, Wildcard)
delegate to; those land in the stacked follow-up PR, together with the resume
tests that exercise this core path. This PR is therefore infra-only and ships
without new tests of its own by design.

#### Main objects this PR modified
- `RawInvIndIterator` (shared core suspend/resume + reader refresh)
- `inverted_index` reader layer (`core`, `mod`, `field_mask`, `geo`, `numeric`)
- `iterators_ffi` term FFI

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

Stacked on #10274.
