### PR TITLE
[MOD-17099] Remove dead SearchDisk_NewNumericIterator FFI wrapper

### DIFF
--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/wildcard.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/wildcard.rs
@@ -45,8 +45,9 @@ pub const unsafe extern "C" fn IsWildcardIterator(it: *const QueryIterator) -> b
 ///
 /// There are three possible code paths:
 ///
-/// 1. **Disk index** — when [`spec.diskSpec`](ffi::IndexSpec::diskSpec) is non-null, delegates to the C
-///    function `SearchDisk_NewWildcardIterator`.
+/// 1. **Disk index** — when [`spec.diskSpec`](ffi::IndexSpec::diskSpec) is non-null, delegates to
+///    the enterprise iterator API via
+///    [`rqe_iterators::wildcard::new_wildcard_iterator_on_disk`].
 /// 2. **[`index_all`](ffi::SchemaRule::index_all) optimized** — when [`SchemaRule`](ffi::SchemaRule)`.index_all` is set, delegates to
 ///    [`rqe_iterators::wildcard::new_wildcard_iterator_optimized`].
 /// 3. **Fallback** — creates a simple [`Wildcard`] iterator that yields all

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -437,8 +437,9 @@ QueryIterator *NewUnionIterator(QueryIterator * *its, int32_t num, bool quick_ex
  *
  * There are three possible code paths:
  *
- * 1. **Disk index** — when [`spec.diskSpec`](ffi::IndexSpec::diskSpec) is non-null, delegates to the C
- *    function `SearchDisk_NewWildcardIterator`.
+ * 1. **Disk index** — when [`spec.diskSpec`](ffi::IndexSpec::diskSpec) is non-null, delegates to
+ *    the enterprise iterator API via
+ *    [`rqe_iterators::wildcard::new_wildcard_iterator_on_disk`].
  * 2. **[`index_all`](ffi::SchemaRule::index_all) optimized** — when [`SchemaRule`](ffi::SchemaRule)`.index_all` is set, delegates to
  *    [`rqe_iterators::wildcard::new_wildcard_iterator_optimized`].
  * 3. **Fallback** — creates a simple [`Wildcard`] iterator that yields all

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -363,11 +363,6 @@ void SearchDisk_FreeSnapshot(RedisSearchDiskSnapshot *snapshot) {
     disk->index.freeSnapshot(snapshot);
 }
 
-QueryIterator* SearchDisk_NewNumericIterator(RedisSearchDiskIndexSpec *index, const RedisSearchCtx *sctx, const NumericFilter *filter, t_fieldIndex fieldIndex, QueryError *status) {
-    RS_ASSERT(disk && index && sctx && sctx->diskSnapshot && filter);
-    return disk->index.newNumericIterator(index, filter, fieldIndex, sctx->diskSnapshot, status);
-}
-
 void SearchDisk_RunGC(RedisSearchDiskIndexSpec *index, DiskGCRunStats *stats) {
     RS_ASSERT(disk && index && stats);
     disk->index.runGC(index, stats);

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -394,24 +394,6 @@ RedisSearchDiskSnapshot* SearchDisk_CreateSnapshot(RedisSearchDiskIndexSpec *ind
  */
 void SearchDisk_FreeSnapshot(RedisSearchDiskSnapshot *snapshot);
 
-/**
- * @brief Create a numeric range IndexIterator over the disk-backed index
- *
- * Wraps the disk API's per-bucket readers in a union iterator that yields
- * doc-ids matching `filter`'s range. The disk snapshot is taken from
- * `sctx->diskSnapshot` (which must be non-NULL) so the buckets are read at
- * the same point in time as sibling iterators in the same query.
- *
- * @param index Pointer to the index
- * @param sctx Search context whose `diskSnapshot` field selects the read view. The
- *             `diskSnapshot` field is required to be non-NULL.
- * @param filter Pointer to the numeric filter (min, max, inclusivity, field spec)
- * @param fieldIndex Field index for the numeric field
- * @param status QueryError to populate with the cause when creation fails (may be NULL)
- * @return Pointer to the IndexIterator, or NULL if no buckets overlap the filter
- */
-QueryIterator* SearchDisk_NewNumericIterator(RedisSearchDiskIndexSpec *index, const RedisSearchCtx *sctx, const NumericFilter *filter, t_fieldIndex fieldIndex, QueryError *status);
-
 // DocTable API wrappers
 
 /**

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -51,9 +51,10 @@ typedef const void* RedisSearchDiskRdbState;
 // Opaque handle for a consistent point-in-time view of the disk database.
 //
 // Created via `IndexDiskAPI.createSnapshot`, released via `IndexDiskAPI.freeSnapshot`.
-// Pass the same snapshot to `newTermIterator` / `newTagIterator` / `newWildcardIterator`
-// so all iterators in a query observe the same database state. The snapshot must outlive
-// every iterator created from it, and must not outlive the originating index spec.
+// Pass the same snapshot to `newTermIterator` / `newTagIterator` and to the Rust-side
+// numeric/wildcard iterator entry points so all iterators in a query observe the same
+// database state. The snapshot must outlive every iterator created from it, and must
+// not outlive the originating index spec.
 typedef const void* RedisSearchDiskSnapshot;
 
 // Opaque handle for the underlying storage-layer write batch.
@@ -520,9 +521,9 @@ typedef struct IndexDiskAPI {
   /**
    * @brief Take a point-in-time snapshot of the disk database for this index.
    *
-   * The returned snapshot can be passed to `newTermIterator`, `newTagIterator`,
-   * `newNumericIterator`, and the Rust-side wildcard iterator entry point so that every
-   * iterator created for one query observes the same database state. Must be released by
+   * The returned snapshot can be passed to `newTermIterator`, `newTagIterator`, and
+   * the Rust-side numeric/wildcard iterator entry points so that every iterator
+   * created for one query observes the same database state. Must be released by
    * `freeSnapshot` when no iterator is still using it.
    *
    * @param index Pointer to the index spec
@@ -538,26 +539,6 @@ typedef struct IndexDiskAPI {
    * @param snapshot Snapshot handle returned by `createSnapshot`
    */
   void (*freeSnapshot)(RedisSearchDiskSnapshot *snapshot);
-
-  /**
-   * @brief Creates a new iterator over a numeric range on the disk-backed index
-   *
-   * Enumerates the in-memory ordered map's buckets that overlap `filter`'s range
-   * and opens one Speedb-snapshot-backed iterator per candidate bucket, with a
-   * per-yielded-entry value filter of `effective_range ∩ filter_range`. The
-   * candidate iterators are heap-merged by `doc_id` via a union iterator, which
-   * also collapses any transient duplicates that the in-flight split protocol
-   * may produce.
-   *
-   * @param index Pointer to the index
-   * @param filter Pointer to the numeric filter (min, max, inclusivity flags, field spec)
-   * @param fieldIndex Field index for the numeric field
-   * @param snapshot Required snapshot for the read view. Must have been returned by
-   *                 `createSnapshot(index)` and must remain valid until the returned iterator is freed.
-   * @param status QueryError to populate with the cause when creation fails (may be NULL)
-   * @return Pointer to the created iterator, or NULL if no buckets overlap the filter
-   */
-  QueryIterator *(*newNumericIterator)(RedisSearchDiskIndexSpec *index, const NumericFilter *filter, t_fieldIndex fieldIndex, RedisSearchDiskSnapshot *snapshot, QueryError* status);
 
   /**
    * @brief Run a GC compaction cycle on the disk index.


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `SearchDisk_NewNumericIterator` (the C wrapper in `search_disk.c`) and the `newNumericIterator` fn-pointer slot on `IndexDiskAPI` are dead FFI surface. The live numeric-iterator path constructs the iterator through the Rust-only `SEARCH_ENTERPRISE_ITERATORS` registry (`SearchEnterpriseIterators::new_numeric_on_disk`) — the same pattern the wildcard iterator moved to in #8759 — and never touches the vtable slot.
2. **Change:** Delete `SearchDisk_NewNumericIterator` and its declaration, remove the `newNumericIterator` slot from `IndexDiskAPI`, and clean up stale doc-comment references to `SearchDisk_NewWildcardIterator` (which was removed years ago but still appears in `wildcard.rs`, `iterators_ffi.h`, and a comment in `search_disk_api.h`).
3. **Outcome:** Smaller FFI surface with no live behavior change; the numeric iterator now has a single, discoverable creation path.

#### Which additional issues this PR fixes

1. MOD-17099

#### Main objects this PR modified

1. `src/search_disk.c` — removed `SearchDisk_NewNumericIterator`.
2. `src/search_disk.h` — removed the corresponding declaration + doc block.
3. `src/search_disk_api.h` — removed the `newNumericIterator` field on `IndexDiskAPI`; refreshed the `newTermIterator`/`newTagIterator` snapshot doc note.
4. `src/redisearch_rs/c_entrypoint/iterators_ffi/src/wildcard.rs`, `src/redisearch_rs/headers/iterators_ffi.h` — updated stale doc comments that still named `SearchDisk_NewWildcardIterator`.

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

Removes a public FFI symbol (`SearchDisk_NewNumericIterator`) and a field on `IndexDiskAPI`. Consumers of the OSS build see a smaller `IndexDiskAPI` struct — this is an ABI change for anyone linking against the previous shape. The paired Enterprise change (RediSearchEnterprise MOD-17099) drops the corresponding Rust FFI vtable initializer field.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal-only FFI cleanup; no user-visible behavior change.

#### Cross-repo coordination

Paired with [RediSearchEnterprise#698](https://github.com/redislabsdev/RediSearchEnterprise/pull/698). **Merge order:** the Enterprise PR pins to this branch's tip and cannot merge until this PR lands; after that lands, the Enterprise submodule pointer must be updated to the merge commit before Enterprise can merge. Removing `newNumericIterator` from `IndexDiskAPI` breaks the Enterprise Rust vtable initializer, and the Enterprise PR removes that initializer field in the same PR — so the two must land together.
