### PR TITLE
[MOD-14885] qast: handle QN_WILDCARD_QUERY in Rust

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -613,20 +613,6 @@ static QueryIterator *iterateExpandedTerms(QueryEvalCtx *q, Trie *terms, const c
   return NewUnionIterator(its, itsSz, true, opts->weight, type, str, q->config);
 }
 
-typedef struct {
-  QueryIterator **its;
-  size_t nits;
-  size_t cap;
-  QueryEvalCtx *q;
-  QueryNodeOptions *opts;
-  double weight;
-  // For tag queries: needed to support disk mode via helpers
-  TagIndex *tagIdx;
-} TrieCallbackCtx;
-
-static int runeIterCb(const rune *r, size_t n, void *p, void *payload, size_t numDocsInTerm);
-static int charIterCb(const char *s, size_t n, void *p, void *payload);
-
 static const char *PrefixNode_GetTypeString(const QueryPrefixNode *pfx) {
   if (pfx->prefix && pfx->suffix) {
     return "INFIX";
@@ -635,153 +621,6 @@ static const char *PrefixNode_GetTypeString(const QueryPrefixNode *pfx) {
   } else {
     return "SUFFIX";
   }
-}
-
-#define TRIE_STR_TOO_LONG_MSG "query string is too long. Maximum allowed length is " STRINGIFY(MAX_RUNE_STR_LEN)
-
-/* Evaluate a prefix node by expanding all its possible matches and creating one big UNION on all
- * of them.
- * Used for Prefix, Contains and suffix nodes.
-*/
-static QueryIterator *Query_EvalWildcardQueryNode(QueryEvalCtx *q, QueryNode *qn) {
-  RS_LOG_ASSERT(qn->type == QN_WILDCARD_QUERY, "query node type should be wildcard query");
-
-  IndexSpec *spec = q->sctx->spec;
-  Trie *t = spec->terms;
-  TrieCallbackCtx ctx = {.q = q, .opts = &qn->opts};
-  RSToken *token = &qn->verb.tok;
-
-  // terms trie and token always exist when wildcard queries reach evaluation
-  RS_ASSERT(t && token->str);
-
-  token->len = Wildcard_RemoveEscape(token->str, token->len);
-  size_t nstr;
-  rune *str = strToLowerRunes(token->str, token->len, &nstr);
-  if (!str) {
-    QueryError_SetError(q->status, QUERY_ERROR_CODE_LIMIT, "Wildcard " TRIE_STR_TOO_LONG_MSG);
-    return NULL;
-  }
-
-  ctx.cap = 8;
-  ctx.its = rm_malloc(sizeof(*ctx.its) * ctx.cap);
-  ctx.nits = 0;
-
-  if (spec->suffix && qn->opts.fieldMask != RS_FIELDMASK_ALL &&
-      (spec->suffixMask & qn->opts.fieldMask) != qn->opts.fieldMask) {
-    QueryError_SetError(q->status, QUERY_ERROR_CODE_GENERIC,
-                        "Contains query on fields without WITHSUFFIXTRIE support");
-    rm_free(str);
-    return NewUnionIterator(ctx.its, 0, true, qn->opts.weight, QN_WILDCARD_QUERY, qn->verb.tok.str,
-                            q->config);
-  }
-
-  // An empty pattern matches exactly the empty term (indexed under INDEXEMPTY), like the
-  // empty-string text query; the trie scans below never contain it, so skip them
-  if (nstr == 0) {
-    charIterCb("", 0, &ctx, NULL);
-    rm_free(str);
-    return NewUnionIterator(ctx.its, ctx.nits, true, qn->opts.weight, QN_WILDCARD_QUERY,
-                            qn->verb.tok.str, q->config);
-  }
-
-  bool fallbackBruteForce = false;
-  // spec support using suffix trie
-  if (spec->suffix) {
-    // TEXT terms are stored lowercased and `str` holds the lowercased
-    // pattern runes, so the candidate recheck in Suffix_CB_Wildcard stays
-    // case-insensitive.
-    SuffixCtx sufCtx = {
-      .trie = spec->suffix,
-      .rune = str,
-      .runelen = nstr,
-      .type = SUFFIX_TYPE_WILDCARD,
-      .callback = charIterCb, // the difference is weather the function receives char or rune
-      .cbCtx = &ctx,
-      .timeout = &q->sctx->time.timeout,
-      .skipTimeoutChecks = q->sctx->time.skipTimeoutChecks,
-    };
-    if (Suffix_IterateWildcard(&sufCtx) == 0) {
-      // if suffix trie cannot be used, use brute force
-      fallbackBruteForce = true;
-    }
-  }
-
-  if (!spec->suffix || fallbackBruteForce) {
-    Trie_IterateWildcard(t, str, nstr, runeIterCb, &ctx, &q->sctx->time.timeout,
-                         q->sctx->time.skipTimeoutChecks);
-  }
-
-  rm_free(str);
-
-  return NewUnionIterator(ctx.its, ctx.nits, true, qn->opts.weight, QN_WILDCARD_QUERY, qn->verb.tok.str, q->config);
-}
-
-static void rangeItersAddIterator(TrieCallbackCtx *ctx, QueryIterator *it) {
-  ctx->its[ctx->nits++] = it;
-  if (ctx->nits == ctx->cap) {
-    ctx->cap *= 2;
-    ctx->its = rm_realloc(ctx->its, ctx->cap * sizeof(*ctx->its));
-  }
-}
-
-static int runeIterCb(const rune *r, size_t n, void *p, void *payload, size_t numDocsInTerm) {
-  TrieCallbackCtx *ctx = p;
-  QueryEvalCtx *q = ctx->q;
-  if (!RS_IsMock && ctx->nits >= q->config->maxPrefixExpansions) {
-    QueryError_SetReachedMaxPrefixExpansionsWarning(q->status);
-    return REDISEARCH_ERR;
-  }
-  RSToken tok = {0};
-  tok.str = runesToStr(r, n, &tok.len);
-  QueryIterator *ir = NULL;
-  if (q->sctx->spec->diskSpec) {
-    double idf = CalculateIDF(q->sctx->spec->stats.scoring.numDocuments, numDocsInTerm);
-    double bm25_idf = CalculateIDF_BM25(q->sctx->spec->stats.scoring.numDocuments, numDocsInTerm);
-    bool needsOffsets = queryNeedsOffsets(q->opts->scorerName, ctx->opts);
-    ir = SearchDisk_NewTermIterator(q->sctx->spec->diskSpec, q->sctx, &tok, ctx->q->tokenId++, q->opts->fieldmask & ctx->opts->fieldMask, 1, idf, bm25_idf, needsOffsets, q->status);
-  } else {
-    ir = Redis_OpenReader(q->sctx, &tok, ctx->q->tokenId++, &q->sctx->spec->docs,
-                                        q->opts->fieldmask & ctx->opts->fieldMask, 1);
-  }
-  rm_free(tok.str);
-  if (ir) {
-    rangeItersAddIterator(ctx, ir);
-  }
-
-  return REDISEARCH_OK;
-}
-
-static int charIterCb(const char *s, size_t n, void *p, void *payload) {
-  TrieCallbackCtx *ctx = p;
-  QueryEvalCtx *q = ctx->q;
-  if (ctx->nits >= q->config->maxPrefixExpansions) {
-    QueryError_SetReachedMaxPrefixExpansionsWarning(q->status);
-    return REDISEARCH_ERR;
-  }
-  RSToken tok = {.str = (char *)s, .len = n};
-  QueryIterator *ir = NULL;
-  if (q->sctx->spec->diskSpec) {
-    RS_LOG_ASSERT(q->sctx->spec->terms, "terms trie is NULL");
-    // The iterator comes from the Suffix Trie, but the actual number of documents is stored in the Terms Trie.
-    size_t rlen = 0;
-    runeBuf buf;
-    rune *runes = runeBufFill(tok.str, tok.len, &buf, &rlen);
-    TrieNode *trienode = Trie_GetNode(q->sctx->spec->terms, runes, rlen, true, NULL);
-    runeBufFree(&buf);
-    size_t numDocsInTerm = trienode ? TrieNode_NumDocs(trienode) : 0;
-    double idf = CalculateIDF(q->sctx->spec->stats.scoring.numDocuments, numDocsInTerm);
-    double bm25_idf = CalculateIDF_BM25(q->sctx->spec->stats.scoring.numDocuments, numDocsInTerm);
-    bool needsOffsets = queryNeedsOffsets(q->opts->scorerName, ctx->opts);
-    ir = SearchDisk_NewTermIterator(q->sctx->spec->diskSpec, q->sctx, &tok, q->tokenId++, q->opts->fieldmask & ctx->opts->fieldMask, 1, idf, bm25_idf, needsOffsets, q->status);
-  } else {
-    ir = Redis_OpenReader(q->sctx, &tok, q->tokenId++, &q->sctx->spec->docs,
-                                        q->opts->fieldmask & ctx->opts->fieldMask, 1);
-  }
-  if (ir) {
-    rangeItersAddIterator(ctx, ir);
-  }
-
-  return REDISEARCH_OK;
 }
 
 static QueryIterator *Query_EvalFuzzyNode(QueryEvalCtx *q, QueryNode *qn) {
@@ -1207,6 +1046,7 @@ QueryIterator *Query_EvalNode(QueryEvalCtx *q, QueryNode *n, const EvalConfig *e
     case QN_TOKEN:
     case QN_GEOMETRY:
     case QN_PREFIX:
+    case QN_WILDCARD_QUERY:
       // These node types have been ported to Rust.
       return Query_EvalNode_Rs(q, n, evalConfig);
     case QN_TAG:
@@ -1215,8 +1055,6 @@ QueryIterator *Query_EvalNode(QueryEvalCtx *q, QueryNode *n, const EvalConfig *e
       return Query_EvalFuzzyNode(q, n);
     case QN_VECTOR:
       return Query_EvalVectorNode(q, n, evalConfig);
-    case QN_WILDCARD_QUERY:
-      return Query_EvalWildcardQueryNode(q,n);
     case QN_MAX: // LCOV_EXCL_LINE — exhaustive switch: all valid QN types handled above
       RS_ABORT("Invalid query node type"); // LCOV_EXCL_LINE
   }

--- a/src/query.c
+++ b/src/query.c
@@ -612,20 +612,6 @@ static QueryIterator *iterateExpandedTerms(QueryEvalCtx *q, Trie *terms, const c
   return NewUnionIterator(its, itsSz, true, opts->weight, type, str, q->config);
 }
 
-typedef struct {
-  QueryIterator **its;
-  size_t nits;
-  size_t cap;
-  QueryEvalCtx *q;
-  QueryNodeOptions *opts;
-  double weight;
-  // For tag queries: needed to support disk mode via helpers
-  TagIndex *tagIdx;
-} TrieCallbackCtx;
-
-static int runeIterCb(const rune *r, size_t n, void *p, void *payload, size_t numDocsInTerm);
-static int charIterCb(const char *s, size_t n, void *p, void *payload);
-
 static const char *PrefixNode_GetTypeString(const QueryPrefixNode *pfx) {
   if (pfx->prefix && pfx->suffix) {
     return "INFIX";
@@ -634,153 +620,6 @@ static const char *PrefixNode_GetTypeString(const QueryPrefixNode *pfx) {
   } else {
     return "SUFFIX";
   }
-}
-
-#define TRIE_STR_TOO_LONG_MSG "query string is too long. Maximum allowed length is " STRINGIFY(MAX_RUNE_STR_LEN)
-
-/* Evaluate a prefix node by expanding all its possible matches and creating one big UNION on all
- * of them.
- * Used for Prefix, Contains and suffix nodes.
-*/
-static QueryIterator *Query_EvalWildcardQueryNode(QueryEvalCtx *q, QueryNode *qn) {
-  RS_LOG_ASSERT(qn->type == QN_WILDCARD_QUERY, "query node type should be wildcard query");
-
-  IndexSpec *spec = q->sctx->spec;
-  Trie *t = spec->terms;
-  TrieCallbackCtx ctx = {.q = q, .opts = &qn->opts};
-  RSToken *token = &qn->verb.tok;
-
-  // terms trie and token always exist when wildcard queries reach evaluation
-  RS_ASSERT(t && token->str);
-
-  token->len = Wildcard_RemoveEscape(token->str, token->len);
-  size_t nstr;
-  rune *str = strToLowerRunes(token->str, token->len, &nstr);
-  if (!str) {
-    QueryError_SetError(q->status, QUERY_ERROR_CODE_LIMIT, "Wildcard " TRIE_STR_TOO_LONG_MSG);
-    return NULL;
-  }
-
-  ctx.cap = 8;
-  ctx.its = rm_malloc(sizeof(*ctx.its) * ctx.cap);
-  ctx.nits = 0;
-
-  if (spec->suffix && qn->opts.fieldMask != RS_FIELDMASK_ALL &&
-      (spec->suffixMask & qn->opts.fieldMask) != qn->opts.fieldMask) {
-    QueryError_SetError(q->status, QUERY_ERROR_CODE_GENERIC,
-                        "Contains query on fields without WITHSUFFIXTRIE support");
-    rm_free(str);
-    return NewUnionIterator(ctx.its, 0, true, qn->opts.weight, QN_WILDCARD_QUERY, qn->verb.tok.str,
-                            q->config);
-  }
-
-  // An empty pattern matches exactly the empty term (indexed under INDEXEMPTY), like the
-  // empty-string text query; the trie scans below never contain it, so skip them
-  if (nstr == 0) {
-    charIterCb("", 0, &ctx, NULL);
-    rm_free(str);
-    return NewUnionIterator(ctx.its, ctx.nits, true, qn->opts.weight, QN_WILDCARD_QUERY,
-                            qn->verb.tok.str, q->config);
-  }
-
-  bool fallbackBruteForce = false;
-  // spec support using suffix trie
-  if (spec->suffix) {
-    // TEXT terms are stored lowercased and `str` holds the lowercased
-    // pattern runes, so the candidate recheck in Suffix_CB_Wildcard stays
-    // case-insensitive.
-    SuffixCtx sufCtx = {
-      .trie = spec->suffix,
-      .rune = str,
-      .runelen = nstr,
-      .type = SUFFIX_TYPE_WILDCARD,
-      .callback = charIterCb, // the difference is weather the function receives char or rune
-      .cbCtx = &ctx,
-      .timeout = &q->sctx->time.timeout,
-      .skipTimeoutChecks = q->sctx->time.skipTimeoutChecks,
-    };
-    if (Suffix_IterateWildcard(&sufCtx) == 0) {
-      // if suffix trie cannot be used, use brute force
-      fallbackBruteForce = true;
-    }
-  }
-
-  if (!spec->suffix || fallbackBruteForce) {
-    Trie_IterateWildcard(t, str, nstr, runeIterCb, &ctx, &q->sctx->time.timeout,
-                         q->sctx->time.skipTimeoutChecks);
-  }
-
-  rm_free(str);
-
-  return NewUnionIterator(ctx.its, ctx.nits, true, qn->opts.weight, QN_WILDCARD_QUERY, qn->verb.tok.str, q->config);
-}
-
-static void rangeItersAddIterator(TrieCallbackCtx *ctx, QueryIterator *it) {
-  ctx->its[ctx->nits++] = it;
-  if (ctx->nits == ctx->cap) {
-    ctx->cap *= 2;
-    ctx->its = rm_realloc(ctx->its, ctx->cap * sizeof(*ctx->its));
-  }
-}
-
-static int runeIterCb(const rune *r, size_t n, void *p, void *payload, size_t numDocsInTerm) {
-  TrieCallbackCtx *ctx = p;
-  QueryEvalCtx *q = ctx->q;
-  if (!RS_IsMock && ctx->nits >= q->config->maxPrefixExpansions) {
-    QueryError_SetReachedMaxPrefixExpansionsWarning(q->status);
-    return REDISEARCH_ERR;
-  }
-  RSToken tok = {0};
-  tok.str = runesToStr(r, n, &tok.len);
-  QueryIterator *ir = NULL;
-  if (q->sctx->spec->diskSpec) {
-    double idf = CalculateIDF(q->sctx->spec->stats.scoring.numDocuments, numDocsInTerm);
-    double bm25_idf = CalculateIDF_BM25(q->sctx->spec->stats.scoring.numDocuments, numDocsInTerm);
-    bool needsOffsets = queryNeedsOffsets(q->opts->scorerName, ctx->opts);
-    ir = SearchDisk_NewTermIterator(q->sctx->spec->diskSpec, q->sctx, &tok, ctx->q->tokenId++, q->opts->fieldmask & ctx->opts->fieldMask, 1, idf, bm25_idf, needsOffsets, q->status);
-  } else {
-    ir = Redis_OpenReader(q->sctx, &tok, ctx->q->tokenId++, &q->sctx->spec->docs,
-                                        q->opts->fieldmask & ctx->opts->fieldMask, 1);
-  }
-  rm_free(tok.str);
-  if (ir) {
-    rangeItersAddIterator(ctx, ir);
-  }
-
-  return REDISEARCH_OK;
-}
-
-static int charIterCb(const char *s, size_t n, void *p, void *payload) {
-  TrieCallbackCtx *ctx = p;
-  QueryEvalCtx *q = ctx->q;
-  if (ctx->nits >= q->config->maxPrefixExpansions) {
-    QueryError_SetReachedMaxPrefixExpansionsWarning(q->status);
-    return REDISEARCH_ERR;
-  }
-  RSToken tok = {.str = (char *)s, .len = n};
-  QueryIterator *ir = NULL;
-  if (q->sctx->spec->diskSpec) {
-    RS_LOG_ASSERT(q->sctx->spec->terms, "terms trie is NULL");
-    // The iterator comes from the Suffix Trie, but the actual number of documents is stored in the Terms Trie.
-    size_t rlen = 0;
-    runeBuf buf;
-    rune *runes = runeBufFill(tok.str, tok.len, &buf, &rlen);
-    TrieNode *trienode = Trie_GetNode(q->sctx->spec->terms, runes, rlen, true, NULL);
-    runeBufFree(&buf);
-    size_t numDocsInTerm = trienode ? TrieNode_NumDocs(trienode) : 0;
-    double idf = CalculateIDF(q->sctx->spec->stats.scoring.numDocuments, numDocsInTerm);
-    double bm25_idf = CalculateIDF_BM25(q->sctx->spec->stats.scoring.numDocuments, numDocsInTerm);
-    bool needsOffsets = queryNeedsOffsets(q->opts->scorerName, ctx->opts);
-    ir = SearchDisk_NewTermIterator(q->sctx->spec->diskSpec, q->sctx, &tok, q->tokenId++, q->opts->fieldmask & ctx->opts->fieldMask, 1, idf, bm25_idf, needsOffsets, q->status);
-  } else {
-    ir = Redis_OpenReader(q->sctx, &tok, q->tokenId++, &q->sctx->spec->docs,
-                                        q->opts->fieldmask & ctx->opts->fieldMask, 1);
-  }
-  if (ir) {
-    rangeItersAddIterator(ctx, ir);
-  }
-
-  return REDISEARCH_OK;
 }
 
 static QueryIterator *Query_EvalFuzzyNode(QueryEvalCtx *q, QueryNode *qn) {
@@ -1206,6 +1045,7 @@ QueryIterator *Query_EvalNode(QueryEvalCtx *q, QueryNode *n, const EvalConfig *e
     case QN_TOKEN:
     case QN_GEOMETRY:
     case QN_PREFIX:
+    case QN_WILDCARD_QUERY:
       // These node types have been ported to Rust.
       return Query_EvalNode_Rs(q, n, evalConfig);
     case QN_TAG:
@@ -1214,8 +1054,6 @@ QueryIterator *Query_EvalNode(QueryEvalCtx *q, QueryNode *n, const EvalConfig *e
       return Query_EvalFuzzyNode(q, n);
     case QN_VECTOR:
       return Query_EvalVectorNode(q, n, evalConfig);
-    case QN_WILDCARD_QUERY:
-      return Query_EvalWildcardQueryNode(q,n);
     case QN_MAX: // LCOV_EXCL_LINE — exhaustive switch: all valid QN types handled above
       RS_ABORT("Invalid query node type"); // LCOV_EXCL_LINE
   }

--- a/src/redisearch_rs/query_eval/src/expansion.rs
+++ b/src/redisearch_rs/query_eval/src/expansion.rs
@@ -202,11 +202,13 @@ pub(crate) fn runes_to_key(runes: &[ffi::rune]) -> Option<Vec<u8>> {
     Some(key)
 }
 
-/// A single prefix expansion in progress: the inputs both walks share, the
+/// A single pattern expansion in progress: the inputs every walk shares, the
 /// context they open readers against, and the readers opened so far.
 ///
-/// Built once per `QN_PREFIX` evaluation and consumed by whichever `expand_via_*`
-/// walk applies, which hands back the accumulated readers.
+/// Built once per `QN_PREFIX` or `QN_WILDCARD_QUERY` evaluation. The prefix walks
+/// consume it and hand back the accumulated readers; the wildcard walks take
+/// `&mut self`, since a declined suffix walk falls back to the terms-trie walk
+/// with both accumulating into the same `children`.
 pub(super) struct Expansion<'a> {
     /// The evaluation context readers are opened against, and where the
     /// expansion-cap warning and the unsupported-fields error are recorded.
@@ -233,11 +235,7 @@ impl Expansion<'_> {
     /// `num_docs` is the term's document count, used only on the disk path for
     /// the IDF.
     pub(crate) fn push_child(&mut self, num_docs: usize, term_bytes: &[u8]) -> ControlFlow<()> {
-        if self.children.len() >= self.max_expansions {
-            self.ctx
-                .status()
-                .warnings_mut()
-                .set_reached_max_prefix_expansions();
+        if self.cap_reached() {
             return ControlFlow::Break(());
         }
         if let Some(it) = open_expanded_term_reader(
@@ -250,5 +248,24 @@ impl Expansion<'_> {
             self.children.push(it);
         }
         ControlFlow::Continue(())
+    }
+
+    /// Whether the expansion cap has been reached, recording the "reached max
+    /// prefix expansions" warning when it has.
+    ///
+    /// [`push_child`](Self::push_child) applies this itself, so a walk only needs
+    /// to consult it directly when producing the term key costs something — a
+    /// walk that keeps calling back after being asked to stop would pay that cost
+    /// once per remaining match.
+    pub(crate) fn cap_reached(&mut self) -> bool {
+        if self.children.len() >= self.max_expansions {
+            self.ctx
+                .status()
+                .warnings_mut()
+                .set_reached_max_prefix_expansions();
+            true
+        } else {
+            false
+        }
     }
 }

--- a/src/redisearch_rs/query_eval/src/lib.rs
+++ b/src/redisearch_rs/query_eval/src/lib.rs
@@ -45,7 +45,7 @@ pub use config::Config;
 
 use nodes::{
     geo, geometry, ids, missing, not, null, numeric, optional, phrase, prefix, token, union,
-    wildcard,
+    wildcard, wildcard_query,
 };
 
 /// The return type of [`eval_node`]: a boxed Rust iterator that implements
@@ -198,6 +198,9 @@ pub fn eval_node<'index>(
         QueryNode::Token { tok } => token::eval(ctx, &node, tok, config),
         QueryNode::Geometry { geomq } => geometry::eval(ctx, geomq),
         QueryNode::Prefix { tok, mode } => prefix::eval(ctx, &node, tok, mode, config),
+        // Binds nothing, so the node stays free to be passed on by value —
+        // evaluation rewrites its token.
+        QueryNode::WildcardQuery { .. } => wildcard_query::eval(ctx, node, config),
         // Node types not yet ported to Rust are delegated back to the C
         // dispatcher.
         _ => eval_node_c(ctx, node, config),

--- a/src/redisearch_rs/query_eval/src/nodes/mod.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/mod.rs
@@ -27,3 +27,4 @@ pub(crate) mod prefix;
 pub(crate) mod token;
 pub(crate) mod union;
 pub(crate) mod wildcard;
+pub(crate) mod wildcard_query;

--- a/src/redisearch_rs/query_eval/src/nodes/wildcard_query.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/wildcard_query.rs
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Evaluation of `QN_WILDCARD_QUERY` query nodes.
+
+use std::{ops::ControlFlow, ptr::NonNull};
+
+use c_trie::{CTrieRef, LoweredPattern, SuffixWalk};
+use query_error::QueryErrorCode;
+use query_types::QueryNodeType;
+use rqe_iterators::union_opaque::build_union_with_q_str;
+
+use crate::{
+    Config, Evaluated, QueryEvalContext, QueryNodeMut,
+    expansion::{Expansion, runes_to_key},
+    expansion_needs_offsets,
+};
+
+/// `QN_WILDCARD_QUERY` — expand a verbatim wildcard pattern (`w'he?l*o'`, where
+/// `*` matches any run of characters and `?` exactly one) over the spec's terms
+/// trie into a union of per-term readers.
+///
+/// Unlike a prefix pattern, a wildcard pattern is not anchored: the spec's suffix
+/// trie is consulted whenever it exists, and the primary terms trie is walked
+/// only when the suffix trie has no literal run to anchor on.
+///
+/// An empty pattern is answered without either walk: it matches exactly the empty
+/// term, whose inverted index is opened directly.
+///
+/// Returns `None` when the pattern is too long to name any term (reported via
+/// [`status`](QueryEvalContext::status)); every other outcome — including no
+/// matches and the unsupported-fields error — yields a union, possibly empty.
+/// The number of expansions is capped by the configured
+/// [`Config::max_prefix_expansions`].
+pub(crate) fn eval<'index>(
+    ctx: &'index mut QueryEvalContext,
+    mut node: QueryNodeMut<'_>,
+    config: Config,
+) -> Option<Evaluated<'index>> {
+    // Read the header first: the token handle below borrows the node exclusively
+    // until the very end, where the profiling query string is read through it, so
+    // nothing may consult `opts` once it is live.
+    //
+    // The reader field mask narrows the node's mask to the query-wide one; the
+    // suffix-trie support check below uses the node's own mask.
+    let node_field_mask = node.opts().field_mask;
+    let weight = node.opts().weight;
+    let is_disk = !ctx.spec().diskSpec.is_null();
+    let needs_offsets = expansion_needs_offsets(ctx, node.opts(), config);
+    let field_mask = node_field_mask & ctx.opts().fieldmask;
+
+    // Before anything reads the token: it doubles as the union's profiling query
+    // string, which must be the unescaped form.
+    let Some(mut tok) = node.token_mut() else {
+        unreachable!("wildcard_query::eval is only reached for a wildcard-query node")
+    };
+    // Both failures are length limits, and the rewrite's bound sits far above the
+    // lowering's, so the error names the lowering's for either.
+    //
+    // As for a prefix pattern, the token is *not* guaranteed to be valid UTF-8, and
+    // the lowering decodes it without validating — which is what makes the pattern
+    // name the same runes the index does, since a term's bytes are decoded the same
+    // unvalidated way when it is indexed.
+    let Some(pattern) = tok
+        .remove_wildcard_escapes()
+        .ok()
+        .and_then(|()| tok.as_ref().as_lower_runes())
+    else {
+        ctx.status().set_error(
+            QueryErrorCode::Limit,
+            &format!(
+                "Wildcard query string is too long. Maximum allowed length is {}",
+                ffi::MAX_RUNE_STR_LEN
+            ),
+        );
+        return None;
+    };
+    let tok = tok.as_ref();
+
+    let suffix_trie = ctx.spec().suffix;
+    let suffix_mask = ctx.spec().suffixMask;
+    let terms_trie = ctx.spec().terms;
+    // Resolved here, with every other read of `ctx`, because `Expansion` borrows
+    // it mutably for the rest of the expansion.
+    let time = &ctx.sctx().time;
+    let timeout = (!time.skipTimeoutChecks).then(|| NonNull::from(&time.timeout));
+
+    let mut expansion = Expansion {
+        ctx,
+        children: Vec::new(),
+        field_mask,
+        is_disk,
+        needs_offsets,
+        max_expansions: config.max_prefix_expansions,
+    };
+
+    debug_assert!(!terms_trie.is_null(), "terms trie should be initialized");
+    // SAFETY: `terms_trie` is the spec's terms `Trie`, valid for and unmutated
+    // during the query (`QueryEvalContext` invariants 1/2).
+    let terms = unsafe { CTrieRef::from_raw(terms_trie) };
+
+    // A spec with a suffix trie may only answer a pattern when every queried field
+    // is covered by it. An unsupported field set is an error that does *not* fall
+    // back to a walk — it yields an empty union — and it is reported for any
+    // pattern, so it is decided before the empty-pattern case below.
+    let fields_unsupported = !suffix_trie.is_null()
+        && node_field_mask != rqe_core::RS_FIELDMASK_ALL
+        && (suffix_mask & node_field_mask) != node_field_mask;
+
+    if fields_unsupported {
+        expansion.ctx.status().set_error(
+            QueryErrorCode::Generic,
+            "Contains query on fields without WITHSUFFIXTRIE support",
+        );
+    } else if pattern.is_empty() {
+        // A pattern that lowercases to nothing wildcard-matches exactly the empty
+        // term, which neither walk below can find: a zero-length key is refused on
+        // insertion, so an indexed empty value exists only as an inverted index.
+        // Open that index directly, as an empty-string query would. A field without
+        // `INDEXEMPTY` has no such index and the pattern matches nothing.
+        //
+        // The IDF count is zero even on the disk path: no zero-length key is ever
+        // inserted, so the terms trie cannot supply one, and the empty term is
+        // scored as one never seen whatever its inverted index holds.
+        let _ = expansion.push_child(0, b"");
+    } else if let Some(pattern) = LoweredPattern::new(&pattern) {
+        // The suffix trie is preferred whenever the spec has one; the brute-force
+        // terms-trie scan is the fallback for a pattern it has no literal run to
+        // anchor on.
+        //
+        // Carries the pattern while it is still un-walked; `None` once a walk has
+        // consumed it.
+        let mut brute_force = Some(pattern);
+        if !suffix_trie.is_null() {
+            // Reached only with the fields supported, ruled on above.
+            let pattern = brute_force
+                .take()
+                .expect("the pattern is un-walked on the first walk");
+            // SAFETY: `suffix_trie` is non-null (checked above) and is the spec's
+            // suffix `Trie`, whose nodes carry the suffix-data payload the walk
+            // expects; it is valid for and unmutated during the query
+            // (`QueryEvalContext` invariants 1/2).
+            let suffix = unsafe { CTrieRef::from_raw(suffix_trie) };
+            brute_force = match expansion
+                .expand_wildcard_via_suffix_trie(&suffix, &terms, pattern, timeout)
+            {
+                // The walk answered the pattern, and consumed it doing so.
+                SuffixWalk::Walked => None,
+                // Nothing to anchor on, so the pattern is still un-walked and the
+                // brute-force scan below has to answer it instead.
+                SuffixWalk::NoAnchor(pattern) => Some(pattern),
+            };
+        }
+        if let Some(pattern) = brute_force {
+            expansion.expand_wildcard_via_terms_trie(&terms, &pattern, timeout);
+        }
+    }
+    // A pattern `LoweredPattern::new` declines falls through to an empty union.
+    // Neither reason it can be declined is reachable from here — the length limit is
+    // the one `as_lower_runes` already applied, and the lowering never yields a zero
+    // rune — but "matches nothing" is the right answer for both anyway.
+
+    let children = expansion.children;
+
+    // Wildcard unions always take the quick-exit path — they only need the matching
+    // id set, never per-child scores — and carry the pattern token as their
+    // profiling query string.
+    let q_str = tok
+        .as_c_str()
+        .expect("wildcard-query token must carry a string");
+    // SAFETY: the union iterator retains the `CStr`, escaping the handle's borrow,
+    // so the token's string must stay put for as long as the iterator does. It was
+    // rewritten once above, before the iterator existed, and only shortened in
+    // place — the pointer never moved — and nothing rewrites it afterwards: the tag
+    // wildcard path, which also unescapes its token, is dispatched separately and
+    // never re-enters this evaluator. Both the token and the iterator are owned by
+    // the query AST, so the string also outlives the iterator.
+    let iter = unsafe {
+        build_union_with_q_str(
+            children,
+            true,
+            config.min_union_iter_heap,
+            QueryNodeType::WildcardQuery,
+            q_str,
+            weight,
+        )
+    };
+    Some(Evaluated::RustCompound(iter))
+}
+
+impl Expansion<'_> {
+    /// Expand a wildcard `pattern` through the spec's suffix trie, accumulating one
+    /// reader per matching term.
+    ///
+    /// `suffix` wraps the spec's suffix trie and `terms` its primary terms trie.
+    /// A [`SuffixWalk::NoAnchor`] hands the pattern back for the caller to retry
+    /// with [`expand_wildcard_via_terms_trie`](Self::expand_wildcard_via_terms_trie).
+    ///
+    /// Terms may repeat: one term can sit under several matching suffix keys, and
+    /// each occurrence opens its own reader and counts against the expansion cap.
+    /// The union deduplicates by document, so this affects cost and the cap, not
+    /// results.
+    fn expand_wildcard_via_suffix_trie(
+        &mut self,
+        suffix: &CTrieRef,
+        terms: &CTrieRef,
+        pattern: LoweredPattern,
+        timeout: Option<NonNull<ffi::timespec>>,
+    ) -> SuffixWalk {
+        // The suffix trie hands terms back already as stored key bytes but carries
+        // no document count, so on the disk path the term's count is looked up in
+        // the primary terms trie for the IDF; the in-memory path ignores it.
+        //
+        // As in the prefix expansion, a key the lookup refuses for not being valid
+        // UTF-8 was never counted in the terms trie either, so the zero it falls
+        // back to is the term's true count.
+        let on_term = |term_bytes: &[u8]| {
+            // The walk may keep calling back after a `Break`, so check the cap
+            // before the document-count lookup, which is a trie walk of its own.
+            if self.cap_reached() {
+                return ControlFlow::Break(());
+            }
+            let num_docs = if self.is_disk {
+                terms.num_docs(term_bytes)
+            } else {
+                0
+            };
+            self.push_child(num_docs, term_bytes)
+        };
+        // SAFETY: `suffix` wraps the spec's valid suffix `Trie`, whose nodes carry
+        // the suffix-data payload the walk expects (caller contract), and `timeout`,
+        // if set, points to the sctx's live timeout `timespec`. The trie is not
+        // mutated or re-iterated for the duration of the call: `on_term` only opens
+        // per-term readers (which read the spec's inverted indexes) and, on the disk
+        // path, looks up the separate primary terms trie — never the suffix trie
+        // being walked.
+        unsafe { suffix.iterate_suffix_wildcard(pattern, timeout, on_term) }
+    }
+
+    /// Brute-force expand a wildcard `pattern` over the primary terms trie,
+    /// accumulating one reader per matching term.
+    ///
+    /// `terms` wraps the spec's primary terms trie and `timeout` bounds the walk
+    /// (`None` runs it to completion).
+    fn expand_wildcard_via_terms_trie(
+        &mut self,
+        terms: &CTrieRef,
+        pattern: &LoweredPattern,
+        timeout: Option<NonNull<ffi::timespec>>,
+    ) {
+        // The primary trie hands terms back as runes (with their document count,
+        // used for the disk IDF), which must be encoded back into the term's key,
+        // byte for byte as the index stored it — WTF-8 rather than UTF-8 where a
+        // rune is a lone surrogate.
+        let on_runes = |runes: &[ffi::rune], num_docs: usize| {
+            // The walk may keep calling back after a `Break`, so check the cap
+            // before reconstructing the key: otherwise each such call pays for an
+            // allocation and an encode whose result is about to be discarded.
+            if self.cap_reached() {
+                return ControlFlow::Break(());
+            }
+            let Some(key) = runes_to_key(runes) else {
+                // The term key cannot be reconstructed; skip this expansion.
+                return ControlFlow::Continue(());
+            };
+            self.push_child(num_docs, &key)
+        };
+        // SAFETY: `terms` wraps the spec's valid primary terms `Trie`; `timeout`, if
+        // set, points to the sctx's live timeout `timespec`. The trie is not mutated
+        // or re-iterated for the duration of the call: `on_runes` only opens per-term
+        // readers, which read the spec's inverted indexes rather than the terms trie
+        // being walked.
+        unsafe {
+            terms.iterate_wildcard(pattern, timeout, on_runes);
+        }
+    }
+}

--- a/src/redisearch_rs/query_eval/src/nodes/wildcard_query.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/wildcard_query.rs
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Evaluation of `QN_WILDCARD_QUERY` query nodes.
+
+use std::{ops::ControlFlow, ptr::NonNull};
+
+use c_trie::{CTrieRef, LoweredPattern, SuffixWalk};
+use query_error::QueryErrorCode;
+use query_types::QueryNodeType;
+use rqe_iterators::union_opaque::build_union_with_q_str;
+
+use crate::{
+    Config, Evaluated, QueryEvalContext, QueryNodeMut,
+    expansion::{Expansion, runes_to_key},
+    expansion_needs_offsets,
+};
+
+/// `QN_WILDCARD_QUERY` — expand a verbatim wildcard pattern (`w'he?l*o'`, where
+/// `*` matches any run of characters and `?` exactly one) over the spec's terms
+/// trie into a union of per-term readers.
+///
+/// Unlike a prefix pattern, a wildcard pattern is not anchored: the spec's suffix
+/// trie is consulted whenever it exists, and the primary terms trie is walked
+/// only when the suffix trie has no literal run to anchor on.
+///
+/// An empty pattern is answered without either walk: it matches exactly the empty
+/// term, whose inverted index is opened directly.
+///
+/// Returns `None` when the pattern is too long to name any term (reported via
+/// [`status`](QueryEvalContext::status)); every other outcome — including no
+/// matches and the unsupported-fields error — yields a union, possibly empty.
+/// The number of expansions is capped by the configured
+/// [`Config::max_prefix_expansions`].
+pub(crate) fn eval<'index>(
+    ctx: &'index mut QueryEvalContext,
+    mut node: QueryNodeMut<'_>,
+    config: Config,
+) -> Option<Evaluated<'index>> {
+    // Read the header first: the token handle below borrows the node exclusively
+    // until the very end, where the profiling query string is read through it, so
+    // nothing may consult `opts` once it is live.
+    //
+    // The reader field mask narrows the node's mask to the query-wide one; the
+    // suffix-trie support check below uses the node's own mask.
+    let node_field_mask = node.opts().field_mask;
+    let weight = node.opts().weight;
+    let is_disk = !ctx.spec().diskSpec.is_null();
+    let needs_offsets = expansion_needs_offsets(ctx, node.opts(), config);
+    let field_mask = node_field_mask & ctx.opts().fieldmask;
+
+    // Before anything reads the token: it doubles as the union's profiling query
+    // string, which must be the unescaped form.
+    let Some(mut tok) = node.token_mut() else {
+        unreachable!("wildcard_query::eval is only reached for a wildcard-query node")
+    };
+    tok.remove_wildcard_escapes();
+
+    // As for a prefix pattern, the token is *not* guaranteed to be valid UTF-8, and
+    // the lowering decodes it without validating — which is what makes the pattern
+    // name the same runes the index does, since a term's bytes are decoded the same
+    // unvalidated way when it is indexed.
+    let Some(pattern) = tok.as_ref().as_lower_runes() else {
+        ctx.status().set_error(
+            QueryErrorCode::Limit,
+            &format!(
+                "Wildcard query string is too long. Maximum allowed length is {}",
+                ffi::MAX_RUNE_STR_LEN
+            ),
+        );
+        return None;
+    };
+    let tok = tok.as_ref();
+
+    let suffix_trie = ctx.spec().suffix;
+    let suffix_mask = ctx.spec().suffixMask;
+    let terms_trie = ctx.spec().terms;
+    // Resolved here, with every other read of `ctx`, because `Expansion` borrows
+    // it mutably for the rest of the expansion.
+    let time = &ctx.sctx().time;
+    let timeout = (!time.skipTimeoutChecks).then(|| NonNull::from(&time.timeout));
+
+    let mut expansion = Expansion {
+        ctx,
+        children: Vec::new(),
+        field_mask,
+        is_disk,
+        needs_offsets,
+        max_expansions: config.max_prefix_expansions,
+    };
+
+    debug_assert!(!terms_trie.is_null(), "terms trie should be initialized");
+    // SAFETY: `terms_trie` is the spec's terms `Trie`, valid for and unmutated
+    // during the query (`QueryEvalContext` invariants 1/2).
+    let terms = unsafe { CTrieRef::from_raw(terms_trie) };
+
+    // A spec with a suffix trie may only answer a pattern when every queried field
+    // is covered by it. An unsupported field set is an error that does *not* fall
+    // back to a walk — it yields an empty union — and it is reported for any
+    // pattern, so it is decided before the empty-pattern case below.
+    let fields_unsupported = !suffix_trie.is_null()
+        && node_field_mask != rqe_core::RS_FIELDMASK_ALL
+        && (suffix_mask & node_field_mask) != node_field_mask;
+
+    if fields_unsupported {
+        expansion.ctx.status().set_error(
+            QueryErrorCode::Generic,
+            "Contains query on fields without WITHSUFFIXTRIE support",
+        );
+    } else if pattern.is_empty() {
+        // A pattern that lowercases to nothing wildcard-matches exactly the empty
+        // term, which neither walk below can find: a zero-length key is refused on
+        // insertion, so an indexed empty value exists only as an inverted index.
+        // Open that index directly, as an empty-string query would. A field without
+        // `INDEXEMPTY` has no such index and the pattern matches nothing.
+        //
+        // The IDF count is zero even on the disk path: no zero-length key is ever
+        // inserted, so the terms trie cannot supply one, and the empty term is
+        // scored as one never seen whatever its inverted index holds.
+        let _ = expansion.push_child(0, b"");
+    } else if let Some(pattern) = LoweredPattern::new(&pattern) {
+        // The suffix trie is preferred whenever the spec has one; the brute-force
+        // terms-trie scan is the fallback for a pattern it has no literal run to
+        // anchor on.
+        //
+        // Carries the pattern while it is still un-walked; `None` once a walk has
+        // consumed it.
+        let mut brute_force = Some(pattern);
+        if !suffix_trie.is_null() {
+            // Reached only with the fields supported, ruled on above.
+            let pattern = brute_force
+                .take()
+                .expect("the pattern is un-walked on the first walk");
+            // SAFETY: `suffix_trie` is non-null (checked above) and is the spec's
+            // suffix `Trie`, whose nodes carry the suffix-data payload the walk
+            // expects; it is valid for and unmutated during the query
+            // (`QueryEvalContext` invariants 1/2).
+            let suffix = unsafe { CTrieRef::from_raw(suffix_trie) };
+            brute_force = match expansion
+                .expand_wildcard_via_suffix_trie(&suffix, &terms, pattern, timeout)
+            {
+                // The walk answered the pattern, and consumed it doing so.
+                SuffixWalk::Walked => None,
+                // Nothing to anchor on, so the pattern is still un-walked and the
+                // brute-force scan below has to answer it instead.
+                SuffixWalk::NoAnchor(pattern) => Some(pattern),
+            };
+        }
+        if let Some(pattern) = brute_force {
+            expansion.expand_wildcard_via_terms_trie(&terms, &pattern, timeout);
+        }
+    }
+    // A pattern `LoweredPattern::new` declines falls through to an empty union.
+    // Neither reason it can be declined is reachable from here — the length limit is
+    // the one `as_lower_runes` already applied, and the lowering never yields a zero
+    // rune — but "matches nothing" is the right answer for both anyway.
+
+    let children = expansion.children;
+
+    // Wildcard unions always take the quick-exit path — they only need the matching
+    // id set, never per-child scores — and carry the pattern token as their
+    // profiling query string.
+    let q_str = tok
+        .as_c_str()
+        .expect("wildcard-query token must carry a string");
+    // SAFETY: the union iterator retains the `CStr`, escaping the handle's borrow,
+    // so the token's string must stay put for as long as the iterator does. It was
+    // rewritten once above, before the iterator existed, and only shortened in
+    // place — the pointer never moved — and nothing rewrites it afterwards: the tag
+    // wildcard path, which also unescapes its token, is dispatched separately and
+    // never re-enters this evaluator. Both the token and the iterator are owned by
+    // the query AST, so the string also outlives the iterator.
+    let iter = unsafe {
+        build_union_with_q_str(
+            children,
+            true,
+            config.min_union_iter_heap,
+            QueryNodeType::WildcardQuery,
+            q_str,
+            weight,
+        )
+    };
+    Some(Evaluated::RustCompound(iter))
+}
+
+impl Expansion<'_> {
+    /// Expand a wildcard `pattern` through the spec's suffix trie, accumulating one
+    /// reader per matching term.
+    ///
+    /// `suffix` wraps the spec's suffix trie and `terms` its primary terms trie.
+    /// A [`SuffixWalk::NoAnchor`] hands the pattern back for the caller to retry
+    /// with [`expand_wildcard_via_terms_trie`](Self::expand_wildcard_via_terms_trie).
+    ///
+    /// Terms may repeat: one term can sit under several matching suffix keys, and
+    /// each occurrence opens its own reader and counts against the expansion cap.
+    /// The union deduplicates by document, so this affects cost and the cap, not
+    /// results.
+    fn expand_wildcard_via_suffix_trie(
+        &mut self,
+        suffix: &CTrieRef,
+        terms: &CTrieRef,
+        pattern: LoweredPattern,
+        timeout: Option<NonNull<ffi::timespec>>,
+    ) -> SuffixWalk {
+        // The suffix trie hands terms back already as stored key bytes but carries
+        // no document count, so on the disk path the term's count is looked up in
+        // the primary terms trie for the IDF; the in-memory path ignores it.
+        //
+        // That lookup refuses a key that is not valid UTF-8, which here is the right
+        // answer rather than a lost count: a disk index only stages a term whose
+        // bytes are valid UTF-8, and the terms trie is only updated for terms that
+        // staged, so a refused key was never counted there in the first place.
+        let on_term = |term_bytes: &[u8]| {
+            // The walk may keep calling back after a `Break`, so check the cap
+            // before the document-count lookup, which is a trie walk of its own.
+            if self.cap_reached() {
+                return ControlFlow::Break(());
+            }
+            let num_docs = if self.is_disk {
+                terms.num_docs(term_bytes)
+            } else {
+                0
+            };
+            self.push_child(num_docs, term_bytes)
+        };
+        // SAFETY: `suffix` wraps the spec's valid suffix `Trie`, whose nodes carry
+        // the suffix-data payload the walk expects (caller contract), and `timeout`,
+        // if set, points to the sctx's live timeout `timespec`. The trie is not
+        // mutated or re-iterated for the duration of the call: `on_term` only opens
+        // per-term readers (which read the spec's inverted indexes) and, on the disk
+        // path, looks up the separate primary terms trie — never the suffix trie
+        // being walked.
+        unsafe { suffix.iterate_suffix_wildcard(pattern, timeout, on_term) }
+    }
+
+    /// Brute-force expand a wildcard `pattern` over the primary terms trie,
+    /// accumulating one reader per matching term.
+    ///
+    /// `terms` wraps the spec's primary terms trie and `timeout` bounds the walk
+    /// (`None` runs it to completion).
+    fn expand_wildcard_via_terms_trie(
+        &mut self,
+        terms: &CTrieRef,
+        pattern: &LoweredPattern,
+        timeout: Option<NonNull<ffi::timespec>>,
+    ) {
+        // The primary trie hands terms back as runes (with their document count,
+        // used for the disk IDF), which must be encoded back into the term's key,
+        // byte for byte as the index stored it — WTF-8 rather than UTF-8 where a
+        // rune is a lone surrogate.
+        let on_runes = |runes: &[ffi::rune], num_docs: usize| {
+            // The walk may keep calling back after a `Break`, so check the cap
+            // before reconstructing the key: otherwise each such call pays for an
+            // allocation and an encode whose result is about to be discarded.
+            if self.cap_reached() {
+                return ControlFlow::Break(());
+            }
+            let Some(key) = runes_to_key(runes) else {
+                // The term key cannot be reconstructed; skip this expansion.
+                return ControlFlow::Continue(());
+            };
+            self.push_child(num_docs, &key)
+        };
+        // SAFETY: `terms` wraps the spec's valid primary terms `Trie`; `timeout`, if
+        // set, points to the sctx's live timeout `timespec`. The trie is not mutated
+        // or re-iterated for the duration of the call: `on_runes` only opens per-term
+        // readers, which read the spec's inverted indexes rather than the terms trie
+        // being walked.
+        unsafe {
+            terms.iterate_wildcard(pattern, timeout, on_runes);
+        }
+    }
+}

