### PR TITLE
[8.10] enable + shrink groupby-collect COLLECT benchmarks

### DIFF
--- a/tests/benchmarks/search-groupby-collect-100K-entity-events-hash-cached-sortby-fields-explicit-k50.yml
+++ b/tests/benchmarks/search-groupby-collect-100K-entity-events-hash-cached-sortby-fields-explicit-k50.yml
@@ -33,7 +33,7 @@ clientconfig:
   - benchmark_type: "read-only"
   - tool: ftsb_redisearch
   - parameters:
-    - workers: 64
+    - workers: 16
     - requests: 100000
     - reporting-period: 1s
     - duration: 120s

--- a/tests/benchmarks/search-groupby-collect-100K-entity-events-hash-cached-sortby-fields-star-offset500-k50.yml
+++ b/tests/benchmarks/search-groupby-collect-100K-entity-events-hash-cached-sortby-fields-star-offset500-k50.yml
@@ -33,7 +33,7 @@ clientconfig:
   - benchmark_type: "read-only"
   - tool: ftsb_redisearch
   - parameters:
-    - workers: 64
+    - workers: 16
     - requests: 100000
     - reporting-period: 1s
     - duration: 120s

--- a/tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-star-offset500-k50.yml
+++ b/tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-star-offset500-k50.yml
@@ -1,5 +1,5 @@
 version: 0.5
-name: "search-groupby-collect-100K-entity-events-hash-cached-sortby-fields-star-offset500-k50"
+name: "search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-star-offset500-k50"
 description: "GROUPBY + COLLECT HASH benchmark with FIELDS * and LIMIT 500 50."
 
 metadata:
@@ -16,7 +16,7 @@ setups:
   - oss-cluster-02-primaries
 
 dbconfig:
-  - dataset_name: "groupby-collect-entity-events-100K-heavy-hash"
+  - dataset_name: "groupby-collect-entity-events-10K-heavy-hash"
   - dataset_load_timeout_secs: 1800
   - init_commands:
     - '"CONFIG" "SET" "search-enable-unstable-features" "yes"'
@@ -25,9 +25,9 @@ dbconfig:
   - parameters:
     - workers: 64
     - reporting-period: 1s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-100K-heavy-hash/groupby-collect-entity-events-100K-heavy-hash.redisearch.commands.SETUP.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-hash/groupby-collect-entity-events-10K-heavy-hash.redisearch.commands.SETUP.csv"
   - check:
-      keyspacelen: 100000
+      keyspacelen: 10000
 
 clientconfig:
   - benchmark_type: "read-only"
@@ -37,4 +37,4 @@ clientconfig:
     - requests: 100000
     - reporting-period: 1s
     - duration: 120s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-100K-heavy-hash/groupby-collect-entity-events-100K-heavy-hash.redisearch.commands.BENCH.QUERY_collect-fields-star-offset500-k50.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-hash/groupby-collect-entity-events-10K-heavy-hash.redisearch.commands.BENCH.QUERY_collect-fields-star-offset500-k50.csv"

--- a/tests/benchmarks/search-groupby-collect-10K-entity-events-json-cached-sortby-fields-explicit-k50.yml
+++ b/tests/benchmarks/search-groupby-collect-10K-entity-events-json-cached-sortby-fields-explicit-k50.yml
@@ -1,5 +1,5 @@
 version: 0.5
-name: "search-groupby-collect-100K-entity-events-json-cached-sortby-fields-explicit-k50"
+name: "search-groupby-collect-10K-entity-events-json-cached-sortby-fields-explicit-k50"
 description: "GROUPBY + COLLECT JSON benchmark with explicit projected fields and LIMIT 0 50."
 
 metadata:
@@ -16,7 +16,7 @@ setups:
   - oss-cluster-02-primaries
 
 dbconfig:
-  - dataset_name: "groupby-collect-entity-events-100K-heavy-json"
+  - dataset_name: "groupby-collect-entity-events-10K-heavy-json"
   - dataset_load_timeout_secs: 1800
   - init_commands:
     - '"CONFIG" "SET" "search-enable-unstable-features" "yes"'
@@ -25,16 +25,16 @@ dbconfig:
   - parameters:
     - workers: 64
     - reporting-period: 1s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-100K-heavy-json/groupby-collect-entity-events-100K-heavy-json.redisjson.commands.SETUP.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-json/groupby-collect-entity-events-10K-heavy-json.redisjson.commands.SETUP.csv"
   - check:
