### PR TITLE
[8.4] [MOD-14309][MOD-14311] Add FT.DEBUG for FT.HYBRID and propagate timeout warnings (#9215)

### DIFF
--- a/src/aggregate/reply_empty.c
+++ b/src/aggregate/reply_empty.c
@@ -117,7 +117,7 @@ static void build_hybrid_empty_internal_reply(RedisModule_Reply *reply, QueryErr
     RedisModule_ReplyKV_Array(reply, "warnings"); // warnings []
     if (QueryError_HasQueryOOMWarning(status)) {
         QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_OUT_OF_MEMORY_SHARD, 1, SHARD_ERR_WARN);
-        RedisModule_Reply_SimpleString(reply, QueryError_Strerror(QUERY_EOOM));
+        RedisModule_Reply_SimpleString(reply, QUERY_WOOM_SHARD);
     }
     RedisModule_Reply_ArrayEnd(reply); // ~warnings
 

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -11,6 +11,7 @@
 #include "hybrid/hybrid_request.h"
 #include "hybrid/hybrid_exec.h"
 #include "aggregate/reply_empty.h"
+#include "hybrid/hybrid_debug.h"
 #include "hybrid/dist_hybrid_plan.h"
 #include "hybrid/parse_hybrid.h"
 #include "dist_plan.h"
@@ -571,7 +572,8 @@ void printDistHybridProfile(RedisModule_Reply *reply, void *ctx) {
 
 static int HybridRequest_prepareForExecution(HybridRequest *hreq,
         RedisModuleCtx *ctx, RedisModuleString **argv, int argc, IndexSpec *sp,
-        size_t numShards, QueryError *status) {
+        size_t numShards, QueryError *status,
+        const HybridDebugParams *debugParams) {
 
     hreq->tailPipeline->qctx.err = status;
     hreq->profile = printDistHybridProfile;
@@ -655,6 +657,18 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     xcmd.forProfiling = profileOptions != EXEC_NO_FLAGS;
     xcmd.rootCommand = C_READ;
 
+    // For debug commands, wrap the shard command with _FT.DEBUG prefix and
+    // append the debug parameters so the shard-side debug handler can apply them.
+    if (debugParams) {
+      MRCommand_Insert(&xcmd, 0, "_FT.DEBUG", sizeof("_FT.DEBUG") - 1);
+      int debug_argv_count = (int)debugParams->debug_params_count + 2;
+      for (int i = 0; i < debug_argv_count; i++) {
+        size_t n;
+        const char *arg = RedisModule_StringPtrLen(debugParams->debug_argv[i], &n);
+        MRCommand_Append(&xcmd, arg, n);
+      }
+    }
+
     // UPDATED: Use new start function with mappings (no dispatcher needed)
     HybridRequest_buildDistRPChain(hreq->requests[0], &xcmd, lookups[0], rpnetNext_StartWithMappings);
     HybridRequest_buildDistRPChain(hreq->requests[1], &xcmd, lookups[1], rpnetNext_StartWithMappings);
@@ -701,9 +715,10 @@ static int HybridRequest_executePlan(HybridRequest *hreq, struct ConcurrentCmdCt
     MRCommand *cmd = &searchRPNet->cmd;
 
     const RSOomPolicy oomPolicy = hreq->reqConfig.oomPolicy;
+    const RSTimeoutPolicy timeoutPolicy = hreq->reqConfig.timeoutPolicy;
     const struct timespec *deadline =
         hreq->sctx ? (const struct timespec *)&hreq->sctx->time.timeout : NULL;
-    if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, hreq->tailPipeline->qctx.err, oomPolicy, deadline)) {
+    if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, hreq->tailPipeline->qctx.err, oomPolicy, timeoutPolicy, deadline)) {
         // Handle error
         StrongRef_Release(searchMappingsRef);
         StrongRef_Release(vsimMappingsRef);
@@ -806,7 +821,66 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
 
     size_t numShards = ConcurrentCmdCtx_GetNumShards(cmdCtx);
 
-    if (HybridRequest_prepareForExecution(hreq, ctx, argv, argc, sp, numShards, &status) != REDISMODULE_OK) {
+    if (HybridRequest_prepareForExecution(hreq, ctx, argv, argc, sp, numShards, &status, NULL) != REDISMODULE_OK) {
+      DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, hreq, reply, &status);
+      return;
+    }
+
+    if (HybridRequest_executePlan(hreq, cmdCtx, reply, &status) != REDISMODULE_OK) {
+        DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, hreq, reply, &status);
+        return;
+    }
+    WeakRef_Release(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
+    IndexSpecRef_Release(strong_ref);
+    RedisModule_EndReply(reply);
+}
+
+void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                            struct ConcurrentCmdCtx *cmdCtx) {
+
+    RedisModule_Reply _reply = RedisModule_NewReply(ctx);
+    RedisModule_Reply *reply = &_reply;
+    QueryError status = QueryError_Default();
+
+    // Parse debug params from the end of argv
+    HybridDebugParams debugParams = parseHybridDebugParamsCount(argv, argc, &status);
+    if (QueryError_HasError(&status)) {
+      DistHybridCleanups(ctx, cmdCtx, NULL, NULL, NULL, reply, &status);
+      return;
+    }
+    if (parseHybridDebugParams(&debugParams, &status) != REDISMODULE_OK) {
+      DistHybridCleanups(ctx, cmdCtx, NULL, NULL, NULL, reply, &status);
+      return;
+    }
+
+    // Strip debug params from argc for parsing
+    int stripped_argc = argc - (int)debugParams.debug_params_count - 2;
+
+    const char *indexname = RedisModule_StringPtrLen(argv[1], NULL);
+    RedisSearchCtx *sctx = NewSearchCtxC(ctx, indexname, true);
+    if (!sctx) {
+        QueryError_SetWithUserDataFmt(&status, QUERY_ENOINDEX, "Index not found", ": %s", indexname);
+        DistHybridCleanups(ctx, cmdCtx, NULL, NULL, NULL, reply, &status);
+        return;
+    }
+
+    StrongRef strong_ref = IndexSpecRef_Promote(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
+    IndexSpec *sp = StrongRef_Get(strong_ref);
+    if (!sp) {
+        SearchCtx_Free(sctx);
+        QueryError_SetCode(&status, QUERY_EDROPPEDBACKGROUND);
+        DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, NULL, reply, &status);
+        return;
+    }
+
+    HybridRequest *hreq = MakeDefaultHybridRequest(sctx);
+
+    size_t numShards = ConcurrentCmdCtx_GetNumShards(cmdCtx);
+
+    // Use stripped_argc so parsing doesn't see debug params;
+    // pass debugParams so the MR command gets _FT.DEBUG prefix + debug args.
+    if (HybridRequest_prepareForExecution(hreq, ctx, argv, stripped_argc, sp, numShards,
+                                          &status, &debugParams) != REDISMODULE_OK) {
       DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, hreq, reply, &status);
       return;
     }

--- a/src/coord/hybrid/dist_hybrid.h
+++ b/src/coord/hybrid/dist_hybrid.h
@@ -21,6 +21,8 @@ extern "C" {
 
 void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                         struct ConcurrentCmdCtx *cmdCtx);
+void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                            struct ConcurrentCmdCtx *cmdCtx);
 
 // For testing purposes
 // numShards is passed from the main thread to ensure thread-safe access

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -36,6 +36,25 @@ static void processHybridError(processCursorMappingCallbackContext *ctx, MRReply
     ctx->errors = array_ensure_append_1(ctx->errors, error);
 }
 
