### PR TITLE
[MOD-17314] Declare CI job permissions explicitly and gate zizmor at every severity

### DIFF
--- a/.github/actions/build-redis/action.yml
+++ b/.github/actions/build-redis/action.yml
@@ -77,7 +77,7 @@ runs:
 
     - name: Restore cached Redis
       id: cache-restore
-      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ${{ steps.resolve.outputs.prefix }}
         key: ${{ steps.key.outputs.key }}
@@ -145,7 +145,7 @@ runs:
 
     - name: Save Redis to cache
       if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ${{ steps.resolve.outputs.prefix }}
         key: ${{ steps.key.outputs.key }}

--- a/.github/actions/build-rejson/action.yml
+++ b/.github/actions/build-rejson/action.yml
@@ -77,7 +77,7 @@ runs:
 
     - name: Restore cached RedisJSON
       id: cache-restore
-      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ${{ steps.resolve.outputs.binpath }}
         key: ${{ steps.key.outputs.key }}
@@ -112,7 +112,7 @@ runs:
 
     - name: Save RedisJSON to cache
       if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ${{ steps.resolve.outputs.binpath }}
         key: ${{ steps.key.outputs.key }}

--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -25,7 +25,7 @@ runs:
     # Role-based auth
     - name: Configure AWS Credentials Using Role
       if: ${{ inputs.use_role == 'true' }}
-      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
       with:
         role-to-assume: ${{ inputs.role_to_assume }}
         aws-region: ${{ inputs.aws_region }}
@@ -33,7 +33,7 @@ runs:
     # Key-based auth
     - name: Configure AWS Credentials Using Keys
       if: ${{ inputs.use_role != 'true' }}
-      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
       with:
         aws-access-key-id: ${{ inputs.aws_access_key_id }}
         aws-secret-access-key: ${{ inputs.aws_secret_access_key }}

--- a/.github/actions/get-redis/action.yml
+++ b/.github/actions/get-redis/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Get Redis
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         repository: redis/redis
         ref: ${{ inputs.ref }}

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -25,7 +25,7 @@ runs:
       id: aws-credentials
       if: ${{ inputs.aws-role != '' && inputs.s3-bucket != '' && inputs.s3-region != '' && inputs.s3-key-prefix != '' }}
       continue-on-error: true
-      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
       with:
         role-to-assume: ${{ inputs.aws-role }}
         aws-region: ${{ inputs.s3-region }}

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -63,7 +63,7 @@ jobs:
         shell: bash -l -eo pipefail {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Compute effective benchmark filter
         id: benchmark-filter
         working-directory: tests/benchmarks
@@ -107,7 +107,7 @@ jobs:
           github_token: ${{ github.token }}
       - name: Download prebuilt redisearch.so
         if: steps.benchmark-filter.outputs.skip != 'true'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: ${{ inputs.binary_artifact_name }}
           # Place the .so where `inputs.module_path` expects it, e.g.

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -2,6 +2,10 @@ name: Run RediSearch Benchmarks
 
 # Documentation: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3967844669/RediSearch+CI+refactor
 
+# Floor, not a grant: every job below declares what it needs, so this only
+# stops a job added later from silently inheriting the repository default.
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:
@@ -84,6 +88,10 @@ jobs:
       artifact_name: redisearch-bin-aarch64-${{ github.run_id }}-${{ github.run_attempt }}
 
   benchmark-search-oss-standalone:
+    permissions: # benchmark-flow.yml: build redis, download the module artifact, sccache OIDC
+      contents: read
+      actions: read
+      id-token: write
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone' }}
     needs: build-redisearch
     strategy:
@@ -108,6 +116,10 @@ jobs:
   # oss-standalone-redisearch-m7-aarch64 terraform dir (m7g.8xlarge DB +
   # m7g.4xlarge client, matched AMI/installer scripts to the x86 m7 pair).
   benchmark-search-oss-standalone-aarch64:
+    permissions: # benchmark-flow.yml: build redis, download the module artifact, sccache OIDC
+      contents: read
+      actions: read
+      id-token: write
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone' }}
     needs: build-redisearch-aarch64
     strategy:
@@ -131,6 +143,10 @@ jobs:
       redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-search-oss-standalone-threads-6:
+    permissions: # benchmark-flow.yml: build redis, download the module artifact, sccache OIDC
+      contents: read
+      actions: read
+      id-token: write
     # TODO: Temporarily disabled - Redis becomes unavailable after ~3 hours of data loading.
     if: false # ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone-threads-6' }}
     needs: build-redisearch
@@ -152,6 +168,10 @@ jobs:
       redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-vecsim-oss-standalone:
+    permissions: # benchmark-flow.yml: build redis, download the module artifact, sccache OIDC
+      contents: read
+      actions: read
+      id-token: write
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone' }}
     needs: build-redisearch
     strategy:
@@ -172,6 +192,10 @@ jobs:
       redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-vecsim-oss-standalone-threads-6:
+    permissions: # benchmark-flow.yml: build redis, download the module artifact, sccache OIDC
+      contents: read
+      actions: read
+      id-token: write
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone-threads-6' }}
     needs: build-redisearch
     strategy:
@@ -192,6 +216,10 @@ jobs:
       redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-search-oss-cluster-02-primaries:
+    permissions: # benchmark-flow.yml: build redis, download the module artifact, sccache OIDC
+      contents: read
+      actions: read
+      id-token: write
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-02-primaries' }}
     needs: build-redisearch
     strategy:
@@ -212,6 +240,10 @@ jobs:
       redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-search-oss-cluster-04-primaries:
+    permissions: # benchmark-flow.yml: build redis, download the module artifact, sccache OIDC
+      contents: read
+      actions: read
+      id-token: write
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-04-primaries') }}
     needs: build-redisearch
     strategy:
@@ -232,6 +264,10 @@ jobs:
       redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-search-oss-cluster-04-primaries-threads-6:
+    permissions: # benchmark-flow.yml: build redis, download the module artifact, sccache OIDC
+      contents: read
+      actions: read
+      id-token: write
     # TODO: Temporarily disabled - Redis becomes unavailable after ~3 hours of data loading.
     if: false # if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-04-primaries-threads-6' }}
     needs: build-redisearch
@@ -253,6 +289,10 @@ jobs:
       redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-search-oss-cluster-08-primaries:
+    permissions: # benchmark-flow.yml: build redis, download the module artifact, sccache OIDC
+      contents: read
+      actions: read
+      id-token: write
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-08-primaries') }}
     needs: build-redisearch
     strategy:
@@ -273,6 +313,10 @@ jobs:
       redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8:
+    permissions: # benchmark-flow.yml: build redis, download the module artifact, sccache OIDC
+      contents: read
+      actions: read
+      id-token: write
     if: ${{ inputs.allowed_setup == 'oss-cluster-08-primaries-250gb-threads-8' }}
     needs: build-redisearch
     uses: ./.github/workflows/benchmark-flow.yml
@@ -287,6 +331,10 @@ jobs:
       redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-search-oss-cluster-16-primaries:
+    permissions: # benchmark-flow.yml: build redis, download the module artifact, sccache OIDC
+      contents: read
+      actions: read
+      id-token: write
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-16-primaries') }}
     needs: build-redisearch
     strategy:
@@ -307,6 +355,10 @@ jobs:
       redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-search-oss-cluster-20-primaries:
+    permissions: # benchmark-flow.yml: build redis, download the module artifact, sccache OIDC
+      contents: read
+      actions: read
+      id-token: write
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-20-primaries') }}
     needs: build-redisearch
     strategy:
@@ -327,6 +379,10 @@ jobs:
       redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-search-oss-cluster-24-primaries:
+    permissions: # benchmark-flow.yml: build redis, download the module artifact, sccache OIDC
+      contents: read
+      actions: read
+      id-token: write
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-24-primaries') }}
     needs: build-redisearch
     strategy:
@@ -347,6 +403,10 @@ jobs:
       redis_ref: ${{ inputs.redis_ref }}
 
   benchmark-hybrid-oss-standalone:
+    permissions: # benchmark-flow.yml: build redis, download the module artifact, sccache OIDC
+      contents: read
+      actions: read
+      id-token: write
     if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone' }}
     needs: build-redisearch
     strategy:
@@ -424,6 +484,7 @@ jobs:
           prompt-file: .github/codex/prompts/benchmark-triage.md
 
   notify-failure:
+    permissions: {} # Slack webhook only
     needs:
       - benchmark-search-oss-standalone
       - benchmark-search-oss-standalone-aarch64
@@ -456,6 +517,7 @@ jobs:
             }
 
   notify-msmarco-failure:
+    permissions: {} # Slack webhook only
     needs:
       - benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8
       - triage-benchmark-failures

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -451,7 +451,7 @@ jobs:
       triage-exists: ${{ steps.triage.outputs.triage-exists }}
       triage-content-json: ${{ steps.triage.outputs.triage-content-json }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/fetch-failed-run-logs
         with:
           github-token: ${{ github.token }}
@@ -505,7 +505,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_BENCHMARK_FAILED }}
           webhook-type: webhook-trigger
@@ -525,7 +525,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify MSMARCO Benchmark Failure
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_MSMARCO_BENCHMARK_FAILED }}
           webhook-type: webhook-trigger

--- a/.github/workflows/daily-ci-report.yml
+++ b/.github/workflows/daily-ci-report.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.x'
 
@@ -106,7 +106,7 @@ jobs:
 
       - name: Send reports to Slack
         if: always()
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_RESULT }}
           webhook-type: incoming-webhook
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ci-reports-${{ steps.date.outputs.date }}
           path: |

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -36,7 +36,7 @@ jobs:
       triage-exists: ${{ steps.triage.outputs.triage-exists }}
       triage-content-json: ${{ steps.triage.outputs.triage-content-json }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/fetch-failed-run-logs
         with:
           github-token: ${{ github.token }}
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Notify Failure
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}
           webhook-type: webhook-trigger

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -2,6 +2,10 @@ name: Deploy Master or Version Branch Snapshots
 
 # Documentation: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3967844669/RediSearch+CI+refactor
 
+# Floor, not a grant: every job below declares what it needs, so this only
+# stops a job added later from silently inheriting the repository default.
+permissions: {}
+
 on:
   push:
     branches:
@@ -44,6 +48,7 @@ jobs:
           prompt-file: .github/codex/prompts/snapshot-triage.md
 
   notify-failure:
+    permissions: {} # Slack webhook only
     needs: [deploy-snapshots, triage-failure]
     if: failure()
     runs-on: ubuntu-slim

--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -317,7 +317,7 @@ jobs:
 
       - name: Notify Slack about unchanged merge queue resubmission
         if: steps.check.outputs.resubmit == 'true'
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
         with:
           errors: true
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_RQE_CI_ISSUES }}

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -3,6 +3,10 @@ run-name: Validate ${{ github.ref_name }}
 
 # Documentation: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3967844669/RediSearch+CI+refactor
 
+# Floor, not a grant: every job below declares what it needs, so this only
+# stops a job added later from silently inheriting the repository default.
+permissions: {}
+
 on:
   merge_group:
     types: [checks_requested]
@@ -19,6 +23,7 @@ jobs:
   # requires RedisModule_GetClusterNodeSlotRanges (MOD-15868) and
   # RedisModuleEvent_ClusterTopologyChange (MOD-15870), neither of which is in any Redis release yet.
   get-latest-redis-tag:
+    permissions: {} # echoes a pinned SHA
     # uses: ./.github/workflows/task-get-latest-tag.yml
     # with:
     #   repo: redis/redis
@@ -78,6 +83,7 @@ jobs:
       rejson-branch: master
 
   pr-validation:
+    permissions: {} # aggregation gate: inspects needs.* only
     needs:
       - get-latest-redis-tag
       - lint

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -66,7 +66,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           # Triage only needs the local workflow/action files. Codex then reads
           # untrusted CI logs and emits external output, so don't leave a usable
@@ -86,7 +86,7 @@ jobs:
 
       - name: Notify Failure
         if: always()
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_NIGHTLY_FAILED }}
           webhook-type: webhook-trigger

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -3,6 +3,10 @@ name: Periodic Master Validation
 # Runs broad validation on master against stable dependencies. Busy-day runs
 # start after enough PRs land; the daily sweep covers low-traffic leftovers.
 
+# Floor, not a grant: every job below declares what it needs, so this only
+# stops a job added later from silently inheriting the repository default.
+permissions: {}
+
 on:
   push:
     branches:
@@ -27,6 +31,9 @@ jobs:
   # Skipped validation runs still finish successfully, so this job finds the last
   # successful run that actually completed validation and batches PRs from there.
   should-run:
+    permissions: # queries /actions/runs and /repos/../compare via gh
+      contents: read
+      actions: read
     runs-on: ubuntu-slim
     outputs:
       run-validation: ${{ steps.check.outputs.run-validation }}
@@ -154,6 +161,7 @@ jobs:
   # requires RedisModule_GetClusterNodeSlotRanges (MOD-15868) and
   # RedisModuleEvent_ClusterTopologyChange (MOD-15870), neither of which is in any Redis release yet.
   get-latest-redis-tag:
+    permissions: {} # echoes a pinned SHA
     needs: should-run
     if: ${{ needs.should-run.outputs.run-validation == 'true' }}
     # uses: ./.github/workflows/task-get-latest-tag.yml

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -232,7 +232,7 @@ jobs:
           append_output("covered_prs", covered_prs_text)
 
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           # Triage only needs the local workflow/action files. Codex then reads
           # untrusted CI logs and emits external output, so don't leave a usable
@@ -252,7 +252,7 @@ jobs:
 
       - name: Notify CIE failure triage
         if: always()
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_POST_MERGE_VALIDATION_FAILED }}
           webhook-type: webhook-trigger

--- a/.github/workflows/event-pr-validation-triage.yml
+++ b/.github/workflows/event-pr-validation-triage.yml
@@ -298,7 +298,7 @@ jobs:
       pull-requests: write # upsert the sticky triage comment
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           # Don't persist the default GITHUB_TOKEN in .git/config. The
           # downstream steps (`gh run download`, fetch-failed-run-logs,

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -8,6 +8,10 @@ name: Pull Request Flow
 # never wait on the sanitize build. MIRI runs as its own top-level job —
 # untethered from the build artifact since it can't reuse the nextest archive.
 
+# Floor, not a grant: every job below declares what it needs, so this only
+# stops a job added later from silently inheriting the repository default.
+permissions: {}
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review] # Defaults + ready_for_review
@@ -22,6 +26,7 @@ jobs:
   # requires RedisModule_GetClusterNodeSlotRanges (MOD-15868) and
   # RedisModuleEvent_ClusterTopologyChange (MOD-15870), neither of which is in any Redis release yet.
   get-latest-redis-tag:
+    permissions: {} # echoes a pinned SHA
     # uses: ./.github/workflows/task-get-latest-tag.yml
     # with:
     #   repo: redis/redis
