### PR TITLE
[MOD-16930] Distinguish unrepresentable trie terms from missing terms in decrement

### DIFF
--- a/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
@@ -23,6 +23,8 @@ pub enum CTrieDecrResult {
     Updated = 1,
     /// numDocs reached 0, term was deleted from the trie.
     Deleted = 2,
+    /// Term too long/unconvertible for the trie; never inserted.
+    Unsupported = 3,
 }
 
 /// Wrapper around the C Trie pointer for safe FFI operations.
@@ -61,6 +63,7 @@ impl CTrieRef {
     /// * `CTrieDecrResult::NotFound` - Term not found in trie
     /// * `CTrieDecrResult::Updated` - numDocs decremented, still > 0
     /// * `CTrieDecrResult::Deleted` - numDocs reached 0, term deleted
+    /// * `CTrieDecrResult::Unsupported` - term too long/unconvertible; never inserted
     ///
     /// # Safety
     ///

--- a/src/spec.c
+++ b/src/spec.c
@@ -3624,6 +3624,7 @@ bool IndexSpec_DecrementTrieTermCount(IndexSpec* sp, const char* term, size_t te
   // Decrement the numDocs count for this term in the trie
   // If numDocs reaches 0, the node will be deleted
   TrieDecrResult result = Trie_DecrementNumDocs(sp->terms, term, term_len, doc_count_decrement);
+  // Only a missing representable term is fatal; UNSUPPORTED (never insertable) is a no-op.
   RS_ASSERT(result != TRIE_DECR_NOT_FOUND);
   return result == TRIE_DECR_DELETED;
 }

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -131,13 +131,13 @@ static TrieDecrResult Trie_DecrementNumDocsRunes(Trie *t, const rune *runes, siz
 
 TrieDecrResult Trie_DecrementNumDocs(Trie *t, const char *s, size_t len, size_t delta) {
   if (len > TRIE_INITIAL_STRING_LEN * sizeof(rune)) {
-    return TRIE_DECR_NOT_FOUND;
+    return TRIE_DECR_UNSUPPORTED;
   }
   runeBuf buf;
   size_t runeLen = len;
   rune *runes = runeBufFill(s, len, &buf, &runeLen);
   if (!runes) {
-    return TRIE_DECR_NOT_FOUND;
+    return TRIE_DECR_UNSUPPORTED;
   }
   TrieDecrResult rc = Trie_DecrementNumDocsRunes(t, runes, runeLen, delta);
   runeBufFree(&buf);
@@ -145,8 +145,9 @@ TrieDecrResult Trie_DecrementNumDocs(Trie *t, const char *s, size_t len, size_t 
 }
 
 static TrieDecrResult Trie_DecrementNumDocsRunes(Trie *t, const rune *runes, size_t len, size_t delta) {
+  // Too long/empty to have been inserted: a no-op, not a missing term.
   if (!runes || len == 0 || len >= TRIE_INITIAL_STRING_LEN) {
-    return TRIE_DECR_NOT_FOUND;
+    return TRIE_DECR_UNSUPPORTED;
   }
 
   // Find the node for this term

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -102,9 +102,10 @@ TrieIterator *Trie_IterateAll(Trie *t);
 
 /* Result codes for Trie_DecrementNumDocs */
 typedef enum {
-  TRIE_DECR_NOT_FOUND = 0,   /* Term not found in trie */
+  TRIE_DECR_NOT_FOUND = 0,   /* Representable term absent (invariant violation) */
   TRIE_DECR_UPDATED = 1,     /* numDocs decremented, still > 0 */
   TRIE_DECR_DELETED = 2,     /* numDocs reached 0, node deleted */
+  TRIE_DECR_UNSUPPORTED = 3, /* Term too long/unconvertible for the trie; never inserted */
 } TrieDecrResult;
 
 /* Decrement the numDocs count for a term in the trie.
@@ -114,10 +115,6 @@ typedef enum {
  *   s     - UTF-8 encoded term string
  *   len   - length of the string in bytes
  *   delta - amount to decrement numDocs by
- * Returns:
- *   TRIE_DECR_NOT_FOUND - term not found
- *   TRIE_DECR_UPDATED   - numDocs decremented but still > 0
- *   TRIE_DECR_DELETED   - numDocs reached 0, node deleted
  */
 TrieDecrResult Trie_DecrementNumDocs(Trie *t, const char *s, size_t len, size_t delta);
 

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -1037,6 +1037,52 @@ static size_t trieGetNumDocs(Trie *t, const char *s) {
   return TrieNode_NumDocs(node);
 }
 
+TEST_F(TrieTest, testDecrementNumDocsRepresentable) {
+  Trie *t = NewTrie(NULL, Trie_Sort_Score);
+  std::unique_ptr<Trie, std::function<void(Trie *)>> tp(t, [](Trie *p) { TrieType_Free(p); });
+
+  trieInsertWithNumDocs(t, "hello", 1.0, 3);
+
+  EXPECT_EQ(TRIE_DECR_UPDATED, Trie_DecrementNumDocs(t, "hello", strlen("hello"), 1));
+  EXPECT_EQ(2, trieGetNumDocs(t, "hello"));
+
+  EXPECT_EQ(TRIE_DECR_DELETED, Trie_DecrementNumDocs(t, "hello", strlen("hello"), 2));
+  EXPECT_EQ(0, trieGetNumDocs(t, "hello"));
+}
+
+// A representable term never inserted must stay distinct (NOT_FOUND) from the
+// unrepresentable case, so the disk-compaction caller can still assert on it.
+TEST_F(TrieTest, testDecrementNumDocsMissingRepresentable) {
+  Trie *t = NewTrie(NULL, Trie_Sort_Score);
+  std::unique_ptr<Trie, std::function<void(Trie *)>> tp(t, [](Trie *p) { TrieType_Free(p); });
+
+  trieInsertWithNumDocs(t, "hello", 1.0, 3);
+  EXPECT_EQ(TRIE_DECR_NOT_FOUND, Trie_DecrementNumDocs(t, "absent", strlen("absent"), 1));
+}
+
+// A term at/over the trie's TRIE_INITIAL_STRING_LEN rune cap is never inserted,
+// so decrementing it reports UNSUPPORTED, not NOT_FOUND.
+TEST_F(TrieTest, testDecrementNumDocsUnrepresentableLongTerm) {
+  Trie *t = NewTrie(NULL, Trie_Sort_Score);
+  std::unique_ptr<Trie, std::function<void(Trie *)>> tp(t, [](Trie *p) { TrieType_Free(p); });
+
+  // 255 runes: representable, inserts and decrements normally.
+  std::string ascii255(TRIE_INITIAL_STRING_LEN - 1, 'a');
+  ASSERT_TRUE(trieInsertWithNumDocs(t, ascii255.c_str(), 1.0, 1));
+  EXPECT_EQ(TRIE_DECR_DELETED, Trie_DecrementNumDocs(t, ascii255.c_str(), ascii255.size(), 1));
+
+  // 256 / 257 runes: trip the rune-length guard.
+  std::string ascii256(TRIE_INITIAL_STRING_LEN, 'a');
+  std::string ascii257(TRIE_INITIAL_STRING_LEN + 1, 'a');
+  EXPECT_EQ(TRIE_DECR_UNSUPPORTED, Trie_DecrementNumDocs(t, ascii256.c_str(), ascii256.size(), 1));
+  EXPECT_EQ(TRIE_DECR_UNSUPPORTED, Trie_DecrementNumDocs(t, ascii257.c_str(), ascii257.size(), 1));
+
+  // 256 copies of U+754C (界), 3 bytes each: trips the earlier byte-length guard.
+  std::string cjk256;
+  for (int i = 0; i < TRIE_INITIAL_STRING_LEN; i++) cjk256 += "\xE7\x95\x8C";
+  EXPECT_EQ(TRIE_DECR_UNSUPPORTED, Trie_DecrementNumDocs(t, cjk256.c_str(), cjk256.size(), 1));
+}
+
 // Regression: TrieType_GenericLoad must preserve sort mode across reload,
 // or Trie_IterateRange's binary search breaks on Lex-sourced tries.
 TEST_F(TrieTest, testRdbSaveLoadLexRangePreservesQueries) {


### PR DESCRIPTION
## Description
Disk (Flex) indexing accepts a TEXT term of ≥256 Unicode runes, but the in-memory
serving trie caps terms at `TRIE_INITIAL_STRING_LEN` (256) runes and silently never
inserts it. Replacing the document orphans the long term's on-disk postings; forced
compaction then decrements that term's count in the trie, which returns
`TRIE_DECR_NOT_FOUND`. The disk-compaction caller asserted that this can never happen
and aborted the shard.

The root problem: `TRIE_DECR_NOT_FOUND` conflated two cases — a *representable* term
that is genuinely (wrongly) missing, and a term the trie *cannot represent at all*.

## Change
- Add `TRIE_DECR_UNSUPPORTED` to `TrieDecrResult`.
- `Trie_DecrementNumDocs` / `Trie_DecrementNumDocsRunes` return `UNSUPPORTED` from the
  length/conversion guards (too long, empty, unconvertible); `!node` and non-terminal
  nodes still return `NOT_FOUND`.
- `IndexSpec_DecrementTrieTermCount` treats `UNSUPPORTED` as a no-op; the
  `RS_ASSERT(result != TRIE_DECR_NOT_FOUND)` still fires for a genuinely-missing
  representable term. FFI signature unchanged (still returns `bool`).
- Mirror `Unsupported` in the Rust `CTrieDecrResult` wrapper.

## Tests
- `test_cpp_trie.cpp`: representable partial/full decrement; representable-missing →
  `NOT_FOUND`; 255-rune control + 256/257-rune and 256×`界` terms → `UNSUPPORTED`.

## Release notes
- [x] This PR requires release notes
- [x] This PR does not require release notes
Bug fix: forced compaction of a disk index containing a very long (≥256-rune) TEXT
term no longer crashes the shard.