### PR TITLE
Move TCP/TLS detection to the main thread, where we construct the new topology - [MOD-15869]

### DIFF
--- a/src/coord/rmr/cluster_topology.c
+++ b/src/coord/rmr/cluster_topology.c
@@ -11,6 +11,7 @@
 #include "endpoint.h"
 #include "rmalloc.h"
 #include "slot_ranges.h"
+#include "config.h"
 #include "rmutil/rm_assert.h"
 
 #include <arpa/inet.h>
@@ -70,6 +71,9 @@ MRClusterTopology *MRClusterTopology_FromAPI(RedisModuleCtx *ctx, const char *au
 
   bool saw_myself = false;
 
+  // Assume all ports are TLS ports according to the `tls-cluster` config.
+  bool is_tls = getRedisConfigBool(ctx, "tls-cluster", false);
+
   // Topology can contain at most one entry per node; replicas and slot-less
   // masters will be skipped, so this is an upper bound on the final size.
   MRClusterTopology *topo = MR_NewTopology(numNodes);
@@ -109,6 +113,7 @@ MRClusterTopology *MRClusterTopology_FromAPI(RedisModuleCtx *ctx, const char *au
       .endpoint = (MREndpoint){
         .host = rm_strdup(ip),
         .port = port,
+        .isTls = is_tls,
         .unixSock = NULL,
         .password = (auth && auth_len > 0) ? rm_strndup(auth, auth_len) : NULL,
       },

--- a/src/coord/rmr/cluster_topology.c
+++ b/src/coord/rmr/cluster_topology.c
@@ -71,7 +71,8 @@ MRClusterTopology *MRClusterTopology_FromAPI(RedisModuleCtx *ctx, const char *au
 
   bool saw_myself = false;
 
-  // Assume all ports are TLS ports according to the `tls-cluster` config.
+  // The port RedisModule_GetClusterNodeInfo is a TLS/TCP port depending on the `tls-cluster` config.
+  // TODO: Improve the API to return the endpoint type (TLS/TCP) instead of relying on this logic mirroring
   bool is_tls = getRedisConfigBool(ctx, "tls-cluster", false);
 
   // Topology can contain at most one entry per node; replicas and slot-less

--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -555,19 +555,9 @@ error:
 extern RedisModuleCtx *RSDummyContext;
 static int checkTLS(RedisModuleString **client_key, RedisModuleString **client_cert,
                     RedisModuleString **ca_cert, RedisModuleString **key_pass) {
-  int ret = 1;
+  int ret = REDIS_OK;
   RedisModuleCtx *ctx = RSDummyContext;
   RedisModule_ThreadSafeContextLock(ctx);
-
-  // On OSS, the cluster topology module API returns the regular client port
-  // when `tls-cluster` is disabled, even if `tls-port` is also configured.
-  // Enterprise still uses the proxy port and should keep the tls-port fallback.
-  if (!getRedisConfigBool(ctx, "tls-cluster", false)) {
-    if (!IsEnterprise() || getRedisConfigNumeric(ctx, "tls-port", 0) == 0) {
-      ret = 0;
-      goto done;
-    }
-  }
 
   *client_key = getRedisConfigValue(ctx, "tls-key-file");
   *client_cert = getRedisConfigValue(ctx, "tls-cert-file");
@@ -575,7 +565,7 @@ static int checkTLS(RedisModuleString **client_key, RedisModuleString **client_c
   *key_pass = getRedisConfigValue(ctx, "tls-key-file-pass");
 
   if (!*client_key || !*client_cert || !*ca_cert){
-    ret = 0;
+    ret = REDIS_ERR;
     if(*client_key){
       RedisModule_FreeString(ctx, *client_key);
       *client_key = NULL;
@@ -594,7 +584,6 @@ static int checkTLS(RedisModuleString **client_key, RedisModuleString **client_c
     }
   }
 
-done:
   RedisModule_ThreadSafeContextUnlock(ctx);
   return ret;
 }
@@ -604,9 +593,13 @@ done:
  * "TLS not configured", which is a no-op) and REDIS_ERR on any setup failure;
  * a warning is logged on failure. The caller owns the ac on failure. */
 static int MRConn_InitTLS(MRConn *conn) {
-  RedisModuleString *client_cert = NULL, *client_key = NULL, *ca_cert = NULL, *key_file_pass = NULL;
-  if (!checkTLS(&client_key, &client_cert, &ca_cert, &key_file_pass)) {
+  if (conn->ep.isTls == false) {
     return REDIS_OK;
+  }
+
+  RedisModuleString *client_cert = NULL, *client_key = NULL, *ca_cert = NULL, *key_file_pass = NULL;
+  if (checkTLS(&client_key, &client_cert, &ca_cert, &key_file_pass) == REDIS_ERR) {
+    return REDIS_ERR;
   }
 
   redisSSLContextError ssl_error = 0;

--- a/src/coord/rmr/endpoint.c
+++ b/src/coord/rmr/endpoint.c
@@ -95,6 +95,7 @@ bool MREndpoint_Equal(const MREndpoint *a, const MREndpoint *b) {
   if (a == b) return true;
   if (!a || !b) return false;
   return a->port == b->port
+      && a->isTls == b->isTls
       && strEqOrBothNull(a->host, b->host)
       && strEqOrBothNull(a->unixSock, b->unixSock)
       && strEqOrBothNull(a->password, b->password);

--- a/src/coord/rmr/endpoint.h
+++ b/src/coord/rmr/endpoint.h
@@ -19,11 +19,13 @@ extern "C" {
 typedef struct MREndpoint {
   char *host;
   int port;
+  bool isTls;
   char *unixSock;
   char *password;
 } MREndpoint;
 
-/* Parse a TCP address into an endpoint, in the format of host:port */
+/* Parse a TCP address into an endpoint, in the format of host:port.
+   The port is assumed to be a TCP port (isTls is always false) */
 int MREndpoint_Parse(const char *addr, MREndpoint *ep);
 
 /* Copy the endpoint's internal strings so freeing it will not hurt another copy of it */

--- a/src/coord/rmr/redise.c
+++ b/src/coord/rmr/redise.c
@@ -123,8 +123,10 @@ MRClusterTopology *RedisEnterprise_ParseTopology(RedisModuleCtx *ctx, RedisModul
   uint32_t numRanges = 0;                  // Mandatory. No default.
   uint32_t numSlots = 16384;               // Default.
 
-  // Assume all ports are TLS ports according to the `tls-cluster` config.
-  bool is_tls = getRedisConfigBool(ctx, "tls-cluster", false);
+  // Determine if we should use TLS ports based on the `tls-cluster` config, and whether our `tls-port` is set.
+  // This is the legacy logic on enterprise, even though `tls-cluster` should always be `yes` if the `tls-port` is set.
+  // Dual port is not expected in legacy enterprise, so `tls-port` indicates that the cluster ports should be TLS.
+  bool is_tls = getRedisConfigBool(ctx, "tls-cluster", false) || getRedisConfigNumeric(ctx, "tls-port", 0) != 0;
 
   // Parse general arguments. No allocation is done here, so we can just return on error
   while (!AC_IsAtEnd(&ac)) {

--- a/src/coord/rmr/redise.c
+++ b/src/coord/rmr/redise.c
@@ -10,6 +10,7 @@
 #include "rmalloc.h"
 #include "rmutil/args.h"
 #include "slot_ranges.h"
+#include "config.h"
 #include <strings.h>
 
 typedef struct {
@@ -122,6 +123,9 @@ MRClusterTopology *RedisEnterprise_ParseTopology(RedisModuleCtx *ctx, RedisModul
   uint32_t numRanges = 0;                  // Mandatory. No default.
   uint32_t numSlots = 16384;               // Default.
 
+  // Assume all ports are TLS ports according to the `tls-cluster` config.
+  bool is_tls = getRedisConfigBool(ctx, "tls-cluster", false);
+
   // Parse general arguments. No allocation is done here, so we can just return on error
   while (!AC_IsAtEnd(&ac)) {
     if (AC_AdvanceIfMatch(&ac, "MYID")) {
@@ -227,6 +231,7 @@ MRClusterTopology *RedisEnterprise_ParseTopology(RedisModuleCtx *ctx, RedisModul
           ERROR_BADVAL("ADDR", addr);
           goto error;
         }
+        sh->node.endpoint.isTls = is_tls;
 
       } else if (AC_AdvanceIfMatch(&ac, "UNIXADDR")) {
         /* Optional UNIXADDR <unix_addr> */

--- a/tests/cpptests/redismock/redismock.cpp
+++ b/tests/cpptests/redismock/redismock.cpp
@@ -1686,6 +1686,14 @@ void RMCK_KeyMetaUnlink(RedisModuleKeyMetaClassId classId, uint64_t *meta) {
   it->second.unlink(nullptr, meta);
 }
 
+int RMCK_ConfigGetBool(RedisModuleCtx *ctx, const char *name, int *res) {
+  if (strcmp(name, "tls-cluster") == 0) {
+    *res = 0; // Simulate that tls-cluster is disabled
+    return REDISMODULE_OK;
+  }
+  return REDISMODULE_ERR; // Unknown config
+}
+
 static void registerApis() {
   REGISTER_API(GetApi);
   REGISTER_API(Alloc);
@@ -1823,6 +1831,9 @@ static void registerApis() {
   REGISTER_API(GetKeyMeta);
   REGISTER_API(SetKeyMeta);
   REGISTER_API(ClearKeyMeta);
+
+  // Config
+  REGISTER_API(ConfigGetBool);
 }
 
 static int RMCK_GetApi(const char *s, void *pp) {

--- a/tests/cpptests/redismock/redismock.cpp
+++ b/tests/cpptests/redismock/redismock.cpp
@@ -1687,8 +1687,16 @@ void RMCK_KeyMetaUnlink(RedisModuleKeyMetaClassId classId, uint64_t *meta) {
 }
 
 int RMCK_ConfigGetBool(RedisModuleCtx *ctx, const char *name, int *res) {
-  if (strcmp(name, "tls-cluster") == 0) {
+  if (!strcmp(name, "tls-cluster")) {
     *res = 0; // Simulate that tls-cluster is disabled
+    return REDISMODULE_OK;
+  }
+  return REDISMODULE_ERR; // Unknown config
+}
+
+int RMCK_ConfigGetNumeric(RedisModuleCtx *ctx, const char *name, long long *res) {
+  if (!strcmp(name, "tls-port")) {
+    *res = 0; // Simulate that tls-port is not set
     return REDISMODULE_OK;
   }
   return REDISMODULE_ERR; // Unknown config
@@ -1834,6 +1842,7 @@ static void registerApis() {
 
   // Config
   REGISTER_API(ConfigGetBool);
+  REGISTER_API(ConfigGetNumeric);
 }
 
 static int RMCK_GetApi(const char *s, void *pp) {


### PR DESCRIPTION
## Describe the changes in the pull request

Add a new `isTls` attribute to `MREndpoint` to record the port type when we construct the endpoint instead of later from the background.

This also allows more flexible logic for what the type of the port is, if the logic diverges based on the topology source.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes