### PR TITLE
[MOD-16912] Trie - query utf8parse for codepoint boundary

### DIFF
--- a/src/redisearch_rs/trie_rs/src/str_trie_map/automaton/utf8.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/automaton/utf8.rs
@@ -40,9 +40,7 @@ impl CodepointDecoder {
 
     /// `true` when the decoder sits on a codepoint boundary (no bytes pending).
     pub(crate) fn at_boundary(&self) -> bool {
-        // A fresh parser is the unique no-pending-bytes state (ground state,
-        // empty accumulator); Parser exposes no query API, but derives PartialEq.
-        self.parser == Parser::new()
+        self.parser.at_codepoint_boundary()
     }
 
     /// Feed one byte. Returns `Ok(Some(c))` when it completes a codepoint,

--- a/src/redisearch_rs/utf8parse/src/lib.rs
+++ b/src/redisearch_rs/utf8parse/src/lib.rs
@@ -57,6 +57,12 @@ impl Parser {
         }
     }
 
+    /// Returns `true` when the parser expects the start of a new UTF-8 sequence
+    /// (no partially decoded codepoint is pending).
+    pub fn at_codepoint_boundary(&self) -> bool {
+        self.state == State::Ground
+    }
+
     /// Advance the parser
     ///
     /// The provider receiver will be called whenever a codepoint is completed or an invalid


### PR DESCRIPTION
> Triggered by
- https://github.com/RediSearch/RediSearch/pull/10470#discussion_r3585214962

> Stacked on
- #10500

## Describe the changes in the pull request

1. Current: `CodepointDecoder::at_boundary` detects the no-pending-bytes state by comparing the parser against a fresh `Parser::new()` via derived `PartialEq` — a workaround for `utf8parse` exposing no state query API.
2. Change: add `Parser::at_codepoint_boundary()` to the forked `utf8parse` workspace crate (`true` iff the parser is in its `Ground` state; every transition back to ground zeroes the accumulator, so no extra check is needed) and make `at_boundary` delegate to it.
3. Outcome: the boundary check states its intent directly against the parser's state instead of relying on a whole-struct equality probe.

#### Which additional issues this PR fixes
1. MOD-16912

#### Main objects this PR modified
1. `src/redisearch_rs/utf8parse` — `Parser::at_codepoint_boundary`
2. `str_trie_map::automaton::utf8` — `CodepointDecoder::at_boundary`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
