### PR TITLE
MOD-17092 FT.HYBRID: forward PARAMS/TIMEOUT from parsed state, not argv re-scan

### DIFF
--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -277,7 +277,7 @@ static void MRCommand_appendVsim(MRCommand *xcmd, RedisModuleString **argv,
 // present) counted inside the block, so shards of any version parse it and never
 // fall back on their own (possibly different) defaults.
 static void MRCommand_appendCombine(MRCommand *xcmd, const HybridCombineWireParams *cp) {
-  if (!cp || !cp->scoringCtx) {
+  if (!cp->scoringCtx) {
     return;
   }
   const HybridScoringContext *sc = cp->scoringCtx;
@@ -355,22 +355,20 @@ static void MRCommand_appendParams(MRCommand *xcmd, dict *params) {
 }
 
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
-                            ProfileOptions profileOptions,
-                            bool sendExplainScore,
-                            const HybridCombineWireParams *combineParams,
-                            dict *params, bool forwardTimeout, long long timeoutMS,
-                            MRCommand *xcmd, arrayof(char*) serialized,
-                            IndexSpec *sp, int *outKArgIndex) {
+                                  const HybridShardWireParams *shardWireParams,
+                                  MRCommand *xcmd,
+                                  arrayof(char *) serialized, IndexSpec *sp, int *outKArgIndex) {
+  RS_ASSERT(shardWireParams != NULL);
   RS_ASSERT(outKArgIndex != NULL);
   const char *index_name = RedisModule_StringPtrLen(argv[1], NULL);
 
   int cmdArgCount = 2;
   const char *cmdArgs[5] = {"_FT.HYBRID", index_name};
 
-  if (profileOptions != EXEC_NO_FLAGS) {
+  if (shardWireParams->profileOptions != EXEC_NO_FLAGS) {
     cmdArgs[0] = "_FT.PROFILE";
     cmdArgs[cmdArgCount++] = "HYBRID";
-    if (profileOptions & EXEC_WITH_PROFILE_LIMITED) {
+    if (shardWireParams->profileOptions & EXEC_WITH_PROFILE_LIMITED) {
       cmdArgs[cmdArgCount++] = "LIMITED";
     }
     cmdArgs[cmdArgCount++] = "QUERY";
@@ -397,7 +395,7 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
   // each shard falling back on its own (possibly changed) defaults. This also
   // normalizes the positional YIELD_SCORE_AS form and a zero argument count
   // into the counted form that all shard versions accept.
-  MRCommand_appendCombine(xcmd, combineParams);
+  MRCommand_appendCombine(xcmd, &shardWireParams->combine);
 
   if (serialized) {
     for (size_t ii = 0; ii < array_len(serialized); ++ii) {
@@ -407,13 +405,13 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
   }
 
   // Reconstruct the PARAMS clause from the resolved parameter dictionary.
-  MRCommand_appendParams(xcmd, params);
+  MRCommand_appendParams(xcmd, shardWireParams->params);
 
   // Forward the client's query timeout when TIMEOUT was set.
-  if (forwardTimeout) {
+  if (shardWireParams->forwardTimeout) {
     char numBuf[HYBRID_NUM_BUF_SIZE];
     MRCommand_Append(xcmd, "TIMEOUT", strlen("TIMEOUT"));
-    int len = snprintf(numBuf, sizeof(numBuf), "%lld", timeoutMS);
+    int len = snprintf(numBuf, sizeof(numBuf), "%lld", shardWireParams->timeoutMS);
     MRCommand_Append(xcmd, numBuf, len);
   }
 
@@ -422,7 +420,7 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
 
   // Forward EXPLAINSCORE so the shard's text scorer produces an RSScoreExplain
   // tree and the shard's merger wraps it.
-  if (sendExplainScore) {
+  if (shardWireParams->sendExplainScore) {
     MRCommand_Append(xcmd, "EXPLAINSCORE", strlen("EXPLAINSCORE"));
   }
 
@@ -757,14 +755,20 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     setupCoordinatorArrangeSteps(hreq->requests[SEARCH_INDEX], hreq->requests[VECTOR_INDEX], &hybridParams);
     RLookup *lookups[HYBRID_REQUEST_NUM_SUBQUERIES] = {0};
 
-    // Capture the resolved COMBINE parameters now, before BuildDistributedPipeline
-    // hands scoringCtx ownership to the merger and nulls the local pointer. The
-    // scoring context object itself is kept alive by the merger, so borrowing it
-    // here is safe. Used to reconstruct an old-shard-compatible COMBINE clause
-    // when building the per-shard command below.
-    HybridCombineWireParams combineParams = {
-        .scoringCtx = hybridParams.scoringCtx,
-        .scoreAlias = hybridParams.aggregationParams.common.scoreAlias,
+    // Capture the parsed state forwarded to the shards, used to build the
+    // per-shard command below. This must happen here, before
+    // BuildDistributedPipeline hands scoringCtx ownership to the merger and nulls
+    // the local pointer: `combine` reconstructs an old-shard-compatible COMBINE
+    // clause from it. The scoring context object itself is kept alive by the
+    // merger, so borrowing it here is safe.
+    HybridShardWireParams shardWireParams = {
+        .profileOptions = profileOptions,
+        .sendExplainScore = (hreq->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) != 0,
+        .combine = {.scoringCtx = hybridParams.scoringCtx,
+                    .scoreAlias = hybridParams.aggregationParams.common.scoreAlias},
+        .params = cmd.search->searchopts.params,
+        .forwardTimeout = cmd.timeoutSpecified,
+        .timeoutMS = cmd.clientTimeoutMS,
     };
 
     arrayof(char*) serialized = HybridRequest_BuildDistributedPipeline(hreq, &hybridParams, lookups, status);
@@ -775,12 +779,8 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
 
     // Construct the command string.
     MRCommand xcmd;
-    bool sendExplainScore = (hreq->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) != 0;
-    dict *params = cmd.search->searchopts.params;
-    HybridRequest_buildMRCommand(argv, argc, profileOptions, sendExplainScore,
-                                 &combineParams, params, cmd.timeoutSpecified,
-                                 cmd.clientTimeoutMS,
-                                 &xcmd, serialized, sp, &hreq->kArgIndex);
+    HybridRequest_buildMRCommand(argv, argc, &shardWireParams, &xcmd, serialized, sp,
+                                 &hreq->kArgIndex);
 
     xcmd.protocol = HYBRID_RESP_PROTOCOL_VERSION;
     xcmd.forCursor = hreq->reqflags & QEXEC_F_IS_CURSOR;

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -69,6 +69,15 @@ struct ConcurrentCmdCtx;
 // We mainly need the resp protocol to be three in order to easily extract the "score" key from the response
 #define HYBRID_RESP_PROTOCOL_VERSION 3
 
+// Scratch buffer for formatting one numeric argument before appending it to an
+// MRCommand. 25 is the exact minimum: the widest output below, plus its NUL.
+//   %.17g  -DBL_MAX   "-1.7976931348623157e+308"  24  RRF CONSTANT, LINEAR ALPHA/BETA
+//   %lld   INT64_MIN  "-9223372036854775808"      20  TIMEOUT
+//   %zu    SIZE_MAX   "18446744073709551615"      20  WINDOW
+//   %lu    ULONG_MAX  "18446744073709551615"      20  PARAMS count
+//   %d     (literal)  "8"                          1  COMBINE argument count
+#define HYBRID_NUM_BUF_SIZE 25
+
 /**
  * Appends all SEARCH-related arguments to MR command.
  * This includes SEARCH keyword, query, and optional SCORER and YIELD_SCORE_AS parameters
@@ -273,7 +282,7 @@ static void MRCommand_appendCombine(MRCommand *xcmd, const HybridCombineWirePara
   }
   const HybridScoringContext *sc = cp->scoringCtx;
   const bool hasAlias = cp->scoreAlias != NULL;
-  char numBuf[32];
+  char numBuf[HYBRID_NUM_BUF_SIZE];
   const size_t numBufSize = sizeof(numBuf);
   int n;
 
@@ -327,17 +336,17 @@ static void MRCommand_appendParams(MRCommand *xcmd, dict *params) {
   if (n == 0) {
     return;
   }
-  char numBuf[32];
+  char numBuf[HYBRID_NUM_BUF_SIZE];
   MRCommand_Append(xcmd, "PARAMS", strlen("PARAMS"));
   int len = snprintf(numBuf, sizeof(numBuf), "%lu", n * 2);
   MRCommand_Append(xcmd, numBuf, len);
 
   dictIterator *it = dictGetIterator(params);
-  dictEntry *entry;
+  const dictEntry *entry;
   while ((entry = dictNext(it))) {
     const char *name = dictGetKey(entry);
     MRCommand_Append(xcmd, name, strlen(name));
-    RedisModuleString *value = dictGetVal(entry);
+    const RedisModuleString *value = dictGetVal(entry);
     size_t valueLen;
     const char *valueData = RedisModule_StringPtrLen(value, &valueLen);
     MRCommand_Append(xcmd, valueData, valueLen);
@@ -402,7 +411,7 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
 
   // Forward the client's query timeout when TIMEOUT was set.
   if (forwardTimeout) {
-    char numBuf[32];
+    char numBuf[HYBRID_NUM_BUF_SIZE];
     MRCommand_Append(xcmd, "TIMEOUT", strlen("TIMEOUT"));
     int len = snprintf(numBuf, sizeof(numBuf), "%lld", timeoutMS);
     MRCommand_Append(xcmd, numBuf, len);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -43,6 +43,7 @@
 #include "aggregate/aggregate.h"
 #include "aggregate/aggregate_plan.h"
 #include "obfuscation/hidden_unicode.h"
+#include "param.h"
 #include "pipeline/pipeline.h"
 #include "query_error.h"
 #include "query_error_ffi.h"
@@ -309,19 +310,49 @@ static void MRCommand_appendCombine(MRCommand *xcmd, const HybridCombineWirePara
   }
 }
 
-// The function transforms FT.HYBRID index SEARCH query VSIM field vector
-// into _FT.HYBRID index SEARCH query VSIM field vector WITHCURSOR
-// _NUM_SSTRING _INDEX_PREFIXES ...
-// stores the index of the K value argument in the MRCommand (for later
-// modification by the command modifier callback in SHARD_K_RATIO optimization).
+/**
+ * Reconstructs the PARAMS clause from the resolved parameter dictionary rather
+ * than re-scanning argv for the "PARAMS" keyword. The emitted order is the
+ * dict-iteration order, which is not necessarily the client's original argument
+ * order; this is safe because parameters are referenced by name.
+ *
+ * @param xcmd - destination MR command to append arguments to
+ * @param params - resolved parameter dictionary (key: name, value: RedisModuleString)
+ */
+static void MRCommand_appendParams(MRCommand *xcmd, dict *params) {
+  if (!params) {
+    return;
+  }
+  unsigned long n = dictSize(params);
+  if (n == 0) {
+    return;
+  }
+  char numBuf[32];
+  MRCommand_Append(xcmd, "PARAMS", strlen("PARAMS"));
+  int len = snprintf(numBuf, sizeof(numBuf), "%lu", n * 2);
+  MRCommand_Append(xcmd, numBuf, len);
+
+  dictIterator *it = dictGetIterator(params);
+  dictEntry *entry;
+  while ((entry = dictNext(it))) {
+    const char *name = dictGetKey(entry);
+    MRCommand_Append(xcmd, name, strlen(name));
+    RedisModuleString *value = dictGetVal(entry);
+    size_t valueLen;
+    const char *valueData = RedisModule_StringPtrLen(value, &valueLen);
+    MRCommand_Append(xcmd, valueData, valueLen);
+  }
+  dictReleaseIterator(it);
+}
+
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             bool sendExplainScore,
                             const HybridCombineWireParams *combineParams,
+                            dict *params, bool forwardTimeout, long long timeoutMS,
                             MRCommand *xcmd, arrayof(char*) serialized,
                             IndexSpec *sp, int *outKArgIndex) {
   RS_ASSERT(outKArgIndex != NULL);
-  int argOffset;
   const char *index_name = RedisModule_StringPtrLen(argv[1], NULL);
 
   int cmdArgCount = 2;
@@ -366,45 +397,19 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
     }
   }
 
-  // Add PARAMS arguments if present
-  argOffset = RMUtil_ArgIndex("PARAMS", argv + vsimOffset, argc - vsimOffset);
-  argOffset = argOffset != -1 ? argOffset + vsimOffset : -1;
-  if (argOffset != -1) {
-    long long nargs;
-    int rc = RedisModule_StringToLongLong(argv[argOffset + 1], &nargs);
+  // Reconstruct the PARAMS clause from the resolved parameter dictionary.
+  MRCommand_appendParams(xcmd, params);
 
-    // PARAMS keyword and count - treat as string
-    MRCommand_AppendRstr(xcmd, argv[argOffset]);
-    MRCommand_AppendRstr(xcmd, argv[argOffset + 1]);
-
-    // append params string including PARAMS keyword and nargs
-    for (int i = 2; i < nargs + 2; ++i) {
-      if (i % 2 == 0) {
-        // Parameter name - treat as string
-        MRCommand_AppendRstr(xcmd, argv[argOffset + i]);
-      } else {
-        // Parameter value - could be binary, treat as binary
-        size_t valueLen;
-        const char *valueData = RedisModule_StringPtrLen(argv[argOffset + i], &valueLen);
-        MRCommand_Append(xcmd, valueData, valueLen);
-      }
-    }
+  // Forward the client's query timeout when TIMEOUT was set.
+  if (forwardTimeout) {
+    char numBuf[32];
+    MRCommand_Append(xcmd, "TIMEOUT", strlen("TIMEOUT"));
+    int len = snprintf(numBuf, sizeof(numBuf), "%lld", timeoutMS);
+    MRCommand_Append(xcmd, numBuf, len);
   }
 
-  // check for timeout argument and append it to the command.
-  // If TIMEOUT exists, it was already validated at AREQ_Compile.
-  argOffset = RMUtil_ArgIndex("TIMEOUT", argv, argc);
-  if (argOffset != -1) {
-    MRCommand_AppendRstr(xcmd, argv[argOffset]);
-    MRCommand_AppendRstr(xcmd, argv[argOffset + 1]);
-  }
-
-  // Add DIALECT arguments if present
-  argOffset = RMUtil_ArgIndex("DIALECT", argv, argc);
-  if (argOffset != -1) {
-    MRCommand_AppendRstr(xcmd, argv[argOffset]);
-    MRCommand_AppendRstr(xcmd, argv[argOffset + 1]);
-  }
+  // DIALECT is deliberately not forwarded: FT.HYBRID rejects it at parse time,
+  // so a valid command never carries one and there is nothing to relay.
 
   // Forward EXPLAINSCORE so the shard's text scorer produces an RSScoreExplain
   // tree and the shard's merger wraps it.
@@ -759,11 +764,14 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
       return REDISMODULE_ERR;
     }
 
-    // Construct the command string
+    // Construct the command string.
     MRCommand xcmd;
     bool sendExplainScore = (hreq->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) != 0;
+    dict *params = cmd.search->searchopts.params;
     HybridRequest_buildMRCommand(argv, argc, profileOptions, sendExplainScore,
-                                 &combineParams, &xcmd, serialized, sp, &hreq->kArgIndex);
+                                 &combineParams, params, cmd.timeoutSpecified,
+                                 cmd.clientTimeoutMS,
+                                 &xcmd, serialized, sp, &hreq->kArgIndex);
 
     xcmd.protocol = HYBRID_RESP_PROTOCOL_VERSION;
     xcmd.forCursor = hreq->reqflags & QEXEC_F_IS_CURSOR;

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -277,7 +277,7 @@ static void MRCommand_appendVsim(MRCommand *xcmd, RedisModuleString **argv,
 // present) counted inside the block, so shards of any version parse it and never
 // fall back on their own (possibly different) defaults.
 static void MRCommand_appendCombine(MRCommand *xcmd, const HybridCombineWireParams *cp) {
-  if (!cp || !cp->scoringCtx) {
+  if (!cp->scoringCtx) {
     return;
   }
   const HybridScoringContext *sc = cp->scoringCtx;
@@ -355,12 +355,10 @@ static void MRCommand_appendParams(MRCommand *xcmd, dict *params) {
 }
 
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
-                            ProfileOptions profileOptions,
-                            bool sendExplainScore,
-                            const HybridCombineWireParams *combineParams,
-                            dict *params, bool forwardTimeout, long long timeoutMS,
-                            MRCommand *xcmd, arrayof(char*) serialized,
-                            IndexSpec *sp, int *outKArgIndex) {
+                                  const HybridShardWireParams *shardWireParams,
+                                  MRCommand *xcmd,
+                                  arrayof(char *) serialized, IndexSpec *sp, int *outKArgIndex) {
+  RS_ASSERT(shardWireParams != NULL);
   RS_ASSERT(outKArgIndex != NULL);
   size_t index_name_len;
   const char *index_name = RedisModule_StringPtrLen(argv[1], &index_name_len);
@@ -369,12 +367,12 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
   const char *cmdArgs[5] = {"_FT.HYBRID", index_name};
   size_t cmdLens[5] = {sizeof("_FT.HYBRID") - 1, index_name_len};
 
-  if (profileOptions != EXEC_NO_FLAGS) {
+  if (shardWireParams->profileOptions != EXEC_NO_FLAGS) {
     cmdArgs[0] = "_FT.PROFILE";
     cmdLens[0] = sizeof("_FT.PROFILE") - 1;
     cmdArgs[cmdArgCount] = "HYBRID";
     cmdLens[cmdArgCount++] = sizeof("HYBRID") - 1;
-    if (profileOptions & EXEC_WITH_PROFILE_LIMITED) {
+    if (shardWireParams->profileOptions & EXEC_WITH_PROFILE_LIMITED) {
       cmdArgs[cmdArgCount] = "LIMITED";
       cmdLens[cmdArgCount++] = sizeof("LIMITED") - 1;
     }
@@ -403,7 +401,7 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
   // each shard falling back on its own (possibly changed) defaults. This also
   // normalizes the positional YIELD_SCORE_AS form and a zero argument count
   // into the counted form that all shard versions accept.
-  MRCommand_appendCombine(xcmd, combineParams);
+  MRCommand_appendCombine(xcmd, &shardWireParams->combine);
 
   if (serialized) {
     for (size_t ii = 0; ii < array_len(serialized); ++ii) {
@@ -413,13 +411,13 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
   }
 
   // Reconstruct the PARAMS clause from the resolved parameter dictionary.
-  MRCommand_appendParams(xcmd, params);
+  MRCommand_appendParams(xcmd, shardWireParams->params);
 
   // Forward the client's query timeout when TIMEOUT was set.
-  if (forwardTimeout) {
+  if (shardWireParams->forwardTimeout) {
     char numBuf[HYBRID_NUM_BUF_SIZE];
     MRCommand_Append(xcmd, "TIMEOUT", strlen("TIMEOUT"));
-    int len = snprintf(numBuf, sizeof(numBuf), "%lld", timeoutMS);
+    int len = snprintf(numBuf, sizeof(numBuf), "%lld", shardWireParams->timeoutMS);
     MRCommand_Append(xcmd, numBuf, len);
   }
 
@@ -428,7 +426,7 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
 
   // Forward EXPLAINSCORE so the shard's text scorer produces an RSScoreExplain
   // tree and the shard's merger wraps it.
-  if (sendExplainScore) {
+  if (shardWireParams->sendExplainScore) {
     MRCommand_AppendLiteral(xcmd, "EXPLAINSCORE");
   }
 
@@ -759,14 +757,20 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     setupCoordinatorArrangeSteps(hreq->requests[SEARCH_INDEX], hreq->requests[VECTOR_INDEX], &hybridParams);
     RLookup *lookups[HYBRID_REQUEST_NUM_SUBQUERIES] = {0};
 
-    // Capture the resolved COMBINE parameters now, before BuildDistributedPipeline
-    // hands scoringCtx ownership to the merger and nulls the local pointer. The
-    // scoring context object itself is kept alive by the merger, so borrowing it
-    // here is safe. Used to reconstruct an old-shard-compatible COMBINE clause
-    // when building the per-shard command below.
-    HybridCombineWireParams combineParams = {
-        .scoringCtx = hybridParams.scoringCtx,
-        .scoreAlias = hybridParams.aggregationParams.common.scoreAlias,
+    // Capture the parsed state forwarded to the shards, used to build the
+    // per-shard command below. This must happen here, before
+    // BuildDistributedPipeline hands scoringCtx ownership to the merger and nulls
+    // the local pointer: `combine` reconstructs an old-shard-compatible COMBINE
+    // clause from it. The scoring context object itself is kept alive by the
+    // merger, so borrowing it here is safe.
+    HybridShardWireParams shardWireParams = {
+        .profileOptions = profileOptions,
+        .sendExplainScore = (hreq->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) != 0,
+        .combine = {.scoringCtx = hybridParams.scoringCtx,
+                    .scoreAlias = hybridParams.aggregationParams.common.scoreAlias},
+        .params = cmd.search->searchopts.params,
+        .forwardTimeout = cmd.timeoutSpecified,
+        .timeoutMS = cmd.clientTimeoutMS,
     };
 
     arrayof(char*) serialized = HybridRequest_BuildDistributedPipeline(hreq, &hybridParams, lookups, status);
@@ -777,12 +781,8 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
 
     // Construct the command string.
     MRCommand xcmd;
-    bool sendExplainScore = (hreq->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) != 0;
-    dict *params = cmd.search->searchopts.params;
-    HybridRequest_buildMRCommand(argv, argc, profileOptions, sendExplainScore,
-                                 &combineParams, params, cmd.timeoutSpecified,
-                                 cmd.clientTimeoutMS,
-                                 &xcmd, serialized, sp, &hreq->kArgIndex);
+    HybridRequest_buildMRCommand(argv, argc, &shardWireParams, &xcmd, serialized, sp,
+                                 &hreq->kArgIndex);
 
     xcmd.protocol = HYBRID_RESP_PROTOCOL_VERSION;
     xcmd.forCursor = hreq->reqflags & QEXEC_F_IS_CURSOR;

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -43,6 +43,7 @@
 #include "aggregate/aggregate.h"
 #include "aggregate/aggregate_plan.h"
 #include "obfuscation/hidden_unicode.h"
+#include "param.h"
 #include "pipeline/pipeline.h"
 #include "query_error.h"
 #include "query_error_ffi.h"
@@ -309,19 +310,49 @@ static void MRCommand_appendCombine(MRCommand *xcmd, const HybridCombineWirePara
   }
 }
 
-// The function transforms FT.HYBRID index SEARCH query VSIM field vector
-// into _FT.HYBRID index SEARCH query VSIM field vector WITHCURSOR
-// _NUM_SSTRING _INDEX_PREFIXES ...
-// stores the index of the K value argument in the MRCommand (for later
-// modification by the command modifier callback in SHARD_K_RATIO optimization).
+/**
+ * Reconstructs the PARAMS clause from the resolved parameter dictionary rather
+ * than re-scanning argv for the "PARAMS" keyword. The emitted order is the
+ * dict-iteration order, which is not necessarily the client's original argument
+ * order; this is safe because parameters are referenced by name.
+ *
+ * @param xcmd - destination MR command to append arguments to
+ * @param params - resolved parameter dictionary (key: name, value: RedisModuleString)
+ */
+static void MRCommand_appendParams(MRCommand *xcmd, dict *params) {
+  if (!params) {
+    return;
+  }
+  unsigned long n = dictSize(params);
+  if (n == 0) {
+    return;
+  }
+  char numBuf[32];
+  MRCommand_Append(xcmd, "PARAMS", strlen("PARAMS"));
+  int len = snprintf(numBuf, sizeof(numBuf), "%lu", n * 2);
+  MRCommand_Append(xcmd, numBuf, len);
+
+  dictIterator *it = dictGetIterator(params);
+  dictEntry *entry;
+  while ((entry = dictNext(it))) {
+    const char *name = dictGetKey(entry);
+    MRCommand_Append(xcmd, name, strlen(name));
+    RedisModuleString *value = dictGetVal(entry);
+    size_t valueLen;
+    const char *valueData = RedisModule_StringPtrLen(value, &valueLen);
+    MRCommand_Append(xcmd, valueData, valueLen);
+  }
+  dictReleaseIterator(it);
+}
+
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             bool sendExplainScore,
                             const HybridCombineWireParams *combineParams,
+                            dict *params, bool forwardTimeout, long long timeoutMS,
                             MRCommand *xcmd, arrayof(char*) serialized,
                             IndexSpec *sp, int *outKArgIndex) {
   RS_ASSERT(outKArgIndex != NULL);
-  int argOffset;
   size_t index_name_len;
   const char *index_name = RedisModule_StringPtrLen(argv[1], &index_name_len);
 
@@ -372,45 +403,19 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
     }
   }
 
-  // Add PARAMS arguments if present
-  argOffset = RMUtil_ArgIndex("PARAMS", argv + vsimOffset, argc - vsimOffset);
-  argOffset = argOffset != -1 ? argOffset + vsimOffset : -1;
-  if (argOffset != -1) {
-    long long nargs;
-    int rc = RedisModule_StringToLongLong(argv[argOffset + 1], &nargs);
+  // Reconstruct the PARAMS clause from the resolved parameter dictionary.
+  MRCommand_appendParams(xcmd, params);
 
-    // PARAMS keyword and count - treat as string
-    MRCommand_AppendRstr(xcmd, argv[argOffset]);
-    MRCommand_AppendRstr(xcmd, argv[argOffset + 1]);
-
-    // append params string including PARAMS keyword and nargs
-    for (int i = 2; i < nargs + 2; ++i) {
-      if (i % 2 == 0) {
-        // Parameter name - treat as string
-        MRCommand_AppendRstr(xcmd, argv[argOffset + i]);
-      } else {
-        // Parameter value - could be binary, treat as binary
-        size_t valueLen;
-        const char *valueData = RedisModule_StringPtrLen(argv[argOffset + i], &valueLen);
-        MRCommand_Append(xcmd, valueData, valueLen);
-      }
-    }
+  // Forward the client's query timeout when TIMEOUT was set.
+  if (forwardTimeout) {
+    char numBuf[32];
+    MRCommand_Append(xcmd, "TIMEOUT", strlen("TIMEOUT"));
+    int len = snprintf(numBuf, sizeof(numBuf), "%lld", timeoutMS);
+    MRCommand_Append(xcmd, numBuf, len);
   }
 
-  // check for timeout argument and append it to the command.
-  // If TIMEOUT exists, it was already validated at AREQ_Compile.
-  argOffset = RMUtil_ArgIndex("TIMEOUT", argv, argc);
-  if (argOffset != -1) {
-    MRCommand_AppendRstr(xcmd, argv[argOffset]);
-    MRCommand_AppendRstr(xcmd, argv[argOffset + 1]);
-  }
-
-  // Add DIALECT arguments if present
-  argOffset = RMUtil_ArgIndex("DIALECT", argv, argc);
-  if (argOffset != -1) {
-    MRCommand_AppendRstr(xcmd, argv[argOffset]);
-    MRCommand_AppendRstr(xcmd, argv[argOffset + 1]);
-  }
+  // DIALECT is deliberately not forwarded: FT.HYBRID rejects it at parse time,
+  // so a valid command never carries one and there is nothing to relay.
 
   // Forward EXPLAINSCORE so the shard's text scorer produces an RSScoreExplain
   // tree and the shard's merger wraps it.
@@ -761,11 +766,14 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
       return REDISMODULE_ERR;
     }
 
-    // Construct the command string
+    // Construct the command string.
     MRCommand xcmd;
     bool sendExplainScore = (hreq->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) != 0;
+    dict *params = cmd.search->searchopts.params;
     HybridRequest_buildMRCommand(argv, argc, profileOptions, sendExplainScore,
-                                 &combineParams, &xcmd, serialized, sp, &hreq->kArgIndex);
+                                 &combineParams, params, cmd.timeoutSpecified,
+                                 cmd.clientTimeoutMS,
+                                 &xcmd, serialized, sp, &hreq->kArgIndex);
 
     xcmd.protocol = HYBRID_RESP_PROTOCOL_VERSION;
     xcmd.forCursor = hreq->reqflags & QEXEC_F_IS_CURSOR;

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -69,6 +69,15 @@ struct ConcurrentCmdCtx;
 // We mainly need the resp protocol to be three in order to easily extract the "score" key from the response
 #define HYBRID_RESP_PROTOCOL_VERSION 3
 
+// Scratch buffer for formatting one numeric argument before appending it to an
+// MRCommand. 25 is the exact minimum: the widest output below, plus its NUL.
+//   %.17g  -DBL_MAX   "-1.7976931348623157e+308"  24  RRF CONSTANT, LINEAR ALPHA/BETA
+//   %lld   INT64_MIN  "-9223372036854775808"      20  TIMEOUT
+//   %zu    SIZE_MAX   "18446744073709551615"      20  WINDOW
+//   %lu    ULONG_MAX  "18446744073709551615"      20  PARAMS count
+//   %d     (literal)  "8"                          1  COMBINE argument count
+#define HYBRID_NUM_BUF_SIZE 25
+
 /**
  * Appends all SEARCH-related arguments to MR command.
  * This includes SEARCH keyword, query, and optional SCORER and YIELD_SCORE_AS parameters
@@ -273,7 +282,7 @@ static void MRCommand_appendCombine(MRCommand *xcmd, const HybridCombineWirePara
   }
   const HybridScoringContext *sc = cp->scoringCtx;
   const bool hasAlias = cp->scoreAlias != NULL;
-  char numBuf[32];
+  char numBuf[HYBRID_NUM_BUF_SIZE];
   const size_t numBufSize = sizeof(numBuf);
   int n;
 
@@ -327,17 +336,17 @@ static void MRCommand_appendParams(MRCommand *xcmd, dict *params) {
   if (n == 0) {
     return;
   }
-  char numBuf[32];
+  char numBuf[HYBRID_NUM_BUF_SIZE];
   MRCommand_Append(xcmd, "PARAMS", strlen("PARAMS"));
   int len = snprintf(numBuf, sizeof(numBuf), "%lu", n * 2);
   MRCommand_Append(xcmd, numBuf, len);
 
   dictIterator *it = dictGetIterator(params);
-  dictEntry *entry;
+  const dictEntry *entry;
   while ((entry = dictNext(it))) {
     const char *name = dictGetKey(entry);
     MRCommand_Append(xcmd, name, strlen(name));
-    RedisModuleString *value = dictGetVal(entry);
+    const RedisModuleString *value = dictGetVal(entry);
     size_t valueLen;
     const char *valueData = RedisModule_StringPtrLen(value, &valueLen);
     MRCommand_Append(xcmd, valueData, valueLen);
@@ -408,7 +417,7 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
 
   // Forward the client's query timeout when TIMEOUT was set.
   if (forwardTimeout) {
-    char numBuf[32];
+    char numBuf[HYBRID_NUM_BUF_SIZE];
     MRCommand_Append(xcmd, "TIMEOUT", strlen("TIMEOUT"));
     int len = snprintf(numBuf, sizeof(numBuf), "%lld", timeoutMS);
     MRCommand_Append(xcmd, numBuf, len);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -277,6 +277,7 @@ static void MRCommand_appendVsim(MRCommand *xcmd, RedisModuleString **argv,
 // present) counted inside the block, so shards of any version parse it and never
 // fall back on their own (possibly different) defaults.
 static void MRCommand_appendCombine(MRCommand *xcmd, const HybridCombineWireParams *cp) {
+  RS_ASSERT(cp != NULL);
   if (!cp->scoringCtx) {
     return;
   }
@@ -420,9 +421,6 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
     int len = snprintf(numBuf, sizeof(numBuf), "%lld", shardWireParams->timeoutMS);
     MRCommand_Append(xcmd, numBuf, len);
   }
-
-  // DIALECT is deliberately not forwarded: FT.HYBRID rejects it at parse time,
-  // so a valid command never carries one and there is nothing to relay.
 
   // Forward EXPLAINSCORE so the shard's text scorer produces an RSScoreExplain
   // tree and the shard's merger wraps it.

--- a/src/coord/hybrid/dist_hybrid.h
+++ b/src/coord/hybrid/dist_hybrid.h
@@ -40,11 +40,28 @@ int DistHybridTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv,
 int DistHybridTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int DistHybridReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
-// For testing purposes
+struct dict;  // forward decl (see util/dict/dict.h): the resolved PARAMS dict
+
+// Builds the per-shard MR command from the coordinator's parsed hybrid request.
+// The function transforms
+//   FT.HYBRID index SEARCH query VSIM field vector
+// into
+//   _FT.HYBRID index SEARCH query VSIM field vector WITHCURSOR _NUM_SSTRING
+//   _INDEX_PREFIXES ...
+// and stores the index of the K value argument in the MRCommand (via
+// outKArgIndex) for later modification by the command modifier callback in the
+// SHARD_K_RATIO optimization.
+//
+// The PARAMS/TIMEOUT clauses are reconstructed from parsed state:
+//   - params: the resolved parameter dictionary.
+//   - forwardTimeout/timeoutMS: when forwardTimeout is true, TIMEOUT <timeoutMS>
+//     is appended.
+// DIALECT is never forwarded (FT.HYBRID rejects it at parse time).
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             bool sendExplainScore,
                             const HybridCombineWireParams *combineParams,
+                            struct dict *params, bool forwardTimeout, long long timeoutMS,
                             MRCommand *xcmd, arrayof(char*) serialized,
                             IndexSpec *sp, int *outKArgIndex);
 

--- a/src/coord/hybrid/dist_hybrid.h
+++ b/src/coord/hybrid/dist_hybrid.h
@@ -42,6 +42,20 @@ int DistHybridReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 
 struct dict;  // forward decl (see util/dict/dict.h): the resolved PARAMS dict
 
+// Coordinator-resolved state that HybridRequest_buildMRCommand forwards to the
+// shards.
+typedef struct {
+  ProfileOptions profileOptions;
+  bool sendExplainScore;
+  HybridCombineWireParams combine;
+  // Resolved parameter dictionary, or NULL when the client supplied no PARAMS.
+  struct dict *params;
+  // TIMEOUT forwarding: when forwardTimeout is true, TIMEOUT <timeoutMS> is
+  // appended.
+  bool forwardTimeout;
+  long long timeoutMS;
+} HybridShardWireParams;
+
 // Builds the per-shard MR command from the coordinator's parsed hybrid request.
 // The function transforms
 //   FT.HYBRID index SEARCH query VSIM field vector
@@ -52,18 +66,12 @@ struct dict;  // forward decl (see util/dict/dict.h): the resolved PARAMS dict
 // outKArgIndex) for later modification by the command modifier callback in the
 // SHARD_K_RATIO optimization.
 //
-// The PARAMS/TIMEOUT clauses are reconstructed from parsed state:
-//   - params: the resolved parameter dictionary.
-//   - forwardTimeout/timeoutMS: when forwardTimeout is true, TIMEOUT <timeoutMS>
-//     is appended.
-// DIALECT is never forwarded (FT.HYBRID rejects it at parse time).
+// argv/argc are the raw client command; `shardWireParams` (required, non-NULL) carries the
+// parsed state to forward. DIALECT is never forwarded (FT.HYBRID rejects it at
+// parse time).
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
-                            ProfileOptions profileOptions,
-                            bool sendExplainScore,
-                            const HybridCombineWireParams *combineParams,
-                            struct dict *params, bool forwardTimeout, long long timeoutMS,
-                            MRCommand *xcmd, arrayof(char*) serialized,
-                            IndexSpec *sp, int *outKArgIndex);
+                                  const HybridShardWireParams *shardWireParams, MRCommand *xcmd,
+                                  arrayof(char *) serialized, IndexSpec *sp, int *outKArgIndex);
 
 #ifdef __cplusplus
 }

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -868,6 +868,12 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
     goto error;
   }
 
+  // Record whether TIMEOUT was explicitly given, and capture the client's value
+  // BEFORE the foreground-timeout cap below, so the coordinator can forward the
+  // exact client timeout to shards without re-scanning argv.
+  parsedCmdCtx->timeoutSpecified = (hybridParseCtx.specifiedArgs & SPECIFIED_ARG_TIMEOUT) != 0;
+  parsedCmdCtx->clientTimeoutMS = parsedCmdCtx->reqConfig->queryTimeoutMS;
+
   // Cap the effective query timeout to search-_max-foreground-timeout-limit
   // when the limit is active. The hybrid request shares a single reqConfig
   // that is later copied into both subqueries through copyHybridConfigToSubquery.

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -881,6 +881,12 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
     goto error;
   }
 
+  // Record whether TIMEOUT was explicitly given, and capture the client's value
+  // BEFORE the foreground-timeout cap below, so the coordinator can forward the
+  // exact client timeout to shards without re-scanning argv.
+  parsedCmdCtx->timeoutSpecified = (hybridParseCtx.specifiedArgs & SPECIFIED_ARG_TIMEOUT) != 0;
+  parsedCmdCtx->clientTimeoutMS = parsedCmdCtx->reqConfig->queryTimeoutMS;
+
   // Cap the effective query timeout to search-_max-foreground-timeout-limit
   // when the limit is active. The hybrid request shares a single reqConfig
   // that is later copied into both subqueries through copyHybridConfigToSubquery.

--- a/src/hybrid/parse_hybrid.h
+++ b/src/hybrid/parse_hybrid.h
@@ -37,6 +37,10 @@ typedef struct ParseHybridCommandCtx {
     RequestConfig* reqConfig;
     CursorConfig* cursorConfig;
     rs_wall_clock_ns_t *coordDispatchTime; // Coordinator dispatch time for internal commands
+
+    // Whether the client explicitly supplied TIMEOUT, and the value it gave.
+    bool timeoutSpecified;
+    long long clientTimeoutMS;
 } ParseHybridCommandCtx;
 
 // Function for parsing hybrid command arguments - exposed for testing

--- a/src/module.c
+++ b/src/module.c
@@ -3767,8 +3767,7 @@ int DistAggregateTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **ar
 int DistAggregateTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 // Forward declaration for initQueryTimeout (defined later in file)
-static int initQueryTimeout(size_t *timeout, int timeoutArgIdx, RedisModuleString **argv,
-                            int argc, QueryError *status);
+static int initQueryTimeout(size_t *timeout, RedisModuleString **argv, int argc, QueryError *status);
 
 /** Debug */
 void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
@@ -3845,8 +3844,7 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   // Early TIMEOUT argument parsing, required for block-client timeout.
   size_t queryTimeoutMS;
   QueryError status = QueryError_Default();
-  if (initQueryTimeout(&queryTimeoutMS, RMUtil_ArgIndex("TIMEOUT", argv, argc),
-                       argv, argc, &status) != REDISMODULE_OK) {
+  if (initQueryTimeout(&queryTimeoutMS, argv, argc, &status) != REDISMODULE_OK) {
     QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&status), 1, COORD_ERR_WARN);
     return QueryError_ReplyAndClear(ctx, &status);
   }
@@ -3893,29 +3891,6 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 
   return ConcurrentSearch_HandleRedisCommandEx(DIST_THREADPOOL, dist_callback, ctx, argv, argc,
                                                &handlerCtx);
-}
-
-// Locate the client's top-level TIMEOUT option in an FT.HYBRID argument vector.
-// Returns the index of the TIMEOUT keyword, or -1 if none is present.
-static int HybridTimeoutArgIndex(RedisModuleString **argv, int argc) {
-  for (int i = 0; i < argc; i++) {
-    size_t len;
-    const char *arg = RedisModule_StringPtrLen(argv[i], &len);
-    if (len == strlen("YIELD_SCORE_AS") && !strncasecmp(arg, "YIELD_SCORE_AS", len)) {
-      i++;  // the following token is a user alias, never a keyword
-    } else if (len == strlen("PARAMS") && !strncasecmp(arg, "PARAMS", len)) {
-      // PARAMS <count> <count tokens>: skip the count and its arguments so a
-      // parameter named or valued "TIMEOUT" is not mistaken for the keyword.
-      long long nargs;
-      if (i + 1 < argc && RedisModule_StringToLongLong(argv[i + 1], &nargs) == REDISMODULE_OK &&
-          nargs > 0 && nargs <= (long long)(argc - i - 2)) {
-        i += 1 + (int)nargs;  // skip the count token and its nargs parameter tokens
-      }
-    } else if (len == strlen("TIMEOUT") && !strncasecmp(arg, "TIMEOUT", len)) {
-      return i;
-    }
-  }
-  return -1;
 }
 
 int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
@@ -3975,12 +3950,10 @@ int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int
     return ReplyBlockDeny(ctx, argv[0]);
   }
 
-  // Parse timeout from command args. Use a hybrid-aware scan so a YIELD_SCORE_AS
-  // alias or PARAMS entry spelled "TIMEOUT" is not mistaken for the keyword.
+  // Parse timeout from command args
   size_t queryTimeoutMS;
   QueryError status = QueryError_Default();
-  if (initQueryTimeout(&queryTimeoutMS, HybridTimeoutArgIndex(argv, argc),
-                       argv, argc, &status) != REDISMODULE_OK) {
+  if (initQueryTimeout(&queryTimeoutMS, argv, argc, &status) != REDISMODULE_OK) {
     QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&status), 1, COORD_ERR_WARN);
     return QueryError_ReplyAndClear(ctx, &status);
   }
@@ -4449,12 +4422,12 @@ typedef void (*BlockedClientFreePrivDataCB) (RedisModuleCtx *ctx, void *privdata
 // The value is also silently capped to search-_max-foreground-timeout-limit
 // when the limit is active; AREQ_Compile sets the QEXEC_S_MAX_TIMEOUT_CAPPED
 // flag on its own request, which is what surfaces the warning to the user.
-static int initQueryTimeout(size_t *timeout, int timeoutArgIdx, RedisModuleString **argv,
-                            int argc, QueryError *status) {
+static int initQueryTimeout(size_t *timeout, RedisModuleString **argv, int argc, QueryError *status) {
   RS_ASSERT(timeout != NULL);
 
   *timeout = RSGlobalConfig.requestConfigParams.queryTimeoutMS;
 
+  int timeoutArgIdx = RMUtil_ArgIndex("TIMEOUT", argv, argc);
   if (timeoutArgIdx >= 0) {
     timeoutArgIdx++;
     ArgsCursor ac;
@@ -4661,8 +4634,7 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   // Early TIMEOUT argument parsing, required for DistSearchBlockClientWithTimeout.
   size_t queryTimeoutMS;
   QueryError status = QueryError_Default();
-  if (initQueryTimeout(&queryTimeoutMS, RMUtil_ArgIndex("TIMEOUT", argv, argc),
-                       argv, argc, &status) != REDISMODULE_OK) {
+  if (initQueryTimeout(&queryTimeoutMS, argv, argc, &status) != REDISMODULE_OK) {
     QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&status), 1, COORD_ERR_WARN);
     return QueryError_ReplyAndClear(ctx, &status);
   }

--- a/src/module.c
+++ b/src/module.c
@@ -3767,7 +3767,8 @@ int DistAggregateTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **ar
 int DistAggregateTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 // Forward declaration for initQueryTimeout (defined later in file)
-static int initQueryTimeout(size_t *timeout, RedisModuleString **argv, int argc, QueryError *status);
+static int initQueryTimeout(size_t *timeout, int timeoutArgIdx, RedisModuleString **argv,
+                            int argc, QueryError *status);
 
 /** Debug */
 void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
@@ -3844,7 +3845,8 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   // Early TIMEOUT argument parsing, required for block-client timeout.
   size_t queryTimeoutMS;
   QueryError status = QueryError_Default();
-  if (initQueryTimeout(&queryTimeoutMS, argv, argc, &status) != REDISMODULE_OK) {
+  if (initQueryTimeout(&queryTimeoutMS, RMUtil_ArgIndex("TIMEOUT", argv, argc),
+                       argv, argc, &status) != REDISMODULE_OK) {
     QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&status), 1, COORD_ERR_WARN);
     return QueryError_ReplyAndClear(ctx, &status);
   }
@@ -3891,6 +3893,29 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 
   return ConcurrentSearch_HandleRedisCommandEx(DIST_THREADPOOL, dist_callback, ctx, argv, argc,
                                                &handlerCtx);
+}
+
+// Locate the client's top-level TIMEOUT option in an FT.HYBRID argument vector.
+// Returns the index of the TIMEOUT keyword, or -1 if none is present.
+static int HybridTimeoutArgIndex(RedisModuleString **argv, int argc) {
+  for (int i = 0; i < argc; i++) {
+    size_t len;
+    const char *arg = RedisModule_StringPtrLen(argv[i], &len);
+    if (len == strlen("YIELD_SCORE_AS") && !strncasecmp(arg, "YIELD_SCORE_AS", len)) {
+      i++;  // the following token is a user alias, never a keyword
+    } else if (len == strlen("PARAMS") && !strncasecmp(arg, "PARAMS", len)) {
+      // PARAMS <count> <count tokens>: skip the count and its arguments so a
+      // parameter named or valued "TIMEOUT" is not mistaken for the keyword.
+      long long nargs;
+      if (i + 1 < argc && RedisModule_StringToLongLong(argv[i + 1], &nargs) == REDISMODULE_OK &&
+          nargs > 0 && nargs <= (long long)(argc - i - 2)) {
+        i += 1 + (int)nargs;  // skip the count token and its nargs parameter tokens
+      }
+    } else if (len == strlen("TIMEOUT") && !strncasecmp(arg, "TIMEOUT", len)) {
+      return i;
+    }
+  }
+  return -1;
 }
 
 int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
@@ -3950,10 +3975,12 @@ int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int
     return ReplyBlockDeny(ctx, argv[0]);
   }
 
-  // Parse timeout from command args
+  // Parse timeout from command args. Use a hybrid-aware scan so a YIELD_SCORE_AS
+  // alias or PARAMS entry spelled "TIMEOUT" is not mistaken for the keyword.
   size_t queryTimeoutMS;
   QueryError status = QueryError_Default();
-  if (initQueryTimeout(&queryTimeoutMS, argv, argc, &status) != REDISMODULE_OK) {
+  if (initQueryTimeout(&queryTimeoutMS, HybridTimeoutArgIndex(argv, argc),
+                       argv, argc, &status) != REDISMODULE_OK) {
     QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&status), 1, COORD_ERR_WARN);
     return QueryError_ReplyAndClear(ctx, &status);
   }
@@ -4422,12 +4449,12 @@ typedef void (*BlockedClientFreePrivDataCB) (RedisModuleCtx *ctx, void *privdata
 // The value is also silently capped to search-_max-foreground-timeout-limit
 // when the limit is active; AREQ_Compile sets the QEXEC_S_MAX_TIMEOUT_CAPPED
 // flag on its own request, which is what surfaces the warning to the user.
-static int initQueryTimeout(size_t *timeout, RedisModuleString **argv, int argc, QueryError *status) {
+static int initQueryTimeout(size_t *timeout, int timeoutArgIdx, RedisModuleString **argv,
+                            int argc, QueryError *status) {
   RS_ASSERT(timeout != NULL);
 
   *timeout = RSGlobalConfig.requestConfigParams.queryTimeoutMS;
 
-  int timeoutArgIdx = RMUtil_ArgIndex("TIMEOUT", argv, argc);
   if (timeoutArgIdx >= 0) {
     timeoutArgIdx++;
     ArgsCursor ac;
@@ -4634,7 +4661,8 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   // Early TIMEOUT argument parsing, required for DistSearchBlockClientWithTimeout.
   size_t queryTimeoutMS;
   QueryError status = QueryError_Default();
-  if (initQueryTimeout(&queryTimeoutMS, argv, argc, &status) != REDISMODULE_OK) {
+  if (initQueryTimeout(&queryTimeoutMS, RMUtil_ArgIndex("TIMEOUT", argv, argc),
+                       argv, argc, &status) != REDISMODULE_OK) {
     QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&status), 1, COORD_ERR_WARN);
     return QueryError_ReplyAndClear(ctx, &status);
   }

--- a/src/module.c
+++ b/src/module.c
@@ -3789,7 +3789,8 @@ int DistAggregateTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **ar
 int DistAggregateTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 // Forward declaration for initQueryTimeout (defined later in file)
-static int initQueryTimeout(size_t *timeout, RedisModuleString **argv, int argc, QueryError *status);
+static int initQueryTimeout(size_t *timeout, int timeoutArgIdx, RedisModuleString **argv,
+                            int argc, QueryError *status);
 
 /** Debug */
 void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
@@ -3866,7 +3867,8 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   // Early TIMEOUT argument parsing, required for block-client timeout.
   size_t queryTimeoutMS;
   QueryError status = QueryError_Default();
-  if (initQueryTimeout(&queryTimeoutMS, argv, argc, &status) != REDISMODULE_OK) {
+  if (initQueryTimeout(&queryTimeoutMS, RMUtil_ArgIndex("TIMEOUT", argv, argc),
+                       argv, argc, &status) != REDISMODULE_OK) {
     QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&status), 1, COORD_ERR_WARN);
     return QueryError_ReplyAndClear(ctx, &status);
   }
@@ -3915,6 +3917,29 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 
   return ConcurrentSearch_HandleRedisCommandEx(DIST_THREADPOOL, dist_callback, ctx, argv, argc,
                                                &handlerCtx);
+}
+
+// Locate the client's top-level TIMEOUT option in an FT.HYBRID argument vector.
+// Returns the index of the TIMEOUT keyword, or -1 if none is present.
+static int HybridTimeoutArgIndex(RedisModuleString **argv, int argc) {
+  for (int i = 0; i < argc; i++) {
+    size_t len;
+    const char *arg = RedisModule_StringPtrLen(argv[i], &len);
+    if (len == strlen("YIELD_SCORE_AS") && !strncasecmp(arg, "YIELD_SCORE_AS", len)) {
+      i++;  // the following token is a user alias, never a keyword
+    } else if (len == strlen("PARAMS") && !strncasecmp(arg, "PARAMS", len)) {
+      // PARAMS <count> <count tokens>: skip the count and its arguments so a
+      // parameter named or valued "TIMEOUT" is not mistaken for the keyword.
+      long long nargs;
+      if (i + 1 < argc && RedisModule_StringToLongLong(argv[i + 1], &nargs) == REDISMODULE_OK &&
+          nargs > 0 && nargs <= (long long)(argc - i - 2)) {
+        i += 1 + (int)nargs;  // skip the count token and its nargs parameter tokens
+      }
+    } else if (len == strlen("TIMEOUT") && !strncasecmp(arg, "TIMEOUT", len)) {
+      return i;
+    }
+  }
+  return -1;
 }
 
 int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
@@ -3974,10 +3999,12 @@ int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int
     return ReplyBlockDeny(ctx, argv[0]);
   }
 
-  // Parse timeout from command args
+  // Parse timeout from command args. Use a hybrid-aware scan so a YIELD_SCORE_AS
+  // alias or PARAMS entry spelled "TIMEOUT" is not mistaken for the keyword.
   size_t queryTimeoutMS;
   QueryError status = QueryError_Default();
-  if (initQueryTimeout(&queryTimeoutMS, argv, argc, &status) != REDISMODULE_OK) {
+  if (initQueryTimeout(&queryTimeoutMS, HybridTimeoutArgIndex(argv, argc),
+                       argv, argc, &status) != REDISMODULE_OK) {
     QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&status), 1, COORD_ERR_WARN);
     return QueryError_ReplyAndClear(ctx, &status);
   }
@@ -4448,12 +4475,12 @@ typedef void (*BlockedClientFreePrivDataCB) (RedisModuleCtx *ctx, void *privdata
 // The value is also silently capped to search-_max-foreground-timeout-limit
 // when the limit is active; AREQ_Compile sets the QEXEC_S_MAX_TIMEOUT_CAPPED
 // flag on its own request, which is what surfaces the warning to the user.
-static int initQueryTimeout(size_t *timeout, RedisModuleString **argv, int argc, QueryError *status) {
+static int initQueryTimeout(size_t *timeout, int timeoutArgIdx, RedisModuleString **argv,
+                            int argc, QueryError *status) {
   RS_ASSERT(timeout != NULL);
 
   *timeout = RSGlobalConfig.requestConfigParams.queryTimeoutMS;
 
-  int timeoutArgIdx = RMUtil_ArgIndex("TIMEOUT", argv, argc);
   if (timeoutArgIdx >= 0) {
     timeoutArgIdx++;
     ArgsCursor ac;
@@ -4660,7 +4687,8 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   // Early TIMEOUT argument parsing, required for DistSearchBlockClientWithTimeout.
   size_t queryTimeoutMS;
   QueryError status = QueryError_Default();
-  if (initQueryTimeout(&queryTimeoutMS, argv, argc, &status) != REDISMODULE_OK) {
+  if (initQueryTimeout(&queryTimeoutMS, RMUtil_ArgIndex("TIMEOUT", argv, argc),
+                       argv, argc, &status) != REDISMODULE_OK) {
     QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&status), 1, COORD_ERR_WARN);
     return QueryError_ReplyAndClear(ctx, &status);
   }

--- a/src/module.c
+++ b/src/module.c
@@ -3789,8 +3789,7 @@ int DistAggregateTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **ar
 int DistAggregateTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 // Forward declaration for initQueryTimeout (defined later in file)
-static int initQueryTimeout(size_t *timeout, int timeoutArgIdx, RedisModuleString **argv,
-                            int argc, QueryError *status);
+static int initQueryTimeout(size_t *timeout, RedisModuleString **argv, int argc, QueryError *status);
 
 /** Debug */
 void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
@@ -3867,8 +3866,7 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   // Early TIMEOUT argument parsing, required for block-client timeout.
   size_t queryTimeoutMS;
   QueryError status = QueryError_Default();
-  if (initQueryTimeout(&queryTimeoutMS, RMUtil_ArgIndex("TIMEOUT", argv, argc),
-                       argv, argc, &status) != REDISMODULE_OK) {
+  if (initQueryTimeout(&queryTimeoutMS, argv, argc, &status) != REDISMODULE_OK) {
     QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&status), 1, COORD_ERR_WARN);
     return QueryError_ReplyAndClear(ctx, &status);
   }
@@ -3917,29 +3915,6 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 
   return ConcurrentSearch_HandleRedisCommandEx(DIST_THREADPOOL, dist_callback, ctx, argv, argc,
                                                &handlerCtx);
-}
-
-// Locate the client's top-level TIMEOUT option in an FT.HYBRID argument vector.
-// Returns the index of the TIMEOUT keyword, or -1 if none is present.
-static int HybridTimeoutArgIndex(RedisModuleString **argv, int argc) {
-  for (int i = 0; i < argc; i++) {
-    size_t len;
-    const char *arg = RedisModule_StringPtrLen(argv[i], &len);
-    if (len == strlen("YIELD_SCORE_AS") && !strncasecmp(arg, "YIELD_SCORE_AS", len)) {
-      i++;  // the following token is a user alias, never a keyword
-    } else if (len == strlen("PARAMS") && !strncasecmp(arg, "PARAMS", len)) {
-      // PARAMS <count> <count tokens>: skip the count and its arguments so a
-      // parameter named or valued "TIMEOUT" is not mistaken for the keyword.
-      long long nargs;
-      if (i + 1 < argc && RedisModule_StringToLongLong(argv[i + 1], &nargs) == REDISMODULE_OK &&
-          nargs > 0 && nargs <= (long long)(argc - i - 2)) {
-        i += 1 + (int)nargs;  // skip the count token and its nargs parameter tokens
-      }
-    } else if (len == strlen("TIMEOUT") && !strncasecmp(arg, "TIMEOUT", len)) {
-      return i;
-    }
-  }
-  return -1;
 }
 
 int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
@@ -3999,12 +3974,10 @@ int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int
     return ReplyBlockDeny(ctx, argv[0]);
   }
 
-  // Parse timeout from command args. Use a hybrid-aware scan so a YIELD_SCORE_AS
-  // alias or PARAMS entry spelled "TIMEOUT" is not mistaken for the keyword.
+  // Parse timeout from command args
   size_t queryTimeoutMS;
   QueryError status = QueryError_Default();
-  if (initQueryTimeout(&queryTimeoutMS, HybridTimeoutArgIndex(argv, argc),
-                       argv, argc, &status) != REDISMODULE_OK) {
+  if (initQueryTimeout(&queryTimeoutMS, argv, argc, &status) != REDISMODULE_OK) {
     QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&status), 1, COORD_ERR_WARN);
     return QueryError_ReplyAndClear(ctx, &status);
   }
@@ -4475,12 +4448,12 @@ typedef void (*BlockedClientFreePrivDataCB) (RedisModuleCtx *ctx, void *privdata
 // The value is also silently capped to search-_max-foreground-timeout-limit
 // when the limit is active; AREQ_Compile sets the QEXEC_S_MAX_TIMEOUT_CAPPED
 // flag on its own request, which is what surfaces the warning to the user.
-static int initQueryTimeout(size_t *timeout, int timeoutArgIdx, RedisModuleString **argv,
-                            int argc, QueryError *status) {
+static int initQueryTimeout(size_t *timeout, RedisModuleString **argv, int argc, QueryError *status) {
   RS_ASSERT(timeout != NULL);
 
   *timeout = RSGlobalConfig.requestConfigParams.queryTimeoutMS;
 
+  int timeoutArgIdx = RMUtil_ArgIndex("TIMEOUT", argv, argc);
   if (timeoutArgIdx >= 0) {
     timeoutArgIdx++;
     ArgsCursor ac;
@@ -4687,8 +4660,7 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   // Early TIMEOUT argument parsing, required for DistSearchBlockClientWithTimeout.
   size_t queryTimeoutMS;
   QueryError status = QueryError_Default();
-  if (initQueryTimeout(&queryTimeoutMS, RMUtil_ArgIndex("TIMEOUT", argv, argc),
-                       argv, argc, &status) != REDISMODULE_OK) {
+  if (initQueryTimeout(&queryTimeoutMS, argv, argc, &status) != REDISMODULE_OK) {
     QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&status), 1, COORD_ERR_WARN);
     return QueryError_ReplyAndClear(ctx, &status);
   }

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -15,12 +15,115 @@
 
 #include "dist_hybrid.h"
 #include "hybrid/hybrid_scoring.h"
+#include "param.h"
 
 #include <string>
 #include <string_view>
 #include <vector>
+#include <set>
+#include <utility>
 
 #define TEST_BLOB_DATA "AQIDBAUGBwgJCg=="
+
+using ParamList = std::vector<std::pair<std::string, std::string>>;
+using PairSet = std::set<std::pair<std::string, std::string>>;
+
+// Copy an MRCommand's args into a binary-safe token vector (each token carries
+// its explicit length, so embedded NULs survive).
+static std::vector<std::string> toTokens(const MRCommand *cmd) {
+  std::vector<std::string> toks;
+  toks.reserve(cmd->num);
+  for (int i = 0; i < cmd->num; i++) toks.emplace_back(cmd->strs[i], cmd->lens[i]);
+  return toks;
+}
+
+// Count output tokens exactly matching `tok` (case-insensitive).
+static int countTok(const std::vector<std::string> &toks, std::string_view tok) {
+  int n = 0;
+  for (const auto &t : toks) {
+    if (t.size() == tok.size() && strncasecmp(t.data(), tok.data(), t.size()) == 0) n++;
+  }
+  return n;
+}
+
+// Collect the {name, value} pairs of the PARAMS clause whose "PARAMS" keyword is
+// at toks[start]; toks[start + 1] is the declared token count (2 * #pairs).
+// *outCount, when non-NULL, receives that count. Values are copied verbatim, so
+// a token vector built from length-delimited wire data stays binary-safe.
+// Centralizes the "PARAMS n k v k v ..." decoding shared by the assertions below.
+static PairSet collectParamsPairs(const std::vector<std::string> &toks, size_t start,
+                                  long *outCount) {
+  long count = (start + 1 < toks.size()) ? atol(toks[start + 1].c_str()) : 0;
+  if (outCount) *outCount = count;
+  PairSet pairs;
+  for (long j = 0; j + 1 < count && start + 3 + (size_t)j < toks.size(); j += 2) {
+    pairs.insert({toks[start + 2 + j], toks[start + 3 + j]});
+  }
+  return pairs;
+}
+
+// Assert the built command carries exactly the PARAMS clause described by
+// `expected` (as an order-independent set of pairs, with count == 2*N), or no
+// PARAMS clause at all when `expected` is empty.
+static void expectParamsBlock(const std::vector<std::string> &toks, const ParamList &expected) {
+  bool found = false;
+  long count = -1;
+  PairSet got;
+  for (size_t i = 0; i + 1 < toks.size(); i++) {
+    if (toks[i] == "PARAMS") {
+      found = true;
+      got = collectParamsPairs(toks, i, &count);
+      break;
+    }
+  }
+  if (expected.empty()) {
+    EXPECT_FALSE(found) << "expected no PARAMS clause";
+    return;
+  }
+  EXPECT_TRUE(found) << "expected a PARAMS clause";
+  EXPECT_EQ(count, (long)expected.size() * 2) << "PARAMS count must be 2 * number of pairs";
+  PairSet want(expected.begin(), expected.end());
+  EXPECT_EQ(got, want);
+}
+
+// Return the token following the first occurrence of `clause`, or "" if absent.
+static std::string valueAfter(const std::vector<std::string> &toks, const char *clause) {
+  for (size_t i = 0; i + 1 < toks.size(); i++) {
+    if (toks[i] == clause) return toks[i + 1];
+  }
+  return "";
+}
+
+// Verify the reconstructed PARAMS and TIMEOUT clauses on an output token stream.
+// A parameter value may itself spell "TIMEOUT"; such occurrences live inside the
+// PARAMS block and must not be counted as the top-level clause, so the expected
+// TIMEOUT token count is (forwarded ? 1 : 0) + (# param values == TIMEOUT).
+static void expectParamsAndTimeout(const std::vector<std::string> &toks,
+                                   const ParamList &expectedPairs,
+                                   bool forwardTimeout, long long timeoutMS) {
+  expectParamsBlock(toks, expectedPairs);
+  int timeoutInParams = 0;
+  for (const auto &kv : expectedPairs) {
+    if (strcasecmp(kv.second.c_str(), "TIMEOUT") == 0) timeoutInParams++;
+  }
+  EXPECT_EQ(countTok(toks, "TIMEOUT"), (forwardTimeout ? 1 : 0) + timeoutInParams);
+  if (forwardTimeout && timeoutInParams == 0) {
+    EXPECT_EQ(valueAfter(toks, "TIMEOUT"), std::to_string(timeoutMS));
+  }
+}
+
+// Build a parameter dict from a flat name,value,... list, recording the
+// expected pairs. Returns NULL for an empty list (the no-PARAMS case). The
+// returned dict is owned by the caller (free with Param_DictFree).
+dict *makeParamsDict(const std::vector<const char*>& paramsKV, ParamList &expectedPairs) {
+  dict *params = paramsKV.empty() ? nullptr : Param_DictCreate();
+  QueryError status = QueryError_Default();
+  for (size_t i = 0; i + 1 < paramsKV.size(); i += 2) {
+    Param_DictAdd(params, paramsKV[i], paramsKV[i + 1], strlen(paramsKV[i + 1]), &status);
+    expectedPairs.push_back({paramsKV[i], paramsKV[i + 1]});
+  }
+  return params;
+}
 
 // Format a double exactly as MRCommand_appendCombine does for the wire
 // (round-trip-safe "%.17g"). Tests use this so expectations can be written
@@ -87,7 +190,9 @@ static HybridCombineWireParams linearWireParams(HybridScoringContext *sc, double
 // block; the oracle spots it in the output (COMBINE followed by a scoring
 // method - a PARAMS-value COMBINE never is) and, if the client supplied its own
 // COMBINE clause, drops that clause from the input side since the reconstructed
-// form replaces it. Returns the output index just past the matched prefix.
+// form replaces it. The PARAMS clause is reconstructed from the parsed dict, so
+// it is compared as an order-independent {name, value} set rather than by
+// position. Returns the output index just past the matched prefix.
 static int verifyArgsPreservedWithReconstructedCombine(
     const MRCommand *xcmd, const std::vector<const char *> &inputArgs,
     const HybridCombineWireParams *cp) {
@@ -117,6 +222,34 @@ static int verifyArgsPreservedWithReconstructedCombine(
           ii += 2;                        // positional YIELD_SCORE_AS <alias>
         }
       }
+      continue;
+    }
+    // PARAMS is reconstructed from the parsed dictionary, so the pair order on
+    // the wire need not match the client's input order. Slice each PARAMS clause
+    // into tokens and compare them as order-independent {name, value} sets via
+    // the shared collectParamsPairs (binary-safe on the length-delimited output).
+    if (strcasecmp(inputArgs[ii], "PARAMS") == 0) {
+      const long inCount = atol(inputArgs[ii + 1]);
+      std::vector<std::string> inToks;
+      for (long k = 0; k < 2 + inCount && ii + (size_t)k < inputArgs.size(); k++) {
+        inToks.emplace_back(inputArgs[ii + k]);
+      }
+      PairSet want = collectParamsPairs(inToks, 0, nullptr);
+      ii += 2 + (size_t)inCount;
+
+      EXPECT_LT(oi + 1, xcmd->num) << "output should carry a reconstructed PARAMS clause";
+      EXPECT_STREQ(xcmd->strs[oi], "PARAMS") << "PARAMS clause expected at output index " << oi;
+      const long outDeclared = (oi + 1 < xcmd->num) ? atol(xcmd->strs[oi + 1]) : 0;
+      std::vector<std::string> outToks;
+      for (int k = 0; k < 2 + (int)outDeclared && oi + k < xcmd->num; k++) {
+        outToks.emplace_back(xcmd->strs[oi + k], xcmd->lens[oi + k]);
+      }
+      long outCount = 0;
+      PairSet got = collectParamsPairs(outToks, 0, &outCount);
+      EXPECT_EQ(outCount, inCount) << "PARAMS count must equal 2 * number of parsed params";
+      EXPECT_EQ(got, want)
+          << "reconstructed PARAMS pairs must match the client's (order-independent)";
+      oi += 2 + (size_t)outCount;
       continue;
     }
     EXPECT_STREQ(xcmd->strs[oi], inputArgs[ii])
@@ -233,8 +366,10 @@ protected:
         MRCommand xcmd;
         int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, &combineParams, &xcmd,
-                                     nullptr, testIndexSpec, &kArgIndex);
+                                     /*sendExplainScore=*/false, &combineParams,
+                                     cmd.search->searchopts.params,
+                                     cmd.timeoutSpecified, cmd.clientTimeoutMS,
+                                     &xcmd, nullptr, testIndexSpec, &kArgIndex);
 
         // Verify the command was built correctly
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
@@ -316,8 +451,10 @@ protected:
         MRCommand xcmd;
         int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, &cp, &xcmd,
-                                     nullptr, testIndexSpec, &kArgIndex);
+                                     /*sendExplainScore=*/false, &cp,
+                                     cmd.search->searchopts.params,
+                                     cmd.timeoutSpecified, cmd.clientTimeoutMS,
+                                     &xcmd, nullptr, testIndexSpec, &kArgIndex);
 
         // Assert the parse-driven path also preserves every non-COMBINE arg by
         // position (this is what verifies the PARAMS block - including any
@@ -365,75 +502,99 @@ protected:
     // Helper function to test command transformation
     void testCommandTransformationWithoutIndexSpec(const std::vector<const char*>& inputArgs,
                                                    const HybridCombineWireParams *combineParams = nullptr) {
-        // Access the global NumShards variable
-        extern size_t NumShards;
-
-        // Convert vector to array for ArgvList constructor
-        std::vector<const char*> argsWithNull = inputArgs;
-        argsWithNull.push_back(nullptr);  // ArgvList expects null-terminated
-
-        // Create ArgvList from input
-        RMCK::ArgvList args(ctx, argsWithNull.data(), inputArgs.size());
-
-        // Build MR command
-        MRCommand xcmd;
-        int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, combineParams, &xcmd,
-                                     nullptr, nullptr, &kArgIndex);
-
-        // Verify transformation: FT.HYBRID -> _FT.HYBRID
-        EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
-
-        // Verify original args are preserved, with the COMBINE clause replaced by
-        // its reconstructed (old-shard-compatible) form.
-        verifyArgsPreservedWithReconstructedCombine(&xcmd, inputArgs, combineParams);
-
-        // Verify WITHCURSOR, WITHSCORES, _NUM_SSTRING, _COORD_DISPATCH_TIME are added at the end
-        // Note: _COORD_DISPATCH_TIME and its placeholder value (2 args) are added after _NUM_SSTRING
-        EXPECT_STREQ(xcmd.strs[xcmd.num - 7], "WITHCURSOR") << "WITHCURSOR should be seventh to last";
-        EXPECT_STREQ(xcmd.strs[xcmd.num - 6], "WITHSCORES") << "WITHSCORES should be sixth to last";
-        EXPECT_STREQ(xcmd.strs[xcmd.num - 5], "_NUM_SSTRING") << "_NUM_SSTRING should be fifth to last";
-        EXPECT_STREQ(xcmd.strs[xcmd.num - 2], "_COORD_DISPATCH_TIME") << "_COORD_DISPATCH_TIME should be second to last";
-        EXPECT_STREQ(xcmd.strs[xcmd.num - 1], "") << "Dispatch time placeholder should be last (empty)";
-
-        MRCommand_Free(&xcmd);
+        testCommandTransformationWithoutIndexSpecWithParams(inputArgs, /*paramsKV=*/{},
+                                                            /*timeoutMS=*/-1, combineParams);
     }
 
     // Helper function to test command transformation
     void testCommandTransformationWithIndexSpec(const std::vector<const char*>& inputArgs,
                                                 const HybridCombineWireParams *combineParams = nullptr) {
-      // Access the global NumShards variable
-      extern size_t NumShards;
+        testCommandTransformationWithIndexSpecAndParams(inputArgs, /*paramsKV=*/{},
+                                                        /*timeoutMS=*/-1, combineParams);
+    }
 
-      // Convert vector to array for ArgvList constructor
-      std::vector<const char*> argsWithNull = inputArgs;
-      argsWithNull.push_back(nullptr);  // ArgvList expects null-terminated
+  void testCommandTransformationWithoutIndexSpecWithParams(
+          const std::vector<const char*>& baseArgs,
+          const std::vector<const char*>& paramsKV,
+          long long timeoutMS,
+          const HybridCombineWireParams *combineParams = nullptr) {
+      ASSERT_EQ(paramsKV.size() % 2, 0u) << "paramsKV must be name,value pairs";
 
-      // Create ArgvList from input
-      RMCK::ArgvList args(ctx, argsWithNull.data(), inputArgs.size());
+      ParamList expectedPairs;
+      dict *params = makeParamsDict(paramsKV, expectedPairs);
+      const bool forwardTimeout = timeoutMS >= 0;
+
+      std::vector<const char*> argsWithNull = baseArgs;
+      argsWithNull.push_back(nullptr);
+      RMCK::ArgvList args(ctx, argsWithNull.data(), baseArgs.size());
+
+      MRCommand xcmd;
+      int kArgIndex = -1;
+      HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
+                                   /*sendExplainScore=*/false, combineParams,
+                                   params, forwardTimeout, forwardTimeout ? timeoutMS : 0,
+                                   &xcmd, nullptr, nullptr, &kArgIndex);
+      if (params) Param_DictFree(params);
+
+      // FT.HYBRID -> _FT.HYBRID, and the base args (no PARAMS/TIMEOUT) preserved
+      // with the COMBINE clause reconstructed.
+      EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
+      verifyArgsPreservedWithReconstructedCombine(&xcmd, baseArgs, combineParams);
+
+      // Check the reconstructed PARAMS/TIMEOUT clauses on the token stream.
+      std::vector<std::string> toks = toTokens(&xcmd);
+      expectParamsAndTimeout(toks, expectedPairs, forwardTimeout, timeoutMS);
+
+      // The fixed trailing block is unaffected by PARAMS/TIMEOUT length.
+      EXPECT_STREQ(xcmd.strs[xcmd.num - 7], "WITHCURSOR") << "WITHCURSOR should be seventh to last";
+      EXPECT_STREQ(xcmd.strs[xcmd.num - 6], "WITHSCORES") << "WITHSCORES should be sixth to last";
+      EXPECT_STREQ(xcmd.strs[xcmd.num - 5], "_NUM_SSTRING") << "_NUM_SSTRING should be fifth to last";
+      EXPECT_STREQ(xcmd.strs[xcmd.num - 2], "_COORD_DISPATCH_TIME") << "_COORD_DISPATCH_TIME should be second to last";
+      EXPECT_STREQ(xcmd.strs[xcmd.num - 1], "") << "Dispatch time placeholder should be last (empty)";
+
+      MRCommand_Free(&xcmd);
+  }
+
+  void testCommandTransformationWithIndexSpecAndParams(
+          const std::vector<const char*>& baseArgs,
+          const std::vector<const char*>& paramsKV,
+          long long timeoutMS,
+          const HybridCombineWireParams *combineParams = nullptr) {
+      ASSERT_EQ(paramsKV.size() % 2, 0u) << "paramsKV must be name,value pairs";
+
+      ParamList expectedPairs;
+      dict *params = makeParamsDict(paramsKV, expectedPairs);
+      const bool forwardTimeout = timeoutMS >= 0;
+
+      std::vector<const char*> argsWithNull = baseArgs;
+      argsWithNull.push_back(nullptr);
+      RMCK::ArgvList args(ctx, argsWithNull.data(), baseArgs.size());
       RefManager *ism = createSpec(ctx, {"prefix1", "prefix2"});
-
-      // Get the IndexSpec from the RefManager
       IndexSpec *sp = get_spec(ism);
       ASSERT_NE(sp, nullptr) << "IndexSpec should be accessible from RefManager";
       ASSERT_NE(sp->rule, nullptr) << "IndexSpec should have a rule";
       ASSERT_NE(sp->rule->prefixes, nullptr) << "IndexSpec rule should have prefixes";
       ASSERT_EQ(array_len(sp->rule->prefixes), 2) << "IndexSpec rule should have 2 prefixes";
 
-      // Build MR command (not testing SHARD_K_RATIO here)
       MRCommand xcmd;
       int kArgIndex = -1;
       HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                   /*sendExplainScore=*/false, combineParams, &xcmd,
-                                   nullptr, sp, &kArgIndex);
-      // Verify transformation: FT.HYBRID -> _FT.HYBRID
+                                   /*sendExplainScore=*/false, combineParams,
+                                   params, forwardTimeout, forwardTimeout ? timeoutMS : 0,
+                                   &xcmd, nullptr, sp, &kArgIndex);
+      if (params) Param_DictFree(params);
+
+      // FT.HYBRID -> _FT.HYBRID, base args preserved, COMBINE reconstructed.
       EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
-      // Verify original args are preserved, with the COMBINE clause replaced by
-      // its reconstructed (old-shard-compatible) form.
-      verifyArgsPreservedWithReconstructedCombine(&xcmd, inputArgs, combineParams);
-      // Verify WITHCURSOR, WITHSCORES, _NUM_SSTRING, SLOTS, _COORD_DISPATCH_TIME, _INDEX_PREFIXES, and prefixes are added at the end
-      // Order: ... WITHCURSOR WITHSCORES _NUM_SSTRING _SLOTS <slots_blob> _COORD_DISPATCH_TIME <placeholder> _INDEX_PREFIXES 2 prefix1 prefix2
+      verifyArgsPreservedWithReconstructedCombine(&xcmd, baseArgs, combineParams);
+
+      // PARAMS/TIMEOUT are emitted before the spec trailing block, so they are
+      // asserted the same way regardless of the spec.
+      std::vector<std::string> toks = toTokens(&xcmd);
+      expectParamsAndTimeout(toks, expectedPairs, forwardTimeout, timeoutMS);
+
+      // Spec-dependent trailing block:
+      // ... WITHCURSOR WITHSCORES _NUM_SSTRING _SLOTS <blob> _COORD_DISPATCH_TIME <placeholder> _INDEX_PREFIXES 2 prefix1 prefix2
       EXPECT_STREQ(xcmd.strs[xcmd.num - 11], "WITHCURSOR") << "WITHCURSOR should be 11th to last";
       EXPECT_STREQ(xcmd.strs[xcmd.num - 10], "WITHSCORES") << "WITHSCORES should be 10th to last";
       EXPECT_STREQ(xcmd.strs[xcmd.num - 9], "_NUM_SSTRING") << "_NUM_SSTRING should be 9th to last";
@@ -446,7 +607,6 @@ protected:
       EXPECT_STREQ(xcmd.strs[xcmd.num - 2], "prefix1") << "First prefix should be 2nd to last";
       EXPECT_STREQ(xcmd.strs[xcmd.num - 1], "prefix2") << "Second prefix should be last";
 
-      // Clean up
       MRCommand_Free(&xcmd);
       freeSpec(ism);
   }
@@ -462,44 +622,27 @@ TEST_F(HybridBuildMRCommandTest, testBasicCommandTransformation) {
     });
 }
 
