### PR TITLE
[MOD-16877] Fix numeric index cardinality and bounds under float compression

### DIFF
--- a/src/redisearch_rs/inverted_index/src/codec/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/numeric.rs
@@ -175,6 +175,114 @@ impl NumericFloatCompression {
     const FLOAT_COMPRESSION_THRESHOLD: f64 = 0.01;
 }
 
+/// An encoder that decides how it will represent a numeric value before writing it.
+///
+/// The representation cannot always hold the value it was given —
+/// [`NumericFloatCompression`] stores an `f32` when the precision loss is below
+/// [its threshold](NumericFloatCompression::FLOAT_COMPRESSION_THRESHOLD), and even
+/// [`Numeric`] normalizes `-0.0` to `+0.0` by encoding it as a tiny integer. That
+/// decision is made inside [`Encoder::encode`], so anything derived from a value —
+/// cardinality, bounds, routing — must be derived from the [`StoredValue`] instead,
+/// or it describes a value the index never returns.
+///
+/// [`prepare`](Self::prepare) exposes the decision on its own and
+/// [`encode_prepared`](Self::encode_prepared) takes it back, so a caller that needs
+/// the outcome up front does not make the encoder work it out twice.
+///
+/// Implementers canonicalize: two inputs represented as the same number produce the
+/// same [`StoredValue`], so distinct stored values are numerically distinct. Callers
+/// that separate values — a cardinality estimate deciding when to split, say — can
+/// rely on that instead of second-guessing the representation.
+pub trait NumericEncoder: Encoder {
+    /// Decide how `value` will be represented. Writes nothing.
+    fn prepare(value: f64) -> PreparedValue;
+
+    /// Write a value whose representation has already been decided.
+    ///
+    /// Equivalent to [`Encoder::encode`] on a record holding the same value, down to
+    /// the bytes.
+    fn encode_prepared<W: Write + std::io::Seek>(
+        writer: W,
+        delta: Self::Delta,
+        prepared: PreparedValue,
+    ) -> std::io::Result<usize>;
+
+    /// The value a reader will decode after `value` is encoded by this encoder.
+    ///
+    /// Idempotent: the stored form of a stored value is itself.
+    fn stored_value(value: f64) -> f64 {
+        Self::prepare(value).stored_value().get()
+    }
+}
+
+impl NumericEncoder for Numeric {
+    fn prepare(value: f64) -> PreparedValue {
+        PreparedValue(Value::from(value, false))
+    }
+
+    fn encode_prepared<W: Write + std::io::Seek>(
+        writer: W,
+        delta: Self::Delta,
+        prepared: PreparedValue,
+    ) -> std::io::Result<usize> {
+        encode_value(writer, delta, prepared.0)
+    }
+}
+
+impl NumericEncoder for NumericFloatCompression {
+    fn prepare(value: f64) -> PreparedValue {
+        PreparedValue(Value::from(value, true))
+    }
+
+    fn encode_prepared<W: Write + std::io::Seek>(
+        writer: W,
+        delta: Self::Delta,
+        prepared: PreparedValue,
+    ) -> std::io::Result<usize> {
+        encode_value(writer, delta, prepared.0)
+    }
+}
+
+/// How a numeric encoder will represent a value: decided, but not yet written.
+///
+/// Not parameterized by encoder on purpose: the byte layout records which
+/// representation was used, so either numeric encoder can write a decision the other
+/// one made, and any numeric decoder reads it back. Preparing with a different
+/// encoder than the index uses is therefore harmless, if pointless.
+#[derive(Debug, Clone, Copy)]
+pub struct PreparedValue(Value);
+
+impl PreparedValue {
+    /// The value a reader will decode for this representation.
+    pub const fn stored_value(self) -> StoredValue {
+        StoredValue(self.0.to_f64())
+    }
+}
+
+/// A numeric value in the exact form an index stores — and therefore returns — it.
+///
+/// Distinct from a plain `f64` so that an input value on its way in cannot be
+/// mistaken for one the index will hand back. See [`NumericEncoder`] for why that
+/// distinction matters.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct StoredValue(f64);
+
+impl StoredValue {
+    /// Wrap a value that came out of a numeric index, which is already in stored
+    /// form.
+    ///
+    /// The caller owns that provenance: pass only values read back through a numeric
+    /// [`Decoder`], never an input value on its way in.
+    pub const fn from_decoded(value: f64) -> Self {
+        Self(value)
+    }
+
+    /// The wrapped value.
+    pub const fn get(self) -> f64 {
+        self.0
+    }
+}
+
 /// The [`Numeric`] encoder only supports encoding deltas that fit within 7 bytes
 #[derive(Debug, PartialEq)]
 pub struct NumericDelta(u64);
