### PR TITLE
[Iterator Revalidation][MOD-17245] MaybeEmpty

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
@@ -14,16 +14,38 @@ use index_spec::IndexSpecReadGuard;
 use rqe_core::DocId;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, empty::Empty,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+    boxed::{ResumeSlotOutcome, resume_child_slot_in_place},
+    empty::Empty,
 };
 
 /// An iterator that is either [`Empty`] or the provided [`RQEIterator`].
 ///
-/// `#[repr(C)]` so that `MaybeEmpty<I>` is layout-compatible with
-/// `MaybeEmpty<I::Suspended>` once the iterator's `Suspended` counterpart
-/// (added in the suspend/resume phase) lines up with `I`.
+/// # Invariants
+///
+/// 1. **Layout compatibility across the child swap.** `MaybeEmpty` is
+///    `#[repr(C)]` over the `#[repr(C)]` [`MaybeEmptyOption`], so `MaybeEmpty<I>`
+///    and `MaybeEmpty<I::Suspended>` are layout-identical given that the `Some`
+///    payload `I` and its `I::Suspended` are. This is what lets
+///    [`suspend`](RQEIteratorBoxed::suspend) / [`resume`](RQESuspendedIterator::resume)
+///    reinterpret the owning `Box` in place. Proven by the `const _` block below.
 #[repr(C)]
 pub struct MaybeEmpty<I>(MaybeEmptyOption<I>);
+
+// Compile-time proof of invariant 1 on `MaybeEmpty`: for a representative child,
+// `MaybeEmpty<I>` and `MaybeEmpty<I::Suspended>` are layout-identical. As a
+// newtype over a `#[repr(C)]` enum we assert size and alignment; the `Some`
+// payload's `I`/`I::Suspended` compatibility is the child's invariant 1 (enforced
+// generically by `suspend_child_slot_in_place`), and `None(Empty)` is `I`-free.
+const _: () = {
+    use crate::Wildcard;
+    use std::mem::{align_of, size_of};
+    type AChild = Wildcard<'static>;
+    type SChild = <Wildcard<'static> as RQEIteratorBoxed<'static>>::Suspended;
+    assert!(size_of::<MaybeEmpty<AChild>>() == size_of::<MaybeEmpty<SChild>>());
+    assert!(align_of::<MaybeEmpty<AChild>>() == align_of::<MaybeEmpty<SChild>>());
+};
 
 impl<'index, I> MaybeEmpty<I>
 where
@@ -145,7 +167,9 @@ where
     #[inline(always)]
     fn num_estimated(&self) -> usize {
         match &self.0 {
-            MaybeEmptyOption::None(empty) => empty.num_estimated(),
+            // Disambiguated against `RQESuspendedIterator::num_estimated`
+            // (Empty's suspended counterpart is itself).
+            MaybeEmptyOption::None(empty) => RQEIterator::num_estimated(empty),
             MaybeEmptyOption::Some(it) => it.num_estimated(),
         }
     }
@@ -153,7 +177,9 @@ where
     #[inline(always)]
     fn last_doc_id(&self) -> DocId {
         match &self.0 {
-            MaybeEmptyOption::None(empty) => empty.last_doc_id(),
+            // Disambiguated against `RQESuspendedIterator::last_doc_id`
+            // (Empty's suspended counterpart is itself).
+            MaybeEmptyOption::None(empty) => RQEIterator::last_doc_id(empty),
             MaybeEmptyOption::Some(it) => it.last_doc_id(),
         }
     }
@@ -180,6 +206,157 @@ where
                 empty.intersection_sort_weight(prioritize_union_children)
             }
             MaybeEmptyOption::Some(it) => it.intersection_sort_weight(prioritize_union_children),
+        }
+    }
+}
+
+impl<'index, I> RQEIteratorBoxed<'index> for MaybeEmpty<I>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = MaybeEmpty<I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Walk the `Some(I)` arm if present — dispatches via the trait so
+        // dyn-erased `I` correctly transitions its vtable. The `None(Empty)`
+        // arm needs no suspend (Empty is a unit struct with no state).
+        //
+        // SAFETY: `raw` came from `Box::into_raw`, exclusively owned and
+        // valid, so the inner enum slot is reachable.
+        let inner: &mut MaybeEmptyOption<I> = unsafe { &mut (*raw).0 };
+        if let MaybeEmptyOption::Some(it) = inner {
+            // SAFETY: `it` is a valid `&mut I` aliased to nothing else;
+            // the function leaves the slot in a valid `I::Suspended` state.
+            unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut I) };
+        }
+        // SAFETY: the `Some` child (if any) now holds `I::Suspended` and
+        // `None(Empty)` is `I`-free, so the allocation is a valid
+        // `MaybeEmpty<I::Suspended>` — layout-identical to the active form by
+        // invariant 1 on `MaybeEmpty` (const proof above), with the child slot's
+        // `I`/`I::Suspended` size/alignment match statically enforced by
+        // `suspend_child_slot_in_place`. `Box::from_raw` reuses the allocation.
+        unsafe { Box::from_raw(raw as *mut MaybeEmpty<I::Suspended>) }
+    }
+}
+
+impl<'query, S> RQESuspendedIterator<'query> for MaybeEmpty<S>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = MaybeEmpty<S::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        /// Outcome of resuming the `Some` child, captured so the `&mut` borrow of
+        /// the inner enum is released before we touch the slot as a raw pointer.
+        enum ChildResume {
+            /// `None(Empty)` arm — no child to resume.
+            NoneArm,
+            /// Child resumed in place; `moved` mirrors `Moved`.
+            Active { moved: bool },
+            /// Child aborted and was consumed; forward `Aborted`.
+            Aborted,
+            /// Child resume failed; forward the error.
+            Failed(RQEIteratorError),
+        }
+
+        let raw = Box::into_raw(self);
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned, initialised,
+        // exclusively owned). `&raw mut` forms a field pointer to the inner enum
+        // without creating a reference.
+        let inner_slot = unsafe { &raw mut (*raw).0 };
+
+        // Resume the child in place. The `&mut` borrow of the enum is confined to
+        // this block so the raw `inner_slot` writes below never alias it.
+        // SAFETY: `inner_slot` is valid and exclusively owned; `&mut *inner_slot`
+        // is a sound unique borrow of the inner enum.
+        let step = match unsafe { &mut *inner_slot } {
+            MaybeEmptyOption::None(_) => ChildResume::NoneArm,
+            MaybeEmptyOption::Some(child) => {
+                // SAFETY: `child` is the valid, exclusively-owned suspended child
+                // payload. On Unchanged/Moved the helper rewrites the slot as a
+                // valid `S::Resumed<'a>`; on Aborted/Err it consumes the child,
+                // leaving the payload uninitialised (handled below).
+                match unsafe { resume_child_slot_in_place(child as *mut S, guard) } {
+                    Ok(ResumeSlotOutcome::Unchanged) => ChildResume::Active { moved: false },
+                    Ok(ResumeSlotOutcome::Moved) => ChildResume::Active { moved: true },
+                    Ok(ResumeSlotOutcome::Aborted) => ChildResume::Aborted,
+                    Err(e) => ChildResume::Failed(e),
+                }
+            }
+        };
+
+        // Forward the child's outcome: an aborted child aborts the whole wrapper
+        // (MaybeEmpty has no virtual fallback), mirroring the previous behaviour.
+        let moved = match step {
+            ChildResume::NoneArm => false,
+            ChildResume::Active { moved } => moved,
+            ChildResume::Aborted => {
+                // Child consumed → the `Some` payload is uninitialised. Overwrite
+                // the enum with `None(Empty)` (no `I` payload) so the box is a
+                // valid owned value again, drop it, and forward `Aborted`.
+                // SAFETY: `inner_slot` valid+owned; `ptr::write` does not drop the
+                // moved-from payload.
+                unsafe { inner_slot.write(MaybeEmptyOption::None(Empty)) };
+                // SAFETY: `raw` is again a valid, exclusively-owned `MaybeEmpty<S>`;
+                // reclaim and drop it (frees the allocation).
+                drop(unsafe { Box::from_raw(raw) });
+                return Ok(ResumeOutcome::Aborted);
+            }
+            ChildResume::Failed(e) => {
+                // As `Aborted`, but forward the error.
+                // SAFETY: `inner_slot` valid+owned; `ptr::write` does not drop the
+                // moved-from payload.
+                unsafe { inner_slot.write(MaybeEmptyOption::None(Empty)) };
+                // SAFETY: `raw` is again a valid, exclusively-owned `MaybeEmpty<S>`;
+                // reclaim and drop it.
+                drop(unsafe { Box::from_raw(raw) });
+                return Err(e);
+            }
+        };
+
+        // `None`, or `Some` resumed in place: reinterpret the owning box, reusing
+        // the allocation so the inline child — which `current()`/`read()` delegate
+        // into, and whose own `resume` preserved its interior addresses — is not
+        // moved (rebuilding via `Box::new` would undo that and dangle the FFI's
+        // cached `header.current`).
+        //
+        // SAFETY: `MaybeEmpty<S>` and `MaybeEmpty<S::Resumed<'a>>` are
+        // layout-identical by invariant 1 on `MaybeEmpty` (const proof above):
+        // `None(Empty)` is `S`-free (and `Empty` is its own resumed counterpart),
+        // and the `Some` payload's `S`/`S::Resumed` size/alignment match is
+        // enforced by `resume_child_slot_in_place`. `Box::from_raw` reuses the
+        // same allocation.
+        let active = unsafe { Box::from_raw(raw.cast::<MaybeEmpty<S::Resumed<'a>>>()) };
+        Ok(if moved {
+            ResumeOutcome::Moved(active)
+        } else {
+            ResumeOutcome::Ok(active)
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        match &self.0 {
+            MaybeEmptyOption::None(_) => 0,
+            MaybeEmptyOption::Some(child) => S::last_doc_id(child),
+        }
+    }
+
+    fn num_estimated(&self) -> usize {
+        match &self.0 {
+            // Empty is its own suspended counterpart; disambiguate against
+            // `RQEIterator::num_estimated`.
+            MaybeEmptyOption::None(empty) => RQESuspendedIterator::num_estimated(empty),
+            MaybeEmptyOption::Some(child) => S::num_estimated(child),
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -18,26 +18,60 @@ use rqe_iterators::{
 #[repr(C)]
 struct Infinite<'index>(index_result::RSIndexResult<'index>);
 
-/// Suspended counterpart of [`Infinite`]. The mock holds only owned data
-/// (no live index borrows), so the suspended form is byte-identical to the
-/// active form at any lifetime.
+/// Suspended counterpart of [`Infinite`].
+///
+/// Parameterised by the query lifetime `'query` and holding the `Suspended`
+/// representation of the result — *not* an `RSIndexResult<'static>`. `current()`
+/// hands out `&mut RSIndexResult`, so a caller may populate the result with
+/// borrowed query data (a term or metric); widening that to `'static` would let
+/// the suspended value outlive the borrow. Carrying the real `'query` and
+/// transitioning through [`RSIndexResult::into_suspended`] keeps the borrow
+/// correctly tracked, matching the real iterators.
+///
+/// `#[repr(C)]` so the byte layout matches [`Infinite`] for the in-place field
+/// transition in `suspend`/`resume` (proven layout-identical by the `const _`
+/// block below).
 #[repr(C)]
-struct InfiniteSuspended(index_result::RSIndexResult<'static>);
+struct InfiniteSuspended<'query>(index_result::SuspendedIndexResult<'query>);
+
+// Compile-time proof that `Infinite` and its suspended counterpart are
+// layout-identical, so the in-place field transition can reinterpret the same
+// allocation. Both are single-field tuple structs over `RawIndexResult<Rf>`
+// (layout-compatible across `Rf`, proven in `index_result`), so field 0 sits at
+// offset 0 in both and only size/alignment need pinning here.
+const _: () = {
+    type A<'a> = Infinite<'a>;
+    type S<'a> = InfiniteSuspended<'a>;
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
 
 impl<'index> RQEIteratorBoxed<'index> for Infinite<'index> {
-    type Suspended = InfiniteSuspended;
+    type Suspended = InfiniteSuspended<'index>;
 
     fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
         let raw = Box::into_raw(self);
-        // SAFETY: `Infinite<'index>` and `InfiniteSuspended` are both
-        // `#[repr(C)]` over `RSIndexResult`; the mock holds no live index
-        // borrows, so the lifetime parameter is phantom and the layouts
-        // are byte-identical. Box::from_raw reuses the same heap.
-        unsafe { Box::from_raw(raw as *mut InfiniteSuspended) }
+        // Transition the `result` field to its `Suspended` representation in
+        // place, reusing the allocation — rather than casting the whole struct's
+        // lifetime to `'static`. Reusing the allocation also keeps the box (and
+        // the result it hands out) at a stable address across the cycle.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+        // initialised, uniquely owned). `&raw mut` forms a field pointer to the
+        // `result` slot without creating a reference.
+        let result_slot = unsafe { &raw mut (*raw).0 };
+        // SAFETY: `result_slot` points at an initialised `RSIndexResult<'index>`
+        // and is unaliased; `into_suspended_in_place` is a safe widening
+        // conversion with no further precondition.
+        unsafe { <index_result::RSIndexResult<'index>>::into_suspended_in_place(result_slot) };
+        // SAFETY: `Infinite<'index>` and `InfiniteSuspended<'index>` are
+        // layout-identical (const proof above); the allocation is reused, so the
+        // box address is preserved and the field is now the suspended form.
+        unsafe { Box::from_raw(raw as *mut InfiniteSuspended<'index>) }
     }
 }
 
-impl<'query> RQESuspendedIterator<'query> for InfiniteSuspended {
+impl<'query> RQESuspendedIterator<'query> for InfiniteSuspended<'query> {
     type Resumed<'a>
         = Infinite<'a>
     where
@@ -51,7 +85,23 @@ impl<'query> RQESuspendedIterator<'query> for InfiniteSuspended {
         'query: 'a,
     {
         let raw = Box::into_raw(self);
-        // SAFETY: layout-identical — see [`Infinite::suspend`].
+        // Mirror `suspend`: transition the `result` field back to its active form
+        // in place, reusing the allocation.
+        //
+        // SAFETY: `raw` came from `Box::into_raw`; `&raw mut` forms a field
+        // pointer to the `result` slot without creating a reference.
+        let result_slot = unsafe { &raw mut (*raw).0 };
+        // SAFETY: `result_slot` points at an initialised
+        // `SuspendedIndexResult<'query>` and is unaliased. `into_active`'s
+        // preconditions hold: this mock only ever stores a virtual result over
+        // owned data (it just bumps `doc_id`), so there are no index-backed
+        // pointers to re-validate; any borrowed query-pipeline data is covered by
+        // the `'query: 'a` bound.
+        unsafe {
+            <index_result::SuspendedIndexResult<'query>>::into_active_in_place::<'a>(result_slot)
+        };
+        // SAFETY: layout-identical (const proof above); the allocation is reused,
+        // so the box address is preserved and the field is now active for `'a`.
         let active = unsafe { Box::from_raw(raw as *mut Infinite<'a>) };
         Ok(ResumeOutcome::Ok(active))
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -347,6 +347,7 @@ fn take_iterator_from_empty_returns_none() {
 
 mod via_resume {
     use super::*;
+    use crate::utils::{Mock, MockIteratorError, MockRevalidateResult};
     use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
 
     #[test]
@@ -398,5 +399,87 @@ mod via_resume {
             &*active as *const _ as usize, addr_before,
             "resume must reuse the allocation (MaybeEmpty delegates into its inline child)"
         );
+    }
+
+    // The local `Infinite` mock always resumes `Ok`/`Unchanged`, so the shared
+    // `Mock` (steerable via `MockData`) drives the remaining resume outcomes:
+    // Moved, Aborted, and a child-resume error.
+
+    /// `Some` child that resumes `Moved` → the wrapper forwards `Moved`.
+    #[test]
+    fn resume_some_child_moved_forwards_moved() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child = Mock::new([1, 2, 3]);
+        child
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        let it = Box::new(MaybeEmpty::new(child));
+
+        let outcome = it.suspend().resume(&guard).expect("resume must not error");
+        assert!(
+            matches!(outcome, ResumeOutcome::Moved(_)),
+            "a child that moved must forward Moved",
+        );
+    }
+
+    /// `Some` child that aborts → the whole wrapper aborts (MaybeEmpty has no
+    /// virtual fallback); the moved-from child slot is torn down as
+    /// `None(Empty)` before the box is freed.
+    #[test]
+    fn resume_some_child_aborted_forwards_aborted() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child = Mock::new([1, 2, 3]);
+        child
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        let it = Box::new(MaybeEmpty::new(child));
+
+        let outcome = it.suspend().resume(&guard).expect("resume must not error");
+        assert!(
+            matches!(outcome, ResumeOutcome::Aborted),
+            "an aborted child must abort the whole MaybeEmpty",
+        );
+    }
+
+    /// `Some` child whose resume itself fails → the error propagates out, after
+    /// the slot is restored to `None(Empty)` so the box drops soundly.
+    #[test]
+    fn resume_some_child_error_propagates() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child = Mock::new([1, 2, 3]);
+        child
+            .data()
+            .set_error_on_resume(Some(MockIteratorError::TimeoutError(None)));
+        let it = Box::new(MaybeEmpty::new(child));
+
+        let result = it.suspend().resume(&guard);
+        assert!(
+            matches!(result, Err(RQEIteratorError::TimedOut)),
+            "a child resume error must propagate out of MaybeEmpty::resume",
+        );
+    }
+
+    /// Suspended-form accessors on the `None` arm: an empty wrapper reports
+    /// position 0 and estimate 0 (delegating to `Empty`).
+    #[test]
+    fn suspended_accessors_none_arm() {
+        let it = Box::new(MaybeEmpty::<Infinite>::new_empty());
+        let suspended = it.suspend();
+        assert_eq!(RQESuspendedIterator::last_doc_id(&*suspended), 0);
+        assert_eq!(RQESuspendedIterator::num_estimated(&*suspended), 0);
+    }
+
+    /// Suspended-form accessors on the `Some` arm: they delegate to the child's
+    /// suspended accessors.
+    #[test]
+    fn suspended_accessors_some_arm() {
+        let mut it = Box::new(MaybeEmpty::new(Mock::new([10, 20, 30])));
+        let _ = it.read().unwrap(); // advance the child to doc 10
+        let suspended = it.suspend();
+        assert_eq!(RQESuspendedIterator::last_doc_id(&*suspended), 10);
+        assert_eq!(RQESuspendedIterator::num_estimated(&*suspended), 3);
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/maybe_empty.rs
@@ -9,12 +9,61 @@
 
 use rqe_core::DocId;
 use rqe_iterators::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome, TypeErasedRQEIterator,
     maybe_empty::MaybeEmpty,
 };
 
 #[derive(Default)]
+#[repr(C)]
 struct Infinite<'index>(index_result::RSIndexResult<'index>);
+
+/// Suspended counterpart of [`Infinite`]. The mock holds only owned data
+/// (no live index borrows), so the suspended form is byte-identical to the
+/// active form at any lifetime.
+#[repr(C)]
+struct InfiniteSuspended(index_result::RSIndexResult<'static>);
+
+impl<'index> RQEIteratorBoxed<'index> for Infinite<'index> {
+    type Suspended = InfiniteSuspended;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `Infinite<'index>` and `InfiniteSuspended` are both
+        // `#[repr(C)]` over `RSIndexResult`; the mock holds no live index
+        // borrows, so the lifetime parameter is phantom and the layouts
+        // are byte-identical. Box::from_raw reuses the same heap.
+        unsafe { Box::from_raw(raw as *mut InfiniteSuspended) }
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for InfiniteSuspended {
+    type Resumed<'a>
+        = Infinite<'a>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        _guard: &index_spec::IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let raw = Box::into_raw(self);
+        // SAFETY: layout-identical — see [`Infinite::suspend`].
+        let active = unsafe { Box::from_raw(raw as *mut Infinite<'a>) };
+        Ok(ResumeOutcome::Ok(active))
+    }
+
+    fn last_doc_id(&self) -> ffi::t_docId {
+        self.0.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        usize::MAX
+    }
+}
 
 impl<'index> RQEIterator<'index> for Infinite<'index> {
     fn current(&mut self) -> Option<&mut index_result::RSIndexResult<'index>> {
@@ -244,4 +293,60 @@ fn take_iterator_from_empty_returns_none() {
     // Still behaves as empty
     assert!(it.at_eof());
     assert!(matches!(it.read(), Ok(None)));
+}
+
+mod via_resume {
+    use super::*;
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    #[test]
+    fn revalidate_empty() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let it = Box::new(MaybeEmpty::<Infinite>::new_empty());
+        // Resuming an empty wrapper stays at the same (empty) position.
+        revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+            .expect("resume failed")
+            .expect_ok();
+    }
+
+    #[test]
+    fn revalidate_not_empty() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let it = Box::new(MaybeEmpty::new(Infinite::default()));
+        // The mock child resumes as `Ok`, so the wrapper does too.
+        revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+            .expect("resume failed")
+            .expect_ok();
+    }
+
+    /// Regression: both `suspend` and `resume` must **reuse the allocation**.
+    /// `MaybeEmpty` delegates `current()`/`read()` into its inline child, so the
+    /// FFI's cached `header.current` points into the box; rebuilding via
+    /// `Box::new` (the previous `resume`) would move the child and dangle it.
+    #[test]
+    fn resume_preserves_box_address() {
+        use rqe_iterators::{RQEIteratorBoxed, RQESuspendedIterator};
+
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let it = Box::new(MaybeEmpty::new(Infinite::default()));
+        let addr_before = &*it as *const _ as usize;
+
+        let suspended = it.suspend();
+        assert_eq!(
+            &*suspended as *const _ as usize, addr_before,
+            "suspend must reuse the allocation"
+        );
+
+        let active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(it) | ResumeOutcome::Moved(it) => it,
+            ResumeOutcome::Aborted => panic!("infinite child should not abort"),
+        };
+        assert_eq!(
+            &*active as *const _ as usize, addr_before,
+            "resume must reuse the allocation (MaybeEmpty delegates into its inline child)"
+        );
+    }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `MaybeEmpty` (the wrapper that is either [`Empty`] or a provided
   child iterator) implements only the legacy `RQEIterator::revalidate`; it has no
   `Box<Self>`-based suspend/resume.
2. **Change:** Implement `RQEIteratorBoxed` + `RQESuspendedIterator` for
   `MaybeEmpty`. `suspend` dispatches the `Some` child through
   `suspend_child_slot_in_place` (correct for type-erased children) and reuses the
   allocation; `resume` transitions the child **in place** via
   `resume_child_slot_in_place` and reuses the allocation (on child `Aborted`/`Err`
   it overwrites the slot with `None(Empty)` and tears down without touching the
   moved-from child, forwarding the outcome). Adds a standalone `const _`
   invariant-1 layout proof for `MaybeEmpty`.
3. **Outcome:** `MaybeEmpty` can be suspended/resumed soundly, including over a
   type-erased child, with the box (and the inline child that `current()`/`read()`
   delegate into) keeping a stable address across the cycle — so the FFI's cached
   `header.current` stays valid. A `Some`-child abort still aborts the whole
   wrapper (no virtual fallback), matching `revalidate`.

Stacked on #10613 (`[Iterator Revalidation] Optional`) and targets
`iter-reval-C3a-optional`. Reviewed against `docs/rqe-iterator-suspend-resume.md`:
crucially, `resume` reuses the allocation rather than rebuilding via `Box::new`,
which would move the inline child and dangle pointers into it.

#### Which additional issues this PR fixes

Part of the Iterator Revalidation epic. Stacked on #10613.

#### Main objects this PR modified

1. `MaybeEmpty` / `MaybeEmptyOption` (`rqe_iterators/src/maybe_empty.rs`) — new
   `RQEIteratorBoxed` / `RQESuspendedIterator` impls + `const _` invariant proof.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal-only: the suspend/resume surface is not yet wired into production; no
user-facing behavior changes.
