### PR TITLE
redis_mock: own a NUL-terminated string copy

### DIFF
--- a/src/redisearch_rs/redis_json_api/src/mock.rs
+++ b/src/redisearch_rs/redis_json_api/src/mock.rs
@@ -18,9 +18,10 @@ use std::ptr::{self, NonNull};
 struct MockState {
     /// The document `openKeyWithFlags` resolves to. `None` models a missing document.
     doc: Option<serde_json::Value>,
-    /// Keeps serialized buffers (`getJSON` / `getJSONFromIter`) alive for the
-    /// lifetime of the mock: `redis_mock`'s `RedisModule_CreateString` stores
-    /// the pointer rather than copying, so the bytes must outlive the string.
+    /// Owns the serialized buffers (`getJSON` / `getJSONFromIter`) minted during
+    /// the mock's lifetime. `redis_mock`'s `RedisModule_CreateString` copies its
+    /// input, so retaining them here is not required for correctness; it simply
+    /// gives each transient buffer a well-defined owner for the call.
     strings: RefCell<Vec<Box<[u8]>>>,
 }
 
@@ -91,8 +92,11 @@ const unsafe fn node<'a>(json: ffi::RedisJSON) -> &'a serde_json::Value {
     unsafe { &*json.cast::<serde_json::Value>() }
 }
 
-/// Create a `RedisModuleString` over `bytes`, keeping the buffer alive in the
-/// mock's string arena.
+/// Create a `RedisModuleString` over `bytes`.
+///
+/// The buffer is parked in the mock's string arena so each transient buffer has
+/// a well-defined owner, but `RedisModule_CreateString` copies its input, so the
+/// arena is not load-bearing for correctness.
 fn arena_string(state: &MockState, bytes: Vec<u8>) -> *mut ffi::RedisModuleString {
     let buf = bytes.into_boxed_slice();
     let ptr = buf.as_ptr();
@@ -101,8 +105,9 @@ fn arena_string(state: &MockState, bytes: Vec<u8>) -> *mut ffi::RedisModuleStrin
     module_string(ptr, len)
 }
 
-/// Mint a `RedisModuleString` over `len` bytes at `ptr`, which the caller must
-/// keep alive (the mock `RedisModule_CreateString` stores the pointer).
+/// Mint a `RedisModuleString` over `len` bytes at `ptr`. The mock
+/// `RedisModule_CreateString` copies the bytes, so `ptr` only needs to stay
+/// valid for the duration of this call.
 fn module_string(ptr: *const u8, len: usize) -> *mut ffi::RedisModuleString {
     // SAFETY: initialized by `redis_mock::init_redis_module_mock`.
     let create = unsafe { redis_module::raw::RedisModule_CreateString }

--- a/src/redisearch_rs/redis_mock/src/key.rs
+++ b/src/redisearch_rs/redis_mock/src/key.rs
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn RedisModule_OpenKey(
     let key = Box::new(UserKey {
         ctx,
         ty: cloned_value,
-        name: keyname_user_string.user,
+        name: keyname_user_string.user(),
     });
     Box::into_raw(key).cast()
 }

--- a/src/redisearch_rs/redis_mock/src/string.rs
+++ b/src/redisearch_rs/redis_mock/src/string.rs
@@ -14,26 +14,33 @@ use std::{
 };
 
 /// Mock implementation of RedisModuleString from redismodule.h for testing purposes.
-#[derive(Default, Copy, Clone)]
+///
+/// Owns a NUL-terminated copy of the bytes it was created from, mirroring
+/// Redis's owned, NUL-terminated (yet binary-safe) sds buffers: callers may
+/// hand in a transient source and still read the string back after that source
+/// is gone. `length` is the logical byte count excluding the trailing NUL.
 #[repr(C)]
 pub(crate) struct UserString {
-    pub(crate) user: *const c_char,
+    /// The owned bytes, NUL-terminated. `length` is `owned.len() - 1`.
+    owned: Box<[c_char]>,
     pub(crate) length: usize,
 }
 
-// Safety: `UserString` is a non-owning, read-only view.
-// As such it may be freely moved as long as the caller
-// ensures the backing allocation stays valid and unmutated.
-unsafe impl Send for UserString {}
-// Safety: `UserString` is a non-owning, read-only view.
-// As such it may be freely accessed by other treads as long
-// as the caller ensures the backing allocation stays valid and unmutated.
-unsafe impl Sync for UserString {}
+impl UserString {
+    /// Pointer to the owned, NUL-terminated bytes, valid for as long as `self`
+    /// is alive. The first `length` bytes are the logical string.
+    pub(crate) fn user(&self) -> *const c_char {
+        self.owned.as_ptr()
+    }
+}
 
 /// Mock implementation of RedisModule_CreateString from redismodule.h for testing purposes.
 ///
+/// A null `ptr` produces a zero-filled string of length `len`, matching real
+/// Redis rather than yielding an empty string.
+///
 /// Safety:
-/// 1. ptr must be a valid pointer to a C string of length len.
+/// 1. ptr must be null, or a valid pointer to `len` initialized bytes.
 #[unsafe(export_name = "_RedisModule_CreateString.1")]
 #[expect(non_snake_case)]
 pub(crate) unsafe extern "C" fn RedisModule_CreateString(
@@ -41,9 +48,26 @@ pub(crate) unsafe extern "C" fn RedisModule_CreateString(
     ptr: *const ::std::ffi::c_char,
     len: usize,
 ) -> *mut redis_module::raw::RedisModuleString {
+    // Build an owned, NUL-terminated copy of `len` bytes so the string can be
+    // read back as a C string even once the caller's source buffer is gone.
+    // Real Redis zero-fills the buffer when the source is NULL (see
+    // `sdsnewlen` / `createEmbeddedStringObject`), producing a string of length
+    // `len` rather than an empty one, so mirror that here.
+    let mut owned = Vec::with_capacity(len + 1);
+    if ptr.is_null() {
+        owned.resize(len, 0);
+    } else {
+        // Safety: precondition 1 guarantees `ptr` covers `len` initialized bytes.
+        let src = unsafe { std::slice::from_raw_parts(ptr, len) };
+        owned.extend_from_slice(src);
+    }
+    owned.push(0);
+
     let val = Arc::new(UserString {
-        user: ptr,
+        // `length` excludes the trailing NUL and always matches `len`, even for
+        // a NULL (zero-filled) source.
         length: len,
+        owned: owned.into_boxed_slice(),
     });
 
     Arc::into_raw(val)
@@ -55,7 +79,7 @@ pub(crate) unsafe extern "C" fn RedisModule_CreateString(
 ///
 /// Safety:
 /// 1. s must be a valid pointer to a RedisModuleString created by this mock implementation.
-/// 2. len must be a valid pointer to a usize.
+/// 2. len must be null, or a valid pointer to a usize.
 #[expect(non_snake_case)]
 pub(crate) unsafe extern "C" fn RedisModule_StringPtrLen(
     s: *const redis_module::raw::RedisModuleString,
@@ -64,11 +88,15 @@ pub(crate) unsafe extern "C" fn RedisModule_StringPtrLen(
     // Safety: The caller ensured the ptr is correct (1.)
     let s = ManuallyDrop::new(unsafe { Arc::from_raw(s.cast::<UserString>()) });
 
-    // Safety: Caller provides valid len pointer (2)
-    unsafe {
-        *len = s.length;
+    // The real API treats `len` as optional; callers that only want the pointer
+    // pass null.
+    if !len.is_null() {
+        // Safety: Caller provides a valid, non-null len pointer (2)
+        unsafe {
+            *len = s.length;
+        }
     }
-    s.user
+    s.user()
 }
 
 /// Mock implementation of RedisModule_FreeString from redismodule.h for testing purposes.
@@ -167,4 +195,62 @@ pub(crate) unsafe extern "C" fn RedisModule_CreateStringPrintf(
     // C variadic are not stable so we cannot actually format the string.
     // Safety: 1. ensures fmt is a valid pointer and we counting the bytes to pass the proper length.
     unsafe { RedisModule_CreateString(ctx, fmt, c_str.count_bytes()) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Creating a string copies its source: the value reads back correctly and
+    /// is NUL-terminated even after the caller's source buffer is gone.
+    #[test]
+    fn create_copies_source_and_nul_terminates() {
+        let s = {
+            let src: Vec<c_char> = b"hello".iter().map(|&b| b as c_char).collect();
+            // Safety: `src` covers `src.len()` initialized bytes.
+            unsafe { RedisModule_CreateString(std::ptr::null_mut(), src.as_ptr(), src.len()) }
+            // `src` is dropped here, before we read `s` back below.
+        };
+
+        let mut len = 0usize;
+        // Safety: `s` was created by the mock; `len` is a valid slot.
+        let ptr = unsafe { RedisModule_StringPtrLen(s, &mut len) };
+        assert_eq!(len, 5);
+        // Safety: the mock stores `len` logical bytes plus a trailing NUL, so
+        // `ptr` is valid for `len + 1` bytes.
+        let bytes = unsafe { std::slice::from_raw_parts(ptr.cast::<u8>(), len + 1) };
+        assert_eq!(bytes, b"hello\0");
+
+        // Safety: `s` was created by the mock and is freed exactly once.
+        unsafe { RedisModule_FreeString(std::ptr::null_mut(), s) };
+    }
+
+    /// A null source pointer yields a zero-filled string of the requested
+    /// length (matching real Redis), and `RedisModule_StringPtrLen` accepts a
+    /// null length out-pointer.
+    #[test]
+    fn null_source_is_zero_filled_and_null_len_ok() {
+        // Safety: a null `ptr` is explicitly allowed (precondition 1).
+        let s = unsafe { RedisModule_CreateString(std::ptr::null_mut(), std::ptr::null(), 7) };
+
+        // A null `len` out-pointer must be accepted without writing through it.
+        // Safety: `s` was created by the mock; the `len` out-pointer may be null.
+        let ptr = unsafe { RedisModule_StringPtrLen(s, std::ptr::null_mut()) };
+
+        let mut len = 42usize;
+        // Safety: `s` was created by the mock; `len` is a valid slot.
+        unsafe { RedisModule_StringPtrLen(s, &mut len) };
+        assert_eq!(
+            len, 7,
+            "a null source is zero-filled to the requested length"
+        );
+
+        // The buffer is `len` zero bytes plus the trailing NUL — all zero.
+        // Safety: `ptr` is valid for `len + 1` bytes.
+        let bytes = unsafe { std::slice::from_raw_parts(ptr.cast::<u8>(), len + 1) };
+        assert_eq!(bytes, &[0u8; 8]);
+
+        // Safety: `s` was created by the mock and is freed exactly once.
+        unsafe { RedisModule_FreeString(std::ptr::null_mut(), s) };
+    }
 }

--- a/src/redisearch_rs/redis_mock/src/string_to_number.rs
+++ b/src/redisearch_rs/redis_mock/src/string_to_number.rs
@@ -19,7 +19,7 @@ use std::{
 ///
 /// # Safety
 /// 1. `s` must either be NULL or point to a valid [`UserString`] whose
-///    `user`/`length` fields describe an initialised byte buffer.
+///    `user()`/`length` describe an initialised byte buffer.
 unsafe fn user_string_bytes<'a>(
     s: *const redis_module::raw::RedisModuleString,
 ) -> Option<&'a [u8]> {
@@ -30,8 +30,8 @@ unsafe fn user_string_bytes<'a>(
     // Safety: The caller ensured the ptr is correct (1.)
     let us = ManuallyDrop::new(unsafe { Arc::from_raw(s.cast::<UserString>()) });
 
-    // Safety: UserString invariant: `user` points to `length` initialised bytes.
-    let bytes = unsafe { std::slice::from_raw_parts(us.user.cast::<u8>(), us.length) };
+    // Safety: UserString invariant: `user()` points to `length` initialised bytes.
+    let bytes = unsafe { std::slice::from_raw_parts(us.user().cast::<u8>(), us.length) };
     Some(bytes)
 }
 

--- a/src/redisearch_rs/rlookup/src/load_document/hash.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/hash.rs
@@ -255,12 +255,12 @@ mod tests {
     use super::*;
     use std::ffi::CString;
 
-    /// Build a [`RedisString`] whose backing bytes live in the caller's `CString`.
+    /// Build a [`RedisString`] from `bytes`.
     ///
-    /// The mock `RedisModule_CreateString` stores the pointer, not a copy, so
-    /// `bytes` must outlive the returned [`RedisString`].
+    /// The mock `RedisModule_CreateString` copies its input, so `bytes` need not
+    /// outlive the returned [`RedisString`].
     fn make_string(bytes: &CString) -> RedisString {
-        // Safety: `bytes` outlives the returned `RedisString` (caller-controlled).
+        // Safety: `bytes` is valid for the duration of the `from_raw_parts` call.
         unsafe { RedisString::from_raw_parts(None, bytes.as_ptr(), bytes.as_bytes().len()) }
     }
 

--- a/src/redisearch_rs/rlookup/tests/load_document_hash.rs
+++ b/src/redisearch_rs/rlookup/tests/load_document_hash.rs
@@ -43,10 +43,10 @@ where
     f(NonNull::from_mut(&mut ctx).cast::<ffi::RedisModuleCtx>())
 }
 
-/// Construct a `RedisString` from a `CString` that the caller keeps alive.
+/// Construct a `RedisString` from a `CString`.
 ///
-/// The mock `RedisModule_CreateString` stores the pointer rather than copying,
-/// so `bytes` must outlive the returned `RedisString`.
+/// The mock `RedisModule_CreateString` copies its input, so `bytes` need not
+/// outlive the returned `RedisString`.
 fn make_redis_string(bytes: &CString) -> RedisString {
     unsafe { RedisString::from_raw_parts(None, bytes.as_ptr(), bytes.as_bytes().len()) }
 }

--- a/src/redisearch_rs/rlookup/tests/load_document_json.rs
+++ b/src/redisearch_rs/rlookup/tests/load_document_json.rs
@@ -42,9 +42,9 @@ redis_mock::mock_or_stub_missing_redis_c_symbols!();
 const MULTI: u32 = ffi::APIVERSION_RETURN_MULTI_CMP_FIRST;
 const PRE_MULTI: u32 = MULTI - 1;
 
-/// Construct a `RedisString` from a `CStr` the caller keeps alive. The mock
-/// `RedisModule_CreateString` stores the pointer rather than copying, so the
-/// bytes must outlive the returned `RedisString`.
+/// Construct a `RedisString` from a `CStr`. The mock
+/// `RedisModule_CreateString` copies its input, so the source bytes need not
+/// outlive the returned `RedisString`.
 fn make_redis_string(bytes: &CStr) -> RedisString {
     unsafe { RedisString::from_raw_parts(None, bytes.as_ptr(), bytes.to_bytes().len()) }
 }


### PR DESCRIPTION
These two changes make the mock faithful to real Redis so a Rust integration
test can exercise a query-error path that builds a RedisModuleString from a
transient source and reads it back.

RedisModule_CreateString now owns a NUL-terminated copy of its bytes instead of
a non-owning view. The geoshape query-error path creates the error string from a
C++ exception's what() inside a catch block; that buffer is freed once the
exception is destroyed, so the old view dangled by the time Rust read it. Real
Redis copies the bytes (into a NUL-terminated, yet binary-safe, sds buffer), and
now the mock does too.

RedisModule_StringPtrLen now accepts a null length out-pointer. Callers that only
want the char pointer pass null (as the geoshape error path does, mirroring the C
RedisModule_StringPtrLen(errMsg, NULL) call); the old mock unconditionally wrote
through it and crashed on null, while the real API treats len as optional.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
