### PR TITLE
Stop re-exporting pure Rust types from ffi crate

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1052,6 +1052,7 @@ dependencies = [
 name = "index_spec"
 version = "0.0.1"
 dependencies = [
+ "document",
  "ffi",
  "field_spec",
  "inverted_index",
@@ -2358,6 +2359,7 @@ dependencies = [
 name = "rqe_iterators_test_utils"
 version = "0.0.1"
 dependencies = [
+ "document",
  "ffi",
  "field",
  "geo",
@@ -2558,6 +2560,7 @@ dependencies = [
 name = "schema_rule"
 version = "0.0.1"
 dependencies = [
+ "document",
  "ffi",
  "pretty_assertions",
  "redis_mock",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2570,6 +2570,7 @@ dependencies = [
  "build_utils",
  "ffi",
  "inverted_index",
+ "query_term",
  "redis_mock",
  "redisearch_rs",
  "rqe_core",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1769,6 +1769,7 @@ version = "0.0.1"
 dependencies = [
  "ffi",
  "query_eval",
+ "query_types",
  "rqe_iterators",
  "workspace_hack",
 ]

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2307,6 +2307,7 @@ dependencies = [
  "query_error",
  "query_term",
  "query_term_ffi",
+ "query_types",
  "redis_mock",
  "redis_reply",
  "redisearch_rs",

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/intersection.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/intersection.rs
@@ -9,7 +9,8 @@
 
 use std::ptr::NonNull;
 
-use ffi::{IteratorType, QueryIterator};
+use ffi::QueryIterator;
+use rqe_iterator_type::IteratorType;
 use rqe_iterators::{
     c2rust::CRQEIterator,
     interop::RQEIteratorWrapper,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/union.rs
@@ -14,7 +14,8 @@ use std::{
     ptr::NonNull,
 };
 
-use ffi::{QueryIterator, QueryNodeType};
+use ffi::QueryIterator;
+use query_types::QueryNodeType;
 
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::{

--- a/src/redisearch_rs/c_entrypoint/query_eval_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/query_eval_ffi/Cargo.toml
@@ -16,5 +16,6 @@ bench = false
 [dependencies]
 ffi.workspace = true
 query_eval.workspace = true
+query_types.workspace = true
 rqe_iterators.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
@@ -16,14 +16,15 @@ use std::{
 };
 
 use ffi::{
-    AREQ, QueryAST, QueryError, QueryEvalCtx, QueryIterator, QueryNodeOptions, RSQueryNode,
-    RSSearchOptions, RedisSearchCtx,
+    AREQ, QueryAST, QueryError, QueryEvalCtx, QueryIterator, RSQueryNode, RSSearchOptions,
+    RedisSearchCtx,
 };
 use query_eval::{
     QueryEvalContext, QueryNodeRef, eval,
     eval::Config,
     scorers::{BuiltInScorer, slop_forces_offsets},
 };
+use query_types::QueryNodeOptions;
 
 /// Snapshot the evaluator's configuration from the process-wide
 /// [`ffi::RSGlobalConfig`].

--- a/src/redisearch_rs/c_wrappers/index_spec/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/index_spec/Cargo.toml
@@ -17,6 +17,7 @@ schema_rule.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]
+document.workspace = true
 pretty_assertions.workspace = true
 
 # Crate required to invoke C symbols

--- a/src/redisearch_rs/c_wrappers/index_spec/tests/tests.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/tests/tests.rs
@@ -54,13 +54,13 @@ fn field_specs() {
 fn rule() {
     let mut index_spec = unsafe { mem::zeroed::<ffi::IndexSpec>() };
     let mut schema_rule = unsafe { mem::zeroed::<ffi::SchemaRule>() };
-    schema_rule.type_ = ffi::DocumentType::Json;
+    schema_rule.type_ = document::DocumentType::Json;
     index_spec.rule = ptr::from_mut(&mut schema_rule);
     let sut = unsafe { IndexSpec::from_raw(ptr::from_ref(&index_spec)) };
 
     let rule = sut.rule();
 
-    assert_eq!(rule.type_(), ffi::DocumentType::Json);
+    assert_eq!(rule.type_(), document::DocumentType::Json);
 }
 
 fn field_spec(field_name: &CStr, field_path: &CStr, index: u16) -> ffi::FieldSpec {

--- a/src/redisearch_rs/c_wrappers/query/src/mock/query_node_ref.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/mock/query_node_ref.rs
@@ -17,7 +17,7 @@ use std::{
 };
 
 use inverted_index::NumericFilter;
-use query_types::QueryNodeType;
+use query_types::{QueryNodeOptions, QueryNodeType};
 use rqe_core::DocId;
 
 /// Owns a heap-allocated [`ffi::RSQueryNode`].
@@ -113,7 +113,7 @@ impl MockQueryNode {
         self.node
     }
 
-    pub fn opts_mut(&mut self) -> &mut ffi::QueryNodeOptions {
+    pub fn opts_mut(&mut self) -> &mut QueryNodeOptions {
         // SAFETY: `self.node` is a valid, exclusively-owned allocation.
         unsafe { &mut (*self.node).opts }
     }

--- a/src/redisearch_rs/c_wrappers/schema_rule/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/schema_rule/Cargo.toml
@@ -9,6 +9,7 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+document.workspace = true
 ffi.workspace = true
 workspace_hack.workspace = true
 

--- a/src/redisearch_rs/c_wrappers/schema_rule/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/schema_rule/src/lib.rs
@@ -14,7 +14,7 @@ use std::{
     slice,
 };
 
-use ffi::DocumentType;
+use document::DocumentType;
 
 /// A safe wrapper around an `ffi::SchemaRule`.
 #[repr(transparent)]

--- a/src/redisearch_rs/c_wrappers/search_disk/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/search_disk/Cargo.toml
@@ -19,6 +19,7 @@ build_utils.workspace = true
 [dependencies]
 ffi.workspace = true
 inverted_index.workspace = true
+query_term.workspace = true
 rqe_core.workspace = true
 rqe_iterators.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/c_wrappers/search_disk/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/search_disk/src/lib.rs
@@ -17,8 +17,8 @@
 
 use std::ptr::NonNull;
 
-use ffi::RSQueryTerm;
 use inverted_index::NumericFilter;
+use query_term::RSQueryTerm;
 use rqe_core::{DocId, FieldIndex, FieldMask};
 use rqe_iterators::{RQEIteratorPrintable, SEARCH_ENTERPRISE_ITERATORS};
 

--- a/src/redisearch_rs/ffi/src/lib.rs
+++ b/src/redisearch_rs/ffi/src/lib.rs
@@ -39,12 +39,10 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 /// Access to the RediSearch Module context
 pub mod context;
 
-/// Use the Rust definitions directly
-pub use document::DocumentType;
-
 // Brought into scope (privately) so the bindgen-generated bindings below can
 // name these Rust-defined types. Consumers import them from their owning crate
 // directly rather than through this crate.
+use document::DocumentType;
 use query_term::{RSQueryTerm, RSTokenFlags};
 use query_types::{QASTValidationFlagsSet, QueryNodeOptions, QueryNodeType};
 use rqe_iterator_type::IteratorType;

--- a/src/redisearch_rs/ffi/src/lib.rs
+++ b/src/redisearch_rs/ffi/src/lib.rs
@@ -43,7 +43,10 @@ pub mod context;
 pub use document::DocumentType;
 pub use query_types::{QASTValidationFlagsSet, QueryNodeFlags, QueryNodeOptions, QueryNodeType};
 
-pub use query_term::{RSQueryTerm, RSTokenFlags};
+// Brought into scope (privately) so the bindgen-generated bindings below can
+// name these Rust-defined types. Consumers import them from `query_term`
+// directly rather than through this crate.
+use query_term::{RSQueryTerm, RSTokenFlags};
 pub use rqe_iterator_type::IteratorType;
 
 #[repr(C)]

--- a/src/redisearch_rs/ffi/src/lib.rs
+++ b/src/redisearch_rs/ffi/src/lib.rs
@@ -44,10 +44,10 @@ pub use document::DocumentType;
 pub use query_types::{QASTValidationFlagsSet, QueryNodeFlags, QueryNodeOptions, QueryNodeType};
 
 // Brought into scope (privately) so the bindgen-generated bindings below can
-// name these Rust-defined types. Consumers import them from `query_term`
+// name these Rust-defined types. Consumers import them from their owning crate
 // directly rather than through this crate.
 use query_term::{RSQueryTerm, RSTokenFlags};
-pub use rqe_iterator_type::IteratorType;
+use rqe_iterator_type::IteratorType;
 
 #[repr(C)]
 #[derive(Debug)]

--- a/src/redisearch_rs/ffi/src/lib.rs
+++ b/src/redisearch_rs/ffi/src/lib.rs
@@ -41,13 +41,13 @@ pub mod context;
 
 /// Use the Rust definitions directly
 pub use document::DocumentType;
-pub use query_types::{QueryNodeFlags, QueryNodeOptions};
+pub use query_types::QueryNodeFlags;
 
 // Brought into scope (privately) so the bindgen-generated bindings below can
 // name these Rust-defined types. Consumers import them from their owning crate
 // directly rather than through this crate.
 use query_term::{RSQueryTerm, RSTokenFlags};
-use query_types::{QASTValidationFlagsSet, QueryNodeType};
+use query_types::{QASTValidationFlagsSet, QueryNodeOptions, QueryNodeType};
 use rqe_iterator_type::IteratorType;
 
 #[repr(C)]

--- a/src/redisearch_rs/ffi/src/lib.rs
+++ b/src/redisearch_rs/ffi/src/lib.rs
@@ -41,7 +41,6 @@ pub mod context;
 
 /// Use the Rust definitions directly
 pub use document::DocumentType;
-pub use query_types::QueryNodeFlags;
 
 // Brought into scope (privately) so the bindgen-generated bindings below can
 // name these Rust-defined types. Consumers import them from their owning crate

--- a/src/redisearch_rs/ffi/src/lib.rs
+++ b/src/redisearch_rs/ffi/src/lib.rs
@@ -41,12 +41,13 @@ pub mod context;
 
 /// Use the Rust definitions directly
 pub use document::DocumentType;
-pub use query_types::{QASTValidationFlagsSet, QueryNodeFlags, QueryNodeOptions, QueryNodeType};
+pub use query_types::{QASTValidationFlagsSet, QueryNodeFlags, QueryNodeOptions};
 
 // Brought into scope (privately) so the bindgen-generated bindings below can
 // name these Rust-defined types. Consumers import them from their owning crate
 // directly rather than through this crate.
 use query_term::{RSQueryTerm, RSTokenFlags};
+use query_types::QueryNodeType;
 use rqe_iterator_type::IteratorType;
 
 #[repr(C)]

--- a/src/redisearch_rs/ffi/src/lib.rs
+++ b/src/redisearch_rs/ffi/src/lib.rs
@@ -41,13 +41,13 @@ pub mod context;
 
 /// Use the Rust definitions directly
 pub use document::DocumentType;
-pub use query_types::{QASTValidationFlagsSet, QueryNodeFlags, QueryNodeOptions};
+pub use query_types::{QueryNodeFlags, QueryNodeOptions};
 
 // Brought into scope (privately) so the bindgen-generated bindings below can
 // name these Rust-defined types. Consumers import them from their owning crate
 // directly rather than through this crate.
 use query_term::{RSQueryTerm, RSTokenFlags};
-use query_types::QueryNodeType;
+use query_types::{QASTValidationFlagsSet, QueryNodeType};
 use rqe_iterator_type::IteratorType;
 
 #[repr(C)]

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -519,23 +519,6 @@ QueryIterator *NewGeometryQueryIterator(const RedisSearchCtx *sctx, const struct
 void SetMetricRLookupHandle(QueryIterator *header, RLookupKeyHandle *key_handle);
 
 /**
- * Append a new child iterator to the intersection.
- *
- * Transfers ownership of `child` to the intersection. Updates the estimated result count
- * if the new child has a lower estimate than the current minimum.
- *
- * # Note
- *
- * Unlike the constructor, this method does **not** re-sort the child list after insertion.
- *
- * # Safety
- *
- * 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator()`].
- * 2. `child` must be a valid non-null pointer to a `QueryIterator`, not aliased.
- */
-void AddIntersectionIteratorChild(QueryIterator *header, QueryIterator *child);
-
-/**
  * Creates a lazily-evaluated vector range iterator.
  *
  * Unlike [`NewMetricIteratorSortedById`](crate::metric::NewMetricIteratorSortedById) and the
@@ -557,6 +540,23 @@ void AddIntersectionIteratorChild(QueryIterator *header, QueryIterator *child);
  * 3. `ctx` must remain valid until the iterator is freed; ownership transfers to the iterator.
  */
 QueryIterator *NewLazyVectorRangeIterator(ProduceResultsFn produce, FreeProducerCtxFn free_ctx, void *ctx, bool yields_metric, bool sorted_by_id, size_t num_estimated, enum MetricType type_);
+
+/**
+ * Append a new child iterator to the intersection.
+ *
+ * Transfers ownership of `child` to the intersection. Updates the estimated result count
+ * if the new child has a lower estimate than the current minimum.
+ *
+ * # Note
+ *
+ * Unlike the constructor, this method does **not** re-sort the child list after insertion.
+ *
+ * # Safety
+ *
+ * 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator()`].
+ * 2. `child` must be a valid non-null pointer to a `QueryIterator`, not aliased.
+ */
+void AddIntersectionIteratorChild(QueryIterator *header, QueryIterator *child);
 
 /**
  * Trims a union iterator for the LIMIT optimizer, then switches to unsorted

--- a/src/redisearch_rs/inverted_index/src/tests/mod.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/mod.rs
@@ -19,7 +19,7 @@ mod index_result;
 mod reader;
 
 #[unsafe(no_mangle)]
-pub extern "C" fn Term_Free(_t: *mut ffi::RSQueryTerm) {
+pub extern "C" fn Term_Free(_t: *mut query_term::RSQueryTerm) {
     panic!("No test created a term record");
 }
 

--- a/src/redisearch_rs/inverted_index/tests/integration/c_mocks.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/c_mocks.rs
@@ -13,7 +13,7 @@
 //! crate. Since all tests share a single binary, each mock symbol must be
 //! defined exactly once.
 
-use ffi::RSQueryTerm;
+use query_term::RSQueryTerm;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn Term_Free(_t: *mut RSQueryTerm) {

--- a/src/redisearch_rs/rlookup/src/row.rs
+++ b/src/redisearch_rs/rlookup/src/row.rs
@@ -409,8 +409,8 @@ pub mod opaque {
 mod tests {
     use std::ptr;
 
+    use document::DocumentType;
     use enumflags2::make_bitflags;
-    use ffi::DocumentType;
 
     use super::*;
 

--- a/src/redisearch_rs/rqe_iterators/Cargo.toml
+++ b/src/redisearch_rs/rqe_iterators/Cargo.toml
@@ -18,6 +18,7 @@ cheadergen.workspace = true
 ffi.workspace = true
 rqe_core.workspace = true
 geo.workspace = true
+query_types.workspace = true
 rqe_iterator_type.workspace = true
 field.workspace = true
 idf.workspace = true

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -11,14 +11,15 @@
 
 use ffi::{
     IteratorStatus_ITERATOR_EOF, IteratorStatus_ITERATOR_NOTFOUND, IteratorStatus_ITERATOR_OK,
-    IteratorStatus_ITERATOR_TIMEOUT, IteratorType, QueryIterator, ValidateStatus_VALIDATE_ABORTED,
+    IteratorStatus_ITERATOR_TIMEOUT, QueryIterator, ValidateStatus_VALIDATE_ABORTED,
     ValidateStatus_VALIDATE_MOVED, ValidateStatus_VALIDATE_OK,
 };
 use rqe_core::DocId;
 
 use crate::{
-    RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, interop::RQEIteratorWrapper,
-    intersection::Intersection, profile_print, profile_print::ProfilePrint,
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    interop::RQEIteratorWrapper, intersection::Intersection, profile_print,
+    profile_print::ProfilePrint,
 };
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/geo.rs
@@ -9,10 +9,11 @@
 
 use std::ptr::NonNull;
 
-use ffi::{GeoDistance, GeoFilter, QueryIterator, QueryNodeType, RedisSearchCtx};
+use ffi::{GeoDistance, GeoFilter, QueryIterator, RedisSearchCtx};
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use geo::{GEO_RANGE_COUNT, hash::InvalidWGS84Coordinates};
 use inverted_index::NumericFilter;
+use query_types::QueryNodeType;
 
 use crate::{
     NumericIteratorVariant, c2rust::CRQEIterator, open_numeric_or_geo_index,

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use ffi::{
     FieldType_INDEXFLD_T_GEO, FieldType_INDEXFLD_T_NUMERIC, IndexFlags, QueryIterator,
-    QueryNodeType, RedisSearchCtx,
+    RedisSearchCtx,
 };
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
@@ -26,6 +26,7 @@ use inverted_index::{
     FilterGeoReader, FilterNumericReader, IndexReader, NumericFilter, NumericReader,
 };
 use numeric_range_tree::{NumericIndexReader, NumericRangeTree};
+use query_types::QueryNodeType;
 use ref_mode::{Active, Ref};
 use rqe_core::DocId;
 

--- a/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_optimized.rs
@@ -342,8 +342,8 @@ where
         self.at_eof
     }
 
-    fn type_(&self) -> ffi::IteratorType {
-        ffi::IteratorType::OptionalOptimized
+    fn type_(&self) -> crate::IteratorType {
+        crate::IteratorType::OptionalOptimized
     }
 
     fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {

--- a/src/redisearch_rs/rqe_iterators/src/optional_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional_reducer.rs
@@ -12,8 +12,9 @@
 
 use std::ptr::NonNull;
 
-use ffi::IteratorType;
 use rqe_core::DocId;
+
+use crate::IteratorType;
 
 use crate::{
     NewWildcardIterator, RQEIterator,

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -24,8 +24,9 @@
 use std::ffi::CStr;
 use std::ptr::NonNull;
 
-use ffi::{QueryIterator, QueryNodeType};
+use ffi::QueryIterator;
 use index_result::RSIndexResult;
+use query_types::QueryNodeType;
 use ref_mode::{Active, Ref, SharedPtr};
 use rqe_core::DocId;
 
@@ -240,20 +241,20 @@ where
         let print_full = !ctx.limited
             || matches!(
                 node_type,
-                ffi::QueryNodeType::Union | ffi::QueryNodeType::Geo | ffi::QueryNodeType::LexRange
+                QueryNodeType::Union | QueryNodeType::Geo | QueryNodeType::LexRange
             );
 
         map.kv_simple_string(c"Type", c"UNION");
 
         let type_str = match node_type {
-            ffi::QueryNodeType::Geo => "GEO",
-            ffi::QueryNodeType::Tag => "TAG",
-            ffi::QueryNodeType::Union => "UNION",
-            ffi::QueryNodeType::Fuzzy => "FUZZY",
-            ffi::QueryNodeType::Prefix => "PREFIX",
-            ffi::QueryNodeType::Numeric => "NUMERIC",
-            ffi::QueryNodeType::LexRange => "LEXRANGE",
-            ffi::QueryNodeType::WildcardQuery => "WILDCARD",
+            QueryNodeType::Geo => "GEO",
+            QueryNodeType::Tag => "TAG",
+            QueryNodeType::Union => "UNION",
+            QueryNodeType::Fuzzy => "FUZZY",
+            QueryNodeType::Prefix => "PREFIX",
+            QueryNodeType::Numeric => "NUMERIC",
+            QueryNodeType::LexRange => "LEXRANGE",
+            QueryNodeType::WildcardQuery => "WILDCARD",
             _ => unreachable!("Invalid type for union"),
         };
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
@@ -237,7 +237,7 @@ fn intersection_two_children() {
 
 #[test]
 fn union_full_print() {
-    use ffi::QueryNodeType;
+    use query_types::QueryNodeType;
     use rqe_iterators::union_opaque::{UnionOpaque, UnionVariant};
 
     let mut replier = init();
@@ -254,7 +254,7 @@ fn union_full_print() {
 
 #[test]
 fn union_limited_non_union_type() {
-    use ffi::QueryNodeType;
+    use query_types::QueryNodeType;
     use rqe_iterators::union_opaque::{UnionOpaque, UnionVariant};
 
     let mut replier = init();
@@ -279,7 +279,7 @@ fn union_limited_non_union_type() {
 
 #[test]
 fn union_limited_geo_prints_full() {
-    use ffi::QueryNodeType;
+    use query_types::QueryNodeType;
     use rqe_iterators::union_opaque::{UnionOpaque, UnionVariant};
 
     let mut replier = init();
@@ -300,7 +300,7 @@ fn union_limited_geo_prints_full() {
 
 #[test]
 fn union_limited_lexrange_prints_full() {
-    use ffi::QueryNodeType;
+    use query_types::QueryNodeType;
     use rqe_iterators::union_opaque::{UnionOpaque, UnionVariant};
 
     let mut replier = init();
@@ -321,7 +321,7 @@ fn union_limited_lexrange_prints_full() {
 
 #[test]
 fn union_with_query_string() {
-    use ffi::QueryNodeType;
+    use query_types::QueryNodeType;
     use ref_mode::SharedPtr;
     use rqe_iterators::union_opaque::{UnionOpaque, UnionVariant};
 

--- a/src/redisearch_rs/rqe_iterators_test_utils/Cargo.toml
+++ b/src/redisearch_rs/rqe_iterators_test_utils/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 ffi.workspace = true
+document.workspace = true
 rqe_core.workspace = true
 field.workspace = true
 geo.workspace = true

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -278,7 +278,7 @@ impl TestContext {
                 0,
                 std::ptr::null(),
                 0,
-                ffi::DocumentType::Hash,
+                document::DocumentType::Hash,
             )
         };
         assert!(!dmd.is_null(), "DocTable_Put returned null");


### PR DESCRIPTION
Stop re-exporting from `ffi` types which are implement in Rust. See `BLOCKLIST_TYPES` in `ffi/build.rs`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
