### PR TITLE
skill: open-pr: report the full PR URL

### DIFF
--- a/.skills/open-pr/SKILL.md
+++ b/.skills/open-pr/SKILL.md
@@ -61,6 +61,11 @@ RediSearch.
    `master`. It is `master` for ordinary work, a release branch when targeting one, and
    the parent change's branch for a deliberately stacked PR — getting this wrong pulls
    the parent's commits into the diff and reviews them again.
+
+   `gh pr create` prints the URL of the new PR. Show it to the user immediately, in full
+   (`https://github.com/<owner>/<repo>/pull/<number>`), as a clickable link — not just the
+   PR number, and not only at the end of the workflow. Steps 8–13 take a long time, and
+   the user should be able to open the PR while they run.
 8. Concurrently, using sub-agents:
    1. Verify the final PR body, title, base, and head.
    2. Load and follow the [/verify](../verify/SKILL.md) skill.
@@ -229,4 +234,10 @@ assuming the create or edit step worked.
 
 ## Output
 
-Report the PR URL.
+Report the full PR URL — `https://github.com/<owner>/<repo>/pull/<number>` — so the user
+can click straight through to it. A bare number, a `#123` reference, or a relative path is
+not enough. Restate it here even if you already showed it in step 7; by this point it has
+scrolled well out of view.
+
+If anything else is worth reporting (verification status, review findings, CI state), the
+URL still goes first.


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `gh pr create` prints the URL of the new PR, but `/open-pr` never
   tells the agent to surface it at that point. The only mention is the closing
   *Output* section — a one-line "Report the PR URL" — which is reached after steps
   8-13 (verification, adversarial review, Codex review, CI monitoring). Those take a
   long time and produce a lot of output, so by the time the agent reports anything the
   URL has scrolled far out of view, and "the PR URL" is loose enough that a bare number
   or a `#123` reference satisfies it.
2. **Change**: Step 7 now says to show the full URL to the user immediately after
   `gh pr create` returns, as a clickable link. The *Output* section spells out the
   required form (`https://github.com/<owner>/<repo>/pull/<number>`), rules out a bare
   number / `#123` / relative path, and says to restate it even though step 7 already
   printed it.
3. **Outcome**: The user can open the PR while the long tail of the workflow is still
   running, and the final report always ends with a link they can click.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `.skills/open-pr/SKILL.md` — step 7 and the *Output* section.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Agent-facing skill documentation only; no module code is touched.
