### PR TITLE
MOD-16121 FT.HYBRID - Support YIELD_SCORE_AS: counted and positional after COMBINE

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2455,12 +2455,6 @@
                     "type": "integer",
                     "token": "WINDOW",
                     "optional": true
-                  },
-                  {
-                    "name": "yield_score_as",
-                    "type": "string",
-                    "token": "YIELD_SCORE_AS",
-                    "optional": true
                   }
                 ]
               },
@@ -2499,16 +2493,16 @@
                     "type": "integer",
                     "token": "WINDOW",
                     "optional": true
-                  },
-                  {
-                    "name": "yield_score_as",
-                    "type": "string",
-                    "token": "YIELD_SCORE_AS",
-                    "optional": true
                   }
                 ]
               }
             ]
+          },
+          {
+            "name": "yield_score_as",
+            "type": "string",
+            "token": "YIELD_SCORE_AS",
+            "optional": true
           }
         ]
       },

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -2677,12 +2677,6 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
                     .type = REDISMODULE_ARG_TYPE_INTEGER,
                     .flags = REDISMODULE_CMD_ARG_OPTIONAL,
                   },
-                  {
-                    .name = "yield_score_as",
-                    .token = "YIELD_SCORE_AS",
-                    .type = REDISMODULE_ARG_TYPE_STRING,
-                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
-                  },
                   {0}
                 },
               },
@@ -2723,17 +2717,17 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
                     .type = REDISMODULE_ARG_TYPE_INTEGER,
                     .flags = REDISMODULE_CMD_ARG_OPTIONAL,
                   },
-                  {
-                    .name = "yield_score_as",
-                    .token = "YIELD_SCORE_AS",
-                    .type = REDISMODULE_ARG_TYPE_STRING,
-                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
-                  },
                   {0}
                 },
               },
               {0}
             },
+          },
+          {
+            .name = "yield_score_as",
+            .token = "YIELD_SCORE_AS",
+            .type = REDISMODULE_ARG_TYPE_STRING,
+            .flags = REDISMODULE_CMD_ARG_OPTIONAL,
           },
           {0}
         },

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -228,6 +228,54 @@ static void MRCommand_appendVsim(MRCommand *xcmd, RedisModuleString **argv,
   }
 }
 
+// Append a reconstructed, old-shard-compatible COMBINE clause built from the
+// coordinator's resolved scoring parameters. All scoring arguments are emitted
+// explicitly with a positive, even argument count and YIELD_SCORE_AS (when
+// present) counted inside the block, so shards of any version parse it and never
+// fall back on their own (possibly different) defaults.
+static void MRCommand_appendCombine(MRCommand *xcmd, const HybridCombineWireParams *cp) {
+  if (!cp || !cp->scoringCtx) {
+    return;
+  }
+  const HybridScoringContext *sc = cp->scoringCtx;
+  const bool hasAlias = cp->scoreAlias != NULL;
+  char numBuf[32];
+  const size_t numBufSize = sizeof(numBuf);
+  int n;
+
+  MRCommand_Append(xcmd, "COMBINE", strlen("COMBINE"));
+  if (sc->scoringType == HYBRID_SCORING_RRF) {
+    // COMBINE RRF <count> CONSTANT <c> WINDOW <w> [YIELD_SCORE_AS <alias>]
+    n = snprintf(numBuf, numBufSize, "%d", hasAlias ? 6 : 4);
+    MRCommand_Append(xcmd, "RRF", strlen("RRF"));
+    MRCommand_Append(xcmd, numBuf, n);
+    MRCommand_Append(xcmd, "CONSTANT", strlen("CONSTANT"));
+    n = snprintf(numBuf, numBufSize, "%.12g", sc->rrfCtx.constant);
+    MRCommand_Append(xcmd, numBuf, n);
+    MRCommand_Append(xcmd, "WINDOW", strlen("WINDOW"));
+    n = snprintf(numBuf, numBufSize, "%zu", sc->rrfCtx.window);
+    MRCommand_Append(xcmd, numBuf, n);
+  } else {
+    // COMBINE LINEAR <count> ALPHA <a> BETA <b> WINDOW <w> [YIELD_SCORE_AS <alias>]
+    n = snprintf(numBuf, numBufSize, "%d", hasAlias ? 8 : 6);
+    MRCommand_Append(xcmd, "LINEAR", strlen("LINEAR"));
+    MRCommand_Append(xcmd, numBuf, n);
+    MRCommand_Append(xcmd, "ALPHA", strlen("ALPHA"));
+    n = snprintf(numBuf, numBufSize, "%.12g", sc->linearCtx.linearWeights[0]);
+    MRCommand_Append(xcmd, numBuf, n);
+    MRCommand_Append(xcmd, "BETA", strlen("BETA"));
+    n = snprintf(numBuf, numBufSize, "%.12g", sc->linearCtx.linearWeights[1]);
+    MRCommand_Append(xcmd, numBuf, n);
+    MRCommand_Append(xcmd, "WINDOW", strlen("WINDOW"));
+    n = snprintf(numBuf, numBufSize, "%zu", sc->linearCtx.window);
+    MRCommand_Append(xcmd, numBuf, n);
+  }
+  if (hasAlias) {
+    MRCommand_Append(xcmd, "YIELD_SCORE_AS", strlen("YIELD_SCORE_AS"));
+    MRCommand_Append(xcmd, cp->scoreAlias, strlen(cp->scoreAlias));
+  }
+}
+
 // The function transforms FT.HYBRID index SEARCH query VSIM field vector
 // into _FT.HYBRID index SEARCH query VSIM field vector WITHCURSOR
 // _NUM_SSTRING _INDEX_PREFIXES ...
