### PR TITLE
[MOD-17034] FT.CREATE/FT.ALTER: reject empty field name

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -1375,6 +1375,25 @@ static bool validateDiskJsonSinglePath(const IndexSpec *sp, const FieldSpec *fs,
   return true;
 }
 
+static bool validateFieldNameAndPath(const char *fieldName, size_t namelen, const char *fieldPath,
+                                     size_t pathlen, QueryError *status) {
+  // An empty field name is unsupported.
+  if (namelen == 0) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "Field name cannot be empty");
+    return false;
+  }
+  if (memchr(fieldName, '\0', namelen) != NULL) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "Field name cannot contain null bytes");
+    return false;
+  }
+  if (fieldPath && memchr(fieldPath, '\0', pathlen) != NULL) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "Field path cannot contain null bytes");
+    return false;
+  }
+
+  return true;
+}
+
 static void IndexSpec_EnsureSuffixForField(IndexSpec *sp, const FieldSpec *fs) {
   if (FieldSpec_IsIndexableText(fs) && FieldSpec_HasSuffixTrie(fs)) {
     sp->suffixMask |= FIELD_BIT(fs);
@@ -1387,6 +1406,7 @@ static void IndexSpec_EnsureSuffixForField(IndexSpec *sp, const FieldSpec *fs) {
 
 /**
  * Add fields to an existing (or newly created) index. If the addition fails,
+ * restore the schema state that was mutated while parsing this field batch.
  */
 static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCursor *ac,
                                        QueryError *status, int isNew) {
@@ -1426,17 +1446,7 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
       fieldPath = NULL;
     }
 
-    // An empty field name is unsupported.
-    if (namelen == 0) {
-      QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "Field name cannot be empty");
-      goto reset;
-    }
-    if (memchr(fieldName, '\0', namelen) != NULL) {
-      QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "Field name cannot contain null bytes");
-      goto reset;
-    }
-    if (fieldPath && memchr(fieldPath, '\0', pathlen) != NULL) {
-      QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "Field path cannot contain null bytes");
+    if (!validateFieldNameAndPath(fieldName, namelen, fieldPath, pathlen, status)) {
       goto reset;
     }
 
@@ -1565,6 +1575,9 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
   return 1;
 
 reset:
+  // Parsing may fail after appending field specs, consuming TEXT field IDs, or
+  // creating suffix-trie state. Restore every snapshot taken before this batch
+  // so failed FT.ALTER commands leave the existing schema unchanged.
   for (size_t ii = prevNumFields; ii < sp->numFields; ++ii) {
     IndexError_Clear(sp->fields[ii].indexError);
     FieldSpec_Cleanup(&sp->fields[ii]);

--- a/src/spec.c
+++ b/src/spec.c
@@ -15,6 +15,7 @@
 #include <math.h>
 #include <ctype.h>
 #include <limits.h>
+#include <string.h>
 
 #include "triemap_ffi.h"
 #include "util/logging.h"
@@ -1397,6 +1398,8 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
   const size_t prevNumFields = sp->numFields;
   const size_t prevSortLen = sp->numSortableFields;
   const IndexFlags prevFlags = sp->flags;
+  Trie *prevSuffix = sp->suffix;
+  const t_fieldMask prevSuffixMask = sp->suffixMask;
 
   while (!AC_IsAtEnd(ac)) {
     if (sp->numFields == SPEC_MAX_FIELDS) {
@@ -1422,11 +1425,13 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
       fieldPath = NULL;
     }
 
-    // An empty field name is unqueryable and, once persisted, crashes fork-GC when
-    // its entries are collected (the GC pipe serializes the name as a zero-length
-    // buffer that the parent decodes as NULL) - see MOD-17034 / MOD-16960.
+    // An empty field name is unsupported.
     if (namelen == 0) {
       QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "Field name cannot be empty");
+      goto reset;
+    }
+    if (memchr(fieldName, '\0', namelen) != NULL) {
+      QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "Field name cannot contain null bytes");
       goto reset;
     }
 
@@ -1562,8 +1567,12 @@ reset:
 
   sp->numFields = prevNumFields;
   sp->numSortableFields = prevSortLen;
