### PR TITLE
c_trie wrapper: add contains/suffix trie-iteration API

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -199,7 +199,11 @@ dependencies = [
 name = "c_trie"
 version = "0.0.1"
 dependencies = [
+ "build_utils",
+ "c_trie",
  "ffi",
+ "redis_mock",
+ "redisearch_rs",
  "strum",
  "workspace_hack",
 ]

--- a/src/redisearch_rs/c_wrappers/c_trie/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/c_trie/Cargo.toml
@@ -8,7 +8,23 @@ publish.workspace = true
 [lints]
 workspace = true
 
+[features]
+# Enabled when building tests so `build.rs` links the C code (`libredisearch_c_bundle`).
+# See https://github.com/rust-lang/cargo/issues/4789#issuecomment-2308131243
+unittest = []
+
+[build-dependencies]
+build_utils.workspace = true
+
 [dependencies]
 ffi.workspace = true
 strum.workspace = true
 workspace_hack.workspace = true
+
+[dev-dependencies]
+# Crates required to link and invoke the C trie symbols from tests.
+c_trie = { path = ".", features = ["unittest"] }
+# `mock_allocator` disables the `RedisAlloc` global allocator so the mock's
+# `RedisModule_Alloc` routes to the system allocator instead of recursing.
+redisearch_rs = { workspace = true, features = ["mock_allocator"] }
+redis_mock.workspace = true

--- a/src/redisearch_rs/c_wrappers/c_trie/build.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/build.rs
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+fn main() {
+    // Only the test binaries need to link the C code; production builds link
+    // `libredisearch_c_bundle` at the final artifact, so gating on `unittest`
+    // keeps the `-l` flag out of the library rlib.
+    #[cfg(feature = "unittest")]
+    build_utils::bind_foreign_c_symbols();
+}

--- a/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
@@ -11,7 +11,112 @@
 //!
 //! This crate provides a safe Rust interface to the C Trie implementation,
 
-use std::ffi::c_char;
+use std::{
+    ffi::{c_char, c_int, c_void},
+    ops::ControlFlow,
+    ptr::NonNull,
+};
+
+use ffi::{SuffixCtx, SuffixType, SuffixType_SUFFIX_TYPE_CONTAINS, SuffixType_SUFFIX_TYPE_SUFFIX};
+
+/// Which side(s) of a term a [`CTrieRef::iterate_suffix`] walk anchors on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SuffixMode {
+    /// Match terms that end with the pattern (`*llo`).
+    Suffix,
+    /// Match terms that contain the pattern anywhere (`*ell*`).
+    Contains,
+}
+
+impl From<SuffixMode> for SuffixType {
+    /// The [`SuffixType`] discriminant for the given [`SuffixMode`].
+    fn from(mode: SuffixMode) -> Self {
+        match mode {
+            SuffixMode::Suffix => SuffixType_SUFFIX_TYPE_SUFFIX,
+            SuffixMode::Contains => SuffixType_SUFFIX_TYPE_CONTAINS,
+        }
+    }
+}
+
+/// Adapts a [`ffi::TrieRangeCallback`] to a Rust closure handed back through
+/// the opaque `ctx` pointer for every matching term.
+///
+/// A panic escaping this `extern "C"` function aborts the process rather than
+/// unwinding across the FFI boundary, keeping that boundary sound.
+///
+/// # Safety
+///
+/// - `ctx` must be the `&mut F` passed as the iterator's `ctx` argument,
+///   exclusively borrowed for the duration of the walk.
+/// - `runes` must point to `len` valid runes, or `len` must be `0` (in which
+///   case `runes` is ignored).
+///
+/// Both hold when the trie invokes this through the function pointer installed
+/// by [`CTrieRef::iterate_contains`].
+unsafe extern "C" fn range_trampoline<F>(
+    runes: *const ffi::rune,
+    len: usize,
+    ctx: *mut c_void,
+    _payload: *mut c_void,
+    num_docs: usize,
+) -> c_int
+where
+    F: FnMut(&[ffi::rune], usize) -> ControlFlow<()>,
+{
+    // SAFETY: `ctx` is the `&mut F` forwarded unchanged by the trie; the closure
+    // outlives every callback invocation of a single iteration call.
+    let callback = unsafe { &mut *(ctx as *mut F) };
+    let runes = if len == 0 {
+        // The pointer may be dangling/null for an empty key.
+        &[][..]
+    } else {
+        // SAFETY: the trie passes `len` valid, contiguous runes.
+        unsafe { std::slice::from_raw_parts(runes, len) }
+    };
+
+    match callback(runes, num_docs) {
+        // 0 continues the walk; any other value stops it.
+        ControlFlow::Continue(()) => 0,
+        ControlFlow::Break(()) => 1,
+    }
+}
+
+/// Adapts a [`ffi::TrieSuffixCallback`] to a Rust closure handed back through
+/// the opaque `ctx` pointer for every matching term.
+///
+/// A panic escaping this `extern "C"` function aborts the process rather than
+/// unwinding across the FFI boundary, keeping that boundary sound.
+///
+/// # Safety
+///
+/// - `ctx` must be the `&mut F` passed as the suffix iterator's context pointer,
+///   exclusively borrowed for the duration of the walk.
+/// - `s` must point to `len` valid bytes, or `len` must be `0`.
+///
+/// Both hold when the suffix trie invokes this through the function pointer
+/// installed by [`CTrieRef::iterate_suffix`].
+unsafe extern "C" fn suffix_trampoline<F>(
+    s: *const c_char,
+    len: usize,
+    ctx: *mut c_void,
+    _payload: *mut c_void,
+) -> c_int
+where
+    F: FnMut(&[u8]) -> ControlFlow<()>,
+{
+    // SAFETY: `ctx` is the `&mut F` forwarded unchanged by the suffix trie.
+    let callback = unsafe { &mut *(ctx as *mut F) };
+    let bytes = if len == 0 {
+        &[][..]
+    } else {
+        // SAFETY: the suffix trie passes `len` valid, contiguous bytes.
+        unsafe { std::slice::from_raw_parts(s.cast::<u8>(), len) }
+    };
+    match callback(bytes) {
+        ControlFlow::Continue(()) => 0,
+        ControlFlow::Break(()) => 1,
+    }
+}
 
 /// Result of a decrement operation on the C Trie.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::FromRepr)]
@@ -149,6 +254,145 @@ impl CTrieRef {
             // SAFETY: `node` is a valid, non-null `TrieNode` returned by the
             // lookup above.
             unsafe { ffi::TrieNode_NumDocs(node) }
+        }
+    }
+
+    /// Visit every term that contains `pattern` (or begins/ends with it), in the
+    /// trie's iteration order.
+    ///
+    /// `pattern` is a rune key. `prefix` and `suffix` together select the match
+    /// anchoring: `prefix` alone matches terms starting with `pattern`, `suffix`
+    /// alone matches terms ending with it, and both set matches terms containing
+    /// it anywhere. With neither set the walk degenerates to an exact-match
+    /// lookup of `pattern` itself, which is not a useful way to call this method.
+    /// For each match the callback receives the term's runes and the number of
+    /// documents indexed under it, and returns [`ControlFlow`] to continue or
+    /// stop the walk early (e.g. once an expansion cap is reached).
+    ///
+    /// An empty `pattern` in suffix/contains mode has nothing to anchor on and
+    /// visits nothing, as does a `pattern` longer than the trie's maximum term
+    /// length (no stored term can match it).
+    ///
+    /// `timeout` bounds the walk: `Some(deadline)` aborts it once the deadline
+    /// passes, while `None` runs it to completion with no deadline.
+    ///
+    /// # Safety
+    ///
+    /// - A `Some` `timeout` must point to a valid [`timespec`](ffi::timespec)
+    ///   that stays valid, and is not mutated (including by another thread), for
+    ///   the duration of the call. The walk reads `*timeout` unsynchronized on
+    ///   every deadline check, so a concurrent write to the pointee is a data
+    ///   race.
+    /// - The wrapped trie must not be mutated, freed, or iterated again for the
+    ///   duration of the call — including from within `callback`. The walk caches
+    ///   raw node and child pointers and reuses them after each callback
+    ///   invocation, so mutating the trie (e.g. deleting a term, or decrementing
+    ///   one to zero, through another handle) can free a node mid-walk and leave
+    ///   those pointers dangling.
+    pub unsafe fn iterate_contains<F>(
+        &self,
+        pattern: &[ffi::rune],
+        prefix: bool,
+        suffix: bool,
+        timeout: Option<NonNull<ffi::timespec>>,
+        mut callback: F,
+    ) where
+        F: FnMut(&[ffi::rune], usize) -> ControlFlow<()>,
+    {
+        // No trie term is longer than `t_len` (`u16`) runes, and the prefix and
+        // exact walks narrow the pattern length to `t_len` when looking up nodes,
+        // truncating anything longer (e.g. 65537 runes becomes 1).
+        if pattern.len() > ffi::t_len::MAX as usize {
+            return;
+        }
+        // There is nothing to anchor on, and nothing to visit, so bail out.
+        if suffix && pattern.is_empty() {
+            return;
+        }
+        // The iterator only honours a deadline when timeout checks are enabled,
+        // and treats a null deadline as already-expired, so the two must move
+        // together: a deadline enables the checks, its absence disables them.
+        let (timeout, skip_timeout_checks) = match timeout {
+            Some(deadline) => (deadline.as_ptr(), false),
+            None => (std::ptr::null_mut(), true),
+        };
+        // SAFETY: `self.ptr` is a valid `Trie` (`CTrieRef` invariant); `pattern`
+        // points to `pattern.len()` runes; `&mut callback` stays alive for the
+        // whole call, so the `ctx` the trampoline reconstitutes is valid; and
+        // `timeout` is null or the valid pointer the caller supplied.
+        unsafe {
+            ffi::Trie_IterateContains(
+                self.ptr,
+                pattern.as_ptr(),
+                pattern.len() as c_int,
+                prefix,
+                suffix,
+                Some(range_trampoline::<F>),
+                std::ptr::from_mut(&mut callback).cast(),
+                timeout,
+                skip_timeout_checks,
+            );
+        }
+    }
+
+    /// Visit every term matched by `pattern` through the *suffix* trie, which
+    /// indexes terms by their suffixes to answer contains/suffix queries without
+    /// a full scan.
+    ///
+    /// `self` must wrap a suffix trie, not the primary terms trie. `pattern` is
+    /// the rune key and `mode` selects a suffix or contains match. Each matching
+    /// term is delivered to `callback` as a UTF-8 byte string — already converted
+    /// from runes by the suffix trie — with no document count; the callback
+    /// returns [`ControlFlow`] to continue or stop.
+    ///
+    /// The suffix-trie walk is recursive and does not check for a timeout, so
+    /// this method takes no deadline. An empty `pattern` visits nothing.
+    ///
+    /// # Safety
+    ///
+    /// - `self` must wrap a suffix trie, whose nodes carry a suffix-data payload.
+    ///   The iterator reinterprets each visited node's payload as that type and
+    ///   dereferences it, so passing the primary terms trie (or any trie with a
+    ///   different payload) is type confusion and undefined behavior.
+    /// - The wrapped trie must not be mutated, freed, or iterated again for the
+    ///   duration of the call — including from within `callback`. The walk caches
+    ///   raw node and child pointers and reuses them after each callback
+    ///   invocation, so mutating the trie through another handle can free a node
+    ///   mid-walk and leave those pointers dangling.
+    pub unsafe fn iterate_suffix<F>(&self, pattern: &[ffi::rune], mode: SuffixMode, mut callback: F)
+    where
+        F: FnMut(&[u8]) -> ControlFlow<()>,
+    {
+        // An empty pattern has no suffix/contains anchor.
+        if pattern.is_empty() {
+            return;
+        }
+        // The suffix-trie node lookup narrows the pattern length to `t_len`
+        // (`u16`), so an over-long pattern would be truncated and match a shorter
+        // key. No stored key can be this long, so nothing can match: bail out
+        // rather than look up a truncated pattern.
+        if pattern.len() > ffi::t_len::MAX as usize {
+            return;
+        }
+        let mut suffix_ctx = SuffixCtx {
+            trie: self.ptr,
+            rune: pattern.as_ptr().cast_mut(),
+            runelen: pattern.len(),
+            cstr: std::ptr::null(),
+            cstrlen: 0,
+            type_: mode.into(),
+            callback: Some(suffix_trampoline::<F>),
+            cbCtx: std::ptr::from_mut(&mut callback).cast(),
+            // The suffix walk ignores these; keep them zeroed.
+            timeout: std::ptr::null_mut(),
+            skipTimeoutChecks: false,
+        };
+        // SAFETY: every `suffix_ctx` field is initialised above with a valid
+        // value — `self.ptr` is a valid suffix `Trie` (caller contract), the
+        // pattern pointer/len describe a live rune slice, and the callback
+        // closure outlives the call.
+        unsafe {
+            ffi::Suffix_IterateContains(std::ptr::from_mut(&mut suffix_ctx));
         }
     }
 

--- a/src/redisearch_rs/c_wrappers/c_trie/tests/iterate.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/tests/iterate.rs
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Integration tests for the trie-iteration API of [`CTrieRef`].
+//!
+//! Each test builds a live C trie through the linked static library, wraps it in
+//! a [`CTrieRef`], and exercises one of the iteration methods.
+
+// Links the Rust-provided and C-provided symbols of the whole module.
+extern crate redisearch_rs;
+// Provides the Redis allocator (and stubs) the C trie code relies on.
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
+use std::{
+    collections::HashSet,
+    ffi::{c_char, c_void},
+    mem,
+    ops::ControlFlow,
+    ptr::{self, NonNull},
+};
+
+use c_trie::{CTrieRef, SuffixMode};
+use ffi::{SuffixType, SuffixType_SUFFIX_TYPE_CONTAINS, SuffixType_SUFFIX_TYPE_SUFFIX};
+
+/// Convert an ASCII/UTF-8 string to the trie's rune (`u16`) key.
+fn to_runes(s: &str) -> Vec<ffi::rune> {
+    // A UTF-8 string decodes to at most as many runes as bytes; the extra slot
+    // gives the conversion room for a trailing rune.
+    let mut buf = vec![0 as ffi::rune; s.len() + 1];
+    // SAFETY: `s` is valid UTF-8 of `s.len()` bytes, so the decode stays within
+    // the slice, and `buf` has room for `s.len() + 1` runes.
+    let n = unsafe { ffi::strToRunesN(s.as_ptr().cast::<c_char>(), s.len(), buf.as_mut_ptr()) };
+    buf.truncate(n);
+    buf
+}
+
+/// Render a rune slice back to a `String`. The test corpus is ASCII, so each
+/// rune is its own byte.
+fn runes_to_string(runes: &[ffi::rune]) -> String {
+    runes.iter().map(|&r| char::from(r as u8)).collect()
+}
+
+/// Build a terms trie holding `terms`, each keyed with `numDocs == term length`
+/// (so tests can assert the document count flows through), run `f`, then free it.
+fn with_terms_trie(terms: &[&str], f: impl FnOnce(&CTrieRef)) {
+    // SAFETY: `NewTrie` returns a fresh, valid, empty terms trie; a terms trie
+    // stores no payload, so a null free callback is correct.
+    let ptr = unsafe { ffi::NewTrie(None, ffi::TrieSortMode_Trie_Sort_Lex) };
+    assert!(!ptr.is_null(), "NewTrie returned null");
+    for term in terms {
+        // SAFETY: `ptr` is the live trie just created; `term` points to
+        // `term.len()` valid UTF-8 bytes; a null payload is accepted.
+        unsafe {
+            ffi::Trie_InsertStringBuffer(
+                ptr,
+                term.as_ptr().cast::<c_char>(),
+                term.len(),
+                1.0,
+                0,
+                ptr::null_mut(),
+                term.chars().count(),
+            );
+        }
+    }
+    // SAFETY: `ptr` is a valid trie that stays alive for the whole closure and
+    // is not freed until after it returns.
+    let trie = unsafe { CTrieRef::from_raw(ptr) };
+    f(&trie);
+    // SAFETY: `ptr` was produced by `NewTrie` and is freed exactly once here,
+    // after the last use of `trie`.
+    unsafe { ffi::TrieType_Free(ptr.cast::<c_void>()) };
+}
+
+/// Build a *suffix* trie holding `terms` (and all their suffixes), run `f`, then
+/// free it. `terms` must be non-empty strings — `addSuffixTrie` asserts on empty.
+fn with_suffix_trie(terms: &[&str], f: impl FnOnce(&CTrieRef)) {
+    // SAFETY: `NewTrie` returns a fresh, valid trie; `suffixTrie_freeCallback` is
+    // the matching free callback for the payloads `addSuffixTrie` inserts.
+    let ptr = unsafe {
+        ffi::NewTrie(
+            Some(ffi::suffixTrie_freeCallback),
+            ffi::TrieSortMode_Trie_Sort_Lex,
+        )
+    };
+    assert!(!ptr.is_null(), "NewTrie returned null");
+    for term in terms {
+        assert!(!term.is_empty(), "addSuffixTrie rejects empty strings");
+        // SAFETY: `ptr` is the live suffix trie; `term` points to `term.len()`
+        // valid, non-empty UTF-8 bytes.
+        unsafe { ffi::addSuffixTrie(ptr, term.as_ptr().cast::<c_char>(), term.len() as u32) };
+    }
+    // SAFETY: as in `with_terms_trie` — `ptr` outlives the closure.
+    let trie = unsafe { CTrieRef::from_raw(ptr) };
+    f(&trie);
+    // SAFETY: freed exactly once after the last use of `trie`.
+    unsafe { ffi::TrieType_Free(ptr.cast::<c_void>()) };
+}
+
+/// Corpus used across the anchoring tests. Every term contains `"ap"`; only
+/// `apple`/`apricot` start with it and only `apple`/`maple` end with `"ple"`.
+const CORPUS: &[&str] = &["apple", "maple", "grape", "apricot", "map"];
+
+fn set(items: &[&str]) -> HashSet<String> {
+    items.iter().map(|s| (*s).to_owned()).collect()
+}
+
+// --- `From<SuffixMode>` -----------------------------------------------------
+
+#[test]
+fn suffix_mode_maps_to_c_discriminant() {
+    assert_eq!(
+        SuffixType::from(SuffixMode::Suffix),
+        SuffixType_SUFFIX_TYPE_SUFFIX
+    );
+    assert_eq!(
+        SuffixType::from(SuffixMode::Contains),
+        SuffixType_SUFFIX_TYPE_CONTAINS
+    );
+}
+
+// --- `iterate_contains` (terms trie) ----------------------------------------
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_contains_prefix_anchor_reports_terms_and_num_docs() {
+    with_terms_trie(CORPUS, |trie| {
+        let runes = to_runes("ap");
+        let mut got: HashSet<(String, usize)> = HashSet::new();
+        // SAFETY: `trie` wraps a live terms trie that is not mutated during the
+        // walk; the timeout is `None`; the closure does not touch the trie.
+        unsafe {
+            trie.iterate_contains(&runes, true, false, None, |term, num_docs| {
+                got.insert((runes_to_string(term), num_docs));
+                ControlFlow::Continue(())
+            });
+        }
+        // Prefix `ap`: only terms starting with it, and `numDocs` == char length.
+        let expected: HashSet<(String, usize)> =
+            [("apple".to_owned(), 5), ("apricot".to_owned(), 7)]
+                .into_iter()
+                .collect();
+        assert_eq!(got, expected);
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_contains_suffix_anchor() {
+    with_terms_trie(CORPUS, |trie| {
+        let runes = to_runes("ple");
+        let mut got = HashSet::new();
+        // SAFETY: live, un-mutated terms trie; `None` timeout.
+        unsafe {
+            trie.iterate_contains(&runes, false, true, None, |term, _| {
+                got.insert(runes_to_string(term));
+                ControlFlow::Continue(())
+            });
+        }
+        assert_eq!(got, set(&["apple", "maple"]));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_contains_contains_anchor() {
+    with_terms_trie(CORPUS, |trie| {
+        let runes = to_runes("ap");
+        let mut got = HashSet::new();
+        // SAFETY: live, un-mutated terms trie; `None` timeout.
+        unsafe {
+            trie.iterate_contains(&runes, true, true, None, |term, _| {
+                got.insert(runes_to_string(term));
+                ControlFlow::Continue(())
+            });
+        }
+        // Every corpus term contains `ap`.
+        assert_eq!(got, set(CORPUS));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_contains_break_stops_walk_early() {
+    with_terms_trie(CORPUS, |trie| {
+        let runes = to_runes("ap");
+        let mut count = 0_usize;
+        // SAFETY: live, un-mutated terms trie; `None` timeout.
+        unsafe {
+            trie.iterate_contains(&runes, true, true, None, |_, _| {
+                count += 1;
+                // Stop after the second match even though five would match.
+                if count >= 2 {
+                    ControlFlow::Break(())
+                } else {
+                    ControlFlow::Continue(())
+                }
+            });
+        }
+        assert_eq!(count, 2, "Break must stop the walk at the second match");
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_contains_empty_pattern_in_suffix_mode_visits_nothing() {
+    with_terms_trie(CORPUS, |trie| {
+        let mut count = 0_usize;
+        // SAFETY: live, un-mutated terms trie; `None` timeout; empty pattern.
+        unsafe {
+            trie.iterate_contains(&[], false, true, None, |_, _| {
+                count += 1;
+                ControlFlow::Continue(())
+            });
+        }
+        assert_eq!(count, 0);
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_contains_some_and_none_timeout_agree() {
+    // `RS_IsMock` is true in this test binary (`RedisModule_CreateTimer` is
+    // unbound), so an actual deadline never fires — deadline *enforcement* is
+    // covered by the C and Python suites. This exercises both branches of the
+    // wrapper's timeout mapping (`None` → skip checks; `Some` → a valid, live
+    // deadline pointer) and confirms they accept input and return the same set.
+    with_terms_trie(CORPUS, |trie| {
+        let runes = to_runes("ap");
+
+        let mut none_hits = HashSet::new();
+        // SAFETY: live, un-mutated terms trie; `None` timeout.
+        unsafe {
+            trie.iterate_contains(&runes, true, true, None, |term, _| {
+                none_hits.insert(runes_to_string(term));
+                ControlFlow::Continue(())
+            });
+        }
+
+        // SAFETY: `timespec` is a plain-old-data struct; an all-zero value is valid.
+        let mut deadline: ffi::timespec = unsafe { mem::zeroed() };
+        deadline.tv_sec = 1_i64 << 40; // far in the future
+        let mut some_hits = HashSet::new();
+        // SAFETY: live, un-mutated terms trie; `deadline` is a valid `timespec`
+        // that outlives the call.
+        unsafe {
+            trie.iterate_contains(
+                &runes,
+                true,
+                true,
+                Some(NonNull::from(&mut deadline)),
+                |term, _| {
+                    some_hits.insert(runes_to_string(term));
+                    ControlFlow::Continue(())
+                },
+            );
+        }
+
+        assert_eq!(none_hits, set(CORPUS));
+        assert_eq!(some_hits, none_hits);
+    });
+}
+
+// --- `iterate_suffix` (suffix trie) -----------------------------------------
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_suffix_suffix_anchor() {
+    with_suffix_trie(CORPUS, |trie| {
+        let runes = to_runes("ple");
+        let mut got = HashSet::new();
+        // SAFETY: `trie` wraps a live suffix trie (matching payload/free
+        // callback) that is not mutated during the walk.
+        unsafe {
+            trie.iterate_suffix(&runes, SuffixMode::Suffix, |bytes| {
+                got.insert(String::from_utf8_lossy(bytes).into_owned());
+                ControlFlow::Continue(())
+            });
+        }
+        assert_eq!(got, set(&["apple", "maple"]));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_suffix_contains_anchor() {
+    with_suffix_trie(CORPUS, |trie| {
+        let runes = to_runes("ap");
+        let mut got = HashSet::new();
+        // SAFETY: live, un-mutated suffix trie.
+        unsafe {
+            trie.iterate_suffix(&runes, SuffixMode::Contains, |bytes| {
+                got.insert(String::from_utf8_lossy(bytes).into_owned());
+                ControlFlow::Continue(())
+            });
+        }
+        assert_eq!(got, set(CORPUS));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_suffix_break_stops_walk_early() {
+    with_suffix_trie(CORPUS, |trie| {
+        let runes = to_runes("ap");
+        let mut count = 0_usize;
+        // SAFETY: live, un-mutated suffix trie.
+        unsafe {
+            trie.iterate_suffix(&runes, SuffixMode::Contains, |_| {
+                count += 1;
+                ControlFlow::Break(())
+            });
+        }
+        assert_eq!(count, 1, "Break must stop after the first match");
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_suffix_empty_pattern_visits_nothing() {
+    with_suffix_trie(CORPUS, |trie| {
+        let mut count = 0_usize;
+        // SAFETY: live, un-mutated suffix trie; empty pattern.
+        unsafe {
+            trie.iterate_suffix(&[], SuffixMode::Contains, |_| {
+                count += 1;
+                ControlFlow::Continue(())
+            });
+        }
+        assert_eq!(count, 0);
+    });
+}

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -447,8 +447,12 @@ const HEADERS: &[HeaderAllowlist] = &[
     },
     HeaderAllowlist {
         path: "src/suffix.h",
-        fns: &[],
-        types: &[],
+        fns: &[
+            "Suffix_IterateContains",
+            "addSuffixTrie",
+            "suffixTrie_freeCallback",
+        ],
+        types: &["SuffixCtx", "SuffixType"],
         vars: &["SUFFIX_STARRED_ANCHOR_PENALTY"],
     },
     HeaderAllowlist {
@@ -465,14 +469,21 @@ const HEADERS: &[HeaderAllowlist] = &[
     },
     HeaderAllowlist {
         path: "src/trie/trie.h",
-        fns: &["Trie_DecrementNumDocs", "Trie_GetNode"],
+        fns: &[
+            "NewTrie",
+            "Trie_DecrementNumDocs",
+            "Trie_GetNode",
+            "Trie_InsertStringBuffer",
+            "Trie_IterateContains",
+            "TrieType_Free",
+        ],
         types: &[],
         vars: &[],
     },
     HeaderAllowlist {
         path: "src/trie/trie_node.h",
         fns: &["TrieNode_NumDocs"],
-        types: &[],
+        types: &["TrieRangeCallback", "TrieSuffixCallback"],
         vars: &[],
     },
     HeaderAllowlist {


### PR DESCRIPTION
Add `CTrieRef::iterate_contains` and
`CTrieRef::iterate_suffix`, plus a `SuffixMode` enum.

Both apply to the index spec's lexicographically sorted tries (`Trie_Sort_Lex`):
the primary terms trie and its suffix trie.

This will be used to implement `QN_PREFIX` AST nodes handling in Rust: the
evaluation expands the node's pattern into a union of per-term readers, walking
the suffix trie with `iterate_suffix` when the pattern is suffix- or
contains-anchored and that trie covers the queried fields, and otherwise falling
back to `iterate_contains` over the terms trie. 

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
