### PR TITLE
[Iterator Revalidation][MOD-17234] Profile

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1488,6 +1488,7 @@ dependencies = [
  "redis_mock",
  "redis_reply",
  "redisearch_rs",
+ "ref_mode",
  "rqe_core",
  "rstest",
  "tracing",

--- a/src/redisearch_rs/inverted_index/src/reader/geo.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/geo.rs
@@ -124,7 +124,6 @@ unsafe impl<IR: SuspendableReader> SuspendableReader for FilterGeoReader<IR> {
 /// proof there).
 unsafe impl<RS: ResumableReader> ResumableReader for FilterGeoReader<RS>
 where
-    for<'a> Self: 'static,
     for<'a> FilterGeoReader<RS::Resumed<'a>>: IndexReader<'a>,
 {
     type Resumed<'a> = FilterGeoReader<RS::Resumed<'a>>;

--- a/src/redisearch_rs/inverted_index/src/reader/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/numeric.rs
@@ -147,7 +147,6 @@ unsafe impl<IR: SuspendableReader> SuspendableReader for FilterNumericReader<IR>
 /// proof there).
 unsafe impl<RS: ResumableReader> ResumableReader for FilterNumericReader<RS>
 where
-    for<'a> Self: 'static,
     for<'a> FilterNumericReader<RS::Resumed<'a>>: IndexReader<'a>,
 {
     type Resumed<'a> = FilterNumericReader<RS::Resumed<'a>>;

--- a/src/redisearch_rs/numeric_range_tree/Cargo.toml
+++ b/src/redisearch_rs/numeric_range_tree/Cargo.toml
@@ -28,6 +28,7 @@ rqe_core.workspace = true
 hyperloglog.workspace = true
 index_result.workspace = true
 inverted_index.workspace = true
+ref_mode.workspace = true
 redis_reply.workspace = true
 generational_slab.workspace = true
 tracing.workspace = true

--- a/src/redisearch_rs/numeric_range_tree/src/index.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/index.rs
@@ -15,10 +15,11 @@
 use ffi::IndexFlags_Index_StoreNumeric;
 use index_result::RSIndexResult;
 use inverted_index::{
-    EntriesTrackingIndex, IndexReader, IndexReaderCore, NumericReader,
+    EntriesTrackingIndex, IndexReader, NumericReader, RawIndexReaderCore,
     debug::Summary,
     numeric::{Numeric, NumericFloatCompression},
 };
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
 /// Enum to hold either compressed or uncompressed numeric index.
@@ -156,14 +157,60 @@ impl NumericIndex {
     }
 }
 
-/// Iterate over the entries stored in a numeric index.
+/// Iterate over the entries stored in a numeric index, parameterised over a
+/// [`Ref`] mode.
 ///
-/// This abstracts over whether the underlying index is compressed or uncompressed.
-pub enum NumericIndexReader<'a> {
+/// Abstracts over whether the underlying index is compressed or uncompressed.
+/// `RawNumericIndexReader<Active<'index>>` (aliased [`NumericIndexReader`]) and
+/// `RawNumericIndexReader<Suspended>` are layout-identical, so the owning
+/// `RawInvIndIterator` can suspend/resume by a same-allocation reinterpretation —
+/// the [`SuspendableReader`](inverted_index::SuspendableReader) /
+/// [`ResumableReader`](inverted_index::ResumableReader) contract. This holds
+/// because `Rf` flows only through the per-variant [`RawIndexReaderCore`]
+/// payloads, each itself layout-compatible (invariant 1 on that type). Enforced
+/// by the `const _` proof below.
+#[repr(C)]
+pub enum RawNumericIndexReader<Rf: Ref> {
     /// Reader over uncompressed entries.
-    Uncompressed(IndexReaderCore<'a, Numeric>),
+    Uncompressed(RawIndexReaderCore<Rf, Numeric>),
     /// Reader over compressed entries.
-    Compressed(IndexReaderCore<'a, NumericFloatCompression>),
+    Compressed(RawIndexReaderCore<Rf, NumericFloatCompression>),
+}
+
+/// Active-form alias of [`RawNumericIndexReader`] — the live numeric reader.
+pub type NumericIndexReader<'index> = RawNumericIndexReader<Active<'index>>;
+
+// Compile-time proof that the `Active` and `Suspended` instantiations of
+// `RawNumericIndexReader` are layout-identical. As an enum we assert size and
+// alignment equality; the per-variant `RawIndexReaderCore` payloads are
+// layout-compatible by their own invariant 1, so a divergence here is a build error.
+const _: () = {
+    use std::mem::{align_of, size_of};
+    type A = RawNumericIndexReader<Active<'static>>;
+    type S = RawNumericIndexReader<Suspended>;
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
+// SAFETY: `RawNumericIndexReader<Active>` and `<Suspended>` are layout-identical
+// (const proof above), as `SuspendableReader` requires.
+unsafe impl<'a> inverted_index::SuspendableReader for NumericIndexReader<'a> {
+    type Suspended = RawNumericIndexReader<Suspended>;
+}
+
+// SAFETY: layout-compatible for the same reason as the `SuspendableReader` impl above.
+unsafe impl inverted_index::ResumableReader for RawNumericIndexReader<Suspended> {
+    type Resumed<'a> = NumericIndexReader<'a>;
+
+    unsafe fn refresh_pointers(&mut self) -> inverted_index::RefreshOutcome {
+        match self {
+            // SAFETY: our caller upholds `ResumableReader::refresh_pointers`'s
+            // read-lock obligation, which we forward unchanged to the inner reader.
+            Self::Uncompressed(r) => unsafe { r.refresh_pointers() },
+            // SAFETY: as above.
+            Self::Compressed(r) => unsafe { r.refresh_pointers() },
+        }
+    }
 }
 
 /// Marker trait for readers producing numeric values.

--- a/src/redisearch_rs/numeric_range_tree/src/lib.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/lib.rs
@@ -77,7 +77,7 @@ mod tree;
 mod unique_id;
 
 pub use arena::NodeIndex;
-pub use index::{NumericIndex, NumericIndexReader};
+pub use index::{NumericIndex, NumericIndexReader, RawNumericIndexReader};
 pub use inverted_index::NumericFilter;
 pub use iter::{IndexedReversePreOrderDfsIterator, ReversePreOrderDfsIterator};
 pub use node::{InternalNode, LeafNode, NumericRangeNode};

--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -219,6 +219,22 @@ impl<'query> TypeErasedRQESuspendedIterator<'query> {
     }
 }
 
+/// Compile-time assertion that `A` and `B` have the same size and alignment.
+///
+/// Call it in a `const {}` block so the check runs at monomorphization: a
+/// mismatch fails to compile instead of causing undefined behaviour when the
+/// suspend/resume helpers reinterpret an allocation from `A` to `B`.
+const fn assert_layout_compatible<A, B>() {
+    assert!(
+        std::mem::size_of::<A>() == std::mem::size_of::<B>(),
+        "size mismatch across suspend/resume transition: active and suspended representations must have identical size"
+    );
+    assert!(
+        std::mem::align_of::<A>() == std::mem::align_of::<B>(),
+        "alignment mismatch across suspend/resume transition: active and suspended representations must have identical alignment"
+    );
+}
+
 /// Suspend a single child slot in place: read the value out, call its
 /// [`RQEIteratorBoxed::suspend`] through the trait, and write the suspended
 /// counterpart back into the same slot.
@@ -241,9 +257,13 @@ impl<'query> TypeErasedRQESuspendedIterator<'query> {
 ///   `I::Suspended` from this point on — typically by performing a whole-box
 ///   cast on the containing composite (relabelling the Vec slot's static
 ///   type) and not reading the slot as `I` again.
-/// * `I` and `I::Suspended` must have the same size and alignment — guaranteed
-///   for all `RQEIteratorBoxed` impls in this crate by their `#[repr(C)]`
-///   layouts over `SharedPtr`/fat-pointer fields.
+///
+/// The size/alignment compatibility of `I` and `I::Suspended` that the internal
+/// `ptr::write` cast relies on is *not* a caller obligation: it is enforced at
+/// compile time by the `assert_layout_compatible` guard at the top of the body
+/// (a mismatched implementer fails to build). It holds for all
+/// `RQEIteratorBoxed` impls in this crate by their `#[repr(C)]` layouts over
+/// `SharedPtr`/fat-pointer fields.
 ///
 /// Between the `ptr::read` and the matching `ptr::write` the slot is logically
 /// uninitialised while the caller (and any composite that owns it) still
@@ -256,6 +276,12 @@ pub unsafe fn suspend_child_slot_in_place<'index, I>(slot: *mut I)
 where
     I: RQEIteratorBoxed<'index> + 'index,
 {
+    // Statically enforce the size/alignment invariant the `ptr::write` cast
+    // below relies on: a mismatched-layout implementer fails to compile here.
+    const { assert_layout_compatible::<I, I::Suspended>() };
+
+    debug_assert!(!slot.is_null(), "slot must not be null");
+
     /// Aborts the process if dropped during unwinding through the
     /// uninitialised-slot window. Disarmed with [`std::mem::forget`] once the
     /// slot has been reinitialised.
@@ -280,12 +306,117 @@ where
     // Only the outer wrapper bytes may differ (and the wrapper's address doesn't
     // matter, see [`crate::interop::revalidate`] for the rationale).
     let suspended = *<I as RQEIteratorBoxed<'index>>::suspend(Box::new(active));
-    // SAFETY: `I` and `I::Suspended` share size and alignment (see contract
-    // above). The slot is uninitialised after the earlier `ptr::read`;
-    // writing a valid `I::Suspended` reinitialises it.
+    // SAFETY: `I` and `I::Suspended` share size and alignment (guaranteed by the
+    // `assert_layout_compatible` guard at the top of the body). The slot is
+    // uninitialised after the earlier `ptr::read`; writing a valid `I::Suspended`
+    // reinitialises it.
     unsafe { std::ptr::write(slot as *mut I::Suspended, suspended) };
     // Slot reinitialised — disarm the abort guard.
     std::mem::forget(bomb);
+}
+
+/// Outcome of [`resume_child_slot_in_place`], mirroring the recoverable
+/// discriminants of [`ResumeOutcome`] but *without* carrying the iterator —
+/// the resumed child is written back into the slot instead.
+pub(crate) enum ResumeSlotOutcome {
+    /// The child resumed at the same position; the slot now holds the active child.
+    Unchanged,
+    /// The child resumed but its position moved forward; the slot now holds the
+    /// active child.
+    Moved,
+    /// The child's state was unrecoverable. It was consumed and the slot is
+    /// **left uninitialised** — see the safety contract.
+    Aborted,
+}
+
+/// Resume a single child slot in place: read the suspended child out, drive its
+/// consuming [`RQESuspendedIterator::resume`] through the trait, and — on a
+/// recoverable outcome — write the resumed counterpart back into the **same
+/// slot**. This is the resume-direction mirror of
+/// [`suspend_child_slot_in_place`].
+///
+/// The inner iterator's own heap allocation is preserved by its `resume`, and
+/// the resumed value is written back to the same slot, so the *slot* address is
+/// stable. A caller that also reuses its own allocation (via
+/// `Box::into_raw`/`Box::from_raw`) therefore preserves every interior address
+/// across the suspend/resume cycle.
+///
+/// # Safety
+///
+/// * `slot` must point to a valid, exclusively-owned `S` value.
+/// * On [`Ok`](ResumeSlotOutcome::Unchanged)/[`Moved`](ResumeSlotOutcome::Moved)
+///   the slot's bytes are a valid `S::Resumed<'a>`; the caller must interpret
+///   the slot (and its container) as `S::Resumed<'a>` from this point on and not
+///   read it as `S` again.
+/// * On [`Aborted`](ResumeSlotOutcome::Aborted) or [`Err`] the child was consumed
+///   by its `resume` and the slot is **left uninitialised**; the caller must tear
+///   the container down WITHOUT dropping the slot.
+///
+/// The size/alignment compatibility of `S` and `S::Resumed<'a>` that the internal
+/// `ptr::write` cast relies on is *not* a caller obligation: it is enforced at
+/// compile time by the `assert_layout_compatible` guard at the top of the body
+/// (a mismatched implementer fails to build). It holds for all
+/// `RQEIteratorBoxed`/`RQESuspendedIterator` impls in this crate by their
+/// `#[repr(C)]` layouts.
+///
+/// Between the `ptr::read` and the matching `ptr::write` (or the caller's
+/// teardown) the slot is logically uninitialised. [`RQESuspendedIterator::resume`]
+/// is a safe trait method that may dispatch to arbitrary (including dyn)
+/// implementations and could panic; as in [`suspend_child_slot_in_place`], a
+/// panic is converted into a process abort rather than an unwind through the
+/// uninitialised slot.
+pub(crate) unsafe fn resume_child_slot_in_place<'query, 'a, S>(
+    slot: *mut S,
+    guard: &IndexSpecReadGuard<'a>,
+) -> Result<ResumeSlotOutcome, RQEIteratorError>
+where
+    S: RQESuspendedIterator<'query>,
+    'query: 'a,
+{
+    // Statically enforce the size/alignment invariant the `ptr::write` cast
+    // below relies on: a mismatched-layout implementer fails to compile here.
+    const { assert_layout_compatible::<S, S::Resumed<'a>>() };
+
+    debug_assert!(!slot.is_null(), "slot must not be null");
+
+    /// Aborts the process if dropped during unwinding through the
+    /// uninitialised-slot window. Disarmed with [`std::mem::forget`] once
+    /// `resume` has returned.
+    struct AbortOnUnwind;
+    impl Drop for AbortOnUnwind {
+        fn drop(&mut self) {
+            std::process::abort();
+        }
+    }
+
+    // SAFETY: caller guarantees `slot` is exclusively owned and points to a
+    // valid `S` value. `ptr::read` moves the value out; the slot bytes are
+    // typed-but-moved-from until the matching `ptr::write` (or teardown) below.
+    let suspended = unsafe { std::ptr::read(slot) };
+    // Armed across the uninitialised-slot window: if `resume` panics, drop
+    // aborts instead of unwinding through the moved-from slot.
+    let bomb = AbortOnUnwind;
+    let outcome = Box::new(suspended).resume(guard);
+    // `resume` returned normally (Ok/Aborted or Err) — the remaining steps below
+    // cannot panic, so disarm before we either write the slot back or hand an
+    // uninitialised slot to the caller for teardown.
+    std::mem::forget(bomb);
+
+    let (active, moved) = match outcome? {
+        ResumeOutcome::Aborted => return Ok(ResumeSlotOutcome::Aborted),
+        ResumeOutcome::Ok(active) => (active, false),
+        ResumeOutcome::Moved(active) => (active, true),
+    };
+    // SAFETY: `S` and `S::Resumed<'a>` share size and alignment (guaranteed by
+    // the `assert_layout_compatible` guard at the top of the body). The slot is
+    // uninitialised after the earlier `ptr::read`; writing a valid
+    // `S::Resumed<'a>` reinitialises it.
+    unsafe { std::ptr::write(slot as *mut S::Resumed<'a>, *active) };
+    Ok(if moved {
+        ResumeSlotOutcome::Moved
+    } else {
+        ResumeSlotOutcome::Unchanged
+    })
 }
 
 // --- Blanket bridges: concrete → dyn-safe -----------------------------------

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -10,8 +10,8 @@
 use std::{f64, ptr::NonNull};
 
 use crate::{
-    FieldExpirationChecker, IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus,
-    SkipToOutcome,
+    FieldExpirationChecker, IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError,
+    RQESuspendedIterator, RQEValidateStatus, ResumeOutcome, SkipToOutcome,
     c2rust::CRQEIterator,
     expiration_checker::{ExpirationChecker, NoOpChecker},
     profile_print::{ProfilePrint, ProfilePrintCtx, format_g},
@@ -24,13 +24,14 @@ use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use inverted_index::{
     FilterGeoReader, FilterNumericReader, IndexReader, NumericFilter, NumericReader,
+    ResumableReader, SuspendableReader,
 };
 use numeric_range_tree::{NumericIndexReader, NumericRangeTree};
 use query_types::QueryNodeType;
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
-use super::core::{InvIndIterator, RawInvIndIterator};
+use super::core::{InvIndIterator, RawInvIndIterator, ResumeStatus};
 
 /// An iterator over numeric inverted index entries, parameterised over a
 /// [`Ref`] mode. See [`Numeric`] for the [`Active`] instantiation that
@@ -44,8 +45,8 @@ use super::core::{InvIndIterator, RawInvIndIterator};
 /// * `R` - The type of the numeric reader.
 /// * `E` - The expiration checker type used to check for expired documents.
 #[repr(C)]
-pub struct RawNumeric<'query, Rf: Ref, R, E = NoOpChecker> {
-    it: RawInvIndIterator<'query, Rf, R, E>,
+pub struct RawNumeric<'query, Rf: Ref, R, E = NoOpChecker, RA = R> {
+    it: RawInvIndIterator<'query, Rf, R, E, RA>,
     /// The numeric range tree and its revision ID, used to detect changes during revalidation.
     range_tree_info: Option<RangeTreeInfo>,
     /// Minimum numeric range, only used in debug print.
@@ -56,7 +57,7 @@ pub struct RawNumeric<'query, Rf: Ref, R, E = NoOpChecker> {
 
 /// Alias for an [`Active`] [`RawNumeric`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
-pub type Numeric<'index, R, E = NoOpChecker> = RawNumeric<'index, Active<'index>, R, E>;
+pub type Numeric<'index, R, E = NoOpChecker> = RawNumeric<'index, Active<'index>, R, E, R>;
 
 /// Information about the numeric range tree backing a [`Numeric`] iterator.
 struct RangeTreeInfo {
@@ -65,6 +66,53 @@ struct RangeTreeInfo {
     /// The revision ID at the time the iterator was created.
     /// Used to detect if the tree has been modified.
     revision_id: u32,
+}
+
+impl<'query, Rf: Ref, R, E, RA> RawNumeric<'query, Rf, R, E, RA> {
+    /// Cached minimum numeric range (only used in debug print / FT.PROFILE).
+    pub const fn range_min(&self) -> f64 {
+        self.range_min
+    }
+
+    /// Cached maximum numeric range (only used in debug print / FT.PROFILE).
+    pub const fn range_max(&self) -> f64 {
+        self.range_max
+    }
+
+    /// Cached [`IndexFlags`] of the underlying inverted index — see
+    /// [`RawInvIndIterator::flags`].
+    pub const fn flags(&self) -> ffi::IndexFlags {
+        self.it.flags()
+    }
+
+    /// Check if the iterator should abort revalidation.
+    ///
+    /// The numeric range tree's revision id changes when the tree is
+    /// modified by GC (a node split or removal). The iterator's cached
+    /// `revision_id` snapshot is compared against the current value; if
+    /// they differ, the cursor is invalidated and the iterator must
+    /// [abort](RQEValidateStatus::Aborted).
+    ///
+    /// Reads only the range tree's `NonNull` pointer and `revision_id` (owned by
+    /// the spec, stable under the read lock); it materializes no `&'a`
+    /// reader/buffer borrow, so it is sound to call on the suspended form during
+    /// [`RQESuspendedIterator::resume`].
+    pub(crate) const fn should_abort(&self) -> bool {
+        // If there's no range tree, we can't check for changes
+        let Some(ref info) = self.range_tree_info else {
+            return false;
+        };
+
+        let current_revision_id = {
+            // SAFETY: Condition 2 of `Self::new` guarantees the tree
+            // remains valid for the iterator's lifetime.
+            let tree = unsafe { info.tree.as_ref() };
+            tree.revision_id()
+        };
+        // If the revision id changed the numeric tree was either completely deleted or a node was split or removed.
+        // The cursor is invalidated so we cannot revalidate the iterator.
+        current_revision_id != info.revision_id
+    }
 }
 
 impl<'index, R, E> Numeric<'index, R, E>
@@ -119,31 +167,6 @@ where
         }
     }
 
-    const fn should_abort(&self) -> bool {
-        // If there's no range tree, we can't check for changes
-        let Some(ref info) = self.range_tree_info else {
-            return false;
-        };
-
-        let current_revision_id = {
-            // SAFETY: Condition 2 of `Self::new` guarantees the tree
-            // remains valid for the iterator's lifetime.
-            let tree = unsafe { info.tree.as_ref() };
-            tree.revision_id()
-        };
-        // If the revision id changed the numeric tree was either completely deleted or a node was split or removed.
-        // The cursor is invalidated so we cannot revalidate the iterator.
-        current_revision_id != info.revision_id
-    }
-
-    pub const fn range_min(&self) -> f64 {
-        self.range_min
-    }
-
-    pub const fn range_max(&self) -> f64 {
-        self.range_max
-    }
-
     /// Get a reference to the underlying reader.
     ///
     /// This is used by FFI code to access the reader.
@@ -152,6 +175,85 @@ where
     }
 }
 
+impl<'index, R, E> RQEIteratorBoxed<'index> for Numeric<'index, R, E>
+where
+    R: NumericReader<'index> + SuspendableReader + 'index,
+    R::Suspended: ResumableReader,
+    for<'a> <R::Suspended as ResumableReader>::Resumed<'a>: NumericReader<'a>,
+    E: ExpirationChecker + 'static,
+{
+    // Reader weakens `R -> R::Suspended`; the frozen `RA = R` slot keeps the
+    // inner iterator's dispatch pointers unchanged across the cast.
+    type Suspended = RawNumeric<'index, Suspended, R::Suspended, E, R>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawNumeric` is `#[repr(C)]` over the inner
+        // `RawInvIndIterator`, layout-identical across modes by invariant 1 on
+        // [`RawInvIndIterator`]: `reader` weakens `R -> R::Suspended` while the
+        // frozen `RA = R` slot keeps the dispatch pointers unchanged. The
+        // remaining fields (`range_tree_info`, `range_min`, `range_max`) carry no
+        // `Rf`, so they survive the cast unchanged. `Box::from_raw` reuses the
+        // same heap allocation.
+        unsafe { Box::from_raw(raw as *mut RawNumeric<'index, Suspended, R::Suspended, E, R>) }
+    }
+}
+
+impl<'query, RS, E, RA> RQESuspendedIterator<'query> for RawNumeric<'query, Suspended, RS, E, RA>
+where
+    RS: ResumableReader,
+    for<'a> RS::Resumed<'a>: NumericReader<'a>,
+    E: ExpirationChecker + 'static,
+{
+    type Resumed<'a>
+        = Numeric<'a, RS::Resumed<'a>, E>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        mut self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Step 1: identity check on the suspended form. On abort we drop the
+        // suspended iterator without promoting it to Active — nothing is
+        // materialized.
+        if self.should_abort() {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        // Step 2: run the shared in-place resume transition on the inner core
+        // iterator (refresh pointers, reset stale offsets, promote the result,
+        // and re-seek if GC moved us). `guard` witnesses the read lock the
+        // refresh requires.
+        let status = self.it.resume_in_place(guard)?;
+
+        // Step 3: reinterpret the owning box's type. The heap address is
+        // preserved across the cast.
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawNumeric` is `#[repr(C)]` over the inner `RawInvIndIterator`
+        // (layout-identical across modes by invariant 1 on `RawInvIndIterator`)
+        // plus the `Rf`-free `range_tree_info`/`range_min`/`range_max` fields.
+        // `resume_in_place` left the inner iterator as a valid active iterator, so
+        // the whole `RawNumeric` is now a valid `Numeric<'a, RS::Resumed<'a>, E>`.
+        let active = unsafe { Box::from_raw(raw as *mut Numeric<'a, RS::Resumed<'a>, E>) };
+
+        Ok(match status {
+            ResumeStatus::Unchanged => ResumeOutcome::Ok(active),
+            ResumeStatus::Moved => ResumeOutcome::Moved(active),
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.it.last_doc_id_field()
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.it.num_estimated()
+    }
+}
 impl<'index, R, E> RQEIterator<'index> for Numeric<'index, R, E>
 where
     R: NumericReader<'index>,
@@ -434,12 +536,12 @@ impl<'index> NumericIteratorVariant<'index> {
         }
     }
 
-    /// Returns the flags from the underlying index reader.
-    pub fn flags(&self) -> IndexFlags {
+    /// Returns the cached flags of the underlying index reader.
+    pub const fn flags(&self) -> IndexFlags {
         match self {
-            Self::Unfiltered(iter) => iter.reader().flags(),
-            Self::Filtered(iter) => iter.reader().flags(),
-            Self::Geo(iter) => iter.reader().flags(),
+            Self::Unfiltered(iter) => iter.flags(),
+            Self::Filtered(iter) => iter.flags(),
+            Self::Geo(iter) => iter.flags(),
         }
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/src/profile.rs
@@ -15,10 +15,14 @@
 
 use std::time::{Duration, Instant};
 
-use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+    boxed::{ResumeSlotOutcome, resume_child_slot_in_place, suspend_child_slot_in_place},
+};
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
 /// Profile counters collected during query execution.
@@ -59,6 +63,18 @@ impl ProfileCounters {
 ///
 /// The collected metrics can be accessed via [`Profile::counters()`] and
 /// [`Profile::wall_time_ns()`].
+///
+/// # Invariants
+///
+/// 1. **Layout compatibility across modes.** `RawProfile` is `#[repr(C)]` and
+///    carries no `Rf`-dependent field other than the zero-sized
+///    `_marker: PhantomData<Rf>`, so its `Active` and `Suspended`
+///    instantiations are layout-identical given that the child `I` and its
+///    `I::Suspended` are. That child-level compatibility is enforced at
+///    monomorphization by [`suspend_child_slot_in_place`]; the wrapper's own
+///    mode-independence is proven by the `const` block below. Together they let
+///    [`suspend`](RQEIteratorBoxed::suspend) reinterpret the owning `Box` in
+///    place.
 #[repr(C)]
 pub struct RawProfile<Rf: Ref, I> {
     child: I,
@@ -71,6 +87,28 @@ pub struct RawProfile<Rf: Ref, I> {
 /// Alias for an [`Active`] [`RawProfile`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
 pub type Profile<'index, I> = RawProfile<Active<'index>, I>;
+
+// Compile-time proof of invariant 1 on `RawProfile`: for a representative
+// concrete child, the `Active` and `Suspended` instantiations are
+// layout-identical. The child slot's own layout compatibility is the child's
+// invariant 1 (enforced generically for every implementer by
+// `suspend_child_slot_in_place`); the wrapper adds only `Rf`-free fields
+// (`counters`, `wall_time`) plus the zero-sized `PhantomData<Rf>`, so the two
+// modes cannot diverge here. `Wildcard` is a representative child whose own
+// `Active`/`Suspended` forms differ but stay layout-compatible.
+const _: () = {
+    use crate::Wildcard;
+    use std::mem::{align_of, offset_of, size_of};
+    type AChild = Wildcard<'static>;
+    type SChild = <Wildcard<'static> as RQEIteratorBoxed<'static>>::Suspended;
+    type A = RawProfile<Active<'static>, AChild>;
+    type S = RawProfile<Suspended, SChild>;
+    assert!(offset_of!(A, child) == offset_of!(S, child));
+    assert!(offset_of!(A, counters) == offset_of!(S, counters));
+    assert!(offset_of!(A, wall_time) == offset_of!(S, wall_time));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
 
 impl<'index, I: RQEIterator<'index>> Profile<'index, I> {
     /// Creates a new Profile iterator wrapping the given child iterator.
@@ -182,5 +220,147 @@ where
         let counters = self.counters();
         let mut child_ctx = ctx.with_counters(counters, self.wall_time_ns());
         self.child().print_profile(map, &mut child_ctx);
+    }
+}
+
+impl<'index, I> RQEIteratorBoxed<'index> for Profile<'index, I>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawProfile<Suspended, I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        // Suspend the child in place and reuse this box's allocation, mirroring
+        // `resume`. A whole-box cast alone is *not* enough: for a type-erased
+        // child (`TypeErasedRQEIterator`) the active and suspended forms carry
+        // different `dyn` vtables, so the transition must be dispatched through
+        // the child's own `suspend` — reinterpreting the bytes would leave the
+        // active vtable in place and make the later `resume` dispatch through the
+        // wrong vtable (UB). `suspend_child_slot_in_place` performs that dispatch
+        // (a no-op whole-box cast for concrete children, a vtable swap for erased
+        // ones). Reusing the allocation also keeps the box (and child-slot)
+        // address stable, which Profile relies on because it delegates
+        // `current()` — and hence the FFI wrapper's cached `header.current`
+        // pointer — into the child's storage.
+        let raw = Box::into_raw(self);
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+        // initialised, exclusively owned). `&raw mut` forms a field pointer to
+        // the `child` slot without creating a reference.
+        let child_slot = unsafe { &raw mut (*raw).child };
+        // SAFETY: `child_slot` points at the valid, exclusively-owned active
+        // child. `suspend_child_slot_in_place` drives the child's own `suspend`
+        // and reinitialises the slot as a valid `I::Suspended` in place.
+        unsafe { suspend_child_slot_in_place(child_slot) };
+        // SAFETY: the child slot now holds a valid `I::Suspended`, so the
+        // allocation is a valid `RawProfile<Suspended, I::Suspended>`: the
+        // `Active` and `Suspended` forms are layout-identical by invariant 1 on
+        // `RawProfile` (const proof above) — `counters`/`wall_time` carry no `Rf`
+        // and `_marker` is a ZST, while the child slot's `I`/`I::Suspended`
+        // size/alignment match is statically enforced by
+        // `suspend_child_slot_in_place`. `Box::from_raw` reuses the same
+        // allocation, so the box address is preserved.
+        unsafe { Box::from_raw(raw as *mut RawProfile<Suspended, I::Suspended>) }
+    }
+}
+
+/// Free a [`RawProfile`] allocation whose `child` slot has already been consumed
+/// (moved-from) by an aborted/failed child resume, without running the child's
+/// drop glue.
+///
+/// # Safety
+///
+/// * `raw` came from `Box::into_raw` and is still exclusively owned by the caller.
+/// * `(*raw).child` is moved-from (uninitialised) and must NOT be dropped.
+/// * No other reference to the allocation exists.
+unsafe fn dealloc_after_child_gone<S>(raw: *mut RawProfile<Suspended, S>) {
+    // SAFETY: `raw` is valid; `&raw mut` forms a field pointer without a reference.
+    let counters = unsafe { &raw mut (*raw).counters };
+    // SAFETY: `counters` is still a valid, owned value; drop it in place.
+    unsafe { std::ptr::drop_in_place(counters) };
+    // SAFETY: `raw` is valid; `&raw mut` forms a field pointer without a reference.
+    let wall_time = unsafe { &raw mut (*raw).wall_time };
+    // SAFETY: `wall_time` is still a valid, owned value; drop it in place.
+    unsafe { std::ptr::drop_in_place(wall_time) };
+    // `_marker` is a ZST with no drop glue.
+    // SAFETY: `raw` was allocated by `Box` with exactly this layout; the `child`
+    // slot is moved-from so it is not dropped. Frees the allocation.
+    unsafe {
+        std::alloc::dealloc(
+            raw.cast::<u8>(),
+            std::alloc::Layout::new::<RawProfile<Suspended, S>>(),
+        )
+    };
+}
+
+impl<'query, S> RQESuspendedIterator<'query> for RawProfile<Suspended, S>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = Profile<'a, S::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Resume the child in place and reuse this box's allocation, mirroring
+        // `RawInvIndIterator::resume`. Profile delegates `current()` — and hence
+        // the FFI wrapper's cached `header.current` pointer — into the child's
+        // storage, so the box (and the child slot inside it) must keep its
+        // address across the cycle; rebuilding via `Box::new` would dangle that
+        // pointer. Profile owns no aggregate result and simply mirrors the
+        // child's `Ok`/`Moved`/`Aborted` outcome.
+        let raw = Box::into_raw(self);
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+        // initialised, exclusively owned). `&raw mut` forms a field pointer to
+        // the `child` slot without creating a reference.
+        let child_slot = unsafe { &raw mut (*raw).child };
+        // SAFETY: `child_slot` points at the valid, exclusively-owned suspended
+        // child. On `Unchanged`/`Moved` the helper reinitialises the slot as
+        // `S::Resumed<'a>`; on `Aborted`/`Err` the child is consumed and the slot
+        // is left uninitialised (handled by the teardown arms below).
+        match unsafe { resume_child_slot_in_place(child_slot, guard) } {
+            Ok(outcome @ (ResumeSlotOutcome::Unchanged | ResumeSlotOutcome::Moved)) => {
+                // SAFETY: the child slot now holds a valid `S::Resumed<'a>`, so
+                // the allocation is a valid `Profile<'a, S::Resumed<'a>>`: the
+                // `Suspended` and `Active` forms are layout-identical by
+                // invariant 1 on `RawProfile` (const proof above) — the non-child
+                // fields carry no `Rf`, while the child slot's `S`/`S::Resumed`
+                // size/alignment match is statically enforced by
+                // `resume_child_slot_in_place`. `Box::from_raw` reuses the same
+                // allocation, preserving the box and child-slot addresses.
+                let active = unsafe { Box::from_raw(raw.cast::<Profile<'a, S::Resumed<'a>>>()) };
+                Ok(if matches!(outcome, ResumeSlotOutcome::Moved) {
+                    ResumeOutcome::Moved(active)
+                } else {
+                    ResumeOutcome::Ok(active)
+                })
+            }
+            Ok(ResumeSlotOutcome::Aborted) => {
+                // SAFETY: the child was consumed by its `resume` (slot
+                // uninitialised); free the reused allocation without dropping the
+                // moved-from child.
+                unsafe { dealloc_after_child_gone(raw) };
+                Ok(ResumeOutcome::Aborted)
+            }
+            Err(e) => {
+                // SAFETY: as the `Aborted` arm — the child is gone, tear the rest down.
+                unsafe { dealloc_after_child_gone(raw) };
+                Err(e)
+            }
+        }
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        S::last_doc_id(&self.child)
+    }
+
+    fn num_estimated(&self) -> usize {
+        S::num_estimated(&self.child)
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -15,13 +15,13 @@ use index_result::{RSIndexResult, RawIndexResult};
 use index_spec::IndexSpecReadGuard;
 use inverted_index::codec::{doc_ids_only::DocIdsOnly, raw_doc_ids_only::RawDocIdsOnly};
 use inverted_index::{DocIdsDecoder, opaque};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 use crate::{
-    Empty, RQEIterator, RQEIteratorError, RQEValidateStatus, SEARCH_ENTERPRISE_ITERATORS,
-    SkipToOutcome,
+    Empty, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SEARCH_ENTERPRISE_ITERATORS, SkipToOutcome,
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 use crate::{IteratorType, QueryError, RQEIteratorPrintable};
@@ -127,6 +127,49 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
     }
 }
 
+impl<'index> RQEIteratorBoxed<'index> for Wildcard<'index> {
+    type Suspended = RawWildcard<'index, Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `RawWildcard` is `#[repr(C)]` with the only `Rf`-dependent
+        // field being `result: RawIndexResult<Rf>`, layout-compatible across
+        // `Rf` (see [`crate::inverted_index::Wildcard::suspend`] for the
+        // same argument). Box::from_raw reuses the same heap allocation.
+        unsafe { Box::from_raw(raw as *mut RawWildcard<'index, Suspended>) }
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for RawWildcard<'query, Suspended> {
+    type Resumed<'a>
+        = Wildcard<'a>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        _guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let raw = Box::into_raw(self);
+        // SAFETY: layout-compatible — see `suspend`. The top-level wildcard
+        // owns no references into the index (it's just a counter), so there
+        // is no state to refresh.
+        let active = unsafe { Box::from_raw(raw as *mut Wildcard<'a>) };
+        Ok(ResumeOutcome::Ok(active))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        // Mode-independent — mirrors the active `num_estimated`.
+        self.top_id as usize
+    }
+}
 /// A marker trait for iterators that match all documents.
 pub trait WildcardIterator<'index>: RQEIterator<'index> {}
 
@@ -291,11 +334,25 @@ impl<'index> RQEIterator<'index> for NewWildcardIterator<'index> {
     }
 
     fn num_estimated(&self) -> usize {
-        delegate_wildcard_iterator!(self, num_estimated)
+        // Disambiguated against `RQESuspendedIterator::num_estimated` for the
+        // `Empty` variant (whose Suspended counterpart is `Empty` itself).
+        match self {
+            Self::NotOptimized(it) => RQEIterator::num_estimated(it),
+            Self::Optimized(it) => RQEIterator::num_estimated(it),
+            Self::Empty(it) => RQEIterator::num_estimated(it),
+            Self::Disk(it) => RQEIterator::num_estimated(it),
+        }
     }
 
     fn last_doc_id(&self) -> DocId {
-        delegate_wildcard_iterator!(self, last_doc_id)
+        // Disambiguated against `RQESuspendedIterator::last_doc_id` for the
+        // `Empty` variant (whose Suspended counterpart is `Empty` itself).
+        match self {
+            Self::NotOptimized(it) => RQEIterator::last_doc_id(it),
+            Self::Optimized(it) => RQEIterator::last_doc_id(it),
+            Self::Empty(it) => RQEIterator::last_doc_id(it),
+            Self::Disk(it) => RQEIterator::last_doc_id(it),
+        }
     }
 
     fn at_eof(&self) -> bool {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -415,6 +415,38 @@ fn numeric_no_range_tree_revalidate() {
     assert_eq!(status, RQEValidateStatus::Ok);
 }
 
+/// Resume sibling of [`numeric_no_range_tree_revalidate`]: with no range tree,
+/// `should_abort` returns false, so a suspend/resume cycle promotes the iterator
+/// back to `Active` (`Ok`) and the position is preserved.
+#[test]
+fn numeric_no_range_tree_resume() {
+    use rqe_iterators::TypeErasedRQEIterator;
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let mut ii =
+        InvertedIndex::<inverted_index::numeric::Numeric>::new(IndexFlags_Index_StoreNumeric);
+    let _ = ii.add_record(&RSIndexResult::build_numeric(1.0).doc_id(1).build());
+    let _ = ii.add_record(&RSIndexResult::build_numeric(2.0).doc_id(3).build());
+
+    // Build without a range tree — should_abort will return false.
+    let it = NumericBuilder::new(ii.reader()).build();
+
+    let guard = mock_ctx.spec_read();
+    let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+        .expect("resume should not fail in this test")
+        .expect_ok();
+
+    // The first doc is still available after resume (no range tree ⇒ no abort).
+    let record = it.read().expect("read failed").expect("expected a result");
+    assert_eq!(record.doc_id, 1);
+
+    // A second resume also succeeds.
+    revalidate_via_resume(it, &guard)
+        .expect("resume should not fail in this test")
+        .expect_ok();
+}
+
 /// A [`GeoFilter`] with a non-null address so `is_numeric_filter()` returns `false`.
 /// `fieldSpec` and `numericFilters` are null — tests using this stub must not
 /// reach code paths that dereference those pointers.
@@ -1101,5 +1133,69 @@ mod not_miri {
 
         test.test
             .revalidate_numeric_after_document_deleted(&mut it, ii);
+    }
+
+    /// Resume-flavored siblings of the `revalidate` tests above: the same
+    /// scenarios driven through a suspend/resume cycle
+    /// ([`revalidate_via_resume`]) rather than in-place [`RQEIterator::revalidate`].
+    mod via_resume {
+        use super::*;
+        use crate::inverted_index::utils::via_resume::{
+            revalidate_at_eof, revalidate_basic, revalidate_numeric_after_document_deleted,
+        };
+        use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator};
+        use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+        #[test]
+        fn numeric_revalidate_basic() {
+            let test = NumericRevalidateTest::new(10);
+            let it = test.create_iterator();
+            revalidate_basic(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn numeric_revalidate_at_eof() {
+            let test = NumericRevalidateTest::new(10);
+            let it = test.create_iterator();
+            revalidate_at_eof(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn numeric_revalidate_after_document_deleted() {
+            let test = NumericRevalidateTest::new(10);
+            let it = test.create_iterator();
+            let ii = test.test.context.numeric_inverted_index();
+            revalidate_numeric_after_document_deleted(&test.test, Box::new(it), ii);
+        }
+
+        /// Resume sibling of [`numeric_revalidate_after_index_disappears`]: a
+        /// range-tree revision bump while suspended (simulating a GC node
+        /// split/removal) must abort the resume, since the cached revision id no
+        /// longer matches.
+        #[test]
+        fn numeric_revalidate_after_range_tree_modified() {
+            let test = NumericRevalidateTest::new(10);
+            let it = Box::new(test.create_iterator());
+            let guard = test.test.context.spec_read();
+
+            // A clean resume cycle works before any modification; read one doc so
+            // the iterator holds a non-trivial position.
+            let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+                .expect("resume should not fail in this test")
+                .expect_ok();
+            assert!(it.read().expect("failed to read").is_some());
+
+            // Bump the range tree's revision id (interior mutability via raw
+            // pointer, so it does not conflict with the read guard).
+            {
+                let rt = test.test.context.numeric_range_tree_mut();
+                rt.increment_revision();
+            }
+
+            // The cached revision no longer matches, so resume must abort.
+            let outcome =
+                revalidate_via_resume(it, &guard).expect("resume should not fail in this test");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+        }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
@@ -14,7 +14,7 @@ use rqe_iterators::{
     profile::{Profile, ProfileCounters},
 };
 
-use crate::utils::{Mock, MockIteratorError};
+use crate::utils::{Mock, MockIteratorError, MockRevalidateResult};
 
 #[test]
 fn type_() {
@@ -220,4 +220,166 @@ fn counters_eof_saturates_at_zero() {
 fn counters_default_is_zero() {
     let counters = ProfileCounters::default();
     assert_eq!(counters.num_reading_operations(), 0);
+}
+
+mod via_resume {
+    use super::*;
+    use rqe_iterators::TypeErasedRQEIterator;
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    #[test]
+    fn profile_revalidate() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child = Wildcard::new(10, 1.0);
+        let mut profile = Box::new(Profile::new(child));
+
+        let _ = profile.read(); // doc 1
+        let _ = profile.read(); // doc 2
+
+        // Resume (Wildcard returns OK)
+        let mut profile =
+            revalidate_via_resume(TypeErasedRQEIterator::new(profile), &mock_ctx.spec_read())
+                .expect("resume failed")
+                .expect_ok();
+
+        // Verify delegation still works
+        assert_eq!(profile.last_doc_id(), 2);
+        assert_eq!(profile.current().unwrap().doc_id, 2);
+    }
+
+    /// The FFI wrapper caches a raw pointer into the iterator (`header.current`),
+    /// so a suspend→resume cycle must reuse the same heap allocation rather than
+    /// reallocate. Exercise the concrete (non-type-erased) path and assert the
+    /// box address survives both transitions.
+    #[test]
+    fn profile_resume_preserves_box_address() {
+        use rqe_iterators::{RQEIteratorBoxed, RQESuspendedIterator, ResumeOutcome};
+
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child = Wildcard::new(10, 1.0);
+        let mut profile = Box::new(Profile::new(child));
+
+        let _ = profile.read(); // doc 1
+        let _ = profile.read(); // doc 2
+
+        let addr_before = &*profile as *const _ as usize;
+
+        let suspended = profile.suspend();
+        assert_eq!(
+            &*suspended as *const _ as usize, addr_before,
+            "suspend must reuse the allocation"
+        );
+
+        let active = match suspended
+            .resume(&mock_ctx.spec_read())
+            .expect("resume failed")
+        {
+            ResumeOutcome::Ok(it) | ResumeOutcome::Moved(it) => it,
+            ResumeOutcome::Aborted => panic!("wildcard child should not abort"),
+        };
+
+        assert_eq!(
+            &*active as *const _ as usize, addr_before,
+            "resume must reuse the same allocation (FFI caches a pointer into it)"
+        );
+        assert_eq!(active.last_doc_id(), 2);
+    }
+
+    /// Regression test for a `Profile` wrapping a *type-erased* child — the
+    /// common case, since composites and the FFI hand `Profile` a
+    /// `TypeErasedRQEIterator`. `Profile::suspend` must drive the child's own
+    /// `suspend` (dispatching through the child's `dyn` vtable) rather than
+    /// blindly reinterpreting the child slot: a whole-box cast leaves the
+    /// child's *active* vtable in place while the type claims it is suspended,
+    /// so the later `resume` would dispatch through the wrong vtable (UB). The
+    /// earlier tests only cover a concrete child, for which the whole-box cast
+    /// happens to be sound.
+    #[test]
+    fn profile_over_type_erased_child_round_trips() {
+        use rqe_iterators::{RQEIteratorBoxed, RQESuspendedIterator, ResumeOutcome};
+
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child = TypeErasedRQEIterator::new(Box::new(Wildcard::new(10, 1.0)));
+        let mut profile = Box::new(Profile::new(child));
+
+        let _ = profile.read(); // doc 1
+        let _ = profile.read(); // doc 2
+
+        let addr_before = &*profile as *const _ as usize;
+
+        let suspended = profile.suspend();
+        let mut active = match suspended
+            .resume(&mock_ctx.spec_read())
+            .expect("resume failed")
+        {
+            ResumeOutcome::Ok(it) | ResumeOutcome::Moved(it) => it,
+            ResumeOutcome::Aborted => panic!("wildcard child should not abort"),
+        };
+
+        // The outer allocation is reused across the cycle...
+        assert_eq!(
+            &*active as *const _ as usize, addr_before,
+            "resume must reuse the same allocation (FFI caches a pointer into it)"
+        );
+        // ...and the type-erased child resumed at the right position and still
+        // reads correctly (would be corrupt if dispatched via the wrong vtable).
+        assert_eq!(active.last_doc_id(), 2);
+        assert_eq!(active.current().unwrap().doc_id, 2);
+        assert_eq!(active.read().unwrap().unwrap().doc_id, 3);
+    }
+
+    /// When the profiled child's revalidation is unrecoverable, `resume` must
+    /// report `Aborted` and tear the reused allocation down *without* dropping
+    /// the already-consumed child slot — exercising the
+    /// `dealloc_after_child_gone` teardown path. A leak, double-drop, or use of
+    /// the moved-from child in that path is what this guards against.
+    #[test]
+    fn profile_resume_aborts_when_child_validation_fails() {
+        use rqe_iterators::{RQEIteratorBoxed, RQESuspendedIterator, ResumeOutcome};
+
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child = Mock::new([1, 2, 3]);
+        child
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        let mut profile = Box::new(Profile::new(child));
+
+        let _ = profile.read(); // doc 1
+
+        let suspended = profile.suspend();
+        let outcome = suspended
+            .resume(&mock_ctx.spec_read())
+            .expect("resume must not surface an error for an aborting child");
+        assert!(
+            matches!(outcome, ResumeOutcome::Aborted),
+            "an unrecoverable child must abort the whole profile",
+        );
+    }
+
+    /// As [`profile_resume_aborts_when_child_validation_fails`], but for the
+    /// realistic case of a *type-erased* child: the abort teardown must run
+    /// correctly when the consumed child slot holds an erased suspended
+    /// iterator rather than a concrete one.
+    #[test]
+    fn profile_over_type_erased_child_aborts_on_validation_failure() {
+        use rqe_iterators::{RQEIteratorBoxed, RQESuspendedIterator, ResumeOutcome};
+
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let mock = Mock::new([1, 2, 3]);
+        mock.data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        let child = TypeErasedRQEIterator::new(Box::new(mock));
+        let mut profile = Box::new(Profile::new(child));
+
+        let _ = profile.read(); // doc 1
+
+        let suspended = profile.suspend();
+        let outcome = suspended
+            .resume(&mock_ctx.spec_read())
+            .expect("resume must not surface an error for an aborting child");
+        assert!(
+            matches!(outcome, ResumeOutcome::Aborted),
+            "an unrecoverable type-erased child must abort the whole profile",
+        );
+    }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

Implement `RQEIteratorBoxed` + `RQESuspendedIterator` for the `Profile`
profiling wrapper.

`Profile` is a pure pass-through wrapper: it holds no virtual result, its only
`Rf`-dependent field is a zero-sized `PhantomData<Rf>`, and `resume` simply
drives the child's `resume` and re-wraps the result, mirroring the child's
`Ok`/`Moved`/`Aborted` outcome.

Split out of #10276 so this trivial, low-risk wrapper can land independently of
the correctness-sensitive Optional family.

#### Main objects this PR modified
- `Profile`

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

Stacked on #10271.