### PR TITLE
ForkGC: Introduce an `OwnedHiddenString` for use in missing docs handler

### DIFF
--- a/src/redisearch_rs/c_wrappers/dict/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/dict/src/lib.rs
@@ -14,7 +14,7 @@ use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 
-use hidden_string::HiddenStringRef;
+use hidden_string::HiddenString;
 use inverted_index::opaque::InvertedIndex;
 
 /// Describes a `Dict` type defined by a `ffi::dictType` with conversion
@@ -101,7 +101,7 @@ pub struct MissingFieldDictType;
 
 // SAFETY:
 // - missingFieldDictType is a valid static ffi::dictType whose callbacks are
-//   compatible with HiddenStringRef keys and Box<InvertedIndex> values.
+//   compatible with HiddenString keys and Box<InvertedIndex> values.
 // - keyDup copies the HiddenString so callers may free the original after insert.
 // - valDestructor is InvIndFreeCb → InvertedIndex_Free, which calls
 //   drop(Box::from_raw(ptr)); insert_val_into_ptr calls Box::into_raw,
@@ -109,7 +109,7 @@ pub struct MissingFieldDictType;
 // - iter_val_from_ptr and mut_val_from_ptr borrow the stored pointer as
 //   &InvertedIndex / &mut InvertedIndex respectively.
 unsafe impl DictType for MissingFieldDictType {
-    type K<'a> = HiddenStringRef<'a>;
+    type K<'a> = &'a HiddenString;
     type InsertV = Box<InvertedIndex>;
     type RefV<'a> = &'a InvertedIndex;
     type MutV<'a> = &'a mut InvertedIndex;
@@ -119,12 +119,12 @@ unsafe impl DictType for MissingFieldDictType {
     }
 
     fn key_into_ptr<'a>(key: Self::K<'a>) -> *mut c_void {
-        key.as_ptr().cast()
+        key.as_ptr().cast_mut().cast()
     }
 
     unsafe fn key_from_ptr<'a>(ptr: *mut c_void) -> Self::K<'a> {
         // SAFETY: caller guarantees ptr is a valid *mut HiddenString for 'a.
-        unsafe { HiddenStringRef::from_raw(ptr.cast::<ffi::HiddenString>()) }
+        unsafe { HiddenString::from_raw(ptr.cast::<ffi::HiddenString>()) }
     }
 
     fn insert_val_into_ptr(val: Self::InsertV) -> *mut c_void {

--- a/src/redisearch_rs/c_wrappers/field_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/field_spec/src/lib.rs
@@ -11,7 +11,7 @@
 
 use enumflags2::BitFlags;
 use enumflags2::bitflags;
-use hidden_string::HiddenStringRef;
+use hidden_string::HiddenString;
 use numeric_range_tree::NumericRangeTree;
 #[cfg(feature = "unittest")]
 use std::ffi::CStr;
@@ -75,16 +75,16 @@ impl FieldSpec {
         std::ptr::from_ref(&self.0)
     }
 
-    /// Get the underlying field name as a `HiddenStringRef`.
-    pub const fn field_name(&self) -> HiddenStringRef<'_> {
+    /// Get the underlying field name as a `&HiddenString`.
+    pub const fn field_name(&self) -> &HiddenString {
         // Safety: (1.) due to creation with `FieldSpec::from_raw`
-        unsafe { HiddenStringRef::from_raw(self.0.fieldName) }
+        unsafe { HiddenString::from_raw(self.0.fieldName) }
     }
 
-    /// Get the underlying field path as a `HiddenStringRef`.
-    pub const fn field_path(&self) -> HiddenStringRef<'_> {
+    /// Get the underlying field path as a `&HiddenString`.
+    pub const fn field_path(&self) -> &HiddenString {
         // Safety: (1.) due to creation with `FieldSpec::from_raw`
-        unsafe { HiddenStringRef::from_raw(self.0.fieldPath) }
+        unsafe { HiddenString::from_raw(self.0.fieldPath) }
     }
 
     /// Return the field types as a typed [`FieldSpecTypes`] bitmask.

--- a/src/redisearch_rs/c_wrappers/field_spec/tests/tests.rs
+++ b/src/redisearch_rs/c_wrappers/field_spec/tests/tests.rs
@@ -28,8 +28,8 @@ fn field_name_and_path() {
 
     let sut = unsafe { FieldSpec::from_raw(ptr::from_ref(&fs)) };
 
-    assert_eq!(sut.field_name().into_secret_value(), name);
-    assert_eq!(sut.field_path().into_secret_value(), path);
+    assert_eq!(sut.field_name().secret_value(), name);
+    assert_eq!(sut.field_path().secret_value(), path);
 
     unsafe {
         ffi::HiddenString_Free(fs.fieldName, true);

--- a/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
@@ -12,53 +12,45 @@
 use std::{
     ffi::CStr,
     fmt::{self, Debug, Pointer},
-    marker::PhantomData,
-    ptr::NonNull,
 };
 
-/// A safe wrapper around a non-null `ffi::HiddenString` reference.
-#[derive(Clone, Copy)]
+/// A safe wrapper around `ffi::HiddenString`
 #[repr(transparent)]
-pub struct HiddenStringRef<'a>(
-    NonNull<ffi::HiddenString>,
-    PhantomData<&'a ffi::HiddenString>,
-);
+pub struct HiddenString(ffi::HiddenString);
 
-impl<'a> HiddenStringRef<'a> {
-    /// Create a `HiddenStringRef` wrapper from a non-null pointer.
+impl HiddenString {
+    /// Get a [`HiddenString`] reference from a raw pointer.
     ///
     /// # Safety
     ///
-    /// 1. `ptr` must be a valid non-null pointer to an `ffi::HiddenString` that is properly initialized.
-    ///    This also applies to any of its subfields.
-    /// 2. The pointed to `ffi::HiddenString` must not be mutated for the entire lifetime of the returned `HiddenStringRef`.
-    ///
-    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
-    pub const unsafe fn from_raw(ptr: *const ffi::HiddenString) -> Self {
-        Self(
-            NonNull::new(ptr.cast_mut()).expect("HiddenString ptr must be non-null"),
-            PhantomData,
-        )
+    /// 1. `ptr` must be a valid, non-null pointer to a properly initialized
+    ///    `ffi::HiddenString`, including its subfields.
+    /// 2. The pointee must not be mutated for the entire lifetime `'a`.
+    pub const unsafe fn from_raw<'a>(ptr: *const ffi::HiddenString) -> &'a Self {
+        // SAFETY: Ensured by caller (1., 2.)
+        unsafe {
+            ptr.cast::<Self>()
+                .as_ref()
+                .expect("HiddenString ptr must be non-null")
+        }
     }
 
     /// Return the raw pointer to the underlying [`ffi::HiddenString`].
-    pub const fn as_ptr(&self) -> *mut ffi::HiddenString {
-        self.0.as_ptr()
+    pub const fn as_ptr(&self) -> *const ffi::HiddenString {
+        &raw const self.0
     }
 
     /// Get the secret (aka. "unsafe" in C land) value from the underlying [`ffi::HiddenString`].
     ///
     /// This is safe **only if** the C function returns a pointer that stays valid
     /// for at least the lifetime of `self`, and the memory contains a NUL at `len`.
-    ///
-    /// This consumes the `HiddenStringRef` and can only be called once.
-    pub fn into_secret_value(self) -> &'a CStr {
+    pub fn secret_value(&self) -> &CStr {
         let mut len = 0;
 
         // Safety:
-        // - `len` is a local variable that we just allocated and is not being referenced anywhere else.
-        // - `self.0` is a valid non-null pointer to an `ffi::HiddenString` due to creation with `HiddenStringRef::from_raw`
-        let data = unsafe { ffi::HiddenString_GetUnsafe(self.0.as_ptr(), &mut len) };
+        // - `len` is a local variable that is not referenced anywhere else.
+        // - `self.as_ptr()` is a valid, non-null `ffi::HiddenString`.
+        let data = unsafe { ffi::HiddenString_GetUnsafe(self.as_ptr(), &mut len) };
         debug_assert!(!data.is_null(), "data must not be null");
 
         // The length doesn't include the nul terminator so we need to add one.
@@ -70,16 +62,16 @@ impl<'a> HiddenStringRef<'a> {
     }
 }
 
-impl Debug for HiddenStringRef<'_> {
+impl Debug for HiddenString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("HiddenStringRef")
+        f.debug_tuple("HiddenString")
             .field(&format_args!("****"))
             .finish()
     }
 }
 
-impl Pointer for HiddenStringRef<'_> {
+impl Pointer for HiddenString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Pointer::fmt(&self.0, f)
+        Pointer::fmt(&self.as_ptr(), f)
     }
 }

--- a/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
@@ -26,9 +26,11 @@ impl HiddenString {
     ///
     /// # Safety
     ///
-    /// 1. `ptr` must be a valid, non-null pointer to a properly initialized
+    /// 1. `ptr` must be a [valid], non-null pointer to a properly initialized
     ///    `ffi::HiddenString`, including its subfields.
     /// 2. The pointee must not be mutated for the entire lifetime `'a`.
+    ///
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
     pub const unsafe fn from_raw<'a>(ptr: *const ffi::HiddenString) -> &'a Self {
         // SAFETY: Ensured by caller (1., 2.)
         unsafe {

--- a/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
@@ -7,11 +7,14 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Safe wrapper around [`ffi::HiddenString`].
+//! Safe wrappers around [`ffi::HiddenString`].
 
 use std::{
     ffi::CStr,
     fmt::{self, Debug, Pointer},
+    marker::PhantomData,
+    ops::Deref,
+    ptr::NonNull,
 };
 
 /// A safe wrapper around `ffi::HiddenString`
@@ -73,5 +76,54 @@ impl Debug for HiddenString {
 impl Pointer for HiddenString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Pointer::fmt(&self.as_ptr(), f)
+    }
+}
+
+/// An owned [`ffi::HiddenString`] that borrows its backing buffer.
+///
+/// On drop it frees the `ffi::HiddenString` wrapper (`takeOwnership = false`, so
+/// the borrowed buffer is left untouched). [`Deref`]s to [`HiddenString`] for
+/// read access.
+pub struct OwnedHiddenString<'a> {
+    ptr: NonNull<ffi::HiddenString>,
+    _phantom: PhantomData<&'a CStr>,
+}
+
+impl<'a> OwnedHiddenString<'a> {
+    /// Create an `OwnedHiddenString` borrowing `bytes` for `'a`.
+    ///
+    /// The underlying `ffi::HiddenString` points directly at `bytes` rather than
+    /// duplicating it, so `bytes` must outlive the returned value.
+    pub fn new(bytes: &'a CStr) -> Self {
+        // Safety:
+        // - `bytes.as_ptr()` is valid for reads of `bytes.count_bytes() + 1` bytes (payload
+        //   plus the trailing NUL) for at least `'a`.
+        // - `takeOwnership = false` makes the C implementation point directly at `bytes`
+        //   instead of duplicating it, which is why we tie the returned value to `'a`.
+        let ptr = unsafe { ffi::NewHiddenString(bytes.as_ptr(), bytes.count_bytes(), false) };
+
+        Self {
+            ptr: NonNull::new(ptr).expect("NewHiddenString should never return a null pointer"),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl Deref for OwnedHiddenString<'_> {
+    type Target = HiddenString;
+
+    fn deref(&self) -> &HiddenString {
+        // Safety: `self.ptr` is a valid `ffi::HiddenString` created in `new`; the returned
+        // reference borrows `self`, so it cannot outlive the owner.
+        unsafe { HiddenString::from_raw(self.ptr.as_ptr()) }
+    }
+}
+
+impl Drop for OwnedHiddenString<'_> {
+    fn drop(&mut self) {
+        // Safety: `self.ptr` was allocated by `NewHiddenString` with `takeOwnership = false`
+        // in `OwnedHiddenString::new`, so freeing it here with `tookOwnership = false` releases
+        // the `ffi::HiddenString` wrapper only, leaving the borrowed buffer untouched.
+        unsafe { ffi::HiddenString_Free(self.ptr.as_ptr(), false) };
     }
 }

--- a/src/redisearch_rs/c_wrappers/hidden_string/tests/tests.rs
+++ b/src/redisearch_rs/c_wrappers/hidden_string/tests/tests.rs
@@ -11,7 +11,7 @@ extern crate redisearch_rs;
 
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
-use hidden_string::HiddenStringRef;
+use hidden_string::HiddenString;
 use pretty_assertions::assert_eq;
 
 #[test]
@@ -22,11 +22,9 @@ use pretty_assertions::assert_eq;
 fn get_secret_value() {
     let input = c"Ab#123!";
     let ffi_hs = unsafe { ffi::NewHiddenString(input.as_ptr(), input.count_bytes(), false) };
-    let sut = unsafe { HiddenStringRef::from_raw(ffi_hs) };
+    let sut = unsafe { HiddenString::from_raw(ffi_hs) };
 
-    let actual = sut.into_secret_value();
-
-    assert_eq!(actual, input);
+    assert_eq!(sut.secret_value(), input);
 
     unsafe { ffi::HiddenString_Free(ffi_hs, false) };
 }
@@ -39,11 +37,9 @@ fn get_secret_value() {
 fn debug_output() {
     let input = c"Ab#123!";
     let ffi_hs = unsafe { ffi::NewHiddenString(input.as_ptr(), input.count_bytes(), false) };
-    let hs = unsafe { HiddenStringRef::from_raw(ffi_hs) };
+    let hs = unsafe { HiddenString::from_raw(ffi_hs) };
 
-    let actual = format!("{hs:?}");
-
-    assert_eq!(actual, "HiddenStringRef(****)");
+    assert_eq!(format!("{hs:?}"), "HiddenString(****)");
 
     unsafe { ffi::HiddenString_Free(ffi_hs, false) };
 }
@@ -56,11 +52,9 @@ fn debug_output() {
 fn pointer_output() {
     let input = c"Ab#123!";
     let ffi_hs = unsafe { ffi::NewHiddenString(input.as_ptr(), input.count_bytes(), false) };
-    let hs = unsafe { HiddenStringRef::from_raw(ffi_hs) };
+    let hs = unsafe { HiddenString::from_raw(ffi_hs) };
 
-    let actual = format!("{hs:p}");
-
-    assert!(actual.starts_with("0x"));
+    assert!(format!("{hs:p}").starts_with("0x"));
 
     unsafe { ffi::HiddenString_Free(ffi_hs, false) };
 }

--- a/src/redisearch_rs/c_wrappers/hidden_string/tests/tests.rs
+++ b/src/redisearch_rs/c_wrappers/hidden_string/tests/tests.rs
@@ -11,8 +11,26 @@ extern crate redisearch_rs;
 
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
-use hidden_string::HiddenString;
+use hidden_string::{HiddenString, OwnedHiddenString};
 use pretty_assertions::assert_eq;
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn owned_wrapper_borrows_buffer_and_frees_on_drop() {
+    let bytes = c"Ab#123!";
+    let hidden = OwnedHiddenString::new(bytes);
+
+    // Deref to `HiddenString` exposes the same secret value as the backing buffer.
+    assert_eq!(hidden.secret_value(), c"Ab#123!");
+
+    // Dropping `hidden` frees the `ffi::HiddenString` wrapper (no manual
+    // `HiddenString_Free`); the borrowed `bytes` buffer is left untouched.
+    drop(hidden);
+    assert_eq!(bytes, c"Ab#123!");
+}
 
 #[test]
 #[cfg_attr(

--- a/src/redisearch_rs/fork_gc/src/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/src/missing_docs.rs
@@ -91,7 +91,7 @@ pub fn collect_missing_docs(writer: &mut impl Write, spec: &IndexSpecReadGuard) 
             continue;
         };
 
-        let field_name = entry.key().into_secret_value();
+        let field_name = entry.key().secret_value();
         Frame::data(field_name.to_bytes()).encode(writer)?;
         deltas
             .serialize(&mut rmp_serde::Serializer::new(&mut *writer))

--- a/src/redisearch_rs/fork_gc/src/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/src/missing_docs.rs
@@ -9,15 +9,14 @@
 
 //! GC collection and application for the `missingFieldDict` inverted indexes.
 
+use std::ffi::{CStr, CString};
 use std::io::{self, Read, Write};
 
+use crate::{ForkGC, Frame};
+use hidden_string::OwnedHiddenString;
 use index_spec::{IndexSpecReadGuard, IndexSpecWriteGuard};
 use inverted_index::GcScanDelta;
-use nul_terminated_bytes::NulTerminatedBytes;
 use serde::Serialize as _;
-
-use crate::util::with_hidden_string_ref;
-use crate::{ForkGC, Frame};
 
 /// Successful outcome of [`handle_missing_docs`].
 #[derive(Debug, Clone, Copy)]
@@ -104,12 +103,16 @@ pub fn collect_missing_docs(writer: &mut impl Write, spec: &IndexSpecReadGuard) 
 /// Decode one missing-docs message from `reader`.
 pub fn receive_missing_docs(
     reader: &mut impl Read,
-) -> Result<Option<(NulTerminatedBytes, GcScanDelta)>, HandleError> {
+) -> Result<Option<(CString, GcScanDelta)>, HandleError> {
     match Frame::decode_nul_terminated(reader)? {
         Frame::Terminator => Ok(None),
         Frame::Data(field_name) => {
             let delta = rmp_serde::from_read::<_, GcScanDelta>(reader)?;
-            Ok(Some((field_name.into_inner(), delta)))
+            let field_name = field_name
+                .into_inner()
+                .into_c_string()
+                .expect("child always sends a field name that is a valid C string");
+            Ok(Some((field_name, delta)))
         }
         Frame::Empty => Err(HandleError::UnexpectedFrame),
     }
@@ -121,39 +124,39 @@ pub fn receive_missing_docs(
 ///
 /// Returns [`ApplyInfo`] with counters the caller can forward to [`update_stats`].
 pub fn apply_missing_docs(
-    field_name: &NulTerminatedBytes,
+    field_name: &CStr,
     delta: GcScanDelta,
     guard: &mut IndexSpecWriteGuard<'_>,
 ) -> Result<ApplyInfo, HandleError> {
-    with_hidden_string_ref(field_name, |key| {
-        let Some(ii) = guard.missing_field_dict_mut().fetch_mut(key) else {
-            return Err(HandleError::FieldNotFound);
-        };
+    let hidden = OwnedHiddenString::new(field_name);
 
-        let gc_info = ii.apply_gc(delta);
+    let Some(ii) = guard.missing_field_dict_mut().fetch_mut(&hidden) else {
+        return Err(HandleError::FieldNotFound);
+    };
 
-        let (extra, remaining_blocks) = if ii.unique_docs() == 0 {
-            let extra = ii.memory_usage();
-            let remaining_blocks = ii.number_of_blocks();
-            guard.missing_field_dict_mut().remove(key);
-            (extra, remaining_blocks)
-        } else {
-            (0, 0)
-        };
+    let gc_info = ii.apply_gc(delta);
 
-        Ok(ApplyInfo {
-            added_block_count: gc_info
-                .block_count_delta
-                .checked_sub(remaining_blocks as i64)
-                .expect("block count delta should never underflow/overflow"),
-            bytes_freed: gc_info
-                .bytes_freed
-                .checked_add(extra)
-                .expect("freed bytes should never overflow"),
-            bytes_allocated: gc_info.bytes_allocated,
-            entries_removed: gc_info.entries_removed,
-            ignored_last_block: gc_info.ignored_last_block,
-        })
+    let (extra, remaining_blocks) = if ii.unique_docs() == 0 {
+        let extra = ii.memory_usage();
+        let remaining_blocks = ii.number_of_blocks();
+        guard.missing_field_dict_mut().remove(&hidden);
+        (extra, remaining_blocks)
+    } else {
+        (0, 0)
+    };
+
+    Ok(ApplyInfo {
+        added_block_count: gc_info
+            .block_count_delta
+            .checked_sub(remaining_blocks as i64)
+            .expect("block count delta should never underflow/overflow"),
+        bytes_freed: gc_info
+            .bytes_freed
+            .checked_add(extra)
+            .expect("freed bytes should never overflow"),
+        bytes_allocated: gc_info.bytes_allocated,
+        entries_removed: gc_info.entries_removed,
+        ignored_last_block: gc_info.ignored_last_block,
     })
 }
 

--- a/src/redisearch_rs/fork_gc/src/numeric.rs
+++ b/src/redisearch_rs/fork_gc/src/numeric.rs
@@ -113,7 +113,7 @@ pub fn collect_numeric(writer: &mut impl Write, spec: &IndexSpecReadGuard) -> io
         .filter_map(|fs| fs.tree().map(|tree| (fs, tree)))
     {
         // Send field header: Frame::Data(field_name) + raw u64 unique_id.
-        let field_name = fs.field_name().into_secret_value().to_bytes();
+        let field_name = fs.field_name().secret_value().to_bytes();
         Frame::data(field_name).encode(writer)?;
         // The C side stores the u32 tree ID in a u64 before sending (zero-extends).
         let unique_id: u64 = u32::from(tree.unique_id()).into();

--- a/src/redisearch_rs/fork_gc/src/util.rs
+++ b/src/redisearch_rs/fork_gc/src/util.rs
@@ -14,7 +14,7 @@ use std::{
     time::Duration,
 };
 
-use hidden_string::HiddenStringRef;
+use hidden_string::HiddenString;
 use nix::poll::{PollFd, PollFlags};
 use nul_terminated_bytes::NulTerminatedBytes;
 use redis_module::raw::RedisModule_ExitFromChild;
@@ -82,17 +82,17 @@ pub fn read_with_timeout<R: Read + AsRawFd>(
     }
 }
 
-/// Wrap `bytes` in a temporary, non-owning [`HiddenStringRef`], pass it to `f`, then free it.
+/// Wrap `bytes` in a temporary, non-owning [`HiddenString`], pass it to `f`, then free it.
 pub fn with_hidden_string_ref<R>(
     bytes: &NulTerminatedBytes,
-    f: impl FnOnce(HiddenStringRef<'_>) -> R,
+    f: impl FnOnce(&HiddenString) -> R,
 ) -> R {
     // SAFETY: NewHiddenString wraps `bytes` into a heap-allocated HiddenString;
     // we only need it for the duration of `f` and free it immediately after.
     let hidden_string =
         unsafe { ffi::NewHiddenString(bytes.as_ptr().cast::<c_char>(), bytes.len(), false) };
     // SAFETY: `hidden_string` was just allocated above and is non-null.
-    let key = unsafe { HiddenStringRef::from_raw(hidden_string) };
+    let key = unsafe { HiddenString::from_raw(hidden_string) };
     let result = f(key);
     // SAFETY: `hidden_string` was allocated by NewHiddenString and is no longer needed.
     unsafe { ffi::HiddenString_Free(hidden_string, false) };

--- a/src/redisearch_rs/fork_gc/src/util.rs
+++ b/src/redisearch_rs/fork_gc/src/util.rs
@@ -7,16 +7,13 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::ffi::c_char;
 use std::{
     io::{self, Read},
     os::fd::AsRawFd,
     time::Duration,
 };
 
-use hidden_string::HiddenString;
 use nix::poll::{PollFd, PollFlags};
-use nul_terminated_bytes::NulTerminatedBytes;
 use redis_module::raw::RedisModule_ExitFromChild;
 
 /// Log a write error and terminate the current process.
@@ -80,21 +77,4 @@ pub fn read_with_timeout<R: Read + AsRawFd>(
             }
         }
     }
-}
-
-/// Wrap `bytes` in a temporary, non-owning [`HiddenString`], pass it to `f`, then free it.
-pub fn with_hidden_string_ref<R>(
-    bytes: &NulTerminatedBytes,
-    f: impl FnOnce(&HiddenString) -> R,
-) -> R {
-    // SAFETY: NewHiddenString wraps `bytes` into a heap-allocated HiddenString;
-    // we only need it for the duration of `f` and free it immediately after.
-    let hidden_string =
-        unsafe { ffi::NewHiddenString(bytes.as_ptr().cast::<c_char>(), bytes.len(), false) };
-    // SAFETY: `hidden_string` was just allocated above and is non-null.
-    let key = unsafe { HiddenString::from_raw(hidden_string) };
-    let result = f(key);
-    // SAFETY: `hidden_string` was allocated by NewHiddenString and is no longer needed.
-    unsafe { ffi::HiddenString_Free(hidden_string, false) };
-    result
 }

--- a/src/redisearch_rs/fork_gc/tests/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/missing_docs.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::{io::Cursor, mem};
+use std::{ffi::CString, io::Cursor, mem};
 
 use dict::MissingFieldDictType;
 use dict::OwnedDict;
@@ -15,8 +15,8 @@ use ffi::IndexFlags_Index_DocIdsOnly;
 use fork_gc::{
     Frame,
     missing_docs::{HandleError, apply_missing_docs, collect_missing_docs, receive_missing_docs},
-    util::with_hidden_string_ref,
 };
+use hidden_string::OwnedHiddenString;
 use index_result::RSIndexResult;
 use index_spec::{IndexSpecReadGuard, IndexSpecWriteGuard};
 use inverted_index::opaque::InvertedIndex as OpaqueInvertedIndex;
@@ -42,9 +42,11 @@ fn index(count: u64) -> Box<OpaqueInvertedIndex> {
 fn make_spec(
     entries: impl IntoIterator<Item = (&'static [u8], Box<OpaqueInvertedIndex>)>,
 ) -> (ffi::IndexSpec, OwnedDict<MissingFieldDictType>) {
-    let mut dict = OwnedDict::create();
+    let mut dict: OwnedDict<MissingFieldDictType> = OwnedDict::create();
     for (field_name, ii) in entries {
-        with_hidden_string_ref(&field_name.into(), |key| dict.try_insert(key, ii).unwrap());
+        let field_name = CString::new(field_name).unwrap();
+        let hidden = OwnedHiddenString::new(&field_name);
+        dict.try_insert(&hidden, ii).unwrap();
     }
 
     // SAFETY: zeroed IndexSpec is valid for read-only field access through the guard.
@@ -182,7 +184,7 @@ fn receive_data_frame_returns_field_name_and_delta() {
 
     let mut cursor = Cursor::new(&buf);
     let (field_name, _delta) = receive_missing_docs(&mut cursor).unwrap().unwrap();
-    assert_eq!(&*field_name, b"age");
+    assert_eq!(field_name, c"age");
 }
 
 #[test]
@@ -193,7 +195,7 @@ fn apply_returns_err_when_field_not_found() {
 
     let mut write_guard = unsafe { IndexSpecWriteGuard::from_locked_mut(&mut spec) };
     assert!(matches!(
-        apply_missing_docs(&b"nonexistent".into(), delta, &mut *write_guard),
+        apply_missing_docs(c"nonexistent", delta, &mut *write_guard),
         Err(HandleError::FieldNotFound)
     ));
 }
@@ -206,14 +208,15 @@ fn apply_succeeds_and_keeps_entry_when_docs_remain() {
     let delta = GcScanDelta::empty_for_testing();
 
     let mut write_guard = unsafe { IndexSpecWriteGuard::from_locked_mut(&mut spec) };
-    let info = apply_missing_docs(&b"age".into(), delta, &mut *write_guard).unwrap();
+    let info = apply_missing_docs(c"age", delta, &mut *write_guard).unwrap();
 
     assert_eq!(info.entries_removed, 0);
+    let hidden = OwnedHiddenString::new(c"age");
     assert!(
-        with_hidden_string_ref(&b"age".into(), |key| write_guard
+        write_guard
             .missing_field_dict_mut()
-            .fetch_mut(key))
-        .is_some()
+            .fetch_mut(&hidden)
+            .is_some()
     );
 }
 
@@ -233,17 +236,18 @@ fn roundtrip_all_docs_deleted_removes_entry() {
     // Parent side: receive.
     let mut cursor = Cursor::new(&buf);
     let (field_name, delta) = receive_missing_docs(&mut cursor).unwrap().unwrap();
-    assert_eq!(&*field_name, b"age");
+    assert_eq!(field_name, c"age");
 
     // Parent side: apply.
     let mut write_guard = unsafe { IndexSpecWriteGuard::from_locked_mut(&mut spec) };
     let info = apply_missing_docs(&field_name, delta, &mut *write_guard).unwrap();
 
+    let hidden = OwnedHiddenString::new(c"age");
     assert!(
-        with_hidden_string_ref(&b"age".into(), |key| write_guard
+        write_guard
             .missing_field_dict_mut()
-            .fetch_mut(key))
-        .is_none()
+            .fetch_mut(&hidden)
+            .is_none()
     );
     assert!(info.bytes_freed > 0);
     assert!(info.entries_removed > 0);

--- a/src/redisearch_rs/nul_terminated_bytes/src/lib.rs
+++ b/src/redisearch_rs/nul_terminated_bytes/src/lib.rs
@@ -9,6 +9,7 @@
 
 //! An owned byte buffer with a trailing NUL.
 
+use std::ffi::{CString, FromVecWithNulError};
 use std::fmt;
 use std::ops::Deref;
 
@@ -73,6 +74,13 @@ impl NulTerminatedBytes {
     /// The full buffer including the trailing NUL byte.
     pub fn as_bytes_with_nul(&self) -> &[u8] {
         &self.0
+    }
+
+    /// Converts into a [`CString`], consuming `self`.
+    ///
+    /// Fails if the payload contains an interior NUL byte.
+    pub fn into_c_string(self) -> Result<CString, FromVecWithNulError> {
+        CString::from_vec_with_nul(self.0.into_vec())
     }
 }
 

--- a/src/redisearch_rs/nul_terminated_bytes/tests/tests.rs
+++ b/src/redisearch_rs/nul_terminated_bytes/tests/tests.rs
@@ -44,6 +44,19 @@ fn from_vec_matches_from_slice() {
 }
 
 #[test]
+fn into_c_string_succeeds_without_interior_nul() {
+    let buf = NulTerminatedBytes::from(b"field_name");
+    let c_string = buf.into_c_string().unwrap();
+    assert_eq!(c_string, c"field_name");
+}
+
+#[test]
+fn into_c_string_fails_with_interior_nul() {
+    let buf = NulTerminatedBytes::from(b"a\0b");
+    assert!(buf.into_c_string().is_err());
+}
+
+#[test]
 fn into_raw_parts_from_raw_parts_round_trip() {
     let buf = NulTerminatedBytes::from(b"a\0b");
     let (ptr, len) = buf.into_raw_parts();

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -502,8 +502,8 @@ fn create_key_from_data<'a>(
     } else {
         let index = usize::try_from(index).expect("index must be positive and fit into usize");
         let field_spec = &field_specs[index];
-        let field_name = field_spec.field_name().into_secret_value();
-        let path = field_spec.field_path().into_secret_value();
+        let field_name = field_spec.field_name().secret_value();
+        let path = field_spec.field_path().secret_value();
 
         RLookupKey::new_with_path(field_name, path, RLookupKeyFlags::empty())
     }


### PR DESCRIPTION
## Describe the changes in the pull request

This is a refactoring only, no change in behavior, with the following changes:

1. Refactor `HiddenStringRef<'a>` into `&HiddenString`. A different way to represent the same thing. This allows me to use `Deref` for the following step.
2. Implement an `OwnedHiddenString<'a>`. An owned reference to a C allocated `ffi::HiddenString` (only with support for borrowing the provided string, hence the `'a`).
3. Use `OwnedHiddenString` in missing docs hander and remove `with_hidden_string_ref`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
