### PR TITLE
[2.10] [MOD-17014] Validate FT.AGGREGATE GROUPBY count

### DIFF
--- a/src/aggregate/aggregate_plan.h
+++ b/src/aggregate/aggregate_plan.h
@@ -6,6 +6,7 @@
 
 #ifndef AGGREGATE_PLAN_H_
 #define AGGREGATE_PLAN_H_
+#include <stdint.h>
 #include <value.h>
 #include <rlookup.h>
 #include <search_options.h>

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -803,7 +803,13 @@ static int parseGroupby(AREQ *req, ArgsCursor *ac, QueryError *status) {
     return REDISMODULE_ERR;
   }
 
-  for (size_t ii = 0; ii < groupArgs.argc; ++ii) {
+  uint32_t propertyCount = (uint32_t)AC_NumArgs(&groupArgs);
+  if (propertyCount > MAX_GROUPBY_PROPERTIES) {
+    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(AC_ERR_ELIMIT));
+    return REDISMODULE_ERR;
+  }
+
+  for (uint32_t ii = 0; ii < propertyCount; ++ii) {
     if (*(char*)groupArgs.objs[ii] != '@') {
       QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments for GROUPBY", ": Unknown property `%s`. Did you mean `@%s`?",
                          groupArgs.objs[ii], groupArgs.objs[ii]);

--- a/src/config.h
+++ b/src/config.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "redismodule.h"
 #include "rmutil/sds.h"
 #include "query_error.h"
@@ -240,6 +242,7 @@ void UpgradeDeprecatedMTConfigs();
 #define DEFAULT_INDEX_CURSOR_LIMIT 128
 #define MAX_AGGREGATE_REQUEST_RESULTS (1ULL << 31)
 #define DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS MAX_AGGREGATE_REQUEST_RESULTS
+#define MAX_GROUPBY_PROPERTIES UINT16_MAX
 #define DEFAULT_MAX_SEARCH_REQUEST_RESULTS 1000000
 #define MAX_SEARCH_REQUEST_RESULTS (1ULL << 31)
 #define MAX_KNN_K (1ULL << 58)

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1099,6 +1099,15 @@ def testGroupProperties(env):
     conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE', 'n', 'NUMERIC', 'SORTABLE', 'tt', 'TAG')
     conn.execute_command('HSET', 'doc1', 't', 'hello', 'n', '1', 'tt', 'foo')
 
+    max_groupby_properties = (1 << 16) - 1
+    env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', str(max_groupby_properties + 1), '@t').error().contains(
+                    'Bad arguments for GROUPBY: Expected an argument, but none provided')
+    too_many_properties = ['@t'] * (max_groupby_properties + 1)
+    env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', str(len(too_many_properties)), *too_many_properties).error().contains(
+                    'Bad arguments for GROUPBY: Value is outside acceptable bounds')
+    env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '-1').error().contains(
+                    'Bad arguments for GROUPBY: Value is outside acceptable bounds')
+
     # Check groupby properties
     env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '3', 't', 'n', 'tt').error().contains(
                     'Bad arguments for GROUPBY: Unknown property `t`. Did you mean `@t`?')


### PR DESCRIPTION
# Description
Backport of #10615 to `2.10`.

The automatic backport does not target `2.10`, so this was created manually. It needed the same adaptation as the `8.2` backport (#10690) — see **Conflict resolution** below.

## What changed

`FT.AGGREGATE ... GROUPBY <nproperties>` now rejects a property count above `MAX_GROUPBY_PROPERTIES` (`UINT16_MAX`) before the group pipeline is built.

The other two guards from the upstream commit are already in effect on `2.10`, because this branch already parses the property list through `AC_GetVarArgs`:

- a count larger than the remaining command arguments is rejected by `AC_GetSlice` (`AC_ERR_NOARG`)
- a negative count is rejected by `AC_GetUnsigned` (`AC_ERR_ELIMIT`)

`FT.HYBRID` does not exist on `2.10`, so its `GROUPBY` sub-arg bound is not part of this backport.

## Why

The parser read `nproperties` as `long long` and passed it to `array_newlen`, whose length is a `uint32_t`. A negative or oversized value could wrap at allocation time while the parse loop kept using the original 64-bit count.

`UINT16_MAX` is the concrete downstream representation limit: GROUPBY properties and reducer aliases both allocate dynamic group-output `RLookup` row slots addressed by a `uint16_t dstidx`. The limit is deliberately not `MAX_AGGREGATE_GROUPS` (that caps materialized result groups at execution time) nor `SPEC_MAX_FIELDS` (GROUPBY can target `APPLY` aliases, not just schema fields).

## Conflict resolution

`2.10` diverges from `master` in two ways that change the shape of this fix.

**1. `parseGroupby` is already `AC_GetVarArgs`-based on `2.10`.** The `long long nproperties` + `array_newlen(const char *, nproperties)` shape that the upstream commit replaces does not exist here — `2.10` reads the property list through `AC_GetVarArgs` and iterates `groupArgs`. So the only missing piece is the upper bound, which is what this backport adds:

```c
  uint32_t propertyCount = (uint32_t)AC_NumArgs(&groupArgs);
  if (propertyCount > MAX_GROUPBY_PROPERTIES) {
    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(AC_ERR_ELIMIT));
    return REDISMODULE_ERR;
  }
```

`QUERY_ERROR_CODE_PARSE_ARGS` was renamed from `QUERY_EPARSEARGS` after `2.10`, so the older name is used here.

**2. `src/hybrid/` does not exist on `2.10`.** `FT.HYBRID` was introduced later, so the `src/hybrid/parse/hybrid_optional_args.c` and `tests/cpptests/test_cpp_parse_hybrid.cpp` changes are dropped (the bot's cherry-pick left them as modify/delete conflicts). `src/config.h` keeps only `MAX_GROUPBY_PROPERTIES`; `src/aggregate/aggregate_plan.h` keeps `value.h` and gains `#include <stdint.h>`.

Net effect: 4 files changed instead of 6, and the three new `test_aggregate.py` assertions apply unchanged.

The resulting patch is **byte-identical** to the `8.2` backport (#10690).

## Validation

Built and tested locally (release, `linux-x64`):

- `./build.sh` — build succeeds, only pre-existing warnings
- `./build.sh RUN_PYTEST TEST="test_aggregate:testGroupProperties"` — **PASS** (3/3 env variants)
- `git diff --check` clean

Note: `2.10` pins Boost 1.84 (`.install/install_boost.sh`); with 1.88 `src/util/hash/hash.cpp` fails to compile for reasons unrelated to this change.

## Original PR
- Title: [MOD-17014] Validate FT.AGGREGATE GROUPBY count
- Link: https://github.com/RediSearch/RediSearch/pull/10615
- Merge commit: `9ec64a812d8964021c5f416f7e3f07523d4dc593`

## Release notes
- [x] This PR requires release notes
- [ ] This PR does not require release notes


[MOD-17014]: https://redislabs.atlassian.net/browse/MOD-17014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