-  // TODO: Why is this masking performed?
-  sp->flags = prevFlags | (sp->flags & Index_HasSuffixTrie);
+  if (sp->suffix && sp->suffix != prevSuffix) {
+    TrieType_Free(sp->suffix);
+  }
+  sp->suffix = prevSuffix;
+  sp->suffixMask = prevSuffixMask;
+  sp->flags = prevFlags;
   return 0;
 }
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -1422,6 +1422,14 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
       fieldPath = NULL;
     }
 
+    // An empty field name is unqueryable and, once persisted, crashes fork-GC when
+    // its entries are collected (the GC pipe serializes the name as a zero-length
+    // buffer that the parent decodes as NULL) - see MOD-17034 / MOD-16960.
+    if (namelen == 0) {
+      QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "Field name cannot be empty");
+      goto reset;
+    }
+
     if (IndexSpec_GetFieldWithLength(sp, fieldName, namelen)) {
       QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Duplicate field in schema", " - %s", fieldName);
       goto reset;

--- a/src/spec.c
+++ b/src/spec.c
@@ -1397,6 +1397,7 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
 
   const size_t prevNumFields = sp->numFields;
   const size_t prevSortLen = sp->numSortableFields;
+  const uint32_t prevFieldIdToIndexLen = array_len(sp->fieldIdToIndex);
   const IndexFlags prevFlags = sp->flags;
   Trie *prevSuffix = sp->suffix;
   const t_fieldMask prevSuffixMask = sp->suffixMask;
@@ -1432,6 +1433,10 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
     }
     if (memchr(fieldName, '\0', namelen) != NULL) {
       QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "Field name cannot contain null bytes");
+      goto reset;
+    }
+    if (fieldPath && memchr(fieldPath, '\0', pathlen) != NULL) {
+      QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "Field path cannot contain null bytes");
       goto reset;
     }
 
@@ -1567,6 +1572,7 @@ reset:
 
   sp->numFields = prevNumFields;
   sp->numSortableFields = prevSortLen;
+  array_set_len(sp->fieldIdToIndex, prevFieldIdToIndexLen);
   if (sp->suffix && sp->suffix != prevSuffix) {
     TrieType_Free(sp->suffix);
   }

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4098,13 +4098,6 @@ def test_mod1548(env):
     res = env.cmd('FT.SEARCH', 'idx', '@categories:{abcat0200000}', 'RETURN', '1', 'prod:id_dotnotation')
     env.assertEqual(res,  [2, 'prod:1', ['prod:id_dotnotation', '35114964'], 'prod:2', ['prod:id_dotnotation', '35114965']])
 
-def test_empty_field_name(env):
-    conn = getConnectionByEnv(env)
-
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', '', 'TEXT').ok()
-    conn.execute_command('hset', 'doc1', '', 'foo')
-    env.expect('FT.SEARCH', 'idx', 'foo').equal([1, 'doc1', ['', 'foo']])
-
 @skip(cluster=True)
 def test_free_resources_on_thread(env):
     conn = getConnectionByEnv(env)

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2293,6 +2293,8 @@ def testEmptyFieldNameRejected(env):
         .error().contains('Field name cannot be empty')
 
 def testFieldNameWithNullByteRejected(env):
+    # Without AS, the schema token is both the document path and the field name.
+    # With AS, the alias is the field name.
     conn = env.getClusterConnectionIfNeeded()
     with env.assertResponseError(contained='Field name cannot contain null bytes'):
         conn.execute_command('FT.CREATE', 'idx_nul_prefix', 'SCHEMA', b'\x00tag', 'TAG')
@@ -2301,12 +2303,24 @@ def testFieldNameWithNullByteRejected(env):
     with env.assertResponseError(contained='Field name cannot contain null bytes'):
         conn.execute_command('FT.CREATE', 'idx_nul_alias', 'SCHEMA', 'tag', 'AS', b'\x00alias', 'TAG')
 