+// Warning strings use a different format than error strings (no prefix).
+// Map warning codes to error codes for uniform handling in ProcessHybridCursorMappings.
+static void processHybridWarning(processCursorMappingCallbackContext *ctx, const MRReply *rep) {
+    const char *warningMessage = MRReply_String(rep, NULL);
+    QueryWarningCode warningCode = QueryWarningCode_GetCodeFromMessage(warningMessage);
+    QueryErrorCode code;
+    if (warningCode == QUERY_WARNING_CODE_TIMED_OUT) {
+        code = QUERY_ETIMEDOUT;
+    } else if (warningCode == QUERY_WARNING_CODE_OUT_OF_MEMORY_SHARD ||
+               warningCode == QUERY_WARNING_CODE_OUT_OF_MEMORY_COORD) {
+        code = QUERY_EOOM;
+    } else {
+        code = QUERY_EGENERIC;
+    }
+    QueryError error = QueryError_Default();
+    QueryError_SetError(&error, code, warningMessage);
+    ctx->errors = array_ensure_append_1(ctx->errors, error);
+}
+
 static void processHybridUnknownReplyType(processCursorMappingCallbackContext *ctx, int replyType) {
     QueryError error = QueryError_Default();
     QueryError_SetWithoutUserDataFmt(&error, QUERY_EUNSUPPTYPE, "Unsupported reply type: %d", replyType);
@@ -58,7 +77,7 @@ static void processHybridResp2(processCursorMappingCallbackContext *ctx, MRReply
         if (strcmp(key, "warnings") == 0) {
             for (size_t j = 0; j < MRReply_Length(value_reply); j++) {
                 MRReply *warningReply = MRReply_ArrayElement(value_reply, j);
-                processHybridError(ctx, warningReply);
+                processHybridWarning(ctx, warningReply);
             }
             continue;
         }
@@ -144,7 +163,7 @@ static void processHybridResp3(processCursorMappingCallbackContext *ctx, MRReply
     if (MRReply_Length(warnings) > 0) {
         for (size_t i = 0; i < MRReply_Length(warnings); i++) {
             MRReply *warningReply = MRReply_ArrayElement(warnings, i);
-            processHybridError(ctx, warningReply);
+            processHybridWarning(ctx, warningReply);
         }
     }
 }
@@ -196,7 +215,7 @@ static void freeCursorMappingCtx(void *privateData) {
     rm_free(ctx);
 }
 
-bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsRef, StrongRef vsimMappingsRef, QueryError *status, const RSOomPolicy oomPolicy, const struct timespec *deadline) {
+bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsRef, StrongRef vsimMappingsRef, QueryError *status, const RSOomPolicy oomPolicy, const RSTimeoutPolicy timeoutPolicy, const struct timespec *deadline) {
     CursorMappings *searchMappings = StrongRef_Get(searchMappingsRef);
     CursorMappings *vsimMappings = StrongRef_Get(vsimMappingsRef);
     RS_ASSERT(array_len(searchMappings->mappings) == 0 && array_len(vsimMappings->mappings) == 0);
@@ -243,6 +262,18 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
         for (size_t i = 0; i < array_len(ctx->errors); i++) {
             if (QueryError_GetCode(&ctx->errors[i]) == QUERY_EOOM && oomPolicy == OomPolicy_Return ) {
                 QueryError_SetQueryOOMWarning(status);
+            } else if (QueryError_GetCode(&ctx->errors[i]) == QUERY_ETIMEDOUT && timeoutPolicy != TimeoutPolicy_Fail) {
+                // RETURN policy: acknowledge the shard timeout but don't set it
+                // on qctx->err. The timeout will propagate through cursor reads
+                // (RPNet detects it from the depleter's last_rc), and
+                // replyWarningsWithSuffixes emits the properly-suffixed warning
+                // (e.g., "(SEARCH)" / "(VSIM)").
+            } else if (QueryError_GetCode(&ctx->errors[i]) == QUERY_ETIMEDOUT) {
+                // FAIL policy: forward the standard timeout error directly,
+                // matching the standalone path which uses QueryError_Strerror().
+                QueryError_SetCode(status, QUERY_ETIMEDOUT);
+                success = false;
+                break;
             } else {
                 QueryError_SetWithoutUserDataFmt(status, QueryError_GetCode(&ctx->errors[i]), "Failed to process shard responses, first error: %s, total error count: %zu",
                     QueryError_GetUserError(&ctx->errors[i]), array_len(ctx->errors));

--- a/src/coord/hybrid/hybrid_cursor_mappings.h
+++ b/src/coord/hybrid/hybrid_cursor_mappings.h
@@ -47,11 +47,13 @@ typedef struct QueryError QueryError;
  * @param vsimMappings Empty array to populate with vector similarity cursor mappings
  * @param status QueryError pointer to store warning/error information
  * @param oomPolicy OOM policy to determine error handling behavior
+ * @param timeoutPolicy Timeout policy: on RETURN, shard timeout warnings are left to propagate
+ *                      through cursor reads; on FAIL, they abort the request with a timeout error
  * @param deadline Absolute (monotonic) time after which the cursor-setup wait gives up and
  *                 reports a timeout, or NULL to wait without a deadline (e.g. timeout disabled)
  * @return true if processing completed (even with warnings), false on fatal errors; status will contain error/warning information
  */
-bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappings, StrongRef vsimMappings, QueryError *status, RSOomPolicy oomPolicy, const struct timespec *deadline);
+bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappings, StrongRef vsimMappings, QueryError *status, RSOomPolicy oomPolicy, RSTimeoutPolicy timeoutPolicy, const struct timespec *deadline);
 
 /**
  * Release resources associated with a cursor mapping

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -28,6 +28,7 @@
 #include "module.h"
 #include "aggregate/aggregate_debug.h"
 #include "hybrid/hybrid_debug.h"
+#include "hybrid/hybrid_exec.h"
 #include "reply.h"
 #include "reply_macros.h"
 #include "obfuscation/obfuscation_api.h"
@@ -1615,11 +1616,45 @@ DEBUG_COMMAND(ProfileCommandCommand_DebugWrapper) {
   return ProfileCommandHandlerImp(ctx, ++argv, --argc, true);
 }
 
+DEBUG_COMMAND(RSShardedHybridCommand_Debug) {
+  if (!debugCommandsEnabled(ctx)) {
+    return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
+  }
+  if (argc < 9) {
+    return RedisModule_WrongArity(ctx);
+  }
+  // Skip _FT.DEBUG prefix — argv now starts at FT.HYBRID / _FT.HYBRID
+  ++argv; --argc;
+
+  QueryError status = QueryError_Default();
+  HybridDebugParams params = parseHybridDebugParamsCount(argv, argc, &status);
+  if (QueryError_HasError(&status)) {
+    return QueryError_ReplyAndClear(ctx, &status);
+  }
+  if (parseHybridDebugParams(&params, &status) != REDISMODULE_OK) {
+    return QueryError_ReplyAndClear(ctx, &status);
+  }
+
+  // Strip debug params from argc so hybridCommandHandler sees a normal command
+  int stripped_argc = argc - (int)params.debug_params_count - 2;
+  return hybridCommandHandler(ctx, argv, stripped_argc, true, EXEC_NO_FLAGS, &params);
+}
+
 DEBUG_COMMAND(HybridCommand_DebugWrapper) {
   if (!debugCommandsEnabled(ctx)) {
     return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
   }
-  return DEBUG_hybridCommandHandler(ctx, ++argv, --argc);
+  if (argc < 9) {
+    // Minimum: _FT.DEBUG FT.HYBRID idx SEARCH query VSIM field vector DEBUG_PARAMS_COUNT count
+    return RedisModule_WrongArity(ctx);
+  }
+
+  if (GetNumShards_UnSafe() == 1) {
+    // Single shard — use standalone handler (skip _FT.DEBUG)
+    return DEBUG_hybridCommandHandler(ctx, ++argv, --argc);
+  }
+
+  return DistHybridCommandInternal(ctx, ++argv, --argc, true, false /* isProfile */);
 }
 
 /**
@@ -2268,7 +2303,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"FT.SEARCH", DistSearchCommand_DebugWrapper},
                                {"_FT.SEARCH", RSSearchCommandShard}, // internal use only, in SA use FT.SEARCH
                                {"FT.HYBRID", HybridCommand_DebugWrapper},
-                               {"_FT.HYBRID", HybridCommand_DebugWrapper}, // internal use only, in SA use FT.HYBRID
+                               {"_FT.HYBRID", RSShardedHybridCommand_Debug},
                                {"FT.PROFILE", ProfileCommandCommand_DebugWrapper},
                                {"_FT.PROFILE", RSProfileCommandShard},
                                /* IMPORTANT NOTE: Every debug command starts with

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -8,6 +8,7 @@
  */
 
 #include "hybrid_debug.h"
