### PR TITLE
[8.8-rse] [MOD-17316] Fix FT.HYBRID replying success with bogus warnings when a depleter loses the index lock

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -827,6 +827,8 @@ static void _replyWarnings(AREQ *req, RedisModule_Reply *reply, int rc) {
     ProfileWarnings_Add(&profileCtx->warnings, PROFILE_WARNING_TYPE_TIMEOUT);
   } else if (rc == RS_RESULT_ERROR) {
     // Non-fatal error
+    RS_LOG_ASSERT(!QueryError_IsOk(qctx->err),
+                  "RS_RESULT_ERROR reached the warning path without a QueryError set");
     RedisModule_Reply_SimpleString(reply, QueryError_GetUserError(qctx->err));
   }
   if (QueryError_HasReachedMaxPrefixExpansionsWarning(qctx->err)) {

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -328,6 +328,7 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   // in RSExecDistAggregate before fanning out, so base.Next is already rpnetNext
   // by the time results are pulled and this function is never reached.
   if (rpnetCreateIterator(nc) != RS_RESULT_OK) {
+    QueryError_SetCode(nc->base.parent->err, QUERY_ERROR_CODE_GENERIC);
     return RS_RESULT_ERROR;
   }
   MR_StartIterator(nc->it, iterStartCb, NULL);

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -84,6 +84,8 @@ static inline HybridWarningMask handleAndReplyWarning(RedisModule_Reply *reply, 
     return HYBRID_WARNING_TIMEOUT;
   } else if (returnCode == RS_RESULT_ERROR) {
     // Non-fatal error — convert to warning
+    RS_LOG_ASSERT(!QueryError_IsOk(err),
+                  "RS_RESULT_ERROR reached the warning path without a QueryError set");
     ReplyWarning(reply, QueryError_GetUserError(err), suffix);
     QueryError_ClearError(err);  // Free allocated message strings
   } else if (QueryError_HasReachedMaxPrefixExpansionsWarning(err)) {

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -281,7 +281,7 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
     rs_wall_clock_init(&now);
 
     // Initialize error tracking for each individual request
-    hybridReq->errors = array_new(QueryError, nrequests);
+    hybridReq->errors = array_newlen(QueryError, nrequests);
     memset(hybridReq->errors, 0, nrequests * sizeof(QueryError));
 
     // Initialize return codes array for tracking subqueries final states

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1769,6 +1769,11 @@ ResultProcessor *RPVectorNormalizer_New(VectorNormFunction normFunc, const RLook
  *  NOTE: Currently the recommended number of upstreams is 2. Using more may
  *  induce performance issues, until a more robust mechanism is implemented.
  *******************************************************************************************************************/
+
+#define SAFE_DEPLETER_LOCK_FAILURE_MSG                                                            \
+  "Failed to acquire index lock for background depletion. A write operation may be in progress. " \
+  "Please retry."
+
 typedef struct {
   ResultProcessor base;                // Base result processor struct
   // We require separate contexts because we have different threads.
@@ -1889,6 +1894,8 @@ static void RPSafeDepleter_DepleteFromUpstream(RPSafeDepleter *self, DepleterSyn
       // Failed to acquire lock - likely a writer is waiting
       // Set error status and return without depleting
       self->last_rc = RS_RESULT_ERROR;
+      QueryError_SetError(self->base.parent->err, QUERY_ERROR_CODE_SAFE_DEPLETER_FAILURE,
+                          SAFE_DEPLETER_LOCK_FAILURE_MSG);
       // Signal that we're skipping the lock phase (for WaitForDepletionToStart)
       atomic_fetch_add(&sync->num_skipped_lock, 1);
       return;
@@ -2261,8 +2268,8 @@ int RPSafeDepleter_DepleteAll(arrayof(ResultProcessor*) safeDepleters, QueryErro
   for (size_t i = 0; i < count; i++) {
     const RPSafeDepleter *safeDepleter = (RPSafeDepleter *)safeDepleters[i];
     if (safeDepleter->last_rc == RS_RESULT_ERROR) {
-      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_SAFE_DEPLETER_FAILURE,
-        "Failed to acquire index lock for background depletion. A write operation may be in progress. Please retry.");
+      QueryError_SetError(status, QUERY_ERROR_CODE_SAFE_DEPLETER_FAILURE,
+                          SAFE_DEPLETER_LOCK_FAILURE_MSG);
       return RS_RESULT_ERROR;
     } else if (safeDepleter->last_rc == RS_RESULT_TIMEDOUT) {
       anyTimedOut = true;
@@ -2431,6 +2438,8 @@ static int RPHybridMerger_Yield(ResultProcessor *rp, SearchResult *r) {
 
   SearchResult *mergedResult = mergeSearchResults(hybridResult, self->hybridScoringCtx, self->lookupCtx, self->explainCtx);
   if (!mergedResult) {
+    QueryError_SetError(rp->parent->err, QUERY_ERROR_CODE_GENERIC,
+                        "Failed to merge hybrid subquery results");
     return RS_RESULT_ERROR;
   }
 

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -497,7 +497,7 @@ def skipTestUntil(date_str, reason=None):
     """
     skip_until(date_str, reason)(lambda: None)()
 
-def _any_skip_condition_set(*, cluster, macos, asan, msan, redis_less_than,
+def _any_skip_condition_set(*, cluster, macos, musl, asan, msan, redis_less_than,
                             redis_greater_equal, min_shards, arch, gc_no_fork,
                             no_json):
     """True if the caller provided at least one skip condition.
@@ -505,12 +505,12 @@ def _any_skip_condition_set(*, cluster, macos, asan, msan, redis_less_than,
     With no conditions, @skip's legacy behaviour is to always skip — used as a
     "temporarily disable this test" marker.
     """
-    return ((cluster is not None) or macos or asan or msan or redis_less_than
+    return ((cluster is not None) or macos or musl or asan or msan or redis_less_than
             or redis_greater_equal or min_shards or (arch is not None)
             or gc_no_fork or no_json)
 
 
-def _skip_fires_statically(*, cluster, macos, asan, msan, min_shards, arch,
+def _skip_fires_statically(*, cluster, macos, musl, asan, msan, min_shards, arch,
                             no_json):
     """Evaluate the subset of @skip predicates that don't need a live Redis.
 
@@ -520,6 +520,8 @@ def _skip_fires_statically(*, cluster, macos, asan, msan, min_shards, arch,
     if cluster is not None and cluster == CLUSTER:
         return True
     if macos and OS == 'macos':
+        return True
+    if musl and MUSL:
         return True
     if arch == platform.machine():
         return True
@@ -549,8 +551,8 @@ def _skip_fires_at_runtime(*, redis_less_than, redis_greater_equal, gc_no_fork):
     return False
 
 
-def skip(cluster=None, macos=False, asan=False, msan=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None, no_json=False):
-    static_kwargs = dict(cluster=cluster, macos=macos, asan=asan, msan=msan,
+def skip(cluster=None, macos=False, musl=False, asan=False, msan=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None, no_json=False):
+    static_kwargs = dict(cluster=cluster, macos=macos, musl=musl, asan=asan, msan=msan,
                          min_shards=min_shards, arch=arch, no_json=no_json)
     runtime_kwargs = dict(redis_less_than=redis_less_than,
                           redis_greater_equal=redis_greater_equal,

--- a/tests/pytests/includes.py
+++ b/tests/pytests/includes.py
@@ -3,6 +3,7 @@ import sys
 import os
 from RLTest import Defaults
 import platform
+import sysconfig
 
 if sys.version_info > (3, 0):
     Defaults.decode_responses = True
@@ -23,3 +24,4 @@ EXTENDED_PYTESTS = not os.getenv('QUICK', '0') == '1'
 
 system=platform.system()
 OS =  'macos' if system == 'Darwin' else system
+MUSL = 'musl' in (sysconfig.get_config_var('MULTIARCH') or '')

--- a/tests/pytests/test_hybrid_multithread.py
+++ b/tests/pytests/test_hybrid_multithread.py
@@ -1,4 +1,5 @@
 import numpy as np
+import threading
 from RLTest import Env
 from common import *
 from utils.hybrid import *
@@ -96,3 +97,55 @@ def test_hybrid_multithread():
         env.assertEqual(getWorkersThpoolStats(env)['totalJobsDone'], 6)
 
     env.assertEqual(getWorkersThpoolStats(env)['numThreadsAlive'], 1)
+
+
+# Skipped on musl, which admits a reader past a queued writer, so the try-lock
+# never fails there.
+@skip(cluster=True, musl=True)
+def test_hybrid_depleter_lock_failure_replies_error():
+    """A depleter that loses the spec try-lock to a queued writer must reply
+    SEARCH_SAFE_DEPLETER_FAILURE.
+    """
+    env = Env(moduleArgs='WORKERS 2 DEFAULT_DIALECT 2', enableDebugCommand=True)
+    skipIfNoEnableAssert(env)
+    setup_basic_index(env)
+    query_vector = np.array([1.3, 0.0]).astype(np.float32).tobytes()
+
+    sync_point = 'BeforeHybridResultsClaim'
+    env.cmd(debug_cmd(), 'SYNC_POINT', 'ARM', sync_point)
+
+    outcome = []
+    def run_hybrid_query(conn, out):
+        try:
+            # TIMEOUT 0 is load-bearing: it disables the sync point's other release
+            # arm, leaving the queued writer as the only way out. Without it the
+            # query can escape by timing out and the test passes vacuously.
+            out.append(('ok', conn.execute_command(
+                'FT.HYBRID', 'idx', 'SEARCH', '@text:(hello)',
+                'VSIM', '@vector', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
+                'TIMEOUT', '0')))
+        except Exception as e:
+            out.append(('err', str(e)))
+
+    query_thread = threading.Thread(target=run_hybrid_query,
+                                    args=(env.getConnection(), outcome), daemon=True)
+    query_thread.start()
+    wait_for_condition(
+        lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', sync_point) == 1, {}),
+        f'Timeout waiting for {sync_point} sync point')
+
+    # Indexing this parks on the spec write lock behind the query's read lock, which
+    # both releases the sync point and makes the depleters' try-lock fail. It returns
+    # once the query has finished and dropped its read lock.
+    env.cmd('HSET', 'text:99', 'text', 'hello queued writer', 'type', 'text')
+
+    query_thread.join(timeout=30)
+    env.assertFalse(query_thread.is_alive(), message='Query thread never completed')
+    if not outcome:
+        return  # still parked; the assertion above is the diagnostic
+
+    kind, payload = outcome[0]
+    # TODO(MOD-16487): once a queued writer no longer aborts hybrid depletion, this
+    # expectation flips — the query should be served instead of erroring.
+    env.assertEqual(kind, 'err', message=f'expected the query to be aborted, got: {payload}')
+    env.assertContains('Failed to acquire index lock for background depletion', str(payload))


### PR DESCRIPTION
## Describe the changes in the pull request

Manual backport of #10658 to `8.8-rse`. The automated backport failed to cherry-pick.

1. **Current**: `FT.HYBRID`'s background depleters take a non-blocking spec read lock. When that try-lock loses the race to a queued writer, the failure was recorded only in `last_rc`. Plain `FT.HYBRID` depletes through `Next`, so the merger saw a bare `RS_RESULT_ERROR` with an unset `QueryError`, which stringifies to its `QUERY_ERROR_CODE_OK` default — the command answered **successfully with `total_results: 0`** and `Success (not an error)` warnings.
2. **Change**: record the failure on the subquery pipeline's `QueryError` at the point of loss, with debug-build assertions at both reply sites pinning the invariant that `RS_RESULT_ERROR` carries a message. Also fixes a latent leak of `hreq->errors[i]` messages (`array_new` -> `array_newlen`, so `array_free_ex` iterates the elements).
3. **Outcome**: standalone `FT.HYBRID` returns the same retryable `SEARCH_SAFE_DEPLETER_FAILURE ... Please retry.` as the cursor and cluster paths. Try-lock behaviour itself is unchanged.

## Original PR

https://github.com/RediSearch/RediSearch/pull/10658 (merge commit `34dcfb241afbaabbe4ad6e087cc1624af76854ce`)

## Changes from original

One conflict, in `tests/pytests/common.py`. Master's `skip()` / `_skip_fires_statically()` carry an `enterprise=` predicate that was never backported to `8.8-rse`, and the upstream commit edits those same signature lines to add `musl=`. Resolved by keeping this branch's signatures and adding only `musl` — the `enterprise` parameter is not introduced here.

All other hunks (`src/aggregate/aggregate_exec.c`, `src/coord/dist_aggregate.c`, `src/hybrid/hybrid_exec.c`, `src/hybrid/hybrid_request.c`, `src/result_processor.c`, `tests/pytests/includes.py`, `tests/pytests/test_hybrid_multithread.py`) applied cleanly and are byte-identical to the original commit.

### Testing

`./build.sh DEBUG=1 ENABLE_ASSERT=1` then `./build.sh RUN_PYTEST DEBUG=1 ENABLE_ASSERT=1 TEST=test_hybrid_multithread.py` — 2/2 pass, including `test_hybrid_depleter_lock_failure_replies_error`.

#### Which additional issues this PR fixes
1. MOD-17316

#### Main objects this PR modified
1. `RPSafeDepleter_DepleteFromUpstream` — records `SAFE_DEPLETER_FAILURE`; message shared with `RPSafeDepleter_DepleteAll`
2. `HybridRequest_Init` — `array_newlen` so `errors[]` are cleared on free
3. `handleAndReplyWarning` (`hybrid_exec.c`) and `_replyWarnings` (`aggregate_exec.c`) — assert that `RS_RESULT_ERROR` carries a message
4. `RPHybridMerger_Yield`, `rpnetNext_Start` — record a message before returning `RS_RESULT_ERROR`
5. `@skip(musl=True)` — new predicate in `common.py` / `includes.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
