### PR TITLE
[MOD-16910] numeric score source: check for doc validity (ttl/deleted)

### DIFF
--- a/src/redisearch_rs/numeric_score_source/src/lib.rs
+++ b/src/redisearch_rs/numeric_score_source/src/lib.rs
@@ -31,7 +31,7 @@ pub mod source;
 
 pub use range_iterator::NumericRangeIterator;
 pub use score_batch::NumericScoreBatch;
-pub use source::NumericScoreSource;
+pub use source::{AllValid, DocValidity, NumericScoreSource};
 
 use std::{cmp::Ordering, num::NonZeroUsize};
 
@@ -42,7 +42,8 @@ use top_k::{TopKIterator, TopKMode};
 ///
 /// Construct one with [`new_numeric_top_k_unfiltered`] or
 /// [`new_numeric_top_k_filtered`].
-pub type NumericTopKIterator<'index> = TopKIterator<'index, NumericScoreSource<'index>>;
+pub type NumericTopKIterator<'index, V = AllValid> =
+    TopKIterator<'index, NumericScoreSource<'index, V>>;
 
 /// Pick the heap comparator for the query's sort direction.
 fn cmp_for(ascending: bool) -> fn(&f64, &f64) -> Ordering {
@@ -59,10 +60,10 @@ fn cmp_for(ascending: bool) -> fn(&f64, &f64) -> Ordering {
 /// value: a numeric source has no native top-k, so the heap ([`TopKMode::Batches`]
 /// with no child) performs the selection. The sort direction is taken from the
 /// `source` (`SORTBY field ASC`/`DESC`).
-pub fn new_numeric_top_k_unfiltered<'index>(
-    source: NumericScoreSource<'index>,
+pub fn new_numeric_top_k_unfiltered<'index, V: DocValidity + 'index>(
+    source: NumericScoreSource<'index, V>,
     k: NonZeroUsize,
-) -> NumericTopKIterator<'index> {
+) -> NumericTopKIterator<'index, V> {
     let cmp = cmp_for(source.ascending());
     TopKIterator::new_with_mode(source, None, k, cmp, TopKMode::Batches)
 }
@@ -71,11 +72,11 @@ pub fn new_numeric_top_k_unfiltered<'index>(
 ///
 /// Uses [`TopKMode::Batches`]: the source's batch is intersected with the
 /// child filter, and the heap keeps the top `k` by numeric value.
