### PR TITLE
[MOD-16365] Fix SEARCH_FIELD_DUP in cluster FT.AGGREGATE when duplicate REDUCE COLLECT calls differ only in option keyword case

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -10,7 +10,6 @@
 #include "aggregate_debug.h"
 #include "search_result_ffi.h"
 #include "reducer.h"
-#include "reducers/collect_parse.h"
 
 #include <cursor.h>
 #include <query.h>
@@ -861,12 +860,6 @@ int PLNGroupStep_AddReducer(PLN_GroupStep *gstp, const char *name, ArgsCursor *a
   if (rv != AC_OK) {
     QERR_MKBADARGS_AC(status, name, rv);
     goto error;
-  }
-
-  // Keyword case must be canonical: getReducerAlias lowercases the args while the reducer
-  // dedup compares bytes (MOD-16365).
-  if (!strcasecmp(name, "COLLECT")) {
-    CollectArgs_NormalizeKeywords(&gr->args);
   }
 
   // See if there is an alias

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -10,6 +10,7 @@
 #include "aggregate_debug.h"
 #include "search_result_ffi.h"
 #include "reducer.h"
+#include "reducers/collect_parse.h"
 
 #include <cursor.h>
 #include <query.h>
@@ -849,46 +850,6 @@ PLN_Reducer *PLNGroupStep_FindReducer(PLN_GroupStep *gstp, const char *name, Arg
   return NULL;
 }
 
-static void asciiToLower(char *s) {
-  for (; *s; s++) {
-    if (*s >= 'A' && *s <= 'Z') {
-      *s += 'a' - 'A';
-    }
-  }
-}
-
-// Bare tokens are unambiguous: COLLECT requires the `@` prefix on every (case-sensitive)
-// field/sort name, so a name can never be mistaken for a keyword.
-static bool isCollectKeyword(const char *tok) {
-  static const char *const keywords[] = {"FIELDS", "SORTBY", "ASC", "DESC", "LIMIT", "DISTINCT"};
-  if (!tok || tok[0] == '@') {
-    return false;
-  }
-  for (size_t i = 0; i < sizeof(keywords) / sizeof(keywords[0]); i++) {
-    if (!strcasecmp(tok, keywords[i])) {
-      return true;
-    }
-  }
-  return false;
-}
-
-// Lowercase COLLECT's option keywords in place so the generated alias (lowercased by
-// getReducerAlias) and the coordinator's byte-wise remote-reducer dedup (AC_Equals) agree.
-// Otherwise two COLLECTs differing only in keyword case get the same synthetic remote alias
-// without deduping, failing the query with SEARCH_FIELD_DUP in cluster (MOD-16365).
-static void normalizeCollectKeywords(const ArgsCursor *args) {
-  if (args->type == AC_TYPE_RSTRING) {
-    return;  // RedisModuleString* tokens, not mutable char buffers (never used for COLLECT)
-  }
-  ArgsCursor it = *args;
-  while (!AC_IsAtEnd(&it)) {
-    char *tok = (char *)AC_GetStringNC(&it, NULL);
-    if (isCollectKeyword(tok)) {
-      asciiToLower(tok);
-    }
-  }
-}
-
 int PLNGroupStep_AddReducer(PLN_GroupStep *gstp, const char *name, ArgsCursor *ac,
                             QueryError *status) {
   // Just a list of functions..
@@ -902,8 +863,10 @@ int PLNGroupStep_AddReducer(PLN_GroupStep *gstp, const char *name, ArgsCursor *a
     goto error;
   }
 
+  // Keyword case must be canonical: getReducerAlias lowercases the args while the reducer
+  // dedup compares bytes (MOD-16365).
   if (!strcasecmp(name, "COLLECT")) {
-    normalizeCollectKeywords(&gr->args);
+    CollectArgs_NormalizeKeywords(&gr->args);
   }
 
   // See if there is an alias

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -849,6 +849,31 @@ PLN_Reducer *PLNGroupStep_FindReducer(PLN_GroupStep *gstp, const char *name, Arg
   return NULL;
 }
 
+// Lowercase an ASCII string in place (avoids locale-dependent tolower()).
+static void asciiToLower(char *s) {
+  for (; *s; s++) {
+    if (*s >= 'A' && *s <= 'Z') {
+      *s += 'a' - 'A';
+    }
+  }
+}
+
+// A COLLECT arg token is an option keyword iff it is bare and matches one of the known
+// keywords. `@`-prefixed tokens are field/sort names, which are case-sensitive; COLLECT
+// requires the `@` prefix on every name, so a bare token can only be a keyword or a number.
+static bool isCollectKeyword(const char *tok) {
+  static const char *const keywords[] = {"FIELDS", "SORTBY", "ASC", "DESC", "LIMIT", "DISTINCT"};
+  if (!tok || tok[0] == '@') {
+    return false;
+  }
+  for (size_t i = 0; i < sizeof(keywords) / sizeof(keywords[0]); i++) {
+    if (!strcasecmp(tok, keywords[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // COLLECT is the only reducer whose argument list interleaves case-insensitive option
 // keywords (FIELDS/SORTBY/ASC/DESC/LIMIT/DISTINCT) with case-sensitive `@field` names.
 // The synthetic reducer alias lowercases the whole arg list (getReducerAlias), but the
@@ -857,25 +882,16 @@ PLN_Reducer *PLNGroupStep_FindReducer(PLN_GroupStep *gstp, const char *name, Arg
 // alias yet fail to dedup, producing two remote reducers with a colliding synthetic alias
 // and failing the query with SEARCH_FIELD_DUP (MOD-16365). Canonicalize the keyword tokens
 // to lowercase up front, on the reducer's own (owned, mutable) arg tokens, so the alias and
-// the dedup agree everywhere the args are later forwarded. `@field`/`@sort` names are left
-// untouched, preserving their case; a bare token can only be a keyword or a number.
-static void normalizeCollectKeywords(ArgsCursor *args) {
-  static const char *const kw[] = {"FIELDS", "SORTBY", "ASC", "DESC", "LIMIT", "DISTINCT"};
+// the dedup agree everywhere the args are later forwarded.
+static void normalizeCollectKeywords(const ArgsCursor *args) {
   if (args->type == AC_TYPE_RSTRING) {
     return;  // tokens are RedisModuleString*, not mutable char buffers (never used for COLLECT)
   }
-  for (size_t i = 0; i < args->argc; i++) {
-    char *tok = (char *)args->objs[i];
-    if (!tok || tok[0] == '@') {
-      continue;  // field/sort names are case-sensitive
-    }
-    for (size_t k = 0; k < sizeof(kw) / sizeof(kw[0]); k++) {
-      if (!strcasecmp(tok, kw[k])) {
-        for (char *p = tok; *p; p++) {
-          if (*p >= 'A' && *p <= 'Z') *p += 'a' - 'A';
-        }
-        break;
-      }
+  ArgsCursor it = *args;  // iterate a copy; the caller's cursor position is untouched
+  while (!AC_IsAtEnd(&it)) {
+    char *tok = (char *)AC_GetStringNC(&it, NULL);
+    if (isCollectKeyword(tok)) {
+      asciiToLower(tok);
     }
   }
 }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -849,7 +849,6 @@ PLN_Reducer *PLNGroupStep_FindReducer(PLN_GroupStep *gstp, const char *name, Arg
   return NULL;
 }
 
-// Lowercase an ASCII string in place (avoids locale-dependent tolower()).
 static void asciiToLower(char *s) {
   for (; *s; s++) {
     if (*s >= 'A' && *s <= 'Z') {
@@ -858,9 +857,8 @@ static void asciiToLower(char *s) {
   }
 }
 
-// A COLLECT arg token is an option keyword iff it is bare and matches one of the known
-// keywords. `@`-prefixed tokens are field/sort names, which are case-sensitive; COLLECT
-// requires the `@` prefix on every name, so a bare token can only be a keyword or a number.
+// Bare tokens are unambiguous: COLLECT requires the `@` prefix on every (case-sensitive)
+// field/sort name, so a name can never be mistaken for a keyword.
 static bool isCollectKeyword(const char *tok) {
   static const char *const keywords[] = {"FIELDS", "SORTBY", "ASC", "DESC", "LIMIT", "DISTINCT"};
   if (!tok || tok[0] == '@') {
@@ -874,20 +872,15 @@ static bool isCollectKeyword(const char *tok) {
   return false;
 }
 
-// COLLECT is the only reducer whose argument list interleaves case-insensitive option
-// keywords (FIELDS/SORTBY/ASC/DESC/LIMIT/DISTINCT) with case-sensitive `@field` names.
-// The synthetic reducer alias lowercases the whole arg list (getReducerAlias), but the
-// remote-reducer dedup in the coordinator compares bytes (AC_Equals -> strcmp). So two
-// COLLECTs differing only in keyword case (e.g. `FIELDS` vs `fields`) map to the same
-// alias yet fail to dedup, producing two remote reducers with a colliding synthetic alias
-// and failing the query with SEARCH_FIELD_DUP (MOD-16365). Canonicalize the keyword tokens
-// to lowercase up front, on the reducer's own (owned, mutable) arg tokens, so the alias and
-// the dedup agree everywhere the args are later forwarded.
+// Lowercase COLLECT's option keywords in place so the generated alias (lowercased by
+// getReducerAlias) and the coordinator's byte-wise remote-reducer dedup (AC_Equals) agree.
+// Otherwise two COLLECTs differing only in keyword case get the same synthetic remote alias
+// without deduping, failing the query with SEARCH_FIELD_DUP in cluster (MOD-16365).
 static void normalizeCollectKeywords(const ArgsCursor *args) {
   if (args->type == AC_TYPE_RSTRING) {
-    return;  // tokens are RedisModuleString*, not mutable char buffers (never used for COLLECT)
+    return;  // RedisModuleString* tokens, not mutable char buffers (never used for COLLECT)
   }
-  ArgsCursor it = *args;  // iterate a copy; the caller's cursor position is untouched
+  ArgsCursor it = *args;
   while (!AC_IsAtEnd(&it)) {
     char *tok = (char *)AC_GetStringNC(&it, NULL);
     if (isCollectKeyword(tok)) {

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -849,6 +849,37 @@ PLN_Reducer *PLNGroupStep_FindReducer(PLN_GroupStep *gstp, const char *name, Arg
   return NULL;
 }
 
+// COLLECT is the only reducer whose argument list interleaves case-insensitive option
+// keywords (FIELDS/SORTBY/ASC/DESC/LIMIT/DISTINCT) with case-sensitive `@field` names.
+// The synthetic reducer alias lowercases the whole arg list (getReducerAlias), but the
+// remote-reducer dedup in the coordinator compares bytes (AC_Equals -> strcmp). So two
+// COLLECTs differing only in keyword case (e.g. `FIELDS` vs `fields`) map to the same
+// alias yet fail to dedup, producing two remote reducers with a colliding synthetic alias
+// and failing the query with SEARCH_FIELD_DUP (MOD-16365). Canonicalize the keyword tokens
+// to lowercase up front, on the reducer's own (owned, mutable) arg tokens, so the alias and
+// the dedup agree everywhere the args are later forwarded. `@field`/`@sort` names are left
+// untouched, preserving their case; a bare token can only be a keyword or a number.
+static void normalizeCollectKeywords(ArgsCursor *args) {
+  static const char *const kw[] = {"FIELDS", "SORTBY", "ASC", "DESC", "LIMIT", "DISTINCT"};
+  if (args->type == AC_TYPE_RSTRING) {
+    return;  // tokens are RedisModuleString*, not mutable char buffers (never used for COLLECT)
+  }
+  for (size_t i = 0; i < args->argc; i++) {
+    char *tok = (char *)args->objs[i];
+    if (!tok || tok[0] == '@') {
+      continue;  // field/sort names are case-sensitive
+    }
+    for (size_t k = 0; k < sizeof(kw) / sizeof(kw[0]); k++) {
+      if (!strcasecmp(tok, kw[k])) {
+        for (char *p = tok; *p; p++) {
+          if (*p >= 'A' && *p <= 'Z') *p += 'a' - 'A';
+        }
+        break;
+      }
+    }
+  }
+}
+
 int PLNGroupStep_AddReducer(PLN_GroupStep *gstp, const char *name, ArgsCursor *ac,
                             QueryError *status) {
   // Just a list of functions..
@@ -860,6 +891,10 @@ int PLNGroupStep_AddReducer(PLN_GroupStep *gstp, const char *name, ArgsCursor *a
   if (rv != AC_OK) {
     QERR_MKBADARGS_AC(status, name, rv);
     goto error;
+  }
+
+  if (!strcasecmp(name, "COLLECT")) {
+    normalizeCollectKeywords(&gr->args);
   }
 
   // See if there is an alias

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -25,10 +25,10 @@
 #define SORT_DIR_ASC "ASC"
 #define SORT_DIR_DESC "DESC"
 
-// COLLECT option keywords, in their normalized (lowercase) spelling.
+// COLLECT option keywords, in their normalized (uppercase) spelling.
 #define COLLECT_NUM_KEYWORDS 6
 static const char *const collectKeywords[COLLECT_NUM_KEYWORDS] = {
-    "fields", "sortby", "asc", "desc", "limit", "distinct"};
+    "FIELDS", "SORTBY", SORT_DIR_ASC, SORT_DIR_DESC, "LIMIT", "DISTINCT"};
 
 typedef struct {
   CollectArgs *args;

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -25,6 +25,11 @@
 #define SORT_DIR_ASC "ASC"
 #define SORT_DIR_DESC "DESC"
 
+// COLLECT option keywords, in their normalized (lowercase) spelling.
+#define COLLECT_NUM_KEYWORDS 6
+static const char *const COLLECT_KEYWORDS[COLLECT_NUM_KEYWORDS] = {
+    "fields", "sortby", "asc", "desc", "limit", "distinct"};
+
 typedef struct {
   CollectArgs *args;
   const ReducerOptions *options;
@@ -286,12 +291,10 @@ void CollectArgs_Free(CollectArgs *args) {
   args->sort_names = NULL;
 }
 
-const char *CollectArgs_CanonicalKeyword(const char *tok) {
-  static const char *const keywords[] = {"fields", "sortby", "asc", "desc", "limit", "distinct"};
-  static const size_t nkeywords = sizeof(keywords) / sizeof(keywords[0]);
-  for (size_t i = 0; i < nkeywords; i++) {
-    if (!strcasecmp(tok, keywords[i])) {
-      return keywords[i];
+const char *CollectArgs_NormalizedKeyword(const char *tok) {
+  for (size_t i = 0; i < COLLECT_NUM_KEYWORDS; i++) {
+    if (!strcasecmp(tok, COLLECT_KEYWORDS[i])) {
+      return COLLECT_KEYWORDS[i];
     }
   }
   return NULL;

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -299,10 +299,11 @@ static void asciiToLower(char *s, size_t len) {
 static bool isCollectKeyword(const char *tok, size_t len) {
   static const char *const keywords[] = {"FIELDS", "SORTBY", SORT_DIR_ASC, SORT_DIR_DESC,
                                          "LIMIT", "DISTINCT"};
+  static const size_t nkeywords = sizeof(keywords) / sizeof(keywords[0]);
   if (len == 0 || tok[0] == '@') {
     return false;
   }
-  for (size_t i = 0; i < sizeof(keywords) / sizeof(keywords[0]); i++) {
+  for (size_t i = 0; i < nkeywords; i++) {
     if (len == strlen(keywords[i]) && !strncasecmp(tok, keywords[i], len)) {
       return true;
     }

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -14,7 +14,6 @@
 #include "spec.h"
 #include "config.h"
 #include "reducers_ffi.h"
-#include <ctype.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdlib.h>
@@ -287,37 +286,15 @@ void CollectArgs_Free(CollectArgs *args) {
   args->sort_names = NULL;
 }
 
-// Bare tokens are unambiguous: COLLECT requires the `@` prefix on every (case-sensitive)
-// field/sort name, so a name can never be mistaken for a keyword.
-static bool isCollectKeyword(const char *tok, size_t len) {
-  static const char *const keywords[] = {"FIELDS", "SORTBY", SORT_DIR_ASC, SORT_DIR_DESC,
-                                         "LIMIT", "DISTINCT"};
+const char *CollectArgs_CanonicalKeyword(const char *tok) {
+  static const char *const keywords[] = {"fields", "sortby", "asc", "desc", "limit", "distinct"};
   static const size_t nkeywords = sizeof(keywords) / sizeof(keywords[0]);
-  if (len == 0 || tok[0] == '@') {
-    return false;
-  }
   for (size_t i = 0; i < nkeywords; i++) {
-    if (len == strlen(keywords[i]) && !strncasecmp(tok, keywords[i], len)) {
-      return true;
+    if (!strcasecmp(tok, keywords[i])) {
+      return keywords[i];
     }
   }
-  return false;
-}
-
-void CollectArgs_NormalizeKeywords(const ArgsCursor *args) {
-  if (args->type == AC_TYPE_RSTRING) {
-    return;  // RedisModuleString* tokens, not mutable char buffers (never used for COLLECT)
-  }
-  ArgsCursor it = *args;
-  while (!AC_IsAtEnd(&it)) {
-    size_t len = 0;
-    char *tok = (char *)AC_GetStringNC(&it, &len);
-    if (tok && isCollectKeyword(tok, len)) {
-      for (size_t i = 0; i < len; i++) {
-        tok[i] = tolower((unsigned char)tok[i]);
-      }
-    }
-  }
+  return NULL;
 }
 
 // ===== Post-parse key resolution (side-effectful: opens RLookupKeys) =====

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -27,7 +27,7 @@
 
 // COLLECT option keywords, in their normalized (lowercase) spelling.
 #define COLLECT_NUM_KEYWORDS 6
-static const char *const COLLECT_KEYWORDS[COLLECT_NUM_KEYWORDS] = {
+static const char *const collectKeywords[COLLECT_NUM_KEYWORDS] = {
     "fields", "sortby", "asc", "desc", "limit", "distinct"};
 
 typedef struct {
@@ -293,8 +293,8 @@ void CollectArgs_Free(CollectArgs *args) {
 
 const char *CollectArgs_NormalizedKeyword(const char *tok) {
   for (size_t i = 0; i < COLLECT_NUM_KEYWORDS; i++) {
-    if (!strcasecmp(tok, COLLECT_KEYWORDS[i])) {
-      return COLLECT_KEYWORDS[i];
+    if (!strcasecmp(tok, collectKeywords[i])) {
+      return collectKeywords[i];
     }
   }
   return NULL;

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -297,18 +297,13 @@ static void asciiToLower(char *s, size_t len) {
 // Bare tokens are unambiguous: COLLECT requires the `@` prefix on every (case-sensitive)
 // field/sort name, so a name can never be mistaken for a keyword.
 static bool isCollectKeyword(const char *tok, size_t len) {
-#define KW(s) {s, sizeof(s) - 1}
-  static const struct {
-    const char *str;
-    size_t len;
-  } keywords[] = {KW("FIELDS"), KW("SORTBY"), KW(SORT_DIR_ASC),
-                  KW(SORT_DIR_DESC), KW("LIMIT"), KW("DISTINCT")};
-#undef KW
+  static const char *const keywords[] = {"FIELDS", "SORTBY", SORT_DIR_ASC, SORT_DIR_DESC,
+                                         "LIMIT", "DISTINCT"};
   if (len == 0 || tok[0] == '@') {
     return false;
   }
   for (size_t i = 0; i < sizeof(keywords) / sizeof(keywords[0]); i++) {
-    if (len == keywords[i].len && !strncasecmp(tok, keywords[i].str, len)) {
+    if (len == strlen(keywords[i]) && !strncasecmp(tok, keywords[i], len)) {
       return true;
     }
   }

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -14,6 +14,7 @@
 #include "spec.h"
 #include "config.h"
 #include "reducers_ffi.h"
+#include <ctype.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdlib.h>
@@ -286,14 +287,6 @@ void CollectArgs_Free(CollectArgs *args) {
   args->sort_names = NULL;
 }
 
-static void asciiToLower(char *s, size_t len) {
-  for (size_t i = 0; i < len; i++) {
-    if (s[i] >= 'A' && s[i] <= 'Z') {
-      s[i] += 'a' - 'A';
-    }
-  }
-}
-
 // Bare tokens are unambiguous: COLLECT requires the `@` prefix on every (case-sensitive)
 // field/sort name, so a name can never be mistaken for a keyword.
 static bool isCollectKeyword(const char *tok, size_t len) {
@@ -320,7 +313,9 @@ void CollectArgs_NormalizeKeywords(const ArgsCursor *args) {
     size_t len = 0;
     char *tok = (char *)AC_GetStringNC(&it, &len);
     if (tok && isCollectKeyword(tok, len)) {
-      asciiToLower(tok, len);
+      for (size_t i = 0; i < len; i++) {
+        tok[i] = tolower((unsigned char)tok[i]);
+      }
     }
   }
 }

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -286,24 +286,29 @@ void CollectArgs_Free(CollectArgs *args) {
   args->sort_names = NULL;
 }
 
-static void asciiToLower(char *s) {
-  for (; *s; s++) {
-    if (*s >= 'A' && *s <= 'Z') {
-      *s += 'a' - 'A';
+static void asciiToLower(char *s, size_t len) {
+  for (size_t i = 0; i < len; i++) {
+    if (s[i] >= 'A' && s[i] <= 'Z') {
+      s[i] += 'a' - 'A';
     }
   }
 }
 
 // Bare tokens are unambiguous: COLLECT requires the `@` prefix on every (case-sensitive)
 // field/sort name, so a name can never be mistaken for a keyword.
-static bool isCollectKeyword(const char *tok) {
-  static const char *const keywords[] = {"FIELDS", "SORTBY", SORT_DIR_ASC, SORT_DIR_DESC,
-                                         "LIMIT", "DISTINCT"};
-  if (!tok || tok[0] == '@') {
+static bool isCollectKeyword(const char *tok, size_t len) {
+#define KW(s) {s, sizeof(s) - 1}
+  static const struct {
+    const char *str;
+    size_t len;
+  } keywords[] = {KW("FIELDS"), KW("SORTBY"), KW(SORT_DIR_ASC),
+                  KW(SORT_DIR_DESC), KW("LIMIT"), KW("DISTINCT")};
+#undef KW
+  if (len == 0 || tok[0] == '@') {
     return false;
   }
   for (size_t i = 0; i < sizeof(keywords) / sizeof(keywords[0]); i++) {
-    if (!strcasecmp(tok, keywords[i])) {
+    if (len == keywords[i].len && !strncasecmp(tok, keywords[i].str, len)) {
       return true;
     }
   }
@@ -316,9 +321,10 @@ void CollectArgs_NormalizeKeywords(const ArgsCursor *args) {
   }
   ArgsCursor it = *args;
   while (!AC_IsAtEnd(&it)) {
-    char *tok = (char *)AC_GetStringNC(&it, NULL);
-    if (isCollectKeyword(tok)) {
-      asciiToLower(tok);
+    size_t len = 0;
+    char *tok = (char *)AC_GetStringNC(&it, &len);
+    if (tok && isCollectKeyword(tok, len)) {
+      asciiToLower(tok, len);
     }
   }
 }

--- a/src/aggregate/reducers/collect.c
+++ b/src/aggregate/reducers/collect.c
@@ -286,6 +286,43 @@ void CollectArgs_Free(CollectArgs *args) {
   args->sort_names = NULL;
 }
 
+static void asciiToLower(char *s) {
+  for (; *s; s++) {
+    if (*s >= 'A' && *s <= 'Z') {
+      *s += 'a' - 'A';
+    }
+  }
+}
+
+// Bare tokens are unambiguous: COLLECT requires the `@` prefix on every (case-sensitive)
+// field/sort name, so a name can never be mistaken for a keyword.
+static bool isCollectKeyword(const char *tok) {
+  static const char *const keywords[] = {"FIELDS", "SORTBY", SORT_DIR_ASC, SORT_DIR_DESC,
+                                         "LIMIT", "DISTINCT"};
+  if (!tok || tok[0] == '@') {
+    return false;
+  }
+  for (size_t i = 0; i < sizeof(keywords) / sizeof(keywords[0]); i++) {
+    if (!strcasecmp(tok, keywords[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void CollectArgs_NormalizeKeywords(const ArgsCursor *args) {
+  if (args->type == AC_TYPE_RSTRING) {
+    return;  // RedisModuleString* tokens, not mutable char buffers (never used for COLLECT)
+  }
+  ArgsCursor it = *args;
+  while (!AC_IsAtEnd(&it)) {
+    char *tok = (char *)AC_GetStringNC(&it, NULL);
+    if (isCollectKeyword(tok)) {
+      asciiToLower(tok);
+    }
+  }
+}
+
 // ===== Post-parse key resolution (side-effectful: opens RLookupKeys) =====
 
 // Resolves stripped names into a freshly-allocated `arrayof(const RLookupKey *)`.

--- a/src/aggregate/reducers/collect_parse.h
+++ b/src/aggregate/reducers/collect_parse.h
@@ -62,10 +62,10 @@ bool CollectArgs_Parse(const ReducerOptions *options, CollectArgs *out);
 void CollectArgs_Free(CollectArgs *args);
 
 /**
- * If `tok` is a COLLECT option keyword, return its canonical (lowercase,
+ * If `tok` is a COLLECT option keyword, return its normalized (lowercase,
  * static) spelling; otherwise NULL.
  */
-const char *CollectArgs_CanonicalKeyword(const char *tok);
+const char *CollectArgs_NormalizedKeyword(const char *tok);
 
 #ifdef __cplusplus
 }

--- a/src/aggregate/reducers/collect_parse.h
+++ b/src/aggregate/reducers/collect_parse.h
@@ -62,10 +62,10 @@ bool CollectArgs_Parse(const ReducerOptions *options, CollectArgs *out);
 void CollectArgs_Free(CollectArgs *args);
 
 /**
- * Lowercase COLLECT's option keywords in place. `@`-prefixed (case-sensitive)
- * field/sort names are left untouched.
+ * If `tok` is a COLLECT option keyword, return its canonical (lowercase,
+ * static) spelling; otherwise NULL.
  */
-void CollectArgs_NormalizeKeywords(const ArgsCursor *args);
+const char *CollectArgs_CanonicalKeyword(const char *tok);
 
 #ifdef __cplusplus
 }

--- a/src/aggregate/reducers/collect_parse.h
+++ b/src/aggregate/reducers/collect_parse.h
@@ -61,6 +61,12 @@ bool CollectArgs_Parse(const ReducerOptions *options, CollectArgs *out);
  */
 void CollectArgs_Free(CollectArgs *args);
 
+/**
+ * Lowercase COLLECT's option keywords in place. `@`-prefixed (case-sensitive)
+ * field/sort names are left untouched.
+ */
+void CollectArgs_NormalizeKeywords(const ArgsCursor *args);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/aggregate/reducers/collect_parse.h
+++ b/src/aggregate/reducers/collect_parse.h
@@ -62,7 +62,7 @@ bool CollectArgs_Parse(const ReducerOptions *options, CollectArgs *out);
 void CollectArgs_Free(CollectArgs *args);
 
 /**
- * If `tok` is a COLLECT option keyword, return its normalized (lowercase,
+ * If `tok` is a COLLECT option keyword, return its normalized (uppercase,
  * static) spelling; otherwise NULL.
  */
 const char *CollectArgs_NormalizedKeyword(const char *tok);

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -415,7 +415,7 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
   remoteObjs[0] = distAllocU64Str(rdctx->alloc, srcArgc);  // <nargs> = reducer args only
   // Shallow copy: only pointers are copied; the strings stay owned by src->args
   // (or are static). Option keywords are normalized so that case-variant
-  // duplicate reducers dedup (MOD-16365); values are forwarded verbatim.
+  // duplicate reducers dedup; values are forwarded verbatim.
   for (size_t i = 0; i < srcArgc; i++) {
     const char *normalized = CollectArgs_NormalizedKeyword(srcObjs[i]);
     remoteObjs[1 + i] = normalized ? normalized : srcObjs[i];

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -414,10 +414,10 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
       std::max(sizeof(char *) * remoteTotal, DIST_REDUCER_BLOCK_SIZE));
   remoteObjs[0] = distAllocU64Str(rdctx->alloc, srcArgc);  // <nargs> = reducer args only
   // Shallow copy: only pointers are copied; the strings stay owned by src->args
-  // (or are static). Option keywords are normalized to their lowercase spelling
-  // so `addRemote`'s byte-wise dedup and the lowercased generated alias agree
-  // on case-variant keywords (e.g. `FIELDS` vs `fields`); values are forwarded
-  // verbatim.
+  // (or are static). Option keywords are normalized to their uppercase spelling
+  // so `addRemote`'s byte-wise dedup treats case-variant keywords (e.g. `FIELDS`
+  // vs `fields`) as identical instead of colliding on the case-folded generated
+  // alias; values are forwarded verbatim.
   for (size_t i = 0; i < srcArgc; i++) {
     const char *normalized = CollectArgs_NormalizedKeyword(srcObjs[i]);
     remoteObjs[1 + i] = normalized ? normalized : srcObjs[i];

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -414,10 +414,8 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
       std::max(sizeof(char *) * remoteTotal, DIST_REDUCER_BLOCK_SIZE));
   remoteObjs[0] = distAllocU64Str(rdctx->alloc, srcArgc);  // <nargs> = reducer args only
   // Shallow copy: only pointers are copied; the strings stay owned by src->args
-  // (or are static). Option keywords are normalized to their uppercase spelling
-  // so `addRemote`'s byte-wise dedup treats case-variant keywords (e.g. `FIELDS`
-  // vs `fields`) as identical instead of colliding on the case-folded generated
-  // alias; values are forwarded verbatim.
+  // (or are static). Option keywords are normalized so that case-variant
+  // duplicate reducers dedup (MOD-16365); values are forwarded verbatim.
   for (size_t i = 0; i < srcArgc; i++) {
     const char *normalized = CollectArgs_NormalizedKeyword(srcObjs[i]);
     remoteObjs[1 + i] = normalized ? normalized : srcObjs[i];

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -415,9 +415,13 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
   remoteObjs[0] = distAllocU64Str(rdctx->alloc, srcArgc);  // <nargs> = reducer args only
   // Shallow copy: only pointers are copied; the strings stay owned by src->args
   // (or are static). Option keywords are normalized so that case-variant
-  // duplicate reducers dedup; values are forwarded verbatim.
+  // duplicate reducers dedup. User data is never normalized: in the (already
+  // validated) COLLECT grammar it only appears `@`-prefixed, as a number, or as
+  // `*`, so a bare alphabetic token can only be an option keyword.
   for (size_t i = 0; i < srcArgc; i++) {
     const char *normalized = CollectArgs_NormalizedKeyword(srcObjs[i]);
+    RS_ASSERT(normalized || srcObjs[i][0] == '@' || srcObjs[i][0] == '*' ||
+              (srcObjs[i][0] >= '0' && srcObjs[i][0] <= '9'));
     remoteObjs[1 + i] = normalized ? normalized : srcObjs[i];
   }
   if (args.has_limit) {

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -420,8 +420,6 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
   // `*`, so a bare alphabetic token can only be an option keyword.
   for (size_t i = 0; i < srcArgc; i++) {
     const char *normalized = CollectArgs_NormalizedKeyword(srcObjs[i]);
-    RS_ASSERT(normalized || srcObjs[i][0] == '@' || srcObjs[i][0] == '*' ||
-              (srcObjs[i][0] >= '0' && srcObjs[i][0] <= '9'));
     remoteObjs[1 + i] = normalized ? normalized : srcObjs[i];
   }
   if (args.has_limit) {

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -414,13 +414,13 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
       std::max(sizeof(char *) * remoteTotal, DIST_REDUCER_BLOCK_SIZE));
   remoteObjs[0] = distAllocU64Str(rdctx->alloc, srcArgc);  // <nargs> = reducer args only
   // Shallow copy: only pointers are copied; the strings stay owned by src->args
-  // (or are static). Option keywords are canonicalized to their lowercase
-  // spelling so `addRemote`'s byte-wise dedup and the lowercased generated
-  // alias agree on case-variant keywords (e.g. `FIELDS` vs `fields`); values
-  // are forwarded verbatim.
+  // (or are static). Option keywords are normalized to their lowercase spelling
+  // so `addRemote`'s byte-wise dedup and the lowercased generated alias agree
+  // on case-variant keywords (e.g. `FIELDS` vs `fields`); values are forwarded
+  // verbatim.
   for (size_t i = 0; i < srcArgc; i++) {
-    const char *canon = CollectArgs_CanonicalKeyword(srcObjs[i]);
-    remoteObjs[1 + i] = canon ? canon : srcObjs[i];
+    const char *normalized = CollectArgs_NormalizedKeyword(srcObjs[i]);
+    remoteObjs[1 + i] = normalized ? normalized : srcObjs[i];
   }
   if (args.has_limit) {
     remoteObjs[1 + limitValIdx] = distAllocU64Str(rdctx->alloc, 0);

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -413,9 +413,15 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
       rdctx->alloc, sizeof(char *) * remoteTotal,
       std::max(sizeof(char *) * remoteTotal, DIST_REDUCER_BLOCK_SIZE));
   remoteObjs[0] = distAllocU64Str(rdctx->alloc, srcArgc);  // <nargs> = reducer args only
-  // Shallow copy: only pointers are copied; the strings stay owned by src->args.
-  // Overwriting a slot below replaces the pointer, it does not free the string.
-  memcpy(remoteObjs + 1, srcObjs, srcArgc * sizeof(char *));
+  // Shallow copy: only pointers are copied; the strings stay owned by src->args
+  // (or are static). Option keywords are canonicalized to their lowercase
+  // spelling so `addRemote`'s byte-wise dedup and the lowercased generated
+  // alias agree on case-variant keywords (e.g. `FIELDS` vs `fields`); values
+  // are forwarded verbatim.
+  for (size_t i = 0; i < srcArgc; i++) {
+    const char *canon = CollectArgs_CanonicalKeyword(srcObjs[i]);
+    remoteObjs[1 + i] = canon ? canon : srcObjs[i];
+  }
   if (args.has_limit) {
     remoteObjs[1 + limitValIdx] = distAllocU64Str(rdctx->alloc, 0);
     remoteObjs[1 + limitValIdx + 1] =

--- a/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
@@ -168,9 +168,9 @@ TEST_F(DistributeCollectTest, FieldsList_NoSortBy_NoLimit) {
   ASSERT_NE(pair.local, nullptr);
 
   EXPECT_EQ(argsAsStrings(pair.remote),
-            (std::vector<std::string>{"FIELDS", "1", "@name"}));
+            (std::vector<std::string>{"fields", "1", "@name"}));
   EXPECT_EQ(argsAsStrings(pair.local),
-            (std::vector<std::string>{"FIELDS", "1", "@name"}));
+            (std::vector<std::string>{"fields", "1", "@name"}));
 
   ASSERT_NE(pair.local->inputAlias, nullptr);
   ASSERT_NE(pair.remote->alias, nullptr);
@@ -182,8 +182,8 @@ TEST_F(DistributeCollectTest, FieldsList_NoSortBy_NoLimit) {
 TEST_F(DistributeCollectTest, FieldsList_SortByOnly_NoLimit) {
   AGGPlan *plan = nullptr;
   // The user omits the per-key direction (`SORTBY 1 @price`, not
-  // `SORTBY 2 @price ASC`). SORTBY is forwarded verbatim with no normalization,
-  // so the omitted direction stays omitted on both sides.
+  // `SORTBY 2 @price ASC`). Aside from keyword-case canonicalization, SORTBY is
+  // forwarded as-is, so the omitted direction stays omitted on both sides.
   AREQ *r = compileAndDistribute(
       {"FIELDS", "1", "@name", "SORTBY", "1", "@price"}, &plan);
   ASSERT_NE(r, nullptr);
@@ -192,8 +192,8 @@ TEST_F(DistributeCollectTest, FieldsList_SortByOnly_NoLimit) {
   ASSERT_NE(pair.remote, nullptr);
   ASSERT_NE(pair.local, nullptr);
 
-  std::vector<std::string> expected = {"FIELDS", "1", "@name",
-                                       "SORTBY", "1", "@price"};
+  std::vector<std::string> expected = {"fields", "1", "@name",
+                                       "sortby", "1", "@price"};
   EXPECT_EQ(argsAsStrings(pair.remote), expected);
   EXPECT_EQ(argsAsStrings(pair.local), expected);
 
@@ -212,12 +212,12 @@ TEST_F(DistributeCollectTest, FieldsList_NoSortBy_Limit_RewritesRemoteLimit) {
 
   // Remote: offset=0, count=2+3=5
   EXPECT_EQ(argsAsStrings(pair.remote),
-            (std::vector<std::string>{"FIELDS", "1", "@name",
-                                      "LIMIT", "0", "5"}));
+            (std::vector<std::string>{"fields", "1", "@name",
+                                      "limit", "0", "5"}));
   // Local: original offset=2, count=3
   EXPECT_EQ(argsAsStrings(pair.local),
-            (std::vector<std::string>{"FIELDS", "1", "@name",
-                                      "LIMIT", "2", "3"}));
+            (std::vector<std::string>{"fields", "1", "@name",
+                                      "limit", "2", "3"}));
 
   AREQ_DecrRef(r);
 }
@@ -235,13 +235,13 @@ TEST_F(DistributeCollectTest, FieldsList_SortBy_Limit_RewritesRemoteLimit) {
   ASSERT_NE(pair.local, nullptr);
 
   EXPECT_EQ(argsAsStrings(pair.remote),
-            (std::vector<std::string>{"FIELDS", "1", "@name",
-                                      "SORTBY", "2", "@price", "ASC",
-                                      "LIMIT", "0", "5"}));
+            (std::vector<std::string>{"fields", "1", "@name",
+                                      "sortby", "2", "@price", "asc",
+                                      "limit", "0", "5"}));
   EXPECT_EQ(argsAsStrings(pair.local),
-            (std::vector<std::string>{"FIELDS", "1", "@name",
-                                      "SORTBY", "2", "@price", "ASC",
-                                      "LIMIT", "2", "3"}));
+            (std::vector<std::string>{"fields", "1", "@name",
+                                      "sortby", "2", "@price", "asc",
+                                      "limit", "2", "3"}));
 
   AREQ_DecrRef(r);
 }
@@ -260,9 +260,9 @@ TEST_F(DistributeCollectTest, FieldsStar_NoSortBy_NoLimit) {
   ASSERT_NE(pair.local, nullptr);
 
   EXPECT_EQ(argsAsStrings(pair.remote),
-            (std::vector<std::string>{"FIELDS", "*"}));
+            (std::vector<std::string>{"fields", "*"}));
   EXPECT_EQ(argsAsStrings(pair.local),
-            (std::vector<std::string>{"FIELDS", "*"}));
+            (std::vector<std::string>{"fields", "*"}));
 
   AREQ_DecrRef(r);
 }
@@ -277,8 +277,8 @@ TEST_F(DistributeCollectTest, FieldsStar_SortByOnly_NoLimit) {
   ASSERT_NE(pair.remote, nullptr);
   ASSERT_NE(pair.local, nullptr);
 
-  std::vector<std::string> expected = {"FIELDS", "*",
-                                       "SORTBY", "2", "@price", "ASC"};
+  std::vector<std::string> expected = {"fields", "*",
+                                       "sortby", "2", "@price", "asc"};
   EXPECT_EQ(argsAsStrings(pair.remote), expected);
   EXPECT_EQ(argsAsStrings(pair.local), expected);
 
@@ -295,9 +295,9 @@ TEST_F(DistributeCollectTest, FieldsStar_NoSortBy_Limit_RewritesRemoteLimit) {
   ASSERT_NE(pair.local, nullptr);
 
   EXPECT_EQ(argsAsStrings(pair.remote),
-            (std::vector<std::string>{"FIELDS", "*", "LIMIT", "0", "5"}));
+            (std::vector<std::string>{"fields", "*", "limit", "0", "5"}));
   EXPECT_EQ(argsAsStrings(pair.local),
-            (std::vector<std::string>{"FIELDS", "*", "LIMIT", "1", "4"}));
+            (std::vector<std::string>{"fields", "*", "limit", "1", "4"}));
 
   AREQ_DecrRef(r);
 }
@@ -315,13 +315,13 @@ TEST_F(DistributeCollectTest, FieldsStar_SortBy_Limit_RewritesRemoteLimit) {
   ASSERT_NE(pair.local, nullptr);
 
   EXPECT_EQ(argsAsStrings(pair.remote),
-            (std::vector<std::string>{"FIELDS", "*",
-                                      "SORTBY", "2", "@price", "DESC",
-                                      "LIMIT", "0", "15"}));
+            (std::vector<std::string>{"fields", "*",
+                                      "sortby", "2", "@price", "desc",
+                                      "limit", "0", "15"}));
   EXPECT_EQ(argsAsStrings(pair.local),
-            (std::vector<std::string>{"FIELDS", "*",
-                                      "SORTBY", "2", "@price", "DESC",
-                                      "LIMIT", "5", "10"}));
+            (std::vector<std::string>{"fields", "*",
+                                      "sortby", "2", "@price", "desc",
+                                      "limit", "5", "10"}));
 
   AREQ_DecrRef(r);
 }

--- a/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
@@ -193,12 +193,10 @@ TEST_F(DistributeCollectTest, FieldsList_SortByOnly_NoLimit) {
   ASSERT_NE(pair.remote, nullptr);
   ASSERT_NE(pair.local, nullptr);
 
-  EXPECT_EQ(argsAsStrings(pair.remote),
-            (std::vector<std::string>{"FIELDS", "1", "@name",
-                                      "SORTBY", "1", "@price"}));
-  EXPECT_EQ(argsAsStrings(pair.local),
-            (std::vector<std::string>{"FIELDS", "1", "@name",
-                                      "SORTBY", "1", "@price"}));
+  std::vector<std::string> expected = {"FIELDS", "1", "@name",
+                                       "SORTBY", "1", "@price"};
+  EXPECT_EQ(argsAsStrings(pair.remote), expected);
+  EXPECT_EQ(argsAsStrings(pair.local), expected);
 
   AREQ_DecrRef(r);
 }
@@ -280,12 +278,10 @@ TEST_F(DistributeCollectTest, FieldsStar_SortByOnly_NoLimit) {
   ASSERT_NE(pair.remote, nullptr);
   ASSERT_NE(pair.local, nullptr);
 
-  EXPECT_EQ(argsAsStrings(pair.remote),
-            (std::vector<std::string>{"FIELDS", "*",
-                                      "SORTBY", "2", "@price", "ASC"}));
-  EXPECT_EQ(argsAsStrings(pair.local),
-            (std::vector<std::string>{"FIELDS", "*",
-                                      "SORTBY", "2", "@price", "ASC"}));
+  std::vector<std::string> expected = {"FIELDS", "*",
+                                       "SORTBY", "2", "@price", "ASC"};
+  EXPECT_EQ(argsAsStrings(pair.remote), expected);
+  EXPECT_EQ(argsAsStrings(pair.local), expected);
 
   AREQ_DecrRef(r);
 }

--- a/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
@@ -182,9 +182,9 @@ TEST_F(DistributeCollectTest, FieldsList_NoSortBy_NoLimit) {
 TEST_F(DistributeCollectTest, FieldsList_SortByOnly_NoLimit) {
   AGGPlan *plan = nullptr;
   // The user omits the per-key direction (`SORTBY 1 @price`, not
-  // `SORTBY 2 @price ASC`). SORTBY is forwarded as-is (keywords canonicalized
-  // to lowercase on the remote side only), so the omitted direction stays
-  // omitted on both sides.
+  // `SORTBY 2 @price ASC`). SORTBY is forwarded as-is (keywords normalized to
+  // lowercase on the remote side only), so the omitted direction stays omitted
+  // on both sides.
   AREQ *r = compileAndDistribute(
       {"FIELDS", "1", "@name", "SORTBY", "1", "@price"}, &plan);
   ASSERT_NE(r, nullptr);

--- a/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
@@ -327,7 +327,6 @@ TEST_F(DistributeCollectTest, FieldsStar_SortBy_Limit_RewritesRemoteLimit) {
   AREQ_DecrRef(r);
 }
 
-
 // ----------------------------------------------------------------------------
 // Keyword case normalization
 // ----------------------------------------------------------------------------

--- a/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
@@ -170,7 +170,7 @@ TEST_F(DistributeCollectTest, FieldsList_NoSortBy_NoLimit) {
   EXPECT_EQ(argsAsStrings(pair.remote),
             (std::vector<std::string>{"fields", "1", "@name"}));
   EXPECT_EQ(argsAsStrings(pair.local),
-            (std::vector<std::string>{"fields", "1", "@name"}));
+            (std::vector<std::string>{"FIELDS", "1", "@name"}));
 
   ASSERT_NE(pair.local->inputAlias, nullptr);
   ASSERT_NE(pair.remote->alias, nullptr);
@@ -182,8 +182,9 @@ TEST_F(DistributeCollectTest, FieldsList_NoSortBy_NoLimit) {
 TEST_F(DistributeCollectTest, FieldsList_SortByOnly_NoLimit) {
   AGGPlan *plan = nullptr;
   // The user omits the per-key direction (`SORTBY 1 @price`, not
-  // `SORTBY 2 @price ASC`). Aside from keyword-case canonicalization, SORTBY is
-  // forwarded as-is, so the omitted direction stays omitted on both sides.
+  // `SORTBY 2 @price ASC`). SORTBY is forwarded as-is (keywords canonicalized
+  // to lowercase on the remote side only), so the omitted direction stays
+  // omitted on both sides.
   AREQ *r = compileAndDistribute(
       {"FIELDS", "1", "@name", "SORTBY", "1", "@price"}, &plan);
   ASSERT_NE(r, nullptr);
@@ -192,10 +193,12 @@ TEST_F(DistributeCollectTest, FieldsList_SortByOnly_NoLimit) {
   ASSERT_NE(pair.remote, nullptr);
   ASSERT_NE(pair.local, nullptr);
 
-  std::vector<std::string> expected = {"fields", "1", "@name",
-                                       "sortby", "1", "@price"};
-  EXPECT_EQ(argsAsStrings(pair.remote), expected);
-  EXPECT_EQ(argsAsStrings(pair.local), expected);
+  EXPECT_EQ(argsAsStrings(pair.remote),
+            (std::vector<std::string>{"fields", "1", "@name",
+                                      "sortby", "1", "@price"}));
+  EXPECT_EQ(argsAsStrings(pair.local),
+            (std::vector<std::string>{"FIELDS", "1", "@name",
+                                      "SORTBY", "1", "@price"}));
 
   AREQ_DecrRef(r);
 }
@@ -216,8 +219,8 @@ TEST_F(DistributeCollectTest, FieldsList_NoSortBy_Limit_RewritesRemoteLimit) {
                                       "limit", "0", "5"}));
   // Local: original offset=2, count=3
   EXPECT_EQ(argsAsStrings(pair.local),
-            (std::vector<std::string>{"fields", "1", "@name",
-                                      "limit", "2", "3"}));
+            (std::vector<std::string>{"FIELDS", "1", "@name",
+                                      "LIMIT", "2", "3"}));
 
   AREQ_DecrRef(r);
 }
@@ -239,9 +242,9 @@ TEST_F(DistributeCollectTest, FieldsList_SortBy_Limit_RewritesRemoteLimit) {
                                       "sortby", "2", "@price", "asc",
                                       "limit", "0", "5"}));
   EXPECT_EQ(argsAsStrings(pair.local),
-            (std::vector<std::string>{"fields", "1", "@name",
-                                      "sortby", "2", "@price", "asc",
-                                      "limit", "2", "3"}));
+            (std::vector<std::string>{"FIELDS", "1", "@name",
+                                      "SORTBY", "2", "@price", "ASC",
+                                      "LIMIT", "2", "3"}));
 
   AREQ_DecrRef(r);
 }
@@ -262,7 +265,7 @@ TEST_F(DistributeCollectTest, FieldsStar_NoSortBy_NoLimit) {
   EXPECT_EQ(argsAsStrings(pair.remote),
             (std::vector<std::string>{"fields", "*"}));
   EXPECT_EQ(argsAsStrings(pair.local),
-            (std::vector<std::string>{"fields", "*"}));
+            (std::vector<std::string>{"FIELDS", "*"}));
 
   AREQ_DecrRef(r);
 }
@@ -277,10 +280,12 @@ TEST_F(DistributeCollectTest, FieldsStar_SortByOnly_NoLimit) {
   ASSERT_NE(pair.remote, nullptr);
   ASSERT_NE(pair.local, nullptr);
 
-  std::vector<std::string> expected = {"fields", "*",
-                                       "sortby", "2", "@price", "asc"};
-  EXPECT_EQ(argsAsStrings(pair.remote), expected);
-  EXPECT_EQ(argsAsStrings(pair.local), expected);
+  EXPECT_EQ(argsAsStrings(pair.remote),
+            (std::vector<std::string>{"fields", "*",
+                                      "sortby", "2", "@price", "asc"}));
+  EXPECT_EQ(argsAsStrings(pair.local),
+            (std::vector<std::string>{"FIELDS", "*",
+                                      "SORTBY", "2", "@price", "ASC"}));
 
   AREQ_DecrRef(r);
 }
@@ -297,7 +302,7 @@ TEST_F(DistributeCollectTest, FieldsStar_NoSortBy_Limit_RewritesRemoteLimit) {
   EXPECT_EQ(argsAsStrings(pair.remote),
             (std::vector<std::string>{"fields", "*", "limit", "0", "5"}));
   EXPECT_EQ(argsAsStrings(pair.local),
-            (std::vector<std::string>{"fields", "*", "limit", "1", "4"}));
+            (std::vector<std::string>{"FIELDS", "*", "LIMIT", "1", "4"}));
 
   AREQ_DecrRef(r);
 }
@@ -319,9 +324,9 @@ TEST_F(DistributeCollectTest, FieldsStar_SortBy_Limit_RewritesRemoteLimit) {
                                       "sortby", "2", "@price", "desc",
                                       "limit", "0", "15"}));
   EXPECT_EQ(argsAsStrings(pair.local),
-            (std::vector<std::string>{"fields", "*",
-                                      "sortby", "2", "@price", "desc",
-                                      "limit", "5", "10"}));
+            (std::vector<std::string>{"FIELDS", "*",
+                                      "SORTBY", "2", "@price", "DESC",
+                                      "LIMIT", "5", "10"}));
 
   AREQ_DecrRef(r);
 }

--- a/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
@@ -18,8 +18,8 @@
 // The key invariants asserted:
 //   - LIMIT on the remote is always rewritten to `0 (offset + count)`.
 //   - LIMIT on the local keeps the user's original offset/count.
-//   - All other tokens (FIELDS, SORTBY, `FIELDS *`) are forwarded verbatim
-//     from the original argv, with no normalization.
+//   - Option keywords are normalized to uppercase on the remote side; all
+//     other tokens — and the entire local argv — are forwarded verbatim.
 //   - The local reducer's `inputAlias` matches the remote reducer's `alias`,
 //     wiring the merge step to its shard payload source.
 
@@ -168,7 +168,7 @@ TEST_F(DistributeCollectTest, FieldsList_NoSortBy_NoLimit) {
   ASSERT_NE(pair.local, nullptr);
 
   EXPECT_EQ(argsAsStrings(pair.remote),
-            (std::vector<std::string>{"fields", "1", "@name"}));
+            (std::vector<std::string>{"FIELDS", "1", "@name"}));
   EXPECT_EQ(argsAsStrings(pair.local),
             (std::vector<std::string>{"FIELDS", "1", "@name"}));
 
@@ -183,7 +183,7 @@ TEST_F(DistributeCollectTest, FieldsList_SortByOnly_NoLimit) {
   AGGPlan *plan = nullptr;
   // The user omits the per-key direction (`SORTBY 1 @price`, not
   // `SORTBY 2 @price ASC`). SORTBY is forwarded as-is (keywords normalized to
-  // lowercase on the remote side only), so the omitted direction stays omitted
+  // uppercase on the remote side only), so the omitted direction stays omitted
   // on both sides.
   AREQ *r = compileAndDistribute(
       {"FIELDS", "1", "@name", "SORTBY", "1", "@price"}, &plan);
@@ -194,8 +194,8 @@ TEST_F(DistributeCollectTest, FieldsList_SortByOnly_NoLimit) {
   ASSERT_NE(pair.local, nullptr);
 
   EXPECT_EQ(argsAsStrings(pair.remote),
-            (std::vector<std::string>{"fields", "1", "@name",
-                                      "sortby", "1", "@price"}));
+            (std::vector<std::string>{"FIELDS", "1", "@name",
+                                      "SORTBY", "1", "@price"}));
   EXPECT_EQ(argsAsStrings(pair.local),
             (std::vector<std::string>{"FIELDS", "1", "@name",
                                       "SORTBY", "1", "@price"}));
@@ -215,8 +215,8 @@ TEST_F(DistributeCollectTest, FieldsList_NoSortBy_Limit_RewritesRemoteLimit) {
 
   // Remote: offset=0, count=2+3=5
   EXPECT_EQ(argsAsStrings(pair.remote),
-            (std::vector<std::string>{"fields", "1", "@name",
-                                      "limit", "0", "5"}));
+            (std::vector<std::string>{"FIELDS", "1", "@name",
+                                      "LIMIT", "0", "5"}));
   // Local: original offset=2, count=3
   EXPECT_EQ(argsAsStrings(pair.local),
             (std::vector<std::string>{"FIELDS", "1", "@name",
@@ -238,9 +238,9 @@ TEST_F(DistributeCollectTest, FieldsList_SortBy_Limit_RewritesRemoteLimit) {
   ASSERT_NE(pair.local, nullptr);
 
   EXPECT_EQ(argsAsStrings(pair.remote),
-            (std::vector<std::string>{"fields", "1", "@name",
-                                      "sortby", "2", "@price", "asc",
-                                      "limit", "0", "5"}));
+            (std::vector<std::string>{"FIELDS", "1", "@name",
+                                      "SORTBY", "2", "@price", "ASC",
+                                      "LIMIT", "0", "5"}));
   EXPECT_EQ(argsAsStrings(pair.local),
             (std::vector<std::string>{"FIELDS", "1", "@name",
                                       "SORTBY", "2", "@price", "ASC",
@@ -263,7 +263,7 @@ TEST_F(DistributeCollectTest, FieldsStar_NoSortBy_NoLimit) {
   ASSERT_NE(pair.local, nullptr);
 
   EXPECT_EQ(argsAsStrings(pair.remote),
-            (std::vector<std::string>{"fields", "*"}));
+            (std::vector<std::string>{"FIELDS", "*"}));
   EXPECT_EQ(argsAsStrings(pair.local),
             (std::vector<std::string>{"FIELDS", "*"}));
 
@@ -281,8 +281,8 @@ TEST_F(DistributeCollectTest, FieldsStar_SortByOnly_NoLimit) {
   ASSERT_NE(pair.local, nullptr);
 
   EXPECT_EQ(argsAsStrings(pair.remote),
-            (std::vector<std::string>{"fields", "*",
-                                      "sortby", "2", "@price", "asc"}));
+            (std::vector<std::string>{"FIELDS", "*",
+                                      "SORTBY", "2", "@price", "ASC"}));
   EXPECT_EQ(argsAsStrings(pair.local),
             (std::vector<std::string>{"FIELDS", "*",
                                       "SORTBY", "2", "@price", "ASC"}));
@@ -300,7 +300,7 @@ TEST_F(DistributeCollectTest, FieldsStar_NoSortBy_Limit_RewritesRemoteLimit) {
   ASSERT_NE(pair.local, nullptr);
 
   EXPECT_EQ(argsAsStrings(pair.remote),
-            (std::vector<std::string>{"fields", "*", "limit", "0", "5"}));
+            (std::vector<std::string>{"FIELDS", "*", "LIMIT", "0", "5"}));
   EXPECT_EQ(argsAsStrings(pair.local),
             (std::vector<std::string>{"FIELDS", "*", "LIMIT", "1", "4"}));
 
@@ -320,13 +320,35 @@ TEST_F(DistributeCollectTest, FieldsStar_SortBy_Limit_RewritesRemoteLimit) {
   ASSERT_NE(pair.local, nullptr);
 
   EXPECT_EQ(argsAsStrings(pair.remote),
-            (std::vector<std::string>{"fields", "*",
-                                      "sortby", "2", "@price", "desc",
-                                      "limit", "0", "15"}));
+            (std::vector<std::string>{"FIELDS", "*",
+                                      "SORTBY", "2", "@price", "DESC",
+                                      "LIMIT", "0", "15"}));
   EXPECT_EQ(argsAsStrings(pair.local),
             (std::vector<std::string>{"FIELDS", "*",
                                       "SORTBY", "2", "@price", "DESC",
                                       "LIMIT", "5", "10"}));
+
+  AREQ_DecrRef(r);
+}
+
+
+// ----------------------------------------------------------------------------
+// Keyword case normalization
+// ----------------------------------------------------------------------------
+
+TEST_F(DistributeCollectTest, KeywordCase_NormalizedOnRemote_VerbatimOnLocal) {
+  AGGPlan *plan = nullptr;
+  AREQ *r = compileAndDistribute({"fields", "1", "@name"}, &plan);
+  ASSERT_NE(r, nullptr);
+
+  auto pair = locateCollectPair(plan);
+  ASSERT_NE(pair.remote, nullptr);
+  ASSERT_NE(pair.local, nullptr);
+
+  EXPECT_EQ(argsAsStrings(pair.remote),
+            (std::vector<std::string>{"FIELDS", "1", "@name"}));
+  EXPECT_EQ(argsAsStrings(pair.local),
+            (std::vector<std::string>{"fields", "1", "@name"}));
 
   AREQ_DecrRef(r);
 }

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -1518,10 +1518,9 @@ def test_two_identical_collect_reducers():
 
 
 def test_two_collect_reducers_case_variant_keywords():
-    # MOD-16365: two REDUCE COLLECT calls that are identical except for the case
-    # of the option keywords (FIELDS/SORTBY/ASC) must still dedup on the remote
-    # side. Before the fix the coordinator emitted two remote reducers sharing one
-    # lowercased synthetic alias and failed with SEARCH_FIELD_DUP in cluster.
+    # Option keywords are case-insensitive: two COLLECTs differing only in
+    # keyword case (FIELDS/SORTBY/ASC) are the same reducer and must return
+    # the same results.
     env = Env(protocol=3)
     _setup_hash(env)
 

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -1535,6 +1535,7 @@ def test_two_collect_reducers_case_variant_keywords():
         'red':    [{'name': 'apple'},  {'name': 'strawberry'}],
         'yellow': [{'name': 'banana'}, {'name': 'lemon'}],
     }
+    env.assertEqual(len(res['results']), len(expected))
     for g in res['results']:
         attrs = g['extra_attributes']
         env.assertEqual(_sort_collected(attrs['names_a'], 'name'), expected[attrs['color']])

--- a/tests/pytests/test_groupby_collect.py
+++ b/tests/pytests/test_groupby_collect.py
@@ -1517,6 +1517,31 @@ def test_two_identical_collect_reducers():
         env.assertEqual(_sort_collected(attrs['names_b'], 'name'), expected[attrs['color']])
 
 
+def test_two_collect_reducers_case_variant_keywords():
+    # MOD-16365: two REDUCE COLLECT calls that are identical except for the case
+    # of the option keywords (FIELDS/SORTBY/ASC) must still dedup on the remote
+    # side. Before the fix the coordinator emitted two remote reducers sharing one
+    # lowercased synthetic alias and failed with SEARCH_FIELD_DUP in cluster.
+    env = Env(protocol=3)
+    _setup_hash(env)
+
+    res = env.cmd(
+        'FT.AGGREGATE', 'idx', '*',
+        'GROUPBY', '1', '@color',
+            'REDUCE', 'COLLECT', '7', 'FIELDS', '1', '@name', 'SORTBY', '2', '@name', 'ASC', 'AS', 'names_a',
+            'REDUCE', 'COLLECT', '7', 'fields', '1', '@name', 'sortby', '2', '@name', 'asc', 'AS', 'names_b')
+
+    expected = {
+        'green':  [{'name': 'kiwi'},   {'name': 'lime'}],
+        'red':    [{'name': 'apple'},  {'name': 'strawberry'}],
+        'yellow': [{'name': 'banana'}, {'name': 'lemon'}],
+    }
+    for g in res['results']:
+        attrs = g['extra_attributes']
+        env.assertEqual(_sort_collected(attrs['names_a'], 'name'), expected[attrs['color']])
+        env.assertEqual(_sort_collected(attrs['names_b'], 'name'), expected[attrs['color']])
+
+
 # ---------------------------------------------------------------------------
 # COLLECT across multiple GROUPBY stages
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** In cluster mode, a `GROUPBY` with two `REDUCE COLLECT` calls that differ only in the case of COLLECT's option keywords (`FIELDS` vs `fields`, `SORTBY`/`ASC`/`DESC`/`LIMIT`/`DISTINCT`) fails:

   ```
   127.0.0.1:30001> FT.AGGREGATE idx * GROUPBY 1 @t1 REDUCE COLLECT 3 FIELDS 1 @t2 AS a REDUCE COLLECT 3 fields 1 @t2 AS b
   (error) SEARCH_FIELD_DUP Property `__generated_aliascollectfields,1,t2` specified more than once
   ```

   The coordinator's remote-reducer dedup compares args byte-wise, so the case variants are treated as different reducers — but the generated remote alias lowercases the args, so both synthetic reducers get the same alias, which RLookup rejects. Identically-spelled duplicates already dedup correctly (#9755); case is the one difference the dedup sees and the alias erases.

2. **Change:** Normalize COLLECT's option keywords when `distributeCollect` builds the remote argv: the copy loop swaps each keyword slot to its normalized uppercase spelling (`CollectArgs_NormalizedKeyword`, a static-table lookup in `collect.c` so the keyword grammar stays in one file). Values (`@field` names, numbers) and the entire local argv are forwarded verbatim, so user-visible plans keep the original casing.

3. **Outcome:** Case-variant duplicate COLLECTs dedup like identical ones: a single remote COLLECT per shard, both local reducers reading it via `inputAlias`. No `SEARCH_FIELD_DUP`, no duplicate shard work. Standalone behavior is unchanged (the bug is cluster-only).

   COLLECT is the only reducer affected — it is the only *distributed* reducer whose args contain option keywords (`FIRST_VALUE` also has keywords but is not distributable).

   Known residual (separate issue): two reducers over distinct schema fields differing only in case (`@t2` vs `@T2`) still collide, for all distributed reducers — an alias-injectivity problem requiring a different fix (uniquifying the internal remote alias).

#### Which additional issues this PR fixes
1. MOD-16365
2. Follow-up to #9755

#### Main objects this PR modified
1. `src/coord/dist_plan.cpp` — `distributeCollect` remote argv build
2. `src/aggregate/reducers/collect.c` / `collect_parse.h` — `CollectArgs_NormalizedKeyword`
3. `tests/pytests/test_groupby_collect.py` — cluster + standalone regression test
4. `tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp` — remote argv asserts normalized keywords; local argv verbatim

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)