### PR TITLE
[MOD-17094] Align build-deps check with install path (clang/LLVM, rust, check-deps mode)

### DIFF
--- a/.github/workflows/task-redis-build-sanity.yml
+++ b/.github/workflows/task-redis-build-sanity.yml
@@ -256,6 +256,19 @@ jobs:
           export PATH="${PATH:-}:$REDISEARCH_CI_SYSTEM_PATH"
           make bootstrap redisearch
 
+      # Assert the dependency check follows the install path: on the environment
+      # `make bootstrap` just produced, RediSearch's check-deps must report green
+      # (no drift between what bootstrap installs and what the check verifies).
+      # Runs RediSearch's own Makefile against this ref's checkout under
+      # modules/redisearch/<SRC_DIR> (default `src`); the outer make has no
+      # bootstrap target to forward CHECK_DEPS through, so invoke it directly.
+      - name: Verify RediSearch build deps match the bootstrap (check-deps)
+        timeout-minutes: ${{ inputs.test-timeout }}
+        working-directory: redis/modules/redisearch/src
+        run: |
+          export PATH="${PATH:-}:$REDISEARCH_CI_SYSTEM_PATH"
+          make bootstrap CHECK_DEPS=1
+
       - name: Run make build redisearch
         timeout-minutes: ${{ inputs.test-timeout }}
         working-directory: redis

