### PR TITLE
[MOD-17314] Audit GitHub Actions workflows with zizmor in PR CI

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -238,6 +238,12 @@ jobs:
         env:
           PERFORMANCE_GH_TOKEN: ${{ secrets.PERFORMANCE_GH_TOKEN }}
           PERFORMANCE_WH_TOKEN: ${{ secrets.PERFORMANCE_WH_TOKEN }}
+          COMPARISON_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          BASELINE_BRANCH: ${{ inputs.base_branch || github.event.pull_request.base.ref }}
+          PULL_REQUEST: ${{ github.event.number }}
+          PERFORMANCE_RTS_HOST: ${{ secrets.PERFORMANCE_RTS_HOST }}
+          PERFORMANCE_RTS_PORT: ${{ secrets.PERFORMANCE_RTS_PORT }}
+          PERFORMANCE_RTS_AUTH: ${{ secrets.PERFORMANCE_RTS_AUTH }}
         # --architectures enables the multi-arch PR comment layout from
         # redisbench-admin 0.12.25+: one H2 section per arch covering
         # branch-over-branch, plus a cross-arch delta section on the PR
@@ -255,14 +261,19 @@ jobs:
         # of this PR on top of its parent. Baselining against master instead
         # shows the cumulative performance impact of the whole stack. Fall back
         # to the PR base branch when no baseline is passed (e.g. workflow_dispatch).
-        run: redisbench-admin compare
-              --defaults_filename ./tests/benchmarks/defaults.yml
-              --comparison-branch ${{ github.event.pull_request.head.ref || github.ref_name }}
-              --baseline-branch ${{ inputs.base_branch || github.event.pull_request.base.ref }}
-              --architectures x86_64,aarch64
-              --auto-approve
-              --pull-request ${{ github.event.number }}
-              --redistimeseries_host ${{ secrets.PERFORMANCE_RTS_HOST }}
-              --redistimeseries_port ${{ secrets.PERFORMANCE_RTS_PORT }}
-              --redistimeseries_pass '${{ secrets.PERFORMANCE_RTS_AUTH }}'
+        #
+        # Everything dynamic goes through env rather than being expanded into the
+        # script: a PR author controls their own branch name, so interpolating it
+        # into a shell command lets them inject arbitrary code.
+        run: |
+          redisbench-admin compare \
+              --defaults_filename ./tests/benchmarks/defaults.yml \
+              --comparison-branch "$COMPARISON_BRANCH" \
+              --baseline-branch "$BASELINE_BRANCH" \
+              --architectures x86_64,aarch64 \
+              --auto-approve \
+              --pull-request "$PULL_REQUEST" \
+              --redistimeseries_host "$PERFORMANCE_RTS_HOST" \
+              --redistimeseries_port "$PERFORMANCE_RTS_PORT" \
+              --redistimeseries_pass "$PERFORMANCE_RTS_AUTH" \
               --last_n_baseline 20

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -51,6 +51,14 @@ jobs:
   spellcheck:
     uses: ./.github/workflows/task-spellcheck.yml
 
+  # Deliberately not gated on check-what-changed: it runs in seconds, and a check
+  # whose entire subject is .github/** should not be skipped based on what else
+  # the PR touched.
+  zizmor:
+    permissions:
+      contents: read # actions/checkout
+    uses: ./.github/workflows/task-zizmor.yml
+
   # ------------------------------------------------------------------
   # Per-job-type pipelines. Each runs its own build → test fan-out
   # independently of the others.
@@ -143,6 +151,7 @@ jobs:
       - get-latest-redis-tag
       - check-what-changed
       - spellcheck
+      - zizmor
       - lint
       - basic-test
       - coverage

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -1,11 +1,9 @@
 name: Release an OSS Version
 
-# Floor for every job: enough for actions/checkout, nothing more. The two jobs
-# that need to write (update-version) or request an AWS JWT (set-artifacts)
-# raise it themselves, so a step added to any other job here does not silently
-# inherit push or PR access.
-permissions:
-  contents: read
+# Every job below declares exactly what it needs. This empty default is the floor
+# rather than a grant: without it a job added later would inherit the repository's
+# default workflow permissions, which can be broader than anything here.
+permissions: {}
 
 on:
   push:
