### PR TITLE
[Iterator Revalidation][MOD-17394] Make RQEIterator::current() a truthful has-current oracle

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -399,6 +399,12 @@ where
 {
     #[inline(always)]
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        // `at_eos` is set only by a read/skip that found no record, never while
+        // sitting on the last valid document, so honouring it here hides the stale
+        // leftover in `self.result` without hiding the final result.
+        if self.at_eos {
+            return None;
+        }
         Some(&mut self.result)
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -161,6 +161,21 @@ pub trait RQEIterator<'index> {
     /// for later in time. The child iterator already has that result anyway,
     /// and it is this method which provides the ability to expose it (for later use).
     ///
+    /// # Contract
+    ///
+    /// This is a *has-current* oracle: `Some(&mut result)` while the iterator is
+    /// positioned on a result, `None` once a [`read`](Self::read) or
+    /// [`skip_to`](Self::skip_to) found nothing and left it positioned *past* its
+    /// last result. Never a stale result once exhausted — that is what lets
+    /// resume-path callers detect a move that landed at EOF.
+    ///
+    /// [`at_eof`](Self::at_eof) does not answer the same question: it is a
+    /// *look-ahead* ("the next [`read`](Self::read) returns `None`") which, for
+    /// some iterators, is already `true` while they still sit on their last
+    /// result. An iterator that clamps on its last result rather than advancing
+    /// past it therefore keeps returning `Some(last)` from here while reporting
+    /// [`at_eof`](Self::at_eof).
+    ///
     /// # Usage
     ///
     /// Calling this method before the first [`read`](Self::read) or [`skip_to`](Self::skip_to),

--- a/src/redisearch_rs/rqe_iterators/src/resume_outcome.rs
+++ b/src/redisearch_rs/rqe_iterators/src/resume_outcome.rs
@@ -28,11 +28,11 @@ pub enum ResumeOutcome<I> {
     /// Resumed, but the position moved forward (the previous `last_doc_id` was
     /// deleted or otherwise no longer present).
     ///
-    /// The move may have landed on a live document or run off the end. Check
-    /// `at_eof()` first: if it is not at EOF, `current()` holds the new
-    /// position; if it is at EOF, `current()` is meaningless — like the real
-    /// iterators, it keeps returning `Some` even past the end, so it must not
-    /// be trusted once `at_eof()` is true.
+    /// The move may have landed on a live document or run off the end;
+    /// [`current`](crate::RQEIterator::current) on the returned iterator tells
+    /// the two apart, `Some` being the new position and `None` a move past the
+    /// last result. Not [`at_eof`](crate::RQEIterator::at_eof), which answers a
+    /// different question — see its contract.
     Moved(I),
     /// Unrecoverable: no active iterator is produced and the suspended iterator
     /// was dropped.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -150,8 +150,16 @@ impl<E: Encoder> BaseTest<E> {
             i += 1;
         }
 
-        // Test reading after skipping to the last id
+        // Sitting on the last result: these iterators only flip `at_eof` once a
+        // read runs past it, so the two states are observable separately here.
+        let last_id = *self.doc_ids.last().unwrap();
+        assert_eq!(it.current().unwrap().doc_id, last_id);
+        assert!(!it.at_eof());
+
         assert!(matches!(it.read(), Ok(None)));
+        assert!(it.current().is_none());
+        assert!(it.at_eof());
+
         let last_doc_id = it.last_doc_id();
         assert!(matches!(it.skip_to(last_doc_id + 1), Ok(None)));
         assert!(it.at_eof());
@@ -179,9 +187,10 @@ impl<E: Encoder> BaseTest<E> {
         assert!(!it.at_eof());
         let res = it.skip_to(self.doc_ids.last().unwrap() + 1);
         assert!(matches!(res, Ok(None)));
-        // we just rewound
+        // The skip found no record, so the iterator is left unpositioned and
+        // `last_doc_id` keeps the value `rewind` gave it.
         assert_eq!(it.last_doc_id(), 0);
-        assert_eq!(it.current().unwrap().doc_id, 0);
+        assert!(it.current().is_none());
         assert!(it.at_eof());
     }
 }
@@ -797,12 +806,12 @@ pub mod via_resume {
         assert_eq!(it.current().unwrap().doc_id, last_doc_id);
 
         test.remove_document(ii, last_doc_id);
-        // The move ran off the end: the iterator is at EOF. In the resume model
-        // EOF is observed via `at_eof()` / `read()`, not `current()` (which,
-        // like the real iterators, keeps returning the last record).
+        // The move runs off the end, which `current()` reports on its own — no
+        // `at_eof()` pre-check needed to interpret it.
         let mut it = revalidate_via_resume(it, &guard)
             .expect("resume should not fail in this test")
             .expect_moved();
+        assert!(it.current().is_none());
         assert!(it.at_eof());
         assert!(it.read().expect("read should not fail").is_none());
     }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -904,6 +904,8 @@ mod optional_iterator_non_sequential_reads {
 
     struct ReadStepIterator<'index, const N: usize> {
         read_steps: [DocId; N],
+        /// Index of the next step to serve, [`utils::past_end_cursor`] once a
+        /// `read`/`skip_to` ran past the last one.
         read_step: usize,
         result: index_result::RSIndexResult<'index>,
     }
