### PR TITLE
[MOD-14879] qast: handle QN_GEOMETRY in Rust

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -838,29 +838,6 @@ bool AREQ_CheckTimedOut(AREQ *areq) {
   return AREQ_TimedOut(areq);
 }
 
-static QueryIterator *Query_EvalGeometryNode(QueryEvalCtx *q, QueryNode *node) {
-  RS_LOG_ASSERT(node->type == QN_GEOMETRY, "query node type should be geometry");
-
-  const FieldSpec *fs = node->gmn.geomq->fs;
-
-  // TODO: open with DONT_CREATE_INDEX once the query string is validated before we get here.
-  // Currently, if  we use DONT_CREATE_INDEX, and the index was not initialized yet, and the query is invalid,
-  // we return results as if the index was empty, instead of raising an error.
-  const GeometryIndex *index = OpenGeometryIndex((FieldSpec *)fs, CREATE_INDEX);
-  const GeometryApi *api = GeometryApi_Get(index);
-  const GeometryQuery *gq = node->gmn.geomq;
-  RedisModuleString *errMsg;
-  FieldFilterContext filterCtx = {.field = {.index_tag = FieldMaskOrIndex_Index, .index = fs->index}, .predicate = FIELD_EXPIRATION_PREDICATE_DEFAULT};
-  QueryIterator *ret = api->query(q->sctx, &filterCtx, index, gq->query_type, gq->format, gq->str, gq->str_len, &errMsg);
-  if (ret == NULL) {
-    QueryError_SetWithUserDataFmt(q->status, QUERY_ERROR_CODE_BAD_VAL, "Error querying geoshape index", ": %s",
-                           RedisModule_StringPtrLen(errMsg, NULL));
-    RedisModule_FreeString(NULL, errMsg);
-  }
-  return ret;
-}
-
-
 static QueryIterator *Query_EvalVectorNode(QueryEvalCtx *q, QueryNode *qn) {
   RS_LOG_ASSERT(qn->type == QN_VECTOR, "query node type should be vector");
 
@@ -1248,6 +1225,7 @@ QueryIterator *Query_EvalNode(QueryEvalCtx *q, QueryNode *n) {
     case QN_NUMERIC:
     case QN_GEO:
     case QN_TOKEN:
+    case QN_GEOMETRY:
       // These node types have been ported to Rust.
       return Query_EvalNode_Rs(q, n);
     case QN_TAG:
@@ -1260,8 +1238,6 @@ QueryIterator *Query_EvalNode(QueryEvalCtx *q, QueryNode *n) {
       return Query_EvalVectorNode(q, n);
     case QN_WILDCARD_QUERY:
       return Query_EvalWildcardQueryNode(q,n);
-    case QN_GEOMETRY:
-      return Query_EvalGeometryNode(q, n);
     case QN_MAX: // LCOV_EXCL_LINE — exhaustive switch: all valid QN types handled above
       RS_ABORT("Invalid query node type"); // LCOV_EXCL_LINE
   }

--- a/src/redisearch_rs/c_wrappers/query/src/mock/query_node_ref.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/mock/query_node_ref.rs
@@ -138,6 +138,21 @@ impl MockQueryNode {
         }
     }
 
+    /// Set the `geomq` field of the geometry-node union variant.
+    ///
+    /// The caller must ensure the node is of Geometry type, so the `gmn` union
+    /// variant is active; otherwise this writes through the wrong variant. The
+    /// caller must also keep `geomq` (and the [`ffi::FieldSpec`] it points at)
+    /// valid for as long as the node is used.
+    pub fn set_geometry(&mut self, geomq: *mut ffi::GeometryQuery) {
+        // SAFETY: `self.node` is valid and exclusively owned; the caller
+        // guarantees the node type is Geometry so the `gmn` variant is active.
+        unsafe {
+            let union_ptr = &raw mut (*self.node).__bindgen_anon_1;
+            (*union_ptr.cast::<ffi::QueryGeometryNode>()).geomq = geomq;
+        }
+    }
+
     /// Set the `prefix` and `suffix` fields of the prefix-node union variant.
     pub fn set_prefix_mode(&mut self, prefix: bool, suffix: bool) {
         // SAFETY: `self.node` is valid and exclusively owned; the caller

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -153,6 +153,18 @@ const HEADERS: &[HeaderAllowlist] = &[
         vars: &[],
     },
     HeaderAllowlist {
+        path: "src/geometry/geometry_api.h",
+        fns: &["GeometryApi_Get"],
+        types: &["GeometryApi"],
+        vars: &[],
+    },
+    HeaderAllowlist {
+        path: "src/geometry_index.h",
+        fns: &["OpenGeometryIndex"],
+        types: &["GeometryQuery"],
+        vars: &[],
+    },
+    HeaderAllowlist {
         path: "src/indexes.h",
         fns: &[
             "Indexes_Init",

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -12,7 +12,7 @@
 //! Converts a parsed query AST node into an executable iterator tree by
 //! dispatching on the [`QueryNodeType`](query_types::QueryNodeType) discriminant.
 
-use std::ptr::NonNull;
+use std::{ffi::CStr, ptr::NonNull};
 
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use index_result::RSIndexResult;
@@ -201,6 +201,7 @@ pub fn eval_node<'index>(
         QueryNode::Numeric { nf } => eval_numeric(ctx, nf, config),
         QueryNode::Geo { gf } => eval_geo(ctx, gf, config),
         QueryNode::Token { tok } => eval_token(ctx, node, tok, config),
+        QueryNode::Geometry { geomq } => eval_geometry(ctx, geomq),
         // Node types not yet ported to Rust are delegated back to the C
         // dispatcher.
         _ => eval_node_c(ctx, node),
@@ -935,4 +936,105 @@ fn eval_token_disk<'index>(
             None
         }
     }
+}
+
+/// `QN_GEOMETRY` — a geometry (WKT/GeoJSON) spatial predicate on a GEOSHAPE
+/// field.
+///
+/// The GEOSHAPE index is a C++ R-tree exposed through a C API
+/// ([`GeometryApi`](ffi::GeometryApi)); this evaluator opens the field's index
+/// and dispatches to its `query` callback. On a query error the API returns
+/// NULL and an error string, which is reported into the query status; the
+/// iterator is `None`.
+fn eval_geometry<'index>(
+    ctx: &'index mut QueryEvalContext,
+    geomq: *mut ffi::GeometryQuery,
+) -> Option<Evaluated<'index>> {
+    debug_assert!(
+        !geomq.is_null(),
+        "geometry node must carry a geometry query"
+    );
+    // SAFETY: a well-formed geometry node carries a valid, non-null
+    // `GeometryQuery` whose `fs` is a valid, non-null `FieldSpec`.
+    let gq = unsafe { &*geomq };
+    let fs = gq.fs;
+    debug_assert!(!fs.is_null(), "geometry query must have a field spec");
+    // SAFETY: `fs` is a valid, non-null `FieldSpec`.
+    let field_index = unsafe { (*fs).index };
+
+    // TODO: pass `false` (don't create the index if missing) once the query
+    // string is validated before reaching this evaluator. Today, if the index
+    // has not been created yet and the query is invalid, not creating it would
+    // return results as if the index were empty instead of raising an error, so
+    // we create it eagerly to force the error path.
+    //
+    // SAFETY: `fs` is a valid `FieldSpec`. `OpenGeometryIndex` does not keep the
+    // pointer; with create-if-missing it may mutate `fs` to lazily attach the
+    // index, which is sound here because no live Rust borrow aliases `fs` (`gq`
+    // borrows the `GeometryQuery`, a separate allocation).
+    let index = unsafe { ffi::OpenGeometryIndex(fs.cast_mut(), true) };
+    debug_assert!(
+        !index.is_null(),
+        "OpenGeometryIndex with create-if-missing must return a valid index"
+    );
+    // SAFETY: `index` is a valid `GeometryIndex` from `OpenGeometryIndex`.
+    let api = unsafe { ffi::GeometryApi_Get(index) };
+    debug_assert!(!api.is_null(), "GeometryApi_Get must return a valid api");
+
+    let field_ctx = FieldFilterContext {
+        field: FieldMaskOrIndex::Index(field_index),
+        predicate: FieldExpirationPredicate::Default,
+    };
+    let sctx = ctx.sctx_ptr();
+    let mut err_msg: *mut ffi::RedisModuleString = std::ptr::null_mut();
+
+    // SAFETY: `api` is a valid `GeometryApi` and its `query` callback is always
+    // populated by `GeometryApi_Get`.
+    let query_fn = unsafe { (*api).query }.expect("geometry api `query` must be set");
+    // SAFETY: all pointers are valid for the duration of the call: `sctx` and
+    // `field_ctx` outlive it, `index` is valid, `gq.str` points to `gq.str_len`
+    // bytes, and `err_msg` is a valid out-pointer.
+    let ret = unsafe {
+        query_fn(
+            sctx,
+            std::ptr::from_ref(&field_ctx).cast(),
+            index,
+            gq.query_type,
+            gq.format,
+            gq.str_,
+            gq.str_len,
+            &mut err_msg,
+        )
+    };
+
+    if ret.is_null() {
+        let detail = if let Some(err) = NonNull::new(err_msg) {
+            // SAFETY: these Redis API function-pointer are set once
+            // during module load and never mutated afterwards, so reading them
+            // during query evaluation cannot race.
+            let string_ptr_len =
+                unsafe { ffi::RedisModule_StringPtrLen }.expect("RedisModule_StringPtrLen unset");
+            // SAFETY: set once at module load, never mutated afterwards (see above).
+            let free_string =
+                unsafe { ffi::RedisModule_FreeString }.expect("RedisModule_FreeString unset");
+            // SAFETY: `err` is a valid `RedisModuleString` returned by the query.
+            let str_ptr = unsafe { string_ptr_len(err.as_ptr(), std::ptr::null_mut()) };
+            // SAFETY: `str_ptr` is a valid, NUL-terminated C string.
+            let s = unsafe { CStr::from_ptr(str_ptr) }
+                .to_string_lossy()
+                .into_owned();
+            // SAFETY: `err` was allocated by the query and is freed exactly once.
+            unsafe { free_string(std::ptr::null_mut(), err.as_ptr()) };
+            s
+        } else {
+            String::new()
+        };
+        ctx.status().set_with_user_data(
+            query_error::QueryErrorCode::BadVal,
+            "Error querying geoshape index",
+            &format!(": {detail}"),
+        );
+    }
+
+    NonNull::new(ret).map(Evaluated::C)
 }