-pub fn new_numeric_top_k_filtered<'index>(
-    source: NumericScoreSource<'index>,
+pub fn new_numeric_top_k_filtered<'index, V: DocValidity + 'index>(
+    source: NumericScoreSource<'index, V>,
     child: impl RQEIterator<'index> + 'index,
     k: NonZeroUsize,
-) -> NumericTopKIterator<'index> {
+) -> NumericTopKIterator<'index, V> {
     let cmp = cmp_for(source.ascending());
     TopKIterator::new_with_mode(
         source,

--- a/src/redisearch_rs/numeric_score_source/src/lib.rs
+++ b/src/redisearch_rs/numeric_score_source/src/lib.rs
@@ -35,15 +35,15 @@ pub use source::{AllValid, DocValidity, NumericScoreSource};
 
 use std::{cmp::Ordering, num::NonZeroUsize};
 
-use rqe_iterators::RQEIterator;
+use rqe_iterators::{ExpirationChecker, NoOpChecker, RQEIterator};
 use top_k::{TopKIterator, TopKMode};
 
 /// A [`TopKIterator`] driven by a [`NumericScoreSource`].
 ///
 /// Construct one with [`new_numeric_top_k_unfiltered`] or
 /// [`new_numeric_top_k_filtered`].
-pub type NumericTopKIterator<'index, V = AllValid> =
-    TopKIterator<'index, NumericScoreSource<'index, V>>;
+pub type NumericTopKIterator<'index, V = AllValid, E = NoOpChecker> =
+    TopKIterator<'index, NumericScoreSource<'index, V, E>>;
 
 /// Pick the heap comparator for the query's sort direction.
 fn cmp_for(ascending: bool) -> fn(&f64, &f64) -> Ordering {
@@ -60,10 +60,14 @@ fn cmp_for(ascending: bool) -> fn(&f64, &f64) -> Ordering {
 /// value: a numeric source has no native top-k, so the heap ([`TopKMode::Batches`]
 /// with no child) performs the selection. The sort direction is taken from the
 /// `source` (`SORTBY field ASC`/`DESC`).
-pub fn new_numeric_top_k_unfiltered<'index, V: DocValidity + 'index>(
-    source: NumericScoreSource<'index, V>,
+pub fn new_numeric_top_k_unfiltered<
+    'index,
+    V: DocValidity + 'index,
+    E: ExpirationChecker + 'index,
+>(
+    source: NumericScoreSource<'index, V, E>,
     k: NonZeroUsize,
-) -> NumericTopKIterator<'index, V> {
+) -> NumericTopKIterator<'index, V, E> {
     let cmp = cmp_for(source.ascending());
     TopKIterator::new_with_mode(source, None, k, cmp, TopKMode::Batches)
 }
@@ -72,11 +76,15 @@ pub fn new_numeric_top_k_unfiltered<'index, V: DocValidity + 'index>(
 ///
 /// Uses [`TopKMode::Batches`]: the source's batch is intersected with the
 /// child filter, and the heap keeps the top `k` by numeric value.
-pub fn new_numeric_top_k_filtered<'index, V: DocValidity + 'index>(
-    source: NumericScoreSource<'index, V>,
+pub fn new_numeric_top_k_filtered<
+    'index,
+    V: DocValidity + 'index,
+    E: ExpirationChecker + 'index,
+>(
+    source: NumericScoreSource<'index, V, E>,
     child: impl RQEIterator<'index> + 'index,
     k: NonZeroUsize,
-) -> NumericTopKIterator<'index, V> {
+) -> NumericTopKIterator<'index, V, E> {
     let cmp = cmp_for(source.ascending());
     TopKIterator::new_with_mode(
         source,

--- a/src/redisearch_rs/numeric_score_source/src/score_batch.rs
+++ b/src/redisearch_rs/numeric_score_source/src/score_batch.rs
@@ -31,6 +31,14 @@ impl NumericScoreBatch {
         );
         Self { items, pos: 0 }
     }
+
+    /// Drop records whose doc id fails `keep`, preserving the strictly
+    /// increasing doc-id order. Called before the batch is consumed, so `pos`
+    /// stays at `0`.
+    pub(crate) fn retain(&mut self, keep: impl Fn(DocId) -> bool) {
+        debug_assert_eq!(self.pos, 0, "retain must run before the batch is read");
+        self.items.retain(|&(doc_id, _)| keep(doc_id));
+    }
 }
 
 impl ScoreBatch for NumericScoreBatch {

--- a/src/redisearch_rs/numeric_score_source/src/score_batch.rs
+++ b/src/redisearch_rs/numeric_score_source/src/score_batch.rs
@@ -32,12 +32,12 @@ impl NumericScoreBatch {
         Self { items, pos: 0 }
     }
 
-    /// Drop records whose doc id fails `keep`, preserving the strictly
+    /// Drop records for which `keep` returns `false`, preserving the strictly
     /// increasing doc-id order. Called before the batch is consumed, so `pos`
     /// stays at `0`.
-    pub(crate) fn retain(&mut self, keep: impl Fn(DocId) -> bool) {
+    pub(crate) fn retain(&mut self, keep: impl Fn(DocId, f64) -> bool) {
         debug_assert_eq!(self.pos, 0, "retain must run before the batch is read");
-        self.items.retain(|&(doc_id, _)| keep(doc_id));
+        self.items.retain(|&(doc_id, score)| keep(doc_id, score));
     }
 }
 

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -16,20 +16,22 @@ use inverted_index::NumericFilter;
 use numeric_range_tree::NumericRangeTree;
 use rqe_core::DocId;
 use rqe_iterator_type::IteratorType;
-use rqe_iterators::RQEIteratorError;
+use rqe_iterators::{ExpirationChecker, NoOpChecker, RQEIteratorError};
 use top_k::{BatchStrategy, ScoreSource};
 
 use crate::range_iterator::NumericRangeIterator;
 use crate::score_batch::NumericScoreBatch;
 
-/// Reports whether a doc id still resolves to a valid result document — one that
-/// is neither deleted nor expired.
+/// Reports whether a doc id still resolves to a live result document — one that
+/// has not been deleted and whose whole-document TTL has not lapsed.
 ///
-/// The numeric index keeps entries for such documents until GC reclaims them, so
-/// the source drops them before they reach the top-k heap. This mirrors the
-/// result processor's per-document validity check: the numeric optimizer's
-/// bounded heap must hold `k` *valid* survivors, and a downstream drop cannot
-/// retroactively admit the live document a stale entry displaced.
+/// This is the document-level check (deletion + whole-doc expiry); *field*-level
+/// TTL is a separate concern carried by an [`ExpirationChecker`]. The numeric
+/// index keeps entries for stale documents until GC reclaims them, so the source
+/// drops them before they reach the top-k heap. This mirrors the result
+/// processor's per-document validity check: the numeric optimizer's bounded heap
+/// must hold `k` *valid* survivors, and a downstream drop cannot retroactively
+/// admit the live document a stale entry displaced.
 pub trait DocValidity {
     /// Returns `true` if `doc_id` still resolves to a valid result document.
     fn is_valid(&self, doc_id: DocId) -> bool;
@@ -105,7 +107,8 @@ const MIN_SUCCESS_RATIO: f64 = 0.01;
 /// - TODO: MOD-14946 Profile metrics
 /// - TODO: MOD-14947 Parity tests
 /// - TODO: MOD-14948 Performance validation
-pub struct NumericScoreSource<'index, V: DocValidity = AllValid> {
+pub struct NumericScoreSource<'index, V: DocValidity = AllValid, E: ExpirationChecker = NoOpChecker>
+{
     /// Value-ordered range stream over the numeric index.
     ranges: NumericRangeIterator<'index>,
     /// Filter driving [`find`](NumericRangeTree::find); its `offset`/`limit`
@@ -136,9 +139,14 @@ pub struct NumericScoreSource<'index, V: DocValidity = AllValid> {
     heap_old_size: usize,
     /// Number of expand-and-retry iterations performed so far.
     num_iterations: usize,
-    /// Drops records for doc ids it reports invalid (deleted or expired) before
-    /// they reach the top-k heap. [`AllValid`] keeps every record.
+    /// Document-level validity oracle: drops records for doc ids it reports
+    /// invalid (deleted or whole-doc expired) before they reach the top-k heap.
+    /// [`AllValid`] keeps every record.
     validity: V,
+    /// Field-level TTL checker: drops records whose sort field has expired before
+    /// they reach the top-k heap, matching the optimizer's numeric field
+    /// predicate. [`NoOpChecker`] keeps every record.
+    expiration: E,
 }
 
 impl<'index> NumericScoreSource<'index> {
@@ -220,18 +228,49 @@ impl<'index> NumericScoreSource<'index> {
             heap_old_size: 0,
             num_iterations: 0,
             validity: AllValid,
+            expiration: NoOpChecker,
         }
     }
 }
 
-impl<'index, V: DocValidity> NumericScoreSource<'index, V> {
+impl<'index, V: DocValidity, E: ExpirationChecker> NumericScoreSource<'index, V, E> {
     /// Attach a document-validity oracle, dropping records for doc ids it reports
-    /// invalid (deleted or expired) from every batch. This is the source's
-    /// equivalent of the numeric optimizer's per-document validity check, keeping
-    /// entries that survive in the index until GC out of the top-k results.
-    pub fn with_validity<V2: DocValidity>(self, validity: V2) -> NumericScoreSource<'index, V2> {
+    /// invalid (deleted or whole-doc expired) from every batch. This is the
+    /// source's equivalent of the numeric optimizer's per-document validity
+    /// check, keeping entries that survive in the index until GC out of the
+    /// top-k results.
+    pub fn with_validity<V2: DocValidity>(self, validity: V2) -> NumericScoreSource<'index, V2, E> {
         NumericScoreSource {
             validity,
+            expiration: self.expiration,
+            ranges: self.ranges,
+            filter: self.filter,
+            initial_offset: self.initial_offset,
+            initial_limit: self.initial_limit,
+            ascending: self.ascending,
+            range_batch_size: self.range_batch_size,
+            num_estimated: self.num_estimated,
+            retry_enabled: self.retry_enabled,
+            num_docs: self.num_docs,
+            child_estimate: self.child_estimate,
+            last_limit_estimate: self.last_limit_estimate,
+            heap_old_size: self.heap_old_size,
+            num_iterations: self.num_iterations,
+        }
+    }
+
+    /// Attach a field-level TTL checker, dropping records whose sort field has
+    /// expired from every batch. This mirrors the numeric optimizer feeding a
+    /// field-expiration predicate to its numeric sub-iterator: the check is
+    /// pre-heap so expired records never displace a live document from the
+    /// bounded top-k.
+    pub fn with_expiration<E2: ExpirationChecker>(
+        self,
+        expiration: E2,
+    ) -> NumericScoreSource<'index, V, E2> {
+        NumericScoreSource {
+            expiration,
+            validity: self.validity,
             ranges: self.ranges,
             filter: self.filter,
             initial_offset: self.initial_offset,
@@ -311,18 +350,34 @@ impl<'index, V: DocValidity> NumericScoreSource<'index, V> {
     }
 }
 
-impl<'index, V: DocValidity> ScoreSource for NumericScoreSource<'index, V> {
+impl<'index, V: DocValidity, E: ExpirationChecker> ScoreSource
+    for NumericScoreSource<'index, V, E>
+{
     type Batch = NumericScoreBatch;
 
     fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
         let Some(mut batch) = self.ranges.next_n(self.range_batch_size)? else {
             return Ok(None);
         };
-        // Drop entries the index still holds for deleted or expired documents;
-        // the range tree only sheds them at GC time. The gate keeps the common
-        // no-filtering case free of the per-record check.
-        if self.validity.may_filter() {
-            batch.retain(|doc_id| self.validity.is_valid(doc_id));
+        // Drop stale entries pre-heap so they never displace a live document from
+        // the bounded top-k: document-level validity (deletion, whole-doc expiry)
+        // and field-level TTL, the two the range tree only sheds at GC time. Each
+        // gate keeps the common no-filtering case free of its per-record check.
+        let filter_validity = self.validity.may_filter();
+        let filter_expiration = self.expiration.has_expiration();
+        if filter_validity || filter_expiration {
+            batch.retain(|doc_id, score| {
+                if filter_validity && !self.validity.is_valid(doc_id) {
+                    return false;
+                }
+                if filter_expiration {
+                    let record = RSIndexResult::build_numeric(score).doc_id(doc_id).build();
+                    if self.expiration.is_expired(&record) {
+                        return false;
+                    }
+                }
+                true
+            });
         }
         Ok(Some(batch))
     }

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -138,7 +138,6 @@ pub struct NumericScoreSource<'index, V: DocValidity = AllValid> {
     num_iterations: usize,
     /// Drops records for doc ids it reports invalid (deleted or expired) before
     /// they reach the top-k heap. [`AllValid`] keeps every record.
-    #[expect(dead_code)]
     validity: V,
 }
 
@@ -316,7 +315,16 @@ impl<'index, V: DocValidity> ScoreSource for NumericScoreSource<'index, V> {
     type Batch = NumericScoreBatch;
 
     fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
-        Ok(self.ranges.next_n(self.range_batch_size)?)
+        let Some(mut batch) = self.ranges.next_n(self.range_batch_size)? else {
+            return Ok(None);
+        };
+        // Drop entries the index still holds for deleted or expired documents;
+        // the range tree only sheds them at GC time. The gate keeps the common
+        // no-filtering case free of the per-record check.
+        if self.validity.may_filter() {
+            batch.retain(|doc_id| self.validity.is_valid(doc_id));
+        }
+        Ok(Some(batch))
     }
 
     fn lookup_score(&mut self, _doc_id: DocId) -> Option<f64> {

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -22,6 +22,41 @@ use top_k::{BatchStrategy, ScoreSource};
 use crate::range_iterator::NumericRangeIterator;
 use crate::score_batch::NumericScoreBatch;
 
+/// Reports whether a doc id still resolves to a valid result document — one that
+/// is neither deleted nor expired.
+///
+/// The numeric index keeps entries for such documents until GC reclaims them, so
+/// the source drops them before they reach the top-k heap. This mirrors the
+/// result processor's per-document validity check: the numeric optimizer's
+/// bounded heap must hold `k` *valid* survivors, and a downstream drop cannot
+/// retroactively admit the live document a stale entry displaced.
+pub trait DocValidity {
+    /// Returns `true` if `doc_id` still resolves to a valid result document.
+    fn is_valid(&self, doc_id: DocId) -> bool;
+
+    /// Fast-path gate: `false` lets the source skip filtering entirely.
+    fn may_filter(&self) -> bool {
+        true
+    }
+}
+
+/// A [`DocValidity`] that treats every document as valid, for when no doc table
+/// is available (the default) or validity filtering is not wanted.
+#[derive(Clone, Copy, Default)]
+pub struct AllValid;
+
+impl DocValidity for AllValid {
+    #[inline(always)]
+    fn is_valid(&self, _doc_id: DocId) -> bool {
+        true
+    }
+
+    #[inline(always)]
+    fn may_filter(&self) -> bool {
+        false
+    }
+}
+
 /// Default number of value-ordered ranges materialized into a single batch.
 ///
 /// Larger batches amortize the per-batch child rewind in the surrounding
@@ -70,7 +105,7 @@ const MIN_SUCCESS_RATIO: f64 = 0.01;
 /// - TODO: MOD-14946 Profile metrics
 /// - TODO: MOD-14947 Parity tests
 /// - TODO: MOD-14948 Performance validation
-pub struct NumericScoreSource<'index> {
+pub struct NumericScoreSource<'index, V: DocValidity = AllValid> {
     /// Value-ordered range stream over the numeric index.
     ranges: NumericRangeIterator<'index>,
     /// Filter driving [`find`](NumericRangeTree::find); its `offset`/`limit`
@@ -101,6 +136,10 @@ pub struct NumericScoreSource<'index> {
     heap_old_size: usize,
     /// Number of expand-and-retry iterations performed so far.
     num_iterations: usize,
+    /// Drops records for doc ids it reports invalid (deleted or expired) before
+    /// they reach the top-k heap. [`AllValid`] keeps every record.
+    #[expect(dead_code)]
+    validity: V,
 }
 
 impl<'index> NumericScoreSource<'index> {
@@ -181,6 +220,32 @@ impl<'index> NumericScoreSource<'index> {
             child_estimate,
             heap_old_size: 0,
             num_iterations: 0,
+            validity: AllValid,
+        }
+    }
+}
+
+impl<'index, V: DocValidity> NumericScoreSource<'index, V> {
+    /// Attach a document-validity oracle, dropping records for doc ids it reports
+    /// invalid (deleted or expired) from every batch. This is the source's
+    /// equivalent of the numeric optimizer's per-document validity check, keeping
+    /// entries that survive in the index until GC out of the top-k results.
+    pub fn with_validity<V2: DocValidity>(self, validity: V2) -> NumericScoreSource<'index, V2> {
+        NumericScoreSource {
+            validity,
+            ranges: self.ranges,
+            filter: self.filter,
+            initial_offset: self.initial_offset,
+            initial_limit: self.initial_limit,
+            ascending: self.ascending,
+            range_batch_size: self.range_batch_size,
+            num_estimated: self.num_estimated,
+            retry_enabled: self.retry_enabled,
+            num_docs: self.num_docs,
+            child_estimate: self.child_estimate,
+            last_limit_estimate: self.last_limit_estimate,
+            heap_old_size: self.heap_old_size,
+            num_iterations: self.num_iterations,
         }
     }
 
@@ -247,7 +312,7 @@ impl<'index> NumericScoreSource<'index> {
     }
 }
 
-impl<'index> ScoreSource for NumericScoreSource<'index> {
+impl<'index, V: DocValidity> ScoreSource for NumericScoreSource<'index, V> {
     type Batch = NumericScoreBatch;
 
     fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -37,9 +37,7 @@ pub trait DocValidity {
     fn is_valid(&self, doc_id: DocId) -> bool;
 
     /// Fast-path gate: `false` lets the source skip filtering entirely.
-    fn may_filter(&self) -> bool {
-        true
-    }
+    fn may_filter(&self) -> bool;
 }
 
 /// A [`DocValidity`] that treats every document as valid, for when no doc table

--- a/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
@@ -13,6 +13,7 @@
 use std::collections::HashSet;
 use std::{iter, num::NonZeroUsize};
 
+use index_result::RSIndexResult;
 use inverted_index::NumericFilter;
 use numeric_range_tree::NumericRangeTree;
 use numeric_range_tree::test_utils::build_tree;
@@ -20,7 +21,7 @@ use numeric_score_source::{
     DocValidity, NumericScoreSource, new_numeric_top_k_filtered, new_numeric_top_k_unfiltered,
 };
 use rqe_core::DocId;
-use rqe_iterators::{IdList, RQEIterator};
+use rqe_iterators::{ExpirationChecker, IdList, RQEIterator};
 use top_k::{ScoreBatch, ScoreSource};
 
 /// A validity oracle backed by an explicit set of deleted doc ids, standing in
@@ -38,6 +39,26 @@ impl DocValidity for DeletedDocs {
 }
 
 impl FromIterator<DocId> for DeletedDocs {
+    fn from_iter<I: IntoIterator<Item = DocId>>(ids: I) -> Self {
+        Self(ids.into_iter().collect())
+    }
+}
+
+/// A field-TTL checker backed by an explicit set of doc ids, standing in for a
+/// TTL table whose entries have lapsed but not yet been reclaimed by GC.
+struct ExpiredDocs(HashSet<DocId>);
+
+impl ExpirationChecker for ExpiredDocs {
+    fn has_expiration(&self) -> bool {
+        !self.0.is_empty()
+    }
+
+    fn is_expired(&self, result: &RSIndexResult) -> bool {
+        self.0.contains(&result.doc_id)
+    }
+}
+
+impl FromIterator<DocId> for ExpiredDocs {
     fn from_iter<I: IntoIterator<Item = DocId>>(ids: I) -> Self {
         Self(ids.into_iter().collect())
     }
@@ -367,4 +388,41 @@ fn filtered_excludes_deleted_docs() {
         got.push((result.doc_id, result.as_numeric().expect("numeric result")));
     }
     assert_eq!(got, vec![(2, 2.0)]);
+}
+
+#[test]
+fn unfiltered_excludes_field_expired_docs() {
+    // Doc 1 holds the top value but its sort field has expired; the numeric-index
+    // entry survives until GC. Pre-heap filtering must drop it so the heap still
+    // fills k live results, best-first — the same fill-to-k the optimizer's field
+    // predicate gives.
+    let tree = tree_from(&[(1, 5.0), (2, 1.0), (3, 4.0), (4, 2.0), (5, 3.0)]);
+    let expired = ExpiredDocs::from_iter([1]);
+    let source =
+        NumericScoreSource::unfiltered(&tree, full_range(), false).with_expiration(expired);
+    let mut it = new_numeric_top_k_unfiltered(source, NonZeroUsize::new(3).unwrap());
+
+    let mut got = Vec::new();
+    while let Some(result) = it.read().unwrap() {
+        got.push((result.doc_id, result.as_numeric().expect("numeric result")));
+    }
+    assert_eq!(got, vec![(3, 4.0), (5, 3.0), (4, 2.0)]);
+}
+
+#[test]
+fn validity_and_expiration_compose() {
+    // Deletion and field-TTL are independent oracles applied together: doc 1 is
+    // deleted and doc 3 is field-expired, so both drop and the heap fills from
+    // the remaining live docs.
+    let tree = tree_from(&[(1, 5.0), (2, 1.0), (3, 4.0), (4, 2.0), (5, 3.0)]);
+    let source = NumericScoreSource::unfiltered(&tree, full_range(), false)
+        .with_validity(DeletedDocs::from_iter([1]))
+        .with_expiration(ExpiredDocs::from_iter([3]));
+    let mut it = new_numeric_top_k_unfiltered(source, NonZeroUsize::new(3).unwrap());
+
+    let mut got = Vec::new();
+    while let Some(result) = it.read().unwrap() {
+        got.push((result.doc_id, result.as_numeric().expect("numeric result")));
+    }
+    assert_eq!(got, vec![(5, 3.0), (4, 2.0), (2, 1.0)]);
 }

--- a/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
@@ -10,17 +10,38 @@
 //! Tests for [`NumericScoreSource`], driven by real [`NumericRangeTree`]
 //! fixtures.
 
+use std::collections::HashSet;
 use std::{iter, num::NonZeroUsize};
 
 use inverted_index::NumericFilter;
 use numeric_range_tree::NumericRangeTree;
 use numeric_range_tree::test_utils::build_tree;
 use numeric_score_source::{
-    NumericScoreSource, new_numeric_top_k_filtered, new_numeric_top_k_unfiltered,
+    DocValidity, NumericScoreSource, new_numeric_top_k_filtered, new_numeric_top_k_unfiltered,
 };
 use rqe_core::DocId;
 use rqe_iterators::{IdList, RQEIterator};
 use top_k::{ScoreBatch, ScoreSource};
+
+/// A validity oracle backed by an explicit set of deleted doc ids, standing in
+/// for a doc table with entries flagged deleted but not yet reclaimed by GC.
+struct DeletedDocs(HashSet<DocId>);
+
+impl DocValidity for DeletedDocs {
+    fn is_valid(&self, doc_id: DocId) -> bool {
+        !self.0.contains(&doc_id)
+    }
+
+    fn may_filter(&self) -> bool {
+        !self.0.is_empty()
+    }
+}
+
+impl FromIterator<DocId> for DeletedDocs {
+    fn from_iter<I: IntoIterator<Item = DocId>>(ids: I) -> Self {
+        Self(ids.into_iter().collect())
+    }
+}
 
 /// Build a numeric tree from `(doc_id, value)` pairs (added in the given order).
 ///
@@ -308,4 +329,42 @@ fn filtered_rewind_after_expansion_repeats_results() {
 
     assert_eq!(first, second);
     assert_eq!(first, vec![(20, 20.0), (1, 1.0)]);
+}
+
+#[test]
+fn unfiltered_excludes_deleted_docs() {
+    // Doc 1 holds the top value but has been deleted; its numeric-index entry
+    // survives until GC. Top-k must skip it and return the next-best live docs.
+    let tree = tree_from(&[(1, 5.0), (2, 1.0), (3, 4.0), (4, 2.0), (5, 3.0)]);
+    let deleted = DeletedDocs::from_iter([1]);
+    let source = NumericScoreSource::unfiltered(&tree, full_range(), false).with_validity(deleted);
+    let mut it = new_numeric_top_k_unfiltered(source, NonZeroUsize::new(3).unwrap());
+
+    let mut got = Vec::new();
+    while let Some(result) = it.read().unwrap() {
+        got.push((result.doc_id, result.as_numeric().expect("numeric result")));
+    }
+    assert_eq!(got, vec![(3, 4.0), (5, 3.0), (4, 2.0)]);
+}
+
+#[test]
+fn filtered_excludes_deleted_docs() {
+    // The child passes docs 2 and 4, and doc 4 has the higher value — but it is
+    // deleted, so only the live match survives the liveness filter.
+    let tree = tree_from(&[(1, 1.0), (2, 2.0), (3, 3.0), (4, 100.0), (5, 5.0)]);
+    let deleted = DeletedDocs::from_iter([4]);
+    let child_ids = vec![2u64, 4u64];
+    let source = NumericScoreSource::filtered(&tree, full_range(), false, 1, 5, child_ids.len())
+        .with_validity(deleted);
+    let mut it = new_numeric_top_k_filtered(
+        source,
+        IdList::<true>::new(child_ids),
+        NonZeroUsize::new(2).unwrap(),
+    );
+
+    let mut got = Vec::new();
+    while let Some(result) = it.read().unwrap() {
+        got.push((result.doc_id, result.as_numeric().expect("numeric result")));
+    }
+    assert_eq!(got, vec![(2, 2.0)]);
 }


### PR DESCRIPTION
- based on https://github.com/RediSearch/RediSearch/pull/10316
- next: https://github.com/RediSearch/RediSearch/pull/10486
- side discussion: https://github.com/RediSearch/RediSearch/pull/10511

2 objectives in this PR:
- field-TTL expiry handling: C side handles that by creating [a numeric iterator with an explicit filter for that TTL](https://github.com/RediSearch/RediSearch/blob/53cb6b53d8daaa85fe8f0aa068071caaa0b9c9be/src/iterators/optimizer_reader.c#L270-L275)
  - In rust, we can support that with the `ExpirationChecker` trait for better testability and separation of concerns.  
- handle deleted documents not GC-ed yet: C handles it when collecting the batches: https://github.com/RediSearch/RediSearch/blob/53cb6b53d8daaa85fe8f0aa068071caaa0b9c9be/src/iterators/optimizer_reader.c#L179-L182
  - before entering the heap

C code for the optimizer doesn't use the same mechanism as hybrid: 

Vector filters expired docs at the end, which is too late so can return fewer results than k. The optimizer filter them before the heap, so the top-k stays full.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