+#include "config.h"
 #include "hybrid_exec.h"
 #include "hybrid_request.h"
 #include "parse_hybrid.h"
@@ -15,27 +16,13 @@
 #include "rmutil/args.h"
 #include "rmalloc.h"
 
-// Debug parameters structure for hybrid queries
-typedef struct {
-  RedisModuleString **debug_argv;
-  unsigned long long debug_params_count;
-
-  // Component-specific timeouts only
-  unsigned long long search_timeout_count;
-  unsigned long long vsim_timeout_count;
-  unsigned long long tail_timeout_count;
-  int search_timeout_set;
-  int vsim_timeout_set;
-  int tail_timeout_set;
-} HybridDebugParams;
-
 // Wrapper structure for hybrid request with debug capabilities
 typedef struct {
   HybridRequest *hreq;                     // Base hybrid request
   HybridDebugParams debug_params;          // Debug parameters
 } HybridRequest_Debug;
 
-static HybridDebugParams parseHybridDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status) {
+HybridDebugParams parseHybridDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status) {
   HybridDebugParams debug_params = {0};
 
   // Verify DEBUG_PARAMS_COUNT exists in its expected position (second to last argument)
@@ -58,6 +45,12 @@ static HybridDebugParams parseHybridDebugParamsCount(RedisModuleString **argv, i
     return debug_params;
   }
 
+  if (debug_params_count > (unsigned long long)(argc - 2)) {
+    QueryError_SetError(status, QUERY_EPARSEARGS,
+                        "DEBUG_PARAMS_COUNT exceeds the number of available arguments");
+    return debug_params;
+  }
+
   debug_params.debug_params_count = debug_params_count;
   int debug_argv_count = debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
   debug_params.debug_argv = argv + (argc - debug_argv_count);
@@ -65,8 +58,7 @@ static HybridDebugParams parseHybridDebugParamsCount(RedisModuleString **argv, i
   return debug_params;
 }
 
-static int parseHybridDebugParams(HybridRequest_Debug *debug_req, QueryError *status) {
-  HybridDebugParams *params = &debug_req->debug_params;
+int parseHybridDebugParams(HybridDebugParams *params, QueryError *status) {
   RedisModuleString **debug_argv = params->debug_argv;
   unsigned long long debug_params_count = params->debug_params_count;
 
@@ -148,7 +140,7 @@ static int parseHybridDebugParams(HybridRequest_Debug *debug_req, QueryError *st
   return REDISMODULE_OK;
 }
 
-static int applyHybridTimeout(HybridRequest *hreq, const HybridDebugParams *params) {
+int applyHybridDebugTimeout(HybridRequest *hreq, const HybridDebugParams *params) {
   // Apply component-specific timeouts to search, vector, and tail pipelines
   // A timeout value of 0 means no timeout for that component
 
@@ -175,8 +167,7 @@ static int applyHybridTimeout(HybridRequest *hreq, const HybridDebugParams *para
 }
 
 static int applyHybridDebugToBuiltPipelines(HybridRequest_Debug *debug_req, QueryError *status) {
-  // Apply component-specific timeouts
-  if (applyHybridTimeout(debug_req->hreq, &debug_req->debug_params) != REDISMODULE_OK) {
+  if (applyHybridDebugTimeout(debug_req->hreq, &debug_req->debug_params) != REDISMODULE_OK) {
     QueryError_SetError(status, QUERY_EPARSEARGS, "Failed to apply timeout to built hybrid pipelines");
     return REDISMODULE_ERR;
   }
@@ -278,7 +269,7 @@ int DEBUG_hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, in
   }
 
   // Parse debug parameters
-  if (parseHybridDebugParams(debug_req, &status) != REDISMODULE_OK) {
+  if (parseHybridDebugParams(&debug_req->debug_params, &status) != REDISMODULE_OK) {
     HybridRequest_Debug_Free(debug_req);
     return QueryError_ReplyAndClear(ctx, &status);
   }

--- a/src/hybrid/hybrid_debug.h
+++ b/src/hybrid/hybrid_debug.h
@@ -10,12 +10,13 @@
 #pragma once
 
 #include "redismodule.h"
-#include "hybrid_request.h"
 #include "query_error.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+struct HybridRequest;
 
 /*
  * Debug Mechanism for FT.HYBRID Command
@@ -44,8 +45,39 @@ extern "C" {
  *   # Tail pipeline timeout
  *   _FT.DEBUG FT.HYBRID idx SEARCH "hello" VSIM @vec $blob TIMEOUT_AFTER_N_TAIL 3 DEBUG_PARAMS_COUNT 2
  *
- * Note: Currently supports single shard mode only. Coordinator-shards support will be added later.
+ * Supports both single shard (standalone) and multi-shard (cluster) modes.
  */
+
+// Debug parameters structure for hybrid queries
+typedef struct {
+  RedisModuleString **debug_argv;
+  unsigned long long debug_params_count;
+
+  unsigned long long search_timeout_count;
+  unsigned long long vsim_timeout_count;
+  unsigned long long tail_timeout_count;
+  int search_timeout_set;
+  int vsim_timeout_set;
+  int tail_timeout_set;
+} HybridDebugParams;
+
+/**
+ * Parse DEBUG_PARAMS_COUNT and debug_argv pointer from the end of argv.
+ * Does NOT parse individual debug params (TIMEOUT_AFTER_N_SEARCH, etc.).
+ * Sets status on error; returns a zeroed struct with debug_params_count==0 on failure.
+ */
+HybridDebugParams parseHybridDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status);
+
+/**
+ * Parse individual debug parameters (TIMEOUT_AFTER_N_SEARCH, etc.) from
+ * the debug_argv region already identified by parseHybridDebugParamsCount.
+ */
+int parseHybridDebugParams(HybridDebugParams *params, QueryError *status);
+
+/**
+ * Apply parsed debug timeouts to the built pipelines of a HybridRequest.
+ */
+int applyHybridDebugTimeout(struct HybridRequest *hreq, const HybridDebugParams *params);
 
 /**
  * Debug command handler for FT.HYBRID (single shard mode).

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -64,8 +64,9 @@ static inline bool handleAndReplyWarning(RedisModule_Reply *reply, QueryError *e
     ReplyWarning(reply, QueryError_Strerror(QUERY_ETIMEDOUT), suffix);
     timeoutOccurred = true;
   } else if (returnCode == RS_RESULT_ERROR) {
-    // Non-fatal error
+    // Non-fatal error - convert to warning
     ReplyWarning(reply, QueryError_GetUserError(err), suffix);
+    QueryError_ClearError(err);
   } else if (QueryError_HasReachedMaxPrefixExpansionsWarning(err)) {
     QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_REACHED_MAX_PREFIX_EXPANSIONS, 1, COORD_ERR_WARN);
     ReplyWarning(reply, QUERY_WMAXPREFIXEXPANSIONS, suffix);

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -403,7 +403,7 @@ int HybridRequest_StartSingleCursor(StrongRef hybrid_ref, RedisModule_Reply *rep
     return REDISMODULE_OK;
 }
 
-static inline void replyWithCursors(RedisModuleCtx *replyCtx, arrayof(Cursor*) cursors) {
+static inline void replyWithCursors(RedisModuleCtx *replyCtx, arrayof(Cursor*) cursors, bool timedOut) {
     RedisModule_Reply _reply = RedisModule_NewReply(replyCtx), *reply = &_reply;
     // Send map of cursor IDs as response
     RedisModule_Reply_Map(reply);
@@ -415,13 +415,15 @@ static inline void replyWithCursors(RedisModuleCtx *replyCtx, arrayof(Cursor*) c
       } else if (IsHybridVectorSubquery(areq)) {
         RedisModule_ReplyKV_LongLong(reply, "VSIM", cursor->id);
       } else {
-        // This should never happen, we currently only support SEARCH and VSIM subqueries
         RS_ABORT_ALWAYS("Unknown subquery type");
       }
       Cursor_Pause(cursor);
     }
-    // Add warnings array
     RedisModule_ReplyKV_Array(reply, "warnings"); // >warnings
+    if (timedOut) {
+      QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_TIMED_OUT, 1, SHARD_ERR_WARN);
+      RedisModule_Reply_SimpleString(reply, QueryError_Strerror(QUERY_ETIMEDOUT));
+    }
     RedisModule_Reply_ArrayEnd(reply); // ~warnings
 
     RedisModule_Reply_MapEnd(reply);
@@ -482,18 +484,28 @@ int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, Q
 
     array_free(depleters);
 
+    bool depletionTimedOut = false;
     if (rc != RS_RESULT_OK) {
-      array_free_ex(cursors, Cursor_Free(*(Cursor**)ptr));
-      if (!QueryError_HasError(status)) {
-        if (rc == RS_RESULT_TIMEDOUT) {
-          QueryError_SetWithoutUserDataFmt(status, QUERY_ETIMEDOUT, "Depleting timed out");
-        } else {
-          QueryError_SetWithoutUserDataFmt(status, QUERY_EGENERIC, "Failed to deplete set of results, rc=%d", rc);
+      if (rc == RS_RESULT_TIMEDOUT && req->reqConfig.timeoutPolicy != TimeoutPolicy_Fail) {
+        // RETURN policy: keep cursors with partial results, emit warning in reply
+        depletionTimedOut = true;
+      } else {
+        // Fatal error or FAIL policy — free everything
+        array_free_ex(cursors, Cursor_Free(*(Cursor**)ptr));
+        if (!QueryError_HasError(status)) {
+          if (rc == RS_RESULT_TIMEDOUT) {
+            // Use the canonical timeout message: the coordinator classifies shard
+            // errors by exact message match, so a custom detail would be treated
+            // as a generic error instead of a timeout.
+            QueryError_SetCode(status, QUERY_ETIMEDOUT);
+          } else {
+            QueryError_SetWithoutUserDataFmt(status, QUERY_EGENERIC, "Failed to deplete set of results, rc=%d", rc);
+          }
         }
+        return REDISMODULE_ERR;
       }
-      return REDISMODULE_ERR;
     }
-    replyWithCursors(replyCtx, cursors);
+    replyWithCursors(replyCtx, cursors, depletionTimedOut);
     array_free(cursors);
     return REDISMODULE_OK;
 }
@@ -539,6 +551,12 @@ static int buildPipelineAndExecute(StrongRef hybrid_ref, HybridPipelineParams *h
   // Record pipeline build time if profiling is enabled
   if (isProfile) {
     hreq->profileClocks.profilePipelineBuildTime = rs_wall_clock_elapsed_ns(&pipelineClock);
+  }
+
+  // Apply debug timeouts after pipeline is built (for _FT.DEBUG FT.HYBRID)
+  if (hreq->debugParams && applyHybridDebugTimeout(hreq, hreq->debugParams) != REDISMODULE_OK) {
+      QueryError_SetError(status, QUERY_EINVAL, "Failed to apply debug timeouts");
+      return REDISMODULE_ERR;
   }
 
   if (!isCursor) {
@@ -657,8 +675,11 @@ void printHybridProfile(RedisModule_Reply *reply, void *ctx) {
  *
  * Parses command arguments, builds hybrid request structure, constructs execution pipeline,
  * and prepares for hybrid search execution.
+ *
+ * This method does not take ownership of `debugParams`.
  */
-int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool internal, ProfileOptions profileOptions) {
+int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool internal,
+                         ProfileOptions profileOptions, const HybridDebugParams *debugParams) {
   // Index name is argv[1]
   if (argc < 2) {
     return RedisModule_WrongArity(ctx);
@@ -691,6 +712,10 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   HybridRequest *hybridRequest = MakeDefaultHybridRequest(sctx);
   hybridRequest->profile = printHybridProfile;
   hybridRequest->tailPipeline->qctx.isProfile = profileOptions & EXEC_WITH_PROFILE;
+  if (debugParams) {
+    hybridRequest->debugParams = rm_malloc(sizeof(*debugParams));
+    *hybridRequest->debugParams = *debugParams;
+  }
   StrongRef hybrid_ref = StrongRef_New(hybridRequest, &FreeHybridRequest);
   HybridPipelineParams hybridParams = {0};
 

--- a/src/hybrid/hybrid_exec.h
+++ b/src/hybrid/hybrid_exec.h
@@ -33,9 +33,13 @@ extern "C" {
  * @param argc Number of arguments in argv
  * @param internal Whether the request is internal (true - shard in cluster setup, false - Coordinator in cluster setup or standalone)
  * @param profileOptions Profile options for the command
+ * @param debugParams Optional debug parameters (NULL for normal execution).
+ *                    When non-NULL, debug timeouts are applied after pipeline building.
+ *                    Caller retains ownership.
  * @return REDISMODULE_OK on success, REDISMODULE_ERR on error
  */
-int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool internal, ProfileOptions profileOptions);
+int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool internal,
+                         ProfileOptions profileOptions, const HybridDebugParams *debugParams);
 
 void HybridRequest_StartCursor(HybridRequest *req, RedisModuleCtx *ctx, arrayof(ResultProcessor*) depleters, QueryError *status, bool coord);
 

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -309,6 +309,9 @@ void HybridRequest_Free(HybridRequest *req) {
 
     // Clean up the tail pipeline error
     QueryError_ClearError(&req->tailPipelineError);
+
+    rm_free(req->debugParams);
+
     if (req->args) {
       for (size_t ii = 0; ii < req->nargs; ++ii) {
         sdsfree(req->args[ii]);

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -2,6 +2,7 @@
 #include "aggregate/aggregate.h"
 #include "pipeline/pipeline.h"
 #include "hybrid/hybrid_scoring.h"
+#include "hybrid/hybrid_debug.h"
 #include "util/references.h"
 #include "redismodule.h"
 
@@ -36,6 +37,11 @@ typedef struct HybridRequest {
     ProfileClocks profileClocks;
     profiler_func profile;
     ProfilePrinterCtx profileCtx;
+
+    // Optional debug parameters for _FT.DEBUG FT.HYBRID.
+    // When non-NULL, debug timeouts are applied after pipeline building.
+    // Heap-allocated and owned by HybridRequest — freed in HybridRequest_Free.
+    HybridDebugParams *debugParams;
 } HybridRequest;
 
 // Blocked client context for HybridRequest background execution

--- a/src/module.c
+++ b/src/module.c
@@ -75,6 +75,8 @@
 #include "search_disk.h"
 #include "rs_wall_clock.h"
 #include "hybrid/hybrid_exec.h"
+#include "hybrid/hybrid_debug.h"
+#include "coord/hybrid/dist_hybrid.h"
 #include "util/redis_mem_info.h"
 #include "aggregate/reply_empty.h"
 #include "asm_state_machine.h"
@@ -1548,11 +1550,11 @@ static int CreateArbitraryWriteSearchCommands(RedisModuleCtx *ctx, const SearchC
 }
 
 int RSShardedHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-return hybridCommandHandler(ctx, argv, argc, true, EXEC_NO_FLAGS);
+return hybridCommandHandler(ctx, argv, argc, true, EXEC_NO_FLAGS, NULL);
 }
 
 int RSClientHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  return hybridCommandHandler(ctx, argv, argc, false, EXEC_NO_FLAGS);
+  return hybridCommandHandler(ctx, argv, argc, false, EXEC_NO_FLAGS, NULL);
 }
 
 #define PROFILE_1ST_PARAM 2
@@ -1624,7 +1626,7 @@ int RSProfileCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
   if (cmdType == COMMAND_HYBRID) {
     RedisModuleString *command = argv[0];
     bool internal = RedisModule_StringPtrLen(command, NULL)[0] == '_'; // _FT.PROFILE or FT.PROFILE
-    hybridCommandHandler(ctx, newArgv, newArgc, internal, withProfile);
+    hybridCommandHandler(ctx, newArgv, newArgc, internal, withProfile, NULL);
   } else {
     // RSExecuteAggregateOrSearch(ctx, newArgv, newArgc, cmdType, withProfile);
     execCommandHandlerFunc(ctx, newArgv, newArgc, cmdType, withProfile);
@@ -3499,6 +3501,10 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 
   if (NumShards == 1) {
     // There is only one shard in the cluster. We can handle the command locally.
+    if (isDebug) {
+      // argv still contains debug params; the non-debug handler would reject them as unknown args.
+      return DEBUG_RSAggregateCommand(ctx, argv, argc);
+    }
     return RSAggregateCommand(ctx, argv, argc);
   } else if (cannotBlockCtx(ctx)) {
     return ReplyBlockDeny(ctx, argv[0]);
@@ -3513,10 +3519,9 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
                                                &handlerCtx);
 }
 
-void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
-                      struct ConcurrentCmdCtx *cmdCtx);
+int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                              bool isDebug, bool isProfile) {
 
-static int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isProfile) {
   if (NumShards == 0) {
     return RedisModule_ReplyWithError(ctx, CLUSTERDOWN_ERR);
   } else if (argc < 3) {
@@ -3537,6 +3542,9 @@ static int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **ar
 
   // Coord callback
   ConcurrentCmdHandler dist_callback = RSExecDistHybrid;
+  if (isDebug) {
+    dist_callback = DEBUG_RSExecDistHybrid;
+  }
 
   // Prepare the spec ref for the background thread
   const char *idx = RedisModule_StringPtrLen(argv[1], NULL);
@@ -3553,6 +3561,10 @@ static int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **ar
   }
 
   if (NumShards == 1) {
+    if (isDebug) {
+      // argv still contains debug params; the non-debug handler would reject them as unknown args.
+      return DEBUG_hybridCommandHandler(ctx, argv, argc);
+    }
     return RSClientHybridCommand(ctx, argv, argc);
   } else if (cannotBlockCtx(ctx)) {
     return ReplyBlockDeny(ctx, argv[0]);
@@ -3568,7 +3580,7 @@ static int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **ar
 }
 
 int DistHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  return DistHybridCommandInternal(ctx, argv, argc, false);
+  return DistHybridCommandInternal(ctx, argv, argc, false /* isDebug */, false /* isProfile */);
 }
 
 static void CursorCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, struct ConcurrentCmdCtx *cmdCtx) {
@@ -3946,6 +3958,10 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
 
   if (NumShards == 1) {
     // There is only one shard in the cluster. We can handle the command locally.
+    if (isDebug) {
+      // argv still contains debug params; the non-debug handler would reject them as unknown args.
+      return DEBUG_RSSearchCommand(ctx, argv, argc);
+    }
     return RSSearchCommand(ctx, argv, argc);
   } else if (cannotBlockCtx(ctx)) {
     return ReplyBlockDeny(ctx, argv[0]);
@@ -3994,12 +4010,18 @@ int ProfileCommandHandlerImp(RedisModuleCtx *ctx, RedisModuleString **argv, int 
     return RSProfileCommandImp(ctx, argv, argc, isDebug);
   }
 
+  // For SEARCH and AGGREGATE, pass isDebug through: their debug param format
+  // (TIMEOUT_AFTER_N, INTERNAL_ONLY) matches the profile debug params.
+  // For HYBRID, always pass false: hybrid uses command-specific debug params
+  // (TIMEOUT_AFTER_N_SEARCH, TIMEOUT_AFTER_N_VSIM, TIMEOUT_AFTER_N_TAIL) that
+  // differ from profile debug params. Passing isDebug=true would select
+  // DEBUG_RSExecDistHybrid, which would fail to parse the profile debug params.
   if (RMUtil_ArgExists("SEARCH", argv, 3, 2)) {
     return DistSearchCommandImp(ctx, argv, argc, isDebug);
   } else if (RMUtil_ArgExists("AGGREGATE", argv, 3, 2)) {
     return DistAggregateCommandImp(ctx, argv, argc, isDebug);
   } else if (RMUtil_ArgExists("HYBRID", argv, 3, 2)) {
-    return DistHybridCommandInternal(ctx, argv, argc, true);
+    return DistHybridCommandInternal(ctx, argv, argc, false, true /* isProfile */);
   }
   return RedisModule_ReplyWithError(ctx, "No `SEARCH`, `AGGREGATE`, or `HYBRID` provided");
 }

--- a/src/module.h
+++ b/src/module.h
@@ -121,6 +121,7 @@ void processResultFormat(uint32_t *flags, MRReply *map);
 
 int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDebug);
 int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDebug);
+int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDebug, bool isProfile);
 int RSProfileCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDebug);
 int ProfileCommandHandlerImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDebug);
 

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1828,13 +1828,22 @@ int RPSafeDepleter_DepleteAll(arrayof(ResultProcessor*) safeDepleters, QueryErro
   // after all depleters acquired their locks (or when any failed).
   // This early release prevents deadlock with SafeLoader GIL acquisition.
 
-  // Check if any depleter skipped the lock phase (timeout before start or lock failure)
-  int num_skipped_lock = atomic_load(&sync->num_skipped_lock);
-  if (num_skipped_lock > 0) {
-    // At least one depleter skipped the lock phase
-    QueryError_SetWithoutUserDataFmt(status, QUERY_ESAFEDEPLETERFAILURE,
-      "Failed to acquire index lock for background depletion. A write operation may be in progress. Please retry.");
-    return RS_RESULT_ERROR;
+  // Check each depleter's final status for errors or timeouts.
+  // Errors (lock failures) take priority over timeouts.
+  bool anyTimedOut = false;
+  for (size_t i = 0; i < count; i++) {
+    const RPSafeDepleter *safeDepleter = (RPSafeDepleter *)safeDepleters[i];
+    if (safeDepleter->last_rc == RS_RESULT_ERROR) {
+      QueryError_SetWithoutUserDataFmt(status, QUERY_ESAFEDEPLETERFAILURE,
+        "Failed to acquire index lock for background depletion. A write operation may be in progress. Please retry.");
+      return RS_RESULT_ERROR;
+    } else if (safeDepleter->last_rc == RS_RESULT_TIMEDOUT) {
+      anyTimedOut = true;
+    }
+  }
+
+  if (anyTimedOut) {
+    return RS_RESULT_TIMEDOUT;
   }
 
   return RS_RESULT_OK;
@@ -2575,13 +2584,16 @@ rs_wall_clock_ns_t RPDepleter_GetDepletionTime(const ResultProcessor *base) {
 }
 
 int RPDepleter_DepleteAll(arrayof(ResultProcessor*) depleters) {
+  bool anyTimedOut = false;
   for (size_t i = 0; i < array_len(depleters); i++) {
     RS_ASSERT(depleters[i]->type == RP_DEPLETER);
     RPDepleter_StartDepletion(depleters[i]);
     const RPDepleter *depleter = (const RPDepleter *)depleters[i];
-    if (depleter->last_rc != RS_RESULT_EOF) {
-      return depleter->last_rc;
+    if (depleter->last_rc == RS_RESULT_ERROR) {
+      return RS_RESULT_ERROR;
+    } else if (depleter->last_rc == RS_RESULT_TIMEDOUT) {
+      anyTimedOut = true;
     }
   }
-  return RS_RESULT_OK;
+  return anyTimedOut ? RS_RESULT_TIMEDOUT : RS_RESULT_OK;
 }

--- a/tests/pytests/test_hybrid_timeout.py
+++ b/tests/pytests/test_hybrid_timeout.py
@@ -42,9 +42,121 @@ def setup_basic_index(env):
     for doc_id, doc_data in test_data.items():
         conn.execute_command('HSET', doc_id, 'description', doc_data['description'], 'embedding', doc_data['embedding'])
 
-# Debug timeout tests using TIMEOUT_AFTER_N_* parameters
-#TODO: remove skip once FT.HYBRID for cluster is implemented
+def test_hybrid_debug_with_no_index_error():
+    """Test error when index does not exist"""
+    env = Env(enableDebugCommand=True)
+    # 8.6 predates the unified SEARCH_* error codes; both the standalone
+    # handler and the coordinator dispatcher reply with this text.
+    env.expect(
+        '_FT.DEBUG', 'FT.HYBRID', 'nonexistent_idx',
+        'SEARCH', '*',
+        'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
+        'TIMEOUT_AFTER_N_SEARCH', '1', 'DEBUG_PARAMS_COUNT', '2').error()\
+        .contains('No such index nonexistent_idx')
+
+
+# ---------------------------------------------------------------------------
+# Parameter validation tests for FT.HYBRID debug commands
+# ---------------------------------------------------------------------------
+
+def _base_hybrid_debug_cmd(idx='idx'):
+    """Build the common prefix for a hybrid debug command."""
+    return ['_FT.DEBUG', 'FT.HYBRID', idx, 'SEARCH', '*',
+            'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector]
+
+def test_hybrid_debug_wrong_arity():
+    """Test wrong arity for both the distributed and shard-level debug wrappers."""
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    # Too few arguments (need at least 9 for _FT.DEBUG FT.HYBRID)
+    env.expect('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM', '@embedding') \
+        .error().contains('wrong number of arguments')
+
+def test_hybrid_debug_missing_debug_params_count():
+    """Test error when DEBUG_PARAMS_COUNT is not provided."""
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    # Valid hybrid command but no DEBUG_PARAMS_COUNT at the end
+    env.expect(*_base_hybrid_debug_cmd(),
+               'TIMEOUT_AFTER_N_SEARCH', '1') \
+        .error().contains('DEBUG_PARAMS_COUNT')
+
+def test_hybrid_debug_invalid_debug_params_count():
+    """Test error when DEBUG_PARAMS_COUNT has an invalid value."""
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    for invalid_count in ['meow', '-1', '0.5']:
+        env.expect(*_base_hybrid_debug_cmd(),
+                   'TIMEOUT_AFTER_N_SEARCH', '1',
+                   'DEBUG_PARAMS_COUNT', invalid_count) \
+            .error().contains('Invalid DEBUG_PARAMS_COUNT count')
+
+def test_hybrid_debug_params_count_exceeds_argc():
+    """Test error when DEBUG_PARAMS_COUNT is larger than the number of available arguments."""
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    env.expect(*_base_hybrid_debug_cmd(),
+               'TIMEOUT_AFTER_N_SEARCH', '1',
+               'DEBUG_PARAMS_COUNT', '9999') \
+        .error().contains('DEBUG_PARAMS_COUNT exceeds')
+
+def test_hybrid_debug_unrecognized_argument():
+    """Test error when an unrecognized debug argument is provided."""
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    env.expect(*_base_hybrid_debug_cmd(),
+               'TIMEOUT_AFTER_N_MEOW', '1',
+               'DEBUG_PARAMS_COUNT', '2') \
+        .error().contains('Unrecognized argument')
+
 @skip(cluster=True)
+def test_hybrid_debug_no_component_timeout_sa():
+    """Test error when no component timeout parameter is specified (SA).
+
+    In SA mode, HybridRequest_Debug_New short-circuits on debug_params_count==0
+    before parseHybridDebugParams can validate. The reply is an error but
+    without the specific "At least one component timeout parameter" message.
+    """
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    env.expect(*_base_hybrid_debug_cmd(), 'DEBUG_PARAMS_COUNT', '0').error()
+
+@skip(cluster=False)
+def test_hybrid_debug_no_component_timeout_cluster():
+    """Test error when no component timeout parameter is specified (cluster).
+
+    In cluster mode, RSShardedHybridCommand_Debug calls parseHybridDebugParams
+    which validates that at least one component timeout is present.
+    """
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    env.expect(*_base_hybrid_debug_cmd(),
+               'DEBUG_PARAMS_COUNT', '0') \
+        .error().contains('At least one component timeout parameter')
+
+def test_hybrid_debug_invalid_timeout_values():
+    """Test error when timeout count values are invalid."""
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    for param in ['TIMEOUT_AFTER_N_SEARCH', 'TIMEOUT_AFTER_N_VSIM', 'TIMEOUT_AFTER_N_TAIL']:
+        for bad_val in ['meow', '-1', '0.5']:
+            env.expect(*_base_hybrid_debug_cmd(),
+                       param, bad_val,
+                       'DEBUG_PARAMS_COUNT', '2') \
+                .error().contains(f'Invalid {param} count')
+
+def test_hybrid_debug_missing_timeout_value():
+    """Test error when timeout parameter is provided without a value."""
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    # TIMEOUT_AFTER_N_SEARCH without its numeric argument;
+    # DEBUG_PARAMS_COUNT 1 means only 1 token is parsed as debug args.
+    env.expect(*_base_hybrid_debug_cmd(),
+               'TIMEOUT_AFTER_N_SEARCH',
+               'DEBUG_PARAMS_COUNT', '1') \
+        .error().contains('TIMEOUT_AFTER_N_SEARCH')
+
+# Debug timeout tests using TIMEOUT_AFTER_N_* parameters
 def test_debug_timeout_fail_search():
     """Test FAIL policy with search timeout using debug parameters"""
     env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT FAIL')
@@ -57,15 +169,13 @@ def test_debug_timeout_fail_vsim():
     setup_basic_index(env)
     env.expect('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector, 'TIMEOUT_AFTER_N_VSIM', '1', 'DEBUG_PARAMS_COUNT', '2').error().contains('Timeout limit was reached')
 
-#TODO: remove skip once FT.HYBRID for cluster is implemented
-@skip(cluster=True)
 def test_debug_timeout_fail_both():
     """Test FAIL policy with both components timeout using debug parameters"""
     env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT FAIL')
     setup_basic_index(env)
     env.expect('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector, 'TIMEOUT_AFTER_N_SEARCH', '1','TIMEOUT_AFTER_N_VSIM', '2', 'DEBUG_PARAMS_COUNT', '4').error().contains('Timeout limit was reached')
 
-#TODO: remove skip once FT.HYBRID for cluster is implemented
+# Tail pipeline runs on the coordinator; debug timeout params aren't applied there in cluster.
 @skip(cluster=True)
 def test_debug_timeout_fail_tail():
     """Test FAIL policy with tail timeout using debug parameters"""
@@ -73,7 +183,7 @@ def test_debug_timeout_fail_tail():
     setup_basic_index(env)
     env.expect('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector, 'TIMEOUT_AFTER_N_TAIL', '1', 'DEBUG_PARAMS_COUNT', '2').error().contains('Timeout limit was reached')
 
-#TODO: remove skip once FT.HYBRID for cluster is implemented
+# Tail pipeline runs on the coordinator; debug timeout params aren't applied there in cluster.
 @skip(cluster=True)
 def test_debug_timeout_return_tail():
     """Test FAIL policy with tail timeout using debug parameters"""
@@ -84,8 +194,6 @@ def test_debug_timeout_return_tail():
     env.assertEqual(['Timeout limit was reached (POST PROCESSING)'], get_warnings(response))
 
 
-#TODO: remove skip once FT.HYBRID for cluster is implemented
-@skip(cluster=True)
 def test_debug_timeout_return_search():
     """Test RETURN policy with search timeout using debug parameters"""
     env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT RETURN')
@@ -94,8 +202,6 @@ def test_debug_timeout_return_search():
                        'TIMEOUT_AFTER_N_SEARCH', '1', 'DEBUG_PARAMS_COUNT', '2')
     env.assertEqual(['Timeout limit was reached (SEARCH)'], get_warnings(response))
 
-#TODO: remove skip once FT.HYBRID for cluster is implemented
-@skip(cluster=True)
 def test_debug_timeout_return_vsim():
     """Test RETURN policy with vector similarity timeout using debug parameters"""
     env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT RETURN')
@@ -104,8 +210,6 @@ def test_debug_timeout_return_vsim():
                        'TIMEOUT_AFTER_N_VSIM', '1', 'DEBUG_PARAMS_COUNT', '2')
     env.assertEqual(['Timeout limit was reached (VSIM)'], get_warnings(response))
 
-#TODO: remove skip once FT.HYBRID for cluster is implemented
-@skip(cluster=True)
 def test_debug_timeout_return_both():
     """Test RETURN policy with both components timeout using debug parameters"""
     env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT RETURN')
@@ -117,7 +221,7 @@ def test_debug_timeout_return_both():
     env.assertTrue('Timeout limit was reached (VSIM)' in get_warnings(response))
     # TODO: add test for tail timeout once MOD-11004 is merged
 
-#TODO: remove skip once FT.HYBRID for cluster is implemented
+# Partial result assertions depend on data distribution across shards.
 @skip(cluster=True)
 def test_debug_timeout_return_with_results():
     """Test RETURN policy returns partial results when components timeout"""
@@ -132,6 +236,87 @@ def test_debug_timeout_return_with_results():
     env.assertTrue('doc:3' in results.keys())
     # Expect exactly one document from VSIM since the timeout occurred after processing one result - should be either doc:2 or doc:4
     env.assertTrue(('doc:2' in results.keys()) ^ ('doc:4' in results.keys()))
+
+# ---------------------------------------------------------------------------
+# Sanity comparison: debug results vs regular results
+# ---------------------------------------------------------------------------
+
+@skip(cluster=True)
+def test_debug_sanity_no_truncation():
+    """Verify a debug query with high timeouts returns the same results as a regular query.
+
+    Analogous to the Sanity() method in test_debug_commands.py for FT.SEARCH/FT.AGGREGATE.
+    """
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+
+    regular_res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM',
+                          '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector)
+    regular_results, regular_count = get_results_from_hybrid_response(regular_res)
+
+    # Timeouts high enough that no component actually times out (4 docs in dataset).
+    debug_res = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM',
+                        '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
+                        'TIMEOUT_AFTER_N_SEARCH', '100', 'TIMEOUT_AFTER_N_VSIM', '100',
+                        'DEBUG_PARAMS_COUNT', '4')
+    debug_results, debug_count = get_results_from_hybrid_response(debug_res)
+
+    env.assertEqual(regular_count, debug_count,
+                    message=f"Expected same count: regular={regular_count}, debug={debug_count}")
+    env.assertEqual(set(regular_results.keys()), set(debug_results.keys()),
+                    message="Debug query should return the same documents as regular query")
+
+@skip(cluster=True)
+def test_debug_sanity_truncated_subset():
+    """Verify a debug query with truncation returns a subset of regular query results."""
+    env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT RETURN')
+    setup_basic_index(env)
+
+    regular_res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM',
+                          '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector)
+    regular_results, _ = get_results_from_hybrid_response(regular_res)
+
+    # Both components limited to 1 result each; the union is at most 2 of the 4 docs.
+    debug_res = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM',
+                        '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
+                        'TIMEOUT_AFTER_N_SEARCH', '1', 'TIMEOUT_AFTER_N_VSIM', '1',
+                        'DEBUG_PARAMS_COUNT', '4')
+    debug_results, debug_count = get_results_from_hybrid_response(debug_res)
+
+    env.assertGreater(len(regular_results), len(debug_results),
+                      message="Debug query with truncation should return fewer documents")
+    env.assertTrue(set(debug_results.keys()).issubset(set(regular_results.keys())),
+                   message="Debug results should be a subset of regular results")
+    warnings = get_warnings(debug_res)
+    env.assertGreater(len(warnings), 0, message="Expected at least one timeout warning")
+
+# ---------------------------------------------------------------------------
+# Boundary: TIMEOUT_AFTER_N_* 0 means "no timeout for that component"
+# ---------------------------------------------------------------------------
+
+@skip(cluster=True)
+def test_debug_timeout_zero_means_no_timeout():
+    """TIMEOUT_AFTER_N_* 0 means "no timeout for this component" — it runs normally.
+
+    This differs from non-hybrid TIMEOUT_AFTER_N where 0 means "timeout immediately."
+    """
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+
+    regular_res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM',
+                          '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector)
+    regular_results, regular_count = get_results_from_hybrid_response(regular_res)
+
+    debug_res = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM',
+                        '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
+                        'TIMEOUT_AFTER_N_SEARCH', '0', 'TIMEOUT_AFTER_N_VSIM', '0',
+                        'DEBUG_PARAMS_COUNT', '4')
+    debug_results, debug_count = get_results_from_hybrid_response(debug_res)
+
+    env.assertEqual(regular_count, debug_count,
+                    message="Timeout 0 should not truncate results")
+    env.assertEqual(set(regular_results.keys()), set(debug_results.keys()),
+                    message="Timeout 0 should return the same documents as regular query")
 
 # Warning and error tests
 #TODO: remove skip once FT.HYBRID for cluster is implemented
@@ -192,6 +377,46 @@ def test_tail_property_not_loaded_error():
                           query_vector, 'LOAD', '1', '@__key', 'APPLY', '2*@__score',\
                           'AS', 'doubled_score').error().contains('Property `__score` not loaded nor in pipeline')
 
+
+@skip(cluster=False)
+def test_debug_profile_hybrid_uses_normal_callback():
+    """Test FT.DEBUG FT.PROFILE is handled correctly."""
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    res = env.cmd(
+        '_FT.DEBUG', 'FT.PROFILE', 'idx', 'HYBRID', 'QUERY',
+        'SEARCH', '*',
+        'VSIM', '@embedding', '$BLOB',
+        'PARAMS', '2', 'BLOB', query_vector)
+    # Basic sanity: we got results and profile info without an error.
+    env.assertIsNotNone(res)
+    env.assertGreater(len(res), 0)
+
+@skip(cluster=False)
+def test_tail_property_not_loaded_warning_coordinator():
+    """Test warning when tail pipeline references property not loaded (coordinator mode)
+
+    Related: test_tail_property_not_loaded_error_standalone
+    In coordinator mode, tail pipeline errors become warnings (protocol limitation).
+    The error code also differs: VALUE_NOT_FOUND (coord) vs PROP_NOT_FOUND (standalone).
+    """
+    env = Env()
+    setup_basic_index(env)
+    # In coordinator, this returns partial results with a warning (POST PROCESSING)
+    response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM', \
+                      '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', \
+                      query_vector, 'LOAD', '1', '@__key', 'APPLY', '2*@__score',\
+                      'AS', 'doubled_score')
+    # Extract warnings from RESP2 (list) or RESP3 (dict)
+    if isinstance(response, dict):
+        warnings = response.get('warnings', [])
+    elif isinstance(response, list) and 'warnings' in response:
+        idx = response.index('warnings')
+        warnings = response[idx + 1] if idx + 1 < len(response) else []
+    else:
+        warnings = []
+    env.assertTrue(any('__score' in w for w in warnings),
+                   message=f"Expected warning about __score, got: {warnings}")
 
 @skip(cluster=False)
 def test_timeout_setup_phase_hybrid():

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -1194,7 +1194,13 @@ class testWarningsAndErrorsCluster:
 
   def test_timeout_cluster(self):
     # In cluster mode, test both shard-level and coordinator-level timeouts.
-    # HYBRID debug is not supported in cluster.
+
+    # Insert enough vec docs so every shard has VSIM data for HYBRID timeout testing.
+    conn = getConnectionByEnv(self.env)
+    for i in range(30):
+      conn.execute_command('HSET', f'vec:timeout_{i}', 'vector', np.array([float(i), 0.0]).astype(np.float32).tobytes())
+
+    query_vec = np.array([1.0, 0.0]).astype(np.float32).tobytes()
 
     # ---------- Timeout Errors ----------
     allShards_change_timeout_policy(self.env, 'FAIL')
@@ -1243,6 +1249,20 @@ class testWarningsAndErrorsCluster:
     self.env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][TIMEOUT_ERROR_COORD_METRIC], str(base_err_coord + 3),
                          message="Coordinator timeout error should be +1 after AGG coordinator timeout")
 
