### PR TITLE
Fix Alpine build warnings from errno include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 
 include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
 
 get_filename_component(root ${CMAKE_CURRENT_LIST_DIR} ABSOLUTE)
 # The `binroot` path includes a platform+profile segment
@@ -49,6 +50,25 @@ function(setup_cc_options)
     set(_common_c_flags "${CMAKE_C_FLAGS} -fPIC -g -pthread -fno-strict-aliasing -Wno-unused-function -Wno-unused-variable -Wno-sign-compare -fcommon -funsigned-char")
     set(_common_cxx_flags "${CMAKE_CXX_FLAGS} -fPIC -g -pthread -fno-strict-aliasing -Wno-unused-function -Wno-unused-variable -Wno-sign-compare")
     set(CMAKE_CXX_STANDARD 20)
+
+    # musl compatibility headers emit #warning for non-portable include paths.
+    # Treat those diagnostics as build failures so Alpine catches them early.
+    execute_process(
+        COMMAND ${CMAKE_C_COMPILER} -dumpmachine
+        OUTPUT_VARIABLE C_COMPILER_TARGET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+    )
+    if(C_COMPILER_TARGET MATCHES "musl" OR EXISTS "/etc/alpine-release")
+        check_c_compiler_flag("-Werror=cpp" HAS_C_WERROR_CPP)
+        check_cxx_compiler_flag("-Werror=cpp" HAS_CXX_WERROR_CPP)
+        if(HAS_C_WERROR_CPP)
+            set(_common_c_flags "${_common_c_flags} -Werror=cpp")
+        endif()
+        if(HAS_CXX_WERROR_CPP)
+            set(_common_cxx_flags "${_common_cxx_flags} -Werror=cpp")
+        endif()
+    endif()
 
     # MOD-14916: inline LSE atomics on Linux AArch64 -- avoid libgcc
     # __aarch64_* outline-atomics helpers on every atomic RMW.

--- a/deps/rmutil/cmdparse.c
+++ b/deps/rmutil/cmdparse.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <limits.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <ctype.h>
 #include <inttypes.h>
 #include <math.h>

--- a/src/util/strconv.h
+++ b/src/util/strconv.h
@@ -7,7 +7,7 @@
 #ifndef RS_STRCONV_H_
 #define RS_STRCONV_H_
 #include <limits.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <math.h>
 #include <string.h>
 #include <ctype.h>


### PR DESCRIPTION
## Describe the changes in the pull request

Current: `src/util/strconv.h` and `deps/rmutil/cmdparse.c` include `<sys/errno.h>`. On musl-based systems such as Alpine Linux, that compatibility header emits a `#warning` redirecting users to `<errno.h>` for every translation unit that reaches it transitively. Alpine CI builds do not currently fail on that warning class.

Change: Use the standard `<errno.h>` header in both files. In CMake, detect musl toolchains or native Alpine builds and add `-Werror=cpp` for C and C++ when the compiler supports it.

Outcome: Alpine/musl builds avoid the repeated redirect warnings, preserve the existing `errno` and `ERANGE` behavior, and fail early if similar preprocessor warnings are reintroduced.

Validation:
1. `rg '#\\s*include\\s*<sys/errno\\.h>' src deps/rmutil` finds no matches.
2. Alpine 3.23 compiler probe with `cc -Werror=cpp` succeeds when including `<errno.h>`.
3. Alpine 3.23 CMake probe verifies `<sys/errno.h>` fails and `<errno.h>` passes when musl CMake flags are applied.
4. `make build TESTS=1` succeeds.

#### Which additional issues this PR fixes
1. Fixes #10510

#### Main objects this PR modified
1. `src/util/strconv.h`
2. `deps/rmutil/cmdparse.c`
3. `CMakeLists.txt`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