-def testFieldPathWithNullByteRejected(env):
+def testHashFieldPathWithNullByteRejected(env):
+    # With AS, the original schema token is stored as a field path separate from
+    # the alias field name.
     conn = env.getClusterConnectionIfNeeded()
     with env.assertResponseError(contained='Field path cannot contain null bytes'):
         conn.execute_command('FT.CREATE', 'idx_path_nul_prefix', 'SCHEMA', b'\x00real', 'AS', 'tag', 'TAG')
     with env.assertResponseError(contained='Field path cannot contain null bytes'):
         conn.execute_command('FT.CREATE', 'idx_path_nul_embedded', 'SCHEMA', b'real\x00tail', 'AS', 'tag', 'TAG')
+
+@skip(no_json=True)
+def testJsonFieldPathWithNullByteRejected(env):
+    conn = env.getClusterConnectionIfNeeded()
+    with env.assertResponseError(contained='Field path cannot contain null bytes'):
+        conn.execute_command('FT.CREATE', 'idx_json_path_nul_prefix', 'ON', 'JSON',
+                             'SCHEMA', b'\x00$.real', 'AS', 'tag', 'TAG')
+    with env.assertResponseError(contained='Field path cannot contain null bytes'):
+        conn.execute_command('FT.CREATE', 'idx_json_path_nul_embedded', 'ON', 'JSON',
+                             'SCHEMA', b'$.real\x00tail', 'AS', 'tag', 'TAG')
 
 def testAlterFailureDoesNotLeaveSuffixTrie(env):
     env.cmd('FT.CREATE', 'idx_suffix_rollback', 'SCHEMA', 't', 'TEXT')
@@ -2323,16 +2337,22 @@ def testAlterFailureDoesNotLeaveSuffixTrie(env):
     env.expect('FT.SEARCH', 'idx_suffix_rollback', '*ell*', 'NOCONTENT').equal([1, 'doc:1'])
 
 def testAlterFailureDoesNotConsumeTextFieldIds(env):
-    env.cmd('FT.CREATE', 'idx_text_id_rollback', 'SCHEMA', 'base', 'TEXT')
+    env.cmd('FT.CREATE', 'idx_text_id_rollback', 'MAXTEXTFIELDS', 'SCHEMA', 'base', 'TEXT')
+    max_text_fields = arch_int_bits()
 
-    for i in range(130):
+    for i in range(max_text_fields - 1):
         env.expect('FT.ALTER', 'idx_text_id_rollback', 'SCHEMA', 'ADD',
                    f'tmp{i}', 'TEXT',
                    '', 'TAG') \
             .error().contains('Field name cannot be empty')
 
+    for i in range(max_text_fields - 1):
+        env.expect('FT.ALTER', 'idx_text_id_rollback', 'SCHEMA', 'ADD',
+                   f'valid_text_{i}', 'TEXT').ok()
+
     env.expect('FT.ALTER', 'idx_text_id_rollback', 'SCHEMA', 'ADD',
-               'valid_text', 'TEXT').ok()
+               'overflow_text', 'TEXT') \
+        .error().contains(f'Schema is limited to {max_text_fields} TEXT fields')
 
 def testSortbyMissingFieldSparse(env):
     # Note, the document needs to have one present sortable field in

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2280,10 +2280,7 @@ def testDuplicateSpec(env):
                 'SCHEMA', 'f1', 'text', 'n1', 'numeric', 'f1', 'text')
 
 def testEmptyFieldNameRejected(env):
-    # An empty field name is unqueryable and, once persisted, crashes fork-GC when its
-    # entries are collected (the GC pipe serializes the name as a zero-length buffer that
-    # the parent decodes as NULL). It must be rejected at schema parse time.
-    # MOD-17034 / MOD-16960.
+    # An empty field name is unsupported.
     for field_type in ('TAG', 'TEXT', 'NUMERIC'):
         env.expect('FT.CREATE', 'idx', 'SCHEMA', '', field_type) \
             .error().contains('Field name cannot be empty')
@@ -2294,6 +2291,29 @@ def testEmptyFieldNameRejected(env):
     env.cmd('FT.CREATE', 'idx_alter', 'SCHEMA', 't', 'TAG')
     env.expect('FT.ALTER', 'idx_alter', 'SCHEMA', 'ADD', '', 'TAG') \
         .error().contains('Field name cannot be empty')
