### PR TITLE
[8.6-rse] [MOD-16192] info: obfuscate index name in IndexesInfo lock-acquire warning

### DIFF
--- a/src/info/indexes_info.c
+++ b/src/info/indexes_info.c
@@ -34,7 +34,7 @@ TotalIndexesInfo IndexesInfo_TotalInfo() {
     // Lock for read
     int rc = pthread_rwlock_rdlock(&sp->rwlock);
     if (rc != 0) {
-      RedisModule_Log(RSDummyContext, "warning", "Failed to acquire read lock on index %s: rc=%d (%s). Cannot continue getting Index info", HiddenString_GetUnsafe(sp->specName, NULL), rc, strerror(rc));
+      RedisModule_Log(RSDummyContext, "warning", "Failed to acquire read lock on index %s: rc=%d (%s). Cannot continue getting Index info", IndexSpec_FormatName(sp, RSGlobalConfig.hideUserDataFromLog), rc, strerror(rc));
       continue;
     }
 


### PR DESCRIPTION
# Description
Backport of #10048 to `8.6-rse`.

Companion to #10055 (the same fix backported to `8.6`). This lands it on the Enterprise (`-rse`) line, which had not received it — the warning still logged the raw index name there.

## Describe the changes in the pull request

1. **Current:** `IndexesInfo_TotalInfo` (`src/info/indexes_info.c:37`) emits a `warning`-level log on rwlock-acquire failure that formats the index name via `HiddenString_GetUnsafe(sp->specName, NULL)`, which unconditionally returns the real (unobfuscated) name — even when `RSGlobalConfig.hideUserDataFromLog` is enabled.
2. **Change:** Switch the format argument to `IndexSpec_FormatName(sp, RSGlobalConfig.hideUserDataFromLog)`, matching the scanner and fork-GC convention.
3. **Outcome:** The warning now respects the user-data hiding config and emits the obfuscated index name when redaction is on. No new includes are needed — `spec.h` already pulls in `config.h`.

#### Which additional issues this PR fixes
1. MOD-16192
2. Relates to MOD-15757 (umbrella for AMR/Azure shard-log redaction; this is one missed site)

#### Main objects this PR modified
1. `src/info/indexes_info.c` — `IndexesInfo_TotalInfo` warning log

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

## Backport notes
Clean cherry-pick of #10048 (master `7c0f07a8`). The pre-image on `8.6-rse` matched master exactly (`HiddenString_GetUnsafe(sp->specName, NULL)`), and `IndexSpec_FormatName(const IndexSpec*, bool)` already exists on `8.6-rse` (`src/spec.h`). No adaptation was required. Build/tests deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
