### PR TITLE
[MOD-17132] Improve FT.PROFILE loader field timing resolution

### DIFF
--- a/src/profile/profile.c
+++ b/src/profile/profile.c
@@ -35,6 +35,7 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
     switch (rp->type) {
       case RP_INDEX:
       case RP_METRICS:
+      case RP_LOADER:
       case RP_KEY_NAME_LOADER:
       case RP_SCORER:
       case RP_SORTER:
@@ -49,10 +50,6 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
       case RP_HYBRID_MERGER:
       case RP_DEPLETER:
       case RP_DISK_ASYNC_LOADER:
-        printProfileType(RPTypeToString(rp->type));
-        break;
-
-      case RP_LOADER:
         printProfileType(RPTypeToString(rp->type));
         break;
 
@@ -81,6 +78,8 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
     printProfileTime(deltaTime);
   }
   printProfileRPCounter(RPProfile_GetCount(rp) - 1);
+  // RP_PROFILE appends timing/counter fields to the map opened by its upstream RP.
+  // Emit loader field details here so RESP2 keeps Type, Time, Results processed order.
   if (printProfileClock && rp->upstream &&
       (rp->upstream->type == RP_LOADER || rp->upstream->type == RP_SAFE_LOADER)) {
     RPLoader_ReplyProfileFields(reply, rp->upstream);

--- a/src/profile/profile.c
+++ b/src/profile/profile.c
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 #include "profile.h"
+#include "result_processor.h"
 #include "types_ffi.h"
 #include "iterators/iterator_api.h"
 #include "iterators_ffi.h"
@@ -34,7 +35,6 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
     switch (rp->type) {
       case RP_INDEX:
       case RP_METRICS:
-      case RP_LOADER:
       case RP_KEY_NAME_LOADER:
       case RP_SCORER:
       case RP_SORTER:
@@ -52,6 +52,13 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
         printProfileType(RPTypeToString(rp->type));
         break;
 
+      case RP_LOADER:
+        printProfileType(RPTypeToString(rp->type));
+        if (printProfileClock) {
+          RPLoader_ReplyProfileFields(reply, rp);
+        }
+        break;
+
       case RP_PROJECTOR:
       case RP_FILTER:
         RPEvaluator_Reply(reply, "Type", rp);
@@ -60,6 +67,9 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
       case RP_SAFE_LOADER:
         printProfileType(RPTypeToString(rp->type));
         printProfileGILTime(rs_wall_clock_convert_ns_to_ms_d(rp->rpGILTime));
+        if (printProfileClock) {
+          RPLoader_ReplyProfileFields(reply, rp);
+        }
         break;
 
       default: // LCOV_EXCL_START — defensive: all valid RPType values are handled above

--- a/src/profile/profile.c
+++ b/src/profile/profile.c
@@ -54,9 +54,6 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
 
       case RP_LOADER:
         printProfileType(RPTypeToString(rp->type));
-        if (printProfileClock) {
-          RPLoader_ReplyProfileFields(reply, rp);
-        }
         break;
 
       case RP_PROJECTOR:
@@ -67,9 +64,6 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
       case RP_SAFE_LOADER:
         printProfileType(RPTypeToString(rp->type));
         printProfileGILTime(rs_wall_clock_convert_ns_to_ms_d(rp->rpGILTime));
-        if (printProfileClock) {
-          RPLoader_ReplyProfileFields(reply, rp);
-        }
         break;
 
       default: // LCOV_EXCL_START — defensive: all valid RPType values are handled above
@@ -87,6 +81,10 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
     printProfileTime(deltaTime);
   }
   printProfileRPCounter(RPProfile_GetCount(rp) - 1);
+  if (printProfileClock && rp->upstream &&
+      (rp->upstream->type == RP_LOADER || rp->upstream->type == RP_SAFE_LOADER)) {
+    RPLoader_ReplyProfileFields(reply, rp->upstream);
+  }
   RedisModule_Reply_MapEnd(reply); // end of recursive map
   return totalRPTime;
 }

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -489,7 +489,6 @@ fn load_specific_keys<'a>(
         dmd: ptr::null(),
         forceString: false,
         profileFields: ptr::null_mut(),
