### PR TITLE
[MOD-14859] FT.INFO: aggregate per-field disk metrics in the coordinator reducer

### DIFF
--- a/src/info/field_spec_info.c
+++ b/src/info/field_spec_info.c
@@ -111,19 +111,15 @@ void FieldSpecInfo_SetStats(FieldSpecInfo *info, FieldSpecStats stats) {
 static void FieldStats_DeserializeDiskMetrics(FieldSpecStats *stats, const MRReply *reply) {
     MRReply *exclusive = MRReply_MapElement(reply, FIELD_DISK_EXCLUSIVE_BYTES);
     MRReply *shared = MRReply_MapElement(reply, FIELD_DISK_SHARED_BYTES);
-    if (exclusive || shared) {
-        stats->textDisk.available = true;
-        if (exclusive) stats->textDisk.exclusive_bytes = MRReply_Integer(exclusive);
-        if (shared) stats->textDisk.shared_bytes = MRReply_Integer(shared);
-    }
+    stats->textDisk.available = exclusive || shared;
+    if (exclusive) stats->textDisk.exclusive_bytes = MRReply_Integer(exclusive);
+    if (shared) stats->textDisk.shared_bytes = MRReply_Integer(shared);
 
     MRReply *totalBytes = MRReply_MapElement(reply, FIELD_DISK_TOTAL_BYTES);
     MRReply *numKeys = MRReply_MapElement(reply, FIELD_DISK_NUM_KEYS);
-    if (totalBytes || numKeys) {
-        stats->cfDisk.available = true;
-        if (totalBytes) stats->cfDisk.total_bytes = MRReply_Integer(totalBytes);
-        if (numKeys) stats->cfDisk.estimate_num_keys = MRReply_Integer(numKeys);
-    }
+    stats->cfDisk.available = totalBytes || numKeys;
+    if (totalBytes) stats->cfDisk.total_bytes = MRReply_Integer(totalBytes);
+    if (numKeys) stats->cfDisk.estimate_num_keys = MRReply_Integer(numKeys);
 }
 
 static FieldSpecStats FieldStats_Deserialize(const char* type, const MRReply* reply){

--- a/src/info/field_spec_info.c
+++ b/src/info/field_spec_info.c
@@ -111,15 +111,22 @@ void FieldSpecInfo_SetStats(FieldSpecInfo *info, FieldSpecStats stats) {
 static void FieldStats_DeserializeDiskMetrics(FieldSpecStats *stats, const MRReply *reply) {
     MRReply *exclusive = MRReply_MapElement(reply, FIELD_DISK_EXCLUSIVE_BYTES);
     MRReply *shared = MRReply_MapElement(reply, FIELD_DISK_SHARED_BYTES);
-    stats->textDisk.available = exclusive || shared;
-    if (exclusive) stats->textDisk.exclusive_bytes = MRReply_Integer(exclusive);
-    if (shared) stats->textDisk.shared_bytes = MRReply_Integer(shared);
+    // The two keys of each metric pair are emitted together by the shard, or not at all.
+    RS_ASSERT((exclusive != NULL) == (shared != NULL));
+    stats->textDisk.available = exclusive && shared;
+    if (stats->textDisk.available) {
+        stats->textDisk.exclusive_bytes = MRReply_Integer(exclusive);
+        stats->textDisk.shared_bytes = MRReply_Integer(shared);
+    }
 
     MRReply *totalBytes = MRReply_MapElement(reply, FIELD_DISK_TOTAL_BYTES);
     MRReply *numKeys = MRReply_MapElement(reply, FIELD_DISK_NUM_KEYS);
-    stats->cfDisk.available = totalBytes || numKeys;
-    if (totalBytes) stats->cfDisk.total_bytes = MRReply_Integer(totalBytes);
-    if (numKeys) stats->cfDisk.estimate_num_keys = MRReply_Integer(numKeys);
+    RS_ASSERT((totalBytes != NULL) == (numKeys != NULL));
+    stats->cfDisk.available = totalBytes && numKeys;
+    if (stats->cfDisk.available) {
+        stats->cfDisk.total_bytes = MRReply_Integer(totalBytes);
+        stats->cfDisk.estimate_num_keys = MRReply_Integer(numKeys);
+    }
 }
 
 static FieldSpecStats FieldStats_Deserialize(const char* type, const MRReply* reply){

--- a/src/info/field_spec_info.c
+++ b/src/info/field_spec_info.c
@@ -11,6 +11,13 @@
 #include "coord/rmr/reply.h"
 #include "search_disk.h"
 
+// Per-field disk metric reply keys, shared by the shard emitter and the
+// coordinator deserializer so both agree on the wire names.
+#define FIELD_DISK_EXCLUSIVE_BYTES "disk_exclusive_bytes"
+#define FIELD_DISK_SHARED_BYTES    "disk_shared_bytes"
+#define FIELD_DISK_TOTAL_BYTES     "disk_total_bytes"
+#define FIELD_DISK_NUM_KEYS        "disk_num_keys"
+
 static FieldType getFieldType(const char *type){
     if (strcmp(type, "vector") == 0) {
         return INDEXFLD_T_VECTOR;
@@ -18,18 +25,42 @@ static FieldType getFieldType(const char *type){
     return 0;
 }
 
-static void FieldSpecStats_Combine(FieldSpecStats *first, const FieldSpecStats *second) {
-    if (!first->type){
-        *first = *second;
+// Per-field disk metrics are cluster-wide totals, so each metric is summed
+// across shards. A shard that omits the `disk` metrics (e.g. an older,
+// mixed-version shard, or a non-disk-backed shard) reports `available = false`
+// and contributes nothing.
+static void PerFieldTextDiskMetrics_Combine(PerFieldTextDiskMetrics *dst,
+                                            const PerFieldTextDiskMetrics *src) {
+    if (!src->available) {
         return;
     }
-    switch (first->type) {
-        case INDEXFLD_T_VECTOR:
-            VectorIndexStats_Agg(&first->vecStats, &second->vecStats);
-            break;
-        default:
-            break;
-        }
+    dst->exclusive_bytes += src->exclusive_bytes;
+    dst->shared_bytes += src->shared_bytes;
+    dst->available = true;
+}
+
+static void PerFieldCfDiskMetrics_Combine(PerFieldCfDiskMetrics *dst,
+                                          const PerFieldCfDiskMetrics *src) {
+    if (!src->available) {
+        return;
+    }
+    dst->total_bytes += src->total_bytes;
+    dst->estimate_num_keys += src->estimate_num_keys;
+    dst->available = true;
+}
+
+static void FieldSpecStats_Combine(FieldSpecStats *first, const FieldSpecStats *second) {
+    // The field type is consistent across shards; adopt it from the first shard
+    // that reports one (non-vector fields carry type 0 on the coordinator).
+    if (!first->type) {
+        first->type = second->type;
+    }
+    if (first->type == INDEXFLD_T_VECTOR) {
+        VectorIndexStats_Agg(&first->vecStats, &second->vecStats);
+    }
+    // Disk metrics apply to every field type, independently of `type`.
+    PerFieldTextDiskMetrics_Combine(&first->textDisk, &second->textDisk);
+    PerFieldCfDiskMetrics_Combine(&first->cfDisk, &second->cfDisk);
 }
 
 FieldSpecInfo FieldSpecInfo_Init() {
@@ -74,6 +105,27 @@ void FieldSpecInfo_SetStats(FieldSpecInfo *info, FieldSpecStats stats) {
     info->stats = stats;
 }
 
+// Parse the optional per-field `disk` metrics emitted by a disk-backed shard.
+// Keys are absent for non-disk-backed or older (mixed-version) shards, in which
+// case `available` stays false and the metrics contribute nothing to the reduce.
+static void FieldStats_DeserializeDiskMetrics(FieldSpecStats *stats, const MRReply *reply) {
+    MRReply *exclusive = MRReply_MapElement(reply, FIELD_DISK_EXCLUSIVE_BYTES);
+    MRReply *shared = MRReply_MapElement(reply, FIELD_DISK_SHARED_BYTES);
+    if (exclusive || shared) {
+        stats->textDisk.available = true;
+        if (exclusive) stats->textDisk.exclusive_bytes = MRReply_Integer(exclusive);
+        if (shared) stats->textDisk.shared_bytes = MRReply_Integer(shared);
+    }
+
+    MRReply *totalBytes = MRReply_MapElement(reply, FIELD_DISK_TOTAL_BYTES);
+    MRReply *numKeys = MRReply_MapElement(reply, FIELD_DISK_NUM_KEYS);
+    if (totalBytes || numKeys) {
+        stats->cfDisk.available = true;
+        if (totalBytes) stats->cfDisk.total_bytes = MRReply_Integer(totalBytes);
+        if (numKeys) stats->cfDisk.estimate_num_keys = MRReply_Integer(numKeys);
+    }
+}
+
 static FieldSpecStats FieldStats_Deserialize(const char* type, const MRReply* reply){
     FieldSpecStats stats = {0};
     FieldType fieldType = getFieldType(type);
@@ -93,6 +145,9 @@ static FieldSpecStats FieldStats_Deserialize(const char* type, const MRReply* re
         default:
             break;
     }
+    // Disk metrics are field-type independent and keyed by name, so parse them
+    // for every field regardless of the vector switch above.
+    FieldStats_DeserializeDiskMetrics(&stats, reply);
     return stats;
 }
 
@@ -114,12 +169,12 @@ void FieldSpecStats_Reply(const FieldSpecStats* stats, RedisModule_Reply *reply)
 
     // Per-field disk metrics (disk-backed indexes only; gated on `available`).
     if (stats->textDisk.available) {
-        REPLY_KVINT("disk_exclusive_bytes", stats->textDisk.exclusive_bytes);
-        REPLY_KVINT("disk_shared_bytes", stats->textDisk.shared_bytes);
+        REPLY_KVINT(FIELD_DISK_EXCLUSIVE_BYTES, stats->textDisk.exclusive_bytes);
+        REPLY_KVINT(FIELD_DISK_SHARED_BYTES, stats->textDisk.shared_bytes);
     }
     if (stats->cfDisk.available) {
-        REPLY_KVINT("disk_total_bytes", stats->cfDisk.total_bytes);
-        REPLY_KVINT("disk_num_keys", stats->cfDisk.estimate_num_keys);
+        REPLY_KVINT(FIELD_DISK_TOTAL_BYTES, stats->cfDisk.total_bytes);
+        REPLY_KVINT(FIELD_DISK_NUM_KEYS, stats->cfDisk.estimate_num_keys);
     }
 }
 

--- a/src/info/field_spec_info.h
+++ b/src/info/field_spec_info.h
@@ -19,6 +19,10 @@
 #include "obfuscation/hidden.h"
 #include "search_disk_api.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct FieldSpecStats {
   union {
     VectorIndexStats vecStats;
@@ -91,3 +95,7 @@ size_t IndexSpec_VectorIndexesSize(IndexSpec *sp);
 
 //Get the combined stats of all vector fields in the index.
 VectorIndexStats IndexSpec_GetVectorIndexesStats(IndexSpec *sp);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/cpptests/coord_tests/test_cpp_field_disk_metrics.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_field_disk_metrics.cpp
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+// Coordinator FT.INFO reducer: aggregation of per-field disk metrics.
+//
+// The shard emits per-field `disk_*` keys inside each `field statistics` entry
+// (see src/info/field_spec_info.c). The coordinator deserializes each shard's
+// entry into an AggregatedFieldSpecInfo and folds them together with
+// AggregatedFieldSpecInfo_Combine. These tests drive that deserialize/combine
+// path with synthetic shard replies, since a real disk backend is not present
+// in the OSS build.
+
+#include "gtest/gtest.h"
+
+#include "info/field_spec_info.h"
+#include "hiredis/hiredis.h"
+#include "hiredis/read.h"
+
+#include <string>
+
+// Minimal RESP2 serializer used to hand-build shard replies. RESP2 arrays are
+// fine: AggregatedFieldSpecInfo_Deserialize reinterprets even-length arrays as
+// maps, and the MR_REPLY_* type codes match hiredis' REDIS_REPLY_* values.
+namespace {
+
+class Resp {
+ public:
+  std::string s;
+  Resp &arr(size_t n) { s += "*" + std::to_string(n) + "\r\n"; return *this; }
+  Resp &str(const std::string &v) {
+    s += "$" + std::to_string(v.size()) + "\r\n" + v + "\r\n";
+    return *this;
+  }
+  Resp &integer(long long v) { s += ":" + std::to_string(v) + "\r\n"; return *this; }
+};
+
+// Append an "N/A" (no-error) Index Errors sub-object: 4 key/value pairs.
+void appendEmptyIndexError(Resp &r) {
+  r.arr(8);
+  r.str("indexing failures").integer(0);
+  r.str("last indexing error").str("N/A");
+  r.str("last indexing error key").str("N/A");
+  r.str("last indexing error time").arr(2).integer(0).integer(0);
+}
+
+// A shard `field statistics` entry with the given identifier/attribute and an
+// empty error object, plus any extra key/value pairs appended by `extra`.
+template <typename Fn>
+std::string fieldEntry(const char *identifier, const char *attribute, size_t extraPairs,
+                       Fn extra) {
+  Resp r;
+  r.arr((3 + extraPairs) * 2);
+  r.str("identifier").str(identifier);
+  r.str("attribute").str(attribute);
+  r.str("Index Errors");
+  appendEmptyIndexError(r);
+  extra(r);
+  return r.s;
+}
+
+MRReply *parseReply(const std::string &resp) {
+  redisReader *reader = redisReaderCreate();
+  EXPECT_NE(reader, nullptr);
+  EXPECT_EQ(redisReaderFeed(reader, resp.data(), resp.size()), REDIS_OK);
+  void *replyPtr = nullptr;
+  EXPECT_EQ(redisReaderGetReply(reader, &replyPtr), REDIS_OK);
+  EXPECT_NE(replyPtr, nullptr);
+  redisReaderFree(reader);
+  return reinterpret_cast<MRReply *>(replyPtr);
+}
+
+// A shard reply plus its deserialized view, tied together so the borrowed
+// identifier/attribute pointers stay valid for the lifetime of the object.
+class ShardEntry {
+ public:
+  explicit ShardEntry(const std::string &resp) : reply_(parseReply(resp)) {
+    info_ = AggregatedFieldSpecInfo_Deserialize(reply_);
+  }
+  ~ShardEntry() {
+    AggregatedFieldSpecInfo_Clear(&info_);
+    freeReplyObject(reply_);
+  }
+  const AggregatedFieldSpecInfo *info() const { return &info_; }
+
+ private:
+  MRReply *reply_;
+  AggregatedFieldSpecInfo info_;
+};
+
+}  // namespace
+
+class FieldDiskMetricsTest : public ::testing::Test {};
+
+// A single text-field shard reply parses into available textDisk metrics and no
+// cf metrics.
+TEST_F(FieldDiskMetricsTest, DeserializeTextField) {
+  ShardEntry shard(fieldEntry("title", "title", 2, [](Resp &r) {
+    r.str("disk_exclusive_bytes").integer(100);
+    r.str("disk_shared_bytes").integer(40);
+  }));
+
+  const FieldSpecStats *stats = &shard.info()->stats;
+  EXPECT_TRUE(stats->textDisk.available);
+  EXPECT_EQ(stats->textDisk.exclusive_bytes, 100u);
+  EXPECT_EQ(stats->textDisk.shared_bytes, 40u);
+  EXPECT_FALSE(stats->cfDisk.available);
+}
+
+// A single tag/numeric/vector-field shard reply parses into available cf
+// metrics and no text metrics.
+TEST_F(FieldDiskMetricsTest, DeserializeCfField) {
+  ShardEntry shard(fieldEntry("n", "n", 2, [](Resp &r) {
+    r.str("disk_total_bytes").integer(4096);
+    r.str("disk_num_keys").integer(12);
+  }));
+
+  const FieldSpecStats *stats = &shard.info()->stats;
+  EXPECT_TRUE(stats->cfDisk.available);
+  EXPECT_EQ(stats->cfDisk.total_bytes, 4096u);
+  EXPECT_EQ(stats->cfDisk.estimate_num_keys, 12u);
+  EXPECT_FALSE(stats->textDisk.available);
+}
+
+// Text-field metrics are summed across shards.
+TEST_F(FieldDiskMetricsTest, CombineTextFieldSums) {
+  ShardEntry s1(fieldEntry("title", "title", 2, [](Resp &r) {
+    r.str("disk_exclusive_bytes").integer(100);
+    r.str("disk_shared_bytes").integer(40);
+  }));
+  ShardEntry s2(fieldEntry("title", "title", 2, [](Resp &r) {
+    r.str("disk_exclusive_bytes").integer(200);
+    r.str("disk_shared_bytes").integer(70);
+  }));
+
+  AggregatedFieldSpecInfo agg = AggregatedFieldSpecInfo_Init();
+  AggregatedFieldSpecInfo_Combine(&agg, s1.info());
+  AggregatedFieldSpecInfo_Combine(&agg, s2.info());
+
+  EXPECT_TRUE(agg.stats.textDisk.available);
+  EXPECT_EQ(agg.stats.textDisk.exclusive_bytes, 300u);
+  EXPECT_EQ(agg.stats.textDisk.shared_bytes, 110u);
+  AggregatedFieldSpecInfo_Clear(&agg);
+}
+
+// Cf-field metrics are summed across shards. Regression guard: before the fix,
+// non-vector fields carry type 0 on the coordinator and Combine overwrote
+// instead of accumulating, so only the last shard's value survived.
+TEST_F(FieldDiskMetricsTest, CombineCfFieldSums) {
+  ShardEntry s1(fieldEntry("n", "n", 2, [](Resp &r) {
+    r.str("disk_total_bytes").integer(1000);
+    r.str("disk_num_keys").integer(10);
+  }));
+  ShardEntry s2(fieldEntry("n", "n", 2, [](Resp &r) {
+    r.str("disk_total_bytes").integer(2500);
+    r.str("disk_num_keys").integer(25);
+  }));
+
+  AggregatedFieldSpecInfo agg = AggregatedFieldSpecInfo_Init();
+  AggregatedFieldSpecInfo_Combine(&agg, s1.info());
+  AggregatedFieldSpecInfo_Combine(&agg, s2.info());
+
+  EXPECT_TRUE(agg.stats.cfDisk.available);
+  EXPECT_EQ(agg.stats.cfDisk.total_bytes, 3500u);
+  EXPECT_EQ(agg.stats.cfDisk.estimate_num_keys, 35u);
+  AggregatedFieldSpecInfo_Clear(&agg);
+}
+
+// Mixed-version cluster: a shard that omits the disk keys must not fail the
+// reduce nor clobber the metrics contributed by disk-aware shards.
+TEST_F(FieldDiskMetricsTest, MixedVersionShardsDoNotClobber) {
+  ShardEntry diskShard(fieldEntry("title", "title", 2, [](Resp &r) {
+    r.str("disk_exclusive_bytes").integer(500);
+    r.str("disk_shared_bytes").integer(60);
+  }));
+  // Old shard: identifier/attribute/error only, no disk_* keys.
+  ShardEntry oldShard(fieldEntry("title", "title", 0, [](Resp &) {}));
+
+  const FieldSpecStats *oldStats = &oldShard.info()->stats;
+  EXPECT_FALSE(oldStats->textDisk.available);
+  EXPECT_FALSE(oldStats->cfDisk.available);
+
+  // Combine in either order: the disk-aware shard's values must survive intact.
+  AggregatedFieldSpecInfo agg = AggregatedFieldSpecInfo_Init();
+  AggregatedFieldSpecInfo_Combine(&agg, oldShard.info());
+  AggregatedFieldSpecInfo_Combine(&agg, diskShard.info());
+  AggregatedFieldSpecInfo_Combine(&agg, oldShard.info());
+
+  EXPECT_TRUE(agg.stats.textDisk.available);
+  EXPECT_EQ(agg.stats.textDisk.exclusive_bytes, 500u);
+  EXPECT_EQ(agg.stats.textDisk.shared_bytes, 60u);
+  AggregatedFieldSpecInfo_Clear(&agg);
+}
+
+// A field for which no shard reports disk metrics stays unavailable (metrics
+// are omitted from the reply), and the reduce still succeeds.
+TEST_F(FieldDiskMetricsTest, NoDiskMetricsAcrossShards) {
+  ShardEntry s1(fieldEntry("body", "body", 0, [](Resp &) {}));
+  ShardEntry s2(fieldEntry("body", "body", 0, [](Resp &) {}));
+
+  AggregatedFieldSpecInfo agg = AggregatedFieldSpecInfo_Init();
+  AggregatedFieldSpecInfo_Combine(&agg, s1.info());
+  AggregatedFieldSpecInfo_Combine(&agg, s2.info());
+
+  EXPECT_FALSE(agg.stats.textDisk.available);
+  EXPECT_FALSE(agg.stats.cfDisk.available);
+  AggregatedFieldSpecInfo_Clear(&agg);
+}


### PR DESCRIPTION
## Describe the changes in the pull request

Phase 3 of the Search-on-Disk observability work: aggregate per-field disk metrics in the coordinator `FT.INFO` reducer.

1. **Current:** Shards emit per-field `disk_*` keys inside each `field statistics` entry (added in MOD-14911), but the coordinator's `AggregatedFieldSpecInfo` deserializer only recognized vector metrics. On a cluster, the per-field disk metrics were silently dropped from the reduced `FT.INFO`.
2. **Change:** The coordinator now parses, aggregates, and re-emits the per-field disk metrics:
   - **Deserialize** `disk_exclusive_bytes`/`disk_shared_bytes` (text fields) and `disk_total_bytes`/`disk_num_keys` (tag/numeric/vector CF fields) for every field type. Absent keys leave `available = false`, so non-disk-backed and older mixed-version shards contribute nothing and never fail the reduce.
   - **Combine** each metric by summation across shards (cluster-wide totals). This also fixes a latent bug: non-vector fields carry `type == 0` on the coordinator, and the old `if (!type) *first = *second` shortcut *overwrote* stats on every shard fold instead of accumulating — so multi-shard totals reported only the last shard. Vector aggregation is unchanged (aggregating from a zeroed struct is equivalent to the previous wholesale copy).
   - **Reply** already emits the disk keys via the shared `FieldSpecStats_Reply`; it is now populated on the coordinator too. Key names are shared between the shard emitter and the coordinator deserializer via constants so they cannot drift.
3. **Outcome:** Coordinator `FT.INFO` includes aggregated per-field `disk_*` sub-maps in `field statistics`; mixed shard versions do not break INFO reduction.

#### Which additional issues this PR fixes
1. MOD-14859
2. Blocked by MOD-14912 (shard emission, closed); unblocks/relates to MOD-14860 (disk FT.INFO tests, enterprise repo).

#### Main objects this PR modified
1. `src/info/field_spec_info.c` — `FieldStats_Deserialize` (+`FieldStats_DeserializeDiskMetrics`), `FieldSpecStats_Combine` (+ per-metric combine helpers), shared key-name constants.
2. `src/info/field_spec_info.h` — `extern "C"` guards so the header links from C++ unit tests.
3. `tests/cpptests/coord_tests/test_cpp_field_disk_metrics.cpp` — new coordinator unit test.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

**User impact:** On a cluster, `FT.INFO` for a disk-backed index now reports per-field disk usage aggregated across shards (`disk_exclusive_bytes`, `disk_shared_bytes`, `disk_total_bytes`, `disk_num_keys`), instead of omitting them.

## Testing

- New `rstest_coord` unit test `FieldDiskMetricsTest` (6 cases) drives deserialize→combine with synthetic RESP shard replies: text-field sums, CF-field sums, mixed-version shard (no clobber, no reduce failure), and no-metrics-anywhere. **6/6 pass.**
- Full `rstest_coord` suite: **136/136 pass** (no regressions).
- An end-to-end Python test is not feasible in OSS: there is no disk backend (`sp->diskSpec` is `NULL`), so nothing emits `disk_*` keys. End-to-end disk `FT.INFO` coverage lives in the enterprise disk repo (MOD-14860).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
