### PR TITLE
link-check: exclude the Stack Overflow redis-tag URL

### DIFF
--- a/scripts/link-check-config.json
+++ b/scripts/link-check-config.json
@@ -1,5 +1,6 @@
 {
   "exclude_urls": [
+    "https://stackoverflow.com/questions/tagged/redis",
     "https://example.com/placeholder",
     "https://localhost",
     "http://localhost",


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: The `link-check` CI job fails on every PR that touches a Markdown file. `CONTRIBUTING.md` links to `https://stackoverflow.com/questions/tagged/redis`, and Cloudflare in front of stackoverflow.com now serves HTTP 403 to non-browser clients — both the checker's `requests` session and its curl fallback are rejected, even though the page loads fine in a browser. Passing the challenge requires JavaScript execution, which no user-agent string can substitute for. The job passed as recently as July 31; the blocking tightened since then.
2. Change: Add the URL to `exclude_urls` in `scripts/link-check-config.json` — the remedy `scripts/README-linkcheck.md` prescribes for persistent bot-blockers.
3. Outcome: `link-check` passes again on PRs touching Markdown files; the Stack Overflow link stays in `CONTRIBUTING.md` for human readers.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. `scripts/link-check-config.json` — one URL added to `exclude_urls`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