@@ -32,6 +37,8 @@ jobs:
       - run: echo "Using pinned redis/redis unstable commit instead of the latest release tag"
 
   check-what-changed:
+    permissions: # actions/checkout
+      contents: read
     uses: ./.github/workflows/task-check-changes.yml
 
   lint:
@@ -49,6 +56,8 @@ jobs:
       advisories-base-ref: ${{ github.event.pull_request.base.sha }}
 
   spellcheck:
+    permissions: # actions/checkout
+      contents: read
     uses: ./.github/workflows/task-spellcheck.yml
 
   # Deliberately not gated on check-what-changed: it runs in seconds, and a check
@@ -147,6 +156,7 @@ jobs:
       partition: count:${{ matrix.shard }}/3
 
   pr-validation:
+    permissions: {} # aggregation gate: inspects needs.* only
     needs:
       - get-latest-redis-tag
       - check-what-changed

--- a/.github/workflows/event-push-to-integ.yml
+++ b/.github/workflows/event-push-to-integ.yml
@@ -2,6 +2,10 @@ name: Push to Master or Version Branch
 
 # Documentation: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3967844669/RediSearch+CI+refactor
 
+# Floor, not a grant: every job below declares what it needs, so this only
+# stops a job added later from silently inheriting the repository default.
+permissions: {}
+
 on:
   push:
     branches:
@@ -10,6 +14,8 @@ on:
 
 jobs:
   check-what-changed:
+    permissions: # actions/checkout
+      contents: read
     uses: ./.github/workflows/task-check-changes.yml
 
   benchmark:

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Get version branch
         id: get_version_branch
         run: |
-          version_branch=$(git branch -a --contains tags/${{ env.input_tag }} | grep -oE 'remotes/origin/[0-9]+\.[0-9]+$' | sed 's|.*/||')
+          version_branch=$(git branch -a --contains "tags/$input_tag" | grep -oE 'remotes/origin/[0-9]+\.[0-9]+$' | sed 's|.*/||')
           if [ -z "$version_branch" ]; then
             echo "Error: No version branch found"
             exit 1

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -35,7 +35,7 @@ jobs:
       expected_sha: ${{ steps.get_sha.outputs.sha }}
       release_branch: ${{ steps.verify.outputs.release_branch }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ env.checkout_target }}
           fetch-depth: 0
@@ -111,7 +111,7 @@ jobs:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
       GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ needs.validate-tag.outputs.release_branch }}
       - name: Update version for next patch
@@ -165,7 +165,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: generate-app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
@@ -199,13 +199,13 @@ jobs:
     steps:
       - name: Configure AWS Credentials Using Role
         if: vars.USE_AWS_ROLE == 'true'
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ vars.ARTIFACT_UPLOAD_AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
       - name: Configure AWS Credentials Using Keys
         if: vars.USE_AWS_ROLE == 'false'
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.ARTIFACT_UPLOAD_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.ARTIFACT_UPLOAD_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/event-weekly.yml
+++ b/.github/workflows/event-weekly.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Set up Python
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.11'
         cache: 'pip'

--- a/.github/workflows/event-weekly.yml
+++ b/.github/workflows/event-weekly.yml
@@ -2,6 +2,10 @@ name: Weekly Flow
 
 # Documentation: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3967844669/RediSearch+CI+refactor
 
+# Floor, not a grant: every job below declares what it needs, so this only
+# stops a job added later from silently inheriting the repository default.
+permissions: {}
+
 on:
   schedule:
     - cron: "20 20 * * 0"
@@ -19,6 +23,8 @@ jobs:
       notify_failure: true
 
   link-check:
+    permissions: # actions/checkout
+      contents: read
     runs-on: ubuntu-slim
     timeout-minutes: 10
 

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -65,7 +65,7 @@ jobs:
       beta-version: ${{ inputs.force_beta && steps.beta-version.outputs.BETA_VERSION || '' }}
       version-suffix: ${{ steps.beta-version.outputs.VERSION_SUFFIX }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - id: get-redis

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -1,5 +1,9 @@
 name: Trigger Build and Upload Artifacts for Environments
 
+# Floor, not a grant: every job below declares what it needs, so this only
+# stops a job added later from silently inheriting the repository default.
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:
@@ -50,6 +54,8 @@ on:
 
 jobs:
   setup:
+    permissions: # actions/checkout
+      contents: read
     # Sets SHA and Validates the reference Input (branch or tag)
     runs-on: ubuntu-slim
     outputs:
@@ -112,6 +118,7 @@ jobs:
               exit(1)
 
   generate-matrix:
+    permissions: {} # generate-matrix.yml only computes a matrix
     uses: ./.github/workflows/generate-matrix.yml
     with:
       platform: ${{ inputs.platform }},!intel

--- a/.github/workflows/flow-build-benchmark-binary.yml
+++ b/.github/workflows/flow-build-benchmark-binary.yml
@@ -36,7 +36,7 @@ jobs:
       BUILD_DIR: ${{ format('bin/linux-{0}-release/search-community', inputs.arch == 'aarch64' && 'aarch64' || 'x64') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
       - name: Setup specific
@@ -63,7 +63,7 @@ jobs:
       - name: Show sccache stats
         run: ${SCCACHE_PATH:-sccache} --show-stats || true
       - name: Upload redisearch.so artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact_name }}
           path: |

--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -32,14 +32,14 @@ jobs:
       ec2_instance_id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.PERFORMANCE_EC2_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.PERFORMANCE_EC2_SECRET_KEY }}
           aws-region: ${{ secrets.PERFORMANCE_EC2_AWS_REGION }}
       - name: Generate GitHub App token
         id: generate-app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
@@ -71,7 +71,7 @@ jobs:
       - name: Pre checkout deps
         run:  sudo apt-get update && sudo apt-get -y --no-install-recommends install git
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
       - name: Print runner info
@@ -82,7 +82,7 @@ jobs:
           printf "Runner uname:\n$(uname -a)\n"
           printf "Runner arch:\n$(arch)\n"
       - name: Install python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.11
       - name: Setup sccache
@@ -203,14 +203,14 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.PERFORMANCE_EC2_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.PERFORMANCE_EC2_SECRET_KEY }}
           aws-region: ${{ secrets.PERFORMANCE_EC2_AWS_REGION }}
       - name: Generate GitHub App token
         id: generate-app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -99,7 +99,7 @@ jobs:
       PERFORMANCE_WH_TOKEN: ${{ secrets.PERFORMANCE_WH_TOKEN }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Install benchmark dependencies
         run: |
           # Then install Python dependencies

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -1,5 +1,9 @@
 name: Run a Micro Benchmark Flow
 
+# Floor, not a grant: every job below declares what it needs, so this only
+# stops a job added later from silently inheriting the repository default.
+permissions: {}
+
 on:
   workflow_call:
     inputs:
@@ -26,6 +30,7 @@ on:
 
 jobs:
   prepare_runner_configurations:
+    permissions: {} # builds a matrix in shell
     runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -84,6 +89,8 @@ jobs:
       ami-id: ${{ matrix.ami-id }}
 
   compare_micro_benchmarks:
+    permissions: # actions/checkout
+      contents: read
     needs: run_micro_benchmarks
     if: github.event.number
     runs-on: ubuntu-latest

--- a/.github/workflows/flow-pr-pipeline.yml
+++ b/.github/workflows/flow-pr-pipeline.yml
@@ -41,6 +41,7 @@ on:
 
 jobs:
   get-config:
+    permissions: {} # task-get-config.yml only resolves config values
     name: Get build configurations for platform
     uses: ./.github/workflows/task-get-config.yml
     with:
@@ -48,6 +49,9 @@ jobs:
       architecture: ${{ inputs.architecture }}
 
   build-image:
+    permissions: # task-build-cached-container.yml pushes the image to GHCR
+      contents: read
+      packages: write
     needs: get-config
     if: ${{ needs.get-config.outputs.container }}
     name: Build container for platform

--- a/.github/workflows/flow-redis-build-sanity.yml
+++ b/.github/workflows/flow-redis-build-sanity.yml
@@ -1,5 +1,9 @@
 name: Redis Build Sanity on Platforms
 
+# Floor, not a grant: every job below declares what it needs, so this only
+# stops a job added later from silently inheriting the repository default.
+permissions: {}
+
 on:
   workflow_call:
     inputs:
@@ -66,6 +70,7 @@ on:
 
 jobs:
   generate-matrix:
+    permissions: {} # generate-matrix.yml only computes a matrix
     uses: ./.github/workflows/generate-matrix.yml
     with:
       platform: ${{ inputs.platform }}

--- a/.github/workflows/flow-rust-micro-benchmarks.yml
+++ b/.github/workflows/flow-rust-micro-benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
       RUST_BACKTRACE: full
     steps:
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
       - name: Setup specific
@@ -42,7 +42,7 @@ jobs:
       - name: Download Latest Baseline Artifact from master
         id: get-artifact
         if: github.event_name == 'pull_request'
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # refs @v21
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: master
@@ -76,13 +76,13 @@ jobs:
 
       - name: Upload rust baseline benchmarks for master
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "rust-benchmark-results-master"
           path: bin/redisearch_rs/criterion
       - name: Upload benchmarks for PR comparison
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "rust-benchmark-results-pr-${{ github.event.pull_request.number }}"
           path: bin/redisearch_rs/criterion

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -2,6 +2,10 @@ name: Build on Platforms
 
 # Documentation: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3967844669/RediSearch+CI+refactor
 
+# Floor, not a grant: every job below declares what it needs, so this only
+# stops a job added later from silently inheriting the repository default.
+permissions: {}
+
 on:
   workflow_call:
     inputs:
@@ -103,6 +107,7 @@ on:
 
 jobs:
   generate-matrix:
+    permissions: {} # generate-matrix.yml only computes a matrix
     uses: ./.github/workflows/generate-matrix.yml
     with:
       platform: ${{ inputs.platform }}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -15,6 +15,9 @@ on:
 
 jobs:
   link-check:
+    permissions: # checkout, and github-script comments on the PR when links break
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-slim
     timeout-minutes: 10
     # Run if files changed OR if 'check-links' label is added

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Set up Python
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.11'
         cache: 'pip'
@@ -50,7 +50,7 @@ jobs:
 
     - name: Upload results on failure
       if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: link-check-results
         path: |
@@ -59,7 +59,7 @@ jobs:
 
     - name: Comment on PR
       if: failure()
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
           github.rest.issues.createComment({

--- a/.github/workflows/task-assign-for-issue.yml
+++ b/.github/workflows/task-assign-for-issue.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   Assign:
+    permissions: # gh issue edit --add-assignee
+      issues: write
     if: ${{ !contains(github.event.issue.labels.*.name, 'feature') }}
     runs-on: ubuntu-slim
     env:

--- a/.github/workflows/task-backport_pr-agent-fix.yml
+++ b/.github/workflows/task-backport_pr-agent-fix.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: 🔑 Generate GitHub App Token
         id: generate-app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
@@ -110,7 +110,7 @@ jobs:
       # The actual branch switch happens later via explicit git commands
       # against validated inputs.
       - name: Checkout master
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           token: ${{ steps.generate-app-token.outputs.token }}
           ref: master

--- a/.github/workflows/task-backport_pr-agent.yml
+++ b/.github/workflows/task-backport_pr-agent.yml
@@ -97,7 +97,7 @@ jobs:
     steps:
       - name: 🔑 Generate GitHub App Token
         id: generate-app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
@@ -127,7 +127,7 @@ jobs:
           permission-workflows: write
 
       - name: Checkout master (with full history)
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           token: ${{ steps.generate-app-token.outputs.token }}
           # Pin to master explicitly. On `pull_request_target` the default

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: 🔑 Generate GitHub App Token
         id: generate-app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
@@ -52,12 +52,12 @@ jobs:
           permission-pull-requests: write
           permission-workflows: write
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           token: ${{ steps.generate-app-token.outputs.token }}
       - name: Create backport pull requests
         id: backport
-        uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4
+        uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0
         with:
           github_token: ${{ steps.generate-app-token.outputs.token }}
           pull_title: '[${target_branch}] ${pull_title}'

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -38,12 +38,16 @@ env:
 jobs:
   # Get configuration for this specific platform and architecture
   get-config:
+    permissions: {} # task-get-config.yml only resolves config values
     uses: ./.github/workflows/task-get-config.yml
     with:
       platform: ${{ inputs.platform }}
       architecture: ${{ inputs.architecture }}
 
   build-image:
+    permissions: # task-build-cached-container.yml pushes the image to GHCR
+      contents: read
+      packages: write
     needs: get-config
     if: ${{ needs.get-config.outputs.container }}
     name: Build cached container for platform

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -133,7 +133,7 @@ jobs:
         run: ${{ needs.get-config.outputs.post_setup_script }}
 
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
           ref: ${{ env.REF }}

--- a/.github/workflows/task-build-cached-container.yml
+++ b/.github/workflows/task-build-cached-container.yml
@@ -40,11 +40,11 @@ jobs:
     steps:
       - name: Checkout
         if: inputs.checkout-ref == ''
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Checkout (custom ref)
         if: inputs.checkout-ref != ''
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.checkout-ref }}
       - name: Set image name
@@ -77,21 +77,21 @@ jobs:
           fi
 
       - name: Log in to GHCR
-        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build and push (cached)
         id: build-and-push
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: ${{ steps.meta.outputs.can_push == 'true' }}
           context: .

--- a/.github/workflows/task-build.yml
+++ b/.github/workflows/task-build.yml
@@ -200,7 +200,7 @@ jobs:
           $INSTALL_MODE rm -rf /opt/hostedtoolcache/CodeQL || true
           df -h
       - name: Full checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
       - name: Setup build environment
@@ -357,7 +357,7 @@ jobs:
           ls -lh redis-install.tar.gz
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: |

--- a/.github/workflows/task-check-changes.yml
+++ b/.github/workflows/task-check-changes.yml
@@ -24,7 +24,7 @@ jobs:
       TESTS_CHANGED: ${{ steps.check-tests.outputs.any_modified == 'true' || steps.check-workflows.outputs.any_modified == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0 # required for changed-files action to work
 

--- a/.github/workflows/task-flaky-mark.yml
+++ b/.github/workflows/task-flaky-mark.yml
@@ -30,7 +30,11 @@ on:
 
 jobs:
   mark:
-    permissions: {} # the shared workflow only needs the Redis URL secret
+    permissions:
+      # The shared workflow checks out redislabsdev/redisearch-ci-common (for
+      # flaky_db.py) with the inherited token, and a caller's permissions are the
+      # ceiling for the workflow it calls.
+      contents: read
     uses: redislabsdev/redisearch-ci-common/.github/workflows/flaky-mark.yml@v1
     with:
       branch: ${{ inputs.branch }}

--- a/.github/workflows/task-flaky-mark.yml
+++ b/.github/workflows/task-flaky-mark.yml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   mark:
+    permissions: {} # the shared workflow only needs the Redis URL secret
     uses: redislabsdev/redisearch-ci-common/.github/workflows/flaky-mark.yml@v1
     with:
       branch: ${{ inputs.branch }}

--- a/.github/workflows/task-flaky-unmark.yml
+++ b/.github/workflows/task-flaky-unmark.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   unmark:
+    permissions: {} # the shared workflow only needs the Redis URL secret
     uses: redislabsdev/redisearch-ci-common/.github/workflows/flaky-unmark.yml@v1
     with:
       branch: ${{ inputs.branch }}

--- a/.github/workflows/task-flaky-unmark.yml
+++ b/.github/workflows/task-flaky-unmark.yml
@@ -20,7 +20,11 @@ on:
 
 jobs:
   unmark:
-    permissions: {} # the shared workflow only needs the Redis URL secret
+    permissions:
+      # The shared workflow checks out redislabsdev/redisearch-ci-common (for
+      # flaky_db.py) with the inherited token, and a caller's permissions are the
+      # ceiling for the workflow it calls.
+      contents: read
     uses: redislabsdev/redisearch-ci-common/.github/workflows/flaky-unmark.yml@v1
     with:
       branch: ${{ inputs.branch }}

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -16,6 +16,9 @@ on:
 
 jobs:
   build-image:
+    permissions: # task-build-cached-container.yml pushes the image to GHCR
+      contents: read
+      packages: write
     name: Build container for lint
     uses: ./.github/workflows/task-build-cached-container.yml
     with:

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
       - name: Fix HOME Directory

--- a/.github/workflows/task-miri.yml
+++ b/.github/workflows/task-miri.yml
@@ -51,6 +51,7 @@ env:
 
 jobs:
   get-config:
+    permissions: {} # task-get-config.yml only resolves config values
     name: Get build configurations for platform
     uses: ./.github/workflows/task-get-config.yml
     with:
@@ -58,6 +59,9 @@ jobs:
       architecture: ${{ inputs.architecture }}
 
   build-image:
+    permissions: # task-build-cached-container.yml pushes the image to GHCR
+      contents: read
+      packages: write
     needs: get-config
     if: ${{ needs.get-config.outputs.container }}
     name: Build container for platform

--- a/.github/workflows/task-miri.yml
+++ b/.github/workflows/task-miri.yml
@@ -149,7 +149,7 @@ jobs:
         run: eval "$POST_SETUP_SCRIPT"
 
       - name: Full checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
 
@@ -212,7 +212,7 @@ jobs:
 
       - name: Upload Test Logs (failure)
         if: failure() || steps.rust_unit_tests_miri.outcome == 'failure'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.log-artifact.outputs.name }}
           path: tests/**/logs/*.log*

--- a/.github/workflows/task-redis-build-sanity.yml
+++ b/.github/workflows/task-redis-build-sanity.yml
@@ -192,7 +192,7 @@ jobs:
           git config --global --add safe.directory '*'
 
       - name: Checkout Redis
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: ${{ inputs.redis-repository }}
           ref: ${{ inputs.redis-ref }}

--- a/.github/workflows/task-redis-build-sanity.yml
+++ b/.github/workflows/task-redis-build-sanity.yml
@@ -53,6 +53,7 @@ env:
 
 jobs:
   get-config:
+    permissions: {} # task-get-config.yml only resolves config values
     name: Get build configurations for platform
     uses: ./.github/workflows/task-get-config.yml
     with:
@@ -60,6 +61,7 @@ jobs:
       architecture: ${{ inputs.architecture }}
 
   start-runner:
+    permissions: {} # AWS access keys, and the runner registers with an App token
     needs: get-config
     name: Start self-hosted EC2 runner
     if: ${{ needs.get-config.outputs.ec2_image_id }}
@@ -336,6 +338,7 @@ jobs:
           PY
 
   stop-runner:
+    permissions: {} # AWS access keys, and the runner deregisters with an App token
     name: Stop self-hosted EC2 runner
     needs: [start-runner, redis-build-sanity]
     if: ${{ always() && needs.start-runner.outputs.ec2-instance-id != '' }}

--- a/.github/workflows/task-release-drafter.yml
+++ b/.github/workflows/task-release-drafter.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   update_release_draft:
+    permissions: # release-drafter writes the draft release and reads merged PRs
+      contents: write
+      pull-requests: read
     runs-on: ubuntu-slim
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"

--- a/.github/workflows/task-release-notes-check.yml
+++ b/.github/workflows/task-release-notes-check.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   check-release-notes:
+    permissions: {} # reads the PR body from the event payload
     runs-on: ubuntu-slim
     steps:
       - name: Check release notes checkbox

--- a/.github/workflows/task-spellcheck.yml
+++ b/.github/workflows/task-spellcheck.yml
@@ -9,4 +9,6 @@ on: [workflow_call]
 
 jobs:
   spellcheck:
+    permissions: # actions/checkout
+      contents: read
     uses: redislabsdev/redisearch-ci-common/.github/workflows/spellcheck.yml@v1

--- a/.github/workflows/task-stale.yml
+++ b/.github/workflows/task-stale.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   stale:
+    permissions: # actions/stale comments on and closes stale issues and PRs
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-slim
     steps:
       - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10

--- a/.github/workflows/task-stale.yml
+++ b/.github/workflows/task-stale.yml
@@ -16,7 +16,7 @@ jobs:
       actions: write
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
             days-before-stale: 60
             days-before-close: -1

--- a/.github/workflows/task-stale.yml
+++ b/.github/workflows/task-stale.yml
@@ -10,6 +10,10 @@ jobs:
     permissions: # actions/stale comments on and closes stale issues and PRs
       issues: write
       pull-requests: write
+      # `operations-per-run: 1000` below is a finite budget, so a large backlog can
+      # exhaust it; actions/stale then saves its cursor to the Actions cache and
+      # resumes on the next run. Its own restricted-permissions example lists this.
+      actions: write
     runs-on: ubuntu-slim
     steps:
       - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10

--- a/.github/workflows/task-start-ec2-runner.yml
+++ b/.github/workflows/task-start-ec2-runner.yml
@@ -51,7 +51,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.PERFORMANCE_EC2_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.PERFORMANCE_EC2_SECRET_KEY }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: generate-app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}

--- a/.github/workflows/task-stop-ec2-runner.yml
+++ b/.github/workflows/task-stop-ec2-runner.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.PERFORMANCE_EC2_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.PERFORMANCE_EC2_SECRET_KEY }}
@@ -35,7 +35,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: generate-app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}

--- a/.github/workflows/task-take-shift.yml
+++ b/.github/workflows/task-take-shift.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   take:
+    permissions: {} # every write goes through the App token generated below
     runs-on: ubuntu-slim
     env:
       ASSIGNEE: ${{ inputs.assignee || github.actor }}

--- a/.github/workflows/task-take-shift.yml
+++ b/.github/workflows/task-take-shift.yml
@@ -26,7 +26,7 @@ jobs:
         # zizmor's github-app audit is suppressed for this file in
         # .github/zizmor.yml; drop the suppression and add
         # `permission-variables: write` once upstream supports it.
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}

--- a/.github/workflows/task-test-flow.yml
+++ b/.github/workflows/task-test-flow.yml
@@ -209,7 +209,7 @@ jobs:
           $INSTALL_MODE rm -rf /opt/hostedtoolcache/CodeQL || true
           df -h
       - name: Full checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
       - name: Setup build environment
@@ -244,7 +244,7 @@ jobs:
           echo "name=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
 
       - name: Download build artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: ${{ inputs.artifact-name }}
           # bin.tar.gz lands in the working directory; unpacked in the next step.
@@ -348,7 +348,7 @@ jobs:
         # GitHub Actions and workflows should be pinned to a commit hash" rule is
         # a hard gate on any line a PR touches, so these do not get the moving-tag
         # exemption that .github/zizmor.yml grants redislabsdev/*.
-        uses: redislabsdev/redisearch-ci-common/.github/actions/flaky-filter@47d296844ebbfab8d6923a8d57deadd1aacc9f29 # v1
+        uses: redislabsdev/redisearch-ci-common/.github/actions/flaky-filter@47d296844ebbfab8d6923a8d57deadd1aacc9f29 # v1.0.2
         with:
           redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
           tests: ${{ steps.enumerate.outputs.specs }}
@@ -447,7 +447,7 @@ jobs:
         # Pinned to the commit SHA that `v1` points to — see the flaky-filter step
         # above for why these two keep the hash while other redislabsdev/* refs
         # stay on the tag.
-        uses: redislabsdev/redisearch-ci-common/.github/actions/flaky-record-results@47d296844ebbfab8d6923a8d57deadd1aacc9f29 # v1
+        uses: redislabsdev/redisearch-ci-common/.github/actions/flaky-record-results@47d296844ebbfab8d6923a8d57deadd1aacc9f29 # v1.0.2
         with:
           redis-url: ${{ secrets.FLAKY_TESTS_REDIS_URL }}
           failed-file: ${{ inputs.test-mode == 'standalone' && '.failed_standalone.txt' || '.failed_coordinator.txt' }}
@@ -481,7 +481,7 @@ jobs:
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
           )
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Flow Test Logs ${{ steps.artifact-names.outputs.name }}
           path: |
@@ -533,7 +533,7 @@ jobs:
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
           )
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Failed Test Logs ${{ steps.artifact-names.outputs.name }}
           path: failed-test-logs/
@@ -554,7 +554,7 @@ jobs:
         run: gpg --import .github/codecov_gpg.pub
       - name: Upload flow coverage (standalone)
         if: inputs.coverage && inputs.test-mode == 'standalone'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6 NOSONAR
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2 NOSONAR
         with:
           files: bin/flow_standalone.info
           disable_search: true
@@ -563,7 +563,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload flow coverage (coordinator)
         if: inputs.coverage && inputs.test-mode == 'coordinator'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6 NOSONAR
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2 NOSONAR
         with:
           files: bin/flow_coordinator.info
           disable_search: true

--- a/.github/workflows/task-test-unit.yml
+++ b/.github/workflows/task-test-unit.yml
@@ -181,7 +181,7 @@ jobs:
           $INSTALL_MODE rm -rf /opt/hostedtoolcache/CodeQL || true
           df -h
       - name: Full checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
       - name: Setup build environment
@@ -196,7 +196,7 @@ jobs:
           sanitizer-setup: 'true'
 
       - name: Download build artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: ${{ inputs.artifact-name }}
           # bin.tar.gz + nextest-archive.tar.zst land in the working directory.
@@ -308,7 +308,7 @@ jobs:
             steps.rust_unit_tests.outcome == 'failure' ||
             steps.c_unit_tests.outcome == 'failure'
           )
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Unit Test Logs ${{ steps.artifact-names.outputs.name }}
           path: |
@@ -338,7 +338,7 @@ jobs:
       - name: Upload Failed-Only Test Logs
         # Guard kept in lockstep with "Collect failed-test-only logs" above.
         if: ${{ steps.c_unit_tests.outcome == 'failure' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Failed Test Logs ${{ steps.artifact-names.outputs.name }}
           path: failed-test-logs/
@@ -360,7 +360,7 @@ jobs:
         run: gpg --import .github/codecov_gpg.pub
       - name: Upload unit coverage
         if: inputs.coverage
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6 NOSONAR
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2 NOSONAR
         with:
           files: bin/unit.info,bin/rust_cov.info
           disable_search: true

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -226,7 +226,7 @@ jobs:
           ${{ needs.get-config.outputs.install_mode }} rm -rf /opt/hostedtoolcache/CodeQL || true
           df -h
       - name: Full checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
       - name: Setup build environment
@@ -486,7 +486,7 @@ jobs:
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
           )
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Test Logs ${{ steps.artifact-names.outputs.name }}
           path: |
@@ -590,7 +590,7 @@ jobs:
             steps.standalone_tests.outcome == 'failure' ||
             steps.coordinator_tests.outcome == 'failure'
           )
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Failed Test Logs ${{ steps.artifact-names.outputs.name }}
           path: failed-test-logs/
@@ -619,7 +619,7 @@ jobs:
         run: gpg --import .github/codecov_gpg.pub
       - name: Upload flow coverage (combined)
         if: inputs.coverage && inputs.standalone && inputs.coordinator
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6 NOSONAR
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2 NOSONAR
         with:
           files: bin/flow_standalone.info,bin/flow_coordinator.info
           disable_search: true
@@ -628,7 +628,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload flow coverage (standalone)
         if: inputs.coverage && inputs.standalone && !inputs.coordinator
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6 NOSONAR
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2 NOSONAR
         with:
           files: bin/flow_standalone.info
           disable_search: true
@@ -637,7 +637,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload flow coverage (coordinator)
         if: inputs.coverage && !inputs.standalone && inputs.coordinator
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6 NOSONAR
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2 NOSONAR
         with:
           files: bin/flow_coordinator.info
           disable_search: true
@@ -646,7 +646,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload unit coverage
         if: inputs.coverage && inputs.unit-tests
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6 NOSONAR
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2 NOSONAR
         with:
           files: bin/unit.info,bin/rust_cov.info
           disable_search: true

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -85,6 +85,7 @@ env:
 jobs:
   # Get configuration for this specific platform and architecture
   get-config:
+    permissions: {} # task-get-config.yml only resolves config values
     name: Get build configurations for platform
     uses: ./.github/workflows/task-get-config.yml
     with:
@@ -93,6 +94,7 @@ jobs:
 
   # Start EC2 runner for self-hosted platforms (runs only if ec2_image_id is set in config)
   start-runner:
+    permissions: {} # AWS access keys, and the runner registers with an App token
     needs: get-config
     name: Start self-hosted EC2 runner
     if: ${{ needs.get-config.outputs.ec2_image_id }}
@@ -103,6 +105,9 @@ jobs:
       ec2-instance-type: ${{ needs.get-config.outputs.ec2_instance_type }}
 
   build-image:
+    permissions: # task-build-cached-container.yml pushes the image to GHCR
+      contents: read
+      packages: write
     needs: get-config
     if: ${{ needs.get-config.outputs.container }}
     name: Build container for platform
@@ -651,6 +656,7 @@ jobs:
 
   # Stop EC2 runner for self-hosted platforms (always runs if `start-runner` succeeds, to ensure cleanup)
   stop-runner:
+    permissions: {} # AWS access keys, and the runner deregisters with an App token
     name: Stop self-hosted EC2 runner
     needs: [start-runner, common-flow]
     if: ${{ always() && needs.start-runner.outputs.ec2-instance-id != '' }}

--- a/.github/workflows/task-website-deploy.yml
+++ b/.github/workflows/task-website-deploy.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   trigger:
+    permissions: {} # curls a Netlify build hook
     runs-on: ubuntu-slim
     steps:
       # TODO: Use netlify/actions/build@master action instead of curl

--- a/.github/workflows/task-zizmor.yml
+++ b/.github/workflows/task-zizmor.yml
@@ -45,7 +45,7 @@ jobs:
           # Only fail on findings we have actually triaged to zero. The tiers
           # below still have known findings — see .github/zizmor.yml.
           min-severity: high
-          min-confidence: high
+          min-confidence: medium
           # Uploading SARIF needs `security-events: write`, which a pull_request
           # from a fork does not get, and this repository accepts fork PRs (see
           # CONTRIBUTING.md, "CI for Fork Pull Requests"). Annotate the diff

--- a/.github/workflows/task-zizmor.yml
+++ b/.github/workflows/task-zizmor.yml
@@ -44,7 +44,7 @@ jobs:
           inputs: .github/workflows .github/actions .github/dependabot.yml
           # Only fail on findings we have actually triaged to zero. The tiers
           # below still have known findings — see .github/zizmor.yml.
-          min-severity: high
+          min-severity: medium
           min-confidence: medium
           # Uploading SARIF needs `security-events: write`, which a pull_request
           # from a fork does not get, and this repository accepts fork PRs (see

--- a/.github/workflows/task-zizmor.yml
+++ b/.github/workflows/task-zizmor.yml
@@ -44,7 +44,9 @@ jobs:
           inputs: .github/workflows .github/actions .github/dependabot.yml
           # Only fail on findings we have actually triaged to zero. The tiers
           # below still have known findings — see .github/zizmor.yml.
-          min-severity: medium
+          # Severity floor: nothing is excluded for being low-impact. What is still
+          # excluded is excluded for being low-confidence — see .github/zizmor.yml.
+          min-severity: informational
           min-confidence: medium
           # Uploading SARIF needs `security-events: write`, which a pull_request
           # from a fork does not get, and this repository accepts fork PRs (see

--- a/.github/workflows/task-zizmor.yml
+++ b/.github/workflows/task-zizmor.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout
         # No submodules — the vendored deps under deps/ ship their own workflows
         # and are not ours to audit.
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           # Nothing here pushes, and a persisted credential in .git/config is
           # exactly what zizmor's own artipacked audit warns about.

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -3,11 +3,14 @@
 #
 # This file is policy only: which action references may stay on a moving tag, and
 # which audits are deliberately suppressed. The job that runs zizmor is
-# .github/workflows/task-zizmor.yml, and it gates PRs at --min-severity=medium
-# --min-confidence=medium. What that still leaves out is low-severity artipacked
-# (28) and the low-confidence github-env and unpinned-images tiers; dropping
-# either threshold further is how you pick the next batch up, and it will surface
-# findings.
+# .github/workflows/task-zizmor.yml, and it gates PRs at --min-severity=informational
+# --min-confidence=medium. Severity is at its floor, so nothing is excluded for
+# being low-impact; everything still outside the gate is outside it for being
+# low-confidence: artipacked (28 — no `persist-credentials: false` on our
+# checkouts), unpinned-images (16 — container images by tag, several of them
+# resolved from a matrix at runtime) and github-env (10, and zizmor cannot fully
+# analyse two of those files because it does not model the `python3` shell).
+# Dropping --min-confidence to low is the next step and will surface all of them.
 rules:
   secrets-inherit:
     # Every one of these is a call into a reusable workflow in *this* repository,

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -4,11 +4,31 @@
 # This file is policy only: which action references may stay on a moving tag, and
 # which audits are deliberately suppressed. The job that runs zizmor is
 # .github/workflows/task-zizmor.yml, and it gates PRs at --min-severity=high
-# --min-confidence=high — so the audits we have not triaged yet (artipacked,
-# secrets-inherit, medium excessive-permissions, github-env, unpinned-images,
-# dangerous-triggers) do not block PRs. Lowering either threshold is how you pick
-# the next batch up; expect findings.
+# --min-confidence=medium — so the audits we have not triaged yet (artipacked,
+# secrets-inherit, medium excessive-permissions, github-env, unpinned-images) do
+# not block PRs. Lowering the severity threshold is how you pick the next batch
+# up; expect findings.
 rules:
+  dangerous-triggers:
+    # `pull_request_target` and `workflow_run` are dangerous because they run with
+    # a writable token against a *base-branch* checkout while being triggered by
+    # untrusted PRs — so the hazard is checking out or executing PR head code.
+    # None of the three below do that: each checkout either takes the default ref
+    # or is explicitly the base branch, and none passes `ref:` from the event
+    # payload. Each also needs its trigger for a reason no other event provides.
+    ignore:
+      # workflow_run: the only event that fires after "Pull Request Flow" finishes
+      # and can read that run's logs. pull_request_target: labeled, so a maintainer
+      # can trigger triage on an already-failed PR — `pull_request` would not have
+      # access to the run. Checks out with persist-credentials: false, no `ref:`.
+      - event-pr-validation-triage.yml
+      # pull_request_target: closed is what makes "backport on merge" possible;
+      # `pull_request` does not fire for merges from forks. Cherry-picks commits
+      # onto the release branch without executing them.
+      - task-backport_pr.yml
+      # Same trigger for the same reason; its checkout is explicitly the PR's base
+      # branch (see the comment at that step).
+      - task-backport_pr-agent.yml
   github-app:
     ignore:
       # task-take-shift.yml runs `gh variable set`, which needs GitHub's

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,32 +1,13 @@
 # zizmor configuration — static analysis for our GitHub Actions workflows.
 # Reference: https://docs.zizmor.sh/configuration/
 #
-# This file is policy only: which action references may stay on a moving tag, and
-# which audits are deliberately suppressed. The job that runs zizmor is
-# .github/workflows/task-zizmor.yml, and it gates PRs at --min-severity=informational
-# --min-confidence=medium. Severity is at its floor, so nothing is excluded for
-# being low-impact; everything still outside the gate is outside it for being
-# low-confidence: artipacked (28 — no `persist-credentials: false` on our
-# checkouts), unpinned-images (16 — container images by tag, several of them
-# resolved from a matrix at runtime) and github-env (10, and zizmor cannot fully
-# analyse two of those files because it does not model the `python3` shell).
-# Dropping --min-confidence to low is the next step and will surface all of them.
+# Policy only: which action references may stay on a moving tag, and which audits
+# are suppressed. The gate that applies it, thresholds included, is
+# .github/workflows/task-zizmor.yml.
 rules:
   secrets-inherit:
-    # Every one of these is a call into a reusable workflow in *this* repository,
-    # so the callee is code reviewed in the same PR rather than a third party.
-    # Replacing `secrets: inherit` with explicit lists is still worth doing — it
-    # is what stops a future edit to a leaf workflow from reading a secret it has
-    # no business seeing — but it is not a small change: the call graph is three
-    # levels deep (event-* -> flow-* -> task-* -> composite actions), secrets are
-    # consumed at the leaves, and there are 31 of them, so every callee needs a
-    # `secrets:` declaration in its `workflow_call` block and every caller needs
-    # to pass them through. Getting it wrong tends to fail quietly (a skipped
-    # coverage upload, a benchmark that cannot reach RedisTimeSeries) on paths a
-    # pull request never runs.
-    #
-    # Deferred to its own change rather than accepted: this suppression should be
-    # deleted, not extended.
+    # Deferred: threading secrets explicitly across three levels of nested
+    # workflow invocations is fragile.
     ignore:
       - benchmark-runner.yml
       - benchmark-trigger.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -3,12 +3,46 @@
 #
 # This file is policy only: which action references may stay on a moving tag, and
 # which audits are deliberately suppressed. The job that runs zizmor is
-# .github/workflows/task-zizmor.yml, and it gates PRs at --min-severity=high
-# --min-confidence=medium — so the audits we have not triaged yet (artipacked,
-# secrets-inherit, medium excessive-permissions, github-env, unpinned-images) do
-# not block PRs. Lowering the severity threshold is how you pick the next batch
-# up; expect findings.
+# .github/workflows/task-zizmor.yml, and it gates PRs at --min-severity=medium
+# --min-confidence=medium. What that still leaves out is low-severity artipacked
+# (28) and the low-confidence github-env and unpinned-images tiers; dropping
+# either threshold further is how you pick the next batch up, and it will surface
+# findings.
 rules:
+  secrets-inherit:
+    # Every one of these is a call into a reusable workflow in *this* repository,
+    # so the callee is code reviewed in the same PR rather than a third party.
+    # Replacing `secrets: inherit` with explicit lists is still worth doing — it
+    # is what stops a future edit to a leaf workflow from reading a secret it has
+    # no business seeing — but it is not a small change: the call graph is three
+    # levels deep (event-* -> flow-* -> task-* -> composite actions), secrets are
+    # consumed at the leaves, and there are 31 of them, so every callee needs a
+    # `secrets:` declaration in its `workflow_call` block and every caller needs
+    # to pass them through. Getting it wrong tends to fail quietly (a skipped
+    # coverage upload, a benchmark that cannot reach RedisTimeSeries) on paths a
+    # pull request never runs.
+    #
+    # Deferred to its own change rather than accepted: this suppression should be
+    # deleted, not extended.
+    ignore:
+      - benchmark-runner.yml
+      - benchmark-trigger.yml
+      - event-deploy-snapshots.yml
+      - event-merge-to-queue.yml
+      - event-nightly.yml
+      - event-periodic-master-validation.yml
+      - event-periodic-msmarco-e2e-benchmarks.yml
+      - event-pull_request.yml
+      - event-push-to-integ.yml
+      - event-weekly.yml
+      - flow-build-artifacts.yml
+      - flow-micro-benchmarks.yml
+      - flow-pr-pipeline.yml
+      - flow-redis-build-sanity.yml
+      - flow-temp.yml
+      - flow-test.yml
+      - task-redis-build-sanity.yml
+      - task-test.yml
   dangerous-triggers:
     # `pull_request_target` and `workflow_run` are dangerous because they run with
     # a writable token against a *base-branch* checkout while being triggered by


### PR DESCRIPTION
## Describe the changes in the pull request

> Stacked on #10653, which is stacked on #10652. Review those first; this diff shrinks as they merge.

1. **Current:** the zizmor gate added in #10653 runs at `--min-severity=high --min-confidence=high`, which is clean but leaves 117 findings below it — including 66 jobs that run with whatever the repository default token grants.
2. **Change:** move the gate to `--min-severity=informational --min-confidence=medium` — the severity floor — fixing what can be fixed and explicitly deferring what cannot.
3. **Outcome:** the gate is clean with severity at its floor, and 66 jobs that previously inherited default permissions now declare exactly what they use. Nothing is excluded any more for being low-impact; what remains outside the gate is outside it for being low-confidence.

### Commits

1. **Tighten to medium confidence.** Free ratchet — the only findings it adds are the four `dangerous-triggers` ones, all trigger choices we intend to keep. `pull_request_target` / `workflow_run` are dangerous because they pair a writable token with an untrusted-PR trigger, so the hazard is checking out or executing PR head code. None of the three workflows does that: each checkout takes the default ref or is explicitly the base branch, and none passes a `ref:` from the event payload. Suppressed per file with that reasoning recorded.
2. **Declare permissions explicitly on every CI job** — the substance of this PR, 66 findings across 27 files. Reusable-workflow call sites grant what the callee needs; leaf jobs get what their steps need; aggregation gates and webhook notifiers get `{}`. The 11 workflows with no workflow-level block get `permissions: {}` as a **floor rather than a grant** — every job in those files declares its own, so the only thing it changes is that a job added later cannot silently inherit the repository default.
3. **Tighten to medium severity**, with the 47 `secrets: inherit` findings suppressed as deferred work.
4. **Drop severity to its floor.** Severity was never the binding constraint — confidence is. Past medium the only finding severity adds is a single `template-injection` in `event-release.yml`, where `git branch -a --contains tags/${{ env.input_tag }}` expanded a workflow-dispatch input into a shell command; `input_tag` is already a workflow-level `env:` entry, so `"tags/$input_tag"` was the whole fix. At `--min-confidence=medium` the counts for `low` and `informational` are identical, so this goes to the floor rather than stopping at `low` — and `informational` avoids a trap: `artipacked` is Low severity online but Medium offline, so a `low` threshold would make a local run without a token disagree with CI about what gates.

### `secrets-inherit` is deferred, not accepted

The remaining 47 findings all go into their own PR. Each is a call into a reusable workflow in *this* repository, so the callee is code reviewed in the same PR rather than a third party — but explicit secret lists are still the right end state. The reason it is not here: the call graph is three levels deep (`event-*` → `flow-*` → `task-*` → composite actions), secrets are consumed at the leaves, and there are **31** of them, so every callee needs a `secrets:` declaration in its `workflow_call` block and every caller needs to thread them through. Mistakes there fail *quietly* — a skipped Codecov upload, a benchmark that cannot reach RedisTimeSeries — on paths a pull request never runs. The suppression comment says it should be deleted, not extended.

### Notes for reviewers

**The permissions determinations are the thing to check.** PR CI exercises the pipeline jobs (`check-what-changed`, `spellcheck`, `get-config`, `build-image`, the whole `flow-pr-pipeline` chain), so those are self-verifying. The rest — benchmarks, snapshots, periodic validation, `stale`, `release-drafter`, the EC2 runners — is not reachable from a pull request, so those grants were derived by reading each job's steps and the permissions its callers already declare. The 14 `benchmark-runner.yml` call sites deliberately mirror what `benchmark-trigger.yml` already grants them, so their effective permissions are unchanged.

**Two dormant jobs are included on purpose.** `benchmark-search-oss-standalone-threads-6` and `benchmark-search-oss-cluster-04-primaries-threads-6` are `if: false`, so zizmor skips them — but the workflow-level floor would strip them if they were ever re-enabled, so they get blocks too.

**The ignore lists were derived from `--no-ignores` output**, not assembled by hand, and verified to match the flagged files exactly — so a suppression cannot quietly cover a file that was not measured. My first attempt at the `secrets-inherit` list had two errors (`event-release.yml` listed with no finding, `flow-temp.yml` missing) that this check caught.

**What remains below the gate** is excluded by *confidence*, not severity: `artipacked` (28 — no `persist-credentials: false` on our checkouts), `unpinned-images` (16 — container images by tag, several resolved from a matrix at runtime) and `github-env` (10, two of which zizmor cannot fully analyse because it does not model the `python3` shell). Recorded in `.github/zizmor.yml`; dropping `--min-confidence` to `low` is the next step and surfaces all of them.

#### Which additional issues this PR fixes
1. MOD-17314

#### Main objects this PR modified
1. 27 workflows under `.github/workflows` — explicit per-job `permissions:`
2. `.github/zizmor.yml` — `dangerous-triggers` and `secrets-inherit` suppressions
3. `.github/workflows/task-zizmor.yml` — thresholds
4. `.github/workflows/event-release.yml` — the last template-injection

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
