### PR TITLE
[MOD-17451] Fix out-of-bounds write and empty-value matching for empty wildcard patterns

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -674,6 +674,15 @@ static QueryIterator *Query_EvalWildcardQueryNode(QueryEvalCtx *q, QueryNode *qn
                             q->config);
   }
 
+  // An empty pattern matches exactly the empty term (indexed under INDEXEMPTY), like the
+  // empty-string text query; the trie scans below never contain it, so skip them
+  if (nstr == 0) {
+    charIterCb("", 0, &ctx, NULL);
+    rm_free(str);
+    return NewUnionIterator(ctx.its, ctx.nits, true, qn->opts.weight, QN_WILDCARD_QUERY,
+                            qn->verb.tok.str, q->config);
+  }
+
   bool fallbackBruteForce = false;
   // spec support using suffix trie
   if (spec->suffix) {
@@ -1026,6 +1035,16 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
 
   size_t itsSz = 0, itsCap = 8;
   QueryIterator **its = rm_malloc(itsCap * sizeof(*its));
+
+  // An empty pattern matches exactly the empty tag value (indexed under INDEXEMPTY),
+  // like the empty-string tag query; skip the suffix-trie and brute-force scans
+  if (tok->len == 0) {
+    QueryIterator *ret = TagIndex_OpenReader(idx, q->sctx, "", 0, 1, fieldIndex, q->status);
+    if (ret) {
+      its[itsSz++] = ret;
+    }
+    return NewUnionIterator(its, itsSz, true, weight, QN_WILDCARD_QUERY, qn->pfx.tok.str, q->config);
+  }
 
   bool fallbackBruteForce = false;
   if (TagIndex_HasSuffix(idx)) {

--- a/src/query.c
+++ b/src/query.c
@@ -665,36 +665,39 @@ static QueryIterator *Query_EvalWildcardQueryNode(QueryEvalCtx *q, QueryNode *qn
   ctx.its = rm_malloc(sizeof(*ctx.its) * ctx.cap);
   ctx.nits = 0;
 
+  if (spec->suffix && qn->opts.fieldMask != RS_FIELDMASK_ALL &&
+      (spec->suffixMask & qn->opts.fieldMask) != qn->opts.fieldMask) {
+    QueryError_SetError(q->status, QUERY_ERROR_CODE_GENERIC,
+                        "Contains query on fields without WITHSUFFIXTRIE support");
+    rm_free(str);
+    return NewUnionIterator(ctx.its, 0, true, qn->opts.weight, QN_WILDCARD_QUERY, qn->verb.tok.str,
+                            q->config);
+  }
+
   bool fallbackBruteForce = false;
   // spec support using suffix trie
   if (spec->suffix) {
-    // all modifier fields are supported
-    if (qn->opts.fieldMask == RS_FIELDMASK_ALL ||
-       (spec->suffixMask & qn->opts.fieldMask) == qn->opts.fieldMask) {
-      // TEXT terms are stored lowercased, so recheck against the lowercased
-      // pattern (Suffix_CB_Wildcard matches cstr) to stay case-insensitive.
-      size_t lcstrlen;
-      char *lcstr = runesToStr(str, nstr, &lcstrlen);
-      SuffixCtx sufCtx = {
-        .trie = spec->suffix,
-        .rune = str,
-        .runelen = nstr,
-        .cstr = lcstr,
-        .cstrlen = lcstrlen,
-        .type = SUFFIX_TYPE_WILDCARD,
-        .callback = charIterCb, // the difference is weather the function receives char or rune
-        .cbCtx = &ctx,
-        .timeout = &q->sctx->time.timeout,
-        .skipTimeoutChecks = q->sctx->time.skipTimeoutChecks,
-      };
-      if (Suffix_IterateWildcard(&sufCtx) == 0) {
-        // if suffix trie cannot be used, use brute force
-        fallbackBruteForce = true;
-      }
-      rm_free(lcstr);
-    } else {
-      QueryError_SetError(q->status, QUERY_ERROR_CODE_GENERIC, "Contains query on fields without WITHSUFFIXTRIE support");
+    // TEXT terms are stored lowercased, so recheck against the lowercased
+    // pattern (Suffix_CB_Wildcard matches cstr) to stay case-insensitive.
+    size_t lcstrlen;
+    char *lcstr = runesToStr(str, nstr, &lcstrlen);
+    SuffixCtx sufCtx = {
+      .trie = spec->suffix,
+      .rune = str,
+      .runelen = nstr,
+      .cstr = lcstr,
+      .cstrlen = lcstrlen,
+      .type = SUFFIX_TYPE_WILDCARD,
+      .callback = charIterCb, // the difference is weather the function receives char or rune
+      .cbCtx = &ctx,
+      .timeout = &q->sctx->time.timeout,
+      .skipTimeoutChecks = q->sctx->time.skipTimeoutChecks,
+    };
+    if (Suffix_IterateWildcard(&sufCtx) == 0) {
+      // if suffix trie cannot be used, use brute force
+      fallbackBruteForce = true;
     }
+    rm_free(lcstr);
   }
 
   if (!spec->suffix || fallbackBruteForce) {

--- a/src/redisearch_rs/rqe_wildcard/tests/integration/remove_escape.rs
+++ b/src/redisearch_rs/rqe_wildcard/tests/integration/remove_escape.rs
@@ -140,9 +140,10 @@ mod ffi_comparison {
         assert_matches_c("foo");
     }
 
-    // No ffi_empty test: the C do-while loop in Wildcard_RemoveEscape
-    // always executes once, so it returns length 1 for len=0 input (a
-    // harmless off-by-one). The Rust version correctly returns empty.
+    #[test]
+    fn ffi_empty() {
+        assert_matches_c("");
+    }
 
     #[test]
     fn ffi_escape_at_beginning() {

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -346,6 +346,10 @@ int Suffix_CB_Wildcard(const rune *rune, size_t len, void *p, void *payload, siz
 }
 
 int Suffix_IterateWildcard(SuffixCtx *sufCtx) {
+  // An empty pattern has no token to anchor on, and the arrays below require a positive length
+  if (sufCtx->cstrlen == 0) {
+    return 0;
+  }
   size_t idx[sufCtx->cstrlen];
   size_t lens[sufCtx->cstrlen];
   int useIdx = Suffix_ChooseToken_rune(sufCtx->rune, sufCtx->runelen, idx, lens);
@@ -504,6 +508,10 @@ end:
 
 arrayof(char*) GetList_SuffixTrieMap_Wildcard(TrieMap *trie, const char *pattern, uint32_t len,
                                               struct timespec timeout, long long maxPrefixExpansions, bool skipTimeoutChecks) {
+  // An empty pattern has no token to anchor on, and the arrays below require a positive length
+  if (len == 0) {
+    return BAD_POINTER;
+  }
   size_t idx[len];
   size_t lens[len];
   // find best token

--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -1387,6 +1387,10 @@ static void wildcardIterate(const TrieNode *n, RangeCtx *r) {
 void TrieNode_IterateWildcard(const TrieNode *n, const rune *str, int nstr,
                               TrieRangeCallback callback, void *ctx, struct timespec *timeout,
                               bool skipTimeoutChecks) {
+  // An empty pattern matches no term, and the initializer below reads str[nstr - 1]
+  if (nstr <= 0) {
+    return;
+  }
   // Use REDISEARCH_UNINITIALIZED counter to skip timeout checks
   RangeCtx r = {
       .callback = callback,

--- a/src/wildcard/wildcard.c
+++ b/src/wildcard/wildcard.c
@@ -136,6 +136,11 @@ size_t Wildcard_TrimPattern(char *pattern, size_t p_len) {
 }
 
 size_t Wildcard_RemoveEscape(char *str, size_t len) {
+  // The scan below reads str[0] unconditionally, and an empty pattern would leave it
+  // with i == 1 != len, taking the unescape path and writing str[1] past the buffer
+  if (len == 0) {
+    return 0;
+  }
   int i = 0;
   do {
     if (str[i] == '\\') break;

--- a/tests/cpptests/test_cpp_suffix.cpp
+++ b/tests/cpptests/test_cpp_suffix.cpp
@@ -9,7 +9,9 @@
 
 #include "gtest/gtest.h"
 #include "suffix.h"
+#include "trie/trie.h"
 #include "trie/rune_util.h"
+#include "triemap_ffi.h"
 #include "redisearch.h"
 
 #include <string>
@@ -155,4 +157,84 @@ TEST_F(SuffixChooseTokenTest, multiByteCharsScoredByRune) {
   EXPECT_EQ(chooseRune("αβγ*δεζη").len, 4u);
   EXPECT_EQ(chooseRune("αβγδε").tokenOrdinal, 0);
   EXPECT_EQ(chooseRune("αβγδε").len, 5u);
+}
+
+// The wildcard entry points size scratch arrays by the pattern length and read
+// its last character, so each must reject an empty pattern itself — the callers
+// that currently pre-filter empty patterns are not part of their contract.
+
+class WildcardEmptyPatternTest : public ::testing::Test {};
+
+static int countSuffixHit(const char *, size_t, void *ctx, void *) {
+  ++*static_cast<int *>(ctx);
+  return REDISEARCH_OK;
+}
+
+static int countRangeHit(const rune *, size_t, void *ctx, void *, size_t) {
+  ++*static_cast<int *>(ctx);
+  return REDISEARCH_OK;
+}
+
+TEST_F(WildcardEmptyPatternTest, suffixTrieIterateSignalsUnusable) {
+  Trie *t = NewTrie(suffixTrie_freeCallback, Trie_Sort_Lex);
+  addSuffixTrie(t, "abc", 3);
+  int hits = 0;
+  struct timespec timeout = {};
+  rune emptyPattern[1] = {0};
+  SuffixCtx ctx = {};
+  ctx.trie = t;
+  ctx.rune = emptyPattern;
+  ctx.runelen = 0;
+  ctx.cstr = "";
+  ctx.cstrlen = 0;
+  ctx.type = SUFFIX_TYPE_WILDCARD;
+  ctx.callback = countSuffixHit;
+  ctx.cbCtx = &hits;
+  ctx.timeout = &timeout;
+  ctx.skipTimeoutChecks = true;
+
+  EXPECT_EQ(Suffix_IterateWildcard(&ctx), 0);
+  EXPECT_EQ(hits, 0);
+
+  // control: a non-empty pattern uses the trie and reaches the callback
+  size_t rlen = 0;
+  runeBuf buf;
+  ctx.rune = runeBufFill("*b*", 3, &buf, &rlen);
+  ctx.runelen = rlen;
+  ctx.cstr = "*b*";
+  ctx.cstrlen = 3;
+  EXPECT_EQ(Suffix_IterateWildcard(&ctx), 1);
+  EXPECT_GT(hits, 0);
+  runeBufFree(&buf);
+
+  TrieType_Free(t);
+}
+
+TEST_F(WildcardEmptyPatternTest, suffixTrieMapListSignalsUnusable) {
+  TrieMap *tm = NewTrieMap();
+  struct timespec timeout = {};
+  EXPECT_EQ((void *)GetList_SuffixTrieMap_Wildcard(tm, "", 0, timeout, 100, true), BAD_POINTER);
+  TrieMap_Free(tm, NULL);
+}
+
+TEST_F(WildcardEmptyPatternTest, trieIterateWildcardEmptyMatchesNothing) {
+  Trie *t = NewTrie(NULL, Trie_Sort_Lex);
+  ASSERT_TRUE(Trie_InsertStringBuffer(t, "abc", 3, 1, 1, NULL, 0));
+  int hits = 0;
+  // The pattern points past a non-'*' sentinel, so the str[nstr - 1] read this
+  // guards against gives a deterministic "no prefix" answer if it ever returns.
+  rune patternBuf[2] = {(rune)'x', 0};
+  rune *emptyPattern = patternBuf + 1;
+  Trie_IterateWildcard(t, emptyPattern, 0, countRangeHit, &hits, NULL, true);
+  EXPECT_EQ(hits, 0);
+
+  // control: "*" matches the inserted term
+  size_t rlen = 0;
+  runeBuf buf;
+  rune *star = runeBufFill("*", 1, &buf, &rlen);
+  Trie_IterateWildcard(t, star, rlen, countRangeHit, &hits, NULL, true);
+  EXPECT_EQ(hits, 1);
+  runeBufFree(&buf);
+
+  TrieType_Free(t);
 }

--- a/tests/ctests/test_wildcard.c
+++ b/tests/ctests/test_wildcard.c
@@ -65,8 +65,27 @@ int _testRemoveEscape(char *str, char *strAfter, int lenAfter) {
   return 0;
 }
 
+// The empty pattern in a buffer sized like a resolved query parameter —
+// rm_calloc(1, len + 1), one byte — so a write past it is outside the
+// allocation and visible to AddressSanitizer, unlike the stack-buffer case in
+// test_removeEscape, which only pins the returned length.
+int test_removeEscapeEmpty() {
+  char *pattern = rm_calloc(1, 1);
+  ASSERT(pattern != NULL);
+
+  ASSERT_EQUAL(0, Wildcard_RemoveEscape(pattern, 0));
+  ASSERT_EQUAL('\0', pattern[0]);
+
+  rm_free(pattern);
+  return 0;
+}
+
 int test_removeEscape() {
   char buf[16];
+
+  // empty pattern is returned unchanged
+  memcpy(buf, "", 1);
+  _testRemoveEscape(buf, "", 0);
 
   memcpy(buf, "foo", 4);
   _testRemoveEscape(buf, "foo", 3);
@@ -221,6 +240,7 @@ TEST_MAIN({
   RMUTil_InitAlloc();
   TESTFUNC(test_StarBreak);
   TESTFUNC(test_removeEscape);
+  TESTFUNC(test_removeEscapeEmpty);
   TESTFUNC(test_trimPattern);
   TESTFUNC(test_match); 
 });

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -423,6 +423,10 @@ def testWildcardOnFieldWithoutSuffixTrie():
     env.expect('FT.SEARCH', 'idx', "@t2:w'hel*o'").error() \
         .contains('WITHSUFFIXTRIE')
 
+    # The error does not depend on the pattern: an empty pattern errors too
+    env.expect('FT.SEARCH', 'idx', "@t2:w'$p'", 'PARAMS', 2, 'p', '').error() \
+        .contains('WITHSUFFIXTRIE')
+
 _MAX_EXPANSIONS_WARNING = 'Max prefix expansions limit was reached'
 
 # A cap above 1, so a truncated expansion is distinguishable from an empty one,

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -546,3 +546,48 @@ def testWildcardSuffixTrieMaxPrefixExpansions():
         _assertMaxExpansionsWarning(env, res)
     finally:
         env.expect(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', previous).ok()
+
+def testEmptyWildcardPattern():
+    """An empty wildcard pattern matches exactly the empty value, on both the
+    suffix-trie and the brute-force paths: nothing on TEXT fields and on TAG fields
+    without INDEXEMPTY, and the empty tag on TAG fields with INDEXEMPTY — consistent
+    with the empty-string tag query. The pattern is supplied through PARAMS because
+    a literal w'' does not parse as a wildcard. Runs in cluster deliberately: the
+    empty parameter value must survive the coordinator fan-out, and the documents
+    need no co-location because FT.SEARCH aggregates across shards."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx_suffix', 'SCHEMA',
+               't', 'TEXT', 'WITHSUFFIXTRIE',
+               'tag', 'TAG', 'WITHSUFFIXTRIE').ok()
+    env.expect('FT.CREATE', 'idx_bf', 'SCHEMA', 't', 'TEXT', 'tag', 'TAG').ok()
+    env.expect('FT.CREATE', 'idx_ie_suffix', 'SCHEMA',
+               't', 'TEXT', 'INDEXEMPTY', 'WITHSUFFIXTRIE',
+               'tag', 'TAG', 'INDEXEMPTY', 'WITHSUFFIXTRIE').ok()
+    env.expect('FT.CREATE', 'idx_ie_bf', 'SCHEMA',
+               't', 'TEXT', 'INDEXEMPTY',
+               'tag', 'TAG', 'INDEXEMPTY').ok()
+    conn.execute_command('HSET', 'doc1', 't', 'hello', 'tag', 'world')
+    conn.execute_command('HSET', 'doc2', 't', '', 'tag', '')
+
+    # without INDEXEMPTY the empty tag is not indexed, so nothing can match
+    for idx in ['idx_suffix', 'idx_bf']:
+        res = env.cmd('FT.SEARCH', idx, "w'$p'", 'PARAMS', 2, 'p', '', 'NOCONTENT')
+        env.assertEqual(res, [0], message=idx)
+        res = env.cmd('FT.SEARCH', idx, "@tag:{w'$p'}", 'PARAMS', 2, 'p', '', 'NOCONTENT')
+        env.assertEqual(res, [0], message=idx)
+
+    # with INDEXEMPTY the empty wildcard pattern matches the empty value,
+    # same as the empty-string queries
+    for idx in ['idx_ie_suffix', 'idx_ie_bf']:
+        res = env.cmd('FT.SEARCH', idx, "w'$p'", 'PARAMS', 2, 'p', '', 'NOCONTENT')
+        env.assertEqual(res, [1, 'doc2'], message=idx)
+        res = env.cmd('FT.SEARCH', idx, "@t:(w'$p')", 'PARAMS', 2, 'p', '', 'NOCONTENT')
+        env.assertEqual(res, [1, 'doc2'], message=idx)
+        res = env.cmd('FT.SEARCH', idx, '@t:("")', 'NOCONTENT')
+        env.assertEqual(res, [1, 'doc2'], message=idx)
+        res = env.cmd('FT.SEARCH', idx, "@tag:{w'$p'}", 'PARAMS', 2, 'p', '', 'NOCONTENT')
+        env.assertEqual(res, [1, 'doc2'], message=idx)
+        res = env.cmd('FT.SEARCH', idx, '@tag:{""}', 'NOCONTENT')
+        env.assertEqual(res, [1, 'doc2'], message=idx)


### PR DESCRIPTION

## Describe the changes in the pull request

1. Current: `Wildcard_RemoveEscape` mishandles an empty pattern: its scan loop reads `str[0]` unconditionally and then takes the unescape path, writing one byte past the buffer (the query parameter resolver allocates exactly `len + 1` bytes) and returning length 1. Every wildcard query with an empty parameter value — `w'$p'` with `PARAMS 2 p ''`, which bypasses the lexer's one-character minimum — triggered that out-of-bounds write and then evaluated a bogus one-byte pattern that matches nothing, including empty TAG values indexed under `INDEXEMPTY`. Downstream wildcard code also assumes a non-empty pattern with nothing enforcing it: `Suffix_IterateWildcard` and `GetList_SuffixTrieMap_Wildcard` size scratch VLAs by the pattern length (zero length is undefined behavior, C11 6.7.6.2p5), and `TrieNode_IterateWildcard` reads `str[nstr - 1]`. In `Query_EvalWildcardQueryNode`, the WITHSUFFIXTRIE field validation also sat in the middle of the scan logic, reached by fall-through.
2. Change: `Wildcard_RemoveEscape` returns an empty pattern unchanged, removing the out-of-bounds write. The query layer then short-circuits empty patterns: instead of scanning the tries (which never contain the empty term), both TEXT and TAG evaluation open the reader for the exact empty value, consistent with the empty-string queries `@t:("")` and `@t:{""}`. The suffix-trie entry points and `TrieNode_IterateWildcard` additionally reject zero-length patterns themselves as defense in depth, with unit tests pinning those contracts. The WITHSUFFIXTRIE field check is hoisted to an early return, so it keeps firing regardless of the pattern. The Rust `rqe_wildcard` crate gains an FFI parity test for the empty input, now that the C function agrees with `remove_escape`.
3. Outcome: no out-of-bounds access for empty wildcard patterns. A wildcard with an empty parameter now matches exactly the documents whose value is the empty string — populated only on `INDEXEMPTY` fields — agreeing with the empty-string queries (previously zero results everywhere); without `INDEXEMPTY` it still matches nothing, and wildcard queries on fields without WITHSUFFIXTRIE support still error. Flow tests pin all of these contracts. One deliberate asymmetry remains: on fields without `INDEXEMPTY`, the empty-string queries error with the `INDEXEMPTY` guidance while the empty wildcard silently returns zero results — kept as-is to preserve the wildcard's existing observable behavior on those fields.

#### Which additional issues this PR fixes

1. MOD-17451

#### Main objects this PR modified

1. `Wildcard_RemoveEscape` (src/wildcard/wildcard.c)
2. `Query_EvalWildcardQueryNode`, `Query_EvalTagWildcardNode` (src/query.c)
3. `Suffix_IterateWildcard`, `GetList_SuffixTrieMap_Wildcard` (src/suffix.c)
4. `TrieNode_IterateWildcard` (src/trie/trie_node.c)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
