### PR TITLE
[MOD-16701] Avoid disk vector locks in fork-child RDB saves

### DIFF
--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -480,10 +480,16 @@ void SearchDisk_FreeVectorIndex(void *vecIndex) {
     disk->vector.freeVectorIndex(vecIndex);
 }
 
-bool SearchDisk_SaveVectorIndexToRDB(void *vecIndex, RedisModuleIO *rdb) {
-    RS_ASSERT(disk && vecIndex && rdb);
-    RS_ASSERT(disk->vector.saveVectorIndexToRDB);
-    return disk->vector.saveVectorIndexToRDB(vecIndex, rdb);
+bool SearchDisk_VectorIndexHasData(void *vecIndex, bool takeLocks) {
+  RS_ASSERT(disk && vecIndex);
+  RS_ASSERT(disk->vector.vectorIndexHasData);
+  return disk->vector.vectorIndexHasData(vecIndex, takeLocks);
+}
+
+bool SearchDisk_SaveVectorIndexToRDB(void *vecIndex, RedisModuleIO *rdb, bool takeLocks) {
+  RS_ASSERT(disk && vecIndex && rdb);
+  RS_ASSERT(disk->vector.saveVectorIndexToRDB);
+  return disk->vector.saveVectorIndexToRDB(vecIndex, rdb, takeLocks);
 }
 
 void* SearchDisk_CreateUnboundVectorIndex(const VecSimParamsDisk *params) {

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -634,6 +634,15 @@ void* SearchDisk_CreateVectorIndex(RedisModuleCtx *ctx, RedisSearchDiskIndexSpec
 void SearchDisk_FreeVectorIndex(void *vecIndex);
 
 /**
+ * @brief Check whether a disk vector index contains data.
+ *
+ * @param vecIndex VecSimIndex* handle
+ * @param takeLocks Whether to synchronize with concurrent index mutations
+ * @return true when the index contains data, false otherwise
+ */
+bool SearchDisk_VectorIndexHasData(void *vecIndex, bool takeLocks);
+
+/**
  * @brief Stream the in-memory state of a quiesced VecSimIndex* directly into
  *        the field's RedisModuleIO RDB stream.
  *
@@ -642,9 +651,10 @@ void SearchDisk_FreeVectorIndex(void *vecIndex);
  *
  * @param vecIndex VecSimIndex* handle
  * @param rdb RedisModuleIO stream to write into
+ * @param takeLocks Whether to synchronize with concurrent index mutations
  * @return true on success, false otherwise
  */
-bool SearchDisk_SaveVectorIndexToRDB(void *vecIndex, RedisModuleIO *rdb);
+bool SearchDisk_SaveVectorIndexToRDB(void *vecIndex, RedisModuleIO *rdb, bool takeLocks);
 
 /**
  * @brief Create a VecSimIndex with no SpeedB storage bound.

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -847,6 +847,15 @@ typedef struct VectorDiskAPI {
   void (*freeVectorIndex)(void* vecIndex);
 
   /**
+   * @brief Check whether a disk vector index contains data.
+   *
+   * @param vecIndex VecSimIndex* handle for the field
+   * @param takeLocks Whether to synchronize with concurrent index mutations
+   * @return true when the index contains data, false otherwise
+   */
+  bool (*vectorIndexHasData)(void *vecIndex, bool takeLocks);
+
+  /**
    * @brief Stream the in-memory state of a quiesced VecSimIndex* directly
    *        into a RedisModuleIO RDB stream.
    *
@@ -857,9 +866,10 @@ typedef struct VectorDiskAPI {
    *
    * @param vecIndex VecSimIndex* handle for the field
    * @param rdb RedisModuleIO stream to write into
+   * @param takeLocks Whether to synchronize with concurrent index mutations
    * @return true on success, false on serialization failure
    */
-  bool (*saveVectorIndexToRDB)(void *vecIndex, RedisModuleIO *rdb);
+  bool (*saveVectorIndexToRDB)(void *vecIndex, RedisModuleIO *rdb, bool takeLocks);
 
   /**
    * @brief Create a VecSimIndex without any SpeedB storage bound.

--- a/src/spec.c
+++ b/src/spec.c
@@ -2363,7 +2363,8 @@ fail:
   return REDISMODULE_ERR;
 }
 
-static void FieldSpec_RdbSave(RedisModuleIO *rdb, FieldSpec *f, int contextFlags) {
+static void FieldSpec_RdbSave(RedisModuleIO *rdb, FieldSpec *f, int contextFlags,
+                              bool takeVecSimLocks) {
   HiddenString_SaveToRdb(f->fieldName, rdb);
   if (HiddenString_Compare(f->fieldPath, f->fieldName) != 0) {
     RedisModule_SaveUnsigned(rdb, 1);
@@ -2402,11 +2403,12 @@ static void FieldSpec_RdbSave(RedisModuleIO *rdb, FieldSpec *f, int contextFlags
       RS_ASSERT(SearchDisk_IsEnabled());
       RS_ASSERT(f->vectorOpts.diskCtx.storage);
 
-      const bool vecSimWithData = f->vectorOpts.vecSimIndex &&
-                               VecSimIndex_IndexSize(f->vectorOpts.vecSimIndex) > 0;
+      const bool vecSimWithData =
+          f->vectorOpts.vecSimIndex &&
+          SearchDisk_VectorIndexHasData(f->vectorOpts.vecSimIndex, takeVecSimLocks);
       RedisModule_SaveUnsigned(rdb, vecSimWithData ? 1 : 0);
       if (vecSimWithData) {
-        bool ok = SearchDisk_SaveVectorIndexToRDB(f->vectorOpts.vecSimIndex, rdb);
+        bool ok = SearchDisk_SaveVectorIndexToRDB(f->vectorOpts.vecSimIndex, rdb, takeVecSimLocks);
         RS_LOG_ASSERT_ALWAYS(ok, "Failed to stream vector index to RDB");
       }
     }
@@ -2959,7 +2961,7 @@ void IndexSpec_RdbSave(RedisModuleIO *rdb, IndexSpec *sp, int contextFlags) {
   RedisModule_SaveUnsigned(rdb, (uint64_t)sp->flags);
   RedisModule_SaveUnsigned(rdb, sp->numFields);
   for (int i = 0; i < sp->numFields; i++) {
-    FieldSpec_RdbSave(rdb, &sp->fields[i], contextFlags);
+    FieldSpec_RdbSave(rdb, &sp->fields[i], contextFlags, needLock);
   }
 
   SchemaRule_RdbSave(sp->rule, rdb);

--- a/src/spec.c
+++ b/src/spec.c
@@ -2364,7 +2364,7 @@ fail:
 }
 
 static void FieldSpec_RdbSave(RedisModuleIO *rdb, FieldSpec *f, int contextFlags,
-                              bool takeVecSimLocks) {
+                              bool takeLocks) {
   HiddenString_SaveToRdb(f->fieldName, rdb);
   if (HiddenString_Compare(f->fieldPath, f->fieldName) != 0) {
     RedisModule_SaveUnsigned(rdb, 1);
@@ -2405,10 +2405,10 @@ static void FieldSpec_RdbSave(RedisModuleIO *rdb, FieldSpec *f, int contextFlags
 
       const bool vecSimWithData =
           f->vectorOpts.vecSimIndex &&
-          SearchDisk_VectorIndexHasData(f->vectorOpts.vecSimIndex, takeVecSimLocks);
+          SearchDisk_VectorIndexHasData(f->vectorOpts.vecSimIndex, takeLocks);
       RedisModule_SaveUnsigned(rdb, vecSimWithData ? 1 : 0);
       if (vecSimWithData) {
-        bool ok = SearchDisk_SaveVectorIndexToRDB(f->vectorOpts.vecSimIndex, rdb, takeVecSimLocks);
+        bool ok = SearchDisk_SaveVectorIndexToRDB(f->vectorOpts.vecSimIndex, rdb, takeLocks);
         RS_LOG_ASSERT_ALWAYS(ok, "Failed to stream vector index to RDB");
       }
     }


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Disk-vector RDB save always uses the regular VecSim size and serialization paths, which may acquire inherited locks in a fork child.
2. Change: Pass the existing main-process lock decision through `FieldSpec_RdbSave` and `VectorDiskAPI`, including a lock-aware data-presence check.
3. Outcome: The Enterprise disk implementation can skip VecSim locks in fork children while preserving synchronization in the main process.

#### Which additional issues this PR fixes
1. MOD-16701

#### Main objects this PR modified
1. `IndexSpec_RdbSave` / `FieldSpec_RdbSave`
2. `VectorDiskAPI`
3. SearchDisk vector wrappers

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

The RDB wire format is unchanged. The corresponding Enterprise implementation and regression coverage will be submitted in a dependent PR.

Validation: full build and 967 C/C++ unit tests passed.