### PR TITLE
[MOD-14988] Share timeout between trie_rs and rqe_iterator crate

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3002,6 +3002,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "timeout"
+version = "0.0.1"
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3005,6 +3005,9 @@ dependencies = [
 [[package]]
 name = "timeout"
 version = "0.0.1"
+dependencies = [
+ "workspace_hack",
+]
 
 [[package]]
 name = "tinystr"

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2324,6 +2324,7 @@ dependencies = [
  "rstest",
  "rstest_reuse",
  "thiserror",
+ "timeout",
  "tracing",
  "trie_rs",
  "ttl_table",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3206,6 +3206,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rqe_wildcard",
+ "timeout",
  "trie_rs",
  "utf8parse",
  "workspace_hack",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "string_utils",
     "tag_index",
     "term_suffix_index",
+    "timeout",
     "tools/license_header_linter",
     "tools/ffi_geiger",
     "tools/safety_report",
@@ -154,6 +155,7 @@ sorting_vector = { path = "./sorting_vector" }
 string_utils = { path = "./string_utils" }
 term_suffix_index = { path = "./term_suffix_index" }
 thin_vec = { path = "./thin_vec" }
+timeout = { path = "timeout" }
 top_k = { path = "./top_k" }
 tracing_assert = { path = "./tracing_assert" }
 vecsim = { path = "./c_wrappers/vecsim" }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -19,7 +19,7 @@ use rqe_iterators::{
     not_optimized::NotOptimized,
     not_reducer::{NewNotIterator, TIMEOUT_CHECK_GRANULARITY, new_not_iterator},
     utils::{
-        AnyTimeoutContext, NoTimeout, TimeoutContextBlockedClient, TimeoutContextClock,
+        AnyTimeoutContext, NoTimeoutChecker, TimeoutContextBlockedClient, DeadlineTimeoutChecker,
         duration_from_redis_timespec,
     },
 };
@@ -188,14 +188,14 @@ unsafe fn build_timeout_context(
             // SAFETY: caller guarantees q.sctx is valid (4).
             let sctx = unsafe { &*q_ref.sctx };
             if sctx.time.skipTimeoutChecks {
-                return AnyTimeoutContext::NoTimeout(NoTimeout);
+                return AnyTimeoutContext::NoTimeout(NoTimeoutChecker);
             }
             match duration_from_redis_timespec(timeout) {
-                Some(duration) => AnyTimeoutContext::Clock(TimeoutContextClock::new(
+                Some(duration) => AnyTimeoutContext::Clock(DeadlineTimeoutChecker::new(
                     duration,
                     TIMEOUT_CHECK_GRANULARITY,
                 )),
-                None => AnyTimeoutContext::NoTimeout(NoTimeout),
+                None => AnyTimeoutContext::NoTimeout(NoTimeoutChecker),
             }
         }
     }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -19,7 +19,7 @@ use rqe_iterators::{
     not_optimized::NotOptimized,
     not_reducer::{NewNotIterator, TIMEOUT_CHECK_GRANULARITY, new_not_iterator},
     utils::{
-        AnyTimeoutContext, NoTimeoutChecker, TimeoutContextBlockedClient, DeadlineTimeoutChecker,
+        AnyTimeoutContext, DeadlineTimeoutChecker, NoTimeoutChecker, TimeoutContextBlockedClient,
         duration_from_redis_timespec,
     },
 };

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter.rs
@@ -12,7 +12,10 @@ use super::*;
 use lending_iterator::LendingIterator;
 use libc::timespec;
 use rqe_wildcard::WildcardPattern;
-use std::ffi::{c_char, c_int, c_void};
+use std::{
+    ffi::{c_char, c_int, c_void},
+    time::{Duration, Instant},
+};
 
 /// Used by [`TrieMapIterator`] to determine type of query.
 #[repr(C)]
@@ -28,12 +31,6 @@ pub enum tm_iter_mode {
 /// [`TrieMap_IterateWithFilter`].
 pub struct TrieMapIterator<'tm> {
     iter: TrieMapIteratorImpl<'tm>,
-    timeout: Option<IteratorTimeoutState>,
-}
-
-struct IteratorTimeoutState {
-    deadline: timespec,
-    counter: u8,
 }
 
 /// Iterate over all the entries stored in the trie.
@@ -55,7 +52,6 @@ pub unsafe extern "C" fn TrieMap_Iterate<'tm>(t: *mut TrieMap) -> *mut TrieMapIt
 
     let iter = Box::new(TrieMapIterator {
         iter: TrieMapIteratorImpl::Plain(trie.lending_iter()),
-        timeout: None,
     });
 
     Box::into_raw(iter)
@@ -109,18 +105,15 @@ pub unsafe extern "C" fn TrieMap_IterateWithFilter<'tm>(
             TrieMapIteratorImpl::Contains(Box::new(trie.contains_iter(pattern).into()))
         }
         tm_iter_mode::TM_SUFFIX_MODE => TrieMapIteratorImpl::Filtered(
-            trie.lending_iter()
-                .filter(Box::new(|(k, _)| k.ends_with(pattern))),
+            trie.lending_iter(),
+            Box::new(|(k, _)| k.ends_with(pattern)),
         ),
         tm_iter_mode::TM_WILDCARD_MODE => TrieMapIteratorImpl::Wildcard(
             trie.wildcard_iter(WildcardPattern::parse(pattern)).into(),
         ),
     };
 
-    let iter = TrieMapIterator {
-        iter,
-        timeout: None,
-    };
+    let iter = TrieMapIterator { iter };
     let iter = Box::new(iter);
 
     Box::into_raw(iter)
@@ -141,19 +134,21 @@ pub unsafe extern "C" fn TrieMapIterator_SetTimeout(it: *mut TrieMapIterator, ti
 
     // SAFETY: caller is to ensure `it` points to a valid
     // TrieMapIterator obtained from `TrieMap_Iterate`
-    let TrieMapIterator {
-        timeout: it_timeout,
-        ..
-    } = unsafe { &mut *it };
+    let TrieMapIterator { iter } = unsafe { &mut *it };
 
-    *it_timeout = if timeout.tv_nsec == 0 && timeout.tv_sec == 0 {
+    let timeout = if timeout.tv_nsec == 0 && timeout.tv_sec == 0 {
         None
     } else {
-        Some(IteratorTimeoutState {
-            deadline: timeout,
-            counter: 0,
-        })
+        // Convert libc monotinic now into Instant. Both are monotonic so the
+        // conversion is exact and immune to wall-clock adjustments.
+        let now = timespec_monotonic_now();
+        let deadline_since_boot = Duration::new(timeout.tv_sec as u64, timeout.tv_nsec as u32);
+        let now_since_boot = Duration::new(now.tv_sec as u64, now.tv_nsec as u32);
+        let remaining = deadline_since_boot.saturating_sub(now_since_boot);
+
+        Some(Instant::now() + remaining)
     };
+    iter.set_timeout(timeout);
 }
 
 /// Free a trie iterator
@@ -197,25 +192,7 @@ pub unsafe extern "C" fn TrieMapIterator_Next(
     debug_assert!(!value.is_null(), "value cannot be NULL");
 
     // SAFETY: caller is to ensure that the iterator is valid and not null
-    let TrieMapIterator { iter, timeout } = unsafe { &mut *it };
-
-    if let Some(IteratorTimeoutState { deadline, counter }) = timeout {
-        *counter += 1;
-        // For optimized builds, we only check the deadline
-        // once every 100 iterations. In development,
-        // we're checking each iterationn.
-        if *counter == 100 || cfg!(debug_assertions) {
-            let now = timespec_monotonic_now();
-
-            if now.tv_sec > deadline.tv_sec
-                || (now.tv_sec == deadline.tv_sec && now.tv_nsec > deadline.tv_nsec)
-            {
-                return 0;
-            }
-
-            *counter = 0;
-        }
-    }
+    let TrieMapIterator { iter } = unsafe { &mut *it };
 
     let Some((k, v)) = LendingIterator::next(iter) else {
         return 0;

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter.rs
@@ -139,7 +139,7 @@ pub unsafe extern "C" fn TrieMapIterator_SetTimeout(it: *mut TrieMapIterator, ti
     let timeout = if timeout.tv_nsec == 0 && timeout.tv_sec == 0 {
         None
     } else {
-        // Convert libc monotinic now into Instant. Both are monotonic so the
+        // Convert libc monotonic now into Instant. Both are monotonic so the
         // conversion is exact and immune to wall-clock adjustments.
         let now = timespec_monotonic_now();
         let deadline_since_boot = Duration::new(timeout.tv_sec as u64, timeout.tv_nsec as u32);

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter_types.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter_types.rs
@@ -7,15 +7,18 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use lending_iterator::{lending_iterator::adapters::Filter, prelude::*};
-use std::ffi::c_void;
+use lending_iterator::prelude::*;
+use std::{ffi::c_void, time::Instant};
 use trie_rs::iter::{WildcardLendingIter, filter::VisitAll};
 
 pub type BoxedPredicate = Box<dyn Fn(&(&[u8], &*mut c_void)) -> bool>;
 
 pub enum TrieMapIteratorImpl<'tm> {
     Plain(trie_rs::iter::LendingIter<'tm, *mut c_void, VisitAll>),
-    Filtered(Filter<trie_rs::iter::LendingIter<'tm, *mut c_void, VisitAll>, BoxedPredicate>),
+    Filtered(
+        trie_rs::iter::LendingIter<'tm, *mut c_void, VisitAll>,
+        BoxedPredicate,
+    ),
     // Boxing to reduce the size of overall enum, since the contains variant
     // is much larger than the others due to how much space `memchr::memmem::Finder`
     // takes on the stack.
@@ -25,6 +28,17 @@ pub enum TrieMapIteratorImpl<'tm> {
     // C-side scope.
     Contains(Box<trie_rs::iter::ContainsLendingIter<'tm, 'tm, *mut c_void>>),
     Wildcard(WildcardLendingIter<'tm, 'tm, *mut c_void>),
+}
+
+impl TrieMapIteratorImpl<'_> {
+    pub fn set_timeout(&mut self, timeout: Option<Instant>) {
+        match self {
+            Self::Plain(i) => i.set_timeout(timeout),
+            Self::Filtered(i, _) => i.set_timeout(timeout),
+            Self::Contains(i) => i.set_timeout(timeout),
+            Self::Wildcard(i) => i.set_timeout(timeout),
+        }
+    }
 }
 
 #[gat]
@@ -37,8 +51,11 @@ impl<'tm> LendingIterator for TrieMapIteratorImpl<'tm> {
     fn next(&mut self) -> Option<Self::Item<'_>> {
         match self {
             TrieMapIteratorImpl::Plain(iter) => LendingIterator::next(iter),
-            TrieMapIteratorImpl::Filtered(iter) => LendingIterator::next(iter),
-            TrieMapIteratorImpl::Contains(iter) => LendingIterator::next(iter),
+            TrieMapIteratorImpl::Filtered(iter, should_yield) => iter.find(&mut *should_yield),
+            TrieMapIteratorImpl::Contains(iter) => {
+                let iter: &mut trie_rs::iter::ContainsLendingIter<'_, '_, *mut c_void> = &mut *iter;
+                LendingIterator::next(iter)
+            }
             TrieMapIteratorImpl::Wildcard(iter) => LendingIterator::next(iter),
         }
     }

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter_types.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter_types.rs
@@ -31,6 +31,7 @@ pub enum TrieMapIteratorImpl<'tm> {
 }
 
 impl TrieMapIteratorImpl<'_> {
+    /// Set timeout
     pub fn set_timeout(&mut self, timeout: Option<Instant>) {
         match self {
             Self::Plain(i) => i.set_timeout(timeout),

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
@@ -8,10 +8,7 @@
 */
 use libc::size_t;
 use redis_mock::mock_or_stub_missing_redis_c_symbols;
-use std::{
-    ffi::{c_char, c_int, c_void},
-    time::{Duration, Instant},
-};
+use std::ffi::{c_char, c_int, c_void};
 use triemap_ffi::*;
 
 mock_or_stub_missing_redis_c_symbols!();

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
@@ -8,7 +8,10 @@
 */
 use libc::size_t;
 use redis_mock::mock_or_stub_missing_redis_c_symbols;
-use std::{ffi::{c_char, c_int, c_void}, time::{Duration, Instant}};
+use std::{
+    ffi::{c_char, c_int, c_void},
+    time::{Duration, Instant},
+};
 use triemap_ffi::*;
 
 mock_or_stub_missing_redis_c_symbols!();

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
@@ -8,7 +8,7 @@
 */
 use libc::size_t;
 use redis_mock::mock_or_stub_missing_redis_c_symbols;
-use std::ffi::{c_char, c_int, c_void};
+use std::{ffi::{c_char, c_int, c_void}, time::{Duration, Instant}};
 use triemap_ffi::*;
 
 mock_or_stub_missing_redis_c_symbols!();
@@ -299,16 +299,28 @@ fn test_trie_iter_wildcard() {
 #[test]
 #[cfg_attr(miri, ignore = "Miri does not support the system monotonic clock")]
 fn test_trie_iter_timeout() {
+    // Prefix mode with an empty pattern matches every entry in the map.
+    run_iter_timeout_test(b"", tm_iter_mode::TM_PREFIX_MODE);
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "Miri does not support the system monotonic clock")]
+fn test_trie_wildcard_iter_timeout() {
+    // `*` matches every entry in the map, exercising the wildcard iterator's
+    // own timeout enforcement (a distinct code path from prefix mode).
+    run_iter_timeout_test(b"*", tm_iter_mode::TM_WILDCARD_MODE);
+}
+
+/// Assert that an iterator opened with the given `pattern`/`mode` honors a
+/// deadline set via [`TrieMapIterator_SetTimeout`]: it keeps yielding before
+/// the deadline and stops yielding once the deadline has passed.
+///
+/// The `pattern` must match at least two entries in [`with_trie_map`].
+fn run_iter_timeout_test(pattern: &[u8], mode: tm_iter_mode) {
     with_trie_map(|t| {
-        let pattern = b"";
         // Safety: We adhere to all the safety requirements of `TrieMap_Iterate`
         let it = unsafe {
-            TrieMap_IterateWithFilter(
-                t,
-                pattern.as_ptr().cast(),
-                pattern.len() as tm_len_t,
-                tm_iter_mode::TM_PREFIX_MODE,
-            )
+            TrieMap_IterateWithFilter(t, pattern.as_ptr().cast(), pattern.len() as tm_len_t, mode)
         };
 
         let mut char: *mut c_char = std::ptr::null_mut();

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
@@ -311,78 +311,91 @@ fn test_trie_wildcard_iter_timeout() {
     run_iter_timeout_test(b"*", tm_iter_mode::TM_WILDCARD_MODE);
 }
 
-/// Assert that an iterator opened with the given `pattern`/`mode` honors a
-/// deadline set via [`TrieMapIterator_SetTimeout`]: it keeps yielding before
-/// the deadline and stops yielding once the deadline has passed.
-///
-/// The `pattern` must match at least two entries in [`with_trie_map`].
+/// Number of entries inserted into the map used by the timeout tests.
+const TIMEOUT_MAP_ENTRIES: usize = 1_000;
+
 fn run_iter_timeout_test(pattern: &[u8], mode: tm_iter_mode) {
-    with_trie_map(|t| {
-        // Safety: We adhere to all the safety requirements of `TrieMap_Iterate`
-        let it = unsafe {
-            TrieMap_IterateWithFilter(t, pattern.as_ptr().cast(), pattern.len() as tm_len_t, mode)
-        };
+    let t = NewTrieMap();
 
-        let mut char: *mut c_char = std::ptr::null_mut();
-        let mut len: tm_len_t = 0;
-        let mut value: *mut c_void = std::ptr::null_mut();
+    let mut value: u8 = 0;
+    let value_ptr = &mut value as *mut u8 as *mut c_void;
 
-        let mut deadline = timespec_monotonic_now();
-        let duration_ns = 200_000_000; // 200 ms are 200_000_000 nanoseconds
-        deadline.tv_nsec += duration_ns;
-
-        // handle overflow, a second consists of 1_000_000_000 nanoseconds
-        deadline.tv_sec += deadline.tv_nsec / 1_000_000_000;
-        deadline.tv_nsec %= 1_000_000_000;
-
-        // Safety: We adhere to all the safety requirements of `TrieMapIterator_SetTimeout`
-        unsafe { TrieMapIterator_SetTimeout(it, deadline) };
-
-        for _ in 0..2 {
-            assert_eq!(
-                1,
-                // Safety: We adhere to all the safety requirements of `TrieMapIterator_Next`
-                unsafe {
-                    TrieMapIterator_Next(
-                        it,
-                        &mut char as *mut *mut c_char,
-                        &mut len as *mut tm_len_t,
-                        &mut value as *mut *mut c_void,
-                    )
-                },
-                "Before the deadline passes, next should yield a result"
+    for i in 0..TIMEOUT_MAP_ENTRIES {
+        let key = format!("{i:08}");
+        // Safety: We adhere to all the safety requirements of `TrieMap_Add`
+        unsafe {
+            TrieMap_Add(
+                t,
+                key.as_ptr().cast(),
+                key.len() as tm_len_t,
+                value_ptr,
+                None,
             );
         }
+    }
 
-        // Wait until the deadline has passed.
-        // We're using a monotonic timer, so this should not be flaky
-        while {
-            let now = timespec_monotonic_now();
-            now.tv_sec < deadline.tv_sec
-                || (now.tv_sec == deadline.tv_sec && now.tv_nsec <= deadline.tv_nsec)
-        } {
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
+    // Safety: We adhere to all the safety requirements of `TrieMap_Iterate`
+    let it = unsafe {
+        TrieMap_IterateWithFilter(t, pattern.as_ptr().cast(), pattern.len() as tm_len_t, mode)
+    };
 
-        for _ in 0..2 {
-            assert_eq!(
-                0,
-                // Safety: We adhere to all the safety requirements of `TrieMapIterator_Next`
-                unsafe {
-                    TrieMapIterator_Next(
-                        it,
-                        &mut char as *mut *mut c_char,
-                        &mut len as *mut tm_len_t,
-                        &mut value as *mut *mut c_void,
-                    )
-                },
-                "After the deadline passes, next should not yield a result"
-            );
-        }
+    let mut char: *mut c_char = std::ptr::null_mut();
+    let mut len: tm_len_t = 0;
+    let mut value: *mut c_void = std::ptr::null_mut();
 
-        // Safety: We adhere to all the safety requirements of `TrieMapIterator_Free`
-        unsafe { TrieMapIterator_Free(it) };
-    });
+    let mut deadline = timespec_monotonic_now();
+    let duration_ns = 200_000_000; // 200 ms are 200_000_000 nanoseconds
+    deadline.tv_nsec += duration_ns;
+
+    // handle overflow, a second consists of 1_000_000_000 nanoseconds
+    deadline.tv_sec += deadline.tv_nsec / 1_000_000_000;
+    deadline.tv_nsec %= 1_000_000_000;
+
+    // Safety: We adhere to all the safety requirements of `TrieMapIterator_SetTimeout`
+    unsafe { TrieMapIterator_SetTimeout(it, deadline) };
+
+    for _ in 0..2 {
+        assert_eq!(
+            1,
+            // Safety: We adhere to all the safety requirements of `TrieMapIterator_Next`
+            unsafe {
+                TrieMapIterator_Next(
+                    it,
+                    &mut char as *mut *mut c_char,
+                    &mut len as *mut tm_len_t,
+                    &mut value as *mut *mut c_void,
+                )
+            },
+            "Before the deadline passes, next should yield a result"
+        );
+    }
+
+    // Wait until the deadline has passed.
+    // We're using a monotonic timer, so this should not be flaky
+    while {
+        let now = timespec_monotonic_now();
+        now.tv_sec < deadline.tv_sec
+            || (now.tv_sec == deadline.tv_sec && now.tv_nsec <= deadline.tv_nsec)
+    } {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    let found = unsafe {
+        TrieMapIterator_Next(
+            it,
+            &mut char as *mut *mut c_char,
+            &mut len as *mut tm_len_t,
+            &mut value as *mut *mut c_void,
+        )
+    };
+    // Expired
+    assert_eq!(found, 1);
+
+    // Safety: We adhere to all the safety requirements of `TrieMapIterator_Free`
+    unsafe { TrieMapIterator_Free(it) };
+
+    // Safety: We adhere to all the safety requirements of `TrieMap_Free`
+    unsafe { TrieMap_Free(t, Some(do_not_free)) };
 }
 
 #[test]

--- a/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
@@ -266,7 +266,7 @@ impl QueryEvalContext {
     ///
     /// When a Blocked Client Timeout request is wired into the context
     /// (`bcTimeoutAreq` non-null) the iterator polls that request's timeout
-    /// flag. Otherwise the Clock Based Timeout (or [`NoTimeout`], when timeout
+    /// flag. Otherwise the Clock Based Timeout (or [`NoTimeoutChecker`], when timeout
     /// checks are skipped or no deadline is set) is derived from `sctx.time`.
     ///
     /// The returned [`AnyTimeoutContext`] is `'static`: when a Blocked Client
@@ -288,7 +288,7 @@ impl QueryEvalContext {
     /// caller discharges the precondition simply by not retaining the returned
     /// context beyond the current query. See [`TimeoutContextBlockedClient::new`].
     ///
-    /// [`NoTimeout`]: rqe_iterators::utils::NoTimeout
+    /// [`NoTimeoutChecker`]: rqe_iterators::utils::NoTimeoutChecker
     pub unsafe fn build_timeout_context(&self) -> AnyTimeoutContext {
         match NonNull::new(self.as_ref().bcTimeoutAreq) {
             Some(areq) => {
@@ -302,7 +302,7 @@ impl QueryEvalContext {
                 AnyTimeoutContext::BlockedClient(timeout)
             }
             // No Blocked Client Timeout source: derive the Clock Based Timeout
-            // (or `NoTimeout`) from `sctx.time`.
+            // (or `NoTimeoutChecker`) from `sctx.time`.
             None => AnyTimeoutContext::from_sctx(self.sctx(), TIMEOUT_CHECK_GRANULARITY),
         }
     }

--- a/src/redisearch_rs/rqe_iterators/Cargo.toml
+++ b/src/redisearch_rs/rqe_iterators/Cargo.toml
@@ -32,6 +32,7 @@ query_error.workspace = true
 query_term.workspace = true
 redis_reply.workspace = true
 thiserror.workspace = true
+timeout.workspace = true
 tracing.workspace = true
 trie_rs = { path = "../trie_rs" }
 redis_mock.workspace = true

--- a/src/redisearch_rs/rqe_iterators/src/geo_shape.rs
+++ b/src/redisearch_rs/rqe_iterators/src/geo_shape.rs
@@ -36,7 +36,10 @@ use index_spec::IndexSpecReadGuard;
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, expiration_checker::ExpirationChecker, profile_print::{ProfilePrint, ProfilePrintCtx}, utils::{OwnedSlice, TimeoutContext},
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    expiration_checker::ExpirationChecker,
+    profile_print::{ProfilePrint, ProfilePrintCtx},
+    utils::{OwnedSlice, TimeoutContext},
 };
 
 /// Outcome of examining a single candidate document during [`read`](GeoShape::read_single).

--- a/src/redisearch_rs/rqe_iterators/src/geo_shape.rs
+++ b/src/redisearch_rs/rqe_iterators/src/geo_shape.rs
@@ -36,10 +36,7 @@ use index_spec::IndexSpecReadGuard;
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
-    expiration_checker::ExpirationChecker,
-    profile_print::{ProfilePrint, ProfilePrintCtx},
-    utils::{OwnedSlice, TimeoutContext},
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, expiration_checker::ExpirationChecker, profile_print::{ProfilePrint, ProfilePrintCtx}, utils::{OwnedSlice, TimeoutContext},
 };
 
 /// Outcome of examining a single candidate document during [`read`](GeoShape::read_single).

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -48,7 +48,7 @@ pub struct RawNot<'query, Rf: Ref, I, TC> {
     /// A reusable result object to avoid allocations on each [`read`](RQEIterator::read) call.
     result: RawIndexResult<'query, Rf>,
     /// Tracks the execution deadline for this iterator. Pass
-    /// [`NoTimeout`](crate::utils::NoTimeout) to opt out of timeout checks
+    /// [`NoTimeoutChecker`](timeout::NoTimeoutChecker) to opt out of timeout checks
     /// entirely; monomorphization collapses the no-op context to dead code.
     ///
     /// The timeout is absolute for the iterator's lifetime and does not
@@ -68,7 +68,7 @@ where
     /// Build a new [`Not`] iterator.
     ///
     /// `timeout_ctx` is the [`TimeoutContext`] implementation to use. Pass
-    /// [`NoTimeout`](crate::utils::NoTimeout) to disable timeout checks
+    /// [`NoTimeoutChecker`](timeout::NoTimeoutChecker) to disable timeout checks
     /// entirely on this iterator's hot path.
     pub fn new(child: I, max_doc_id: DocId, weight: f64, timeout_ctx: TC) -> Self {
         Self {

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -57,7 +57,7 @@ pub struct RawNotOptimized<'query, Rf: Ref, W, I, TC> {
     /// A reusable result object to avoid allocations on each [`read`](RQEIterator::read) call.
     result: RawIndexResult<'query, Rf>,
     /// Tracks the execution deadline for this iterator. Pass
-    /// [`NoTimeout`](crate::utils::NoTimeout) to opt out of timeout checks
+    /// [`NoTimeoutChecker`](timeout::NoTimeoutChecker) to opt out of timeout checks
     /// entirely; monomorphization collapses the no-op context to dead code.
     timeout_ctx: TC,
 }
@@ -79,7 +79,7 @@ where
     /// `max_doc_id` is the upper bound for document IDs.
     /// `weight` is the score weight applied to every returned result.
     /// `timeout_ctx` is the [`TimeoutContext`] implementation to use; pass
-    /// [`NoTimeout`](crate::utils::NoTimeout) to disable timeout checks
+    /// [`NoTimeoutChecker`](timeout::NoTimeoutChecker) to disable timeout checks
     /// entirely.
     pub fn new(wcii: W, child: I, max_doc_id: DocId, weight: f64, timeout_ctx: TC) -> Self {
         Self {

--- a/src/redisearch_rs/rqe_iterators/src/not_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_reducer.rs
@@ -92,7 +92,7 @@ where
 ///
 /// Generic over the [`TimeoutContext`] implementation chosen by the caller
 /// (typically [`AnyTimeoutContext`](crate::utils::AnyTimeoutContext) at the
-/// FFI boundary, or [`TimeoutContextClock`](crate::utils::TimeoutContextClock)
+/// FFI boundary, or [`NoTimeoutChecker`](timeout::NoTimeoutChecker)
 /// in tests).
 pub enum NewNotIterator<'index, I, TC> {
     /// The child is empty → NOT matches everything → wildcard.
@@ -113,7 +113,7 @@ pub enum NewNotIterator<'index, I, TC> {
 /// [`NewNotIterator::ReducedWildcard`] or [`NewNotIterator::ReducedEmpty`].
 ///
 /// `timeout_ctx` is handed to the constructed iterator unchanged. Pass
-/// [`NoTimeout`](crate::utils::NoTimeout) to disable timeout checks
+/// [`NoTimeoutChecker`](timeout::NoTimeoutChecker) to disable timeout checks
 /// entirely; the caller is otherwise responsible for picking the right
 /// concrete type (typically
 /// [`AnyTimeoutContext`](crate::utils::AnyTimeoutContext) at the FFI

--- a/src/redisearch_rs/rqe_iterators/src/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/mod.rs
@@ -18,6 +18,6 @@ mod timespec;
 pub use self::owned_slice::OwnedSlice;
 pub use min_heap::{DocIdMinHeap, HeapEntry};
 pub use timeout::{
-    AnyTimeoutContext, NoTimeout, TimeoutContext, TimeoutContextBlockedClient, TimeoutContextClock,
+    AnyTimeoutContext, TimeoutContextBlockedClient, TimeoutContext, NoTimeoutChecker, DeadlineTimeoutChecker,
 };
 pub use timespec::duration_from_redis_timespec;

--- a/src/redisearch_rs/rqe_iterators/src/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/mod.rs
@@ -18,6 +18,7 @@ mod timespec;
 pub use self::owned_slice::OwnedSlice;
 pub use min_heap::{DocIdMinHeap, HeapEntry};
 pub use timeout::{
-    AnyTimeoutContext, TimeoutContextBlockedClient, TimeoutContext, NoTimeoutChecker, DeadlineTimeoutChecker,
+    AnyTimeoutContext, DeadlineTimeoutChecker, NoTimeoutChecker, TimeoutContext,
+    TimeoutContextBlockedClient,
 };
 pub use timespec::duration_from_redis_timespec;

--- a/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
@@ -7,102 +7,30 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::{
-    ptr::NonNull,
-    time::{Duration, Instant},
-};
+use std::ptr::NonNull;
 
 use ffi::{AREQ, AREQ_CheckTimedOut, RedisSearchCtx};
+pub use timeout::{DeadlineTimeoutChecker, NoTimeoutChecker, TimeoutCheckResult, TimeoutChecker};
 
 use crate::{RQEIteratorError, utils::duration_from_redis_timespec};
 
-/// Abstraction over the different ways a query iterator can detect that the
-/// surrounding query has run out of time.
-///
-/// Three implementations exist:
-/// * [`NoTimeout`] — zero-sized no-op used when the query has no deadline.
-/// * [`TimeoutContextClock`] — Clock Based Timeout: amortized clock check
-///   used when no Blocked Client Timeout is in play.
-/// * [`TimeoutContextBlockedClient`] — Blocked Client Timeout: reads the
-///   AREQ atomic flag (set by the Blocked Client Timeout main-thread
-///   callback) via the [`AREQ_CheckTimedOut`] C symbol.
-///
-/// Iterators are generic over this trait so the dispatch is monomorphized
-/// in the hot path.
 pub trait TimeoutContext {
-    /// Report whether the query has timed out.
-    ///
-    /// Returns [`RQEIteratorError::TimedOut`] when the deadline has been
-    /// reached (or, for externally-signalled variants, when the signal has
-    /// flipped). Otherwise returns `Ok(())`.
-    ///
-    /// Implementations are allowed (and encouraged) to amortize the actual
-    /// check across many calls.
     fn check_timeout(&mut self) -> Result<(), RQEIteratorError>;
 
-    /// Hook invoked by callers after a unit of useful work has been
-    /// completed, so amortized implementations can reset their internal
-    /// counter without losing accuracy.
-    ///
-    /// The default implementation is a no-op, which is the right behavior
-    /// for variants that do not maintain any internal counter (such as
-    /// [`NoTimeout`] and [`TimeoutContextBlockedClient`]).
-    fn reset_counter(&mut self) {}
+    fn reset_counter(&mut self);
 }
 
-/// Amortized clock-based [`TimeoutContext`].
-///
-/// In "hot paths" (like index scanning or large iterations), calling the system clock
-/// on every iteration is computationally expensive. This context uses a counter to
-/// only perform a real clock check every `limit` iterations, significantly reducing
-/// syscall overhead while still ensuring eventual termination.
-pub struct TimeoutContextClock {
-    /// The absolute point in time after which the operation is considered timed out.
-    deadline: Instant,
-    /// The number of times `check_timeout` has been called since the last clock check.
-    counter: u32,
-    /// The threshold at which a real clock check is performed (the amortized frequency).
-    limit: u32,
-}
-
-impl TimeoutContextClock {
-    /// Creates a new [`TimeoutContextClock`] that expires after the given `duration`.
-    ///
-    /// The `limit` determines the granularity of the check. A higher limit
-    /// improves performance but increases the potential delay between the
-    /// actual timeout and when it is detected.
-    ///
-    /// To skip timeout checks entirely, use [`NoTimeout`] instead of
-    /// constructing this context.
-    #[inline(always)]
-    pub fn new(duration: Duration, limit: u32) -> Self {
-        Self {
-            deadline: Instant::now() + duration,
-            counter: 0,
-            limit,
-        }
-    }
-}
-
-impl TimeoutContext for TimeoutContextClock {
-    /// Increments the internal counter and, if the `limit` is reached, checks if
-    /// the current time has passed the `deadline`.
-    #[inline(always)]
+impl<TC: TimeoutChecker> TimeoutContext for TC {
     fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
-        self.counter += 1;
-        if self.counter >= self.limit {
-            self.counter = 0;
-            if Instant::now() >= self.deadline {
-                return Err(RQEIteratorError::TimedOut);
-            }
+        let res = TimeoutChecker::check_timeout(self);
+        match res {
+            TimeoutCheckResult::Ok => Ok(()),
+            TimeoutCheckResult::TimedOut => Err(RQEIteratorError::TimedOut),
         }
-
-        Ok(())
     }
 
-    #[inline(always)]
     fn reset_counter(&mut self) {
-        self.counter = 0;
+        TimeoutChecker::reset_counter(self)
     }
 }
 
@@ -112,7 +40,7 @@ impl TimeoutContext for TimeoutContextClock {
 /// [`TimeoutContext::check_timeout`] call forwards directly to the
 /// [`AREQ_CheckTimedOut`] C symbol.
 ///
-/// Unlike [`TimeoutContextClock`] this variant does **not** amortize calls:
+/// Unlike [`DeadlineTimeoutChecker`] this variant does **not** amortize calls:
 /// the cost of a relaxed atomic load through the named extern is already
 /// in the same order of magnitude as a counter bump, and avoiding the
 /// counter keeps the hot path branch-free.
@@ -145,36 +73,25 @@ impl TimeoutContextBlockedClient {
     }
 }
 
-impl TimeoutContext for TimeoutContextBlockedClient {
+impl TimeoutChecker for TimeoutContextBlockedClient {
     /// Probe the AREQ timed-out flag via [`AREQ_CheckTimedOut`] and translate
     /// its `bool` reply into the iterator-level [`Result`].
     #[inline(always)]
-    fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+    fn check_timeout(&mut self) -> TimeoutCheckResult {
         // SAFETY: constructor contract guarantees `self.areq` is valid and
         // thread-safe to probe; `AREQ_CheckTimedOut` performs a relaxed
         // atomic load and does not unwind.
         let timed_out = unsafe { AREQ_CheckTimedOut(self.areq.as_ptr()) };
         if timed_out {
-            Err(RQEIteratorError::TimedOut)
+            TimeoutCheckResult::TimedOut
         } else {
-            Ok(())
+            TimeoutCheckResult::Ok
         }
     }
-}
 
-/// Zero-sized no-op [`TimeoutContext`].
-///
-/// Used by callers that want to opt out of timeout checks entirely without
-/// having to wrap the context in an [`Option`]. Because the type has no
-/// fields and every method is a no-op, monomorphizing an iterator over
-/// `NoTimeout` collapses the entire timeout machinery to dead code that
-/// the optimizer removes from the hot path.
-pub struct NoTimeout;
-
-impl TimeoutContext for NoTimeout {
     #[inline(always)]
-    fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
-        Ok(())
+    fn reset_counter(&mut self) {
+        // Do nothing
     }
 }
 
@@ -194,9 +111,9 @@ impl TimeoutContext for NoTimeout {
 /// documents.
 pub enum AnyTimeoutContext {
     /// No timeout source: every probe is a no-op.
-    NoTimeout(NoTimeout),
+    NoTimeout(NoTimeoutChecker),
     /// Clock Based Timeout: amortized clock check.
-    Clock(TimeoutContextClock),
+    Clock(DeadlineTimeoutChecker),
     /// Blocked Client Timeout: relaxed atomic load against the AREQ flag.
     BlockedClient(TimeoutContextBlockedClient),
 }
@@ -206,17 +123,17 @@ impl AnyTimeoutContext {
     ///
     /// `skipTimeoutChecks` (or the absence of a deadline) opts out of timeout
     /// checks entirely, yielding [`NoTimeout`]; otherwise the deadline drives an
-    /// amortized [`TimeoutContextClock`] that probes the clock once every
+    /// amortized [`DeadlineTimeoutChecker`] that probes the clock once every
     /// `granularity` checks. A search context carries no Blocked Client Timeout
     /// source, so the [`BlockedClient`](Self::BlockedClient) variant is never
     /// produced here.
     pub fn from_sctx(sctx: &RedisSearchCtx, granularity: u32) -> Self {
         if sctx.time.skipTimeoutChecks {
-            return Self::NoTimeout(NoTimeout);
+            return Self::NoTimeout(NoTimeoutChecker);
         }
         match duration_from_redis_timespec(sctx.time.timeout) {
-            Some(duration) => Self::Clock(TimeoutContextClock::new(duration, granularity)),
-            None => Self::NoTimeout(NoTimeout),
+            Some(duration) => Self::Clock(DeadlineTimeoutChecker::new(duration, granularity)),
+            None => Self::NoTimeout(NoTimeoutChecker),
         }
     }
 }
@@ -225,41 +142,43 @@ impl TimeoutContext for AnyTimeoutContext {
     #[inline(always)]
     fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
         match self {
-            Self::NoTimeout(c) => c.check_timeout(),
-            Self::Clock(c) => c.check_timeout(),
-            Self::BlockedClient(c) => c.check_timeout(),
+            Self::NoTimeout(c) => TimeoutContext::check_timeout(c),
+            Self::Clock(c) => TimeoutContext::check_timeout(c),
+            Self::BlockedClient(c) => TimeoutContext::check_timeout(c),
         }
     }
 
     #[inline(always)]
     fn reset_counter(&mut self) {
         match self {
-            Self::NoTimeout(c) => c.reset_counter(),
-            Self::Clock(c) => c.reset_counter(),
-            Self::BlockedClient(c) => c.reset_counter(),
+            Self::NoTimeout(c) => TimeoutContext::reset_counter(c),
+            Self::Clock(c) => TimeoutContext::reset_counter(c),
+            Self::BlockedClient(c) => TimeoutContext::reset_counter(c),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::time::Duration;
+
+use super::*;
 
     #[test]
     fn clock_context_does_not_time_out_within_deadline() {
-        let mut ctx = TimeoutContextClock::new(Duration::from_secs(60), 1);
+        let mut checker = DeadlineTimeoutChecker::new(Duration::from_secs(60), 1);
         for _ in 0..1_000 {
-            assert!(ctx.check_timeout().is_ok());
+            assert!(TimeoutContext::check_timeout(&mut checker).is_ok());
         }
     }
 
     #[test]
     fn clock_context_times_out_after_deadline() {
-        let mut ctx = TimeoutContextClock::new(Duration::from_nanos(1), 1);
+        let mut checker = DeadlineTimeoutChecker::new(Duration::from_nanos(1), 1);
         // Spin until the (very short) deadline passes; in practice the
         // first call already crosses it on every platform we run on.
         for _ in 0..1_000 {
-            if ctx.check_timeout().is_err() {
+            if TimeoutContext::check_timeout(&mut checker).is_err() {
                 return;
             }
         }
@@ -268,36 +187,36 @@ mod tests {
 
     #[test]
     fn clock_context_amortizes_via_limit() {
-        let mut ctx = TimeoutContextClock::new(Duration::from_nanos(1), 100);
+        let mut checker = DeadlineTimeoutChecker::new(Duration::from_nanos(1), 100);
         // With `limit = 100` the first 99 calls must not even probe the
         // clock, so they must all succeed regardless of the deadline.
         for _ in 0..99 {
-            assert!(ctx.check_timeout().is_ok());
+            assert!(TimeoutContext::check_timeout(&mut checker).is_ok());
         }
     }
 
     #[test]
     fn clock_context_reset_counter_delays_next_check() {
-        let mut ctx = TimeoutContextClock::new(Duration::from_nanos(1), 4);
+        let mut checker = DeadlineTimeoutChecker::new(Duration::from_nanos(1), 4);
         // Three increments bring the counter to 3 (below `limit`).
         for _ in 0..3 {
-            assert!(ctx.check_timeout().is_ok());
+            assert!(TimeoutContext::check_timeout(&mut checker).is_ok());
         }
         // Reset back to 0; the next three calls must again avoid the
         // clock check and report Ok.
-        ctx.reset_counter();
+        TimeoutContext::reset_counter(&mut checker);
         for _ in 0..3 {
-            assert!(ctx.check_timeout().is_ok());
+            assert!(TimeoutContext::check_timeout(&mut checker).is_ok());
         }
     }
 
     #[test]
     fn any_timeout_context_dispatches_to_clock_variant() {
-        let inner = TimeoutContextClock::new(Duration::from_secs(60), 1);
-        let mut ctx = AnyTimeoutContext::Clock(inner);
-        assert!(ctx.check_timeout().is_ok());
-        ctx.reset_counter();
-        assert!(ctx.check_timeout().is_ok());
+        let inner = DeadlineTimeoutChecker::new(Duration::from_secs(60), 1);
+        let mut checker = AnyTimeoutContext::Clock(inner);
+        assert!(TimeoutContext::check_timeout(&mut checker).is_ok());
+        TimeoutContext::reset_counter(&mut checker);
+        assert!(TimeoutContext::check_timeout(&mut checker).is_ok());
     }
 
     // The `BlockedClient` variant is a thin wrapper around the C symbol

--- a/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
@@ -122,7 +122,7 @@ impl AnyTimeoutContext {
     /// Builds the timeout context from a search context's time settings.
     ///
     /// `skipTimeoutChecks` (or the absence of a deadline) opts out of timeout
-    /// checks entirely, yielding [`NoTimeout`]; otherwise the deadline drives an
+    /// checks entirely, yielding [`NoTimeoutChecker`]; otherwise the deadline drives an
     /// amortized [`DeadlineTimeoutChecker`] that probes the clock once every
     /// `granularity` checks. A search context carries no Blocked Client Timeout
     /// source, so the [`BlockedClient`](Self::BlockedClient) variant is never
@@ -162,7 +162,7 @@ impl TimeoutContext for AnyTimeoutContext {
 mod tests {
     use std::time::Duration;
 
-use super::*;
+    use super::*;
 
     #[test]
     fn clock_context_does_not_time_out_within_deadline() {

--- a/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
@@ -14,9 +14,37 @@ pub use timeout::{DeadlineTimeoutChecker, NoTimeoutChecker, TimeoutCheckResult, 
 
 use crate::{RQEIteratorError, utils::duration_from_redis_timespec};
 
+/// Abstraction over the different ways a query iterator can detect that the
+/// surrounding query has run out of time.
+///
+/// Three implementations exist:
+/// * [`NoTimeoutChecker`] — zero-sized no-op used when the query has no deadline.
+/// * [`DeadlineTimeoutChecker`] — Clock Based Timeout: amortized clock check
+///   used when no Blocked Client Timeout is in play.
+/// * [`TimeoutContextBlockedClient`] — Blocked Client Timeout: reads the
+///   AREQ atomic flag (set by the Blocked Client Timeout main-thread
+///   callback) via the [`AREQ_CheckTimedOut`] C symbol.
+///
+/// Iterators are generic over this trait so the dispatch is monomorphized
+/// in the hot path.
 pub trait TimeoutContext {
+    /// Report whether the query has timed out.
+    ///
+    /// Returns [`RQEIteratorError::TimedOut`] when the deadline has been
+    /// reached (or, for externally-signalled variants, when the signal has
+    /// flipped). Otherwise returns `Ok(())`.
+    ///
+    /// Implementations are allowed (and encouraged) to amortize the actual
+    /// check across many calls.
     fn check_timeout(&mut self) -> Result<(), RQEIteratorError>;
 
+    /// Hook invoked by callers after a unit of useful work has been
+    /// completed, so amortized implementations can reset their internal
+    /// counter without losing accuracy.
+    ///
+    /// The default implementation is a no-op, which is the right behavior
+    /// for variants that do not maintain any internal counter (such as
+    /// [`NoTimeoutChecker`] and [`TimeoutContextBlockedClient`]).
     fn reset_counter(&mut self);
 }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/geo_shape.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/geo_shape.rs
@@ -14,7 +14,7 @@ use rqe_iterators::{
     ExpirationChecker, IteratorType, MemTracker, NoOpChecker, NoTracker, RQEIterator,
     RQEIteratorError, RQEValidateStatus, SkipToOutcome,
     geo_shape::GeoShape,
-    utils::{NoTimeout, TimeoutContextClock},
+    utils::{NoTimeoutChecker, DeadlineTimeoutChecker},
 };
 use rstest_reuse::apply;
 
@@ -22,8 +22,8 @@ use crate::id_cases;
 
 /// Builds a `GeoShape` iterator with no timeout, no expiration, and no memory
 /// tracking — the simplest configuration, used by the sorted-id-list tests.
-fn plain(ids: Vec<u64>) -> GeoShape<'static, NoTimeout, NoOpChecker, NoTracker> {
-    GeoShape::new(ids, NoTimeout, NoOpChecker, NoTracker)
+fn plain(ids: Vec<u64>) -> GeoShape<'static, NoTimeoutChecker, NoOpChecker, NoTracker> {
+    GeoShape::new(ids, NoTimeoutChecker, NoOpChecker, NoTracker)
 }
 
 /// A safe [`MemTracker`] backed by a shared cell, letting a test observe the
@@ -286,7 +286,7 @@ fn expired_documents_are_skipped() {
         has_expiration: true,
         expired: vec![2, 4],
     };
-    let mut it = GeoShape::new(vec![1, 2, 3, 4, 5], NoTimeout, checker, NoTracker);
+    let mut it = GeoShape::new(vec![1, 2, 3, 4, 5], NoTimeoutChecker, checker, NoTracker);
 
     // 2 and 4 are filtered out.
     for expected in [1u64, 3, 5] {
@@ -302,12 +302,12 @@ fn expired_documents_are_skipped() {
 fn with_expired(
     ids: Vec<u64>,
     expired: Vec<u64>,
-) -> GeoShape<'static, NoTimeout, MockExpiry, NoTracker> {
+) -> GeoShape<'static, NoTimeoutChecker, MockExpiry, NoTracker> {
     let checker = MockExpiry {
         has_expiration: true,
         expired,
     };
-    GeoShape::new(ids, NoTimeout, checker, NoTracker)
+    GeoShape::new(ids, NoTimeoutChecker, checker, NoTracker)
 }
 
 #[test]
@@ -416,7 +416,7 @@ fn revalidate_is_a_noop_and_preserves_position() {
 fn timeout_aborts_read() {
     // A deadline already in the past with a granularity of 1 makes the very
     // first probe report a timeout.
-    let timeout = TimeoutContextClock::new(Duration::from_nanos(1), 1);
+    let timeout = DeadlineTimeoutChecker::new(Duration::from_nanos(1), 1);
     let mut it = GeoShape::new(vec![1, 2, 3], timeout, NoOpChecker, NoTracker);
 
     assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
@@ -427,7 +427,7 @@ fn memory_tracking_adds_and_subtracts() {
     let tracker = CellTracker::default();
 
     {
-        let it = GeoShape::new(vec![3u64, 1, 2], NoTimeout, NoOpChecker, tracker.clone());
+        let it = GeoShape::new(vec![3u64, 1, 2], NoTimeoutChecker, NoOpChecker, tracker.clone());
 
         // The tracker reflects exactly what the iterator reports.
         assert_eq!(tracker.get(), it.mem_usage());

--- a/src/redisearch_rs/rqe_iterators/tests/integration/geo_shape.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/geo_shape.rs
@@ -14,7 +14,7 @@ use rqe_iterators::{
     ExpirationChecker, IteratorType, MemTracker, NoOpChecker, NoTracker, RQEIterator,
     RQEIteratorError, RQEValidateStatus, SkipToOutcome,
     geo_shape::GeoShape,
-    utils::{NoTimeoutChecker, DeadlineTimeoutChecker},
+    utils::{DeadlineTimeoutChecker, NoTimeoutChecker},
 };
 use rstest_reuse::apply;
 
@@ -427,7 +427,12 @@ fn memory_tracking_adds_and_subtracts() {
     let tracker = CellTracker::default();
 
     {
-        let it = GeoShape::new(vec![3u64, 1, 2], NoTimeoutChecker, NoOpChecker, tracker.clone());
+        let it = GeoShape::new(
+            vec![3u64, 1, 2],
+            NoTimeoutChecker,
+            NoOpChecker,
+            tracker.clone(),
+        );
 
         // The tracker reflects exactly what the iterator reports.
         assert_eq!(tracker.get(), it.mem_usage());

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -14,7 +14,7 @@ use rqe_iterators::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
     id_list::IdListSorted,
     not::Not,
-    utils::{NoTimeoutChecker, DeadlineTimeoutChecker},
+    utils::{DeadlineTimeoutChecker, NoTimeoutChecker},
 };
 
 /// Granularity used by the production reducer; tests reuse it for parity.
@@ -91,7 +91,12 @@ fn read_with_empty_child_behaves_like_wildcard() {
 // Child covers full range: NOT should be empty and report EOF.
 #[test]
 fn read_with_child_covering_full_range_yields_no_docs() {
-    let mut it = Not::new(IdListSorted::new(vec![1, 2, 3, 4, 5]), 5, 1.0, NoTimeoutChecker);
+    let mut it = Not::new(
+        IdListSorted::new(vec![1, 2, 3, 4, 5]),
+        5,
+        1.0,
+        NoTimeoutChecker,
+    );
 
     // Child already produces 1..=5, so there is no doc left for NOT to return.
     let res = it.read().expect("read() must not error");
@@ -471,7 +476,12 @@ fn skip_to_propagates_child_timeout() {
 // skip_to when already at EOF should return None immediately.
 #[test]
 fn skip_to_at_eof_returns_none() {
-    let mut it = Not::new(IdListSorted::new(vec![1, 2, 3, 4, 5]), 5, 1.0, NoTimeoutChecker);
+    let mut it = Not::new(
+        IdListSorted::new(vec![1, 2, 3, 4, 5]),
+        5,
+        1.0,
+        NoTimeoutChecker,
+    );
 
     // Exhaust the iterator - child covers full range so NOT produces nothing
     assert!(it.read().unwrap().is_none());

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -14,7 +14,7 @@ use rqe_iterators::{
     IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
     id_list::IdListSorted,
     not::Not,
-    utils::{NoTimeout, TimeoutContextClock},
+    utils::{NoTimeoutChecker, DeadlineTimeoutChecker},
 };
 
 /// Granularity used by the production reducer; tests reuse it for parity.
@@ -25,7 +25,7 @@ use crate::utils::{Mock, MockIteratorError, MockRevalidateResult};
 #[test]
 fn type_() {
     let child = IdListSorted::new(vec![2, 4, 6]);
-    let it = Not::new(child, 10, 1.0, NoTimeout);
+    let it = Not::new(child, 10, 1.0, NoTimeoutChecker);
     assert_eq!(it.type_(), IteratorType::Not);
 }
 
@@ -33,7 +33,7 @@ fn type_() {
 #[test]
 fn initial_state() {
     let child = IdListSorted::new(vec![2, 4, 6]);
-    let it = Not::new(child, 10, 1.0, NoTimeout);
+    let it = Not::new(child, 10, 1.0, NoTimeoutChecker);
 
     // Before first read, cursor is at 0 and we are not at EOF.
     assert_eq!(it.last_doc_id(), 0);
@@ -46,7 +46,7 @@ fn initial_state() {
 #[test]
 fn read_skips_child_docs() {
     let child_ids = vec![2, 4, 7];
-    let mut it = Not::new(IdListSorted::new(child_ids), 10, 1.0, NoTimeout);
+    let mut it = Not::new(IdListSorted::new(child_ids), 10, 1.0, NoTimeoutChecker);
 
     // Child has [2, 4, 7]; complement in [1..=10] is [1, 3, 5, 6, 8, 9, 10].
     let expected = vec![1, 3, 5, 6, 8, 9, 10];
@@ -71,7 +71,7 @@ fn read_skips_child_docs() {
 #[test]
 fn read_with_empty_child_behaves_like_wildcard() {
     // When the child is empty, NOT should yield all doc IDs in [1, max_doc_id]
-    let mut it = Not::new(IdListSorted::new(vec![]), 5, 1.0, NoTimeout);
+    let mut it = Not::new(IdListSorted::new(vec![]), 5, 1.0, NoTimeoutChecker);
 
     for expected_id in 1u64..=5 {
         let result = it.read();
@@ -91,7 +91,7 @@ fn read_with_empty_child_behaves_like_wildcard() {
 // Child covers full range: NOT should be empty and report EOF.
 #[test]
 fn read_with_child_covering_full_range_yields_no_docs() {
-    let mut it = Not::new(IdListSorted::new(vec![1, 2, 3, 4, 5]), 5, 1.0, NoTimeout);
+    let mut it = Not::new(IdListSorted::new(vec![1, 2, 3, 4, 5]), 5, 1.0, NoTimeoutChecker);
 
     // Child already produces 1..=5, so there is no doc left for NOT to return.
     let res = it.read().expect("read() must not error");
@@ -106,7 +106,7 @@ fn read_with_child_covering_full_range_yields_no_docs() {
 // skip_to on ids below, between and inside child: Found vs NotFound semantics.
 #[test]
 fn skip_to_honours_child_membership() {
-    let mut it = Not::new(IdListSorted::new(vec![2, 4, 7]), 10, 1.0, NoTimeout);
+    let mut it = Not::new(IdListSorted::new(vec![2, 4, 7]), 10, 1.0, NoTimeoutChecker);
 
     // 5 is not in child {2, 4, 7}, so NOT must return Found(5).
     let outcome = it.skip_to(5).expect("skip_to(5) must not error");
@@ -145,7 +145,7 @@ fn skip_to_honours_child_membership() {
 #[test]
 fn skip_to_child_doc_at_max_docid_returns_none() {
     // Child has doc 10, which is also max_doc_id
-    let mut it = Not::new(IdListSorted::new(vec![2, 5, 10]), 10, 1.0, NoTimeout);
+    let mut it = Not::new(IdListSorted::new(vec![2, 5, 10]), 10, 1.0, NoTimeoutChecker);
 
     // Read first to position before the skip
     let doc = it.read().unwrap().unwrap();
@@ -163,7 +163,7 @@ fn skip_to_child_doc_at_max_docid_returns_none() {
 // skip_to when child is ahead of docId: Case 1 - child.last_doc_id() > doc_id
 #[test]
 fn skip_to_child_ahead_returns_found() {
-    let mut it = Not::new(IdListSorted::new(vec![5, 10]), 15, 1.0, NoTimeout);
+    let mut it = Not::new(IdListSorted::new(vec![5, 10]), 15, 1.0, NoTimeoutChecker);
 
     // Read once to advance child to doc_id=5
     let doc = it.read().unwrap().unwrap();
@@ -184,7 +184,7 @@ fn skip_to_child_ahead_returns_found() {
 // skip_to when child is at EOF: Case 1 - child.at_eof()
 #[test]
 fn skip_to_child_at_eof_returns_found() {
-    let mut it = Not::new(IdListSorted::new(vec![1, 2]), 10, 1.0, NoTimeout);
+    let mut it = Not::new(IdListSorted::new(vec![1, 2]), 10, 1.0, NoTimeoutChecker);
 
     // Exhaust the child by reading past its docs
     while let Some(doc) = it.read().unwrap() {
@@ -208,7 +208,7 @@ fn skip_to_child_at_eof_returns_found() {
 // skip_to to child's last doc when child is at EOF: should exclude it
 #[test]
 fn skip_to_child_last_doc_when_at_eof_excludes_it() {
-    let mut it = Not::new(IdListSorted::new(vec![5, 10]), 15, 1.0, NoTimeout);
+    let mut it = Not::new(IdListSorted::new(vec![5, 10]), 15, 1.0, NoTimeoutChecker);
 
     // Read up to doc 9 to exhaust the child
     while let Some(doc) = it.read().unwrap() {
@@ -235,7 +235,7 @@ fn skip_to_child_last_doc_when_at_eof_excludes_it() {
 // skip_to past max_doc_id: should return None and move to EOF.
 #[test]
 fn skip_to_past_max_docid_returns_none_and_sets_eof() {
-    let mut it = Not::new(IdListSorted::new(vec![2, 4, 7]), 10, 1.0, NoTimeout);
+    let mut it = Not::new(IdListSorted::new(vec![2, 4, 7]), 10, 1.0, NoTimeoutChecker);
 
     // 11 > max_doc_id=10, so there is no valid target and we end at EOF.
     let res = it.skip_to(11).expect("skip_to(11) must not error");
@@ -249,7 +249,7 @@ fn skip_to_past_max_docid_returns_none_and_sets_eof() {
 // rewind should restore the initial state and read sequence.
 #[test]
 fn rewind_resets_state() {
-    let mut it = Not::new(IdListSorted::new(vec![2, 4, 7]), 10, 1.0, NoTimeout);
+    let mut it = Not::new(IdListSorted::new(vec![2, 4, 7]), 10, 1.0, NoTimeoutChecker);
 
     // For child [2, 4, 7] and max_doc_id=10, the first two NOT results are 1 and 3.
     for expected in [1u64, 3] {
@@ -274,7 +274,7 @@ fn rewind_resets_state() {
 fn revalidate_child_ok_preserves_exclusions() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let child = Mock::new([2, 4]);
-    let mut it = Not::new(child, 5, 1.0, NoTimeout);
+    let mut it = Not::new(child, 5, 1.0, NoTimeoutChecker);
 
     let status = it
         .revalidate(&*mock_ctx.spec_read())
@@ -297,7 +297,7 @@ fn revalidate_child_aborted_replaces_child_with_empty() {
     let child = Mock::new([2, 4]);
     let mut data = child.data();
     data.set_revalidate_result(MockRevalidateResult::Abort);
-    let mut it = Not::new(child, 5, 1.0, NoTimeout);
+    let mut it = Not::new(child, 5, 1.0, NoTimeoutChecker);
 
     let status = it
         .revalidate(&*mock_ctx.spec_read())
@@ -320,7 +320,7 @@ fn revalidate_child_moved_on_fresh_iterator() {
     let child = Mock::new([2, 4]);
     let mut data = child.data();
     data.set_revalidate_result(MockRevalidateResult::Move);
-    let mut it = Not::new(child, 5, 1.0, NoTimeout);
+    let mut it = Not::new(child, 5, 1.0, NoTimeoutChecker);
 
     // Revalidate before any read/skip_to - both iterators at doc_id = 0
     let status = it
@@ -344,7 +344,7 @@ fn revalidate_child_moved_after_read_with_child_ahead() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let child = Mock::new([5, 10]);
     let mut data = child.data();
-    let mut it = Not::new(child, 15, 1.0, NoTimeout);
+    let mut it = Not::new(child, 15, 1.0, NoTimeoutChecker);
 
     // Read first doc (1) - child will be at 5, NOT at 1
     let doc = it.read().expect("read() failed").expect("expected doc");
@@ -378,7 +378,7 @@ fn revalidate_child_moved_after_skip_to_with_child_ahead() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     let child = Mock::new([8, 15]);
     let mut data = child.data();
-    let mut it = Not::new(child, 20, 1.0, NoTimeout);
+    let mut it = Not::new(child, 20, 1.0, NoTimeoutChecker);
 
     // Skip to 3 - child will be at 8, NOT at 3
     let outcome = it
@@ -422,7 +422,7 @@ fn read_propagates_child_timeout() {
     let mut data = child.data();
     // Set child to return timeout error when it reaches EOF
     data.set_error_at_done(Some(MockIteratorError::TimeoutError(None)));
-    let mut it = Not::new(child, 6, 1.0, NoTimeout);
+    let mut it = Not::new(child, 6, 1.0, NoTimeoutChecker);
 
     // Read docs that are NOT in child: [1, 2, 4, 6]
     // Child has [3, 5]. When NOT reads doc 6, child.read() is called to check
@@ -455,7 +455,7 @@ fn skip_to_propagates_child_timeout() {
     let mut data = child.data();
     // Set child to return timeout error when it reaches EOF
     data.set_error_at_done(Some(MockIteratorError::TimeoutError(None)));
-    let mut it = Not::new(child, 10, 1.0, NoTimeout);
+    let mut it = Not::new(child, 10, 1.0, NoTimeoutChecker);
 
     // skip_to(7) - child has [2,4,6], child.last_doc_id()=0 < 7, so we call
     // child.skip_to(7) which will go past child's last doc (6) and hit EOF,
@@ -471,7 +471,7 @@ fn skip_to_propagates_child_timeout() {
 // skip_to when already at EOF should return None immediately.
 #[test]
 fn skip_to_at_eof_returns_none() {
-    let mut it = Not::new(IdListSorted::new(vec![1, 2, 3, 4, 5]), 5, 1.0, NoTimeout);
+    let mut it = Not::new(IdListSorted::new(vec![1, 2, 3, 4, 5]), 5, 1.0, NoTimeoutChecker);
 
     // Exhaust the iterator - child covers full range so NOT produces nothing
     assert!(it.read().unwrap().is_none());
@@ -491,7 +491,7 @@ fn skip_to_at_eof_returns_none() {
 #[test]
 fn skip_to_child_behind_child_skip_returns_eof() {
     // Child has [2], max_doc_id=10
-    let mut it = Not::new(IdListSorted::new(vec![2]), 10, 1.0, NoTimeout);
+    let mut it = Not::new(IdListSorted::new(vec![2]), 10, 1.0, NoTimeoutChecker);
 
     // Read first doc (1) to advance child to position 2
     let doc = it.read().unwrap().unwrap();
@@ -529,7 +529,7 @@ fn read_timeout_via_timeout_ctx() {
         child,
         10_000,
         1.0,
-        TimeoutContextClock::new(Duration::from_micros(50), CLOCK_CHECK_GRANULARITY),
+        DeadlineTimeoutChecker::new(Duration::from_micros(50), CLOCK_CHECK_GRANULARITY),
     );
 
     let result = it.read();
@@ -551,7 +551,7 @@ fn skip_to_timeout_via_timeout_ctx() {
         child,
         10_000,
         1.0,
-        TimeoutContextClock::new(Duration::from_micros(50), CLOCK_CHECK_GRANULARITY),
+        DeadlineTimeoutChecker::new(Duration::from_micros(50), CLOCK_CHECK_GRANULARITY),
     );
 
     for idx in 1..=4_999 {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -14,7 +14,7 @@ use rqe_core::DocId;
 use rqe_iterators::{
     RQEIterator, RQEIteratorError, SkipToOutcome,
     not_optimized::NotOptimized,
-    utils::{NoTimeout, TimeoutContextClock},
+    utils::{NoTimeoutChecker, DeadlineTimeoutChecker},
 };
 
 /// Granularity used by the production reducer; tests reuse it for parity.
@@ -45,7 +45,7 @@ fn read_test(wc_ids: Vec<DocId>, child_ids: Vec<DocId>, max_doc_id: DocId) {
     let wc_helper = WildcardHelper::new(&wc_ids);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(child_ids);
-    let mut it = NotOptimized::new(wcii, child, max_doc_id, 1.0, NoTimeout);
+    let mut it = NotOptimized::new(wcii, child, max_doc_id, 1.0, NoTimeoutChecker);
 
     let mut actual = Vec::new();
     while let Ok(Some(doc)) = it.read() {
@@ -87,7 +87,7 @@ fn read_continuous_child_empty_wc() {
     let wc_helper = WildcardHelper::new(&[]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![1, 2, 3]);
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeoutChecker);
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
 }
@@ -148,7 +148,7 @@ fn skip_to_beyond_max_returns_eof() {
     let wc_helper = WildcardHelper::new(&[1, 2, 3, 4, 5]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![2, 4]);
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeoutChecker);
 
     assert!(it.skip_to(11).unwrap().is_none());
     assert!(it.at_eof());
@@ -162,7 +162,7 @@ fn skip_to_found_in_wc_not_in_child() {
     let wc_helper = WildcardHelper::new(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![2, 4, 6, 8, 10]);
-    let mut it = NotOptimized::new(wcii, child, 15, 1.0, NoTimeout);
+    let mut it = NotOptimized::new(wcii, child, 15, 1.0, NoTimeoutChecker);
 
     let outcome = it.skip_to(3).unwrap();
     match outcome {
@@ -180,7 +180,7 @@ fn skip_to_in_child_returns_not_found() {
     let wc_helper = WildcardHelper::new(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![2, 4, 6, 8, 10]);
-    let mut it = NotOptimized::new(wcii, child, 15, 1.0, NoTimeout);
+    let mut it = NotOptimized::new(wcii, child, 15, 1.0, NoTimeoutChecker);
 
     let outcome = it.skip_to(2).unwrap();
     match outcome {
@@ -198,7 +198,7 @@ fn skip_to_not_in_wc_returns_not_found() {
     let wc_helper = WildcardHelper::new(&[5, 10, 15, 20]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![10]);
-    let mut it = NotOptimized::new(wcii, child, 25, 1.0, NoTimeout);
+    let mut it = NotOptimized::new(wcii, child, 25, 1.0, NoTimeoutChecker);
 
     // Skip to 7: not in wcii, wcii advances to 10. 10 is in child, so advance
     // further to 15 which is valid.
@@ -220,7 +220,7 @@ fn skip_to_all_test(wc_ids: Vec<DocId>, child_ids: Vec<DocId>, max_doc_id: DocId
         let wc_helper = WildcardHelper::new(&wc_ids);
         let wcii = wc_helper.create_wildcard();
         let child = MockVec::new(child_ids.clone());
-        let mut it = NotOptimized::new(wcii, child, max_doc_id, 1.0, NoTimeout);
+        let mut it = NotOptimized::new(wcii, child, max_doc_id, 1.0, NoTimeoutChecker);
 
         let expected_id = expected.iter().find(|&&eid| eid >= id);
         let is_exact = expected.contains(&id);
@@ -276,7 +276,7 @@ fn skip_to_sequential() {
     let wc_helper = WildcardHelper::new(&wc_ids);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(child_ids);
-    let mut it = NotOptimized::new(wcii, child, 15, 1.0, NoTimeout);
+    let mut it = NotOptimized::new(wcii, child, 15, 1.0, NoTimeoutChecker);
 
     // Skip to each expected result sequentially.
     for &eid in &expected {
@@ -298,7 +298,7 @@ fn num_estimated_returns_wcii_estimate() {
     let wc_helper = WildcardHelper::new(&[1, 2, 3, 4, 5]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![2, 4]);
-    let it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
+    let it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeoutChecker);
     assert_eq!(it.num_estimated(), 5);
 }
 
@@ -311,7 +311,7 @@ fn rewind_resets_state() {
     let wc_helper = WildcardHelper::new(&wc_ids);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(child_ids);
-    let mut it = NotOptimized::new(wcii, child, 15, 1.0, NoTimeout);
+    let mut it = NotOptimized::new(wcii, child, 15, 1.0, NoTimeoutChecker);
 
     for pass in 0..5 {
         for j in 0..=pass.min(expected.len() - 1) {
@@ -329,7 +329,7 @@ fn initial_state() {
     let wc_helper = WildcardHelper::new(&[1, 2, 3, 4, 5]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![2, 4]);
-    let it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
+    let it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeoutChecker);
 
     assert_eq!(it.last_doc_id(), 0);
     assert!(!it.at_eof());
@@ -341,7 +341,7 @@ fn current_always_returns_some() {
     let wc_helper = WildcardHelper::new(&[1, 2, 3]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![2]);
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeoutChecker);
 
     // Before any read.
     assert!(it.current().is_some());
@@ -362,7 +362,7 @@ fn skip_to_case2_eof() {
     let wc_helper = WildcardHelper::new(&[1, 2, 3]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![1, 2, 3]);
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeoutChecker);
 
     let outcome = it.skip_to(1).unwrap();
     assert!(outcome.is_none());
@@ -379,7 +379,7 @@ fn skip_to_case2_not_found() {
     let wc_helper = WildcardHelper::new(&[1, 3, 5, 7]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![3, 5]);
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeoutChecker);
 
     let doc = it.read().unwrap().unwrap();
     assert_eq!(doc.doc_id, 1);
@@ -403,7 +403,7 @@ fn skip_to_case2_exhausted() {
     let wc_helper = WildcardHelper::new(&[1, 3, 5]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![3, 5]);
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeoutChecker);
 
     let doc = it.read().unwrap().unwrap();
     assert_eq!(doc.doc_id, 1);
@@ -423,7 +423,7 @@ fn skip_to_case1_child_exhausted() {
     let wc_helper = WildcardHelper::new(&[1, 3, 5]);
     let wcii = wc_helper.create_wildcard();
     let child = MockVec::new(vec![2, 4]);
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeoutChecker);
 
     // Consume docs to exhaust the child iterator.
     let doc = it.read().unwrap().unwrap();
@@ -458,7 +458,7 @@ fn child_timeout_on_first_read() {
     let mut child_data = child.data();
     child_data.set_error_at_done(Some(MockIteratorError::TimeoutError(None)));
 
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeoutChecker);
     let rc = it.read();
     assert!(
         matches!(rc, Err(RQEIteratorError::TimedOut)),
@@ -474,7 +474,7 @@ fn child_timeout_on_subsequent_read() {
     let wcii = wc_helper.create_wildcard();
     let child = Mock::new([2, 4, 6]);
     let mut child_data = child.data();
-    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeout);
+    let mut it = NotOptimized::new(wcii, child, 10, 1.0, NoTimeoutChecker);
 
     // Read first result: 1 (not in child).
     let doc = it.read().unwrap().unwrap();
@@ -506,7 +506,7 @@ fn child_timeout_on_skip_to() {
     let mut child_data = child.data();
     child_data.set_error_at_done(Some(MockIteratorError::TimeoutError(None)));
 
-    let mut it = NotOptimized::new(wcii, child, 15, 1.0, NoTimeout);
+    let mut it = NotOptimized::new(wcii, child, 15, 1.0, NoTimeoutChecker);
 
     let rc = it.skip_to(1);
     assert!(
@@ -534,7 +534,7 @@ fn read_timeout_via_timeout_ctx() {
         child,
         10_000,
         1.0,
-        TimeoutContextClock::new(Duration::from_micros(50), CLOCK_CHECK_GRANULARITY),
+        DeadlineTimeoutChecker::new(Duration::from_micros(50), CLOCK_CHECK_GRANULARITY),
     );
 
     let result = it.read();
@@ -578,7 +578,7 @@ mod revalidate {
             '_,
             rqe_iterators::inverted_index::Wildcard<'_, DocIdsOnly>,
             Mock<'_, { CHILD_IDS.len() }>,
-            NoTimeout,
+            NoTimeoutChecker,
         >,
         crate::utils::MockData,
     ) {
@@ -586,7 +586,7 @@ mod revalidate {
         let wcii = rqe_iterators::inverted_index::Wildcard::new(ii.reader(), 1.0);
         let child = Mock::new(CHILD_IDS);
         let child_data = child.data();
-        let it = NotOptimized::new(wcii, child, 100, 1.0, NoTimeout);
+        let it = NotOptimized::new(wcii, child, 100, 1.0, NoTimeoutChecker);
         (it, child_data)
     }
 
@@ -781,7 +781,7 @@ mod revalidate {
         let child = Mock::<1>::new([100]); // child won't match
         let mut child_data = child.data();
         child_data.set_revalidate_result(MockRevalidateResult::Ok);
-        let mut it = NotOptimized::new(wcii, child, 200, 1.0, NoTimeout);
+        let mut it = NotOptimized::new(wcii, child, 200, 1.0, NoTimeoutChecker);
 
         // Read the single document.
         let doc = it.read().unwrap().unwrap();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -14,7 +14,7 @@ use rqe_core::DocId;
 use rqe_iterators::{
     RQEIterator, RQEIteratorError, SkipToOutcome,
     not_optimized::NotOptimized,
-    utils::{NoTimeoutChecker, DeadlineTimeoutChecker},
+    utils::{DeadlineTimeoutChecker, NoTimeoutChecker},
 };
 
 /// Granularity used by the production reducer; tests reuse it for parity.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_reducer.rs
@@ -13,7 +13,7 @@ use rqe_core::DocId;
 use rqe_iterators::{
     Empty, IteratorType, RQEIterator, SkipToOutcome, Wildcard,
     not_reducer::{NewNotIterator, new_not_iterator},
-    utils::NoTimeout,
+    utils::NoTimeoutChecker,
 };
 use rqe_iterators_test_utils::MockContext;
 
@@ -25,13 +25,13 @@ fn call_new_not_iterator<'a, I>(
     child: I,
     max_doc_id: DocId,
     ctx: &'a MockContext,
-) -> NewNotIterator<'a, I, NoTimeout>
+) -> NewNotIterator<'a, I, NoTimeoutChecker>
 where
     I: RQEIterator<'a> + 'a,
 {
     // SAFETY: `MockContext` guarantees valid FFI structures for the lifetime
-    // of the context. `NoTimeout` disables timeout checks at zero runtime cost.
-    unsafe { new_not_iterator(child, max_doc_id, 1.0, NoTimeout, ctx.qctx()) }
+    // of the context. `NoTimeoutChecker` disables timeout checks at zero runtime cost.
+    unsafe { new_not_iterator(child, max_doc_id, 1.0, NoTimeoutChecker, ctx.qctx()) }
 }
 
 // ---------------------------------------------------------------------------
@@ -214,7 +214,7 @@ fn weight_is_propagated() {
     let weight = 0.42;
 
     // SAFETY: MockContext guarantees valid FFI structures.
-    let result = unsafe { new_not_iterator(child, 5, weight, NoTimeout, ctx.qctx()) };
+    let result = unsafe { new_not_iterator(child, 5, weight, NoTimeoutChecker, ctx.qctx()) };
 
     let NewNotIterator::Not(mut it) = result else {
         panic!("Expected Not variant");

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profilable.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profilable.rs
@@ -13,7 +13,7 @@ use rqe_iterators::{
     optional::Optional,
     profile::Profile,
     union::{Union, UnionQuickFlat},
-    utils::NoTimeout,
+    utils::NoTimeoutChecker,
 };
 
 use crate::utils::Mock;
@@ -42,7 +42,7 @@ fn leaf_wraps_self() {
 #[test]
 fn not_wraps_child_and_self() {
     let child = Mock::new([2, 4]);
-    let not = Not::new(child, 5, 1.0, NoTimeout);
+    let not = Not::new(child, 5, 1.0, NoTimeoutChecker);
     let mut profiled = Profile::new(not);
 
     assert_eq!(profiled.counters().read, 0);
@@ -69,7 +69,7 @@ fn not_wraps_child_and_self() {
 #[test]
 fn not_empty_child() {
     let child = Mock::new([]);
-    let not = Not::new(child, 3, 1.0, NoTimeout);
+    let not = Not::new(child, 3, 1.0, NoTimeoutChecker);
     let mut profiled = Profile::new(not);
 
     for expected in 1..=3 {
@@ -245,7 +245,7 @@ fn leaf_skip_to() {
 #[test]
 fn not_skip_to() {
     let child = Mock::new([3, 7]);
-    let not = Not::new(child, 10, 1.0, NoTimeout);
+    let not = Not::new(child, 10, 1.0, NoTimeoutChecker);
     let mut profiled = Profile::new(not);
 
     // skip_to(5): doc 5 is not in child {3,7}, so NOT yields it.
@@ -258,7 +258,7 @@ fn not_skip_to() {
 #[test]
 fn not_rewind() {
     let child = Mock::new([2]);
-    let not = Not::new(child, 5, 1.0, NoTimeout);
+    let not = Not::new(child, 5, 1.0, NoTimeoutChecker);
     let mut profiled = Profile::new(not);
 
     let _ = profiled.read().unwrap(); // doc 1

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
@@ -180,7 +180,8 @@ fn profile_wrapping_empty_after_reads() {
 fn not_with_child() {
     let mut replier = init();
     let child = rqe_iterators::Empty;
-    let iter = rqe_iterators::not::Not::new(child, 100, 1.0, rqe_iterators::utils::NoTimeoutChecker);
+    let iter =
+        rqe_iterators::not::Not::new(child, 100, 1.0, rqe_iterators::utils::NoTimeoutChecker);
     let reply = print(&mut replier, &iter, false);
     insta::assert_debug_snapshot!(reply);
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile_print.rs
@@ -180,7 +180,7 @@ fn profile_wrapping_empty_after_reads() {
 fn not_with_child() {
     let mut replier = init();
     let child = rqe_iterators::Empty;
-    let iter = rqe_iterators::not::Not::new(child, 100, 1.0, rqe_iterators::utils::NoTimeout);
+    let iter = rqe_iterators::not::Not::new(child, 100, 1.0, rqe_iterators::utils::NoTimeoutChecker);
     let reply = print(&mut replier, &iter, false);
     insta::assert_debug_snapshot!(reply);
 }
@@ -195,7 +195,7 @@ fn not_optimized_with_child() {
         child,
         100,
         1.0,
-        rqe_iterators::utils::NoTimeout,
+        rqe_iterators::utils::NoTimeoutChecker,
     );
     let reply = print(&mut replier, &iter, false);
     insta::assert_debug_snapshot!(reply);

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/geo_shape.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/geo_shape.rs
@@ -13,7 +13,9 @@ use std::{hint::black_box, time::Duration};
 
 use criterion::{BenchmarkGroup, Criterion, measurement::WallTime};
 use rqe_core::DocId;
-use rqe_iterators::{NoOpChecker, NoTracker, RQEIterator, geo_shape::GeoShape, utils::NoTimeoutChecker};
+use rqe_iterators::{
+    NoOpChecker, NoTracker, RQEIterator, geo_shape::GeoShape, utils::NoTimeoutChecker,
+};
 
 /// The Rust [`GeoShape`] configured the way the sorted-id-list benchmark needs:
 /// no timeout, no field-expiration, no memory tracking.

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/geo_shape.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/geo_shape.rs
@@ -13,11 +13,11 @@ use std::{hint::black_box, time::Duration};
 
 use criterion::{BenchmarkGroup, Criterion, measurement::WallTime};
 use rqe_core::DocId;
-use rqe_iterators::{NoOpChecker, NoTracker, RQEIterator, geo_shape::GeoShape, utils::NoTimeout};
+use rqe_iterators::{NoOpChecker, NoTracker, RQEIterator, geo_shape::GeoShape, utils::NoTimeoutChecker};
 
 /// The Rust [`GeoShape`] configured the way the sorted-id-list benchmark needs:
 /// no timeout, no field-expiration, no memory tracking.
-type RustGeoShape = GeoShape<'static, NoTimeout, NoOpChecker, NoTracker>;
+type RustGeoShape = GeoShape<'static, NoTimeoutChecker, NoOpChecker, NoTracker>;
 
 #[derive(Default)]
 pub struct Bencher;
@@ -56,7 +56,7 @@ impl Bencher {
 
     /// Build a Rust [`GeoShape`] over `ids` (no timeout/expiration/tracking).
     fn rust_iter(ids: Vec<DocId>) -> RustGeoShape {
-        GeoShape::new(ids, NoTimeout, NoOpChecker, NoTracker)
+        GeoShape::new(ids, NoTimeoutChecker, NoOpChecker, NoTracker)
     }
 
     pub fn bench(&self, c: &mut Criterion) {

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not.rs
@@ -12,7 +12,9 @@
 use std::{hint::black_box, time::Duration};
 
 use criterion::{BenchmarkGroup, Criterion, measurement::WallTime};
-use rqe_iterators::{RQEIterator, empty::Empty, id_list::IdListSorted, not::Not, utils::NoTimeoutChecker};
+use rqe_iterators::{
+    RQEIterator, empty::Empty, id_list::IdListSorted, not::Not, utils::NoTimeoutChecker,
+};
 
 #[derive(Default)]
 pub struct Bencher;

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not.rs
@@ -12,7 +12,7 @@
 use std::{hint::black_box, time::Duration};
 
 use criterion::{BenchmarkGroup, Criterion, measurement::WallTime};
-use rqe_iterators::{RQEIterator, empty::Empty, id_list::IdListSorted, not::Not, utils::NoTimeout};
+use rqe_iterators::{RQEIterator, empty::Empty, id_list::IdListSorted, not::Not, utils::NoTimeoutChecker};
 
 #[derive(Default)]
 pub struct Bencher;
@@ -23,10 +23,10 @@ impl Bencher {
 
     const MAX_DOC_ID: u64 = 1_000_000;
 
-    /// Disable timeout checks in benchmarks: [`NoTimeout`] is a zero-sized
+    /// Disable timeout checks in benchmarks: [`NoTimeoutChecker`] is a zero-sized
     /// no-op so the iterator's `check_timeout` path is dead code after
     /// monomorphization.
-    const TIMEOUT_CTX: NoTimeout = NoTimeout;
+    const TIMEOUT_CTX: NoTimeoutChecker = NoTimeoutChecker;
 
     fn benchmark_group<'a>(
         &self,

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/not_optimized.rs
@@ -14,7 +14,7 @@ use std::{hint::black_box, time::Duration};
 use criterion::{BenchmarkGroup, Criterion, measurement::WallTime};
 use rqe_iterators::{
     RQEIterator, empty::Empty, id_list::IdListSorted, not_optimized::NotOptimized,
-    utils::NoTimeout, wildcard::new_wildcard_iterator_optimized,
+    utils::NoTimeoutChecker, wildcard::new_wildcard_iterator_optimized,
 };
 use rqe_iterators_test_utils::TestContext;
 
@@ -49,10 +49,10 @@ impl Bencher {
     const SPARSE_STEP: usize = 200;
     /// Step size for skip_to() calls.
     const SKIP_TO_STEP: u64 = 100;
-    /// Disable timeout checks in benchmarks: [`NoTimeout`] is a zero-sized
+    /// Disable timeout checks in benchmarks: [`NoTimeoutChecker`] is a zero-sized
     /// no-op so the iterator's `check_timeout` path is dead code after
     /// monomorphization.
-    const TIMEOUT_CTX: NoTimeout = NoTimeout;
+    const TIMEOUT_CTX: NoTimeoutChecker = NoTimeoutChecker;
 
     fn benchmark_group<'a>(
         &self,

--- a/src/redisearch_rs/timeout/Cargo.toml
+++ b/src/redisearch_rs/timeout/Cargo.toml
@@ -11,5 +11,3 @@ bench = false
 
 [lints]
 workspace = true
-
-[dependencies]

--- a/src/redisearch_rs/timeout/Cargo.toml
+++ b/src/redisearch_rs/timeout/Cargo.toml
@@ -2,8 +2,8 @@
 name = "timeout"
 version.workspace = true
 edition.workspace = true
-# Same license as the original `thin_vec` crate.
-license = "MIT or Apache-2.0"
+license-file.workspace = true
+publish.workspace = true
 
 [lib]
 # See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
@@ -11,3 +11,6 @@ bench = false
 
 [lints]
 workspace = true
+
+[dependencies]
+workspace_hack.workspace = true

--- a/src/redisearch_rs/timeout/Cargo.toml
+++ b/src/redisearch_rs/timeout/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "timeout"
+version.workspace = true
+edition.workspace = true
+# Same license as the original `thin_vec` crate.
+license = "MIT or Apache-2.0"
+
+[lib]
+# See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/src/redisearch_rs/timeout/src/lib.rs
+++ b/src/redisearch_rs/timeout/src/lib.rs
@@ -74,10 +74,15 @@ impl TimeoutChecker for DeadlineTimeoutChecker {
         // For optimized builds, we only check the deadline
         // once every `self.limit` iterations. In development,
         // we're checking each iteration.
-        if (self.counter >= self.limit || cfg!(debug_assertions))
-            && Instant::now() >= self.deadline
-        {
-            return TimeoutCheckResult::TimedOut;
+        if self.counter >= self.limit || cfg!(debug_assertions) {
+            // Reset the counter whenever we probe the clock so the next
+            // `limit` calls are amortized again. Without this reset the
+            // counter would stay `>= limit` forever, turning every
+            // subsequent call into a real clock check.
+            self.counter = 0;
+            if Instant::now() >= self.deadline {
+                return TimeoutCheckResult::TimedOut;
+            }
         }
 
         TimeoutCheckResult::Ok
@@ -184,6 +189,25 @@ mod tests {
         for _ in 0..99 {
             assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
         }
+    }
+
+    #[test]
+    fn clock_context_amortizes_repeatedly_after_first_probe() {
+        // Deadline is effectively unreachable, so the checker must always
+        // report Ok. With `limit = 100`, the clock is probed on calls
+        // 100, 200, 300, ... and the counter must reset each time. The
+        // calls in between (never a multiple of `limit`) must not probe
+        // the clock. Regression test for a counter that was left `>= limit`
+        // after the first probe, which turned every later call into a
+        // clock check.
+        let limit = 100;
+        let mut ctx = DeadlineTimeoutChecker::new(Duration::from_secs(3600), limit);
+        for _ in 0..(limit as usize * 5) {
+            assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+        }
+        // After probing on the last multiple of `limit`, the counter must
+        // have been reset rather than left at `limit`.
+        assert!(ctx.counter < limit);
     }
 
     #[test]

--- a/src/redisearch_rs/timeout/src/lib.rs
+++ b/src/redisearch_rs/timeout/src/lib.rs
@@ -76,9 +76,7 @@ impl TimeoutChecker for DeadlineTimeoutChecker {
         // prompt detection construct the checker with a small `limit`.
         if self.counter >= self.limit {
             // Reset the counter whenever we probe the clock so the next
-            // `limit` calls are amortized again. Without this reset the
-            // counter would stay `>= limit` forever, turning every
-            // subsequent call into a real clock check.
+            // `limit` calls are amortized again.
             self.counter = 0;
             if Instant::now() >= self.deadline {
                 return TimeoutCheckResult::TimedOut;
@@ -104,8 +102,7 @@ impl TimeoutChecker for DeadlineTimeoutChecker {
 pub struct NoTimeoutChecker;
 
 impl TimeoutChecker for NoTimeoutChecker {
-    /// Increments the internal counter and, if the `limit` is reached, checks if
-    /// the current time has passed the `deadline`.
+    /// No-op. Always returns [`TimeoutCheckResult::Ok`].
     #[inline(always)]
     fn check_timeout(&mut self) -> TimeoutCheckResult {
         TimeoutCheckResult::Ok
@@ -138,34 +135,5 @@ impl TimeoutChecker for AnyTimeoutChecker {
             Self::NoTimeout(c) => c.reset_counter(),
             Self::Deadline(c) => c.reset_counter(),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // NOTE: behavioral tests that only exercise the public API live in
-    // `tests/tests.rs`. This module keeps only the tests that must inspect
-    // private internals (e.g. the amortization `counter`), which an
-    // integration test cannot reach.
-
-    #[test]
-    fn clock_context_amortizes_repeatedly_after_first_probe() {
-        // Deadline is effectively unreachable, so the checker must always
-        // report Ok. With `limit = 100`, the clock is probed on calls
-        // 100, 200, 300, ... and the counter must reset each time. The
-        // calls in between (never a multiple of `limit`) must not probe
-        // the clock. Regression test for a counter that was left `>= limit`
-        // after the first probe, which turned every later call into a
-        // clock check.
-        let limit = 100;
-        let mut ctx = DeadlineTimeoutChecker::new(Duration::from_secs(3600), limit);
-        for _ in 0..(limit as usize * 5) {
-            assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
-        }
-        // After probing on the last multiple of `limit`, the counter must
-        // have been reset rather than left at `limit`.
-        assert!(ctx.counter < limit);
     }
 }

--- a/src/redisearch_rs/timeout/src/lib.rs
+++ b/src/redisearch_rs/timeout/src/lib.rs
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::time::{Duration, Instant};
+
+/// Identify the result of [`TimeoutChecker::check_timeout`].
+pub enum TimeoutCheckResult {
+    /// The checker timed out.
+    TimedOut,
+    /// The checker is still ok.
+    Ok,
+}
+
+/// Abstraction over the timeout checker.
+pub trait TimeoutChecker {
+    /// Report whether the query has timed out.
+    ///
+    /// Returns [`TimeoutCheckResult::TimedOut`] when the deadline has been
+    /// reached. Otherwise returns [`TimeoutCheckResult::Ok`].
+    fn check_timeout(&mut self) -> TimeoutCheckResult;
+
+    /// The caller invokes this method after a unit of useful work has been
+    /// completed, so amortized implementations can reset their internal
+    /// counter without losing accuracy.
+    fn reset_counter(&mut self);
+}
+
+/// Amortized clock checker.
+///
+/// In "hot paths" (like index scanning or large iterations), calling the system clock
+/// on every iteration is computationally expensive. This context uses a counter to
+/// only perform a real clock check every `limit` iterations, significantly reducing
+/// syscall overhead while still ensuring eventual termination.
+pub struct DeadlineTimeoutChecker {
+    /// The absolute point in time after which the operation is considered timed out.
+    deadline: Instant,
+    /// The number of times `check_timeout` has been called since the last clock check.
+    counter: u32,
+    /// The threshold at which a real clock check is performed (the amortized frequency).
+    limit: u32,
+}
+
+impl DeadlineTimeoutChecker {
+    /// Creates a new [`TimeoutChecker`] that expires after the given `duration`.
+    ///
+    /// The `limit` determines the granularity of the check. A higher limit
+    /// improves performance but increases the potential delay between the
+    /// actual timeout and when it is detected.
+    ///
+    /// To skip timeout checks entirely, use [`NoTimeoutChecker`] instead of
+    /// constructing this context.
+    #[inline(always)]
+    pub fn new(duration: Duration, limit: u32) -> Self {
+        Self {
+            deadline: Instant::now() + duration,
+            counter: 0,
+            limit,
+        }
+    }
+}
+
+impl TimeoutChecker for DeadlineTimeoutChecker {
+    /// Increments the internal counter and, if the `limit` is reached, checks if
+    /// the current time has passed the `deadline`.
+    #[inline(always)]
+    fn check_timeout(&mut self) -> TimeoutCheckResult {
+        self.counter += 1;
+        // For optimized builds, we only check the deadline
+        // once every `self.limit` iterations. In development,
+        // we're checking each iteration.
+        if self.counter >= self.limit || cfg!(debug_assertions) {
+            if Instant::now() >= self.deadline {
+                return TimeoutCheckResult::TimedOut;
+            }
+            
+        }
+
+        TimeoutCheckResult::Ok
+    }
+
+    #[inline(always)]
+    fn reset_counter(&mut self) {
+        self.counter = 0;
+    }
+}
+
+/// Zero-sized no-op [`TimeoutContext`].
+///
+/// Used by callers that want to opt out of timeout checks entirely without
+/// having to wrap the context in an [`Option`]. Because the type has no
+/// fields and every method is a no-op, monomorphizing an iterator over
+/// `NoTimeout` collapses the entire timeout machinery to dead code that
+/// the optimizer removes from the hot path.
+pub struct NoTimeoutChecker;
+
+impl TimeoutChecker for NoTimeoutChecker {
+    /// Increments the internal counter and, if the `limit` is reached, checks if
+    /// the current time has passed the `deadline`.
+    #[inline(always)]
+    fn check_timeout(&mut self) -> TimeoutCheckResult {
+        TimeoutCheckResult::Ok
+    }
+
+    #[inline(always)]
+    fn reset_counter(&mut self) {
+    }
+}
+
+/// Type-erased [`TimeoutContext`] wrapping the concrete variants.
+pub enum AnyTimeoutChecker {
+    /// No timeout source: every probe is a no-op.
+    NoTimeout(NoTimeoutChecker),
+    /// Clock Based Timeout: amortized clock check.
+    Deadline(DeadlineTimeoutChecker),
+}
+
+impl TimeoutChecker for AnyTimeoutChecker {
+    #[inline(always)]
+    fn check_timeout(&mut self) -> TimeoutCheckResult {
+        
+        match self {
+            Self::NoTimeout(c) => {
+                c.check_timeout()
+            },
+            Self::Deadline(c) => {
+                c.check_timeout()
+            },
+        }
+    }
+
+    #[inline(always)]
+    fn reset_counter(&mut self) {
+        match self {
+            Self::NoTimeout(c) => c.reset_counter(),
+            Self::Deadline(c) => c.reset_counter(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_timeout() {
+        let mut ctx = NoTimeoutChecker;
+        // Spin for a while, no timeout is reached
+        for _ in 0..1_000 {
+            assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+        }
+    }
+
+    #[test]
+    fn clock_context_does_not_time_out_within_deadline() {
+        let mut ctx = DeadlineTimeoutChecker::new(Duration::from_secs(60), 1);
+        for _ in 0..1_000 {
+            assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+        }
+    }
+
+    #[test]
+    fn clock_context_times_out_after_deadline() {
+        let mut ctx = DeadlineTimeoutChecker::new(Duration::from_nanos(1), 1);
+        // Spin until the (very short) deadline passes; in practice the
+        // first call already crosses it on every platform we run on.
+        for _ in 0..1_000 {
+            if matches!(ctx.check_timeout(), TimeoutCheckResult::TimedOut) {
+                return;
+            }
+        }
+        panic!("clock context never timed out");
+    }
+
+    #[test]
+    fn clock_context_amortizes_via_limit() {
+        let mut ctx = DeadlineTimeoutChecker::new(Duration::from_nanos(1), 100);
+        // With `limit = 100` the first 99 calls must not even probe the
+        // clock, so they must all succeed regardless of the deadline.
+        for _ in 0..99 {
+            assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+        }
+    }
+
+    #[test]
+    fn clock_context_reset_counter_delays_next_check() {
+        let mut ctx = DeadlineTimeoutChecker::new(Duration::from_nanos(1), 4);
+        // Three increments bring the counter to 3 (below `limit`).
+        for _ in 0..3 {
+            assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+        }
+        // Reset back to 0; the next three calls must again avoid the
+        // clock check and report Ok.
+        ctx.reset_counter();
+        for _ in 0..3 {
+            assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+        }
+    }
+
+    #[test]
+    fn any_timeout_context_dispatches_to_clock_variant() {
+        let inner = DeadlineTimeoutChecker::new(Duration::from_secs(60), 1);
+        let mut ctx = AnyTimeoutChecker::Deadline(inner);
+        assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+        ctx.reset_counter();
+        assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+    }
+}

--- a/src/redisearch_rs/timeout/src/lib.rs
+++ b/src/redisearch_rs/timeout/src/lib.rs
@@ -151,45 +151,10 @@ impl TimeoutChecker for AnyTimeoutChecker {
 mod tests {
     use super::*;
 
-    #[test]
-    fn no_timeout() {
-        let mut ctx = NoTimeoutChecker;
-        // Spin for a while, no timeout is reached
-        for _ in 0..1_000 {
-            assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
-        }
-    }
-
-    #[test]
-    fn clock_context_does_not_time_out_within_deadline() {
-        let mut ctx = DeadlineTimeoutChecker::new(Duration::from_secs(60), 1);
-        for _ in 0..1_000 {
-            assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
-        }
-    }
-
-    #[test]
-    fn clock_context_times_out_after_deadline() {
-        let mut ctx = DeadlineTimeoutChecker::new(Duration::from_nanos(1), 1);
-        // Spin until the (very short) deadline passes; in practice the
-        // first call already crosses it on every platform we run on.
-        for _ in 0..1_000 {
-            if matches!(ctx.check_timeout(), TimeoutCheckResult::TimedOut) {
-                return;
-            }
-        }
-        panic!("clock context never timed out");
-    }
-
-    #[test]
-    fn clock_context_amortizes_via_limit() {
-        let mut ctx = DeadlineTimeoutChecker::new(Duration::from_nanos(1), 100);
-        // With `limit = 100` the first 99 calls must not even probe the
-        // clock, so they must all succeed regardless of the deadline.
-        for _ in 0..99 {
-            assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
-        }
-    }
+    // NOTE: behavioral tests that only exercise the public API live in
+    // `tests/tests.rs`. This module keeps only the tests that must inspect
+    // private internals (e.g. the amortization `counter`), which an
+    // integration test cannot reach.
 
     #[test]
     fn clock_context_amortizes_repeatedly_after_first_probe() {
@@ -208,29 +173,5 @@ mod tests {
         // After probing on the last multiple of `limit`, the counter must
         // have been reset rather than left at `limit`.
         assert!(ctx.counter < limit);
-    }
-
-    #[test]
-    fn clock_context_reset_counter_delays_next_check() {
-        let mut ctx = DeadlineTimeoutChecker::new(Duration::from_nanos(1), 4);
-        // Three increments bring the counter to 3 (below `limit`).
-        for _ in 0..3 {
-            assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
-        }
-        // Reset back to 0; the next three calls must again avoid the
-        // clock check and report Ok.
-        ctx.reset_counter();
-        for _ in 0..3 {
-            assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
-        }
-    }
-
-    #[test]
-    fn any_timeout_context_dispatches_to_clock_variant() {
-        let inner = DeadlineTimeoutChecker::new(Duration::from_secs(60), 1);
-        let mut ctx = AnyTimeoutChecker::Deadline(inner);
-        assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
-        ctx.reset_counter();
-        assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
     }
 }

--- a/src/redisearch_rs/timeout/src/lib.rs
+++ b/src/redisearch_rs/timeout/src/lib.rs
@@ -31,7 +31,7 @@ pub trait TimeoutChecker {
     fn reset_counter(&mut self);
 }
 
-/// Amortized clock checker.
+/// Amortized clock [`TimeoutChecker`].
 ///
 /// In "hot paths" (like index scanning or large iterations), calling the system clock
 /// on every iteration is computationally expensive. This context uses a counter to
@@ -74,11 +74,10 @@ impl TimeoutChecker for DeadlineTimeoutChecker {
         // For optimized builds, we only check the deadline
         // once every `self.limit` iterations. In development,
         // we're checking each iteration.
-        if self.counter >= self.limit || cfg!(debug_assertions) {
-            if Instant::now() >= self.deadline {
-                return TimeoutCheckResult::TimedOut;
-            }
-            
+        if (self.counter >= self.limit || cfg!(debug_assertions))
+            && Instant::now() >= self.deadline
+        {
+            return TimeoutCheckResult::TimedOut;
         }
 
         TimeoutCheckResult::Ok
@@ -90,12 +89,12 @@ impl TimeoutChecker for DeadlineTimeoutChecker {
     }
 }
 
-/// Zero-sized no-op [`TimeoutContext`].
+/// Zero-sized no-op [`TimeoutChecker`].
 ///
 /// Used by callers that want to opt out of timeout checks entirely without
 /// having to wrap the context in an [`Option`]. Because the type has no
 /// fields and every method is a no-op, monomorphizing an iterator over
-/// `NoTimeout` collapses the entire timeout machinery to dead code that
+/// `NoTimeoutChecker` collapses the entire timeout machinery to dead code that
 /// the optimizer removes from the hot path.
 pub struct NoTimeoutChecker;
 
@@ -112,7 +111,7 @@ impl TimeoutChecker for NoTimeoutChecker {
     }
 }
 
-/// Type-erased [`TimeoutContext`] wrapping the concrete variants.
+/// Type-erased [`TimeoutChecker`] wrapping the concrete variants.
 pub enum AnyTimeoutChecker {
     /// No timeout source: every probe is a no-op.
     NoTimeout(NoTimeoutChecker),

--- a/src/redisearch_rs/timeout/src/lib.rs
+++ b/src/redisearch_rs/timeout/src/lib.rs
@@ -71,10 +71,10 @@ impl TimeoutChecker for DeadlineTimeoutChecker {
     #[inline(always)]
     fn check_timeout(&mut self) -> TimeoutCheckResult {
         self.counter += 1;
-        // For optimized builds, we only check the deadline
-        // once every `self.limit` iterations. In development,
-        // we're checking each iteration.
-        if self.counter >= self.limit || cfg!(debug_assertions) {
+        // We only check the deadline once every `self.limit` iterations,
+        // amortizing the cost of probing the clock. Callers that need
+        // prompt detection construct the checker with a small `limit`.
+        if self.counter >= self.limit {
             // Reset the counter whenever we probe the clock so the next
             // `limit` calls are amortized again. Without this reset the
             // counter would stay `>= limit` forever, turning every
@@ -112,8 +112,7 @@ impl TimeoutChecker for NoTimeoutChecker {
     }
 
     #[inline(always)]
-    fn reset_counter(&mut self) {
-    }
+    fn reset_counter(&mut self) {}
 }
 
 /// Type-erased [`TimeoutChecker`] wrapping the concrete variants.
@@ -127,14 +126,9 @@ pub enum AnyTimeoutChecker {
 impl TimeoutChecker for AnyTimeoutChecker {
     #[inline(always)]
     fn check_timeout(&mut self) -> TimeoutCheckResult {
-        
         match self {
-            Self::NoTimeout(c) => {
-                c.check_timeout()
-            },
-            Self::Deadline(c) => {
-                c.check_timeout()
-            },
+            Self::NoTimeout(c) => c.check_timeout(),
+            Self::Deadline(c) => c.check_timeout(),
         }
     }
 

--- a/src/redisearch_rs/timeout/tests/tests.rs
+++ b/src/redisearch_rs/timeout/tests/tests.rs
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::time::Duration;
+
+use timeout::{
+    AnyTimeoutChecker, DeadlineTimeoutChecker, NoTimeoutChecker, TimeoutCheckResult, TimeoutChecker,
+};
+
+#[test]
+fn no_timeout() {
+    let mut ctx = NoTimeoutChecker;
+    // Spin for a while, no timeout is reached
+    for _ in 0..1_000 {
+        assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+    }
+}
+
+#[test]
+fn clock_context_does_not_time_out_within_deadline() {
+    let mut ctx = DeadlineTimeoutChecker::new(Duration::from_secs(60), 1);
+    for _ in 0..1_000 {
+        assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+    }
+}
+
+#[test]
+fn clock_context_times_out_after_deadline() {
+    let mut ctx = DeadlineTimeoutChecker::new(Duration::from_nanos(1), 1);
+    // Spin until the (very short) deadline passes; in practice the
+    // first call already crosses it on every platform we run on.
+    for _ in 0..1_000 {
+        if matches!(ctx.check_timeout(), TimeoutCheckResult::TimedOut) {
+            return;
+        }
+    }
+    panic!("clock context never timed out");
+}
+
+#[test]
+fn clock_context_amortizes_via_limit() {
+    let mut ctx = DeadlineTimeoutChecker::new(Duration::from_nanos(1), 100);
+    // With `limit = 100` the first 99 calls must not even probe the
+    // clock, so they must all succeed regardless of the deadline.
+    for _ in 0..99 {
+        assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+    }
+}
+
+#[test]
+fn clock_context_reset_counter_delays_next_check() {
+    let mut ctx = DeadlineTimeoutChecker::new(Duration::from_nanos(1), 4);
+    // Three increments bring the counter to 3 (below `limit`).
+    for _ in 0..3 {
+        assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+    }
+    // Reset back to 0; the next three calls must again avoid the
+    // clock check and report Ok.
+    ctx.reset_counter();
+    for _ in 0..3 {
+        assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+    }
+}
+
+#[test]
+fn any_timeout_context_dispatches_to_clock_variant() {
+    let inner = DeadlineTimeoutChecker::new(Duration::from_secs(60), 1);
+    let mut ctx = AnyTimeoutChecker::Deadline(inner);
+    assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+    ctx.reset_counter();
+    assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+}

--- a/src/redisearch_rs/timeout/tests/tests.rs
+++ b/src/redisearch_rs/timeout/tests/tests.rs
@@ -76,3 +76,22 @@ fn any_timeout_context_dispatches_to_clock_variant() {
     ctx.reset_counter();
     assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
 }
+
+#[test]
+fn any_timeout_context_dispatches_to_no_timeout_variant() {
+    let mut ctx = AnyTimeoutChecker::NoTimeout(NoTimeoutChecker);
+    // The no-timeout variant must always report Ok, both before and
+    // after a counter reset, and the reset itself must be a no-op that
+    // never changes that behavior.
+    assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+    ctx.reset_counter();
+    assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+}
+
+#[test]
+fn no_timeout_reset_counter_is_a_noop() {
+    let mut ctx = NoTimeoutChecker;
+    ctx.reset_counter();
+    // Resetting must not affect the always-Ok result.
+    assert!(matches!(ctx.check_timeout(), TimeoutCheckResult::Ok));
+}

--- a/src/redisearch_rs/trie_rs/Cargo.toml
+++ b/src/redisearch_rs/trie_rs/Cargo.toml
@@ -22,6 +22,7 @@ lending-iterator.workspace = true
 libc.workspace = true
 memchr.workspace = true
 rqe_wildcard.workspace = true
+timeout.workspace = true
 utf8parse.workspace = true
 workspace_hack.workspace = true
 

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/driver.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/driver.rs
@@ -123,6 +123,7 @@ impl<'tm, Data, A: Automaton> AutomatonIter<'tm, Data, A> {
         iter
     }
 
+    /// Set timeout
     pub(crate) fn set_timeout(&mut self, timeout: Option<Instant>) {
         self.timeout = timeout.into()
     }

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/driver.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/driver.rs
@@ -14,9 +14,12 @@
 //! branches on the returned [`StateClass`]; see that enum's doc for the
 //! four cases.
 
+use std::time::Instant;
+
 use super::{Automaton, StateClass};
-use crate::trie_map::node::Node;
+use crate::{iter::timeout::IteratorTimeoutState, trie_map::node::Node};
 use lending_iterator::prelude::*;
+use timeout::TimeoutCheckResult;
 
 /// Iterator that traverses a trie under the control of a streaming
 /// [`Automaton`].
@@ -33,6 +36,8 @@ pub struct AutomatonIter<'tm, Data, A: Automaton> {
     /// driver truncates and re-extends this in place as it descends and
     /// backtracks, instead of allocating a fresh `Vec` per yield.
     key: Vec<u8>,
+    /// The timeout state
+    timeout: IteratorTimeoutState,
 }
 
 /// One pending visit on the traversal stack.
@@ -70,6 +75,7 @@ impl<'tm, Data, A: Automaton> AutomatonIter<'tm, Data, A> {
             stack: Vec::new(),
             automaton,
             key: Vec::new(),
+            timeout: IteratorTimeoutState::no_timeout(),
         }
     }
 
@@ -92,6 +98,7 @@ impl<'tm, Data, A: Automaton> AutomatonIter<'tm, Data, A> {
             stack: Vec::new(),
             automaton,
             key: key_prefix,
+            timeout: IteratorTimeoutState::no_timeout(),
         };
         if let Some(node) = start_node {
             // Sequence the calls: `step_all` takes `&mut automaton`, so we
@@ -116,9 +123,17 @@ impl<'tm, Data, A: Automaton> AutomatonIter<'tm, Data, A> {
         iter
     }
 
+    pub(crate) fn set_timeout(&mut self, timeout: Option<Instant>) {
+        self.timeout = timeout.into()
+    }
+
     /// Advance to the next matching entry, returning a reference to its data.
     pub(crate) fn advance(&mut self) -> Option<&'tm Data> {
         loop {
+            if matches!(self.timeout.check(), TimeoutCheckResult::TimedOut) {
+                return None;
+            }
+
             match self.stack.pop()? {
                 Frame::Visit {
                     node,

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/wildcard/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/wildcard/mod.rs
@@ -148,6 +148,8 @@ pub mod atoms;
 pub mod nfa;
 pub mod nfa_bit_set;
 
+use std::time::Instant;
+
 pub use nfa::WildcardNfa;
 pub use nfa_bit_set::NfaBitSet;
 
@@ -181,6 +183,14 @@ impl<'tm, 'p, Data> WildcardIter<'tm, 'p, Data> {
             Self::U64(it) => it.key(),
             Self::U128(it) => it.key(),
             Self::Filter(it) => it.key(),
+        }
+    }
+
+    pub(crate) fn set_timeout(&mut self, timeout: Option<Instant>) {
+        match self {
+            Self::U64(it) => it.set_timeout(timeout),
+            Self::U128(it) => it.set_timeout(timeout),
+            Self::Filter(it) => it.set_timeout(timeout),
         }
     }
 }
@@ -227,6 +237,12 @@ impl<'tm, 'p, Data> Iterator for WildcardIter<'tm, 'p, Data> {
 
 /// Lending-iterator wrapper for [`WildcardIter`].
 pub struct WildcardLendingIter<'tm, 'p, Data>(WildcardIter<'tm, 'p, Data>);
+
+impl<'tm, 'p, Data> WildcardLendingIter<'tm, 'p, Data> {
+    pub fn set_timeout(&mut self, timeout: Option<Instant>) {
+        self.0.set_timeout(timeout);
+    }
+}
 
 impl<'tm, 'p, Data> From<WildcardIter<'tm, 'p, Data>> for WildcardLendingIter<'tm, 'p, Data> {
     fn from(iter: WildcardIter<'tm, 'p, Data>) -> Self {

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/wildcard/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/automaton/wildcard/mod.rs
@@ -186,6 +186,7 @@ impl<'tm, 'p, Data> WildcardIter<'tm, 'p, Data> {
         }
     }
 
+    /// Set timeout
     pub(crate) fn set_timeout(&mut self, timeout: Option<Instant>) {
         match self {
             Self::U64(it) => it.set_timeout(timeout),
@@ -239,6 +240,7 @@ impl<'tm, 'p, Data> Iterator for WildcardIter<'tm, 'p, Data> {
 pub struct WildcardLendingIter<'tm, 'p, Data>(WildcardIter<'tm, 'p, Data>);
 
 impl<'tm, 'p, Data> WildcardLendingIter<'tm, 'p, Data> {
+    /// Set timeout
     pub fn set_timeout(&mut self, timeout: Option<Instant>) {
         self.0.set_timeout(timeout);
     }

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
@@ -7,8 +7,14 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use crate::trie_map::node::Node;
+use std::time::Instant;
+
+use crate::{
+    iter::timeout::{IteratorTimeoutState},
+    trie_map::node::Node,
+};
 use memchr::memmem::Finder;
+use timeout::TimeoutCheckResult;
 
 /// Iterates over all the entries in a [`TrieMap`](crate::TrieMap) that contain the target fragment,
 /// in lexicographical order.
@@ -22,6 +28,8 @@ pub struct ContainsIter<'tm, 't, Data> {
     key: Vec<u8>,
     /// The target fragment we are looking for.
     finder: Finder<'t>,
+    /// The timeout
+    timeout: IteratorTimeoutState,
 }
 
 struct StackItem<'tm, Data> {
@@ -49,6 +57,7 @@ impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {
                 .collect(),
             key: vec![],
             finder,
+            timeout: IteratorTimeoutState::no_timeout(),
         }
     }
 
@@ -58,7 +67,12 @@ impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {
             stack: vec![],
             key: vec![],
             finder: Finder::new(b""),
+            timeout: IteratorTimeoutState::no_timeout(),
         }
+    }
+
+    pub(crate) fn set_timeout(&mut self, timeout: Option<Instant>) {
+        self.timeout = timeout.into()
     }
 }
 
@@ -73,6 +87,10 @@ impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {
     /// key to the one matching that node's entry
     pub(crate) fn advance(&mut self) -> Option<&'tm Data> {
         loop {
+            if matches!(self.timeout.check(), TimeoutCheckResult::TimedOut) {
+                return None;
+            }
+
             let StackItem {
                 node,
                 was_visited,

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
@@ -9,10 +9,7 @@
 
 use std::time::Instant;
 
-use crate::{
-    iter::timeout::{IteratorTimeoutState},
-    trie_map::node::Node,
-};
+use crate::{iter::timeout::IteratorTimeoutState, trie_map::node::Node};
 use memchr::memmem::Finder;
 use timeout::TimeoutCheckResult;
 

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/lending.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/lending.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::time::Instant;
+
 use super::{Iter, filter::TraversalFilter};
 use lending_iterator::prelude::*;
 
@@ -32,6 +34,10 @@ impl<'tm, Data, F> LendingIter<'tm, Data, F> {
         F1: TraversalFilter,
     {
         LendingIter(self.0.traversal_filter(f))
+    }
+
+    pub fn set_timeout(&mut self, timeout: Option<Instant>) {
+        self.0.set_timeout(timeout)
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/lending.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/lending.rs
@@ -36,6 +36,7 @@ impl<'tm, Data, F> LendingIter<'tm, Data, F> {
         LendingIter(self.0.traversal_filter(f))
     }
 
+    /// Set timeout
     pub fn set_timeout(&mut self, timeout: Option<Instant>) {
         self.0.set_timeout(timeout)
     }

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/lending_contains.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/lending_contains.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::time::Instant;
+
 use super::ContainsIter;
 use lending_iterator::prelude::*;
 
@@ -19,6 +21,12 @@ pub struct ContainsLendingIter<'tm, 't, Data>(ContainsIter<'tm, 't, Data>);
 impl<'tm, 't, Data> From<ContainsIter<'tm, 't, Data>> for ContainsLendingIter<'tm, 't, Data> {
     fn from(iter: ContainsIter<'tm, 't, Data>) -> Self {
         ContainsLendingIter(iter)
+    }
+}
+
+impl<'tm, 't, Data> ContainsLendingIter<'tm, 't, Data> {
+    pub fn set_timeout(&mut self, timeout: Option<Instant>) {
+        self.0.set_timeout(timeout)
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/lending_contains.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/lending_contains.rs
@@ -25,6 +25,7 @@ impl<'tm, 't, Data> From<ContainsIter<'tm, 't, Data>> for ContainsLendingIter<'t
 }
 
 impl<'tm, 't, Data> ContainsLendingIter<'tm, 't, Data> {
+    /// Set timeout
     pub fn set_timeout(&mut self, timeout: Option<Instant>) {
         self.0.set_timeout(timeout)
     }

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/mod.rs
@@ -17,6 +17,7 @@ mod lending_contains;
 mod lending_range;
 mod prefixes;
 mod range;
+mod timeout;
 mod unfiltered;
 mod values;
 mod wildcard;

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/timeout.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/timeout.rs
@@ -9,7 +9,9 @@
 
 use std::time::Instant;
 
-use timeout::{AnyTimeoutChecker, DeadlineTimeoutChecker, NoTimeoutChecker, TimeoutCheckResult, TimeoutChecker};
+use timeout::{
+    AnyTimeoutChecker, DeadlineTimeoutChecker, NoTimeoutChecker, TimeoutCheckResult, TimeoutChecker,
+};
 
 pub struct IteratorTimeoutState(AnyTimeoutChecker);
 
@@ -29,8 +31,10 @@ impl From<Option<Instant>> for IteratorTimeoutState {
             None => Self::no_timeout(),
             Some(deadline) => {
                 let duration = deadline.saturating_duration_since(Instant::now());
-                Self(AnyTimeoutChecker::Deadline(DeadlineTimeoutChecker::new(duration, 100)))
-            },
+                Self(AnyTimeoutChecker::Deadline(DeadlineTimeoutChecker::new(
+                    duration, 100,
+                )))
+            }
         }
     }
 }

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/timeout.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/timeout.rs
@@ -30,9 +30,14 @@ impl From<Option<Instant>> for IteratorTimeoutState {
         match value {
             None => Self::no_timeout(),
             Some(deadline) => {
+                // Amortize the clock probe over many iterations in release
+                // builds; in debug/test builds probe every iteration so
+                // deadlines are honored promptly.
+                const TIMEOUT_CHECK_LIMIT: u32 = if cfg!(debug_assertions) { 1 } else { 100 };
                 let duration = deadline.saturating_duration_since(Instant::now());
                 Self(AnyTimeoutChecker::Deadline(DeadlineTimeoutChecker::new(
-                    duration, 100,
+                    duration,
+                    TIMEOUT_CHECK_LIMIT,
                 )))
             }
         }

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/timeout.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/timeout.rs
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::time::Instant;
+
+use timeout::{AnyTimeoutChecker, DeadlineTimeoutChecker, NoTimeoutChecker, TimeoutCheckResult, TimeoutChecker};
+
+pub struct IteratorTimeoutState(AnyTimeoutChecker);
+
+impl IteratorTimeoutState {
+    pub const fn no_timeout() -> Self {
+        Self(AnyTimeoutChecker::NoTimeout(NoTimeoutChecker))
+    }
+
+    pub fn check(&mut self) -> TimeoutCheckResult {
+        self.0.check_timeout()
+    }
+}
+
+impl From<Option<Instant>> for IteratorTimeoutState {
+    fn from(value: Option<Instant>) -> Self {
+        match value {
+            None => Self::no_timeout(),
+            Some(deadline) => {
+                let duration = deadline.saturating_duration_since(Instant::now());
+                Self(AnyTimeoutChecker::Deadline(DeadlineTimeoutChecker::new(duration, 100)))
+            },
+        }
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/timeout.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/timeout.rs
@@ -16,10 +16,12 @@ use timeout::{
 pub struct IteratorTimeoutState(AnyTimeoutChecker);
 
 impl IteratorTimeoutState {
+    /// No timeout state
     pub const fn no_timeout() -> Self {
         Self(AnyTimeoutChecker::NoTimeout(NoTimeoutChecker))
     }
 
+    /// Check timeout state
     pub fn check(&mut self) -> TimeoutCheckResult {
         self.0.check_timeout()
     }
@@ -30,14 +32,9 @@ impl From<Option<Instant>> for IteratorTimeoutState {
         match value {
             None => Self::no_timeout(),
             Some(deadline) => {
-                // Amortize the clock probe over many iterations in release
-                // builds; in debug/test builds probe every iteration so
-                // deadlines are honored promptly.
-                const TIMEOUT_CHECK_LIMIT: u32 = if cfg!(debug_assertions) { 1 } else { 100 };
                 let duration = deadline.saturating_duration_since(Instant::now());
                 Self(AnyTimeoutChecker::Deadline(DeadlineTimeoutChecker::new(
-                    duration,
-                    TIMEOUT_CHECK_LIMIT,
+                    duration, 100,
                 )))
             }
         }

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/unfiltered.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/unfiltered.rs
@@ -12,10 +12,7 @@ use std::time::Instant;
 use timeout::TimeoutCheckResult;
 
 use super::filter::{TraversalFilter, VisitAll};
-use crate::{
-    iter::timeout::{IteratorTimeoutState},
-    trie_map::node::Node,
-};
+use crate::{iter::timeout::IteratorTimeoutState, trie_map::node::Node};
 
 /// Iterates over the entries of a [`TrieMap`](crate::TrieMap) in lexicographical order.
 ///

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/unfiltered.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/unfiltered.rs
@@ -7,8 +7,15 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::time::Instant;
+
+use timeout::TimeoutCheckResult;
+
 use super::filter::{TraversalFilter, VisitAll};
-use crate::trie_map::node::Node;
+use crate::{
+    iter::timeout::{IteratorTimeoutState},
+    trie_map::node::Node,
+};
 
 /// Iterates over the entries of a [`TrieMap`](crate::TrieMap) in lexicographical order.
 ///
@@ -22,6 +29,8 @@ pub struct Iter<'tm, Data, F> {
     /// Concatenation of the labels of current node and its ancestors,
     /// i.e. the key of the current node.
     key: Vec<u8>,
+    /// Timeout for this iterator
+    timeout: IteratorTimeoutState,
 }
 
 impl<'tm, Data, F> Iter<'tm, Data, F> {
@@ -35,7 +44,13 @@ impl<'tm, Data, F> Iter<'tm, Data, F> {
             stack,
             filter: f,
             key,
+            timeout: IteratorTimeoutState::no_timeout(),
         }
+    }
+
+    /// Set timeout
+    pub fn set_timeout(&mut self, timeout: Option<Instant>) {
+        self.timeout = timeout.into();
     }
 }
 
@@ -65,6 +80,7 @@ where
             stack: root.into_iter().map(|node| (node, false)).collect(),
             key: prefix,
             filter: visit_descendants,
+            timeout: IteratorTimeoutState::no_timeout(),
         }
     }
 
@@ -78,6 +94,10 @@ where
     /// key to the one matching that node's entry
     pub(crate) fn advance(&mut self) -> Option<&'tm Data> {
         loop {
+            if matches!(self.timeout.check(), TimeoutCheckResult::TimedOut) {
+                return None;
+            }
+
             let (node, was_visited) = self.stack.pop()?;
 
             if !was_visited {

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/wildcard.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/wildcard.rs
@@ -44,6 +44,7 @@ impl<'tm, 'p, Data> WildcardFilterIter<'tm, 'p, Data> {
         Self(iter)
     }
 
+    /// Set timeout
     pub(crate) fn set_timeout(&mut self, timeout: Option<Instant>) {
         self.0.set_timeout(timeout);
     }

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/wildcard.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/wildcard.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::time::Instant;
+
 use crate::trie_map::node::Node;
 
 use super::{
@@ -16,10 +18,8 @@ use super::{
 use rqe_wildcard::{MatchOutcome, WildcardPattern};
 
 /// Per-key filter-based wildcard iterator. Public-named because it
-/// appears as the inner value of
-/// [`WildcardIter::Filter`](super::automaton::WildcardIter::Filter),
-/// but it can only be obtained through that dispatcher — the direct
-/// constructor on [`TrieMap`](crate::TrieMap) is crate-private.
+/// is wrapped into a [`WildcardIter`](super::automaton::WildcardIter)
+/// (via its `From` impl) by the wildcard dispatcher.
 pub struct WildcardFilterIter<'tm, 'p, Data>(Iter<'tm, Data, WildcardFilter<'p>>);
 
 impl<'tm, 'p, Data> WildcardFilterIter<'tm, 'p, Data> {
@@ -42,6 +42,10 @@ impl<'tm, 'p, Data> WildcardFilterIter<'tm, 'p, Data> {
         }
         .traversal_filter(WildcardFilter(pattern));
         Self(iter)
+    }
+
+    pub(crate) fn set_timeout(&mut self, timeout: Option<Instant>) {
+        self.0.set_timeout(timeout);
     }
 
     /// Advance to the next matching entry; returns a reference to its data.


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current:
  - `TrieMapIterator` timeout is handled by the `trie_map_ffi` crate.
  - `rqe_iterators` crate has an identical timeout implementation. 
2. Change: 
  - create `timeout` crate
  - use it in `trie_rs` and `rqe_iterators` crates
  - re-adapt `triemap_ffi` crate to forward the timeout to the Rust side
3. Outcome: 
  - Reuse shared timeout logic.
  - TagIndex Rust port can wrap MapTrieIterator and reuse the timeout feature.

#### Which additional issues this PR fixes
1. MOD-14988

#### Main objects this PR modified
1. triemap_ffi crate
2. rqe_iterators crate
3. TrieMapIterator and related

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
