### PR TITLE
Add dropindex writer contention benchmark

### DIFF
--- a/tests/benchmarks/disabled/search-dropindex-keepdocs-gil-writer-contention.yml
+++ b/tests/benchmarks/disabled/search-dropindex-keepdocs-gil-writer-contention.yml
@@ -1,0 +1,53 @@
+version: 0.5
+name: "search-dropindex-keepdocs-gil-writer-contention"
+description: |
+  FT.DROPINDEX KEEPDOCS writer contention benchmark.
+
+  The setup stream creates 10K HASH indexes and loads 500 documents per index.
+  The benchmark stream then repeats:
+  1. Drop one known index with FT._DROPINDEXIFX and _FORCEKEEPDOCS.
+  2. Run 100 short foreground INCR writes.
+
+  This deterministic sequence keeps foreground writers adjacent to background
+  index cleanup and prevents a writer-only tail after all indexes are dropped.
+
+metadata:
+  component: "search"
+  use_case: "FT.DROPINDEX KEEPDOCS background cleanup and main-thread writer contention"
+  index_count: 10000
+  docs_per_index: 500
+  doc_count: 5000000
+  writes_per_drop: 100
+
+timeout_seconds: 3600
+dataset_load_timeout_secs: 7200
+
+setups:
+  - oss-standalone
+
+dbconfig:
+  - dataset_name: "dropindex-keepdocs-gil-10K-indexes-500-docs"
+  - redis-topologies:
+      - oss-standalone
+  - configuration-parameters:
+    - save: '""'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 1
+    - requests: 0
+    - pipeline: 1
+    - reporting-period: 5s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/dropindex-keepdocs-gil-10K-indexes-500-docs/dropindex-keepdocs-gil-10K-indexes-500-docs.redisearch.commands.SETUP.csv"
+  - dataset_load_timeout_secs: 7200
+  - check:
+      keyspacelen: 5000000
+
+clientconfig:
+  - benchmark_type: "mixed"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 1
+    - requests: 0
+    - pipeline: 1
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/dropindex-keepdocs-gil-10K-indexes-500-docs/dropindex-keepdocs-gil-10K-indexes-500-docs.redisearch.commands.BENCH.csv"

--- a/tests/benchmarks/scripts/README.md
+++ b/tests/benchmarks/scripts/README.md
@@ -153,9 +153,45 @@ redis-cli -p 6379 FT.CREATE ms_marco_idx ON HASH PREFIX 1 doc: SCHEMA \
 
 ---
 