-// Test command with PARAMS
+// Test command with PARAMS (supplied separately, as parse would produce them).
 TEST_F(HybridBuildMRCommandTest, testCommandWithParams) {
-    testCommandTransformationWithoutIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-        "VSIM", "@vector_field", "$BLOB",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA
-    });
-    testCommandTransformationWithIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-        "VSIM", "@vector_field", "$BLOB",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA
-    });
+    const std::vector<const char*> baseArgs = {
+        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)", "VSIM", "@vector_field", "$BLOB"};
+    const std::vector<const char*> paramsKV = {"param1", "hello", "BLOB", TEST_BLOB_DATA};
+    testCommandTransformationWithoutIndexSpecWithParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
+    testCommandTransformationWithIndexSpecAndParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
 }
 
-// Test command with TIMEOUT
+// Test command with TIMEOUT (no params).
 TEST_F(HybridBuildMRCommandTest, testCommandWithTimeout) {
-    testCommandTransformationWithoutIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "hello",
-        "VSIM", "@vector_field", TEST_BLOB_DATA,
-        "TIMEOUT", "5000"
-    });
-    testCommandTransformationWithIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "hello",
-        "VSIM", "@vector_field", TEST_BLOB_DATA,
-        "TIMEOUT", "5000"
-    });
+    const std::vector<const char*> baseArgs = {
+        "FT.HYBRID", "test_idx", "SEARCH", "hello", "VSIM", "@vector_field", TEST_BLOB_DATA};
+    testCommandTransformationWithoutIndexSpecWithParams(baseArgs, /*paramsKV=*/{}, /*timeoutMS=*/5000);
+    testCommandTransformationWithIndexSpecAndParams(baseArgs, /*paramsKV=*/{}, /*timeoutMS=*/5000);
 }
 
