### PR TITLE
[MOD-17351] Fix cluster FT.AGGREGATE WITHCOUNT hang caused by a coordinator thread-pool initialization race

### DIFF
--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -335,8 +335,7 @@ static void redisearch_thpool_verify_init(struct redisearch_thpool_t *thpool_p) 
     }
   }
 
-  LOG_IF_EXISTS("verbose", "Thread pool of size %zu initialized successfully",
-                thpool_p->n_threads)
+  LOG_IF_EXISTS("verbose", "Thread pool of size %zu initialized successfully", n_threads)
 }
 
 size_t redisearch_thpool_add_threads(redisearch_thpool_t *thpool_p,
@@ -371,7 +370,7 @@ size_t redisearch_thpool_add_threads(redisearch_thpool_t *thpool_p,
   }
 
   LOG_IF_EXISTS("verbose", "Thread pool size increased to %zu successfully", n_threads)
-  return thpool_p->n_threads;
+  return n_threads;
 }
 
 /* Add work to the thread pool */

--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -105,13 +105,8 @@ typedef struct priority_queue {
 typedef struct redisearch_thpool_t {
   size_t n_threads;
   volatile atomic_size_t num_threads_alive;   /* threads currently alive   */
-  ThpoolState state;                          /* threadpool state. Written only under the jobqueues
-                                                lock. Job submitters may run on any thread (e.g. the
-                                                coordinator IO thread), so the lazy-init decision in
-                                                push_chain_verify_init_threads reads it under the
-                                                lock. Other readers (add_threads, config reduce,
-                                                is_initialized) are main-thread-only and target
-                                                pools whose initializer is also the main thread. */
+  ThpoolState state;                          /* threadpool state, read and written under the
+                                                jobqueues lock */
   priorityJobqueue jobqueues;                 /* job queue                 */
   LogFunc log;                                /* log callback              */
   volatile atomic_size_t total_jobs_done;     /* statistics for observability */
@@ -123,15 +118,10 @@ typedef struct redisearch_thpool_t {
 
 /* Set (for its whole lifetime) to the pool a worker thread belongs to, from
  * within thread_do. NULL on any non-worker thread (e.g. the main thread).
- * Used to detect re-entrant job submission: a worker submitting jobs to its
- * OWN pool must never run verify_init. The reachable case is a pool draining
- * in TERMINATE_WHEN_EMPTY (state == THPOOL_UNINITIALIZED while workers are
- * still alive): the revive path coordinates every live worker through a
- * barrier that counts the submitter itself, which is stuck initiating the
- * barrier and can never arrive at it -> deadlock. Skipping is safe because
- * TERMINATE_WHEN_EMPTY workers keep draining the queue until it is empty, so
- * the jobs just pushed are still executed; reviving the pool to full strength
- * is deferred to the next non-worker submission. */
+ * A worker submitting jobs to its OWN pool must never run verify_init: the
+ * revive barrier counts every live worker, including the submitter, which
+ * would then wait on its own arrival. Skipping is safe: draining workers
+ * only exit once the queue is empty, so the pushed jobs still run. */
 static __thread redisearch_thpool_t *g_thpool_self = NULL;
 
 
@@ -245,17 +235,9 @@ struct redisearch_thpool_t *redisearch_thpool_create(size_t num_threads, size_t 
 /* Initialise thread pool. Must be called with the pool lock held and with
  * `state != THPOOL_INITIALIZED`; releases the lock.
  *
- * The caller's state check, the decision below and the INITIALIZED transition
- * form a single critical section, so submitters racing from other threads
- * (e.g. the coordinator IO thread pushing a deferred job while the main
- * thread performs the first-use initialization) either perform the whole
- * initialization or skip it entirely. They can never observe a
- * mid-initialization pool and misread it as the revive case (MOD-17351).
- *
- * INITIALIZED is published before the revive drain / thread spawn complete;
- * it means "initialization is owned and its jobs are queued", not "all
- * threads are up". Jobs pushed by racing submitters are simply drained once
- * the threads are. */
+ * INITIALIZED is published before the revive drain / thread spawn complete:
+ * it means initialization is owned and its jobs are queued, not that all
+ * threads are up. Jobs pushed meanwhile are drained once the threads are. */
 static void redisearch_thpool_verify_init(struct redisearch_thpool_t *thpool_p) {
   /** Either:
    * case 1: There are no threads alive, just add n_threads threads.
@@ -274,9 +256,8 @@ static void redisearch_thpool_verify_init(struct redisearch_thpool_t *thpool_p) 
   size_t n_threads = thpool_p->n_threads;
   size_t n_new_threads = 0;
 
-  /* Case-2 coordination state. Lives at function scope so it outlives the
-   * admin jobs, which are guaranteed done before barrier_wait_and_destroy
-   * returns. */
+  /* Case-2 coordination state, at function scope so it outlives the admin
+   * jobs (all done before barrier_wait_and_destroy returns). */
   barrier_t barrier;
   SignalThreadCtx job_arg_revive = {.barrier = &barrier, .new_state = THREAD_RUNNING};
   SignalThreadCtx job_arg_kill = {.barrier = &barrier, .new_state = THREAD_TERMINATE_ASAP};
@@ -322,16 +303,15 @@ static void redisearch_thpool_verify_init(struct redisearch_thpool_t *thpool_p) 
     n_new_threads = n_threads;
   }
 
-  /* Publish INITIALIZED before releasing the lock so racing submitters skip
-   * initialization; see the function comment for what the flag means. */
+  /* Publish INITIALIZED before releasing the lock so concurrent submitters
+   * skip initialization. */
   thpool_p->state = THPOOL_INITIALIZED;
   redisearch_thpool_unlock(thpool_p);
 
   if (curr_num_threads_alive) {
     /* Wait for the threads to pass the barrier and destroy the barrier.
-     * New threads (case 2.b) are spawned only after this drain completes so
-     * they cannot take an admin job intended for a TERMINATE_WHEN_EMPTY
-     * thread (each live thread must run exactly one). */
+     * New threads (case 2.b) are spawned only after this drain, so each
+     * live thread runs exactly one admin job. */
     barrier_wait_and_destroy(&barrier);
   }
 
@@ -361,11 +341,13 @@ static void redisearch_thpool_verify_init(struct redisearch_thpool_t *thpool_p) 
 
 size_t redisearch_thpool_add_threads(redisearch_thpool_t *thpool_p,
                                      size_t n_threads_to_add) {
-  /* n_threads is only configured and read by the main thread (protected by the GIL). */
   RS_ASSERT(n_threads_to_add > 0 && "Number of threads to add must be greater than 0");
+  redisearch_thpool_lock(thpool_p);
   size_t n_threads = thpool_p->n_threads + n_threads_to_add;
   thpool_p->n_threads = n_threads;
-  if (thpool_p->state == THPOOL_UNINITIALIZED) {
+  ThpoolState state = thpool_p->state;
+  redisearch_thpool_unlock(thpool_p);
+  if (state == THPOOL_UNINITIALIZED) {
     // If the thpool is not initialized, we just set the n_threads and return, so that when workers are added
     // they will be initialized with the new n_threads.
     return n_threads;
@@ -481,15 +463,13 @@ static void redisearch_thpool_push_chain_verify_init_threads(
   priority_queue_push_chain_unsafe(&thpool_p->jobqueues, f_newjob_p, l_newjob_p, n, priority);
 
   /* Lazy initialization. The push, the state check and the initialization
-   * decision share one lock hold: submitters run on multiple threads (main
-   * thread and the coordinator IO thread), and an unlocked check here used to
-   * misread a mid-initialization pool as "threads alive in
-   * TERMINATE_WHEN_EMPTY" and deadlock on the revive barrier (MOD-17351).
-   *
-   * Skip when the submitter is one of this pool's own workers (see
-   * g_thpool_self): the revive barrier would count the submitter itself,
-   * which can never arrive at it. The jobs just pushed are still drained by
-   * the live workers. */
+   * decision share one lock hold, so a concurrent submitter can never
+   * observe a mid-initialization pool. Skip when the submitter is one of
+   * this pool's own workers (see g_thpool_self).
+   * Note: a non-worker submitter that finds the pool draining
+   * (TERMINATE_WHEN_EMPTY) blocks on the revive barrier until every live
+   * worker finishes its current job, so it must not push jobs that depend
+   * on its own further progress to a pool that can be draining. */
   if (thpool_p->state == THPOOL_INITIALIZED || g_thpool_self == thpool_p) {
     redisearch_thpool_unlock(thpool_p);
     return;
@@ -559,8 +539,7 @@ void redisearch_thpool_terminate_threads(redisearch_thpool_t *thpool_p) {
     while (thpool_p->num_threads_alive) {
       usleep(1);
     }
-    /* Re-acquire the lock for the state transition (`state` is written only
-     * under the pool lock). */
+    /* Re-acquire the lock for the state transition. */
     redisearch_thpool_lock(thpool_p);
   }
   thpool_p->state = THPOOL_UNINITIALIZED;
@@ -656,7 +635,10 @@ int redisearch_thpool_paused(redisearch_thpool_t *thpool_p) {
 }
 
 int redisearch_thpool_is_initialized(redisearch_thpool_t *thpool_p) {
-  return thpool_p->state == THPOOL_INITIALIZED;
+  redisearch_thpool_lock(thpool_p);
+  int initialized = thpool_p->state == THPOOL_INITIALIZED;
+  redisearch_thpool_unlock(thpool_p);
+  return initialized;
 }
 
 void redisearch_thpool_resume_threads(redisearch_thpool_t *thpool_p) {
@@ -725,13 +707,9 @@ static void *thread_do(void *p) {
 
   LOG_IF_EXISTS("verbose", "Creating background thread: %s", thread_name)
 
-  /* Mark thread as alive (initialized).
-   * Ordering invariant: `num_threads_alive` and `started` are set BEFORE the
-   * first queue pull below (the first operation that needs the pool lock).
-   * verify_init's started-wait relies on this: it must be able to complete
-   * even if its caller still interacts with the pool under the lock, and by
-   * the time `started` is observed the alive count already includes this
-   * thread. */
+  /* Mark thread as alive (initialized). Both `num_threads_alive` and
+   * `started` must be set before the first queue pull (which takes the pool
+   * lock), so an initializer's started-wait always completes. */
   thpool_p->num_threads_alive += 1;
   threadCtx thread_ctx = {.thread_state = THREAD_RUNNING};
   // Set to true after accounting num_threads_alive, useful for testing
@@ -1113,28 +1091,30 @@ static void admin_job_change_state_last_destroys_barrier(void *job_arg_) {
 }
 
 void redisearch_thpool_schedule_config_reduce_threads_job(redisearch_thpool_t *thpool_p, size_t n_threads_to_remove, bool terminate_when_empty) {
-  /* n_threads is only configured and read by the main thread (protected by the GIL). */
   /** THPOOL_UNINITIALIZED means either:
    * 1. thpool->n_threads > 0, and there are no threads alive
    * 2. There are threads alive in TERMINATE_WHEN_EMPTY state.
    * In any case we cannot remove more threads. */
+  redisearch_thpool_lock(thpool_p);
   if (thpool_p->state == THPOOL_UNINITIALIZED || thpool_p->n_threads == 0) {
     if (thpool_p->n_threads > 0) {
       // If is UNINITIALIZED, at least it would lazily initialize less threads
       RS_ASSERT(thpool_p->n_threads >= n_threads_to_remove && "Number of threads can't be negative");
       thpool_p->n_threads -= n_threads_to_remove;
     }
+    redisearch_thpool_unlock(thpool_p);
     return;
   }
 
   size_t n_threads = thpool_p->n_threads;
-  LOG_IF_EXISTS("verbose", "Scheduling from main thread to remove %zu threads", n_threads_to_remove);
   RS_LOG_ASSERT((!terminate_when_empty || n_threads_to_remove == n_threads), "If remove_all is set, n_threads_to_remove must be equal to n_threads");
   RS_LOG_ASSERT(thpool_p->n_threads >= n_threads_to_remove, "Number of threads can't be negative");
   RS_LOG_ASSERT(thpool_p->jobqueues.state == JOBQ_RUNNING, "Can't remove threads while jobq is paused");
 
   ThreadState new_state = terminate_when_empty ? THREAD_TERMINATE_WHEN_EMPTY : THREAD_TERMINATE_ASAP;
   thpool_p->n_threads -= n_threads_to_remove;
+  redisearch_thpool_unlock(thpool_p);
+  LOG_IF_EXISTS("verbose", "Scheduling from main thread to remove %zu threads", n_threads_to_remove);
   redisearch_thpool_work_t jobs[n_threads_to_remove];
   /* Create a barrier. */
   pthread_barrier_t *barrier = rm_malloc(sizeof(pthread_barrier_t));

--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -105,7 +105,13 @@ typedef struct priority_queue {
 typedef struct redisearch_thpool_t {
   size_t n_threads;
   volatile atomic_size_t num_threads_alive;   /* threads currently alive   */
-  ThpoolState state;                          /* threadpool state, accessed only by the main thread */
+  ThpoolState state;                          /* threadpool state. Written only under the jobqueues
+                                                lock. Job submitters may run on any thread (e.g. the
+                                                coordinator IO thread), so the lazy-init decision in
+                                                push_chain_verify_init_threads reads it under the
+                                                lock. Other readers (add_threads, config reduce,
+                                                is_initialized) are main-thread-only and target
+                                                pools whose initializer is also the main thread. */
   priorityJobqueue jobqueues;                 /* job queue                 */
   LogFunc log;                                /* log callback              */
   volatile atomic_size_t total_jobs_done;     /* statistics for observability */
@@ -118,8 +124,14 @@ typedef struct redisearch_thpool_t {
 /* Set (for its whole lifetime) to the pool a worker thread belongs to, from
  * within thread_do. NULL on any non-worker thread (e.g. the main thread).
  * Used to detect re-entrant job submission: a worker submitting jobs to its
- * OWN pool must not run the verify_init all-threads barrier, because the
- * submitting worker cannot also arrive at that barrier -> deadlock. */
+ * OWN pool must never run verify_init. The reachable case is a pool draining
+ * in TERMINATE_WHEN_EMPTY (state == THPOOL_UNINITIALIZED while workers are
+ * still alive): the revive path coordinates every live worker through a
+ * barrier that counts the submitter itself, which is stuck initiating the
+ * barrier and can never arrive at it -> deadlock. Skipping is safe because
+ * TERMINATE_WHEN_EMPTY workers keep draining the queue until it is empty, so
+ * the jobs just pushed are still executed; reviving the pool to full strength
+ * is deferred to the next non-worker submission. */
 static __thread redisearch_thpool_t *g_thpool_self = NULL;
 
 
@@ -230,12 +242,22 @@ struct redisearch_thpool_t *redisearch_thpool_create(size_t num_threads, size_t 
   return thpool_p;
 }
 
-/* Initialise thread pool. This function is not thread safe. */
+/* Initialise thread pool. Must be called with the pool lock held and with
+ * `state != THPOOL_INITIALIZED`; releases the lock.
+ *
+ * The caller's state check, the decision below and the INITIALIZED transition
+ * form a single critical section, so submitters racing from other threads
+ * (e.g. the coordinator IO thread pushing a deferred job while the main
+ * thread performs the first-use initialization) either perform the whole
+ * initialization or skip it entirely. They can never observe a
+ * mid-initialization pool and misread it as the revive case (MOD-17351).
+ *
+ * INITIALIZED is published before the revive drain / thread spawn complete;
+ * it means "initialization is owned and its jobs are queued", not "all
+ * threads are up". Jobs pushed by racing submitters are simply drained once
+ * the threads are. */
 static void redisearch_thpool_verify_init(struct redisearch_thpool_t *thpool_p) {
-  if (thpool_p->state == THPOOL_INITIALIZED)
-    return; // Already initialized and all threads are active.
-
-  /** Else, either:
+  /** Either:
    * case 1: There are no threads alive, just add n_threads threads.
    * case 2: There are threads alive in terminate_when_empty state.
    * In this case, we need to add the missing threads to adjust
@@ -248,10 +270,17 @@ static void redisearch_thpool_verify_init(struct redisearch_thpool_t *thpool_p) 
    *              terminate when empty and *might also* increased n_threads)
    *              - n_threads_to_revive = num_threads_alive
    *              - n_new_threads = n_threads - num_threads_alive new threads */
-  redisearch_thpool_lock(thpool_p);
   size_t curr_num_threads_alive = thpool_p->num_threads_alive;
   size_t n_threads = thpool_p->n_threads;
   size_t n_new_threads = 0;
+
+  /* Case-2 coordination state. Lives at function scope so it outlives the
+   * admin jobs, which are guaranteed done before barrier_wait_and_destroy
+   * returns. */
+  barrier_t barrier;
+  SignalThreadCtx job_arg_revive = {.barrier = &barrier, .new_state = THREAD_RUNNING};
+  SignalThreadCtx job_arg_kill = {.barrier = &barrier, .new_state = THREAD_TERMINATE_ASAP};
+
   if (curr_num_threads_alive) { // Case 2 - some or all threads are alive in
                                 // TERMINATE_WHEN_EMPTY state
     size_t n_threads_to_revive = 0;
@@ -269,21 +298,18 @@ static void redisearch_thpool_verify_init(struct redisearch_thpool_t *thpool_p) 
     }
 
     /* In both cases we send `curr_num_threads_alive` jobs. */
-    barrier_t barrier;
     barrier_init(&barrier, NULL, curr_num_threads_alive);
 
     /* Create jobs and their args */
     redisearch_thpool_work_t jobs[curr_num_threads_alive];
 
     /* Set new state of `n_threads_to_revive` threads state to 'THREAD_RUNNING' */
-    SignalThreadCtx job_arg_revive = {.barrier = &barrier, .new_state = THREAD_RUNNING};
     for (size_t i = 0; i < n_threads_to_revive; i++) {
       jobs[i].arg_p = &job_arg_revive;
       jobs[i].function_p = admin_job_change_state;
     }
 
     /* Set new state of `n_threads_to_kill` threads state to 'THREAD_TERMINATE_ASAP' */
-    SignalThreadCtx job_arg_kill = {.barrier = &barrier, .new_state = THREAD_TERMINATE_ASAP};
     for (size_t i = n_threads_to_revive; i < curr_num_threads_alive; i++) {
       jobs[i].arg_p = &job_arg_kill;
       jobs[i].function_p = admin_job_change_state;
@@ -292,14 +318,21 @@ static void redisearch_thpool_verify_init(struct redisearch_thpool_t *thpool_p) 
     jobsChain jobs_chain = create_jobs_chain(jobs, curr_num_threads_alive);
     priority_queue_push_chain_unsafe(&thpool_p->jobqueues, jobs_chain.first_job, jobs_chain.last_job,
         curr_num_threads_alive, THPOOL_PRIORITY_ADMIN);
-
-    /* Unlock to allow the threads to pull from the jobq */
-    redisearch_thpool_unlock(thpool_p);
-    /* Wait on for the threads to pass the barrier and destroy the barrier */
-    barrier_wait_and_destroy(&barrier);
   } else { // Case 1 - no threads alive
-    redisearch_thpool_unlock(thpool_p);
     n_new_threads = n_threads;
+  }
+
+  /* Publish INITIALIZED before releasing the lock so racing submitters skip
+   * initialization; see the function comment for what the flag means. */
+  thpool_p->state = THPOOL_INITIALIZED;
+  redisearch_thpool_unlock(thpool_p);
+
+  if (curr_num_threads_alive) {
+    /* Wait for the threads to pass the barrier and destroy the barrier.
+     * New threads (case 2.b) are spawned only after this drain completes so
+     * they cannot take an admin job intended for a TERMINATE_WHEN_EMPTY
+     * thread (each live thread must run exactly one). */
+    barrier_wait_and_destroy(&barrier);
   }
 
   /* Add new threads if needed */
@@ -321,7 +354,6 @@ static void redisearch_thpool_verify_init(struct redisearch_thpool_t *thpool_p) 
       usleep(1);
     }
   }
-  thpool_p->state = THPOOL_INITIALIZED;
 
   LOG_IF_EXISTS("verbose", "Thread pool of size %zu initialized successfully",
                 thpool_p->n_threads)
@@ -445,21 +477,25 @@ static void redisearch_thpool_push_chain(
 static void redisearch_thpool_push_chain_verify_init_threads(
   redisearch_thpool_t *thpool_p, job *f_newjob_p, job *l_newjob_p, size_t n,
   thpool_priority priority) {
-  redisearch_thpool_push_chain(thpool_p, f_newjob_p, l_newjob_p, n, priority);
+  redisearch_thpool_lock(thpool_p);
+  priority_queue_push_chain_unsafe(&thpool_p->jobqueues, f_newjob_p, l_newjob_p, n, priority);
 
-  /* Never run verify_init from within one of this pool's own worker threads.
-   * verify_init coordinates every live worker through a barrier; the submitting
-   * worker is one of them but is stuck here initiating the barrier, so it can
-   * never be reached. The pool is already running (the caller is a live
-   * worker), so the jobs just pushed will be drained by the running workers;
-   * spawning or reviving threads is only ever required from a non-worker
-   * thread. */
-  if (g_thpool_self == thpool_p) {
+  /* Lazy initialization. The push, the state check and the initialization
+   * decision share one lock hold: submitters run on multiple threads (main
+   * thread and the coordinator IO thread), and an unlocked check here used to
+   * misread a mid-initialization pool as "threads alive in
+   * TERMINATE_WHEN_EMPTY" and deadlock on the revive barrier (MOD-17351).
+   *
+   * Skip when the submitter is one of this pool's own workers (see
+   * g_thpool_self): the revive barrier would count the submitter itself,
+   * which can never arrive at it. The jobs just pushed are still drained by
+   * the live workers. */
+  if (thpool_p->state == THPOOL_INITIALIZED || g_thpool_self == thpool_p) {
+    redisearch_thpool_unlock(thpool_p);
     return;
   }
 
-  /* Initialize threads if needed */
-  redisearch_thpool_verify_init(thpool_p);
+  redisearch_thpool_verify_init(thpool_p); // Releases the lock.
 }
 
 /* Wait until all jobs have finished */
@@ -523,10 +559,12 @@ void redisearch_thpool_terminate_threads(redisearch_thpool_t *thpool_p) {
     while (thpool_p->num_threads_alive) {
       usleep(1);
     }
-  } else {
-    redisearch_thpool_unlock(thpool_p);
+    /* Re-acquire the lock for the state transition (`state` is written only
+     * under the pool lock). */
+    redisearch_thpool_lock(thpool_p);
   }
   thpool_p->state = THPOOL_UNINITIALIZED;
+  redisearch_thpool_unlock(thpool_p);
 }
 
 /* Destroy the threadpool */
@@ -687,7 +725,13 @@ static void *thread_do(void *p) {
 
   LOG_IF_EXISTS("verbose", "Creating background thread: %s", thread_name)
 
-  /* Mark thread as alive (initialized) */
+  /* Mark thread as alive (initialized).
+   * Ordering invariant: `num_threads_alive` and `started` are set BEFORE the
+   * first queue pull below (the first operation that needs the pool lock).
+   * verify_init's started-wait relies on this: it must be able to complete
+   * even if its caller still interacts with the pool under the lock, and by
+   * the time `started` is observed the alive count already includes this
+   * thread. */
   thpool_p->num_threads_alive += 1;
   threadCtx thread_ctx = {.thread_state = THREAD_RUNNING};
   // Set to true after accounting num_threads_alive, useful for testing
@@ -1108,6 +1152,9 @@ void redisearch_thpool_schedule_config_reduce_threads_job(redisearch_thpool_t *t
   // As per the input, I know i am Initialized, I do not need to verify it (and avoid waiting)
   redisearch_thpool_add_n_work_not_verify_init(thpool_p, jobs, n_threads_to_remove, THPOOL_PRIORITY_ADMIN);
   if (terminate_when_empty) {
+    /* `state` is written only under the pool lock. */
+    redisearch_thpool_lock(thpool_p);
     thpool_p->state = THPOOL_UNINITIALIZED;
+    redisearch_thpool_unlock(thpool_p);
   }
 }

--- a/tests/cpptests/test_cpp_thpool.cpp
+++ b/tests/cpptests/test_cpp_thpool.cpp
@@ -654,21 +654,16 @@ TEST_P(PriorityThpoolTestRuntimeConfig, TestWorkerCanAddJobsWhileTerminateWhenEm
     ASSERT_EQ(stats.total_pending_jobs, 0);
 }
 
-/** Regression test for MOD-17351: concurrent first-use lazy initialization.
- *
- * Two non-worker threads race add_work on an uninitialized pool. One of them
- * pushes a job that blocks until that submitter's add_work returns — modeling
- * the coordinator IO thread, whose deferred-execution job depends on the
- * submitting (IO) thread's further progress. Before the fix, the second
- * submitter could observe the pool mid-initialization (threads alive, state
- * not yet INITIALIZED), misread it as "threads draining in
- * TERMINATE_WHEN_EMPTY", and block on a revive barrier counting the worker
- * that runs the blocked job -> deadlock (the test would hang). The loop gives
- * the race window (the thread-spawn duration) many chances to be hit. */
+/** Two non-worker threads race add_work on an uninitialized pool. One of
+ * them pushes a job that blocks until that submitter's add_work returns. A
+ * submitter that observes the pool mid-initialization and blocks on a revive
+ * barrier counting the worker running the blocked job would deadlock (the
+ * test hangs). The loop gives the race window (the thread-spawn duration)
+ * many chances to be hit. */
 TEST(ThpoolConcurrentInit, TestConcurrentLazyInitFromTwoThreads) {
     typedef struct {
-        volatile std::atomic<bool> &release;
-        volatile std::atomic<size_t> &executed;
+        std::atomic<bool> &release;
+        std::atomic<size_t> &executed;
     } RaceCtx;
 
     auto blockedJob = [](void *p) {
@@ -686,8 +681,8 @@ TEST(ThpoolConcurrentInit, TestConcurrentLazyInitFromTwoThreads) {
     for (int iter = 0; iter < 100; iter++) {
         redisearch_thpool_t *pool = redisearch_thpool_create(4, 0, LogCallback, "test");
 
-        volatile std::atomic<bool> release{false};
-        volatile std::atomic<size_t> executed{0};
+        std::atomic<bool> release{false};
+        std::atomic<size_t> executed{0};
         RaceCtx ctx = {release, executed};
 
         std::thread first_submitter([&] {

--- a/tests/cpptests/test_cpp_thpool.cpp
+++ b/tests/cpptests/test_cpp_thpool.cpp
@@ -661,34 +661,34 @@ TEST_P(PriorityThpoolTestRuntimeConfig, TestWorkerCanAddJobsWhileTerminateWhenEm
  * test hangs). The loop gives the race window (the thread-spawn duration)
  * many chances to be hit. */
 TEST(ThpoolConcurrentInit, TestConcurrentLazyInitFromTwoThreads) {
-    typedef struct {
+    struct RaceCtx {
         std::atomic<bool> &release;
         std::atomic<size_t> &executed;
-    } RaceCtx;
+    };
 
-    auto blockedJob = [](void *p) {
-        RaceCtx *ctx = (RaceCtx *)p;
+    auto blockedJob = [](void *p) {  // NOSONAR(S5008) thpool job signature
+        auto *ctx = (RaceCtx *)p;
         while (!ctx->release) {
-            usleep(1);
+            std::this_thread::sleep_for(std::chrono::microseconds(1));
         }
         ctx->executed++;
     };
-    auto trivialJob = [](void *p) {
-        RaceCtx *ctx = (RaceCtx *)p;
+    auto trivialJob = [](void *p) {  // NOSONAR(S5008) thpool job signature
+        auto *ctx = (RaceCtx *)p;
         ctx->executed++;
     };
 
     for (int iter = 0; iter < 100; iter++) {
         redisearch_thpool_t *pool = redisearch_thpool_create(4, 0, LogCallback, "test");
 
-        std::atomic<bool> release{false};
+        std::atomic release{false};
         std::atomic<size_t> executed{0};
         RaceCtx ctx = {release, executed};
 
-        std::thread first_submitter([&] {
+        std::thread first_submitter([pool, &ctx, trivialJob] {  // NOSONAR(S6168) C++17
             redisearch_thpool_add_work(pool, trivialJob, &ctx, THPOOL_PRIORITY_HIGH);
         });
-        std::thread io_submitter([&] {
+        std::thread io_submitter([pool, &ctx, &release, blockedJob] {  // NOSONAR(S6168) C++17
             redisearch_thpool_add_work(pool, blockedJob, &ctx, THPOOL_PRIORITY_HIGH);
             // The blocked job only completes on progress made after add_work
             // returns, like a job depending on the IO thread's event loop.
@@ -699,7 +699,7 @@ TEST(ThpoolConcurrentInit, TestConcurrentLazyInitFromTwoThreads) {
         io_submitter.join();
 
         while (executed < 2) {
-            usleep(1);
+            std::this_thread::sleep_for(std::chrono::microseconds(1));
         }
         redisearch_thpool_destroy(pool);
     }

--- a/tests/cpptests/test_cpp_thpool.cpp
+++ b/tests/cpptests/test_cpp_thpool.cpp
@@ -654,6 +654,62 @@ TEST_P(PriorityThpoolTestRuntimeConfig, TestWorkerCanAddJobsWhileTerminateWhenEm
     ASSERT_EQ(stats.total_pending_jobs, 0);
 }
 
+/** Regression test for MOD-17351: concurrent first-use lazy initialization.
+ *
+ * Two non-worker threads race add_work on an uninitialized pool. One of them
+ * pushes a job that blocks until that submitter's add_work returns — modeling
+ * the coordinator IO thread, whose deferred-execution job depends on the
+ * submitting (IO) thread's further progress. Before the fix, the second
+ * submitter could observe the pool mid-initialization (threads alive, state
+ * not yet INITIALIZED), misread it as "threads draining in
+ * TERMINATE_WHEN_EMPTY", and block on a revive barrier counting the worker
+ * that runs the blocked job -> deadlock (the test would hang). The loop gives
+ * the race window (the thread-spawn duration) many chances to be hit. */
+TEST(ThpoolConcurrentInit, TestConcurrentLazyInitFromTwoThreads) {
+    typedef struct {
+        volatile std::atomic<bool> &release;
+        volatile std::atomic<size_t> &executed;
+    } RaceCtx;
+
+    auto blockedJob = [](void *p) {
+        RaceCtx *ctx = (RaceCtx *)p;
+        while (!ctx->release) {
+            usleep(1);
+        }
+        ctx->executed++;
+    };
+    auto trivialJob = [](void *p) {
+        RaceCtx *ctx = (RaceCtx *)p;
+        ctx->executed++;
+    };
+
+    for (int iter = 0; iter < 100; iter++) {
+        redisearch_thpool_t *pool = redisearch_thpool_create(4, 0, LogCallback, "test");
+
+        volatile std::atomic<bool> release{false};
+        volatile std::atomic<size_t> executed{0};
+        RaceCtx ctx = {release, executed};
+
+        std::thread first_submitter([&] {
+            redisearch_thpool_add_work(pool, trivialJob, &ctx, THPOOL_PRIORITY_HIGH);
+        });
+        std::thread io_submitter([&] {
+            redisearch_thpool_add_work(pool, blockedJob, &ctx, THPOOL_PRIORITY_HIGH);
+            // The blocked job only completes on progress made after add_work
+            // returns, like a job depending on the IO thread's event loop.
+            release = true;
+        });
+
+        first_submitter.join();
+        io_submitter.join();
+
+        while (executed < 2) {
+            usleep(1);
+        }
+        redisearch_thpool_destroy(pool);
+    }
+}
+
 /** This test purpose is to show we can add threads to a pool that was set to 0 threads. */
 TEST_P(PriorityThpoolTestRuntimeConfig, TestAddThreadsToEmptyPool) {
     size_t total_jobs_pushed = 0;


### PR DESCRIPTION

## Describe the changes in the pull request

1. **Current:** `redisearch_thpool_verify_init` reads and writes the pool `state` outside the pool lock, assuming main-thread-only submitters. Since the WITHCOUNT deferred dispatch, `dispatchDeferred` submits to the coordinator (DIST) pool from the IO (libuv) thread. When a query's full shard round trip completes inside the main thread's first-use pool-spawn window (~1ms), the IO thread observes the pool mid-initialization (workers alive, `state` not yet `INITIALIZED`), misreads it as "threads draining in TERMINATE_WHEN_EMPTY", and blocks in `barrier_wait_and_destroy` on a revive barrier whose count includes a worker that itself waits on the IO thread's progress (`executeAggregateDeferred` parked in `MRChannel_PopWithTimeout`). Three-way deadlock: the query hangs forever and the blocked client is never unblocked. Observed twice in CI as a hang of `test_aggregate_barrier:test_barrier_handles_error_in_shard_resp3` (oss-cluster, gcc_14-trixie ARM64 and alpine_3.23 X64); the macOS occurrence in MOD-17019 matches the same signature.
2. **Change:** Make the job push, the state check, and the initialization decision a single critical section under the existing `jobqueues.lock` (`redisearch_thpool_push_chain_verify_init_threads` + `verify_init`). `INITIALIZED` is published under the lock *before* the revive drain / thread spawn, so racing submitters either perform the whole initialization or skip it entirely — the mid-initialization state is no longer observable. The operational sequence (case-2 admin-job drain before spawning new threads; spawn/started-wait outside the lock) is unchanged. The remaining unlocked `state` writes (`terminate_threads`, `schedule_config_reduce_threads_job`) move under the lock, and the load-bearing invariants (`thread_do` sets `num_threads_alive`/`started` before its first queue pull; `g_thpool_self`'s surviving purpose) are documented. No new atomics or states.
3. **Outcome:** Cluster `FT.AGGREGATE ... WITHCOUNT` can no longer deadlock on first use of the coordinator thread pool. A new stress regression test (`ThpoolConcurrentInit.TestConcurrentLazyInitFromTwoThreads`) races two submitters on an uninitialized pool, one of whose jobs depends on its submitter's post-`add_work` progress — it hangs before the fix and passes after.

#### Which additional issues this PR fixes
1. MOD-17351
2. MOD-17019 (flaky `test_aggregate_barrier:test_barrier_handles_error_in_shard_*` — same root cause)

#### Main objects this PR modified
1. `deps/thpool/thpool.c` — `redisearch_thpool_push_chain_verify_init_threads`, `redisearch_thpool_verify_init`, `redisearch_thpool_terminate_threads`, `redisearch_thpool_schedule_config_reduce_threads_job`, `thread_do` (comments)
2. `tests/cpptests/test_cpp_thpool.cpp` — new `ThpoolConcurrentInit.TestConcurrentLazyInitFromTwoThreads` regression test

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
