### PR TITLE
Trie - move empty-input guards to query layer

### DIFF
--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -164,9 +164,17 @@ impl TermSuffixIndex {
     /// `needle` yields nothing. A term may be yielded more than once
     /// (once per matching suffix entry).
     pub fn iter_contains(&self, needle: &str) -> impl Iterator<Item = &str> {
-        let lowered = unicode::tolower_cow(needle);
-        self.inner
-            .prefixed_values(&lowered)
+        // An empty needle denotes no term here, but to the trie it is a
+        // prefix of every key.
+        let subtree = if needle.is_empty() {
+            None
+        } else {
+            let lowered = unicode::tolower_cow(needle);
+            Some(self.inner.prefixed_values(&lowered))
+        };
+        subtree
+            .into_iter()
+            .flatten()
             .flat_map(|data| data.terms().map(|term| &**term))
     }
 

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/contains.rs
@@ -12,19 +12,15 @@ use crate::{TrieMap, iter, str_trie_map::iter::unfiltered::key_to_string};
 /// Substring-filtered iterator over a [`StrTrieMap`](crate::str_trie_map::StrTrieMap),
 /// in lexicographical key order.
 ///
-/// Empty `target` yields zero matches (mirrors the C `Trie_IterateContains`
-/// short-circuit) by delegating to an empty inner iterator.
+/// Empty `target` yields every entry — the empty string is a substring of
+/// every key.
 ///
 /// See [`crate::iter::ContainsIter`] for the underlying traversal.
 pub struct ContainsIter<'tm, 'p, Data: 'tm>(iter::ContainsIter<'tm, 'p, Data>);
 
 impl<'tm, 'p, Data: 'tm> ContainsIter<'tm, 'p, Data> {
     pub(crate) fn new(trie: &'tm TrieMap<Data>, target: &'p str) -> Self {
-        if target.is_empty() {
-            Self(iter::ContainsIter::empty())
-        } else {
-            Self(trie.contains_iter(target.as_bytes()))
-        }
+        Self(trie.contains_iter(target.as_bytes()))
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/prefixed.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/prefixed.rs
@@ -16,20 +16,15 @@ use crate::{
 /// Prefix-filtered iterator over a [`StrTrieMap`](crate::str_trie_map::StrTrieMap),
 /// in lexicographical key order.
 ///
-/// Empty `prefix` yields zero matches — differs from
-/// [`TrieMap::prefixed_iter`] which yields every entry on `&[]`. The
-/// short-circuit is encoded by delegating to an empty inner iterator.
+/// Empty `prefix` yields every entry, like [`TrieMap::prefixed_iter`] on
+/// `&[]` — the empty string is a prefix of every key.
 ///
 /// See [`crate::iter::Iter`] for the underlying traversal.
 pub struct PrefixedIter<'tm, Data: 'tm>(iter::Iter<'tm, Data, filter::VisitAll>);
 
 impl<'tm, Data: 'tm> PrefixedIter<'tm, Data> {
     pub(crate) fn new(trie: &'tm TrieMap<Data>, prefix: &str) -> Self {
-        if prefix.is_empty() {
-            Self(iter::Iter::empty())
-        } else {
-            Self(trie.prefixed_iter(prefix.as_bytes()))
-        }
+        Self(trie.prefixed_iter(prefix.as_bytes()))
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/prefixed_values.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/prefixed_values.rs
@@ -12,20 +12,15 @@ use crate::{TrieMap, iter::Values};
 /// Prefix-filtered value iterator over a [`StrTrieMap`](crate::str_trie_map::StrTrieMap),
 /// in lexicographical key order.
 ///
-/// Empty `prefix` yields zero matches — differs from
-/// [`TrieMap::prefixed_values`] which yields every entry on `&[]`. The
-/// short-circuit is encoded by delegating to an empty inner iterator.
+/// Empty `prefix` yields every value, like [`TrieMap::prefixed_values`] on
+/// `&[]` — the empty string is a prefix of every key.
 ///
 /// See [`crate::iter::Values`] for the underlying traversal.
 pub struct PrefixedValues<'tm, Data: 'tm>(Values<'tm, Data>);
 
 impl<'tm, Data: 'tm> PrefixedValues<'tm, Data> {
     pub(crate) fn new(trie: &'tm TrieMap<Data>, prefix: &str) -> Self {
-        if prefix.is_empty() {
-            Self(Values::new(None))
-        } else {
-            Self(trie.prefixed_values(prefix.as_bytes()))
-        }
+        Self(trie.prefixed_values(prefix.as_bytes()))
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/iter/suffixed.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/iter/suffixed.rs
@@ -19,8 +19,8 @@ use crate::{
 /// Wrapper-only — [`crate::iter`] has no suffix iterator. Byte `ends_with`
 /// on UTF-8 keys agrees with [`str::ends_with`] because UTF-8 is
 /// self-synchronizing: a multibyte sequence cannot be a suffix of another
-/// codepoint. Empty `suffix` yields zero matches by delegating to an empty
-/// inner iterator.
+/// codepoint. Empty `suffix` yields every entry — the empty string is a
+/// suffix of every key.
 ///
 /// See [`crate::iter::Iter`] for the underlying traversal.
 pub struct SuffixedIter<'tm, Data: 'tm> {
@@ -30,12 +30,6 @@ pub struct SuffixedIter<'tm, Data: 'tm> {
 
 impl<'tm, Data: 'tm> SuffixedIter<'tm, Data> {
     pub(crate) fn new(trie: &'tm TrieMap<Data>, suffix: &str) -> Self {
-        if suffix.is_empty() {
-            return Self {
-                target_bytes: Box::new([]),
-                iter: iter::Iter::empty(),
-            };
-        }
         Self {
             target_bytes: suffix.as_bytes().to_vec().into_boxed_slice(),
             iter: trie.iter(),

--- a/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/str_trie_map/mod.rs
@@ -94,9 +94,8 @@ impl<Data> StrTrieMap<Data> {
     /// order. See [`TrieMap::prefixed_iter`].
     ///
     /// Byte-prefix matching is codepoint-safe because UTF-8 codepoint
-    /// boundaries align with byte boundaries. Empty `prefix` yields zero
-    /// matches (this differs from the inner method, which would yield all
-    /// entries).
+    /// boundaries align with byte boundaries. Empty `prefix` yields every
+    /// entry — the empty string is a prefix of every key.
     pub fn prefixed_iter(&self, prefix: &str) -> iter::PrefixedIter<'_, Data> {
         iter::PrefixedIter::new(&self.inner, prefix)
     }
@@ -105,9 +104,8 @@ impl<Data> StrTrieMap<Data> {
     /// `prefix`, in lexicographical order. See [`TrieMap::prefixed_values`].
     ///
     /// Byte-prefix matching is codepoint-safe because UTF-8 codepoint
-    /// boundaries align with byte boundaries. Empty `prefix` yields zero
-    /// matches (this differs from the inner method, which would yield all
-    /// entries).
+    /// boundaries align with byte boundaries. Empty `prefix` yields every
+    /// value — the empty string is a prefix of every key.
     pub fn prefixed_values(&self, prefix: &str) -> iter::PrefixedValues<'_, Data> {
         iter::PrefixedValues::new(&self.inner, prefix)
     }
@@ -115,14 +113,15 @@ impl<Data> StrTrieMap<Data> {
     /// Yield every entry whose key ends with `suffix`. Filters by byte
     /// `ends_with` — correct because UTF-8 is self-synchronizing (a
     /// multibyte sequence cannot be a suffix of another codepoint). Empty
-    /// `suffix` yields zero matches.
+    /// `suffix` yields every entry — the empty string is a suffix of every
+    /// key.
     pub fn suffixed_iter(&self, suffix: &str) -> iter::SuffixedIter<'_, Data> {
         iter::SuffixedIter::new(&self.inner, suffix)
     }
 
     /// Yield every entry whose key contains `target` as a substring.
-    /// Empty `target` yields zero matches — without this short-circuit
-    /// memchr semantics would match every term.
+    /// Empty `target` yields every entry — the empty string is a substring
+    /// of every key.
     pub fn contains_iter<'tm, 'p>(&'tm self, target: &'p str) -> iter::ContainsIter<'tm, 'p, Data> {
         iter::ContainsIter::new(&self.inner, target)
     }

--- a/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/trie_map/iter/contains.rs
@@ -58,16 +58,6 @@ impl<'tm, 't, Data> ContainsIter<'tm, 't, Data> {
         }
     }
 
-    /// Creates a new empty contains iterator, that yields no entries.
-    pub(crate) fn empty() -> Self {
-        Self {
-            stack: vec![],
-            key: vec![],
-            finder: Finder::new(b""),
-            timeout: IteratorTimeoutState::no_timeout(),
-        }
-    }
-
     pub(crate) fn set_timeout(&mut self, timeout: Option<Instant>) {
         self.timeout = timeout.into()
     }

--- a/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/empty_input.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/empty_input.rs
@@ -7,10 +7,9 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! The wrapper short-circuits three iterators when their input is empty,
-//! diverging from the inner [`TrieMap`](trie_rs::TrieMap) (whose
-//! [`prefixed_iter(&[])`](trie_rs::TrieMap::prefixed_iter) yields every
-//! entry).
+//! Empty search input matches every entry: the empty string is a prefix,
+//! suffix, and substring of every key — the same semantics as the inner
+//! [`TrieMap`](trie_rs::TrieMap).
 
 use trie_rs::str_trie_map::StrTrieMap;
 
@@ -23,22 +22,29 @@ fn populated() -> StrTrieMap<i32> {
 }
 
 #[test]
-fn prefixed_iter_empty_prefix_yields_nothing() {
+fn prefixed_iter_empty_prefix_yields_every_entry() {
     let trie = populated();
     let hits: Vec<_> = trie.prefixed_iter("").collect();
-    assert!(hits.is_empty());
+    assert_eq!(hits.len(), trie.len());
 }
 
 #[test]
-fn contains_iter_empty_target_yields_nothing() {
+fn prefixed_values_empty_prefix_yields_every_value() {
+    let trie = populated();
+    let hits: Vec<_> = trie.prefixed_values("").collect();
+    assert_eq!(hits.len(), trie.len());
+}
+
+#[test]
+fn contains_iter_empty_target_yields_every_entry() {
     let trie = populated();
     let hits: Vec<_> = trie.contains_iter("").collect();
-    assert!(hits.is_empty());
+    assert_eq!(hits.len(), trie.len());
 }
 
 #[test]
-fn suffixed_iter_empty_suffix_yields_nothing() {
+fn suffixed_iter_empty_suffix_yields_every_entry() {
     let trie = populated();
     let hits: Vec<_> = trie.suffixed_iter("").collect();
-    assert!(hits.is_empty());
+    assert_eq!(hits.len(), trie.len());
 }

--- a/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/mod.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/str_trie_map/mod.rs
@@ -8,7 +8,7 @@
 */
 
 mod case_insensitive_iter;
-mod empty_short_circuits;
+mod empty_input;
 mod fuzzy_iter;
 mod range_iter;
 mod return_value_contracts;


### PR DESCRIPTION
The empty string is a prefix, suffix, and substring of every key, so `StrTrieMap's` affix iterators (`prefixed`, `prefixed_values`, `suffixed`, `contains`) now yield every entry on empty input, matching the inner `TrieMap` and the automaton-backed iterators.

Treating an empty search term as "no term" is query policy, not string semantics, and different consumers need different answers (e.g. `fork_gc` walks the whole dictionary via an empty prefix). The guard moves to `TermSuffixIndex's` `iter_contains`, next to its existing `iter_suffix` guard; `SpellcheckDictionary` already rejects empty terms at insertion and needs nothing.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
