### PR TITLE
[MOD-13983] Review the pagination logic in NumericRangeTree

### DIFF
--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/lib.rs
@@ -36,6 +36,7 @@ pub use gc::*;
 pub use iterator::*;
 pub use node::*;
 use numeric_range_tree::AddResult;
+use numeric_range_tree::RangeWindow;
 use numeric_range_tree::TrimEmptyLeavesResult;
 pub use range::*;
 pub use tree::*;
@@ -187,7 +188,7 @@ pub unsafe extern "C" fn NumericRangeTree_Find(
     // SAFETY: Caller ensures `nf` is a valid, non-null pointer.
     let filter = unsafe { &*nf };
 
-    let ranges = tree.find(filter);
+    let ranges = tree.find_windowed(filter, RangeWindow::from_filter(filter));
 
     // Convert Vec<&NumericRange> to a boxed slice of pointers.
     let range_ptrs: Box<[*const numeric_range_tree::NumericRange]> = ranges

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/src/lib.rs
@@ -36,6 +36,7 @@ pub use gc::*;
 pub use iterator::*;
 pub use node::*;
 use numeric_range_tree::AddResult;
+use numeric_range_tree::RangeWindow;
 use numeric_range_tree::TrimEmptyLeavesResult;
 pub use range::*;
 pub use tree::*;
@@ -194,7 +195,7 @@ pub unsafe extern "C" fn NumericRangeTree_Find(
     // SAFETY: Caller ensures `nf` is a valid, non-null pointer.
     let filter = unsafe { &*nf };
 
-    let ranges = tree.find(filter);
+    let ranges = tree.find_windowed(filter, RangeWindow::from_filter(filter));
 
     // Convert Vec<&NumericRange> to a boxed slice of pointers.
     let range_ptrs: Box<[*const numeric_range_tree::NumericRange]> = ranges

--- a/src/redisearch_rs/headers/numeric_range_tree_ffi.h
+++ b/src/redisearch_rs/headers/numeric_range_tree_ffi.h
@@ -326,18 +326,6 @@ size_t NumericRangeTree_GetNumRanges(const struct NumericRangeTree *t);
 const struct InvertedIndexNumeric *NumericRange_GetEntries(const struct NumericRange *range);
 
 /**
- * Create a new [`NumericRangeTree`].
- *
- * Returns an opaque pointer to the newly created tree.
- * To free the tree, use [`NumericRangeTree_Free`].
- *
- * If `compress_floats` is true, the tree will use float compression which
- * attempts to store f64 values as f32 when precision loss is acceptable (< 0.01).
- * This corresponds to the `RSGlobalConfig.numericCompress` setting.
- */
-struct NumericRangeTree *NewNumericRangeTree(bool compress_floats);
-
-/**
  * Parse a serialized GC entry and apply it to the specified node.
  *
  * The entry data must have the wire format produced by the numeric child
@@ -355,6 +343,18 @@ struct NumericRangeTree *NewNumericRangeTree(bool compress_floats);
  * - `entry_data` must point to a valid byte buffer of at least `entry_len` bytes.
  */
 struct ApplyGcEntryResult NumericRangeTree_ApplyGcEntry(struct NumericRangeTree *tree, uint32_t node_position, uint32_t node_generation, const uint8_t *entry_data, size_t entry_len);
+
+/**
+ * Create a new [`NumericRangeTree`].
+ *
+ * Returns an opaque pointer to the newly created tree.
+ * To free the tree, use [`NumericRangeTree_Free`].
+ *
+ * If `compress_floats` is true, the tree will use float compression which
+ * attempts to store f64 values as f32 when precision loss is acceptable (< 0.01).
+ * This corresponds to the `RSGlobalConfig.numericCompress` setting.
+ */
+struct NumericRangeTree *NewNumericRangeTree(bool compress_floats);
 
 /**
  * Get the total size of inverted indexes in the tree.

--- a/src/redisearch_rs/inverted_index/src/reader/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/numeric.rs
@@ -44,13 +44,16 @@ pub struct NumericFilter {
     pub ascending: bool,
 
     /// Minimum number of results needed
+    #[deprecated(note = "iteration state, not a value predicate; owned by the paginating caller")]
     pub limit: usize,
 
     /// Number of results to skip
+    #[deprecated(note = "iteration state, not a value predicate; owned by the paginating caller")]
     pub offset: usize,
 }
 
 impl Default for NumericFilter {
+    #[expect(deprecated, reason = "field initialiser")]
     fn default() -> Self {
         Self {
             min: 0.0,

--- a/src/redisearch_rs/inverted_index/src/reader/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/reader/numeric.rs
@@ -44,16 +44,16 @@ pub struct NumericFilter {
     pub ascending: bool,
 
     /// Minimum number of results needed
-    #[deprecated(note = "iteration state, not a value predicate; owned by the paginating caller")]
+    #[deprecated(note = "pagination state, not part of the filter: the caller paginating owns it")]
     pub limit: usize,
 
     /// Number of results to skip
-    #[deprecated(note = "iteration state, not a value predicate; owned by the paginating caller")]
+    #[deprecated(note = "pagination state, not part of the filter: the caller paginating owns it")]
     pub offset: usize,
 }
 
 impl Default for NumericFilter {
-    #[expect(deprecated, reason = "field initialiser")]
+    #[expect(deprecated, reason = "initialises the deprecated fields")]
     fn default() -> Self {
         Self {
             min: 0.0,

--- a/src/redisearch_rs/inverted_index/src/tests/reader/geo.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/reader/geo.rs
@@ -54,8 +54,7 @@ fn reading_filter_based_on_geo_filter() {
         field_spec: ptr::null(),
         geo_filter: &geo_filter as *const _ as *const _,
         ascending: true,
-        limit: 0,
-        offset: 0,
+        ..Default::default()
     };
 
     let mut reader = FilterGeoReader::new(filter, iter.into_iter());

--- a/src/redisearch_rs/inverted_index/src/tests/reader/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/reader/numeric.rs
@@ -14,6 +14,7 @@ use index_result::RSIndexResult;
 use pretty_assertions::assert_eq;
 
 #[test]
+#[expect(deprecated, reason = "exhaustive struct literal")]
 fn reading_filter_based_on_numeric_filter() {
     // Make an iterator with three records having different numeric values. The second record will be
     // filtered out based on the numeric filter.

--- a/src/redisearch_rs/numeric_range_tree/benches/find.rs
+++ b/src/redisearch_rs/numeric_range_tree/benches/find.rs
@@ -19,8 +19,8 @@ use std::time::Duration;
 use criterion::measurement::WallTime;
 use criterion::{BenchmarkGroup, Criterion, criterion_group, criterion_main};
 use inverted_index::NumericFilter;
-use numeric_range_tree::NumericRangeTree;
 use numeric_range_tree::test_utils::{build_large_tree, build_tree};
+use numeric_range_tree::{NumericRangeTree, RangeWindow};
 
 fn bench_leaf_only(group: &mut BenchmarkGroup<'_, WallTime>, tree: &NumericRangeTree) {
     let filter = NumericFilter {
@@ -103,15 +103,19 @@ fn bench_with_offset_limit(group: &mut BenchmarkGroup<'_, WallTime>, tree: &Nume
     let filter = NumericFilter {
         min: 0.0,
         max: 5000.0,
-        offset: 100,
-        limit: 10,
         ..Default::default()
     };
+    let window = RangeWindow {
+        offset: 100,
+        limit: 10,
+    };
     assert!(
-        !tree.find(&filter).is_empty(),
+        !tree.find_windowed(&filter, window).is_empty(),
         "With Offset/Limit: should return some ranges"
     );
-    group.bench_function("With Offset/Limit", |b| b.iter(|| tree.find(&filter)));
+    group.bench_function("With Offset/Limit", |b| {
+        b.iter(|| tree.find_windowed(&filter, window))
+    });
 }
 
 fn benchmark_find(c: &mut Criterion) {

--- a/src/redisearch_rs/numeric_range_tree/src/arena.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/arena.rs
@@ -126,7 +126,7 @@ impl NodeArena {
     ///
     /// Yields `(NodeIndex, &NumericRangeNode)` pairs.
     #[cfg_attr(
-        not(all(feature = "unittest", not(miri))),
+        not(all(feature = "unittest", debug_assertions, not(miri))),
         expect(dead_code, reason = "used by invariant checks in unittest feature")
     )]
     pub fn iter(&self) -> impl Iterator<Item = (NodeIndex, &NumericRangeNode)> {

--- a/src/redisearch_rs/numeric_range_tree/src/lib.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/lib.rs
@@ -75,6 +75,7 @@ mod node;
 mod range;
 mod tree;
 mod unique_id;
+mod window;
 
 pub use arena::NodeIndex;
 pub use index::{NumericIndex, NumericIndexReader, RawNumericIndexReader};
@@ -87,6 +88,7 @@ pub use tree::{
     TrimEmptyLeavesResult,
 };
 pub use unique_id::TreeUniqueId;
+pub use window::RangeWindow;
 
 #[cfg(feature = "test-utils")]
 pub mod test_utils;

--- a/src/redisearch_rs/numeric_range_tree/src/tree/find.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/find.rs
@@ -17,6 +17,7 @@ use inverted_index::NumericFilter;
 
 use super::NumericRangeTree;
 use crate::arena::{NodeArena, NodeIndex};
+use crate::window::RangeWindow;
 use crate::{NumericRange, NumericRangeNode};
 
 impl NumericRangeTree {
@@ -24,7 +25,7 @@ impl NumericRangeTree {
     ///
     /// Returns a vector of references to ranges that overlap with the filter's
     /// min/max bounds. The ranges are returned in order based on the filter's
-    /// ascending/descending preference.
+    /// ascending/descending preference, and are pairwise disjoint.
     ///
     /// # Optimization Goal
     ///
@@ -33,21 +34,28 @@ impl NumericRangeTree {
     /// is completely contained within the filter bounds, we return that single
     /// range instead of descending to its children—this is why internal nodes
     /// retain their ranges up to `max_depth_range`.
-    ///
-    /// # Offset Handling
-    ///
-    /// The `filter.offset` and `filter.limit` parameters enable pagination.
-    /// We track the running total of documents and skip ranges until we've
-    /// passed the offset. See `recursive_find_ranges` for the special handling
-    /// of the first overlapping leaf.
     pub fn find<'a>(&'a self, filter: &NumericFilter) -> Vec<&'a NumericRange> {
-        let mut ranges = Vec::with_capacity(8);
-        let mut total = 0usize;
+        self.find_windowed(filter, RangeWindow::UNBOUNDED)
+    }
 
-        Self::recursive_find_ranges(&mut ranges, &self.nodes, self.root, filter, &mut total);
+    /// Like [`find`](Self::find), but returning only the ranges that cover
+    /// `window`.
+    ///
+    /// Read [`RangeWindow`] before reaching for this: the window is measured in
+    /// whole ranges, so it holds only for a caller that walks the stream
+    /// end-to-end.
+    pub fn find_windowed<'a>(
+        &'a self,
+        filter: &NumericFilter,
+        window: RangeWindow,
+    ) -> Vec<&'a NumericRange> {
+        let mut ranges = Vec::with_capacity(8);
+        let mut cursor = WindowCursor::new(window);
+
+        Self::recursive_find_ranges(&mut ranges, &self.nodes, self.root, filter, &mut cursor);
 
         #[cfg(all(feature = "unittest", not(miri)))]
-        Self::check_find_invariants(&ranges, filter, total);
+        Self::check_find_invariants(&ranges, filter, window, cursor.total);
 
         ranges
     }
@@ -73,10 +81,9 @@ impl NumericRangeTree {
         nodes: &'a NodeArena,
         node_idx: NodeIndex,
         filter: &NumericFilter,
-        total: &mut usize,
+        cursor: &mut WindowCursor,
     ) {
-        // Check if we've reached the limit
-        if filter.limit > 0 && *total >= filter.offset.saturating_add(filter.limit) {
+        if cursor.is_covered() {
             return;
         }
 
@@ -95,8 +102,7 @@ impl NumericRangeTree {
 
             // If the range is completely contained in the search bounds, add it
             if contained {
-                *total += num_docs as usize;
-                if *total > filter.offset {
+                if cursor.admit(num_docs as usize) {
                     ranges.push(range);
                 }
                 return;
@@ -118,7 +124,7 @@ impl NumericRangeTree {
                             nodes,
                             internal.left_index(),
                             filter,
-                            total,
+                            cursor,
                         );
                     }
                     if max >= internal.value {
@@ -127,7 +133,7 @@ impl NumericRangeTree {
                             nodes,
                             internal.right_index(),
                             filter,
-                            total,
+                            cursor,
                         );
                     }
                 } else {
@@ -138,7 +144,7 @@ impl NumericRangeTree {
                             nodes,
                             internal.right_index(),
                             filter,
-                            total,
+                            cursor,
                         );
                     }
                     if min <= internal.value {
@@ -147,35 +153,68 @@ impl NumericRangeTree {
                             nodes,
                             internal.left_index(),
                             filter,
-                            total,
+                            cursor,
                         );
                     }
                 }
             }
             NumericRangeNode::Leaf(leaf) => {
-                let num_docs = leaf.range.num_docs();
-                *total += if *total == 0 && filter.offset == 0 {
-                    // This is the first range of the result set.
-                    // It the range _overlaps_ with the filter range,
-                    // but isn't contained within it, it might contain documents
-                    // that sit outside the filter range.
-                    // For example, if the filter range is [10, 20] and the leaf range is [5, 11],
-                    // the leaf range contains documents that are outside the filter range.
-                    //
-                    // If we sum its `num_docs` to the running total, we may
-                    // end up overcounting the number of documents that match
-                    // the filter range, thus returning less documents than expected.
-                    // We choose the opposite strategy: we potentially return _more_ documents
-                    // than necessary, leaving it to the result set iterator to precisely filter
-                    // out the ones that sit outside the filter range.
-                    1
-                } else {
-                    num_docs as usize
-                };
-                if *total > filter.offset {
+                if cursor.admit_partial(leaf.range.num_docs() as usize) {
                     ranges.push(&leaf.range);
                 }
             }
         }
+    }
+}
+
+/// Running position of a windowed walk over the tree's value-ordered stream.
+///
+/// Tracks how many documents the walk has passed so far, in traversal order,
+/// and decides from that whether a range falls inside [`RangeWindow`]. An
+/// unbounded window keeps every range and counts nothing.
+struct WindowCursor {
+    window: RangeWindow,
+    /// Documents passed so far, the unit the window's bounds are measured in.
+    total: usize,
+}
+
+impl WindowCursor {
+    const fn new(window: RangeWindow) -> Self {
+        Self { window, total: 0 }
+    }
+
+    /// Whether the walk has reached the end of the window and can stop.
+    const fn is_covered(&self) -> bool {
+        self.window.limit > 0 && self.total >= self.window.offset.saturating_add(self.window.limit)
+    }
+
+    /// Account a range lying entirely within the filter bounds, reporting
+    /// whether it sits past `offset` and must be kept.
+    const fn admit(&mut self, num_docs: usize) -> bool {
+        if !self.window.is_bounded() {
+            return true;
+        }
+        self.total += num_docs;
+        self.total > self.window.offset
+    }
+
+    /// Account a leaf that overlaps the filter bounds without being contained in
+    /// them, reporting whether it must be kept.
+    ///
+    /// Such a leaf holds an unknown mix of in-bounds and out-of-bounds
+    /// documents. Counting all of them would overstate how much of the window is
+    /// covered and cut the result short, so the leaf opening the window counts as
+    /// a single document: the walk errs toward returning more ranges than needed
+    /// and leaves exact filtering to the reader.
+    const fn admit_partial(&mut self, num_docs: usize) -> bool {
+        if !self.window.is_bounded() {
+            return true;
+        }
+        self.total += if self.total == 0 && self.window.offset == 0 {
+            1
+        } else {
+            num_docs
+        };
+        self.total > self.window.offset
     }
 }

--- a/src/redisearch_rs/numeric_range_tree/src/tree/find.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/find.rs
@@ -51,7 +51,7 @@ impl NumericRangeTree {
 
         Self::recursive_find_ranges(&mut ranges, &self.nodes, self.root, filter, &mut cursor);
 
-        #[cfg(all(feature = "unittest", not(miri)))]
+        #[cfg(all(feature = "unittest", debug_assertions, not(miri)))]
         self.check_find_invariants(&ranges, filter, window);
 
         ranges

--- a/src/redisearch_rs/numeric_range_tree/src/tree/find.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/find.rs
@@ -52,7 +52,7 @@ impl NumericRangeTree {
         Self::recursive_find_ranges(&mut ranges, &self.nodes, self.root, filter, &mut cursor);
 
         #[cfg(all(feature = "unittest", not(miri)))]
-        Self::check_find_invariants(&ranges, filter, window, cursor.total);
+        self.check_find_invariants(&ranges, filter, window);
 
         ranges
     }

--- a/src/redisearch_rs/numeric_range_tree/src/tree/find.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/find.rs
@@ -38,12 +38,9 @@ impl NumericRangeTree {
         self.find_windowed(filter, RangeWindow::UNBOUNDED)
     }
 
-    /// Like [`find`](Self::find), but returning only the ranges that cover
-    /// `window`.
+    /// Like [`find`](Self::find), but returns only the ranges covering `window`.
     ///
-    /// Read [`RangeWindow`] before reaching for this: the window is measured in
-    /// whole ranges, so it holds only for a caller that walks the stream
-    /// end-to-end.
+    /// Ranges are returned whole, so the result overshoots the window's bounds.
     pub fn find_windowed<'a>(
         &'a self,
         filter: &NumericFilter,
@@ -159,7 +156,17 @@ impl NumericRangeTree {
                 }
             }
             NumericRangeNode::Leaf(leaf) => {
-                if cursor.admit_partial(leaf.range.num_docs() as usize) {
+                // This range only overlaps the filter, so an unknown number of its
+                // documents sit outside it. Counting them all could cover `limit` on
+                // the very first range, ending the traversal before a single match is
+                // collected. `1` — the smallest count that still admits the range —
+                // errs the other way, returning too many ranges rather than too few.
+                let num_docs = if cursor.at_window_start() {
+                    1
+                } else {
+                    leaf.range.num_docs() as usize
+                };
+                if cursor.admit(num_docs) {
                     ranges.push(&leaf.range);
                 }
             }
@@ -167,14 +174,13 @@ impl NumericRangeTree {
     }
 }
 
-/// Running position of a windowed walk over the tree's value-ordered stream.
+/// Position of a traversal within its [`RangeWindow`].
 ///
-/// Tracks how many documents the walk has passed so far, in traversal order,
-/// and decides from that whether a range falls inside [`RangeWindow`]. An
-/// unbounded window keeps every range and counts nothing.
+/// Counts the documents passed so far and decides from that which ranges to
+/// keep. An unbounded window keeps every range and counts nothing.
 struct WindowCursor {
     window: RangeWindow,
-    /// Documents passed so far, the unit the window's bounds are measured in.
+    /// Documents passed so far.
     total: usize,
 }
 
@@ -183,38 +189,23 @@ impl WindowCursor {
         Self { window, total: 0 }
     }
 
-    /// Whether the walk has reached the end of the window and can stop.
+    /// Whether the end of the window is reached and the traversal can stop.
     const fn is_covered(&self) -> bool {
         self.window.limit > 0 && self.total >= self.window.offset.saturating_add(self.window.limit)
     }
 
-    /// Account a range lying entirely within the filter bounds, reporting
-    /// whether it sits past `offset` and must be kept.
+    /// Whether the next range counted will be the first one kept.
+    const fn at_window_start(&self) -> bool {
+        self.total == 0 && self.window.offset == 0
+    }
+
+    /// Count a range's documents, returning whether the range sits past `offset`
+    /// and must be kept.
     const fn admit(&mut self, num_docs: usize) -> bool {
         if !self.window.is_bounded() {
             return true;
         }
         self.total += num_docs;
-        self.total > self.window.offset
-    }
-
-    /// Account a leaf that overlaps the filter bounds without being contained in
-    /// them, reporting whether it must be kept.
-    ///
-    /// Such a leaf holds an unknown mix of in-bounds and out-of-bounds
-    /// documents. Counting all of them would overstate how much of the window is
-    /// covered and cut the result short, so the leaf opening the window counts as
-    /// a single document: the walk errs toward returning more ranges than needed
-    /// and leaves exact filtering to the reader.
-    const fn admit_partial(&mut self, num_docs: usize) -> bool {
-        if !self.window.is_bounded() {
-            return true;
-        }
-        self.total += if self.total == 0 && self.window.offset == 0 {
-            1
-        } else {
-            num_docs
-        };
         self.total > self.window.offset
     }
 }

--- a/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/gc.rs
@@ -184,7 +184,7 @@ impl NumericRangeTree {
             self.stats.inverted_indexes_size += info.bytes_allocated - info.bytes_freed;
         }
 
-        #[cfg(all(feature = "unittest", not(miri)))]
+        #[cfg(all(feature = "unittest", debug_assertions, not(miri)))]
         self.check_tree_invariants();
 
         Some(SingleNodeGcResult {
@@ -262,12 +262,12 @@ impl NumericRangeTree {
     /// Removes leaf nodes that have no documents and prunes the tree structure
     /// accordingly. Returns information about what changed.
     pub fn trim_empty_leaves(&mut self) -> TrimEmptyLeavesResult {
-        #[cfg(all(feature = "unittest", not(miri)))]
+        #[cfg(all(feature = "unittest", debug_assertions, not(miri)))]
         let (stats_before, revision_id_before) = (self.stats, self.revision_id);
 
         let result = self._trim_empty_leaves();
 
-        #[cfg(all(feature = "unittest", not(miri)))]
+        #[cfg(all(feature = "unittest", debug_assertions, not(miri)))]
         {
             self.check_trim_delta_invariants(stats_before, revision_id_before, &result);
             self.check_tree_invariants();

--- a/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/insert.rs
@@ -65,7 +65,7 @@ impl NumericRangeTree {
         is_multivalued: bool,
         max_depth_range: usize,
     ) -> AddResult {
-        #[cfg(all(feature = "unittest", not(miri)))]
+        #[cfg(all(feature = "unittest", debug_assertions, not(miri)))]
         let (stats_before, revision_id_before, total_records_before) =
             (self.stats, self.revision_id, self.total_records());
 
@@ -77,7 +77,7 @@ impl NumericRangeTree {
             max_depth_range,
         );
 
-        #[cfg(all(feature = "unittest", not(miri)))]
+        #[cfg(all(feature = "unittest", debug_assertions, not(miri)))]
         {
             self.check_delta_invariants(
                 stats_before,

--- a/src/redisearch_rs/numeric_range_tree/src/tree/invariants.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/invariants.rs
@@ -232,8 +232,8 @@ impl NumericRangeTree {
     /// 3. **Limit sufficiency** — when the window has a `limit` and the tree
     ///    contained enough matching documents (`total >= offset + limit`), the
     ///    returned ranges must collectively hold at least `limit` documents.
-    ///    Both sides of this are measured in the window's own approximate
-    ///    document count, so it is the weakest of the three.
+    ///    Both counts are rounded up to whole ranges, so this is the weakest of
+    ///    the three.
     pub(crate) fn check_find_invariants(
         ranges: &[&NumericRange],
         filter: &NumericFilter,

--- a/src/redisearch_rs/numeric_range_tree/src/tree/invariants.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/invariants.rs
@@ -20,6 +20,7 @@ use super::{AddResult, CheckedCount, NumericRangeTree, TreeStats, TrimEmptyLeave
 use crate::NumericRange;
 use crate::NumericRangeNode;
 use crate::arena::NodeIndex;
+use crate::window::RangeWindow;
 
 impl NumericRangeTree {
     /// Sum `num_entries()` across every node that has a range.
@@ -228,12 +229,15 @@ impl NumericRangeTree {
     /// 2. **Ordering** — consecutive ranges are strictly ordered (ascending or
     ///    descending based on the filter's `ascending` flag). This transitively
     ///    implies pairwise non-overlap.
-    /// 3. **Limit sufficiency** — when `limit > 0` and the tree contained
-    ///    enough matching documents (`total >= offset + limit`), the returned
-    ///    ranges must collectively hold at least `limit` documents.
+    /// 3. **Limit sufficiency** — when the window has a `limit` and the tree
+    ///    contained enough matching documents (`total >= offset + limit`), the
+    ///    returned ranges must collectively hold at least `limit` documents.
+    ///    Both sides of this are measured in the window's own approximate
+    ///    document count, so it is the weakest of the three.
     pub(crate) fn check_find_invariants(
         ranges: &[&NumericRange],
         filter: &NumericFilter,
+        window: RangeWindow,
         total: usize,
     ) {
         // Every returned range must overlap the filter.
@@ -276,8 +280,8 @@ impl NumericRangeTree {
         // Limit sufficiency: if limit > 0 and we had enough matching documents
         // (total >= offset + limit), the returned ranges must contain at least
         // `limit` documents whose values fall within the filter bounds.
-        if filter.limit > 0 {
-            let target = filter.offset.saturating_add(filter.limit);
+        if window.limit > 0 {
+            let target = window.offset.saturating_add(window.limit);
             if total >= target {
                 let mut docs: usize = 0;
                 for range in ranges {
@@ -297,11 +301,11 @@ impl NumericRangeTree {
                     }
                 }
                 assert!(
-                    docs >= filter.limit,
+                    docs >= window.limit,
                     "find invariant violated: limit={} but returned ranges contain only \
                      {docs} in-bounds docs (total={total}, offset={})",
-                    filter.limit,
-                    filter.offset,
+                    window.limit,
+                    window.offset,
                 );
             }
         }

--- a/src/redisearch_rs/numeric_range_tree/src/tree/invariants.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/invariants.rs
@@ -13,8 +13,7 @@
 //! after every mutation (`add`, `trim_empty_leaves`) to catch structural
 //! violations early.
 
-use index_result::RSIndexResult;
-use inverted_index::{IndexReader, NumericFilter};
+use inverted_index::NumericFilter;
 
 use super::{AddResult, CheckedCount, NumericRangeTree, TreeStats, TrimEmptyLeavesResult};
 use crate::NumericRange;
@@ -229,16 +228,14 @@ impl NumericRangeTree {
     /// 2. **Ordering** — consecutive ranges are strictly ordered (ascending or
     ///    descending based on the filter's `ascending` flag). This transitively
     ///    implies pairwise non-overlap.
-    /// 3. **Limit sufficiency** — when the window has a `limit` and the tree
-    ///    contained enough matching documents (`total >= offset + limit`), the
-    ///    returned ranges must collectively hold at least `limit` documents.
-    ///    Both counts are rounded up to whole ranges, so this is the weakest of
-    ///    the three.
+    /// 3. **Windowing** — a window only trims the traversal, so its result is a
+    ///    contiguous stretch of the ranges the same filter returns unbounded,
+    ///    and only a non-zero `limit` may cut the tail short.
     pub(crate) fn check_find_invariants(
+        &self,
         ranges: &[&NumericRange],
         filter: &NumericFilter,
         window: RangeWindow,
-        total: usize,
     ) {
         // Every returned range must overlap the filter.
         for (i, range) in ranges.iter().enumerate() {
@@ -277,38 +274,50 @@ impl NumericRangeTree {
             }
         }
 
-        // Limit sufficiency: if limit > 0 and we had enough matching documents
-        // (total >= offset + limit), the returned ranges must contain at least
-        // `limit` documents whose values fall within the filter bounds.
-        if window.limit > 0 {
-            let target = window.offset.saturating_add(window.limit);
-            if total >= target {
-                let mut docs: usize = 0;
-                for range in ranges {
-                    if range.contained_in(filter.min, filter.max) {
-                        docs += range.num_docs() as usize;
-                    } else {
-                        let mut reader = range.reader();
-                        let mut result = RSIndexResult::build_numeric(0.0).build();
-                        while reader.next_record(&mut result).unwrap_or(false) {
-                            // SAFETY: The entries in a NumericRange always contain
-                            // numeric data—they are created via `RSIndexResult::numeric`.
-                            let value = unsafe { result.as_numeric_unchecked() };
-                            if filter.value_in_range(value) {
-                                docs += 1;
-                            }
-                        }
-                    }
-                }
-                assert!(
-                    docs >= window.limit,
-                    "find invariant violated: limit={} but returned ranges contain only \
-                     {docs} in-bounds docs (total={total}, offset={})",
-                    window.limit,
-                    window.offset,
-                );
-            }
+        // Windowing. Both traversals visit the same ranges in the same order, so
+        // a window can only drop a prefix (the ranges before `offset`) and a
+        // suffix (everything past `limit`) of the unbounded result.
+        if !window.is_bounded() {
+            return;
         }
+        let all = self.find(filter);
+        let Some(first) = ranges.first() else {
+            return;
+        };
+        let start = all
+            .iter()
+            .position(|range| std::ptr::eq(*range, *first))
+            .unwrap_or_else(|| {
+                panic!(
+                    "find invariant violated: windowed range [{}, {}] is absent from the \
+                     unbounded result",
+                    first.min_val(),
+                    first.max_val(),
+                )
+            });
+        let end = start + ranges.len();
+        assert!(
+            all.get(start..end).is_some_and(|slice| {
+                slice
+                    .iter()
+                    .zip(ranges)
+                    .all(|(all, windowed)| std::ptr::eq(*all, *windowed))
+            }),
+            "find invariant violated: the {} windowed ranges are not a contiguous stretch of \
+             the {} unbounded ones (offset={}, limit={})",
+            ranges.len(),
+            all.len(),
+            window.offset,
+            window.limit,
+        );
+
+        // Without a limit the traversal never stops early, so nothing may be
+        // missing from the tail.
+        assert!(
+            window.limit > 0 || end == all.len(),
+            "find invariant violated: an offset-only window dropped {} range(s) from the tail",
+            all.len() - end,
+        );
     }
 
     /// Verify all structural invariants of the tree.

--- a/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
@@ -20,7 +20,7 @@
 mod find;
 mod gc;
 mod insert;
-#[cfg(all(feature = "unittest", not(miri)))]
+#[cfg(all(feature = "unittest", debug_assertions, not(miri)))]
 mod invariants;
 mod util;
 

--- a/src/redisearch_rs/numeric_range_tree/src/window.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/window.rs
@@ -25,9 +25,6 @@ use inverted_index::NumericFilter;
 /// handed. Anything else — a window taken from a user-supplied `LIMIT`, say —
 /// re-serves documents from the range straddling `offset` and yields fewer than
 /// `limit` fresh ones.
-///
-/// TODO: MOD-13920 — fold windowing into the callers that paginate, so
-/// [`find`](crate::NumericRangeTree::find) answers only value queries.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct RangeWindow {
     /// Documents to skip before the first returned range.
@@ -47,6 +44,7 @@ impl RangeWindow {
     ///
     /// The single bridge from the window fields on [`NumericFilter`]; it goes
     /// away with them, leaving callers to pass their own [`RangeWindow`].
+    #[expect(deprecated, reason = "this is the bridge that retires them")]
     pub const fn from_filter(filter: &NumericFilter) -> Self {
         Self {
             offset: filter.offset,

--- a/src/redisearch_rs/numeric_range_tree/src/window.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/window.rs
@@ -7,44 +7,30 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Windowing over the value-ordered range stream of a numeric range tree.
+//! Windowing over the ranges a numeric range tree returns.
 
 use inverted_index::NumericFilter;
 
-/// A slice of a tree's value-ordered document stream, for callers that consume
-/// the stream one window at a time.
-///
-/// Both bounds are counted in documents, in the traversal order fixed by the
-/// filter's `ascending` flag, and both are approximate: the tree can only skip
-/// and stop at range boundaries, and it counts a range's whole document set —
-/// including documents outside the filter bounds and documents deleted but not
-/// yet collected.
-///
-/// A window is therefore only usable by a caller that walks the stream
-/// end-to-end, advancing `offset` by the document count of the ranges it was
-/// handed. Anything else — a window taken from a user-supplied `LIMIT`, say —
-/// re-serves documents from the range straddling `offset` and yields fewer than
-/// `limit` fresh ones.
+/// A slice of the ranges a tree returns, measured in documents.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct RangeWindow {
     /// Documents to skip before the first returned range.
     pub offset: usize,
-    /// Documents to cover before the walk stops. `0` means "no bound".
+    /// Documents to cover before stopping. `0` means no bound.
     pub limit: usize,
 }
 
 impl RangeWindow {
-    /// The whole stream: skip nothing, stop at nothing.
+    /// Every range: skip nothing, stop at nothing.
     pub const UNBOUNDED: Self = Self {
         offset: 0,
         limit: 0,
     };
 
-    /// Read the window a filter carries.
+    /// Take the window from a filter's deprecated `offset`/`limit` fields.
     ///
-    /// The single bridge from the window fields on [`NumericFilter`]; it goes
-    /// away with them, leaving callers to pass their own [`RangeWindow`].
-    #[expect(deprecated, reason = "this is the bridge that retires them")]
+    /// Goes away with those fields; new callers build their own window.
+    #[expect(deprecated, reason = "reads the fields it replaces")]
     pub const fn from_filter(filter: &NumericFilter) -> Self {
         Self {
             offset: filter.offset,
@@ -52,7 +38,7 @@ impl RangeWindow {
         }
     }
 
-    /// Whether this window restricts the stream at all.
+    /// Whether this window leaves out any range.
     pub const fn is_bounded(&self) -> bool {
         self.offset > 0 || self.limit > 0
     }

--- a/src/redisearch_rs/numeric_range_tree/src/window.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/window.rs
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Windowing over the value-ordered range stream of a numeric range tree.
+
+use inverted_index::NumericFilter;
+
+/// A slice of a tree's value-ordered document stream, for callers that consume
+/// the stream one window at a time.
+///
+/// Both bounds are counted in documents, in the traversal order fixed by the
+/// filter's `ascending` flag, and both are approximate: the tree can only skip
+/// and stop at range boundaries, and it counts a range's whole document set —
+/// including documents outside the filter bounds and documents deleted but not
+/// yet collected.
+///
+/// A window is therefore only usable by a caller that walks the stream
+/// end-to-end, advancing `offset` by the document count of the ranges it was
+/// handed. Anything else — a window taken from a user-supplied `LIMIT`, say —
+/// re-serves documents from the range straddling `offset` and yields fewer than
+/// `limit` fresh ones.
+///
+/// TODO: MOD-13920 — fold windowing into the callers that paginate, so
+/// [`find`](crate::NumericRangeTree::find) answers only value queries.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RangeWindow {
+    /// Documents to skip before the first returned range.
+    pub offset: usize,
+    /// Documents to cover before the walk stops. `0` means "no bound".
+    pub limit: usize,
+}
+
+impl RangeWindow {
+    /// The whole stream: skip nothing, stop at nothing.
+    pub const UNBOUNDED: Self = Self {
+        offset: 0,
+        limit: 0,
+    };
+
+    /// Read the window a filter carries.
+    ///
+    /// The single bridge from the window fields on [`NumericFilter`]; it goes
+    /// away with them, leaving callers to pass their own [`RangeWindow`].
+    pub const fn from_filter(filter: &NumericFilter) -> Self {
+        Self {
+            offset: filter.offset,
+            limit: filter.limit,
+        }
+    }
+
+    /// Whether this window restricts the stream at all.
+    pub const fn is_bounded(&self) -> bool {
+        self.offset > 0 || self.limit > 0
+    }
+}

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/find.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/find.rs
@@ -210,6 +210,49 @@ fn test_find_unbounded_window_matches_find() {
     }
 }
 
+/// A window whose `limit` the tree cannot fill still returns every matching
+/// range: a window may overshoot, but it may not drop a match.
+#[test]
+fn test_find_windowed_with_fewer_matches_than_limit() {
+    // Two value clusters, each with enough cardinality to split the root, and a
+    // gap between them wide enough that the split value lands inside it.
+    let mut tree = NumericRangeTree::new(false);
+    let mut doc: u64 = 1;
+    for i in 0..500u64 {
+        tree.add(doc, 5.0 + (i % 50) as f64 * 0.08, false, false, 0);
+        doc += 1;
+        tree.add(doc, 21.0 + (i % 50) as f64 * 0.08, false, false, 0);
+        doc += 1;
+    }
+    assert_eq!(
+        tree.num_leaves(),
+        2,
+        "fixture must split into exactly the two cluster leaves"
+    );
+
+    // The filter slices through both clusters, so neither leaf is contained in
+    // it: the traversal cannot know how many of their documents match without
+    // reading them. Fewer documents match than the limit asks for.
+    let filter = make_filter_full(8.0, 22.0, true);
+    let windowed = tree.find_windowed(
+        &filter,
+        RangeWindow {
+            offset: 0,
+            limit: 300,
+        },
+    );
+
+    let all = tree.find(&filter);
+    assert_eq!(
+        windowed.len(),
+        all.len(),
+        "a window the tree cannot fill must not restrict the result"
+    );
+    for (windowed, all) in windowed.iter().zip(&all) {
+        assert!(std::ptr::eq(*windowed, *all));
+    }
+}
+
 #[test]
 fn test_find_on_empty_tree() {
     let tree = NumericRangeTree::new(false);

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/find.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/find.rs
@@ -253,6 +253,76 @@ fn test_find_windowed_with_fewer_matches_than_limit() {
     }
 }
 
+/// Consecutive windows must tile the unbounded result: advancing `offset` by
+/// the consumed ranges' whole-`num_docs` sum yields the next ranges in order,
+/// with no gap, no overlap, and nothing left over.
+///
+/// This is the contract the optimizer's expand-and-retry loop relies on
+/// (`OPT_Rewind` advances the filter's offset by the drained iterator's
+/// estimate; `NumericScoreSource::expand_window` does the same with its
+/// `RangeWindow`). It is also where the first window's head-leaf-counted-as-1
+/// rule and the full-count offset advance must agree with each other.
+#[rstest]
+#[cfg_attr(miri, ignore = "Too slow to run under miri")]
+fn test_find_windowed_windows_tile(#[values(true, false)] ascending: bool) {
+    let tree = build_large_tree(false);
+    // Fractional bounds so both boundary leaves overlap the filter without
+    // being contained in it, exercising the head-leaf special case.
+    let filter = make_filter_full(2.5, 4321.5, ascending);
+
+    let all = tree.find(&filter);
+    assert!(all.len() > 3, "fixture must produce several ranges");
+
+    // Walk the tree window by window, advancing `offset` the way the
+    // consumers do: by the whole-range document count of what was consumed.
+    let mut window = RangeWindow {
+        offset: 0,
+        limit: 100,
+    };
+    let mut tiled = Vec::new();
+    loop {
+        let ranges = tree.find_windowed(&filter, window);
+        if ranges.is_empty() {
+            break;
+        }
+        window.offset += ranges.iter().map(|r| r.num_docs() as usize).sum::<usize>();
+        tiled.extend(ranges);
+        assert!(
+            tiled.len() <= all.len(),
+            "windows returned more ranges than the unbounded find: overlap or \
+             non-termination (offset={}, limit={})",
+            window.offset,
+            window.limit,
+        );
+    }
+
+    // Both sequences borrow ranges from the same tree, so correct tiling means
+    // they hold literally the same ranges in the same order — which pointer
+    // identity states directly, proving completeness, order, and disjointedness
+    // at once. Comparing bounds instead would assume `(min_val, max_val)`
+    // uniquely identifies a range, and the tree does not promise that: with
+    // `max_depth_range > 0`, an internal node retains a range indexing the
+    // same documents as its subtree, whose bounds can coincide with a child
+    // leaf's. The containment shortcut in the traversal picks between exactly
+    // those two, so a bounds comparison could miss a divergence there.
+    assert_eq!(
+        tiled.len(),
+        all.len(),
+        "windows must cover every range exactly once"
+    );
+    for (i, (tiled, all)) in tiled.iter().zip(all.iter()).enumerate() {
+        assert!(
+            std::ptr::eq(*tiled, *all),
+            "window tiling diverged from the unbounded result at position {i}: \
+             got [{}, {}], expected [{}, {}]",
+            tiled.min_val(),
+            tiled.max_val(),
+            all.min_val(),
+            all.max_val(),
+        );
+    }
+}
+
 #[test]
 fn test_find_on_empty_tree() {
     let tree = NumericRangeTree::new(false);

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/find.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/find.rs
@@ -10,23 +10,15 @@
 //! Tests for `NumericRangeTree::find` — range query functionality.
 
 use inverted_index::NumericFilter;
-use numeric_range_tree::NumericRangeTree;
+use numeric_range_tree::{NumericRangeTree, RangeWindow};
 use rstest::rstest;
 
-/// Build a filter with full control over ascending, offset and limit.
-fn make_filter_full(
-    min: f64,
-    max: f64,
-    ascending: bool,
-    offset: usize,
-    limit: usize,
-) -> NumericFilter {
+/// Build a filter with full control over the bounds and traversal order.
+fn make_filter_full(min: f64, max: f64, ascending: bool) -> NumericFilter {
     NumericFilter {
         min,
         max,
         ascending,
-        offset,
-        limit,
         ..Default::default()
     }
 }
@@ -164,9 +156,16 @@ fn test_find_with_offset_and_limit() {
         ..Default::default()
     };
     let all_ranges = tree.find(&filter_all);
+    let filter = make_filter_full(0.0, 5000.0, true);
+
     // Now use a limit.
-    let filter_limited = make_filter_full(0.0, 5000.0, true, 0, 10);
-    let limited_ranges = tree.find(&filter_limited);
+    let limited_ranges = tree.find_windowed(
+        &filter,
+        RangeWindow {
+            offset: 0,
+            limit: 10,
+        },
+    );
     // Limited should return fewer or equal ranges.
     assert!(
         limited_ranges.len() <= all_ranges.len(),
@@ -176,14 +175,39 @@ fn test_find_with_offset_and_limit() {
     );
 
     // With offset, we should also get fewer or equal ranges.
-    let filter_offset = make_filter_full(0.0, 5000.0, true, 100, 10);
-    let offset_ranges = tree.find(&filter_offset);
+    let offset_ranges = tree.find_windowed(
+        &filter,
+        RangeWindow {
+            offset: 100,
+            limit: 10,
+        },
+    );
     assert!(
         offset_ranges.len() <= all_ranges.len(),
         "offset find ({}) should return <= all ranges ({})",
         offset_ranges.len(),
         all_ranges.len()
     );
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "Too slow to run under miri")]
+fn test_find_unbounded_window_matches_find() {
+    let tree = build_large_tree(false);
+    let filter = make_filter_full(0.0, 5000.0, true);
+
+    let windowed = tree.find_windowed(&filter, RangeWindow::UNBOUNDED);
+    let all = tree.find(&filter);
+
+    assert_eq!(
+        windowed.len(),
+        all.len(),
+        "an unbounded window must restrict nothing"
+    );
+    for (windowed, all) in windowed.iter().zip(all.iter()) {
+        assert_eq!(windowed.min_val(), all.min_val());
+        assert_eq!(windowed.max_val(), all.max_val());
+    }
 }
 
 #[test]

--- a/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
+++ b/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
@@ -20,13 +20,13 @@ use std::collections::HashSet;
 
 use index_result::RSIndexResult;
 use inverted_index::{FilterNumericReader, IndexReader as _, NumericFilter};
-use numeric_range_tree::{NumericRange, NumericRangeTree};
+use numeric_range_tree::{NumericRange, NumericRangeTree, RangeWindow};
 use rqe_core::DocId;
 
 use crate::score_batch::NumericScoreBatch;
 
-/// Streams a numeric tree's ranges in value order, windowed by the filter's
-/// `offset`/`limit` and chunked by [`next_n`](Self::next_n).
+/// Streams a numeric tree's ranges in value order, restricted to a
+/// [`RangeWindow`] and chunked by [`next_n`](Self::next_n).
 pub struct NumericRangeIterator<'index> {
     tree: &'index NumericRangeTree,
     /// Ranges matching the current filter window, best-score-first.
@@ -46,27 +46,31 @@ pub struct NumericRangeIterator<'index> {
 }
 
 impl<'index> NumericRangeIterator<'index> {
-    /// Resolve `filter` against `tree` and prepare to stream the matching
-    /// ranges best-score-first.
-    pub fn new(tree: &'index NumericRangeTree, filter: &NumericFilter) -> Self {
+    /// Resolve `filter` against `tree` over `window` and prepare to stream the
+    /// matching ranges best-score-first.
+    pub fn new(
+        tree: &'index NumericRangeTree,
+        filter: &NumericFilter,
+        window: RangeWindow,
+    ) -> Self {
         Self {
             tree,
-            ranges: tree.find(filter),
+            ranges: tree.find_windowed(filter, window),
             pos: 0,
             filter: *filter,
             emitted: HashSet::new(),
         }
     }
 
-    /// Re-resolve the (typically expanded) `filter` and restart from the first
-    /// matching range.
+    /// Re-resolve onto the (typically advanced) `window` and restart from its
+    /// first matching range.
     ///
     /// The emitted-doc set is kept: expansion moves to a strictly worse,
     /// disjoint value window, so a doc already scored on a better value must
     /// stay suppressed. Use [`forget_emitted`](Self::forget_emitted) to reset it
     /// when restarting the whole query.
-    pub fn refind(&mut self, filter: &NumericFilter) {
-        self.ranges = self.tree.find(filter);
+    pub fn refind(&mut self, filter: &NumericFilter, window: RangeWindow) {
+        self.ranges = self.tree.find_windowed(filter, window);
         self.pos = 0;
         self.filter = *filter;
     }
@@ -80,7 +84,7 @@ impl<'index> NumericRangeIterator<'index> {
     /// Sum of `num_docs` across every range in the current window.
     ///
     /// Used as the per-window document estimate, both for the source's
-    /// `num_estimated` and to advance the filter `offset` past a consumed
+    /// `num_estimated` and to advance the window's `offset` past a consumed
     /// window on retry.
     pub fn total_docs_estimate(&self) -> usize {
         self.ranges.iter().map(|r| r.num_docs() as usize).sum()
@@ -169,7 +173,7 @@ fn coalesce_by_doc_id(items: &mut Vec<(DocId, f64)>, ascending: bool) {
 #[cfg(test)]
 mod tests {
     use inverted_index::NumericFilter;
-    use numeric_range_tree::NumericRangeTree;
+    use numeric_range_tree::{NumericRangeTree, RangeWindow};
     use rqe_core::DocId;
     use top_k::ScoreBatch;
 
@@ -190,7 +194,7 @@ mod tests {
         filter: &NumericFilter,
         per_batch: usize,
     ) -> Vec<(DocId, f64)> {
-        let mut it = NumericRangeIterator::new(tree, filter);
+        let mut it = NumericRangeIterator::new(tree, filter, RangeWindow::UNBOUNDED);
         let mut pairs = Vec::new();
         while let Some(mut batch) = it.next_n(per_batch).unwrap() {
             while let Some(pair) = batch.next() {

--- a/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
+++ b/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
@@ -62,7 +62,7 @@ impl<'index> NumericRangeIterator<'index> {
         }
     }
 
-    /// Re-resolve onto the (typically advanced) `window` and restart from its
+    /// Re-resolve onto `window`, usually the next one, and restart from its
     /// first matching range.
     ///
     /// The emitted-doc set is kept: expansion moves to a strictly worse,

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -13,7 +13,7 @@
 
 use index_result::RSIndexResult;
 use inverted_index::NumericFilter;
-use numeric_range_tree::NumericRangeTree;
+use numeric_range_tree::{NumericRangeTree, RangeWindow};
 use rqe_core::DocId;
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::{ExpirationChecker, NoOpChecker, RQEIteratorError};
@@ -80,7 +80,7 @@ const MIN_SUCCESS_RATIO: f64 = 0.01;
 ///
 /// A document's score is its value in the numeric field. The source asks the
 /// [`NumericRangeTree`] for the field's ranges in score order (per `ascending`),
-/// windowed by the filter's `offset`/`limit`, and hands them to the surrounding
+/// restricted to a [`RangeWindow`], and hands them to the surrounding
 /// [`TopKIterator`] as doc-id-ordered batches. Because batches arrive
 /// best-score-first, a full heap (`heap_count >= k`) means no later batch can
 /// improve the result, so [`batch_strategy`](ScoreSource::batch_strategy) can
@@ -90,8 +90,8 @@ const MIN_SUCCESS_RATIO: f64 = 0.01;
 ///
 /// With a filter child, the initial window may be too small to fill the heap.
 /// When a window is drained with `heap_count < k`,
-/// [`batch_strategy`](ScoreSource::batch_strategy) advances `offset`/`limit` to
-/// the next disjoint window and returns [`BatchStrategy::ExpandWindow`]. The
+/// [`batch_strategy`](ScoreSource::batch_strategy) advances the window to the
+/// next disjoint one and returns [`BatchStrategy::ExpandWindow`]. The
 /// windows are disjoint in value space, so the heap keeps accumulating the
 /// global top `k` across them. The unfiltered path reads an unbounded window and
 /// never retries.
@@ -109,12 +109,13 @@ pub struct NumericScoreSource<'index, V: DocValidity = AllValid, E: ExpirationCh
 {
     /// Value-ordered range stream over the numeric index.
     ranges: NumericRangeIterator<'index>,
-    /// Filter driving [`find`](NumericRangeTree::find); its `offset`/`limit`
-    /// window is mutated in place by the retry expansion.
+    /// Value predicate driving [`find_windowed`](NumericRangeTree::find_windowed).
     filter: NumericFilter,
-    /// Initial `offset`/`limit` of `filter`, restored by [`rewind`](ScoreSource::rewind).
-    initial_offset: usize,
-    initial_limit: usize,
+    /// Slice of the value-ordered stream currently being read, advanced in place
+    /// by the retry expansion.
+    window: RangeWindow,
+    /// The window the source started on, restored by [`rewind`](ScoreSource::rewind).
+    initial_window: RangeWindow,
     /// Sort direction (`SORTBY field ASC`/`DESC`), also written into `filter`.
     ascending: bool,
     /// Number of value-ordered ranges materialized per batch. Always `>= 1`.
@@ -150,9 +151,8 @@ pub struct NumericScoreSource<'index, V: DocValidity = AllValid, E: ExpirationCh
 impl<'index> NumericScoreSource<'index> {
     /// Build a source for the unfiltered case (no filter child): an unbounded
     /// value-ordered window with no retry. `filter` is the numeric range over
-    /// the sort field that picks which ranges to read; its `offset`/`limit`
-    /// window is ignored here, since `LIMIT k` is served by the heap plus the
-    /// early `Stop`.
+    /// the sort field that picks which ranges to read; there is no window to
+    /// size, since `LIMIT k` is served by the heap plus the early `Stop`.
     pub fn unfiltered(
         tree: &'index NumericRangeTree,
         filter: NumericFilter,
@@ -170,19 +170,27 @@ impl<'index> NumericScoreSource<'index> {
         range_batch_size: usize,
     ) -> Self {
         filter.ascending = ascending;
-        filter.limit = 0;
-        filter.offset = 0;
-        Self::build(tree, filter, ascending, range_batch_size, 0, 0, false)
+        Self::build(
+            tree,
+            filter,
+            RangeWindow::UNBOUNDED,
+            ascending,
+            range_batch_size,
+            0,
+            0,
+            false,
+        )
     }
 
     /// Build a filtered source with the expand-and-retry path enabled.
     ///
+    /// `window` is the initial slice of the value-ordered stream to read.
     /// `num_docs` is the total document count and `child_estimate` the filter
-    /// child's selectivity estimate; both size the retry windows. `filter.limit`
-    /// is the initial window size.
+    /// child's selectivity estimate; both size the retry windows.
     pub fn filtered(
         tree: &'index NumericRangeTree,
         mut filter: NumericFilter,
+        window: RangeWindow,
         ascending: bool,
         range_batch_size: usize,
         num_docs: usize,
@@ -192,6 +200,7 @@ impl<'index> NumericScoreSource<'index> {
         Self::build(
             tree,
             filter,
+            window,
             ascending,
             range_batch_size,
             num_docs,
@@ -200,22 +209,24 @@ impl<'index> NumericScoreSource<'index> {
         )
     }
 
+    #[expect(clippy::too_many_arguments, reason = "private constructor")]
     fn build(
         tree: &'index NumericRangeTree,
         filter: NumericFilter,
+        window: RangeWindow,
         ascending: bool,
         range_batch_size: usize,
         num_docs: usize,
         child_estimate: usize,
         retry_enabled: bool,
     ) -> Self {
-        let ranges = NumericRangeIterator::new(tree, &filter);
+        let ranges = NumericRangeIterator::new(tree, &filter, window);
         let num_estimated = ranges.total_docs_estimate();
         Self {
             ranges,
-            last_limit_estimate: filter.limit,
-            initial_offset: filter.offset,
-            initial_limit: filter.limit,
+            last_limit_estimate: window.limit,
+            initial_window: window,
+            window,
             filter,
             ascending,
             range_batch_size: range_batch_size.max(1),
@@ -243,8 +254,8 @@ impl<'index, V: DocValidity, E: ExpirationChecker> NumericScoreSource<'index, V,
             expiration: self.expiration,
             ranges: self.ranges,
             filter: self.filter,
-            initial_offset: self.initial_offset,
-            initial_limit: self.initial_limit,
+            window: self.window,
+            initial_window: self.initial_window,
             ascending: self.ascending,
             range_batch_size: self.range_batch_size,
             num_estimated: self.num_estimated,
@@ -271,8 +282,8 @@ impl<'index, V: DocValidity, E: ExpirationChecker> NumericScoreSource<'index, V,
             validity: self.validity,
             ranges: self.ranges,
             filter: self.filter,
-            initial_offset: self.initial_offset,
-            initial_limit: self.initial_limit,
+            window: self.window,
+            initial_window: self.initial_window,
             ascending: self.ascending,
             range_batch_size: self.range_batch_size,
             num_estimated: self.num_estimated,
@@ -316,25 +327,25 @@ impl<'index, V: DocValidity, E: ExpirationChecker> NumericScoreSource<'index, V,
         }
         // A `limit == 0` window is unbounded and has already read every remaining
         // range, so there is nothing left to expand into.
-        if self.filter.limit == 0 {
+        if self.window.limit == 0 {
             return false;
         }
 
-        self.filter.offset += self.ranges.total_docs_estimate();
+        self.window.offset += self.ranges.total_docs_estimate();
         let success_ratio = self.success_ratio(heap_count);
 
         if success_ratio < MIN_SUCCESS_RATIO || self.num_iterations + 1 >= MAX_ITERATIONS {
             // Hits are too sparse, or this is the last allowed retry: drop the
             // window limit so the retry reads every remaining range.
-            self.filter.limit = 0;
+            self.window.limit = 0;
         } else {
             let results_missing = k.saturating_sub(heap_count);
             let estimate = estimate_limit(self.num_docs, self.child_estimate, results_missing);
             self.last_limit_estimate = ((estimate as f64) * success_ratio) as usize;
-            self.filter.limit = self.last_limit_estimate.max(1);
+            self.window.limit = self.last_limit_estimate.max(1);
         }
 
-        self.ranges.refind(&self.filter);
+        self.ranges.refind(&self.filter, self.window);
 
         // The advanced window resolved to no ranges: the tree is exhausted, so
         // report no expansion rather than a spurious empty one.
@@ -394,13 +405,12 @@ impl<'index, V: DocValidity, E: ExpirationChecker> ScoreSource
         // Full reset to the initial window. The expand-and-retry path resolves
         // its own windows inside `expand_window`, so this is only reached for an
         // outer rewind that restarts the whole query.
-        self.filter.offset = self.initial_offset;
-        self.filter.limit = self.initial_limit;
-        self.last_limit_estimate = self.initial_limit;
+        self.window = self.initial_window;
+        self.last_limit_estimate = self.initial_window.limit;
         self.num_iterations = 0;
         self.heap_old_size = 0;
         self.ranges.forget_emitted();
-        self.ranges.refind(&self.filter);
+        self.ranges.refind(&self.filter, self.window);
     }
 
     fn build_result<'r>(&self, doc_id: DocId, score: f64) -> RSIndexResult<'r>

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -111,8 +111,7 @@ pub struct NumericScoreSource<'index, V: DocValidity = AllValid, E: ExpirationCh
     ranges: NumericRangeIterator<'index>,
     /// Value predicate driving [`find_windowed`](NumericRangeTree::find_windowed).
     filter: NumericFilter,
-    /// Slice of the value-ordered stream currently being read, advanced in place
-    /// by the retry expansion.
+    /// Slice of the ranges currently being read; the retry expansion advances it.
     window: RangeWindow,
     /// The window the source started on, restored by [`rewind`](ScoreSource::rewind).
     initial_window: RangeWindow,
@@ -149,10 +148,10 @@ pub struct NumericScoreSource<'index, V: DocValidity = AllValid, E: ExpirationCh
 }
 
 impl<'index> NumericScoreSource<'index> {
-    /// Build a source for the unfiltered case (no filter child): an unbounded
-    /// value-ordered window with no retry. `filter` is the numeric range over
-    /// the sort field that picks which ranges to read; there is no window to
-    /// size, since `LIMIT k` is served by the heap plus the early `Stop`.
+    /// Build a source for the unfiltered case (no filter child): every range, in
+    /// value order, with no retry. `filter` is the numeric range over the sort
+    /// field that picks which ranges to read; there is no window to size, since
+    /// `LIMIT k` is served by the heap plus the early `Stop`.
     pub fn unfiltered(
         tree: &'index NumericRangeTree,
         filter: NumericFilter,

--- a/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/numeric_score_source/tests/integration/source.rs
@@ -15,8 +15,8 @@ use std::{iter, num::NonZeroUsize};
 
 use index_result::RSIndexResult;
 use inverted_index::NumericFilter;
-use numeric_range_tree::NumericRangeTree;
 use numeric_range_tree::test_utils::build_tree;
+use numeric_range_tree::{NumericRangeTree, RangeWindow};
 use numeric_score_source::{
     DocValidity, NumericScoreSource, new_numeric_top_k_filtered, new_numeric_top_k_unfiltered,
 };
@@ -120,6 +120,7 @@ fn run_filtered(
     let source = NumericScoreSource::filtered(
         &tree,
         full_range(),
+        RangeWindow::UNBOUNDED,
         ascending,
         range_batch_size,
         pairs.len(),
@@ -218,9 +219,11 @@ fn filtered_retry_expands_window_to_reach_low_scored_match() {
     let tree = build_tree(20, false, 0);
     assert!(tree.num_leaves() > 1, "fixture must split into many ranges");
 
-    let mut filter = full_range();
-    filter.limit = 1;
-    let source = NumericScoreSource::filtered(&tree, filter, false, 1, 20, 1);
+    let window = RangeWindow {
+        offset: 0,
+        limit: 1,
+    };
+    let source = NumericScoreSource::filtered(&tree, full_range(), window, false, 1, 20, 1);
     let mut it = new_numeric_top_k_filtered(
         source,
         IdList::<true>::new(vec![1u64]),
@@ -258,9 +261,11 @@ fn filtered_retry_reaches_match_past_multivalue_inflated_ranges() {
     );
 
     let num_docs = 5; // docs 1..=4 plus the match doc
-    let mut filter = full_range();
-    filter.limit = 1;
-    let source = NumericScoreSource::filtered(&tree, filter, false, 1, num_docs, 1);
+    let window = RangeWindow {
+        offset: 0,
+        limit: 1,
+    };
+    let source = NumericScoreSource::filtered(&tree, full_range(), window, false, 1, num_docs, 1);
     let mut it = new_numeric_top_k_filtered(
         source,
         IdList::<true>::new(vec![match_id]),
@@ -304,9 +309,11 @@ fn filtered_retry_keeps_high_match_across_windows() {
     let tree = build_tree(20, false, 0);
     assert!(tree.num_leaves() > 1, "fixture must split into many ranges");
 
-    let mut filter = full_range();
-    filter.limit = 1;
-    let source = NumericScoreSource::filtered(&tree, filter, false, 1, 20, 2);
+    let window = RangeWindow {
+        offset: 0,
+        limit: 1,
+    };
+    let source = NumericScoreSource::filtered(&tree, full_range(), window, false, 1, 20, 2);
     let mut it = new_numeric_top_k_filtered(
         source,
         IdList::<true>::new(vec![1u64, 20u64]),
@@ -327,9 +334,11 @@ fn filtered_rewind_after_expansion_repeats_results() {
     let tree = build_tree(20, false, 0);
     let child = vec![1u64, 20u64];
 
-    let mut filter = full_range();
-    filter.limit = 1;
-    let source = NumericScoreSource::filtered(&tree, filter, false, 1, 20, 2);
+    let window = RangeWindow {
+        offset: 0,
+        limit: 1,
+    };
+    let source = NumericScoreSource::filtered(&tree, full_range(), window, false, 1, 20, 2);
     let mut it = new_numeric_top_k_filtered(
         source,
         IdList::<true>::new(child),
@@ -375,8 +384,16 @@ fn filtered_excludes_deleted_docs() {
     let tree = tree_from(&[(1, 1.0), (2, 2.0), (3, 3.0), (4, 100.0), (5, 5.0)]);
     let deleted = DeletedDocs::from_iter([4]);
     let child_ids = vec![2u64, 4u64];
-    let source = NumericScoreSource::filtered(&tree, full_range(), false, 1, 5, child_ids.len())
-        .with_validity(deleted);
+    let source = NumericScoreSource::filtered(
+        &tree,
+        full_range(),
+        RangeWindow::UNBOUNDED,
+        false,
+        1,
+        5,
+        child_ids.len(),
+    )
+    .with_validity(deleted);
     let mut it = new_numeric_top_k_filtered(
         source,
         IdList::<true>::new(child_ids),

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -427,7 +427,7 @@ impl<'index> NumericIteratorVariant<'index> {
             }
         };
 
-        // The optimizer paginates the sort field by mutating the filter's window
+        // The optimizer paginates the sort field by changing the filter's window
         // between rewinds; every other query leaves it unbounded.
         let ranges = tree.find_windowed(filter, RangeWindow::from_filter(filter));
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -26,7 +26,7 @@ use inverted_index::{
     FilterGeoReader, FilterNumericReader, IndexReader, NumericFilter, NumericReader,
     ResumableReader, SuspendableReader,
 };
-use numeric_range_tree::{NumericIndexReader, NumericRangeTree};
+use numeric_range_tree::{NumericIndexReader, NumericRangeTree, RangeWindow};
 use query_types::QueryNodeType;
 use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
@@ -427,7 +427,9 @@ impl<'index> NumericIteratorVariant<'index> {
             }
         };
 
-        let ranges = tree.find(filter);
+        // The optimizer paginates the sort field by mutating the filter's window
+        // between rewinds; every other query leaves it unbounded.
+        let ranges = tree.find_windowed(filter, RangeWindow::from_filter(filter));
 
         let range_tree: Option<&NumericRangeTree> = if filter.field_spec.is_null() {
             None


### PR DESCRIPTION
- New `RangeWindow { offset, limit }` with UNBOUNDED and a from_filter conversion.
  - Objective is to move this offset + limit completely out of `NumericFilter`, I didn't yet because C uses it to set it early before passing to rust. I marked them deprecated for better discoverability.
  - :warning: These deprecations will be removed in MOD-17465.
  - `RangeWindow::from_filter` is the only remaining reader of `NumericFilter::offset/limit`.
- `WindowCursor` uses the range + the count of total documents to know when to stop
- the over-counting logic is kept where is was in `recursive_find_ranges`
- no behaviour change.

<details><summary>Benchmarks</summary>
<p>
Interestingly, I checked benches and it yielded positive results, it's not a critically hot loop as far as I know but interesting to see.

I ran it twice, to double check results:
- forward: I ran benchmarks on master first: less is best
- reverse: I ran benchmarks on master last: more is best

| case | OLD r1 | OLD r2 | NEW r1 | NEW r2 | forward Δ | reverse Δ |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Leaf Only | 18.62 | 18.87 | 17.71 | 17.35 | −4.92% | +8.75% |
| Multiple Leaves | 30.80 | 30.75 | 28.39 | 27.96 | −7.84% | +9.96% |
| Full Tree Scan | 85.84 | 85.16 | 86.13 | 79.40 | +0.34% | +7.26% |
| No Match | 19.49 | 19.82 | 18.66 | 18.16 | −4.26% | +9.09% |
| Contained Internal | 285.07 | 281.80 | 264.58 | 255.09 | −7.19% | +10.47% |
| With Offset/Limit | 24.45 | 24.36 | 23.77 | 23.67 | −2.77% | +2.90% |

</p>
</details> 

#### Impacts for rust numeric top k

- NumericScoreSource owns its window rather than mutating the filter — it's the crate that keeps windowing after the fields die.


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
