### PR TITLE
CI: skip macOS Intel (x86_64) test runners; keep macOS ARM

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -50,7 +50,9 @@ jobs:
     uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:
-      platform: 'macos-26,alpine:3.23,intel'
+      # macOS Intel (x86_64) test runners are excluded while the macOS runner
+      # problem is mitigated; macOS ARM still runs.
+      platform: 'macos-26,!macos-26~x86_64,alpine:3.23,intel'
       architecture: all
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       options: skip-tests,fail-fast

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -50,9 +50,9 @@ jobs:
     uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:
-      # macOS Intel (x86_64) test runners are excluded while the macOS runner
-      # problem is mitigated; macOS ARM still runs.
-      platform: 'macos-26,!macos-26~x86_64,alpine:3.23,intel'
+      # This job only builds (skip-tests), so it does not hit the flaky macOS
+      # test runners; keep macOS Intel (x86_64) here for build coverage.
+      platform: 'macos-26,alpine:3.23,intel'
       architecture: all
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       options: skip-tests,fail-fast

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -26,7 +26,9 @@ jobs:
     uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:
-      platform: all
+      # macOS Intel (x86_64) test runners are excluded while the macOS runner
+      # problem is mitigated; macOS ARM still runs.
+      platform: all,!macos-14~x86_64,!macos-15~x86_64,!macos-26~x86_64
       architecture: all
       # Track unstable so nightly catches upstream Redis breakage; PR/merge
       # CI uses the latest release.

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -176,7 +176,9 @@ jobs:
     uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:
-      platform: 'ubuntu:noble,macos-26,alpine:3.23,intel'
+      # macOS Intel (x86_64) test runners are excluded while the macOS runner
+      # problem is mitigated; macOS ARM still runs.
+      platform: 'ubuntu:noble,macos-26,!macos-26~x86_64,alpine:3.23,intel'
       architecture: all
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "", "coverage": "", "sanitize": ""}'

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
     inputs:
       platform:
-        description: 'Platform filter, comma-separated list. Use "all" for all platforms, "!platform" to exclude (e.g., "all,!intel")'
+        description: 'Platform filter, comma-separated list. Use "all" for all platforms, "!platform" to exclude a platform on every architecture, and "!platform~arch" to exclude a single platform/architecture combination (e.g., "all,!intel,!macos-26~x86_64")'
         type: string
         default: all
       architecture:
@@ -108,7 +108,18 @@ jobs:
 
           # Parse comma-separated filters
           platform_list = [p.strip() for p in platform_filter.split(',') if p.strip()]
-          exclude_list = [p[1:] for p in platform_list if p.startswith('!')]
+          # Exclusions come in two forms:
+          #   "!platform"       -> drop that platform on every architecture
+          #   "!platform~arch"  -> drop a single platform/architecture combination
+          # ("~" separates arch because "-" already appears in platform names, e.g. macos-26.)
+          exclude_platforms = set()
+          exclude_combinations = set()
+          for token in (p[1:] for p in platform_list if p.startswith('!')):
+              platform_part, sep, architecture_part = token.partition('~')
+              if sep:
+                  exclude_combinations.add((platform_part, architecture_part))
+              else:
+                  exclude_platforms.add(platform_part)
           requested_optional_combinations = [
               (platform, architecture)
               for platform, architecture in optional_combinations
@@ -121,7 +132,8 @@ jobs:
               (platform, architecture)
               for platform, architecture in candidate_combinations
               if (platform in platform_list or 'all' in platform_list) and
-                 (platform not in exclude_list) and
+                 (platform not in exclude_platforms) and
+                 ((platform, architecture) not in exclude_combinations) and
                  (architecture == architecture_filter or architecture_filter == 'all')
           ]
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** CI runs the full test suite on macOS Intel (x86_64) runners in the nightly and periodic master-validation flows. These runners are slow, scarce, and flaky (heavy test-suite timeouts and ephemeral-port exhaustion).
2. **Change:** Stop scheduling the **test** suite on macOS x86_64 while the runner problem is mitigated, keeping macOS ARM (aarch64) coverage. The platform filter in `generate-matrix.yml` gains a `!platform~arch` form that excludes a single platform/architecture combination; the test-running callers (nightly `test-all-platforms`, periodic master validation) apply `!macos-*~x86_64`. Build-only jobs still target macOS x86_64: the merge-queue `build-unique-oses` job (runs with `skip-tests`), `redis-build-sanity`, and the `event-release.yml` artifact manifest — so we keep building and shipping Intel-mac binaries.
3. **Outcome:** No **test** jobs run on macOS Intel runners; macOS ARM continues to run everywhere it did before, and macOS Intel builds are still exercised and shipped. Reverting is a one-line change per caller (drop the `!macos-*~x86_64` tokens).

#### Which additional issues this PR fixes
1. MOD-... (macOS Intel runner reliability; to be linked)

#### Main objects this PR modified
1. `.github/workflows/generate-matrix.yml` — exclusion parser now supports `!platform~arch` (single platform/arch combo) in addition to `!platform`.
2. `.github/workflows/event-nightly.yml`, `.github/workflows/event-periodic-master-validation.yml` — exclude `macos-*~x86_64` from the test matrix.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI-only change; no user-facing product behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
