### PR TITLE
[8.6-rse] SVS shared thread pool integration (MOD-9881, MOD-17089)

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1115,6 +1115,13 @@ void AREQ_Execute_Callback(blockedClientReqCtx *BCRctx) {
     sctx->redisCtx = outctx;
   }
 
+#ifdef ENABLE_ASSERT
+  // Sync point (debug): pause before acquiring the spec read lock.
+  // Unlike BeforeFirstRead, this does NOT hold any lock, so the main thread
+  // can still acquire the spec write lock (e.g. for HSET / indexing).
+  SyncPoint_Wait(SYNC_POINT_BEFORE_SPEC_LOCK);
+#endif
+
   // lock spec
   RedisSearchCtx_LockSpecRead(sctx);
 

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -108,6 +108,7 @@ void StoreResultsDebugCtx_SetPause(bool pause);
 #define SYNC_POINT_AFTER_ITERATOR_CREATE       "AfterIteratorCreate"
 #define SYNC_POINT_BEFORE_FIRST_READ           "BeforeFirstRead"
 #define SYNC_POINT_BEFORE_DIST_HYBRID_PROMOTE  "BeforeDistHybridPromote"
+#define SYNC_POINT_BEFORE_SPEC_LOCK            "BeforeSpecLock"
 
 // SyncPoint API function declarations
 // Arm a sync point - subsequent calls to SyncPoint_Wait will block

--- a/src/info/indexes_info.c
+++ b/src/info/indexes_info.c
@@ -10,6 +10,7 @@
 #include "util/dict.h"
 #include "spec.h"
 #include "field_spec_info.h"
+#include "VecSim/vec_sim.h"
 #include <string.h>  // Add this for strerror
 
 // Assuming the GIL is held by the caller
@@ -85,5 +86,11 @@ TotalIndexesInfo IndexesInfo_TotalInfo() {
   dictReleaseIterator(iter);
   if (info.min_mem == -1) info.min_mem = 0;             // No index found
   if (BGIndexerInProgress) info.total_active_write_threads++;  // BG indexer is currently active
+
+  // Process-wide vector memory not tied to any specific spec (e.g. the shared SVS
+  // thread pool singleton).
+  size_t shared_vector_mem = VecSim_GetSharedMemory();
+  info.fields_stats.total_vector_idx_mem += shared_vector_mem;
+  info.total_mem += shared_vector_mem;
   return info;
 }

--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -262,7 +262,10 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
   size_t inverted_size = isDisk ? 0 : sp->stats.invertedSize;
   // Vector indexes (e.g. HNSW) remain in memory even when the rest of the
   // index is stored on disk, so their memory must always be reported.
-  size_t vector_indexes_size = IndexSpec_VectorIndexesSize(specForOpeningIndexes);
+  // VecSim_GetSharedMemory() returns process-wide vector-related allocations not
+  // tied to any single index (e.g. the shared SVS thread pool singleton).
+  size_t vector_indexes_size = IndexSpec_VectorIndexesSize(specForOpeningIndexes) +
+                               VecSim_GetSharedMemory();
   size_t total_ii_blocks = isDisk ? 0 : TotalIIBlocks();
   size_t offset_vecs_size = isDisk ? 0 : sp->stats.offsetVecsSize;
   size_t doc_table_size = isDisk ? 0 : sp->docs.memsize;

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -163,6 +163,14 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
   // Handle deprecated MT configurations
   UpgradeDeprecatedMTConfigs();
 
+  // Register rm_malloc memory functions as vector similarity memory functions.
+  // Must be done before workersThreadPool_CreatePool, which calls VecSim_UpdateThreadPoolSize
+  // and may allocate VecSim internal structures (shared SVS thread pool).
+  VecSimMemoryFunctions vecsimMemoryFunctions = {.allocFunction = rm_malloc, .callocFunction = rm_calloc, .reallocFunction = rm_realloc, .freeFunction = rm_free};
+  VecSim_SetMemoryFunctions(vecsimMemoryFunctions);
+  VecSim_SetTimeoutCallbackFunction((timeoutCallbackFunction)TimedOut_WithCtx);
+  VecSim_SetLogCallbackFunction(VecSimLogCallback);
+
   // Init threadpool.
   if (workersThreadPool_CreatePool(RSGlobalConfig.numWorkerThreads) == REDISMODULE_ERR) {
     return REDISMODULE_ERR;
@@ -214,10 +222,5 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
   Initialize_RdbNotifications(ctx);
   Initialize_RoleChangeNotifications(ctx);
 
-  // Register rm_malloc memory functions as vector similarity memory functions.
-  VecSimMemoryFunctions vecsimMemoryFunctions = {.allocFunction = rm_malloc, .callocFunction = rm_calloc, .reallocFunction = rm_realloc, .freeFunction = rm_free};
-  VecSim_SetMemoryFunctions(vecsimMemoryFunctions);
-  VecSim_SetTimeoutCallbackFunction((timeoutCallbackFunction)TimedOut_WithCtx);
-  VecSim_SetLogCallbackFunction(VecSimLogCallback);
   return REDISMODULE_OK;
 }

--- a/src/spec.c
+++ b/src/spec.c
@@ -1340,7 +1340,8 @@ static int parseVectorField(IndexSpec *sp, StrongRef sp_ref, FieldSpec *fs, Args
     params->primaryIndexParams->algoParams.svsParams.graph_max_degree = SVS_VAMANA_DEFAULT_GRAPH_MAX_DEGREE;
     params->primaryIndexParams->algoParams.svsParams.construction_window_size = SVS_VAMANA_DEFAULT_CONSTRUCTION_WINDOW_SIZE;
     params->primaryIndexParams->algoParams.svsParams.multi = multi;
-    params->primaryIndexParams->algoParams.svsParams.num_threads = workersThreadPool_NumThreads();
+    // num_threads is deprecated — SVS indexes now share a global thread pool managed
+    // via VecSim_UpdateThreadPoolSize(). Leave it at 0 (default) to avoid the deprecation warning.
     params->primaryIndexParams->algoParams.svsParams.leanvec_dim = SVS_VAMANA_DEFAULT_LEANVEC_DIM;
     params->primaryIndexParams->logCtx = logCtx;
     result = parseVectorField_svs(fs, params, ac, status);

--- a/src/util/workers.c
+++ b/src/util/workers.c
@@ -39,14 +39,11 @@ static void yieldCallback(void *yieldCtx) {
 static void workersThreadPool_OnActivation(size_t new_num) {
   // Log that we've enabled the thread pool.
   RedisModule_Log(RSDummyContext, "notice", "Enabled workers threadpool of size %lu", new_num);
-  // Change VecSim write mode temporarily for fast RDB loading of vector index (if needed).
-  VecSim_SetWriteMode(VecSim_WriteAsync);
 }
 
 /* Configure here anything that needs to know it cannot use the thread pool anymore */
 static void workersThreadPool_OnDeactivation(size_t old_num) {
   RedisModule_Log(RSDummyContext, "notice", "Disabled workers threadpool of size %lu", old_num);
-  VecSim_SetWriteMode(VecSim_WriteInPlace);
 }
 
 // set up workers' thread pool
@@ -60,6 +57,8 @@ int workersThreadPool_CreatePool(size_t worker_count) {
   } else {
     workersThreadPool_OnDeactivation(worker_count);
   }
+  // Set the shared SVS thread pool size to match the worker pool.
+  VecSim_UpdateThreadPoolSize(worker_count);
   return REDISMODULE_OK;
 }
 
@@ -102,6 +101,10 @@ void workersThreadPool_SetNumWorkers() {
     RedisModule_Log(RSDummyContext, "notice", "Scheduling config_reduce_threads_job to remove %zu threads ASAP", curr_workers - worker_count);
     redisearch_thpool_schedule_config_reduce_threads_job(_workers_thpool, curr_workers - worker_count, false);
   }
+
+  // Notify VecSim of the (possibly new) pool size. VecSim_UpdateThreadPoolSize handles all
+  // transitions: 0 sets in-place mode, >0 sets async mode and resizes the shared SVS thread pool.
+  VecSim_UpdateThreadPoolSize(worker_count);
 }
 
 // return number of currently working threads

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -697,6 +697,11 @@ void VecSim_TieredParams_Init(TieredIndexParams *params, StrongRef sp_ref) {
 }
 
 void VecSimLogCallback(void *ctx, const char *level, const char *message) {
+  if (ctx == NULL) {
+    // Allow global VecSim log (e.g., shared thread pool) — no per-index context.
+    RedisModule_Log(RSDummyContext, level, "VecSim: %s", message);
+    return;
+  }
   VecSimLogCtx *log_ctx = (VecSimLogCtx *)ctx;
   RedisModule_Log(RSDummyContext, level, "vector index '%s' - %s", log_ctx->index_field_name, message);
 }

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -421,7 +421,10 @@ def test_redis_info():
   env.assertGreater(res['search_largest_memory_index_human'], 0)
   env.assertGreater(res['search_smallest_memory_index'], 0)
   env.assertGreater(res['search_smallest_memory_index_human'], 0)
-  env.assertEqual(res['search_used_memory_vector_index'], 0)
+  # search_used_memory_vector_index folds in the process-wide shared SVS thread
+  # pool memory, which has a small non-zero baseline once the pool singleton is
+  # initialized — even for indexes without vector fields.
+  env.assertGreaterEqual(res['search_used_memory_vector_index'], 0)
   # env.assertGreater(res['search_total_indexing_time'], 0)   # Introduces flakiness
 
   # ========== Cursors statistics ==========
@@ -617,9 +620,14 @@ def test_redis_info_modules_vecsim():
     set_doc(f'doc_svs:{i}')
   env.expect(debug_cmd(), 'WORKERS', 'DRAIN').ok()
 
