### PR TITLE
[MOD-17314] Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/build-redis/action.yml
+++ b/.github/actions/build-redis/action.yml
@@ -77,7 +77,7 @@ runs:
 
     - name: Restore cached Redis
       id: cache-restore
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
       with:
         path: ${{ steps.resolve.outputs.prefix }}
         key: ${{ steps.key.outputs.key }}
@@ -145,7 +145,7 @@ runs:
 
     - name: Save Redis to cache
       if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
       with:
         path: ${{ steps.resolve.outputs.prefix }}
         key: ${{ steps.key.outputs.key }}

--- a/.github/actions/build-rejson/action.yml
+++ b/.github/actions/build-rejson/action.yml
@@ -77,7 +77,7 @@ runs:
 
     - name: Restore cached RedisJSON
       id: cache-restore
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
       with:
         path: ${{ steps.resolve.outputs.binpath }}
         key: ${{ steps.key.outputs.key }}
@@ -112,7 +112,7 @@ runs:
 
     - name: Save RedisJSON to cache
       if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
       with:
         path: ${{ steps.resolve.outputs.binpath }}
         key: ${{ steps.key.outputs.key }}

--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -25,7 +25,7 @@ runs:
     # Role-based auth
     - name: Configure AWS Credentials Using Role
       if: ${{ inputs.use_role == 'true' }}
-      uses: aws-actions/configure-aws-credentials@v6
+      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
       with:
         role-to-assume: ${{ inputs.role_to_assume }}
         aws-region: ${{ inputs.aws_region }}
@@ -33,7 +33,7 @@ runs:
     # Key-based auth
     - name: Configure AWS Credentials Using Keys
       if: ${{ inputs.use_role != 'true' }}
-      uses: aws-actions/configure-aws-credentials@v6
+      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
       with:
         aws-access-key-id: ${{ inputs.aws_access_key_id }}
         aws-secret-access-key: ${{ inputs.aws_secret_access_key }}

--- a/.github/actions/get-redis/action.yml
+++ b/.github/actions/get-redis/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Get Redis
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       with:
         repository: redis/redis
         ref: ${{ inputs.ref }}

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -176,7 +176,7 @@ runs:
     # Cache Rust packages
     - name: Cache Rust packages
       if: ${{ inputs.rust-cache == 'true' }}
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         prefix-key: ${{ inputs.rust-cache-prefix-key }}
         key: ${{ inputs.rust-cache-key }}

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -25,13 +25,13 @@ runs:
       id: aws-credentials
       if: ${{ inputs.aws-role != '' && inputs.s3-bucket != '' && inputs.s3-region != '' && inputs.s3-key-prefix != '' }}
       continue-on-error: true
-      uses: aws-actions/configure-aws-credentials@v6
+      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
       with:
         role-to-assume: ${{ inputs.aws-role }}
         aws-region: ${{ inputs.s3-region }}
 
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.10
+      uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       with:
         # Disable the post-run stats annotation as it runs outside the
         # container and reports nothing. We show stats ourselves.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+
+# Every third-party action in .github/ is pinned to a commit SHA (enforced by
+# .github/zizmor.yml + .github/workflows/task-zizmor.yml). A pinned SHA never
+# picks up upstream fixes on its own, so Dependabot owns keeping them current —
+# it rewrites both the SHA and the `# v6` trailing comment.
+#
+# Only the actions in this repository are in scope. Dependabot does not descend
+# into the vendored submodules under deps/, which carry their own workflows.
+updates:
+  - package-ecosystem: github-actions
+    directories:
+      - "/"                    # .github/workflows/
+      - "/.github/actions/*"   # our composite actions' action.yml
+    schedule:
+      interval: weekly
+    cooldown:
+      # Don't adopt a release the moment it is published: a compromised version
+      # is usually caught and yanked within days, and we gain nothing from being
+      # first. zizmor's dependabot-cooldown audit wants at least 7 days.
+      default-days: 7
+    groups:
+      # One PR per week for all action bumps rather than ~20 separate ones.
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -63,7 +63,7 @@ jobs:
         shell: bash -l -eo pipefail {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Compute effective benchmark filter
         id: benchmark-filter
         working-directory: tests/benchmarks
@@ -107,7 +107,7 @@ jobs:
           github_token: ${{ github.token }}
       - name: Download prebuilt redisearch.so
         if: steps.benchmark-filter.outputs.skip != 'true'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: ${{ inputs.binary_artifact_name }}
           # Place the .so where `inputs.module_path` expects it, e.g.
@@ -127,7 +127,7 @@ jobs:
           python3 -m pip install -r tests/benchmarks/requirements.txt
       - name: install terraform
         if: steps.benchmark-filter.outputs.skip != 'true'
-        uses: hashicorp/setup-terraform@v4.0.1
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: 1.11.1
           terraform_wrapper: false

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -391,7 +391,7 @@ jobs:
       triage-exists: ${{ steps.triage.outputs.triage-exists }}
       triage-content-json: ${{ steps.triage.outputs.triage-content-json }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/fetch-failed-run-logs
         with:
           github-token: ${{ github.token }}
@@ -444,7 +444,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}
           webhook-type: webhook-trigger
@@ -463,7 +463,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify MSMARCO Benchmark Failure
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_MSMARCO_BENCHMARK_FAILED }}
           webhook-type: webhook-trigger

--- a/.github/workflows/daily-ci-report.yml
+++ b/.github/workflows/daily-ci-report.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.x'
 
@@ -106,7 +106,7 @@ jobs:
 
       - name: Send reports to Slack
         if: always()
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_RESULT }}
           webhook-type: incoming-webhook
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ci-reports-${{ steps.date.outputs.date }}
           path: |

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -32,7 +32,7 @@ jobs:
       triage-exists: ${{ steps.triage.outputs.triage-exists }}
       triage-content-json: ${{ steps.triage.outputs.triage-content-json }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/fetch-failed-run-logs
         with:
           github-token: ${{ github.token }}
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}
           webhook-type: webhook-trigger

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -317,7 +317,7 @@ jobs:
 
       - name: Notify Slack about unchanged merge queue resubmission
         if: steps.check.outputs.resubmit == 'true'
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3
         with:
           errors: true
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_ISSUES }}

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -66,7 +66,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # Triage only needs the local workflow/action files. Codex then reads
           # untrusted CI logs and emits external output, so don't leave a usable
@@ -86,7 +86,7 @@ jobs:
 
       - name: Notify Failure
         if: always()
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_NIGHTLY_FAILED }}
           webhook-type: webhook-trigger

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -224,7 +224,7 @@ jobs:
           append_output("covered_prs", covered_prs_text)
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # Triage only needs the local workflow/action files. Codex then reads
           # untrusted CI logs and emits external output, so don't leave a usable
@@ -244,7 +244,7 @@ jobs:
 
       - name: Notify CIE failure triage
         if: always()
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_POST_MERGE_VALIDATION_FAILED }}
           webhook-type: webhook-trigger

--- a/.github/workflows/event-pr-validation-triage.yml
+++ b/.github/workflows/event-pr-validation-triage.yml
@@ -298,7 +298,7 @@ jobs:
       pull-requests: write # upsert the sticky triage comment
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # Don't persist the default GITHUB_TOKEN in .git/config. The
           # downstream steps (`gh run download`, fetch-failed-run-logs,

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -34,7 +34,7 @@ jobs:
       expected_sha: ${{ steps.get_sha.outputs.sha }}
       release_branch: ${{ steps.verify.outputs.release_branch }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ env.checkout_target }}
           fetch-depth: 0
@@ -107,7 +107,7 @@ jobs:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
       GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.validate-tag.outputs.release_branch }}
       - name: Update version for next patch
