### PR TITLE
Add FT.DEBUG NUMERIC_BUCKET_MAP: disk numeric bucket-map introspection

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -3421,6 +3421,41 @@ DEBUG_COMMAND(DumpDeletedIds) {
   return REDISMODULE_OK;
 }
 
+// FT.DEBUG NUMERIC_BUCKET_MAP <index> <field>
+// Dumps the in-memory bucket routing map of a disk numeric field as a JSON
+// string: [{"max_val": ..., "state": "Active"|"BeingCreated", ("source": ...,)
+// "num_entries": ...}, ...]. Debug/testing only (e.g. asserting a bucket
+// split's routing state on a master and its replica).
+DEBUG_COMMAND(NumericBucketMap) {
+  if (!debugCommandsEnabled(ctx)) {
+    return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
+  }
+  if (argc != 4) {
+    return RedisModule_WrongArity(ctx);
+  }
+  GET_SEARCH_CTX(argv[2])
+
+  if (!sctx->spec->diskSpec) {
+    RedisModule_ReplyWithError(sctx->redisCtx, "NUMERIC_BUCKET_MAP is only supported on disk indexes");
+  } else {
+    const FieldSpec *fs = getFieldByNameAndType(sctx->spec, argv[3], INDEXFLD_T_NUMERIC);
+    if (!fs) {
+      RedisModule_ReplyWithError(sctx->redisCtx, "Unknown numeric field");
+    } else {
+      char *json = SearchDisk_DebugDumpNumericBucketMap(sctx->spec->diskSpec, fs->index);
+      if (!json) {
+        RedisModule_ReplyWithError(sctx->redisCtx, "No bucket map for field");
+      } else {
+        RedisModule_ReplyWithStringBuffer(sctx->redisCtx, json, strlen(json));
+        SearchDisk_FreeDebugString(json);
+      }
+    }
+  }
+
+  SearchCtx_Free(sctx);
+  return REDISMODULE_OK;
+}
+
 /**
  * FT.DEBUG REGISTER_TEST_SCORERS
  * Register the test scorers for testing purposes.
@@ -3522,6 +3557,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"VECSIM_MOCK_TIMEOUT", VecSimMockTimeout},
                                {"GET_MAX_DOC_ID", GetMaxDocId},
                                {"DUMP_DELETED_IDS", DumpDeletedIds},
+                               {"NUMERIC_BUCKET_MAP", NumericBucketMap},
                                {"DISK_IO_CONTROL", DiskIOControl},
                                {"REGISTER_TEST_SCORERS", RegisterTestScorers},
                                {"SET_MAX_INDEXES", SetMaxIndexes},

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -3446,8 +3446,8 @@ DEBUG_COMMAND(NumericBucketMap) {
       if (!json) {
         RedisModule_ReplyWithError(sctx->redisCtx, "No bucket map for field");
       } else {
-        RedisModule_ReplyWithStringBuffer(sctx->redisCtx, json, strlen(json));
-        SearchDisk_FreeDebugString(json);
+        RedisModule_ReplyWithStringBuffer(sctx->redisCtx, json, sdslen(json));
+        sdsfree(json);
       }
     }
   }

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -390,6 +390,16 @@ size_t SearchDisk_GetDeletedIds(RedisSearchDiskIndexSpec *handle, t_docId *buffe
     return disk->docTable.getDeletedIds(handle, buffer, buffer_size);
 }
 
+char *SearchDisk_DebugDumpNumericBucketMap(RedisSearchDiskIndexSpec *handle, t_fieldIndex fieldIndex) {
+    RS_ASSERT(disk && handle);
+    return disk->index.debugDumpNumericBucketMap(handle, fieldIndex);
+}
+
+void SearchDisk_FreeDebugString(char *str) {
+    RS_ASSERT(disk);
+    disk->index.freeDebugString(str);
+}
+
 bool SearchDisk_ReplaceKey(RedisSearchDiskIndexSpec *handle, t_docId docId, const char *newKey, size_t newKeyLen) {
     RS_ASSERT(disk && handle);
     return disk->docTable.replaceKey(handle, docId, newKey, newKeyLen);

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -392,12 +392,7 @@ size_t SearchDisk_GetDeletedIds(RedisSearchDiskIndexSpec *handle, t_docId *buffe
 
 char *SearchDisk_DebugDumpNumericBucketMap(RedisSearchDiskIndexSpec *handle, t_fieldIndex fieldIndex) {
     RS_ASSERT(disk && handle);
-    return disk->index.debugDumpNumericBucketMap(handle, fieldIndex);
-}
-
-void SearchDisk_FreeDebugString(char *str) {
-    RS_ASSERT(disk);
-    disk->index.freeDebugString(str);
+    return disk->index.debugDumpNumericBucketMap(handle, fieldIndex, &sdsnewlen);
 }
 
 bool SearchDisk_ReplaceKey(RedisSearchDiskIndexSpec *handle, t_docId docId, const char *newKey, size_t newKeyLen) {

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -482,6 +482,19 @@ uint64_t SearchDisk_GetDeletedIdsCount(RedisSearchDiskIndexSpec *handle);
 size_t SearchDisk_GetDeletedIds(RedisSearchDiskIndexSpec *handle, t_docId *buffer, size_t buffer_size);
 
 /**
+ * @brief Debug: dump a numeric field's in-memory bucket routing map as JSON.
+ *
+ * @return Newly allocated JSON string (release with SearchDisk_FreeDebugString),
+ *         or NULL when the field has no numeric index on this handle.
+ */
+char *SearchDisk_DebugDumpNumericBucketMap(RedisSearchDiskIndexSpec *handle, t_fieldIndex fieldIndex);
+
+/**
+ * @brief Frees a string returned by SearchDisk_DebugDumpNumericBucketMap.
+ */
+void SearchDisk_FreeDebugString(char *str);
+
+/**
  * @brief Replace the key name in document metadata for a given document ID
  *
  * Used when a Redis key is renamed - updates the document metadata to reflect

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -484,15 +484,10 @@ size_t SearchDisk_GetDeletedIds(RedisSearchDiskIndexSpec *handle, t_docId *buffe
 /**
  * @brief Debug: dump a numeric field's in-memory bucket routing map as JSON.
  *
- * @return Newly allocated JSON string (release with SearchDisk_FreeDebugString),
- *         or NULL when the field has no numeric index on this handle.
+ * @return sds JSON string (release with sdsfree), or NULL when the field has
+ *         no numeric index on this handle.
  */
 char *SearchDisk_DebugDumpNumericBucketMap(RedisSearchDiskIndexSpec *handle, t_fieldIndex fieldIndex);
