### PR TITLE
query_eval: use CTrieRef for term doc-count lookup in eval_token_disk

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1742,6 +1742,7 @@ name = "query_eval"
 version = "0.0.1"
 dependencies = [
  "build_utils",
+ "c_trie",
  "cheadergen",
  "ffi",
  "field",

--- a/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
@@ -83,6 +83,72 @@ impl CTrieRef {
         CTrieDecrResult::from_repr(result).unwrap_or(CTrieDecrResult::NotFound)
     }
 
+    /// Number of documents indexed under `term`, or `0` if the term is absent
+    /// from the trie.
+    ///
+    /// `term` is UTF-8 encoded; it is converted to runes internally and looked
+    /// up as an exact match. Used to compute a term's inverse document
+    /// frequency (IDF).
+    ///
+    /// Returns `0` for input that cannot correspond to a stored term — invalid
+    /// UTF-8, or a term longer than the trie can hold — since such a term can
+    /// never have been inserted.
+    ///
+    /// # Safety
+    ///
+    /// This function is safe to call if the `CTrieRef` was created safely.
+    pub fn num_docs(&self, term: &[u8]) -> usize {
+        // Terms longer than the trie can store are never present, so report zero
+        // without a lookup (mirrors the C insertion/decrement guards). This also
+        // bounds the rune count to `term.len()`, keeping it within `t_len` so the
+        // narrowing cast below cannot wrap and match a shorter term by mistake.
+        if term.len() > ffi::TRIE_INITIAL_STRING_LEN as usize * std::mem::size_of::<ffi::rune>() {
+            return 0;
+        }
+
+        // The rune conversion decodes UTF-8 without bounds-checking multibyte
+        // sequences against the slice end, so a truncated or invalid sequence
+        // could read past `term`. Reject non-UTF-8 input up front; such a term
+        // cannot match a stored (rune-decoded) term anyway.
+        if std::str::from_utf8(term).is_err() {
+            return 0;
+        }
+
+        // A UTF-8 string yields at most as many runes as bytes; the extra slot
+        // leaves room for the conversion to write a trailing rune.
+        let mut runes = vec![0 as ffi::rune; term.len() + 1];
+        // SAFETY: `term` is valid UTF-8 of `term.len()` bytes, so the decode
+        // stays within the slice, and `runes` has room for `term.len() + 1`
+        // runes, so the conversion writes within bounds.
+        let rlen = unsafe {
+            ffi::strToRunesN(
+                term.as_ptr() as *const c_char,
+                term.len(),
+                runes.as_mut_ptr(),
+            )
+        };
+        // SAFETY: `self.ptr` is a valid `Trie` (`CTrieRef` invariant); `runes`/
+        // `rlen` describe a valid rune slice, and `rlen <= term.len()` fits
+        // `t_len` (guarded above).
+        let node = unsafe {
+            ffi::Trie_GetNode(
+                self.ptr,
+                runes.as_ptr(),
+                rlen as ffi::t_len,
+                true,
+                std::ptr::null_mut(),
+            )
+        };
+
+        if node.is_null() {
+            0
+        } else {
+            // SAFETY: `node` is a valid, non-null `TrieNode` returned by the
+            // lookup above.
+            unsafe { ffi::TrieNode_NumDocs(node) }
+        }
+    }
+
     /// Get the raw pointer to the C Trie.
     ///
     /// This is useful when you need to pass the pointer to other C functions.

--- a/src/redisearch_rs/query_eval/Cargo.toml
+++ b/src/redisearch_rs/query_eval/Cargo.toml
@@ -14,6 +14,7 @@ unittest = []
 build_utils.workspace = true
 
 [dependencies]
+c_trie.workspace = true
 cheadergen.workspace = true
 ffi.workspace = true
 field.workspace = true

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -14,6 +14,7 @@
 
 use std::ptr::NonNull;
 
+use c_trie::CTrieRef;
 use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use index_result::RSIndexResult;
 use inverted_index::NumericFilter;
@@ -871,32 +872,16 @@ fn eval_token_disk<'index>(
     // build a disk term iterator through the enterprise API.
     // SAFETY: in search-on-disk mode the terms trie is always initialised.
     debug_assert!(!spec.terms.is_null(), "terms trie should be initialized");
-    // A `QN_TOKEN` node always carries a non-null term string; the `strToRunesN`
-    // read below relies on it.
+    // A `QN_TOKEN` node always carries a non-null term string; the term lookup
+    // below relies on it.
     debug_assert!(!tok.str_.is_null(), "token string should not be null");
 
-    let mut runes = vec![0 as ffi::rune; tok.len + 1];
-    // SAFETY: `tok.str_` points to `tok.len` valid bytes; `runes` has room
-    // for `tok.len + 1` runes (a UTF-8 string yields at most as many runes
-    // as bytes), so `strToRunesN` writes within bounds.
-    let rlen = unsafe { ffi::strToRunesN(tok.str_, tok.len, runes.as_mut_ptr()) };
-    // SAFETY: `spec.terms` is a valid `Trie` (checked non-null above) and
-    // `runes`/`rlen` describe a valid rune slice.
-    let trienode = unsafe {
-        ffi::Trie_GetNode(
-            spec.terms,
-            runes.as_ptr(),
-            rlen as ffi::t_len,
-            true,
-            std::ptr::null_mut(),
-        )
-    };
-    let num_docs_in_term = if trienode.is_null() {
-        0
-    } else {
-        // SAFETY: `trienode` is a valid, non-null `TrieNode` from `Trie_GetNode`.
-        unsafe { ffi::TrieNode_NumDocs(trienode) }
-    };
+    // SAFETY: `spec.terms` is a valid `Trie` (checked non-null above) that
+    // outlives this lookup.
+    let terms = unsafe { CTrieRef::from_raw(spec.terms) };
+    // SAFETY: `tok.str_` points to `tok.len` valid bytes from the query node.
+    let term_bytes = unsafe { std::slice::from_raw_parts(tok.str_.cast::<u8>(), tok.len) };
+    let num_docs_in_term = terms.num_docs(term_bytes);
     let num_documents = spec.stats.scoring.numDocuments;
     let idf = idf::calculate_idf(num_documents, num_docs_in_term);
     let bm25_idf = idf::calculate_idf_bm25(num_documents, num_docs_in_term);


### PR DESCRIPTION
Add `CTrieRef::num_docs`, wrapping the `strToRunesN + Trie_GetNode + TrieNode_NumDocs` sequence behind a single safe method, and use it in `eval_token_disk` instead of an inline raw-FFI block.

I didn't know about `CTrieRef`. Let's use and extend it as the following nodes will keep using it.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