@@ -27,6 +25,8 @@ jobs:
   validate-tag:
     # Verify that the tag matches the version in src/version.h
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions:
+      contents: read # actions/checkout, plus `git branch`/`rev-parse` below
     outputs:
       cur_version: ${{ steps.verify.outputs.cur_version }}
       next_version: ${{ steps.verify.outputs.next_version }}

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -1,10 +1,11 @@
 name: Release an OSS Version
 
-# Added these to use JWT token to connect with AWS
+# Floor for every job: enough for actions/checkout, nothing more. The two jobs
+# that need to write (update-version) or request an AWS JWT (set-artifacts)
+# raise it themselves, so a step added to any other job here does not silently
+# inherit push or PR access.
 permissions:
-  id-token:       write   # This is required for requesting the JWT
-  contents:       write   # This is required for actions/checkout (read) and to push commits (write)
-  pull-requests:  write   # This is required for creating a PR
+  contents: read
 
 on:
   push:
@@ -98,6 +99,9 @@ jobs:
     runs-on: ubuntu-slim
     needs: validate-tag
     if: needs.validate-tag.outputs.should_bump == 'true'
+    permissions:
+      contents: write      # push the bump-version branch with checkout's credentials
+      pull-requests: write # `gh pr create --reviewer` below, via github.token
     env:
       BRANCH: bump-version-${{ needs.validate-tag.outputs.next_version }}
       # Common environment variables for security (shell injection prevention)
@@ -178,6 +182,8 @@ jobs:
           gh pr merge "$BRANCH" -R "$GITHUB_REPOSITORY" --auto
 
   generate-matrix:
+    # Pure computation: no checkout, no API calls.
+    permissions: {}
     uses: ./.github/workflows/generate-matrix.yml
     with:
       platform: all,!intel
@@ -186,6 +192,10 @@ jobs:
   set-artifacts:
     needs: [validate-tag, generate-matrix]
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    permissions:
+      # OIDC JWT for the ARTIFACT_UPLOAD_AWS_ROLE_TO_ASSUME path below. This job
+      # never checks the repository out, so it needs nothing else.
+      id-token: write
     steps:
       - name: Configure AWS Credentials Using Role
         if: vars.USE_AWS_ROLE == 'true'

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -70,16 +70,23 @@ jobs:
           echo "tag=8897348030c20bcd26841bc7d3ec7227f8187aeb" >> $GITHUB_OUTPUT
       - name: Generate Beta Version unique identifier
         id: beta-version
+        # Expanded through env rather than into the script body: a ref name is
+        # attacker-controllable, and interpolating it directly would let it inject
+        # shell code. Matches the "Validate Reference" step below.
+        env:
+          GIT_REF_NAME: ${{ github.ref_name }}
+          FORCE_BETA_INPUT: ${{ inputs.force_beta }}
+          GIT_SHA_RESOLVED: ${{ steps.set-sha.outputs.sha }}
         run: |
           # Generate beta version for master branch builds or when force_beta is enabled
-          BRANCH_NAME="${{ github.ref_name }}"
-          FORCE_BETA="${{ inputs.force_beta }}"
+          BRANCH_NAME="$GIT_REF_NAME"
+          FORCE_BETA="$FORCE_BETA_INPUT"
           echo "Building from branch: $BRANCH_NAME"
           echo "Force beta enabled: $FORCE_BETA"
           # Generate timestamp at workflow start for consistent beta versioning across all builds
           TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
           # Use git SHA for version suffix to ensure uniqueness
-          GIT_SHA="${{ steps.set-sha.outputs.sha }}"
+          GIT_SHA="$GIT_SHA_RESOLVED"
           SHORT_SHA="${GIT_SHA:0:7}"
           VERSION_SUFFIX=".${TIMESTAMP}.${SHORT_SHA}"
           echo VERSION_SUFFIX=$VERSION_SUFFIX >> $GITHUB_OUTPUT

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -121,8 +121,18 @@ jobs:
       - name: Show sccache stats
         run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Collect results
