### PR TITLE
[MOD-16877] Fix numeric index cardinality and bounds not matching the stored values

### DIFF
--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/gc.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/gc.rs
@@ -12,11 +12,15 @@
 use ffi::{DocTable_Exists, RedisSearchCtx};
 use inverted_index::GcScanDelta;
 use numeric_range_tree::{
-    CompactIfSparseResult, IndexedReversePreOrderDfsIterator, NodeGcDelta, NodeIndex,
-    NumericRangeTree, SingleNodeGcResult,
+    CompactIfSparseResult, GcSurvivorStats, IndexedReversePreOrderDfsIterator, NodeGcDelta,
+    NodeIndex, NumericRangeTree, SingleNodeGcResult,
 };
 use rqe_core::DocId;
 use serde::{Deserialize, Serialize};
+
+/// Size of the fixed-width trailer that follows the msgpack-encoded delta:
+/// the survivor statistics with the last block, then the ones without it.
+const TRAILER_SIZE: usize = 2 * GcSurvivorStats::WIRE_SIZE;
 
 /// Conditionally trim empty leaves and compact the node slab.
 ///
@@ -58,7 +62,7 @@ pub struct NumericGcNodeEntry {
     /// The node's slab generation.
     /// The second half of a [`NodeIndex`].
     pub node_generation: u32,
-    /// Pointer to the serialized entry data (msgpack delta + HLL registers).
+    /// Pointer to the serialized entry data (msgpack delta + survivor statistics).
     pub data: *const u8,
     /// Length of the serialized entry data in bytes.
     pub data_len: usize,
@@ -71,7 +75,7 @@ pub struct NumericGcNodeEntry {
 ///
 /// Each call to `Next` scans the next node in DFS order via
 /// [`NumericRangeNode::scan_gc`][numeric_range_tree::NumericRangeNode::scan_gc]
-/// and serializes the delta + HLL registers into an internal buffer.
+/// and serializes the delta + survivor statistics into an internal buffer.
 /// The caller can then write the entry data to the pipe immediately,
 /// avoiding buffering all deltas in memory.
 pub struct NumericGcScanner<'tree> {
@@ -124,9 +128,9 @@ pub unsafe extern "C" fn NumericGcScanner_New<'tree>(
 
 /// Advance the scanner to the next node with GC work.
 ///
-/// Scans nodes in DFS order, skipping those without GC work. When a node
-/// with work is found, its delta and HLL registers are serialized into the
-/// scanner's internal buffer.
+/// Scans nodes in DFS order, skipping those without GC work. When a node with work
+/// is found, its delta and the statistics recomputed over the surviving entries are
+/// serialized into the scanner's internal buffer.
 ///
 /// Returns `true` if an entry was produced (and `*entry` is populated),
 /// `false` when all nodes have been visited.
@@ -136,8 +140,12 @@ pub unsafe extern "C" fn NumericGcScanner_New<'tree>(
 /// # Wire format for `entry.data`
 ///
 /// ```text
-/// [delta_msgpack][64-byte hll_with][64-byte hll_without]
+/// [delta_msgpack][stats_with_last_block][stats_without_last_block]
 /// ```
+///
+/// where each `stats_*` block is `[64-byte hll registers][f64 min][f64 max]`, the
+/// bounds in native byte order. The trailer is fixed-width, so the parent recovers
+/// the msgpack payload by trimming [`TRAILER_SIZE`] bytes off the end.
 ///
 /// # Safety
 ///
@@ -175,12 +183,8 @@ pub unsafe extern "C" fn NumericGcScanner_Next(
             continue;
         }
 
-        scanner
-            .buffer
-            .extend_from_slice(&delta.registers_with_last_block);
-        scanner
-            .buffer
-            .extend_from_slice(&delta.registers_without_last_block);
+        delta.with_last_block.write_to(&mut scanner.buffer);
+        delta.without_last_block.write_to(&mut scanner.buffer);
 
         // SAFETY: Caller ensures `entry` is valid
         let entry = unsafe { &mut *entry };
@@ -253,7 +257,7 @@ pub struct ApplyGcEntryResult {
 ///
 /// The entry data must have the wire format produced by [`NumericGcScanner_Next`]:
 /// ```text
-/// [delta_msgpack][64-byte hll_with][64-byte hll_without]
+/// [delta_msgpack][stats_with_last_block][stats_without_last_block]
 /// ```
 ///
 /// Returns an [`ApplyGcEntryResult`] whose [`status`](ApplyGcEntryStatus)
@@ -274,16 +278,14 @@ pub unsafe extern "C" fn NumericRangeTree_ApplyGcEntry(
     debug_assert!(!tree.is_null(), "tree cannot be NULL");
     debug_assert!(!entry_data.is_null(), "entry_data cannot be NULL");
 
-    const HLL_REGISTER_SIZE: usize = 64;
-
     // SAFETY: Caller ensures pointers are valid
     let tree = unsafe { &mut *tree };
     // SAFETY: Caller ensures entry_data is valid for entry_len bytes
     let data = unsafe { std::slice::from_raw_parts(entry_data, entry_len) };
 
-    // The entry format is: [delta_msgpack][64-byte hll_with][64-byte hll_without]
-    // We need at least 128 bytes for the two HLL register arrays.
-    if data.len() < HLL_REGISTER_SIZE * 2 {
+    // The entry format is: [delta_msgpack][stats_with_last_block][stats_without_last_block]
+    // We need at least the fixed-width trailer holding the two statistics blocks.
+    if data.len() < TRAILER_SIZE {
         tracing::warn!(
             node_position = node_position,
             node_generation = node_generation,
@@ -297,10 +299,28 @@ pub unsafe extern "C" fn NumericRangeTree_ApplyGcEntry(
         };
     }
 
-    let hll_start = data.len() - HLL_REGISTER_SIZE * 2;
-    let msgpack_data = &data[..hll_start];
-    let hll_with = &data[hll_start..hll_start + HLL_REGISTER_SIZE];
-    let hll_without = &data[hll_start + HLL_REGISTER_SIZE..];
+    let trailer_start = data.len() - TRAILER_SIZE;
+    let msgpack_data = &data[..trailer_start];
+    let (with, without) = data[trailer_start..].split_at(GcSurvivorStats::WIRE_SIZE);
+    // Both halves are exactly `WIRE_SIZE` long by construction, so these reads cannot
+    // fail — but this function is `extern "C"`, so it reports the impossible case
+    // instead of unwinding into C.
+    let (Some(with_last_block), Some(without_last_block)) = (
+        GcSurvivorStats::read_from(with),
+        GcSurvivorStats::read_from(without),
+    ) else {
+        tracing::warn!(
+            node_position = node_position,
+            node_generation = node_generation,
+            entry_len = entry_len,
+            tree_id = %tree.unique_id(),
+            "Skipping a GcEntry whose survivor statistics could not be decoded."
+        );
+        return ApplyGcEntryResult {
+            status: ApplyGcEntryStatus::DeserializationError,
+            ..Default::default()
+        };
+    };
 
     let delta: GcScanDelta = match GcScanDelta::deserialize(&mut rmp_serde::Deserializer::new(
         &mut std::io::Cursor::new(msgpack_data),
@@ -322,15 +342,10 @@ pub unsafe extern "C" fn NumericRangeTree_ApplyGcEntry(
         }
     };
 
-    let mut regs_with = [0u8; HLL_REGISTER_SIZE];
-    let mut regs_without = [0u8; HLL_REGISTER_SIZE];
-    regs_with.copy_from_slice(hll_with);
-    regs_without.copy_from_slice(hll_without);
-
     let node_gc_delta = NodeGcDelta {
         delta,
-        registers_with_last_block: regs_with,
-        registers_without_last_block: regs_without,
+        with_last_block,
+        without_last_block,
     };
 
     match tree.apply_gc_to_node(

--- a/src/redisearch_rs/headers/numeric_range_tree.h
+++ b/src/redisearch_rs/headers/numeric_range_tree.h
@@ -28,27 +28,6 @@ typedef struct InvertedIndexNumeric InvertedIndexNumeric;
 typedef struct ReversePreOrderDfsIterator ReversePreOrderDfsIterator;
 
 /**
- * A numeric range is a leaf-level storage unit in the numeric range tree.
- *
- * It stores document IDs and their associated numeric values in an inverted index,
- * along with metadata for range queries and cardinality estimation.
- *
- * # Structure
- *
- * - **Bounds** (`min_val`, `max_val`): Track the actual value range for overlap
- *   and containment tests during queries.
- * - **Cardinality** (`hll`): HyperLogLog estimator for the number of distinct
- *   values, used to decide when to split.
- * - **Entries** (`entries`): Inverted index storing (docId, value) pairs.
- *
- * # Initialization
- *
- * New ranges start with inverted bounds (`min_val = +∞`, `max_val = -∞`) so
- * the first added value correctly sets both bounds.
- */
-typedef struct NumericRange NumericRange;
-
-/**
  * A numeric range tree for efficient range queries over numeric values.
  *
  * The tree organizes documents by their numeric field values into a balanced
@@ -82,6 +61,27 @@ typedef struct NumericRange NumericRange;
  * [`Self::MAXIMUM_DEPTH_IMBALANCE`].
  */
 typedef struct NumericRangeTree NumericRangeTree;
+
+/**
+ * A numeric range is a leaf-level storage unit in the numeric range tree.
+ *
+ * It stores document IDs and their associated numeric values in an inverted index,
+ * along with metadata for range queries and cardinality estimation.
+ *
+ * # Structure
+ *
+ * - **Bounds** (`min_val`, `max_val`): Track the actual value range for overlap
+ *   and containment tests during queries.
+ * - **Cardinality** (`hll`): HyperLogLog estimator for the number of distinct
+ *   values, used to decide when to split.
+ * - **Entries** (`entries`): Inverted index storing (docId, value) pairs.
+ *
+ * # Initialization
+ *
+ * New ranges start with inverted bounds (`min_val = +∞`, `max_val = -∞`) so
+ * the first added value correctly sets both bounds.
+ */
+typedef struct NumericRange NumericRange;
 
 /**
  * A node in the numeric range tree.

--- a/src/redisearch_rs/headers/numeric_range_tree_ffi.h
+++ b/src/redisearch_rs/headers/numeric_range_tree_ffi.h
@@ -46,7 +46,7 @@ typedef struct NumericFilter NumericFilter;
  *
  * Each call to `Next` scans the next node in DFS order via
  * [`NumericRangeNode::scan_gc`][numeric_range_tree::NumericRangeNode::scan_gc]
- * and serializes the delta + HLL registers into an internal buffer.
+ * and serializes the delta + survivor statistics into an internal buffer.
  * The caller can then write the entry data to the pipe immediately,
  * avoiding buffering all deltas in memory.
  */
@@ -78,7 +78,7 @@ typedef struct NumericGcNodeEntry {
    */
   uint32_t node_generation;
   /**
-   * Pointer to the serialized entry data (msgpack delta + HLL registers).
+   * Pointer to the serialized entry data (msgpack delta + survivor statistics).
    */
   const uint8_t *data;
   /**
@@ -464,9 +464,9 @@ void NumericRangeTree_Free(struct NumericRangeTree *t);
 /**
  * Advance the scanner to the next node with GC work.
  *
- * Scans nodes in DFS order, skipping those without GC work. When a node
- * with work is found, its delta and HLL registers are serialized into the
- * scanner's internal buffer.
+ * Scans nodes in DFS order, skipping those without GC work. When a node with work
+ * is found, its delta and the statistics recomputed over the surviving entries are
+ * serialized into the scanner's internal buffer.
  *
  * Returns `true` if an entry was produced (and `*entry` is populated),
  * `false` when all nodes have been visited.
@@ -476,8 +476,12 @@ void NumericRangeTree_Free(struct NumericRangeTree *t);
  * # Wire format for `entry.data`
  *
  * ```text
- * [delta_msgpack][64-byte hll_with][64-byte hll_without]
+ * [delta_msgpack][stats_with_last_block][stats_without_last_block]
  * ```
+ *
+ * where each `stats_*` block is `[64-byte hll registers][f64 min][f64 max]`, the
+ * bounds in native byte order. The trailer is fixed-width, so the parent recovers
+ * the msgpack payload by trimming [`TRAILER_SIZE`] bytes off the end.
  *
  * # Safety
  *
@@ -563,7 +567,7 @@ size_t NumericRangeTree_BaseSize(void);
  *
  * The entry data must have the wire format produced by [`NumericGcScanner_Next`]:
  * ```text
- * [delta_msgpack][64-byte hll_with][64-byte hll_without]
+ * [delta_msgpack][stats_with_last_block][stats_without_last_block]
  * ```
  *
  * Returns an [`ApplyGcEntryResult`] whose [`status`](ApplyGcEntryStatus)

--- a/src/redisearch_rs/inverted_index/src/codec/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/numeric.rs
@@ -175,6 +175,117 @@ impl NumericFloatCompression {
     const FLOAT_COMPRESSION_THRESHOLD: f64 = 0.01;
 }
 
+/// An encoder that decides how it will represent a numeric value before writing it.
+///
+/// The representation cannot always hold the value it was given —
+/// [`NumericFloatCompression`] stores an `f32` when the precision loss is below its
+/// threshold, and even [`Numeric`] normalizes `-0.0` to `+0.0` by encoding it as a
+/// tiny integer. That decision is made inside [`Encoder::encode`], so callers who
+/// derive anything from a value — cardinality estimates, range bounds, routing
+/// decisions — would otherwise be reasoning about a value the index never returns.
+///
+/// This trait exposes the decision on its own ([`prepare`](Self::prepare)) and lets
+/// it be handed back for writing ([`encode_prepared`](Self::encode_prepared)), so a
+/// caller that needs to know the outcome up front does not force the encoder to work
+/// it out twice.
+pub trait NumericEncoder: Encoder {
+    /// Decide how `value` will be represented. Writes nothing.
+    fn prepare(value: f64) -> PreparedValue;
+
+    /// Write a value whose representation has already been decided.
+    ///
+    /// Equivalent to [`Encoder::encode`] on a record holding the same value, down to
+    /// the bytes.
+    fn encode_prepared<W: Write + std::io::Seek>(
+        writer: W,
+        delta: Self::Delta,
+        prepared: PreparedValue,
+    ) -> std::io::Result<usize>;
+
+    /// The value a reader will decode after `value` is encoded by this encoder.
+    ///
+    /// Idempotent: the stored form of a stored value is itself.
+    fn stored_value(value: f64) -> f64 {
+        Self::prepare(value).stored_value().get()
+    }
+}
+
+impl NumericEncoder for Numeric {
+    fn prepare(value: f64) -> PreparedValue {
+        PreparedValue(Value::from(value, false))
+    }
+
+    fn encode_prepared<W: Write + std::io::Seek>(
+        writer: W,
+        delta: Self::Delta,
+        prepared: PreparedValue,
+    ) -> std::io::Result<usize> {
+        encode_value(writer, delta, prepared.0)
+    }
+}
+
+impl NumericEncoder for NumericFloatCompression {
+    fn prepare(value: f64) -> PreparedValue {
+        PreparedValue(Value::from(value, true))
+    }
+
+    fn encode_prepared<W: Write + std::io::Seek>(
+        writer: W,
+        delta: Self::Delta,
+        prepared: PreparedValue,
+    ) -> std::io::Result<usize> {
+        encode_value(writer, delta, prepared.0)
+    }
+}
+
+/// How a numeric encoder will represent a value: decided, but not yet written.
+///
+/// Produced by [`NumericEncoder::prepare`] and consumed by
+/// [`NumericEncoder::encode_prepared`]. Carrying the decision around lets a caller
+/// learn the [`stored_value`](Self::stored_value) *and* write the entry while the
+/// encoder classifies the value only once.
+///
+/// Not parameterized by encoder on purpose: the byte layout records which
+/// representation was used, so either numeric encoder can write a decision the other
+/// one made, and any numeric decoder reads it back. Preparing with a different
+/// encoder than the index uses is therefore harmless, if pointless.
+#[derive(Debug, Clone, Copy)]
+pub struct PreparedValue(Value);
+
+impl PreparedValue {
+    /// The value a reader will decode for this representation.
+    pub const fn stored_value(self) -> StoredValue {
+        StoredValue(self.0.to_f64())
+    }
+}
+
+/// A numeric value in the exact form an index stores — and therefore returns — it.
+///
+/// Wrapping the value makes the lossy step visible in the type system: a plain
+/// `f64` cannot be mistaken for something the index will hand back, so statistics
+/// and routing decisions cannot accidentally be computed over an input value that
+/// the encoder is about to change.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct StoredValue(f64);
+
+impl StoredValue {
+    /// Wrap a value that came out of a numeric index.
+    ///
+    /// Decoded values are already in stored form, so this is free — no
+    /// classification is needed, which is what keeps read-only paths (the GC scan,
+    /// bounds and cardinality rebuilds) cheap. The caller is responsible for that
+    /// provenance: pass only values read back through a numeric [`Decoder`], never an
+    /// input value on its way in.
+    pub const fn from_decoded(value: f64) -> Self {
+        Self(value)
+    }
+
+    /// The wrapped value.
+    pub const fn get(self) -> f64 {
+        self.0
+    }
+}
+
 /// The [`Numeric`] encoder only supports encoding deltas that fit within 7 bytes
 #[derive(Debug, PartialEq)]
 pub struct NumericDelta(u64);
@@ -237,7 +348,7 @@ impl Encoder for NumericFloatCompression {
 }
 
 fn encode<W: Write + std::io::Seek>(
-    mut writer: W,
+    writer: W,
     delta: NumericDelta,
     record: &RSIndexResult,
     compress_floats: bool,
@@ -246,6 +357,19 @@ fn encode<W: Write + std::io::Seek>(
         .as_numeric()
         .expect("numeric encoder will only be called for numeric records");
 
+    encode_value(writer, delta, Value::from(num_record, compress_floats))
+}
+
+/// Write a value whose representation has already been decided.
+///
+/// The single writer for both entry points: [`Encoder::encode`] classifies and calls
+/// this, [`NumericEncoder::encode_prepared`] passes on a classification the caller
+/// already has.
+fn encode_value<W: Write + std::io::Seek>(
+    mut writer: W,
+    delta: NumericDelta,
+    value: Value,
+) -> std::io::Result<usize> {
     let delta = delta.pack();
 
     // Trim trailing zeros from delta so that we store as little as possible
@@ -253,7 +377,7 @@ fn encode<W: Write + std::io::Seek>(
     let delta = &delta[..end];
     let delta_bytes = delta.len() as _;
 
-    let bytes_written = match Value::from(num_record, compress_floats) {
+    let bytes_written = match value {
         Value::TinyInteger(i) => {
             let header = Header {
                 delta_bytes,
@@ -613,7 +737,7 @@ impl FromSlice for f64 {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum Value {
     TinyInteger(u8),
     IntegerPositive(u64),
@@ -666,6 +790,27 @@ impl Value {
                     }
                 }
             }
+        }
+    }
+
+    /// The `f64` a reader decodes for this representation.
+    ///
+    /// Mirrors [`decode`] arm for arm. `decode` deliberately does not go through
+    /// `Value` — it is on the read hot path and reconstructs the number straight
+    /// from the bytes — so the two are kept in agreement by
+    /// `numeric_stored_value_matches_encode_decode` in the integration tests
+    /// rather than by sharing code.
+    const fn to_f64(self) -> f64 {
+        match self {
+            Value::TinyInteger(i) => i as f64,
+            Value::IntegerPositive(i) => i as f64,
+            Value::IntegerNegative(i) => (i as f64).copysign(-1.0),
+            Value::Float32Positive(f) => f as f64,
+            Value::Float32Negative(f) => f.copysign(-1.0) as f64,
+            Value::Float64Positive(f) => f,
+            Value::Float64Negative(f) => f.copysign(-1.0),
+            Value::FloatInfinity => f64::INFINITY,
+            Value::FloatNegInfinity => f64::NEG_INFINITY,
         }
     }
 }

--- a/src/redisearch_rs/inverted_index/src/index/core.rs
+++ b/src/redisearch_rs/inverted_index/src/index/core.rs
@@ -19,6 +19,7 @@ use crate::{
     BlockCapacity, Encoder, IdDelta,
     controlled_cursor::ControlledCursor,
     debug::{BlockSummary, Summary},
+    numeric::{NumericEncoder, PreparedValue},
 };
 use ffi::{IndexFlags, IndexFlags_Index_HasMultiValue};
 use index_result::RSIndexResult;
@@ -193,8 +194,23 @@ impl<E: Encoder> InvertedIndex<E> {
     /// It is expected that the document ID of the record is greater than or equal to the last
     /// document ID in the index.
     pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<AddRecordOutcome> {
-        let doc_id = record.doc_id;
+        self.add_entry(record.doc_id, |writer, delta| {
+            E::encode(writer, delta, record)
+        })
+    }
 
+    /// Add an entry for `doc_id`, letting `encode` write the payload.
+    ///
+    /// Everything an add does apart from writing the payload — rejecting or counting
+    /// duplicates, picking or starting a block, computing the delta and retrying in a
+    /// fresh block when it does not fit, accounting for buffer growth, and updating
+    /// the block and index counters — depends only on the document ID. Keeping that
+    /// here lets callers who hold something other than an [`RSIndexResult`] (see
+    /// [`Self::add_prepared_record`]) reuse all of it.
+    fn add_entry<F>(&mut self, doc_id: DocId, encode: F) -> std::io::Result<AddRecordOutcome>
+    where
+        F: FnOnce(ControlledCursor<'_>, E::Delta) -> std::io::Result<usize>,
+    {
         let same_doc = match (
             E::ALLOW_DUPLICATES,
             self.last_doc_id().map(|d| d == doc_id).unwrap_or_default(),
@@ -240,7 +256,7 @@ impl<E: Encoder> InvertedIndex<E> {
 
         let buf_cap = block.buffer.capacity();
         let writer = block.writer();
-        let _bytes_written = E::encode(writer, delta, record)?;
+        let _bytes_written = encode(writer, delta)?;
 
         // We don't use `_bytes_written` returned by the encoder to determine by how much memory
         // grew because the buffer might have had enough capacity for the bytes in the encoding.
@@ -386,5 +402,24 @@ impl<E: Encoder> InvertedIndex<E> {
     /// revalidation.
     pub const fn unique_id(&self) -> IndexUniqueId {
         self.unique_id
+    }
+}
+
+impl<E: NumericEncoder> InvertedIndex<E> {
+    /// Add an entry whose representation the caller already asked the encoder to
+    /// decide, via [`NumericEncoder::prepare`].
+    ///
+    /// Equivalent to [`Self::add_record`] with a numeric record holding the same
+    /// document ID and value — same bytes, same outcome — but the encoder does not
+    /// classify the value a second time, and no [`RSIndexResult`] has to be built to
+    /// carry it.
+    pub fn add_prepared_record(
+        &mut self,
+        doc_id: DocId,
+        prepared: PreparedValue,
+    ) -> std::io::Result<AddRecordOutcome> {
+        self.add_entry(doc_id, |writer, delta| {
+            E::encode_prepared(writer, delta, prepared)
+        })
     }
 }

--- a/src/redisearch_rs/inverted_index/src/index/with_entries.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_entries.rs
@@ -10,6 +10,7 @@
 use crate::{
     AddRecordOutcome, DecodedBy, Encoder, GcApplyInfo, GcScanDelta, IndexBlock, InvertedIndex,
     debug::{BlockSummary, Summary},
+    numeric::{NumericEncoder, PreparedValue},
     reader::IndexReaderCore,
 };
 use ffi::IndexFlags;
@@ -156,5 +157,21 @@ impl<E: Encoder + DecodedBy> EntriesTrackingIndex<E> {
         self.number_of_entries -= info.entries_removed;
 
         info
+    }
+}
+
+impl<E: NumericEncoder> EntriesTrackingIndex<E> {
+    /// Add an entry whose representation the encoder already decided — see
+    /// [`InvertedIndex::add_prepared_record`].
+    pub fn add_prepared_record(
+        &mut self,
+        doc_id: DocId,
+        prepared: PreparedValue,
+    ) -> std::io::Result<AddRecordOutcome> {
+        let result = self.index.add_prepared_record(doc_id, prepared)?;
+
+        self.number_of_entries += 1;
+
+        Ok(result)
     }
 }

--- a/src/redisearch_rs/inverted_index/src/tests/index.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/index.rs
@@ -628,3 +628,54 @@ fn blocks_summary_store_numeric() {
         ]
     );
 }
+
+/// The prepared write path must leave the index in exactly the state the
+/// record-based path would: same bytes, same block layout, same growth accounting.
+/// Anything less and callers would have to know which path an index was built with.
+#[test]
+fn add_prepared_record_matches_add_record() {
+    use crate::numeric::{Numeric, NumericEncoder};
+
+    // Values chosen to exercise every representation the encoder picks between:
+    // tiny int, wide int, negative, f32, f64, and infinity.
+    let values = [
+        0.0,
+        3.0,
+        -7.0,
+        1024.0,
+        0.5,
+        1e-9,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+        9_007_199_254_740_993.0,
+    ];
+
+    let mut from_records = InvertedIndex::<Numeric>::new(IndexFlags_Index_StoreNumeric);
+    let mut from_prepared = InvertedIndex::<Numeric>::new(IndexFlags_Index_StoreNumeric);
+
+    for (i, value) in values.iter().enumerate() {
+        let doc_id = i as DocId + 1;
+
+        let record = RSIndexResult::build_numeric(*value).doc_id(doc_id).build();
+        let record_outcome = from_records.add_record(&record).unwrap();
+        let prepared_outcome = from_prepared
+            .add_prepared_record(doc_id, Numeric::prepare(*value))
+            .unwrap();
+
+        assert_eq!(
+            record_outcome, prepared_outcome,
+            "outcomes diverged while adding {value} for doc {doc_id}"
+        );
+    }
+
+    assert_eq!(
+        from_records.blocks_summary(),
+        from_prepared.blocks_summary(),
+        "block layout diverged"
+    );
+    assert_eq!(from_records.memory_usage(), from_prepared.memory_usage());
+
+    let record_bytes: Vec<_> = from_records.blocks.iter().map(|b| b.data()).collect();
+    let prepared_bytes: Vec<_> = from_prepared.blocks.iter().map(|b| b.data()).collect();
+    assert_eq!(record_bytes, prepared_bytes, "encoded bytes diverged");
+}

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/numeric.rs
@@ -10,10 +10,187 @@
 use index_result::RSIndexResult;
 use inverted_index::{
     Decoder, Encoder, IdDelta,
-    numeric::{Numeric, NumericDelta, NumericFloatCompression},
+    numeric::{Numeric, NumericDelta, NumericEncoder, NumericFloatCompression},
 };
 use pretty_assertions::assert_eq;
 use std::io::Cursor;
+
+/// Encode `value` with `E` and decode it again, returning what a reader sees.
+fn round_trip<E: Encoder<Delta = NumericDelta> + Decoder>(value: f64) -> f64 {
+    let mut buf = Cursor::new(Vec::new());
+    let record = RSIndexResult::build_numeric(value).doc_id(1).build();
+    E::encode(&mut buf, NumericDelta::from_u64(0).unwrap(), &record).expect("to encode");
+
+    let buf = buf.into_inner();
+    let mut buf = Cursor::new(buf.as_ref());
+    let decoded = E::decode_new(&mut buf, 1).expect("to decode");
+
+    decoded.as_numeric().expect("a numeric record")
+}
+
+/// `stored_value` must predict exactly what an encode/decode round trip produces —
+/// that is the whole point of the trait, and the two implementations are separate
+/// code (`decode` rebuilds the number straight from the bytes for speed).
+fn assert_stored_value_matches_round_trip(value: f64) {
+    for (name, predicted, actual) in [
+        (
+            "Numeric",
+            Numeric::stored_value(value),
+            round_trip::<Numeric>(value),
+        ),
+        (
+            "NumericFloatCompression",
+            NumericFloatCompression::stored_value(value),
+            round_trip::<NumericFloatCompression>(value),
+        ),
+    ] {
+        assert_eq!(
+            predicted.to_bits(),
+            actual.to_bits(),
+            "{name}: stored_value({value}) predicted {predicted} but a round trip yields {actual}"
+        );
+        // Storing a stored value must be a no-op, or quantizing on the way in would
+        // not be idempotent and repeated GC passes could keep shifting statistics.
+        let twice = match name {
+            "Numeric" => Numeric::stored_value(predicted),
+            _ => NumericFloatCompression::stored_value(predicted),
+        };
+        assert_eq!(
+            twice.to_bits(),
+            predicted.to_bits(),
+            "{name}: stored_value is not idempotent for {value}"
+        );
+    }
+}
+
+#[test]
+fn stored_value_matches_encode_decode_for_edge_cases() {
+    for value in [
+        0.0,
+        -0.0, // stored as a tiny int, so it comes back as +0.0
+        1.0,
+        7.0,
+        8.0,
+        -1.0,
+        -8.0,
+        0.5,
+        -0.5,
+        3.124,                   // compressible: within the 0.01 threshold
+        100.500001,              // collapses onto 100.5 as an f32
+        1e-9, // NOT compressible: relative error is tiny, absolute is smaller still
+        9_007_199_254_740_993.0, // 2^53 + 1
+        4_503_599_627_370_496.0, // a 52-bit geohash-shaped value
+        f64::MAX,
+        f64::MIN,
+        f64::MIN_POSITIVE,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+    ] {
+        assert_stored_value_matches_round_trip(value);
+    }
+}
+
+/// The two write entry points must be interchangeable down to the bytes: whichever
+/// one a caller reaches for, the block content has to be identical, or an index
+/// written through the prepared path would decode differently.
+fn assert_encode_prepared_matches_encode(value: f64, delta: u64) {
+    fn compare<E: Encoder<Delta = NumericDelta> + NumericEncoder>(value: f64, delta: u64) {
+        let record = RSIndexResult::build_numeric(value).doc_id(1).build();
+
+        let mut from_record = Cursor::new(Vec::new());
+        let record_bytes = E::encode(
+            &mut from_record,
+            NumericDelta::from_u64(delta).unwrap(),
+            &record,
+        )
+        .expect("to encode");
+
+        let mut from_prepared = Cursor::new(Vec::new());
+        let prepared_bytes = E::encode_prepared(
+            &mut from_prepared,
+            NumericDelta::from_u64(delta).unwrap(),
+            E::prepare(value),
+        )
+        .expect("to encode");
+
+        assert_eq!(
+            from_record.into_inner(),
+            from_prepared.into_inner(),
+            "encode and encode_prepared disagree for value {value}, delta {delta}"
+        );
+        assert_eq!(record_bytes, prepared_bytes);
+    }
+
+    compare::<Numeric>(value, delta);
+    compare::<NumericFloatCompression>(value, delta);
+}
+
+#[test]
+fn encode_prepared_matches_encode_for_edge_cases() {
+    for value in [
+        0.0,
+        -0.0,
+        7.0,
+        -8.0,
+        3.124,
+        100.500001,
+        1e-9,
+        9_007_199_254_740_993.0,
+        f64::MAX,
+        f64::MIN,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+    ] {
+        for delta in [0, 1, 255, 72_057_594_037_927_935] {
+            assert_encode_prepared_matches_encode(value, delta);
+        }
+    }
+}
+
+#[test]
+fn stored_value_maps_negative_zero_to_positive_zero() {
+    // Both encoders take the tiny-integer path for zero, so the sign is dropped.
+    // Statistics computed over stored values must treat the two as one value.
+    for stored in [
+        Numeric::stored_value(-0.0),
+        NumericFloatCompression::stored_value(-0.0),
+    ] {
+        assert!(
+            stored.is_sign_positive() && stored == 0.0,
+            "-0.0 should be stored as +0.0, got {stored}"
+        );
+    }
+}
+
+#[test]
+fn stored_value_of_nan_stays_nan() {
+    // NaN survives as NaN (the payload may differ), so it can never move a bound:
+    // every comparison against it is false.
+    assert!(Numeric::stored_value(f64::NAN).is_nan());
+    assert!(NumericFloatCompression::stored_value(f64::NAN).is_nan());
+}
+
+#[test]
+fn compression_collapses_neighbouring_values_to_one_stored_value() {
+    // The MOD-16877 shape: distinct f64s inside one f32 bucket. With compression on
+    // they are a single stored value, so anything derived from them (cardinality,
+    // bounds) must see one value, not many.
+    let values: Vec<f64> = (0..8).map(|i| 100.5 + i as f64 * 1e-7).collect();
+    let stored: Vec<f64> = values
+        .iter()
+        .map(|&v| NumericFloatCompression::stored_value(v))
+        .collect();
+
+    assert!(
+        stored.windows(2).all(|w| w[0] == w[1]),
+        "expected one stored value, got {stored:?}"
+    );
+    assert_eq!(stored[0], 100.5);
+
+    // Without compression they stay distinct.
+    let exact: Vec<f64> = values.iter().map(|&v| Numeric::stored_value(v)).collect();
+    assert_eq!(exact, values);
+}
 
 /// Tests for integer values between 0 and 7 which should use the [TINY header](super#tiny-type) format.
 #[test]
@@ -638,6 +815,36 @@ mod property_based {
                 .expect("to decode numeric record");
 
             assert_eq!(record_decoded, record, "failed for value: {}", value);
+        }
+
+        /// Keeps `Value::to_f64` (which backs `stored_value`) in agreement with
+        /// `decode`, which reconstructs values from the bytes independently.
+        #[test]
+        fn numeric_stored_value_matches_encode_decode(value in f64::MIN..f64::MAX) {
+            assert_stored_value_matches_round_trip(value);
+        }
+
+        /// The prepared path must be byte-identical to the record path.
+        #[test]
+        fn numeric_encode_prepared_matches_encode(
+            value in f64::MIN..f64::MAX,
+            delta in 0u64..72_057_594_037_927_935u64,
+        ) {
+            assert_encode_prepared_matches_encode(value, delta);
+        }
+
+        /// Re-preparing a stored value must be a no-op: the tree prepares on the way
+        /// in, and split redistribution prepares values it read back out again.
+        #[test]
+        fn numeric_stored_value_is_idempotent(value in f64::MIN..f64::MAX) {
+            let once = Numeric::stored_value(value);
+            assert_eq!(Numeric::stored_value(once).to_bits(), once.to_bits());
+
+            let once = NumericFloatCompression::stored_value(value);
+            assert_eq!(
+                NumericFloatCompression::stored_value(once).to_bits(),
+                once.to_bits(),
+            );
         }
     }
 }

--- a/src/redisearch_rs/numeric_range_tree/src/index.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/index.rs
@@ -17,7 +17,7 @@ use index_result::RSIndexResult;
 use inverted_index::{
     EntriesTrackingIndex, IndexReader, NumericReader, RawIndexReaderCore,
     debug::Summary,
-    numeric::{Numeric, NumericFloatCompression},
+    numeric::{Numeric, NumericEncoder, NumericFloatCompression, PreparedValue},
 };
 use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
@@ -45,17 +45,48 @@ impl NumericIndex {
         }
     }
 
-    /// Add a record to the index. Returns `(memory_growth, blocks_added)` — see
-    /// [`InvertedIndex::add_record`][inverted_index::InvertedIndex::add_record].
+    /// Ask this index's encoder how it will represent `value`.
+    ///
+    /// The returned [`PreparedValue`] carries both what a reader will decode
+    /// ([`PreparedValue::stored_value`], which is what statistics and routing must be
+    /// computed on) and the decision needed to write the entry — so the value is
+    /// classified once per add rather than once per question.
+    pub fn prepare(&self, value: f64) -> PreparedValue {
+        match self {
+            NumericIndex::Uncompressed(_) => Numeric::prepare(value),
+            NumericIndex::Compressed(_) => NumericFloatCompression::prepare(value),
+        }
+    }
+
+    /// [`Self::prepare`] for callers that hold the `compress_floats` flag rather than
+    /// an index — the tree prepares on the way in, before it has descended to the leaf
+    /// whose index will write the entry.
+    ///
+    /// Kept next to [`Self::new`] so the flag-to-encoder mapping lives in one place.
+    pub fn prepare_for(compress_floats: bool, value: f64) -> PreparedValue {
+        if compress_floats {
+            NumericFloatCompression::prepare(value)
+        } else {
+            Numeric::prepare(value)
+        }
+    }
+
+    /// Add an entry whose representation was already decided by [`Self::prepare`].
+    /// Returns `(memory_growth, blocks_added)` — see
+    /// [`InvertedIndex::add_prepared_record`][inverted_index::InvertedIndex::add_prepared_record].
     ///
     /// # Panics
     ///
     /// Panics if the underlying write fails. This should never happen with
     /// in-memory inverted indexes, so a panic indicates a bug.
-    pub fn add_record(&mut self, record: &RSIndexResult) -> inverted_index::AddRecordOutcome {
+    pub fn add_prepared_record(
+        &mut self,
+        doc_id: DocId,
+        prepared: PreparedValue,
+    ) -> inverted_index::AddRecordOutcome {
         let result = match self {
-            NumericIndex::Uncompressed(idx) => idx.add_record(record),
-            NumericIndex::Compressed(idx) => idx.add_record(record),
+            NumericIndex::Uncompressed(idx) => idx.add_prepared_record(doc_id, prepared),
+            NumericIndex::Compressed(idx) => idx.add_prepared_record(doc_id, prepared),
         };
         result.expect("in-memory inverted index write cannot fail")
     }

--- a/src/redisearch_rs/numeric_range_tree/src/lib.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/lib.rs
@@ -81,7 +81,7 @@ pub use index::{NumericIndex, NumericIndexReader, RawNumericIndexReader};
 pub use inverted_index::NumericFilter;
 pub use iter::{IndexedReversePreOrderDfsIterator, ReversePreOrderDfsIterator};
 pub use node::{InternalNode, LeafNode, NumericRangeNode};
-pub use range::NumericRange;
+pub use range::{GcSurvivorStats, Hll, NumericRange, ValueBounds};
 pub use tree::{
     AddResult, CompactIfSparseResult, NodeGcDelta, NumericRangeTree, SingleNodeGcResult,
     TrimEmptyLeavesResult,

--- a/src/redisearch_rs/numeric_range_tree/src/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/range.rs
@@ -16,20 +16,26 @@
 use hyperloglog::{HyperLogLog6, WyHasher};
 use index_result::RSIndexResult;
 use inverted_index::IndexReader as _;
+use inverted_index::numeric::{PreparedValue, StoredValue};
 use rqe_core::DocId;
 
 use crate::index::{NumericIndex, NumericIndexReader};
 
 /// Newtype around [`f64`] that hashes via native-endian bytes.
 ///
-/// Ensures HLL cardinality estimation uses a consistent raw bit representation,
-/// so `-0.0` and `+0.0` are distinct and no float comparison is involved.
+/// Ensures HLL cardinality estimation uses a consistent raw bit representation, so
+/// no float comparison is involved.
+///
+/// Only constructible from a [`StoredValue`]: cardinality has to count the values
+/// the index actually holds. Two inputs that the encoder maps onto the same stored
+/// value are one value here — including `-0.0` and `+0.0`, which every numeric
+/// encoder stores as `+0.0`.
 #[derive(Debug, Clone, Copy)]
 pub struct NumericValue(f64);
 
-impl From<f64> for NumericValue {
-    fn from(value: f64) -> Self {
-        Self(value)
+impl From<StoredValue> for NumericValue {
+    fn from(value: StoredValue) -> Self {
+        Self(value.get())
     }
 }
 
@@ -44,6 +50,161 @@ impl std::hash::Hash for NumericValue {
 /// See the [crate-level documentation](crate#cardinality-estimation) for details
 /// on precision, error rate, and memory usage.
 pub type Hll = HyperLogLog6<NumericValue, WyHasher>;
+
+/// The smallest and largest value observed over a set of numeric entries.
+///
+/// Starts inverted (`min = +∞`, `max = -∞`) so the first observed value sets both
+/// ends. An interval that never observed a value stays inverted, which is exactly
+/// the sentinel [`NumericRange`] uses for "no entries".
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ValueBounds {
+    min: f64,
+    max: f64,
+}
+
+impl ValueBounds {
+    /// Bounds that have observed no value at all.
+    pub const EMPTY: Self = Self {
+        min: f64::INFINITY,
+        max: f64::NEG_INFINITY,
+    };
+
+    /// Build bounds from a previously extracted `(min, max)` pair.
+    ///
+    /// Used when bounds are reconstructed from the GC pipe. Pass
+    /// [`Self::EMPTY`]'s components to denote "no value observed".
+    pub const fn from_min_max(min: f64, max: f64) -> Self {
+        Self { min, max }
+    }
+
+    /// Widen the bounds to include `value`.
+    ///
+    /// Takes a [`StoredValue`] because bounds exist to describe what queries will
+    /// read out of the index, which is the stored form rather than the input.
+    ///
+    /// `NaN` compares false against everything, so it never moves either end.
+    pub const fn observe(&mut self, value: StoredValue) {
+        let value = value.get();
+        if value < self.min {
+            self.min = value;
+        }
+        if value > self.max {
+            self.max = value;
+        }
+    }
+
+    /// Widen the bounds to include everything `other` observed.
+    ///
+    /// Merging [`Self::EMPTY`] is a no-op — its inverted ends must not be mistaken
+    /// for observed values.
+    pub const fn merge(&mut self, other: Self) {
+        if other.min < self.min {
+            self.min = other.min;
+        }
+        if other.max > self.max {
+            self.max = other.max;
+        }
+    }
+
+    /// The smallest observed value, or `f64::INFINITY` if none was observed.
+    pub const fn min(&self) -> f64 {
+        self.min
+    }
+
+    /// The largest observed value, or `f64::NEG_INFINITY` if none was observed.
+    pub const fn max(&self) -> f64 {
+        self.max
+    }
+}
+
+impl Default for ValueBounds {
+    fn default() -> Self {
+        Self::EMPTY
+    }
+}
+
+/// Per-range statistics recomputed over the surviving entries during a GC scan.
+///
+/// The GC child cannot mutate the parent's ranges, so it ships these numbers back
+/// over the pipe and the parent installs them via
+/// [`NumericRange::reset_stats_after_gc`]. Cardinality and bounds travel together
+/// because they are derived from the same pass over the surviving entries and must
+/// be applied together.
+#[derive(Debug, Clone, Copy)]
+pub struct GcSurvivorStats {
+    /// HyperLogLog registers covering the surviving entries.
+    pub registers: [u8; Hll::size()],
+    /// Value bounds covering the surviving entries.
+    pub bounds: ValueBounds,
+}
+
+impl GcSurvivorStats {
+    /// Statistics for a scan that observed no surviving entry.
+    pub const EMPTY: Self = Self {
+        registers: [0; Hll::size()],
+        bounds: ValueBounds::EMPTY,
+    };
+
+    /// Length of the byte string produced by [`Self::write_to`].
+    pub const WIRE_SIZE: usize = Hll::size() + 2 * size_of::<f64>();
+
+    /// Append the wire representation of these statistics to `buffer`.
+    ///
+    /// The GC child writes this into the pipe the parent reads from. Bounds use
+    /// native byte order: the only reader is the parent of the fork that produced
+    /// them, so both ends always agree on endianness.
+    pub fn write_to(&self, buffer: &mut Vec<u8>) {
+        buffer.extend_from_slice(&self.registers);
+        buffer.extend_from_slice(&self.bounds.min().to_ne_bytes());
+        buffer.extend_from_slice(&self.bounds.max().to_ne_bytes());
+    }
+
+    /// Rebuild statistics from the [`Self::write_to`] representation.
+    ///
+    /// Returns `None` unless `bytes` is exactly [`Self::WIRE_SIZE`] long. The values
+    /// themselves are trusted: they come from this process's own GC child.
+    pub fn read_from(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != Self::WIRE_SIZE {
+            return None;
+        }
+
+        let (registers, bounds) = bytes.split_at(Hll::size());
+        let (min, max) = bounds.split_at(size_of::<f64>());
+
+        let mut stats = Self {
+            registers: [0; Hll::size()],
+            bounds: ValueBounds::from_min_max(
+                f64::from_ne_bytes(min.try_into().expect("min is 8 bytes long")),
+                f64::from_ne_bytes(max.try_into().expect("max is 8 bytes long")),
+            ),
+        };
+        stats.registers.copy_from_slice(registers);
+        Some(stats)
+    }
+}
+
+impl Default for GcSurvivorStats {
+    fn default() -> Self {
+        Self::EMPTY
+    }
+}
+
+/// Whether a GC apply may tighten a range's value bounds.
+///
+/// GC entries are applied one node at a time, parents before children, with the
+/// spec lock released in between — so a node's bounds can only be tightened if
+/// nothing else depends on them describing more than that node's own entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GcBoundsUpdate {
+    /// Shrink the bounds to what the surviving entries need. Correct for leaf
+    /// ranges, whose bounds describe exactly their own entries.
+    Tighten,
+    /// Leave the bounds untouched. Used for the ranges retained on internal nodes:
+    /// those must stay a superset of their whole subtree, and the descendants are
+    /// applied *after* the ancestor, so tightening here would leave the tree
+    /// temporarily claiming an ancestor range narrower than its children.
+    Keep,
+}
 
 /// A numeric range is a leaf-level storage unit in the numeric range tree.
 ///
@@ -67,17 +228,18 @@ pub struct NumericRange {
     /// The minimum value stored in this range.
     /// Initialized to `f64::INFINITY` so any value will be smaller.
     ///
-    /// This is a monotone *lower bound*, not necessarily the smallest value the
-    /// range currently stores: it is lowered when a smaller value is added, but
-    /// never raised. GC removes entries without tightening it, so after the
-    /// documents holding the smallest value are collected it sits strictly below
-    /// every surviving value.
+    /// Lowered by [`Self::add_without_cardinality`] when a smaller value arrives and
+    /// raised by [`Self::reset_stats_after_gc`] when GC removes the entries that were
+    /// holding it. Always a valid *lower bound* on the values the range stores; only
+    /// exactly the smallest stored value if the last GC pass tightened it.
+    ///
+    /// Expressed in stored form, like every value that reaches a range, so it is
+    /// directly comparable with what a reader decodes.
     min_val: f64,
     /// The maximum value stored in this range.
     /// Initialized to `f64::NEG_INFINITY` so any value will be larger.
     ///
-    /// Monotone *upper bound*, with the same caveat as `min_val`: GC never
-    /// lowers it.
+    /// Upper bound, maintained symmetrically to [`Self::min_val`].
     max_val: f64,
     /// HyperLogLog for estimating the number of distinct values (cardinality).
     /// Used to decide when to split the range.
@@ -107,9 +269,14 @@ impl NumericRange {
     /// reporting how many bytes the inverted index grew by and how many new index blocks the
     /// write created.
     ///
+    /// Takes a [`PreparedValue`] — the encoder's decision, from
+    /// [`NumericIndex::prepare`] (or [`NumericIndex::prepare_for`]) — so the bounds
+    /// and the cardinality estimate describe what the index will return, and the
+    /// value is not classified again on the way to the index.
+    ///
     /// [`AddRecordOutcome`]: inverted_index::AddRecordOutcome
-    pub fn add(&mut self, doc_id: DocId, value: f64) -> inverted_index::AddRecordOutcome {
-        self.hll.add(&value.into());
+    pub fn add(&mut self, doc_id: DocId, value: PreparedValue) -> inverted_index::AddRecordOutcome {
+        self.hll.add(&value.stored_value().into());
         self.add_without_cardinality(doc_id, value)
     }
 
@@ -128,19 +295,20 @@ impl NumericRange {
     pub fn add_without_cardinality(
         &mut self,
         doc_id: DocId,
-        value: f64,
+        value: PreparedValue,
     ) -> inverted_index::AddRecordOutcome {
-        // Update bounds
-        if value < self.min_val {
-            self.min_val = value;
+        let stored = value.stored_value().get();
+
+        // Update bounds. These are the values a reader will decode, since they come
+        // from the representation the index is about to write.
+        if stored < self.min_val {
+            self.min_val = stored;
         }
-        if value > self.max_val {
-            self.max_val = value;
+        if stored > self.max_val {
+            self.max_val = stored;
         }
 
-        // Add to inverted index
-        let record = RSIndexResult::build_numeric(value).doc_id(doc_id).build();
-        self.entries.add_record(&record)
+        self.entries.add_prepared_record(doc_id, value)
     }
 
     /// Get the estimated cardinality (number of distinct values).
@@ -205,57 +373,93 @@ impl NumericRange {
         &self.hll
     }
 
-    /// Reset the HLL cardinality after garbage collection.
+    /// Reset the cardinality estimate and the value bounds after garbage collection.
     ///
-    /// This sets the HLL registers from GC scan results and re-adds entries
-    /// from blocks that were added since the fork.
+    /// The GC child recomputed both over the entries that survived its scan. This
+    /// installs those numbers, then rescans the blocks the scan could not account
+    /// for — blocks the parent appended after the fork, plus the last block when the
+    /// apply step had to ignore it — so that neither statistic misses an entry that
+    /// is still in the index.
+    ///
+    /// # Bounds only tighten
+    ///
+    /// Adds and scans both observe values in stored form, so the recomputed interval
+    /// is always contained in the one the range already reported. That is an
+    /// invariant, not something this routine has to enforce — it is asserted below so
+    /// a future divergence between the two shows up here rather than as a range that
+    /// silently stops covering its own entries.
+    ///
+    /// Pass [`GcBoundsUpdate::Keep`] to skip the bounds update entirely; see that
+    /// variant's documentation for when that is required.
     ///
     /// # Arguments
     ///
-    /// * `ignored_last_block` - Whether the last block was ignored during GC scan (from `GcApplyInfo`)
+    /// * `ignored_last_block` - Whether the last block was ignored during the GC apply (from `GcApplyInfo`)
     /// * `blocks_since_fork` - Number of new blocks added since the fork
-    /// * `registers_with_last_block` - HLL registers including the last block's cardinality
-    /// * `registers_without_last_block` - HLL registers excluding the last block's cardinality
-    pub(crate) fn reset_cardinality_after_gc(
+    /// * `with_last_block` - Survivor statistics including the last scanned block
+    /// * `without_last_block` - Survivor statistics excluding the last scanned block
+    /// * `bounds_update` - Whether the value bounds may be tightened
+    pub(crate) fn reset_stats_after_gc(
         &mut self,
         ignored_last_block: bool,
         blocks_since_fork: usize,
-        registers_with_last_block: &[u8; Hll::size()],
-        registers_without_last_block: &[u8; Hll::size()],
+        with_last_block: &GcSurvivorStats,
+        without_last_block: &GcSurvivorStats,
+        bounds_update: GcBoundsUpdate,
     ) {
         let mut blocks_to_rescan = blocks_since_fork;
 
-        if ignored_last_block {
-            self.hll.set_registers(*registers_without_last_block);
+        let mut bounds = if ignored_last_block {
+            self.hll.set_registers(without_last_block.registers);
             blocks_to_rescan += 1; // The last block was ignored, so re-add it too
+            without_last_block.bounds
         } else {
-            self.hll.set_registers(*registers_with_last_block);
-            if blocks_to_rescan == 0 {
-                return; // No new blocks since fork, we're done
+            self.hll.set_registers(with_last_block.registers);
+            with_last_block.bounds
+        };
+
+        if blocks_to_rescan > 0 {
+            // Get the starting point for the update - iterate entries added since fork
+            let num_blocks = self.entries.num_blocks();
+            debug_assert!(
+                blocks_to_rescan <= num_blocks,
+                "The number of blocks should never decrease in between two GC runs, \
+                therefore the number of blocks to rescan can never be greater than the current number of blocks"
+            );
+            let start_idx = num_blocks - blocks_to_rescan;
+
+            if let Some(start_id) = self.entries.block_first_id(start_idx) {
+                // Iterate entries added since fork and fold them into the cardinality
+                // estimation and the bounds.
+                let mut reader = self.entries.reader();
+                reader.skip_to(start_id);
+                let mut result = RSIndexResult::build_numeric(0.0).build();
+                while reader.next_record(&mut result).unwrap_or(false) {
+                    // SAFETY: We know the result contains numeric data
+                    let value = unsafe { result.as_numeric_unchecked() };
+                    // Read back out of the index, so already in stored form.
+                    let value = StoredValue::from_decoded(value);
+                    self.hll.add(&value.into());
+                    bounds.observe(value);
+                }
             }
         }
 
-        // Get the starting point for HLL update - iterate entries added since fork
-        let num_blocks = self.entries.num_blocks();
-        debug_assert!(
-            blocks_to_rescan <= num_blocks,
-            "The number of blocks should never decrease in between two GC runs, \
-            therefore the number of blocks to rescan can never be greater than the current number of blocks"
-        );
-        let start_idx = num_blocks - blocks_to_rescan;
-        let Some(start_id) = self.entries.block_first_id(start_idx) else {
-            return;
-        };
+        if bounds_update == GcBoundsUpdate::Tighten {
+            // See "Bounds only tighten" above. An empty interval (nothing survived) is
+            // inverted, so it trivially satisfies both comparisons.
+            debug_assert!(
+                bounds.min() >= self.min_val && bounds.max() <= self.max_val,
+                "recomputed bounds [{}, {}] must be contained in the reported bounds [{}, {}] — \
+                 both are observed in stored form",
+                bounds.min(),
+                bounds.max(),
+                self.min_val,
+                self.max_val,
+            );
 
-        // Iterate entries added since fork and update the cardinality estimation
-        // via HLL.
-        let mut reader = self.entries.reader();
-        reader.skip_to(start_id);
-        let mut result = RSIndexResult::build_numeric(0.0).build();
-        while reader.next_record(&mut result).unwrap_or(false) {
-            // SAFETY: We know the result contains numeric data
-            let value = unsafe { result.as_numeric_unchecked() };
-            self.hll.add(&value.into());
+            self.min_val = bounds.min();
+            self.max_val = bounds.max();
         }
     }
 }

--- a/src/redisearch_rs/numeric_range_tree/src/test_utils.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/test_utils.rs
@@ -12,7 +12,6 @@
 //! Gated behind the `test_utils` feature so that production builds do not
 //! include these utilities.
 
-use index_result::RSIndexResult;
 use inverted_index::{Encoder, numeric::Numeric};
 
 use crate::{NodeGcDelta, NodeIndex, NumericRangeNode, NumericRangeTree};
@@ -114,6 +113,10 @@ pub fn build_tree_at_split_edge() -> (NumericRangeTree, u64) {
 ///
 /// Uses zeroed HLL registers. For accurate HLL values, use
 /// [`NumericRangeNode::scan_gc`] directly or [`scan_node_delta_with_hll`].
+///
+/// The recomputed value bounds are always accurate — a delta carrying empty bounds
+/// would tell the parent that nothing survived, which is a different scenario from
+/// "cardinality was not computed".
 pub fn scan_node_delta(
     tree: &NumericRangeTree,
     node_idx: NodeIndex,
@@ -129,30 +132,11 @@ pub fn scan_node_delta_with_hll(
     doc_exist: &dyn Fn(u64) -> bool,
     hll_fn: impl Fn(&inverted_index::GcScanDelta) -> ([u8; 64], [u8; 64]),
 ) -> Option<NodeGcDelta> {
-    let node = tree.node(node_idx);
-    node.range()
-        .and_then(|range| -> Option<inverted_index::GcScanDelta> {
-            range
-                .entries()
-                .scan_gc(
-                    doc_exist,
-                    None::<
-                        for<'index> fn(
-                            &RSIndexResult<'index>,
-                            &inverted_index::RepairContext<'index>,
-                        ),
-                    >,
-                )
-                .expect("scan_gc should not fail")
-        })
-        .map(|delta| {
-            let (hll_with, hll_without) = hll_fn(&delta);
-            NodeGcDelta {
-                delta,
-                registers_with_last_block: hll_with,
-                registers_without_last_block: hll_without,
-            }
-        })
+    let mut delta = tree.node(node_idx).scan_gc(doc_exist)?;
+    let (hll_with, hll_without) = hll_fn(&delta.delta);
+    delta.with_last_block.registers = hll_with;
+    delta.without_last_block.registers = hll_without;
+    Some(delta)
 }
 
 /// Scan all nodes in the tree and collect GC deltas for nodes that have work.

--- a/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
@@ -17,26 +17,33 @@ use rqe_core::DocId;
 use std::collections::HashMap;
 
 use index_result::RSIndexResult;
+use inverted_index::numeric::StoredValue;
 use inverted_index::{GcApplyInfo, GcScanDelta};
 
 use super::{NumericRangeTree, TrimEmptyLeavesResult};
 use crate::NumericRangeNode;
 use crate::arena::{NodeArena, NodeIndex};
-use crate::range::Hll;
+use crate::range::{GcBoundsUpdate, GcSurvivorStats, Hll, ValueBounds};
 
 /// GC delta data for a single node, as computed by the child process.
 ///
-/// Contains the inverted index GC delta plus the HyperLogLog registers
-/// captured during the scan. One `NodeGcDelta` is produced per DFS node
-/// that had GC work.
+/// Contains the inverted index GC delta plus the per-range statistics
+/// ([`GcSurvivorStats`]: cardinality registers and value bounds) recomputed over
+/// the surviving entries. One `NodeGcDelta` is produced per DFS node that had GC
+/// work.
+///
+/// The statistics come in two flavours because the parent may have appended to the
+/// last block after the fork, in which case the apply step ignores that block's
+/// repair and the parent rescans it instead — see
+/// [`NumericRange::reset_stats_after_gc`][crate::NumericRange::reset_stats_after_gc].
 #[derive(Debug)]
 pub struct NodeGcDelta {
     /// The inverted index GC scan delta.
     pub delta: GcScanDelta,
-    /// HLL registers including the last scanned block's cardinality.
-    pub registers_with_last_block: [u8; Hll::size()],
-    /// HLL registers excluding the last scanned block's cardinality.
-    pub registers_without_last_block: [u8; Hll::size()],
+    /// Survivor statistics including the last scanned block.
+    pub with_last_block: GcSurvivorStats,
+    /// Survivor statistics excluding the last scanned block.
+    pub without_last_block: GcSurvivorStats,
 }
 
 /// Result of applying GC to a single node.
@@ -71,8 +78,12 @@ pub struct CompactIfSparseResult {
 impl NumericRangeNode {
     /// Scan a single node's inverted index for GC work.
     ///
-    /// Scan the inverted index associated with its range for deleted
-    /// documents, and computes HLL registers for cardinality re-estimation.
+    /// Scan the inverted index associated with its range for deleted documents, and
+    /// recompute the cardinality registers and the value bounds over the entries that
+    /// survive the scan.
+    ///
+    /// The scan visits every block, so the recomputed statistics cover the whole
+    /// index — not just the blocks that need repairing.
     ///
     /// Returns `Some(NodeGcDelta)` if the node had GC work, `None` otherwise
     /// (either the node has no range, or no documents were deleted).
@@ -80,27 +91,32 @@ impl NumericRangeNode {
         let range = self.range()?;
 
         // The logical index of the last block — used inside the repair closure to route
-        // each entry's HLL contribution into the correct accumulator. Comparing by
+        // each entry's contribution into the correct accumulator. Comparing by
         // logical index instead of pointer equality is robust to future changes that
         // produce blocks via owned snapshots (where block addresses can shift).
         let last_block_idx = range.entries().num_blocks().saturating_sub(1);
 
-        // HLL tracking for cardinality (re)estimation.
+        // Cardinality and bounds tracking, split so that the parent can drop the last
+        // block's contribution if it turns out to have changed since the fork.
         //
-        // `majority_hll` accumulates all blocks except the last one.
-        // `last_block_hll` accumulates only the last block.
+        // The `majority_*` accumulators cover all blocks except the last one.
+        // The `last_block_*` accumulators cover only the last block.
         let mut majority_hll = Hll::new();
         let mut last_block_hll = Hll::new();
+        let mut majority_bounds = ValueBounds::EMPTY;
+        let mut last_block_bounds = ValueBounds::EMPTY;
 
         let mut repair_fn = |res: &RSIndexResult, ctx: &inverted_index::RepairContext<'_>| {
             // SAFETY: We know this is a numeric index result
-            let value = unsafe { res.as_numeric_unchecked() };
-            let target = if ctx.block_idx == last_block_idx {
-                &mut last_block_hll
+            // Scanned straight out of the index, so already in stored form.
+            let value = StoredValue::from_decoded(unsafe { res.as_numeric_unchecked() });
+            let (hll, bounds) = if ctx.block_idx == last_block_idx {
+                (&mut last_block_hll, &mut last_block_bounds)
             } else {
-                &mut majority_hll
+                (&mut majority_hll, &mut majority_bounds)
             };
-            target.add(&value.into());
+            hll.add(&value.into());
+            bounds.observe(value);
         };
 
         let delta = range
@@ -109,13 +125,21 @@ impl NumericRangeNode {
             .ok()
             .flatten()?;
 
-        // Merge majority into last_block to get "with last block" registers.
+        // Merge majority into last_block to get the "with last block" statistics.
         last_block_hll.merge(&majority_hll);
+        let mut with_last_block_bounds = last_block_bounds;
+        with_last_block_bounds.merge(majority_bounds);
 
         Some(NodeGcDelta {
             delta,
-            registers_with_last_block: *last_block_hll.registers(),
-            registers_without_last_block: *majority_hll.registers(),
+            with_last_block: GcSurvivorStats {
+                registers: *last_block_hll.registers(),
+                bounds: with_last_block_bounds,
+            },
+            without_last_block: GcSurvivorStats {
+                registers: *majority_hll.registers(),
+                bounds: majority_bounds,
+            },
         })
     }
 }
@@ -124,8 +148,9 @@ impl NumericRangeTree {
     /// Apply a GC delta to a single node by index.
     ///
     /// Looks up the node in the arena, applies the delta to its range's
-    /// inverted index, resets cardinality via HLL, and updates tree-level
-    /// stats (`num_entries`, `inverted_indexes_size`, `empty_leaves`).
+    /// inverted index, reinstalls the range's cardinality estimate and value
+    /// bounds, and updates tree-level stats (`num_entries`,
+    /// `inverted_indexes_size`, `empty_leaves`).
     ///
     /// Returns per-node GC statistics, if there is a node with the given index.
     /// Returns `None` if there isn't one.
@@ -154,12 +179,21 @@ impl NumericRangeTree {
         // Apply GC delta to the index.
         let info: GcApplyInfo = range.entries_mut().apply_gc(delta.delta);
 
-        // Reset cardinality with proper HLL recalculation.
-        range.reset_cardinality_after_gc(
+        // Reinstall the cardinality estimate and — for leaves — the value bounds the
+        // child recomputed over the surviving entries. Ranges retained on internal
+        // nodes keep their bounds: they must stay a superset of the whole subtree,
+        // and this routine is called on an ancestor before its descendants.
+        let bounds_update = if is_leaf {
+            GcBoundsUpdate::Tighten
+        } else {
+            GcBoundsUpdate::Keep
+        };
+        range.reset_stats_after_gc(
             info.ignored_last_block,
             n_new_blocks_since_fork,
-            &delta.registers_with_last_block,
-            &delta.registers_without_last_block,
+            &delta.with_last_block,
+            &delta.without_last_block,
+            bounds_update,
         );
 
         // Track empty ranges (only count leaves, and only on transition to empty).

--- a/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
@@ -17,9 +17,11 @@ use index_result::RSIndexResult;
 use inverted_index::IndexReader as _;
 use rqe_core::DocId;
 
+use inverted_index::numeric::PreparedValue;
+
 use super::{AddResult, CheckedCount, NumericRangeTree};
 use crate::arena::{NodeArena, NodeIndex};
-use crate::{InternalNode, NumericRange, NumericRangeNode};
+use crate::{InternalNode, NumericIndex, NumericRange, NumericRangeNode};
 
 impl NumericRangeTree {
     /// Last depth level that does NOT use the maximum split cardinality.
@@ -102,6 +104,15 @@ impl NumericRangeTree {
         }
         self.last_doc_id = doc_id;
 
+        // The one place the encoder's lossy step is applied. Everything below —
+        // routing, bounds, cardinality, split medians — works on the value the index
+        // will actually return, so none of it can disagree with storage. The decision
+        // travels with the value, so the leaf writes it without classifying again.
+        //
+        // Prepared with this tree's own flag, never the global config: the config is
+        // settable at runtime, while a tree keeps the flag it was created with.
+        let value = NumericIndex::prepare_for(self.compress_floats, value);
+
         let rv = Self::node_add(
             &mut self.nodes,
             self.root,
@@ -159,7 +170,7 @@ impl NumericRangeTree {
         nodes: &mut NodeArena,
         node_idx: NodeIndex,
         doc_id: DocId,
-        value: f64,
+        value: PreparedValue,
         depth: usize,
         max_depth_range: usize,
         compress_floats: bool,
@@ -171,7 +182,9 @@ impl NumericRangeTree {
                 let NumericRangeNode::Internal(internal) = &nodes[node_idx] else {
                     unreachable!()
                 };
-                let child_idx = if value < internal.value {
+                // `internal.value` is a threshold, not a stored value — it can be
+                // `next_up` of one — so the comparison unwraps rather than lifting it.
+                let child_idx = if value.stored_value().get() < internal.value {
                     internal.left_index()
                 } else {
                     internal.right_index()
@@ -278,10 +291,9 @@ impl NumericRangeTree {
     /// are identical—the median would equal the minimum, and without adjustment
     /// all entries would go to the right child, leaving the left empty.
     ///
-    /// The adjustment only fires when the range's `min_val` bound matches the
-    /// smallest value the range actually stores. That is not always the case, so
-    /// a split can still leave one child empty—see the comment on `newly_empty`
-    /// below.
+    /// The adjustment relies on `min_val` matching the smallest value the range
+    /// actually stores, which holds because values are quantized before they reach a
+    /// range and GC recomputes the bounds over the surviving entries.
     ///
     /// # Note
     ///
@@ -331,7 +343,11 @@ impl NumericRangeTree {
         while reader.next_record(&mut result).unwrap_or(false) {
             // SAFETY: We know the result contains numeric data
             let entry_value = unsafe { result.as_numeric_unchecked() };
-            let target_idx = if entry_value < split {
+            // Redistributed entries come straight back out of the parent's index, so
+            // they are already in stored form — preparing one is idempotent, and the
+            // child needs the decision to write the entry.
+            let entry_value = NumericIndex::prepare_for(compress_floats, entry_value);
+            let target_idx = if entry_value.stored_value().get() < split {
                 left_idx
             } else {
                 right_idx
@@ -346,30 +362,28 @@ impl NumericRangeTree {
         }
         drop(result);
 
-        // A split can leave a child leaf empty whenever every entry falls on the
-        // same side of `split`. Two known ways to get there:
+        // A split strands an empty child leaf whenever every entry falls on the same
+        // side of `split`. That should now be unreachable: the leaf's statistics are
+        // exact, so a split implies at least two distinct stored values, and the
+        // `split == min_val` adjustment above guarantees the smallest of them goes
+        // left while something larger goes right.
         //
-        // 1. Float compression collapses every stored value to the same f32. The
-        //    median then equals `min_val`, the split point becomes `next_up(min)`,
-        //    and every entry lands in the *left* child.
-        // 2. `min_val` is stale. GC removes entries from a range but never raises
-        //    its bounds, so once the documents holding the smallest value are
-        //    collected, `min_val` sits below every surviving value. If a majority
-        //    of the survivors share the smallest surviving value, that value is the
-        //    median, the `split == min_val` guard above does not fire, and every
-        //    entry lands in the *right* child.
+        // It was reachable while cardinality was estimated over pre-encoding values
+        // (MOD-16877): a leaf of values that all collapsed to the same stored f32
+        // looked high-cardinality, split, and sent every entry one way. Values are
+        // quantized on the way in now, so that leaf never splits.
         //
-        // Such an empty leaf must be reflected in `empty_leaves`, otherwise a
-        // later add routed to it would decrement the counter below zero. The
-        // parent had >= 1 entry (we split only after adding), so at most one of
-        // the two new children can be empty.
+        // The accounting stays as a self-correcting net — an uncounted empty leaf
+        // underflows `empty_leaves` on the next add routed to it, which aborts the
+        // process across the non-unwinding FFI boundary. Two `num_docs()` reads per
+        // split is a cheap price for turning that into a no-op.
         let newly_empty = [left_idx, right_idx]
             .into_iter()
             .filter(|&i| nodes[i].range().is_some_and(|r| r.num_docs() == 0))
             .count();
-        debug_assert!(
-            newly_empty <= 1,
-            "a non-empty parent must yield at least one non-empty child"
+        debug_assert_eq!(
+            newly_empty, 0,
+            "exact per-leaf statistics should leave both children of a split non-empty"
         );
         *empty_leaves += newly_empty;
 
@@ -388,6 +402,9 @@ impl NumericRangeTree {
     }
 
     /// Compute the median value from a range's entries.
+    ///
+    /// Returns a plain `f64`: the median is a comparison threshold from here on, and
+    /// may be adjusted with `next_up` into a value no entry holds.
     fn compute_median(range: &NumericRange) -> f64 {
         let num_entries = range.num_entries();
         if num_entries == 0 {

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/gc.rs
@@ -301,6 +301,165 @@ fn hll_cardinality_is_recomputed_correctly_when_last_block_fully_emptied(
 }
 
 // ============================================================================
+// Value bounds recomputation
+// ============================================================================
+
+#[rstest]
+fn gc_tightens_leaf_bounds(#[values(false, true)] compress_floats: bool) {
+    // Values are powers of two so float compression stores them losslessly and the
+    // assertions can compare exactly.
+    let mut tree = NumericRangeTree::new(compress_floats);
+    for (doc_id, value) in [(1, 8.0), (2, 16.0), (3, 32.0), (4, 64.0)] {
+        tree.add(doc_id, value, false, 0);
+    }
+    let range = tree.root().range().unwrap();
+    assert_eq!((range.min_val(), range.max_val()), (8.0, 64.0));
+
+    // Delete the documents holding both extremes.
+    gc_all_ranges(&mut tree, &|doc_id| doc_id == 2 || doc_id == 3);
+
+    let range = tree.root().range().unwrap();
+    assert_eq!(
+        (range.min_val(), range.max_val()),
+        (16.0, 32.0),
+        "bounds should shrink to the surviving values"
+    );
+}
+
+#[rstest]
+fn gc_emptying_a_leaf_resets_its_bounds(#[values(false, true)] compress_floats: bool) {
+    let mut tree = NumericRangeTree::new(compress_floats);
+    for doc_id in 1..=10 {
+        tree.add(doc_id, 42.0, false, 0);
+    }
+
+    // Delete every document.
+    gc_all_ranges(&mut tree, &|_| false);
+
+    let range = tree.root().range().unwrap();
+    assert_eq!(range.num_docs(), 0);
+    assert_eq!(
+        (range.min_val(), range.max_val()),
+        (f64::INFINITY, f64::NEG_INFINITY),
+        "an emptied range should be back to the inverted bounds of a fresh range"
+    );
+    assert!(
+        !range.overlaps(0.0, 100.0),
+        "an emptied range should no longer overlap the filter its old bounds matched"
+    );
+    assert_eq!(tree.empty_leaves(), 1);
+}
+
+#[test]
+fn gc_keeps_the_bounds_of_ranges_retained_on_internal_nodes() {
+    // Ranges retained on internal nodes must stay a superset of their subtree.
+    // Entries are applied ancestor-first, so tightening them would transiently
+    // publish an ancestor range narrower than its own children.
+    let n = SPLIT_TRIGGER * 2;
+    let mut tree = build_tree(n, false, 2);
+
+    let retained_before: Vec<_> = tree
+        .indexed_iter()
+        .filter(|(_, node)| !node.is_leaf())
+        .filter_map(|(idx, node)| node.range().map(|r| (idx, r.min_val(), r.max_val())))
+        .collect();
+    assert!(
+        !retained_before.is_empty(),
+        "max_depth_range=2 should retain at least one internal range"
+    );
+
+    // Delete the lower half of the documents — the smallest values go away.
+    gc_all_ranges(&mut tree, &|doc_id| doc_id > n / 2);
+
+    for (idx, min_before, max_before) in retained_before {
+        let range = tree
+            .node(idx)
+            .range()
+            .expect("GC should not drop a retained range");
+        assert_eq!(
+            (range.min_val(), range.max_val()),
+            (min_before, max_before),
+            "the range retained on internal node {idx:?} should keep its bounds"
+        );
+    }
+}
+
+#[rstest]
+fn gc_bounds_cover_entries_written_to_new_blocks_after_the_fork(
+    #[values(false, true)] compress_floats: bool,
+) {
+    // Two full blocks, so post-scan writes start a new block and leave the scanned
+    // last block untouched — the `blocks_since_fork` rescan path.
+    let n = ENTRIES_PER_BLOCK * 2;
+    let mut tree = NumericRangeTree::new(compress_floats);
+    for doc_id in 1..=n {
+        tree.add(doc_id, 42.0, false, 0);
+    }
+
+    let delta = scan_node_delta(&tree, tree.root_index(), &|doc_id| {
+        doc_id > ENTRIES_PER_BLOCK
+    })
+    .expect("should have GC work");
+
+    // Parent writes after the fork, outside the surviving range on both ends.
+    tree.add(n + 1, 4.0, false, 0);
+    tree.add(n + 2, 128.0, false, 0);
+
+    let result = tree.apply_gc_to_node(tree.root_index(), delta).unwrap();
+    assert!(
+        !result.index_gc_info.ignored_last_block,
+        "the scanned last block was full, so post-fork writes went to a new block"
+    );
+
+    let range = tree.root().range().unwrap();
+    assert_eq!(
+        (range.min_val(), range.max_val()),
+        (4.0, 128.0),
+        "bounds must cover the entries the scan never saw"
+    );
+}
+
+#[rstest]
+fn gc_bounds_cover_an_ignored_last_block(#[values(false, true)] compress_floats: bool) {
+    // Block 0 (full): 42.0. Block 1 (partial): 64.0, except its final document,
+    // which holds the largest value in the range.
+    let partial = ENTRIES_PER_BLOCK / 2;
+    let n = ENTRIES_PER_BLOCK + partial;
+    let mut tree = NumericRangeTree::new(compress_floats);
+    for doc_id in 1..=n {
+        let value = if doc_id <= ENTRIES_PER_BLOCK {
+            42.0
+        } else if doc_id == n {
+            1024.0
+        } else {
+            64.0
+        };
+        tree.add(doc_id, value, false, 0);
+    }
+
+    // Delete only the document holding 1024.0, which lives in the last block.
+    let delta = scan_node_delta(&tree, tree.root_index(), &|doc_id| doc_id != n)
+        .expect("should have GC work");
+
+    // A post-scan write into the same (partial) block makes the apply step ignore
+    // that block's repair, so the 1024.0 entry stays in the index.
+    tree.add(n + 1, 64.0, false, 0);
+
+    let result = tree.apply_gc_to_node(tree.root_index(), delta).unwrap();
+    assert!(
+        result.index_gc_info.ignored_last_block,
+        "the last block changed after the scan, so its repair must be ignored"
+    );
+
+    let range = tree.root().range().unwrap();
+    assert_eq!(
+        (range.min_val(), range.max_val()),
+        (42.0, 1024.0),
+        "bounds must still cover the entry whose repair was ignored"
+    );
+}
+
+// ============================================================================
 // GC repopulation and intensive delete tests
 // ============================================================================
 
@@ -455,8 +614,8 @@ fn gc_on_node_without_range() {
             tree.root_index(),
             NodeGcDelta {
                 delta: delta.delta,
-                registers_with_last_block: delta.registers_with_last_block,
-                registers_without_last_block: delta.registers_without_last_block,
+                with_last_block: delta.with_last_block,
+                without_last_block: delta.without_last_block,
             },
         )
         .unwrap();

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/range.rs
@@ -9,7 +9,21 @@
 
 //! Tests for NumericRange.
 
-use numeric_range_tree::NumericRange;
+use inverted_index::numeric::{PreparedValue, StoredValue};
+use numeric_range_tree::{GcSurvivorStats, NumericIndex, NumericRange, ValueBounds};
+use rstest::rstest;
+
+/// Ask an uncompressed encoder how it will represent `value` — the form
+/// [`NumericRange::add`] takes, so that bounds and cardinality describe what the
+/// index will return.
+fn prepared(value: f64) -> PreparedValue {
+    NumericIndex::prepare_for(false, value)
+}
+
+/// The value an uncompressed range will store for `value`, for [`ValueBounds`].
+fn stored(value: f64) -> StoredValue {
+    prepared(value).stored_value()
+}
 
 #[test]
 fn test_new_range_bounds() {
@@ -24,15 +38,15 @@ fn test_new_range_bounds() {
 fn test_add_updates_bounds() {
     let mut range = NumericRange::new(false);
 
-    range.add(1, 5.0);
+    range.add(1, prepared(5.0));
     assert_eq!(range.min_val(), 5.0);
     assert_eq!(range.max_val(), 5.0);
 
-    range.add(2, 10.0);
+    range.add(2, prepared(10.0));
     assert_eq!(range.min_val(), 5.0);
     assert_eq!(range.max_val(), 10.0);
 
-    range.add(3, 2.0);
+    range.add(3, prepared(2.0));
     assert_eq!(range.min_val(), 2.0);
     assert_eq!(range.max_val(), 10.0);
 }
@@ -41,9 +55,9 @@ fn test_add_updates_bounds() {
 fn test_add_updates_cardinality() {
     let mut range = NumericRange::new(false);
 
-    range.add(1, 1.0);
-    range.add(2, 2.0);
-    range.add(3, 3.0);
+    range.add(1, prepared(1.0));
+    range.add(2, prepared(2.0));
+    range.add(3, prepared(3.0));
 
     // HLL gives approximate count, but for small counts it should be reasonably accurate
     let card = range.cardinality();
@@ -56,8 +70,8 @@ fn test_add_updates_cardinality() {
 #[test]
 fn test_contained_in() {
     let mut range = NumericRange::new(false);
-    range.add(1, 5.0);
-    range.add(2, 10.0);
+    range.add(1, prepared(5.0));
+    range.add(2, prepared(10.0));
 
     // Range [5, 10] is contained in [0, 20]
     assert!(range.contained_in(0.0, 20.0));
@@ -72,8 +86,8 @@ fn test_contained_in() {
 #[test]
 fn test_overlaps() {
     let mut range = NumericRange::new(false);
-    range.add(1, 5.0);
-    range.add(2, 10.0);
+    range.add(1, prepared(5.0));
+    range.add(2, prepared(10.0));
 
     // Overlapping cases
     assert!(range.overlaps(0.0, 6.0)); // left overlap
@@ -100,9 +114,9 @@ fn test_add_without_cardinality() {
     let mut range = NumericRange::new(false);
 
     // Add entries without updating cardinality
-    range.add_without_cardinality(1, 5.0);
-    range.add_without_cardinality(2, 10.0);
-    range.add_without_cardinality(3, 2.0);
+    range.add_without_cardinality(1, prepared(5.0));
+    range.add_without_cardinality(2, prepared(10.0));
+    range.add_without_cardinality(3, prepared(2.0));
 
     // Bounds should be updated
     assert_eq!(range.min_val(), 2.0);
@@ -119,11 +133,11 @@ fn test_add_without_cardinality_vs_add() {
     let mut range_without_card = NumericRange::new(false);
 
     // Add same values to both
-    range_with_card.add(1, 5.0);
-    range_with_card.add(2, 10.0);
+    range_with_card.add(1, prepared(5.0));
+    range_with_card.add(2, prepared(10.0));
 
-    range_without_card.add_without_cardinality(1, 5.0);
-    range_without_card.add_without_cardinality(2, 10.0);
+    range_without_card.add_without_cardinality(1, prepared(5.0));
+    range_without_card.add_without_cardinality(2, prepared(10.0));
 
     // Bounds should be the same
     assert_eq!(range_with_card.min_val(), range_without_card.min_val());
@@ -143,13 +157,13 @@ fn test_num_docs() {
     let mut range = NumericRange::new(false);
     assert_eq!(range.num_docs(), 0);
 
-    range.add(1, 5.0);
+    range.add(1, prepared(5.0));
     assert_eq!(range.num_docs(), 1);
 
-    range.add(2, 10.0);
+    range.add(2, prepared(10.0));
     assert_eq!(range.num_docs(), 2);
 
-    range.add(3, 15.0);
+    range.add(3, prepared(15.0));
     assert_eq!(range.num_docs(), 3);
 }
 
@@ -158,8 +172,8 @@ fn test_entries_accessor() {
     use numeric_range_tree::NumericIndex;
 
     let mut range = NumericRange::new(false);
-    range.add(1, 5.0);
-    range.add(2, 10.0);
+    range.add(1, prepared(5.0));
+    range.add(2, prepared(10.0));
 
     let entries = range.entries();
     match entries {
@@ -177,9 +191,9 @@ fn test_entries_accessor() {
 #[test]
 fn test_hll_accessor() {
     let mut range = NumericRange::new(false);
-    range.add(1, 5.0);
-    range.add(2, 10.0);
-    range.add(3, 15.0);
+    range.add(1, prepared(5.0));
+    range.add(2, prepared(10.0));
+    range.add(3, prepared(15.0));
 
     let hll = range.hll();
     // HLL count should approximate the number of distinct values
@@ -195,11 +209,151 @@ fn test_inverted_index_size() {
     let mut range = NumericRange::new(false);
     let initial_size = range.memory_usage();
 
-    range.add(1, 5.0);
+    range.add(1, prepared(5.0));
     let size_after_one = range.memory_usage();
     assert!(size_after_one >= initial_size);
 
-    range.add(2, 10.0);
+    range.add(2, prepared(10.0));
     let size_after_two = range.memory_usage();
     assert!(size_after_two >= size_after_one);
+}
+
+// ============================================================================
+// ValueBounds / GcSurvivorStats
+// ============================================================================
+
+#[test]
+fn test_value_bounds_observe_and_merge() {
+    let mut bounds = ValueBounds::EMPTY;
+    assert_eq!(bounds.min(), f64::INFINITY);
+    assert_eq!(bounds.max(), f64::NEG_INFINITY);
+
+    bounds.observe(stored(5.0));
+    assert_eq!((bounds.min(), bounds.max()), (5.0, 5.0));
+    bounds.observe(stored(-2.0));
+    bounds.observe(stored(7.0));
+    assert_eq!((bounds.min(), bounds.max()), (-2.0, 7.0));
+
+    // NaN never moves either end.
+    bounds.observe(stored(f64::NAN));
+    assert_eq!((bounds.min(), bounds.max()), (-2.0, 7.0));
+
+    // Merging empty bounds must not drag the ends out to the inverted sentinels.
+    bounds.merge(ValueBounds::EMPTY);
+    assert_eq!((bounds.min(), bounds.max()), (-2.0, 7.0));
+
+    let mut other = ValueBounds::EMPTY;
+    other.observe(stored(-10.0));
+    other.observe(stored(3.0));
+    bounds.merge(other);
+    assert_eq!((bounds.min(), bounds.max()), (-10.0, 7.0));
+
+    // Merging into empty bounds adopts the other interval.
+    let mut empty = ValueBounds::EMPTY;
+    empty.merge(bounds);
+    assert_eq!((empty.min(), empty.max()), (-10.0, 7.0));
+}
+
+#[test]
+fn test_gc_survivor_stats_wire_round_trip() {
+    let mut bounds = ValueBounds::EMPTY;
+    bounds.observe(stored(-1.5));
+    bounds.observe(stored(1024.25));
+    let stats = GcSurvivorStats {
+        registers: std::array::from_fn(|i| i as u8),
+        bounds,
+    };
+
+    let mut buffer = Vec::new();
+    stats.write_to(&mut buffer);
+    assert_eq!(buffer.len(), GcSurvivorStats::WIRE_SIZE);
+
+    let decoded = GcSurvivorStats::read_from(&buffer).expect("a full-size buffer should decode");
+    assert_eq!(decoded.registers, stats.registers);
+    assert_eq!(decoded.bounds, stats.bounds);
+
+    // The empty sentinel survives the round trip too — the parent must be able to
+    // tell "nothing survived" from "bounds unknown".
+    let mut buffer = Vec::new();
+    GcSurvivorStats::EMPTY.write_to(&mut buffer);
+    let decoded = GcSurvivorStats::read_from(&buffer).expect("a full-size buffer should decode");
+    assert_eq!(decoded.bounds, ValueBounds::EMPTY);
+
+    // Anything but an exact-size buffer is rejected.
+    assert!(GcSurvivorStats::read_from(&buffer[..buffer.len() - 1]).is_none());
+    buffer.push(0);
+    assert!(GcSurvivorStats::read_from(&buffer).is_none());
+}
+
+// ============================================================================
+// Stored-value quantization
+// ============================================================================
+
+#[test]
+fn test_compressed_range_treats_collapsing_values_as_one() {
+    // Two distinct f64s inside the same f32 bucket. A compressed range stores one
+    // value for both, so its statistics must report one value.
+    let mut range = NumericRange::new(true);
+    let index = NumericIndex::new(true);
+    range.add(1, index.prepare(100.5));
+    range.add(2, index.prepare(100.500001));
+
+    assert_eq!(range.num_entries(), 2);
+    assert_eq!(
+        range.cardinality(),
+        1,
+        "both inputs collapse onto the same stored value"
+    );
+    assert_eq!(
+        (range.min_val(), range.max_val()),
+        (100.5, 100.5),
+        "bounds must equal the stored value, not the inputs"
+    );
+
+    // The same two inputs stay distinct without compression.
+    let mut range = NumericRange::new(false);
+    let index = NumericIndex::new(false);
+    range.add(1, index.prepare(100.5));
+    range.add(2, index.prepare(100.500001));
+    assert_eq!(range.cardinality(), 2);
+    assert_eq!((range.min_val(), range.max_val()), (100.5, 100.500001));
+}
+
+#[rstest]
+fn test_signed_zeros_are_one_stored_value(#[values(false, true)] compress_floats: bool) {
+    // Every numeric encoder writes zero as a tiny integer, dropping the sign, so
+    // `-0.0` and `+0.0` are indistinguishable once stored.
+    let mut range = NumericRange::new(compress_floats);
+    let index = NumericIndex::new(compress_floats);
+    range.add(1, index.prepare(-0.0));
+    range.add(2, index.prepare(0.0));
+
+    assert_eq!(range.cardinality(), 1);
+    assert!(range.min_val().is_sign_positive());
+    assert_eq!((range.min_val(), range.max_val()), (0.0, 0.0));
+}
+
+#[rstest]
+fn test_geohash_values_are_stored_exactly(#[values(false, true)] compress_floats: bool) {
+    // GEO fields share this tree: `encodeGeo` yields a 52-bit integer as an f64,
+    // which takes the encoder's integer path and is never rounded — with or without
+    // float compression. Quantization must therefore be the identity here.
+    let geohashes = [0.0, 1.0, 3_659_155_824_453_222.0, (1u64 << 52) as f64 - 1.0];
+
+    let index = NumericIndex::new(compress_floats);
+    for geohash in geohashes {
+        assert_eq!(
+            index.prepare(geohash).stored_value().get(),
+            geohash,
+            "geohash {geohash} must survive quantization unchanged"
+        );
+    }
+
+    let mut range = NumericRange::new(compress_floats);
+    for (i, geohash) in geohashes.iter().enumerate() {
+        range.add(i as u64 + 1, index.prepare(*geohash));
+    }
+    assert_eq!(range.cardinality(), geohashes.len());
+    assert_eq!(range.min_val(), geohashes[0]);
+    assert_eq!(range.max_val(), geohashes[geohashes.len() - 1]);
 }

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/tree.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/tree.rs
@@ -201,82 +201,81 @@ fn test_split_with_identical_values() {
     );
 }
 
-/// Regression test for the `empty_leaves` underflow crash (MOD-16877, a
-/// production crash on 8.6.6): a split that creates an empty child leaf must
-/// count it.
+/// The compression route into the MOD-16877 `empty_leaves` underflow crash (a
+/// production crash on 8.6.6), now closed at the source.
 ///
-/// With float compression enabled, cardinality is estimated over the original
-/// f64 values while entries are stored — and split-redistributed — as compressed
-/// f32. When enough distinct f64 values collapse to a single f32, the split is
-/// triggered (HLL sees them as distinct) but every stored value is identical, so
-/// all entries are redistributed to one child and the other child leaf is created
-/// empty. That empty leaf must be reflected in `empty_leaves`; otherwise a later
-/// add routed to it decrements the counter below zero and aborts the process via
-/// the non-unwinding FFI boundary.
+/// It used to run: cardinality was estimated over the original f64 values while
+/// entries were stored — and split-redistributed — as compressed f32. Enough
+/// distinct f64s collapsing onto one f32 looked like a high-cardinality leaf, so a
+/// split fired even though every stored value was identical; all entries went to
+/// one child, the other was created empty and uncounted, and the next add routed
+/// into it decremented `empty_leaves` below zero, aborting the process across the
+/// non-unwinding FFI boundary.
 ///
-/// Compression is not the only way to get an empty child leaf — see
-/// `test_split_after_gc_stale_min_counts_empty_leaf`.
+/// Values are quantized on the way in now, so the collapsing values *are* one value
+/// to the tree: cardinality stays at 1 and no split fires at all. The
+/// `empty_leaves` accounting in `split_node` survives as a guard, but nothing in
+/// this scenario reaches it.
 #[test]
-fn test_split_with_compression_collapse_counts_empty_leaf() {
+fn test_compression_collapse_does_not_inflate_cardinality() {
     let mut tree = NumericRangeTree::new(true); // float compression ON
 
     // Distinct f64 values tightly clustered within a single f32 rounding bucket
     // around 100.5 (exactly representable in f32). Each differs from the next by
-    // 1e-7 — far above the f64 ULP near 100.5 (~1e-14), so they are distinct to
+    // 1e-7 — far above the f64 ULP near 100.5 (~1e-14), so they were distinct to
     // the HLL cardinality estimator, but far below the f32 ULP near 100.5
     // (~7.6e-6), so all round to the same stored f32 (100.5), well within the
     // 0.01 compression threshold.
     let value_at = |i: u64| 100.5 + (i - 1) as f64 * 1e-7;
 
-    // Add distinct-but-collapsing values until the first split fires. Because the
-    // stored values are all identical (f32 100.5), the redistribution sends every
-    // entry to the left child and leaves the right child empty. This empty leaf
-    // must be counted; before the fix, `empty_leaves` stayed 0 here (caught by the
-    // `check_tree_invariants` assertion inside `add`).
-    let mut split_at = None;
+    // Well past the point where the old cardinality estimate would have split.
     for i in 1..=(SPLIT_TRIGGER + 8) {
         tree.add(i, value_at(i), false, 0);
-        if tree.num_leaves() == 2 {
-            split_at = Some(i);
-            break;
-        }
     }
-    let split_at = split_at.expect("compressed-but-distinct values should trigger a split");
 
-    // Right after the split, before any further add re-populates it:
+    assert!(
+        tree.root().is_leaf(),
+        "collapsing values are one stored value, so no split should fire (got {} leaves)",
+        tree.num_leaves()
+    );
+
+    let range = tree.root().range().unwrap();
     assert_eq!(
-        tree.empty_leaves(),
+        range.cardinality(),
         1,
-        "the empty child leaf created by the split must be counted"
+        "cardinality must count stored values, not the inputs that collapsed onto them"
     );
-
-    // Routing uses the *original* f64 value, so the next (larger) value is routed
-    // to the empty right child and re-populates it. Before the fix this decremented
-    // `empty_leaves` from 0, underflowing the counter and aborting the process.
-    let next = split_at + 1;
-    tree.add(next, value_at(next), false, 0);
     assert_eq!(
-        tree.empty_leaves(),
-        0,
-        "re-populating the empty leaf should bring the counter back to zero"
+        (range.min_val(), range.max_val()),
+        (100.5, 100.5),
+        "bounds must describe the stored value a reader will decode"
     );
+    assert_eq!(tree.empty_leaves(), 0);
+
+    // The add that used to hit the underflow. Nothing was ever stranded, so the
+    // counter is not touched.
+    let next = SPLIT_TRIGGER + 9;
+    tree.add(next, value_at(next), false, 0);
+    assert_eq!(tree.empty_leaves(), 0);
 }
 
-/// Same `empty_leaves` underflow as
-/// `test_split_with_compression_collapse_counts_empty_leaf` (MOD-16877), reached
-/// with float compression *disabled* — compression is not required to strand an
-/// empty child leaf.
+/// The compression-free route into the MOD-16877 `empty_leaves` underflow, now
+/// closed at the source.
 ///
-/// The other ingredient is a stale `min_val`. GC removes entries from a range but
-/// never raises its bounds, so a leaf whose smallest-valued documents were all
-/// collected keeps reporting the old minimum. `split_node`'s
-/// `split == min_val` guard then compares the median of the *surviving* entries
-/// against a bound no surviving entry has, so it does not fire. If a majority of
-/// the survivors share the smallest surviving value, that value *is* the median
-/// and becomes the split point, so every entry satisfies `value >= split` and
-/// lands in the right child — leaving the left child empty.
+/// It used to run: GC removed entries without raising `min_val`, so a leaf whose
+/// smallest-valued documents had all been collected kept reporting the old minimum.
+/// `split_node`'s `split == min_val` guard then compared the median of the
+/// *surviving* entries against a bound no survivor had, so it did not fire — and
+/// with a majority of the survivors sharing the smallest surviving value, that value
+/// became the split point, sending every entry to the right child and stranding the
+/// left one empty.
+///
+/// GC now recomputes a leaf's bounds over the surviving entries, so the median
+/// equals `min_val` again, the guard fires, and the split lands entries on both
+/// sides. Its sibling `test_compression_collapse_does_not_inflate_cardinality`
+/// covers the other route; both now pin the cause, not the symptom.
 #[test]
-fn test_split_after_gc_stale_min_counts_empty_leaf() {
+fn test_split_after_gc_does_not_strand_empty_leaf() {
     let mut tree = NumericRangeTree::new(false); // float compression OFF
 
     /// Number of documents sharing the value 100.0. They must remain a majority of
@@ -294,8 +293,8 @@ fn test_split_after_gc_stale_min_counts_empty_leaf() {
     assert!(tree.root().is_leaf());
     assert_eq!(tree.empty_leaves(), 0, "the root leaf holds every document");
 
-    // Delete doc 1 and collect it. Its entry is physically removed and the HLL is
-    // re-estimated over the survivors, but `min_val` stays 0.0.
+    // Delete doc 1 and collect it. Its entry is physically removed and both the HLL
+    // and the bounds are recomputed over the survivors.
     gc_all_ranges(&mut tree, &|doc_id| doc_id != 1);
     assert_eq!(tree.num_entries(), MAJORITY as usize);
     assert_eq!(
@@ -305,8 +304,8 @@ fn test_split_after_gc_stale_min_counts_empty_leaf() {
     );
     assert_eq!(
         tree.root().range().unwrap().min_val(),
-        0.0,
-        "GC must not raise a range's lower bound — that staleness is the trigger"
+        100.0,
+        "GC must raise the lower bound to the smallest surviving value"
     );
 
     // Push cardinality over the split threshold using distinct values strictly
@@ -323,30 +322,26 @@ fn test_split_after_gc_stale_min_counts_empty_leaf() {
     }
     assert!(split_fired, "distinct values should trigger a split");
 
-    // The split point is the median (100.0), not `next_up(min_val)`, so every
-    // entry went right and the left leaf is empty.
-    assert_eq!(tree.root().split_value(), Some(100.0));
-    let (left_idx, _) = tree.root().child_indices().unwrap();
-    assert_eq!(
-        tree.node(left_idx).range().unwrap().num_docs(),
-        0,
-        "the split should have left the left child empty"
-    );
+    // The median now equals the (tightened) `min_val`, so the split point is
+    // `next_up(100.0)`: the block of 100.0s goes left, everything above goes right.
+    assert_eq!(tree.root().split_value(), Some(100.0f64.next_up()));
+    let (left_idx, right_idx) = tree.root().child_indices().unwrap();
+    for (label, idx) in [("left", left_idx), ("right", right_idx)] {
+        assert!(
+            tree.node(idx).range().unwrap().num_docs() > 0,
+            "the {label} child should have received entries"
+        );
+    }
     assert_eq!(
         tree.empty_leaves(),
-        1,
-        "the empty child leaf created by the split must be counted"
+        0,
+        "the split should not strand an empty leaf at all"
     );
 
-    // Any later value below the split point is routed to that empty leaf. Before
-    // the fix this decremented `empty_leaves` from 0, underflowing the counter and
-    // aborting the process across the non-unwinding FFI boundary.
+    // The add that used to hit the underflow: a value below the split point. It is
+    // routed to a populated leaf now, so the counter is never decremented.
     tree.add(doc_id, 50.0, false, 0);
-    assert_eq!(
-        tree.empty_leaves(),
-        0,
-        "re-populating the empty leaf should bring the counter back to zero"
-    );
+    assert_eq!(tree.empty_leaves(), 0);
 }
 
 #[test]

--- a/src/redisearch_rs/numeric_range_tree/tests/proptest-regressions/properties.txt
+++ b/src/redisearch_rs/numeric_range_tree/tests/proptest-regressions/properties.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc d624227c2a290e04f03c3eca8cf38e8f4ef099c04e9bf8390484214970c75d9d # shrinks to num_entries = 119, delete_ratio = 0.8385281892398074, max_depth_range = 1


### PR DESCRIPTION
## Describe the changes in the pull request

A numeric range tracks value bounds (`min_val`/`max_val`) and a HyperLogLog cardinality estimate, and the tree makes structural decisions from them: which child an entry is routed to, when a leaf splits, and where it splits. Both statistics were computed from values the index never returns, in two independent ways.

1. **Current — the encoder's representation was invisible.** `Value::from` decides per value whether to store an f64, an f32, an integer or a 3-bit tiny int. It is a pure function of the value and the compression flag, but it lived entirely inside `Encoder::encode`, so nothing could ask what was about to be stored:
   - Cardinality counted distinct *inputs*. Under `_NUMERIC_COMPRESS` many collapse onto one stored f32, so a leaf whose stored values were all identical looked high-cardinality, split, sent every entry to one child and stranded the other empty. That is the MOD-16877 crash (#10513): the uncounted empty leaf underflowed `empty_leaves` on the next add routed into it, aborting the process across the non-unwinding FFI boundary.
   - Bounds had the same flaw — a bound could sit *inside* the set of values a reader decodes.
   - Routing descended by the input value while storage rounded, so an entry could decode on the far side of the split value it was routed by.
   - Even with compression off, `-0.0` is stored as a tiny integer and decodes as `+0.0`, while the cardinality estimator hashed the two as distinct.

   **Current — bounds were write-only.** Adds pushed `min_val`/`max_val` outwards and nothing pulled them back: GC removed entries without touching them. A range whose extreme-valued documents had all been collected kept reporting bounds no surviving entry justified. That is the compression-free route into the same underflow, covered by the tests added in #10628: with `min_val` stranded below every survivor, `split_node`'s `split == min_val` guard could not fire, so a leaf where a majority of survivors shared the smallest surviving value split at that value and sent every entry one way.

2. **Change** — three changes, each closing one gap:
   - `NumericEncoder::prepare` hands out the encoder's decision as an opaque `PreparedValue`, and `encode_prepared` accepts it back. `Encoder::encode` is re-expressed through both, so classification lives in one place (`Value::from`) and byte-writing in one place (`encode_value`), reachable through two entry points. The record-agnostic half of `InvertedIndex::add_record` — duplicate handling, block selection, delta computation and its new-block retry, growth accounting, counters — is factored into `add_entry`, so `add_prepared_record` reuses all of it. The other ten codecs and the generic `Encoder` trait are untouched.
   - `NumericRangeTree::_add` prepares once, before routing, and the decision travels with the value to the leaf that writes it: one classification per add, and statistics, routing and storage cannot disagree. `PreparedValue::stored_value` yields a `StoredValue`, the only thing range bounds and the HLL accept — a raw `f64` can no longer reach a statistic. Quantization uses the tree's own `compress_floats`, never the global config, which is settable at runtime while a tree keeps the flag it was created with.
   - The GC scan already walks every surviving entry to rebuild the HLL registers, so it now tracks bounds in the same pass and ships both back over the pipe as `GcSurvivorStats`. The parent installs them and rescans the blocks the scan could not account for — blocks appended after the fork, plus the last block when its repair had to be ignored — so neither statistic misses an entry still in the index. Only **leaf** ranges are tightened: entries are applied ancestor-first with the spec lock released in between, so tightening a range retained on an internal node would transiently publish an ancestor narrower than its own children.

3. **Outcome** — statistics now describe what a reader decodes. The MOD-16877 crash has no cause left on either route: the collapsing-values leaf no longer looks high-cardinality, and GC no longer leaves `min_val` stale. Split points and query pruning become exact rather than approximate under compression. The `empty_leaves` accounting from #10513 stays as a self-correcting guard, with an assertion that exact statistics should make it unreachable.

**Behaviour changes to be aware of when reviewing:** reported cardinality and bound values change under `_NUMERIC_COMPRESS` (they now describe stored values), and `-0.0`/`+0.0` count as one value for every numeric encoder. GEO fields share this tree — `encodeGeo` yields a 52-bit integral geohash, which takes the encoder's integer path, so quantization is provably the identity there (pinned by a test).

**The GC pipe trailer format changed** (it now carries the recomputed bounds next to the HLL registers). I left "introduces serialization changes" unchecked because the pipe has exactly one writer and one reader — a fork of the same process image — and numeric indexes are not persisted at all: they are rebuilt by keyspace scan on load. There is no cross-version or on-disk compatibility surface here. Flag it if you read that box more broadly.

**Testing.** Both MOD-16877 regression tests are rewritten from asserting the symptom (the empty leaf is counted) to asserting the cause is gone (cardinality does not inflate; the split lands entries on both sides). The two write paths are pinned to each other by a proptest asserting **byte-identical** encoder output across the full `f64` range and an index-level test asserting identical bytes, block layout, memory usage and `AddRecordOutcome`. A proptest also pins `stored_value` to a real encode/decode round trip, which is what keeps the prediction honest against the decoder.

Verified: 306/306 `inverted_index` + `numeric_range_tree` tests, miri 257/257, `make lint` clean, `cargo fmt --check` clean, `make generate-rust-headers` no diff, C build green, `test_gc.py` 21/21 against the built module, and the full pytest suite green on an earlier revision of this work (only `test_cluster_set_errors` and `test_with_tls` fail locally, both for known environmental reasons documented in the test source).

**Not measured:** the write path now classifies each value once instead of twice and builds no `RSIndexResult` per add. My dev machine is too noisy to quantify that (the same bench case drifted 465–512 ns across runs of identical code), so the benchmark is deliberately left to a clean environment rather than quoted from here.

#### Which additional issues this PR fixes
1. MOD-16877 (root cause; #10513 fixed the crash symptom, #10628 added coverage for the second route)

#### Main objects this PR modified
1. `NumericEncoder` / `PreparedValue` / `StoredValue`, `encode_value` split out of `encode` — `src/redisearch_rs/inverted_index/src/codec/numeric.rs`
2. `InvertedIndex::add_entry` extraction + `add_prepared_record` — `src/redisearch_rs/inverted_index/src/index/core.rs`, mirrored on `EntriesTrackingIndex` in `with_entries.rs`
3. `NumericRange::add*`, `ValueBounds`, `GcSurvivorStats`, `reset_stats_after_gc` — `src/redisearch_rs/numeric_range_tree/src/range.rs`
4. `NumericRangeNode::scan_gc` + `apply_gc_to_node` (bounds over survivors, leaf-only tightening) — `src/redisearch_rs/numeric_range_tree/src/tree/gc.rs`
5. `NumericRangeTree::_add` / `node_add` / `split_node` — `src/redisearch_rs/numeric_range_tree/src/tree/insert.rs`
6. GC pipe trailer — `src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/gc.rs`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Numeric index cardinality estimates and range bounds now describe the values the index actually stores. Previously, with `_NUMERIC_COMPRESS` enabled, they were computed from the pre-compression values, which made the tree split and prune on numbers no query would ever see — and was the root cause of a crash that could take down a shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
