### PR TITLE
MOD-17243: Fix INT8/UINT8 cosine hybrid query normalization

### DIFF
--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -280,8 +280,13 @@ static VecSimQueryReply_Code computeDistances_RAM(HybridIterator *hr) {
 
   // Normalize query vector for cosine metric (RAM path only - disk handles this internally).
   if (hr->indexMetric == VecSimMetric_Cosine) {
-    qvector = rm_malloc(hr->dimension * VecSimType_sizeof(hr->vecType));
-    memcpy(qvector, hr->query.vector, hr->dimension * VecSimType_sizeof(hr->vecType));
+    size_t vec_size = hr->dimension * VecSimType_sizeof(hr->vecType);
+    // For some cases blob_size may be larger than vec_size.
+    // For example, for INT8/UINT8, VecSim_Normalize appends the norm (a float) at the
+    // end of the blob.
+    size_t blob_size = VecSimParams_GetQueryBlobSize(hr->vecType, hr->dimension, hr->indexMetric);
+    qvector = rm_malloc(blob_size);
+    memcpy(qvector, hr->query.vector, vec_size);
     VecSim_Normalize(qvector, hr->dimension, hr->vecType);
   }
 

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -2644,3 +2644,45 @@ def test_vector_index_ptr_valid(env):
     # Server will reply OK but crash afterwards, so a PING is required to verify
     env.expect('FLUSHALL').noError()
     env.expect('PING').noError()
+
+
+def test_hybrid_adhoc_int8_uint8_cosine():
+    """
+    Test hybrid ad-hoc brute force search with INT8/UINT8 vectors and Cosine metric.
+    This covers query-vector normalization in computeDistances_RAM.
+    """
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+    dim = 4
+    qty = 10
+    k = 3
+
+    for data_type in ('INT8', 'UINT8'):
+        index_args = ['TYPE', data_type, 'DIM', dim, 'DISTANCE_METRIC', 'COSINE']
+        conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'FLAT',
+                             len(index_args), *index_args, 't', 'TEXT')
+
+        query_vec = None
+        for i in range(1, qty + 1):
+            type_limit = 127 if data_type == 'INT8' else 255
+            vector_values = [min(type_limit, i + j) for j in range(dim)]
+            query_vec = create_np_array_typed(vector_values, data_type)
+            conn.execute_command('HSET', i, 'v', query_vec.tobytes(), 't', 'text')
+
+        res = env.cmd('FT.SEARCH', 'idx', f'(text)=>[KNN {k} @v $vec_param HYBRID_POLICY ADHOC_BF]',
+                      'SORTBY', '__v_score',
+                      'PARAMS', 2, 'vec_param', query_vec.tobytes(),
+                      'RETURN', 2, 't', '__v_score')
+
+        env.assertEqual(res[0], k, message=f'{data_type}: expected {k} results')
+        debug_info = to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', 'idx', 'v'))
+        env.assertEqual(debug_info['LAST_SEARCH_MODE'], 'HYBRID_ADHOC_BF', message=data_type)
+
+        env.assertEqual(res[1], str(qty),
+                        message=f'{data_type}: expected doc {qty} to be the closest result. res = {res}')
+        first_res_values = res[2]
+        first_res_dist = first_res_values[first_res_values.index('__v_score') + 1]
+        env.assertEqual(float(first_res_dist), 0,
+                        message=f'{data_type}: expected exact self-match distance to be 0. res = {res}')
+
+        conn.execute_command('FLUSHALL')


### PR DESCRIPTION
Fixes query-vector buffer sizing in hybrid ad-hoc brute-force cosine search for INT8 and UINT8 vector fields.

`computeDistances_RAM` copied cosine query vectors into a buffer sized as `dimension * VecSimType_sizeof(type)` before calling `VecSim_Normalize`. INT8 and UINT8 cosine normalization can append the vector norm to the query blob, so the copy needs to be allocated with `VecSimParams_GetQueryBlobSize(...)` while still copying only the raw vector bytes from the user query.

This PR also adds a focused Python regression that exercises INT8 and UINT8 cosine `HYBRID_POLICY ADHOC_BF`, verifies the ad-hoc path is used, and checks the exact self-match distance.

Validation:

- `REJSON=0 ./build.sh RUN_PYTEST ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="test_vecsim:test_hybrid_adhoc_int8_uint8_cosine"`

Notes:

- Attempted the same focused run with `SAN=address`, but the local run did not reach the test because the ASAN Redis startup failed before accepting connections. The normal focused run passes on the rebased branch.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Fix INT8/UINT8 cosine hybrid query normalization to allocate enough query-blob space before normalization.