### PR TITLE
[8.4] [MOD-16878] Fix cursor lifetime race in hybrid replyWithCursors

### DIFF
--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -409,7 +409,6 @@ static inline void replyWithCursors(RedisModuleCtx *replyCtx, arrayof(Cursor*) c
     RedisModule_Reply_Map(reply);
     for (size_t i = 0; i < array_len(cursors); i++) {
       Cursor *cursor = cursors[i];
-      Cursor_Pause(cursor);
       AREQ *areq = cursor->execState;
       if (IsHybridSearchSubquery(areq)) {
         RedisModule_ReplyKV_LongLong(reply, "SEARCH", cursor->id);
@@ -419,6 +418,7 @@ static inline void replyWithCursors(RedisModuleCtx *replyCtx, arrayof(Cursor*) c
         // This should never happen, we currently only support SEARCH and VSIM subqueries
         RS_ABORT_ALWAYS("Unknown subquery type");
       }
+      Cursor_Pause(cursor);
     }
     // Add warnings array
     RedisModule_ReplyKV_Array(reply, "warnings"); // >warnings


### PR DESCRIPTION
## Describe the changes in the pull request

Backport of #10451 to **8.4** — **fix only**.

1. **Current:** `replyWithCursors()` called `Cursor_Pause(cursor)` and *then* read `cursor->execState` / `cursor->id`. `Cursor_Pause()` frees the cursor when `delete_mark` is set — which a concurrent index teardown (`FLUSHALL` / `FT.DROPINDEX` → `CursorList_Empty`) sets on still-in-flight cursors. The reply raced that free, read an already-freed `AREQ`, and crashed the shard worker thread (SIGSEGV).
2. **Change:** Snapshot `execState` / `id` / subquery type **before** `Cursor_Pause()`, and pause last — matching the cursor-ownership discipline `AREQ_StartCursor` / `runCursor` already follow.
3. **Outcome:** No use-after-free; the shard survives cursor teardown that races the cursor reply.

The deterministic regression test from the original PR is **omitted** on this branch: it depends on the `FT.DEBUG QUERY_CONTROLLER *_HYBRID_STORE_CURSORS` pause hook, which does not exist on 8.4. Coverage remains on master and 8.8.

#### Which additional issues this PR fixes
1. MOD-16878

#### Main objects this PR modified
1. `src/hybrid/hybrid_exec.c` (`replyWithCursors`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: fixes a shard crash (SIGSEGV) in the `FT.HYBRID` cursor path when a cursor teardown (`FLUSHALL` / `FT.DROPINDEX`) races the cursor reply.

## Original PR
https://github.com/RediSearch/RediSearch/pull/10451

## Changes from original
Fix-only backport: the `hybrid_exec.c` change is identical to the original; the regression test is omitted (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
