### PR TITLE
[MOD-16877] Add regression coverage for the numeric empty_leaves underflow without compression

### DIFF
--- a/src/redisearch_rs/numeric_range_tree/src/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/range.rs
@@ -66,9 +66,18 @@ pub type Hll = HyperLogLog6<NumericValue, WyHasher>;
 pub struct NumericRange {
     /// The minimum value stored in this range.
     /// Initialized to `f64::INFINITY` so any value will be smaller.
+    ///
+    /// This is a monotone *lower bound*, not necessarily the smallest value the
+    /// range currently stores: it is lowered when a smaller value is added, but
+    /// never raised. GC removes entries without tightening it, so after the
+    /// documents holding the smallest value are collected it sits strictly below
+    /// every surviving value.
     min_val: f64,
     /// The maximum value stored in this range.
     /// Initialized to `f64::NEG_INFINITY` so any value will be larger.
+    ///
+    /// Monotone *upper bound*, with the same caveat as `min_val`: GC never
+    /// lowers it.
     max_val: f64,
     /// HyperLogLog for estimating the number of distinct values (cardinality).
     /// Used to decide when to split the range.

--- a/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
@@ -278,6 +278,11 @@ impl NumericRangeTree {
     /// are identical—the median would equal the minimum, and without adjustment
     /// all entries would go to the right child, leaving the left empty.
     ///
+    /// The adjustment only fires when the range's `min_val` bound matches the
+    /// smallest value the range actually stores. That is not always the case, so
+    /// a split can still leave one child empty—see the comment on `newly_empty`
+    /// below.
+    ///
     /// # Note
     ///
     /// The original range is retained in the node (now internal). It may be
@@ -341,9 +346,19 @@ impl NumericRangeTree {
         }
         drop(result);
 
-        // A split can leave a child leaf empty: when float compression collapses
-        // every stored value to the same f32, the median equals the minimum, the
-        // split point becomes `next_up(min)`, and all entries land on one side.
+        // A split can leave a child leaf empty whenever every entry falls on the
+        // same side of `split`. Two known ways to get there:
+        //
+        // 1. Float compression collapses every stored value to the same f32. The
+        //    median then equals `min_val`, the split point becomes `next_up(min)`,
+        //    and every entry lands in the *left* child.
+        // 2. `min_val` is stale. GC removes entries from a range but never raises
+        //    its bounds, so once the documents holding the smallest value are
+        //    collected, `min_val` sits below every surviving value. If a majority
+        //    of the survivors share the smallest surviving value, that value is the
+        //    median, the `split == min_val` guard above does not fire, and every
+        //    entry lands in the *right* child.
+        //
         // Such an empty leaf must be reflected in `empty_leaves`, otherwise a
         // later add routed to it would decrement the counter below zero. The
         // parent had >= 1 entry (we split only after adding), so at most one of

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/tree.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/tree.rs
@@ -12,7 +12,7 @@
 use numeric_range_tree::NumericRangeTree;
 use rstest::rstest;
 
-use numeric_range_tree::test_utils::{SPLIT_TRIGGER, build_tree, walk_with_depth};
+use numeric_range_tree::test_utils::{SPLIT_TRIGGER, build_tree, gc_all_ranges, walk_with_depth};
 
 #[test]
 fn test_new_tree() {
@@ -213,6 +213,9 @@ fn test_split_with_identical_values() {
 /// empty. That empty leaf must be reflected in `empty_leaves`; otherwise a later
 /// add routed to it decrements the counter below zero and aborts the process via
 /// the non-unwinding FFI boundary.
+///
+/// Compression is not the only way to get an empty child leaf — see
+/// `test_split_after_gc_stale_min_counts_empty_leaf`.
 #[test]
 fn test_split_with_compression_collapse_counts_empty_leaf() {
     let mut tree = NumericRangeTree::new(true); // float compression ON
@@ -252,6 +255,93 @@ fn test_split_with_compression_collapse_counts_empty_leaf() {
     // `empty_leaves` from 0, underflowing the counter and aborting the process.
     let next = split_at + 1;
     tree.add(next, value_at(next), false, 0);
+    assert_eq!(
+        tree.empty_leaves(),
+        0,
+        "re-populating the empty leaf should bring the counter back to zero"
+    );
+}
+
+/// Same `empty_leaves` underflow as
+/// `test_split_with_compression_collapse_counts_empty_leaf` (MOD-16877), reached
+/// with float compression *disabled* — compression is not required to strand an
+/// empty child leaf.
+///
+/// The other ingredient is a stale `min_val`. GC removes entries from a range but
+/// never raises its bounds, so a leaf whose smallest-valued documents were all
+/// collected keeps reporting the old minimum. `split_node`'s
+/// `split == min_val` guard then compares the median of the *surviving* entries
+/// against a bound no surviving entry has, so it does not fire. If a majority of
+/// the survivors share the smallest surviving value, that value *is* the median
+/// and becomes the split point, so every entry satisfies `value >= split` and
+/// lands in the right child — leaving the left child empty.
+#[test]
+fn test_split_after_gc_stale_min_counts_empty_leaf() {
+    let mut tree = NumericRangeTree::new(false); // float compression OFF
+
+    /// Number of documents sharing the value 100.0. They must remain a majority of
+    /// the leaf's entries once the split fires, so that the median lands on 100.0:
+    /// the loop below adds at most `SPLIT_TRIGGER` further entries, and
+    /// `MAJORITY > SPLIT_TRIGGER` keeps the median index within the block.
+    const MAJORITY: u64 = 40;
+
+    // Doc 1 is the only document below 100.0, so it alone sets `min_val` to 0.0.
+    tree.add(1, 0.0, false, 0);
+
+    for doc_id in 2..=(MAJORITY + 1) {
+        tree.add(doc_id, 100.0, false, 0);
+    }
+    assert!(tree.root().is_leaf());
+    assert_eq!(tree.empty_leaves(), 0, "the root leaf holds every document");
+
+    // Delete doc 1 and collect it. Its entry is physically removed and the HLL is
+    // re-estimated over the survivors, but `min_val` stays 0.0.
+    gc_all_ranges(&mut tree, &|doc_id| doc_id != 1);
+    assert_eq!(tree.num_entries(), MAJORITY as usize);
+    assert_eq!(
+        tree.empty_leaves(),
+        0,
+        "the leaf still holds the surviving documents"
+    );
+    assert_eq!(
+        tree.root().range().unwrap().min_val(),
+        0.0,
+        "GC must not raise a range's lower bound — that staleness is the trigger"
+    );
+
+    // Push cardinality over the split threshold using distinct values strictly
+    // greater than 100.0, so 100.0 stays the smallest surviving value.
+    let mut doc_id = MAJORITY + 2;
+    let mut split_fired = false;
+    for i in 1..=SPLIT_TRIGGER {
+        tree.add(doc_id, 100.0 + i as f64, false, 0);
+        doc_id += 1;
+        if tree.num_leaves() == 2 {
+            split_fired = true;
+            break;
+        }
+    }
+    assert!(split_fired, "distinct values should trigger a split");
+
+    // The split point is the median (100.0), not `next_up(min_val)`, so every
+    // entry went right and the left leaf is empty.
+    assert_eq!(tree.root().split_value(), Some(100.0));
+    let (left_idx, _) = tree.root().child_indices().unwrap();
+    assert_eq!(
+        tree.node(left_idx).range().unwrap().num_docs(),
+        0,
+        "the split should have left the left child empty"
+    );
+    assert_eq!(
+        tree.empty_leaves(),
+        1,
+        "the empty child leaf created by the split must be counted"
+    );
+
+    // Any later value below the split point is routed to that empty leaf. Before
+    // the fix this decremented `empty_leaves` from 0, underflowing the counter and
+    // aborting the process across the non-unwinding FFI boundary.
+    tree.add(doc_id, 50.0, false, 0);
     assert_eq!(
         tree.empty_leaves(),
         0,


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** #10513 fixed the `empty_leaves` underflow crash (MOD-16877) by counting the empty child leaf a split can create, but attributed that empty leaf solely to float compression: with `_NUMERIC_COMPRESS` on, distinct f64 values collapse to one stored f32, so the median equals `min_val`, the split point becomes `next_up(min)`, and every entry lands in one child. Both the code comments and the ticket therefore scope the exposure to users who enable numeric compression.
2. **Change:** Compression is not required. A range's `min_val` is a *monotone lower bound* — lowered when a smaller value is added, never raised, and GC (`apply_gc_to_node`) removes entries without tightening it. Once the documents holding a leaf's smallest value are collected, `min_val` sits below every surviving value, so `split_node`'s `split == min_val` guard compares the median of the survivors against a bound no survivor has and does not fire. If a majority of the survivors share the smallest surviving value, that value *is* the median and becomes the split point: every entry satisfies `value >= split`, all of them go to the right child, and the left child leaf is created empty. This PR adds a regression test for that path with compression **disabled**, and rewrites the comments that named compression as the sole cause.
3. **Outcome:** No production behavior change — the accounting fix from #10513 already covers this case, since it counts empty children regardless of what caused them. What changes is coverage and accuracy: the second, compression-independent route into the crash is now pinned by a test, and the next reader of `split_node` is not told that compression is the only way a split can strand an empty leaf.

Verified by temporarily reverting the `newly_empty` accounting from #10513:

| state of `split_node` | result for the new test |
| --- | --- |
| as on `master` (fix in place) | pass |
| `newly_empty` accounting removed | fails on the debug invariant — `empty_leaves: memoized=0, computed=1` |
| accounting removed *and* debug invariants disabled (release/production config) | `Underflow!` panic in `CheckedCount` on the following add — the production SIGABRT |

`cargo nextest run -p numeric_range_tree` 131/131, `make lint` clean, `cargo fmt --check` clean, and both regression tests pass under `cargo +nightly miri nextest run`.

#### Which additional issues this PR fixes
1. MOD-16877 (follow-up to #10513 — no code fix needed, the exposure was wider than the ticket describes)

#### Main objects this PR modified
1. New regression test `test_split_after_gc_stale_min_counts_empty_leaf` — `src/redisearch_rs/numeric_range_tree/tests/integration/tree.rs`
2. `NumericRangeTree::split_node` comments (both causes of an empty child leaf) — `src/redisearch_rs/numeric_range_tree/src/tree/insert.rs`
3. `NumericRange::min_val` / `max_val` field docs (monotone bounds, not tightened by GC) — `src/redisearch_rs/numeric_range_tree/src/range.rs`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Tests and comments only; the user-facing fix shipped in #10513.

> Note: since this documents that the 8.6 exposure was not limited to `_NUMERIC_COMPRESS`, MOD-16877 should be updated accordingly. Backporting this test alongside the #10513 backport to `8.6` / `8.6-rse` is optional but cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
