### PR TITLE
ci: fix coverage jobs

### DIFF
--- a/.github/actions/build-redis/action.yml
+++ b/.github/actions/build-redis/action.yml
@@ -101,6 +101,18 @@ runs:
         COVERAGE: ${{ inputs.coverage }}
         BUILD_TLS: ${{ inputs.build_tls }}
       run: |
+        # A sanitizer Redis must be built by the same clang that builds the
+        # module. gcc's -fsanitize=address links libasan dynamically, and the
+        # resulting redis-server aborts on startup with "ASan runtime does not
+        # come first in initial library list" — which surfaces far downstream as
+        # RLTest failing to read the server version. Refuse to build the broken
+        # thing: the caller is responsible for putting the sanitizer toolchain in
+        # CC (setup-build-env does this for every workflow that gets here).
+        if [[ "$SAN" == "address" && "$(basename "${CC:-cc}")" != clang* ]]; then
+          echo "SANITIZER=address requires CC to point at clang, got '${CC:-<unset>}'." >&2
+          echo "Configure the sanitizer toolchain before this action runs." >&2
+          exit 1
+        fi
         EXTRA=()
         if [[ "$BUILD_TLS" == "true" ]]; then
           EXTRA+=("BUILD_TLS=yes")
@@ -109,6 +121,27 @@ runs:
           EXTRA+=("REDIS_CFLAGS=-DCOVERAGE_TEST")
         fi
         make PREFIX="$PREFIX" install "${EXTRA[@]}" SANITIZER="$SAN"
+
+    - name: Verify redis-server runs
+      # Guards both ways into this point: a fresh build and a restored cache
+      # entry (which may predate the current key scheme, or have been written by
+      # a job with a different toolchain). "v=<version>" is what RLTest parses
+      # out of the banner, so checking for it here means a server that cannot
+      # start fails this step, with its own output, rather than every test in
+      # every downstream flow job failing on a symptom.
+      # The exit code is ignored on purpose: a sanitizer build can exit non-zero
+      # from a leak report after printing the banner.
+      shell: bash
+      env:
+        PREFIX: ${{ steps.resolve.outputs.prefix }}
+      run: |
+        set -euo pipefail
+        VERSION=$("$PREFIX/bin/redis-server" --version || true)
+        echo "$VERSION"
+        if [[ "$VERSION" != *"v="* ]]; then
+          echo "redis-server did not report a usable version." >&2
+          exit 1
+        fi
 
     - name: Save Redis to cache
       if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}

--- a/.github/actions/build-redis/action.yml
+++ b/.github/actions/build-redis/action.yml
@@ -64,7 +64,14 @@ runs:
         SAN_LABEL="${SAN:-none}"
         # Sanitize platform id for use in a cache key.
         PLATFORM_SAFE=$(echo "$PLATFORM_ID" | sed 's#[^A-Za-z0-9_.-]#-#g')
-        KEY="redis-${SHA}-${PLATFORM_SAFE}-${ARCH}-san_${SAN_LABEL}-cov_${COV}-tls_${TLS}"
+        # The compiler is part of the ABI of the produced binary, not just of
+        # how fast it built: a sanitizer Redis built by clang links the ASan
+        # runtime statically, while a gcc one loads libasan dynamically. Mixing
+        # the two across jobs yields a redis-server that aborts at startup with
+        # "ASan runtime does not come first in initial library list", so entries
+        # built with different compilers must never share a cache key.
+        CC_ID=$(basename "${CC:-cc}" | sed 's#[^A-Za-z0-9_.-]#-#g')
+        KEY="redis-${SHA}-${PLATFORM_SAFE}-${ARCH}-san_${SAN_LABEL}-cov_${COV}-tls_${TLS}-cc_${CC_ID}"
         echo "key=$KEY" >> "$GITHUB_OUTPUT"
         echo "Cache key: $KEY"
 

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -226,6 +226,7 @@ runs:
       shell: bash -l -eo pipefail {0}
       env:
         LLVM_FULL_CONFIG: ${{ inputs.llvm-full-config }}
+        BUILD_REDIS: ${{ inputs.build-redis }}
       run: |
         CLANG_BIN=$(find /usr/bin /usr/local/bin -name "clang-[0-9]*" 2>/dev/null | sort -V | tail -1)
         if [[ -z "$CLANG_BIN" ]]; then
@@ -235,8 +236,11 @@ runs:
         CLANG_VERSION=$(basename $CLANG_BIN | sed 's/clang-//')
         echo "Using LLVM version: $CLANG_VERSION"
         # task-build / task-test / task-test-unit pin the C/C++ compiler to the
-        # sanitizer-enabled clang; task-test-flow only needs the symbolizer.
-        if [[ "$LLVM_FULL_CONFIG" == "true" ]]; then
+        # sanitizer-enabled clang; jobs that only run tests need the symbolizer.
+        # A job that may compile Redis here always needs the pinned clang too,
+        # whatever it asked for: a gcc-built sanitizer redis-server aborts at
+        # startup ("ASan runtime does not come first in initial library list").
+        if [[ "$LLVM_FULL_CONFIG" == "true" || "$BUILD_REDIS" == "true" ]]; then
           echo "CC=$CLANG_BIN" >> $GITHUB_ENV
           echo "CXX=$(dirname $CLANG_BIN)/clang++-$CLANG_VERSION" >> $GITHUB_ENV
           echo "LD=$CLANG_BIN" >> $GITHUB_ENV

