### PR TITLE
[8.8] [MOD-16878] Fix cursor lifetime race in hybrid replyWithCursors

### DIFF
--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -617,7 +617,6 @@ static inline void replyWithCursors(RedisModuleCtx *replyCtx, arrayof(Cursor*) c
     RedisModule_Reply_Map(reply);
     for (size_t i = 0; i < array_len(cursors); i++) {
       Cursor *cursor = cursors[i];
-      Cursor_Pause(cursor);
       AREQ *areq = cursor->execState;
       if (IsHybridSearchSubquery(areq)) {
         RedisModule_ReplyKV_LongLong(reply, "SEARCH", cursor->id);
@@ -626,6 +625,7 @@ static inline void replyWithCursors(RedisModuleCtx *replyCtx, arrayof(Cursor*) c
       } else {
         RS_ABORT_ALWAYS("Unknown subquery type");
       }
+      Cursor_Pause(cursor);
     }
     RedisModule_ReplyKV_Array(reply, "warnings"); // >warnings
     if (timedOut) {

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -234,6 +234,75 @@ def _wait_pinned_shard_with_blocked_cmd(shard_conn, sync_point, cmd_name, timeou
         f'Shard not pinned at {sync_point} with a blocked {cmd_name} client within {timeout}s')
 
 
+def _setup_hybrid_index(env):
+    """Create a small hybrid index with a few docs on `env` and return a query vector."""
+    for i in range(1, env.shardsCount + 1):
+        verify_shard_init(env.getConnection(i))
+    conn = getConnectionByEnv(env)
+    env.expect(
+        'FT.CREATE', 'hybrid_idx', 'PREFIX', '1', 'hybrid_doc', 'SCHEMA',
+        'name', 'TEXT',
+        'embedding', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2'
+    ).ok()
+    for i in range(100):
+        vec = np.array([float(i), float(i)], dtype=np.float32).tobytes()
+        conn.execute_command('HSET', f'hybrid_doc{i}', 'name', f'hello{i}', 'embedding', vec)
+    return np.array([0.0, 0.0], dtype=np.float32).tobytes()
+
+
+# Skipped under ASan pending MOD-16907.
+@skip(cluster=False, asan=True)
+def test_hybrid_cursors_race_with_flushall():
+    """Regression for MOD-16878: publishing a shard's _FT.HYBRID cursors must not
+    race with concurrent cursor cleanup (FLUSHALL / DROPINDEX / ...).
+
+    Pause the shard just after it stores its cursors, FLUSHALL it, then resume and
+    assert the shard did not crash.
+    """
+    env = Env(moduleArgs='WORKERS 1', protocol=3)
+    skipIfNoEnableAssert(env)  # QUERY_CONTROLLER pause hooks are ENABLE_ASSERT-only
+    query_vec = _setup_hybrid_index(env)
+
+    target_shard = non_coord_shard_conns(env)[0]
+    # Keep the query alive and long-running (RETURN policy + large TIMEOUT) so it
+    # stays paused while we trigger the race.
+    run_command_on_all_shards(env, 'CONFIG', 'SET', ON_TIMEOUT_CONFIG, 'return')
+    query = ['FT.HYBRID', 'hybrid_idx', 'SEARCH', '*',
+             'VSIM', '@embedding', '$BLOB',
+             'PARAMS', '2', 'BLOB', query_vec, 'TIMEOUT', '60000']
+
+    def run_hybrid_ignore_errors():
+        # The query may error after the flush; we only assert the shard stays up.
+        try:
+            env.cmd(*query)
+        except Exception:
+            pass
+
+    target_shard.execute_command(debug_cmd(), 'QUERY_CONTROLLER',
+                                 'SET_PAUSE_AFTER_HYBRID_STORE_CURSORS', 'true')
+    t = threading.Thread(target=run_hybrid_ignore_errors, daemon=True)
+    t.start()
+
+    wait_for_condition(
+        lambda: (target_shard.execute_command(
+            debug_cmd(), 'QUERY_CONTROLLER',
+            'GET_IS_HYBRID_STORE_CURSORS_PAUSED') == 1, {}),
+        'shard did not pause after storing _FT.HYBRID cursors')
+
+    # Flush the shard while its cursors are still in flight, so the teardown
+    # runs concurrently with the cursor reply.
+    target_shard.execute_command('FLUSHALL')
+
+    # Resume the worker; it must finish replying without crashing the shard.
+    target_shard.execute_command(debug_cmd(), 'QUERY_CONTROLLER',
+                                 'SET_PAUSE_AFTER_HYBRID_STORE_CURSORS', 'false')
+    t.join(timeout=10)
+    env.assertFalse(t.is_alive(), message="FT.HYBRID thread should have finished")
+
+    # The shard survived the race.
+    env.assertEqual(target_shard.execute_command('PING'), True)
+
+
 class TestCoordinatorTimeout:
     """Tests for the blocked client timeout mechanism for the coordinator."""
 


### PR DESCRIPTION
## Describe the changes in the pull request

Backport of #10451 to **8.8** (full: fix + test).

1. **Current:** `replyWithCursors()` called `Cursor_Pause(cursor)` and *then* read `cursor->execState` / `cursor->id`. `Cursor_Pause()` frees the cursor when `delete_mark` is set — which a concurrent index teardown (`FLUSHALL` / `FT.DROPINDEX` → `CursorList_Empty`) sets on still-in-flight cursors. The reply raced that free, read an already-freed `AREQ`, and crashed the shard worker thread (SIGSEGV).
2. **Change:** Snapshot `execState` / `id` / subquery type **before** `Cursor_Pause()`, and pause last — matching the cursor-ownership discipline `AREQ_StartCursor` / `runCursor` already follow.
3. **Outcome:** No use-after-free; the shard survives cursor teardown that races the cursor reply.

Includes the deterministic regression test `test_hybrid_cursors_race_with_flushall` (the `HYBRID_STORE_CURSORS` debug hook it relies on is present on 8.8).

#### Which additional issues this PR fixes
1. MOD-16878

#### Main objects this PR modified
1. `src/hybrid/hybrid_exec.c` (`replyWithCursors`)
2. `tests/pytests/test_blocked_client_timeout.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: fixes a shard crash (SIGSEGV) in the `FT.HYBRID` cursor path when a cursor teardown (`FLUSHALL` / `FT.DROPINDEX`) races the cursor reply.

## Original PR
https://github.com/RediSearch/RediSearch/pull/10451

## Changes from original
Test placed manually: the PR diff's context anchor (`_internal_hybrid_cursor_map`, from an unrelated PR not on 8.8) is absent here, so the two new functions were appended before `class TestCoordinatorTimeout:`. The `hybrid_exec.c` fix and the test additions are otherwise byte-for-byte identical to the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
