### PR TITLE
[MOD-16912] Trie - generic automaton_iter

### DIFF
--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/mod.rs
@@ -30,8 +30,8 @@
 //! - [`classify`](Automaton::classify): tag the current state with a
 //!   [`StateClass`] that tells the driver whether to yield the current
 //!   key and whether to keep recursing.
-//! - optionally [`literal_prefix`](Automaton::literal_prefix): a byte
-//!   prefix every accepted key starts with, letting the traversal jump
+//! - [`literal_prefix`](Automaton::literal_prefix): a byte prefix every
+//!   accepted key starts with (or `None`), letting the traversal jump
 //!   straight to that subtree instead of descending from the root.
 //!
 //! [`driver::AutomatonIter`] is the generic iterator that drives any
@@ -151,9 +151,7 @@ pub trait Automaton {
     ///
     /// Every key the automaton accepts must start with the returned bytes —
     /// keys outside the prefix subtree are never visited, so a too-long or
-    /// wrong prefix silently drops matches. `None` (the default) disables
-    /// the jump.
-    fn literal_prefix(&self) -> Option<&[u8]> {
-        None
-    }
+    /// wrong prefix silently drops matches. Return `None` to disable the
+    /// jump and descend from the trie root.
+    fn literal_prefix(&self) -> Option<&[u8]>;
 }

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/mod.rs
@@ -30,6 +30,9 @@
 //! - [`classify`](Automaton::classify): tag the current state with a
 //!   [`StateClass`] that tells the driver whether to yield the current
 //!   key and whether to keep recursing.
+//! - optionally [`literal_prefix`](Automaton::literal_prefix): a byte
+//!   prefix every accepted key starts with, letting the traversal jump
+//!   straight to that subtree instead of descending from the root.
 //!
 //! [`driver::AutomatonIter`] is the generic iterator that drives any
 //! `Automaton` over a trie via a DFS that carries the post-edge state
@@ -137,5 +140,20 @@ pub trait Automaton {
             s = self.step(&s, b)?;
         }
         Some(s)