--- a/src/redisearch_rs/query_eval/tests/integration/geometry.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/geometry.rs
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! QN_GEOMETRY → GEOSHAPE (R-tree) query iterator.
+//!
+//! Needs a real GEOSHAPE field whose R-tree index is created on demand, so it
+//! relies on the full-FFI `TestContext`.
+//!
+//! Disabled under Miri: `TestContext` and the geometry backend call into the
+//! C/C++ library, which Miri cannot execute.
+#![cfg(not(miri))]
+
+use std::ffi::CString;
+
+use query::mock::MockQueryNode;
+use query_error::QueryErrorCode;
+use query_eval::{
+    QueryEvalContext, QueryNodeRef,
+    eval::{self, Config, EvalResult},
+};
+use query_types::QueryNodeType;
+use rqe_iterators::RQEIterator;
+use rqe_iterators_test_utils::{GlobalGuard, TestContext};
+
+/// A well-formed WKT polygon.
+const VALID_POLYGON: &str = "POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))";
+/// The same polygon with a misspelled keyword, which the backend rejects while
+/// parsing — the query syntax around it is still valid, so evaluation reaches
+/// the backend before failing.
+const INVALID_POLYGON: &str = "POLIGON((0 0, 0 10, 10 10, 10 0, 0 0))"; // codespell:ignore poligon
+
+/// Owns everything a `QN_GEOMETRY` evaluation borrows — the FFI `TestContext`,
+/// the [`QueryEvalContext`], the node, the geometry query, and its backing WKT
+/// string — so [`eval`](Self::eval) can hand the evaluated iterator back to the
+/// caller.
+///
+/// The iterator borrows `ctx`, which points into the other fields, so they must
+/// all outlive it. They do: `TestContext` keeps its state behind heap
+/// allocations, `geomq` is boxed (stable address) and the WKT string is owned
+/// here, all freed only when the fixture is dropped, after every evaluated
+/// iterator.
+struct GeometryFixture {
+    _guard: GlobalGuard,
+    _context: TestContext,
+    ctx: QueryEvalContext,
+    node: MockQueryNode,
+    // Boxed so its address stays stable while the node holds a raw pointer to it.
+    _geomq: Box<ffi::GeometryQuery>,
+    // Backing storage for the query string `geomq.str_` points at.
+    _wkt: CString,
+}
+
+impl GeometryFixture {
+    /// Build a `QN_GEOMETRY` node for a `within` query over `wkt` against an
+    /// empty GEOSHAPE index.
+    fn new(wkt: &str) -> Self {
+        let _guard = GlobalGuard::default();
+
+        let context = TestContext::geometry();
+
+        // SAFETY: `context.qctx()` returns a valid, exclusively-owned
+        // `QueryEvalCtx` (with real `status`/`config`), upholding the
+        // `QueryEvalContext::new` invariants.
+        let ctx = unsafe { QueryEvalContext::new(context.qctx()) };
+
+        let wkt = CString::new(wkt).expect("wkt must not contain an interior NUL");
+        let mut geomq = Box::new(ffi::GeometryQuery {
+            format: ffi::GEOMETRY_FORMAT_GEOMETRY_FORMAT_WKT,
+            query_type: ffi::QueryType_WITHIN,
+            fs: context.field_spec() as *const _,
+            str_: wkt.as_ptr(),
+            str_len: wkt.as_bytes().len(),
+        });
+
+        let mut node = MockQueryNode::new(QueryNodeType::Geometry);
+        node.opts_mut().weight = 1.0;
+        node.set_geometry(&mut *geomq as *mut ffi::GeometryQuery);
+
+        Self {
+            _guard,
+            _context: context,
+            ctx,
+            node,
+            _geomq: geomq,
+            _wkt: wkt,
+        }
+    }
+
+    /// Index `wkt` under `doc_id` in the fixture's GEOSHAPE index so a matching
+    /// query can return it.
+    ///
+    /// Must be called before [`eval`](Self::eval): `OpenGeometryIndex` lazily
+    /// creates the R-tree and stores it on the field spec, so both the insert
+    /// here and the query in `eval` operate on the same index.
+    fn add_geometry(&self, doc_id: u64, wkt: &str) {
+        let fs = self._context.field_spec() as *const ffi::FieldSpec as *mut ffi::FieldSpec;
+        let wkt = CString::new(wkt).expect("wkt must not contain an interior NUL");
+
+        // SAFETY: `fs` is a valid GEOSHAPE `FieldSpec`; create-if-missing lazily
+        // attaches the R-tree index.
+        let index = unsafe { ffi::OpenGeometryIndex(fs, true) };
+        // SAFETY: `index` is a valid `GeometryIndex` from `OpenGeometryIndex`.
+        let api = unsafe { ffi::GeometryApi_Get(index) };
+        // SAFETY: `GeometryApi_Get` always populates the `addGeomStr` callback.
+        let add = unsafe { (*api).addGeomStr }.expect("geometry api `addGeomStr` must be set");
+
+        let mut err: *mut ffi::RedisModuleString = std::ptr::null_mut();
+        // SAFETY: `index` is valid, `wkt` points to `wkt.as_bytes().len()` bytes,
+        // and `err` is a valid out-pointer.
+        let rc = unsafe {
+            add(
+                index,
+                ffi::GEOMETRY_FORMAT_GEOMETRY_FORMAT_WKT,
+                wkt.as_ptr(),
+                wkt.as_bytes().len(),
+                doc_id,
+                &mut err,
+            )
+        };
+        // `addGeomStr` follows the C convention: non-zero on success, 0 (with
+        // `err` set) on failure.
+        assert_ne!(rc, 0, "indexing a well-formed geometry must succeed");
+        assert!(err.is_null(), "a successful insert must not set an error");
+    }
+
+    /// Evaluate the node, returning the boxed iterator, or `None` when
+    /// evaluation produced no iterator.
+    fn eval(&mut self) -> Option<EvalResult<'_>> {
+        // SAFETY: `self.node` is a valid, live `RSQueryNode` for the call.
+        let node_ref = unsafe { QueryNodeRef::new(self.node.as_non_null()) };
+        eval::eval_node(&mut self.ctx, &node_ref, Config::default()).map(|e| e.into_boxed())
+    }
+}
+
+/// Collect the doc ids the iterator yields, in order.
+fn read_all(it: &mut EvalResult<'_>) -> Vec<u64> {
+    let mut ids = Vec::new();
+    while let Some(r) = it.read().expect("read must not error") {
+        ids.push(r.doc_id);
+    }
+    ids
+}
+
+#[test]
+fn eval_geometry_valid_query_on_empty_index_yields_empty_iterator() {
+    // A well-formed query against the (empty) index builds a valid iterator that
+    // yields no documents; this is not an error.
+    let mut fixture = GeometryFixture::new(VALID_POLYGON);
+    {
+        let mut it = fixture
+            .eval()
+            .expect("a well-formed geometry query must build an iterator");
+        assert!(
+            it.read().expect("read must not error").is_none(),
+            "an empty geoshape index must yield no documents"
+        );
+    }
+    assert!(fixture.ctx.status().is_ok());
+}
+
+#[test]
+fn eval_geometry_matches_contained_geometry() {
+    // A `within` query over `VALID_POLYGON` (the 0..10 square) must return only
+    // the indexed geometry that lies inside it, not the one outside.
+    let mut fixture = GeometryFixture::new(VALID_POLYGON);
+    fixture.add_geometry(1, "POLYGON((2 2, 2 4, 4 4, 4 2, 2 2))");
+    fixture.add_geometry(2, "POLYGON((20 20, 20 24, 24 24, 24 20, 20 20))");
+
+    {
+        let mut it = fixture
+            .eval()
+            .expect("a well-formed geometry query must build an iterator");
+        assert_eq!(
+            read_all(&mut it),
+            vec![1],
+            "only the geometry within the query polygon must match"
+        );
+    }
+    assert!(fixture.ctx.status().is_ok());
+}
+
+#[test]
+fn eval_geometry_invalid_wkt_reports_error() {
+    // A malformed geometry string makes the backend reject the query, which must
+    // surface as a `BadVal` error and yield no iterator.
+    let mut fixture = GeometryFixture::new(INVALID_POLYGON);
+    assert!(
+        fixture.eval().is_none(),
+        "a rejected geometry query must not build an iterator"
+    );
+
+    let status = fixture.ctx.status();
+    assert_eq!(
+        status.code(),
+        QueryErrorCode::BadVal,
+        "a rejected geometry query must report a bad-value error"
+    );
+
+    // The public message must stay free of the (user-controlled) backend detail,
+    // which belongs only in the private message — mirroring the C
+    // `QueryError_SetWithUserDataFmt` split.
+    let public = status
+        .public_message()
+        .expect("a set error must have a public message")
+        .to_str()
+        .unwrap();
+    assert_eq!(public, "Error querying geoshape index");
+
+    let private = status
+        .private_message()
+        .expect("a set error must have a private message")
+        .to_str()
+        .unwrap();
+    assert!(
+        private.contains("Error querying geoshape index:"),
+        "the private message must carry the prefixed detail, got {private:?}"
+    );
+}