--- a/.github/workflows/task-build.yml
+++ b/.github/workflows/task-build.yml
@@ -340,6 +340,22 @@ jobs:
           echo "Tarball size:"
           ls -lh bin.tar.gz
 
+      # Ship the Redis install tree alongside the module. The flow-test jobs used
+      # to obtain it from the shared Actions cache that the step above populates,
+      # but a cache miss there (eviction, a re-run after the entry aged out) made
+      # them build Redis themselves — with the default compiler rather than the
+      # sanitizer clang used here, producing a redis-server that aborts with
+      # "ASan runtime does not come first in initial library list". Shipping it in
+      # the artifact makes the toolchain match by construction, so the cache is a
+      # build-time optimisation only and can never change what the tests run.
+      # tar (not the artifact zip) to preserve the executable bits.
+      - name: Package Redis install tree
+        run: |
+          set -euo pipefail
+          tar -czf redis-install.tar.gz redis-install
+          echo "Redis tarball size:"
+          ls -lh redis-install.tar.gz
+
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
@@ -347,6 +363,7 @@ jobs:
           path: |
             bin.tar.gz
             nextest-archive.tar.zst
+            redis-install.tar.gz
           if-no-files-found: error
           retention-days: 1
 

--- a/.github/workflows/task-test-flow.yml
+++ b/.github/workflows/task-test-flow.yml
@@ -223,10 +223,9 @@ jobs:
           sanitizer-setup: 'true'
           # Flow tests only need the ASAN symbolizer, not CC/CXX/LD pinned to clang.
           llvm-full-config: 'false'
-          build-redis: 'true'
-          redis-ref: ${{ inputs.redis-ref }}
-          coverage: ${{ inputs.coverage }}
-          redis-cache-platform-id: ${{ inputs.container || inputs.env }}
+          # No compilation happens in this job, Redis included: the build job
+          # ships its redis-install tree in the artifact and we unpack it below.
+          build-redis: 'false'
 
       - name: Set Artifact Names
         id: artifact-names
@@ -262,6 +261,37 @@ jobs:
           du -sh bin
           echo "Module binaries:"
           find bin -name 'redisearch.so' -o -name 'redisearch.dylib' 2>/dev/null
+
+      - name: Restore Redis from build artifact
+        # Same install tree, same toolchain as the module under test. The
+        # `--version` check mirrors what RLTest parses to decide the server
+        # version (it wants a "v=<version>" field on stdout): assert it here so a
+        # server that can't start fails this step with its own diagnostics,
+        # instead of every test reporting the downstream symptom
+        # ("Could not extract Redis version") with the cause nowhere in sight.
+        # The exit code is deliberately ignored — a sanitizer build can exit
+        # non-zero from a leak report while still having printed the banner.
+        run: |
+          set -euo pipefail
+          tar -xzf redis-install.tar.gz
+          rm redis-install.tar.gz
+          PREFIX="$GITHUB_WORKSPACE/redis-install"
+          VERSION=$("$PREFIX/bin/redis-server" --version || true)
+          echo "$VERSION"
+          if [[ "$VERSION" != *"v="* ]]; then
+            echo "redis-server did not report a usable version; RLTest cannot run against it" >&2
+            exit 1
+          fi
+          echo "$PREFIX/bin" >> "$GITHUB_PATH"
+          echo "REDIS_SERVER=$PREFIX/bin/redis-server" >> "$GITHUB_ENV"
+          # Some container images ship an /etc/profile that unconditionally
+          # rewrites PATH for root, wiping the GITHUB_PATH addition above for
+          # the steps that run under `bash -l`. Re-prepend it from profile.d,
+          # like the build-redis action does.
+          if [[ -d /etc/profile.d && ( -w /etc/profile.d || $(id -u) -eq 0 ) ]]; then
+            printf 'export PATH="%s:$PATH"\n' "$PREFIX/bin" > /etc/profile.d/redis-prefix.sh
+            chmod 0644 /etc/profile.d/redis-prefix.sh
+          fi
 
       # Enumerate the suite (LIST=1 => RLTest --collect-only, one "<file>:<test>"
       # spec per line). Needed to shard and as the input to flaky filtering.


### PR DESCRIPTION
## Describe the changes in the pull request

Sanitizer flow-test jobs fail whenever the Redis Actions cache misses: they
build Redis themselves without the clang pinning, and the resulting gcc ASan
`redis-server` aborts at startup, so every test reports "Could not extract
Redis version".

- **Ship Redis in the build artifact.** The build job already builds Redis with
  the sanitizer clang to prime the cache; it now packs `redis-install/` into the
  artifact and the flow jobs unpack it instead of building their own. The
  toolchain matches the module under test by construction, and the cache becomes
  a build-time optimisation only. Also adds the compiler to the Redis cache key
  and pins clang whenever `setup-build-env` may compile Redis.
- **Harden the remaining fallback.** `build-redis` refuses to build with
  `SANITIZER=address` unless `CC` is clang, and smoke-tests `redis-server`
  before the cache save, so a server that cannot start is never cached or handed
  to the caller.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
