### PR TITLE
[MOD-17919] Backport flow: resolve App-token owner from the repo, not a hard-coded org

### DIFF
--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -33,31 +33,39 @@ jobs:
     steps:
       - name: 🔑 Generate GitHub App Token
         id: generate-app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
           # Resolve the App installation from the repository that triggered the
           # run, never a hard-coded org. A literal `owner: RediSearch` breaks
           # this flow in any fork or mirror (e.g. redislabsdev/RediSearch): the
-          # action looks up `https://api.github.com/users/RediSearch/installation`,
-          # which 404s for an App not installed on that org, so the token is
-          # never minted and the whole backport job fails. `github.repository_owner`
-          # always matches the current repo's owner, so the same workflow works
-          # unchanged wherever it runs. Mirrors the agent backport flows
-          # (task-backport_pr-agent*.yml), which already parameterize this.
+          # action looks up `users/RediSearch/installation`, which 404s for an
+          # App not installed on that org, so the token is never minted and the
+          # whole backport job fails. `github.repository_owner` always matches
+          # the current repo's owner, so the workflow runs unchanged wherever it
+          # lives. Mirrors the agent flows (task-backport_pr-agent*.yml).
           owner: ${{ github.repository_owner }}
-          # Scope the installation token to THIS repo only. Without `repositories`,
-          # the token is minted for every repo the App can access under the owner;
-          # restricting it keeps the grant least-privilege.
+          # Without this the token reaches every repository the app is installed
+          # on across the org, not just this one.
           repositories: ${{ github.event.repository.name }}
+          # And without these it inherits the app installation's full permission
+          # set. korthout/backport-action needs: contents to push the cherry-picked
+          # branch, pull-requests to open the backport PR, request the author as
+          # reviewer, copy labels and enable auto-merge, and workflows because a
+          # backport whose commits touch .github/workflows/** is otherwise refused
+          # ("without `workflows` permission") — GitHub gates ref and contents
+          # writes that carry workflow files behind that permission separately.
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           token: ${{ steps.generate-app-token.outputs.token }}
       - name: Create backport pull requests
         id: backport
-        uses: korthout/backport-action@v4
+        uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0
         with:
           github_token: ${{ steps.generate-app-token.outputs.token }}
           pull_title: '[${target_branch}] ${pull_title}'

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -33,31 +33,31 @@ jobs:
     steps:
       - name: 🔑 Generate GitHub App Token
         id: generate-app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
-          owner: RediSearch
-          # Without this the token reaches every repository the app is installed
-          # on across the org, not just this one.
-          repositories: RediSearch
-          # And without these it inherits the app installation's full permission
-          # set. korthout/backport-action needs: contents to push the cherry-picked
-          # branch, pull-requests to open the backport PR, request the author as
-          # reviewer, copy labels and enable auto-merge, and workflows because a
-          # backport whose commits touch .github/workflows/** is otherwise refused
-          # ("without `workflows` permission") — GitHub gates ref and contents
-          # writes that carry workflow files behind that permission separately.
-          permission-contents: write
-          permission-pull-requests: write
-          permission-workflows: write
+          # Resolve the App installation from the repository that triggered the
+          # run, never a hard-coded org. A literal `owner: RediSearch` breaks
+          # this flow in any fork or mirror (e.g. redislabsdev/RediSearch): the
+          # action looks up `https://api.github.com/users/RediSearch/installation`,
+          # which 404s for an App not installed on that org, so the token is
+          # never minted and the whole backport job fails. `github.repository_owner`
+          # always matches the current repo's owner, so the same workflow works
+          # unchanged wherever it runs. Mirrors the agent backport flows
+          # (task-backport_pr-agent*.yml), which already parameterize this.
+          owner: ${{ github.repository_owner }}
+          # Scope the installation token to THIS repo only. Without `repositories`,
+          # the token is minted for every repo the App can access under the owner;
+          # restricting it keeps the grant least-privilege.
+          repositories: ${{ github.event.repository.name }}
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.generate-app-token.outputs.token }}
       - name: Create backport pull requests
         id: backport
-        uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0
+        uses: korthout/backport-action@v4
         with:
           github_token: ${{ steps.generate-app-token.outputs.token }}
           pull_title: '[${target_branch}] ${pull_title}'


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `task-backport_pr.yml` (the legacy korthout backport flow) mints its GitHub App token with a hard-coded `owner: RediSearch`. That only works in `RediSearch/RediSearch`. In any fork or private mirror the step looks up `https://api.github.com/users/RediSearch/installation`, which 404s for an App that isn't installed on the `RediSearch` org, so the token is never minted and the entire backport job fails.
2. **Change:** Resolve the owner dynamically from the triggering repo — `owner: ${{ github.repository_owner }}` — and scope the token to the current repo with `repositories: ${{ github.event.repository.name }}`. This mirrors the pattern the agent backport flows (`task-backport_pr-agent*.yml`) already use.
3. **Outcome:** The workflow runs unchanged wherever it lives (public repo, forks, `redislabsdev/RediSearch` mirror), and the minted token stays least-privilege (scoped to the one repo instead of every repo the App can access under the owner).

### Observed failure this fixes
On `redislabsdev/RediSearch`, the backport job failed at the token step:
```
owner: RediSearch
Input 'repositories' is not set. Creating token for all repositories owned by RediSearch.
Failed to create token for "RediSearch" (attempt 1): Not Found
  url: 'https://api.github.com/users/RediSearch/installation'
Token is not set
```

#### Main objects this PR modified
1. `.github/workflows/task-backport_pr.yml` — dynamic `owner` + scoped `repositories` on the App-token step.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI/automation-only change (backport workflow token scoping); no user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)