### PR TITLE
[MOD-14988] Rework RQE Iterator

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1171,6 +1171,7 @@ dependencies = [
  "rqe_core",
  "rqe_iterator_type",
  "rqe_iterators",
+ "trie_rs",
  "workspace_hack",
 ]
 
@@ -2298,6 +2299,7 @@ dependencies = [
  "index_spec",
  "insta",
  "inverted_index",
+ "iterators_ffi",
  "libc",
  "numeric_range_tree",
  "pretty_assertions",

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
@@ -35,5 +35,6 @@ query_types.workspace = true
 redis_reply.workspace = true
 rqe_iterator_type.workspace = true
 rqe_iterators.workspace = true
+trie_rs.workspace = true
 workspace_hack.workspace = true
 

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/mod.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/mod.rs
@@ -14,4 +14,5 @@ mod tag;
 mod term;
 mod wildcard;
 
+pub use tag::CTagIndexLookup;
 pub use term::NewInvIndIterator_TermQuery;

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
@@ -14,7 +14,9 @@ use index_result::{RSIndexResult, RSQueryTerm};
 use inverted_index::{IndexReader, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly};
 use rqe_core::DocId;
 use rqe_iterators::{
-    FieldExpirationChecker, IteratorType, interop::RQEIteratorWrapper, inverted_index::Tag,
+    FieldExpirationChecker, IteratorType,
+    interop::RQEIteratorWrapper,
+    inverted_index::{CTagIndexLookup, Tag},
     profile_print,
 };
 
@@ -162,6 +164,10 @@ pub unsafe extern "C" fn NewInvIndIterator_TagQuery(
 
     // SAFETY: 3. guarantees tag_idx is valid and non-null
     let tag_idx_nn = unsafe { NonNull::new_unchecked(tag_idx as *mut _) };
+    // SAFETY: 3., 4. guarantee tag_idx and its TrieMap stay valid for the
+    // lifetime of the iterator; the encoding match is enforced by the
+    // DocIdsOnly/RawDocIdsOnly dispatch below.
+    let lookup = unsafe { CTagIndexLookup::new(tag_idx_nn) };
 
     // SAFETY: 5. guarantees sctx is valid and non-null
     let sctx_nn = unsafe { NonNull::new_unchecked(sctx as *mut _) };
@@ -188,7 +194,7 @@ pub unsafe extern "C" fn NewInvIndIterator_TagQuery(
             // 7. guarantees term ownership transfer.
             // The DocIdsOnly match arm ensures the encoding variant matches.
             TagIterator::Encoded(unsafe {
-                Tag::new(reader, sctx_nn, tag_idx_nn, term, weight, checker)
+                Tag::new(reader, sctx_nn, lookup, term, weight, checker)
             })
         }
         inverted_index_ffi::InvertedIndex::RawDocIdsOnly(ii) => {
@@ -201,9 +207,7 @@ pub unsafe extern "C" fn NewInvIndIterator_TagQuery(
             // 5., 6. guarantee context/spec validity.
             // 7. guarantees term ownership transfer.
             // The RawDocIdsOnly match arm ensures the encoding variant matches.
-            TagIterator::Raw(unsafe {
-                Tag::new(reader, sctx_nn, tag_idx_nn, term, weight, checker)
-            })
+            TagIterator::Raw(unsafe { Tag::new(reader, sctx_nn, lookup, term, weight, checker) })
         }
         _ => panic!(
             "Tag iterator requires a DocIdsOnly or RawDocIdsOnly inverted index, got: {:?}",

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/tag.rs
@@ -11,12 +11,14 @@ use std::{fmt::Debug, ptr::NonNull};
 
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use index_result::{RSIndexResult, RSQueryTerm};
-use inverted_index::{IndexReader, doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly};
+use inverted_index::{
+    IndexReader, doc_ids_only::DocIdsOnly, opaque::OpaqueEncoding, raw_doc_ids_only::RawDocIdsOnly,
+};
 use rqe_core::DocId;
 use rqe_iterators::{
     FieldExpirationChecker, IteratorType,
     interop::RQEIteratorWrapper,
-    inverted_index::{CTagIndexLookup, Tag},
+    inverted_index::{Tag, TagLookup},
     profile_print,
 };
 
@@ -26,8 +28,8 @@ use rqe_iterators::{
 /// the standard variable-length encoding ([`DocIdsOnly`]) and the fixed 4-byte
 /// raw encoding ([`RawDocIdsOnly`]) are supported.
 pub(super) enum TagIterator<'index> {
-    Encoded(Tag<'index, DocIdsOnly, FieldExpirationChecker>),
-    Raw(Tag<'index, RawDocIdsOnly, FieldExpirationChecker>),
+    Encoded(Tag<'index, DocIdsOnly, CTagIndexLookup, FieldExpirationChecker>),
+    Raw(Tag<'index, RawDocIdsOnly, CTagIndexLookup, FieldExpirationChecker>),
 }
 
 impl Debug for TagIterator<'_> {
@@ -107,6 +109,49 @@ impl<'index> rqe_iterators::RQEIterator<'index> for TagIterator<'index> {
 
     fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
         1.0
+    }
+}
+
+/// [`TagLookup`] over the C TagIndex's opaque `TrieMap` (`tag_index.values`).
+pub struct CTagIndexLookup(NonNull<ffi::TagIndex>);
+
+impl CTagIndexLookup {
+    /// Create a lookup over the given C TagIndex.
+    ///
+    /// # Safety
+    ///
+    /// 1. `tag_index` must point to a valid TagIndex and remain valid for
+    ///    the lifetime of this lookup (and of any iterator holding it).
+    /// 2. `tag_index.values`, when non-null, must be a valid
+    ///    [`TrieMapOpaque`](trie_rs::TrieMapOpaque) pointer.
+    /// 3. The entries in `tag_index.values` must point to opaque
+    ///    [`InvertedIndex`](inverted_index::opaque::InvertedIndex)es whose
+    ///    encoding variant matches the `E` this lookup is used with.
+    pub const unsafe fn new(tag_index: NonNull<ffi::TagIndex>) -> Self {
+        Self(tag_index)
+    }
+}
+
+impl<E> TagLookup<E> for CTagIndexLookup
+where
+    E: OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+{
+    fn find(&self, tag: &[u8]) -> Option<&inverted_index::InvertedIndex<E>> {
+        // SAFETY: 1. in `Self::new` guarantees `tag_index` is valid.
+        let tag_idx = unsafe { self.0.as_ref() };
+        if tag_idx.values.is_null() {
+            // No values trie means no postings for any tag.
+            return None;
+        }
+        // SAFETY: 2. in `Self::new` guarantees `values` is a valid `TrieMapOpaque`.
+        let trie = unsafe { &*tag_idx.values.cast::<trie_rs::TrieMapOpaque>() };
+        let idx = trie.find(tag)?;
+        // SAFETY: 3. in `Self::new` guarantees the trie entry points to a valid
+        // opaque `InvertedIndex`.
+        let opaque = idx.cast::<inverted_index::opaque::InvertedIndex>().as_ptr();
+        // SAFETY: 3. `from_opaque` panics when the encoding
+        // variant doesn't match `E`.
+        Some(E::from_opaque(unsafe { &*opaque }))
     }
 }
 

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -595,6 +595,42 @@ void TrimUnionIterator(QueryIterator *it, size_t limit, bool asc);
 void Profile_PrintIterators(RedisModuleCtx *ctx, const QueryIterator *root, bool limited, bool print_profile_clock);
 
 /**
+ * Creates a new wildcard inverted index iterator for querying all existing documents.
+ *
+ * # Parameters
+ *
+ * * `idx` - Pointer to the existingDocs inverted index (DocIdsOnly or RawDocIdsOnly encoded).
+ * * `sctx` - Pointer to the Redis search context.
+ * * `weight` - Weight to apply to all results.
+ *
+ * # Returns
+ *
+ * A pointer to a `QueryIterator` that can be used from C code.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ *
+ * 1. `idx` must be a valid pointer to an `InvertedIndex` and cannot be NULL.
+ * 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
+ *    mechanism detects when the index has been replaced via `spec.existingDocs` pointer
+ *    comparison.
+ * 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
+ * 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
+ */
+QueryIterator *NewInvIndIterator_WildcardQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, double weight);
+
+/**
+ * Get a mutable reference to the [`RLookupKey`] stored inside this metric iterator.
+ *
+ * # Safety
+ *
+ * 1. `header` is a valid non-null pointer to a [`QueryIterator`].
+ * 2. `header` was built via [`NewMetricIteratorSortedByScore`] or [`NewMetricIteratorSortedById`].
+ */
+RLookupKey * *GetMetricOwnKeyRef(QueryIterator *header);
+
+/**
  * Creates a new tag inverted index iterator.
  *
  * # Parameters
@@ -630,42 +666,6 @@ void Profile_PrintIterators(RedisModuleCtx *ctx, const QueryIterator *root, bool
  *    `NewQueryTerm`) and cannot be NULL. Ownership is transferred to the iterator.
  */
 QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagIndex *tag_idx, const RedisSearchCtx *sctx, union FieldMaskOrIndex field_mask_or_index, struct RSQueryTerm *term, double weight);
-
-/**
- * Creates a new wildcard inverted index iterator for querying all existing documents.
- *
- * # Parameters
- *
- * * `idx` - Pointer to the existingDocs inverted index (DocIdsOnly or RawDocIdsOnly encoded).
- * * `sctx` - Pointer to the Redis search context.
- * * `weight` - Weight to apply to all results.
- *
- * # Returns
- *
- * A pointer to a `QueryIterator` that can be used from C code.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- *
- * 1. `idx` must be a valid pointer to an `InvertedIndex` and cannot be NULL.
- * 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
- *    mechanism detects when the index has been replaced via `spec.existingDocs` pointer
- *    comparison.
- * 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
- * 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
- */
-QueryIterator *NewInvIndIterator_WildcardQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, double weight);
-
-/**
- * Get a mutable reference to the [`RLookupKey`] stored inside this metric iterator.
- *
- * # Safety
- *
- * 1. `header` is a valid non-null pointer to a [`QueryIterator`].
- * 2. `header` was built via [`NewMetricIteratorSortedByScore`] or [`NewMetricIteratorSortedById`].
- */
-RLookupKey * *GetMetricOwnKeyRef(QueryIterator *header);
 
 /**
  * Creates a NOT iterator, choosing between non-optimized and optimized based

--- a/src/redisearch_rs/rqe_iterators/Cargo.toml
+++ b/src/redisearch_rs/rqe_iterators/Cargo.toml
@@ -44,6 +44,7 @@ workspace_hack.workspace = true
 approx.workspace = true
 decorum.workspace = true
 insta.workspace = true
+iterators_ffi = { path = "../c_entrypoint/iterators_ffi" }
 pretty_assertions.workspace = true
 proptest = { workspace = true, features = ["std"] }
 query_term_ffi = { path = "../c_entrypoint/query_term_ffi" }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
@@ -27,6 +27,6 @@ pub use numeric::{
     Numeric, NumericIteratorVariant, build_numeric_filter_iterator, open_numeric_or_geo_index,
 };
 
-pub use tag::{CTagIndexLookup, Tag, TagLookup};
+pub use tag::{Tag, TagLookup};
 pub use term::{Term, TermIndexReader, build_term_iterator};
 pub use wildcard::Wildcard;

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
@@ -26,6 +26,7 @@ pub use missing::{Missing, new_missing_iterator};
 pub use numeric::{
     Numeric, NumericIteratorVariant, build_numeric_filter_iterator, open_numeric_or_geo_index,
 };
-pub use tag::Tag;
+
+pub use tag::{CTagIndexLookup, Tag, TagLookup};
 pub use term::{Term, TermIndexReader, build_term_iterator};
 pub use wildcard::Wildcard;

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -28,6 +28,56 @@ use crate::{
 
 use super::{InvIndIterator, core::RawInvIndIterator};
 
+/// Resolves a tag value to the inverted index currently stored for it in a
+/// tag-index container.
+pub trait TagLookup<E> {
+    /// The inverted index currently stored for `tag`, if any.
+    fn find(&self, tag: &[u8]) -> Option<&inverted_index::InvertedIndex<E>>;
+}
+
+/// [`TagLookup`] over the C `TagIndex`'s opaque `TrieMap` (`tag_index.values`).
+pub struct CTagIndexLookup(NonNull<TagIndex>);
+
+impl CTagIndexLookup {
+    /// Create a lookup over the given C [`TagIndex`].
+    ///
+    /// # Safety
+    ///
+    /// 1. `tag_index` must point to a valid [`TagIndex`] and remain valid for
+    ///    the lifetime of this lookup (and of any iterator holding it).
+    /// 2. `tag_index.values`, when non-null, must be a valid
+    ///    [`TrieMapOpaque`](trie_rs::TrieMapOpaque) pointer.
+    /// 3. The entries in `tag_index.values` must point to opaque
+    ///    [`InvertedIndex`](inverted_index::opaque::InvertedIndex)es whose
+    ///    encoding variant matches the `E` this lookup is used with.
+    pub const unsafe fn new(tag_index: NonNull<TagIndex>) -> Self {
+        Self(tag_index)
+    }
+}
+
+impl<E> TagLookup<E> for CTagIndexLookup
+where
+    E: OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
+{
+    fn find(&self, tag: &[u8]) -> Option<&inverted_index::InvertedIndex<E>> {
+        // SAFETY: 1. in `Self::new` guarantees `tag_index` is valid.
+        let tag_idx = unsafe { self.0.as_ref() };
+        if tag_idx.values.is_null() {
+            // No values trie means no postings for any tag.
+            return None;
+        }
+        // SAFETY: 2. in `Self::new` guarantees `values` is a valid `TrieMapOpaque`.
+        let trie = unsafe { &*tag_idx.values.cast::<trie_rs::TrieMapOpaque>() };
+        let idx = trie.find(tag)?;
+        // SAFETY: 3. in `Self::new` guarantees the trie entry points to a valid
+        // opaque `InvertedIndex`.
+        let opaque = idx.cast::<inverted_index::opaque::InvertedIndex>().as_ptr();
+        // SAFETY: 3. `from_opaque` panics when the encoding
+        // variant doesn't match `E`.
+        Some(E::from_opaque(unsafe { &*opaque }))
+    }
+}
+
 /// An iterator over documents matching a specific tag value, parameterised
 /// over a [`Ref`] mode. See [`Tag`] for the [`Active`] instantiation that
 /// implements [`RQEIterator`].
@@ -44,28 +94,39 @@ use super::{InvIndIterator, core::RawInvIndIterator};
 /// * `Rf` - The [`Ref`] mode (see [`RawInvIndIterator`] for details).
 /// * `E` - The encoding type for the inverted index. Its decoder must implement [`DocIdsDecoder`].
 /// * `C` - The expiration checker type.
+/// * `L` - The [`TagLookup`] used to detect GC changes during revalidation.
 #[repr(C)]
-pub struct RawTag<'query, Rf: Ref, E, C = crate::expiration_checker::NoOpChecker> {
+pub struct RawTag<
+    'query,
+    Rf: Ref,
+    E,
+    C = crate::expiration_checker::NoOpChecker,
+    L = CTagIndexLookup,
+> {
     it: RawInvIndIterator<'query, Rf, RawIndexReaderCore<Rf, E>, C>,
-    tag_index: NonNull<TagIndex>,
+    lookup: L,
 }
 
 /// Alias for an [`Active`] [`RawTag`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
-pub type Tag<'index, E, C = crate::expiration_checker::NoOpChecker> =
-    RawTag<'index, Active<'index>, E, C>;
+pub type Tag<'index, E, C = crate::expiration_checker::NoOpChecker, L = CTagIndexLookup> =
+    RawTag<'index, Active<'index>, E, C, L>;
 
-impl<'index, E, C> Tag<'index, E, C>
+impl<'index, E, C, L> Tag<'index, E, C, L>
 where
-    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>> + 'index,
+    E: DecodedBy + 'index,
     <E as DecodedBy>::Decoder: DocIdsDecoder,
     C: ExpirationChecker,
+    L: TagLookup<E>,
 {
     /// Create an iterator returning documents matching the given tag value.
     ///
     /// `term` is the query term representing the tag value. It is stored in the
     /// result and used during revalidation to look up the tag's inverted index
-    /// in the [`TagIndex`]'s [`TrieMapOpaque`](trie_rs::TrieMapOpaque).
+    /// through `lookup`.
+    ///
+    /// `lookup` must resolve tags in the container that holds the inverted
+    /// index `reader` reads from.
     ///
     /// `weight` is the scoring weight applied to the result record.
     ///
@@ -73,17 +134,10 @@ where
     ///
     /// 1. `context` must point to a valid [`RedisSearchCtx`].
     /// 2. `context.spec` must be a non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec).
-    /// 3. `tag_index` must point to a valid [`TagIndex`].
-    /// 4. `tag_index` must remain valid for the lifetime of the iterator.
-    /// 5. `tag_index.values` must be a valid non-null [`TrieMapOpaque`](trie_rs::TrieMapOpaque) pointer.
-    /// 6. The entry in `tag_index.values` for the tag value, when non-null,
-    ///    must point to an opaque
-    ///    [`InvertedIndex`](inverted_index::opaque::InvertedIndex) whose encoding
-    ///    variant matches `E`.
     pub unsafe fn new(
         reader: IndexReaderCore<'index, E>,
         context: NonNull<RedisSearchCtx>,
-        tag_index: NonNull<TagIndex>,
+        lookup: L,
         mut term: Box<RSQueryTerm>,
         weight: f64,
         expiration_checker: C,
@@ -99,27 +153,16 @@ where
         term.set_idf(idf::calculate_idf(total_docs, term_docs));
         term.set_bm25_idf(idf::calculate_idf_bm25(total_docs, term_docs));
 
-        // Check 6.: the trie entry's encoding variant matches E.
+        // The trie entry's encoding variant must match E.
         debug_assert!(
             {
-                // SAFETY: 3. and 4. guarantee tag_index is valid.
-                let tag_idx = unsafe { tag_index.as_ref() };
-                if !tag_idx.values.is_null() {
-                    let term_bytes = term
-                        .as_bytes()
-                        .expect("Tag iterator query term should have a non-null string");
-                    // SAFETY: 5. guarantees values is a valid TrieMap.
-                    let trie = unsafe { &*tag_idx.values.cast::<trie_rs::TrieMapOpaque>() };
-                    // If the entry exists, `from_opaque` panics when the variant doesn't match E.
-                    if let Some(idx) = trie.find(term_bytes) {
-                        let opaque = idx.cast::<inverted_index::opaque::InvertedIndex>().as_ptr();
-                        // SAFETY: 6. guarantees the trie entry points to a valid opaque InvertedIndex.
-                        let _ = E::from_opaque(unsafe { &*opaque });
-                    }
-                }
+                let term_bytes = term
+                    .as_bytes()
+                    .expect("Tag iterator query term should have a non-null string");
+                let _ = lookup.find(term_bytes);
                 true
             },
-            "tag_index entry for the tag value must have an encoding variant matching E",
+            "the lookup entry for the tag value must have an encoding variant matching E",
         );
 
         let result = RSIndexResult::build_term()
@@ -132,7 +175,7 @@ where
 
         Self {
             it: InvIndIterator::new(reader, result, expiration_checker),
-            tag_index,
+            lookup,
         }
     }
 
@@ -151,33 +194,16 @@ where
             .query_term()
             .expect("Tag iterator should always have a query term");
 
-        // Look up the tag value in the TagIndex's TrieMap.
-        // SAFETY: 3. and 4. guarantee `tag_index` is valid.
-        let tag_idx = unsafe { self.tag_index.as_ref() };
-
-        debug_assert!(
-            !tag_idx.values.is_null(),
-            "tag_index.values must be non-null",
-        );
         let term_bytes = term
             .as_bytes()
             .expect("Tag iterator query term should have a non-null string");
-        // SAFETY: 5. guarantees `tag_idx.values` is a valid `triemap_ffi::TrieMap`
-        // created by `NewTrieMap`.
-        let trie = unsafe { &*tag_idx.values.cast::<trie_rs::TrieMapOpaque>() };
 
-        let Some(idx) = trie.find(term_bytes) else {
+        match self.lookup.find(term_bytes) {
             // The inverted index was collected entirely by GC, or the
             // value is a null sentinel (disk mode).
-            return true;
-        };
-
-        let opaque = idx.cast::<inverted_index::opaque::InvertedIndex>().as_ptr();
-        // SAFETY: 6. guarantees the encoding variant matches E.
-        // `find` guarantees the pointer is non-null.
-        let ii = E::from_opaque(unsafe { &*opaque });
-
-        !self.it.reader.points_to_ii(ii)
+            None => true,
+            Some(ii) => !self.it.reader.points_to_ii(ii),
+        }
     }
 
     /// Get a reference to the underlying reader.
@@ -186,11 +212,12 @@ where
     }
 }
 
-impl<'index, E, C> RQEIterator<'index> for Tag<'index, E, C>
+impl<'index, E, C, L> RQEIterator<'index> for Tag<'index, E, C, L>
 where
-    E: DecodedBy + OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>> + 'index,
+    E: DecodedBy + 'index,
     <E as DecodedBy>::Decoder: DocIdsDecoder,
     C: ExpirationChecker,
+    L: TagLookup<E>,
 {
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
@@ -252,13 +279,12 @@ where
     }
 }
 
-impl<'index, E, C> ProfilePrint for Tag<'index, E, C>
+impl<'index, E, C, L> ProfilePrint for Tag<'index, E, C, L>
 where
-    E: inverted_index::DecodedBy
-        + inverted_index::opaque::OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>
-        + 'index,
+    E: inverted_index::DecodedBy + 'index,
     <E as inverted_index::DecodedBy>::Decoder: inverted_index::DocIdsDecoder,
     C: crate::expiration_checker::ExpirationChecker,
+    L: TagLookup<E>,
 {
     fn print_profile(&self, map: &mut redis_reply::MapBuilder<'_>, ctx: &mut ProfilePrintCtx<'_>) {
         map.kv_simple_string(c"Type", c"TAG");

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -9,13 +9,10 @@
 
 use std::ptr::NonNull;
 
-use ffi::{RedisSearchCtx, TagIndex};
+use ffi::RedisSearchCtx;
 use index_result::{RSIndexResult, RSOffsetSlice};
 use index_spec::IndexSpecReadGuard;
-use inverted_index::{
-    DecodedBy, DocIdsDecoder, IndexReader, IndexReaderCore, RawIndexReaderCore,
-    opaque::OpaqueEncoding,
-};
+use inverted_index::{DecodedBy, DocIdsDecoder, IndexReader, IndexReaderCore, RawIndexReaderCore};
 use query_term::RSQueryTerm;
 use ref_mode::{Active, Ref};
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
@@ -33,49 +30,6 @@ use super::{InvIndIterator, core::RawInvIndIterator};
 pub trait TagLookup<E> {
     /// The inverted index currently stored for `tag`, if any.
     fn find(&self, tag: &[u8]) -> Option<&inverted_index::InvertedIndex<E>>;
-}
-
-/// [`TagLookup`] over the C `TagIndex`'s opaque `TrieMap` (`tag_index.values`).
-pub struct CTagIndexLookup(NonNull<TagIndex>);
-
-impl CTagIndexLookup {
-    /// Create a lookup over the given C [`TagIndex`].
-    ///
-    /// # Safety
-    ///
-    /// 1. `tag_index` must point to a valid [`TagIndex`] and remain valid for
-    ///    the lifetime of this lookup (and of any iterator holding it).
-    /// 2. `tag_index.values`, when non-null, must be a valid
-    ///    [`TrieMapOpaque`](trie_rs::TrieMapOpaque) pointer.
-    /// 3. The entries in `tag_index.values` must point to opaque
-    ///    [`InvertedIndex`](inverted_index::opaque::InvertedIndex)es whose
-    ///    encoding variant matches the `E` this lookup is used with.
-    pub const unsafe fn new(tag_index: NonNull<TagIndex>) -> Self {
-        Self(tag_index)
-    }
-}
-
-impl<E> TagLookup<E> for CTagIndexLookup
-where
-    E: OpaqueEncoding<Storage = inverted_index::InvertedIndex<E>>,
-{
-    fn find(&self, tag: &[u8]) -> Option<&inverted_index::InvertedIndex<E>> {
-        // SAFETY: 1. in `Self::new` guarantees `tag_index` is valid.
-        let tag_idx = unsafe { self.0.as_ref() };
-        if tag_idx.values.is_null() {
-            // No values trie means no postings for any tag.
-            return None;
-        }
-        // SAFETY: 2. in `Self::new` guarantees `values` is a valid `TrieMapOpaque`.
-        let trie = unsafe { &*tag_idx.values.cast::<trie_rs::TrieMapOpaque>() };
-        let idx = trie.find(tag)?;
-        // SAFETY: 3. in `Self::new` guarantees the trie entry points to a valid
-        // opaque `InvertedIndex`.
-        let opaque = idx.cast::<inverted_index::opaque::InvertedIndex>().as_ptr();
-        // SAFETY: 3. `from_opaque` panics when the encoding
-        // variant doesn't match `E`.
-        Some(E::from_opaque(unsafe { &*opaque }))
-    }
 }
 
 /// An iterator over documents matching a specific tag value, parameterised
@@ -96,23 +50,17 @@ where
 /// * `C` - The expiration checker type.
 /// * `L` - The [`TagLookup`] used to detect GC changes during revalidation.
 #[repr(C)]
-pub struct RawTag<
-    'query,
-    Rf: Ref,
-    E,
-    C = crate::expiration_checker::NoOpChecker,
-    L = CTagIndexLookup,
-> {
+pub struct RawTag<'query, Rf: Ref, E, L, C = crate::expiration_checker::NoOpChecker> {
     it: RawInvIndIterator<'query, Rf, RawIndexReaderCore<Rf, E>, C>,
     lookup: L,
 }
 
 /// Alias for an [`Active`] [`RawTag`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
-pub type Tag<'index, E, C = crate::expiration_checker::NoOpChecker, L = CTagIndexLookup> =
-    RawTag<'index, Active<'index>, E, C, L>;
+pub type Tag<'index, E, L, C = crate::expiration_checker::NoOpChecker> =
+    RawTag<'index, Active<'index>, E, L, C>;
 
-impl<'index, E, C, L> Tag<'index, E, C, L>
+impl<'index, E, L, C> Tag<'index, E, L, C>
 where
     E: DecodedBy + 'index,
     <E as DecodedBy>::Decoder: DocIdsDecoder,
@@ -213,7 +161,7 @@ where
     }
 }
 
-impl<'index, E, C, L> RQEIterator<'index> for Tag<'index, E, C, L>
+impl<'index, E, L, C> RQEIterator<'index> for Tag<'index, E, L, C>
 where
     E: DecodedBy + 'index,
     <E as DecodedBy>::Decoder: DocIdsDecoder,
@@ -280,7 +228,7 @@ where
     }
 }
 
-impl<'index, E, C, L> ProfilePrint for Tag<'index, E, C, L>
+impl<'index, E, L, C> ProfilePrint for Tag<'index, E, L, C>
 where
     E: inverted_index::DecodedBy + 'index,
     <E as inverted_index::DecodedBy>::Decoder: inverted_index::DocIdsDecoder,

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/tag.rs
@@ -125,15 +125,16 @@ where
     /// result and used during revalidation to look up the tag's inverted index
     /// through `lookup`.
     ///
-    /// `lookup` must resolve tags in the container that holds the inverted
-    /// index `reader` reads from.
-    ///
     /// `weight` is the scoring weight applied to the result record.
     ///
     /// # Safety
     ///
     /// 1. `context` must point to a valid [`RedisSearchCtx`].
     /// 2. `context.spec` must be a non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec).
+    /// 3. `lookup` must resolve tags in the container that holds the inverted
+    ///    index `reader` reads from. Otherwise revalidation may wrongly
+    ///    conclude the reader's index is still alive after GC freed it,
+    ///    leading to a use-after-free.
     pub unsafe fn new(
         reader: IndexReaderCore<'index, E>,
         context: NonNull<RedisSearchCtx>,

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -14,13 +14,12 @@ use index_result::RSIndexResult;
 use inverted_index::doc_ids_only::DocIdsOnly;
 use query_term::RSQueryTerm;
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
-use rqe_iterators::{
-    IteratorType, NoOpChecker, RQEIterator,
-    inverted_index::{CTagIndexLookup, Tag},
-};
+use rqe_iterators::{IteratorType, NoOpChecker, RQEIterator, inverted_index::Tag};
 use rqe_iterators_test_utils::MockContext;
 
 use crate::inverted_index::utils::BaseTest;
+
+use iterators_ffi::inverted_index::CTagIndexLookup;
 
 struct TagBaseTest {
     test: BaseTest<DocIdsOnly>,
@@ -48,7 +47,7 @@ impl TagBaseTest {
         RSQueryTerm::new("test_tag", 0, 0)
     }
 
-    fn create_iterator(&self) -> Tag<'_, DocIdsOnly, NoOpChecker> {
+    fn create_iterator(&self) -> Tag<'_, DocIdsOnly, CTagIndexLookup, NoOpChecker> {
         let reader = self.test.ii.reader();
         let term = Self::create_term();
         // SAFETY: `mock_ctx` provides a valid `RedisSearchCtx` with a valid `spec`
@@ -145,7 +144,7 @@ mod not_miri {
             }
         }
 
-        fn create_iterator(&self) -> Tag<'_, DocIdsOnly, NoOpChecker> {
+        fn create_iterator(&self) -> Tag<'_, DocIdsOnly, CTagIndexLookup, NoOpChecker> {
             let ii = DocIdsOnly::from_opaque(self.test.context.tag_inverted_index());
             let tag_index = self.test.context.tag_index();
             let term = RSQueryTerm::new("test_tag", 0, 0);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -14,7 +14,10 @@ use index_result::RSIndexResult;
 use inverted_index::doc_ids_only::DocIdsOnly;
 use query_term::RSQueryTerm;
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
-use rqe_iterators::{IteratorType, NoOpChecker, RQEIterator, inverted_index::Tag};
+use rqe_iterators::{
+    IteratorType, NoOpChecker, RQEIterator,
+    inverted_index::{CTagIndexLookup, Tag},
+};
 use rqe_iterators_test_utils::MockContext;
 
 use crate::inverted_index::utils::BaseTest;
@@ -56,7 +59,7 @@ impl TagBaseTest {
             Tag::new(
                 reader,
                 self.test.mock_ctx.sctx(),
-                self.test.mock_ctx.tag_index(),
+                CTagIndexLookup::new(self.test.mock_ctx.tag_index()),
                 term,
                 0.0,
                 NoOpChecker,
@@ -99,7 +102,7 @@ fn tag_empty_index() {
         Tag::new(
             reader,
             mock_ctx.sctx(),
-            mock_ctx.tag_index(),
+            CTagIndexLookup::new(mock_ctx.tag_index()),
             term,
             0.0,
             NoOpChecker,
@@ -152,7 +155,7 @@ mod not_miri {
                 Tag::new(
                     ii.reader(),
                     self.test.context.sctx,
-                    tag_index,
+                    CTagIndexLookup::new(tag_index),
                     term,
                     0.0,
                     NoOpChecker,

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
@@ -408,7 +408,7 @@ fn tag_with_query_term() {
         rqe_iterators::inverted_index::Tag::new(
             reader,
             mock_ctx.sctx(),
-            rqe_iterators::inverted_index::CTagIndexLookup::new(mock_ctx.tag_index()),
+            iterators_ffi::inverted_index::CTagIndexLookup::new(mock_ctx.tag_index()),
             RSQueryTerm::new("my_tag", 0, 0),
             0.0,
             rqe_iterators::NoOpChecker,

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
@@ -408,7 +408,7 @@ fn tag_with_query_term() {
         rqe_iterators::inverted_index::Tag::new(
             reader,
             mock_ctx.sctx(),
-            mock_ctx.tag_index(),
+            rqe_iterators::inverted_index::CTagIndexLookup::new(mock_ctx.tag_index()),
             RSQueryTerm::new("my_tag", 0, 0),
             0.0,
             rqe_iterators::NoOpChecker,

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/tag.rs
@@ -14,7 +14,10 @@ use std::hint::black_box;
 use criterion::{BenchmarkGroup, Criterion, measurement::Measurement};
 use index_result::RSQueryTerm;
 use inverted_index::{doc_ids_only::DocIdsOnly, opaque::OpaqueEncoding};
-use rqe_iterators::{RQEIterator, SkipToOutcome, inverted_index::Tag};
+use rqe_iterators::{
+    RQEIterator, SkipToOutcome,
+    inverted_index::{CTagIndexLookup, Tag},
+};
 use rqe_iterators_test_utils::TestContext;
 
 use super::{INDEX_SIZE, SKIP_TO_STEP, SPARSE_DELTA, benchmark_group};
@@ -74,7 +77,7 @@ impl TagBencher {
                     Tag::new(
                         ii.reader(),
                         context.sctx,
-                        context.tag_index(),
+                        CTagIndexLookup::new(context.tag_index()),
                         term,
                         0.0,
                         rqe_iterators::NoOpChecker,
@@ -104,7 +107,7 @@ impl TagBencher {
                     Tag::new(
                         ii.reader(),
                         context.sctx,
-                        context.tag_index(),
+                        CTagIndexLookup::new(context.tag_index()),
                         term,
                         0.0,
                         rqe_iterators::NoOpChecker,

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index/tag.rs
@@ -14,10 +14,8 @@ use std::hint::black_box;
 use criterion::{BenchmarkGroup, Criterion, measurement::Measurement};
 use index_result::RSQueryTerm;
 use inverted_index::{doc_ids_only::DocIdsOnly, opaque::OpaqueEncoding};
-use rqe_iterators::{
-    RQEIterator, SkipToOutcome,
-    inverted_index::{CTagIndexLookup, Tag},
-};
+use iterators_ffi::inverted_index::CTagIndexLookup;
+use rqe_iterators::{RQEIterator, SkipToOutcome, inverted_index::Tag};
 use rqe_iterators_test_utils::TestContext;
 
 use super::{INDEX_SIZE, SKIP_TO_STEP, SPARSE_DELTA, benchmark_group};


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: the tag iterator (`rqe_iterators::inverted_index::Tag`) is hard-wired to the C `TagIndex` — it dereferences `tag_index.values` as a `TrieMapOpaque` directly in `new()` and `revalidate()`.
 2. Change: introduce a `TagLookup<E>` trait that resolves a tag value to its inverted index, with `CTagIndexLookup` as the implementation over the C `TagIndex`. `RawTag`/`Tag` gain a lookup type parameter (defaulting to `CTagIndexLookup`), and the tag-index safety contract moves from `Tag::new` to `CTagIndexLookup::new`. This lets future tag index implementations (MOD-14988) plug in their own lookup without touching the iterator.
 3. Outcome: no runtime change. The only semantic nuance: a null `tag_index.values` is now handled as "no postings for any tag" instead of being a safety-contract violation.

#### Which additional issues this PR fixes
1. MOD-14988

#### Main objects this PR modified
1. rqe_iterators::inverted_index::Tag

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
