### PR TITLE
skill: rust-review: check ffi items

### DIFF
--- a/.skills/rust-review/SKILL.md
+++ b/.skills/rust-review/SKILL.md
@@ -202,6 +202,44 @@ Check especially for:
 For any security-sensitive finding, state the concrete impact and the input or code path
 that can trigger it.
 
+#### 3f. Don't reach Rust-native items through the `ffi` crate
+
+The `ffi::` path is reserved for **actual C items** — types and functions defined
+in C and bound via bindgen (e.g. `ffi::RSToken`, `ffi::Redis_OpenReaderIndex`,
+`ffi::IndexSpec`). Rust code should never reach a Rust-native item through `ffi`
+when it can call the real Rust API directly. Two forms of this violation:
+
+**Re-exported types.** `ffi` `pub use`s some types that have a real Rust
+implementation in another crate (e.g. `ffi/src/lib.rs` doing
+`pub use query_term::{RSQueryTerm, RSTokenFlags};`). Reference these through their
+**owning crate** (`query_term::RSQueryTerm`), not the re-export (`ffi::RSQueryTerm`).
+To classify an `ffi::Foo`, grep the `ffi` crate for its definition:
+`grep -n "Foo" src/redisearch_rs/ffi/src/*.rs`. A `pub use <crate>::Foo;` line
+means it is Rust-native and should be referenced as `<crate>::Foo`.
+
+**C-ABI entrypoint functions.** Functions in `c_entrypoint/*_ffi/` crates are
+Rust functions exported to C (`#[no_mangle] pub extern "C" fn`), usually thin
+shims over a pure-Rust API. Rust calling one of these through its `ffi` symbol is
+a pointless Rust → C-ABI → Rust round-trip that also re-crosses the FFI boundary
+(losing type safety, taking raw pointers, degrading errors to sentinels like
+`NAN`/null). Call the underlying Rust API instead. For example, prefer
+`geo::hash::haversine_distance(..)` over `ffi::geohashGetDistance(..)`, whose body
+is just a wrapper around it. To spot these, grep `c_entrypoint/` for the symbol:
+`grep -rn "fn geohashGetDistance" src/redisearch_rs/c_entrypoint`; a
+`pub extern "C" fn` hit means the function is Rust-native, and the pure-Rust API
+it wraps should be called directly.
+
+In both cases the `ffi::` path obscures that the item is Rust-native (implying a
+C/FFI boundary that isn't there) and is inconsistent with the crate that defines
+it and with tests that already name it directly.
+
+Violations (report as suggestions):
+- `ffi::Foo` used for a type that `ffi` re-exports from another Rust crate.
+- A call to `ffi::some_fn` whose definition is a `pub extern "C" fn` in a
+  `c_entrypoint/*_ffi/` crate, instead of calling the pure-Rust API it wraps.
+
+In either case add the owning crate as a dependency if it isn't one already.
+
 ### 4. Porting-mode checks (only when porting mode = true)
 
 #### 4a. Semantic equivalence
@@ -258,4 +296,5 @@ Blocking violations: any issue in 3a, 3b, 4a, or 4b, plus any 3e issue that
 can cause memory unsoundness, crashes, data exposure, unauthorized access, or
 denial of service.
 Suggestions: issues in 3c (debug-assert pre-conditions), 3d (intra-doc links),
-and low-risk robustness improvements in 3e.
+3f (reaching Rust-native types/functions through `ffi` instead of their owning
+crate), and low-risk robustness improvements in 3e.


### PR DESCRIPTION
Ensure to not accidentally ffi for types or functions that are ported to Rust already.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
