### PR TITLE
MOD-16121 MOD-16891: Restore FT.HYBRID COMBINE YIELD_SCORE_AS counted syntax

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2412,6 +2412,12 @@
                     "type": "integer",
                     "token": "WINDOW",
                     "optional": true
+                  },
+                  {
+                    "name": "yield_score_as",
+                    "type": "string",
+                    "token": "YIELD_SCORE_AS",
+                    "optional": true
                   }
                 ]
               },
@@ -2450,16 +2456,16 @@
                     "type": "integer",
                     "token": "WINDOW",
                     "optional": true
+                  },
+                  {
+                    "name": "yield_score_as",
+                    "type": "string",
+                    "token": "YIELD_SCORE_AS",
+                    "optional": true
                   }
                 ]
               }
             ]
-          },
-          {
-            "name": "yield_score_as",
-            "type": "string",
-            "token": "YIELD_SCORE_AS",
-            "optional": true
           }
         ]
       },

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -2631,6 +2631,12 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
                     .type = REDISMODULE_ARG_TYPE_INTEGER,
                     .flags = REDISMODULE_CMD_ARG_OPTIONAL,
                   },
+                  {
+                    .name = "yield_score_as",
+                    .token = "YIELD_SCORE_AS",
+                    .type = REDISMODULE_ARG_TYPE_STRING,
+                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                  },
                   {0}
                 },
               },
@@ -2671,17 +2677,17 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
                     .type = REDISMODULE_ARG_TYPE_INTEGER,
                     .flags = REDISMODULE_CMD_ARG_OPTIONAL,
                   },
+                  {
+                    .name = "yield_score_as",
+                    .token = "YIELD_SCORE_AS",
+                    .type = REDISMODULE_ARG_TYPE_STRING,
+                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                  },
                   {0}
                 },
               },
               {0}
             },
-          },
-          {
-            .name = "yield_score_as",
-            .token = "YIELD_SCORE_AS",
-            .type = REDISMODULE_ARG_TYPE_STRING,
-            .flags = REDISMODULE_CMD_ARG_OPTIONAL,
           },
           {0}
         },

--- a/src/hybrid/parse/hybrid_combine.c
+++ b/src/hybrid/parse/hybrid_combine.c
@@ -24,6 +24,9 @@ static inline bool getVarArgsForClause(ArgsCursor* ac, ArgsCursor* target, const
   } else if (rc != AC_OK) {
     QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid %s argument count, error: %s", clause, AC_Strerror(rc));
     return false;
+  } else if (count == 0) {
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Explicitly specifying %s requires at least one argument, argument count must be positive", clause);
+    return false;
   } else if (count % 2 != 0) {
     QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "%s expects pairs of key value arguments, argument count must be an even number", clause);
     return false;
@@ -40,7 +43,7 @@ static inline bool getVarArgsForClause(ArgsCursor* ac, ArgsCursor* target, const
   return true;
 }
 
