### PR TITLE
string_utiles: add runes conversion helpers

### DIFF
--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -456,7 +456,7 @@ const HEADERS: &[HeaderAllowlist] = &[
     },
     HeaderAllowlist {
         path: "src/trie/rune_util.h",
-        fns: &["strToLowerRunes", "strToRunesN"],
+        fns: &["runesToStr", "strToLowerRunes", "strToRunesN"],
         types: &[],
         vars: &["MAX_RUNE_STR_LEN"],
     },

--- a/src/redisearch_rs/string_utils/src/runes.rs
+++ b/src/redisearch_rs/string_utils/src/runes.rs
@@ -28,6 +28,11 @@ pub struct RuneStrTooLong {
 ///
 /// Each Unicode codepoint is lowercased and then truncated to [`u16`].
 ///
+/// The whole of `s` is converted: a NUL codepoint is folded and truncated like
+/// any other rather than ending the conversion, unlike [`utf8_to_lower_runes`],
+/// which stops there because the key it builds must match how a term was
+/// indexed.
+///
 /// Returns [`Err(`[`RuneStrTooLong`]`)`] if the resulting rune count exceeds
 /// [`MAX_RUNE_STR_LEN`].
 pub fn str_to_lower_runes(s: &str) -> Result<Vec<u16>, RuneStrTooLong> {
@@ -103,6 +108,107 @@ pub fn runes_to_string(runes: &[u16]) -> Option<String> {
     String::from_utf8(runes_to_utf8(runes)?).ok()
 }
 
+/// The codepoints of a rune-encoded byte string, decoded exactly as the trie's
+/// keys were encoded and *before* any truncation to [`u16`].
+///
+/// Yielding [`u32`] rather than a rune lets a caller that case-folds do so on the
+/// full codepoint, which is where the fold is defined; truncating first would
+/// fold the wrong character. Callers that do not fold truncate immediately.
+///
+/// The sequence width is classified from the lead byte by the same ranges C's
+/// `nu_utf8_read` uses — `0x00..=0x7F` → 1 byte, `0x80..=0xDF` → 2, `0xE0..=0xEF`
+/// → 3, `0xF0..=0xFF` → 4 — **not** by the stricter `110xxxxx`/`11110xxx` bit
+/// prefixes. So a byte the strict tests reject (a bare continuation byte or an
+/// `0xF8..=0xFF` lead) is still consumed as a multi-byte sequence, matching how
+/// the C indexer decoded it; classifying it as malformed here would make such a
+/// key unlookable.
+///
+/// Continuation bytes are likewise **not** validated to be of the `10xxxxxx`
+/// form: each is masked (`& 0x3F`) and folded into the codepoint unconditionally,
+/// exactly as `nu_utf8_read` does. So `[0xC3, b'(']` decodes to the same
+/// codepoint the C indexer would have produced (`0x00E8`) rather than stopping.
+/// Validating either the lead or the continuation bytes would diverge from how
+/// terms are actually stored.
+///
+/// A *truncated* trailing sequence — a lead byte whose continuation bytes run
+/// past the end of the input — still yields a codepoint, with the missing bytes
+/// taken as zero. That reproduces what the C decoder observes: the token buffers
+/// it reads are NUL-terminated, so it consumes terminator bytes as the missing
+/// continuations and produces exactly the same codepoint (`[0xC3]` → `0x00C0`).
+/// Dropping the sequence instead would turn a one-rune key into an empty one,
+/// which as a prefix matches every term rather than the term it names. No read
+/// ever crosses the end of the input: the zeros are supplied, not read.
+///
+/// A NUL codepoint is yielded like any other; stopping there is the caller's
+/// choice, since only some of the conversions treat it as a terminator.
+struct Codepoints<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Codepoints<'a> {
+    const fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+}
+
+impl Iterator for Codepoints<'_> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<u32> {
+        let b = *self.bytes.get(self.offset)?;
+        // Classify the width from the lead byte using C `nu_utf8_read`'s ranges.
+        let width = if b < 0x80 {
+            1
+        } else if b < 0xE0 {
+            2
+        } else if b < 0xF0 {
+            3
+        } else {
+            4
+        };
+        // Continuation byte `k` of the current sequence, masked with `& 0x3F`
+        // exactly as `nu_utf8_read` does. One that runs past the end of `bytes`
+        // is taken as zero — the terminator byte the C decoder reads there.
+        let cont = |k: usize| -> u32 {
+            u32::from(self.bytes.get(self.offset + k).copied().unwrap_or(0)) & 0x3F
+        };
+        let codepoint = match width {
+            1 => u32::from(b),
+            2 => (u32::from(b) & 0x1F) << 6 | cont(1),
+            3 => (u32::from(b) & 0x0F) << 12 | cont(1) << 6 | cont(2),
+            _ => (u32::from(b) & 0x07) << 18 | cont(1) << 12 | cont(2) << 6 | cont(3),
+        };
+        // Clamp so a truncated sequence leaves the iterator exactly at the end
+        // rather than past it.
+        self.offset = (self.offset + width).min(self.bytes.len());
+        Some(codepoint)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.bytes.len() - self.offset;
+        // Upper bound: a one-byte sequence per remaining byte.
+        //
+        // Lower bound: each codepoint consumes at most four bytes, and every
+        // remaining byte is consumed — a truncated trailing sequence still
+        // yields a codepoint rather than stranding its bytes.
+        (remaining.div_ceil(4), Some(remaining))
+    }
+}
+
+/// Lowercase a single decoded codepoint, yielding the codepoints it folds to.
+///
+/// A value that is not a Unicode scalar value — a lone surrogate, or anything an
+/// out-of-range lead byte produced — has no case mapping and is passed through
+/// unchanged, mirroring the C fold, which leaves a codepoint it has no entry for
+/// alone. Exactly one of the two branches below yields.
+fn fold_codepoint(codepoint: u32) -> impl Iterator<Item = u32> {
+    let scalar = char::from_u32(codepoint);
+    let folded = scalar.map(char::to_lowercase);
+    let verbatim = scalar.is_none().then_some(codepoint);
+    folded.into_iter().flatten().map(u32::from).chain(verbatim)
+}
+
 /// Decode a byte string into the runes ([`u16`]) a term was indexed under,
 /// reproducing the C `strToRunesN` conversion the trie is built with.
 ///
@@ -120,76 +226,108 @@ pub fn runes_to_string(runes: &[u16]) -> Option<String> {
 ///   query resolve to the same key instead of silently missing it.
 ///
 /// Unlike a UTF-8-validating decode, this recovers the same runes the term was
-/// stored under, so a surrogate-bearing key still matches.
+/// stored under, so a surrogate-bearing key still matches. See [`Codepoints`]
+/// for how a sequence's width and codepoint are derived, including from bytes a
+/// strict decoder would reject.
 ///
-/// The sequence width is classified from the lead byte by the same ranges C's
-/// `nu_utf8_read` uses — `0x00..=0x7F` → 1 byte, `0x80..=0xDF` → 2, `0xE0..=0xEF`
-/// → 3, `0xF0..=0xFF` → 4 — **not** by the stricter `110xxxxx`/`11110xxx` bit
-/// prefixes. So a byte the strict tests reject (a bare continuation byte or an
-/// `0xF8..=0xFF` lead) is still consumed as a multi-byte sequence, matching how
-/// the C indexer decoded it; classifying it as malformed here would make such a
-/// key unlookable.
-///
-/// Continuation bytes are likewise **not** validated to be of the `10xxxxxx`
-/// form: each is masked (`& 0x3F`) and folded into the codepoint unconditionally,
-/// exactly as `nu_utf8_read` does. So `[0xC3, b'(']` decodes to the same rune the
-/// C indexer would have produced (`0x00E8`) rather than stopping. Validating
-/// either the lead or the continuation bytes would diverge from how terms are
-/// actually stored.
-///
-/// Decoding stops only at the first NUL codepoint (keys are NUL-terminated) and
-/// at a *truncated* sequence — a lead byte whose continuation bytes run past the
-/// end of `bytes` (the one place this is stricter than the C decoder, which would
-/// read past its buffer); no read ever crosses that end.
+/// Decoding stops at the first NUL codepoint (keys are NUL-terminated). A
+/// truncated trailing sequence still yields a codepoint, its missing bytes taken
+/// as zero; no read ever crosses the end of `bytes`.
 pub fn utf8_to_runes(bytes: &[u8]) -> Vec<u16> {
     let mut runes = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        let b = bytes[i];
-        // Classify the width from the lead byte using C `nu_utf8_read`'s ranges.
-        let width = if b < 0x80 {
-            1
-        } else if b < 0xE0 {
-            2
-        } else if b < 0xF0 {
-            3
-        } else {
-            4
-        };
-        // A sequence whose continuation bytes run past the end of `bytes` is
-        // truncated: stop rather than read out of bounds (C would read past its
-        // buffer here).
-        if i + width > bytes.len() {
-            break;
-        }
-        // Decode the codepoint, masking continuation bytes with `& 0x3F` exactly
-        // as `nu_utf8_read` does, then truncate to `u16` as `strToRunesN`'s
-        // `(rune)cp` does — so the recovered runes match the key the trie was
-        // built under (a non-BMP codepoint folds to its low 16 bits).
-        let codepoint: u32 = match width {
-            1 => u32::from(b),
-            2 => (u32::from(b) & 0x1F) << 6 | (u32::from(bytes[i + 1]) & 0x3F),
-            3 => {
-                (u32::from(b) & 0x0F) << 12
-                    | (u32::from(bytes[i + 1]) & 0x3F) << 6
-                    | (u32::from(bytes[i + 2]) & 0x3F)
-            }
-            _ => {
-                (u32::from(b) & 0x07) << 18
-                    | (u32::from(bytes[i + 1]) & 0x3F) << 12
-                    | (u32::from(bytes[i + 2]) & 0x3F) << 6
-                    | (u32::from(bytes[i + 3]) & 0x3F)
-            }
-        };
-        // Keys are NUL-terminated; a `0` codepoint marks the end of the string.
-        // Test the full codepoint before truncating, as `strToRunesN` does — a
-        // four-byte codepoint is never `0`, so it is never mistaken for a
-        // terminator.
-        if codepoint == 0 {
-            break;
-        }
-        runes.push(codepoint as u16);
-        i += width;
-    }
+    runes.extend(
+        Codepoints::new(bytes)
+            // Keys are NUL-terminated; a `0` codepoint marks the end of the
+            // string. Test the full codepoint before truncating, as
+            // `strToRunesN` does — a four-byte codepoint is never `0`, so it is
+            // never mistaken for a terminator.
+            .take_while(|&codepoint| codepoint != 0)
+            // Truncate to `u16` as `strToRunesN`'s `(rune)cp` does, so the
+            // recovered runes match the key the trie was built under (a non-BMP
+            // codepoint folds to its low 16 bits).
+            .map(|codepoint| codepoint as u16),
+    );
     runes
+}
+
+/// Lowercase a byte string and convert it to the runes ([`u16`]) a term is
+/// looked up under, reproducing the C `strToLowerRunes` conversion.
+///
+/// This is the case-folding counterpart of [`utf8_to_runes`] and shares its
+/// lenient decoding: `bytes` is a binary-safe query token or trie key, not
+/// necessarily valid UTF-8, and every byte sequence must fold to the same runes
+/// the term was indexed under. In particular a malformed sequence such as
+/// `[0xC3, b'(']` folds to `0x00E8` and a WTF-8 lone surrogate to its own rune,
+/// where a validating decode would substitute [`char::REPLACEMENT_CHARACTER`]
+/// and look up a key that was never stored.
+///
+/// Each codepoint is lowercased *before* being truncated to [`u16`], which is
+/// the order the C conversion uses and the only correct one: a non-BMP codepoint
+/// folds by its full value, so truncating first would fold an unrelated
+/// character (`U+10400` folds to `U+10428` → rune `0x0428`, whereas truncating
+/// first would fold `U+0400` → rune `0x0450`).
+///
+/// Decoding stops at the first codepoint that decodes to `0`, like
+/// [`utf8_to_runes`]. This is not merely truncation: a term is stored under the
+/// runes up to its first such codepoint — both the tokenizer that lowercases
+/// document text and the trie encoder terminate there — so a lookup key must too,
+/// or it would carry a `0` rune no stored term has and match nothing. The `0`
+/// is tested on the decoded codepoint, before folding and truncation, so a byte
+/// sequence that decodes to `0` without being a literal NUL byte (e.g. the
+/// overlong encoding `[0xC0, 0x80]`) ends the key just the same. A truncated
+/// trailing sequence still yields a codepoint, its missing bytes taken as zero,
+/// and no read crosses the end of `bytes`.
+///
+/// Returns [`Err(`[`RuneStrTooLong`]`)`] if the folded rune count exceeds
+/// [`MAX_RUNE_STR_LEN`], measured before the buffer is allocated so that an
+/// over-limit token does not allocate proportionally to its length.
+pub fn utf8_to_lower_runes(bytes: &[u8]) -> Result<Vec<u16>, RuneStrTooLong> {
+    let len = Codepoints::new(bytes)
+        .take_while(|&codepoint| codepoint != 0)
+        .flat_map(fold_codepoint)
+        .count();
+    if len > MAX_RUNE_STR_LEN {
+        return Err(RuneStrTooLong { len });
+    }
+    let mut runes = Vec::with_capacity(len);
+    runes.extend(
+        Codepoints::new(bytes)
+            .take_while(|&codepoint| codepoint != 0)
+            .flat_map(fold_codepoint)
+            .map(|codepoint| codepoint as u16),
+    );
+    Ok(runes)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// The bounds [`Codepoints`] reports must bracket the number of codepoints
+    /// it actually yields, including when the input ends in a truncated sequence
+    /// whose missing bytes are supplied as zero.
+    #[test]
+    fn size_hint_brackets_the_yielded_count() {
+        // A complete four-byte sequence followed by a lead byte whose
+        // continuation bytes run past the end: five bytes, two codepoints.
+        let cases: &[&[u8]] = &[
+            b"",
+            b"a",
+            &[0xF0, 0x41, 0x41, 0x41, 0xF0],
+            &[0xC3],
+            &[b'a', 0xE2, 0x82],
+            "Héllo Wörld".as_bytes(),
+            &[0xF0, 0x9F, 0x98, 0x80],
+        ];
+
+        for bytes in cases {
+            let (lower, upper) = Codepoints::new(bytes).size_hint();
+            let count = Codepoints::new(bytes).count();
+            assert!(
+                lower <= count && count <= upper.expect("the upper bound is always known"),
+                "size_hint {:?} does not bracket {count} for {bytes:?}",
+                (lower, upper),
+            );
+        }
+    }
 }

--- a/src/redisearch_rs/string_utils/src/runes.rs
+++ b/src/redisearch_rs/string_utils/src/runes.rs
@@ -31,14 +31,19 @@ pub struct RuneStrTooLong {
 /// Returns [`Err(`[`RuneStrTooLong`]`)`] if the resulting rune count exceeds
 /// [`MAX_RUNE_STR_LEN`].
 pub fn str_to_lower_runes(s: &str) -> Result<Vec<u16>, RuneStrTooLong> {
-    let runes: Vec<u16> = s
-        .chars()
-        .flat_map(char::to_lowercase)
-        .map(|c| c as u16)
-        .collect();
-    if runes.len() > MAX_RUNE_STR_LEN {
-        return Err(RuneStrTooLong { len: runes.len() });
+    // Measure the folded length first, in a single non-allocating pass, and
+    // reject an over-limit string before allocating a buffer proportional to it.
+    // A caller-supplied wildcard token can be arbitrarily long, so allocating
+    // the full rune vector just to discover it exceeds the limit would waste
+    // memory proportional to the input. This mirrors the C `strToLowerRunes`,
+    // which measures with `nu_strtransformnlen` before allocating.
+    let len = s.chars().flat_map(char::to_lowercase).count();
+    if len > MAX_RUNE_STR_LEN {
+        return Err(RuneStrTooLong { len });
     }
+    // The measured length is exact, so the buffer is sized once and never grown.
+    let mut runes = Vec::with_capacity(len);
+    runes.extend(s.chars().flat_map(char::to_lowercase).map(|c| c as u16));
     Ok(runes)
 }
 

--- a/src/redisearch_rs/string_utils/src/runes.rs
+++ b/src/redisearch_rs/string_utils/src/runes.rs
@@ -41,3 +41,59 @@ pub fn str_to_lower_runes(s: &str) -> Result<Vec<u16>, RuneStrTooLong> {
     }
     Ok(runes)
 }
+
+/// Convert a rune slice into an owned UTF-8 byte string.
+///
+/// Returns [`None`] when the slice is longer than [`MAX_RUNE_STR_LEN`] runes.
+pub fn runes_to_utf8(runes: &[u16]) -> Option<Vec<u8>> {
+    if runes.len() > MAX_RUNE_STR_LEN {
+        return None;
+    }
+    // A rune encodes to at most three bytes, and the slice is already known to
+    // be within `MAX_RUNE_STR_LEN`, so reserving the worst case costs at most a
+    // few kilobytes and removes the growth entirely.
+    let mut bytes = Vec::with_capacity(runes.len() * 3);
+    for &rune in runes {
+        // Encoding stops at the first `0` rune: keys are stored NUL-terminated,
+        // so a `0` marks the end of the string and any runes past it are ignored.
+        if rune == 0 {
+            break;
+        }
+        // Each rune is a UTF-16 code unit widened to its codepoint and UTF-8
+        // encoded directly.
+        let cp = rune as u32;
+        match cp {
+            0x0000..=0x007F => bytes.push(cp as u8),
+            // `0x0080..=0x07FF`: encoded as two bytes, splitting the 11 payload
+            // bits into a `110xxxxx` lead byte and a `10xxxxxx` continuation byte.
+            0x0080..=0x07FF => {
+                bytes.push(0xC0 | (cp >> 6) as u8);
+                bytes.push(0x80 | (cp & 0x3F) as u8);
+            }
+            // `0x0800..=0xFFFF`, including the surrogate range (`0xD800..=0xDFFF`,
+            // produced when an astral-plane codepoint was truncated to `u16` at
+            // index time): encoded to its 3-byte form, not rejected, so the
+            // reconstructed key stays matchable against the inverted index. Lone
+            // surrogates are not valid Unicode scalar values, so `char` / `String`
+            // cannot represent them and the bytes are assembled by hand rather
+            // than via `char::encode_utf8`.
+            _ => {
+                bytes.push(0xE0 | (cp >> 12) as u8);
+                bytes.push(0x80 | ((cp >> 6) & 0x3F) as u8);
+                bytes.push(0x80 | (cp & 0x3F) as u8);
+            }
+        }
+    }
+    Some(bytes)
+}
+
+/// Like [`runes_to_utf8`], but hands back an owned [`String`].
+///
+/// Returns [`None`] when the reconstructed bytes are not valid UTF-8 — which
+/// happens exactly when a rune lies in the surrogate range `0xD800..=0xDFFF`,
+/// where [`runes_to_utf8`] emits (technically ill-formed) WTF-8 bytes that
+/// a [`String`] cannot hold — or when the slice is longer than
+/// [`MAX_RUNE_STR_LEN`] runes.
+pub fn runes_to_string(runes: &[u16]) -> Option<String> {
+    String::from_utf8(runes_to_utf8(runes)?).ok()
+}

--- a/src/redisearch_rs/string_utils/src/runes.rs
+++ b/src/redisearch_rs/string_utils/src/runes.rs
@@ -97,3 +97,94 @@ pub fn runes_to_utf8(runes: &[u16]) -> Option<Vec<u8>> {
 pub fn runes_to_string(runes: &[u16]) -> Option<String> {
     String::from_utf8(runes_to_utf8(runes)?).ok()
 }
+
+/// Decode a byte string into the runes ([`u16`]) a term was indexed under,
+/// reproducing the C `strToRunesN` conversion the trie is built with.
+///
+/// Two kinds of input reach this decoder and both must map to the same rune key
+/// the term was stored under:
+/// - A **rune-encoded (WTF-8) key** — the inverse of [`runes_to_utf8`] — whose
+///   codepoints are all `0x0000..=0xFFFF`, so it is at most three bytes per rune,
+///   **including lone surrogates** (`0xD800..=0xDFFF`, which valid UTF-8 forbids
+///   but which appear when a non-BMP codepoint was truncated to [`u16`] at index
+///   time).
+/// - A **raw query token** typed by the user, which may contain a genuine
+///   four-byte (non-BMP) sequence — e.g. an emoji. The index stored such a term
+///   by truncating each codepoint to [`u16`] (`strToRunesN` does `(rune)cp`), so
+///   this decoder truncates the four-byte codepoint the same way, letting the
+///   query resolve to the same key instead of silently missing it.
+///
+/// Unlike a UTF-8-validating decode, this recovers the same runes the term was
+/// stored under, so a surrogate-bearing key still matches.
+///
+/// The sequence width is classified from the lead byte by the same ranges C's
+/// `nu_utf8_read` uses — `0x00..=0x7F` → 1 byte, `0x80..=0xDF` → 2, `0xE0..=0xEF`
+/// → 3, `0xF0..=0xFF` → 4 — **not** by the stricter `110xxxxx`/`11110xxx` bit
+/// prefixes. So a byte the strict tests reject (a bare continuation byte or an
+/// `0xF8..=0xFF` lead) is still consumed as a multi-byte sequence, matching how
+/// the C indexer decoded it; classifying it as malformed here would make such a
+/// key unlookable.
+///
+/// Continuation bytes are likewise **not** validated to be of the `10xxxxxx`
+/// form: each is masked (`& 0x3F`) and folded into the codepoint unconditionally,
+/// exactly as `nu_utf8_read` does. So `[0xC3, b'(']` decodes to the same rune the
+/// C indexer would have produced (`0x00E8`) rather than stopping. Validating
+/// either the lead or the continuation bytes would diverge from how terms are
+/// actually stored.
+///
+/// Decoding stops only at the first NUL codepoint (keys are NUL-terminated) and
+/// at a *truncated* sequence — a lead byte whose continuation bytes run past the
+/// end of `bytes` (the one place this is stricter than the C decoder, which would
+/// read past its buffer); no read ever crosses that end.
+pub fn utf8_to_runes(bytes: &[u8]) -> Vec<u16> {
+    let mut runes = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        // Classify the width from the lead byte using C `nu_utf8_read`'s ranges.
+        let width = if b < 0x80 {
+            1
+        } else if b < 0xE0 {
+            2
+        } else if b < 0xF0 {
+            3
+        } else {
+            4
+        };
+        // A sequence whose continuation bytes run past the end of `bytes` is
+        // truncated: stop rather than read out of bounds (C would read past its
+        // buffer here).
+        if i + width > bytes.len() {
+            break;
+        }
+        // Decode the codepoint, masking continuation bytes with `& 0x3F` exactly
+        // as `nu_utf8_read` does, then truncate to `u16` as `strToRunesN`'s
+        // `(rune)cp` does — so the recovered runes match the key the trie was
+        // built under (a non-BMP codepoint folds to its low 16 bits).
+        let codepoint: u32 = match width {
+            1 => u32::from(b),
+            2 => (u32::from(b) & 0x1F) << 6 | (u32::from(bytes[i + 1]) & 0x3F),
+            3 => {
+                (u32::from(b) & 0x0F) << 12
+                    | (u32::from(bytes[i + 1]) & 0x3F) << 6
+                    | (u32::from(bytes[i + 2]) & 0x3F)
+            }
+            _ => {
+                (u32::from(b) & 0x07) << 18
+                    | (u32::from(bytes[i + 1]) & 0x3F) << 12
+                    | (u32::from(bytes[i + 2]) & 0x3F) << 6
+                    | (u32::from(bytes[i + 3]) & 0x3F)
+            }
+        };
+        // Keys are NUL-terminated; a `0` codepoint marks the end of the string.
+        // Test the full codepoint before truncating, as `strToRunesN` does — a
+        // four-byte codepoint is never `0`, so it is never mistaken for a
+        // terminator.
+        if codepoint == 0 {
+            break;
+        }
+        runes.push(codepoint as u16);
+        i += width;
+    }
+    runes
+}

--- a/src/redisearch_rs/string_utils/src/tag.rs
+++ b/src/redisearch_rs/string_utils/src/tag.rs
@@ -21,13 +21,13 @@ const fn is_c_space(b: u8) -> bool {
     matches!(b, b' ' | b'\t' | b'\n' | b'\r' | b'\x0B' | b'\x0C')
 }
 
-/// Remove tag escape sequences and optionally convert to lowercase.
+/// Normalise a tag value into the form it is indexed and looked up under.
 ///
 /// 1. Strips backslash escapes that precede ASCII punctuation or whitespace.
 /// 2. If `case_sensitive` is `false`, converts the result to lowercase using
 ///    [`unicode::tolower`](crate::unicode::tolower) (per-character, no
 ///    context-dependent rules).
-pub fn strtolower(s: &str, case_sensitive: bool) -> Cow<'_, str> {
+pub fn normalize(s: &str, case_sensitive: bool) -> Cow<'_, str> {
     let bytes = s.as_bytes();
     // Only `\` before ASCII punctuation or C-locale whitespace counts as
     // an escape; `\` before a letter (e.g. `\n` as two literal bytes) is

--- a/src/redisearch_rs/string_utils/tests/integration/main.rs
+++ b/src/redisearch_rs/string_utils/tests/integration/main.rs
@@ -17,4 +17,5 @@ mod str_to_lower_runes;
 mod tag_normalize;
 mod unicode_tolower;
 mod unicode_tolower_capped;
+mod utf8_to_lower_runes;
 mod utf8_to_runes;

--- a/src/redisearch_rs/string_utils/tests/integration/main.rs
+++ b/src/redisearch_rs/string_utils/tests/integration/main.rs
@@ -11,6 +11,8 @@
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 extern crate redisearch_rs;
 
+mod runes_to_string;
+mod runes_to_utf8;
 mod str_to_lower_runes;
 mod tag_strtolower;
 mod unicode_tolower;

--- a/src/redisearch_rs/string_utils/tests/integration/main.rs
+++ b/src/redisearch_rs/string_utils/tests/integration/main.rs
@@ -14,7 +14,7 @@ extern crate redisearch_rs;
 mod runes_to_string;
 mod runes_to_utf8;
 mod str_to_lower_runes;
-mod tag_strtolower;
+mod tag_normalize;
 mod unicode_tolower;
 mod unicode_tolower_capped;
 mod utf8_to_runes;

--- a/src/redisearch_rs/string_utils/tests/integration/main.rs
+++ b/src/redisearch_rs/string_utils/tests/integration/main.rs
@@ -17,3 +17,4 @@ mod str_to_lower_runes;
 mod tag_strtolower;
 mod unicode_tolower;
 mod unicode_tolower_capped;
+mod utf8_to_runes;

--- a/src/redisearch_rs/string_utils/tests/integration/runes_to_string.rs
+++ b/src/redisearch_rs/string_utils/tests/integration/runes_to_string.rs
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use string_utils::runes::{MAX_RUNE_STR_LEN, runes_to_string};
+
+/// Widen each character of `s` to a single rune, without lowercasing.
+fn runes(s: &str) -> Vec<u16> {
+    s.chars().map(|c| c as u16).collect()
+}
+
+#[test]
+fn ascii() {
+    assert_eq!(runes_to_string(&runes("abc")).unwrap(), "abc");
+}
+
+#[test]
+fn empty() {
+    assert_eq!(runes_to_string(&[]).unwrap(), "");
+}
+
+#[test]
+fn bmp_non_ascii() {
+    // `é` (U+00E9) and `€` (U+20AC) are BMP scalar values, so the widened runes
+    // round-trip back to the original string.
+    let s = "é€";
+    assert_eq!(runes_to_string(&runes(s)).unwrap(), s);
+}
+
+#[test]
+fn surrogate_is_rejected() {
+    // A lone surrogate (U+D800) is a valid rune but not a valid Unicode scalar
+    // value, so the reconstructed bytes are not valid UTF-8. Unlike
+    // `runes_to_utf8` (which yields the 3-byte WTF-8 form), the `String`
+    // variant returns `None` rather than an ill-formed string.
+    assert_eq!(runes_to_string(&[0xD800]), None);
+}
+
+#[test]
+fn too_long_returns_none() {
+    let too_long = vec![b'a' as u16; MAX_RUNE_STR_LEN + 1];
+    assert!(runes_to_string(&too_long).is_none());
+}
+
+#[test]
+fn stops_at_first_null_rune() {
+    // Inherited from `runes_to_utf8`: a `0` rune ends the string.
+    assert_eq!(
+        runes_to_string(&[b'a' as u16, 0, b'b' as u16]).unwrap(),
+        "a"
+    );
+}
+
+/// Compare `runes_to_string` against the real C `runesToStr`, which is the
+/// routine it reimplements. Only exercised for scalar-value runes (no
+/// surrogates), the domain where a `String` result is defined.
+#[cfg(not(miri))]
+mod ffi_comparison {
+    use proptest::prelude::*;
+    use std::ffi::c_void;
+    use string_utils::runes::runes_to_string;
+
+    /// Call C `runesToStr` via FFI and return the UTF-8 bytes it produced, or
+    /// `None` when it returns NULL (the slice exceeds `MAX_RUNE_STR_LEN`).
+    fn c_runes_to_str(runes: &[u16]) -> Option<Vec<u8>> {
+        let mut len: usize = 0;
+        // SAFETY: `runes` is a valid slice of `runes.len()` runes; `runesToStr`
+        // returns a freshly `rm_calloc`'d, NUL-terminated buffer of `len` bytes,
+        // or NULL.
+        let ptr = unsafe { ffi::runesToStr(runes.as_ptr(), runes.len(), &mut len) };
+        if ptr.is_null() {
+            return None;
+        }
+        // SAFETY: `ptr` points to `len` valid bytes.
+        let bytes = unsafe { std::slice::from_raw_parts(ptr.cast::<u8>(), len) }.to_vec();
+        // SAFETY: `RedisModule_Free` is a `static mut` set by the test harness and
+        // not mutated concurrently.
+        let rm_free = unsafe { ffi::RedisModule_Free.expect("Redis allocator not available") };
+        // SAFETY: `ptr` was allocated by `rm_calloc` (backed by RedisModule_Alloc).
+        unsafe { rm_free(ptr.cast::<c_void>()) };
+        Some(bytes)
+    }
+
+    fn assert_matches_c(runes: &[u16]) {
+        let c_bytes = c_runes_to_str(runes).expect("FFI runesToStr returned NULL unexpectedly");
+        let rust = runes_to_string(runes).expect("runes_to_string returned None unexpectedly");
+        assert_eq!(
+            rust.as_bytes(),
+            c_bytes.as_slice(),
+            "mismatch for runes {runes:?}: rust={:?}, c={c_bytes:?}",
+            rust.as_bytes(),
+        );
+    }
+
+    #[test]
+    fn ffi_ascii() {
+        assert_matches_c(&[b'A' as u16, b'b' as u16, b'C' as u16]);
+    }
+
+    #[test]
+    fn ffi_empty() {
+        assert_matches_c(&[]);
+    }
+
+    #[test]
+    fn ffi_bmp_non_ascii() {
+        // "Héllo Wörld" widened to runes.
+        assert_matches_c(&"Héllo Wörld".chars().map(|c| c as u16).collect::<Vec<_>>());
+    }
+
+    /// Generate rune slices of BMP scalar values (excluding the surrogate range
+    /// `0xD800..=0xDFFF`), up to `MAX_RUNE_STR_LEN` long.
+    fn scalar_runes() -> impl Strategy<Value = Vec<u16>> {
+        proptest::collection::vec(prop_oneof![0x0000u16..=0xD7FF, 0xE000u16..=0xFFFF], 0..=128)
+    }
+
+    proptest! {
+        #[test]
+        fn matches_c(runes in scalar_runes()) {
+            assert_matches_c(&runes);
+        }
+    }
+}

--- a/src/redisearch_rs/string_utils/tests/integration/runes_to_utf8.rs
+++ b/src/redisearch_rs/string_utils/tests/integration/runes_to_utf8.rs
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use string_utils::runes::{MAX_RUNE_STR_LEN, runes_to_utf8, str_to_lower_runes};
+
+/// Widen each character of `s` to a single rune, without lowercasing — the
+/// inverse of what [`runes_to_utf8`] reconstructs for BMP input.
+fn runes(s: &str) -> Vec<u16> {
+    s.chars().map(|c| c as u16).collect()
+}
+
+#[test]
+fn ascii_round_trips() {
+    assert_eq!(runes_to_utf8(&runes("abc")).unwrap(), b"abc");
+}
+
+#[test]
+fn empty_yields_empty_string() {
+    assert_eq!(runes_to_utf8(&[]).unwrap(), Vec::<u8>::new());
+}
+
+#[test]
+fn bmp_non_ascii_round_trips() {
+    // `é` (U+00E9) and `€` (U+20AC) are BMP codepoints that fit a single rune,
+    // so widening then UTF-8 encoding reproduces the original bytes.
+    let s = "é€";
+    assert_eq!(runes_to_utf8(&runes(s)).unwrap(), s.as_bytes());
+}
+
+#[test]
+fn inverts_str_to_lower_runes() {
+    // Lowercasing to runes and back reconstructs the lowercased string's bytes.
+    let s = "Héllo Wörld";
+    let lowered: String = s.chars().flat_map(char::to_lowercase).collect();
+    let recovered = runes_to_utf8(&str_to_lower_runes(s).unwrap()).unwrap();
+    assert_eq!(recovered, lowered.as_bytes());
+}
+
+#[test]
+fn surrogate_rune_is_encoded_not_rejected() {
+    // A lone surrogate (U+D800) is not a valid Unicode scalar value, but it is a
+    // valid rune — produced when an astral-plane codepoint is truncated to `u16`
+    // at index time. It must be encoded to its 3-byte UTF-8 form (so the key
+    // still matches the index), not rejected.
+    assert_eq!(runes_to_utf8(&[0xD800]).unwrap(), vec![0xED, 0xA0, 0x80]);
+}
+
+#[test]
+fn too_long_returns_none() {
+    // Beyond the maximum rune length the conversion cannot be performed and
+    // returns `None` rather than a truncated string.
+    let too_long = vec![b'a' as u16; MAX_RUNE_STR_LEN + 1];
+    assert!(runes_to_utf8(&too_long).is_none());
+}
+
+#[test]
+fn stops_at_first_null_rune() {
+    // Keys are stored NUL-terminated, so a `0` rune ends the string and any
+    // runes after it are ignored — matching C `runesToStr`.
+    assert_eq!(runes_to_utf8(&[b'a' as u16, 0, b'b' as u16]).unwrap(), b"a");
+    assert_eq!(runes_to_utf8(&[0]).unwrap(), Vec::<u8>::new());
+}
+
+/// Compare the hand-rolled encoder against the real C `runesToStr`, which is the
+/// routine it reimplements. Covers every rune value including the surrogate
+/// range, where both must emit identical 3-byte WTF-8 output.
+#[cfg(not(miri))]
+mod ffi_comparison {
+    use proptest::prelude::*;
+    use std::ffi::c_void;
+    use string_utils::runes::runes_to_utf8;
+
+    /// Call C `runesToStr` via FFI and return the bytes it produced, or `None`
+    /// when it returns NULL (the slice exceeds `MAX_RUNE_STR_LEN`).
+    fn c_runes_to_str(runes: &[u16]) -> Option<Vec<u8>> {
+        let mut len: usize = 0;
+        // SAFETY: `runes` is a valid slice of `runes.len()` runes; `runesToStr`
+        // returns a freshly `rm_calloc`'d, NUL-terminated buffer of `len` bytes,
+        // or NULL.
+        let ptr = unsafe { ffi::runesToStr(runes.as_ptr(), runes.len(), &mut len) };
+        if ptr.is_null() {
+            return None;
+        }
+        // SAFETY: `ptr` points to `len` valid bytes.
+        let bytes = unsafe { std::slice::from_raw_parts(ptr.cast::<u8>(), len) }.to_vec();
+        // SAFETY: `RedisModule_Free` is a `static mut` set by the test harness and
+        // not mutated concurrently.
+        let rm_free = unsafe { ffi::RedisModule_Free.expect("Redis allocator not available") };
+        // SAFETY: `ptr` was allocated by `rm_calloc` (backed by RedisModule_Alloc).
+        unsafe { rm_free(ptr.cast::<c_void>()) };
+        Some(bytes)
+    }
+
+    fn assert_matches_c(runes: &[u16]) {
+        let c_bytes = c_runes_to_str(runes).expect("FFI runesToStr returned NULL unexpectedly");
+        let rust = runes_to_utf8(runes).expect("runes_to_utf8 returned None");
+        assert_eq!(rust, c_bytes, "mismatch for runes {runes:?}");
+    }
+
+    #[test]
+    fn ffi_surrogate() {
+        assert_matches_c(&[0xD800]);
+    }
+
+    proptest! {
+        // Any rune value, surrogates included, up to `MAX_RUNE_STR_LEN` long.
+        #[test]
+        fn matches_c(runes in proptest::collection::vec(any::<u16>(), 0..=128)) {
+            assert_matches_c(&runes);
+        }
+    }
+}

--- a/src/redisearch_rs/string_utils/tests/integration/tag_normalize.rs
+++ b/src/redisearch_rs/string_utils/tests/integration/tag_normalize.rs
@@ -11,65 +11,65 @@ use string_utils::tag;
 
 #[test]
 fn unescape_punct() {
-    assert_eq!(tag::strtolower("hello\\!world", false), "hello!world");
+    assert_eq!(tag::normalize("hello\\!world", false), "hello!world");
 }
 
 #[test]
 fn unescape_space() {
-    assert_eq!(tag::strtolower("hello\\ world", false), "hello world");
+    assert_eq!(tag::normalize("hello\\ world", false), "hello world");
 }
 
 #[test]
 fn no_unescape_alpha() {
-    assert_eq!(tag::strtolower("hello\\nworld", false), "hello\\nworld");
+    assert_eq!(tag::normalize("hello\\nworld", false), "hello\\nworld");
 }
 
 #[test]
 fn case_sensitive() {
-    assert_eq!(tag::strtolower("Hello\\!World", true), "Hello!World");
+    assert_eq!(tag::normalize("Hello\\!World", true), "Hello!World");
 }
 
 #[test]
 fn case_insensitive() {
-    assert_eq!(tag::strtolower("Hello\\!World", false), "hello!world");
+    assert_eq!(tag::normalize("Hello\\!World", false), "hello!world");
 }
 
 #[test]
 fn empty() {
-    assert_eq!(tag::strtolower("", false), "");
+    assert_eq!(tag::normalize("", false), "");
 }
 
 #[test]
 fn trailing_backslash() {
-    assert_eq!(tag::strtolower("abc\\", false), "abc\\");
+    assert_eq!(tag::normalize("abc\\", false), "abc\\");
 }
 
 #[test]
 fn unescape_vertical_tab() {
     // Vertical tab (0x0B) is whitespace per C isspace() — must be unescaped.
-    assert_eq!(tag::strtolower("hello\\\x0Bworld", false), "hello\x0Bworld");
+    assert_eq!(tag::normalize("hello\\\x0Bworld", false), "hello\x0Bworld");
 }
 
 #[test]
 fn consecutive_escapes() {
     // `\\!` = bytes [0x5C, 0x5C, 0x21]: first `\` is removed (next is
     // punct `\`), second `\` and `!` are kept — matches C behavior.
-    assert_eq!(tag::strtolower("\\\\!", false), "\\!");
+    assert_eq!(tag::normalize("\\\\!", false), "\\!");
 }
 
 #[test]
 fn escaped_backslash_before_alpha() {
     // `\\n` = bytes [0x5C, 0x5C, 0x6E]: first `\` removed (next is punct
     // `\`), second `\` kept, `n` is not punct/space so kept verbatim.
-    assert_eq!(tag::strtolower("\\\\n", false), "\\n");
+    assert_eq!(tag::normalize("\\\\n", false), "\\n");
 }
 
 #[test]
 fn sigma_lowercased_per_character() {
     // Per-character lowercasing: Σ always maps to σ (no context-dependent
     // final-sigma rule), matching the C `unicode_tolower` behaviour.
-    assert_eq!(tag::strtolower("ΣΣΣΣΣ", false), "σσσσσ");
-    assert_eq!(tag::strtolower("ΝΕΑΝΊΑΣ", false), "νεανίασ");
+    assert_eq!(tag::normalize("ΣΣΣΣΣ", false), "σσσσσ");
+    assert_eq!(tag::normalize("ΝΕΑΝΊΑΣ", false), "νεανίασ");
 }
 
 #[test]
@@ -78,14 +78,14 @@ fn case_insensitive_matches_unicode_tolower() {
 
     for s in ["ΣΣΣΣΣ", "ΝΕΑΝΊΑΣ", "Straße", "HELLO", "σίγμα"] {
         assert_eq!(
-            tag::strtolower(s, false),
+            tag::normalize(s, false),
             unicode::tolower(s),
-            "tag::strtolower({s:?}, false) != unicode::tolower",
+            "tag::normalize({s:?}, false) != unicode::tolower",
         );
     }
 }
 
-// Compare Rust tag_strtolower against C tag_strtolower via FFI.
+// Compare Rust `tag::normalize` against C `tag_strtolower` via FFI.
 // The C function may rm_free/rm_malloc *pstr, so input must be
 // allocated with the Redis allocator.
 #[cfg(not(miri))]
@@ -131,7 +131,7 @@ mod ffi_comparison {
 
     fn assert_tag_matches_c(s: &str, case_sensitive: bool) {
         let c_result = c_tag_strtolower(s, case_sensitive);
-        let rust_result = tag::strtolower(s, case_sensitive);
+        let rust_result = tag::normalize(s, case_sensitive);
         assert_eq!(
             rust_result, c_result,
             "mismatch for input {:?} (case_sensitive={}): rust={:?}, c={:?}",
@@ -231,7 +231,7 @@ mod proptest_checks {
     proptest! {
         #[test]
         fn case_insensitive_is_lowercase(s in tag_input()) {
-            let result = tag::strtolower(&s, false);
+            let result = tag::normalize(&s, false);
             assert_eq!(
                 result,
                 result.to_lowercase(),
@@ -242,12 +242,12 @@ mod proptest_checks {
 
         #[test]
         fn case_sensitive_then_lower_eq_case_insensitive(s in tag_input()) {
-            let sensitive = tag::strtolower(&s, true);
+            let sensitive = tag::normalize(&s, true);
             let then_lower = unicode::tolower(&sensitive);
-            let insensitive = tag::strtolower(&s, false);
+            let insensitive = tag::normalize(&s, false);
             assert_eq!(
                 then_lower, insensitive,
-                "unicode_tolower(tag::strtolower(s, true)) != tag::strtolower(s, false) for {:?}",
+                "unicode::tolower(tag::normalize(s, true)) != tag::normalize(s, false) for {:?}",
                 s
             );
         }

--- a/src/redisearch_rs/string_utils/tests/integration/utf8_to_lower_runes.rs
+++ b/src/redisearch_rs/string_utils/tests/integration/utf8_to_lower_runes.rs
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use string_utils::runes::{MAX_RUNE_STR_LEN, runes_to_utf8, utf8_to_lower_runes};
+
+#[test]
+fn ascii_lowercases() {
+    let expected: Vec<u16> = "hello".encode_utf16().collect();
+    assert_eq!(utf8_to_lower_runes(b"HeLLo").unwrap(), expected);
+}
+
+#[test]
+fn empty_yields_empty() {
+    assert_eq!(utf8_to_lower_runes(b"").unwrap(), Vec::<u16>::new());
+}
+
+#[test]
+fn bmp_non_ascii_lowercases() {
+    // `Ä` (U+00C4) folds to `ä` (U+00E4), `Ω` (U+03A9) to `ω` (U+03C9).
+    assert_eq!(
+        utf8_to_lower_runes("ÄΩ".as_bytes()).unwrap(),
+        vec![0x00E4, 0x03C9]
+    );
+}
+
+#[test]
+fn malformed_sequence_decodes_leniently() {
+    // `[0xC3, b'(']` is not valid UTF-8, but the trie's keys were built with a
+    // decoder that masks continuation bytes unconditionally: it yields
+    // (0xC3 & 0x1F) << 6 | (0x28 & 0x3F) = 0x00E8, which is already lowercase.
+    // A validating decode would substitute U+FFFD here and look up a key that
+    // was never stored.
+    assert_eq!(utf8_to_lower_runes(&[0xC3, b'(']).unwrap(), vec![0x00E8]);
+}
+
+#[test]
+fn surrogate_bytes_are_preserved() {
+    // WTF-8 bytes for a lone surrogate, as emitted for a non-BMP codepoint that
+    // was truncated to a rune at index time. The surrogate has no case mapping
+    // and must survive the fold to resolve the key it was stored under.
+    let bytes = runes_to_utf8(&[0xD800]).unwrap();
+    assert_eq!(utf8_to_lower_runes(&bytes).unwrap(), vec![0xD800]);
+}
+
+#[test]
+fn out_of_range_lead_byte_is_consumed() {
+    // A `0xF8..=0xFF` lead is a 4-byte start for this decoder, not a malformed
+    // byte: 0xF8 0x81 0x82 0x83 -> (0x81 & 0x3F) << 12 | (0x82 & 0x3F) << 6
+    // | (0x83 & 0x3F) = 0x1083, which is already lowercase.
+    assert_eq!(
+        utf8_to_lower_runes(&[0xF8, 0x81, 0x82, 0x83]).unwrap(),
+        vec![0x1083]
+    );
+}
+
+#[test]
+fn folds_before_truncating_to_a_rune() {
+    // `𐐀` (U+10400, DESERET CAPITAL LETTER LONG I) folds to U+10428, whose low
+    // 16 bits are 0x0428. Truncating to a rune first would instead fold U+0400
+    // to U+0450 and yield 0x0450 — a different key.
+    assert_eq!(utf8_to_lower_runes("𐐀".as_bytes()).unwrap(), vec![0x0428]);
+}
+
+#[test]
+fn stops_at_first_nul_codepoint() {
+    // A term is stored under the runes up to its first NUL codepoint, so the key
+    // stops there too; the `B` after the literal NUL is not part of the key.
+    assert_eq!(utf8_to_lower_runes(b"a\0B").unwrap(), vec![u16::from(b'a')]);
+}
+
+#[test]
+fn stops_at_decoded_nul_before_end() {
+    // The stop is on the decoded codepoint, so a sequence that decodes to `0`
+    // without being a literal NUL byte — the overlong encoding `[0xC0, 0x80]` —
+    // ends the key just the same, and the trailing bytes are not decoded.
+    assert_eq!(
+        utf8_to_lower_runes(&[b'a', 0xC0, 0x80, b'b', b'c']).unwrap(),
+        vec![u16::from(b'a')]
+    );
+}
+
+#[test]
+fn truncated_trailing_sequence_zero_fills() {
+    // A lead byte whose continuation bytes run past the end still yields a rune,
+    // its missing bytes taken as zero — the terminator byte the C decoder reads
+    // there. Dropping the sequence would leave an empty key, which as a prefix
+    // matches every term instead of the one it names.
+    // `[0xE2, 0x82]` -> (0xE2 & 0x0F) << 12 | (0x82 & 0x3F) << 6 = 0x2080, which
+    // has no case mapping.
+    assert_eq!(
+        utf8_to_lower_runes(&[b'a', 0xE2, 0x82]).unwrap(),
+        vec![u16::from(b'a'), 0x2080]
+    );
+    // `[0xC3]` -> (0xC3 & 0x1F) << 6 = 0x00C0 (`À`), which folds to 0x00E0 (`à`).
+    assert_eq!(utf8_to_lower_runes(&[0xC3]).unwrap(), vec![0x00E0]);
+}
+
+#[test]
+fn at_and_over_the_maximum_length() {
+    let at_max = vec![b'a'; MAX_RUNE_STR_LEN];
+    assert_eq!(
+        utf8_to_lower_runes(&at_max).unwrap().len(),
+        MAX_RUNE_STR_LEN
+    );
+
+    let over_max = vec![b'a'; MAX_RUNE_STR_LEN + 1];
+    let err = utf8_to_lower_runes(&over_max).expect_err("exceeds the maximum rune length");
+    assert_eq!(err.len, MAX_RUNE_STR_LEN + 1);
+}
+
+#[test]
+fn length_is_measured_after_folding() {
+    // `İ` (U+0130) folds to two codepoints, so a string that fits the limit
+    // before folding can exceed it after.
+    let input = "İ".repeat(MAX_RUNE_STR_LEN / 2 + 1);
+    let err = utf8_to_lower_runes(input.as_bytes()).expect_err("folded form exceeds the maximum");
+    assert!(err.len > MAX_RUNE_STR_LEN);
+}
+
+/// Compare against the real C `strToLowerRunes`, which is the routine this
+/// reimplements, over binary-safe input including sequences a validating UTF-8
+/// decoder would reject.
+#[cfg(not(miri))]
+mod ffi_comparison {
+    use proptest::prelude::*;
+    use std::ffi::c_void;
+    use string_utils::runes::utf8_to_lower_runes;
+
+    /// Call C `strToLowerRunes` via FFI and return the resulting rune slice, or
+    /// `None` when it returns NULL (the folded form exceeds `MAX_RUNE_STR_LEN`).
+    ///
+    /// The token is handed over NUL-terminated with three spare terminator
+    /// bytes, exactly as the query layer stores it. C classifies a sequence's
+    /// width from its lead byte and reads that many bytes without
+    /// bounds-checking, so a truncated trailing sequence reads terminators; the
+    /// spares keep even a four-byte lead inside the allocation while `len` still
+    /// describes the token itself. That is what [`utf8_to_lower_runes`]
+    /// reproduces by taking a missing continuation byte as zero, so truncated
+    /// input can be compared directly rather than padded away.
+    ///
+    /// One constraint remains on `bytes`: no sequence in it may decode to
+    /// codepoint `0`. This conversion stops at the first such codepoint, matching
+    /// how a term is indexed, while the C routine in this branch's base does not
+    /// yet; a separate change reconciles them. It is a property of the *decoded*
+    /// text, not of the bytes: `[0xA0, 0x40]` holds no NUL byte and still decodes
+    /// to `0`. Until that change is in the base, such input is excluded from the
+    /// comparison; afterwards the two agree and the exclusion should go away.
+    fn c_str_to_lower_runes(bytes: &[u8]) -> Option<Vec<u16>> {
+        let mut unicode_len: usize = 0;
+        let mut buf = bytes.to_vec();
+        buf.extend_from_slice(&[0, 0, 0]);
+        // SAFETY: `buf` holds `bytes` followed by three NUL bytes, so a sequence
+        // starting anywhere within the first `bytes.len()` bytes — at most four
+        // bytes wide — stays inside the allocation. `strToLowerRunes` returns a
+        // freshly `rm_calloc`'d array of `unicode_len` runes, or NULL.
+        let ptr =
+            unsafe { ffi::strToLowerRunes(buf.as_ptr().cast(), bytes.len(), &mut unicode_len) };
+        if ptr.is_null() {
+            return None;
+        }
+        // SAFETY: `ptr` is a valid `rm_calloc`'d array of `unicode_len` runes.
+        let runes = unsafe { std::slice::from_raw_parts(ptr, unicode_len) }.to_vec();
+        // SAFETY: `RedisModule_Free` is a `static mut` set by the test harness and
+        // not mutated concurrently.
+        let rm_free = unsafe { ffi::RedisModule_Free.expect("Redis allocator not available") };
+        // SAFETY: `ptr` was allocated by `rm_calloc` (backed by RedisModule_Alloc).
+        unsafe { rm_free(ptr.cast::<c_void>()) };
+        Some(runes)
+    }
+
+    /// Whether `bytes` decodes to a `0` codepoint anywhere — the input excluded
+    /// from the oracle comparison, see [`c_str_to_lower_runes`].
+    ///
+    /// Detected with an independent lenient decode (the same lead-byte ranges the
+    /// conversion uses), because [`utf8_to_lower_runes`] now stops at the first
+    /// such codepoint and so no longer surfaces it. The test is on the decoded
+    /// codepoint, before truncation: a `0` *rune* produced by truncating a
+    /// non-zero codepoint (`U+10000`) is not a `0` *codepoint*, and the C routine
+    /// is fine with it. Delete this together with the exclusions once the base
+    /// carries the reconciling change.
+    fn decodes_a_nul(bytes: &[u8]) -> bool {
+        let mut i = 0;
+        while i < bytes.len() {
+            let b = bytes[i];
+            let width = if b < 0x80 {
+                1
+            } else if b < 0xE0 {
+                2
+            } else if b < 0xF0 {
+                3
+            } else {
+                4
+            };
+            // A continuation byte past the end is taken as zero, matching the
+            // conversion and the terminator the C decoder reads there.
+            let cont = |k: usize| u32::from(bytes.get(i + k).copied().unwrap_or(0)) & 0x3F;
+            let cp = match width {
+                1 => u32::from(b),
+                2 => (u32::from(b) & 0x1F) << 6 | cont(1),
+                3 => (u32::from(b) & 0x0F) << 12 | cont(1) << 6 | cont(2),
+                _ => (u32::from(b) & 0x07) << 18 | cont(1) << 12 | cont(2) << 6 | cont(3),
+            };
+            if cp == 0 {
+                return true;
+            }
+            i += width;
+        }
+        false
+    }
+
+    fn assert_matches_c(bytes: &[u8]) {
+        assert!(
+            !decodes_a_nul(bytes),
+            "input decoding to a NUL codepoint is excluded from the oracle comparison",
+        );
+        let c_runes =
+            c_str_to_lower_runes(bytes).expect("FFI strToLowerRunes returned NULL unexpectedly");
+        let rust_runes = utf8_to_lower_runes(bytes).expect("within the maximum rune length");
+        assert_eq!(
+            rust_runes, c_runes,
+            "mismatch for bytes {bytes:?}: rust={rust_runes:?}, c={c_runes:?}",
+        );
+    }
+
+    #[test]
+    fn ffi_ascii() {
+        assert_matches_c(b"ABC");
+    }
+
+    #[test]
+    fn ffi_empty() {
+        assert_matches_c(b"");
+    }
+
+    #[test]
+    fn ffi_bmp_unicode() {
+        assert_matches_c("Héllo Wörld".as_bytes());
+    }
+
+    #[test]
+    fn ffi_malformed_sequence() {
+        assert_matches_c(&[0xC3, b'(']);
+    }
+
+    #[test]
+    fn ffi_surrogate_bytes() {
+        assert_matches_c(&[0xED, 0xA0, 0x80]);
+    }
+
+    #[test]
+    fn ffi_non_bmp() {
+        assert_matches_c("𐐀😀".as_bytes());
+    }
+
+    #[test]
+    fn ffi_truncated_trailing_sequence() {
+        // The token ends on a lead byte whose continuation is missing; C reads
+        // the terminator there, and the conversion supplies the same zero.
+        assert_matches_c(&[0xC3]);
+        assert_matches_c(&[b'a', b'b', 0xC3]);
+        assert_matches_c(&[b'a', 0xE2, 0x82]);
+    }
+
+    proptest! {
+        /// Arbitrary binary input — malformed and truncated sequences included —
+        /// folds to the same runes as the C conversion. Input decoding to a `0`
+        /// codepoint is excluded (see [`c_str_to_lower_runes`]); the NUL byte
+        /// itself is kept out of the generator so the rejection stays rare rather
+        /// than a quarter of all cases. Once the base carries the reconciling
+        /// change, drop the `prop_assume!` and cover them.
+        #[test]
+        fn matches_c(bytes in proptest::collection::vec(1u8..=u8::MAX, 0..64)) {
+            prop_assume!(!decodes_a_nul(&bytes));
+            assert_matches_c(&bytes);
+        }
+    }
+}

--- a/src/redisearch_rs/string_utils/tests/integration/utf8_to_runes.rs
+++ b/src/redisearch_rs/string_utils/tests/integration/utf8_to_runes.rs
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use string_utils::runes::{runes_to_utf8, utf8_to_runes};
+
+#[test]
+fn ascii_round_trips() {
+    assert_eq!(
+        utf8_to_runes(b"abc"),
+        vec![b'a' as u16, b'b' as u16, b'c' as u16]
+    );
+}
+
+#[test]
+fn empty_yields_empty() {
+    assert_eq!(utf8_to_runes(b""), Vec::<u16>::new());
+}
+
+#[test]
+fn two_and_three_byte_bmp() {
+    // `é` (U+00E9, 2-byte) and `€` (U+20AC, 3-byte).
+    assert_eq!(utf8_to_runes("é€".as_bytes()), vec![0x00E9, 0x20AC]);
+}
+
+#[test]
+fn stops_at_nul() {
+    // A NUL byte terminates the key: bytes after it are ignored.
+    assert_eq!(utf8_to_runes(b"ab\0cd"), vec![b'a' as u16, b'b' as u16]);
+}
+
+#[test]
+fn truncated_trailing_sequence_stops() {
+    // A lead byte without its continuation bytes ends the decode without any
+    // out-of-bounds read.
+    assert_eq!(utf8_to_runes(&[b'a', 0xE2, 0x82]), vec![b'a' as u16]);
+    assert_eq!(utf8_to_runes(&[0xC3]), Vec::<u16>::new());
+}
+
+#[test]
+fn lead_byte_width_matches_c_ranges() {
+    // Width is classified by C `nu_utf8_read`'s lead-byte ranges, not the strict
+    // `110xxxxx`/`11110xxx` prefixes. A bare continuation byte (0x80..=0xBF) as a
+    // lead is a 2-byte start in C: `[0x81, 0x81]` -> (0x81 & 0x1F) << 6 | (0x81 &
+    // 0x3F) = 0x41, not a stop.
+    assert_eq!(utf8_to_runes(&[0x81, 0x81]), vec![0x41]);
+    // A 0xF8..=0xFF lead is a 4-byte start in C (truncated to `u16`); it must not
+    // be treated as malformed. For 0xF8 0x81 0x82 0x83 the codepoint is
+    // (0x81 & 0x3F) << 12 | (0x82 & 0x3F) << 6 | (0x83 & 0x3F) = 0x1083.
+    assert_eq!(utf8_to_runes(&[0xF8, 0x81, 0x82, 0x83]), vec![0x1083]);
+}
+
+#[test]
+fn malformed_continuation_is_masked_like_c() {
+    // Continuation bytes are not validated: a lead byte followed by a
+    // non-continuation byte is masked and folded like the C `nu_utf8_read`, not
+    // rejected. `[0xC3, b'(']` -> (0xC3 & 0x1F) << 6 | (0x28 & 0x3F) = 0x00E8,
+    // the same rune the C indexer would store. Validating here would make a
+    // malformed-but-indexed key stop matching, diverging from how it was stored.
+    assert_eq!(utf8_to_runes(&[0xC3, b'(']), vec![0x00E8]);
+}
+
+#[test]
+fn four_byte_utf8_truncates_like_strtorunesn() {
+    // A raw query token may hold a genuine 4-byte (non-BMP) sequence — e.g. the
+    // emoji "😀" = F0 9F 98 80, U+1F600. The index stored it by truncating the
+    // codepoint to `u16` (`(rune)0x1F600 == 0xF600`), so decoding must truncate
+    // the same way for the query to resolve to the stored key.
+    assert_eq!(utf8_to_runes("😀".as_bytes()), vec![0xF600]);
+    assert_eq!(
+        utf8_to_runes(&[b'a', 0xF0, 0x9F, 0x98, 0x80, b'b']),
+        vec![b'a' as u16, 0xF600, b'b' as u16]
+    );
+    // A truncated 4-byte sequence (lead byte without all continuation bytes)
+    // stops the decode without reading past the slice.
+    assert_eq!(utf8_to_runes(&[b'a', 0xF0, 0x9F]), vec![b'a' as u16]);
+}
+
+#[test]
+fn surrogate_round_trips() {
+    // A lone surrogate rune (as produced when a non-BMP codepoint is truncated to
+    // `u16` at index time) is emitted as 3-byte WTF-8 by `runes_to_utf8` and must
+    // decode back to the same rune — the case a UTF-8-validating decode would
+    // drop.
+    let runes = vec![0xD800u16, 0x0041, 0xDFFF];
+    let bytes = runes_to_utf8(&runes).expect("encodes to WTF-8");
+    assert!(
+        std::str::from_utf8(&bytes).is_err(),
+        "surrogate bytes are not valid UTF-8"
+    );
+    assert_eq!(utf8_to_runes(&bytes), runes);
+}
+
+#[cfg_attr(miri, ignore = "Too slow to be run under miri.")]
+#[test]
+fn round_trips_all_bmp_runes() {
+    // Every non-zero BMP rune (skipping `0`, the terminator) survives an
+    // encode/decode round-trip, surrogates included. `runes_to_utf8` caps at
+    // `MAX_RUNE_STR_LEN`, so walk the space in chunks under that limit.
+    for chunk in (1..=0xFFFFu16).collect::<Vec<u16>>().chunks(512) {
+        let bytes = runes_to_utf8(chunk).expect("chunk is within MAX_RUNE_STR_LEN");
+        assert_eq!(utf8_to_runes(&bytes), chunk.to_vec());
+    }
+}
+
+#[cfg(not(miri))]
+mod proptest_checks {
+    use proptest::prelude::*;
+    use string_utils::runes::{MAX_RUNE_STR_LEN, runes_to_utf8, utf8_to_runes};
+
+    proptest! {
+        /// For any sequence of non-zero runes (surrogates included), encoding
+        /// with `runes_to_utf8` and decoding back reproduces the exact runes, so
+        /// `utf8_to_runes` is the inverse of `runes_to_utf8`. `0` is excluded
+        /// because it is the string terminator, not a stored rune.
+        #[test]
+        fn inverts_runes_to_utf8(
+            runes in proptest::collection::vec(1u16..=0xFFFF, 0..=MAX_RUNE_STR_LEN),
+        ) {
+            let bytes = runes_to_utf8(&runes).expect("within MAX_RUNE_STR_LEN");
+            prop_assert_eq!(utf8_to_runes(&bytes), runes);
+        }
+
+        /// Decoding arbitrary — including malformed or truncated — bytes never
+        /// panics or reads out of bounds, and never yields more runes than input
+        /// bytes (each rune consumes at least one byte).
+        #[test]
+        fn arbitrary_bytes_never_panic(bytes in proptest::collection::vec(any::<u8>(), 0..512)) {
+            let runes = utf8_to_runes(&bytes);
+            prop_assert!(runes.len() <= bytes.len());
+        }
+    }
+}

--- a/src/redisearch_rs/string_utils/tests/integration/utf8_to_runes.rs
+++ b/src/redisearch_rs/string_utils/tests/integration/utf8_to_runes.rs
@@ -35,11 +35,19 @@ fn stops_at_nul() {
 }
 
 #[test]
-fn truncated_trailing_sequence_stops() {
-    // A lead byte without its continuation bytes ends the decode without any
-    // out-of-bounds read.
-    assert_eq!(utf8_to_runes(&[b'a', 0xE2, 0x82]), vec![b'a' as u16]);
-    assert_eq!(utf8_to_runes(&[0xC3]), Vec::<u16>::new());
+fn truncated_trailing_sequence_zero_fills() {
+    // A lead byte whose continuation bytes run past the end still yields a rune,
+    // its missing bytes taken as zero — the terminator byte the C decoder reads
+    // there. Dropping the sequence would turn a one-rune key into an empty one.
+    // `[0xE2, 0x82]` is a 3-byte lead with one byte missing:
+    // (0xE2 & 0x0F) << 12 | (0x82 & 0x3F) << 6 | 0 = 0x2080.
+    assert_eq!(
+        utf8_to_runes(&[b'a', 0xE2, 0x82]),
+        vec![b'a' as u16, 0x2080]
+    );
+    // `[0xC3]` is a 2-byte lead with its continuation missing:
+    // (0xC3 & 0x1F) << 6 | 0 = 0x00C0.
+    assert_eq!(utf8_to_runes(&[0xC3]), vec![0x00C0]);
 }
 
 #[test]
@@ -76,9 +84,12 @@ fn four_byte_utf8_truncates_like_strtorunesn() {
         utf8_to_runes(&[b'a', 0xF0, 0x9F, 0x98, 0x80, b'b']),
         vec![b'a' as u16, 0xF600, b'b' as u16]
     );
-    // A truncated 4-byte sequence (lead byte without all continuation bytes)
-    // stops the decode without reading past the slice.
-    assert_eq!(utf8_to_runes(&[b'a', 0xF0, 0x9F]), vec![b'a' as u16]);
+    // A truncated 4-byte sequence zero-fills its two missing bytes rather than
+    // reading past the slice: (0xF0 & 0x07) << 18 | (0x9F & 0x3F) << 12 = 0x1F000.
+    assert_eq!(
+        utf8_to_runes(&[b'a', 0xF0, 0x9F]),
+        vec![b'a' as u16, 0xF000]
+    );
 }
 
 #[test]


### PR DESCRIPTION
- move runes code to its own module.
- add new runes conversion helpers which will be used to implement the `QN_PREFIX` node.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
