### PR TITLE
Run `cargo clippy --fix` on tests for offending crates

### DIFF
--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/fork_gc.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/fork_gc.rs
@@ -89,7 +89,7 @@ mod tests {
     extern "C" fn vec_writer(ctx: *mut c_void, buf: *const c_void, len: size_t) {
         unsafe {
             let v = &mut *(ctx as *mut Vec<u8>);
-            let src = core::slice::from_raw_parts(buf as *const u8, len as usize);
+            let src = core::slice::from_raw_parts(buf as *const u8, len);
             v.extend_from_slice(src);
         }
     }
@@ -97,7 +97,7 @@ mod tests {
     extern "C" fn vec_reader(ctx: *mut c_void, buf: *mut c_void, len: size_t) -> c_int {
         unsafe {
             let v = &mut *(ctx as *mut Vec<u8>);
-            let want = len as usize;
+            let want = len;
             if v.len() < want {
                 return 1;
             }

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
@@ -28,7 +28,7 @@ macro_rules! assert_entries {
     };
 }
 
-unsafe extern "C" fn do_not_free(_val: *mut c_void) {
+const unsafe extern "C" fn do_not_free(_val: *mut c_void) {
     // We're using stack-allocated types (i.e. integers) as values,
     // so there's nothing to be freed.
 }

--- a/src/redisearch_rs/c_entrypoint/value_ffi/tests/array.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/tests/array.rs
@@ -12,7 +12,6 @@ use value_ffi::constructors::RSValue_NewNumber;
 use value_ffi::getters::RSValue_Number_Get;
 use value_ffi::shared::RSValue_DecrRef;
 
-#[expect(non_upper_case_globals)]
 #[unsafe(no_mangle)]
 pub static mut RSDummyContext: *mut redis_mock::ffi::RedisModuleCtx =
     redis_mock::globals::redis_module_ctx();

--- a/src/redisearch_rs/c_entrypoint/value_ffi/tests/array.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/tests/array.rs
@@ -12,7 +12,7 @@ use value_ffi::constructors::RSValue_NewNumber;
 use value_ffi::getters::RSValue_Number_Get;
 use value_ffi::shared::RSValue_DecrRef;
 
-#[allow(non_upper_case_globals)]
+#[expect(non_upper_case_globals)]
 #[unsafe(no_mangle)]
 pub static mut RSDummyContext: *mut redis_mock::ffi::RedisModuleCtx =
     redis_mock::globals::redis_module_ctx();

--- a/src/redisearch_rs/c_entrypoint/value_ffi/tests/map.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/tests/map.rs
@@ -13,7 +13,6 @@ use value_ffi::getters::RSValue_Number_Get;
 use value_ffi::map::*;
 use value_ffi::shared::RSValue_DecrRef;
 
-#[expect(non_upper_case_globals)]
 #[unsafe(no_mangle)]
 pub static mut RSDummyContext: *mut redis_mock::ffi::RedisModuleCtx =
     redis_mock::globals::redis_module_ctx();

--- a/src/redisearch_rs/c_entrypoint/value_ffi/tests/map.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/tests/map.rs
@@ -13,7 +13,7 @@ use value_ffi::getters::RSValue_Number_Get;
 use value_ffi::map::*;
 use value_ffi::shared::RSValue_DecrRef;
 
-#[allow(non_upper_case_globals)]
+#[expect(non_upper_case_globals)]
 #[unsafe(no_mangle)]
 pub static mut RSDummyContext: *mut redis_mock::ffi::RedisModuleCtx =
     redis_mock::globals::redis_module_ctx();

--- a/src/redisearch_rs/generational_slab/tests/slab.rs
+++ b/src/redisearch_rs/generational_slab/tests/slab.rs
@@ -737,7 +737,7 @@ fn get_disjoint_mut_out_of_bounds_index_error() {
         big_slab.insert(0);
     }
     // key at position 5
-    let k5 = big_slab.iter().last().unwrap().0;
+    let k5 = big_slab.iter().next_back().unwrap().0;
 
     // Index 0 and 1 are valid, but index 5 is out of bounds (beyond len)
     assert_eq!(

--- a/src/redisearch_rs/geo/tests/integration/hash/neighbors.rs
+++ b/src/redisearch_rs/geo/tests/integration/hash/neighbors.rs
@@ -333,7 +333,7 @@ mod proptests {
     }
 }
 
-fn named_neighbors(nbrs: &GeoHashNeighbors) -> [(&str, Option<GeoHashBits>); 8] {
+const fn named_neighbors(nbrs: &GeoHashNeighbors) -> [(&str, Option<GeoHashBits>); 8] {
     [
         ("north", nbrs.north),
         ("south", nbrs.south),

--- a/src/redisearch_rs/inverted_index/src/tests/gc.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/gc.rs
@@ -44,7 +44,7 @@ fn index_block_repair_delete() {
             0,
             cb,
             None::<fn(&RSIndexResult, &crate::RepairContext<'_>)>,
-            PhantomData::<Dummy>::default(),
+            PhantomData::<Dummy>,
         )
         .unwrap();
 
@@ -75,7 +75,7 @@ fn index_block_repair_unchanged() {
             0,
             cb,
             None::<fn(&RSIndexResult, &crate::RepairContext<'_>)>,
-            PhantomData::<Dummy>::default(),
+            PhantomData::<Dummy>,
         )
         .unwrap();
 
@@ -101,7 +101,7 @@ fn index_block_repair_some_deletions() {
             0,
             cb,
             None::<fn(&RSIndexResult, &crate::RepairContext<'_>)>,
-            PhantomData::<Dummy>::default(),
+            PhantomData::<Dummy>,
         )
         .unwrap();
 
@@ -211,7 +211,7 @@ fn index_block_repair_delta_too_big() {
             0,
             cb,
             None::<fn(&RSIndexResult, &crate::RepairContext<'_>)>,
-            PhantomData::<SmallDeltaDummy>::default(),
+            PhantomData::<SmallDeltaDummy>,
         )
         .unwrap();
 
@@ -585,7 +585,7 @@ fn ii_apply_gc_last_block_updated() {
         ii.memory_usage(),
         24 // Size of an empty inverted index
         + 8 // Size of the header of the thinvec storing blocks
-        + IndexBlock::STACK_SIZE * 1 // Size of the index blocks
+        + IndexBlock::STACK_SIZE // Size of the index blocks
         + 16 // Size of the buffer of the first index block
     );
 

--- a/src/redisearch_rs/inverted_index/tests/integration/c_mocks.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/c_mocks.rs
@@ -16,7 +16,7 @@
 use query_term::RSQueryTerm;
 
 #[unsafe(no_mangle)]
-pub extern "C" fn Term_Free(_t: *mut RSQueryTerm) {
+pub const extern "C" fn Term_Free(_t: *mut RSQueryTerm) {
     // Several tests use stack-allocated RSQueryTerm values, so this must be a
     // no-op rather than panicking on non-null pointers.
 }

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/fields_offsets.rs
@@ -178,12 +178,12 @@ fn test_encode_fields_offsets_output_too_small() {
     let record = index_result::RSIndexResult::build_term().build();
 
     let res = FieldsOffsets::encode(&mut cursor, 0, &record);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::WriteZero);
 
     let res = FieldsOffsetsWide::encode(&mut cursor, 0, &record);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::WriteZero);
 }
@@ -195,12 +195,12 @@ fn test_decode_fields_offsets_input_too_small() {
     let mut cursor = Cursor::new(buf.as_ref());
 
     let res = FieldsOffsets::decode_new(&mut cursor, 100);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 
     let res = FieldsOffsetsWide::decode_new(&mut cursor, 100);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }
@@ -212,12 +212,12 @@ fn test_decode_fields_offsets_empty_input() {
     let mut cursor = Cursor::new(buf.as_ref());
 
     let res = FieldsOffsets::decode_new(&mut cursor, 100);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 
     let res = FieldsOffsetsWide::decode_new(&mut cursor, 100);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/freqs_offsets.rs
@@ -75,7 +75,7 @@ fn test_encode_freqs_offsets_output_too_small() {
     let record = index_result::RSIndexResult::build_term().build();
 
     let res = FreqsOffsets::encode(&mut cursor, 0, &record);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::WriteZero);
 }
@@ -87,7 +87,7 @@ fn test_decode_freqs_offsets_input_too_small() {
     let mut cursor = Cursor::new(buf.as_ref());
 
     let res = FreqsOffsets::decode_new(&mut cursor, 100);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }
@@ -99,7 +99,7 @@ fn test_decode_freqs_offsets_empty_input() {
     let mut cursor = Cursor::new(buf.as_ref());
 
     let res = FreqsOffsets::decode_new(&mut cursor, 100);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/full.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/full.rs
@@ -124,7 +124,7 @@ fn test_encode_full_wide() {
             vec![1, 255, 255, 1, 3, 1, 1, 2, 3],
         ),
         (
-            u32::MAX as u32,
+            u32::MAX,
             1,
             1,
             vec![1, 2, 3],
@@ -133,7 +133,7 @@ fn test_encode_full_wide() {
         // field mask larger than 32 bits
         #[cfg(target_pointer_width = "64")]
         (
-            u32::MAX as u32,
+            u32::MAX,
             u32::MAX,
             u32::MAX as FieldMask,
             vec![1; 100],
@@ -147,7 +147,7 @@ fn test_encode_full_wide() {
         ),
         #[cfg(target_pointer_width = "64")]
         (
-            u32::MAX as u32,
+            u32::MAX,
             u32::MAX,
             u128::MAX,
             vec![1; 100],
@@ -208,12 +208,12 @@ fn test_encode_full_output_too_small() {
     let record = TestTermRecord::new(10, 1, 1, &[1]);
 
     let res = Full::encode(&mut cursor, 0, &record.record);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::WriteZero);
 
     let res = FullWide::encode(&mut cursor, 0, &record.record);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::WriteZero);
 }
@@ -225,12 +225,12 @@ fn test_decode_full_input_too_small() {
     let mut cursor = Cursor::new(buf.as_ref());
 
     let res = Full::decode_new(&mut cursor, 100);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 
     let res = FullWide::decode_new(&mut cursor, 100);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }
@@ -242,12 +242,12 @@ fn test_decode_full_empty_input() {
     let mut cursor = Cursor::new(buf.as_ref());
 
     let res = Full::decode_new(&mut cursor, 100);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 
     let res = FullWide::decode_new(&mut cursor, 100);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }
@@ -259,12 +259,12 @@ fn test_offsets_too_short() {
     let mut cursor = Cursor::new(buf.as_ref());
 
     let res = Full::decode_new(&mut cursor, 100);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 
     let res = FullWide::decode_new(&mut cursor, 100);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/offsets_only.rs
@@ -73,7 +73,7 @@ fn test_encode_offsets_only_output_too_small() {
     let record = index_result::RSIndexResult::build_term().build();
 
     let res = OffsetsOnly::encode(&mut cursor, 0, &record);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::WriteZero);
 }
@@ -85,7 +85,7 @@ fn test_decode_offsets_only_input_too_small() {
     let mut cursor = Cursor::new(buf.as_ref());
 
     let res = OffsetsOnly::decode_new(&mut cursor, 100);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }
@@ -97,7 +97,7 @@ fn test_decode_offsets_only_empty_input() {
     let mut cursor = Cursor::new(buf.as_ref());
 
     let res = OffsetsOnly::decode_new(&mut cursor, 100);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/raw_doc_ids_only.rs
@@ -57,7 +57,7 @@ fn test_encode_raw_doc_ids_only_output_too_small() {
     let record = index_result::RSIndexResult::build_virt().build();
 
     let res = RawDocIdsOnly::encode(&mut cursor, 0, &record);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::WriteZero);
 }
@@ -69,7 +69,7 @@ fn test_decode_raw_doc_ids_only_input_too_small() {
     let mut cursor = Cursor::new(buf.as_ref());
 
     let res = RawDocIdsOnly::decode_new(&mut cursor, 100);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }
@@ -81,7 +81,7 @@ fn test_decode_raw_doc_ids_only_empty_input() {
     let mut cursor = Cursor::new(buf.as_ref());
 
     let res = RawDocIdsOnly::decode_new(&mut cursor, 100);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }

--- a/src/redisearch_rs/inverted_index/tests/integration/metrics.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/metrics.rs
@@ -23,7 +23,7 @@ use std::ptr;
 ///
 /// The metrics code only stores and compares the borrow's address, so the
 /// field values are intentionally meaningless.
-fn make_key() -> RLookupKey {
+const fn make_key() -> RLookupKey {
     RLookupKey {
         dstidx: 0,
         svidx: 0,

--- a/src/redisearch_rs/qint/tests/qint.rs
+++ b/src/redisearch_rs/qint/tests/qint.rs
@@ -264,7 +264,7 @@ mod property_based {
             }
         }
 
-        pub fn leading_byte(&self) -> u8 {
+        pub const fn leading_byte(&self) -> u8 {
             let mut leading_byte = 0b00000000u8;
             match &self {
                 PropEncoding::QInt2((_, expected_size)) => {


### PR DESCRIPTION
Should we consider running clippy for tests ?

running `cargo clippy --tests 2>&1 | grep generated` on master :

```
warning: `redis_json_api` (lib) generated 1 warning (run `cargo clippy --fix --lib -p redis_json_api` to apply 1 suggestion)
warning: `redis_json_api` (lib test) generated 1 warning (1 duplicate)
warning: `value_ffi` (test "string") generated 41 warnings (run `cargo clippy --fix --test "string" -p value_ffi` to apply 1 suggestion)
warning: `field_spec` (lib) generated 5 warnings (run `cargo clippy --fix --lib -p field_spec` to apply 2 suggestions)
warning: `trie_rs` (test "integration") generated 1 warning (run `cargo clippy --fix --test "integration" -p trie_rs` to apply 1 suggestion)
warning: `value_ffi` (test "array") generated 3 warnings (run `cargo clippy --fix --test "array" -p value_ffi` to apply 1 suggestion)
warning: `value_ffi` (test "map") generated 3 warnings (run `cargo clippy --fix --test "map" -p value_ffi` to apply 1 suggestion)
warning: `buffer` (test "tests") generated 16 warnings
warning: `qint` (test "qint") generated 3 warnings (run `cargo clippy --fix --test "qint" -p qint` to apply 1 suggestion)
warning: `inverted_index_ffi` (lib test) generated 6 warnings (run `cargo clippy --fix --lib -p inverted_index_ffi --tests` to apply 2 suggestions)
warning: `generational_slab` (test "slab") generated 3 warnings (run `cargo clippy --fix --test "slab" -p generational_slab` to apply 1 suggestion)
warning: `geo` (test "integration") generated 1 warning (run `cargo clippy --fix --test "integration" -p geo` to apply 1 suggestion)
warning: `triemap_ffi` (test "trie") generated 2 warnings (run `cargo clippy --fix --test "trie" -p triemap_ffi` to apply 1 suggestion)
warning: `redis_mock` (lib test) generated 3 warnings
warning: `inverted_index` (lib test) generated 8 warnings (run `cargo clippy --fix --lib -p inverted_index --tests` to apply 5 suggestions)
warning: `inverted_index` (test "integration") generated 54 warnings
```

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