@@ -920,6 +922,9 @@ mod optional_iterator_non_sequential_reads {
 
     impl<'index, const N: usize> RQEIterator<'index> for ReadStepIterator<'index, N> {
         fn current(&mut self) -> Option<&mut index_result::RSIndexResult<'index>> {
+            if self.read_step == utils::past_end_cursor(N) {
+                return None;
+            }
             Some(&mut self.result)
         }
 
@@ -928,6 +933,7 @@ mod optional_iterator_non_sequential_reads {
         ) -> Result<Option<&mut index_result::RSIndexResult<'index>>, rqe_iterators::RQEIteratorError>
         {
             if self.at_eof() {
+                self.read_step = utils::past_end_cursor(N);
                 return Ok(None);
             }
 
@@ -946,7 +952,10 @@ mod optional_iterator_non_sequential_reads {
             }
 
             match self.result.doc_id.cmp(&doc_id) {
-                std::cmp::Ordering::Less => Ok(None),
+                std::cmp::Ordering::Less => {
+                    self.read_step = utils::past_end_cursor(N);
+                    Ok(None)
+                }
                 std::cmp::Ordering::Equal => Ok(Some(SkipToOutcome::Found(&mut self.result))),
                 std::cmp::Ordering::Greater => Ok(Some(SkipToOutcome::NotFound(&mut self.result))),
             }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -11,6 +11,8 @@ use std::{cell::RefCell, rc::Rc, time::Duration};
 
 use index_result::{RSIndexResult, RSOffsetSlice};
 use rqe_core::{DocId, RS_FIELDMASK_ALL};
+
+use super::past_end_cursor;
 use rqe_iterators::{IteratorType, RQEIterator, WildcardIterator};
 
 /// Test iterator used in unit tests that expect an [`RQEIterator`]
@@ -63,6 +65,8 @@ pub struct Mock<'index, const N: usize> {
     /// single-byte LEB128 varint encoding, so the byte can be passed directly to
     /// [`RSOffsetSlice::from_slice`] without a separate encoding step.
     positions: Option<[u8; N]>,
+    /// Index of the next document to serve, [`past_end_cursor`] once a
+    /// `read`/`skip_to` ran past the last one.
     next_index: usize,
     data: MockData,
 }
@@ -333,6 +337,9 @@ impl<'index, const N: usize> Mock<'index, N> {
 
 impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        if self.next_index == past_end_cursor(N) {
+            return None;
+        }
         Some(&mut self.result)
     }
 
@@ -346,6 +353,8 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
             // Check if we should force return None (simulating misbehaving iterator)
             if data.force_read_none {
                 data.force_read_none = false; // Clear after one use
+                // Deliberately not recorded as past the end: only the `None` is
+                // fabricated, the mock still has documents to serve.
                 return Ok(None);
             }
 
@@ -353,6 +362,7 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
                 return if let Some(err) = data.error_at_done {
                     Err(err.into_rqe_iterator_error())
                 } else {
+                    self.next_index = past_end_cursor(N);
                     Ok(None)
                 };
             }
@@ -394,6 +404,7 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
             return if let Some(err) = data.error_at_done {
                 Err(err.into_rqe_iterator_error())
             } else {
+                self.next_index = past_end_cursor(N);
                 Ok(None)
             };
         }
@@ -429,13 +440,17 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
             MockRevalidateResult::Ok => rqe_iterators::RQEValidateStatus::Ok,
             MockRevalidateResult::Abort => rqe_iterators::RQEValidateStatus::Aborted,
             MockRevalidateResult::Move => {
-                rqe_iterators::RQEValidateStatus::Moved {
-                    current: (self.next_index < N).then(|| {
-                        // Simulate a move by incrementing nextIndex
-                        self.set_result(self.next_index);
-                        self.next_index += 1;
-                        &mut self.result
-                    }),
+                if self.next_index < N {
+                    // Simulate a move by incrementing nextIndex
+                    self.set_result(self.next_index);
+                    self.next_index += 1;
+                    rqe_iterators::RQEValidateStatus::Moved {
+                        current: Some(&mut self.result),
+                    }
+                } else {
+                    // The move ran off the end, leaving the iterator unpositioned.
+                    self.next_index = past_end_cursor(N);
+                    rqe_iterators::RQEValidateStatus::Moved { current: None }
                 }
             }
         })
@@ -584,6 +599,10 @@ impl<'query, const N: usize> rqe_iterators::RQESuspendedIterator<'query> for Moc
                         self.result.doc_id = doc_id;
                     }
                     self.next_index += 1;
+                } else {
+                    // The move ran off the end, leaving the resumed iterator
+                    // unpositioned.
+                    self.next_index = past_end_cursor(N);
                 }
                 true
             }
@@ -622,6 +641,8 @@ impl<'query, const N: usize> rqe_iterators::RQESuspendedIterator<'query> for Moc
 pub struct MockVec<'index> {
     result: RSIndexResult<'index>,
     doc_ids: Vec<DocId>,
+    /// Index of the next document to serve, [`past_end_cursor`] once a
+    /// `read`/`skip_to` ran past the last one.
     next_index: usize,
     data: MockData,
 }
@@ -651,6 +672,9 @@ impl<'index> MockVec<'index> {
 
 impl<'index> RQEIterator<'index> for MockVec<'index> {
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        if self.next_index == past_end_cursor(self.doc_ids.len()) {
+            return None;
+        }
         Some(&mut self.result)
     }
 
@@ -670,6 +694,7 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
                 return if let Some(err) = data.error_at_done {
                     Err(err.into_rqe_iterator_error())
                 } else {
+                    self.next_index = past_end_cursor(self.doc_ids.len());
                     Ok(None)
                 };
             }
@@ -708,6 +733,7 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
             return if let Some(err) = data.error_at_done {
                 Err(err.into_rqe_iterator_error())
             } else {
+                self.next_index = past_end_cursor(n);
                 Ok(None)
             };
         }
@@ -743,13 +769,19 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
         Ok(match revalidate_result {
             MockRevalidateResult::Ok => rqe_iterators::RQEValidateStatus::Ok,
             MockRevalidateResult::Abort => rqe_iterators::RQEValidateStatus::Aborted,
-            MockRevalidateResult::Move => rqe_iterators::RQEValidateStatus::Moved {
-                current: (self.next_index < n).then(|| {
+            MockRevalidateResult::Move => {
+                if self.next_index < n {
                     self.result.doc_id = self.doc_ids[self.next_index];
                     self.next_index += 1;
-                    &mut self.result
-                }),
-            },
+                    rqe_iterators::RQEValidateStatus::Moved {
+                        current: Some(&mut self.result),
+                    }
+                } else {
+                    // The move ran off the end, leaving the iterator unpositioned.
+                    self.next_index = past_end_cursor(n);
+                    rqe_iterators::RQEValidateStatus::Moved { current: None }
+                }
+            }
         })
     }
 
@@ -864,6 +896,10 @@ impl<'query> rqe_iterators::RQESuspendedIterator<'query> for MockVecSuspended {
                     // offsets), so setting `doc_id` alone is sufficient.
                     self.result.doc_id = self.doc_ids[self.next_index];
                     self.next_index += 1;
+                } else {
+                    // The move ran off the end, leaving the resumed iterator
+                    // unpositioned.
+                    self.next_index = past_end_cursor(self.doc_ids.len());
                 }
                 true
             }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mod.rs
@@ -24,6 +24,8 @@ use rqe_iterators::{IteratorType, RQEIterator, RQEIteratorError, SkipToOutcome};
 /// `RSIndexResult::field_mask`.
 pub(crate) struct FieldMaskMock {
     doc_ids: Vec<u64>,
+    /// Index of the next document to serve, [`past_end_cursor`] once we ran past
+    /// the last one.
     next: usize,
     result: RSIndexResult<'static>,
     mask: inverted_index::FieldMask,
@@ -42,11 +44,15 @@ impl FieldMaskMock {
 
 impl RQEIterator<'static> for FieldMaskMock {
     fn current(&mut self) -> Option<&mut RSIndexResult<'static>> {
+        if self.next == past_end_cursor(self.doc_ids.len()) {
+            return None;
+        }
         Some(&mut self.result)
     }
 
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'static>>, RQEIteratorError> {
         if self.next >= self.doc_ids.len() {
+            self.next = past_end_cursor(self.doc_ids.len());
             return Ok(None);
         }
         self.result.doc_id = self.doc_ids[self.next];
@@ -63,6 +69,7 @@ impl RQEIterator<'static> for FieldMaskMock {
             self.next += 1;
         }
         if self.next >= self.doc_ids.len() {
+            self.next = past_end_cursor(self.doc_ids.len());
             return Ok(None);
         }
         self.result.doc_id = self.doc_ids[self.next];
@@ -110,6 +117,17 @@ impl RQEIterator<'static> for FieldMaskMock {
 
 use rqe_core::DocId;
 use std::collections::BTreeSet;
