### PR TITLE
c_wrappers: add rs_token

### DIFF
--- a/src/query_param.c
+++ b/src/query_param.c
@@ -211,7 +211,13 @@ int QueryParam_Resolve(Param *param, dict *params, unsigned int dialectVersion, 
       return 1;
 
     case PARAM_TERM_CASE:
-      *(char**)param->target = rm_strdup(val);
+      // Copy all `val_len` bytes (the value is binary-safe and may contain
+      // interior NULs) with a trailing NUL terminator, keeping `target_len`
+      // consistent with the allocation. `rm_strdup` stops at the first interior
+      // NUL, which would leave `*target_len == val_len` describing a range past
+      // the end of the allocation.
+      *(char**)param->target = rm_calloc(1, val_len + 1);
+      memcpy(*(char**)param->target, val, val_len);
       if (param->target_len) *param->target_len = val_len;
       return 1;
 

--- a/src/query_param.h
+++ b/src/query_param.h
@@ -12,6 +12,10 @@
 #include "query_parser/tokenizer.h"
 #include "param.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct QueryParseCtx;
 
 typedef enum {
@@ -60,3 +64,7 @@ bool QueryParam_SetParam(struct QueryParseCtx *q, Param *target_param, void *tar
  * Parse the parameters from ac into the dest params.
  */
 int parseParams (dict **destParams, ArgsCursor *ac, QueryError *status);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1753,6 +1753,7 @@ dependencies = [
  "rlookup",
  "rqe_core",
  "rqe_iterators",
+ "rs_token",
  "search_disk",
  "workspace_hack",
 ]
@@ -1801,6 +1802,7 @@ dependencies = [
  "rqe_core",
  "rqe_iterators",
  "rqe_iterators_test_utils",
+ "rs_token",
  "search_disk",
  "thiserror",
  "workspace_hack",
@@ -2458,6 +2460,19 @@ dependencies = [
  "value_ffi",
  "varint_ffi",
  "wildcard",
+ "workspace_hack",
+]
+
+[[package]]
+name = "rs_token"
+version = "0.0.1"
+dependencies = [
+ "build_utils",
+ "ffi",
+ "query_term",
+ "redis_mock",
+ "redisearch_rs",
+ "rs_token",
  "workspace_hack",
 ]
 

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -146,6 +146,7 @@ ref_mode = { path = "./ref_mode" }
 result_processor = { path = "./result_processor" }
 rlookup = { path = "./rlookup" }
 rm_array = { path = "./c_wrappers/rm_array" }
+rs_token = { path = "./c_wrappers/rs_token" }
 query_types = { path = "./query_types" }
 rqe_core = { path = "./rqe_core" }
 rqe_iterator_type = { path = "./rqe_iterator_type" }

--- a/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
@@ -20,7 +20,7 @@ use ffi::{
     RedisSearchCtx,
 };
 use query_eval::{
-    QueryEvalContext, QueryNodeRef, eval,
+    QueryEvalContext, QueryNodeMut, eval,
     eval::Config,
     scorers::{BuiltInScorer, slop_forces_offsets},
 };
@@ -172,13 +172,16 @@ pub unsafe extern "C" fn Query_EvalNode_Rs(
     // it exclusively for the duration of this call.
     let mut ctx = unsafe { QueryEvalContext::new(q) };
     // SAFETY: `n` is a non-null pointer to a valid `RSQueryNode` (precondition 2),
-    // borrowed only for the duration of this call.
-    let node = unsafe { QueryNodeRef::new(n) };
+    // borrowed only for the duration of this call. Evaluation owns the subtree
+    // exclusively: the C dispatcher hands each node to exactly one evaluator and
+    // waits for it to return, and query evaluation is single-threaded, so no
+    // other wrapper or reference into this subtree is live for the call.
+    let node = unsafe { QueryNodeMut::new(n) };
 
     // SAFETY: `config` is non-null (checked) and points to a valid `Config`
     // (precondition 3); read by value here (`Config` is `Copy`).
     let config = unsafe { config.read() };
-    match eval::eval_node(&mut ctx, &node, config) {
+    match eval::eval_node(&mut ctx, node, config) {
         // The returned handle is heap-allocated and self-owning; erasing its
         // borrow is sound because the index data it reads outlives it
         // (precondition 1).
@@ -257,12 +260,14 @@ pub unsafe extern "C" fn QAST_Iterate(
     // pointer fields satisfy the `QueryEvalContext::new` invariants per the
     // preconditions, and it is borrowed exclusively for the call.
     let mut ctx = unsafe { QueryEvalContext::new(q) };
-    // SAFETY: `root` is a valid `RSQueryNode` (precondition 1).
-    let node = unsafe { QueryNodeRef::new(root) };
+    // SAFETY: `root` is a valid `RSQueryNode` and the whole AST is borrowed
+    // exclusively for the duration of this call (precondition 1), so evaluation
+    // owns the tree: no other wrapper or reference into it is live.
+    let node = unsafe { QueryNodeMut::new(root) };
 
     let config = eval_config(ctx.config());
     // The returned handle is heap-allocated and self-owning; erasing its borrow
     // of the transient `qectx` is sound because the index data it reads
     // (reachable via `sctx`/`spec`) outlives it.
-    eval::qast_iterate(&mut ctx, &node, config).into_c_iterator()
+    eval::qast_iterate(&mut ctx, node, config).into_c_iterator()
 }

--- a/src/redisearch_rs/c_wrappers/query/src/query_node_ref.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_node_ref.rs
@@ -14,6 +14,7 @@ use std::{marker::PhantomData, ops::Deref, ptr::NonNull};
 use inverted_index::NumericFilter;
 use query_types::{QueryNodeOptions, QueryNodeType};
 use rqe_core::{DocId, FieldMask};
+use rs_token::{RSTokenRef, RSTokenRefNulTerminated};
 
 /// The wildcard expansion mode for a [`QueryNode::Prefix`] node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -34,8 +35,9 @@ pub enum WildcardMode {
 /// (`Union`, `Not`, `Optional`, `Wildcard`, `Null`) are unit variants —
 /// their semantics come entirely from the shared header and child list.
 ///
-/// Fields that embed an [`ffi::RSToken`] are exposed as references because
-/// the token struct contains bitfields that cannot be cleanly inlined.
+/// Fields that embed an [`ffi::RSToken`] are exposed as [`Copy`] [`RSTokenRef`]
+/// handles because the token struct contains bitfields that cannot be cleanly
+/// inlined.
 pub enum QueryNode<'a> {
     /// A list of child nodes with intersection semantics, or a literal phrase
     /// when the children are token nodes.
@@ -50,8 +52,9 @@ pub enum QueryNode<'a> {
     /// A terminal, single-term node.
     Token {
         /// The token string, length, and associated metadata (stemming,
-        /// phonetic flags, etc.).
-        tok: &'a ffi::RSToken,
+        /// phonetic flags, etc.). Not guaranteed to be NUL-terminated: an
+        /// expanded token may come from the length-delimited `ExpandToken` API.
+        tok: RSTokenRef<'a>,
     },
     /// A numeric range filter.
     Numeric {
@@ -76,7 +79,7 @@ pub enum QueryNode<'a> {
     /// A prefix (and/or suffix) wildcard expansion node.
     Prefix {
         /// The base token to expand.
-        tok: &'a ffi::RSToken,
+        tok: RSTokenRefNulTerminated<'a>,
         /// The wildcard mode for this prefix node.
         mode: WildcardMode,
     },
@@ -98,7 +101,7 @@ pub enum QueryNode<'a> {
     /// A fuzzy (Levenshtein distance) match node.
     Fuzzy {
         /// The base token to fuzzy-match.
-        tok: &'a ffi::RSToken,
+        tok: RSTokenRefNulTerminated<'a>,
         /// Maximum edit distance (1, 2, or 3).
         max_dist: i32,
     },
@@ -110,7 +113,7 @@ pub enum QueryNode<'a> {
     /// A verbatim wildcard-pattern query (e.g. `w'hel*o'`).
     WildcardQuery {
         /// The raw pattern token.
-        tok: &'a ffi::RSToken,
+        tok: RSTokenRefNulTerminated<'a>,
     },
     /// A null/no-op node produced when the query contains only stopwords.
     Null,
@@ -229,7 +232,14 @@ impl QueryNodeRef {
 
     /// Convert the C tagged union into a [`QueryNode`] enum.
     pub fn as_enum(&self) -> QueryNode<'_> {
-        let inner = self.as_ffi_ref();
+        // Root the union access in the *raw* node pointer rather than a
+        // `&ffi::RSQueryNode`. The token handles built below ([`RSTokenRef`]) must
+        // carry raw provenance: a query node's token is mutated in place during C
+        // evaluation, and a handle derived from a shared reference would be
+        // invalidated by that write, making a later accessor call undefined
+        // behaviour. Reading `type_` and taking the union address through the raw
+        // pointer forms no reference to the node.
+        let node = self.as_non_null().as_ptr();
         // Each arm has its own `unsafe` block so that every union access
         // is individually justified, satisfying `multiple_unsafe_ops_per_block`.
         //
@@ -240,12 +250,15 @@ impl QueryNodeRef {
         // active variant type.  This avoids `__BindgenUnionField::as_ref()`
         // which uses `transmute` from a ZST reference — UB under Stacked
         // Borrows (and flagged by miri).
-        let union_ptr = &raw const inner.__bindgen_anon_1;
+        // SAFETY: `node` points to an initialised node (invariant 1 of `new`).
+        let node_type = unsafe { (*node).type_ };
+        // SAFETY: as above; `&raw const` forms no reference to the node.
+        let union_ptr = unsafe { &raw const (*node).__bindgen_anon_1 };
 
         // SAFETY (all arms): the caller (transitively, invariant 1 of `new`)
         // guarantees the node is properly initialised, so `type_` matches the
         // active union variant and the cast is sound.
-        match inner.type_ {
+        match node_type {
             QueryNodeType::Phrase => {
                 // SAFETY: `type_` is `Phrase`, so the union holds a `QueryPhraseNode`.
                 let pn = unsafe { &*union_ptr.cast::<ffi::QueryPhraseNode>() };
@@ -255,8 +268,12 @@ impl QueryNodeRef {
             }
             QueryNodeType::Union => QueryNode::Union,
             QueryNodeType::Token => QueryNode::Token {
-                // SAFETY: `type_` is `Token`, so the union holds an `RSToken`.
-                tok: unsafe { &*union_ptr.cast::<ffi::RSToken>() },
+                // SAFETY: `type_` is `Token`, so the union holds an `RSToken` whose
+                // `str_`/`len` describe a valid byte range for the node's lifetime,
+                // satisfying `from_ffi`. The pointer is raw (not reference-derived),
+                // as `from_ffi` requires. Token strings may come from the
+                // length-delimited `ExpandToken` API, so no NUL-termination.
+                tok: unsafe { RSTokenRef::from_ffi(union_ptr.cast::<ffi::RSToken>()) },
             },
             QueryNodeType::Numeric => {
                 // SAFETY: `type_` is `Numeric`, so the union holds a `QueryNumericNode`.
@@ -284,11 +301,21 @@ impl QueryNodeRef {
                 QueryNode::Geometry { geomq: gmn.geomq }
             }
             QueryNodeType::Prefix => {
-                // SAFETY: `type_` is `Prefix`, so the union holds a `QueryPrefixNode`.
-                let pfx = unsafe { &*union_ptr.cast::<ffi::QueryPrefixNode>() };
+                let pfx = union_ptr.cast::<ffi::QueryPrefixNode>();
+                // SAFETY: `type_` is `Prefix`, so `pfx` points to a valid
+                // `QueryPrefixNode`; `&raw const` takes the token address, keeping
+                // it raw (not reference-derived).
+                let tok = unsafe { &raw const (*pfx).tok };
+                // SAFETY: as above; read the prefix flag.
+                let prefix = unsafe { (*pfx).prefix };
+                // SAFETY: as above; read the suffix flag.
+                let suffix = unsafe { (*pfx).suffix };
                 QueryNode::Prefix {
-                    tok: &pfx.tok,
-                    mode: match (pfx.prefix, pfx.suffix) {
+                    // SAFETY: `tok` addresses a valid, NUL-terminated query-node
+                    // token owned by the node, and is raw (not reference-derived),
+                    // as `from_nul_terminated_ffi` requires.
+                    tok: unsafe { RSTokenRefNulTerminated::from_nul_terminated_ffi(tok) },
+                    mode: match (prefix, suffix) {
                         (true, false) => WildcardMode::Prefix,
                         (false, true) => WildcardMode::Suffix,
                         (true, true) => WildcardMode::Contains,
@@ -331,11 +358,19 @@ impl QueryNodeRef {
                 }
             }
             QueryNodeType::Fuzzy => {
-                // SAFETY: `type_` is `Fuzzy`, so the union holds a `QueryFuzzyNode`.
-                let fz = unsafe { &*union_ptr.cast::<ffi::QueryFuzzyNode>() };
+                let fz = union_ptr.cast::<ffi::QueryFuzzyNode>();
+                // SAFETY: `type_` is `Fuzzy`, so `fz` points to a valid
+                // `QueryFuzzyNode`; `&raw const` takes the token address, keeping
+                // it raw (not reference-derived).
+                let tok = unsafe { &raw const (*fz).tok };
+                // SAFETY: as above; read `maxDist`.
+                let max_dist = unsafe { (*fz).maxDist };
                 QueryNode::Fuzzy {
-                    tok: &fz.tok,
-                    max_dist: fz.maxDist,
+                    // SAFETY: `tok` addresses a valid, NUL-terminated query-node
+                    // token owned by the node, and is raw, as
+                    // `from_nul_terminated_ffi` requires.
+                    tok: unsafe { RSTokenRefNulTerminated::from_nul_terminated_ffi(tok) },
+                    max_dist,
                 }
             }
             QueryNodeType::Vector => {
@@ -344,9 +379,17 @@ impl QueryNodeRef {
                 QueryNode::Vector { vq: vn.vq }
             }
             QueryNodeType::WildcardQuery => {
-                // SAFETY: `type_` is `WildcardQuery`, so the union holds a `QueryVerbatimNode`.
-                let verb = unsafe { &*union_ptr.cast::<ffi::QueryVerbatimNode>() };
-                QueryNode::WildcardQuery { tok: &verb.tok }
+                let verb = union_ptr.cast::<ffi::QueryVerbatimNode>();
+                // SAFETY: `type_` is `WildcardQuery`, so `verb` points to a valid
+                // `QueryVerbatimNode`; `&raw const` takes the token address,
+                // keeping it raw (not reference-derived).
+                let tok = unsafe { &raw const (*verb).tok };
+                QueryNode::WildcardQuery {
+                    // SAFETY: `tok` addresses a valid, NUL-terminated query-node
+                    // token owned by the node, and is raw, as
+                    // `from_nul_terminated_ffi` requires.
+                    tok: unsafe { RSTokenRefNulTerminated::from_nul_terminated_ffi(tok) },
+                }
             }
             QueryNodeType::Null => QueryNode::Null,
             QueryNodeType::Missing => {

--- a/src/redisearch_rs/c_wrappers/query/src/query_node_ref.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_node_ref.rs
@@ -134,7 +134,8 @@ pub enum QueryNode<'a> {
 /// type.
 ///
 /// All accessors here are read-only. Mutation goes through an exclusive
-/// [`QueryNodeMut`], obtained via [`as_mut`](Self::as_mut).
+/// [`QueryNodeMut`], which is where a caller asserts exclusive access once and
+/// then hands it down the subtree.
 ///
 /// # Ownership
 ///
@@ -183,29 +184,6 @@ impl QueryNodeRef {
         &self.as_ffi_ref().opts
     }
 
-    /// Upgrade this shared view into an exclusive [`QueryNodeMut`] over the same
-    /// node subtree, enabling in-place mutation.
-    ///
-    /// # Safety
-    ///
-    /// The caller must have **exclusive** access to this node and all of its
-    /// descendants for the lifetime of the returned [`QueryNodeMut`]: while that
-    /// wrapper — or any [`QueryNodeMut`] reborrowed from it via
-    /// [`child_mut`](QueryNodeMut::child_mut) — is live, no other
-    /// [`QueryNodeRef`]/[`QueryNodeMut`] wrapping a node in this subtree may be
-    /// used, and no reference obtained from one (e.g. via [`opts`](Self::opts))
-    /// may be live. This cannot be enforced by the borrow checker because
-    /// wrappers to the same node can be minted from safe code (e.g.
-    /// [`child`](Self::child)); upholding it is the caller's responsibility.
-    ///
-    /// This is the single point where exclusivity is asserted. Given it, every
-    /// write through the returned [`QueryNodeMut`] is safe: its `&mut`-based API
-    /// and reborrowing [`child_mut`](QueryNodeMut::child_mut) keep each
-    /// individual mutation statically free of aliasing.
-    pub const unsafe fn as_mut(&self) -> QueryNodeMut<'_> {
-        QueryNodeMut(self.0, PhantomData)
-    }
-
     /// The number of child nodes.
     ///
     /// Returns 0 when the `children` pointer is null (leaf nodes).
@@ -231,34 +209,28 @@ impl QueryNodeRef {
     }
 
     /// Convert the C tagged union into a [`QueryNode`] enum.
+    ///
+    /// Every payload borrowed out of the node — token handles, slices, nested
+    /// references — carries the `&self` borrow, so the node stays shared-borrowed
+    /// for as long as any of them is in use. A caller holding a
+    /// [`QueryNodeMut`] therefore cannot mutate the node, or hand it to the C
+    /// evaluator, while a payload from a previous `as_enum` is still live: the
+    /// borrow checker rejects it.
     pub fn as_enum(&self) -> QueryNode<'_> {
-        // Root the union access in the *raw* node pointer rather than a
-        // `&ffi::RSQueryNode`. The token handles built below ([`RSTokenRef`]) must
-        // carry raw provenance: a query node's token is mutated in place during C
-        // evaluation, and a handle derived from a shared reference would be
-        // invalidated by that write, making a later accessor call undefined
-        // behaviour. Reading `type_` and taking the union address through the raw
-        // pointer forms no reference to the node.
-        let node = self.as_non_null().as_ptr();
+        let inner = self.as_ffi_ref();
         // Each arm has its own `unsafe` block so that every union access
         // is individually justified, satisfying `multiple_unsafe_ops_per_block`.
         //
-        // SAFETY (all arms): the caller (transitively, invariant 1 of `new`)
-        // guarantees the node is properly initialised, so `type_` matches
-        // the active union variant.
         // Obtain a raw pointer to the union once; each arm casts it to the
         // active variant type.  This avoids `__BindgenUnionField::as_ref()`
         // which uses `transmute` from a ZST reference — UB under Stacked
         // Borrows (and flagged by miri).
-        // SAFETY: `node` points to an initialised node (invariant 1 of `new`).
-        let node_type = unsafe { (*node).type_ };
-        // SAFETY: as above; `&raw const` forms no reference to the node.
-        let union_ptr = unsafe { &raw const (*node).__bindgen_anon_1 };
+        let union_ptr = &raw const inner.__bindgen_anon_1;
 
         // SAFETY (all arms): the caller (transitively, invariant 1 of `new`)
         // guarantees the node is properly initialised, so `type_` matches the
         // active union variant and the cast is sound.
-        match node_type {
+        match inner.type_ {
             QueryNodeType::Phrase => {
                 // SAFETY: `type_` is `Phrase`, so the union holds a `QueryPhraseNode`.
                 let pn = unsafe { &*union_ptr.cast::<ffi::QueryPhraseNode>() };
@@ -269,10 +241,10 @@ impl QueryNodeRef {
             QueryNodeType::Union => QueryNode::Union,
             QueryNodeType::Token => QueryNode::Token {
                 // SAFETY: `type_` is `Token`, so the union holds an `RSToken` whose
-                // `str_`/`len` describe a valid byte range for the node's lifetime,
-                // satisfying `from_ffi`. The pointer is raw (not reference-derived),
-                // as `from_ffi` requires. Token strings may come from the
-                // length-delimited `ExpandToken` API, so no NUL-termination.
+                // `str_`/`len` describe a valid byte range, unmutated for the
+                // `&self` borrow the handle carries — satisfying `from_ffi`. Token
+                // strings may come from the length-delimited `ExpandToken` API, so
+                // no NUL-termination.
                 tok: unsafe { RSTokenRef::from_ffi(union_ptr.cast::<ffi::RSToken>()) },
             },
             QueryNodeType::Numeric => {
@@ -301,21 +273,16 @@ impl QueryNodeRef {
                 QueryNode::Geometry { geomq: gmn.geomq }
             }
             QueryNodeType::Prefix => {
-                let pfx = union_ptr.cast::<ffi::QueryPrefixNode>();
-                // SAFETY: `type_` is `Prefix`, so `pfx` points to a valid
-                // `QueryPrefixNode`; `&raw const` takes the token address, keeping
-                // it raw (not reference-derived).
-                let tok = unsafe { &raw const (*pfx).tok };
-                // SAFETY: as above; read the prefix flag.
-                let prefix = unsafe { (*pfx).prefix };
-                // SAFETY: as above; read the suffix flag.
-                let suffix = unsafe { (*pfx).suffix };
+                // SAFETY: `type_` is `Prefix`, so the union holds a `QueryPrefixNode`.
+                let pfx = unsafe { &*union_ptr.cast::<ffi::QueryPrefixNode>() };
                 QueryNode::Prefix {
-                    // SAFETY: `tok` addresses a valid, NUL-terminated query-node
-                    // token owned by the node, and is raw (not reference-derived),
-                    // as `from_nul_terminated_ffi` requires.
-                    tok: unsafe { RSTokenRefNulTerminated::from_nul_terminated_ffi(tok) },
-                    mode: match (prefix, suffix) {
+                    // SAFETY: `pfx.tok` is a valid, NUL-terminated query-node token
+                    // owned by the node and unmutated for the `&self` borrow the
+                    // handle carries, as `from_nul_terminated_ffi` requires.
+                    tok: unsafe {
+                        RSTokenRefNulTerminated::from_nul_terminated_ffi(&raw const pfx.tok)
+                    },
+                    mode: match (pfx.prefix, pfx.suffix) {
                         (true, false) => WildcardMode::Prefix,
                         (false, true) => WildcardMode::Suffix,
                         (true, true) => WildcardMode::Contains,
@@ -358,19 +325,16 @@ impl QueryNodeRef {
                 }
             }
             QueryNodeType::Fuzzy => {
-                let fz = union_ptr.cast::<ffi::QueryFuzzyNode>();
-                // SAFETY: `type_` is `Fuzzy`, so `fz` points to a valid
-                // `QueryFuzzyNode`; `&raw const` takes the token address, keeping
-                // it raw (not reference-derived).
-                let tok = unsafe { &raw const (*fz).tok };
-                // SAFETY: as above; read `maxDist`.
-                let max_dist = unsafe { (*fz).maxDist };
+                // SAFETY: `type_` is `Fuzzy`, so the union holds a `QueryFuzzyNode`.
+                let fz = unsafe { &*union_ptr.cast::<ffi::QueryFuzzyNode>() };
                 QueryNode::Fuzzy {
-                    // SAFETY: `tok` addresses a valid, NUL-terminated query-node
-                    // token owned by the node, and is raw, as
-                    // `from_nul_terminated_ffi` requires.
-                    tok: unsafe { RSTokenRefNulTerminated::from_nul_terminated_ffi(tok) },
-                    max_dist,
+                    // SAFETY: `fz.tok` is a valid, NUL-terminated query-node token
+                    // owned by the node and unmutated for the `&self` borrow the
+                    // handle carries, as `from_nul_terminated_ffi` requires.
+                    tok: unsafe {
+                        RSTokenRefNulTerminated::from_nul_terminated_ffi(&raw const fz.tok)
+                    },
+                    max_dist: fz.maxDist,
                 }
             }
             QueryNodeType::Vector => {
@@ -379,16 +343,15 @@ impl QueryNodeRef {
                 QueryNode::Vector { vq: vn.vq }
             }
             QueryNodeType::WildcardQuery => {
-                let verb = union_ptr.cast::<ffi::QueryVerbatimNode>();
-                // SAFETY: `type_` is `WildcardQuery`, so `verb` points to a valid
-                // `QueryVerbatimNode`; `&raw const` takes the token address,
-                // keeping it raw (not reference-derived).
-                let tok = unsafe { &raw const (*verb).tok };
+                // SAFETY: `type_` is `WildcardQuery`, so the union holds a `QueryVerbatimNode`.
+                let verb = unsafe { &*union_ptr.cast::<ffi::QueryVerbatimNode>() };
                 QueryNode::WildcardQuery {
-                    // SAFETY: `tok` addresses a valid, NUL-terminated query-node
-                    // token owned by the node, and is raw, as
-                    // `from_nul_terminated_ffi` requires.
-                    tok: unsafe { RSTokenRefNulTerminated::from_nul_terminated_ffi(tok) },
+                    // SAFETY: `verb.tok` is a valid, NUL-terminated query-node token
+                    // owned by the node and unmutated for the `&self` borrow the
+                    // handle carries, as `from_nul_terminated_ffi` requires.
+                    tok: unsafe {
+                        RSTokenRefNulTerminated::from_nul_terminated_ffi(&raw const verb.tok)
+                    },
                 }
             }
             QueryNodeType::Null => QueryNode::Null,
@@ -411,17 +374,23 @@ impl QueryNodeRef {
 
 /// Exclusive, mutable view of a [`ffi::RSQueryNode`] subtree.
 ///
-/// Obtained from [`QueryNodeRef::as_mut`], whose `unsafe` contract establishes
+/// Obtained from [`new`](Self::new), whose `unsafe` contract establishes
 /// exclusive access to the node and its descendants. Given that invariant, the
 /// mutating API here is **safe**: [`and_field_mask`](Self::and_field_mask) takes
 /// `&mut self`, and [`child_mut`](Self::child_mut) reborrows `&mut self`, so the
 /// borrow checker guarantees that while a child view is live the parent (and any
 /// sibling view) cannot be read or mutated — no two live wrappers ever alias the
-/// same node. The exclusivity asserted once at [`as_mut`](QueryNodeRef::as_mut)
-/// thus propagates down the subtree without any further `unsafe`.
+/// same node. The exclusivity asserted once at [`new`](Self::new) thus
+/// propagates down the subtree without any further `unsafe`.
 ///
-/// The lifetime `'node` ties the view to the originating [`QueryNodeRef`] so it
-/// cannot outlive the borrowed node.
+/// Crucially, it also propagates to everything *read out of* the node. A payload
+/// borrowed via [`as_enum`](QueryNodeRef::as_enum) — a token handle, an id slice
+/// — carries a shared reborrow of this view, so while such a payload is live the
+/// `&mut self` methods are unreachable and the view cannot be moved (e.g. handed
+/// to the C evaluator, which rewrites tokens in place).
+///
+/// The lifetime `'node` ties the view to the borrowed node so it cannot outlive
+/// it.
 ///
 /// Read-only access goes through [`Deref`]: all of [`QueryNodeRef`]'s shared
 /// accessors (`opts`, `num_children`, …) are reachable on a [`QueryNodeMut`]
@@ -437,10 +406,38 @@ pub struct QueryNodeMut<'node>(
 );
 
 impl QueryNodeMut<'_> {
+    /// Wrap a raw [`NonNull`] pointer to a [`ffi::RSQueryNode`] as an exclusive
+    /// view of that node and its descendants.
+    ///
+    /// This is the **single** point where exclusive access to an AST subtree is
+    /// asserted. Everything below it — mutation, child traversal, and the borrows
+    /// handed out by [`as_enum`](QueryNodeRef::as_enum) — is then checked by the
+    /// borrow checker, so no further `unsafe` assertion about aliasing is needed
+    /// anywhere in the subtree walk.
+    ///
+    /// # Safety
+    ///
+    /// 1. `ptr` must point to a [valid], properly initialised
+    ///    [`ffi::RSQueryNode`].
+    /// 2. The caller must have **exclusive** access to that node and all of its
+    ///    descendants for the lifetime of the returned view: for as long as it —
+    ///    or anything reborrowed from it via [`child_mut`](Self::child_mut) — is
+    ///    live, no other [`QueryNodeRef`]/[`QueryNodeMut`] wrapping a node in this
+    ///    subtree may be used, and neither may any reference or handle obtained
+    ///    from one. This is not enforceable by the borrow checker because
+    ///    wrappers to the same node can be minted from safe code (e.g.
+    ///    [`child`](QueryNodeRef::child)) and because C holds its own pointers
+    ///    into the AST; upholding it is the caller's responsibility.
+    ///
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+    pub const unsafe fn new(ptr: NonNull<ffi::RSQueryNode>) -> Self {
+        Self(ptr, PhantomData)
+    }
+
     /// Intersect `mask` into this node's [field mask](QueryNodeOptions::field_mask).
     pub fn and_field_mask(&mut self, mask: FieldMask) {
         // `&mut self` plus the exclusive-access invariant of
-        // [`QueryNodeRef::as_mut`] guarantee no other wrapper or reference
+        // [`QueryNodeMut::new`] guarantee no other wrapper or reference
         // aliases this node, so the read-modify-write below cannot race or
         // alias a live reference.
         //

--- a/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
@@ -155,7 +155,7 @@ fn as_enum_token() {
     let QueryNode::Token { tok } = node.as_enum() else {
         panic!("expected Token");
     };
-    assert!(tok.str_.is_null());
+    assert!(tok.as_bytes().is_none());
 }
 
 #[test]

--- a/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
@@ -8,7 +8,7 @@
 */
 
 use inverted_index::NumericFilter;
-use query::{QueryNode, QueryNodeRef, WildcardMode, mock::MockQueryNode};
+use query::{QueryNode, QueryNodeMut, QueryNodeRef, WildcardMode, mock::MockQueryNode};
 use query_types::QueryNodeType;
 
 #[test]
@@ -155,8 +155,7 @@ fn as_enum_token() {
     let QueryNode::Token { tok } = node.as_enum() else {
         panic!("expected Token");
     };
-    // SAFETY: nothing evaluates or frees the node while the (absent) view lives.
-    assert!(unsafe { tok.as_bytes() }.is_none());
+    assert!(tok.as_bytes().is_none());
 }
 
 #[test]
@@ -242,10 +241,10 @@ fn query_node_mut_narrows_child_field_masks() {
     parent.opts_mut().field_mask = 0b0110;
     parent.set_children(&[child1.as_ptr(), child2.as_ptr()]);
 
-    let node = unsafe { QueryNodeRef::new(parent.as_non_null()) };
-    // SAFETY: `node` is the sole wrapper to this subtree for the duration of
-    // the test; no other wrapper or derived reference is live.
-    let mut node = unsafe { node.as_mut() };
+    // SAFETY: `parent` is a valid node and `node` is the sole wrapper to this
+    // subtree for the duration of the test; no other wrapper or derived
+    // reference is live.
+    let mut node = unsafe { QueryNodeMut::new(parent.as_non_null()) };
     assert_eq!(node.num_children(), 2);
     let mask = node.opts().field_mask;
 
@@ -270,8 +269,8 @@ fn query_node_mut_narrows_child_field_masks() {
 #[should_panic(expected = "out of bounds")]
 fn query_node_mut_child_out_of_bounds_panics() {
     let mock = MockQueryNode::new(QueryNodeType::Wildcard);
-    let node = unsafe { QueryNodeRef::new(mock.as_non_null()) };
-    // SAFETY: sole wrapper to a leaf node; no other wrapper or reference live.
-    let mut node = unsafe { node.as_mut() };
+    // SAFETY: sole wrapper to a valid leaf node; no other wrapper or reference
+    // live.
+    let mut node = unsafe { QueryNodeMut::new(mock.as_non_null()) };
     let _ = node.child_mut(0);
 }

--- a/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
@@ -155,7 +155,8 @@ fn as_enum_token() {
     let QueryNode::Token { tok } = node.as_enum() else {
         panic!("expected Token");
     };
-    assert!(tok.as_bytes().is_none());
+    // SAFETY: nothing evaluates or frees the node while the (absent) view lives.
+    assert!(unsafe { tok.as_bytes() }.is_none());
 }
 
 #[test]

--- a/src/redisearch_rs/c_wrappers/rs_token/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/rs_token/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "query"
+name = "rs_token"
 version.workspace = true
 edition.workspace = true
 license-file.workspace = true
@@ -10,26 +10,18 @@ publish.workspace = true
 # see https://github.com/rust-lang/cargo/issues/4789#issuecomment-2308131243
 unittest = []
 
+[lints]
+workspace = true
+
 [build-dependencies]
 build_utils.workspace = true
 
 [dependencies]
 ffi.workspace = true
-inverted_index.workspace = true
-query_error.workspace = true
-query_flags.workspace = true
-query_types.workspace = true
-rlookup.workspace = true
-rqe_core.workspace = true
-rqe_iterators.workspace = true
-rs_token.workspace = true
-search_disk.workspace = true
+query_term.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]
-query = { path = ".", features = ["unittest"] }
 redis_mock.workspace = true
 redisearch_rs = { workspace = true, features = ["mock_allocator"] }
-
-[lints]
-workspace = true
+rs_token = { path = ".", features = ["unittest"] }

--- a/src/redisearch_rs/c_wrappers/rs_token/build.rs
+++ b/src/redisearch_rs/c_wrappers/rs_token/build.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+fn main() {
+    #[cfg(feature = "unittest")]
+    build_utils::bind_foreign_c_symbols();
+}

--- a/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Safe wrapper around [`ffi::RSToken`].
+
+use std::{
+    ffi::{CStr, c_char},
+    marker::PhantomData,
+    ptr::NonNull,
+};
+
+use query_term::RSTokenFlags;
+
+/// The most bytes the C `strToLowerRunes` decoder (`nu_utf8_read`) reads past a
+/// multibyte lead byte. A UTF-8 sequence is at most four bytes, so the decoder
+/// touches at most three bytes beyond the lead — and it does so without any
+/// bounds check. Padding a decoder input with this many trailing zero bytes
+/// keeps a truncated trailing lead byte from reading out of bounds.
+const NU_MAX_READAHEAD: usize = 3;
+
+/// Upper bound on how many token bytes are copied for a rune conversion. A term
+/// is stored under at most [`ffi::MAX_RUNE_STR_LEN`] runes, and every UTF-8
+/// codepoint — at most four bytes — folds to at least one rune, so any input
+/// longer than this decodes to more runes than `MAX_RUNE_STR_LEN`. Such a token
+/// is rejected by the C `strToLowerRunes` and can match no stored term either
+/// way, so capping the copy here keeps a huge token from forcing an equally huge
+/// transient allocation before that rejection.
+const MAX_DECODE_BYTES: usize = 4 * (ffi::MAX_RUNE_STR_LEN as usize + 1);
+
+/// How many bytes the C decoder (`nu_utf8_read`) consumes for the lead byte `b`,
+/// mirroring its branches exactly — including that it treats a stray
+/// continuation byte (`0x80..=0xBF`) as a two-byte lead rather than rejecting it.
+const fn nu_seq_len(b: u8) -> usize {
+    match b {
+        0x00..=0x7F => 1,
+        0x80..=0xDF => 2,
+        0xE0..=0xEF => 3,
+        0xF0..=0xFF => 4,
+    }
+}
+
+/// Whether handing `bytes` to the C decoder would read past its end.
+///
+/// The decoder walks the input one sequence at a time, reading [`nu_seq_len`]
+/// bytes from each position it lands on without checking that many remain. This
+/// replays that same walk — the lengths alone decide where it lands, so no
+/// decoding is needed — and reports whether any step would run off the end. It
+/// is exact rather than conservative: a well-formed input, whatever its last
+/// character, never trips it, and only a genuinely truncated trailing sequence
+/// does.
+///
+/// `false` means no read can escape `bytes`, so it may be decoded in place; the
+/// padded copy is only needed when this returns `true`.
+fn tail_may_overread(bytes: &[u8]) -> bool {
+    let mut pos = 0;
+    while pos < bytes.len() {
+        let seq_len = nu_seq_len(bytes[pos]);
+        if pos + seq_len > bytes.len() {
+            return true;
+        }
+        pos += seq_len;
+    }
+    false
+}
+
+/// Safe, read-only, [`Copy`] handle borrowing a query-node's [`ffi::RSToken`].
+///
+/// An [`ffi::RSToken`] is a plain-data struct — a `(string, length)` pair plus a
+/// packed flags bitfield. This handle borrows one for the lifetime `'a` and
+/// exposes the string as a byte slice and the flags as a scalar, keeping the raw
+/// pointer handling behind a safe surface. It is a thin, [`Copy`] wrapper, so it
+/// is passed by value rather than behind another reference.
+///
+/// It holds a raw pointer rather than a `&'a `[`ffi::RSToken`] because a query
+/// node's token is **not immutable**: evaluation rewrites it in place (escape
+/// removal, case folding) and can even replace its backing buffer, so a live
+/// shared reference to it would be undefined behaviour. The handle therefore
+/// makes no immutability promise; its accessors return short-lived views tied to
+/// the handle borrow, and a [`as_bytes`](RSTokenRef::as_bytes) slice or
+/// [`as_c_str`](RSTokenRef::as_c_str) [`CStr`] obtained from it **must not be
+/// retained across evaluation of the owning node** — read from it, or copy out of
+/// it (e.g. via [`as_lower_runes`](RSTokenRef::as_lower_runes)), before evaluation
+/// runs.
+///
+/// The `NUL_TERMINATED` const parameter is a typestate flag recording whether the
+/// token string is NUL-terminated:
+///
+/// - [`RSTokenRef<'a, true>`] additionally guarantees the string is
+///   NUL-terminated, so it exposes a *safe* [`as_c_str`](RSTokenRef::as_c_str).
+///   Query-node tokens produced by the parser for prefix, fuzzy, and verbatim
+///   nodes are NUL-terminated and use this variant.
+/// - [`RSTokenRef<'a, false>`] (the default) makes no such promise: tokens built
+///   from a raw `(pointer, length)` slice — e.g. tag values or trie-expansion
+///   terms — may not be NUL-terminated, so `as_c_str` is not available on it.
+///   Plain term (`QN_TOKEN`) nodes also use this variant, because token
+///   expansion can replace their string with a length-delimited one.
+#[derive(Clone, Copy)]
+pub struct RSTokenRef<'a, const NUL_TERMINATED: bool = false> {
+    tok: NonNull<ffi::RSToken>,
+    /// Ties the handle to the token's `'a` borrow for the borrow checker without
+    /// asserting, as a live `&'a ffi::RSToken` would, that the token stays
+    /// unmutated for `'a`.
+    _token: PhantomData<&'a ffi::RSToken>,
+}
+
+/// An [`RSTokenRef`] whose string is known to be NUL-terminated.
+pub type RSTokenRefNulTerminated<'a> = RSTokenRef<'a, true>;
+
+impl<'a, const NUL_TERMINATED: bool> RSTokenRef<'a, NUL_TERMINATED> {
+    /// Wrap a raw [`NonNull`] pointer to an [`ffi::RSToken`] as a [`Copy`] handle
+    /// carrying a `'a` borrow. Upholding the `str_`/`len` — and, for the
+    /// NUL-terminated variant, NUL-termination — invariants, and the raw-provenance
+    /// requirement, is the job of the public `unsafe` constructors that wrap it.
+    const fn new(tok: NonNull<ffi::RSToken>) -> Self {
+        Self {
+            tok,
+            _token: PhantomData,
+        }
+    }
+
+    /// A transient shared reference to the borrowed token, for reading its
+    /// fields. It is used only momentarily by internal callers, so it never
+    /// aliases an in-place mutation of the token.
+    const fn token(&self) -> &ffi::RSToken {
+        // SAFETY: the constructor's contract guarantees `tok` addresses a valid,
+        // readable `ffi::RSToken` for the handle's `'a`. The returned borrow is
+        // tied to `&self` and used transiently, not held across evaluation.
+        unsafe { self.tok.as_ref() }
+    }
+
+    /// A pointer to the underlying raw [`ffi::RSToken`], for the few call sites
+    /// that must hand the token back to C. The pointer is valid for `'a`.
+    pub const fn as_ptr(&self) -> *const ffi::RSToken {
+        self.tok.as_ptr().cast_const()
+    }
+
+    /// The length in bytes of the token string.
+    pub const fn len(&self) -> usize {
+        self.token().len
+    }
+
+    /// Whether the token string is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.token().len == 0
+    }
+
+    /// The token's per-term flags (stemming, phonetic, expansion, …).
+    pub fn flags(&self) -> RSTokenFlags {
+        self.token().flags()
+    }
+
+    /// The token string as a byte slice, or `None` when the token carries no
+    /// string (a null `str_` pointer).
+    ///
+    /// The slice is tied to this handle borrow and must not be retained across
+    /// evaluation of the owning node, which may mutate or free the token.
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        let tok = self.token();
+        let ptr = NonNull::new(tok.str_)?;
+        // SAFETY: the constructors' contract guarantees a non-null `str_`
+        // addresses `len` initialized bytes, readable for the duration of this
+        // borrow. The returned slice is tied to `&self`, so it cannot outlive it.
+        Some(unsafe { std::slice::from_raw_parts(ptr.as_ptr().cast::<u8>(), tok.len) })
+    }
+
+    /// Lowercase the token string and convert it to runes, e.g. for a trie
+    /// lookup.
+    ///
+    /// A token is a byte string and need not be valid UTF-8, so the bytes are
+    /// decoded the same way a term is indexed — each codepoint folded to
+    /// lowercase before being truncated to a rune — rather than validated. A
+    /// token carrying malformed bytes therefore resolves the runes the index
+    /// stored them as, instead of a key built from replacement characters that
+    /// was never stored.
+    ///
+    /// Content after a first interior NUL byte is ignored, matching the
+    /// up-to-NUL rune sequence the indexer stores for such a term.
+    ///
+    /// Returns `None` when the token carries no string (a null `str_` pointer) or
+    /// when the lowercased string exceeds the maximum rune-string length, in
+    /// which case it can name no stored term.
+    pub fn as_lower_runes(&self) -> Option<Vec<u16>> {
+        let bytes = self.as_bytes()?;
+
+        // `strToLowerRunes` stops at the first NUL its decoder yields — a literal
+        // `0` byte or an overlong encoding of one — and reports the runes before
+        // it, matching the indexer, so we needn't strip interior NULs ourselves.
+        //
+        // But its decoder (`nu_utf8_read`) reads a fixed 2–4 bytes from a
+        // multibyte lead byte with no bounds check, so a token ending in a
+        // truncated lead (e.g. a lone `0xF0`) would read past the end. Where that
+        // can happen, decode a private copy instead: one capped at
+        // `MAX_DECODE_BYTES`, since a longer token decodes to more runes than any
+        // stored term can have and is rejected regardless, so the cap only avoids
+        // a needless huge transient copy; and padded with `NU_MAX_READAHEAD`
+        // trailing zero bytes so the decoder can never read past the content.
+        //
+        // The common case needs neither: a token short enough to escape the cap
+        // and not ending in a truncated sequence — which is every well-formed
+        // one — is handed to C in place, with no copy at all.
+        if bytes.len() <= MAX_DECODE_BYTES && !tail_may_overread(bytes) {
+            // SAFETY: `tail_may_overread` ruled out every read past `bytes`, so
+            // the decoder stays within it (see that function's contract).
+            return unsafe { Self::to_lower_runes(bytes.as_ptr(), bytes.len()) };
+        }
+
+        let decode_len = bytes.len().min(MAX_DECODE_BYTES);
+        let mut buf = Vec::with_capacity(decode_len + NU_MAX_READAHEAD);
+        buf.extend_from_slice(&bytes[..decode_len]);
+        buf.resize(decode_len + NU_MAX_READAHEAD, 0);
+
+        // SAFETY: `buf` holds `decode_len` content bytes followed by
+        // `NU_MAX_READAHEAD` zero bytes; since `nu_utf8_read` reads at most
+        // `NU_MAX_READAHEAD` bytes past any lead byte it decodes, every read stays
+        // within `buf`.
+        unsafe { Self::to_lower_runes(buf.as_ptr(), decode_len) }
+    }
+
+    /// Lowercase `len` bytes at `ptr` to runes via the C converter, returning
+    /// `None` when it declines the conversion because the result would exceed the
+    /// maximum rune-string length.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must address `len` initialized bytes, *and* the C decoder must not
+    /// read past them: `nu_utf8_read` consumes a fixed 1–4 bytes from whatever
+    /// lead byte it lands on with no bounds check, so the caller must either pad
+    /// the allocation with [`NU_MAX_READAHEAD`] trailing bytes or establish that
+    /// no such over-read can occur (see [`tail_may_overread`]).
+    unsafe fn to_lower_runes(ptr: *const u8, len: usize) -> Option<Vec<u16>> {
+        let mut nrunes: usize = 0;
+        // SAFETY: the caller guarantees the decoder's reads stay in bounds. The
+        // call returns a freshly allocated buffer of `nrunes` runes, or NULL when
+        // the folded length exceeds the maximum.
+        let ptr = unsafe { ffi::strToLowerRunes(ptr.cast::<c_char>(), len, &mut nrunes) };
+        let ptr = NonNull::new(ptr)?;
+        // SAFETY: `ptr` points to `nrunes` valid runes written by the call above.
+        let runes = unsafe { std::slice::from_raw_parts(ptr.as_ptr(), nrunes) }.to_vec();
+        // SAFETY: `RedisModule_Free` is set during module init and not mutated
+        // afterwards.
+        let rm_free = unsafe { ffi::RedisModule_Free.expect("Redis allocator not available") };
+        // SAFETY: `ptr` was allocated by the module allocator inside
+        // `strToLowerRunes`.
+        unsafe { rm_free(ptr.as_ptr().cast::<std::ffi::c_void>()) };
+        Some(runes)
+    }
+}
+
+impl<'a> RSTokenRef<'a, false> {
+    /// Wrap a raw pointer to an [`ffi::RSToken`] whose string is *not* guaranteed
+    /// to be NUL-terminated (e.g. a token built from a raw `(pointer, length)`
+    /// slice).
+    ///
+    /// If the string *is* known to be NUL-terminated, use
+    /// [`from_nul_terminated_ffi`](RSTokenRef::from_nul_terminated_ffi) instead.
+    ///
+    /// # Safety
+    ///
+    /// - `tok` must be non-null and point to a valid [`ffi::RSToken`] that stays
+    ///   allocated and readable for the whole of the handle's `'a` lifetime; when
+    ///   its `str_` is non-null it must address `len` initialized bytes.
+    /// - `tok` must be a **raw** pointer whose provenance permits the token to be
+    ///   mutated through other pointers — e.g. obtained with `&raw const` from a
+    ///   raw node pointer. It must **not** be derived from a `&ffi::RSToken` (a
+    ///   shared reference), because a query node's token is mutated in place
+    ///   during evaluation: a foreign write would then invalidate a
+    ///   reference-derived pointer and every later accessor call would be
+    ///   undefined behaviour. The bytes need not stay *unchanged* — the handle
+    ///   makes no immutability promise — but a view returned by an accessor must
+    ///   not be used after the token is mutated or freed (see the type-level note).
+    pub const unsafe fn from_ffi(tok: *const ffi::RSToken) -> Self {
+        // SAFETY: the caller guarantees `tok` is non-null.
+        Self::new(unsafe { NonNull::new_unchecked(tok.cast_mut()) })
+    }
+}
+
+impl<'a> RSTokenRef<'a, true> {
+    /// Wrap a raw pointer to an [`ffi::RSToken`] whose string is known to be
+    /// NUL-terminated, such as a query-node token produced by the parser. This
+    /// unlocks the safe [`as_c_str`](RSTokenRef::as_c_str) accessor.
+    ///
+    /// # Safety
+    ///
+    /// In addition to [`from_ffi`](RSTokenRef::from_ffi)'s requirements (including
+    /// raw provenance), a non-null `str_` must be terminated by a NUL byte at
+    /// index `len` — i.e. `str_[len]` is readable and equal to `0`, so the
+    /// allocation spans at least `len + 1` bytes (a C string of content
+    /// length `len`).
+    pub const unsafe fn from_nul_terminated_ffi(tok: *const ffi::RSToken) -> Self {
+        // In debug builds, sanity-check the NUL-termination the caller promised.
+        // Read the fields through the raw pointer, forming no reference.
+        #[cfg(debug_assertions)]
+        {
+            // SAFETY: the caller guarantees `tok` points to a valid `RSToken`.
+            let str_ = unsafe { (*tok).str_ };
+            if !str_.is_null() {
+                // SAFETY: the caller guarantees `tok` points to a valid `RSToken`.
+                let len = unsafe { (*tok).len };
+                // SAFETY: the caller guarantees `str_` is a NUL-terminated string
+                // of content length `len`, so `str_.add(len)` is the in-bounds
+                // terminator address.
+                let terminator_ptr = unsafe { str_.add(len) };
+                // SAFETY: `terminator_ptr` addresses the in-bounds terminator byte.
+                let terminator = unsafe { *terminator_ptr };
+                assert!(terminator == 0, "token string must be NUL-terminated");
+            }
+        }
+        // SAFETY: the caller guarantees `tok` is non-null.
+        Self::new(unsafe { NonNull::new_unchecked(tok.cast_mut()) })
+    }
+
+    /// The token string as a NUL-terminated [`CStr`], or `None` when the token
+    /// carries no string (a null `str_` pointer).
+    ///
+    /// This is safe: the NUL-termination requirement is discharged once, at
+    /// construction time, by
+    /// [`from_nul_terminated_ffi`](RSTokenRef::from_nul_terminated_ffi)'s
+    /// `unsafe` contract.
+    ///
+    /// The [`CStr`] is tied to this handle borrow and must not be retained across
+    /// evaluation of the owning node, which may mutate or free the token.
+    pub fn as_c_str(&self) -> Option<&CStr> {
+        let tok = self.token();
+        let ptr = NonNull::new(tok.str_)?;
+        // SAFETY: this is an `RSTokenRef<true>`, so its constructor guaranteed a
+        // non-null `str_` points to a NUL-terminated string readable for this
+        // borrow, which the returned `CStr`, tied to `&self`, cannot outlive.
+        Some(unsafe { CStr::from_ptr(ptr.as_ptr()) })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn well_formed_input_needs_no_padding() {
+        // Nothing here can over-read, so all of it decodes in place: ASCII, and
+        // sequences of every width sitting flush against the end.
+        assert!(!tail_may_overread(b""));
+        assert!(!tail_may_overread(b"hello"));
+        assert!(!tail_may_overread(b"ab\0cd"));
+        assert!(!tail_may_overread("é".as_bytes()));
+        assert!(!tail_may_overread("日本".as_bytes()));
+        assert!(!tail_may_overread("ab😀".as_bytes()));
+    }
+
+    #[test]
+    fn truncated_trailing_sequence_needs_padding() {
+        // A lead byte announcing more bytes than remain: the decoder would read
+        // past the end, so these must take the padded-copy path.
+        assert!(tail_may_overread(b"ab\xF0"));
+        assert!(tail_may_overread(b"ab\xF0\x9F"));
+        assert!(tail_may_overread(b"ab\xF0\x9F\x98"));
+        assert!(tail_may_overread(b"ab\xE0"));
+        assert!(tail_may_overread(b"ab\xC3"));
+        // A stray continuation byte at the end is read as a two-byte lead.
+        assert!(tail_may_overread(b"ab\x80"));
+    }
+
+    #[test]
+    fn earlier_malformed_bytes_do_not_force_padding() {
+        // The damage is mid-string: the walk resynchronises past it and still
+        // lands inside the input, so no over-read is possible.
+        assert!(!tail_may_overread(b"\xC3(ab"));
+    }
+}

--- a/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
@@ -11,7 +11,6 @@
 
 use std::{
     ffi::{CStr, c_char},
-    marker::PhantomData,
     ptr::NonNull,
 };
 
@@ -77,26 +76,21 @@ fn tail_may_overread(bytes: &[u8]) -> bool {
 /// pointer handling behind a safe surface. It is a thin, [`Copy`] wrapper, so it
 /// is passed by value rather than behind another reference.
 ///
-/// It holds a raw pointer rather than a `&'a `[`ffi::RSToken`] because a query
-/// node's token is **not immutable**: evaluation rewrites it in place (escape
-/// removal, case folding) and can even replace its backing buffer, so a live
-/// shared reference to it would be undefined behaviour.
+/// # Why the accessors are safe
 ///
-/// The handle therefore makes no immutability promise, which splits its
-/// accessors in two:
+/// A query node's token is **not immutable**: evaluation rewrites it in place
+/// (escape removal, case folding) and can even `free` its backing buffer and
+/// install a new one. What keeps a view of the string from dangling is the
+/// lifetime `'a`: a handle is only ever minted from a shared borrow of the
+/// owning node, and every mutation path — including handing the node to the C
+/// evaluator — requires an exclusive borrow of it. So while a handle, or
+/// anything derived from it, is live, no mutation of the token can be
+/// expressed. Constructing a handle whose `'a` does *not* come from such a
+/// borrow is what the `unsafe` constructors guard.
 ///
-/// - Those returning a scalar copy — [`len`](RSTokenRef::len),
-///   [`is_empty`](RSTokenRef::is_empty), [`flags`](RSTokenRef::flags) — read the
-///   token transiently and are safe.
-/// - Those returning a *view* into the token's string —
-///   [`as_bytes`](RSTokenRef::as_bytes) and [`as_c_str`](RSTokenRef::as_c_str) —
-///   are `unsafe`, because the view's lifetime is tied to the handle borrow,
-///   which says nothing about when the owning node is next evaluated. Evaluation
-///   may rewrite or `free` the string underneath a live view, and the borrow
-///   checker cannot see that, so the caller has to guarantee the view is done
-///   with first. Copying out of the token instead — e.g. via
-///   [`as_lower_runes`](RSTokenRef::as_lower_runes), which returns an owned value
-///   — needs no such guarantee.
+/// `'a` being a no-mutation window is also what lets the handle simply hold a
+/// `&'a `[`ffi::RSToken`]: the freeze a shared reference asserts is exactly the
+/// window's guarantee, so there is nothing left for a raw pointer to buy.
 ///
 /// The `NUL_TERMINATED` const parameter is a typestate flag recording whether the
 /// token string is NUL-terminated:
@@ -113,82 +107,50 @@ fn tail_may_overread(bytes: &[u8]) -> bool {
 ///   expansion can replace their string with a length-delimited one.
 #[derive(Clone, Copy)]
 pub struct RSTokenRef<'a, const NUL_TERMINATED: bool = false> {
-    tok: NonNull<ffi::RSToken>,
-    /// Ties the handle to the token's `'a` borrow for the borrow checker without
-    /// asserting, as a live `&'a ffi::RSToken` would, that the token stays
-    /// unmutated for `'a`.
-    _token: PhantomData<&'a ffi::RSToken>,
+    tok: &'a ffi::RSToken,
 }
 
 /// An [`RSTokenRef`] whose string is known to be NUL-terminated.
 pub type RSTokenRefNulTerminated<'a> = RSTokenRef<'a, true>;
 
 impl<'a, const NUL_TERMINATED: bool> RSTokenRef<'a, NUL_TERMINATED> {
-    /// Wrap a raw [`NonNull`] pointer to an [`ffi::RSToken`] as a [`Copy`] handle
-    /// carrying a `'a` borrow. Upholding the `str_`/`len` — and, for the
-    /// NUL-terminated variant, NUL-termination — invariants, and the raw-provenance
-    /// requirement, is the job of the public `unsafe` constructors that wrap it.
-    const fn new(tok: NonNull<ffi::RSToken>) -> Self {
-        Self {
-            tok,
-            _token: PhantomData,
-        }
-    }
-
-    /// A transient shared reference to the borrowed token, for reading its
-    /// fields. It is used only momentarily by internal callers, so it never
-    /// aliases an in-place mutation of the token.
-    const fn token(&self) -> &ffi::RSToken {
-        // SAFETY: the constructor's contract guarantees `tok` addresses a valid,
-        // readable `ffi::RSToken` for the handle's `'a`. The returned borrow is
-        // tied to `&self` and used transiently, not held across evaluation.
-        unsafe { self.tok.as_ref() }
-    }
-
-    /// A pointer to the underlying raw [`ffi::RSToken`], for the few call sites
-    /// that must hand the token back to C. The pointer is valid for `'a`.
+    /// A pointer to the underlying [`ffi::RSToken`], for the few call sites that
+    /// must hand the token back to C. The pointer is valid for `'a`, and — like
+    /// everything else reachable through this handle — C may only read through
+    /// it: `'a` is a no-mutation window.
     pub const fn as_ptr(&self) -> *const ffi::RSToken {
-        self.tok.as_ptr().cast_const()
+        std::ptr::from_ref(self.tok)
     }
 
     /// The length in bytes of the token string.
     pub const fn len(&self) -> usize {
-        self.token().len
+        self.tok.len
     }
 
     /// Whether the token string is empty.
     pub const fn is_empty(&self) -> bool {
-        self.token().len == 0
+        self.tok.len == 0
     }
 
     /// The token's per-term flags (stemming, phonetic, expansion, …).
     pub fn flags(&self) -> RSTokenFlags {
-        self.token().flags()
+        self.tok.flags()
     }
 
     /// The token string as a byte slice, or `None` when the token carries no
     /// string (a null `str_` pointer).
     ///
-    /// # Safety
-    ///
-    /// The owning node must not be evaluated, mutated, or freed while the
-    /// returned slice is live. Evaluation rewrites a token's string in place
-    /// (escape removal, case folding) and may `free` its backing buffer and
-    /// install a new one, which would leave the slice dangling and its length
-    /// stale.
-    ///
-    /// The borrow checker cannot enforce this: the slice's lifetime is tied to
-    /// this handle borrow, which says nothing about when evaluation runs. Read
-    /// from the slice, or copy out of it (e.g. via
-    /// [`as_lower_runes`](RSTokenRef::as_lower_runes), which returns an owned
-    /// value), before handing the node back to the evaluator.
-    pub unsafe fn as_bytes(&self) -> Option<&[u8]> {
-        let tok = self.token();
-        let ptr = NonNull::new(tok.str_)?;
+    /// The slice borrows for `'a`, not for `&self`: the handle is [`Copy`], so
+    /// tying the slice to a particular copy of it would be arbitrary. `'a` is the
+    /// borrow of the owning node, which is exactly as long as the string is
+    /// guaranteed to stay put — see [the type's docs](RSTokenRef).
+    pub fn as_bytes(&self) -> Option<&'a [u8]> {
+        let ptr = NonNull::new(self.tok.str_)?;
         // SAFETY: the constructors' contract guarantees a non-null `str_`
-        // addresses `len` initialized bytes, readable for the duration of this
-        // borrow. The returned slice is tied to `&self`, so it cannot outlive it.
-        Some(unsafe { std::slice::from_raw_parts(ptr.as_ptr().cast::<u8>(), tok.len) })
+        // addresses `len` initialized bytes, and that they stay readable and
+        // unmutated for `'a` — no mutation of the token can be expressed while a
+        // borrow of the owning node is outstanding.
+        Some(unsafe { std::slice::from_raw_parts(ptr.as_ptr().cast::<u8>(), self.tok.len) })
     }
 
     /// Lowercase the token string and convert it to runes, e.g. for a trie
@@ -208,11 +170,7 @@ impl<'a, const NUL_TERMINATED: bool> RSTokenRef<'a, NUL_TERMINATED> {
     /// when the lowercased string exceeds the maximum rune-string length, in
     /// which case it can name no stored term.
     pub fn as_lower_runes(&self) -> Option<Vec<u16>> {
-        // SAFETY: the slice is consumed within this call. The only C reached
-        // while it is live is `strToLowerRunes`, which reads the bytes and
-        // neither evaluates the owning node nor touches the token, so nothing
-        // can invalidate it. The runes are copied out before returning.
-        let bytes = unsafe { self.as_bytes() }?;
+        let bytes = self.as_bytes()?;
 
         // `strToLowerRunes` stops at the first NUL its decoder yields — a literal
         // `0` byte or an overlong encoding of one — and reports the runes before
@@ -291,20 +249,19 @@ impl<'a> RSTokenRef<'a, false> {
     /// - `tok` must be non-null and point to a valid [`ffi::RSToken`] that stays
     ///   allocated and readable for the whole of the handle's `'a` lifetime; when
     ///   its `str_` is non-null it must address `len` initialized bytes.
-    /// - `tok` must be a **raw** pointer whose provenance permits the token to be
-    ///   mutated through other pointers — e.g. obtained with `&raw const` from a
-    ///   raw node pointer. It must **not** be derived from a `&ffi::RSToken` (a
-    ///   shared reference), because a query node's token is mutated in place
-    ///   during evaluation: a foreign write would then invalidate a
-    ///   reference-derived pointer and every later accessor call would be
-    ///   undefined behaviour. The bytes need not stay *unchanged* — the handle
-    ///   makes no immutability promise; keeping a *view* of them valid is instead
-    ///   the obligation of the `unsafe` accessors that return one
-    ///   ([`as_bytes`](RSTokenRef::as_bytes), [`as_c_str`](RSTokenRef::as_c_str)).
+    /// - Neither the token nor the bytes its `str_` addresses may be mutated or
+    ///   freed for `'a`. This is what makes the accessors safe, so `'a` must be
+    ///   chosen to make it true — in practice by deriving it from a borrow that
+    ///   every mutation path already conflicts with — for a query-node token,
+    ///   the shared borrow of the owning node it was read out of. A `'a` picked
+    ///   freely (e.g. inferred as `'static`) would let a view outlive the bytes.
     pub const unsafe fn from_ffi(tok: *const ffi::RSToken) -> Self {
         debug_assert!(!tok.is_null(), "token pointer must not be null");
-        // SAFETY: the caller guarantees `tok` is non-null.
-        Self::new(unsafe { NonNull::new_unchecked(tok.cast_mut()) })
+        // SAFETY: the caller guarantees `tok` is non-null, points to a valid
+        // `RSToken`, and that it is neither mutated nor freed for `'a`, which is
+        // what the shared reference asserts.
+        let tok = unsafe { &*tok };
+        Self { tok }
     }
 }
 
@@ -315,33 +272,27 @@ impl<'a> RSTokenRef<'a, true> {
     ///
     /// # Safety
     ///
-    /// In addition to [`from_ffi`](RSTokenRef::from_ffi)'s requirements (including
-    /// raw provenance), a non-null `str_` must be terminated by a NUL byte at
-    /// index `len` — i.e. `str_[len]` is readable and equal to `0`, so the
-    /// allocation spans at least `len + 1` bytes (a C string of content
-    /// length `len`).
+    /// In addition to [`from_ffi`](RSTokenRef::from_ffi)'s requirements, a
+    /// non-null `str_` must be terminated by a NUL byte at index `len` — i.e.
+    /// `str_[len]` is readable and equal to `0`, so the allocation spans at least
+    /// `len + 1` bytes (a C string of content length `len`).
     pub const unsafe fn from_nul_terminated_ffi(tok: *const ffi::RSToken) -> Self {
         debug_assert!(!tok.is_null(), "token pointer must not be null");
+        // SAFETY: as for `from_ffi` — the caller guarantees `tok` is non-null and
+        // points to a valid `RSToken` that is neither mutated nor freed for `'a`.
+        let tok = unsafe { &*tok };
         // In debug builds, sanity-check the NUL-termination the caller promised.
-        // Read the fields through the raw pointer, forming no reference.
         #[cfg(debug_assertions)]
-        {
-            // SAFETY: the caller guarantees `tok` points to a valid `RSToken`.
-            let str_ = unsafe { (*tok).str_ };
-            if !str_.is_null() {
-                // SAFETY: the caller guarantees `tok` points to a valid `RSToken`.
-                let len = unsafe { (*tok).len };
-                // SAFETY: the caller guarantees `str_` is a NUL-terminated string
-                // of content length `len`, so `str_.add(len)` is the in-bounds
-                // terminator address.
-                let terminator_ptr = unsafe { str_.add(len) };
-                // SAFETY: `terminator_ptr` addresses the in-bounds terminator byte.
-                let terminator = unsafe { *terminator_ptr };
-                assert!(terminator == 0, "token string must be NUL-terminated");
-            }
+        if !tok.str_.is_null() {
+            // SAFETY: the caller guarantees `str_` is a NUL-terminated string of
+            // content length `len`, so `str_.add(len)` is the in-bounds
+            // terminator address.
+            let terminator_ptr = unsafe { tok.str_.add(tok.len) };
+            // SAFETY: `terminator_ptr` addresses the in-bounds terminator byte.
+            let terminator = unsafe { *terminator_ptr };
+            assert!(terminator == 0, "token string must be NUL-terminated");
         }
-        // SAFETY: the caller guarantees `tok` is non-null.
-        Self::new(unsafe { NonNull::new_unchecked(tok.cast_mut()) })
+        Self { tok }
     }
 
     /// The token string as a NUL-terminated [`CStr`], or `None` when the token
@@ -351,18 +302,13 @@ impl<'a> RSTokenRef<'a, true> {
     /// by [`from_nul_terminated_ffi`](RSTokenRef::from_nul_terminated_ffi)'s
     /// `unsafe` contract, so this accessor exists only on this variant.
     ///
-    /// # Safety
-    ///
-    /// As for [`as_bytes`](RSTokenRef::as_bytes): the owning node must not be
-    /// evaluated, mutated, or freed while the returned [`CStr`] is live, since
-    /// evaluation may rewrite the token's string in place or `free` its backing
-    /// buffer.
-    pub unsafe fn as_c_str(&self) -> Option<&CStr> {
-        let tok = self.token();
-        let ptr = NonNull::new(tok.str_)?;
+    /// As for [`as_bytes`](RSTokenRef::as_bytes), the result borrows for `'a`.
+    pub fn as_c_str(&self) -> Option<&'a CStr> {
+        let ptr = NonNull::new(self.tok.str_)?;
         // SAFETY: this is an `RSTokenRef<true>`, so its constructor guaranteed a
-        // non-null `str_` points to a NUL-terminated string readable for this
-        // borrow, which the returned `CStr`, tied to `&self`, cannot outlive.
+        // non-null `str_` points to a NUL-terminated string that stays readable
+        // and unmutated for `'a` — no mutation of the token can be expressed
+        // while a borrow of the owning node is outstanding.
         Some(unsafe { CStr::from_ptr(ptr.as_ptr()) })
     }
 }

--- a/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
@@ -80,21 +80,32 @@ fn tail_may_overread(bytes: &[u8]) -> bool {
 /// It holds a raw pointer rather than a `&'a `[`ffi::RSToken`] because a query
 /// node's token is **not immutable**: evaluation rewrites it in place (escape
 /// removal, case folding) and can even replace its backing buffer, so a live
-/// shared reference to it would be undefined behaviour. The handle therefore
-/// makes no immutability promise; its accessors return short-lived views tied to
-/// the handle borrow, and a [`as_bytes`](RSTokenRef::as_bytes) slice or
-/// [`as_c_str`](RSTokenRef::as_c_str) [`CStr`] obtained from it **must not be
-/// retained across evaluation of the owning node** — read from it, or copy out of
-/// it (e.g. via [`as_lower_runes`](RSTokenRef::as_lower_runes)), before evaluation
-/// runs.
+/// shared reference to it would be undefined behaviour.
+///
+/// The handle therefore makes no immutability promise, which splits its
+/// accessors in two:
+///
+/// - Those returning a scalar copy — [`len`](RSTokenRef::len),
+///   [`is_empty`](RSTokenRef::is_empty), [`flags`](RSTokenRef::flags) — read the
+///   token transiently and are safe.
+/// - Those returning a *view* into the token's string —
+///   [`as_bytes`](RSTokenRef::as_bytes) and [`as_c_str`](RSTokenRef::as_c_str) —
+///   are `unsafe`, because the view's lifetime is tied to the handle borrow,
+///   which says nothing about when the owning node is next evaluated. Evaluation
+///   may rewrite or `free` the string underneath a live view, and the borrow
+///   checker cannot see that, so the caller has to guarantee the view is done
+///   with first. Copying out of the token instead — e.g. via
+///   [`as_lower_runes`](RSTokenRef::as_lower_runes), which returns an owned value
+///   — needs no such guarantee.
 ///
 /// The `NUL_TERMINATED` const parameter is a typestate flag recording whether the
 /// token string is NUL-terminated:
 ///
 /// - [`RSTokenRef<'a, true>`] additionally guarantees the string is
-///   NUL-terminated, so it exposes a *safe* [`as_c_str`](RSTokenRef::as_c_str).
-///   Query-node tokens produced by the parser for prefix, fuzzy, and verbatim
-///   nodes are NUL-terminated and use this variant.
+///   NUL-terminated, which is what unlocks
+///   [`as_c_str`](RSTokenRef::as_c_str). Query-node tokens produced by the parser
+///   for prefix, fuzzy, and verbatim nodes are NUL-terminated and use this
+///   variant.
 /// - [`RSTokenRef<'a, false>`] (the default) makes no such promise: tokens built
 ///   from a raw `(pointer, length)` slice — e.g. tag values or trie-expansion
 ///   terms — may not be NUL-terminated, so `as_c_str` is not available on it.
@@ -158,9 +169,20 @@ impl<'a, const NUL_TERMINATED: bool> RSTokenRef<'a, NUL_TERMINATED> {
     /// The token string as a byte slice, or `None` when the token carries no
     /// string (a null `str_` pointer).
     ///
-    /// The slice is tied to this handle borrow and must not be retained across
-    /// evaluation of the owning node, which may mutate or free the token.
-    pub fn as_bytes(&self) -> Option<&[u8]> {
+    /// # Safety
+    ///
+    /// The owning node must not be evaluated, mutated, or freed while the
+    /// returned slice is live. Evaluation rewrites a token's string in place
+    /// (escape removal, case folding) and may `free` its backing buffer and
+    /// install a new one, which would leave the slice dangling and its length
+    /// stale.
+    ///
+    /// The borrow checker cannot enforce this: the slice's lifetime is tied to
+    /// this handle borrow, which says nothing about when evaluation runs. Read
+    /// from the slice, or copy out of it (e.g. via
+    /// [`as_lower_runes`](RSTokenRef::as_lower_runes), which returns an owned
+    /// value), before handing the node back to the evaluator.
+    pub unsafe fn as_bytes(&self) -> Option<&[u8]> {
         let tok = self.token();
         let ptr = NonNull::new(tok.str_)?;
         // SAFETY: the constructors' contract guarantees a non-null `str_`
@@ -186,7 +208,11 @@ impl<'a, const NUL_TERMINATED: bool> RSTokenRef<'a, NUL_TERMINATED> {
     /// when the lowercased string exceeds the maximum rune-string length, in
     /// which case it can name no stored term.
     pub fn as_lower_runes(&self) -> Option<Vec<u16>> {
-        let bytes = self.as_bytes()?;
+        // SAFETY: the slice is consumed within this call. The only C reached
+        // while it is live is `strToLowerRunes`, which reads the bytes and
+        // neither evaluates the owning node nor touches the token, so nothing
+        // can invalidate it. The runes are copied out before returning.
+        let bytes = unsafe { self.as_bytes() }?;
 
         // `strToLowerRunes` stops at the first NUL its decoder yields — a literal
         // `0` byte or an overlong encoding of one — and reports the runes before
@@ -272,8 +298,9 @@ impl<'a> RSTokenRef<'a, false> {
     ///   during evaluation: a foreign write would then invalidate a
     ///   reference-derived pointer and every later accessor call would be
     ///   undefined behaviour. The bytes need not stay *unchanged* — the handle
-    ///   makes no immutability promise — but a view returned by an accessor must
-    ///   not be used after the token is mutated or freed (see the type-level note).
+    ///   makes no immutability promise; keeping a *view* of them valid is instead
+    ///   the obligation of the `unsafe` accessors that return one
+    ///   ([`as_bytes`](RSTokenRef::as_bytes), [`as_c_str`](RSTokenRef::as_c_str)).
     pub const unsafe fn from_ffi(tok: *const ffi::RSToken) -> Self {
         debug_assert!(!tok.is_null(), "token pointer must not be null");
         // SAFETY: the caller guarantees `tok` is non-null.
@@ -320,14 +347,17 @@ impl<'a> RSTokenRef<'a, true> {
     /// The token string as a NUL-terminated [`CStr`], or `None` when the token
     /// carries no string (a null `str_` pointer).
     ///
-    /// This is safe: the NUL-termination requirement is discharged once, at
-    /// construction time, by
-    /// [`from_nul_terminated_ffi`](RSTokenRef::from_nul_terminated_ffi)'s
-    /// `unsafe` contract.
+    /// The NUL-termination requirement is discharged once, at construction time,
+    /// by [`from_nul_terminated_ffi`](RSTokenRef::from_nul_terminated_ffi)'s
+    /// `unsafe` contract, so this accessor exists only on this variant.
     ///
-    /// The [`CStr`] is tied to this handle borrow and must not be retained across
-    /// evaluation of the owning node, which may mutate or free the token.
-    pub fn as_c_str(&self) -> Option<&CStr> {
+    /// # Safety
+    ///
+    /// As for [`as_bytes`](RSTokenRef::as_bytes): the owning node must not be
+    /// evaluated, mutated, or freed while the returned [`CStr`] is live, since
+    /// evaluation may rewrite the token's string in place or `free` its backing
+    /// buffer.
+    pub unsafe fn as_c_str(&self) -> Option<&CStr> {
         let tok = self.token();
         let ptr = NonNull::new(tok.str_)?;
         // SAFETY: this is an `RSTokenRef<true>`, so its constructor guaranteed a

--- a/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
@@ -302,6 +302,11 @@ impl<'a> RSTokenRef<'a, true> {
     /// by [`from_nul_terminated_ffi`](RSTokenRef::from_nul_terminated_ffi)'s
     /// `unsafe` contract, so this accessor exists only on this variant.
     ///
+    /// Content after a first interior NUL byte is ignored, as for
+    /// [`as_lower_runes`](RSTokenRef::as_lower_runes): the result ends at that
+    /// NUL, so it is shorter than [`len`](RSTokenRef::len) and covers less than
+    /// [`as_bytes`](RSTokenRef::as_bytes).
+    ///
     /// As for [`as_bytes`](RSTokenRef::as_bytes), the result borrows for `'a`.
     pub fn as_c_str(&self) -> Option<&'a CStr> {
         let ptr = NonNull::new(self.tok.str_)?;

--- a/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
@@ -275,6 +275,7 @@ impl<'a> RSTokenRef<'a, false> {
     ///   makes no immutability promise — but a view returned by an accessor must
     ///   not be used after the token is mutated or freed (see the type-level note).
     pub const unsafe fn from_ffi(tok: *const ffi::RSToken) -> Self {
+        debug_assert!(!tok.is_null(), "token pointer must not be null");
         // SAFETY: the caller guarantees `tok` is non-null.
         Self::new(unsafe { NonNull::new_unchecked(tok.cast_mut()) })
     }
@@ -293,6 +294,7 @@ impl<'a> RSTokenRef<'a, true> {
     /// allocation spans at least `len + 1` bytes (a C string of content
     /// length `len`).
     pub const unsafe fn from_nul_terminated_ffi(tok: *const ffi::RSToken) -> Self {
+        debug_assert!(!tok.is_null(), "token pointer must not be null");
         // In debug builds, sanity-check the NUL-termination the caller promised.
         // Read the fields through the raw pointer, forming no reference.
         #[cfg(debug_assertions)]

--- a/src/redisearch_rs/c_wrappers/rs_token/tests/tests.rs
+++ b/src/redisearch_rs/c_wrappers/rs_token/tests/tests.rs
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+#![cfg_attr(miri, allow(dead_code, unused_imports))]
+
+use std::ffi::c_char;
+
+use query_term::RSTokenFlags;
+use rs_token::RSTokenRef;
+
+// Install the mock Redis allocator so the C `strToLowerRunes` can allocate, and
+// force the combined C bundle to be linked into the test binary.
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+extern crate redisearch_rs;
+
+/// Build a raw [`ffi::RSToken`] borrowing `s`'s bytes, with `str_` null when `s`
+/// is `None`.
+fn build_raw(s: Option<&[u8]>, flags: RSTokenFlags) -> ffi::RSToken {
+    // SAFETY: `RSToken` is plain data whose all-zero bit pattern is a valid,
+    // empty token.
+    let mut raw: ffi::RSToken = unsafe { std::mem::zeroed() };
+    match s {
+        Some(bytes) => {
+            raw.str_ = bytes.as_ptr() as *mut c_char;
+            raw.len = bytes.len();
+        }
+        None => {
+            raw.str_ = std::ptr::null_mut();
+            raw.len = 0;
+        }
+    }
+    raw.set_flags(flags);
+    raw
+}
+
+/// Run `f` on a not-necessarily-NUL-terminated [`RSTokenRef`] wrapping `s`.
+fn with_token<R>(s: Option<&[u8]>, flags: RSTokenFlags, f: impl FnOnce(RSTokenRef) -> R) -> R {
+    let raw = build_raw(s, flags);
+    // SAFETY: `raw.str_`/`raw.len` describe `s`'s bytes (or a null string),
+    // which outlive the borrow passed to `f`, satisfying `from_ffi`'s contract.
+    f(unsafe { RSTokenRef::from_ffi(&raw const raw) })
+}
+
+/// Run `f` on a NUL-terminated [`RSTokenRef<true>`] wrapping `content` (a null
+/// token when `content` is `None`). `content` is the string *without* its
+/// terminator: the helper owns a NUL-terminated copy so that, per the
+/// `(str_, len)` convention, `len` is the content length and `str_[len]` is the
+/// terminator.
+fn with_nul_token<R>(
+    content: Option<&[u8]>,
+    flags: RSTokenFlags,
+    f: impl FnOnce(RSTokenRef<true>) -> R,
+) -> R {
+    let owned = content.map(|c| {
+        let mut v = c.to_vec();
+        v.push(0);
+        v
+    });
+    // SAFETY: `RSToken` is plain data whose all-zero bit pattern is a valid,
+    // empty token.
+    let mut raw: ffi::RSToken = unsafe { std::mem::zeroed() };
+    if let (Some(buf), Some(c)) = (&owned, content) {
+        raw.str_ = buf.as_ptr() as *mut c_char;
+        raw.len = c.len();
+    }
+    raw.set_flags(flags);
+    // SAFETY: `owned` keeps a NUL-terminated buffer alive for the borrow passed
+    // to `f`; `raw.len` is its content length, so `str_[len]` is the terminator,
+    // satisfying `from_nul_terminated_ffi`'s contract.
+    f(unsafe { RSTokenRef::from_nul_terminated_ffi(&raw const raw) })
+}
+
+#[test]
+fn exposes_bytes_len_and_flags() {
+    with_token(Some(b"Hello"), 0x2A, |tok| {
+        assert_eq!(tok.len(), 5);
+        assert!(!tok.is_empty());
+        assert_eq!(tok.as_bytes(), Some(&b"Hello"[..]));
+        assert_eq!(tok.flags(), 0x2A);
+    });
+}
+
+#[test]
+fn null_string_yields_none() {
+    with_nul_token(None, 0, |tok| {
+        assert!(tok.is_empty());
+        assert_eq!(tok.as_bytes(), None);
+        assert!(tok.as_lower_runes().is_none());
+        // The token carries no string, so `as_c_str` returns `None`.
+        assert!(tok.as_c_str().is_none());
+    });
+}
+
+#[test]
+fn exposes_nul_terminated_c_str() {
+    with_nul_token(Some(b"Hello"), 0, |tok| {
+        assert_eq!(tok.len(), 5);
+        let c_str = tok.as_c_str().expect("token carries a string");
+        assert_eq!(c_str, c"Hello");
+    });
+}
+
+// These tests call the C `strToLowerRunes`, so they cannot run under miri.
+#[cfg(not(miri))]
+mod lower_runes {
+    use super::*;
+
+    #[test]
+    fn lower_runes_lowercases() {
+        with_nul_token(Some(b"HeLLo"), 0, |tok| {
+            let runes = tok.as_lower_runes().unwrap();
+            let expected: Vec<u16> = "hello".encode_utf16().collect();
+            assert_eq!(runes, expected);
+        });
+    }
+
+    #[test]
+    fn lower_runes_decodes_invalid_utf8_leniently() {
+        // A token is a byte string, and a term is indexed under the runes its bytes
+        // decode to without validation: `[0xC3, b'(']` must resolve 0x00E8, the rune
+        // the index stored it as. Validating would build a key from replacement
+        // characters that was never stored.
+        with_nul_token(Some(b"\xC3("), 0, |tok| {
+            let runes = tok.as_lower_runes().unwrap();
+            assert_eq!(runes, vec![0x00E8]);
+        });
+    }
+
+    #[test]
+    fn lower_runes_preserves_surrogate_bytes() {
+        // The three-byte form of a lone surrogate — what a non-BMP codepoint
+        // truncated to a rune re-encodes to — survives the conversion instead of
+        // being replaced.
+        with_nul_token(Some(b"\xED\xA0\x80"), 0, |tok| {
+            let runes = tok.as_lower_runes().unwrap();
+            assert_eq!(runes, vec![0xD800]);
+        });
+    }
+
+    #[test]
+    fn lower_runes_works_without_nul_termination() {
+        // `as_lower_runes` is length-bounded, so it is available on the default
+        // (not-necessarily-NUL-terminated) variant too. `with_token` borrows the
+        // slice directly, with no terminator after its `len` bytes.
+        with_token(Some(b"HeLLo"), 0, |tok| {
+            let runes = tok.as_lower_runes().unwrap();
+            let expected: Vec<u16> = "hello".encode_utf16().collect();
+            assert_eq!(runes, expected);
+        });
+    }
+
+    // Best exercised under AddressSanitizer, where an unbounded read would fault.
+    #[test]
+    fn lower_runes_truncated_lead_stays_in_bounds() {
+        // `0xF0` starts a four-byte sequence, but only one byte follows it. The C
+        // decoder reads a fixed four bytes regardless; `as_lower_runes` pads the
+        // decoder input so that over-read lands in its own trailing zero bytes rather
+        // than past the token. The leading content still decodes normally.
+        with_token(Some(b"ab\xF0"), 0, |tok| {
+            let runes = tok.as_lower_runes().expect("conversion succeeds");
+            assert_eq!(&runes[..2], &[b'a' as u16, b'b' as u16]);
+        });
+    }
+
+    #[test]
+    fn lower_runes_too_long_yields_none() {
+        // One rune past the maximum yields `None` rather than truncating: the C
+        // `strToLowerRunes` declines the conversion and returns a null pointer.
+        let content = vec![b'a'; ffi::MAX_RUNE_STR_LEN as usize + 1];
+        with_nul_token(Some(&content), 0, |tok| {
+            assert!(tok.as_lower_runes().is_none());
+        });
+    }
+
+    #[test]
+    fn lower_runes_huge_token_yields_none_without_huge_copy() {
+        // A token far larger than any storable term is rejected after copying only a
+        // bounded prefix (`MAX_DECODE_BYTES`), not the whole input. The result is the
+        // same `None` the full decode would produce, since it can match no term.
+        let content = vec![b'a'; 1 << 20];
+        with_token(Some(&content), 0, |tok| {
+            assert!(tok.as_lower_runes().is_none());
+        });
+    }
+}
+
+#[test]
+fn as_ptr_round_trips_to_the_borrowed_token() {
+    let raw = build_raw(Some(b"Hello"), 0);
+    // SAFETY: `raw` outlives the borrow held by `tok`, satisfying `from_ffi`.
+    let tok = unsafe { RSTokenRef::from_ffi(&raw const raw) };
+    assert_eq!(tok.as_ptr(), std::ptr::from_ref(&raw));
+}
+
+/// A handle retained across an in-place mutation of the token (as query
+/// evaluation performs from C) and then read must not be undefined behaviour.
+/// This holds only because the handle carries *raw* provenance; a handle derived
+/// from a `&ffi::RSToken` would be invalidated by the foreign write. Run under
+/// miri (both Stacked and Tree Borrows) this is the regression guard.
+#[test]
+fn handle_survives_foreign_mutation() {
+    let mut raw = build_raw(Some(b"hello"), 0);
+    // A raw pointer to the token, as C holds to the node it owns.
+    let node: *mut ffi::RSToken = &raw mut raw;
+    // SAFETY: `node` is non-null and raw (not reference-derived), and `raw`
+    // outlives `tok`, satisfying `from_ffi`.
+    let tok = unsafe { RSTokenRef::from_ffi(node.cast_const()) };
+    // "C evaluation" mutates the token in place through its own pointer.
+    // SAFETY: `node` is valid and there is no live reference aliasing it.
+    unsafe { (*node).len = 3 };
+    // A later safe accessor must observe the mutation without UB.
+    assert_eq!(tok.len(), 3);
+}
+
+/// A non-NUL-terminated string handed to [`RSTokenRef::from_nul_terminated_ffi`]
+/// trips the debug-only termination check. The check compiles out of release
+/// builds, so this test only runs when debug assertions are enabled.
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "token string must be NUL-terminated")]
+fn non_nul_terminated_string_trips_debug_assert() {
+    // `str_[len]` is `b'X'`, not a terminator: in bounds and readable (so the
+    // check's own dereference is sound) but non-zero, so the assertion fails.
+    let buf = b"abcX";
+    // SAFETY: `RSToken` is plain data whose all-zero bit pattern is a valid,
+    // empty token.
+    let mut raw: ffi::RSToken = unsafe { std::mem::zeroed() };
+    raw.str_ = buf.as_ptr() as *mut c_char;
+    raw.len = 3;
+    // SAFETY: `raw.str_`/`raw.len` describe a valid 3-byte range whose next byte
+    // is in bounds and readable, so the debug check's dereference is sound — it
+    // observes the missing terminator and panics.
+    let _ = unsafe { RSTokenRef::from_nul_terminated_ffi(&raw const raw) };
+}

--- a/src/redisearch_rs/c_wrappers/rs_token/tests/tests.rs
+++ b/src/redisearch_rs/c_wrappers/rs_token/tests/tests.rs
@@ -80,7 +80,9 @@ fn exposes_bytes_len_and_flags() {
     with_token(Some(b"Hello"), 0x2A, |tok| {
         assert_eq!(tok.len(), 5);
         assert!(!tok.is_empty());
-        assert_eq!(tok.as_bytes(), Some(&b"Hello"[..]));
+        // SAFETY: the token is a local that nothing mutates or frees while the
+        // slice lives.
+        assert_eq!(unsafe { tok.as_bytes() }, Some(&b"Hello"[..]));
         assert_eq!(tok.flags(), 0x2A);
     });
 }
@@ -89,10 +91,12 @@ fn exposes_bytes_len_and_flags() {
 fn null_string_yields_none() {
     with_nul_token(None, 0, |tok| {
         assert!(tok.is_empty());
-        assert_eq!(tok.as_bytes(), None);
+        // SAFETY (both): the token is a local that nothing mutates or frees
+        // while the (absent) views live.
+        assert_eq!(unsafe { tok.as_bytes() }, None);
         assert!(tok.as_lower_runes().is_none());
         // The token carries no string, so `as_c_str` returns `None`.
-        assert!(tok.as_c_str().is_none());
+        assert!(unsafe { tok.as_c_str() }.is_none());
     });
 }
 
@@ -100,7 +104,9 @@ fn null_string_yields_none() {
 fn exposes_nul_terminated_c_str() {
     with_nul_token(Some(b"Hello"), 0, |tok| {
         assert_eq!(tok.len(), 5);
-        let c_str = tok.as_c_str().expect("token carries a string");
+        // SAFETY: `with_nul_token` keeps the buffer alive and unmutated for the
+        // whole closure, so the `CStr` stays valid.
+        let c_str = unsafe { tok.as_c_str() }.expect("token carries a string");
         assert_eq!(c_str, c"Hello");
     });
 }

--- a/src/redisearch_rs/c_wrappers/rs_token/tests/tests.rs
+++ b/src/redisearch_rs/c_wrappers/rs_token/tests/tests.rs
@@ -80,9 +80,7 @@ fn exposes_bytes_len_and_flags() {
     with_token(Some(b"Hello"), 0x2A, |tok| {
         assert_eq!(tok.len(), 5);
         assert!(!tok.is_empty());
-        // SAFETY: the token is a local that nothing mutates or frees while the
-        // slice lives.
-        assert_eq!(unsafe { tok.as_bytes() }, Some(&b"Hello"[..]));
+        assert_eq!(tok.as_bytes(), Some(&b"Hello"[..]));
         assert_eq!(tok.flags(), 0x2A);
     });
 }
@@ -91,12 +89,10 @@ fn exposes_bytes_len_and_flags() {
 fn null_string_yields_none() {
     with_nul_token(None, 0, |tok| {
         assert!(tok.is_empty());
-        // SAFETY (both): the token is a local that nothing mutates or frees
-        // while the (absent) views live.
-        assert_eq!(unsafe { tok.as_bytes() }, None);
+        assert_eq!(tok.as_bytes(), None);
         assert!(tok.as_lower_runes().is_none());
         // The token carries no string, so `as_c_str` returns `None`.
-        assert!(unsafe { tok.as_c_str() }.is_none());
+        assert!(tok.as_c_str().is_none());
     });
 }
 
@@ -104,9 +100,7 @@ fn null_string_yields_none() {
 fn exposes_nul_terminated_c_str() {
     with_nul_token(Some(b"Hello"), 0, |tok| {
         assert_eq!(tok.len(), 5);
-        // SAFETY: `with_nul_token` keeps the buffer alive and unmutated for the
-        // whole closure, so the `CStr` stays valid.
-        let c_str = unsafe { tok.as_c_str() }.expect("token carries a string");
+        let c_str = tok.as_c_str().expect("token carries a string");
         assert_eq!(c_str, c"Hello");
     });
 }
@@ -203,24 +197,34 @@ fn as_ptr_round_trips_to_the_borrowed_token() {
     assert_eq!(tok.as_ptr(), std::ptr::from_ref(&raw));
 }
 
-/// A handle retained across an in-place mutation of the token (as query
-/// evaluation performs from C) and then read must not be undefined behaviour.
-/// This holds only because the handle carries *raw* provenance; a handle derived
-/// from a `&ffi::RSToken` would be invalidated by the foreign write. Run under
-/// miri (both Stacked and Tree Borrows) this is the regression guard.
+/// The production lifecycle: C mutates a node's token in place *between*
+/// evaluations, and each evaluation mints a fresh handle. A handle's `'a` is a
+/// no-mutation window, so the write must fall outside every window — but the
+/// pointer C writes through, and the one a later handle reads through, alias the
+/// same token, and neither may be invalidated by the other. Run under miri (both
+/// Stacked and Tree Borrows) this is the regression guard for that aliasing.
 #[test]
-fn handle_survives_foreign_mutation() {
+fn handle_reflects_mutation_between_borrows() {
     let mut raw = build_raw(Some(b"hello"), 0);
     // A raw pointer to the token, as C holds to the node it owns.
     let node: *mut ffi::RSToken = &raw mut raw;
-    // SAFETY: `node` is non-null and raw (not reference-derived), and `raw`
-    // outlives `tok`, satisfying `from_ffi`.
+
+    // First evaluation: mint a handle, read through it, and let it die.
+    // SAFETY: `node` is non-null, valid, and raw (not reference-derived); `raw`
+    // outlives the handle and nothing mutates the token while it is live.
     let tok = unsafe { RSTokenRef::from_ffi(node.cast_const()) };
-    // "C evaluation" mutates the token in place through its own pointer.
+    assert_eq!(tok.len(), 5);
+
+    // "C evaluation" then mutates the token in place through its own pointer,
+    // with no handle live.
     // SAFETY: `node` is valid and there is no live reference aliasing it.
     unsafe { (*node).len = 3 };
-    // A later safe accessor must observe the mutation without UB.
+
+    // The next evaluation mints a fresh handle and observes the mutation.
+    // SAFETY: as above for the new no-mutation window.
+    let tok = unsafe { RSTokenRef::from_ffi(node.cast_const()) };
     assert_eq!(tok.len(), 3);
+    assert_eq!(tok.as_bytes(), Some(&b"hel"[..]));
 }
 
 /// A non-NUL-terminated string handed to [`RSTokenRef::from_nul_terminated_ffi`]

--- a/src/redisearch_rs/query_eval/Cargo.toml
+++ b/src/redisearch_rs/query_eval/Cargo.toml
@@ -27,6 +27,7 @@ query_term.workspace = true
 query_types.workspace = true
 rqe_core.workspace = true
 rqe_iterators.workspace = true
+rs_token.workspace = true
 search_disk.workspace = true
 thiserror.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -34,6 +34,7 @@ use rqe_iterators::{
     optional_reducer::{NewOptionalIterator, new_optional_iterator},
     union_opaque::build_union,
 };
+use rs_token::RSTokenRef;
 use search_disk::SearchDiskHandle;
 
 use crate::{
@@ -790,18 +791,18 @@ fn eval_geo<'index>(
 fn eval_token<'index>(
     ctx: &'index mut QueryEvalContext,
     node: &QueryNodeRef,
-    tok: &ffi::RSToken,
+    tok: RSTokenRef,
     config: Config,
 ) -> Option<Evaluated<'index>> {
     // A `QN_TOKEN` node always carries a non-null term string.
-    debug_assert!(!tok.str_.is_null(), "token string should not be null");
+    let term_bytes = tok.as_bytes();
+    debug_assert!(term_bytes.is_some(), "token string should not be null");
+    let term_bytes = term_bytes.unwrap_or_default();
     let opts = node.opts();
     let weight = opts.weight;
     // the node's field mask narrowed to the query's.
     let effective_field_mask = opts.field_mask & ctx.opts().fieldmask;
     let token_id = ctx.next_token_id() as i32;
-    // SAFETY: `tok.str_` points to `tok.len` valid bytes from the query node.
-    let term_bytes = unsafe { std::slice::from_raw_parts(tok.str_.cast::<u8>(), tok.len) };
     let term = RSQueryTerm::new_bytes(term_bytes, token_id, tok.flags());
 
     // SAFETY: `ctx.spec().diskSpec` is either null or a valid
@@ -832,7 +833,7 @@ fn eval_token<'index>(
 /// field(s)), dropping `term`.
 fn open_term_reader<'index>(
     ctx: &'index mut QueryEvalContext,
-    tok: &ffi::RSToken,
+    tok: RSTokenRef,
     term: Box<RSQueryTerm>,
     weight: f64,
     effective_field_mask: FieldMask,
@@ -845,13 +846,8 @@ fn open_term_reader<'index>(
     // SAFETY: `ctx.sctx_ptr()` is valid (`QueryEvalContext` invariant 2) and
     // `tok` is the query node's `RSToken`; `Redis_OpenReaderIndex` only reads the
     // token and does not retain it.
-    let idx = unsafe {
-        ffi::Redis_OpenReaderIndex(
-            ctx.sctx_ptr(),
-            std::ptr::from_ref(tok),
-            effective_field_mask,
-        )
-    };
+    let idx =
+        unsafe { ffi::Redis_OpenReaderIndex(ctx.sctx_ptr(), tok.as_ptr(), effective_field_mask) };
     let idx = NonNull::new(idx)?;
 
     // SAFETY: `ctx.sctx_ptr()` is non-null (`QueryEvalContext` invariant 2).
@@ -886,7 +882,7 @@ fn open_term_reader<'index>(
 fn eval_token_disk<'index>(
     ctx: &'index mut QueryEvalContext,
     disk: SearchDiskHandle,
-    tok: &ffi::RSToken,
+    tok: RSTokenRef,
     mut term: Box<RSQueryTerm>,
     opts: &QueryNodeOptions,
     weight: f64,
@@ -900,13 +896,13 @@ fn eval_token_disk<'index>(
     debug_assert!(!spec.terms.is_null(), "terms trie should be initialized");
     // A `QN_TOKEN` node always carries a non-null term string; the term lookup
     // below relies on it.
-    debug_assert!(!tok.str_.is_null(), "token string should not be null");
+    let term_bytes = tok.as_bytes();
+    debug_assert!(term_bytes.is_some(), "token string should not be null");
+    let term_bytes = term_bytes.unwrap_or_default();
 
     // SAFETY: `spec.terms` is a valid `Trie` (checked non-null above) that
     // outlives this lookup.
     let terms = unsafe { CTrieRef::from_raw(spec.terms) };
-    // SAFETY: `tok.str_` points to `tok.len` valid bytes from the query node.
-    let term_bytes = unsafe { std::slice::from_raw_parts(tok.str_.cast::<u8>(), tok.len) };
     let num_docs_in_term = terms.num_docs(term_bytes);
     let num_documents = spec.stats.scoring.numDocuments;
     let idf = idf::calculate_idf(num_documents, num_docs_in_term);

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -38,7 +38,7 @@ use rs_token::RSTokenRef;
 use search_disk::SearchDiskHandle;
 
 use crate::{
-    QueryEvalContext, QueryNode, QueryNodeRef,
+    QueryEvalContext, QueryNode, QueryNodeMut, QueryNodeRef,
     scorers::{BuiltInScorer, RequestedScorer},
 };
 
@@ -199,7 +199,7 @@ impl<'index> Evaluated<'index> {
 /// iterator (`None`), an [`Empty`] iterator is returned.
 pub fn qast_iterate<'index>(
     ctx: &'index mut QueryEvalContext,
-    root: &QueryNodeRef,
+    root: QueryNodeMut<'_>,
     config: Config,
 ) -> Evaluated<'index> {
     eval_node(ctx, root, config).unwrap_or_else(|| Evaluated::RustLeaf(Box::new(Empty)))
@@ -208,14 +208,22 @@ pub fn qast_iterate<'index>(
 /// Evaluate a single query node, producing the corresponding iterator.
 ///
 /// Returns `None` when the node produces no results.
+///
+/// The node is taken as an **exclusive** [`QueryNodeMut`], by value. Evaluation
+/// mutates the AST — it narrows children's field masks, and the C evaluator it
+/// falls back to rewrites tokens in place — so a shared borrow would be a lie.
+/// Taking it by value is also what lets the borrow checker police that: an arm
+/// that reads a payload out of the node (e.g. a token handle) keeps it
+/// shared-borrowed, and can therefore neither mutate it nor hand it on to a
+/// callee that might.
 pub fn eval_node<'index>(
     ctx: &'index mut QueryEvalContext,
-    node: &QueryNodeRef,
+    node: QueryNodeMut<'_>,
     config: Config,
 ) -> Option<Evaluated<'index>> {
     match node.as_enum() {
         QueryNode::Null => Some(eval_null()),
-        QueryNode::Wildcard => Some(eval_wildcard(ctx, node)),
+        QueryNode::Wildcard => Some(eval_wildcard(ctx, &node)),
         QueryNode::Ids { keys, doc_ids } => Some(eval_ids(ctx, keys, doc_ids)),
         QueryNode::Missing { field } => eval_missing(ctx, field).map(Evaluated::RustLeaf),
         QueryNode::Optional => Some(eval_optional(ctx, node, config)),
@@ -224,7 +232,7 @@ pub fn eval_node<'index>(
         QueryNode::Union => Some(eval_union(ctx, node, config)),
         QueryNode::Numeric { nf } => eval_numeric(ctx, nf, config),
         QueryNode::Geo { gf } => eval_geo(ctx, gf, config),
-        QueryNode::Token { tok } => eval_token(ctx, node, tok, config),
+        QueryNode::Token { tok } => eval_token(ctx, &node, tok, config),
         QueryNode::Geometry { geomq } => eval_geometry(ctx, geomq),
         // Node types not yet ported to Rust are delegated back to the C
         // dispatcher.
@@ -237,9 +245,13 @@ pub fn eval_node<'index>(
 ///
 /// Returns `None` when `Query_EvalNode` produces no iterator (NULL), preserving
 /// the C semantics where some nodes (e.g. an empty expansion) yield no results.
+///
+/// Consumes `node`: the C dispatcher mutates the subtree it is given — it
+/// rewrites wildcard and prefix tokens in place — so no borrow of it may still
+/// be outstanding. Taking it by value makes the borrow checker enforce that.
 fn eval_node_c<'index>(
     ctx: &'index mut QueryEvalContext,
-    node: &QueryNodeRef,
+    node: QueryNodeMut<'_>,
     config: Config,
 ) -> Option<Evaluated<'index>> {
     let q = ctx.as_non_null().as_ptr();
@@ -247,9 +259,9 @@ fn eval_node_c<'index>(
     let config = (&raw const config).cast::<ffi::EvalConfig>();
     // SAFETY: `q` comes from a live `QueryEvalContext` (a valid `QueryEvalCtx`
     // with exclusive access, since `ctx` is `&mut`) and `n` from a live
-    // `QueryNodeRef` (a valid `RSQueryNode`), satisfying `Query_EvalNode`'s
-    // contract. `config` points to a live `Config` valid for the duration of the
-    // call.
+    // `QueryNodeMut` (a valid `RSQueryNode` we hold exclusively, so C may mutate
+    // it), satisfying `Query_EvalNode`'s contract. `config` points to a live
+    // `Config` valid for the duration of the call.
     let it = unsafe { ffi::Query_EvalNode(q, n, config) };
     NonNull::new(it).map(Evaluated::C)
 }
@@ -262,7 +274,7 @@ fn eval_node_c<'index>(
 /// equivalent to one that matches nothing.
 fn eval_child_iterator(
     ctx: &mut QueryEvalContext,
-    child: &QueryNodeRef,
+    child: QueryNodeMut<'_>,
     config: Config,
 ) -> CRQEIterator {
     let ptr = match eval_node(&mut *ctx, child, config) {
@@ -411,7 +423,7 @@ fn eval_missing<'index>(
 /// child matches but does not exclude documents that don't.
 fn eval_optional<'index>(
     ctx: &'index mut QueryEvalContext,
-    node: &QueryNodeRef,
+    mut node: QueryNodeMut<'_>,
     config: Config,
 ) -> Evaluated<'index> {
     debug_assert_eq!(
@@ -423,8 +435,7 @@ fn eval_optional<'index>(
     // Evaluate the child. A `None` child becomes an `Empty` iterator, which
     // `new_optional_iterator` reduces to a wildcard fallback — an empty optional
     // matches every document as a virtual hit.
-    let child_node = node.child(0);
-    let child = eval_child_iterator(ctx, &child_node, config);
+    let child = eval_child_iterator(ctx, node.child_mut(0), config);
 
     // SAFETY: the preconditions of `new_optional_iterator` map to
     // `QueryEvalContext::new` invariants:
@@ -472,7 +483,7 @@ fn eval_optional<'index>(
 /// single child.
 fn eval_not<'index>(
     ctx: &'index mut QueryEvalContext,
-    node: &QueryNodeRef,
+    mut node: QueryNodeMut<'_>,
     config: Config,
 ) -> Evaluated<'index> {
     debug_assert_eq!(
@@ -491,8 +502,7 @@ fn eval_not<'index>(
     // nodes can nest (e.g. `-(-foo)`), and the outer NOT must keep the flag set
     // while the inner one is being evaluated and after it returns.
     let prev_in_not_sub_tree = ctx.set_in_not_sub_tree(true);
-    let child_node = node.child(0);
-    let child = eval_child_iterator(ctx, &child_node, config);
+    let child = eval_child_iterator(ctx, node.child_mut(0), config);
     ctx.set_in_not_sub_tree(prev_in_not_sub_tree);
 
     // SAFETY: invariant (2) of `QueryEvalContext::new` guarantees `bcTimeoutAreq`
@@ -551,27 +561,17 @@ fn eval_not<'index>(
 ///   from the node's own options, falling back to the query-wide defaults.
 fn eval_phrase<'index>(
     ctx: &'index mut QueryEvalContext,
-    node: &QueryNodeRef,
+    mut node: QueryNodeMut<'_>,
     exact: bool,
     config: Config,
 ) -> Option<Evaluated<'index>> {
-    // Query evaluation is single-threaded and walks each AST node exactly once,
-    // top-down, so we hold exclusive access to this phrase node and its
-    // descendants for the duration of the call: no other wrapper into this
-    // subtree, and no reference derived from one, is live here.
-    //
-    // SAFETY: that exclusive-access precondition is exactly what `as_mut`
-    // requires. It is asserted once, here; every field-mask write below then
-    // goes through the exclusive `QueryNodeMut` and is statically alias-free.
-    let mut node = unsafe { node.as_mut() };
-
     let num_children = node.num_children();
     let node_mask = node.opts().field_mask;
     // A single-child intersection is just the child; return it directly.
     if num_children == 1 {
         let mut child = node.child_mut(0);
         child.and_field_mask(node_mask);
-        return eval_node(ctx, child.as_ref(), config);
+        return eval_node(ctx, child, config);
     }
 
     let weight = node.opts().weight;
@@ -595,7 +595,7 @@ fn eval_phrase<'index>(
     for i in 0..num_children {
         let mut child = node.child_mut(i);
         child.and_field_mask(node_mask);
-        children.push(eval_child_iterator(ctx, child.as_ref(), config));
+        children.push(eval_child_iterator(ctx, child, config));
     }
 
     let result_ptr = match new_intersection_iterator(children) {
@@ -628,7 +628,7 @@ fn eval_phrase<'index>(
 /// is zero.
 fn eval_union<'index>(
     ctx: &'index mut QueryEvalContext,
-    node: &QueryNodeRef,
+    mut node: QueryNodeMut<'_>,
     config: Config,
 ) -> Evaluated<'index> {
     // Parsers and expanders always create unions with 2+ children.
@@ -649,16 +649,11 @@ fn eval_union<'index>(
     let min_union_iter_heap = config.min_union_iter_heap;
 
     // Recursively evaluate every child, narrowing its field mask first.
-    //
-    // SAFETY: query evaluation is single-threaded and walks each AST node
-    // exactly once, top-down, so we hold exclusive access to this node and its
-    // subtree for the duration of the call — exactly what `as_mut` requires.
-    let mut node = unsafe { node.as_mut() };
     let children: Vec<CRQEIterator> = (0..num_children)
         .map(|i| {
             let mut child = node.child_mut(i);
             child.and_field_mask(node_mask);
-            eval_child_iterator(ctx, child.as_ref(), config)
+            eval_child_iterator(ctx, child, config)
         })
         .collect();
 
@@ -799,10 +794,7 @@ fn eval_token<'index>(
     // the node's field mask narrowed to the query's.
     let effective_field_mask = opts.field_mask & ctx.opts().fieldmask;
     let token_id = ctx.next_token_id() as i32;
-    // SAFETY: the borrowed bytes are consumed by `new_bytes`, which copies them
-    // into a Rust-owned buffer, before the node is evaluated or handed back to C,
-    // so nothing can rewrite or free the token's string while the slice is live.
-    let term_bytes = unsafe { tok.as_bytes() };
+    let term_bytes = tok.as_bytes();
     // A `QN_TOKEN` node always carries a non-null term string.
     debug_assert!(term_bytes.is_some(), "token string should not be null");
     let term = RSQueryTerm::new_bytes(term_bytes.unwrap_or_default(), token_id, tok.flags());
@@ -896,10 +888,7 @@ fn eval_token_disk<'index>(
     // build a disk term iterator through the enterprise API.
     // SAFETY: in search-on-disk mode the terms trie is always initialised.
     debug_assert!(!spec.terms.is_null(), "terms trie should be initialized");
-    // SAFETY: the borrowed bytes are consumed by the trie lookup below, which
-    // only reads them, before the node is evaluated or handed back to C, so
-    // nothing can rewrite or free the token's string while the slice is live.
-    let term_bytes = unsafe { tok.as_bytes() };
+    let term_bytes = tok.as_bytes();
     // A `QN_TOKEN` node always carries a non-null term string; the term lookup
     // below relies on it.
     debug_assert!(term_bytes.is_some(), "token string should not be null");

--- a/src/redisearch_rs/query_eval/src/eval.rs
+++ b/src/redisearch_rs/query_eval/src/eval.rs
@@ -794,16 +794,18 @@ fn eval_token<'index>(
     tok: RSTokenRef,
     config: Config,
 ) -> Option<Evaluated<'index>> {
-    // A `QN_TOKEN` node always carries a non-null term string.
-    let term_bytes = tok.as_bytes();
-    debug_assert!(term_bytes.is_some(), "token string should not be null");
-    let term_bytes = term_bytes.unwrap_or_default();
     let opts = node.opts();
     let weight = opts.weight;
     // the node's field mask narrowed to the query's.
     let effective_field_mask = opts.field_mask & ctx.opts().fieldmask;
     let token_id = ctx.next_token_id() as i32;
-    let term = RSQueryTerm::new_bytes(term_bytes, token_id, tok.flags());
+    // SAFETY: the borrowed bytes are consumed by `new_bytes`, which copies them
+    // into a Rust-owned buffer, before the node is evaluated or handed back to C,
+    // so nothing can rewrite or free the token's string while the slice is live.
+    let term_bytes = unsafe { tok.as_bytes() };
+    // A `QN_TOKEN` node always carries a non-null term string.
+    debug_assert!(term_bytes.is_some(), "token string should not be null");
+    let term = RSQueryTerm::new_bytes(term_bytes.unwrap_or_default(), token_id, tok.flags());
 
     // SAFETY: `ctx.spec().diskSpec` is either null or a valid
     // `RedisSearchDiskIndexSpec` that stays valid for `'index` (`QueryEvalContext`
@@ -894,16 +896,18 @@ fn eval_token_disk<'index>(
     // build a disk term iterator through the enterprise API.
     // SAFETY: in search-on-disk mode the terms trie is always initialised.
     debug_assert!(!spec.terms.is_null(), "terms trie should be initialized");
+    // SAFETY: the borrowed bytes are consumed by the trie lookup below, which
+    // only reads them, before the node is evaluated or handed back to C, so
+    // nothing can rewrite or free the token's string while the slice is live.
+    let term_bytes = unsafe { tok.as_bytes() };
     // A `QN_TOKEN` node always carries a non-null term string; the term lookup
     // below relies on it.
-    let term_bytes = tok.as_bytes();
     debug_assert!(term_bytes.is_some(), "token string should not be null");
-    let term_bytes = term_bytes.unwrap_or_default();
 
     // SAFETY: `spec.terms` is a valid `Trie` (checked non-null above) that
     // outlives this lookup.
     let terms = unsafe { CTrieRef::from_raw(spec.terms) };
-    let num_docs_in_term = terms.num_docs(term_bytes);
+    let num_docs_in_term = terms.num_docs(term_bytes.unwrap_or_default());
     let num_documents = spec.stats.scoring.numDocuments;
     let idf = idf::calculate_idf(num_documents, num_docs_in_term);
     let bm25_idf = idf::calculate_idf_bm25(num_documents, num_docs_in_term);

--- a/src/redisearch_rs/query_eval/src/lib.rs
+++ b/src/redisearch_rs/query_eval/src/lib.rs
@@ -15,7 +15,7 @@ pub mod eval;
 // The query wrapper types live in the `query` crate (`c_wrappers/query`), and
 // the scorer/expander name modules in `query_types`; both are re-exported here
 // so `query_eval` (and its FFI crate) can refer to them through a single module.
-pub use query::{QueryEvalContext, QueryNode, QueryNodeRef};
+pub use query::{QueryEvalContext, QueryNode, QueryNodeMut, QueryNodeRef};
 pub use query_types::{expanders, scorers};
 
 #[cfg(test)]

--- a/src/redisearch_rs/query_eval/tests/integration/geo.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/geo.rs
@@ -20,7 +20,7 @@ use geo::GEO_RANGE_COUNT;
 use query::mock::MockQueryNode;
 use query_error::QueryErrorCode;
 use query_eval::{
-    QueryEvalContext, QueryNodeRef,
+    QueryEvalContext, QueryNodeMut,
     eval::{self, Config, EvalResult},
 };
 use query_types::QueryNodeType;
@@ -89,8 +89,8 @@ impl GeoFixture {
     /// evaluation produced no iterator.
     fn eval(&mut self) -> Option<EvalResult<'_>> {
         // SAFETY: `self.node` is a valid, live `RSQueryNode` for the call.
-        let node_ref = unsafe { QueryNodeRef::new(self.node.as_non_null()) };
-        eval::eval_node(&mut self.ctx, &node_ref, Config::default()).map(|e| e.into_boxed())
+        let node_ref = unsafe { QueryNodeMut::new(self.node.as_non_null()) };
+        eval::eval_node(&mut self.ctx, node_ref, Config::default()).map(|e| e.into_boxed())
     }
 }
 

--- a/src/redisearch_rs/query_eval/tests/integration/geometry.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/geometry.rs
@@ -21,7 +21,7 @@ use std::ffi::CString;
 use query::mock::MockQueryNode;
 use query_error::QueryErrorCode;
 use query_eval::{
-    QueryEvalContext, QueryNodeRef,
+    QueryEvalContext, QueryNodeMut,
     eval::{self, Config, EvalResult},
 };
 use query_types::QueryNodeType;
@@ -133,8 +133,8 @@ impl GeometryFixture {
     /// evaluation produced no iterator.
     fn eval(&mut self) -> Option<EvalResult<'_>> {
         // SAFETY: `self.node` is a valid, live `RSQueryNode` for the call.
-        let node_ref = unsafe { QueryNodeRef::new(self.node.as_non_null()) };
-        eval::eval_node(&mut self.ctx, &node_ref, Config::default()).map(|e| e.into_boxed())
+        let node_ref = unsafe { QueryNodeMut::new(self.node.as_non_null()) };
+        eval::eval_node(&mut self.ctx, node_ref, Config::default()).map(|e| e.into_boxed())
     }
 }
 

--- a/src/redisearch_rs/query_eval/tests/integration/ids.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/ids.rs
@@ -9,7 +9,7 @@
 
 //! QN_IDS → IdList
 
-use query_eval::{QueryEvalContext, QueryNodeRef, eval, eval::Config};
+use query_eval::{QueryEvalContext, QueryNodeMut, eval, eval::Config};
 use query_types::QueryNodeType;
 use rqe_iterators::{IteratorType, RQEIterator};
 
@@ -26,9 +26,9 @@ fn eval_ids_with_pre_resolved_doc_ids() {
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
     mock_node.set_ids(keys.as_ptr(), doc_ids.as_mut_ptr(), keys.len());
-    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(mock_node.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
 
@@ -56,9 +56,9 @@ fn eval_ids_deduplicates() {
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
     mock_node.set_ids(keys.as_ptr(), doc_ids.as_mut_ptr(), keys.len());
-    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(mock_node.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
 
@@ -80,9 +80,9 @@ fn eval_ids_filters_zero_doc_ids() {
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
     mock_node.set_ids(keys.as_ptr(), doc_ids.as_mut_ptr(), keys.len());
-    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(mock_node.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
 
@@ -102,9 +102,9 @@ fn eval_ids_all_zero_produces_empty_list() {
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
     mock_node.set_ids(keys.as_ptr(), doc_ids.as_mut_ptr(), keys.len());
-    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(mock_node.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
 
@@ -119,9 +119,9 @@ fn eval_ids_empty_keys() {
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
     mock_node.set_ids(std::ptr::null(), std::ptr::null_mut(), 0);
-    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(mock_node.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
 
@@ -166,9 +166,9 @@ mod ids_doctable {
 
         let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
         mock_node.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
-        let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(mock_node.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("should not be None")
             .into_boxed();
 
@@ -199,9 +199,9 @@ mod ids_doctable {
 
         let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
         mock_node.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
-        let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(mock_node.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("should not be None")
             .into_boxed();
 

--- a/src/redisearch_rs/query_eval/tests/integration/missing.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/missing.rs
@@ -19,7 +19,7 @@
 #![cfg(not(miri))]
 
 use ffi::IndexFlags_Index_StoreFreqs;
-use query_eval::{QueryEvalContext, QueryNodeRef, eval, eval::Config};
+use query_eval::{QueryEvalContext, QueryNodeMut, eval, eval::Config};
 use query_types::QueryNodeType;
 use rqe_iterators::{IteratorType, RQEIterator};
 use rqe_iterators_test_utils::{GlobalGuard, TestContext};
@@ -39,9 +39,9 @@ fn eval_missing_returns_iterator_over_missing_docs() {
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Missing);
     mock_node.set_missing_field(context.field_spec());
-    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(mock_node.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("field has missing values, so should not be None")
         .into_boxed();
 
@@ -65,10 +65,10 @@ fn eval_missing_no_values_returns_none() {
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Missing);
     mock_node.set_missing_field(context.field_spec());
-    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(mock_node.as_non_null()) };
 
     assert!(
-        eval::eval_node(&mut ctx, &node, Config::default()).is_none(),
+        eval::eval_node(&mut ctx, node, Config::default()).is_none(),
         "no missing values for the field, so eval should return None"
     );
 }
@@ -85,9 +85,9 @@ fn qast_iterate_substitutes_empty_for_none() {
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Missing);
     mock_node.set_missing_field(context.field_spec());
-    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(mock_node.as_non_null()) };
 
-    let mut it = eval::qast_iterate(&mut ctx, &node, Config::default()).into_boxed();
+    let mut it = eval::qast_iterate(&mut ctx, node, Config::default()).into_boxed();
 
     assert_eq!(it.type_(), IteratorType::Empty);
     assert!(it.at_eof());

--- a/src/redisearch_rs/query_eval/tests/integration/not.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/not.rs
@@ -9,7 +9,7 @@
 
 //! QN_NOT → Not / Wildcard / Empty (via the reducer shortcircuits)
 
-use query_eval::{QueryEvalContext, QueryNodeRef, eval, eval::Config};
+use query_eval::{QueryEvalContext, QueryNodeMut, eval, eval::Config};
 use query_types::QueryNodeType;
 use rqe_iterators::{IteratorType, RQEIterator};
 
@@ -29,9 +29,9 @@ fn eval_not_empty_child_falls_back_to_wildcard() {
     let mut not = MockQueryNode::new(QueryNodeType::Not);
     not.opts_mut().weight = 1.0;
     not.set_children(&[null_child.as_ptr()]);
-    let node = unsafe { QueryNodeRef::new(not.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(not.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
 
@@ -57,9 +57,9 @@ fn eval_not_wildcard_child_reduces_to_empty() {
     let mut not = MockQueryNode::new(QueryNodeType::Not);
     not.opts_mut().weight = 1.0;
     not.set_children(&[wc_child.as_ptr()]);
-    let node = unsafe { QueryNodeRef::new(not.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(not.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
 
@@ -114,9 +114,9 @@ mod not {
         let mut not = MockQueryNode::new(QueryNodeType::Not);
         not.opts_mut().weight = 1.0;
         not.set_children(&[ids_child.as_ptr()]);
-        let node = unsafe { QueryNodeRef::new(not.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(not.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("should not be None")
             .into_boxed();
 
@@ -163,9 +163,9 @@ mod not {
         let mut not = MockQueryNode::new(QueryNodeType::Not);
         not.opts_mut().weight = 1.0;
         not.set_children(&[missing_child.as_ptr()]);
-        let node = unsafe { QueryNodeRef::new(not.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(not.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("a not node always yields an iterator")
             .into_boxed();
 
@@ -210,9 +210,9 @@ mod not {
         let mut not = MockQueryNode::new(QueryNodeType::Not);
         not.opts_mut().weight = 1.0;
         not.set_children(&[ids_child.as_ptr()]);
-        let node = unsafe { QueryNodeRef::new(not.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(not.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("should not be None")
             .into_boxed();
 

--- a/src/redisearch_rs/query_eval/tests/integration/null.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/null.rs
@@ -9,7 +9,7 @@
 
 //! QN_NULL → Empty
 
-use query_eval::{QueryEvalContext, QueryNodeRef, eval, eval::Config};
+use query_eval::{QueryEvalContext, QueryNodeMut, eval, eval::Config};
 use query_types::QueryNodeType;
 use rqe_iterators::{IteratorType, RQEIterator};
 
@@ -20,9 +20,9 @@ fn eval_null_returns_empty_iterator() {
     let mut mock_ctx = MockQueryEvalCtx::new();
     let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
     let mock_node = MockQueryNode::new(QueryNodeType::Null);
-    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(mock_node.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
 

--- a/src/redisearch_rs/query_eval/tests/integration/numeric.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/numeric.rs
@@ -19,7 +19,7 @@ use index_result::RSIndexResult;
 use inverted_index::NumericFilter;
 use query::mock::MockQueryNode;
 use query_eval::{
-    QueryEvalContext, QueryNodeRef,
+    QueryEvalContext, QueryNodeMut,
     eval::{self, Config, EvalResult},
 };
 use query_types::QueryNodeType;
@@ -98,8 +98,8 @@ impl NumericFixture {
     /// produced no iterator.
     fn eval(&mut self) -> Option<EvalResult<'_>> {
         // SAFETY: `self.node` is a valid, live `RSQueryNode` for the call.
-        let node_ref = unsafe { QueryNodeRef::new(self.node.as_non_null()) };
-        eval::eval_node(&mut self.ctx, &node_ref, Config::default()).map(|e| e.into_boxed())
+        let node_ref = unsafe { QueryNodeMut::new(self.node.as_non_null()) };
+        eval::eval_node(&mut self.ctx, node_ref, Config::default()).map(|e| e.into_boxed())
     }
 }
 

--- a/src/redisearch_rs/query_eval/tests/integration/optional.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/optional.rs
@@ -9,7 +9,7 @@
 
 //! QN_OPTIONAL → Optional / Wildcard (via the reducer shortcircuits)
 
-use query_eval::{QueryEvalContext, QueryNodeRef, eval, eval::Config};
+use query_eval::{QueryEvalContext, QueryNodeMut, eval, eval::Config};
 use query_types::QueryNodeType;
 use rqe_iterators::{IteratorType, RQEIterator};
 
@@ -28,9 +28,9 @@ fn eval_optional_empty_child_falls_back_to_wildcard() {
     let mut opt = MockQueryNode::new(QueryNodeType::Optional);
     opt.opts_mut().weight = 1.0;
     opt.set_children(&[null_child.as_ptr()]);
-    let node = unsafe { QueryNodeRef::new(opt.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(opt.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
 
@@ -57,9 +57,9 @@ fn eval_optional_wildcard_child_passes_through() {
     let mut opt = MockQueryNode::new(QueryNodeType::Optional);
     opt.opts_mut().weight = 2.0;
     opt.set_children(&[wc_child.as_ptr()]);
-    let node = unsafe { QueryNodeRef::new(opt.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(opt.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
 
@@ -112,9 +112,9 @@ mod optional {
         let mut opt = MockQueryNode::new(QueryNodeType::Optional);
         opt.opts_mut().weight = 1.0;
         opt.set_children(&[ids_child.as_ptr()]);
-        let node = unsafe { QueryNodeRef::new(opt.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(opt.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("should not be None")
             .into_boxed();
 
@@ -160,9 +160,9 @@ mod optional {
         let mut opt = MockQueryNode::new(QueryNodeType::Optional);
         opt.opts_mut().weight = 1.0;
         opt.set_children(&[missing_child.as_ptr()]);
-        let node = unsafe { QueryNodeRef::new(opt.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(opt.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("an optional node always yields an iterator")
             .into_boxed();
 
@@ -203,9 +203,9 @@ mod optional {
         let mut opt = MockQueryNode::new(QueryNodeType::Optional);
         opt.opts_mut().weight = 1.0;
         opt.set_children(&[ids_child.as_ptr()]);
-        let node = unsafe { QueryNodeRef::new(opt.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(opt.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("an optional node always yields an iterator")
             .into_boxed();
 

--- a/src/redisearch_rs/query_eval/tests/integration/phrase.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/phrase.rs
@@ -9,7 +9,7 @@
 
 //! QN_PHRASE → Intersection
 
-use query_eval::{QueryEvalContext, QueryNodeRef, eval, eval::Config};
+use query_eval::{QueryEvalContext, QueryNodeMut, eval, eval::Config};
 use query_types::QueryNodeType;
 use rqe_iterators::{IteratorType, RQEIterator};
 
@@ -32,9 +32,9 @@ fn eval_phrase_single_child_returns_child() {
     let mut phrase = MockQueryNode::new(QueryNodeType::Phrase);
     phrase.opts_mut().weight = 1.0;
     phrase.set_children(&[wc_child.as_ptr()]);
-    let node = unsafe { QueryNodeRef::new(phrase.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(phrase.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
 
@@ -102,9 +102,9 @@ mod phrase {
         // -1 → no slop constraint, i.e. a plain set intersection.
         phrase.opts_mut().max_slop = -1;
         phrase.set_children(&[c1.as_ptr(), c2.as_ptr()]);
-        let node = unsafe { QueryNodeRef::new(phrase.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(phrase.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("should not be None")
             .into_boxed();
 
@@ -162,9 +162,9 @@ mod phrase {
         // `in_order`.
         phrase.opts_mut().max_slop = -1;
         phrase.set_children(&[c1.as_ptr(), c2.as_ptr()]);
-        let node = unsafe { QueryNodeRef::new(phrase.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(phrase.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("should not be None")
             .into_boxed();
 
@@ -223,9 +223,9 @@ mod phrase {
         phrase.opts_mut().max_slop = -1;
         phrase.opts_mut().in_order = 1;
         phrase.set_children(&[c1.as_ptr(), c2.as_ptr()]);
-        let node = unsafe { QueryNodeRef::new(phrase.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(phrase.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("should not be None")
             .into_boxed();
 
@@ -278,9 +278,9 @@ mod phrase {
         phrase.opts_mut().weight = 1.0;
         phrase.opts_mut().max_slop = -1;
         phrase.set_children(&[missing_child.as_ptr(), ids_child.as_ptr()]);
-        let node = unsafe { QueryNodeRef::new(phrase.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(phrase.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("a multi-child phrase always yields an iterator")
             .into_boxed();
 
@@ -334,9 +334,9 @@ mod phrase {
         // Exact phrase → `eval_phrase` resolves `(Some(0), true)`.
         phrase.set_phrase_exact(1);
         phrase.set_children(&[c1.as_ptr(), c2.as_ptr()]);
-        let node = unsafe { QueryNodeRef::new(phrase.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(phrase.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("should not be None")
             .into_boxed();
 
@@ -382,9 +382,9 @@ mod phrase_reducer {
         phrase.opts_mut().weight = 1.0;
         phrase.set_phrase_exact(1);
         phrase.set_children(&[c1.as_ptr(), c2.as_ptr()]);
-        let node = unsafe { QueryNodeRef::new(phrase.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(phrase.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("a multi-child phrase always yields an iterator")
             .into_boxed();
 
@@ -413,9 +413,9 @@ mod phrase_reducer {
         // `Some(slop as u32)` branch of the max-slop computation.
         phrase.opts_mut().max_slop = 2;
         phrase.set_children(&[c1.as_ptr(), c2.as_ptr()]);
-        let node = unsafe { QueryNodeRef::new(phrase.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(phrase.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("a multi-child phrase always yields an iterator")
             .into_boxed();
 

--- a/src/redisearch_rs/query_eval/tests/integration/qast_iterate.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/qast_iterate.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use query_eval::{QueryEvalContext, QueryNodeRef, eval, eval::Config};
+use query_eval::{QueryEvalContext, QueryNodeMut, eval, eval::Config};
 use query_types::QueryNodeType;
 use rqe_iterators::{IteratorType, RQEIterator};
 
@@ -18,9 +18,9 @@ fn qast_iterate_evaluates_root_node() {
     let mut mock_ctx = MockQueryEvalCtx::new();
     let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
     let mock_node = MockQueryNode::new(QueryNodeType::Null);
-    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(mock_node.as_non_null()) };
 
-    let mut it = eval::qast_iterate(&mut ctx, &node, Config::default()).into_boxed();
+    let mut it = eval::qast_iterate(&mut ctx, node, Config::default()).into_boxed();
 
     assert_eq!(it.type_(), IteratorType::Empty);
     assert!(it.at_eof());

--- a/src/redisearch_rs/query_eval/tests/integration/token.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/token.rs
@@ -26,7 +26,7 @@ use ffi::{
 use index_result::{RSIndexResult, RSOffsetSlice};
 use query::mock::MockQueryNode;
 use query_eval::{
-    QueryEvalContext, QueryNodeRef,
+    QueryEvalContext, QueryNodeMut,
     eval::{self, Config, EvalResult},
 };
 use query_term::RSQueryTerm;
@@ -114,8 +114,8 @@ impl TokenFixture {
     /// evaluation produced no iterator.
     fn eval(&mut self) -> Option<EvalResult<'_>> {
         // SAFETY: `self.node` is a valid, live `RSQueryNode` for the call.
-        let node_ref = unsafe { QueryNodeRef::new(self.node.as_non_null()) };
-        eval::eval_node(&mut self.ctx, &node_ref, Config::default()).map(|e| e.into_boxed())
+        let node_ref = unsafe { QueryNodeMut::new(self.node.as_non_null()) };
+        eval::eval_node(&mut self.ctx, node_ref, Config::default()).map(|e| e.into_boxed())
     }
 }
 

--- a/src/redisearch_rs/query_eval/tests/integration/union.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/union.rs
@@ -9,7 +9,7 @@
 
 //! QN_UNION → Union
 
-use query_eval::{QueryEvalContext, QueryNodeRef, eval, eval::Config};
+use query_eval::{QueryEvalContext, QueryNodeMut, eval, eval::Config};
 use query_types::QueryNodeType;
 use rqe_iterators::{IteratorType, RQEIterator};
 
@@ -30,9 +30,9 @@ fn eval_union_merges_children() {
     let mut union = MockQueryNode::new(QueryNodeType::Union);
     union.opts_mut().weight = 1.0;
     union.set_children(&[c1.as_ptr(), c2.as_ptr()]);
-    let node = unsafe { QueryNodeRef::new(union.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(union.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
 
@@ -63,9 +63,9 @@ fn eval_union_zero_weight_takes_quick_exit() {
     // Zero weight drives `quick_exit = true`.
     union.opts_mut().weight = 0.0;
     union.set_children(&[c1.as_ptr(), c2.as_ptr()]);
-    let node = unsafe { QueryNodeRef::new(union.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(union.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
 
@@ -99,9 +99,9 @@ fn eval_union_in_not_subtree_takes_quick_exit() {
     // Non-zero weight, so only the `in_not_sub_tree` disjunct can enable quick-exit.
     union.opts_mut().weight = 1.0;
     union.set_children(&[c1.as_ptr(), c2.as_ptr()]);
-    let node = unsafe { QueryNodeRef::new(union.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(union.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
 
@@ -173,9 +173,9 @@ mod union {
         let mut union = MockQueryNode::new(QueryNodeType::Union);
         union.opts_mut().weight = 1.0;
         union.set_children(&[c1.as_ptr(), c2.as_ptr()]);
-        let node = unsafe { QueryNodeRef::new(union.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(union.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("should not be None")
             .into_boxed();
 
@@ -231,9 +231,9 @@ mod union {
         let mut union = MockQueryNode::new(QueryNodeType::Union);
         union.opts_mut().weight = 1.0;
         union.set_children(&[missing_child.as_ptr(), ids_child.as_ptr()]);
-        let node = unsafe { QueryNodeRef::new(union.as_non_null()) };
+        let node = unsafe { QueryNodeMut::new(union.as_non_null()) };
 
-        let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+        let mut it = eval::eval_node(&mut ctx, node, Config::default())
             .expect("a multi-child union always yields an iterator")
             .into_boxed();
 

--- a/src/redisearch_rs/query_eval/tests/integration/wildcard.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/wildcard.rs
@@ -9,7 +9,7 @@
 
 //! QN_WILDCARD → Wildcard
 
-use query_eval::{QueryEvalContext, QueryNodeRef, eval, eval::Config};
+use query_eval::{QueryEvalContext, QueryNodeMut, eval, eval::Config};
 use query_types::QueryNodeType;
 use rqe_iterators::{IteratorType, RQEIterator};
 
@@ -23,9 +23,9 @@ fn eval_wildcard_returns_wildcard_iterator() {
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Wildcard);
     mock_node.opts_mut().weight = 1.0;
-    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(mock_node.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
 
@@ -42,9 +42,9 @@ fn eval_wildcard_empty_index() {
     let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
 
     let mock_node = MockQueryNode::new(QueryNodeType::Wildcard);
-    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(mock_node.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
 
@@ -60,9 +60,9 @@ fn eval_wildcard_respects_weight() {
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Wildcard);
     mock_node.opts_mut().weight = 2.5;
-    let node = unsafe { QueryNodeRef::new(mock_node.as_non_null()) };
+    let node = unsafe { QueryNodeMut::new(mock_node.as_non_null()) };
 
-    let mut it = eval::eval_node(&mut ctx, &node, Config::default())
+    let mut it = eval::eval_node(&mut ctx, node, Config::default())
         .expect("should not be None")
         .into_boxed();
     let result = it.read().unwrap().expect("should have a result");

--- a/tests/cpptests/test_cpp_query.cpp
+++ b/tests/cpptests/test_cpp_query.cpp
@@ -22,14 +22,17 @@ extern "C" {
 #include "query_test_utils.h"
 #include "iterators_ffi.h"
 #include "query_eval_ffi.h"
+#include "rmalloc.h"
 
 #include "gtest/gtest.h"
 
 #include <array>
+#include <cstring>
 #include <stdio.h>
 
 extern "C" int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key,
                                    DocumentType type, RedisModuleKey *openKey);
+
 
 #define QUERY_PARSE_CTX(ctx, qt, opts) NewQueryParseCtx(&ctx, qt, strlen(qt), &opts);
 
@@ -1092,4 +1095,49 @@ TEST_F(QueryTest, testWildcard) {
   ASSERT_STREQ("?*?*?", n->verb.tok.str);
 
   Indexes_RemoveSpecFromGlobals(ref, false);
+}
+
+// A PARAM_TERM_CASE value is binary-safe and may contain interior NULs. It must
+// be duplicated in full, NUL-terminated, with the reported length matching the
+// allocation. A previous implementation used rm_strdup, which truncated the copy
+// at the first interior NUL while still reporting the full length, so reading the
+// reported target_len bytes ran past the end of the allocation. The value below
+// has a long tail after the interior NUL, so reading all target_len bytes runs
+// far past the truncated allocation — a heap-buffer-overflow under
+// AddressSanitizer — while also asserting the value is preserved intact.
+TEST_F(QueryTest, testParamTermCaseBinaryValue) {
+  QueryError err = QueryError_Default();
+  dict *params = Param_DictCreate();
+
+  // 'a', interior NUL, then a long tail. rm_strdup would stop at the NUL and
+  // allocate only 2 bytes while still reporting the full length.
+  char value[64];
+  value[0] = 'a';
+  value[1] = '\0';
+  memset(value + 2, 'b', sizeof(value) - 2);
+  ASSERT_EQ(0, Param_DictAdd(params, "p", value, sizeof(value), &err));
+  ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
+
+  char *resolved = NULL;
+  size_t resolved_len = 0;
+  Param param = {};
+  param.name = "p";
+  param.len = 1;
+  param.type = PARAM_TERM_CASE;
+  param.target = &resolved;
+  param.target_len = &resolved_len;
+
+  int rc = QueryParam_Resolve(&param, params, 2, &err);
+  ASSERT_EQ(1, rc);
+  ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
+
+  // The whole binary value is preserved, not truncated at the interior NUL.
+  // Reading all resolved_len bytes here is where a truncated allocation faults.
+  ASSERT_EQ(sizeof(value), resolved_len);
+  ASSERT_EQ(0, memcmp(resolved, value, resolved_len));
+  // A trailing terminator sits at index len, so the allocation spans len + 1.
+  ASSERT_EQ('\0', resolved[resolved_len]);
+
+  rm_free(resolved);
+  Param_DictFree(params);
 }


### PR DESCRIPTION
Safe wrapper around `ffi::RSToken`. Will be used to implement `QN_PREFIX` node.
`RsToken` may or may not be NUL terminated so make it explicit using a type parameter.

Also making `QueryParam_Resolve` safer by properly handling params with interior NUL.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