+
+def testFieldNameWithNullByteRejected(env):
+    conn = env.getClusterConnectionIfNeeded()
+    with env.assertResponseError(contained='Field name cannot contain null bytes'):
+        conn.execute_command('FT.CREATE', 'idx_nul_prefix', 'SCHEMA', b'\x00tag', 'TAG')
+    with env.assertResponseError(contained='Field name cannot contain null bytes'):
+        conn.execute_command('FT.CREATE', 'idx_nul_embedded', 'SCHEMA', b'tag\x00name', 'TAG')
+    with env.assertResponseError(contained='Field name cannot contain null bytes'):
+        conn.execute_command('FT.CREATE', 'idx_nul_alias', 'SCHEMA', 'tag', 'AS', b'\x00alias', 'TAG')
+
+def testAlterFailureDoesNotLeaveSuffixTrie(env):
+    env.cmd('FT.CREATE', 'idx_suffix_rollback', 'SCHEMA', 't', 'TEXT')
+    conn = env.getClusterConnectionIfNeeded()
+    conn.execute_command('HSET', 'doc:1', 't', 'hello')
+    waitForIndex(env, 'idx_suffix_rollback')
+    env.expect('FT.SEARCH', 'idx_suffix_rollback', '*ell*', 'NOCONTENT').equal([1, 'doc:1'])
+
+    env.expect('FT.ALTER', 'idx_suffix_rollback', 'SCHEMA', 'ADD',
+               'suffix', 'TEXT', 'WITHSUFFIXTRIE',
+               '', 'TEXT') \
+        .error().contains('Field name cannot be empty')
+
+    env.expect('FT.SEARCH', 'idx_suffix_rollback', '*ell*', 'NOCONTENT').equal([1, 'doc:1'])
 
 def testSortbyMissingFieldSparse(env):
     # Note, the document needs to have one present sortable field in

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2301,6 +2301,13 @@ def testFieldNameWithNullByteRejected(env):
     with env.assertResponseError(contained='Field name cannot contain null bytes'):
         conn.execute_command('FT.CREATE', 'idx_nul_alias', 'SCHEMA', 'tag', 'AS', b'\x00alias', 'TAG')
 
+def testFieldPathWithNullByteRejected(env):
+    conn = env.getClusterConnectionIfNeeded()
+    with env.assertResponseError(contained='Field path cannot contain null bytes'):
+        conn.execute_command('FT.CREATE', 'idx_path_nul_prefix', 'SCHEMA', b'\x00real', 'AS', 'tag', 'TAG')
+    with env.assertResponseError(contained='Field path cannot contain null bytes'):
+        conn.execute_command('FT.CREATE', 'idx_path_nul_embedded', 'SCHEMA', b'real\x00tail', 'AS', 'tag', 'TAG')
+
 def testAlterFailureDoesNotLeaveSuffixTrie(env):
     env.cmd('FT.CREATE', 'idx_suffix_rollback', 'SCHEMA', 't', 'TEXT')
     conn = env.getClusterConnectionIfNeeded()
@@ -2314,6 +2321,18 @@ def testAlterFailureDoesNotLeaveSuffixTrie(env):
         .error().contains('Field name cannot be empty')
 
     env.expect('FT.SEARCH', 'idx_suffix_rollback', '*ell*', 'NOCONTENT').equal([1, 'doc:1'])
+
+def testAlterFailureDoesNotConsumeTextFieldIds(env):
+    env.cmd('FT.CREATE', 'idx_text_id_rollback', 'SCHEMA', 'base', 'TEXT')
+
+    for i in range(130):
+        env.expect('FT.ALTER', 'idx_text_id_rollback', 'SCHEMA', 'ADD',
+                   f'tmp{i}', 'TEXT',
+                   '', 'TAG') \
+            .error().contains('Field name cannot be empty')
+
+    env.expect('FT.ALTER', 'idx_text_id_rollback', 'SCHEMA', 'ADD',
+               'valid_text', 'TEXT').ok()
 
 def testSortbyMissingFieldSparse(env):
     # Note, the document needs to have one present sortable field in

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2279,6 +2279,22 @@ def testDuplicateSpec(env):
         env.cmd('FT.CREATE', 'idx', 'ON', 'HASH',
                 'SCHEMA', 'f1', 'text', 'n1', 'numeric', 'f1', 'text')
 
