### PR TITLE
[8.4] CI: skip macOS Intel (x86_64) test runners; keep macOS ARM

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -48,7 +48,9 @@ jobs:
     uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:
-      platform: all
+      # macOS Intel (x86_64) test runners are excluded while the macOS runner
+      # problem is mitigated; macOS ARM still runs.
+      platform: all,!macos-14~x86_64,!macos-15~x86_64,!macos-26~x86_64
       architecture: all
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "QUICK=1", "coverage": "", "sanitize": ""}'

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -50,7 +50,7 @@ jobs:
     with:
       # macOS Intel (x86_64) test runners are excluded while the macOS runner
       # problem is mitigated; macOS ARM still runs.
-      platform: all,!macos-14~x86_64,!macos-15~x86_64,!macos-26~x86_64
+      platform: all,!macos~x86_64
       architecture: all
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "QUICK=1", "coverage": "", "sanitize": ""}'

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -23,7 +23,9 @@ jobs:
     uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:
-      platform: all
+      # macOS Intel (x86_64) test runners are excluded while the macOS runner
+      # problem is mitigated; macOS ARM still runs.
+      platform: all,!macos-14~x86_64,!macos-15~x86_64,!macos-26~x86_64
       architecture: all
       redis-ref: unstable
       job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -25,7 +25,7 @@ jobs:
     with:
       # macOS Intel (x86_64) test runners are excluded while the macOS runner
       # problem is mitigated; macOS ARM still runs.
-      platform: all,!macos-14~x86_64,!macos-15~x86_64,!macos-26~x86_64
+      platform: all,!macos~x86_64
       architecture: all
       redis-ref: unstable
       job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
     inputs:
       platform:
-        description: 'Platform filter, comma-separated list. Use "all" for all platforms, "!platform" to exclude (e.g., "all,!intel")'
+        description: 'Platform filter, comma-separated list. Use "all" for all platforms, "!platform" to exclude a platform on every architecture, and "!platform~arch" to exclude a single platform/architecture combination (e.g., "all,!intel,!macos-26~x86_64")'
         type: string
         default: all
       architecture:
@@ -80,15 +80,27 @@ jobs:
           include_sanitize = "${{ inputs.include-sanitize }}" == "true"
 
           # Parse comma-separated filters
-          platform_list = [p.strip() for p in platform_filter.split(',')]
-          exclude_list = [p[1:] for p in platform_list if p.startswith('!')]
+          platform_list = [p.strip() for p in platform_filter.split(',') if p.strip()]
+          # Exclusions come in two forms:
+          #   "!platform"       -> drop that platform on every architecture
+          #   "!platform~arch"  -> drop a single platform/architecture combination
+          # ("~" separates arch because "-" already appears in platform names, e.g. macos-26.)
+          exclude_platforms = set()
+          exclude_combinations = set()
+          for token in (p[1:] for p in platform_list if p.startswith('!')):
+              platform_part, sep, architecture_part = token.partition('~')
+              if sep:
+                  exclude_combinations.add((platform_part, architecture_part))
+              else:
+                  exclude_platforms.add(platform_part)
 
           # Filter combinations based on inputs
           matrix_items = [
               {'platform': platform, 'architecture': architecture, 'job-type': 'test'}
               for platform, architecture in all_combinations
               if (platform in platform_list or 'all' in platform_list) and
-                 (platform not in exclude_list) and
+                 (platform not in exclude_platforms) and
+                 ((platform, architecture) not in exclude_combinations) and
                  (architecture == architecture_filter or architecture_filter == 'all')
           ]
 


### PR DESCRIPTION
## Describe the changes in the pull request

Backport of #10463 to the `8.4` release branch.

1. **Current:** `8.4` runs the macOS Intel (x86_64) test lane in its merge queue and nightly matrices. Those GitHub runners are emulated and dramatically slower than every other lane, causing recurrent timeout / ephemeral-port-exhaustion flakes that gate the merge queue (the macOS x86_64 runner flakes).
2. **Change:** Exclude the macOS x86_64 *test* combination (`!macos~x86_64`) from the merge-queue and nightly matrices, and add the `!platform~arch` single-combination exclusion syntax to `generate-matrix.yml`.
3. **Outcome:** macOS x86_64 tests no longer gate CI while the runner problem is mitigated; macOS ARM still runs and macOS x86_64 build coverage is unaffected. Mirrors the state already present on 8.10.

#### Which additional issues this PR fixes
1. Backport of #10463

#### Main objects this PR modified
1. `.github/workflows/generate-matrix.yml` — `!platform~arch` exclusion syntax
2. `.github/workflows/event-merge-to-queue.yml` — exclude macOS x86_64 from the merge-queue test matrix
3. `.github/workflows/event-nightly.yml` — exclude macOS x86_64 from the nightly test matrix

#### Changes from original
Adapted for the `8.4` branch layout (differs from master): master restructured the merge queue into a build-only job plus an ubuntu test job, whereas `8.4` keeps its monolithic `test-matrix`, so the exclusion is applied there directly. On this branch the matrix names the macOS platform `macos` (not `macos-<version>`), so the exclusion is `!macos~x86_64` rather than the per-version form used on master. `8.4`'s `generate-matrix.yml` uses the older `all_combinations`/`filtered_combinations` structure; the exclusion parser was ported preserving that structure. There is no `event-periodic-master-validation.yml` on this branch.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI-only change (no user-facing behavior change).
