### PR TITLE
[MOD-16803] ADHOC_BF hybrid vector queries honor index-level RERANK TRUE

### DIFF
--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -237,9 +237,7 @@ QueryIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, QueryIterator
         return NULL;
       }
       // On disk (Flex) HNSW, query-time RERANK is an override only. When the query omits
-      // it, fall back to the index's create-time RERANK default so the pre-filtered
-      // ADHOC_BF hybrid path reranks consistently with topKQuery and BATCHES (MOD-16803).
-      // diskCtx.indexName is non-NULL exactly for disk-backed vector fields.
+      // it, fall back to the index's create-time RERANK default
       if (vq->field->vectorOpts.diskCtx.indexName != NULL &&
           qParams.hnswDiskRuntimeParams.shouldRerank == VecSimBool_UNSET) {
         qParams.hnswDiskRuntimeParams.shouldRerank =

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -236,6 +236,15 @@ QueryIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, QueryIterator
                                     &qParams, queryType, q->status) != VecSim_OK)  {
         return NULL;
       }
+      // On disk (Flex) HNSW, query-time RERANK is an override only. When the query omits
+      // it, fall back to the index's create-time RERANK default so the pre-filtered
+      // ADHOC_BF hybrid path reranks consistently with topKQuery and BATCHES (MOD-16803).
+      // diskCtx.indexName is non-NULL exactly for disk-backed vector fields.
+      if (vq->field->vectorOpts.diskCtx.indexName != NULL &&
+          qParams.hnswDiskRuntimeParams.shouldRerank == VecSimBool_UNSET) {
+        qParams.hnswDiskRuntimeParams.shouldRerank =
+            vq->field->vectorOpts.diskCtx.rerank ? VecSimBool_TRUE : VecSimBool_FALSE;
+      }
       if (vq->knn.k > MAX_KNN_K) {
         QueryError_SetWithoutUserDataFmt(q->status, QUERY_ERROR_CODE_INVAL,
                                                "Error parsing vector similarity query: query " VECSIM_KNN_K_TOO_LARGE_ERR_MSG ", must not exceed %zu", MAX_KNN_K);


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** On a disk (Flex) HNSW index created with the mandatory `RERANK TRUE`, pre-filtered (hybrid) KNN queries with `HYBRID_POLICY ADHOC_BF` skip the FP32 rerank pass and yield **SQ8-quantized approximate distances** whenever the query omits a query-time `RERANK`. The result: wrong yielded scores, wrong top-K membership/order, and disagreement with `HYBRID_POLICY BATCHES` (which honors the index setting) on the same `(doc, query)` pair. The default silently behaves as `RERANK FALSE`, contradicting the index definition — query-time `RERANK` is meant to be an *override* only.
2. **Change:** In `NewVectorIterator` (KNN case), after resolving the query params, fall back to the field's create-time `RERANK` default (`vectorOpts.diskCtx.rerank`) when the query omits `RERANK` on a disk-backed vector field. Because `shouldRerank` is now resolved to a concrete value before it reaches the hybrid iterator, the existing `computeDistances_Disk` rerank gate honors it without change. An explicit query-time `RERANK TRUE/FALSE` still wins.
3. **Outcome:** `ADHOC_BF` now returns exact FP32 distances and the correct top-K on `RERANK TRUE` indexes — consistent with `BATCHES` and `topKQuery` — while a query-time `RERANK false` still overrides to approximate.

#### Which additional issues this PR fixes
1. MOD-16803

#### Main objects this PR modified
1. `src/vector_index.c` — `NewVectorIterator` (disk KNN param resolution)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Fixes ADHOC_BF hybrid vector queries returning quantized (approximate) distances and a wrong top-K on disk HNSW indexes created with `RERANK TRUE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