@@ -236,6 +284,7 @@ static void MRCommand_appendVsim(MRCommand *xcmd, RedisModuleString **argv,
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             bool sendExplainScore,
+                            const HybridCombineWireParams *combineParams,
                             MRCommand *xcmd, arrayof(char*) serialized,
                             IndexSpec *sp, int *outKArgIndex) {
   RS_ASSERT(outKArgIndex != NULL);
@@ -266,27 +315,14 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
   int vsimOffset = RMUtil_ArgIndex("VSIM", argv, argc);
   MRCommand_appendVsim(xcmd, argv, argc, vsimOffset, outKArgIndex);
 
-  int combineOffset = RMUtil_ArgIndex("COMBINE", argv + vsimOffset, argc - vsimOffset);
-  combineOffset = combineOffset != -1 ? combineOffset + vsimOffset : -1;
-  bool hasCombine = combineOffset != -1;
-
-  // Add COMBINE
-  if (combineOffset != -1) {
-    MRCommand_AppendRstr(xcmd, argv[combineOffset]);
-    // Add RRF/LINEAR and its arguments
-    argOffset = RMUtil_ArgIndex("RRF", argv + vsimOffset, argc - vsimOffset);
-    if (argOffset == -1) {
-      argOffset = RMUtil_ArgIndex("LINEAR", argv + vsimOffset, argc - vsimOffset);
-    }
-    argOffset = argOffset != -1 ? argOffset + vsimOffset : -1;
-    if (argOffset != -1 && argOffset < argc - 2) {
-      long long nargs;
-      RedisModule_StringToLongLong(argv[argOffset + 1], &nargs);
-
-      for (int i = 0; i < nargs + 2; ++i) {
-        MRCommand_AppendRstr(xcmd, argv[argOffset + i]);
-      }
-    }
+  // Reconstruct the COMBINE clause from the coordinator's resolved scoring
+  // parameters instead of copying the client's raw tokens. This normalizes the
+  // positional YIELD_SCORE_AS form and a zero argument count into the legacy
+  // counted form that all shard versions accept.
+  // Gate on the COMBINE token appearing after VSIM (not inside the SEARCH query
+  // text) so we only forward COMBINE when the client actually specified it.
+  if (RMUtil_ArgIndex("COMBINE", argv + vsimOffset, argc - vsimOffset) != -1) {
+    MRCommand_appendCombine(xcmd, combineParams);
   }
 
   if (serialized) {
@@ -687,6 +723,16 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     setupCoordinatorArrangeSteps(hreq->requests[SEARCH_INDEX], hreq->requests[VECTOR_INDEX], &hybridParams);
     RLookup *lookups[HYBRID_REQUEST_NUM_SUBQUERIES] = {0};
 
+    // Capture the resolved COMBINE parameters now, before BuildDistributedPipeline
+    // hands scoringCtx ownership to the merger and nulls the local pointer. The
+    // scoring context object itself is kept alive by the merger, so borrowing it
+    // here is safe. Used to reconstruct an old-shard-compatible COMBINE clause
+    // when building the per-shard command below.
+    HybridCombineWireParams combineParams = {
+        .scoringCtx = hybridParams.scoringCtx,
+        .scoreAlias = hybridParams.aggregationParams.common.scoreAlias,
+    };
+
     arrayof(char*) serialized = HybridRequest_BuildDistributedPipeline(hreq, &hybridParams, lookups, status);
     if (!serialized) {
       HybridPipelineParams_Cleanup(&hybridParams);
@@ -697,7 +743,7 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     MRCommand xcmd;
     bool sendExplainScore = (hreq->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) != 0;
     HybridRequest_buildMRCommand(argv, argc, profileOptions, sendExplainScore,
-                                 &xcmd, serialized, sp, &hreq->kArgIndex);
+                                 &combineParams, &xcmd, serialized, sp, &hreq->kArgIndex);
 
     xcmd.protocol = HYBRID_RESP_PROTOCOL_VERSION;
     xcmd.forCursor = hreq->reqflags & QEXEC_F_IS_CURSOR;

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -315,15 +315,16 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
   int vsimOffset = RMUtil_ArgIndex("VSIM", argv, argc);
   MRCommand_appendVsim(xcmd, argv, argc, vsimOffset, outKArgIndex);
 
-  // Reconstruct the COMBINE clause from the coordinator's resolved scoring
-  // parameters instead of copying the client's raw tokens. This normalizes the
-  // positional YIELD_SCORE_AS form and a zero argument count into the legacy
-  // counted form that all shard versions accept.
-  // Gate on the COMBINE token appearing after VSIM (not inside the SEARCH query
-  // text) so we only forward COMBINE when the client actually specified it.
-  if (RMUtil_ArgIndex("COMBINE", argv + vsimOffset, argc - vsimOffset) != -1) {
-    MRCommand_appendCombine(xcmd, combineParams);
-  }
+  // Always reconstruct and forward the coordinator's resolved COMBINE clause
+  // (in the legacy counted form).
+  // Forwarding it unconditionally - even when the client omitted COMBINE and
+  // the coordinator filled in defaults - pins every shard to identical fusion
+  // parameters (constant/weights/window), so hybrid results stay consistent
+  // across shards of different versions during a rolling upgrade rather than
+  // each shard falling back on its own (possibly changed) defaults. This also
+  // normalizes the positional YIELD_SCORE_AS form and a zero argument count
+  // into the counted form that all shard versions accept.
+  MRCommand_appendCombine(xcmd, combineParams);
 
   if (serialized) {
     for (size_t ii = 0; ii < array_len(serialized); ++ii) {

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -250,7 +250,7 @@ static void MRCommand_appendCombine(MRCommand *xcmd, const HybridCombineWirePara
     MRCommand_Append(xcmd, "RRF", strlen("RRF"));
     MRCommand_Append(xcmd, numBuf, n);
     MRCommand_Append(xcmd, "CONSTANT", strlen("CONSTANT"));
-    n = snprintf(numBuf, numBufSize, "%.12g", sc->rrfCtx.constant);
+    n = snprintf(numBuf, numBufSize, "%.17g", sc->rrfCtx.constant);
     MRCommand_Append(xcmd, numBuf, n);
     MRCommand_Append(xcmd, "WINDOW", strlen("WINDOW"));
     n = snprintf(numBuf, numBufSize, "%zu", sc->rrfCtx.window);
@@ -261,10 +261,10 @@ static void MRCommand_appendCombine(MRCommand *xcmd, const HybridCombineWirePara
     MRCommand_Append(xcmd, "LINEAR", strlen("LINEAR"));
     MRCommand_Append(xcmd, numBuf, n);
     MRCommand_Append(xcmd, "ALPHA", strlen("ALPHA"));
-    n = snprintf(numBuf, numBufSize, "%.12g", sc->linearCtx.linearWeights[0]);
+    n = snprintf(numBuf, numBufSize, "%.17g", sc->linearCtx.linearWeights[0]);
     MRCommand_Append(xcmd, numBuf, n);
     MRCommand_Append(xcmd, "BETA", strlen("BETA"));
-    n = snprintf(numBuf, numBufSize, "%.12g", sc->linearCtx.linearWeights[1]);
+    n = snprintf(numBuf, numBufSize, "%.17g", sc->linearCtx.linearWeights[1]);
     MRCommand_Append(xcmd, numBuf, n);
     MRCommand_Append(xcmd, "WINDOW", strlen("WINDOW"));
     n = snprintf(numBuf, numBufSize, "%zu", sc->linearCtx.window);

--- a/src/coord/hybrid/dist_hybrid.h
+++ b/src/coord/hybrid/dist_hybrid.h
@@ -18,6 +18,18 @@ extern "C" {
 #include "rmr/command.h"
 #include "profile/options.h"
 #include "vector_index.h"
+#include "hybrid/hybrid_scoring.h"
+
+// Resolved COMBINE parameters captured on the coordinator, used to reconstruct
+// an old-shard-compatible COMBINE clause on the wire (see HybridRequest_buildMRCommand).
+typedef struct {
+  // Resolved scoring parameters. Borrowed, not owned: points at the request's
+  // HybridScoringContext, which the merger keeps alive past command building.
+  const HybridScoringContext *scoringCtx;
+  // YIELD_SCORE_AS alias for the combined score, or NULL. Carried alongside
+  // scoringCtx because HybridScoringContext has no alias field.
+  const char *scoreAlias;
+} HybridCombineWireParams;
 
 void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                         struct ConcurrentCmdCtx *cmdCtx);
@@ -32,6 +44,7 @@ int DistHybridReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             bool sendExplainScore,
+                            const HybridCombineWireParams *combineParams,
                             MRCommand *xcmd, arrayof(char*) serialized,
                             IndexSpec *sp, int *outKArgIndex);
 

--- a/src/hybrid/hybrid_scoring.h
+++ b/src/hybrid/hybrid_scoring.h
@@ -11,6 +11,8 @@ extern "C" {
 // Default constants for hybrid search parameters
 #define HYBRID_DEFAULT_WINDOW 20
 #define HYBRID_DEFAULT_RRF_CONSTANT 60
+#define HYBRID_DEFAULT_LINEAR_ALPHA 0.3
+#define HYBRID_DEFAULT_LINEAR_BETA 0.7
 
 typedef enum {
   HYBRID_SCORING_LINEAR,

--- a/src/hybrid/parse/hybrid_combine.c
+++ b/src/hybrid/parse/hybrid_combine.c
@@ -12,9 +12,6 @@
 #include "util/arg_parser.h"
 #include <string.h>
 
-#define HYBRID_DEFAULT_ALPHA 0.3
-#define HYBRID_DEFAULT_BETA 0.7
-
 static inline bool getVarArgsForClause(ArgsCursor* ac, ArgsCursor* target, const char *clause, QueryError* status) {
   unsigned int count = 0;
   int rc = AC_GetUnsigned(ac, &count, 0);
@@ -23,9 +20,6 @@ static inline bool getVarArgsForClause(ArgsCursor* ac, ArgsCursor* target, const
     return false;
   } else if (rc != AC_OK) {
     QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid %s argument count, error: %s", clause, AC_Strerror(rc));
-    return false;
-  } else if (count == 0) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Explicitly specifying %s requires at least one argument, argument count must be positive", clause);
     return false;
   } else if (count % 2 != 0) {
     QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "%s expects pairs of key value arguments, argument count must be an even number", clause);
@@ -43,7 +37,8 @@ static inline bool getVarArgsForClause(ArgsCursor* ac, ArgsCursor* target, const
   return true;
 }
 
-static void parseLinearClause(ArgsCursor *ac, HybridLinearContext *linearCtx, RSSearchOptions* searchOpts, QueryError *status) {
+static void parseLinearClause(ArgsCursor *ac, HybridLinearContext *linearCtx,
+                              RSSearchOptions *searchOpts, QueryError *status) {
   // LINEAR 4 ALPHA 0.1 BETA 0.9 ...
   //        ^
 
@@ -66,6 +61,9 @@ static void parseLinearClause(ArgsCursor *ac, HybridLinearContext *linearCtx, RS
   // Define the required arguments
   ArgParser_AddDouble(parser, "ALPHA", "Alpha weight value", &alphaValue);
   ArgParser_AddDouble(parser, "BETA", "Beta weight value", &betaValue);
+  // Legacy (counted) form of YIELD_SCORE_AS: accepted inside the method argument
+  // count for backward compatibility. The positional form (after the method
+  // block) is handled in handleCombine.
   ArgParser_AddString(parser, "YIELD_SCORE_AS", "Alias for the combined score", &searchOpts->scoreAlias);
 
   int windowValue = HYBRID_DEFAULT_WINDOW;
@@ -96,14 +94,15 @@ static void parseLinearClause(ArgsCursor *ac, HybridLinearContext *linearCtx, RS
   }
 
   // Store the parsed values
-  linearCtx->linearWeights[0] = hasAlpha ? alphaValue : HYBRID_DEFAULT_ALPHA;
-  linearCtx->linearWeights[1] = hasBeta ? betaValue : HYBRID_DEFAULT_BETA;
+  linearCtx->linearWeights[0] = hasAlpha ? alphaValue : HYBRID_DEFAULT_LINEAR_ALPHA;
+  linearCtx->linearWeights[1] = hasBeta ? betaValue : HYBRID_DEFAULT_LINEAR_BETA;
   linearCtx->window = windowValue;
 
   ArgParser_Free(parser);
 }
 
-static bool parseRRFArgs(ArgsCursor *ac, double *constant, int *window, bool *hasExplicitWindow, RSSearchOptions* searchOpts, QueryError *status) {
+static bool parseRRFArgs(ArgsCursor *ac, double *constant, int *window, bool *hasExplicitWindow,
+                          RSSearchOptions *searchOpts, QueryError *status) {
   *hasExplicitWindow = false;
   ArgsCursor rrf = {0};
   if (!getVarArgsForClause(ac, &rrf, "RRF", status)) {
@@ -127,6 +126,9 @@ static bool parseRRFArgs(ArgsCursor *ac, double *constant, int *window, bool *ha
                     ARG_OPT_DEFAULT_INT, HYBRID_DEFAULT_WINDOW,
                     ARG_OPT_RANGE, 1LL, LLONG_MAX,
                     ARG_OPT_END);
+  // Legacy (counted) form of YIELD_SCORE_AS: accepted inside the method argument
+  // count for backward compatibility. The positional form (after the method
+  // block) is handled in handleCombine.
   ArgParser_AddString(parser, "YIELD_SCORE_AS", "Alias for the combined score", &searchOpts->scoreAlias);
 
   // Parse the arguments
@@ -142,7 +144,27 @@ static bool parseRRFArgs(ArgsCursor *ac, double *constant, int *window, bool *ha
 }
 
 
-static void parseRRFClause(ArgsCursor *ac, HybridRRFContext *rrfCtx, RSSearchOptions *searchOpts, QueryError *status) {
+// Parse the positional YIELD_SCORE_AS <alias> clause that may follow a COMBINE
+// method. The alias is applied to the merged (tail) score, so it is stored in
+// the tail search options rather than in either subquery.
+//   COMBINE RRF|LINEAR ... YIELD_SCORE_AS <alias>
+//                                         ^
+static void parseCombineYieldScoreClause(ArgsCursor *ac, HybridParseContext *ctx, QueryError *status) {
+  if (AC_IsAtEnd(ac)) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing argument value for YIELD_SCORE_AS");
+    return;
+  }
+  if (AC_GetString(ac, &ctx->searchopts->scoreAlias, NULL, 0) != AC_OK) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_BAD_VAL, "Invalid YIELD_SCORE_AS value");
+    return;
+  }
+  // Mirror the SEARCH subquery path so the combined score is emitted as a field
+  // and applyRichResultsOptimization does not skip collecting it.
+  *ctx->reqFlags |= QEXEC_F_SEND_SCORES_AS_FIELD;
+}
+
+static void parseRRFClause(ArgsCursor *ac, HybridRRFContext *rrfCtx,
+                            RSSearchOptions *searchOpts, QueryError *status) {
   // RRF 4 CONSTANT 6 WINDOW 20 ...
   //     ^
   // RRF LIMIT
@@ -185,11 +207,38 @@ void handleCombine(ArgParser *parser, const void *value, void *user_data) {
 
   combineCtx->scoringType = parsedScoringType;
   ArgsCursor *ac = parser->cursor;
+  // The method ArgParser writes the legacy "counted" YIELD_SCORE_AS (form A)
+  // directly into searchopts->scoreAlias. Snapshot it so we can tell afterwards
+  // whether form A consumed the alias, and reject a second (positional) one.
+  const char *aliasBefore = ctx->searchopts->scoreAlias;
   if (parsedScoringType == HYBRID_SCORING_LINEAR) {
     combineCtx->linearCtx.linearWeights = rm_calloc(numWeights, sizeof(double));
     combineCtx->linearCtx.numWeights = numWeights;
     parseLinearClause(ac, &combineCtx->linearCtx, ctx->searchopts, status);
   } else if (parsedScoringType == HYBRID_SCORING_RRF) {
     parseRRFClause(ac, &combineCtx->rrfCtx, ctx->searchopts, status);
+  }
+  if (QueryError_HasError(status)) {
+    return;
+  }
+  bool yieldParsedInBlock = (ctx->searchopts->scoreAlias != aliasBefore);
+
+  if (AC_AdvanceIfMatch(ac, "YIELD_SCORE_AS")) {
+    // Positional form B. Reject if the alias was already given in the counted
+    // form A (specified more than once).
+    if (yieldParsedInBlock) {
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS,
+                          "YIELD_SCORE_AS specified more than once");
+      return;
+    }
+    parseCombineYieldScoreClause(ac, ctx, status);
+    if (QueryError_HasError(status)) {
+      return;
+    }
+  } else if (yieldParsedInBlock) {
+    // Form A: the alias was written to searchopts->scoreAlias by the method
+    // ArgParser. Mirror the SEARCH subquery path so the combined score is
+    // emitted as a field and applyRichResultsOptimization does not skip it.
+    *ctx->reqFlags |= QEXEC_F_SEND_SCORES_AS_FIELD;
   }
 }

--- a/src/hybrid/parse/hybrid_optional_args.c
+++ b/src/hybrid/parse/hybrid_optional_args.c
@@ -202,8 +202,6 @@ int HybridParseOptionalArgs(HybridParseContext *ctx, ArgsCursor *ac, bool intern
                          ARG_OPT_CALLBACK, handleFilter, ctx,
                          ARG_OPT_END);
 
-    // TODO: Add YIELD_SCORE_AS support for score aliasing
-
     // Parse the arguments
     ArgParseResult parseResult = ArgParser_Parse(parser);
 

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -75,35 +75,47 @@ static HybridCombineWireParams linearWireParams(HybridScoringContext *sc, double
   return HybridCombineWireParams{sc, alias};
 }
 
-// Walk input and output argv in tandem, asserting non-COMBINE args are
-// preserved by position. Where the input has a COMBINE clause, the output is
-// expected to carry the reconstructed clause instead (self-delimiting input
-// clause: COMBINE <method> <count> <count-args...> [YIELD_SCORE_AS <alias>]).
-// Returns the output index just past the matched prefix.
+// Assert every input arg is preserved by position in the output. The
+// coordinator always inserts one reconstructed COMBINE clause after the VSIM
+// block; the oracle spots it in the output (COMBINE followed by a scoring
+// method - a PARAMS-value COMBINE never is) and, if the client supplied its own
+// COMBINE clause, drops that clause from the input side since the reconstructed
+// form replaces it. Returns the output index just past the matched prefix.
 static int verifyArgsPreservedWithReconstructedCombine(
     const MRCommand *xcmd, const std::vector<const char *> &inputArgs,
     const HybridCombineWireParams *cp) {
+  const bool expectReconstructed = cp && cp->scoringCtx;
+  bool reconstructedMatched = false;
   int oi = 1;  // strs[0] is _FT.HYBRID, checked separately
   for (size_t ii = 1; ii < inputArgs.size();) {
-    if (strcasecmp(inputArgs[ii], "COMBINE") == 0 && cp && cp->scoringCtx) {
+    const bool outStartsReconstructed =
+        expectReconstructed && !reconstructedMatched && oi + 1 < xcmd->num &&
+        xcmd->lens[oi] == strlen("COMBINE") &&
+        strncasecmp(xcmd->strs[oi], "COMBINE", xcmd->lens[oi]) == 0 &&
+        (!strcasecmp(xcmd->strs[oi + 1], "RRF") || !strcasecmp(xcmd->strs[oi + 1], "LINEAR"));
+    if (outStartsReconstructed) {
       for (const auto &tok : expectedCombineTokens(*cp)) {
         EXPECT_STREQ(xcmd->strs[oi], tok.c_str())
             << "Reconstructed COMBINE token mismatch at output index " << oi;
         oi++;
       }
-      // Skip the input COMBINE clause: COMBINE + method + count + N args.
-      ii += 2;                          // COMBINE, method
-      long n = atol(inputArgs[ii]);     // count
-      ii += 1 + (size_t)n;              // count token + its args
-      if (ii < inputArgs.size() && strcasecmp(inputArgs[ii], "YIELD_SCORE_AS") == 0) {
-        ii += 2;                        // positional YIELD_SCORE_AS <alias>
+      reconstructedMatched = true;
+      // If the client supplied its own COMBINE clause at this position, drop it
+      // from the input stream: COMBINE + method + count + N args.
+      if (strcasecmp(inputArgs[ii], "COMBINE") == 0) {
+        ii += 2;                          // COMBINE, method
+        long n = atol(inputArgs[ii]);     // count
+        ii += 1 + (size_t)n;              // count token + its args
+        if (ii < inputArgs.size() && strcasecmp(inputArgs[ii], "YIELD_SCORE_AS") == 0) {
+          ii += 2;                        // positional YIELD_SCORE_AS <alias>
+        }
       }
-    } else {
-      EXPECT_STREQ(xcmd->strs[oi], inputArgs[ii])
-          << "Argument at input index " << ii << " should be preserved";
-      oi++;
-      ii++;
+      continue;
     }
+    EXPECT_STREQ(xcmd->strs[oi], inputArgs[ii])
+        << "Argument at input index " << ii << " should be preserved";
+    oi++;
+    ii++;
   }
   return oi;
 }
@@ -301,9 +313,11 @@ protected:
                                      nullptr, testIndexSpec, &kArgIndex);
 
         // Assert the parse-driven path also preserves every non-COMBINE arg by
-        // position and reconstructs the COMBINE clause against the computed
-        // oracle. The caller additionally pins the extracted clause against a
-        // literal vector, so the two oracles stay independent.
+        // position (this is what verifies the PARAMS block - including any
+        // COMBINE token used as a param value - is forwarded verbatim) and
+        // reconstructs the COMBINE clause against the computed oracle. The caller
+        // additionally pins the extracted clause against a literal vector, so the
+        // two oracles stay independent.
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
         verifyArgsPreservedWithReconstructedCombine(&xcmd, inputArgs, &cp);
 
@@ -827,11 +841,57 @@ TEST_F(HybridBuildMRCommandTest, testCombineLinearArgsCountedAliasAndWindowRecon
     EXPECT_EQ(clause, expected);
 }
 
-// No COMBINE clause -> nothing forwarded (matches legacy behavior).
-TEST_F(HybridBuildMRCommandTest, testNoCombineNotForwarded) {
+// No COMBINE clause -> the coordinator still forwards its resolved defaults in
+// counted form, so every shard fuses identically regardless of its own version
+// defaults (rolling-upgrade consistency).
+TEST_F(HybridBuildMRCommandTest, testNoCombineForwardsResolvedDefault) {
     auto clause = buildAndExtractCombineClause({
         "FT.HYBRID", "test_idx", "SEARCH", "hello", "VSIM", "@vector_field", "$BLOB",
         "PARAMS", "2", "BLOB", TEST_BLOB_DATA
     });
-    EXPECT_TRUE(clause.empty());
+    std::vector<std::string> expected = {"COMBINE", "RRF", "4", "CONSTANT", "60", "WINDOW", "20"};
+    EXPECT_EQ(clause, expected);
+}
+
+// COMBINE LINEAR 0 YIELD_SCORE_AS s (positional alias, zero count) ->
+// counted form with the alias folded into the count (8), full defaults expanded.
+TEST_F(HybridBuildMRCommandTest, testCombineLinearZeroCountPositionalAliasReconstructed) {
+    auto clause = buildAndExtractCombineClause({
+        "FT.HYBRID", "test_idx", "SEARCH", "hello", "VSIM", "@vector_field", "$BLOB",
+        "COMBINE", "LINEAR", "0", "YIELD_SCORE_AS", "fused_score",
+        "PARAMS", "2", "BLOB", TEST_BLOB_DATA
+    });
+    std::vector<std::string> expected = {
+        "COMBINE", "LINEAR", "8", "ALPHA", "0.3", "BETA", "0.7", "WINDOW", "20",
+        "YIELD_SCORE_AS", "fused_score"};
+    EXPECT_EQ(clause, expected);
+}
+
+// COMBINE RRF 4 CONSTANT 60 WINDOW 20 YIELD_SCORE_AS s (full args + positional
+// alias) -> counted form with the alias folded into the count (6).
+TEST_F(HybridBuildMRCommandTest, testCombineRRFFullPositionalAliasReconstructed) {
+    auto clause = buildAndExtractCombineClause({
+        "FT.HYBRID", "test_idx", "SEARCH", "hello", "VSIM", "@vector_field", "$BLOB",
+        "COMBINE", "RRF", "4", "CONSTANT", "60", "WINDOW", "20", "YIELD_SCORE_AS", "fused_score",
+        "PARAMS", "2", "BLOB", TEST_BLOB_DATA
+    });
+    std::vector<std::string> expected = {
+        "COMBINE", "RRF", "6", "CONSTANT", "60", "WINDOW", "20",
+        "YIELD_SCORE_AS", "fused_score"};
+    EXPECT_EQ(clause, expected);
+}
+
+// A COMBINE token that appears only as a PARAMS *value* (not as a top-level
+// clause after VSIM) must not be mistaken for the fusion clause. The
+// coordinator forwards exactly one reconstructed clause built from its resolved
+// (default) scoring context; the extracted clause is that default, and the
+// positional oracle inside the helper confirms the PARAMS block - including its
+// literal "COMBINE" value - is preserved verbatim.
+TEST_F(HybridBuildMRCommandTest, testCombineInsideParamsNotMistakenForClause) {
+    auto clause = buildAndExtractCombineClause({
+        "FT.HYBRID", "test_idx", "SEARCH", "hello", "VSIM", "@vector_field", "$BLOB",
+        "PARAMS", "4", "BLOB", TEST_BLOB_DATA, "COMBINE", "value"
+    });
+    std::vector<std::string> expected = {"COMBINE", "RRF", "4", "CONSTANT", "60", "WINDOW", "20"};
+    EXPECT_EQ(clause, expected);
 }

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -22,9 +22,20 @@
 
 #define TEST_BLOB_DATA "AQIDBAUGBwgJCg=="
 
+// Format a double exactly as MRCommand_appendCombine does for the wire
+// (round-trip-safe "%.17g"). Tests use this so expectations can be written
+// against readable source values - fmtWireDouble(0.7) - instead of pinning the
+// expanded form (0.69999999999999996) by hand.
+static std::string fmtWireDouble(double v) {
+  char buf[32];
+  snprintf(buf, sizeof(buf), "%.17g", v);
+  return std::string(buf);
+}
+
 // Rebuild the exact tokens the coordinator is expected to emit for a
 // reconstructed COMBINE clause. Mirrors MRCommand_appendCombine so the wire
-// format is pinned byte-for-byte (including the "%.12g" double formatting).
+// format is pinned byte-for-byte (including the "%.17g" round-trip double
+// formatting via fmtWireDouble).
 static std::vector<std::string> expectedCombineTokens(const HybridCombineWireParams &cp) {
   std::vector<std::string> t;
   if (!cp.scoringCtx) {
@@ -32,25 +43,21 @@ static std::vector<std::string> expectedCombineTokens(const HybridCombineWirePar
   }
   const HybridScoringContext *sc = cp.scoringCtx;
   const bool hasAlias = cp.scoreAlias != nullptr;
-  char buf[32];
   t.push_back("COMBINE");
   if (sc->scoringType == HYBRID_SCORING_RRF) {
     t.push_back("RRF");
     t.push_back(std::to_string(hasAlias ? 6 : 4));
     t.push_back("CONSTANT");
-    snprintf(buf, sizeof(buf), "%.12g", sc->rrfCtx.constant);
-    t.push_back(buf);
+    t.push_back(fmtWireDouble(sc->rrfCtx.constant));
     t.push_back("WINDOW");
     t.push_back(std::to_string(sc->rrfCtx.window));
   } else {
     t.push_back("LINEAR");
     t.push_back(std::to_string(hasAlias ? 8 : 6));
     t.push_back("ALPHA");
-    snprintf(buf, sizeof(buf), "%.12g", sc->linearCtx.linearWeights[0]);
-    t.push_back(buf);
+    t.push_back(fmtWireDouble(sc->linearCtx.linearWeights[0]));
     t.push_back("BETA");
-    snprintf(buf, sizeof(buf), "%.12g", sc->linearCtx.linearWeights[1]);
-    t.push_back(buf);
+    t.push_back(fmtWireDouble(sc->linearCtx.linearWeights[1]));
     t.push_back("WINDOW");
     t.push_back(std::to_string(sc->linearCtx.window));
   }
@@ -796,7 +803,7 @@ TEST_F(HybridBuildMRCommandTest, testCombineLinearZeroCountReconstructed) {
         "PARAMS", "2", "BLOB", TEST_BLOB_DATA
     });
     std::vector<std::string> expected = {
-        "COMBINE", "LINEAR", "6", "ALPHA", "0.3", "BETA", "0.7", "WINDOW", "20"};
+        "COMBINE", "LINEAR", "6", "ALPHA", fmtWireDouble(0.3), "BETA", fmtWireDouble(0.7), "WINDOW", "20"};
     EXPECT_EQ(clause, expected);
 }
 
@@ -809,7 +816,7 @@ TEST_F(HybridBuildMRCommandTest, testCombineLinearCountedAliasReconstructed) {
         "PARAMS", "2", "BLOB", TEST_BLOB_DATA
     });
     std::vector<std::string> expected = {
-        "COMBINE", "LINEAR", "8", "ALPHA", "0.3", "BETA", "0.7", "WINDOW", "20",
+        "COMBINE", "LINEAR", "8", "ALPHA", fmtWireDouble(0.3), "BETA", fmtWireDouble(0.7), "WINDOW", "20",
         "YIELD_SCORE_AS", "s"};
     EXPECT_EQ(clause, expected);
 }
@@ -823,7 +830,7 @@ TEST_F(HybridBuildMRCommandTest, testCombineLinearCountedAliasAndWindowReconstru
         "PARAMS", "2", "BLOB", TEST_BLOB_DATA
     });
     std::vector<std::string> expected = {
-        "COMBINE", "LINEAR", "8", "ALPHA", "0.3", "BETA", "0.7", "WINDOW", "20",
+        "COMBINE", "LINEAR", "8", "ALPHA", fmtWireDouble(0.3), "BETA", fmtWireDouble(0.7), "WINDOW", "20",
         "YIELD_SCORE_AS", "s"};
     EXPECT_EQ(clause, expected);
 }
@@ -836,7 +843,7 @@ TEST_F(HybridBuildMRCommandTest, testCombineLinearArgsCountedAliasAndWindowRecon
         "PARAMS", "2", "BLOB", TEST_BLOB_DATA
     });
     std::vector<std::string> expected = {
-        "COMBINE", "LINEAR", "8", "ALPHA", "0.45", "BETA", "0.65",
+        "COMBINE", "LINEAR", "8", "ALPHA", fmtWireDouble(0.45), "BETA", fmtWireDouble(0.65),
         "WINDOW", "20", "YIELD_SCORE_AS", "s"};
     EXPECT_EQ(clause, expected);
 }
@@ -862,7 +869,7 @@ TEST_F(HybridBuildMRCommandTest, testCombineLinearZeroCountPositionalAliasRecons
         "PARAMS", "2", "BLOB", TEST_BLOB_DATA
     });
     std::vector<std::string> expected = {
-        "COMBINE", "LINEAR", "8", "ALPHA", "0.3", "BETA", "0.7", "WINDOW", "20",
+        "COMBINE", "LINEAR", "8", "ALPHA", fmtWireDouble(0.3), "BETA", fmtWireDouble(0.7), "WINDOW", "20",
         "YIELD_SCORE_AS", "fused_score"};
     EXPECT_EQ(clause, expected);
 }

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -43,27 +43,27 @@ static std::vector<std::string> expectedCombineTokens(const HybridCombineWirePar
   }
   const HybridScoringContext *sc = cp.scoringCtx;
   const bool hasAlias = cp.scoreAlias != nullptr;
-  t.push_back("COMBINE");
+  t.emplace_back("COMBINE");
   if (sc->scoringType == HYBRID_SCORING_RRF) {
-    t.push_back("RRF");
+    t.emplace_back("RRF");
     t.push_back(std::to_string(hasAlias ? 6 : 4));
-    t.push_back("CONSTANT");
+    t.emplace_back("CONSTANT");
     t.push_back(fmtWireDouble(sc->rrfCtx.constant));
-    t.push_back("WINDOW");
+    t.emplace_back("WINDOW");
     t.push_back(std::to_string(sc->rrfCtx.window));
   } else {
-    t.push_back("LINEAR");
+    t.emplace_back("LINEAR");
     t.push_back(std::to_string(hasAlias ? 8 : 6));
-    t.push_back("ALPHA");
+    t.emplace_back("ALPHA");
     t.push_back(fmtWireDouble(sc->linearCtx.linearWeights[0]));
-    t.push_back("BETA");
+    t.emplace_back("BETA");
     t.push_back(fmtWireDouble(sc->linearCtx.linearWeights[1]));
-    t.push_back("WINDOW");
+    t.emplace_back("WINDOW");
     t.push_back(std::to_string(sc->linearCtx.window));
   }
   if (hasAlias) {
-    t.push_back("YIELD_SCORE_AS");
-    t.push_back(cp.scoreAlias);
+    t.emplace_back("YIELD_SCORE_AS");
+    t.emplace_back(cp.scoreAlias);
   }
   return t;
 }
@@ -334,7 +334,7 @@ protected:
                 int count = (i + 2 < xcmd.num) ? atoi(xcmd.strs[i + 2]) : 0;
                 int end = i + 3 + count;
                 for (int j = i; j < end && j < xcmd.num; j++) {
-                    out.push_back(std::string(xcmd.strs[j], xcmd.lens[j]));
+                    out.emplace_back(xcmd.strs[j], xcmd.lens[j]);
                 }
                 break;
             }

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -13,16 +13,99 @@
 #include "redisearch_rs/headers/query_error.h"
 #include "hybrid/hybrid_cursor_mappings.h"
 
+#include "dist_hybrid.h"
+#include "hybrid/hybrid_scoring.h"
+
+#include <string>
 #include <string_view>
+#include <vector>
 
 #define TEST_BLOB_DATA "AQIDBAUGBwgJCg=="
 
-extern "C" {
-void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
-                                  ProfileOptions profileOptions,
-                                  bool sendExplainScore,
-                                  MRCommand *xcmd, arrayof(char *) serialized,
-                                  IndexSpec *sp, int *outKArgIndex);
+// Rebuild the exact tokens the coordinator is expected to emit for a
+// reconstructed COMBINE clause. Mirrors MRCommand_appendCombine so the wire
+// format is pinned byte-for-byte (including the "%.12g" double formatting).
+static std::vector<std::string> expectedCombineTokens(const HybridCombineWireParams &cp) {
+  std::vector<std::string> t;
+  if (!cp.scoringCtx) {
+    return t;
+  }
+  const HybridScoringContext *sc = cp.scoringCtx;
+  const bool hasAlias = cp.scoreAlias != nullptr;
+  char buf[32];
+  t.push_back("COMBINE");
+  if (sc->scoringType == HYBRID_SCORING_RRF) {
+    t.push_back("RRF");
+    t.push_back(std::to_string(hasAlias ? 6 : 4));
+    t.push_back("CONSTANT");
+    snprintf(buf, sizeof(buf), "%.12g", sc->rrfCtx.constant);
+    t.push_back(buf);
+    t.push_back("WINDOW");
+    t.push_back(std::to_string(sc->rrfCtx.window));
+  } else {
+    t.push_back("LINEAR");
+    t.push_back(std::to_string(hasAlias ? 8 : 6));
+    t.push_back("ALPHA");
+    snprintf(buf, sizeof(buf), "%.12g", sc->linearCtx.linearWeights[0]);
+    t.push_back(buf);
+    t.push_back("BETA");
+    snprintf(buf, sizeof(buf), "%.12g", sc->linearCtx.linearWeights[1]);
+    t.push_back(buf);
+    t.push_back("WINDOW");
+    t.push_back(std::to_string(sc->linearCtx.window));
+  }
+  if (hasAlias) {
+    t.push_back("YIELD_SCORE_AS");
+    t.push_back(cp.scoreAlias);
+  }
+  return t;
+}
+
+// Fill a caller-owned HybridScoringContext for a LINEAR wire clause. Both `sc`
+// and the 2-element `weights` array must outlive the returned params.
+static HybridCombineWireParams linearWireParams(HybridScoringContext *sc, double *weights,
+                                                double alpha, double beta, size_t window,
+                                                const char *alias = nullptr) {
+  weights[0] = alpha;
+  weights[1] = beta;
+  sc->scoringType = HYBRID_SCORING_LINEAR;
+  sc->linearCtx.linearWeights = weights;
+  sc->linearCtx.numWeights = 2;
+  sc->linearCtx.window = window;
+  return HybridCombineWireParams{sc, alias};
+}
+
+// Walk input and output argv in tandem, asserting non-COMBINE args are
+// preserved by position. Where the input has a COMBINE clause, the output is
+// expected to carry the reconstructed clause instead (self-delimiting input
+// clause: COMBINE <method> <count> <count-args...> [YIELD_SCORE_AS <alias>]).
+// Returns the output index just past the matched prefix.
+static int verifyArgsPreservedWithReconstructedCombine(
+    const MRCommand *xcmd, const std::vector<const char *> &inputArgs,
+    const HybridCombineWireParams *cp) {
+  int oi = 1;  // strs[0] is _FT.HYBRID, checked separately
+  for (size_t ii = 1; ii < inputArgs.size();) {
+    if (strcasecmp(inputArgs[ii], "COMBINE") == 0 && cp && cp->scoringCtx) {
+      for (const auto &tok : expectedCombineTokens(*cp)) {
+        EXPECT_STREQ(xcmd->strs[oi], tok.c_str())
+            << "Reconstructed COMBINE token mismatch at output index " << oi;
+        oi++;
+      }
+      // Skip the input COMBINE clause: COMBINE + method + count + N args.
+      ii += 2;                          // COMBINE, method
+      long n = atol(inputArgs[ii]);     // count
+      ii += 1 + (size_t)n;              // count token + its args
+      if (ii < inputArgs.size() && strcasecmp(inputArgs[ii], "YIELD_SCORE_AS") == 0) {
+        ii += 2;                        // positional YIELD_SCORE_AS <alias>
+      }
+    } else {
+      EXPECT_STREQ(xcmd->strs[oi], inputArgs[ii])
+          << "Argument at input index " << ii << " should be preserved";
+      oi++;
+      ii++;
+    }
+  }
+  return oi;
 }
 
 class HybridBuildMRCommandTest : public ::testing::Test {
@@ -121,11 +204,17 @@ protected:
         const VectorQuery *vq = validateVectorQuery(cmd.vector, expectedK, expectedRatio);
         ASSERT_NE(vq, nullptr) << "VectorQuery validation failed";
 
+        // Borrow the resolved scoring context (as the coordinator does before
+        // the merger takes ownership) so the reconstructed COMBINE clause is
+        // forwarded to the shard.
+        HybridCombineWireParams combineParams{hybridParams.scoringCtx,
+                                              hybridParams.aggregationParams.common.scoreAlias};
+
         // Build MR command - now returns kArgIndex instead of calculating effectiveK
         MRCommand xcmd;
         int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, &xcmd,
+                                     /*sendExplainScore=*/false, &combineParams, &xcmd,
                                      nullptr, testIndexSpec, &kArgIndex);
 
         // Verify the command was built correctly
@@ -166,6 +255,76 @@ protected:
         HybridRequest_DecrRef(hreq);
     }
 
+    // Parse a full FT.HYBRID command, build the per-shard MR command as the
+    // coordinator would (capturing resolved scoring params), and return the
+    // reconstructed COMBINE clause tokens found in the output (empty if none).
+    // The clause is self-delimiting: COMBINE <method> <count> <count args...>.
+    std::vector<std::string> buildAndExtractCombineClause(const std::vector<const char*>& inputArgs) {
+        std::vector<std::string> out;
+        std::vector<const char*> argsWithNull = inputArgs;
+        argsWithNull.push_back(nullptr);
+        RMCK::ArgvList args(ctx, argsWithNull.data(), inputArgs.size());
+
+        RedisSearchCtx *sctx = NewSearchCtxC(ctx, "test_idx", true);
+        EXPECT_NE(sctx, nullptr);
+        if (!sctx) return out;
+        HybridRequest *hreq = MakeDefaultHybridRequest(sctx);
+
+        HybridPipelineParams hybridParams = {};
+        ParseHybridCommandCtx cmd = {};
+        cmd.search = hreq->requests[0];
+        cmd.vector = hreq->requests[1];
+        cmd.tailPlan = &hreq->tailPipeline->ap;
+        cmd.hybridParams = &hybridParams;
+        cmd.reqConfig = &hreq->reqConfig;
+        cmd.cursorConfig = &hreq->cursorConfig;
+        cmd.coordDispatchTime = &hreq->profileClocks.coordDispatchTime;
+
+        ArgsCursor ac = {};
+        HybridRequest_InitArgsCursor(hreq, &ac, args, args.size());
+        QueryError status = QueryError_Default();
+        int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, &status, false, EXEC_NO_FLAGS);
+        EXPECT_EQ(rc, REDISMODULE_OK) << QueryError_GetDisplayableError(&status, false);
+        if (rc != REDISMODULE_OK) {
+            if (hybridParams.scoringCtx) HybridScoringContext_Free(hybridParams.scoringCtx);
+            HybridRequest_DecrRef(hreq);
+            return out;
+        }
+
+        HybridCombineWireParams cp{hybridParams.scoringCtx,
+                                   hybridParams.aggregationParams.common.scoreAlias};
+
+        MRCommand xcmd;
+        int kArgIndex = -1;
+        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
+                                     /*sendExplainScore=*/false, &cp, &xcmd,
+                                     nullptr, testIndexSpec, &kArgIndex);
+
+        // Assert the parse-driven path also preserves every non-COMBINE arg by
+        // position and reconstructs the COMBINE clause against the computed
+        // oracle. The caller additionally pins the extracted clause against a
+        // literal vector, so the two oracles stay independent.
+        EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
+        verifyArgsPreservedWithReconstructedCombine(&xcmd, inputArgs, &cp);
+
+        for (int i = 0; i < xcmd.num; i++) {
+            if (xcmd.lens[i] == strlen("COMBINE") &&
+                strncasecmp(xcmd.strs[i], "COMBINE", xcmd.lens[i]) == 0) {
+                int count = (i + 2 < xcmd.num) ? atoi(xcmd.strs[i + 2]) : 0;
+                int end = i + 3 + count;
+                for (int j = i; j < end && j < xcmd.num; j++) {
+                    out.push_back(std::string(xcmd.strs[j], xcmd.lens[j]));
+                }
+                break;
+            }
+        }
+
+        MRCommand_Free(&xcmd);
+        HybridScoringContext_Free(hybridParams.scoringCtx);
+        HybridRequest_DecrRef(hreq);
+        return out;
+    }
+
     // Helper function to find K value in MRCommand
     // Returns the index of K keyword, or -1 if not found
     // If found, kValue will contain the K value as long long