+        # Everything dynamic goes through env rather than being expanded into the
+        # script: a PR author controls their own branch name, so interpolating it
+        # into a shell command lets them inject arbitrary code.
         env:
           INPUT_ARCHITECTURE: ${{ inputs.architecture }}
+          PERFORMANCE_RTS_HOST: ${{ secrets.PERFORMANCE_RTS_HOST }}
+          PERFORMANCE_RTS_PORT: ${{ secrets.PERFORMANCE_RTS_PORT }}
+          PERFORMANCE_RTS_AUTH: ${{ secrets.PERFORMANCE_RTS_AUTH }}
+          GITHUB_REPO_NAME: ${{ github.event.repository.name }}
+          GITHUB_ORG_NAME: ${{ github.repository_owner }}
+          GITHUB_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          GITHUB_ACTOR_NAME: ${{ github.triggering_actor }}
         run: |
           # Determine OS name
           OS_NAME=$(uname | tr '[:upper:]' '[:lower:]')
@@ -170,14 +180,14 @@ jobs:
           for file in $JSON_FILES; do
             echo "Processing $file..."
             redisbench-admin export \
-              --redistimeseries_host ${{ secrets.PERFORMANCE_RTS_HOST }} \
-              --redistimeseries_port ${{ secrets.PERFORMANCE_RTS_PORT }} \
+              --redistimeseries_host "$PERFORMANCE_RTS_HOST" \
+              --redistimeseries_port "$PERFORMANCE_RTS_PORT" \
               --redistimeseries_user default \
-              --redistimeseries_pass '${{ secrets.PERFORMANCE_RTS_AUTH }}' \
-              --github_repo ${{ github.event.repository.name }} \
-              --github_org ${{ github.repository_owner }} \
-              --github_branch ${{ github.head_ref || github.ref_name }} \
-              --github_actor ${{ github.triggering_actor }} \
+              --redistimeseries_pass "$PERFORMANCE_RTS_AUTH" \
+              --github_repo "$GITHUB_REPO_NAME" \
+              --github_org "$GITHUB_ORG_NAME" \
+              --github_branch "$GITHUB_BRANCH_NAME" \
+              --github_actor "$GITHUB_ACTOR_NAME" \
               --results-format google.benchmark \
               --benchmark-result-file "$file" \
               --triggering_env redisearch-micro-benchmarks \

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -103,17 +103,30 @@ jobs:
         # normally the PR base branch, or master when the 'bench:vs-master'
         # label is set. Fall back to the PR base branch when no baseline is
         # passed (e.g. workflow_dispatch runs).
+        #
+        # Everything dynamic goes through env rather than being expanded into the
+        # script: a PR author controls their own branch name, so interpolating it
+        # into a shell command lets them inject arbitrary code.
+        env:
+          COMPARISON_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          BASELINE_BRANCH: ${{ inputs.base_branch || github.event.pull_request.base.ref }}
+          PULL_REQUEST: ${{ github.event.number }}
+          PERFORMANCE_RTS_HOST: ${{ secrets.PERFORMANCE_RTS_HOST }}
+          PERFORMANCE_RTS_PORT: ${{ secrets.PERFORMANCE_RTS_PORT }}
+          PERFORMANCE_RTS_AUTH: ${{ secrets.PERFORMANCE_RTS_AUTH }}
+          GITHUB_REPO_NAME: ${{ github.event.repository.name }}
+          GITHUB_ORG_NAME: ${{ github.repository_owner }}
         run: |
           redisbench-admin compare \
-          --comparison-branch ${{ github.event.pull_request.head.ref || github.ref_name }} \
-          --baseline-branch ${{ inputs.base_branch || github.event.pull_request.base.ref }} \
+          --comparison-branch "$COMPARISON_BRANCH" \
+          --baseline-branch "$BASELINE_BRANCH" \
           --auto-approve \
