### PR TITLE
[MOD-16818] FT.SEARCH with KNN and SORTBY by distance reports the wrong number of matching documents in cluster

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3102,10 +3102,15 @@ static void knnPostProcess(searchReducerCtx *rCtx) {
         }
       }
     }
+    // ProcessKNNSearchReply does not accumulate the shards' totals, and the
+    // KNN heap is bounded by K, so the merged heap count is the total.
+    rCtx->totalReplies = heap_count(rCtx->pq);
+  } else {
+    // SORTBY-by-distance: rCtx->pq is a response window sized
+    // min(K, offset+count), so its count is not the total. processSearchReply
+    // summed the shards' totals (each at most K hits globally); clamp to K.
+    rCtx->totalReplies = MIN(reducerSpecialCaseCtx->knn.k, rCtx->totalReplies);
   }
-  // We can always get at most K results
-  rCtx->totalReplies = heap_count(rCtx->pq);
-
 }
 
 // Atomic (relaxed) access to the FT.SEARCH MR execution-phase marker: the BG

--- a/src/module.c
+++ b/src/module.c
@@ -3102,13 +3102,19 @@ static void knnPostProcess(searchReducerCtx *rCtx) {
         }
       }
     }
-    // ProcessKNNSearchReply does not accumulate the shards' totals, and the
-    // KNN heap is bounded by K, so the merged heap count is the total.
+    // `shouldSort`: ProcessKNNSearchReply never accumulated the shards'
+    // total_results, it only fed the K-bounded knn.pq. rCtx->pq is sized
+    // MAX(K, offset+count) on this path (see setKNNSpecialCase), so the merge
+    // above dropped nothing and its count is exactly the number of matching
+    // documents, min(K, global matches).
     rCtx->totalReplies = heap_count(rCtx->pq);
   } else {
-    // SORTBY-by-distance: rCtx->pq is a response window sized
-    // min(K, offset+count), so its count is not the total. processSearchReply
-    // summed the shards' totals (each at most K hits globally); clamp to K.
+    // SORTBY by the distance field: processSearchReply already summed each
+    // shard's total_results, i.e. sum_i min(K, matches_i). rCtx->pq here is only
+    // a response window sized MIN(K, offset+count), so its count is not a hit
+    // count. Clamping the sum to K is exact: if every shard has at most K
+    // matches the sum *is* the global match count, and otherwise both the sum
+    // and the global match count are >= K.
     rCtx->totalReplies = MIN(reducerSpecialCaseCtx->knn.k, rCtx->totalReplies);
   }
 }

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -164,6 +164,53 @@ def test_search_knn_limit_offset_resp2():
 def test_search_knn_limit_offset_resp3():
     _search_knn_limit_offset(protocol=3)
 
+def _search_knn_sortby_limit_total(protocol):
+    # MOD-16818: with KNN + SORTBY <distance field>, the coordinator sized its
+    # merge heap by min(K, offset+count) and reported the heap count as the
+    # total, so `total` grew with the LIMIT window instead of staying at
+    # min(K, matches) on every page.
+    env = Env(protocol=protocol, moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG', 'v', 'VECTOR', 'FLAT', '6',
+            'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2')
+    for i in range(30):
+        conn.execute_command('HSET', f'vdoc{{{i:02d}}}', 't', 'tiny' if i < 8 else 'rest',
+                             'v', np.array([float(i), 0.0], dtype=np.float32).tobytes())
+    waitForIndex(env, 'idx')
+
+    blob = np.array([0.0, 0.0], dtype=np.float32).tobytes()
+
+    def run(query, offset, count):
+        res = env.cmd('FT.SEARCH', 'idx', query, 'PARAMS', '2', 'B', blob,
+                      'SORTBY', 'dist', 'LIMIT', str(offset), str(count),
+                      'NOCONTENT', 'DIALECT', '2')
+        if protocol == 3:
+            return res['total_results'], [row['id'] for row in res['results']]
+        return res[0], res[1:]
+
+    # 30 matches, K=20: total must be 20 on every page, rows follow the window
+    for offset, count in [(0, 5), (5, 5), (15, 5), (0, 20)]:
+        total, ids = run('*=>[KNN 20 @v $B AS dist]', offset, count)
+        env.assertEqual(total, 20, message=f'LIMIT {offset} {count}')
+        env.assertEqual(ids, [f'vdoc{{{i:02d}}}' for i in range(offset, offset + count)],
+                        message=f'LIMIT {offset} {count}')
+
+    # filter (8 matches) smaller than K=20: total must be 8 on every page
+    for offset, count in [(0, 5), (5, 5)]:
+        total, ids = run('@t:{tiny}=>[KNN 20 @v $B AS dist]', offset, count)
+        env.assertEqual(total, 8, message=f'tiny LIMIT {offset} {count}')
+        env.assertEqual(ids, [f'vdoc{{{i:02d}}}' for i in range(offset, min(offset + count, 8))],
+                        message=f'tiny LIMIT {offset} {count}')
+
+@skip(cluster=False, redis_less_than="7.0.0")
+def test_search_knn_sortby_limit_total_resp2():
+    _search_knn_sortby_limit_total(protocol=2)
+
+@skip(cluster=False, redis_less_than="7.0.0")
+def test_search_knn_sortby_limit_total_resp3():
+    _search_knn_sortby_limit_total(protocol=3)
+
 @skip(redis_less_than="7.0.0")
 def test_search_timeout():
     num_range = 1000

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -166,9 +166,11 @@ def test_search_knn_limit_offset_resp3():
 
 def _search_knn_sortby_limit_total(protocol):
     # MOD-16818: with KNN + SORTBY <distance field>, the coordinator sized its
-    # merge heap by min(K, offset+count) and reported the heap count as the
-    # total, so `total` grew with the LIMIT window instead of staying at
-    # min(K, matches) on every page.
+    # merge heap by min(K, offset+count) and reported the heap count as
+    # `total_results`, so the reported number of matching documents was the size
+    # of the response window (0 for `LIMIT 0 0`) instead of min(K, matches).
+    # The same assertions run in standalone, where they always held - this pins
+    # the cluster reply to the single-shard behavior.
     env = Env(protocol=protocol, moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
 
@@ -189,25 +191,26 @@ def _search_knn_sortby_limit_total(protocol):
             return res['total_results'], [row['id'] for row in res['results']]
         return res[0], res[1:]
 
-    # 30 matches, K=20: total must be 20 on every page, rows follow the window
-    for offset, count in [(0, 5), (5, 5), (15, 5), (0, 20)]:
+    # 30 documents match, K=20: the query matches 20 documents on every page,
+    # including the count-only `LIMIT 0 0`. Rows follow the window.
+    for offset, count in [(0, 0), (0, 5), (5, 5), (15, 5), (0, 20)]:
         total, ids = run('*=>[KNN 20 @v $B AS dist]', offset, count)
         env.assertEqual(total, 20, message=f'LIMIT {offset} {count}')
         env.assertEqual(ids, [f'vdoc{{{i:02d}}}' for i in range(offset, offset + count)],
                         message=f'LIMIT {offset} {count}')
 
     # filter (8 matches) smaller than K=20: total must be 8 on every page
-    for offset, count in [(0, 5), (5, 5)]:
+    for offset, count in [(0, 0), (0, 5), (5, 5)]:
         total, ids = run('@t:{tiny}=>[KNN 20 @v $B AS dist]', offset, count)
         env.assertEqual(total, 8, message=f'tiny LIMIT {offset} {count}')
         env.assertEqual(ids, [f'vdoc{{{i:02d}}}' for i in range(offset, min(offset + count, 8))],
                         message=f'tiny LIMIT {offset} {count}')
 
-@skip(cluster=False, redis_less_than="7.0.0")
+@skip(redis_less_than="7.0.0")
 def test_search_knn_sortby_limit_total_resp2():
     _search_knn_sortby_limit_total(protocol=2)
 
-@skip(cluster=False, redis_less_than="7.0.0")
+@skip(redis_less_than="7.0.0")
 def test_search_knn_sortby_limit_total_resp3():
     _search_knn_sortby_limit_total(protocol=3)
 


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: On a multi-shard cluster, `FT.SEARCH ... =>[KNN K ...] SORTBY <distance field>` reports `total_results` as the size of the requested response window, `min(K, offset+count)`, instead of the number of documents matching the query. `setKNNSpecialCase` sizes the reducer heap (and the per-shard `LIMIT` rewrite) at `min(K, offset+count)`, and `knnPostProcess` then overwrites the correctly shard-summed `totalReplies` with `heap_count(pq)`. So for a query with 20 matching documents, `LIMIT 0 5` reports 5, and the count-only `LIMIT 0 0` reports 0. `total_results` is defined as the number of documents matching the query (see the reply construction in `src/aggregate/aggregate_exec.c`) — it is not a count of returned rows — so any client that reads it, whether to render "N results found" or to decide how many pages exist, gets a wrong number. Returned rows were always correct. Queries without `SORTBY` by the distance field were unaffected.
2. Change: In `knnPostProcess`, use `heap_count` only on the `shouldSort` path, where `ProcessKNNSearchReply` never accumulates shard totals and the merge heap is sized `MAX(K, offset+count)`. On the `SORTBY`-by-distance path, clamp the shard-summed `totalReplies` to K instead of overwriting it: each shard reports `min(K, its matches)`, so the clamped sum is exactly `min(K, global matches)` — if every shard has at most K matches the sum *is* the global match count, and otherwise both the sum and the global count are at least K. The heap sizing and the shard `LIMIT` rewrite are untouched — they are a valid response-window optimization; only the total accounting was wrong.
3. Outcome: `total_results` is `min(K, matching documents)` on every `LIMIT` page, including `LIMIT 0 0`, matching standalone. Returned rows are unchanged. The new regression tests (`test_search_knn_sortby_limit_total_resp2/resp3`) run in both standalone and cluster mode, so they also pin the cluster reply to the single-shard behavior; in cluster they fail on master with `total=0/5/10` where 20 is expected. `test_resp3.py` (38), `test_coordinator.py` (14) and `test_vecsim.py` (50) all pass in OSS-cluster mode.

#### Which additional issues this PR fixes
1. MOD-16818

#### Main objects this PR modified
1. `knnPostProcess` (src/module.c) — reply-total accounting for the coordinator's KNN merge
2. `tests/pytests/test_resp3.py` — regression tests for KNN + SORTBY <dist> + LIMIT totals (incl. `LIMIT 0 0` and filter-smaller-than-K), run in standalone and cluster

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