-static void parseLinearClause(ArgsCursor *ac, HybridLinearContext *linearCtx, QueryError *status) {
+static void parseLinearClause(ArgsCursor *ac, HybridLinearContext *linearCtx, RSSearchOptions* searchOpts, QueryError *status) {
   // LINEAR 4 ALPHA 0.1 BETA 0.9 ...
   //        ^
 
@@ -63,6 +66,7 @@ static void parseLinearClause(ArgsCursor *ac, HybridLinearContext *linearCtx, Qu
   // Define the required arguments
   ArgParser_AddDouble(parser, "ALPHA", "Alpha weight value", &alphaValue);
   ArgParser_AddDouble(parser, "BETA", "Beta weight value", &betaValue);
+  ArgParser_AddString(parser, "YIELD_SCORE_AS", "Alias for the combined score", &searchOpts->scoreAlias);
 
   int windowValue = HYBRID_DEFAULT_WINDOW;
   ArgParser_AddIntV(parser, "WINDOW", "LINEAR window size (must be positive)",
@@ -99,7 +103,7 @@ static void parseLinearClause(ArgsCursor *ac, HybridLinearContext *linearCtx, Qu
   ArgParser_Free(parser);
 }
 
-static bool parseRRFArgs(ArgsCursor *ac, double *constant, int *window, bool *hasExplicitWindow, QueryError *status) {
+static bool parseRRFArgs(ArgsCursor *ac, double *constant, int *window, bool *hasExplicitWindow, RSSearchOptions* searchOpts, QueryError *status) {
   *hasExplicitWindow = false;
   ArgsCursor rrf = {0};
   if (!getVarArgsForClause(ac, &rrf, "RRF", status)) {
@@ -123,6 +127,7 @@ static bool parseRRFArgs(ArgsCursor *ac, double *constant, int *window, bool *ha
                     ARG_OPT_DEFAULT_INT, HYBRID_DEFAULT_WINDOW,
                     ARG_OPT_RANGE, 1LL, LLONG_MAX,
                     ARG_OPT_END);
+  ArgParser_AddString(parser, "YIELD_SCORE_AS", "Alias for the combined score", &searchOpts->scoreAlias);
 
   // Parse the arguments
   ArgParseResult result = ArgParser_Parse(parser);
@@ -137,26 +142,7 @@ static bool parseRRFArgs(ArgsCursor *ac, double *constant, int *window, bool *ha
 }
 
 
-// Parse the positional YIELD_SCORE_AS <alias> clause that may follow a COMBINE
-// method. The alias is applied to the merged (tail) score, so it is stored in
-// the tail search options rather than in either subquery.
-//   COMBINE RRF|LINEAR ... YIELD_SCORE_AS <alias>
-//                                         ^
-static void parseCombineYieldScoreClause(ArgsCursor *ac, HybridParseContext *ctx, QueryError *status) {
-  if (AC_IsAtEnd(ac)) {
-    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing argument value for YIELD_SCORE_AS");
-    return;
-  }
-  if (AC_GetString(ac, &ctx->searchopts->scoreAlias, NULL, 0) != AC_OK) {
-    QueryError_SetError(status, QUERY_ERROR_CODE_BAD_VAL, "Invalid YIELD_SCORE_AS value");
-    return;
-  }
-  // Mirror the SEARCH subquery path so the combined score is emitted as a field
-  // and applyRichResultsOptimization does not skip collecting it.
-  *ctx->reqFlags |= QEXEC_F_SEND_SCORES_AS_FIELD;
-}
-
-static void parseRRFClause(ArgsCursor *ac, HybridRRFContext *rrfCtx, QueryError *status) {
+static void parseRRFClause(ArgsCursor *ac, HybridRRFContext *rrfCtx, RSSearchOptions *searchOpts, QueryError *status) {
   // RRF 4 CONSTANT 6 WINDOW 20 ...
   //     ^
   // RRF LIMIT
@@ -166,7 +152,7 @@ static void parseRRFClause(ArgsCursor *ac, HybridRRFContext *rrfCtx, QueryError 
   int windowValue = HYBRID_DEFAULT_WINDOW;
   bool hasExplicitWindow = false;
 
-  if (!parseRRFArgs(ac, &constantValue, &windowValue, &hasExplicitWindow, status)) {
+  if (!parseRRFArgs(ac, &constantValue, &windowValue, &hasExplicitWindow, searchOpts, status)) {
     return;
   }
 
@@ -202,18 +188,8 @@ void handleCombine(ArgParser *parser, const void *value, void *user_data) {
   if (parsedScoringType == HYBRID_SCORING_LINEAR) {
     combineCtx->linearCtx.linearWeights = rm_calloc(numWeights, sizeof(double));
     combineCtx->linearCtx.numWeights = numWeights;
-    parseLinearClause(ac, &combineCtx->linearCtx, status);
+    parseLinearClause(ac, &combineCtx->linearCtx, ctx->searchopts, status);
   } else if (parsedScoringType == HYBRID_SCORING_RRF) {
-    parseRRFClause(ac, &combineCtx->rrfCtx, status);
-  }
-  if (QueryError_HasError(status)) {
-    return;
-  }
-
-  if (AC_AdvanceIfMatch(ac, "YIELD_SCORE_AS")) {
-    parseCombineYieldScoreClause(ac, ctx, status);
-    if (QueryError_HasError(status)) {
-      return;
-    }
+    parseRRFClause(ac, &combineCtx->rrfCtx, ctx->searchopts, status);
   }
 }

--- a/src/hybrid/parse/hybrid_optional_args.c
+++ b/src/hybrid/parse/hybrid_optional_args.c
@@ -202,6 +202,8 @@ int HybridParseOptionalArgs(HybridParseContext *ctx, ArgsCursor *ac, bool intern
                          ARG_OPT_CALLBACK, handleFilter, ctx,
                          ARG_OPT_END);
 
+    // TODO: Add YIELD_SCORE_AS support for score aliasing
+
     // Parse the arguments
     ArgParseResult parseResult = ArgParser_Parse(parser);
 

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -1320,11 +1320,9 @@ TEST_F(ParseHybridTest, testLoadInsufficientFields) {
 // ============================================================================
 
 TEST_F(ParseHybridTest, testCombineRRFWithoutArgument) {
-  // Test RANGE with missing YIELD_DISTANCE_AS value
+  // Test RANGE with missing YIELD_DISTANCE_AS value (early return before CheckEnd)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "COMBINE", "RRF", "0", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  parseCommand(args);
-  // Verify default scoring type is RRF
-  assertRRFScoringCtx(HYBRID_DEFAULT_RRF_CONSTANT, HYBRID_DEFAULT_WINDOW);
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Explicitly specifying RRF requires at least one argument, argument count must be positive");
 }
 
 TEST_F(ParseHybridTest, testCombineRRFWithOddArgumentCount) {

--- a/tests/pytests/test_hybrid_linear.py
+++ b/tests/pytests/test_hybrid_linear.py
@@ -72,7 +72,7 @@ def test_hybrid_linear_default_weights():
         'VSIM', '@embedding', '$BLOB',
             'KNN', '2', 'K', '10',
             'YIELD_SCORE_AS', 'v_score',
-        'COMBINE', 'LINEAR', '2', 'WINDOW', '10',
+        'COMBINE', 'LINEAR', '2',
             'YIELD_SCORE_AS', 'fused_score',
         'PARAMS', '2', 'BLOB', query_vector)
     results, _ = get_results_from_hybrid_response(response)
@@ -115,7 +115,7 @@ def test_hybrid_linear_explicit_weights():
         'VSIM', '@embedding', '$BLOB',
             'KNN', '2', 'K', '10',
             'YIELD_SCORE_AS', 'v_score',
-        'COMBINE', 'LINEAR', '4', 'ALPHA', alpha, 'BETA', beta,
+        'COMBINE', 'LINEAR', '6', 'ALPHA', alpha, 'BETA', beta,
             'YIELD_SCORE_AS', 'fused_score',
         'PARAMS', '2', 'BLOB', query_vector)
     results, _ = get_results_from_hybrid_response(response)

--- a/tests/pytests/test_hybrid_load.py
+++ b/tests/pytests/test_hybrid_load.py
@@ -182,7 +182,7 @@ def test_load_all_docs_and_yield():
                 'YIELD_SCORE_AS', 'search_score',
             'VSIM', '@vector', '$BLOB',
                 'YIELD_SCORE_AS', 'vector_score',
-            'COMBINE', 'LINEAR', '4', 'ALPHA', 0.3, 'BETA', 0.7,
+            'COMBINE', 'LINEAR', '6', 'ALPHA', 0.3, 'BETA', 0.7,
                 'YIELD_SCORE_AS', 'fused_score',
             'LOAD', '*',
             'PARAMS', '2', 'BLOB', QUERY_VECTOR,

--- a/tests/pytests/test_hybrid_yield.py
+++ b/tests/pytests/test_hybrid_yield.py
@@ -229,8 +229,7 @@ def test_hybrid_search_yield_score_as_after_combine():
     # YIELD_SCORE_AS after COMBINE should work
     response = env.cmd(
         'FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', '$BLOB',
-        'COMBINE', 'RRF', '2', 'CONSTANT', '60',
-            'YIELD_SCORE_AS', 'search_score',
+        'COMBINE', 'RRF', '4', 'CONSTANT', '60', 'YIELD_SCORE_AS', 'search_score',
         'PARAMS', '2', 'BLOB', query_vector)
     results, _ = get_results_from_hybrid_response(response)
 
@@ -242,124 +241,6 @@ def test_hybrid_search_yield_score_as_after_combine():
         env.assertTrue('search_score' in doc_result)
         search_score = float(doc_result['search_score'])
         env.assertGreater(search_score, 0)
-
-def test_hybrid_combine_yield_score_as_is_positional():
-    """YIELD_SCORE_AS is positional after the COMBINE method clause and must not
-    be counted in the method argument count."""
-    env = Env()
-    setup_basic_index(env)
-    query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
-
-    env.expect(
-        'FT.HYBRID', 'idx',
-        'SEARCH', 'shoes',
-        'VSIM', '@embedding', '$BLOB',
-        'COMBINE', 'RRF', '4', 'CONSTANT', '60', 'YIELD_SCORE_AS', 'search_score',
-        'PARAMS', '2', 'BLOB', query_vector)\
-            .error().contains('YIELD_SCORE_AS: Unknown argument')
-
-def test_hybrid_combine_duplicate_yield_score_as_error():
-    """A duplicate YIELD_SCORE_AS after the COMBINE clause is rejected."""
-    env = Env()
-    setup_basic_index(env)
-    query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
-
-    env.expect(
-        'FT.HYBRID', 'idx',
-        'SEARCH', 'shoes',
-        'VSIM', '@embedding', '$BLOB',
-        'COMBINE', 'RRF', '2', 'CONSTANT', '60',
-            'YIELD_SCORE_AS', 'score1',
-            'YIELD_SCORE_AS', 'score2',
-        'PARAMS', '2', 'BLOB', query_vector)\
-            .error().contains('YIELD_SCORE_AS: Unknown argument')
-
-def test_hybrid_combine_missing_argument():
-    """Test that missing argument value for YIELD_SCORE_AS after COMBINE clause
-    results in an error"""
-    env = Env()
-    setup_basic_index(env)
-
-    env.expect(
-        'FT.HYBRID', 'idx',
-        'SEARCH', 'shoes',
-        'VSIM', '@embedding', '$BLOB',
-        'COMBINE', 'RRF', '2', 'CONSTANT', '60',
-            'YIELD_SCORE_AS')\
-            .error().contains('Missing argument value for YIELD_SCORE_AS')
-
-def test_hybrid_combine_without_fusion():
-    """Test that COMBINE without a fusion method fails"""
-    env = Env()
-    setup_basic_index(env)
-    query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
-
-    env.expect(
-        'FT.HYBRID', 'idx',
-        'SEARCH', 'shoes',
-        'VSIM', '@embedding', '$BLOB',
-        'COMBINE',
-            'YIELD_SCORE_AS', 'score1',
-        'PARAMS', '2', 'BLOB', query_vector)\
-            .error().contains('COMBINE: Invalid value for argument')
-
-def test_hybrid_linear_combine_and_fused_score():
-    """Test that COMBINE with LINEAR method and count of 0 is supported"""
-    env = Env()
-    setup_basic_index(env)
-    query_vector = np.array([1.2, 0.3]).astype(np.float32).tobytes()
-
-    res = env.cmd(
-        'FT.HYBRID', 'idx',
-            'SEARCH', 'blue',
-            'VSIM', '@embedding', '$BLOB',
-            'COMBINE', 'LINEAR', '0',
-            'YIELD_SCORE_AS', 'fuse_score',
-        'PARAMS', '2', 'BLOB', query_vector)
-    results, _ = get_results_from_hybrid_response(res)
-
-    # Execute the same command with COMBINE with LINEAR method to verify that
-    # the results are the same
-    res_with_linear = env.cmd(
-        'FT.HYBRID', 'idx',
-            'SEARCH', 'blue',
-            'VSIM', '@embedding', '$BLOB',
-            'COMBINE', 'LINEAR', '4', 'ALPHA', '0.3', 'BETA', '0.7',
-            'YIELD_SCORE_AS', 'fuse_score',
-        'PARAMS', '2', 'BLOB', query_vector)
-    results_with_linear, _ = get_results_from_hybrid_response(res_with_linear)
-
-    env.assertEqual(results, results_with_linear,
-                    message="Results with COMBINE LINEAR count 0 should match results with COMBINE LINEAR count 4")
-
-def test_hybrid_rrf_combine_and_fused_score():
-    """Test that COMBINE with RRF method and count of 0 is supported"""
-    env = Env()
-    setup_basic_index(env)
-    query_vector = np.array([1.2, 0.3]).astype(np.float32).tobytes()
-
-    res = env.cmd(
-        'FT.HYBRID', 'idx',
-        'SEARCH', 'blue',
-        'VSIM', '@embedding', '$BLOB',
-        'COMBINE', 'RRF', '0',
-        'YIELD_SCORE_AS', 'fused_score',
-        'PARAMS', '2', 'BLOB', query_vector)
-    results, _ = get_results_from_hybrid_response(res)
-
-    # Execute the same command with COMBINE with RRF method to verify that
-    # the results are the same
-    res_with_rrf = env.cmd(
-        'FT.HYBRID', 'idx',
-        'SEARCH', 'blue',
-        'VSIM', '@embedding', '$BLOB',
-        'COMBINE', 'RRF', '2', 'CONSTANT', '60',
-        'YIELD_SCORE_AS', 'fused_score',
-        'PARAMS', '2', 'BLOB', query_vector)
-    results_with_rrf, _ = get_results_from_hybrid_response(res_with_rrf)
-
-    env.assertEqual(results, results_with_rrf,
-                    message="Results with COMBINE RRF count 0 should match results with COMBINE RRF constant 60")
 
 def test_hybrid_multiple_yield_after_combine_error():
     """Test that multiple YIELD parameters after COMBINE keyword fail"""
@@ -389,7 +270,7 @@ def test_hybrid_yield_score_as_all_possible_scores():
         'VSIM', '@embedding', '$BLOB',
             'KNN', '2', 'K', '10',
             'YIELD_SCORE_AS', 'v_score',
-        'COMBINE', 'LINEAR', '4', 'ALPHA', alpha, 'BETA', beta,
+        'COMBINE', 'LINEAR', '6', 'ALPHA', alpha, 'BETA', beta,
             'YIELD_SCORE_AS', 'fused_score',
         'APPLY', f"{alpha}*case(exists(@s_score), @s_score ,0) + {beta}*case(exists(@v_score), @v_score,0)", 'AS', 'calculated_score',
         'PARAMS', '2', 'BLOB', query_vector)


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: PR #10002 changed `FT.HYBRID COMBINE` so the combined-score `YIELD_SCORE_AS` alias is positional after the `RRF` / `LINEAR` counted argument block.
2. Change: Revert #10002 on master and restore the previous counted-argument syntax for `YIELD_SCORE_AS` inside `COMBINE` method arguments.
3. Outcome: Existing clients that emit the counted form, such as `COMBINE RRF 4 CONSTANT 60 YIELD_SCORE_AS fused_score`, keep working for the 8.10 RC1 train.

#### Which additional issues this PR fixes
1. MOD-16121
2. MOD-16891
3. #10002

#### Main objects this PR modified
1. `src/hybrid/parse/hybrid_combine.c`
2. `commands.json`
3. `src/command_info/command_info.c`
4. `src/hybrid/parse/hybrid_optional_args.c`
5. `tests/cpptests/test_cpp_parse_hybrid.cpp`
6. `tests/pytests/test_hybrid_yield.py`
7. `tests/pytests/test_hybrid_linear.py`
8. `tests/pytests/test_hybrid_load.py`

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Restores compatibility for existing `FT.HYBRID COMBINE` clients that include `YIELD_SCORE_AS` in the counted `RRF` / `LINEAR` argument list.