### PR TITLE
[Iterator Revalidation][MOD-17244] Optional

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -9,12 +9,14 @@
 
 //! Supporting types for [`Optional`].
 
-use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use index_result::{RSIndexResult, RSResultKind, RawIndexResult};
+use ref_mode::{Active, Ref, Suspended};
 use std::cmp;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+    boxed::{ResumeSlotOutcome, resume_child_slot_in_place, suspend_child_slot_in_place},
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 use index_spec::IndexSpecReadGuard;
@@ -26,6 +28,18 @@ use rqe_core::{DocId, RS_FIELDMASK_ALL};
 ///
 /// Parameterised over a [`Ref`] mode — see [`Optional`] for the [`Active`]
 /// instantiation that implements [`RQEIterator`].
+///
+/// # Invariants
+///
+/// 1. **Layout compatibility across modes.** `RawOptional` is `#[repr(C)]` and
+///    its only `Rf`-dependent field is `result: RawIndexResult<Rf>`, which is
+///    layout-compatible across `Rf` (proven in `index_result`). Given that the
+///    child `I` and its `I::Suspended` are layout-compatible (the
+///    [`RQEIteratorBoxed`] contract, preserved through the `#[repr(C)]`
+///    [`OptionalChild`] slot), the `Active` and `Suspended` instantiations are
+///    layout-identical. This is what lets
+///    [`suspend`](RQEIteratorBoxed::suspend) reinterpret the owning `Box` in
+///    place.
 #[repr(C)]
 pub struct RawOptional<'query, Rf: Ref, I> {
     /// Inclusive upper bound on document identifiers to iterate over.
@@ -107,6 +121,28 @@ impl<I> OptionalChild<I> {
 /// Alias for an [`Active`] [`RawOptional`] — the only instantiation with an
 /// [`RQEIterator`] impl today.
 pub type Optional<'index, I> = RawOptional<'index, Active<'index>, I>;
+
+// Compile-time proof of invariant 1 on `RawOptional`: for a representative
+// concrete child, the `Active` and `Suspended` instantiations are
+// layout-identical. The `result: RawIndexResult<Rf>` field's own cross-`Rf`
+// layout compatibility is proven in `index_result`; the `OptionalChild<I>` slot's
+// is the child's invariant 1 (enforced generically by
+// `suspend_child_slot_in_place`). The `offset_of!` asserts pin down that neither
+// the enum child nor the result field shifts across modes.
+const _: () = {
+    use crate::Wildcard;
+    use std::mem::{align_of, offset_of, size_of};
+    type AChild = Wildcard<'static>;
+    type SChild = <Wildcard<'static> as RQEIteratorBoxed<'static>>::Suspended;
+    type A = RawOptional<'static, Active<'static>, AChild>;
+    type S = RawOptional<'static, Suspended, SChild>;
+    assert!(offset_of!(A, max_doc_id) == offset_of!(S, max_doc_id));
+    assert!(offset_of!(A, weight) == offset_of!(S, weight));
+    assert!(offset_of!(A, result) == offset_of!(S, result));
+    assert!(offset_of!(A, child) == offset_of!(S, child));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
 
 impl<'index, I> Optional<'index, I>
 where
@@ -293,6 +329,188 @@ where
     }
 }
 
+impl<'index, I> RQEIteratorBoxed<'index> for Optional<'index, I>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawOptional<'index, Suspended, I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Transition the child in place (if present). A whole-box cast alone is
+        // *not* enough for a type-erased child: its active and suspended forms
+        // carry different `dyn` vtables, so the transition must be dispatched
+        // through the child's own `suspend` — which `suspend_child_slot_in_place`
+        // does (a no-op whole-box cast for concrete children, a vtable swap for
+        // erased ones). A `Gone` child has no payload to transition.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned, initialised,
+        // exclusively owned). The `&mut` borrow of the child enum is confined to
+        // this `if let`; `c` is the valid, exclusively-owned active child payload.
+        if let OptionalChild::Present(c) = unsafe { &mut (*raw).child } {
+            // SAFETY: `c` points at a valid, exclusively-owned `I`; the helper
+            // reinitialises the slot as a valid `I::Suspended` in place.
+            unsafe { suspend_child_slot_in_place(c as *mut I) };
+        }
+        // SAFETY: the `Present` child (if any) now holds `I::Suspended` and `Gone`
+        // has no payload, so the allocation is a valid
+        // `RawOptional<Suspended, I::Suspended>`: layout-identical to the active
+        // form by invariant 1 on `RawOptional` (const proof above) —
+        // `result: RawIndexResult<Rf>` is layout-compatible across `Rf`, and the
+        // child slot's `I`/`I::Suspended` size/alignment match is statically
+        // enforced by `suspend_child_slot_in_place`. `Box::from_raw` reuses the
+        // same allocation, so the box address is preserved.
+        unsafe { Box::from_raw(raw as *mut RawOptional<'index, Suspended, I::Suspended>) }
+    }
+}
+
+impl<'query, S> RQESuspendedIterator<'query> for RawOptional<'query, Suspended, S>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = Optional<'a, S::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        /// Outcome of resuming the child slot, captured so the `&mut` borrow of
+        /// the child enum is released before we touch the slot as a raw pointer.
+        enum ChildResume {
+            /// Child was already `Gone` — stays fully virtual.
+            Absent,
+            /// Child resumed into the slot; `moved` mirrors `Moved`.
+            Active { last: DocId, moved: bool },
+            /// Child aborted and was consumed; the slot must be set to `Gone`.
+            Aborted { last: DocId },
+            /// Child resume failed; the slot must be restored to `Gone` and the
+            /// box freed.
+            Failed(RQEIteratorError),
+        }
+
+        // `Optional`'s `result` must still be a virtual sentinel. It is handed
+        // out mutably via `current()`/`read()`/`skip_to`, so a consumer could in
+        // principle have replaced its `data` with a real, index-backed payload.
+        // Reinterpreting that `Suspended → Active` would assert `'index` borrows
+        // that `Optional` cannot re-validate (it owns no backing for this
+        // sentinel), so we fail the resume rather than risk UB. `kind() ==
+        // Virtual` is the whole condition: `data` is the only `Rf`-parametrized
+        // field, so it is all the reinterpretation touches — `metrics` are
+        // `'query`-scoped and `dmd` is a plain `*const` raw pointer in both modes.
+        // Checked here, safely via `&self`, before `Box::into_raw` opens the
+        // raw-pointer critical section, so a violation just drops `self` (the
+        // `Box`) normally.
+        if self.result.kind() != RSResultKind::Virtual {
+            return Err(RQEIteratorError::IoError(std::io::Error::other(
+                "Optional resume: result is no longer a virtual sentinel; its \
+                 index-backed data cannot be re-validated",
+            )));
+        }
+
+        let raw = Box::into_raw(self);
+
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned, initialised,
+        // exclusively owned). `&raw mut` forms a field pointer to the child enum
+        // without creating a reference.
+        let child_slot = unsafe { &raw mut (*raw).child };
+
+        // Resume the child in place. The `&mut` borrow of the enum is confined to
+        // this block so the raw `child_slot` writes below never alias it.
+        // SAFETY: `child_slot` is non-null, aligned, initialised, and
+        // exclusively owned (from `Box::into_raw`), so `&mut *child_slot` is a
+        // sound unique borrow of the child enum.
+        let step = match unsafe { &mut *child_slot } {
+            OptionalChild::Gone => ChildResume::Absent,
+            OptionalChild::Present(c) => {
+                let last = S::last_doc_id(c);
+                // SAFETY: `c` is the valid, exclusively-owned suspended child
+                // payload. On Unchanged/Moved the helper rewrites the slot as a
+                // valid `S::Resumed<'a>`; on Aborted/Err it consumes the child,
+                // leaving the payload uninitialised (handled below).
+                match unsafe { resume_child_slot_in_place(c as *mut S, guard) } {
+                    Ok(ResumeSlotOutcome::Unchanged) => ChildResume::Active { last, moved: false },
+                    Ok(ResumeSlotOutcome::Moved) => ChildResume::Active { last, moved: true },
+                    Ok(ResumeSlotOutcome::Aborted) => ChildResume::Aborted { last },
+                    Err(e) => ChildResume::Failed(e),
+                }
+            }
+        };
+
+        // Mirror `revalidate`: an aborted child is dropped (`Gone`), leaving us
+        // fully virtual — it never aborts the whole `Optional`.
+        let (child_disturbed, last_child_doc_id) = match step {
+            ChildResume::Absent => (false, 0),
+            ChildResume::Active { last, moved } => (moved, last),
+            ChildResume::Aborted { last } => {
+                // Child consumed → payload uninitialised. Overwrite the enum with
+                // `Gone` (no payload); Optional becomes fully virtual.
+                // SAFETY: `child_slot` is valid and exclusively owned; `ptr::write`
+                // does not drop the moved-from payload.
+                unsafe { child_slot.write(OptionalChild::Gone) };
+                (true, last)
+            }
+            ChildResume::Failed(e) => {
+                // As `Aborted`, but the failure aborts the whole resume. Restore a
+                // valid `Gone` child so the box is a well-formed owned value again,
+                // then drop it (frees `result` + the allocation) and propagate.
+                // SAFETY: `child_slot` valid+owned; the payload is moved-from, so
+                // `ptr::write` must not drop it.
+                unsafe { child_slot.write(OptionalChild::Gone) };
+                // SAFETY: `raw` is again a valid, exclusively-owned
+                // `RawOptional<Suspended, S>` (child `Gone`, `result` still
+                // suspended); reclaim it as a `Box` and drop it.
+                drop(unsafe { Box::from_raw(raw) });
+                return Err(e);
+            }
+        };
+
+        // The child slot now holds a valid active child (or `Gone`). Reinterpret
+        // the owning box in place, reusing the allocation so the `result` pointer
+        // handed out by `current()`/`read()`/`skip_to` — and the FFI's cached
+        // `header.current` — stays valid across the cycle; rebuilding via
+        // `Box::new` would move `result` and dangle those pointers.
+        //
+        // SAFETY: layout-identical to the suspended form by invariant 1 on
+        // `RawOptional` (const proof above). `result` is a virtual sentinel built
+        // via `build_virt()` (its `data` is `RawResultData::Virtual`, `dmd` is
+        // null, `metrics` is empty), so it carries no index pointers and its
+        // `Suspended → Active<'a>` re-typing is unconditionally sound; the child
+        // slot's `S`/`S::Resumed` size/alignment match is enforced by
+        // `resume_child_slot_in_place`; the remaining fields carry no `Rf`.
+        // `Box::from_raw` reuses the same allocation.
+        let mut active = unsafe { Box::from_raw(raw.cast::<Optional<'a, S::Resumed<'a>>>()) };
+
+        // Mirror `revalidate`: a child that aborted or moved forces a re-read
+        // iff the previous result came from the child (its doc id matches the
+        // aggregate's current doc id) rather than being a virtual sentinel.
+        let moved = if child_disturbed && last_child_doc_id == active.result.doc_id {
+            active.read()?;
+            true
+        } else {
+            false
+        };
+
+        Ok(if moved {
+            ResumeOutcome::Moved(active)
+        } else {
+            ResumeOutcome::Ok(active)
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.max_doc_id as usize
+    }
+}
 impl<'index> crate::interop::ProfileChildren<'index>
     for Optional<'index, crate::c2rust::CRQEIterator>
 {

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -399,7 +399,7 @@ where
         // principle have replaced its `data` with a real, index-backed payload.
         // Reinterpreting that `Suspended → Active` would assert `'index` borrows
         // that `Optional` cannot re-validate (it owns no backing for this
-        // sentinel), so we fail the resume rather than risk UB. `kind() ==
+        // sentinel), so we abort the resume rather than risk UB. `kind() ==
         // Virtual` is the whole condition: `data` is the only `Rf`-parametrized
         // field, so it is all the reinterpretation touches — `metrics` are
         // `'query`-scoped and `dmd` is a plain `*const` raw pointer in both modes.
@@ -407,10 +407,7 @@ where
         // raw-pointer critical section, so a violation just drops `self` (the
         // `Box`) normally.
         if self.result.kind() != RSResultKind::Virtual {
-            return Err(RQEIteratorError::IoError(std::io::Error::other(
-                "Optional resume: result is no longer a virtual sentinel; its \
-                 index-backed data cannot be re-validated",
-            )));
+            return Ok(ResumeOutcome::Aborted);
         }
 
         let raw = Box::into_raw(self);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -1143,3 +1143,66 @@ mod optional_iterator_non_sequential_reads {
         let _ = it.read();
     }
 }
+
+mod via_resume {
+    use super::*;
+    use rqe_iterators::{
+        RQEIteratorBoxed, RQESuspendedIterator, ResumeOutcome, TypeErasedRQEIterator,
+    };
+
+    /// Regression: `Optional` wrapping a *type-erased* child must dispatch the
+    /// child's own `suspend`/`resume` rather than byte-casting the child slot
+    /// (a byte cast keeps the erased child's active `dyn` vtable under a
+    /// suspended type, so `resume` would dispatch through the wrong vtable), and
+    /// must **reuse its allocation** across the cycle because it hands out
+    /// `&mut self.result` (a pointer into the box) from
+    /// `current()`/`read()`/`skip_to`.
+    #[test]
+    fn optional_over_type_erased_child_round_trips() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // Type-erased child — the case a whole-box cast gets wrong.
+        let child = TypeErasedRQEIterator::new(Box::new(Wildcard::new(10, 1.0)));
+        let mut optional = Box::new(Optional::new(MAX_DOC_ID, WEIGHT, child));
+
+        // Advance into the real-child range (docs 1..=10 come from the child).
+        let _ = optional.read().unwrap(); // doc 1
+        let _ = optional.read().unwrap(); // doc 2
+        let last_before = optional.last_doc_id();
+        let addr_before = &*optional as *const _ as usize;
+
+        let suspended = optional.suspend();
+        let mut active = match suspended
+            .resume(&mock_ctx.spec_read())
+            .expect("resume failed")
+        {
+            ResumeOutcome::Ok(it) | ResumeOutcome::Moved(it) => it,
+            ResumeOutcome::Aborted => panic!("Optional never aborts as a whole"),
+        };
+
+        // Allocation reused → the box (and the `result` it hands out) keeps its
+        // address across the cycle.
+        assert_eq!(
+            &*active as *const _ as usize, addr_before,
+            "resume must reuse the allocation (Optional hands out &mut self.result)"
+        );
+        // The erased child must have survived the round-trip. If `suspend`
+        // byte-casts instead of dispatching, the retained active vtable makes the
+        // child resume dispatch through the wrong vtable; Optional then reads it
+        // as a spurious abort and drops the child to `Gone` (fully virtual). So a
+        // surviving `Present` child is the discriminating signal.
+        assert!(
+            active.child().is_some(),
+            "type-erased child must survive suspend/resume (not be dropped to Gone)"
+        );
+        assert_eq!(active.last_doc_id(), last_before);
+        // Doc `last_before + 1` (3) is within the child's range (1..=10), so it is
+        // a *real* child hit with the Optional's weight applied — not a virtual
+        // sentinel (which is what a dropped child would yield).
+        let next = active.read().unwrap().unwrap();
+        assert_eq!(next.doc_id, last_before + 1);
+        assert_eq!(next.weight, WEIGHT, "must be a real (weighted) child hit");
+    }
+
+    const MAX_DOC_ID: DocId = 100;
+    const WEIGHT: f64 = 2.0;
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -1146,6 +1146,8 @@ mod optional_iterator_non_sequential_reads {
 
 mod via_resume {
     use super::*;
+    use crate::utils::{Mock, MockIteratorError, MockRevalidateResult};
+    use index_result::{RSIndexResult, RSResultKind};
     use rqe_iterators::{
         RQEIteratorBoxed, RQESuspendedIterator, ResumeOutcome, TypeErasedRQEIterator,
     };
@@ -1201,6 +1203,222 @@ mod via_resume {
         let next = active.read().unwrap().unwrap();
         assert_eq!(next.doc_id, last_before + 1);
         assert_eq!(next.weight, WEIGHT, "must be a real (weighted) child hit");
+    }
+
+    // The tests below drive concrete `Mock` children (rather than the
+    // type-erased case above) so `MockData` can steer the child's
+    // resume outcome, covering every branch of `Optional`'s resume:
+    // the non-virtual-sentinel guard, a `Gone` child, and a `Present` child
+    // that resumes Unchanged / Moved / Aborted / Err — each crossed with
+    // whether the last emitted result was a child hit (forcing a re-read) or a
+    // virtual sentinel.
+
+    /// Non-virtual-sentinel guard: if a consumer has replaced the virtual
+    /// sentinel handed out by `read`/`current`/`skip_to` with index-backed
+    /// data, `resume` cannot prove the new `'index` borrows are still valid, so
+    /// it aborts the whole `Optional` rather than reinterpret `Suspended →
+    /// Active`.
+    #[test]
+    fn resume_aborts_when_result_no_longer_virtual() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // `[5]` has no hit at doc 1, so the first read yields the virtual sentinel.
+        let child = Mock::new([5]);
+        let mut optional = Box::new(Optional::new(MAX_DOC_ID, WEIGHT, child));
+
+        let sentinel = optional.read().unwrap().unwrap();
+        assert_eq!(sentinel.kind(), RSResultKind::Virtual);
+        // Simulate a consumer swapping the sentinel for a real, index-backed
+        // result (e.g. a numeric record).
+        *sentinel = RSIndexResult::build_numeric(1.0).build();
+
+        let outcome = optional
+            .suspend()
+            .resume(&mock_ctx.spec_read())
+            .expect("resume must not surface an error for a non-virtual sentinel");
+        assert!(
+            matches!(outcome, ResumeOutcome::Aborted),
+            "a non-virtual sentinel must abort the resume",
+        );
+    }
+
+    /// `Gone` child: an `Optional` whose child has already been dropped stays
+    /// fully virtual and resumes cleanly. The first cycle aborts the child
+    /// (covering the abort-then-`Ok`, no-re-read branch); the second cycle
+    /// covers the `Gone`/Absent branch.
+    #[test]
+    fn resume_with_gone_child_stays_virtual() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // `[5]` yields a virtual sentinel at doc 1, so the aborting child's last
+        // doc id (5) does not match the current doc id (1): no re-read.
+        let child = Mock::new([5]);
+        child
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        let mut optional = Box::new(Optional::new(MAX_DOC_ID, WEIGHT, child));
+
+        let _ = optional.read().unwrap(); // virtual sentinel (doc 1)
+
+        // First cycle: the child aborts and is dropped to `Gone`. The last
+        // result was virtual, so no re-read happens and the outcome is `Ok`.
+        let active = match optional
+            .suspend()
+            .resume(&mock_ctx.spec_read())
+            .expect("resume failed")
+        {
+            ResumeOutcome::Ok(it) => it,
+            ResumeOutcome::Moved(_) => {
+                panic!("aborted child after a virtual result must not re-read (Ok)")
+            }
+            ResumeOutcome::Aborted => panic!("Optional never aborts as a whole for a child abort"),
+        };
+        assert!(
+            active.child().is_none(),
+            "aborted child must be dropped to Gone"
+        );
+
+        // Second cycle: the child is already `Gone` — the Absent branch.
+        let active = match active
+            .suspend()
+            .resume(&mock_ctx.spec_read())
+            .expect("resume failed")
+        {
+            ResumeOutcome::Ok(it) => it,
+            ResumeOutcome::Moved(_) => panic!("a Gone child must resume as Ok, not Moved"),
+            ResumeOutcome::Aborted => panic!("a Gone child must resume as Ok, not Aborted"),
+        };
+        assert!(active.child().is_none(), "the child stays Gone");
+    }
+
+    /// `Present` child that reports `Moved`, with the last result coming from
+    /// the child: `Optional` must re-read to avoid stale data and report
+    /// `Moved`.
+    #[test]
+    fn resume_moved_child_with_child_hit_rereads() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // `[1]` hits at doc 1, so the first read is a real (weighted) child hit.
+        let child = Mock::new([1]);
+        child
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        let mut optional = Box::new(Optional::new(MAX_DOC_ID, WEIGHT, child));
+
+        let hit = optional.read().unwrap().unwrap();
+        assert_eq!(hit.doc_id, 1);
+        assert_eq!(hit.weight, WEIGHT, "doc 1 is a real child hit");
+
+        let suspended = optional.suspend();
+        // The suspended form exposes the aggregate's position/estimate to a
+        // composite parent that inspects a suspended child mid-resume.
+        assert_eq!(suspended.last_doc_id(), 1);
+        assert_eq!(suspended.num_estimated(), MAX_DOC_ID as usize);
+
+        let outcome = suspended
+            .resume(&mock_ctx.spec_read())
+            .expect("resume failed");
+        assert!(
+            matches!(outcome, ResumeOutcome::Moved(_)),
+            "a moved child whose hit was the last result must re-read (Moved)",
+        );
+    }
+
+    /// `Present` child that moves during resume, forcing a re-read whose own
+    /// `read` then fails: the error propagates out of `Optional::resume`.
+    #[test]
+    fn resume_reread_error_propagates() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // `[1]` hits at doc 1 (a real hit, so the resume re-reads), and the child
+        // errors once it reaches its end — which the re-read triggers.
+        let child = Mock::new([1]);
+        {
+            let mut data = child.data();
+            data.set_revalidate_result(MockRevalidateResult::Move);
+            data.set_error_at_done(Some(MockIteratorError::TimeoutError(None)));
+        }
+        let mut optional = Box::new(Optional::new(MAX_DOC_ID, WEIGHT, child));
+
+        let _ = optional.read().unwrap(); // doc 1 (child hit)
+
+        let result = optional.suspend().resume(&mock_ctx.spec_read());
+        assert!(
+            matches!(result, Err(rqe_iterators::RQEIteratorError::TimedOut)),
+            "an error from the re-read must propagate out of Optional::resume",
+        );
+    }
+
+    /// `Present` child that reports `Moved`, with the last result being a
+    /// virtual sentinel: no re-read, reported as `Ok`.
+    #[test]
+    fn resume_moved_child_after_virtual_does_not_reread() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // `[5]` has no hit at doc 1, so the first read is the virtual sentinel.
+        let child = Mock::new([5]);
+        child
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        let mut optional = Box::new(Optional::new(MAX_DOC_ID, WEIGHT, child));
+
+        let sentinel = optional.read().unwrap().unwrap();
+        assert_eq!(sentinel.doc_id, 1, "doc 1 is a virtual sentinel");
+
+        let outcome = optional
+            .suspend()
+            .resume(&mock_ctx.spec_read())
+            .expect("resume failed");
+        assert!(
+            matches!(outcome, ResumeOutcome::Ok(_)),
+            "a moved child after a virtual result must not re-read (Ok)",
+        );
+    }
+
+    /// `Present` child that reports `Aborted`, with the last result coming from
+    /// the child: the child is dropped to `Gone` and `Optional` re-reads,
+    /// reporting `Moved`.
+    #[test]
+    fn resume_aborted_child_with_hit_rereads_and_drops_child() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child = Mock::new([1]);
+        child
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        let mut optional = Box::new(Optional::new(MAX_DOC_ID, WEIGHT, child));
+
+        let hit = optional.read().unwrap().unwrap();
+        assert_eq!(hit.doc_id, 1);
+
+        let active = match optional
+            .suspend()
+            .resume(&mock_ctx.spec_read())
+            .expect("resume failed")
+        {
+            ResumeOutcome::Moved(it) => it,
+            ResumeOutcome::Ok(_) => panic!("an aborted child hit must re-read and report Moved"),
+            ResumeOutcome::Aborted => panic!("Optional never aborts as a whole for a child abort"),
+        };
+        assert!(
+            active.child().is_none(),
+            "aborted child must be dropped to Gone"
+        );
+    }
+
+    /// `Present` child whose own resume fails: `Optional::resume` propagates the
+    /// error (after restoring a well-formed `Gone`-child box so it drops
+    /// soundly).
+    #[test]
+    fn resume_propagates_child_error() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child = Mock::new([1]);
+        child
+            .data()
+            .set_error_on_resume(Some(MockIteratorError::TimeoutError(None)));
+        let mut optional = Box::new(Optional::new(MAX_DOC_ID, WEIGHT, child));
+
+        let _ = optional.read().unwrap(); // doc 1 (child hit)
+
+        let result = optional.suspend().resume(&mock_ctx.spec_read());
+        assert!(
+            matches!(result, Err(rqe_iterators::RQEIteratorError::TimedOut)),
+            "a child resume error must propagate out of Optional::resume",
+        );
     }
 
     const MAX_DOC_ID: DocId = 100;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -133,6 +133,7 @@ impl MockData {
             validation_count: 0,
             read_count: 0,
             error_at_done: None,
+            resume_error: None,
             delays: Vec::new(),
             force_read_none: false,
         })))
@@ -158,6 +159,18 @@ impl MockData {
     /// If `maybe_err` is `None`, end of input is reported as `Ok(None)`.
     pub fn set_error_at_done(&mut self, maybe_err: Option<MockIteratorError>) -> &mut Self {
         self.0.borrow_mut().error_at_done = maybe_err;
+        self
+    }
+
+    /// Configure an error that the suspended counterpart's
+    /// [`RQESuspendedIterator::resume`](rqe_iterators::RQESuspendedIterator::resume)
+    /// will return instead of resuming.
+    ///
+    /// This simulates a child whose revalidation-via-resume fails (rather than
+    /// aborts or moves), so tests can exercise the error-propagation branch of
+    /// iterators that wrap a child across the suspend/resume cycle.
+    pub fn set_error_on_resume(&mut self, maybe_err: Option<MockIteratorError>) -> &mut Self {
+        self.0.borrow_mut().resume_error = maybe_err;
         self
     }
 
@@ -213,6 +226,9 @@ struct MockDataInternal {
     validation_count: usize,
     read_count: usize,
     error_at_done: Option<MockIteratorError>,
+    /// Error returned by the suspended counterpart's `resume` instead of
+    /// resuming. See [`MockData::set_error_on_resume`].
+    resume_error: Option<MockIteratorError>,
     delays: Vec<(DocId, Duration)>,
     /// If true, the next call to `read()` will return `None` even if not at EOF.
     /// Simulates Inverted Index iterators that discover EOF only when `read()` is called.
@@ -534,11 +550,17 @@ impl<'query, const N: usize> rqe_iterators::RQESuspendedIterator<'query> for Moc
         // [`MockData`] — mirrors what `Mock::revalidate` does on the legacy
         // path, so tests driving suspend/resume see the same per-mock
         // outcomes as before.
-        let revalidate_result = {
+        let (revalidate_result, resume_error) = {
             let mut data = self.data.0.borrow_mut();
             data.validation_count += 1;
-            data.revalidate_result
+            (data.revalidate_result, data.resume_error)
         };
+        // Injected resume failure (see `MockData::set_error_on_resume`): drop the
+        // suspended mock and surface the error, mirroring a real child whose
+        // revalidation-via-resume fails.
+        if let Some(err) = resume_error {
+            return Err(err.into_rqe_iterator_error());
+        }
         let moved = match revalidate_result {
             MockRevalidateResult::Ok => false,
             MockRevalidateResult::Move => {
@@ -822,11 +844,17 @@ impl<'query> rqe_iterators::RQESuspendedIterator<'query> for MockVecSuspended {
         // [`MockData`] — mirrors what `MockVec::revalidate` does on the legacy
         // path, so tests driving suspend/resume see the same per-mock
         // outcomes as before.
-        let revalidate_result = {
+        let (revalidate_result, resume_error) = {
             let mut data = self.data.0.borrow_mut();
             data.validation_count += 1;
-            data.revalidate_result
+            (data.revalidate_result, data.resume_error)
         };
+        // Injected resume failure (see `MockData::set_error_on_resume`): drop the
+        // suspended mock and surface the error, mirroring a real child whose
+        // revalidation-via-resume fails.
+        if let Some(err) = resume_error {
+            return Err(err.into_rqe_iterator_error());
+        }
         let moved = match revalidate_result {
             MockRevalidateResult::Ok => false,
             MockRevalidateResult::Move => {


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `Optional` (the optional-match wrapper) implements only the
   legacy `RQEIterator::revalidate`; it has no `Box<Self>`-based suspend/resume,
   so it cannot participate in the new lock-release/reacquire revalidation flow.
2. **Change:** Implement `RQEIteratorBoxed` + `RQESuspendedIterator` for
   `Optional`. The wrapper transitions its child through the shared
   `suspend_child_slot_in_place` / `resume_child_slot_in_place` helpers —
   dispatching the child's *own* suspend/resume (correct for type-erased
   children, whose active/suspended forms carry different `dyn` vtables) — and
   **reuses its heap allocation** across the cycle, because it hands out
   `&mut self.result` (a pointer into the box) via `current()`/`read()`/`skip_to`
   and the FFI caches `header.current`. Adds a standalone `const _` "invariant 1"
   layout proof for `RawOptional`.
3. **Outcome:** `Optional` can be suspended and resumed soundly, including when
   it wraps a type-erased child, with the box (and the virtual `result` it lends
   out) keeping a stable address across the cycle. An aborted child collapses to
   `Gone`/fully-virtual, mirroring `revalidate`.

This PR is stacked on #10544 (`[Iterator Revalidation] Profile`) and targets
`iter-reval-C3a-profile`. It is split into two commits: the initial `Optional`
suspend/resume implementation, and a follow-up that (a) dispatches the child on
`suspend` instead of byte-casting the child slot — a type-erased child would
otherwise resume through the wrong vtable (UB) — and (b) resumes **in place**
instead of reallocating via `Box::new`, which would dangle the FFI's cached
`header.current` pointer.

Reviewed against `docs/rqe-iterator-suspend-resume.md`.

#### Which additional issues this PR fixes

Part of the Iterator Revalidation epic. Stacked on #10544.

#### Main objects this PR modified

1. `Optional` / `RawOptional` (`rqe_iterators/src/optional.rs`) — new
   `RQEIteratorBoxed` / `RQESuspendedIterator` impls + `const _` invariant proof.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal-only: the suspend/resume surface is not yet wired into production; no
user-facing behavior changes.