+    # Test timeout error in FT.HYBRID (shards via TIMEOUT_AFTER_N_VSIM)
+    self.env.expect(debug_cmd(), 'FT.HYBRID', 'idx_vec', 'SEARCH', 'hello world',
+                    'VSIM', '@vector', '$BLOB', 'PARAMS', '2', 'BLOB', query_vec,
+                    'TIMEOUT_AFTER_N_VSIM', 1, 'DEBUG_PARAMS_COUNT', 2).error().contains('Timeout limit was reached')
+    # Shards: +1 each (total +4)
+    for shardId in range(1, self.env.shardsCount + 1):
+      shard_conn = self.env.getConnection(shardId)
+      wait_for_info_metric(shard_conn, [WARN_ERR_SECTION, TIMEOUT_ERROR_SHARD_METRIC], str(base_err_shards[shardId] + 4),
+                           msg=f"Shard {shardId} HYBRID VSIM timeout error should be +4")
+    # Coord: +4
+    info_coord = info_modules_to_dict(self.env)
+    self.env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][TIMEOUT_ERROR_COORD_METRIC], str(base_err_coord + 4),
+                         message="Coordinator timeout error should be +4 after FT.HYBRID")
+
     # ---------- Timeout Warnings ----------
     allShards_change_timeout_policy(self.env, 'RETURN')
 
@@ -1263,6 +1283,18 @@ class testWarningsAndErrorsCluster:
     info_coord = info_modules_to_dict(self.env)
     self.env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC], str(base_warn_coord),
                          message="Coordinator timeout warning should not change after FT.SEARCH")
+
+    # Test timeout warning in FT.HYBRID (shards via TIMEOUT_AFTER_N_VSIM)
+    self.env.expect(debug_cmd(), 'FT.HYBRID', 'idx_vec', 'SEARCH', 'hello world',
+                    'VSIM', '@vector', '$BLOB', 'PARAMS', '2', 'BLOB', query_vec,
+                    'TIMEOUT_AFTER_N_VSIM', 1, 'DEBUG_PARAMS_COUNT', 2).noError()
+    # In RETURN mode, the shard increments timeout_warning twice per hybrid query:
+    # once from the internal AREQ subquery timeout and once from replyWithCursors.
+    # Shards: +2 each (total: SEARCH +1, HYBRID +2 = +3)
+    for shardId in range(1, self.env.shardsCount + 1):
+      shard_conn = self.env.getConnection(shardId)
+      wait_for_info_metric(shard_conn, [WARN_ERR_SECTION, TIMEOUT_WARNING_SHARD_METRIC], str(base_warn_shards[shardId] + 3),
+                           msg=f"Shard {shardId} HYBRID VSIM timeout warning should be +3")
 
     # Test other metrics not changed (on shards)
     tested_in_this_test = [TIMEOUT_ERROR_SHARD_METRIC, TIMEOUT_WARNING_SHARD_METRIC, TIMEOUT_ERROR_COORD_METRIC, TIMEOUT_WARNING_COORD_METRIC]