+  # search_used_memory_vector_index aggregates per-index MEMORY across all vector
+  # fields plus VecSim_GetSharedMemory() (folded in once).
+  expected_vec_mem = lambda field_infos: (sum(int(fi['MEMORY']) for fi in field_infos) +
+                                          int(field_infos[0]['SHARED_MEMORY']))
+
   info = env.cmd('INFO', 'MODULES')
   field_infos = [to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', f'idx{i}', 'vec')) for i in range(1, 5)]
-  env.assertEqual(info['search_used_memory_vector_index'], sum(field_info['MEMORY'] for field_info in field_infos))
+  env.assertEqual(info['search_used_memory_vector_index'], expected_vec_mem(field_infos))
   # Validate that vector indexes are accounted in the total index memory
   env.assertGreater(info['search_used_memory_indexes'], info['search_used_memory_vector_index'])
   env.assertEqual(info['search_gc_marked_deleted_vectors'], 0)
@@ -629,7 +637,7 @@ def test_redis_info_modules_vecsim():
 
   info = env.cmd('INFO', 'MODULES')
   field_infos = [to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', f'idx{i}', 'vec')) for i in range(1, 5)]
-  env.assertEqual(info['search_used_memory_vector_index'], sum(field_info['MEMORY'] for field_info in field_infos))
+  env.assertEqual(info['search_used_memory_vector_index'], expected_vec_mem(field_infos))
   # 3 vectors were marked as deleted (1 for each hnsw index and 1 for svs)
   env.assertEqual(info['search_gc_marked_deleted_vectors'], 3)
   env.assertEqual(to_dict(field_infos[0]['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 1)
@@ -642,7 +650,7 @@ def test_redis_info_modules_vecsim():
 
   info = env.cmd('INFO', 'MODULES')
   field_infos = [to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', f'idx{i}', 'vec')) for i in range(1, 5)]
-  env.assertEqual(info['search_used_memory_vector_index'], sum(field_info['MEMORY'] for field_info in field_infos))
+  env.assertEqual(info['search_used_memory_vector_index'], expected_vec_mem(field_infos))
   env.assertEqual(info['search_gc_marked_deleted_vectors'], 0)
   env.assertEqual(to_dict(field_infos[0]['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 0)
   env.assertEqual(to_dict(field_infos[1]['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 0)

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -523,7 +523,9 @@ def test_info():
       'sortable_values_size_mb': 0.0,
       'geoshapes_sz_mb': 0.0,
       'total_inverted_index_blocks': ANY,
-      'vector_index_sz_mb': 0.0,
+      # vector_index_sz_mb folds in the process-wide shared SVS thread pool memory,
+      # which has a small non-zero baseline once the pool singleton is initialized.
+      'vector_index_sz_mb': ANY,
       'Index Errors': {
           'indexing failures': 0,
           'last indexing error': 'N/A',
@@ -1327,9 +1329,18 @@ def test_ft_info():
       initial_doc_table_size_mb = 8072 / (1024 * 1024)
       # Size of an empty TrieMap
       key_table_sz_mb = 24 / (1024 * 1024)
-      total_index_memory_sz_mb = initial_doc_table_size_mb + key_table_sz_mb
+      per_node_index_memory_sz_mb = initial_doc_table_size_mb + key_table_sz_mb
 
       res = order_dict(r.execute_command('ft.info', 'idx'))
+
+      # The FT.INFO vector_index_sz_mb field folds in VecSim_GetSharedMemory()
+      # (process-wide vector allocations not tied to any single index). For an
+      # index without vector fields IndexSpec_VectorIndexesSize() is 0, so
+      # vector_index_sz_mb is exactly that global overhead. In cluster mode it's
+      # already aggregated across shards. We pin to the response value so
+      # total_index_memory_sz_mb stays exact (rather than an ANY match).
+      global_vector_mem_mb = res['vector_index_sz_mb']
+      total_index_memory_sz_mb = per_node_index_memory_sz_mb + global_vector_mem_mb
 
       exp = {
         'attributes': [
@@ -1404,7 +1415,7 @@ def test_ft_info():
         'geoshapes_sz_mb': 0.0,
         'total_indexing_time': 0.0,
         'total_inverted_index_blocks': 0.0,
-        'vector_index_sz_mb': 0.0,
+        'vector_index_sz_mb': global_vector_mem_mb,
         'Index Errors': {
               'indexing failures': 0,
               'last indexing error': 'N/A',
@@ -1469,7 +1480,10 @@ def test_ft_info():
         'key_table_size_mb': nodes * key_table_sz_mb,
         'tag_overhead_sz_mb': 0.0,
         'text_overhead_sz_mb': 0.0,
-        'total_index_memory_sz_mb': nodes * total_index_memory_sz_mb,
+        # global_vector_mem_mb is already aggregated across shards (FT.INFO sums
+        # vector_index_sz_mb from each shard), so it's added once — not multiplied
+        # by `nodes` — to the per-node base * nodes.
+        'total_index_memory_sz_mb': nodes * per_node_index_memory_sz_mb + global_vector_mem_mb,
         'max_doc_id': 0,
         'num_docs': 0,
         'num_records': 0,
@@ -1483,7 +1497,7 @@ def test_ft_info():
         'sortable_values_size_mb': 0.0,
         'geoshapes_sz_mb': 0.0,
         'total_inverted_index_blocks': 0,
-        'vector_index_sz_mb': 0.0,
+        'vector_index_sz_mb': global_vector_mem_mb,
         'Index Errors': {
               'indexing failures': 0,
               'last indexing error': 'N/A',

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -339,8 +339,8 @@ def test_create():
         conn.execute_command('FT.CREATE', 'idx2', 'SCHEMA', 'v_FLAT', 'VECTOR', 'FLAT', '8', 'TYPE', data_type,
                              'DIM', '1024', 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', '10')
 
-        expected_HNSW = ['ALGORITHM', 'TIERED', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'MANAGEMENT_LAYER_MEMORY', dummy_val, 'BACKGROUND_INDEXING', 0, 'TIERED_BUFFER_LIMIT', 1024, 'FRONTEND_INDEX', ['ALGORITHM', 'FLAT', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024], 'BACKEND_INDEX', ['ALGORITHM', 'HNSW', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024, 'M', 16, 'EF_CONSTRUCTION', 200, 'EF_RUNTIME', 10, 'MAX_LEVEL', -1, 'ENTRYPOINT', -1, 'EPSILON', '0.01', 'NUMBER_OF_MARKED_DELETED', 0], 'TIERED_HNSW_SWAP_JOBS_THRESHOLD', 1024]
-        expected_FLAT = ['ALGORITHM', 'FLAT', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'L2', 'IS_MULTI_VALUE', 0, 'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024]
+        expected_HNSW = ['ALGORITHM', 'TIERED', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'MANAGEMENT_LAYER_MEMORY', dummy_val, 'BACKGROUND_INDEXING', 0, 'TIERED_BUFFER_LIMIT', 1024, 'FRONTEND_INDEX', ['ALGORITHM', 'FLAT', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024], 'BACKEND_INDEX', ['ALGORITHM', 'HNSW', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024, 'M', 16, 'EF_CONSTRUCTION', 200, 'EF_RUNTIME', 10, 'MAX_LEVEL', -1, 'ENTRYPOINT', -1, 'EPSILON', '0.01', 'NUMBER_OF_MARKED_DELETED', 0], 'TIERED_HNSW_SWAP_JOBS_THRESHOLD', 1024, 'SHARED_MEMORY', dummy_val]
+        expected_FLAT = ['ALGORITHM', 'FLAT', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'L2', 'IS_MULTI_VALUE', 0, 'IS_DISK', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024, 'SHARED_MEMORY', dummy_val]
 
         # SVS-VAMANA only supports FLOAT32 and FLOAT16 data types
         if data_type in ('FLOAT32', 'FLOAT16'):
@@ -357,15 +357,18 @@ def test_create():
                                                       'BLOCK_SIZE', 1024, 'QUANT_BITS', 'NONE', 'ALPHA', 1.2, 'GRAPH_MAX_DEGREE', 32, 'CONSTRUCTION_WINDOW_SIZE', 200,
                                                       'MAX_CANDIDATE_POOL_SIZE', 600, 'PRUNE_TO', 28, 'USE_SEARCH_HISTORY', 1, 'NUM_THREADS', 1, 'LAST_RESERVED_NUM_THREADS', 1,
                                                       'NUMBER_OF_MARKED_DELETED', 0, 'SEARCH_WINDOW_SIZE', 10, 'SEARCH_BUFFER_CAPACITY', 10, 'LEANVEC_DIMENSION', 0, 'EPSILON', 0.01],
-                                                      'TIERED_SVS_TRAINING_THRESHOLD', 1024, 'TIERED_SVS_UPDATE_THRESHOLD', 1024, 'TIERED_SVS_THREADS_RESERVE_TIMEOUT', 5000]
+                                                      'TIERED_SVS_TRAINING_THRESHOLD', 1024, 'TIERED_SVS_UPDATE_THRESHOLD', 1024, 'TIERED_SVS_THREADS_RESERVE_TIMEOUT', 5000,
+                                                      'SHARED_MEMORY', dummy_val]
 
         for _ in env.reloadingIterator():
             info = ['identifier', 'v_HNSW', 'attribute', 'v_HNSW', 'type', 'VECTOR']
             env.assertEqual(index_info(env, 'idx1')['attributes'][0][:len(info)], info)
+
             info_data_HNSW = conn.execute_command(debug_cmd(), "VECSIM_INFO", "idx1", "v_HNSW")
             # replace memory values with a dummy value - irrelevant for the test
             info_data_HNSW[info_data_HNSW.index('MEMORY') + 1] = dummy_val
             info_data_HNSW[info_data_HNSW.index('MANAGEMENT_LAYER_MEMORY') + 1] = dummy_val
+            info_data_HNSW[info_data_HNSW.index('SHARED_MEMORY') + 1] = dummy_val
             front = info_data_HNSW[info_data_HNSW.index('FRONTEND_INDEX') + 1]
             front[front.index('MEMORY') + 1] = dummy_val
             back = info_data_HNSW[info_data_HNSW.index('BACKEND_INDEX') + 1]
@@ -376,6 +379,7 @@ def test_create():
             info_data_FLAT = conn.execute_command(debug_cmd(), "VECSIM_INFO", "idx2", "v_FLAT")
             # replace memory value with a dummy value - irrelevant for the test
             info_data_FLAT[info_data_FLAT.index('MEMORY') + 1] = dummy_val
+            info_data_FLAT[info_data_FLAT.index('SHARED_MEMORY') + 1] = dummy_val
 
             env.assertEqual(info_data_FLAT, expected_FLAT)
 
@@ -387,6 +391,7 @@ def test_create():
                 # replace memory values with a dummy value - irrelevant for the test
                 info_data_SVS_VAMANA[info_data_SVS_VAMANA.index('MEMORY') + 1] = dummy_val
                 info_data_SVS_VAMANA[info_data_SVS_VAMANA.index('MANAGEMENT_LAYER_MEMORY') + 1] = dummy_val
+                info_data_SVS_VAMANA[info_data_SVS_VAMANA.index('SHARED_MEMORY') + 1] = dummy_val
                 front_svs = info_data_SVS_VAMANA[info_data_SVS_VAMANA.index('FRONTEND_INDEX') + 1]
                 front_svs[front_svs.index('MEMORY') + 1] = dummy_val
                 back_svs = info_data_SVS_VAMANA[info_data_SVS_VAMANA.index('BACKEND_INDEX') + 1]

--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -259,6 +259,84 @@ def test_memory_info():
 
         env.execute_command('FLUSHALL')
 
+@skip(cluster=True)
+def test_svs_shared_threadpool_memory_info():
+    """Verify shared SVS thread pool memory accounting:
+      * FT.DEBUG VECSIM_INFO exposes it as the top-level SHARED_MEMORY field
+        (appended once by the VecSim C API wrapper, not inside the nested
+        FRONTEND_INDEX/BACKEND_INDEX sections).
+      * FT.INFO vector_index_sz_mb folds it in once per call (per-spec scope).
+      * INFO MODULES search_used_memory_vector_index folds it in once per call
+        (process-wide scope).
+      * For a single SVS index, both FT.INFO and INFO MODULES report the same
+        bytes — vector field memory + pool memory.
+      * Pool memory is added once per call regardless of the number of vector
+        fields in the spec or specs in the process — no double-counting.
+
+    All observations are validated before and after growing the worker pool, which
+    physically resizes the shared SVS pool.
+    """
+    initial_workers = 1
+    grown_workers = 4
+    env = Env(moduleArgs=f'DEFAULT_DIALECT 2 WORKERS {initial_workers}')
+    dim = 2
+    shared_mem_field = 'SHARED_MEMORY'
+
+    # The shared SVS pool singleton is initialized at module init via
+    # workersThreadPool_CreatePool -> VecSim_UpdateThreadPoolSize, so the field is
+    # always present in the debug info once any SVS index exists.
+    create_vector_index(env, dim, alg='SVS-VAMANA')
+
+    def measure():
+        # SHARED_MEMORY is appended once at the top level by the VecSim C API
+        # wrapper, not inside the nested BACKEND_INDEX/FRONTEND_INDEX sections.
+        debug_info = get_tiered_debug_info(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)
+        env.assertTrue(shared_mem_field in debug_info,
+                       message=f"VECSIM_INFO missing top-level '{shared_mem_field}': {debug_info}")
+        info_modules = env.cmd('INFO', 'MODULES')
+        return {
+            'debug_svs_pool_mem': int(debug_info[shared_mem_field]),
+            'debug_per_index_mem': int(debug_info['MEMORY']),
+            'info_modules_vec_mem': int(info_modules['search_used_memory_vector_index']),
+            'ft_info_vec_bytes': int(float(index_info(env, DEFAULT_INDEX_NAME)['vector_index_sz_mb']) * 0x100000),
+        }
+
+    def assert_invariants(label, m):
+        # FT.INFO and INFO MODULES report the same total for a single SVS field:
+        # per-index memory + pool memory, both folded once.
+        expected = m['debug_per_index_mem'] + m['debug_svs_pool_mem']
+        env.assertEqual(m['ft_info_vec_bytes'], expected,
+                        message=f"[{label}] FT.INFO vector_index_sz_mb should equal per-index + pool: {m}")
+        env.assertEqual(m['info_modules_vec_mem'], expected,
+                        message=f"[{label}] INFO MODULES search_used_memory_vector_index should equal per-index + pool: {m}")
+        env.assertEqual(m['ft_info_vec_bytes'], m['info_modules_vec_mem'],
+                        message=f"[{label}] FT.INFO vector_index_sz_mb should match INFO MODULES "
+                                f"search_used_memory_vector_index: {m}")
+
+    # ---- Initial state ----
+    before = measure()
+    env.assertGreater(before['debug_svs_pool_mem'], 0, message="shared pool memory should be > 0 after pool initialization")
+    assert_invariants('before resize', before)
+
+    # ---- Grow the worker pool ----
+    # CONFIG SET WORKERS triggers VecSim_UpdateThreadPoolSize, which physically
+    # resizes the shared SVS pool (synchronous when no jobs are pending).
+    env.execute_command(config_cmd(), 'SET', 'WORKERS', grown_workers)
+
+    after = measure()
+    env.assertGreater(after['debug_svs_pool_mem'], before['debug_svs_pool_mem'],
+                      message=f"SHARED_MEMORY should grow when workers go from "
+                              f"{initial_workers} to {grown_workers}: before={before}, after={after}")
+    assert_invariants('after resize', after)
+
+    # Both FT.INFO and INFO MODULES vector memory grow by exactly the pool growth
+    # (per-index memory is unchanged by the pool resize).
+    pool_growth = after['debug_svs_pool_mem'] - before['debug_svs_pool_mem']
+    env.assertEqual(after['ft_info_vec_bytes'] - before['ft_info_vec_bytes'], pool_growth,
+                    message=f"FT.INFO vector_index_sz_mb growth should match pool growth: before={before}, after={after}")
+    env.assertEqual(after['info_modules_vec_mem'] - before['info_modules_vec_mem'], pool_growth,
+                    message=f"INFO MODULES search_used_memory_vector_index growth should match pool growth: before={before}, after={after}")
+
 
 func_gen = lambda tn, comp, dt, dist, wr: lambda: queries_sanity(tn, comp, dt, dist, wr)
 for workers in [0, 4]:

--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -20,7 +20,9 @@ from common import (
     waitForIndex,
     SkipTest,
     call_and_store,
-    getWorkersThpoolStats
+    getWorkersThpoolStats,
+    wait_for_condition,
+    skipIfNoEnableAssert,
 )
 
 VECSIM_SVS_DATA_TYPES = ['FLOAT32', 'FLOAT16']
@@ -414,25 +416,18 @@ def change_threads(initial_workers, final_workers):
     env.execute_command(config_cmd(), 'SET', 'WORKERS', final_workers)
     env.assertEqual(int(env.execute_command(config_cmd(), 'GET', 'WORKERS')[0][1]), final_workers, message=message_prefix)
 
-    # TODO: new num_threads should be `final_workers` once VecSim gets notified of RediSearch thread pool changes
-    # last_reserved_num_threads should remain the same as we didn't do any operation
-    verify_num_threads(initial_workers, prev_last_reserved_num_threads, message=f"{message_prefix}, after changing workers to {final_workers}")
+    # VecSim is notified of worker count changes via VecSim_UpdateThreadPoolSize.
+    # NUM_THREADS (shared pool size) should now reflect the new worker count.
+    # last_reserved_num_threads should remain the same as we didn't do any operation.
+    verify_num_threads(final_workers, prev_last_reserved_num_threads, message=f"{message_prefix}, after changing workers to {final_workers}")
 
     # Add more vectors to trigger background indexing
     populate_with_vectors(env, dim=dim, num_docs=update_threshold, datatype='FLOAT32', initial_doc_id=training_threshold + 1)
     wait_for_background_indexing(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME, message=f"{message_prefix}, add more vectors to trigger update")
-    # Since VecSim doesn't get notified when RediSearch worker count changes, when RediSearch worker count changes
-    # svs index continues to request the original number of threads during operations
-    #
-    # The actual thread reservation will be limited by the current RediSearch worker count
-    # - If workers decreased: requested > actual_workers
-    # - If workers increased: requested < actual_workers
-    #
-    # TODO: Expected behavior after VecSim gets worker change notifications:
-    # - num_threads should reflect the current RediSearch worker count
-    # - last_reserved_num_threads should match the actual threads used in operations
-    expected_last_reserved_num_threads = min(final_workers, initial_workers)
-    verify_num_threads(initial_workers, expected_last_reserved_num_threads,
+    # After VecSim gets worker change notifications:
+    # - num_threads reflects the current RediSearch worker count (shared pool size)
+    # - last_reserved_num_threads matches the actual threads used in operations (up to final_workers)
+    verify_num_threads(final_workers, final_workers,
                     message=f"{message_prefix}, after changing workers to {final_workers} and triggering another update job")
 
 def test_change_threads_turn_on():
@@ -624,3 +619,153 @@ def test_gc_no_workers():
     env = Env(moduleArgs=f'DEFAULT_DIALECT 2 FORK_GC_RUN_INTERVAL 1000000 FORK_GC_CLEAN_THRESHOLD 0 WORKERS {num_workers}'
                          f' _FREE_RESOURCE_ON_THREAD FALSE')
     gc_test_common(env, num_workers)
+
+@skip(cluster=True)
+def test_resize_workers_during_pending_svs_jobs():
+    """WORKERS shrink while SVS update jobs are queued behind blocked queries.
+
+    Uses SYNC_POINT to block all worker threads on queries, then adds vectors
+    (SVS update jobs queue behind the blocked queries), then shrinks WORKERS
+    (allowed because the queue is RUNNING, not PAUSED). On signal, queries
+    release, workers resume, and the SVS jobs execute with the resized pool.
+
+    Uses BeforeSpecLock (not BeforeFirstRead) so that blocked workers do NOT
+    hold the spec read lock — this allows the main thread to acquire the spec
+    write lock for HSET / indexing without deadlocking.
+    """
+    initial_workers = 4
+    final_workers = 2
+    env = Env(moduleArgs=f'DEFAULT_DIALECT 2 WORKERS {initial_workers}')
+    skipIfNoEnableAssert(env)
+    training_threshold = DEFAULT_BLOCK_SIZE
+    dim = 2
+    sync_point = 'BeforeSpecLock'
+
+    # Train the index and add a text field for query blocking
+    create_vector_index(env, dim, alg='SVS-vamana', additional_schema_args=['t', 'TEXT'])
+
+    populate_with_vectors(env, dim=dim, num_docs=training_threshold, datatype='FLOAT32')
+    # Add a text value so FT.SEARCH t:hello has something to find
+    env.execute_command('HSET', 'doc1', 't', 'hello')
+    wait_for_background_indexing(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME,
+                                message="training")
+
+    backend_info = get_tiered_backend_debug_info(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)
+    env.assertEqual(backend_info['NUM_THREADS'], initial_workers, message="after training")
+
+    # ARM the sync point — queries will block at BeforeSpecLock (no lock held)
+    env.expect(debug_cmd(), 'SYNC_POINT', 'CLEAR').ok()
+    env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point).ok()
+
+    # Fire initial_workers queries from separate connections to block all workers
+    query_threads = []
+    for _ in range(initial_workers):
+        conn = env.getConnection()
+        results, errors = [], []
+        t = threading.Thread(
+            target=lambda c, r, e: r.append(c.execute_command('FT.SEARCH', DEFAULT_INDEX_NAME, '*', 'NOCONTENT', 'LIMIT', '0', '0')),
+            args=(conn, results, errors),
+            daemon=True
+        )
+        query_threads.append(t)
+        t.start()
+
+    # Wait until all workers are blocked at the sync point.
+    # Each blocked query is a job in progress, so numJobsInProgress == initial_workers
+    # means all workers are occupied and stuck.
+    wait_for_condition(
+        lambda: (getWorkersThpoolStats(env)['numJobsInProgress'] == initial_workers, {}),
+        'Timeout waiting for all workers to reach sync point')
+
+    # All workers are now blocked on queries (without holding spec lock).
+    # Add vectors — SVS update jobs are created (beginScheduledJob snapshots
+    # pool=4) and queued behind the blocked queries.
+    populate_with_vectors(env, dim=dim, num_docs=training_threshold,
+                          datatype='FLOAT32', initial_doc_id=training_threshold + 1)
+
+    # Shrink workers. Queue is RUNNING (not PAUSED), so this succeeds.
+    # VecSim_UpdateThreadPoolSize(2) is called — but since SVS scheduled jobs
+    # are pending (beginScheduledJob was called), the SVS pool shrink is DEFERRED
+    # until endScheduledJob fires.
+    env.execute_command(config_cmd(), 'SET', 'WORKERS', final_workers)
+
+    # Release all blocked queries
+    env.expect(debug_cmd(), 'SYNC_POINT', 'SIGNAL', sync_point).ok()
+
+    # Wait for queries to finish
+    for t in query_threads:
+        t.join(timeout=30)
+
+    # Wait for SVS background indexing to complete
+    wait_for_background_indexing(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME,
+                                message="after resize and signal")
+
+    # Pool size should reflect the new worker count (deferred resize applied)
+    backend_info = get_tiered_backend_debug_info(env, DEFAULT_INDEX_NAME, DEFAULT_FIELD_NAME)
+    env.assertEqual(backend_info['NUM_THREADS'], final_workers,
+                    message="NUM_THREADS should match final workers")
+
+    # Verify search still works
+    query = create_random_np_array_typed(dim, 'FLOAT32')
+    res = env.execute_command('FT.SEARCH', DEFAULT_INDEX_NAME,
+                              f'*=>[KNN 10 @{DEFAULT_FIELD_NAME} $vec_param]',
+                              'PARAMS', 2, 'vec_param', query.tobytes(), 'NOCONTENT')
+    env.assertEqual(res[0], 10, message="KNN search should return results after resize")
+
+@skip(cluster=True)
+def test_multiple_svs_indexes_share_pool():
+    """Two SVS indexes share the same SVS thread pool. Both see the same
+    pool size and both complete operations after a WORKERS resize."""
+    initial_workers = 4
+    final_workers = 2
+    env = Env(moduleArgs=f'DEFAULT_DIALECT 2 WORKERS {initial_workers}')
+    training_threshold = DEFAULT_BLOCK_SIZE
+    dim = 2
+    idx1, idx2 = 'idx1', 'idx2'
+    field = DEFAULT_FIELD_NAME
+
+    # Create two SVS indexes on the same field (both index the same docs)
+    create_vector_index(env, dim, index_name=idx1, field_name=field, alg='SVS-VAMANA')
+    create_vector_index(env, dim, index_name=idx2, field_name=field, alg='SVS-VAMANA')
+
+    # Populate past training threshold
+    populate_with_vectors(env, training_threshold, dim, field_name=field)
+
+    for idx in [idx1, idx2]:
+        wait_for_background_indexing(env, idx, field, message=f"{idx} training")
+
+    # Both should report initial pool size
+    for idx in [idx1, idx2]:
+        info = get_tiered_backend_debug_info(env, idx, field)
+        env.assertEqual(info['NUM_THREADS'], initial_workers,
+                        message=f"{idx} NUM_THREADS before resize")
+
+    # Resize workers
+    env.execute_command(config_cmd(), 'SET', 'WORKERS', final_workers)
+
+    # Both should immediately see the new pool size
+    for idx in [idx1, idx2]:
+        info = get_tiered_backend_debug_info(env, idx, field)
+        env.assertEqual(info['NUM_THREADS'], final_workers,
+                        message=f"{idx} NUM_THREADS after resize")
+
+    # Trigger update jobs on both indexes
+    populate_with_vectors(env, training_threshold, dim, field_name=field,
+                          initial_doc_id=training_threshold + 1)
+
+    for idx in [idx1, idx2]:
+        wait_for_background_indexing(env, idx, field, message=f"{idx} after resize")
+
+    # Both indexes should still report the resized pool
+    for idx in [idx1, idx2]:
+        info = get_tiered_backend_debug_info(env, idx, field)
+        env.assertEqual(info['NUM_THREADS'], final_workers,
+                        message=f"{idx} NUM_THREADS after update")
+
+    # Verify search works on both
+    query = create_random_np_array_typed(dim, 'FLOAT32')
+    for idx in [idx1, idx2]:
+        res = env.execute_command('FT.SEARCH', idx,
+                                  f'*=>[KNN 10 @{field} $vec_param]',
+                                  'PARAMS', 2, 'vec_param', query.tobytes(), 'NOCONTENT')
+        env.assertEqual(res[0], 10, message=f"{idx} KNN search should return results")

--- a/tests/pytests/vecsim_utils.py
+++ b/tests/pytests/vecsim_utils.py
@@ -73,7 +73,17 @@ def get_tiered_backend_debug_info(env, index_name, field_name) -> dict:
     return to_dict(tiered_index_info['BACKEND_INDEX'])
 
 def get_vecsim_memory(env, index_key, field_name):
-    return float(to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", index_key, field_name))["MEMORY"])/0x100000
+    # Returns the vector-related memory in MB for a SINGLE field: the per-index
+    # allocator (MEMORY) plus the process-wide VecSim shared memory (SHARED_MEMORY,
+    # e.g. the shared SVS thread pool).
+    #
+    # NOTE: SHARED_MEMORY is process-wide, so it is included on every call. Do not
+    # sum this across multiple vector fields of the same index/process — that would
+    # count the shared term once per field. Compare per single field only (matching
+    # how FT.INFO vector_index_sz_mb folds the shared term in exactly once).
+    info = to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", index_key, field_name))
+    total = float(info["MEMORY"]) + float(info.get("SHARED_MEMORY", 0))
+    return total / 0x100000
 
 def get_vecsim_index_size(env, index_key, field_name):
     return int(to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", index_key, field_name))["INDEX_SIZE"])


### PR DESCRIPTION
## Describe the changes in the pull request

Backport of [#8956](https://github.com/RediSearch/RediSearch/pull/8956) to `8.6-rse`, fixing per-index SVS OS thread explosion (a workload creating many SVS indexes can exhaust the OS thread limit).

1. **Current:** Each SVS index created its own thread pool sized at index creation time. RediSearch toggled `VecSim_SetWriteMode()` on worker pool activation/deactivation, but never notified VecSim when `WORKERS` was dynamically resized — so the SVS pool size would drift out of sync, and K indexes meant K×N OS threads.
2. **Change:** Call the new `VecSim_UpdateThreadPoolSize()` API on pool creation and whenever `WORKERS` changes, replacing the old ad-hoc `VecSim_SetWriteMode()` toggling. Stop setting the deprecated `SVSParams::num_threads`. Support global (no per-index context) VecSim log messages. Requires the companion VecSim backport (VectorSimilarity#998, MOD-17089) which introduces the shared thread pool.
3. **Outcome:** The shared SVS thread pool always matches the RediSearch worker count. All SVS indexes share the same pool (N threads total, not K×N).

#### Which additional issues this PR fixes
1. MOD-17089
2. #8956 (original PR on `master`)

#### Main objects this PR modified
1. `deps/VectorSimilarity` — bumped submodule to include shared pool refactor (VectorSimilarity#998)
2. `src/module-init/module-init.c` — moved VecSim callback registration before worker pool init
3. `src/util/workers.c` — replaced `VecSim_SetWriteMode()` with `VecSim_UpdateThreadPoolSize()` on pool create and resize
4. `src/spec.c` — stopped setting deprecated `SVSParams::num_threads`
5. `src/vector_index.c` — added support for global VecSim log messages (NULL context)
6. `src/aggregate/aggregate_exec.c` — added `BeforeSpecLock` debug sync point
7. `tests/pytests/test_vecsim_svs.py` — tests for shared pool resizing and multi-index pool sharing

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

**Enhancement**: SVS-VAMANA vector indexes now share a single global thread pool that automatically adjusts its size when the `WORKERS` configuration is changed at runtime, replacing the previous per-index thread pool approach — fixing OS thread exhaustion with many SVS indexes.

---

Clean cherry-pick from `master` (`f2fcc2f6`), no code changes needed — only conflict was the submodule pointer, now repointed to the merged VecSim `8.6` tip (VectorSimilarity#998, merged via rebase). Full unit test suite + `test_vecsim_svs.py` rerun green after the repoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up commit

CI (`test_vecsim.py:test_create`) failed on the initial push: VectorSimilarity#972 (part of the cherry-pick chain above) adds a `SHARED_MEMORY` field to every VecSim index's debug-info output — unconditional, all algorithm types, not SVS-specific — which broke this repo's pre-existing hardcoded field-list assertions.

Fixed by cherry-picking master's own fix for this: `9c40bd221` (#9858, MOD-15578). Did not apply clean — this branch's `src/info/info_command.c` has diverged (disk-index support that doesn't exist on master) — resolved by keeping this branch's own surrounding code and applying only #9858's actual net change (`vector_indexes_size += VecSim_GetSharedMemory()`). Rebuilt, full C unit suite green again, `test_vecsim.py` + `test_vecsim_svs.py` rerun 93/93 pass.