+# Dropindex KEEPDOCS Writer Contention Dataset
+
+Generate the dataset used by
+`tests/benchmarks/disabled/search-dropindex-keepdocs-gil-writer-contention.yml`.
+
+The default dataset creates 10K HASH indexes, loads 500 documents per index
+(5M HASH keys), then generates a deterministic benchmark stream where every
+`FT._DROPINDEXIFX ... _FORCEKEEPDOCS` is immediately followed by 100 short
+foreground `INCR` writes. The deterministic stream keeps those writes adjacent
+to background cleanup and avoids measuring a writer-only tail after all indexes
+are dropped.
+
+```bash
+python3 generate_dropindex_writer_contention_dataset.py \
+  --output-dir ./output/dropindex-keepdocs-gil-10K-indexes-500-docs
+
+./upload_to_s3.sh \
+  dropindex-keepdocs-gil-10K-indexes-500-docs \
+  ./output/dropindex-keepdocs-gil-10K-indexes-500-docs
+```
+
+After uploading both the SETUP and BENCH files, move the benchmark YAML out of
+`tests/benchmarks/disabled/` to enable it in the regular benchmark runner.
+
+For local smoke testing, scale the workload down:
+
+```bash
+python3 generate_dropindex_writer_contention_dataset.py \
+  --dataset-name dropindex-keepdocs-gil-smoke \
+  --index-count 10 \
+  --docs-per-index 50 \
+  --writes-per-drop 10 \
+  --output-dir ./output/dropindex-keepdocs-gil-smoke
+```
+
+---
+
 ## References
 
 - [ir-datasets: msmarco-document-v2](https://ir-datasets.com/msmarco-document-v2.html)
 - [ftsb - Full-Text Search Benchmark](https://github.com/RediSearch/ftsb)
 - Confluence: "Performance Search - Load & Index measurements"
-

--- a/tests/benchmarks/scripts/generate_dropindex_writer_contention_dataset.py
+++ b/tests/benchmarks/scripts/generate_dropindex_writer_contention_dataset.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2006-Present, Redis Ltd.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+# GNU Affero General Public License v3 (AGPLv3).
+
+"""
+Generate an FTSB workload for FT.DROPINDEX KEEPDOCS cleanup contention.
+
+The setup stream creates many small HASH indexes and loads documents into their
+matching prefixes. The benchmark stream then drops each index with forced
+KEEPDOCS semantics and immediately runs a bounded batch of short foreground
+Redis writes. This keeps the measured writer workload adjacent to background
+index cleanup and avoids a long writer-only tail after all indexes are gone.
+"""
+
+import argparse
+import csv
+from pathlib import Path
+
+
+DEFAULT_DATASET_NAME = "dropindex-keepdocs-gil-10K-indexes-500-docs"
+DEFAULT_INDEX_COUNT = 10_000
+DEFAULT_DOCS_PER_INDEX = 500
+DEFAULT_WRITES_PER_DROP = 100
+DEFAULT_PAYLOAD_BYTES = 64
+
+
+def positive_int(value):
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value!r}")
+    return parsed
+
+
+def non_negative_int(value):
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError(f"expected a non-negative integer, got {value!r}")
+    return parsed
+
+
+def make_payload(index_id, doc_id, payload_bytes):
+    if payload_bytes == 0:
+        return ""
+
+    token = f"dropindex-gil idx-{index_id} doc-{doc_id} "
+    repeats = payload_bytes // len(token) + 1
+    return (token * repeats)[:payload_bytes]
+
+
+def write_setup_file(output_file, index_count, docs_per_index, payload_bytes):
+    with output_file.open("w", encoding="utf-8", newline="") as outfile:
+        writer = csv.writer(outfile, quoting=csv.QUOTE_ALL)
+
+        for index_id in range(1, index_count + 1):
+            writer.writerow(
+                [
+                    "WRITE",
+                    "create-index",
+                    "1",
+                    "FT.CREATE",
+                    f"idx:{index_id}",
+                    "ON",
+                    "HASH",
+                    "PREFIX",
+                    "1",
+                    f"doc:{index_id}:",
+                    "SCHEMA",
+                    "body",
+                    "TEXT",
+                ]
+            )
+
+        for index_id in range(1, index_count + 1):
+            for doc_id in range(1, docs_per_index + 1):
+                writer.writerow(
+                    [
+                        "WRITE",
+                        "load-doc",
+                        "1",
+                        "HSET",
+                        f"doc:{index_id}:{doc_id}",
+                        "body",
+                        make_payload(index_id, doc_id, payload_bytes),
+                    ]
+                )
+
+
+def write_benchmark_file(output_file, index_count, writes_per_drop):
+    with output_file.open("w", encoding="utf-8", newline="") as outfile:
+        writer = csv.writer(outfile, quoting=csv.QUOTE_ALL)
+
+        for index_id in range(1, index_count + 1):
+            writer.writerow(
+                [
+                    "WRITE",
+                    "drop-index",
+                    "1",
+                    "FT._DROPINDEXIFX",
+                    f"idx:{index_id}",
+                    "_FORCEKEEPDOCS",
+                ]
+            )
+
+            for write_id in range(1, writes_per_drop + 1):
+                writer.writerow(
+                    [
+                        "WRITE",
+                        "foreground-write",
+                        "1",
+                        "INCR",
+                        f"writer:{index_id}:{write_id}",
+                    ]
+                )
+
+
+def generate_files(
+    output_dir,
+    dataset_name,
+    index_count,
+    docs_per_index,
+    writes_per_drop,
+    payload_bytes,
+):
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    setup_file = output_dir / f"{dataset_name}.redisearch.commands.SETUP.csv"
+    benchmark_file = output_dir / f"{dataset_name}.redisearch.commands.BENCH.csv"
+
+    write_setup_file(setup_file, index_count, docs_per_index, payload_bytes)
+    write_benchmark_file(benchmark_file, index_count, writes_per_drop)
+
+    return setup_file, benchmark_file
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate RediSearch FT.DROPINDEX KEEPDOCS writer contention benchmark data."
+    )
+    parser.add_argument("--output-dir", type=Path, default=Path("./output"))
+    parser.add_argument("--dataset-name", default=DEFAULT_DATASET_NAME)
+    parser.add_argument("--index-count", type=positive_int, default=DEFAULT_INDEX_COUNT)
+    parser.add_argument("--docs-per-index", type=positive_int, default=DEFAULT_DOCS_PER_INDEX)
+    parser.add_argument("--writes-per-drop", type=positive_int, default=DEFAULT_WRITES_PER_DROP)
+    parser.add_argument("--payload-bytes", type=non_negative_int, default=DEFAULT_PAYLOAD_BYTES)
+    args = parser.parse_args()
+
+    setup_file, benchmark_file = generate_files(
+        args.output_dir,
+        args.dataset_name,
+        args.index_count,
+        args.docs_per_index,
+        args.writes_per_drop,
+        args.payload_bytes,
+    )
+
+    setup_commands = args.index_count + (args.index_count * args.docs_per_index)
+    benchmark_commands = args.index_count * (args.writes_per_drop + 1)
+
+    print("Dataset generation complete")
+    print(f"  Dataset: {args.dataset_name}")
+    print(f"  Indexes: {args.index_count:,}")
+    print(f"  Documents: {args.index_count * args.docs_per_index:,}")
+    print(f"  Setup commands: {setup_commands:,}")
+    print(f"  Benchmark commands: {benchmark_commands:,}")
+    print(f"  Setup file: {setup_file}")
+    print(f"  Benchmark file: {benchmark_file}")
+    print(
+        "  Upload: "
+        f"aws s3 cp {args.output_dir}/ "
+        f"s3://benchmarks.redislabs/redisearch/datasets/{args.dataset_name}/ --recursive"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/scripts/test_generate_dropindex_writer_contention_dataset.py
+++ b/tests/benchmarks/scripts/test_generate_dropindex_writer_contention_dataset.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2006-Present, Redis Ltd.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+# GNU Affero General Public License v3 (AGPLv3).
+
+import csv
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("generate_dropindex_writer_contention_dataset.py")
+
+
+def load_generator_module():
+    if not SCRIPT.exists():
+        raise AssertionError(f"generator script does not exist: {SCRIPT}")
+
+    spec = importlib.util.spec_from_file_location("generate_dropindex_writer_contention_dataset", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_rows(path):
+    with path.open(newline="", encoding="utf-8") as infile:
+        return list(csv.reader(infile))
+
+
+class GenerateDropIndexWriterContentionDatasetTest(unittest.TestCase):
+    def test_setup_file_creates_indexes_before_loading_documents(self):
+        generator = load_generator_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            setup_file = Path(tmp) / "setup.csv"
+            generator.write_setup_file(
+                setup_file,
+                index_count=2,
+                docs_per_index=3,
+                payload_bytes=12,
+            )
+
+            rows = read_rows(setup_file)
+
+        self.assertEqual(8, len(rows))
+        self.assertEqual(
+            [
+                "WRITE",
+                "create-index",
+                "1",
+                "FT.CREATE",
+                "idx:1",
+                "ON",
+                "HASH",
+                "PREFIX",
+                "1",
+                "doc:1:",
+                "SCHEMA",
+                "body",
+                "TEXT",
+            ],
+            rows[0],
+        )
+        self.assertEqual("FT.CREATE", rows[1][3])
+        self.assertEqual(["WRITE", "load-doc", "1", "HSET", "doc:1:1", "body"], rows[2][:6])
+        self.assertEqual(12, len(rows[2][6]))
+        self.assertEqual(["WRITE", "load-doc", "1", "HSET", "doc:2:3", "body"], rows[-1][:6])
+
+    def test_benchmark_file_interleaves_each_drop_with_bounded_writer_batch(self):
+        generator = load_generator_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bench_file = Path(tmp) / "bench.csv"
+            generator.write_benchmark_file(
+                bench_file,
+                index_count=2,
+                writes_per_drop=2,
+            )
+
+            rows = read_rows(bench_file)
+
+        self.assertEqual(
+            [
+                ["WRITE", "drop-index", "1", "FT._DROPINDEXIFX", "idx:1", "_FORCEKEEPDOCS"],
+                ["WRITE", "foreground-write", "1", "INCR", "writer:1:1"],
+                ["WRITE", "foreground-write", "1", "INCR", "writer:1:2"],
+                ["WRITE", "drop-index", "1", "FT._DROPINDEXIFX", "idx:2", "_FORCEKEEPDOCS"],
+                ["WRITE", "foreground-write", "1", "INCR", "writer:2:1"],
+                ["WRITE", "foreground-write", "1", "INCR", "writer:2:2"],
+            ],
+            rows,
+        )
+
+    def test_generate_files_uses_expected_benchmark_names(self):
+        generator = load_generator_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            setup_file, benchmark_file = generator.generate_files(
+                Path(tmp),
+                dataset_name="tiny-dropindex-gil",
+                index_count=1,
+                docs_per_index=1,
+                writes_per_drop=1,
+                payload_bytes=8,
+            )
+
+            self.assertTrue(setup_file.exists())
+            self.assertTrue(benchmark_file.exists())
+            self.assertEqual(
+                "tiny-dropindex-gil.redisearch.commands.SETUP.csv",
+                setup_file.name,
+            )
+            self.assertEqual(
+                "tiny-dropindex-gil.redisearch.commands.BENCH.csv",
+                benchmark_file.name,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a macrobenchmark dataset generator for `FT.DROPINDEX` KEEPDOCS cleanup contention with foreground Redis writers.
- Generate a deterministic FTSB dataset that creates 10K HASH indexes, loads 500 docs per index, then repeats: drop one index with forced KEEPDOCS semantics and immediately run 100 short `INCR` writes.
- Keep the benchmark YAML under `tests/benchmarks/disabled/` until the generated SETUP and BENCH CSV files are uploaded to the public benchmark dataset bucket.

## Scope
This benchmark is intentionally writer-only. It does not include `FT.SEARCH` commands; the goal is to measure foreground Redis write behavior while background KEEPDOCS cleanup holds the GIL in short batches. Search-side impact should be covered by a separate benchmark if we decide to measure it.

## Why
PR #10561 changes the index cleanup path to prune document-id metadata in the background while taking the Redis GIL for short batches. This benchmark gives us a master baseline for foreground writer behavior while that background cleanup is running.

The benchmark stream is deterministic instead of probability-based: it drops one known index, runs a bounded writer batch, then moves to the next index. That keeps measured foreground writes adjacent to cleanup and avoids measuring a writer-only tail after all indexes have already been deleted.

## Validation
- `python3 tests/benchmarks/scripts/test_generate_dropindex_writer_contention_dataset.py -v`
- `python3 -m py_compile tests/benchmarks/scripts/generate_dropindex_writer_contention_dataset.py tests/benchmarks/scripts/test_generate_dropindex_writer_contention_dataset.py`
- Parsed `tests/benchmarks/disabled/search-dropindex-keepdocs-gil-writer-contention.yml` with `yaml.safe_load` and asserted key metadata/parameters.
- Generated a tiny 3-index sample and confirmed benchmark rows drop each index and run only the expected foreground `INCR` writes.

## Operational note
The YAML points at the intended public S3 dataset path, but it is intentionally disabled until the full dataset is generated and uploaded:

```bash
python3 tests/benchmarks/scripts/generate_dropindex_writer_contention_dataset.py \
  --output-dir ./output/dropindex-keepdocs-gil-10K-indexes-500-docs

./tests/benchmarks/scripts/upload_to_s3.sh \
  dropindex-keepdocs-gil-10K-indexes-500-docs \
  ./output/dropindex-keepdocs-gil-10K-indexes-500-docs
```

After both files are uploaded, move `tests/benchmarks/disabled/search-dropindex-keepdocs-gil-writer-contention.yml` back to `tests/benchmarks/` to enable the benchmark runner.

## Release notes
- [ ] This PR requires release notes
- [x] This PR does not require release notes