### PR DESCRIPTION
## Describe the changes in the pull request

Backport of #9215 to the 8.4 line (cherry-picked from the 8.6 backport, #10414).

1. Current: On 8.4, `FT.DEBUG FT.HYBRID` is not supported in cluster mode, and FT.HYBRID does not surface shard timeout warnings to the client in cluster mode.
2. Change: Adds `_FT.DEBUG FT.HYBRID` / `FT.DEBUG FT.HYBRID` support on the coordinator (debug timeout injection via `TIMEOUT_AFTER_N_SEARCH/VSIM/TAIL` + `DEBUG_PARAMS_COUNT`), and propagates shard timeout warnings through the cursor-mapping and cursor-read paths so the coordinator emits them in the reply's `warnings` array (RETURN policy) or a clean timeout error (FAIL policy), with correct `INFO` warning/error metrics.
3. Outcome: `FT.DEBUG FT.HYBRID` works in cluster mode on 8.4, and FT.HYBRID cluster queries report shard timeouts the same way FT.SEARCH/FT.AGGREGATE do.

Original PR: #9215 ([MOD-14309][MOD-14311], merged to master as 02bc76a93). 8.6 backport: #10414 — all 8.6 adaptation rationales (canonical timeout message, exact-match classification, RETURN-STRICT removal, `CoordRequestCtx` removal, dropped reply-callback infrastructure, test-string fixes) apply here identically and are documented there.

