### PR TITLE
[2.10] CI: retry setup dependency installs to survive mirror blips

### DIFF
--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -59,11 +59,29 @@ jobs:
       # Build command
       BUILD_CMD: echo '::group::Build' && make build VERBOSE= GIT_BRANCH=$BRANCH && echo '::endgroup::'
       GITHUB_REPOSITORY: ${{ github.repository }}
+      # Retry wrapper for setup scripts: transient package-manager failures
+      # (e.g. `apt update` hitting a flaky Ubuntu ports mirror on ARM64 runners)
+      # should not fail the whole job. `{0}` is replaced with the command via `format`.
+      SETUP_RETRY_LOOP: |
+        SUCCESS=0
+        for i in 1 2 3 4 5; do
+          echo "Attempt $i of 5"
+          if {0}; then
+            echo "Setup succeeded"
+            SUCCESS=1
+            break
+          fi
+          if [ $i -lt 5 ]; then
+            echo "Setup failed, retrying in 30 seconds..."
+            sleep 30
+          fi
+        done
+        [ $SUCCESS -eq 1 ] || exit 1
     steps:
       # Setup
       - name: Pre-steps Dependencies
         if: needs.get-config.outputs.setup_script
-        run: ${{ needs.get-config.outputs.setup_script }}
+        run: ${{ format(env.SETUP_RETRY_LOOP, needs.get-config.outputs.setup_script) }}
       - name: Get Installation Mode
         id: mode
         run: |

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -53,6 +53,24 @@ env:
   REJSON: ${{ inputs.rejson && 1 || 0 }}  # convert the boolean input to numeric
   VERBOSE_UTESTS: 1
   COV: ${{ inputs.coverage && 1 || 0 }}  # convert the boolean input to numeric
+  # Retry wrapper for setup scripts: transient package-manager failures
+  # (e.g. `apt update` hitting a flaky Ubuntu ports mirror on ARM64 runners)
+  # should not fail the whole job. `{0}` is replaced with the command via `format`.
+  SETUP_RETRY_LOOP: |
+    SUCCESS=0
+    for i in 1 2 3 4 5; do
+      echo "Attempt $i of 5"
+      if {0}; then
+        echo "Setup succeeded"
+        SUCCESS=1
+        break
+      fi
+      if [ $i -lt 5 ]; then
+        echo "Setup failed, retrying in 30 seconds..."
+        sleep 30
+      fi
+    done
+    [ $SUCCESS -eq 1 ] || exit 1
 
 jobs:
   # Get configuration for this specific platform and architecture
@@ -75,7 +93,7 @@ jobs:
     steps:
       - name: Pre-steps Dependencies
         if: needs.get-config.outputs.setup_script
-        run: ${{ needs.get-config.outputs.setup_script }}
+        run: ${{ format(env.SETUP_RETRY_LOOP, needs.get-config.outputs.setup_script) }}
 
       - name: Get Installation Mode
         id: mode


### PR DESCRIPTION
**Describe the changes in the pull request**

1. **Current state:** The `Pre-steps Dependencies` step in `task-test.yml` and `task-build-artifacts.yml` runs each platform's setup script (e.g. `apt update && apt install -y git`) exactly once, with no retry. Transient package-manager failures — most often `apt update` hitting a flaky Ubuntu ports mirror on **ARM64 container jobs** (exit code 100) — fail the whole job. Because the test matrix is fail-fast, one such blip cancels every sibling job and blocks the entire 2.10 merge queue, regardless of the PR being merged. This has been recurring on the 2.10 merge queue (e.g. [run 29484488597](https://github.com/RediSearch/RediSearch/actions/runs/29484488597), `ubuntu:jammy (aarch64)`; the run before it, `ubuntu:focal (aarch64)`).

2. **Change:** Wrap the setup script in the `SETUP_RETRY_LOOP` helper (5 attempts, 30s backoff), exactly as `master`, `8.6`, `8.6-rse`, and `8.8` already do. This robustness mechanism was introduced on master in #7748 and was simply never backported to 2.10.

3. **Outcome:** A single transient mirror failure is retried instead of failing the job, so the 2.10 merge queue is no longer blocked by infra blips.

CI-only change — no product code or behavior is affected.

**Original PR**
- #7748 — the master PR that introduced the `SETUP_RETRY_LOOP` setup-retry mechanism this backports.

**Which issues this PR fixes**
1. Recurring 2.10 merge-queue failures at `Pre-steps Dependencies` (apt exit code 100 on ARM64 containers)

**Main objects this PR modified**
1. `.github/workflows/task-test.yml`
2. `.github/workflows/task-build-artifacts.yml`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)