### PR TITLE
[MOD-14948] TopK Numeric micro benchmarks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -58,7 +58,7 @@ RUST_TOOLCHAIN_MODIFIER="" # Rust toolchain to use (e.g., +nightly)
 
 # Rust code is built first, so exclude benchmarking crates that link C code,
 # since the static libraries they depend on haven't been built yet.
-EXCLUDE_RUST_BENCHING_CRATES_LINKING_C="--exclude inverted_index_bencher --exclude rqe_iterators_bencher --exclude iterators_ffi --exclude top_k_bencher --exclude trie_bencher --exclude triemap_ffi --exclude ttl_table_bencher --exclude vector_score_source_bencher"
+EXCLUDE_RUST_BENCHING_CRATES_LINKING_C="--exclude inverted_index_bencher --exclude numeric_score_source_bencher --exclude rqe_iterators_bencher --exclude iterators_ffi --exclude top_k_bencher --exclude trie_bencher --exclude triemap_ffi --exclude ttl_table_bencher --exclude vector_score_source_bencher"
 
 # Retrieve our pinned nightly version.
 NIGHTLY_VERSION=$(cat ${ROOT}/.rust-nightly)

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1553,6 +1553,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "numeric_score_source_bencher"
+version = "0.0.1"
+dependencies = [
+ "build_utils",
+ "cc",
+ "criterion",
+ "ffi",
+ "index_result",
+ "inverted_index",
+ "numeric_range_tree",
+ "numeric_score_source",
+ "redis_mock",
+ "redisearch_rs",
+ "rqe_core",
+ "rqe_iterators",
+ "rqe_iterators_test_utils",
+ "workspace_hack",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1556,6 +1556,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "numeric_score_source_bencher"
+version = "0.0.1"
+dependencies = [
+ "build_utils",
+ "cc",
+ "criterion",
+ "ffi",
+ "index_result",
+ "inverted_index",
+ "numeric_range_tree",
+ "numeric_score_source",
+ "redis-module",
+ "redis_mock",
+ "redisearch_rs",
+ "rqe_core",
+ "rqe_iterators",
+ "rqe_iterators_test_utils",
+ "workspace_hack",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -54,6 +54,7 @@ members = [
     "vector_score_source",
     "vector_score_source_bencher",
     "numeric_score_source",
+    "numeric_score_source_bencher",
     "trie_rs",
     "ttl_table",
     "utf8parse",

--- a/src/redisearch_rs/numeric_score_source_bencher/Cargo.toml
+++ b/src/redisearch_rs/numeric_score_source_bencher/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "numeric_score_source_bencher"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+# See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false
+
+# Rust NumericTopKIterator vs the real C OptimizerIterator (apples-to-apples).
+[[bench]]
+name = "numeric_top_k_optimizer"
+harness = false
+
+[build-dependencies]
+build_utils = { path = "../build_utils" }
+cc.workspace = true
+
+[dependencies]
+criterion.workspace = true
+ffi.workspace = true
+index_result.workspace = true
+inverted_index.workspace = true
+numeric_range_tree.workspace = true
+numeric_score_source = { path = "../numeric_score_source" }
+redis-module.workspace = true
+redis_mock.workspace = true
+rqe_core.workspace = true
+rqe_iterators = { workspace = true }
+rqe_iterators_test_utils.workspace = true
+workspace_hack.workspace = true
+# Crate required to invoke C symbols and keep Rust-defined FFI symbols alive.
+redisearch_rs = { path = "../c_entrypoint/redisearch_rs", features = [
+    "mock_allocator",
+] }

--- a/src/redisearch_rs/numeric_score_source_bencher/Cargo.toml
+++ b/src/redisearch_rs/numeric_score_source_bencher/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "numeric_score_source_bencher"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+# See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false
+
+# Rust NumericTopKIterator vs the real C OptimizerIterator (apples-to-apples).
+[[bench]]
+name = "numeric_top_k_optimizer"
+harness = false
+
+[build-dependencies]
+build_utils = { path = "../build_utils" }
+cc.workspace = true
+
+[dependencies]
+criterion.workspace = true
+ffi.workspace = true
+index_result.workspace = true
+inverted_index.workspace = true
+numeric_range_tree.workspace = true
+numeric_score_source = { path = "../numeric_score_source" }
+redis_mock.workspace = true
+rqe_core.workspace = true
+rqe_iterators = { workspace = true }
+rqe_iterators_test_utils.workspace = true
+workspace_hack.workspace = true
+# Crate required to invoke C symbols and keep Rust-defined FFI symbols alive.
+redisearch_rs = { path = "../c_entrypoint/redisearch_rs", features = [
+    "mock_allocator",
+] }

--- a/src/redisearch_rs/numeric_score_source_bencher/benches/numeric_top_k_optimizer.rs
+++ b/src/redisearch_rs/numeric_score_source_bencher/benches/numeric_top_k_optimizer.rs
@@ -20,13 +20,16 @@
 //!   iterators nor the Rust source, on its default `NoTimeoutChecker`, polls
 //!   one, so no timeout bookkeeping is priced into either arm.
 //!
-//! Three groups × two sides (rust / c):
+//! Four groups × two sides (rust / c):
 //!
 //! - `numeric_top_k/filtered`    — sorted-id child passing a tenth of the index.
 //! - `numeric_top_k/unfiltered`  — no child filter on the Rust side, the child
 //!   the C planner uses for a bare `SORTBY` (a wildcard) on the C side.
 //! - `numeric_top_k/selectivity` — child selectivity swept at a fixed index size
 //!   and `k`, across the range where the retry expansion starts to bite.
+//! - `numeric_top_k/expensive_child` — the same sweep with the ids behind a
+//!   union of eight id lists, so that reading, skipping and rewinding the child
+//!   costs what a real filter subtree costs.
 //!
 //! Known asymmetries:
 //!
@@ -61,7 +64,7 @@ use numeric_score_source::{
     NumericScoreSource, new_numeric_top_k_filtered, new_numeric_top_k_unfiltered,
 };
 use rqe_core::DocId;
-use rqe_iterators::{IdList, RQEIterator};
+use rqe_iterators::{IdList, RQEIterator, UnionQuickFlat};
 use rqe_iterators_test_utils::TestContext;
 
 /// Sort direction both sides run in (`SORTBY <field> ASC`).
@@ -78,12 +81,14 @@ const FIELD: &CStr = c"num_field";
 unsafe extern "C" {
     /// Drive the real C `OptimizerIterator` over a child filter and count
     /// results. A null `ids` selects a wildcard child over doc ids
-    /// `1..=child_count`, otherwise the ids are taken as a sorted-id child.
+    /// `1..=child_count`, otherwise the ids are taken as a sorted-id child —
+    /// spread over a union of `union_arity` such lists when that exceeds 1.
     fn bench_c_optimizer(
         sctx: *mut RedisSearchCtx,
         field_name: *const c_char,
         ids: *mut DocId,
         child_count: usize,
+        union_arity: usize,
         k: usize,
         ascending: c_int,
     ) -> usize;
@@ -178,7 +183,10 @@ impl Index {
 }
 
 /// Run one Rust top-k scan against the given child ids, returning result count.
-fn run_rust_filtered(index: &Index, ids: &[DocId], k: NonZeroUsize) -> usize {
+///
+/// `union_arity` above 1 spreads the ids over that many id lists behind a union,
+/// making every child read, skip and rewind cost more than a single list would.
+fn run_rust_filtered(index: &Index, ids: &[DocId], union_arity: usize, k: NonZeroUsize) -> usize {
     let child_estimate = ids.len();
     let filter = NumericFilter {
         limit: estimate_limit(index.n, child_estimate, k.get()),
@@ -192,14 +200,35 @@ fn run_rust_filtered(index: &Index, ids: &[DocId], k: NonZeroUsize) -> usize {
         index.n,
         child_estimate,
     );
-    // Fresh owned copy each call, mirroring the C side's per-run id allocation.
-    let child = IdList::<true>::new(ids.to_vec());
-    let mut it = new_numeric_top_k_filtered(source, child, k);
+    // Fresh owned copies each call, mirroring the C side's per-run allocation.
     let mut count = 0usize;
-    while it.read().unwrap().is_some() {
-        count += 1;
+    if union_arity > 1 {
+        let child = UnionQuickFlat::new(partition_ids(ids, union_arity));
+        let mut it = new_numeric_top_k_filtered(source, child, k);
+        while it.read().unwrap().is_some() {
+            count += 1;
+        }
+    } else {
+        let child = IdList::<true>::new(ids.to_vec());
+        let mut it = new_numeric_top_k_filtered(source, child, k);
+        while it.read().unwrap().is_some() {
+            count += 1;
+        }
     }
     count
+}
+
+/// Spread `ids` round-robin over `arity` sorted id lists.
+///
+/// Every list then holds ids from across the whole doc-id space, so each step of
+/// the union over them interleaves the lists rather than draining one at a time.
+fn partition_ids(ids: &[DocId], arity: usize) -> Vec<IdList<'static, true>> {
+    (0..arity)
+        .map(|slot| {
+            let part: Vec<DocId> = ids.iter().skip(slot).step_by(arity).copied().collect();
+            IdList::new(part)
+        })
+        .collect()
 }
 
 /// Run one Rust top-k scan with no child filter, returning result count.
@@ -215,7 +244,7 @@ fn run_rust_unfiltered(index: &Index, k: NonZeroUsize) -> usize {
 
 /// Run one C OptimizerIterator scan to depletion, returning result count.
 /// `ids` of `None` selects the wildcard child, matching the Rust unfiltered run.
-fn run_c(index: &Index, ids: Option<&[DocId]>, k: NonZeroUsize) -> usize {
+fn run_c(index: &Index, ids: Option<&[DocId]>, union_arity: usize, k: NonZeroUsize) -> usize {
     // Fresh owned copy each call: the child iterator frees it via RedisModule_Free.
     let (ids_ptr, child_count) = match ids {
         Some(ids) => (alloc_owned_ids(ids), ids.len()),
@@ -230,6 +259,7 @@ fn run_c(index: &Index, ids: Option<&[DocId]>, k: NonZeroUsize) -> usize {
             FIELD.as_ptr(),
             ids_ptr,
             child_count,
+            union_arity,
             k.get(),
             ASCENDING as c_int,
         )
@@ -239,11 +269,11 @@ fn run_c(index: &Index, ids: Option<&[DocId]>, k: NonZeroUsize) -> usize {
 /// Validate that both sides produce the expected result count before the timed
 /// loop starts. Catches iterator bugs, shim error paths, and index setup
 /// mistakes that would otherwise silently corrupt the Rust/C timing comparison.
-fn preflight(index: &Index, ids: Option<&[DocId]>, k: NonZeroUsize) {
+fn preflight(index: &Index, ids: Option<&[DocId]>, union_arity: usize, k: NonZeroUsize) {
     let expected = k.get().min(ids.map_or(index.n, <[DocId]>::len));
 
     let rust_count = match ids {
-        Some(ids) => run_rust_filtered(index, ids, k),
+        Some(ids) => run_rust_filtered(index, ids, union_arity, k),
         None => run_rust_unfiltered(index, k),
     };
     assert_eq!(
@@ -255,7 +285,7 @@ fn preflight(index: &Index, ids: Option<&[DocId]>, k: NonZeroUsize) {
         child = ids.map(<[DocId]>::len),
     );
 
-    let c_count = run_c(index, ids, k);
+    let c_count = run_c(index, ids, union_arity, k);
     assert_eq!(
         c_count,
         expected,
@@ -278,14 +308,14 @@ fn bench_filtered(c: &mut Criterion) {
             let ids = child_ids(n, (n / 10).max(k.get()));
             let param_str = format!("n{n}_k{k}");
 
-            preflight(&index, Some(&ids), k);
+            preflight(&index, Some(&ids), 1, k);
 
             group.bench_with_input(BenchmarkId::new("rust", &param_str), &(n, k), |b, _| {
-                b.iter(|| black_box(run_rust_filtered(&index, &ids, k)))
+                b.iter(|| black_box(run_rust_filtered(&index, &ids, 1, k)))
             });
 
             group.bench_with_input(BenchmarkId::new("c", &param_str), &(n, k), |b, _| {
-                b.iter(|| black_box(run_c(&index, Some(&ids), k)))
+                b.iter(|| black_box(run_c(&index, Some(&ids), 1, k)))
             });
         }
     }
@@ -304,14 +334,14 @@ fn bench_unfiltered(c: &mut Criterion) {
         for k in [10usize, 100].map(|k| NonZeroUsize::new(k).unwrap()) {
             let param_str = format!("n{n}_k{k}");
 
-            preflight(&index, None, k);
+            preflight(&index, None, 1, k);
 
             group.bench_with_input(BenchmarkId::new("rust", &param_str), &(n, k), |b, _| {
                 b.iter(|| black_box(run_rust_unfiltered(&index, k)))
             });
 
             group.bench_with_input(BenchmarkId::new("c", &param_str), &(n, k), |b, _| {
-                b.iter(|| black_box(run_c(&index, None, k)))
+                b.iter(|| black_box(run_c(&index, None, 1, k)))
             });
         }
     }
@@ -355,19 +385,62 @@ fn bench_selectivity(c: &mut Criterion) {
     for case in SELECTIVITY_CASES {
         let ids = child_ids(N, case.child_count);
 
-        preflight(&index, Some(&ids), k);
+        preflight(&index, Some(&ids), 1, k);
 
         group.bench_with_input(BenchmarkId::new("rust", case.label), &(), |b, _| {
-            b.iter(|| black_box(run_rust_filtered(&index, &ids, k)));
+            b.iter(|| black_box(run_rust_filtered(&index, &ids, 1, k)));
         });
 
         group.bench_with_input(BenchmarkId::new("c", case.label), &(), |b, _| {
-            b.iter(|| black_box(run_c(&index, Some(&ids), k)));
+            b.iter(|| black_box(run_c(&index, Some(&ids), 1, k)));
         });
     }
 
     group.finish();
 }
 
-criterion_group!(benches, bench_filtered, bench_unfiltered, bench_selectivity);
+// ── Expensive child ──────────────────────────────────────────────────────────
+//
+// The same selectivities as above, but with the ids spread over a union of eight
+// id lists instead of one. Every child read, skip and rewind now costs a pass
+// over eight sub-iterators, which is what a real text filter subtree looks like.
+//
+// Both sides walk this child; only the Rust side walks it twice, once to prune
+// the batch during materialization and once to intersect it. This group is what
+// prices that second walk.
+
+/// Number of id lists the expensive child's union spans.
+const UNION_ARITY: usize = 8;
+
+fn bench_expensive_child(c: &mut Criterion) {
+    let mut group = c.benchmark_group("numeric_top_k/expensive_child");
+
+    const N: usize = 100_000;
+    let k = NonZeroUsize::new(100).unwrap();
+    let index = Index::new(N);
+
+    for case in SELECTIVITY_CASES {
+        let ids = child_ids(N, case.child_count);
+
+        preflight(&index, Some(&ids), UNION_ARITY, k);
+
+        group.bench_with_input(BenchmarkId::new("rust", case.label), &(), |b, _| {
+            b.iter(|| black_box(run_rust_filtered(&index, &ids, UNION_ARITY, k)));
+        });
+
+        group.bench_with_input(BenchmarkId::new("c", case.label), &(), |b, _| {
+            b.iter(|| black_box(run_c(&index, Some(&ids), UNION_ARITY, k)));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_filtered,
+    bench_unfiltered,
+    bench_selectivity,
+    bench_expensive_child
+);
 criterion_main!(benches);

--- a/src/redisearch_rs/numeric_score_source_bencher/benches/numeric_top_k_optimizer.rs
+++ b/src/redisearch_rs/numeric_score_source_bencher/benches/numeric_top_k_optimizer.rs
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Apples-to-apples numeric top-k benchmark: Rust `NumericTopKIterator` vs the
+//! *real* C `OptimizerIterator` (`iterators/optimizer_reader.c`).
+//!
+//! Both sides:
+//! - read the same numeric range tree, doc table and search context, built once
+//!   per index size by `TestContext::numeric`,
+//! - walk the field's ranges in value order under an `offset`/`limit` window,
+//!   widening it when the window drains before the heap is full,
+//! - maintain a real bounded top-k heap over the same child filter,
+//! - run without a query deadline: neither the optimizer and its child
+//!   iterators nor the Rust source, on its default `NoTimeoutChecker`, polls
+//!   one, so no timeout bookkeeping is priced into either arm.
+//!
+//! Three groups × two sides (rust / c):
+//!
+//! - `numeric_top_k/filtered`    — sorted-id child passing a tenth of the index.
+//! - `numeric_top_k/unfiltered`  — no child filter on the Rust side, the child
+//!   the C planner uses for a bare `SORTBY` (a wildcard) on the C side.
+//! - `numeric_top_k/selectivity` — child selectivity swept at a fixed index size
+//!   and `k`, across the range where the retry expansion starts to bite.
+//!
+//! Known asymmetries:
+//!
+//! - Window sizing dominates the unfiltered group. The C optimizer always sizes
+//!   its first window from the child's selectivity, so a wildcard child bounds it
+//!   at roughly `k` documents; the Rust unfiltered source reads an unbounded
+//!   window and can only stop on a batch boundary, so it materializes
+//!   [`RANGE_BATCH_SIZE`] whole ranges before the full heap lets it stop.
+//! - The C side has no unfiltered mode: `Q_OPT_PARTIAL_RANGE` still drives the
+//!   optimizer through a wildcard child, one `Read` plus one doc-table borrow per
+//!   candidate that the Rust source skips entirely.
+//! - The C side drops candidates whose document metadata is gone; the Rust source
+//!   is benchmarked with the default `AllValid` oracle, which performs no
+//!   per-document validity check.
+
+// Pull in the lib to ensure FFI stubs and mock allocator symbols are linked.
+use numeric_score_source_bencher as _;
+
+use std::{
+    ffi::{CStr, c_char, c_int},
+    hint::black_box,
+    num::NonZeroUsize,
+    ptr,
+};
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use ffi::RedisSearchCtx;
+use index_result::RSIndexResult;
+use inverted_index::NumericFilter;
+use numeric_range_tree::{NumericRangeTree, RangeWindow};
+use numeric_score_source::{
+    NumericScoreSource, new_numeric_top_k_filtered, new_numeric_top_k_unfiltered,
+};
+use redis_module::RedisModule_Alloc;
+use rqe_core::DocId;
+use rqe_iterators::{IdList, RQEIterator};
+use rqe_iterators_test_utils::TestContext;
+
+/// Sort direction both sides run in (`SORTBY <field> ASC`).
+const ASCENDING: bool = true;
+
+/// Ranges materialized per batch, matching the source's own default.
+const RANGE_BATCH_SIZE: usize = 8;
+
+/// Numeric field of the schema `TestContext::numeric` creates.
+const FIELD: &CStr = c"num_field";
+
+// ── C shim (from optimizer_shim.c, compiled by build.rs) ─────────────────────
+
+unsafe extern "C" {
+    /// Drive the real C `OptimizerIterator` over a child filter and count
+    /// results. A null `ids` selects a wildcard child over doc ids
+    /// `1..=child_count`, otherwise the ids are taken as a sorted-id child.
+    fn bench_c_optimizer(
+        sctx: *mut RedisSearchCtx,
+        field_name: *const c_char,
+        ids: *mut DocId,
+        child_count: usize,
+        k: usize,
+        ascending: c_int,
+    ) -> usize;
+}
+
+/// Allocate a `RedisModule_Alloc`-owned copy of `ids`, so the child iterator's
+/// `OwnedSlice` can free it via the matching `RedisModule_Free` (same mock
+/// allocator pair). Ownership is transferred to `bench_c_optimizer`.
+fn alloc_owned_ids(ids: &[DocId]) -> *mut DocId {
+    // SAFETY: the mock allocator is installed once, by linking redis_mock, and
+    // never reassigned.
+    let alloc = unsafe { RedisModule_Alloc }.expect("mock allocator not initialised");
+    // SAFETY: `alloc` returns a fresh allocation of the requested size.
+    let ptr = unsafe { alloc(std::mem::size_of_val(ids)) }.cast::<DocId>();
+    // SAFETY: `ptr` is a fresh allocation sized for `ids.len()` doc ids, and
+    // cannot overlap `ids`.
+    unsafe { ptr::copy_nonoverlapping(ids.as_ptr(), ptr, ids.len()) };
+    ptr
+}
+
+/// Whole-field filter: matches every value.
+///
+/// `NumericFilter::default()` bounds the window at `0.0..f64::MAX`; the `±inf`
+/// bounds here match the whole-field span the optimizer sorts over.
+fn full_range() -> NumericFilter {
+    NumericFilter {
+        min: f64::NEG_INFINITY,
+        max: f64::INFINITY,
+        ..NumericFilter::default()
+    }
+}
+
+/// Value indexed for `doc_id`, a permutation of `0..n` so that value order is
+/// uncorrelated with doc-id order — otherwise a value-ordered scan would walk
+/// the index in doc-id order and never exercise the intersection.
+const fn value_for(doc_id: DocId, n: usize) -> f64 {
+    (doc_id.wrapping_mul(2_654_435_761) % n as u64) as f64
+}
+
+/// Generate `count` sorted child ids drawn uniformly from `[1, n]`.
+fn child_ids(n: usize, count: usize) -> Vec<DocId> {
+    let step = (n / count).max(1);
+    (0..count).map(|i| (i * step + 1).min(n) as DocId).collect()
+}
+
+/// Window size to start from, given the child's selectivity: how many documents
+/// must be read in value order to expect `k` of them to pass the child. Both
+/// sides start from this estimate — the C optimizer computes it internally.
+fn estimate_limit(num_docs: usize, child_estimate: usize, k: usize) -> usize {
+    if num_docs == 0 || child_estimate == 0 {
+        return 0;
+    }
+    let ratio = child_estimate as f64 / num_docs as f64;
+    (k as f64 / ratio) as usize + 1
+}
+
+/// An index of `n` documents shared by both sides: a numeric range tree over
+/// [`value_for`], a doc table holding every indexed doc id, and the search
+/// context the C optimizer reads them through.
+struct Index {
+    ctx: TestContext,
+    n: usize,
+}
+
+impl Index {
+    fn new(n: usize) -> Self {
+        let records = (1..=n as DocId).map(|id| {
+            RSIndexResult::build_numeric(value_for(id, n))
+                .doc_id(id)
+                .build()
+        });
+        let ctx = TestContext::numeric(records, false);
+
+        // The C optimizer drops any candidate whose document metadata is
+        // missing, so every indexed doc id needs a doc table entry.
+        for i in 1..=n {
+            ctx.add_document(&format!("doc{i}"));
+        }
+
+        Self { ctx, n }
+    }
+
+    /// Borrow the numeric index. Kept short-lived: the C side re-derives its own
+    /// reference to the same tree through the field spec.
+    fn tree(&self) -> &NumericRangeTree {
+        self.ctx.numeric_range_tree_ref()
+    }
+
+    const fn sctx(&self) -> *mut RedisSearchCtx {
+        self.ctx.sctx.as_ptr()
+    }
+}
+
+/// Run one Rust top-k scan against the given child ids, returning result count.
+fn run_rust_filtered(index: &Index, ids: &[DocId], k: NonZeroUsize) -> usize {
+    let child_estimate = ids.len();
+    let window = RangeWindow {
+        offset: 0,
+        limit: estimate_limit(index.n, child_estimate, k.get()),
+    };
+    let source = NumericScoreSource::filtered(
+        index.tree(),
+        full_range(),
+        window,
+        ASCENDING,
+        RANGE_BATCH_SIZE,
+        index.n,
+        child_estimate,
+    );
+    // Fresh owned copy each call, mirroring the C side's per-run id allocation.
+    let child = IdList::<true>::new(ids.to_vec());
+    let mut it = new_numeric_top_k_filtered(source, child, k);
+    let mut count = 0usize;
+    while it.read().unwrap().is_some() {
+        count += 1;
+    }
+    count
+}
+
+/// Run one Rust top-k scan with no child filter, returning result count.
+fn run_rust_unfiltered(index: &Index, k: NonZeroUsize) -> usize {
+    let source = NumericScoreSource::unfiltered(index.tree(), full_range(), ASCENDING);
+    let mut it = new_numeric_top_k_unfiltered(source, k);
+    let mut count = 0usize;
+    while it.read().unwrap().is_some() {
+        count += 1;
+    }
+    count
+}
+
+/// Run one C OptimizerIterator scan to depletion, returning result count.
+/// `ids` of `None` selects the wildcard child, matching the Rust unfiltered run.
+fn run_c(index: &Index, ids: Option<&[DocId]>, k: NonZeroUsize) -> usize {
+    // Fresh owned copy each call: the child iterator frees it via RedisModule_Free.
+    let (ids_ptr, child_count) = match ids {
+        Some(ids) => (alloc_owned_ids(ids), ids.len()),
+        None => (ptr::null_mut(), index.n),
+    };
+    // SAFETY: the search context and its spec outlive the call; `ids_ptr` is
+    // either null or a sorted, owned array of `child_count` ids whose ownership
+    // transfers to the call. `FIELD` names a numeric field of the spec.
+    unsafe {
+        bench_c_optimizer(
+            index.sctx(),
+            FIELD.as_ptr(),
+            ids_ptr,
+            child_count,
+            k.get(),
+            ASCENDING as c_int,
+        )
+    }
+}
+
+/// Validate that both sides produce the expected result count before the timed
+/// loop starts. Catches iterator bugs, shim error paths, and index setup
+/// mistakes that would otherwise silently corrupt the Rust/C timing comparison.
+fn preflight(index: &Index, ids: Option<&[DocId]>, k: NonZeroUsize) {
+    let expected = k.get().min(ids.map_or(index.n, <[DocId]>::len));
+
+    let rust_count = match ids {
+        Some(ids) => run_rust_filtered(index, ids, k),
+        None => run_rust_unfiltered(index, k),
+    };
+    assert_eq!(
+        rust_count,
+        expected,
+        "Rust iterator produced {rust_count} results (expected {expected}) \
+         for k={k}, n={n}, child={child:?}",
+        n = index.n,
+        child = ids.map(<[DocId]>::len),
+    );
+
+    let c_count = run_c(index, ids, k);
+    assert_eq!(
+        c_count,
+        expected,
+        "C shim produced {c_count} results (expected {expected}) \
+         for k={k}, n={n}, child={child:?}",
+        n = index.n,
+        child = ids.map(<[DocId]>::len),
+    );
+}
+
+// ── Filtered ─────────────────────────────────────────────────────────────────
+
+fn bench_filtered(c: &mut Criterion) {
+    let mut group = c.benchmark_group("numeric_top_k/filtered");
+
+    for n in [10_000usize, 100_000] {
+        let index = Index::new(n);
+
+        for k in [10usize, 100].map(|k| NonZeroUsize::new(k).unwrap()) {
+            let ids = child_ids(n, (n / 10).max(k.get()));
+            let param_str = format!("n{n}_k{k}");
+
+            preflight(&index, Some(&ids), k);
+
+            group.bench_with_input(BenchmarkId::new("rust", &param_str), &(n, k), |b, _| {
+                b.iter(|| black_box(run_rust_filtered(&index, &ids, k)))
+            });
+
+            group.bench_with_input(BenchmarkId::new("c", &param_str), &(n, k), |b, _| {
+                b.iter(|| black_box(run_c(&index, Some(&ids), k)))
+            });
+        }
+    }
+
+    group.finish();
+}
+
+// ── Unfiltered ───────────────────────────────────────────────────────────────
+
+fn bench_unfiltered(c: &mut Criterion) {
+    let mut group = c.benchmark_group("numeric_top_k/unfiltered");
+
+    for n in [10_000usize, 100_000] {
+        let index = Index::new(n);
+
+        for k in [10usize, 100].map(|k| NonZeroUsize::new(k).unwrap()) {
+            let param_str = format!("n{n}_k{k}");
+
+            preflight(&index, None, k);
+
+            group.bench_with_input(BenchmarkId::new("rust", &param_str), &(n, k), |b, _| {
+                b.iter(|| black_box(run_rust_unfiltered(&index, k)))
+            });
+
+            group.bench_with_input(BenchmarkId::new("c", &param_str), &(n, k), |b, _| {
+                b.iter(|| black_box(run_c(&index, None, k)))
+            });
+        }
+    }
+
+    group.finish();
+}
+
+// ── Child selectivity ────────────────────────────────────────────────────────
+//
+// At a fixed index size and top-k, sweep how much of the index the child filter
+// passes. A tight filter forces the value-ordered window to be widened (and
+// re-read) before the heap fills; a loose one fills it from the first window.
+
+struct SelectivityCase {
+    label: &'static str,
+    child_count: usize,
+}
+
+const SELECTIVITY_CASES: &[SelectivityCase] = &[
+    SelectivityCase {
+        label: "sparse_1pct",
+        child_count: 1_000,
+    },
+    SelectivityCase {
+        label: "moderate_10pct",
+        child_count: 10_000,
+    },
+    SelectivityCase {
+        label: "loose_50pct",
+        child_count: 50_000,
+    },
+];
+
+fn bench_selectivity(c: &mut Criterion) {
+    let mut group = c.benchmark_group("numeric_top_k/selectivity");
+
+    const N: usize = 100_000;
+    let k = NonZeroUsize::new(100).unwrap();
+    let index = Index::new(N);
+
+    for case in SELECTIVITY_CASES {
+        let ids = child_ids(N, case.child_count);
+
+        preflight(&index, Some(&ids), k);
+
+        group.bench_with_input(BenchmarkId::new("rust", case.label), &(), |b, _| {
+            b.iter(|| black_box(run_rust_filtered(&index, &ids, k)));
+        });
+
+        group.bench_with_input(BenchmarkId::new("c", case.label), &(), |b, _| {
+            b.iter(|| black_box(run_c(&index, Some(&ids), k)));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_filtered, bench_unfiltered, bench_selectivity);
+criterion_main!(benches);

--- a/src/redisearch_rs/numeric_score_source_bencher/benches/numeric_top_k_optimizer.rs
+++ b/src/redisearch_rs/numeric_score_source_bencher/benches/numeric_top_k_optimizer.rs
@@ -63,7 +63,6 @@ use numeric_range_tree::{NumericRangeTree, RangeWindow};
 use numeric_score_source::{
     NumericScoreSource, new_numeric_top_k_filtered, new_numeric_top_k_unfiltered,
 };
-use redis_module::RedisModule_Alloc;
 use rqe_core::DocId;
 use rqe_iterators::{IdList, RQEIterator, UnionQuickFlat};
 use rqe_iterators_test_utils::TestContext;
@@ -84,30 +83,17 @@ unsafe extern "C" {
     /// results. A null `ids` selects a wildcard child over doc ids
     /// `1..=child_count`, otherwise the ids are taken as a sorted-id child —
     /// spread over a union of `union_arity` such lists when that exceeds 1.
+    ///
+    /// `ids` is borrowed for the call; the shim allocates each child's own list.
     fn bench_c_optimizer(
         sctx: *mut RedisSearchCtx,
         field_name: *const c_char,
-        ids: *mut DocId,
+        ids: *const DocId,
         child_count: usize,
         union_arity: usize,
         k: usize,
         ascending: c_int,
     ) -> usize;
-}
-
-/// Allocate a `RedisModule_Alloc`-owned copy of `ids`, so the child iterator's
-/// `OwnedSlice` can free it via the matching `RedisModule_Free` (same mock
-/// allocator pair). Ownership is transferred to `bench_c_optimizer`.
-fn alloc_owned_ids(ids: &[DocId]) -> *mut DocId {
-    // SAFETY: the mock allocator is installed once, by linking redis_mock, and
-    // never reassigned.
-    let alloc = unsafe { RedisModule_Alloc }.expect("mock allocator not initialised");
-    // SAFETY: `alloc` returns a fresh allocation of the requested size.
-    let ptr = unsafe { alloc(std::mem::size_of_val(ids)) }.cast::<DocId>();
-    // SAFETY: `ptr` is a fresh allocation sized for `ids.len()` doc ids, and
-    // cannot overlap `ids`.
-    unsafe { ptr::copy_nonoverlapping(ids.as_ptr(), ptr, ids.len()) };
-    ptr
 }
 
 /// Whole-field filter: matches every value.
@@ -247,14 +233,13 @@ fn run_rust_unfiltered(index: &Index, k: NonZeroUsize) -> usize {
 /// Run one C OptimizerIterator scan to depletion, returning result count.
 /// `ids` of `None` selects the wildcard child, matching the Rust unfiltered run.
 fn run_c(index: &Index, ids: Option<&[DocId]>, union_arity: usize, k: NonZeroUsize) -> usize {
-    // Fresh owned copy each call: the child iterator frees it via RedisModule_Free.
     let (ids_ptr, child_count) = match ids {
-        Some(ids) => (alloc_owned_ids(ids), ids.len()),
-        None => (ptr::null_mut(), index.n),
+        Some(ids) => (ids.as_ptr(), ids.len()),
+        None => (ptr::null(), index.n),
     };
     // SAFETY: the search context and its spec outlive the call; `ids_ptr` is
-    // either null or a sorted, owned array of `child_count` ids whose ownership
-    // transfers to the call. `FIELD` names a numeric field of the spec.
+    // either null or a sorted array of `child_count` ids, only read from for the
+    // duration of the call. `FIELD` names a numeric field of the spec.
     unsafe {
         bench_c_optimizer(
             index.sctx(),

--- a/src/redisearch_rs/numeric_score_source_bencher/benches/numeric_top_k_optimizer.rs
+++ b/src/redisearch_rs/numeric_score_source_bencher/benches/numeric_top_k_optimizer.rs
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Apples-to-apples numeric top-k benchmark: Rust `NumericTopKIterator` vs the
+//! *real* C `OptimizerIterator` (`iterators/optimizer_reader.c`).
+//!
+//! Both sides:
+//! - read the same numeric range tree, doc table and search context, built once
+//!   per index size by `TestContext::numeric`,
+//! - walk the field's ranges in value order under an `offset`/`limit` window,
+//!   widening it when the window drains before the heap is full,
+//! - maintain a real bounded top-k heap over the same child filter,
+//! - run without a query deadline: neither the optimizer and its child
+//!   iterators nor the Rust source, on its default `NoTimeoutChecker`, polls
+//!   one, so no timeout bookkeeping is priced into either arm.
+//!
+//! Three groups × two sides (rust / c):
+//!
+//! - `numeric_top_k/filtered`    — sorted-id child passing a tenth of the index.
+//! - `numeric_top_k/unfiltered`  — no child filter on the Rust side, the child
+//!   the C planner uses for a bare `SORTBY` (a wildcard) on the C side.
+//! - `numeric_top_k/selectivity` — child selectivity swept at a fixed index size
+//!   and `k`, across the range where the retry expansion starts to bite.
+//!
+//! Known asymmetries:
+//!
+//! - Window sizing dominates the unfiltered group. The C optimizer always sizes
+//!   its first window from the child's selectivity, so a wildcard child bounds it
+//!   at roughly `k` documents; the Rust unfiltered source reads an unbounded
+//!   window and can only stop on a batch boundary, so it materializes
+//!   [`RANGE_BATCH_SIZE`] whole ranges before the full heap lets it stop.
+//! - The C side has no unfiltered mode: `Q_OPT_PARTIAL_RANGE` still drives the
+//!   optimizer through a wildcard child, one `Read` plus one doc-table borrow per
+//!   candidate that the Rust source skips entirely.
+//! - The C side drops candidates whose document metadata is gone; the Rust source
+//!   is benchmarked with the default `AllValid` oracle, which performs no
+//!   per-document validity check.
+
+// Pull in the lib to ensure FFI stubs and mock allocator symbols are linked.
+use numeric_score_source_bencher as _;
+
+use std::{
+    ffi::{CStr, c_char, c_int},
+    hint::black_box,
+    num::NonZeroUsize,
+    ptr,
+};
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use ffi::{RedisModule_Alloc, RedisSearchCtx};
+use index_result::RSIndexResult;
+use inverted_index::NumericFilter;
+use numeric_range_tree::NumericRangeTree;
+use numeric_score_source::{
+    NumericScoreSource, new_numeric_top_k_filtered, new_numeric_top_k_unfiltered,
+};
+use rqe_core::DocId;
+use rqe_iterators::{IdList, RQEIterator};
+use rqe_iterators_test_utils::TestContext;
+
+/// Sort direction both sides run in (`SORTBY <field> ASC`).
+const ASCENDING: bool = true;
+
+/// Ranges materialized per batch, matching the source's own default.
+const RANGE_BATCH_SIZE: usize = 8;
+
+/// Numeric field of the schema `TestContext::numeric` creates.
+const FIELD: &CStr = c"num_field";
+
+// ── C shim (from optimizer_shim.c, compiled by build.rs) ─────────────────────
+
+unsafe extern "C" {
+    /// Drive the real C `OptimizerIterator` over a child filter and count
+    /// results. A null `ids` selects a wildcard child over doc ids
+    /// `1..=child_count`, otherwise the ids are taken as a sorted-id child.
+    fn bench_c_optimizer(
+        sctx: *mut RedisSearchCtx,
+        field_name: *const c_char,
+        ids: *mut DocId,
+        child_count: usize,
+        k: usize,
+        ascending: c_int,
+    ) -> usize;
+}
+
+/// Allocate a `RedisModule_Alloc`-owned copy of `ids`, so the child iterator's
+/// `OwnedSlice` can free it via the matching `RedisModule_Free` (same mock
+/// allocator pair). Ownership is transferred to `bench_c_optimizer`.
+fn alloc_owned_ids(ids: &[DocId]) -> *mut DocId {
+    // SAFETY: the mock allocator is installed once, by linking redis_mock, and
+    // never reassigned.
+    let alloc = unsafe { RedisModule_Alloc }.expect("mock allocator not initialised");
+    // SAFETY: `alloc` returns a fresh allocation of the requested size.
+    let ptr = unsafe { alloc(std::mem::size_of_val(ids)) }.cast::<DocId>();
+    // SAFETY: `ptr` is a fresh allocation sized for `ids.len()` doc ids, and
+    // cannot overlap `ids`.
+    unsafe { ptr::copy_nonoverlapping(ids.as_ptr(), ptr, ids.len()) };
+    ptr
+}
+
+/// Whole-field filter: matches every value.
+///
+/// `NumericFilter::default()` bounds the window at `0.0..f64::MAX`; the `±inf`
+/// bounds here match the whole-field span the optimizer sorts over.
+fn full_range() -> NumericFilter {
+    NumericFilter {
+        min: f64::NEG_INFINITY,
+        max: f64::INFINITY,
+        ..NumericFilter::default()
+    }
+}
+
+/// Value indexed for `doc_id`, a permutation of `0..n` so that value order is
+/// uncorrelated with doc-id order — otherwise a value-ordered scan would walk
+/// the index in doc-id order and never exercise the intersection.
+const fn value_for(doc_id: DocId, n: usize) -> f64 {
+    (doc_id.wrapping_mul(2_654_435_761) % n as u64) as f64
+}
+
+/// Generate `count` sorted child ids drawn uniformly from `[1, n]`.
+fn child_ids(n: usize, count: usize) -> Vec<DocId> {
+    let step = (n / count).max(1);
+    (0..count).map(|i| (i * step + 1).min(n) as DocId).collect()
+}
+
+/// Window size to start from, given the child's selectivity: how many documents
+/// must be read in value order to expect `k` of them to pass the child. Both
+/// sides start from this estimate — the C optimizer computes it internally.
+fn estimate_limit(num_docs: usize, child_estimate: usize, k: usize) -> usize {
+    if num_docs == 0 || child_estimate == 0 {
+        return 0;
+    }
+    let ratio = child_estimate as f64 / num_docs as f64;
+    (k as f64 / ratio) as usize + 1
+}
+
+/// An index of `n` documents shared by both sides: a numeric range tree over
+/// [`value_for`], a doc table holding every indexed doc id, and the search
+/// context the C optimizer reads them through.
+struct Index {
+    ctx: TestContext,
+    n: usize,
+}
+
+impl Index {
+    fn new(n: usize) -> Self {
+        let records = (1..=n as DocId).map(|id| {
+            RSIndexResult::build_numeric(value_for(id, n))
+                .doc_id(id)
+                .build()
+        });
+        let ctx = TestContext::numeric(records, false);
+
+        // The C optimizer drops any candidate whose document metadata is
+        // missing, so every indexed doc id needs a doc table entry.
+        for i in 1..=n {
+            ctx.add_document(&format!("doc{i}"));
+        }
+
+        Self { ctx, n }
+    }
+
+    /// Borrow the numeric index. Kept short-lived: the C side re-derives its own
+    /// reference to the same tree through the field spec.
+    fn tree(&self) -> &NumericRangeTree {
+        self.ctx.numeric_range_tree_ref()
+    }
+
+    const fn sctx(&self) -> *mut RedisSearchCtx {
+        self.ctx.sctx.as_ptr()
+    }
+}
+
+/// Run one Rust top-k scan against the given child ids, returning result count.
+fn run_rust_filtered(index: &Index, ids: &[DocId], k: NonZeroUsize) -> usize {
+    let child_estimate = ids.len();
+    let filter = NumericFilter {
+        limit: estimate_limit(index.n, child_estimate, k.get()),
+        ..full_range()
+    };
+    let source = NumericScoreSource::filtered(
+        index.tree(),
+        filter,
+        ASCENDING,
+        RANGE_BATCH_SIZE,
+        index.n,
+        child_estimate,
+    );
+    // Fresh owned copy each call, mirroring the C side's per-run id allocation.
+    let child = IdList::<true>::new(ids.to_vec());
+    let mut it = new_numeric_top_k_filtered(source, child, k);
+    let mut count = 0usize;
+    while it.read().unwrap().is_some() {
+        count += 1;
+    }
+    count
+}
+
+/// Run one Rust top-k scan with no child filter, returning result count.
+fn run_rust_unfiltered(index: &Index, k: NonZeroUsize) -> usize {
+    let source = NumericScoreSource::unfiltered(index.tree(), full_range(), ASCENDING);
+    let mut it = new_numeric_top_k_unfiltered(source, k);
+    let mut count = 0usize;
+    while it.read().unwrap().is_some() {
+        count += 1;
+    }
+    count
+}
+
+/// Run one C OptimizerIterator scan to depletion, returning result count.
+/// `ids` of `None` selects the wildcard child, matching the Rust unfiltered run.
+fn run_c(index: &Index, ids: Option<&[DocId]>, k: NonZeroUsize) -> usize {
+    // Fresh owned copy each call: the child iterator frees it via RedisModule_Free.
+    let (ids_ptr, child_count) = match ids {
+        Some(ids) => (alloc_owned_ids(ids), ids.len()),
+        None => (ptr::null_mut(), index.n),
+    };
+    // SAFETY: the search context and its spec outlive the call; `ids_ptr` is
+    // either null or a sorted, owned array of `child_count` ids whose ownership
+    // transfers to the call. `FIELD` names a numeric field of the spec.
+    unsafe {
+        bench_c_optimizer(
+            index.sctx(),
+            FIELD.as_ptr(),
+            ids_ptr,
+            child_count,
+            k.get(),
+            ASCENDING as c_int,
+        )
+    }
+}
+
+/// Validate that both sides produce the expected result count before the timed
+/// loop starts. Catches iterator bugs, shim error paths, and index setup
+/// mistakes that would otherwise silently corrupt the Rust/C timing comparison.
+fn preflight(index: &Index, ids: Option<&[DocId]>, k: NonZeroUsize) {
+    let expected = k.get().min(ids.map_or(index.n, <[DocId]>::len));
+
+    let rust_count = match ids {
+        Some(ids) => run_rust_filtered(index, ids, k),
+        None => run_rust_unfiltered(index, k),
+    };
+    assert_eq!(
+        rust_count,
+        expected,
+        "Rust iterator produced {rust_count} results (expected {expected}) \
+         for k={k}, n={n}, child={child:?}",
+        n = index.n,
+        child = ids.map(<[DocId]>::len),
+    );
+
+    let c_count = run_c(index, ids, k);
+    assert_eq!(
+        c_count,
+        expected,
+        "C shim produced {c_count} results (expected {expected}) \
+         for k={k}, n={n}, child={child:?}",
+        n = index.n,
+        child = ids.map(<[DocId]>::len),
+    );
+}
+
+// ── Filtered ─────────────────────────────────────────────────────────────────
+
+fn bench_filtered(c: &mut Criterion) {
+    let mut group = c.benchmark_group("numeric_top_k/filtered");
+
+    for n in [10_000usize, 100_000] {
+        let index = Index::new(n);
+
+        for k in [10usize, 100].map(|k| NonZeroUsize::new(k).unwrap()) {
+            let ids = child_ids(n, (n / 10).max(k.get()));
+            let param_str = format!("n{n}_k{k}");
+
+            preflight(&index, Some(&ids), k);
+
+            group.bench_with_input(BenchmarkId::new("rust", &param_str), &(n, k), |b, _| {
+                b.iter(|| black_box(run_rust_filtered(&index, &ids, k)))
+            });
+
+            group.bench_with_input(BenchmarkId::new("c", &param_str), &(n, k), |b, _| {
+                b.iter(|| black_box(run_c(&index, Some(&ids), k)))
+            });
+        }
+    }
+
+    group.finish();
+}
+
+// ── Unfiltered ───────────────────────────────────────────────────────────────
+
+fn bench_unfiltered(c: &mut Criterion) {
+    let mut group = c.benchmark_group("numeric_top_k/unfiltered");
+
+    for n in [10_000usize, 100_000] {
+        let index = Index::new(n);
+
+        for k in [10usize, 100].map(|k| NonZeroUsize::new(k).unwrap()) {
+            let param_str = format!("n{n}_k{k}");
+
+            preflight(&index, None, k);
+
+            group.bench_with_input(BenchmarkId::new("rust", &param_str), &(n, k), |b, _| {
+                b.iter(|| black_box(run_rust_unfiltered(&index, k)))
+            });
+
+            group.bench_with_input(BenchmarkId::new("c", &param_str), &(n, k), |b, _| {
+                b.iter(|| black_box(run_c(&index, None, k)))
+            });
+        }
+    }
+
+    group.finish();
+}
+
+// ── Child selectivity ────────────────────────────────────────────────────────
+//
+// At a fixed index size and top-k, sweep how much of the index the child filter
+// passes. A tight filter forces the value-ordered window to be widened (and
+// re-read) before the heap fills; a loose one fills it from the first window.
+
+struct SelectivityCase {
+    label: &'static str,
+    child_count: usize,
+}
+
+const SELECTIVITY_CASES: &[SelectivityCase] = &[
+    SelectivityCase {
+        label: "sparse_1pct",
+        child_count: 1_000,
+    },
+    SelectivityCase {
+        label: "moderate_10pct",
+        child_count: 10_000,
+    },
+    SelectivityCase {
+        label: "loose_50pct",
+        child_count: 50_000,
+    },
+];
+
+fn bench_selectivity(c: &mut Criterion) {
+    let mut group = c.benchmark_group("numeric_top_k/selectivity");
+
+    const N: usize = 100_000;
+    let k = NonZeroUsize::new(100).unwrap();
+    let index = Index::new(N);
+
+    for case in SELECTIVITY_CASES {
+        let ids = child_ids(N, case.child_count);
+
+        preflight(&index, Some(&ids), k);
+
+        group.bench_with_input(BenchmarkId::new("rust", case.label), &(), |b, _| {
+            b.iter(|| black_box(run_rust_filtered(&index, &ids, k)));
+        });
+
+        group.bench_with_input(BenchmarkId::new("c", case.label), &(), |b, _| {
+            b.iter(|| black_box(run_c(&index, Some(&ids), k)));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_filtered, bench_unfiltered, bench_selectivity);
+criterion_main!(benches);

--- a/src/redisearch_rs/numeric_score_source_bencher/benches/numeric_top_k_optimizer.rs
+++ b/src/redisearch_rs/numeric_score_source_bencher/benches/numeric_top_k_optimizer.rs
@@ -20,13 +20,16 @@
 //!   iterators nor the Rust source, on its default `NoTimeoutChecker`, polls
 //!   one, so no timeout bookkeeping is priced into either arm.
 //!
-//! Three groups × two sides (rust / c):
+//! Four groups × two sides (rust / c):
 //!
 //! - `numeric_top_k/filtered`    — sorted-id child passing a tenth of the index.
 //! - `numeric_top_k/unfiltered`  — no child filter on the Rust side, the child
 //!   the C planner uses for a bare `SORTBY` (a wildcard) on the C side.
 //! - `numeric_top_k/selectivity` — child selectivity swept at a fixed index size
 //!   and `k`, across the range where the retry expansion starts to bite.
+//! - `numeric_top_k/expensive_child` — the same sweep with the ids behind a
+//!   union of eight id lists, so that reading, skipping and rewinding the child
+//!   costs what a real filter subtree costs.
 //!
 //! Known asymmetries:
 //!
@@ -62,7 +65,7 @@ use numeric_score_source::{
 };
 use redis_module::RedisModule_Alloc;
 use rqe_core::DocId;
-use rqe_iterators::{IdList, RQEIterator};
+use rqe_iterators::{IdList, RQEIterator, UnionQuickFlat};
 use rqe_iterators_test_utils::TestContext;
 
 /// Sort direction both sides run in (`SORTBY <field> ASC`).
@@ -79,12 +82,14 @@ const FIELD: &CStr = c"num_field";
 unsafe extern "C" {
     /// Drive the real C `OptimizerIterator` over a child filter and count
     /// results. A null `ids` selects a wildcard child over doc ids
-    /// `1..=child_count`, otherwise the ids are taken as a sorted-id child.
+    /// `1..=child_count`, otherwise the ids are taken as a sorted-id child —
+    /// spread over a union of `union_arity` such lists when that exceeds 1.
     fn bench_c_optimizer(
         sctx: *mut RedisSearchCtx,
         field_name: *const c_char,
         ids: *mut DocId,
         child_count: usize,
+        union_arity: usize,
         k: usize,
         ascending: c_int,
     ) -> usize;
@@ -179,7 +184,10 @@ impl Index {
 }
 
 /// Run one Rust top-k scan against the given child ids, returning result count.
-fn run_rust_filtered(index: &Index, ids: &[DocId], k: NonZeroUsize) -> usize {
+///
+/// `union_arity` above 1 spreads the ids over that many id lists behind a union,
+/// making every child read, skip and rewind cost more than a single list would.
+fn run_rust_filtered(index: &Index, ids: &[DocId], union_arity: usize, k: NonZeroUsize) -> usize {
     let child_estimate = ids.len();
     let window = RangeWindow {
         offset: 0,
@@ -194,14 +202,35 @@ fn run_rust_filtered(index: &Index, ids: &[DocId], k: NonZeroUsize) -> usize {
         index.n,
         child_estimate,
     );
-    // Fresh owned copy each call, mirroring the C side's per-run id allocation.
-    let child = IdList::<true>::new(ids.to_vec());
-    let mut it = new_numeric_top_k_filtered(source, child, k);
+    // Fresh owned copies each call, mirroring the C side's per-run allocation.
     let mut count = 0usize;
-    while it.read().unwrap().is_some() {
-        count += 1;
+    if union_arity > 1 {
+        let child = UnionQuickFlat::new(partition_ids(ids, union_arity));
+        let mut it = new_numeric_top_k_filtered(source, child, k);
+        while it.read().unwrap().is_some() {
+            count += 1;
+        }
+    } else {
+        let child = IdList::<true>::new(ids.to_vec());
+        let mut it = new_numeric_top_k_filtered(source, child, k);
+        while it.read().unwrap().is_some() {
+            count += 1;
+        }
     }
     count
+}
+
+/// Spread `ids` round-robin over `arity` sorted id lists.
+///
+/// Every list then holds ids from across the whole doc-id space, so each step of
+/// the union over them interleaves the lists rather than draining one at a time.
+fn partition_ids(ids: &[DocId], arity: usize) -> Vec<IdList<'static, true>> {
+    (0..arity)
+        .map(|slot| {
+            let part: Vec<DocId> = ids.iter().skip(slot).step_by(arity).copied().collect();
+            IdList::new(part)
+        })
+        .collect()
 }
 
 /// Run one Rust top-k scan with no child filter, returning result count.
@@ -217,7 +246,7 @@ fn run_rust_unfiltered(index: &Index, k: NonZeroUsize) -> usize {
 
 /// Run one C OptimizerIterator scan to depletion, returning result count.
 /// `ids` of `None` selects the wildcard child, matching the Rust unfiltered run.
-fn run_c(index: &Index, ids: Option<&[DocId]>, k: NonZeroUsize) -> usize {
+fn run_c(index: &Index, ids: Option<&[DocId]>, union_arity: usize, k: NonZeroUsize) -> usize {
     // Fresh owned copy each call: the child iterator frees it via RedisModule_Free.
     let (ids_ptr, child_count) = match ids {
         Some(ids) => (alloc_owned_ids(ids), ids.len()),
@@ -232,6 +261,7 @@ fn run_c(index: &Index, ids: Option<&[DocId]>, k: NonZeroUsize) -> usize {
             FIELD.as_ptr(),
             ids_ptr,
             child_count,
+            union_arity,
             k.get(),
             ASCENDING as c_int,
         )
@@ -241,11 +271,11 @@ fn run_c(index: &Index, ids: Option<&[DocId]>, k: NonZeroUsize) -> usize {
 /// Validate that both sides produce the expected result count before the timed
 /// loop starts. Catches iterator bugs, shim error paths, and index setup
 /// mistakes that would otherwise silently corrupt the Rust/C timing comparison.
-fn preflight(index: &Index, ids: Option<&[DocId]>, k: NonZeroUsize) {
+fn preflight(index: &Index, ids: Option<&[DocId]>, union_arity: usize, k: NonZeroUsize) {
     let expected = k.get().min(ids.map_or(index.n, <[DocId]>::len));
 
     let rust_count = match ids {
-        Some(ids) => run_rust_filtered(index, ids, k),
+        Some(ids) => run_rust_filtered(index, ids, union_arity, k),
         None => run_rust_unfiltered(index, k),
     };
     assert_eq!(
@@ -257,7 +287,7 @@ fn preflight(index: &Index, ids: Option<&[DocId]>, k: NonZeroUsize) {
         child = ids.map(<[DocId]>::len),
     );
 
-    let c_count = run_c(index, ids, k);
+    let c_count = run_c(index, ids, union_arity, k);
     assert_eq!(
         c_count,
         expected,
@@ -280,14 +310,14 @@ fn bench_filtered(c: &mut Criterion) {
             let ids = child_ids(n, (n / 10).max(k.get()));
             let param_str = format!("n{n}_k{k}");
 
-            preflight(&index, Some(&ids), k);
+            preflight(&index, Some(&ids), 1, k);
 
             group.bench_with_input(BenchmarkId::new("rust", &param_str), &(n, k), |b, _| {
-                b.iter(|| black_box(run_rust_filtered(&index, &ids, k)))
+                b.iter(|| black_box(run_rust_filtered(&index, &ids, 1, k)))
             });
 
             group.bench_with_input(BenchmarkId::new("c", &param_str), &(n, k), |b, _| {
-                b.iter(|| black_box(run_c(&index, Some(&ids), k)))
+                b.iter(|| black_box(run_c(&index, Some(&ids), 1, k)))
             });
         }
     }
@@ -306,14 +336,14 @@ fn bench_unfiltered(c: &mut Criterion) {
         for k in [10usize, 100].map(|k| NonZeroUsize::new(k).unwrap()) {
             let param_str = format!("n{n}_k{k}");
 
-            preflight(&index, None, k);
+            preflight(&index, None, 1, k);
 
             group.bench_with_input(BenchmarkId::new("rust", &param_str), &(n, k), |b, _| {
                 b.iter(|| black_box(run_rust_unfiltered(&index, k)))
             });
 
             group.bench_with_input(BenchmarkId::new("c", &param_str), &(n, k), |b, _| {
-                b.iter(|| black_box(run_c(&index, None, k)))
+                b.iter(|| black_box(run_c(&index, None, 1, k)))
             });
         }
     }
@@ -357,19 +387,62 @@ fn bench_selectivity(c: &mut Criterion) {
     for case in SELECTIVITY_CASES {
         let ids = child_ids(N, case.child_count);
 
-        preflight(&index, Some(&ids), k);
+        preflight(&index, Some(&ids), 1, k);
 
         group.bench_with_input(BenchmarkId::new("rust", case.label), &(), |b, _| {
-            b.iter(|| black_box(run_rust_filtered(&index, &ids, k)));
+            b.iter(|| black_box(run_rust_filtered(&index, &ids, 1, k)));
         });
 
         group.bench_with_input(BenchmarkId::new("c", case.label), &(), |b, _| {
-            b.iter(|| black_box(run_c(&index, Some(&ids), k)));
+            b.iter(|| black_box(run_c(&index, Some(&ids), 1, k)));
         });
     }
 
     group.finish();
 }
 
-criterion_group!(benches, bench_filtered, bench_unfiltered, bench_selectivity);
+// ── Expensive child ──────────────────────────────────────────────────────────
+//
+// The same selectivities as above, but with the ids spread over a union of eight
+// id lists instead of one. Every child read, skip and rewind now costs a pass
+// over eight sub-iterators, which is what a real text filter subtree looks like.
+//
+// Both sides walk this child; only the Rust side walks it twice, once to prune
+// the batch during materialization and once to intersect it. This group is what
+// prices that second walk.
+
+/// Number of id lists the expensive child's union spans.
+const UNION_ARITY: usize = 8;
+
+fn bench_expensive_child(c: &mut Criterion) {
+    let mut group = c.benchmark_group("numeric_top_k/expensive_child");
+
+    const N: usize = 100_000;
+    let k = NonZeroUsize::new(100).unwrap();
+    let index = Index::new(N);
+
+    for case in SELECTIVITY_CASES {
+        let ids = child_ids(N, case.child_count);
+
+        preflight(&index, Some(&ids), UNION_ARITY, k);
+
+        group.bench_with_input(BenchmarkId::new("rust", case.label), &(), |b, _| {
+            b.iter(|| black_box(run_rust_filtered(&index, &ids, UNION_ARITY, k)));
+        });
+
+        group.bench_with_input(BenchmarkId::new("c", case.label), &(), |b, _| {
+            b.iter(|| black_box(run_c(&index, Some(&ids), UNION_ARITY, k)));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_filtered,
+    bench_unfiltered,
+    bench_selectivity,
+    bench_expensive_child
+);
 criterion_main!(benches);

--- a/src/redisearch_rs/numeric_score_source_bencher/benches/optimizer_shim.c
+++ b/src/redisearch_rs/numeric_score_source_bencher/benches/optimizer_shim.c
@@ -35,9 +35,8 @@
 
 /* Rust-backed child iterators (src/redisearch_rs/headers/iterators_ffi.h).
  * NewSortedIdListIterator takes ownership of `ids` and frees them with
- * RedisModule_Free, so the caller must allocate `ids` with RedisModule_Alloc
- * (done Rust-side in the bench, so the alloc/free pair matches the mock
- * allocator). */
+ * RedisModule_Free, so every buffer handed to it here comes from
+ * RedisModule_Alloc rather than the C runtime's allocator. */
 QueryIterator *NewSortedIdListIterator(t_docId *ids, uint64_t num, double weight);
 QueryIterator *NewWildcardIterator_NonOptimized(t_docId max_id, double weight);
 /* Takes ownership of `its` and of every child it holds. */
@@ -45,29 +44,35 @@ QueryIterator *NewUnionIterator(QueryIterator **its, int32_t num, bool quick_exi
                                 QueryNodeType type_, const char *q_str,
                                 const IteratorsConfig *config);
 
-/* Spread `ids` round-robin over `arity` sorted-id-list iterators and union them.
+/* Sorted-id-list child over every `stride`-th id of `ids`, starting at `offset`.
+ *
+ * A stride of 1 selects them all. The buffer the child takes ownership of is
+ * filled in a single pass, so a child costs one allocation and one copy of the
+ * ids it holds — no more than building the equivalent list Rust-side. */
+static QueryIterator *make_id_list_child(const t_docId *ids, size_t count, size_t offset,
+                                         size_t stride) {
+  size_t len = count > offset ? (count - offset + stride - 1) / stride : 0;
+  t_docId *part = RedisModule_Alloc((len ? len : 1) * sizeof(*part));
+  size_t i = 0;
+  for (size_t j = offset; j < count; j += stride) {
+    part[i++] = ids[j];
+  }
+  return NewSortedIdListIterator(part, len, 1.0);
+}
+
+/* Spread `ids` round-robin over `arity` sorted-id-list children and union them.
  *
  * Every child then holds ids from across the whole doc-id space, so each step of
  * the union interleaves them — the cost a single id list does not have. The
- * union takes ownership of the array and of its children; `ids` is consumed
- * here.
- *
- * The iterators release all three allocations with RedisModule_Free, so they are
- * taken from the matching allocator rather than the C runtime's.
+ * union takes ownership of the array and of its children; `ids` itself is only
+ * borrowed.
  */
-static QueryIterator *make_union_child(t_docId *ids, size_t count, size_t arity,
+static QueryIterator *make_union_child(const t_docId *ids, size_t count, size_t arity,
                                        const IteratorsConfig *config) {
   QueryIterator **its = RedisModule_Alloc(arity * sizeof(*its));
   for (size_t slot = 0; slot < arity; slot++) {
-    size_t len = count > slot ? (count - slot + arity - 1) / arity : 0;
-    t_docId *part = RedisModule_Alloc((len ? len : 1) * sizeof(*part));
-    size_t i = 0;
-    for (size_t j = slot; j < count; j += arity) {
-      part[i++] = ids[j];
-    }
-    its[slot] = NewSortedIdListIterator(part, len, 1.0);
+    its[slot] = make_id_list_child(ids, count, slot, arity);
   }
-  RedisModule_Free(ids);
   // quick_exit matches the union the query planner builds for a filter child.
   return NewUnionIterator(its, (int32_t)arity, true, 1.0, QN_UNION, NULL, config);
 }
@@ -87,10 +92,9 @@ static size_t drain(QueryIterator *it) {
 
 /* Run the real OptimizerIterator over a child filter and count the results.
  *
- * `ids` is an owning pointer (allocated via RedisModule_Alloc by the caller),
- * sorted ascending, of length `child_count`; ownership is transferred to the
- * child iterator, which frees it via RedisModule_Free. A NULL `ids` selects a
- * wildcard child spanning doc ids 1..=`child_count`, the unfiltered case.
+ * `ids` is borrowed for the duration of the call: sorted ascending, of length
+ * `child_count`, and only read from. A NULL `ids` selects a wildcard child
+ * spanning doc ids 1..=`child_count`, the unfiltered case.
  *
  * `union_arity` above 1 wraps the same ids in a union of that many sorted id
  * lists, so the child costs more per read, skip and rewind than a single list.
@@ -98,7 +102,7 @@ static size_t drain(QueryIterator *it) {
  * The numeric filter spans the whole field and is created by the iterator
  * itself, which also sizes the first window from the child's estimate.
  */
-size_t bench_c_optimizer(RedisSearchCtx *sctx, const char *field_name, t_docId *ids,
+size_t bench_c_optimizer(RedisSearchCtx *sctx, const char *field_name, const t_docId *ids,
                          size_t child_count, size_t union_arity, size_t k, int ascending) {
   IteratorsConfig config;
   iteratorsConfig_init(&config);
@@ -109,7 +113,7 @@ size_t bench_c_optimizer(RedisSearchCtx *sctx, const char *field_name, t_docId *
   } else if (union_arity > 1) {
     child = make_union_child(ids, child_count, union_arity, &config);
   } else {
-    child = NewSortedIdListIterator(ids, child_count, 1.0);
+    child = make_id_list_child(ids, child_count, 0, 1);
   }
 
   QOptimizer opt = {0};

--- a/src/redisearch_rs/numeric_score_source_bencher/benches/optimizer_shim.c
+++ b/src/redisearch_rs/numeric_score_source_bencher/benches/optimizer_shim.c
@@ -26,6 +26,7 @@
 
 #include "config.h"
 #include "query_optimizer.h"
+#include "query_types.h"
 #include "redisearch.h"
 #include "search_ctx.h"
 #include "spec.h"
@@ -39,6 +40,37 @@
  * allocator). */
 QueryIterator *NewSortedIdListIterator(t_docId *ids, uint64_t num, double weight);
 QueryIterator *NewWildcardIterator_NonOptimized(t_docId max_id, double weight);
+/* Takes ownership of `its` and of every child it holds. */
+QueryIterator *NewUnionIterator(QueryIterator **its, int32_t num, bool quick_exit, double weight,
+                                QueryNodeType type_, const char *q_str,
+                                const IteratorsConfig *config);
+
+/* Spread `ids` round-robin over `arity` sorted-id-list iterators and union them.
+ *
+ * Every child then holds ids from across the whole doc-id space, so each step of
+ * the union interleaves them — the cost a single id list does not have. The
+ * union takes ownership of the array and of its children; `ids` is consumed
+ * here.
+ *
+ * The iterators release all three allocations with RedisModule_Free, so they are
+ * taken from the matching allocator rather than the C runtime's.
+ */
+static QueryIterator *make_union_child(t_docId *ids, size_t count, size_t arity,
+                                       const IteratorsConfig *config) {
+  QueryIterator **its = RedisModule_Alloc(arity * sizeof(*its));
+  for (size_t slot = 0; slot < arity; slot++) {
+    size_t len = count > slot ? (count - slot + arity - 1) / arity : 0;
+    t_docId *part = RedisModule_Alloc((len ? len : 1) * sizeof(*part));
+    size_t i = 0;
+    for (size_t j = slot; j < count; j += arity) {
+      part[i++] = ids[j];
+    }
+    its[slot] = NewSortedIdListIterator(part, len, 1.0);
+  }
+  RedisModule_Free(ids);
+  // quick_exit matches the union the query planner builds for a filter child.
+  return NewUnionIterator(its, (int32_t)arity, true, 1.0, QN_UNION, NULL, config);
+}
 
 /* Read an iterator to depletion and count the results.
  *
@@ -60,16 +92,25 @@ static size_t drain(QueryIterator *it) {
  * child iterator, which frees it via RedisModule_Free. A NULL `ids` selects a
  * wildcard child spanning doc ids 1..=`child_count`, the unfiltered case.
  *
+ * `union_arity` above 1 wraps the same ids in a union of that many sorted id
+ * lists, so the child costs more per read, skip and rewind than a single list.
+ *
  * The numeric filter spans the whole field and is created by the iterator
  * itself, which also sizes the first window from the child's estimate.
  */
 size_t bench_c_optimizer(RedisSearchCtx *sctx, const char *field_name, t_docId *ids,
-                         size_t child_count, size_t k, int ascending) {
+                         size_t child_count, size_t union_arity, size_t k, int ascending) {
   IteratorsConfig config;
   iteratorsConfig_init(&config);
 
-  QueryIterator *child = ids ? NewSortedIdListIterator(ids, child_count, 1.0)
-                             : NewWildcardIterator_NonOptimized(child_count, 1.0);
+  QueryIterator *child;
+  if (!ids) {
+    child = NewWildcardIterator_NonOptimized(child_count, 1.0);
+  } else if (union_arity > 1) {
+    child = make_union_child(ids, child_count, union_arity, &config);
+  } else {
+    child = NewSortedIdListIterator(ids, child_count, 1.0);
+  }
 
   QOptimizer opt = {0};
   opt.sctx = sctx;

--- a/src/redisearch_rs/numeric_score_source_bencher/benches/optimizer_shim.c
+++ b/src/redisearch_rs/numeric_score_source_bencher/benches/optimizer_shim.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+/*
+ * C baseline that drives the *real* OptimizerIterator (iterators/optimizer_reader.c),
+ * the production counterpart of the Rust NumericTopKIterator / NumericScoreSource.
+ *
+ * It links against libredisearch_c_bundle.a (bundled by build_utils), which provides
+ * NewOptimizerIterator, the Rust-backed child iterators and numeric range iterator,
+ * the doc table, and the min-max heap.
+ *
+ * The search context, index spec, numeric range tree and doc table are all built
+ * Rust-side (`rqe_iterators_test_utils::TestContext`) and handed in, so both sides
+ * of the benchmark read the very same index.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "config.h"
+#include "query_optimizer.h"
+#include "redisearch.h"
+#include "search_ctx.h"
+#include "spec.h"
+#include "iterators/iterator_api.h"
+#include "iterators/optimizer_reader.h"
+
+/* Rust-backed child iterators (src/redisearch_rs/headers/iterators_ffi.h).
+ * NewSortedIdListIterator takes ownership of `ids` and frees them with
+ * RedisModule_Free, so the caller must allocate `ids` with RedisModule_Alloc
+ * (done Rust-side in the bench, so the alloc/free pair matches the mock
+ * allocator). */
+QueryIterator *NewSortedIdListIterator(t_docId *ids, uint64_t num, double weight);
+QueryIterator *NewWildcardIterator_NonOptimized(t_docId max_id, double weight);
+
+/* Read an iterator to depletion and count the results.
+ *
+ * Results carrying a borrowed document metadata (the optimizer's heap entries)
+ * release it here, the way the result-processor pipeline does downstream. */
+static size_t drain(QueryIterator *it) {
+  size_t count = 0;
+  while (it->Read(it) == ITERATOR_OK) {
+    count++;
+    DMD_Return(it->current->dmd);
+  }
+  return count;
+}
+
+/* Run the real OptimizerIterator over a child filter and count the results.
+ *
+ * `ids` is an owning pointer (allocated via RedisModule_Alloc by the caller),
+ * sorted ascending, of length `child_count`; ownership is transferred to the
+ * child iterator, which frees it via RedisModule_Free. A NULL `ids` selects a
+ * wildcard child spanning doc ids 1..=`child_count`, the unfiltered case.
+ *
+ * The numeric filter spans the whole field and is created by the iterator
+ * itself, which also sizes the first window from the child's estimate.
+ */
+size_t bench_c_optimizer(RedisSearchCtx *sctx, const char *field_name, t_docId *ids,
+                         size_t child_count, size_t k, int ascending) {
+  IteratorsConfig config;
+  iteratorsConfig_init(&config);
+
+  QueryIterator *child = ids ? NewSortedIdListIterator(ids, child_count, 1.0)
+                             : NewWildcardIterator_NonOptimized(child_count, 1.0);
+
+  QOptimizer opt = {0};
+  opt.sctx = sctx;
+  opt.limit = k;
+  opt.asc = (bool)ascending;
+  opt.fieldName = field_name;
+  opt.field = IndexSpec_GetFieldWithLength(sctx->spec, field_name, strlen(field_name));
+
+  QueryIterator *it = NewOptimizerIterator(&opt, child, &config);
+  if (it == NULL) {
+    child->Free(child);
+    return 0;
+  }
+
+  size_t count = drain(it);
+  it->Free(it);  // also frees the child iterator and the owned numeric filter
+  return count;
+}

--- a/src/redisearch_rs/numeric_score_source_bencher/build.rs
+++ b/src/redisearch_rs/numeric_score_source_bencher/build.rs
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+fn main() {
+    // Emit optimizer_shim before redisearch_c_bundle: static archives resolve
+    // left-to-right, and the shim's symbols are defined in libredisearch_c_bundle.a.
+    compile_optimizer_shim();
+    build_utils::bind_foreign_c_symbols();
+}
+
+fn compile_optimizer_shim() {
+    use build_utils::repository_root;
+
+    let root = repository_root().expect("Could not find repository root");
+    let src = root.join("src");
+    let deps = root.join("deps");
+
+    cc::Build::new()
+        // Drives the real C OptimizerIterator from libredisearch_c_bundle.a, as a
+        // faithful counterpart to the Rust NumericTopKIterator.
+        .file("benches/optimizer_shim.c")
+        // Silence warnings originating from transitively-included RediSearch
+        // headers (static helpers, sign-compare in inline funcs, etc.) — they
+        // are not actionable from this shim and the main CMake build already
+        // suppresses them.
+        .flag_if_supported("-Wno-unused-function")
+        .flag_if_supported("-Wno-unused-variable")
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-sign-compare")
+        .include(&src)
+        // `deps` (rmutil/*) and RedisModulesSDK (redismodule.h) are pulled in
+        // transitively by spec.h / search_ctx.h for the optimizer shim.
+        .include(&deps)
+        .include(deps.join("RedisModulesSDK"))
+        .include(src.join("iterators"))
+        .include(deps.join("VectorSimilarity").join("src"))
+        .include(deps.join("rmalloc"))
+        .include(src.join("redisearch_rs").join("headers"))
+        .include(src.join("buffer"))
+        .include(src.join("ttl_table"))
+        .include(src.join("trie"))
+        .compile("optimizer_shim");
+
+    println!("cargo:rerun-if-changed=benches/optimizer_shim.c");
+}

--- a/src/redisearch_rs/numeric_score_source_bencher/src/lib.rs
+++ b/src/redisearch_rs/numeric_score_source_bencher/src/lib.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+// Some of the missing C symbols are actually Rust-provided.
+
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+extern crate redisearch_rs;


### PR DESCRIPTION
This PR adds benchmarks to compare Rust against C implementation for numeric top K.

Current findings are that current Rust implementation is slower :warning: ; but below is a list of possible improvements we'll tackle in follow ups, where cumulative improvements are promising.

Noise is around 4%, table reports median times

| benchmark              |     Rust |        C | ratio     |
| ---------------------- | -------: | -------: | --------- |
| filtered n10k k10      | 24.42 µs | 12.39 µs | 1.97      |
| filtered n10k k100     | 57.52 µs | 36.95 µs | 1.56      |
| filtered n100k k10     | 61.61 µs | 30.30 µs | 2.03      |
| filtered n100k k100    | 64.15 µs | 35.11 µs | 1.83      |
| unfiltered n10k k10    | 168.6 µs | 17.40 µs | 9.69      |
| unfiltered n10k k100   | 176.4 µs | 28.77 µs | 6.13      |
| unfiltered n100k k10   | 487.0 µs | 37.96 µs | 12.83     |
| unfiltered n100k k100  | 502.7 µs | 52.72 µs | 9.54      |
| selectivity 1% child   | 373.7 µs | 166.6 µs | 2.24      |
| selectivity 10% child  | 64.66 µs | 34.95 µs | 1.85      |
| selectivity 50% child  | 66.44 µs | 54.88 µs | 1.21      |
| expensive child, 1%    | 385.6 µs | 194.5 µs | 1.98      |
| expensive child, 10%   | 103.2 µs | 92.02 µs | 1.12      |
| expensive child, 50%   | 136.5 µs | 161.3 µs | **0.85**  |

### Follow ups:

- https://github.com/RediSearch/RediSearch/pull/10875
- https://github.com/RediSearch/RediSearch/pull/10746
  - https://github.com/RediSearch/RediSearch/pull/10873
    - https://github.com/RediSearch/RediSearch/pull/10873
      - https://github.com/RediSearch/RediSearch/pull/10874
        - https://github.com/RediSearch/RediSearch/pull/10876

<details><summary>Details</summary>
<p>

- Size the unfiltered window from `k` instead of leaving it unbounded (was resolving the whole
  field, then materializing 8 ranges before the heap could stop it).
- Skip the cross-batch de-duplication set and the coalescing pass on single-valued fields — a
  document can only be reached twice by a value-ordered scan if it carries several values.
  - tracked by MOD-17353
- Merge the batch's already-sorted per-range runs instead of re-sorting the concatenation.
  - in C, Nothing is materialized, so nothing is ever out of order, that's a design decision we were worried about.
- Let the filter child drive materialization, so index blocks holding no candidate are never
  decoded.


Final:

| benchmark              |     Rust |        C | ratio     |
| ---------------------- | -------: | -------: | --------- |
| filtered n10k k10      | 11.85 µs | 12.68 µs | **0.93**  |
| filtered n10k k100     | 25.91 µs | 38.26 µs | **0.68**  |
| filtered n100k k10     | 29.23 µs | 30.39 µs | **0.96**  |
| filtered n100k k100    | 31.38 µs | 35.00 µs | **0.90**  |
| unfiltered n10k k10    | 11.53 µs | 17.55 µs | **0.66**  |
| unfiltered n10k k100   | 16.50 µs | 28.54 µs | **0.58**  |
| unfiltered n100k k10   | 25.76 µs | 38.16 µs | **0.67**  |
| unfiltered n100k k100  | 31.50 µs | 52.68 µs | **0.60**  |
| selectivity 1% child   | 166.5 µs | 167.0 µs | **1.00**  |
| selectivity 10% child  | 31.52 µs | 35.00 µs | **0.90**  |
| selectivity 50% child  | 45.52 µs | 53.92 µs | **0.84**  |
| expensive child, 1%    | 230.2 µs | 195.6 µs | 1.18      |
| expensive child, 10%   | 77.81 µs | 92.97 µs | **0.84**  |
| expensive child, 50%   | 145.8 µs | 161.0 µs | **0.91**  |
</p>
</details> 

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
