### PR TITLE
[RED-209108] Faster job pickup in worker thread pool: wake workers based on pending jobs, not batch size

### DIFF
--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -894,9 +894,6 @@ static void priority_queue_push_chain_unsafe(priorityJobqueue *priority_queue_p,
                         l_newjob_p, n);
     break;
   }
-  /* Wake workers based on the total pending count so that no worker keeps
-   * sleeping while multiple jobs are pending. Busy workers are not blocked on
-   * the condvar, so a broadcast only wakes actual sleepers. */
   if (priority_queue_len_unsafe(priority_queue_p) > 1) {
     pthread_cond_broadcast(&priority_queue_p->has_jobs);
   } else {

--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -894,12 +894,9 @@ static void priority_queue_push_chain_unsafe(priorityJobqueue *priority_queue_p,
                         l_newjob_p, n);
     break;
   }
-  /* Decide how many workers to wake based on the TOTAL number of pending jobs,
-   * not on how many jobs this call pushed. A single-job push onto a non-empty
-   * queue means previous wakeups have not been consumed yet (or were missed),
-   * so a lone signal could leave sleeping workers idle while multiple jobs are
-   * pending. Broadcasting is cheap in that state: workers that are busy are not
-   * waiting on the condition variable, so only the (few) sleepers wake up. */
+  /* Wake workers based on the total pending count so that no worker keeps
+   * sleeping while multiple jobs are pending. Busy workers are not blocked on
+   * the condvar, so a broadcast only wakes actual sleepers. */
   if (priority_queue_len_unsafe(priority_queue_p) > 1) {
     pthread_cond_broadcast(&priority_queue_p->has_jobs);
   } else {

--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -894,7 +894,13 @@ static void priority_queue_push_chain_unsafe(priorityJobqueue *priority_queue_p,
                         l_newjob_p, n);
     break;
   }
-  if (n > 1) {
+  /* Decide how many workers to wake based on the TOTAL number of pending jobs,
+   * not on how many jobs this call pushed. A single-job push onto a non-empty
+   * queue means previous wakeups have not been consumed yet (or were missed),
+   * so a lone signal could leave sleeping workers idle while multiple jobs are
+   * pending. Broadcasting is cheap in that state: workers that are busy are not
+   * waiting on the condition variable, so only the (few) sleepers wake up. */
+  if (priority_queue_len_unsafe(priority_queue_p) > 1) {
     pthread_cond_broadcast(&priority_queue_p->has_jobs);
   } else {
     pthread_cond_signal(&priority_queue_p->has_jobs);


### PR DESCRIPTION

## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: When pushing jobs to the worker thread pool, the wake-up decision is based on how many jobs the current call pushed: `pthread_cond_signal` for a single job, `pthread_cond_broadcast` for a chain. Vector ingestion submits one job per vector, so it always takes the single-signal path — even when the queue already holds a backlog of pending jobs. If a previous wake-up was delayed or lost (e.g. glibc condvar lost-wakeup bug BZ#25847, fixed only in glibc 2.41), workers can stay asleep while multiple jobs are pending, until some later push happens to signal again.
2. Change: Base the wake-up decision on the **total number of pending jobs** after the push, not on the number of jobs pushed in this call. If more than one job is pending, broadcast; otherwise signal one worker. Broadcasting in that state is cheap: busy workers are not waiting on the condition variable, so only actual sleepers are woken, and a sleeping worker while jobs are pending is exactly the state we want to break.
3. Outcome: Whenever a backlog exists, every sleeping worker is woken, making the pool self-healing against missed or delayed wake-ups. A microbenchmark (single producer submitting jobs one at a time, 6 workers) shows p99 push→job-start handoff latency improving from ~245µs to ~55µs near saturation and from ~103µs to ~16µs at high job rates, with no regression in throughput, wall time, or producer-side cost in any tested regime. Investigated as part of RED-209108 (RoF vector-ingestion worker starvation); production validation on the customer-like setup is pending.

#### Which additional issues this PR fixes
1. RED-209108

#### Main objects this PR modified
1. `deps/thpool/thpool.c` — `priority_queue_push_chain_unsafe()` wake-up policy

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

🤖 Generated with [Claude Code](https://claude.com/claude-code)