-        profileFieldsCount: 0,
     };
 
     // Safety: All pointers passed to this function are non-null and properly aligned since we created them above in this function.

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -488,6 +488,8 @@ fn load_specific_keys<'a>(
         cachedOnly: false,
         dmd: ptr::null(),
         forceString: false,
+        profileFields: ptr::null_mut(),
+        profileFieldsCount: 0,
     };
 
     // Safety: All pointers passed to this function are non-null and properly aligned since we created them above in this function.

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -36,6 +36,7 @@
 #include "search_result.h"
 #include "search_result_ffi.h"
 #include "redisearch.h"
+#include "reply.h"
 #include "asm_state_machine.h"
 #include "index_result_async_read.h"
 
@@ -1015,6 +1016,7 @@ static void rploaderFreeInternal(ResultProcessor *base) {
   RPLoader *lc = (RPLoader *)base;
   QueryError_ClearError(&lc->status);
   rm_free(lc->loadopts.keys);
+  rm_free(lc->loadopts.profileFields);
 }
 
 static void rploaderFree(ResultProcessor *base) {
@@ -1022,7 +1024,9 @@ static void rploaderFree(ResultProcessor *base) {
   rm_free(base);
 }
 
-static void rploaderNew_setLoadOpts(RPLoader *self, RedisSearchCtx *sctx, RLookup *lk, const RLookupKey **keys, size_t nkeys, bool forceLoad) {
+static void rploaderNew_setLoadOpts(RPLoader *self, RedisSearchCtx *sctx, RLookup *lk,
+                                    const RLookupKey **keys, size_t nkeys, bool forceLoad,
+                                    bool withProfile) {
   self->loadopts.forceString = 1; // used in `LOAD_ALLKEYS` mode.
   self->loadopts.forceLoad = forceLoad;
   self->loadopts.status = &self->status;
@@ -1032,6 +1036,13 @@ static void rploaderNew_setLoadOpts(RPLoader *self, RedisSearchCtx *sctx, RLooku
     self->loadopts.keys = rm_malloc(sizeof(*keys) * nkeys);
     memcpy(self->loadopts.keys, keys, sizeof(*keys) * nkeys);
     self->loadopts.nkeys = nkeys;
+    if (withProfile) {
+      self->loadopts.profileFields = rm_calloc(nkeys, sizeof(*self->loadopts.profileFields));
+      self->loadopts.profileFieldsCount = nkeys;
+      for (size_t ii = 0; ii < nkeys; ++ii) {
+        self->loadopts.profileFields[ii].key = keys[ii];
+      }
+    }
     self->load_all = false;
   } else {
     self->load_all = true;
@@ -1041,10 +1052,12 @@ static void rploaderNew_setLoadOpts(RPLoader *self, RedisSearchCtx *sctx, RLooku
   self->lk = lk;
 }
 
-static ResultProcessor *RPPlainLoader_New(RedisSearchCtx *sctx, RLookup *lk, const RLookupKey **keys, size_t nkeys, bool forceLoad) {
+static ResultProcessor *RPPlainLoader_New(RedisSearchCtx *sctx, RLookup *lk,
+                                          const RLookupKey **keys, size_t nkeys, bool forceLoad,
+                                          bool withProfile) {
   RPLoader *self = rm_calloc(1, sizeof(*self));
 
-  rploaderNew_setLoadOpts(self, sctx, lk, keys, nkeys, forceLoad);
+  rploaderNew_setLoadOpts(self, sctx, lk, keys, nkeys, forceLoad, withProfile);
 
   self->base.Next = rploaderNext;
   self->base.Free = rploaderFree;
@@ -1343,10 +1356,12 @@ static void rpSafeLoaderFree(ResultProcessor *base) {
   rm_free(sl);
 }
 
-static ResultProcessor *RPSafeLoader_New(RedisSearchCtx *sctx, RLookup *lk, const RLookupKey **keys, size_t nkeys, bool forceLoad) {
+static ResultProcessor *RPSafeLoader_New(RedisSearchCtx *sctx, RLookup *lk,
+                                         const RLookupKey **keys, size_t nkeys, bool forceLoad,
+                                         bool withProfile) {
   RPSafeLoader *sl = rm_calloc(1, sizeof(*sl));
 
-  rploaderNew_setLoadOpts(&sl->base_loader, sctx, lk, keys, nkeys, forceLoad);
+  rploaderNew_setLoadOpts(&sl->base_loader, sctx, lk, keys, nkeys, forceLoad, withProfile);
 
   sl->BufferBlocks = NULL;
   sl->buffer_results_count = 0;
@@ -1408,13 +1423,53 @@ ResultProcessor *RPLoader_New(RedisSearchCtx *sctx, uint32_t reqflags, RLookup *
     }
   }
   *outStateflags |= QEXEC_S_HAS_LOAD;
+  const bool withProfile = reqflags & QEXEC_F_PROFILE;
   if (reqflags & QEXEC_F_RUN_IN_BACKGROUND) {
     // Assumes that Redis is *NOT* locked while executing the loader
-    return RPSafeLoader_New(sctx, lk, keys, nkeys, forceLoad);
+    return RPSafeLoader_New(sctx, lk, keys, nkeys, forceLoad, withProfile);
   } else {
     // Assumes that Redis *IS* locked while executing the loader
-    return RPPlainLoader_New(sctx, lk, keys, nkeys, forceLoad);
+    return RPPlainLoader_New(sctx, lk, keys, nkeys, forceLoad, withProfile);
   }
+}
+
+static const RPLoader *RPLoader_GetProfileSource(const ResultProcessor *base) {
+  switch (base->type) {
+    case RP_LOADER:
+      return (const RPLoader *)base;
+    case RP_SAFE_LOADER:
+      return &((const RPSafeLoader *)base)->base_loader;
+    default:
+      RS_ABORT("RPLoader profile requested for non-loader RP");
+  }
+}
+
+void RPLoader_ReplyProfileFields(RedisModule_Reply *reply, const ResultProcessor *base) {
+  const RPLoader *loader = RPLoader_GetProfileSource(base);
+  const RLookupLoadFieldProfile *fields = loader->loadopts.profileFields;
+  if (!fields || loader->loadopts.profileFieldsCount == 0) {
+    return;
+  }
+
+  RedisModule_ReplyKV_Array(reply, "Field loads profile");
+  for (size_t ii = 0; ii < loader->loadopts.profileFieldsCount; ++ii) {
+    const RLookupLoadFieldProfile *field = &fields[ii];
+    const char *fieldName = RLookupKey_GetPath(field->key);
+    if (!fieldName) {
+      fieldName = RLookupKey_GetName(field->key);
+    }
+    if (!fieldName) {
+      fieldName = "";
+    }
+
+    RedisModule_Reply_Map(reply);
+    RedisModule_ReplyKV_StringBuffer(reply, "Field", fieldName, strlen(fieldName));
+    RedisModule_ReplyKV_Double(reply, "Time",
+                               rs_wall_clock_convert_ns_to_ms_d(field->loadTimeNs));
+    RedisModule_ReplyKV_LongLong(reply, "Results processed", field->loadCount);
+    RedisModule_Reply_MapEnd(reply);
+  }
+  RedisModule_Reply_ArrayEnd(reply);
 }
 
 // Consumes the input loader and returns a new safe loader that wraps it.

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1440,10 +1440,12 @@ static const RPLoader *RPLoader_GetProfileSource(const ResultProcessor *base) {
 
 void RPLoader_ReplyProfileFields(RedisModule_Reply *reply, const ResultProcessor *base) {
   const RPLoader *loader = RPLoader_GetProfileSource(base);
-  const RLookupLoadFieldProfile *fields = loader->loadopts.profileFields;
-  if (!fields || loader->loadopts.nkeys == 0) {
+  if (loader->loadopts.nkeys == 0) {
     return;
   }
+
+  const RLookupLoadFieldProfile *fields = loader->loadopts.profileFields;
+  RS_LOG_ASSERT(fields, "profileFields must exist for explicit LOAD profile");
 
   RedisModule_ReplyKV_Array(reply, "Field loads profile");
   for (size_t ii = 0; ii < loader->loadopts.nkeys; ++ii) {

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1038,7 +1038,6 @@ static void rploaderNew_setLoadOpts(RPLoader *self, RedisSearchCtx *sctx, RLooku
     self->loadopts.nkeys = nkeys;
     if (withProfile) {
       self->loadopts.profileFields = rm_calloc(nkeys, sizeof(*self->loadopts.profileFields));
-      self->loadopts.profileFieldsCount = nkeys;
     }
     self->load_all = false;
   } else {
@@ -1442,12 +1441,12 @@ static const RPLoader *RPLoader_GetProfileSource(const ResultProcessor *base) {
 void RPLoader_ReplyProfileFields(RedisModule_Reply *reply, const ResultProcessor *base) {
   const RPLoader *loader = RPLoader_GetProfileSource(base);
   const RLookupLoadFieldProfile *fields = loader->loadopts.profileFields;
-  if (!fields || loader->loadopts.profileFieldsCount == 0) {
+  if (!fields || loader->loadopts.nkeys == 0) {
     return;
   }
 
   RedisModule_ReplyKV_Array(reply, "Field loads profile");
-  for (size_t ii = 0; ii < loader->loadopts.profileFieldsCount; ++ii) {
+  for (size_t ii = 0; ii < loader->loadopts.nkeys; ++ii) {
     const RLookupKey *key = loader->loadopts.keys[ii];
     const RLookupLoadFieldProfile *field = &fields[ii];
     const char *fieldName = RLookupKey_GetPath(key);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1039,9 +1039,6 @@ static void rploaderNew_setLoadOpts(RPLoader *self, RedisSearchCtx *sctx, RLooku
     if (withProfile) {
       self->loadopts.profileFields = rm_calloc(nkeys, sizeof(*self->loadopts.profileFields));
       self->loadopts.profileFieldsCount = nkeys;
-      for (size_t ii = 0; ii < nkeys; ++ii) {
-        self->loadopts.profileFields[ii].key = keys[ii];
-      }
     }
     self->load_all = false;
   } else {
@@ -1434,14 +1431,12 @@ ResultProcessor *RPLoader_New(RedisSearchCtx *sctx, uint32_t reqflags, RLookup *
 }
 
 static const RPLoader *RPLoader_GetProfileSource(const ResultProcessor *base) {
-  switch (base->type) {
-    case RP_LOADER:
-      return (const RPLoader *)base;
-    case RP_SAFE_LOADER:
-      return &((const RPSafeLoader *)base)->base_loader;
-    default:
-      RS_ABORT("RPLoader profile requested for non-loader RP");
+  RS_LOG_ASSERT(base->type == RP_LOADER || base->type == RP_SAFE_LOADER,
+                "RPLoader profile requested for non-loader RP");
+  if (base->type == RP_SAFE_LOADER) {
+    return &((const RPSafeLoader *)base)->base_loader;
   }
+  return (const RPLoader *)base;
 }
 
 void RPLoader_ReplyProfileFields(RedisModule_Reply *reply, const ResultProcessor *base) {
@@ -1453,10 +1448,11 @@ void RPLoader_ReplyProfileFields(RedisModule_Reply *reply, const ResultProcessor
 
   RedisModule_ReplyKV_Array(reply, "Field loads profile");
   for (size_t ii = 0; ii < loader->loadopts.profileFieldsCount; ++ii) {
+    const RLookupKey *key = loader->loadopts.keys[ii];
     const RLookupLoadFieldProfile *field = &fields[ii];
-    const char *fieldName = RLookupKey_GetPath(field->key);
+    const char *fieldName = RLookupKey_GetPath(key);
     if (!fieldName) {
-      fieldName = RLookupKey_GetName(field->key);
+      fieldName = RLookupKey_GetName(key);
     }
     if (!fieldName) {
       fieldName = "";

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -28,6 +28,7 @@
 #include "rmutil/rm_assert.h"
 
 typedef struct RLookupKey RLookupKey;
+typedef struct RedisModule_Reply RedisModule_Reply;
 
 #ifdef __cplusplus
 extern "C" {
@@ -207,6 +208,7 @@ ResultProcessor *RPPager_New(size_t offset, size_t limit);
 struct AREQ;
 struct RequestSyncCtx;
 ResultProcessor *RPLoader_New(RedisSearchCtx *sctx, uint32_t reqflags, RLookup *lk, const RLookupKey **keys, size_t nkeys, bool forceLoad, uint32_t *outStateflags);
+void RPLoader_ReplyProfileFields(RedisModule_Reply *reply, const ResultProcessor *base);
 
 void SetLoadersForBG(QueryProcessingCtx *qctx);
 void SetLoadersForMainThread(QueryProcessingCtx *qctx);

--- a/src/rlookup_load_document.c
+++ b/src/rlookup_load_document.c
@@ -14,6 +14,7 @@
 #include "doc_types.h"
 #include "value_ffi.h"
 #include "util/arr.h"
+#include "rs_wall_clock.h"
 
 typedef enum {
   RLOOKUP_C_STR = 0,
@@ -193,7 +194,20 @@ int loadIndividualKeys(RLookup *it, RLookupRow *dst, RLookupLoadOptions *options
   if (options->nkeys) {
     for (size_t ii = 0; ii < options->nkeys; ++ii) {
       const RLookupKey *kk = options->keys[ii];
-      if (getKey(kk, dst, options, &key) != REDISMODULE_OK) {
+      RLookupLoadFieldProfile *profile = NULL;
+      if (options->profileFields && ii < options->profileFieldsCount) {
+        profile = &options->profileFields[ii];
+      }
+      rs_wall_clock start;
+      if (profile) {
+        rs_wall_clock_init(&start);
+      }
+      int loadRc = getKey(kk, dst, options, &key);
+      if (profile) {
+        profile->loadTimeNs += rs_wall_clock_elapsed_ns(&start);
+        profile->loadCount++;
+      }
+      if (loadRc != REDISMODULE_OK) {
         goto done;
       }
     }

--- a/src/rlookup_load_document.c
+++ b/src/rlookup_load_document.c
@@ -192,23 +192,27 @@ int loadIndividualKeys(RLookup *it, RLookupRow *dst, RLookupLoadOptions *options
   // (success could also be when no value is found and nothing is loaded into `dst`,
   //  for example, with a JSONPath with no matches)
   if (options->nkeys) {
-    for (size_t ii = 0; ii < options->nkeys; ++ii) {
-      const RLookupKey *kk = options->keys[ii];
-      RLookupLoadFieldProfile *profile = NULL;
-      if (options->profileFields && ii < options->profileFieldsCount) {
-        profile = &options->profileFields[ii];
-      }
-      rs_wall_clock start;
-      if (profile) {
+    if (options->profileFields) {
+      RS_LOG_ASSERT(options->profileFieldsCount == options->nkeys,
+                    "profileFields must match explicit LOAD keys");
+      for (size_t ii = 0; ii < options->nkeys; ++ii) {
+        const RLookupKey *kk = options->keys[ii];
+        RLookupLoadFieldProfile *profile = &options->profileFields[ii];
+        rs_wall_clock start;
         rs_wall_clock_init(&start);
-      }
-      int loadRc = getKey(kk, dst, options, &key);
-      if (profile) {
+        int loadRc = getKey(kk, dst, options, &key);
         profile->loadTimeNs += rs_wall_clock_elapsed_ns(&start);
         profile->loadCount++;
+        if (loadRc != REDISMODULE_OK) {
+          goto done;
+        }
       }
-      if (loadRc != REDISMODULE_OK) {
-        goto done;
+    } else {
+      for (size_t ii = 0; ii < options->nkeys; ++ii) {
+        const RLookupKey *kk = options->keys[ii];
+        if (getKey(kk, dst, options, &key) != REDISMODULE_OK) {
+          goto done;
+        }
       }
     }
   } else { // If we called load to perform IF operation with FT.ADD command

--- a/src/rlookup_load_document.c
+++ b/src/rlookup_load_document.c
@@ -50,25 +50,30 @@ static inline bool isValueAvailable(const RLookupKey *kk, const RLookupRow *dst,
     ));
 }
 
+typedef int (*GetKeyFunc)(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOptions *options,
+                          void **keyobj, size_t keyIndex);
+
 static int getKeyCommonHash(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOptions *options,
-                        RedisModuleKey **keyobj) {
+                        void **keyobj, size_t keyIndex) {
+  REDISMODULE_NOT_USED(keyIndex);
   if (isValueAvailable(kk, dst, options)) {
     return REDISMODULE_OK;
   }
 
+  RedisModuleKey **hashKey = (RedisModuleKey **)keyobj;
   const char *keyPtr = options->dmd ? options->dmd->keyPtr : options->keyPtr;
   // In this case, the flag must be obtained via HGET
-  if (!*keyobj) {
+  if (!*hashKey) {
     RedisModuleCtx *ctx = options->sctx->redisCtx;
     RedisModuleString *keyName =
         RedisModule_CreateString(ctx, keyPtr, strlen(keyPtr));
-    *keyobj = RedisModule_OpenKey(ctx, keyName, DOCUMENT_OPEN_KEY_QUERY_FLAGS);
+    *hashKey = RedisModule_OpenKey(ctx, keyName, DOCUMENT_OPEN_KEY_QUERY_FLAGS);
     RedisModule_FreeString(ctx, keyName);
-    if (!*keyobj) {
+    if (!*hashKey) {
       QueryError_SetCode(options->status, QUERY_ERROR_CODE_NO_DOC);
       return REDISMODULE_ERR;
     }
-    if (RedisModule_KeyType(*keyobj) != REDISMODULE_KEYTYPE_HASH) {
+    if (RedisModule_KeyType(*hashKey) != REDISMODULE_KEYTYPE_HASH) {
       QueryError_SetCode(options->status, QUERY_ERROR_CODE_REDIS_KEY_TYPE);
       return REDISMODULE_ERR;
     }
@@ -78,7 +83,7 @@ static int getKeyCommonHash(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOp
   RedisModuleString *val = NULL;
   RSValue *rsv = NULL;
 
-  RedisModule_HashGet(*keyobj, REDISMODULE_HASH_CFIELDS, RLookupKey_GetPath(kk), &val, NULL);
+  RedisModule_HashGet(*hashKey, REDISMODULE_HASH_CFIELDS, RLookupKey_GetPath(kk), &val, NULL);
 
   if (val != NULL) {
     // `val` was created by `RedisModule_HashGet` and is owned by us.
@@ -87,7 +92,7 @@ static int getKeyCommonHash(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOp
     rsv = hvalToValue(val, (RLookupKey_GetFlags(kk) & RLOOKUP_F_NUMERIC) ? RLOOKUP_C_DBL : RLOOKUP_C_STR);
     RedisModule_FreeString(RSDummyContext, val);
   } else if (!strcmp(RLookupKey_GetPath(kk), UNDERSCORE_KEY)) {
-    const RedisModuleString *keyName = RedisModule_GetKeyNameFromModuleKey(*keyobj);
+    const RedisModuleString *keyName = RedisModule_GetKeyNameFromModuleKey(*hashKey);
     rsv = hvalToValue(keyName, RLOOKUP_C_STR);
   } else {
     return REDISMODULE_OK;
@@ -100,7 +105,8 @@ static int getKeyCommonHash(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOp
 
 
 static int getKeyCommonJSON(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOptions *options,
-                        RedisJSON *keyobj) {
+                        void **keyobj, size_t keyIndex) {
+  REDISMODULE_NOT_USED(keyIndex);
   if (!japi) {
     QueryError_SetCode(options->status, QUERY_ERROR_CODE_UNSUPP_TYPE);
     RedisModule_Log(RSDummyContext, "warning", "cannot operate on a JSON index as RedisJSON is not loaded");
@@ -115,13 +121,14 @@ static int getKeyCommonJSON(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOp
   RedisModuleCtx *ctx = options->sctx->redisCtx;
   const bool keyPtrFromDMD = options->dmd != NULL;
   char *keyPtr = keyPtrFromDMD ? options->dmd->keyPtr : (char *)options->keyPtr;
-  if (!*keyobj) {
+  RedisJSON *jsonKey = (RedisJSON *)keyobj;
+  if (!*jsonKey) {
 
     RedisModuleString* keyName = RedisModule_CreateString(ctx, keyPtr, keyPtrFromDMD ? sdslen(keyPtr) : strlen(keyPtr));
-    *keyobj = japi->openKeyWithFlags(ctx, keyName, DOCUMENT_OPEN_KEY_QUERY_FLAGS);
+    *jsonKey = japi->openKeyWithFlags(ctx, keyName, DOCUMENT_OPEN_KEY_QUERY_FLAGS);
     RedisModule_FreeString(ctx, keyName);
 
-    if (!*keyobj) {
+    if (!*jsonKey) {
       QueryError_SetCode(options->status, QUERY_ERROR_CODE_NO_DOC);
       return REDISMODULE_ERR;
     }
@@ -131,7 +138,7 @@ static int getKeyCommonJSON(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOp
   RedisModuleString *val = NULL;
   RSValue *rsv = NULL;
 
-  JSONResultsIterator jsonIter = (*RLookupKey_GetPath(kk) == '$') ? japi->get(*keyobj, RLookupKey_GetPath(kk)) : NULL;
+  JSONResultsIterator jsonIter = (*RLookupKey_GetPath(kk) == '$') ? japi->get(*jsonKey, RLookupKey_GetPath(kk)) : NULL;
 
   if (!jsonIter) {
     // The field does not exist and and it isn't `__key`
@@ -153,8 +160,31 @@ static int getKeyCommonJSON(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOp
   return REDISMODULE_OK;
 }
 
-typedef int (*GetKeyFunc)(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOptions *options,
-                          void **keyobj);
+static int getKeyProfiled(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOptions *options,
+                          void **keyobj, size_t keyIndex, GetKeyFunc getKey) {
+  RS_LOG_ASSERT(options->profileFields, "profileFields must be set for profiled loads");
+  RS_LOG_ASSERT(keyIndex < options->nkeys, "profile field index must match explicit LOAD keys");
+
+  RLookupLoadFieldProfile *profile = &options->profileFields[keyIndex];
+  rs_wall_clock start;
+  rs_wall_clock_init(&start);
+  int rc = getKey(kk, dst, options, keyobj, keyIndex);
+  profile->loadTimeNs += rs_wall_clock_elapsed_ns(&start);
+  profile->loadCount++;
+  return rc;
+}
+
+static int getKeyCommonHashProfiled(const RLookupKey *kk, RLookupRow *dst,
+                                    RLookupLoadOptions *options, void **keyobj,
+                                    size_t keyIndex) {
+  return getKeyProfiled(kk, dst, options, keyobj, keyIndex, getKeyCommonHash);
+}
+
+static int getKeyCommonJSONProfiled(const RLookupKey *kk, RLookupRow *dst,
+                                    RLookupLoadOptions *options, void **keyobj,
+                                    size_t keyIndex) {
+  return getKeyProfiled(kk, dst, options, keyobj, keyIndex, getKeyCommonJSON);
+}
 
 
 int loadIndividualKeys(RLookup *it, RLookupRow *dst, RLookupLoadOptions *options) {
@@ -184,35 +214,23 @@ int loadIndividualKeys(RLookup *it, RLookupRow *dst, RLookupLoadOptions *options
       key = options->openKey;
     }
   }
-  GetKeyFunc getKey = (type == DocumentType_Hash) ? (GetKeyFunc)getKeyCommonHash :
-                                                    (GetKeyFunc)getKeyCommonJSON;
+  const bool profileExplicitKeys = options->profileFields && options->nkeys;
+  GetKeyFunc getKey;
+  if (type == DocumentType_Hash) {
+    getKey = profileExplicitKeys ? getKeyCommonHashProfiled : getKeyCommonHash;
+  } else {
+    getKey = profileExplicitKeys ? getKeyCommonJSONProfiled : getKeyCommonJSON;
+  }
   int rc = REDISMODULE_ERR;
   // On error we silently skip the rest
   // On success we continue
   // (success could also be when no value is found and nothing is loaded into `dst`,
   //  for example, with a JSONPath with no matches)
   if (options->nkeys) {
-    if (options->profileFields) {
-      RS_LOG_ASSERT(options->profileFieldsCount == options->nkeys,
-                    "profileFields must match explicit LOAD keys");
-      for (size_t ii = 0; ii < options->nkeys; ++ii) {
-        const RLookupKey *kk = options->keys[ii];
-        RLookupLoadFieldProfile *profile = &options->profileFields[ii];
-        rs_wall_clock start;
-        rs_wall_clock_init(&start);
-        int loadRc = getKey(kk, dst, options, &key);
-        profile->loadTimeNs += rs_wall_clock_elapsed_ns(&start);
-        profile->loadCount++;
-        if (loadRc != REDISMODULE_OK) {
-          goto done;
-        }
-      }
-    } else {
-      for (size_t ii = 0; ii < options->nkeys; ++ii) {
-        const RLookupKey *kk = options->keys[ii];
-        if (getKey(kk, dst, options, &key) != REDISMODULE_OK) {
-          goto done;
-        }
+    for (size_t ii = 0; ii < options->nkeys; ++ii) {
+      const RLookupKey *kk = options->keys[ii];
+      if (getKey(kk, dst, options, &key, ii) != REDISMODULE_OK) {
+        goto done;
       }
     }
   } else { // If we called load to perform IF operation with FT.ADD command
@@ -229,7 +247,7 @@ int loadIndividualKeys(RLookup *it, RLookupRow *dst, RLookupLoadOptions *options
           continue;
         }
       }
-      if (getKey(kk, dst, options, &key) != REDISMODULE_OK) {
+      if (getKey(kk, dst, options, &key, 0) != REDISMODULE_OK) {
         goto done;
       }
     }

--- a/src/rlookup_load_document.h
+++ b/src/rlookup_load_document.h
@@ -16,6 +16,12 @@ extern "C" {
 #endif
 
 typedef struct {
+  const RLookupKey *key;
+  uint64_t loadTimeNs;
+  uint64_t loadCount;
+} RLookupLoadFieldProfile;
+
+typedef struct {
   struct RedisSearchCtx *sctx;
 
   /** Needed for the key name, and perhaps the sortable */
@@ -55,6 +61,9 @@ typedef struct {
    * Force string return; don't coerce to native type
    */
   bool forceString;
+
+  RLookupLoadFieldProfile *profileFields;
+  size_t profileFieldsCount;
 
   struct QueryError *status;
 } RLookupLoadOptions;

--- a/src/rlookup_load_document.h
+++ b/src/rlookup_load_document.h
@@ -16,7 +16,8 @@ extern "C" {
 #endif
 
 typedef struct {
-  const RLookupKey *key;
+  /* Per explicit LOAD key counters. Loader cost can differ by field source,
+   * value size, conversion, and JSON path materialization. */
   uint64_t loadTimeNs;
   uint64_t loadCount;
 } RLookupLoadFieldProfile;

--- a/src/rlookup_load_document.h
+++ b/src/rlookup_load_document.h
@@ -64,7 +64,6 @@ typedef struct {
   bool forceString;
 
   RLookupLoadFieldProfile *profileFields;
-  size_t profileFieldsCount;
 
   struct QueryError *status;
 } RLookupLoadOptions;

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -948,6 +948,29 @@ def sum_rp_times(env, shard):
       total += float(rp_dict.get('Time', 0))
   return total
 
+@skip(cluster=True)
+def testProfileLoaderFieldTimes():
+  env = Env(protocol=3)
+  conn = getConnectionByEnv(env)
+
+  env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'true')
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'n', 'NUMERIC').ok()
+
+  for i in range(3):
+    conn.execute_command('HSET', f'doc{i}', 't', 'hello', 'n', i)
+
+  res = env.cmd('FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*',
+                'LOAD', '2', '@t', '@n')
+  _, shards = extract_profile_coordinator_and_shards(env, res)
+  loader = next(rp for rp in shards[0]['Result processors profile'] if rp['Type'] == 'Loader')
+
+  env.assertContains('Field loads profile', loader)
+  fields = {field['Field']: field for field in loader['Field loads profile']}
+  env.assertEqual(set(fields.keys()), {'t', 'n'})
+  for field in fields.values():
+    env.assertEqual(field['Results processed'], 3)
+    env.assertGreaterEqual(float(field['Time']), 0)
+
 def ProfileTotalTimeConsistency(env, num_docs):
   """Tests that Total profile time >= sum of Result Processor times.
 


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: `FT.PROFILE` reports total loader processor time, but does not break down explicit `LOAD` cost per field.
2. Change: Track timing and load counts for each explicitly loaded in-memory field, then include a `Field loads profile` section in loader profile output when profile clocks are enabled.
3. Outcome: Profiling can identify which loaded fields account for loader time, making slow field access easier to isolate.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. `RLookupLoadOptions` and in-memory document loading
2. Loader result processor profile output
3. `FT.PROFILE` Python coverage

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
