### PR TITLE
[MOD-17014] Validate FT.AGGREGATE GROUPBY count

### DIFF
--- a/src/aggregate/aggregate_plan.h
+++ b/src/aggregate/aggregate_plan.h
@@ -8,6 +8,7 @@
 */
 #ifndef AGGREGATE_PLAN_H_
 #define AGGREGATE_PLAN_H_
+#include <stdint.h>
 #include <value_ffi.h>
 #include <rlookup.h>
 #include <search_options.h>
@@ -37,6 +38,9 @@ typedef enum {
 } PLN_StepType;
 
 #define PLANTYPE_ANY_REDUCER (PLN_T__MAX + 1)
+
+// GROUPBY keys are addressed through RLookupKey.dstidx, which is uint16_t.
+#define MAX_GROUPBY_PROPERTIES UINT16_MAX
 
 typedef enum {
   PLN_F_ALIAS = 0x01,  // Plan step has an alias

--- a/src/aggregate/aggregate_plan.h
+++ b/src/aggregate/aggregate_plan.h
@@ -39,9 +39,6 @@ typedef enum {
 
 #define PLANTYPE_ANY_REDUCER (PLN_T__MAX + 1)
 
-// GROUPBY keys are addressed through RLookupKey.dstidx, which is uint16_t.
-#define MAX_GROUPBY_PROPERTIES UINT16_MAX
-
 typedef enum {
   PLN_F_ALIAS = 0x01,  // Plan step has an alias
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -951,7 +951,7 @@ static int parseGroupby(AGGPlan *plan, ArgsCursor *ac, QueryError *status) {
 
   long long nproperties;
   int rv = AC_GetLongLong(ac, &nproperties, AC_F_GE0);
-  if (rv != AC_OK || nproperties > UINT32_MAX) {
+  if (rv != AC_OK || nproperties > MAX_GROUPBY_PROPERTIES) {
     rv = rv != AC_OK ? rv : AC_ERR_ELIMIT;
     QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -958,9 +958,11 @@ static int parseGroupby(AGGPlan *plan, ArgsCursor *ac, QueryError *status) {
   }
 
   uint32_t propertyCount = (uint32_t)nproperties;
-  if (propertyCount > AC_NumRemaining(ac)) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments",
-                                  " for GROUPBY: %s", AC_Strerror(AC_ERR_NOARG));
+
+  ArgsCursor propertiesAC = {0};
+  rv = AC_GetSlice(ac, &propertiesAC, propertyCount);
+  if (rv != AC_OK) {
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
 
@@ -968,7 +970,7 @@ static int parseGroupby(AGGPlan *plan, ArgsCursor *ac, QueryError *status) {
   for (uint32_t i = 0; i < propertyCount; ++i) {
     const char *property;
     size_t propertyLen;
-    rv = AC_GetString(ac, &property, &propertyLen, 0);
+    rv = AC_GetString(&propertiesAC, &property, &propertyLen, 0);
     if (rv != AC_OK) {
       QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(rv));
       array_free(properties);

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -957,7 +957,7 @@ static int parseGroupby(AGGPlan *plan, ArgsCursor *ac, QueryError *status) {
   }
 
   uint32_t propertyCount = (uint32_t)AC_NumArgs(&propertiesAC);
-  if (propertyCount > MAX_GROUPBY_PROPERTIES) {
+  if (propertyCount > MAX_GROUPBY_PROPERTIES || propertyCount == 0) {
     QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(AC_ERR_ELIMIT));
     return REDISMODULE_ERR;
   }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -957,7 +957,7 @@ static int parseGroupby(AGGPlan *plan, ArgsCursor *ac, QueryError *status) {
   }
 
   uint32_t propertyCount = (uint32_t)AC_NumArgs(&propertiesAC);
-  if (propertyCount > MAX_GROUPBY_PROPERTIES || propertyCount == 0) {
+  if (propertyCount > MAX_GROUPBY_PROPERTIES) {
     QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(AC_ERR_ELIMIT));
     return REDISMODULE_ERR;
   }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -950,22 +950,21 @@ static int parseGroupby(AGGPlan *plan, ArgsCursor *ac, QueryError *status) {
   AC_GetString(ac, &s, NULL, AC_F_NOADVANCE);
 
   long long nproperties;
-  int rv = AC_GetLongLong(ac, &nproperties, AC_F_GE0);
+  int rv = AC_GetLongLong(ac, &nproperties, AC_F_GE0 | AC_F_NOADVANCE);
   if (rv != AC_OK || nproperties > MAX_GROUPBY_PROPERTIES) {
     rv = rv != AC_OK ? rv : AC_ERR_ELIMIT;
     QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
 
-  uint32_t propertyCount = (uint32_t)nproperties;
-
   ArgsCursor propertiesAC = {0};
-  rv = AC_GetSlice(ac, &propertiesAC, propertyCount);
+  rv = AC_GetVarArgs(ac, &propertiesAC);
   if (rv != AC_OK) {
     QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
 
+  uint32_t propertyCount = (uint32_t)AC_NumArgs(&propertiesAC);
   const char **properties = array_newlen(const char *, propertyCount);
   for (uint32_t i = 0; i < propertyCount; ++i) {
     const char *property;

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -949,22 +949,19 @@ static int parseGroupby(AGGPlan *plan, ArgsCursor *ac, QueryError *status) {
   const char *s;
   AC_GetString(ac, &s, NULL, AC_F_NOADVANCE);
 
-  long long nproperties;
-  int rv = AC_GetLongLong(ac, &nproperties, AC_F_GE0 | AC_F_NOADVANCE);
-  if (rv != AC_OK || nproperties > MAX_GROUPBY_PROPERTIES) {
-    rv = rv != AC_OK ? rv : AC_ERR_ELIMIT;
-    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(rv));
-    return REDISMODULE_ERR;
-  }
-
   ArgsCursor propertiesAC = {0};
-  rv = AC_GetVarArgs(ac, &propertiesAC);
+  int rv = AC_GetVarArgs(ac, &propertiesAC);
   if (rv != AC_OK) {
     QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
 
   uint32_t propertyCount = (uint32_t)AC_NumArgs(&propertiesAC);
+  if (propertyCount > MAX_GROUPBY_PROPERTIES) {
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(AC_ERR_ELIMIT));
+    return REDISMODULE_ERR;
+  }
+
   const char **properties = array_newlen(const char *, propertyCount);
   for (uint32_t i = 0; i < propertyCount; ++i) {
     const char *property;

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -950,14 +950,22 @@ static int parseGroupby(AGGPlan *plan, ArgsCursor *ac, QueryError *status) {
   AC_GetString(ac, &s, NULL, AC_F_NOADVANCE);
 
   long long nproperties;
-  int rv = AC_GetLongLong(ac, &nproperties, 0);
-  if (rv != AC_OK) {
+  int rv = AC_GetLongLong(ac, &nproperties, AC_F_GE0);
+  if (rv != AC_OK || nproperties > UINT32_MAX) {
+    rv = rv != AC_OK ? rv : AC_ERR_ELIMIT;
     QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
 
-  const char **properties = array_newlen(const char *, nproperties);
-  for (size_t i = 0; i < nproperties; ++i) {
+  uint32_t propertyCount = (uint32_t)nproperties;
+  if (propertyCount > AC_NumRemaining(ac)) {
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments",
+                                  " for GROUPBY: %s", AC_Strerror(AC_ERR_NOARG));
+    return REDISMODULE_ERR;
+  }
+
+  const char **properties = array_newlen(const char *, propertyCount);
+  for (uint32_t i = 0; i < propertyCount; ++i) {
     const char *property;
     size_t propertyLen;
     rv = AC_GetString(ac, &property, &propertyLen, 0);

--- a/src/config.h
+++ b/src/config.h
@@ -8,6 +8,8 @@
 */
 #pragma once
 
+#include <stdint.h>
+
 #include "redismodule.h"
 #include "hiredis/sds.h"
 #include "rmutil/args.h"
@@ -351,6 +353,7 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
 #define DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS MAX_AGGREGATE_REQUEST_RESULTS
 #define MAX_AGGREGATE_GROUPS (1ULL << 26)
 #define DEFAULT_MAX_AGGREGATE_GROUPS 1000000
+#define MAX_GROUPBY_PROPERTIES UINT16_MAX
 // Lower aggregate caps used as the registration-time defaults in flex (disk)
 // mode: bound result materialization and the per-shard group count to reduce
 // OOM risk (the coordinator multiplies the group cap by the shard count).

--- a/src/hybrid/parse/hybrid_optional_args.c
+++ b/src/hybrid/parse/hybrid_optional_args.c
@@ -178,7 +178,7 @@ int HybridParseOptionalArgs(HybridParseContext *ctx, ArgsCursor *ac, bool intern
 
     // GROUPBY nproperties property [property ...] [REDUCE function nargs arg [arg ...] [AS alias]] [...]
     ArgParser_AddSubArgsV(parser, "GROUPBY", "Group results by properties with reducers",
-                         &subArgs, 1, -1,
+                         &subArgs, 1, MAX_GROUPBY_PROPERTIES,
                          ARG_OPT_OPTIONAL,
                          ARG_OPT_CALLBACK, handleGroupby, ctx,
                          ARG_OPT_END);

--- a/src/hybrid/parse/hybrid_optional_args.c
+++ b/src/hybrid/parse/hybrid_optional_args.c
@@ -178,7 +178,7 @@ int HybridParseOptionalArgs(HybridParseContext *ctx, ArgsCursor *ac, bool intern
 
     // GROUPBY nproperties property [property ...] [REDUCE function nargs arg [arg ...] [AS alias]] [...]
     ArgParser_AddSubArgsV(parser, "GROUPBY", "Group results by properties with reducers",
-                         &subArgs, 1, MAX_GROUPBY_PROPERTIES,
+                         &subArgs, 0, MAX_GROUPBY_PROPERTIES,
                          ARG_OPT_OPTIONAL,
                          ARG_OPT_CALLBACK, handleGroupby, ctx,
                          ARG_OPT_END);

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -1541,6 +1541,13 @@ TEST_F(ParseHybridTest, testGroupByNoProperties) {
   testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "GROUPBY: Failed to parse the argument count");
 }
 
+TEST_F(ParseHybridTest, testGroupByRejectsTooManyProperties) {
+  const std::string too_many_properties = std::to_string(MAX_GROUPBY_PROPERTIES + 1);
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "PARAMS", "2", "BLOB", TEST_BLOB_DATA,
+                      "GROUPBY", too_many_properties.c_str(), "@title");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "GROUPBY: Invalid argument count");
+}
+
 TEST_F(ParseHybridTest, testGroupByPropertyMissingAtPrefix) {
   // Test GROUPBY with property missing @ prefix
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "PARAMS", "2", "BLOB", TEST_BLOB_DATA, "GROUPBY", "1", "title");

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1280,6 +1280,11 @@ def testGroupProperties(env):
     conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE', 'n', 'NUMERIC', 'SORTABLE', 'tt', 'TAG')
     conn.execute_command('HSET', 'doc1', 't', 'hello', 'n', '1', 'tt', 'foo')
 
+    env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', str(1 << 32), '@t').error().contains(
+                    'Bad arguments for GROUPBY: Value is outside acceptable bounds')
+    env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '-1').error().contains(
+                    'Bad arguments for GROUPBY: Value is outside acceptable bounds')
+
     # Check groupby properties
     env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '3', 't', 'n', 'tt').error().contains(
                     'Bad arguments for GROUPBY: Unknown property `t`. Did you mean `@t`?')

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1280,7 +1280,8 @@ def testGroupProperties(env):
     conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE', 'n', 'NUMERIC', 'SORTABLE', 'tt', 'TAG')
     conn.execute_command('HSET', 'doc1', 't', 'hello', 'n', '1', 'tt', 'foo')
 
-    env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', str(1 << 32), '@t').error().contains(
+    max_groupby_properties = (1 << 16) - 1
+    env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', str(max_groupby_properties + 1), '@t').error().contains(
                     'Bad arguments for GROUPBY: Value is outside acceptable bounds')
     env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '-1').error().contains(
                     'Bad arguments for GROUPBY: Value is outside acceptable bounds')

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1282,6 +1282,9 @@ def testGroupProperties(env):
 
     max_groupby_properties = (1 << 16) - 1
     env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', str(max_groupby_properties + 1), '@t').error().contains(
+                    'Bad arguments for GROUPBY: Expected an argument, but none provided')
+    too_many_properties = ['@t'] * (max_groupby_properties + 1)
+    env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', str(len(too_many_properties)), *too_many_properties).error().contains(
                     'Bad arguments for GROUPBY: Value is outside acceptable bounds')
     env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '-1').error().contains(
                     'Bad arguments for GROUPBY: Value is outside acceptable bounds')


### PR DESCRIPTION
## What changed

`FT.AGGREGATE ... GROUPBY <nproperties>` is now validated before allocating or building the group pipeline:

- reject negative property counts and counts above `UINT16_MAX`
- reject property counts larger than the remaining command arguments before `array_newlen`
- cap the shared group output lookup at `properties + reducer outputs <= UINT16_MAX`
- keep the limit independent of schema field count, since `GROUPBY` keys may also be `APPLY` aliases
- validate coordinator-rewritten local and remote GROUPBY steps after `COUNT`/`AVG` expansion, including generated local `APPLY` outputs
- move GROUPBY property scratch arrays from stack storage to reusable `Grouper` heap storage
- replace recursive group-value extraction with an iterative Cartesian-product walk that preserves prefix hashes and recomputes only the changed suffix

## Why

The original parser read `nproperties` as `long long`, then passed it to `array_newlen`, whose length is represented as `uint32_t`. A negative or oversized value could therefore wrap at allocation time while the parse loop continued using the original 64-bit count.

The limit is not `MAX_AGGREGATE_GROUPS`: that config caps materialized result groups during execution. It is also not `SPEC_MAX_FIELDS`, because `GROUPBY` can target pipeline aliases produced by `APPLY` as well as schema fields.

The concrete downstream representation limit is the group output `RLookup`: GROUPBY properties and reducer aliases both allocate dynamic row slots addressed by `uint16_t dstidx`. Keeping their combined count at or below `UINT16_MAX` prevents assigning an unrepresentable output slot. The execution-side stack arrays and recursive extraction were removed so large, valid APPLY-alias GROUPBY counts do not become a stack-depth limitation.

## Validation

- `./build.sh RUN_UNIT_TESTS=1 TEST="AggTest.GroupByOutputSlotLimitIncludesReducers"`
- `./build.sh RUN_UNIT_TESTS=1 TEST="DistributeCollectTest.DistributionRejectsExpandedGroupOutputSlotOverflow"`
- `./build.sh RUN_UNIT_TESTS=1 TEST="DistributeCollectTest.DistributionRejectsExpandedAvgApplyOutputSlotOverflow"`
- `./bin/linux-x64-release/search-community/tests/cpptests/coord_tests/rstest_coord --gtest_filter="DistributeCollectTest.DistributionRejectsExpanded*"` - 2 passed
- `./build.sh RUN_PYTEST=1 ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="test_aggregate:testGroupProperties"`
- `./build.sh RUN_PYTEST=1 ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="test_groupby_collect"` - 58 passed
- `./build.sh RUN_PYTEST=1 ENABLE_ASSERT=1 TEST_TIMEOUT=20 TEST="test_aggregate"` - 70 passed
- `git diff --check`