+
+/// The cursor value the mock iterators in these tests use to record that a
+/// `read`/`skip_to` ran past their last document, given the number of documents
+/// they hold.
+///
+/// A cursor equal to `len` cannot express it: that is also the state while still
+/// sitting on the last document, and [`RQEIterator::current`] has to tell the two
+/// apart (it is `Some` on the last document, `None` past it).
+pub(crate) fn past_end_cursor(len: usize) -> usize {
+    len + 1
+}
 
 /// Drain all documents from an iterator and return their doc_ids.
 pub(crate) fn drain_doc_ids<'index, I: RQEIterator<'index>>(it: &mut I) -> Vec<DocId> {

--- a/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
+++ b/src/redisearch_rs/top_k/tests/integration/adhoc_lifecycle.rs
@@ -146,7 +146,12 @@ impl<'index> ErrOnSecondRead<'index> {
 
 impl<'index> RQEIterator<'index> for ErrOnSecondRead<'index> {
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
-        None
+        // Later reads fail rather than report depletion, so this stub never
+        // advances past its single document once it has been read.
+        if self.n == 0 {
+            return None;
+        }
+        Some(&mut self.result)
     }
 
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {

--- a/src/redisearch_rs/top_k/tests/integration/revalidation.rs
+++ b/src/redisearch_rs/top_k/tests/integration/revalidation.rs
@@ -84,24 +84,33 @@ impl<'index> RQEIterator<'index> for AbortOnRevalidate {
 /// surfacing the child's reposition as its own.
 struct MovedOnRevalidate<'index> {
     current: RSIndexResult<'index>,
+    /// Set once [`RQEIterator::read`] reported depletion, after which
+    /// [`RQEIterator::current`] no longer advertises a position.
+    at_eos: bool,
 }
 
 impl<'index> MovedOnRevalidate<'index> {
     fn new() -> Self {
         Self {
             current: RSIndexResult::build_virt().doc_id(7).build(),
+            at_eos: false,
         }
     }
 }
 
 impl<'index> RQEIterator<'index> for MovedOnRevalidate<'index> {
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
-        None
+        // Sits on the document its `revalidate` reports as the moved-to position.
+        if self.at_eos {
+            return None;
+        }
+        Some(&mut self.current)
     }
 
     fn read(
         &mut self,
     ) -> Result<Option<&mut RSIndexResult<'index>>, rqe_iterators::RQEIteratorError> {
+        self.at_eos = true;
         Ok(None)
     }
 
@@ -133,7 +142,9 @@ impl<'index> RQEIterator<'index> for MovedOnRevalidate<'index> {
     }
 
     fn at_eof(&self) -> bool {
-        false
+        // The next `read` does report depletion, even while `current` still
+        // reports a position.
+        true
     }
 
     fn type_(&self) -> rqe_iterator_type::IteratorType {


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `RQEIterator::current()` was not a reliable "has-current" oracle. The inverted-index iterators (`InvIndIterator`, backing Term/Tag/Numeric/Missing/Wildcard) returned a stale `Some(last result)` even after a `read`/`skip_to` had run *past* the end of the posting list. Callers could therefore only trust `current()` in combination with a separate `at_eof()` check — and `at_eof()` is a *look-ahead* predicate ("the next `read` returns `None`") that is already `true` while the iterator still sits on its last valid result, so the two cannot be conflated. This is what pushed the resume path toward fragile pre/post `last_doc_id` heuristics to reconstruct "did the move land on a live doc?".

2. **Change:** Tighten and document the `current()` contract: it returns `Some(&mut result)` while positioned on a result, and `None` once the iterator has advanced *past* its last result. Concretely, `InvIndIterator::current()` now returns `None` when `at_eos` is set (a read/skip found no record), instead of the stale leftover. It is explicitly distinct from `at_eof()` (the look-ahead). Iterators that clamp on their last result (IdList / the optional family) correctly keep returning `Some(last)` — that last result genuinely *is* their current — and the single-child wrappers (MaybeEmpty / Profile / Metric) inherit the fix by delegation, so only the InvInd family needed a code change.

3. **Outcome:** `current()` is now a truthful has-current oracle. Resume-path callers can recover a `Moved` outcome via `current()` alone (`Some` = new position, `None` = ran off the end), without the `at_eof()`-then-`current()` footgun or `last_doc_id` snapshot heuristics. No user-facing behavior change: every existing `current()` consumer already tolerated `None` (the FFI `sync_current` maps it to a null `header.current`; composites use `if let Some(..)`), and the full `rqe_iterators` suite (793 tests) plus the end-to-end Python suite pass.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs` — `InvIndIterator::current()` returns `None` past EOF (`at_eos`).
2. `src/redisearch_rs/rqe_iterators/src/lib.rs` — tightened the `RQEIterator::current()` trait-contract doc (has-current oracle; distinct from `at_eof()`).
3. `src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs` — updated/added assertions for the `current() == None` past EOF vs `at_eof()` look-ahead distinction.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