-// Test command with DIALECT
-TEST_F(HybridBuildMRCommandTest, testCommandWithDialect) {
-    testCommandTransformationWithoutIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "hello",
-        "VSIM", "@vector_field", TEST_BLOB_DATA,
-        "DIALECT", "2"
-    });
-}
+// Note: there is no DIALECT test - FT.HYBRID rejects DIALECT at parse time, so
+// it is never forwarded to shards
 
-// Test command with DIALECT
+// Test command with COMBINE
 TEST_F(HybridBuildMRCommandTest, testCommandWithCombine) {
     HybridScoringContext sc = {};
     double w[2];
@@ -507,14 +650,12 @@ TEST_F(HybridBuildMRCommandTest, testCommandWithCombine) {
     testCommandTransformationWithoutIndexSpec({
         "FT.HYBRID", "test_idx", "SEARCH", "hello",
         "VSIM", "@vector_field", TEST_BLOB_DATA, "FILTER", "@tag:{invalid_tag}",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "DIALECT", "2"
+        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3"
     }, &cp);
     testCommandTransformationWithIndexSpec({
         "FT.HYBRID", "test_idx", "SEARCH", "hello",
         "VSIM", "@vector_field", TEST_BLOB_DATA, "FILTER", "@tag:{invalid_tag}",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "DIALECT", "2"
+        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3"
     }, &cp);
 }
 
@@ -568,48 +709,28 @@ TEST_F(HybridBuildMRCommandTest, testFilterWithPolicyBatchSizeAndCombine) {
     }, &cp);
 }
 
