### PR TITLE
[MOD-17197] Fix SST replication hang and corrupt numeric snapshot when disk GC is mid-cycle

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 #include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
 
 #include "gc.h"
 #include "fork_gc.h"
@@ -23,6 +25,9 @@
 #include "debug_commands.h"
 
 static redisearch_thpool_t *gcThreadpool_g = NULL;
+// Guarded by the GIL. Only used to pause GC contexts created while a window is already open;
+// live ones are paused/resumed by walking IndexSpec->gc.
+static bool gcSchedulingPauseActiveForConsistency_g = false;
 
 typedef struct GCDebugTask {
   GCContext* gc;
@@ -38,6 +43,9 @@ static GCDebugTask *GCDebugTaskCreate(GCContext *gc, RedisModuleBlockedClient* b
 
 GCContext* GCContext_CreateGC(StrongRef spec_ref, uint32_t gcPolicy) {
   GCContext* ret = rm_calloc(1, sizeof(GCContext));
+  if (gcSchedulingPauseActiveForConsistency_g) {
+    RS_AtomicUintFetchOrRelaxed(&ret->schedFlags, GC_SCHED_PAUSED);
+  }
   switch (gcPolicy) {
     case GCPolicy_Fork:
       ret->gcCtx = FGC_Create(spec_ref, &ret->callbacks);
@@ -57,6 +65,10 @@ static void taskCallback(void* data);
 
 static bool GCContext_RunPending(GCContext* gc) {
   return (RS_AtomicUintLoadRelaxed(&gc->schedFlags) & GC_SCHED_RUN_PENDING) != 0;
+}
+
+static bool GCContext_PausedForConsistency(GCContext* gc) {
+  return (RS_AtomicUintLoadRelaxed(&gc->schedFlags) & GC_SCHED_PAUSED) != 0;
 }
 
 static long long getNextPeriod(struct timespec interval) {
@@ -79,7 +91,8 @@ static RedisModuleTimerID scheduleNextIn(GCContext* gc, struct timespec interval
 // the no-timer-while-a-run-is-pending invariant comes from QueueRun declining and timerCallback
 // zeroing timerID, not from the RunPending check here.
 static bool GCContext_ArmTimerIn(GCContext* gc, struct timespec interval) {
-  if (!gc->enabled || gc->timerID || GCContext_RunPending(gc)) {
+  if (!gc->enabled || gc->timerID || GCContext_RunPending(gc) ||
+      GCContext_PausedForConsistency(gc)) {
     return false;
   }
   gc->timerID = scheduleNextIn(gc, interval);
@@ -174,8 +187,8 @@ static void timerCallback(RedisModuleCtx* ctx, void* data) {
   GCContext* gc = data;
   gc->timerID = 0;  // the timer that just fired is gone
 
-  if (!gc->enabled) {
-    return;
+  if (!gc->enabled || GCContext_PausedForConsistency(gc)) {
+    return;  // the resume path re-arms
   }
   if (RedisModule_AvoidReplicaTraffic && RedisModule_AvoidReplicaTraffic()) {
     // If slave traffic is not allowed it means that there is a state machine running
@@ -191,6 +204,9 @@ void GCContext_StartNow(GCContext* gc) {
   RS_LOG_ASSERT_FMT(!gc->enabled && gc->timerID == 0,
                     "GC %p: StartNow called while GC is already running", gc);
   gc->enabled = true;
+  if (GCContext_PausedForConsistency(gc)) {
+    return;  // the resume path arms a timer instead
+  }
   GCContext_QueueRun(gc);
 }
 
@@ -209,6 +225,9 @@ bool GCContext_BeginDrop(GCContext* gc) {
   // the timer eventually discovering the drop and nothing ever doing so. A no-op when already
   // enabled, which is why it cannot disturb the ordinary path below.
   gc->enabled = true;
+  // Same for a consistency-window pause, and for the same reason -- the window's resume
+  // re-derives its set by walking specDict_g, which this spec is about to leave.
+  RS_AtomicUintFetchAndRelaxed(&gc->schedFlags, ~(unsigned)GC_SCHED_PAUSED);
   // An armed timer, or a run in flight (which now re-arms), will discover the drop on its own --
   // the mechanism `IndexSpec_Free` already relies on. Leave those alone: a run in flight also
   // frees this context itself, on the GC thread and without the GIL, as soon as the unlink makes
@@ -235,6 +254,28 @@ void GCContext_StopFutureRuns(GCContext* gc) {
 
 bool GCContext_IsEnabled(const GCContext* gc) {
   return gc->enabled;
+}
+
+void GCContext_PauseSchedulingForConsistency(GCContext* gc) {
+  if (!gc) {
+    return;
+  }
+  RS_AtomicUintFetchOrRelaxed(&gc->schedFlags, GC_SCHED_PAUSED);
+  GCContext_DisarmTimer(gc);
+}
+
+void GCContext_ResumeSchedulingAfterConsistency(GCContext* gc) {
+  if (!gc || !GCContext_PausedForConsistency(gc)) {
+    return;
+  }
+  // Clearing PAUSED and reading RUN_PENDING is one read-modify-write, so this cannot see a
+  // half-updated word. A run that outlived the window re-arms from its own one-shot; arming
+  // here as well would leave two live timers for one GC, the first of them orphaned.
+  const unsigned prev =
+      RS_AtomicUintFetchAndRelaxed(&gc->schedFlags, ~(unsigned)GC_SCHED_PAUSED);
+  if (!(prev & GC_SCHED_RUN_PENDING)) {
+    GCContext_ArmTimer(gc);
+  }
 }
 
 void GCContext_StopMock(GCContext* gc) {
@@ -303,9 +344,48 @@ void GC_ThreadPoolStart() {
 
 void GC_ThreadPoolDestroy() {
   if (gcThreadpool_g != NULL) {
+    if (redisearch_thpool_paused(gcThreadpool_g)) {
+      gcSchedulingPauseActiveForConsistency_g = false;
+      redisearch_thpool_resume_threads(gcThreadpool_g);
+    }
     RedisModule_ThreadSafeContextUnlock(RSDummyContext);
     redisearch_thpool_destroy(gcThreadpool_g);
     gcThreadpool_g = NULL;
     RedisModule_ThreadSafeContextLock(RSDummyContext);
+  }
+}
+
+void GC_ThreadPoolPauseForConsistency(void) {
+  gcSchedulingPauseActiveForConsistency_g = true;
+  if (gcThreadpool_g) {
+    redisearch_thpool_pause_threads_no_wait(gcThreadpool_g);
+  }
+}
+
+bool GC_ThreadPoolWaitForPause(long timeoutMs) {
+  if (!gcThreadpool_g) {
+    return true;
+  }
+  // The queue is already flagged paused, so no new job can start; wait only for the running
+  // ones to return. Bounded because this runs on the main thread with the GIL held -- an
+  // unbounded spin here stalls the whole shard.
+  struct timespec start;
+  clock_gettime(CLOCK_MONOTONIC, &start);
+  while (redisearch_thpool_num_jobs_in_progress(gcThreadpool_g)) {
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    long elapsedMs = (now.tv_sec - start.tv_sec) * 1000 + (now.tv_nsec - start.tv_nsec) / 1000000;
+    if (elapsedMs >= timeoutMs) {
+      return false;
+    }
+    usleep(100);
+  }
+  return true;
+}
+
+void GC_ThreadPoolResumeAfterConsistency(void) {
+  gcSchedulingPauseActiveForConsistency_g = false;
+  if (gcThreadpool_g && redisearch_thpool_paused(gcThreadpool_g)) {
+    redisearch_thpool_resume_threads(gcThreadpool_g);
   }
 }

--- a/src/gc.h
+++ b/src/gc.h
@@ -27,6 +27,7 @@ extern "C" {
 // Bits of GCContext.schedFlags.
 typedef enum {
   GC_SCHED_RUN_PENDING = 0x01,  // a run is queued on the GC pool, or executing
+  GC_SCHED_PAUSED = 0x02,       // a disk consistency window is open
 } GCSchedFlags;
 
 typedef struct InfoGCStats {
@@ -69,7 +70,8 @@ typedef struct GCContext {
 GCContext* GCContext_CreateGC(StrongRef spec_ref, uint32_t gcPolicy);
 // Start the GC periodic. Next run will be added to the job-queue after the interval
 void GCContext_Start(GCContext* gc);
-// Start the GC periodic. Next run will be added to the job-queue immediately
+// Start the GC periodic. Next run is queued immediately -- unless a run already owns the
+// re-arm, or a consistency window is open, in which case it comes after the interval instead.
 void GCContext_StartNow(GCContext* gc);
 void GCContext_StopMock(GCContext* gc);
 void GCContext_RenderStats(GCContext* gc, RedisModule_Reply* ctx);
@@ -92,6 +94,10 @@ bool GCContext_BeginDrop(GCContext* gc);
 // that discovers the drop and frees the context.
 void GCContext_FinishDrop(GCContext* gc);
 bool GCContext_IsEnabled(const GCContext* gc);
+// Suspend/resume scheduling for a disk consistency window, leaving `enabled` untouched so a
+// GC stopped by a debug command stays stopped across one. Both require the GIL.
+void GCContext_PauseSchedulingForConsistency(GCContext* gc);
+void GCContext_ResumeSchedulingAfterConsistency(GCContext* gc);
 
 static inline void InfoGCStats_Add(InfoGCStats* dst, const InfoGCStats* src) {
   dst->totalCollectedBytes += src->totalCollectedBytes;
@@ -101,6 +107,13 @@ static inline void InfoGCStats_Add(InfoGCStats* dst, const InfoGCStats* src) {
 
 void GC_ThreadPoolStart();
 void GC_ThreadPoolDestroy();
+// Stop the GC pool from pulling new jobs. Returns immediately; use GC_ThreadPoolWaitForPause
+// to wait out the ones already running.
+void GC_ThreadPoolPauseForConsistency(void);
+// Wait, up to `timeoutMs`, for the running GC jobs to return. Returns false on timeout. Must
+// follow GC_ThreadPoolPauseForConsistency, or a new job can start the moment this returns.
+bool GC_ThreadPoolWaitForPause(long timeoutMs);
+void GC_ThreadPoolResumeAfterConsistency(void);
 
 #ifdef __cplusplus
 }

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -30,6 +30,7 @@
 #include "cursor.h"
 #include "search_disk.h"
 #include "disk_gc.h"
+#include "gc.h"
 #include "doc_id_meta.h"
 #include "module_init_ffi.h"
 #include "document_rs.h"
@@ -724,7 +725,7 @@ void ShutdownDiskClose(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subev
   } else {
     // Hot restart preserves the on-disk DBs, but SearchDisk_Close still closes the
     // shared DiskContext; wait out any in-flight disk GC run first so no compaction
-    // races that close. The checkpoint (index_spec_pre_checkpoint) already
+    // races that close. The checkpoint (index_spec_open_consistency_window) already
     // disable_compactions()d during the save, so this wait is prompt. Nothing clears
     // sp->diskSpec here, so release the lock immediately — the wait is all we need.
     DiskGC_LockRunsAndDisable();
@@ -822,24 +823,87 @@ static void ForEachIndex(void (*fn)(IndexSpec *)) {
   dictReleaseIterator(iter);
 }
 
+static void PauseIndexGCSchedulingForConsistency(IndexSpec *sp) {
+  if (sp->gc) {
+    GCContext_PauseSchedulingForConsistency(sp->gc);
+  }
+}
+
+static void ResumeIndexGCSchedulingAfterConsistency(IndexSpec *sp) {
+  if (sp->gc) {
+    GCContext_ResumeSchedulingAfterConsistency(sp->gc);
+  }
+}
+
+static void FlushIndexForConsistency(IndexSpec *sp) {
+  if (sp->diskSpec) {
+    SearchDisk_Flush(sp->diskSpec);
+  }
+}
+
+// ForEachIndex takes a one-argument hook, so the gate flag rides in these two.
+static void CloseWindowReopeningGate(IndexSpec *sp) {
+  SearchDisk_CloseConsistencyWindow(sp, true);
+}
+
+static void CloseWindowKeepingGateClosed(IndexSpec *sp) {
+  SearchDisk_CloseConsistencyWindow(sp, false);
+}
+
+static bool InForkChild(void) {
+  return (RedisModule_GetContextFlags(RSDummyContext) & REDISMODULE_CTX_FLAGS_IS_CHILD) != 0;
+}
+
+// Backstop only; the begin hook cancels compactions first, so the expected wait is that
+// cycle's cancellation tail. Bounded because it runs on the main thread under the GIL.
+#define DISK_GC_CONSISTENCY_DRAIN_TIMEOUT_MS 5000
+
 //Keeps track to know if SST replication holds the lock avoiding background vector index building jobs from running
 static bool vecsimdisk_sst_consistency_lock_held = false;
+// Spans PRE_CHECKPOINT..POST_FORK as one hold, unlike the VecSim lock.
+static bool disk_gc_paused_for_consistency = false;
 
-// Begin a consistent on-disk save window.
-// Shared by the SST replication checkpoint (flush = SearchDisk_PreCheckpoint),
-// the SST replication fork (flush = SearchDisk_PreFork) and the foreground
-// hot-restart save (flush = SearchDisk_PreCheckpoint), so the callers cannot
-// drift apart on the lock/flag protocol. Pairs with DiskConsistencyWindow_End
-// or DiskConsistencyWindow_Close.
-static void DiskConsistencyWindow_Begin(void (*flush)(IndexSpec *)) {
+// Begin a consistent on-disk save window. Shared by the SST replication checkpoint and
+// fork and the foreground hot-restart save, so the callers cannot drift apart on the
+// lock/flag protocol. Pairs with DiskConsistencyWindow_End or _Close.
+//
+// The step order is load-bearing. Cancelling compactions first is what lets the drain
+// finish promptly; the drain is what keeps a GC thread from being mid-mutation of a
+// numeric BucketMap when the fork lands (MOD-17197); and flushing last, under the vector
+// consistency lock, is what keeps both writer classes out of the snapshot.
+static void DiskConsistencyWindow_Begin(void) {
+  if (!disk_gc_paused_for_consistency) {
+    GC_ThreadPoolPauseForConsistency();               // no queued job starts
+    ForEachIndex(PauseIndexGCSchedulingForConsistency);  // no timer queues one
+    disk_gc_paused_for_consistency = true;
+  }
+
+  ForEachIndex(SearchDisk_OpenConsistencyWindow);  // disable + cancel compactions
+
+  if (!GC_ThreadPoolWaitForPause(DISK_GC_CONSISTENCY_DRAIN_TIMEOUT_MS)) {
+    // Cannot decline the snapshot from here - the subevent handler returns void.
+    RedisModule_Log(RSDummyContext, "warning",
+                    "Disk consistency window: disk GC did not drain within %d ms; "
+                    "proceeding without the fork-safety guarantee",
+                    DISK_GC_CONSISTENCY_DRAIN_TIMEOUT_MS);
+  }
+
+  // After the drain, never before: a GC run needing this lock would deadlock against us.
   VecSimDisk_AcquireConsistencyLock();
   vecsimdisk_sst_consistency_lock_held = true;
-  ForEachIndex(flush);
+
+  // Flush last, under the lock. Both classes of background writer are now excluded: the
+  // disk GC by the drain, vector jobs by the lock. Flushing inside the hook above would
+  // leave the whole drain as a gap in which vector jobs could dirty on-disk state.
+  ForEachIndex(FlushIndexForConsistency);
 }
 
 // Release the consistency lock opened by DiskConsistencyWindow_Begin without
 // running any per-index finalize work. Used where there is no matching disk
 // hook (e.g. SST POST_CHECKPOINT, which OSS handles on its own).
+//
+// This deliberately leaves disk GC paused: SST keeps it paused through POST_FORK/ABORT,
+// and a successful hot restart keeps it paused through process exit.
 //
 // The caller must check vecsimdisk_sst_consistency_lock_held before calling
 // this on a path where the window may never have been opened.
@@ -848,15 +912,46 @@ static void DiskConsistencyWindow_Close(void) {
   vecsimdisk_sst_consistency_lock_held = false;
 }
 
-// End the consistent on-disk save window opened by DiskConsistencyWindow_Begin,
-// running `finalize` against every disk-backed index before releasing the lock.
-//
-// The caller must check vecsimdisk_sst_consistency_lock_held before calling
-// this on a path where the window may never have been opened (e.g. SST ABORT).
-static void DiskConsistencyWindow_End(void (*finalize)(IndexSpec *)) {
-  ForEachIndex(finalize);
-  DiskConsistencyWindow_Close();
+// How to end the window. The finalize hook and the disk-GC disposition are correlated, so
+// they travel as one parameter rather than two that could disagree.
+typedef enum {
+  // POST_FORK, SST ABORT, or a failed foreground save: the process keeps running.
+  DISK_WINDOW_END_RESUME,
+  // Successful hot restart: the process exits shortly and the kept on-disk DBs must stay
+  // frozen at what restart.rdb serialized, so disk GC stays paused and the numeric
+  // consistency gate stays closed.
+  DISK_WINDOW_END_HOT_RESTART,
+} DiskWindowEnd;
+
+// End the window opened by DiskConsistencyWindow_Begin. Safe on a path where the window
+// was never opened, or was only partly opened (e.g. SST ABORT): each half is unwound only
+// if held. The halves have different lifetimes - POST_CHECKPOINT releases the VecSim lock
+// but keeps disk GC paused - so an abort between POST_CHECKPOINT and PRE_FORK sees the
+// pause held and the lock not.
+static void DiskConsistencyWindow_End(DiskWindowEnd how) {
+  if (InForkChild()) {
+    // COW-inherited flags, not a window this process opened. The child owns no GC threads
+    // and must not run the finalize hooks - they re-enable compactions against DB files
+    // the parent owns.
+    vecsimdisk_sst_consistency_lock_held = false;
+    disk_gc_paused_for_consistency = false;
+    return;
+  }
+
+  ForEachIndex(how == DISK_WINDOW_END_HOT_RESTART ? CloseWindowKeepingGateClosed
+                                                  : CloseWindowReopeningGate);
+
+  if (how == DISK_WINDOW_END_RESUME && disk_gc_paused_for_consistency) {
+    ForEachIndex(ResumeIndexGCSchedulingAfterConsistency);
+    GC_ThreadPoolResumeAfterConsistency();
+    disk_gc_paused_for_consistency = false;
+  }
+
+  if (vecsimdisk_sst_consistency_lock_held) {
+    DiskConsistencyWindow_Close();
+  }
 }
+
 
 // SST replication event handler.
 //
@@ -880,7 +975,7 @@ static void SSTReplicationEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
       // index jobs cannot mutate on-disk state while the checkpoint is taken.
       // Released at POST_CHECKPOINT (or unwound by ABORT). PRE_FORK opens a
       // fresh window afterwards.
-      DiskConsistencyWindow_Begin(SearchDisk_PreCheckpoint);
+      DiskConsistencyWindow_Begin();
       break;
     case REDISMODULE_SUBEVENT_SST_REPL_POST_CHECKPOINT:
       RedisModule_Log(ctx, "notice", "SST replication: POST_CHECKPOINT");
@@ -891,23 +986,18 @@ static void SSTReplicationEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
       break;
     case REDISMODULE_SUBEVENT_SST_REPL_PRE_FORK:
       RedisModule_Log(ctx, "notice", "SST replication: PRE_FORK");
-      DiskConsistencyWindow_Begin(SearchDisk_PreFork);
+      DiskConsistencyWindow_Begin();
       break;
     case REDISMODULE_SUBEVENT_SST_REPL_POST_FORK:
       RedisModule_Log(ctx, "notice", "SST replication: POST_FORK");
       RS_ASSERT(vecsimdisk_sst_consistency_lock_held);
-      DiskConsistencyWindow_End(SearchDisk_PostFork);
+      DiskConsistencyWindow_End(DISK_WINDOW_END_RESUME);
       break;
     case REDISMODULE_SUBEVENT_SST_REPL_ABORT:
       RedisModule_Log(ctx, "notice", "SST replication: ABORT");
-      // The abort can fire before PRE_FORK opened the window, so the lock may
-      // not be held. Always run ReplicationAbort; only unwind the window when
-      // it was actually opened.
-      if (vecsimdisk_sst_consistency_lock_held) {
-        DiskConsistencyWindow_End(SearchDisk_ReplicationAbort);
-      } else {
-        ForEachIndex(SearchDisk_ReplicationAbort);
-      }
+      // Can fire anywhere between PRE_CHECKPOINT and POST_FORK, so either half of the
+      // window may or may not be held; End unwinds each only if it is.
+      DiskConsistencyWindow_End(DISK_WINDOW_END_RESUME);
       break;
     default:
       RS_LOG_ASSERT_FMT(false, "Received unknown sub-event %llu for SST replication", (unsigned long long)subevent);
@@ -948,19 +1038,20 @@ static void PersistenceEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
       // Hot restart: a RAM-only RDB (restart.rdb) is being saved in the
       // foreground alongside the on-disk state. The replication
       // SST_REPL_PRE_FORK consistency hook never fires for a foreground save,
-      // so open the consistency window here instead (flushing via PreCheckpoint).
+      // so open the consistency window here instead.
       RedisModule_Log(ctx, "notice", "SAVE start mode=HOT_RESTART proc=main sst=true disk_index=preserved");
       // Latch so the upcoming shutdown keeps the on-disk DBs (see ShutdownDiskClose).
       g_hotRestartSave = true;
-      DiskConsistencyWindow_Begin(SearchDisk_PreCheckpoint);
+      DiskConsistencyWindow_Begin();
     }
     break;
   case REDISMODULE_SUBEVENT_PERSISTENCE_ENDED:
     if (vecsimdisk_sst_consistency_lock_held) {
-      // Re-enable compactions but keep the numeric consistency gate
-      // closed: the writes it guards must stay coherent with the
-      // just-serialized RDB (see SearchDisk_HotRestartSaveEnded).
-      DiskConsistencyWindow_End(SearchDisk_HotRestartSaveEnded);
+      // Only a real hot restart freezes: the process exits shortly, so resuming GC or
+      // reopening the gate would let the kept DBs advance past what restart.rdb captured.
+      // Any other SST save reaching here leaves the process running, so it must unwind.
+      DiskConsistencyWindow_End(g_hotRestartSave ? DISK_WINDOW_END_HOT_RESTART
+                                                 : DISK_WINDOW_END_RESUME);
       RedisModule_Log(ctx, "notice", "SAVE end mode=%s sst=true ok=true",
                       g_hotRestartSave ? "HOT_RESTART" : "SST_REPL");
     } else if (!useSst) {
@@ -971,8 +1062,8 @@ static void PersistenceEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
   case REDISMODULE_SUBEVENT_PERSISTENCE_FAILED:
     if (vecsimdisk_sst_consistency_lock_held) {
       // Unwind the hot-restart consistency window opened at SYNC_RDB_START,
-      // re-enabling compactions defensively via ReplicationAbort on failure.
-      DiskConsistencyWindow_End(SearchDisk_ReplicationAbort);
+      // re-enabling compactions defensively on failure.
+      DiskConsistencyWindow_End(DISK_WINDOW_END_RESUME);
       // The window may have been opened by a foreground hot-restart save
       // (g_hotRestartSave) or by an SST-replication fork (child observing the
       // COW-inherited flag) — log the actual mode before clearing the latch.

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -615,31 +615,15 @@ void SearchDisk_Flush(RedisSearchDiskIndexSpec* index) {
   disk->index.flush(index);
 }
 
-void SearchDisk_PreCheckpoint(IndexSpec *sp) {
+void SearchDisk_OpenConsistencyWindow(IndexSpec *sp) {
   RS_ASSERT(disk && sp && sp->diskSpec);
-  // No read/write lock taken from spec. Disabling compaction and calling SearchDisk_PreCheckpoint from main thread
-  // ensures no writes while checkpoint taken.
-  disk->index.preCheckpoint(sp->diskSpec);
+  // No spec lock taken: being on the main thread is what keeps writes out.
+  disk->index.openConsistencyWindow(sp->diskSpec);
 }
 
-void SearchDisk_PreFork(IndexSpec *sp) {
+void SearchDisk_CloseConsistencyWindow(IndexSpec *sp, bool reopenNumericGate) {
   RS_ASSERT(disk && sp && sp->diskSpec);
-  disk->index.preFork(sp->diskSpec);
-}
-
-void SearchDisk_PostFork(IndexSpec *sp) {
-  RS_ASSERT(disk && sp && sp->diskSpec);
-  disk->index.postFork(sp->diskSpec);
-}
-
-void SearchDisk_HotRestartSaveEnded(IndexSpec *sp) {
-  RS_ASSERT(disk && sp && sp->diskSpec);
-  disk->index.hotRestartSaveEnded(sp->diskSpec);
-}
-
-void SearchDisk_ReplicationAbort(IndexSpec *sp) {
-  RS_ASSERT(disk && sp && sp->diskSpec);
-  disk->index.replicationAbort(sp->diskSpec);
+  disk->index.closeConsistencyWindow(sp->diskSpec, reopenNumericGate);
 }
 
 void SearchDisk_UpdateBufferBudget(RedisModuleCtx *ctx, int percentage) {

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -853,48 +853,29 @@ uint64_t SearchDisk_GetDiskUsage(RedisSearchDiskIndexSpec* index);
 void SearchDisk_Flush(RedisSearchDiskIndexSpec* index);
 
 /**
- * @brief Master-side SST replication PRE_CHECKPOINT hook for a single index.
+ * @brief Open the consistency window on a single index.
  *
- * Acquires the IndexSpec read lock (blocks writes, allows queries) and
- * dispatches to the disk-side preCheckpoint hook.
- *
- * @param sp Pointer to the IndexSpec (must have a non-NULL diskSpec)
- */
-void SearchDisk_PreCheckpoint(IndexSpec *sp);
-
-/**
- * @brief Master-side SST replication PRE_FORK hook for a single index.
- *
- * Dispatches to the disk-side preFork hook.
+ * Replaces the former PreCheckpoint/PreFork pair. Disables and cancels manual compactions
+ * and closes the numeric consistency gate; does not flush - the caller does that under the
+ * vector consistency lock. Idempotent within a cycle. Takes no IndexSpec lock: running on
+ * the main thread is what keeps writes out.
  *
  * @param sp Pointer to the IndexSpec (must have a non-NULL diskSpec)
  */
-void SearchDisk_PreFork(IndexSpec *sp);
+void SearchDisk_OpenConsistencyWindow(IndexSpec *sp);
 
 /**
- * @brief Master-side SST replication POST_FORK hook for a single index.
+ * @brief Close the consistency window on a single index, re-enabling compactions.
  *
- * Dispatches to the disk-side postFork hook.
+ * Replaces the former PostFork/ReplicationAbort/HotRestartSaveEnded trio. Tolerates a
+ * window that was never opened, so the abort paths need no special case. Pass
+ * reopenNumericGate=false on a successful hot restart, where the gate must stay closed
+ * through process exit.
  *
  * @param sp Pointer to the IndexSpec
+ * @param reopenNumericGate Whether to reopen the numeric consistency gate
  */
-void SearchDisk_PostFork(IndexSpec *sp);
-
-/**
- * @brief Hot-restart save-ended hook: re-enable compactions, keep the numeric
- * consistency gate closed. See IndexDiskAPI.hotRestartSaveEnded.
- */
-void SearchDisk_HotRestartSaveEnded(IndexSpec *sp);
-
-/**
- * @brief Master-side SST replication ABORT hook for a single index.
- *
- * Dispatches to the disk-side replicationAbort hook, then releases whichever
- * subset of locks (fork lock, read lock) is currently held for this cycle.
- *
- * @param sp Pointer to the IndexSpec
- */
-void SearchDisk_ReplicationAbort(IndexSpec *sp);
+void SearchDisk_CloseConsistencyWindow(IndexSpec *sp, bool reopenNumericGate);
 
 /**
  * @brief Update the buffer budget and WBM in response to RAM configuration changes
@@ -935,7 +916,7 @@ typedef enum {
   // A numeric split between its Step B scan and its Step C+D commit (GC
   // thread) — the mid-flight, nothing-committed point.
   SEARCH_DISK_SITE_NUMERIC_SPLIT_PRE_COMMIT = 3,
-  // index_spec_pre_checkpoint right after the consistency gate of the
+  // index_spec_open_consistency_window right after the consistency gate of the
   // numeric index closes (main thread); cross-wake source for
   // deterministically deferring a held split.
   SEARCH_DISK_SITE_NUMERIC_GATE_CLOSED = 4,

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -599,45 +599,40 @@ typedef struct IndexDiskAPI {
   void (*updateMaxOpenFiles)(RedisSearchDiskIndexSpec *index, int maxOpenFiles);
 
   /**
-   * @brief Master-side SST replication PRE_CHECKPOINT hook.
+   * @brief Open a consistency window on one index. Main thread; no IndexSpec lock held.
    *
-   * Called once per index before the replication checkpoint is taken.
-   * Caller holds the IndexSpec read lock for the duration of this call.
+   * Replaces the former preCheckpoint/preFork pair. Called at every window-open point
+   * (SST PRE_CHECKPOINT, SST PRE_FORK, foreground hot-restart save), so it must be
+   * idempotent within a cycle.
+   *
+   * Must disable and cancel manual compactions, and close the numeric consistency gate.
+   * Must NOT flush: the caller flushes separately via `flush`, after taking the vector
+   * consistency lock, so vector-job writes are excluded from the snapshot too. Cancelling
+   * compactions here is what lets the caller's disk-GC drain finish promptly. Both effects
+   * last until closeConsistencyWindow.
    *
    * POST_CHECKPOINT has no matching disk hook - OSS handles it on its own.
    *
    * @param index Pointer to the disk index spec
    */
-  void (*preCheckpoint)(RedisSearchDiskIndexSpec *index);
+  void (*openConsistencyWindow)(RedisSearchDiskIndexSpec *index);
 
   /**
-   * @brief Master-side SST replication PRE_FORK hook.
+   * @brief Close the consistency window on one index.
    *
-   * Called once per index before the replication snapshot fork.
+   * Replaces the former postFork/replicationAbort/hotRestartSaveEnded trio. Called at
+   * POST_FORK, at ABORT from anywhere in the cycle, and at the end of a foreground save,
+   * so it must tolerate a window that was never opened.
    *
-   * @param index Pointer to the disk index spec
-   */
-  void (*preFork)(RedisSearchDiskIndexSpec *index);
-
-  /**
-   * @brief Master-side SST replication POST_FORK hook.
-   *
-   * Called once per index after the snapshot fork.
+   * Always re-enables compactions. Reopens the numeric consistency gate only when
+   * `reopenNumericGate` is true - a successful hot restart passes false, because the
+   * process exits shortly and reopening would let a deferred split finalize after the RDB
+   * serialized its pre-finalize state.
    *
    * @param index Pointer to the disk index spec
+   * @param reopenNumericGate Whether to reopen the numeric consistency gate
    */
-  void (*postFork)(RedisSearchDiskIndexSpec *index);
-
-  /**
-   * @brief Master-side SST replication ABORT hook.
-   *
-   * Called once per index when the replication cycle is aborted at any point
-   * between PRE_CHECKPOINT and POST_FORK. The disk implementation is free to
-   * undo whatever state it set up in the preceding `pre*` hook.
-   *
-   * @param index Pointer to the disk index spec
-   */
-  void (*replicationAbort)(RedisSearchDiskIndexSpec *index);
+  void (*closeConsistencyWindow)(RedisSearchDiskIndexSpec *index, bool reopenNumericGate);
 
   /**
    * @brief Debug: dump a numeric field's in-memory bucket routing map.
@@ -653,18 +648,6 @@ typedef struct IndexDiskAPI {
    */
   char *(*debugDumpNumericBucketMap)(RedisSearchDiskIndexSpec *index, t_fieldIndex fieldIndex, AllocateKeyCallback allocate);
 
-  /**
-   * @brief Hot-restart save-ended hook.
-   *
-   * Called once per index after a successful foreground hot-restart save.
-   * Re-enables compactions (the on-disk DBs are kept and the process exits
-   * shortly) but deliberately leaves the numeric consistency gate closed:
-   * reopening it would let a deferred split finalize after the RDB
-   * serialized its pre-finalize state.
-   *
-   * @param index Pointer to the disk index spec
-   */
-  void (*hotRestartSaveEnded)(RedisSearchDiskIndexSpec *index);
 } IndexDiskAPI;
 
 typedef struct DocTableDiskAPI {

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -729,3 +729,55 @@ TEST_F(FGCTestNumeric, testNumericBlocksSinceFork) {
   cur_cardinality -= 2;
   EXPECT_EQ(cur_cardinality, NumericRange_GetCardinality(rootRange));
 }
+
+/**
+ * Disk consistency windows pause GC scheduling. These cover the state machine directly --
+ * the flow tests cannot reach it, since nothing in OSS opens a window.
+ */
+
+static unsigned gcSchedFlags(GCContext *gc) {
+  return RS_AtomicUintLoadRelaxed(&gc->schedFlags);
+}
+
+TEST_F(FGCTest, testConsistencyWindowPauseDisarmsAndResumeClears) {
+  GCContext *gc = get_spec(ism)->gc;
+
+  GCContext_PauseSchedulingForConsistency(gc);
+  ASSERT_TRUE(gcSchedFlags(gc) & GC_SCHED_PAUSED);
+  ASSERT_EQ(gc->timerID, 0);  // the window must not leave a timer behind
+  ASSERT_TRUE(GCContext_IsEnabled(gc));  // pausing is not stopping
+
+  GCContext_ResumeSchedulingAfterConsistency(gc);
+  ASSERT_FALSE(gcSchedFlags(gc) & GC_SCHED_PAUSED);
+}
+
+TEST_F(FGCTest, testPauseSurvivesResumeOnAStoppedGC) {
+  GCContext *gc = get_spec(ism)->gc;
+
+  // A GC stopped by a debug command must stay stopped across a window.
+  GCContext_StopFutureRuns(gc);
+  GCContext_PauseSchedulingForConsistency(gc);
+  GCContext_ResumeSchedulingAfterConsistency(gc);
+
+  ASSERT_FALSE(GCContext_IsEnabled(gc));
+  ASSERT_EQ(gc->timerID, 0);
+}
+
+TEST_F(FGCTest, testStartNowDoesNotQueueWhilePaused) {
+  GCContext *gc = get_spec(ism)->gc;
+  GCContext_StopFutureRuns(gc);  // StartNow requires a stopped GC
+  GCContext_PauseSchedulingForConsistency(gc);
+
+  GCContext_StartNow(gc);
+  // Enabled, but nothing queued onto the paused pool: the resume path arms instead.
+  ASSERT_TRUE(GCContext_IsEnabled(gc));
+  ASSERT_FALSE(gcSchedFlags(gc) & GC_SCHED_RUN_PENDING);
+
+  GCContext_ResumeSchedulingAfterConsistency(gc);
+}
+
+TEST_F(FGCTest, testWaitForPauseReturnsWhenNothingIsRunning) {
+  GC_ThreadPoolPauseForConsistency();
+  ASSERT_TRUE(GC_ThreadPoolWaitForPause(10));
+  GC_ThreadPoolResumeAfterConsistency();
+}

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -274,6 +274,10 @@ class TestDebugCommands(object):
         self.env.expect(debug_cmd(), 'GC_CONTINUE_SCHEDULE', 'idx').ok()
         # CONTINUE must leave the GC enabled, not merely reply OK.
         self.env.expect(debug_cmd(), 'GC_CONTINUE_SCHEDULE', 'idx').error().contains('GC is already running periodically')
+        # And a forced cycle must still run and unblock its client, which a job stranded on a
+        # paused pool would not.
+        with TimeLimit(30, 'GC_FORCEINVOKE did not complete after GC_CONTINUE_SCHEDULE'):
+            forceInvokeGC(self.env, 'idx')
         # STOP is idempotent.
         self.env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
         self.env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()


### PR DESCRIPTION
> **Rebased onto #10728**, three deep: `master` ← #10747 (GC scheduling state model) ← #10728 (main-thread re-arm, MOD-17309) ← this. Two mechanisms from the previous revision are **deleted** rather than ported — see *What the stack absorbed*. Review threads from before the rebase are detached from their line anchors but still readable.

## Describe the changes in the pull request

**1. Current.** The fork child serializes each disk index's numeric `BucketMap` and takes its lock without holding any `IndexSpec` lock, on the grounds that the child's memory is a snapshot (`IndexSpec_RdbSave`: `needLock = … && inMainProcess`). But `fork()` clones only the calling thread, and `BucketMap` is a `BTreeMap<BucketKey, Arc<BucketEntry>>` that the disk GC mutates — a numeric split's Step A inserts into it under the map write lock. Two failure modes follow:

- The GC thread is mid-`insert`. `BTreeMap::insert` splits nodes and rewrites parent links, so it has intermediate states that are not a valid tree. The child inherits one and walks it into the RDB: a crash, or a corrupt numeric index shipped to the replica.
- The GC thread holds the write lock. The child's `read()` blocks on a lock whose owner does not exist in the child, so the fork never completes and replication stalls with no diagnostic.

The deadlock is the *symptom*; the tearing is the hazard. Not taking the lock in the child would remove the hang and leave the torn read, which is why the fix has to exclude mid-mutation writers rather than avoid the lock.

**2. Change.** Hold disk GC quiesced across the consistency window so no GC thread can be mid-mutation when the fork lands. `DiskConsistencyWindow_Begin` now:

1. pauses the GC threadpool and every spec's GC scheduling — one stops a queued job starting, the other stops a timer queueing one;
2. runs the disk open hook, which disables and cancels in-flight compactions;
3. waits out the GC run that was already executing;
4. takes the VecSim consistency lock — *after* the drain, never before, so a GC run needing that lock cannot deadlock against a main thread holding it while waiting for that run;
5. flushes, under the lock, for every index.

The pause spans `PRE_CHECKPOINT..POST_FORK` as a single hold: resuming at `POST_CHECKPOINT` would let a fresh cycle start and be mid-mutation when the fork arrives.

The drain is bounded at 5s because it runs on the main thread with the GIL held. Ordering is what makes that bound reachable: the disk hook cancels compactions first, so the expected wait is a cycle's cancellation tail rather than a full synchronous compaction of every column family.

**On timeout it logs a warning and proceeds, and the consequences are worse than "the fork may catch a torn map".** It goes on to take the VecSim lock and flush *with a GC run still executing*, so `SearchDisk_Flush` also races an in-flight compaction on the same DB. It proceeds anyway because the subevent handler returns `void` and cannot decline the snapshot, and a stalled shard is worse than a fork we cannot vouch for — but the log line understates it and there is no counter, so this is grep-only rather than alertable. Both are follow-ups.

`GC_SCHED_PAUSED` joins `RUN_PENDING` in the `schedFlags` word, which is what #10747 sized that word for.

`Indexes_RemoveSpecFromGlobals` now resumes scheduling before deleting the spec from the registry. `IndexSpec_Free` deliberately does not free the `GCContext` — it relies on a future run discovering the drop and self-terminating — and a window breaks that contract by disarming the timer while queueing nothing. Since the window's resume re-derives its set by walking `specDict_g`, a spec dropped mid-window would never be resumed, leaking the `GCContext`, its `DiskGC` and its `WeakRef` (which pins the spec's `RefManager`) for the life of the process, with `gc_total_docs_not_collected` permanently inflated. This covers `FT.DROPINDEX` and the drop-all/`FLUSHALL` paths alike. Note the same shape is latent on master via `FT.DEBUG GC_STOP_SCHEDULE`; what this PR changes is that windows open automatically on every SST cycle, so an ordinary drop can hit it.

**3. Outcome.** The child's map acquisition is uncontended and the tree it walks is intact, so replication neither hangs on a fork child nor ships a torn numeric index.

## What the stack absorbed

Both of these were load-bearing before the rebase and are now unnecessary, not merely relocated:

- **`GCContext_ReArmAfterRun` is gone** — a `ThreadSafeContextTryLock` + `usleep(1)` spin with a bail-if-paused escape, which existed only because the re-arm ran on the GC thread and would otherwise deadlock against a main thread inside the drain waiting for that very job. #10728 moves the arm to a main-thread one-shot, so there is nothing to spin on and nothing to bail out of. Note this is also why the PR could not simply sit beside #10728: arming from the GC thread *is* MOD-17309, so this change would have kept shipping that crash in the disk path.
- **The relaxed-atomic handshake collapsed.** Run-completion and window-resume used to be a store-then-load on each side across two threads, which relaxed accesses do not order — hence each side reading the other's bit from the return value of its own read-modify-write. Both sides now run on the main thread and are serialized by the event loop. The single RMW left in `GCContext_ResumeSchedulingAfterConsistency` is there for clarity; correctness no longer rests on it.

Also dropped as superseded: this branch's `debug_commands.c` changes. `GCContext_StopFutureRuns` / `GCContext_IsEnabled` already land in #10747, and the branch's `GC_FORCEINVOKE` timeout edit predates — and would have reverted — MOD-17448 (#10732), now in master.

## Three unwind bugs the spanning pause exposed

All three share a root cause: the GC pause has a longer lifetime than the VecSim lock, so every path that used to unwind one now has to decide about the other.

- **An `ABORT` between `POST_CHECKPOINT` and `PRE_FORK` left disk GC paused forever.** The window's two halves have different lifetimes — `POST_CHECKPOINT` releases the VecSim lock but deliberately keeps GC paused — so branching on the lock flag alone missed the pause. `DiskConsistencyWindow_End` now unwinds each half only if held, which also removed the branching at the `ABORT` call site.
- **A successful hot restart resumed disk GC.** `PERSISTENCE_ENDED` called the full unwind, but there the process exits shortly and the kept on-disk DBs must stay frozen at what `restart.rdb` serialized — a resumed GC cycle could finalize a deferred numeric split and advance the disk past the RAM bucket map the RDB captured. `PERSISTENCE_ENDED` now releases only the VecSim half, gated on `g_hotRestartSave`; `PERSISTENCE_FAILED` still unwinds fully, since there the process keeps running.
- **The fork child could run the finalize hooks off its COW-inherited flags**, re-enabling manual compactions against DB files the parent owns. `End` now returns early in the child.

## API change: five replication hooks become three

`⚠️ Requires the matching disk-side PR` — the `IndexDiskAPI` field names change, so an unmatched disk build leaves them NULL.

| Before | After |
|---|---|
| `preCheckpoint`, `preFork` | `openConsistencyWindow` |
| `postFork`, `replicationAbort` | `closeConsistencyWindow` |
| `hotRestartSaveEnded` | unchanged |

`preCheckpoint` and `preFork` differed by one call — `preCheckpoint` disabled and cancelled manual compactions before flushing, `preFork` only flushed. That asymmetry forced OSS to choose a hook based on whether the window was already open, since the GC drain only terminates promptly once compactions are cancelled. `openConsistencyWindow` disables and cancels compactions and closes the numeric gate — it deliberately does *not* flush, since the caller must do that under the vector consistency lock — and is idempotent within a cycle (the disabled state is a flag, not a refcount, and nothing is in flight to cancel the second time).

`postFork` and `replicationAbort` were the same operation; the abort variant merely tolerated compactions not being disabled. `closeConsistencyWindow` tolerates a window that was never opened, which removes the last special case from the SST `ABORT` path.

`hotRestartSaveEnded` stays separate deliberately: it re-enables compactions but leaves the numeric consistency gate closed, so it is not a window close.

Both header docs also described the locking wrongly and in different ways — `search_disk.h` claimed `PreCheckpoint` *acquires* the IndexSpec read lock, `search_disk_api.h` claimed the *caller holds* it. Neither is true; the implementation takes no spec lock. Corrected, and the compaction-then-flush ordering is now written down, since callers depend on it.

## Validation

- Build: clean with `DEBUG=1 ENABLE_ASSERT=1`; no new warnings.
- Unit tests: 982 passed, 0 failed (4 new).
- Flow tests: 247 passed, 0 failed across `test_gc`, `test_debug_commands`, `test_existing`, `test_missing`, `test_issues`, `test_info_modules`.

Covered by tests: `testGCStopAndContinueSchedule` asserts `GC_CONTINUE_SCHEDULE` genuinely re-enables collection and that a forced cycle still runs and unblocks its client under a time limit — the second half is what a job stranded on the newly-pausable pool would fail. `test_existing.py` drives `GC_STOP_SCHEDULE`/`GC_CONTINUE_SCHEDULE` in stop/work/continue pairs, exercising the round-trip incidentally.

Four new `tests/cpptests/test_cpp_forkgc.cpp` cases cover the pause/resume state machine directly, since no OSS flow test can open a window: pause disarms the timer and leaves `enabled` set; a GC stopped by a debug command stays stopped across a window; `GCContext_StartNow` does not queue onto a paused pool; and `GC_ThreadPoolWaitForPause` returns when nothing is running.

**Not covered**, and stated rather than implied:

- **The leak fix above has no test.** In `RS_IsMock` — the only mode cpptests run — `IndexSpec_Free` frees the GC unconditionally, so the mock cannot exhibit the bug. The real check is ASan on a disk-enabled deployment, and note the `sanitize`/`coverage`/`miri` lanes are **skipped** on this PR because its base is not `master`; they will first run once the stack merges and this retargets.
- `GC_ThreadPoolWaitForPause`'s timeout arithmetic. Reaching it needs a GC job already running when the pause lands, which needs an injectable GC callback — `GCContext_CreateGC` wires `FGC_Create`/`DiskGC_Create` and takes no hook.
- The end-to-end fork-safety assertion. It needs a disk-side rendezvous that parks a GC thread *while holding* the map write lock; the existing `numeric_split_pre_commit` parks between Steps B and C, where nothing is held.
- The hot-restart and SST `ABORT` unwind paths, which have no OSS-only driver.
- The 5s drain timeout path.

## Open questions and known follow-ups

- **`DiskConsistencyWindow_End` now releases the VecSim lock only if `vecsimdisk_sst_consistency_lock_held`**, where it used to release unconditionally. `PERSISTENCE_RDB_START` / `PERSISTENCE_SYNC_RDB_START` clear that flag without touching the lock, so if either can fire in the *parent* mid-window, the lock leaks for the life of the process and background vector index building stops — and the `RS_ASSERT` meant to catch it is a NOP in release. Whether those events reach the parent or only the fork child is not answerable from OSS; **this needs a disk-side answer before merge.** `POST_CHECKPOINT` still releases unconditionally, so the two sibling paths currently disagree about whether the flag or the lock is authoritative.
- A partially-opened window leaks a *global* GC pause with no log line, no timeout and nothing in `INFO`, so on-disk garbage would grow unbounded and silently. OSS now depends on RSE firing exactly one of `POST_FORK`/`ABORT` after every `PRE_CHECKPOINT`. Worth logging the transitions and exposing the state.
- `GC_FORCEINVOKE` posts straight onto the pool with no paused check, so a blocked client can now be stranded for the whole window. Should fail fast while paused.
- `IndexDiskAPI` is unversioned while this change removes two pointers from its middle; a leading `apiVersion` checked in `SearchDisk_SetAPI` would turn a silent slot mismatch into a clean failure.
- `src/spec.c` hardcodes `GCPolicy_Fork` for legacy-RDB specs in `legacySpecDict`, which the window's `ForEachIndex` does not walk. In a Flex deployment loading a legacy RDB that GC would never be paused, and the drain would burn its full timeout under the GIL. Judged very unlikely but not ruled out.
- The `PERSISTENCE_ENDED` `SST_REPL` branch now routes to `DISK_WINDOW_END_RESUME`, reopening the numeric gate where the old code kept it closed. If that branch is only ever the fork child the new early return makes it dead; needs the disk side to confirm which.

## Not in this PR

- `PRE_FORK` must be the last thing before `fork()`, with no return to the event loop in between. OSS cannot enforce or test that; it is an RSE-side guarantee this change depends on.
- A way to decline the snapshot from the hook, so the 5s timeout has somewhere to go other than a warning.
- Disk-side `try_read()` on the child's map acquisition, so a regressed invariant fails the save loudly instead of blocking.
- The renamed hook fields are guarded only by `RS_ASSERT`, a no-op in release builds, so a mismatched disk build would call a NULL pointer. Accepted because OSS and disk ship as a single shared object, so the skew cannot occur; the guard belongs on the disk side.

#### Which additional issues this PR fixes
1. MOD-17197
2. Complements redislabsdev/RediSearchEnterprise#635 (MOD-16337), which owns snapshot coherence; this PR owns fork safety.
3. Stacked on #10728 and #10747. Merge those first, in that order.

#### Main objects this PR modified
1. GC pause / bounded drain / resume, and the `GC_SCHED_PAUSED` bit (`src/gc.c`, `src/gc.h`)
2. SST replication and hot-restart consistency window (`src/notifications.c`)
3. Disk replication hooks: 5 → 3, with corrected contracts (`src/search_disk_api.h`, `src/search_disk.h`, `src/search_disk.c`)

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Fixes SST replication hanging, or replicating a corrupt numeric index, when disk GC is mid-cycle at the snapshot fork.
