### PR TITLE
[MOD-17099] Remove dead SearchDisk_GetVectorIndexTotalMemory wrapper

### DIFF
--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -577,11 +577,6 @@ uint64_t SearchDisk_GetInvertedIndexTotalMemory(RedisSearchDiskIndexSpec* index)
   return disk->metrics.getInvertedIndexTotalMemory(disk_db, index);
 }
 
-uint64_t SearchDisk_GetVectorIndexTotalMemory(RedisSearchDiskIndexSpec* index) {
-  RS_ASSERT(disk && disk_db && index);
-  return disk->metrics.getVectorIndexTotalMemory(disk_db, index);
-}
-
 uint64_t SearchDisk_GetNumRecords(RedisSearchDiskIndexSpec* index) {
   RS_ASSERT(disk && index);
   return disk->metrics.getNumRecords(index);

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -759,19 +759,6 @@ uint64_t SearchDisk_GetDocTableTotalMemory(RedisSearchDiskIndexSpec* index);
 uint64_t SearchDisk_GetInvertedIndexTotalMemory(RedisSearchDiskIndexSpec* index);
 
 /**
- * @brief Get vector index memory for a disk index
- *
- * Returns disk-side vector index memory in bytes from the latest collected snapshot.
- * Does not include RAM-only accounting from non-disk paths.
- * Call SearchDisk_CollectIndexMetrics(index) before this getter.
- * Requires initialized SearchDisk and non-null index (RS_ASSERT).
- *
- * @param index Pointer to the disk index spec
- * @return Vector index memory in bytes
- */
-uint64_t SearchDisk_GetVectorIndexTotalMemory(RedisSearchDiskIndexSpec* index);
-
-/**
  * @brief Get the disk-owned total number of records for a disk index
  *
  * Returns the disk-side num_records counter used by FT.INFO.

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -1019,18 +1019,6 @@ typedef struct MetricsDiskAPI {
   uint64_t (*getInvertedIndexTotalMemory)(RedisSearchDisk *disk, RedisSearchDiskIndexSpec *index);
 
   /**
-   * @brief Get total vector index memory for a specific index
-   *
-   * Returns disk-side vector index memory in bytes from the latest collected snapshot.
-   * Does not include RAM-only accounting from non-disk paths.
-   *
-   * @param disk Pointer to the disk context
-   * @param index Pointer to the index spec
-   * @return Vector index memory in bytes
-   */
-  uint64_t (*getVectorIndexTotalMemory)(RedisSearchDisk *disk, RedisSearchDiskIndexSpec *index);
-
-  /**
    * @brief Get the disk-owned total number of records for a specific index
    *
    * Returns the disk-side num_records counter used by FT.INFO.


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `SearchDisk_GetVectorIndexTotalMemory` exists as a C wrapper (with a declaration in `search_disk.h` and a `MetricsDiskAPI::getVectorIndexTotalMemory` vtable slot in `search_disk_api.h`), but has zero callers anywhere — checked across RediSearch, RediSearchEnterprise (`redisearch_disk/`, `vecsim_disk/`), and the flow tests.
2. Change: remove the dead C wrapper, its declaration, and the vtable slot. The corresponding Rust-side FFI wrapper and `DiskContext::get_vector_index_total_memory` method are removed in the paired RediSearchEnterprise PR.
3. Outcome: dead FFI surface eliminated; no behavior change.

The two live sibling wrappers (`SearchDisk_GetInvertedIndexTotalMemory` and `SearchDisk_GetDocTableTotalMemory`) are retained — they remain wired into FT.INFO via `spec.c` and `info/info_command.c`. The `disk_vector_index` INFO section emitted by `DiskContext::output_info_metrics` is a separate live path (reads `ColumnFamilyMetrics.total_memory()` directly on aggregated metrics) and is unaffected.

#### Which additional issues this PR fixes
1. MOD-17099

#### Main objects this PR modified
1. `src/search_disk.c` — remove `SearchDisk_GetVectorIndexTotalMemory` definition
2. `src/search_disk.h` — remove declaration
3. `src/search_disk_api.h` — remove `MetricsDiskAPI::getVectorIndexTotalMemory` vtable slot

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal-only cleanup: no user-facing surface changes (the removed wrapper had zero callers and never reached FT.INFO or any command).

#### Cross-repo coordination

This PR is paired with a RediSearchEnterprise PR that removes the Rust-side wrapper and `DiskContext::get_vector_index_total_memory` method, and bumps the `deps/RediSearch` submodule pointer to this branch. **Merge order:** this OSS PR must land first. After it merges to master, the RediSearchEnterprise branch must have its submodule pointer updated to the master merge commit before Enterprise can merge — that submodule bump is a manual follow-up.