-          --pull-request ${{ github.event.number }} \
-          --redistimeseries_host ${{ secrets.PERFORMANCE_RTS_HOST }} \
-          --redistimeseries_port ${{ secrets.PERFORMANCE_RTS_PORT }} \
-          --redistimeseries_pass '${{ secrets.PERFORMANCE_RTS_AUTH }}' \
-          --github_repo ${{ github.event.repository.name }} \
-          --github_org ${{ github.repository_owner }} \
+          --pull-request "$PULL_REQUEST" \
+          --redistimeseries_host "$PERFORMANCE_RTS_HOST" \
+          --redistimeseries_port "$PERFORMANCE_RTS_PORT" \
+          --redistimeseries_pass "$PERFORMANCE_RTS_AUTH" \
+          --github_repo "$GITHUB_REPO_NAME" \
+          --github_org "$GITHUB_ORG_NAME" \
           --triggering_env redisearch-micro-benchmarks \
           --metric_name cpu_time \
           --metric_mode 'lower-better' \

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -38,6 +38,15 @@ jobs:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
           owner: RediSearch
+          # Without this the token reaches every repository the app is installed
+          # on across the org, not just this one.
+          repositories: RediSearch
+          # And without these it inherits the app installation's full permission
+          # set. korthout/backport-action needs exactly two: contents to push the
+          # cherry-picked branch, pull-requests to open the backport PR, request
+          # the author as reviewer, copy labels and enable auto-merge.
+          permission-contents: write
+          permission-pull-requests: write
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -42,11 +42,15 @@ jobs:
           # on across the org, not just this one.
           repositories: RediSearch
           # And without these it inherits the app installation's full permission
-          # set. korthout/backport-action needs exactly two: contents to push the
-          # cherry-picked branch, pull-requests to open the backport PR, request
-          # the author as reviewer, copy labels and enable auto-merge.
+          # set. korthout/backport-action needs: contents to push the cherry-picked
+          # branch, pull-requests to open the backport PR, request the author as
+          # reviewer, copy labels and enable auto-merge, and workflows because a
+          # backport whose commits touch .github/workflows/** is otherwise refused
+          # ("without `workflows` permission") — GitHub gates ref and contents
+          # writes that carry workflow files behind that permission separately.
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:

--- a/.github/workflows/task-take-shift.yml
+++ b/.github/workflows/task-take-shift.yml
@@ -17,6 +17,14 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-app-token
+        # This token is scoped to a single repository but still inherits the app
+        # installation's full permission set, because the one permission it needs
+        # cannot be requested: `gh variable set` requires GitHub's "Variables"
+        # repository permission, and create-github-app-token exposes no
+        # `permission-variables` input for it (actions/create-github-app-token#231).
+        # zizmor's github-app audit is suppressed for this file in
+        # .github/zizmor.yml; drop the suppression and add
+        # `permission-variables: write` once upstream supports it.
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}

--- a/.github/workflows/task-test-flow.yml
+++ b/.github/workflows/task-test-flow.yml
@@ -501,6 +501,7 @@ jobs:
           )
         env:
           FAILEDFILE: ${{ inputs.test-mode == 'standalone' && '.failed_standalone.txt' || '.failed_coordinator.txt' }}
+          TEST_MODE: ${{ inputs.test-mode }}
         run: |
           set +e
           DEST="failed-test-logs"
@@ -521,7 +522,7 @@ jobs:
           # Stash the failed-test list under a non-hidden name (upload-artifact
           # drops dot-prefixed files); triage treats failed-tests-*.txt as the
           # authoritative failure list.
-          cp "$FAILEDFILE" "$DEST/failed-tests-${{ inputs.test-mode }}.txt" 2>/dev/null || true
+          cp "$FAILEDFILE" "$DEST/failed-tests-${TEST_MODE}.txt" 2>/dev/null || true
           echo "Failed-test logs bundled: $(find "$DEST" -type f | wc -l)"
           exit 0
 

