### PR TITLE
[8.6-rse] [MOD-14309][MOD-14311] Add FT.DEBUG for FT.HYBRID and propagate timeout warnings (#9215)

### DIFF
--- a/src/aggregate/reply_empty.c
+++ b/src/aggregate/reply_empty.c
@@ -132,7 +132,7 @@ int common_hybrid_query_reply_empty(RedisModuleCtx *ctx, QueryErrorCode errCode,
         RedisModule_ReplyKV_Array(coordInfoReply,"warnings"); // warnings []
         if (QueryError_HasQueryOOMWarning(&status)) {
             QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_OUT_OF_MEMORY_SHARD, 1, SHARD_ERR_WARN);
-            RedisModule_Reply_SimpleString(coordInfoReply, QueryError_Strerror(QUERY_ERROR_CODE_OUT_OF_MEMORY));
+            RedisModule_Reply_SimpleString(coordInfoReply, QueryWarning_Strwarning(QUERY_WARNING_CODE_OUT_OF_MEMORY_SHARD));
         }
         RedisModule_Reply_ArrayEnd(coordInfoReply); // ~warnings
 

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -10,6 +10,7 @@
 #include "dist_hybrid.h"
 #include "hybrid/hybrid_request.h"
 #include "hybrid/hybrid_exec.h"
+#include "hybrid/hybrid_debug.h"
 #include "hybrid/dist_hybrid_plan.h"
 #include "hybrid/parse_hybrid.h"
 #include "dist_plan.h"
@@ -581,7 +582,8 @@ static bool shouldCheckInPipelineTimeoutCoord(HybridRequest *req) {
 
 static int HybridRequest_prepareForExecution(HybridRequest *hreq,
         RedisModuleCtx *ctx, RedisModuleString **argv, int argc, IndexSpec *sp,
-        size_t numShards, QueryError *status) {
+        size_t numShards, QueryError *status,
+        const HybridDebugParams *debugParams) {
 
     hreq->tailPipeline->qctx.err = status;
     hreq->profile = printDistHybridProfile;
@@ -670,6 +672,18 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     xcmd.rootCommand = C_READ;
     xcmd.coordStartTime = hreq->profileClocks.coordStartTime;
 
+    // For debug commands, wrap the shard command with _FT.DEBUG prefix and
+    // append the debug parameters so the shard-side debug handler can apply them.
+    if (debugParams) {
+      MRCommand_Insert(&xcmd, 0, "_FT.DEBUG", sizeof("_FT.DEBUG") - 1);
+      int debug_argv_count = (int)debugParams->debug_params_count + 2;
+      for (int i = 0; i < debug_argv_count; i++) {
+        size_t n;
+        const char *arg = RedisModule_StringPtrLen(debugParams->debug_argv[i], &n);
+        MRCommand_Append(&xcmd, arg, n);
+      }
+    }
+
     // UPDATED: Use new start function with mappings (no dispatcher needed)
     HybridRequest_buildDistRPChain(hreq->requests[0], &xcmd, lookups[0], rpnetNext_StartWithMappings);
     HybridRequest_buildDistRPChain(hreq->requests[1], &xcmd, lookups[1], rpnetNext_StartWithMappings);
@@ -717,9 +731,10 @@ static int HybridRequest_executePlan(HybridRequest *hreq, struct ConcurrentCmdCt
     cmd->coordStartTime = hreq->profileClocks.coordStartTime;
 
     const RSOomPolicy oomPolicy = hreq->reqConfig.oomPolicy;
+    const RSTimeoutPolicy timeoutPolicy = hreq->reqConfig.timeoutPolicy;
     const struct timespec *deadline =
         hreq->sctx ? (const struct timespec *)&hreq->sctx->time.timeout : NULL;
-    if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, hreq->tailPipeline->qctx.err, oomPolicy, deadline)) {
+    if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, hreq->tailPipeline->qctx.err, oomPolicy, timeoutPolicy, deadline)) {
         // Handle error
         StrongRef_Release(searchMappingsRef);
         StrongRef_Release(vsimMappingsRef);
@@ -857,7 +872,83 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
     hreq->profileClocks.coordStartTime = ConcurrentCmdCtx_GetCoordStartTime(cmdCtx);
     size_t numShards = ConcurrentCmdCtx_GetNumShards(cmdCtx);
 
-    if (HybridRequest_prepareForExecution(hreq, ctx, argv, argc, sp, numShards, &status) != REDISMODULE_OK) {
+    if (HybridRequest_prepareForExecution(hreq, ctx, argv, argc, sp, numShards, &status, NULL) != REDISMODULE_OK) {
+      DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, hreq, reply, &status);
+      return;
+    }
+
+    if (HybridRequest_executePlan(hreq, cmdCtx, reply, &status) != REDISMODULE_OK) {
+        DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, hreq, reply, &status);
+        return;
+    }
+    WeakRef_Release(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
+    IndexSpecRef_Release(strong_ref);
+    RedisModule_EndReply(reply);
+}
+
+void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                            struct ConcurrentCmdCtx *cmdCtx) {
+
+    CoordRequestCtx *reqCtx = RedisModule_BlockClientGetPrivateData(ConcurrentCmdCtx_GetBlockedClient(cmdCtx));
+
+    if(CoordRequestCtx_TimedOut(reqCtx)) {
+      return;
+    }
+
+    RedisModule_Reply _reply = RedisModule_NewReply(ctx);
+    RedisModule_Reply *reply = &_reply;
+    QueryError status = QueryError_Default();
+
+    // Parse debug params from the end of argv
+    HybridDebugParams debugParams = parseHybridDebugParamsCount(argv, argc, &status);
+    if (QueryError_HasError(&status)) {
+      DistHybridCleanups(ctx, cmdCtx, NULL, NULL, NULL, reply, &status);
+      return;
+    }
+    if (parseHybridDebugParams(&debugParams, &status) != REDISMODULE_OK) {
+      DistHybridCleanups(ctx, cmdCtx, NULL, NULL, NULL, reply, &status);
+      return;
+    }
+
+    // Strip debug params from argc for parsing
+    int stripped_argc = argc - (int)debugParams.debug_params_count - 2;
+
+    const char *indexname = RedisModule_StringPtrLen(argv[1], NULL);
+    RedisSearchCtx *sctx = NewSearchCtxC(ctx, indexname, true);
+    if (!sctx) {
+        QueryError_SetWithUserDataFmt(&status, QUERY_ERROR_CODE_NO_INDEX, "Index not found", ": %s", indexname);
+        DistHybridCleanups(ctx, cmdCtx, NULL, NULL, NULL, reply, &status);
+        return;
+    }
+
+    StrongRef strong_ref = IndexSpecRef_Promote(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
+    IndexSpec *sp = StrongRef_Get(strong_ref);
+    if (!sp) {
+        SearchCtx_Free(sctx);
+        QueryError_SetCode(&status, QUERY_ERROR_CODE_DROPPED_BACKGROUND);
+        DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, NULL, reply, &status);
+        return;
+    }
+
+    CoordRequestCtx_LockSetRequest(reqCtx);
+    if (CoordRequestCtx_TimedOut(reqCtx)) {
+        CoordRequestCtx_UnlockSetRequest(reqCtx);
+        SearchCtx_Free(sctx);
+        DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, NULL, reply, &status);
+        return;
+    }
+
+    HybridRequest *hreq = MakeDefaultHybridRequest(sctx);
+    CoordRequestCtx_SetRequest(reqCtx, hreq);
+    CoordRequestCtx_UnlockSetRequest(reqCtx);
+
+    hreq->profileClocks.coordStartTime = ConcurrentCmdCtx_GetCoordStartTime(cmdCtx);
+    size_t numShards = ConcurrentCmdCtx_GetNumShards(cmdCtx);
+
+    // Use stripped_argc so parsing doesn't see debug params;
+    // pass debugParams so the MR command gets _FT.DEBUG prefix + debug args.
+    if (HybridRequest_prepareForExecution(hreq, ctx, argv, stripped_argc, sp, numShards,
+                                          &status, &debugParams) != REDISMODULE_OK) {
       DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, hreq, reply, &status);
       return;
     }

--- a/src/coord/hybrid/dist_hybrid.h
+++ b/src/coord/hybrid/dist_hybrid.h
@@ -21,6 +21,8 @@ extern "C" {
 
 void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                         struct ConcurrentCmdCtx *cmdCtx);