@@ -183,7 +342,8 @@ protected:
     }
 
     // Helper function to test command transformation
-    void testCommandTransformationWithoutIndexSpec(const std::vector<const char*>& inputArgs) {
+    void testCommandTransformationWithoutIndexSpec(const std::vector<const char*>& inputArgs,
+                                                   const HybridCombineWireParams *combineParams = nullptr) {
         // Access the global NumShards variable
         extern size_t NumShards;
 
@@ -198,16 +358,15 @@ protected:
         MRCommand xcmd;
         int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, &xcmd,
+                                     /*sendExplainScore=*/false, combineParams, &xcmd,
                                      nullptr, nullptr, &kArgIndex);
 
         // Verify transformation: FT.HYBRID -> _FT.HYBRID
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
 
-        // Verify all other original args are preserved (except first). Attention: This is not true if TIMEOUT is not at the end before DIALECT
-        for (size_t i = 1; i < inputArgs.size(); i++) {
-            EXPECT_STREQ(xcmd.strs[i], inputArgs[i]) << "Argument at index " << i << " should be preserved";
-        }
+        // Verify original args are preserved, with the COMBINE clause replaced by
+        // its reconstructed (old-shard-compatible) form.
+        verifyArgsPreservedWithReconstructedCombine(&xcmd, inputArgs, combineParams);
 
         // Verify WITHCURSOR, WITHSCORES, _NUM_SSTRING, _COORD_DISPATCH_TIME are added at the end
         // Note: _COORD_DISPATCH_TIME and its placeholder value (2 args) are added after _NUM_SSTRING
@@ -221,7 +380,8 @@ protected:
     }
 
     // Helper function to test command transformation
