### PR TITLE
[MOD-16948] test(vector_score_source): serialize tests sharing the global VecSim timeout callback

### DIFF
--- a/src/redisearch_rs/vector_score_source/tests/integration/source_pytest_parity.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source_pytest_parity.rs
@@ -19,15 +19,11 @@
 //! Data model (shared with `source.rs`): unless noted, doc `i` is `[i; dim]`
 //! under L2, so distance to query `[q; dim]` is `dim*(q-i)^2`.
 
-use std::{
-    ffi::c_void,
-    num::NonZeroUsize,
-    sync::{Mutex, MutexGuard, PoisonError},
-};
+use std::num::NonZeroUsize;
 
 use ffi::VecSimIndex_Free;
 use rqe_core::DocId;
-use rqe_iterators::{RQEIterator, RQEIteratorError};
+use rqe_iterators::RQEIterator;
 use top_k::{TopKIterator, TopKMode};
 use vector_score_source::test_utils::{
     asc, build_flat_cosine_index, build_flat_index, build_hnsw_index, collect_ids, make_child,
@@ -35,36 +31,12 @@ use vector_score_source::test_utils::{
 };
 use vector_score_source::{new_vector_top_k_filtered, new_vector_top_k_unfiltered};
 
-/// Serializes every test in this file against VecSim's *process-global* timeout
-/// callback (`VecSim_SetTimeoutCallbackFunction`).
-///
-/// The `*_propagates_timeout` tests install an `always_timed_out` callback via
-/// [`MockTimeout`]; every other test runs a VecSim query that consults that same
-/// global. Under `cargo nextest` each test is its own process, so the mutation
-/// is naturally isolated — but the coverage lane runs `cargo llvm-cov test`
-/// (plain multithreaded libtest, one process), where a concurrent query test
-/// would observe the mutated callback and spuriously fail with `TimedOut`.
-/// Holding this lock for the whole test body keeps the mutation exclusive on
-/// every harness. It is uncontended (and effectively free) under nextest.
-static VECSIM_TIMEOUT_LOCK: Mutex<()> = Mutex::new(());
-
-/// Acquire [`VECSIM_TIMEOUT_LOCK`] for the caller's scope. Recovers from a
-/// poisoned lock so a genuinely failing test surfaces its own panic instead of
-/// cascading into every sibling that takes the lock afterwards.
-#[must_use]
-fn serialize_vecsim_test() -> MutexGuard<'static, ()> {
-    VECSIM_TIMEOUT_LOCK
-        .lock()
-        .unwrap_or_else(PoisonError::into_inner)
-}
-
 // FLAT backend coverage (source.rs only exercises HNSW).
 
 /// From `test_hybrid_query_batches_mode_with_text`: unfiltered KNN on FLAT.
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn flat_unfiltered_returns_top_k_nearest_by_score() {
-    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (100, 10, 4);
     let index = build_flat_index(n, dim);
 
@@ -85,7 +57,6 @@ fn flat_unfiltered_returns_top_k_nearest_by_score() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn flat_filtered_full_child_yields_best_first() {
-    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (100, 10, 4);
     let index = build_flat_index(n, dim);
 
@@ -109,7 +80,6 @@ fn flat_filtered_full_child_yields_best_first() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn cosine_metric_filtered_top_k_are_highest_ids() {
-    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (100, 10, 4);
     let index = build_flat_cosine_index(n, dim);
 
@@ -139,7 +109,6 @@ fn cosine_metric_filtered_top_k_are_highest_ids() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn middle_query_orders_by_distance_then_lower_id() {
-    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (100usize, 10usize, 4usize);
     let mid = (n / 2) as DocId;
     let index = build_flat_index(n, dim);
@@ -168,7 +137,6 @@ fn middle_query_orders_by_distance_then_lower_id() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn dim1_unfiltered_knn_top3() {
-    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (10, 3, 1);
     let index = build_flat_index(n, dim);
 
@@ -191,7 +159,6 @@ fn dim1_unfiltered_knn_top3() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn dim1_filtered_subset_knn_top3() {
-    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (10, 3, 1);
     let index = build_flat_index(n, dim);
 
@@ -216,7 +183,6 @@ fn dim1_filtered_subset_knn_top3() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn batches_switch_to_adhoc_yields_no_duplicates() {
-    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (10, 3, 1);
     let index = build_flat_index(n, dim);
 
@@ -251,7 +217,6 @@ fn batches_switch_to_adhoc_yields_no_duplicates() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn small_index_prefers_adhoc() {
-    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (1000, 10, 4);
     let index = build_hnsw_index(n, dim);
 
@@ -270,7 +235,6 @@ fn small_index_prefers_adhoc() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn numeric_like_subset_batches_matches_adhoc() {
-    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (200, 10, 4);
     let child_ids: Vec<DocId> = (150..=n as DocId).collect();
     let expected: Vec<DocId> = ((n as DocId - 9)..=n as DocId).rev().collect();
@@ -300,7 +264,6 @@ fn numeric_like_subset_batches_matches_adhoc() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn custom_k_returns_exactly_k() {
-    let _serial = serialize_vecsim_test();
     let dim = 4;
     let n = 100;
     for k in [2usize, 5] {
@@ -317,90 +280,4 @@ fn custom_k_returns_exactly_k() {
         // SAFETY: no live references to the index remain.
         unsafe { VecSimIndex_Free(index.as_ptr()) };
     }
-}
-
-unsafe extern "C" {
-    fn VecSim_SetTimeoutCallbackFunction(
-        cb: Option<unsafe extern "C" fn(*mut c_void) -> std::ffi::c_int>,
-    );
-}
-
-unsafe extern "C" fn always_timed_out(_ctx: *mut c_void) -> std::ffi::c_int {
-    1
-}
-
-unsafe extern "C" fn never_timed_out(_ctx: *mut c_void) -> std::ffi::c_int {
-    0
-}
-
-/// Installs the always-timeout callback; restores the no-op on drop so a
-/// panicking assertion cannot leak timeout state to later tests.
-///
-/// The mutated callback is process-global, so callers must hold
-/// [`VECSIM_TIMEOUT_LOCK`] (via [`serialize_vecsim_test`]) for the lifetime of
-/// this guard — acquire it *before* `enable()` and keep it until *after* this
-/// guard drops — so no concurrent query test observes the mutation.
-struct MockTimeout;
-impl MockTimeout {
-    fn enable() -> Self {
-        // SAFETY: the fn pointer is valid for the whole program.
-        unsafe { VecSim_SetTimeoutCallbackFunction(Some(always_timed_out)) };
-        MockTimeout
-    }
-}
-impl Drop for MockTimeout {
-    fn drop(&mut self) {
-        // SAFETY: the fn pointer is valid for the whole program.
-        unsafe { VecSim_SetTimeoutCallbackFunction(Some(never_timed_out)) };
-    }
-}
-
-/// From `test_vecsim.py::TestTimeoutReached` (KNN branch).
-#[test]
-#[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
-fn unfiltered_propagates_timeout() {
-    // Acquire before enable() so the global-callback mutation stays exclusive;
-    // released after `_mock` restores the callback (reverse drop order).
-    let _serial = serialize_vecsim_test();
-    let (n, k, dim) = (100, 10, 4);
-    let index = build_hnsw_index(n, dim);
-    let _mock = MockTimeout::enable();
-
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, uniform_blob(n as f32, dim), n, k, n) };
-    let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
-
-    assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
-}
-
-/// From `test_vecsim.py::TestTimeoutReached` (hybrid BATCHES branch).
-#[test]
-#[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
-fn batches_propagates_timeout() {
-    // Acquire before enable() so the global-callback mutation stays exclusive;
-    // released after `_mock` restores the callback (reverse drop order).
-    let _serial = serialize_vecsim_test();
-    let (n, k, dim) = (100, 10, 4);
-    let index = build_hnsw_index(n, dim);
-    let _mock = MockTimeout::enable();
-
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, uniform_blob(n as f32, dim), n, k, n) };
-    let mut it = TopKIterator::new_with_mode(
-        source,
-        Some(make_child((1..=n as DocId).collect())),
-        NonZeroUsize::new(k).unwrap(),
-        asc,
-        TopKMode::Batches,
-    );
-
-    assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }

--- a/src/redisearch_rs/vector_score_source/tests/integration/source_pytest_parity.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source_pytest_parity.rs
@@ -19,7 +19,11 @@
 //! Data model (shared with `source.rs`): unless noted, doc `i` is `[i; dim]`
 //! under L2, so distance to query `[q; dim]` is `dim*(q-i)^2`.
 
-use std::{ffi::c_void, num::NonZeroUsize};
+use std::{
+    ffi::c_void,
+    num::NonZeroUsize,
+    sync::{Mutex, MutexGuard, PoisonError},
+};
 
 use ffi::VecSimIndex_Free;
 use rqe_core::DocId;
@@ -31,12 +35,36 @@ use vector_score_source::test_utils::{
 };
 use vector_score_source::{new_vector_top_k_filtered, new_vector_top_k_unfiltered};
 
+/// Serializes every test in this file against VecSim's *process-global* timeout
+/// callback (`VecSim_SetTimeoutCallbackFunction`).
+///
+/// The `*_propagates_timeout` tests install an `always_timed_out` callback via
+/// [`MockTimeout`]; every other test runs a VecSim query that consults that same
+/// global. Under `cargo nextest` each test is its own process, so the mutation
+/// is naturally isolated — but the coverage lane runs `cargo llvm-cov test`
+/// (plain multithreaded libtest, one process), where a concurrent query test
+/// would observe the mutated callback and spuriously fail with `TimedOut`.
+/// Holding this lock for the whole test body keeps the mutation exclusive on
+/// every harness. It is uncontended (and effectively free) under nextest.
+static VECSIM_TIMEOUT_LOCK: Mutex<()> = Mutex::new(());
+
+/// Acquire [`VECSIM_TIMEOUT_LOCK`] for the caller's scope. Recovers from a
+/// poisoned lock so a genuinely failing test surfaces its own panic instead of
+/// cascading into every sibling that takes the lock afterwards.
+#[must_use]
+fn serialize_vecsim_test() -> MutexGuard<'static, ()> {
+    VECSIM_TIMEOUT_LOCK
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
+
 // FLAT backend coverage (source.rs only exercises HNSW).
 
 /// From `test_hybrid_query_batches_mode_with_text`: unfiltered KNN on FLAT.
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn flat_unfiltered_returns_top_k_nearest_by_score() {
+    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (100, 10, 4);
     let index = build_flat_index(n, dim);
 
@@ -57,6 +85,7 @@ fn flat_unfiltered_returns_top_k_nearest_by_score() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn flat_filtered_full_child_yields_best_first() {
+    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (100, 10, 4);
     let index = build_flat_index(n, dim);
 
@@ -80,6 +109,7 @@ fn flat_filtered_full_child_yields_best_first() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn cosine_metric_filtered_top_k_are_highest_ids() {
+    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (100, 10, 4);
     let index = build_flat_cosine_index(n, dim);
 
@@ -109,6 +139,7 @@ fn cosine_metric_filtered_top_k_are_highest_ids() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn middle_query_orders_by_distance_then_lower_id() {
+    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (100usize, 10usize, 4usize);
     let mid = (n / 2) as DocId;
     let index = build_flat_index(n, dim);
@@ -137,6 +168,7 @@ fn middle_query_orders_by_distance_then_lower_id() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn dim1_unfiltered_knn_top3() {
+    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (10, 3, 1);
     let index = build_flat_index(n, dim);
 
@@ -159,6 +191,7 @@ fn dim1_unfiltered_knn_top3() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn dim1_filtered_subset_knn_top3() {
+    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (10, 3, 1);
     let index = build_flat_index(n, dim);
 
@@ -183,6 +216,7 @@ fn dim1_filtered_subset_knn_top3() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn batches_switch_to_adhoc_yields_no_duplicates() {
+    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (10, 3, 1);
     let index = build_flat_index(n, dim);
 
@@ -217,6 +251,7 @@ fn batches_switch_to_adhoc_yields_no_duplicates() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn small_index_prefers_adhoc() {
+    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (1000, 10, 4);
     let index = build_hnsw_index(n, dim);
 
@@ -235,6 +270,7 @@ fn small_index_prefers_adhoc() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn numeric_like_subset_batches_matches_adhoc() {
+    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (200, 10, 4);
     let child_ids: Vec<DocId> = (150..=n as DocId).collect();
     let expected: Vec<DocId> = ((n as DocId - 9)..=n as DocId).rev().collect();
@@ -264,6 +300,7 @@ fn numeric_like_subset_batches_matches_adhoc() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn custom_k_returns_exactly_k() {
+    let _serial = serialize_vecsim_test();
     let dim = 4;
     let n = 100;
     for k in [2usize, 5] {
@@ -299,7 +336,10 @@ unsafe extern "C" fn never_timed_out(_ctx: *mut c_void) -> std::ffi::c_int {
 /// Installs the always-timeout callback; restores the no-op on drop so a
 /// panicking assertion cannot leak timeout state to later tests.
 ///
-/// Concurrent query tests rely on nextest's process isolation.
+/// The mutated callback is process-global, so callers must hold
+/// [`VECSIM_TIMEOUT_LOCK`] (via [`serialize_vecsim_test`]) for the lifetime of
+/// this guard — acquire it *before* `enable()` and keep it until *after* this
+/// guard drops — so no concurrent query test observes the mutation.
 struct MockTimeout;
 impl MockTimeout {
     fn enable() -> Self {
@@ -319,6 +359,9 @@ impl Drop for MockTimeout {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn unfiltered_propagates_timeout() {
+    // Acquire before enable() so the global-callback mutation stays exclusive;
+    // released after `_mock` restores the callback (reverse drop order).
+    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (100, 10, 4);
     let index = build_hnsw_index(n, dim);
     let _mock = MockTimeout::enable();
@@ -338,6 +381,9 @@ fn unfiltered_propagates_timeout() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn batches_propagates_timeout() {
+    // Acquire before enable() so the global-callback mutation stays exclusive;
+    // released after `_mock` restores the callback (reverse drop order).
+    let _serial = serialize_vecsim_test();
     let (n, k, dim) = (100, 10, 4);
     let index = build_hnsw_index(n, dim);
     let _mock = MockTimeout::enable();

--- a/src/redisearch_rs/vector_score_source/tests/vecsim_timeout.rs
+++ b/src/redisearch_rs/vector_score_source/tests/vecsim_timeout.rs
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Timeout-propagation tests for [`VectorScoreSource`], ported from
+//! `test_vecsim.py::TestTimeoutReached`.
+//!
+//! These live in their **own test binary** (hence their own process) on
+//! purpose. They install a *process-global* VecSim timeout callback
+//! (`VecSim_SetTimeoutCallbackFunction`) set to always-timed-out, which any
+//! concurrent VecSim query in the same process would observe. The rest of the
+//! suite (`tests/integration/*`) is full of VecSim query tests; keeping the
+//! timeout tests out of that binary means the global mutation can never reach a
+//! query test, regardless of the harness — `cargo nextest` (process-per-test),
+//! `cargo test`, or the coverage lane's `cargo llvm-cov test` (multithreaded
+//! libtest, one process). See MOD-16948 / PR #10493: relying on nextest's
+//! process isolation alone left the coverage lane racy.
+//!
+//! Within this binary the two tests are still serialized against each other,
+//! because one test's teardown (restoring the no-op callback) would otherwise
+//! clear the always-timed-out callback another test is still asserting on.
+
+use std::{
+    ffi::c_void,
+    num::NonZeroUsize,
+    sync::{Mutex, MutexGuard, PoisonError},
+};
+
+use ffi::VecSimIndex_Free;
+use rqe_core::DocId;
+use rqe_iterators::{RQEIterator, RQEIteratorError};
+use top_k::{TopKIterator, TopKMode};
+use vector_score_source::new_vector_top_k_unfiltered;
+use vector_score_source::test_utils::{
+    asc, build_hnsw_index, make_child, make_source, uniform_blob,
+};
+
+// Provide stubs for C symbols that the linked C archive references but that
+// these tests never exercise (Redis module API surface).
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+extern crate redisearch_rs;
+
+unsafe extern "C" {
+    fn VecSim_SetTimeoutCallbackFunction(
+        cb: Option<unsafe extern "C" fn(*mut c_void) -> std::ffi::c_int>,
+    );
+}
+
+unsafe extern "C" fn always_timed_out(_ctx: *mut c_void) -> std::ffi::c_int {
+    1
+}
+
+unsafe extern "C" fn never_timed_out(_ctx: *mut c_void) -> std::ffi::c_int {
+    0
+}
+
+/// Serializes the two timeout tests against each other: both install a
+/// process-global always-timed-out callback and restore the no-op on drop, so
+/// running them concurrently could let one test's teardown clear the callback
+/// while the other is still asserting on it.
+static TIMEOUT_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// Acquire [`TIMEOUT_TEST_LOCK`] for the caller's scope, recovering from a
+/// poisoned lock so a genuinely failing test surfaces its own panic instead of
+/// cascading into the sibling test.
+#[must_use]
+fn serialize() -> MutexGuard<'static, ()> {
+    TIMEOUT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
+
+/// Installs the always-timeout callback; restores the no-op on drop so a
+/// panicking assertion cannot leak timeout state to the sibling test.
+struct MockTimeout;
+impl MockTimeout {
+    fn enable() -> Self {
+        // SAFETY: the fn pointer is valid for the whole program.
+        unsafe { VecSim_SetTimeoutCallbackFunction(Some(always_timed_out)) };
+        MockTimeout
+    }
+}
+impl Drop for MockTimeout {
+    fn drop(&mut self) {
+        // SAFETY: the fn pointer is valid for the whole program.
+        unsafe { VecSim_SetTimeoutCallbackFunction(Some(never_timed_out)) };
+    }
+}
+
+/// From `test_vecsim.py::TestTimeoutReached` (KNN branch).
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
+fn unfiltered_propagates_timeout() {
+    // Acquire before enable() so the global-callback mutation stays exclusive;
+    // released after `_mock` restores the callback (reverse drop order).
+    let _serial = serialize();
+    let (n, k, dim) = (100, 10, 4);
+    let index = build_hnsw_index(n, dim);
+    let _mock = MockTimeout::enable();
+
+    // SAFETY: index outlives the iterator (freed at end of scope).
+    let source = unsafe { make_source(index, uniform_blob(n as f32, dim), n, k, n) };
+    let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
+
+    assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
+
+    drop(it);
+    // SAFETY: no live references to the index remain.
+    unsafe { VecSimIndex_Free(index.as_ptr()) };
+}
+
+/// From `test_vecsim.py::TestTimeoutReached` (hybrid BATCHES branch).
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
+fn batches_propagates_timeout() {
+    // Acquire before enable() so the global-callback mutation stays exclusive;
+    // released after `_mock` restores the callback (reverse drop order).
+    let _serial = serialize();
+    let (n, k, dim) = (100, 10, 4);
+    let index = build_hnsw_index(n, dim);
+    let _mock = MockTimeout::enable();
+
+    // SAFETY: index outlives the iterator (freed at end of scope).
+    let source = unsafe { make_source(index, uniform_blob(n as f32, dim), n, k, n) };
+    let mut it = TopKIterator::new_with_mode(
+        source,
+        Some(make_child((1..=n as DocId).collect())),
+        NonZeroUsize::new(k).unwrap(),
+        asc,
+        TopKMode::Batches,
+    );
+
+    assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
+
+    drop(it);
+    // SAFETY: no live references to the index remain.
+    unsafe { VecSimIndex_Free(index.as_ptr()) };
+}


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The `source_pytest_parity` integration tests in `vector_score_source` share a *process-global* VecSim timeout callback (`VecSim_SetTimeoutCallbackFunction`). `unfiltered_propagates_timeout` and `batches_propagates_timeout` install an `always_timed_out` callback via the `MockTimeout` helper; every other test in the file runs a VecSim query that consults that same global. Isolation relied entirely on `cargo nextest`'s process-per-test model.
2. **Change:** Guard every test in the file with a shared `Mutex` (`VECSIM_TIMEOUT_LOCK`) held for the whole test body, so a timeout-mutating test can never run concurrently with a query test — regardless of harness. The timeout tests acquire the lock *before* `MockTimeout::enable()` so the global mutation is restored before the lock is released (reverse drop order). Poisoned locks are recovered so a genuine failure surfaces its own panic instead of cascading.
3. **Outcome:** The **coverage** CI lane runs `cargo llvm-cov test` (plain multithreaded libtest, one process — not nextest), where the `always_timed_out` callback leaked into a concurrently-running query test and caused spurious `Err(TimedOut)` panics (e.g. `flat_unfiltered_returns_top_k_nearest_by_score` failing in `collect_ids`). Serializing removes the race on every harness; the lock is uncontended (free) under nextest.

Example failure this fixes: [run 29410915512](https://github.com/RediSearch/RediSearch/actions/runs/29410915512), job "coverage (x86_64) (Standalone)".

#### Which additional issues this PR fixes
1. MOD-16948

#### Main objects this PR modified
1. `src/redisearch_rs/vector_score_source/tests/integration/source_pytest_parity.rs`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Test-only change (fixes a CI-lane test-isolation flake); no user-facing behavior change.