+void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                            struct ConcurrentCmdCtx *cmdCtx);
 
 int DistHybridTimeoutFailClient(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int DistHybridReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -38,6 +38,24 @@ static void processHybridError(processCursorMappingCallbackContext *ctx, MRReply
     ctx->errors = array_ensure_append_1(ctx->errors, error);
 }
 
+// Warning strings use a different format than error strings (no prefix).
+// Map warning codes to error codes for uniform handling in ProcessHybridCursorMappings.
+static void processHybridWarning(processCursorMappingCallbackContext *ctx, const MRReply *rep) {
+    const char *warningMessage = MRReply_String(rep, NULL);
+    QueryWarningCode warningCode = QueryWarningCode_GetCodeFromMessage(warningMessage);
+    QueryError error = QueryError_Default();
+    if (warningCode == QUERY_WARNING_CODE_TIMED_OUT) {
+        QueryError_SetCode(&error, QUERY_ERROR_CODE_TIMED_OUT);
+    } else if (warningCode == QUERY_WARNING_CODE_OUT_OF_MEMORY_SHARD ||
+               warningCode == QUERY_WARNING_CODE_OUT_OF_MEMORY_COORD) {
+        QueryError_SetCode(&error, QUERY_ERROR_CODE_OUT_OF_MEMORY);
+    } else {
+        QueryError_SetCode(&error, QUERY_ERROR_CODE_GENERIC);
+    }
+    QueryError_SetDetail(&error, warningMessage);
+    ctx->errors = array_ensure_append_1(ctx->errors, error);
+}
+
 static void processHybridUnknownReplyType(processCursorMappingCallbackContext *ctx, int replyType) {
     QueryError error = QueryError_Default();
     QueryError_SetWithoutUserDataFmt(&error, QUERY_ERROR_CODE_UNSUPP_TYPE, "Unsupported reply type: %d", replyType);
@@ -61,7 +79,7 @@ static void processHybridResp2(processCursorMappingCallbackContext *ctx, MRReply
         if (strcmp(key, "warnings") == 0) {
             for (size_t j = 0; j < MRReply_Length(value_reply); j++) {
                 MRReply *warningReply = MRReply_ArrayElement(value_reply, j);
-                processHybridError(ctx, warningReply);
+                processHybridWarning(ctx, warningReply);
             }
             continue;
         }
@@ -150,7 +168,7 @@ static void processHybridResp3(processCursorMappingCallbackContext *ctx, MRReply
     if (MRReply_Length(warnings) > 0) {
         for (size_t i = 0; i < MRReply_Length(warnings); i++) {
             MRReply *warningReply = MRReply_ArrayElement(warnings, i);
-            processHybridError(ctx, warningReply);
+            processHybridWarning(ctx, warningReply);
         }
     }
 }
@@ -203,7 +221,7 @@ static void freeCursorMappingCtx(void *privateData) {
     rm_free(ctx);
 }
 
-bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsRef, StrongRef vsimMappingsRef, QueryError *status, const RSOomPolicy oomPolicy, const struct timespec *deadline) {
+bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsRef, StrongRef vsimMappingsRef, QueryError *status, const RSOomPolicy oomPolicy, const RSTimeoutPolicy timeoutPolicy, const struct timespec *deadline) {
     CursorMappings *searchMappings = StrongRef_Get(searchMappingsRef);
     CursorMappings *vsimMappings = StrongRef_Get(vsimMappingsRef);
     RS_ASSERT(array_len(searchMappings->mappings) == 0 && array_len(vsimMappings->mappings) == 0);
@@ -250,6 +268,21 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
         for (size_t i = 0; i < array_len(ctx->errors); i++) {
             if (QueryError_GetCode(&ctx->errors[i]) == QUERY_ERROR_CODE_OUT_OF_MEMORY && oomPolicy == OomPolicy_Return ) {
                 QueryError_SetQueryOOMWarning(status);
+            } else if (QueryError_GetCode(&ctx->errors[i]) == QUERY_ERROR_CODE_TIMED_OUT && timeoutPolicy != TimeoutPolicy_Fail) {
+                // RETURN / RETURN-STRICT policy: acknowledge the shard timeout but
+                // don't set it on qctx->err. The timeout will propagate through cursor
+                // reads (RPNet detects it from the depleter's last_rc), and
+                // replyWarningsWithSuffixes emits the properly-suffixed warning
+                // (e.g., "(SEARCH)" / "(VSIM)").
+                // Note: for the _FT.DEBUG FT.HYBRID path, RETURN-STRICT is rejected
+                // earlier in parseHybridDebugParams, so only RETURN reaches here in
+                // debug mode.
+            } else if (QueryError_GetCode(&ctx->errors[i]) == QUERY_ERROR_CODE_TIMED_OUT) {
+                // FAIL policy: forward the standard timeout error directly,
+                // matching the standalone path which uses QueryError_Strerror().
+                QueryError_SetCode(status, QUERY_ERROR_CODE_TIMED_OUT);
+                success = false;
+                break;
             } else {
                 QueryError_SetWithoutUserDataFmt(status, QueryError_GetCode(&ctx->errors[i]), "Failed to process shard responses, first error: %s, total error count: %zu",
                     QueryError_GetUserError(&ctx->errors[i]), array_len(ctx->errors));

--- a/src/coord/hybrid/hybrid_cursor_mappings.h
+++ b/src/coord/hybrid/hybrid_cursor_mappings.h
@@ -48,11 +48,13 @@ typedef struct QueryError QueryError;
  * @param vsimMappings Empty array to populate with vector similarity cursor mappings
  * @param status QueryError pointer to store warning/error information
  * @param oomPolicy OOM policy to determine error handling behavior
+ * @param timeoutPolicy Timeout policy: on RETURN/RETURN-STRICT, shard timeout warnings are left to
+ *                      propagate through cursor reads; on FAIL, they abort the request with a timeout error
  * @param deadline Absolute (monotonic) time after which the cursor-setup wait gives up and
  *                 reports a timeout, or NULL to wait without a deadline (e.g. timeout disabled)
  * @return true if processing completed (even with warnings), false on fatal errors; status will contain error/warning information
  */
-bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappings, StrongRef vsimMappings, QueryError *status, RSOomPolicy oomPolicy, const struct timespec *deadline);
+bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappings, StrongRef vsimMappings, QueryError *status, RSOomPolicy oomPolicy, RSTimeoutPolicy timeoutPolicy, const struct timespec *deadline);
 
 /**
  * Release resources associated with a cursor mapping

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -29,6 +29,7 @@
 #include "module.h"
 #include "aggregate/aggregate_debug.h"
 #include "hybrid/hybrid_debug.h"
+#include "hybrid/hybrid_exec.h"
 #include "reply.h"
 #include "reply_macros.h"
 #include "obfuscation/obfuscation_api.h"
@@ -1764,11 +1765,45 @@ DEBUG_COMMAND(ProfileCommandCommand_DebugWrapper) {
   return ProfileCommandHandlerImp(ctx, ++argv, --argc, true);
 }
 
+DEBUG_COMMAND(RSShardedHybridCommand_Debug) {
+  if (!debugCommandsEnabled(ctx)) {
+    return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
+  }
+  if (argc < 9) {
+    return RedisModule_WrongArity(ctx);
+  }
+  // Skip _FT.DEBUG prefix — argv now starts at FT.HYBRID / _FT.HYBRID
+  ++argv; --argc;
+
+  QueryError status = QueryError_Default();
+  HybridDebugParams params = parseHybridDebugParamsCount(argv, argc, &status);
+  if (QueryError_HasError(&status)) {
+    return QueryError_ReplyAndClear(ctx, &status);
+  }
+  if (parseHybridDebugParams(&params, &status) != REDISMODULE_OK) {
+    return QueryError_ReplyAndClear(ctx, &status);
+  }
+
+  // Strip debug params from argc so hybridCommandHandler sees a normal command
+  int stripped_argc = argc - (int)params.debug_params_count - 2;
+  return hybridCommandHandler(ctx, argv, stripped_argc, true, EXEC_NO_FLAGS, &params);
+}
+
 DEBUG_COMMAND(HybridCommand_DebugWrapper) {
   if (!debugCommandsEnabled(ctx)) {
     return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
   }
-  return DEBUG_hybridCommandHandler(ctx, ++argv, --argc);
+  if (argc < 9) {
+    // Minimum: _FT.DEBUG FT.HYBRID idx SEARCH query VSIM field vector DEBUG_PARAMS_COUNT count
+    return RedisModule_WrongArity(ctx);
+  }
+
+  if (GetNumShards_UnSafe() == 1) {
+    // Single shard — use standalone handler (skip _FT.DEBUG)
+    return DEBUG_hybridCommandHandler(ctx, ++argv, --argc);
+  }
+
+  return DistHybridCommandInternal(ctx, ++argv, --argc, true, false /* isProfile */);
 }
 
 /**
@@ -2802,7 +2837,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"FT.SEARCH", DistSearchCommand_DebugWrapper},
                                {"_FT.SEARCH", RSSearchCommandShard}, // internal use only, in SA use FT.SEARCH
                                {"FT.HYBRID", HybridCommand_DebugWrapper},
-                               {"_FT.HYBRID", HybridCommand_DebugWrapper}, // internal use only, in SA use FT.HYBRID
+                               {"_FT.HYBRID", RSShardedHybridCommand_Debug},
                                {"FT.PROFILE", ProfileCommandCommand_DebugWrapper},
                                {"_FT.PROFILE", RSProfileCommandShard},
                                /* IMPORTANT NOTE: Every debug command starts with

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -8,6 +8,7 @@
  */
 
 #include "hybrid_debug.h"
+#include "config.h"
 #include "hybrid_exec.h"
 #include "hybrid_request.h"
 #include "parse_hybrid.h"
@@ -16,27 +17,13 @@
 #include "rmalloc.h"
 #include "search_disk_utils.h"
 
-// Debug parameters structure for hybrid queries
-typedef struct {
-  RedisModuleString **debug_argv;
-  unsigned long long debug_params_count;
-
-  // Component-specific timeouts only
-  unsigned long long search_timeout_count;
-  unsigned long long vsim_timeout_count;
-  unsigned long long tail_timeout_count;
-  int search_timeout_set;
-  int vsim_timeout_set;
-  int tail_timeout_set;
-} HybridDebugParams;
-
 // Wrapper structure for hybrid request with debug capabilities
 typedef struct {
   HybridRequest *hreq;                     // Base hybrid request
   HybridDebugParams debug_params;          // Debug parameters
 } HybridRequest_Debug;
 
-static HybridDebugParams parseHybridDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status) {
+HybridDebugParams parseHybridDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status) {
   HybridDebugParams debug_params = {0};
 
   // Verify DEBUG_PARAMS_COUNT exists in its expected position (second to last argument)
@@ -59,6 +46,12 @@ static HybridDebugParams parseHybridDebugParamsCount(RedisModuleString **argv, i
     return debug_params;
   }
 
+  if (debug_params_count > (unsigned long long)(argc - 2)) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS,
+                        "DEBUG_PARAMS_COUNT exceeds the number of available arguments");
+    return debug_params;
+  }
+
   debug_params.debug_params_count = debug_params_count;
   int debug_argv_count = debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
   debug_params.debug_argv = argv + (argc - debug_argv_count);
