### PR TITLE
[MOD-16895] Fix SVS queries_sanity timeout on coverage CI lane

### DIFF
--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -399,6 +399,11 @@ for workers in [0, 4]:
     # for non intel machines, we only test NO_COMPRESSION and any compression type (will result in GlobalSQ8)
     compression_types = SVS_COMPRESSION_TYPES if is_intel_opt_enabled() and EXTENDED_PYTESTS else ['NO_COMPRESSION', 'LVQ8']
     for compression_type in compression_types:
+        # Full-precision synchronous (WORKERS 0) Vamana construction over this test's large
+        # windows overruns the per-test timeout under coverage instrumentation (MOD-12324).
+        # The async and compressed variants stay in budget; the full matrix still runs standalone.
+        if CODE_COVERAGE and workers == 0 and compression_type == 'NO_COMPRESSION':
+            continue
         for data_type in VECSIM_SVS_DATA_TYPES:
             metrics = VECSIM_DISTANCE_METRICS if EXTENDED_PYTESTS else ['IP']
             for metric in metrics:


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `test_vecsim_svs.py::queries_sanity` builds an SVS-VAMANA index with `CONSTRUCTION_WINDOW_SIZE = SEARCH_WINDOW_SIZE = num_docs` (~1126) — large windows the test needs for its exact-nearest-neighbor assertions. For the `NO_COMPRESSION` (full-precision) + `WORKERS 0` (synchronous, single-threaded) combos, that graph construction is ~O(N·W) on the main thread. Under the coverage (gcov `--coverage` / `-DCOVERAGE_TEST`) build's ~10× slowdown it exceeds the 120s per-test timeout. In nightly Periodic Master Validation the `NO_COMPRESSION_FLOAT32_{COSINE,IP}` variants timed out ([run 29288715176](https://github.com/RediSearch/RediSearch/actions/runs/29288715176/job/86958736987)); the `_async` (WORKERS 4) twins, all compressed variants, and every non-instrumented lane (Ubuntu Noble, Intel, sanitize, macOS) passed — so this is CI cost, not a product regression.
2. **Change:** Under `CODE_COVERAGE`, skip the `NO_COMPRESSION` + `WORKERS 0` `queries_sanity` combos.
3. **Outcome:** The coverage lane drops exactly the 6 full-precision synchronous combos (verified via test collection) while keeping the async `NO_COMPRESSION` variants (full compression/datatype/metric matrix) and the synchronous compressed (`LVQ8`) variants (synchronous-transfer code path). The complete matrix still runs on the standalone lanes. Normal lanes are unchanged (84 tests, identical to before — the guard is a no-op when `CODE_COVERAGE` is unset).

#### Which additional issues this PR fixes
1. MOD-16895
2. Recurrence of the class previously addressed by MOD-12324 (#7305) and MOD-15490 (#9664)

#### Main objects this PR modified
1. `tests/pytests/test_vecsim_svs.py` — `queries_sanity` test generation loop

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
