### PR TITLE
[MOD-17316] Fix FT.HYBRID replying success with bogus warnings when a depleter loses the index lock

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -871,14 +871,10 @@ static void _replyWarnings(AREQ *req, RedisModule_Reply *reply, int rc) {
     RedisModule_Reply_SimpleString(reply, QueryWarning_Strwarning(QUERY_WARNING_CODE_TIMED_OUT));
     ProfileWarnings_Add(&profileCtx->warnings, PROFILE_WARNING_TYPE_TIMEOUT);
   } else if (rc == RS_RESULT_ERROR) {
-    // Non-fatal error. An unset QueryError would render as the OK code's default,
-    // "Success (not an error)", and its OK code also slips past ShouldReplyWithError.
+    // Non-fatal error
     RS_LOG_ASSERT(!QueryError_IsOk(qctx->err),
                   "RS_RESULT_ERROR reached the warning path without a QueryError set");
-    RedisModule_Reply_SimpleString(reply,
-                                   QueryError_IsOk(qctx->err)
-                                       ? QueryError_StrerrorDefaultMessage(QUERY_ERROR_CODE_GENERIC)
-                                       : QueryError_GetUserError(qctx->err));
+    RedisModule_Reply_SimpleString(reply, QueryError_GetUserError(qctx->err));
   }
   if (QueryError_HasReachedMaxPrefixExpansionsWarning(qctx->err)) {
     QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_REACHED_MAX_PREFIX_EXPANSIONS, 1, !IsInternal(req));

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -871,8 +871,16 @@ static void _replyWarnings(AREQ *req, RedisModule_Reply *reply, int rc) {
     RedisModule_Reply_SimpleString(reply, QueryWarning_Strwarning(QUERY_WARNING_CODE_TIMED_OUT));
     ProfileWarnings_Add(&profileCtx->warnings, PROFILE_WARNING_TYPE_TIMEOUT);
   } else if (rc == RS_RESULT_ERROR) {
-    // Non-fatal error
-    RedisModule_Reply_SimpleString(reply, QueryError_GetUserError(qctx->err));
+    // Non-fatal error. A stage that aborts must leave a message behind: on an unset
+    // QueryError, GetUserError returns the QUERY_ERROR_CODE_OK default and we would
+    // reply "Success (not an error)" as a warning (and, since the code is OK, the
+    // caller's ShouldReplyWithError check would not have caught it either).
+    RS_LOG_ASSERT(!QueryError_IsOk(qctx->err),
+                  "RS_RESULT_ERROR reached the warning path without a QueryError set");
+    RedisModule_Reply_SimpleString(reply,
+                                   QueryError_IsOk(qctx->err)
+                                       ? QueryError_StrerrorDefaultMessage(QUERY_ERROR_CODE_GENERIC)
+                                       : QueryError_GetUserError(qctx->err));
   }
   if (QueryError_HasReachedMaxPrefixExpansionsWarning(qctx->err)) {
     QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_REACHED_MAX_PREFIX_EXPANSIONS, 1, !IsInternal(req));

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -871,10 +871,8 @@ static void _replyWarnings(AREQ *req, RedisModule_Reply *reply, int rc) {
     RedisModule_Reply_SimpleString(reply, QueryWarning_Strwarning(QUERY_WARNING_CODE_TIMED_OUT));
     ProfileWarnings_Add(&profileCtx->warnings, PROFILE_WARNING_TYPE_TIMEOUT);
   } else if (rc == RS_RESULT_ERROR) {
-    // Non-fatal error. A stage that aborts must leave a message behind: on an unset
-    // QueryError, GetUserError returns the QUERY_ERROR_CODE_OK default and we would
-    // reply "Success (not an error)" as a warning (and, since the code is OK, the
-    // caller's ShouldReplyWithError check would not have caught it either).
+    // Non-fatal error. An unset QueryError would render as the OK code's default,
+    // "Success (not an error)", and its OK code also slips past ShouldReplyWithError.
     RS_LOG_ASSERT(!QueryError_IsOk(qctx->err),
                   "RS_RESULT_ERROR reached the warning path without a QueryError set");
     RedisModule_Reply_SimpleString(reply,

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -361,6 +361,10 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   // in RSExecDistAggregate before fanning out, so base.Next is already rpnetNext
   // by the time results are pulled and this function is never reached.
   if (rpnetCreateIterator(nc) != RS_RESULT_OK) {
+    // Record the failure, as the eager WITHCOUNT caller (dispatchAggregateDeferred)
+    // already does. RS_RESULT_ERROR with no message set renders as the
+    // QUERY_ERROR_CODE_OK default in the reply's warnings array.
+    QueryError_SetCode(nc->base.parent->err, QUERY_ERROR_CODE_GENERIC);
     return RS_RESULT_ERROR;
   }
   MR_StartIterator(nc->it, iterStartCb, NULL);

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -361,7 +361,6 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   // in RSExecDistAggregate before fanning out, so base.Next is already rpnetNext
   // by the time results are pulled and this function is never reached.
   if (rpnetCreateIterator(nc) != RS_RESULT_OK) {
-    // Mirrors the eager WITHCOUNT caller, dispatchAggregateDeferred.
     QueryError_SetCode(nc->base.parent->err, QUERY_ERROR_CODE_GENERIC);
     return RS_RESULT_ERROR;
   }

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -361,9 +361,7 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   // in RSExecDistAggregate before fanning out, so base.Next is already rpnetNext
   // by the time results are pulled and this function is never reached.
   if (rpnetCreateIterator(nc) != RS_RESULT_OK) {
-    // Record the failure, as the eager WITHCOUNT caller (dispatchAggregateDeferred)
-    // already does. RS_RESULT_ERROR with no message set renders as the
-    // QUERY_ERROR_CODE_OK default in the reply's warnings array.
+    // Mirrors the eager WITHCOUNT caller, dispatchAggregateDeferred.
     QueryError_SetCode(nc->base.parent->err, QUERY_ERROR_CODE_GENERIC);
     return RS_RESULT_ERROR;
   }

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -100,8 +100,18 @@ static inline HybridWarningMask handleAndReplyWarning(RedisModule_Reply *reply, 
     ReplyWarning(reply, QueryWarning_Strwarning(QUERY_WARNING_CODE_TIMED_OUT), suffix);
     return HYBRID_WARNING_TIMEOUT;
   } else if (returnCode == RS_RESULT_ERROR) {
-    // Non-fatal error — convert to warning
-    ReplyWarning(reply, QueryError_GetUserError(err), suffix);
+    // Non-fatal error — convert to warning. Only the soft codes that
+    // HybridRequest_GetError deliberately lets through reach here; anything else
+    // would already have been replied as an error, so `err` must carry a message.
+    // Producers have forgotten to set one before (RPSafeDepleter_DepleteFromUpstream),
+    // and QueryError_GetUserError would then return the QUERY_ERROR_CODE_OK default,
+    // emitting "Success (not an error)" as the warning text.
+    RS_LOG_ASSERT(!QueryError_IsOk(err),
+                  "RS_RESULT_ERROR reached the warning path without a QueryError set");
+    ReplyWarning(reply,
+                 QueryError_IsOk(err) ? QueryError_StrerrorDefaultMessage(QUERY_ERROR_CODE_GENERIC)
+                                      : QueryError_GetUserError(err),
+                 suffix);
     QueryError_ClearError(err);  // Free allocated message strings
   } else if (QueryError_HasReachedMaxPrefixExpansionsWarning(err)) {
     ReplyWarning(reply, QUERY_WMAXPREFIXEXPANSIONS, suffix);

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -100,12 +100,10 @@ static inline HybridWarningMask handleAndReplyWarning(RedisModule_Reply *reply, 
     ReplyWarning(reply, QueryWarning_Strwarning(QUERY_WARNING_CODE_TIMED_OUT), suffix);
     return HYBRID_WARNING_TIMEOUT;
   } else if (returnCode == RS_RESULT_ERROR) {
-    // Non-fatal error — convert to warning. Only the soft codes that
-    // HybridRequest_GetError deliberately lets through reach here; anything else
-    // would already have been replied as an error, so `err` must carry a message.
-    // Producers have forgotten to set one before (RPSafeDepleter_DepleteFromUpstream),
-    // and QueryError_GetUserError would then return the QUERY_ERROR_CODE_OK default,
-    // emitting "Success (not an error)" as the warning text.
+    // Non-fatal error — convert to warning. Only the soft codes
+    // HybridRequest_GetError lets through reach here; anything else was already
+    // replied as an error. Falling back matters because GetUserError would
+    // otherwise return the OK code's default, "Success (not an error)".
     RS_LOG_ASSERT(!QueryError_IsOk(err),
                   "RS_RESULT_ERROR reached the warning path without a QueryError set");
     ReplyWarning(reply,

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -100,16 +100,10 @@ static inline HybridWarningMask handleAndReplyWarning(RedisModule_Reply *reply, 
     ReplyWarning(reply, QueryWarning_Strwarning(QUERY_WARNING_CODE_TIMED_OUT), suffix);
     return HYBRID_WARNING_TIMEOUT;
   } else if (returnCode == RS_RESULT_ERROR) {
-    // Non-fatal error — convert to warning. Only the soft codes
-    // HybridRequest_GetError lets through reach here; anything else was already
-    // replied as an error. Falling back matters because GetUserError would
-    // otherwise return the OK code's default, "Success (not an error)".
+    // Non-fatal error — convert to warning
     RS_LOG_ASSERT(!QueryError_IsOk(err),
                   "RS_RESULT_ERROR reached the warning path without a QueryError set");
-    ReplyWarning(reply,
-                 QueryError_IsOk(err) ? QueryError_StrerrorDefaultMessage(QUERY_ERROR_CODE_GENERIC)
-                                      : QueryError_GetUserError(err),
-                 suffix);
+    ReplyWarning(reply, QueryError_GetUserError(err), suffix);
     QueryError_ClearError(err);  // Free allocated message strings
   } else if (QueryError_HasReachedMaxPrefixExpansionsWarning(err)) {
     ReplyWarning(reply, QUERY_WMAXPREFIXEXPANSIONS, suffix);

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -288,7 +288,11 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
     rs_wall_clock_init(&now);
 
     // Initialize error tracking for each individual request
-    hybridReq->errors = array_new(QueryError, nrequests);
+    // array_newlen, not array_new: the elements are written by direct indexing
+    // rather than appended, so a capacity-only array would keep array_len at 0 and
+    // HybridRequest_Free's array_free_ex would clear none of them, leaking any
+    // message stored in errors[i].
+    hybridReq->errors = array_newlen(QueryError, nrequests);
     memset(hybridReq->errors, 0, nrequests * sizeof(QueryError));
 
     // Initialize return codes array for tracking subqueries final states

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -288,10 +288,6 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
     rs_wall_clock_init(&now);
 
     // Initialize error tracking for each individual request
-    // array_newlen, not array_new: the elements are written by direct indexing
-    // rather than appended, so a capacity-only array would keep array_len at 0 and
-    // HybridRequest_Free's array_free_ex would clear none of them, leaking any
-    // message stored in errors[i].
     hybridReq->errors = array_newlen(QueryError, nrequests);
     memset(hybridReq->errors, 0, nrequests * sizeof(QueryError));
 

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1974,9 +1974,6 @@ static void RPSafeDepleter_DepleteFromUpstream(RPSafeDepleter *self, DepleterSyn
       // Failed to acquire lock - likely a writer is waiting
       // Set error status and return without depleting
       self->last_rc = RS_RESULT_ERROR;
-      // `last_rc` alone only reaches the cursor path; when depletion is driven
-      // through Next the pipeline error is the only channel out. Writing it from
-      // this thread is safe: readers wait for done_depleting.
       QueryError_SetError(self->base.parent->err, QUERY_ERROR_CODE_SAFE_DEPLETER_FAILURE,
                           SAFE_DEPLETER_LOCK_FAILURE_MSG);
       // Signal that we're skipping the lock phase (for WaitForDepletionToStart)

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1848,6 +1848,14 @@ ResultProcessor *RPVectorNormalizer_New(VectorNormFunction normFunc, const RLook
  *  NOTE: Currently the recommended number of upstreams is 2. Using more may
  *  induce performance issues, until a more robust mechanism is implemented.
  *******************************************************************************************************************/
+
+// Reported when a depleting thread's try-lock loses to a queued writer. Shared by
+// both drain paths — RPSafeDepleter_DepleteFromUpstream (reached through Next) and
+// RPSafeDepleter_DepleteAll (the cursor path) — so the two cannot drift.
+#define SAFE_DEPLETER_LOCK_FAILURE_MSG                                                            \
+  "Failed to acquire index lock for background depletion. A write operation may be in progress. " \
+  "Please retry."
+
 typedef struct {
   ResultProcessor base;                // Base result processor struct
   // We require separate contexts because we have different threads.
@@ -1968,6 +1976,15 @@ static void RPSafeDepleter_DepleteFromUpstream(RPSafeDepleter *self, DepleterSyn
       // Failed to acquire lock - likely a writer is waiting
       // Set error status and return without depleting
       self->last_rc = RS_RESULT_ERROR;
+      // Record the failure on this pipeline's QueryError as well. `last_rc` alone
+      // only reaches the cursor path, which re-derives the message in
+      // RPSafeDepleter_DepleteAll; when depletion is driven through Next (plain
+      // FT.HYBRID) the merger sees a bare RS_RESULT_ERROR, and an unset QueryError
+      // renders as the "Success (not an error)" default instead of a real error.
+      // Safe to write from the depleting thread: the reader (the Next-calling
+      // thread) only inspects it once done_depleting has been signalled.
+      QueryError_SetError(self->base.parent->err, QUERY_ERROR_CODE_SAFE_DEPLETER_FAILURE,
+                          SAFE_DEPLETER_LOCK_FAILURE_MSG);
       // Signal that we're skipping the lock phase (for WaitForDepletionToStart)
       atomic_fetch_add(&sync->num_skipped_lock, 1);
       return;
@@ -2340,8 +2357,8 @@ int RPSafeDepleter_DepleteAll(arrayof(ResultProcessor*) safeDepleters, QueryErro
   for (size_t i = 0; i < count; i++) {
     const RPSafeDepleter *safeDepleter = (RPSafeDepleter *)safeDepleters[i];
     if (safeDepleter->last_rc == RS_RESULT_ERROR) {
-      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_SAFE_DEPLETER_FAILURE,
-        "Failed to acquire index lock for background depletion. A write operation may be in progress. Please retry.");
+      QueryError_SetError(status, QUERY_ERROR_CODE_SAFE_DEPLETER_FAILURE,
+                          SAFE_DEPLETER_LOCK_FAILURE_MSG);
       return RS_RESULT_ERROR;
     } else if (safeDepleter->last_rc == RS_RESULT_TIMEDOUT) {
       anyTimedOut = true;
@@ -2510,6 +2527,10 @@ static int RPHybridMerger_Yield(ResultProcessor *rp, SearchResult *r) {
 
   SearchResult *mergedResult = mergeSearchResults(hybridResult, self->hybridScoringCtx, self->lookupCtx, self->explainCtx);
   if (!mergedResult) {
+    // Record a message: the reply path renders an unset QueryError as the
+    // "Success (not an error)" default rather than as a failure.
+    QueryError_SetError(rp->parent->err, QUERY_ERROR_CODE_GENERIC,
+                        "Failed to merge hybrid subquery results");
     return RS_RESULT_ERROR;
   }
 

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1849,9 +1849,7 @@ ResultProcessor *RPVectorNormalizer_New(VectorNormFunction normFunc, const RLook
  *  induce performance issues, until a more robust mechanism is implemented.
  *******************************************************************************************************************/
 
-// Reported when a depleting thread's try-lock loses to a queued writer. Shared by
-// both drain paths — RPSafeDepleter_DepleteFromUpstream (reached through Next) and
-// RPSafeDepleter_DepleteAll (the cursor path) — so the two cannot drift.
+// Shared by both drain paths so the two cannot drift.
 #define SAFE_DEPLETER_LOCK_FAILURE_MSG                                                            \
   "Failed to acquire index lock for background depletion. A write operation may be in progress. " \
   "Please retry."
@@ -1976,13 +1974,9 @@ static void RPSafeDepleter_DepleteFromUpstream(RPSafeDepleter *self, DepleterSyn
       // Failed to acquire lock - likely a writer is waiting
       // Set error status and return without depleting
       self->last_rc = RS_RESULT_ERROR;
-      // Record the failure on this pipeline's QueryError as well. `last_rc` alone
-      // only reaches the cursor path, which re-derives the message in
-      // RPSafeDepleter_DepleteAll; when depletion is driven through Next (plain
-      // FT.HYBRID) the merger sees a bare RS_RESULT_ERROR, and an unset QueryError
-      // renders as the "Success (not an error)" default instead of a real error.
-      // Safe to write from the depleting thread: the reader (the Next-calling
-      // thread) only inspects it once done_depleting has been signalled.
+      // `last_rc` alone only reaches the cursor path; when depletion is driven
+      // through Next the pipeline error is the only channel out. Writing it from
+      // this thread is safe: readers wait for done_depleting.
       QueryError_SetError(self->base.parent->err, QUERY_ERROR_CODE_SAFE_DEPLETER_FAILURE,
                           SAFE_DEPLETER_LOCK_FAILURE_MSG);
       // Signal that we're skipping the lock phase (for WaitForDepletionToStart)
@@ -2527,8 +2521,6 @@ static int RPHybridMerger_Yield(ResultProcessor *rp, SearchResult *r) {
 
   SearchResult *mergedResult = mergeSearchResults(hybridResult, self->hybridScoringCtx, self->lookupCtx, self->explainCtx);
   if (!mergedResult) {
-    // Record a message: the reply path renders an unset QueryError as the
-    // "Success (not an error)" default rather than as a failure.
     QueryError_SetError(rp->parent->err, QUERY_ERROR_CODE_GENERIC,
                         "Failed to merge hybrid subquery results");
     return RS_RESULT_ERROR;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1849,7 +1849,6 @@ ResultProcessor *RPVectorNormalizer_New(VectorNormFunction normFunc, const RLook
  *  induce performance issues, until a more robust mechanism is implemented.
  *******************************************************************************************************************/
 
-// Shared by both drain paths so the two cannot drift.
 #define SAFE_DEPLETER_LOCK_FAILURE_MSG                                                            \
   "Failed to acquire index lock for background depletion. A write operation may be in progress. " \
   "Please retry."

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -725,7 +725,7 @@ def skipTestUntil(date_str, reason=None):
     """
     skip_until(date_str, reason)(lambda: None)()
 
-def _any_skip_condition_set(*, cluster, macos, asan, msan, redis_less_than,
+def _any_skip_condition_set(*, cluster, macos, musl, asan, msan, redis_less_than,
                             redis_greater_equal, min_shards, arch, gc_no_fork,
                             no_json, enterprise):
     """True if the caller provided at least one skip condition.
@@ -733,12 +733,12 @@ def _any_skip_condition_set(*, cluster, macos, asan, msan, redis_less_than,
     With no conditions, @skip's legacy behaviour is to always skip — used as a
     "temporarily disable this test" marker.
     """
-    return ((cluster is not None) or macos or asan or msan or redis_less_than
+    return ((cluster is not None) or macos or musl or asan or msan or redis_less_than
             or redis_greater_equal or min_shards or (arch is not None)
             or gc_no_fork or no_json or (enterprise is not None))
 
 
-def _skip_fires_statically(*, cluster, macos, asan, msan, min_shards, arch, no_json, enterprise):
+def _skip_fires_statically(*, cluster, macos, musl, asan, msan, min_shards, arch, no_json, enterprise):
     """Evaluate the subset of @skip predicates that don't need a live Redis.
 
     Excludes redis_less_than/redis_greater_equal/gc_no_fork — those genuinely
@@ -747,6 +747,8 @@ def _skip_fires_statically(*, cluster, macos, asan, msan, min_shards, arch, no_j
     if cluster is not None and cluster == CLUSTER:
         return True
     if macos and OS == 'macos':
+        return True
+    if musl and MUSL:
         return True
     if arch == platform.machine():
         return True
@@ -778,8 +780,8 @@ def _skip_fires_at_runtime(*, redis_less_than, redis_greater_equal, gc_no_fork):
     return False
 
 
-def skip(cluster=None, macos=False, asan=False, msan=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None, no_json=False, enterprise=None):
-    static_kwargs = dict(cluster=cluster, macos=macos, asan=asan, msan=msan,
+def skip(cluster=None, macos=False, musl=False, asan=False, msan=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None, no_json=False, enterprise=None):
+    static_kwargs = dict(cluster=cluster, macos=macos, musl=musl, asan=asan, msan=msan,
                          min_shards=min_shards, arch=arch, no_json=no_json, enterprise=enterprise)
     runtime_kwargs = dict(redis_less_than=redis_less_than,
                           redis_greater_equal=redis_greater_equal,

--- a/tests/pytests/includes.py
+++ b/tests/pytests/includes.py
@@ -25,5 +25,4 @@ RS_TEST_ENTERPRISE = os.getenv('RS_TEST_ENTERPRISE', '0') == '1'
 
 system=platform.system()
 OS =  'macos' if system == 'Darwin' else system
-# platform.system() reports the kernel, so it cannot tell musl from glibc.
 MUSL = 'musl' in (sysconfig.get_config_var('MULTIARCH') or '')

--- a/tests/pytests/includes.py
+++ b/tests/pytests/includes.py
@@ -3,6 +3,7 @@ import sys
 import os
 from RLTest import Defaults
 import platform
+import sysconfig
 
 if sys.version_info > (3, 0):
     Defaults.decode_responses = True
@@ -24,3 +25,5 @@ RS_TEST_ENTERPRISE = os.getenv('RS_TEST_ENTERPRISE', '0') == '1'
 
 system=platform.system()
 OS =  'macos' if system == 'Darwin' else system
+# platform.system() reports the kernel, so it cannot tell musl from glibc.
+MUSL = 'musl' in (sysconfig.get_config_var('MULTIARCH') or '')

--- a/tests/pytests/test_hybrid_multithread.py
+++ b/tests/pytests/test_hybrid_multithread.py
@@ -100,8 +100,7 @@ def test_hybrid_multithread():
 
 
 # Skipped on musl, which admits a reader past a queued writer, so the try-lock
-# never fails there. glibc (writer-preferring, see IndexSpec_InitLock) and Darwin
-# both fail it.
+# never fails there.
 @skip(cluster=True, musl=True)
 def test_hybrid_depleter_lock_failure_replies_error():
     """A depleter that loses the spec try-lock to a queued writer must reply

--- a/tests/pytests/test_hybrid_multithread.py
+++ b/tests/pytests/test_hybrid_multithread.py
@@ -100,14 +100,13 @@ def test_hybrid_multithread():
 
 
 @skip(cluster=True)
-def test_hybrid_depleter_lock_failure_never_replies_success():
-    """A depleter whose try-lock loses to a queued writer must abort the command,
-    never reply a successful empty result set warning "Success (not an error)".
+def test_hybrid_depleter_lock_failure_replies_error():
+    """A depleter that loses the spec try-lock to a queued writer must reply
+    SEARCH_SAFE_DEPLETER_FAILURE.
 
     Whether a *queued* writer (rather than a lock-holding one) fails a try-lock is
-    libc-dependent — glibc and Darwin fail it, musl does not — so both outcomes are
-    accepted; the invariant asserted is that the OK-code default never ships either
-    way.
+    libc-dependent — glibc and Darwin fail it, musl does not — so where the depleters
+    win the lock instead, the query must simply return its results.
     """
     env = Env(moduleArgs='WORKERS 2 DEFAULT_DIALECT 2', enableDebugCommand=True)
     skipIfNoEnableAssert(env)
@@ -152,4 +151,4 @@ def test_hybrid_depleter_lock_failure_never_replies_success():
     if kind == 'err':
         env.assertContains('Failed to acquire index lock for background depletion', payload)
     else:
-        env.assertNotContains('Success (not an error)', str(payload))
+        env.assertGreater(payload[recursive_index(payload, 'total_results')[-1] + 1], 0)

--- a/tests/pytests/test_hybrid_multithread.py
+++ b/tests/pytests/test_hybrid_multithread.py
@@ -1,4 +1,5 @@
 import numpy as np
+import threading
 from RLTest import Env
 from common import *
 from utils.hybrid import *
@@ -96,3 +97,75 @@ def test_hybrid_multithread():
         env.assertEqual(getWorkersThpoolStats(env)['totalJobsDone'], 6)
 
     env.assertEqual(getWorkersThpoolStats(env)['numThreadsAlive'], 1)
+
+
+@skip(cluster=True)
+def test_hybrid_depleter_lock_failure_never_replies_success():
+    """A background depleter whose try-lock loses to a queued writer must abort the
+    command with SEARCH_SAFE_DEPLETER_FAILURE, never reply a successful empty result
+    set whose warnings read "Success (not an error) (SEARCH|VSIM|POST PROCESSING)".
+
+    Parks the query at BeforeHybridResultsClaim (before the depleters are
+    scheduled), then queues a writer behind the query thread's read lock. The sync
+    point's own release predicate fires on PendingSpecWriters, so the query resumes
+    straight into the try-lock race.
+
+    TIMEOUT 0 is load-bearing, not incidental: the predicate is
+    `HybridRequest_TimedOut(hreq) || PendingSpecWriters_Get() > 0` and
+    SyncPoint_WaitUntil has no internal deadline, so disabling the query timeout
+    leaves the queued writer as the *only* way the query can ever be released.
+    Reaching the assertions therefore proves the interleaving happened, rather than
+    the test passing because the query quietly timed out instead.
+
+    Only glibc's writer-preferring rwlock fails a try-lock for a *queued* writer;
+    on the reader-preferring rwlock used on macOS/FreeBSD the depleters acquire the
+    lock and the query simply succeeds. Both outcomes are accepted here — what is
+    asserted is that the OK-code default string never reaches the client.
+    """
+    env = Env(moduleArgs='WORKERS 2 DEFAULT_DIALECT 2', enableDebugCommand=True)
+    skipIfNoEnableAssert(env)
+    setup_basic_index(env)
+    query_vector = np.array([1.3, 0.0]).astype(np.float32).tobytes()
+
+    sync_point = 'BeforeHybridResultsClaim'
+    env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+    env.cmd(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point)
+
+    outcome = []
+    def run_hybrid_query(conn, out):
+        try:
+            out.append(('ok', conn.execute_command(
+                'FT.HYBRID', 'idx', 'SEARCH', '@text:(hello)',
+                'VSIM', '@vector', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
+                'TIMEOUT', '0')))
+        except Exception as e:
+            out.append(('err', str(e)))
+
+    query_thread = threading.Thread(target=run_hybrid_query,
+                                    args=(env.getConnection(), outcome), daemon=True)
+    query_thread.start()
+    wait_for_condition(
+        lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1, {}),
+        f'Timeout waiting for {sync_point} sync point')
+
+    # Indexing this write takes the spec write lock on the main thread, which parks
+    # behind the query thread's read lock and bumps PendingSpecWriters. That is what
+    # both releases the sync point and makes the depleters' try-lock fail.
+    writer_conn = env.getConnection()
+    writer_thread = threading.Thread(
+        target=lambda: writer_conn.execute_command(
+            'HSET', 'text:99', 'text', 'hello queued writer', 'type', 'text'),
+        daemon=True)
+    writer_thread.start()
+
+    query_thread.join(timeout=30)
+    env.assertFalse(query_thread.is_alive(), message='Query thread never completed')
+    writer_thread.join(timeout=30)
+
+    env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+
+    kind, payload = outcome[0]
+    if kind == 'err':
+        env.assertContains('Failed to acquire index lock for background depletion', payload)
+    else:
+        env.assertNotContains('Success (not an error)', str(payload))

--- a/tests/pytests/test_hybrid_multithread.py
+++ b/tests/pytests/test_hybrid_multithread.py
@@ -104,9 +104,10 @@ def test_hybrid_depleter_lock_failure_never_replies_success():
     """A depleter whose try-lock loses to a queued writer must abort the command,
     never reply a successful empty result set warning "Success (not an error)".
 
-    Only glibc's writer-preferring rwlock fails a try-lock for a *queued* writer, so
-    on macOS/FreeBSD the depleters win the lock and the query just succeeds. Both
-    outcomes are accepted; the assertion is that the OK-code default never ships.
+    Whether a *queued* writer (rather than a lock-holding one) fails a try-lock is
+    libc-dependent — glibc and Darwin fail it, musl does not — so both outcomes are
+    accepted; the invariant asserted is that the OK-code default never ships either
+    way.
     """
     env = Env(moduleArgs='WORKERS 2 DEFAULT_DIALECT 2', enableDebugCommand=True)
     skipIfNoEnableAssert(env)
@@ -145,6 +146,9 @@ def test_hybrid_depleter_lock_failure_never_replies_success():
     env.assertFalse(query_thread.is_alive(), message='Query thread never completed')
 
     kind, payload = outcome[0]
+    # Record which branch ran: a green run alone does not say whether the
+    # lock-failure path was reached on this platform.
+    env.debugPrint(f'depleter try-lock outcome: {kind}', force=True)
     if kind == 'err':
         env.assertContains('Failed to acquire index lock for background depletion', payload)
     else:

--- a/tests/pytests/test_hybrid_multithread.py
+++ b/tests/pytests/test_hybrid_multithread.py
@@ -101,26 +101,12 @@ def test_hybrid_multithread():
 
 @skip(cluster=True)
 def test_hybrid_depleter_lock_failure_never_replies_success():
-    """A background depleter whose try-lock loses to a queued writer must abort the
-    command with SEARCH_SAFE_DEPLETER_FAILURE, never reply a successful empty result
-    set whose warnings read "Success (not an error) (SEARCH|VSIM|POST PROCESSING)".
+    """A depleter whose try-lock loses to a queued writer must abort the command,
+    never reply a successful empty result set warning "Success (not an error)".
 
-    Parks the query at BeforeHybridResultsClaim (before the depleters are
-    scheduled), then queues a writer behind the query thread's read lock. The sync
-    point's own release predicate fires on PendingSpecWriters, so the query resumes
-    straight into the try-lock race.
-
-    TIMEOUT 0 is load-bearing, not incidental: the predicate is
-    `HybridRequest_TimedOut(hreq) || PendingSpecWriters_Get() > 0` and
-    SyncPoint_WaitUntil has no internal deadline, so disabling the query timeout
-    leaves the queued writer as the *only* way the query can ever be released.
-    Reaching the assertions therefore proves the interleaving happened, rather than
-    the test passing because the query quietly timed out instead.
-
-    Only glibc's writer-preferring rwlock fails a try-lock for a *queued* writer;
-    on the reader-preferring rwlock used on macOS/FreeBSD the depleters acquire the
-    lock and the query simply succeeds. Both outcomes are accepted here — what is
-    asserted is that the OK-code default string never reaches the client.
+    Only glibc's writer-preferring rwlock fails a try-lock for a *queued* writer, so
+    on macOS/FreeBSD the depleters win the lock and the query just succeeds. Both
+    outcomes are accepted; the assertion is that the OK-code default never ships.
     """
     env = Env(moduleArgs='WORKERS 2 DEFAULT_DIALECT 2', enableDebugCommand=True)
     skipIfNoEnableAssert(env)
@@ -134,6 +120,9 @@ def test_hybrid_depleter_lock_failure_never_replies_success():
     outcome = []
     def run_hybrid_query(conn, out):
         try:
+            # TIMEOUT 0 is load-bearing: it disables the sync point's other release
+            # arm, leaving the queued writer as the only way out. Without it the
+            # query can escape by timing out and the test passes vacuously.
             out.append(('ok', conn.execute_command(
                 'FT.HYBRID', 'idx', 'SEARCH', '@text:(hello)',
                 'VSIM', '@vector', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
@@ -148,9 +137,8 @@ def test_hybrid_depleter_lock_failure_never_replies_success():
         lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1, {}),
         f'Timeout waiting for {sync_point} sync point')
 
-    # Indexing this write takes the spec write lock on the main thread, which parks
-    # behind the query thread's read lock and bumps PendingSpecWriters. That is what
-    # both releases the sync point and makes the depleters' try-lock fail.
+    # Indexing this parks on the spec write lock behind the query's read lock,
+    # which both releases the sync point and makes the depleters' try-lock fail.
     writer_conn = env.getConnection()
     writer_thread = threading.Thread(
         target=lambda: writer_conn.execute_command(

--- a/tests/pytests/test_hybrid_multithread.py
+++ b/tests/pytests/test_hybrid_multithread.py
@@ -145,5 +145,7 @@ def test_hybrid_depleter_lock_failure_replies_error():
         return  # still parked; the assertion above is the diagnostic
 
     kind, payload = outcome[0]
+    # TODO(MOD-16487): once a queued writer no longer aborts hybrid depletion, this
+    # expectation flips — the query should be served instead of erroring.
     env.assertEqual(kind, 'err', message=f'expected the query to be aborted, got: {payload}')
     env.assertContains('Failed to acquire index lock for background depletion', str(payload))

--- a/tests/pytests/test_hybrid_multithread.py
+++ b/tests/pytests/test_hybrid_multithread.py
@@ -143,6 +143,8 @@ def test_hybrid_depleter_lock_failure_replies_error():
 
     query_thread.join(timeout=30)
     env.assertFalse(query_thread.is_alive(), message='Query thread never completed')
+    if not outcome:
+        return  # still parked; the assertion above is the diagnostic
 
     kind, payload = outcome[0]
     # Record which branch ran: a green run alone does not say whether the

--- a/tests/pytests/test_hybrid_multithread.py
+++ b/tests/pytests/test_hybrid_multithread.py
@@ -1,3 +1,4 @@
+import glob
 import numpy as np
 import threading
 from RLTest import Env
@@ -103,13 +104,14 @@ def test_hybrid_multithread():
 def test_hybrid_depleter_lock_failure_replies_error():
     """A depleter that loses the spec try-lock to a queued writer must reply
     SEARCH_SAFE_DEPLETER_FAILURE.
-
-    Whether a *queued* writer (rather than a lock-holding one) fails a try-lock is
-    libc-dependent — glibc and Darwin fail it, musl does not — so where the depleters
-    win the lock instead, the query must simply return its results.
     """
     env = Env(moduleArgs='WORKERS 2 DEFAULT_DIALECT 2', enableDebugCommand=True)
     skipIfNoEnableAssert(env)
+    # musl admits a reader past a queued writer, so the try-lock never fails there
+    # and the failure cannot be provoked. glibc (writer-preferring, see
+    # IndexSpec_InitLock) and Darwin both fail it.
+    if glob.glob('/lib/ld-musl-*.so.1'):
+        env.skip()
     setup_basic_index(env)
     query_vector = np.array([1.3, 0.0]).astype(np.float32).tobytes()
 
@@ -147,10 +149,5 @@ def test_hybrid_depleter_lock_failure_replies_error():
         return  # still parked; the assertion above is the diagnostic
 
     kind, payload = outcome[0]
-    # Record which branch ran: a green run alone does not say whether the
-    # lock-failure path was reached on this platform.
-    env.debugPrint(f'depleter try-lock outcome: {kind}', force=True)
-    if kind == 'err':
-        env.assertContains('Failed to acquire index lock for background depletion', payload)
-    else:
-        env.assertGreater(payload[recursive_index(payload, 'total_results')[-1] + 1], 0)
+    env.assertEqual(kind, 'err', message=f'expected the query to be aborted, got: {payload}')
+    env.assertContains('Failed to acquire index lock for background depletion', str(payload))

--- a/tests/pytests/test_hybrid_multithread.py
+++ b/tests/pytests/test_hybrid_multithread.py
@@ -114,7 +114,6 @@ def test_hybrid_depleter_lock_failure_never_replies_success():
     query_vector = np.array([1.3, 0.0]).astype(np.float32).tobytes()
 
     sync_point = 'BeforeHybridResultsClaim'
-    env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
     env.cmd(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point)
 
     outcome = []
@@ -137,20 +136,13 @@ def test_hybrid_depleter_lock_failure_never_replies_success():
         lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1, {}),
         f'Timeout waiting for {sync_point} sync point')
 
-    # Indexing this parks on the spec write lock behind the query's read lock,
-    # which both releases the sync point and makes the depleters' try-lock fail.
-    writer_conn = env.getConnection()
-    writer_thread = threading.Thread(
-        target=lambda: writer_conn.execute_command(
-            'HSET', 'text:99', 'text', 'hello queued writer', 'type', 'text'),
-        daemon=True)
-    writer_thread.start()
+    # Indexing this parks on the spec write lock behind the query's read lock, which
+    # both releases the sync point and makes the depleters' try-lock fail. It returns
+    # once the query has finished and dropped its read lock.
+    env.cmd('HSET', 'text:99', 'text', 'hello queued writer', 'type', 'text')
 
     query_thread.join(timeout=30)
     env.assertFalse(query_thread.is_alive(), message='Query thread never completed')
-    writer_thread.join(timeout=30)
-
-    env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
 
     kind, payload = outcome[0]
     if kind == 'err':

--- a/tests/pytests/test_hybrid_multithread.py
+++ b/tests/pytests/test_hybrid_multithread.py
@@ -1,4 +1,3 @@
-import glob
 import numpy as np
 import threading
 from RLTest import Env
@@ -100,18 +99,16 @@ def test_hybrid_multithread():
     env.assertEqual(getWorkersThpoolStats(env)['numThreadsAlive'], 1)
 
 
-@skip(cluster=True)
+# Skipped on musl, which admits a reader past a queued writer, so the try-lock
+# never fails there. glibc (writer-preferring, see IndexSpec_InitLock) and Darwin
+# both fail it.
+@skip(cluster=True, musl=True)
 def test_hybrid_depleter_lock_failure_replies_error():
     """A depleter that loses the spec try-lock to a queued writer must reply
     SEARCH_SAFE_DEPLETER_FAILURE.
     """
     env = Env(moduleArgs='WORKERS 2 DEFAULT_DIALECT 2', enableDebugCommand=True)
     skipIfNoEnableAssert(env)
-    # musl admits a reader past a queued writer, so the try-lock never fails there
-    # and the failure cannot be provoked. glibc (writer-preferring, see
-    # IndexSpec_InitLock) and Darwin both fail it.
-    if glob.glob('/lib/ld-musl-*.so.1'):
-        env.skip()
     setup_basic_index(env)
     query_vector = np.array([1.3, 0.0]).astype(np.float32).tobytes()
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `FT.HYBRID`'s background depleters take a non-blocking spec read lock so they cannot deadlock against a queued writer. Losing that race is a known limitation — but the loss was recorded only in `last_rc`. The cursor path re-derives a message from it; plain `FT.HYBRID` depletes through `Next`, so the merger saw a bare `RS_RESULT_ERROR` with an unset `QueryError`, which stringifies to its `QUERY_ERROR_CODE_OK` default. The reply carried `Success (not an error) (SEARCH|VSIM|POST PROCESSING)` as warnings and, since the code was `OK`, `ShouldReplyWithError` did not fire either: the command answered **successfully with `total_results: 0`**.

2. **Change**: record the failure on the subquery pipeline's `QueryError` at the point of loss. Debug-build assertions at both reply sites pin the invariant that `RS_RESULT_ERROR` carries a message. Two currently-unreachable siblings fixed alongside — the merger's merge-failure branch, and the lazy `rpnetCreateIterator` caller which, unlike the eager one, recorded nothing.

3. **Outcome**: standalone `FT.HYBRID` returns the same `SEARCH_SAFE_DEPLETER_FAILURE ... Please retry.` as the cursor and cluster paths — a retryable error instead of a silently empty success. Try-lock behaviour itself is unchanged.

**Also fixes a pre-existing leak.** `hreq->errors` was built with `array_new` (capacity only, `array_len` 0) but written by direct indexing, so `HybridRequest_Free`'s `array_free_ex` iterated zero elements and any message in `errors[i]` leaked. Latent until now — nothing reliably put one there on a tested path. ASan flagged it on this branch; `array_newlen` fixes it.

**Behaviour change**: under write contention this now errors where it previously returned a bogus empty success — the same error `tests/pytests/test_asm.py` already tolerates for the cluster path. Clients asserting on this scenario need the same accommodation.

### Testing

`test_hybrid_depleter_lock_failure_replies_error` parks the query at the existing `BeforeHybridResultsClaim` sync point, queues a writer behind its read lock, and requires the error. That sync point's release predicate already keys off `PendingSpecWriters`; `TIMEOUT 0` removes its other arm so the queued writer is the only way the query can be released — confirmed non-vacuous by negative control (remove the writer ⇒ the test hangs and fails).

Only glibc and Darwin fail a try-lock for a *queued* writer; musl does not, so it is skipped via a new `@skip(musl=True)`. The test fails without this fix, and CI confirms the fixed line executes on glibc — the ASan trace runs through `result_processor.c:1976`.

#### Which additional issues this PR fixes
1. MOD-17316

#### Main objects this PR modified
1. `RPSafeDepleter_DepleteFromUpstream` — records `SAFE_DEPLETER_FAILURE`; message shared with `RPSafeDepleter_DepleteAll`
2. `HybridRequest_Init` — `array_newlen` so `errors[]` are cleared on free
3. `handleAndReplyWarning` (`hybrid_exec.c`) and `_replyWarnings` (`aggregate_exec.c`) — assert that `RS_RESULT_ERROR` carries a message
4. `RPHybridMerger_Yield`, `rpnetNext_Start` — record a message before returning `RS_RESULT_ERROR`
5. `@skip(musl=True)` — new predicate in `common.py` / `includes.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
