### PR TITLE
MOD-17100: fix wrong reporting after OOM on async background indexing

### DIFF
--- a/src/indexes_scanner.c
+++ b/src/indexes_scanner.c
@@ -38,9 +38,11 @@ static_assert(
 );
 
 // Record a background-indexing failure on the scanner's spec so clients see it. See the
-// header for the full contract. Promotes the scanner's spec and, while it is alive,
-// records `error` as the spec's last indexing error (visible in FT.INFO "Index Errors"),
-// so a partially-built index is not silently treated as complete. When `oom` is set it
+// header for the full contract. Promotes the scanner's spec and, while it is alive AND this
+// scanner is still the spec's current one (a newer scan may have superseded it while the GIL
+// was released — see the inline note), records `error` as the spec's last indexing error
+// (visible in FT.INFO "Index Errors"), so a partially-built index is not silently treated as
+// complete. When `oom` is set it
 // additionally marks the failure as out-of-memory: it sets the spec's scan_failed_OOM
 // flag (consulted at query time to warn results may be incomplete, aggregated in
 // FT.INFO) and raises the OOM background-index status flag — pass false for non-OOM
@@ -70,18 +72,34 @@ void IndexesScanner_RecordBackgroundFailure(RedisModuleCtx *ctx, IndexesScanner 
   StrongRef curr_run_ref = WeakRef_Promote(scanner->spec_ref);
   IndexSpec *sp = StrongRef_Get(curr_run_ref);
   if (sp) {
-    // Error message does not contain user data. scanner->OOMkey may be NULL when no
-    // single key is to blame; IndexError_AddError falls back to the NA sentinel then.
-    IndexError_AddError(&sp->stats.indexError, error, error, scanner->OOMkey);
-    if (oom) {
-      sp->scan_failed_OOM = true;
-      // Freeze how far the aborted scan got: once IndexesScanner_Free clears the
-      // scanner, IndexesScanner_IndexedPercent would otherwise default to 1.0 and hide
-      // the incomplete build. Store the raw scanned-key count (the scanner is still
-      // alive here); IndexesScanner_IndexedPercent divides it by the live DbSize so the
-      // partial build is not reported as complete.
-      sp->scan_failed_OOM_scanned_keys = scanner->scannedKeys;
-      IndexError_RaiseBackgroundIndexFailureFlag(&sp->stats.indexError);
+    // A newer scan may have superseded this one while the GIL was released (the async OOM
+    // path drops it between aborting the cursor and re-taking it here): a recovery FT.ALTER
+    // would have run IndexesScanner_New, which cancels this scanner, installs a replacement
+    // as sp->scanner, and clears the OOM state. Recording this stale scanner's failure now
+    // would clobber that fresh state — re-raising scan_failed_OOM makes IndexSpec_UpdateDoc
+    // reject the replacement scan's keys, leaving the index permanently partial. So only
+    // record while this scanner is still the spec's current one. Both this function and
+    // IndexesScanner_New run under the GIL, so the check is serialized against the swap.
+    if (sp->scanner == scanner) {
+      // Error message does not contain user data. scanner->OOMkey may be NULL when no
+      // single key is to blame; IndexError_AddError falls back to the NA sentinel then.
+      IndexError_AddError(&sp->stats.indexError, error, error, scanner->OOMkey);
+      if (oom) {
+        sp->scan_failed_OOM = true;
+        // Freeze how far the aborted scan got: once IndexesScanner_Free clears the
+        // scanner, IndexesScanner_IndexedPercent would otherwise default to 1.0 and hide
+        // the incomplete build. Store the raw scanned-key count (the scanner is still
+        // alive here); IndexesScanner_IndexedPercent divides it by the live DbSize so the
+        // partial build is not reported as complete.
+        sp->scan_failed_OOM_scanned_keys = scanner->scannedKeys;
+        IndexError_RaiseBackgroundIndexFailureFlag(&sp->stats.indexError);
+      }
+    } else {
+      RedisModule_Log(ctx, "notice",
+                      "Scanning index %s in background: %s but a newer scan superseded it; "
+                      "not recording the failure",
+                      scanner->spec_name_for_logs,
+                      oom ? "cancelled due to OOM" : "failed");
     }
     StrongRef_Release(curr_run_ref);
   } else {
@@ -187,9 +205,14 @@ IndexesScanner *IndexesScanner_New(StrongRef global_ref) {
   }
   spec->scanner = scanner;
   spec->scan_in_progress = true;
-  spec->scan_failed_OOM = false;
-  spec->scan_failed_OOM_scanned_keys = 0;
-  IndexError_ClearBackgroundIndexFailureFlag(&spec->stats.indexError);
+  // NOTE: the persisted OOM state (scan_failed_OOM / scan_failed_OOM_scanned_keys / the
+  // background-index failure flag) is deliberately NOT cleared here. A recovery scan starting
+  // does not mean the index is complete yet — it still holds only the aborted build's partial
+  // data until this scan finishes. Clearing now would drop the query-time "partial data"
+  // warnings and flip FT.INFO to OK during that window. Instead the state is cleared in
+  // IndexesScanner_Free once the scan completes successfully. The write-block in
+  // IndexSpec_UpdateDoc is separately suppressed while scan_in_progress holds, so this scan can
+  // still index despite scan_failed_OOM remaining set.
 
   return scanner;
 }
@@ -205,6 +228,17 @@ void IndexesScanner_Free(IndexesScanner *scanner) {
       if (spec->scanner == scanner) {
         spec->scanner = NULL;
         spec->scan_in_progress = false;
+        // A scan that completed successfully (not cancelled, and it did not abort on OOM)
+        // supersedes any earlier OOM-aborted build: clear the persisted OOM state now, so
+        // percent_indexed, FT.INFO's background-indexing status, and query-time "partial
+        // data" warnings all reflect the now-complete index. A cancelled or OOM-aborted
+        // scan leaves the state untouched (a superseded scan is not the current scanner, so
+        // it does not reach here; an OOM abort keeps the failure visible for recovery).
+        if (!IndexesScanner_IsCancelled(scanner) && !scanner->scanFailedOnOOM) {
+          spec->scan_failed_OOM = false;
+          spec->scan_failed_OOM_scanned_keys = 0;
+          IndexError_ClearBackgroundIndexFailureFlag(&spec->stats.indexError);
+        }
       }
       StrongRef_Release(tmp);
     }

--- a/src/indexes_scanner.c
+++ b/src/indexes_scanner.c
@@ -12,6 +12,7 @@
 // the debug-scanner variant, and the background-indexing memory-limit helpers.
 
 #include <assert.h>
+#include <math.h>
 
 #include "indexes_scanner.h"
 
@@ -78,8 +79,12 @@ void IndexesScanner_RecordBackgroundFailure(RedisModuleCtx *ctx, IndexesScanner 
       // Freeze how far the aborted scan got: once IndexesScanner_Free clears the
       // scanner, IndexesScanner_IndexedPercent would otherwise default to 1.0 and
       // hide the incomplete build. The scanner is still alive here, so this reads
-      // its live scannedKeys/DbSize fraction.
-      sp->scan_failed_OOM_percent = IndexesScanner_IndexedPercent(ctx, scanner, sp);
+      // its live scannedKeys/DbSize fraction. Cap strictly below 1.0: an OOM-aborted
+      // build is by definition incomplete, but duplicate SCAN deliveries can push
+      // scannedKeys to (or past) DbSize, which IndexesScanner_IndexedPercent clamps to
+      // a complete-looking 1.0 — that must never be reported for a failed build.
+      double pct = IndexesScanner_IndexedPercent(ctx, scanner, sp);
+      sp->scan_failed_OOM_percent = pct < 1.0 ? pct : nextafter(1.0, 0.0);
       IndexError_RaiseBackgroundIndexFailureFlag(&sp->stats.indexError);
     }
     StrongRef_Release(curr_run_ref);

--- a/src/indexes_scanner.c
+++ b/src/indexes_scanner.c
@@ -83,7 +83,7 @@ void IndexesScanner_RecordBackgroundFailure(RedisModuleCtx *ctx, IndexesScanner 
       // scannedKeys to (or past) DbSize, which IndexesScanner_IndexedPercent clamps to
       // a complete-looking 1.0 — that must never be reported for a failed build.
       double pct = IndexesScanner_IndexedPercent(ctx, scanner, sp);
-      sp->scan_failed_OOM_percent = pct < 1.0 ? pct : nextafter(1.0, 0.0);
+      sp->scan_failed_OOM_percent = pct < 1.0 ? pct : 1.0;
       IndexError_RaiseBackgroundIndexFailureFlag(&sp->stats.indexError);
     }
     StrongRef_Release(curr_run_ref);

--- a/src/indexes_scanner.c
+++ b/src/indexes_scanner.c
@@ -187,6 +187,9 @@ IndexesScanner *IndexesScanner_New(StrongRef global_ref) {
   }
   spec->scanner = scanner;
   spec->scan_in_progress = true;
+  spec->scan_failed_OOM = false;
+  spec->scan_failed_OOM_scanned_keys = 0;
+  IndexError_ClearBackgroundIndexFailureFlag(&spec->stats.indexError);
 
   return scanner;
 }

--- a/src/indexes_scanner.c
+++ b/src/indexes_scanner.c
@@ -72,14 +72,13 @@ void IndexesScanner_RecordBackgroundFailure(RedisModuleCtx *ctx, IndexesScanner 
   StrongRef curr_run_ref = WeakRef_Promote(scanner->spec_ref);
   IndexSpec *sp = StrongRef_Get(curr_run_ref);
   if (sp) {
-    // A newer scan may have superseded this one while the GIL was released (the async OOM
-    // path drops it between aborting the cursor and re-taking it here): a recovery FT.ALTER
-    // would have run IndexesScanner_New, which cancels this scanner, installs a replacement
-    // as sp->scanner, and clears the OOM state. Recording this stale scanner's failure now
-    // would clobber that fresh state — re-raising scan_failed_OOM makes IndexSpec_UpdateDoc
-    // reject the replacement scan's keys, leaving the index permanently partial. So only
-    // record while this scanner is still the spec's current one. Both this function and
-    // IndexesScanner_New run under the GIL, so the check is serialized against the swap.
+    // A newer scan may have superseded this one while the GIL was released (the async OOM path
+    // drops it between aborting the cursor and re-taking it here): a recovery FT.ALTER would have
+    // run IndexesScanner_New, which cancels this scanner, installs a replacement as sp->scanner,
+    // and cleared the OOM state. Recording this stale scanner's failure now would clobber that
+    // fresh state — re-raising scan_failed_OOM makes IndexSpec_UpdateDoc reject the replacement
+    // scan's keys, leaving the index permanently partial. So only record while this scanner is
+    // still the spec's current one. Both this function and IndexesScanner_New run under the GIL.
     if (sp->scanner == scanner) {
       // Error message does not contain user data. scanner->OOMkey may be NULL when no
       // single key is to blame; IndexError_AddError falls back to the NA sentinel then.
@@ -205,14 +204,14 @@ IndexesScanner *IndexesScanner_New(StrongRef global_ref) {
   }
   spec->scanner = scanner;
   spec->scan_in_progress = true;
-  // NOTE: the persisted OOM state (scan_failed_OOM / scan_failed_OOM_scanned_keys / the
-  // background-index failure flag) is deliberately NOT cleared here. A recovery scan starting
-  // does not mean the index is complete yet — it still holds only the aborted build's partial
-  // data until this scan finishes. Clearing now would drop the query-time "partial data"
-  // warnings and flip FT.INFO to OK during that window. Instead the state is cleared in
-  // IndexesScanner_Free once the scan completes successfully. The write-block in
-  // IndexSpec_UpdateDoc is separately suppressed while scan_in_progress holds, so this scan can
-  // still index despite scan_failed_OOM remaining set.
+  // A fresh scan supersedes any earlier OOM-aborted build: clear the persisted OOM state so
+  // percent_indexed, FT.INFO's background-indexing status, and the new-document write-block in
+  // IndexSpec_UpdateDoc reflect this run rather than the old failure. If this scan also aborts on
+  // OOM, IndexesScanner_RecordBackgroundFailure re-sets them (and its supersession guard keeps a
+  // stale, superseded scanner from re-setting them behind this scan's back).
+  spec->scan_failed_OOM = false;
+  spec->scan_failed_OOM_scanned_keys = 0;
+  IndexError_ClearBackgroundIndexFailureFlag(&spec->stats.indexError);
 
   return scanner;
 }
@@ -228,17 +227,6 @@ void IndexesScanner_Free(IndexesScanner *scanner) {
       if (spec->scanner == scanner) {
         spec->scanner = NULL;
         spec->scan_in_progress = false;
-        // A scan that completed successfully (not cancelled, and it did not abort on OOM)
-        // supersedes any earlier OOM-aborted build: clear the persisted OOM state now, so
-        // percent_indexed, FT.INFO's background-indexing status, and query-time "partial
-        // data" warnings all reflect the now-complete index. A cancelled or OOM-aborted
-        // scan leaves the state untouched (a superseded scan is not the current scanner, so
-        // it does not reach here; an OOM abort keeps the failure visible for recovery).
-        if (!IndexesScanner_IsCancelled(scanner) && !scanner->scanFailedOnOOM) {
-          spec->scan_failed_OOM = false;
-          spec->scan_failed_OOM_scanned_keys = 0;
-          IndexError_ClearBackgroundIndexFailureFlag(&spec->stats.indexError);
-        }
       }
       StrongRef_Release(tmp);
     }

--- a/src/indexes_scanner.c
+++ b/src/indexes_scanner.c
@@ -75,6 +75,11 @@ void IndexesScanner_RecordBackgroundFailure(RedisModuleCtx *ctx, IndexesScanner 
     IndexError_AddError(&sp->stats.indexError, error, error, scanner->OOMkey);
     if (oom) {
       sp->scan_failed_OOM = true;
+      // Freeze how far the aborted scan got: once IndexesScanner_Free clears the
+      // scanner, IndexesScanner_IndexedPercent would otherwise default to 1.0 and
+      // hide the incomplete build. The scanner is still alive here, so this reads
+      // its live scannedKeys/DbSize fraction.
+      sp->scan_failed_OOM_percent = IndexesScanner_IndexedPercent(ctx, scanner, sp);
       IndexError_RaiseBackgroundIndexFailureFlag(&sp->stats.indexError);
     }
     StrongRef_Release(curr_run_ref);
@@ -141,7 +146,10 @@ double IndexesScanner_IndexedPercent(RedisModuleCtx *ctx, IndexesScanner *scanne
       return 0;
     }
   } else {
-    return 1.0;
+    // No active scanner: the build completed (1.0), unless the last background
+    // build aborted on OOM — then report the fraction it reached, frozen in
+    // scan_failed_OOM_percent, so a partial index isn't shown as complete.
+    return sp->scan_failed_OOM ? sp->scan_failed_OOM_percent : 1.0;
   }
 }
 

--- a/src/indexes_scanner.c
+++ b/src/indexes_scanner.c
@@ -12,7 +12,6 @@
 // the debug-scanner variant, and the background-indexing memory-limit helpers.
 
 #include <assert.h>
-#include <math.h>
 
 #include "indexes_scanner.h"
 

--- a/src/indexes_scanner.c
+++ b/src/indexes_scanner.c
@@ -76,14 +76,11 @@ void IndexesScanner_RecordBackgroundFailure(RedisModuleCtx *ctx, IndexesScanner 
     if (oom) {
       sp->scan_failed_OOM = true;
       // Freeze how far the aborted scan got: once IndexesScanner_Free clears the
-      // scanner, IndexesScanner_IndexedPercent would otherwise default to 1.0 and
-      // hide the incomplete build. The scanner is still alive here, so this reads
-      // its live scannedKeys/DbSize fraction. Cap strictly below 1.0: an OOM-aborted
-      // build is by definition incomplete, but duplicate SCAN deliveries can push
-      // scannedKeys to (or past) DbSize, which IndexesScanner_IndexedPercent clamps to
-      // a complete-looking 1.0 — that must never be reported for a failed build.
-      double pct = IndexesScanner_IndexedPercent(ctx, scanner, sp);
-      sp->scan_failed_OOM_percent = pct < 1.0 ? pct : 1.0;
+      // scanner, IndexesScanner_IndexedPercent would otherwise default to 1.0 and hide
+      // the incomplete build. Store the raw scanned-key count (the scanner is still
+      // alive here); IndexesScanner_IndexedPercent divides it by the live DbSize so the
+      // partial build is not reported as complete.
+      sp->scan_failed_OOM_scanned_keys = scanner->scannedKeys;
       IndexError_RaiseBackgroundIndexFailureFlag(&sp->stats.indexError);
     }
     StrongRef_Release(curr_run_ref);
@@ -138,23 +135,23 @@ bool isAsyncBgIndexingMemoryOverLimit(RedisModuleCtx *ctx) {
 }
 
 double IndexesScanner_IndexedPercent(RedisModuleCtx *ctx, IndexesScanner *scanner, const IndexSpec *sp) {
-  if (scanner || sp->scan_in_progress) {
-    if (scanner) {
-      size_t totalKeys = RedisModule_DbSize(ctx);
-      // scannedKeys counts every delivery, so duplicate deliveries (SCAN/AsyncScan are
-      // at-least-once) can push it past totalKeys; clamp so the reported percent never
-      // exceeds 100%.
-      double pct = totalKeys > 0 ? (double)scanner->scannedKeys / totalKeys : 0;
-      return pct > 1.0 ? 1.0 : pct;
-    } else {
-      return 0;
-    }
+  // Pick the scanned-key count to measure against the current DbSize:
+  size_t scannedKeys;
+  if (scanner) {
+    scannedKeys = scanner->scannedKeys;             // active scan: live progress
+  } else if (sp->scan_in_progress) {
+    return 0.0;                                     // scan pending, no scanner yet: 0%
+  } else if (sp->scan_failed_OOM) {
+    scannedKeys = sp->scan_failed_OOM_scanned_keys; // last build OOM-aborted: frozen progress
   } else {
-    // No active scanner: the build completed (1.0), unless the last background
-    // build aborted on OOM — then report the fraction it reached, frozen in
-    // scan_failed_OOM_percent, so a partial index isn't shown as complete.
-    return sp->scan_failed_OOM ? sp->scan_failed_OOM_percent : 1.0;
+    return 1.0;                                     // no scan pending: build completed
   }
+  size_t totalKeys = RedisModule_DbSize(ctx);
+  // scannedKeys counts every delivery, so duplicate deliveries (SCAN/AsyncScan are
+  // at-least-once) can push it past totalKeys; clamp so the reported percent never
+  // exceeds 100%.
+  double pct = totalKeys > 0 ? (double)scannedKeys / totalKeys : 0.0;
+  return pct > 1.0 ? 1.0 : pct;
 }
 
 IndexesScanner *IndexesScanner_NewGlobal() {

--- a/src/indexes_scanner.h
+++ b/src/indexes_scanner.h
@@ -102,9 +102,9 @@ void IndexesScanner_ResetProgression(struct IndexesScanner *scanner);
 
 // Fraction (0..1) of the keyspace indexed, for FT.INFO's percent_indexed. While a scan is
 // active it is scannedKeys/DbSize (clamped to 1.0). With no active scanner it is 1.0 —
-// except when the last background build aborted on OOM (sp->scan_failed_OOM), where it
-// returns the fraction that build reached (sp->scan_failed_OOM_percent) so an incomplete
-// index is not reported as complete.
+// except when the last background build aborted on OOM (sp->scan_failed_OOM), where the
+// key count that build reached (sp->scan_failed_OOM_scanned_keys) is divided by the current
+// DbSize so an incomplete index is not reported as complete.
 double IndexesScanner_IndexedPercent(RedisModuleCtx *ctx, IndexesScanner *scanner, const IndexSpec *sp);
 
 // Record a background-indexing failure on the scanner's spec so it is visible to

--- a/src/indexes_scanner.h
+++ b/src/indexes_scanner.h
@@ -100,6 +100,11 @@ void IndexesScanner_Free(IndexesScanner *scanner);
 void IndexesScanner_Cancel(struct IndexesScanner *scanner);
 void IndexesScanner_ResetProgression(struct IndexesScanner *scanner);
 
+// Fraction (0..1) of the keyspace indexed, for FT.INFO's percent_indexed. While a scan is
+// active it is scannedKeys/DbSize (clamped to 1.0). With no active scanner it is 1.0 —
+// except when the last background build aborted on OOM (sp->scan_failed_OOM), where it
+// returns the fraction that build reached (sp->scan_failed_OOM_percent) so an incomplete
+// index is not reported as complete.
 double IndexesScanner_IndexedPercent(RedisModuleCtx *ctx, IndexesScanner *scanner, const IndexSpec *sp);
 
 // Record a background-indexing failure on the scanner's spec so it is visible to

--- a/src/info/index_error.c
+++ b/src/info/index_error.c
@@ -81,6 +81,11 @@ void IndexError_RaiseBackgroundIndexFailureFlag(IndexError *error) {
     error->background_indexing_OOM_failure = true;
 }
 
+void IndexError_ClearBackgroundIndexFailureFlag(IndexError *error) {
+    // Change the background_indexing_OOM_failure flag to false.
+    error->background_indexing_OOM_failure = false;
+}
+
 void IndexError_Clear(IndexError error) {
     RS_ASSERT(error.last_error_without_user_data && error.last_error_with_user_data);
     if (!NA_rstr) initDefaultKey();

--- a/src/info/index_error.h
+++ b/src/info/index_error.h
@@ -96,6 +96,11 @@ IndexError IndexError_Deserialize(MRReply *reply, bool withOOMstatus);
 // Change the background_indexing_OOM_failure flag to true.
 void IndexError_RaiseBackgroundIndexFailureFlag(IndexError *error);
 
+// Clear the background_indexing_OOM_failure flag (e.g. when a fresh scan supersedes an
+// earlier OOM-aborted build). Only clears the status flag, not the cumulative failure
+// count or last-error message, which are historical.
+void IndexError_ClearBackgroundIndexFailureFlag(IndexError *error);
+
 // Get the background_indexing_OOM_failure flag.
 bool IndexError_HasBackgroundIndexingOOMFailure(const IndexError *error);
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -2190,7 +2190,7 @@ static void initializeIndexSpec(IndexSpec *sp, const HiddenString *name, IndexFl
   sp->scanner = NULL;
   sp->scan_in_progress = false;
   sp->scan_failed_OOM = false;
-  sp->scan_failed_OOM_percent = 0;
+  sp->scan_failed_OOM_scanned_keys = 0;
   sp->diskSpec = NULL;
   sp->pendingDiskRdbState = NULL;
   sp->diskRegistered = false;

--- a/src/spec.c
+++ b/src/spec.c
@@ -3375,11 +3375,7 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
 
   QueryError status = QueryError_Default();
 
-  // Block new documents while the index is knowingly incomplete from an OOM-aborted build,
-  // but NOT while a scan is in progress: a recovery scan (and the real-time writes alongside
-  // it) must be allowed to index, even though scan_failed_OOM stays set until that scan
-  // completes successfully (it still gates the query-time "partial data" warnings meanwhile).
-  if(spec->scan_failed_OOM && !spec->scan_in_progress) {
+  if(spec->scan_failed_OOM) {
     QueryError_SetWithoutUserDataFmt(&status, QUERY_ERROR_CODE_INDEX_BG_OOM_FAIL, "Index background scan did not complete due to OOM. New documents will not be indexed.");
     IndexError_AddQueryError(&spec->stats.indexError, &status, key);
     QueryError_ClearError(&status);

--- a/src/spec.c
+++ b/src/spec.c
@@ -2190,6 +2190,7 @@ static void initializeIndexSpec(IndexSpec *sp, const HiddenString *name, IndexFl
   sp->scanner = NULL;
   sp->scan_in_progress = false;
   sp->scan_failed_OOM = false;
+  sp->scan_failed_OOM_percent = 0;
   sp->diskSpec = NULL;
   sp->pendingDiskRdbState = NULL;
   sp->diskRegistered = false;

--- a/src/spec.c
+++ b/src/spec.c
@@ -3375,7 +3375,11 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
 
   QueryError status = QueryError_Default();
 
-  if(spec->scan_failed_OOM) {
+  // Block new documents while the index is knowingly incomplete from an OOM-aborted build,
+  // but NOT while a scan is in progress: a recovery scan (and the real-time writes alongside
+  // it) must be allowed to index, even though scan_failed_OOM stays set until that scan
+  // completes successfully (it still gates the query-time "partial data" warnings meanwhile).
+  if(spec->scan_failed_OOM && !spec->scan_in_progress) {
     QueryError_SetWithoutUserDataFmt(&status, QUERY_ERROR_CODE_INDEX_BG_OOM_FAIL, "Index background scan did not complete due to OOM. New documents will not be indexed.");
     IndexError_AddQueryError(&spec->stats.indexError, &status, key);
     QueryError_ClearError(&status);

--- a/src/spec.h
+++ b/src/spec.h
@@ -325,6 +325,11 @@ typedef struct IndexSpec {
   // in favor on a newer, pending scan
   bool scan_in_progress;
   bool scan_failed_OOM; // background indexing failed due to Out Of Memory
+  // Fraction of the keyspace the background build had scanned when it aborted on
+  // OOM, frozen before the scanner is freed. FT.INFO reports it as percent_indexed
+  // while scan_failed_OOM holds, so an OOM-cancelled build is distinguishable from
+  // a completed one (which reports 1.0). Only meaningful when scan_failed_OOM is set.
+  double scan_failed_OOM_percent;
   bool monitorDocumentExpiration;
   bool monitorFieldExpiration;
   bool isDuplicate;               // Marks that this index is a duplicate of an existing one

--- a/src/spec.h
+++ b/src/spec.h
@@ -325,11 +325,12 @@ typedef struct IndexSpec {
   // in favor on a newer, pending scan
   bool scan_in_progress;
   bool scan_failed_OOM; // background indexing failed due to Out Of Memory
-  // Fraction of the keyspace the background build had scanned when it aborted on
-  // OOM, frozen before the scanner is freed. FT.INFO reports it as percent_indexed
-  // while scan_failed_OOM holds, so an OOM-cancelled build is distinguishable from
-  // a completed one (which reports 1.0). Only meaningful when scan_failed_OOM is set.
-  double scan_failed_OOM_percent;
+  // Number of keys the background build had scanned when it aborted on OOM, frozen
+  // before the scanner is freed. IndexesScanner_IndexedPercent derives percent_indexed
+  // from it (over the current DbSize) while scan_failed_OOM holds, so an OOM-cancelled
+  // build is distinguishable from a completed one (which reports 1.0). Only meaningful
+  // when scan_failed_OOM is set.
+  size_t scan_failed_OOM_scanned_keys;
   bool monitorDocumentExpiration;
   bool monitorFieldExpiration;
   bool isDuplicate;               // Marks that this index is a duplicate of an existing one

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -1342,10 +1342,13 @@ def distinct_shard_tags(conn):
                 return
 
 def waitForIndexFinishScan(env, idx = 'idx'):
-    # Wait for the index to finish scan
-    # Check if equals 1 for RESP3 support
+    # Wait for the index to finish scanning. Poll the 'indexing' flag rather than
+    # percent_indexed: a background build aborted on OOM freezes percent_indexed
+    # below 1.0 (so a partial index isn't reported as complete), so it would never
+    # reach 1 and this would time out. 'indexing' drops to 0 once the scan ends,
+    # whether it completed or was cancelled by OOM.
     with TimeLimit(60, 'Timeout while waiting for index to finish scan'):
-        while index_info(env, idx)['percent_indexed'] not in (1, '1'):
+        while index_info(env, idx)['indexing'] not in (0, '0'):
             time.sleep(0.1)
 
 def bgScanCommand():
@@ -1402,10 +1405,10 @@ def allShards_waitForIndexStatus(env, status, idx='idx'):
         shard_waitForIndexStatus(env, shardId, status, idx)
 
 def shard_waitForIndexFinishScan(env, shardId, idx = 'idx'):
-    # Wait for the index to finish scan
-    # Check if equals 1 for RESP3 support
+    # Wait for the index to finish scanning. See waitForIndexFinishScan: poll the
+    # 'indexing' flag, since an OOM-aborted build freezes percent_indexed below 1.0.
     with TimeLimit(60, 'Timeout while waiting for index to finish scan'):
-        while index_info(env, idx)['percent_indexed'] not in (1, '1'):
+        while index_info(env, idx)['indexing'] not in (0, '0'):
             time.sleep(0.1)
 
 def allShards_waitForIndexFinishScan(env, idx = 'idx'):

--- a/tests/pytests/test_index_oom.py
+++ b/tests/pytests/test_index_oom.py
@@ -67,7 +67,8 @@ def test_stop_background_indexing_on_low_mem(env):
   env.assertEqual(docs_in_index, num_docs_scanned)
   # percent_indexed must reflect the OOM-cancelled build, not default to 1.0:
   # it is frozen at the fraction scanned when the scan aborted (~num_docs_scanned/num_docs).
-  percent_indexed = index_info(env)['percent_indexed']
+  # Cast to float: under RESP2 FT.INFO returns numeric values as strings.
+  percent_indexed = float(index_info(env)['percent_indexed'])
   env.assertLess(percent_indexed, 1.0)
   env.assertAlmostEqual(percent_indexed, num_docs_scanned / num_docs, delta=0.05)
   # Verify that used_memory is close to 80% (config set) of maxmemory
@@ -516,7 +517,7 @@ def test_oom_100_percent(env):
   error_dict = get_index_errors_dict(env)
   env.assertEqual(error_dict[bgIndexingStatusStr], OOMfailureStr)
   # The build aborted before indexing any doc; percent_indexed must not report 1.0.
-  env.assertLess(index_info(env)['percent_indexed'], 1.0)
+  env.assertLess(float(index_info(env)['percent_indexed']), 1.0)
 
 @skip(cluster=True)
 def test_pseudo_enterprise_oom_retry_success(env):
@@ -557,7 +558,7 @@ def test_pseudo_enterprise_oom_retry_success(env):
   # Verify index BG indexing status is OK
   env.assertEqual(index_errors[bgIndexingStatusStr], 'OK')
   # A build that recovered and completed still reports fully indexed.
-  env.assertEqual(index_info(env)['percent_indexed'], 1.0)
+  env.assertEqual(float(index_info(env)['percent_indexed']), 1.0)
 
 @skip(cluster=True)
 def test_pseudo_enterprise_oom_retry_failure(env):

--- a/tests/pytests/test_index_oom.py
+++ b/tests/pytests/test_index_oom.py
@@ -131,67 +131,6 @@ def test_oom_state_cleared_on_successful_rescan(env):
   env.assertEqual(get_index_errors_dict(env)[bgIndexingStatusStr], 'OK')
 
 @skip(cluster=True)
-def test_oom_status_persists_during_recovery_scan():
-  # The user-visible OOM state (percent_indexed < 1, FT.INFO 'background indexing status' =
-  # OOM failure, and the query "partial data" warning) must persist for the whole duration of
-  # a recovery scan: until it completes, the index still holds only the aborted build's partial
-  # data. The state is cleared only once the recovery scan finishes successfully. Meanwhile the
-  # new-document write-block is suppressed while the scan is in progress, so the recovery scan
-  # can actually index. RESP3 so the search warning is directly accessible.
-  env = Env(protocol=3)
-  oom_test_config(env)
-
-  num_docs = 1000
-  for i in range(num_docs):
-      env.expect('HSET', f'doc{i}', 'name', f'name{i}').equal(1)
-
-  # Drive a partial, OOM-cancelled initial build.
-  env.expect(bgScanCommand(), 'SET_PAUSE_ON_OOM', 'true').ok()
-  num_docs_scanned = num_docs // 4
-  env.expect(bgScanCommand(), 'SET_PAUSE_ON_SCANNED_DOCS', num_docs_scanned).ok()
-  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT').ok()
-  waitForIndexPauseScan(env, 'idx')
-  set_tight_maxmemory_for_oom(env, 0.85)
-  env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
-  waitForIndexStatus(env, 'PAUSED_ON_OOM', 'idx')
-  env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
-  waitForIndexFinishScan(env, 'idx')
-
-  # OOM state visible after the aborted build.
-  env.assertEqual(get_index_errors_dict(env)[bgIndexingStatusStr], OOMfailureStr)
-  env.assertLess(float(index_info(env)['percent_indexed']), 1.0)
-  env.assertEqual(env.cmd('FT.SEARCH', 'idx', '*')['warning'][0], partial_results_warning_str)
-
-  # Start a recovery scan, but pause it mid-flight so we can observe the in-progress window.
-  set_unlimited_maxmemory_for_oom(env)
-  env.expect(bgScanCommand(), 'SET_PAUSE_ON_OOM', 'false').ok()
-  env.expect(bgScanCommand(), 'SET_PAUSE_ON_SCANNED_DOCS', num_docs_scanned).ok()
-  env.expect(bgScanCommand(), 'SET_PAUSE_BEFORE_SCAN', 'true').ok()
-  env.expect('FT.ALTER', 'idx', 'SCHEMA', 'ADD', 'age', 'NUMERIC').ok()
-  waitForIndexStatus(env, 'NEW', 'idx')
-  env.expect(bgScanCommand(), 'SET_PAUSE_BEFORE_SCAN', 'false').ok()
-  env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
-  waitForIndexPauseScan(env, 'idx')
-
-  # Recovery is in progress and the index is still partial: the OOM state must NOT be cleared
-  # yet. (Before this fix it was cleared at scan start, silently dropping the warning.)
-  env.assertEqual(get_index_errors_dict(env)[bgIndexingStatusStr], OOMfailureStr)
-  env.assertLess(float(index_info(env)['percent_indexed']), 1.0)
-  env.assertEqual(env.cmd('FT.SEARCH', 'idx', '*')['warning'][0], partial_results_warning_str)
-
-  # Let the recovery scan run to completion.
-  env.expect(bgScanCommand(), 'SET_PAUSE_ON_SCANNED_DOCS', 0).ok()
-  env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
-  waitForIndexFinishScan(env, 'idx')
-
-  # Now the index is complete: the OOM state is cleared and every doc is indexed (the write-block
-  # did not reject the recovery scan's keys).
-  env.assertEqual(get_index_num_docs(env), num_docs)
-  env.assertEqual(float(index_info(env)['percent_indexed']), 1.0)
-  env.assertEqual(get_index_errors_dict(env)[bgIndexingStatusStr], 'OK')
-  env.assertNotContains(partial_results_warning_str, env.cmd('FT.SEARCH', 'idx', '*').get('warning', []))
-
-@skip(cluster=True)
 def test_stop_indexing_low_mem_verbosity():
   # Change to resp3
   env = Env(protocol=3)

--- a/tests/pytests/test_index_oom.py
+++ b/tests/pytests/test_index_oom.py
@@ -65,6 +65,11 @@ def test_stop_background_indexing_on_low_mem(env):
   # Verify that only num_docs_scanned were indexed
   docs_in_index = get_index_num_docs(env)
   env.assertEqual(docs_in_index, num_docs_scanned)
+  # percent_indexed must reflect the OOM-cancelled build, not default to 1.0:
+  # it is frozen at the fraction scanned when the scan aborted (~num_docs_scanned/num_docs).
+  percent_indexed = index_info(env)['percent_indexed']
+  env.assertLess(percent_indexed, 1.0)
+  env.assertAlmostEqual(percent_indexed, num_docs_scanned / num_docs, delta=0.05)
   # Verify that used_memory is close to 80% (config set) of maxmemory
   memory_ratio = get_memory_consumption_ratio(env)
   env.assertAlmostEqual(memory_ratio, 0.85, delta=0.1)
@@ -510,6 +515,8 @@ def test_oom_100_percent(env):
   # Verify OOM status
   error_dict = get_index_errors_dict(env)
   env.assertEqual(error_dict[bgIndexingStatusStr], OOMfailureStr)
+  # The build aborted before indexing any doc; percent_indexed must not report 1.0.
+  env.assertLess(index_info(env)['percent_indexed'], 1.0)
 
 @skip(cluster=True)
 def test_pseudo_enterprise_oom_retry_success(env):
@@ -549,6 +556,8 @@ def test_pseudo_enterprise_oom_retry_success(env):
   env.assertEqual(docs_in_index, num_docs)
   # Verify index BG indexing status is OK
   env.assertEqual(index_errors[bgIndexingStatusStr], 'OK')
+  # A build that recovered and completed still reports fully indexed.
+  env.assertEqual(index_info(env)['percent_indexed'], 1.0)
 
 @skip(cluster=True)
 def test_pseudo_enterprise_oom_retry_failure(env):

--- a/tests/pytests/test_index_oom.py
+++ b/tests/pytests/test_index_oom.py
@@ -131,6 +131,67 @@ def test_oom_state_cleared_on_successful_rescan(env):
   env.assertEqual(get_index_errors_dict(env)[bgIndexingStatusStr], 'OK')
 
 @skip(cluster=True)
+def test_oom_status_persists_during_recovery_scan():
+  # The user-visible OOM state (percent_indexed < 1, FT.INFO 'background indexing status' =
+  # OOM failure, and the query "partial data" warning) must persist for the whole duration of
+  # a recovery scan: until it completes, the index still holds only the aborted build's partial
+  # data. The state is cleared only once the recovery scan finishes successfully. Meanwhile the
+  # new-document write-block is suppressed while the scan is in progress, so the recovery scan
+  # can actually index. RESP3 so the search warning is directly accessible.
+  env = Env(protocol=3)
+  oom_test_config(env)
+
+  num_docs = 1000
+  for i in range(num_docs):
+      env.expect('HSET', f'doc{i}', 'name', f'name{i}').equal(1)
+
+  # Drive a partial, OOM-cancelled initial build.
+  env.expect(bgScanCommand(), 'SET_PAUSE_ON_OOM', 'true').ok()
+  num_docs_scanned = num_docs // 4
+  env.expect(bgScanCommand(), 'SET_PAUSE_ON_SCANNED_DOCS', num_docs_scanned).ok()
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT').ok()
+  waitForIndexPauseScan(env, 'idx')
+  set_tight_maxmemory_for_oom(env, 0.85)
+  env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
+  waitForIndexStatus(env, 'PAUSED_ON_OOM', 'idx')
+  env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
+  waitForIndexFinishScan(env, 'idx')
+
+  # OOM state visible after the aborted build.
+  env.assertEqual(get_index_errors_dict(env)[bgIndexingStatusStr], OOMfailureStr)
+  env.assertLess(float(index_info(env)['percent_indexed']), 1.0)
+  env.assertEqual(env.cmd('FT.SEARCH', 'idx', '*')['warning'][0], partial_results_warning_str)
+
+  # Start a recovery scan, but pause it mid-flight so we can observe the in-progress window.
+  set_unlimited_maxmemory_for_oom(env)
+  env.expect(bgScanCommand(), 'SET_PAUSE_ON_OOM', 'false').ok()
+  env.expect(bgScanCommand(), 'SET_PAUSE_ON_SCANNED_DOCS', num_docs_scanned).ok()
+  env.expect(bgScanCommand(), 'SET_PAUSE_BEFORE_SCAN', 'true').ok()
+  env.expect('FT.ALTER', 'idx', 'SCHEMA', 'ADD', 'age', 'NUMERIC').ok()
+  waitForIndexStatus(env, 'NEW', 'idx')
+  env.expect(bgScanCommand(), 'SET_PAUSE_BEFORE_SCAN', 'false').ok()
+  env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
+  waitForIndexPauseScan(env, 'idx')
+
+  # Recovery is in progress and the index is still partial: the OOM state must NOT be cleared
+  # yet. (Before this fix it was cleared at scan start, silently dropping the warning.)
+  env.assertEqual(get_index_errors_dict(env)[bgIndexingStatusStr], OOMfailureStr)
+  env.assertLess(float(index_info(env)['percent_indexed']), 1.0)
+  env.assertEqual(env.cmd('FT.SEARCH', 'idx', '*')['warning'][0], partial_results_warning_str)
+
+  # Let the recovery scan run to completion.
+  env.expect(bgScanCommand(), 'SET_PAUSE_ON_SCANNED_DOCS', 0).ok()
+  env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
+  waitForIndexFinishScan(env, 'idx')
+
+  # Now the index is complete: the OOM state is cleared and every doc is indexed (the write-block
+  # did not reject the recovery scan's keys).
+  env.assertEqual(get_index_num_docs(env), num_docs)
+  env.assertEqual(float(index_info(env)['percent_indexed']), 1.0)
+  env.assertEqual(get_index_errors_dict(env)[bgIndexingStatusStr], 'OK')
+  env.assertNotContains(partial_results_warning_str, env.cmd('FT.SEARCH', 'idx', '*').get('warning', []))
+
+@skip(cluster=True)
 def test_stop_indexing_low_mem_verbosity():
   # Change to resp3
   env = Env(protocol=3)

--- a/tests/pytests/test_index_oom.py
+++ b/tests/pytests/test_index_oom.py
@@ -114,8 +114,15 @@ def test_oom_state_cleared_on_successful_rescan(env):
   env.expect(bgScanCommand(), 'SET_PAUSE_ON_OOM', 'false').ok()
   env.expect(bgScanCommand(), 'SET_PAUSE_ON_SCANNED_DOCS', 0).ok()
 
-  # FT.ALTER schedules a fresh full scan over all keys.
+  # FT.ALTER schedules a fresh full scan over all keys. Gate it with SET_PAUSE_BEFORE_SCAN
+  # and wait for the 'NEW' status before resuming: the scan is scheduled asynchronously, so
+  # without this waitForIndexFinishScan could observe 'indexing'=0 (the scan hasn't started
+  # yet) and return before the rescan runs, especially under load.
+  env.expect(bgScanCommand(), 'SET_PAUSE_BEFORE_SCAN', 'true').ok()
   env.expect('FT.ALTER', 'idx', 'SCHEMA', 'ADD', 'age', 'NUMERIC').ok()
+  waitForIndexStatus(env, 'NEW', 'idx')
+  env.expect(bgScanCommand(), 'SET_PAUSE_BEFORE_SCAN', 'false').ok()
+  env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
   waitForIndexFinishScan(env, 'idx')
 
   # The successful rescan must have cleared the OOM state.

--- a/tests/pytests/test_index_oom.py
+++ b/tests/pytests/test_index_oom.py
@@ -76,6 +76,54 @@ def test_stop_background_indexing_on_low_mem(env):
   env.assertAlmostEqual(memory_ratio, 0.85, delta=0.1)
 
 @skip(cluster=True)
+def test_oom_state_cleared_on_successful_rescan(env):
+  # An OOM-aborted build persists scan_failed_OOM / scan_failed_OOM_scanned_keys on the
+  # spec. A later scan that completes (e.g. triggered by FT.ALTER once memory recovers)
+  # must clear that state: percent_indexed back to 1.0, background indexing status OK,
+  # and all docs indexed. Otherwise a fully-rebuilt index keeps reporting the old partial
+  # progress and "OOM failure" forever.
+  oom_test_config(env)
+
+  num_docs = 1000
+  for i in range(num_docs):
+      env.expect('HSET', f'doc{i}', 'name', f'name{i}').equal(1)
+
+  # Drive a partial, OOM-cancelled initial scan (same recipe as
+  # test_stop_background_indexing_on_low_mem): pause after a quarter of the docs, then
+  # tighten memory so resuming trips the OOM guard and cancels the build.
+  env.expect(bgScanCommand(), 'SET_PAUSE_ON_OOM', 'true').ok()
+  num_docs_scanned = num_docs // 4
+  env.expect(bgScanCommand(), 'SET_PAUSE_ON_SCANNED_DOCS', num_docs_scanned).ok()
+
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT').ok()
+  waitForIndexPauseScan(env, 'idx')
+  set_tight_maxmemory_for_oom(env, 0.85)
+  env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
+  waitForIndexStatus(env, 'PAUSED_ON_OOM', 'idx')
+  env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
+  waitForIndexFinishScan(env, 'idx')
+
+  # Precondition: the aborted build is reported as incomplete.
+  env.assertEqual(get_index_num_docs(env), num_docs_scanned)
+  env.assertLess(float(index_info(env)['percent_indexed']), 1.0)
+  env.assertEqual(get_index_errors_dict(env)[bgIndexingStatusStr], OOMfailureStr)
+
+  # Memory recovers, and the debug pauses that shaped the aborted scan are lifted so the
+  # next scan runs to completion.
+  set_unlimited_maxmemory_for_oom(env)
+  env.expect(bgScanCommand(), 'SET_PAUSE_ON_OOM', 'false').ok()
+  env.expect(bgScanCommand(), 'SET_PAUSE_ON_SCANNED_DOCS', 0).ok()
+
+  # FT.ALTER schedules a fresh full scan over all keys.
+  env.expect('FT.ALTER', 'idx', 'SCHEMA', 'ADD', 'age', 'NUMERIC').ok()
+  waitForIndexFinishScan(env, 'idx')
+
+  # The successful rescan must have cleared the OOM state.
+  env.assertEqual(get_index_num_docs(env), num_docs)
+  env.assertEqual(float(index_info(env)['percent_indexed']), 1.0)
+  env.assertEqual(get_index_errors_dict(env)[bgIndexingStatusStr], 'OK')
+
+@skip(cluster=True)
 def test_stop_indexing_low_mem_verbosity():
   # Change to resp3
   env = Env(protocol=3)


### PR DESCRIPTION
## Describe the changes in the pull request

On the event of an async background indexing failing because of OOM, the FT.INFO should not report a 100% indexed.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
