### PR TITLE
[MOD-15973] Count hybrid warning metrics once per query

### DIFF
--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -40,6 +40,25 @@
 
 #include <time.h>
 
+typedef uint8_t HybridWarningMask;
+
+enum {
+  HYBRID_WARNING_NONE = 0,
+  HYBRID_WARNING_TIMEOUT = 1U << 0,
+  HYBRID_WARNING_MAX_PREFIX_EXPANSIONS = 1U << 1,
+  // Mask used for possible sub-queries and postprocessing
+};
+
+static void updateHybridWarningMetrics(HybridWarningMask warnings) {
+  if (warnings & HYBRID_WARNING_TIMEOUT) {
+    QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_TIMED_OUT, 1, COORD_ERR_WARN);
+  }
+  if (warnings & HYBRID_WARNING_MAX_PREFIX_EXPANSIONS) {
+    QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_REACHED_MAX_PREFIX_EXPANSIONS, 1,
+                                           COORD_ERR_WARN);
+  }
+}
+
 // Send a warning message to the client, optionally appending a suffix to identify the source
 static inline void ReplyWarning(RedisModule_Reply *reply, const char *message, const char *suffix) {
   if (suffix) {
@@ -56,24 +75,23 @@ static inline void ReplyWarning(RedisModule_Reply *reply, const char *message, c
 // Handles query errors and sends warnings to client.
 // ignoreTimeout: ignore timeout in tail if there's a timeout in subquery
 // suffix: identifies where the error occurred ("SEARCH"/"VSIM"/"POST PROCESSING")
-// Returns true if a timeout occurred and was processed as a warning
-static inline bool handleAndReplyWarning(RedisModule_Reply *reply, QueryError *err, int returnCode, const char *suffix, bool ignoreTimeout) {
-  bool timeoutOccurred = false;
+// Returns the category of warning emitted, if any.
+static inline HybridWarningMask handleAndReplyWarning(RedisModule_Reply *reply, QueryError *err,
+                                                      int returnCode, const char *suffix,
+                                                      bool ignoreTimeout) {
   if (returnCode == RS_RESULT_TIMEDOUT && !ignoreTimeout) {
-    // Track warnings in global statistics
-    QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_TIMED_OUT, 1, COORD_ERR_WARN);
     ReplyWarning(reply, QueryWarning_Strwarning(QUERY_WARNING_CODE_TIMED_OUT), suffix);
-    timeoutOccurred = true;
+    return HYBRID_WARNING_TIMEOUT;
   } else if (returnCode == RS_RESULT_ERROR) {
     // Non-fatal error — convert to warning
     ReplyWarning(reply, QueryError_GetUserError(err), suffix);
     QueryError_ClearError(err);  // Free allocated message strings
   } else if (QueryError_HasReachedMaxPrefixExpansionsWarning(err)) {
-    QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_REACHED_MAX_PREFIX_EXPANSIONS, 1, COORD_ERR_WARN);
     ReplyWarning(reply, QUERY_WMAXPREFIXEXPANSIONS, suffix);
+    return HYBRID_WARNING_MAX_PREFIX_EXPANSIONS;
   }
 
-  return timeoutOccurred;
+  return HYBRID_WARNING_NONE;
 }
 
 static bool HybridRequest_HasShardTimedOutWarning(const HybridRequest *hreq) {
@@ -109,21 +127,26 @@ static int replyForHybridPreExecutionTimeout(RedisModuleCtx *ctx, bool internal,
   return common_hybrid_query_reply_empty(ctx, QUERY_ERROR_CODE_TIMED_OUT, internal, isProfile);
 }
 
-// Reply with warnings, adding suffixes to indicate the originating context (search/vsim/post-processing)
-static void replyWarningsWithSuffixes(RedisModule_Reply *reply, HybridRequest *hreq,
-                                       QueryProcessingCtx *qctx, int postProcessingRC) {
-  bool timeoutInSubquery = false;
+// Reply with warnings, adding suffixes to indicate the originating context
+// (search/vsim/post-processing)
+static HybridWarningMask replyWarningsWithSuffixes(RedisModule_Reply *reply, HybridRequest *hreq,
+                                                   QueryProcessingCtx *qctx, int postProcessingRC) {
+  HybridWarningMask warnings = HYBRID_WARNING_NONE;
 
   // Handle warnings from each subquery, adding appropriate suffix
   for (size_t i = 0; i < hreq->nrequests; ++i) {
     QueryError* err = &hreq->errors[i];
     const char* suffix = i == 0 ? SEARCH_SUFFIX : VSIM_SUFFIX;
     const int subQueryReturnCode = hreq->subqueriesReturnCodes[i];
-    timeoutInSubquery = handleAndReplyWarning(reply, err, subQueryReturnCode, suffix, false) || timeoutInSubquery;
+    warnings |= handleAndReplyWarning(reply, err, subQueryReturnCode, suffix, false);
   }
 
   // Handle warnings from post-processing stage
-  handleAndReplyWarning(reply, qctx->err, postProcessingRC, POST_PROCESSING_SUFFIX, timeoutInSubquery);
+  const bool timeoutInSubquery = warnings & HYBRID_WARNING_TIMEOUT;
+  warnings |= handleAndReplyWarning(reply, qctx->err, postProcessingRC, POST_PROCESSING_SUFFIX,
+                                    timeoutInSubquery);
+
+  return warnings;
 }
 
 static void HREQ_Execute_Callback(blockedClientHybridCtx *BCHCtx);
@@ -348,6 +371,7 @@ static void finishSendChunkReply_hybrid(HybridRequest *hreq, RedisModule_Reply *
   RedisModule_Reply_ArrayEnd(reply); // >results
 
   // warnings
+  HybridWarningMask warnings = HYBRID_WARNING_NONE;
   RedisModule_ReplyKV_Array(reply, "warnings"); // >warnings
   RedisSearchCtx *sctx = HREQ_SearchCtx(hreq);
   if (sctx->spec && sctx->spec->scan_failed_OOM) {
@@ -361,13 +385,13 @@ static void finishSendChunkReply_hybrid(HybridRequest *hreq, RedisModule_Reply *
   }
   const bool timeoutWarningReplied = QueryError_GetCode(qctx->err) == QUERY_ERROR_CODE_TIMED_OUT;
   if (timeoutWarningReplied) {
-    QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_TIMED_OUT, 1, COORD_ERR_WARN);
     RedisModule_Reply_SimpleString(reply, QueryWarning_Strwarning(QUERY_WARNING_CODE_TIMED_OUT));
+    warnings |= HYBRID_WARNING_TIMEOUT;
   }
   if (!timeoutWarningReplied && HybridRequest_HasShardTimedOutWarning(hreq) &&
       !HybridRequest_HasTimedOutSubquery(hreq)) {
-    QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_TIMED_OUT, 1, COORD_ERR_WARN);
     RedisModule_Reply_SimpleString(reply, QueryWarning_Strwarning(QUERY_WARNING_CODE_TIMED_OUT));
+    warnings |= HYBRID_WARNING_TIMEOUT;
   }
   // The cap flag is mirrored on both subqueries by parseHybridCommand; checking
   // the search subquery is sufficient.
@@ -376,7 +400,8 @@ static void finishSendChunkReply_hybrid(HybridRequest *hreq, RedisModule_Reply *
     RedisModule_Reply_SimpleString(reply, QueryWarning_Strwarning(QUERY_WARNING_CODE_MAX_TIMEOUT_CAPPED));
   }
 
-  replyWarningsWithSuffixes(reply, hreq, qctx, rc);
+  warnings |= replyWarningsWithSuffixes(reply, hreq, qctx, rc);
+  updateHybridWarningMetrics(warnings);
 
   RedisModule_Reply_ArrayEnd(reply); // >warnings
 

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -3757,7 +3757,7 @@ class TestCoordinatorTimeout:
         callers assert their tail-shape-specific reply expectations.
 
         Shared assertions (single reply, two per-subquery TIMEOUT warnings,
-        coord warning counter ``+2``, other metrics unchanged) and full
+        coord warning counter ``+1``, other metrics unchanged) and full
         cleanup (signal sync point on every shard, restore previous
         on-timeout policy) are performed by this driver.
         """
@@ -3832,14 +3832,12 @@ class TestCoordinatorTimeout:
             env.assertContains('Timeout', warnings[1],
                                message=f"Expected VSIM TIMEOUT warning, got: {warnings}")
 
-            # finishSendChunkReply_hybrid -> replyWarningsWithSuffixes bumps
-            # the coord timeout-warning metric once per subquery that returned
-            # RS_RESULT_TIMEDOUT, so the metric grows by the number of
-            # subqueries.
+            # Both warning strings belong to one top-level FT.HYBRID query, so
+            # the coordinator timeout-warning metric increases only once.
             after_info = info_modules_to_dict(env)
             env.assertEqual(after_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC],
-                            str(base_warn_coord + 2),
-                            message="Coordinator timeout warning should be +2 (one per subquery)")
+                            str(base_warn_coord + 1),
+                            message="Coordinator timeout warning should be +1 per query")
             _verify_metrics_not_changed(env, env, before_info, [TIMEOUT_WARNING_COORD_METRIC])
         finally:
             for c in all_shard_conns:
@@ -3866,8 +3864,7 @@ class TestCoordinatorTimeout:
         empty when the timeout fires and the reply carries 0 rows + two
         per-subquery TIMEOUT warnings. This is the channel-wake analogue
         of ``test_return_strict_timeout_all_shards_paused_aggregate``
-        (which bumps the warning counter +1; hybrid bumps +2, one per
-        subquery, see MOD-15973).
+        (both commands bump the warning counter once per top-level query).
         """
         def assert_reply(result):
             env = self.env
@@ -3996,7 +3993,7 @@ class TestCoordinatorTimeout:
         responsive shards, which the driver counts deterministically.
 
         Shared assertions (single reply, two per-subquery TIMEOUT
-        warnings, coord warning counter ``+2``, other metrics
+        warnings, coord warning counter ``+1``, other metrics
         unchanged) and best-effort cleanup (SIGCONT the shard, clear
         coord sync, restore previous on-timeout policy) are performed
         by this driver.
@@ -4124,8 +4121,8 @@ class TestCoordinatorTimeout:
 
             after_info = info_modules_to_dict(env)
             env.assertEqual(after_info[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC],
-                            str(base_warn_coord + 2),
-                            message="Coordinator timeout warning should be +2 (one per subquery)")
+                            str(base_warn_coord + 1),
+                            message="Coordinator timeout warning should be +1 per query")
             _verify_metrics_not_changed(env, env, before_info, [TIMEOUT_WARNING_COORD_METRIC])
 
         finally:

--- a/tests/pytests/test_hybrid_timeout.py
+++ b/tests/pytests/test_hybrid_timeout.py
@@ -1,6 +1,7 @@
 from RLTest import Env
 from includes import *
 from common import *
+from test_info_modules import info_modules_to_dict
 import psutil
 
 # Test data with deterministic vectors
@@ -359,6 +360,10 @@ def test_maxprefixexpansions_warning_both_components():
     conn = env.getClusterConnectionIfNeeded()
     add_run_prefix_docs(conn)
     run_command_on_all_shards(env, config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '1')
+    coord_section = 'search_coordinator_warnings_and_errors'
+    metric = 'search_coord_total_query_warnings_max_prefix_expansions'
+    before_info = info_modules_to_dict(env)
+    base_warning_count = int(before_info[coord_section][metric])
 
     # Both SEARCH and VSIM return results
     response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'run*', 'VSIM', \
@@ -366,6 +371,9 @@ def test_maxprefixexpansions_warning_both_components():
     warning = get_warnings(response)
     env.assertTrue('Max prefix expansions limit was reached (SEARCH)' in warning)
     env.assertTrue('Max prefix expansions limit was reached (VSIM)' in warning)
+    after_info = info_modules_to_dict(env)
+    env.assertEqual(after_info[coord_section][metric], str(base_warning_count + 1),
+                    message="Coordinator max-prefix warning should be +1 per query")
 
 @skip(cluster=True)
 def test_tail_property_not_loaded_error_standalone():


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: A single FT.HYBRID query can increment coordinator warning metrics once per timed-out subquery, so simultaneous SEARCH and VSIM warnings double-count the top-level query.
2. Change: Accumulate emitted hybrid warning categories in a compact mask, preserve the per-subquery warning strings, and update each coordinator warning metric once after the reply is assembled.
3. Outcome: Hybrid timeout and max-prefix warning metrics count affected client queries rather than individual warning strings.

#### Which additional issues this PR fixes
1. MOD-15973

#### Main objects this PR modified
1. Hybrid warning reply and metric accounting in `src/hybrid/hybrid_exec.c`.
2. Coordinator timeout metric expectations in `test_blocked_client_timeout.py`.
3. Hybrid max-prefix warning metric coverage in `test_hybrid_timeout.py`.

#### Validation
- `make pytest TEST=test_hybrid_timeout` — 30 passed, 0 failed.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.