### PR TITLE
[MOD-17409] Hold the command argv on requests; strictly parse numeric command arguments

### DIFF
--- a/deps/rmutil/CMakeLists.txt
+++ b/deps/rmutil/CMakeLists.txt
@@ -8,17 +8,28 @@ add_library(rmutil OBJECT
     util.c
     vector.c)
 
-if (RMUTIL_TESTS)
+if (RMUTIL_TESTS OR BUILD_SEARCH_UNIT_TESTS)
 	function(_rmutilTest name)
 		add_executable(${name} "${name}.c" $<TARGET_OBJECTS:rmutil>)
 		target_compile_definitions(${name} PRIVATE REDISMODULE_MAIN)
-		target_link_libraries(${name} ${CMAKE_LD_LIBS})
+		# libm: the rmutil objects (cmdparse.c) use round()
+		target_link_libraries(${name} ${CMAKE_LD_LIBS} m)
+		# The unit-test runner discovers C test binaries by scanning
+		# <build>/tests/ctests for test_* executables.
+		set_target_properties(${name} PROPERTIES
+			RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/ctests")
 		add_test(NAME "${name}" COMMAND "${name}")
 	endfunction()
 
-	file(GLOB TEST_SOURCES "test_*.c")
-	foreach(n ${TEST_SOURCES})
-		get_filename_component(test_name ${n} NAME_WE)
-		_rmutilTest("${test_name}")
-	endforeach()
+	# Only test_args is maintained and part of the unit-test run; the other
+	# test_*.c files here predate the module and are opt-in via RMUTIL_TESTS.
+	_rmutilTest(test_args)
+	if (RMUTIL_TESTS)
+		file(GLOB TEST_SOURCES "test_*.c")
+		list(REMOVE_ITEM TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/test_args.c")
+		foreach(n ${TEST_SOURCES})
+			get_filename_component(test_name ${n} NAME_WE)
+			_rmutilTest("${test_name}")
+		endforeach()
+	endif()
 endif()

--- a/deps/rmutil/args.c
+++ b/deps/rmutil/args.c
@@ -59,6 +59,19 @@ int AC_AdvanceIfMatch(ArgsCursor *ac, const char *s) {
     AC_Advance(ac);                \
   }
 
+/* The current token as a NUL-terminated C string, for any cursor backing.
+ * Numeric conversions go through this so that a token means the same number
+ * no matter what backs the cursor: request parsing has legacy contracts tied
+ * to the strtoll/strtod semantics below (e.g. DIALECT 1 treats an empty
+ * filter value as 0), and those must not change when a parse path switches
+ * to RedisModuleString-backed cursors. */
+static const char *currentCString(ArgsCursor *ac) {
+  if (ac->type == AC_TYPE_RSTRING) {
+    return RedisModule_StringPtrLen(ac->objs[ac->offset], NULL);
+  }
+  return AC_CURRENT(ac);
+}
+
 static int tryReadAsDouble(ArgsCursor *ac, long long *ll, int flags) {
   double dTmp = 0.0;
   if (AC_GetDouble(ac, &dTmp, flags | AC_F_NOADVANCE) != AC_OK) {
@@ -87,16 +100,11 @@ int AC_GetLongLong(ArgsCursor *ac, long long *ll, int flags) {
   // Try to parse the number as a normal integer first. If that fails, try
   // to parse it as a double. This will work if the number is in the format of
   // 3.00, OR if the number is in the format of 3.14 *AND* AC_F_COALESCE is set.
-  if (ac->type == AC_TYPE_RSTRING) {
-    if (RedisModule_StringToLongLong(AC_CURRENT(ac), &tmpll) == REDISMODULE_ERR) {
-      hasErr = 1;
-    }
-  } else {
-    char *endptr = AC_CURRENT(ac);
-    tmpll = strtoll(AC_CURRENT(ac), &endptr, 10);
-    if (*endptr != '\0' || tmpll == LLONG_MIN || tmpll == LLONG_MAX) {
-      hasErr = 1;
-    }
+  const char *str = currentCString(ac);
+  char *endptr = (char *)str;
+  tmpll = strtoll(str, &endptr, 10);
+  if (*endptr != '\0' || tmpll == LLONG_MIN || tmpll == LLONG_MAX) {
+    hasErr = 1;
   }
 
   if (hasErr && tryReadAsDouble(ac, &tmpll, flags) != AC_OK) {
@@ -144,16 +152,11 @@ GEN_AC_FUNC(AC_GetSize, size_t, 0, SIZE_MAX, 1)
 
 int AC_GetDouble(ArgsCursor *ac, double *d, int flags) {
   double tmpd = 0;
-  if (ac->type == AC_TYPE_RSTRING) {
-    if (RedisModule_StringToDouble(ac->objs[ac->offset], &tmpd) != REDISMODULE_OK) {
-      return AC_ERR_PARSE;
-    }
-  } else {
-    char *endptr = AC_CURRENT(ac);
-    tmpd = strtod(AC_CURRENT(ac), &endptr);
-    if (*endptr != '\0' || tmpd == HUGE_VAL || tmpd == -HUGE_VAL) {
-      return AC_ERR_PARSE;
-    }
+  const char *str = currentCString(ac);
+  char *endptr = (char *)str;
+  tmpd = strtod(str, &endptr);
+  if (*endptr != '\0' || tmpd == HUGE_VAL || tmpd == -HUGE_VAL) {
+    return AC_ERR_PARSE;
   }
   if ((flags & AC_F_GE0) && tmpd < 0.0) {
     return AC_ERR_ELIMIT;

--- a/deps/rmutil/args.c
+++ b/deps/rmutil/args.c
@@ -59,19 +59,6 @@ int AC_AdvanceIfMatch(ArgsCursor *ac, const char *s) {
     AC_Advance(ac);                \
   }
 
-/* The current token as a NUL-terminated C string, for any cursor backing.
- * Numeric conversions go through this so that a token means the same number
- * no matter what backs the cursor: request parsing has legacy contracts tied
- * to the strtoll/strtod semantics below (e.g. DIALECT 1 treats an empty
- * filter value as 0), and those must not change when a parse path switches
- * to RedisModuleString-backed cursors. */
-static const char *currentCString(ArgsCursor *ac) {
-  if (ac->type == AC_TYPE_RSTRING) {
-    return RedisModule_StringPtrLen(ac->objs[ac->offset], NULL);
-  }
-  return AC_CURRENT(ac);
-}
-
 static int tryReadAsDouble(ArgsCursor *ac, long long *ll, int flags) {
   double dTmp = 0.0;
   if (AC_GetDouble(ac, &dTmp, flags | AC_F_NOADVANCE) != AC_OK) {
@@ -100,11 +87,21 @@ int AC_GetLongLong(ArgsCursor *ac, long long *ll, int flags) {
   // Try to parse the number as a normal integer first. If that fails, try
   // to parse it as a double. This will work if the number is in the format of
   // 3.00, OR if the number is in the format of 3.14 *AND* AC_F_COALESCE is set.
-  const char *str = currentCString(ac);
-  char *endptr = (char *)str;
-  tmpll = strtoll(str, &endptr, 10);
-  if (*endptr != '\0' || tmpll == LLONG_MIN || tmpll == LLONG_MAX) {
-    hasErr = 1;
+  // Here and in AC_GetDouble: RSTRING-backed cursors carry user command argv
+  // and parse with the strict RedisModule conversions (canonical form, no
+  // whitespace, no empty tokens, overflow via errno). The char* branches keep
+  // C-library leniency and only ever see internally generated canonical
+  // tokens (e.g. serialized plan args).
+  if (ac->type == AC_TYPE_RSTRING) {
+    if (RedisModule_StringToLongLong(AC_CURRENT(ac), &tmpll) == REDISMODULE_ERR) {
+      hasErr = 1;
+    }
+  } else {
+    char *endptr = AC_CURRENT(ac);
+    tmpll = strtoll(AC_CURRENT(ac), &endptr, 10);
+    if (*endptr != '\0' || tmpll == LLONG_MIN || tmpll == LLONG_MAX) {
+      hasErr = 1;
+    }
   }
 
   if (hasErr && tryReadAsDouble(ac, &tmpll, flags) != AC_OK) {
@@ -152,11 +149,16 @@ GEN_AC_FUNC(AC_GetSize, size_t, 0, SIZE_MAX, 1)
 
 int AC_GetDouble(ArgsCursor *ac, double *d, int flags) {
   double tmpd = 0;
-  const char *str = currentCString(ac);
-  char *endptr = (char *)str;
-  tmpd = strtod(str, &endptr);
-  if (*endptr != '\0' || tmpd == HUGE_VAL || tmpd == -HUGE_VAL) {
-    return AC_ERR_PARSE;
+  if (ac->type == AC_TYPE_RSTRING) {
+    if (RedisModule_StringToDouble(ac->objs[ac->offset], &tmpd) != REDISMODULE_OK) {
+      return AC_ERR_PARSE;
+    }
+  } else {
+    char *endptr = AC_CURRENT(ac);
+    tmpd = strtod(AC_CURRENT(ac), &endptr);
+    if (*endptr != '\0' || tmpd == HUGE_VAL || tmpd == -HUGE_VAL) {
+      return AC_ERR_PARSE;
+    }
   }
   if ((flags & AC_F_GE0) && tmpd < 0.0) {
     return AC_ERR_ELIMIT;

--- a/deps/rmutil/args.c
+++ b/deps/rmutil/args.c
@@ -64,17 +64,15 @@ static int tryReadAsDouble(ArgsCursor *ac, long long *ll, int flags) {
   if (AC_GetDouble(ac, &dTmp, flags | AC_F_NOADVANCE) != AC_OK) {
     return AC_ERR_PARSE;
   }
-  // Converting a double outside [LLONG_MIN, 2^63) to long long is undefined
-  // behavior, and the RString conversion accepts literal "inf" — the casts
-  // below must never see such a value. Note (double)LLONG_MAX rounds up to
-  // exactly 2^63, making it the correct exclusive bound; (double)LLONG_MIN
-  // is exact. NaN has no meaningful integer value under either flag.
+  // Casting a double outside [LLONG_MIN, 2^63) to long long is UB, and the
+  // RString conversion accepts literal "inf" — reject NaN and handle the
+  // range before any cast. (double)LLONG_MAX rounds up to exactly 2^63,
+  // making it the correct exclusive bound.
   if (isnan(dTmp)) {
     return AC_ERR_PARSE;
   }
   if (flags & AC_F_COALESCE) {
-    // Coalescing means "coerce whatever number was given": saturate
-    // out-of-range values (inf included) to the representable range.
+    // Coalescing coerces: saturate out-of-range values (inf included)
     if (dTmp >= (double)LLONG_MAX) {
       *ll = LLONG_MAX;
     } else if (dTmp < (double)LLONG_MIN) {
@@ -85,8 +83,7 @@ static int tryReadAsDouble(ArgsCursor *ac, long long *ll, int flags) {
     return AC_OK;
   }
 
-  // Non-coalescing accepts only values that survive the integral round-trip;
-  // out-of-range values cannot, so reject them before the undefined cast.
+  // Non-coalescing: out-of-range values cannot survive the integral round-trip
   if (!(dTmp >= (double)LLONG_MIN && dTmp < (double)LLONG_MAX)) {
     return AC_ERR_PARSE;
   }
@@ -108,11 +105,9 @@ int AC_GetLongLong(ArgsCursor *ac, long long *ll, int flags) {
   // Try to parse the number as a normal integer first. If that fails, try
   // to parse it as a double. This will work if the number is in the format of
   // 3.00, OR if the number is in the format of 3.14 *AND* AC_F_COALESCE is set.
-  // Here and in AC_GetDouble: RSTRING-backed cursors carry user command argv
-  // and parse with the strict RedisModule conversions (canonical form, no
-  // whitespace, no empty tokens, overflow via errno). The char* branches keep
-  // C-library leniency and only ever see internally generated canonical
-  // tokens (e.g. serialized plan args).
+  // Here and in AC_GetDouble: RSTRING cursors carry user command argv and use
+  // the strict RedisModule conversions; the char* branches keep C-library
+  // leniency and only ever see internally generated canonical tokens.
   if (ac->type == AC_TYPE_RSTRING) {
     if (RedisModule_StringToLongLong(AC_CURRENT(ac), &tmpll) == REDISMODULE_ERR) {
       hasErr = 1;

--- a/deps/rmutil/args.c
+++ b/deps/rmutil/args.c
@@ -64,6 +64,15 @@ static int tryReadAsDouble(ArgsCursor *ac, long long *ll, int flags) {
   if (AC_GetDouble(ac, &dTmp, flags | AC_F_NOADVANCE) != AC_OK) {
     return AC_ERR_PARSE;
   }
+  // Converting a double outside [LLONG_MIN, 2^63) to long long is undefined
+  // behavior, and the RString conversion accepts literal "inf". A single
+  // range predicate rejects inf, nan (both comparisons are false for nan)
+  // and finite out-of-range values before either cast below. Note
+  // (double)LLONG_MAX rounds up to exactly 2^63, making it the correct
+  // exclusive bound; (double)LLONG_MIN is exact.
+  if (!(dTmp >= (double)LLONG_MIN && dTmp < (double)LLONG_MAX)) {
+    return AC_ERR_PARSE;
+  }
   if (flags & AC_F_COALESCE) {
     *ll = dTmp;
     return AC_OK;

--- a/deps/rmutil/args.c
+++ b/deps/rmutil/args.c
@@ -65,19 +65,31 @@ static int tryReadAsDouble(ArgsCursor *ac, long long *ll, int flags) {
     return AC_ERR_PARSE;
   }
   // Converting a double outside [LLONG_MIN, 2^63) to long long is undefined
-  // behavior, and the RString conversion accepts literal "inf". A single
-  // range predicate rejects inf, nan (both comparisons are false for nan)
-  // and finite out-of-range values before either cast below. Note
-  // (double)LLONG_MAX rounds up to exactly 2^63, making it the correct
-  // exclusive bound; (double)LLONG_MIN is exact.
-  if (!(dTmp >= (double)LLONG_MIN && dTmp < (double)LLONG_MAX)) {
+  // behavior, and the RString conversion accepts literal "inf" — the casts
+  // below must never see such a value. Note (double)LLONG_MAX rounds up to
+  // exactly 2^63, making it the correct exclusive bound; (double)LLONG_MIN
+  // is exact. NaN has no meaningful integer value under either flag.
+  if (isnan(dTmp)) {
     return AC_ERR_PARSE;
   }
   if (flags & AC_F_COALESCE) {
-    *ll = dTmp;
+    // Coalescing means "coerce whatever number was given": saturate
+    // out-of-range values (inf included) to the representable range.
+    if (dTmp >= (double)LLONG_MAX) {
+      *ll = LLONG_MAX;
+    } else if (dTmp < (double)LLONG_MIN) {
+      *ll = LLONG_MIN;
+    } else {
+      *ll = dTmp;
+    }
     return AC_OK;
   }
 
+  // Non-coalescing accepts only values that survive the integral round-trip;
+  // out-of-range values cannot, so reject them before the undefined cast.
+  if (!(dTmp >= (double)LLONG_MIN && dTmp < (double)LLONG_MAX)) {
+    return AC_ERR_PARSE;
+  }
   if ((double)(long long)dTmp != dTmp) {
     return AC_ERR_PARSE;
   } else {

--- a/deps/rmutil/args.h
+++ b/deps/rmutil/args.h
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <stdint.h>
+#include <string.h>
 #include "hiredis/sds.h"
 #include "redismodule.h"
 
@@ -208,7 +209,20 @@ static inline const char *AC_Strerror(int code) {
 #define AC_IsAtEnd(ac) ((ac)->offset >= (ac)->argc)
 #define AC_NumRemaining(ac) ((ac)->argc - (ac)->offset)
 #define AC_NumArgs(ac) (ac)->argc
-#define AC_StringArg(ac, N) (const char *)((ac)->objs[N])
+
+/* Return the N'th argument as a C string, for any cursor type. `len` is
+ * optional. (A blind `objs[N]` cast is only valid for C-string/sds cursors —
+ * an RString cursor's objs are RedisModuleString pointers.) */
+static inline const char *AC_StringArg(const ArgsCursor *ac, size_t n, size_t *len) {
+  if (ac->type == AC_TYPE_RSTRING) {
+    return RedisModule_StringPtrLen((RedisModuleString *)ac->objs[n], len);
+  }
+  const char *s = (const char *)ac->objs[n];
+  if (len) {
+    *len = ac->type == AC_TYPE_SDS ? sdslen((sds)s) : strlen(s);
+  }
+  return s;
+}
 #ifdef __cplusplus
 }
 

--- a/deps/rmutil/test_args.c
+++ b/deps/rmutil/test_args.c
@@ -94,7 +94,56 @@ static int testTypeConversion() {
   return 0;
 }
 
+// Integer conversion through the double fallback, at and beyond the
+// representable range.
+static int testNumericConversionLimits() {
+  const char *objs[] = {NULL};
+  ArgsCursor ac;
+  ArgsCursor_InitCString(&ac, objs, 1);
+
+  long long llArg;
+  // nan has no meaningful integer value under either flag
+  PREP_ARG("nan");
+  ASSERT(AC_ERR_PARSE == AC_GetLongLong(&ac, &llArg, 0));
+  ASSERT(AC_ERR_PARSE == AC_GetLongLong(&ac, &llArg, AC_F_COALESCE));
+
+  // Out-of-range doubles: coalescing saturates by sign...
+  PREP_ARG("1e30");
+  ASSERT(0 == AC_GetLongLong(&ac, &llArg, AC_F_COALESCE));
+  ASSERT(LLONG_MAX == llArg);
+  PREP_ARG("-1e30");
+  ASSERT(0 == AC_GetLongLong(&ac, &llArg, AC_F_COALESCE));
+  ASSERT(LLONG_MIN == llArg);
+
+  // ...and plain conversion rejects: the value cannot survive the integral
+  // round-trip
+  PREP_ARG("1e30");
+  ASSERT(AC_ERR_PARSE == AC_GetLongLong(&ac, &llArg, 0));
+  PREP_ARG("-1e30");
+  ASSERT(AC_ERR_PARSE == AC_GetLongLong(&ac, &llArg, 0));
+
+  // 2^63 is the exclusive bound: rejected plain, clamped when coalescing
+  PREP_ARG("9223372036854775808");
+  ASSERT(AC_ERR_PARSE == AC_GetLongLong(&ac, &llArg, 0));
+  ASSERT(0 == AC_GetLongLong(&ac, &llArg, AC_F_COALESCE));
+  ASSERT(LLONG_MAX == llArg);
+
+  // -2^63 is exactly representable: accepted, via the double fallback (the
+  // integer path treats the strtoll LLONG_MIN return value as overflow)
+  PREP_ARG("-9223372036854775808");
+  ASSERT(0 == AC_GetLongLong(&ac, &llArg, 0));
+  ASSERT(LLONG_MIN == llArg);
+
+  // Fractional input truncates only when coalescing
+  PREP_ARG("3.99");
+  ASSERT(AC_ERR_PARSE == AC_GetLongLong(&ac, &llArg, 0));
+  ASSERT(0 == AC_GetLongLong(&ac, &llArg, AC_F_COALESCE));
+  ASSERT(3 == llArg);
+  return 0;
+}
+
 TEST_MAIN({
   TESTFUNC(testCArgs);
   TESTFUNC(testTypeConversion);
+  TESTFUNC(testNumericConversionLimits);
 })

--- a/deps/rmutil/test_args.c
+++ b/deps/rmutil/test_args.c
@@ -115,8 +115,7 @@ static int testNumericConversionLimits() {
   ASSERT(0 == AC_GetLongLong(&ac, &llArg, AC_F_COALESCE));
   ASSERT(LLONG_MIN == llArg);
 
-  // ...and plain conversion rejects: the value cannot survive the integral
-  // round-trip
+  // ...and plain conversion rejects
   PREP_ARG("1e30");
   ASSERT(AC_ERR_PARSE == AC_GetLongLong(&ac, &llArg, 0));
   PREP_ARG("-1e30");

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -557,7 +557,8 @@ AREQ *AREQ_New(void);
  * Redis-specific states and may be unit-tested. This largely just
  * compiles the options and parses the commands..
  */
-int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, uint32_t offset, bool isDiskIndex, QueryError *status);
+int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, uint32_t offset, bool isDiskIndex,
+                 QueryError *status);
 
 /**
  * Parse aggregate plan arguments (GROUPBY, APPLY, LOAD, FILTER) from an ArgsCursor.

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -480,9 +480,9 @@ static inline const char *AREQ_Query(const AREQ *req, size_t *len) {
 /* Allocate a heap BlockedRequestCtx owning the request (refcount=1), wire the
  * `brc` back-pointer, and take the argv holds (see `argv`). Main-thread
  * only; `argv` must not be NULL. */
-BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **argv, size_t argc);
+BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **argv, uint32_t argc);
 BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid,
-                                               RedisModuleString **argv, size_t argc);
+                                               RedisModuleString **argv, uint32_t argc);
 
 /* TRANSITIONAL(MOD-16691): increment / decrement the wrapper's reference
  * count. DecrRef triggers BlockedRequestCtx_Free when the count drops to

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -9,6 +9,8 @@
 #ifndef RS_AGGREGATE_H__
 #define RS_AGGREGATE_H__
 
+#include <stdint.h>
+
 #include "query_flags.h"
 #include "value_ffi.h"
 #include "query.h"
@@ -345,6 +347,9 @@ typedef struct AREQ {
 /* Forward declaration; full type lives in hybrid_request.h. */
 struct HybridRequest;
 
+/* BlockedRequestCtx.queryOffset value meaning "no query argument". */
+#define QUERY_OFFSET_NONE UINT32_MAX
+
 /**
  * Heap-allocated owning wrapper around a top-level request (AREQ or
  * HybridRequest). It is the single owner of the query and holds the
@@ -362,14 +367,19 @@ struct BlockedRequestCtx {
    * borrows from; may be a superset of the parsed slice. Taken at
    * construction, on the main thread (string refcounts are not thread safe);
    * released in BlockedRequestCtx_Free, after the owned request. */
-  RedisModuleString **argvHolds;
-  size_t nargvHolds;
+  RedisModuleString **argv;
+  uint32_t argc;
 
-  /* The owned request's parse slice within argvHolds; the query string is
-   * parseSlice[0]. Set where the query is discovered (AREQ_Compile;
-   * setSubQueryArg for hybrid subs). NULL means no query argument (a VSIM
-   * sub without FILTER, or the container). */
-  RedisModuleString **parseSlice;
+  /* The logical command length within argv — the extent parsing may
+   * read. Set with the holds at construction; the debug constructors lower
+   * it so the trailing debug params stay held but unparsed. */
+  uint32_t parseArgc;
+
+  /* Index of the owned request's query string within argv — the start
+   * of its parse slice. Set where the query is discovered (AREQ_Compile;
+   * setSubQueryArg for hybrid subs). QUERY_OFFSET_NONE means no query
+   * argument (a VSIM sub without FILTER, or the container). */
+  uint32_t queryOffset;
 
   /* Partial-timeout coordination. The CAS claim grants exclusive ownership of
    * the result-production phase: the BG-thread winner runs AggregateResults
@@ -457,17 +467,18 @@ struct BlockedRequestCtx {
 
 /* The request's query string: the first argument of its parse slice, backed
  * by the wrapper's held argv. A request with no query argument (a hybrid
- * VSIM sub-request without a FILTER) matches everything. */
+ * VSIM sub-request without a FILTER) defaults to the match-all wildcard
+ * query "*". */
 static inline const char *AREQ_Query(const AREQ *req, size_t *len) {
-  if (req->brc->parseSlice == NULL) {
+  if (req->brc->queryOffset == QUERY_OFFSET_NONE) {
     if (len) *len = 1;
     return "*";
   }
-  return RedisModule_StringPtrLen(req->brc->parseSlice[0], len);
+  return RedisModule_StringPtrLen(req->brc->argv[req->brc->queryOffset], len);
 }
 
 /* Allocate a heap BlockedRequestCtx owning the request (refcount=1), wire the
- * `brc` back-pointer, and take the argv holds (see `argvHolds`). Main-thread
+ * `brc` back-pointer, and take the argv holds (see `argv`). Main-thread
  * only; `argv` must not be NULL. */
 BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **argv, size_t argc);
 BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid,
@@ -540,11 +551,13 @@ void AREQ_DecrRef(AREQ *req);
 AREQ *AREQ_New(void);
 
 /**
- * Compile the request given the arguments. This does not rely on
+ * Compile the request from the wrapper's held argv, starting at `offset`
+ * (the query token) and reading up to the wrapper's `parseArgc` — the holds are
+ * the only string source by construction. This does not rely on
  * Redis-specific states and may be unit-tested. This largely just
  * compiles the options and parses the commands..
  */
-int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDiskIndex, QueryError *status);
+int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, uint32_t offset, bool isDiskIndex, QueryError *status);
 
 /**
  * Parse aggregate plan arguments (GROUPBY, APPLY, LOAD, FILTER) from an ArgsCursor.

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -468,8 +468,7 @@ static inline const char *AREQ_Query(const AREQ *req, size_t *len) {
 
 /* Allocate a heap BlockedRequestCtx owning the request (refcount=1), wire the
  * `brc` back-pointer, and take the argv holds (see `argvHolds`). Main-thread
- * only. `argv` may be NULL only for a request that is never parsed (parsing
- * asserts the holds are present). */
+ * only; `argv` must not be NULL. */
 BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **argv, size_t argc);
 BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid,
                                                RedisModuleString **argv, size_t argc);

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -372,7 +372,13 @@ struct BlockedRequestCtx {
    * AREQ_Compile for plain requests, setSubQueryArg for hybrid sub-requests.
    * SIZE_MAX (the constructor default) means no query argument — a hybrid
    * VSIM sub-request without a FILTER, or a hybrid container (whose tail has
-   * no query of its own). Meaningless until parsing. */
+   * no query of its own). Meaningless until parsing.
+   * Per flow: 2 for standalone commands and shard-side _FT.AGGREGATE (holds
+   * cover the full argv; the slice starts past command + index name);
+   * variable for shard-side profile commands (past the ParseProfile prefix);
+   * 1 for the hybrid SEARCH sub (stepped holds are ["SEARCH", <query>, ...]);
+   * data-dependent for the hybrid VSIM sub's optional FILTER — the one
+   * position no context hardcodes, which is why this is a stored field. */
   size_t parseOffset;
 
   /* Partial-timeout coordination. The CAS claim grants exclusive ownership of

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -376,11 +376,11 @@ struct BlockedRequestCtx {
   } query;
 
   /* Held references to the command argv strings the owned request's plan
-   * borrows from. Taken on the main thread only (string refcounts are not
-   * thread safe): by AREQ_Compile / HybridRequest_InitArgsCursor for flows
-   * that parse on the main thread, or by the coordinator dispatcher before
-   * going to the background. Released in BlockedRequestCtx_Free, after the
-   * owned request. May be a superset of the parsed slice. */
+   * borrows from. Invariant: taken at the dispatch site, on the main thread
+   * (string refcounts are not thread safe), before any parsing begins —
+   * AREQ_Compile and HybridRequest_InitArgsCursor assert they are present.
+   * Released in BlockedRequestCtx_Free, after the owned request. May be a
+   * superset of the parsed slice. */
   RedisModuleString **argvHolds;
   size_t nargvHolds;
 

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -253,16 +253,9 @@ static inline void RequestSyncState_Destroy(RequestSyncState *st) {
 }
 
 typedef struct AREQ {
-  /* Held references to the argv strings this request's plan borrows from.
-   * Taken by AREQ_Compile (main-thread parse flows), the coordinator
-   * dispatcher (BG parse flows), or HybridRequest_HoldArgv (hybrid
-   * sub-AREQs). Held and released on the main thread only. May be a superset
-   * of the parsed slice. */
-  RedisModuleString **argvHolds;
-  size_t nargvHolds;
-
-  /* Where this request's arguments start within argvHolds. Borrowed view;
-   * the references are owned by argvHolds. */
+  /* Where this request's arguments start within its wrapper's held argv
+   * (brc->argvHolds). Borrowed view; the references are owned by the
+   * wrapper. */
   RedisModuleString **parseArgv;
 
   /** Search query string (borrowed from the held argv) and its length */
@@ -373,6 +366,15 @@ struct BlockedRequestCtx {
     AREQ *areq;
     struct HybridRequest *hybrid;
   } query;
+
+  /* Held references to the command argv strings the owned request's plan
+   * borrows from. Taken on the main thread only (string refcounts are not
+   * thread safe): by AREQ_Compile / HybridRequest_InitArgsCursor for flows
+   * that parse on the main thread, or by the coordinator dispatcher before
+   * going to the background. Released in BlockedRequestCtx_Free, after the
+   * owned request. May be a superset of the parsed slice. */
+  RedisModuleString **argvHolds;
+  size_t nargvHolds;
 
   /* Partial-timeout coordination. The CAS claim grants exclusive ownership of
    * the result-production phase: the BG-thread winner runs AggregateResults
@@ -499,12 +501,10 @@ static inline struct HybridRequest *BlockedRequestCtx_GetHybrid(BlockedRequestCt
  * step makes the wrapper single-owner. */
 void AREQ_Free(AREQ *req);
 
-/* Hold references to `argv` strings whose contents this request's plan
- * borrows. Called by AREQ_Compile for flows that parse on the main thread,
- * by the coordinator dispatcher before going to the background, and by
- * HybridRequest_HoldArgv for hybrid sub-AREQs. Main-thread only; released in
- * AREQ_Free, which runs on the main thread for wrapped requests. */
-void AREQ_HoldArgv(AREQ *req, RedisModuleString **argv, size_t argc);
+/* Hold references to `argv` strings whose contents the wrapped request's
+ * plan borrows (see BlockedRequestCtx.argvHolds). Main-thread only; released
+ * in BlockedRequestCtx_Free, which runs on the main thread. */
+void BlockedRequestCtx_HoldArgv(BlockedRequestCtx *brc, RedisModuleString **argv, size_t argc);
 AREQ *AREQ_IncrRef(AREQ *req);
 void AREQ_DecrRef(AREQ *req);
 

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -481,8 +481,7 @@ static inline const char *AREQ_Query(const AREQ *req, size_t *len) {
  * `brc` back-pointer, and take the argv holds (see `argv`). Main-thread
  * only; `argv` must not be NULL. */
 BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **argv, uint32_t argc);
-BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid,
-                                               RedisModuleString **argv, uint32_t argc);
+BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid, RedisModuleString **argv, uint32_t argc);
 
 /* TRANSITIONAL(MOD-16691): increment / decrement the wrapper's reference
  * count. DecrRef triggers BlockedRequestCtx_Free when the count drops to
@@ -557,8 +556,7 @@ AREQ *AREQ_New(void);
  * Redis-specific states and may be unit-tested. This largely just
  * compiles the options and parses the commands..
  */
-int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, uint32_t offset, bool isDiskIndex,
-                 QueryError *status);
+int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, uint32_t offset, bool isDiskIndex, QueryError *status);
 
 /**
  * Parse aggregate plan arguments (GROUPBY, APPLY, LOAD, FILTER) from an ArgsCursor.

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -257,6 +257,12 @@ typedef struct AREQ {
   sds *args;
   size_t nargs;
 
+  /* Held references to argv strings this request's plan borrows from (hybrid
+   * sub-AREQs; see HybridRequest_HoldArgv). Held and released on the main
+   * thread only. */
+  RedisModuleString **argvHolds;
+  size_t nargvHolds;
+
   /** Search query string */
   const char *query;
 
@@ -489,6 +495,11 @@ static inline struct HybridRequest *BlockedRequestCtx_GetHybrid(BlockedRequestCt
  * sub-AREQs). Deleted with the wrapper refcount once the cursor-ownership
  * step makes the wrapper single-owner. */
 void AREQ_Free(AREQ *req);
+
+/* Hold references to `argv` strings whose contents this request's plan
+ * borrows (see HybridRequest_HoldArgv). Main-thread only; released in
+ * AREQ_Free, which runs on the main thread for wrapped requests. */
+void AREQ_HoldArgv(AREQ *req, RedisModuleString **argv, size_t argc);
 AREQ *AREQ_IncrRef(AREQ *req);
 void AREQ_DecrRef(AREQ *req);
 

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -253,12 +253,6 @@ static inline void RequestSyncState_Destroy(RequestSyncState *st) {
 }
 
 typedef struct AREQ {
-  /* Where this request's arguments start within its wrapper's held argv
-   * (brc->argvHolds). The first argument is the request's query string (see
-   * AREQ_Query). Borrowed view; the references are owned by the wrapper.
-   * NULL for a hybrid VSIM sub-request with no FILTER (no query argument). */
-  RedisModuleString **parseArgv;
-
   /** For hybrid queries: contains parsed vector data and partially constructed query node */
   ParsedVectorData *parsedVectorData;
 
@@ -338,7 +332,7 @@ typedef struct AREQ {
   RequestSyncState syncState;
 
   // Non-owning back-pointer to the heap wrapper that owns this request.
-  // Set for the top-level request; NULL for hybrid sub-AREQs.
+  // Every AREQ is wrapped at construction (hybrid sub-AREQs included).
   BlockedRequestCtx *brc;
 
   // Flag to indicate whether to skip timeout checks using clock checks
@@ -347,17 +341,6 @@ typedef struct AREQ {
   bool useReplyCallback;
 
 } AREQ;
-
-/* The request's query string: the first argument of its parse slice, backed
- * by the wrapper's held argv. A request with no query argument (a hybrid
- * VSIM sub-request without a FILTER) matches everything. */
-static inline const char *AREQ_Query(const AREQ *req, size_t *len) {
-  if (!req->parseArgv) {
-    if (len) *len = 1;
-    return "*";
-  }
-  return RedisModule_StringPtrLen(req->parseArgv[0], len);
-}
 
 /* Forward declaration; full type lives in hybrid_request.h. */
 struct HybridRequest;
@@ -383,6 +366,14 @@ struct BlockedRequestCtx {
    * superset of the parsed slice. */
   RedisModuleString **argvHolds;
   size_t nargvHolds;
+
+  /* Where the owned request's parse slice starts within argvHolds; the query
+   * string is argvHolds[parseOffset]. Set where the query is discovered:
+   * AREQ_Compile for plain requests, setSubQueryArg for hybrid sub-requests.
+   * SIZE_MAX (the constructor default) means no query argument — a hybrid
+   * VSIM sub-request without a FILTER, or a hybrid container (whose tail has
+   * no query of its own). Meaningless until parsing. */
+  size_t parseOffset;
 
   /* Partial-timeout coordination. The CAS claim grants exclusive ownership of
    * the result-production phase: the BG-thread winner runs AggregateResults
@@ -467,6 +458,17 @@ struct BlockedRequestCtx {
   void *registry_node;
   bool registry_node_is_cursor;
 };
+
+/* The request's query string: the first argument of its parse slice, backed
+ * by the wrapper's held argv. A request with no query argument (a hybrid
+ * VSIM sub-request without a FILTER) matches everything. */
+static inline const char *AREQ_Query(const AREQ *req, size_t *len) {
+  if (req->brc->parseOffset == SIZE_MAX) {
+    if (len) *len = 1;
+    return "*";
+  }
+  return RedisModule_StringPtrLen(req->brc->argvHolds[req->brc->parseOffset], len);
+}
 
 /* Allocate a heap BlockedRequestCtx that takes ownership of the request,
  * initializes the result-production coordination state (refcount=1), and

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -254,13 +254,10 @@ static inline void RequestSyncState_Destroy(RequestSyncState *st) {
 
 typedef struct AREQ {
   /* Where this request's arguments start within its wrapper's held argv
-   * (brc->argvHolds). Borrowed view; the references are owned by the
-   * wrapper. */
+   * (brc->argvHolds). The first argument is the request's query string (see
+   * AREQ_Query). Borrowed view; the references are owned by the wrapper.
+   * NULL for a hybrid VSIM sub-request with no FILTER (no query argument). */
   RedisModuleString **parseArgv;
-
-  /** Search query string (borrowed from the held argv) and its length */
-  const char *query;
-  size_t queryLen;
 
   /** For hybrid queries: contains parsed vector data and partially constructed query node */
   ParsedVectorData *parsedVectorData;
@@ -350,6 +347,17 @@ typedef struct AREQ {
   bool useReplyCallback;
 
 } AREQ;
+
+/* The request's query string: the first argument of its parse slice, backed
+ * by the wrapper's held argv. A request with no query argument (a hybrid
+ * VSIM sub-request without a FILTER) matches everything. */
+static inline const char *AREQ_Query(const AREQ *req, size_t *len) {
+  if (!req->parseArgv) {
+    if (len) *len = 1;
+    return "*";
+  }
+  return RedisModule_StringPtrLen(req->parseArgv[0], len);
+}
 
 /* Forward declaration; full type lives in hybrid_request.h. */
 struct HybridRequest;

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -365,12 +365,11 @@ struct BlockedRequestCtx {
   RedisModuleString **argvHolds;
   size_t nargvHolds;
 
-  /* Where the owned request's parse slice starts within argvHolds; the query
-   * string is argvHolds[parseOffset]. Set where the query is discovered
-   * (AREQ_Compile; setSubQueryArg for hybrid subs). SIZE_MAX means no query
-   * argument (a VSIM sub without FILTER, or the container). A stored field
-   * because the VSIM sub's FILTER position is data-dependent. */
-  size_t parseOffset;
+  /* The owned request's parse slice within argvHolds; the query string is
+   * parseSlice[0]. Set where the query is discovered (AREQ_Compile;
+   * setSubQueryArg for hybrid subs). NULL means no query argument (a VSIM
+   * sub without FILTER, or the container). */
+  RedisModuleString **parseSlice;
 
   /* Partial-timeout coordination. The CAS claim grants exclusive ownership of
    * the result-production phase: the BG-thread winner runs AggregateResults
@@ -460,11 +459,11 @@ struct BlockedRequestCtx {
  * by the wrapper's held argv. A request with no query argument (a hybrid
  * VSIM sub-request without a FILTER) matches everything. */
 static inline const char *AREQ_Query(const AREQ *req, size_t *len) {
-  if (req->brc->parseOffset == SIZE_MAX) {
+  if (req->brc->parseSlice == NULL) {
     if (len) *len = 1;
     return "*";
   }
-  return RedisModule_StringPtrLen(req->brc->argvHolds[req->brc->parseOffset], len);
+  return RedisModule_StringPtrLen(req->brc->parseSlice[0], len);
 }
 
 /* Allocate a heap BlockedRequestCtx owning the request (refcount=1), wire the
@@ -509,7 +508,6 @@ static inline struct HybridRequest *BlockedRequestCtx_GetHybrid(BlockedRequestCt
  * sub-AREQs). Deleted with the wrapper refcount once the cursor-ownership
  * step makes the wrapper single-owner. */
 void AREQ_Free(AREQ *req);
-
 AREQ *AREQ_IncrRef(AREQ *req);
 void AREQ_DecrRef(AREQ *req);
 

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -359,26 +359,17 @@ struct BlockedRequestCtx {
   } query;
 
   /* Held references to the command argv strings the owned request's plan
-   * borrows from. Invariant: taken at the dispatch site, on the main thread
-   * (string refcounts are not thread safe), before any parsing begins —
-   * AREQ_Compile and HybridRequest_InitArgsCursor assert they are present.
-   * Released in BlockedRequestCtx_Free, after the owned request. May be a
-   * superset of the parsed slice. */
+   * borrows from; may be a superset of the parsed slice. Taken at
+   * construction, on the main thread (string refcounts are not thread safe);
+   * released in BlockedRequestCtx_Free, after the owned request. */
   RedisModuleString **argvHolds;
   size_t nargvHolds;
 
   /* Where the owned request's parse slice starts within argvHolds; the query
-   * string is argvHolds[parseOffset]. Set where the query is discovered:
-   * AREQ_Compile for plain requests, setSubQueryArg for hybrid sub-requests.
-   * SIZE_MAX (the constructor default) means no query argument — a hybrid
-   * VSIM sub-request without a FILTER, or a hybrid container (whose tail has
-   * no query of its own). Meaningless until parsing.
-   * Per flow: 2 for standalone commands and shard-side _FT.AGGREGATE (holds
-   * cover the full argv; the slice starts past command + index name);
-   * variable for shard-side profile commands (past the ParseProfile prefix);
-   * 1 for the hybrid SEARCH sub (stepped holds are ["SEARCH", <query>, ...]);
-   * data-dependent for the hybrid VSIM sub's optional FILTER — the one
-   * position no context hardcodes, which is why this is a stored field. */
+   * string is argvHolds[parseOffset]. Set where the query is discovered
+   * (AREQ_Compile; setSubQueryArg for hybrid subs). SIZE_MAX means no query
+   * argument (a VSIM sub without FILTER, or the container). A stored field
+   * because the VSIM sub's FILTER position is data-dependent. */
   size_t parseOffset;
 
   /* Partial-timeout coordination. The CAS claim grants exclusive ownership of
@@ -476,12 +467,10 @@ static inline const char *AREQ_Query(const AREQ *req, size_t *len) {
   return RedisModule_StringPtrLen(req->brc->argvHolds[req->brc->parseOffset], len);
 }
 
-/* Allocate a heap BlockedRequestCtx that takes ownership of the request,
- * initializes the result-production coordination state (refcount=1), wires
- * the non-owning back-pointer (`brc`) on the owned request, and takes the
- * argv holds (see `argvHolds`). Main-thread only — construction is where the
- * string references are taken. `argv` may be NULL only for a request that is
- * never parsed (parsing asserts the holds are present). */
+/* Allocate a heap BlockedRequestCtx owning the request (refcount=1), wire the
+ * `brc` back-pointer, and take the argv holds (see `argvHolds`). Main-thread
+ * only. `argv` may be NULL only for a request that is never parsed (parsing
+ * asserts the holds are present). */
 BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **argv, size_t argc);
 BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid,
                                                RedisModuleString **argv, size_t argc);

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -471,10 +471,14 @@ static inline const char *AREQ_Query(const AREQ *req, size_t *len) {
 }
 
 /* Allocate a heap BlockedRequestCtx that takes ownership of the request,
- * initializes the result-production coordination state (refcount=1), and
- * wires the non-owning back-pointer (`brc`) on the owned request. */
-BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq);
-BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid);
+ * initializes the result-production coordination state (refcount=1), wires
+ * the non-owning back-pointer (`brc`) on the owned request, and takes the
+ * argv holds (see `argvHolds`). Main-thread only — construction is where the
+ * string references are taken. `argv` may be NULL only for a request that is
+ * never parsed (parsing asserts the holds are present). */
+BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **argv, size_t argc);
+BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid,
+                                               RedisModuleString **argv, size_t argc);
 
 /* TRANSITIONAL(MOD-16691): increment / decrement the wrapper's reference
  * count. DecrRef triggers BlockedRequestCtx_Free when the count drops to
@@ -511,10 +515,6 @@ static inline struct HybridRequest *BlockedRequestCtx_GetHybrid(BlockedRequestCt
  * step makes the wrapper single-owner. */
 void AREQ_Free(AREQ *req);
 
-/* Hold references to `argv` strings whose contents the wrapped request's
- * plan borrows (see BlockedRequestCtx.argvHolds). Main-thread only; released
- * in BlockedRequestCtx_Free, which runs on the main thread. */
-void BlockedRequestCtx_HoldArgv(BlockedRequestCtx *brc, RedisModuleString **argv, size_t argc);
 AREQ *AREQ_IncrRef(AREQ *req);
 void AREQ_DecrRef(AREQ *req);
 

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -474,7 +474,12 @@ static inline const char *AREQ_Query(const AREQ *req, size_t *len) {
     if (len) *len = 1;
     return "*";
   }
-  return RedisModule_StringPtrLen(req->brc->argv[req->brc->queryOffset], len);
+  const char *query = RedisModule_StringPtrLen(req->brc->argv[req->brc->queryOffset], len);
+  // TRANSITIONAL: report the C-string length, truncating at the first NUL, so a
+  // query with embedded NULs behaves as it always has.
+  // TODO: remove — the true length is what StringPtrLen already reported.
+  if (len) *len = strlen(query);
+  return query;
 }
 
 /* Allocate a heap BlockedRequestCtx owning the request (refcount=1), wire the

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -253,18 +253,21 @@ static inline void RequestSyncState_Destroy(RequestSyncState *st) {
 }
 
 typedef struct AREQ {
-  /* Arguments converted to sds. Received on input */
-  sds *args;
-  size_t nargs;
-
-  /* Held references to argv strings this request's plan borrows from (hybrid
-   * sub-AREQs; see HybridRequest_HoldArgv). Held and released on the main
-   * thread only. */
+  /* Held references to the argv strings this request's plan borrows from.
+   * Taken by AREQ_Compile (main-thread parse flows), the coordinator
+   * dispatcher (BG parse flows), or HybridRequest_HoldArgv (hybrid
+   * sub-AREQs). Held and released on the main thread only. May be a superset
+   * of the parsed slice. */
   RedisModuleString **argvHolds;
   size_t nargvHolds;
 
-  /** Search query string */
+  /* Where this request's arguments start within argvHolds. Borrowed view;
+   * the references are owned by argvHolds. */
+  RedisModuleString **parseArgv;
+
+  /** Search query string (borrowed from the held argv) and its length */
   const char *query;
+  size_t queryLen;
 
   /** For hybrid queries: contains parsed vector data and partially constructed query node */
   ParsedVectorData *parsedVectorData;
@@ -497,7 +500,9 @@ static inline struct HybridRequest *BlockedRequestCtx_GetHybrid(BlockedRequestCt
 void AREQ_Free(AREQ *req);
 
 /* Hold references to `argv` strings whose contents this request's plan
- * borrows (see HybridRequest_HoldArgv). Main-thread only; released in
+ * borrows. Called by AREQ_Compile for flows that parse on the main thread,
+ * by the coordinator dispatcher before going to the background, and by
+ * HybridRequest_HoldArgv for hybrid sub-AREQs. Main-thread only; released in
  * AREQ_Free, which runs on the main thread for wrapped requests. */
 void AREQ_HoldArgv(AREQ *req, RedisModuleString **argv, size_t argc);
 AREQ *AREQ_IncrRef(AREQ *req);

--- a/src/aggregate/aggregate_debug.c
+++ b/src/aggregate/aggregate_debug.c
@@ -54,9 +54,10 @@ AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *statu
   debug_req->debug_params = debug_params;
 
   AREQ *r = &debug_req->r;
-  // Wrap the debug AREQ in its single-owner sync context.
+  // Wrap the debug AREQ in its single-owner sync context, holding the full
+  // argv (a superset: callers trim the debug tail off the parsed argc).
   // Must be called after rm_realloc so r points to stable memory.
-  BlockedRequestCtx_NewAREQ(r);
+  BlockedRequestCtx_NewAREQ(r, argv, argc);
   AREQ_AddRequestFlags(r, QEXEC_F_DEBUG);
 
   return debug_req;

--- a/src/aggregate/aggregate_debug.c
+++ b/src/aggregate/aggregate_debug.c
@@ -54,9 +54,10 @@ AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *statu
   debug_req->debug_params = debug_params;
 
   AREQ *r = &debug_req->r;
-  // Holds the full argv (callers trim the debug tail off the parsed argc).
-  // Must be called after rm_realloc so r points to stable memory.
+  // Holds the full argv; `parseArgc` excludes the debug tail so parsing stops
+  // before it. Must be called after rm_realloc so r points to stable memory.
   BlockedRequestCtx_NewAREQ(r, argv, argc);
+  r->brc->parseArgc = (uint32_t)(argc - debug_argv_count);
   AREQ_AddRequestFlags(r, QEXEC_F_DEBUG);
 
   return debug_req;

--- a/src/aggregate/aggregate_debug.c
+++ b/src/aggregate/aggregate_debug.c
@@ -54,8 +54,7 @@ AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *statu
   debug_req->debug_params = debug_params;
 
   AREQ *r = &debug_req->r;
-  // Wrap the debug AREQ in its single-owner sync context, holding the full
-  // argv (a superset: callers trim the debug tail off the parsed argc).
+  // Holds the full argv (callers trim the debug tail off the parsed argc).
   // Must be called after rm_realloc so r points to stable memory.
   BlockedRequestCtx_NewAREQ(r, argv, argc);
   AREQ_AddRequestFlags(r, QEXEC_F_DEBUG);

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1543,10 +1543,9 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
   return rc;
 }
 
-static int buildRequest(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int type,
-                        QueryError *status, AREQ **r) {
+static int buildRequest(RedisModuleCtx *ctx, int type, QueryError *status, AREQ **r) {
   int rc = REDISMODULE_ERR;
-  const char *indexname = RedisModule_StringPtrLen(argv[1], NULL);
+  const char *indexname = RedisModule_StringPtrLen((*r)->brc->argv[1], NULL);
   RedisSearchCtx *sctx = NULL;
   RedisModuleCtx *thctx = NULL;
 
@@ -1559,7 +1558,8 @@ static int buildRequest(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
 
   AREQ_AddRequestFlags(*r, QEXEC_FORMAT_DEFAULT);
 
-  if (AREQ_Compile(*r, ctx, argv + 2, argc - 2, SearchDisk_IsEnabledForValidation(), status) != REDISMODULE_OK) {
+  if (AREQ_Compile(*r, ctx, 2 /* past the command and index names */,
+                   SearchDisk_IsEnabledForValidation(), status) != REDISMODULE_OK) {
     RS_LOG_ASSERT(QueryError_HasError(status), "Query has error");
     goto done;
   }
@@ -1600,11 +1600,12 @@ done:
   return rc;
 }
 
-static int prepareRequest(AREQ **r_ptr, RedisModuleCtx *ctx, RedisModuleString **argv, int argc, CommandType type, ProfileOptions profileOptions, QueryError *status) {
+static int prepareRequest(AREQ **r_ptr, RedisModuleCtx *ctx, CommandType type, ProfileOptions profileOptions, QueryError *status) {
   AREQ *r = *r_ptr;
-  // If we got here, we know `argv[0]` is a valid registered command name.
-  // If it starts with an underscore, it is an internal command.
-  if (RedisModule_StringPtrLen(argv[0], NULL)[0] == '_') {
+  // If we got here, we know the command name (the first held argument) is a
+  // valid registered command. If it starts with an underscore, it is an
+  // internal command.
+  if (RedisModule_StringPtrLen(r->brc->argv[0], NULL)[0] == '_') {
     AREQ_AddRequestFlags(r, QEXEC_F_INTERNAL);
   }
 
@@ -1619,7 +1620,7 @@ static int prepareRequest(AREQ **r_ptr, RedisModuleCtx *ctx, RedisModuleString *
   // This function also builds the RedisSearchCtx
   // It will search for the spec according to the name given in the argv array,
   // and ensure the spec is valid.
-  if (buildRequest(ctx, argv, argc, type, status, r_ptr) != REDISMODULE_OK) {
+  if (buildRequest(ctx, type, status, r_ptr) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
 
@@ -2083,7 +2084,7 @@ int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
   AREQ *r = AREQ_New();
   BlockedRequestCtx_NewAREQ(r, argv, argc);
 
-  if (prepareRequest(&r, ctx, r->brc->argvHolds, argc, type, profileOptions, &status) != REDISMODULE_OK) {
+  if (prepareRequest(&r, ctx, type, profileOptions, &status) != REDISMODULE_OK) {
     RS_ASSERT(r == NULL);
     if (QueryError_GetCode(&status) == QUERY_ERROR_CODE_TIMED_OUT) {
       return replyForPreExecutionTimeout(ctx, argv, argc, profileOptions, &status);
@@ -2121,7 +2122,7 @@ char *RS_GetExplainOutput(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
                           QueryError *status) {
   AREQ *r = AREQ_New();
   BlockedRequestCtx_NewAREQ(r, argv, argc);
-  if (buildRequest(ctx, r->brc->argvHolds, argc, COMMAND_EXPLAIN, status, &r) != REDISMODULE_OK) {
+  if (buildRequest(ctx, COMMAND_EXPLAIN, status, &r) != REDISMODULE_OK) {
     return NULL;
   }
   RedisSearchCtx *sctx = AREQ_SearchCtx(r);
@@ -2735,9 +2736,10 @@ int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   debug_params = debug_req->debug_params;
 
   debug_argv_count = debug_params.debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
-  // Parse the query, not including the debug params (the holds cover the full argv)
+  // Parsing stops before the debug params: the constructor set the wrapper's
+  // `parseArgc` below the debug tail (the holds still cover the full argv).
 
-  if (prepareRequest(&r, ctx, r->brc->argvHolds, argc - debug_argv_count, type, profileOptions, &status) != REDISMODULE_OK) {
+  if (prepareRequest(&r, ctx, type, profileOptions, &status) != REDISMODULE_OK) {
     RS_ASSERT(r == NULL);
     if (QueryError_GetCode(&status) == QUERY_ERROR_CODE_TIMED_OUT) {
       return replyForPreExecutionTimeout(ctx, argv, argc - debug_argv_count, profileOptions, &status);

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1258,10 +1258,8 @@ static void blockedClientReqCtx_destroy(blockedClientReqCtx *BCRctx) {
   // the owner clears it via blockedClientReqCtx_setRequest(BCRctx, NULL),
   // so this conditional avoids a double-decr while still handling error paths
   // where AREQ_Execute() is never called.
-  // Must precede UnblockClient: once the client is unblocked, the main thread
-  // may run OnFree and drop the cycle reference, and a release from here
-  // would then be the final one — freeing the wrapper, and the module
-  // strings it holds, off the main thread.
+  // Must precede UnblockClient: once unblocked, the main thread may drop the
+  // cycle reference, making this release the final one — off the main thread.
   if (BCRctx->req) {
     AREQ_DecrRef(BCRctx->req);
     BCRctx->req = NULL;
@@ -2083,9 +2081,6 @@ int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
   }
 
   AREQ *r = AREQ_New();
-  // Construction takes the argv holds (here, on the main thread); parsing
-  // reads from them, and the plan's borrows outlive this handler (cursors,
-  // worker execution).
   BlockedRequestCtx_NewAREQ(r, argv, argc);
 
   if (prepareRequest(&r, ctx, r->brc->argvHolds, argc, type, profileOptions, &status) != REDISMODULE_OK) {
@@ -2740,8 +2735,7 @@ int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   debug_params = debug_req->debug_params;
 
   debug_argv_count = debug_params.debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
-  // Parse the query, not including debug params (the holds, taken by
-  // AREQ_Debug_New, cover the full argv — a superset)
+  // Parse the query, not including the debug params (the holds cover the full argv)
 
   if (prepareRequest(&r, ctx, r->brc->argvHolds, argc - debug_argv_count, type, profileOptions, &status) != REDISMODULE_OK) {
     RS_ASSERT(r == NULL);

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -2080,8 +2080,11 @@ int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
 
   AREQ *r = AREQ_New();
   BlockedRequestCtx_NewAREQ(r);
+  // Hold the argv here, on the main thread, and parse from the holds: the
+  // plan's borrows must outlive this handler (cursors, worker execution).
+  BlockedRequestCtx_HoldArgv(r->brc, argv, argc);
 
-  if (prepareRequest(&r, ctx, argv, argc, type, profileOptions, &status) != REDISMODULE_OK) {
+  if (prepareRequest(&r, ctx, r->brc->argvHolds, argc, type, profileOptions, &status) != REDISMODULE_OK) {
     RS_ASSERT(r == NULL);
     if (QueryError_GetCode(&status) == QUERY_ERROR_CODE_TIMED_OUT) {
       return replyForPreExecutionTimeout(ctx, argv, argc, profileOptions, &status);
@@ -2119,7 +2122,8 @@ char *RS_GetExplainOutput(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
                           QueryError *status) {
   AREQ *r = AREQ_New();
   BlockedRequestCtx_NewAREQ(r);
-  if (buildRequest(ctx, argv, argc, COMMAND_EXPLAIN, status, &r) != REDISMODULE_OK) {
+  BlockedRequestCtx_HoldArgv(r->brc, argv, argc);
+  if (buildRequest(ctx, r->brc->argvHolds, argc, COMMAND_EXPLAIN, status, &r) != REDISMODULE_OK) {
     return NULL;
   }
   RedisSearchCtx *sctx = AREQ_SearchCtx(r);
@@ -2733,9 +2737,12 @@ int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   debug_params = debug_req->debug_params;
 
   debug_argv_count = debug_params.debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
+  // Hold the full argv (a superset: the debug tail is trimmed off the parsed
+  // argc below, and separately held by AREQ_Debug_New).
+  BlockedRequestCtx_HoldArgv(r->brc, argv, argc);
   // Parse the query, not including debug params
 
-  if (prepareRequest(&r, ctx, argv, argc - debug_argv_count, type, profileOptions, &status) != REDISMODULE_OK) {
+  if (prepareRequest(&r, ctx, r->brc->argvHolds, argc - debug_argv_count, type, profileOptions, &status) != REDISMODULE_OK) {
     RS_ASSERT(r == NULL);
     if (QueryError_GetCode(&status) == QUERY_ERROR_CODE_TIMED_OUT) {
       return replyForPreExecutionTimeout(ctx, argv, argc - debug_argv_count, profileOptions, &status);

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1600,8 +1600,7 @@ done:
   return rc;
 }
 
-static int prepareRequest(AREQ **r_ptr, RedisModuleCtx *ctx, CommandType type,
-                          ProfileOptions profileOptions, QueryError *status) {
+static int prepareRequest(AREQ **r_ptr, RedisModuleCtx *ctx, CommandType type, ProfileOptions profileOptions, QueryError *status) {
   AREQ *r = *r_ptr;
   // If we got here, we know the command name (the first held argument) is a
   // valid registered command. If it starts with an underscore, it is an

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1253,19 +1253,23 @@ static void blockedClientReqCtx_setRequest(blockedClientReqCtx *BCRctx, AREQ *re
 }
 
 static void blockedClientReqCtx_destroy(blockedClientReqCtx *BCRctx) {
-  RedisModule_BlockedClientMeasureTimeEnd(BCRctx->blockedClient);
-  void *privdata = RedisModule_BlockClientGetPrivateData(BCRctx->blockedClient);
-  RedisModule_UnblockClient(BCRctx->blockedClient, privdata);
-
   // Release the owned AREQ reference if it has not already been released.
   // On the normal success path, AREQ_Execute() releases the reference and
   // the owner clears it via blockedClientReqCtx_setRequest(BCRctx, NULL),
   // so this conditional avoids a double-decr while still handling error paths
   // where AREQ_Execute() is never called.
+  // Must precede UnblockClient: once the client is unblocked, the main thread
+  // may run OnFree and drop the cycle reference, and a release from here
+  // would then be the final one — freeing the wrapper, and the module
+  // strings it holds, off the main thread.
   if (BCRctx->req) {
     AREQ_DecrRef(BCRctx->req);
     BCRctx->req = NULL;
   }
+
+  RedisModule_BlockedClientMeasureTimeEnd(BCRctx->blockedClient);
+  void *privdata = RedisModule_BlockClientGetPrivateData(BCRctx->blockedClient);
+  RedisModule_UnblockClient(BCRctx->blockedClient, privdata);
 
   WeakRef_Release(BCRctx->spec_ref);
   rm_free(BCRctx);

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -2079,10 +2079,10 @@ int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
   }
 
   AREQ *r = AREQ_New();
-  BlockedRequestCtx_NewAREQ(r);
-  // Hold the argv here, on the main thread, and parse from the holds: the
-  // plan's borrows must outlive this handler (cursors, worker execution).
-  BlockedRequestCtx_HoldArgv(r->brc, argv, argc);
+  // Construction takes the argv holds (here, on the main thread); parsing
+  // reads from them, and the plan's borrows outlive this handler (cursors,
+  // worker execution).
+  BlockedRequestCtx_NewAREQ(r, argv, argc);
 
   if (prepareRequest(&r, ctx, r->brc->argvHolds, argc, type, profileOptions, &status) != REDISMODULE_OK) {
     RS_ASSERT(r == NULL);
@@ -2121,8 +2121,7 @@ int RSExecuteAggregateOrSearch(RedisModuleCtx *ctx, RedisModuleString **argv, in
 char *RS_GetExplainOutput(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                           QueryError *status) {
   AREQ *r = AREQ_New();
-  BlockedRequestCtx_NewAREQ(r);
-  BlockedRequestCtx_HoldArgv(r->brc, argv, argc);
+  BlockedRequestCtx_NewAREQ(r, argv, argc);
   if (buildRequest(ctx, r->brc->argvHolds, argc, COMMAND_EXPLAIN, status, &r) != REDISMODULE_OK) {
     return NULL;
   }
@@ -2737,10 +2736,8 @@ int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   debug_params = debug_req->debug_params;
 
   debug_argv_count = debug_params.debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
-  // Hold the full argv (a superset: the debug tail is trimmed off the parsed
-  // argc below, and separately held by AREQ_Debug_New).
-  BlockedRequestCtx_HoldArgv(r->brc, argv, argc);
-  // Parse the query, not including debug params
+  // Parse the query, not including debug params (the holds, taken by
+  // AREQ_Debug_New, cover the full argv — a superset)
 
   if (prepareRequest(&r, ctx, r->brc->argvHolds, argc - debug_argv_count, type, profileOptions, &status) != REDISMODULE_OK) {
     RS_ASSERT(r == NULL);

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1600,7 +1600,8 @@ done:
   return rc;
 }
 
-static int prepareRequest(AREQ **r_ptr, RedisModuleCtx *ctx, CommandType type, ProfileOptions profileOptions, QueryError *status) {
+static int prepareRequest(AREQ **r_ptr, RedisModuleCtx *ctx, CommandType type,
+                          ProfileOptions profileOptions, QueryError *status) {
   AREQ *r = *r_ptr;
   // If we got here, we know the command name (the first held argument) is a
   // valid registered command. If it starts with an underscore, it is an

--- a/src/aggregate/aggregate_plan.c
+++ b/src/aggregate/aggregate_plan.c
@@ -328,7 +328,7 @@ void AGPLN_Dump(const AGGPlan *pln) {
       case PLN_T_LOAD: {
         const PLN_LoadStep *lstp = (PLN_LoadStep *)stp;
         for (size_t ii = 0; ii < lstp->args.argc; ++ii) {
-          printf("  %s\n", (char *)lstp->args.objs[ii]);
+          printf("  %s\n", AC_StringArg(&lstp->args, ii, NULL));
         }
         break;
       }
@@ -346,7 +346,7 @@ void AGPLN_Dump(const AGGPlan *pln) {
             printf("    ARGS:[");
           }
           for (size_t jj = 0; jj < r->args.argc; ++jj) {
-            printf("%s ", (char *)r->args.objs[jj]);
+            printf("%s ", AC_StringArg(&r->args, jj, NULL));
           }
           printf("]\n");
         }
@@ -375,7 +375,7 @@ static inline void append_uint(myArgArray_t *arr, unsigned long long ll) {
 }
 static inline void append_ac(myArgArray_t *arr, const ArgsCursor *ac) {
   for (size_t ii = 0; ii < ac->argc; ++ii) {
-    append_string(arr, AC_StringArg(ac, ii));
+    append_string(arr, AC_StringArg(ac, ii, NULL));
   }
 }
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1407,16 +1407,12 @@ static bool shouldCheckInPipelineTimeout(RedisModuleCtx* ctx, AREQ *req) {
 int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDiskIndex, QueryError *status) {
   BlockedRequestCtx *brc = req->brc;
   RS_ASSERT(brc != NULL);
-  if (!brc->argvHolds) {
-    // Parsing on the main thread with the caller's argv: hold references so
-    // the plan's borrows stay valid for the request's lifetime. Flows that
-    // parse on a background thread hold the argv at dispatch (on the main
-    // thread) and pass a slice of the holds here instead.
-    BlockedRequestCtx_HoldArgv(brc, argv, argc);
-    argv = brc->argvHolds;
-  } else {
-    RS_ASSERT(brc->argvHolds <= argv && argv + argc <= brc->argvHolds + brc->nargvHolds);
-  }
+  // The dispatch site held the argv on the main thread and passes a slice of
+  // the holds here; the plan's borrows stay valid for the request's lifetime.
+  // Holding lazily instead would touch string refcounts on whatever thread
+  // parses, and refcounts are main-thread-only.
+  RS_ASSERT(brc->argvHolds != NULL);
+  RS_ASSERT(brc->argvHolds <= argv && argv + argc <= brc->argvHolds + brc->nargvHolds);
   req->parseArgv = argv;
 
   // Parse the query and basic keywords first..

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1565,13 +1565,9 @@ static int applyGlobalFilters(RSSearchOptions *opts, QueryAST *ast, const RedisS
   }
 
   if (opts->inkeys) {
-    // The id-filter chain (including its Rust evaluation) consumes
-    // (pointer, length) views; build them over the held argv strings.
-    RSStringView *keys = rm_malloc(sizeof(*keys) * opts->ninkeys);
-    for (size_t ii = 0; ii < opts->ninkeys; ++ii) {
-      keys[ii].data = RedisModule_StringPtrLen(opts->inkeys[ii], &keys[ii].len);
-    }
-    QAST_GlobalFilterOptions filterOpts = {.keys = keys, .nkeys = opts->ninkeys};
+    // inkeys is a window into the held argv, which outlives the AST; the
+    // id-filter node borrows it as-is.
+    QAST_GlobalFilterOptions filterOpts = {.keys = opts->inkeys, .nkeys = opts->ninkeys};
 
     // For SearchDisk, resolve docIds from keys on the main thread
     if (SearchDisk_IsEnabled()) {
@@ -1589,9 +1585,6 @@ static int applyGlobalFilters(RSSearchOptions *opts, QueryAST *ast, const RedisS
 
     QAST_SetGlobalFilters(ast, &filterOpts);
     // Non-NULL only if the transfer to the query node did not happen.
-    if (filterOpts.keys) {
-      rm_free(filterOpts.keys);
-    }
     if (filterOpts.docIds) {
       rm_free(filterOpts.docIds);
     }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1152,6 +1152,7 @@ bool SearchTime_IsTimedOut(void *arg) {
 static BlockedRequestCtx *BlockedRequestCtx_NewCommon(RequestKind kind) {
   BlockedRequestCtx *brc = rm_calloc(1, sizeof(BlockedRequestCtx));
   brc->kind = kind;
+  brc->parseOffset = SIZE_MAX;  // "no query argument" until parsing finds one
   brc->refcount = 1;
   brc->requiresAggregateResultsSync = false;
   brc->aggregatingResults = false;
@@ -1413,7 +1414,7 @@ int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int a
   // parses, and refcounts are main-thread-only.
   RS_ASSERT(brc->argvHolds != NULL);
   RS_ASSERT(brc->argvHolds <= argv && argv + argc <= brc->argvHolds + brc->nargvHolds);
-  req->parseArgv = argv;
+  brc->parseOffset = argv - brc->argvHolds;
 
   // Parse the query and basic keywords first..
   ArgsCursor ac = {0};
@@ -1424,7 +1425,7 @@ int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int a
     return REDISMODULE_ERR;
   }
 
-  AC_Advance(&ac);  // The query string: parseArgv[0], read via AREQ_Query
+  AC_Advance(&ac);  // The query string: argvHolds[parseOffset], read via AREQ_Query
   initializeAREQ(req);
   RSSearchOptions *searchOpts = &req->searchopts;
   ParseAggPlanContext papCtx;
@@ -1604,7 +1605,7 @@ static bool IsIndexCoherent(AREQ *req) {
     return true;
   }
 
-  RedisModuleString **args = req->parseArgv;
+  RedisModuleString **args = req->brc->argvHolds + req->brc->parseOffset;
   long long n_prefixes = 0;
   RedisModule_StringToLongLong(args[req->prefixesOffset + 1], &n_prefixes);
   // The first argument is at req->prefixesOffset + 2

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -61,6 +61,7 @@
 #include "rlookup.h"
 #include "rlookup_ffi.h"
 #include "rmalloc.h"
+#include "util/misc.h"
 #include "rmutil/args.h"
 #include "rmutil/rm_assert.h"
 #include "rqe_core.h"
@@ -1152,7 +1153,7 @@ bool SearchTime_IsTimedOut(void *arg) {
 static BlockedRequestCtx *BlockedRequestCtx_NewCommon(RequestKind kind) {
   BlockedRequestCtx *brc = rm_calloc(1, sizeof(BlockedRequestCtx));
   brc->kind = kind;
-  brc->parseSlice = NULL;  // "no query argument" until parsing finds one
+  brc->queryOffset = QUERY_OFFSET_NONE;  // "no query argument" until parsing finds one
   brc->refcount = 1;
   brc->requiresAggregateResultsSync = false;
   brc->aggregatingResults = false;
@@ -1179,20 +1180,41 @@ void BlockedRequestCtx_DecrRef(BlockedRequestCtx *brc) {
 }
 
 /* Hold references to `argv` strings whose contents the wrapped request's
- * plan borrows (see BlockedRequestCtx.argvHolds). Runs at construction, on
+ * plan borrows (see BlockedRequestCtx.argv). Runs at construction, on
  * the main thread; released in BlockedRequestCtx_Free, also on main. */
 static void holdArgv(BlockedRequestCtx *brc, RedisModuleString **argv, size_t argc) {
   RS_ASSERT(argv != NULL);
-  RS_ASSERT(brc->argvHolds == NULL);
-  brc->argvHolds = rm_malloc(argc * sizeof(*brc->argvHolds));
-  brc->nargvHolds = argc;
+  RS_ASSERT(brc->argv == NULL);
+  brc->argv = rm_malloc(argc * sizeof(*brc->argv));
+  brc->argc = (uint32_t)argc;
+  brc->parseArgc = (uint32_t)argc;  // debug constructors lower it to exclude the debug tail
   for (size_t ii = 0; ii < argc; ++ii) {
-    brc->argvHolds[ii] = RedisModule_HoldString(NULL, argv[ii]);
+    brc->argv[ii] = RedisModule_HoldString(NULL, argv[ii]);
     // Redis auto-trims (reallocates) retained argv right after the command
     // callback returns — racing any thread already reading the string. Trim
     // here instead, before any borrow exists or a worker can see it.
-    RedisModule_TrimStringAllocation(brc->argvHolds[ii]);
+    RedisModule_TrimStringAllocation(brc->argv[ii]);
   }
+}
+
+/* Release an argv array taken by holdArgv: drop each string reference and
+ * free the array. Main-thread only (string refcounts are not thread safe). */
+static void releaseArgv(RedisModuleString **argv, uint32_t argc) {
+  for (uint32_t ii = 0; ii < argc; ++ii) {
+    RedisModule_FreeString(NULL, argv[ii]);
+  }
+  rm_free(argv);
+}
+
+typedef struct {
+  RedisModuleString **argv;
+  uint32_t argc;
+} DeferredArgvRelease;
+
+static void releaseArgvOnMainThread(void *privdata) {
+  DeferredArgvRelease *deferred = privdata;
+  releaseArgv(deferred->argv, deferred->argc);
+  rm_free(deferred);
 }
 
 BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **argv, size_t argc) {
@@ -1232,12 +1254,20 @@ void BlockedRequestCtx_Free(BlockedRequestCtx *brc) {
   } else {
     HybridRequest_Free(brc->query.hybrid);
   }
-  if (brc->argvHolds) {
-    // After the request: its plan borrows from these strings
-    for (size_t ii = 0; ii < brc->nargvHolds; ++ii) {
-      RedisModule_FreeString(NULL, brc->argvHolds[ii]);
-    }
-    rm_free(brc->argvHolds);
+  // Every wrapper is born with its holds (construction invariant), released
+  // after the request: its plan borrows from these strings.
+  RS_ASSERT(brc->argv != NULL);
+  if (MainThread_Is()) {
+    releaseArgv(brc->argv, brc->argc);
+  } else {
+    // String references may only be released on the main thread; bounce the
+    // release to the main event loop. The API exists on every supported
+    // server (Redis 7+) and only fails on a NULL callback.
+    DeferredArgvRelease *deferred = rm_malloc(sizeof(*deferred));
+    *deferred = (DeferredArgvRelease){.argv = brc->argv, .argc = brc->argc};
+    int rc = RedisModule_EventLoopAddOneShot(releaseArgvOnMainThread, deferred);
+    RS_ASSERT(rc == REDISMODULE_OK);
+    (void)rc;
   }
   rm_free(brc);
 }
@@ -1424,24 +1454,22 @@ static bool shouldCheckInPipelineTimeout(RedisModuleCtx* ctx, AREQ *req) {
 
 }
 
-int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDiskIndex, QueryError *status) {
+int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, uint32_t offset, bool isDiskIndex, QueryError *status) {
   BlockedRequestCtx *brc = req->brc;
   RS_ASSERT(brc != NULL);
-  // `argv` must be a slice of the holds taken at construction — holding here
-  // instead would touch string refcounts on whatever thread parses.
-  RS_ASSERT(brc->argvHolds <= argv && argv + argc <= brc->argvHolds + brc->nargvHolds);
-  brc->parseSlice = argv;
+  RS_ASSERT(offset <= brc->parseArgc && brc->parseArgc <= brc->argc);
+  brc->queryOffset = offset;
 
   // Parse the query and basic keywords first..
   ArgsCursor ac = {0};
-  ArgsCursor_InitRString(&ac, argv, argc);
+  ArgsCursor_InitRString(&ac, brc->argv + offset, brc->parseArgc - offset);
 
   if (AC_IsAtEnd(&ac)) {
     QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "No query string provided");
     return REDISMODULE_ERR;
   }
 
-  AC_Advance(&ac);  // The query string: parseSlice[0], read via AREQ_Query
+  AC_Advance(&ac);  // The query string: argv[queryOffset], read via AREQ_Query
   initializeAREQ(req);
   RSSearchOptions *searchOpts = &req->searchopts;
   ParseAggPlanContext papCtx;
@@ -1614,7 +1642,7 @@ static bool IsIndexCoherent(AREQ *req) {
     return true;
   }
 
-  RedisModuleString **args = req->brc->parseSlice;
+  RedisModuleString **args = req->brc->argv + req->brc->queryOffset;
   long long n_prefixes = 0;
   RedisModule_StringToLongLong(args[req->prefixesOffset + 1], &n_prefixes);
   // The first argument is at req->prefixesOffset + 2

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1918,9 +1918,27 @@ void AREQ_Free(AREQ *req) {
 
   rm_free(req->args);
 
+  if (req->argvHolds) {
+    // Runs on the main thread (wrapper OnFree / container free): argv string
+    // refcounts are not thread safe.
+    for (size_t ii = 0; ii < req->nargvHolds; ++ii) {
+      RedisModule_FreeString(NULL, req->argvHolds[ii]);
+    }
+    rm_free(req->argvHolds);
+  }
+
   RequestSyncState_Destroy(&req->syncState);
 
   rm_free(req);
+}
+
+void AREQ_HoldArgv(AREQ *req, RedisModuleString **argv, size_t argc) {
+  RS_ASSERT(req->argvHolds == NULL);
+  req->argvHolds = rm_calloc(argc, sizeof(*req->argvHolds));
+  req->nargvHolds = argc;
+  for (size_t ii = 0; ii < argc; ++ii) {
+    req->argvHolds[ii] = RedisModule_HoldString(NULL, argv[ii]);
+  }
 }
 
 void AREQ_CleanUpStoredCursor(AREQ *req) {

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1178,21 +1178,40 @@ void BlockedRequestCtx_DecrRef(BlockedRequestCtx *brc) {
   }
 }
 
-BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq) {
+/* Hold references to `argv` strings whose contents the wrapped request's
+ * plan borrows (see BlockedRequestCtx.argvHolds). Runs at construction, on
+ * the main thread; released in BlockedRequestCtx_Free, also on main. */
+static void holdArgv(BlockedRequestCtx *brc, RedisModuleString **argv, size_t argc) {
+  RS_ASSERT(brc->argvHolds == NULL);
+  brc->argvHolds = rm_malloc(argc * sizeof(*brc->argvHolds));
+  brc->nargvHolds = argc;
+  for (size_t ii = 0; ii < argc; ++ii) {
+    brc->argvHolds[ii] = RedisModule_HoldString(NULL, argv[ii]);
+  }
+}
+
+BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **argv, size_t argc) {
   // Wrapping an already-wrapped request would silently leak the first wrapper.
   RS_ASSERT(areq->brc == NULL);
   BlockedRequestCtx *brc = BlockedRequestCtx_NewCommon(REQUEST_KIND_AREQ);
   brc->query.areq = areq;
   areq->brc = brc;
+  if (argv) {
+    holdArgv(brc, argv, argc);
+  }
   return brc;
 }
 
-BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid) {
+BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid,
+                                               RedisModuleString **argv, size_t argc) {
   // Wrapping an already-wrapped request would silently leak the first wrapper.
   RS_ASSERT(hybrid->brc == NULL);
   BlockedRequestCtx *brc = BlockedRequestCtx_NewCommon(REQUEST_KIND_HYBRID);
   brc->query.hybrid = hybrid;
   hybrid->brc = brc;
+  if (argv) {
+    holdArgv(brc, argv, argc);
+  }
   return brc;
 }
 
@@ -1930,15 +1949,6 @@ void AREQ_Free(AREQ *req) {
   RequestSyncState_Destroy(&req->syncState);
 
   rm_free(req);
-}
-
-void BlockedRequestCtx_HoldArgv(BlockedRequestCtx *brc, RedisModuleString **argv, size_t argc) {
-  RS_ASSERT(brc->argvHolds == NULL);
-  brc->argvHolds = rm_malloc(argc * sizeof(*brc->argvHolds));
-  brc->nargvHolds = argc;
-  for (size_t ii = 0; ii < argc; ++ii) {
-    brc->argvHolds[ii] = RedisModule_HoldString(NULL, argv[ii]);
-  }
 }
 
 void AREQ_CleanUpStoredCursor(AREQ *req) {

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1437,7 +1437,7 @@ int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int a
     return REDISMODULE_ERR;
   }
 
-  req->query = AC_GetStringNC(&ac, &req->queryLen);
+  AC_Advance(&ac);  // The query string: parseArgv[0], read via AREQ_Query
   initializeAREQ(req);
   RSSearchOptions *searchOpts = &req->searchopts;
   ParseAggPlanContext papCtx;
@@ -1768,7 +1768,9 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   bool skipParse = req->parsedVectorData && req->parsedVectorData->skipFilterIntegration;
 
   if (!skipParse) {
-    int rv = QAST_Parse(ast, sctx, opts, req->query, req->queryLen, dialectVersion, status);
+    size_t queryLen;
+    const char *query = AREQ_Query(req, &queryLen);
+    int rv = QAST_Parse(ast, sctx, opts, query, queryLen, dialectVersion, status);
     if (rv != REDISMODULE_OK) {
       return REDISMODULE_ERR;
     }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1227,8 +1227,7 @@ BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **arg
   return brc;
 }
 
-BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid,
-                                               RedisModuleString **argv, uint32_t argc) {
+BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid, RedisModuleString **argv, uint32_t argc) {
   // Wrapping an already-wrapped request would silently leak the first wrapper.
   RS_ASSERT(hybrid->brc == NULL);
   BlockedRequestCtx *brc = BlockedRequestCtx_NewCommon(REQUEST_KIND_HYBRID);
@@ -1453,8 +1452,7 @@ static bool shouldCheckInPipelineTimeout(RedisModuleCtx* ctx, AREQ *req) {
 
 }
 
-int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, uint32_t offset, bool isDiskIndex,
-                 QueryError *status) {
+int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, uint32_t offset, bool isDiskIndex, QueryError *status) {
   BlockedRequestCtx *brc = req->brc;
   RS_ASSERT(brc != NULL);
   RS_ASSERT(offset <= brc->parseArgc && brc->parseArgc <= brc->argc);

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -777,19 +777,10 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
     return REDISMODULE_ERR;
   }
 
-  // INKEYS: the id-filter evaluation (including its Rust side) consumes sds
-  // keys; materialize owned copies of just these args.
-  if (inKeys.argc) {
-    searchOpts->inkeys = rm_malloc(sizeof(*searchOpts->inkeys) * inKeys.argc);
-    for (size_t ii = 0; ii < inKeys.argc; ++ii) {
-      size_t n;
-      const char *s = AC_StringArg(&inKeys, ii, &n);
-      searchOpts->inkeys[ii] = sdsnewlen(s, n);
-    }
-  }
+  // INKEYS / INFIELDS: sub-cursors of the parse cursor; objs are
+  // RedisModuleString pointers, borrowed from the request's held argv.
+  searchOpts->inkeys = (RedisModuleString **)inKeys.objs;
   searchOpts->ninkeys = inKeys.argc;
-  // INFIELDS: a sub-cursor of the parse cursor; objs are RedisModuleString
-  // pointers, borrowed from the request's held argv.
   searchOpts->legacy.infields = (RedisModuleString **)inFields.objs;
   searchOpts->legacy.ninfields = inFields.argc;
   // if language is NULL, set it to RS_LANG_UNSET and it will be updated
@@ -1577,25 +1568,33 @@ static int applyGlobalFilters(RSSearchOptions *opts, QueryAST *ast, const RedisS
   }
 
   if (opts->inkeys) {
-    QAST_GlobalFilterOptions filterOpts = {.keys = opts->inkeys, .nkeys = opts->ninkeys};
+    // The id-filter chain (including its Rust evaluation) consumes
+    // (pointer, length) views; build them over the held argv strings.
+    RSStringView *keys = rm_malloc(sizeof(*keys) * opts->ninkeys);
+    for (size_t ii = 0; ii < opts->ninkeys; ++ii) {
+      keys[ii].data = RedisModule_StringPtrLen(opts->inkeys[ii], &keys[ii].len);
+    }
+    QAST_GlobalFilterOptions filterOpts = {.keys = keys, .nkeys = opts->ninkeys};
 
     // For SearchDisk, resolve docIds from keys on the main thread
     if (SearchDisk_IsEnabled()) {
       filterOpts.docIds = rm_malloc(sizeof(t_docId) * opts->ninkeys);
       for (size_t ii = 0; ii < opts->ninkeys; ++ii) {
         uint64_t docId = 0;
-        RedisModuleString* keyName = RedisModule_CreateString(
-            sctx->redisCtx, opts->inkeys[ii], sdslen(opts->inkeys[ii]));
-        if (DocIdMeta_Get(sctx->redisCtx, keyName, sctx->spec->specId, &docId) == REDISMODULE_OK) {
+        if (DocIdMeta_Get(sctx->redisCtx, opts->inkeys[ii], sctx->spec->specId, &docId) ==
+            REDISMODULE_OK) {
           filterOpts.docIds[ii] = docId;
         } else {
           filterOpts.docIds[ii] = 0;  // Mark as not found
         }
-        RedisModule_FreeString(sctx->redisCtx, keyName);
       }
     }
 
     QAST_SetGlobalFilters(ast, &filterOpts);
+    // Non-NULL only if the transfer to the query node did not happen.
+    if (filterOpts.keys) {
+      rm_free(filterOpts.keys);
+    }
     if (filterOpts.docIds) {
       rm_free(filterOpts.docIds);
     }
@@ -1909,12 +1908,6 @@ void AREQ_Free(AREQ *req) {
     SearchCtx_Free(sctx);
   }
 
-  if (req->searchopts.inkeys) {
-    for (size_t ii = 0; ii < req->searchopts.ninkeys; ++ii) {
-      sdsfree(req->searchopts.inkeys[ii]);
-    }
-    rm_free(req->searchopts.inkeys);
-  }
   if (req->searchopts.legacy.filters) {
     for (size_t ii = 0; ii < array_len(req->searchopts.legacy.filters); ++ii) {
       LegacyNumericFilter *nf = req->searchopts.legacy.filters[ii];

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1182,6 +1182,7 @@ void BlockedRequestCtx_DecrRef(BlockedRequestCtx *brc) {
  * plan borrows (see BlockedRequestCtx.argvHolds). Runs at construction, on
  * the main thread; released in BlockedRequestCtx_Free, also on main. */
 static void holdArgv(BlockedRequestCtx *brc, RedisModuleString **argv, size_t argc) {
+  RS_ASSERT(argv != NULL);
   RS_ASSERT(brc->argvHolds == NULL);
   brc->argvHolds = rm_malloc(argc * sizeof(*brc->argvHolds));
   brc->nargvHolds = argc;
@@ -1200,9 +1201,7 @@ BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **arg
   BlockedRequestCtx *brc = BlockedRequestCtx_NewCommon(REQUEST_KIND_AREQ);
   brc->query.areq = areq;
   areq->brc = brc;
-  if (argv) {
-    holdArgv(brc, argv, argc);
-  }
+  holdArgv(brc, argv, argc);
   return brc;
 }
 
@@ -1213,9 +1212,7 @@ BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid,
   BlockedRequestCtx *brc = BlockedRequestCtx_NewCommon(REQUEST_KIND_HYBRID);
   brc->query.hybrid = hybrid;
   hybrid->brc = brc;
-  if (argv) {
-    holdArgv(brc, argv, argc);
-  }
+  holdArgv(brc, argv, argc);
   return brc;
 }
 
@@ -1432,7 +1429,6 @@ int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int a
   RS_ASSERT(brc != NULL);
   // `argv` must be a slice of the holds taken at construction — holding here
   // instead would touch string refcounts on whatever thread parses.
-  RS_ASSERT(brc->argvHolds != NULL);
   RS_ASSERT(brc->argvHolds <= argv && argv + argc <= brc->argvHolds + brc->nargvHolds);
   brc->parseSlice = argv;
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1187,11 +1187,9 @@ static void holdArgv(BlockedRequestCtx *brc, RedisModuleString **argv, size_t ar
   brc->nargvHolds = argc;
   for (size_t ii = 0; ii < argc; ++ii) {
     brc->argvHolds[ii] = RedisModule_HoldString(NULL, argv[ii]);
-    // A held client argv string may carry network-buffer slack, and Redis
-    // auto-trims (reallocates) retained argv right after the command callback
-    // returns — racing any thread already reading the string, and moving the
-    // buffer under any borrowed pointer. Trim here instead: on the main
-    // thread, before parsing borrows the buffers or a worker can see them.
+    // Redis auto-trims (reallocates) retained argv right after the command
+    // callback returns — racing any thread already reading the string. Trim
+    // here instead, before any borrow exists or a worker can see it.
     RedisModule_TrimStringAllocation(brc->argvHolds[ii]);
   }
 }
@@ -1238,8 +1236,7 @@ void BlockedRequestCtx_Free(BlockedRequestCtx *brc) {
     HybridRequest_Free(brc->query.hybrid);
   }
   if (brc->argvHolds) {
-    // After the request: its plan borrows from these strings. Runs on the
-    // main thread; argv string refcounts are not thread safe.
+    // After the request: its plan borrows from these strings
     for (size_t ii = 0; ii < brc->nargvHolds; ++ii) {
       RedisModule_FreeString(NULL, brc->argvHolds[ii]);
     }
@@ -1433,10 +1430,8 @@ static bool shouldCheckInPipelineTimeout(RedisModuleCtx* ctx, AREQ *req) {
 int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDiskIndex, QueryError *status) {
   BlockedRequestCtx *brc = req->brc;
   RS_ASSERT(brc != NULL);
-  // The dispatch site held the argv on the main thread and passes a slice of
-  // the holds here; the plan's borrows stay valid for the request's lifetime.
-  // Holding lazily instead would touch string refcounts on whatever thread
-  // parses, and refcounts are main-thread-only.
+  // `argv` must be a slice of the holds taken at construction — holding here
+  // instead would touch string refcounts on whatever thread parses.
   RS_ASSERT(brc->argvHolds != NULL);
   RS_ASSERT(brc->argvHolds <= argv && argv + argc <= brc->argvHolds + brc->nargvHolds);
   brc->parseOffset = argv - brc->argvHolds;

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1220,6 +1220,14 @@ void BlockedRequestCtx_Free(BlockedRequestCtx *brc) {
   } else {
     HybridRequest_Free(brc->query.hybrid);
   }
+  if (brc->argvHolds) {
+    // After the request: its plan borrows from these strings. Runs on the
+    // main thread; argv string refcounts are not thread safe.
+    for (size_t ii = 0; ii < brc->nargvHolds; ++ii) {
+      RedisModule_FreeString(NULL, brc->argvHolds[ii]);
+    }
+    rm_free(brc->argvHolds);
+  }
   rm_free(brc);
 }
 
@@ -1406,15 +1414,17 @@ static bool shouldCheckInPipelineTimeout(RedisModuleCtx* ctx, AREQ *req) {
 }
 
 int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDiskIndex, QueryError *status) {
-  if (!req->argvHolds) {
+  BlockedRequestCtx *brc = req->brc;
+  RS_ASSERT(brc != NULL);
+  if (!brc->argvHolds) {
     // Parsing on the main thread with the caller's argv: hold references so
     // the plan's borrows stay valid for the request's lifetime. Flows that
     // parse on a background thread hold the argv at dispatch (on the main
     // thread) and pass a slice of the holds here instead.
-    AREQ_HoldArgv(req, argv, argc);
-    argv = req->argvHolds;
+    BlockedRequestCtx_HoldArgv(brc, argv, argc);
+    argv = brc->argvHolds;
   } else {
-    RS_ASSERT(req->argvHolds <= argv && argv + argc <= req->argvHolds + req->nargvHolds);
+    RS_ASSERT(brc->argvHolds <= argv && argv + argc <= brc->argvHolds + brc->nargvHolds);
   }
   req->parseArgv = argv;
 
@@ -1932,26 +1942,17 @@ void AREQ_Free(AREQ *req) {
     req->parsedVectorData = NULL;
   }
 
-  if (req->argvHolds) {
-    // Runs on the main thread (wrapper OnFree / container free): argv string
-    // refcounts are not thread safe.
-    for (size_t ii = 0; ii < req->nargvHolds; ++ii) {
-      RedisModule_FreeString(NULL, req->argvHolds[ii]);
-    }
-    rm_free(req->argvHolds);
-  }
-
   RequestSyncState_Destroy(&req->syncState);
 
   rm_free(req);
 }
 
-void AREQ_HoldArgv(AREQ *req, RedisModuleString **argv, size_t argc) {
-  RS_ASSERT(req->argvHolds == NULL);
-  req->argvHolds = rm_calloc(argc, sizeof(*req->argvHolds));
-  req->nargvHolds = argc;
+void BlockedRequestCtx_HoldArgv(BlockedRequestCtx *brc, RedisModuleString **argv, size_t argc) {
+  RS_ASSERT(brc->argvHolds == NULL);
+  brc->argvHolds = rm_calloc(argc, sizeof(*brc->argvHolds));
+  brc->nargvHolds = argc;
   for (size_t ii = 0; ii < argc; ++ii) {
-    req->argvHolds[ii] = RedisModule_HoldString(NULL, argv[ii]);
+    brc->argvHolds[ii] = RedisModule_HoldString(NULL, argv[ii]);
   }
 }
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1152,7 +1152,7 @@ bool SearchTime_IsTimedOut(void *arg) {
 static BlockedRequestCtx *BlockedRequestCtx_NewCommon(RequestKind kind) {
   BlockedRequestCtx *brc = rm_calloc(1, sizeof(BlockedRequestCtx));
   brc->kind = kind;
-  brc->parseOffset = SIZE_MAX;  // "no query argument" until parsing finds one
+  brc->parseSlice = NULL;  // "no query argument" until parsing finds one
   brc->refcount = 1;
   brc->requiresAggregateResultsSync = false;
   brc->aggregatingResults = false;
@@ -1434,7 +1434,7 @@ int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int a
   // instead would touch string refcounts on whatever thread parses.
   RS_ASSERT(brc->argvHolds != NULL);
   RS_ASSERT(brc->argvHolds <= argv && argv + argc <= brc->argvHolds + brc->nargvHolds);
-  brc->parseOffset = argv - brc->argvHolds;
+  brc->parseSlice = argv;
 
   // Parse the query and basic keywords first..
   ArgsCursor ac = {0};
@@ -1445,7 +1445,7 @@ int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int a
     return REDISMODULE_ERR;
   }
 
-  AC_Advance(&ac);  // The query string: argvHolds[parseOffset], read via AREQ_Query
+  AC_Advance(&ac);  // The query string: parseSlice[0], read via AREQ_Query
   initializeAREQ(req);
   RSSearchOptions *searchOpts = &req->searchopts;
   ParseAggPlanContext papCtx;
@@ -1618,7 +1618,7 @@ static bool IsIndexCoherent(AREQ *req) {
     return true;
   }
 
-  RedisModuleString **args = req->brc->argvHolds + req->brc->parseOffset;
+  RedisModuleString **args = req->brc->parseSlice;
   long long n_prefixes = 0;
   RedisModule_StringToLongLong(args[req->prefixesOffset + 1], &n_prefixes);
   // The first argument is at req->prefixesOffset + 2

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1610,7 +1610,7 @@ static bool IsIndexCoherent(AREQ *req) {
   RedisModule_StringToLongLong(args[req->prefixesOffset + 1], &n_prefixes);
   // The first argument is at req->prefixesOffset + 2
   RedisModuleString **prefixes = args + req->prefixesOffset + 2;
-  return IndexSpec_IsCoherentArgs(AREQ_SearchCtx(req)->spec, prefixes, n_prefixes);
+  return IndexSpec_IsCoherent(AREQ_SearchCtx(req)->spec, prefixes, n_prefixes);
 }
 
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1944,7 +1944,7 @@ void AREQ_Free(AREQ *req) {
 
 void BlockedRequestCtx_HoldArgv(BlockedRequestCtx *brc, RedisModuleString **argv, size_t argc) {
   RS_ASSERT(brc->argvHolds == NULL);
-  brc->argvHolds = rm_calloc(argc, sizeof(*brc->argvHolds));
+  brc->argvHolds = rm_malloc(argc * sizeof(*brc->argvHolds));
   brc->nargvHolds = argc;
   for (size_t ii = 0; ii < argc; ++ii) {
     brc->argvHolds[ii] = RedisModule_HoldString(NULL, argv[ii]);

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1187,6 +1187,12 @@ static void holdArgv(BlockedRequestCtx *brc, RedisModuleString **argv, size_t ar
   brc->nargvHolds = argc;
   for (size_t ii = 0; ii < argc; ++ii) {
     brc->argvHolds[ii] = RedisModule_HoldString(NULL, argv[ii]);
+    // A held client argv string may carry network-buffer slack, and Redis
+    // auto-trims (reallocates) retained argv right after the command callback
+    // returns — racing any thread already reading the string, and moving the
+    // buffer under any borrowed pointer. Trim here instead: on the main
+    // thread, before parsing borrows the buffers or a worker can see them.
+    RedisModule_TrimStringAllocation(brc->argvHolds[ii]);
   }
 }
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -777,9 +777,20 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
     return REDISMODULE_ERR;
   }
 
-  searchOpts->inkeys = (const sds*)inKeys.objs;
+  // INKEYS: the id-filter evaluation (including its Rust side) consumes sds
+  // keys; materialize owned copies of just these args.
+  if (inKeys.argc) {
+    searchOpts->inkeys = rm_malloc(sizeof(*searchOpts->inkeys) * inKeys.argc);
+    for (size_t ii = 0; ii < inKeys.argc; ++ii) {
+      size_t n;
+      const char *s = AC_StringArg(&inKeys, ii, &n);
+      searchOpts->inkeys[ii] = sdsnewlen(s, n);
+    }
+  }
   searchOpts->ninkeys = inKeys.argc;
-  searchOpts->legacy.infields = (const char **)inFields.objs;
+  // INFIELDS: a sub-cursor of the parse cursor; objs are RedisModuleString
+  // pointers, borrowed from the request's held argv.
+  searchOpts->legacy.infields = (RedisModuleString **)inFields.objs;
   searchOpts->legacy.ninfields = inFields.argc;
   // if language is NULL, set it to RS_LANG_UNSET and it will be updated
   // later, taking the index language
@@ -1395,25 +1406,28 @@ static bool shouldCheckInPipelineTimeout(RedisModuleCtx* ctx, AREQ *req) {
 }
 
 int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDiskIndex, QueryError *status) {
-  req->args = rm_malloc(sizeof(*req->args) * argc);
-  req->nargs = argc;
-  // Copy the arguments into an owned array of sds strings
-  for (size_t ii = 0; ii < argc; ++ii) {
-    size_t n;
-    const char *s = RedisModule_StringPtrLen(argv[ii], &n);
-    req->args[ii] = sdsnewlen(s, n);
+  if (!req->argvHolds) {
+    // Parsing on the main thread with the caller's argv: hold references so
+    // the plan's borrows stay valid for the request's lifetime. Flows that
+    // parse on a background thread hold the argv at dispatch (on the main
+    // thread) and pass a slice of the holds here instead.
+    AREQ_HoldArgv(req, argv, argc);
+    argv = req->argvHolds;
+  } else {
+    RS_ASSERT(req->argvHolds <= argv && argv + argc <= req->argvHolds + req->nargvHolds);
   }
+  req->parseArgv = argv;
 
   // Parse the query and basic keywords first..
   ArgsCursor ac = {0};
-  ArgsCursor_InitSDS(&ac, req->args, req->nargs);
+  ArgsCursor_InitRString(&ac, argv, argc);
 
   if (AC_IsAtEnd(&ac)) {
     QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "No query string provided");
     return REDISMODULE_ERR;
   }
 
-  req->query = AC_GetStringNC(&ac, NULL);
+  req->query = AC_GetStringNC(&ac, &req->queryLen);
   initializeAREQ(req);
   RSSearchOptions *searchOpts = &req->searchopts;
   ParseAggPlanContext papCtx;
@@ -1560,8 +1574,6 @@ static int applyGlobalFilters(RSSearchOptions *opts, QueryAST *ast, const RedisS
       filterOpts.docIds = rm_malloc(sizeof(t_docId) * opts->ninkeys);
       for (size_t ii = 0; ii < opts->ninkeys; ++ii) {
         uint64_t docId = 0;
-        // TODO: inkeys are extracted from RedisModuleString* in the command arguments, we should consider
-        // changing the search options to also use RedisModuleString* to avoid this extra conversion
         RedisModuleString* keyName = RedisModule_CreateString(
             sctx->redisCtx, opts->inkeys[ii], sdslen(opts->inkeys[ii]));
         if (DocIdMeta_Get(sctx->redisCtx, keyName, sctx->spec->specId, &docId) == REDISMODULE_OK) {
@@ -1587,11 +1599,12 @@ static bool IsIndexCoherent(AREQ *req) {
     return true;
   }
 
-  sds *args = req->args;
-  long long n_prefixes = strtol(args[req->prefixesOffset + 1], NULL, 10);
+  RedisModuleString **args = req->parseArgv;
+  long long n_prefixes = 0;
+  RedisModule_StringToLongLong(args[req->prefixesOffset + 1], &n_prefixes);
   // The first argument is at req->prefixesOffset + 2
-  sds *prefixes = args + req->prefixesOffset + 2;
-  return IndexSpec_IsCoherent(AREQ_SearchCtx(req)->spec, prefixes, n_prefixes);
+  RedisModuleString **prefixes = args + req->prefixesOffset + 2;
+  return IndexSpec_IsCoherentArgs(AREQ_SearchCtx(req)->spec, prefixes, n_prefixes);
 }
 
 
@@ -1698,8 +1711,9 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   if (opts->legacy.ninfields) {
     opts->fieldmask = 0;
     for (size_t ii = 0; ii < opts->legacy.ninfields; ++ii) {
-      const char *s = opts->legacy.infields[ii];
-      t_fieldMask bit = IndexSpec_GetFieldBit(index, s, strlen(s));
+      size_t slen;
+      const char *s = RedisModule_StringPtrLen(opts->legacy.infields[ii], &slen);
+      t_fieldMask bit = IndexSpec_GetFieldBit(index, s, slen);
       opts->fieldmask |= bit;
     }
   }
@@ -1744,7 +1758,7 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   bool skipParse = req->parsedVectorData && req->parsedVectorData->skipFilterIntegration;
 
   if (!skipParse) {
-    int rv = QAST_Parse(ast, sctx, opts, req->query, strlen(req->query), dialectVersion, status);
+    int rv = QAST_Parse(ast, sctx, opts, req->query, req->queryLen, dialectVersion, status);
     if (rv != REDISMODULE_OK) {
       return REDISMODULE_ERR;
     }
@@ -1883,9 +1897,11 @@ void AREQ_Free(AREQ *req) {
     SearchCtx_Free(sctx);
   }
 
-  for (size_t ii = 0; ii < req->nargs; ++ii) {
-    sdsfree(req->args[ii]);
-    req->args[ii] = NULL;
+  if (req->searchopts.inkeys) {
+    for (size_t ii = 0; ii < req->searchopts.ninkeys; ++ii) {
+      sdsfree(req->searchopts.inkeys[ii]);
+    }
+    rm_free(req->searchopts.inkeys);
   }
   if (req->searchopts.legacy.filters) {
     for (size_t ii = 0; ii < array_len(req->searchopts.legacy.filters); ++ii) {
@@ -1915,8 +1931,6 @@ void AREQ_Free(AREQ *req) {
     ParsedVectorData_Free(req->parsedVectorData);
     req->parsedVectorData = NULL;
   }
-
-  rm_free(req->args);
 
   if (req->argvHolds) {
     // Runs on the main thread (wrapper OnFree / container free): argv string

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1182,13 +1182,13 @@ void BlockedRequestCtx_DecrRef(BlockedRequestCtx *brc) {
 /* Hold references to `argv` strings whose contents the wrapped request's
  * plan borrows (see BlockedRequestCtx.argv). Runs at construction, on
  * the main thread; released in BlockedRequestCtx_Free, also on main. */
-static void holdArgv(BlockedRequestCtx *brc, RedisModuleString **argv, size_t argc) {
+static void holdArgv(BlockedRequestCtx *brc, RedisModuleString **argv, uint32_t argc) {
   RS_ASSERT(argv != NULL);
   RS_ASSERT(brc->argv == NULL);
   brc->argv = rm_malloc(argc * sizeof(*brc->argv));
-  brc->argc = (uint32_t)argc;
-  brc->parseArgc = (uint32_t)argc;  // debug constructors lower it to exclude the debug tail
-  for (size_t ii = 0; ii < argc; ++ii) {
+  brc->argc = argc;
+  brc->parseArgc = argc;  // debug constructors lower it to exclude the debug tail
+  for (uint32_t ii = 0; ii < argc; ++ii) {
     brc->argv[ii] = RedisModule_HoldString(NULL, argv[ii]);
     // Redis auto-trims (reallocates) retained argv right after the command
     // callback returns — racing any thread already reading the string. Trim
@@ -1217,7 +1217,7 @@ static void releaseArgvOnMainThread(void *privdata) {
   rm_free(deferred);
 }
 
-BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **argv, size_t argc) {
+BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **argv, uint32_t argc) {
   // Wrapping an already-wrapped request would silently leak the first wrapper.
   RS_ASSERT(areq->brc == NULL);
   BlockedRequestCtx *brc = BlockedRequestCtx_NewCommon(REQUEST_KIND_AREQ);
@@ -1228,7 +1228,7 @@ BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **arg
 }
 
 BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid,
-                                               RedisModuleString **argv, size_t argc) {
+                                               RedisModuleString **argv, uint32_t argc) {
   // Wrapping an already-wrapped request would silently leak the first wrapper.
   RS_ASSERT(hybrid->brc == NULL);
   BlockedRequestCtx *brc = BlockedRequestCtx_NewCommon(REQUEST_KIND_HYBRID);

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1461,8 +1461,12 @@ int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, uint32_t offset, bool isDiskInd
   brc->queryOffset = offset;
 
   // Parse the query and basic keywords first..
+  // The cursor covers the whole held command, pre-advanced to the parse
+  // start: positions recorded off the cursor (syntax-error offsets,
+  // prefixesOffset) are relative to the full command, not the parsed tail.
   ArgsCursor ac = {0};
-  ArgsCursor_InitRString(&ac, brc->argv + offset, brc->parseArgc - offset);
+  ArgsCursor_InitRString(&ac, brc->argv, brc->parseArgc);
+  AC_AdvanceBy(&ac, offset);
 
   if (AC_IsAtEnd(&ac)) {
     QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "No query string provided");
@@ -1642,7 +1646,9 @@ static bool IsIndexCoherent(AREQ *req) {
     return true;
   }
 
-  RedisModuleString **args = req->brc->argv + req->brc->queryOffset;
+  // prefixesOffset indexes the full held command (recorded off the compile
+  // cursor, which covers the whole command).
+  RedisModuleString **args = req->brc->argv;
   long long n_prefixes = 0;
   RedisModule_StringToLongLong(args[req->prefixesOffset + 1], &n_prefixes);
   // The first argument is at req->prefixesOffset + 2

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1261,9 +1261,8 @@ void BlockedRequestCtx_Free(BlockedRequestCtx *brc) {
     releaseArgv(brc->argv, brc->argc);
   } else {
     // String references may only be released on the main thread; bounce the
-    // release to the main event loop. The API exists on every supported
-    // server (Redis 7+) and only fails on a NULL callback.
-    DeferredArgvRelease *deferred = rm_malloc(sizeof(*deferred));
+    // release to the main event loop.
+    DeferredArgvRelease *deferred = rm_new(DeferredArgvRelease);
     *deferred = (DeferredArgvRelease){.argv = brc->argv, .argc = brc->argc};
     int rc = RedisModule_EventLoopAddOneShot(releaseArgvOnMainThread, deferred);
     RS_ASSERT(rc == REDISMODULE_OK);
@@ -1454,7 +1453,8 @@ static bool shouldCheckInPipelineTimeout(RedisModuleCtx* ctx, AREQ *req) {
 
 }
 
-int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, uint32_t offset, bool isDiskIndex, QueryError *status) {
+int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, uint32_t offset, bool isDiskIndex,
+                 QueryError *status) {
   BlockedRequestCtx *brc = req->brc;
   RS_ASSERT(brc != NULL);
   RS_ASSERT(offset <= brc->parseArgc && brc->parseArgc <= brc->argc);
@@ -1622,8 +1622,7 @@ static int applyGlobalFilters(RSSearchOptions *opts, QueryAST *ast, const RedisS
       filterOpts.docIds = rm_malloc(sizeof(t_docId) * opts->ninkeys);
       for (size_t ii = 0; ii < opts->ninkeys; ++ii) {
         uint64_t docId = 0;
-        if (DocIdMeta_Get(sctx->redisCtx, opts->inkeys[ii], sctx->spec->specId, &docId) ==
-            REDISMODULE_OK) {
+        if (DocIdMeta_Get(sctx->redisCtx, opts->inkeys[ii], sctx->spec->specId, &docId) == REDISMODULE_OK) {
           filterOpts.docIds[ii] = docId;
         } else {
           filterOpts.docIds[ii] = 0;  // Mark as not found

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -761,11 +761,12 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
     }
   }
 
-  // Parse from the held argv — this job's argv copies die with the job, the
-  // plan's borrows must not. The job argv mirrors the original, so offsets
-  // computed on it index the holds too.
-  RS_ASSERT(r->brc->argvHolds && (size_t)argc <= r->brc->nargvHolds);
-  rc = AREQ_Compile(r, ctx, r->brc->argvHolds + ac.offset, argc - ac.offset, SearchDisk_IsEnabledForValidation(), status);
+  // Compile parses the held argv — this job's argv copies die with the job,
+  // the plan's borrows must not. The job argv mirrors the original, so the
+  // offset computed on it indexes the holds too, and this view's length must
+  // match the wrapper's parse extent (the debug dispatcher trims both).
+  RS_ASSERT((uint32_t)argc == r->brc->parseArgc);
+  rc = AREQ_Compile(r, ctx, ac.offset, SearchDisk_IsEnabledForValidation(), status);
   if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
 
   // User-facing cursors are unsupported on disk (flex). Reject before fan-out.

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -761,11 +761,9 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
     }
   }
 
-  // Parse from the request's held argv (taken by the dispatcher on the main
-  // thread): this job's argv copies die with the job, while the plan's borrows
-  // must live as long as the request. The job argv mirrors the original, so
-  // offsets computed on it index the holds too (debug flows only trim the
-  // trailing debug params off argc, keeping the holds a superset).
+  // Parse from the held argv — this job's argv copies die with the job, the
+  // plan's borrows must not. The job argv mirrors the original, so offsets
+  // computed on it index the holds too.
   RS_ASSERT(r->brc->argvHolds && (size_t)argc <= r->brc->nargvHolds);
   rc = AREQ_Compile(r, ctx, r->brc->argvHolds + ac.offset, argc - ac.offset, SearchDisk_IsEnabledForValidation(), status);
   if (rc != REDISMODULE_OK) return REDISMODULE_ERR;

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -766,8 +766,8 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
   // must live as long as the request. The job argv mirrors the original, so
   // offsets computed on it index the holds too (debug flows only trim the
   // trailing debug params off argc, keeping the holds a superset).
-  RS_ASSERT(r->argvHolds && (size_t)argc <= r->nargvHolds);
-  rc = AREQ_Compile(r, ctx, r->argvHolds + ac.offset, argc - ac.offset, SearchDisk_IsEnabledForValidation(), status);
+  RS_ASSERT(r->brc->argvHolds && (size_t)argc <= r->brc->nargvHolds);
+  rc = AREQ_Compile(r, ctx, r->brc->argvHolds + ac.offset, argc - ac.offset, SearchDisk_IsEnabledForValidation(), status);
   if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
 
   // User-facing cursors are unsupported on disk (flex). Reject before fan-out.

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -761,7 +761,13 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
     }
   }
 
-  rc = AREQ_Compile(r, ctx, argv + ac.offset, argc - ac.offset, SearchDisk_IsEnabledForValidation(), status);
+  // Parse from the request's held argv (taken by the dispatcher on the main
+  // thread): this job's argv copies die with the job, while the plan's borrows
+  // must live as long as the request. The job argv mirrors the original, so
+  // offsets computed on it index the holds too (debug flows only trim the
+  // trailing debug params off argc, keeping the holds a superset).
+  RS_ASSERT(r->argvHolds && (size_t)argc <= r->nargvHolds);
+  rc = AREQ_Compile(r, ctx, r->argvHolds + ac.offset, argc - ac.offset, SearchDisk_IsEnabledForValidation(), status);
   if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
 
   // User-facing cursors are unsupported on disk (flex). Reject before fan-out.

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -786,9 +786,10 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
   if(dialect >= 2) {
     // Check if we have KNN in the query string, and if so, parse the query string to see if it is
     // a KNN section in the query. IN that case, we treat this as a SORTBY+LIMIT step.
-    if(strcasestr(r->query, "KNN")) {
+    const char *query = AREQ_Query(r, NULL);
+    if(strcasestr(query, "KNN")) {
       // For distributed aggregation, command type detection is automatic
-      knnCtx = prepareOptionalTopKCase(r->query, argv, argc, dialect, status);
+      knnCtx = prepareOptionalTopKCase(query, argv, argc, dialect, status);
       *knnCtx_ptr = knnCtx;
       if (QueryError_HasError(status)) {
         return REDISMODULE_ERR;

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -785,10 +785,11 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
   if(dialect >= 2) {
     // Check if we have KNN in the query string, and if so, parse the query string to see if it is
     // a KNN section in the query. IN that case, we treat this as a SORTBY+LIMIT step.
-    const char *query = AREQ_Query(r, NULL);
+    size_t queryLen;
+    const char *query = AREQ_Query(r, &queryLen);
     if(strcasestr(query, "KNN")) {
       // For distributed aggregation, command type detection is automatic
-      knnCtx = prepareOptionalTopKCase(query, argv, argc, dialect, status);
+      knnCtx = prepareOptionalTopKCase(query, queryLen, argv, argc, dialect, status);
       *knnCtx_ptr = knnCtx;
       if (QueryError_HasError(status)) {
         return REDISMODULE_ERR;

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -787,7 +787,7 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
     // a KNN section in the query. IN that case, we treat this as a SORTBY+LIMIT step.
     size_t queryLen;
     const char *query = AREQ_Query(r, &queryLen);
-    if(strcasestr(query, "KNN")) {
+    if (strcasestr(query, "KNN")) {
       // For distributed aggregation, command type detection is automatic
       knnCtx = prepareOptionalTopKCase(query, queryLen, argv, argc, dialect, status);
       *knnCtx_ptr = knnCtx;

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -409,22 +409,15 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
   }
 
   const size_t srcArgc = src->args.argc;  // reducer args (no leading <nargs>)
-  // Materialize the source tokens as C strings (type-aware: the plan cursor
-  // may be RString-backed, in which case objs are RedisModuleString pointers).
-  // No per-token duplication: each pointer is the token's own NUL-terminated
-  // buffer, owned by the request for its whole lifetime.
-  auto srcObjs = (const char **)BlkAlloc_Alloc(
-      rdctx->alloc, sizeof(char *) * srcArgc,
-      std::max(sizeof(char *) * srcArgc, DIST_REDUCER_BLOCK_SIZE));
-  for (size_t i = 0; i < srcArgc; i++) {
-    srcObjs[i] = AC_StringArg(&src->args, i, NULL);
-  }
+  // Source tokens are read through the type-aware accessor (the plan cursor
+  // may be RString-backed): each returned pointer is the token's own
+  // NUL-terminated buffer, owned by the request for its whole lifetime.
 
   // Locate the LIMIT offset slot in the original argv.
-  size_t limitValIdx = SIZE_MAX;  // index into srcObjs of the LIMIT offset token
+  size_t limitValIdx = SIZE_MAX;  // index of the LIMIT offset token
   if (args.has_limit) {
     for (size_t i = 0; i + 2 < srcArgc; i++) {
-      if (!strcasecmp(srcObjs[i], "LIMIT")) {
+      if (!strcasecmp(AC_StringArg(&src->args, i, NULL), "LIMIT")) {
         limitValIdx = i + 1;
         break;
       }
@@ -444,8 +437,9 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
   // validated) COLLECT grammar it only appears `@`-prefixed, as a number, or as
   // `*`, so a bare alphabetic token can only be an option keyword.
   for (size_t i = 0; i < srcArgc; i++) {
-    const char *normalized = CollectArgs_NormalizedKeyword(srcObjs[i]);
-    remoteObjs[1 + i] = normalized ? normalized : srcObjs[i];
+    const char *tok = AC_StringArg(&src->args, i, NULL);
+    const char *normalized = CollectArgs_NormalizedKeyword(tok);
+    remoteObjs[1 + i] = normalized ? normalized : tok;
   }
   if (args.has_limit) {
     remoteObjs[1 + limitValIdx] = distAllocU64Str(rdctx->alloc, 0);
@@ -470,7 +464,9 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
       rdctx->alloc, sizeof(char *) * localTotal,
       std::max(sizeof(char *) * localTotal, DIST_REDUCER_BLOCK_SIZE));
   localObjs[0] = distAllocU64Str(rdctx->alloc, srcArgc);  // unchanged count
-  memcpy(localObjs + 1, srcObjs, srcArgc * sizeof(char *));
+  for (size_t i = 0; i < srcArgc; i++) {
+    localObjs[1 + i] = AC_StringArg(&src->args, i, NULL);
+  }
   localObjs[srcArgc + 1] = "AS";          // static literal, outside <nargs>
   localObjs[srcArgc + 2] = src->alias;    // owned by src; outlives this call
   ArgsCursor localArgs;

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -142,7 +142,8 @@ struct ReducerDistCtx {
   }
 
   const char *srcarg(size_t n) const {
-    auto *s = (const char *)srcReducer->args.objs[n];
+    // Type-aware: hybrid tail plans carry RString-backed arg cursors.
+    const char *s = AC_StringArg(&srcReducer->args, n, NULL);
     return stripAtPrefix(s);
   }
 };

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -381,7 +381,7 @@ static int distributeAvg(ReducerDistCtx *rdctx, QueryError *status) {
  *
  * Both halves of the split GROUPBY forward the original COLLECT argv pointers
  * verbatim; only what actually differs between the two sides is synthesized.
- * FIELDS / SORTBY tokens are reused directly from `src->args.objs` — no
+ * FIELDS / SORTBY tokens reuse the source tokens' own string buffers — no
  * per-token duplication.
  *
  * Limited path: whenever the user supplied `LIMIT offset count`, the remote
@@ -409,7 +409,16 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
   }
 
   const size_t srcArgc = src->args.argc;  // reducer args (no leading <nargs>)
-  auto srcObjs = (const char **)src->args.objs;
+  // Materialize the source tokens as C strings (type-aware: the plan cursor
+  // may be RString-backed, in which case objs are RedisModuleString pointers).
+  // No per-token duplication: each pointer is the token's own NUL-terminated
+  // buffer, owned by the request for its whole lifetime.
+  auto srcObjs = (const char **)BlkAlloc_Alloc(
+      rdctx->alloc, sizeof(char *) * srcArgc,
+      std::max(sizeof(char *) * srcArgc, DIST_REDUCER_BLOCK_SIZE));
+  for (size_t i = 0; i < srcArgc; i++) {
+    srcObjs[i] = AC_StringArg(&src->args, i, NULL);
+  }
 
   // Locate the LIMIT offset slot in the original argv.
   size_t limitValIdx = SIZE_MAX;  // index into srcObjs of the LIMIT offset token

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -409,9 +409,8 @@ static int distributeCollect(ReducerDistCtx *rdctx, QueryError *status) {
   }
 
   const size_t srcArgc = src->args.argc;  // reducer args (no leading <nargs>)
-  // Source tokens are read through the type-aware accessor (the plan cursor
-  // may be RString-backed): each returned pointer is the token's own
-  // NUL-terminated buffer, owned by the request for its whole lifetime.
+  // Source tokens are read type-aware (the plan cursor may be RString-backed);
+  // each returned buffer is owned by the request for its whole lifetime.
 
   // Locate the LIMIT offset slot in the original argv.
   size_t limitValIdx = SIZE_MAX;  // index of the LIMIT offset token

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -682,19 +682,17 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     cmd.reqConfig = &hreq->reqConfig;
     cmd.coordDispatchTime = &hreq->profileClocks.coordDispatchTime;
 
-    // RString cursor used only to detect the profile prefix and count tokens
-    // consumed. We don't feed it to parseHybridCommand because AC_GetString on
-    // an RString cursor returns pointers into auto-memory that dies with the
-    // dispatcher ctx.
+    // Scans this job's argv only to detect the profile prefix and count the
+    // tokens it consumed; nothing borrows from it.
     ArgsCursor profileAc = {0};
     ArgsCursor_InitRString(&profileAc, argv, argc);
     ProfileOptions profileOptions = EXEC_NO_FLAGS;
     int rc = ParseProfile(&profileAc, status, &profileOptions);
     if (rc == REDISMODULE_ERR) return REDISMODULE_ERR;
 
-    // Hreq-owned sds copies of argv[2:] (skips command + index). parseHybridCommand
-    // and the RLookup machinery borrow pointers into this cursor's strings, so they
-    // must outlive the dispatcher ctx.
+    // Parse from the request's held argv (taken by the dispatcher on the main
+    // thread): parseHybridCommand and the RLookup machinery borrow pointers
+    // into these strings, so they must outlive this job's own argv copies.
     ArgsCursor ac = {0};
     HybridRequest_InitArgsCursor(hreq, &ac, argv, argc);
 

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -682,17 +682,15 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     cmd.reqConfig = &hreq->reqConfig;
     cmd.coordDispatchTime = &hreq->profileClocks.coordDispatchTime;
 
-    // Scans this job's argv only to detect the profile prefix and count the
-    // tokens it consumed; nothing borrows from it.
+    // Only detects the profile prefix; nothing borrows from the job's argv here.
     ArgsCursor profileAc = {0};
     ArgsCursor_InitRString(&profileAc, argv, argc);
     ProfileOptions profileOptions = EXEC_NO_FLAGS;
     int rc = ParseProfile(&profileAc, status, &profileOptions);
     if (rc == REDISMODULE_ERR) return REDISMODULE_ERR;
 
-    // Parse from the request's held argv (taken by the dispatcher on the main
-    // thread): parseHybridCommand and the RLookup machinery borrow pointers
-    // into these strings, so they must outlive this job's own argv copies.
+    // Parse from the held argv — the parse borrows pointers into these
+    // strings, which must outlive this job's own argv copies.
     ArgsCursor ac = {0};
     HybridRequest_InitArgsCursor(hreq, &ac, argv, argc);
 

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -692,7 +692,7 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     // Parse from the held argv — the parse borrows pointers into these
     // strings, which must outlive this job's own argv copies.
     ArgsCursor ac = {0};
-    HybridRequest_InitArgsCursor(hreq, &ac, argv, argc);
+    HybridRequest_InitArgsCursor(hreq, &ac, argc);
 
     if (profileOptions != EXEC_NO_FLAGS) {
         // Skip the tokens ParseProfile consumed beyond command + index.

--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -166,6 +166,12 @@ t_docId DocTable_GetId(const DocTable *dt, const char *s, size_t n) {
   return DocIdMap_Get(&dt->dim, s, n);
 }
 
+t_docId DocTable_GetIdR(const DocTable *dt, const RedisModuleString *r) {
+  size_t n;
+  const char *s = RedisModule_StringPtrLen(r, &n);
+  return DocTable_GetId(dt, s, n);
+}
+
 /* Set the payload for a document. Returns 1 if we set the payload, 0 if we couldn't find the
  * document */
 int DocTable_SetPayload(DocTable *t, RSDocumentMetadata *dmd, const char *data, size_t len) {

--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -213,10 +213,10 @@ t_docId DocTable_GetId(const DocTable *dt, const char *s, size_t n);
   size_t n;                     \
   const char *s = RedisModule_StringPtrLen(r, &n);
 
-static inline t_docId DocTable_GetIdR(const DocTable *dt, RedisModuleString *r) {
-  STRVARS_FROM_RSTRING(r);
-  return DocTable_GetId(dt, s, n);
-}
+/* DocTable_GetId from a RedisModuleString key. A real (exported) function so
+ * the Rust query evaluator can resolve id-filter keys without touching the
+ * module API. */
+t_docId DocTable_GetIdR(const DocTable *dt, const RedisModuleString *r);
 
 /* Free the table and all the keys of documents */
 void DocTable_Free(DocTable *t);

--- a/src/geo_index.c
+++ b/src/geo_index.c
@@ -24,11 +24,9 @@
 static double extractUnitFactor(GeoDistance unit);
 
 /* Legacy contract: an explicitly empty GEOFILTER value parses as 0 under
- * DIALECT 1; dialect >= 2 rejects it through `hasEmptyFilterValue` with a
- * dedicated error. The strict argv conversions no longer parse "" as a
- * number, so an empty token is recognized on conversion failure instead.
- * Returns true when the current token is empty, coercing `*target` to 0 and
- * raising the flag. */
+ * DIALECT 1; dialect >= 2 rejects it via `hasEmptyFilterValue`. The strict
+ * conversions no longer parse "" as a number, so the empty token is
+ * recognized on conversion failure: returns true, coercing `*target` to 0. */
 static bool CoalesceEmptyFilterValue(ArgsCursor *ac, double *target,
                                      bool *hasEmptyFilterValue) {
   const char *val;

--- a/src/geo_index.c
+++ b/src/geo_index.c
@@ -23,13 +23,24 @@
 
 static double extractUnitFactor(GeoDistance unit);
 
-static void CheckAndSetEmptyFilterValue(ArgsCursor *ac, bool *hasEmptyFilterValue) {
+/* Legacy contract: an explicitly empty GEOFILTER value parses as 0 under
+ * DIALECT 1; dialect >= 2 rejects it through `hasEmptyFilterValue` with a
+ * dedicated error. The strict argv conversions no longer parse "" as a
+ * number, so an empty token is recognized on conversion failure instead.
+ * Returns true when the current token is empty, coercing `*target` to 0 and
+ * raising the flag. */
+static bool CoalesceEmptyFilterValue(ArgsCursor *ac, double *target,
+                                     bool *hasEmptyFilterValue) {
   const char *val;
+  size_t len;
 
-  int rv = AC_GetString(ac, &val, NULL, AC_F_NOADVANCE);
-  if (rv == AC_OK && !(*val)) {
-    *hasEmptyFilterValue = true;
+  int rv = AC_GetString(ac, &val, &len, AC_F_NOADVANCE);
+  if (rv != AC_OK || len != 0) {
+    return false;
   }
+  *target = 0;
+  *hasEmptyFilterValue = true;
+  return true;
 }
 
 /* Parse a geo filter from redis arguments. We assume the filter args start at argv[0], and FILTER
@@ -51,30 +62,24 @@ int GeoFilter_LegacyParse(LegacyGeoFilter *gf, ArgsCursor *ac, bool *hasEmptyFil
     QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for <geo property>: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
-  if ((rv = AC_GetDouble(ac, &gf->base.lon, AC_F_NOADVANCE) != AC_OK)) {
+  rv = AC_GetDouble(ac, &gf->base.lon, AC_F_NOADVANCE);
+  if (rv != AC_OK && !CoalesceEmptyFilterValue(ac, &gf->base.lon, hasEmptyFilterValue)) {
     QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for <lon>: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
-  if (gf->base.lon == 0) {
-    CheckAndSetEmptyFilterValue(ac, hasEmptyFilterValue);
-  }
   AC_Advance(ac);
 
-  if ((rv = AC_GetDouble(ac, &gf->base.lat, AC_F_NOADVANCE)) != AC_OK) {
+  rv = AC_GetDouble(ac, &gf->base.lat, AC_F_NOADVANCE);
+  if (rv != AC_OK && !CoalesceEmptyFilterValue(ac, &gf->base.lat, hasEmptyFilterValue)) {
     QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for <lat>: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
-  if (gf->base.lat == 0) {
-    CheckAndSetEmptyFilterValue(ac, hasEmptyFilterValue);
-  }
   AC_Advance(ac);
 
-  if ((rv = AC_GetDouble(ac, &gf->base.radius, AC_F_NOADVANCE)) != AC_OK) {
+  rv = AC_GetDouble(ac, &gf->base.radius, AC_F_NOADVANCE);
+  if (rv != AC_OK && !CoalesceEmptyFilterValue(ac, &gf->base.radius, hasEmptyFilterValue)) {
     QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for <radius>: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
-  }
-  if (gf->base.radius == 0) {
-    CheckAndSetEmptyFilterValue(ac, hasEmptyFilterValue);
   }
   AC_Advance(ac);
 

--- a/src/geo_index.c
+++ b/src/geo_index.c
@@ -27,8 +27,7 @@ static double extractUnitFactor(GeoDistance unit);
  * DIALECT 1; dialect >= 2 rejects it via `hasEmptyFilterValue`. The strict
  * conversions no longer parse "" as a number, so the empty token is
  * recognized on conversion failure: returns true, coercing `*target` to 0. */
-static bool CoalesceEmptyFilterValue(ArgsCursor *ac, double *target,
-                                     bool *hasEmptyFilterValue) {
+static bool CoalesceEmptyFilterValue(ArgsCursor *ac, double *target, bool *hasEmptyFilterValue) {
   const char *val;
   size_t len;
 

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -186,6 +186,9 @@ static HybridRequest_Debug* HybridRequest_Debug_New(RedisModuleCtx *ctx, RedisMo
   int hybrid_argc = argc - debug_argv_count;
 
   HybridRequest *hreq = MakeDefaultHybridRequest(sctx);
+  // Hold the full argv on the main thread before parsing (a superset: the
+  // debug tail is trimmed off hybrid_argc).
+  HybridRequest_HoldArgv(hreq, argv, argc);
   ArgsCursor ac = {0};
   HybridRequest_InitArgsCursor(hreq, &ac, argv, hybrid_argc);
 

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -185,10 +185,9 @@ static HybridRequest_Debug* HybridRequest_Debug_New(RedisModuleCtx *ctx, RedisMo
   int debug_argv_count = debug_params.debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>`
   int hybrid_argc = argc - debug_argv_count;
 
-  HybridRequest *hreq = MakeDefaultHybridRequest(sctx);
-  // Hold the full argv on the main thread before parsing (a superset: the
-  // debug tail is trimmed off hybrid_argc).
-  HybridRequest_HoldArgv(hreq, argv, argc);
+  // Construction holds the full argv (a superset: the debug tail is trimmed
+  // off hybrid_argc below).
+  HybridRequest *hreq = MakeDefaultHybridRequest(sctx, argv, argc);
   ArgsCursor ac = {0};
   HybridRequest_InitArgsCursor(hreq, &ac, argv, hybrid_argc);
 

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -185,8 +185,7 @@ static HybridRequest_Debug* HybridRequest_Debug_New(RedisModuleCtx *ctx, RedisMo
   int debug_argv_count = debug_params.debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>`
   int hybrid_argc = argc - debug_argv_count;
 
-  // Construction holds the full argv (a superset: the debug tail is trimmed
-  // off hybrid_argc below).
+  // Holds the full argv; the debug tail is trimmed off hybrid_argc below
   HybridRequest *hreq = MakeDefaultHybridRequest(sctx, argv, argc);
   ArgsCursor ac = {0};
   HybridRequest_InitArgsCursor(hreq, &ac, argv, hybrid_argc);

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -188,7 +188,7 @@ static HybridRequest_Debug* HybridRequest_Debug_New(RedisModuleCtx *ctx, RedisMo
   // Holds the full argv; the debug tail is trimmed off hybrid_argc below
   HybridRequest *hreq = MakeDefaultHybridRequest(sctx, argv, argc);
   ArgsCursor ac = {0};
-  HybridRequest_InitArgsCursor(hreq, &ac, argv, hybrid_argc);
+  HybridRequest_InitArgsCursor(hreq, &ac, hybrid_argc);
 
   HybridPipelineParams hybridParams = {0};  // Stack allocation
   ParseHybridCommandCtx cmd = {0};

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -833,8 +833,7 @@ int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, Q
       if (!cursor) {
         break;
       }
-      // RETURN_STRICT FT.CURSOR READ cycles run the claim/done-latch handshake
-      // against the read AREQ's wrapper, at per-sub-AREQ granularity.
+      // FT.CURSOR READ cycles run against the read sub-AREQ's wrapper.
       // TRANSITIONAL(MOD-16691): the cursor's own hold rides hybrid_ref until
       // the container-handoff step.
       RS_ASSERT(areq->brc != NULL);
@@ -1343,8 +1342,6 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   StrongRef spec_ref = IndexSpec_GetStrongRefUnsafe(sctx->spec);
   CurrentThread_SetIndexSpec(spec_ref);
 
-  // Construction takes the argv holds the plans will borrow from (this
-  // handler runs on the main thread).
   HybridRequest *hybridRequest = MakeDefaultHybridRequest(sctx, argv, argc);
   hybridRequest->profile = printHybridProfile;
   hybridRequest->tailPipeline->qctx.isProfile = profileOptions & EXEC_WITH_PROFILE;

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -1344,6 +1344,9 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   CurrentThread_SetIndexSpec(spec_ref);
 
   HybridRequest *hybridRequest = MakeDefaultHybridRequest(sctx);
+  // This handler parses inline on the main thread; hold the argv the plans
+  // will borrow from before parsing starts.
+  HybridRequest_HoldArgv(hybridRequest, argv, argc);
   hybridRequest->profile = printHybridProfile;
   hybridRequest->tailPipeline->qctx.isProfile = profileOptions & EXEC_WITH_PROFILE;
   if (debugParams) {

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -1343,10 +1343,9 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   StrongRef spec_ref = IndexSpec_GetStrongRefUnsafe(sctx->spec);
   CurrentThread_SetIndexSpec(spec_ref);
 
-  HybridRequest *hybridRequest = MakeDefaultHybridRequest(sctx);
-  // This handler parses inline on the main thread; hold the argv the plans
-  // will borrow from before parsing starts.
-  HybridRequest_HoldArgv(hybridRequest, argv, argc);
+  // Construction takes the argv holds the plans will borrow from (this
+  // handler runs on the main thread).
+  HybridRequest *hybridRequest = MakeDefaultHybridRequest(sctx, argv, argc);
   hybridRequest->profile = printHybridProfile;
   hybridRequest->tailPipeline->qctx.isProfile = profileOptions & EXEC_WITH_PROFILE;
   if (debugParams) {

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -1361,7 +1361,7 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   cmd.coordDispatchTime = &hybridRequest->profileClocks.coordDispatchTime;
 
   ArgsCursor ac = {0};
-  HybridRequest_InitArgsCursor(hybridRequest, &ac, argv, argc);
+  HybridRequest_InitArgsCursor(hybridRequest, &ac, argc);
 
   if (parseHybridCommand(ctx, &ac, sctx, &cmd, &status, internal, profileOptions) != REDISMODULE_OK) {
     return CleanupAndReplyStatus(ctx, hybrid_ref, cmd.hybridParams, &status, internal);

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -833,14 +833,11 @@ int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, Q
       if (!cursor) {
         break;
       }
-      // A cursor-backing sub-AREQ needs its own heap BlockedRequestCtx: RETURN_STRICT
-      // FT.CURSOR READ cycles run the claim/done-latch handshake against the read
-      // AREQ's wrapper (req->brc), at per-sub-AREQ granularity. Ownership is
-      // unchanged — the hybrid request still owns the sub-AREQ, and the wrapper is
-      // freed with it (HybridRequest_Free -> AREQ_DecrRef -> BlockedRequestCtx_Free).
+      // RETURN_STRICT FT.CURSOR READ cycles run the claim/done-latch handshake
+      // against the read AREQ's wrapper, at per-sub-AREQ granularity.
       // TRANSITIONAL(MOD-16691): the cursor's own hold rides hybrid_ref until
       // the container-handoff step.
-      BlockedRequestCtx_NewAREQ(areq);
+      RS_ASSERT(areq->brc != NULL);
       // The cursor lifetime will determine the hybrid request lifetime
       cursor->query = areq->brc;
       cursor->hybrid_ref = StrongRef_Clone(hybrid_ref);

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -280,61 +280,61 @@ int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params
  */
 void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **requests,
                         size_t nrequests, RedisModuleString **argv, uint32_t argc) {
-    hybridReq->requests = requests;
-    hybridReq->nrequests = nrequests;
-    hybridReq->sctx = sctx;
-    hybridReq->kArgIndex = -1;
-    // Snapshot the request's config; nothing may re-read RSGlobalConfig for
-    // the request's lifetime.
-    hybridReq->reqConfig = RSGlobalConfig.requestConfigParams;
+  hybridReq->requests = requests;
+  hybridReq->nrequests = nrequests;
+  hybridReq->sctx = sctx;
+  hybridReq->kArgIndex = -1;
+  // Snapshot the request's config; nothing may re-read RSGlobalConfig for
+  // the request's lifetime.
+  hybridReq->reqConfig = RSGlobalConfig.requestConfigParams;
 
-    rs_wall_clock now = {0};
-    rs_wall_clock_init(&now);
+  rs_wall_clock now = {0};
+  rs_wall_clock_init(&now);
 
-    // Initialize error tracking for each individual request
-    hybridReq->errors = array_newlen(QueryError, nrequests);
-    memset(hybridReq->errors, 0, nrequests * sizeof(QueryError));
+  // Initialize error tracking for each individual request
+  hybridReq->errors = array_newlen(QueryError, nrequests);
+  memset(hybridReq->errors, 0, nrequests * sizeof(QueryError));
 
-    // Initialize return codes array for tracking subqueries final states
-    hybridReq->subqueriesReturnCodes = rm_calloc(nrequests, sizeof(RPStatus));
+  // Initialize return codes array for tracking subqueries final states
+  hybridReq->subqueriesReturnCodes = rm_calloc(nrequests, sizeof(RPStatus));
 
-    // Initialize the tail pipeline that will merge results from all requests
-    hybridReq->tailPipeline = rm_calloc(1, sizeof(Pipeline));
-    AGPLN_Init(&hybridReq->tailPipeline->ap);
-    hybridReq->tailPipelineError = QueryError_Default();
-    Pipeline_Initialize(hybridReq->tailPipeline, hybridReq->reqConfig.timeoutPolicy, &hybridReq->tailPipelineError);
+  // Initialize the tail pipeline that will merge results from all requests
+  hybridReq->tailPipeline = rm_calloc(1, sizeof(Pipeline));
+  AGPLN_Init(&hybridReq->tailPipeline->ap);
+  hybridReq->tailPipelineError = QueryError_Default();
+  Pipeline_Initialize(hybridReq->tailPipeline, hybridReq->reqConfig.timeoutPolicy,
+                      &hybridReq->tailPipelineError);
 
-    // Initialize pipelines for each individual request
-    for (size_t i = 0; i < nrequests; i++) {
-        initializeAREQ(requests[i]);
-        // Each sub-AREQ gets its own wrapper, holding the whole command
-        // rather than its own slice: slice boundaries are only discovered
-        // while parsing, and sub pipelines borrow beyond their slice anyway
-        // (distributed tail steps like LOAD, PARAMS).
-        BlockedRequestCtx_NewAREQ(requests[i], argv, argc);
-        hybridReq->errors[i] = QueryError_Default();
-        Pipeline_Initialize(&requests[i]->pipeline, requests[i]->reqConfig.timeoutPolicy, &hybridReq->errors[i]);
-    }
-    hybridReq->profileClocks.initClock = now;
+  // Initialize pipelines for each individual request
+  for (size_t i = 0; i < nrequests; i++) {
+    initializeAREQ(requests[i]);
+    // Each sub-AREQ gets its own wrapper, holding the whole command
+    // rather than its own slice: slice boundaries are only discovered
+    // while parsing, and sub pipelines borrow beyond their slice anyway
+    // (distributed tail steps like LOAD, PARAMS).
+    BlockedRequestCtx_NewAREQ(requests[i], argv, argc);
+    hybridReq->errors[i] = QueryError_Default();
+    Pipeline_Initialize(&requests[i]->pipeline, requests[i]->reqConfig.timeoutPolicy,
+                        &hybridReq->errors[i]);
+  }
+  hybridReq->profileClocks.initClock = now;
 
-    // Initialize timeout coordination fields (embedded per-request slot only;
-    // the aggregate-coord fields live on the heap BlockedRequestCtx wrapper).
-    RequestSyncState_Init(&hybridReq->syncState);
-    pthread_mutex_init(&hybridReq->cursorMutex, NULL);
-
-
+  // Initialize timeout coordination fields (embedded per-request slot only;
+  // the aggregate-coord fields live on the heap BlockedRequestCtx wrapper).
+  RequestSyncState_Init(&hybridReq->syncState);
+  pthread_mutex_init(&hybridReq->cursorMutex, NULL);
 }
 
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests,
                                  RedisModuleString **argv, uint32_t argc) {
-    // The wrappers hold the full command; each sub takes its own holds — a
-    // sub's borrows can outlive the container.
-    HybridRequest *hybridReq = rm_calloc(1, sizeof(*hybridReq));
-    HybridRequest_Init(hybridReq, sctx, requests, nrequests, argv, argc);
-    // Wrap the top-level hybrid request in its single-owner sync context.
-    // Sets hybridReq->brc; ownership is released via HybridRequest_DecrRef.
-    BlockedRequestCtx_NewHybrid(hybridReq, argv, argc);
-    return hybridReq;
+  // The wrappers hold the full command; each sub takes its own holds — a
+  // sub's borrows can outlive the container.
+  HybridRequest *hybridReq = rm_calloc(1, sizeof(*hybridReq));
+  HybridRequest_Init(hybridReq, sctx, requests, nrequests, argv, argc);
+  // Wrap the top-level hybrid request in its single-owner sync context.
+  // Sets hybridReq->brc; ownership is released via HybridRequest_DecrRef.
+  BlockedRequestCtx_NewHybrid(hybridReq, argv, argc);
+  return hybridReq;
 }
 
 void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, uint32_t argc) {
@@ -500,7 +500,8 @@ static RedisSearchCtx* createThreadSafeSearchContext(RedisModuleCtx *ctx, const 
   return NewSearchCtxC(detachedCtx, indexname, true);
 }
 
-HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx, RedisModuleString **argv, uint32_t argc) {
+HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx, RedisModuleString **argv,
+                                        uint32_t argc) {
   extern size_t NumShards;  // Declared in module.c
   AREQ *search = AREQ_New();
   AREQ *vector = AREQ_New();

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -307,16 +307,10 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
     // Initialize pipelines for each individual request
     for (size_t i = 0; i < nrequests; i++) {
         initializeAREQ(requests[i]);
-        // Each sub-AREQ gets its own wrapper at construction (on the main
-        // thread, like every request wrapper): cursor-backing sub-AREQs run
-        // RETURN_STRICT FT.CURSOR READ cycles against it. Freed with the
-        // sub-AREQ (AREQ_DecrRef -> BlockedRequestCtx_Free).
-        // Each sub holds the whole command, not just its own slice: the
-        // slice boundaries are only discovered while parsing (holds must
-        // come first), and sub pipelines borrow beyond their slice anyway —
-        // tail-plan steps (e.g. LOAD) are distributed into sub pipelines,
-        // and PARAMS live in the tail. The sub holds mirror the container's
-        // index for index.
+        // Each sub-AREQ gets its own wrapper, holding the whole command
+        // rather than its own slice: slice boundaries are only discovered
+        // while parsing, and sub pipelines borrow beyond their slice anyway
+        // (distributed tail steps like LOAD, PARAMS).
         BlockedRequestCtx_NewAREQ(requests[i], argv, argc);
         hybridReq->errors[i] = QueryError_Default();
         Pipeline_Initialize(&requests[i]->pipeline, requests[i]->reqConfig.timeoutPolicy, &hybridReq->errors[i]);
@@ -333,9 +327,8 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
 
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests,
                                  RedisModuleString **argv, int argc) {
-    // Skip the command and index tokens; the wrappers hold the rest. The
-    // sub-AREQ wrappers take their own holds: a sub's plan borrows must stay
-    // valid for the sub's own lifetime, which can exceed the container's.
+    // Skip the command and index tokens; the wrappers hold the rest. Each sub
+    // takes its own holds — a sub's borrows can outlive the container.
     if (argv) {
       const int step = argc > 2 ? 2 : argc;
       argv += step;
@@ -352,11 +345,8 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
 void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, RedisModuleString **argv, int argc) {
   // skip command and index name
   const int step = argc > 2 ? 2 : argc;
-  // Construction held the argv on the main thread, before any parsing
-  // begins; string refcounts are main-thread-only.
   RS_ASSERT(req->brc->argvHolds != NULL);
-  // The caller's argc bounds the parse (the coordinator debug flow strips
-  // trailing debug params); the holds may cover a superset.
+  // argc bounds the parse; the holds may cover a superset (debug flows)
   RS_ASSERT((size_t)(argc - step) <= req->brc->nargvHolds);
   ArgsCursor_InitRString(ac, req->brc->argvHolds, argc - step);
 }

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -344,8 +344,8 @@ void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, RedisModul
   // skip command and index name
   const int step = argc > 2 ? 2 : argc;
   // argc bounds the parse; the holds may cover a superset (debug flows)
-  RS_ASSERT((size_t)(argc - step) <= req->brc->nargvHolds);
-  ArgsCursor_InitRString(ac, req->brc->argvHolds, argc - step);
+  RS_ASSERT((size_t)(argc - step) <= req->brc->argc);
+  ArgsCursor_InitRString(ac, req->brc->argv, argc - step);
 }
 
 /**

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -278,7 +278,8 @@ int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params
  * @param requests Array of AREQ pointers, the hybrid request takes ownership
  * @param nrequests Number of requests in the array
  */
-void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **requests, size_t nrequests) {
+void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **requests,
+                        size_t nrequests, RedisModuleString **argv, int argc) {
     hybridReq->requests = requests;
     hybridReq->nrequests = nrequests;
     hybridReq->sctx = sctx;
@@ -307,11 +308,16 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
     for (size_t i = 0; i < nrequests; i++) {
         initializeAREQ(requests[i]);
         // Each sub-AREQ gets its own wrapper at construction (on the main
-        // thread, like every request wrapper): it carries the sub's argv
-        // holds, and cursor-backing sub-AREQs run RETURN_STRICT FT.CURSOR
-        // READ cycles against it. Freed with the sub-AREQ
-        // (AREQ_DecrRef -> BlockedRequestCtx_Free).
-        BlockedRequestCtx_NewAREQ(requests[i]);
+        // thread, like every request wrapper): cursor-backing sub-AREQs run
+        // RETURN_STRICT FT.CURSOR READ cycles against it. Freed with the
+        // sub-AREQ (AREQ_DecrRef -> BlockedRequestCtx_Free).
+        // Each sub holds the whole command, not just its own slice: the
+        // slice boundaries are only discovered while parsing (holds must
+        // come first), and sub pipelines borrow beyond their slice anyway —
+        // tail-plan steps (e.g. LOAD) are distributed into sub pipelines,
+        // and PARAMS live in the tail. The sub holds mirror the container's
+        // index for index.
+        BlockedRequestCtx_NewAREQ(requests[i], argv, argc);
         hybridReq->errors[i] = QueryError_Default();
         Pipeline_Initialize(&requests[i]->pipeline, requests[i]->reqConfig.timeoutPolicy, &hybridReq->errors[i]);
     }
@@ -325,35 +331,29 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
 
 }
 
-HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests) {
+HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests,
+                                 RedisModuleString **argv, int argc) {
+    // Skip the command and index tokens; the wrappers hold the rest. The
+    // sub-AREQ wrappers take their own holds: a sub's plan borrows must stay
+    // valid for the sub's own lifetime, which can exceed the container's.
+    if (argv) {
+      const int step = argc > 2 ? 2 : argc;
+      argv += step;
+      argc -= step;
+    }
     HybridRequest *hybridReq = rm_calloc(1, sizeof(*hybridReq));
-    HybridRequest_Init(hybridReq, sctx, requests, nrequests);
+    HybridRequest_Init(hybridReq, sctx, requests, nrequests, argv, argc);
     // Wrap the top-level hybrid request in its single-owner sync context.
     // Sets hybridReq->brc; ownership is released via HybridRequest_DecrRef.
-    BlockedRequestCtx_NewHybrid(hybridReq);
+    BlockedRequestCtx_NewHybrid(hybridReq, argv, argc);
     return hybridReq;
-}
-
-void HybridRequest_HoldArgv(HybridRequest *req, RedisModuleString **argv, int argc) {
-  // skip command and index name
-  const int step = argc > 2 ? 2 : argc;
-  argv += step;
-  argc -= step;
-  BlockedRequestCtx_HoldArgv(req->brc, argv, argc);
-  // Each sub-AREQ's wrapper takes its own holds: the sub's plan borrows must
-  // stay valid for the sub-AREQ's own lifetime, which can exceed the
-  // container's. The arrays are parallel: sub holds mirror the container's
-  // holds index for index.
-  for (size_t i = 0; i < req->nrequests; i++) {
-    BlockedRequestCtx_HoldArgv(req->requests[i]->brc, argv, argc);
-  }
 }
 
 void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, RedisModuleString **argv, int argc) {
   // skip command and index name
   const int step = argc > 2 ? 2 : argc;
-  // The dispatch site held the argv on the main thread (HybridRequest_HoldArgv)
-  // before any parsing begins; string refcounts are main-thread-only.
+  // Construction held the argv on the main thread, before any parsing
+  // begins; string refcounts are main-thread-only.
   RS_ASSERT(req->brc->argvHolds != NULL);
   // The caller's argc bounds the parse (the coordinator debug flow strips
   // trailing debug params); the holds may cover a superset.
@@ -514,7 +514,7 @@ static RedisSearchCtx* createThreadSafeSearchContext(RedisModuleCtx *ctx, const 
   return NewSearchCtxC(detachedCtx, indexname, true);
 }
 
-HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx) {
+HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx, RedisModuleString **argv, int argc) {
   extern size_t NumShards;  // Declared in module.c
   AREQ *search = AREQ_New();
   AREQ *vector = AREQ_New();
@@ -524,7 +524,7 @@ HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx) {
   arrayof(AREQ*) requests = array_new(AREQ*, HYBRID_REQUEST_NUM_SUBQUERIES);
   requests = array_ensure_append_1(requests, search);
   requests = array_ensure_append_1(requests, vector);
-  return HybridRequest_New(sctx, requests, array_len(requests));
+  return HybridRequest_New(sctx, requests, array_len(requests), argv, argc);
 }
 
 void AddValidationErrorContext(AREQ *req, QueryError *status) {

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -278,8 +278,7 @@ int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params
  * @param requests Array of AREQ pointers, the hybrid request takes ownership
  * @param nrequests Number of requests in the array
  */
-void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **requests,
-                        size_t nrequests, RedisModuleString **argv, uint32_t argc) {
+void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **requests, size_t nrequests, RedisModuleString **argv, uint32_t argc) {
   hybridReq->requests = requests;
   hybridReq->nrequests = nrequests;
   hybridReq->sctx = sctx;
@@ -325,8 +324,7 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
   pthread_mutex_init(&hybridReq->cursorMutex, NULL);
 }
 
-HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests,
-                                 RedisModuleString **argv, uint32_t argc) {
+HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests, RedisModuleString **argv, uint32_t argc) {
   // The wrappers hold the full command; each sub takes its own holds — a
   // sub's borrows can outlive the container.
   HybridRequest *hybridReq = rm_calloc(1, sizeof(*hybridReq));
@@ -500,8 +498,7 @@ static RedisSearchCtx* createThreadSafeSearchContext(RedisModuleCtx *ctx, const 
   return NewSearchCtxC(detachedCtx, indexname, true);
 }
 
-HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx, RedisModuleString **argv,
-                                        uint32_t argc) {
+HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx, RedisModuleString **argv, uint32_t argc) {
   extern size_t NumShards;  // Declared in module.c
   AREQ *search = AREQ_New();
   AREQ *vector = AREQ_New();

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -327,11 +327,8 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
 
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests,
                                  RedisModuleString **argv, int argc) {
-    // Skip the command and index tokens; the wrappers hold the rest. Each sub
-    // takes its own holds — a sub's borrows can outlive the container.
-    const int step = argc > 2 ? 2 : argc;
-    argv += step;
-    argc -= step;
+    // The wrappers hold the full command; each sub takes its own holds — a
+    // sub's borrows can outlive the container.
     HybridRequest *hybridReq = rm_calloc(1, sizeof(*hybridReq));
     HybridRequest_Init(hybridReq, sctx, requests, nrequests, argv, argc);
     // Wrap the top-level hybrid request in its single-owner sync context.
@@ -340,12 +337,14 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
     return hybridReq;
 }
 
-void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, RedisModuleString **argv, int argc) {
-  // skip command and index name
-  const int step = argc > 2 ? 2 : argc;
-  // argc bounds the parse; the holds may cover a superset (debug flows)
-  RS_ASSERT((size_t)(argc - step) <= req->brc->argc);
-  ArgsCursor_InitRString(ac, req->brc->argv, argc - step);
+void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, int argc) {
+  // argc bounds the parse; the holds may cover a superset (debug flows).
+  RS_ASSERT((size_t)argc <= req->brc->argc);
+  // The cursor covers the whole held command, pre-advanced past the command
+  // and index names: recorded positions (sub queryOffsets, syntax-error
+  // offsets) are relative to the full command.
+  ArgsCursor_InitRString(ac, req->brc->argv, argc);
+  AC_AdvanceBy(ac, argc > 2 ? 2 : argc);
 }
 
 /**

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -279,7 +279,7 @@ int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params
  * @param nrequests Number of requests in the array
  */
 void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **requests,
-                        size_t nrequests, RedisModuleString **argv, int argc) {
+                        size_t nrequests, RedisModuleString **argv, uint32_t argc) {
     hybridReq->requests = requests;
     hybridReq->nrequests = nrequests;
     hybridReq->sctx = sctx;
@@ -326,7 +326,7 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
 }
 
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests,
-                                 RedisModuleString **argv, int argc) {
+                                 RedisModuleString **argv, uint32_t argc) {
     // The wrappers hold the full command; each sub takes its own holds — a
     // sub's borrows can outlive the container.
     HybridRequest *hybridReq = rm_calloc(1, sizeof(*hybridReq));
@@ -337,13 +337,13 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
     return hybridReq;
 }
 
-void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, int argc) {
+void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, uint32_t argc) {
   // argc bounds the parse; the holds may cover a superset (debug flows).
-  RS_ASSERT((size_t)argc <= req->brc->argc);
+  RS_ASSERT(argc <= req->brc->argc);
   // The cursor covers the whole held command, pre-advanced past the command
   // and index names: recorded positions (sub queryOffsets, syntax-error
   // offsets) are relative to the full command.
-  ArgsCursor_InitRString(ac, req->brc->argv, argc);
+  ArgsCursor_InitRString(ac, req->brc->argv, (int)argc);
   AC_AdvanceBy(ac, argc > 2 ? 2 : argc);
 }
 
@@ -500,7 +500,7 @@ static RedisSearchCtx* createThreadSafeSearchContext(RedisModuleCtx *ctx, const 
   return NewSearchCtxC(detachedCtx, indexname, true);
 }
 
-HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx, RedisModuleString **argv, int argc) {
+HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx, RedisModuleString **argv, uint32_t argc) {
   extern size_t NumShards;  // Declared in module.c
   AREQ *search = AREQ_New();
   AREQ *vector = AREQ_New();

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -328,22 +328,34 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
     return hybridReq;
 }
 
-void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, RedisModuleString **argv, int argc) {
+void HybridRequest_HoldArgv(HybridRequest *req, RedisModuleString **argv, int argc) {
+  RS_ASSERT(req->argv == NULL);
   // skip command and index name
   const int step = argc > 2 ? 2 : argc;
   argv += step;
   argc -= step;
-  req->args = rm_calloc(argc, sizeof(*req->args));
+  req->argv = rm_calloc(argc, sizeof(*req->argv));
   req->nargs = argc;
-  // Copy the arguments into an owned array of sds strings
-  for (size_t ii = 0; ii < argc; ++ii) {
-    size_t n;
-    const char *s = RedisModule_StringPtrLen(argv[ii], &n);
-    req->args[ii] = sdsnewlen(s, n);
+  for (int ii = 0; ii < argc; ++ii) {
+    req->argv[ii] = RedisModule_HoldString(NULL, argv[ii]);
   }
+  // Each sub-AREQ takes its own holds: its plan's borrows must stay valid for
+  // the sub-AREQ's own lifetime, which can exceed the container's.
+  for (size_t i = 0; i < req->nrequests; i++) {
+    AREQ_HoldArgv(req->requests[i], req->argv, req->nargs);
+  }
+}
 
-  // Parse the query and basic keywords first..
-  ArgsCursor_InitSDS(ac, req->args, req->nargs);
+void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, RedisModuleString **argv, int argc) {
+  // skip command and index name
+  const int step = argc > 2 ? 2 : argc;
+  if (!req->argv) {
+    HybridRequest_HoldArgv(req, argv, argc);
+  }
+  // The caller's argc bounds the parse (the coordinator debug flow strips
+  // trailing debug params); the holds may cover a superset.
+  RS_ASSERT((size_t)(argc - step) <= req->nargs);
+  ArgsCursor_InitRString(ac, req->argv, argc - step);
 }
 
 /**
@@ -428,11 +440,13 @@ void HybridRequest_Free(HybridRequest *req) {
 
     RequestSyncState_Destroy(&req->syncState);
 
-    if (req->args) {
+    if (req->argv) {
+      // Runs on the main thread (wrapper OnFree / inline release): argv
+      // string refcounts are not thread safe.
       for (size_t ii = 0; ii < req->nargs; ++ii) {
-        sdsfree(req->args[ii]);
+        RedisModule_FreeString(NULL, req->argv[ii]);
       }
-      rm_free(req->args);
+      rm_free(req->argv);
     }
 
     rm_free(req);

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -329,11 +329,9 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
                                  RedisModuleString **argv, int argc) {
     // Skip the command and index tokens; the wrappers hold the rest. Each sub
     // takes its own holds — a sub's borrows can outlive the container.
-    if (argv) {
-      const int step = argc > 2 ? 2 : argc;
-      argv += step;
-      argc -= step;
-    }
+    const int step = argc > 2 ? 2 : argc;
+    argv += step;
+    argc -= step;
     HybridRequest *hybridReq = rm_calloc(1, sizeof(*hybridReq));
     HybridRequest_Init(hybridReq, sctx, requests, nrequests, argv, argc);
     // Wrap the top-level hybrid request in its single-owner sync context.
@@ -345,7 +343,6 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
 void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, RedisModuleString **argv, int argc) {
   // skip command and index name
   const int step = argc > 2 ? 2 : argc;
-  RS_ASSERT(req->brc->argvHolds != NULL);
   // argc bounds the parse; the holds may cover a superset (debug flows)
   RS_ASSERT((size_t)(argc - step) <= req->brc->nargvHolds);
   ArgsCursor_InitRString(ac, req->brc->argvHolds, argc - step);

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -301,20 +301,20 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
     hybridReq->tailPipeline = rm_calloc(1, sizeof(Pipeline));
     AGPLN_Init(&hybridReq->tailPipeline->ap);
     hybridReq->tailPipelineError = QueryError_Default();
-  Pipeline_Initialize(hybridReq->tailPipeline, hybridReq->reqConfig.timeoutPolicy,
-                      &hybridReq->tailPipelineError);
+    Pipeline_Initialize(hybridReq->tailPipeline, hybridReq->reqConfig.timeoutPolicy,
+                        &hybridReq->tailPipelineError);
 
     // Initialize pipelines for each individual request
     for (size_t i = 0; i < nrequests; i++) {
         initializeAREQ(requests[i]);
-    // Each sub-AREQ gets its own wrapper, holding the whole command
-    // rather than its own slice: slice boundaries are only discovered
-    // while parsing, and sub pipelines borrow beyond their slice anyway
-    // (distributed tail steps like LOAD, PARAMS).
-    BlockedRequestCtx_NewAREQ(requests[i], argv, argc);
+        // Each sub-AREQ gets its own wrapper, holding the whole command
+        // rather than its own slice: slice boundaries are only discovered
+        // while parsing, and sub pipelines borrow beyond their slice anyway
+        // (distributed tail steps like LOAD, PARAMS).
+        BlockedRequestCtx_NewAREQ(requests[i], argv, argc);
         hybridReq->errors[i] = QueryError_Default();
-    Pipeline_Initialize(&requests[i]->pipeline, requests[i]->reqConfig.timeoutPolicy,
-                        &hybridReq->errors[i]);
+        Pipeline_Initialize(&requests[i]->pipeline, requests[i]->reqConfig.timeoutPolicy,
+                            &hybridReq->errors[i]);
     }
     hybridReq->profileClocks.initClock = now;
 
@@ -325,13 +325,13 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
 }
 
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests, RedisModuleString **argv, uint32_t argc) {
-  // The wrappers hold the full command; each sub takes its own holds — a
-  // sub's borrows can outlive the container.
+    // The wrappers hold the full command; each sub takes its own holds — a
+    // sub's borrows can outlive the container.
     HybridRequest *hybridReq = rm_calloc(1, sizeof(*hybridReq));
-  HybridRequest_Init(hybridReq, sctx, requests, nrequests, argv, argc);
+    HybridRequest_Init(hybridReq, sctx, requests, nrequests, argv, argc);
     // Wrap the top-level hybrid request in its single-owner sync context.
     // Sets hybridReq->brc; ownership is released via HybridRequest_DecrRef.
-  BlockedRequestCtx_NewHybrid(hybridReq, argv, argc);
+    BlockedRequestCtx_NewHybrid(hybridReq, argv, argc);
     return hybridReq;
 }
 

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -279,60 +279,60 @@ int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params
  * @param nrequests Number of requests in the array
  */
 void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **requests, size_t nrequests, RedisModuleString **argv, uint32_t argc) {
-  hybridReq->requests = requests;
-  hybridReq->nrequests = nrequests;
-  hybridReq->sctx = sctx;
-  hybridReq->kArgIndex = -1;
-  // Snapshot the request's config; nothing may re-read RSGlobalConfig for
-  // the request's lifetime.
-  hybridReq->reqConfig = RSGlobalConfig.requestConfigParams;
+    hybridReq->requests = requests;
+    hybridReq->nrequests = nrequests;
+    hybridReq->sctx = sctx;
+    hybridReq->kArgIndex = -1;
+    // Snapshot the request's config; nothing may re-read RSGlobalConfig for
+    // the request's lifetime.
+    hybridReq->reqConfig = RSGlobalConfig.requestConfigParams;
 
-  rs_wall_clock now = {0};
-  rs_wall_clock_init(&now);
+    rs_wall_clock now = {0};
+    rs_wall_clock_init(&now);
 
-  // Initialize error tracking for each individual request
-  hybridReq->errors = array_newlen(QueryError, nrequests);
-  memset(hybridReq->errors, 0, nrequests * sizeof(QueryError));
+    // Initialize error tracking for each individual request
+    hybridReq->errors = array_newlen(QueryError, nrequests);
+    memset(hybridReq->errors, 0, nrequests * sizeof(QueryError));
 
-  // Initialize return codes array for tracking subqueries final states
-  hybridReq->subqueriesReturnCodes = rm_calloc(nrequests, sizeof(RPStatus));
+    // Initialize return codes array for tracking subqueries final states
+    hybridReq->subqueriesReturnCodes = rm_calloc(nrequests, sizeof(RPStatus));
 
-  // Initialize the tail pipeline that will merge results from all requests
-  hybridReq->tailPipeline = rm_calloc(1, sizeof(Pipeline));
-  AGPLN_Init(&hybridReq->tailPipeline->ap);
-  hybridReq->tailPipelineError = QueryError_Default();
+    // Initialize the tail pipeline that will merge results from all requests
+    hybridReq->tailPipeline = rm_calloc(1, sizeof(Pipeline));
+    AGPLN_Init(&hybridReq->tailPipeline->ap);
+    hybridReq->tailPipelineError = QueryError_Default();
   Pipeline_Initialize(hybridReq->tailPipeline, hybridReq->reqConfig.timeoutPolicy,
                       &hybridReq->tailPipelineError);
 
-  // Initialize pipelines for each individual request
-  for (size_t i = 0; i < nrequests; i++) {
-    initializeAREQ(requests[i]);
+    // Initialize pipelines for each individual request
+    for (size_t i = 0; i < nrequests; i++) {
+        initializeAREQ(requests[i]);
     // Each sub-AREQ gets its own wrapper, holding the whole command
     // rather than its own slice: slice boundaries are only discovered
     // while parsing, and sub pipelines borrow beyond their slice anyway
     // (distributed tail steps like LOAD, PARAMS).
     BlockedRequestCtx_NewAREQ(requests[i], argv, argc);
-    hybridReq->errors[i] = QueryError_Default();
+        hybridReq->errors[i] = QueryError_Default();
     Pipeline_Initialize(&requests[i]->pipeline, requests[i]->reqConfig.timeoutPolicy,
                         &hybridReq->errors[i]);
-  }
-  hybridReq->profileClocks.initClock = now;
+    }
+    hybridReq->profileClocks.initClock = now;
 
-  // Initialize timeout coordination fields (embedded per-request slot only;
-  // the aggregate-coord fields live on the heap BlockedRequestCtx wrapper).
-  RequestSyncState_Init(&hybridReq->syncState);
-  pthread_mutex_init(&hybridReq->cursorMutex, NULL);
+    // Initialize timeout coordination fields (embedded per-request slot only;
+    // the aggregate-coord fields live on the heap BlockedRequestCtx wrapper).
+    RequestSyncState_Init(&hybridReq->syncState);
+    pthread_mutex_init(&hybridReq->cursorMutex, NULL);
 }
 
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests, RedisModuleString **argv, uint32_t argc) {
   // The wrappers hold the full command; each sub takes its own holds — a
   // sub's borrows can outlive the container.
-  HybridRequest *hybridReq = rm_calloc(1, sizeof(*hybridReq));
+    HybridRequest *hybridReq = rm_calloc(1, sizeof(*hybridReq));
   HybridRequest_Init(hybridReq, sctx, requests, nrequests, argv, argc);
-  // Wrap the top-level hybrid request in its single-owner sync context.
-  // Sets hybridReq->brc; ownership is released via HybridRequest_DecrRef.
+    // Wrap the top-level hybrid request in its single-owner sync context.
+    // Sets hybridReq->brc; ownership is released via HybridRequest_DecrRef.
   BlockedRequestCtx_NewHybrid(hybridReq, argv, argc);
-  return hybridReq;
+    return hybridReq;
 }
 
 void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, uint32_t argc) {

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -306,6 +306,12 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
     // Initialize pipelines for each individual request
     for (size_t i = 0; i < nrequests; i++) {
         initializeAREQ(requests[i]);
+        // Each sub-AREQ gets its own wrapper at construction (on the main
+        // thread, like every request wrapper): it carries the sub's argv
+        // holds, and cursor-backing sub-AREQs run RETURN_STRICT FT.CURSOR
+        // READ cycles against it. Freed with the sub-AREQ
+        // (AREQ_DecrRef -> BlockedRequestCtx_Free).
+        BlockedRequestCtx_NewAREQ(requests[i]);
         hybridReq->errors[i] = QueryError_Default();
         Pipeline_Initialize(&requests[i]->pipeline, requests[i]->reqConfig.timeoutPolicy, &hybridReq->errors[i]);
     }
@@ -329,33 +335,30 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
 }
 
 void HybridRequest_HoldArgv(HybridRequest *req, RedisModuleString **argv, int argc) {
-  RS_ASSERT(req->argv == NULL);
   // skip command and index name
   const int step = argc > 2 ? 2 : argc;
   argv += step;
   argc -= step;
-  req->argv = rm_calloc(argc, sizeof(*req->argv));
-  req->nargs = argc;
-  for (int ii = 0; ii < argc; ++ii) {
-    req->argv[ii] = RedisModule_HoldString(NULL, argv[ii]);
-  }
-  // Each sub-AREQ takes its own holds: its plan's borrows must stay valid for
-  // the sub-AREQ's own lifetime, which can exceed the container's.
+  BlockedRequestCtx_HoldArgv(req->brc, argv, argc);
+  // Each sub-AREQ's wrapper takes its own holds: the sub's plan borrows must
+  // stay valid for the sub-AREQ's own lifetime, which can exceed the
+  // container's. The arrays are parallel: sub holds mirror the container's
+  // holds index for index.
   for (size_t i = 0; i < req->nrequests; i++) {
-    AREQ_HoldArgv(req->requests[i], req->argv, req->nargs);
+    BlockedRequestCtx_HoldArgv(req->requests[i]->brc, argv, argc);
   }
 }
 
 void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, RedisModuleString **argv, int argc) {
   // skip command and index name
   const int step = argc > 2 ? 2 : argc;
-  if (!req->argv) {
+  if (!req->brc->argvHolds) {
     HybridRequest_HoldArgv(req, argv, argc);
   }
   // The caller's argc bounds the parse (the coordinator debug flow strips
   // trailing debug params); the holds may cover a superset.
-  RS_ASSERT((size_t)(argc - step) <= req->nargs);
-  ArgsCursor_InitRString(ac, req->argv, argc - step);
+  RS_ASSERT((size_t)(argc - step) <= req->brc->nargvHolds);
+  ArgsCursor_InitRString(ac, req->brc->argvHolds, argc - step);
 }
 
 /**
@@ -439,15 +442,6 @@ void HybridRequest_Free(HybridRequest *req) {
     rm_free(req->debugParams);
 
     RequestSyncState_Destroy(&req->syncState);
-
-    if (req->argv) {
-      // Runs on the main thread (wrapper OnFree / inline release): argv
-      // string refcounts are not thread safe.
-      for (size_t ii = 0; ii < req->nargs; ++ii) {
-        RedisModule_FreeString(NULL, req->argv[ii]);
-      }
-      rm_free(req->argv);
-    }
 
     rm_free(req);
 }

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -352,9 +352,9 @@ void HybridRequest_HoldArgv(HybridRequest *req, RedisModuleString **argv, int ar
 void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, RedisModuleString **argv, int argc) {
   // skip command and index name
   const int step = argc > 2 ? 2 : argc;
-  if (!req->brc->argvHolds) {
-    HybridRequest_HoldArgv(req, argv, argc);
-  }
+  // The dispatch site held the argv on the main thread (HybridRequest_HoldArgv)
+  // before any parsing begins; string refcounts are main-thread-only.
+  RS_ASSERT(req->brc->argvHolds != NULL);
   // The caller's argc bounds the parse (the coordinator debug flow strips
   // trailing debug params); the holds may cover a superset.
   RS_ASSERT((size_t)(argc - step) <= req->brc->nargvHolds);

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -301,8 +301,7 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
     hybridReq->tailPipeline = rm_calloc(1, sizeof(Pipeline));
     AGPLN_Init(&hybridReq->tailPipeline->ap);
     hybridReq->tailPipelineError = QueryError_Default();
-    Pipeline_Initialize(hybridReq->tailPipeline, hybridReq->reqConfig.timeoutPolicy,
-                        &hybridReq->tailPipelineError);
+    Pipeline_Initialize(hybridReq->tailPipeline, hybridReq->reqConfig.timeoutPolicy, &hybridReq->tailPipelineError);
 
     // Initialize pipelines for each individual request
     for (size_t i = 0; i < nrequests; i++) {
@@ -313,8 +312,7 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
         // (distributed tail steps like LOAD, PARAMS).
         BlockedRequestCtx_NewAREQ(requests[i], argv, argc);
         hybridReq->errors[i] = QueryError_Default();
-        Pipeline_Initialize(&requests[i]->pipeline, requests[i]->reqConfig.timeoutPolicy,
-                            &hybridReq->errors[i]);
+        Pipeline_Initialize(&requests[i]->pipeline, requests[i]->reqConfig.timeoutPolicy, &hybridReq->errors[i]);
     }
     hybridReq->profileClocks.initClock = now;
 

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -151,10 +151,9 @@ typedef struct blockedClientHybridCtx {
  * @param sctx The main search context for the hybrid request - the redisCtx inside can change if moving to different thread
  * @param requests Array of AREQ pointers representing individual search requests, the hybrid request will take ownership of the array
  * @param nrequests Number of requests in the array
- * @param argv The command argv; the container's and each sub-request's
- *   wrapper take holds on the strings past the command and index tokens
- *   (main-thread only — see BlockedRequestCtx.argvHolds). May be NULL only
- *   for a request that is never parsed.
+ * @param argv The command argv, not NULL; the container's and each
+ *   sub-request's wrapper take holds on the strings past the command and
+ *   index tokens (main-thread only — see BlockedRequestCtx.argvHolds)
  * @param argc Number of strings in argv
 */
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests,
@@ -169,7 +168,7 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
  * @param requests Array of AREQ pointers, the hybrid request takes ownership
  * @param nrequests Number of requests in the array
  * @param argv Already-stepped argv slice each sub-request's wrapper holds
- *   (see HybridRequest_New); may be NULL
+ *   (see HybridRequest_New); not NULL
  * @param argc Number of strings in argv
  */
 void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **requests,

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -21,61 +21,61 @@ struct Cursor;
 #define HYBRID_IMPLICIT_KEY_FIELD "__key"
 
 typedef struct HybridRequest {
-  arrayof(AREQ *) requests;
-  size_t nrequests;
-  QueryError tailPipelineError;
-  QueryError *errors;
-  Pipeline *tailPipeline;
-  RequestConfig reqConfig;
-  CursorConfig cursorConfig;
-  RPStatus *subqueriesReturnCodes;  // Array to store return codes from each subquery
-  RedisSearchCtx *sctx;
-  QEFlags reqflags;
-  ProfileClocks profileClocks;
-  profiler_func profile;
-  ProfilePrinterCtx profileCtx;
+    arrayof(AREQ*) requests;
+    size_t nrequests;
+    QueryError tailPipelineError;
+    QueryError *errors;
+    Pipeline *tailPipeline;
+    RequestConfig reqConfig;
+    CursorConfig cursorConfig;
+    RPStatus *subqueriesReturnCodes;  // Array to store return codes from each subquery
+    RedisSearchCtx *sctx;
+    QEFlags reqflags;
+    ProfileClocks profileClocks;
+    profiler_func profile;
+    ProfilePrinterCtx profileCtx;
 
-  // Synchronization context for timeout/reply callbacks.
-  // Holds the per-request timeout flag and abort-wake channel.
-  RequestSyncState syncState;
+    // Synchronization context for timeout/reply callbacks.
+    // Holds the per-request timeout flag and abort-wake channel.
+    RequestSyncState syncState;
 
-  // Non-owning back-pointer to the heap wrapper that owns this request.
-  BlockedRequestCtx *brc;
+    // Non-owning back-pointer to the heap wrapper that owns this request.
+    BlockedRequestCtx *brc;
 
-  // Flag to indicate whether to skip timeout checks using clock checks
-  bool skipTimeoutChecks;
+    // Flag to indicate whether to skip timeout checks using clock checks
+    bool skipTimeoutChecks;
 
-  bool useReplyCallback;
+    bool useReplyCallback;
 
-  // State for reply_callback path (FAIL policy with workers in coordinator mode)
-  // Background thread stores results here, then calls UnblockClient.
-  // Mutex for synchronizing cursor creation with timeout callback.
-  // Protects cursor array access to ensure proper cleanup on timeout.
-  pthread_mutex_t cursorMutex;
+    // State for reply_callback path (FAIL policy with workers in coordinator mode)
+    // Background thread stores results here, then calls UnblockClient.
+    // Mutex for synchronizing cursor creation with timeout callback.
+    // Protects cursor array access to ensure proper cleanup on timeout.
+    pthread_mutex_t cursorMutex;
 
-  // Array of depleted cursors for reply_callback path (internal hybrid search).
-  // Non-NULL only after the initial cursor pipelines are safe to publish.
-  // Protected by cursorMutex to synchronize with timeout callback.
-  // Cleanup is handled by:
-  // - reply_callback: frees array after replying with cursor IDs
-  // - timeout_callback: acquires lock and consumes published cursors, if any
-  // - HybridRequest_StartCursors: checks timedOut flag before publishing, or frees on error
-  arrayof(struct Cursor *) cursors;
+    // Array of depleted cursors for reply_callback path (internal hybrid search).
+    // Non-NULL only after the initial cursor pipelines are safe to publish.
+    // Protected by cursorMutex to synchronize with timeout callback.
+    // Cleanup is handled by:
+    // - reply_callback: frees array after replying with cursor IDs
+    // - timeout_callback: acquires lock and consumes published cursors, if any
+    // - HybridRequest_StartCursors: checks timedOut flag before publishing, or frees on error
+    arrayof(struct Cursor*) cursors;
 
-  // Optional debug parameters for _FT.DEBUG FT.HYBRID.
-  // When non-NULL, debug timeouts are applied after pipeline building.
-  // Heap-allocated and owned by HybridRequest — freed in HybridRequest_Free.
-  HybridDebugParams *debugParams;
+    // Optional debug parameters for _FT.DEBUG FT.HYBRID.
+    // When non-NULL, debug timeouts are applied after pipeline building.
+    // Heap-allocated and owned by HybridRequest — freed in HybridRequest_Free.
+    HybridDebugParams *debugParams;
 
-  // Thread pool ID used for coordinator depletion and tail continuation jobs.
-  // Set once before pipeline construction; read by BuildDistributedDepletionPipeline
-  // and scheduleHybridTail.
-  int poolId;
-  // Index of the K value argument in the MRCommand for SHARD_K_RATIO
-  // optimization.
-  // Set during command building, used by command modifier callback. -1 if
-  // not applicable.
-  int kArgIndex;
+    // Thread pool ID used for coordinator depletion and tail continuation jobs.
+    // Set once before pipeline construction; read by BuildDistributedDepletionPipeline
+    // and scheduleHybridTail.
+    int poolId;
+    // Index of the K value argument in the MRCommand for SHARD_K_RATIO
+    // optimization.
+    // Set during command building, used by command modifier callback. -1 if
+    // not applicable.
+    int kArgIndex;
 } HybridRequest;
 
 // Timeout helper functions for HybridRequest (mirrors AREQ pattern)
@@ -148,16 +148,14 @@ typedef struct blockedClientHybridCtx {
  * Create a new HybridRequest that manages multiple search requests for hybrid search.
  * This function initializes the hybrid request structure and sets up the tail pipeline
  * that will be used to merge and process results from all individual search requests.
- * @param sctx The main search context for the hybrid request - the redisCtx inside can change if
- * moving to different thread
- * @param requests Array of AREQ pointers representing individual search requests, the hybrid
- * request will take ownership of the array
+ * @param sctx The main search context for the hybrid request - the redisCtx inside can change if moving to different thread
+ * @param requests Array of AREQ pointers representing individual search requests, the hybrid request will take ownership of the array
  * @param nrequests Number of requests in the array
  * @param argv The command argv, not NULL; the container's and each
  *   sub-request's wrapper take holds on the full command (main-thread only —
  *   see BlockedRequestCtx.argv)
  * @param argc Number of strings in argv
- */
+*/
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests, RedisModuleString **argv, uint32_t argc);
 
 /**

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -152,8 +152,8 @@ typedef struct blockedClientHybridCtx {
  * @param requests Array of AREQ pointers representing individual search requests, the hybrid request will take ownership of the array
  * @param nrequests Number of requests in the array
  * @param argv The command argv, not NULL; the container's and each
- *   sub-request's wrapper take holds on the strings past the command and
- *   index tokens (main-thread only — see BlockedRequestCtx.argv)
+ *   sub-request's wrapper take holds on the full command (main-thread only —
+ *   see BlockedRequestCtx.argv)
  * @param argc Number of strings in argv
 */
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests,

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -157,7 +157,7 @@ typedef struct blockedClientHybridCtx {
  * @param argc Number of strings in argv
 */
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests,
-                                 RedisModuleString **argv, int argc);
+                                 RedisModuleString **argv, uint32_t argc);
 
 /**
  * Initialize an already-allocated (zeroed) HybridRequest.
@@ -172,12 +172,12 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
  * @param argc Number of strings in argv
  */
 void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **requests,
-                        size_t nrequests, RedisModuleString **argv, int argc);
+                        size_t nrequests, RedisModuleString **argv, uint32_t argc);
 
 /* Wrap the request's held argv (taken at construction) in a parse cursor.
  * The caller's argc bounds the parse; the holds may cover a superset (the
  * coordinator debug flow strips trailing debug params). */
-void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor* ac, int argc);
+void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor* ac, uint32_t argc);
 
 /**
  * Build the depletion pipeline for hybrid search processing.
@@ -287,7 +287,7 @@ int HybridRequest_GetError(HybridRequest *req, QueryError *status);
 
 void HybridRequest_ClearErrors(HybridRequest *req);
 
-HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx, RedisModuleString **argv, int argc);
+HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx, RedisModuleString **argv, uint32_t argc);
 
 /**
  * Add information to validation error messages based on request type (VSIM/SEARCH subquery).

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -153,7 +153,7 @@ typedef struct blockedClientHybridCtx {
  * @param nrequests Number of requests in the array
  * @param argv The command argv, not NULL; the container's and each
  *   sub-request's wrapper take holds on the strings past the command and
- *   index tokens (main-thread only — see BlockedRequestCtx.argvHolds)
+ *   index tokens (main-thread only — see BlockedRequestCtx.argv)
  * @param argc Number of strings in argv
 */
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests,

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -21,10 +21,13 @@ struct Cursor;
 #define HYBRID_IMPLICIT_KEY_FIELD "__key"
 
 typedef struct HybridRequest {
-    /* Arguments converted to sds. Received on input */
-    // We need to copy the arguments so rlookup keys can point to them
-    // in short lifetime of the strings
-    sds *args;
+    /* Held references to the command argv (past the command and index
+     * tokens). Parse-time borrows (query strings, field names, RLookup keys)
+     * point into these strings, so they stay valid for the holder's lifetime
+     * independent of the dispatcher's argv. String refcounts are not thread
+     * safe: held and released on the main thread only (see
+     * HybridRequest_HoldArgv). */
+    RedisModuleString **argv;
     size_t nargs;
 
     arrayof(AREQ*) requests;
@@ -175,6 +178,16 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
 * We need to clone the arguments so the objects that rely on them can use them throughout the lifetime of the hybrid request
 * For example lookup keys
 */
+/* Hold the command argv (past the command and index tokens) on the request
+ * and each sub-AREQ, so parse-time borrows into the argv strings stay valid
+ * for each holder's lifetime. Main-thread only (string refcount operations
+ * are not thread safe); released by the owners' free paths, which run on the
+ * main thread. */
+void HybridRequest_HoldArgv(HybridRequest *req, RedisModuleString **argv, int argc);
+
+/* Wrap the request's held argv in a parse cursor. Holds the argv first when
+ * the request does not hold it yet (main-thread callers); the coordinator
+ * dispatcher holds on the main thread before queuing the background parse. */
 void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor* ac, RedisModuleString **argv, int argc);
 
 /**

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -151,8 +151,14 @@ typedef struct blockedClientHybridCtx {
  * @param sctx The main search context for the hybrid request - the redisCtx inside can change if moving to different thread
  * @param requests Array of AREQ pointers representing individual search requests, the hybrid request will take ownership of the array
  * @param nrequests Number of requests in the array
+ * @param argv The command argv; the container's and each sub-request's
+ *   wrapper take holds on the strings past the command and index tokens
+ *   (main-thread only — see BlockedRequestCtx.argvHolds). May be NULL only
+ *   for a request that is never parsed.
+ * @param argc Number of strings in argv
 */
-HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests);
+HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests,
+                                 RedisModuleString **argv, int argc);
 
 /**
  * Initialize an already-allocated (zeroed) HybridRequest.
@@ -162,23 +168,16 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
  * @param sctx The search context for the hybrid request
  * @param requests Array of AREQ pointers, the hybrid request takes ownership
  * @param nrequests Number of requests in the array
+ * @param argv Already-stepped argv slice each sub-request's wrapper holds
+ *   (see HybridRequest_New); may be NULL
+ * @param argc Number of strings in argv
  */
-void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **requests, size_t nrequests);
+void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **requests,
+                        size_t nrequests, RedisModuleString **argv, int argc);
 
-/*
-* We need to clone the arguments so the objects that rely on them can use them throughout the lifetime of the hybrid request
-* For example lookup keys
-*/
-/* Hold the command argv (past the command and index tokens) on the request
- * and each sub-AREQ, so parse-time borrows into the argv strings stay valid
- * for each holder's lifetime. Main-thread only (string refcount operations
- * are not thread safe); released by the owners' free paths, which run on the
- * main thread. */
-void HybridRequest_HoldArgv(HybridRequest *req, RedisModuleString **argv, int argc);
-
-/* Wrap the request's held argv in a parse cursor. Holds the argv first when
- * the request does not hold it yet (main-thread callers); the coordinator
- * dispatcher holds on the main thread before queuing the background parse. */
+/* Wrap the request's held argv (taken at construction) in a parse cursor.
+ * The caller's argc bounds the parse; the holds may cover a superset (the
+ * coordinator debug flow strips trailing debug params). */
 void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor* ac, RedisModuleString **argv, int argc);
 
 /**
@@ -289,7 +288,7 @@ int HybridRequest_GetError(HybridRequest *req, QueryError *status);
 
 void HybridRequest_ClearErrors(HybridRequest *req);
 
-HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx);
+HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx, RedisModuleString **argv, int argc);
 
 /**
  * Add information to validation error messages based on request type (VSIM/SEARCH subquery).

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -21,15 +21,6 @@ struct Cursor;
 #define HYBRID_IMPLICIT_KEY_FIELD "__key"
 
 typedef struct HybridRequest {
-    /* Held references to the command argv (past the command and index
-     * tokens). Parse-time borrows (query strings, field names, RLookup keys)
-     * point into these strings, so they stay valid for the holder's lifetime
-     * independent of the dispatcher's argv. String refcounts are not thread
-     * safe: held and released on the main thread only (see
-     * HybridRequest_HoldArgv). */
-    RedisModuleString **argv;
-    size_t nargs;
-
     arrayof(AREQ*) requests;
     size_t nrequests;
     QueryError tailPipelineError;

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -21,61 +21,61 @@ struct Cursor;
 #define HYBRID_IMPLICIT_KEY_FIELD "__key"
 
 typedef struct HybridRequest {
-    arrayof(AREQ*) requests;
-    size_t nrequests;
-    QueryError tailPipelineError;
-    QueryError *errors;
-    Pipeline *tailPipeline;
-    RequestConfig reqConfig;
-    CursorConfig cursorConfig;
-    RPStatus *subqueriesReturnCodes;  // Array to store return codes from each subquery
-    RedisSearchCtx *sctx;
-    QEFlags reqflags;
-    ProfileClocks profileClocks;
-    profiler_func profile;
-    ProfilePrinterCtx profileCtx;
+  arrayof(AREQ *) requests;
+  size_t nrequests;
+  QueryError tailPipelineError;
+  QueryError *errors;
+  Pipeline *tailPipeline;
+  RequestConfig reqConfig;
+  CursorConfig cursorConfig;
+  RPStatus *subqueriesReturnCodes;  // Array to store return codes from each subquery
+  RedisSearchCtx *sctx;
+  QEFlags reqflags;
+  ProfileClocks profileClocks;
+  profiler_func profile;
+  ProfilePrinterCtx profileCtx;
 
-    // Synchronization context for timeout/reply callbacks.
-    // Holds the per-request timeout flag and abort-wake channel.
-    RequestSyncState syncState;
+  // Synchronization context for timeout/reply callbacks.
+  // Holds the per-request timeout flag and abort-wake channel.
+  RequestSyncState syncState;
 
-    // Non-owning back-pointer to the heap wrapper that owns this request.
-    BlockedRequestCtx *brc;
+  // Non-owning back-pointer to the heap wrapper that owns this request.
+  BlockedRequestCtx *brc;
 
-    // Flag to indicate whether to skip timeout checks using clock checks
-    bool skipTimeoutChecks;
+  // Flag to indicate whether to skip timeout checks using clock checks
+  bool skipTimeoutChecks;
 
-    bool useReplyCallback;
+  bool useReplyCallback;
 
-    // State for reply_callback path (FAIL policy with workers in coordinator mode)
-    // Background thread stores results here, then calls UnblockClient.
-    // Mutex for synchronizing cursor creation with timeout callback.
-    // Protects cursor array access to ensure proper cleanup on timeout.
-    pthread_mutex_t cursorMutex;
+  // State for reply_callback path (FAIL policy with workers in coordinator mode)
+  // Background thread stores results here, then calls UnblockClient.
+  // Mutex for synchronizing cursor creation with timeout callback.
+  // Protects cursor array access to ensure proper cleanup on timeout.
+  pthread_mutex_t cursorMutex;
 
-    // Array of depleted cursors for reply_callback path (internal hybrid search).
-    // Non-NULL only after the initial cursor pipelines are safe to publish.
-    // Protected by cursorMutex to synchronize with timeout callback.
-    // Cleanup is handled by:
-    // - reply_callback: frees array after replying with cursor IDs
-    // - timeout_callback: acquires lock and consumes published cursors, if any
-    // - HybridRequest_StartCursors: checks timedOut flag before publishing, or frees on error
-    arrayof(struct Cursor*) cursors;
+  // Array of depleted cursors for reply_callback path (internal hybrid search).
+  // Non-NULL only after the initial cursor pipelines are safe to publish.
+  // Protected by cursorMutex to synchronize with timeout callback.
+  // Cleanup is handled by:
+  // - reply_callback: frees array after replying with cursor IDs
+  // - timeout_callback: acquires lock and consumes published cursors, if any
+  // - HybridRequest_StartCursors: checks timedOut flag before publishing, or frees on error
+  arrayof(struct Cursor *) cursors;
 
-    // Optional debug parameters for _FT.DEBUG FT.HYBRID.
-    // When non-NULL, debug timeouts are applied after pipeline building.
-    // Heap-allocated and owned by HybridRequest — freed in HybridRequest_Free.
-    HybridDebugParams *debugParams;
+  // Optional debug parameters for _FT.DEBUG FT.HYBRID.
+  // When non-NULL, debug timeouts are applied after pipeline building.
+  // Heap-allocated and owned by HybridRequest — freed in HybridRequest_Free.
+  HybridDebugParams *debugParams;
 
-    // Thread pool ID used for coordinator depletion and tail continuation jobs.
-    // Set once before pipeline construction; read by BuildDistributedDepletionPipeline
-    // and scheduleHybridTail.
-    int poolId;
-    // Index of the K value argument in the MRCommand for SHARD_K_RATIO
-    // optimization.
-    // Set during command building, used by command modifier callback. -1 if
-    // not applicable.
-    int kArgIndex;
+  // Thread pool ID used for coordinator depletion and tail continuation jobs.
+  // Set once before pipeline construction; read by BuildDistributedDepletionPipeline
+  // and scheduleHybridTail.
+  int poolId;
+  // Index of the K value argument in the MRCommand for SHARD_K_RATIO
+  // optimization.
+  // Set during command building, used by command modifier callback. -1 if
+  // not applicable.
+  int kArgIndex;
 } HybridRequest;
 
 // Timeout helper functions for HybridRequest (mirrors AREQ pattern)
@@ -148,14 +148,16 @@ typedef struct blockedClientHybridCtx {
  * Create a new HybridRequest that manages multiple search requests for hybrid search.
  * This function initializes the hybrid request structure and sets up the tail pipeline
  * that will be used to merge and process results from all individual search requests.
- * @param sctx The main search context for the hybrid request - the redisCtx inside can change if moving to different thread
- * @param requests Array of AREQ pointers representing individual search requests, the hybrid request will take ownership of the array
+ * @param sctx The main search context for the hybrid request - the redisCtx inside can change if
+ * moving to different thread
+ * @param requests Array of AREQ pointers representing individual search requests, the hybrid
+ * request will take ownership of the array
  * @param nrequests Number of requests in the array
  * @param argv The command argv, not NULL; the container's and each
  *   sub-request's wrapper take holds on the full command (main-thread only —
  *   see BlockedRequestCtx.argv)
  * @param argc Number of strings in argv
-*/
+ */
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests,
                                  RedisModuleString **argv, uint32_t argc);
 
@@ -177,7 +179,7 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
 /* Wrap the request's held argv (taken at construction) in a parse cursor.
  * The caller's argc bounds the parse; the holds may cover a superset (the
  * coordinator debug flow strips trailing debug params). */
-void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor* ac, uint32_t argc);
+void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, uint32_t argc);
 
 /**
  * Build the depletion pipeline for hybrid search processing.
@@ -287,7 +289,8 @@ int HybridRequest_GetError(HybridRequest *req, QueryError *status);
 
 void HybridRequest_ClearErrors(HybridRequest *req);
 
-HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx, RedisModuleString **argv, uint32_t argc);
+HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx, RedisModuleString **argv,
+                                        uint32_t argc);
 
 /**
  * Add information to validation error messages based on request type (VSIM/SEARCH subquery).

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -167,7 +167,7 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
  * @param sctx The search context for the hybrid request
  * @param requests Array of AREQ pointers, the hybrid request takes ownership
  * @param nrequests Number of requests in the array
- * @param argv Already-stepped argv slice each sub-request's wrapper holds
+ * @param argv The full command argv each sub-request's wrapper holds
  *   (see HybridRequest_New); not NULL
  * @param argc Number of strings in argv
  */
@@ -177,7 +177,7 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
 /* Wrap the request's held argv (taken at construction) in a parse cursor.
  * The caller's argc bounds the parse; the holds may cover a superset (the
  * coordinator debug flow strips trailing debug params). */
-void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor* ac, RedisModuleString **argv, int argc);
+void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor* ac, int argc);
 
 /**
  * Build the depletion pipeline for hybrid search processing.

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -158,8 +158,7 @@ typedef struct blockedClientHybridCtx {
  *   see BlockedRequestCtx.argv)
  * @param argc Number of strings in argv
  */
-HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests,
-                                 RedisModuleString **argv, uint32_t argc);
+HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests, RedisModuleString **argv, uint32_t argc);
 
 /**
  * Initialize an already-allocated (zeroed) HybridRequest.
@@ -173,8 +172,7 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
  *   (see HybridRequest_New); not NULL
  * @param argc Number of strings in argv
  */
-void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **requests,
-                        size_t nrequests, RedisModuleString **argv, uint32_t argc);
+void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **requests, size_t nrequests, RedisModuleString **argv, uint32_t argc);
 
 /* Wrap the request's held argv (taken at construction) in a parse cursor.
  * The caller's argc bounds the parse; the holds may cover a superset (the
@@ -289,8 +287,7 @@ int HybridRequest_GetError(HybridRequest *req, QueryError *status);
 
 void HybridRequest_ClearErrors(HybridRequest *req);
 
-HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx, RedisModuleString **argv,
-                                        uint32_t argc);
+HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx, RedisModuleString **argv, uint32_t argc);
 
 /**
  * Add information to validation error messages based on request type (VSIM/SEARCH subquery).

--- a/src/hybrid/parse/hybrid_callbacks.c
+++ b/src/hybrid/parse/hybrid_callbacks.c
@@ -23,6 +23,7 @@
 #include "slots_tracker_ffi.h"
 #include "hybrid/vector_query_utils.h"
 #include "vector_index.h"
+#include "rmutil/rm_assert.h"
 #include "rmalloc.h"
 #include "VecSim/vec_sim_common.h"
 #include "aggregate/aggregate.h"
@@ -489,21 +490,15 @@ void handleNumSString(ArgParser *parser, const void *value, void *user_data) {
     ctx->specifiedArgs |= SPECIFIED_ARG_NUM_SSTRING;
 }
 
-// _INDEX_PREFIXES callback - implements EXACT original logic from handleIndexPrefixes
+// _INDEX_PREFIXES callback
 void handleIndexPrefixes(ArgParser *parser, const void *value, void *user_data) {
   HybridParseContext *ctx = (HybridParseContext*)user_data;
   ArgsCursor *paramsArgs = (ArgsCursor*)value;
-  QueryError *status = ctx->status;
-  while (!AC_IsAtEnd(paramsArgs)) {
-    const char *prefix;
-    size_t prefixLen;
-    if (AC_GetString(paramsArgs, &prefix, &prefixLen, 0) != AC_OK) {
-      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments for _INDEX_PREFIXES");
-      return;
-    }
-    sds prefixSds = sdsnewlen(prefix, prefixLen);
-    array_ensure_append_1(*ctx->prefixes, prefixSds);
-  }
+  // The slice is a window into the request's held argv, which outlives the
+  // parse — borrow it instead of copying.
+  RS_ASSERT(paramsArgs->type == AC_TYPE_RSTRING);
+  ctx->prefixes = (RedisModuleString **)paramsArgs->objs;
+  ctx->nprefixes = paramsArgs->argc;
 }
 
 // SLOTS_STR callback - implements EXACT original logic from handleCommonArgs

--- a/src/hybrid/parse/hybrid_callbacks.c
+++ b/src/hybrid/parse/hybrid_callbacks.c
@@ -494,8 +494,7 @@ void handleNumSString(ArgParser *parser, const void *value, void *user_data) {
 void handleIndexPrefixes(ArgParser *parser, const void *value, void *user_data) {
   HybridParseContext *ctx = (HybridParseContext*)user_data;
   ArgsCursor *paramsArgs = (ArgsCursor*)value;
-  // The slice is a window into the request's held argv, which outlives the
-  // parse — borrow it instead of copying.
+  // The slice is a window into the held argv, which outlives the parse — borrow it
   RS_ASSERT(paramsArgs->type == AC_TYPE_RSTRING);
   ctx->prefixes = (RedisModuleString **)paramsArgs->objs;
   ctx->nprefixes = paramsArgs->argc;

--- a/src/hybrid/parse/hybrid_optional_args.h
+++ b/src/hybrid/parse/hybrid_optional_args.h
@@ -58,7 +58,7 @@ typedef struct {
     QEFlags *reqFlags;                      // Request flags
     size_t *maxResults;                     // Maximum results
     /* Index prefixes from _INDEX_PREFIXES: a borrowed window into the
-     * request's held argv (see BlockedRequestCtx.argvHolds). */
+     * request's held argv (see BlockedRequestCtx.argv). */
     RedisModuleString **prefixes;
     size_t nprefixes;
     const RedisModuleSlotRangeArray **querySlots; // Slots requested from coordinator (referenced from AREQ)

--- a/src/hybrid/parse/hybrid_optional_args.h
+++ b/src/hybrid/parse/hybrid_optional_args.h
@@ -57,7 +57,10 @@ typedef struct {
     RequestConfig *reqConfig;               // Request configuration for DIALECT/TIMEOUT
     QEFlags *reqFlags;                      // Request flags
     size_t *maxResults;                     // Maximum results
-    arrayof(sds) *prefixes;                 // Prefixes for the index
+    /* Index prefixes from _INDEX_PREFIXES: a borrowed window into the
+     * request's held argv (see BlockedRequestCtx.argvHolds). */
+    RedisModuleString **prefixes;
+    size_t nprefixes;
     const RedisModuleSlotRangeArray **querySlots; // Slots requested from coordinator (referenced from AREQ)
     uint32_t *keySpaceVersion;                 // Slots version for the request (referenced from AREQ)
     rs_wall_clock_ns_t *coordDispatchTime;     // Coordinator dispatch time for internal commands

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -972,8 +972,7 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
   applyKNNTopKWindowConstraint(vectorRequest->parsedVectorData, hybridParams);
 
   if (hybridParseCtx.nprefixes &&
-      !IndexSpec_IsCoherent(parsedCmdCtx->search->sctx->spec, hybridParseCtx.prefixes,
-                            hybridParseCtx.nprefixes)) {
+      !IndexSpec_IsCoherent(parsedCmdCtx->search->sctx->spec, hybridParseCtx.prefixes, hybridParseCtx.nprefixes)) {
     QueryError_SetError(status, QUERY_ERROR_CODE_MISMATCH, NULL);
     goto error;
   }

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -47,6 +47,22 @@
 #include "slots_tracker_ffi.h"
 #include "util/arr/arr.h"
 
+// Record the sub-request's query argument: parseArgv points at the current
+// cursor token within the sub-request's OWN held argv (the container's holds
+// do not outlive the container; the sub-request may). Both hold the same
+// string references, so the token is located by pointer identity.
+static void setSubQueryArg(AREQ *sub, const ArgsCursor *ac) {
+  RedisModuleString *tok = (RedisModuleString *)AC_CURRENT(ac);
+  BlockedRequestCtx *brc = sub->brc;
+  for (size_t i = 0; i < brc->nargvHolds; i++) {
+    if (brc->argvHolds[i] == tok) {
+      sub->parseArgv = brc->argvHolds + i;
+      return;
+    }
+  }
+  RS_ABORT("sub-query token not found in the sub-request's held argv");
+}
+
 // Helper function to set error message with proper plural vs singular form
 static void setExpectedArgumentsError(QueryError *status, unsigned int expected, int provided) {
   const char *verb = (provided == 1) ? "was" : "were";
@@ -85,7 +101,8 @@ static int parseSearchSubquery(ArgsCursor *ac, AREQ *sreq, QueryError *status) {
     return REDISMODULE_ERR;
   }
 
-  sreq->query = AC_GetStringNC(ac, &sreq->queryLen);
+  setSubQueryArg(sreq, ac);
+  AC_Advance(ac);
   RSSearchOptions *searchOpts = &sreq->searchopts;
 
   // Currently only SCORER is possible in SEARCH. Maybe will add support for SORTBY and others later
@@ -330,12 +347,14 @@ static int parseFilterClause(ArgsCursor *ac, AREQ *vreq, ParsedVectorData *pvd, 
     return REDISMODULE_ERR;
   }
 
-  // Parse filter-expression (required, positional) - store in vreq->query directly
-  vreq->query = AC_GetStringNC(&argCursor, &vreq->queryLen);
-  if (!vreq->query) {
+  // Parse filter-expression (required, positional): becomes the sub-request's
+  // query argument.
+  if (AC_IsAtEnd(&argCursor)) {
     QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing filter-expression for FILTER");
     return REDISMODULE_ERR;
   }
+  setSubQueryArg(vreq, &argCursor);
+  AC_Advance(&argCursor);
 
   // Use ArgParser for optional POLICY and BATCH_SIZE
   ArgParser *parser = ArgParser_New(&argCursor, "FILTER");
@@ -485,11 +504,12 @@ static int parseVectorSubquery(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
     }
     if (AC_GetUnsignedLongLong(ac, &count, 0) != AC_OK) {
       // it's a string, not a number, preserving some degree of backward compatibility
-      vreq->query = AC_GetStringNC(ac, &vreq->queryLen);
-      if (!vreq->query) {
+      if (AC_IsAtEnd(ac)) {
         QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid filter-expression for FILTER");
         goto error;
       }
+      setSubQueryArg(vreq, ac);
+      AC_Advance(ac);
     } else if (parseFilterClause(ac, vreq, pvd, status, count) != REDISMODULE_OK) {
       goto error;
     }
@@ -515,13 +535,12 @@ static int parseVectorSubquery(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
   }
 
 final:
-  // Set implicit "*" filter if no explicit filter was provided.
+  // No explicit FILTER: the sub-request has no query argument, and AREQ_Query
+  // defaults to matching everything ("*").
   // For RANGE queries without explicit FILTER, we also set skipFilterIntegration
   // so the vector node becomes the root directly (no PHRASE/intersection needed).
   // This preserves BY_SCORE ordering from the iterator.
-  if (!vreq->query) {
-    vreq->query = "*";
-    vreq->queryLen = 1;
+  if (!vreq->parseArgv) {
     // For RANGE without explicit filter, skip the filter integration
     // so the vector node is the root and returns results sorted by score.
     if (vq->type == VECSIM_QT_RANGE) {

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -49,13 +49,27 @@
 
 // Record the sub-request's query argument: parseOffset locates the current
 // cursor token within the sub-request's OWN held argv (the container's holds
-// do not outlive the container; the sub-request may). Both hold the same
-// string references, so the token is located by pointer identity.
+// do not outlive the container; the sub-request may). Both hold references
+// taken from the same argv, so the token is normally the same object in both
+// arrays — but HoldString is allowed to return a copy (it does for
+// static-refcount sources), so fall back to byte equality. That suffices:
+// parseOffset's only consumer reads the token's bytes (AREQ_Query), for which
+// any equal-valued slot is interchangeable.
 static void setSubQueryArg(AREQ *sub, const ArgsCursor *ac) {
   RedisModuleString *tok = (RedisModuleString *)AC_CURRENT(ac);
   BlockedRequestCtx *brc = sub->brc;
   for (size_t i = 0; i < brc->nargvHolds; i++) {
     if (brc->argvHolds[i] == tok) {
+      brc->parseOffset = i;
+      return;
+    }
+  }
+  size_t tokLen;
+  const char *tokStr = RedisModule_StringPtrLen(tok, &tokLen);
+  for (size_t i = 0; i < brc->nargvHolds; i++) {
+    size_t len;
+    const char *s = RedisModule_StringPtrLen(brc->argvHolds[i], &len);
+    if (len == tokLen && memcmp(s, tokStr, len) == 0) {
       brc->parseOffset = i;
       return;
     }

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -85,7 +85,7 @@ static int parseSearchSubquery(ArgsCursor *ac, AREQ *sreq, QueryError *status) {
     return REDISMODULE_ERR;
   }
 
-  sreq->query = AC_GetStringNC(ac, NULL);
+  sreq->query = AC_GetStringNC(ac, &sreq->queryLen);
   RSSearchOptions *searchOpts = &sreq->searchopts;
 
   // Currently only SCORER is possible in SEARCH. Maybe will add support for SORTBY and others later
@@ -331,7 +331,7 @@ static int parseFilterClause(ArgsCursor *ac, AREQ *vreq, ParsedVectorData *pvd, 
   }
 
   // Parse filter-expression (required, positional) - store in vreq->query directly
-  vreq->query = AC_GetStringNC(&argCursor, NULL);
+  vreq->query = AC_GetStringNC(&argCursor, &vreq->queryLen);
   if (!vreq->query) {
     QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing filter-expression for FILTER");
     return REDISMODULE_ERR;
@@ -485,7 +485,7 @@ static int parseVectorSubquery(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
     }
     if (AC_GetUnsignedLongLong(ac, &count, 0) != AC_OK) {
       // it's a string, not a number, preserving some degree of backward compatibility
-      vreq->query = AC_GetStringNC(ac, NULL);
+      vreq->query = AC_GetStringNC(ac, &vreq->queryLen);
       if (!vreq->query) {
         QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid filter-expression for FILTER");
         goto error;
@@ -521,6 +521,7 @@ final:
   // This preserves BY_SCORE ordering from the iterator.
   if (!vreq->query) {
     vreq->query = "*";
+    vreq->queryLen = 1;
     // For RANGE without explicit filter, skip the filter integration
     // so the vector node is the root and returns results sorted by score.
     if (vq->type == VECSIM_QT_RANGE) {

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -49,22 +49,13 @@
 
 // Record the sub-request's query argument by its index within the held argv.
 // Every parse cursor here walks the container's holds, and each sub's holds
-// mirror them index-for-index (all hold the stepped command argv, in order),
-// so a cursor-derived offset addresses the same token in the sub's own holds.
+// mirror them index-for-index (all hold the same command argv, in order), so
+// a cursor-derived offset addresses the same token in the sub's own holds.
 // `queryOffset` is in root-cursor coordinates: for a slice cursor, the
 // caller adds the slice's base (the root offset recorded before AC_GetSlice).
-static void setSubQueryArg(AREQ *sub, const ArgsCursor *ac, uint32_t queryOffset) {
+static void setSubQueryArg(AREQ *sub, uint32_t queryOffset) {
   BlockedRequestCtx *brc = sub->brc;
   RS_ASSERT(queryOffset < brc->argc);
-#ifdef ENABLE_ASSERT
-  // The mirror invariant: the token at the cursor and the sub's hold at the
-  // derived index carry the same bytes (they may be distinct objects only if
-  // HoldString returned a copy).
-  size_t tokLen, heldLen;
-  const char *tokStr = RedisModule_StringPtrLen((RedisModuleString *)AC_CURRENT(ac), &tokLen);
-  const char *heldStr = RedisModule_StringPtrLen(brc->argv[queryOffset], &heldLen);
-  RS_ASSERT(tokLen == heldLen && memcmp(tokStr, heldStr, tokLen) == 0);
-#endif
   brc->queryOffset = queryOffset;
 }
 
@@ -106,7 +97,7 @@ static int parseSearchSubquery(ArgsCursor *ac, AREQ *sreq, QueryError *status) {
     return REDISMODULE_ERR;
   }
 
-  setSubQueryArg(sreq, ac, (uint32_t)ac->offset);
+  setSubQueryArg(sreq, (uint32_t)ac->offset);
   AC_Advance(ac);
   RSSearchOptions *searchOpts = &sreq->searchopts;
 
@@ -361,7 +352,7 @@ static int parseFilterClause(ArgsCursor *ac, AREQ *vreq, ParsedVectorData *pvd, 
     QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing filter-expression for FILTER");
     return REDISMODULE_ERR;
   }
-  setSubQueryArg(vreq, &argCursor, sliceBase + (uint32_t)argCursor.offset);
+  setSubQueryArg(vreq, sliceBase + (uint32_t)argCursor.offset);
   AC_Advance(&argCursor);
 
   // Use ArgParser for optional POLICY and BATCH_SIZE
@@ -516,7 +507,7 @@ static int parseVectorSubquery(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
         QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid filter-expression for FILTER");
         goto error;
       }
-      setSubQueryArg(vreq, ac, (uint32_t)ac->offset);
+      setSubQueryArg(vreq, (uint32_t)ac->offset);
       AC_Advance(ac);
     } else if (parseFilterClause(ac, vreq, pvd, status, count) != REDISMODULE_OK) {
       goto error;

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -47,31 +47,25 @@
 #include "slots_tracker_ffi.h"
 #include "util/arr/arr.h"
 
-// Record the sub-request's query argument: locate the current cursor token
-// within the sub-request's OWN held argv (the container's holds may die
-// first). The token is normally the same object in both hold arrays, but
-// HoldString may return a copy — fall back to byte equality; the only
-// consumer (AREQ_Query) just reads the token's bytes.
-static void setSubQueryArg(AREQ *sub, const ArgsCursor *ac) {
-  RedisModuleString *tok = (RedisModuleString *)AC_CURRENT(ac);
+// Record the sub-request's query argument by its index within the held argv.
+// Every parse cursor here walks the container's holds, and each sub's holds
+// mirror them index-for-index (all hold the stepped command argv, in order),
+// so a cursor-derived offset addresses the same token in the sub's own holds.
+// `queryOffset` is in root-cursor coordinates: for a slice cursor, the
+// caller adds the slice's base (the root offset recorded before AC_GetSlice).
+static void setSubQueryArg(AREQ *sub, const ArgsCursor *ac, uint32_t queryOffset) {
   BlockedRequestCtx *brc = sub->brc;
-  for (size_t i = 0; i < brc->nargvHolds; i++) {
-    if (brc->argvHolds[i] == tok) {
-      brc->parseSlice = &brc->argvHolds[i];
-      return;
-    }
-  }
-  size_t tokLen;
-  const char *tokStr = RedisModule_StringPtrLen(tok, &tokLen);
-  for (size_t i = 0; i < brc->nargvHolds; i++) {
-    size_t len;
-    const char *s = RedisModule_StringPtrLen(brc->argvHolds[i], &len);
-    if (len == tokLen && memcmp(s, tokStr, len) == 0) {
-      brc->parseSlice = &brc->argvHolds[i];
-      return;
-    }
-  }
-  RS_ABORT("sub-query token not found in the sub-request's held argv");
+  RS_ASSERT(queryOffset < brc->argc);
+#ifdef ENABLE_ASSERT
+  // The mirror invariant: the token at the cursor and the sub's hold at the
+  // derived index carry the same bytes (they may be distinct objects only if
+  // HoldString returned a copy).
+  size_t tokLen, heldLen;
+  const char *tokStr = RedisModule_StringPtrLen((RedisModuleString *)AC_CURRENT(ac), &tokLen);
+  const char *heldStr = RedisModule_StringPtrLen(brc->argv[queryOffset], &heldLen);
+  RS_ASSERT(tokLen == heldLen && memcmp(tokStr, heldStr, tokLen) == 0);
+#endif
+  brc->queryOffset = queryOffset;
 }
 
 // Helper function to set error message with proper plural vs singular form
@@ -112,7 +106,7 @@ static int parseSearchSubquery(ArgsCursor *ac, AREQ *sreq, QueryError *status) {
     return REDISMODULE_ERR;
   }
 
-  setSubQueryArg(sreq, ac);
+  setSubQueryArg(sreq, ac, (uint32_t)ac->offset);
   AC_Advance(ac);
   RSSearchOptions *searchOpts = &sreq->searchopts;
 
@@ -349,6 +343,9 @@ static int parseFilterClause(ArgsCursor *ac, AREQ *vreq, ParsedVectorData *pvd, 
   //                                                 ^
 
   ArgsCursor argCursor= {0};
+  // The slice's base in root-cursor coordinates (AC_GetSlice anchors the
+  // slice at the parent's current offset, then advances the parent).
+  const uint32_t sliceBase = (uint32_t)ac->offset;
   int res = AC_GetSlice(ac, &argCursor, count);
   if (res == AC_ERR_NOARG) {
     QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Not enough arguments", " in %s, specified %llu but provided only %u", "FILTER", count, AC_NumRemaining(ac));
@@ -364,7 +361,7 @@ static int parseFilterClause(ArgsCursor *ac, AREQ *vreq, ParsedVectorData *pvd, 
     QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing filter-expression for FILTER");
     return REDISMODULE_ERR;
   }
-  setSubQueryArg(vreq, &argCursor);
+  setSubQueryArg(vreq, &argCursor, sliceBase + (uint32_t)argCursor.offset);
   AC_Advance(&argCursor);
 
   // Use ArgParser for optional POLICY and BATCH_SIZE
@@ -519,7 +516,7 @@ static int parseVectorSubquery(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
         QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid filter-expression for FILTER");
         goto error;
       }
-      setSubQueryArg(vreq, ac);
+      setSubQueryArg(vreq, ac, (uint32_t)ac->offset);
       AC_Advance(ac);
     } else if (parseFilterClause(ac, vreq, pvd, status, count) != REDISMODULE_OK) {
       goto error;
@@ -551,7 +548,7 @@ final:
   // For RANGE queries without explicit FILTER, we also set skipFilterIntegration
   // so the vector node becomes the root directly (no PHRASE/intersection needed).
   // This preserves BY_SCORE ordering from the iterator.
-  if (vreq->brc->parseSlice == NULL) {
+  if (vreq->brc->queryOffset == QUERY_OFFSET_NONE) {
     // For RANGE without explicit filter, skip the filter integration
     // so the vector node is the root and returns results sorted by score.
     if (vq->type == VECSIM_QT_RANGE) {

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -57,7 +57,7 @@ static void setSubQueryArg(AREQ *sub, const ArgsCursor *ac) {
   BlockedRequestCtx *brc = sub->brc;
   for (size_t i = 0; i < brc->nargvHolds; i++) {
     if (brc->argvHolds[i] == tok) {
-      brc->parseOffset = i;
+      brc->parseSlice = &brc->argvHolds[i];
       return;
     }
   }
@@ -67,7 +67,7 @@ static void setSubQueryArg(AREQ *sub, const ArgsCursor *ac) {
     size_t len;
     const char *s = RedisModule_StringPtrLen(brc->argvHolds[i], &len);
     if (len == tokLen && memcmp(s, tokStr, len) == 0) {
-      brc->parseOffset = i;
+      brc->parseSlice = &brc->argvHolds[i];
       return;
     }
   }
@@ -551,7 +551,7 @@ final:
   // For RANGE queries without explicit FILTER, we also set skipFilterIntegration
   // so the vector node becomes the root directly (no PHRASE/intersection needed).
   // This preserves BY_SCORE ordering from the iterator.
-  if (vreq->brc->parseOffset == SIZE_MAX) {
+  if (vreq->brc->parseSlice == NULL) {
     // For RANGE without explicit filter, skip the filter integration
     // so the vector node is the root and returns results sorted by score.
     if (vq->type == VECSIM_QT_RANGE) {

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -840,9 +840,6 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
   searchRequest->ast.validationFlags |= QAST_NO_VECTOR;
   vectorRequest->ast.validationFlags |= QAST_NO_WEIGHT | QAST_NO_VECTOR;
 
-  // Prefixes for the index
-  arrayof(sds) prefixes = array_new(sds, 0);
-
   // Slot ranges info for distributed execution
   const RedisModuleSlotRangeArray *requestSlotRanges = NULL;
   uint32_t keySpaceVersion = INVALID_KEYSPACE_VERSION;
@@ -851,7 +848,6 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
   const char *vectorScoreFieldAlias = NULL;
   PLN_VectorNormalizerStep *vnStep = NULL;
   PLN_ArrangeStep *arrangeStep = NULL;
-  size_t prefixCount = 0;
   AggregationPipelineParams params;
   HybridParseContext hybridParseCtx;
 
@@ -878,12 +874,10 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
       .cursorConfig = parsedCmdCtx->cursorConfig,
       .reqConfig = parsedCmdCtx->reqConfig,
       .maxResults = &maxHybridResults,
-      .prefixes = &prefixes,
       .querySlots = &requestSlotRanges,
       .keySpaceVersion = &keySpaceVersion,
       .coordDispatchTime = parsedCmdCtx->coordDispatchTime,
   };
-  // may change prefixes in internal array_ensure_append_1
   if (HybridParseOptionalArgs(&hybridParseCtx, ac, internal) != REDISMODULE_OK) {
     goto error;
   }
@@ -978,13 +972,12 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
   // Apply KNN K ≤ WINDOW constraint after all argument resolution is complete
   applyKNNTopKWindowConstraint(vectorRequest->parsedVectorData, hybridParams);
 
-  prefixCount = array_len(*hybridParseCtx.prefixes);
-  if (prefixCount && !IndexSpec_IsCoherent(parsedCmdCtx->search->sctx->spec, *hybridParseCtx.prefixes, prefixCount)) {
+  if (hybridParseCtx.nprefixes &&
+      !IndexSpec_IsCoherent(parsedCmdCtx->search->sctx->spec, hybridParseCtx.prefixes,
+                            hybridParseCtx.nprefixes)) {
     QueryError_SetError(status, QUERY_ERROR_CODE_MISMATCH, NULL);
     goto error;
   }
-  array_free_ex(prefixes, sdsfree(*(sds *)ptr));
-  prefixes = NULL;
 
   // Apply context to each request
   if (AREQ_ApplyContext(searchRequest, searchRequest->sctx, status) != REDISMODULE_OK) {
@@ -1024,8 +1017,6 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
   return REDISMODULE_OK;
 
 error:
-  array_free_ex(prefixes, sdsfree(*(sds *)ptr));
-  prefixes = NULL;
   if (requestSlotRanges) {
     rm_free((void *)requestSlotRanges);
   }

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -47,14 +47,11 @@
 #include "slots_tracker_ffi.h"
 #include "util/arr/arr.h"
 
-// Record the sub-request's query argument: parseOffset locates the current
-// cursor token within the sub-request's OWN held argv (the container's holds
-// do not outlive the container; the sub-request may). Both hold references
-// taken from the same argv, so the token is normally the same object in both
-// arrays — but HoldString is allowed to return a copy (it does for
-// static-refcount sources), so fall back to byte equality. That suffices:
-// parseOffset's only consumer reads the token's bytes (AREQ_Query), for which
-// any equal-valued slot is interchangeable.
+// Record the sub-request's query argument: locate the current cursor token
+// within the sub-request's OWN held argv (the container's holds may die
+// first). The token is normally the same object in both hold arrays, but
+// HoldString may return a copy — fall back to byte equality; the only
+// consumer (AREQ_Query) just reads the token's bytes.
 static void setSubQueryArg(AREQ *sub, const ArgsCursor *ac) {
   RedisModuleString *tok = (RedisModuleString *)AC_CURRENT(ac);
   BlockedRequestCtx *brc = sub->brc;

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -47,7 +47,7 @@
 #include "slots_tracker_ffi.h"
 #include "util/arr/arr.h"
 
-// Record the sub-request's query argument: parseArgv points at the current
+// Record the sub-request's query argument: parseOffset locates the current
 // cursor token within the sub-request's OWN held argv (the container's holds
 // do not outlive the container; the sub-request may). Both hold the same
 // string references, so the token is located by pointer identity.
@@ -56,7 +56,7 @@ static void setSubQueryArg(AREQ *sub, const ArgsCursor *ac) {
   BlockedRequestCtx *brc = sub->brc;
   for (size_t i = 0; i < brc->nargvHolds; i++) {
     if (brc->argvHolds[i] == tok) {
-      sub->parseArgv = brc->argvHolds + i;
+      brc->parseOffset = i;
       return;
     }
   }
@@ -540,7 +540,7 @@ final:
   // For RANGE queries without explicit FILTER, we also set skipFilterIntegration
   // so the vector node becomes the root directly (no PHRASE/intersection needed).
   // This preserves BY_SCORE ordering from the iterator.
-  if (!vreq->parseArgv) {
+  if (vreq->brc->parseOffset == SIZE_MAX) {
     // For RANGE without explicit filter, skip the filter integration
     // so the vector node is the root and returns results sorted by score.
     if (vq->type == VECSIM_QT_RANGE) {

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -23,6 +23,7 @@
 #include "extension.h"
 #include "alias.h"
 #include "notifications.h"
+#include "util/misc.h"
 #include "ext/default.h"
 #include "json.h"
 #include "VecSim/vec_sim.h"
@@ -110,6 +111,7 @@ int RediSearch_Init(RedisModuleCtx *ctx) {
   DO_LOG("debug", "RediSearch base address: %p", info.dli_fbase);
 #endif
   RS_Initialized = 1;
+  MainThread_Set();
 
   if (!RSDummyContext) {
     RSDummyContext = RedisModule_GetDetachedThreadSafeContext(ctx);

--- a/src/module.c
+++ b/src/module.c
@@ -3868,6 +3868,12 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     BlockedRequestCtx_NewAREQ(r);
   }
 
+  // Parsing runs on the BG thread with the job's argv copies, which die with
+  // the job. Hold the original argv here, on the main thread (string
+  // refcounts are not thread safe), so the plan's borrows stay valid for the
+  // request's lifetime; parsing borrows from these holds.
+  AREQ_HoldArgv(r, argv, argc);
+
   ConcurrentSearchHandlerCtx handlerCtx;
   ConcurrentSearchHandlerCtx_Init(&handlerCtx);
 

--- a/src/module.c
+++ b/src/module.c
@@ -2269,7 +2269,8 @@ void setKNNSpecialCase(searchRequestCtx *req, specialCaseCtx *knn_ctx) {
 // Prepare a TOPK special case, return a context with the required KNN fields if query is
 // valid and contains KNN section, NULL otherwise (and set proper error in *status* if error
 // was found).
-specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleString **argv, int argc, uint dialectVersion,
+specialCaseCtx *prepareOptionalTopKCase(const char *query_string, size_t query_len,
+                                        RedisModuleString **argv, int argc, uint dialectVersion,
                                         QueryError *status) {
 
   // First, parse the query params if exists, to set the params in the query parser ctx.
@@ -2288,7 +2289,7 @@ specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleStr
   opts.params = params;
   QueryParseCtx qpCtx = {
       .raw = query_string,
-      .len = strlen(query_string),
+      .len = query_len,
       .sctx = &sctx,
       .opts = &opts,
       .status = status,
@@ -2491,7 +2492,8 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
   if (dialect >= 2) {
     // Note: currently there is only one single case. For extending those cases we should use a trie here.
     if (strcasestr(req->queryString, "KNN")) {
-      specialCaseCtx *knnCtx = prepareOptionalTopKCase(req->queryString, argv, argc, dialect, status);
+      specialCaseCtx *knnCtx = prepareOptionalTopKCase(req->queryString, strlen(req->queryString),
+                                                        argv, argc, dialect, status);
       if (QueryError_HasError(status)) {
         searchRequestCtx_Free(req);
         return NULL;

--- a/src/module.c
+++ b/src/module.c
@@ -3865,14 +3865,13 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     r = &debug_req->r;
   } else {
     r = AREQ_New();
-    BlockedRequestCtx_NewAREQ(r);
+    BlockedRequestCtx_NewAREQ(r, argv, argc);
   }
-
-  // Parsing runs on the BG thread with the job's argv copies, which die with
-  // the job. Hold the original argv here, on the main thread (string
-  // refcounts are not thread safe), so the plan's borrows stay valid for the
-  // request's lifetime; parsing borrows from these holds.
-  BlockedRequestCtx_HoldArgv(r->brc, argv, argc);
+  // Either construction path held the original argv here, on the main thread
+  // (string refcounts are not thread safe). Parsing runs on the BG thread
+  // with the job's argv copies, which die with the job — it borrows from
+  // these holds instead, so the plan's borrows stay valid for the request's
+  // lifetime.
 
   ConcurrentSearchHandlerCtx handlerCtx;
   ConcurrentSearchHandlerCtx_Init(&handlerCtx);
@@ -3970,14 +3969,13 @@ int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int
   // thread; the sub-AREQ contexts are detached thread-safe contexts.
   RedisSearchCtx *sctx = NewSearchCtxC(ctx, idx, true);
   RS_ASSERT(sctx != NULL);  // the index was validated above in the same GIL window
-  HybridRequest *hreq = MakeDefaultHybridRequest(sctx);
+  // Construction holds the argv strings the background parse will borrow
+  // from — string refcount operations are main-thread-only, and the
+  // ConcurrentCmdCtx's own argv copies die with the job.
+  HybridRequest *hreq = MakeDefaultHybridRequest(sctx, argv, argc);
   // The tail sctx aliased this handler's ctx, which dies when the handler
   // returns. The BG executor re-points it at its own thread-safe ctx.
   sctx->redisCtx = NULL;
-  // Hold the argv strings the background parse will borrow from — string
-  // refcount operations are main-thread-only, and the ConcurrentCmdCtx's own
-  // argv copies die with the job.
-  HybridRequest_HoldArgv(hreq, argv, argc);
 
   RSTimeoutPolicy policy = hreq->reqConfig.timeoutPolicy;
   hreq->brc->requiresAggregateResultsSync = (policy == TimeoutPolicy_ReturnStrict);

--- a/src/module.c
+++ b/src/module.c
@@ -3872,7 +3872,7 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   // the job. Hold the original argv here, on the main thread (string
   // refcounts are not thread safe), so the plan's borrows stay valid for the
   // request's lifetime; parsing borrows from these holds.
-  AREQ_HoldArgv(r, argv, argc);
+  BlockedRequestCtx_HoldArgv(r->brc, argv, argc);
 
   ConcurrentSearchHandlerCtx handlerCtx;
   ConcurrentSearchHandlerCtx_Init(&handlerCtx);

--- a/src/module.c
+++ b/src/module.c
@@ -2287,14 +2287,13 @@ specialCaseCtx *prepareOptionalTopKCase(const char *query_string, size_t query_l
   RedisSearchCtx sctx = {0};
   RSSearchOptions opts = {0};
   opts.params = params;
-  QueryParseCtx qpCtx = {
-      .raw = query_string,
-      .len = query_len,
-      .sctx = &sctx,
-      .opts = &opts,
-      .status = status,
+  QueryParseCtx qpCtx = {.raw = query_string,
+                         .len = query_len,
+                         .sctx = &sctx,
+                         .opts = &opts,
+                         .status = status,
 #ifdef PARSER_DEBUG
-      .trace_log = NULL
+                         .trace_log = NULL
 #endif
   };
 
@@ -2493,7 +2492,7 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
     // Note: currently there is only one single case. For extending those cases we should use a trie here.
     if (strcasestr(req->queryString, "KNN")) {
       specialCaseCtx *knnCtx = prepareOptionalTopKCase(req->queryString, strlen(req->queryString),
-                                                        argv, argc, dialect, status);
+                                                       argv, argc, dialect, status);
       if (QueryError_HasError(status)) {
         searchRequestCtx_Free(req);
         return NULL;

--- a/src/module.c
+++ b/src/module.c
@@ -3867,11 +3867,8 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     r = AREQ_New();
     BlockedRequestCtx_NewAREQ(r, argv, argc);
   }
-  // Either construction path held the original argv here, on the main thread
-  // (string refcounts are not thread safe). Parsing runs on the BG thread
-  // with the job's argv copies, which die with the job — it borrows from
-  // these holds instead, so the plan's borrows stay valid for the request's
-  // lifetime.
+  // Either path took the argv holds here, on the main thread; the BG parse
+  // borrows from them (the job's own argv copies die with the job).
 
   ConcurrentSearchHandlerCtx handlerCtx;
   ConcurrentSearchHandlerCtx_Init(&handlerCtx);
@@ -3969,9 +3966,8 @@ int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int
   // thread; the sub-AREQ contexts are detached thread-safe contexts.
   RedisSearchCtx *sctx = NewSearchCtxC(ctx, idx, true);
   RS_ASSERT(sctx != NULL);  // the index was validated above in the same GIL window
-  // Construction holds the argv strings the background parse will borrow
-  // from — string refcount operations are main-thread-only, and the
-  // ConcurrentCmdCtx's own argv copies die with the job.
+  // Construction takes the argv holds here, on the main thread; the BG parse
+  // borrows from them (the job's own argv copies die with the job).
   HybridRequest *hreq = MakeDefaultHybridRequest(sctx, argv, argc);
   // The tail sctx aliased this handler's ctx, which dies when the handler
   // returns. The BG executor re-points it at its own thread-safe ctx.

--- a/src/module.c
+++ b/src/module.c
@@ -3968,6 +3968,10 @@ int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int
   // The tail sctx aliased this handler's ctx, which dies when the handler
   // returns. The BG executor re-points it at its own thread-safe ctx.
   sctx->redisCtx = NULL;
+  // Hold the argv strings the background parse will borrow from — string
+  // refcount operations are main-thread-only, and the ConcurrentCmdCtx's own
+  // argv copies die with the job.
+  HybridRequest_HoldArgv(hreq, argv, argc);
 
   RSTimeoutPolicy policy = hreq->reqConfig.timeoutPolicy;
   hreq->brc->requiresAggregateResultsSync = (policy == TimeoutPolicy_ReturnStrict);

--- a/src/module.c
+++ b/src/module.c
@@ -2269,9 +2269,7 @@ void setKNNSpecialCase(searchRequestCtx *req, specialCaseCtx *knn_ctx) {
 // Prepare a TOPK special case, return a context with the required KNN fields if query is
 // valid and contains KNN section, NULL otherwise (and set proper error in *status* if error
 // was found).
-specialCaseCtx *prepareOptionalTopKCase(const char *query_string, size_t query_len,
-                                        RedisModuleString **argv, int argc, uint dialectVersion,
-                                        QueryError *status) {
+specialCaseCtx *prepareOptionalTopKCase(const char *query_string, size_t query_len, RedisModuleString **argv, int argc, uint dialectVersion, QueryError *status) {
 
   // First, parse the query params if exists, to set the params in the query parser ctx.
   dict *params = NULL;
@@ -2357,7 +2355,12 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
   }
 
   int argvOffset = 2 + req->profileArgs;
-  req->queryString = rm_strdup(RedisModule_StringPtrLen(argv[argvOffset++], NULL));
+  size_t queryLen;
+  const char *queryPtr = RedisModule_StringPtrLen(argv[argvOffset++], &queryLen);
+  // Length-faithful copy: keeps any embedded NULs the client sent, matching
+  // the (buffer, length) parse downstream.
+  req->queryString = rm_strndup(queryPtr, queryLen);
+  req->queryStringLen = queryLen;
   req->limit = 10;
   req->offset = 0;
   req->specialCases = NULL;
@@ -2491,7 +2494,7 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
   if (dialect >= 2) {
     // Note: currently there is only one single case. For extending those cases we should use a trie here.
     if (strcasestr(req->queryString, "KNN")) {
-      specialCaseCtx *knnCtx = prepareOptionalTopKCase(req->queryString, strlen(req->queryString),
+      specialCaseCtx *knnCtx = prepareOptionalTopKCase(req->queryString, req->queryStringLen,
                                                        argv, argc, dialect, status);
       if (QueryError_HasError(status)) {
         searchRequestCtx_Free(req);

--- a/src/module.c
+++ b/src/module.c
@@ -2360,7 +2360,10 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
   // Length-faithful copy: keeps any embedded NULs the client sent, matching
   // the (buffer, length) parse downstream.
   req->queryString = rm_strndup(queryPtr, queryLen);
-  req->queryStringLen = queryLen;
+  // TRANSITIONAL: record the C-string length, truncating at the first NUL, so a query
+  // with embedded NULs behaves as it always has — consistent with AREQ_Query on the shards.
+  // TODO: remove — the true length is queryLen.
+  req->queryStringLen = strlen(req->queryString);
   req->limit = 10;
   req->offset = 0;
   req->specialCases = NULL;

--- a/src/module.h
+++ b/src/module.h
@@ -136,7 +136,7 @@ bool debugCommandsEnabled(RedisModuleCtx *ctx);
 
 specialCaseCtx *prepareOptionalTopKCase(const char *query_string, size_t query_len,
                                         RedisModuleString **argv, int argc, uint dialectVersion,
-                             QueryError *status);
+                                        QueryError *status);
 
 void SpecialCaseCtx_Free(specialCaseCtx* ctx);
 

--- a/src/module.h
+++ b/src/module.h
@@ -134,7 +134,8 @@ typedef struct {
 
 bool debugCommandsEnabled(RedisModuleCtx *ctx);
 
-specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleString **argv, int argc, uint dialectVersion,
+specialCaseCtx *prepareOptionalTopKCase(const char *query_string, size_t query_len,
+                                        RedisModuleString **argv, int argc, uint dialectVersion,
                              QueryError *status);
 
 void SpecialCaseCtx_Free(specialCaseCtx* ctx);

--- a/src/module.h
+++ b/src/module.h
@@ -103,6 +103,7 @@ struct searchReducerCtx;
 
 typedef struct {
   char *queryString;
+  size_t queryStringLen;
   long long offset;
   long long limit;
   long long requestedResultsCount;
@@ -134,9 +135,7 @@ typedef struct {
 
 bool debugCommandsEnabled(RedisModuleCtx *ctx);
 
-specialCaseCtx *prepareOptionalTopKCase(const char *query_string, size_t query_len,
-                                        RedisModuleString **argv, int argc, uint dialectVersion,
-                                        QueryError *status);
+specialCaseCtx *prepareOptionalTopKCase(const char *query_string, size_t query_len, RedisModuleString **argv, int argc, uint dialectVersion, QueryError *status);
 
 void SpecialCaseCtx_Free(specialCaseCtx* ctx);
 

--- a/src/query.c
+++ b/src/query.c
@@ -136,6 +136,10 @@ void QueryNode_Free(QueryNode *n) {
       QueryGeometryNode_Free(&n->gmn);
       break;
     case QN_IDS:
+      if (n->fn.keys) {
+        rm_free(n->fn.keys);
+        n->fn.keys = NULL;
+      }
       if (n->fn.docIds) {
         rm_free(n->fn.docIds);
         n->fn.docIds = NULL;
@@ -479,9 +483,11 @@ void QAST_SetGlobalFilters(QueryAST *ast, QAST_GlobalFilterOptions *options) {
   }
   if (options->keys) {
     QueryNode *n = NewQueryNode(QN_IDS);
+    // Transfer ownership of the key views and docIds to the QueryNode
+    // (freed in QueryNode_Free)
     n->fn.keys = options->keys;
     n->fn.len = options->nkeys;
-    // Transfer ownership of docIds to the QueryNode (freed in QueryNode_Free)
+    options->keys = NULL;
     n->fn.docIds = options->docIds;
     options->docIds = NULL;
     SetFilterNode(ast, n);
@@ -1708,7 +1714,7 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
             RS_ASSERT(SearchDisk_IsEnabled());
             did = qs->fn.docIds[i];
           } else {
-            did = DocTable_GetId(&spec->docs, qs->fn.keys[i], sdslen(qs->fn.keys[i]));
+            did = DocTable_GetId(&spec->docs, qs->fn.keys[i].data, qs->fn.keys[i].len);
           }
           if (did != 0) {
             s = sdscatprintf(s, "%" PRIu64 ",", did);

--- a/src/query.c
+++ b/src/query.c
@@ -136,10 +136,7 @@ void QueryNode_Free(QueryNode *n) {
       QueryGeometryNode_Free(&n->gmn);
       break;
     case QN_IDS:
-      if (n->fn.keys) {
-        rm_free(n->fn.keys);
-        n->fn.keys = NULL;
-      }
+      // fn.keys is a borrowed window into the request's held argv; not freed here
       if (n->fn.docIds) {
         rm_free(n->fn.docIds);
         n->fn.docIds = NULL;
@@ -483,11 +480,9 @@ void QAST_SetGlobalFilters(QueryAST *ast, QAST_GlobalFilterOptions *options) {
   }
   if (options->keys) {
     QueryNode *n = NewQueryNode(QN_IDS);
-    // Transfer ownership of the key views and docIds to the QueryNode
-    // (freed in QueryNode_Free)
-    n->fn.keys = options->keys;
+    n->fn.keys = options->keys;  // borrowed from the request's held argv
     n->fn.len = options->nkeys;
-    options->keys = NULL;
+    // Transfer ownership of the docIds to the QueryNode (freed in QueryNode_Free)
     n->fn.docIds = options->docIds;
     options->docIds = NULL;
     SetFilterNode(ast, n);
@@ -1714,7 +1709,7 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
             RS_ASSERT(SearchDisk_IsEnabled());
             did = qs->fn.docIds[i];
           } else {
-            did = DocTable_GetId(&spec->docs, qs->fn.keys[i].data, qs->fn.keys[i].len);
+            did = DocTable_GetIdR(&spec->docs, qs->fn.keys[i]);
           }
           if (did != 0) {
             s = sdscatprintf(s, "%" PRIu64 ",", did);

--- a/src/query.h
+++ b/src/query.h
@@ -90,9 +90,9 @@ typedef struct {
   // Used to set an empty iterator when a legacy filter's field is not found with Dialect 1
   bool empty;
 
-  /** Views of the keys to limit to, and the length of that array. The array
-   * is transferred to the query node by QAST_SetGlobalFilters. */
-  RSStringView *keys;
+  /** The keys to limit to: a borrowed window into the request's held argv
+   * (see BlockedRequestCtx.argvHolds). Not owned. */
+  RedisModuleString **keys;
   /** Pre-resolved document IDs (for SearchDisk, resolved on main thread). Same length as keys. (Not owned) */
   t_docId *docIds;
   size_t nkeys;

--- a/src/query.h
+++ b/src/query.h
@@ -90,8 +90,9 @@ typedef struct {
   // Used to set an empty iterator when a legacy filter's field is not found with Dialect 1
   bool empty;
 
-  /** List of keys to limit to, and the length of that array. Not owned. */
-  const sds *keys;
+  /** Views of the keys to limit to, and the length of that array. The array
+   * is transferred to the query node by QAST_SetGlobalFilters. */
+  RSStringView *keys;
   /** Pre-resolved document IDs (for SearchDisk, resolved on main thread). Same length as keys. (Not owned) */
   t_docId *docIds;
   size_t nkeys;

--- a/src/query.h
+++ b/src/query.h
@@ -91,7 +91,7 @@ typedef struct {
   bool empty;
 
   /** The keys to limit to: a borrowed window into the request's held argv
-   * (see BlockedRequestCtx.argvHolds). Not owned. */
+   * (see BlockedRequestCtx.argv). Not owned. */
   RedisModuleString **keys;
   /** Pre-resolved document IDs (for SearchDisk, resolved on main thread). Same length as keys. (Not owned) */
   t_docId *docIds;

--- a/src/query_node.h
+++ b/src/query_node.h
@@ -77,8 +77,16 @@ typedef struct {
   struct VectorQuery *vq;
 } QueryVectorNode;
 
+/* A borrowed (pointer, length) view of a string owned elsewhere. */
 typedef struct {
-  const sds *keys;
+  const char *data;
+  size_t len;
+} RSStringView;
+
+typedef struct {
+  /* Views of the key names, borrowing from the request's held argv. The
+   * array itself is owned by the node (freed in QueryNode_Free). */
+  RSStringView *keys;
   // Pre-resolved document IDs (for SearchDisk, resolved on main thread)
   t_docId *docIds;
   size_t len;

--- a/src/query_node.h
+++ b/src/query_node.h
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include "query_types.h"
 #include "redisearch.h"
+#include "redismodule.h"
 #include "hiredis/sds.h"
 #include "param.h"
 
@@ -77,16 +78,10 @@ typedef struct {
   struct VectorQuery *vq;
 } QueryVectorNode;
 
-/* A borrowed (pointer, length) view of a string owned elsewhere. */
 typedef struct {
-  const char *data;
-  size_t len;
-} RSStringView;
-
-typedef struct {
-  /* Views of the key names, borrowing from the request's held argv. The
-   * array itself is owned by the node (freed in QueryNode_Free). */
-  RSStringView *keys;
+  /* The key names: a borrowed window into the request's held argv (see
+   * BlockedRequestCtx.argvHolds), which outlives the AST. Not owned. */
+  RedisModuleString **keys;
   // Pre-resolved document IDs (for SearchDisk, resolved on main thread)
   t_docId *docIds;
   size_t len;

--- a/src/query_node.h
+++ b/src/query_node.h
@@ -80,7 +80,7 @@ typedef struct {
 
 typedef struct {
   /* The key names: a borrowed window into the request's held argv (see
-   * BlockedRequestCtx.argvHolds), which outlives the AST. Not owned. */
+   * BlockedRequestCtx.argv), which outlives the AST. Not owned. */
   RedisModuleString **keys;
   // Pre-resolved document IDs (for SearchDisk, resolved on main thread)
   t_docId *docIds;

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1766,6 +1766,7 @@ dependencies = [
  "query_error",
  "query_flags",
  "query_types",
+ "redis-module",
  "redis_mock",
  "redisearch_rs",
  "rlookup",

--- a/src/redisearch_rs/c_wrappers/query/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/query/Cargo.toml
@@ -15,6 +15,7 @@ build_utils.workspace = true
 
 [dependencies]
 ffi.workspace = true
+redis-module.workspace = true
 inverted_index.workspace = true
 query_error.workspace = true
 query_flags.workspace = true

--- a/src/redisearch_rs/c_wrappers/query/src/mock/query_node_ref.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/mock/query_node_ref.rs
@@ -214,13 +214,18 @@ impl MockQueryNode {
     /// Set the fields of the IDs-node union variant.
     ///
     /// `keys` and `doc_ids` must outlive this `MockQueryNode`.
-    pub fn set_ids(&mut self, keys: *const ffi::RSStringView, doc_ids: *mut DocId, len: usize) {
+    pub fn set_ids(
+        &mut self,
+        keys: *mut *mut ffi::RedisModuleString,
+        doc_ids: *mut DocId,
+        len: usize,
+    ) {
         // SAFETY: `self.node` is valid and exclusively owned; the caller
         // guarantees the node type is Ids so the `fn` variant is active.
         unsafe {
             let union_ptr = &raw mut (*self.node).__bindgen_anon_1;
             let ids = &mut *union_ptr.cast::<ffi::QueryIdFilterNode>();
-            ids.keys = keys.cast_mut();
+            ids.keys = keys;
             ids.docIds = doc_ids;
             ids.len = len;
         }

--- a/src/redisearch_rs/c_wrappers/query/src/mock/query_node_ref.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/mock/query_node_ref.rs
@@ -214,13 +214,13 @@ impl MockQueryNode {
     /// Set the fields of the IDs-node union variant.
     ///
     /// `keys` and `doc_ids` must outlive this `MockQueryNode`.
-    pub fn set_ids(&mut self, keys: *const ffi::sds, doc_ids: *mut DocId, len: usize) {
+    pub fn set_ids(&mut self, keys: *const ffi::RSStringView, doc_ids: *mut DocId, len: usize) {
         // SAFETY: `self.node` is valid and exclusively owned; the caller
         // guarantees the node type is Ids so the `fn` variant is active.
         unsafe {
             let union_ptr = &raw mut (*self.node).__bindgen_anon_1;
             let ids = &mut *union_ptr.cast::<ffi::QueryIdFilterNode>();
-            ids.keys = keys;
+            ids.keys = keys.cast_mut();
             ids.docIds = doc_ids;
             ids.len = len;
         }

--- a/src/redisearch_rs/c_wrappers/query/src/mock/query_node_ref.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/mock/query_node_ref.rs
@@ -216,7 +216,7 @@ impl MockQueryNode {
     /// `keys` and `doc_ids` must outlive this `MockQueryNode`.
     pub fn set_ids(
         &mut self,
-        keys: *mut *mut ffi::RedisModuleString,
+        keys: *mut *mut redis_module::raw::RedisModuleString,
         doc_ids: *mut DocId,
         len: usize,
     ) {

--- a/src/redisearch_rs/c_wrappers/query/src/query_node_ref.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_node_ref.rs
@@ -97,8 +97,9 @@ pub enum QueryNode<'a> {
     },
     /// A filter by explicit document key names.
     Ids {
-        /// SDS key strings to match against.
-        keys: &'a [ffi::sds],
+        /// (pointer, length) views of the key names to match against,
+        /// borrowing from storage owned by the request (its held argv).
+        keys: &'a [ffi::RSStringView],
         /// Pre-resolved document IDs (resolved on the main thread for
         /// search-on-disk).  `None` when not in disk mode.
         doc_ids: Option<&'a [DocId]>,
@@ -313,7 +314,7 @@ impl QueryNodeRef {
                         &[]
                     } else {
                         // SAFETY: invariant (1) of `new` guarantees `keys` is a
-                        // valid pointer to `len` SDS strings when non-null.
+                        // valid pointer to `len` string views when non-null.
                         unsafe { std::slice::from_raw_parts(fn_.keys, len) }
                     },
                     doc_ids: if fn_.docIds.is_null() {

--- a/src/redisearch_rs/c_wrappers/query/src/query_node_ref.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_node_ref.rs
@@ -100,7 +100,7 @@ pub enum QueryNode<'a> {
         /// The key names to match against: `RedisModuleString`s borrowed
         /// from storage owned by the request (its held argv). Opaque to
         /// Rust; resolved through `DocTable_GetIdR`.
-        keys: &'a [*mut ffi::RedisModuleString],
+        keys: &'a [*mut redis_module::raw::RedisModuleString],
         /// Pre-resolved document IDs (resolved on the main thread for
         /// search-on-disk).  `None` when not in disk mode.
         doc_ids: Option<&'a [DocId]>,

--- a/src/redisearch_rs/c_wrappers/query/src/query_node_ref.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_node_ref.rs
@@ -97,9 +97,10 @@ pub enum QueryNode<'a> {
     },
     /// A filter by explicit document key names.
     Ids {
-        /// (pointer, length) views of the key names to match against,
-        /// borrowing from storage owned by the request (its held argv).
-        keys: &'a [ffi::RSStringView],
+        /// The key names to match against: `RedisModuleString`s borrowed
+        /// from storage owned by the request (its held argv). Opaque to
+        /// Rust; resolved through `DocTable_GetIdR`.
+        keys: &'a [*mut ffi::RedisModuleString],
         /// Pre-resolved document IDs (resolved on the main thread for
         /// search-on-disk).  `None` when not in disk mode.
         doc_ids: Option<&'a [DocId]>,
@@ -314,7 +315,7 @@ impl QueryNodeRef {
                         &[]
                     } else {
                         // SAFETY: invariant (1) of `new` guarantees `keys` is a
-                        // valid pointer to `len` string views when non-null.
+                        // valid pointer to `len` string pointers when non-null.
                         unsafe { std::slice::from_raw_parts(fn_.keys, len) }
                     },
                     doc_ids: if fn_.docIds.is_null() {

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -129,6 +129,7 @@ const HEADERS: &[HeaderAllowlist] = &[
             "DMD_Free",
             "DocTable_Exists",
             "DocTable_GetId",
+            "DocTable_GetIdR",
             "DocTable_Put",
         ],
         types: &[],

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -25,8 +25,6 @@ typedef struct timespec timespec;
 typedef struct AREQ AREQ;
 
 
-typedef struct RedisModuleCtx RedisModuleCtx;
-
 /**
  * Smart pointer handle for [`RLookupKey`] that can be
  * invalidated when the iterator that owns the key is freed.
@@ -108,6 +106,8 @@ typedef struct InvertedIndex InvertedIndex;
 typedef struct NumericRangeTree NumericRangeTree;
 
 typedef struct RLookupKey RLookupKey;
+
+typedef struct RedisModuleCtx RedisModuleCtx;
 
 /**
  * Results returned by a [`ProduceResultsFn`].

--- a/src/redisearch_rs/headers/numeric_range_tree_ffi.h
+++ b/src/redisearch_rs/headers/numeric_range_tree_ffi.h
@@ -33,12 +33,12 @@ typedef enum ApplyGcEntryStatus {
   DeserializationError,
 } ApplyGcEntryStatus;
 
-typedef struct RedisModuleCtx RedisModuleCtx;
-
 /**
  * Filter details to apply to numeric values
  */
 typedef struct NumericFilter NumericFilter;
+
+typedef struct RedisModuleCtx RedisModuleCtx;
 
 /**
  * An opaque inverted index reader structure. The actual implementation is determined at runtime

--- a/src/redisearch_rs/headers/rlookup_ffi.h
+++ b/src/redisearch_rs/headers/rlookup_ffi.h
@@ -10,8 +10,6 @@
 #include "search_result_rs.h"
 #include "rlookup.h"
 
-typedef struct RedisModuleKey RedisModuleKey;
-
 /**
  * The C version of a [`SharedValue`](value::SharedValue)
  */
@@ -23,6 +21,8 @@ typedef struct RSValue RSValue;
  * and a list of fields loaded by the chain
  */
 typedef struct SearchResult SearchResult;
+
+typedef struct RedisModuleKey RedisModuleKey;
 
 typedef struct QueryError QueryError;
 

--- a/src/redisearch_rs/headers/value_ffi.h
+++ b/src/redisearch_rs/headers/value_ffi.h
@@ -26,8 +26,6 @@ typedef enum RSValueType {
   RSValueType_Map = 8,
 } RSValueType;
 
-typedef struct RedisModuleString RedisModuleString;
-
 /**
  * Opaque map structure used during map construction.
  * Holds uninitialized entries that are populated via [`RSValue_MapBuilderSetEntry`]
@@ -39,6 +37,8 @@ typedef struct RSValueMapBuilder RSValueMapBuilder;
  * The C version of a [`SharedValue`](value::SharedValue)
  */
 typedef struct RSValue RSValue;
+
+typedef struct RedisModuleString RedisModuleString;
 
 typedef struct QueryError QueryError;
 

--- a/src/redisearch_rs/query_eval/src/nodes/ids.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/ids.rs
@@ -20,15 +20,15 @@ use crate::{Evaluated, QueryEvalContext};
 /// Resolves each key to a document ID, sorts, deduplicates, and creates a
 /// sorted [`IdListSorted`] iterator.
 ///
-/// * `keys` — SDS key strings from the query node.  When `doc_ids` is
-///   `None`, each key is looked up in the [`DocTable`](ffi::DocTable) to
-///   obtain its document ID.
+/// * `keys` — (pointer, length) views of the key names from the query node.
+///   When `doc_ids` is `None`, each key is looked up in the
+///   [`DocTable`](ffi::DocTable) to obtain its document ID.
 /// * `doc_ids` — when present (search-on-disk mode), contains pre-resolved
 ///   document IDs positionally matching `keys`, bypassing the `DocTable`
 ///   lookup.
 pub(crate) fn eval<'index>(
     ctx: &'index mut QueryEvalContext,
-    keys: &[ffi::sds],
+    keys: &[ffi::RSStringView],
     doc_ids: Option<&[DocId]>,
 ) -> Evaluated<'index> {
     // Pre-resolved `doc_ids` are only produced on the search-on-disk path, so
@@ -52,13 +52,11 @@ pub(crate) fn eval<'index>(
         // In-memory: resolve each key to a doc id through the `DocTable`.
         None => keys
             .iter()
-            .filter_map(|&key| {
-                // SAFETY: `key` is a valid SDS string (guaranteed by
-                // `QueryNodeRef`); `sdslen_rust` reads its header.
-                let key_len = unsafe { ffi::sdslen_rust(key) };
-                // SAFETY: `doc_table()` returns a valid `DocTable` reference
-                // (`QueryEvalContext` invariant).
-                let did = unsafe { ffi::DocTable_GetId(ctx.doc_table(), key, key_len) };
+            .filter_map(|key| {
+                // SAFETY: `key` is a valid (pointer, length) view (guaranteed
+                // by `QueryNodeRef`) and `doc_table()` returns a valid
+                // `DocTable` reference (`QueryEvalContext` invariant).
+                let did = unsafe { ffi::DocTable_GetId(ctx.doc_table(), key.data, key.len) };
                 (did != 0).then_some(did)
             })
             .collect(),

--- a/src/redisearch_rs/query_eval/src/nodes/ids.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/ids.rs
@@ -28,7 +28,7 @@ use crate::{Evaluated, QueryEvalContext};
 ///   lookup.
 pub(crate) fn eval<'index>(
     ctx: &'index mut QueryEvalContext,
-    keys: &[*mut ffi::RedisModuleString],
+    keys: &[*mut redis_module::raw::RedisModuleString],
     doc_ids: Option<&[DocId]>,
 ) -> Evaluated<'index> {
     // Pre-resolved `doc_ids` are only produced on the search-on-disk path, so

--- a/src/redisearch_rs/query_eval/src/nodes/ids.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/ids.rs
@@ -20,15 +20,15 @@ use crate::{Evaluated, QueryEvalContext};
 /// Resolves each key to a document ID, sorts, deduplicates, and creates a
 /// sorted [`IdListSorted`] iterator.
 ///
-/// * `keys` — (pointer, length) views of the key names from the query node.
-///   When `doc_ids` is `None`, each key is looked up in the
+/// * `keys` — the key names to match against, borrowing the request's held
+///   argv. When `doc_ids` is `None`, each key is looked up in the
 ///   [`DocTable`](ffi::DocTable) to obtain its document ID.
 /// * `doc_ids` — when present (search-on-disk mode), contains pre-resolved
 ///   document IDs positionally matching `keys`, bypassing the `DocTable`
 ///   lookup.
 pub(crate) fn eval<'index>(
     ctx: &'index mut QueryEvalContext,
-    keys: &[ffi::RSStringView],
+    keys: &[*mut ffi::RedisModuleString],
     doc_ids: Option<&[DocId]>,
 ) -> Evaluated<'index> {
     // Pre-resolved `doc_ids` are only produced on the search-on-disk path, so
@@ -52,11 +52,12 @@ pub(crate) fn eval<'index>(
         // In-memory: resolve each key to a doc id through the `DocTable`.
         None => keys
             .iter()
-            .filter_map(|key| {
-                // SAFETY: `key` is a valid (pointer, length) view (guaranteed
-                // by `QueryNodeRef`) and `doc_table()` returns a valid
-                // `DocTable` reference (`QueryEvalContext` invariant).
-                let did = unsafe { ffi::DocTable_GetId(ctx.doc_table(), key.data, key.len) };
+            .filter_map(|&key| {
+                // SAFETY: `key` is a valid `RedisModuleString` (guaranteed by
+                // `QueryNodeRef`: the node borrows the request's held argv)
+                // and `doc_table()` returns a valid `DocTable` reference
+                // (`QueryEvalContext` invariant).
+                let did = unsafe { ffi::DocTable_GetIdR(ctx.doc_table(), key) };
                 (did != 0).then_some(did)
             })
             .collect(),

--- a/src/redisearch_rs/query_eval/tests/integration/ids.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/ids.rs
@@ -15,7 +15,7 @@ use rqe_iterators::{IteratorType, RQEIterator};
 
 use query::mock::{MockQueryEvalCtx, MockQueryNode};
 
-use crate::util::null_view;
+use crate::util::MockKeys;
 
 #[test]
 fn eval_ids_with_pre_resolved_doc_ids() {
@@ -23,7 +23,7 @@ fn eval_ids_with_pre_resolved_doc_ids() {
     mock_ctx.enable_disk_mode();
     let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
 
-    let keys = vec![null_view(); 3];
+    let keys = MockKeys::nulls(3);
     let mut doc_ids: Vec<u64> = vec![10, 5, 20];
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
@@ -53,7 +53,7 @@ fn eval_ids_deduplicates() {
     mock_ctx.enable_disk_mode();
     let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
 
-    let keys = vec![null_view(); 4];
+    let keys = MockKeys::nulls(4);
     let mut doc_ids: Vec<u64> = vec![3, 3, 7, 7];
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
@@ -77,7 +77,7 @@ fn eval_ids_filters_zero_doc_ids() {
     mock_ctx.enable_disk_mode();
     let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
 
-    let keys = vec![null_view(); 3];
+    let keys = MockKeys::nulls(3);
     let mut doc_ids: Vec<u64> = vec![0, 5, 0];
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
@@ -99,7 +99,7 @@ fn eval_ids_all_zero_produces_empty_list() {
     mock_ctx.enable_disk_mode();
     let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
 
-    let keys = vec![null_view(); 2];
+    let keys = MockKeys::nulls(2);
     let mut doc_ids: Vec<u64> = vec![0, 0];
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
@@ -123,7 +123,7 @@ fn eval_ids_empty_keys() {
     let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
-    mock_node.set_ids(std::ptr::null(), std::ptr::null_mut(), 0);
+    mock_node.set_ids(std::ptr::null_mut(), std::ptr::null_mut(), 0);
     let node = unsafe { QueryNodeMut::new(mock_node.as_non_null()) };
 
     let mut it = eval_node(&mut ctx, node, Config::default())
@@ -141,7 +141,7 @@ fn eval_ids_empty_keys() {
 // QN_IDS → IdList, resolving key names through the DocTable
 //
 // The lightweight `MockQueryEvalCtx` has an empty `DocTable`, so the key→docId
-// resolution path (`DocTable_GetId`) is exercised here with the full-FFI
+// resolution path (`DocTable_GetIdR`) is exercised here with the full-FFI
 // `TestContext`, which can register real documents.
 // ---------------------------------------------------------------------------
 
@@ -153,7 +153,7 @@ mod ids_doctable {
     use rqe_iterators_test_utils::{GlobalGuard, TestContext};
 
     use super::*;
-    use crate::util::key_view;
+    use crate::util::MockKeys;
 
     #[test]
     fn eval_ids_resolves_keys_through_doc_table() {
@@ -170,7 +170,7 @@ mod ids_doctable {
         // Query for both known keys plus an unknown one, which must resolve to
         // id 0 and be filtered out. `doc_ids` is NULL, so the DocTable lookup
         // path is taken.
-        let keys = vec![key_view("doc_b"), key_view("ghost"), key_view("doc_a")];
+        let keys = MockKeys::new(&["doc_b", "ghost", "doc_a"]);
 
         let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
         mock_node.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
@@ -198,7 +198,7 @@ mod ids_doctable {
         let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
 
         // None of these keys exist in the (empty) DocTable.
-        let keys = vec![key_view("nope"), key_view("missing")];
+        let keys = MockKeys::new(&["nope", "missing"]);
 
         let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
         mock_node.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());

--- a/src/redisearch_rs/query_eval/tests/integration/ids.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/ids.rs
@@ -15,13 +15,15 @@ use rqe_iterators::{IteratorType, RQEIterator};
 
 use query::mock::{MockQueryEvalCtx, MockQueryNode};
 
+use crate::util::null_view;
+
 #[test]
 fn eval_ids_with_pre_resolved_doc_ids() {
     let mut mock_ctx = MockQueryEvalCtx::new();
     mock_ctx.enable_disk_mode();
     let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
 
-    let keys: Vec<ffi::sds> = vec![std::ptr::null_mut(); 3];
+    let keys = vec![null_view(); 3];
     let mut doc_ids: Vec<u64> = vec![10, 5, 20];
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
@@ -51,7 +53,7 @@ fn eval_ids_deduplicates() {
     mock_ctx.enable_disk_mode();
     let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
 
-    let keys: Vec<ffi::sds> = vec![std::ptr::null_mut(); 4];
+    let keys = vec![null_view(); 4];
     let mut doc_ids: Vec<u64> = vec![3, 3, 7, 7];
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
@@ -75,7 +77,7 @@ fn eval_ids_filters_zero_doc_ids() {
     mock_ctx.enable_disk_mode();
     let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
 
-    let keys: Vec<ffi::sds> = vec![std::ptr::null_mut(); 3];
+    let keys = vec![null_view(); 3];
     let mut doc_ids: Vec<u64> = vec![0, 5, 0];
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
@@ -97,7 +99,7 @@ fn eval_ids_all_zero_produces_empty_list() {
     mock_ctx.enable_disk_mode();
     let mut ctx = unsafe { QueryEvalContext::new(mock_ctx.as_non_null()) };
 
-    let keys: Vec<ffi::sds> = vec![std::ptr::null_mut(); 2];
+    let keys = vec![null_view(); 2];
     let mut doc_ids: Vec<u64> = vec![0, 0];
 
     let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
@@ -143,15 +145,15 @@ fn eval_ids_empty_keys() {
 // `TestContext`, which can register real documents.
 // ---------------------------------------------------------------------------
 
-// Disabled under Miri: `TestContext` and SDS creation call into the C library,
-// which Miri cannot execute.
+// Disabled under Miri: `TestContext` calls into the C library, which Miri
+// cannot execute.
 #[cfg(not(miri))]
 mod ids_doctable {
     use ffi::IndexFlags_Index_StoreFreqs;
     use rqe_iterators_test_utils::{GlobalGuard, TestContext};
 
     use super::*;
-    use crate::util::new_sds;
+    use crate::util::key_view;
 
     #[test]
     fn eval_ids_resolves_keys_through_doc_table() {
@@ -168,7 +170,7 @@ mod ids_doctable {
         // Query for both known keys plus an unknown one, which must resolve to
         // id 0 and be filtered out. `doc_ids` is NULL, so the DocTable lookup
         // path is taken.
-        let keys: Vec<ffi::sds> = vec![new_sds("doc_b"), new_sds("ghost"), new_sds("doc_a")];
+        let keys = vec![key_view("doc_b"), key_view("ghost"), key_view("doc_a")];
 
         let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
         mock_node.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
@@ -186,11 +188,6 @@ mod ids_doctable {
         assert_eq!(r.doc_id, id_b);
         assert!(matches!(it.read(), Ok(None)));
         assert!(it.at_eof());
-
-        for key in keys {
-            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
-            unsafe { ffi::sdsfree(key) };
-        }
     }
 
     #[test]
@@ -201,7 +198,7 @@ mod ids_doctable {
         let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
 
         // None of these keys exist in the (empty) DocTable.
-        let keys: Vec<ffi::sds> = vec![new_sds("nope"), new_sds("missing")];
+        let keys = vec![key_view("nope"), key_view("missing")];
 
         let mut mock_node = MockQueryNode::new(QueryNodeType::Ids);
         mock_node.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
@@ -215,10 +212,5 @@ mod ids_doctable {
         assert!(!it.at_eof());
         assert!(matches!(it.read(), Ok(None)));
         assert!(it.at_eof());
-
-        for key in keys {
-            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
-            unsafe { ffi::sdsfree(key) };
-        }
     }
 }

--- a/src/redisearch_rs/query_eval/tests/integration/not.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/not.rs
@@ -84,7 +84,7 @@ mod not {
     use rqe_iterators_test_utils::{GlobalGuard, TestContext};
 
     use super::*;
-    use crate::util::key_view;
+    use crate::util::MockKeys;
 
     #[test]
     fn eval_not_wraps_real_child_in_not() {
@@ -107,7 +107,7 @@ mod not {
         let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
 
         // QN_IDS child resolving to the middle document only.
-        let keys = vec![key_view("doc_b")];
+        let keys = MockKeys::new(&["doc_b"]);
         let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
         ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
 
@@ -128,7 +128,6 @@ mod not {
         }
         assert!(matches!(it.read(), Ok(None)));
         assert!(it.at_eof());
-
     }
 
     #[test]
@@ -199,7 +198,7 @@ mod not {
         // QN_IDS child resolving to a real document → neither empty nor a
         // wildcard, so the reducer skips its shortcircuits and reaches the
         // optimized constructor.
-        let keys = vec![key_view("doc_b")];
+        let keys = MockKeys::new(&["doc_b"]);
         let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
         ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
 
@@ -218,6 +217,5 @@ mod not {
         // optimized NOT yields nothing — but it must drain cleanly.
         assert!(matches!(it.read(), Ok(None)));
         assert!(it.at_eof());
-
     }
 }

--- a/src/redisearch_rs/query_eval/tests/integration/not.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/not.rs
@@ -84,7 +84,7 @@ mod not {
     use rqe_iterators_test_utils::{GlobalGuard, TestContext};
 
     use super::*;
-    use crate::util::new_sds;
+    use crate::util::key_view;
 
     #[test]
     fn eval_not_wraps_real_child_in_not() {
@@ -107,7 +107,7 @@ mod not {
         let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
 
         // QN_IDS child resolving to the middle document only.
-        let keys: Vec<ffi::sds> = vec![new_sds("doc_b")];
+        let keys = vec![key_view("doc_b")];
         let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
         ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
 
@@ -129,10 +129,6 @@ mod not {
         assert!(matches!(it.read(), Ok(None)));
         assert!(it.at_eof());
 
-        for key in keys {
-            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
-            unsafe { ffi::sdsfree(key) };
-        }
     }
 
     #[test]
@@ -203,7 +199,7 @@ mod not {
         // QN_IDS child resolving to a real document → neither empty nor a
         // wildcard, so the reducer skips its shortcircuits and reaches the
         // optimized constructor.
-        let keys: Vec<ffi::sds> = vec![new_sds("doc_b")];
+        let keys = vec![key_view("doc_b")];
         let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
         ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
 
@@ -223,9 +219,5 @@ mod not {
         assert!(matches!(it.read(), Ok(None)));
         assert!(it.at_eof());
 
-        for key in keys {
-            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
-            unsafe { ffi::sdsfree(key) };
-        }
     }
 }

--- a/src/redisearch_rs/query_eval/tests/integration/optional.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/optional.rs
@@ -81,15 +81,15 @@ fn eval_optional_wildcard_child_passes_through() {
 //   wildcard fallback distinct from the structurally-empty shortcircuit.
 // ---------------------------------------------------------------------------
 
-// Disabled under Miri: `TestContext` and SDS creation call into the C library,
-// which Miri cannot execute.
+// Disabled under Miri: `TestContext` calls into the C library, which Miri
+// cannot execute.
 #[cfg(not(miri))]
 mod optional {
     use ffi::IndexFlags_Index_StoreFreqs;
     use rqe_iterators_test_utils::{GlobalGuard, TestContext};
 
     use super::*;
-    use crate::util::key_view;
+    use crate::util::MockKeys;
 
     #[test]
     fn eval_optional_wraps_real_child_in_optional() {
@@ -105,7 +105,7 @@ mod optional {
         let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
 
         // QN_IDS child resolving to the two known documents.
-        let keys = vec![key_view("doc_a"), key_view("doc_b")];
+        let keys = MockKeys::new(&["doc_a", "doc_b"]);
         let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
         ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
 
@@ -126,7 +126,6 @@ mod optional {
         }
         assert!(matches!(it.read(), Ok(None)));
         assert!(it.at_eof());
-
     }
 
     #[test]
@@ -192,7 +191,7 @@ mod optional {
         // QN_IDS child resolving to a real document → neither empty nor a
         // wildcard, so the reducer skips its shortcircuits and reaches the
         // optimized constructor.
-        let keys = vec![key_view("doc_a")];
+        let keys = MockKeys::new(&["doc_a"]);
         let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
         ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
 
@@ -210,6 +209,5 @@ mod optional {
         // empty and the iterator yields nothing — but it must drain cleanly.
         assert!(matches!(it.read(), Ok(None)));
         assert!(it.at_eof());
-
     }
 }

--- a/src/redisearch_rs/query_eval/tests/integration/optional.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/optional.rs
@@ -89,7 +89,7 @@ mod optional {
     use rqe_iterators_test_utils::{GlobalGuard, TestContext};
 
     use super::*;
-    use crate::util::new_sds;
+    use crate::util::key_view;
 
     #[test]
     fn eval_optional_wraps_real_child_in_optional() {
@@ -105,7 +105,7 @@ mod optional {
         let mut ctx = unsafe { QueryEvalContext::new(context.qctx()) };
 
         // QN_IDS child resolving to the two known documents.
-        let keys: Vec<ffi::sds> = vec![new_sds("doc_a"), new_sds("doc_b")];
+        let keys = vec![key_view("doc_a"), key_view("doc_b")];
         let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
         ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
 
@@ -127,10 +127,6 @@ mod optional {
         assert!(matches!(it.read(), Ok(None)));
         assert!(it.at_eof());
 
-        for key in keys {
-            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
-            unsafe { ffi::sdsfree(key) };
-        }
     }
 
     #[test]
@@ -196,7 +192,7 @@ mod optional {
         // QN_IDS child resolving to a real document → neither empty nor a
         // wildcard, so the reducer skips its shortcircuits and reaches the
         // optimized constructor.
-        let keys: Vec<ffi::sds> = vec![new_sds("doc_a")];
+        let keys = vec![key_view("doc_a")];
         let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
         ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
 
@@ -215,9 +211,5 @@ mod optional {
         assert!(matches!(it.read(), Ok(None)));
         assert!(it.at_eof());
 
-        for key in keys {
-            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
-            unsafe { ffi::sdsfree(key) };
-        }
     }
 }

--- a/src/redisearch_rs/query_eval/tests/integration/phrase.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/phrase.rs
@@ -63,7 +63,7 @@ mod phrase {
     use rqe_iterators_test_utils::{GlobalGuard, TestContext};
 
     use super::*;
-    use crate::util::new_sds;
+    use crate::util::key_view;
 
     #[test]
     fn eval_phrase_intersects_children() {
@@ -90,8 +90,8 @@ mod phrase {
 
         // child 1 matches {doc_a, doc_b}; child 2 matches {doc_b, doc_c}; the
         // intersection is {doc_b}.
-        let keys1: Vec<ffi::sds> = vec![new_sds("doc_a"), new_sds("doc_b")];
-        let keys2: Vec<ffi::sds> = vec![new_sds("doc_b"), new_sds("doc_c")];
+        let keys1 = vec![key_view("doc_a"), key_view("doc_b")];
+        let keys2 = vec![key_view("doc_b"), key_view("doc_c")];
         let mut c1 = MockQueryNode::new(QueryNodeType::Ids);
         c1.set_ids(keys1.as_ptr(), std::ptr::null_mut(), keys1.len());
         let mut c2 = MockQueryNode::new(QueryNodeType::Ids);
@@ -113,10 +113,6 @@ mod phrase {
         assert_eq!(r.doc_id, 2);
         assert!(matches!(it.read(), Ok(None)));
 
-        for key in keys1.into_iter().chain(keys2) {
-            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
-            unsafe { ffi::sdsfree(key) };
-        }
     }
 
     #[test]
@@ -149,8 +145,8 @@ mod phrase {
 
         // child 1 matches {doc_a, doc_b}; child 2 matches {doc_b, doc_c}; the
         // intersection is {doc_b}.
-        let keys1: Vec<ffi::sds> = vec![new_sds("doc_a"), new_sds("doc_b")];
-        let keys2: Vec<ffi::sds> = vec![new_sds("doc_b"), new_sds("doc_c")];
+        let keys1 = vec![key_view("doc_a"), key_view("doc_b")];
+        let keys2 = vec![key_view("doc_b"), key_view("doc_c")];
         let mut c1 = MockQueryNode::new(QueryNodeType::Ids);
         c1.set_ids(keys1.as_ptr(), std::ptr::null_mut(), keys1.len());
         let mut c2 = MockQueryNode::new(QueryNodeType::Ids);
@@ -173,10 +169,6 @@ mod phrase {
         assert_eq!(r.doc_id, 2);
         assert!(matches!(it.read(), Ok(None)));
 
-        for key in keys1.into_iter().chain(keys2) {
-            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
-            unsafe { ffi::sdsfree(key) };
-        }
     }
 
     #[test]
@@ -210,8 +202,8 @@ mod phrase {
 
         // child 1 matches {doc_a, doc_b}; child 2 matches {doc_b, doc_c}; the
         // intersection is {doc_b}.
-        let keys1: Vec<ffi::sds> = vec![new_sds("doc_a"), new_sds("doc_b")];
-        let keys2: Vec<ffi::sds> = vec![new_sds("doc_b"), new_sds("doc_c")];
+        let keys1 = vec![key_view("doc_a"), key_view("doc_b")];
+        let keys2 = vec![key_view("doc_b"), key_view("doc_c")];
         let mut c1 = MockQueryNode::new(QueryNodeType::Ids);
         c1.set_ids(keys1.as_ptr(), std::ptr::null_mut(), keys1.len());
         let mut c2 = MockQueryNode::new(QueryNodeType::Ids);
@@ -234,10 +226,6 @@ mod phrase {
         assert_eq!(r.doc_id, 2);
         assert!(matches!(it.read(), Ok(None)));
 
-        for key in keys1.into_iter().chain(keys2) {
-            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
-            unsafe { ffi::sdsfree(key) };
-        }
     }
 
     #[test]
@@ -270,7 +258,7 @@ mod phrase {
         let mut missing_child = MockQueryNode::new(QueryNodeType::Missing);
         missing_child.set_missing_field(context.field_spec());
         // child 2: QN_IDS resolving to a real document.
-        let keys: Vec<ffi::sds> = vec![new_sds("doc_a")];
+        let keys = vec![key_view("doc_a")];
         let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
         ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
 
@@ -288,10 +276,6 @@ mod phrase {
         assert!(matches!(it.read(), Ok(None)));
         assert!(it.at_eof());
 
-        for key in keys {
-            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
-            unsafe { ffi::sdsfree(key) };
-        }
     }
 
     #[test]
@@ -322,8 +306,8 @@ mod phrase {
         let mut ctx = unsafe { QueryEvalContext::new(qctx) };
 
         // Both children resolve to the shared document `doc_b`.
-        let keys1: Vec<ffi::sds> = vec![new_sds("doc_b")];
-        let keys2: Vec<ffi::sds> = vec![new_sds("doc_b")];
+        let keys1 = vec![key_view("doc_b")];
+        let keys2 = vec![key_view("doc_b")];
         let mut c1 = MockQueryNode::new(QueryNodeType::Ids);
         c1.set_ids(keys1.as_ptr(), std::ptr::null_mut(), keys1.len());
         let mut c2 = MockQueryNode::new(QueryNodeType::Ids);
@@ -347,10 +331,6 @@ mod phrase {
         assert!(matches!(it.read(), Ok(None)));
         assert!(it.at_eof());
 
-        for key in keys1.into_iter().chain(keys2) {
-            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
-            unsafe { ffi::sdsfree(key) };
-        }
     }
 }
 

--- a/src/redisearch_rs/query_eval/tests/integration/phrase.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/phrase.rs
@@ -55,15 +55,15 @@ fn eval_phrase_single_child_returns_child() {
 // plain set intersection, requiring no positional offsets.
 // ---------------------------------------------------------------------------
 
-// Disabled under Miri: `TestContext` and SDS creation call into the C library,
-// which Miri cannot execute.
+// Disabled under Miri: `TestContext` calls into the C library, which Miri
+// cannot execute.
 #[cfg(not(miri))]
 mod phrase {
     use ffi::IndexFlags_Index_StoreFreqs;
     use rqe_iterators_test_utils::{GlobalGuard, TestContext};
 
     use super::*;
-    use crate::util::key_view;
+    use crate::util::MockKeys;
 
     #[test]
     fn eval_phrase_intersects_children() {
@@ -90,8 +90,8 @@ mod phrase {
 
         // child 1 matches {doc_a, doc_b}; child 2 matches {doc_b, doc_c}; the
         // intersection is {doc_b}.
-        let keys1 = vec![key_view("doc_a"), key_view("doc_b")];
-        let keys2 = vec![key_view("doc_b"), key_view("doc_c")];
+        let keys1 = MockKeys::new(&["doc_a", "doc_b"]);
+        let keys2 = MockKeys::new(&["doc_b", "doc_c"]);
         let mut c1 = MockQueryNode::new(QueryNodeType::Ids);
         c1.set_ids(keys1.as_ptr(), std::ptr::null_mut(), keys1.len());
         let mut c2 = MockQueryNode::new(QueryNodeType::Ids);
@@ -112,7 +112,6 @@ mod phrase {
         let r = it.read().unwrap().expect("should have a result");
         assert_eq!(r.doc_id, 2);
         assert!(matches!(it.read(), Ok(None)));
-
     }
 
     #[test]
@@ -145,8 +144,8 @@ mod phrase {
 
         // child 1 matches {doc_a, doc_b}; child 2 matches {doc_b, doc_c}; the
         // intersection is {doc_b}.
-        let keys1 = vec![key_view("doc_a"), key_view("doc_b")];
-        let keys2 = vec![key_view("doc_b"), key_view("doc_c")];
+        let keys1 = MockKeys::new(&["doc_a", "doc_b"]);
+        let keys2 = MockKeys::new(&["doc_b", "doc_c"]);
         let mut c1 = MockQueryNode::new(QueryNodeType::Ids);
         c1.set_ids(keys1.as_ptr(), std::ptr::null_mut(), keys1.len());
         let mut c2 = MockQueryNode::new(QueryNodeType::Ids);
@@ -168,7 +167,6 @@ mod phrase {
         let r = it.read().unwrap().expect("should have a result");
         assert_eq!(r.doc_id, 2);
         assert!(matches!(it.read(), Ok(None)));
-
     }
 
     #[test]
@@ -202,8 +200,8 @@ mod phrase {
 
         // child 1 matches {doc_a, doc_b}; child 2 matches {doc_b, doc_c}; the
         // intersection is {doc_b}.
-        let keys1 = vec![key_view("doc_a"), key_view("doc_b")];
-        let keys2 = vec![key_view("doc_b"), key_view("doc_c")];
+        let keys1 = MockKeys::new(&["doc_a", "doc_b"]);
+        let keys2 = MockKeys::new(&["doc_b", "doc_c"]);
         let mut c1 = MockQueryNode::new(QueryNodeType::Ids);
         c1.set_ids(keys1.as_ptr(), std::ptr::null_mut(), keys1.len());
         let mut c2 = MockQueryNode::new(QueryNodeType::Ids);
@@ -225,7 +223,6 @@ mod phrase {
         let r = it.read().unwrap().expect("should have a result");
         assert_eq!(r.doc_id, 2);
         assert!(matches!(it.read(), Ok(None)));
-
     }
 
     #[test]
@@ -258,7 +255,7 @@ mod phrase {
         let mut missing_child = MockQueryNode::new(QueryNodeType::Missing);
         missing_child.set_missing_field(context.field_spec());
         // child 2: QN_IDS resolving to a real document.
-        let keys = vec![key_view("doc_a")];
+        let keys = MockKeys::new(&["doc_a"]);
         let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
         ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
 
@@ -275,7 +272,6 @@ mod phrase {
         assert_eq!(it.type_(), IteratorType::Empty);
         assert!(matches!(it.read(), Ok(None)));
         assert!(it.at_eof());
-
     }
 
     #[test]
@@ -306,8 +302,8 @@ mod phrase {
         let mut ctx = unsafe { QueryEvalContext::new(qctx) };
 
         // Both children resolve to the shared document `doc_b`.
-        let keys1 = vec![key_view("doc_b")];
-        let keys2 = vec![key_view("doc_b")];
+        let keys1 = MockKeys::new(&["doc_b"]);
+        let keys2 = MockKeys::new(&["doc_b"]);
         let mut c1 = MockQueryNode::new(QueryNodeType::Ids);
         c1.set_ids(keys1.as_ptr(), std::ptr::null_mut(), keys1.len());
         let mut c2 = MockQueryNode::new(QueryNodeType::Ids);
@@ -330,7 +326,6 @@ mod phrase {
         assert_eq!(r.doc_id, 2);
         assert!(matches!(it.read(), Ok(None)));
         assert!(it.at_eof());
-
     }
 }
 

--- a/src/redisearch_rs/query_eval/tests/integration/union.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/union.rs
@@ -130,8 +130,7 @@ mod union {
     use rqe_iterators_test_utils::{GlobalGuard, TestContext};
 
     use super::*;
-    use crate::util::key_view;
-
+    use crate::util::MockKeys;
 
     #[test]
     fn eval_union_merges_distinct_children() {
@@ -159,8 +158,8 @@ mod union {
 
         // child 1 matches {doc_a, doc_b}; child 2 matches {doc_b, doc_c}; the
         // union is {doc_a, doc_b, doc_c}.
-        let keys1 = vec![key_view("doc_a"), key_view("doc_b")];
-        let keys2 = vec![key_view("doc_b"), key_view("doc_c")];
+        let keys1 = MockKeys::new(&["doc_a", "doc_b"]);
+        let keys2 = MockKeys::new(&["doc_b", "doc_c"]);
         let mut c1 = MockQueryNode::new(QueryNodeType::Ids);
         c1.set_ids(keys1.as_ptr(), std::ptr::null_mut(), keys1.len());
         let mut c2 = MockQueryNode::new(QueryNodeType::Ids);
@@ -181,7 +180,6 @@ mod union {
             assert_eq!(r.doc_id, expected);
         }
         assert!(matches!(it.read(), Ok(None)));
-
     }
 
     #[test]
@@ -216,7 +214,7 @@ mod union {
         let mut missing_child = MockQueryNode::new(QueryNodeType::Missing);
         missing_child.set_missing_field(context.field_spec());
         // child 2: QN_IDS resolving to a real document.
-        let keys = vec![key_view("doc_a")];
+        let keys = MockKeys::new(&["doc_a"]);
         let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
         ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
 
@@ -235,6 +233,5 @@ mod union {
         let r = it.read().unwrap().expect("should have a result");
         assert_eq!(r.doc_id, 1);
         assert!(matches!(it.read(), Ok(None)));
-
     }
 }

--- a/src/redisearch_rs/query_eval/tests/integration/union.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/union.rs
@@ -121,8 +121,8 @@ fn eval_union_in_not_subtree_takes_quick_exit() {
 // distinct documents, which requires the full-FFI `TestContext`.
 // ---------------------------------------------------------------------------
 
-// Disabled under Miri: `TestContext` and SDS creation call into the C library,
-// which Miri cannot execute.
+// Disabled under Miri: `TestContext` calls into the C library, which Miri
+// cannot execute.
 #[cfg(not(miri))]
 mod union {
     use ffi::IndexFlags_Index_StoreFreqs;
@@ -130,12 +130,8 @@ mod union {
     use rqe_iterators_test_utils::{GlobalGuard, TestContext};
 
     use super::*;
+    use crate::util::key_view;
 
-    fn new_sds(s: &str) -> ffi::sds {
-        // SAFETY: `s` points to `s.len()` valid bytes; `sdsnewlen` copies them
-        // into a freshly allocated SDS string.
-        unsafe { ffi::sdsnewlen(s.as_ptr().cast(), s.len()) }
-    }
 
     #[test]
     fn eval_union_merges_distinct_children() {
@@ -163,8 +159,8 @@ mod union {
 
         // child 1 matches {doc_a, doc_b}; child 2 matches {doc_b, doc_c}; the
         // union is {doc_a, doc_b, doc_c}.
-        let keys1: Vec<ffi::sds> = vec![new_sds("doc_a"), new_sds("doc_b")];
-        let keys2: Vec<ffi::sds> = vec![new_sds("doc_b"), new_sds("doc_c")];
+        let keys1 = vec![key_view("doc_a"), key_view("doc_b")];
+        let keys2 = vec![key_view("doc_b"), key_view("doc_c")];
         let mut c1 = MockQueryNode::new(QueryNodeType::Ids);
         c1.set_ids(keys1.as_ptr(), std::ptr::null_mut(), keys1.len());
         let mut c2 = MockQueryNode::new(QueryNodeType::Ids);
@@ -186,10 +182,6 @@ mod union {
         }
         assert!(matches!(it.read(), Ok(None)));
 
-        for key in keys1.into_iter().chain(keys2) {
-            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
-            unsafe { ffi::sdsfree(key) };
-        }
     }
 
     #[test]
@@ -224,7 +216,7 @@ mod union {
         let mut missing_child = MockQueryNode::new(QueryNodeType::Missing);
         missing_child.set_missing_field(context.field_spec());
         // child 2: QN_IDS resolving to a real document.
-        let keys: Vec<ffi::sds> = vec![new_sds("doc_a")];
+        let keys = vec![key_view("doc_a")];
         let mut ids_child = MockQueryNode::new(QueryNodeType::Ids);
         ids_child.set_ids(keys.as_ptr(), std::ptr::null_mut(), keys.len());
 
@@ -244,9 +236,5 @@ mod union {
         assert_eq!(r.doc_id, 1);
         assert!(matches!(it.read(), Ok(None)));
 
-        for key in keys {
-            // SAFETY: each `key` was allocated by `sdsnewlen` and is freed once.
-            unsafe { ffi::sdsfree(key) };
-        }
     }
 }

--- a/src/redisearch_rs/query_eval/tests/integration/util.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/util.rs
@@ -9,14 +9,19 @@
 
 //! Shared helpers for the query_eval integration tests.
 
-/// Create an SDS string from `s`. The caller owns the result and must free
-/// it with [`ffi::sdsfree`].
-///
-/// Gated out under Miri: [`ffi::sdsnewlen`] calls into the C library, which
-/// Miri cannot execute.
-#[cfg(not(miri))]
-pub fn new_sds(s: &str) -> ffi::sds {
-    // SAFETY: `s` points to `s.len()` valid bytes; `sdsnewlen` copies them
-    // into a freshly allocated SDS string.
-    unsafe { ffi::sdsnewlen(s.as_ptr().cast(), s.len()) }
+/// A borrowed (pointer, length) view of `s`, as consumed by the id-filter
+/// node. `'static` keeps the borrow trivially valid for the test's lifetime.
+pub fn key_view(s: &'static str) -> ffi::RSStringView {
+    ffi::RSStringView {
+        data: s.as_ptr().cast(),
+        len: s.len(),
+    }
+}
+
+/// A NULL key view, for tests that never read the keys (pre-resolved doc ids).
+pub fn null_view() -> ffi::RSStringView {
+    ffi::RSStringView {
+        data: std::ptr::null(),
+        len: 0,
+    }
 }

--- a/src/redisearch_rs/query_eval/tests/integration/util.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/util.rs
@@ -13,7 +13,7 @@
 /// borrows the pointer array (mirroring production, where the keys are a
 /// window into the request's held argv); this owner must outlive the
 /// evaluation and frees the strings on drop.
-pub struct MockKeys(Vec<*mut ffi::RedisModuleString>);
+pub struct MockKeys(Vec<*mut redis_module::raw::RedisModuleString>);
 
 impl MockKeys {
     pub fn new(names: &[&str]) -> Self {
@@ -25,7 +25,7 @@ impl MockKeys {
             names
                 .iter()
                 .map(|name| {
-                    redis_mock::string::create_string(name).cast::<ffi::RedisModuleString>()
+                    redis_mock::string::create_string(name).cast::<redis_module::raw::RedisModuleString>()
                 })
                 .collect(),
         )
@@ -37,7 +37,7 @@ impl MockKeys {
         Self(vec![std::ptr::null_mut(); n])
     }
 
-    pub fn as_ptr(&self) -> *mut *mut ffi::RedisModuleString {
+    pub fn as_ptr(&self) -> *mut *mut redis_module::raw::RedisModuleString {
         self.0.as_ptr().cast_mut()
     }
 

--- a/src/redisearch_rs/query_eval/tests/integration/util.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/util.rs
@@ -25,7 +25,8 @@ impl MockKeys {
             names
                 .iter()
                 .map(|name| {
-                    redis_mock::string::create_string(name).cast::<redis_module::raw::RedisModuleString>()
+                    redis_mock::string::create_string(name)
+                        .cast::<redis_module::raw::RedisModuleString>()
                 })
                 .collect(),
         )

--- a/src/redisearch_rs/query_eval/tests/integration/util.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/util.rs
@@ -9,19 +9,50 @@
 
 //! Shared helpers for the query_eval integration tests.
 
-/// A borrowed (pointer, length) view of `s`, as consumed by the id-filter
-/// node. `'static` keeps the borrow trivially valid for the test's lifetime.
-pub fn key_view(s: &'static str) -> ffi::RSStringView {
-    ffi::RSStringView {
-        data: s.as_ptr().cast(),
-        len: s.len(),
+/// Owned mock `RedisModuleString` keys for an id-filter node. The node
+/// borrows the pointer array (mirroring production, where the keys are a
+/// window into the request's held argv); this owner must outlive the
+/// evaluation and frees the strings on drop.
+pub struct MockKeys(Vec<*mut ffi::RedisModuleString>);
+
+impl MockKeys {
+    pub fn new(names: &[&str]) -> Self {
+        // The key-resolution path (`DocTable_GetIdR`) reads the keys through
+        // the `RedisModule_StringPtrLen` function pointer — wire it (and the
+        // rest of the module API) to the mock implementations.
+        redis_mock::init_redis_module_mock();
+        Self(
+            names
+                .iter()
+                .map(|name| {
+                    redis_mock::string::create_string(name).cast::<ffi::RedisModuleString>()
+                })
+                .collect(),
+        )
+    }
+
+    /// Placeholder (null) keys for tests that never read them (pre-resolved
+    /// doc ids).
+    pub fn nulls(n: usize) -> Self {
+        Self(vec![std::ptr::null_mut(); n])
+    }
+
+    pub fn as_ptr(&self) -> *mut *mut ffi::RedisModuleString {
+        self.0.as_ptr().cast_mut()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
     }
 }
 
-/// A NULL key view, for tests that never read the keys (pre-resolved doc ids).
-pub fn null_view() -> ffi::RSStringView {
-    ffi::RSStringView {
-        data: std::ptr::null(),
-        len: 0,
+impl Drop for MockKeys {
+    fn drop(&mut self) {
+        for &key in &self.0 {
+            if !key.is_null() {
+                // SAFETY: created by the mock in `new`, freed exactly once here.
+                unsafe { redis_mock::string::free_string(key.cast()) };
+            }
+        }
     }
 }

--- a/src/redisearch_rs/redis_mock/src/string.rs
+++ b/src/redisearch_rs/redis_mock/src/string.rs
@@ -197,6 +197,25 @@ pub(crate) unsafe extern "C" fn RedisModule_CreateStringPrintf(
     unsafe { RedisModule_CreateString(ctx, fmt, c_str.count_bytes()) }
 }
 
+/// Create a mock `RedisModuleString` holding a copy of `s`. Convenience for
+/// tests that need to hand real string objects to code under test; release
+/// with [`free_string`].
+pub fn create_string(s: &str) -> *mut redis_module::raw::RedisModuleString {
+    // SAFETY: `s` covers `s.len()` initialized bytes.
+    unsafe { RedisModule_CreateString(std::ptr::null_mut(), s.as_ptr().cast(), s.len()) }
+}
+
+/// Release a string created by [`create_string`] (or by the mocked module
+/// API).
+///
+/// # Safety
+/// `s` must come from the mock `RedisModule_CreateString` family and must not
+/// have been released already.
+pub unsafe fn free_string(s: *mut redis_module::raw::RedisModuleString) {
+    // SAFETY: forwarded preconditions.
+    unsafe { RedisModule_FreeString(std::ptr::null_mut(), s) }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -108,7 +108,7 @@ typedef struct {
   struct {
     LegacyNumericFilter **filters;
     LegacyGeoFilter **geo_filters;
-    /* Borrowed from the request's held argv (see AREQ.argvHolds) */
+    /* Borrowed from the request's held argv (see BlockedRequestCtx.argvHolds) */
     RedisModuleString **infields;
     size_t ninfields;
   } legacy;

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -96,7 +96,7 @@ typedef struct {
   t_fieldMask fieldmask;
   int slop;
 
-  /* Borrowed from the request's held argv (see BlockedRequestCtx.argvHolds) */
+  /* Borrowed from the request's held argv (see BlockedRequestCtx.argv) */
   RedisModuleString **inkeys;
   size_t ninkeys;
 
@@ -107,7 +107,7 @@ typedef struct {
   struct {
     LegacyNumericFilter **filters;
     LegacyGeoFilter **geo_filters;
-    /* Borrowed from the request's held argv (see BlockedRequestCtx.argvHolds) */
+    /* Borrowed from the request's held argv (see BlockedRequestCtx.argv) */
     RedisModuleString **infields;
     size_t ninfields;
   } legacy;

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -96,9 +96,8 @@ typedef struct {
   t_fieldMask fieldmask;
   int slop;
 
-  /* Owned sds copies of the INKEYS args (freed with the request): the
-   * id-filter evaluation, including its Rust side, consumes sds keys. */
-  sds *inkeys;
+  /* Borrowed from the request's held argv (see BlockedRequestCtx.argvHolds) */
+  RedisModuleString **inkeys;
   size_t ninkeys;
 
   const StopWordList *stopwords;

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -96,7 +96,9 @@ typedef struct {
   t_fieldMask fieldmask;
   int slop;
 
-  const sds *inkeys;
+  /* Owned sds copies of the INKEYS args (freed with the request): the
+   * id-filter evaluation, including its Rust side, consumes sds keys. */
+  sds *inkeys;
   size_t ninkeys;
 
   const StopWordList *stopwords;
@@ -106,7 +108,8 @@ typedef struct {
   struct {
     LegacyNumericFilter **filters;
     LegacyGeoFilter **geo_filters;
-    const char **infields;
+    /* Borrowed from the request's held argv (see AREQ.argvHolds) */
+    RedisModuleString **infields;
     size_t ninfields;
   } legacy;
 } RSSearchOptions;

--- a/src/spec.c
+++ b/src/spec.c
@@ -1616,6 +1616,30 @@ int IndexSpec_AddFields(StrongRef spec_ref, IndexSpec *sp, RedisModuleCtx *ctx, 
   return IndexSpec_AddFieldsInternal(sp, spec_ref, ac, status, 0);
 }
 
+bool IndexSpec_IsCoherentArgs(IndexSpec *spec, RedisModuleString **prefixes, size_t n_prefixes) {
+  if (!spec || !spec->rule) {
+    return false;
+  }
+  arrayof(HiddenUnicodeString*) spec_prefixes = spec->rule->prefixes;
+  if (n_prefixes != array_len(spec_prefixes)) {
+    return false;
+  }
+
+  // Validate that the prefixes in the arguments are the same as the ones in the
+  // index (also in the same order)
+  for (size_t i = 0; i < n_prefixes; i++) {
+    size_t spec_len, arg_len;
+    const char *spec_str = HiddenUnicodeString_GetUnsafe(spec_prefixes[i], &spec_len);
+    const char *arg = RedisModule_StringPtrLen(prefixes[i], &arg_len);
+    if (spec_len != arg_len || memcmp(spec_str, arg, arg_len) != 0) {
+      // Unmatching prefixes
+      return false;
+    }
+  }
+
+  return true;
+}
+
 bool IndexSpec_IsCoherent(IndexSpec *spec, sds* prefixes, size_t n_prefixes) {
   if (!spec || !spec->rule) {
     return false;

--- a/src/spec.c
+++ b/src/spec.c
@@ -1640,7 +1640,6 @@ bool IndexSpec_IsCoherent(IndexSpec *spec, RedisModuleString **prefixes, size_t 
   return true;
 }
 
-
 inline static bool isSpecOnDisk(const IndexSpec *sp) {
   return SearchDisk_IsEnabled();
 }

--- a/src/spec.c
+++ b/src/spec.c
@@ -1616,7 +1616,7 @@ int IndexSpec_AddFields(StrongRef spec_ref, IndexSpec *sp, RedisModuleCtx *ctx, 
   return IndexSpec_AddFieldsInternal(sp, spec_ref, ac, status, 0);
 }
 
-bool IndexSpec_IsCoherentArgs(IndexSpec *spec, RedisModuleString **prefixes, size_t n_prefixes) {
+bool IndexSpec_IsCoherent(IndexSpec *spec, RedisModuleString **prefixes, size_t n_prefixes) {
   if (!spec || !spec->rule) {
     return false;
   }
@@ -1640,27 +1640,6 @@ bool IndexSpec_IsCoherentArgs(IndexSpec *spec, RedisModuleString **prefixes, siz
   return true;
 }
 
-bool IndexSpec_IsCoherent(IndexSpec *spec, sds* prefixes, size_t n_prefixes) {
-  if (!spec || !spec->rule) {
-    return false;
-  }
-  arrayof(HiddenUnicodeString*) spec_prefixes = spec->rule->prefixes;
-  if (n_prefixes != array_len(spec_prefixes)) {
-    return false;
-  }
-
-  // Validate that the prefixes in the arguments are the same as the ones in the
-  // index (also in the same order)
-  for (size_t i = 0; i < n_prefixes; i++) {
-    sds arg = prefixes[i];
-    if (HiddenUnicodeString_CompareC(spec_prefixes[i], arg) != 0) {
-      // Unmatching prefixes
-      return false;
-    }
-  }
-
-  return true;
-}
 
 inline static bool isSpecOnDisk(const IndexSpec *sp) {
   return SearchDisk_IsEnabled();

--- a/src/spec.h
+++ b/src/spec.h
@@ -626,6 +626,7 @@ int IndexSpec_AddFields(StrongRef ref, IndexSpec *sp, RedisModuleCtx *ctx, ArgsC
                         QueryError *status);
 
 bool IndexSpec_IsCoherent(IndexSpec *sp, sds* prefixes, size_t n_prefixes);
+bool IndexSpec_IsCoherentArgs(IndexSpec *sp, RedisModuleString **prefixes, size_t n_prefixes);
 
 /**
  * Checks that the given parameters pass memory limits (used while starting from RDB)

--- a/src/spec.h
+++ b/src/spec.h
@@ -625,8 +625,9 @@ int IndexSpec_CreateTextId(IndexSpec *sp, t_fieldIndex index);
 int IndexSpec_AddFields(StrongRef ref, IndexSpec *sp, RedisModuleCtx *ctx, ArgsCursor *ac,
                         QueryError *status);
 
-bool IndexSpec_IsCoherent(IndexSpec *sp, sds* prefixes, size_t n_prefixes);
-bool IndexSpec_IsCoherentArgs(IndexSpec *sp, RedisModuleString **prefixes, size_t n_prefixes);
+/* Check that `prefixes` (an _INDEX_PREFIXES argv slice) matches the spec's
+ * rule prefixes, in the same order. */
+bool IndexSpec_IsCoherent(IndexSpec *sp, RedisModuleString **prefixes, size_t n_prefixes);
 
 /**
  * Checks that the given parameters pass memory limits (used while starting from RDB)

--- a/src/util/misc.c
+++ b/src/util/misc.c
@@ -8,10 +8,23 @@
 */
 #include "misc.h"
 
+#include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "query_error_ffi.h"
+
+static pthread_t mainThread;
+static bool mainThreadSet = false;
+
+void MainThread_Set(void) {
+  mainThread = pthread_self();
+  mainThreadSet = true;
+}
+
+bool MainThread_Is(void) {
+  return !mainThreadSet || pthread_equal(mainThread, pthread_self());
+}
 
 void GenericAofRewrite_DisabledHandler(RedisModuleIO *aof, RedisModuleString *key, void *value) {
   RedisModule_Log(RedisModule_GetContextFromIO(aof), "error",

--- a/src/util/misc.c
+++ b/src/util/misc.c
@@ -15,15 +15,13 @@
 #include "query_error_ffi.h"
 
 static pthread_t mainThread;
-static bool mainThreadSet = false;
 
 void MainThread_Set(void) {
   mainThread = pthread_self();
-  mainThreadSet = true;
 }
 
 bool MainThread_Is(void) {
-  return !mainThreadSet || pthread_equal(mainThread, pthread_self());
+  return pthread_equal(mainThread, pthread_self());
 }
 
 void GenericAofRewrite_DisabledHandler(RedisModuleIO *aof, RedisModuleString *key, void *value) {

--- a/src/util/misc.h
+++ b/src/util/misc.h
@@ -20,12 +20,20 @@ typedef struct QueryError QueryError;
  */
 void GenericAofRewrite_DisabledHandler(RedisModuleIO *aof, RedisModuleString *key, void *value);
 
-/* Record the calling thread as the process main thread (called at module init). */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Record the calling thread as the process main thread. Called at module
+ * init; unit-test mains call it in their setup. */
 void MainThread_Set(void);
 
-/* True when called from the main thread — or from any thread before
- * MainThread_Set was called (unit tests run without module init). */
+/* True when called from the thread recorded by MainThread_Set. */
 bool MainThread_Is(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 // null-unsafe
 int GetRedisErrorCodeLength(const char* error);

--- a/src/util/misc.h
+++ b/src/util/misc.h
@@ -20,6 +20,13 @@ typedef struct QueryError QueryError;
  */
 void GenericAofRewrite_DisabledHandler(RedisModuleIO *aof, RedisModuleString *key, void *value);
 
+/* Record the calling thread as the process main thread (called at module init). */
+void MainThread_Set(void);
+
+/* True when called from the main thread — or from any thread before
+ * MainThread_Set was called (unit tests run without module init). */
+bool MainThread_Is(void);
+
 // null-unsafe
 int GetRedisErrorCodeLength(const char* error);
 

--- a/tests/cpptests/common.cpp
+++ b/tests/cpptests/common.cpp
@@ -16,6 +16,7 @@
 #include "redismock/internal.h"
 
 #include "gtest/gtest.h"
+#include "util/misc.h"
 
 extern "C" {
 
@@ -84,6 +85,7 @@ std::vector<std::string> RS::search(RSIndex *index, const char *s) {
 
 int main(int argc, char **argv) {
   RS::InstallSegvStackTraceHandler();
+  MainThread_Set();
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new MyEnvironment());
   return RUN_ALL_TESTS();

--- a/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
@@ -80,6 +80,7 @@ protected:
 
     QueryError qerr = QueryError_Default();
     AREQ *r = AREQ_New();
+    BlockedRequestCtx_NewAREQ(r);  // AREQ_Compile requires a wrapper (it carries the argv holds)
     AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR);
     int rc = AREQ_Compile(r, ctx, rmArgs, rmArgs.size(), false, &qerr);
     EXPECT_EQ(rc, REDISMODULE_OK) << QueryError_GetUserError(&qerr);

--- a/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
@@ -81,7 +81,7 @@ protected:
     QueryError qerr = QueryError_Default();
     AREQ *r = AREQ_New();
     AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR);
-    BlockedRequestCtx_NewAREQ(r, rmArgs, rmArgs.size());  // construction takes the argv holds AREQ_Compile parses from
+    BlockedRequestCtx_NewAREQ(r, rmArgs, rmArgs.size());
     int rc = AREQ_Compile(r, ctx, r->brc->argvHolds, rmArgs.size(), false, &qerr);
     EXPECT_EQ(rc, REDISMODULE_OK) << QueryError_GetUserError(&qerr);
     if (rc != REDISMODULE_OK) {

--- a/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
@@ -82,7 +82,7 @@ protected:
     AREQ *r = AREQ_New();
     AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR);
     BlockedRequestCtx_NewAREQ(r, rmArgs, rmArgs.size());
-    int rc = AREQ_Compile(r, ctx, r->brc->argvHolds, rmArgs.size(), false, &qerr);
+    int rc = AREQ_Compile(r, ctx, 0, false, &qerr);
     EXPECT_EQ(rc, REDISMODULE_OK) << QueryError_GetUserError(&qerr);
     if (rc != REDISMODULE_OK) {
       AREQ_DecrRef(r);

--- a/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
@@ -82,7 +82,8 @@ protected:
     AREQ *r = AREQ_New();
     BlockedRequestCtx_NewAREQ(r);  // AREQ_Compile requires a wrapper (it carries the argv holds)
     AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR);
-    int rc = AREQ_Compile(r, ctx, rmArgs, rmArgs.size(), false, &qerr);
+    BlockedRequestCtx_HoldArgv(r->brc, rmArgs, rmArgs.size());
+    int rc = AREQ_Compile(r, ctx, r->brc->argvHolds, rmArgs.size(), false, &qerr);
     EXPECT_EQ(rc, REDISMODULE_OK) << QueryError_GetUserError(&qerr);
     if (rc != REDISMODULE_OK) {
       AREQ_DecrRef(r);

--- a/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
@@ -80,9 +80,8 @@ protected:
 
     QueryError qerr = QueryError_Default();
     AREQ *r = AREQ_New();
-    BlockedRequestCtx_NewAREQ(r);  // AREQ_Compile requires a wrapper (it carries the argv holds)
     AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR);
-    BlockedRequestCtx_HoldArgv(r->brc, rmArgs, rmArgs.size());
+    BlockedRequestCtx_NewAREQ(r, rmArgs, rmArgs.size());  // construction takes the argv holds AREQ_Compile parses from
     int rc = AREQ_Compile(r, ctx, r->brc->argvHolds, rmArgs.size(), false, &qerr);
     EXPECT_EQ(rc, REDISMODULE_OK) << QueryError_GetUserError(&qerr);
     if (rc != REDISMODULE_OK) {

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -208,7 +208,7 @@ protected:
         cmd.coordDispatchTime = &hreq->profileClocks.coordDispatchTime;
 
         ArgsCursor ac = {};
-        HybridRequest_InitArgsCursor(hreq, &ac, args, args.size());
+        HybridRequest_InitArgsCursor(hreq, &ac, args.size());
 
         QueryError status = QueryError_Default();
         if (int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, &status, false, EXEC_NO_FLAGS); rc != REDISMODULE_OK) {
@@ -300,7 +300,7 @@ protected:
         cmd.coordDispatchTime = &hreq->profileClocks.coordDispatchTime;
 
         ArgsCursor ac = {};
-        HybridRequest_InitArgsCursor(hreq, &ac, args, args.size());
+        HybridRequest_InitArgsCursor(hreq, &ac, args.size());
         QueryError status = QueryError_Default();
         int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, &status, false, EXEC_NO_FLAGS);
         EXPECT_EQ(rc, REDISMODULE_OK) << QueryError_GetDisplayableError(&status, false);

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -193,7 +193,7 @@ protected:
         RedisSearchCtx *sctx = NewSearchCtxC(ctx, "test_idx", true);
         ASSERT_NE(sctx, nullptr) << "Failed to create search context";
 
-        HybridRequest *hreq = MakeDefaultHybridRequest(sctx);
+        HybridRequest *hreq = MakeDefaultHybridRequest(sctx, args, args.size());
         ASSERT_NE(hreq, nullptr) << "Failed to create hybrid request";
 
         // Stack-allocated variables (following hybrid_debug.c pattern)
@@ -208,7 +208,6 @@ protected:
         cmd.coordDispatchTime = &hreq->profileClocks.coordDispatchTime;
 
         ArgsCursor ac = {};
-        HybridRequest_HoldArgv(hreq, args, args.size());
         HybridRequest_InitArgsCursor(hreq, &ac, args, args.size());
 
         QueryError status = QueryError_Default();
@@ -288,7 +287,7 @@ protected:
         RedisSearchCtx *sctx = NewSearchCtxC(ctx, "test_idx", true);
         EXPECT_NE(sctx, nullptr);
         if (!sctx) return out;
-        HybridRequest *hreq = MakeDefaultHybridRequest(sctx);
+        HybridRequest *hreq = MakeDefaultHybridRequest(sctx, args, args.size());
 
         HybridPipelineParams hybridParams = {};
         ParseHybridCommandCtx cmd = {};
@@ -301,7 +300,6 @@ protected:
         cmd.coordDispatchTime = &hreq->profileClocks.coordDispatchTime;
 
         ArgsCursor ac = {};
-        HybridRequest_HoldArgv(hreq, args, args.size());
         HybridRequest_InitArgsCursor(hreq, &ac, args, args.size());
         QueryError status = QueryError_Default();
         int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, &status, false, EXEC_NO_FLAGS);

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -208,6 +208,7 @@ protected:
         cmd.coordDispatchTime = &hreq->profileClocks.coordDispatchTime;
 
         ArgsCursor ac = {};
+        HybridRequest_HoldArgv(hreq, args, args.size());
         HybridRequest_InitArgsCursor(hreq, &ac, args, args.size());
 
         QueryError status = QueryError_Default();
@@ -300,6 +301,7 @@ protected:
         cmd.coordDispatchTime = &hreq->profileClocks.coordDispatchTime;
 
         ArgsCursor ac = {};
+        HybridRequest_HoldArgv(hreq, args, args.size());
         HybridRequest_InitArgsCursor(hreq, &ac, args, args.size());
         QueryError status = QueryError_Default();
         int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, &status, false, EXEC_NO_FLAGS);

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -59,7 +59,7 @@ TEST_F(AggTest, testBasic) {
   AREQ *rr = AREQ_New();
   RMCK::ArgvList aggArgs(ctx, "*");
   BlockedRequestCtx_NewAREQ(rr, aggArgs, aggArgs.size());
-  rv = AREQ_Compile(rr, ctx, rr->brc->argvHolds, aggArgs.size(), false, &qerr);
+  rv = AREQ_Compile(rr, ctx, 0, false, &qerr);
   ASSERT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);
   ASSERT_FALSE(QueryError_HasError(&qerr));
   RedisSearchCtx *sctx = NewSearchCtxC(ctx, spec->specName, true);
@@ -310,7 +310,7 @@ TEST_F(AggTest, AvoidingCompleteResultStructOpt) {
     AREQ_AddRequestFlags(rr, flags);
     RMCK::ArgvList aggArgs(ctx, "*", args...);
     BlockedRequestCtx_NewAREQ(rr, aggArgs, aggArgs.size());
-    int rv = AREQ_Compile(rr, ctx, rr->brc->argvHolds, aggArgs.size(), false, &qerr);
+    int rv = AREQ_Compile(rr, ctx, 0, false, &qerr);
     EXPECT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);
     bool res = rr->searchopts.flags & Search_CanSkipRichResults;
     QueryError_ClearError(&qerr);

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -57,6 +57,7 @@ TEST_F(AggTest, testBasic) {
   RedisModule_FreeString(ctx, vtmp);
 
   AREQ *rr = AREQ_New();
+  BlockedRequestCtx_NewAREQ(rr);  // AREQ_Compile requires a wrapper (it carries the argv holds)
   RMCK::ArgvList aggArgs(ctx, "*");
   rv = AREQ_Compile(rr, ctx, aggArgs, aggArgs.size(), false, &qerr);
   ASSERT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);
@@ -306,6 +307,7 @@ TEST_F(AggTest, AvoidingCompleteResultStructOpt) {
   auto scenario = [&](QEFlags flags, auto... args) -> bool {
     QueryError qerr = QueryError_Default();
     AREQ *rr = AREQ_New();
+    BlockedRequestCtx_NewAREQ(rr);  // AREQ_Compile requires a wrapper (it carries the argv holds)
     AREQ_AddRequestFlags(rr, flags);
     RMCK::ArgvList aggArgs(ctx, "*", args...);
     int rv = AREQ_Compile(rr, ctx, aggArgs, aggArgs.size(), false, &qerr);

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -58,7 +58,7 @@ TEST_F(AggTest, testBasic) {
 
   AREQ *rr = AREQ_New();
   RMCK::ArgvList aggArgs(ctx, "*");
-  BlockedRequestCtx_NewAREQ(rr, aggArgs, aggArgs.size());  // construction takes the argv holds AREQ_Compile parses from
+  BlockedRequestCtx_NewAREQ(rr, aggArgs, aggArgs.size());
   rv = AREQ_Compile(rr, ctx, rr->brc->argvHolds, aggArgs.size(), false, &qerr);
   ASSERT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);
   ASSERT_FALSE(QueryError_HasError(&qerr));
@@ -309,7 +309,7 @@ TEST_F(AggTest, AvoidingCompleteResultStructOpt) {
     AREQ *rr = AREQ_New();
     AREQ_AddRequestFlags(rr, flags);
     RMCK::ArgvList aggArgs(ctx, "*", args...);
-    BlockedRequestCtx_NewAREQ(rr, aggArgs, aggArgs.size());  // construction takes the argv holds AREQ_Compile parses from
+    BlockedRequestCtx_NewAREQ(rr, aggArgs, aggArgs.size());
     int rv = AREQ_Compile(rr, ctx, rr->brc->argvHolds, aggArgs.size(), false, &qerr);
     EXPECT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);
     bool res = rr->searchopts.flags & Search_CanSkipRichResults;

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -57,9 +57,8 @@ TEST_F(AggTest, testBasic) {
   RedisModule_FreeString(ctx, vtmp);
 
   AREQ *rr = AREQ_New();
-  BlockedRequestCtx_NewAREQ(rr);  // AREQ_Compile requires a wrapper (it carries the argv holds)
   RMCK::ArgvList aggArgs(ctx, "*");
-  BlockedRequestCtx_HoldArgv(rr->brc, aggArgs, aggArgs.size());
+  BlockedRequestCtx_NewAREQ(rr, aggArgs, aggArgs.size());  // construction takes the argv holds AREQ_Compile parses from
   rv = AREQ_Compile(rr, ctx, rr->brc->argvHolds, aggArgs.size(), false, &qerr);
   ASSERT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);
   ASSERT_FALSE(QueryError_HasError(&qerr));
@@ -308,10 +307,9 @@ TEST_F(AggTest, AvoidingCompleteResultStructOpt) {
   auto scenario = [&](QEFlags flags, auto... args) -> bool {
     QueryError qerr = QueryError_Default();
     AREQ *rr = AREQ_New();
-    BlockedRequestCtx_NewAREQ(rr);  // AREQ_Compile requires a wrapper (it carries the argv holds)
     AREQ_AddRequestFlags(rr, flags);
     RMCK::ArgvList aggArgs(ctx, "*", args...);
-    BlockedRequestCtx_HoldArgv(rr->brc, aggArgs, aggArgs.size());
+    BlockedRequestCtx_NewAREQ(rr, aggArgs, aggArgs.size());  // construction takes the argv holds AREQ_Compile parses from
     int rv = AREQ_Compile(rr, ctx, rr->brc->argvHolds, aggArgs.size(), false, &qerr);
     EXPECT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);
     bool res = rr->searchopts.flags & Search_CanSkipRichResults;

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -59,7 +59,8 @@ TEST_F(AggTest, testBasic) {
   AREQ *rr = AREQ_New();
   BlockedRequestCtx_NewAREQ(rr);  // AREQ_Compile requires a wrapper (it carries the argv holds)
   RMCK::ArgvList aggArgs(ctx, "*");
-  rv = AREQ_Compile(rr, ctx, aggArgs, aggArgs.size(), false, &qerr);
+  BlockedRequestCtx_HoldArgv(rr->brc, aggArgs, aggArgs.size());
+  rv = AREQ_Compile(rr, ctx, rr->brc->argvHolds, aggArgs.size(), false, &qerr);
   ASSERT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);
   ASSERT_FALSE(QueryError_HasError(&qerr));
   RedisSearchCtx *sctx = NewSearchCtxC(ctx, spec->specName, true);
@@ -310,7 +311,8 @@ TEST_F(AggTest, AvoidingCompleteResultStructOpt) {
     BlockedRequestCtx_NewAREQ(rr);  // AREQ_Compile requires a wrapper (it carries the argv holds)
     AREQ_AddRequestFlags(rr, flags);
     RMCK::ArgvList aggArgs(ctx, "*", args...);
-    int rv = AREQ_Compile(rr, ctx, aggArgs, aggArgs.size(), false, &qerr);
+    BlockedRequestCtx_HoldArgv(rr->brc, aggArgs, aggArgs.size());
+    int rv = AREQ_Compile(rr, ctx, rr->brc->argvHolds, aggArgs.size(), false, &qerr);
     EXPECT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);
     bool res = rr->searchopts.flags & Search_CanSkipRichResults;
     QueryError_ClearError(&qerr);

--- a/tests/cpptests/test_cpp_areq_compile.cpp
+++ b/tests/cpptests/test_cpp_areq_compile.cpp
@@ -132,7 +132,8 @@ TEST_P(AREQBinarySlotRangeTest, testBinarySlotRangeParsing) {
     argv.push_back(createBinaryString(binary_data));
 
     // Test AREQ_Compile
-    int result = AREQ_Compile(req, ctx, argv.data(), argv.size(), false, &status);
+    BlockedRequestCtx_HoldArgv(req->brc, argv.data(), argv.size());
+    int result = AREQ_Compile(req, ctx, req->brc->argvHolds, argv.size(), false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed for: " << test_data.description;
     EXPECT_FALSE(QueryError_HasError(&status)) << "Should not have query error for: " << test_data.description;
@@ -223,7 +224,8 @@ TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
     argv.push_back(createBinaryString(binary_data));
 
     // Test AREQ_Compile
-    int result = AREQ_Compile(req, ctx, argv.data(), argv.size(), false, &status);
+    BlockedRequestCtx_HoldArgv(req->brc, argv.data(), argv.size());
+    int result = AREQ_Compile(req, ctx, req->brc->argvHolds, argv.size(), false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";
     EXPECT_FALSE(QueryError_HasError(&status)) << "Should not have query error";
@@ -259,7 +261,8 @@ TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
     argv.push_back(RedisModule_CreateString(ctx, SLOTS_STR, strlen(SLOTS_STR)));
 
     // Test AREQ_Compile - should fail due to insufficient arguments
-    int result = AREQ_Compile(req, ctx, argv.data(), argv.size(), false, &status);
+    BlockedRequestCtx_HoldArgv(req->brc, argv.data(), argv.size());
+    int result = AREQ_Compile(req, ctx, req->brc->argvHolds, argv.size(), false, &status);
 
     EXPECT_EQ(result, REDISMODULE_ERR) << "AREQ_Compile should fail with insufficient arguments";
     EXPECT_TRUE(QueryError_HasError(&status)) << "Should have query error";
@@ -302,7 +305,8 @@ TEST_F(AREQTest, testComplexAggregateWithCursorAndSlotRanges) {
     argv.push_back(RedisModule_CreateString(ctx, "@__score", 8));
 
     // Test AREQ_Compile
-    int result = AREQ_Compile(req, ctx, argv.data(), argv.size(), false, &status);
+    BlockedRequestCtx_HoldArgv(req->brc, argv.data(), argv.size());
+    int result = AREQ_Compile(req, ctx, req->brc->argvHolds, argv.size(), false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";
     EXPECT_FALSE(QueryError_HasError(&status)) << "Should not have query error";

--- a/tests/cpptests/test_cpp_areq_compile.cpp
+++ b/tests/cpptests/test_cpp_areq_compile.cpp
@@ -131,7 +131,7 @@ TEST_P(AREQBinarySlotRangeTest, testBinarySlotRangeParsing) {
     argv.push_back(createBinaryString(binary_data));
 
     // Test AREQ_Compile
-    BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());  // construction takes the argv holds AREQ_Compile parses from
+    BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());
     int result = AREQ_Compile(req, ctx, req->brc->argvHolds, argv.size(), false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed for: " << test_data.description;
@@ -222,7 +222,7 @@ TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
     argv.push_back(createBinaryString(binary_data));
 
     // Test AREQ_Compile
-    BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());  // construction takes the argv holds AREQ_Compile parses from
+    BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());
     int result = AREQ_Compile(req, ctx, req->brc->argvHolds, argv.size(), false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";
@@ -258,7 +258,7 @@ TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
     argv.push_back(RedisModule_CreateString(ctx, SLOTS_STR, strlen(SLOTS_STR)));
 
     // Test AREQ_Compile - should fail due to insufficient arguments
-    BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());  // construction takes the argv holds AREQ_Compile parses from
+    BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());
     int result = AREQ_Compile(req, ctx, req->brc->argvHolds, argv.size(), false, &status);
 
     EXPECT_EQ(result, REDISMODULE_ERR) << "AREQ_Compile should fail with insufficient arguments";
@@ -301,7 +301,7 @@ TEST_F(AREQTest, testComplexAggregateWithCursorAndSlotRanges) {
     argv.push_back(RedisModule_CreateString(ctx, "@__score", 8));
 
     // Test AREQ_Compile
-    BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());  // construction takes the argv holds AREQ_Compile parses from
+    BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());
     int result = AREQ_Compile(req, ctx, req->brc->argvHolds, argv.size(), false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";

--- a/tests/cpptests/test_cpp_areq_compile.cpp
+++ b/tests/cpptests/test_cpp_areq_compile.cpp
@@ -113,6 +113,7 @@ TEST_P(AREQBinarySlotRangeTest, testBinarySlotRangeParsing) {
     const auto& test_data = GetParam();
 
     AREQ* req = AREQ_New();
+    BlockedRequestCtx_NewAREQ(req);  // AREQ_Compile requires a wrapper (it carries the argv holds)
     ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
 
     // Mark req as internal to bypass checks
@@ -202,6 +203,7 @@ INSTANTIATE_TEST_SUITE_P(
 // Test binary slot range parsing with single range
 TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
     AREQ* req = AREQ_New();
+    BlockedRequestCtx_NewAREQ(req);  // AREQ_Compile requires a wrapper (it carries the argv holds)
     ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
 
     // Mark req as internal to bypass checks
@@ -243,6 +245,7 @@ TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
 // Test error handling for insufficient arguments
 TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
     AREQ* req = AREQ_New();
+    BlockedRequestCtx_NewAREQ(req);  // AREQ_Compile requires a wrapper (it carries the argv holds)
     ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
 
     // Mark req as internal to bypass checks
@@ -272,6 +275,7 @@ TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
 // Test complex aggregate query with cursor, scorer, and slot ranges
 TEST_F(AREQTest, testComplexAggregateWithCursorAndSlotRanges) {
     AREQ* req = AREQ_New();
+    BlockedRequestCtx_NewAREQ(req);  // AREQ_Compile requires a wrapper (it carries the argv holds)
     ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
 
     // Mark req as internal to bypass checks

--- a/tests/cpptests/test_cpp_areq_compile.cpp
+++ b/tests/cpptests/test_cpp_areq_compile.cpp
@@ -132,7 +132,7 @@ TEST_P(AREQBinarySlotRangeTest, testBinarySlotRangeParsing) {
 
     // Test AREQ_Compile
     BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());
-    int result = AREQ_Compile(req, ctx, req->brc->argvHolds, argv.size(), false, &status);
+    int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed for: " << test_data.description;
     EXPECT_FALSE(QueryError_HasError(&status)) << "Should not have query error for: " << test_data.description;
@@ -223,7 +223,7 @@ TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
 
     // Test AREQ_Compile
     BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());
-    int result = AREQ_Compile(req, ctx, req->brc->argvHolds, argv.size(), false, &status);
+    int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";
     EXPECT_FALSE(QueryError_HasError(&status)) << "Should not have query error";
@@ -259,7 +259,7 @@ TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
 
     // Test AREQ_Compile - should fail due to insufficient arguments
     BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());
-    int result = AREQ_Compile(req, ctx, req->brc->argvHolds, argv.size(), false, &status);
+    int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_ERR) << "AREQ_Compile should fail with insufficient arguments";
     EXPECT_TRUE(QueryError_HasError(&status)) << "Should have query error";
@@ -302,7 +302,7 @@ TEST_F(AREQTest, testComplexAggregateWithCursorAndSlotRanges) {
 
     // Test AREQ_Compile
     BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());
-    int result = AREQ_Compile(req, ctx, req->brc->argvHolds, argv.size(), false, &status);
+    int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";
     EXPECT_FALSE(QueryError_HasError(&status)) << "Should not have query error";

--- a/tests/cpptests/test_cpp_areq_compile.cpp
+++ b/tests/cpptests/test_cpp_areq_compile.cpp
@@ -113,7 +113,6 @@ TEST_P(AREQBinarySlotRangeTest, testBinarySlotRangeParsing) {
     const auto& test_data = GetParam();
 
     AREQ* req = AREQ_New();
-    BlockedRequestCtx_NewAREQ(req);  // AREQ_Compile requires a wrapper (it carries the argv holds)
     ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
 
     // Mark req as internal to bypass checks
@@ -132,7 +131,7 @@ TEST_P(AREQBinarySlotRangeTest, testBinarySlotRangeParsing) {
     argv.push_back(createBinaryString(binary_data));
 
     // Test AREQ_Compile
-    BlockedRequestCtx_HoldArgv(req->brc, argv.data(), argv.size());
+    BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());  // construction takes the argv holds AREQ_Compile parses from
     int result = AREQ_Compile(req, ctx, req->brc->argvHolds, argv.size(), false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed for: " << test_data.description;
@@ -204,7 +203,6 @@ INSTANTIATE_TEST_SUITE_P(
 // Test binary slot range parsing with single range
 TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
     AREQ* req = AREQ_New();
-    BlockedRequestCtx_NewAREQ(req);  // AREQ_Compile requires a wrapper (it carries the argv holds)
     ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
 
     // Mark req as internal to bypass checks
@@ -224,7 +222,7 @@ TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
     argv.push_back(createBinaryString(binary_data));
 
     // Test AREQ_Compile
-    BlockedRequestCtx_HoldArgv(req->brc, argv.data(), argv.size());
+    BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());  // construction takes the argv holds AREQ_Compile parses from
     int result = AREQ_Compile(req, ctx, req->brc->argvHolds, argv.size(), false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";
@@ -247,7 +245,6 @@ TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
 // Test error handling for insufficient arguments
 TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
     AREQ* req = AREQ_New();
-    BlockedRequestCtx_NewAREQ(req);  // AREQ_Compile requires a wrapper (it carries the argv holds)
     ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
 
     // Mark req as internal to bypass checks
@@ -261,7 +258,7 @@ TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
     argv.push_back(RedisModule_CreateString(ctx, SLOTS_STR, strlen(SLOTS_STR)));
 
     // Test AREQ_Compile - should fail due to insufficient arguments
-    BlockedRequestCtx_HoldArgv(req->brc, argv.data(), argv.size());
+    BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());  // construction takes the argv holds AREQ_Compile parses from
     int result = AREQ_Compile(req, ctx, req->brc->argvHolds, argv.size(), false, &status);
 
     EXPECT_EQ(result, REDISMODULE_ERR) << "AREQ_Compile should fail with insufficient arguments";
@@ -278,7 +275,6 @@ TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
 // Test complex aggregate query with cursor, scorer, and slot ranges
 TEST_F(AREQTest, testComplexAggregateWithCursorAndSlotRanges) {
     AREQ* req = AREQ_New();
-    BlockedRequestCtx_NewAREQ(req);  // AREQ_Compile requires a wrapper (it carries the argv holds)
     ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
 
     // Mark req as internal to bypass checks
@@ -305,7 +301,7 @@ TEST_F(AREQTest, testComplexAggregateWithCursorAndSlotRanges) {
     argv.push_back(RedisModule_CreateString(ctx, "@__score", 8));
 
     // Test AREQ_Compile
-    BlockedRequestCtx_HoldArgv(req->brc, argv.data(), argv.size());
+    BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());  // construction takes the argv holds AREQ_Compile parses from
     int result = AREQ_Compile(req, ctx, req->brc->argvHolds, argv.size(), false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";

--- a/tests/cpptests/test_cpp_hybrid.cpp
+++ b/tests/cpptests/test_cpp_hybrid.cpp
@@ -27,7 +27,10 @@ TEST_F(HybridRequestBasicTest, testHybridRequestCreationBasic) {
   requests = array_ensure_append_1(requests, req1);
   requests = array_ensure_append_1(requests, req2);
 
-  HybridRequest *hybridReq = HybridRequest_New(NULL, requests, 2, NULL, 0);
+  // Construction requires an argv; the command + index tokens are stepped
+  // over, so the wrappers hold nothing here.
+  RMCK::ArgvList args(NULL, "FT.HYBRID", "idx");
+  HybridRequest *hybridReq = HybridRequest_New(NULL, requests, 2, args, args.size());
   ASSERT_TRUE(hybridReq != nullptr);
   ASSERT_EQ(hybridReq->nrequests, 2);
   ASSERT_TRUE(hybridReq->requests != nullptr);

--- a/tests/cpptests/test_cpp_hybrid.cpp
+++ b/tests/cpptests/test_cpp_hybrid.cpp
@@ -27,7 +27,7 @@ TEST_F(HybridRequestBasicTest, testHybridRequestCreationBasic) {
   requests = array_ensure_append_1(requests, req1);
   requests = array_ensure_append_1(requests, req2);
 
-  HybridRequest *hybridReq = HybridRequest_New(NULL, requests, 2);
+  HybridRequest *hybridReq = HybridRequest_New(NULL, requests, 2, NULL, 0);
   ASSERT_TRUE(hybridReq != nullptr);
   ASSERT_EQ(hybridReq->nrequests, 2);
   ASSERT_TRUE(hybridReq->requests != nullptr);

--- a/tests/cpptests/test_cpp_hybrid_defaults.cpp
+++ b/tests/cpptests/test_cpp_hybrid_defaults.cpp
@@ -37,8 +37,6 @@ protected:
 
     sctx = NewSearchCtxC(ctx, index_name.c_str(), true);
     ASSERT_TRUE(sctx != NULL);
-    // The request is constructed by parseCommand — construction takes the
-    // argv holds, so it needs the command args.
     result = NULL;
     hybridParams = {0};
   }

--- a/tests/cpptests/test_cpp_hybrid_defaults.cpp
+++ b/tests/cpptests/test_cpp_hybrid_defaults.cpp
@@ -37,12 +37,10 @@ protected:
 
     sctx = NewSearchCtxC(ctx, index_name.c_str(), true);
     ASSERT_TRUE(sctx != NULL);
-    result = MakeDefaultHybridRequest(sctx);
+    // The request is constructed by parseCommand — construction takes the
+    // argv holds, so it needs the command args.
+    result = NULL;
     hybridParams = {0};
-    parseCtx.search = result->requests[0];
-    parseCtx.vector = result->requests[1];
-    parseCtx.tailPlan = &result->tailPipeline->ap;
-    parseCtx.hybridParams = &hybridParams;
   }
 
   void TearDown() override {
@@ -69,6 +67,12 @@ protected:
   HybridRequest *parseCommand(RMCK::ArgvList& args) {
     QueryError status = QueryError_Default();
 
+    result = MakeDefaultHybridRequest(sctx, args, args.size());
+    parseCtx.search = result->requests[0];
+    parseCtx.vector = result->requests[1];
+    parseCtx.tailPlan = &result->tailPipeline->ap;
+    parseCtx.hybridParams = &hybridParams;
+
     EXPECT_TRUE(result->sctx != NULL) << "Failed to create search context";
 
     ParseHybridCommandCtx cmd = {0};
@@ -80,7 +84,6 @@ protected:
     cmd.cursorConfig = &result->cursorConfig;
 
     ArgsCursor ac = {0};
-    HybridRequest_HoldArgv(result, args, args.size());
     HybridRequest_InitArgsCursor(result, &ac, args, args.size());
     int rc =  parseHybridCommand(ctx, &ac, result->sctx, &cmd, &status, false, EXEC_NO_FLAGS);
     if (rc != REDISMODULE_OK) {

--- a/tests/cpptests/test_cpp_hybrid_defaults.cpp
+++ b/tests/cpptests/test_cpp_hybrid_defaults.cpp
@@ -80,6 +80,7 @@ protected:
     cmd.cursorConfig = &result->cursorConfig;
 
     ArgsCursor ac = {0};
+    HybridRequest_HoldArgv(result, args, args.size());
     HybridRequest_InitArgsCursor(result, &ac, args, args.size());
     int rc =  parseHybridCommand(ctx, &ac, result->sctx, &cmd, &status, false, EXEC_NO_FLAGS);
     if (rc != REDISMODULE_OK) {

--- a/tests/cpptests/test_cpp_hybrid_defaults.cpp
+++ b/tests/cpptests/test_cpp_hybrid_defaults.cpp
@@ -82,7 +82,7 @@ protected:
     cmd.cursorConfig = &result->cursorConfig;
 
     ArgsCursor ac = {0};
-    HybridRequest_InitArgsCursor(result, &ac, args, args.size());
+    HybridRequest_InitArgsCursor(result, &ac, args.size());
     int rc =  parseHybridCommand(ctx, &ac, result->sctx, &cmd, &status, false, EXEC_NO_FLAGS);
     if (rc != REDISMODULE_OK) {
       HybridRequest_DecrRef(result);

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -77,9 +77,7 @@ class ParseHybridTest : public ::testing::Test {
       QueryError_ClearError(&qerr);
     }
     ASSERT_TRUE(spec);
-    // The request is constructed per test by recreateHybridRequest —
-    // construction takes the argv holds, so it needs the command args.
-    // parseCommandInternal constructs lazily when a test did not.
+    // Constructed lazily, per test: recreateHybridRequest or parseCommandInternal
     hybridRequest = NULL;
     hybridParams = {0};
     result = {};
@@ -123,8 +121,6 @@ class ParseHybridTest : public ::testing::Test {
   int parseCommandInternal(RMCK::ArgvList& args) {
     QueryError status = QueryError_Default();
     ArgsCursor ac = {0};
-    // Tests that mutate RSGlobalConfig construct explicitly (the request
-    // snapshots the config at construction); everyone else constructs here.
     if (!hybridRequest) {
       recreateHybridRequest(args);
     }
@@ -134,9 +130,8 @@ class ParseHybridTest : public ::testing::Test {
     return rc;
   }
 
-  // (Re)construct the request from the command args. Construction takes the
-  // argv holds and snapshots request-scoped config, so tests that mutate
-  // RSGlobalConfig call this after mutating to observe the change.
+  // (Re)construct the request from the command args. Construction snapshots
+  // request-scoped config, so tests that mutate RSGlobalConfig call this after.
   void recreateHybridRequest(RMCK::ArgvList& args) {
     if (hybridRequest) {
       HybridRequest_DecrRef(hybridRequest);

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -124,7 +124,7 @@ class ParseHybridTest : public ::testing::Test {
     if (!hybridRequest) {
       recreateHybridRequest(args);
     }
-    HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
+    HybridRequest_InitArgsCursor(hybridRequest, &ac, args.size());
     int rc = parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false, EXEC_NO_FLAGS);
     EXPECT_TRUE(QueryError_IsOk(&status)) << "Parse failed: " << QueryError_GetDisplayableError(&status, false);
     return rc;
@@ -1043,7 +1043,7 @@ TEST_F(ParseHybridTest, testExternalCommandWith_NUM_SSTRING) {
   QueryError status = QueryError_Default();
   ArgsCursor ac = {0};
   recreateHybridRequest(args);
-  HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
+  HybridRequest_InitArgsCursor(hybridRequest, &ac, args.size());
   parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false, EXEC_NO_FLAGS);
   EXPECT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_PARSE_ARGS) << "Should fail as external command";
   QueryError_ClearError(&status);
@@ -1064,7 +1064,7 @@ TEST_F(ParseHybridTest, testExternalCommandWithWithScores) {
   QueryError status = QueryError_Default();
   ArgsCursor ac = {0};
   recreateHybridRequest(args);
-  HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
+  HybridRequest_InitArgsCursor(hybridRequest, &ac, args.size());
   parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false, EXEC_NO_FLAGS);
   EXPECT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_PARSE_ARGS) << "Public FT.HYBRID should reject WITHSCORES";
   QueryError_ClearError(&status);
@@ -1098,7 +1098,7 @@ TEST_F(ParseHybridTest, testInternalCommandWith_NUM_SSTRING) {
   recreateHybridRequest(args);
   ASSERT_FALSE(result.hybridParams->aggregationParams.common.reqflags & QEXEC_F_TYPED);
   ArgsCursor ac = {0};
-  HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
+  HybridRequest_InitArgsCursor(hybridRequest, &ac, args.size());
   parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, true, EXEC_NO_FLAGS);
   EXPECT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_OK) << "Should succeed as internal command";
   QueryError_ClearError(&status);
@@ -1122,7 +1122,7 @@ void ParseHybridTest::testErrorCode(RMCK::ArgvList& args, QueryErrorCode expecte
   // Create a fresh sctx for this test
   ArgsCursor ac = {0};
   recreateHybridRequest(args);
-  HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
+  HybridRequest_InitArgsCursor(hybridRequest, &ac, args.size());
   int rc = parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false, EXEC_NO_FLAGS);
   ASSERT_TRUE(rc == REDISMODULE_ERR) << "parsing error: " << QueryError_GetUserError(&status);
   ASSERT_EQ(QueryError_GetCode(&status), expected_code) << "parsing error: " << QueryError_GetUserError(&status);

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -127,6 +127,7 @@ class ParseHybridTest : public ::testing::Test {
   int parseCommandInternal(RMCK::ArgvList& args) {
     QueryError status = QueryError_Default();
     ArgsCursor ac = {0};
+    HybridRequest_HoldArgv(hybridRequest, args, args.size());
     HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
     int rc = parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false, EXEC_NO_FLAGS);
     EXPECT_TRUE(QueryError_IsOk(&status)) << "Parse failed: " << QueryError_GetDisplayableError(&status, false);
@@ -1042,6 +1043,7 @@ TEST_F(ParseHybridTest, testExternalCommandWith_NUM_SSTRING) {
 
   QueryError status = QueryError_Default();
   ArgsCursor ac = {0};
+  HybridRequest_HoldArgv(hybridRequest, args, args.size());
   HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
   parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false, EXEC_NO_FLAGS);
   EXPECT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_PARSE_ARGS) << "Should fail as external command";
@@ -1062,6 +1064,7 @@ TEST_F(ParseHybridTest, testExternalCommandWithWithScores) {
 
   QueryError status = QueryError_Default();
   ArgsCursor ac = {0};
+  HybridRequest_HoldArgv(hybridRequest, args, args.size());
   HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
   parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false, EXEC_NO_FLAGS);
   EXPECT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_PARSE_ARGS) << "Public FT.HYBRID should reject WITHSCORES";
@@ -1095,6 +1098,7 @@ TEST_F(ParseHybridTest, testInternalCommandWith_NUM_SSTRING) {
 
   ASSERT_FALSE(result.hybridParams->aggregationParams.common.reqflags & QEXEC_F_TYPED);
   ArgsCursor ac = {0};
+  HybridRequest_HoldArgv(hybridRequest, args, args.size());
   HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
   parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, true, EXEC_NO_FLAGS);
   EXPECT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_OK) << "Should succeed as internal command";
@@ -1118,6 +1122,7 @@ void ParseHybridTest::testErrorCode(RMCK::ArgvList& args, QueryErrorCode expecte
 
   // Create a fresh sctx for this test
   ArgsCursor ac = {0};
+  HybridRequest_HoldArgv(hybridRequest, args, args.size());
   HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
   int rc = parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false, EXEC_NO_FLAGS);
   ASSERT_TRUE(rc == REDISMODULE_ERR) << "parsing error: " << QueryError_GetUserError(&status);

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -77,16 +77,12 @@ class ParseHybridTest : public ::testing::Test {
       QueryError_ClearError(&qerr);
     }
     ASSERT_TRUE(spec);
-    hybridRequest = MakeDefaultHybridRequest(NewSearchCtxC(ctx, index_name.c_str(), true));
-
+    // The request is constructed per test by recreateHybridRequest —
+    // construction takes the argv holds, so it needs the command args.
+    // parseCommandInternal constructs lazily when a test did not.
+    hybridRequest = NULL;
     hybridParams = {0};
-    result.search = hybridRequest->requests[0];
-    result.vector = hybridRequest->requests[1];
-    result.tailPlan = &hybridRequest->tailPipeline->ap;
-    result.hybridParams = &hybridParams;
-    result.reqConfig = &hybridRequest->reqConfig;
-    result.cursorConfig = &hybridRequest->cursorConfig;
-    result.coordDispatchTime = &hybridRequest->profileClocks.coordDispatchTime;
+    result = {};
   }
 
   void TearDown() override {
@@ -127,22 +123,30 @@ class ParseHybridTest : public ::testing::Test {
   int parseCommandInternal(RMCK::ArgvList& args) {
     QueryError status = QueryError_Default();
     ArgsCursor ac = {0};
-    HybridRequest_HoldArgv(hybridRequest, args, args.size());
+    // Tests that mutate RSGlobalConfig construct explicitly (the request
+    // snapshots the config at construction); everyone else constructs here.
+    if (!hybridRequest) {
+      recreateHybridRequest(args);
+    }
     HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
     int rc = parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false, EXEC_NO_FLAGS);
     EXPECT_TRUE(QueryError_IsOk(&status)) << "Parse failed: " << QueryError_GetDisplayableError(&status, false);
     return rc;
   }
 
-  // Request-scoped config is captured at request construction, not at parse.
-  // Tests that mutate RSGlobalConfig must reconstruct the request afterwards
-  // to observe the change.
-  void recreateHybridRequest() {
-    HybridRequest_DecrRef(hybridRequest);
-    hybridRequest = MakeDefaultHybridRequest(NewSearchCtxC(ctx, index_name.c_str(), true));
+  // (Re)construct the request from the command args. Construction takes the
+  // argv holds and snapshots request-scoped config, so tests that mutate
+  // RSGlobalConfig call this after mutating to observe the change.
+  void recreateHybridRequest(RMCK::ArgvList& args) {
+    if (hybridRequest) {
+      HybridRequest_DecrRef(hybridRequest);
+    }
+    hybridRequest =
+        MakeDefaultHybridRequest(NewSearchCtxC(ctx, index_name.c_str(), true), args, args.size());
     result.search = hybridRequest->requests[0];
     result.vector = hybridRequest->requests[1];
     result.tailPlan = &hybridRequest->tailPipeline->ap;
+    result.hybridParams = &hybridParams;
     result.reqConfig = &hybridRequest->reqConfig;
     result.cursorConfig = &hybridRequest->cursorConfig;
     result.coordDispatchTime = &hybridRequest->profileClocks.coordDispatchTime;
@@ -233,8 +237,8 @@ TEST_F(ParseHybridTest, testValidInputWithReqConfig) {
 TEST_F(ParseHybridTest, testConfigOOMFailPolicyPropagation) {
   // Create a basic hybrid query: FT.HYBRID <index> SEARCH hello VSIM world
   RSGlobalConfig.requestConfigParams.oomPolicy = OomPolicy_Fail;
-  recreateHybridRequest();
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  recreateHybridRequest(args);
 
   parseCommand(args);
   ASSERT_EQ(result.reqConfig->oomPolicy, OomPolicy_Fail);
@@ -245,8 +249,8 @@ TEST_F(ParseHybridTest, testConfigOOMFailPolicyPropagation) {
 TEST_F(ParseHybridTest, testConfigOOMReturnPolicyPropagation) {
   // Create a basic hybrid query: FT.HYBRID <index> SEARCH hello VSIM world
   RSGlobalConfig.requestConfigParams.oomPolicy = OomPolicy_Return;
-  recreateHybridRequest();
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  recreateHybridRequest(args);
 
   parseCommand(args);
   ASSERT_EQ(result.reqConfig->oomPolicy, OomPolicy_Return);
@@ -258,8 +262,8 @@ TEST_F(ParseHybridTest, testConfigOOMIgnorePolicyPropagation) {
 
   // Create a basic hybrid query: FT.HYBRID <index> SEARCH hello VSIM world
   RSGlobalConfig.requestConfigParams.oomPolicy = OomPolicy_Ignore;
-  recreateHybridRequest();
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  recreateHybridRequest(args);
   parseCommand(args);
   ASSERT_EQ(result.reqConfig->oomPolicy, OomPolicy_Ignore);
   ASSERT_EQ(result.vector->reqConfig.oomPolicy, OomPolicy_Ignore);
@@ -274,12 +278,12 @@ TEST_F(ParseHybridTest, testConfigSnapshotUsedForParseDefaults) {
   unsigned int savedDialect = RSGlobalConfig.requestConfigParams.dialectVersion;
   RSGlobalConfig.requestConfigParams.queryTimeoutMS = 1234;
   RSGlobalConfig.requestConfigParams.dialectVersion = 4;
-  recreateHybridRequest();
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  recreateHybridRequest(args);
   // Simulate FT.CONFIG SET landing between dispatch and the background parse.
   RSGlobalConfig.requestConfigParams.queryTimeoutMS = 5678;
   RSGlobalConfig.requestConfigParams.dialectVersion = 2;
 
-  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
   parseCommand(args);
 
   ASSERT_EQ(result.reqConfig->queryTimeoutMS, 1234);
@@ -1043,7 +1047,7 @@ TEST_F(ParseHybridTest, testExternalCommandWith_NUM_SSTRING) {
 
   QueryError status = QueryError_Default();
   ArgsCursor ac = {0};
-  HybridRequest_HoldArgv(hybridRequest, args, args.size());
+  recreateHybridRequest(args);
   HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
   parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false, EXEC_NO_FLAGS);
   EXPECT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_PARSE_ARGS) << "Should fail as external command";
@@ -1064,7 +1068,7 @@ TEST_F(ParseHybridTest, testExternalCommandWithWithScores) {
 
   QueryError status = QueryError_Default();
   ArgsCursor ac = {0};
-  HybridRequest_HoldArgv(hybridRequest, args, args.size());
+  recreateHybridRequest(args);
   HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
   parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false, EXEC_NO_FLAGS);
   EXPECT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_PARSE_ARGS) << "Public FT.HYBRID should reject WITHSCORES";
@@ -1096,9 +1100,9 @@ TEST_F(ParseHybridTest, testInternalCommandWith_NUM_SSTRING) {
 
   QueryError status = QueryError_Default();
 
+  recreateHybridRequest(args);
   ASSERT_FALSE(result.hybridParams->aggregationParams.common.reqflags & QEXEC_F_TYPED);
   ArgsCursor ac = {0};
-  HybridRequest_HoldArgv(hybridRequest, args, args.size());
   HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
   parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, true, EXEC_NO_FLAGS);
   EXPECT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_OK) << "Should succeed as internal command";
@@ -1122,7 +1126,7 @@ void ParseHybridTest::testErrorCode(RMCK::ArgvList& args, QueryErrorCode expecte
 
   // Create a fresh sctx for this test
   ArgsCursor ac = {0};
-  HybridRequest_HoldArgv(hybridRequest, args, args.size());
+  recreateHybridRequest(args);
   HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
   int rc = parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false, EXEC_NO_FLAGS);
   ASSERT_TRUE(rc == REDISMODULE_ERR) << "parsing error: " << QueryError_GetUserError(&status);

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -132,7 +132,7 @@ class ParseHybridTest : public ::testing::Test {
 
   // (Re)construct the request from the command args. Construction snapshots
   // request-scoped config, so tests that mutate RSGlobalConfig call this after.
-  void recreateHybridRequest(RMCK::ArgvList& args) {
+  void recreateHybridRequest(RMCK::ArgvList &args) {
     if (hybridRequest) {
       HybridRequest_DecrRef(hybridRequest);
     }
@@ -273,7 +273,8 @@ TEST_F(ParseHybridTest, testConfigSnapshotUsedForParseDefaults) {
   unsigned int savedDialect = RSGlobalConfig.requestConfigParams.dialectVersion;
   RSGlobalConfig.requestConfigParams.queryTimeoutMS = 1234;
   RSGlobalConfig.requestConfigParams.dialectVersion = 4;
-  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector",
+                      "$BLOB", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
   recreateHybridRequest(args);
   // Simulate FT.CONFIG SET landing between dispatch and the background parse.
   RSGlobalConfig.requestConfigParams.queryTimeoutMS = 5678;

--- a/tests/cpptests/test_cpp_parse_hybrid_iterators.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid_iterators.cpp
@@ -131,6 +131,7 @@ bool SetupHybridIteratorTest(RedisModuleCtx *ctx,
     };
 
     ArgsCursor ac = {0};
+    HybridRequest_HoldArgv(testCtx->hybridReq, args, args.size());
     HybridRequest_InitArgsCursor(testCtx->hybridReq, &ac, args, args.size());
 
     int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, &testCtx->status, false, EXEC_NO_FLAGS);

--- a/tests/cpptests/test_cpp_parse_hybrid_iterators.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid_iterators.cpp
@@ -114,7 +114,7 @@ bool SetupHybridIteratorTest(RedisModuleCtx *ctx,
     RedisSearchCtx *sctx = NewSearchCtxC(ctx, specName, true);
     if (!sctx) return false;
 
-    testCtx->hybridReq = MakeDefaultHybridRequest(sctx);
+    testCtx->hybridReq = MakeDefaultHybridRequest(sctx, args, args.size());
     if (!testCtx->hybridReq) return false;
 
     // Step 4: Parse the hybrid command
@@ -131,7 +131,6 @@ bool SetupHybridIteratorTest(RedisModuleCtx *ctx,
     };
 
     ArgsCursor ac = {0};
-    HybridRequest_HoldArgv(testCtx->hybridReq, args, args.size());
     HybridRequest_InitArgsCursor(testCtx->hybridReq, &ac, args, args.size());
 
     int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, &testCtx->status, false, EXEC_NO_FLAGS);

--- a/tests/cpptests/test_cpp_parse_hybrid_iterators.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid_iterators.cpp
@@ -131,7 +131,7 @@ bool SetupHybridIteratorTest(RedisModuleCtx *ctx,
     };
 
     ArgsCursor ac = {0};
-    HybridRequest_InitArgsCursor(testCtx->hybridReq, &ac, args, args.size());
+    HybridRequest_InitArgsCursor(testCtx->hybridReq, &ac, args.size());
 
     int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, &testCtx->status, false, EXEC_NO_FLAGS);
     if (rc != REDISMODULE_OK) return false;

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -159,7 +159,7 @@ HybridRequest* ParseAndBuildHybridRequest(RedisModuleCtx *ctx, const char* index
   };
 
   ArgsCursor ac = {0};
-  HybridRequest_InitArgsCursor(hybridReq, &ac, args, args.size());
+  HybridRequest_InitArgsCursor(hybridReq, &ac, args.size());
   // Parse the hybrid command - this fills out hybridParams
   int rc = parseHybridCommand(ctx, &ac, test_sctx, &cmd, status, false, EXEC_NO_FLAGS);
   if (rc != REDISMODULE_OK) {

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -159,6 +159,7 @@ HybridRequest* ParseAndBuildHybridRequest(RedisModuleCtx *ctx, const char* index
   };
 
   ArgsCursor ac = {0};
+  HybridRequest_HoldArgv(hybridReq, args, args.size());
   HybridRequest_InitArgsCursor(hybridReq, &ac, args, args.size());
   // Parse the hybrid command - this fills out hybridParams
   int rc = parseHybridCommand(ctx, &ac, test_sctx, &cmd, status, false, EXEC_NO_FLAGS);

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -140,7 +140,7 @@ HybridRequest* ParseAndBuildHybridRequest(RedisModuleCtx *ctx, const char* index
   }
 
   // Create HybridRequest and allocate hybrid params
-  HybridRequest* hybridReq = MakeDefaultHybridRequest(test_sctx);
+  HybridRequest* hybridReq = MakeDefaultHybridRequest(test_sctx, args, args.size());
   if (!hybridReq) {
     return nullptr;
   }
@@ -159,7 +159,6 @@ HybridRequest* ParseAndBuildHybridRequest(RedisModuleCtx *ctx, const char* index
   };
 
   ArgsCursor ac = {0};
-  HybridRequest_HoldArgv(hybridReq, args, args.size());
   HybridRequest_InitArgsCursor(hybridReq, &ac, args, args.size());
   // Parse the hybrid command - this fills out hybridParams
   int rc = parseHybridCommand(ctx, &ac, test_sctx, &cmd, status, false, EXEC_NO_FLAGS);

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -140,7 +140,7 @@ HybridRequest* ParseAndBuildHybridRequest(RedisModuleCtx *ctx, const char* index
   }
 
   // Create HybridRequest and allocate hybrid params
-  HybridRequest* hybridReq = MakeDefaultHybridRequest(test_sctx, args, args.size());
+  HybridRequest *hybridReq = MakeDefaultHybridRequest(test_sctx, args, args.size());
   if (!hybridReq) {
     return nullptr;
   }

--- a/tests/cpptests/test_distagg.cpp
+++ b/tests/cpptests/test_distagg.cpp
@@ -44,7 +44,8 @@ static void testAverage() {
                     "sortby", "2", "@avg_price", "DESC"                 // nl
   );
   QueryError status{QueryErrorCode(0)};
-  int rc = AREQ_Compile(r, ctx, vv, vv.size(), false, &status);
+  BlockedRequestCtx_HoldArgv(r->brc, vv, vv.size());
+  int rc = AREQ_Compile(r, ctx, r->brc->argvHolds, vv.size(), false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
     abort();
@@ -104,7 +105,8 @@ static void testCountDistinct() {
                     "REDUCE", "COUNT", "0"                                                     // nl
   );
   QueryError status{QueryErrorCode(0)};
-  int rc = AREQ_Compile(r, ctx, vv, vv.size(), false, &status);
+  BlockedRequestCtx_HoldArgv(r->brc, vv, vv.size());
+  int rc = AREQ_Compile(r, ctx, r->brc->argvHolds, vv.size(), false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
     abort();
@@ -143,7 +145,8 @@ static void testSplit() {
                     "REDUCE", "COUNT", "0"                                                     // nl
   );
   QueryError status{QueryErrorCode(0)};
-  int rc = AREQ_Compile(r, ctx, vv, vv.size(), false, &status);
+  BlockedRequestCtx_HoldArgv(r->brc, vv, vv.size());
+  int rc = AREQ_Compile(r, ctx, r->brc->argvHolds, vv.size(), false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
     abort();

--- a/tests/cpptests/test_distagg.cpp
+++ b/tests/cpptests/test_distagg.cpp
@@ -12,6 +12,7 @@
 #include "aggregate/aggregate.h"
 #include "tests/cpptests/redismock/util.h"
 #include "common.h"
+#include "util/misc.h"
 
 #include <vector>
 
@@ -174,6 +175,7 @@ static void testSplit() {
 
 int main(int, char **) {
   RS::InstallSegvStackTraceHandler();
+  MainThread_Set();
   RMCK::init();
   testAverage();
   testCountDistinct();

--- a/tests/cpptests/test_distagg.cpp
+++ b/tests/cpptests/test_distagg.cpp
@@ -35,6 +35,7 @@ static int my_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
 static void testAverage() {
   AREQ *r = AREQ_New();
+  BlockedRequestCtx_NewAREQ(r);  // AREQ_Compile requires a wrapper (it carries the argv holds)
   RMCK::Context ctx{};
   RMCK::ArgvList vv(ctx, "sony",                                        // nl
                     "GROUPBY", "1", "@brand",                           // nl
@@ -94,6 +95,7 @@ static void testAverage() {
  */
 static void testCountDistinct() {
   AREQ *r = AREQ_New();
+  BlockedRequestCtx_NewAREQ(r);  // AREQ_Compile requires a wrapper (it carries the argv holds)
   AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR); // mark for coordinator pipeline
   RMCK::Context ctx{};
   RMCK::ArgvList vv(ctx, "*",                                                                  // nl
@@ -132,6 +134,7 @@ static void testCountDistinct() {
 }
 static void testSplit() {
   AREQ *r = AREQ_New();
+  BlockedRequestCtx_NewAREQ(r);  // AREQ_Compile requires a wrapper (it carries the argv holds)
   AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR); // mark for coordinator pipeline
   RMCK::Context ctx{};
   RMCK::ArgvList vv(ctx, "*",                                                                  // nl

--- a/tests/cpptests/test_distagg.cpp
+++ b/tests/cpptests/test_distagg.cpp
@@ -44,7 +44,7 @@ static void testAverage() {
   );
   QueryError status{QueryErrorCode(0)};
   BlockedRequestCtx_NewAREQ(r, vv, vv.size());
-  int rc = AREQ_Compile(r, ctx, r->brc->argvHolds, vv.size(), false, &status);
+  int rc = AREQ_Compile(r, ctx, 0, false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
     abort();
@@ -104,7 +104,7 @@ static void testCountDistinct() {
   );
   QueryError status{QueryErrorCode(0)};
   BlockedRequestCtx_NewAREQ(r, vv, vv.size());
-  int rc = AREQ_Compile(r, ctx, r->brc->argvHolds, vv.size(), false, &status);
+  int rc = AREQ_Compile(r, ctx, 0, false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
     abort();
@@ -143,7 +143,7 @@ static void testSplit() {
   );
   QueryError status{QueryErrorCode(0)};
   BlockedRequestCtx_NewAREQ(r, vv, vv.size());
-  int rc = AREQ_Compile(r, ctx, r->brc->argvHolds, vv.size(), false, &status);
+  int rc = AREQ_Compile(r, ctx, 0, false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
     abort();

--- a/tests/cpptests/test_distagg.cpp
+++ b/tests/cpptests/test_distagg.cpp
@@ -35,7 +35,6 @@ static int my_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
 static void testAverage() {
   AREQ *r = AREQ_New();
-  BlockedRequestCtx_NewAREQ(r);  // AREQ_Compile requires a wrapper (it carries the argv holds)
   RMCK::Context ctx{};
   RMCK::ArgvList vv(ctx, "sony",                                        // nl
                     "GROUPBY", "1", "@brand",                           // nl
@@ -44,7 +43,7 @@ static void testAverage() {
                     "sortby", "2", "@avg_price", "DESC"                 // nl
   );
   QueryError status{QueryErrorCode(0)};
-  BlockedRequestCtx_HoldArgv(r->brc, vv, vv.size());
+  BlockedRequestCtx_NewAREQ(r, vv, vv.size());  // construction takes the argv holds AREQ_Compile parses from
   int rc = AREQ_Compile(r, ctx, r->brc->argvHolds, vv.size(), false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
@@ -96,7 +95,6 @@ static void testAverage() {
  */
 static void testCountDistinct() {
   AREQ *r = AREQ_New();
-  BlockedRequestCtx_NewAREQ(r);  // AREQ_Compile requires a wrapper (it carries the argv holds)
   AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR); // mark for coordinator pipeline
   RMCK::Context ctx{};
   RMCK::ArgvList vv(ctx, "*",                                                                  // nl
@@ -105,7 +103,7 @@ static void testCountDistinct() {
                     "REDUCE", "COUNT", "0"                                                     // nl
   );
   QueryError status{QueryErrorCode(0)};
-  BlockedRequestCtx_HoldArgv(r->brc, vv, vv.size());
+  BlockedRequestCtx_NewAREQ(r, vv, vv.size());  // construction takes the argv holds AREQ_Compile parses from
   int rc = AREQ_Compile(r, ctx, r->brc->argvHolds, vv.size(), false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
@@ -136,7 +134,6 @@ static void testCountDistinct() {
 }
 static void testSplit() {
   AREQ *r = AREQ_New();
-  BlockedRequestCtx_NewAREQ(r);  // AREQ_Compile requires a wrapper (it carries the argv holds)
   AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR); // mark for coordinator pipeline
   RMCK::Context ctx{};
   RMCK::ArgvList vv(ctx, "*",                                                                  // nl
@@ -145,7 +142,7 @@ static void testSplit() {
                     "REDUCE", "COUNT", "0"                                                     // nl
   );
   QueryError status{QueryErrorCode(0)};
-  BlockedRequestCtx_HoldArgv(r->brc, vv, vv.size());
+  BlockedRequestCtx_NewAREQ(r, vv, vv.size());  // construction takes the argv holds AREQ_Compile parses from
   int rc = AREQ_Compile(r, ctx, r->brc->argvHolds, vv.size(), false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));

--- a/tests/cpptests/test_distagg.cpp
+++ b/tests/cpptests/test_distagg.cpp
@@ -43,7 +43,7 @@ static void testAverage() {
                     "sortby", "2", "@avg_price", "DESC"                 // nl
   );
   QueryError status{QueryErrorCode(0)};
-  BlockedRequestCtx_NewAREQ(r, vv, vv.size());  // construction takes the argv holds AREQ_Compile parses from
+  BlockedRequestCtx_NewAREQ(r, vv, vv.size());
   int rc = AREQ_Compile(r, ctx, r->brc->argvHolds, vv.size(), false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
@@ -103,7 +103,7 @@ static void testCountDistinct() {
                     "REDUCE", "COUNT", "0"                                                     // nl
   );
   QueryError status{QueryErrorCode(0)};
-  BlockedRequestCtx_NewAREQ(r, vv, vv.size());  // construction takes the argv holds AREQ_Compile parses from
+  BlockedRequestCtx_NewAREQ(r, vv, vv.size());
   int rc = AREQ_Compile(r, ctx, r->brc->argvHolds, vv.size(), false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
@@ -142,7 +142,7 @@ static void testSplit() {
                     "REDUCE", "COUNT", "0"                                                     // nl
   );
   QueryError status{QueryErrorCode(0)};
-  BlockedRequestCtx_NewAREQ(r, vv, vv.size());  // construction takes the argv holds AREQ_Compile parses from
+  BlockedRequestCtx_NewAREQ(r, vv, vv.size());
   int rc = AREQ_Compile(r, ctx, r->brc->argvHolds, vv.size(), false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));

--- a/tests/pytests/test_empty.py
+++ b/tests/pytests/test_empty.py
@@ -1342,14 +1342,14 @@ def testEmptyLegacyGeoFilters():
     res = conn.execute_command('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '2.2945', '48.8584', '10', 'km', 'DIALECT', 1)
     env.assertEqual(res, [1, 'Tel Aviv', ['location', '2.2945,48.8584']])
     
-    res = conn.execute_command('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '', '51.47',  '1', 'km', 'DIALECT', 1)
-    env.assertEqual(res, [1, 'New York', ['location', '0,51.47']])
+    # Empty coordinate/radius values fail to parse in every dialect: command
+    # argv numbers go through the strict RedisModule string conversions.
+    env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '', '51.47',  '1', 'km', 'DIALECT', 1).error().contains('Bad arguments for <lon>')
 
-    res = conn.execute_command('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '', '1', 'km', 'DIALECT', 1)
-    env.assertEqual(res, [1, 'Chicago', ['location', '51.47,0']])
-    
-    env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '0', '', 'km', 'DIALECT', 1).error().contains('Invalid GeoFilter radius')
-    
+    env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '', '1', 'km', 'DIALECT', 1).error().contains('Bad arguments for <lat>')
+
+    env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '0', '', 'km', 'DIALECT', 1).error().contains('Bad arguments for <radius>')
+
     env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '0', '1', '', 'DIALECT', 1).error().contains('Unknown distance unit')
 
     MAX_DIALECT = set_max_dialect(env)
@@ -1357,13 +1357,13 @@ def testEmptyLegacyGeoFilters():
         env.set_dialect(dialect)
         res = conn.execute_command('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '2.2945', '48.8584', '10', 'km')
         env.assertEqual(res, [1, 'Tel Aviv', ['location', '2.2945,48.8584']])
-    
-        env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '', '51.47',  '1', 'km').error().contains('Numeric/Geo filter')
 
-        env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '', '1', 'km').contains('Numeric/Geo filter value/s')
+        env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '', '51.47',  '1', 'km').error().contains('Bad arguments for <lon>')
+
+        env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '', '1', 'km').error().contains('Bad arguments for <lat>')
         
-        env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '0', '', 'km', 'DIALECT', 1).error().contains('Invalid GeoFilter radius')
-        
+        env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '0', '', 'km', 'DIALECT', 1).error().contains('Bad arguments for <radius>')
+
         env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '0', '1', '', 'DIALECT', 1).error().contains('Unknown distance unit')
 
 def testEmptyParam():

--- a/tests/pytests/test_empty.py
+++ b/tests/pytests/test_empty.py
@@ -1342,14 +1342,14 @@ def testEmptyLegacyGeoFilters():
     res = conn.execute_command('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '2.2945', '48.8584', '10', 'km', 'DIALECT', 1)
     env.assertEqual(res, [1, 'Tel Aviv', ['location', '2.2945,48.8584']])
     
-    # Empty coordinate/radius values fail to parse in every dialect: command
-    # argv numbers go through the strict RedisModule string conversions.
-    env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '', '51.47',  '1', 'km', 'DIALECT', 1).error().contains('Bad arguments for <lon>')
+    res = conn.execute_command('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '', '51.47',  '1', 'km', 'DIALECT', 1)
+    env.assertEqual(res, [1, 'New York', ['location', '0,51.47']])
 
-    env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '', '1', 'km', 'DIALECT', 1).error().contains('Bad arguments for <lat>')
-
-    env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '0', '', 'km', 'DIALECT', 1).error().contains('Bad arguments for <radius>')
-
+    res = conn.execute_command('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '', '1', 'km', 'DIALECT', 1)
+    env.assertEqual(res, [1, 'Chicago', ['location', '51.47,0']])
+    
+    env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '0', '', 'km', 'DIALECT', 1).error().contains('Invalid GeoFilter radius')
+    
     env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '0', '1', '', 'DIALECT', 1).error().contains('Unknown distance unit')
 
     MAX_DIALECT = set_max_dialect(env)
@@ -1357,13 +1357,13 @@ def testEmptyLegacyGeoFilters():
         env.set_dialect(dialect)
         res = conn.execute_command('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '2.2945', '48.8584', '10', 'km')
         env.assertEqual(res, [1, 'Tel Aviv', ['location', '2.2945,48.8584']])
+    
+        env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '', '51.47',  '1', 'km').error().contains('Numeric/Geo filter')
 
-        env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '', '51.47',  '1', 'km').error().contains('Bad arguments for <lon>')
-
-        env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '', '1', 'km').error().contains('Bad arguments for <lat>')
+        env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '', '1', 'km').contains('Numeric/Geo filter value/s')
         
-        env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '0', '', 'km', 'DIALECT', 1).error().contains('Bad arguments for <radius>')
-
+        env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '0', '', 'km', 'DIALECT', 1).error().contains('Invalid GeoFilter radius')
+        
         env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '0', '1', '', 'DIALECT', 1).error().contains('Unknown distance unit')
 
 def testEmptyParam():


### PR DESCRIPTION
## Describe the changes in the pull request

Preparation step of the blocked-client / cross-thread ownership refactor (#9426): the request wrapper holds `RedisModule_HoldString` references to the command argv, and everything the request needs from its arguments — parsing, the query string, plan borrows, the id-filter keys, the coherence-check prefixes — borrows from those held strings. All per-request argument copying is gone.

**Built on #10737** (cursor ownership — park/free at end of cycle on the main thread, **merged**; this PR now bases directly on master), which this PR relies on: the module-string references introduced here must only be released on the main thread, and #10737 is what routes the cursor-driven frees (including the hybrid sub-cursor drain chain) there. Follows #10515 (coordinator main-thread allocation, merged).

1. **Current:** `HybridRequest.args` and `AREQ.args` are sds deep copies of the command argv, owned by the request. The plans borrow from those buffers, which for hybrid ties every sub-AREQ's lifetime to the container's — the blocker for dissolving the container at the end of the initial WITHCURSOR cycle (§3.6 of the design, next step of MOD-16991). INKEYS additionally flows sds keys through the id-filter chain into the Rust query evaluation, and the hybrid `_INDEX_PREFIXES` check makes one more sds copy of each prefix.
2. **Change** (one commit per step):
   - **Held argv instead of sds copies.** References are taken on the **main thread only** (string refcounts are not thread-safe) and released on main (`BlockedRequestCtx_Free`, after the owned request). Each string is `RedisModule_TrimStringAllocation`-ed at hold time: Redis auto-trims (reallocates) retained argv right after the command callback returns, which is not thread-safe against a worker already reading the holds — trimming at hold time runs the same reallocation on the main thread before parsing borrows the buffers, and the auto-trim then finds nothing to do.
   - **The holds live on the `BlockedRequestCtx` wrapper** — the one context every request kind has. One implementation for any query; hybrid sub-AREQs get their wrapper at construction (main thread) instead of at cursor-publish time, and each sub wrapper takes its own holds so the sub's plan borrows outlive the container.
   - **The wrapper is constructed with its argv.** `BlockedRequestCtx_NewAREQ` / `NewHybrid` take `(argv, argc)` and hold at construction — there is no create-then-hold two-step and no exported hold API; every request is born with its holds, and construction asserts a non-NULL argv — a future background-parsing flow constructed without argv fails deterministically in debug builds rather than touching string refcounts off the main thread. Hybrid sub-wrappers hold the whole stepped command, not just their slice — slice boundaries are only discovered while parsing, and sub pipelines borrow beyond their slice anyway (distributed tail LOAD steps, PARAMS).
   - **The wrapper records how its command parses.** The wrapper carries `argv`/`argc` (the held command), `parseArgc` (the logical command length — the debug constructor sets it below the held debug tail, so debug callers no longer trim), and `queryOffset` (the query token's index, set where the query is discovered: `AREQ_Compile` / the hybrid sub-query parser, which derives it positionally from the parse cursor). `AREQ_Query(req, &len)` reads `argv[queryOffset]`; `QUERY_OFFSET_NONE` means "no query argument" (a VSIM sub-request without FILTER defaults to the `*` wildcard). `AREQ_Compile(req, ctx, offset, ...)` parses the holds directly — no argv/argc parameters anywhere in the chain, making the holds the only expressible string source. This also removed the `strlen` at `QAST_Parse` time. The AST's own query copy stays — the query parser unescapes it **in place**, which must never touch a client argv string. Off-main wrapper frees defer just the argv release to the main event loop (string refcounts are main-thread-only).
   - **Id-filter keys borrow the held module strings directly.** `QueryIdFilterNode.keys` is the INKEYS argv window itself (`RedisModuleString **`) — no per-query view/copy array to build, transfer, or free. Key resolution goes through `DocTable_GetIdR` (the existing header inline, given linkage), so the Rust `eval_ids` resolves keys without touching the module API; Rust tests mint keys through `redis_mock`'s string mock.
   - **Hybrid `_INDEX_PREFIXES` borrows its slice** from the holds instead of sds-copying each prefix for the one-shot coherence check; the sds flavor of `IndexSpec_IsCoherent` lost its last caller and is deleted (the `RedisModuleString` flavor takes its name).
   - The RString-backed cursors surfaced two latent type-blind readers that would have fed `RedisModuleString` pointers to the shards as command tokens: `AC_StringArg` (raw `objs[N]` cast, used by the tail-plan serializer and the distributed-reducer arg reader) and `distributeCollect` (forwarded raw cursor objs). Both now read through the type-aware accessor at each use site, with no per-token duplication and no intermediate arrays.
   - **Intentional behavior change — strict numeric argument parsing.** The AC numeric conversions differ by cursor backing: the char* branch (which used to back request parsing) goes through `strtoll`/`strtod`, which accept empty tokens (as 0) and leading whitespace, and rejected literal `inf` / exact `LLONG_MAX` only as a side effect of testing the C APIs' overflow *return values* instead of `errno`. With the request argv now RString-backed, every user-provided positional numeric argument (`LIMIT`, `TIMEOUT`, legacy `GEOFILTER` lon/lat/radius, hybrid `KNN`/`RADIUS`/`EPSILON`, arg counts, …) parses with the strict RedisModule conversions: canonical-form integers, no whitespace, no empty tokens, overflow via `errno`. The legacy `GEOFILTER` empty-value contract is **preserved** by recognizing the empty token on conversion failure instead of after a lenient parse: DIALECT 1 still coerces an empty lon/lat/radius to 0, and dialect ≥ 2 keeps its dedicated "Numeric/Geo filter value/s cannot be empty" error (`testEmptyLegacyGeoFilters` unchanged). Internal char*-backed cursors (serialized plan tokens, canonical decimal) keep the C-library path.
3. **Outcome:** requests own no argument storage and copy no argument bytes — the wrapper's held argv backs everything (the AST's private, parser-mutated query buffer is the one deliberate copy). The upcoming container handoff (#10745) can dissolve the HybridRequest at the end of the initial cycle without invalidating any sub-AREQ borrows, for free.

Verified per commit (workers enabled; cluster runs with `REDIS_STANDALONE=0`), and re-verified on the final tree after rebasing onto master post-#10515 merge:
- C/C++ unit tests: 978/978; Rust `query`/`query_eval`/`redis_mock`: 97/97, clippy clean
- Standalone: `test.py` + `test_aggregate.py` + `test_cursors.py` + `test_hybrid.py` + `test_blocked_client_timeout.py` + `test_hybrid_timeout.py`: 403/408 — every failure reproduces identically on the base build (known bare-runner workers-on environmental set)
- Cluster: the same suites minus `test.py`, plus `test_hybrid_dist.py`: 253/254 (the one failure is the same environmental set)

The combined stack tip (this + #10745) additionally passed the full unit-test suite after each restack.

#### Which additional issues this PR fixes
1. MOD-17409 (part of the query-lifetime refactor; design: MOD-15430; prerequisite for MOD-16991)
2. Design: #9426

#### Main objects this PR modified
1. `BlockedRequestCtx` (`argv`/`argc`/`parseArgc`/`queryOffset` — owns the held command argv and its parse indicators for any request kind)
2. `AREQ` (`args`/`nargs`/`query`/`parseArgv` removed; `AREQ_Query` reads through the wrapper)
3. `HybridRequest` (`args` removed; `New`/`Init`/`MakeDefaultHybridRequest` thread argv to the sub-AREQ wrappers; `_INDEX_PREFIXES` borrows)
4. `QueryIdFilterNode` / Rust `eval_ids` (sds keys → borrowed `RedisModuleString**`; new exported `DocTable_GetIdR`)
5. `IndexSpec_IsCoherent` (single `RedisModuleString**` flavor)
6. `AC_StringArg` (`deps/rmutil/args.h`) and `distributeCollect` (`src/coord/dist_plan.cpp`) — type-aware token reads

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)



