### PR TITLE
[MOD-14947] Fix incorrect optimizer scorer type classification

### DIFF
--- a/src/query_optimizer.c
+++ b/src/query_optimizer.c
@@ -73,20 +73,15 @@ void QOptimizer_Parse(AREQ *req) {
     opt->scorerType = SCORER_TYPE_NONE;
   } else {
     const char *scorer = req->searchopts.scorerName;
-    if (!scorer || !strcmp(scorer, BM25_STD_SCORER_NAME)) {      // default is BM25STD
-      opt->scorerType = SCORER_TYPE_TERM;
-    } else if (!strcmp(scorer, TFIDF_SCORER_NAME)) {
-      opt->scorerType = SCORER_TYPE_TERM;
-    } else if (!strcmp(scorer, TFIDF_DOCNORM_SCORER_NAME)) {
-      opt->scorerType = SCORER_TYPE_TERM;
-    } else if (!strcmp(scorer, DISMAX_SCORER_NAME)) {
-      opt->scorerType = SCORER_TYPE_TERM;
-    } else if (!strcmp(scorer, BM25_SCORER_NAME)) {
-      opt->scorerType = SCORER_TYPE_TERM;
-    } else if (!strcmp(scorer, DOCSCORE_SCORER)) {
+    // Scorers reading only document metadata, never term data.
+    if (scorer && (!strcmp(scorer, DOCSCORE_SCORER) ||
+                   !strcmp(scorer, HAMMINGDISTANCE_SCORER))) {
       opt->scorerType = SCORER_TYPE_DOC;
-    } else if (!strcmp(scorer, HAMMINGDISTANCE_SCORER)) {
-      opt->scorerType = SCORER_TYPE_DOC;
+    } else {
+      // Every other scorer, including the default and any extension-provided
+      // one, needs scoring. Claiming otherwise drops the scorer and sorter from
+      // the pipeline, so results come back unranked.
+      opt->scorerType = SCORER_TYPE_TERM;
     }
   }
 }

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -689,11 +689,12 @@ def testDeletedDocsDuringCollection(env):
 
 @skip(cluster=True)
 def testScorerTypes(env):
-    """Each scorer name ranks identically whether or not the optimizer runs.
+    """Every registered scorer ranks identically whether or not the optimizer runs.
 
-    Term frequency, field length and document score all differ per document, so
-    every scorer produces a distinct ranking. A scorer classified as needing no
-    scoring therefore returns a visibly different order, instead of matching the
+    A scorer the optimizer classifies as needing no scoring loses the scorer and
+    sorter from its pipeline and comes back unranked. Term frequency, field length
+    and document score all differ per document, so each scorer produces a distinct
+    ranking and that loss shows up as a different order rather than matching the
     unoptimized path by coincidence.
     """
     conn = getConnectionByEnv(env)
@@ -704,7 +705,8 @@ def testScorerTypes(env):
         conn.execute_command('hset', i, 'n', i, '__score', (num_docs - i) / num_docs, 't', text)
 
     params = ['limit', 0, 3, 'NOCONTENT', 'WITHSCORES']
-    for scorer in ['BM25STD', 'TFIDF', 'TFIDF.DOCNORM', 'DISMAX', 'BM25', 'DOCSCORE', 'HAMMING']:
+    for scorer in ['BM25STD', 'BM25STD.TANH', 'BM25STD.NORM', 'TFIDF', 'TFIDF.DOCNORM',
+                   'DISMAX', 'BM25', 'DOCSCORE', 'HAMMING']:
         compare_optimized_to_not_nocontent(env, ['ft.search', 'idx', 'foo', 'SCORER', scorer],
                                            params, 'scorer ' + scorer)
 


### PR DESCRIPTION
- based on https://github.com/RediSearch/RediSearch/pull/10655 
- Follow up to https://github.com/RediSearch/RediSearch/pull/10655/files#r3680948563

Test showcase the expected behaviour, red without the fix.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
