### PR TITLE
[MOD-14988] triemap_ffi: TrieMapIterator support for tries with inline values

### DIFF
--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter.rs
@@ -7,12 +7,16 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use super::iter_types::TrieMapIteratorImpl;
+use super::iter_types::{
+    InlineContainsIter, InlineFilteredIter, InlineValuesIter, InlineWildcardIter,
+    TrieMapIteratorImpl,
+};
 use super::*;
 use lending_iterator::LendingIterator;
 use libc::timespec;
 use rqe_wildcard::WildcardPattern;
 use std::ffi::{c_char, c_int, c_void};
+use trie_rs::iter::filter::VisitAll;
 
 /// Used by [`TrieMapIterator`] to determine type of query.
 #[repr(C)]
@@ -24,11 +28,63 @@ pub enum tm_iter_mode {
     TM_WILDCARD_MODE = 3,
 }
 
-/// Opaque type TrieMapIterator. Obtained from calling [`TrieMap_Iterate`] or
-/// [`TrieMap_IterateWithFilter`].
+/// Opaque type TrieMapIterator. Obtained from calling [`TrieMap_Iterate`],
+/// [`TrieMap_IterateWithFilter`], or `TrieMapIterator::from_*` methods.
 pub struct TrieMapIterator<'tm> {
     iter: TrieMapIteratorImpl<'tm>,
     timeout: Option<IteratorTimeoutState>,
+}
+
+impl<'tm> TrieMapIterator<'tm> {
+    /// Iterate a Rust trie whose values are stored inline (rather than as
+    /// `*mut c_void`). [`TrieMapIterator_Next`] will write, for each entry,
+    /// the address of the value stored inside the trie. That pointer stays
+    /// valid as long as the trie is not mutated.
+    ///
+    /// This lets Rust-backed containers (e.g. the tag index's values trie)
+    /// hand C the same opaque iterator it gets from [`TrieMap_Iterate`].
+    pub fn from_inline_values<V: 'tm>(iter: trie_rs::iter::LendingIter<'tm, V, VisitAll>) -> Self {
+        Self {
+            iter: TrieMapIteratorImpl::Erased(Box::new(InlineValuesIter(iter))),
+            timeout: None,
+        }
+    }
+
+    /// Same as [`TrieMapIterator::from_inline_values`], over the entries whose
+    /// key contains a target fragment.
+    pub fn from_inline_contains<V: 'tm>(
+        iter: trie_rs::iter::ContainsLendingIter<'tm, 'tm, V>,
+    ) -> Self {
+        Self {
+            iter: TrieMapIteratorImpl::Erased(Box::new(InlineContainsIter(iter))),
+            timeout: None,
+        }
+    }
+
+    /// Same as [`TrieMapIterator::from_inline_values`], over the entries whose
+    /// key matches a wildcard pattern.
+    pub fn from_inline_wildcard<V: 'tm>(
+        iter: trie_rs::iter::WildcardLendingIter<'tm, 'tm, V>,
+    ) -> Self {
+        Self {
+            iter: TrieMapIteratorImpl::Erased(Box::new(InlineWildcardIter(iter))),
+            timeout: None,
+        }
+    }
+
+    /// Same as [`TrieMapIterator::from_inline_values`], over the entries whose
+    /// key ends with `suffix`.
+    pub fn from_inline_suffix_filter<V: 'tm>(
+        iter: trie_rs::iter::LendingIter<'tm, V, VisitAll>,
+        suffix: Vec<u8>,
+    ) -> Self {
+        Self {
+            iter: TrieMapIteratorImpl::Erased(Box::new(InlineFilteredIter(
+                iter.filter(Box::new(move |(k, _)| k.ends_with(&suffix))),
+            ))),
+            timeout: None,
+        }
+    }
 }
 
 struct IteratorTimeoutState {
@@ -234,7 +290,7 @@ pub unsafe extern "C" fn TrieMapIterator_Next(
     // SAFETY: caller is to ensure that `ptr` is
     // a mutable, well-aligned pointer to a `*mut c_void`
     unsafe {
-        value.write(*v);
+        value.write(v);
     }
 
     1

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter.rs
@@ -36,13 +36,15 @@ pub struct TrieMapIterator<'tm> {
 }
 
 impl<'tm> TrieMapIterator<'tm> {
-    /// Iterate a Rust trie whose values are stored inline (rather than as
-    /// `*mut c_void`). [`TrieMapIterator_Next`] will write, for each entry,
+    /// Iterate a Rust trie whose values are stored inline.
+    /// [`TrieMapIterator_Next`] will write, for each entry,
     /// the address of the value stored inside the trie. That pointer stays
     /// valid as long as the trie is not mutated.
     ///
-    /// This lets Rust-backed containers (e.g. the tag index's values trie)
-    /// hand C the same opaque iterator it gets from [`TrieMap_Iterate`].
+    /// The pointer aliases trie-internal storage and is **read-only**: writing
+    /// through it is undefined behavior (it aliases the shared borrow held by
+    /// the iterator). See [`ErasedValuesIter`](super::iter_types::ErasedValuesIter)
+    /// for the full contract.
     pub fn from_inline_values<V: 'tm>(iter: trie_rs::iter::LendingIter<'tm, V, VisitAll>) -> Self {
         Self {
             iter: TrieMapIteratorImpl::Erased(Box::new(InlineValuesIter(iter))),
@@ -240,6 +242,11 @@ pub unsafe extern "C" fn TrieMapIterator_Free(it: *mut TrieMapIterator) {
 ///   pointer is invalidated upon calling [`TrieMapIterator_Next`] again.
 /// - `len` must point to a valid `tm_len_t` which will be set to the length of the current key.
 /// - `value` must point to a valid pointer, which will be set to the value of the current key.
+///
+/// For iterators over a trie whose values are stored inline (created via the
+/// `from_inline_*` constructors), the written `value` points into trie-internal
+/// storage and must be treated as **read-only**, so writing through it is undefined
+/// behavior.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMapIterator_Next(
     it: *mut TrieMapIterator,
@@ -287,7 +294,7 @@ pub unsafe extern "C" fn TrieMapIterator_Next(
     unsafe {
         len.write(k.len() as tm_len_t);
     }
-    // SAFETY: caller is to ensure that `ptr` is
+    // SAFETY: caller is to ensure that `value` is
     // a mutable, well-aligned pointer to a `*mut c_void`
     unsafe {
         value.write(v);

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter_types.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter_types.rs
@@ -19,9 +19,28 @@ pub type BoxedPredicate = Box<dyn Fn(&(&[u8], &*mut c_void)) -> bool>;
 /// Lets [`TrieMapIterator`](super::TrieMapIterator) iterate Rust tries whose
 /// values are stored inline (rather than as `*mut c_void`), handing C a
 /// pointer to each inline value.
+/// Therefore, the user needs to know the type, so it can use pointer cast to
+/// recovering a pointer to the concrete type. This is ok because
+/// the concrete value types are `Sized`: `&V` is then a thin pointer.
+///
+/// # Read-only contract
+///
+/// The returned pointer aliases storage owned by the trie, and it is derived
+/// from a *shared* borrow (`&V`) held for the duration of the iteration (the
+/// underlying trie iterators yield `&'tm V` and borrow the trie immutably).
+/// Callers **must treat the pointer as read-only**: writing through it while
+/// the iteration's shared borrow is live is undefined behavior under Rust's
+/// aliasing model.
+///
+/// The ABI still exposes a mutable `void **` for compatibility with the
+/// pointer-valued trie (see [`TrieMapIteratorImpl::Plain`]), where the yielded
+/// value is a *copy* of a pointer to an object living outside the trie and is
+/// therefore genuinely writable. That asymmetry is exactly why this read-only
+/// contract has to be stated explicitly for the inline path.
 pub trait ErasedValuesIter {
-    /// Advance to the next entry, returning its key and the address of its
-    /// value. The key slice is invalidated by the next call.
+    /// Advance to the next entry, returning its key and the read-only address
+    /// of its value (see the [trait][ErasedValuesIter] docs for the read-only
+    /// contract). The key slice is invalidated by the next call.
     fn next(&mut self) -> Option<(&[u8], *mut c_void)>;
 }
 
@@ -31,6 +50,10 @@ pub struct InlineValuesIter<'tm, V>(pub trie_rs::iter::LendingIter<'tm, V, Visit
 
 impl<'tm, V> ErasedValuesIter for InlineValuesIter<'tm, V> {
     fn next(&mut self) -> Option<(&[u8], *mut c_void)> {
+        // `cast_mut` only shapes the pointer to the mutable `void **` ABI; the
+        // provenance stays that of the shared `&V`. This is sound because the
+        // contract is read-only — see the `ErasedValuesIter` docs. The same
+        // applies to the other inline adapters below.
         LendingIterator::next(&mut self.0)
             .map(|(k, v)| (k, std::ptr::from_ref(v).cast_mut().cast()))
     }
@@ -59,12 +82,11 @@ impl<'tm, V> ErasedValuesIter for InlineWildcardIter<'tm, V> {
 }
 
 /// Key predicate for [`InlineFilteredIter`]. Owns whatever state it needs
-/// (e.g. the suffix pattern), unlike [`BoxedPredicate`] whose captures collapse
+/// unlike [`BoxedPredicate`] whose captures collapse
 /// to the trie lifetime at the FFI boundary.
 pub type BoxedInlinePredicate<V> = Box<dyn Fn(&(&[u8], &V)) -> bool>;
 
-/// Like [`InlineValuesIter`], filtered by a predicate on the entries (used for
-/// suffix mode, where the trie offers no dedicated traversal).
+/// Like [`InlineValuesIter`], filtered by a predicate on the entries.
 pub struct InlineFilteredIter<'tm, V>(
     pub Filter<trie_rs::iter::LendingIter<'tm, V, VisitAll>, BoxedInlinePredicate<V>>,
 );
@@ -88,8 +110,7 @@ pub enum TrieMapIteratorImpl<'tm> {
     // C-side scope.
     Contains(Box<trie_rs::iter::ContainsLendingIter<'tm, 'tm, *mut c_void>>),
     Wildcard(WildcardLendingIter<'tm, 'tm, *mut c_void>),
-    // A trie whose values are stored inline, with the value type erased:
-    // yields the address of each value instead of a stored pointer.
+    // A trie whose values are stored inline, with the value type erased.
     Erased(Box<dyn ErasedValuesIter + 'tm>),
 }
 

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter_types.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter_types.rs
@@ -13,6 +13,69 @@ use trie_rs::iter::{WildcardLendingIter, filter::VisitAll};
 
 pub type BoxedPredicate = Box<dyn Fn(&(&[u8], &*mut c_void)) -> bool>;
 
+/// A lending iterator over `(key, value address)` pairs where the value type
+/// has been erased.
+///
+/// Lets [`TrieMapIterator`](super::TrieMapIterator) iterate Rust tries whose
+/// values are stored inline (rather than as `*mut c_void`), handing C a
+/// pointer to each inline value.
+pub trait ErasedValuesIter {
+    /// Advance to the next entry, returning its key and the address of its
+    /// value. The key slice is invalidated by the next call.
+    fn next(&mut self) -> Option<(&[u8], *mut c_void)>;
+}
+
+/// Adapter erasing the value type of a [`trie_rs::iter::LendingIter`], yielding
+/// the address of each inline value instead of the value itself.
+pub struct InlineValuesIter<'tm, V>(pub trie_rs::iter::LendingIter<'tm, V, VisitAll>);
+
+impl<'tm, V> ErasedValuesIter for InlineValuesIter<'tm, V> {
+    fn next(&mut self) -> Option<(&[u8], *mut c_void)> {
+        LendingIterator::next(&mut self.0)
+            .map(|(k, v)| (k, std::ptr::from_ref(v).cast_mut().cast()))
+    }
+}
+
+/// Like [`InlineValuesIter`], for a [`trie_rs::iter::ContainsLendingIter`]
+/// (entries whose key contains a target fragment).
+pub struct InlineContainsIter<'tm, V>(pub trie_rs::iter::ContainsLendingIter<'tm, 'tm, V>);
+
+impl<'tm, V> ErasedValuesIter for InlineContainsIter<'tm, V> {
+    fn next(&mut self) -> Option<(&[u8], *mut c_void)> {
+        LendingIterator::next(&mut self.0)
+            .map(|(k, v)| (k, std::ptr::from_ref(v).cast_mut().cast()))
+    }
+}
+
+/// Like [`InlineValuesIter`], for a [`WildcardLendingIter`]
+/// (entries whose key matches a wildcard pattern).
+pub struct InlineWildcardIter<'tm, V>(pub WildcardLendingIter<'tm, 'tm, V>);
+
+impl<'tm, V> ErasedValuesIter for InlineWildcardIter<'tm, V> {
+    fn next(&mut self) -> Option<(&[u8], *mut c_void)> {
+        LendingIterator::next(&mut self.0)
+            .map(|(k, v)| (k, std::ptr::from_ref(v).cast_mut().cast()))
+    }
+}
+
+/// Key predicate for [`InlineFilteredIter`]. Owns whatever state it needs
+/// (e.g. the suffix pattern), unlike [`BoxedPredicate`] whose captures collapse
+/// to the trie lifetime at the FFI boundary.
+pub type BoxedInlinePredicate<V> = Box<dyn Fn(&(&[u8], &V)) -> bool>;
+
+/// Like [`InlineValuesIter`], filtered by a predicate on the entries (used for
+/// suffix mode, where the trie offers no dedicated traversal).
+pub struct InlineFilteredIter<'tm, V>(
+    pub Filter<trie_rs::iter::LendingIter<'tm, V, VisitAll>, BoxedInlinePredicate<V>>,
+);
+
+impl<'tm, V> ErasedValuesIter for InlineFilteredIter<'tm, V> {
+    fn next(&mut self) -> Option<(&[u8], *mut c_void)> {
+        LendingIterator::next(&mut self.0)
+            .map(|(k, v)| (k, std::ptr::from_ref(v).cast_mut().cast()))
+    }
+}
+
 pub enum TrieMapIteratorImpl<'tm> {
     Plain(trie_rs::iter::LendingIter<'tm, *mut c_void, VisitAll>),
     Filtered(Filter<trie_rs::iter::LendingIter<'tm, *mut c_void, VisitAll>, BoxedPredicate>),
@@ -25,6 +88,9 @@ pub enum TrieMapIteratorImpl<'tm> {
     // C-side scope.
     Contains(Box<trie_rs::iter::ContainsLendingIter<'tm, 'tm, *mut c_void>>),
     Wildcard(WildcardLendingIter<'tm, 'tm, *mut c_void>),
+    // A trie whose values are stored inline, with the value type erased:
+    // yields the address of each value instead of a stored pointer.
+    Erased(Box<dyn ErasedValuesIter + 'tm>),
 }
 
 #[gat]
@@ -32,14 +98,21 @@ impl<'tm> LendingIterator for TrieMapIteratorImpl<'tm> {
     type Item<'next>
     where
         Self: 'next,
-    = (&'next [u8], &'tm *mut c_void);
+    = (&'next [u8], *mut c_void);
 
     fn next(&mut self) -> Option<Self::Item<'_>> {
         match self {
-            TrieMapIteratorImpl::Plain(iter) => LendingIterator::next(iter),
-            TrieMapIteratorImpl::Filtered(iter) => LendingIterator::next(iter),
-            TrieMapIteratorImpl::Contains(iter) => LendingIterator::next(iter),
-            TrieMapIteratorImpl::Wildcard(iter) => LendingIterator::next(iter),
+            TrieMapIteratorImpl::Plain(iter) => LendingIterator::next(iter).map(|(k, v)| (k, *v)),
+            TrieMapIteratorImpl::Filtered(iter) => {
+                LendingIterator::next(iter).map(|(k, v)| (k, *v))
+            }
+            TrieMapIteratorImpl::Contains(iter) => {
+                LendingIterator::next(iter).map(|(k, v)| (k, *v))
+            }
+            TrieMapIteratorImpl::Wildcard(iter) => {
+                LendingIterator::next(iter).map(|(k, v)| (k, *v))
+            }
+            TrieMapIteratorImpl::Erased(iter) => iter.next(),
         }
     }
 }

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
@@ -297,6 +297,73 @@ fn test_trie_iter_wildcard() {
 }
 
 #[test]
+fn test_trie_iter_inline_values() {
+    let mut trie = trie_rs::TrieMap::new();
+    let entries = [(b"bike".as_slice(), 10u64), (b"cool", 20), (b"cider", 30)];
+    for (key, value) in entries {
+        trie.insert(key, value);
+    }
+
+    let it = Box::into_raw(Box::new(TrieMapIterator::from_inline_values(
+        trie.lending_iter(),
+    )));
+
+    let mut char: *mut c_char = std::ptr::null_mut();
+    let mut len: tm_len_t = 0;
+    let mut value: *mut c_void = std::ptr::null_mut();
+
+    let mut yielded = Vec::new();
+    // Safety: We adhere to all the safety requirements of `TrieMapIterator_Next`
+    while let 1 = unsafe { TrieMapIterator_Next(it, &mut char, &mut len, &mut value) } {
+        // Safety: We're reconstructing the keys created above
+        let key: &[u8] = unsafe { std::slice::from_raw_parts(char.cast(), len as usize) };
+
+        // The yielded pointer must be the address of the value stored inline
+        // in the trie, not a copy.
+        let stored = trie.find(key).expect("yielded key is in the trie");
+        assert!(
+            std::ptr::eq(value.cast::<u64>(), stored),
+            "value pointer should point at the inline value for {:?}",
+            String::from_utf8_lossy(key),
+        );
+
+        // Safety: `value` points at the `u64` stored inline in the trie
+        yielded.push((String::from_utf8(key.to_vec()).unwrap(), unsafe {
+            *value.cast::<u64>()
+        }));
+    }
+
+    // Safety: We adhere to all the safety requirements of `TrieMapIterator_Free`
+    unsafe { TrieMapIterator_Free(it) };
+
+    assert_eq!(
+        yielded,
+        [("bike", 10), ("cider", 30), ("cool", 20)].map(|(k, v)| (k.to_owned(), v)),
+        "entries should be yielded in lexicographical key order",
+    );
+}
+
+#[test]
+fn test_trie_iter_inline_values_empty() {
+    let trie: trie_rs::TrieMap<u64> = trie_rs::TrieMap::new();
+
+    let it = Box::into_raw(Box::new(TrieMapIterator::from_inline_values(
+        trie.lending_iter(),
+    )));
+
+    let mut char: *mut c_char = std::ptr::null_mut();
+    let mut len: tm_len_t = 0;
+    let mut value: *mut c_void = std::ptr::null_mut();
+
+    // Safety: We adhere to all the safety requirements of `TrieMapIterator_Next`
+    let got = unsafe { TrieMapIterator_Next(it, &mut char, &mut len, &mut value) };
+    assert_eq!(got, 0, "an empty trie should yield no entries");
+
+    // Safety: We adhere to all the safety requirements of `TrieMapIterator_Free`
+    unsafe { TrieMapIterator_Free(it) };
+}
+
+#[test]
 #[cfg_attr(miri, ignore = "Miri does not support the system monotonic clock")]
 fn test_trie_iter_timeout() {
     with_trie_map(|t| {

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
@@ -344,6 +344,112 @@ fn test_trie_iter_inline_values() {
 }
 
 #[test]
+fn test_trie_iter_inline_values_struct() {
+    #[derive(Debug, Clone, PartialEq)]
+    struct Posting {
+        /// Number of documents carrying the tag.
+        doc_count: u32,
+        /// Highest document id seen for the tag.
+        last_doc_id: u64,
+    }
+
+    let mut trie = trie_rs::TrieMap::new();
+    let entries = [
+        (
+            b"bike".as_slice(),
+            Posting {
+                doc_count: 3,
+                last_doc_id: 42,
+            },
+        ),
+        (
+            b"cool",
+            Posting {
+                doc_count: 1,
+                last_doc_id: 7,
+            },
+        ),
+        (
+            b"cider",
+            Posting {
+                doc_count: 9,
+                last_doc_id: 1000,
+            },
+        ),
+    ];
+    for (key, value) in &entries {
+        trie.insert(key, value.clone());
+    }
+
+    let it = Box::into_raw(Box::new(TrieMapIterator::from_inline_values(
+        trie.lending_iter(),
+    )));
+
+    let mut char: *mut c_char = std::ptr::null_mut();
+    let mut len: tm_len_t = 0;
+    let mut value: *mut c_void = std::ptr::null_mut();
+
+    let mut yielded = Vec::new();
+    // Safety: We adhere to all the safety requirements of `TrieMapIterator_Next`
+    while let 1 = unsafe { TrieMapIterator_Next(it, &mut char, &mut len, &mut value) } {
+        // Safety: We're reconstructing the key created above.
+        let key: &[u8] = unsafe { std::slice::from_raw_parts(char.cast(), len as usize) };
+
+        // The reverse conversion is *just a cast*: `value` is the address of the
+        // `Posting` stored inline in the trie node, type-erased to `*mut c_void`.
+        // Casting it back to `*mut Posting` recovers the concrete type, with all
+        // fields intact — the erasure only ever hid the type from the signature,
+        // never touched the bytes.
+        let posting_ptr = value.cast::<Posting>();
+
+        // The yielded pointer must be the address of the value stored inline in
+        // the trie, not a copy.
+        let stored = trie.find(key).expect("yielded key is in the trie");
+        assert!(
+            std::ptr::eq(posting_ptr, stored),
+            "value pointer should point at the inline Posting for {:?}",
+            String::from_utf8_lossy(key),
+        );
+
+        // Safety: `posting_ptr` points at the `Posting` stored inline in the trie.
+        let posting = unsafe { &*posting_ptr };
+        yielded.push((String::from_utf8(key.to_vec()).unwrap(), posting.clone()));
+    }
+
+    // Safety: We adhere to all the safety requirements of `TrieMapIterator_Free`
+    unsafe { TrieMapIterator_Free(it) };
+
+    assert_eq!(
+        yielded,
+        [
+            (
+                "bike",
+                Posting {
+                    doc_count: 3,
+                    last_doc_id: 42
+                },
+            ),
+            (
+                "cider",
+                Posting {
+                    doc_count: 9,
+                    last_doc_id: 1000
+                },
+            ),
+            (
+                "cool",
+                Posting {
+                    doc_count: 1,
+                    last_doc_id: 7
+                }
+            ),
+        ]
+        .map(|(k, v)| (k.to_owned(), v)),
+        "entries should be yielded in lexicographical key order",
+    );
+}
+
+#[test]
 fn test_trie_iter_inline_values_empty() {
     let trie: trie_rs::TrieMap<u64> = trie_rs::TrieMap::new();
 
@@ -361,6 +467,92 @@ fn test_trie_iter_inline_values_empty() {
 
     // Safety: We adhere to all the safety requirements of `TrieMapIterator_Free`
     unsafe { TrieMapIterator_Free(it) };
+}
+
+/// Drain an inline-value iterator over a `u64` trie into `(key, value)` pairs,
+/// then free it. Shared by the inline contains/wildcard/suffix tests below.
+fn collect_inline_u64(it: *mut TrieMapIterator) -> Vec<(String, u64)> {
+    let mut char: *mut c_char = std::ptr::null_mut();
+    let mut len: tm_len_t = 0;
+    let mut value: *mut c_void = std::ptr::null_mut();
+
+    let mut yielded = Vec::new();
+    // Safety: We adhere to all the safety requirements of `TrieMapIterator_Next`
+    while let 1 = unsafe { TrieMapIterator_Next(it, &mut char, &mut len, &mut value) } {
+        // Safety: We're reconstructing the keys inserted by the caller.
+        let key: &[u8] = unsafe { std::slice::from_raw_parts(char.cast(), len as usize) };
+        // Safety: `value` points at the `u64` stored inline in the trie.
+        yielded.push((String::from_utf8(key.to_vec()).unwrap(), unsafe {
+            *value.cast::<u64>()
+        }));
+    }
+
+    // Safety: We adhere to all the safety requirements of `TrieMapIterator_Free`
+    unsafe { TrieMapIterator_Free(it) };
+    yielded
+}
+
+#[test]
+fn test_trie_iter_inline_contains() {
+    let mut trie = trie_rs::TrieMap::new();
+    for (key, value) in [
+        (b"apple".as_slice(), 1u64),
+        (b"pineapple", 2),
+        (b"grape", 3),
+    ] {
+        trie.insert(key, value);
+    }
+
+    // Exercises `InlineContainsIter::next`.
+    let it = Box::into_raw(Box::new(TrieMapIterator::from_inline_contains(
+        trie.contains_iter(b"apple").into(),
+    )));
+
+    assert_eq!(
+        collect_inline_u64(it),
+        [("apple", 1), ("pineapple", 2)].map(|(k, v)| (k.to_owned(), v)),
+        "only keys containing \"apple\" should be yielded, in key order",
+    );
+}
+
+#[test]
+fn test_trie_iter_inline_wildcard() {
+    let mut trie = trie_rs::TrieMap::new();
+    for (key, value) in [(b"bike".as_slice(), 1u64), (b"cool", 2), (b"cider", 3)] {
+        trie.insert(key, value);
+    }
+
+    // Exercises `InlineWildcardIter::next`.
+    let it = Box::into_raw(Box::new(TrieMapIterator::from_inline_wildcard(
+        trie.wildcard_iter(rqe_wildcard::WildcardPattern::parse(b"c*"))
+            .into(),
+    )));
+
+    assert_eq!(
+        collect_inline_u64(it),
+        [("cider", 3), ("cool", 2)].map(|(k, v)| (k.to_owned(), v)),
+        "only keys matching \"c*\" should be yielded, in key order",
+    );
+}
+
+#[test]
+fn test_trie_iter_inline_suffix_filter() {
+    let mut trie = trie_rs::TrieMap::new();
+    for (key, value) in [(b"bike".as_slice(), 1u64), (b"cool", 2), (b"apple", 3)] {
+        trie.insert(key, value);
+    }
+
+    // Exercises `InlineFilteredIter::next`.
+    let it = Box::into_raw(Box::new(TrieMapIterator::from_inline_suffix_filter(
+        trie.lending_iter(),
+        b"e".to_vec(),
+    )));
+
+    assert_eq!(
+        collect_inline_u64(it),
+        [("apple", 3), ("bike", 1)].map(|(k, v)| (k.to_owned(), v)),
+        "only keys ending with \"e\" should be yielded, in key order",
+    );
 }
 
 #[test]

--- a/src/redisearch_rs/headers/triemap_ffi.h
+++ b/src/redisearch_rs/headers/triemap_ffi.h
@@ -35,7 +35,7 @@ typedef struct TrieMap TrieMap;
 
 /**
  * Opaque type TrieMapIterator. Obtained from calling [`TrieMap_Iterate`],
- * [`TrieMap_IterateWithFilter`], or [`TrieMapIterator::from_inline_values`].
+ * [`TrieMap_IterateWithFilter`], or `TrieMapIterator::from_*` methods.
  */
 typedef struct TrieMapIterator TrieMapIterator;
 
@@ -300,6 +300,11 @@ void TrieMapIterator_Free(struct TrieMapIterator *it);
  *   pointer is invalidated upon calling [`TrieMapIterator_Next`] again.
  * - `len` must point to a valid `tm_len_t` which will be set to the length of the current key.
  * - `value` must point to a valid pointer, which will be set to the value of the current key.
+ *
+ * For iterators over a trie whose values are stored inline (created via the
+ * `from_inline_*` constructors), the written `value` points into trie-internal
+ * storage and must be treated as **read-only**, so writing through it is undefined
+ * behavior.
  */
 int TrieMapIterator_Next(struct TrieMapIterator *it, char * *ptr, tm_len_t *len, void * *value);
 

--- a/src/redisearch_rs/headers/triemap_ffi.h
+++ b/src/redisearch_rs/headers/triemap_ffi.h
@@ -34,8 +34,8 @@ typedef enum tm_iter_mode {
 typedef struct TrieMap TrieMap;
 
 /**
- * Opaque type TrieMapIterator. Obtained from calling [`TrieMap_Iterate`] or
- * [`TrieMap_IterateWithFilter`].
+ * Opaque type TrieMapIterator. Obtained from calling [`TrieMap_Iterate`],
+ * [`TrieMap_IterateWithFilter`], or [`TrieMapIterator::from_inline_values`].
  */
 typedef struct TrieMapIterator TrieMapIterator;
 
@@ -144,19 +144,6 @@ struct TrieMap *NewTrieMap(void);
 void TrieMap_IterateRange(const struct TrieMap *trie, const char *min, int minlen, bool includeMin, const char *max, int maxlen, bool includeMax, TrieMapRangeCallback callback, void *ctx);
 
 /**
- * Iterate over all the entries stored in the trie.
- *
- * Invoke [`TrieMapIterator_Next`] to get the results from the iteration. If there are no entries,
- * the first call to next will return 0.
- *
- * # Safety
- * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
- * - `t` must not be freed while the iterator lives.
- */
-struct TrieMapIterator *TrieMap_Iterate(struct TrieMap *t);
-
-/**
  * Free the [`TrieMapResultBuf`] and its contents.
  */
 void TrieMapResultBuf_Free(TrieMapResultBuf buf);
@@ -196,6 +183,29 @@ int TrieMap_Add(struct TrieMap *t, const char *str, tm_len_t len, void *value, T
 void *TrieMapResultBuf_GetByIndex(TrieMapResultBuf *buf, size_t index);
 
 /**
+ * Get the length of the TrieMapResultBuf.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `buf` must point to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
+ */
+size_t TrieMapResultBuf_Len(TrieMapResultBuf *buf);
+
+/**
+ * Iterate over all the entries stored in the trie.
+ *
+ * Invoke [`TrieMapIterator_Next`] to get the results from the iteration. If there are no entries,
+ * the first call to next will return 0.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ * - `t` must not be freed while the iterator lives.
+ */
+struct TrieMapIterator *TrieMap_Iterate(struct TrieMap *t);
+
+/**
  * Iterate over the trie entries that match the given predicate.
  *
  * Depending on `iter_mode`, they can either be:
@@ -216,29 +226,6 @@ void *TrieMapResultBuf_GetByIndex(TrieMapResultBuf *buf, size_t index);
  *   which will be set to the current key. It may only be NULL in case `prefix_len == 0`.
  */
 struct TrieMapIterator *TrieMap_IterateWithFilter(struct TrieMap *t, const char *prefix, tm_len_t prefix_len, enum tm_iter_mode iter_mode);
-
-/**
- * Get the length of the TrieMapResultBuf.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `buf` must point to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
- */
-size_t TrieMapResultBuf_Len(TrieMapResultBuf *buf);
-
-/**
- * Set timeout limit used for affix queries. This timeout is checked in
- * [`TrieMapIterator_Next`], which will return `0` if the timeout is reached.
- *
- * If the provided timeout is 0, it's interpreted as unlimited.
- *
- * # Safety
- * The following invariants must be upheld when calling this function:
- * - `it` must point to a valid [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
- *   [`TrieMap_IterateWithFilter`] and cannot be NULL.
- */
-void TrieMapIterator_SetTimeout(struct TrieMapIterator *it, timespec timeout);
 
 /**
  * Find the entry with a given string and length, and return its value, even if
@@ -264,6 +251,34 @@ void TrieMapIterator_SetTimeout(struct TrieMapIterator *it, timespec timeout);
 void *TrieMap_Find(const struct TrieMap *t, const char *str, tm_len_t len);
 
 /**
+ * Set timeout limit used for affix queries. This timeout is checked in
+ * [`TrieMapIterator_Next`], which will return `0` if the timeout is reached.
+ *
+ * If the provided timeout is 0, it's interpreted as unlimited.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `it` must point to a valid [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
+ *   [`TrieMap_IterateWithFilter`] and cannot be NULL.
+ */
+void TrieMapIterator_SetTimeout(struct TrieMapIterator *it, timespec timeout);
+
+/**
+ * Mark a node as deleted. It also optimizes the trie by merging nodes if
+ * needed. If freeCB is given, it will be used to free the value (not the node)
+ * of the deleted node. If it doesn't, we simply call free().
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ * - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
+ * - `len` can be 0. If so, `str` is regarded as an empty string.
+ * - if `func` is not NULL, it must be a valid function pointer of the type [`freeCB`].
+ */
+int TrieMap_Delete(struct TrieMap *t, const char *str, tm_len_t len, freeCB func);
+
+/**
  * Free a trie iterator
  *
  * # Safety
@@ -287,21 +302,6 @@ void TrieMapIterator_Free(struct TrieMapIterator *it);
  * - `value` must point to a valid pointer, which will be set to the value of the current key.
  */
 int TrieMapIterator_Next(struct TrieMapIterator *it, char * *ptr, tm_len_t *len, void * *value);
-
-/**
- * Mark a node as deleted. It also optimizes the trie by merging nodes if
- * needed. If freeCB is given, it will be used to free the value (not the node)
- * of the deleted node. If it doesn't, we simply call free().
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
- * - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
- * - `len` can be 0. If so, `str` is regarded as an empty string.
- * - if `func` is not NULL, it must be a valid function pointer of the type [`freeCB`].
- */
-int TrieMap_Delete(struct TrieMap *t, const char *str, tm_len_t len, freeCB func);
 
 /**
  * Free the trie's root and all its children recursively. If freeCB is given, we


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: TrieMapIterator supports only pointers as value (`*c_void`), which will be cast to the correct pointer. It yields a reference to that stored pointer, and `TrieMapIterator_Next` writes the pointer out to the caller. Instead, the Rust `TagIndex` implementation will store inlined values, so it cannot use the `TrieMapIterator`.
3. Change: Introduce new `TrieMapIteratorImpl::Erased` variant that holds a `dyn ErasedValuesIter`
4. Outcome: Rust `TagIndex` implementation can return `TrieMapIterator`

#### Which additional issues this PR fixes
1. MOD-14988

#### Main objects this PR modified
- `triemap_ffi` — `TrieMapIterator`, `TrieMapIteratorImpl`, new `ErasedValuesIter` trait and inline-value adapters

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes