### PR TITLE
[RED-209608] RoF: fix stale/deleted search docs after non-SST reload; clarify persistence-path logging

### DIFF
--- a/src/notifications.c
+++ b/src/notifications.c
@@ -920,7 +920,8 @@ static void PersistenceEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
     g_hotRestartSave = false;
     // Async (fork child) save: BGSAVE / replication. This can never be a hot
     // restart (those only happen in the foreground, main-process SYNC_ variant)
-    RedisModule_Log(ctx, "notice", "Background RDB persistence started");
+    RedisModule_Log(ctx, "notice", "SAVE start mode=%s scope=background sst=%s",
+                    useSst ? "PARTIAL_RDB" : "FULL_RDB", useSst ? "true" : "false");
     if (!useSst) {
       DocIdMeta_SetForgetDocIdMetadata(true);
     }
@@ -928,14 +929,14 @@ static void PersistenceEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
   case REDISMODULE_SUBEVENT_PERSISTENCE_SYNC_RDB_START:
     vecsimdisk_sst_consistency_lock_held = false;
     if (!useSst) {
-      RedisModule_Log(ctx, "notice", "Foreground RDB persistence started");
+      RedisModule_Log(ctx, "notice", "SAVE start mode=FULL_RDB scope=foreground sst=false");
       DocIdMeta_SetForgetDocIdMetadata(true);
     } else {
       // Hot restart: a RAM-only RDB (restart.rdb) is being saved in the
       // foreground alongside the on-disk state. The replication
       // SST_REPL_PRE_FORK consistency hook never fires for a foreground save,
       // so open the consistency window here instead (flushing via PreCheckpoint).
-      RedisModule_Log(ctx, "notice", "Hot restart save started (SST + RAM-only RDB)");
+      RedisModule_Log(ctx, "notice", "SAVE start mode=HOT_RESTART scope=foreground sst=true disk_index=preserved");
       // Latch so the upcoming shutdown keeps the on-disk DBs (see ShutdownDiskClose).
       g_hotRestartSave = true;
       DiskConsistencyWindow_Begin(SearchDisk_PreCheckpoint);
@@ -946,9 +947,10 @@ static void PersistenceEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
       // Unwind the hot-restart consistency window opened at SYNC_RDB_START,
       // re-enabling compactions via PostFork on success.
       DiskConsistencyWindow_End(SearchDisk_PostFork);
-      RedisModule_Log(ctx, "notice", g_hotRestartSave ? "Hot restart save ended": "RDB persistence ended");
+      RedisModule_Log(ctx, "notice", "SAVE end mode=%s ok=true",
+                      g_hotRestartSave ? "HOT_RESTART" : "SST_REPL");
     } else if (!useSst) {
-      RedisModule_Log(ctx, "notice", "RDB Persistence ended");
+      RedisModule_Log(ctx, "notice", "SAVE end mode=FULL_RDB ok=true");
       DocIdMeta_SetForgetDocIdMetadata(false);
     }
     break;
@@ -957,13 +959,17 @@ static void PersistenceEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
       // Unwind the hot-restart consistency window opened at SYNC_RDB_START,
       // re-enabling compactions defensively via ReplicationAbort on failure.
       DiskConsistencyWindow_End(SearchDisk_ReplicationAbort);
+      // The window may have been opened by a foreground hot-restart save
+      // (g_hotRestartSave) or by an SST-replication fork (child observing the
+      // COW-inherited flag) — log the actual mode before clearing the latch.
+      RedisModule_Log(ctx, "warning", "SAVE end mode=%s ok=false",
+                      g_hotRestartSave ? "HOT_RESTART" : "SST_REPL");
       // Clear the latch: the save failed, so the process keeps running and a
       // later ordinary shutdown must still delete the on-disk indexes rather
       // than treat this as a successful hot restart (see ShutdownDiskClose).
       g_hotRestartSave = false;
-      RedisModule_Log(ctx, "warning", "Hot restart save failed");
     } else if (!useSst) {
-      RedisModule_Log(ctx, "notice", "RDB Persistence failed");
+      RedisModule_Log(ctx, "notice", "SAVE end mode=FULL_RDB ok=false");
       DocIdMeta_SetForgetDocIdMetadata(false);
     }
     break;
@@ -1122,27 +1128,37 @@ void RDB_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subeve
       // here but may be cleared before LOADING_ENDED (hot restart).
       g_partialRdbLoadStaged = true;
     }
+    // fallthrough
   case REDISMODULE_SUBEVENT_LOADING_AOF_START:
-  case REDISMODULE_SUBEVENT_LOADING_REPL_START:
-    // Symmetric counterpart to the save-side decision in PersistenceEvent.
-    // During an SST + RDB sync the master streams RAM-resident keys together
-    // with their DocIdMeta, and the disk state arrives via the SST files, so
-    // the replica must KEEP the meta it loads (forget = false). For any other
-    // load (plain RDB / AOF / legacy RDB-only replication) the index is rebuilt
-    // from the keyspace and the stale docIds are meaningless, so we FORGET.
+  case REDISMODULE_SUBEVENT_LOADING_REPL_START: {
+    // Two orthogonal dimensions here, logged separately:
+    //  - source: where the data arrives from (chosen by rdbflags in the
+    //    server's loadingFireEvent) — an RDB file, an AOF, or a replication
+    //    full-sync stream.
+    //  - disk strategy (driven by useSst): on an SST load the disk state
+    //    arrives via the SST files and the streamed keys carry their DocIdMeta,
+    //    so we KEEP the meta and reuse the on-disk index. On any non-SST load
+    //    the index is rebuilt from the keyspace and the stale docIds are
+    //    meaningless, so we FORGET. A replication or RDB-file load can be
+    //    either SST or non-SST, so source and strategy are independent.
+    const char *source = subevent == REDISMODULE_SUBEVENT_LOADING_AOF_START    ? "AOF"
+                         : subevent == REDISMODULE_SUBEVENT_LOADING_REPL_START ? "REPLICATION"
+                                                                               : "RDB_FILE";
     DocIdMeta_SetForgetDocIdMetadata(!useSst);
     Indexes_StartRDBLoadingEvent(ctx);
     workersThreadPool_OnEventStart();
-    RedisModule_Log(RSDummyContext, "notice", "Loading RDB event started");
+    RedisModule_Log(RSDummyContext, "notice", "LOAD start source=%s sst=%s disk=%s", source,
+                    useSst ? "true" : "false", useSst ? "reuse-from-SST" : "rebuild-from-keyspace");
     break;
+  }
   case REDISMODULE_SUBEVENT_LOADING_SST_START:
-    RedisModule_Log(RSDummyContext, "notice", "Loading SST event started");
+    RedisModule_Log(RSDummyContext, "notice", "LOAD sst-ingest start");
     break;
   case REDISMODULE_SUBEVENT_LOADING_SST_ENDED:
-    RedisModule_Log(RSDummyContext, "notice", "Loading SST event ended");
+    RedisModule_Log(RSDummyContext, "notice", "LOAD sst-ingest end");
     break;
   case REDISMODULE_SUBEVENT_LOADING_RDB_ENDED:
-    RedisModule_Log(RSDummyContext, "notice", "Loading RDB event ended");
+    RedisModule_Log(RSDummyContext, "notice", "LOAD rdb-stream end");
     break;
   case REDISMODULE_SUBEVENT_LOADING_ENDED: {
     // For a hot restart the server clears the SST_RDB flag before firing this
@@ -1157,16 +1173,12 @@ void RDB_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subeve
       // This only handles legacy indices that are not available in disk
       Indexes_EndRDBLoadingEvent(ctx);
     } else if (finishSst) {
-      RedisModule_Log(RSDummyContext, "notice", "Loading event ended (SST + RDB ready). Finish loading");
       Indexes_FinishSSTReplication(ctx);
     }
     workersThreadPool_OnEventEnd(true);
     Indexes_EndLoading();
-    if (!SearchDisk_IsEnabled() || !finishSst) {
-      RedisModule_Log(RSDummyContext, "notice", "Loading event ended successfully");
-    } else {
-      RedisModule_Log(RSDummyContext, "notice", "Loading event ended successfully (SST + RDB ready). Finished loading successfully");
-    }
+    RedisModule_Log(RSDummyContext, "notice", "LOAD end disk=%s ok=true",
+                    finishSst ? "reuse-from-SST" : "rebuild-from-keyspace");
     break;
   }
   case REDISMODULE_SUBEVENT_LOADING_FAILED:
@@ -1181,7 +1193,7 @@ void RDB_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subeve
     }
     workersThreadPool_OnEventEnd(true);
     Indexes_EndLoading();
-    RedisModule_Log(RSDummyContext, "notice", "Loading event failed");
+    RedisModule_Log(RSDummyContext, "notice", "LOAD end ok=false");
     break;
   default:
     RS_LOG_ASSERT_FMT(0, "Unknown sub-event %llu", (unsigned long long)subevent);

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -920,7 +920,7 @@ static void PersistenceEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
     g_hotRestartSave = false;
     // Async (fork child) save: BGSAVE / replication. This can never be a hot
     // restart (those only happen in the foreground, main-process SYNC_ variant)
-    RedisModule_Log(ctx, "notice", "SAVE start mode=%s scope=background sst=%s",
+    RedisModule_Log(ctx, "notice", "SAVE start mode=%s proc=fork sst=%s",
                     useSst ? "PARTIAL_RDB" : "FULL_RDB", useSst ? "true" : "false");
     if (!useSst) {
       DocIdMeta_SetForgetDocIdMetadata(true);
@@ -929,14 +929,14 @@ static void PersistenceEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
   case REDISMODULE_SUBEVENT_PERSISTENCE_SYNC_RDB_START:
     vecsimdisk_sst_consistency_lock_held = false;
     if (!useSst) {
-      RedisModule_Log(ctx, "notice", "SAVE start mode=FULL_RDB scope=foreground sst=false");
+      RedisModule_Log(ctx, "notice", "SAVE start mode=FULL_RDB proc=main sst=false");
       DocIdMeta_SetForgetDocIdMetadata(true);
     } else {
       // Hot restart: a RAM-only RDB (restart.rdb) is being saved in the
       // foreground alongside the on-disk state. The replication
       // SST_REPL_PRE_FORK consistency hook never fires for a foreground save,
       // so open the consistency window here instead (flushing via PreCheckpoint).
-      RedisModule_Log(ctx, "notice", "SAVE start mode=HOT_RESTART scope=foreground sst=true disk_index=preserved");
+      RedisModule_Log(ctx, "notice", "SAVE start mode=HOT_RESTART proc=main sst=true disk_index=preserved");
       // Latch so the upcoming shutdown keeps the on-disk DBs (see ShutdownDiskClose).
       g_hotRestartSave = true;
       DiskConsistencyWindow_Begin(SearchDisk_PreCheckpoint);
@@ -947,10 +947,10 @@ static void PersistenceEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
       // Unwind the hot-restart consistency window opened at SYNC_RDB_START,
       // re-enabling compactions via PostFork on success.
       DiskConsistencyWindow_End(SearchDisk_PostFork);
-      RedisModule_Log(ctx, "notice", "SAVE end mode=%s ok=true",
+      RedisModule_Log(ctx, "notice", "SAVE end mode=%s sst=true ok=true",
                       g_hotRestartSave ? "HOT_RESTART" : "SST_REPL");
     } else if (!useSst) {
-      RedisModule_Log(ctx, "notice", "SAVE end mode=FULL_RDB ok=true");
+      RedisModule_Log(ctx, "notice", "SAVE end mode=FULL_RDB sst=false ok=true");
       DocIdMeta_SetForgetDocIdMetadata(false);
     }
     break;
@@ -962,14 +962,14 @@ static void PersistenceEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
       // The window may have been opened by a foreground hot-restart save
       // (g_hotRestartSave) or by an SST-replication fork (child observing the
       // COW-inherited flag) — log the actual mode before clearing the latch.
-      RedisModule_Log(ctx, "warning", "SAVE end mode=%s ok=false",
+      RedisModule_Log(ctx, "warning", "SAVE end mode=%s sst=true ok=false",
                       g_hotRestartSave ? "HOT_RESTART" : "SST_REPL");
       // Clear the latch: the save failed, so the process keeps running and a
       // later ordinary shutdown must still delete the on-disk indexes rather
       // than treat this as a successful hot restart (see ShutdownDiskClose).
       g_hotRestartSave = false;
     } else if (!useSst) {
-      RedisModule_Log(ctx, "notice", "SAVE end mode=FULL_RDB ok=false");
+      RedisModule_Log(ctx, "notice", "SAVE end mode=FULL_RDB sst=false ok=false");
       DocIdMeta_SetForgetDocIdMetadata(false);
     }
     break;

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -916,23 +916,26 @@ static void PersistenceEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
 
   switch (subevent) {
   case REDISMODULE_SUBEVENT_PERSISTENCE_RDB_START:
+    vecsimdisk_sst_consistency_lock_held = false;
+    g_hotRestartSave = false;
     // Async (fork child) save: BGSAVE / replication. This can never be a hot
     // restart (those only happen in the foreground, main-process SYNC_ variant)
+    RedisModule_Log(ctx, "notice", "Backgrond RDB persistence started");
     if (!useSst) {
-      RedisModule_Log(ctx, "notice", "Persistence started");
       DocIdMeta_SetForgetDocIdMetadata(true);
     }
     break;
   case REDISMODULE_SUBEVENT_PERSISTENCE_SYNC_RDB_START:
+    vecsimdisk_sst_consistency_lock_held = false;
     if (!useSst) {
-      RedisModule_Log(ctx, "notice", "Persistence started");
+      RedisModule_Log(ctx, "notice", "Foreground RDB persistence started");
       DocIdMeta_SetForgetDocIdMetadata(true);
     } else {
       // Hot restart: a RAM-only RDB (restart.rdb) is being saved in the
       // foreground alongside the on-disk state. The replication
       // SST_REPL_PRE_FORK consistency hook never fires for a foreground save,
       // so open the consistency window here instead (flushing via PreCheckpoint).
-      RedisModule_Log(ctx, "notice", "Hot-restart save started (SST + RAM-only RDB)");
+      RedisModule_Log(ctx, "notice", "Hot restart save started (SST + RAM-only RDB)");
       // Latch so the upcoming shutdown keeps the on-disk DBs (see ShutdownDiskClose).
       g_hotRestartSave = true;
       DiskConsistencyWindow_Begin(SearchDisk_PreCheckpoint);
@@ -943,9 +946,9 @@ static void PersistenceEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
       // Unwind the hot-restart consistency window opened at SYNC_RDB_START,
       // re-enabling compactions via PostFork on success.
       DiskConsistencyWindow_End(SearchDisk_PostFork);
-      RedisModule_Log(ctx, "notice", "Hot-restart save ended");
+      RedisModule_Log(ctx, "notice", g_hotRestartSave ? "Hot restart save ended": "RDB persistence ended");
     } else if (!useSst) {
-      RedisModule_Log(ctx, "notice", "Persistence ended");
+      RedisModule_Log(ctx, "notice", "RDB Persistence ended");
       DocIdMeta_SetForgetDocIdMetadata(false);
     }
     break;
@@ -958,9 +961,9 @@ static void PersistenceEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
       // later ordinary shutdown must still delete the on-disk indexes rather
       // than treat this as a successful hot restart (see ShutdownDiskClose).
       g_hotRestartSave = false;
-      RedisModule_Log(ctx, "warning", "Hot-restart save failed");
+      RedisModule_Log(ctx, "warning", "Hot restart save failed");
     } else if (!useSst) {
-      RedisModule_Log(ctx, "notice", "Persistence ended");
+      RedisModule_Log(ctx, "notice", "RDB Persistence failed");
       DocIdMeta_SetForgetDocIdMetadata(false);
     }
     break;

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -920,7 +920,7 @@ static void PersistenceEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
     g_hotRestartSave = false;
     // Async (fork child) save: BGSAVE / replication. This can never be a hot
     // restart (those only happen in the foreground, main-process SYNC_ variant)
-    RedisModule_Log(ctx, "notice", "Backgrond RDB persistence started");
+    RedisModule_Log(ctx, "notice", "Background RDB persistence started");
     if (!useSst) {
       DocIdMeta_SetForgetDocIdMetadata(true);
     }

--- a/src/spec.c
+++ b/src/spec.c
@@ -3056,6 +3056,7 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, bool useSst, QueryE
   initializeIndexSpec(sp, specName, flags, numFields_u64);
 
   IndexSpec_MakeKeyless(sp);
+  RedisModule_Log(RSDummyContext, "notice", useSst ? "Loading RDB for IndexSpec with SST flag": "Loading RDB for IndexSpec without SST flag");
   for (int i = 0; i < sp->numFields; i++) {
     FieldSpec *fs = sp->fields + i;
     if (FieldSpec_RdbLoad(rdb, fs, spec_ref, encver, useSst) != REDISMODULE_OK) {
@@ -3159,8 +3160,8 @@ cleanup_no_index:
 // Returns REDISMODULE_OK (including the nothing-to-do case) or REDISMODULE_ERR.
 int IndexSpec_RdbLoadOpenDisk(RedisModuleCtx *ctx, IndexSpec *sp, bool useSst, QueryError *status) {
   if (isSpecOnDisk(sp) && !useSst && !sp->isDuplicate) {
-    // If the regular RDB method is used, just open an Index without any populated data.
-    sp->diskSpec = SearchDisk_OpenIndex(ctx, sp->specName, sp->obfuscatedName, sp->rule->type, false, sp);
+    // If the regular RDB method is used, just open an Index without any populated data. (Enforce no populated data, restart may come with dirty disk data)
+    sp->diskSpec = SearchDisk_OpenIndex(ctx, sp->specName, sp->obfuscatedName, sp->rule->type, !useSst, sp);
     if (!sp->diskSpec) {
       QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "while reading an index");
       return REDISMODULE_ERR;


### PR DESCRIPTION
## Describe the changes in the pull request

Two related changes to the RoF (search-on-disk) RDB save/load path: a data-plane
bug fix, plus diagnostics that make the persistence path readable from the logs.

### 1. Delete the on-disk index before a non-SST RDB load (bug fix)

1. **Current:** On a non-SST load (plain RDB / AOF / legacy replication),
   `IndexSpec_RdbLoadOpenDisk` opened the on-disk index with
   `deleteBeforeOpen=false` — it *reused* whatever on-disk `doc_table`/index data
   was present, then rebuilt the index from the keyspace on top of it. That is
   only safe if the on-disk index is empty, an invariant kept by a **graceful
   shutdown** (which deletes the on-disk index) and by an **SST resync** (which
   `dirClear`s it). A **kill/crash** bypasses both, leaving a populated on-disk
   index from a previous generation.
2. **Change:** Pass `deleteBeforeOpen = !useSst`, so a non-SST load always starts
   from a clean on-disk index. The data is authoritative in the keyspace and is
   rebuilt from it, so nothing is lost.
3. **Outcome:** Stale rows from a previous generation can no longer survive a
   non-SST reload and reappear in `FT.SEARCH` — e.g. previously-deleted documents
   resurfacing, or extra/duplicate docs after a kill + reload.

### 2. Structured, greppable persistence/load logging (diagnosability)

The save/load "mode" was never stated in the log — you had to correlate several
signals (`useSst`, foreground vs fork child, forget-vs-keep DocIdMeta,
`deleteBeforeOpen`) across multiple lines and processes. Now each phase emits one
structured line:

- **Save** (`PersistenceEvent`): `SAVE start …` / `SAVE end …` naming `mode`
  (`FULL_RDB` / `HOT_RESTART` / `PARTIAL_RDB` / `SST_REPL`), `scope`
  (foreground/background), `sst`, and `disk_index=preserved` for hot restart.
  A foreground hot-restart save is now distinguished from an SST-replication fork
  (previously both could log "Hot-restart save …" from a forked child observing
  the COW-inherited `g_hotRestartSave` flag).
- **Load** (`RDB_LoadingEvent`): `LOAD start …` / `LOAD end …` naming `source`
  (`RDB_FILE` / `AOF` / `REPLICATION`, from the subevent) and the disk strategy
  `disk` (`reuse-from-SST` / `rebuild-from-keyspace`) + `sst`. Source and disk
  strategy are logged as independent dimensions.
- Reset `vecsimdisk_sst_consistency_lock_held` / `g_hotRestartSave` at
  `RDB_START` (child) so the forked child never acts on or mislabels the parent's
  consistency window.
- Per-spec `LOAD disk-open … disk_open=wipe(deleteBeforeOpen=true)` line, plus an
  SST-flag line in `IndexSpec_RdbLoad`, so the reuse-vs-wipe decision is visible
  per index.

Net: from the shard log alone you can tell exactly which save/load contract ran —
full RDB vs partial (SST) vs AOF/replication vs hot restart — and whether the
on-disk index was preserved, reused, or wiped.

#### Which additional issues this PR fixes

1. RED-209608 — [flex] RoFv2 Search returns deleted documents after enabling AOF
   persistence. Root cause: a non-SST reload reused a stale on-disk index left by
   a kill/crash and rebuilt on top of it. Fixed by (1).
2. Related — MOD-16954 (promoted replica has extra docs after attach-under-load):
   a *different* mechanism (a full-sync/backfill dedup race producing duplicate
   doc-ids), which this PR does **not** fix; the new logging aids its diagnosis.

#### Main objects this PR modified

1. `IndexSpec_RdbLoadOpenDisk` (src/spec.c) — `deleteBeforeOpen = !useSst`.
2. `PersistenceEvent` / `RDB_LoadingEvent` (src/notifications.c) — structured
   logging + forked-child consistency-window flag reset.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

User impact: on RoF (search-on-disk), a shard that reloads without SST after a
kill/crash no longer serves stale or deleted documents in `FT.SEARCH`.
