### PR TITLE
Fix iwyu to be less specific about ssl imports

### DIFF
--- a/scripts/iwyu.imp
+++ b/scripts/iwyu.imp
@@ -1,0 +1,16 @@
+# include-what-you-use mapping overrides for RediSearch.
+#
+# Entries are ["private-header", "private", "public-header", "public"]: IWYU
+# will suggest the public header whenever a symbol is found in the private one.
+
+[
+  # OpenSSL exposes its declarations through <openssl/ssl.h>. The headers below
+  # are implementation details whose names and contents differ across the
+  # OpenSSL versions we build against (1.1.1 has <openssl/ossl_typ.h> and no
+  # <openssl/types.h>; 3.x is the reverse), so they must never be named
+  # directly.
+  { include: ["<openssl/types.h>", "private", "<openssl/ssl.h>", "public"] },
+  { include: ["<openssl/ossl_typ.h>", "private", "<openssl/ssl.h>", "public"] },
+  { include: ["<openssl/ssl3.h>", "private", "<openssl/ssl.h>", "public"] },
+  { include: ["<openssl/tls1.h>", "private", "<openssl/ssl.h>", "public"] },
+]

--- a/scripts/iwyu.sh
+++ b/scripts/iwyu.sh
@@ -16,5 +16,8 @@ if [[ -z "${DB:-}" ]]; then
 fi
 echo "# compile db: $DB"
 
-iwyu_tool -p "$DB" "${@:-src}" \
+# Absolute: iwyu_tool runs each compilation from the compile db's directory.
+MAPPING=$(cd "$(dirname "$0")" && pwd)/iwyu.imp
+
+iwyu_tool -p "$DB" "${@:-src}" -- -Xiwyu "--mapping_file=$MAPPING" \
   | fix_include --nocomments --ignore_re '\.h$|query_parser/|src/geometry/rtree.cpp'

--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -9,8 +9,7 @@
 #include "conn.h"
 
 #include <uv.h>
-#include <openssl/ssl3.h>
-#include <openssl/types.h>
+#include <openssl/ssl.h>
 #include <string.h>
 #include <sys/time.h>
 


### PR DESCRIPTION
Some distributions provide older version of ssl, which this import broke.

I added a iwyu mapping file to avoid this issue happenning again, we'll be able to add more if needed.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