@@ -237,7 +345,7 @@ impl Encoder for NumericFloatCompression {
 }
 
 fn encode<W: Write + std::io::Seek>(
-    mut writer: W,
+    writer: W,
     delta: NumericDelta,
     record: &RSIndexResult,
     compress_floats: bool,
@@ -246,6 +354,16 @@ fn encode<W: Write + std::io::Seek>(
         .as_numeric()
         .expect("numeric encoder will only be called for numeric records");
 
+    encode_value(writer, delta, Value::from(num_record, compress_floats))
+}
+
+/// Write a value whose representation has already been decided — the single writer
+/// behind both [`Encoder::encode`] and [`NumericEncoder::encode_prepared`].
+fn encode_value<W: Write + std::io::Seek>(
+    mut writer: W,
+    delta: NumericDelta,
+    value: Value,
+) -> std::io::Result<usize> {
     let delta = delta.pack();
 
     // Trim trailing zeros from delta so that we store as little as possible
@@ -253,7 +371,7 @@ fn encode<W: Write + std::io::Seek>(
     let delta = &delta[..end];
     let delta_bytes = delta.len() as _;
 
-    let bytes_written = match Value::from(num_record, compress_floats) {
+    let bytes_written = match value {
         Value::TinyInteger(i) => {
             let header = Header {
                 delta_bytes,
@@ -613,7 +731,7 @@ impl FromSlice for f64 {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum Value {
     TinyInteger(u8),
     IntegerPositive(u64),
@@ -654,7 +772,19 @@ impl Value {
                             && (abs_val - f32_value as f64).abs()
                                 < NumericFloatCompression::FLOAT_COMPRESSION_THRESHOLD)
                     {
-                        if v.is_sign_positive() {
+                        // A magnitude that rounds to zero has collapsed *onto* zero, so
+                        // store the canonical zero — the representation a literal `0.0`
+                        // gets — rather than a signed f32 zero. Otherwise two inputs this
+                        // encoder decided to represent as zero become two stored values
+                        // that compare equal, and every consumer would have to know which
+                        // stored values are secretly the same value.
+                        //
+                        // Only reachable with compression on: without it this branch needs
+                        // `back_to_f64 == abs_val`, which for a zero `f32_value` means
+                        // `abs_val` is zero — already claimed by the integer branch above.
+                        if f32_value == 0.0 {
+                            Value::TinyInteger(0)
+                        } else if v.is_sign_positive() {
                             Value::Float32Positive(f32_value)
                         } else {
                             Value::Float32Negative(f32_value)
@@ -666,6 +796,25 @@ impl Value {
                     }
                 }
             }
+        }
+    }
+
+    /// The `f64` a reader decodes for this representation.
+    ///
+    /// Mirrors [`decode`] arm for arm rather than sharing code with it: `decode` is on
+    /// the read hot path and rebuilds the number straight from the bytes. The
+    /// `numeric_stored_value_matches_encode_decode` proptest keeps the two in step.
+    const fn to_f64(self) -> f64 {
+        match self {
+            Value::TinyInteger(i) => i as f64,
+            Value::IntegerPositive(i) => i as f64,
+            Value::IntegerNegative(i) => (i as f64).copysign(-1.0),
+            Value::Float32Positive(f) => f as f64,
+            Value::Float32Negative(f) => f.copysign(-1.0) as f64,
+            Value::Float64Positive(f) => f,
+            Value::Float64Negative(f) => f.copysign(-1.0),
+            Value::FloatInfinity => f64::INFINITY,
+            Value::FloatNegInfinity => f64::NEG_INFINITY,
         }
     }
 }

--- a/src/redisearch_rs/inverted_index/src/index/core.rs
+++ b/src/redisearch_rs/inverted_index/src/index/core.rs
@@ -19,6 +19,7 @@ use crate::{
     BlockCapacity, Encoder, IdDelta,
     controlled_cursor::ControlledCursor,
     debug::{BlockSummary, Summary},
+    numeric::{NumericEncoder, PreparedValue},
 };
 use ffi::{IndexFlags, IndexFlags_Index_HasMultiValue};
 use index_result::RSIndexResult;
@@ -193,8 +194,20 @@ impl<E: Encoder> InvertedIndex<E> {
     /// It is expected that the document ID of the record is greater than or equal to the last
     /// document ID in the index.
     pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<AddRecordOutcome> {
-        let doc_id = record.doc_id;
+        self.add_entry(record.doc_id, |writer, delta| {
+            E::encode(writer, delta, record)
+        })
+    }
 
+    /// Add an entry for `doc_id`, letting `encode` write the payload.
+    ///
+    /// Everything an add does apart from writing the payload depends only on the
+    /// document ID, so callers holding something other than an [`RSIndexResult`] —
+    /// see [`Self::add_prepared_record`] — reuse all of it.
+    fn add_entry<F>(&mut self, doc_id: DocId, encode: F) -> std::io::Result<AddRecordOutcome>
+    where
+        F: FnOnce(ControlledCursor<'_>, E::Delta) -> std::io::Result<usize>,
+    {
         let same_doc = match (
             E::ALLOW_DUPLICATES,
             self.last_doc_id().map(|d| d == doc_id).unwrap_or_default(),
@@ -240,7 +253,7 @@ impl<E: Encoder> InvertedIndex<E> {
 
         let buf_cap = block.buffer.capacity();
         let writer = block.writer();
-        let _bytes_written = E::encode(writer, delta, record)?;
+        let _bytes_written = encode(writer, delta)?;
 
         // We don't use `_bytes_written` returned by the encoder to determine by how much memory
         // grew because the buffer might have had enough capacity for the bytes in the encoding.
@@ -386,5 +399,23 @@ impl<E: Encoder> InvertedIndex<E> {
     /// revalidation.
     pub const fn unique_id(&self) -> IndexUniqueId {
         self.unique_id
+    }
+}
+
+impl<E: NumericEncoder> InvertedIndex<E> {
+    /// Add an entry whose representation the caller already obtained from
+    /// [`NumericEncoder::prepare`].
+    ///
+    /// Equivalent to [`Self::add_record`] with a numeric record holding the same
+    /// document ID and value — same bytes, same outcome — without classifying the
+    /// value a second time or building an [`RSIndexResult`] to carry it.
+    pub fn add_prepared_record(
+        &mut self,
+        doc_id: DocId,
+        prepared: PreparedValue,
+    ) -> std::io::Result<AddRecordOutcome> {
+        self.add_entry(doc_id, |writer, delta| {
+            E::encode_prepared(writer, delta, prepared)
+        })
     }
 }

--- a/src/redisearch_rs/inverted_index/src/index/with_entries.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_entries.rs
@@ -10,6 +10,7 @@
 use crate::{
     AddRecordOutcome, DecodedBy, Encoder, GcApplyInfo, GcScanDelta, IndexBlock, InvertedIndex,
     debug::{BlockSummary, Summary},
+    numeric::{NumericEncoder, PreparedValue},
     reader::IndexReaderCore,
 };
 use ffi::IndexFlags;
@@ -156,5 +157,21 @@ impl<E: Encoder + DecodedBy> EntriesTrackingIndex<E> {
         self.number_of_entries -= info.entries_removed;
 
         info
+    }
+}
+
+impl<E: NumericEncoder> EntriesTrackingIndex<E> {
+    /// Add an entry whose representation the encoder already decided — see
+    /// [`InvertedIndex::add_prepared_record`].
+    pub fn add_prepared_record(
+        &mut self,
+        doc_id: DocId,
+        prepared: PreparedValue,
+    ) -> std::io::Result<AddRecordOutcome> {
+        let result = self.index.add_prepared_record(doc_id, prepared)?;
+
+        self.number_of_entries += 1;
+
+        Ok(result)
     }
 }

--- a/src/redisearch_rs/inverted_index/src/tests/index.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/index.rs
@@ -628,3 +628,54 @@ fn blocks_summary_store_numeric() {
         ]
     );
 }
+
+/// The prepared write path must leave the index in exactly the state the
+/// record-based path would: same bytes, same block layout, same growth accounting.
+/// Anything less and callers would have to know which path an index was built with.
+#[test]
+fn add_prepared_record_matches_add_record() {
+    use crate::numeric::{Numeric, NumericEncoder};
+
+    // Values chosen to exercise every representation the encoder picks between:
+    // tiny int, wide int, negative, f32, f64, and infinity.
+    let values = [
+        0.0,
+        3.0,
+        -7.0,
+        1024.0,
+        0.5,
+        1e-9,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+        9_007_199_254_740_993.0,
+    ];
+
+    let mut from_records = InvertedIndex::<Numeric>::new(IndexFlags_Index_StoreNumeric);
+    let mut from_prepared = InvertedIndex::<Numeric>::new(IndexFlags_Index_StoreNumeric);
+
+    for (i, value) in values.iter().enumerate() {
+        let doc_id = i as DocId + 1;
+
+        let record = RSIndexResult::build_numeric(*value).doc_id(doc_id).build();
+        let record_outcome = from_records.add_record(&record).unwrap();
+        let prepared_outcome = from_prepared
+            .add_prepared_record(doc_id, Numeric::prepare(*value))
+            .unwrap();
+
+        assert_eq!(
+            record_outcome, prepared_outcome,
+            "outcomes diverged while adding {value} for doc {doc_id}"
+        );
+    }
+
+    assert_eq!(
+        from_records.blocks_summary(),
+        from_prepared.blocks_summary(),
+        "block layout diverged"
+    );
+    assert_eq!(from_records.memory_usage(), from_prepared.memory_usage());
+
+    let record_bytes: Vec<_> = from_records.blocks.iter().map(|b| b.data()).collect();
+    let prepared_bytes: Vec<_> = from_prepared.blocks.iter().map(|b| b.data()).collect();
+    assert_eq!(record_bytes, prepared_bytes, "encoded bytes diverged");
+}

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/numeric.rs
@@ -10,10 +10,213 @@
 use index_result::RSIndexResult;
 use inverted_index::{
     Decoder, Encoder, IdDelta,
-    numeric::{Numeric, NumericDelta, NumericFloatCompression},
+    numeric::{Numeric, NumericDelta, NumericEncoder, NumericFloatCompression},
 };
 use pretty_assertions::assert_eq;
 use std::io::Cursor;
+
+/// Encode `value` with `E` and decode it again, returning what a reader sees.
+fn round_trip<E: Encoder<Delta = NumericDelta> + Decoder>(value: f64) -> f64 {
+    let mut buf = Cursor::new(Vec::new());
+    let record = RSIndexResult::build_numeric(value).doc_id(1).build();
+    E::encode(&mut buf, NumericDelta::from_u64(0).unwrap(), &record).expect("to encode");
+
+    let buf = buf.into_inner();
+    let mut buf = Cursor::new(buf.as_ref());
+    let decoded = E::decode_new(&mut buf, 1).expect("to decode");
+
+    decoded.as_numeric().expect("a numeric record")
+}
+
+/// `stored_value` must predict exactly what an encode/decode round trip produces, and
+/// the two are separate code paths — see `Value::to_f64`.
+fn assert_stored_value_matches_round_trip(value: f64) {
+    for (name, predicted, actual) in [
+        (
+            "Numeric",
+            Numeric::stored_value(value),
+            round_trip::<Numeric>(value),
+        ),
+        (
+            "NumericFloatCompression",
+            NumericFloatCompression::stored_value(value),
+            round_trip::<NumericFloatCompression>(value),
+        ),
+    ] {
+        assert_eq!(
+            predicted.to_bits(),
+            actual.to_bits(),
+            "{name}: stored_value({value}) predicted {predicted} but a round trip yields {actual}"
+        );
+        // Storing a stored value must be a no-op, or repeated preparation could keep
+        // shifting statistics.
+        let twice = match name {
+            "Numeric" => Numeric::stored_value(predicted),
+            _ => NumericFloatCompression::stored_value(predicted),
+        };
+        assert_eq!(
+            twice.to_bits(),
+            predicted.to_bits(),
+            "{name}: stored_value is not idempotent for {value}"
+        );
+    }
+}
+
+#[test]
+fn stored_value_matches_encode_decode_for_edge_cases() {
+    for value in [
+        0.0,
+        -0.0, // stored as a tiny int, so it comes back as +0.0
+        1.0,
+        7.0,
+        8.0,
+        -1.0,
+        -8.0,
+        0.5,
+        -0.5,
+        3.124,                   // compressible: within the 0.01 threshold
+        100.500001,              // collapses onto 100.5 as an f32
+        1e-9, // NOT compressible: relative error is tiny, absolute is smaller still
+        9_007_199_254_740_993.0, // 2^53 + 1
+        4_503_599_627_370_496.0, // a 52-bit geohash-shaped value
+        f64::MAX,
+        f64::MIN,
+        f64::MIN_POSITIVE,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+    ] {
+        assert_stored_value_matches_round_trip(value);
+    }
+}
+
+/// The two write entry points must be interchangeable down to the bytes, or an index
+/// written through the prepared path would decode differently.
+fn assert_encode_prepared_matches_encode(value: f64, delta: u64) {
+    fn compare<E: Encoder<Delta = NumericDelta> + NumericEncoder>(value: f64, delta: u64) {
+        let record = RSIndexResult::build_numeric(value).doc_id(1).build();
+
+        let mut from_record = Cursor::new(Vec::new());
+        let record_bytes = E::encode(
+            &mut from_record,
+            NumericDelta::from_u64(delta).unwrap(),
+            &record,
+        )
+        .expect("to encode");
+
+        let mut from_prepared = Cursor::new(Vec::new());
+        let prepared_bytes = E::encode_prepared(
+            &mut from_prepared,
+            NumericDelta::from_u64(delta).unwrap(),
+            E::prepare(value),
+        )
+        .expect("to encode");
+
+        assert_eq!(
+            from_record.into_inner(),
+            from_prepared.into_inner(),
+            "encode and encode_prepared disagree for value {value}, delta {delta}"
+        );
+        assert_eq!(record_bytes, prepared_bytes);
+    }
+
+    compare::<Numeric>(value, delta);
+    compare::<NumericFloatCompression>(value, delta);
+}
+
+#[test]
+fn encode_prepared_matches_encode_for_edge_cases() {
+    for value in [
+        0.0,
+        -0.0,
+        7.0,
+        -8.0,
+        3.124,
+        100.500001,
+        1e-9,
+        9_007_199_254_740_993.0,
+        f64::MAX,
+        f64::MIN,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+    ] {
+        for delta in [0, 1, 255, 72_057_594_037_927_935] {
+            assert_encode_prepared_matches_encode(value, delta);
+        }
+    }
+}
+
+#[test]
+fn stored_value_maps_negative_zero_to_positive_zero() {
+    // Both encoders take the tiny-integer path for zero, so the sign is dropped.
+    for stored in [
+        Numeric::stored_value(-0.0),
+        NumericFloatCompression::stored_value(-0.0),
+    ] {
+        assert!(
+            stored.is_sign_positive() && stored == 0.0,
+            "-0.0 should be stored as +0.0, got {stored}"
+        );
+    }
+}
+
+/// Magnitudes that round to zero collapse onto the *canonical* zero, whatever their
+/// sign.
+///
+/// Compression stores an f32 whenever the loss is under its threshold, and for a
+/// subnormal magnitude that f32 is zero. Keeping the sign flag there would produce a
+/// `-0.0` stored value: numerically equal to `+0.0`, so no filter could separate the
+/// two, yet distinct enough to fool a consumer that keys values by bit pattern.
+#[test]
+fn compression_collapse_to_zero_is_canonical() {
+    for input in [
+        5e-324,
+        -5e-324,
+        f64::MIN_POSITIVE,
+        -f64::MIN_POSITIVE,
+        1e-60,
+        -1e-60,
+    ] {
+        let stored = NumericFloatCompression::stored_value(input);
+        assert_eq!(stored, 0.0, "{input} should collapse onto zero");
+        assert!(
+            stored.is_sign_positive(),
+            "{input} collapsed onto a negative zero"
+        );
+
+        // Without compression such a magnitude is kept exactly, so no collapse and no
+        // canonicalization question.
+        assert_eq!(Numeric::stored_value(input).to_bits(), input.to_bits());
+    }
+}
+
+#[test]
+fn stored_value_of_nan_stays_nan() {
+    // NaN survives as NaN (the payload may differ), so it can never move a bound:
+    // every comparison against it is false.
+    assert!(Numeric::stored_value(f64::NAN).is_nan());
+    assert!(NumericFloatCompression::stored_value(f64::NAN).is_nan());
+}
+
+#[test]
+fn compression_collapses_neighbouring_values_to_one_stored_value() {
+    // The MOD-16877 shape: distinct f64s inside one f32 bucket collapse to a single
+    // stored value under compression.
+    let values: Vec<f64> = (0..8).map(|i| 100.5 + i as f64 * 1e-7).collect();
+    let stored: Vec<f64> = values
+        .iter()
+        .map(|&v| NumericFloatCompression::stored_value(v))
+        .collect();
+
+    assert!(
+        stored.windows(2).all(|w| w[0] == w[1]),
+        "expected one stored value, got {stored:?}"
+    );
+    assert_eq!(stored[0], 100.5);
+
+    // Without compression they stay distinct.
+    let exact: Vec<f64> = values.iter().map(|&v| Numeric::stored_value(v)).collect();
+    assert_eq!(exact, values);
+}
 
 /// Tests for integer values between 0 and 7 which should use the [TINY header](super#tiny-type) format.
 #[test]
@@ -638,6 +841,36 @@ mod property_based {
                 .expect("to decode numeric record");
 
             assert_eq!(record_decoded, record, "failed for value: {}", value);
+        }
+
+        /// Keeps `Value::to_f64` (which backs `stored_value`) in agreement with
+        /// `decode`, which reconstructs values from the bytes independently.
+        #[test]
+        fn numeric_stored_value_matches_encode_decode(value in f64::MIN..f64::MAX) {
+            assert_stored_value_matches_round_trip(value);
+        }
+
+        /// The prepared path must be byte-identical to the record path.
+        #[test]
+        fn numeric_encode_prepared_matches_encode(
+            value in f64::MIN..f64::MAX,
+            delta in 0u64..72_057_594_037_927_935u64,
+        ) {
+            assert_encode_prepared_matches_encode(value, delta);
+        }
+
+        /// Re-preparing a stored value must be a no-op: the tree prepares on the way
+        /// in, and split redistribution prepares values it read back out again.
+        #[test]
+        fn numeric_stored_value_is_idempotent(value in f64::MIN..f64::MAX) {
+            let once = Numeric::stored_value(value);
+            assert_eq!(Numeric::stored_value(once).to_bits(), once.to_bits());
+
+            let once = NumericFloatCompression::stored_value(value);
+            assert_eq!(
+                NumericFloatCompression::stored_value(once).to_bits(),
+                once.to_bits(),
+            );
         }
     }
 }

--- a/src/redisearch_rs/numeric_range_tree/src/index.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/index.rs
@@ -17,7 +17,7 @@ use index_result::RSIndexResult;
 use inverted_index::{
     EntriesTrackingIndex, IndexReader, NumericReader, RawIndexReaderCore,
     debug::Summary,
-    numeric::{Numeric, NumericFloatCompression},
+    numeric::{Numeric, NumericEncoder, NumericFloatCompression, PreparedValue},
 };
 use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
@@ -45,8 +45,34 @@ impl NumericIndex {
         }
     }
 
+    /// Ask this index's encoder how it will represent `value` — see
+    /// [`NumericEncoder::prepare`].
+    pub fn prepare(&self, value: f64) -> PreparedValue {
+        match self {
+            NumericIndex::Uncompressed(_) => Numeric::prepare(value),
+            NumericIndex::Compressed(_) => NumericFloatCompression::prepare(value),
+        }
+    }
+
+    /// [`Self::prepare`] for callers that hold the `compress_floats` flag rather than
+    /// an index — the tree prepares on the way in, before it has descended to the leaf
+    /// whose index will write the entry. Kept next to [`Self::new`], which owns the
+    /// same flag-to-encoder mapping.
+    pub fn prepare_for(compress_floats: bool, value: f64) -> PreparedValue {
+        if compress_floats {
+            NumericFloatCompression::prepare(value)
+        } else {
+            Numeric::prepare(value)
+        }
+    }
+
     /// Add a record to the index. Returns `(memory_growth, blocks_added)` — see
     /// [`InvertedIndex::add_record`][inverted_index::InvertedIndex::add_record].
+    ///
+    /// For callers that already hold an [`RSIndexResult`] and derive nothing from the
+    /// value. A caller that also needs to know what will be stored should
+    /// [`prepare`](Self::prepare) it and use
+    /// [`add_prepared_record`](Self::add_prepared_record) instead of asking twice.
     ///
     /// # Panics
     ///
@@ -56,6 +82,26 @@ impl NumericIndex {
         let result = match self {
             NumericIndex::Uncompressed(idx) => idx.add_record(record),
             NumericIndex::Compressed(idx) => idx.add_record(record),
+        };
+        result.expect("in-memory inverted index write cannot fail")
+    }
+
+    /// Add an entry whose representation was already decided by [`Self::prepare`].
+    /// Returns `(memory_growth, blocks_added)` — see
+    /// [`InvertedIndex::add_prepared_record`][inverted_index::InvertedIndex::add_prepared_record].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the underlying write fails. This should never happen with
+    /// in-memory inverted indexes, so a panic indicates a bug.
+    pub fn add_prepared_record(
+        &mut self,
+        doc_id: DocId,
+        prepared: PreparedValue,
+    ) -> inverted_index::AddRecordOutcome {
+        let result = match self {
+            NumericIndex::Uncompressed(idx) => idx.add_prepared_record(doc_id, prepared),
+            NumericIndex::Compressed(idx) => idx.add_prepared_record(doc_id, prepared),
         };
         result.expect("in-memory inverted index write cannot fail")
     }

--- a/src/redisearch_rs/numeric_range_tree/src/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/range.rs
@@ -16,20 +16,24 @@
 use hyperloglog::{HyperLogLog6, WyHasher};
 use index_result::RSIndexResult;
 use inverted_index::IndexReader as _;
+use inverted_index::numeric::{PreparedValue, StoredValue};
 use rqe_core::DocId;
 
 use crate::index::{NumericIndex, NumericIndexReader};
 
 /// Newtype around [`f64`] that hashes via native-endian bytes.
 ///
-/// Ensures HLL cardinality estimation uses a consistent raw bit representation,
-/// so `-0.0` and `+0.0` are distinct and no float comparison is involved.
+/// Ensures HLL cardinality estimation uses a consistent raw bit representation, so
+/// no float comparison is involved.
+///
+/// Only constructible from a [`StoredValue`], so inputs the encoder maps onto the
+/// same stored value count once — including `-0.0` and `+0.0`.
 #[derive(Debug, Clone, Copy)]
 pub struct NumericValue(f64);
 
-impl From<f64> for NumericValue {
-    fn from(value: f64) -> Self {
-        Self(value)
+impl From<StoredValue> for NumericValue {
+    fn from(value: StoredValue) -> Self {
+        Self(value.get())
     }
 }
 
@@ -67,16 +71,16 @@ pub struct NumericRange {
     /// The minimum value stored in this range.
     /// Initialized to `f64::INFINITY` so any value will be smaller.
     ///
-    /// This is a monotone *lower bound*, not necessarily the smallest value the
-    /// range currently stores: it is lowered when a smaller value is added, but
-    /// never raised. GC removes entries without tightening it, so after the
-    /// documents holding the smallest value are collected it sits strictly below
-    /// every surviving value.
+    /// A monotone *lower bound* in [`StoredValue`] form, not necessarily the smallest
+    /// value the range currently stores: it is lowered when a smaller value is added,
+    /// but never raised. GC removes entries without tightening it, so once the
+    /// documents holding the smallest value are collected it sits strictly below every
+    /// surviving value.
     min_val: f64,
     /// The maximum value stored in this range.
     /// Initialized to `f64::NEG_INFINITY` so any value will be larger.
     ///
-    /// Monotone *upper bound*, with the same caveat as `min_val`: GC never
+    /// Monotone *upper bound*, with the same caveat as [`Self::min_val`]: GC never
     /// lowers it.
     max_val: f64,
     /// HyperLogLog for estimating the number of distinct values (cardinality).
@@ -107,9 +111,12 @@ impl NumericRange {
     /// reporting how many bytes the inverted index grew by and how many new index blocks the
     /// write created.
     ///
+    /// Takes the encoder's decision from [`NumericIndex::prepare`], so both statistics
+    /// describe what the index will return.
+    ///
     /// [`AddRecordOutcome`]: inverted_index::AddRecordOutcome
-    pub fn add(&mut self, doc_id: DocId, value: f64) -> inverted_index::AddRecordOutcome {
-        self.hll.add(&value.into());
+    pub fn add(&mut self, doc_id: DocId, value: PreparedValue) -> inverted_index::AddRecordOutcome {
+        self.hll.add(&value.stored_value().into());
         self.add_without_cardinality(doc_id, value)
     }
 
@@ -128,19 +135,18 @@ impl NumericRange {
     pub fn add_without_cardinality(
         &mut self,
         doc_id: DocId,
-        value: f64,
+        value: PreparedValue,
     ) -> inverted_index::AddRecordOutcome {
-        // Update bounds
-        if value < self.min_val {
-            self.min_val = value;
+        let stored = value.stored_value().get();
+
+        if stored < self.min_val {
+            self.min_val = stored;
         }
-        if value > self.max_val {
-            self.max_val = value;
+        if stored > self.max_val {
+            self.max_val = stored;
         }
 
-        // Add to inverted index
-        let record = RSIndexResult::build_numeric(value).doc_id(doc_id).build();
-        self.entries.add_record(&record)
+        self.entries.add_prepared_record(doc_id, value)
     }
 
     /// Get the estimated cardinality (number of distinct values).
@@ -255,7 +261,8 @@ impl NumericRange {
         while reader.next_record(&mut result).unwrap_or(false) {
             // SAFETY: We know the result contains numeric data
             let value = unsafe { result.as_numeric_unchecked() };
-            self.hll.add(&value.into());
+            // Read back out of the index, so already in stored form.
+            self.hll.add(&StoredValue::from_decoded(value).into());
         }
     }
 }

--- a/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
@@ -17,6 +17,7 @@ use rqe_core::DocId;
 use std::collections::HashMap;
 
 use index_result::RSIndexResult;
+use inverted_index::numeric::StoredValue;
 use inverted_index::{GcApplyInfo, GcScanDelta};
 
 use super::{NumericRangeTree, TrimEmptyLeavesResult};
@@ -93,8 +94,9 @@ impl NumericRangeNode {
         let mut last_block_hll = Hll::new();
 
         let mut repair_fn = |res: &RSIndexResult, ctx: &inverted_index::RepairContext<'_>| {
-            // SAFETY: We know this is a numeric index result
-            let value = unsafe { res.as_numeric_unchecked() };
+            // SAFETY: We know this is a numeric index result. Scanned straight out of
+            // the index, so already in stored form.
+            let value = StoredValue::from_decoded(unsafe { res.as_numeric_unchecked() });
             let target = if ctx.block_idx == last_block_idx {
                 &mut last_block_hll
             } else {

--- a/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
@@ -15,11 +15,12 @@
 
 use index_result::RSIndexResult;
 use inverted_index::IndexReader as _;
+use inverted_index::numeric::PreparedValue;
 use rqe_core::DocId;
 
 use super::{AddResult, CheckedCount, NumericRangeTree};
 use crate::arena::{NodeArena, NodeIndex};
-use crate::{InternalNode, NumericRange, NumericRangeNode};
+use crate::{InternalNode, NumericIndex, NumericRange, NumericRangeNode};
 
 impl NumericRangeTree {
     /// Last depth level that does NOT use the maximum split cardinality.
@@ -102,6 +103,15 @@ impl NumericRangeTree {
         }
         self.last_doc_id = doc_id;
 
+        // The one place the encoder's lossy step is applied. Everything below —
+        // routing, bounds, cardinality, split medians — works on the value the index
+        // will actually return, so none of it can disagree with storage. The decision
+        // travels with the value, so the leaf writes it without classifying again.
+        //
+        // Prepared with this tree's own flag, never the global config: the config is
+        // settable at runtime, while a tree keeps the flag it was created with.
+        let value = NumericIndex::prepare_for(self.compress_floats, value);
+
         let rv = Self::node_add(
             &mut self.nodes,
             self.root,
@@ -159,7 +169,7 @@ impl NumericRangeTree {
         nodes: &mut NodeArena,
         node_idx: NodeIndex,
         doc_id: DocId,
-        value: f64,
+        value: PreparedValue,
         depth: usize,
         max_depth_range: usize,
         compress_floats: bool,
@@ -171,7 +181,9 @@ impl NumericRangeTree {
                 let NumericRangeNode::Internal(internal) = &nodes[node_idx] else {
                     unreachable!()
                 };
-                let child_idx = if value < internal.value {
+                // `internal.value` is a threshold, not a stored value — it can be
+                // `next_up` of one — so the comparison unwraps rather than lifting it.
+                let child_idx = if value.stored_value().get() < internal.value {
                     internal.left_index()
                 } else {
                     internal.right_index()
@@ -278,10 +290,9 @@ impl NumericRangeTree {
     /// are identical—the median would equal the minimum, and without adjustment
     /// all entries would go to the right child, leaving the left empty.
     ///
-    /// The adjustment only fires when the range's `min_val` bound matches the
-    /// smallest value the range actually stores. That is not always the case, so
-    /// a split can still leave one child empty—see the comment on `newly_empty`
-    /// below.
+    /// The adjustment relies on `min_val` matching the smallest value the range
+    /// stores. Adds maintain that; GC does not, so a split can still leave one child
+    /// empty — see the `newly_empty` comment in the body.
     ///
     /// # Note
     ///
@@ -331,7 +342,11 @@ impl NumericRangeTree {
         while reader.next_record(&mut result).unwrap_or(false) {
             // SAFETY: We know the result contains numeric data
             let entry_value = unsafe { result.as_numeric_unchecked() };
-            let target_idx = if entry_value < split {
+            // Redistributed entries come straight back out of the parent's index, so
+            // they are already in stored form — preparing one is idempotent, and the
+            // child needs the decision to write the entry.
+            let entry_value = NumericIndex::prepare_for(compress_floats, entry_value);
+            let target_idx = if entry_value.stored_value().get() < split {
                 left_idx
             } else {
                 right_idx
@@ -346,23 +361,12 @@ impl NumericRangeTree {
         }
         drop(result);
 
-        // A split can leave a child leaf empty whenever every entry falls on the
-        // same side of `split`. Two known ways to get there:
-        //
-        // 1. Float compression collapses every stored value to the same f32. The
-        //    median then equals `min_val`, the split point becomes `next_up(min)`,
-        //    and every entry lands in the *left* child.
-        // 2. `min_val` is stale. GC removes entries from a range but never raises
-        //    its bounds, so once the documents holding the smallest value are
-        //    collected, `min_val` sits below every surviving value. If a majority
-        //    of the survivors share the smallest surviving value, that value is the
-        //    median, the `split == min_val` guard above does not fire, and every
-        //    entry lands in the *right* child.
-        //
-        // Such an empty leaf must be reflected in `empty_leaves`, otherwise a
-        // later add routed to it would decrement the counter below zero. The
-        // parent had >= 1 entry (we split only after adding), so at most one of
-        // the two new children can be empty.
+        // A split strands an empty child leaf when every entry falls on the same side
+        // of `split`, which still happens while GC leaves `min_val` stale: the guard
+        // above cannot fire against a bound no surviving entry holds. It must be
+        // counted, or a later add routed to that leaf underflows `empty_leaves` and
+        // aborts the process across the non-unwinding FFI boundary (MOD-16877). The
+        // parent had >= 1 entry, so at most one child can come out empty.
         let newly_empty = [left_idx, right_idx]
             .into_iter()
             .filter(|&i| nodes[i].range().is_some_and(|r| r.num_docs() == 0))

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/range.rs
@@ -9,7 +9,17 @@
 
 //! Tests for NumericRange.
 
-use numeric_range_tree::NumericRange;
+use index_result::RSIndexResult;
+use inverted_index::IndexReader as _;
+use inverted_index::numeric::PreparedValue;
+use numeric_range_tree::{NumericIndex, NumericRange};
+use rstest::rstest;
+
+/// Ask an uncompressed encoder how it will represent `value` — the form
+/// [`NumericRange::add`] takes.
+fn prepared(value: f64) -> PreparedValue {
+    NumericIndex::prepare_for(false, value)
+}
 
 #[test]
 fn test_new_range_bounds() {
@@ -24,15 +34,15 @@ fn test_new_range_bounds() {
 fn test_add_updates_bounds() {
     let mut range = NumericRange::new(false);
 
-    range.add(1, 5.0);
+    range.add(1, prepared(5.0));
     assert_eq!(range.min_val(), 5.0);
     assert_eq!(range.max_val(), 5.0);
 
-    range.add(2, 10.0);
+    range.add(2, prepared(10.0));
     assert_eq!(range.min_val(), 5.0);
     assert_eq!(range.max_val(), 10.0);
 
-    range.add(3, 2.0);
+    range.add(3, prepared(2.0));
     assert_eq!(range.min_val(), 2.0);
     assert_eq!(range.max_val(), 10.0);
 }
@@ -41,9 +51,9 @@ fn test_add_updates_bounds() {
 fn test_add_updates_cardinality() {
     let mut range = NumericRange::new(false);
 
-    range.add(1, 1.0);
-    range.add(2, 2.0);
-    range.add(3, 3.0);
+    range.add(1, prepared(1.0));
+    range.add(2, prepared(2.0));
+    range.add(3, prepared(3.0));
 
     // HLL gives approximate count, but for small counts it should be reasonably accurate
     let card = range.cardinality();
@@ -56,8 +66,8 @@ fn test_add_updates_cardinality() {
 #[test]
 fn test_contained_in() {
     let mut range = NumericRange::new(false);
-    range.add(1, 5.0);
-    range.add(2, 10.0);
+    range.add(1, prepared(5.0));
+    range.add(2, prepared(10.0));
 
     // Range [5, 10] is contained in [0, 20]
     assert!(range.contained_in(0.0, 20.0));
@@ -72,8 +82,8 @@ fn test_contained_in() {
 #[test]
 fn test_overlaps() {
     let mut range = NumericRange::new(false);
-    range.add(1, 5.0);
-    range.add(2, 10.0);
+    range.add(1, prepared(5.0));
+    range.add(2, prepared(10.0));
 
     // Overlapping cases
     assert!(range.overlaps(0.0, 6.0)); // left overlap
@@ -100,9 +110,9 @@ fn test_add_without_cardinality() {
     let mut range = NumericRange::new(false);
 
     // Add entries without updating cardinality
-    range.add_without_cardinality(1, 5.0);
-    range.add_without_cardinality(2, 10.0);
-    range.add_without_cardinality(3, 2.0);
+    range.add_without_cardinality(1, prepared(5.0));
+    range.add_without_cardinality(2, prepared(10.0));
+    range.add_without_cardinality(3, prepared(2.0));
 
     // Bounds should be updated
     assert_eq!(range.min_val(), 2.0);
@@ -119,11 +129,11 @@ fn test_add_without_cardinality_vs_add() {
     let mut range_without_card = NumericRange::new(false);
 
     // Add same values to both
-    range_with_card.add(1, 5.0);
-    range_with_card.add(2, 10.0);
+    range_with_card.add(1, prepared(5.0));
+    range_with_card.add(2, prepared(10.0));
 
-    range_without_card.add_without_cardinality(1, 5.0);
-    range_without_card.add_without_cardinality(2, 10.0);
+    range_without_card.add_without_cardinality(1, prepared(5.0));
+    range_without_card.add_without_cardinality(2, prepared(10.0));
 
     // Bounds should be the same
     assert_eq!(range_with_card.min_val(), range_without_card.min_val());
@@ -143,13 +153,13 @@ fn test_num_docs() {
     let mut range = NumericRange::new(false);
     assert_eq!(range.num_docs(), 0);
 
-    range.add(1, 5.0);
+    range.add(1, prepared(5.0));
     assert_eq!(range.num_docs(), 1);
 
-    range.add(2, 10.0);
+    range.add(2, prepared(10.0));
     assert_eq!(range.num_docs(), 2);
 
-    range.add(3, 15.0);
+    range.add(3, prepared(15.0));
     assert_eq!(range.num_docs(), 3);
 }
 
@@ -158,8 +168,8 @@ fn test_entries_accessor() {
     use numeric_range_tree::NumericIndex;
 
     let mut range = NumericRange::new(false);
-    range.add(1, 5.0);
-    range.add(2, 10.0);
+    range.add(1, prepared(5.0));
+    range.add(2, prepared(10.0));
 
     let entries = range.entries();
     match entries {
@@ -177,9 +187,9 @@ fn test_entries_accessor() {
 #[test]
 fn test_hll_accessor() {
     let mut range = NumericRange::new(false);
-    range.add(1, 5.0);
-    range.add(2, 10.0);
-    range.add(3, 15.0);
+    range.add(1, prepared(5.0));
+    range.add(2, prepared(10.0));
+    range.add(3, prepared(15.0));
 
     let hll = range.hll();
     // HLL count should approximate the number of distinct values
@@ -195,11 +205,159 @@ fn test_inverted_index_size() {
     let mut range = NumericRange::new(false);
     let initial_size = range.memory_usage();
 
-    range.add(1, 5.0);
+    range.add(1, prepared(5.0));
     let size_after_one = range.memory_usage();
     assert!(size_after_one >= initial_size);
 
-    range.add(2, 10.0);
+    range.add(2, prepared(10.0));
     let size_after_two = range.memory_usage();
     assert!(size_after_two >= size_after_one);
+}
+
+// ============================================================================
+// Stored-value quantization
+// ============================================================================
+
+#[test]
+fn test_compressed_range_treats_collapsing_values_as_one() {
+    // Two distinct f64s inside the same f32 bucket. A compressed range stores one
+    // value for both, so its statistics must report one value.
+    let mut range = NumericRange::new(true);
+    let index = NumericIndex::new(true);
+    range.add(1, index.prepare(100.5));
+    range.add(2, index.prepare(100.500001));
+
+    assert_eq!(range.num_entries(), 2);
+    assert_eq!(
+        range.cardinality(),
+        1,
+        "both inputs collapse onto the same stored value"
+    );
+    assert_eq!(
+        (range.min_val(), range.max_val()),
+        (100.5, 100.5),
+        "bounds must equal the stored value, not the inputs"
+    );
+
+    // The same two inputs stay distinct without compression.
+    let mut range = NumericRange::new(false);
+    let index = NumericIndex::new(false);
+    range.add(1, index.prepare(100.5));
+    range.add(2, index.prepare(100.500001));
+    assert_eq!(range.cardinality(), 2);
+    assert_eq!((range.min_val(), range.max_val()), (100.5, 100.500001));
+}
+
+#[rstest]
+fn test_signed_zeros_are_one_stored_value(#[values(false, true)] compress_floats: bool) {
+    // Every numeric encoder writes zero as a tiny integer, dropping the sign, so
+    // `-0.0` and `+0.0` are indistinguishable once stored.
+    let mut range = NumericRange::new(compress_floats);
+    let index = NumericIndex::new(compress_floats);
+    range.add(1, index.prepare(-0.0));
+    range.add(2, index.prepare(0.0));
+
+    assert_eq!(range.cardinality(), 1);
+    assert!(range.min_val().is_sign_positive());
+    assert_eq!((range.min_val(), range.max_val()), (0.0, 0.0));
+}
+
+#[rstest]
+fn test_geohash_values_are_stored_exactly(#[values(false, true)] compress_floats: bool) {
+    // GEO fields share this tree: `encodeGeo` yields a 52-bit integral geohash, which
+    // takes the encoder's integer path and is never rounded — with or without float
+    // compression. Quantization must therefore be the identity here.
+    let geohashes = [0.0, 1.0, 3_659_155_824_453_222.0, (1u64 << 52) as f64 - 1.0];
+
+    let index = NumericIndex::new(compress_floats);
+    for geohash in geohashes {
+        assert_eq!(
+            index.prepare(geohash).stored_value().get(),
+            geohash,
+            "geohash {geohash} must survive preparation unchanged"
+        );
+    }
+
+    let mut range = NumericRange::new(compress_floats);
+    for (i, geohash) in geohashes.iter().enumerate() {
+        range.add(i as u64 + 1, index.prepare(*geohash));
+    }
+    assert_eq!(range.cardinality(), geohashes.len());
+    assert_eq!(range.min_val(), geohashes[0]);
+    assert_eq!(range.max_val(), geohashes[geohashes.len() - 1]);
+}
+
+#[rstest]
+fn test_numeric_index_write_paths_agree(#[values(false, true)] compress_floats: bool) {
+    // The two write paths must be interchangeable. This also keeps `add_record`
+    // exercised from inside this crate: with no in-crate caller it reads as dead code
+    // and invites removal, which breaks downstream test suites.
+    let values = [0.0, 3.0, -7.0, 1024.0, 0.5, 100.500001, f64::INFINITY];
+
+    let mut from_records = NumericIndex::new(compress_floats);
+    let mut from_prepared = NumericIndex::new(compress_floats);
+
+    for (i, value) in values.iter().enumerate() {
+        let doc_id = i as u64 + 1;
+        let record = RSIndexResult::build_numeric(*value).doc_id(doc_id).build();
+
+        let record_outcome = from_records.add_record(&record);
+        let prepared_outcome =
+            from_prepared.add_prepared_record(doc_id, from_prepared.prepare(*value));
+
+        assert_eq!(
+            record_outcome, prepared_outcome,
+            "outcomes diverged while adding {value} for doc {doc_id}"
+        );
+    }
+
+    assert_eq!(
+        from_records.number_of_entries(),
+        from_prepared.number_of_entries()
+    );
+    assert_eq!(from_records.memory_usage(), from_prepared.memory_usage());
+    assert_eq!(
+        from_records.summary().number_of_blocks,
+        from_prepared.summary().number_of_blocks,
+        "block layout diverged"
+    );
+
+    // And the entries decode identically.
+    let decode = |index: &NumericIndex| {
+        let mut reader = index.reader();
+        let mut result = RSIndexResult::build_numeric(0.0).build();
+        let mut decoded = Vec::new();
+        while reader.next_record(&mut result).unwrap_or(false) {
+            // SAFETY: a numeric index only ever holds numeric records
+            decoded.push((result.doc_id, unsafe { result.as_numeric_unchecked() }));
+        }
+        decoded
+    };
+    assert_eq!(decode(&from_records), decode(&from_prepared));
+}
+
+#[test]
+fn test_compressed_signed_zero_collapse_counts_once() {
+    // Under float compression a magnitude below the smallest f32 subnormal rounds to
+    // zero, for either sign. Both must arrive as the same stored value, or the two
+    // would compare equal to bounds, routing and filters while a cardinality estimate
+    // keyed by bit pattern counted them separately — enough to make a leaf of
+    // comparably identical values look splittable.
+    let index = NumericIndex::new(true);
+    let positive = index.prepare(5e-324).stored_value().get();
+    let negative = index.prepare(-5e-324).stored_value().get();
+    assert_eq!(positive.to_bits(), negative.to_bits());
+    assert_eq!(positive, 0.0);
+    assert!(positive.is_sign_positive());
+
+    let mut range = NumericRange::new(true);
+    range.add(1, index.prepare(5e-324));
+    range.add(2, index.prepare(-5e-324));
+
+    assert_eq!((range.min_val(), range.max_val()), (0.0, 0.0));
+    assert_eq!(
+        range.cardinality(),
+        1,
+        "stored values that compare equal must count once"
+    );
 }

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/tree.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/tree.rs
@@ -201,23 +201,16 @@ fn test_split_with_identical_values() {
     );
 }
 
-/// Regression test for the `empty_leaves` underflow crash (MOD-16877, a
-/// production crash on 8.6.6): a split that creates an empty child leaf must
-/// count it.
+/// Distinct f64s that collapse onto one stored f32 must count as one value.
 ///
-/// With float compression enabled, cardinality is estimated over the original
-/// f64 values while entries are stored — and split-redistributed — as compressed
-/// f32. When enough distinct f64 values collapse to a single f32, the split is
-/// triggered (HLL sees them as distinct) but every stored value is identical, so
-/// all entries are redistributed to one child and the other child leaf is created
-/// empty. That empty leaf must be reflected in `empty_leaves`; otherwise a later
-/// add routed to it decrements the counter below zero and aborts the process via
-/// the non-unwinding FFI boundary.
+/// Estimating cardinality over the inputs instead made such a leaf look
+/// high-cardinality, split it, and strand an empty child — the compression route into
+/// the MOD-16877 crash. Preparing values on the way in closes it: no split fires.
 ///
-/// Compression is not the only way to get an empty child leaf — see
-/// `test_split_after_gc_stale_min_counts_empty_leaf`.
+/// The stale-`min_val` route is still open here, which is why `split_node` keeps
+/// counting empty children — see `test_split_after_gc_stale_min_counts_empty_leaf`.
 #[test]
-fn test_split_with_compression_collapse_counts_empty_leaf() {
+fn test_compression_collapse_does_not_inflate_cardinality() {
     let mut tree = NumericRangeTree::new(true); // float compression ON
 
     // Distinct f64 values tightly clustered within a single f32 rounding bucket
@@ -228,42 +221,39 @@ fn test_split_with_compression_collapse_counts_empty_leaf() {
     // 0.01 compression threshold.
     let value_at = |i: u64| 100.5 + (i - 1) as f64 * 1e-7;
 
-    // Add distinct-but-collapsing values until the first split fires. Because the
-    // stored values are all identical (f32 100.5), the redistribution sends every
-    // entry to the left child and leaves the right child empty. This empty leaf
-    // must be counted; before the fix, `empty_leaves` stayed 0 here (caught by the
-    // `check_tree_invariants` assertion inside `add`).
-    let mut split_at = None;
+    // Well past the point where the old cardinality estimate would have split.
     for i in 1..=(SPLIT_TRIGGER + 8) {
         tree.add(i, value_at(i), false, 0);
-        if tree.num_leaves() == 2 {
-            split_at = Some(i);
-            break;
-        }
     }
-    let split_at = split_at.expect("compressed-but-distinct values should trigger a split");
 
-    // Right after the split, before any further add re-populates it:
+    assert!(
+        tree.root().is_leaf(),
+        "collapsing values are one stored value, so no split should fire (got {} leaves)",
+        tree.num_leaves()
+    );
+
+    let range = tree.root().range().unwrap();
     assert_eq!(
-        tree.empty_leaves(),
+        range.cardinality(),
         1,
-        "the empty child leaf created by the split must be counted"
+        "cardinality must count stored values, not the inputs that collapsed onto them"
     );
-
-    // Routing uses the *original* f64 value, so the next (larger) value is routed
-    // to the empty right child and re-populates it. Before the fix this decremented
-    // `empty_leaves` from 0, underflowing the counter and aborting the process.
-    let next = split_at + 1;
-    tree.add(next, value_at(next), false, 0);
     assert_eq!(
-        tree.empty_leaves(),
-        0,
-        "re-populating the empty leaf should bring the counter back to zero"
+        (range.min_val(), range.max_val()),
+        (100.5, 100.5),
+        "bounds must describe the stored value a reader will decode"
     );
+    assert_eq!(tree.empty_leaves(), 0);
+
+    // The add that used to hit the underflow. Nothing was ever stranded, so the
+    // counter is not touched.
+    let next = SPLIT_TRIGGER + 9;
+    tree.add(next, value_at(next), false, 0);
+    assert_eq!(tree.empty_leaves(), 0);
 }
 
 /// Same `empty_leaves` underflow as
-/// `test_split_with_compression_collapse_counts_empty_leaf` (MOD-16877), reached
+/// `test_compression_collapse_does_not_inflate_cardinality` (MOD-16877), reached
 /// with float compression *disabled* — compression is not required to strand an
 /// empty child leaf.
 ///
@@ -471,4 +461,48 @@ fn test_max_depth_range_removes_deep_ranges(#[values(false, true)] compress_floa
             );
         }
     });
+}
+
+/// A leaf holding nothing but comparably-equal zeros must not split.
+///
+/// Under float compression, alternating `±5e-324` collapses onto `+0.0` and `-0.0`.
+/// Every comparison in the tree treats those as equal, so there is no split point that
+/// separates them: the size-triggered split path needs `cardinality > 1`, and if
+/// cardinality counts the two zeros separately the split fires anyway and strands an
+/// empty child — the degenerate shape this work exists to remove.
+#[test]
+#[cfg_attr(miri, ignore = "Too slow to run under miri")]
+fn test_compressed_signed_zero_collapse_does_not_split() {
+    let mut tree = NumericRangeTree::new(true); // float compression ON
+
+    // One past the size-triggered split threshold, alternating the sign.
+    let n = NumericRangeTree::MAXIMUM_RANGE_SIZE as u64 + 1;
+    for doc_id in 1..=n {
+        let value = if doc_id % 2 == 0 { 5e-324 } else { -5e-324 };
+        tree.add(doc_id, value, false, 0);
+    }
+
+    if let Some((left, right)) = tree.root().child_indices() {
+        let docs = |idx| tree.node(idx).range().map_or(0, |r| r.num_docs());
+        panic!(
+            "split with no value to split on: children hold {} and {} documents, \
+             and empty_leaves is {}",
+            docs(left),
+            docs(right),
+            tree.empty_leaves(),
+        );
+    }
+
+    let range = tree.root().range().expect("a leaf keeps its range");
+    assert_eq!(
+        (range.min_val(), range.max_val()),
+        (0.0, 0.0),
+        "every stored value compares equal to zero"
+    );
+    assert_eq!(
+        range.cardinality(),
+        1,
+        "the two signed zeros must count as one value"
+    );
+    assert_eq!(tree.empty_leaves(), 0);
 }


### PR DESCRIPTION
## Describe the changes in the pull request

First of two stacked PRs. This one makes numeric statistics agree with what the encoder stores; the follow-up (based on this branch) stops those statistics going stale after GC.

1. **Current.** The numeric block encoder decides per value whether to store an f64, an f32, an integer or a 3-bit tiny int. That decision is a pure function of the value and the compression flag — `Value::from` in `codec/numeric.rs` — but it lived entirely inside `Encoder::encode`, so nothing could ask what the index was about to store. `numeric_range_tree` derives both its statistics and its structural decisions from the value it is *handed*:
   - **Cardinality counted distinct inputs.** Under `_NUMERIC_COMPRESS` many collapse onto one stored f32, so a leaf whose stored values were all identical looked high-cardinality, split, sent every entry to one child and stranded the other empty. That is the MOD-16877 crash (#10513): the uncounted empty leaf underflowed `empty_leaves` on the next add routed into it, aborting the process across the non-unwinding FFI boundary.
   - **Bounds recorded input values,** so `min_val`/`max_val` could sit inside the set of values a reader decodes.
   - **Routing descended by the input value** while storage rounded, so an entry could decode on the far side of the split value it was routed by.
   - Even with compression **off**, `-0.0` is stored as a tiny integer and decodes as `+0.0`, while the cardinality estimator hashed the two as distinct.

2. **Change.** Make the encoder the authority, and ask it exactly once.
   - `NumericEncoder::prepare` hands out the decision as an opaque `PreparedValue`; `encode_prepared` accepts it back. `Encoder::encode` is re-expressed in terms of both, so classification lives in one place (`Value::from`) and byte-writing in one place (`encode_value`), reachable through two entry points.
   - The record-agnostic half of `InvertedIndex::add_record` — duplicate handling, block selection, delta computation and its new-block retry, growth accounting, counters — is factored into `add_entry`, so `add_prepared_record` reuses all of it. The other ten codecs and the generic `Encoder` trait are untouched.
   - `NumericRangeTree::_add` prepares once, before it routes, and the decision travels with the value to the leaf that writes it: one classification per add, and no `RSIndexResult` built to carry it. `PreparedValue::stored_value` yields a `StoredValue`, the only thing range bounds and the HLL accept — a raw `f64` can no longer reach a statistic. Read-only paths keep the free `StoredValue::from_decoded`, so the GC scan and the post-fork cardinality rebuild stay classification-free.
   - Quantization uses the tree's own `compress_floats`, never `RSGlobalConfig.numericCompress`: the config is settable at runtime while a tree keeps the flag it was created with.

3. **Outcome.** Statistics, routing and storage cannot disagree, and the compression route into the MOD-16877 crash is gone at the source: the collapsing-values leaf no longer looks high-cardinality, so it never splits.

**What this PR deliberately does *not* fix.** The other route into the same underflow is a stale `min_val` — GC removes entries without ever raising a range's bounds. That is still live here, which is why `split_node` keeps counting the empty children a split creates, and why #10628's `test_split_after_gc_stale_min_counts_empty_leaf` still passes unchanged on this branch. The stacked follow-up closes it.

**Behaviour changes to be aware of when reviewing:** reported cardinality and bound values change under `_NUMERIC_COMPRESS` (they now describe stored values), and `-0.0`/`+0.0` count as one value for every numeric encoder. GEO fields share this tree — `encodeGeo` yields a 52-bit integral geohash, which takes the encoder's integer path, so quantization is provably the identity there (pinned by a test).

**Testing.** The two write paths are pinned to each other by a proptest asserting **byte-identical** encoder output across the full `f64` range × both encoders × several deltas, and an index-level test asserting identical bytes, block layout, memory usage and `AddRecordOutcome` between `add_record` and `add_prepared_record`. A second proptest pins `stored_value` to a real encode/decode round trip, which is what keeps the prediction honest against the decoder — `decode` reconstructs values straight from the bytes and deliberately does not go through `Value`. #10513's compression regression test moves from asserting the symptom (the empty leaf is counted) to asserting the cause is gone (cardinality does not inflate; no split fires).

Verified on this revision alone: 295/295 `inverted_index` + `numeric_range_tree` tests, `make lint` clean, `cargo fmt --check` clean, `make generate-rust-headers` no diff, C build green, `test_gc.py` 21/21 against the built module.

**Not measured:** the write path now classifies each value once instead of twice and builds no `RSIndexResult` per add. My dev machine is too noisy to quantify that (the same bench case drifted 465–512 ns across runs of identical code), so the benchmark is left to a clean environment rather than quoted from here.

#### Which additional issues this PR fixes
1. MOD-16877 (compression route, at the source; #10513 fixed the crash symptom)

#### Main objects this PR modified
1. `NumericEncoder`, `PreparedValue`, `StoredValue`, `encode_value` split out of `encode` — `src/redisearch_rs/inverted_index/src/codec/numeric.rs`
2. `InvertedIndex::add_entry` extraction + `add_prepared_record` — `src/redisearch_rs/inverted_index/src/index/core.rs`, mirrored on `EntriesTrackingIndex` in `with_entries.rs`
3. `NumericIndex::prepare` / `prepare_for` / `add_prepared_record` — `src/redisearch_rs/numeric_range_tree/src/index.rs`
4. `NumericRange::add` / `add_without_cardinality`, `NumericValue` — `src/redisearch_rs/numeric_range_tree/src/range.rs`
5. `NumericRangeTree::_add` / `node_add` / `split_node` — `src/redisearch_rs/numeric_range_tree/src/tree/insert.rs`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Numeric index cardinality estimates and range bounds now describe the values the index actually stores. Previously, with `_NUMERIC_COMPRESS` enabled, they were computed from the pre-compression values, so the index split and pruned on numbers no query would ever see — and that mismatch was the root cause of a crash that could take down a shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
