### PR TITLE
[MOD-14739] Rename libredisearch_all to libredisearch_c_bundle

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -378,7 +378,7 @@ prepare_cmake_arguments() {
   # the CMake cache retains CMAKE_INTERPROCEDURAL_OPTIMIZATION=true and the
   # static libraries already built from it contain LLVM bitcode, which
   # non-LTO consumers reject at link time (the Rust test binaries linking
-  # libredisearch_all.a through the default cc/bfd linker fail with
+  # libredisearch_c_bundle.a through the default cc/bfd linker fail with
   # "file format not recognized"). Inherit LTO from the cache so a re-drive
   # without the LTO argument (e.g. `make test` after an LTO `make build`)
   # keeps the matching clang/lld toolchain. FORCE wipes the directory in

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -243,7 +243,7 @@ macro(collect_static_libs target out_libs out_targets)
     set(${out_targets} ${_COLLECT_TARGETS})
 endmacro()
 
-set(REDISEARCH_ALL_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/libredisearch_all.a")
+set(REDISEARCH_C_BUNDLE_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/libredisearch_c_bundle.a")
 
 # Collect all static library dependencies from redisearch_c
 set(LIBS_TO_MERGE "")
@@ -270,7 +270,7 @@ endif()
 
 list(REMOVE_DUPLICATES LIBS_TO_MERGE)
 list(REMOVE_DUPLICATES VISITED_TARGETS)
-message(STATUS "Static libraries for libredisearch_all.a: ${LIBS_TO_MERGE}")
+message(STATUS "Static libraries for libredisearch_c_bundle.a: ${LIBS_TO_MERGE}")
 
 # Combine targets and library paths for DEPENDS
 set(MERGE_DEPENDS ${VISITED_TARGETS} ${LIBS_TO_MERGE})
@@ -280,10 +280,10 @@ list(REMOVE_DUPLICATES MERGE_DEPENDS)
 if(APPLE)
     # macOS: use libtool to merge static libraries
     add_custom_command(
-        OUTPUT ${REDISEARCH_ALL_OUTPUT}
-        COMMAND libtool -static -no_warning_for_no_symbols -o ${REDISEARCH_ALL_OUTPUT} ${LIBS_TO_MERGE}
+        OUTPUT ${REDISEARCH_C_BUNDLE_OUTPUT}
+        COMMAND libtool -static -no_warning_for_no_symbols -o ${REDISEARCH_C_BUNDLE_OUTPUT} ${LIBS_TO_MERGE}
         DEPENDS ${MERGE_DEPENDS}
-        COMMENT "Creating unified libredisearch_all.a with libtool"
+        COMMENT "Creating unified libredisearch_c_bundle.a with libtool"
         VERBATIM
         COMMAND_EXPAND_LISTS
     )
@@ -292,19 +292,19 @@ else()
     set(MRI_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/merge_libs.mri")
     string(REPLACE ";" "\nADDLIB " ADDLIB_COMMANDS "${LIBS_TO_MERGE}")
     file(GENERATE OUTPUT ${MRI_SCRIPT} CONTENT
-"CREATE ${REDISEARCH_ALL_OUTPUT}
+"CREATE ${REDISEARCH_C_BUNDLE_OUTPUT}
 ADDLIB ${ADDLIB_COMMANDS}
 SAVE
 END
 ")
     add_custom_command(
-        OUTPUT ${REDISEARCH_ALL_OUTPUT}
-        COMMAND ${CMAKE_COMMAND} -E rm -f ${REDISEARCH_ALL_OUTPUT}
+        OUTPUT ${REDISEARCH_C_BUNDLE_OUTPUT}
+        COMMAND ${CMAKE_COMMAND} -E rm -f ${REDISEARCH_C_BUNDLE_OUTPUT}
         COMMAND ar -M < ${MRI_SCRIPT}
         DEPENDS ${MERGE_DEPENDS} ${MRI_SCRIPT}
-        COMMENT "Creating unified libredisearch_all.a with ar"
+        COMMENT "Creating unified libredisearch_c_bundle.a with ar"
         VERBATIM
     )
 endif()
 
-add_custom_target(redisearch_all ALL DEPENDS ${REDISEARCH_ALL_OUTPUT})
+add_custom_target(redisearch_c_bundle ALL DEPENDS ${REDISEARCH_C_BUNDLE_OUTPUT})

--- a/src/redisearch_rs/CONTRIBUTING.md
+++ b/src/redisearch_rs/CONTRIBUTING.md
@@ -113,7 +113,7 @@ That's not an issue when it comes to _compilation_, but it becomes a challenge i
 
 ### Our solution
 
-The CMake build creates `libredisearch_all.a`, a unified static library that bundles all C/C++ dependencies (including VectorSimilarity, SVS, spdlog, etc.). Rust crates that need to link against C code use the `build_utils::bind_foreign_c_symbols()` function in their `build.rs` to link this library.
+The CMake build creates `libredisearch_c_bundle.a`, a unified static library that bundles all C/C++ dependencies (including VectorSimilarity, SVS, spdlog, etc.). Rust crates that need to link against C code use the `build_utils::bind_foreign_c_symbols()` function in their `build.rs` to link this library.
 
 They must also depend on `redisearch_rs` and invoke `redis_mock::mock_or_stub_missing_redis_c_symbols!()` to ensure that C symbols defined in Rust are available.
 

--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -64,13 +64,13 @@ pub fn rerun_if_c_changes(dir: &Path) -> std::io::Result<()> {
 /// Link all the relevant C dependencies to allow Rust (testing and benchmarking) code to invoke
 /// RediSearch C symbols.
 ///
-/// This links a single combined static library (`libredisearch_all.a`) that bundles
+/// This links a single combined static library (`libredisearch_c_bundle.a`) that bundles
 /// all C code and dependencies together. The combined library is created by CMake
 /// during the build process.
 pub fn bind_foreign_c_symbols() {
     let bin_root = bin_root();
     force_link_time_symbol_resolution();
-    link_redisearch_all(&bin_root).unwrap_or_else(|e| panic!("{e}"));
+    link_redisearch_c_bundle(&bin_root).unwrap_or_else(|e| panic!("{e}"));
     link_mkl(&bin_root.join("_deps/svs-src/lib"));
     link_c_plusplus();
 }
@@ -120,12 +120,12 @@ fn bin_root() -> PathBuf {
     }
 }
 
-/// Link `libredisearch_all.a` using the `-bundle` modifier, returning an error if the
+/// Link `libredisearch_c_bundle.a` using the `-bundle` modifier, returning an error if the
 /// library is not found.
 ///
 /// The `-bundle` modifier prevents the (very large) C archive from being
 /// embedded into every Rust rlib in the dependency tree. Instead, the linker
-/// flag `-lredisearch_all` propagates to final binaries (tests, benchmarks)
+/// flag `-lredisearch_c_bundle` propagates to final binaries (tests, benchmarks)
 /// where the linker selectively pulls only the objects that are actually
 /// needed. This avoids two problems:
 ///
@@ -138,11 +138,11 @@ fn bin_root() -> PathBuf {
 /// Callers that need soft-fail behaviour (e.g. lint-only runs where the
 /// library has not been built) can inspect the returned `Err` and emit a
 /// `cargo::warning` instead of panicking.
-pub fn link_redisearch_all(bin_root: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+pub fn link_redisearch_c_bundle(bin_root: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let lib_dir = bin_root.join("src");
-    let lib = lib_dir.join("libredisearch_all.a");
+    let lib = lib_dir.join("libredisearch_c_bundle.a");
     if std::fs::exists(&lib).unwrap_or(false) {
-        println!("cargo::rustc-link-lib=static:-bundle=redisearch_all");
+        println!("cargo::rustc-link-lib=static:-bundle=redisearch_c_bundle");
         println!("cargo::rerun-if-changed={}", lib.display());
         println!("cargo::rustc-link-search=native={}", lib_dir.display());
         Ok(lib)
@@ -153,9 +153,9 @@ pub fn link_redisearch_all(bin_root: &Path) -> Result<PathBuf, Box<dyn std::erro
 
 /// Link Intel MKL separately if present.
 ///
-/// MKL is excluded from `libredisearch_all.a` because its ~42K object files
+/// MKL is excluded from `libredisearch_c_bundle.a` because its ~42K object files
 /// overflow the `u16` archive member index in rustc's `ar_archive_writer`.
-/// Like `redisearch_all`, we link with `-bundle` to avoid rlib bloat.
+/// Like `redisearch_c_bundle`, we link with `-bundle` to avoid rlib bloat.
 ///
 /// `svs_lib_dir` is the directory that contains `libmkl_static_library.a`.
 /// Its location varies across build configurations, so callers are responsible

--- a/src/redisearch_rs/c_entrypoint/redisearch_rs/build.rs
+++ b/src/redisearch_rs/c_entrypoint/redisearch_rs/build.rs
@@ -33,10 +33,10 @@ use walkdir::WalkDir;
 ///
 /// We have issues when it comes to tests and benchmarks.
 /// Some of our tests and benchmarks need to invoke C-defined symbols, which are provided by
-/// the `redisearch_all` static library. Those C-defined symbols may in turn call back into Rust-defined FFI
+/// the `redisearch_c_bundle` static library. Those C-defined symbols may in turn call back into Rust-defined FFI
 /// symbols. `cargo` isn't able to see this relationship: `redisearch_rs` is consumed
 /// as a regular Rust dependency (an `rlib`) by our tests and benchmarks, and the FFI symbols it
-/// defines are stripped out as unused. This in turn causes the `redisearch_all` static library to fail linking,
+/// defines are stripped out as unused. This in turn causes the `redisearch_c_bundle` static library to fail linking,
 /// since the Rust-provided symbols it needs are missing.
 ///
 /// # Obvious Solutions That Don't Work

--- a/src/redisearch_rs/c_wrappers/search_disk/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/search_disk/Cargo.toml
@@ -9,7 +9,7 @@ publish.workspace = true
 workspace = true
 
 [features]
-# Enabled when building tests so `build.rs` links the C code (`libredisearch_all.a`).
+# Enabled when building tests so `build.rs` links the C code (`libredisearch_c_bundle.a`).
 # See https://github.com/rust-lang/cargo/issues/4789#issuecomment-2308131243
 unittest = []
 

--- a/src/redisearch_rs/c_wrappers/search_disk/tests/handle.rs
+++ b/src/redisearch_rs/c_wrappers/search_disk/tests/handle.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-// `rqe_iterators` (a dependency of `search_disk`) links `libredisearch_all.a`,
+// `rqe_iterators` (a dependency of `search_disk`) links `libredisearch_c_bundle.a`,
 // whose C objects call back into Rust FFI symbols exported only by the
 // `c_entrypoint/*_ffi` crates. A normal build garbage-collects those C objects,
 // but a coverage build keeps dead code, so the symbols must resolve. Force-link

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -9,7 +9,7 @@
 
 // Stub `AREQ_CheckTimedOut` for lib unit tests so the linker doesn't pull
 // `query.c.o` (and its C/coord/SSL transitive closure) from
-// `libredisearch_all.a`. The flag is only ever set by Redis on the main
+// `libredisearch_c_bundle.a`. The flag is only ever set by Redis on the main
 // thread, which doesn't exist here. Integration tests use the real symbol.
 #[cfg(test)]
 #[unsafe(no_mangle)]

--- a/src/redisearch_rs/rqe_wildcard/Cargo.toml
+++ b/src/redisearch_rs/rqe_wildcard/Cargo.toml
@@ -37,7 +37,7 @@ rqe_wildcard = { path = ".", features = ["unittest"] }
 wildcard_cloudflare.workspace = true
 
 # FFI crates whose #[no_mangle] symbols are referenced by objects in
-# libredisearch_all.a. They must be listed here (and force-linked via
+# libredisearch_c_bundle.a. They must be listed here (and force-linked via
 # `extern crate` in tests/integration/main.rs) so the linker can
 # resolve those symbols when building the test binary.
 fnv_ffi = { path = "../c_entrypoint/fnv_ffi" }

--- a/src/redisearch_rs/rqe_wildcard/tests/integration/main.rs
+++ b/src/redisearch_rs/rqe_wildcard/tests/integration/main.rs
@@ -8,7 +8,7 @@
 */
 
 // Provide stubs for Redis allocator and OpenSSL symbols referenced by
-// libredisearch_all.a, and force-link FFI crates so their #[no_mangle]
+// libredisearch_c_bundle.a, and force-link FFI crates so their #[no_mangle]
 // symbols satisfy archive references. All FFI crates are needed because
 // wildcard.c.o's RS_ABORT macro (in debug builds) pulls in RSDummyContext,
 // which cascades through most of the archive.

--- a/src/redisearch_rs/tag_index/Cargo.toml
+++ b/src/redisearch_rs/tag_index/Cargo.toml
@@ -6,7 +6,7 @@ license-file.workspace = true
 publish.workspace = true
 
 [features]
-# Enabled when building tests so `build.rs` links the C code (`libredisearch_all`).
+# Enabled when building tests so `build.rs` links the C code (`libredisearch_c_bundle`).
 # See https://github.com/rust-lang/cargo/issues/4789#issuecomment-2308131243
 unittest = []
 

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -111,7 +111,7 @@
 mod suffix;
 
 // Force-link the umbrella `redisearch_rs` crate so its `#[used]` symbol table keeps the
-// Rust FFI functions that the linked C code (`libredisearch_all`) calls back into, and
+// Rust FFI functions that the linked C code (`libredisearch_c_bundle`) calls back into, and
 // stub any remaining Redis module C symbols the tests pull in. Without the `extern crate`
 // reference the umbrella rlib is dropped as unused and those symbols go undefined at link
 // time. Mirrors `numeric_range_tree`/`query_eval`/`top_k`.

--- a/src/redisearch_rs/vector_score_source/src/lib.rs
+++ b/src/redisearch_rs/vector_score_source/src/lib.rs
@@ -15,7 +15,7 @@
 //! [`top_k::ScoreSource`] that drives [`TopKIterator`] against a VecSim index.
 
 // Force-link the umbrella `redisearch_rs` crate so the `QueryError_*` (and other)
-// Rust FFI symbols that `libredisearch_all.a` calls back into are retained in the
+// Rust FFI symbols that `libredisearch_c_bundle.a` calls back into are retained in the
 // lib unit-test binary, which links the C archive via the `unittest` feature.
 #[cfg(test)]
 extern crate redisearch_rs;

--- a/src/redisearch_rs/vector_score_source_bencher/benches/hybrid_shim.c
+++ b/src/redisearch_rs/vector_score_source_bencher/benches/hybrid_shim.c
@@ -12,7 +12,7 @@
  * the production counterpart of the Rust VectorTopKIterator / VectorScoreSource.
  *
  *
- * It links against libredisearch_all.a (bundled by build_utils), which provides
+ * It links against libredisearch_c_bundle.a (bundled by build_utils), which provides
  * NewHybridVectorIterator, the Rust-backed NewSortedIdListIterator child, the
  * doc table, and the min-max heap.
  *

--- a/src/redisearch_rs/vector_score_source_bencher/build.rs
+++ b/src/redisearch_rs/vector_score_source_bencher/build.rs
@@ -8,8 +8,8 @@
 */
 
 fn main() {
-    // Emit hybrid_shim before redisearch_all: static archives resolve
-    // left-to-right, and the shim's symbols are defined in libredisearch_all.a.
+    // Emit hybrid_shim before redisearch_c_bundle: static archives resolve
+    // left-to-right, and the shim's symbols are defined in libredisearch_c_bundle.a.
     compile_hybrid_shim();
     build_utils::bind_foreign_c_symbols();
 }
@@ -22,7 +22,7 @@ fn compile_hybrid_shim() {
     let deps = root.join("deps");
 
     cc::Build::new()
-        // Drives the real C HybridIterator from libredisearch_all.a, as a
+        // Drives the real C HybridIterator from libredisearch_c_bundle.a, as a
         // faithful counterpart to the Rust VectorTopKIterator.
         .file("benches/hybrid_shim.c")
         // Silence warnings originating from transitively-included RediSearch


### PR DESCRIPTION
## Describe the changes in the pull request

The unified static archive is currently called `libredisearch_all.a`, which isn't accurate — it holds only the C/C++ symbols, not the Rust code. This gives it a clearer name: `libredisearch_c_bundle.a` (CMake target `redisearch_c_bundle`, `build_utils` helper `link_redisearch_c_bundle`). All comments and references are updated to match. No behavioural change.

#### Which additional issues this PR fixes
1. MOD-14739

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
