### PR TITLE
[8.6] [MOD-17014] Validate FT.AGGREGATE GROUPBY count

### DIFF
--- a/src/aggregate/aggregate_plan.h
+++ b/src/aggregate/aggregate_plan.h
@@ -8,6 +8,7 @@
 */
 #ifndef AGGREGATE_PLAN_H_
 #define AGGREGATE_PLAN_H_
+#include <stdint.h>
 #include <value.h>
 #include <rlookup.h>
 #include <search_options.h>

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -876,18 +876,24 @@ static int parseGroupby(AGGPlan *plan, ArgsCursor *ac, QueryError *status) {
   const char *s;
   AC_GetString(ac, &s, NULL, AC_F_NOADVANCE);
 
-  long long nproperties;
-  int rv = AC_GetLongLong(ac, &nproperties, 0);
+  ArgsCursor propertiesAC = {0};
+  int rv = AC_GetVarArgs(ac, &propertiesAC);
   if (rv != AC_OK) {
     QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
 
-  const char **properties = array_newlen(const char *, nproperties);
-  for (size_t i = 0; i < nproperties; ++i) {
+  uint32_t propertyCount = (uint32_t)AC_NumArgs(&propertiesAC);
+  if (propertyCount > MAX_GROUPBY_PROPERTIES) {
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(AC_ERR_ELIMIT));
+    return REDISMODULE_ERR;
+  }
+
+  const char **properties = array_newlen(const char *, propertyCount);
+  for (uint32_t i = 0; i < propertyCount; ++i) {
     const char *property;
     size_t propertyLen;
-    rv = AC_GetString(ac, &property, &propertyLen, 0);
+    rv = AC_GetString(&propertiesAC, &property, &propertyLen, 0);
     if (rv != AC_OK) {
       QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(rv));
       array_free(properties);

--- a/src/config.h
+++ b/src/config.h
@@ -8,6 +8,8 @@
 */
 #pragma once
 
+#include <stdint.h>
+
 #include "redismodule.h"
 #include "hiredis/sds.h"
 #include "query_error.h"
@@ -312,6 +314,7 @@ char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName);
 #define DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS MAX_AGGREGATE_REQUEST_RESULTS
 #define MAX_AGGREGATE_GROUPS (1ULL << 26)
 #define DEFAULT_MAX_AGGREGATE_GROUPS 1000000
+#define MAX_GROUPBY_PROPERTIES UINT16_MAX
 #define DEFAULT_MAX_CURSOR_IDLE 300000
 #define DEFAULT_MAX_PREFIX_EXPANSIONS 200
 #define DEFAULT_MAX_SEARCH_REQUEST_RESULTS 1000000

--- a/src/hybrid/parse/hybrid_optional_args.c
+++ b/src/hybrid/parse/hybrid_optional_args.c
@@ -169,7 +169,7 @@ int HybridParseOptionalArgs(HybridParseContext *ctx, ArgsCursor *ac, bool intern
 
     // GROUPBY nproperties property [property ...] [REDUCE function nargs arg [arg ...] [AS alias]] [...]
     ArgParser_AddSubArgsV(parser, "GROUPBY", "Group results by properties with reducers",
-                         &subArgs, 1, -1,
+                         &subArgs, 0, MAX_GROUPBY_PROPERTIES,
                          ARG_OPT_OPTIONAL,
                          ARG_OPT_CALLBACK, handleGroupby, ctx,
                          ARG_OPT_END);

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -1511,6 +1511,13 @@ TEST_F(ParseHybridTest, testGroupByNoProperties) {
   testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "GROUPBY: Failed to parse the argument count");
 }
 
+TEST_F(ParseHybridTest, testGroupByRejectsTooManyProperties) {
+  const std::string too_many_properties = std::to_string(MAX_GROUPBY_PROPERTIES + 1);
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "PARAMS", "2", "BLOB", TEST_BLOB_DATA,
+                      "GROUPBY", too_many_properties.c_str(), "@title");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "GROUPBY: Invalid argument count");
+}
+
 TEST_F(ParseHybridTest, testGroupByPropertyMissingAtPrefix) {
   // Test GROUPBY with property missing @ prefix
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "PARAMS", "2", "BLOB", TEST_BLOB_DATA, "GROUPBY", "1", "title");

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1259,6 +1259,15 @@ def testGroupProperties(env):
     conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE', 'n', 'NUMERIC', 'SORTABLE', 'tt', 'TAG')
     conn.execute_command('HSET', 'doc1', 't', 'hello', 'n', '1', 'tt', 'foo')
 
