### PR TITLE
[8.2] deps: bump crossbeam-epoch 0.9.18 to 0.9.20

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Describe the changes in the pull request

Backport of #10418 to the `8.2` release branch.

1. Current: `8.2` locks `crossbeam-epoch` to `0.9.18`, which is flagged by cargo-deny for `RUSTSEC-2026-0204` and causes merge-queue lint failures.
2. Change: Bump `crossbeam-epoch` to `0.9.20` via `cargo update -p crossbeam-epoch`.
3. Outcome: The Rust advisory gate no longer fails on the `crossbeam-epoch` advisory; only the existing ignored `paste` unmaintained advisory remains reported.

#### Which additional issues this PR fixes
1. Backport of #10418

#### Main objects this PR modified
1. `src/redisearch_rs/Cargo.lock` - updates `crossbeam-epoch` version and checksum only

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI/dependency hygiene only; no user-facing behavior change.

Validation:
- `cargo update --manifest-path src/redisearch_rs/Cargo.toml -p crossbeam-epoch`
- `PATH=/tmp/cargo-deny-0.20.2/bin:$PATH python3 scripts/cargo_deny_advisory_gate.py --manifest-path src/redisearch_rs/Cargo.toml --compare-to-base --base-ref fd1fd47489571ac83ac539d99d147f1ad16ead69`