### PR TITLE
[MOD-16990] Fix release build: include <stdatomic.h> in block_client.c

### DIFF
--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+#include <stdatomic.h>
+
 #include "redismodule.h"
 #include "util/references.h"
 #include "info/info_redis/types/blocked_queries.h"


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `master` fails to build in release configuration. `BlockedRequestCtx_BeginCycle` in `src/info/info_redis/block_client.c:40` calls `atomic_store_explicit(&brc->strictReadOwner, BRC_READ_OWNER_NONE, memory_order_relaxed)`, but the file has no `#include <stdatomic.h>`. The declarations only reached the translation unit transitively via `debug_commands.h`, which is included under `#ifdef ENABLE_ASSERT` — so assert-enabled builds (all PR CI configurations) compile, and release builds do not:

   ```
   src/info/info_redis/block_client.c:40:3: error: call to undeclared function 'atomic_store_explicit'; ISO C99 and later do not support implicit function declarations
   src/info/info_redis/block_client.c:40:69: error: use of undeclared identifier 'memory_order_relaxed'
   make[3]: *** [src/CMakeFiles/rscore.dir/info/info_redis/block_client.c.o] Error 1
   ```

   The `benchmark / build-redisearch{,-aarch64}` jobs (`make build LTO=1`, no `ENABLE_ASSERT`) have been red on every `master` push since #10515 merged, on both x86_64 and aarch64 — first failure [run 30817113255](https://github.com/RediSearch/RediSearch/actions/runs/30817748316/job/91699768028) at `7df138b97`. The include that used to supply the declarations indirectly (`aggregate/aggregate.h`) was dropped from this file earlier by #8895 (`include-what-you-use`), so the breakage only surfaced once #10515 added the atomic store.

2. **Change**: include `<stdatomic.h>` directly in `block_client.c`, as `aggregate/aggregate_request.c` already does for its atomic accesses on the same `BlockedRequestCtx` fields.

3. **Outcome**: `block_client.c` compiles in both release and assert-enabled configurations; the benchmark build jobs on `master` go green again.

Verified locally by compiling the translation unit with the CI flag set (`-Werror=implicit-function-declaration`) in both configurations:

| source | `ENABLE_ASSERT` | result |
| --- | --- | --- |
| `master` as-is | unset (release) | fails, same two errors as CI |
| `master` as-is | `=1` | compiles |
| this PR | unset (release) | compiles |
| this PR | `=1` | compiles |

#### Which additional issues this PR fixes
1. MOD-16990
2. Follow-up to #10515, interacting with #8895

#### Main objects this PR modified
1. `src/info/info_redis/block_client.c`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Build-only fix; no user-visible behavior change. The broken configuration never shipped — it was caught on `master` before a release build was published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
