### PR TITLE
[8.6-rse] [MOD-17316] Fix FT.HYBRID replying success with bogus warnings when a depleter loses the index lock

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -692,6 +692,8 @@ static void _replyWarnings(AREQ *req, RedisModule_Reply *reply, int rc) {
     ProfileWarnings_Add(&profileCtx->warnings, PROFILE_WARNING_TYPE_TIMEOUT);
   } else if (rc == RS_RESULT_ERROR) {
     // Non-fatal error
+    RS_LOG_ASSERT(!QueryError_IsOk(qctx->err),
+                  "RS_RESULT_ERROR reached the warning path without a QueryError set");
     RedisModule_Reply_SimpleString(reply, QueryError_GetUserError(qctx->err));
   }
   if (QueryError_HasReachedMaxPrefixExpansionsWarning(qctx->err)) {

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -58,6 +58,7 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   if (HasWithCount(nc->areq) && IsAggregate(nc->areq)) {
     ShardResponseBarrier *barrier = shardResponseBarrier_New();
     if (!barrier) {
+      QueryError_SetCode(nc->base.parent->err, QUERY_ERROR_CODE_GENERIC);
       return RS_RESULT_ERROR;
     }
     nc->shardResponseBarrier = barrier;
@@ -83,6 +84,7 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
       shardResponseBarrier_Free(nc->shardResponseBarrier);
       nc->shardResponseBarrier = NULL;
     }
+    QueryError_SetCode(nc->base.parent->err, QUERY_ERROR_CODE_GENERIC);
     return RS_RESULT_ERROR;
   }
 

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -84,6 +84,8 @@ static inline HybridWarningMask handleAndReplyWarning(RedisModule_Reply *reply, 
     return HYBRID_WARNING_TIMEOUT;
   } else if (returnCode == RS_RESULT_ERROR) {
     // Non-fatal error — convert to warning
+    RS_LOG_ASSERT(!QueryError_IsOk(err),
+                  "RS_RESULT_ERROR reached the warning path without a QueryError set");
     ReplyWarning(reply, QueryError_GetUserError(err), suffix);
     QueryError_ClearError(err);  // Free allocated message strings
   } else if (QueryError_HasReachedMaxPrefixExpansionsWarning(err)) {

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -221,7 +221,7 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
     rs_wall_clock_init(&now);
 
     // Initialize error tracking for each individual request
-    hybridReq->errors = array_new(QueryError, nrequests);
+    hybridReq->errors = array_newlen(QueryError, nrequests);
     memset(hybridReq->errors, 0, nrequests * sizeof(QueryError));
 
     // Initialize return codes array for tracking subqueries final states

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1645,6 +1645,11 @@ ResultProcessor *RPVectorNormalizer_New(VectorNormFunction normFunc, const RLook
  *  NOTE: Currently the recommended number of upstreams is 2. Using more may
  *  induce performance issues, until a more robust mechanism is implemented.
  *******************************************************************************************************************/
+
+#define SAFE_DEPLETER_LOCK_FAILURE_MSG                                                            \
+  "Failed to acquire index lock for background depletion. A write operation may be in progress. " \
+  "Please retry."
+
 typedef struct {
   ResultProcessor base;                // Base result processor struct
   // We require separate contexts because we have different threads.
@@ -1755,6 +1760,8 @@ static void RPSafeDepleter_DepleteFromUpstream(RPSafeDepleter *self, DepleterSyn
       // Failed to acquire lock - likely a writer is waiting
       // Set error status and return without depleting
       self->last_rc = RS_RESULT_ERROR;
+      QueryError_SetError(self->base.parent->err, QUERY_ERROR_CODE_SAFE_DEPLETER_FAILURE,
+                          SAFE_DEPLETER_LOCK_FAILURE_MSG);
       // Signal that we're skipping the lock phase (for WaitForDepletionToStart)
       atomic_fetch_add(&sync->num_skipped_lock, 1);
       return;
@@ -2066,8 +2073,8 @@ int RPSafeDepleter_DepleteAll(arrayof(ResultProcessor*) safeDepleters, QueryErro
   for (size_t i = 0; i < count; i++) {
     const RPSafeDepleter *safeDepleter = (RPSafeDepleter *)safeDepleters[i];
     if (safeDepleter->last_rc == RS_RESULT_ERROR) {
-      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_SAFE_DEPLETER_FAILURE,
-        "Failed to acquire index lock for background depletion. A write operation may be in progress. Please retry.");
+      QueryError_SetError(status, QUERY_ERROR_CODE_SAFE_DEPLETER_FAILURE,
+                          SAFE_DEPLETER_LOCK_FAILURE_MSG);
       return RS_RESULT_ERROR;
     } else if (safeDepleter->last_rc == RS_RESULT_TIMEDOUT) {
       anyTimedOut = true;
@@ -2232,6 +2239,8 @@ static int RPHybridMerger_Yield(ResultProcessor *rp, SearchResult *r) {
 
   SearchResult *mergedResult = mergeSearchResults(hybridResult, self->hybridScoringCtx, self->lookupCtx);
   if (!mergedResult) {
+    QueryError_SetError(rp->parent->err, QUERY_ERROR_CODE_GENERIC,
+                        "Failed to merge hybrid subquery results");
     return RS_RESULT_ERROR;
   }
 


### PR DESCRIPTION
## Describe the changes in the pull request

Manual backport of #10658 to `8.6-rse`. The automated backport failed to cherry-pick.

1. **Current**: `FT.HYBRID`'s background depleters take a non-blocking spec read lock. When that try-lock loses the race to a queued writer, the failure was recorded only in `last_rc`. Plain `FT.HYBRID` depletes through `Next`, so the merger saw a bare `RS_RESULT_ERROR` with an unset `QueryError`, which stringifies to its `QUERY_ERROR_CODE_OK` default — the command answered **successfully with `total_results: 0`** and `Success (not an error)` warnings.
2. **Change**: record the failure on the subquery pipeline's `QueryError` at the point of loss, with debug-build assertions at both reply sites pinning the invariant that `RS_RESULT_ERROR` carries a message. Also fixes a latent leak of `hreq->errors[i]` messages (`array_new` -> `array_newlen`, so `array_free_ex` iterates the elements).
3. **Outcome**: standalone `FT.HYBRID` returns the same retryable `SEARCH_SAFE_DEPLETER_FAILURE ... Please retry.` as the cursor and cluster paths. Try-lock behaviour itself is unchanged.

## Original PR

https://github.com/RediSearch/RediSearch/pull/10658 (merge commit `34dcfb241afbaabbe4ad6e087cc1624af76854ce`)

## Changes from original

**The regression test is not included.** `test_hybrid_depleter_lock_failure_replies_error` drives the real mechanism through the `BeforeHybridResultsClaim` sync point, which does not exist on `8.6-rse`. Backporting it would mean backporting the sync-point instrumentation first. The `@skip(musl=True)` predicate and the `MUSL` flag are omitted along with it: this branch still has the pre-decomposition monolithic `skip()` (no `_skip_fires_statically` / `_any_skip_condition_set` split), so the predicate would have to be re-implemented against a different shape for no consumer. So `tests/pytests/common.py`, `tests/pytests/includes.py` and `tests/pytests/test_hybrid_multithread.py` are untouched here.

**`src/coord/dist_aggregate.c` hand-ported.** Master extracted `rpnetCreateIterator()`; this branch still builds and dispatches the iterator inline in `rpnetNext_Start`, which has *two* `RS_RESULT_ERROR` exits (barrier allocation and iterator creation) rather than master's one. `QueryError_SetCode` is set on both.

The remaining hunks (`src/aggregate/aggregate_exec.c`, `src/hybrid/hybrid_exec.c`, `src/hybrid/hybrid_request.c`, `src/result_processor.c`) carry the same change as the original commit.

### Testing

Built with `./build.sh DEBUG=1 ENABLE_ASSERT=1`, then:

- `TEST=test_asm.py` — 42/42 pass. This is the suite that exercises the depleter lock-failure path on the cluster side, so it is the local evidence that the two new `RS_LOG_ASSERT`s do not fire on a reachable path.
- `TEST=test_hybrid_multithread.py` — 1/1 pass (the branch's pre-existing test).

There is no direct regression test for the fixed standalone path on this branch, for the reason above.

#### Which additional issues this PR fixes
1. MOD-17316

#### Main objects this PR modified
1. `RPSafeDepleter_DepleteFromUpstream` — records `SAFE_DEPLETER_FAILURE`; message shared with `RPSafeDepleter_DepleteAll`
2. `HybridRequest_Init` — `array_newlen` so `errors[]` are cleared on free
3. `handleAndReplyWarning` (`hybrid_exec.c`) and `_replyWarnings` (`aggregate_exec.c`) — assert that `RS_RESULT_ERROR` carries a message
4. `RPHybridMerger_Yield`, `rpnetNext_Start` — record a message before returning `RS_RESULT_ERROR`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