<details>
<summary><b>Conflict-resolution notes (8.4-specific, on top of the 8.6 adaptation)</b></summary>

Cherry-picked from the 8.6 backport commit rather than master (5 content conflicts + 2 modify/delete, vs 13 from master). 8.4-specific deltas:

- **Rust `query_error_ffi` crate + generated header dropped** (modify/delete — the crate doesn't exist on 8.4; `query_error` is still C). Verified no-op: the 8.6 change kept exact-equality matching and added null-pointer guards, and 8.4's C `QueryError_GetCodeFromMessage` / `QueryWarningCode_GetCodeFromMessage` already have both.
- **Error-code renames**: 8.4 uses the old short names — all ported hunks translated (`QUERY_ERROR_CODE_TIMED_OUT` → `QUERY_ETIMEDOUT`, `…OUT_OF_MEMORY` → `QUERY_EOOM`, `…GENERIC` → `QUERY_EGENERIC`, `…NO_INDEX` → `QUERY_ENOINDEX`, `…DROPPED_BACKGROUND` → `QUERY_EDROPPEDBACKGROUND`, `…PARSE_ARGS` → `QUERY_EPARSEARGS`, `…INVAL` → `QUERY_EINVAL`, `…SAFE_DEPLETER_FAILURE` → `QUERY_ESAFEDEPLETERFAILURE`).
- **`QueryError_SetDetail` doesn't exist on 8.4**: `processHybridWarning` now uses a single `QueryError_SetError(code, message)`, which sets both code and detail.
- **Coordinator dispatch-time tracking dropped**: `ConcurrentCmdCtx_GetCoordStartTime` doesn't exist on 8.4 (its `ConcurrentCmdCtx` doesn't carry `coordStartTime`), and 8.4's non-debug `RSExecDistHybrid` does no dispatch-time tracking either — the debug path mirrors it exactly.
- **`applyHybridTimeout` → `applyHybridDebugTimeout` rename**: the pick renamed the helper; one 8.4-drifted call site resolved to the new name.
- **`module.c` `DistHybridCommandInternal`**: was `static` without `isDebug` on 8.4; took the pick's signature (declared in `module.h`), dropped the now-redundant local `RSExecDistHybrid` forward declaration.