@@ -66,8 +59,7 @@ static HybridDebugParams parseHybridDebugParamsCount(RedisModuleString **argv, i
   return debug_params;
 }
 
-static int parseHybridDebugParams(HybridRequest_Debug *debug_req, QueryError *status) {
-  HybridDebugParams *params = &debug_req->debug_params;
+int parseHybridDebugParams(HybridDebugParams *params, QueryError *status) {
   RedisModuleString **debug_argv = params->debug_argv;
   unsigned long long debug_params_count = params->debug_params_count;
 
@@ -146,10 +138,16 @@ static int parseHybridDebugParams(HybridRequest_Debug *debug_req, QueryError *st
     return REDISMODULE_ERR;
   }
 
+  if (RSGlobalConfig.requestConfigParams.timeoutPolicy == TimeoutPolicy_ReturnStrict) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS,
+                        "FT.HYBRID debug timeout is not supported with ON_TIMEOUT RETURN-STRICT");
+    return REDISMODULE_ERR;
+  }
+
   return REDISMODULE_OK;
 }
 
-static int applyHybridTimeout(HybridRequest *hreq, const HybridDebugParams *params) {
+int applyHybridDebugTimeout(HybridRequest *hreq, const HybridDebugParams *params) {
   // Apply component-specific timeouts to search, vector, and tail pipelines
   // A timeout value of 0 means no timeout for that component
 
@@ -176,8 +174,7 @@ static int applyHybridTimeout(HybridRequest *hreq, const HybridDebugParams *para
 }
 
 static int applyHybridDebugToBuiltPipelines(HybridRequest_Debug *debug_req, QueryError *status) {
-  // Apply component-specific timeouts
-  if (applyHybridTimeout(debug_req->hreq, &debug_req->debug_params) != REDISMODULE_OK) {
+  if (applyHybridDebugTimeout(debug_req->hreq, &debug_req->debug_params) != REDISMODULE_OK) {
     QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Failed to apply timeout to built hybrid pipelines");
     return REDISMODULE_ERR;
   }
@@ -283,7 +280,7 @@ int DEBUG_hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, in
   }
 
   // Parse debug parameters
-  if (parseHybridDebugParams(debug_req, &status) != REDISMODULE_OK) {
+  if (parseHybridDebugParams(&debug_req->debug_params, &status) != REDISMODULE_OK) {
     HybridRequest_Debug_Free(debug_req);
     return QueryError_ReplyAndClear(ctx, &status);
   }

--- a/src/hybrid/hybrid_debug.h
+++ b/src/hybrid/hybrid_debug.h
@@ -10,12 +10,13 @@
 #pragma once
 
 #include "redismodule.h"
-#include "hybrid_request.h"
 #include "query_error.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+struct HybridRequest;
 
 /*
  * Debug Mechanism for FT.HYBRID Command
@@ -44,8 +45,39 @@ extern "C" {
  *   # Tail pipeline timeout
  *   _FT.DEBUG FT.HYBRID idx SEARCH "hello" VSIM @vec $blob TIMEOUT_AFTER_N_TAIL 3 DEBUG_PARAMS_COUNT 2
  *
- * Note: Currently supports single shard mode only. Coordinator-shards support will be added later.
+ * Supports both single shard (standalone) and multi-shard (cluster) modes.
  */
+
+// Debug parameters structure for hybrid queries
+typedef struct {
+  RedisModuleString **debug_argv;
+  unsigned long long debug_params_count;
+
+  unsigned long long search_timeout_count;
+  unsigned long long vsim_timeout_count;
+  unsigned long long tail_timeout_count;
+  int search_timeout_set;
+  int vsim_timeout_set;
+  int tail_timeout_set;
+} HybridDebugParams;
+
+/**
+ * Parse DEBUG_PARAMS_COUNT and debug_argv pointer from the end of argv.
+ * Does NOT parse individual debug params (TIMEOUT_AFTER_N_SEARCH, etc.).
+ * Sets status on error; returns a zeroed struct with debug_params_count==0 on failure.
+ */
+HybridDebugParams parseHybridDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status);
+
+/**
+ * Parse individual debug parameters (TIMEOUT_AFTER_N_SEARCH, etc.) from
+ * the debug_argv region already identified by parseHybridDebugParamsCount.
+ */
+int parseHybridDebugParams(HybridDebugParams *params, QueryError *status);
+
+/**
+ * Apply parsed debug timeouts to the built pipelines of a HybridRequest.
+ */
+int applyHybridDebugTimeout(struct HybridRequest *hreq, const HybridDebugParams *params);
 
 /**
  * Debug command handler for FT.HYBRID (single shard mode).

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -597,7 +597,7 @@ int HybridRequest_StartSingleCursor(StrongRef hybrid_ref, RedisModule_Reply *rep
     return REDISMODULE_OK;
 }
 
-static inline void replyWithCursors(RedisModuleCtx *replyCtx, arrayof(Cursor*) cursors) {
+static inline void replyWithCursors(RedisModuleCtx *replyCtx, arrayof(Cursor*) cursors, bool timedOut) {
     RedisModule_Reply _reply = RedisModule_NewReply(replyCtx), *reply = &_reply;
     // Send map of cursor IDs as response
     RedisModule_Reply_Map(reply);
@@ -609,13 +609,15 @@ static inline void replyWithCursors(RedisModuleCtx *replyCtx, arrayof(Cursor*) c
       } else if (IsHybridVectorSubquery(areq)) {
         RedisModule_ReplyKV_LongLong(reply, "VSIM", cursor->id);
       } else {
-        // This should never happen, we currently only support SEARCH and VSIM subqueries
         RS_ABORT_ALWAYS("Unknown subquery type");
       }
       Cursor_Pause(cursor);
     }
-    // Add warnings array
     RedisModule_ReplyKV_Array(reply, "warnings"); // >warnings
+    if (timedOut) {
+      QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_TIMED_OUT, 1, SHARD_ERR_WARN);
+      RedisModule_Reply_SimpleString(reply, QueryWarning_Strwarning(QUERY_WARNING_CODE_TIMED_OUT));
+    }
     RedisModule_Reply_ArrayEnd(reply); // ~warnings
 
     RedisModule_Reply_MapEnd(reply);
@@ -676,18 +678,25 @@ int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, Q
 
     array_free(depleters);
 
+    bool depletionTimedOut = false;
     if (rc != RS_RESULT_OK) {
-      array_free_ex(cursors, Cursor_Free(*(Cursor**)ptr));
-      if (!QueryError_HasError(status)) {
-        if (rc == RS_RESULT_TIMEDOUT) {
-          QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_TIMED_OUT, "Depleting timed out");
-        } else {
-          QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_GENERIC, "Failed to deplete set of results, rc=%d", rc);
+      if (rc == RS_RESULT_TIMEDOUT && req->reqConfig.timeoutPolicy != TimeoutPolicy_Fail) {
+        // RETURN policy: keep cursors with partial results, emit warning in reply
+        depletionTimedOut = true;
+      } else {
+        // Fatal error or FAIL policy — free everything
+        array_free_ex(cursors, Cursor_Free(*(Cursor**)ptr));
+        if (!QueryError_HasError(status)) {
+          if (rc == RS_RESULT_TIMEDOUT) {
+            QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_TIMED_OUT, "Depleting timed out");
+          } else {
+            QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_GENERIC, "Failed to deplete set of results, rc=%d", rc);
+          }
         }
+        return REDISMODULE_ERR;
       }
-      return REDISMODULE_ERR;
     }
-    replyWithCursors(replyCtx, cursors);
+    replyWithCursors(replyCtx, cursors, depletionTimedOut);
     array_free(cursors);
     return REDISMODULE_OK;
 }
@@ -733,6 +742,12 @@ static int buildPipelineAndExecute(StrongRef hybrid_ref, HybridPipelineParams *h
   // Record pipeline build time if profiling is enabled
   if (isProfile) {
     hreq->profileClocks.profilePipelineBuildTime = rs_wall_clock_elapsed_ns(&pipelineClock);
+  }
+
+  // Apply debug timeouts after pipeline is built (for _FT.DEBUG FT.HYBRID)
+  if (hreq->debugParams && applyHybridDebugTimeout(hreq, hreq->debugParams) != REDISMODULE_OK) {
+      QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "Failed to apply debug timeouts");
+      return REDISMODULE_ERR;
   }
 
   if (!isCursor) {
@@ -851,8 +866,11 @@ void printHybridProfile(RedisModule_Reply *reply, void *ctx) {
  *
  * Parses command arguments, builds hybrid request structure, constructs execution pipeline,
  * and prepares for hybrid search execution.
+ *
+ * This method does not take ownership of `debugParams`.
  */
-int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool internal, ProfileOptions profileOptions) {
+int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool internal,
+                         ProfileOptions profileOptions, const HybridDebugParams *debugParams) {
   // Index name is argv[1]
   if (argc < 2) {
     return RedisModule_WrongArity(ctx);
@@ -888,6 +906,10 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   HybridRequest *hybridRequest = MakeDefaultHybridRequest(sctx);
   hybridRequest->profile = printHybridProfile;
   hybridRequest->tailPipeline->qctx.isProfile = profileOptions & EXEC_WITH_PROFILE;
+  if (debugParams) {
+    hybridRequest->debugParams = rm_malloc(sizeof(*debugParams));
+    *hybridRequest->debugParams = *debugParams;
+  }
   StrongRef hybrid_ref = StrongRef_New(hybridRequest, &FreeHybridRequest);
   HybridPipelineParams hybridParams = {0};
 

--- a/src/hybrid/hybrid_exec.h
+++ b/src/hybrid/hybrid_exec.h
@@ -33,9 +33,13 @@ extern "C" {
  * @param argc Number of arguments in argv
  * @param internal Whether the request is internal (true - shard in cluster setup, false - Coordinator in cluster setup or standalone)
  * @param profileOptions Profile options for the command
+ * @param debugParams Optional debug parameters (NULL for normal execution).
+ *                    When non-NULL, debug timeouts are applied after pipeline building.
+ *                    Caller retains ownership.
  * @return REDISMODULE_OK on success, REDISMODULE_ERR on error
  */
-int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool internal, ProfileOptions profileOptions);
+int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool internal,
+                         ProfileOptions profileOptions, const HybridDebugParams *debugParams);
 
 void HybridRequest_StartCursor(HybridRequest *req, RedisModuleCtx *ctx, arrayof(ResultProcessor*) depleters, QueryError *status, bool coord);
 

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -330,6 +330,8 @@ static void HybridRequest_Free(HybridRequest *req) {
     // Clean up storedReplyState
     ChunkReplyState_Destroy(&req->storedReplyState);
 
+    rm_free(req->debugParams);
+
     if (req->args) {
       for (size_t ii = 0; ii < req->nargs; ++ii) {
         sdsfree(req->args[ii]);

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -3,6 +3,7 @@
 #include "aggregate/aggregate.h"
 #include "pipeline/pipeline.h"
 #include "hybrid/hybrid_scoring.h"
+#include "hybrid/hybrid_debug.h"
 #include "util/references.h"
 #include "redismodule.h"
 
@@ -50,6 +51,11 @@ typedef struct HybridRequest {
     // Background thread stores results here, then calls UnblockClient.
     // The reply_callback reads from here to build the reply on the main thread.
     ChunkReplyState storedReplyState;
+
+    // Optional debug parameters for _FT.DEBUG FT.HYBRID.
+    // When non-NULL, debug timeouts are applied after pipeline building.
+    // Heap-allocated and owned by HybridRequest — freed in HybridRequest_Free.
+    HybridDebugParams *debugParams;
 } HybridRequest;
 
 // Timeout helper functions for HybridRequest (mirrors AREQ pattern)

--- a/src/module.c
+++ b/src/module.c
@@ -75,6 +75,7 @@
 #include "search_disk_utils.h"
 #include "rs_wall_clock.h"
 #include "hybrid/hybrid_exec.h"
+#include "hybrid/hybrid_debug.h"
 #include "coord/coord_request_ctx.h"
 #include "coord/hybrid/dist_hybrid.h"
 #include "util/redis_mem_info.h"
@@ -1600,11 +1601,11 @@ static int CreateArbitraryWriteSearchCommands(RedisModuleCtx *ctx, const SearchC
 }
 
 int RSShardedHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-return hybridCommandHandler(ctx, argv, argc, true, EXEC_NO_FLAGS);
+return hybridCommandHandler(ctx, argv, argc, true, EXEC_NO_FLAGS, NULL);
 }
 
 int RSClientHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  return hybridCommandHandler(ctx, argv, argc, false, EXEC_NO_FLAGS);
+  return hybridCommandHandler(ctx, argv, argc, false, EXEC_NO_FLAGS, NULL);
 }
 
 #define PROFILE_1ST_PARAM 2
@@ -1676,7 +1677,7 @@ int RSProfileCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
   if (cmdType == COMMAND_HYBRID) {
     RedisModuleString *command = argv[0];
     bool internal = RedisModule_StringPtrLen(command, NULL)[0] == '_'; // _FT.PROFILE or FT.PROFILE
-    hybridCommandHandler(ctx, newArgv, newArgc, internal, withProfile);
+    hybridCommandHandler(ctx, newArgv, newArgc, internal, withProfile, NULL);
   } else {
     // RSExecuteAggregateOrSearch(ctx, newArgv, newArgc, cmdType, withProfile);
     execCommandHandlerFunc(ctx, newArgv, newArgc, cmdType, withProfile);
@@ -3703,6 +3704,10 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 
   if (NumShards == 1) {
     // There is only one shard in the cluster. We can handle the command locally.
+    if (isDebug) {
+      // argv still contains debug params; the non-debug handler would reject them as unknown args.
+      return DEBUG_RSAggregateCommand(ctx, argv, argc);
+    }
     return RSAggregateCommand(ctx, argv, argc);
   } else if (cannotBlockCtx(ctx)) {
     return ReplyBlockDeny(ctx, argv[0]);
@@ -3730,8 +3735,8 @@ static void DistHybridFreePrivData(RedisModuleCtx *ctx, void *privdata) {
   CoordRequestCtx_Free((CoordRequestCtx *)privdata);
 }
 
-static int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
-                                     bool isProfile) {
+int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                              bool isDebug, bool isProfile) {
   // Capture start time for coordinator dispatch time tracking
   rs_wall_clock_ns_t coordInitialTime = rs_wall_clock_now_ns();
 
@@ -3759,6 +3764,9 @@ static int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **ar
 
   // Coord callback
   ConcurrentCmdHandler dist_callback = RSExecDistHybrid;
+  if (isDebug) {
+    dist_callback = DEBUG_RSExecDistHybrid;
+  }
 
   // Prepare the spec ref for the background thread
   const char *idx = RedisModule_StringPtrLen(argv[1], NULL);
@@ -3775,6 +3783,10 @@ static int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **ar
   }
 
   if (NumShards == 1) {
+    if (isDebug) {
+      // argv still contains debug params; the non-debug handler would reject them as unknown args.
+      return DEBUG_hybridCommandHandler(ctx, argv, argc);
+    }
     return RSClientHybridCommand(ctx, argv, argc);
   } else if (cannotBlockCtx(ctx)) {
     return ReplyBlockDeny(ctx, argv[0]);
@@ -3813,7 +3825,7 @@ static int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **ar
 }
 
 int DistHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  return DistHybridCommandInternal(ctx, argv, argc, false);
+  return DistHybridCommandInternal(ctx, argv, argc, false /* isDebug */, false /* isProfile */);
 }
 
 static inline int CursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, RedisModuleCmdFunc subcmd, ConcurrentCmdHandler dist_callback) {
@@ -4394,6 +4406,10 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
 
   if (NumShards == 1) {
     // There is only one shard in the cluster. We can handle the command locally.
+    if (isDebug) {
+      // argv still contains debug params; the non-debug handler would reject them as unknown args.
+      return DEBUG_RSSearchCommand(ctx, argv, argc);
+    }
     return RSSearchCommand(ctx, argv, argc);
   } else if (cannotBlockCtx(ctx)) {
     return ReplyBlockDeny(ctx, argv[0]);
@@ -4490,12 +4506,18 @@ int ProfileCommandHandlerImp(RedisModuleCtx *ctx, RedisModuleString **argv, int 
     return RSProfileCommandImp(ctx, argv, argc, isDebug);
   }
 
+  // For SEARCH and AGGREGATE, pass isDebug through: their debug param format
+  // (TIMEOUT_AFTER_N, INTERNAL_ONLY) matches the profile debug params.
+  // For HYBRID, always pass false: hybrid uses command-specific debug params
+  // (TIMEOUT_AFTER_N_SEARCH, TIMEOUT_AFTER_N_VSIM, TIMEOUT_AFTER_N_TAIL) that
+  // differ from profile debug params. Passing isDebug=true would select
+  // DEBUG_RSExecDistHybrid, which would fail to parse the profile debug params.
   if (RMUtil_ArgExists("SEARCH", argv, 3, 2)) {
     return DistSearchCommandImp(ctx, argv, argc, isDebug);
   } else if (RMUtil_ArgExists("AGGREGATE", argv, 3, 2)) {
     return DistAggregateCommandImp(ctx, argv, argc, isDebug);
   } else if (RMUtil_ArgExists("HYBRID", argv, 3, 2)) {
-    return DistHybridCommandInternal(ctx, argv, argc, true);
+    return DistHybridCommandInternal(ctx, argv, argc, false, true /* isProfile */);
   }
   return RedisModule_ReplyWithError(ctx, "No `SEARCH`, `AGGREGATE`, or `HYBRID` provided");
 }

--- a/src/module.h
+++ b/src/module.h
@@ -127,6 +127,7 @@ void processResultFormat(uint32_t *flags, MRReply *map);
 
 int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDebug);
 int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDebug);
+int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDebug, bool isProfile);
 int RSProfileCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDebug);
 int ProfileCommandHandlerImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDebug);
 

