### PR TITLE
[8.2] MOD-6841: test distributed profile parse error

### DIFF
--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -1,5 +1,13 @@
 from common import *
 
+def test_profile_missing_query_error_on_coordinator():
+    """MOD-6841: exercise the distributed parser, not the single-shard optimization."""
+    env = Env(shardsCount=3)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect('FT.PROFILE', 'idx', 'SEARCH', 'banana', 'banana').error().equal(
+        'The QUERY keyword is expected')
+
+
 @skip(cluster=False)
 def testInfo(env):
     conn = getConnectionByEnv(env)


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: MOD-6841 is covered only by a single-shard assertion that bypasses the distributed request parser.
2. Change: Add a focused three-shard regression for `FT.PROFILE idx SEARCH banana banana`.
3. Outcome: The 8.2 PR flow records whether the coordinator returns `The QUERY keyword is expected` instead of the default `Success (not an error)`. This diagnostic PR does not change production behavior.

#### Which additional issues this PR fixes

1. MOD-6841

#### Main objects this PR modified

1. `tests/pytests/test_coordinator.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