Not related to this PR: 8.4's VectorSimilarity pin force-builds ScalableVectorSearch, whose fmt 11.2.0 fails to compile on current macOS SDKs (missing `<cstdlib>`; fixed upstream later). Local verification used a build-dir-only fmt patch; Linux CI is unaffected.

**Follow-up commit — fixes a pre-existing 8.4 coordinator leak surfaced by this PR's sanitize job:** `handleAndReplyWarning`'s error-to-warning branch never cleared the `QueryError`; on the coordinator `qctx->err` points at `RSExecDistHybrid`'s stack-local status which nothing clears, leaking the formatted error detail. The missing `QueryError_ClearError` came from MOD-11806 on master and reached 8.6 inside the [8.6] MOD-15113 backport (#9886), but the [8.4] sibling (#9887) dropped it — so `test_hybrid_groupby_coordinator_group_limit` was already leaking on 8.4 before this PR; the new `test_tail_property_not_loaded_warning_coordinator` hits the same path. One-line fix matching master/8.6.

Verification: full DEBUG build green; all 23 `test_hybrid_*` pytest files pass in standalone and cluster (163/163 each); `test_info_modules.py::testWarningsAndErrorsCluster` 7/7.

</details>

#### Which additional issues this PR fixes

1. MOD-15120
2. MOD-15121

#### Main objects this PR modified

1. `src/coord/hybrid/dist_hybrid.c` — `DEBUG_RSExecDistHybrid`, debug-param plumbing into the MR command
2. `src/coord/hybrid/hybrid_cursor_mappings.c` — warning classification + timeout-policy handling
3. `src/hybrid/hybrid_exec.c` / `hybrid_debug.c` — debug timeout application, RETURN-policy cursor retention, warning emission
4. `src/debug_commands.c`, `src/module.c` — `FT.DEBUG FT.HYBRID` / `_FT.DEBUG _FT.HYBRID` dispatch
5. `src/result_processor.c` — depleter `DepleteAll` error/timeout priority

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MOD-14309]: https://redislabs.atlassian.net/browse/MOD-14309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
