### PR TITLE
Topk: merge profile metrics from numeric and vector together.

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3581,6 +3581,7 @@ dependencies = [
  "cc",
  "criterion",
  "ffi",
+ "redis-module",
  "redis_mock",
  "redisearch_rs",
  "rqe_iterators",

--- a/src/redisearch_rs/numeric_score_source/src/lib.rs
+++ b/src/redisearch_rs/numeric_score_source/src/lib.rs
@@ -35,15 +35,18 @@ pub use source::{AllValid, DocValidity, NumericScoreSource};
 
 use std::{cmp::Ordering, num::NonZeroUsize};
 
-use rqe_iterators::{ExpirationChecker, NoOpChecker, RQEIterator};
+use rqe_iterators::{
+    ExpirationChecker, NoOpChecker, RQEIterator,
+    utils::{NoTimeoutChecker, TimeoutContext},
+};
 use top_k::{TopKIterator, TopKMode};
 
 /// A [`TopKIterator`] driven by a [`NumericScoreSource`].
 ///
 /// Construct one with [`new_numeric_top_k_unfiltered`] or
 /// [`new_numeric_top_k_filtered`].
-pub type NumericTopKIterator<'index, V = AllValid, E = NoOpChecker> =
-    TopKIterator<'index, NumericScoreSource<'index, V, E>>;
+pub type NumericTopKIterator<'index, V = AllValid, E = NoOpChecker, T = NoTimeoutChecker> =
+    TopKIterator<'index, NumericScoreSource<'index, V, E, T>>;
 
 /// Pick the heap comparator for the query's sort direction.
 fn cmp_for(ascending: bool) -> fn(&f64, &f64) -> Ordering {
@@ -64,10 +67,11 @@ pub fn new_numeric_top_k_unfiltered<
     'index,
     V: DocValidity + 'index,
     E: ExpirationChecker + 'index,
+    T: TimeoutContext + 'index,
 >(
-    source: NumericScoreSource<'index, V, E>,
+    source: NumericScoreSource<'index, V, E, T>,
     k: NonZeroUsize,
-) -> NumericTopKIterator<'index, V, E> {
+) -> NumericTopKIterator<'index, V, E, T> {
     let cmp = cmp_for(source.ascending());
     TopKIterator::new_with_mode(source, None, k, cmp, TopKMode::Batches)
 }
@@ -80,11 +84,12 @@ pub fn new_numeric_top_k_filtered<
     'index,
     V: DocValidity + 'index,
     E: ExpirationChecker + 'index,
+    T: TimeoutContext + 'index,
 >(
-    source: NumericScoreSource<'index, V, E>,
+    source: NumericScoreSource<'index, V, E, T>,
     child: impl RQEIterator<'index> + 'index,
     k: NonZeroUsize,
-) -> NumericTopKIterator<'index, V, E> {
+) -> NumericTopKIterator<'index, V, E, T> {
     let cmp = cmp_for(source.ascending());
     TopKIterator::new_with_mode(
         source,

--- a/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
+++ b/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
@@ -133,9 +133,10 @@ impl<'index> NumericRangeIterator<'index> {
 /// direction; occurrences already handed out by an earlier batch (tracked in
 /// `emitted`) are dropped, since their better value was scored there.
 ///
-/// `timeout` is polled once per record; the amortized counter accumulates
-/// across records and ranges, so the real clock check fires every
-/// `granularity` reads.
+/// `timeout` is polled once per record and once more before the sort, so a
+/// large batch stays deadline-aware across its ordering pass. The amortized
+/// counter accumulates across records and ranges, so the real clock check
+/// fires every `granularity` reads.
 fn merge_ranges(
     ranges: &[&NumericRange],
     filter: NumericFilter,
@@ -157,6 +158,7 @@ fn merge_ranges(
             items.push((record.doc_id, score));
         }
     }
+    timeout.check_timeout()?;
     items.sort_unstable_by_key(|(doc_id, _)| *doc_id);
     coalesce_by_doc_id(&mut items, filter.ascending);
     emitted.extend(items.iter().map(|(doc_id, _)| *doc_id));

--- a/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
+++ b/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
@@ -22,6 +22,7 @@ use index_result::RSIndexResult;
 use inverted_index::{FilterNumericReader, IndexReader as _, NumericFilter};
 use numeric_range_tree::{NumericRange, NumericRangeTree};
 use rqe_core::DocId;
+use rqe_iterators::{RQEIteratorError, utils::TimeoutContext};
 
 use crate::score_batch::NumericScoreBatch;
 
@@ -94,13 +95,24 @@ impl<'index> NumericRangeIterator<'index> {
     /// Materialize the next `n` value-ordered ranges into one doc-id-ordered
     /// batch, or `Ok(None)` once the window is exhausted.
     ///
-    /// `n` is clamped to at least `1`.
-    pub fn next_n(&mut self, n: usize) -> std::io::Result<Option<NumericScoreBatch>> {
+    /// `n` is clamped to at least `1`. `timeout` is polled once per record read
+    /// so a long materialization aborts with [`RQEIteratorError::TimedOut`]
+    /// rather than running past the query deadline.
+    pub fn next_n(
+        &mut self,
+        n: usize,
+        timeout: &mut impl TimeoutContext,
+    ) -> Result<Option<NumericScoreBatch>, RQEIteratorError> {
         if self.pos >= self.ranges.len() {
             return Ok(None);
         }
         let end = (self.pos + n.max(1)).min(self.ranges.len());
-        let batch = merge_ranges(&self.ranges[self.pos..end], self.filter, &mut self.emitted)?;
+        let batch = merge_ranges(
+            &self.ranges[self.pos..end],
+            self.filter,
+            &mut self.emitted,
+            timeout,
+        )?;
         self.pos = end;
         Ok(Some(batch))
     }
@@ -120,16 +132,22 @@ impl<'index> NumericRangeIterator<'index> {
 /// coalesced to a single entry carrying the doc's best score for the sort
 /// direction; occurrences already handed out by an earlier batch (tracked in
 /// `emitted`) are dropped, since their better value was scored there.
+///
+/// `timeout` is polled once per record; the amortized counter accumulates
+/// across records and ranges, so the real clock check fires every
+/// `granularity` reads.
 fn merge_ranges(
     ranges: &[&NumericRange],
     filter: NumericFilter,
     emitted: &mut HashSet<DocId>,
-) -> std::io::Result<NumericScoreBatch> {
+    timeout: &mut impl TimeoutContext,
+) -> Result<NumericScoreBatch, RQEIteratorError> {
     let mut items: Vec<(DocId, f64)> = Vec::new();
     let mut record = RSIndexResult::build_numeric(0.0).build();
     for range in ranges {
         let mut reader = FilterNumericReader::new(filter, range.reader());
         while reader.next_record(&mut record)? {
+            timeout.check_timeout()?;
             if emitted.contains(&record.doc_id) {
                 continue;
             }
@@ -171,6 +189,7 @@ mod tests {
     use inverted_index::NumericFilter;
     use numeric_range_tree::NumericRangeTree;
     use rqe_core::DocId;
+    use rqe_iterators::utils::NoTimeoutChecker;
     use top_k::ScoreBatch;
 
     use super::NumericRangeIterator;
@@ -191,8 +210,9 @@ mod tests {
         per_batch: usize,
     ) -> Vec<(DocId, f64)> {
         let mut it = NumericRangeIterator::new(tree, filter);
+        let mut timeout = NoTimeoutChecker;
         let mut pairs = Vec::new();
-        while let Some(mut batch) = it.next_n(per_batch).unwrap() {
+        while let Some(mut batch) = it.next_n(per_batch, &mut timeout).unwrap() {
             while let Some(pair) = batch.next() {
                 pairs.push(pair);
             }

--- a/src/redisearch_rs/numeric_score_source/src/score_batch.rs
+++ b/src/redisearch_rs/numeric_score_source/src/score_batch.rs
@@ -10,6 +10,7 @@
 //! [`NumericScoreBatch`] — a [`ScoreBatch`] over a drained numeric iterator.
 
 use rqe_core::DocId;
+use rqe_iterators::RQEIteratorError;
 use top_k::ScoreBatch;
 
 /// A [`ScoreBatch`] backed by a doc-id-ordered `Vec<(DocId, f64)>`.
@@ -32,12 +33,31 @@ impl NumericScoreBatch {
         Self { items, pos: 0 }
     }
 
-    /// Drop records for which `keep` returns `false`, preserving the strictly
-    /// increasing doc-id order. Called before the batch is consumed, so `pos`
-    /// stays at `0`.
-    pub(crate) fn retain(&mut self, keep: impl Fn(DocId, f64) -> bool) {
+    /// Drop records for which `keep` returns `Ok(false)`, preserving the strictly
+    /// increasing doc-id order, and return the filtered batch. Called before the
+    /// batch is read, so `pos` stays at `0`.
+    ///
+    /// `keep` is fallible so it can poll the query deadline per record. The first
+    /// [`Err`] is returned and short-circuits the scan.
+    pub(crate) fn retain(
+        mut self,
+        mut keep: impl FnMut(DocId, f64) -> Result<bool, RQEIteratorError>,
+    ) -> Result<Self, RQEIteratorError> {
         debug_assert_eq!(self.pos, 0, "retain must run before the batch is read");
-        self.items.retain(|&(doc_id, score)| keep(doc_id, score));
+        let mut result = Ok(());
+        self.items.retain(|&(doc_id, score)| {
+            if result.is_err() {
+                return false;
+            }
+            match keep(doc_id, score) {
+                Ok(keep) => keep,
+                Err(err) => {
+                    result = Err(err);
+                    false
+                }
+            }
+        });
+        result.map(|()| self)
     }
 }
 

--- a/src/redisearch_rs/numeric_score_source/src/score_batch.rs
+++ b/src/redisearch_rs/numeric_score_source/src/score_batch.rs
@@ -44,20 +44,18 @@ impl NumericScoreBatch {
         mut keep: impl FnMut(DocId, f64) -> Result<bool, RQEIteratorError>,
     ) -> Result<Self, RQEIteratorError> {
         debug_assert_eq!(self.pos, 0, "retain must run before the batch is read");
-        let mut result = Ok(());
-        self.items.retain(|&(doc_id, score)| {
-            if result.is_err() {
-                return false;
+        // Two-pointer compaction so the first `Err` exits immediately instead of
+        // scanning the rest of the batch as `Vec::retain` would.
+        let mut write = 0;
+        for read in 0..self.items.len() {
+            let item = self.items[read];
+            if keep(item.0, item.1)? {
+                self.items[write] = item;
+                write += 1;
             }
-            match keep(doc_id, score) {
-                Ok(keep) => keep,
-                Err(err) => {
-                    result = Err(err);
-                    false
-                }
-            }
-        });
-        result.map(|()| self)
+        }
+        self.items.truncate(write);
+        Ok(self)
     }
 }
 

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -103,6 +103,22 @@ const MIN_SUCCESS_RATIO: f64 = 0.01;
 ///
 /// [`TopKIterator`]: top_k::TopKIterator
 ///
+/// # Revalidation
+///
+/// The source has no revalidate step of its own: the wrapping [`TopKIterator`]
+/// collects eagerly and then yields from a materialized buffer, so once results
+/// are collected the range stream is never read again. A revalidate therefore
+/// only consults the filter child — a child abort aborts the query, and a child
+/// reposition collapses to `Ok` because it cannot move a cursor that reads from
+/// the buffer.
+///
+/// # Rewind after timeout
+///
+/// A timeout aborts collection with the heap and range stream left partway;
+/// [`rewind`](ScoreSource::rewind) is what restores a clean, re-runnable state
+/// (fresh heap, ranges re-resolved to the initial window). The query deadline is
+/// absolute and is *not* reset by rewind.
+///
 /// Not implemented yet:
 /// - TODO: MOD-14946 Profile metrics
 /// - TODO: MOD-14947 Parity tests

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -16,7 +16,10 @@ use inverted_index::NumericFilter;
 use numeric_range_tree::NumericRangeTree;
 use rqe_core::DocId;
 use rqe_iterator_type::IteratorType;
-use rqe_iterators::{ExpirationChecker, NoOpChecker, RQEIteratorError};
+use rqe_iterators::{
+    ExpirationChecker, NoOpChecker, RQEIteratorError,
+    utils::{NoTimeoutChecker, TimeoutContext},
+};
 use top_k::{BatchStrategy, ScoreSource};
 
 use crate::range_iterator::NumericRangeIterator;
@@ -101,12 +104,15 @@ const MIN_SUCCESS_RATIO: f64 = 0.01;
 /// [`TopKIterator`]: top_k::TopKIterator
 ///
 /// Not implemented yet:
-/// - TODO: MOD-14945 Timeout handling
 /// - TODO: MOD-14946 Profile metrics
 /// - TODO: MOD-14947 Parity tests
 /// - TODO: MOD-14948 Performance validation
-pub struct NumericScoreSource<'index, V: DocValidity = AllValid, E: ExpirationChecker = NoOpChecker>
-{
+pub struct NumericScoreSource<
+    'index,
+    V: DocValidity = AllValid,
+    E: ExpirationChecker = NoOpChecker,
+    T: TimeoutContext = NoTimeoutChecker,
+> {
     /// Value-ordered range stream over the numeric index.
     ranges: NumericRangeIterator<'index>,
     /// Filter driving [`find`](NumericRangeTree::find); its `offset`/`limit`
@@ -145,6 +151,9 @@ pub struct NumericScoreSource<'index, V: DocValidity = AllValid, E: ExpirationCh
     /// they reach the top-k heap, matching the optimizer's numeric field
     /// predicate. [`NoOpChecker`] keeps every record.
     expiration: E,
+    /// Query-deadline poll, checked once per record during batch materialization
+    /// and once per step during yielding. [`NoTimeoutChecker`] never times out.
+    timeout: T,
 }
 
 impl<'index> NumericScoreSource<'index> {
@@ -227,20 +236,27 @@ impl<'index> NumericScoreSource<'index> {
             num_iterations: 0,
             validity: AllValid,
             expiration: NoOpChecker,
+            timeout: NoTimeoutChecker,
         }
     }
 }
 
-impl<'index, V: DocValidity, E: ExpirationChecker> NumericScoreSource<'index, V, E> {
+impl<'index, V: DocValidity, E: ExpirationChecker, T: TimeoutContext>
+    NumericScoreSource<'index, V, E, T>
+{
     /// Attach a document-validity oracle, dropping records for doc ids it reports
     /// invalid (deleted or whole-doc expired) from every batch. This is the
     /// source's equivalent of the numeric optimizer's per-document validity
     /// check, keeping entries that survive in the index until GC out of the
     /// top-k results.
-    pub fn with_validity<V2: DocValidity>(self, validity: V2) -> NumericScoreSource<'index, V2, E> {
+    pub fn with_validity<V2: DocValidity>(
+        self,
+        validity: V2,
+    ) -> NumericScoreSource<'index, V2, E, T> {
         NumericScoreSource {
             validity,
             expiration: self.expiration,
+            timeout: self.timeout,
             ranges: self.ranges,
             filter: self.filter,
             initial_offset: self.initial_offset,
@@ -265,10 +281,38 @@ impl<'index, V: DocValidity, E: ExpirationChecker> NumericScoreSource<'index, V,
     pub fn with_expiration<E2: ExpirationChecker>(
         self,
         expiration: E2,
-    ) -> NumericScoreSource<'index, V, E2> {
+    ) -> NumericScoreSource<'index, V, E2, T> {
         NumericScoreSource {
             expiration,
             validity: self.validity,
+            timeout: self.timeout,
+            ranges: self.ranges,
+            filter: self.filter,
+            initial_offset: self.initial_offset,
+            initial_limit: self.initial_limit,
+            ascending: self.ascending,
+            range_batch_size: self.range_batch_size,
+            num_estimated: self.num_estimated,
+            retry_enabled: self.retry_enabled,
+            num_docs: self.num_docs,
+            child_estimate: self.child_estimate,
+            last_limit_estimate: self.last_limit_estimate,
+            heap_old_size: self.heap_old_size,
+            num_iterations: self.num_iterations,
+        }
+    }
+
+    /// Attach a query-deadline poll, checked once per record during
+    /// materialization and once per step during yielding. [`NoTimeoutChecker`] (the
+    /// default) never times out.
+    pub fn with_timeout<T2: TimeoutContext>(
+        self,
+        timeout: T2,
+    ) -> NumericScoreSource<'index, V, E, T2> {
+        NumericScoreSource {
+            timeout,
+            validity: self.validity,
+            expiration: self.expiration,
             ranges: self.ranges,
             filter: self.filter,
             initial_offset: self.initial_offset,
@@ -348,13 +392,18 @@ impl<'index, V: DocValidity, E: ExpirationChecker> NumericScoreSource<'index, V,
     }
 }
 
-impl<'index, V: DocValidity, E: ExpirationChecker> ScoreSource
-    for NumericScoreSource<'index, V, E>
+impl<'index, V: DocValidity, E: ExpirationChecker, T: TimeoutContext> ScoreSource
+    for NumericScoreSource<'index, V, E, T>
 {
     type Batch = NumericScoreBatch;
 
     fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
-        let Some(mut batch) = self.ranges.next_n(self.range_batch_size)? else {
+        // `ranges` and `timeout` are disjoint fields; the split borrow lets the
+        // materialization loop poll the deadline once per record.
+        let Some(mut batch) = self
+            .ranges
+            .next_n(self.range_batch_size, &mut self.timeout)?
+        else {
             return Ok(None);
         };
         // Drop stale entries pre-heap so they never displace a live document from
@@ -435,9 +484,10 @@ impl<'index, V: DocValidity, E: ExpirationChecker> ScoreSource
     }
 
     fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
-        // TODO: MOD-14945 — real timeout handling. The numeric source never
-        // times out yet.
-        Ok(())
+        // Yielding-phase hook. Collection self-checks per record via `next_batch`,
+        // because the surrounding `TopKIterator` collects eagerly and only polls
+        // this during yielding.
+        self.timeout.check_timeout()
     }
 
     fn attach_score_metric<'r>(&self, _result: &mut RSIndexResult<'r>, _score: f64)

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -416,7 +416,7 @@ impl<'index, V: DocValidity, E: ExpirationChecker, T: TimeoutContext> ScoreSourc
     fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
         // `ranges` and `timeout` are disjoint fields; the split borrow lets the
         // materialization loop poll the deadline once per record.
-        let Some(mut batch) = self
+        let Some(batch) = self
             .ranges
             .next_n(self.range_batch_size, &mut self.timeout)?
         else {

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -428,20 +428,22 @@ impl<'index, V: DocValidity, E: ExpirationChecker, T: TimeoutContext> ScoreSourc
         // gate keeps the common no-filtering case free of its per-record check.
         let filter_validity = self.validity.may_filter();
         let filter_expiration = self.expiration.has_expiration();
-        if filter_validity || filter_expiration {
-            batch.retain(|doc_id, score| {
-                if filter_validity && !self.validity.is_valid(doc_id) {
-                    return false;
-                }
-                if filter_expiration {
-                    let record = RSIndexResult::build_numeric(score).doc_id(doc_id).build();
-                    if self.expiration.is_expired(&record) {
-                        return false;
-                    }
-                }
-                true
-            });
+        if !filter_validity && !filter_expiration {
+            return Ok(Some(batch));
         }
+        let batch = batch.retain(|doc_id, score| {
+            self.timeout.check_timeout()?;
+            if filter_validity && !self.validity.is_valid(doc_id) {
+                return Ok(false);
+            }
+            if filter_expiration {
+                let record = RSIndexResult::build_numeric(score).doc_id(doc_id).build();
+                if self.expiration.is_expired(&record) {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        })?;
         Ok(Some(batch))
     }
 

--- a/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
@@ -463,6 +463,35 @@ fn iterator_read_propagates_timeout() {
 }
 
 #[test]
+fn filtering_scan_is_timeout_aware() {
+    // Single-leaf tree of four records, materialized into one batch. The clock's
+    // deadline is already elapsed, but its granularity is one above the record
+    // count, so the four per-record polls in materialization never reach a real
+    // probe. The timeout can only surface if the stale-record filtering scan
+    // keeps polling the same amortized counter past that granularity.
+    let pairs = [(1u64, 4.0), (2, 3.0), (3, 2.0), (4, 1.0)];
+    let tree = tree_from(&pairs);
+    let past_deadline =
+        || TimeoutContextClock::new(Duration::from_nanos(1), pairs.len() as u32 + 1);
+
+    // No filtering: materialization alone stays below the probe granularity, so
+    // the batch is produced without timing out.
+    let mut unfiltered =
+        NumericScoreSource::unfiltered(&tree, full_range(), false).with_timeout(past_deadline());
+    assert!(unfiltered.next_batch().unwrap().is_some());
+
+    // With a validity filter, the post-materialization scan polls per record and
+    // crosses the deadline that materialization alone could not reach.
+    let mut filtered = NumericScoreSource::unfiltered(&tree, full_range(), false)
+        .with_validity(DeletedDocs::from_iter([2]))
+        .with_timeout(past_deadline());
+    assert!(matches!(
+        filtered.next_batch(),
+        Err(RQEIteratorError::TimedOut)
+    ));
+}
+
+#[test]
 fn amortized_check_does_not_probe_below_granularity() {
     // Deadline is in the past, but with a granularity far above the record count
     // the clock is never probed, so the batch is produced without timing out.

--- a/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
@@ -11,6 +11,7 @@
 //! fixtures.
 
 use std::collections::HashSet;
+use std::time::Duration;
 use std::{iter, num::NonZeroUsize};
 
 use index_result::RSIndexResult;
@@ -21,7 +22,10 @@ use numeric_score_source::{
     DocValidity, NumericScoreSource, new_numeric_top_k_filtered, new_numeric_top_k_unfiltered,
 };
 use rqe_core::DocId;
-use rqe_iterators::{ExpirationChecker, IdList, RQEIterator};
+use rqe_iterators::{
+    ExpirationChecker, IdList, RQEIterator, RQEIteratorError,
+    utils::{DeadlineTimeoutChecker, NoTimeoutChecker},
+};
 use top_k::{ScoreBatch, ScoreSource};
 
 /// A validity oracle backed by an explicit set of deleted doc ids, standing in
@@ -425,4 +429,63 @@ fn validity_and_expiration_compose() {
         got.push((result.doc_id, result.as_numeric().expect("numeric result")));
     }
     assert_eq!(got, vec![(5, 3.0), (4, 2.0), (2, 1.0)]);
+}
+
+/// A clock context whose deadline is already in the past, probed on every call.
+fn expired_clock() -> DeadlineTimeoutChecker {
+    DeadlineTimeoutChecker::new(Duration::from_nanos(1), 1)
+}
+
+#[test]
+fn collection_times_out_during_materialization() {
+    // Multi-leaf tree so `next_batch` reads several ranges' records; the first
+    // per-record poll crosses the already-elapsed deadline.
+    let tree = build_tree(20, false, 0);
+    let mut source =
+        NumericScoreSource::unfiltered(&tree, full_range(), false).with_timeout(expired_clock());
+
+    assert!(matches!(
+        source.next_batch(),
+        Err(RQEIteratorError::TimedOut)
+    ));
+}
+
+#[test]
+fn iterator_read_propagates_timeout() {
+    // Eager collection runs inside the first `read()`, so the timeout surfaces
+    // there rather than being swallowed.
+    let tree = build_tree(20, false, 0);
+    let source =
+        NumericScoreSource::unfiltered(&tree, full_range(), false).with_timeout(expired_clock());
+    let mut it = new_numeric_top_k_unfiltered(source, NonZeroUsize::new(3).unwrap());
+
+    assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
+}
+
+#[test]
+fn amortized_check_does_not_probe_below_granularity() {
+    // Deadline is in the past, but with a granularity far above the record count
+    // the clock is never probed, so the batch is produced without timing out.
+    let tree = build_tree(20, false, 0);
+    let never_probes = DeadlineTimeoutChecker::new(Duration::from_nanos(1), 1_000_000);
+    let mut source =
+        NumericScoreSource::unfiltered(&tree, full_range(), false).with_timeout(never_probes);
+
+    assert!(source.next_batch().unwrap().is_some());
+}
+
+#[test]
+fn no_timeout_default_never_times_out() {
+    // The explicit `NoTimeoutChecker` context (the struct default) yields the full
+    // result set, matching the behavior of every other test's default source.
+    let tree = tree_from(&[(1, 5.0), (2, 1.0), (3, 4.0)]);
+    let source =
+        NumericScoreSource::unfiltered(&tree, full_range(), false).with_timeout(NoTimeoutChecker);
+    let mut it = new_numeric_top_k_unfiltered(source, NonZeroUsize::new(3).unwrap());
+
+    let mut got = Vec::new();
+    while let Some(result) = it.read().unwrap() {
+        got.push((result.doc_id, result.as_numeric().expect("numeric result")));
+    }
+    assert_eq!(got, vec![(1, 5.0), (3, 4.0), (2, 1.0)]);
 }

--- a/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
@@ -433,7 +433,7 @@ fn validity_and_expiration_compose() {
     assert_eq!(got, vec![(5, 3.0), (4, 2.0), (2, 1.0)]);
 }
 
-/// A clock context whose deadline is already in the past, probed on every call.
+/// A clock context whose deadline is already in the past.
 fn expired_clock() -> DeadlineTimeoutChecker {
     DeadlineTimeoutChecker::new(Duration::from_nanos(1), 1)
 }
@@ -566,13 +566,14 @@ impl TimeoutOnce {
 
 impl TimeoutContext for TimeoutOnce {
     fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
-        if !self.fired {
-            if self.succeed_first == 0 {
-                self.fired = true;
-                return Err(RQEIteratorError::TimedOut);
-            }
-            self.succeed_first -= 1;
+        if self.fired {
+            return Ok(());
         }
+        if self.succeed_first == 0 {
+            self.fired = true;
+            return Err(RQEIteratorError::TimedOut);
+        }
+        self.succeed_first -= 1;
         Ok(())
     }
 

--- a/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
@@ -10,7 +10,9 @@
 //! Tests for [`NumericScoreSource`], driven by real [`NumericRangeTree`]
 //! fixtures.
 
+use std::cell::Cell;
 use std::collections::HashSet;
+use std::rc::Rc;
 use std::time::Duration;
 use std::{iter, num::NonZeroUsize};
 
@@ -436,6 +438,29 @@ fn expired_clock() -> DeadlineTimeoutChecker {
     DeadlineTimeoutChecker::new(Duration::from_nanos(1), 1)
 }
 
+/// Counts `check_timeout` calls and never times out. The shared counter is
+/// readable after the source has taken ownership of the context, so a test can
+/// assert exactly how many polls a phase performed.
+#[derive(Clone, Default)]
+struct CountingTimeout(Rc<Cell<u32>>);
+
+impl CountingTimeout {
+    fn calls(&self) -> u32 {
+        self.0.get()
+    }
+}
+
+impl TimeoutContext for CountingTimeout {
+    fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+        self.0.set(self.0.get() + 1);
+        Ok(())
+    }
+
+    fn reset_counter(&mut self) {
+        // Every call is counted, so there is no amortization state to reset.
+    }
+}
+
 #[test]
 fn collection_times_out_during_materialization() {
     // Multi-leaf tree so `next_batch` reads several ranges' records; the first
@@ -464,27 +489,26 @@ fn iterator_read_propagates_timeout() {
 
 #[test]
 fn filtering_scan_is_timeout_aware() {
-    // Single-leaf tree of four records, materialized into one batch. The clock's
-    // deadline is already elapsed, but its granularity is one above the record
-    // count, so the four per-record polls in materialization never reach a real
-    // probe. The timeout can only surface if the stale-record filtering scan
-    // keeps polling the same amortized counter past that granularity.
+    // Single-leaf tree of four records, materialized into one batch. Materialization
+    // polls once per record and once before the sort; the stale-record filtering
+    // scan then adds one poll per record. A deadline primed to survive
+    // materialization must therefore surface inside that scan.
     let pairs = [(1u64, 4.0), (2, 3.0), (3, 2.0), (4, 1.0)];
     let tree = tree_from(&pairs);
-    let past_deadline =
-        || TimeoutContextClock::new(Duration::from_nanos(1), pairs.len() as u32 + 1);
-
-    // No filtering: materialization alone stays below the probe granularity, so
-    // the batch is produced without timing out.
+    // Pin the number of polls materialization performs, so the filtered case can
+    // prime a one-shot timeout that fires only once the filtering scan begins.
+    let counter = CountingTimeout::default();
     let mut unfiltered =
-        NumericScoreSource::unfiltered(&tree, full_range(), false).with_timeout(past_deadline());
+        NumericScoreSource::unfiltered(&tree, full_range(), false).with_timeout(counter.clone());
     assert!(unfiltered.next_batch().unwrap().is_some());
+    let materialization_polls = counter.calls();
+    assert_eq!(materialization_polls, pairs.len() as u32 + 1);
 
-    // With a validity filter, the post-materialization scan polls per record and
-    // crosses the deadline that materialization alone could not reach.
+    // A one-shot timeout that survives materialization fires on the filtering
+    // scan's first poll, proving the scan honors the deadline.
     let mut filtered = NumericScoreSource::unfiltered(&tree, full_range(), false)
         .with_validity(DeletedDocs::from_iter([2]))
-        .with_timeout(past_deadline());
+        .with_timeout(TimeoutOnce::new(materialization_polls));
     assert!(matches!(
         filtered.next_batch(),
         Err(RQEIteratorError::TimedOut)

--- a/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
@@ -24,7 +24,7 @@ use numeric_score_source::{
 use rqe_core::DocId;
 use rqe_iterators::{
     ExpirationChecker, IdList, RQEIterator, RQEIteratorError,
-    utils::{DeadlineTimeoutChecker, NoTimeoutChecker},
+    utils::{DeadlineTimeoutChecker, NoTimeoutChecker, TimeoutContext},
 };
 use top_k::{ScoreBatch, ScoreSource};
 
@@ -488,4 +488,95 @@ fn no_timeout_default_never_times_out() {
         got.push((result.doc_id, result.as_numeric().expect("numeric result")));
     }
     assert_eq!(got, vec![(1, 5.0), (3, 4.0), (2, 1.0)]);
+}
+
+/// Times out exactly once, after `succeed_first` probes, then never again.
+///
+/// A test double for the rewind-after-timeout recovery path: a real absolute
+/// deadline keeps firing, but a one-shot lets the rewound pass run to completion
+/// so its results can be checked. Rewinding the source does not touch the
+/// timeout context, so the fired state persists across the rewind, exactly as an
+/// absolute deadline would.
+struct TimeoutOnce {
+    succeed_first: u32,
+    fired: bool,
+}
+
+impl TimeoutOnce {
+    fn new(succeed_first: u32) -> Self {
+        Self {
+            succeed_first,
+            fired: false,
+        }
+    }
+}
+
+impl TimeoutContext for TimeoutOnce {
+    fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+        if !self.fired {
+            if self.succeed_first == 0 {
+                self.fired = true;
+                return Err(RQEIteratorError::TimedOut);
+            }
+            self.succeed_first -= 1;
+        }
+        Ok(())
+    }
+
+    fn reset_counter(&mut self) {
+        // The probe budget is fixed for the whole run, not amortized.
+    }
+}
+
+/// Collect an unfiltered top-k iterator to exhaustion into `(doc_id, score)`.
+fn drain_top_k<'a, V: DocValidity + 'a, E: ExpirationChecker + 'a, T: TimeoutContext + 'a>(
+    it: &mut numeric_score_source::NumericTopKIterator<'a, V, E, T>,
+) -> Vec<(DocId, f64)> {
+    let mut got = Vec::new();
+    while let Some(result) = it.read().unwrap() {
+        got.push((result.doc_id, result.as_numeric().expect("numeric result")));
+    }
+    got
+}
+
+#[test]
+fn rewind_after_timeout_reproduces_full_results() {
+    // k == doc count forces the whole index to be read (the heap never fills, so
+    // no early `Stop`), guaranteeing the one-shot timeout fires mid-collection.
+    let tree = build_tree(20, false, 0);
+    let k = NonZeroUsize::new(20).unwrap();
+
+    let reference = {
+        let source = NumericScoreSource::with_range_batch_size(&tree, full_range(), false, 1);
+        drain_top_k(&mut new_numeric_top_k_unfiltered(source, k))
+    };
+
+    // Time out partway through the first collection; earlier batches have already
+    // landed in the heap when the deadline fires.
+    let source = NumericScoreSource::with_range_batch_size(&tree, full_range(), false, 1)
+        .with_timeout(TimeoutOnce::new(8));
+    let mut it = new_numeric_top_k_unfiltered(source, k);
+    assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
+
+    // Rewind discards the partial heap and re-resolves the ranges from the start;
+    // the one-shot deadline has fired, so the second pass runs clean and must
+    // reproduce the reference exactly — no dropped, duplicated, or reordered docs.
+    it.rewind();
+    assert_eq!(drain_top_k(&mut it), reference);
+}
+
+#[test]
+fn rewind_after_persistent_timeout_times_out_again() {
+    // A deadline already in the past keeps firing. Rewinding after a timeout must
+    // leave the iterator in a clean, re-runnable state (no stale collecting phase,
+    // no panic) and time out again, since the deadline is absolute and rewind
+    // does not extend it.
+    let tree = build_tree(20, false, 0);
+    let source = NumericScoreSource::with_range_batch_size(&tree, full_range(), false, 1)
+        .with_timeout(expired_clock());
+    let mut it = new_numeric_top_k_unfiltered(source, NonZeroUsize::new(5).unwrap());
+
+    assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
+    it.rewind();
+    assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
 }

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -538,6 +538,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> RQEIterat
         *self.heap = TopKHeap::new(self.k, self.compare);
         self.results.clear();
         *self.current = None;
+        self.metrics = TopKMetrics::default();
         self.source.rewind();
         if let Some(child) = &mut self.child {
             child.rewind();

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -301,6 +301,8 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
                     self.heap.push(doc_id, score);
                 }
             }
+            // Batch consumption is unpolled; check once at the boundary.
+            self.source.check_timeout()?;
             match self.source.batch_strategy(self.heap.len(), self.k.get()) {
                 BatchStrategy::Continue => continue,
                 BatchStrategy::Stop => break,

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -595,6 +595,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> RQEIterat
         *self.heap = TopKHeap::new(self.k, self.compare);
         self.results.clear();
         *self.current = None;
+        self.metrics = TopKMetrics::default();
         self.source.rewind();
         if let Some(child) = &mut self.child {
             child.rewind();

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -448,7 +448,8 @@ fn yield_timeout_polled_while_skipping_expired() {
         BatchStrategy::Stop
     })
     .with_expired([1, 2])
-    .with_timeout_after(1);
+    // 1 for the batch-boundary poll in collection, then the yield-time poll trips.
+    .with_timeout_after(2);
     let mut it = ContractChecker::new_unordered(TopKIterator::new(
         source,
         make_child(vec![1, 2, 3]),
@@ -483,7 +484,9 @@ fn yield_timeout_polled_before_yielding_valid() {
     let source = MockScoreSource::new(vec![vec![(1, 0.1), (2, 0.2), (3, 0.3)]], vec![], |_, _| {
         BatchStrategy::Stop
     })
-    .with_timeout_after(2);
+    // 1 for the batch-boundary poll in collection, then the first yield passes and
+    // the second trips.
+    .with_timeout_after(3);
     let mut it = ContractChecker::new_unordered(TopKIterator::new(
         source,
         make_child(vec![1, 2, 3]),

--- a/src/redisearch_rs/vector_score_source_bencher/Cargo.toml
+++ b/src/redisearch_rs/vector_score_source_bencher/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "vector_score_source_bencher"
-version.workspace = true
 edition.workspace = true
 license-file.workspace = true
+name = "vector_score_source_bencher"
 publish.workspace = true
+version.workspace = true
 
 [lints]
 workspace = true
@@ -14,23 +14,24 @@ bench = false
 
 # Rust VectorTopKIterator vs the real C HybridIterator (apples-to-apples).
 [[bench]]
-name = "vector_top_k_hybrid"
 harness = false
+name = "vector_top_k_hybrid"
 
 [build-dependencies]
-build_utils = { path = "../build_utils" }
+build_utils = {path = "../build_utils"}
 cc.workspace = true
 
 [dependencies]
 criterion.workspace = true
 ffi.workspace = true
 redis_mock.workspace = true
-rqe_iterators = { workspace = true }
+rqe_iterators = {workspace = true}
 rqe_iterators_test_utils.workspace = true
-top_k = { path = "../top_k" }
-vector_score_source = { path = "../vector_score_source" }
+top_k = {path = "../top_k"}
+vector_score_source = {path = "../vector_score_source"}
 workspace_hack.workspace = true
 # Crate required to invoke C symbols and keep Rust-defined FFI symbols alive.
-redisearch_rs = { path = "../c_entrypoint/redisearch_rs", features = [
-    "mock_allocator",
-] }
+redis-module = {workspace = true}
+redisearch_rs = {path = "../c_entrypoint/redisearch_rs", features = [
+  "mock_allocator",
+]}

--- a/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
+++ b/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
@@ -44,11 +44,13 @@ use std::cmp::Ordering;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use ffi::{
-    HNSWParams, RedisModule_Alloc, VecSearchMode_HYBRID_ADHOC_BF, VecSearchMode_HYBRID_BATCHES,
+    HNSWParams, VecSearchMode_HYBRID_ADHOC_BF, VecSearchMode_HYBRID_BATCHES,
     VecSimAlgo_VecSimAlgo_HNSWLIB, VecSimIndex, VecSimIndex_AddVector, VecSimIndex_Free,
     VecSimIndex_New, VecSimMetric_VecSimMetric_L2, VecSimParams, VecSimQueryParams,
     VecSimType_VecSimType_FLOAT32, timespec,
 };
+
+use redis_module::RedisModule_Alloc;
 use rqe_iterators::{IdList, RQEIterator};
 use rqe_iterators_test_utils::MockExpirationChecker;
 use top_k::{TopKIterator, TopKMode};
@@ -57,7 +59,7 @@ use vector_score_source::VectorScoreSource;
 /// Score order for vector distance: ascending (lower distance = better).
 /// Matches the comparator `vector_score_source` uses internally.
 fn asc_cmp(a: &f64, b: &f64) -> Ordering {
-    a.partial_cmp(b).unwrap_or(Ordering::Equal)
+    a.total_cmp(b)
 }
 
 // ── C shim (from hybrid_shim.c, compiled by build.rs) ────────────────────────

--- a/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
+++ b/src/redisearch_rs/vector_score_source_bencher/benches/vector_top_k_hybrid.rs
@@ -56,8 +56,8 @@ use vector_score_source::VectorScoreSource;
 
 /// Score order for vector distance: ascending (lower distance = better).
 /// Matches the comparator `vector_score_source` uses internally.
-fn asc_cmp(a: f64, b: f64) -> Ordering {
-    a.partial_cmp(&b).unwrap_or(Ordering::Equal)
+fn asc_cmp(a: &f64, b: &f64) -> Ordering {
+    a.total_cmp(b)
 }
 
 // ── C shim (from hybrid_shim.c, compiled by build.rs) ────────────────────────


### PR DESCRIPTION
This PR merges WIP numeric work on top of WIP vector top k work to better anticipate shared design arounds metrics handling.

This should be minimalistic once the dependents PRs are merged:
- https://github.com/RediSearch/RediSearch/pull/10221
- https://github.com/RediSearch/RediSearch/pull/10486

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
