### PR TITLE
[8.8-rse] Block NUMERIC field creation for disk (Flex) indexes

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -1286,6 +1286,7 @@ static int parseFieldSpec(ArgsCursor *ac, IndexSpec *sp, StrongRef sp_ref, Field
     // Skip SORTABLE and NOINDEX options
     return 1;
   } else if (AC_AdvanceIfMatch(ac, SPEC_NUMERIC_STR)) {  // numeric field
+    if (!SearchDisk_MarkUnsupportedFieldIfDiskEnabled(SPEC_NUMERIC_STR, fs, status)) goto error;
     fs->types |= INDEXFLD_T_NUMERIC;
     if (AC_AdvanceIfMatch(ac, SPEC_INDEXMISSING_STR)) {
       fs->options |= FieldSpec_IndexMissing;
@@ -1470,8 +1471,8 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
 
     if (isSpecOnDiskForValidation(sp))
     {
-      if (!FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && !FIELD_IS(fs, INDEXFLD_T_VECTOR) && !FIELD_IS(fs, INDEXFLD_T_TAG) && !FIELD_IS(fs, INDEXFLD_T_NUMERIC)) {
-        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Disk index does not support non-TEXT/VECTOR/TAG/NUMERIC fields");
+      if (!FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && !FIELD_IS(fs, INDEXFLD_T_VECTOR) && !FIELD_IS(fs, INDEXFLD_T_TAG)) {
+        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Disk index does not support non-TEXT/VECTOR/TAG fields");
         goto reset;
       }
       if (fs->options & FieldSpec_NotIndexable) {

--- a/tests/pytests/test_flex_validation.py
+++ b/tests/pytests/test_flex_validation.py
@@ -48,6 +48,8 @@ def test_invalid_field_type(env):
         .error().contains('GEO fields are not supported in Flex indexes')
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA', 'field', 'GEOSHAPE') \
         .error().contains('GEOSHAPE fields are not supported in Flex indexes')
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SKIPINITIALSCAN', 'SCHEMA', 'field', 'NUMERIC') \
+        .error().contains('NUMERIC fields are not supported in Flex indexes')
 
 
 @skip(cluster=True)


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: on the 8.8-rse release line, NUMERIC fields are accepted at FT.CREATE time on Flex (disk) indexes (#10389 was reverted by #10410 before the branch point), but the disk numeric index is not production-ready — replication and hot restart do not coherently snapshot the BucketMap RAM half together with the SpeedB disk half.
2. Change: Re-applies #10389 on 8.8-rse: NUMERIC fields are rejected at FT.CREATE time on Flex indexes ("NUMERIC fields are not supported in Flex indexes"), the same way GEO and GEOSHAPE fields are rejected, and NUMERIC is dropped from the disk-supported field types in the schema catch-all validation. RAM (non-Flex) indexes are unaffected.
3. Outcome: a Flex index cannot be created with a NUMERIC field in the 8.8 release. Master is intentionally NOT blocked — numeric work continues there.

Enterprise counterpart: redislabsdev/RediSearchDisk#688 (targets enterprise `8.8`; its gitlink consumes this change via redislabsdev/RediSearch `8.8-rse`, so this PR should be synced into the private fork after merging).

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. `parseFieldSpec` / `IndexSpec_AddFieldsInternal` (src/spec.c) — NUMERIC rejection on Flex
2. `tests/pytests/test_flex_validation.py` — rejection assertion

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