-    void testCommandTransformationWithIndexSpec(const std::vector<const char*>& inputArgs) {
+    void testCommandTransformationWithIndexSpec(const std::vector<const char*>& inputArgs,
+                                                const HybridCombineWireParams *combineParams = nullptr) {
       // Access the global NumShards variable
       extern size_t NumShards;
 
@@ -244,14 +404,13 @@ protected:
       MRCommand xcmd;
       int kArgIndex = -1;
       HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                   /*sendExplainScore=*/false, &xcmd,
+                                   /*sendExplainScore=*/false, combineParams, &xcmd,
                                    nullptr, sp, &kArgIndex);
       // Verify transformation: FT.HYBRID -> _FT.HYBRID
       EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
-      // Verify all other original args are preserved (except first). Attention: This is not true if TIMEOUT is not at the end before DIALECT
-      for (size_t i = 1; i < inputArgs.size(); i++) {
-          EXPECT_STREQ(xcmd.strs[i], inputArgs[i]) << "Argument at index " << i << " should be preserved";
-      }
+      // Verify original args are preserved, with the COMBINE clause replaced by
+      // its reconstructed (old-shard-compatible) form.
+      verifyArgsPreservedWithReconstructedCombine(&xcmd, inputArgs, combineParams);
       // Verify WITHCURSOR, WITHSCORES, _NUM_SSTRING, SLOTS, _COORD_DISPATCH_TIME, _INDEX_PREFIXES, and prefixes are added at the end
       // Order: ... WITHCURSOR WITHSCORES _NUM_SSTRING _SLOTS <slots_blob> _COORD_DISPATCH_TIME <placeholder> _INDEX_PREFIXES 2 prefix1 prefix2
       EXPECT_STREQ(xcmd.strs[xcmd.num - 11], "WITHCURSOR") << "WITHCURSOR should be 11th to last";
@@ -321,18 +480,21 @@ TEST_F(HybridBuildMRCommandTest, testCommandWithDialect) {
 
 // Test command with DIALECT
 TEST_F(HybridBuildMRCommandTest, testCommandWithCombine) {
+    HybridScoringContext sc = {};
+    double w[2];
+    HybridCombineWireParams cp = linearWireParams(&sc, w, 0.7, 0.3, HYBRID_DEFAULT_WINDOW);
     testCommandTransformationWithoutIndexSpec({
         "FT.HYBRID", "test_idx", "SEARCH", "hello",
         "VSIM", "@vector_field", TEST_BLOB_DATA, "FILTER", "@tag:{invalid_tag}",
         "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
         "DIALECT", "2"
-    });
+    }, &cp);
     testCommandTransformationWithIndexSpec({
         "FT.HYBRID", "test_idx", "SEARCH", "hello",
         "VSIM", "@vector_field", TEST_BLOB_DATA, "FILTER", "@tag:{invalid_tag}",
         "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
         "DIALECT", "2"
-    });
+    }, &cp);
 }
 
 