-      keyspacelen: 100000
+      keyspacelen: 10000
 
 clientconfig:
   - benchmark_type: "read-only"
   - tool: ftsb_redisearch
   - parameters:
-    - workers: 64
+    - workers: 16
     - requests: 100000
     - reporting-period: 1s
     - duration: 120s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-100K-heavy-json/groupby-collect-entity-events-100K-heavy-json.redisjson.commands.BENCH.QUERY_collect-fields-explicit-k50.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-json/groupby-collect-entity-events-10K-heavy-json.redisjson.commands.BENCH.QUERY_collect-fields-explicit-k50.csv"

--- a/tests/benchmarks/search-groupby-collect-10K-entity-events-json-cached-sortby-fields-star-offset500-k50.yml
+++ b/tests/benchmarks/search-groupby-collect-10K-entity-events-json-cached-sortby-fields-star-offset500-k50.yml
@@ -1,5 +1,5 @@
 version: 0.5
-name: "search-groupby-collect-100K-entity-events-json-cached-sortby-fields-star-offset500-k50"
+name: "search-groupby-collect-10K-entity-events-json-cached-sortby-fields-star-offset500-k50"
 description: "GROUPBY + COLLECT JSON benchmark with FIELDS * and LIMIT 500 50."
 
 metadata:
@@ -16,7 +16,7 @@ setups:
   - oss-cluster-02-primaries
 
 dbconfig:
-  - dataset_name: "groupby-collect-entity-events-100K-heavy-json"
+  - dataset_name: "groupby-collect-entity-events-10K-heavy-json"
   - dataset_load_timeout_secs: 1800
   - init_commands:
     - '"CONFIG" "SET" "search-enable-unstable-features" "yes"'
@@ -25,16 +25,16 @@ dbconfig:
   - parameters:
     - workers: 64
     - reporting-period: 1s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-100K-heavy-json/groupby-collect-entity-events-100K-heavy-json.redisjson.commands.SETUP.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-json/groupby-collect-entity-events-10K-heavy-json.redisjson.commands.SETUP.csv"
   - check:
-      keyspacelen: 100000
+      keyspacelen: 10000
 
 clientconfig:
   - benchmark_type: "read-only"
   - tool: ftsb_redisearch
   - parameters:
-    - workers: 64
+    - workers: 16
     - requests: 100000
     - reporting-period: 1s
     - duration: 120s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-100K-heavy-json/groupby-collect-entity-events-100K-heavy-json.redisjson.commands.BENCH.QUERY_collect-fields-star-offset500-k50.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-json/groupby-collect-entity-events-10K-heavy-json.redisjson.commands.BENCH.QUERY_collect-fields-star-offset500-k50.csv"


### PR DESCRIPTION
## Describe the changes in the pull request

Backport of two master PRs to `8.10`, one commit each:

1. **[MOD-17201] enable groupby-collect COLLECT benchmarks in CI** — original #10592
2. **[MOD-17201] shrink groupby-collect hash star-offset500 benchmark to 10K** — original #10618

**Current:** On `8.10` the four `search-groupby-collect-*` COLLECT benchmarks exist (from #9794, already present via resync #10448) at their original 100K / 64-client-worker configuration.
**Change:** Bring `8.10` in line with master: re-tune the COLLECT benchmarks so they complete on the CI infra — hash client workers 64→16, json variants shrunk to a distinct 10K identity, and the hash `star-offset500` variant shrunk to 10K (it stalls at 100K).
**Outcome:** The four COLLECT variants match master byte-for-byte and run green on `oss-standalone`.

Note: #9794 ("Add GROUPBY COLLECT benchmarks") is **already present on `8.10`** (resync #10448), so it is not re-applied here. The `disabled/` directory does not exist on `8.10`, so #10592's `disabled/README.md` edit is intentionally dropped during the backport; all four benchmark files end up identical to master.

#### Which additional issues this PR fixes
1. MOD-17201
2. Backport of #10592 and #10618

#### Main objects this PR modified
1. `tests/benchmarks/search-groupby-collect-100K-entity-events-hash-cached-sortby-fields-explicit-k50.yml` — client workers 64→16
2. `tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-star-offset500-k50.yml` — renamed from 100K, shrunk to 10K
3. `tests/benchmarks/search-groupby-collect-10K-entity-events-json-cached-sortby-fields-{explicit,star-offset500}-k50.yml` — renamed from 100K, shrunk to 10K

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

[MOD-17201]: https://redislabs.atlassian.net/browse/MOD-17201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOD-17201]: https://redislabs.atlassian.net/browse/MOD-17201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