--- a/.install/verify_build_deps.sh
+++ b/.install/verify_build_deps.sh
@@ -63,20 +63,20 @@ emit_result() {
   local dep=$1 status=$2 msg=${3:-} vtag=${4:-}
   if ! report_mode; then
     printf "%-20s" "$dep"
-    if [ "$status" = ok ]; then
+    if [[ "$status" == ok ]]; then
       echo -e "${GREEN}✓${NC}"
     else
       echo -e "${msg:-${RED}✗${NC}}"
     fi
   fi
-  if [ "$status" = ok ]; then
+  if [[ "$status" == ok ]]; then
     if is_optional_dep "$dep"; then DEPS_OPT_OK="$DEPS_OPT_OK $dep"; else DEPS_OK="$DEPS_OK $dep"; fi
   elif is_optional_dep "$dep"; then
     # Match the RTS report convention: optional-missing records carry no version tag.
     DEPS_OPT_MISSING="$DEPS_OPT_MISSING $dep"
   else
     local tag=$dep
-    [ -n "$vtag" ] && tag="$dep:$vtag"
+    [[ -n "$vtag" ]] && tag="$dep:$vtag"
     DEPS_MISSING="$DEPS_MISSING $tag"
     missing_deps=true
   fi
@@ -130,7 +130,7 @@ fi
 
 # Function to detect the operating system
 detect_os() {
-  if [ -f /etc/os-release ]; then
+  if [[ -f /etc/os-release ]]; then
     . /etc/os-release
     if [[ "$ID" == "amzn" ]]; then
       if [[ "$VERSION_ID" == "2" ]]; then
@@ -379,9 +379,9 @@ for dep in "${!dependencies[@]}"; do
       actual_version=$($get_version "$dep")
       $check_func $actual_version $min_version $max_version
       result=$?
-      if [ "$result" -eq 1 ]; then # below min version
+      if [[ "$result" -eq 1 ]]; then # below min version
         emit_result "$dep" missing "${YELLOW}✗ (need version >= $min_version, found version $actual_version)${NC}" "$min_version"
-      elif [ "$result" -eq 2 ]; then # exceeded max version
+      elif [[ "$result" -eq 2 ]]; then # exceeded max version
         emit_result "$dep" missing "${YELLOW}✗ (need version < $max_version, found version $actual_version)${NC}" "$min_version"
       else
         emit_result "$dep" ok
@@ -485,7 +485,7 @@ fi
 # Suggest using the all-in-one installation script
 echo -e "\n\033[0;36mTo install or inspect dependencies, check the following script:\033[0m"
 is_docker() {
-  [ -f /.dockerenv ] || grep -q docker /proc/1/cgroup 2>/dev/null
+  [[ -f /.dockerenv ]] || grep -q docker /proc/1/cgroup 2>/dev/null
 }
 mode=$(is_docker && echo "" || echo "sudo")
 echo -e "cd .install && ./install_script.sh ${mode}"

--- a/.install/verify_build_deps.sh
+++ b/.install/verify_build_deps.sh
@@ -71,10 +71,14 @@ emit_result() {
   fi
   if [ "$status" = ok ]; then
     if is_optional_dep "$dep"; then DEPS_OPT_OK="$DEPS_OPT_OK $dep"; else DEPS_OK="$DEPS_OK $dep"; fi
+  elif is_optional_dep "$dep"; then
+    # Match the RTS report convention: optional-missing records carry no version tag.
+    DEPS_OPT_MISSING="$DEPS_OPT_MISSING $dep"
   else
     local tag=$dep
     [ -n "$vtag" ] && tag="$dep:$vtag"
-    if is_optional_dep "$dep"; then DEPS_OPT_MISSING="$DEPS_OPT_MISSING $tag"; else DEPS_MISSING="$DEPS_MISSING $tag"; missing_deps=true; fi
+    DEPS_MISSING="$DEPS_MISSING $tag"
+    missing_deps=true
   fi
 }
 

--- a/.install/verify_build_deps.sh
+++ b/.install/verify_build_deps.sh
@@ -51,7 +51,7 @@ DEPS_OPT_MISSING=""
 OPTIONAL_DEPS="ld.lld"
 is_optional_dep() { case " $OPTIONAL_DEPS " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
 
-report_mode() { [ -n "${DEPS_REPORT_FILE:-}" ]; }
+report_mode() { [[ -n "${DEPS_REPORT_FILE:-}" ]]; }
 
 # emit_result <name> ok
 # emit_result <name> missing [human_message] [report_version]

--- a/.install/verify_build_deps.sh
+++ b/.install/verify_build_deps.sh
@@ -53,27 +53,11 @@ is_optional_dep() { case " $OPTIONAL_DEPS " in *" $1 "*) return 0 ;; *) return 1
 
 report_mode() { [ -n "${DEPS_REPORT_FILE:-}" ]; }
 
-record_ok() {
-  if is_optional_dep "$1"; then DEPS_OPT_OK="$DEPS_OPT_OK $1"; else DEPS_OK="$DEPS_OK $1"; fi
-}
-
-# record_missing <name> [version]. Optional deps are bucketed separately and do
-# NOT flip missing_deps (they can't fail the check).
-record_missing() {
-  local tag=$1
-  [ -n "${2:-}" ] && tag="$1:$2"
-  if is_optional_dep "$1"; then
-    DEPS_OPT_MISSING="$DEPS_OPT_MISSING $tag"
-  else
-    DEPS_MISSING="$DEPS_MISSING $tag"
-    missing_deps=true
-  fi
-}
-
 # emit_result <name> ok
 # emit_result <name> missing [human_message] [report_version]
 # Prints one aligned human line (skipped in aggregate mode) and records the
-# outcome. human_message defaults to a red ✗; pass a yellow message for
+# outcome. Optional deps (OPTIONAL_DEPS) go to their own bucket and never flip
+# missing_deps. human_message defaults to a red ✗; pass a yellow message for
 # present-but-wrong-version failures.
 emit_result() {
   local dep=$1 status=$2 msg=${3:-} vtag=${4:-}
@@ -86,9 +70,11 @@ emit_result() {
     fi
   fi
   if [ "$status" = ok ]; then
-    record_ok "$dep"
+    if is_optional_dep "$dep"; then DEPS_OPT_OK="$DEPS_OPT_OK $dep"; else DEPS_OK="$DEPS_OK $dep"; fi
   else
-    record_missing "$dep" "$vtag"
+    local tag=$dep
+    [ -n "$vtag" ] && tag="$dep:$vtag"
+    if is_optional_dep "$dep"; then DEPS_OPT_MISSING="$DEPS_OPT_MISSING $tag"; else DEPS_MISSING="$DEPS_MISSING $tag"; missing_deps=true; fi
   fi
 }
 
@@ -102,6 +88,30 @@ emit_deps_report() {
   for p in $DEPS_OPT_OK;      do echo "opt_ok $p"       >> "$DEPS_REPORT_FILE"; done
   for p in $DEPS_OPT_MISSING; do echo "opt_missing $p"  >> "$DEPS_REPORT_FILE"; done
   return 0
+}
+
+# ============================================
+# LLVM toolchain resolution (shared by the Linux loop and the macOS clang check)
+# ============================================
+
+# Extract the major version from an LLVM tool's --version output. clang prints
+# "clang version 21.1.8", lld prints "LLD 21.1.8" (no "version" word), so match
+# the first X.Y[.Z] token rather than keying off a label.
+get_llvm_major() {
+  "$1" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 | cut -d. -f1
+}
+
+# Resolve the LLVM-toolchain binary the build uses: build.sh prefers the
+# version-suffixed name (clang-$LLVM_VERSION), falling back to the unversioned
+# one whose major must match. Uses `command -v` directly (not check_command) so
+# it also works when sourced on macOS, where check_command is never defined.
+get_llvm_tool() {
+  local base=$1
+  if command -v "${base}-${LLVM_VERSION}" &>/dev/null; then
+    echo "${base}-${LLVM_VERSION}"
+  elif command -v "$base" &>/dev/null; then
+    echo "$base"
+  fi
 }
 
 # ============================================
@@ -228,25 +238,6 @@ get_cmake_version() {
 
 get_cheadergen_version() {
   cheadergen --version 2>/dev/null | awk '{print $NF}' || echo "unknown"
-}
-
-# Extract the major version from an LLVM tool's --version output. clang prints
-# "clang version 21.1.8", lld prints "LLD 21.1.8" (no "version" word), so match
-# the first X.Y[.Z] token rather than keying off a label.
-get_llvm_major() {
-  "$1" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 | cut -d. -f1
-}
-
-# Resolve the LLVM-toolchain binary the build actually uses: build.sh prefers
-# the version-suffixed name (clang-$LLVM_VERSION) and falls back to the
-# unversioned one whose major must match. Echoes the resolved binary or nothing.
-get_llvm_tool() {
-  local base=$1
-  if check_command "${base}-${LLVM_VERSION}"; then
-    echo "${base}-${LLVM_VERSION}"
-  elif check_command "$base"; then
-    echo "$base"
-  fi
 }
 
 # ==== Version Checkers ====

--- a/.install/verify_build_deps.sh
+++ b/.install/verify_build_deps.sh
@@ -64,6 +64,8 @@ emit_result() {
   if ! report_mode; then
     if [[ "$status" == ok ]]; then
       printf '%-20s%b\n' "$dep" "${GREEN}✓${NC}"
+    elif is_optional_dep "$dep"; then
+      : # optional-missing isn't a failure: reported only in the "Optional (not installed)" section
     else
       printf '%-20s%b\n' "$dep" "${msg:-${RED}✗${NC}}"
     fi

--- a/.install/verify_build_deps.sh
+++ b/.install/verify_build_deps.sh
@@ -62,11 +62,10 @@ report_mode() { [ -n "${DEPS_REPORT_FILE:-}" ]; }
 emit_result() {
   local dep=$1 status=$2 msg=${3:-} vtag=${4:-}
   if ! report_mode; then
-    printf "%-20s" "$dep"
     if [[ "$status" == ok ]]; then
-      echo -e "${GREEN}✓${NC}"
+      printf '%-20s%b\n' "$dep" "${GREEN}✓${NC}"
     else
-      echo -e "${msg:-${RED}✗${NC}}"
+      printf '%-20s%b\n' "$dep" "${msg:-${RED}✗${NC}}"
     fi
   fi
   if [[ "$status" == ok ]]; then

--- a/.install/verify_build_deps.sh
+++ b/.install/verify_build_deps.sh
@@ -72,7 +72,7 @@ emit_result() {
   if [[ "$status" == ok ]]; then
     if is_optional_dep "$dep"; then DEPS_OPT_OK="$DEPS_OPT_OK $dep"; else DEPS_OK="$DEPS_OK $dep"; fi
   elif is_optional_dep "$dep"; then
-    # Match the RTS report convention: optional-missing records carry no version tag.
+    # Optional-missing records carry no version tag, per the shared bootstrap report format.
     DEPS_OPT_MISSING="$DEPS_OPT_MISSING $dep"
   else
     local tag=$dep

--- a/.install/verify_build_deps.sh
+++ b/.install/verify_build_deps.sh
@@ -12,10 +12,8 @@ REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 REQUIRED_CHEADERGEN_VERSION=$(cat "$REPO_ROOT/.cheadergen-version")
 source "$SCRIPT_DIR/version_compare.sh"
 
-# Pinned toolchain versions, read from the SAME files the install path uses so
-# the check can't specify a different version than what bootstrap installs:
-#   LLVM_VERSION      — clang/lld major (install_llvm.sh)
-#   PINNED_RUST_VERSION — exact rust toolchain (install_rust.sh reads the same)
+# Toolchain version pins, read from the same files the install path uses so the
+# check can't drift from what bootstrap installs.
 source "$SCRIPT_DIR/LLVM_VERSION.sh"
 PINNED_RUST_VERSION=$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
   "$REPO_ROOT/rust-toolchain.toml" | head -1)
@@ -49,8 +47,7 @@ DEPS_OPT_MISSING=""
 
 # Optional = installed by bootstrap but NOT needed for the default (non-LTO)
 # build/run, so their absence must not fail the check. lld is only used as the
-# LTO linker (build.sh, -fuse-ld=lld); a plain `make build` uses the system
-# linker. Matched by dependency name.
+# LTO linker; a plain `make build` uses the system linker.
 OPTIONAL_DEPS="lld"
 is_optional_dep() { case " $OPTIONAL_DEPS " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
 
@@ -286,22 +283,16 @@ check_cmake_version() {
 # OS-Specific Dependencies
 # ============================================
 
-# Define common dependencies
-# Verification methods:
-#   command — present on PATH (optionally version-checked via version_checks)
-#   package — installed per the OS package manager
-#   cheadergen — present and matching .cheadergen-version
-#   llvm    — clang/lld toolchain, major pinned to LLVM_VERSION.sh
-#   rust    — cargo present and the pinned rust-toolchain.toml version available
+# Common dependencies, keyed to a verify_method dispatched in the loop below.
 declare -A common_dependencies=(
-  ["make"]="command"       # Verify using command -v
-  ["gcc"]="command"        # Verify using command -v
-  ["g++"]="command"        # Verify using command -v
-  ["python3"]="command"    # Verify using command -v
-  ["cmake"]="command"      # Verify using command -v
-  ["cargo"]="rust"         # Verify presence + pinned toolchain
-  ["clang"]="llvm"         # LLVM C compiler (bindgen/libclang need it; LTO uses it)
-  ["lld"]="llvm"           # LTO linker — optional (see OPTIONAL_DEPS)
+  ["make"]="command"
+  ["gcc"]="command"
+  ["g++"]="command"
+  ["python3"]="command"
+  ["cmake"]="command"
+  ["cargo"]="rust"
+  ["clang"]="llvm"   # required: bindgen/libclang need it, LTO uses it as CC
+  ["lld"]="llvm"     # LTO linker only -> optional (see OPTIONAL_DEPS)
 )
 
 # cheadergen is only needed when regenerating Rust C headers.

--- a/.install/verify_build_deps.sh
+++ b/.install/verify_build_deps.sh
@@ -46,9 +46,9 @@ DEPS_OPT_OK=""
 DEPS_OPT_MISSING=""
 
 # Optional = installed by bootstrap but NOT needed for the default (non-LTO)
-# build/run, so their absence must not fail the check. lld is only used as the
-# LTO linker; a plain `make build` uses the system linker.
-OPTIONAL_DEPS="lld"
+# build/run, so their absence must not fail the check. ld.lld is only used as
+# the LTO linker; a plain `make build` uses the system linker.
+OPTIONAL_DEPS="ld.lld"
 is_optional_dep() { case " $OPTIONAL_DEPS " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
 
 report_mode() { [ -n "${DEPS_REPORT_FILE:-}" ]; }
@@ -282,8 +282,8 @@ declare -A common_dependencies=(
   ["python3"]="command"
   ["cmake"]="command"
   ["cargo"]="rust"
-  ["clang"]="llvm"   # required: bindgen/libclang need it, LTO uses it as CC
-  ["lld"]="llvm"     # LTO linker only -> optional (see OPTIONAL_DEPS)
+  ["clang"]="llvm"    # required: bindgen/libclang need it, LTO uses it as CC
+  ["ld.lld"]="llvm"   # LTO linker only -> optional (see OPTIONAL_DEPS)
 )
 
 # cheadergen is only needed when regenerating Rust C headers.
@@ -398,7 +398,13 @@ for dep in "${!dependencies[@]}"; do
     tool=$(get_llvm_tool "$dep")
     if [[ -z "$tool" ]]; then
       emit_result "$dep" missing "${RED}✗ (LLVM $LLVM_VERSION toolchain not found)${NC}" "$LLVM_VERSION"
+    elif [[ "$tool" == "${dep}-${LLVM_VERSION}" ]]; then
+      # A version-suffixed binary (clang-21, ld.lld-21) is the pinned major by
+      # name — trust it without running --version. Matters for ld.lld: the
+      # bare `lld` driver prints no version, so probing it reports "unknown".
+      emit_result "$dep" ok
     else
+      # Fell back to the unversioned binary; confirm its major.
       actual_major=$(get_llvm_major "$tool")
       if [[ "$actual_major" == "$LLVM_VERSION" ]]; then
         emit_result "$dep" ok

--- a/.install/verify_build_deps.sh
+++ b/.install/verify_build_deps.sh
@@ -12,6 +12,14 @@ REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 REQUIRED_CHEADERGEN_VERSION=$(cat "$REPO_ROOT/.cheadergen-version")
 source "$SCRIPT_DIR/version_compare.sh"
 
+# Pinned toolchain versions, read from the SAME files the install path uses so
+# the check can't specify a different version than what bootstrap installs:
+#   LLVM_VERSION      — clang/lld major (install_llvm.sh)
+#   PINNED_RUST_VERSION — exact rust toolchain (install_rust.sh reads the same)
+source "$SCRIPT_DIR/LLVM_VERSION.sh"
+PINNED_RUST_VERSION=$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+  "$REPO_ROOT/rust-toolchain.toml" | head -1)
+
 should_check_cheadergen() {
   case "${REDISEARCH_GENERATE_HEADERS:-1}" in
     0|OFF|off|false|FALSE|False|NO|no)
@@ -24,12 +32,88 @@ should_check_cheadergen() {
 }
 
 # ============================================
+# check-deps report state (shared cross-module bootstrap contract)
+# ============================================
+# This script never installs — it only reports. The shared `make bootstrap
+# check-deps` (see Makefile) runs it to learn what each module needs.
+#
+# When DEPS_REPORT_FILE is set (aggregate mode), machine-readable records are
+# appended and the per-dependency human list is suppressed, so the outer
+# bootstrap can print one deduped union across all modules. Record format:
+#   ok <name> | missing <name>[:<version>] | opt_ok <name> | opt_missing <name>
+missing_deps=false
+DEPS_OK=""
+DEPS_MISSING=""
+DEPS_OPT_OK=""
+DEPS_OPT_MISSING=""
+
+# Optional = installed by bootstrap but NOT needed for the default (non-LTO)
+# build/run, so their absence must not fail the check. lld is only used as the
+# LTO linker (build.sh, -fuse-ld=lld); a plain `make build` uses the system
+# linker. Matched by dependency name.
+OPTIONAL_DEPS="lld"
+is_optional_dep() { case " $OPTIONAL_DEPS " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
+
+report_mode() { [ -n "${DEPS_REPORT_FILE:-}" ]; }
+
+record_ok() {
+  if is_optional_dep "$1"; then DEPS_OPT_OK="$DEPS_OPT_OK $1"; else DEPS_OK="$DEPS_OK $1"; fi
+}
+
+# record_missing <name> [version]. Optional deps are bucketed separately and do
+# NOT flip missing_deps (they can't fail the check).
+record_missing() {
+  local tag=$1
+  [ -n "${2:-}" ] && tag="$1:$2"
+  if is_optional_dep "$1"; then
+    DEPS_OPT_MISSING="$DEPS_OPT_MISSING $tag"
+  else
+    DEPS_MISSING="$DEPS_MISSING $tag"
+    missing_deps=true
+  fi
+}
+
+# emit_result <name> ok
+# emit_result <name> missing [human_message] [report_version]
+# Prints one aligned human line (skipped in aggregate mode) and records the
+# outcome. human_message defaults to a red ✗; pass a yellow message for
+# present-but-wrong-version failures.
+emit_result() {
+  local dep=$1 status=$2 msg=${3:-} vtag=${4:-}
+  if ! report_mode; then
+    printf "%-20s" "$dep"
+    if [ "$status" = ok ]; then
+      echo -e "${GREEN}✓${NC}"
+    else
+      echo -e "${msg:-${RED}✗${NC}}"
+    fi
+  fi
+  if [ "$status" = ok ]; then
+    record_ok "$dep"
+  else
+    record_missing "$dep" "$vtag"
+  fi
+}
+
+# Append the machine-readable records in aggregate mode. Returns 0 (and writes)
+# only when DEPS_REPORT_FILE is set, so callers can `emit_deps_report && exit 0`.
+emit_deps_report() {
+  report_mode || return 1
+  local p
+  for p in $DEPS_OK;          do echo "ok $p"           >> "$DEPS_REPORT_FILE"; done
+  for p in $DEPS_MISSING;     do echo "missing $p"      >> "$DEPS_REPORT_FILE"; done
+  for p in $DEPS_OPT_OK;      do echo "opt_ok $p"       >> "$DEPS_REPORT_FILE"; done
+  for p in $DEPS_OPT_MISSING; do echo "opt_missing $p"  >> "$DEPS_REPORT_FILE"; done
+  return 0
+}
+
+# ============================================
 # OS Detection
 # ============================================
 
 # Check if the OS is macOS (Darwin)
 if [[ "$(uname -s)" == "Darwin" ]]; then
-    source .install/verify_build_deps_macos.sh
+    source "$SCRIPT_DIR/verify_build_deps_macos.sh"
     exit $?
 fi
 
@@ -149,6 +233,25 @@ get_cheadergen_version() {
   cheadergen --version 2>/dev/null | awk '{print $NF}' || echo "unknown"
 }
 
+# Extract the major version from an LLVM tool's --version output. clang prints
+# "clang version 21.1.8", lld prints "LLD 21.1.8" (no "version" word), so match
+# the first X.Y[.Z] token rather than keying off a label.
+get_llvm_major() {
+  "$1" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 | cut -d. -f1
+}
+
+# Resolve the LLVM-toolchain binary the build actually uses: build.sh prefers
+# the version-suffixed name (clang-$LLVM_VERSION) and falls back to the
+# unversioned one whose major must match. Echoes the resolved binary or nothing.
+get_llvm_tool() {
+  local base=$1
+  if check_command "${base}-${LLVM_VERSION}"; then
+    echo "${base}-${LLVM_VERSION}"
+  elif check_command "$base"; then
+    echo "$base"
+  fi
+}
+
 # ==== Version Checkers ====
 
 check_min_version() {
@@ -184,13 +287,21 @@ check_cmake_version() {
 # ============================================
 
 # Define common dependencies
+# Verification methods:
+#   command — present on PATH (optionally version-checked via version_checks)
+#   package — installed per the OS package manager
+#   cheadergen — present and matching .cheadergen-version
+#   llvm    — clang/lld toolchain, major pinned to LLVM_VERSION.sh
+#   rust    — cargo present and the pinned rust-toolchain.toml version available
 declare -A common_dependencies=(
   ["make"]="command"       # Verify using command -v
   ["gcc"]="command"        # Verify using command -v
   ["g++"]="command"        # Verify using command -v
   ["python3"]="command"    # Verify using command -v
   ["cmake"]="command"      # Verify using command -v
-  ["cargo"]="command"      # Verify using command -v
+  ["cargo"]="rust"         # Verify presence + pinned toolchain
+  ["clang"]="llvm"         # LLVM C compiler (bindgen/libclang need it; LTO uses it)
+  ["lld"]="llvm"           # LTO linker — optional (see OPTIONAL_DEPS)
 )
 
 # cheadergen is only needed when regenerating Rust C headers.
@@ -266,80 +377,109 @@ fi
 # ============================================
 
 # Print header
-echo -e "\n===== Build Dependencies Checker =====\n"
-
-# Arrays to store missing dependencies
-missing_deps=false
+report_mode || echo -e "\n===== Build Dependencies Checker =====\n"
 
 # Check each dependency
 for dep in "${!dependencies[@]}"; do
-  printf "%-20s" "$dep"
-
   verify_method=${dependencies[$dep]}
 
   # Check based on verification method
   if [[ "$verify_method" == "command" ]]; then
-    # missing dep
     if ! check_command "$dep"; then
-      echo -e "${RED}✗${NC}"
-      missing_deps=true
-    else
-      # dep exist, check if version verification is needed
-      if [[ -n "${version_checks[$dep]}" ]]; then
-        # Extract version check function and minimum version
-        read -r get_version check_func min_version max_version <<< "${version_checks[$dep]}"
-
-        # Run the check function
-        actual_version=$($get_version "$dep")
-        $check_func $actual_version $min_version $max_version
-        result=$?
-        if [ "$result" -eq 1 ]; then # below min version
-          echo -e "${YELLOW}✗ (need version >= $min_version, found version $actual_version)${NC}"
-          missing_deps=true
-        elif [ "$result" -eq 2 ]; then # exceeded max version
-          echo -e "${YELLOW}✗ (need version < $max_version, found version $actual_version)${NC}"
-          missing_deps=true
-        else
-          echo -e "${GREEN}✓${NC}"
-        fi
+      emit_result "$dep" missing
+    elif [[ -n "${version_checks[$dep]}" ]]; then
+      # dep exists, run its version check
+      read -r get_version check_func min_version max_version <<< "${version_checks[$dep]}"
+      actual_version=$($get_version "$dep")
+      $check_func $actual_version $min_version $max_version
+      result=$?
+      if [ "$result" -eq 1 ]; then # below min version
+        emit_result "$dep" missing "${YELLOW}✗ (need version >= $min_version, found version $actual_version)${NC}" "$min_version"
+      elif [ "$result" -eq 2 ]; then # exceeded max version
+        emit_result "$dep" missing "${YELLOW}✗ (need version < $max_version, found version $actual_version)${NC}" "$min_version"
       else
-        # No version check needed
-        echo -e "${GREEN}✓${NC}"
+        emit_result "$dep" ok
       fi
+    else
+      # No version check needed
+      emit_result "$dep" ok
     fi
   elif [[ "$verify_method" == "package" ]]; then
-    # Lookup the package checker for the current OS
+    # Lookup the package checker for the current OS and call it dynamically
     package_checker=${os_package_checkers["$OS"]}
-
-    # Call the package checker dynamically
     if $package_checker "$dep"; then
-      echo -e "${GREEN}✓${NC}"
+      emit_result "$dep" ok
     else
-      echo -e "${RED}✗${NC}"
-      missing_deps=true
+      emit_result "$dep" missing
+    fi
+  elif [[ "$verify_method" == "llvm" ]]; then
+    tool=$(get_llvm_tool "$dep")
+    if [[ -z "$tool" ]]; then
+      emit_result "$dep" missing "${RED}✗ (LLVM $LLVM_VERSION toolchain not found)${NC}" "$LLVM_VERSION"
+    else
+      actual_major=$(get_llvm_major "$tool")
+      if [[ "$actual_major" == "$LLVM_VERSION" ]]; then
+        emit_result "$dep" ok
+      else
+        emit_result "$dep" missing "${YELLOW}✗ (need LLVM $LLVM_VERSION, found ${actual_major:-unknown})${NC}" "$LLVM_VERSION"
+      fi
+    fi
+  elif [[ "$verify_method" == "rust" ]]; then
+    if check_command rustup; then
+      # Read-only: is the pinned toolchain installed? `rustup toolchain list`
+      # never triggers an auto-install (unlike resolving the pin via `cargo`).
+      if rustup toolchain list 2>/dev/null | grep -q "^${PINNED_RUST_VERSION}-"; then
+        emit_result "$dep" ok
+      else
+        emit_result "$dep" missing "${YELLOW}✗ (need Rust $PINNED_RUST_VERSION toolchain)${NC}" "$PINNED_RUST_VERSION"
+      fi
+    elif check_command cargo; then
+      # No rustup (e.g. a distro cargo): fall back to a version floor.
+      actual_version=$(cargo --version 2>/dev/null | awk '{print $2}')
+      if [[ -n "$actual_version" ]] && version_ge "$actual_version" "$PINNED_RUST_VERSION"; then
+        emit_result "$dep" ok
+      else
+        emit_result "$dep" missing "${YELLOW}✗ (need Rust >= $PINNED_RUST_VERSION, found ${actual_version:-none})${NC}" "$PINNED_RUST_VERSION"
+      fi
+    else
+      emit_result "$dep" missing "" "$PINNED_RUST_VERSION"
     fi
   elif [[ "$verify_method" == "cheadergen" ]]; then
     if ! check_command "$dep"; then
-      echo -e "${RED}✗${NC}"
-      missing_deps=true
+      emit_result "$dep" missing
     else
       actual_version=$(get_cheadergen_version)
       if [[ "$actual_version" == "$REQUIRED_CHEADERGEN_VERSION" ]]; then
-        echo -e "${GREEN}✓${NC}"
+        emit_result "$dep" ok
       else
-        echo -e "${YELLOW}✗ (need version $REQUIRED_CHEADERGEN_VERSION, found version $actual_version)${NC}"
-        missing_deps=true
+        emit_result "$dep" missing "${YELLOW}✗ (need version $REQUIRED_CHEADERGEN_VERSION, found version $actual_version)${NC}" "$REQUIRED_CHEADERGEN_VERSION"
       fi
     fi
   else # no method is defined for this dependency
-    echo -e "${YELLOW} (no method defined)${NC}"
-    missing_deps=true
+    emit_result "$dep" missing "${YELLOW} (no method defined)${NC}"
   fi
 done
 
 # ============================================
+# Aggregate report mode: emit records for the outer bootstrap and stop here.
+# ============================================
+if emit_deps_report; then
+  n_ok=$(set -- $DEPS_OK; echo $#)
+  n_missing=$(set -- $DEPS_MISSING; echo $#)
+  echo "==> [redisearch] checked: $n_ok installed, $n_missing missing"
+  exit 0
+fi
+
+# ============================================
 # Missing Dependencies Handling
 # ============================================
+
+# Optional deps (installed by bootstrap, not needed for a default build) are
+# reported separately and never fail the check.
+if [[ -n "$DEPS_OPT_MISSING" ]]; then
+  echo -e "\n${YELLOW}Optional (not installed; needed only for LTO/extra features):${NC}"
+  for p in $DEPS_OPT_MISSING; do echo -e "    ${p%%:*}"; done
+fi
 
 # Print installation instructions if there are missing dependencies
 if $missing_deps; then

--- a/.install/verify_build_deps_macos.sh
+++ b/.install/verify_build_deps_macos.sh
@@ -35,6 +35,12 @@ check_clang() {
     return
   fi
 
+  # clang-<major> is the pinned major by name — trust it without --version.
+  if [[ "$tool" == "clang-${LLVM_VERSION}" ]]; then
+    emit_result clang ok
+    return
+  fi
+
   local major
   major=$(get_llvm_major "$tool")
   if [[ "$major" == "$LLVM_VERSION" ]]; then

--- a/.install/verify_build_deps_macos.sh
+++ b/.install/verify_build_deps_macos.sh
@@ -1,63 +1,16 @@
 #!/usr/bin/env bash
+#
+# macOS build-dependency checks. Sourced by verify_build_deps.sh on Darwin, and
+# NOT meant to run standalone: it relies on the colors, version pins
+# (LLVM_VERSION / PINNED_RUST_VERSION), report helpers (emit_result /
+# emit_deps_report / report_mode / get_llvm_tool / get_llvm_major),
+# should_check_cheadergen and REQUIRED_CHEADERGEN_VERSION that the parent
+# defines before sourcing this file.
 
-# Set colors for output
-GREEN='\033[0;32m'
-RED='\033[0;31m'
-BLUE='\033[0;34m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
-
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
-REQUIRED_CHEADERGEN_VERSION=$(cat "$REPO_ROOT/.cheadergen-version")
-
-# Normally sourced by verify_build_deps.sh (which sources these first); source
-# them defensively so this script also works if invoked on its own. All are
-# idempotent.
-source "$SCRIPT_DIR/version_compare.sh"
-source "$SCRIPT_DIR/LLVM_VERSION.sh"
-PINNED_RUST_VERSION=$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
-  "$REPO_ROOT/rust-toolchain.toml" | head -1)
-
-# The report state and helpers (record_ok / record_missing / emit_result /
-# emit_deps_report / is_optional_dep / report_mode / missing_deps) come from
-# verify_build_deps.sh. Provide minimal fallbacks so standalone use still works.
-: "${missing_deps:=false}"
 if ! declare -F emit_result >/dev/null 2>&1; then
-  DEPS_OK="" DEPS_MISSING="" DEPS_OPT_OK="" DEPS_OPT_MISSING=""
-  report_mode() { [ -n "${DEPS_REPORT_FILE:-}" ]; }
-  is_optional_dep() { return 1; }
-  record_ok() { DEPS_OK="$DEPS_OK $1"; }
-  record_missing() { local t=$1; [ -n "${2:-}" ] && t="$1:$2"; DEPS_MISSING="$DEPS_MISSING $t"; missing_deps=true; }
-  emit_result() {
-    local dep=$1 status=$2 msg=${3:-} vtag=${4:-}
-    if ! report_mode; then
-      printf "%-20s" "$dep"
-      [ "$status" = ok ] && echo -e "${GREEN}✓${NC}" || echo -e "${msg:-${RED}✗${NC}}"
-    fi
-    [ "$status" = ok ] && record_ok "$dep" || record_missing "$dep" "$vtag"
-  }
-  emit_deps_report() {
-    report_mode || return 1
-    local p
-    for p in $DEPS_OK;         do echo "ok $p"          >> "$DEPS_REPORT_FILE"; done
-    for p in $DEPS_MISSING;    do echo "missing $p"     >> "$DEPS_REPORT_FILE"; done
-    for p in $DEPS_OPT_OK;     do echo "opt_ok $p"      >> "$DEPS_REPORT_FILE"; done
-    for p in $DEPS_OPT_MISSING;do echo "opt_missing $p" >> "$DEPS_REPORT_FILE"; done
-    return 0
-  }
+  echo "verify_build_deps_macos.sh must be sourced by verify_build_deps.sh" >&2
+  return 1 2>/dev/null || exit 1
 fi
-
-should_check_cheadergen() {
-  case "${REDISEARCH_GENERATE_HEADERS:-1}" in
-    0|OFF|off|false|FALSE|False|NO|no)
-      return 1
-      ;;
-    *)
-      return 0
-      ;;
-  esac
-}
 
 # ============================================
 # Checkers
@@ -75,20 +28,15 @@ check_cmd_dep() {
 # same major Rust uses. Apple's system clang has a different versioning scheme
 # and won't report LLVM_VERSION, so it's correctly rejected.
 check_clang() {
-  local tool=""
-  if command -v "clang-${LLVM_VERSION}" &>/dev/null; then
-    tool="clang-${LLVM_VERSION}"
-  elif command -v clang &>/dev/null; then
-    tool="clang"
-  fi
-
+  local tool
+  tool=$(get_llvm_tool clang)
   if [[ -z "$tool" ]]; then
     emit_result clang missing "${RED}✗${NC}" "$LLVM_VERSION"
     return
   fi
 
   local major
-  major=$("$tool" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 | cut -d. -f1)
+  major=$(get_llvm_major "$tool")
   if [[ "$major" == "$LLVM_VERSION" ]]; then
     emit_result clang ok
   elif [[ "$(command -v "$tool")" == *"/llvm"* ]]; then

--- a/.install/verify_build_deps_macos.sh
+++ b/.install/verify_build_deps_macos.sh
@@ -63,7 +63,6 @@ should_check_cheadergen() {
 # Checkers
 # ============================================
 
-# Present-on-PATH check.
 check_cmd_dep() {
   if command -v "$1" &>/dev/null; then
     emit_result "$1" ok

--- a/.install/verify_build_deps_macos.sh
+++ b/.install/verify_build_deps_macos.sh
@@ -11,6 +11,43 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 REQUIRED_CHEADERGEN_VERSION=$(cat "$REPO_ROOT/.cheadergen-version")
 
+# Normally sourced by verify_build_deps.sh (which sources these first); source
+# them defensively so this script also works if invoked on its own. All are
+# idempotent.
+source "$SCRIPT_DIR/version_compare.sh"
+source "$SCRIPT_DIR/LLVM_VERSION.sh"
+PINNED_RUST_VERSION=$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+  "$REPO_ROOT/rust-toolchain.toml" | head -1)
+
+# The report state and helpers (record_ok / record_missing / emit_result /
+# emit_deps_report / is_optional_dep / report_mode / missing_deps) come from
+# verify_build_deps.sh. Provide minimal fallbacks so standalone use still works.
+: "${missing_deps:=false}"
+if ! declare -F emit_result >/dev/null 2>&1; then
+  DEPS_OK="" DEPS_MISSING="" DEPS_OPT_OK="" DEPS_OPT_MISSING=""
+  report_mode() { [ -n "${DEPS_REPORT_FILE:-}" ]; }
+  is_optional_dep() { return 1; }
+  record_ok() { DEPS_OK="$DEPS_OK $1"; }
+  record_missing() { local t=$1; [ -n "${2:-}" ] && t="$1:$2"; DEPS_MISSING="$DEPS_MISSING $t"; missing_deps=true; }
+  emit_result() {
+    local dep=$1 status=$2 msg=${3:-} vtag=${4:-}
+    if ! report_mode; then
+      printf "%-20s" "$dep"
+      [ "$status" = ok ] && echo -e "${GREEN}✓${NC}" || echo -e "${msg:-${RED}✗${NC}}"
+    fi
+    [ "$status" = ok ] && record_ok "$dep" || record_missing "$dep" "$vtag"
+  }
+  emit_deps_report() {
+    report_mode || return 1
+    local p
+    for p in $DEPS_OK;         do echo "ok $p"          >> "$DEPS_REPORT_FILE"; done
+    for p in $DEPS_MISSING;    do echo "missing $p"     >> "$DEPS_REPORT_FILE"; done
+    for p in $DEPS_OPT_OK;     do echo "opt_ok $p"      >> "$DEPS_REPORT_FILE"; done
+    for p in $DEPS_OPT_MISSING;do echo "opt_missing $p" >> "$DEPS_REPORT_FILE"; done
+    return 0
+  }
+fi
+
 should_check_cheadergen() {
   case "${REDISEARCH_GENERATE_HEADERS:-1}" in
     0|OFF|off|false|FALSE|False|NO|no)
@@ -23,90 +60,107 @@ should_check_cheadergen() {
 }
 
 # ============================================
-# Dependencies
+# Checkers
 # ============================================
-# Define dependencies and their corresponding check methods
-mac_os_deps=("make" "python3" "cmake" "cargo" "clang" "openssl" "brew")
-mac_os_deps_types=(
-    "check_command" # Check for "make"
-    "check_command" # Check for "python3"
-    "check_command" # Check for "cmake"
-    "check_command" # Check for "cargo"
-    "check_clang"   # Check for "clang"
-    "check_command" # Check for "openssl"
-    "check_command" # Check for "brew"
-)
 
-# cheadergen is only needed when regenerating Rust C headers.
-# REDISEARCH_GENERATE_HEADERS=0 builds from checked-in headers.
-if should_check_cheadergen; then
-  mac_os_deps+=("cheadergen")
-  mac_os_deps_types+=("check_cheadergen")
-fi
-
-# Function to check if a command is available
-check_command() {
-  local cmd=$1
-  printf "%-20s" "$cmd"
-
-  if ! command -v "$cmd" &>/dev/null; then
-    echo -e "${RED}✗${NC}"
-    missing_deps=true
+# Present-on-PATH check.
+check_cmd_dep() {
+  if command -v "$1" &>/dev/null; then
+    emit_result "$1" ok
   else
-    echo -e "${GREEN}✓${NC}"
+    emit_result "$1" missing
   fi
 }
 
+# clang must be the LLVM build (Homebrew llvm@N), pinned to LLVM_VERSION — the
+# same major Rust uses. Apple's system clang has a different versioning scheme
+# and won't report LLVM_VERSION, so it's correctly rejected.
 check_clang() {
-    printf "%-20s" "clang"
+  local tool=""
+  if command -v "clang-${LLVM_VERSION}" &>/dev/null; then
+    tool="clang-${LLVM_VERSION}"
+  elif command -v clang &>/dev/null; then
+    tool="clang"
+  fi
 
-    if command -v clang &>/dev/null; then
-        clang_path=$(command -v clang)
-        if [[ "$clang_path" == *"/llvm"* ]]; then
-            echo -e "${GREEN}✓${NC}"
-        else
-            echo -e "${YELLOW}✗ Expected LLVM Clang${NC}"
-            missing_deps=true
-        fi
-    else
-        echo -e "${RED}✗${NC}"
-        missing_deps=true
-    fi
-}
-
-check_cheadergen() {
-  local cmd=$1
-  printf "%-20s" "$cmd"
-
-  if ! command -v "$cmd" &>/dev/null; then
-    echo -e "${RED}✗${NC}"
-    missing_deps=true
+  if [[ -z "$tool" ]]; then
+    emit_result clang missing "${RED}✗${NC}" "$LLVM_VERSION"
     return
   fi
 
-  local actual_version
-  actual_version=$("$cmd" --version 2>/dev/null | awk '{print $NF}' || echo "unknown")
-  if [[ "$actual_version" == "$REQUIRED_CHEADERGEN_VERSION" ]]; then
-    echo -e "${GREEN}✓${NC}"
+  local major
+  major=$("$tool" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 | cut -d. -f1)
+  if [[ "$major" == "$LLVM_VERSION" ]]; then
+    emit_result clang ok
+  elif [[ "$(command -v "$tool")" == *"/llvm"* ]]; then
+    emit_result clang missing "${YELLOW}✗ (need LLVM $LLVM_VERSION, found ${major:-unknown})${NC}" "$LLVM_VERSION"
   else
-    echo -e "${YELLOW}✗ (need version $REQUIRED_CHEADERGEN_VERSION, found version $actual_version)${NC}"
-    missing_deps=true
+    emit_result clang missing "${YELLOW}✗ Expected LLVM Clang (need $LLVM_VERSION)${NC}" "$LLVM_VERSION"
+  fi
+}
+
+# cargo present + the pinned rust-toolchain.toml version available. Prefer
+# `rustup toolchain list` (read-only; never auto-installs) over resolving the
+# pin through `cargo`.
+check_rust() {
+  if command -v rustup &>/dev/null; then
+    if rustup toolchain list 2>/dev/null | grep -q "^${PINNED_RUST_VERSION}-"; then
+      emit_result cargo ok
+    else
+      emit_result cargo missing "${YELLOW}✗ (need Rust $PINNED_RUST_VERSION toolchain)${NC}" "$PINNED_RUST_VERSION"
+    fi
+  elif command -v cargo &>/dev/null; then
+    local actual
+    actual=$(cargo --version 2>/dev/null | awk '{print $2}')
+    if [[ -n "$actual" ]] && version_ge "$actual" "$PINNED_RUST_VERSION"; then
+      emit_result cargo ok
+    else
+      emit_result cargo missing "${YELLOW}✗ (need Rust >= $PINNED_RUST_VERSION, found ${actual:-none})${NC}" "$PINNED_RUST_VERSION"
+    fi
+  else
+    emit_result cargo missing "" "$PINNED_RUST_VERSION"
+  fi
+}
+
+check_cheadergen() {
+  if ! command -v cheadergen &>/dev/null; then
+    emit_result cheadergen missing
+    return
+  fi
+  local actual_version
+  actual_version=$(cheadergen --version 2>/dev/null | awk '{print $NF}' || echo "unknown")
+  if [[ "$actual_version" == "$REQUIRED_CHEADERGEN_VERSION" ]]; then
+    emit_result cheadergen ok
+  else
+    emit_result cheadergen missing "${YELLOW}✗ (need version $REQUIRED_CHEADERGEN_VERSION, found version $actual_version)${NC}" "$REQUIRED_CHEADERGEN_VERSION"
   fi
 }
 
 # ============================================
-# Main Loop
+# Main
 # ============================================
-# Print header
-echo -e "\n===== Build Dependencies Checker =====\n"
+report_mode || echo -e "\n===== Build Dependencies Checker =====\n"
 
-missing_deps=false
+check_cmd_dep make
+check_cmd_dep python3
+check_cmd_dep cmake
+check_rust
+check_clang
+check_cmd_dep openssl
+check_cmd_dep brew
+if should_check_cheadergen; then
+  check_cheadergen
+fi
 
-for i in "${!mac_os_deps[@]}"; do
-  dep="${mac_os_deps[$i]}"
-  check_function="${mac_os_deps_types[$i]}"
-  $check_function "$dep"
-done
+# ============================================
+# Aggregate report mode: emit records and stop here.
+# ============================================
+if emit_deps_report; then
+  n_ok=$(set -- $DEPS_OK; echo $#)
+  n_missing=$(set -- $DEPS_MISSING; echo $#)
+  echo "==> [redisearch] checked: $n_ok installed, $n_missing missing"
+  return 0 2>/dev/null || exit 0
+fi
 
 # ============================================
 # Missing Dependencies Handling

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,8 @@ Setup:
   make bootstrap     Install build- and test-time system dependencies.
                      Auto-prefixes `sudo` when not root.
     SUDO=cmd           Override the privilege-escalation command (default: auto)
+    CHECK_DEPS=1       Only report which dependencies are missing; install nothing
+                       (set DEPS_REPORT_FILE=<path> for machine-readable output)
   make fetch         Download and prepare dependent modules
 
 Build:
@@ -225,8 +227,12 @@ help:
 SUDO ?= $(shell [ "$$(id -u)" -eq 0 ] || echo sudo)
 
 bootstrap:
+ifeq ($(CHECK_DEPS),1)
+	@CHECK_DEPS=1 $(ROOT)/.install/verify_build_deps.sh
+else
 	@echo "Installing build dependencies..."
 	@cd $(ROOT)/.install && ./install_script.sh $(SUDO)
+endif
 
 fetch:
 	@echo "Fetching dependencies..."


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The build-deps check (`.install/verify_build_deps.sh`) and the install path (`.install/install_script.sh` + per-distro scripts) keep separate, hand-maintained dependency lists that have drifted. The install sets up the LLVM/clang toolchain on every platform (`install_llvm.sh`, pinned to `LLVM_VERSION.sh`), but the Linux checker never verified it — so the check could pass on a host the build can't compile on.
2. **Change:** Extend the dependency check to verify the toolchain the bootstrap actually installs, reconcile the Linux and macOS checkers, and expose a non-installing check mode for the shared cross-module bootstrap.
   - **Verify `clang`** pinned to `LLVM_VERSION.sh` (major 21), resolving `clang-<ver>` → `clang` exactly like `build.sh`'s LTO path. Required — `bindgen`/libclang need it for any build.
   - **Verify `ld.lld`** as an *optional* (LTO-only) dep: reported, never fails the check. Probed via `ld.lld` (which reports a version reliably) rather than the bare `lld` generic driver; a version-suffixed binary (`clang-21` / `ld.lld-21`) is trusted as the pinned major by name.
   - Replace the bare `cargo` presence check with a **pinned Rust** check (from `rust-toolchain.toml`) via read-only `rustup toolchain list` (no accidental auto-install), with a `cargo --version` floor fallback when rustup is absent.
   - The macOS checker now pins clang's major version too. Both checkers read the same `LLVM_VERSION.sh` and `rust-toolchain.toml` the install path uses, so Linux and macOS verify a consistent toolchain.
   - **`make bootstrap CHECK_DEPS=1`** runs the check and installs nothing; **`DEPS_REPORT_FILE=<path>`** emits machine-readable records (`ok` / `missing` / `opt_ok` / `opt_missing`, with `name:version` tags) for the shared `make bootstrap` to aggregate across modules.
   - CI: the redis build-sanity flow now runs the check on the freshly bootstrapped environment (after `make bootstrap`, before build), so drift between install and check fails CI on the affected platform.
3. **Outcome:** The check now verifies what the bootstrap actually installs, so it can no longer pass on a host missing the LLVM/clang toolchain or the pinned Rust; and RediSearch exposes the check-deps interface the shared bootstrap consumes.

**Behavior notes for reviewers:**
- `make build` (via `verify-deps`) now requires `clang-21` and the pinned Rust toolchain. Anyone who ran `make bootstrap` has both; others can bypass with `IGNORE_MISSING_DEPS=1`. This is intended — the check now reflects the build's real needs.
- On a fresh checkout that never built/bootstrapped, the pinned Rust toolchain reports "missing" even though `cargo` would auto-install it on first use — correct per "verify what bootstrap installs," just slightly stricter than before.

> Note: the check and the install still maintain their dependency lists separately. It is worth considering evolving the installation scripts so the check can be *derived* from the install path (a non-installing mode over the same scripts) — that would give a single source of truth and better fit the shared bootstrap's capabilities. Out of scope for this PR.

**Testing:** `bash -n` on both scripts; macOS runs of human mode (all-pass), aggregate `DEPS_REPORT_FILE` mode (clean records), and a forced version mismatch (`✗`, `missing clang:21`, exit 1 human / exit 0 aggregate); Linux primitives (LLVM major extraction, rustup probe) unit-tested against real tool output. Verified end-to-end on the redis build-sanity flow (ubuntu `x86_64`): bootstrap → check → LTO build → run all green.

#### Which additional issues this PR fixes
1. MOD-17094 (parent epic MOD-15732; relates to initiative RED-191626)

#### Main objects this PR modified
1. `.install/verify_build_deps.sh` — clang / ld.lld / pinned-Rust checks + `DEPS_REPORT_FILE` aggregate mode
2. `.install/verify_build_deps_macos.sh` — clang major pin + pinned-Rust check + report mode; shares helpers with the Linux script
3. `Makefile` — `make bootstrap CHECK_DEPS=1` routing + help text
4. `.github/workflows/task-redis-build-sanity.yml` — runs the check on the bootstrapped environment

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