--- a/src/redisearch_rs/query_eval/tests/integration/main.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/main.rs
@@ -12,6 +12,7 @@ redis_mock::mock_or_stub_missing_redis_c_symbols!();
 extern crate redisearch_rs;
 
 mod geo;
+mod geometry;
 mod ids;
 mod missing;
 mod not;

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -127,6 +127,9 @@ enum TestContextInner {
         tag_index: ptr::NonNull<ffi::TagIndex>,
         inverted_index: ptr::NonNull<ffi::InvertedIndex>,
     },
+    Geometry {
+        field_spec: ptr::NonNull<ffi::FieldSpec>,
+    },
 }
 
 /// Create a spec and search context from the given schema and index name.
@@ -417,6 +420,42 @@ impl TestContext {
                 field_spec: fs,
                 numeric_range_tree: NonNull::from_mut(numeric_range_tree),
             },
+        }
+    }
+
+    /// Create a new [`TestContext`] with an empty GEOSHAPE (flat) field.
+    ///
+    /// The underlying R-tree index is created lazily on first query, so no
+    /// document setup is needed to exercise query evaluation: a valid query
+    /// against the empty index yields an empty iterator, while a malformed
+    /// geometry string surfaces a query error.
+    pub fn geometry() -> Self {
+        // Serialize TestContext creation to avoid concurrent access to C global state
+        let _lock = CONTEXT_MUTEX.lock().unwrap();
+
+        let ctx = ModuleCtx::new();
+        let index_name = unique_index_name("geometry_idx");
+        let (spec, sctx) = create_spec_sctx(&ctx, "SCHEMA geom GEOSHAPE FLAT", &index_name);
+
+        let field_name = CString::new("geom").unwrap();
+        // SAFETY: `spec` is a valid, non-null `IndexSpec` just returned by
+        // `create_spec_sctx`, and `field_name` is a valid NUL-terminated string
+        // whose byte length matches the pointer passed alongside it.
+        let fs = unsafe {
+            ffi::IndexSpec_GetFieldWithLength(
+                spec,
+                field_name.as_ptr(),
+                field_name.as_bytes().len(),
+            )
+        };
+        let field_spec = ptr::NonNull::new(fs as _).expect("FieldSpec should not be null");
+
+        Self {
+            _ctx: ctx,
+            sctx,
+            spec,
+            qctx: OnceCell::new(),
+            inner: TestContextInner::Geometry { field_spec },
         }
     }
 
@@ -767,7 +806,8 @@ impl TestContext {
             TestContextInner::Numeric { field_spec, .. }
             | TestContextInner::Term { field_spec, .. }
             | TestContextInner::Missing { field_spec, .. }
-            | TestContextInner::Tag { field_spec, .. } => unsafe { field_spec.as_ref() },
+            | TestContextInner::Tag { field_spec, .. }
+            | TestContextInner::Geometry { field_spec, .. } => unsafe { field_spec.as_ref() },
             TestContextInner::Wildcard { .. } => panic!("Wildcard context has no field spec"),
         }
     }


### PR DESCRIPTION
Port `Query_EvalGeometryNode` to Rust: open the `GEOSHAPE index`, dispatch to the geometry API's query callback, and report a query error via `set_with_user_data` so the backend detail stays out of the obfuscated public message. 



#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
