### PR TITLE
test: add Python test for geoshape query error

### DIFF
--- a/tests/pytests/test_geometry_flat.py
+++ b/tests/pytests/test_geometry_flat.py
@@ -214,6 +214,22 @@ def testWKTQueryError(env):
   env.expect('FT.SEARCH', 'idx', '@name:(Ho*) @geom:[contains $poly]', 'PARAMS', 2, 'moly', 'POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))]', 'NOCONTENT', 'DIALECT', 3).error().contains('SEARCH_PARAM_NOT_FOUND Parameter not found')
   env.expect('FT.SEARCH', 'idx', '@name:(Ho*) @geom:[within $poly]', 'NOCONTENT', 'DIALECT', 3).error().contains('SEARCH_PARAM_NOT_FOUND Parameter not found')
 
+def testWKTQueryGeoshapeError(env):
+  ''' A syntactically valid query whose geometry string fails to parse must
+      surface the geoshape query error, wrapped with a fixed prefix and the
+      backend's detail. '''
+  conn = getConnectionByEnv(env)
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'geom', 'GEOSHAPE', 'FLAT').ok()
+  conn.execute_command('HSET', 'doc', 'geom', 'POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))')
+
+  # The predicate and parameter are well-formed, so the query parser accepts
+  # them and the parameter value is handed verbatim to the geometry backend,
+  # which rejects the misspelled geometry keyword. The error must carry the
+  # fixed prefix; the backend detail follows the colon.
+  env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2,
+             'poly', 'POLIGON((0 0, 0 150, 150 150, 150 0, 0 0))', 'NOCONTENT',
+             'DIALECT', 3).error().contains('Error querying geoshape index:')
+
 def testSimpleUpdate(env):
   ''' Test updating geometries '''
 


### PR DESCRIPTION
Assert that a syntactically valid query with a malformed geometry string surfaces the 'Error querying geoshape index:' reply.



#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
