### PR TITLE
[MOD-16940] FT.INFO: fix num_records going negative after GC on INDEXMISSING fields

### DIFF
--- a/src/fork_gc/missing_docs.c
+++ b/src/fork_gc/missing_docs.c
@@ -99,7 +99,13 @@ FGCError FGC_parentHandleMissingDocs(ForkGC *gc) {
     IndexStats_BlockCountAdd(&sctx->spec->stats, -(int64_t)InvertedIndex_NumBlocks(idx));
     dictDelete(sctx->spec->missingFieldDict, fieldName);
   }
-  FGC_updateStats(gc, sctx, info.entries_removed, info.bytes_freed, info.bytes_allocated, info.ignored_last_block);
+  // Pass 0 for recordsRemoved: missing-field index entries are not counted in
+  // spec->stats.numRecords on insertion (writeMissingFieldDocs updates invertedSize
+  // and the block count but not numRecords), so subtracting them here underflows
+  // numRecords (it can go negative once enough missing-field docs are collected).
+  // This matches the existing-docs GC, which deliberately passes 0 for the same
+  // reason. invertedSize IS accounted on insertion, so its bytes are still applied.
+  FGC_updateStats(gc, sctx, 0, info.bytes_freed, info.bytes_allocated, info.ignored_last_block);
 
 cleanup:
 

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -51,6 +51,41 @@ def testBasicGCWithEmptyInvIdx(env):
     env.expect(debug_cmd(), 'DUMP_INVIDX', 'idx', 'world').error().contains('Can not find the inverted index')
 
 @skip(cluster=True)
+def testGCMissingFieldNumRecords(env):
+    # Regression: deleting documents indexed in a missing-field (INDEXMISSING)
+    # inverted index must not underflow the spec's num_records. Missing-field
+    # entries are not counted in num_records on insertion, so the fork GC must
+    # not subtract them on removal (it previously did, driving num_records
+    # negative once enough missing-field docs were collected).
+    env.expect(config_cmd(), 'set', 'FORK_GC_CLEAN_THRESHOLD', 0).equal('OK')
+    env.assertOk(env.cmd('ft.create', 'idx', 'schema', 't', 'text', 'm', 'tag', 'INDEXMISSING'))
+    waitForIndex(env, 'idx')
+
+    n = 100
+    for i in range(n):
+        # Even docs carry field `m`; odd docs are missing it (populating the
+        # missing-field index for `m`).
+        if i % 2 == 0:
+            env.cmd('hset', f'doc{i}', 't', 'hello', 'm', 'x')
+        else:
+            env.cmd('hset', f'doc{i}', 't', 'hello')
+
+    # Half the docs are missing `m`.
+    env.assertEqual(env.cmd('ft.search', 'idx', 'ismissing(@m)', 'LIMIT', 0, 0, 'DIALECT', 2)[0], n // 2)
+    before = int(index_info(env, 'idx')['num_records'])
+    env.assertGreater(before, 0)
+
+    # Delete everything and collect.
+    for i in range(n):
+        env.cmd('del', f'doc{i}')
+    forceInvokeGC(env, 'idx')
+
+    # num_records must return to 0 -- and above all must never be negative.
+    after = int(index_info(env, 'idx')['num_records'])
+    env.assertEqual(after, 0)
+    env.assertGreaterEqual(after, 0)
+
+@skip(cluster=True)
 def testNumericGCIntensive(env):
     NumberOfDocs = 1000
     env.expect(config_cmd(), 'set', 'FORK_GC_CLEAN_THRESHOLD', 0).equal('OK')


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** Documents indexed in a missing-field (`INDEXMISSING`) inverted index are written to that index (updating `invertedSize` + block count) but are **not** counted in the spec's `num_records`. When those documents are later deleted, however, the missing-docs fork GC subtracts the removed entries from `num_records` via `FGC_updateStats`. Because removal is accounted while insertion is not, `num_records` (reported by `FT.INFO`) can go **negative**. Example: an index with a text field and an `INDEXMISSING` field, half the docs missing it — `FT.INFO` reports `num_records = 30000`, then after deleting all docs and running GC it reports `num_records = -10000`. Reproduces on current `master` with the default fork GC (RAM indexes, standalone).
2. **Change:** Make the missing-docs GC pass `0` for the removed-records count in `FGC_updateStats`, matching the parallel existing-docs GC — which already does exactly this, with the note *"existingDocs entries are not counted on insertion."* `invertedSize` **is** accounted on insertion, so its bytes are still subtracted on GC (unchanged).
3. **Outcome:** `num_records` stays consistent — it returns to `0` when all documents are deleted and never underflows for indexes with `INDEXMISSING` fields.

#### Which additional issues this PR fixes
1. MOD-16940

#### Main objects this PR modified
1. `src/fork_gc/missing_docs.c` — `FGC_parentHandleMissingDocs` passes `0` for `recordsRemoved`.
2. `tests/pytests/test_gc.py` — new regression test `testGCMissingFieldNumRecords`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: fixes `FT.INFO` `num_records` going negative after garbage collection on indexes with `INDEXMISSING` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