@@ -374,34 +536,43 @@ TEST_F(HybridBuildMRCommandTest, testFilterWithBatchSizeAndPolicyReversed) {
 
 // Test FILTER with POLICY, BATCH_SIZE and COMBINE
 TEST_F(HybridBuildMRCommandTest, testFilterWithPolicyBatchSizeAndCombine) {
+    HybridScoringContext sc = {};
+    double w[2];
+    HybridCombineWireParams cp = linearWireParams(&sc, w, 0.7, 0.3, HYBRID_DEFAULT_WINDOW);
     testCommandTransformationWithoutIndexSpec({
         "FT.HYBRID", "test_idx", "SEARCH", "hello",
         "VSIM", "@vector_field", TEST_BLOB_DATA,
         "FILTER", "5", "@tag:{test}", "POLICY", "BATCHES", "BATCH_SIZE", "100",
         "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3"
-    });
+    }, &cp);
 }
 
 // Test complex command with all optional parameters
 TEST_F(HybridBuildMRCommandTest, testComplexCommandWithAllParams) {
+    HybridScoringContext sc = {};
+    double w[2];
+    HybridCombineWireParams cp = linearWireParams(&sc, w, 0.7, 0.3, HYBRID_DEFAULT_WINDOW);
     testCommandTransformationWithoutIndexSpec({
         "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
         "VSIM", "@vector_field", "$BLOB",
         "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
         "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA,
         "TIMEOUT", "3000", "DIALECT", "2"
-    });
+    }, &cp);
     testCommandTransformationWithIndexSpec({
         "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
         "VSIM", "@vector_field", "$BLOB",
         "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
         "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA,
         "TIMEOUT", "3000", "DIALECT", "2"
-    });
+    }, &cp);
 }
 
 // Test complex command with all optional parameters
 TEST_F(HybridBuildMRCommandTest, testComplexCommandParamsAfterTimeout) {
+    HybridScoringContext sc = {};
+    double w[2];
+    HybridCombineWireParams cp = linearWireParams(&sc, w, 0.7, 0.3, HYBRID_DEFAULT_WINDOW);
     testCommandTransformationWithoutIndexSpec({
         "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
         "VSIM", "@vector_field", "$BLOB",
@@ -409,7 +580,7 @@ TEST_F(HybridBuildMRCommandTest, testComplexCommandParamsAfterTimeout) {
         "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA,
         "TIMEOUT", "3000",
         "DIALECT", "2"
-    });
+    }, &cp);
     testCommandTransformationWithIndexSpec({
         "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
         "VSIM", "@vector_field", "$BLOB",
@@ -417,7 +588,7 @@ TEST_F(HybridBuildMRCommandTest, testComplexCommandParamsAfterTimeout) {
         "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA,
         "TIMEOUT", "3000",
         "DIALECT", "2"
-    });
+    }, &cp);
 }
 
 // Test minimal command
@@ -454,7 +625,7 @@ TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
         MRCommand xcmd;
         int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, &xcmd,
+                                     /*sendExplainScore=*/false, /*combineParams=*/nullptr, &xcmd,
                                      nullptr, nullptr, &kArgIndex);
 
         EXPECT_EQ(countToken(&xcmd, "EXPLAINSCORE"), 1)
@@ -474,7 +645,7 @@ TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
         MRCommand xcmd;
         int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, &xcmd,
+                                     /*sendExplainScore=*/false, /*combineParams=*/nullptr, &xcmd,
                                      nullptr, nullptr, &kArgIndex);
 
         EXPECT_EQ(countToken(&xcmd, "EXPLAINSCORE"), 1)
@@ -492,7 +663,7 @@ TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
         MRCommand xcmd;
         int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/true, &xcmd,
+                                     /*sendExplainScore=*/true, /*combineParams=*/nullptr, &xcmd,
                                      nullptr, nullptr, &kArgIndex);
 
         EXPECT_EQ(countToken(&xcmd, "EXPLAINSCORE"), 1)
@@ -541,4 +712,126 @@ TEST_F(HybridBuildMRCommandTest, testShardKRatioNoModificationWhenRatioIsOne) {
         "PARAMS", "2", "BLOB", TEST_BLOB_DATA
     }, /*numShards=*/4, /*expectedK=*/50, /*expectedRatio=*/1.0,
     /*expectedEffectiveK=*/50);
+}
+
+// ============================================================================
+// Old-shard-compatible COMBINE reconstruction
+//
+// The coordinator must never forward the positional YIELD_SCORE_AS form or a
+// zero argument count to shards (old shards reject both). It reconstructs the
+// clause from the resolved scoring params into the legacy counted form with an
+// explicit, positive, even argument count.
+// ============================================================================
+
+// COMBINE RRF 0 -> explicit defaults with a positive even count.
+TEST_F(HybridBuildMRCommandTest, testCombineRRFZeroCountReconstructed) {
+    auto clause = buildAndExtractCombineClause({
+        "FT.HYBRID", "test_idx", "SEARCH", "hello", "VSIM", "@vector_field", "$BLOB",
+        "COMBINE", "RRF", "0",
+        "PARAMS", "2", "BLOB", TEST_BLOB_DATA
+    });
+    std::vector<std::string> expected = {"COMBINE", "RRF", "4", "CONSTANT", "60", "WINDOW", "20"};
+    EXPECT_EQ(clause, expected);
+}
+
+// COMBINE RRF 0 YIELD_SCORE_AS s (positional alias, zero count) ->
+// counted form with the alias folded into the count (6).
+TEST_F(HybridBuildMRCommandTest, testCombineRRFZeroCountPositionalAliasReconstructed) {
+    auto clause = buildAndExtractCombineClause({
+        "FT.HYBRID", "test_idx", "SEARCH", "hello", "VSIM", "@vector_field", "$BLOB",
+        "COMBINE", "RRF", "0", "YIELD_SCORE_AS", "s",
+        "PARAMS", "2", "BLOB", TEST_BLOB_DATA
+    });
+    std::vector<std::string> expected = {"COMBINE", "RRF", "6", "CONSTANT", "60",
+                                         "WINDOW", "20", "YIELD_SCORE_AS", "s"};
+    EXPECT_EQ(clause, expected);
+}
+
+// COMBINE RRF 2 YIELD_SCORE_AS s (counted alias) produces the same
+// wire form as the positional variant above.
+TEST_F(HybridBuildMRCommandTest, testCombineRRFCountedAliasReconstructed) {
+    auto clause = buildAndExtractCombineClause({
+        "FT.HYBRID", "test_idx", "SEARCH", "hello", "VSIM", "@vector_field", "$BLOB",
+        "COMBINE", "RRF", "2", "YIELD_SCORE_AS", "s",
+        "PARAMS", "2", "BLOB", TEST_BLOB_DATA
+    });
+    std::vector<std::string> expected = {"COMBINE", "RRF", "6", "CONSTANT", "60",
+                                         "WINDOW", "20", "YIELD_SCORE_AS", "s"};
+    EXPECT_EQ(clause, expected);
+}
+
+// COMBINE RRF 4 CONSTANT 60 YIELD_SCORE_AS s (counted alias) produces the same
+// wire form as the positional variant above.
+TEST_F(HybridBuildMRCommandTest, testCombineRRFCountedAliasAndConstantReconstructed) {
+    auto clause = buildAndExtractCombineClause({
+        "FT.HYBRID", "test_idx", "SEARCH", "hello", "VSIM", "@vector_field", "$BLOB",
+        "COMBINE", "RRF", "4", "CONSTANT", "60.5", "YIELD_SCORE_AS", "s",
+        "PARAMS", "2", "BLOB", TEST_BLOB_DATA
+    });
+    std::vector<std::string> expected = {
+        "COMBINE", "RRF", "6", "CONSTANT", "60.5", "WINDOW", "20",
+        "YIELD_SCORE_AS", "s"};
+    EXPECT_EQ(clause, expected);
+}
+
+// COMBINE LINEAR 0 -> explicit default weights with a positive even count.
+TEST_F(HybridBuildMRCommandTest, testCombineLinearZeroCountReconstructed) {
+    auto clause = buildAndExtractCombineClause({
+        "FT.HYBRID", "test_idx", "SEARCH", "hello", "VSIM", "@vector_field", "$BLOB",
+        "COMBINE", "LINEAR", "0",
+        "PARAMS", "2", "BLOB", TEST_BLOB_DATA
+    });
+    std::vector<std::string> expected = {
+        "COMBINE", "LINEAR", "6", "ALPHA", "0.3", "BETA", "0.7", "WINDOW", "20"};
+    EXPECT_EQ(clause, expected);
+}
+
+// COMBINE LINEAR 2 YIELD_SCORE_AS s (counted alias) produces the same
+// wire form as the positional variant above.
+TEST_F(HybridBuildMRCommandTest, testCombineLinearCountedAliasReconstructed) {
+    auto clause = buildAndExtractCombineClause({
+        "FT.HYBRID", "test_idx", "SEARCH", "hello", "VSIM", "@vector_field", "$BLOB",
+        "COMBINE", "LINEAR", "2", "YIELD_SCORE_AS", "s",
+        "PARAMS", "2", "BLOB", TEST_BLOB_DATA
+    });
+    std::vector<std::string> expected = {
+        "COMBINE", "LINEAR", "8", "ALPHA", "0.3", "BETA", "0.7", "WINDOW", "20",
+        "YIELD_SCORE_AS", "s"};
+    EXPECT_EQ(clause, expected);
+}
+
+// COMBINE LINEAR 4 YIELD_SCORE_AS s WINDOW 20 (counted alias) produces the same
+// wire form as the positional variant above.
+TEST_F(HybridBuildMRCommandTest, testCombineLinearCountedAliasAndWindowReconstructed) {
+    auto clause = buildAndExtractCombineClause({
+        "FT.HYBRID", "test_idx", "SEARCH", "hello", "VSIM", "@vector_field", "$BLOB",
+        "COMBINE", "LINEAR", "4", "YIELD_SCORE_AS", "s", "WINDOW", "20",
+        "PARAMS", "2", "BLOB", TEST_BLOB_DATA
+    });
+    std::vector<std::string> expected = {
+        "COMBINE", "LINEAR", "8", "ALPHA", "0.3", "BETA", "0.7", "WINDOW", "20",
+        "YIELD_SCORE_AS", "s"};
+    EXPECT_EQ(clause, expected);
+}
+
+TEST_F(HybridBuildMRCommandTest, testCombineLinearArgsCountedAliasAndWindowReconstructed) {
+    auto clause = buildAndExtractCombineClause({
+        "FT.HYBRID", "test_idx", "SEARCH", "hello", "VSIM", "@vector_field", "$BLOB",
+        "COMBINE", "LINEAR", "8", "ALPHA", "0.45", "BETA", "0.65",
+            "YIELD_SCORE_AS", "s", "WINDOW", "20",
+        "PARAMS", "2", "BLOB", TEST_BLOB_DATA
+    });
+    std::vector<std::string> expected = {
+        "COMBINE", "LINEAR", "8", "ALPHA", "0.45", "BETA", "0.65",
+        "WINDOW", "20", "YIELD_SCORE_AS", "s"};
+    EXPECT_EQ(clause, expected);
+}
+
+// No COMBINE clause -> nothing forwarded (matches legacy behavior).
+TEST_F(HybridBuildMRCommandTest, testNoCombineNotForwarded) {
+    auto clause = buildAndExtractCombineClause({
+        "FT.HYBRID", "test_idx", "SEARCH", "hello", "VSIM", "@vector_field", "$BLOB",
+        "PARAMS", "2", "BLOB", TEST_BLOB_DATA
+    });
+    EXPECT_TRUE(clause.empty());
 }

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -143,12 +143,13 @@ class ParseHybridTest : public ::testing::Test {
 } while(0)
 
 
-#define assertLinearScoringCtx(Weight0, Weight1) do { \
+#define assertLinearScoringCtx(Weight0, Weight1, Window) do { \
   ASSERT_EQ(result.hybridParams->scoringCtx->scoringType, HYBRID_SCORING_LINEAR); \
   ASSERT_EQ(result.hybridParams->scoringCtx->linearCtx.numWeights, HYBRID_REQUEST_NUM_SUBQUERIES); \
   ASSERT_TRUE(result.hybridParams->scoringCtx->linearCtx.linearWeights != NULL); \
   ASSERT_DOUBLE_EQ(result.hybridParams->scoringCtx->linearCtx.linearWeights[0], Weight0); \
   ASSERT_DOUBLE_EQ(result.hybridParams->scoringCtx->linearCtx.linearWeights[1], Weight1); \
+  ASSERT_EQ(result.hybridParams->scoringCtx->linearCtx.window, Window); \
 } while(0)
 
 #define assertRRFScoringCtx(Constant, Window) do { \