-// Test complex command with all optional parameters
+// Test complex command with COMBINE + PARAMS + TIMEOUT together.
 TEST_F(HybridBuildMRCommandTest, testComplexCommandWithAllParams) {
     HybridScoringContext sc = {};
     double w[2];
     HybridCombineWireParams cp = linearWireParams(&sc, w, 0.7, 0.3, HYBRID_DEFAULT_WINDOW);
-    testCommandTransformationWithoutIndexSpec({
+    const std::vector<const char*> baseArgs = {
         "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
         "VSIM", "@vector_field", "$BLOB",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA,
-        "TIMEOUT", "3000", "DIALECT", "2"
-    }, &cp);
-    testCommandTransformationWithIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-        "VSIM", "@vector_field", "$BLOB",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA,
-        "TIMEOUT", "3000", "DIALECT", "2"
-    }, &cp);
+        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3"};
+    const std::vector<const char*> paramsKV = {"param1", "hello", "BLOB", TEST_BLOB_DATA};
+    testCommandTransformationWithoutIndexSpecWithParams(baseArgs, paramsKV, /*timeoutMS=*/3000, &cp);
+    testCommandTransformationWithIndexSpecAndParams(baseArgs, paramsKV, /*timeoutMS=*/3000, &cp);
 }
 
-// Test complex command with all optional parameters
-TEST_F(HybridBuildMRCommandTest, testComplexCommandParamsAfterTimeout) {
-    HybridScoringContext sc = {};
-    double w[2];
-    HybridCombineWireParams cp = linearWireParams(&sc, w, 0.7, 0.3, HYBRID_DEFAULT_WINDOW);
-    testCommandTransformationWithoutIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-        "VSIM", "@vector_field", "$BLOB",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA,
-        "TIMEOUT", "3000",
-        "DIALECT", "2"
-    }, &cp);
-    testCommandTransformationWithIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-        "VSIM", "@vector_field", "$BLOB",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA,
-        "TIMEOUT", "3000",
-        "DIALECT", "2"
-    }, &cp);
+// A parameter *value* that spells a top-level keyword is carried inside the PARAMS
+// block, never mistaken for that clause (the value happens to be "TIMEOUT" here).
+TEST_F(HybridBuildMRCommandTest, testCommandWithParamValueSpellingKeyword) {
+    const std::vector<const char*> baseArgs = {
+        "FT.HYBRID", "test_idx", "SEARCH", "@title:($p)", "VSIM", "@vector_field", "$BLOB"};
+    const std::vector<const char*> paramsKV = {"p", "TIMEOUT", "BLOB", TEST_BLOB_DATA};
+    testCommandTransformationWithoutIndexSpecWithParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
+    testCommandTransformationWithIndexSpecAndParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
 }
 
 // Test minimal command