-
-/**
- * @brief Frees a string returned by SearchDisk_DebugDumpNumericBucketMap.
- */
-void SearchDisk_FreeDebugString(char *str);
 
 /**
  * @brief Replace the key name in document metadata for a given document ID

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -641,6 +641,25 @@ typedef struct IndexDiskAPI {
    * @param index Pointer to the disk index spec
    */
   void (*replicationAbort)(RedisSearchDiskIndexSpec *index);
+
+  /**
+   * @brief Debug: dump a numeric field's in-memory bucket routing map.
+   *
+   * Returns a NUL-terminated JSON array describing every bucket of the
+   * field's map (max value, state, entry count), or NULL when the field has
+   * no numeric index on this handle. Release with `freeDebugString`.
+   *
+   * @param index Pointer to the disk index spec
+   * @param fieldIndex The numeric field's index
+   */
+  char *(*debugDumpNumericBucketMap)(RedisSearchDiskIndexSpec *index, t_fieldIndex fieldIndex);
+
+  /**
+   * @brief Frees a string returned by `debugDumpNumericBucketMap`.
+   *
+   * @param str The string to free (NULL is a no-op)
+   */
+  void (*freeDebugString)(char *str);
 } IndexDiskAPI;
 
 typedef struct DocTableDiskAPI {

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -645,21 +645,16 @@ typedef struct IndexDiskAPI {
   /**
    * @brief Debug: dump a numeric field's in-memory bucket routing map.
    *
-   * Returns a NUL-terminated JSON array describing every bucket of the
-   * field's map (max value, state, entry count), or NULL when the field has
-   * no numeric index on this handle. Release with `freeDebugString`.
+   * Writes a JSON array describing every bucket of the field's map (max
+   * value, state, entry count) into memory obtained from `allocate`, so the
+   * caller owns the result through its own allocator. Returns NULL when the
+   * field has no numeric index on this handle.
    *
    * @param index Pointer to the disk index spec
    * @param fieldIndex The numeric field's index
+   * @param allocate Copying allocator for the returned string (e.g. sdsnewlen)
    */
-  char *(*debugDumpNumericBucketMap)(RedisSearchDiskIndexSpec *index, t_fieldIndex fieldIndex);
-
-  /**
-   * @brief Frees a string returned by `debugDumpNumericBucketMap`.
-   *
-   * @param str The string to free (NULL is a no-op)
-   */
-  void (*freeDebugString)(char *str);
+  char *(*debugDumpNumericBucketMap)(RedisSearchDiskIndexSpec *index, t_fieldIndex fieldIndex, AllocateKeyCallback allocate);
 } IndexDiskAPI;
 
 typedef struct DocTableDiskAPI {

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -72,6 +72,7 @@ class TestDebugCommands(object):
             'VECSIM_MOCK_TIMEOUT',
             'GET_MAX_DOC_ID',
             'DUMP_DELETED_IDS',
+            'NUMERIC_BUCKET_MAP',
             'DISK_IO_CONTROL',
             'REGISTER_TEST_SCORERS',
             'SET_MAX_INDEXES',


### PR DESCRIPTION
## Summary

Adds `_FT.DEBUG NUMERIC_BUCKET_MAP <index> <field>`: dump a disk numeric field's in-memory bucket routing map as a JSON string — one object per bucket with `max_val`, `state` (`Active` / `BeingCreated` + its split `source`), and `num_entries`.

C side only: the `FT.DEBUG` dispatcher (mirroring `DUMP_DELETED_IDS` — debug-gated, disk-only, numeric-field validated) plus two new `IndexDiskAPI` entries (`debugDumpNumericBucketMap`, `freeDebugString`) with `SearchDisk_*` wrappers. The implementation lands in redisearch_disk (RediSearchEnterprise redislabsdev/RediSearchEnterprise#663, which pins this branch).

Motivation: direct introspection of the numeric routing state for the MOD-16337 replication/hot-restart tests, which assert a mid-split (`BeingCreated`) bucket's state on a master and its replica.

Tested via the Enterprise flow suite (debug.feature split scenario + the MOD-16337 mid-split scenarios).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Release notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
