### PR TITLE
[MOD-16877] Fix numeric range bounds going stale after garbage collection

### DIFF
--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/gc.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/gc.rs
@@ -12,11 +12,15 @@
 use ffi::{DocTable_Exists, RedisSearchCtx};
 use inverted_index::GcScanDelta;
 use numeric_range_tree::{
-    CompactIfSparseResult, IndexedReversePreOrderDfsIterator, NodeGcDelta, NodeIndex,
-    NumericRangeTree, SingleNodeGcResult,
+    CompactIfSparseResult, GcSurvivorStats, IndexedReversePreOrderDfsIterator, NodeGcDelta,
+    NodeIndex, NumericRangeTree, SingleNodeGcResult,
 };
 use rqe_core::DocId;
 use serde::{Deserialize, Serialize};
+
+/// Size of the fixed-width trailer that follows the msgpack-encoded delta:
+/// the survivor statistics with the last block, then the ones without it.
+const TRAILER_SIZE: usize = 2 * GcSurvivorStats::WIRE_SIZE;
 
 /// Conditionally trim empty leaves and compact the node slab.
 ///
@@ -58,7 +62,7 @@ pub struct NumericGcNodeEntry {
     /// The node's slab generation.
     /// The second half of a [`NodeIndex`].
     pub node_generation: u32,
-    /// Pointer to the serialized entry data (msgpack delta + HLL registers).
+    /// Pointer to the serialized entry data (msgpack delta + survivor statistics).
     pub data: *const u8,
     /// Length of the serialized entry data in bytes.
     pub data_len: usize,
@@ -71,7 +75,7 @@ pub struct NumericGcNodeEntry {
 ///
 /// Each call to `Next` scans the next node in DFS order via
 /// [`NumericRangeNode::scan_gc`][numeric_range_tree::NumericRangeNode::scan_gc]
-/// and serializes the delta + HLL registers into an internal buffer.
+/// and serializes the delta + survivor statistics into an internal buffer.
 /// The caller can then write the entry data to the pipe immediately,
 /// avoiding buffering all deltas in memory.
 pub struct NumericGcScanner<'tree> {
@@ -124,9 +128,9 @@ pub unsafe extern "C" fn NumericGcScanner_New<'tree>(
 
 /// Advance the scanner to the next node with GC work.
 ///
-/// Scans nodes in DFS order, skipping those without GC work. When a node
-/// with work is found, its delta and HLL registers are serialized into the
-/// scanner's internal buffer.
+/// Scans nodes in DFS order, skipping those without GC work. When a node with work
+/// is found, its delta and the statistics recomputed over the surviving entries are
+/// serialized into the scanner's internal buffer.
 ///
 /// Returns `true` if an entry was produced (and `*entry` is populated),
 /// `false` when all nodes have been visited.
@@ -136,8 +140,12 @@ pub unsafe extern "C" fn NumericGcScanner_New<'tree>(
 /// # Wire format for `entry.data`
 ///
 /// ```text
-/// [delta_msgpack][64-byte hll_with][64-byte hll_without]
+/// [delta_msgpack][stats_with_last_block][stats_without_last_block]
 /// ```
+///
+/// where each `stats_*` block is `[64-byte hll registers][f64 min][f64 max]`, the
+/// bounds in native byte order. The trailer is fixed-width, so the parent recovers
+/// the msgpack payload by trimming [`TRAILER_SIZE`] bytes off the end.
 ///
 /// # Safety
 ///
@@ -175,12 +183,8 @@ pub unsafe extern "C" fn NumericGcScanner_Next(
             continue;
         }
 
-        scanner
-            .buffer
-            .extend_from_slice(&delta.registers_with_last_block);
-        scanner
-            .buffer
-            .extend_from_slice(&delta.registers_without_last_block);
+        delta.with_last_block.write_to(&mut scanner.buffer);
+        delta.without_last_block.write_to(&mut scanner.buffer);
 
         // SAFETY: Caller ensures `entry` is valid
         let entry = unsafe { &mut *entry };
@@ -251,10 +255,7 @@ pub struct ApplyGcEntryResult {
 
 /// Parse a serialized GC entry and apply it to the specified node.
 ///
-/// The entry data must have the wire format produced by [`NumericGcScanner_Next`]:
-/// ```text
-/// [delta_msgpack][64-byte hll_with][64-byte hll_without]
-/// ```
+/// `entry_data` must be in the wire format [`NumericGcScanner_Next`] documents.
 ///
 /// Returns an [`ApplyGcEntryResult`] whose [`status`](ApplyGcEntryStatus)
 /// indicates success, node-not-found, or deserialization error.
@@ -274,16 +275,12 @@ pub unsafe extern "C" fn NumericRangeTree_ApplyGcEntry(
     debug_assert!(!tree.is_null(), "tree cannot be NULL");
     debug_assert!(!entry_data.is_null(), "entry_data cannot be NULL");
 
-    const HLL_REGISTER_SIZE: usize = 64;
-
     // SAFETY: Caller ensures pointers are valid
     let tree = unsafe { &mut *tree };
     // SAFETY: Caller ensures entry_data is valid for entry_len bytes
     let data = unsafe { std::slice::from_raw_parts(entry_data, entry_len) };
 
-    // The entry format is: [delta_msgpack][64-byte hll_with][64-byte hll_without]
-    // We need at least 128 bytes for the two HLL register arrays.
-    if data.len() < HLL_REGISTER_SIZE * 2 {
+    if data.len() < TRAILER_SIZE {
         tracing::warn!(
             node_position = node_position,
             node_generation = node_generation,
@@ -297,10 +294,28 @@ pub unsafe extern "C" fn NumericRangeTree_ApplyGcEntry(
         };
     }
 
-    let hll_start = data.len() - HLL_REGISTER_SIZE * 2;
-    let msgpack_data = &data[..hll_start];
-    let hll_with = &data[hll_start..hll_start + HLL_REGISTER_SIZE];
-    let hll_without = &data[hll_start + HLL_REGISTER_SIZE..];
+    let trailer_start = data.len() - TRAILER_SIZE;
+    let msgpack_data = &data[..trailer_start];
+    let (with, without) = data[trailer_start..].split_at(GcSurvivorStats::WIRE_SIZE);
+    // Both halves are exactly `WIRE_SIZE` long by construction, so these reads cannot
+    // fail — but this function is `extern "C"`, so it reports the impossible case
+    // instead of unwinding into C.
+    let (Some(with_last_block), Some(without_last_block)) = (
+        GcSurvivorStats::read_from(with),
+        GcSurvivorStats::read_from(without),
+    ) else {
+        tracing::warn!(
+            node_position = node_position,
+            node_generation = node_generation,
+            entry_len = entry_len,
+            tree_id = %tree.unique_id(),
+            "Skipping a GcEntry whose survivor statistics could not be decoded."
+        );
+        return ApplyGcEntryResult {
+            status: ApplyGcEntryStatus::DeserializationError,
+            ..Default::default()
+        };
+    };
 
     let delta: GcScanDelta = match GcScanDelta::deserialize(&mut rmp_serde::Deserializer::new(
         &mut std::io::Cursor::new(msgpack_data),
@@ -322,15 +337,10 @@ pub unsafe extern "C" fn NumericRangeTree_ApplyGcEntry(
         }
     };
 
-    let mut regs_with = [0u8; HLL_REGISTER_SIZE];
-    let mut regs_without = [0u8; HLL_REGISTER_SIZE];
-    regs_with.copy_from_slice(hll_with);
-    regs_without.copy_from_slice(hll_without);
-
     let node_gc_delta = NodeGcDelta {
         delta,
-        registers_with_last_block: regs_with,
-        registers_without_last_block: regs_without,
+        with_last_block,
+        without_last_block,
     };
 
     match tree.apply_gc_to_node(

--- a/src/redisearch_rs/headers/numeric_range_tree.h
+++ b/src/redisearch_rs/headers/numeric_range_tree.h
@@ -28,27 +28,6 @@ typedef struct InvertedIndexNumeric InvertedIndexNumeric;
 typedef struct ReversePreOrderDfsIterator ReversePreOrderDfsIterator;
 
 /**
- * A numeric range is a leaf-level storage unit in the numeric range tree.
- *
- * It stores document IDs and their associated numeric values in an inverted index,
- * along with metadata for range queries and cardinality estimation.
- *
- * # Structure
- *
- * - **Bounds** (`min_val`, `max_val`): Track the actual value range for overlap
- *   and containment tests during queries.
- * - **Cardinality** (`hll`): HyperLogLog estimator for the number of distinct
- *   values, used to decide when to split.
- * - **Entries** (`entries`): Inverted index storing (docId, value) pairs.
- *
- * # Initialization
- *
- * New ranges start with inverted bounds (`min_val = +∞`, `max_val = -∞`) so
- * the first added value correctly sets both bounds.
- */
-typedef struct NumericRange NumericRange;
-
-/**
  * A numeric range tree for efficient range queries over numeric values.
  *
  * The tree organizes documents by their numeric field values into a balanced
@@ -82,6 +61,27 @@ typedef struct NumericRange NumericRange;
  * [`Self::MAXIMUM_DEPTH_IMBALANCE`].
  */
 typedef struct NumericRangeTree NumericRangeTree;
+
+/**
+ * A numeric range is a leaf-level storage unit in the numeric range tree.
+ *
+ * It stores document IDs and their associated numeric values in an inverted index,
+ * along with metadata for range queries and cardinality estimation.
+ *
+ * # Structure
+ *
+ * - **Bounds** (`min_val`, `max_val`): Track the actual value range for overlap
+ *   and containment tests during queries.
+ * - **Cardinality** (`hll`): HyperLogLog estimator for the number of distinct
+ *   values, used to decide when to split.
+ * - **Entries** (`entries`): Inverted index storing (docId, value) pairs.
+ *
+ * # Initialization
+ *
+ * New ranges start with inverted bounds (`min_val = +∞`, `max_val = -∞`) so
+ * the first added value correctly sets both bounds.
+ */
+typedef struct NumericRange NumericRange;
 
 /**
  * A node in the numeric range tree.

--- a/src/redisearch_rs/headers/numeric_range_tree_ffi.h
+++ b/src/redisearch_rs/headers/numeric_range_tree_ffi.h
@@ -46,7 +46,7 @@ typedef struct NumericFilter NumericFilter;
  *
  * Each call to `Next` scans the next node in DFS order via
  * [`NumericRangeNode::scan_gc`][numeric_range_tree::NumericRangeNode::scan_gc]
- * and serializes the delta + HLL registers into an internal buffer.
+ * and serializes the delta + survivor statistics into an internal buffer.
  * The caller can then write the entry data to the pipe immediately,
  * avoiding buffering all deltas in memory.
  */
@@ -78,7 +78,7 @@ typedef struct NumericGcNodeEntry {
    */
   uint32_t node_generation;
   /**
-   * Pointer to the serialized entry data (msgpack delta + HLL registers).
+   * Pointer to the serialized entry data (msgpack delta + survivor statistics).
    */
   const uint8_t *data;
   /**
@@ -464,9 +464,9 @@ void NumericRangeTree_Free(struct NumericRangeTree *t);
 /**
  * Advance the scanner to the next node with GC work.
  *
- * Scans nodes in DFS order, skipping those without GC work. When a node
- * with work is found, its delta and HLL registers are serialized into the
- * scanner's internal buffer.
+ * Scans nodes in DFS order, skipping those without GC work. When a node with work
+ * is found, its delta and the statistics recomputed over the surviving entries are
+ * serialized into the scanner's internal buffer.
  *
  * Returns `true` if an entry was produced (and `*entry` is populated),
  * `false` when all nodes have been visited.
@@ -476,8 +476,12 @@ void NumericRangeTree_Free(struct NumericRangeTree *t);
  * # Wire format for `entry.data`
  *
  * ```text
- * [delta_msgpack][64-byte hll_with][64-byte hll_without]
+ * [delta_msgpack][stats_with_last_block][stats_without_last_block]
  * ```
+ *
+ * where each `stats_*` block is `[64-byte hll registers][f64 min][f64 max]`, the
+ * bounds in native byte order. The trailer is fixed-width, so the parent recovers
+ * the msgpack payload by trimming [`TRAILER_SIZE`] bytes off the end.
  *
  * # Safety
  *
@@ -561,10 +565,7 @@ size_t NumericRangeTree_BaseSize(void);
 /**
  * Parse a serialized GC entry and apply it to the specified node.
  *
- * The entry data must have the wire format produced by [`NumericGcScanner_Next`]:
- * ```text
- * [delta_msgpack][64-byte hll_with][64-byte hll_without]
- * ```
+ * `entry_data` must be in the wire format [`NumericGcScanner_Next`] documents.
  *
  * Returns an [`ApplyGcEntryResult`] whose [`status`](ApplyGcEntryStatus)
  * indicates success, node-not-found, or deserialization error.

--- a/src/redisearch_rs/inverted_index/src/codec/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/codec/numeric.rs
@@ -175,6 +175,114 @@ impl NumericFloatCompression {
     const FLOAT_COMPRESSION_THRESHOLD: f64 = 0.01;
 }
 
+/// An encoder that decides how it will represent a numeric value before writing it.
+///
+/// The representation cannot always hold the value it was given —
+/// [`NumericFloatCompression`] stores an `f32` when the precision loss is below
+/// [its threshold](NumericFloatCompression::FLOAT_COMPRESSION_THRESHOLD), and even
+/// [`Numeric`] normalizes `-0.0` to `+0.0` by encoding it as a tiny integer. That
+/// decision is made inside [`Encoder::encode`], so anything derived from a value —
+/// cardinality, bounds, routing — must be derived from the [`StoredValue`] instead,
+/// or it describes a value the index never returns.
+///
+/// [`prepare`](Self::prepare) exposes the decision on its own and
+/// [`encode_prepared`](Self::encode_prepared) takes it back, so a caller that needs
+/// the outcome up front does not make the encoder work it out twice.
+///
+/// Implementers canonicalize: two inputs represented as the same number produce the
+/// same [`StoredValue`], so distinct stored values are numerically distinct. Callers
+/// that separate values — a cardinality estimate deciding when to split, say — can
+/// rely on that instead of second-guessing the representation.
+pub trait NumericEncoder: Encoder {
+    /// Decide how `value` will be represented. Writes nothing.
+    fn prepare(value: f64) -> PreparedValue;
+
+    /// Write a value whose representation has already been decided.
+    ///
+    /// Equivalent to [`Encoder::encode`] on a record holding the same value, down to
+    /// the bytes.
+    fn encode_prepared<W: Write + std::io::Seek>(
+        writer: W,
+        delta: Self::Delta,
+        prepared: PreparedValue,
+    ) -> std::io::Result<usize>;
+
+    /// The value a reader will decode after `value` is encoded by this encoder.
+    ///
+    /// Idempotent: the stored form of a stored value is itself.
+    fn stored_value(value: f64) -> f64 {
+        Self::prepare(value).stored_value().get()
+    }
+}
+
+impl NumericEncoder for Numeric {
+    fn prepare(value: f64) -> PreparedValue {
+        PreparedValue(Value::from(value, false))
+    }
+
+    fn encode_prepared<W: Write + std::io::Seek>(
+        writer: W,
+        delta: Self::Delta,
+        prepared: PreparedValue,
+    ) -> std::io::Result<usize> {
+        encode_value(writer, delta, prepared.0)
+    }
+}
+
+impl NumericEncoder for NumericFloatCompression {
+    fn prepare(value: f64) -> PreparedValue {
+        PreparedValue(Value::from(value, true))
+    }
+
+    fn encode_prepared<W: Write + std::io::Seek>(
+        writer: W,
+        delta: Self::Delta,
+        prepared: PreparedValue,
+    ) -> std::io::Result<usize> {
+        encode_value(writer, delta, prepared.0)
+    }
+}
+
+/// How a numeric encoder will represent a value: decided, but not yet written.
+///
+/// Not parameterized by encoder on purpose: the byte layout records which
+/// representation was used, so either numeric encoder can write a decision the other
+/// one made, and any numeric decoder reads it back. Preparing with a different
+/// encoder than the index uses is therefore harmless, if pointless.
+#[derive(Debug, Clone, Copy)]
+pub struct PreparedValue(Value);
+
+impl PreparedValue {
+    /// The value a reader will decode for this representation.
+    pub const fn stored_value(self) -> StoredValue {
+        StoredValue(self.0.to_f64())
+    }
+}
+
+/// A numeric value in the exact form an index stores — and therefore returns — it.
+///
+/// Distinct from a plain `f64` so that an input value on its way in cannot be
+/// mistaken for one the index will hand back. See [`NumericEncoder`] for why that
+/// distinction matters.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct StoredValue(f64);
+
+impl StoredValue {
+    /// Wrap a value that came out of a numeric index, which is already in stored
+    /// form.
+    ///
+    /// The caller owns that provenance: pass only values read back through a numeric
+    /// [`Decoder`], never an input value on its way in.
+    pub const fn from_decoded(value: f64) -> Self {
+        Self(value)
+    }
+
+    /// The wrapped value.
+    pub const fn get(self) -> f64 {
+        self.0
+    }
+}
+
 /// The [`Numeric`] encoder only supports encoding deltas that fit within 7 bytes
 #[derive(Debug, PartialEq)]
 pub struct NumericDelta(u64);
@@ -237,7 +345,7 @@ impl Encoder for NumericFloatCompression {
 }
 
 fn encode<W: Write + std::io::Seek>(
-    mut writer: W,
+    writer: W,
     delta: NumericDelta,
     record: &RSIndexResult,
     compress_floats: bool,
@@ -246,6 +354,16 @@ fn encode<W: Write + std::io::Seek>(
         .as_numeric()
         .expect("numeric encoder will only be called for numeric records");
 
+    encode_value(writer, delta, Value::from(num_record, compress_floats))
+}
+
+/// Write a value whose representation has already been decided — the single writer
+/// behind both [`Encoder::encode`] and [`NumericEncoder::encode_prepared`].
+fn encode_value<W: Write + std::io::Seek>(
+    mut writer: W,
+    delta: NumericDelta,
+    value: Value,
+) -> std::io::Result<usize> {
     let delta = delta.pack();
 
     // Trim trailing zeros from delta so that we store as little as possible
@@ -253,7 +371,7 @@ fn encode<W: Write + std::io::Seek>(
     let delta = &delta[..end];
     let delta_bytes = delta.len() as _;
 
-    let bytes_written = match Value::from(num_record, compress_floats) {
+    let bytes_written = match value {
         Value::TinyInteger(i) => {
             let header = Header {
                 delta_bytes,
@@ -613,7 +731,7 @@ impl FromSlice for f64 {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum Value {
     TinyInteger(u8),
     IntegerPositive(u64),
@@ -654,7 +772,19 @@ impl Value {
                             && (abs_val - f32_value as f64).abs()
                                 < NumericFloatCompression::FLOAT_COMPRESSION_THRESHOLD)
                     {
-                        if v.is_sign_positive() {
+                        // A magnitude that rounds to zero has collapsed *onto* zero, so
+                        // store the canonical zero — the representation a literal `0.0`
+                        // gets — rather than a signed f32 zero. Otherwise two inputs this
+                        // encoder decided to represent as zero become two stored values
+                        // that compare equal, and every consumer would have to know which
+                        // stored values are secretly the same value.
+                        //
+                        // Only reachable with compression on: without it this branch needs
+                        // `back_to_f64 == abs_val`, which for a zero `f32_value` means
+                        // `abs_val` is zero — already claimed by the integer branch above.
+                        if f32_value == 0.0 {
+                            Value::TinyInteger(0)
+                        } else if v.is_sign_positive() {
                             Value::Float32Positive(f32_value)
                         } else {
                             Value::Float32Negative(f32_value)
@@ -666,6 +796,25 @@ impl Value {
                     }
                 }
             }
+        }
+    }
+
+    /// The `f64` a reader decodes for this representation.
+    ///
+    /// Mirrors [`decode`] arm for arm rather than sharing code with it: `decode` is on
+    /// the read hot path and rebuilds the number straight from the bytes. The
+    /// `numeric_stored_value_matches_encode_decode` proptest keeps the two in step.
+    const fn to_f64(self) -> f64 {
+        match self {
+            Value::TinyInteger(i) => i as f64,
+            Value::IntegerPositive(i) => i as f64,
+            Value::IntegerNegative(i) => (i as f64).copysign(-1.0),
+            Value::Float32Positive(f) => f as f64,
+            Value::Float32Negative(f) => f.copysign(-1.0) as f64,
+            Value::Float64Positive(f) => f,
+            Value::Float64Negative(f) => f.copysign(-1.0),
+            Value::FloatInfinity => f64::INFINITY,
+            Value::FloatNegInfinity => f64::NEG_INFINITY,
         }
     }
 }

--- a/src/redisearch_rs/inverted_index/src/index/core.rs
+++ b/src/redisearch_rs/inverted_index/src/index/core.rs
@@ -19,6 +19,7 @@ use crate::{
     BlockCapacity, Encoder, IdDelta,
     controlled_cursor::ControlledCursor,
     debug::{BlockSummary, Summary},
+    numeric::{NumericEncoder, PreparedValue},
 };
 use ffi::{IndexFlags, IndexFlags_Index_HasMultiValue};
 use index_result::RSIndexResult;
@@ -193,8 +194,20 @@ impl<E: Encoder> InvertedIndex<E> {
     /// It is expected that the document ID of the record is greater than or equal to the last
     /// document ID in the index.
     pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<AddRecordOutcome> {
-        let doc_id = record.doc_id;
+        self.add_entry(record.doc_id, |writer, delta| {
+            E::encode(writer, delta, record)
+        })
+    }
 
+    /// Add an entry for `doc_id`, letting `encode` write the payload.
+    ///
+    /// Everything an add does apart from writing the payload depends only on the
+    /// document ID, so callers holding something other than an [`RSIndexResult`] —
+    /// see [`Self::add_prepared_record`] — reuse all of it.
+    fn add_entry<F>(&mut self, doc_id: DocId, encode: F) -> std::io::Result<AddRecordOutcome>
+    where
+        F: FnOnce(ControlledCursor<'_>, E::Delta) -> std::io::Result<usize>,
+    {
         let same_doc = match (
             E::ALLOW_DUPLICATES,
             self.last_doc_id().map(|d| d == doc_id).unwrap_or_default(),
@@ -240,7 +253,7 @@ impl<E: Encoder> InvertedIndex<E> {
 
         let buf_cap = block.buffer.capacity();
         let writer = block.writer();
-        let _bytes_written = E::encode(writer, delta, record)?;
+        let _bytes_written = encode(writer, delta)?;
 
         // We don't use `_bytes_written` returned by the encoder to determine by how much memory
         // grew because the buffer might have had enough capacity for the bytes in the encoding.
@@ -386,5 +399,23 @@ impl<E: Encoder> InvertedIndex<E> {
     /// revalidation.
     pub const fn unique_id(&self) -> IndexUniqueId {
         self.unique_id
+    }
+}
+
+impl<E: NumericEncoder> InvertedIndex<E> {
+    /// Add an entry whose representation the caller already obtained from
+    /// [`NumericEncoder::prepare`].
+    ///
+    /// Equivalent to [`Self::add_record`] with a numeric record holding the same
+    /// document ID and value — same bytes, same outcome — without classifying the
+    /// value a second time or building an [`RSIndexResult`] to carry it.
+    pub fn add_prepared_record(
+        &mut self,
+        doc_id: DocId,
+        prepared: PreparedValue,
+    ) -> std::io::Result<AddRecordOutcome> {
+        self.add_entry(doc_id, |writer, delta| {
+            E::encode_prepared(writer, delta, prepared)
+        })
     }
 }

--- a/src/redisearch_rs/inverted_index/src/index/with_entries.rs
+++ b/src/redisearch_rs/inverted_index/src/index/with_entries.rs
@@ -10,6 +10,7 @@
 use crate::{
     AddRecordOutcome, DecodedBy, Encoder, GcApplyInfo, GcScanDelta, IndexBlock, InvertedIndex,
     debug::{BlockSummary, Summary},
+    numeric::{NumericEncoder, PreparedValue},
     reader::IndexReaderCore,
 };
 use ffi::IndexFlags;
@@ -156,5 +157,21 @@ impl<E: Encoder + DecodedBy> EntriesTrackingIndex<E> {
         self.number_of_entries -= info.entries_removed;
 
         info
+    }
+}
+
+impl<E: NumericEncoder> EntriesTrackingIndex<E> {
+    /// Add an entry whose representation the encoder already decided — see
+    /// [`InvertedIndex::add_prepared_record`].
+    pub fn add_prepared_record(
+        &mut self,
+        doc_id: DocId,
+        prepared: PreparedValue,
+    ) -> std::io::Result<AddRecordOutcome> {
+        let result = self.index.add_prepared_record(doc_id, prepared)?;
+
+        self.number_of_entries += 1;
+
+        Ok(result)
     }
 }

--- a/src/redisearch_rs/inverted_index/src/tests/index.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/index.rs
@@ -628,3 +628,54 @@ fn blocks_summary_store_numeric() {
         ]
     );
 }
+
+/// The prepared write path must leave the index in exactly the state the
+/// record-based path would: same bytes, same block layout, same growth accounting.
+/// Anything less and callers would have to know which path an index was built with.
+#[test]
+fn add_prepared_record_matches_add_record() {
+    use crate::numeric::{Numeric, NumericEncoder};
+
+    // Values chosen to exercise every representation the encoder picks between:
+    // tiny int, wide int, negative, f32, f64, and infinity.
+    let values = [
+        0.0,
+        3.0,
+        -7.0,
+        1024.0,
+        0.5,
+        1e-9,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+        9_007_199_254_740_993.0,
+    ];
+
+    let mut from_records = InvertedIndex::<Numeric>::new(IndexFlags_Index_StoreNumeric);
+    let mut from_prepared = InvertedIndex::<Numeric>::new(IndexFlags_Index_StoreNumeric);
+
+    for (i, value) in values.iter().enumerate() {
+        let doc_id = i as DocId + 1;
+
+        let record = RSIndexResult::build_numeric(*value).doc_id(doc_id).build();
+        let record_outcome = from_records.add_record(&record).unwrap();
+        let prepared_outcome = from_prepared
+            .add_prepared_record(doc_id, Numeric::prepare(*value))
+            .unwrap();
+
+        assert_eq!(
+            record_outcome, prepared_outcome,
+            "outcomes diverged while adding {value} for doc {doc_id}"
+        );
+    }
+
+    assert_eq!(
+        from_records.blocks_summary(),
+        from_prepared.blocks_summary(),
+        "block layout diverged"
+    );
+    assert_eq!(from_records.memory_usage(), from_prepared.memory_usage());
+
+    let record_bytes: Vec<_> = from_records.blocks.iter().map(|b| b.data()).collect();
+    let prepared_bytes: Vec<_> = from_prepared.blocks.iter().map(|b| b.data()).collect();
+    assert_eq!(record_bytes, prepared_bytes, "encoded bytes diverged");
+}

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/numeric.rs
@@ -10,10 +10,213 @@
 use index_result::RSIndexResult;
 use inverted_index::{
     Decoder, Encoder, IdDelta,
-    numeric::{Numeric, NumericDelta, NumericFloatCompression},
+    numeric::{Numeric, NumericDelta, NumericEncoder, NumericFloatCompression},
 };
 use pretty_assertions::assert_eq;
 use std::io::Cursor;
+
+/// Encode `value` with `E` and decode it again, returning what a reader sees.
+fn round_trip<E: Encoder<Delta = NumericDelta> + Decoder>(value: f64) -> f64 {
+    let mut buf = Cursor::new(Vec::new());
+    let record = RSIndexResult::build_numeric(value).doc_id(1).build();
+    E::encode(&mut buf, NumericDelta::from_u64(0).unwrap(), &record).expect("to encode");
+
+    let buf = buf.into_inner();
+    let mut buf = Cursor::new(buf.as_ref());
+    let decoded = E::decode_new(&mut buf, 1).expect("to decode");
+
+    decoded.as_numeric().expect("a numeric record")
+}
+
+/// `stored_value` must predict exactly what an encode/decode round trip produces, and
+/// the two are separate code paths — see `Value::to_f64`.
+fn assert_stored_value_matches_round_trip(value: f64) {
+    for (name, predicted, actual) in [
+        (
+            "Numeric",
+            Numeric::stored_value(value),
+            round_trip::<Numeric>(value),
+        ),
+        (
+            "NumericFloatCompression",
+            NumericFloatCompression::stored_value(value),
+            round_trip::<NumericFloatCompression>(value),
+        ),
+    ] {
+        assert_eq!(
+            predicted.to_bits(),
+            actual.to_bits(),
+            "{name}: stored_value({value}) predicted {predicted} but a round trip yields {actual}"
+        );
+        // Storing a stored value must be a no-op, or repeated preparation could keep
+        // shifting statistics.
+        let twice = match name {
+            "Numeric" => Numeric::stored_value(predicted),
+            _ => NumericFloatCompression::stored_value(predicted),
+        };
+        assert_eq!(
+            twice.to_bits(),
+            predicted.to_bits(),
+            "{name}: stored_value is not idempotent for {value}"
+        );
+    }
+}
+
+#[test]
+fn stored_value_matches_encode_decode_for_edge_cases() {
+    for value in [
+        0.0,
+        -0.0, // stored as a tiny int, so it comes back as +0.0
+        1.0,
+        7.0,
+        8.0,
+        -1.0,
+        -8.0,
+        0.5,
+        -0.5,
+        3.124,                   // compressible: within the 0.01 threshold
+        100.500001,              // collapses onto 100.5 as an f32
+        1e-9, // NOT compressible: relative error is tiny, absolute is smaller still
+        9_007_199_254_740_993.0, // 2^53 + 1
+        4_503_599_627_370_496.0, // a 52-bit geohash-shaped value
+        f64::MAX,
+        f64::MIN,
+        f64::MIN_POSITIVE,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+    ] {
+        assert_stored_value_matches_round_trip(value);
+    }
+}
+
+/// The two write entry points must be interchangeable down to the bytes, or an index
+/// written through the prepared path would decode differently.
+fn assert_encode_prepared_matches_encode(value: f64, delta: u64) {
+    fn compare<E: Encoder<Delta = NumericDelta> + NumericEncoder>(value: f64, delta: u64) {
+        let record = RSIndexResult::build_numeric(value).doc_id(1).build();
+
+        let mut from_record = Cursor::new(Vec::new());
+        let record_bytes = E::encode(
+            &mut from_record,
+            NumericDelta::from_u64(delta).unwrap(),
+            &record,
+        )
+        .expect("to encode");
+
+        let mut from_prepared = Cursor::new(Vec::new());
+        let prepared_bytes = E::encode_prepared(
+            &mut from_prepared,
+            NumericDelta::from_u64(delta).unwrap(),
+            E::prepare(value),
+        )
+        .expect("to encode");
+
+        assert_eq!(
+            from_record.into_inner(),
+            from_prepared.into_inner(),
+            "encode and encode_prepared disagree for value {value}, delta {delta}"
+        );
+        assert_eq!(record_bytes, prepared_bytes);
+    }
+
+    compare::<Numeric>(value, delta);
+    compare::<NumericFloatCompression>(value, delta);
+}
+
+#[test]
+fn encode_prepared_matches_encode_for_edge_cases() {
+    for value in [
+        0.0,
+        -0.0,
+        7.0,
+        -8.0,
+        3.124,
+        100.500001,
+        1e-9,
+        9_007_199_254_740_993.0,
+        f64::MAX,
+        f64::MIN,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+    ] {
+        for delta in [0, 1, 255, 72_057_594_037_927_935] {
+            assert_encode_prepared_matches_encode(value, delta);
+        }
+    }
+}
+
+#[test]
+fn stored_value_maps_negative_zero_to_positive_zero() {
+    // Both encoders take the tiny-integer path for zero, so the sign is dropped.
+    for stored in [
+        Numeric::stored_value(-0.0),
+        NumericFloatCompression::stored_value(-0.0),
+    ] {
+        assert!(
+            stored.is_sign_positive() && stored == 0.0,
+            "-0.0 should be stored as +0.0, got {stored}"
+        );
+    }
+}
+
+/// Magnitudes that round to zero collapse onto the *canonical* zero, whatever their
+/// sign.
+///
+/// Compression stores an f32 whenever the loss is under its threshold, and for a
+/// subnormal magnitude that f32 is zero. Keeping the sign flag there would produce a
+/// `-0.0` stored value: numerically equal to `+0.0`, so no filter could separate the
+/// two, yet distinct enough to fool a consumer that keys values by bit pattern.
+#[test]
+fn compression_collapse_to_zero_is_canonical() {
+    for input in [
+        5e-324,
+        -5e-324,
+        f64::MIN_POSITIVE,
+        -f64::MIN_POSITIVE,
+        1e-60,
+        -1e-60,
+    ] {
+        let stored = NumericFloatCompression::stored_value(input);
+        assert_eq!(stored, 0.0, "{input} should collapse onto zero");
+        assert!(
+            stored.is_sign_positive(),
+            "{input} collapsed onto a negative zero"
+        );
+
+        // Without compression such a magnitude is kept exactly, so no collapse and no
+        // canonicalization question.
+        assert_eq!(Numeric::stored_value(input).to_bits(), input.to_bits());
+    }
+}
+
+#[test]
+fn stored_value_of_nan_stays_nan() {
+    // NaN survives as NaN (the payload may differ), so it can never move a bound:
+    // every comparison against it is false.
+    assert!(Numeric::stored_value(f64::NAN).is_nan());
+    assert!(NumericFloatCompression::stored_value(f64::NAN).is_nan());
+}
+
+#[test]
+fn compression_collapses_neighbouring_values_to_one_stored_value() {
+    // The MOD-16877 shape: distinct f64s inside one f32 bucket collapse to a single
+    // stored value under compression.
+    let values: Vec<f64> = (0..8).map(|i| 100.5 + i as f64 * 1e-7).collect();
+    let stored: Vec<f64> = values
+        .iter()
+        .map(|&v| NumericFloatCompression::stored_value(v))
+        .collect();
+
+    assert!(
+        stored.windows(2).all(|w| w[0] == w[1]),
+        "expected one stored value, got {stored:?}"
+    );
+    assert_eq!(stored[0], 100.5);
+
+    // Without compression they stay distinct.
+    let exact: Vec<f64> = values.iter().map(|&v| Numeric::stored_value(v)).collect();
+    assert_eq!(exact, values);
+}
 
 /// Tests for integer values between 0 and 7 which should use the [TINY header](super#tiny-type) format.
 #[test]
@@ -638,6 +841,36 @@ mod property_based {
                 .expect("to decode numeric record");
 
             assert_eq!(record_decoded, record, "failed for value: {}", value);
+        }
+
+        /// Keeps `Value::to_f64` (which backs `stored_value`) in agreement with
+        /// `decode`, which reconstructs values from the bytes independently.
+        #[test]
+        fn numeric_stored_value_matches_encode_decode(value in f64::MIN..f64::MAX) {
+            assert_stored_value_matches_round_trip(value);
+        }
+
+        /// The prepared path must be byte-identical to the record path.
+        #[test]
+        fn numeric_encode_prepared_matches_encode(
+            value in f64::MIN..f64::MAX,
+            delta in 0u64..72_057_594_037_927_935u64,
+        ) {
+            assert_encode_prepared_matches_encode(value, delta);
+        }
+
+        /// Re-preparing a stored value must be a no-op: the tree prepares on the way
+        /// in, and split redistribution prepares values it read back out again.
+        #[test]
+        fn numeric_stored_value_is_idempotent(value in f64::MIN..f64::MAX) {
+            let once = Numeric::stored_value(value);
+            assert_eq!(Numeric::stored_value(once).to_bits(), once.to_bits());
+
+            let once = NumericFloatCompression::stored_value(value);
+            assert_eq!(
+                NumericFloatCompression::stored_value(once).to_bits(),
+                once.to_bits(),
+            );
         }
     }
 }

--- a/src/redisearch_rs/numeric_range_tree/src/index.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/index.rs
@@ -17,7 +17,7 @@ use index_result::RSIndexResult;
 use inverted_index::{
     EntriesTrackingIndex, IndexReader, NumericReader, RawIndexReaderCore,
     debug::Summary,
-    numeric::{Numeric, NumericFloatCompression},
+    numeric::{Numeric, NumericEncoder, NumericFloatCompression, PreparedValue},
 };
 use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
@@ -45,8 +45,34 @@ impl NumericIndex {
         }
     }
 
+    /// Ask this index's encoder how it will represent `value` — see
+    /// [`NumericEncoder::prepare`].
+    pub fn prepare(&self, value: f64) -> PreparedValue {
+        match self {
+            NumericIndex::Uncompressed(_) => Numeric::prepare(value),
+            NumericIndex::Compressed(_) => NumericFloatCompression::prepare(value),
+        }
+    }
+
+    /// [`Self::prepare`] for callers that hold the `compress_floats` flag rather than
+    /// an index — the tree prepares on the way in, before it has descended to the leaf
+    /// whose index will write the entry. Kept next to [`Self::new`], which owns the
+    /// same flag-to-encoder mapping.
+    pub fn prepare_for(compress_floats: bool, value: f64) -> PreparedValue {
+        if compress_floats {
+            NumericFloatCompression::prepare(value)
+        } else {
+            Numeric::prepare(value)
+        }
+    }
+
     /// Add a record to the index. Returns `(memory_growth, blocks_added)` — see
     /// [`InvertedIndex::add_record`][inverted_index::InvertedIndex::add_record].
+    ///
+    /// For callers that already hold an [`RSIndexResult`] and derive nothing from the
+    /// value. A caller that also needs to know what will be stored should
+    /// [`prepare`](Self::prepare) it and use
+    /// [`add_prepared_record`](Self::add_prepared_record) instead of asking twice.
     ///
     /// # Panics
     ///
@@ -56,6 +82,26 @@ impl NumericIndex {
         let result = match self {
             NumericIndex::Uncompressed(idx) => idx.add_record(record),
             NumericIndex::Compressed(idx) => idx.add_record(record),
+        };
+        result.expect("in-memory inverted index write cannot fail")
+    }
+
+    /// Add an entry whose representation was already decided by [`Self::prepare`].
+    /// Returns `(memory_growth, blocks_added)` — see
+    /// [`InvertedIndex::add_prepared_record`][inverted_index::InvertedIndex::add_prepared_record].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the underlying write fails. This should never happen with
+    /// in-memory inverted indexes, so a panic indicates a bug.
+    pub fn add_prepared_record(
+        &mut self,
+        doc_id: DocId,
+        prepared: PreparedValue,
+    ) -> inverted_index::AddRecordOutcome {
+        let result = match self {
+            NumericIndex::Uncompressed(idx) => idx.add_prepared_record(doc_id, prepared),
+            NumericIndex::Compressed(idx) => idx.add_prepared_record(doc_id, prepared),
         };
         result.expect("in-memory inverted index write cannot fail")
     }

--- a/src/redisearch_rs/numeric_range_tree/src/lib.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/lib.rs
@@ -81,7 +81,7 @@ pub use index::{NumericIndex, NumericIndexReader, RawNumericIndexReader};
 pub use inverted_index::NumericFilter;
 pub use iter::{IndexedReversePreOrderDfsIterator, ReversePreOrderDfsIterator};
 pub use node::{InternalNode, LeafNode, NumericRangeNode};
-pub use range::NumericRange;
+pub use range::{GcSurvivorStats, Hll, NumericRange, ValueBounds};
 pub use tree::{
     AddResult, CompactIfSparseResult, NodeGcDelta, NumericRangeTree, SingleNodeGcResult,
     TrimEmptyLeavesResult,

--- a/src/redisearch_rs/numeric_range_tree/src/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/range.rs
@@ -49,6 +49,151 @@ impl std::hash::Hash for NumericValue {
 /// on precision, error rate, and memory usage.
 pub type Hll = HyperLogLog6<NumericValue, WyHasher>;
 
+/// The smallest and largest value observed over a set of numeric entries.
+///
+/// Starts inverted (`min = +∞`, `max = -∞`) so the first observed value sets both
+/// ends. An interval that never observed a value stays inverted, which is exactly
+/// the sentinel [`NumericRange`] uses for "no entries".
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ValueBounds {
+    min: f64,
+    max: f64,
+}
+
+impl ValueBounds {
+    /// Bounds that have observed no value at all.
+    pub const EMPTY: Self = Self {
+        min: f64::INFINITY,
+        max: f64::NEG_INFINITY,
+    };
+
+    /// Build bounds from a previously extracted `(min, max)` pair — pass
+    /// [`Self::EMPTY`]'s components to denote "no value observed".
+    pub const fn from_min_max(min: f64, max: f64) -> Self {
+        Self { min, max }
+    }
+
+    /// Widen the bounds to include `value`.
+    ///
+    /// `NaN` compares false against everything, so it never moves either end.
+    pub const fn observe(&mut self, value: StoredValue) {
+        let value = value.get();
+        if value < self.min {
+            self.min = value;
+        }
+        if value > self.max {
+            self.max = value;
+        }
+    }
+
+    /// Widen the bounds to include everything `other` observed.
+    ///
+    /// Merging [`Self::EMPTY`] is a no-op — its inverted ends must not be mistaken
+    /// for observed values.
+    pub const fn merge(&mut self, other: Self) {
+        if other.min < self.min {
+            self.min = other.min;
+        }
+        if other.max > self.max {
+            self.max = other.max;
+        }
+    }
+
+    /// The smallest observed value, or `f64::INFINITY` if none was observed.
+    pub const fn min(&self) -> f64 {
+        self.min
+    }
+
+    /// The largest observed value, or `f64::NEG_INFINITY` if none was observed.
+    pub const fn max(&self) -> f64 {
+        self.max
+    }
+}
+
+impl Default for ValueBounds {
+    fn default() -> Self {
+        Self::EMPTY
+    }
+}
+
+/// Per-range statistics recomputed over the surviving entries during a GC scan.
+///
+/// The GC child cannot mutate the parent's ranges, so it ships these numbers back
+/// over the pipe and the parent installs them via
+/// [`NumericRange::reset_stats_after_gc`]. Cardinality and bounds travel together
+/// because they are derived from the same pass over the surviving entries and must
+/// be applied together.
+#[derive(Debug, Clone, Copy)]
+pub struct GcSurvivorStats {
+    /// HyperLogLog registers covering the surviving entries.
+    pub registers: [u8; Hll::size()],
+    /// Value bounds covering the surviving entries.
+    pub bounds: ValueBounds,
+}
+
+impl GcSurvivorStats {
+    /// Statistics for a scan that observed no surviving entry.
+    pub const EMPTY: Self = Self {
+        registers: [0; Hll::size()],
+        bounds: ValueBounds::EMPTY,
+    };
+
+    /// Length of the byte string produced by [`Self::write_to`].
+    pub const WIRE_SIZE: usize = Hll::size() + 2 * size_of::<f64>();
+
+    /// Append the wire representation of these statistics to `buffer`.
+    ///
+    /// Bounds use native byte order: the only reader is the parent of the fork that
+    /// produced them, so both ends always agree on endianness.
+    pub fn write_to(&self, buffer: &mut Vec<u8>) {
+        buffer.extend_from_slice(&self.registers);
+        buffer.extend_from_slice(&self.bounds.min().to_ne_bytes());
+        buffer.extend_from_slice(&self.bounds.max().to_ne_bytes());
+    }
+
+    /// Rebuild statistics from the [`Self::write_to`] representation.
+    ///
+    /// Returns `None` unless `bytes` is exactly [`Self::WIRE_SIZE`] long. The values
+    /// themselves are trusted: they come from this process's own GC child.
+    pub fn read_from(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != Self::WIRE_SIZE {
+            return None;
+        }
+
+        let (registers, bounds) = bytes.split_at(Hll::size());
+        let (min, max) = bounds.split_at(size_of::<f64>());
+
+        let mut stats = Self {
+            registers: [0; Hll::size()],
+            bounds: ValueBounds::from_min_max(
+                f64::from_ne_bytes(min.try_into().expect("min is 8 bytes long")),
+                f64::from_ne_bytes(max.try_into().expect("max is 8 bytes long")),
+            ),
+        };
+        stats.registers.copy_from_slice(registers);
+        Some(stats)
+    }
+}
+
+impl Default for GcSurvivorStats {
+    fn default() -> Self {
+        Self::EMPTY
+    }
+}
+
+/// Whether a GC apply may tighten a range's value bounds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GcBoundsUpdate {
+    /// Shrink the bounds to what the surviving entries need. Correct for leaf
+    /// ranges, whose bounds describe exactly their own entries.
+    Tighten,
+    /// Leave the bounds untouched. Used for the ranges retained on internal nodes:
+    /// those must stay a superset of their whole subtree, and the descendants are
+    /// applied *after* the ancestor, so tightening here would leave the tree
+    /// temporarily claiming an ancestor range narrower than its children.
+    Keep,
+}
+
 /// A numeric range is a leaf-level storage unit in the numeric range tree.
 ///
 /// It stores document IDs and their associated numeric values in an inverted index,
@@ -71,17 +216,15 @@ pub struct NumericRange {
     /// The minimum value stored in this range.
     /// Initialized to `f64::INFINITY` so any value will be smaller.
     ///
-    /// A monotone *lower bound* in [`StoredValue`] form, not necessarily the smallest
-    /// value the range currently stores: it is lowered when a smaller value is added,
-    /// but never raised. GC removes entries without tightening it, so once the
-    /// documents holding the smallest value are collected it sits strictly below every
-    /// surviving value.
+    /// A [`StoredValue`] lowered by [`Self::add_without_cardinality`] when a smaller
+    /// value arrives and raised by [`Self::reset_stats_after_gc`] when GC removes the
+    /// entries that were holding it. Always a valid *lower bound*; only exactly the
+    /// smallest stored value if the last GC pass tightened it.
     min_val: f64,
     /// The maximum value stored in this range.
     /// Initialized to `f64::NEG_INFINITY` so any value will be larger.
     ///
-    /// Monotone *upper bound*, with the same caveat as [`Self::min_val`]: GC never
-    /// lowers it.
+    /// Upper bound, maintained symmetrically to [`Self::min_val`].
     max_val: f64,
     /// HyperLogLog for estimating the number of distinct values (cardinality).
     /// Used to decide when to split the range.
@@ -211,58 +354,86 @@ impl NumericRange {
         &self.hll
     }
 
-    /// Reset the HLL cardinality after garbage collection.
+    /// Reset the cardinality estimate and the value bounds after garbage collection.
     ///
-    /// This sets the HLL registers from GC scan results and re-adds entries
-    /// from blocks that were added since the fork.
+    /// The GC child recomputed both over the entries that survived its scan. This
+    /// installs those numbers, then rescans the blocks the scan could not account
+    /// for — blocks the parent appended after the fork, plus the last block when the
+    /// apply step had to ignore it — so that neither statistic misses an entry that
+    /// is still in the index.
     ///
-    /// # Arguments
+    /// `ignored_last_block` comes from the [`GcApplyInfo`] the apply step returned.
+    /// Pass [`GcBoundsUpdate::Keep`] to skip the bounds update; see that variant.
     ///
-    /// * `ignored_last_block` - Whether the last block was ignored during GC scan (from `GcApplyInfo`)
-    /// * `blocks_since_fork` - Number of new blocks added since the fork
-    /// * `registers_with_last_block` - HLL registers including the last block's cardinality
-    /// * `registers_without_last_block` - HLL registers excluding the last block's cardinality
-    pub(crate) fn reset_cardinality_after_gc(
+    /// # Bounds only tighten
+    ///
+    /// Adds and scans both observe values in stored form, so the recomputed interval
+    /// is always contained in the one already reported — asserted below, so a future
+    /// divergence surfaces here rather than as a range that stops covering its own
+    /// entries.
+    ///
+    /// [`GcApplyInfo`]: inverted_index::GcApplyInfo
+    pub(crate) fn reset_stats_after_gc(
         &mut self,
         ignored_last_block: bool,
         blocks_since_fork: usize,
-        registers_with_last_block: &[u8; Hll::size()],
-        registers_without_last_block: &[u8; Hll::size()],
+        with_last_block: &GcSurvivorStats,
+        without_last_block: &GcSurvivorStats,
+        bounds_update: GcBoundsUpdate,
     ) {
         let mut blocks_to_rescan = blocks_since_fork;
 
-        if ignored_last_block {
-            self.hll.set_registers(*registers_without_last_block);
+        let mut bounds = if ignored_last_block {
+            self.hll.set_registers(without_last_block.registers);
             blocks_to_rescan += 1; // The last block was ignored, so re-add it too
+            without_last_block.bounds
         } else {
-            self.hll.set_registers(*registers_with_last_block);
-            if blocks_to_rescan == 0 {
-                return; // No new blocks since fork, we're done
+            self.hll.set_registers(with_last_block.registers);
+            with_last_block.bounds
+        };
+
+        if blocks_to_rescan > 0 {
+            // Get the starting point for the update - iterate entries added since fork
+            let num_blocks = self.entries.num_blocks();
+            debug_assert!(
+                blocks_to_rescan <= num_blocks,
+                "The number of blocks should never decrease in between two GC runs, \
+                therefore the number of blocks to rescan can never be greater than the current number of blocks"
+            );
+            let start_idx = num_blocks - blocks_to_rescan;
+
+            if let Some(start_id) = self.entries.block_first_id(start_idx) {
+                // Iterate entries added since fork and fold them into the cardinality
+                // estimation and the bounds.
+                let mut reader = self.entries.reader();
+                reader.skip_to(start_id);
+                let mut result = RSIndexResult::build_numeric(0.0).build();
+                while reader.next_record(&mut result).unwrap_or(false) {
+                    // SAFETY: We know the result contains numeric data
+                    let value = unsafe { result.as_numeric_unchecked() };
+                    // Read back out of the index, so already in stored form.
+                    let value = StoredValue::from_decoded(value);
+                    self.hll.add(&value.into());
+                    bounds.observe(value);
+                }
             }
         }
 
-        // Get the starting point for HLL update - iterate entries added since fork
-        let num_blocks = self.entries.num_blocks();
-        debug_assert!(
-            blocks_to_rescan <= num_blocks,
-            "The number of blocks should never decrease in between two GC runs, \
-            therefore the number of blocks to rescan can never be greater than the current number of blocks"
-        );
-        let start_idx = num_blocks - blocks_to_rescan;
-        let Some(start_id) = self.entries.block_first_id(start_idx) else {
-            return;
-        };
+        if bounds_update == GcBoundsUpdate::Tighten {
+            // See "Bounds only tighten" above. An empty interval (nothing survived) is
+            // inverted, so it trivially satisfies both comparisons.
+            debug_assert!(
+                bounds.min() >= self.min_val && bounds.max() <= self.max_val,
+                "recomputed bounds [{}, {}] must be contained in the reported bounds [{}, {}] — \
+                 both are observed in stored form",
+                bounds.min(),
+                bounds.max(),
+                self.min_val,
+                self.max_val,
+            );
 
-        // Iterate entries added since fork and update the cardinality estimation
-        // via HLL.
-        let mut reader = self.entries.reader();
-        reader.skip_to(start_id);
-        let mut result = RSIndexResult::build_numeric(0.0).build();
-        while reader.next_record(&mut result).unwrap_or(false) {
-            // SAFETY: We know the result contains numeric data
-            let value = unsafe { result.as_numeric_unchecked() };
-            // Read back out of the index, so already in stored form.
-            self.hll.add(&StoredValue::from_decoded(value).into());
+            self.min_val = bounds.min();
+            self.max_val = bounds.max();
         }
     }
 }

--- a/src/redisearch_rs/numeric_range_tree/src/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/range.rs
@@ -16,20 +16,24 @@
 use hyperloglog::{HyperLogLog6, WyHasher};
 use index_result::RSIndexResult;
 use inverted_index::IndexReader as _;
+use inverted_index::numeric::{PreparedValue, StoredValue};
 use rqe_core::DocId;
 
 use crate::index::{NumericIndex, NumericIndexReader};
 
 /// Newtype around [`f64`] that hashes via native-endian bytes.
 ///
-/// Ensures HLL cardinality estimation uses a consistent raw bit representation,
-/// so `-0.0` and `+0.0` are distinct and no float comparison is involved.
+/// Ensures HLL cardinality estimation uses a consistent raw bit representation, so
+/// no float comparison is involved.
+///
+/// Only constructible from a [`StoredValue`], so inputs the encoder maps onto the
+/// same stored value count once — including `-0.0` and `+0.0`.
 #[derive(Debug, Clone, Copy)]
 pub struct NumericValue(f64);
 
-impl From<f64> for NumericValue {
-    fn from(value: f64) -> Self {
-        Self(value)
+impl From<StoredValue> for NumericValue {
+    fn from(value: StoredValue) -> Self {
+        Self(value.get())
     }
 }
 
@@ -67,16 +71,16 @@ pub struct NumericRange {
     /// The minimum value stored in this range.
     /// Initialized to `f64::INFINITY` so any value will be smaller.
     ///
-    /// This is a monotone *lower bound*, not necessarily the smallest value the
-    /// range currently stores: it is lowered when a smaller value is added, but
-    /// never raised. GC removes entries without tightening it, so after the
-    /// documents holding the smallest value are collected it sits strictly below
-    /// every surviving value.
+    /// A monotone *lower bound* in [`StoredValue`] form, not necessarily the smallest
+    /// value the range currently stores: it is lowered when a smaller value is added,
+    /// but never raised. GC removes entries without tightening it, so once the
+    /// documents holding the smallest value are collected it sits strictly below every
+    /// surviving value.
     min_val: f64,
     /// The maximum value stored in this range.
     /// Initialized to `f64::NEG_INFINITY` so any value will be larger.
     ///
-    /// Monotone *upper bound*, with the same caveat as `min_val`: GC never
+    /// Monotone *upper bound*, with the same caveat as [`Self::min_val`]: GC never
     /// lowers it.
     max_val: f64,
     /// HyperLogLog for estimating the number of distinct values (cardinality).
@@ -107,9 +111,12 @@ impl NumericRange {
     /// reporting how many bytes the inverted index grew by and how many new index blocks the
     /// write created.
     ///
+    /// Takes the encoder's decision from [`NumericIndex::prepare`], so both statistics
+    /// describe what the index will return.
+    ///
     /// [`AddRecordOutcome`]: inverted_index::AddRecordOutcome
-    pub fn add(&mut self, doc_id: DocId, value: f64) -> inverted_index::AddRecordOutcome {
-        self.hll.add(&value.into());
+    pub fn add(&mut self, doc_id: DocId, value: PreparedValue) -> inverted_index::AddRecordOutcome {
+        self.hll.add(&value.stored_value().into());
         self.add_without_cardinality(doc_id, value)
     }
 
@@ -128,19 +135,18 @@ impl NumericRange {
     pub fn add_without_cardinality(
         &mut self,
         doc_id: DocId,
-        value: f64,
+        value: PreparedValue,
     ) -> inverted_index::AddRecordOutcome {
-        // Update bounds
-        if value < self.min_val {
-            self.min_val = value;
+        let stored = value.stored_value().get();
+
+        if stored < self.min_val {
+            self.min_val = stored;
         }
-        if value > self.max_val {
-            self.max_val = value;
+        if stored > self.max_val {
+            self.max_val = stored;
         }
 
-        // Add to inverted index
-        let record = RSIndexResult::build_numeric(value).doc_id(doc_id).build();
-        self.entries.add_record(&record)
+        self.entries.add_prepared_record(doc_id, value)
     }
 
     /// Get the estimated cardinality (number of distinct values).
@@ -255,7 +261,8 @@ impl NumericRange {
         while reader.next_record(&mut result).unwrap_or(false) {
             // SAFETY: We know the result contains numeric data
             let value = unsafe { result.as_numeric_unchecked() };
-            self.hll.add(&value.into());
+            // Read back out of the index, so already in stored form.
+            self.hll.add(&StoredValue::from_decoded(value).into());
         }
     }
 }

--- a/src/redisearch_rs/numeric_range_tree/src/test_utils.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/test_utils.rs
@@ -12,7 +12,6 @@
 //! Gated behind the `test_utils` feature so that production builds do not
 //! include these utilities.
 
-use index_result::RSIndexResult;
 use inverted_index::{Encoder, numeric::Numeric};
 
 use crate::{NodeGcDelta, NodeIndex, NumericRangeNode, NumericRangeTree};
@@ -114,6 +113,10 @@ pub fn build_tree_at_split_edge() -> (NumericRangeTree, u64) {
 ///
 /// Uses zeroed HLL registers. For accurate HLL values, use
 /// [`NumericRangeNode::scan_gc`] directly or [`scan_node_delta_with_hll`].
+///
+/// The recomputed value bounds are always accurate — a delta carrying empty bounds
+/// would tell the parent that nothing survived, which is a different scenario from
+/// "cardinality was not computed".
 pub fn scan_node_delta(
     tree: &NumericRangeTree,
     node_idx: NodeIndex,
@@ -129,30 +132,11 @@ pub fn scan_node_delta_with_hll(
     doc_exist: &dyn Fn(u64) -> bool,
     hll_fn: impl Fn(&inverted_index::GcScanDelta) -> ([u8; 64], [u8; 64]),
 ) -> Option<NodeGcDelta> {
-    let node = tree.node(node_idx);
-    node.range()
-        .and_then(|range| -> Option<inverted_index::GcScanDelta> {
-            range
-                .entries()
-                .scan_gc(
-                    doc_exist,
-                    None::<
-                        for<'index> fn(
-                            &RSIndexResult<'index>,
-                            &inverted_index::RepairContext<'index>,
-                        ),
-                    >,
-                )
-                .expect("scan_gc should not fail")
-        })
-        .map(|delta| {
-            let (hll_with, hll_without) = hll_fn(&delta);
-            NodeGcDelta {
-                delta,
-                registers_with_last_block: hll_with,
-                registers_without_last_block: hll_without,
-            }
-        })
+    let mut delta = tree.node(node_idx).scan_gc(doc_exist)?;
+    let (hll_with, hll_without) = hll_fn(&delta.delta);
+    delta.with_last_block.registers = hll_with;
+    delta.without_last_block.registers = hll_without;
+    Some(delta)
 }
 
 /// Scan all nodes in the tree and collect GC deltas for nodes that have work.

--- a/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
@@ -17,6 +17,7 @@ use rqe_core::DocId;
 use std::collections::HashMap;
 
 use index_result::RSIndexResult;
+use inverted_index::numeric::StoredValue;
 use inverted_index::{GcApplyInfo, GcScanDelta};
 
 use super::{NumericRangeTree, TrimEmptyLeavesResult};
@@ -93,8 +94,9 @@ impl NumericRangeNode {
         let mut last_block_hll = Hll::new();
 
         let mut repair_fn = |res: &RSIndexResult, ctx: &inverted_index::RepairContext<'_>| {
-            // SAFETY: We know this is a numeric index result
-            let value = unsafe { res.as_numeric_unchecked() };
+            // SAFETY: We know this is a numeric index result. Scanned straight out of
+            // the index, so already in stored form.
+            let value = StoredValue::from_decoded(unsafe { res.as_numeric_unchecked() });
             let target = if ctx.block_idx == last_block_idx {
                 &mut last_block_hll
             } else {

--- a/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
@@ -23,21 +23,27 @@ use inverted_index::{GcApplyInfo, GcScanDelta};
 use super::{NumericRangeTree, TrimEmptyLeavesResult};
 use crate::NumericRangeNode;
 use crate::arena::{NodeArena, NodeIndex};
-use crate::range::Hll;
+use crate::range::{GcBoundsUpdate, GcSurvivorStats, Hll, ValueBounds};
 
 /// GC delta data for a single node, as computed by the child process.
 ///
-/// Contains the inverted index GC delta plus the HyperLogLog registers
-/// captured during the scan. One `NodeGcDelta` is produced per DFS node
-/// that had GC work.
+/// Contains the inverted index GC delta plus the per-range statistics
+/// ([`GcSurvivorStats`]: cardinality registers and value bounds) recomputed over
+/// the surviving entries. One `NodeGcDelta` is produced per DFS node that had GC
+/// work.
+///
+/// The statistics come in two flavours because the parent may have appended to the
+/// last block after the fork, in which case the apply step ignores that block's
+/// repair and the parent rescans it instead — see
+/// [`NumericRange::reset_stats_after_gc`][crate::NumericRange::reset_stats_after_gc].
 #[derive(Debug)]
 pub struct NodeGcDelta {
     /// The inverted index GC scan delta.
     pub delta: GcScanDelta,
-    /// HLL registers including the last scanned block's cardinality.
-    pub registers_with_last_block: [u8; Hll::size()],
-    /// HLL registers excluding the last scanned block's cardinality.
-    pub registers_without_last_block: [u8; Hll::size()],
+    /// Survivor statistics including the last scanned block.
+    pub with_last_block: GcSurvivorStats,
+    /// Survivor statistics excluding the last scanned block.
+    pub without_last_block: GcSurvivorStats,
 }
 
 /// Result of applying GC to a single node.
@@ -72,8 +78,12 @@ pub struct CompactIfSparseResult {
 impl NumericRangeNode {
     /// Scan a single node's inverted index for GC work.
     ///
-    /// Scan the inverted index associated with its range for deleted
-    /// documents, and computes HLL registers for cardinality re-estimation.
+    /// Scan the inverted index associated with its range for deleted documents, and
+    /// recompute the cardinality registers and the value bounds over the entries that
+    /// survive the scan.
+    ///
+    /// The scan visits every block, so the recomputed statistics cover the whole
+    /// index — not just the blocks that need repairing.
     ///
     /// Returns `Some(NodeGcDelta)` if the node had GC work, `None` otherwise
     /// (either the node has no range, or no documents were deleted).
@@ -81,28 +91,32 @@ impl NumericRangeNode {
         let range = self.range()?;
 
         // The logical index of the last block — used inside the repair closure to route
-        // each entry's HLL contribution into the correct accumulator. Comparing by
+        // each entry's contribution into the correct accumulator. Comparing by
         // logical index instead of pointer equality is robust to future changes that
         // produce blocks via owned snapshots (where block addresses can shift).
         let last_block_idx = range.entries().num_blocks().saturating_sub(1);
 
-        // HLL tracking for cardinality (re)estimation.
+        // Cardinality and bounds tracking, split so that the parent can drop the last
+        // block's contribution if it turns out to have changed since the fork.
         //
-        // `majority_hll` accumulates all blocks except the last one.
-        // `last_block_hll` accumulates only the last block.
+        // The `majority_*` accumulators cover all blocks except the last one.
+        // The `last_block_*` accumulators cover only the last block.
         let mut majority_hll = Hll::new();
         let mut last_block_hll = Hll::new();
+        let mut majority_bounds = ValueBounds::EMPTY;
+        let mut last_block_bounds = ValueBounds::EMPTY;
 
         let mut repair_fn = |res: &RSIndexResult, ctx: &inverted_index::RepairContext<'_>| {
-            // SAFETY: We know this is a numeric index result. Scanned straight out of
-            // the index, so already in stored form.
+            // SAFETY: We know this is a numeric index result
+            // Scanned straight out of the index, so already in stored form.
             let value = StoredValue::from_decoded(unsafe { res.as_numeric_unchecked() });
-            let target = if ctx.block_idx == last_block_idx {
-                &mut last_block_hll
+            let (hll, bounds) = if ctx.block_idx == last_block_idx {
+                (&mut last_block_hll, &mut last_block_bounds)
             } else {
-                &mut majority_hll
+                (&mut majority_hll, &mut majority_bounds)
             };
-            target.add(&value.into());
+            hll.add(&value.into());
+            bounds.observe(value);
         };
 
         let delta = range
@@ -111,13 +125,21 @@ impl NumericRangeNode {
             .ok()
             .flatten()?;
 
-        // Merge majority into last_block to get "with last block" registers.
+        // Merge majority into last_block to get the "with last block" statistics.
         last_block_hll.merge(&majority_hll);
+        let mut with_last_block_bounds = last_block_bounds;
+        with_last_block_bounds.merge(majority_bounds);
 
         Some(NodeGcDelta {
             delta,
-            registers_with_last_block: *last_block_hll.registers(),
-            registers_without_last_block: *majority_hll.registers(),
+            with_last_block: GcSurvivorStats {
+                registers: *last_block_hll.registers(),
+                bounds: with_last_block_bounds,
+            },
+            without_last_block: GcSurvivorStats {
+                registers: *majority_hll.registers(),
+                bounds: majority_bounds,
+            },
         })
     }
 }
@@ -126,8 +148,9 @@ impl NumericRangeTree {
     /// Apply a GC delta to a single node by index.
     ///
     /// Looks up the node in the arena, applies the delta to its range's
-    /// inverted index, resets cardinality via HLL, and updates tree-level
-    /// stats (`num_entries`, `inverted_indexes_size`, `empty_leaves`).
+    /// inverted index, reinstalls the range's cardinality estimate and value
+    /// bounds, and updates tree-level stats (`num_entries`,
+    /// `inverted_indexes_size`, `empty_leaves`).
     ///
     /// Returns per-node GC statistics, if there is a node with the given index.
     /// Returns `None` if there isn't one.
@@ -156,12 +179,17 @@ impl NumericRangeTree {
         // Apply GC delta to the index.
         let info: GcApplyInfo = range.entries_mut().apply_gc(delta.delta);
 
-        // Reset cardinality with proper HLL recalculation.
-        range.reset_cardinality_after_gc(
+        let bounds_update = if is_leaf {
+            GcBoundsUpdate::Tighten
+        } else {
+            GcBoundsUpdate::Keep
+        };
+        range.reset_stats_after_gc(
             info.ignored_last_block,
             n_new_blocks_since_fork,
-            &delta.registers_with_last_block,
-            &delta.registers_without_last_block,
+            &delta.with_last_block,
+            &delta.without_last_block,
+            bounds_update,
         );
 
         // Track empty ranges (only count leaves, and only on transition to empty).

--- a/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
@@ -15,11 +15,12 @@
 
 use index_result::RSIndexResult;
 use inverted_index::IndexReader as _;
+use inverted_index::numeric::PreparedValue;
 use rqe_core::DocId;
 
 use super::{AddResult, CheckedCount, NumericRangeTree};
 use crate::arena::{NodeArena, NodeIndex};
-use crate::{InternalNode, NumericRange, NumericRangeNode};
+use crate::{InternalNode, NumericIndex, NumericRange, NumericRangeNode};
 
 impl NumericRangeTree {
     /// Last depth level that does NOT use the maximum split cardinality.
@@ -102,6 +103,15 @@ impl NumericRangeTree {
         }
         self.last_doc_id = doc_id;
 
+        // The one place the encoder's lossy step is applied. Everything below —
+        // routing, bounds, cardinality, split medians — works on the value the index
+        // will actually return, so none of it can disagree with storage. The decision
+        // travels with the value, so the leaf writes it without classifying again.
+        //
+        // Prepared with this tree's own flag, never the global config: the config is
+        // settable at runtime, while a tree keeps the flag it was created with.
+        let value = NumericIndex::prepare_for(self.compress_floats, value);
+
         let rv = Self::node_add(
             &mut self.nodes,
             self.root,
@@ -159,7 +169,7 @@ impl NumericRangeTree {
         nodes: &mut NodeArena,
         node_idx: NodeIndex,
         doc_id: DocId,
-        value: f64,
+        value: PreparedValue,
         depth: usize,
         max_depth_range: usize,
         compress_floats: bool,
@@ -171,7 +181,9 @@ impl NumericRangeTree {
                 let NumericRangeNode::Internal(internal) = &nodes[node_idx] else {
                     unreachable!()
                 };
-                let child_idx = if value < internal.value {
+                // `internal.value` is a threshold, not a stored value — it can be
+                // `next_up` of one — so the comparison unwraps rather than lifting it.
+                let child_idx = if value.stored_value().get() < internal.value {
                     internal.left_index()
                 } else {
                     internal.right_index()
@@ -278,10 +290,9 @@ impl NumericRangeTree {
     /// are identical—the median would equal the minimum, and without adjustment
     /// all entries would go to the right child, leaving the left empty.
     ///
-    /// The adjustment only fires when the range's `min_val` bound matches the
-    /// smallest value the range actually stores. That is not always the case, so
-    /// a split can still leave one child empty—see the comment on `newly_empty`
-    /// below.
+    /// The adjustment relies on `min_val` matching the smallest value the range
+    /// stores. Adds maintain that; GC does not, so a split can still leave one child
+    /// empty — see the `newly_empty` comment in the body.
     ///
     /// # Note
     ///
@@ -331,7 +342,11 @@ impl NumericRangeTree {
         while reader.next_record(&mut result).unwrap_or(false) {
             // SAFETY: We know the result contains numeric data
             let entry_value = unsafe { result.as_numeric_unchecked() };
-            let target_idx = if entry_value < split {
+            // Redistributed entries come straight back out of the parent's index, so
+            // they are already in stored form — preparing one is idempotent, and the
+            // child needs the decision to write the entry.
+            let entry_value = NumericIndex::prepare_for(compress_floats, entry_value);
+            let target_idx = if entry_value.stored_value().get() < split {
                 left_idx
             } else {
                 right_idx
@@ -346,23 +361,12 @@ impl NumericRangeTree {
         }
         drop(result);
 
-        // A split can leave a child leaf empty whenever every entry falls on the
-        // same side of `split`. Two known ways to get there:
-        //
-        // 1. Float compression collapses every stored value to the same f32. The
-        //    median then equals `min_val`, the split point becomes `next_up(min)`,
-        //    and every entry lands in the *left* child.
-        // 2. `min_val` is stale. GC removes entries from a range but never raises
-        //    its bounds, so once the documents holding the smallest value are
-        //    collected, `min_val` sits below every surviving value. If a majority
-        //    of the survivors share the smallest surviving value, that value is the
-        //    median, the `split == min_val` guard above does not fire, and every
-        //    entry lands in the *right* child.
-        //
-        // Such an empty leaf must be reflected in `empty_leaves`, otherwise a
-        // later add routed to it would decrement the counter below zero. The
-        // parent had >= 1 entry (we split only after adding), so at most one of
-        // the two new children can be empty.
+        // A split strands an empty child leaf when every entry falls on the same side
+        // of `split`, which still happens while GC leaves `min_val` stale: the guard
+        // above cannot fire against a bound no surviving entry holds. It must be
+        // counted, or a later add routed to that leaf underflows `empty_leaves` and
+        // aborts the process across the non-unwinding FFI boundary (MOD-16877). The
+        // parent had >= 1 entry, so at most one child can come out empty.
         let newly_empty = [left_idx, right_idx]
             .into_iter()
             .filter(|&i| nodes[i].range().is_some_and(|r| r.num_docs() == 0))

--- a/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
@@ -291,8 +291,8 @@ impl NumericRangeTree {
     /// all entries would go to the right child, leaving the left empty.
     ///
     /// The adjustment relies on `min_val` matching the smallest value the range
-    /// stores. Adds maintain that; GC does not, so a split can still leave one child
-    /// empty — see the `newly_empty` comment in the body.
+    /// stores, which holds because values are prepared before they reach a range and
+    /// GC recomputes the bounds over the surviving entries.
     ///
     /// # Note
     ///
@@ -361,19 +361,21 @@ impl NumericRangeTree {
         }
         drop(result);
 
-        // A split strands an empty child leaf when every entry falls on the same side
-        // of `split`, which still happens while GC leaves `min_val` stale: the guard
-        // above cannot fire against a bound no surviving entry holds. It must be
-        // counted, or a later add routed to that leaf underflows `empty_leaves` and
-        // aborts the process across the non-unwinding FFI boundary (MOD-16877). The
-        // parent had >= 1 entry, so at most one child can come out empty.
+        // A split strands an empty child leaf when every entry falls on the same side of
+        // `split`. Exact per-leaf statistics should make that unreachable: a split needs
+        // two distinct stored values, encoders keep distinct stored values numerically
+        // distinct, and the adjustment above then sends the smallest left and something
+        // larger right. The one gap is `NaN`, which compares equal to nothing and so has
+        // no split point at all. The count stays as a net either way — an uncounted empty
+        // leaf underflows `empty_leaves` on the next add routed to it and aborts the
+        // process across the non-unwinding FFI boundary (MOD-16877).
         let newly_empty = [left_idx, right_idx]
             .into_iter()
             .filter(|&i| nodes[i].range().is_some_and(|r| r.num_docs() == 0))
             .count();
         debug_assert!(
-            newly_empty <= 1,
-            "a non-empty parent must yield at least one non-empty child"
+            newly_empty == 0 || split.is_nan(),
+            "a split on comparable values must leave both children non-empty"
         );
         *empty_leaves += newly_empty;
 
@@ -392,6 +394,9 @@ impl NumericRangeTree {
     }
 
     /// Compute the median value from a range's entries.
+    ///
+    /// Returns a plain `f64`: the median is a comparison threshold from here on, and
+    /// may be adjusted with `next_up` into a value no entry holds.
     fn compute_median(range: &NumericRange) -> f64 {
         let num_entries = range.num_entries();
         if num_entries == 0 {

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/gc.rs
@@ -301,6 +301,165 @@ fn hll_cardinality_is_recomputed_correctly_when_last_block_fully_emptied(
 }
 
 // ============================================================================
+// Value bounds recomputation
+// ============================================================================
+
+#[rstest]
+fn gc_tightens_leaf_bounds(#[values(false, true)] compress_floats: bool) {
+    // Values are powers of two so float compression stores them losslessly and the
+    // assertions can compare exactly.
+    let mut tree = NumericRangeTree::new(compress_floats);
+    for (doc_id, value) in [(1, 8.0), (2, 16.0), (3, 32.0), (4, 64.0)] {
+        tree.add(doc_id, value, false, 0);
+    }
+    let range = tree.root().range().unwrap();
+    assert_eq!((range.min_val(), range.max_val()), (8.0, 64.0));
+
+    // Delete the documents holding both extremes.
+    gc_all_ranges(&mut tree, &|doc_id| doc_id == 2 || doc_id == 3);
+
+    let range = tree.root().range().unwrap();
+    assert_eq!(
+        (range.min_val(), range.max_val()),
+        (16.0, 32.0),
+        "bounds should shrink to the surviving values"
+    );
+}
+
+#[rstest]
+fn gc_emptying_a_leaf_resets_its_bounds(#[values(false, true)] compress_floats: bool) {
+    let mut tree = NumericRangeTree::new(compress_floats);
+    for doc_id in 1..=10 {
+        tree.add(doc_id, 42.0, false, 0);
+    }
+
+    // Delete every document.
+    gc_all_ranges(&mut tree, &|_| false);
+
+    let range = tree.root().range().unwrap();
+    assert_eq!(range.num_docs(), 0);
+    assert_eq!(
+        (range.min_val(), range.max_val()),
+        (f64::INFINITY, f64::NEG_INFINITY),
+        "an emptied range should be back to the inverted bounds of a fresh range"
+    );
+    assert!(
+        !range.overlaps(0.0, 100.0),
+        "an emptied range should no longer overlap the filter its old bounds matched"
+    );
+    assert_eq!(tree.empty_leaves(), 1);
+}
+
+#[test]
+fn gc_keeps_the_bounds_of_ranges_retained_on_internal_nodes() {
+    // Ranges retained on internal nodes must stay a superset of their subtree.
+    // Entries are applied ancestor-first, so tightening them would transiently
+    // publish an ancestor range narrower than its own children.
+    let n = SPLIT_TRIGGER * 2;
+    let mut tree = build_tree(n, false, 2);
+
+    let retained_before: Vec<_> = tree
+        .indexed_iter()
+        .filter(|(_, node)| !node.is_leaf())
+        .filter_map(|(idx, node)| node.range().map(|r| (idx, r.min_val(), r.max_val())))
+        .collect();
+    assert!(
+        !retained_before.is_empty(),
+        "max_depth_range=2 should retain at least one internal range"
+    );
+
+    // Delete the lower half of the documents — the smallest values go away.
+    gc_all_ranges(&mut tree, &|doc_id| doc_id > n / 2);
+
+    for (idx, min_before, max_before) in retained_before {
+        let range = tree
+            .node(idx)
+            .range()
+            .expect("GC should not drop a retained range");
+        assert_eq!(
+            (range.min_val(), range.max_val()),
+            (min_before, max_before),
+            "the range retained on internal node {idx:?} should keep its bounds"
+        );
+    }
+}
+
+#[rstest]
+fn gc_bounds_cover_entries_written_to_new_blocks_after_the_fork(
+    #[values(false, true)] compress_floats: bool,
+) {
+    // Two full blocks, so post-scan writes start a new block and leave the scanned
+    // last block untouched — the `blocks_since_fork` rescan path.
+    let n = ENTRIES_PER_BLOCK * 2;
+    let mut tree = NumericRangeTree::new(compress_floats);
+    for doc_id in 1..=n {
+        tree.add(doc_id, 42.0, false, 0);
+    }
+
+    let delta = scan_node_delta(&tree, tree.root_index(), &|doc_id| {
+        doc_id > ENTRIES_PER_BLOCK
+    })
+    .expect("should have GC work");
+
+    // Parent writes after the fork, outside the surviving range on both ends.
+    tree.add(n + 1, 4.0, false, 0);
+    tree.add(n + 2, 128.0, false, 0);
+
+    let result = tree.apply_gc_to_node(tree.root_index(), delta).unwrap();
+    assert!(
+        !result.index_gc_info.ignored_last_block,
+        "the scanned last block was full, so post-fork writes went to a new block"
+    );
+
+    let range = tree.root().range().unwrap();
+    assert_eq!(
+        (range.min_val(), range.max_val()),
+        (4.0, 128.0),
+        "bounds must cover the entries the scan never saw"
+    );
+}
+
+#[rstest]
+fn gc_bounds_cover_an_ignored_last_block(#[values(false, true)] compress_floats: bool) {
+    // Block 0 (full): 42.0. Block 1 (partial): 64.0, except its final document,
+    // which holds the largest value in the range.
+    let partial = ENTRIES_PER_BLOCK / 2;
+    let n = ENTRIES_PER_BLOCK + partial;
+    let mut tree = NumericRangeTree::new(compress_floats);
+    for doc_id in 1..=n {
+        let value = if doc_id <= ENTRIES_PER_BLOCK {
+            42.0
+        } else if doc_id == n {
+            1024.0
+        } else {
+            64.0
+        };
+        tree.add(doc_id, value, false, 0);
+    }
+
+    // Delete only the document holding 1024.0, which lives in the last block.
+    let delta = scan_node_delta(&tree, tree.root_index(), &|doc_id| doc_id != n)
+        .expect("should have GC work");
+
+    // A post-scan write into the same (partial) block makes the apply step ignore
+    // that block's repair, so the 1024.0 entry stays in the index.
+    tree.add(n + 1, 64.0, false, 0);
+
+    let result = tree.apply_gc_to_node(tree.root_index(), delta).unwrap();
+    assert!(
+        result.index_gc_info.ignored_last_block,
+        "the last block changed after the scan, so its repair must be ignored"
+    );
+
+    let range = tree.root().range().unwrap();
+    assert_eq!(
+        (range.min_val(), range.max_val()),
+        (42.0, 1024.0),
+        "bounds must still cover the entry whose repair was ignored"
+    );
+}
+
+// ============================================================================
 // GC repopulation and intensive delete tests
 // ============================================================================
 
@@ -455,8 +614,8 @@ fn gc_on_node_without_range() {
             tree.root_index(),
             NodeGcDelta {
                 delta: delta.delta,
-                registers_with_last_block: delta.registers_with_last_block,
-                registers_without_last_block: delta.registers_without_last_block,
+                with_last_block: delta.with_last_block,
+                without_last_block: delta.without_last_block,
             },
         )
         .unwrap();

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/range.rs
@@ -9,7 +9,17 @@
 
 //! Tests for NumericRange.
 
-use numeric_range_tree::NumericRange;
+use index_result::RSIndexResult;
+use inverted_index::IndexReader as _;
+use inverted_index::numeric::PreparedValue;
+use numeric_range_tree::{NumericIndex, NumericRange};
+use rstest::rstest;
+
+/// Ask an uncompressed encoder how it will represent `value` — the form
+/// [`NumericRange::add`] takes.
+fn prepared(value: f64) -> PreparedValue {
+    NumericIndex::prepare_for(false, value)
+}
 
 #[test]
 fn test_new_range_bounds() {
@@ -24,15 +34,15 @@ fn test_new_range_bounds() {
 fn test_add_updates_bounds() {
     let mut range = NumericRange::new(false);
 
-    range.add(1, 5.0);
+    range.add(1, prepared(5.0));
     assert_eq!(range.min_val(), 5.0);
     assert_eq!(range.max_val(), 5.0);
 
-    range.add(2, 10.0);
+    range.add(2, prepared(10.0));
     assert_eq!(range.min_val(), 5.0);
     assert_eq!(range.max_val(), 10.0);
 
-    range.add(3, 2.0);
+    range.add(3, prepared(2.0));
     assert_eq!(range.min_val(), 2.0);
     assert_eq!(range.max_val(), 10.0);
 }
@@ -41,9 +51,9 @@ fn test_add_updates_bounds() {
 fn test_add_updates_cardinality() {
     let mut range = NumericRange::new(false);
 
-    range.add(1, 1.0);
-    range.add(2, 2.0);
-    range.add(3, 3.0);
+    range.add(1, prepared(1.0));
+    range.add(2, prepared(2.0));
+    range.add(3, prepared(3.0));
 
     // HLL gives approximate count, but for small counts it should be reasonably accurate
     let card = range.cardinality();
@@ -56,8 +66,8 @@ fn test_add_updates_cardinality() {
 #[test]
 fn test_contained_in() {
     let mut range = NumericRange::new(false);
-    range.add(1, 5.0);
-    range.add(2, 10.0);
+    range.add(1, prepared(5.0));
+    range.add(2, prepared(10.0));
 
     // Range [5, 10] is contained in [0, 20]
     assert!(range.contained_in(0.0, 20.0));
@@ -72,8 +82,8 @@ fn test_contained_in() {
 #[test]
 fn test_overlaps() {
     let mut range = NumericRange::new(false);
-    range.add(1, 5.0);
-    range.add(2, 10.0);
+    range.add(1, prepared(5.0));
+    range.add(2, prepared(10.0));
 
     // Overlapping cases
     assert!(range.overlaps(0.0, 6.0)); // left overlap
@@ -100,9 +110,9 @@ fn test_add_without_cardinality() {
     let mut range = NumericRange::new(false);
 
     // Add entries without updating cardinality
-    range.add_without_cardinality(1, 5.0);
-    range.add_without_cardinality(2, 10.0);
-    range.add_without_cardinality(3, 2.0);
+    range.add_without_cardinality(1, prepared(5.0));
+    range.add_without_cardinality(2, prepared(10.0));
+    range.add_without_cardinality(3, prepared(2.0));
 
     // Bounds should be updated
     assert_eq!(range.min_val(), 2.0);
@@ -119,11 +129,11 @@ fn test_add_without_cardinality_vs_add() {
     let mut range_without_card = NumericRange::new(false);
 
     // Add same values to both
-    range_with_card.add(1, 5.0);
-    range_with_card.add(2, 10.0);
+    range_with_card.add(1, prepared(5.0));
+    range_with_card.add(2, prepared(10.0));
 
-    range_without_card.add_without_cardinality(1, 5.0);
-    range_without_card.add_without_cardinality(2, 10.0);
+    range_without_card.add_without_cardinality(1, prepared(5.0));
+    range_without_card.add_without_cardinality(2, prepared(10.0));
 
     // Bounds should be the same
     assert_eq!(range_with_card.min_val(), range_without_card.min_val());
@@ -143,13 +153,13 @@ fn test_num_docs() {
     let mut range = NumericRange::new(false);
     assert_eq!(range.num_docs(), 0);
 
-    range.add(1, 5.0);
+    range.add(1, prepared(5.0));
     assert_eq!(range.num_docs(), 1);
 
-    range.add(2, 10.0);
+    range.add(2, prepared(10.0));
     assert_eq!(range.num_docs(), 2);
 
-    range.add(3, 15.0);
+    range.add(3, prepared(15.0));
     assert_eq!(range.num_docs(), 3);
 }
 
@@ -158,8 +168,8 @@ fn test_entries_accessor() {
     use numeric_range_tree::NumericIndex;
 
     let mut range = NumericRange::new(false);
-    range.add(1, 5.0);
-    range.add(2, 10.0);
+    range.add(1, prepared(5.0));
+    range.add(2, prepared(10.0));
 
     let entries = range.entries();
     match entries {
@@ -177,9 +187,9 @@ fn test_entries_accessor() {
 #[test]
 fn test_hll_accessor() {
     let mut range = NumericRange::new(false);
-    range.add(1, 5.0);
-    range.add(2, 10.0);
-    range.add(3, 15.0);
+    range.add(1, prepared(5.0));
+    range.add(2, prepared(10.0));
+    range.add(3, prepared(15.0));
 
     let hll = range.hll();
     // HLL count should approximate the number of distinct values
@@ -195,11 +205,159 @@ fn test_inverted_index_size() {
     let mut range = NumericRange::new(false);
     let initial_size = range.memory_usage();
 
-    range.add(1, 5.0);
+    range.add(1, prepared(5.0));
     let size_after_one = range.memory_usage();
     assert!(size_after_one >= initial_size);
 
-    range.add(2, 10.0);
+    range.add(2, prepared(10.0));
     let size_after_two = range.memory_usage();
     assert!(size_after_two >= size_after_one);
+}
+
+// ============================================================================
+// Stored-value quantization
+// ============================================================================
+
+#[test]
+fn test_compressed_range_treats_collapsing_values_as_one() {
+    // Two distinct f64s inside the same f32 bucket. A compressed range stores one
+    // value for both, so its statistics must report one value.
+    let mut range = NumericRange::new(true);
+    let index = NumericIndex::new(true);
+    range.add(1, index.prepare(100.5));
+    range.add(2, index.prepare(100.500001));
+
+    assert_eq!(range.num_entries(), 2);
+    assert_eq!(
+        range.cardinality(),
+        1,
+        "both inputs collapse onto the same stored value"
+    );
+    assert_eq!(
+        (range.min_val(), range.max_val()),
+        (100.5, 100.5),
+        "bounds must equal the stored value, not the inputs"
+    );
+
+    // The same two inputs stay distinct without compression.
+    let mut range = NumericRange::new(false);
+    let index = NumericIndex::new(false);
+    range.add(1, index.prepare(100.5));
+    range.add(2, index.prepare(100.500001));
+    assert_eq!(range.cardinality(), 2);
+    assert_eq!((range.min_val(), range.max_val()), (100.5, 100.500001));
+}
+
+#[rstest]
+fn test_signed_zeros_are_one_stored_value(#[values(false, true)] compress_floats: bool) {
+    // Every numeric encoder writes zero as a tiny integer, dropping the sign, so
+    // `-0.0` and `+0.0` are indistinguishable once stored.
+    let mut range = NumericRange::new(compress_floats);
+    let index = NumericIndex::new(compress_floats);
+    range.add(1, index.prepare(-0.0));
+    range.add(2, index.prepare(0.0));
+
+    assert_eq!(range.cardinality(), 1);
+    assert!(range.min_val().is_sign_positive());
+    assert_eq!((range.min_val(), range.max_val()), (0.0, 0.0));
+}
+
+#[rstest]
+fn test_geohash_values_are_stored_exactly(#[values(false, true)] compress_floats: bool) {
+    // GEO fields share this tree: `encodeGeo` yields a 52-bit integral geohash, which
+    // takes the encoder's integer path and is never rounded — with or without float
+    // compression. Quantization must therefore be the identity here.
+    let geohashes = [0.0, 1.0, 3_659_155_824_453_222.0, (1u64 << 52) as f64 - 1.0];
+
+    let index = NumericIndex::new(compress_floats);
+    for geohash in geohashes {
+        assert_eq!(
+            index.prepare(geohash).stored_value().get(),
+            geohash,
+            "geohash {geohash} must survive preparation unchanged"
+        );
+    }
+
+    let mut range = NumericRange::new(compress_floats);
+    for (i, geohash) in geohashes.iter().enumerate() {
+        range.add(i as u64 + 1, index.prepare(*geohash));
+    }
+    assert_eq!(range.cardinality(), geohashes.len());
+    assert_eq!(range.min_val(), geohashes[0]);
+    assert_eq!(range.max_val(), geohashes[geohashes.len() - 1]);
+}
+
+#[rstest]
+fn test_numeric_index_write_paths_agree(#[values(false, true)] compress_floats: bool) {
+    // The two write paths must be interchangeable. This also keeps `add_record`
+    // exercised from inside this crate: with no in-crate caller it reads as dead code
+    // and invites removal, which breaks downstream test suites.
+    let values = [0.0, 3.0, -7.0, 1024.0, 0.5, 100.500001, f64::INFINITY];
+
+    let mut from_records = NumericIndex::new(compress_floats);
+    let mut from_prepared = NumericIndex::new(compress_floats);
+
+    for (i, value) in values.iter().enumerate() {
+        let doc_id = i as u64 + 1;
+        let record = RSIndexResult::build_numeric(*value).doc_id(doc_id).build();
+
+        let record_outcome = from_records.add_record(&record);
+        let prepared_outcome =
+            from_prepared.add_prepared_record(doc_id, from_prepared.prepare(*value));
+
+        assert_eq!(
+            record_outcome, prepared_outcome,
+            "outcomes diverged while adding {value} for doc {doc_id}"
+        );
+    }
+
+    assert_eq!(
+        from_records.number_of_entries(),
+        from_prepared.number_of_entries()
+    );
+    assert_eq!(from_records.memory_usage(), from_prepared.memory_usage());
+    assert_eq!(
+        from_records.summary().number_of_blocks,
+        from_prepared.summary().number_of_blocks,
+        "block layout diverged"
+    );
+
+    // And the entries decode identically.
+    let decode = |index: &NumericIndex| {
+        let mut reader = index.reader();
+        let mut result = RSIndexResult::build_numeric(0.0).build();
+        let mut decoded = Vec::new();
+        while reader.next_record(&mut result).unwrap_or(false) {
+            // SAFETY: a numeric index only ever holds numeric records
+            decoded.push((result.doc_id, unsafe { result.as_numeric_unchecked() }));
+        }
+        decoded
+    };
+    assert_eq!(decode(&from_records), decode(&from_prepared));
+}
+
+#[test]
+fn test_compressed_signed_zero_collapse_counts_once() {
+    // Under float compression a magnitude below the smallest f32 subnormal rounds to
+    // zero, for either sign. Both must arrive as the same stored value, or the two
+    // would compare equal to bounds, routing and filters while a cardinality estimate
+    // keyed by bit pattern counted them separately — enough to make a leaf of
+    // comparably identical values look splittable.
+    let index = NumericIndex::new(true);
+    let positive = index.prepare(5e-324).stored_value().get();
+    let negative = index.prepare(-5e-324).stored_value().get();
+    assert_eq!(positive.to_bits(), negative.to_bits());
+    assert_eq!(positive, 0.0);
+    assert!(positive.is_sign_positive());
+
+    let mut range = NumericRange::new(true);
+    range.add(1, index.prepare(5e-324));
+    range.add(2, index.prepare(-5e-324));
+
+    assert_eq!((range.min_val(), range.max_val()), (0.0, 0.0));
+    assert_eq!(
+        range.cardinality(),
+        1,
+        "stored values that compare equal must count once"
+    );
 }

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/range.rs
@@ -11,14 +11,19 @@
 
 use index_result::RSIndexResult;
 use inverted_index::IndexReader as _;
-use inverted_index::numeric::PreparedValue;
-use numeric_range_tree::{NumericIndex, NumericRange};
+use inverted_index::numeric::{PreparedValue, StoredValue};
+use numeric_range_tree::{GcSurvivorStats, NumericIndex, NumericRange, ValueBounds};
 use rstest::rstest;
 
 /// Ask an uncompressed encoder how it will represent `value` — the form
 /// [`NumericRange::add`] takes.
 fn prepared(value: f64) -> PreparedValue {
     NumericIndex::prepare_for(false, value)
+}
+
+/// The value an uncompressed range will store for `value`, for [`ValueBounds`].
+fn stored(value: f64) -> StoredValue {
+    prepared(value).stored_value()
 }
 
 #[test]
@@ -215,6 +220,73 @@ fn test_inverted_index_size() {
 }
 
 // ============================================================================
+// ValueBounds / GcSurvivorStats
+// ============================================================================
+
+#[test]
+fn test_value_bounds_observe_and_merge() {
+    let mut bounds = ValueBounds::EMPTY;
+    assert_eq!(bounds.min(), f64::INFINITY);
+    assert_eq!(bounds.max(), f64::NEG_INFINITY);
+
+    bounds.observe(stored(5.0));
+    assert_eq!((bounds.min(), bounds.max()), (5.0, 5.0));
+    bounds.observe(stored(-2.0));
+    bounds.observe(stored(7.0));
+    assert_eq!((bounds.min(), bounds.max()), (-2.0, 7.0));
+
+    // NaN never moves either end.
+    bounds.observe(stored(f64::NAN));
+    assert_eq!((bounds.min(), bounds.max()), (-2.0, 7.0));
+
+    // Merging empty bounds must not drag the ends out to the inverted sentinels.
+    bounds.merge(ValueBounds::EMPTY);
+    assert_eq!((bounds.min(), bounds.max()), (-2.0, 7.0));
+
+    let mut other = ValueBounds::EMPTY;
+    other.observe(stored(-10.0));
+    other.observe(stored(3.0));
+    bounds.merge(other);
+    assert_eq!((bounds.min(), bounds.max()), (-10.0, 7.0));
+
+    // Merging into empty bounds adopts the other interval.
+    let mut empty = ValueBounds::EMPTY;
+    empty.merge(bounds);
+    assert_eq!((empty.min(), empty.max()), (-10.0, 7.0));
+}
+
+#[test]
+fn test_gc_survivor_stats_wire_round_trip() {
+    let mut bounds = ValueBounds::EMPTY;
+    bounds.observe(stored(-1.5));
+    bounds.observe(stored(1024.25));
+    let stats = GcSurvivorStats {
+        registers: std::array::from_fn(|i| i as u8),
+        bounds,
+    };
+
+    let mut buffer = Vec::new();
+    stats.write_to(&mut buffer);
+    assert_eq!(buffer.len(), GcSurvivorStats::WIRE_SIZE);
+
+    let decoded = GcSurvivorStats::read_from(&buffer).expect("a full-size buffer should decode");
+    assert_eq!(decoded.registers, stats.registers);
+    assert_eq!(decoded.bounds, stats.bounds);
+
+    // The empty sentinel survives the round trip too — the parent must be able to
+    // tell "nothing survived" from "bounds unknown".
+    let mut buffer = Vec::new();
+    GcSurvivorStats::EMPTY.write_to(&mut buffer);
+    let decoded = GcSurvivorStats::read_from(&buffer).expect("a full-size buffer should decode");
+    assert_eq!(decoded.bounds, ValueBounds::EMPTY);
+
+    // Anything but an exact-size buffer is rejected.
+    assert!(GcSurvivorStats::read_from(&buffer[..buffer.len() - 1]).is_none());
+    buffer.push(0);
+    assert!(GcSurvivorStats::read_from(&buffer).is_none());
+}
+
+// ============================================================================
 // Stored-value quantization
 // ============================================================================
 
@@ -264,9 +336,9 @@ fn test_signed_zeros_are_one_stored_value(#[values(false, true)] compress_floats
 
 #[rstest]
 fn test_geohash_values_are_stored_exactly(#[values(false, true)] compress_floats: bool) {
-    // GEO fields share this tree: `encodeGeo` yields a 52-bit integral geohash, which
-    // takes the encoder's integer path and is never rounded — with or without float
-    // compression. Quantization must therefore be the identity here.
+    // GEO fields share this tree: `encodeGeo` yields a 52-bit integer as an f64,
+    // which takes the encoder's integer path and is never rounded — with or without
+    // float compression. Quantization must therefore be the identity here.
     let geohashes = [0.0, 1.0, 3_659_155_824_453_222.0, (1u64 << 52) as f64 - 1.0];
 
     let index = NumericIndex::new(compress_floats);
@@ -274,7 +346,7 @@ fn test_geohash_values_are_stored_exactly(#[values(false, true)] compress_floats
         assert_eq!(
             index.prepare(geohash).stored_value().get(),
             geohash,
-            "geohash {geohash} must survive preparation unchanged"
+            "geohash {geohash} must survive quantization unchanged"
         );
     }
 

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/tree.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/tree.rs
@@ -206,16 +206,13 @@ fn test_split_with_identical_values() {
 /// Estimating cardinality over the inputs instead made such a leaf look
 /// high-cardinality, split it, and strand an empty child — the compression route into
 /// the MOD-16877 crash. Preparing values on the way in closes it: no split fires.
-///
-/// The stale-`min_val` route is still open here, which is why `split_node` keeps
-/// counting empty children — see `test_split_after_gc_stale_min_counts_empty_leaf`.
 #[test]
 fn test_compression_collapse_does_not_inflate_cardinality() {
     let mut tree = NumericRangeTree::new(true); // float compression ON
 
     // Distinct f64 values tightly clustered within a single f32 rounding bucket
     // around 100.5 (exactly representable in f32). Each differs from the next by
-    // 1e-7 — far above the f64 ULP near 100.5 (~1e-14), so they are distinct to
+    // 1e-7 — far above the f64 ULP near 100.5 (~1e-14), so they were distinct to
     // the HLL cardinality estimator, but far below the f32 ULP near 100.5
     // (~7.6e-6), so all round to the same stored f32 (100.5), well within the
     // 0.01 compression threshold.
@@ -252,21 +249,15 @@ fn test_compression_collapse_does_not_inflate_cardinality() {
     assert_eq!(tree.empty_leaves(), 0);
 }
 
-/// Same `empty_leaves` underflow as
-/// `test_compression_collapse_does_not_inflate_cardinality` (MOD-16877), reached
-/// with float compression *disabled* — compression is not required to strand an
-/// empty child leaf.
+/// A leaf whose smallest-valued documents were all collected must not strand an empty
+/// child when it splits.
 ///
-/// The other ingredient is a stale `min_val`. GC removes entries from a range but
-/// never raises its bounds, so a leaf whose smallest-valued documents were all
-/// collected keeps reporting the old minimum. `split_node`'s
-/// `split == min_val` guard then compares the median of the *surviving* entries
-/// against a bound no surviving entry has, so it does not fire. If a majority of
-/// the survivors share the smallest surviving value, that value *is* the median
-/// and becomes the split point, so every entry satisfies `value >= split` and
-/// lands in the right child — leaving the left child empty.
+/// While GC left `min_val` stale, `split_node`'s guard compared the median of the
+/// survivors against a bound no survivor held, so it split *at* the smallest surviving
+/// value and sent every entry one way — the compression-free route into the MOD-16877
+/// crash. Recomputing the bounds over the survivors closes it.
 #[test]
-fn test_split_after_gc_stale_min_counts_empty_leaf() {
+fn test_split_after_gc_does_not_strand_empty_leaf() {
     let mut tree = NumericRangeTree::new(false); // float compression OFF
 
     /// Number of documents sharing the value 100.0. They must remain a majority of
@@ -284,8 +275,8 @@ fn test_split_after_gc_stale_min_counts_empty_leaf() {
     assert!(tree.root().is_leaf());
     assert_eq!(tree.empty_leaves(), 0, "the root leaf holds every document");
 
-    // Delete doc 1 and collect it. Its entry is physically removed and the HLL is
-    // re-estimated over the survivors, but `min_val` stays 0.0.
+    // Delete doc 1 and collect it. Its entry is physically removed and both the HLL
+    // and the bounds are recomputed over the survivors.
     gc_all_ranges(&mut tree, &|doc_id| doc_id != 1);
     assert_eq!(tree.num_entries(), MAJORITY as usize);
     assert_eq!(
@@ -295,8 +286,8 @@ fn test_split_after_gc_stale_min_counts_empty_leaf() {
     );
     assert_eq!(
         tree.root().range().unwrap().min_val(),
-        0.0,
-        "GC must not raise a range's lower bound — that staleness is the trigger"
+        100.0,
+        "GC must raise the lower bound to the smallest surviving value"
     );
 
     // Push cardinality over the split threshold using distinct values strictly
@@ -313,30 +304,26 @@ fn test_split_after_gc_stale_min_counts_empty_leaf() {
     }
     assert!(split_fired, "distinct values should trigger a split");
 
-    // The split point is the median (100.0), not `next_up(min_val)`, so every
-    // entry went right and the left leaf is empty.
-    assert_eq!(tree.root().split_value(), Some(100.0));
-    let (left_idx, _) = tree.root().child_indices().unwrap();
-    assert_eq!(
-        tree.node(left_idx).range().unwrap().num_docs(),
-        0,
-        "the split should have left the left child empty"
-    );
+    // The median now equals the (tightened) `min_val`, so the split point is
+    // `next_up(100.0)`: the block of 100.0s goes left, everything above goes right.
+    assert_eq!(tree.root().split_value(), Some(100.0f64.next_up()));
+    let (left_idx, right_idx) = tree.root().child_indices().unwrap();
+    for (label, idx) in [("left", left_idx), ("right", right_idx)] {
+        assert!(
+            tree.node(idx).range().unwrap().num_docs() > 0,
+            "the {label} child should have received entries"
+        );
+    }
     assert_eq!(
         tree.empty_leaves(),
-        1,
-        "the empty child leaf created by the split must be counted"
+        0,
+        "the split should not strand an empty leaf at all"
     );
 
-    // Any later value below the split point is routed to that empty leaf. Before
-    // the fix this decremented `empty_leaves` from 0, underflowing the counter and
-    // aborting the process across the non-unwinding FFI boundary.
+    // The add that used to hit the underflow: a value below the split point. It is
+    // routed to a populated leaf now, so the counter is never decremented.
     tree.add(doc_id, 50.0, false, 0);
-    assert_eq!(
-        tree.empty_leaves(),
-        0,
-        "re-populating the empty leaf should bring the counter back to zero"
-    );
+    assert_eq!(tree.empty_leaves(), 0);
 }
 
 #[test]

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/tree.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/tree.rs
@@ -201,23 +201,16 @@ fn test_split_with_identical_values() {
     );
 }
 
-/// Regression test for the `empty_leaves` underflow crash (MOD-16877, a
-/// production crash on 8.6.6): a split that creates an empty child leaf must
-/// count it.
+/// Distinct f64s that collapse onto one stored f32 must count as one value.
 ///
-/// With float compression enabled, cardinality is estimated over the original
-/// f64 values while entries are stored — and split-redistributed — as compressed
-/// f32. When enough distinct f64 values collapse to a single f32, the split is
-/// triggered (HLL sees them as distinct) but every stored value is identical, so
-/// all entries are redistributed to one child and the other child leaf is created
-/// empty. That empty leaf must be reflected in `empty_leaves`; otherwise a later
-/// add routed to it decrements the counter below zero and aborts the process via
-/// the non-unwinding FFI boundary.
+/// Estimating cardinality over the inputs instead made such a leaf look
+/// high-cardinality, split it, and strand an empty child — the compression route into
+/// the MOD-16877 crash. Preparing values on the way in closes it: no split fires.
 ///
-/// Compression is not the only way to get an empty child leaf — see
-/// `test_split_after_gc_stale_min_counts_empty_leaf`.
+/// The stale-`min_val` route is still open here, which is why `split_node` keeps
+/// counting empty children — see `test_split_after_gc_stale_min_counts_empty_leaf`.
 #[test]
-fn test_split_with_compression_collapse_counts_empty_leaf() {
+fn test_compression_collapse_does_not_inflate_cardinality() {
     let mut tree = NumericRangeTree::new(true); // float compression ON
 
     // Distinct f64 values tightly clustered within a single f32 rounding bucket
@@ -228,42 +221,39 @@ fn test_split_with_compression_collapse_counts_empty_leaf() {
     // 0.01 compression threshold.
     let value_at = |i: u64| 100.5 + (i - 1) as f64 * 1e-7;
 
-    // Add distinct-but-collapsing values until the first split fires. Because the
-    // stored values are all identical (f32 100.5), the redistribution sends every
-    // entry to the left child and leaves the right child empty. This empty leaf
-    // must be counted; before the fix, `empty_leaves` stayed 0 here (caught by the
-    // `check_tree_invariants` assertion inside `add`).
-    let mut split_at = None;
+    // Well past the point where the old cardinality estimate would have split.
     for i in 1..=(SPLIT_TRIGGER + 8) {
         tree.add(i, value_at(i), false, 0);
-        if tree.num_leaves() == 2 {
-            split_at = Some(i);
-            break;
-        }
     }
-    let split_at = split_at.expect("compressed-but-distinct values should trigger a split");
 
-    // Right after the split, before any further add re-populates it:
+    assert!(
+        tree.root().is_leaf(),
+        "collapsing values are one stored value, so no split should fire (got {} leaves)",
+        tree.num_leaves()
+    );
+
+    let range = tree.root().range().unwrap();
     assert_eq!(
-        tree.empty_leaves(),
+        range.cardinality(),
         1,
-        "the empty child leaf created by the split must be counted"
+        "cardinality must count stored values, not the inputs that collapsed onto them"
     );
-
-    // Routing uses the *original* f64 value, so the next (larger) value is routed
-    // to the empty right child and re-populates it. Before the fix this decremented
-    // `empty_leaves` from 0, underflowing the counter and aborting the process.
-    let next = split_at + 1;
-    tree.add(next, value_at(next), false, 0);
     assert_eq!(
-        tree.empty_leaves(),
-        0,
-        "re-populating the empty leaf should bring the counter back to zero"
+        (range.min_val(), range.max_val()),
+        (100.5, 100.5),
+        "bounds must describe the stored value a reader will decode"
     );
+    assert_eq!(tree.empty_leaves(), 0);
+
+    // The add that used to hit the underflow. Nothing was ever stranded, so the
+    // counter is not touched.
+    let next = SPLIT_TRIGGER + 9;
+    tree.add(next, value_at(next), false, 0);
+    assert_eq!(tree.empty_leaves(), 0);
 }
 
 /// Same `empty_leaves` underflow as
-/// `test_split_with_compression_collapse_counts_empty_leaf` (MOD-16877), reached
+/// `test_compression_collapse_does_not_inflate_cardinality` (MOD-16877), reached
 /// with float compression *disabled* — compression is not required to strand an
 /// empty child leaf.
 ///
@@ -471,4 +461,48 @@ fn test_max_depth_range_removes_deep_ranges(#[values(false, true)] compress_floa
             );
         }
     });
+}
+
+/// A leaf holding nothing but comparably-equal zeros must not split.
+///
+/// Under float compression, alternating `±5e-324` collapses onto `+0.0` and `-0.0`.
+/// Every comparison in the tree treats those as equal, so there is no split point that
+/// separates them: the size-triggered split path needs `cardinality > 1`, and if
+/// cardinality counts the two zeros separately the split fires anyway and strands an
+/// empty child — the degenerate shape this work exists to remove.
+#[test]
+#[cfg_attr(miri, ignore = "Too slow to run under miri")]
+fn test_compressed_signed_zero_collapse_does_not_split() {
+    let mut tree = NumericRangeTree::new(true); // float compression ON
+
+    // One past the size-triggered split threshold, alternating the sign.
+    let n = NumericRangeTree::MAXIMUM_RANGE_SIZE as u64 + 1;
+    for doc_id in 1..=n {
+        let value = if doc_id % 2 == 0 { 5e-324 } else { -5e-324 };
+        tree.add(doc_id, value, false, 0);
+    }
+
+    if let Some((left, right)) = tree.root().child_indices() {
+        let docs = |idx| tree.node(idx).range().map_or(0, |r| r.num_docs());
+        panic!(
+            "split with no value to split on: children hold {} and {} documents, \
+             and empty_leaves is {}",
+            docs(left),
+            docs(right),
+            tree.empty_leaves(),
+        );
+    }
+
+    let range = tree.root().range().expect("a leaf keeps its range");
+    assert_eq!(
+        (range.min_val(), range.max_val()),
+        (0.0, 0.0),
+        "every stored value compares equal to zero"
+    );
+    assert_eq!(
+        range.cardinality(),
+        1,
+        "the two signed zeros must count as one value"
+    );
+    assert_eq!(tree.empty_leaves(), 0);
 }

--- a/src/redisearch_rs/numeric_range_tree/tests/proptest-regressions/properties.txt
+++ b/src/redisearch_rs/numeric_range_tree/tests/proptest-regressions/properties.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc d624227c2a290e04f03c3eca8cf38e8f4ef099c04e9bf8390484214970c75d9d # shrinks to num_entries = 119, delete_ratio = 0.8385281892398074, max_depth_range = 1


### PR DESCRIPTION
## Describe the changes in the pull request

> **Stacked on #10637** — base branch is `luca-numeric-quantize-boundary`, so review and merge that one first. Only the top commit belongs to this PR.

1. **Current.** A range's `min_val`/`max_val` are write-only: adds push them outwards and nothing ever pulls them back. GC removes entries without touching them, so a range whose extreme-valued documents have all been collected keeps reporting bounds no surviving entry justifies.

   That is the second route into the MOD-16877 `empty_leaves` underflow — the one covered by the tests added in #10628, and the one #10637 deliberately leaves open. With `min_val` stranded below every surviving value, `split_node`'s `split == min_val` guard cannot fire, so a leaf where a majority of the survivors share the smallest surviving value splits *at* that value, sends every entry to one child and strands the other empty. A later add routed into that leaf decrements `empty_leaves` below zero, which aborts the process across the non-unwinding FFI boundary.

   Stale bounds also cost query performance: a range whose bounds no longer describe its contents is visited by filters that cannot match anything in it.

2. **Change.** The GC scan already walks every surviving entry to rebuild the HyperLogLog registers, so it now tracks the value bounds in the same pass and ships both back over the pipe as `GcSurvivorStats`. The parent installs them and rescans the blocks the scan could not account for — blocks appended after the fork, plus the last block when its repair had to be ignored — so neither statistic can miss an entry that is still in the index.

   **Only leaf ranges are tightened,** which is the subtle part. Entries are applied one node at a time, ancestors before descendants, with the spec lock released in between. Tightening a range retained on an internal node would therefore transiently publish an ancestor range narrower than its own children — visible to queries running in that window. Leaves are what `split_node` reads, so that is where tightness matters; `GcBoundsUpdate` records the distinction at the call site. (The alternative, applying entries in post-order so descendants land first, would allow tightening internal ranges too, but needs a new post-order arena iterator — left out deliberately.)

3. **Outcome.** Both statistics are now exact, so a split implies at least two distinct stored values and the `split == min_val` adjustment guarantees entries land on both sides: the empty-child branch in `split_node` becomes unreachable. It stays as a self-correcting net, with an assertion that exact statistics should prevent it — an uncounted empty leaf is a process abort, so two `num_docs()` reads per split is a cheap guard. #10628's regression test moves from asserting the symptom (the empty leaf is counted) to asserting the cause is gone (bounds tighten, and the split lands entries on both sides).

**The GC pipe trailer grows** the recomputed bounds alongside the HLL registers. I left "introduces serialization changes" unchecked because the pipe has exactly one writer and one reader — a fork of the same process image — and numeric indexes are not persisted at all: they are rebuilt by keyspace scan on load. There is no cross-version or on-disk compatibility surface. Flag it if you read that box more broadly.

**Testing.** New GC tests cover: bounds tightening to the surviving extremes (both compression settings); an emptied leaf resetting to the inverted sentinel and no longer overlapping the filter its old bounds matched; retained internal ranges keeping their bounds; and the two paths the scan cannot account for — entries written to new blocks after the fork, and an ignored last block whose still-present entry must keep the bounds conservative. Plus unit tests for `ValueBounds` (including that merging an empty interval is a no-op — the bug I introduced and caught here) and the `GcSurvivorStats` pipe round trip.

The proptest regression seed committed with this change is the one that caught the ancestor-before-descendant ordering constraint; it is re-run first on every proptest execution.

Verified on this revision: 306/306 `inverted_index` + `numeric_range_tree` tests, `make lint` clean, `cargo fmt --check` clean, `make generate-rust-headers` doc churn only, C build green, `test_gc.py` 21/21 against the built module. The equivalent tree also passed miri 257/257 and the full pytest suite (2150/2152 — the two failures are `test_cluster_set_errors` and `test_with_tls`, both environmental and documented in the test source).

#### Which additional issues this PR fixes
1. MOD-16877 (stale-bounds route, at the source; #10513 fixed the crash symptom, #10628 added coverage, #10637 closed the compression route)

#### Main objects this PR modified
1. `ValueBounds`, `GcSurvivorStats`, `GcBoundsUpdate`, `NumericRange::reset_stats_after_gc` — `src/redisearch_rs/numeric_range_tree/src/range.rs`
2. `NumericRangeNode::scan_gc` + `NumericRangeTree::apply_gc_to_node` — `src/redisearch_rs/numeric_range_tree/src/tree/gc.rs`
3. `split_node`'s empty-child guard — `src/redisearch_rs/numeric_range_tree/src/tree/insert.rs`
4. GC pipe trailer — `src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/gc.rs`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Numeric range bounds are now recomputed when garbage collection removes the documents that were holding them. Previously they only ever widened, so after deletions an index could keep splitting and scanning ranges based on values it no longer contained — and that staleness was the root cause of a crash that could take down a shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