@@ -626,17 +747,6 @@ TEST_F(HybridBuildMRCommandTest, testMinimalCommand) {
 // option, not by argv text. A SEARCH query token or PARAMS value equal to
 // "EXPLAINSCORE" must not trigger forwarding; sendExplainScore=true must.
 TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
-    auto countToken = [](const MRCommand *cmd, std::string_view tok) {
-        int n = 0;
-        for (int i = 0; i < cmd->num; i++) {
-            if (cmd->lens[i] == tok.size() &&
-                strncasecmp(cmd->strs[i], tok.data(), tok.size()) == 0) {
-                n++;
-            }
-        }
-        return n;
-    };
-
     {
         std::vector<const char *> input = {
             "FT.HYBRID", "test_idx", "SEARCH", "EXPLAINSCORE",
@@ -646,30 +756,40 @@ TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
         MRCommand xcmd;
         int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, /*combineParams=*/nullptr, &xcmd,
-                                     nullptr, nullptr, &kArgIndex);
+                                     /*sendExplainScore=*/false, /*combineParams=*/nullptr,
+                                     /*params=*/nullptr,
+                                     /*forwardTimeout=*/false, /*timeoutMS=*/0,
+                                     &xcmd, nullptr, nullptr, &kArgIndex);
 
-        EXPECT_EQ(countToken(&xcmd, "EXPLAINSCORE"), 1)
+        EXPECT_EQ(countTok(toTokens(&xcmd), "EXPLAINSCORE"), 1)
             << "EXPLAINSCORE in the search query must not be re-appended as a "
                "top-level shard option";
         MRCommand_Free(&xcmd);
     }
 
+    // A PARAMS *value* equal to "EXPLAINSCORE" is carried inside the PARAMS
+    // block (reconstructed from the parsed dict) and must not be re-appended as
+    // a top-level shard option when the parsed flag is unset. It therefore
+    // appears exactly once - as the param value.
     {
         std::vector<const char *> input = {
             "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-            "VSIM", "@vector_field", "$BLOB",
-            "PARAMS", "4", "param1", "EXPLAINSCORE", "BLOB", TEST_BLOB_DATA,
-            nullptr};
+            "VSIM", "@vector_field", "$BLOB", nullptr};
         RMCK::ArgvList args(ctx, input.data(), input.size() - 1);
+
+        ParamList expectedPairs;
+        dict *params = makeParamsDict({"param1", "EXPLAINSCORE", "BLOB", TEST_BLOB_DATA},
+                                      expectedPairs);
 
         MRCommand xcmd;
         int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, /*combineParams=*/nullptr, &xcmd,
-                                     nullptr, nullptr, &kArgIndex);
+                                     /*sendExplainScore=*/false, /*combineParams=*/nullptr,
+                                     params, /*forwardTimeout=*/false, /*timeoutMS=*/0,
+                                     &xcmd, nullptr, nullptr, &kArgIndex);
+        Param_DictFree(params);
 
-        EXPECT_EQ(countToken(&xcmd, "EXPLAINSCORE"), 1)
+        EXPECT_EQ(countTok(toTokens(&xcmd), "EXPLAINSCORE"), 1)
             << "EXPLAINSCORE as a PARAMS value must not be re-appended as a "
                "top-level shard option";
         MRCommand_Free(&xcmd);
@@ -684,10 +804,11 @@ TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
         MRCommand xcmd;
         int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/true, /*combineParams=*/nullptr, &xcmd,
-                                     nullptr, nullptr, &kArgIndex);
+                                     /*sendExplainScore=*/true, /*combineParams=*/nullptr,
+                                     /*params=*/nullptr, /*forwardTimeout=*/false, /*timeoutMS=*/0,
+                                     &xcmd, nullptr, nullptr, &kArgIndex);
 
-        EXPECT_EQ(countToken(&xcmd, "EXPLAINSCORE"), 1)
+        EXPECT_EQ(countTok(toTokens(&xcmd), "EXPLAINSCORE"), 1)
             << "EXPLAINSCORE should be appended exactly once when the parsed "
                "flag is set";
         MRCommand_Free(&xcmd);

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -358,17 +358,20 @@ protected:
         // Borrow the resolved scoring context (as the coordinator does before
         // the merger takes ownership) so the reconstructed COMBINE clause is
         // forwarded to the shard.
-        HybridCombineWireParams combineParams{hybridParams.scoringCtx,
-                                              hybridParams.aggregationParams.common.scoreAlias};
+        HybridShardWireParams shardWireParams = {};
+        shardWireParams.combine = HybridCombineWireParams{
+            hybridParams.scoringCtx,
+            hybridParams.aggregationParams.common.scoreAlias
+        };
+        shardWireParams.params = cmd.search->searchopts.params;
+        shardWireParams.forwardTimeout = cmd.timeoutSpecified;
+        shardWireParams.timeoutMS = cmd.clientTimeoutMS;
 
         // Build MR command - now returns kArgIndex instead of calculating effectiveK
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, &combineParams,
-                                     cmd.search->searchopts.params,
-                                     cmd.timeoutSpecified, cmd.clientTimeoutMS,
-                                     &xcmd, nullptr, testIndexSpec, &kArgIndex);
+        HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr,
+                                     testIndexSpec, &kArgIndex);
 
         // Verify the command was built correctly
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
@@ -444,16 +447,19 @@ protected:
             return out;
         }
 
-        HybridCombineWireParams cp{hybridParams.scoringCtx,
-                                   hybridParams.aggregationParams.common.scoreAlias};
+        HybridShardWireParams shardWireParams = {};
+        shardWireParams.combine = HybridCombineWireParams{
+            hybridParams.scoringCtx,
+            hybridParams.aggregationParams.common.scoreAlias
+        };
+        shardWireParams.params = cmd.search->searchopts.params;
+        shardWireParams.forwardTimeout = cmd.timeoutSpecified;
+        shardWireParams.timeoutMS = cmd.clientTimeoutMS;
 
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, &cp,
-                                     cmd.search->searchopts.params,
-                                     cmd.timeoutSpecified, cmd.clientTimeoutMS,
-                                     &xcmd, nullptr, testIndexSpec, &kArgIndex);
+        HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr,
+                                     testIndexSpec, &kArgIndex);
 
         // Assert the parse-driven path also preserves every non-COMBINE arg by
         // position (this is what verifies the PARAMS block - including any
@@ -462,7 +468,7 @@ protected:
         // additionally pins the extracted clause against a literal vector, so the
         // two oracles stay independent.
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
-        verifyArgsPreservedWithReconstructedCombine(&xcmd, inputArgs, &cp);
+        verifyArgsPreservedWithReconstructedCombine(&xcmd, inputArgs, &shardWireParams.combine);
 
         for (int i = 0; i < xcmd.num; i++) {
             if (xcmd.lens[i] == strlen("COMBINE") &&
@@ -527,12 +533,16 @@ protected:
       argsWithNull.push_back(nullptr);
       RMCK::ArgvList args(ctx, argsWithNull.data(), baseArgs.size());
 
+      HybridShardWireParams shardWireParams = {};
+      if (combineParams) shardWireParams.combine = *combineParams;
+      shardWireParams.params = params;
+      shardWireParams.forwardTimeout = forwardTimeout;
+      shardWireParams.timeoutMS = forwardTimeout ? timeoutMS : 0;
+
       MRCommand xcmd;
       int kArgIndex = -1;
-      HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                   /*sendExplainScore=*/false, combineParams,
-                                   params, forwardTimeout, forwardTimeout ? timeoutMS : 0,
-                                   &xcmd, nullptr, nullptr, &kArgIndex);
+      HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr, nullptr,
+                                   &kArgIndex);
       if (params) Param_DictFree(params);
 
       // FT.HYBRID -> _FT.HYBRID, and the base args (no PARAMS/TIMEOUT) preserved
@@ -575,12 +585,16 @@ protected:
       ASSERT_NE(sp->rule->prefixes, nullptr) << "IndexSpec rule should have prefixes";
       ASSERT_EQ(array_len(sp->rule->prefixes), 2) << "IndexSpec rule should have 2 prefixes";
 
+      HybridShardWireParams shardWireParams = {};
+      if (combineParams) shardWireParams.combine = *combineParams;
+      shardWireParams.params = params;
+      shardWireParams.forwardTimeout = forwardTimeout;
+      shardWireParams.timeoutMS = forwardTimeout ? timeoutMS : 0;
+
       MRCommand xcmd;
       int kArgIndex = -1;
-      HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                   /*sendExplainScore=*/false, combineParams,
-                                   params, forwardTimeout, forwardTimeout ? timeoutMS : 0,
-                                   &xcmd, nullptr, sp, &kArgIndex);
+      HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr, sp,
+                                   &kArgIndex);
       if (params) Param_DictFree(params);
 
       // FT.HYBRID -> _FT.HYBRID, base args preserved, COMBINE reconstructed.
@@ -752,13 +766,11 @@ TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
             "VSIM", "@vector_field", TEST_BLOB_DATA, nullptr};
         RMCK::ArgvList args(ctx, input.data(), input.size() - 1);
 
+        HybridShardWireParams shardWireParams = {};  // no COMBINE, no PARAMS, no TIMEOUT
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, /*combineParams=*/nullptr,
-                                     /*params=*/nullptr,
-                                     /*forwardTimeout=*/false, /*timeoutMS=*/0,
-                                     &xcmd, nullptr, nullptr, &kArgIndex);
+        HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr, nullptr,
+                                     &kArgIndex);
 
         EXPECT_EQ(countTok(toTokens(&xcmd), "EXPLAINSCORE"), 1)
             << "EXPLAINSCORE in the search query must not be re-appended as a "
@@ -780,12 +792,13 @@ TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
         dict *params = makeParamsDict({"param1", "EXPLAINSCORE", "BLOB", TEST_BLOB_DATA},
                                       expectedPairs);
 
+        HybridShardWireParams shardWireParams = {};
+        shardWireParams.params = params;
+
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, /*combineParams=*/nullptr,
-                                     params, /*forwardTimeout=*/false, /*timeoutMS=*/0,
-                                     &xcmd, nullptr, nullptr, &kArgIndex);
+        HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr, nullptr,
+                                     &kArgIndex);
         Param_DictFree(params);
 
         EXPECT_EQ(countTok(toTokens(&xcmd), "EXPLAINSCORE"), 1)
@@ -800,12 +813,13 @@ TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
             "VSIM", "@vector_field", TEST_BLOB_DATA, nullptr};
         RMCK::ArgvList args(ctx, input.data(), input.size() - 1);
 
+        HybridShardWireParams shardWireParams = {};
+        shardWireParams.sendExplainScore = true;
+
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/true, /*combineParams=*/nullptr,
-                                     /*params=*/nullptr, /*forwardTimeout=*/false, /*timeoutMS=*/0,
-                                     &xcmd, nullptr, nullptr, &kArgIndex);
+        HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr, nullptr,
+                                     &kArgIndex);
 
         EXPECT_EQ(countTok(toTokens(&xcmd), "EXPLAINSCORE"), 1)
             << "EXPLAINSCORE should be appended exactly once when the parsed "

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -57,7 +57,7 @@ static PairSet collectParamsPairs(const std::vector<std::string> &toks, size_t s
   if (outCount) *outCount = count;
   PairSet pairs;
   for (long j = 0; j + 1 < count && start + 3 + (size_t)j < toks.size(); j += 2) {
-    pairs.insert({toks[start + 2 + j], toks[start + 3 + j]});
+    pairs.emplace(toks[start + 2 + j], toks[start + 3 + j]);
   }
   return pairs;
 }