+def testEmptyFieldNameRejected(env):
+    # An empty field name is unqueryable and, once persisted, crashes fork-GC when its
+    # entries are collected (the GC pipe serializes the name as a zero-length buffer that
+    # the parent decodes as NULL). It must be rejected at schema parse time.
+    # MOD-17034 / MOD-16960.
+    for field_type in ('TAG', 'TEXT', 'NUMERIC'):
+        env.expect('FT.CREATE', 'idx', 'SCHEMA', '', field_type) \
+            .error().contains('Field name cannot be empty')
+    # empty name supplied via an explicit AS alias
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'myfield', 'AS', '', 'TAG') \
+        .error().contains('Field name cannot be empty')
+    # empty name added via FT.ALTER
+    env.cmd('FT.CREATE', 'idx_alter', 'SCHEMA', 't', 'TAG')
+    env.expect('FT.ALTER', 'idx_alter', 'SCHEMA', 'ADD', '', 'TAG') \
+        .error().contains('Field name cannot be empty')
+
 def testSortbyMissingFieldSparse(env):
     # Note, the document needs to have one present sortable field in
     # order for the indexer to give it a sort vector

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2340,6 +2340,9 @@ def testAlterFailureDoesNotConsumeTextFieldIds(env):
     env.cmd('FT.CREATE', 'idx_text_id_rollback', 'MAXTEXTFIELDS', 'SCHEMA', 'base', 'TEXT')
     max_text_fields = arch_int_bits()
 
+    # Exercise the whole TEXT field-id space, not just one failed ALTER. If rollback
+    # leaks fieldIdToIndex entries, the failure only becomes visible once later valid
+    # additions reach the architecture-specific field-mask limit.
     for i in range(max_text_fields - 1):
         env.expect('FT.ALTER', 'idx_text_id_rollback', 'SCHEMA', 'ADD',
                    f'tmp{i}', 'TEXT',


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `FT.CREATE` / `FT.ALTER` accept an **empty field name** (`""`) — either as the schema token (`SCHEMA "" TAG`) or as an explicit alias (`… AS "" TAG`). `IndexSpec_AddFieldsInternal` never checks that the parsed name is non-empty, so `IndexSpec_CreateField` stores `fs->name = ""` and the field indexes data normally.
2. **Change:** Reject an empty field name at schema-parse time (`IndexSpec_AddFieldsInternal`, `src/spec.c`) with the error `Field name cannot be empty`, for both `FT.CREATE` and `FT.ALTER`, covering the plain-token, `AS`-alias, and `ALTER … ADD` forms.
3. **Outcome:** An empty-named field can no longer be created. This closes the root cause of a production crash: an empty-named **TAG** field crashes fork-GC on older lines — the GC child serializes the field name as a zero-length buffer, the parent decodes it as `NULL`, and `IndexSpec_GetFormattedKeyByName` does `strlen(NULL)` → SIGSEGV (`si_code 1`, `(nil)`). Because the empty-named field is persisted, it becomes a deterministic crash loop on every AOF/RDB reload (see MOD-16960).

Note on scope: on `master` the fork-GC tag path was already refactored to resolve the field by explicit length (`IndexSpec_GetFieldWithLength`), so master does not hit the `strlen(NULL)` crash — but it still *accepted* empty names, which this PR fixes. **Backports to release branches (2.10.x / 8.x) should additionally guard the fork-GC tag path against a NULL / zero-length field name**, so already-persisted empty-named fields (created before this fix) don't keep crashing GC.

#### Which additional issues this PR fixes
1. MOD-17034
2. MOD-16960

#### Main objects this PR modified
1. `src/spec.c` — `IndexSpec_AddFieldsInternal`: reject `namelen == 0`.
2. `tests/pytests/test.py` — `testEmptyFieldNameRejected`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

`FT.CREATE` / `FT.ALTER` now reject an empty field name instead of silently creating an unqueryable field that could crash fork-GC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
