### PR TITLE
Remove unused deadsnakes PPA from Focal setup

### DIFF
--- a/.install/ubuntu_20.04.sh
+++ b/.install/ubuntu_20.04.sh
@@ -5,9 +5,6 @@ MODE=$1 # whether to install using sudo or not
 
 $MODE apt update -qq
 $MODE apt upgrade -yqq
-$MODE apt install -yqq software-properties-common
-$MODE add-apt-repository ppa:deadsnakes/ppa -y
-$MODE apt update -yqq
 
 $MODE apt install -yqq wget make clang-format gcc lcov git openssl libssl-dev \
     unzip rsync build-essential gcc-10 g++-10 curl libclang-dev gdb


### PR DESCRIPTION
## What changed

Remove the unused deadsnakes PPA setup from the Ubuntu Focal build environment, including the `software-properties-common` dependency that was only needed for `add-apt-repository`.

## Why

The Focal artifact jobs fail before compilation while `add-apt-repository` tries to resolve `ppa:deadsnakes/ppa` through Launchpad:

```text
Cannot add PPA: 'ppa:~deadsnakes/ubuntu/ppa'.
ERROR: '~deadsnakes' user or team does not exist.
```

The `uv` migration removed the Python 3.12 packages previously supplied by this PPA, but left the repository setup behind. No package installed by the Focal script now comes from deadsnakes.

Removing the unused PPA also removes the redundant second `apt update` and the `software-properties-common` dependency that existed solely for `add-apt-repository`.

## Impact

Ubuntu Focal artifact builds no longer depend on Launchpad's PPA-resolution endpoint during setup. Compiler and build dependencies are unchanged.

## Validation

- `bash -n .install/ubuntu_20.04.sh`
- `git diff --check`


#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