@@ -103,8 +103,8 @@ static void expectParamsAndTimeout(const std::vector<std::string> &toks,
                                    bool forwardTimeout, long long timeoutMS) {
   expectParamsBlock(toks, expectedPairs);
   int timeoutInParams = 0;
-  for (const auto &kv : expectedPairs) {
-    if (strcasecmp(kv.second.c_str(), "TIMEOUT") == 0) timeoutInParams++;
+  for (const auto &[name, value] : expectedPairs) {
+    if (strcasecmp(value.c_str(), "TIMEOUT") == 0) timeoutInParams++;
   }
   EXPECT_EQ(countTok(toks, "TIMEOUT"), (forwardTimeout ? 1 : 0) + timeoutInParams);
   if (forwardTimeout && timeoutInParams == 0) {
@@ -115,12 +115,14 @@ static void expectParamsAndTimeout(const std::vector<std::string> &toks,
 // Build a parameter dict from a flat name,value,... list, recording the
 // expected pairs. Returns NULL for an empty list (the no-PARAMS case). The
 // returned dict is owned by the caller (free with Param_DictFree).
-dict *makeParamsDict(const std::vector<const char*>& paramsKV, ParamList &expectedPairs) {
+dict *makeParamsDict(const std::vector<std::string>& paramsKV, ParamList &expectedPairs) {
   dict *params = paramsKV.empty() ? nullptr : Param_DictCreate();
   QueryError status = QueryError_Default();
   for (size_t i = 0; i + 1 < paramsKV.size(); i += 2) {
-    Param_DictAdd(params, paramsKV[i], paramsKV[i + 1], strlen(paramsKV[i + 1]), &status);
-    expectedPairs.push_back({paramsKV[i], paramsKV[i + 1]});
+    const std::string &name = paramsKV[i];
+    const std::string &value = paramsKV[i + 1];
+    Param_DictAdd(params, name.c_str(), value.data(), value.size(), &status);
+    expectedPairs.emplace_back(name, value);
   }
   return params;
 }
@@ -185,14 +187,46 @@ static HybridCombineWireParams linearWireParams(HybridScoringContext *sc, double
   return HybridCombineWireParams{sc, alias};
 }
 
+// Advance `ii` past a client-supplied COMBINE clause - COMBINE + method + count
+// + N args, plus a trailing positional YIELD_SCORE_AS <alias>.
+// No-op when the client supplied no COMBINE.
+static void skipClientCombineClause(const std::vector<const char *> &inputArgs, size_t &ii) {
+  if (strcasecmp(inputArgs[ii], "COMBINE") != 0) {
+    return;
+  }
+  ii += 2;                             // COMBINE, method
+  const long n = atol(inputArgs[ii]);  // count
+  ii += 1 + (size_t)n;                 // count token + its args
+  if (ii < inputArgs.size() && strcasecmp(inputArgs[ii], "YIELD_SCORE_AS") == 0) {
+    ii += 2;                           // positional YIELD_SCORE_AS <alias>
+  }
+}
+
+// Assert the output PARAMS clause at `oi` carries exactly the pairs of the input
+// PARAMS clause at `ii`, then advance both indices past their clause.
+static void verifyParamsClause(const MRCommand *xcmd, const std::vector<const char *> &inputArgs,
+                               size_t &ii, int &oi) {
+  const std::vector<std::string> inToks(inputArgs.begin(), inputArgs.end());
+  long inCount = 0;
+  PairSet want = collectParamsPairs(inToks, ii, &inCount);
+  ii += 2 + (size_t)inCount;
+
+  EXPECT_LT(oi + 1, xcmd->num) << "output should carry a reconstructed PARAMS clause";
+  EXPECT_STREQ(xcmd->strs[oi], "PARAMS") << "PARAMS clause expected at output index " << oi;
+  long outCount = 0;
+  PairSet got = collectParamsPairs(toTokens(xcmd), oi, &outCount);
+  EXPECT_EQ(outCount, inCount) << "PARAMS count must equal 2 * number of parsed params";
+  EXPECT_EQ(got, want)
+      << "reconstructed PARAMS pairs must match the client's (order-independent)";
+  oi += 2 + (size_t)outCount;
+}
+
 // Assert every input arg is preserved by position in the output. The
 // coordinator always inserts one reconstructed COMBINE clause after the VSIM
 // block; the oracle spots it in the output (COMBINE followed by a scoring
 // method - a PARAMS-value COMBINE never is) and, if the client supplied its own
 // COMBINE clause, drops that clause from the input side since the reconstructed
-// form replaces it. The PARAMS clause is reconstructed from the parsed dict, so
-// it is compared as an order-independent {name, value} set rather than by
-// position. Returns the output index just past the matched prefix.
+// form replaces it.
 static int verifyArgsPreservedWithReconstructedCombine(
     const MRCommand *xcmd, const std::vector<const char *> &inputArgs,
     const HybridCombineWireParams *cp) {
@@ -212,50 +246,15 @@ static int verifyArgsPreservedWithReconstructedCombine(
         oi++;
       }
       reconstructedMatched = true;
-      // If the client supplied its own COMBINE clause at this position, drop it
-      // from the input stream: COMBINE + method + count + N args.
-      if (strcasecmp(inputArgs[ii], "COMBINE") == 0) {
-        ii += 2;                          // COMBINE, method
-        long n = atol(inputArgs[ii]);     // count
-        ii += 1 + (size_t)n;              // count token + its args
-        if (ii < inputArgs.size() && strcasecmp(inputArgs[ii], "YIELD_SCORE_AS") == 0) {
-          ii += 2;                        // positional YIELD_SCORE_AS <alias>
-        }
-      }
-      continue;
+      skipClientCombineClause(inputArgs, ii);
+    } else if (strcasecmp(inputArgs[ii], "PARAMS") == 0) {
+      verifyParamsClause(xcmd, inputArgs, ii, oi);
+    } else {
+      EXPECT_STREQ(xcmd->strs[oi], inputArgs[ii])
+          << "Argument at input index " << ii << " should be preserved";
+      oi++;
+      ii++;
     }
-    // PARAMS is reconstructed from the parsed dictionary, so the pair order on
-    // the wire need not match the client's input order. Slice each PARAMS clause
-    // into tokens and compare them as order-independent {name, value} sets via
-    // the shared collectParamsPairs (binary-safe on the length-delimited output).
-    if (strcasecmp(inputArgs[ii], "PARAMS") == 0) {
-      const long inCount = atol(inputArgs[ii + 1]);
-      std::vector<std::string> inToks;
-      for (long k = 0; k < 2 + inCount && ii + (size_t)k < inputArgs.size(); k++) {
-        inToks.emplace_back(inputArgs[ii + k]);
-      }
-      PairSet want = collectParamsPairs(inToks, 0, nullptr);
-      ii += 2 + (size_t)inCount;
-
-      EXPECT_LT(oi + 1, xcmd->num) << "output should carry a reconstructed PARAMS clause";
-      EXPECT_STREQ(xcmd->strs[oi], "PARAMS") << "PARAMS clause expected at output index " << oi;
-      const long outDeclared = (oi + 1 < xcmd->num) ? atol(xcmd->strs[oi + 1]) : 0;
-      std::vector<std::string> outToks;
-      for (int k = 0; k < 2 + (int)outDeclared && oi + k < xcmd->num; k++) {
-        outToks.emplace_back(xcmd->strs[oi + k], xcmd->lens[oi + k]);
-      }
-      long outCount = 0;
-      PairSet got = collectParamsPairs(outToks, 0, &outCount);
-      EXPECT_EQ(outCount, inCount) << "PARAMS count must equal 2 * number of parsed params";
-      EXPECT_EQ(got, want)
-          << "reconstructed PARAMS pairs must match the client's (order-independent)";
-      oi += 2 + (size_t)outCount;
-      continue;
-    }
-    EXPECT_STREQ(xcmd->strs[oi], inputArgs[ii])
-        << "Argument at input index " << ii << " should be preserved";
-    oi++;
-    ii++;
   }
   return oi;
 }
@@ -515,7 +514,7 @@ protected:
 
   void testCommandTransformationWithoutIndexSpecWithParams(
           const std::vector<const char*>& baseArgs,
-          const std::vector<const char*>& paramsKV,
+          const std::vector<std::string>& paramsKV,
           long long timeoutMS,
           const HybridCombineWireParams *combineParams = nullptr) {
       ASSERT_EQ(paramsKV.size() % 2, 0u) << "paramsKV must be name,value pairs";
@@ -557,7 +556,7 @@ protected:
 
   void testCommandTransformationWithIndexSpecAndParams(
           const std::vector<const char*>& baseArgs,
-          const std::vector<const char*>& paramsKV,
+          const std::vector<std::string>& paramsKV,
           long long timeoutMS,
           const HybridCombineWireParams *combineParams = nullptr) {
       ASSERT_EQ(paramsKV.size() % 2, 0u) << "paramsKV must be name,value pairs";
@@ -626,7 +625,7 @@ TEST_F(HybridBuildMRCommandTest, testBasicCommandTransformation) {
 TEST_F(HybridBuildMRCommandTest, testCommandWithParams) {
     const std::vector<const char*> baseArgs = {
         "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)", "VSIM", "@vector_field", "$BLOB"};
-    const std::vector<const char*> paramsKV = {"param1", "hello", "BLOB", TEST_BLOB_DATA};
+    const std::vector<std::string> paramsKV = {"param1", "hello", "BLOB", TEST_BLOB_DATA};
     testCommandTransformationWithoutIndexSpecWithParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
     testCommandTransformationWithIndexSpecAndParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
 }
@@ -718,7 +717,7 @@ TEST_F(HybridBuildMRCommandTest, testComplexCommandWithAllParams) {
         "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
         "VSIM", "@vector_field", "$BLOB",
         "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3"};
-    const std::vector<const char*> paramsKV = {"param1", "hello", "BLOB", TEST_BLOB_DATA};
+    const std::vector<std::string> paramsKV = {"param1", "hello", "BLOB", TEST_BLOB_DATA};
     testCommandTransformationWithoutIndexSpecWithParams(baseArgs, paramsKV, /*timeoutMS=*/3000, &cp);
     testCommandTransformationWithIndexSpecAndParams(baseArgs, paramsKV, /*timeoutMS=*/3000, &cp);
 }
@@ -728,7 +727,7 @@ TEST_F(HybridBuildMRCommandTest, testComplexCommandWithAllParams) {
 TEST_F(HybridBuildMRCommandTest, testCommandWithParamValueSpellingKeyword) {
     const std::vector<const char*> baseArgs = {
         "FT.HYBRID", "test_idx", "SEARCH", "@title:($p)", "VSIM", "@vector_field", "$BLOB"};
-    const std::vector<const char*> paramsKV = {"p", "TIMEOUT", "BLOB", TEST_BLOB_DATA};
+    const std::vector<std::string> paramsKV = {"p", "TIMEOUT", "BLOB", TEST_BLOB_DATA};
     testCommandTransformationWithoutIndexSpecWithParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
     testCommandTransformationWithIndexSpecAndParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
 }

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -57,7 +57,7 @@ static PairSet collectParamsPairs(const std::vector<std::string> &toks, size_t s
   if (outCount) *outCount = count;
   PairSet pairs;
   for (long j = 0; j + 1 < count && start + 3 + (size_t)j < toks.size(); j += 2) {
-    pairs.insert({toks[start + 2 + j], toks[start + 3 + j]});
+    pairs.emplace(toks[start + 2 + j], toks[start + 3 + j]);
   }
   return pairs;
 }
@@ -103,8 +103,8 @@ static void expectParamsAndTimeout(const std::vector<std::string> &toks,
                                    bool forwardTimeout, long long timeoutMS) {
   expectParamsBlock(toks, expectedPairs);
   int timeoutInParams = 0;
-  for (const auto &kv : expectedPairs) {
-    if (strcasecmp(kv.second.c_str(), "TIMEOUT") == 0) timeoutInParams++;
+  for (const auto &[name, value] : expectedPairs) {
+    if (strcasecmp(value.c_str(), "TIMEOUT") == 0) timeoutInParams++;
   }
   EXPECT_EQ(countTok(toks, "TIMEOUT"), (forwardTimeout ? 1 : 0) + timeoutInParams);
   if (forwardTimeout && timeoutInParams == 0) {
@@ -115,12 +115,14 @@ static void expectParamsAndTimeout(const std::vector<std::string> &toks,
 // Build a parameter dict from a flat name,value,... list, recording the
 // expected pairs. Returns NULL for an empty list (the no-PARAMS case). The
 // returned dict is owned by the caller (free with Param_DictFree).
-dict *makeParamsDict(const std::vector<const char*>& paramsKV, ParamList &expectedPairs) {
+dict *makeParamsDict(const std::vector<std::string>& paramsKV, ParamList &expectedPairs) {
   dict *params = paramsKV.empty() ? nullptr : Param_DictCreate();
   QueryError status = QueryError_Default();
   for (size_t i = 0; i + 1 < paramsKV.size(); i += 2) {
-    Param_DictAdd(params, paramsKV[i], paramsKV[i + 1], strlen(paramsKV[i + 1]), &status);
-    expectedPairs.push_back({paramsKV[i], paramsKV[i + 1]});
+    const std::string &name = paramsKV[i];
+    const std::string &value = paramsKV[i + 1];
+    Param_DictAdd(params, name.c_str(), value.data(), value.size(), &status);
+    expectedPairs.emplace_back(name, value);
   }
   return params;
 }
@@ -185,14 +187,46 @@ static HybridCombineWireParams linearWireParams(HybridScoringContext *sc, double
   return HybridCombineWireParams{sc, alias};
 }
 
+// Advance `ii` past a client-supplied COMBINE clause - COMBINE + method + count
+// + N args, plus a trailing positional YIELD_SCORE_AS <alias>.
+// No-op when the client supplied no COMBINE.
+static void skipClientCombineClause(const std::vector<const char *> &inputArgs, size_t &ii) {
+  if (strcasecmp(inputArgs[ii], "COMBINE") != 0) {
+    return;
+  }
+  ii += 2;                             // COMBINE, method
+  const long n = atol(inputArgs[ii]);  // count
+  ii += 1 + (size_t)n;                 // count token + its args
+  if (ii < inputArgs.size() && strcasecmp(inputArgs[ii], "YIELD_SCORE_AS") == 0) {
+    ii += 2;                           // positional YIELD_SCORE_AS <alias>
+  }
+}
+
+// Assert the output PARAMS clause at `oi` carries exactly the pairs of the input
+// PARAMS clause at `ii`, then advance both indices past their clause.
+static void verifyParamsClause(const MRCommand *xcmd, const std::vector<const char *> &inputArgs,
+                               size_t &ii, int &oi) {
+  const std::vector<std::string> inToks(inputArgs.begin(), inputArgs.end());
+  long inCount = 0;
+  PairSet want = collectParamsPairs(inToks, ii, &inCount);
+  ii += 2 + (size_t)inCount;
+
+  EXPECT_LT(oi + 1, xcmd->num) << "output should carry a reconstructed PARAMS clause";
+  EXPECT_STREQ(xcmd->strs[oi], "PARAMS") << "PARAMS clause expected at output index " << oi;
+  long outCount = 0;
+  PairSet got = collectParamsPairs(toTokens(xcmd), oi, &outCount);
+  EXPECT_EQ(outCount, inCount) << "PARAMS count must equal 2 * number of parsed params";
+  EXPECT_EQ(got, want)
+      << "reconstructed PARAMS pairs must match the client's (order-independent)";
+  oi += 2 + (size_t)outCount;
+}
+
 // Assert every input arg is preserved by position in the output. The
 // coordinator always inserts one reconstructed COMBINE clause after the VSIM
 // block; the oracle spots it in the output (COMBINE followed by a scoring
 // method - a PARAMS-value COMBINE never is) and, if the client supplied its own
 // COMBINE clause, drops that clause from the input side since the reconstructed
-// form replaces it. The PARAMS clause is reconstructed from the parsed dict, so
-// it is compared as an order-independent {name, value} set rather than by
-// position. Returns the output index just past the matched prefix.
+// form replaces it.
 static int verifyArgsPreservedWithReconstructedCombine(
     const MRCommand *xcmd, const std::vector<const char *> &inputArgs,
     const HybridCombineWireParams *cp) {
@@ -212,52 +246,17 @@ static int verifyArgsPreservedWithReconstructedCombine(
         oi++;
       }
       reconstructedMatched = true;
-      // If the client supplied its own COMBINE clause at this position, drop it
-      // from the input stream: COMBINE + method + count + N args.
-      if (strcasecmp(inputArgs[ii], "COMBINE") == 0) {
-        ii += 2;                          // COMBINE, method
-        long n = atol(inputArgs[ii]);     // count
-        ii += 1 + (size_t)n;              // count token + its args
-        if (ii < inputArgs.size() && strcasecmp(inputArgs[ii], "YIELD_SCORE_AS") == 0) {
-          ii += 2;                        // positional YIELD_SCORE_AS <alias>
-        }
-      }
-      continue;
+      skipClientCombineClause(inputArgs, ii);
+    } else if (strcasecmp(inputArgs[ii], "PARAMS") == 0) {
+      verifyParamsClause(xcmd, inputArgs, ii, oi);
+    } else {
+      EXPECT_STREQ(xcmd->strs[oi], inputArgs[ii])
+          << "Argument at input index " << ii << " should be preserved";
+      EXPECT_EQ(xcmd->lens[oi], strlen(inputArgs[ii]))
+          << "Recorded length at output index " << oi << " should match the arg bytes";
+      oi++;
+      ii++;
     }
-    // PARAMS is reconstructed from the parsed dictionary, so the pair order on
-    // the wire need not match the client's input order. Slice each PARAMS clause
-    // into tokens and compare them as order-independent {name, value} sets via
-    // the shared collectParamsPairs (binary-safe on the length-delimited output).
-    if (strcasecmp(inputArgs[ii], "PARAMS") == 0) {
-      const long inCount = atol(inputArgs[ii + 1]);
-      std::vector<std::string> inToks;
-      for (long k = 0; k < 2 + inCount && ii + (size_t)k < inputArgs.size(); k++) {
-        inToks.emplace_back(inputArgs[ii + k]);
-      }
-      PairSet want = collectParamsPairs(inToks, 0, nullptr);
-      ii += 2 + (size_t)inCount;
-
-      EXPECT_LT(oi + 1, xcmd->num) << "output should carry a reconstructed PARAMS clause";
-      EXPECT_STREQ(xcmd->strs[oi], "PARAMS") << "PARAMS clause expected at output index " << oi;
-      const long outDeclared = (oi + 1 < xcmd->num) ? atol(xcmd->strs[oi + 1]) : 0;
-      std::vector<std::string> outToks;
-      for (int k = 0; k < 2 + (int)outDeclared && oi + k < xcmd->num; k++) {
-        outToks.emplace_back(xcmd->strs[oi + k], xcmd->lens[oi + k]);
-      }
-      long outCount = 0;
-      PairSet got = collectParamsPairs(outToks, 0, &outCount);
-      EXPECT_EQ(outCount, inCount) << "PARAMS count must equal 2 * number of parsed params";
-      EXPECT_EQ(got, want)
-          << "reconstructed PARAMS pairs must match the client's (order-independent)";
-      oi += 2 + (size_t)outCount;
-      continue;
-    }
-    EXPECT_STREQ(xcmd->strs[oi], inputArgs[ii])
-        << "Argument at input index " << ii << " should be preserved";
-    EXPECT_EQ(xcmd->lens[oi], strlen(inputArgs[ii]))
-        << "Recorded length at output index " << oi << " should match the arg bytes";
-    oi++;
-    ii++;
   }
   return oi;
 }
@@ -517,7 +516,7 @@ protected:
 
   void testCommandTransformationWithoutIndexSpecWithParams(
           const std::vector<const char*>& baseArgs,
-          const std::vector<const char*>& paramsKV,
+          const std::vector<std::string>& paramsKV,
           long long timeoutMS,
           const HybridCombineWireParams *combineParams = nullptr) {
       ASSERT_EQ(paramsKV.size() % 2, 0u) << "paramsKV must be name,value pairs";
@@ -559,7 +558,7 @@ protected:
 
   void testCommandTransformationWithIndexSpecAndParams(
           const std::vector<const char*>& baseArgs,
-          const std::vector<const char*>& paramsKV,
+          const std::vector<std::string>& paramsKV,
           long long timeoutMS,
           const HybridCombineWireParams *combineParams = nullptr) {
       ASSERT_EQ(paramsKV.size() % 2, 0u) << "paramsKV must be name,value pairs";
@@ -628,7 +627,7 @@ TEST_F(HybridBuildMRCommandTest, testBasicCommandTransformation) {
 TEST_F(HybridBuildMRCommandTest, testCommandWithParams) {
     const std::vector<const char*> baseArgs = {
         "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)", "VSIM", "@vector_field", "$BLOB"};
-    const std::vector<const char*> paramsKV = {"param1", "hello", "BLOB", TEST_BLOB_DATA};
+    const std::vector<std::string> paramsKV = {"param1", "hello", "BLOB", TEST_BLOB_DATA};
     testCommandTransformationWithoutIndexSpecWithParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
     testCommandTransformationWithIndexSpecAndParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
 }
@@ -720,7 +719,7 @@ TEST_F(HybridBuildMRCommandTest, testComplexCommandWithAllParams) {
         "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
         "VSIM", "@vector_field", "$BLOB",
         "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3"};
-    const std::vector<const char*> paramsKV = {"param1", "hello", "BLOB", TEST_BLOB_DATA};
+    const std::vector<std::string> paramsKV = {"param1", "hello", "BLOB", TEST_BLOB_DATA};
     testCommandTransformationWithoutIndexSpecWithParams(baseArgs, paramsKV, /*timeoutMS=*/3000, &cp);
     testCommandTransformationWithIndexSpecAndParams(baseArgs, paramsKV, /*timeoutMS=*/3000, &cp);
 }
@@ -730,7 +729,7 @@ TEST_F(HybridBuildMRCommandTest, testComplexCommandWithAllParams) {
 TEST_F(HybridBuildMRCommandTest, testCommandWithParamValueSpellingKeyword) {
     const std::vector<const char*> baseArgs = {
         "FT.HYBRID", "test_idx", "SEARCH", "@title:($p)", "VSIM", "@vector_field", "$BLOB"};
-    const std::vector<const char*> paramsKV = {"p", "TIMEOUT", "BLOB", TEST_BLOB_DATA};
+    const std::vector<std::string> paramsKV = {"p", "TIMEOUT", "BLOB", TEST_BLOB_DATA};
     testCommandTransformationWithoutIndexSpecWithParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
     testCommandTransformationWithIndexSpecAndParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
 }

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -360,17 +360,20 @@ protected:
         // Borrow the resolved scoring context (as the coordinator does before
         // the merger takes ownership) so the reconstructed COMBINE clause is
         // forwarded to the shard.
-        HybridCombineWireParams combineParams{hybridParams.scoringCtx,
-                                              hybridParams.aggregationParams.common.scoreAlias};
+        HybridShardWireParams shardWireParams = {};
+        shardWireParams.combine = HybridCombineWireParams{
+            hybridParams.scoringCtx,
+            hybridParams.aggregationParams.common.scoreAlias
+        };
+        shardWireParams.params = cmd.search->searchopts.params;
+        shardWireParams.forwardTimeout = cmd.timeoutSpecified;
+        shardWireParams.timeoutMS = cmd.clientTimeoutMS;
 
         // Build MR command - now returns kArgIndex instead of calculating effectiveK
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, &combineParams,
-                                     cmd.search->searchopts.params,
-                                     cmd.timeoutSpecified, cmd.clientTimeoutMS,
-                                     &xcmd, nullptr, testIndexSpec, &kArgIndex);
+        HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr,
+                                     testIndexSpec, &kArgIndex);
 
         // Verify the command was built correctly
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
@@ -446,16 +449,19 @@ protected:
             return out;
         }
 
-        HybridCombineWireParams cp{hybridParams.scoringCtx,
-                                   hybridParams.aggregationParams.common.scoreAlias};
+        HybridShardWireParams shardWireParams = {};
+        shardWireParams.combine = HybridCombineWireParams{
+            hybridParams.scoringCtx,
+            hybridParams.aggregationParams.common.scoreAlias
+        };
+        shardWireParams.params = cmd.search->searchopts.params;
+        shardWireParams.forwardTimeout = cmd.timeoutSpecified;
+        shardWireParams.timeoutMS = cmd.clientTimeoutMS;
 
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, &cp,
-                                     cmd.search->searchopts.params,
-                                     cmd.timeoutSpecified, cmd.clientTimeoutMS,
-                                     &xcmd, nullptr, testIndexSpec, &kArgIndex);
+        HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr,
+                                     testIndexSpec, &kArgIndex);
 
         // Assert the parse-driven path also preserves every non-COMBINE arg by
         // position (this is what verifies the PARAMS block - including any
@@ -464,7 +470,7 @@ protected:
         // additionally pins the extracted clause against a literal vector, so the
         // two oracles stay independent.
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
-        verifyArgsPreservedWithReconstructedCombine(&xcmd, inputArgs, &cp);
+        verifyArgsPreservedWithReconstructedCombine(&xcmd, inputArgs, &shardWireParams.combine);
 
         for (int i = 0; i < xcmd.num; i++) {
             if (xcmd.lens[i] == strlen("COMBINE") &&
@@ -529,12 +535,16 @@ protected:
       argsWithNull.push_back(nullptr);
       RMCK::ArgvList args(ctx, argsWithNull.data(), baseArgs.size());
 
+      HybridShardWireParams shardWireParams = {};
+      if (combineParams) shardWireParams.combine = *combineParams;
+      shardWireParams.params = params;
+      shardWireParams.forwardTimeout = forwardTimeout;
+      shardWireParams.timeoutMS = forwardTimeout ? timeoutMS : 0;
+
       MRCommand xcmd;
       int kArgIndex = -1;
-      HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                   /*sendExplainScore=*/false, combineParams,
-                                   params, forwardTimeout, forwardTimeout ? timeoutMS : 0,
-                                   &xcmd, nullptr, nullptr, &kArgIndex);
+      HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr, nullptr,
+                                   &kArgIndex);
       if (params) Param_DictFree(params);
 
       // FT.HYBRID -> _FT.HYBRID, and the base args (no PARAMS/TIMEOUT) preserved
@@ -577,12 +587,16 @@ protected:
       ASSERT_NE(sp->rule->prefixes, nullptr) << "IndexSpec rule should have prefixes";
       ASSERT_EQ(array_len(sp->rule->prefixes), 2) << "IndexSpec rule should have 2 prefixes";
 
+      HybridShardWireParams shardWireParams = {};
+      if (combineParams) shardWireParams.combine = *combineParams;
+      shardWireParams.params = params;
+      shardWireParams.forwardTimeout = forwardTimeout;
+      shardWireParams.timeoutMS = forwardTimeout ? timeoutMS : 0;
+
       MRCommand xcmd;
       int kArgIndex = -1;
-      HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                   /*sendExplainScore=*/false, combineParams,
-                                   params, forwardTimeout, forwardTimeout ? timeoutMS : 0,
-                                   &xcmd, nullptr, sp, &kArgIndex);
+      HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr, sp,
+                                   &kArgIndex);
       if (params) Param_DictFree(params);
 
       // FT.HYBRID -> _FT.HYBRID, base args preserved, COMBINE reconstructed.
@@ -754,14 +768,11 @@ TEST_F(HybridBuildMRCommandTest, testBinaryArgsForwardedAtFullLength) {
     RMCK::ArgvList args(ctx, std::vector<std::string>{
         "FT.HYBRID", index, "SEARCH", query, "VSIM", "@vec", vector});
 
+    HybridShardWireParams shardWireParams = {};  // no COMBINE, no PARAMS, no TIMEOUT
     MRCommand xcmd;
     int kArgIndex = -1;
-    HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                 /*sendExplainScore=*/false,
-                                 /*combineParams=*/nullptr,
-                                 /*params=*/nullptr,
-                                 /*forwardTimeout=*/false, /*timeoutMS=*/0,
-                                 &xcmd, nullptr, nullptr, &kArgIndex);
+    HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr, nullptr,
+                                 &kArgIndex);
 
     // _FT.HYBRID <index> SEARCH <query> VSIM @vec <vector> ...
     ASSERT_GE(xcmd.num, 7);
@@ -785,13 +796,11 @@ TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
             "VSIM", "@vector_field", TEST_BLOB_DATA, nullptr};
         RMCK::ArgvList args(ctx, input.data(), input.size() - 1);
 
+        HybridShardWireParams shardWireParams = {};  // no COMBINE, no PARAMS, no TIMEOUT
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, /*combineParams=*/nullptr,
-                                     /*params=*/nullptr,
-                                     /*forwardTimeout=*/false, /*timeoutMS=*/0,
-                                     &xcmd, nullptr, nullptr, &kArgIndex);
+        HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr, nullptr,
+                                     &kArgIndex);
 
         EXPECT_EQ(countTok(toTokens(&xcmd), "EXPLAINSCORE"), 1)
             << "EXPLAINSCORE in the search query must not be re-appended as a "
@@ -813,12 +822,13 @@ TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
         dict *params = makeParamsDict({"param1", "EXPLAINSCORE", "BLOB", TEST_BLOB_DATA},
                                       expectedPairs);
 
+        HybridShardWireParams shardWireParams = {};
+        shardWireParams.params = params;
+
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, /*combineParams=*/nullptr,
-                                     params, /*forwardTimeout=*/false, /*timeoutMS=*/0,
-                                     &xcmd, nullptr, nullptr, &kArgIndex);
+        HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr, nullptr,
+                                     &kArgIndex);
         Param_DictFree(params);
 
         EXPECT_EQ(countTok(toTokens(&xcmd), "EXPLAINSCORE"), 1)
@@ -833,12 +843,13 @@ TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
             "VSIM", "@vector_field", TEST_BLOB_DATA, nullptr};
         RMCK::ArgvList args(ctx, input.data(), input.size() - 1);
 
+        HybridShardWireParams shardWireParams = {};
+        shardWireParams.sendExplainScore = true;
+
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/true, /*combineParams=*/nullptr,
-                                     /*params=*/nullptr, /*forwardTimeout=*/false, /*timeoutMS=*/0,
-                                     &xcmd, nullptr, nullptr, &kArgIndex);
+        HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr, nullptr,
+                                     &kArgIndex);
 
         EXPECT_EQ(countTok(toTokens(&xcmd), "EXPLAINSCORE"), 1)
             << "EXPLAINSCORE should be appended exactly once when the parsed "

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -15,12 +15,115 @@
 
 #include "dist_hybrid.h"
 #include "hybrid/hybrid_scoring.h"
+#include "param.h"
 
 #include <string>
 #include <string_view>
 #include <vector>
+#include <set>
+#include <utility>
 
 #define TEST_BLOB_DATA "AQIDBAUGBwgJCg=="
+
+using ParamList = std::vector<std::pair<std::string, std::string>>;
+using PairSet = std::set<std::pair<std::string, std::string>>;
+
+// Copy an MRCommand's args into a binary-safe token vector (each token carries
+// its explicit length, so embedded NULs survive).
+static std::vector<std::string> toTokens(const MRCommand *cmd) {
+  std::vector<std::string> toks;
+  toks.reserve(cmd->num);
+  for (int i = 0; i < cmd->num; i++) toks.emplace_back(cmd->strs[i], cmd->lens[i]);
+  return toks;
+}
+
+// Count output tokens exactly matching `tok` (case-insensitive).
+static int countTok(const std::vector<std::string> &toks, std::string_view tok) {
+  int n = 0;
+  for (const auto &t : toks) {
+    if (t.size() == tok.size() && strncasecmp(t.data(), tok.data(), t.size()) == 0) n++;
+  }
+  return n;
+}
+
+// Collect the {name, value} pairs of the PARAMS clause whose "PARAMS" keyword is
+// at toks[start]; toks[start + 1] is the declared token count (2 * #pairs).
+// *outCount, when non-NULL, receives that count. Values are copied verbatim, so
+// a token vector built from length-delimited wire data stays binary-safe.
+// Centralizes the "PARAMS n k v k v ..." decoding shared by the assertions below.
+static PairSet collectParamsPairs(const std::vector<std::string> &toks, size_t start,
+                                  long *outCount) {
+  long count = (start + 1 < toks.size()) ? atol(toks[start + 1].c_str()) : 0;
+  if (outCount) *outCount = count;
+  PairSet pairs;
+  for (long j = 0; j + 1 < count && start + 3 + (size_t)j < toks.size(); j += 2) {
+    pairs.insert({toks[start + 2 + j], toks[start + 3 + j]});
+  }
+  return pairs;
+}
+
+// Assert the built command carries exactly the PARAMS clause described by
+// `expected` (as an order-independent set of pairs, with count == 2*N), or no
+// PARAMS clause at all when `expected` is empty.
+static void expectParamsBlock(const std::vector<std::string> &toks, const ParamList &expected) {
+  bool found = false;
+  long count = -1;
+  PairSet got;
+  for (size_t i = 0; i + 1 < toks.size(); i++) {
+    if (toks[i] == "PARAMS") {
+      found = true;
+      got = collectParamsPairs(toks, i, &count);
+      break;
+    }
+  }
+  if (expected.empty()) {
+    EXPECT_FALSE(found) << "expected no PARAMS clause";
+    return;
+  }
+  EXPECT_TRUE(found) << "expected a PARAMS clause";
+  EXPECT_EQ(count, (long)expected.size() * 2) << "PARAMS count must be 2 * number of pairs";
+  PairSet want(expected.begin(), expected.end());
+  EXPECT_EQ(got, want);
+}
+
+// Return the token following the first occurrence of `clause`, or "" if absent.
+static std::string valueAfter(const std::vector<std::string> &toks, const char *clause) {
+  for (size_t i = 0; i + 1 < toks.size(); i++) {
+    if (toks[i] == clause) return toks[i + 1];
+  }
+  return "";
+}
+
+// Verify the reconstructed PARAMS and TIMEOUT clauses on an output token stream.
+// A parameter value may itself spell "TIMEOUT"; such occurrences live inside the
+// PARAMS block and must not be counted as the top-level clause, so the expected
+// TIMEOUT token count is (forwarded ? 1 : 0) + (# param values == TIMEOUT).
+static void expectParamsAndTimeout(const std::vector<std::string> &toks,
+                                   const ParamList &expectedPairs,
+                                   bool forwardTimeout, long long timeoutMS) {
+  expectParamsBlock(toks, expectedPairs);
+  int timeoutInParams = 0;
+  for (const auto &kv : expectedPairs) {
+    if (strcasecmp(kv.second.c_str(), "TIMEOUT") == 0) timeoutInParams++;
+  }
+  EXPECT_EQ(countTok(toks, "TIMEOUT"), (forwardTimeout ? 1 : 0) + timeoutInParams);
+  if (forwardTimeout && timeoutInParams == 0) {
+    EXPECT_EQ(valueAfter(toks, "TIMEOUT"), std::to_string(timeoutMS));
+  }
+}
+
+// Build a parameter dict from a flat name,value,... list, recording the
+// expected pairs. Returns NULL for an empty list (the no-PARAMS case). The
+// returned dict is owned by the caller (free with Param_DictFree).
+dict *makeParamsDict(const std::vector<const char*>& paramsKV, ParamList &expectedPairs) {
+  dict *params = paramsKV.empty() ? nullptr : Param_DictCreate();
+  QueryError status = QueryError_Default();
+  for (size_t i = 0; i + 1 < paramsKV.size(); i += 2) {
+    Param_DictAdd(params, paramsKV[i], paramsKV[i + 1], strlen(paramsKV[i + 1]), &status);
+    expectedPairs.push_back({paramsKV[i], paramsKV[i + 1]});
+  }
+  return params;
+}
 
 // Format a double exactly as MRCommand_appendCombine does for the wire
 // (round-trip-safe "%.17g"). Tests use this so expectations can be written
@@ -87,7 +190,9 @@ static HybridCombineWireParams linearWireParams(HybridScoringContext *sc, double
 // block; the oracle spots it in the output (COMBINE followed by a scoring
 // method - a PARAMS-value COMBINE never is) and, if the client supplied its own
 // COMBINE clause, drops that clause from the input side since the reconstructed
-// form replaces it. Returns the output index just past the matched prefix.
+// form replaces it. The PARAMS clause is reconstructed from the parsed dict, so
+// it is compared as an order-independent {name, value} set rather than by
+// position. Returns the output index just past the matched prefix.
 static int verifyArgsPreservedWithReconstructedCombine(
     const MRCommand *xcmd, const std::vector<const char *> &inputArgs,
     const HybridCombineWireParams *cp) {
@@ -117,6 +222,34 @@ static int verifyArgsPreservedWithReconstructedCombine(
           ii += 2;                        // positional YIELD_SCORE_AS <alias>
         }
       }
+      continue;
+    }
+    // PARAMS is reconstructed from the parsed dictionary, so the pair order on
+    // the wire need not match the client's input order. Slice each PARAMS clause
+    // into tokens and compare them as order-independent {name, value} sets via
+    // the shared collectParamsPairs (binary-safe on the length-delimited output).
+    if (strcasecmp(inputArgs[ii], "PARAMS") == 0) {
+      const long inCount = atol(inputArgs[ii + 1]);
+      std::vector<std::string> inToks;
+      for (long k = 0; k < 2 + inCount && ii + (size_t)k < inputArgs.size(); k++) {
+        inToks.emplace_back(inputArgs[ii + k]);
+      }
+      PairSet want = collectParamsPairs(inToks, 0, nullptr);
+      ii += 2 + (size_t)inCount;
+
+      EXPECT_LT(oi + 1, xcmd->num) << "output should carry a reconstructed PARAMS clause";
+      EXPECT_STREQ(xcmd->strs[oi], "PARAMS") << "PARAMS clause expected at output index " << oi;
+      const long outDeclared = (oi + 1 < xcmd->num) ? atol(xcmd->strs[oi + 1]) : 0;
+      std::vector<std::string> outToks;
+      for (int k = 0; k < 2 + (int)outDeclared && oi + k < xcmd->num; k++) {
+        outToks.emplace_back(xcmd->strs[oi + k], xcmd->lens[oi + k]);
+      }
+      long outCount = 0;
+      PairSet got = collectParamsPairs(outToks, 0, &outCount);
+      EXPECT_EQ(outCount, inCount) << "PARAMS count must equal 2 * number of parsed params";
+      EXPECT_EQ(got, want)
+          << "reconstructed PARAMS pairs must match the client's (order-independent)";
+      oi += 2 + (size_t)outCount;
       continue;
     }
     EXPECT_STREQ(xcmd->strs[oi], inputArgs[ii])
@@ -235,8 +368,10 @@ protected:
         MRCommand xcmd;
         int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, &combineParams, &xcmd,
-                                     nullptr, testIndexSpec, &kArgIndex);
+                                     /*sendExplainScore=*/false, &combineParams,
+                                     cmd.search->searchopts.params,
+                                     cmd.timeoutSpecified, cmd.clientTimeoutMS,
+                                     &xcmd, nullptr, testIndexSpec, &kArgIndex);
 
         // Verify the command was built correctly
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
@@ -318,8 +453,10 @@ protected:
         MRCommand xcmd;
         int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, &cp, &xcmd,
-                                     nullptr, testIndexSpec, &kArgIndex);
+                                     /*sendExplainScore=*/false, &cp,
+                                     cmd.search->searchopts.params,
+                                     cmd.timeoutSpecified, cmd.clientTimeoutMS,
+                                     &xcmd, nullptr, testIndexSpec, &kArgIndex);
 
         // Assert the parse-driven path also preserves every non-COMBINE arg by
         // position (this is what verifies the PARAMS block - including any
@@ -367,75 +504,99 @@ protected:
     // Helper function to test command transformation
     void testCommandTransformationWithoutIndexSpec(const std::vector<const char*>& inputArgs,
                                                    const HybridCombineWireParams *combineParams = nullptr) {
-        // Access the global NumShards variable
-        extern size_t NumShards;
-
-        // Convert vector to array for ArgvList constructor
-        std::vector<const char*> argsWithNull = inputArgs;
-        argsWithNull.push_back(nullptr);  // ArgvList expects null-terminated
-
-        // Create ArgvList from input
-        RMCK::ArgvList args(ctx, argsWithNull.data(), inputArgs.size());
-
-        // Build MR command
-        MRCommand xcmd;
-        int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, combineParams, &xcmd,
-                                     nullptr, nullptr, &kArgIndex);
-
-        // Verify transformation: FT.HYBRID -> _FT.HYBRID
-        EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
-
-        // Verify original args are preserved, with the COMBINE clause replaced by
-        // its reconstructed (old-shard-compatible) form.
-        verifyArgsPreservedWithReconstructedCombine(&xcmd, inputArgs, combineParams);
-
-        // Verify WITHCURSOR, WITHSCORES, _NUM_SSTRING, _COORD_DISPATCH_TIME are added at the end
-        // Note: _COORD_DISPATCH_TIME and its placeholder value (2 args) are added after _NUM_SSTRING
-        EXPECT_STREQ(xcmd.strs[xcmd.num - 7], "WITHCURSOR") << "WITHCURSOR should be seventh to last";
-        EXPECT_STREQ(xcmd.strs[xcmd.num - 6], "WITHSCORES") << "WITHSCORES should be sixth to last";
-        EXPECT_STREQ(xcmd.strs[xcmd.num - 5], "_NUM_SSTRING") << "_NUM_SSTRING should be fifth to last";
-        EXPECT_STREQ(xcmd.strs[xcmd.num - 2], "_COORD_DISPATCH_TIME") << "_COORD_DISPATCH_TIME should be second to last";
-        EXPECT_STREQ(xcmd.strs[xcmd.num - 1], "") << "Dispatch time placeholder should be last (empty)";
-
-        MRCommand_Free(&xcmd);
+        testCommandTransformationWithoutIndexSpecWithParams(inputArgs, /*paramsKV=*/{},
+                                                            /*timeoutMS=*/-1, combineParams);
     }
 
     // Helper function to test command transformation
     void testCommandTransformationWithIndexSpec(const std::vector<const char*>& inputArgs,
                                                 const HybridCombineWireParams *combineParams = nullptr) {
-      // Access the global NumShards variable
-      extern size_t NumShards;
+        testCommandTransformationWithIndexSpecAndParams(inputArgs, /*paramsKV=*/{},
+                                                        /*timeoutMS=*/-1, combineParams);
+    }
 
-      // Convert vector to array for ArgvList constructor
-      std::vector<const char*> argsWithNull = inputArgs;
-      argsWithNull.push_back(nullptr);  // ArgvList expects null-terminated
+  void testCommandTransformationWithoutIndexSpecWithParams(
+          const std::vector<const char*>& baseArgs,
+          const std::vector<const char*>& paramsKV,
+          long long timeoutMS,
+          const HybridCombineWireParams *combineParams = nullptr) {
+      ASSERT_EQ(paramsKV.size() % 2, 0u) << "paramsKV must be name,value pairs";
 
-      // Create ArgvList from input
-      RMCK::ArgvList args(ctx, argsWithNull.data(), inputArgs.size());
+      ParamList expectedPairs;
+      dict *params = makeParamsDict(paramsKV, expectedPairs);
+      const bool forwardTimeout = timeoutMS >= 0;
+
+      std::vector<const char*> argsWithNull = baseArgs;
+      argsWithNull.push_back(nullptr);
+      RMCK::ArgvList args(ctx, argsWithNull.data(), baseArgs.size());
+
+      MRCommand xcmd;
+      int kArgIndex = -1;
+      HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
+                                   /*sendExplainScore=*/false, combineParams,
+                                   params, forwardTimeout, forwardTimeout ? timeoutMS : 0,
+                                   &xcmd, nullptr, nullptr, &kArgIndex);
+      if (params) Param_DictFree(params);
+
+      // FT.HYBRID -> _FT.HYBRID, and the base args (no PARAMS/TIMEOUT) preserved
+      // with the COMBINE clause reconstructed.
+      EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
+      verifyArgsPreservedWithReconstructedCombine(&xcmd, baseArgs, combineParams);
+
+      // Check the reconstructed PARAMS/TIMEOUT clauses on the token stream.
+      std::vector<std::string> toks = toTokens(&xcmd);
+      expectParamsAndTimeout(toks, expectedPairs, forwardTimeout, timeoutMS);
+
+      // The fixed trailing block is unaffected by PARAMS/TIMEOUT length.
+      EXPECT_STREQ(xcmd.strs[xcmd.num - 7], "WITHCURSOR") << "WITHCURSOR should be seventh to last";
+      EXPECT_STREQ(xcmd.strs[xcmd.num - 6], "WITHSCORES") << "WITHSCORES should be sixth to last";
+      EXPECT_STREQ(xcmd.strs[xcmd.num - 5], "_NUM_SSTRING") << "_NUM_SSTRING should be fifth to last";
+      EXPECT_STREQ(xcmd.strs[xcmd.num - 2], "_COORD_DISPATCH_TIME") << "_COORD_DISPATCH_TIME should be second to last";
+      EXPECT_STREQ(xcmd.strs[xcmd.num - 1], "") << "Dispatch time placeholder should be last (empty)";
+
+      MRCommand_Free(&xcmd);
+  }
+
+  void testCommandTransformationWithIndexSpecAndParams(
+          const std::vector<const char*>& baseArgs,
+          const std::vector<const char*>& paramsKV,
+          long long timeoutMS,
+          const HybridCombineWireParams *combineParams = nullptr) {
+      ASSERT_EQ(paramsKV.size() % 2, 0u) << "paramsKV must be name,value pairs";
+
+      ParamList expectedPairs;
+      dict *params = makeParamsDict(paramsKV, expectedPairs);
+      const bool forwardTimeout = timeoutMS >= 0;
+
+      std::vector<const char*> argsWithNull = baseArgs;
+      argsWithNull.push_back(nullptr);
+      RMCK::ArgvList args(ctx, argsWithNull.data(), baseArgs.size());
       RefManager *ism = createSpec(ctx, {"prefix1", "prefix2"});
-
-      // Get the IndexSpec from the RefManager
       IndexSpec *sp = get_spec(ism);
       ASSERT_NE(sp, nullptr) << "IndexSpec should be accessible from RefManager";
       ASSERT_NE(sp->rule, nullptr) << "IndexSpec should have a rule";
       ASSERT_NE(sp->rule->prefixes, nullptr) << "IndexSpec rule should have prefixes";
       ASSERT_EQ(array_len(sp->rule->prefixes), 2) << "IndexSpec rule should have 2 prefixes";
 
-      // Build MR command (not testing SHARD_K_RATIO here)
       MRCommand xcmd;
       int kArgIndex = -1;
       HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                   /*sendExplainScore=*/false, combineParams, &xcmd,
-                                   nullptr, sp, &kArgIndex);
-      // Verify transformation: FT.HYBRID -> _FT.HYBRID
+                                   /*sendExplainScore=*/false, combineParams,
+                                   params, forwardTimeout, forwardTimeout ? timeoutMS : 0,
+                                   &xcmd, nullptr, sp, &kArgIndex);
+      if (params) Param_DictFree(params);
+
+      // FT.HYBRID -> _FT.HYBRID, base args preserved, COMBINE reconstructed.
       EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
-      // Verify original args are preserved, with the COMBINE clause replaced by
-      // its reconstructed (old-shard-compatible) form.
-      verifyArgsPreservedWithReconstructedCombine(&xcmd, inputArgs, combineParams);
-      // Verify WITHCURSOR, WITHSCORES, _NUM_SSTRING, SLOTS, _COORD_DISPATCH_TIME, _INDEX_PREFIXES, and prefixes are added at the end
-      // Order: ... WITHCURSOR WITHSCORES _NUM_SSTRING _SLOTS <slots_blob> _COORD_DISPATCH_TIME <placeholder> _INDEX_PREFIXES 2 prefix1 prefix2
+      verifyArgsPreservedWithReconstructedCombine(&xcmd, baseArgs, combineParams);
+
+      // PARAMS/TIMEOUT are emitted before the spec trailing block, so they are
+      // asserted the same way regardless of the spec.
+      std::vector<std::string> toks = toTokens(&xcmd);
+      expectParamsAndTimeout(toks, expectedPairs, forwardTimeout, timeoutMS);
+
+      // Spec-dependent trailing block:
+      // ... WITHCURSOR WITHSCORES _NUM_SSTRING _SLOTS <blob> _COORD_DISPATCH_TIME <placeholder> _INDEX_PREFIXES 2 prefix1 prefix2
       EXPECT_STREQ(xcmd.strs[xcmd.num - 11], "WITHCURSOR") << "WITHCURSOR should be 11th to last";
       EXPECT_STREQ(xcmd.strs[xcmd.num - 10], "WITHSCORES") << "WITHSCORES should be 10th to last";
       EXPECT_STREQ(xcmd.strs[xcmd.num - 9], "_NUM_SSTRING") << "_NUM_SSTRING should be 9th to last";
@@ -448,7 +609,6 @@ protected:
       EXPECT_STREQ(xcmd.strs[xcmd.num - 2], "prefix1") << "First prefix should be 2nd to last";
       EXPECT_STREQ(xcmd.strs[xcmd.num - 1], "prefix2") << "Second prefix should be last";
 
-      // Clean up
       MRCommand_Free(&xcmd);
       freeSpec(ism);
   }
@@ -464,44 +624,27 @@ TEST_F(HybridBuildMRCommandTest, testBasicCommandTransformation) {
     });
 }
 
-// Test command with PARAMS
+// Test command with PARAMS (supplied separately, as parse would produce them).
 TEST_F(HybridBuildMRCommandTest, testCommandWithParams) {
-    testCommandTransformationWithoutIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-        "VSIM", "@vector_field", "$BLOB",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA
-    });
-    testCommandTransformationWithIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-        "VSIM", "@vector_field", "$BLOB",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA
-    });
+    const std::vector<const char*> baseArgs = {
+        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)", "VSIM", "@vector_field", "$BLOB"};
+    const std::vector<const char*> paramsKV = {"param1", "hello", "BLOB", TEST_BLOB_DATA};
+    testCommandTransformationWithoutIndexSpecWithParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
+    testCommandTransformationWithIndexSpecAndParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
 }
 
-// Test command with TIMEOUT
+// Test command with TIMEOUT (no params).
 TEST_F(HybridBuildMRCommandTest, testCommandWithTimeout) {
-    testCommandTransformationWithoutIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "hello",
-        "VSIM", "@vector_field", TEST_BLOB_DATA,
-        "TIMEOUT", "5000"
-    });
-    testCommandTransformationWithIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "hello",
-        "VSIM", "@vector_field", TEST_BLOB_DATA,
-        "TIMEOUT", "5000"
-    });
+    const std::vector<const char*> baseArgs = {
+        "FT.HYBRID", "test_idx", "SEARCH", "hello", "VSIM", "@vector_field", TEST_BLOB_DATA};
+    testCommandTransformationWithoutIndexSpecWithParams(baseArgs, /*paramsKV=*/{}, /*timeoutMS=*/5000);
+    testCommandTransformationWithIndexSpecAndParams(baseArgs, /*paramsKV=*/{}, /*timeoutMS=*/5000);
 }
 
-// Test command with DIALECT
-TEST_F(HybridBuildMRCommandTest, testCommandWithDialect) {
-    testCommandTransformationWithoutIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "hello",
-        "VSIM", "@vector_field", TEST_BLOB_DATA,
-        "DIALECT", "2"
-    });
-}
+// Note: there is no DIALECT test - FT.HYBRID rejects DIALECT at parse time, so
+// it is never forwarded to shards
 
-// Test command with DIALECT
+// Test command with COMBINE
 TEST_F(HybridBuildMRCommandTest, testCommandWithCombine) {
     HybridScoringContext sc = {};
     double w[2];
@@ -509,14 +652,12 @@ TEST_F(HybridBuildMRCommandTest, testCommandWithCombine) {
     testCommandTransformationWithoutIndexSpec({
         "FT.HYBRID", "test_idx", "SEARCH", "hello",
         "VSIM", "@vector_field", TEST_BLOB_DATA, "FILTER", "@tag:{invalid_tag}",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "DIALECT", "2"
+        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3"
     }, &cp);
     testCommandTransformationWithIndexSpec({
         "FT.HYBRID", "test_idx", "SEARCH", "hello",
         "VSIM", "@vector_field", TEST_BLOB_DATA, "FILTER", "@tag:{invalid_tag}",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "DIALECT", "2"
+        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3"
     }, &cp);
 }
 
@@ -570,48 +711,28 @@ TEST_F(HybridBuildMRCommandTest, testFilterWithPolicyBatchSizeAndCombine) {
     }, &cp);
 }
 
-// Test complex command with all optional parameters
+// Test complex command with COMBINE + PARAMS + TIMEOUT together.
 TEST_F(HybridBuildMRCommandTest, testComplexCommandWithAllParams) {
     HybridScoringContext sc = {};
     double w[2];
     HybridCombineWireParams cp = linearWireParams(&sc, w, 0.7, 0.3, HYBRID_DEFAULT_WINDOW);
-    testCommandTransformationWithoutIndexSpec({
+    const std::vector<const char*> baseArgs = {
         "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
         "VSIM", "@vector_field", "$BLOB",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA,
-        "TIMEOUT", "3000", "DIALECT", "2"
-    }, &cp);
-    testCommandTransformationWithIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-        "VSIM", "@vector_field", "$BLOB",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA,
-        "TIMEOUT", "3000", "DIALECT", "2"
-    }, &cp);
+        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3"};
+    const std::vector<const char*> paramsKV = {"param1", "hello", "BLOB", TEST_BLOB_DATA};
+    testCommandTransformationWithoutIndexSpecWithParams(baseArgs, paramsKV, /*timeoutMS=*/3000, &cp);
+    testCommandTransformationWithIndexSpecAndParams(baseArgs, paramsKV, /*timeoutMS=*/3000, &cp);
 }
 
-// Test complex command with all optional parameters
-TEST_F(HybridBuildMRCommandTest, testComplexCommandParamsAfterTimeout) {
-    HybridScoringContext sc = {};
-    double w[2];
-    HybridCombineWireParams cp = linearWireParams(&sc, w, 0.7, 0.3, HYBRID_DEFAULT_WINDOW);
-    testCommandTransformationWithoutIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-        "VSIM", "@vector_field", "$BLOB",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA,
-        "TIMEOUT", "3000",
-        "DIALECT", "2"
-    }, &cp);
-    testCommandTransformationWithIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-        "VSIM", "@vector_field", "$BLOB",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA,
-        "TIMEOUT", "3000",
-        "DIALECT", "2"
-    }, &cp);
+// A parameter *value* that spells a top-level keyword is carried inside the PARAMS
+// block, never mistaken for that clause (the value happens to be "TIMEOUT" here).
+TEST_F(HybridBuildMRCommandTest, testCommandWithParamValueSpellingKeyword) {
+    const std::vector<const char*> baseArgs = {
+        "FT.HYBRID", "test_idx", "SEARCH", "@title:($p)", "VSIM", "@vector_field", "$BLOB"};
+    const std::vector<const char*> paramsKV = {"p", "TIMEOUT", "BLOB", TEST_BLOB_DATA};
+    testCommandTransformationWithoutIndexSpecWithParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
+    testCommandTransformationWithIndexSpecAndParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
 }
 
 // Test minimal command
@@ -637,8 +758,11 @@ TEST_F(HybridBuildMRCommandTest, testBinaryArgsForwardedAtFullLength) {
     MRCommand xcmd;
     int kArgIndex = -1;
     HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                 /*sendExplainScore=*/false, nullptr, &xcmd,
-                                 nullptr, nullptr, &kArgIndex);
+                                 /*sendExplainScore=*/false,
+                                 /*combineParams=*/nullptr,
+                                 /*params=*/nullptr,
+                                 /*forwardTimeout=*/false, /*timeoutMS=*/0,
+                                 &xcmd, nullptr, nullptr, &kArgIndex);
 
     // _FT.HYBRID <index> SEARCH <query> VSIM @vec <vector> ...
     ASSERT_GE(xcmd.num, 7);
@@ -656,17 +780,6 @@ TEST_F(HybridBuildMRCommandTest, testBinaryArgsForwardedAtFullLength) {
 // option, not by argv text. A SEARCH query token or PARAMS value equal to
 // "EXPLAINSCORE" must not trigger forwarding; sendExplainScore=true must.
 TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
-    auto countToken = [](const MRCommand *cmd, std::string_view tok) {
-        int n = 0;
-        for (int i = 0; i < cmd->num; i++) {
-            if (cmd->lens[i] == tok.size() &&
-                strncasecmp(cmd->strs[i], tok.data(), tok.size()) == 0) {
-                n++;
-            }
-        }
-        return n;
-    };
-
     {
         std::vector<const char *> input = {
             "FT.HYBRID", "test_idx", "SEARCH", "EXPLAINSCORE",
@@ -676,30 +789,40 @@ TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
         MRCommand xcmd;
         int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, /*combineParams=*/nullptr, &xcmd,
-                                     nullptr, nullptr, &kArgIndex);
+                                     /*sendExplainScore=*/false, /*combineParams=*/nullptr,
+                                     /*params=*/nullptr,
+                                     /*forwardTimeout=*/false, /*timeoutMS=*/0,
+                                     &xcmd, nullptr, nullptr, &kArgIndex);
 
-        EXPECT_EQ(countToken(&xcmd, "EXPLAINSCORE"), 1)
+        EXPECT_EQ(countTok(toTokens(&xcmd), "EXPLAINSCORE"), 1)
             << "EXPLAINSCORE in the search query must not be re-appended as a "
                "top-level shard option";
         MRCommand_Free(&xcmd);
     }
 
+    // A PARAMS *value* equal to "EXPLAINSCORE" is carried inside the PARAMS
+    // block (reconstructed from the parsed dict) and must not be re-appended as
+    // a top-level shard option when the parsed flag is unset. It therefore
+    // appears exactly once - as the param value.
     {
         std::vector<const char *> input = {
             "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-            "VSIM", "@vector_field", "$BLOB",
-            "PARAMS", "4", "param1", "EXPLAINSCORE", "BLOB", TEST_BLOB_DATA,
-            nullptr};
+            "VSIM", "@vector_field", "$BLOB", nullptr};
         RMCK::ArgvList args(ctx, input.data(), input.size() - 1);
+
+        ParamList expectedPairs;
+        dict *params = makeParamsDict({"param1", "EXPLAINSCORE", "BLOB", TEST_BLOB_DATA},
+                                      expectedPairs);
 
         MRCommand xcmd;
         int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, /*combineParams=*/nullptr, &xcmd,
-                                     nullptr, nullptr, &kArgIndex);
+                                     /*sendExplainScore=*/false, /*combineParams=*/nullptr,
+                                     params, /*forwardTimeout=*/false, /*timeoutMS=*/0,
+                                     &xcmd, nullptr, nullptr, &kArgIndex);
+        Param_DictFree(params);
 
-        EXPECT_EQ(countToken(&xcmd, "EXPLAINSCORE"), 1)
+        EXPECT_EQ(countTok(toTokens(&xcmd), "EXPLAINSCORE"), 1)
             << "EXPLAINSCORE as a PARAMS value must not be re-appended as a "
                "top-level shard option";
         MRCommand_Free(&xcmd);
@@ -714,10 +837,11 @@ TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
         MRCommand xcmd;
         int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/true, /*combineParams=*/nullptr, &xcmd,
-                                     nullptr, nullptr, &kArgIndex);
+                                     /*sendExplainScore=*/true, /*combineParams=*/nullptr,
+                                     /*params=*/nullptr, /*forwardTimeout=*/false, /*timeoutMS=*/0,
+                                     &xcmd, nullptr, nullptr, &kArgIndex);
 
-        EXPECT_EQ(countToken(&xcmd, "EXPLAINSCORE"), 1)
+        EXPECT_EQ(countTok(toTokens(&xcmd), "EXPLAINSCORE"), 1)
             << "EXPLAINSCORE should be appended exactly once when the parsed "
                "flag is set";
         MRCommand_Free(&xcmd);

--- a/tests/pytests/test_hybrid_yield.py
+++ b/tests/pytests/test_hybrid_yield.py
@@ -284,12 +284,17 @@ def test_hybrid_yield_score_as_keyword_alias():
         # Counted form: count 4 covers CONSTANT 60 YIELD_SCORE_AS <alias>
         counted, _ = get_results_from_hybrid_response(env.cmd(
             'FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', '$BLOB',
+            # initQueryTimeout() detects the keyword TIMEOUT by arg scanning,
+            # so we need to place it before the COMBINE clause to avoid confusion.
+            # Remove this once MOD-17165 is implemented.
+            'TIMEOUT', '1000',
             'COMBINE', 'RRF', '4', 'CONSTANT', '60', 'YIELD_SCORE_AS', alias,
             'PARAMS', '2', 'BLOB', query_vector))
 
         # Positional form: count 2 covers CONSTANT 60, YIELD_SCORE_AS follows
         positional, _ = get_results_from_hybrid_response(env.cmd(
             'FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', '$BLOB',
+            'TIMEOUT', '1000',
             'COMBINE', 'RRF', '2', 'CONSTANT', '60', 'YIELD_SCORE_AS', alias,
             'PARAMS', '2', 'BLOB', query_vector))
 

--- a/tests/pytests/test_hybrid_yield.py
+++ b/tests/pytests/test_hybrid_yield.py
@@ -250,7 +250,7 @@ def test_hybrid_combine_yield_score_as_both_forms():
     produce the same results."""
     env = Env()
     setup_basic_index(env)
-    query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
+    query_vector = np.array([1.2, 0.3]).astype(np.float32).tobytes()
 
     # Counted form: count 4 covers CONSTANT 60 YIELD_SCORE_AS search_score
     counted, _ = get_results_from_hybrid_response(env.cmd(
@@ -271,6 +271,35 @@ def test_hybrid_combine_yield_score_as_both_forms():
             env.assertGreater(float(results[doc_key]['search_score']), 0)
     env.assertEqual(counted, positional,
                     message="Counted and positional YIELD_SCORE_AS must be equivalent")
+
+def test_hybrid_yield_score_as_keyword_alias():
+    """A YIELD_SCORE_AS alias that collides with a top-level keyword
+    (PARAMS/TIMEOUT/DIALECT) must not confuse the coordinator when it builds the
+    per-shard command."""
+    env = Env()
+    setup_basic_index(env)
+    query_vector = np.array([1.2, 0.3]).astype(np.float32).tobytes()
+
+    for alias in ('PARAMS', 'TIMEOUT', 'DIALECT', 'YIELD_SCORE_AS'):
+        # Counted form: count 4 covers CONSTANT 60 YIELD_SCORE_AS <alias>
+        counted, _ = get_results_from_hybrid_response(env.cmd(
+            'FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', '$BLOB',
+            'COMBINE', 'RRF', '4', 'CONSTANT', '60', 'YIELD_SCORE_AS', alias,
+            'PARAMS', '2', 'BLOB', query_vector))
+
+        # Positional form: count 2 covers CONSTANT 60, YIELD_SCORE_AS follows
+        positional, _ = get_results_from_hybrid_response(env.cmd(
+            'FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', '$BLOB',
+            'COMBINE', 'RRF', '2', 'CONSTANT', '60', 'YIELD_SCORE_AS', alias,
+            'PARAMS', '2', 'BLOB', query_vector))
+
+        env.assertGreater(len(counted.keys()), 0, message=f"alias={alias}")
+        for results in (counted, positional):
+            for doc_key in results:
+                env.assertTrue(alias in results[doc_key], message=f"alias={alias}")
+                env.assertGreater(float(results[doc_key][alias]), 0, message=f"alias={alias}")
+        env.assertEqual(counted, positional,
+                        message=f"Counted and positional YIELD_SCORE_AS must be equivalent (alias={alias})")
 
 def test_hybrid_combine_duplicate_yield_score_as_error():
     """A duplicate YIELD_SCORE_AS after the COMBINE clause is rejected."""


### PR DESCRIPTION
## Description

1. **Current:** 
    - When the coordinator builds the per-shard `_FT.HYBRID` command, it reconstructed the `PARAMS`, `TIMEOUT`, and `DIALECT` clauses by re-scanning the raw `argv` with `RMUtil_ArgIndex("PARAMS"/"TIMEOUT"/"DIALECT", ...)`. This positional keyword search is fragile: a `YIELD_SCORE_AS` alias or a `PARAMS` name/value that happens to be spelled `PARAMS`, `TIMEOUT`, or `DIALECT` is indistinguishable from the real top-level keyword, so the coordinator could misidentify arguments and build a malformed shard command. 
    - `TIMEOUT` was also relayed verbatim from argv 
    - `DIALECT` was forwarded despite `FT.HYBRID` rejecting it at parse time.

2. **Change:**
   - `HybridRequest_buildMRCommand` now takes the already-parsed state instead of re-scanning `argv`:
     - `PARAMS` is reconstructed from the resolved parameter dictionary (`searchopts.params`) via a new `MRCommand_appendParams` helper. 
     - `TIMEOUT` is forwarded from `timeoutSpecified` / `clientTimeoutMS`
     - `DIALECT` is no longer forwarded (a valid `FT.HYBRID` never carries one).

3. **Outcome:** 
  - The coordinator builds the correct per-shard command regardless of user-chosen `YIELD_SCORE_AS` aliases or parameter names, the client timeout is forwarded accurately, and `DIALECT` is no longer needlessly relayed.

#### Which additional issues this PR fixes
1. MOD-17092

#### Main objects this PR modified
1. `HybridRequest_buildMRCommand` + new `MRCommand_appendParams` (`src/coord/hybrid/dist_hybrid.c/.h`)
2. `parseHybridCommand` / `ParseHybridCommandCtx` (`src/hybrid/parse_hybrid.c/.h`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Fixes incorrect per-shard command construction for clustered `FT.HYBRID` when a `YIELD_SCORE_AS` alias or `PARAMS` entry collides with a top-level keyword (`PARAMS`/`TIMEOUT`/`DIALECT`), and forwards the exact client-requested query timeout to shards.