--- a/.github/workflows/task-zizmor.yml
+++ b/.github/workflows/task-zizmor.yml
@@ -1,0 +1,54 @@
+name: Zizmor GitHub Actions Audit
+
+# Documentation: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3967844669/RediSearch+CI+refactor
+#
+# Static analysis over our own CI configuration — the one part of the repository
+# that no other check looks at. zizmor catches shell injection through `${{ }}`
+# expansion, over-broad GITHUB_TOKEN and GitHub App permissions, and third-party
+# actions referenced by a mutable tag. See https://docs.zizmor.sh.
+#
+# Policy (which refs may stay on a tag, which audits are suppressed and why)
+# lives in .github/zizmor.yml, which zizmor discovers on its own.
+
+on: [workflow_call]
+
+jobs:
+  zizmor:
+    name: zizmor
+    # Not ubuntu-slim: zizmor-action runs zizmor from a container image and bails
+    # out with "Cannot run this action without Docker" when there is no daemon,
+    # which is the case on the slim runners.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read # actions/checkout
+    steps:
+      - name: Checkout
+        # No submodules — the vendored deps under deps/ ship their own workflows
+        # and are not ours to audit.
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # Nothing here pushes, and a persisted credential in .git/config is
+          # exactly what zizmor's own artipacked audit warns about.
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          # Pinned so a zizmor release that adds or tightens an audit turns this
+          # job red on the PR that bumps it, not on an unrelated PR.
+          version: 1.28.0
+          # Explicit paths. The action's default of "." would also collect the
+          # workflows vendored under deps/VectorSimilarity, deps/libuv,
+          # deps/hiredis and friends.
+          inputs: .github/workflows .github/actions .github/dependabot.yml
+          # Only fail on findings we have actually triaged to zero. The tiers
+          # below still have known findings — see .github/zizmor.yml.
+          min-severity: high
+          min-confidence: high
+          # Uploading SARIF needs `security-events: write`, which a pull_request
+          # from a fork does not get, and this repository accepts fork PRs (see
+          # CONTRIBUTING.md, "CI for Fork Pull Requests"). Annotate the diff
+          # instead. The two options are mutually exclusive.
+          advanced-security: false
+          annotations: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -9,6 +9,16 @@
 # block PRs. Lowering either threshold is how you pick the next batch up; expect
 # findings.
 rules:
+  github-app:
+    ignore:
+      # task-take-shift.yml runs `gh variable set`, which needs GitHub's
+      # "Variables" repository permission. create-github-app-token exposes no
+      # `permission-variables` input, so that token cannot be narrowed to what it
+      # actually uses (actions/create-github-app-token#231). It is already scoped
+      # to a single repository. Suppressed here rather than with an inline
+      # `# zizmor: ignore[...]` comment because that has to sit on the `uses:`
+      # line, where Dependabot rewrites the trailing version comment.
+      - task-take-shift.yml
   unpinned-uses:
     config:
       policies:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -2,12 +2,12 @@
 # Reference: https://docs.zizmor.sh/configuration/
 #
 # This file is policy only: which action references may stay on a moving tag, and
-# which audits are deliberately suppressed. The CI job that runs zizmor is wired
-# up separately, and gates PRs at --min-severity=high --min-confidence=high — so
-# the audits we have not triaged yet (artipacked, secrets-inherit, medium
-# excessive-permissions, github-env, unpinned-images, dangerous-triggers) do not
-# block PRs. Lowering either threshold is how you pick the next batch up; expect
-# findings.
+# which audits are deliberately suppressed. The job that runs zizmor is
+# .github/workflows/task-zizmor.yml, and it gates PRs at --min-severity=high
+# --min-confidence=high — so the audits we have not triaged yet (artipacked,
+# secrets-inherit, medium excessive-permissions, github-env, unpinned-images,
+# dangerous-triggers) do not block PRs. Lowering either threshold is how you pick
+# the next batch up; expect findings.
 rules:
   github-app:
     ignore:


### PR DESCRIPTION
## Describe the changes in the pull request

> Stacked on #10652 — review that one first. The diff shown here will shrink once #10652 merges.

1. **Current:** nothing checks our CI configuration itself. `make lint` is Rust-only and `task-spellcheck.yml` covers prose, so shell injection through `${{ }}` expansion, over-broad `GITHUB_TOKEN` and GitHub App permissions, and mutable action references were only ever caught by review.
2. **Change:** fix the 20 high-severity/high-confidence [zizmor](https://docs.zizmor.sh) findings that survive #10652, then add `task-zizmor.yml` as a blocking PR check wired into the existing `pr-validation` gate.
3. **Outcome:** `zizmor --min-severity=high --min-confidence=high` reports **zero findings**, and regressions now fail CI instead of reaching `master`.

### Commits

1. **Pass workflow context through env instead of interpolating it** — 14 `template-injection` findings. Expanding a `${{ }}` context into a `run:` body splices its value into the script before the shell sees it, so a value containing shell metacharacters executes as code. `github.event.pull_request.head.ref` and `github.head_ref` are the sharp cases: a contributor picks their own branch name, and these steps run with the performance-tracking secrets in scope. Each affected step now passes its dynamic values via `env:` and references them as quoted shell variables, following the pattern already used by the `run-remote` step in `benchmark-flow.yml`. This also stops passing the RedisTimeSeries credentials on the command line, where they are visible to anything that can read the process table on the runner.
2. **Scope the GitHub App tokens we mint in CI** — 3 `github-app` findings. `task-backport_pr.yml` is narrowed to this repository and to `contents: write` + `pull-requests: write`, which is what `korthout/backport-action` documents for the features we enable.
3. **Grant release-workflow permissions per job** — 3 `excessive-permissions` findings. `event-release.yml` declared `id-token: write`, `contents: write` and `pull-requests: write` at the workflow level, so all four jobs got all three. Workflow level drops to `contents: read`; `update-version` keeps the two writes it needs, `set-artifacts` keeps `id-token: write` for the AWS OIDC path, and `generate-matrix` gets `permissions: {}`.
4. **Add the zizmor job and wire it in.** `task-zizmor.yml` is a `workflow_call` unit called from `event-pull_request.yml` and added to the `pr-validation` needs list, so it gates PRs through the existing aggregation job — **the branch-protection required-check list does not change**.

### Notes for reviewers

**Two changes have no automated coverage.** Nothing in PR CI exercises `event-release.yml`, `task-backport_pr.yml` or `task-take-shift.yml`, so commits 2 and 3 were reviewed by walking each job's steps and cross-checking the actions' documented permission requirements rather than by a green run. Commit 3 is standalone if you would rather handle the release workflow separately.

**`task-take-shift.yml` could not be narrowed.** It runs `gh variable set`, which needs GitHub's "Variables" repository permission, and `actions/create-github-app-token` exposes no `permission-variables` input to request it (actions/create-github-app-token#231 is still open). Requesting anything else would drop the permission it depends on and break the workflow. The audit is suppressed for that file in `.github/zizmor.yml`, with the reason recorded in both places. The suppression lives in the config rather than an inline `# zizmor: ignore[github-app]` comment because zizmor only honours those on the same line as the finding — here the `uses:` line, whose trailing comment Dependabot rewrites on every SHA bump.

**Why the thresholds are `high`/`high`.** The tiers below still have known findings — 28 `artipacked`, 47 `secrets-inherit` (the house pattern for local reusable workflows), 66 medium `excessive-permissions`, plus low-confidence `github-env`, `unpinned-images` and `dangerous-triggers`. They are listed in `.github/zizmor.yml` so that tightening the thresholds later is a deliberate, visible step rather than a surprise. Across the whole stack the full audit goes from 160 high-severity findings to 30, and **no new findings are introduced at any severity**.

**Other job configuration worth a look:** `version: 1.28.0` is pinned so a zizmor release that adds an audit fails the PR that bumps it rather than arbitrary unrelated PRs; `advanced-security: false` with `annotations: true` because uploading SARIF needs `security-events: write`, which a `pull_request` from a fork does not get; and `inputs` is explicit because the action's default of `.` would also collect the workflows vendored under `deps/VectorSimilarity`, `deps/libuv` and `deps/hiredis`.

#### Which additional issues this PR fixes
1. MOD-17314

#### Main objects this PR modified
1. `.github/workflows/task-zizmor.yml` (new) and `event-pull_request.yml`
2. `benchmark-flow.yml`, `flow-micro-benchmarks.yml`, `flow-micro-benchmarks-runner.yml`, `flow-build-artifacts.yml`, `task-test-flow.yml`
3. `task-backport_pr.yml`, `task-take-shift.yml`, `event-release.yml`
4. `.github/zizmor.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
