### PR TITLE
[2.8] Remove unused deadsnakes PPA from Focal setup

### DIFF
--- a/.install/ubuntu_20.04.sh
+++ b/.install/ubuntu_20.04.sh
@@ -5,9 +5,6 @@ MODE=$1 # whether to install using sudo or not
 
 $MODE apt update -qq
 $MODE apt upgrade -yqq
-$MODE apt install -yqq software-properties-common
-$MODE add-apt-repository ppa:deadsnakes/ppa -y
-$MODE apt update -yqq
 
 $MODE apt install -yqq wget make clang-format gcc lcov git openssl libssl-dev \
     unzip rsync build-essential gcc-10 g++-10 curl libclang-dev gdb


### PR DESCRIPTION
Backport of #10659 to 2.8.

## Original PR

https://github.com/RediSearch/RediSearch/pull/10659

## Changes from original

Clean cherry-pick, no changes needed. Removes the unused deadsnakes PPA setup and the `software-properties-common` package that was only needed by `add-apt-repository`.

## Validation

- `bash -n .install/ubuntu_20.04.sh`
- `git diff --check origin/2.8..HEAD`
- Patch ID matches the original PR
- Full build reached 84% but failed in unchanged `src/util/circular_buffer.c` because the host compiler does not expose the branch's legacy `ATOMIC_VAR_INIT` interface

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