@@ -161,7 +161,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: generate-app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
@@ -189,13 +189,13 @@ jobs:
     steps:
       - name: Configure AWS Credentials Using Role
         if: vars.USE_AWS_ROLE == 'true'
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           role-to-assume: ${{ vars.ARTIFACT_UPLOAD_AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
       - name: Configure AWS Credentials Using Keys
         if: vars.USE_AWS_ROLE == 'false'
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-access-key-id: ${{ secrets.ARTIFACT_UPLOAD_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.ARTIFACT_UPLOAD_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/event-weekly.yml
+++ b/.github/workflows/event-weekly.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
       with:
         python-version: '3.11'
         cache: 'pip'

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -59,7 +59,7 @@ jobs:
       beta-version: ${{ inputs.force_beta && steps.beta-version.outputs.BETA_VERSION || '' }}
       version-suffix: ${{ steps.beta-version.outputs.VERSION_SUFFIX }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - id: get-redis

--- a/.github/workflows/flow-build-benchmark-binary.yml
+++ b/.github/workflows/flow-build-benchmark-binary.yml
@@ -36,7 +36,7 @@ jobs:
       BUILD_DIR: ${{ format('bin/linux-{0}-release/search-community', inputs.arch == 'aarch64' && 'aarch64' || 'x64') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           submodules: recursive
       - name: Setup specific
@@ -63,7 +63,7 @@ jobs:
       - name: Show sccache stats
         run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Upload redisearch.so artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ inputs.artifact_name }}
           path: |

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -32,14 +32,14 @@ jobs:
       ec2_instance_id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-access-key-id: ${{ secrets.PERFORMANCE_EC2_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.PERFORMANCE_EC2_SECRET_KEY }}
           aws-region: ${{ secrets.PERFORMANCE_EC2_AWS_REGION }}
       - name: Generate GitHub App token
         id: generate-app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
@@ -48,7 +48,7 @@ jobs:
           permission-administration: write
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.6.1
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ steps.generate-app-token.outputs.token }}
@@ -71,7 +71,7 @@ jobs:
       - name: Pre checkout deps
         run:  sudo apt-get update && sudo apt-get -y --no-install-recommends install git
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           submodules: recursive
       - name: Print runner info
@@ -82,7 +82,7 @@ jobs:
           printf "Runner uname:\n$(uname -a)\n"
           printf "Runner arch:\n$(arch)\n"
       - name: Install python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: 3.11
       - name: Setup sccache
@@ -193,14 +193,14 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-access-key-id: ${{ secrets.PERFORMANCE_EC2_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.PERFORMANCE_EC2_SECRET_KEY }}
           aws-region: ${{ secrets.PERFORMANCE_EC2_AWS_REGION }}
       - name: Generate GitHub App token
         id: generate-app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
@@ -208,7 +208,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-administration: write
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.6.1
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: stop
           github-token: ${{ steps.generate-app-token.outputs.token }}

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -92,7 +92,7 @@ jobs:
       PERFORMANCE_WH_TOKEN: ${{ secrets.PERFORMANCE_WH_TOKEN }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Install benchmark dependencies
         run: |
           # Then install Python dependencies

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
       RUST_BACKTRACE: full
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           submodules: recursive
       - name: Setup specific
@@ -76,13 +76,13 @@ jobs:
 
       - name: Upload rust baseline benchmarks for master
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: "rust-benchmark-results-master"
           path: bin/redisearch_rs/criterion
       - name: Upload benchmarks for PR comparison
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: "rust-benchmark-results-pr-${{ github.event.pull_request.number }}"
           path: bin/redisearch_rs/criterion

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
       with:
         python-version: '3.11'
         cache: 'pip'
@@ -47,7 +47,7 @@ jobs:
 
     - name: Upload results on failure
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: link-check-results
         path: |
@@ -56,7 +56,7 @@ jobs:
 
     - name: Comment on PR
       if: failure()
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         script: |
           github.rest.issues.createComment({

--- a/.github/workflows/task-backport_pr-agent-fix.yml
+++ b/.github/workflows/task-backport_pr-agent-fix.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: 🔑 Generate GitHub App Token
         id: generate-app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
@@ -110,7 +110,7 @@ jobs:
       # The actual branch switch happens later via explicit git commands
       # against validated inputs.
       - name: Checkout master
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           token: ${{ steps.generate-app-token.outputs.token }}
           ref: master

--- a/.github/workflows/task-backport_pr-agent.yml
+++ b/.github/workflows/task-backport_pr-agent.yml
@@ -97,7 +97,7 @@ jobs:
     steps:
       - name: 🔑 Generate GitHub App Token
         id: generate-app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
@@ -127,7 +127,7 @@ jobs:
           permission-workflows: write
 
       - name: Checkout master (with full history)
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           token: ${{ steps.generate-app-token.outputs.token }}
           # Pin to master explicitly. On `pull_request_target` the default

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -33,18 +33,18 @@ jobs:
     steps:
       - name: 🔑 Generate GitHub App Token
         id: generate-app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
           owner: RediSearch
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           token: ${{ steps.generate-app-token.outputs.token }}
       - name: Create backport pull requests
         id: backport
-        uses: korthout/backport-action@v4
+        uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4
         with:
           github_token: ${{ steps.generate-app-token.outputs.token }}
           pull_title: '[${target_branch}] ${pull_title}'

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -129,7 +129,7 @@ jobs:
         run: ${{ needs.get-config.outputs.post_setup_script }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           submodules: recursive
           ref: ${{ env.REF }}

--- a/.github/workflows/task-build-cached-container.yml
+++ b/.github/workflows/task-build-cached-container.yml
@@ -40,11 +40,11 @@ jobs:
     steps:
       - name: Checkout
         if: inputs.checkout-ref == ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Checkout (custom ref)
         if: inputs.checkout-ref != ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ inputs.checkout-ref }}
       - name: Set image name
@@ -77,21 +77,21 @@ jobs:
           fi
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Build and push (cached)
         id: build-and-push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           push: ${{ steps.meta.outputs.can_push == 'true' }}
           context: .

--- a/.github/workflows/task-build.yml
+++ b/.github/workflows/task-build.yml
@@ -200,7 +200,7 @@ jobs:
           $INSTALL_MODE rm -rf /opt/hostedtoolcache/CodeQL || true
           df -h
       - name: Full checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           submodules: recursive
       - name: Setup build environment
@@ -357,7 +357,7 @@ jobs:
           ls -lh redis-install.tar.gz
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ inputs.artifact-name }}
           path: |

--- a/.github/workflows/task-build.yml
+++ b/.github/workflows/task-build.yml
@@ -279,7 +279,7 @@ jobs:
 
       - name: Package build outputs
         # We package bin/ as a tarball for two reasons:
-        #   1. actions/upload-artifact@v4 uses zip internally and strips Unix
+        #   1. actions/upload-artifact uses zip internally and strips Unix
         #      executable bits, which breaks the C/C++ test binaries on the
         #      downstream test jobs. tar preserves modes.
         #   2. Lets us prune intermediates with `find` before packing. The
@@ -357,7 +357,7 @@ jobs:
           ls -lh redis-install.tar.gz
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifact-name }}
           path: |

--- a/.github/workflows/task-check-changes.yml
+++ b/.github/workflows/task-check-changes.yml
@@ -24,20 +24,20 @@ jobs:
       TESTS_CHANGED: ${{ steps.check-tests.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0 # required for changed-files action to work
 
       - name: Check if any workflows were changed
         id: check-workflows
-        uses: tj-actions/changed-files@v47.0.6
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with: # Only run on changes to these paths (workflows)
           files: |
                 .github/workflows/**
                 .github/actions/**
       - name: Check if code was changed
         id: check-code
-        uses: tj-actions/changed-files@v47.0.6
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
                 *
@@ -78,13 +78,13 @@ jobs:
           fetch_additional_submodule_history: true
       - name: Check if CMake files were changed
         id: check-cmake
-        uses: tj-actions/changed-files@v47.0.6
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
                 **/CMakeLists.txt
       - name: Check if benchmark files were changed
         id: check-benchmarks
-        uses: tj-actions/changed-files@v47.0.6
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
                 tests/benchmarks/**
@@ -92,7 +92,7 @@ jobs:
           fetch_additional_submodule_history: true
       - name: Check if tests were changed
         id: check-tests
-        uses: tj-actions/changed-files@v47.0.6
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with: # Only run on changes to these paths (tests related changes)
           files: |
                 tests/**
@@ -100,7 +100,7 @@ jobs:
           fetch_additional_submodule_history: true
       - name: Check if rust micro-benchmarks were changed
         id: check-micro-benchmarks
-        uses: tj-actions/changed-files@v47.0.6
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with: # Only run on changes to these paths (redisearch_rs)
           files: |
               src/redisearch_rs/**
@@ -123,7 +123,7 @@ jobs:
               **/*.pdf
       - name: Check if Rust CMake files were changed
         id: check-rust-cmake
-        uses: tj-actions/changed-files@v47.0.6
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
               src/redisearch_rs/CMakeLists.txt

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           submodules: recursive
       - name: Fix HOME Directory
@@ -95,7 +95,7 @@ jobs:
           command: .install/test_deps/install_rust_deps.sh ${{ steps.mode.outputs.mode }}
           github_token: ${{ github.token }}
       # Cache Rust packages and binaries
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           prefix-key: "v1-rust"
           # The cargo workspaces and target directory configuration.

--- a/.github/workflows/task-miri.yml
+++ b/.github/workflows/task-miri.yml
@@ -145,7 +145,7 @@ jobs:
         run: eval "$POST_SETUP_SCRIPT"
 
       - name: Full checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           submodules: recursive
 
@@ -208,7 +208,7 @@ jobs:
 
       - name: Upload Test Logs (failure)
         if: failure() || steps.rust_unit_tests_miri.outcome == 'failure'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ steps.log-artifact.outputs.name }}
           path: tests/**/logs/*.log*

--- a/.github/workflows/task-miri.yml
+++ b/.github/workflows/task-miri.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Set log artifact name
         # Artifact names can't contain : / etc. (platform is e.g. "ubuntu:latest")
-        # and must be unique per shard, or actions/upload-artifact@v4 errors on
+        # and must be unique per shard, or actions/upload-artifact errors on
         # the second shard. Fold the partition (e.g. count:1/3) into the name and
         # sanitise invalid characters.
         id: log-artifact
@@ -208,7 +208,7 @@ jobs:
 
       - name: Upload Test Logs (failure)
         if: failure() || steps.rust_unit_tests_miri.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.log-artifact.outputs.name }}
           path: tests/**/logs/*.log*

--- a/.github/workflows/task-redis-build-sanity.yml
+++ b/.github/workflows/task-redis-build-sanity.yml
@@ -190,7 +190,7 @@ jobs:
           git config --global --add safe.directory '*'
 
       - name: Checkout Redis
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           repository: ${{ inputs.redis-repository }}
           ref: ${{ inputs.redis-ref }}

--- a/.github/workflows/task-release-drafter.yml
+++ b/.github/workflows/task-release-drafter.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v7.3.1
+      - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/.github/workflows/task-stale.yml
+++ b/.github/workflows/task-stale.yml
@@ -9,7 +9,7 @@ jobs:
   stale:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
         with:
             days-before-stale: 60
             days-before-close: -1

--- a/.github/workflows/task-start-ec2-runner.yml
+++ b/.github/workflows/task-start-ec2-runner.yml
@@ -51,7 +51,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-access-key-id: ${{ secrets.PERFORMANCE_EC2_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.PERFORMANCE_EC2_SECRET_KEY }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: generate-app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
@@ -69,7 +69,7 @@ jobs:
 
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.6.1
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: start
           github-token: ${{ steps.generate-app-token.outputs.token }}

--- a/.github/workflows/task-stop-ec2-runner.yml
+++ b/.github/workflows/task-stop-ec2-runner.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-access-key-id: ${{ secrets.PERFORMANCE_EC2_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.PERFORMANCE_EC2_SECRET_KEY }}
@@ -35,7 +35,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: generate-app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
@@ -44,7 +44,7 @@ jobs:
           permission-administration: write
 
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.6.1
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef # v2.6.1
         with:
           mode: stop
           github-token: ${{ steps.generate-app-token.outputs.token }}

--- a/.github/workflows/task-take-shift.yml
+++ b/.github/workflows/task-take-shift.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}

--- a/.github/workflows/task-test-flow.yml
+++ b/.github/workflows/task-test-flow.yml
@@ -209,7 +209,7 @@ jobs:
           $INSTALL_MODE rm -rf /opt/hostedtoolcache/CodeQL || true
           df -h
       - name: Full checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           submodules: recursive
       - name: Setup build environment
@@ -244,7 +244,7 @@ jobs:
           echo "name=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
 
       - name: Download build artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: ${{ inputs.artifact-name }}
           # bin.tar.gz lands in the working directory; unpacked in the next step.
@@ -478,7 +478,7 @@ jobs:
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
           )
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Flow Test Logs ${{ steps.artifact-names.outputs.name }}
           path: |
@@ -529,7 +529,7 @@ jobs:
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
           )
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Failed Test Logs ${{ steps.artifact-names.outputs.name }}
           path: failed-test-logs/
@@ -550,7 +550,7 @@ jobs:
         run: gpg --import .github/codecov_gpg.pub
       - name: Upload flow coverage (standalone)
         if: inputs.coverage && inputs.test-mode == 'standalone'
-        uses: codecov/codecov-action@v6 # NOSONAR
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6 NOSONAR
         with:
           files: bin/flow_standalone.info
           disable_search: true
@@ -559,7 +559,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload flow coverage (coordinator)
         if: inputs.coverage && inputs.test-mode == 'coordinator'
-        uses: codecov/codecov-action@v6 # NOSONAR
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6 NOSONAR
         with:
           files: bin/flow_coordinator.info
           disable_search: true

--- a/.github/workflows/task-test-flow.yml
+++ b/.github/workflows/task-test-flow.yml
@@ -344,9 +344,11 @@ jobs:
         id: flaky
         if: ${{ env.IS_FORK_PR != 'true' && steps.enumerate.outputs.specs }}
         continue-on-error: true
-        # First-party shared CI: tracked by the moving `v1` tag on purpose so
-        # org-wide fixes propagate without a bump here. See .github/zizmor.yml.
-        uses: redislabsdev/redisearch-ci-common/.github/actions/flaky-filter@v1
+        # Pinned to the commit SHA that `v1` points to. SonarCloud's "External
+        # GitHub Actions and workflows should be pinned to a commit hash" rule is
+        # a hard gate on any line a PR touches, so these do not get the moving-tag
+        # exemption that .github/zizmor.yml grants redislabsdev/*.
+        uses: redislabsdev/redisearch-ci-common/.github/actions/flaky-filter@47d296844ebbfab8d6923a8d57deadd1aacc9f29 # v1
         with:
           redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
           tests: ${{ steps.enumerate.outputs.specs }}
@@ -442,9 +444,10 @@ jobs:
       - name: Record failures to flaky DB
         if: ${{ always() && env.IS_FORK_PR != 'true' }}
         continue-on-error: true
-        # First-party shared CI: tracked by the moving `v1` tag on purpose so
-        # org-wide fixes propagate without a bump here. See .github/zizmor.yml.
-        uses: redislabsdev/redisearch-ci-common/.github/actions/flaky-record-results@v1
+        # Pinned to the commit SHA that `v1` points to — see the flaky-filter step
+        # above for why these two keep the hash while other redislabsdev/* refs
+        # stay on the tag.
+        uses: redislabsdev/redisearch-ci-common/.github/actions/flaky-record-results@47d296844ebbfab8d6923a8d57deadd1aacc9f29 # v1
         with:
           redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
           failed-file: ${{ inputs.test-mode == 'standalone' && '.failed_standalone.txt' || '.failed_coordinator.txt' }}

--- a/.github/workflows/task-test-flow.yml
+++ b/.github/workflows/task-test-flow.yml
@@ -244,7 +244,7 @@ jobs:
           echo "name=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.artifact-name }}
           # bin.tar.gz lands in the working directory; unpacked in the next step.
@@ -344,9 +344,9 @@ jobs:
         id: flaky
         if: ${{ env.IS_FORK_PR != 'true' && steps.enumerate.outputs.specs }}
         continue-on-error: true
-        # Pinned to the full commit SHA that the `v1` tag points to (external
-        # actions must be pinned to a commit hash, not a moving tag).
-        uses: redislabsdev/redisearch-ci-common/.github/actions/flaky-filter@47d296844ebbfab8d6923a8d57deadd1aacc9f29 # v1
+        # First-party shared CI: tracked by the moving `v1` tag on purpose so
+        # org-wide fixes propagate without a bump here. See .github/zizmor.yml.
+        uses: redislabsdev/redisearch-ci-common/.github/actions/flaky-filter@v1
         with:
           redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
           tests: ${{ steps.enumerate.outputs.specs }}
@@ -442,9 +442,9 @@ jobs:
       - name: Record failures to flaky DB
         if: ${{ always() && env.IS_FORK_PR != 'true' }}
         continue-on-error: true
-        # Pinned to the full commit SHA that the `v1` tag points to (external
-        # actions must be pinned to a commit hash, not a moving tag).
-        uses: redislabsdev/redisearch-ci-common/.github/actions/flaky-record-results@47d296844ebbfab8d6923a8d57deadd1aacc9f29 # v1
+        # First-party shared CI: tracked by the moving `v1` tag on purpose so
+        # org-wide fixes propagate without a bump here. See .github/zizmor.yml.
+        uses: redislabsdev/redisearch-ci-common/.github/actions/flaky-record-results@v1
         with:
           redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
           failed-file: ${{ inputs.test-mode == 'standalone' && '.failed_standalone.txt' || '.failed_coordinator.txt' }}
@@ -478,7 +478,7 @@ jobs:
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
           )
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Flow Test Logs ${{ steps.artifact-names.outputs.name }}
           path: |
@@ -529,7 +529,7 @@ jobs:
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
           )
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Failed Test Logs ${{ steps.artifact-names.outputs.name }}
           path: failed-test-logs/

--- a/.github/workflows/task-test-unit.yml
+++ b/.github/workflows/task-test-unit.yml
@@ -181,7 +181,7 @@ jobs:
           $INSTALL_MODE rm -rf /opt/hostedtoolcache/CodeQL || true
           df -h
       - name: Full checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           submodules: recursive
       - name: Setup build environment
@@ -196,7 +196,7 @@ jobs:
           sanitizer-setup: 'true'
 
       - name: Download build artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: ${{ inputs.artifact-name }}
           # bin.tar.gz + nextest-archive.tar.zst land in the working directory.
@@ -308,7 +308,7 @@ jobs:
             steps.rust_unit_tests.outcome == 'failure' ||
             steps.c_unit_tests.outcome == 'failure'
           )
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Unit Test Logs ${{ steps.artifact-names.outputs.name }}
           path: |
@@ -338,7 +338,7 @@ jobs:
       - name: Upload Failed-Only Test Logs
         # Guard kept in lockstep with "Collect failed-test-only logs" above.
         if: ${{ steps.c_unit_tests.outcome == 'failure' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Failed Test Logs ${{ steps.artifact-names.outputs.name }}
           path: failed-test-logs/
@@ -360,7 +360,7 @@ jobs:
         run: gpg --import .github/codecov_gpg.pub
       - name: Upload unit coverage
         if: inputs.coverage
-        uses: codecov/codecov-action@v6 # NOSONAR
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6 NOSONAR
         with:
           files: bin/unit.info,bin/rust_cov.info
           disable_search: true

--- a/.github/workflows/task-test-unit.yml
+++ b/.github/workflows/task-test-unit.yml
@@ -196,7 +196,7 @@ jobs:
           sanitizer-setup: 'true'
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.artifact-name }}
           # bin.tar.gz + nextest-archive.tar.zst land in the working directory.
@@ -308,7 +308,7 @@ jobs:
             steps.rust_unit_tests.outcome == 'failure' ||
             steps.c_unit_tests.outcome == 'failure'
           )
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Unit Test Logs ${{ steps.artifact-names.outputs.name }}
           path: |
@@ -338,7 +338,7 @@ jobs:
       - name: Upload Failed-Only Test Logs
         # Guard kept in lockstep with "Collect failed-test-only logs" above.
         if: ${{ steps.c_unit_tests.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Failed Test Logs ${{ steps.artifact-names.outputs.name }}
           path: failed-test-logs/

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -221,7 +221,7 @@ jobs:
           ${{ needs.get-config.outputs.install_mode }} rm -rf /opt/hostedtoolcache/CodeQL || true
           df -h
       - name: Full checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           submodules: recursive
       - name: Setup build environment
@@ -481,7 +481,7 @@ jobs:
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
           )
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Test Logs ${{ steps.artifact-names.outputs.name }}
           path: |
@@ -585,7 +585,7 @@ jobs:
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
           )
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Failed Test Logs ${{ steps.artifact-names.outputs.name }}
           path: failed-test-logs/
@@ -614,7 +614,7 @@ jobs:
         run: gpg --import .github/codecov_gpg.pub
       - name: Upload flow coverage (combined)
         if: inputs.coverage && inputs.standalone && inputs.coordinator
-        uses: codecov/codecov-action@v6 # NOSONAR
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6 NOSONAR
         with:
           files: bin/flow_standalone.info,bin/flow_coordinator.info
           disable_search: true
@@ -623,7 +623,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload flow coverage (standalone)
         if: inputs.coverage && inputs.standalone && !inputs.coordinator
-        uses: codecov/codecov-action@v6 # NOSONAR
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6 NOSONAR
         with:
           files: bin/flow_standalone.info
           disable_search: true
@@ -632,7 +632,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload flow coverage (coordinator)
         if: inputs.coverage && !inputs.standalone && inputs.coordinator
-        uses: codecov/codecov-action@v6 # NOSONAR
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6 NOSONAR
         with:
           files: bin/flow_coordinator.info
           disable_search: true
@@ -641,7 +641,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload unit coverage
         if: inputs.coverage && inputs.unit-tests
-        uses: codecov/codecov-action@v6 # NOSONAR
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6 NOSONAR
         with:
           files: bin/unit.info,bin/rust_cov.info
           disable_search: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,24 @@
+# zizmor configuration — static analysis for our GitHub Actions workflows.
+# Reference: https://docs.zizmor.sh/configuration/
+#
+# This file is policy only: which action references may stay on a moving tag, and
+# which audits are deliberately suppressed. The CI job that runs zizmor is wired
+# up separately, and gates PRs at --min-severity=high --min-confidence=high — so
+# the audits we have not triaged yet (artipacked, secrets-inherit, medium
+# excessive-permissions, github-env, unpinned-images, dangerous-triggers) do not
+# block PRs. Lowering either threshold is how you pick the next batch up; expect
+# findings.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # First-party shared CI lives in the public redislabsdev/redisearch-ci-common
+        # repository and is tracked by a moving major tag on purpose, so org-wide CI
+        # fixes propagate without a bump here. `ref-pin` still rejects an outright
+        # unpinned or branch-tracking reference.
+        redislabsdev/*: ref-pin
+        # Everything else must be a full commit SHA: a tag is mutable, and whoever
+        # controls the upstream repository can repoint it at code that then runs with
+        # this workflow's token and secrets. Dependabot keeps the pins current
+        # (see .github/dependabot.yml).
+        "*": hash-pin


### PR DESCRIPTION
## Describe the changes in the pull request

Groundwork for adding [zizmor](https://docs.zizmor.sh) as a blocking PR check, split out so the mechanical diff does not bury the substantive changes. The gate itself is in the follow-up PR, stacked on this one.

1. **Current:** every third-party action in `.github/` is referenced by a floating tag (`actions/checkout@v6`) — 110 call sites, with only 4 SHA-pinned. A tag is mutable: whoever controls the upstream repository can repoint it at arbitrary code, which then runs with our workflow's token and secrets. There is also no Dependabot or Renovate config in the repo at all.
2. **Change:** pin all 110 third-party call sites to full commit SHAs, keeping the tag as a trailing comment; declare the pinning policy in `.github/zizmor.yml`; add `.github/dependabot.yml` so the pins stay current.
3. **Outcome:** no behaviour change — every SHA is the commit its tag resolved to at the time of this change, so CI executes exactly what it did before. `zizmor`'s `unpinned-uses` audit goes from 123 findings to 0.

### Commits

1. **Consolidate action versions.** A few actions were referenced at two majors, which would otherwise leave two SHAs (and two Dependabot streams) for one action. `actions/upload-artifact` v4 (6 sites) → v7, matching the 7 sites already on v7; `actions/download-artifact` v4 (2 sites) → v7. Checked the changelogs first: v5–v7 only move the runtime to Node 24 and add an opt-in `archive` input, and v5's breaking change only affects downloads by `artifact-ids` — both of our sites download by `name`. Also normalises the `redislabsdev` `flaky-filter` / `flaky-record-results` refs, where two call sites were SHA-pinned and three were on `@v1`.
2. **Pin third-party actions to commit SHAs.** 23 distinct refs resolved with `gh api repos/<owner>/<repo>/commits/<ref>`, which dereferences annotated tags to the commit they point at.
3. **Add `.github/zizmor.yml`.** Declares the policy the previous commit implements, so it is enforced rather than applied once.
4. **Add `.github/dependabot.yml`.** Weekly, grouped into a single PR rather than ~20, covering both `.github/workflows` and our composite actions. A 7-day cooldown keeps us from adopting a release the moment it is published, which is when a compromised version is most likely to still be live.

### Deliberately left on a moving tag

- `uses: ./...` local workflows and composite actions — versioned with this repository.
- `redislabsdev/redisearch-ci-common` (15 call sites), so org-wide CI fixes keep propagating without a bump here. Encoded as `redislabsdev/*: ref-pin` in `.github/zizmor.yml`; `ref-pin` still rejects an outright unpinned or branch-tracking reference.

#### Which additional issues this PR fixes
1. MOD-17314

#### Main objects this PR modified
1. All 40 workflows and composite actions under `.github/workflows` and `.github/actions` that reference a third-party action
2. `.github/zizmor.yml` (new)
3. `.github/dependabot.yml` (new)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
