### PR TITLE
Document local sccache setup in build skill

### DIFF
--- a/.skills/build/SKILL.md
+++ b/.skills/build/SKILL.md
@@ -23,7 +23,15 @@ if command -v sccache >/dev/null 2>&1; then
   repo_parent="$(cd "$repo_root/.." && pwd)"
   export SCCACHE_CACHE_SIZE="${SCCACHE_CACHE_SIZE:-30G}"
   export SCCACHE_BASEDIRS="${SCCACHE_BASEDIRS:-$repo_parent}"
-  export RUSTC_WRAPPER="${RUSTC_WRAPPER:-sccache}"
+  if SCCACHE_PROBE_OUTPUT="$(sccache --show-stats 2>&1)"; then
+    export RUSTC_WRAPPER="${RUSTC_WRAPPER:-sccache}"
+  else
+    echo "WARNING: sccache server failed to start; building Rust without sccache" >&2
+    echo "$SCCACHE_PROBE_OUTPUT" >&2
+    case "${RUSTC_WRAPPER-}" in
+      sccache|*/sccache) unset RUSTC_WRAPPER ;;
+    esac
+  fi
 fi
 ```
 `build.sh` already configures CMake to use `sccache` for C/C++ when it is available.

--- a/.skills/build/SKILL.md
+++ b/.skills/build/SKILL.md
@@ -12,6 +12,42 @@ Run this skill after making code changes to verify they compile.
 
 ## Instructions
 
+### Local sccache Environment
+Before running a build command locally, enable `sccache` for both C/C++ and Rust if it is
+installed. This snippet assumes a Bash/POSIX shell, matching `build.sh`; on native Windows
+PowerShell or `cmd.exe`, use Git Bash/WSL or set equivalent environment variables manually.
+Run the setup in the same shell invocation as the build command so the exported variables apply.
+```bash
+if command -v sccache >/dev/null 2>&1; then
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  repo_parent="$(cd "$repo_root/.." && pwd)"
+  export SCCACHE_CACHE_SIZE="${SCCACHE_CACHE_SIZE:-30G}"
+  export SCCACHE_BASEDIRS="${SCCACHE_BASEDIRS:-$repo_parent}"
+  export RUSTC_WRAPPER="${RUSTC_WRAPPER:-sccache}"
+fi
+```
+`build.sh` already configures CMake to use `sccache` for C/C++ when it is available.
+`RUSTC_WRAPPER` is needed so Cargo also routes Rust compilation through `sccache`.
+The default `SCCACHE_BASEDIRS` is the parent directory of the current Git checkout, so sibling
+worktrees share normalized paths. Override it explicitly if worktrees live in multiple locations.
+Use the OS-specific separator required by `sccache` when setting multiple base directories.
+
+If verifying cache use, run:
+```bash
+sccache --show-stats
+```
+Check that `Base directories` and `Max cache size` reflect the exported settings. If they do
+not, the `sccache` server was probably already running with older settings. Do not restart it
+while another build may be active; otherwise restart it once after exporting the variables:
+```bash
+sccache --stop-server || true
+sccache --start-server
+```
+
+Do not set `CARGO_INCREMENTAL=0` by default. Use it only when the goal is better Rust cache
+reuse across clean worktrees, since disabling incremental compilation can slow tight local
+edit-build loops in a single worktree.
+
 ### Full Build (C + Rust)
 ```bash
 ./build.sh


### PR DESCRIPTION
## Describe the changes in the pull request

Current: The build skill lists the repo build commands but does not mention local `sccache` setup, so Rust builds launched through Cargo do not get explicit `RUSTC_WRAPPER` guidance and local cross-worktree cache behavior is easy to misconfigure.

Change: Add a local `sccache` environment section to `.skills/build/SKILL.md` that sets cache size, derives `SCCACHE_BASEDIRS` from the current Git checkout parent, sets `RUSTC_WRAPPER=sccache`, documents shell portability limits, and explains how to verify/restart the `sccache` server when settings were applied after it was already running.

Outcome: Future build-skill users get consistent local C/C++ and Rust compiler-cache guidance without assuming a fixed checkout path or disabling Cargo incremental compilation by default.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `.skills/build/SKILL.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Validation:

- `python3 /home/jonathan/.codex/skills/.system/skill-creator/scripts/quick_validate.py .skills/build`
- `bash -n <(sed -n '/^if command -v sccache/,/^fi$/p' .skills/build/SKILL.md)`
- `git diff --check`