--- a/src/redisearch_rs/query_eval/tests/integration/main.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/main.rs
@@ -26,3 +26,4 @@ mod token;
 mod union;
 mod util;
 mod wildcard;
+mod wildcard_query;

--- a/src/redisearch_rs/query_eval/tests/integration/wildcard_query.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/wildcard_query.rs
@@ -1,0 +1,888 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! QN_WILDCARD_QUERY → expand a verbatim wildcard pattern (`*` matches any run
+//! of characters, `?` exactly one) over the terms trie into a union of per-term
+//! readers.
+//!
+//! Covers both expansion walks — the brute-force terms-trie scan and the
+//! suffix-trie fast path, including the fallback from one to the other. Each test
+//! populates the terms trie with a handful of terms and queries a pattern,
+//! asserting the union yields exactly the documents of the matching terms.
+//!
+//! Disabled under Miri: `TestContext` calls into the C library, which Miri
+//! cannot execute.
+#![cfg(not(miri))]
+
+use index_result::{RSIndexResult, RSOffsetSlice};
+use query::mock::MockQueryNode;
+use query_error::QueryErrorCode;
+use query_eval::{
+    Config, EvalResult, QueryEvalContext, QueryNode, QueryNodeMut, QueryNodeRef, eval_node,
+};
+use query_term::RSQueryTerm;
+use query_types::QueryNodeType;
+use rqe_core::{FieldMask, RS_FIELDMASK_ALL};
+use rqe_iterators::{IteratorType, RQEIterator};
+use rqe_iterators_test_utils::{GlobalGuard, TestContext};
+
+/// All (low 32) field-mask bits set, so the reader's field-mask filter never
+/// excludes a document unless a test narrows the mask deliberately.
+const ALL_INDEXED_FIELDS: FieldMask = u32::MAX as FieldMask;
+
+/// Build term postings for the given document IDs, each indexed under
+/// `field_mask`.
+fn term_records(doc_ids: &[u64], field_mask: FieldMask) -> Vec<RSIndexResult<'static>> {
+    const OFFSETS: &[u8] = &[0];
+    doc_ids
+        .iter()
+        .map(|&doc_id| {
+            let mut term = RSQueryTerm::new("t", 1, 0);
+            term.set_idf(5.0);
+            term.set_bm25_idf(10.0);
+            RSIndexResult::build_term()
+                .borrowed_record(Some(term), RSOffsetSlice::from_slice(OFFSETS))
+                .doc_id(doc_id)
+                .field_mask(field_mask)
+                .frequency(1)
+                .build()
+        })
+        .collect()
+}
+
+/// The default term set: `apple`(1,2), `apricot`(3), `grape`(4), `banana`(5).
+fn default_terms() -> Vec<(&'static [u8], Vec<u64>)> {
+    vec![
+        (b"apple", vec![1, 2]),
+        (b"apricot", vec![3]),
+        (b"grape", vec![4]),
+        (b"banana", vec![5]),
+    ]
+}
+
+/// How to build a [`WildcardFixture`]. [`Default`] describes the case most tests
+/// want, leaving each test to override only the knob it exercises.
+struct WildcardOptions {
+    /// The terms to index, each with the documents indexed under it. Byte
+    /// strings, not `str`s: the terms trie decodes them without validating, so a
+    /// term key may hold bytes UTF-8 forbids.
+    terms: Vec<(&'static [u8], Vec<u64>)>,
+    /// Whether to declare the field `WITHSUFFIXTRIE`, which makes the expansion
+    /// prefer the suffix trie over the brute-force terms-trie scan.
+    with_suffix_trie: bool,
+    /// The node's weight, applied once by the enclosing union.
+    weight: f64,
+    /// The node's field mask: the fields the query asks about. Also decides
+    /// whether the suffix trie may be used, since every queried field must be
+    /// covered by it.
+    field_mask: FieldMask,
+    /// The query-wide field mask, which the node's mask is narrowed by before
+    /// reaching each reader. Deliberately separate from
+    /// [`field_mask`](Self::field_mask): only one of the two gates the
+    /// suffix-trie decision.
+    query_field_mask: FieldMask,
+    /// The field mask each indexed posting carries, which the reader intersects
+    /// with the effective mask.
+    record_field_mask: FieldMask,
+    /// Overrides [`Config::max_prefix_expansions`]. [`None`] keeps the default,
+    /// which no realistic test term set can reach.
+    max_expansions: Option<u32>,
+    /// Overrides [`Config::min_term_prefix`]. Used to show it does *not* apply to
+    /// a wildcard pattern.
+    min_term_prefix: Option<u32>,
+}
+
+impl Default for WildcardOptions {
+    fn default() -> Self {
+        Self {
+            terms: default_terms(),
+            with_suffix_trie: false,
+            weight: 1.0,
+            field_mask: RS_FIELDMASK_ALL,
+            query_field_mask: RS_FIELDMASK_ALL,
+            record_field_mask: ALL_INDEXED_FIELDS,
+            max_expansions: None,
+            min_term_prefix: None,
+        }
+    }
+}
+
+/// Owns everything a `QN_WILDCARD_QUERY` evaluation borrows, so a test can hold a
+/// single value and let the whole graph drop together at the end.
+struct WildcardFixture {
+    /// Registers the process-exit cleanup of the global spec dictionaries.
+    _guard: GlobalGuard,
+    /// Owns the index: the spec, its search context, the terms trie, and the
+    /// per-term inverted indexes. Must outlive [`ctx`](Self::ctx).
+    _context: TestContext,
+    /// The evaluation context under test. Also carries the query status, so tests
+    /// read errors and warnings back through it.
+    ctx: QueryEvalContext,
+    /// The `QN_WILDCARD_QUERY` node being evaluated.
+    node: MockQueryNode,
+    /// The evaluation config threaded into [`eval_node`].
+    config: Config,
+    /// Backs the token's string pointer in [`node`](Self::node), which borrows it
+    /// as a raw pointer; must outlive it.
+    ///
+    /// Held as a `Vec<u8>` rather than a `CString` because evaluation *rewrites*
+    /// the token in place to strip escapes, and because a test may need a pattern
+    /// that is not valid UTF-8. The buffer always carries a trailing NUL, which
+    /// the node's token requires.
+    _token: Vec<u8>,
+}
+
+impl WildcardFixture {
+    /// Default terms, brute-force scan, unit weight, all fields.
+    fn new(pattern: &str) -> Self {
+        Self::build(pattern.as_bytes(), WildcardOptions::default())
+    }
+
+    /// Like [`new`](Self::new) but declares the field `WITHSUFFIXTRIE`, so the
+    /// expansion prefers the suffix trie.
+    fn with_suffix_trie(pattern: &str) -> Self {
+        Self::build(
+            pattern.as_bytes(),
+            WildcardOptions {
+                with_suffix_trie: true,
+                ..WildcardOptions::default()
+            },
+        )
+    }
+
+    fn build(pattern: &[u8], opts: WildcardOptions) -> Self {
+        let _guard = GlobalGuard::default();
+
+        let record_field_mask = opts.record_field_mask;
+        let records = opts
+            .terms
+            .into_iter()
+            .map(move |(term, doc_ids)| (term, term_records(&doc_ids, record_field_mask)));
+        let context = TestContext::prefix(records, opts.with_suffix_trie);
+
+        let qctx = context.qctx();
+        // The expansion narrows each term's field mask with the query-wide one;
+        // the zero-init options leave it 0, which would mask out every field.
+        // SAFETY: `qctx` points to a valid, exclusively-owned `QueryEvalCtx`.
+        let opts_ptr = unsafe { (*qctx.as_ptr()).opts.cast_mut() };
+        // SAFETY: `opts_ptr` is the context's valid, exclusively-owned
+        // `RSSearchOptions`.
+        unsafe {
+            (*opts_ptr).fieldmask = opts.query_field_mask;
+        };
+
+        let mut config = Config::default();
+        if let Some(cap) = opts.max_expansions {
+            config.max_prefix_expansions = cap as usize;
+        }
+        if let Some(min) = opts.min_term_prefix {
+            config.min_term_prefix = min;
+        }
+        // SAFETY: `qctx` upholds the `QueryEvalContext::new` invariants and is
+        // exclusively owned by this fixture.
+        let ctx = unsafe { QueryEvalContext::new(qctx) };
+
+        // The token must be NUL-terminated: the node type promises it, and
+        // evaluation both unescapes through it and hands it to the union as a
+        // C string.
+        let mut token = pattern.to_vec();
+        token.push(0);
+        let mut node = MockQueryNode::new(QueryNodeType::WildcardQuery);
+        node.opts_mut().weight = opts.weight;
+        node.opts_mut().field_mask = opts.field_mask;
+        node.set_token(token.as_mut_ptr().cast(), pattern.len());
+
+        Self {
+            _guard,
+            _context: context,
+            ctx,
+            node,
+            config,
+            _token: token,
+        }
+    }
+
+    /// Evaluate the node, returning the boxed iterator, or `None` when evaluation
+    /// produced no iterator.
+    fn eval(&mut self) -> Option<EvalResult<'_>> {
+        // SAFETY: `self.node` is a valid, live `RSQueryNode` for the call.
+        let node_ref = unsafe { QueryNodeMut::new(self.node.as_non_null()) };
+        eval_node(&mut self.ctx, node_ref, self.config).map(|e| e.into_boxed())
+    }
+
+    /// The token's current string, which evaluation may have rewritten in place.
+    ///
+    /// Copied out rather than borrowed: the handle the token is read through
+    /// borrows from the local view of the node, not from the fixture.
+    fn token_bytes(&self) -> Vec<u8> {
+        // SAFETY: `self.node` is a valid, live `RSQueryNode`, and this shared
+        // borrow of the fixture rules out a concurrent exclusive view of it.
+        let node = unsafe { QueryNodeRef::new(self.node.as_non_null()) };
+        let QueryNode::WildcardQuery { tok } = node.as_enum() else {
+            panic!("fixture builds a wildcard-query node");
+        };
+        tok.as_bytes()
+            .expect("fixture installs a token string")
+            .to_vec()
+    }
+
+    /// The current query error code (`Ok` when no error was set).
+    fn status_code(&mut self) -> QueryErrorCode {
+        self.ctx.status().code()
+    }
+
+    /// The current query error message.
+    fn status_message(&mut self) -> String {
+        self.ctx
+            .status()
+            .public_message()
+            .map(|m| m.to_string_lossy().into_owned())
+            .unwrap_or_default()
+    }
+
+    /// Whether the "reached max prefix expansions" warning was recorded.
+    fn reached_max_expansions(&mut self) -> bool {
+        self.ctx.status().warnings().reached_max_prefix_expansions()
+    }
+}
+
+/// Drain an iterator into the list of document IDs it yields, in order.
+fn collect_doc_ids(it: &mut EvalResult) -> Vec<u64> {
+    let mut ids = Vec::new();
+    while let Some(r) = it.read().expect("read must not error") {
+        ids.push(r.doc_id);
+    }
+    ids
+}
+
+// ── matching ───────────────────────────────────────────────────────────────
+
+#[test]
+fn eval_wildcard_query_star_expands_and_unions_matches() {
+    // `ap*` matches `apple` and `apricot`, whose documents union to {1, 2, 3}.
+    let mut fixture = WildcardFixture::new("ap*");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(it.type_(), IteratorType::Union);
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3]);
+}
+
+#[test]
+fn eval_wildcard_query_question_mark_matches_exactly_one_character() {
+    // `?rape` matches `grape` but not `rape` or `ggrape`: `?` is exactly one.
+    let mut fixture = WildcardFixture::build(
+        b"?rape",
+        WildcardOptions {
+            terms: vec![
+                (b"grape", vec![4]),
+                (b"rape", vec![6]),
+                (b"ggrape", vec![7]),
+            ],
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![4]);
+}
+
+#[test]
+fn eval_wildcard_query_mixed_star_and_question_mark() {
+    // `a?*t` — `a`, exactly one character, any run, then a final `t`: `apricot`
+    // matches, `apple` does not end in `t`, `at` has nothing for the `?`.
+    let mut fixture = WildcardFixture::build(
+        b"a?*t",
+        WildcardOptions {
+            terms: vec![(b"apricot", vec![3]), (b"apple", vec![1]), (b"at", vec![8])],
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![3]);
+}
+
+#[test]
+fn eval_wildcard_query_interior_star_matches_around_it() {
+    // `a*t` anchors both ends: `apricot` matches, `apple` does not.
+    let mut fixture = WildcardFixture::new("a*t");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![3]);
+}
+
+#[test]
+fn eval_wildcard_query_lowercases_the_pattern() {
+    // Terms are indexed lowercased, so the pattern is lowercased before the trie
+    // walk: `AP*` expands exactly like `ap*`.
+    let mut fixture = WildcardFixture::new("AP*");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3]);
+}
+
+#[test]
+fn eval_wildcard_query_single_match_collapses_to_the_reader() {
+    // `gr*` matches only `grape`; a union of one child collapses to that child's
+    // term reader, which carries the per-expansion unit weight rather than the
+    // node weight — the node weight is applied only by a real union.
+    let mut fixture = WildcardFixture::build(
+        b"gr*",
+        WildcardOptions {
+            weight: 5.0,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(it.type_(), IteratorType::InvIdxTerm);
+    let r = it.read().expect("read must not error").expect("one result");
+    assert_eq!(r.doc_id, 4);
+    assert_eq!(r.weight, 1.0, "expanded child readers carry unit weight");
+}
+
+#[test]
+fn eval_wildcard_query_union_carries_the_node_weight() {
+    // `ap*` expands to two terms, so a real union is built and it carries the
+    // node's weight. This is the counterpart to the single-match case below: there
+    // the union collapses to its child and the node weight is deliberately absent,
+    // so without this test nothing would notice the weight being dropped, or the
+    // wrong value being passed, on the path where it does apply.
+    let mut fixture = WildcardFixture::build(
+        b"ap*",
+        WildcardOptions {
+            weight: 5.0,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(it.type_(), IteratorType::Union);
+    let r = it.read().expect("read must not error").expect("one result");
+    assert_eq!(r.weight, 5.0, "a real union carries the node weight");
+}
+
+#[test]
+fn eval_wildcard_query_no_match_yields_empty_union() {
+    // `zz*` matches no term: evaluation still returns an iterator, which reads
+    // nothing — it is never `None`.
+    let mut fixture = WildcardFixture::new("zz*");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), Vec::<u64>::new());
+}
+
+#[test]
+fn eval_wildcard_query_expands_a_term_whose_key_is_not_utf8() {
+    // A term key is not necessarily valid UTF-8. `\xED\xA0\xBD` is the three-byte
+    // encoding of the lone surrogate `U+D83D`, which UTF-8 forbids — and which is
+    // what a non-BMP codepoint becomes once the trie truncates it to a 16-bit
+    // rune. The expansion must hand those bytes to the inverted-index lookup
+    // unvalidated, or the term's document is dropped.
+    let mut fixture = WildcardFixture::build(
+        b"ap*",
+        WildcardOptions {
+            terms: vec![(b"ap\xED\xA0\xBDle", vec![7]), (b"apple", vec![1, 2])],
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 7]);
+}
+
+#[test]
+fn eval_wildcard_query_skips_expansion_without_inverted_index() {
+    // `apex` is in the terms trie but has no document, so it opens no reader and
+    // contributes nothing; the other two `ap` expansions still union to {1, 2, 3}.
+    let mut fixture = WildcardFixture::build(
+        b"ap*",
+        WildcardOptions {
+            terms: vec![
+                (b"apple", vec![1, 2]),
+                (b"apex", vec![]),
+                (b"apricot", vec![3]),
+            ],
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3]);
+}
+
+// ── escapes ────────────────────────────────────────────────────────────────
+
+#[test]
+fn eval_wildcard_query_removes_escapes_from_the_token() {
+    // `ap\*le` unescapes to `ap*le` before the walk, so the `*` is a wildcard and
+    // the pattern matches `apple`. The token is rewritten *in place*, because it
+    // is also what the union reports as its profiling query string.
+    let mut fixture = WildcardFixture::new("ap\\*le");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2]);
+    drop(it);
+    assert_eq!(
+        fixture.token_bytes(),
+        b"ap*le",
+        "the escape is stripped from the node's own token"
+    );
+}
+
+#[test]
+fn eval_wildcard_query_removes_a_trailing_backslash() {
+    // A pattern ending in a lone backslash drops it: `apple\` becomes `apple`,
+    // which matches the term exactly.
+    //
+    // This is the one input shape where escape removal reads the byte *past* the
+    // token — the escape has nothing after it, so the converter copies the
+    // terminator into its place and stops there. Nothing else in this file
+    // exercises that read.
+    let mut fixture = WildcardFixture::new("apple\\");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2]);
+    drop(it);
+    assert_eq!(
+        fixture.token_bytes(),
+        b"apple",
+        "the trailing backslash is dropped, shortening the token"
+    );
+}
+
+#[test]
+fn eval_wildcard_query_escape_removal_leaves_an_unescaped_token_alone() {
+    // A pattern with no backslash is returned unchanged, length included.
+    let mut fixture = WildcardFixture::new("ap*");
+    let _ = fixture.eval();
+    assert_eq!(fixture.token_bytes(), b"ap*");
+}
+
+// ── degenerate patterns ────────────────────────────────────────────────────
+
+/// The default terms plus the empty term, indexing document 9 — what an
+/// `INDEXEMPTY` field's empty value produces. It reaches the inverted index only:
+/// neither trie accepts a zero-length key.
+fn terms_with_empty() -> Vec<(&'static [u8], Vec<u64>)> {
+    let mut terms = default_terms();
+    terms.push((b"", vec![9]));
+    terms
+}
+
+#[test]
+fn eval_wildcard_query_empty_pattern_matches_nothing_without_an_empty_term() {
+    // An empty pattern matches exactly the empty term. Without `INDEXEMPTY` there
+    // is no inverted index for it, so the union comes back empty — and that is a
+    // miss, not an error.
+    let mut fixture = WildcardFixture::new("");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), Vec::<u64>::new());
+    drop(it);
+    assert_eq!(
+        fixture.status_code(),
+        QueryErrorCode::Ok,
+        "an empty pattern is not an error, just a miss"
+    );
+}
+
+#[test]
+fn eval_wildcard_query_empty_pattern_matches_the_empty_term() {
+    // With the empty term indexed, an empty pattern matches it and nothing else:
+    // the reader is opened directly, since no trie holds a zero-length key for a
+    // walk to find.
+    let mut fixture = WildcardFixture::build(
+        b"",
+        WildcardOptions {
+            terms: terms_with_empty(),
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![9]);
+    drop(it);
+    assert_eq!(fixture.status_code(), QueryErrorCode::Ok);
+}
+
+#[test]
+fn eval_wildcard_query_empty_pattern_matches_the_empty_term_with_a_suffix_trie() {
+    // Same answer on a spec with a suffix trie: the empty pattern is recognised
+    // before either walk is chosen, so neither runs — the suffix walk's own
+    // no-anchor path is not what produces this answer.
+    let mut fixture = WildcardFixture::build(
+        b"",
+        WildcardOptions {
+            terms: terms_with_empty(),
+            with_suffix_trie: true,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![9]);
+}
+
+#[test]
+fn eval_wildcard_query_empty_pattern_respects_the_field_mask() {
+    // The empty term's reader is opened with the same effective field mask as any
+    // expanded term's, so a document indexed under another field is not matched.
+    let mut fixture = WildcardFixture::build(
+        b"",
+        WildcardOptions {
+            terms: terms_with_empty(),
+            field_mask: 0b01,
+            record_field_mask: 0b10,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), Vec::<u64>::new());
+}
+
+#[test]
+fn eval_wildcard_query_bare_star_matches_every_term() {
+    // `*` is the shortest pattern that matches everything. It is also the case
+    // that reads the element past the pattern — a pattern ending in `*` makes the
+    // matcher dereference its cursor without re-checking it against the end — so
+    // the terminator the pattern carries has to be there and has to be zero.
+    let mut fixture = WildcardFixture::new("*");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3, 4, 5]);
+}
+
+#[test]
+fn eval_wildcard_query_ignores_min_term_prefix() {
+    // A wildcard pattern has no minimum length: unlike a prefix node, it is not
+    // rejected for being shorter than `min_term_prefix`. Copying that guard over
+    // would silently turn `w'*'` into a miss under the default MINPREFIX of 2.
+    let mut fixture = WildcardFixture::build(
+        b"*",
+        WildcardOptions {
+            min_term_prefix: Some(10),
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3, 4, 5]);
+}
+
+#[test]
+fn eval_wildcard_query_too_long_reports_limit_error() {
+    // A pattern longer than `MAX_RUNE_STR_LEN` (1024) cannot be lowered to runes.
+    // The message is user-visible, and names this node type rather than the
+    // prefix/suffix/infix wording a prefix node uses.
+    let long = "a".repeat(2000);
+    let mut fixture = WildcardFixture::new(&long);
+    assert!(
+        fixture.eval().is_none(),
+        "an over-long pattern yields no iterator"
+    );
+    assert_eq!(fixture.status_code(), QueryErrorCode::Limit);
+    assert_eq!(
+        fixture.status_message(),
+        "Wildcard query string is too long. Maximum allowed length is 1024"
+    );
+}
+
+// ── field masks ────────────────────────────────────────────────────────────
+
+#[test]
+fn eval_wildcard_query_narrows_the_reader_field_mask_to_the_query() {
+    // The readers are opened under the node's mask intersected with the
+    // query-wide one. Here the postings are indexed under field bit 0 and the
+    // node asks for every field, but the query narrows to bit 1 — so nothing
+    // matches, even though the node's own mask would have admitted it.
+    let mut fixture = WildcardFixture::build(
+        b"ap*",
+        WildcardOptions {
+            field_mask: RS_FIELDMASK_ALL,
+            query_field_mask: 0b10,
+            record_field_mask: 0b01,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), Vec::<u64>::new());
+    drop(it);
+    assert_eq!(
+        fixture.status_code(),
+        QueryErrorCode::Ok,
+        "narrowing by the query mask is not an error"
+    );
+
+    // Same postings and node, but the query-wide mask now admits the field they
+    // are indexed under — showing the exclusion above came from the mask and not
+    // from the terms.
+    let mut fixture = WildcardFixture::build(
+        b"ap*",
+        WildcardOptions {
+            field_mask: RS_FIELDMASK_ALL,
+            query_field_mask: 0b01,
+            record_field_mask: 0b01,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3]);
+}
+
+#[test]
+fn eval_wildcard_query_field_mask_excludes_every_expansion() {
+    // The node queries a field the postings are not indexed under, so no
+    // expansion opens a reader and the (empty) union yields nothing.
+    let mut fixture = WildcardFixture::build(
+        b"ap*",
+        WildcardOptions {
+            field_mask: 0b10,
+            record_field_mask: 0b01,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), Vec::<u64>::new());
+}
+
+// ── suffix trie ────────────────────────────────────────────────────────────
+
+#[test]
+fn eval_wildcard_query_via_suffix_trie_matches_the_same_terms() {
+    // The suffix-trie path yields the same result as the brute-force scan.
+    let mut fixture = WildcardFixture::with_suffix_trie("*ricot");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![3]);
+}
+
+#[test]
+fn eval_wildcard_query_via_suffix_trie_matches_an_interior_run() {
+    // `*ppl*` anchors on `ppl`, which the suffix trie can look up.
+    let mut fixture = WildcardFixture::with_suffix_trie("*ppl*");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2]);
+}
+
+#[test]
+fn eval_wildcard_query_falls_back_to_brute_force_without_an_anchor() {
+    // The suffix trie is chosen a token at a time, splitting the pattern on `*`,
+    // so a pattern that is nothing but `*` leaves no token to anchor on. The
+    // suffix walk declines it and the brute-force scan over the terms trie
+    // answers instead, matching every term.
+    //
+    // Note that `?` does *not* make a pattern unanchorable — the split is on `*`
+    // alone, so `?*` anchors on the `?` token and goes through the suffix trie.
+    let mut fixture = WildcardFixture::with_suffix_trie("*");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3, 4, 5]);
+    drop(it);
+    assert_eq!(
+        fixture.status_code(),
+        QueryErrorCode::Ok,
+        "falling back to brute force is not an error"
+    );
+}
+
+#[test]
+fn eval_wildcard_query_via_suffix_trie_anchors_on_a_question_mark_token() {
+    // `?*` splits into the single token `?`, which the suffix trie can anchor on,
+    // so this goes through the suffix walk rather than the fallback above. Every
+    // term of at least one character matches either way; the point is that the
+    // two paths agree.
+    let mut fixture = WildcardFixture::with_suffix_trie("?*");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3, 4, 5]);
+}
+
+#[test]
+fn eval_wildcard_query_unsupported_fields_errors_without_falling_back() {
+    // The spec has a suffix trie but the node queries a field outside it. That is
+    // an error, and — unlike the no-anchor case above — it does *not* fall back to
+    // the brute-force scan: the union comes back empty.
+    let mut fixture = WildcardFixture::build(
+        b"*ppl*",
+        WildcardOptions {
+            with_suffix_trie: true,
+            // A field bit the suffix trie does not cover, and not "all fields",
+            // which would be accepted unconditionally.
+            field_mask: 0b10,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), Vec::<u64>::new());
+    drop(it);
+    assert_eq!(fixture.status_code(), QueryErrorCode::Generic);
+    assert_eq!(
+        fixture.status_message(),
+        "Contains query on fields without WITHSUFFIXTRIE support"
+    );
+}
+
+#[test]
+fn eval_wildcard_query_unsupported_fields_error_applies_to_an_empty_pattern() {
+    // The field-support check does not depend on the pattern: an empty pattern on
+    // a field the suffix trie does not cover is still the unsupported-fields
+    // error. It outranks the empty-pattern match below it — the empty term is
+    // indexed here, so answering the pattern instead would both drop a
+    // user-visible error and return a document the error says nothing about.
+    let mut fixture = WildcardFixture::build(
+        b"",
+        WildcardOptions {
+            terms: terms_with_empty(),
+            with_suffix_trie: true,
+            field_mask: 0b10,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), Vec::<u64>::new());
+    drop(it);
+    assert_eq!(fixture.status_code(), QueryErrorCode::Generic);
+    assert_eq!(
+        fixture.status_message(),
+        "Contains query on fields without WITHSUFFIXTRIE support"
+    );
+}
+
+// ── expansion cap ──────────────────────────────────────────────────────────
+
+#[test]
+fn eval_wildcard_query_caps_expansions_and_warns() {
+    // Three terms match `ax*` but `max_prefix_expansions` is 2: only the first two
+    // expansions are opened, and the "reached max" warning is set.
+    let mut fixture = WildcardFixture::build(
+        b"ax*",
+        WildcardOptions {
+            terms: vec![(b"axa", vec![1]), (b"axb", vec![2]), (b"axc", vec![3])],
+            max_expansions: Some(2),
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(
+        collect_doc_ids(&mut it).len(),
+        2,
+        "expansion is capped at max_prefix_expansions"
+    );
+    drop(it);
+    assert!(
+        fixture.reached_max_expansions(),
+        "hitting the cap records the reached-max warning"
+    );
+}
+
+/// The three terms `abab`, `abc` and `xab` all contain `ab`, with one document
+/// each, so `*ab*` matches every one of them however it is expanded.
+fn ab_terms() -> Vec<(&'static [u8], Vec<u64>)> {
+    vec![(b"abab", vec![1]), (b"abc", vec![2]), (b"xab", vec![3])]
+}
+
+#[test]
+fn eval_wildcard_query_caps_expansions_on_the_suffix_trie_walk() {
+    // The cap applies to the suffix-trie walk too, and it counts readers *opened*,
+    // not distinct terms: `abab` is reachable under more than one matching suffix
+    // key, so it is expanded more than once and each expansion counts.
+    //
+    // A cap of 3 is what makes that observable, and is also what lets this test
+    // tell the two walks apart. Three distinct terms match, so the brute-force
+    // walk fits inside a cap of 3 exactly — all three documents, no warning. The
+    // suffix walk spends one of its three on the repeat of `abab`, so it loses a
+    // document *and* trips the warning. Were the suffix walk to quietly decline
+    // and fall back, this test would see the brute-force answer and fail; that is
+    // the one place the two paths differ by result rather than only by cost.
+    let mut fixture = WildcardFixture::build(
+        b"*ab*",
+        WildcardOptions {
+            with_suffix_trie: true,
+            terms: ab_terms(),
+            max_expansions: Some(3),
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(
+        collect_doc_ids(&mut it),
+        vec![1, 3],
+        "a repeated expansion consumes cap budget, costing document 2"
+    );
+    drop(it);
+    assert!(
+        fixture.reached_max_expansions(),
+        "hitting the cap records the reached-max warning"
+    );
+}
+
+#[test]
+fn eval_wildcard_query_brute_force_walk_does_not_repeat_a_term() {
+    // The counterpart to the test above, on the same terms and the same cap but
+    // with no suffix trie: the brute-force walk visits each matching term once, so
+    // all three fit within a cap of 3 and no warning is recorded. Together the two
+    // tests pin which walk ran, not merely that some walk did.
+    let mut fixture = WildcardFixture::build(
+        b"*ab*",
+        WildcardOptions {
+            with_suffix_trie: false,
+            terms: ab_terms(),
+            max_expansions: Some(3),
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3]);
+    drop(it);
+    assert!(
+        !fixture.reached_max_expansions(),
+        "three distinct terms fit within a cap of three"
+    );
+}

--- a/src/redisearch_rs/query_eval/tests/integration/wildcard_query.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/wildcard_query.rs
@@ -1,0 +1,875 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! QN_WILDCARD_QUERY → expand a verbatim wildcard pattern (`*` matches any run
+//! of characters, `?` exactly one) over the terms trie into a union of per-term
+//! readers.
+//!
+//! Covers both expansion walks — the brute-force terms-trie scan and the
+//! suffix-trie fast path, including the fallback from one to the other. Each test
+//! populates the terms trie with a handful of terms and queries a pattern,
+//! asserting the union yields exactly the documents of the matching terms.
+//!
+//! Disabled under Miri: `TestContext` calls into the C library, which Miri
+//! cannot execute.
+#![cfg(not(miri))]
+
+use index_result::{RSIndexResult, RSOffsetSlice};
+use query::mock::{MockQueryNode, TokenNodeType};
+use query_error::QueryErrorCode;
+use query_eval::{
+    Config, EvalResult, QueryEvalContext, QueryNode, QueryNodeMut, QueryNodeRef, eval_node,
+};
+use query_term::RSQueryTerm;
+use rqe_core::{FieldMask, RS_FIELDMASK_ALL};
+use rqe_iterators::{IteratorType, RQEIterator};
+use rqe_iterators_test_utils::{GlobalGuard, TestContext};
+
+/// All (low 32) field-mask bits set, so the reader's field-mask filter never
+/// excludes a document unless a test narrows the mask deliberately.
+const ALL_INDEXED_FIELDS: FieldMask = u32::MAX as FieldMask;
+
+/// Build term postings for the given document IDs, each indexed under
+/// `field_mask`.
+fn term_records(doc_ids: &[u64], field_mask: FieldMask) -> Vec<RSIndexResult<'static>> {
+    const OFFSETS: &[u8] = &[0];
+    doc_ids
+        .iter()
+        .map(|&doc_id| {
+            let mut term = RSQueryTerm::new("t", 1, 0);
+            term.set_idf(5.0);
+            term.set_bm25_idf(10.0);
+            RSIndexResult::build_term()
+                .borrowed_record(Some(term), RSOffsetSlice::from_slice(OFFSETS))
+                .doc_id(doc_id)
+                .field_mask(field_mask)
+                .frequency(1)
+                .build()
+        })
+        .collect()
+}
+
+/// The default term set: `apple`(1,2), `apricot`(3), `grape`(4), `banana`(5).
+fn default_terms() -> Vec<(&'static [u8], Vec<u64>)> {
+    vec![
+        (b"apple", vec![1, 2]),
+        (b"apricot", vec![3]),
+        (b"grape", vec![4]),
+        (b"banana", vec![5]),
+    ]
+}
+
+/// How to build a [`WildcardFixture`]. [`Default`] describes the case most tests
+/// want, leaving each test to override only the knob it exercises.
+struct WildcardOptions {
+    /// The terms to index, each with the documents indexed under it. Byte
+    /// strings, not `str`s: the terms trie decodes them without validating, so a
+    /// term key may hold bytes UTF-8 forbids.
+    terms: Vec<(&'static [u8], Vec<u64>)>,
+    /// Whether to declare the field `WITHSUFFIXTRIE`, which makes the expansion
+    /// prefer the suffix trie over the brute-force terms-trie scan.
+    with_suffix_trie: bool,
+    /// The node's weight, applied once by the enclosing union.
+    weight: f64,
+    /// The node's field mask: the fields the query asks about. Also decides
+    /// whether the suffix trie may be used, since every queried field must be
+    /// covered by it.
+    field_mask: FieldMask,
+    /// The query-wide field mask, which the node's mask is narrowed by before
+    /// reaching each reader. Deliberately separate from
+    /// [`field_mask`](Self::field_mask): only one of the two gates the
+    /// suffix-trie decision.
+    query_field_mask: FieldMask,
+    /// The field mask each indexed posting carries, which the reader intersects
+    /// with the effective mask.
+    record_field_mask: FieldMask,
+    /// Overrides [`Config::max_prefix_expansions`]. [`None`] keeps the default,
+    /// which no realistic test term set can reach.
+    max_expansions: Option<u32>,
+    /// Overrides [`Config::min_term_prefix`]. Used to show it does *not* apply to
+    /// a wildcard pattern.
+    min_term_prefix: Option<u32>,
+}
+
+impl Default for WildcardOptions {
+    fn default() -> Self {
+        Self {
+            terms: default_terms(),
+            with_suffix_trie: false,
+            weight: 1.0,
+            field_mask: RS_FIELDMASK_ALL,
+            query_field_mask: RS_FIELDMASK_ALL,
+            record_field_mask: ALL_INDEXED_FIELDS,
+            max_expansions: None,
+            min_term_prefix: None,
+        }
+    }
+}
+
+/// Owns everything a `QN_WILDCARD_QUERY` evaluation borrows, so a test can hold a
+/// single value and let the whole graph drop together at the end.
+struct WildcardFixture {
+    /// Registers the process-exit cleanup of the global spec dictionaries.
+    _guard: GlobalGuard,
+    /// Owns the index: the spec, its search context, the terms trie, and the
+    /// per-term inverted indexes. Must outlive [`ctx`](Self::ctx).
+    _context: TestContext,
+    /// The evaluation context under test. Also carries the query status, so tests
+    /// read errors and warnings back through it.
+    ctx: QueryEvalContext,
+    /// The `QN_WILDCARD_QUERY` node being evaluated.
+    node: MockQueryNode,
+    /// The evaluation config threaded into [`eval_node`].
+    config: Config,
+}
+
+impl WildcardFixture {
+    /// Default terms, brute-force scan, unit weight, all fields.
+    fn new(pattern: &str) -> Self {
+        Self::build(pattern.as_bytes(), WildcardOptions::default())
+    }
+
+    /// Like [`new`](Self::new) but declares the field `WITHSUFFIXTRIE`, so the
+    /// expansion prefers the suffix trie.
+    fn with_suffix_trie(pattern: &str) -> Self {
+        Self::build(
+            pattern.as_bytes(),
+            WildcardOptions {
+                with_suffix_trie: true,
+                ..WildcardOptions::default()
+            },
+        )
+    }
+
+    fn build(pattern: &[u8], opts: WildcardOptions) -> Self {
+        let _guard = GlobalGuard::default();
+
+        let record_field_mask = opts.record_field_mask;
+        let records = opts
+            .terms
+            .into_iter()
+            .map(move |(term, doc_ids)| (term, term_records(&doc_ids, record_field_mask)));
+        let context = TestContext::prefix(records, opts.with_suffix_trie);
+
+        let qctx = context.qctx();
+        // The expansion narrows each term's field mask with the query-wide one;
+        // the zero-init options leave it 0, which would mask out every field.
+        // SAFETY: `qctx` points to a valid, exclusively-owned `QueryEvalCtx`.
+        let opts_ptr = unsafe { (*qctx.as_ptr()).opts.cast_mut() };
+        // SAFETY: `opts_ptr` is the context's valid, exclusively-owned
+        // `RSSearchOptions`.
+        unsafe {
+            (*opts_ptr).fieldmask = opts.query_field_mask;
+        };
+
+        let mut config = Config::default();
+        if let Some(cap) = opts.max_expansions {
+            config.max_prefix_expansions = cap as usize;
+        }
+        if let Some(min) = opts.min_term_prefix {
+            config.min_term_prefix = min;
+        }
+        // SAFETY: `qctx` upholds the `QueryEvalContext::new` invariants and is
+        // exclusively owned by this fixture.
+        let ctx = unsafe { QueryEvalContext::new(qctx) };
+
+        // `with_token` gives the node a writable, NUL-terminated copy of the
+        // pattern that it owns: evaluation unescapes through the token in place
+        // and hands it to the union as a C string, so it needs both.
+        let mut node = MockQueryNode::with_token(TokenNodeType::WildcardQuery, pattern);
+        node.opts_mut().weight = opts.weight;
+        node.opts_mut().field_mask = opts.field_mask;
+
+        Self {
+            _guard,
+            _context: context,
+            ctx,
+            node,
+            config,
+        }
+    }
+
+    /// Evaluate the node, returning the boxed iterator, or `None` when evaluation
+    /// produced no iterator.
+    fn eval(&mut self) -> Option<EvalResult<'_>> {
+        // SAFETY: `self.node` is a valid, live `RSQueryNode` for the call.
+        let node_ref = unsafe { QueryNodeMut::new(self.node.as_non_null()) };
+        eval_node(&mut self.ctx, node_ref, self.config).map(|e| e.into_boxed())
+    }
+
+    /// The token's current string, which evaluation may have rewritten in place.
+    ///
+    /// Copied out rather than borrowed: the handle the token is read through
+    /// borrows from the local view of the node, not from the fixture.
+    fn token_bytes(&self) -> Vec<u8> {
+        // SAFETY: `self.node` is a valid, live `RSQueryNode`, and this shared
+        // borrow of the fixture rules out a concurrent exclusive view of it.
+        let node = unsafe { QueryNodeRef::new(self.node.as_non_null()) };
+        let QueryNode::WildcardQuery { tok } = node.as_enum() else {
+            panic!("fixture builds a wildcard-query node");
+        };
+        tok.as_bytes()
+            .expect("fixture installs a token string")
+            .to_vec()
+    }
+
+    /// The current query error code (`Ok` when no error was set).
+    fn status_code(&mut self) -> QueryErrorCode {
+        self.ctx.status().code()
+    }
+
+    /// The current query error message.
+    fn status_message(&mut self) -> String {
+        self.ctx
+            .status()
+            .public_message()
+            .map(|m| m.to_string_lossy().into_owned())
+            .unwrap_or_default()
+    }
+
+    /// Whether the "reached max prefix expansions" warning was recorded.
+    fn reached_max_expansions(&mut self) -> bool {
+        self.ctx.status().warnings().reached_max_prefix_expansions()
+    }
+}
+
+/// Drain an iterator into the list of document IDs it yields, in order.
+fn collect_doc_ids(it: &mut EvalResult) -> Vec<u64> {
+    let mut ids = Vec::new();
+    while let Some(r) = it.read().expect("read must not error") {
+        ids.push(r.doc_id);
+    }
+    ids
+}
+
+// ── matching ───────────────────────────────────────────────────────────────
+
+#[test]
+fn eval_wildcard_query_star_expands_and_unions_matches() {
+    // `ap*` matches `apple` and `apricot`, whose documents union to {1, 2, 3}.
+    let mut fixture = WildcardFixture::new("ap*");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(it.type_(), IteratorType::Union);
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3]);
+}
+
+#[test]
+fn eval_wildcard_query_question_mark_matches_exactly_one_character() {
+    // `?rape` matches `grape` but not `rape` or `ggrape`: `?` is exactly one.
+    let mut fixture = WildcardFixture::build(
+        b"?rape",
+        WildcardOptions {
+            terms: vec![
+                (b"grape", vec![4]),
+                (b"rape", vec![6]),
+                (b"ggrape", vec![7]),
+            ],
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![4]);
+}
+
+#[test]
+fn eval_wildcard_query_mixed_star_and_question_mark() {
+    // `a?*t` — `a`, exactly one character, any run, then a final `t`: `apricot`
+    // matches, `apple` does not end in `t`, `at` has nothing for the `?`.
+    let mut fixture = WildcardFixture::build(
+        b"a?*t",
+        WildcardOptions {
+            terms: vec![(b"apricot", vec![3]), (b"apple", vec![1]), (b"at", vec![8])],
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![3]);
+}
+
+#[test]
+fn eval_wildcard_query_interior_star_matches_around_it() {
+    // `a*t` anchors both ends: `apricot` matches, `apple` does not.
+    let mut fixture = WildcardFixture::new("a*t");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![3]);
+}
+
+#[test]
+fn eval_wildcard_query_lowercases_the_pattern() {
+    // Terms are indexed lowercased, so the pattern is lowercased before the trie
+    // walk: `AP*` expands exactly like `ap*`.
+    let mut fixture = WildcardFixture::new("AP*");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3]);
+}
+
+#[test]
+fn eval_wildcard_query_single_match_collapses_to_the_reader() {
+    // `gr*` matches only `grape`; a union of one child collapses to that child's
+    // term reader, which carries the per-expansion unit weight rather than the
+    // node weight — the node weight is applied only by a real union.
+    let mut fixture = WildcardFixture::build(
+        b"gr*",
+        WildcardOptions {
+            weight: 5.0,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(it.type_(), IteratorType::InvIdxTerm);
+    let r = it.read().expect("read must not error").expect("one result");
+    assert_eq!(r.doc_id, 4);
+    assert_eq!(r.weight, 1.0, "expanded child readers carry unit weight");
+}
+
+#[test]
+fn eval_wildcard_query_union_carries_the_node_weight() {
+    // `ap*` expands to two terms, so a real union is built and it carries the
+    // node's weight. This is the counterpart to the single-match case above: there
+    // the union collapses to its child and the node weight is deliberately absent,
+    // so without this test nothing would notice the weight being dropped, or the
+    // wrong value being passed, on the path where it does apply.
+    let mut fixture = WildcardFixture::build(
+        b"ap*",
+        WildcardOptions {
+            weight: 5.0,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(it.type_(), IteratorType::Union);
+    let r = it.read().expect("read must not error").expect("one result");
+    assert_eq!(r.weight, 5.0, "a real union carries the node weight");
+}
+
+#[test]
+fn eval_wildcard_query_no_match_yields_empty_union() {
+    // `zz*` matches no term: evaluation still returns an iterator, which reads
+    // nothing — it is never `None`.
+    let mut fixture = WildcardFixture::new("zz*");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), Vec::<u64>::new());
+}
+
+#[test]
+fn eval_wildcard_query_expands_a_term_whose_key_is_not_utf8() {
+    // A term key is not necessarily valid UTF-8. `\xED\xA0\xBD` is the three-byte
+    // encoding of the lone surrogate `U+D83D`, which UTF-8 forbids — and which is
+    // what a non-BMP codepoint becomes once the trie truncates it to a 16-bit
+    // rune. The expansion must hand those bytes to the inverted-index lookup
+    // unvalidated, or the term's document is dropped.
+    let mut fixture = WildcardFixture::build(
+        b"ap*",
+        WildcardOptions {
+            terms: vec![(b"ap\xED\xA0\xBDle", vec![7]), (b"apple", vec![1, 2])],
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 7]);
+}
+
+#[test]
+fn eval_wildcard_query_skips_expansion_without_inverted_index() {
+    // `apex` is in the terms trie but has no document, so it opens no reader and
+    // contributes nothing; the other two `ap` expansions still union to {1, 2, 3}.
+    let mut fixture = WildcardFixture::build(
+        b"ap*",
+        WildcardOptions {
+            terms: vec![
+                (b"apple", vec![1, 2]),
+                (b"apex", vec![]),
+                (b"apricot", vec![3]),
+            ],
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3]);
+}
+
+// ── escapes ────────────────────────────────────────────────────────────────
+
+#[test]
+fn eval_wildcard_query_removes_escapes_from_the_token() {
+    // `ap\*le` unescapes to `ap*le` before the walk, so the `*` is a wildcard and
+    // the pattern matches `apple`. The token is rewritten *in place*, because it
+    // is also what the union reports as its profiling query string.
+    let mut fixture = WildcardFixture::new("ap\\*le");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2]);
+    drop(it);
+    assert_eq!(
+        fixture.token_bytes(),
+        b"ap*le",
+        "the escape is stripped from the node's own token"
+    );
+}
+
+#[test]
+fn eval_wildcard_query_removes_a_trailing_backslash() {
+    // A pattern ending in a lone backslash drops it: `apple\` becomes `apple`,
+    // which matches the term exactly.
+    //
+    // This is the one input shape where escape removal reads the byte *past* the
+    // token — the escape has nothing after it, so the converter copies the
+    // terminator into its place and stops there. Nothing else in this file
+    // exercises that read.
+    let mut fixture = WildcardFixture::new("apple\\");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2]);
+    drop(it);
+    assert_eq!(
+        fixture.token_bytes(),
+        b"apple",
+        "the trailing backslash is dropped, shortening the token"
+    );
+}
+
+#[test]
+fn eval_wildcard_query_escape_removal_leaves_an_unescaped_token_alone() {
+    // A pattern with no backslash is returned unchanged, length included.
+    let mut fixture = WildcardFixture::new("ap*");
+    let _ = fixture.eval();
+    assert_eq!(fixture.token_bytes(), b"ap*");
+}
+
+// ── degenerate patterns ────────────────────────────────────────────────────
+
+/// The default terms plus the empty term, indexing document 9 — what an
+/// `INDEXEMPTY` field's empty value produces. It reaches the inverted index only:
+/// neither trie accepts a zero-length key.
+fn terms_with_empty() -> Vec<(&'static [u8], Vec<u64>)> {
+    let mut terms = default_terms();
+    terms.push((b"", vec![9]));
+    terms
+}
+
+#[test]
+fn eval_wildcard_query_empty_pattern_matches_nothing_without_an_empty_term() {
+    // An empty pattern matches exactly the empty term. Without `INDEXEMPTY` there
+    // is no inverted index for it, so the union comes back empty — and that is a
+    // miss, not an error.
+    let mut fixture = WildcardFixture::new("");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), Vec::<u64>::new());
+    drop(it);
+    assert_eq!(
+        fixture.status_code(),
+        QueryErrorCode::Ok,
+        "an empty pattern is not an error, just a miss"
+    );
+}
+
+#[test]
+fn eval_wildcard_query_empty_pattern_matches_the_empty_term() {
+    // With the empty term indexed, an empty pattern matches it and nothing else:
+    // the reader is opened directly, since no trie holds a zero-length key for a
+    // walk to find.
+    let mut fixture = WildcardFixture::build(
+        b"",
+        WildcardOptions {
+            terms: terms_with_empty(),
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![9]);
+    drop(it);
+    assert_eq!(fixture.status_code(), QueryErrorCode::Ok);
+}
+
+#[test]
+fn eval_wildcard_query_empty_pattern_matches_the_empty_term_with_a_suffix_trie() {
+    // Same answer on a spec with a suffix trie: the empty pattern is recognised
+    // before either walk is chosen, so neither runs — the suffix walk's own
+    // no-anchor path is not what produces this answer.
+    let mut fixture = WildcardFixture::build(
+        b"",
+        WildcardOptions {
+            terms: terms_with_empty(),
+            with_suffix_trie: true,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![9]);
+}
+
+#[test]
+fn eval_wildcard_query_empty_pattern_respects_the_field_mask() {
+    // The empty term's reader is opened with the same effective field mask as any
+    // expanded term's, so a document indexed under another field is not matched.
+    let mut fixture = WildcardFixture::build(
+        b"",
+        WildcardOptions {
+            terms: terms_with_empty(),
+            field_mask: 0b01,
+            record_field_mask: 0b10,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), Vec::<u64>::new());
+}
+
+#[test]
+fn eval_wildcard_query_bare_star_matches_every_term() {
+    // `*` is the shortest pattern that matches everything. It is also the case
+    // that reads the element past the pattern — a pattern ending in `*` makes the
+    // matcher dereference its cursor without re-checking it against the end — so
+    // the terminator the pattern carries has to be there and has to be zero.
+    let mut fixture = WildcardFixture::new("*");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3, 4, 5]);
+}
+
+#[test]
+fn eval_wildcard_query_ignores_min_term_prefix() {
+    // A wildcard pattern has no minimum length: unlike a prefix node, it is not
+    // rejected for being shorter than `min_term_prefix`. Copying that guard over
+    // would silently turn `w'*'` into a miss under the default MINPREFIX of 2.
+    let mut fixture = WildcardFixture::build(
+        b"*",
+        WildcardOptions {
+            min_term_prefix: Some(10),
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3, 4, 5]);
+}
+
+#[test]
+fn eval_wildcard_query_too_long_reports_limit_error() {
+    // A pattern longer than `MAX_RUNE_STR_LEN` (1024) cannot be lowered to runes.
+    // The message is user-visible, and names this node type rather than the
+    // prefix/suffix/infix wording a prefix node uses.
+    let long = "a".repeat(2000);
+    let mut fixture = WildcardFixture::new(&long);
+    assert!(
+        fixture.eval().is_none(),
+        "an over-long pattern yields no iterator"
+    );
+    assert_eq!(fixture.status_code(), QueryErrorCode::Limit);
+    assert_eq!(
+        fixture.status_message(),
+        "Wildcard query string is too long. Maximum allowed length is 1024"
+    );
+}
+
+// ── field masks ────────────────────────────────────────────────────────────
+
+#[test]
+fn eval_wildcard_query_narrows_the_reader_field_mask_to_the_query() {
+    // The readers are opened under the node's mask intersected with the
+    // query-wide one. Here the postings are indexed under field bit 0 and the
+    // node asks for every field, but the query narrows to bit 1 — so nothing
+    // matches, even though the node's own mask would have admitted it.
+    let mut fixture = WildcardFixture::build(
+        b"ap*",
+        WildcardOptions {
+            field_mask: RS_FIELDMASK_ALL,
+            query_field_mask: 0b10,
+            record_field_mask: 0b01,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), Vec::<u64>::new());
+    drop(it);
+    assert_eq!(
+        fixture.status_code(),
+        QueryErrorCode::Ok,
+        "narrowing by the query mask is not an error"
+    );
+
+    // Same postings and node, but the query-wide mask now admits the field they
+    // are indexed under — showing the exclusion above came from the mask and not
+    // from the terms.
+    let mut fixture = WildcardFixture::build(
+        b"ap*",
+        WildcardOptions {
+            field_mask: RS_FIELDMASK_ALL,
+            query_field_mask: 0b01,
+            record_field_mask: 0b01,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3]);
+}
+
+#[test]
+fn eval_wildcard_query_field_mask_excludes_every_expansion() {
+    // The node queries a field the postings are not indexed under, so no
+    // expansion opens a reader and the (empty) union yields nothing.
+    let mut fixture = WildcardFixture::build(
+        b"ap*",
+        WildcardOptions {
+            field_mask: 0b10,
+            record_field_mask: 0b01,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), Vec::<u64>::new());
+}
+
+// ── suffix trie ────────────────────────────────────────────────────────────
+
+#[test]
+fn eval_wildcard_query_via_suffix_trie_matches_the_same_terms() {
+    // The suffix-trie path yields the same result as the brute-force scan.
+    let mut fixture = WildcardFixture::with_suffix_trie("*ricot");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![3]);
+}
+
+#[test]
+fn eval_wildcard_query_via_suffix_trie_matches_an_interior_run() {
+    // `*ppl*` anchors on `ppl`, which the suffix trie can look up.
+    let mut fixture = WildcardFixture::with_suffix_trie("*ppl*");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2]);
+}
+
+#[test]
+fn eval_wildcard_query_falls_back_to_brute_force_without_an_anchor() {
+    // The suffix trie is chosen a token at a time, splitting the pattern on `*`,
+    // so a pattern that is nothing but `*` leaves no token to anchor on. The
+    // suffix walk declines it and the brute-force scan over the terms trie
+    // answers instead, matching every term.
+    //
+    // Note that `?` does *not* make a pattern unanchorable — the split is on `*`
+    // alone, so `?*` anchors on the `?` token and goes through the suffix trie.
+    let mut fixture = WildcardFixture::with_suffix_trie("*");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3, 4, 5]);
+    drop(it);
+    assert_eq!(
+        fixture.status_code(),
+        QueryErrorCode::Ok,
+        "falling back to brute force is not an error"
+    );
+}
+
+#[test]
+fn eval_wildcard_query_via_suffix_trie_anchors_on_a_question_mark_token() {
+    // `?*` splits into the single token `?`, which the suffix trie can anchor on,
+    // so this goes through the suffix walk rather than the fallback above. Every
+    // term of at least one character matches either way; the point is that the
+    // two paths agree.
+    let mut fixture = WildcardFixture::with_suffix_trie("?*");
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3, 4, 5]);
+}
+
+#[test]
+fn eval_wildcard_query_unsupported_fields_errors_without_falling_back() {
+    // The spec has a suffix trie but the node queries a field outside it. That is
+    // an error, and — unlike the no-anchor case above — it does *not* fall back to
+    // the brute-force scan: the union comes back empty.
+    let mut fixture = WildcardFixture::build(
+        b"*ppl*",
+        WildcardOptions {
+            with_suffix_trie: true,
+            // A field bit the suffix trie does not cover, and not "all fields",
+            // which would be accepted unconditionally.
+            field_mask: 0b10,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), Vec::<u64>::new());
+    drop(it);
+    assert_eq!(fixture.status_code(), QueryErrorCode::Generic);
+    assert_eq!(
+        fixture.status_message(),
+        "Contains query on fields without WITHSUFFIXTRIE support"
+    );
+}
+
+#[test]
+fn eval_wildcard_query_unsupported_fields_error_applies_to_an_empty_pattern() {
+    // The field-support check does not depend on the pattern: an empty pattern on
+    // a field the suffix trie does not cover is still the unsupported-fields
+    // error. It outranks the empty-pattern match below it — the empty term is
+    // indexed here, so answering the pattern instead would both drop a
+    // user-visible error and return a document the error says nothing about.
+    let mut fixture = WildcardFixture::build(
+        b"",
+        WildcardOptions {
+            terms: terms_with_empty(),
+            with_suffix_trie: true,
+            field_mask: 0b10,
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), Vec::<u64>::new());
+    drop(it);
+    assert_eq!(fixture.status_code(), QueryErrorCode::Generic);
+    assert_eq!(
+        fixture.status_message(),
+        "Contains query on fields without WITHSUFFIXTRIE support"
+    );
+}
+
+// ── expansion cap ──────────────────────────────────────────────────────────
+
+#[test]
+fn eval_wildcard_query_caps_expansions_and_warns() {
+    // Three terms match `ax*` but `max_prefix_expansions` is 2: only the first two
+    // expansions are opened, and the "reached max" warning is set.
+    let mut fixture = WildcardFixture::build(
+        b"ax*",
+        WildcardOptions {
+            terms: vec![(b"axa", vec![1]), (b"axb", vec![2]), (b"axc", vec![3])],
+            max_expansions: Some(2),
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(
+        collect_doc_ids(&mut it).len(),
+        2,
+        "expansion is capped at max_prefix_expansions"
+    );
+    drop(it);
+    assert!(
+        fixture.reached_max_expansions(),
+        "hitting the cap records the reached-max warning"
+    );
+}
+
+/// The three terms `abab`, `abc` and `xab` all contain `ab`, with one document
+/// each, so `*ab*` matches every one of them however it is expanded.
+fn ab_terms() -> Vec<(&'static [u8], Vec<u64>)> {
+    vec![(b"abab", vec![1]), (b"abc", vec![2]), (b"xab", vec![3])]
+}
+
+#[test]
+fn eval_wildcard_query_caps_expansions_on_the_suffix_trie_walk() {
+    // The cap applies to the suffix-trie walk too, and it counts readers *opened*,
+    // not distinct terms: `abab` is reachable under more than one matching suffix
+    // key, so it is expanded more than once and each expansion counts.
+    //
+    // A cap of 3 is what makes that observable, and is also what lets this test
+    // tell the two walks apart. Three distinct terms match, so the brute-force
+    // walk fits inside a cap of 3 exactly — all three documents, no warning. The
+    // suffix walk spends one of its three on the repeat of `abab`, so it loses a
+    // document *and* trips the warning. Were the suffix walk to quietly decline
+    // and fall back, this test would see the brute-force answer and fail; that is
+    // the one place the two paths differ by result rather than only by cost.
+    let mut fixture = WildcardFixture::build(
+        b"*ab*",
+        WildcardOptions {
+            with_suffix_trie: true,
+            terms: ab_terms(),
+            max_expansions: Some(3),
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(
+        collect_doc_ids(&mut it),
+        vec![1, 3],
+        "a repeated expansion consumes cap budget, costing document 2"
+    );
+    drop(it);
+    assert!(
+        fixture.reached_max_expansions(),
+        "hitting the cap records the reached-max warning"
+    );
+}
+
+#[test]
+fn eval_wildcard_query_brute_force_walk_does_not_repeat_a_term() {
+    // The counterpart to the test above, on the same terms and the same cap but
+    // with no suffix trie: the brute-force walk visits each matching term once, so
+    // all three fit within a cap of 3 and no warning is recorded. Together the two
+    // tests pin which walk ran, not merely that some walk did.
+    let mut fixture = WildcardFixture::build(
+        b"*ab*",
+        WildcardOptions {
+            with_suffix_trie: false,
+            terms: ab_terms(),
+            max_expansions: Some(3),
+            ..WildcardOptions::default()
+        },
+    );
+    let mut it = fixture
+        .eval()
+        .expect("a wildcard always builds an iterator");
+    assert_eq!(collect_doc_ids(&mut it), vec![1, 2, 3]);
+    drop(it);
+    assert!(
+        !fixture.reached_max_expansions(),
+        "three distinct terms fit within a cap of three"
+    );
+}

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/test_context.rs
@@ -556,6 +556,11 @@ impl TestContext {
     /// `WITHSUFFIXTRIE` and each term is also inserted into the spec's suffix
     /// trie, exercising the suffix-trie expansion path instead of the brute-force
     /// terms-trie scan.
+    ///
+    /// The empty term is a special case, and is faithful to the indexer: neither
+    /// trie takes a zero-length key — the terms trie refuses one and the suffix
+    /// trie is gated against it — so an empty term contributes only its inverted
+    /// index, exactly as an `INDEXEMPTY` field's empty value does.
     pub fn prefix<T, S>(terms: T, with_suffix_trie: bool) -> Self
     where
         T: IntoIterator<Item = (S, Vec<RSIndexResult<'static>>)>,
@@ -595,8 +600,10 @@ impl TestContext {
             unsafe {
                 ffi::IndexSpec_AddTerm(spec, cterm.as_ptr(), cterm.as_bytes().len());
             }
-            // Mirror the indexer by also feeding the suffix trie when enabled.
-            if with_suffix_trie {
+            // Mirror the indexer by also feeding the suffix trie when enabled —
+            // including its gate against the empty term, which `addSuffixTrie`
+            // asserts on.
+            if with_suffix_trie && !cterm.as_bytes().is_empty() {
                 // SAFETY: `spec` is a valid, non-null `IndexSpec` just returned
                 // by `create_spec_sctx`.
                 let suffix = unsafe { (*spec).suffix };


### PR DESCRIPTION
> Stacked on #10748 — base that first. The diff below is this commit only.

## Describe the changes in the pull request

1. **Current**: `Query_EvalNode` still dispatches `QN_WILDCARD_QUERY` — the verbatim wildcard query `w'he?l*o'`, where `*` matches any run of characters and `?` exactly one — to the C `Query_EvalWildcardQueryNode`.
2. **Change**: evaluate it in `query_eval` instead, and delete the C evaluator along with the two trie callbacks it was the only caller of (`runeIterCb`, `charIterCb`) and their shared helpers.
3. **Outcome**: `QN_TAG`, `QN_FUZZY` and `QN_VECTOR` are the last node types C still dispatches. No user-visible change.

The expansion mirrors the C: unescape the pattern token in place (via `token_mut()` from #10748), lower it to runes, prefer the spec's suffix trie when it has one and every queried field is covered by it, fall back to a brute-force terms-trie walk when the suffix trie has no literal run to anchor on, and union the per-term readers with the pattern as the union's profiling query string. A field set the suffix trie does not cover is an error that does not fall back, and — as in the C — that check does not depend on the pattern, so it still fires for one that lowercases to nothing.

### The empty pattern

An empty pattern is answered without either walk, again as the C does: it matches exactly the empty term, which neither trie can hold, since a zero-length key is refused on insertion. Under `INDEXEMPTY` that term exists as an inverted index and nothing else, so its reader is opened directly, the way an empty-string query opens it; without `INDEXEMPTY` there is no such index and the pattern matches nothing. The unsupported-fields error outranks this, so an empty pattern on a field the suffix trie does not cover still reports the error rather than the document.

`TestContext::prefix` gains the indexer's own gate against feeding the empty term to the suffix trie, so a fixture can index one — `addSuffixTrie` asserts on a zero-length key, and the real indexer never hands it one either.

### Reading this next to the prefix evaluator

Two details worth stating because both are easy to get wrong:

- the suffix-support decision uses the node's **own** field mask, while readers use it narrowed by the query-wide one;
- a wildcard pattern has **no minimum length**, so the `min_term_prefix` check that guards a prefix node must not be copied here — doing so would silently turn `w'*'` into a miss under the default `MINPREFIX`.

### The expansion cap

The cap check moves out of `push_child` into `Expansion::cap_reached` so a walk can consult it before doing work `push_child` would discard. Both wildcard walks need that: the trie honours a stop request only on the sub-tree path it takes for a pattern ending in `*`, so for any other pattern it keeps calling back over the rest of the trie. Without the check, every one of those calls would reconstruct a term key, or on the disk path also look its document count up in the terms trie.

### The sentinel

The C wildcard matchers read one element **past** the pattern — its value decides the match for a pattern ending in `*`. They get away with it because the converters that produce a pattern over-allocate by one and zero it. A pattern reaching Rust as a plain `Vec` has no such element, so `LoweredPattern` owns that layout and keeps the raw pointers crate-private.

`iterate_suffix_wildcard` consumes the pattern and hands it back as `SuffixWalk::NoAnchor` only when it declined, so the fallback walk over the primary terms trie has it and a walk that ran cannot be asked for it again.

### Deliberate difference from the C

One, with no production effect: the deleted `runeIterCb` skipped the expansion cap when `RS_IsMock`, while `charIterCb` on the other walk applied it unconditionally. Both walks now apply it. `RS_IsMock` is true only under the C++ unit-test harness, which never evaluates a wildcard query — it only parses one.

The tag wildcard path is unchanged and stays in C: it expands over the tag index's `TrieMap`, and C reaches it through the unported `Query_EvalTagNode`.

#### Which additional issues this PR fixes
1. MOD-14885

#### Main objects this PR modified
1. `src/query.c` — `Query_EvalWildcardQueryNode`, `runeIterCb`, `charIterCb`, `rangeItersAddIterator`, `TrieCallbackCtx` removed; `QN_WILDCARD_QUERY` dispatched to Rust
2. `query_eval::eval` — `eval_wildcard_query`, plus two wildcard walks on the shared `Expansion`
3. `Expansion::cap_reached` — cap check split out of `push_child`
4. `rqe_iterators_test_utils::TestContext::prefix` — gated against feeding the empty term to the suffix trie

The header reads (`opts.field_mask`, `opts.weight`, the offsets decision) now happen *before* the token handle is taken, because that handle borrows the node exclusively until the very end — it is what the union's profiling query string is read through, so nothing may consult `opts` once it is live.

The unescape is fallible (`TokenTooLong`, from #10748), and its failure joins the existing rune-length failure on one path: both are length limits, the escape converter's bound sits far above `MAX_RUNE_STR_LEN`, so the existing "Wildcard query string is too long" error is the right report for either.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