--- a/src/redisearch_rs/c_entrypoint/query_error_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_error_ffi/src/lib.rs
@@ -107,28 +107,38 @@ pub const extern "C" fn QueryError_CodeMaxValue() -> u8 {
 
 /// Returns a [`QueryErrorCode`] given an error message.
 ///
+/// Matches the message by its prefix (e.g., `"SEARCH_TIMEOUT "`) rather than
+/// exact equality, so that custom messages like `"SEARCH_TIMEOUT Depleting
+/// timed out"` are correctly classified.
+///
 /// This only supports the query error codes [`QueryErrorCode::TimedOut`],
 /// [`QueryErrorCode::OutOfMemory`], and [`QueryErrorCode::UnavailableSlots`].
 /// If another message is provided, [`QueryErrorCode::Generic`] is returned.
 ///
+/// If the message is a null pointer, [`QueryErrorCode::Generic`] is returned.
 ///
 /// # Safety
 ///
 /// - `message` must be a valid C string or a NULL pointer.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn QueryError_GetCodeFromMessage(message: *const c_char) -> QueryErrorCode {
-    const TIMED_OUT_ERROR_CSTR: &CStr = QueryErrorCode::TimedOut.to_c_str();
-    const OUT_OF_MEMORY_ERROR_CSTR: &CStr = QueryErrorCode::OutOfMemory.to_c_str();
-    const UNAVAILABLE_SLOTS_ERROR_CSTR: &CStr = QueryErrorCode::UnavailableSlots.to_c_str();
+    if message.is_null() {
+        return QueryErrorCode::Generic;
+    }
 
-    // Safety: see safety requirement above.
-    let message = unsafe { CStr::from_ptr(message) };
+    const TIMED_OUT_PREFIX: &[u8] = QueryErrorCode::TimedOut.prefix_c_str().to_bytes();
+    const OUT_OF_MEMORY_PREFIX: &[u8] = QueryErrorCode::OutOfMemory.prefix_c_str().to_bytes();
+    const UNAVAILABLE_SLOTS_PREFIX: &[u8] =
+        QueryErrorCode::UnavailableSlots.prefix_c_str().to_bytes();
 
-    if message == TIMED_OUT_ERROR_CSTR {
+    // Safety: see safety requirement above and the handling of null pointer at the start.
+    let message = unsafe { CStr::from_ptr(message) }.to_bytes();
+
+    if message.starts_with(TIMED_OUT_PREFIX) {
         QueryErrorCode::TimedOut
-    } else if message == OUT_OF_MEMORY_ERROR_CSTR {
+    } else if message.starts_with(OUT_OF_MEMORY_PREFIX) {
         QueryErrorCode::OutOfMemory
-    } else if message == UNAVAILABLE_SLOTS_ERROR_CSTR {
+    } else if message.starts_with(UNAVAILABLE_SLOTS_PREFIX) {
         QueryErrorCode::UnavailableSlots
     } else {
         QueryErrorCode::Generic
@@ -442,6 +452,8 @@ pub unsafe extern "C" fn QueryError_SetQueryOOMWarning(query_error: *mut OpaqueQ
 /// [`QueryWarningCode::OutOfMemoryShard`] and [`QueryWarningCode::OutOfMemoryCoord`]. If another message is provided,
 /// [`QueryWarningCode::Ok`] is returned.
 ///
+/// If the message is a null pointer, returns [`QueryWarningCode::Ok`].
+///
 /// # Safety
 ///
 /// - `message` must be a valid C string or a NULL pointer.
@@ -449,13 +461,17 @@ pub unsafe extern "C" fn QueryError_SetQueryOOMWarning(query_error: *mut OpaqueQ
 pub unsafe extern "C" fn QueryWarningCode_GetCodeFromMessage(
     message: *const c_char,
 ) -> QueryWarningCode {
+    if message.is_null() {
+        return QueryWarningCode::Ok;
+    }
+
     const TIMED_OUT_WARNING_CSTR: &CStr = QueryWarningCode::TimedOut.to_c_str();
     const REACHED_MAX_PREFIX_EXPANSIONS_WARNING_CSTR: &CStr =
         QueryWarningCode::ReachedMaxPrefixExpansions.to_c_str();
     const OUT_OF_MEMORY_COORD_WARNING_CSTR: &CStr = QueryWarningCode::OutOfMemoryCoord.to_c_str();
     const OUT_OF_MEMORY_SHARD_WARNING_CSTR: &CStr = QueryWarningCode::OutOfMemoryShard.to_c_str();
 
-    // Safety: see safety requirement above.
+    // Safety: see safety requirement above and the handling of null pointer at the start.
     let message = unsafe { CStr::from_ptr(message) };
 
     if message == TIMED_OUT_WARNING_CSTR {

--- a/src/redisearch_rs/headers/query_error.h
+++ b/src/redisearch_rs/headers/query_error.h
@@ -229,10 +229,15 @@ uint8_t QueryError_CodeMaxValue(void);
 /**
  * Returns a [`QueryErrorCode`] given an error message.
  *
+ * Matches the message by its prefix (e.g., `"SEARCH_TIMEOUT "`) rather than
+ * exact equality, so that custom messages like `"SEARCH_TIMEOUT Depleting
+ * timed out"` are correctly classified.
+ *
  * This only supports the query error codes [`QueryErrorCode::TimedOut`],
  * [`QueryErrorCode::OutOfMemory`], and [`QueryErrorCode::UnavailableSlots`].
  * If another message is provided, [`QueryErrorCode::Generic`] is returned.
  *
+ * If the message is a null pointer, [`QueryErrorCode::Generic`] is returned.
  *
  * # Safety
  *
@@ -405,6 +410,8 @@ void QueryError_SetQueryOOMWarning(struct QueryError *query_error);
  * This only supports the query error codes [`QueryWarningCode::TimedOut`], [`QueryWarningCode::ReachedMaxPrefixExpansions`],
  * [`QueryWarningCode::OutOfMemoryShard`] and [`QueryWarningCode::OutOfMemoryCoord`]. If another message is provided,
  * [`QueryWarningCode::Ok`] is returned.
+ *
+ * If the message is a null pointer, returns [`QueryWarningCode::Ok`].
  *
  * # Safety
  *

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -2060,13 +2060,22 @@ int RPSafeDepleter_DepleteAll(arrayof(ResultProcessor*) safeDepleters, QueryErro
   // after all depleters acquired their locks (or when any failed).
   // This early release prevents deadlock with SafeLoader GIL acquisition.
 
-  // Check if any depleter skipped the lock phase (timeout before start or lock failure)
-  int num_skipped_lock = atomic_load(&sync->num_skipped_lock);
-  if (num_skipped_lock > 0) {
-    // At least one depleter skipped the lock phase
-    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_SAFE_DEPLETER_FAILURE,
-      "Failed to acquire index lock for background depletion. A write operation may be in progress. Please retry.");
-    return RS_RESULT_ERROR;
+  // Check each depleter's final status for errors or timeouts.
+  // Errors (lock failures) take priority over timeouts.
+  bool anyTimedOut = false;
+  for (size_t i = 0; i < count; i++) {
+    const RPSafeDepleter *safeDepleter = (RPSafeDepleter *)safeDepleters[i];
+    if (safeDepleter->last_rc == RS_RESULT_ERROR) {
+      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_SAFE_DEPLETER_FAILURE,
+        "Failed to acquire index lock for background depletion. A write operation may be in progress. Please retry.");
+      return RS_RESULT_ERROR;
+    } else if (safeDepleter->last_rc == RS_RESULT_TIMEDOUT) {
+      anyTimedOut = true;
+    }
+  }
+
+  if (anyTimedOut) {
+    return RS_RESULT_TIMEDOUT;
   }
 
   return RS_RESULT_OK;
@@ -2813,13 +2822,16 @@ rs_wall_clock_ns_t RPDepleter_GetDepletionTime(const ResultProcessor *base) {
 }
 
 int RPDepleter_DepleteAll(arrayof(ResultProcessor*) depleters) {
+  bool anyTimedOut = false;
   for (size_t i = 0; i < array_len(depleters); i++) {
     RS_ASSERT(depleters[i]->type == RP_DEPLETER);
     RPDepleter_StartDepletion(depleters[i]);
     const RPDepleter *depleter = (const RPDepleter *)depleters[i];
-    if (depleter->last_rc != RS_RESULT_EOF) {
-      return depleter->last_rc;
+    if (depleter->last_rc == RS_RESULT_ERROR) {
+      return RS_RESULT_ERROR;
+    } else if (depleter->last_rc == RS_RESULT_TIMEDOUT) {
+      anyTimedOut = true;
     }
   }
-  return RS_RESULT_OK;
+  return anyTimedOut ? RS_RESULT_TIMEDOUT : RS_RESULT_OK;
 }

--- a/tests/pytests/test_hybrid_timeout.py
+++ b/tests/pytests/test_hybrid_timeout.py
@@ -53,9 +53,109 @@ def test_hybrid_debug_with_no_index_error():
         'TIMEOUT_AFTER_N_SEARCH', '1', 'DEBUG_PARAMS_COUNT', '2').error()\
         .contains('SEARCH_INDEX_NOT_FOUND Index not found: nonexistent_idx')
 
-# Debug timeout tests using TIMEOUT_AFTER_N_* parameters
-#TODO: remove skip once FT.HYBRID for cluster is implemented
+
+# ---------------------------------------------------------------------------
+# Parameter validation tests for FT.HYBRID debug commands
+# ---------------------------------------------------------------------------
+
+def _base_hybrid_debug_cmd(idx='idx'):
+    """Build the common prefix for a hybrid debug command."""
+    return ['_FT.DEBUG', 'FT.HYBRID', idx, 'SEARCH', '*',
+            'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector]
+
+def test_hybrid_debug_wrong_arity():
+    """Test wrong arity for both the distributed and shard-level debug wrappers."""
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    # Too few arguments (need at least 9 for _FT.DEBUG FT.HYBRID)
+    env.expect('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM', '@embedding') \
+        .error().contains('wrong number of arguments')
+
+def test_hybrid_debug_missing_debug_params_count():
+    """Test error when DEBUG_PARAMS_COUNT is not provided."""
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    # Valid hybrid command but no DEBUG_PARAMS_COUNT at the end
+    env.expect(*_base_hybrid_debug_cmd(),
+               'TIMEOUT_AFTER_N_SEARCH', '1') \
+        .error().contains('DEBUG_PARAMS_COUNT')
+
+def test_hybrid_debug_invalid_debug_params_count():
+    """Test error when DEBUG_PARAMS_COUNT has an invalid value."""
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    for invalid_count in ['meow', '-1', '0.5']:
+        env.expect(*_base_hybrid_debug_cmd(),
+                   'TIMEOUT_AFTER_N_SEARCH', '1',
+                   'DEBUG_PARAMS_COUNT', invalid_count) \
+            .error().contains('Invalid DEBUG_PARAMS_COUNT count')
+
+def test_hybrid_debug_params_count_exceeds_argc():
+    """Test error when DEBUG_PARAMS_COUNT is larger than the number of available arguments."""
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    env.expect(*_base_hybrid_debug_cmd(),
+               'TIMEOUT_AFTER_N_SEARCH', '1',
+               'DEBUG_PARAMS_COUNT', '9999') \
+        .error().contains('DEBUG_PARAMS_COUNT exceeds')
+
+def test_hybrid_debug_unrecognized_argument():
+    """Test error when an unrecognized debug argument is provided."""
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    env.expect(*_base_hybrid_debug_cmd(),
+               'TIMEOUT_AFTER_N_MEOW', '1',
+               'DEBUG_PARAMS_COUNT', '2') \
+        .error().contains('Unrecognized argument')
+
 @skip(cluster=True)
+def test_hybrid_debug_no_component_timeout_sa():
+    """Test error when no component timeout parameter is specified (SA).
+
+    In SA mode, HybridRequest_Debug_New short-circuits on debug_params_count==0
+    before parseHybridDebugParams can validate. The reply is an error but
+    without the specific "At least one component timeout parameter" message.
+    """
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    env.expect(*_base_hybrid_debug_cmd(), 'DEBUG_PARAMS_COUNT', '0').error()
+
+@skip(cluster=False)
+def test_hybrid_debug_no_component_timeout_cluster():
+    """Test error when no component timeout parameter is specified (cluster).
+
+    In cluster mode, RSShardedHybridCommand_Debug calls parseHybridDebugParams
+    which validates that at least one component timeout is present.
+    """
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    env.expect(*_base_hybrid_debug_cmd(),
+               'DEBUG_PARAMS_COUNT', '0') \
+        .error().contains('At least one component timeout parameter')
+
+def test_hybrid_debug_invalid_timeout_values():
+    """Test error when timeout count values are invalid."""
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    for param in ['TIMEOUT_AFTER_N_SEARCH', 'TIMEOUT_AFTER_N_VSIM', 'TIMEOUT_AFTER_N_TAIL']:
+        for bad_val in ['meow', '-1', '0.5']:
+            env.expect(*_base_hybrid_debug_cmd(),
+                       param, bad_val,
+                       'DEBUG_PARAMS_COUNT', '2') \
+                .error().contains(f'Invalid {param} count')
+
+def test_hybrid_debug_missing_timeout_value():
+    """Test error when timeout parameter is provided without a value."""
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    # TIMEOUT_AFTER_N_SEARCH without its numeric argument;
+    # DEBUG_PARAMS_COUNT 1 means only 1 token is parsed as debug args.
+    env.expect(*_base_hybrid_debug_cmd(),
+               'TIMEOUT_AFTER_N_SEARCH',
+               'DEBUG_PARAMS_COUNT', '1') \
+        .error().contains('TIMEOUT_AFTER_N_SEARCH')
+
+# Debug timeout tests using TIMEOUT_AFTER_N_* parameters
 def test_debug_timeout_fail_search():
     """Test FAIL policy with search timeout using debug parameters"""
     env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT FAIL')
@@ -68,15 +168,13 @@ def test_debug_timeout_fail_vsim():
     setup_basic_index(env)
     env.expect('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector, 'TIMEOUT_AFTER_N_VSIM', '1', 'DEBUG_PARAMS_COUNT', '2').error().contains('SEARCH_TIMEOUT Timeout limit was reached')
 
-#TODO: remove skip once FT.HYBRID for cluster is implemented
-@skip(cluster=True)
 def test_debug_timeout_fail_both():
     """Test FAIL policy with both components timeout using debug parameters"""
     env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT FAIL')
     setup_basic_index(env)
     env.expect('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector, 'TIMEOUT_AFTER_N_SEARCH', '1','TIMEOUT_AFTER_N_VSIM', '2', 'DEBUG_PARAMS_COUNT', '4').error().contains('SEARCH_TIMEOUT Timeout limit was reached')
 
-#TODO: remove skip once FT.HYBRID for cluster is implemented
+# Tail pipeline runs on the coordinator; debug timeout params aren't applied there in cluster.
 @skip(cluster=True)
 def test_debug_timeout_fail_tail():
     """Test FAIL policy with tail timeout using debug parameters"""
@@ -84,7 +182,7 @@ def test_debug_timeout_fail_tail():
     setup_basic_index(env)
     env.expect('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector, 'TIMEOUT_AFTER_N_TAIL', '1', 'DEBUG_PARAMS_COUNT', '2').error().contains('SEARCH_TIMEOUT Timeout limit was reached')
 
-#TODO: remove skip once FT.HYBRID for cluster is implemented
+# Tail pipeline runs on the coordinator; debug timeout params aren't applied there in cluster.
 @skip(cluster=True)
 def test_debug_timeout_return_tail():
     """Test FAIL policy with tail timeout using debug parameters"""
@@ -95,8 +193,6 @@ def test_debug_timeout_return_tail():
     env.assertEqual(['Timeout limit was reached (POST PROCESSING)'], get_warnings(response))
 
 
-#TODO: remove skip once FT.HYBRID for cluster is implemented
-@skip(cluster=True)
 def test_debug_timeout_return_search():
     """Test RETURN policy with search timeout using debug parameters"""
     env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT RETURN')
@@ -105,8 +201,6 @@ def test_debug_timeout_return_search():
                        'TIMEOUT_AFTER_N_SEARCH', '1', 'DEBUG_PARAMS_COUNT', '2')
     env.assertEqual(['Timeout limit was reached (SEARCH)'], get_warnings(response))
 
-#TODO: remove skip once FT.HYBRID for cluster is implemented
-@skip(cluster=True)
 def test_debug_timeout_return_vsim():
     """Test RETURN policy with vector similarity timeout using debug parameters"""
     env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT RETURN')
@@ -115,8 +209,6 @@ def test_debug_timeout_return_vsim():
                        'TIMEOUT_AFTER_N_VSIM', '1', 'DEBUG_PARAMS_COUNT', '2')
     env.assertEqual(['Timeout limit was reached (VSIM)'], get_warnings(response))
 
-#TODO: remove skip once FT.HYBRID for cluster is implemented
-@skip(cluster=True)
 def test_debug_timeout_return_both():
     """Test RETURN policy with both components timeout using debug parameters"""
     env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT RETURN')
@@ -128,7 +220,7 @@ def test_debug_timeout_return_both():
     env.assertTrue('Timeout limit was reached (VSIM)' in get_warnings(response))
     # TODO: add test for tail timeout once MOD-11004 is merged
 
-#TODO: remove skip once FT.HYBRID for cluster is implemented
+# Partial result assertions depend on data distribution across shards.
 @skip(cluster=True)
 def test_debug_timeout_return_with_results():
     """Test RETURN policy returns partial results when components timeout"""
@@ -143,6 +235,87 @@ def test_debug_timeout_return_with_results():
     env.assertTrue('doc:3' in results.keys())
     # Expect exactly one document from VSIM since the timeout occurred after processing one result - should be either doc:2 or doc:4
     env.assertTrue(('doc:2' in results.keys()) ^ ('doc:4' in results.keys()))
+
+# ---------------------------------------------------------------------------
+# Sanity comparison: debug results vs regular results
+# ---------------------------------------------------------------------------
+
+@skip(cluster=True)
+def test_debug_sanity_no_truncation():
+    """Verify a debug query with high timeouts returns the same results as a regular query.
+
+    Analogous to the Sanity() method in test_debug_commands.py for FT.SEARCH/FT.AGGREGATE.
+    """
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+
+    regular_res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM',
+                          '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector)
+    regular_results, regular_count = get_results_from_hybrid_response(regular_res)
+
+    # Timeouts high enough that no component actually times out (4 docs in dataset).
+    debug_res = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM',
+                        '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
+                        'TIMEOUT_AFTER_N_SEARCH', '100', 'TIMEOUT_AFTER_N_VSIM', '100',
+                        'DEBUG_PARAMS_COUNT', '4')
+    debug_results, debug_count = get_results_from_hybrid_response(debug_res)
+
+    env.assertEqual(regular_count, debug_count,
+                    message=f"Expected same count: regular={regular_count}, debug={debug_count}")
+    env.assertEqual(set(regular_results.keys()), set(debug_results.keys()),
+                    message="Debug query should return the same documents as regular query")
+
+@skip(cluster=True)
+def test_debug_sanity_truncated_subset():
+    """Verify a debug query with truncation returns a subset of regular query results."""
+    env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT RETURN')
+    setup_basic_index(env)
+
+    regular_res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM',
+                          '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector)
+    regular_results, _ = get_results_from_hybrid_response(regular_res)
+
+    # Both components limited to 1 result each; the union is at most 2 of the 4 docs.
+    debug_res = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM',
+                        '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
+                        'TIMEOUT_AFTER_N_SEARCH', '1', 'TIMEOUT_AFTER_N_VSIM', '1',
+                        'DEBUG_PARAMS_COUNT', '4')
+    debug_results, debug_count = get_results_from_hybrid_response(debug_res)
+
+    env.assertGreater(len(regular_results), len(debug_results),
+                      message="Debug query with truncation should return fewer documents")
+    env.assertTrue(set(debug_results.keys()).issubset(set(regular_results.keys())),
+                   message="Debug results should be a subset of regular results")
+    warnings = get_warnings(debug_res)
+    env.assertGreater(len(warnings), 0, message="Expected at least one timeout warning")
+
+# ---------------------------------------------------------------------------
+# Boundary: TIMEOUT_AFTER_N_* 0 means "no timeout for that component"
+# ---------------------------------------------------------------------------
+
+@skip(cluster=True)
+def test_debug_timeout_zero_means_no_timeout():
+    """TIMEOUT_AFTER_N_* 0 means "no timeout for this component" — it runs normally.
+
+    This differs from non-hybrid TIMEOUT_AFTER_N where 0 means "timeout immediately."
+    """
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+
+    regular_res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM',
+                          '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector)
+    regular_results, regular_count = get_results_from_hybrid_response(regular_res)
+
+    debug_res = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM',
+                        '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
+                        'TIMEOUT_AFTER_N_SEARCH', '0', 'TIMEOUT_AFTER_N_VSIM', '0',
+                        'DEBUG_PARAMS_COUNT', '4')
+    debug_results, debug_count = get_results_from_hybrid_response(debug_res)
+
+    env.assertEqual(regular_count, debug_count,
+                    message="Timeout 0 should not truncate results")
+    env.assertEqual(set(regular_results.keys()), set(debug_results.keys()),
+                    message="Timeout 0 should return the same documents as regular query")
 
 # Warning and error tests
 #TODO: remove skip once FT.HYBRID warning handling for cluster is stable
@@ -208,9 +381,23 @@ def test_tail_property_not_loaded_error_standalone():
               'AS', 'doubled_score').error().contains('__score')
 
 @skip(cluster=False)
+def test_debug_profile_hybrid_uses_normal_callback():
+    """Test FT.DEBUG FT.PROFILE is handled correctly."""
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    res = env.cmd(
+        '_FT.DEBUG', 'FT.PROFILE', 'idx', 'HYBRID', 'QUERY',
+        'SEARCH', '*',
+        'VSIM', '@embedding', '$BLOB',
+        'PARAMS', '2', 'BLOB', query_vector)
+    # Basic sanity: we got results and profile info without an error.
+    env.assertIsNotNone(res)
+    env.assertGreater(len(res), 0)
+
+@skip(cluster=False)
 def test_tail_property_not_loaded_warning_coordinator():
     """Test warning when tail pipeline references property not loaded (coordinator mode)
-    
+
     Related: test_tail_property_not_loaded_error_standalone
     In coordinator mode, tail pipeline errors become warnings (protocol limitation).
     The error code also differs: VALUE_NOT_FOUND (coord) vs PROP_NOT_FOUND (standalone).
@@ -233,6 +420,15 @@ def test_tail_property_not_loaded_warning_coordinator():
     env.assertTrue(any('__score' in w for w in warnings),
                    message=f"Expected warning about __score, got: {warnings}")
 
+def test_debug_timeout_return_strict_rejected():
+    """Test that _FT.DEBUG FT.HYBRID rejects ON_TIMEOUT RETURN-STRICT policy."""
+    env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT RETURN-STRICT')
+    setup_basic_index(env)
+    env.expect(
+        '_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running',
+        'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
+        'TIMEOUT_AFTER_N_SEARCH', '1', 'DEBUG_PARAMS_COUNT', '2'
+    ).error().contains('not supported with ON_TIMEOUT RETURN-STRICT')
 
 @skip(cluster=False)
 def test_timeout_setup_phase_hybrid():

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -1202,7 +1202,13 @@ class testWarningsAndErrorsCluster:
 
   def test_timeout_cluster(self):
     # In cluster mode, test both shard-level and coordinator-level timeouts.
-    # HYBRID debug is not supported in cluster.
+
+    # Insert enough vec docs so every shard has VSIM data for HYBRID timeout testing.
+    conn = getConnectionByEnv(self.env)
+    for i in range(30):
+      conn.execute_command('HSET', f'vec:timeout_{i}', 'vector', np.array([float(i), 0.0]).astype(np.float32).tobytes())
+
+    query_vec = np.array([1.0, 0.0]).astype(np.float32).tobytes()
 
     # ---------- Timeout Errors ----------
     allShards_change_timeout_policy(self.env, 'FAIL')
@@ -1249,6 +1255,22 @@ class testWarningsAndErrorsCluster:
     self.env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][TIMEOUT_ERROR_COORD_METRIC], str(base_err_coord + 3),
                          message="Coordinator timeout error should be +1 after AGG coordinator timeout")
 
+    # Test timeout error in FT.HYBRID (shards via TIMEOUT_AFTER_N_VSIM)
+    self.env.expect(debug_cmd(), 'FT.HYBRID', 'idx_vec', 'SEARCH', 'hello world',
+                    'VSIM', '@vector', '$BLOB', 'PARAMS', '2', 'BLOB', query_vec,
+                    'TIMEOUT_AFTER_N_VSIM', 1, 'DEBUG_PARAMS_COUNT', 2).error().contains('SEARCH_TIMEOUT Timeout limit was reached')
+    # Shards: +1 each (total +4)
+    for shardId in range(1, self.env.shardsCount + 1):
+      shard_conn = self.env.getConnection(shardId)
+      wait_for_info_metric(shard_conn, [WARN_ERR_SECTION, TIMEOUT_ERROR_SHARD_METRIC], str(base_err_shards[shardId] + 4),
+                           msg=f"Shard {shardId} HYBRID VSIM timeout error should be +4")
+    # Coord: +5 — on 8.6-rse each dist-hybrid FAIL error is counted twice:
+    # DistHybridCleanups counts it when storing the error, and
+    # DistHybridReplyCallback counts it again when replying it.
+    info_coord = info_modules_to_dict(self.env)
+    self.env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][TIMEOUT_ERROR_COORD_METRIC], str(base_err_coord + 5),
+                         message="Coordinator timeout error should be +5 after FT.HYBRID (double-counted on 8.6-rse)")
+
     # ---------- Timeout Warnings ----------
     allShards_change_timeout_policy(self.env, 'RETURN')
 
@@ -1269,6 +1291,18 @@ class testWarningsAndErrorsCluster:
     info_coord = info_modules_to_dict(self.env)
     self.env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][TIMEOUT_WARNING_COORD_METRIC], str(base_warn_coord),
                          message="Coordinator timeout warning should not change after FT.SEARCH")
+
+    # Test timeout warning in FT.HYBRID (shards via TIMEOUT_AFTER_N_VSIM)
+    self.env.expect(debug_cmd(), 'FT.HYBRID', 'idx_vec', 'SEARCH', 'hello world',
+                    'VSIM', '@vector', '$BLOB', 'PARAMS', '2', 'BLOB', query_vec,
+                    'TIMEOUT_AFTER_N_VSIM', 1, 'DEBUG_PARAMS_COUNT', 2).noError()
+    # In RETURN mode, the shard increments timeout_warning twice per hybrid query:
+    # once from the internal AREQ subquery timeout and once from replyWithCursors.
+    # Shards: +2 each (total: SEARCH +1, HYBRID +2 = +3)
+    for shardId in range(1, self.env.shardsCount + 1):
+      shard_conn = self.env.getConnection(shardId)
+      wait_for_info_metric(shard_conn, [WARN_ERR_SECTION, TIMEOUT_WARNING_SHARD_METRIC], str(base_warn_shards[shardId] + 3),
+                           msg=f"Shard {shardId} HYBRID VSIM timeout warning should be +3")
 
     # Test other metrics not changed (on shards)
     tested_in_this_test = [TIMEOUT_ERROR_SHARD_METRIC, TIMEOUT_WARNING_SHARD_METRIC, TIMEOUT_ERROR_COORD_METRIC, TIMEOUT_WARNING_COORD_METRIC]


### PR DESCRIPTION
## Describe the changes in the pull request

Backport of #9215 to the 8.6-rse line.

1. Current: On 8.6-rse, `FT.DEBUG FT.HYBRID` is not supported in cluster mode, and FT.HYBRID does not surface shard timeout warnings to the client in cluster mode.
2. Change: Cherry-pick of master's #9215 — adds `_FT.DEBUG FT.HYBRID` / `FT.DEBUG FT.HYBRID` support on the coordinator (debug timeout injection via `TIMEOUT_AFTER_N_SEARCH/VSIM/TAIL` + `DEBUG_PARAMS_COUNT`), and propagates shard timeout warnings so the coordinator emits them in the reply's `warnings` array (RETURN/RETURN-STRICT policies) or a clean timeout error (FAIL policy), with `INFO` warning/error metrics.
3. Outcome: `FT.DEBUG FT.HYBRID` works in cluster mode on 8.6-rse, and FT.HYBRID cluster queries report shard timeouts the same way FT.SEARCH/FT.AGGREGATE do.

Original PR: #9215 ([MOD-14309][MOD-14311], master `02bc76a93`). Siblings: #10414 (8.6), #10512 (8.4). Unlike those, this pick is from **master's original commit**: 8.6-rse branched from master in late March 2026 and already has MOD-11806 (prefixed error messages), RETURN-STRICT, and `CoordRequestCtx`, so none of the big 8.6/8.4 adaptations apply here.

<details>
<summary><b>Conflict-resolution notes (8.6-rse adaptation)</b></summary>

7 conflicts; `reply_empty.c`, `dist_hybrid.c/h`, `hybrid_debug.c/h`, `debug_commands.c`, `result_processor.c`, and the Rust `query_error_ffi` changes applied cleanly.

- **`hybrid_cursor_mappings.c/h`**: mini-ported the `RSTimeoutPolicy` parameter into `ProcessHybridCursorMappings` (master had it from MOD-13189, which landed after 8.6-rse branched); adopted #9215's classification verbatim, including the RETURN-STRICT comment.
- **`hybrid_exec.c` (`HybridRequest_StartCursors`)**: grafted #9215's RETURN-policy behavior (keep cursors with partial results + emit the timeout warning via `replyWithCursors`) onto 8.6-rse's local-cursor-array shape — master's `req->cursors`/`cursorMutex` and the hybrid blocked-client cursor callbacks (`HybridQueryTimeoutFailCallback` et al.) landed on master after 8.6-rse branched and are not part of this backport. Master's `"Depleting timed out"` detail message is kept as-is (prefix-matching classification works here).
- **`hybrid_request.h/.c`**: took only #9215's actual additions (`HybridDebugParams *debugParams` + its free); dropped the `cursorMutex`/`cursors` context from the missing infrastructure.
- **`module.c`**: took master's public `DistHybridCommandInternal(..., bool isDebug, ...)` signature while keeping 8.6-rse's own `CoordRequestCtx` declarations around it.
- **Tests**: kept #9215's tests verbatim (prefixed assertions and the RETURN-STRICT rejection test are valid here); merged with 8.6-rse's `test_timeout_setup_phase_hybrid` (#10201) and renumbered the `test_info_modules.py` FT.HYBRID timeout block after 8.6-rse's MOD-15113 aggregate block (#9885).
- **Pre-existing metric double-count (flagged, not fixed)**: on 8.6-rse, each dist-hybrid FAIL error increments the coordinator error metric **twice** — `DistHybridCleanups` counts it when storing the error into `storedReplyState`, and `DistHybridReplyCallback` counts it again when replying it. The backported metrics test was adapted to expect the doubled count with an explanatory comment. This affects any dist-hybrid error routed through the stored-reply path and predates this PR; it likely deserves its own ticket.

Verification: full DEBUG build green; all 23 `test_hybrid_*` pytest files pass in standalone (165/165) and cluster; `test_info_modules.py::testWarningsAndErrorsCluster` 7/7.

</details>

#### Which additional issues this PR fixes

1. MOD-15120
2. MOD-15121

#### Main objects this PR modified

1. `src/coord/hybrid/dist_hybrid.c` — `DEBUG_RSExecDistHybrid`, debug-param plumbing into the MR command
2. `src/coord/hybrid/hybrid_cursor_mappings.c` — warning classification + timeout-policy handling
3. `src/hybrid/hybrid_exec.c` / `hybrid_debug.c` — debug timeout application, RETURN-policy cursor retention, warning emission
4. `src/debug_commands.c`, `src/module.c` — `FT.DEBUG FT.HYBRID` / `_FT.DEBUG _FT.HYBRID` dispatch
5. `src/result_processor.c` — depleter `DepleteAll` error/timeout priority
6. `src/redisearch_rs/c_entrypoint/query_error_ffi` — prefix-based message→code classification + null guards

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MOD-14309]: https://redislabs.atlassian.net/browse/MOD-14309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