@@ -254,7 +255,178 @@ TEST_F(ParseHybridTest, testWithCombineLinear) {
   parseCommand(args);
 
   // Verify LINEAR scoring type was set
-  assertLinearScoringCtx(0.7, 0.3);
+  assertLinearScoringCtx(0.7, 0.3, HYBRID_DEFAULT_WINDOW);
+}
+
+// YIELD_SCORE_AS after COMBINE is accepted in two equivalent forms:
+//   (A) counted   - inside the method argument count (legacy)
+//   (B) positional - after the method argument block (current)
+// Both must yield the same alias and scoring parameters.
+TEST_F(ParseHybridTest, testRRFCountedYieldScoreOnly) {
+  // Counted form: count 2 covers YIELD_SCORE_AS fused_score
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "RRF", "2", "YIELD_SCORE_AS", "fused_score",
+      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  parseCommand(args);
+  assertRRFScoringCtx(HYBRID_DEFAULT_RRF_CONSTANT, HYBRID_DEFAULT_WINDOW);
+  ASSERT_STREQ(result.hybridParams->aggregationParams.common.scoreAlias, "fused_score");
+}
+
+TEST_F(ParseHybridTest, testLinearCountedYieldScoreOnly) {
+  // Counted form: count 2 covers YIELD_SCORE_AS fused_score
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "LINEAR", "2", "YIELD_SCORE_AS", "fused_score",
+      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  parseCommand(args);
+  assertLinearScoringCtx(HYBRID_DEFAULT_LINEAR_ALPHA, HYBRID_DEFAULT_LINEAR_BETA, HYBRID_DEFAULT_WINDOW);
+  ASSERT_STREQ(result.hybridParams->aggregationParams.common.scoreAlias, "fused_score");
+}
+
+TEST_F(ParseHybridTest, testRRFPositionalYieldScoreOnly) {
+  // Positional form: YIELD_SCORE_AS follows the block
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "RRF", "0", "YIELD_SCORE_AS", "fused_score",
+      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  parseCommand(args);
+  assertRRFScoringCtx(HYBRID_DEFAULT_RRF_CONSTANT, HYBRID_DEFAULT_WINDOW);
+  ASSERT_STREQ(result.hybridParams->aggregationParams.common.scoreAlias, "fused_score");
+}
+
+TEST_F(ParseHybridTest, testLinearPositionalYieldScoreOnly) {
+  // Positional form: YIELD_SCORE_AS follows the block
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "LINEAR", "0", "YIELD_SCORE_AS", "fused_score",
+      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  parseCommand(args);
+  assertLinearScoringCtx(HYBRID_DEFAULT_LINEAR_ALPHA, HYBRID_DEFAULT_LINEAR_BETA, HYBRID_DEFAULT_WINDOW);
+  ASSERT_STREQ(result.hybridParams->aggregationParams.common.scoreAlias, "fused_score");
+}
+
+TEST_F(ParseHybridTest, testCombineRRFCountedYieldScore) {
+  // Counted form: count 4 covers CONSTANT 80 YIELD_SCORE_AS fused_score
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "RRF", "4", "CONSTANT", "80", "YIELD_SCORE_AS", "fused_score",
+      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  parseCommand(args);
+  assertRRFScoringCtx(80, HYBRID_DEFAULT_WINDOW);
+  ASSERT_STREQ(result.hybridParams->aggregationParams.common.scoreAlias, "fused_score");
+}
+
+TEST_F(ParseHybridTest, testCombineRRFPositionalYieldScore) {
+  // Positional form: count 2 covers CONSTANT 60, YIELD_SCORE_AS follows the block
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "RRF", "2", "CONSTANT", "90",
+      "YIELD_SCORE_AS", "fused_score",
+      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  parseCommand(args);
+  assertRRFScoringCtx(90, HYBRID_DEFAULT_WINDOW);
+  ASSERT_STREQ(result.hybridParams->aggregationParams.common.scoreAlias, "fused_score");
+}
+
+TEST_F(ParseHybridTest, testCombineLinearCountedYieldScore) {
+  // Counted form: count 6 covers ALPHA 0.7 BETA 0.3 YIELD_SCORE_AS s
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "LINEAR", "6", "ALPHA", "0.7", "BETA", "0.3", "YIELD_SCORE_AS", "fused_score",
+      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  parseCommand(args);
+  assertLinearScoringCtx(0.7, 0.3, HYBRID_DEFAULT_WINDOW);
+  ASSERT_STREQ(result.hybridParams->aggregationParams.common.scoreAlias, "fused_score");
+}
+
+TEST_F(ParseHybridTest, testCombineLinearYieldScorePositional) {
+  // Positional form: count 4 covers ALPHA 0.7 BETA 0.3, YIELD_SCORE_AS follows
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
+      "YIELD_SCORE_AS", "fused_score",
+      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  parseCommand(args);
+  assertLinearScoringCtx(0.7, 0.3, HYBRID_DEFAULT_WINDOW);
+  ASSERT_STREQ(result.hybridParams->aggregationParams.common.scoreAlias, "fused_score");
+}
+
+TEST_F(ParseHybridTest, testCombineAndPositionalYieldScoreError) {
+  // Alias given both counted (inside count 4) and positionally -> rejected
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "RRF", "4", "CONSTANT", "60", "YIELD_SCORE_AS", "a",
+      "YIELD_SCORE_AS", "b",
+      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "YIELD_SCORE_AS specified more than once");
+}
+
+TEST_F(ParseHybridTest, testCombineCount0AndPositionalYieldScoreSpecifiedTwiceError) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "RRF", "0",
+      "YIELD_SCORE_AS", "a", "YIELD_SCORE_AS", "b",
+      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "YIELD_SCORE_AS: Unknown argument");
+}
+
+TEST_F(ParseHybridTest, testCombineLinearCount0AndPositionalYieldScoreSpecifiedTwiceError) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "LINEAR", "0",
+      "YIELD_SCORE_AS", "a", "YIELD_SCORE_AS", "b",
+      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "YIELD_SCORE_AS: Unknown argument");
+}
+
+TEST_F(ParseHybridTest, testYieldScoreWithoutCombineError) {
+  // Test RANGE with missing YIELD_DISTANCE_AS value
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA,
+    "YIELD_SCORE_AS", "fused_score");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "YIELD_SCORE_AS: Unknown argument");
+}
+
+TEST_F(ParseHybridTest, testCombineRRFWithoutArgument) {
+  // Test RANGE with missing YIELD_DISTANCE_AS value
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+    "COMBINE", "RRF", "0",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  parseCommand(args);
+  // Verify default scoring type is RRF
+  assertRRFScoringCtx(HYBRID_DEFAULT_RRF_CONSTANT, HYBRID_DEFAULT_WINDOW);
+}
+
+TEST_F(ParseHybridTest, testCombineRRFWithoutArgumentAfterParams) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA,
+    "COMBINE", "RRF", "0");
+  parseCommand(args);
+  assertRRFScoringCtx(HYBRID_DEFAULT_RRF_CONSTANT, HYBRID_DEFAULT_WINDOW);
+}
+
+TEST_F(ParseHybridTest, testCombineLinearWithoutArgument) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+    "COMBINE", "LINEAR", "0",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  parseCommand(args);
+  // No ALPHA/BETA -> default weights
+  assertLinearScoringCtx(HYBRID_DEFAULT_LINEAR_ALPHA, HYBRID_DEFAULT_LINEAR_BETA, HYBRID_DEFAULT_WINDOW);
+}
+
+TEST_F(ParseHybridTest, testCombineLinearWithoutArgumentAfterParams) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA,
+    "COMBINE", "LINEAR", "0");
+  parseCommand(args);
+  // No ALPHA/BETA -> default weights
+  assertLinearScoringCtx(HYBRID_DEFAULT_LINEAR_ALPHA, HYBRID_DEFAULT_LINEAR_BETA, HYBRID_DEFAULT_WINDOW);
 }
 
 TEST_F(ParseHybridTest, testWithCombineRRF) {
@@ -348,7 +520,7 @@ TEST_F(ParseHybridTest, testComplexSingleLineCommand) {
   parseCommand(args);
 
   // Verify LINEAR scoring type was set
-  assertLinearScoringCtx(0.65, 0.35);
+  assertLinearScoringCtx(0.65, 0.35, HYBRID_DEFAULT_WINDOW);
 }
 
 TEST_F(ParseHybridTest, testExplicitWindowAndLimitWithImplicitK) {
@@ -1319,15 +1491,18 @@ TEST_F(ParseHybridTest, testLoadInsufficientFields) {
 // Test not yet supported arguments
 // ============================================================================
 
-TEST_F(ParseHybridTest, testCombineRRFWithoutArgument) {
-  // Test RANGE with missing YIELD_DISTANCE_AS value (early return before CheckEnd)
-  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "COMBINE", "RRF", "0", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Explicitly specifying RRF requires at least one argument, argument count must be positive");
-}
-
 TEST_F(ParseHybridTest, testCombineRRFWithOddArgumentCount) {
   // Test RANGE with missing YIELD_DISTANCE_AS value (early return before CheckEnd)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "COMBINE", "RRF", "1", "WINDOW", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "RRF expects pairs of key value arguments, argument count must be an even number");
+}
+
+TEST_F(ParseHybridTest, testCombineRRFWithOddArgumentCountAfterParams) {
+  // Test RANGE with missing YIELD_DISTANCE_AS value (early return before CheckEnd)
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello", "VSIM", "@vector",
+    "$BLOB", "PARAMS", "2", "BLOB", TEST_BLOB_DATA,
+    "COMBINE", "RRF", "1", "WINDOW");
   testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "RRF expects pairs of key value arguments, argument count must be an even number");
 }
 

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -352,11 +352,91 @@ TEST_F(ParseHybridTest, testCombineLinearYieldScorePositional) {
   ASSERT_STREQ(result.hybridParams->aggregationParams.common.scoreAlias, "fused_score");
 }
 
-TEST_F(ParseHybridTest, testCombineAndPositionalYieldScoreError) {
+TEST_F(ParseHybridTest, testRRFFullArgsYieldScorePositional) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "RRF", "4", "CONSTANT", "70", "WINDOW", "15",
+      "YIELD_SCORE_AS", "fused_score",
+      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  parseCommand(args);
+  assertRRFScoringCtx(70, 15);
+  ASSERT_STREQ(result.hybridParams->aggregationParams.common.scoreAlias, "fused_score");
+}
+
+TEST_F(ParseHybridTest, testLinearFullArgsYieldScorePositional) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "LINEAR", "6", "ALPHA", "0.55", "BETA", "0.45", "WINDOW", "30",
+      "YIELD_SCORE_AS", "fused_score",
+      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  parseCommand(args);
+  assertLinearScoringCtx(0.55, 0.45, 30);
+  ASSERT_STREQ(result.hybridParams->aggregationParams.common.scoreAlias, "fused_score");
+}
+
+TEST_F(ParseHybridTest, testRRFFullArgsYieldScoreCounted) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "RRF", "6", "CONSTANT", "70", "WINDOW", "15",
+        "YIELD_SCORE_AS", "fused_score",
+      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  parseCommand(args);
+  assertRRFScoringCtx(70, 15);
+  ASSERT_STREQ(result.hybridParams->aggregationParams.common.scoreAlias, "fused_score");
+}
+
+TEST_F(ParseHybridTest, testLinearFullArgsYieldScoreCounted) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "LINEAR", "8", "ALPHA", "0.55", "BETA", "0.45", "WINDOW", "30",
+        "YIELD_SCORE_AS", "fused_score",
+      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  parseCommand(args);
+  assertLinearScoringCtx(0.55, 0.45, 30);
+  ASSERT_STREQ(result.hybridParams->aggregationParams.common.scoreAlias, "fused_score");
+}
+
+// ============================================================================
+// No COMBINE clause, but PARAMS contains COMBINE token
+// ============================================================================
+
+TEST_F(ParseHybridTest, testRRFCombineTokenInParams) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "$q", "VSIM", "@vector", "$BLOB",
+      "PARAMS", "6", "BLOB", TEST_BLOB_DATA, "q", "hello", "COMBINE", "value");
+  parseCommand(args);
+  // Verify default scoring type is RRF
+  assertRRFScoringCtx(HYBRID_DEFAULT_RRF_CONSTANT, HYBRID_DEFAULT_WINDOW);
+}
+
+TEST_F(ParseHybridTest, testLinearCombineTokenInParams) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "$q", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "LINEAR", "4", "ALPHA", "0.9", "BETA", "0.1",
+      "PARAMS", "6", "BLOB", TEST_BLOB_DATA, "q", "hello", "COMBINE", "value");
+  parseCommand(args);
+  assertLinearScoringCtx(0.9, 0.1, HYBRID_DEFAULT_WINDOW);
+}
+
+// ============================================================================
+// HYBRID + YIELD_SCORE_AS error cases
+// ============================================================================
+
+TEST_F(ParseHybridTest, testRRFCountedAndPositionalYieldScoreError) {
   // Alias given both counted (inside count 4) and positionally -> rejected
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
       "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
       "COMBINE", "RRF", "4", "CONSTANT", "60", "YIELD_SCORE_AS", "a",
+      "YIELD_SCORE_AS", "b",
+      "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "YIELD_SCORE_AS specified more than once");
+}
+
+TEST_F(ParseHybridTest, testLinearCountedAndPositionalYieldScoreError) {
+  // Alias given both counted (inside count 6) and positionally -> rejected
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+      "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
+      "COMBINE", "LINEAR", "6", "ALPHA", "0.7", "BETA", "0.3", "YIELD_SCORE_AS", "a",
       "YIELD_SCORE_AS", "b",
       "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
   testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "YIELD_SCORE_AS specified more than once");

