### PR TITLE
[MOD-17292] LoadDocument cleanup

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2280,6 +2280,7 @@ dependencies = [
  "rlookup_ffi",
  "search_result",
  "sorting_vector",
+ "tracing",
  "value",
  "value_ffi",
  "workspace_hack",

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/Cargo.toml
@@ -23,6 +23,7 @@ value.workspace = true
 value_ffi = { path = "../value_ffi" }
 query_error.workspace = true
 workspace_hack.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 # Crate required to invoke C symbols

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/lookup.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/lookup.rs
@@ -635,6 +635,16 @@ pub unsafe extern "C" fn RLookup_LoadRuleFields(
 
     match res {
         Ok(_) => ffi::REDISMODULE_OK as i32,
+        Err(err) if err.is_stale_document() => {
+            tracing::debug!(
+                ?lookup,
+                ?dst_row,
+                ?search_ctx,
+                "rlookup::load_rule_fields skipped stale document: {err:?}"
+            );
+
+            ffi::REDISMODULE_ERR as i32
+        }
         Err(err) => {
             tracing::error!(
                 ?lookup,

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/lookup.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/lookup.rs
@@ -8,13 +8,14 @@
 */
 
 use libc::size_t;
+use query_error::{QueryError, opaque::OpaqueQueryError};
 use rlookup::{
     IndexSpec, IndexSpecCache, OpaqueRLookup, OpaqueRLookupRow, RLookup, RLookupKey,
     RLookupKeyFlag, RLookupKeyFlags, RLookupOptions, RLookupRow, SchemaRule,
 };
 use std::{
     borrow::Cow,
-    ffi::{CStr, c_char},
+    ffi::{CStr, CString, c_char},
     pin::Pin,
     ptr::{self, NonNull},
     slice,
@@ -603,7 +604,7 @@ pub unsafe extern "C" fn RLookup_LoadRuleFields(
     index_spec: Option<NonNull<ffi::IndexSpec>>,
     key: *const c_char,
     open_key: *mut ffi::RedisModuleKey,
-    status: Option<NonNull<ffi::QueryError>>,
+    status: Option<NonNull<OpaqueQueryError>>,
 ) -> i32 {
     // Safety: ensured by caller (1.)
     let search_ctx = unsafe { search_ctx.unwrap().as_mut() };
@@ -625,9 +626,31 @@ pub unsafe extern "C" fn RLookup_LoadRuleFields(
     let key = unsafe { CStr::from_ptr(key) };
 
     // Safety: ensured by caller (8.)
-    let status = unsafe { status.unwrap().as_mut() };
+    let open_key = unsafe { open_key.as_ref() };
 
-    lookup.load_rule_fields(search_ctx, dst_row, index_spec, key, open_key, status)
+    // Safety: ensured by caller (9.)
+    let status = unsafe { QueryError::from_opaque_non_null(status.unwrap()) };
+
+    let res = lookup.load_rule_fields(search_ctx, dst_row, index_spec, key, open_key);
+
+    match res {
+        Ok(_) => ffi::REDISMODULE_OK as i32,
+        Err(err) => {
+            tracing::error!(
+                ?lookup,
+                ?dst_row,
+                ?search_ctx,
+                "rlookup::load_rule_fields failed with {err:?}"
+            );
+
+            status.set_code_and_message(
+                err.to_query_error_code(),
+                CString::new(err.to_string()).ok(),
+            );
+
+            ffi::REDISMODULE_ERR as i32
+        }
+    }
 }
 
 /// Return an iterator over an [`RLookup`]'s key list.

--- a/src/redisearch_rs/headers/rlookup.h
+++ b/src/redisearch_rs/headers/rlookup.h
@@ -40,26 +40,6 @@ typedef struct RLookupKey RLookupKey;
 #  endif
 #endif
 
-enum RLookup_Opt
-#ifdef __cplusplus
-  : uint32_t
-#endif // __cplusplus
- {
-  /**
-   * If the key cannot be found, do not mark it as an error, but create it and
-   * mark it as F_UNRESOLVED
-   */
-  RLOOKUP_OPT_ALLOWUNRESOLVED = 0x01,
-  /**
-   * If a loader was added to load the entire document, this flag will allow
-   * later calls to GetKey in read mode to create a key (from the schema) even if it is not sortable
-   */
-  RLOOKUP_OPT_ALLLOADED = 0x02,
-};
-#ifndef __cplusplus
-typedef uint32_t RLookup_Opt;
-#endif // __cplusplus
-
 enum RLookup_F
 #ifdef __cplusplus
   : uint32_t
@@ -126,6 +106,26 @@ enum RLookup_F
 };
 #ifndef __cplusplus
 typedef uint32_t RLookup_F;
+#endif // __cplusplus
+
+enum RLookup_Opt
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  /**
+   * If the key cannot be found, do not mark it as an error, but create it and
+   * mark it as F_UNRESOLVED
+   */
+  RLOOKUP_OPT_ALLOWUNRESOLVED = 0x01,
+  /**
+   * If a loader was added to load the entire document, this flag will allow
+   * later calls to GetKey in read mode to create a key (from the schema) even if it is not sortable
+   */
+  RLOOKUP_OPT_ALLLOADED = 0x02,
+};
+#ifndef __cplusplus
+typedef uint32_t RLookup_Opt;
 #endif // __cplusplus
 
 /**

--- a/src/redisearch_rs/headers/rlookup_ffi.h
+++ b/src/redisearch_rs/headers/rlookup_ffi.h
@@ -600,7 +600,7 @@ void RLookup_Cleanup(struct RLookup *lookup);
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-int32_t RLookup_LoadRuleFields(RedisSearchCtx *search_ctx, struct RLookup *lookup, struct RLookupRow *dst_row, IndexSpec *index_spec, const char *key, RedisModuleKey *open_key, QueryError *status);
+int32_t RLookup_LoadRuleFields(RedisSearchCtx *search_ctx, struct RLookup *lookup, struct RLookupRow *dst_row, IndexSpec *index_spec, const char *key, RedisModuleKey *open_key, struct QueryError *status);
 
 /**
  * Return an iterator over an [`RLookup`]'s key list.

--- a/src/redisearch_rs/redis_json_api/src/key_values.rs
+++ b/src/redisearch_rs/redis_json_api/src/key_values.rs
@@ -58,13 +58,8 @@ impl<'a> KeyValuesIterator<'a> {
         api: &'a RedisJsonApi,
         len: usize,
     ) -> Self {
-        let vtable = api.vtable();
-        let next = vtable
-            .nextKeyValue
-            .expect("RedisJSON API function `nextKeyValue` not available");
-        let free = vtable
-            .freeKeyValuesIter
-            .expect("RedisJSON API function `freeKeyValuesIter` not available");
+        let next = vtable_fn!(api, nextKeyValue);
+        let free = vtable_fn!(api, freeKeyValuesIter);
 
         Self {
             ptr,

--- a/src/redisearch_rs/redis_json_api/src/lib.rs
+++ b/src/redisearch_rs/redis_json_api/src/lib.rs
@@ -7,6 +7,22 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+/// Read a function slot out of the vtable, panicking if the provider left it empty.
+macro_rules! vtable_fn {
+    ($api:expr, $field:ident) => {{
+        let vtable = ($api).vtable();
+
+        // Safety: `$field` is part of the V7 prefix, which every accepted provider allocated.
+        let slot = unsafe { (&raw const (*vtable.as_ptr()).$field).read() };
+
+        slot.expect(concat!(
+            "RedisJSON API function `",
+            stringify!($field),
+            "` not available"
+        ))
+    }};
+}
+
 mod key_values;
 #[cfg(feature = "test-mock")]
 pub mod mock;
@@ -16,24 +32,15 @@ mod value;
 
 use ffi::RedisJSONAPI as RedisJsonApiVTable;
 use redis_module::{RedisString, key::KeyFlags};
-use std::{error::Error, ffi::CStr, fmt};
+use std::{error::Error, ffi::CStr, fmt, ptr::NonNull};
 
 pub use key_values::KeyValuesIterator;
 pub use path::JsonPath;
 pub use results::ResultsIter;
 pub use value::{JsonType, JsonValue, JsonValueRef};
 
-/// Minimum RedisJSON API version this wrapper accepts.
-///
-/// This is deliberately **8**, higher than the C-side minimum
-/// `RedisJSONAPI_MIN_API_VER` (currently 7): the C code supports V7, but
-/// [`RedisJsonApi`] stores the acquired vtable as a `&'static RedisJSONAPI`
-/// reference — whose type is the latest (V8) layout. Forming that reference
-/// asserts the whole struct is a valid, in-bounds `RedisJSONAPI`; a genuine V7
-/// provider allocates a shorter vtable (ending after the V7 `getArray` slot), so
-/// accepting V7 here would read past the allocation — undefined behavior,
-/// independent of which fields are read.
-pub const MIN_API_VERSION: i32 = 8;
+/// Minimum RedisJSON API version this wrapper accepts, kept in lockstep with the C side.
+pub const MIN_API_VERSION: i32 = ffi::RedisJSONAPI_MIN_API_VER.cast_signed();
 
 /// Latest API version (V8).
 pub const LATEST_API_VERSION: i32 = 8;
@@ -53,7 +60,7 @@ pub const JSON_ROOT: &CStr = c"$";
 /// operations must be performed with appropriate Redis context locking.
 #[derive(Debug, Clone, Copy)]
 pub struct RedisJsonApi {
-    vtable: &'static RedisJsonApiVTable,
+    vtable: NonNull<RedisJsonApiVTable>,
 }
 
 impl RedisJsonApi {
@@ -70,25 +77,23 @@ impl RedisJsonApi {
         // Safety: once the global pointer is initialized it will not be written to again.
         let vtable_ptr = unsafe { ffi::japi };
 
-        // Check version compatibility BEFORE forming a reference to the vtable.
         // Safety: japi_ver is initialized alongside japi.
         let version = unsafe { ffi::japi_ver };
         if version < MIN_API_VERSION {
             return None;
         }
 
-        // Safety: being V8+, the provider allocated at least a full `RedisJSONAPI`,
-        // so the reference is in-bounds; `as_ref` still yields `None` for a null
-        // pointer. Ensured by caller (1.).
-        let vtable = unsafe { vtable_ptr.as_ref()? };
-
-        Some(Self { vtable })
+        Some(Self {
+            vtable: NonNull::new(vtable_ptr)?,
+        })
     }
 
     /// Construct an API handle from a caller-provided vtable.
     #[cfg(feature = "test-mock")]
     pub const fn from_vtable(vtable: &'static RedisJsonApiVTable) -> Self {
-        Self { vtable }
+        Self {
+            vtable: NonNull::from_ref(vtable),
+        }
     }
 
     /// Returns the current API version.
@@ -114,10 +119,7 @@ impl RedisJsonApi {
         ctx: *mut ffi::RedisModuleCtx,
         key_name: &RedisString,
     ) -> Option<JsonValueRef<'_>> {
-        let vtable = self.vtable();
-        let open_key = vtable
-            .openKey
-            .expect("RedisJSON API function `openKey` not available");
+        let open_key = vtable_fn!(self, openKey);
 
         // Safety: ensured by caller (1.)
         let ptr = unsafe { open_key(ctx, key_name.inner.cast()) };
@@ -141,10 +143,7 @@ impl RedisJsonApi {
         ctx: *mut ffi::RedisModuleCtx,
         key_name: &CStr,
     ) -> Option<JsonValueRef<'_>> {
-        let vtable = self.vtable();
-        let open_key_from_str = vtable
-            .openKeyFromStr
-            .expect("RedisJSON API function `openKeyFromStr` not available");
+        let open_key_from_str = vtable_fn!(self, openKeyFromStr);
 
         // Safety: ensured by caller (1.)
         let ptr = unsafe { open_key_from_str(ctx, key_name.as_ptr()) };
@@ -171,10 +170,7 @@ impl RedisJsonApi {
         key_name: &RedisString,
         flags: KeyFlags,
     ) -> Option<JsonValueRef<'_>> {
-        let vtable = self.vtable();
-        let open_key_with_flags = vtable
-            .openKeyWithFlags
-            .expect("RedisJSON API function `openKeyWithFlags` not available");
+        let open_key_with_flags = vtable_fn!(self, openKeyWithFlags);
 
         // Safety: ensured by caller (1.)
         let ptr = unsafe {
@@ -220,7 +216,7 @@ impl RedisJsonApi {
         }
     }
 
-    pub const fn vtable(&self) -> &'static RedisJsonApiVTable {
+    pub const fn vtable(&self) -> NonNull<RedisJsonApiVTable> {
         self.vtable
     }
 }

--- a/src/redisearch_rs/redis_json_api/src/mock.rs
+++ b/src/redisearch_rs/redis_json_api/src/mock.rs
@@ -18,6 +18,9 @@ use std::ptr::{self, NonNull};
 struct MockState {
     /// The document `openKeyWithFlags` resolves to. `None` models a missing document.
     doc: Option<serde_json::Value>,
+    /// When set, `getJsonFromHandle` returns NULL regardless of `doc`, modelling a
+    /// pinned handle that cannot be resolved to a JSON root.
+    handle_returns_null: bool,
     /// Owns the serialized buffers (`getJSON` / `getJSONFromIter`) minted during
     /// the mock's lifetime. `redis_mock`'s `RedisModule_CreateString` copies its
     /// input, so retaining them here is not required for correctness; it simply
@@ -36,8 +39,26 @@ pub fn with_json_api<R>(
     doc: Option<serde_json::Value>,
     f: impl FnOnce(RedisJsonApi, NonNull<ffi::RedisModuleCtx>) -> R,
 ) -> R {
+    with_json_api_state(doc, false, f)
+}
+
+/// Like [`with_json_api`], but `getJsonFromHandle` resolves to NULL so callers can
+/// exercise the by-name open fallback in the borrowed-handle path.
+pub fn with_json_api_broken_handle<R>(
+    doc: Option<serde_json::Value>,
+    f: impl FnOnce(RedisJsonApi, NonNull<ffi::RedisModuleCtx>) -> R,
+) -> R {
+    with_json_api_state(doc, true, f)
+}
+
+fn with_json_api_state<R>(
+    doc: Option<serde_json::Value>,
+    handle_returns_null: bool,
+    f: impl FnOnce(RedisJsonApi, NonNull<ffi::RedisModuleCtx>) -> R,
+) -> R {
     let state = MockState {
         doc,
+        handle_returns_null,
         strings: RefCell::new(Vec::new()),
     };
     // Derive the handle from a shared reference: we never form `&mut state`
@@ -179,8 +200,8 @@ unsafe extern "C" fn get_json_from_handle(key: *mut ffi::RedisModuleKey) -> ffi:
     // Safety: ensured by caller (1.)
     let state = unsafe { &*key.cast::<MockState>() };
     match &state.doc {
-        Some(value) => ptr::from_ref(value).cast(),
-        None => ptr::null(),
+        Some(value) if !state.handle_returns_null => ptr::from_ref(value).cast(),
+        _ => ptr::null(),
     }
 }
 

--- a/src/redisearch_rs/redis_json_api/src/path.rs
+++ b/src/redisearch_rs/redis_json_api/src/path.rs
@@ -45,10 +45,7 @@ impl<'a> JsonPath<'a> {
         ctx: *mut ffi::RedisModuleCtx,
         api: &'a RedisJsonApi,
     ) -> Result<Self, RedisString> {
-        let vtable = api.vtable();
-        let path_parse = vtable
-            .pathParse
-            .expect("RedisJSON API function `pathParse` not available");
+        let path_parse = vtable_fn!(api, pathParse);
 
         let mut err_msg: *mut ffi::RedisModuleString = std::ptr::null_mut();
 
@@ -56,9 +53,7 @@ impl<'a> JsonPath<'a> {
         let ptr = unsafe { path_parse(path.as_ptr(), ctx, &raw mut err_msg) };
 
         if let Some(ptr) = NonNull::new(ptr as *mut c_void) {
-            let path_free = vtable
-                .pathFree
-                .expect("RedisJSON API function `pathFree` not available");
+            let path_free = vtable_fn!(api, pathFree);
 
             Ok(Self {
                 ptr,
@@ -80,10 +75,7 @@ impl<'a> JsonPath<'a> {
     ///
     /// Only available with RedisJSON API v2 and later.
     pub fn is_single(&self) -> bool {
-        let vtable = self.api.vtable();
-        let path_is_single = vtable
-            .pathIsSingle
-            .expect("RedisJSON API function `pathIsSingle` not available");
+        let path_is_single = vtable_fn!(self.api, pathIsSingle);
 
         // Safety: `ptr` is valid by construction.
         unsafe { path_is_single(self.ptr.as_ptr()) != 0 }
@@ -97,10 +89,7 @@ impl<'a> JsonPath<'a> {
     ///
     /// Only available with RedisJSON API v2 and later.
     pub fn path_has_defined_order(&self) -> bool {
-        let vtable = self.api.vtable();
-        let path_has_defined_order = vtable
-            .pathHasDefinedOrder
-            .expect("RedisJSON API function `pathHasDefinedOrder` not available");
+        let path_has_defined_order = vtable_fn!(self.api, pathHasDefinedOrder);
 
         // Safety: `ptr` is valid by construction.
         unsafe { path_has_defined_order(self.ptr.as_ptr()) != 0 }

--- a/src/redisearch_rs/redis_json_api/src/results.rs
+++ b/src/redisearch_rs/redis_json_api/src/results.rs
@@ -40,17 +40,9 @@ impl<'a> ResultsIter<'a> {
     ///
     /// 1. `ptr` must be a valid ptr obtained from `get`.
     pub(crate) unsafe fn from_non_null(ptr: NonNull<c_void>, api: &'a RedisJsonApi) -> Self {
-        let vtable = api.vtable();
-
-        let next = vtable
-            .next
-            .expect("RedisJSON API function `next` not available");
-        let free = vtable
-            .freeIter
-            .expect("RedisJSON API function `freeIter` not available");
-        let len = vtable
-            .len
-            .expect("RedisJSON API function `len` not available");
+        let next = vtable_fn!(api, next);
+        let free = vtable_fn!(api, freeIter);
+        let len = vtable_fn!(api, len);
 
         Self {
             ptr,
@@ -77,10 +69,7 @@ impl<'a> ResultsIter<'a> {
     ///
     /// Only available with RedisJSON API v3 and later.
     pub fn reset(&mut self) {
-        let vtable = self.api.vtable();
-        let reset_iter = vtable
-            .resetIter
-            .expect("RedisJSON API function `resetIter` not available");
+        let reset_iter = vtable_fn!(self.api, resetIter);
 
         // Safety: `ptr` is valid by construction.
         unsafe { reset_iter(self.ptr.as_ptr()) };
@@ -98,10 +87,7 @@ impl<'a> ResultsIter<'a> {
         &self,
         ctx: *mut ffi::RedisModuleCtx,
     ) -> Result<RedisString, SerializeError> {
-        let vtable = self.api.vtable();
-        let get_json_from_iter = vtable
-            .getJSONFromIter
-            .expect("RedisJSON API function `getJSONFromIter` not available");
+        let get_json_from_iter = vtable_fn!(self.api, getJSONFromIter);
         let mut str: *mut ffi::RedisModuleString = std::ptr::null_mut();
 
         // Safety: `ptr` and `ctx` are valid by construction/caller guarantee

--- a/src/redisearch_rs/redis_json_api/src/value.rs
+++ b/src/redisearch_rs/redis_json_api/src/value.rs
@@ -107,10 +107,7 @@ impl<'a> JsonValueRef<'a> {
 
     /// Return the length of the value if it is an Object or Array
     pub fn len(&self) -> Option<usize> {
-        let vtable = self.api.vtable();
-        let get_len = vtable
-            .getLen
-            .expect("RedisJSON API function `getLen` not available");
+        let get_len = vtable_fn!(self.api, getLen);
 
         let mut out: usize = 0;
 
@@ -131,10 +128,7 @@ impl<'a> JsonValueRef<'a> {
 
     /// Returns the type of this `JsonValue`.
     pub fn get_type(&self) -> JsonType {
-        let vtable = self.api.vtable();
-        let get_type = vtable
-            .getType
-            .expect("RedisJSON API function `getType` not available");
+        let get_type = vtable_fn!(self.api, getType);
 
         // Safety: `ptr` is valid by construction.
         let raw = unsafe { get_type(self.ptr) };
@@ -144,10 +138,7 @@ impl<'a> JsonValueRef<'a> {
 
     /// Returns the i64 value of this `JsonValue`s if it is a Number or `None` otherwise.
     pub fn get_int(&self) -> Option<i64> {
-        let vtable = self.api.vtable();
-        let get_int = vtable
-            .getInt
-            .expect("RedisJSON API function `getInt` not available");
+        let get_int = vtable_fn!(self.api, getInt);
 
         let mut out: i64 = 0;
 
@@ -163,10 +154,7 @@ impl<'a> JsonValueRef<'a> {
 
     /// Returns the f64 value of this `JsonValue`s if it is a Number or `None` otherwise.
     pub fn get_double(&self) -> Option<f64> {
-        let vtable = self.api.vtable();
-        let get_double = vtable
-            .getDouble
-            .expect("RedisJSON API function `getDouble` not available");
+        let get_double = vtable_fn!(self.api, getDouble);
 
         let mut out: f64 = 0.0;
 
@@ -182,10 +170,7 @@ impl<'a> JsonValueRef<'a> {
 
     /// Returns the boolean value of this `JsonValue`s if it is a Boolean or `None` otherwise.
     pub fn get_bool(&self) -> Option<bool> {
-        let vtable = self.api.vtable();
-        let get_boolean = vtable
-            .getBoolean
-            .expect("RedisJSON API function `getBoolean` not available");
+        let get_boolean = vtable_fn!(self.api, getBoolean);
 
         let mut out: i32 = 0;
 
@@ -201,10 +186,7 @@ impl<'a> JsonValueRef<'a> {
 
     /// Returns the string value of this `JsonValue`s if it is a String or `None` otherwise.
     pub fn get_str(&self) -> Option<&str> {
-        let vtable = self.api.vtable();
-        let get_string = vtable
-            .getString
-            .expect("RedisJSON API function `getString` not available");
+        let get_string = vtable_fn!(self.api, getString);
 
         let mut str: *const c_char = std::ptr::null();
         let mut len: usize = 0;
@@ -226,10 +208,7 @@ impl<'a> JsonValueRef<'a> {
     ///
     /// Only available with RedisJSON API v6 and later.
     pub fn get_at(&self, idx: usize) -> Option<JsonValue<'_>> {
-        let vtable = self.api.vtable();
-        let get_at = vtable
-            .getAt
-            .expect("RedisJSON API function `getAt` not available");
+        let get_at = vtable_fn!(self.api, getAt);
 
         let mut out = JsonValue::new(self.api);
 
@@ -256,10 +235,7 @@ impl<'a> JsonValueRef<'a> {
         let (ptr, len) = if let Some(len) = self.len()
             && len > 0
         {
-            let vtable = self.api.vtable();
-            let get_key_values = vtable
-                .getKeyValues
-                .expect("RedisJSON API function `getKeyValues` not available");
+            let get_key_values = vtable_fn!(self.api, getKeyValues);
 
             // Safety: `ptr` is valid by construction.
             let ptr = unsafe { get_key_values(self.ptr) };
@@ -277,8 +253,7 @@ impl<'a> JsonValueRef<'a> {
 
     /// Returns an iterator over values matched by `path`.
     pub fn get(&self, path: &CStr) -> Option<ResultsIter<'_>> {
-        let api = self.api.vtable();
-        let get = api.get.expect("RedisJSON API function `get` not available");
+        let get = vtable_fn!(self.api, get);
 
         // Safety: `ptr` is valid by construction and CStr ensures `ptr` is a valid c string.
         let ptr = unsafe { get(self.ptr, path.as_ptr()) };
@@ -299,10 +274,7 @@ impl<'a> JsonValueRef<'a> {
         &self,
         ctx: *mut ffi::RedisModuleCtx,
     ) -> Result<RedisString, SerializeError> {
-        let api = self.api.vtable();
-        let get_json = api
-            .getJSON
-            .expect("RedisJSON API function `getJSON` not available");
+        let get_json = vtable_fn!(self.api, getJSON);
 
         let mut str: *mut ffi::RedisModuleString = std::ptr::null_mut();
 
@@ -338,13 +310,8 @@ impl<'a> JsonValue<'a> {
     ///
     /// Only available with RedisJSON API v6 and later.
     pub(crate) fn new(api: &'a RedisJsonApi) -> Self {
-        let vtable = api.vtable();
-        let alloc_json = vtable
-            .allocJson
-            .expect("RedisJSON API function `allocJson` not available");
-        let free = vtable
-            .freeJson
-            .expect("RedisJSON API function `freeJson` not available");
+        let alloc_json = vtable_fn!(api, allocJson);
+        let free = vtable_fn!(api, freeJson);
 
         // Safety: the redis json module is initialized at this point
         let ptr = unsafe { alloc_json() };

--- a/src/redisearch_rs/rlookup/src/load_document/json.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/json.rs
@@ -91,6 +91,9 @@ impl DocumentFormat for JsonDocumentFormat<'_> {
             self.japi
                 .open_from_handle(ptr::from_ref(open_key).cast_mut().cast())
         }
+        // If we fail to open the JSON root from the borrowed handle: fall back to
+        // open the document by name.
+        .or_else(|| self.open_key(key_name))
         .ok_or(LoadFieldError::KeyNotFound)?;
 
         Ok(JsonFieldLoader {

--- a/src/redisearch_rs/rlookup/src/load_document/mod.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/mod.rs
@@ -68,6 +68,9 @@ pub enum LoadFieldError {
     /// Failed to open the underlying redis key.
     #[error("Redis API error: {0}")]
     Redis(redis_module::RedisError),
+
+    #[error("attempted to load JSON document, but JSON extension was not loaded.")]
+    JsonUnsupported,
 }
 
 // TODO remove once upstream redis_module::RedisError implements std::error::Error
@@ -85,7 +88,14 @@ impl LoadFieldError {
             Self::WrongKeyType => QueryErrorCode::RedisKeyType,
             Self::JsonSerialization(_) => QueryErrorCode::Generic,
             Self::Redis(_) => QueryErrorCode::Generic,
+            Self::JsonUnsupported => QueryErrorCode::UnsuppType,
         }
+    }
+
+    /// Whether this error is the expected outcome of a document being deleted,
+    /// expiring, or changing type between the iterator and the loader.
+    pub const fn is_stale_document(&self) -> bool {
+        matches!(self, Self::KeyNotFound | Self::WrongKeyType)
     }
 }
 
@@ -104,8 +114,15 @@ pub enum LoadAllError {
     JsonSerialization(#[from] redis_json_api::SerializeError),
 }
 
+impl LoadAllError {
+    /// Whether this error is the expected outcome of a document being deleted,
+    /// expiring, or changing type between the iterator and the loader.
+    pub const fn is_stale_document(&self) -> bool {
+        matches!(self, Self::OpenKeyFailed | Self::JsonRootMissing)
+    }
+}
+
 pub struct DocumentLoader<'env, 'a, F: DocumentFormat> {
-    rlookup: &'env mut RLookup<'a>,
     dst_row: &'env mut RLookupRow<'a>,
     ctx: NonNull<ffi::RedisModuleCtx>,
     force_load: bool,
@@ -154,7 +171,6 @@ pub trait FieldLoader {
 
 impl<'env, 'a, F: DocumentFormat> DocumentLoader<'env, 'a, F> {
     pub fn new(
-        rlookup: &'env mut RLookup<'a>,
         dst_row: &'env mut RLookupRow<'a>,
         ctx: NonNull<ffi::RedisModuleCtx>,
         dmd: &'a DocumentMetadata,
@@ -170,7 +186,6 @@ impl<'env, 'a, F: DocumentFormat> DocumentLoader<'env, 'a, F> {
         dst_row.set_sorting_vector(Some(sorting_vector));
 
         Self {
-            rlookup,
             dst_row,
             ctx,
             force_load: false,
@@ -213,12 +228,14 @@ impl<'env, 'a, F: DocumentFormat> DocumentLoader<'env, 'a, F> {
     /// be preferred if you need to load all keys in an rlookup.
     ///
     /// `Self::force_load` has **no effect** on this method, all keys are always loaded anyways.
-    pub fn load_all(self) -> Result<(), LoadAllError> {
-        self.format.load_all(
-            self.rlookup,
-            self.dst_row,
-            &self.dmd.key_name(Some(self.ctx)),
-        )
+    ///
+    /// Unlike [`Self::load_specific`], this needs `&mut RLookup` because it may create new keys on
+    /// the fly. It is taken here rather than held by the loader so the per-field
+    /// [`Self::load_specific`] path never carries a mutable borrow that could alias caller-supplied
+    /// key references.
+    pub fn load_all(self, rlookup: &mut RLookup) -> Result<(), LoadAllError> {
+        self.format
+            .load_all(rlookup, self.dst_row, &self.dmd.key_name(Some(self.ctx)))
     }
 }
 

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -10,13 +10,20 @@
 mod key;
 mod key_list;
 
+use crate::HashDocumentFormat;
+use crate::JsonDocumentFormat;
+use crate::LoadFieldError;
 use crate::{
     IndexSpec, RLookupRow,
     bindings::{FieldSpec, FieldSpecOption, FieldSpecOptions, IndexSpecCache},
+    load_document,
 };
+use document::DocumentType;
 use enumflags2::{BitFlags, bitflags};
 use key_list::KeyList;
-use std::{borrow::Cow, ffi::CStr, pin::Pin, ptr};
+use redis_json_api::RedisJsonApi;
+use redis_module::RedisString;
+use std::{borrow::Cow, ffi::CStr, pin::Pin, ptr::NonNull};
 
 pub use key::{GET_KEY_FLAGS, RLookupKey, RLookupKeyFlag, RLookupKeyFlags, TRANSIENT_FLAGS};
 pub use key_list::{Cursor, CursorMut, Iter, IterMut};
@@ -397,39 +404,89 @@ impl<'a> RLookup<'a> {
         self.keys.rowlen
     }
 
+    /// Returns the schema-source keys eligible for individual document loading.
+    ///
+    /// Mirrors the C `loadIndividualKeys` selection for the "load every loadable
+    /// key" case (`nkeys == 0`): only keys flagged [`RLookupKeyFlag::SchemaSrc`]
+    /// are considered, and when `cached_only` is set without `force_load` the set
+    /// is further restricted to keys backed by the sorting vector
+    /// ([`RLookupKeyFlag::SvSrc`]).
+    pub fn schema_src_keys(
+        &self,
+        cached_only: bool,
+        force_load: bool,
+    ) -> impl Iterator<Item = &RLookupKey<'a>> {
+        self.iter()
+            .filter(|k| k.flags.contains(RLookupKeyFlag::SchemaSrc))
+            .filter(move |k| !cached_only || force_load || k.flags.contains(RLookupKeyFlag::SvSrc))
+    }
+
+    /// `open_key`, when `Some`, is an already-open handle for `key_name` that the loader
+    /// reuses instead of opening the document by name; it is borrowed, not closed here.
     pub fn load_rule_fields(
         &mut self,
         search_ctx: &mut ffi::RedisSearchCtx,
         dst_row: &mut RLookupRow<'a>,
         index_spec: &'a IndexSpec,
-        key: &CStr,
-        open_key: *mut ffi::RedisModuleKey,
-        status: &mut ffi::QueryError,
-    ) -> i32 {
-        let keys = create_keys_from_spec(index_spec);
-        let pushed_keys = keys.into_iter().map(|k| self.keys.push(k)).collect();
-        load_specific_keys(
-            self,
-            search_ctx,
-            dst_row,
-            index_spec,
-            key,
-            open_key,
-            pushed_keys,
-            status,
-        )
+        key_name: &CStr,
+        open_key: Option<&ffi::RedisModuleKey>,
+    ) -> Result<(), LoadFieldError> {
+        // NB: eagerly consume the entire iterator, so the **side-effect-full* `self.keys.push` happens
+        // for every key.
+        let keys_to_load: Vec<_> = create_keys_from_spec(index_spec)
+            .map(|k| self.keys.push(k))
+            .collect();
+
+        let key_name =
+            RedisString::create_from_slice(search_ctx.redisCtx.cast(), key_name.to_bytes());
+
+        match index_spec.rule().type_() {
+            DocumentType::Hash => {
+                let format =
+                    HashDocumentFormat::new(NonNull::new(search_ctx.redisCtx).unwrap(), false);
+
+                load_document::load_specific_keys(
+                    &format,
+                    dst_row,
+                    &key_name,
+                    keys_to_load,
+                    true,
+                    open_key,
+                )
+            }
+            DocumentType::Json => {
+                // Safety: this function will be called long after module initialization
+                let japi = unsafe { RedisJsonApi::get().ok_or(LoadFieldError::JsonUnsupported) }?;
+
+                let format = JsonDocumentFormat::new(
+                    NonNull::new(search_ctx.redisCtx).unwrap(),
+                    &japi,
+                    search_ctx.apiVersion,
+                );
+
+                load_document::load_specific_keys(
+                    &format,
+                    dst_row,
+                    &key_name,
+                    keys_to_load,
+                    true,
+                    open_key,
+                )
+            }
+            DocumentType::Unsupported => unimplemented!("unsupported document type"),
+        }
     }
 }
 
-fn create_keys_from_spec<'a>(index_spec: &'a IndexSpec) -> Vec<RLookupKey<'a>> {
-    // TODO: Consider returning `impl Iterator` in order to avoid the `collect()` allocation below, refer to Jira ticket MOD-13907.
+fn create_keys_from_spec<'a>(
+    index_spec: &'a IndexSpec,
+) -> impl ExactSizeIterator<Item = RLookupKey<'a>> {
     let rule = index_spec.rule();
     let field_specs = index_spec.field_specs();
     rule.filter_fields_index()
         .iter()
         .zip(rule.filter_fields())
         .map(|(&index, filter_field)| create_key_from_data(index, filter_field, field_specs))
-        .collect::<Vec<_>>()
 }
 
 fn create_key_from_data<'a>(
@@ -448,51 +505,6 @@ fn create_key_from_data<'a>(
 
         RLookupKey::new_with_path(field_name, path, RLookupKeyFlags::empty())
     }
-}
-
-#[expect(
-    clippy::too_many_arguments,
-    reason = "thin wrapper that forwards its distinct inputs into the `RLookupLoadOptions` FFI struct"
-)]
-fn load_specific_keys<'a>(
-    lookup: &mut RLookup<'a>,
-    search_ctx: &mut ffi::RedisSearchCtx,
-    dst_row: &mut RLookupRow<'a>,
-    index_spec: &IndexSpec,
-    key: &CStr,
-    open_key: *mut ffi::RedisModuleKey,
-    keys: Vec<Pin<&mut RLookupKey>>,
-    status: &mut ffi::QueryError,
-) -> i32 {
-    let lookup = lookup.as_opaque_mut_ptr().cast::<ffi::RLookup>();
-    let dst_row = ptr::from_mut(dst_row).cast::<ffi::RLookupRow>();
-
-    let mut keys = keys
-        .into_iter()
-        .map(|k| {
-            // Safety: `ffi::RLookupLoadOptions` requires a mutable pointer to the key array. We have full control over these keys as we handle them in the keylist. The following statements are not optimal, but will have to do for now.
-            let k = unsafe { Pin::into_inner_unchecked(k.into_ref()) };
-            ptr::from_ref(k).cast::<ffi::RLookupKey>()
-        })
-        .collect::<Vec<_>>();
-
-    let mut options = ffi::RLookupLoadOptions {
-        keys: keys.as_mut_ptr(),
-        nkeys: keys.len(),
-        sctx: ptr::from_mut(search_ctx),
-        keyPtr: key.as_ptr(),
-        openKey: open_key,
-        type_: index_spec.rule().type_(),
-        status: ptr::from_mut(status),
-        forceLoad: true,
-        cachedOnly: false,
-        dmd: ptr::null(),
-        forceString: false,
-        profileFields: ptr::null_mut(),
-    };
-
-    // Safety: All pointers passed to this function are non-null and properly aligned since we created them above in this function.
-    unsafe { ffi::loadIndividualKeys(lookup, dst_row, &mut options) }
 }
 
 pub mod opaque {
@@ -1290,19 +1302,22 @@ mod tests {
         let index_spec = unsafe { IndexSpec::from_raw(&raw const index_spec) };
 
         // Act
-        let actual = super::create_keys_from_spec(index_spec);
+        let mut actual = super::create_keys_from_spec(index_spec);
 
         // Assert
         assert_eq!(actual.len(), 3);
 
-        assert_eq!(actual[0].name(), c"ff0");
-        assert_eq!(actual[0].path(), &Some(c"ff0".into()));
+        let key = actual.next().unwrap();
+        assert_eq!(key.name(), c"ff0");
+        assert_eq!(key.path(), &Some(c"ff0".into()));
 
-        assert_eq!(actual[1].name(), c"fn0");
-        assert_eq!(actual[1].path(), &Some(c"fp0".into()));
+        let key = actual.next().unwrap();
+        assert_eq!(key.name(), c"fn0");
+        assert_eq!(key.path(), &Some(c"fp0".into()));
 
-        assert_eq!(actual[2].name(), c"fn1");
-        assert_eq!(actual[2].path(), &Some(c"fp1".into()));
+        let key = actual.next().unwrap();
+        assert_eq!(key.name(), c"fn1");
+        assert_eq!(key.path(), &Some(c"fp1".into()));
 
         // Clean up
         unsafe { ffi::array_free(schema_rule.filter_fields.cast()) };
@@ -1340,5 +1355,80 @@ mod tests {
         res.fieldPath =
             unsafe { ffi::NewHiddenString(field_path.as_ptr(), field_path.count_bytes(), false) };
         res
+    }
+
+    /// Build an [`RLookup`] whose key list mirrors the selection cases exercised by
+    /// `schema_src_keys`: a non-schema key (must never be selected), a schema key
+    /// without a sorting-vector source, and a schema key with one.
+    fn rlookup_with_selection_keys<'a>() -> RLookup<'a> {
+        let mut rlookup = RLookup::new();
+        rlookup.keys.push(RLookupKey::new(
+            c"query_only",
+            make_bitflags!(RLookupKeyFlag::QuerySrc),
+        ));
+        rlookup.keys.push(RLookupKey::new(
+            c"schema_no_sv",
+            make_bitflags!(RLookupKeyFlag::SchemaSrc),
+        ));
+        rlookup.keys.push(RLookupKey::new(
+            c"schema_sv",
+            make_bitflags!(RLookupKeyFlag::{SchemaSrc | SvSrc}),
+        ));
+        rlookup
+    }
+
+    fn selected_names<'a>(
+        rlookup: &'a RLookup<'a>,
+        cached_only: bool,
+        force_load: bool,
+    ) -> Vec<CString> {
+        rlookup
+            .schema_src_keys(cached_only, force_load)
+            .map(|k| k.name().as_ref().to_owned())
+            .collect()
+    }
+
+    // Non-schema keys (e.g. QuerySrc) are never selected for individual loading.
+    #[test]
+    fn schema_src_keys_excludes_non_schema_keys() {
+        let rlookup = rlookup_with_selection_keys();
+        let names = selected_names(&rlookup, false, false);
+        assert_eq!(
+            names,
+            vec![c"schema_no_sv".to_owned(), c"schema_sv".to_owned()]
+        );
+    }
+
+    // `cached_only && !force_load` restricts the selection to sorting-vector-backed keys.
+    #[test]
+    fn schema_src_keys_cached_only_restricts_to_sv_src() {
+        let rlookup = rlookup_with_selection_keys();
+        let names = selected_names(&rlookup, true, false);
+        assert_eq!(names, vec![c"schema_sv".to_owned()]);
+    }
+
+    // `force_load` overrides `cached_only`: all schema keys are selected again.
+    #[test]
+    fn schema_src_keys_force_load_overrides_cached_only() {
+        let rlookup = rlookup_with_selection_keys();
+        let names = selected_names(&rlookup, true, true);
+        assert_eq!(
+            names,
+            vec![c"schema_no_sv".to_owned(), c"schema_sv".to_owned()]
+        );
+    }
+
+    // Without `cached_only`, the SvSrc flag has no effect on the selection.
+    #[test]
+    fn schema_src_keys_not_cached_only_ignores_sv_src() {
+        let rlookup = rlookup_with_selection_keys();
+        assert_eq!(
+            selected_names(&rlookup, false, true),
+            vec![c"schema_no_sv".to_owned(), c"schema_sv".to_owned()]
+        );
+        assert_eq!(
+            selected_names(&rlookup, false, false),
+            vec![c"schema_no_sv".to_owned(), c"schema_sv".to_owned()]
+        );
     }
 }

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -452,6 +452,7 @@ impl<'a> RLookup<'a> {
                     keys_to_load,
                     true,
                     open_key,
+                    None,
                 )
             }
             DocumentType::Json => {
@@ -471,6 +472,7 @@ impl<'a> RLookup<'a> {
                     keys_to_load,
                     true,
                     open_key,
+                    None,
                 )
             }
             DocumentType::Unsupported => unimplemented!("unsupported document type"),

--- a/src/redisearch_rs/rlookup/src/lookup/key.rs
+++ b/src/redisearch_rs/rlookup/src/lookup/key.rs
@@ -10,7 +10,7 @@
 use std::{
     borrow::Cow,
     ffi::{CStr, c_char},
-    mem,
+    fmt, mem,
     ops::{Deref, DerefMut},
     pin::Pin,
     ptr::{self, NonNull},
@@ -139,7 +139,6 @@ pub const TRANSIENT_FLAGS: RLookupKeyFlags =
 ///
 #[cheadergen::config(skip)]
 #[pin_project(!Unpin)]
-#[derive(Debug)]
 #[repr(C)]
 pub struct RLookupKey<'a> {
     /// RLookupKey fields exposed to C.
@@ -154,6 +153,14 @@ pub struct RLookupKey<'a> {
     _name: Cow<'a, CStr>,
     #[pin]
     _path: Option<Cow<'a, CStr>>,
+}
+
+impl fmt::Debug for RLookupKey<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RLookupKey")
+            .field("header", &self.header)
+            .finish_non_exhaustive()
+    }
 }
 
 #[cheadergen::config(export, rename = "RLookupKey")]

--- a/src/redisearch_rs/rlookup/src/row.rs
+++ b/src/redisearch_rs/rlookup/src/row.rs
@@ -11,7 +11,7 @@ use crate::{
     RLookup, RLookupKey, RLookupKeyFlag, RLookupKeyFlags, SchemaRule, lookup::TRANSIENT_FLAGS,
 };
 use sorting_vector::{RSSortingVector, RSSortingVectorRef};
-use std::{borrow::Cow, ffi::CStr};
+use std::{borrow::Cow, ffi::CStr, fmt};
 use thin_vec::ThinVec;
 use value::SharedValue;
 
@@ -31,7 +31,6 @@ fn is_special_key(rule: &SchemaRule, key: &RLookupKey) -> bool {
 /// Force this internal type to opaque so cheadergen does not warn about it
 /// being reached by value through `SearchResult._row_data` — both names emit
 /// to the same C tag, and the wrapper provides the actual layout.
-#[derive(Debug)]
 #[cheadergen::config(export, opaque)]
 pub struct RLookupRow<'a> {
     /// A reference to the sorting vector.
@@ -43,6 +42,16 @@ pub struct RLookupRow<'a> {
     /// The number of values in [`RLookupRow::dyn_values`] that are `is_some()`. Note that this
     /// is not the length of [`RLookupRow::dyn_values`]
     num_dyn_values: u32,
+}
+
+impl fmt::Debug for RLookupRow<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // NB: we purposefully DO NOT include the sorting_vector and dyn_values fields here,
+        // so we don't accidentally leak user-data into log messages!
+        f.debug_struct("RLookupRow")
+            .field("num_dyn_values", &self.num_dyn_values)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'a> Default for RLookupRow<'a> {

--- a/src/redisearch_rs/rlookup/tests/load_document_json.proptest-regressions
+++ b/src/redisearch_rs/rlookup/tests/load_document_json.proptest-regressions
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc a5427da3a7280c6d9af3700e3a20a1e6e298a17a28b7449bd903b50ed3d4a1af # shrinks to scalar = Null

--- a/src/redisearch_rs/rlookup/tests/load_document_json.rs
+++ b/src/redisearch_rs/rlookup/tests/load_document_json.rs
@@ -24,7 +24,7 @@
 
 use proptest::prelude::{Just, Strategy, any, prop_oneof};
 use proptest::proptest;
-use redis_json_api::mock::with_json_api;
+use redis_json_api::mock::{with_json_api, with_json_api_broken_handle};
 use redis_module::RedisString;
 use rlookup::{
     DocumentFormat, FieldLoader, JsonDocumentFormat, LoadAllError, RLookup, RLookupKeyFlags,
@@ -364,5 +364,34 @@ fn borrow_loads_field_like_open() {
             ffi::japi = saved_api;
             ffi::japi_ver = saved_ver;
         }
+    });
+}
+
+/// When the borrowed handle cannot be resolved to a JSON root, `borrow` must fall
+/// back to opening the document by name.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn borrow_falls_back_to_open_by_name() {
+    redis_mock::init_redis_module_mock();
+    with_json_api_broken_handle(Some(json!({ "name": "alice" })), |japi, ctx| {
+        let format = JsonDocumentFormat::new(ctx, &japi, PRE_MULTI);
+        let key_name = make_redis_string(c"doc:1");
+
+        let mut rlookup = RLookup::new();
+        let key = rlookup
+            .get_key_load(c"$.name", c"$.name", RLookupKeyFlags::empty())
+            .unwrap();
+        let mut row = RLookupRow::new();
+
+        // The mock models the pinned handle by the context pointer.
+        // Safety: the mock resolves the handle to the document root.
+        let open_key = unsafe { ctx.cast::<ffi::RedisModuleKey>().as_ref() };
+        format
+            .borrow(open_key, &key_name)
+            .expect("borrow should fall back to open-by-name")
+            .load_field(key, &mut row)
+            .unwrap();
+
+        assert_eq!(row.get(key).unwrap().as_str_bytes(), Some(&b"alice"[..]));
     });
 }

--- a/src/redisearch_rs/rlookup/tests/load_document_json.rs
+++ b/src/redisearch_rs/rlookup/tests/load_document_json.rs
@@ -328,7 +328,7 @@ fn borrow_loads_field_like_open() {
         // Safety: the test is single-threaded and the mock vtable is 'static.
         let (saved_api, saved_ver) = unsafe { (ffi::japi, ffi::japi_ver) };
         unsafe {
-            ffi::japi = std::ptr::from_ref(japi.vtable()).cast_mut();
+            ffi::japi = japi.vtable().as_ptr();
             ffi::japi_ver = redis_json_api::LATEST_API_VERSION;
         }
 


### PR DESCRIPTION
Now that we have decided to merge #8631 _after_ the release window AND I had to port the profiling changes, I decided to split out the standalone cleanup changes I made addressing the reviews comments into its own Pr so we can merge it ahead of time.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