+    max_groupby_properties = (1 << 16) - 1
+    env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', str(max_groupby_properties + 1), '@t').error().contains(
+                    'Bad arguments for GROUPBY: Expected an argument, but none provided')
+    too_many_properties = ['@t'] * (max_groupby_properties + 1)
+    env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', str(len(too_many_properties)), *too_many_properties).error().contains(
+                    'Bad arguments for GROUPBY: Value is outside acceptable bounds')
+    env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '-1').error().contains(
+                    'Bad arguments for GROUPBY: Value is outside acceptable bounds')
+
     # Check groupby properties
     env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '3', 't', 'n', 'tt').error().contains(
                     'Bad arguments for GROUPBY: Unknown property `t`. Did you mean `@t`?')


### PR DESCRIPTION
# Description
Backport of #10615 to `8.6`.

The automatic backport failed to cherry-pick. Resolved manually — see **Conflict resolution** below.

## What changed

`FT.AGGREGATE ... GROUPBY <nproperties>` is validated before the group pipeline is allocated or built:

- parse the property list with `AC_GetVarArgs`, so a count larger than the remaining command arguments is rejected before `array_newlen`
- reject counts above `MAX_GROUPBY_PROPERTIES` (`UINT16_MAX`)
- negative counts are rejected by `AC_GetUnsigned` inside `AC_GetVarArgs`
- bound the `FT.HYBRID` `GROUPBY` sub-args at `MAX_GROUPBY_PROPERTIES` instead of `-1` (unbounded)

## Why

The parser read `nproperties` as `long long` and passed it to `array_newlen`, whose length is a `uint32_t`. A negative or oversized value could wrap at allocation time while the parse loop kept using the original 64-bit count.

`UINT16_MAX` is the concrete downstream representation limit: GROUPBY properties and reducer aliases both allocate dynamic group-output `RLookup` row slots addressed by a `uint16_t dstidx`. The limit is deliberately not `MAX_AGGREGATE_GROUPS` (that caps materialized result groups at execution time) nor `SPEC_MAX_FIELDS` (GROUPBY can target `APPLY` aliases, not just schema fields).
## Conflict resolution

Two files conflicted; both are context-only, no behavioural difference from `master`.

| File | Conflict | Resolution |
|---|---|---|
| `src/aggregate/aggregate_plan.h` | `master` includes `value_ffi.h`; this branch still includes `value.h` | kept `value.h`, added the new `#include <stdint.h>` |
| `src/config.h` | the upstream hunk also carried unrelated flex/disk defines (`DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS_FLEX`, `DEFAULT_MAX_AGGREGATE_GROUPS_FLEX`) that do not exist on this branch | kept only `#define MAX_GROUPBY_PROPERTIES UINT16_MAX` |

The resulting patch is byte-identical to the clean cherry-pick onto `8.8-rse`.

## Validation

- patch verified byte-identical to the clean cherry-pick onto `8.8-rse`
- `git diff --check` clean
- Not built locally. The same patch was built and tested on `8.4` (`ParseHybridTest.testGroupBy*` 3/3 pass, `test_aggregate:testGroupProperties` pass); relying on PR CI for this branch's matrix.

## Original PR
- Title: [MOD-17014] Validate FT.AGGREGATE GROUPBY count
- Link: https://github.com/RediSearch/RediSearch/pull/10615
- Merge commit: `9ec64a812d8964021c5f416f7e3f07523d4dc593`

## Release notes
- [x] This PR requires release notes
- [ ] This PR does not require release notes


[MOD-17014]: https://redislabs.atlassian.net/browse/MOD-17014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