+    }
+
+    /// A byte prefix that every accepted key starts with, if the automaton
+    /// knows one. [`TrieMap::automaton_iter`](crate::TrieMap::automaton_iter)
+    /// uses it to jump straight to the subtree holding the keys with that
+    /// prefix instead of descending from the trie root.
+    ///
+    /// # Contract
+    ///
+    /// Every key the automaton accepts must start with the returned bytes —
+    /// keys outside the prefix subtree are never visited, so a too-long or
+    /// wrong prefix silently drops matches. `None` (the default) disables
+    /// the jump.
+    fn literal_prefix(&self) -> Option<&[u8]> {
+        None
     }
 }

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/wildcard/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/wildcard/mod.rs
@@ -160,9 +160,9 @@ use rqe_wildcard::WildcardPattern;
 /// given pattern. See the module documentation for the selection criteria.
 pub enum WildcardIter<'tm, 'p, Data> {
     /// `u64`-backed NFA — pattern has ≤ 63 atoms.
-    U64(AutomatonIter<'tm, Data, WildcardNfa<u64>>),
+    U64(AutomatonIter<'tm, Data, WildcardNfa<'p, u64>>),
     /// `u128`-backed NFA — pattern has 64..=127 atoms.
-    U128(AutomatonIter<'tm, Data, WildcardNfa<u128>>),
+    U128(AutomatonIter<'tm, Data, WildcardNfa<'p, u128>>),
     /// Filter-based fallback — pattern has ≥ 128 atoms.
     Filter(WildcardFilterIter<'tm, 'p, Data>),
 }

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/wildcard/nfa.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/wildcard/nfa.rs
@@ -25,7 +25,7 @@
 use super::super::{Automaton, StateClass};
 use super::atoms::{Atom, flatten};
 use super::nfa_bit_set::NfaBitSet;
-use rqe_wildcard::WildcardPattern;
+use rqe_wildcard::{Token, WildcardPattern};
 
 /// One row of the ε-closure table.
 ///
@@ -164,8 +164,12 @@ pub(super) fn nfa_step<S: NfaBitSet>(
 /// (absent if the pattern has no `*`), and a couple of cached
 /// bit-patterns that let [`Self::classify`] short-circuit the two
 /// special accept shapes (permanent, terminal).
-pub struct WildcardNfa<S: NfaBitSet> {
+pub struct WildcardNfa<'p, S: NfaBitSet> {
     atoms: Vec<Atom>,
+    /// The pattern's leading literal token, if it starts with one —
+    /// borrowed straight from the pattern bytes, so compiling stays
+    /// allocation-minimal. Reported via [`Automaton::literal_prefix`].
+    literal_prefix: Option<&'p [u8]>,
     /// The accept position — atoms.len(). A state set containing this
     /// position means the whole pattern has matched.
     accept: usize,
@@ -186,7 +190,7 @@ pub struct WildcardNfa<S: NfaBitSet> {
     epsilon_table: Option<Vec<EpsilonRow<S>>>,
 }
 
-impl<S: NfaBitSet> WildcardNfa<S> {
+impl<'p, S: NfaBitSet> WildcardNfa<'p, S> {
     /// Compile a pattern into an NFA backed by `S`.
     ///
     /// Callers should match the width to the atom count: `S = u64` for
@@ -202,7 +206,7 @@ impl<S: NfaBitSet> WildcardNfa<S> {
     /// release builds (the underlying shift wraps modulo the type width
     /// in Rust). Going through [`super::WildcardIter`]
     /// guarantees this never fires.
-    pub(crate) fn compile(pattern: &WildcardPattern<'_>) -> Self {
+    pub(crate) fn compile(pattern: &WildcardPattern<'p>) -> Self {
         assert!(
             pattern.atom_count() < S::CAPACITY,
             "WildcardNfa backend has capacity {} but pattern needs {} atoms; route through WildcardIter for automatic backend selection",
@@ -210,6 +214,10 @@ impl<S: NfaBitSet> WildcardNfa<S> {
             pattern.atom_count(),
         );
         let atoms = flatten(pattern);
+        let literal_prefix = match pattern.tokens().first() {
+            Some(Token::Literal(lit)) => Some(*lit),
+            _ => None,
+        };
         let accept = atoms.len();
         let epsilon_table = atoms
             .iter()
@@ -220,6 +228,7 @@ impl<S: NfaBitSet> WildcardNfa<S> {
         let accept_only = S::singleton(accept, accept);
         Self {
             atoms,
+            literal_prefix,
             accept,
             start_state,
             trailing_star,
@@ -229,12 +238,16 @@ impl<S: NfaBitSet> WildcardNfa<S> {
     }
 }
 
-impl<S: NfaBitSet> Automaton for WildcardNfa<S> {
+impl<'p, S: NfaBitSet> Automaton for WildcardNfa<'p, S> {
     type State = S;
 
     #[inline]
     fn start(&self) -> Self::State {
         self.start_state.clone()
+    }
+
+    fn literal_prefix(&self) -> Option<&[u8]> {
+        self.literal_prefix
     }
 
     #[inline]

--- a/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/mod.rs
@@ -22,7 +22,7 @@ use crate::trie_map::{
     node::Node,
     utils::strip_prefix,
 };
-use rqe_wildcard::{Token, WildcardPattern};
+use rqe_wildcard::WildcardPattern;
 use std::fmt;
 
 #[derive(Clone, PartialEq, Eq)]
@@ -232,39 +232,34 @@ impl<Data> TrieMap<Data> {
         // while the NFA arms simply drop it on return.
         match WildcardBackend::for_pattern(&pattern) {
             WildcardBackend::U64 => {
-                let nfa = WildcardNfa::<u64>::compile(&pattern);
-                let iter = self.automaton_iter_with_prefix_shortcut(pattern.tokens(), nfa);
-                WildcardIter::U64(iter)
+                WildcardIter::U64(self.automaton_iter(WildcardNfa::<u64>::compile(&pattern)))
             }
             WildcardBackend::U128 => {
-                let nfa = WildcardNfa::<u128>::compile(&pattern);
-                let iter = self.automaton_iter_with_prefix_shortcut(pattern.tokens(), nfa);
-                WildcardIter::U128(iter)
+                WildcardIter::U128(self.automaton_iter(WildcardNfa::<u128>::compile(&pattern)))
             }
             WildcardBackend::Filter => WildcardIter::Filter(self.wildcard_filter_iter(pattern)),
         }
     }
 
-    fn automaton_iter_with_prefix_shortcut<A: Automaton>(
-        &self,
-        tokens: &[Token<'_>],
-        automaton: A,
-    ) -> AutomatonIter<'_, Data, A> {
+    /// Iterate over the entries accepted by `automaton`, in lexicographical
+    /// key order. See [`Automaton`] for the state-machine contract and
+    /// [`AutomatonIter`] for the traversal it drives.
+    ///
+    /// If the automaton reports a [literal prefix](Automaton::literal_prefix),
+    /// the traversal jumps straight to the subtree containing every key with
+    /// that prefix instead of descending from the root.
+    pub fn automaton_iter<A: Automaton>(&self, automaton: A) -> AutomatonIter<'_, Data, A> {
         let Some(root) = self.root.as_ref() else {
             return AutomatonIter::empty(automaton);
         };
-        // If the pattern starts with a literal, jump straight to the subtree
-        // containing every key with that prefix and let the iterator pick up
-        // from there.
-        if let Some(Token::Literal(lit)) = tokens.first() {
-            match root.find_root_for_prefix(lit) {
+        match automaton.literal_prefix() {
+            Some(prefix) => match root.find_root_for_prefix(prefix) {
                 Some((subroot, subroot_prefix)) => {
                     AutomatonIter::new(Some(subroot), subroot_prefix, automaton)
                 }
                 None => AutomatonIter::empty(automaton),
-            }
-        } else {
-            AutomatonIter::new(Some(root), Vec::new(), automaton)
+            },
+            None => AutomatonIter::new(Some(root), Vec::new(), automaton),
         }
     }
 

--- a/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/automaton.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/automaton.rs
@@ -16,12 +16,13 @@ use trie_rs::TrieMap;
 use trie_rs::iter::{Automaton, StateClass};
 
 /// Accepts exactly the keys equal to `needle`, byte for byte. The state is
-/// the number of needle bytes matched so far. `advertise_prefix` toggles the
-/// [`Automaton::literal_prefix`] hint (the full needle) so tests can compare
-/// the subtree-jump path against the root descent.
+/// the number of needle bytes matched so far. `advertise_len` controls the
+/// [`Automaton::literal_prefix`] hint — any prefix of the needle is a legal
+/// hint per the trait contract — so tests can compare the subtree-jump path
+/// against the root descent at every landing depth. `None` disables the hint.
 struct ExactBytes {
     needle: Vec<u8>,
-    advertise_prefix: bool,
+    advertise_len: Option<usize>,
 }
 
 impl Automaton for ExactBytes {
@@ -44,7 +45,7 @@ impl Automaton for ExactBytes {
     }
 
     fn literal_prefix(&self) -> Option<&[u8]> {
-        self.advertise_prefix.then_some(&self.needle)
+        self.advertise_len.map(|n| &self.needle[..n])
     }
 }
 
@@ -66,12 +67,20 @@ fn build_trie() -> TrieMap<u32> {
     trie
 }
 
-fn matches(trie: &TrieMap<u32>, needle: &[u8], advertise_prefix: bool) -> Vec<Vec<u8>> {
+fn matches_at<Data>(
+    trie: &TrieMap<Data>,
+    needle: &[u8],
+    advertise_len: Option<usize>,
+) -> Vec<Vec<u8>> {
     let automaton = ExactBytes {
         needle: needle.to_vec(),
-        advertise_prefix,
+        advertise_len,
     };
     trie.automaton_iter(automaton).map(|(k, _)| k).collect()
+}
+
+fn matches(trie: &TrieMap<u32>, needle: &[u8], advertise_prefix: bool) -> Vec<Vec<u8>> {
+    matches_at(trie, needle, advertise_prefix.then_some(needle.len()))
 }
 
 #[test]
@@ -119,4 +128,52 @@ fn empty_trie_yields_nothing() {
 
     assert!(matches(&trie, b"anything", true).is_empty());
     assert!(matches(&trie, b"anything", false).is_empty());
+}
+
+#[cfg(not(miri))]
+mod property_based {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig {
+            cases: 256,
+            ..Default::default()
+        })]
+
+        /// Random keys + needle over a shared 3-letter alphabet (so needles
+        /// collide with trie structure), sweeping every legal advertised
+        /// prefix length: each jump depth must agree with the root descent,
+        /// and both must equal the trivially computed exact-match answer.
+        #[test]
+        fn prefix_jump_agrees_with_root_descent_at_every_depth(
+            keys in prop::collection::vec("[a-c]{0,6}", 1..30),
+            needle in "[a-c]{0,7}",
+        ) {
+            let mut trie = TrieMap::new();
+            for k in &keys {
+                trie.insert(k.as_bytes(), ());
+            }
+
+            let expected: Vec<Vec<u8>> = keys
+                .iter()
+                .any(|k| k == &needle)
+                .then(|| vec![needle.clone().into_bytes()])
+                .unwrap_or_default();
+
+            let descent = matches_at(&trie, needle.as_bytes(), None);
+            prop_assert_eq!(&descent, &expected, "root descent, needle=`{}`", needle);
+
+            for len in 0..=needle.len() {
+                let jumped = matches_at(&trie, needle.as_bytes(), Some(len));
+                prop_assert_eq!(
+                    &jumped,
+                    &descent,
+                    "jump vs descent, needle=`{}`, advertise_len={}",
+                    needle,
+                    len,
+                );
+            }
+        }
+    }
 }

--- a/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/automaton.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/automaton.rs
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Drive [`TrieMap::automaton_iter`] with an automaton defined outside the
+//! crate, pinning the public extension point: the [`Automaton`] trait is
+//! implementable by consumers, and the [`Automaton::literal_prefix`] subtree
+//! jump yields the same entries as a plain root descent.
+
+use trie_rs::TrieMap;
+use trie_rs::iter::{Automaton, StateClass};
+
+/// Accepts exactly the keys equal to `needle`, byte for byte. The state is
+/// the number of needle bytes matched so far. `advertise_prefix` toggles the
+/// [`Automaton::literal_prefix`] hint (the full needle) so tests can compare
+/// the subtree-jump path against the root descent.
+struct ExactBytes {
+    needle: Vec<u8>,
+    advertise_prefix: bool,
+}
+
+impl Automaton for ExactBytes {
+    type State = usize;
+
+    fn start(&self) -> usize {
+        0
+    }
+
+    fn step(&mut self, state: &usize, byte: u8) -> Option<usize> {
+        (self.needle.get(*state) == Some(&byte)).then_some(state + 1)
+    }
+
+    fn classify(&self, state: &usize) -> StateClass {
+        if *state == self.needle.len() {
+            StateClass::Terminal
+        } else {
+            StateClass::Live
+        }
+    }
+
+    fn literal_prefix(&self) -> Option<&[u8]> {
+        self.advertise_prefix.then_some(&self.needle)
+    }
+}
+
+fn build_trie() -> TrieMap<u32> {
+    let mut trie = TrieMap::new();
+    for (i, word) in [
+        b"".as_ref(),
+        b"ban",
+        b"banana",
+        b"band",
+        b"bandana",
+        b"apple",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        trie.insert(word, i as u32);
+    }
+    trie
+}
+
+fn matches(trie: &TrieMap<u32>, needle: &[u8], advertise_prefix: bool) -> Vec<Vec<u8>> {
+    let automaton = ExactBytes {
+        needle: needle.to_vec(),
+        advertise_prefix,
+    };
+    trie.automaton_iter(automaton).map(|(k, _)| k).collect()
+}
+
+#[test]
+fn custom_automaton_yields_full_keys() {
+    let trie = build_trie();
+
+    // "band" sits below the "ban" node: the prefix jump must still yield the
+    // full key, not the suffix relative to the subtree root.
+    assert_eq!(matches(&trie, b"band", true), vec![b"band".to_vec()]);
+}
+
+#[test]
+fn prefix_jump_agrees_with_root_descent() {
+    let trie = build_trie();
+
+    for needle in [
+        b"".as_ref(),
+        b"ban",
+        b"banana",
+        b"band",
+        b"bandana",
+        b"bandanas",
+        b"apple",
+        b"app",
+        b"zebra",
+    ] {
+        assert_eq!(
+            matches(&trie, needle, true),
+            matches(&trie, needle, false),
+            "prefix jump and root descent disagree for {needle:?}",
+        );
+    }
+}
+
+#[test]
+fn absent_prefix_yields_nothing() {
+    let trie = build_trie();
+
+    assert!(matches(&trie, b"zebra", true).is_empty());
+}
+
+#[test]
+fn empty_trie_yields_nothing() {
+    let trie = TrieMap::<u32>::new();
+
+    assert!(matches(&trie, b"anything", true).is_empty());
+    assert!(matches(&trie, b"anything", false).is_empty());
+}

--- a/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/trie_map/iter/mod.rs
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+mod automaton;
 mod contains;
 mod filter;
 mod prefixed;


### PR DESCRIPTION
> Stack 1/4 — foundations. Followed by
- https://github.com/RediSearch/RediSearch/pull/10470

## Describe the changes in the pull request

1. **Current**: The byte-level automaton driver is reachable only through `TrieMap::wildcard_iter`, and the leading-literal subtree jump is a wildcard-only helper taking the pattern's token list.
2. **Change**: Promote both to the framework — a public `TrieMap::automaton_iter` drives any `Automaton` over the trie, and the jump becomes an `Automaton::literal_prefix` hook: an automaton that knows a byte prefix every accepted key starts with reports it, and traversal starts at that subtree instead of the root. `WildcardNfa` captures its leading literal at compile time (borrowing from the pattern, hence the new lifetime) and is otherwise unchanged.
3. **Outcome**: The automaton framework is a public extension point. An integration test pins it: an out-of-crate `Automaton` impl drives `automaton_iter`, and the `literal_prefix` jump yields the same entries as a plain root descent.

#### Which additional issues this PR fixes
1. MOD-16912

#### Main objects this PR modified
1. `TrieMap::automaton_iter`
2. `Automaton::literal_prefix`, `WildcardNfa`

#### Benchmarks

`trie_bencher` wildcard groups (criterion, 100 samples/group), this branch vs `master` baseline, local macOS (LTO off, known ±6% drift floor):

| Bench | Δ time | p | Read |
|---|---|---|---|
| Wiki-1K `Ab*` (leading literal → jump) | −1.4% | <0.05 | noise |
| Wiki-1K `Apollo ??` (leading literal, fixed-len, ~195 ns) | +7.6% → +3.5% on re-run | <0.05 | noise (4 pp drift between identical runs) |
| Gutenberg `*ly` (no prefix, root descent) | −3.2% | <0.05 | noise |
| Gutenberg `*a×70*` (u128, high overlap) | +0.0% | 0.96 | unchanged |
| Gutenberg `*Zabc…×70*` (u128, low overlap) | +4.5% | <0.05 | noise |

**Conclusion**: no perf signal — mixed-sign deltas within the noise floor, biggest mover non-reproducible. Matches expectation: the per-byte hot loop (`step`/`step_all`/`classify`, driver DFS) is byte-identical; only iterator construction moved behind a monomorphized trait call.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