--- a/tests/pytests/test_hybrid_linear.py
+++ b/tests/pytests/test_hybrid_linear.py
@@ -72,7 +72,7 @@ def test_hybrid_linear_default_weights():
         'VSIM', '@embedding', '$BLOB',
             'KNN', '2', 'K', '10',
             'YIELD_SCORE_AS', 'v_score',
-        'COMBINE', 'LINEAR', '2',
+        'COMBINE', 'LINEAR', '0',
             'YIELD_SCORE_AS', 'fused_score',
         'PARAMS', '2', 'BLOB', query_vector)
     results, _ = get_results_from_hybrid_response(response)
@@ -115,7 +115,7 @@ def test_hybrid_linear_explicit_weights():
         'VSIM', '@embedding', '$BLOB',
             'KNN', '2', 'K', '10',
             'YIELD_SCORE_AS', 'v_score',
-        'COMBINE', 'LINEAR', '6', 'ALPHA', alpha, 'BETA', beta,
+        'COMBINE', 'LINEAR', '4', 'ALPHA', alpha, 'BETA', beta,
             'YIELD_SCORE_AS', 'fused_score',
         'PARAMS', '2', 'BLOB', query_vector)
     results, _ = get_results_from_hybrid_response(response)

--- a/tests/pytests/test_hybrid_load.py
+++ b/tests/pytests/test_hybrid_load.py
@@ -182,7 +182,7 @@ def test_load_all_docs_and_yield():
                 'YIELD_SCORE_AS', 'search_score',
             'VSIM', '@vector', '$BLOB',
                 'YIELD_SCORE_AS', 'vector_score',
-            'COMBINE', 'LINEAR', '6', 'ALPHA', 0.3, 'BETA', 0.7,
+            'COMBINE', 'LINEAR', '4', 'ALPHA', 0.3, 'BETA', 0.7,
                 'YIELD_SCORE_AS', 'fused_score',
             'LOAD', '*',
             'PARAMS', '2', 'BLOB', QUERY_VECTOR,

--- a/tests/pytests/test_hybrid_yield.py
+++ b/tests/pytests/test_hybrid_yield.py
@@ -229,7 +229,8 @@ def test_hybrid_search_yield_score_as_after_combine():
     # YIELD_SCORE_AS after COMBINE should work
     response = env.cmd(
         'FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', '$BLOB',
-        'COMBINE', 'RRF', '4', 'CONSTANT', '60', 'YIELD_SCORE_AS', 'search_score',
+        'COMBINE', 'RRF', '2', 'CONSTANT', '60',
+            'YIELD_SCORE_AS', 'search_score',
         'PARAMS', '2', 'BLOB', query_vector)
     results, _ = get_results_from_hybrid_response(response)
 
@@ -241,6 +242,138 @@ def test_hybrid_search_yield_score_as_after_combine():
         env.assertTrue('search_score' in doc_result)
         search_score = float(doc_result['search_score'])
         env.assertGreater(search_score, 0)
+
+def test_hybrid_combine_yield_score_as_both_forms():
+    """YIELD_SCORE_AS after COMBINE is accepted in two equivalent forms for
+    backward compatibility: counted inside the method argument count (legacy),
+    and positional after the method block (current). Both must succeed and
+    produce the same results."""
+    env = Env()
+    setup_basic_index(env)
+    query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
+
+    # Counted form: count 4 covers CONSTANT 60 YIELD_SCORE_AS search_score
+    counted, _ = get_results_from_hybrid_response(env.cmd(
+        'FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', '$BLOB',
+        'COMBINE', 'RRF', '4', 'CONSTANT', '60', 'YIELD_SCORE_AS', 'search_score',
+        'PARAMS', '2', 'BLOB', query_vector))
+
+    # Positional form: count 2 covers CONSTANT 60, YIELD_SCORE_AS follows
+    positional, _ = get_results_from_hybrid_response(env.cmd(
+        'FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', '$BLOB',
+        'COMBINE', 'RRF', '2', 'CONSTANT', '60', 'YIELD_SCORE_AS', 'search_score',
+        'PARAMS', '2', 'BLOB', query_vector))
+
+    env.assertGreater(len(counted.keys()), 0)
+    for results in (counted, positional):
+        for doc_key in results:
+            env.assertTrue('search_score' in results[doc_key])
+            env.assertGreater(float(results[doc_key]['search_score']), 0)
+    env.assertEqual(counted, positional,
+                    message="Counted and positional YIELD_SCORE_AS must be equivalent")
+
+def test_hybrid_combine_duplicate_yield_score_as_error():
+    """A duplicate YIELD_SCORE_AS after the COMBINE clause is rejected."""
+    env = Env()
+    setup_basic_index(env)
+    query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
+
+    env.expect(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'shoes',
+        'VSIM', '@embedding', '$BLOB',
+        'COMBINE', 'RRF', '2', 'CONSTANT', '60',
+            'YIELD_SCORE_AS', 'score1',
+            'YIELD_SCORE_AS', 'score2',
+        'PARAMS', '2', 'BLOB', query_vector)\
+            .error().contains('YIELD_SCORE_AS: Unknown argument')
+
+def test_hybrid_combine_missing_argument():
+    """Test that missing argument value for YIELD_SCORE_AS after COMBINE clause
+    results in an error"""
+    env = Env()
+    setup_basic_index(env)
+
+    env.expect(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'shoes',
+        'VSIM', '@embedding', '$BLOB',
+        'COMBINE', 'RRF', '2', 'CONSTANT', '60',
+            'YIELD_SCORE_AS')\
+            .error().contains('Missing argument value for YIELD_SCORE_AS')
+
+def test_hybrid_combine_without_fusion():
+    """Test that COMBINE without a fusion method fails"""
+    env = Env()
+    setup_basic_index(env)
+    query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
+
+    env.expect(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'shoes',
+        'VSIM', '@embedding', '$BLOB',
+        'COMBINE',
+            'YIELD_SCORE_AS', 'score1',
+        'PARAMS', '2', 'BLOB', query_vector)\
+            .error().contains('COMBINE: Invalid value for argument')
+
+def test_hybrid_linear_combine_and_fused_score():
+    """Test that COMBINE with LINEAR method and count of 0 is supported"""
+    env = Env()
+    setup_basic_index(env)
+    query_vector = np.array([1.2, 0.3]).astype(np.float32).tobytes()
+
+    res = env.cmd(
+        'FT.HYBRID', 'idx',
+            'SEARCH', 'blue',
+            'VSIM', '@embedding', '$BLOB',
+            'COMBINE', 'LINEAR', '0',
+            'YIELD_SCORE_AS', 'fuse_score',
+        'PARAMS', '2', 'BLOB', query_vector)
+    results, _ = get_results_from_hybrid_response(res)
+
+    # Execute the same command with COMBINE with LINEAR method to verify that
+    # the results are the same
+    res_with_linear = env.cmd(
+        'FT.HYBRID', 'idx',
+            'SEARCH', 'blue',
+            'VSIM', '@embedding', '$BLOB',
+            'COMBINE', 'LINEAR', '4', 'ALPHA', '0.3', 'BETA', '0.7',
+            'YIELD_SCORE_AS', 'fuse_score',
+        'PARAMS', '2', 'BLOB', query_vector)
+    results_with_linear, _ = get_results_from_hybrid_response(res_with_linear)
+
+    env.assertEqual(results, results_with_linear,
+                    message="Results with COMBINE LINEAR count 0 should match results with COMBINE LINEAR count 4")
+
+def test_hybrid_rrf_combine_and_fused_score():
+    """Test that COMBINE with RRF method and count of 0 is supported"""
+    env = Env()
+    setup_basic_index(env)
+    query_vector = np.array([1.2, 0.3]).astype(np.float32).tobytes()
+
+    res = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'blue',
+        'VSIM', '@embedding', '$BLOB',
+        'COMBINE', 'RRF', '0',
+        'YIELD_SCORE_AS', 'fused_score',
+        'PARAMS', '2', 'BLOB', query_vector)
+    results, _ = get_results_from_hybrid_response(res)
+
+    # Execute the same command with COMBINE with RRF method to verify that
+    # the results are the same
+    res_with_rrf = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'blue',
+        'VSIM', '@embedding', '$BLOB',
+        'COMBINE', 'RRF', '2', 'CONSTANT', '60',
+        'YIELD_SCORE_AS', 'fused_score',
+        'PARAMS', '2', 'BLOB', query_vector)
+    results_with_rrf, _ = get_results_from_hybrid_response(res_with_rrf)
+
+    env.assertEqual(results, results_with_rrf,
+                    message="Results with COMBINE RRF count 0 should match results with COMBINE RRF constant 60")
 
 def test_hybrid_multiple_yield_after_combine_error():
     """Test that multiple YIELD parameters after COMBINE keyword fail"""
@@ -270,7 +403,7 @@ def test_hybrid_yield_score_as_all_possible_scores():
         'VSIM', '@embedding', '$BLOB',
             'KNN', '2', 'K', '10',
             'YIELD_SCORE_AS', 'v_score',
-        'COMBINE', 'LINEAR', '6', 'ALPHA', alpha, 'BETA', beta,
+        'COMBINE', 'LINEAR', '4', 'ALPHA', alpha, 'BETA', beta,
             'YIELD_SCORE_AS', 'fused_score',
         'APPLY', f"{alpha}*case(exists(@s_score), @s_score ,0) + {beta}*case(exists(@v_score), @v_score,0)", 'AS', 'calculated_score',
         'PARAMS', '2', 'BLOB', query_vector)


### PR DESCRIPTION
## Description

Current: 
`FT.HYBRID ... COMBINE ... YIELD_SCORE_AS` supports the fused-score alias only in the existing counted form, where `YIELD_SCORE_AS <alias>` is included inside the `COMBINE` method argument count.

Change: 
Add support for a positional `YIELD_SCORE_AS <alias>` after the `COMBINE` method argument block, while keeping the existing counted form accepted for backward compatibility. The coordinator reconstructs the distributed `COMBINE` clause from resolved scoring parameters before dispatching to shards, emitting an old-shard-compatible counted form with explicit scoring arguments and the alias folded into the count when present.

Outcome: 
Users can write `YIELD_SCORE_AS` in either counted or positional form, existing queries continue to work, `COMBINE ... 0` resolves to default scoring parameters, and mixed-version cluster dispatch avoids sending positional or zero-count `COMBINE` forms to older shards.

#### Which additional issues this PR fixes
1. MOD-16121

#### Main objects this PR modified
1. `src/hybrid/parse/hybrid_combine.c` - accepts counted and positional fused-score aliases, supports zero-count default COMBINE args.
2. `src/coord/hybrid/dist_hybrid.c` / `.h` - reconstructs distributed COMBINE wire params from resolved scoring context.
3. `commands.json` / `src/command_info/command_info.c` - updates command metadata for the positional alias form.
4. `tests/cpptests/test_cpp_parse_hybrid.cpp` - covers parser compatibility for both forms.
5. `tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp` - covers coordinator COMBINE reconstruction.
6. `tests/pytests/test_hybrid_yield.py`, `test_hybrid_linear.py`, `test_hybrid_load.py` - covers end-to-end alias behavior.

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes