### PR TITLE
[MOD-17201] shrink groupby-collect hash star-offset500 benchmark to 10K

### DIFF
--- a/tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-star-offset500-k50.yml
+++ b/tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-star-offset500-k50.yml
@@ -1,5 +1,5 @@
 version: 0.5
-name: "search-groupby-collect-100K-entity-events-hash-cached-sortby-fields-star-offset500-k50"
+name: "search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-star-offset500-k50"
 description: "GROUPBY + COLLECT HASH benchmark with FIELDS * and LIMIT 500 50."
 
 metadata:
@@ -16,7 +16,7 @@ setups:
   - oss-cluster-02-primaries
 
 dbconfig:
-  - dataset_name: "groupby-collect-entity-events-100K-heavy-hash"
+  - dataset_name: "groupby-collect-entity-events-10K-heavy-hash"
   - dataset_load_timeout_secs: 1800
   - init_commands:
     - '"CONFIG" "SET" "search-enable-unstable-features" "yes"'
@@ -25,9 +25,9 @@ dbconfig:
   - parameters:
     - workers: 64
     - reporting-period: 1s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-100K-heavy-hash/groupby-collect-entity-events-100K-heavy-hash.redisearch.commands.SETUP.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-hash/groupby-collect-entity-events-10K-heavy-hash.redisearch.commands.SETUP.csv"
   - check:
-      keyspacelen: 100000
+      keyspacelen: 10000
 
 clientconfig:
   - benchmark_type: "read-only"
@@ -37,4 +37,4 @@ clientconfig:
     - requests: 100000
     - reporting-period: 1s
     - duration: 120s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-100K-heavy-hash/groupby-collect-entity-events-100K-heavy-hash.redisearch.commands.BENCH.QUERY_collect-fields-star-offset500-k50.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-hash/groupby-collect-entity-events-10K-heavy-hash.redisearch.commands.BENCH.QUERY_collect-fields-star-offset500-k50.csv"


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** #10592 re-enabled the hash COLLECT benchmarks at 100K, but the `search-groupby-collect-100K-entity-events-hash-cached-sortby-fields-star-offset500-k50` variant stalls. The `FIELDS *` / `LIMIT 500 50` window pages to offset 500 and gathers large collected arrays per group across the full 100K dataset, so the 120s run never returns and the client is killed by the 1200s SSH timeout — failing the master benchmark job ([run 30264705082](https://github.com/RediSearch/RediSearch/actions/runs/30264705082/job/89974798568)).
2. **Change:** It already stalls at 16 workers, so lowering concurrency doesn't help — it's a per-query cost problem. Shrink it to a distinct **10K** identity, mirroring the json variants #10592 reduced for the same reason: dataset → `groupby-collect-entity-events-10K-heavy-hash`, `keyspacelen` → 10000, `name:` → `...-10K-...` (a new metric series, so 10K numbers aren't compared against historical 100K baselines). A new `10K-heavy-hash` dataset (same profile/seed as the existing `10K-heavy-json`) was uploaded to S3.
3. **Outcome:** The `star-offset500` hash COLLECT benchmark completes on the CI infra with a stable baseline, restoring a green master benchmark job. The `hash-explicit-100K` variant is untouched — its `0-50` window is cheap and completes at 100K.

#### Which additional issues this PR fixes
1. MOD-17201
2. Related: MOD-16899, follow-up to #10592

#### Main objects this PR modified
1. `tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-star-offset500-k50.yml` — renamed from the disabled-stalling 100K hash variant; dataset → 10K-heavy-hash, keyspacelen → 10000

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes