### PR TITLE
[MOD-16877] Fix numeric range tree crash (empty_leaves underflow) under numeric compression

### DIFF
--- a/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
@@ -246,7 +246,7 @@ impl NumericRangeTree {
                 if card >= Self::get_split_cardinality(depth)
                     || (num_entries > Self::MAXIMUM_RANGE_SIZE && card > 1)
                 {
-                    Self::split_node(nodes, node_idx, &mut rv, compress_floats);
+                    Self::split_node(nodes, node_idx, &mut rv, compress_floats, empty_leaves);
 
                     // Check if we're too high up to retain this node's range
                     if nodes[node_idx].max_depth() > max_depth_range as u32 {
@@ -287,6 +287,7 @@ impl NumericRangeTree {
         node_idx: NodeIndex,
         rv: &mut AddResult,
         compress_floats: bool,
+        empty_leaves: &mut CheckedCount,
     ) {
         let parent_range = nodes[node_idx]
             .take_range()
@@ -339,6 +340,23 @@ impl NumericRangeTree {
             rv.num_records_delta += 1;
         }
         drop(result);
+
+        // A split can leave a child leaf empty: when float compression collapses
+        // every stored value to the same f32, the median equals the minimum, the
+        // split point becomes `next_up(min)`, and all entries land on one side.
+        // Such an empty leaf must be reflected in `empty_leaves`, otherwise a
+        // later add routed to it would decrement the counter below zero. The
+        // parent had >= 1 entry (we split only after adding), so at most one of
+        // the two new children can be empty.
+        let newly_empty = [left_idx, right_idx]
+            .into_iter()
+            .filter(|&i| nodes[i].range().is_some_and(|r| r.num_docs() == 0))
+            .count();
+        debug_assert!(
+            newly_empty <= 1,
+            "a non-empty parent must yield at least one non-empty child"
+        );
+        *empty_leaves += newly_empty;
 
         // Replace the old leaf with a new internal node.
         nodes[node_idx] = NumericRangeNode::internal_indexed(

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/tree.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/tree.rs
@@ -201,8 +201,9 @@ fn test_split_with_identical_values() {
     );
 }
 
-/// Regression test for the `empty_leaves` underflow crash (MOD production crash
-/// on 8.6.6): a split that creates an empty child leaf must count it.
+/// Regression test for the `empty_leaves` underflow crash (MOD-16877, a
+/// production crash on 8.6.6): a split that creates an empty child leaf must
+/// count it.
 ///
 /// With float compression enabled, cardinality is estimated over the original
 /// f64 values while entries are stored — and split-redistributed — as compressed

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/tree.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/tree.rs
@@ -201,6 +201,63 @@ fn test_split_with_identical_values() {
     );
 }
 
+/// Regression test for the `empty_leaves` underflow crash (MOD production crash
+/// on 8.6.6): a split that creates an empty child leaf must count it.
+///
+/// With float compression enabled, cardinality is estimated over the original
+/// f64 values while entries are stored — and split-redistributed — as compressed
+/// f32. When enough distinct f64 values collapse to a single f32, the split is
+/// triggered (HLL sees them as distinct) but every stored value is identical, so
+/// all entries are redistributed to one child and the other child leaf is created
+/// empty. That empty leaf must be reflected in `empty_leaves`; otherwise a later
+/// add routed to it decrements the counter below zero and aborts the process via
+/// the non-unwinding FFI boundary.
+#[test]
+fn test_split_with_compression_collapse_counts_empty_leaf() {
+    let mut tree = NumericRangeTree::new(true); // float compression ON
+
+    // Distinct f64 values tightly clustered within a single f32 rounding bucket
+    // around 100.5 (exactly representable in f32). Each differs from the next by
+    // 1e-7 — far above the f64 ULP near 100.5 (~1e-14), so they are distinct to
+    // the HLL cardinality estimator, but far below the f32 ULP near 100.5
+    // (~7.6e-6), so all round to the same stored f32 (100.5), well within the
+    // 0.01 compression threshold.
+    let value_at = |i: u64| 100.5 + (i - 1) as f64 * 1e-7;
+
+    // Add distinct-but-collapsing values until the first split fires. Because the
+    // stored values are all identical (f32 100.5), the redistribution sends every
+    // entry to the left child and leaves the right child empty. This empty leaf
+    // must be counted; before the fix, `empty_leaves` stayed 0 here (caught by the
+    // `check_tree_invariants` assertion inside `add`).
+    let mut split_at = None;
+    for i in 1..=(SPLIT_TRIGGER + 8) {
+        tree.add(i, value_at(i), false, 0);
+        if tree.num_leaves() == 2 {
+            split_at = Some(i);
+            break;
+        }
+    }
+    let split_at = split_at.expect("compressed-but-distinct values should trigger a split");
+
+    // Right after the split, before any further add re-populates it:
+    assert_eq!(
+        tree.empty_leaves(),
+        1,
+        "the empty child leaf created by the split must be counted"
+    );
+
+    // Routing uses the *original* f64 value, so the next (larger) value is routed
+    // to the empty right child and re-populates it. Before the fix this decremented
+    // `empty_leaves` from 0, underflowing the counter and aborting the process.
+    let next = split_at + 1;
+    tree.add(next, value_at(next), false, 0);
+    assert_eq!(
+        tree.empty_leaves(),
+        0,
+        "re-populating the empty leaf should bring the counter back to zero"
+    );
+}
+
 #[test]
 #[cfg_attr(miri, ignore = "Too slow to run under miri")]
 fn test_deep_tree_balancing() {


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** With float compression (`_NUMERIC_COMPRESS`) enabled, the numeric range tree estimates a leaf's cardinality over the original **f64** values, but stores and split-redistributes entries as compressed **f32**. When enough distinct f64 values collapse to a single f32, a split is triggered (HLL still sees them as distinct) yet every *stored* value is identical, so the median equals the minimum, the split point becomes `next_up(min)`, and **all** entries are redistributed to one child — leaving the sibling leaf empty. `split_node` updated `num_leaves`/`num_ranges` but never counted that new empty leaf in `empty_leaves`.
2. **Change:** `split_node` now counts any child leaf it creates empty and adds it to `empty_leaves` (with a `debug_assert!` that a non-empty parent yields at most one empty child). The `CheckedCount` underflow panic is intentionally left in place — a violated invariant should still fail loudly; the fix is to stop violating it.
3. **Outcome:** `empty_leaves` stays consistent with the tree, so a later add routed to that leaf no longer decrements the counter below zero. Previously the underflow panicked and — because it crosses the non-unwinding `extern "C"` FFI boundary — aborted the whole `redis-server` (SIGABRT). Seen in production on 8.6.6 via a plain `HSET` re-indexing a document.

#### Which additional issues this PR fixes
1. MOD-16877

#### Main objects this PR modified
1. `NumericRangeTree::split_node` — `src/redisearch_rs/numeric_range_tree/src/tree/insert.rs`
2. New regression test `test_split_with_compression_collapse_counts_empty_leaf` — `src/redisearch_rs/numeric_range_tree/tests/integration/tree.rs`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Fixes a crash (SIGABRT) that could take down a shard when a numeric field is indexed with numeric compression enabled.

> Note: the production crash is on the 8.6 line, so this will need a backport to `8.6` / `8.6-rse` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)