### PR TITLE
[2.10] [MOD-17472] FT.AGGREGATE: drop rows invalidated during field loading

### DIFF
--- a/src/aggregate/aggregate_debug.c
+++ b/src/aggregate/aggregate_debug.c
@@ -52,6 +52,7 @@ int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status) {
   ArgsCursor_InitRString(&ac, debug_argv, debug_params_count);
   ArgsCursor timeoutArgs = {0};
   int internal_only = 0;
+  int pauseBeforeSafeLoaderGIL = 0;
   ArgsCursor pauseBeforeArgs = {0};
   ArgsCursor pauseAfterArgs = {0};
   ACArgSpec debugArgsSpec[] = {
@@ -72,6 +73,9 @@ int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status) {
        .type = AC_ARGTYPE_SUBARGS_N,
        .target = &pauseBeforeArgs,
        .slicelen = 2},
+      {.name = "PAUSE_BEFORE_SAFE_LOADER_GIL",
+       .type = AC_ARGTYPE_BOOLFLAG,
+       .target = &pauseBeforeSafeLoaderGIL},
       {NULL}};
 
   ACArgSpec *errSpec = NULL;
@@ -116,6 +120,16 @@ int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status) {
       // Take this into account when adding more debug types that are modifying the rp pipeline.
       PipelineAddTimeoutAfterCount(&debug_req->r, results_count);
     }
+    return REDISMODULE_OK;
+  }
+
+  if (pauseBeforeSafeLoaderGIL) {
+    if (!(debug_req->r.reqflags & QEXEC_F_RUN_IN_BACKGROUND)) {
+      QueryError_SetError(status, QUERY_EPARSEARGS,
+                          "PAUSE_BEFORE_SAFE_LOADER_GIL is only supported with WORKERS");
+      return REDISMODULE_ERR;
+    }
+    debug_req->r.qiter.debugPauseBeforeSafeLoaderGIL = true;
     return REDISMODULE_OK;
   }
 

--- a/src/aggregate/aggregate_debug.h
+++ b/src/aggregate/aggregate_debug.h
@@ -59,6 +59,10 @@
  *           - Only applicable in FT.AGGREGATE cluster mode.
  *           - Controls whether the pause applies to the coordinator pipeline or shard-level processing.
  *           - If specified, the pause applies only to the coordinator, not the shards.
+ *       - **`PAUSE_BEFORE_SAFE_LOADER_GIL`**:
+ *         - Pauses a background query after the safe loader buffers its rows and releases the
+ *           spec read lock, immediately before it takes the Redis GIL to load fields.
+ *         - Intended for deterministic re-index-during-load tests.
  *
  *   - `<DEBUG_PARAMS_COUNT>`:
  *     - Specifies the number of expected arguments in `<DEBUG_QUERY_ARGS>`.

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -406,7 +406,9 @@ long calc_results_len(AREQ *req, size_t limit) {
   size_t reqOffset = arng && arng->isLimited ? arng->offset : 0;
   size_t resultFactor = getResultsFactor(req);
 
-  size_t expected_res = ((reqLimit + reqOffset) <= req->maxSearchResults) ? req->qiter.totalResults : MIN(req->maxSearchResults, req->qiter.totalResults);
+  // Report matches minus the rows the loader dropped (deleted/re-indexed mid-load).
+  size_t reported = QITR_ReportedTotal(&req->qiter);
+  size_t expected_res = ((reqLimit + reqOffset) <= req->maxSearchResults) ? reported : MIN(req->maxSearchResults, reported);
   size_t reqResults = expected_res > reqOffset ? expected_res - reqOffset : 0;
 
   return 1 + MIN(limit, MIN(reqLimit, reqResults)) * resultFactor;
@@ -439,6 +441,7 @@ void finishSendChunk(AREQ *req, SearchResult **results, SearchResult *r, bool cu
 
   // Reset the total results length:
   req->qiter.totalResults = 0;
+  req->qiter.skippedResults = 0;
 
   QueryError_ClearError(req->qiter.err);
 }
@@ -495,7 +498,8 @@ static void sendChunk_Resp2(AREQ *req, RedisModule_Reply *reply, size_t limit,
 
     RedisModule_Reply_Array(reply);
 
-    RedisModule_Reply_LongLong(reply, req->qiter.totalResults);
+    // Report matches minus rows the loader dropped (deleted/re-indexed mid-load).
+    RedisModule_Reply_LongLong(reply, QITR_ReportedTotal(&req->qiter));
     nelem++;
 
     // Once we get here, we want to return the results we got from the pipeline (with no error)
@@ -655,8 +659,8 @@ static void sendChunk_Resp3(AREQ *req, RedisModule_Reply *reply, size_t limit,
 done_3:
     RedisModule_Reply_ArrayEnd(reply); // >results
 
-    // <total_results>
-    RedisModule_ReplyKV_LongLong(reply, "total_results", req->qiter.totalResults);
+    // <total_results> - matches minus rows the loader dropped (deleted/re-indexed mid-load).
+    RedisModule_ReplyKV_LongLong(reply, "total_results", QITR_ReportedTotal(&req->qiter));
 
     // <error>
     RedisModule_ReplyKV_Array(reply, "warning"); // >warnings

--- a/src/aggregate/group_by.c
+++ b/src/aggregate/group_by.c
@@ -228,6 +228,9 @@ static int Grouper_rpAccum(ResultProcessor *base, SearchResult *res) {
   if (rc == RS_RESULT_EOF) {
     base->Next = Grouper_rpYield;
     base->parent->totalResults = kh_size(g->groups);
+    // Group count doesn't include rows the loader dropped upstream; clear the skip
+    // correction so it isn't subtracted from it at reply time.
+    base->parent->skippedResults = 0;
     g->iter = kh_begin(khid);
     return Grouper_rpYield(base, res);
   } else {

--- a/src/query_optimizer.c
+++ b/src/query_optimizer.c
@@ -281,6 +281,8 @@ void QOptimizer_UpdateTotalResults(AREQ *req) {
     PLN_ArrangeStep *arng = AGPLN_GetArrangeStep(&req->ap);
     size_t reqLimit = arng && arng->isLimited ? arng->limit : DEFAULT_LIMIT;
     size_t reqOffset = arng && arng->isLimited ? arng->offset : 0;
+    req->qiter.totalResults = QITR_ReportedTotal(&req->qiter);
+    req->qiter.skippedResults = 0;
     req->qiter.totalResults = req->qiter.totalResults > reqOffset ?
                               req->qiter.totalResults - reqOffset : 0;
     if(req->qiter.totalResults > reqLimit) {

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -652,10 +652,6 @@ static void rpLoader_loadDocument(RPLoader *self, SearchResult *r) {
   }
 }
 
-static inline bool loaderResultIsEmittable(const SearchResult *r) {
-  return !(r->flags & Result_ExpiredDoc);
-}
-
 static inline void loaderDropResult(ResultProcessor *base, SearchResult *r) {
   base->parent->skippedResults++;
   SearchResult_Destroy(r);
@@ -842,8 +838,11 @@ static void rpSafeLoader_Load(RPSafeLoader *self) {
   // iterate the buffer.
   // TODO: implement `GetNextResult` that gets the current block to save calculation time.
   while ((curr_res = GetNextResult(self))) {
+    // Only deletion before loading means the row was invalidated in the unlocked window.
+    // Loading can itself mark a lazily expired key deleted on Redis 6/7.
+    bool wasDeletedBeforeLoad = curr_res->dmd->flags & Document_Deleted;
     rpLoader_loadDocument(&self->base_loader, curr_res);
-    if (!loaderResultIsEmittable(curr_res)) {
+    if (wasDeletedBeforeLoad) {
       loaderDropResult(&self->base_loader.base, curr_res);
     }
   }

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -840,11 +840,11 @@ static void rpSafeLoader_Load(RPSafeLoader *self) {
   while ((curr_res = GetNextResult(self))) {
     // Only deletion before loading means the row was invalidated in the unlocked window.
     // Loading can itself mark a lazily expired key deleted on Redis 6/7.
-    bool wasDeletedBeforeLoad = curr_res->dmd->flags & Document_Deleted;
-    rpLoader_loadDocument(&self->base_loader, curr_res);
-    if (wasDeletedBeforeLoad) {
+    if (curr_res->dmd->flags & Document_Deleted) {
       loaderDropResult(&self->base_loader.base, curr_res);
+      continue;
     }
+    rpLoader_loadDocument(&self->base_loader, curr_res);
   }
 
   // Reset the iterator

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -652,6 +652,16 @@ static void rpLoader_loadDocument(RPLoader *self, SearchResult *r) {
   }
 }
 
+static inline bool loaderResultIsEmittable(const SearchResult *r) {
+  return !(r->flags & Result_ExpiredDoc);
+}
+
+static inline void loaderDropResult(ResultProcessor *base, SearchResult *r) {
+  base->parent->skippedResults++;
+  SearchResult_Destroy(r);
+  memset(r, 0, sizeof(*r));
+}
+
 static int rploaderNext(ResultProcessor *base, SearchResult *r) {
   RPLoader *lc = (RPLoader *)base;
   int rc = base->upstream->Next(base->upstream, r);
@@ -833,6 +843,9 @@ static void rpSafeLoader_Load(RPSafeLoader *self) {
   // TODO: implement `GetNextResult` that gets the current block to save calculation time.
   while ((curr_res = GetNextResult(self))) {
     rpLoader_loadDocument(&self->base_loader, curr_res);
+    if (!loaderResultIsEmittable(curr_res)) {
+      loaderDropResult(&self->base_loader.base, curr_res);
+    }
   }
 
   // Reset the iterator
@@ -841,14 +854,16 @@ static void rpSafeLoader_Load(RPSafeLoader *self) {
 
 static int rpSafeLoaderNext_Yield(ResultProcessor *rp, SearchResult *result_output) {
   RPSafeLoader *self = (RPSafeLoader *)rp;
-  SearchResult *curr_res = GetNextResult(self);
+  SearchResult *curr_res;
 
-  if (curr_res) {
+  while ((curr_res = GetNextResult(self))) {
+    if (curr_res->dmd == NULL) {
+      continue;
+    }
     SetResult(curr_res, result_output);
     return RS_RESULT_OK;
-  } else {
-    return rpSafeLoader_ResetAndReturnLastCode(self, result_output);
   }
+  return rpSafeLoader_ResetAndReturnLastCode(self, result_output);
 }
 
 /*********************************************************************************/

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -890,6 +890,16 @@ static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
   // First, we verify that we unlocked the spec before we lock Redis.
   RedisSearchCtx_UnlockSpec(sctx);
 
+  if (rp->parent->debugPauseBeforeSafeLoaderGIL) {
+    // One-shot deterministic test hook: let the main thread re-index a buffered document after
+    // its old metadata was captured, but before the loader validates it under the Redis GIL.
+    rp->parent->debugPauseBeforeSafeLoaderGIL = false;
+    QueryDebugCtx_SetPause(true);
+    while (QueryDebugCtx_IsPaused()) {
+      usleep(1000);
+    }
+  }
+
   bool isQueryProfile = rp->parent->isProfile;
   rs_wall_clock rpStartTime;
   if (isQueryProfile) rs_wall_clock_init(&rpStartTime);

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -93,8 +93,8 @@ typedef struct {
   // and decremented by others who might disqualify results
   uint32_t totalResults;
 
-  // Results counted in totalResults but dropped by a buffering result processor
-  // because the document was deleted, re-indexed, or expired mid-load.
+  // Results counted in totalResults but dropped by a buffering result processor because the
+  // document was deleted or re-indexed after buffering and before loading.
   uint32_t skippedResults;
 
   // the number of results we requested to return at the current chunk.

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -105,6 +105,10 @@ typedef struct {
   // Background indexing OOM warning
   bool bgScanOOM;
 
+  // Debug-only rendezvous used to invalidate a buffered result before the safe loader takes the
+  // Redis GIL. Set only by _FT.DEBUG queries.
+  bool debugPauseBeforeSafeLoaderGIL;
+
   bool isProfile;
   RSTimeoutPolicy timeoutPolicy;
 } QueryIterator, QueryProcessingCtx;

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -17,6 +17,7 @@
 #include "rlookup.h"
 #include "extension.h"
 #include "score_explain.h"
+#include "rmutil/rm_assert.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -92,6 +93,10 @@ typedef struct {
   // and decremented by others who might disqualify results
   uint32_t totalResults;
 
+  // Results counted in totalResults but dropped by a buffering result processor
+  // because the document was deleted, re-indexed, or expired mid-load.
+  uint32_t skippedResults;
+
   // the number of results we requested to return at the current chunk.
   // This value is meant to be used by the RP to limit the number of results
   // returned by its upstream RP ONLY.
@@ -116,6 +121,12 @@ typedef struct {
 IndexIterator *QITR_GetRootFilter(QueryIterator *it);
 void QITR_PushRP(QueryIterator *it, struct ResultProcessor *rp);
 void QITR_FreeChain(QueryIterator *qitr);
+
+static inline uint32_t QITR_ReportedTotal(const QueryProcessingCtx *qctx) {
+  RS_LOG_ASSERT(qctx->skippedResults <= qctx->totalResults,
+                "skippedResults must not exceed totalResults");
+  return qctx->totalResults - qctx->skippedResults;
+}
 
 /*
  * SearchResult - the object all the processing chain is working on.

--- a/tests/pytests/test_issue_6526.py
+++ b/tests/pytests/test_issue_6526.py
@@ -8,10 +8,7 @@ def test_aggregate_drops_doc_reindexed_during_load():
     # A dedicated environment is required for the background safe-loader path and its debug hook.
     if not MT_BUILD:
         raise SkipTest('MT_BUILD is not set')
-    env = Env(
-        enableDebugCommand=True,
-        moduleArgs='WORKERS 1 MIN_OPERATION_WORKERS 0',
-    )
+    env = Env(enableDebugCommand=True, moduleArgs='WORKERS 1')
     conn = getConnectionByEnv(env)
 
     env.expect(
@@ -23,7 +20,7 @@ def test_aggregate_drops_doc_reindexed_during_load():
     conn.execute_command('HSET', 'doc:2', 'n', '2', 'title', 'two')
     waitForIndex(env, 'idx')
 
-    query = ['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'LOAD', '1', '@n']
+    query = ['FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@n']
     args = parseDebugQueryCommandArgs(query, ['PAUSE_BEFORE_SAFE_LOADER_GIL'])
     query_conn = env.getConnection()
     outcome = []
@@ -37,10 +34,18 @@ def test_aggregate_drops_doc_reindexed_during_load():
     thread = threading.Thread(target=run_query, daemon=True)
     thread.start()
 
+    def loader_paused_or_query_finished():
+        paused = getIsRPPaused(env)
+        return paused == 1 or bool(outcome), {
+            'paused': paused,
+            'outcome': repr(outcome),
+        }
+
     wait_for_condition(
-        lambda: (getIsRPPaused(env) == 1, {}),
+        loader_paused_or_query_finished,
         'Timeout waiting for the safe loader to release the spec lock'
     )
+    env.assertEqual(outcome, [], message='query finished before reaching the safe loader pause')
 
     try:
         # Replacing doc:1 pops the metadata buffered by the query and assigns a new doc ID.

--- a/tests/pytests/test_issue_6526.py
+++ b/tests/pytests/test_issue_6526.py
@@ -1,0 +1,57 @@
+from common import *
+import threading
+
+
+@skip(cluster=True)
+def test_aggregate_drops_doc_reindexed_during_load():
+    """FT.AGGREGATE must not emit an empty row for a doc invalidated before LOAD."""
+    # A dedicated environment is required for the background safe-loader path and its debug hook.
+    if not MT_BUILD:
+        raise SkipTest('MT_BUILD is not set')
+    env = Env(enableDebugCommand=True, moduleArgs='WORKERS 1')
+    conn = getConnectionByEnv(env)
+
+    env.expect(
+        'FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'doc:',
+        'SCHEMA', 'n', 'NUMERIC', 'title', 'TEXT', 'SORTABLE'
+    ).ok()
+    env.cmd(config_cmd(), 'SET', 'TIMEOUT', '0')
+    conn.execute_command('HSET', 'doc:1', 'n', '1', 'title', 'one')
+    conn.execute_command('HSET', 'doc:2', 'n', '2', 'title', 'two')
+    waitForIndex(env, 'idx')
+
+    query = ['FT.AGGREGATE', 'idx', '*', 'WITHCOUNT', 'LOAD', '1', '@n']
+    args = parseDebugQueryCommandArgs(query, ['PAUSE_BEFORE_SAFE_LOADER_GIL'])
+    query_conn = env.getConnection()
+    outcome = []
+
+    def run_query():
+        try:
+            outcome.append(query_conn.execute_command(debug_cmd(), *args))
+        except Exception as error:
+            outcome.append(error)
+
+    thread = threading.Thread(target=run_query, daemon=True)
+    thread.start()
+
+    wait_for_condition(
+        lambda: (getIsRPPaused(env) == 1, {}),
+        'Timeout waiting for the safe loader to release the spec lock'
+    )
+
+    try:
+        # Replacing doc:1 pops the metadata buffered by the query and assigns a new doc ID.
+        conn.execute_command('HSET', 'doc:1', 'n', '1', 'title', 'one-reindexed')
+    finally:
+        setPauseRPResume(env)
+
+    thread.join(timeout=10)
+    env.assertFalse(thread.is_alive(), message='query did not resume after loader signal')
+    env.assertEqual(len(outcome), 1, message=outcome)
+    env.assertFalse(isinstance(outcome[0], Exception), message=outcome[0])
+
+    total, rows = outcome[0][0], outcome[0][1:]
+    invalid_rows = [row for row in rows if row is None or row == []]
+    env.assertEqual(invalid_rows, [], message=f'invalid aggregate row: {outcome[0]}')
+    env.assertEqual(rows, [['n', '2']], message=outcome[0])
+    env.assertEqual(total, len(rows), message=outcome[0])

--- a/tests/pytests/test_issue_6526.py
+++ b/tests/pytests/test_issue_6526.py
@@ -63,3 +63,25 @@ def test_aggregate_drops_doc_reindexed_during_load():
     env.assertEqual(invalid_rows, [], message=f'invalid aggregate row: {outcome[0]}')
     env.assertEqual(rows, [['n', '2']], message=outcome[0])
     env.assertEqual(total, len(rows), message=outcome[0])
+
+
+@skip(cluster=True, redis_less_than='7.2')
+def test_safe_loader_preserves_lazy_expiration_row():
+    """A Redis 6/7 lazy-expiration load failure must keep the legacy null row."""
+    if not MT_BUILD:
+        raise SkipTest('MT_BUILD is not set')
+    env = Env(enableDebugCommand=True, moduleArgs='WORKERS 1')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    conn.execute_command('HSET', 'doc1', 't', 'bar')
+    conn.execute_command('HSET', 'doc2', 't', 'arr')
+
+    conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
+    try:
+        conn.execute_command('PEXPIRE', 'doc1', 1)
+        conn.execute_command('DEBUG', 'SLEEP', 0.01)
+        res = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', 1, '@t')
+        env.assertEqual(res, [1, None, ['t', 'arr']])
+    finally:
+        conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '1')

--- a/tests/pytests/test_issue_6526.py
+++ b/tests/pytests/test_issue_6526.py
@@ -8,7 +8,10 @@ def test_aggregate_drops_doc_reindexed_during_load():
     # A dedicated environment is required for the background safe-loader path and its debug hook.
     if not MT_BUILD:
         raise SkipTest('MT_BUILD is not set')
-    env = Env(enableDebugCommand=True, moduleArgs='WORKERS 1')
+    env = Env(
+        enableDebugCommand=True,
+        moduleArgs='WORKERS 1 MIN_OPERATION_WORKERS 0',
+    )
     conn = getConnectionByEnv(env)
 
     env.expect(

--- a/tests/pytests/test_issue_6526.py
+++ b/tests/pytests/test_issue_6526.py
@@ -67,7 +67,7 @@ def test_aggregate_drops_doc_reindexed_during_load():
 
 @skip(cluster=True, redis_less_than='7.2')
 def test_safe_loader_preserves_lazy_expiration_row():
-    """A Redis 6/7 lazy-expiration load failure must keep the legacy null row."""
+    """A Redis 6/7 lazy-expiration load failure must keep the legacy row and total."""
     if not MT_BUILD:
         raise SkipTest('MT_BUILD is not set')
     env = Env(enableDebugCommand=True, moduleArgs='WORKERS 1')
@@ -82,6 +82,6 @@ def test_safe_loader_preserves_lazy_expiration_row():
         conn.execute_command('PEXPIRE', 'doc1', 1)
         conn.execute_command('DEBUG', 'SLEEP', 0.01)
         res = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', 1, '@t')
-        env.assertEqual(res, [1, None, ['t', 'arr']])
+        env.assertEqual(res, [2, None, ['t', 'arr']])
     finally:
         conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '1')

--- a/tests/pytests/test_issue_6526.py
+++ b/tests/pytests/test_issue_6526.py
@@ -2,9 +2,7 @@ from common import *
 import threading
 
 
-@skip(cluster=True)
-def test_aggregate_drops_doc_reindexed_during_load():
-    """FT.AGGREGATE must not emit an empty row for a doc invalidated before LOAD."""
+def _run_query_with_reindex_during_load(query):
     # A dedicated environment is required for the background safe-loader path and its debug hook.
     if not MT_BUILD:
         raise SkipTest('MT_BUILD is not set')
@@ -20,7 +18,6 @@ def test_aggregate_drops_doc_reindexed_during_load():
     conn.execute_command('HSET', 'doc:2', 'n', '2', 'title', 'two')
     waitForIndex(env, 'idx')
 
-    query = ['FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@n']
     args = parseDebugQueryCommandArgs(query, ['PAUSE_BEFORE_SAFE_LOADER_GIL'])
     query_conn = env.getConnection()
     outcome = []
@@ -57,12 +54,47 @@ def test_aggregate_drops_doc_reindexed_during_load():
     env.assertFalse(thread.is_alive(), message='query did not resume after loader signal')
     env.assertEqual(len(outcome), 1, message=outcome)
     env.assertFalse(isinstance(outcome[0], Exception), message=outcome[0])
+    return env, outcome[0]
 
-    total, rows = outcome[0][0], outcome[0][1:]
+
+@skip(cluster=True)
+def test_aggregate_drops_doc_reindexed_during_load():
+    """FT.AGGREGATE must not emit an empty row for a doc invalidated before LOAD."""
+    env, result = _run_query_with_reindex_during_load(
+        ['FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@n']
+    )
+
+    total, rows = result[0], result[1:]
     invalid_rows = [row for row in rows if row is None or row == []]
-    env.assertEqual(invalid_rows, [], message=f'invalid aggregate row: {outcome[0]}')
-    env.assertEqual(rows, [['n', '2']], message=outcome[0])
-    env.assertEqual(total, len(rows), message=outcome[0])
+    env.assertEqual(invalid_rows, [], message=f'invalid aggregate row: {result}')
+    env.assertEqual(rows, [['n', '2']], message=result)
+    env.assertEqual(total, len(rows), message=result)
+
+
+@skip(cluster=True)
+def test_aggregate_groupby_drops_doc_reindexed_during_load():
+    """GROUPBY must not subtract an upstream loader drop from its recomputed group count."""
+    env, result = _run_query_with_reindex_during_load(
+        ['FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@n', 'GROUPBY', '1', '@n']
+    )
+
+    total, rows = result[0], result[1:]
+    env.assertEqual(rows, [['n', '2']], message=result)
+    env.assertEqual(total, len(rows), message=result)
+
+
+@skip(cluster=True)
+def test_search_optimizer_drops_doc_reindexed_during_load():
+    """The optimizer must fold the loader-drop correction before applying LIMIT."""
+    env, result = _run_query_with_reindex_during_load(
+        ['FT.SEARCH', 'idx', '*', 'WITHOUTCOUNT', 'LIMIT', '0', '10']
+    )
+
+    total, flat_results = result[0], result[1:]
+    pairs = list(zip(flat_results[0::2], flat_results[1::2]))
+    env.assertEqual([fields for _, fields in pairs if fields is None], [], message=result)
+    env.assertEqual([key for key, _ in pairs], ['doc:2'], message=result)
+    env.assertEqual(total, len(pairs), message=result)
 
 
 @skip(cluster=True)

--- a/tests/pytests/test_issue_6526.py
+++ b/tests/pytests/test_issue_6526.py
@@ -65,7 +65,7 @@ def test_aggregate_drops_doc_reindexed_during_load():
     env.assertEqual(total, len(rows), message=outcome[0])
 
 
-@skip(cluster=True, redis_less_than='7.2')
+@skip(cluster=True)
 def test_safe_loader_preserves_lazy_expiration_row():
     """A Redis 6/7 lazy-expiration load failure must keep the legacy row and total."""
     if not MT_BUILD:
@@ -79,8 +79,9 @@ def test_safe_loader_preserves_lazy_expiration_row():
 
     conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
     try:
-        conn.execute_command('PEXPIRE', 'doc1', 1)
-        conn.execute_command('DEBUG', 'SLEEP', 0.01)
+        # A longer TTL avoids the pre-7.2 PEXPIRE time-sampling race.
+        conn.execute_command('PEXPIRE', 'doc1', 1000)
+        conn.execute_command('DEBUG', 'SLEEP', 1.1)
         res = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', 1, '@t')
         env.assertEqual(res, [2, None, ['t', 'arr']])
     finally:


### PR DESCRIPTION
**Describe the changes in the pull request**

1. On 2.10, a concurrent re-index can invalidate a row buffered by the background safe loader.
   The loader marks it expired but still returns it, so `FT.AGGREGATE ... LOAD` emits a null/empty
   row and an inflated total.
2. Adapt the safe-loader drop and reported-count logic from master PR #10251 to the 2.10 result
   structures. To preserve Redis 6/7 lazy-expiration behavior, drop only rows whose metadata was
   already deleted before key loading; the plain loader remains unchanged and no Redis 8-only API
   is used.
3. Add a deterministic debug rendezvous and pytest that re-index one buffered document between
   safe-loader buffering and loading. Before the fix, focused CI reproduced
   `[2, None, ['n', '2']]`; after the fix, only `['n', '2']` is returned with total `1`.
4. Add a compatibility pytest that forces lazy expiration during safe loading and requires the
   legacy null-row result. This separates expiration during Redis key access from the concurrent
   re-index fixed here. [Focused Redis 7.4 CI](https://github.com/RediSearch/RediSearch/actions/runs/30979471967)
   passes both tests. A second [focused run](https://github.com/RediSearch/RediSearch/actions/runs/30981327771)
   passes them against the exact Redis parent revision before `REDISMODULE_OPEN_KEY_NOEFFECTS` was
   introduced, validating the relevant old key-opening semantics. Final
   [automatic PR CI](https://github.com/RediSearch/RediSearch/actions/runs/30980006553) passes
   standalone/coordinator builds, unit tests, quick flow suites, and PR validation.

**Which issues this PR fixes**
1. #6526
2. [MOD-17472](https://redislabs.atlassian.net/browse/MOD-17472)

Backport of master fix [MOD-16507](https://redislabs.atlassian.net/browse/MOD-16507) /
[PR #10251](https://github.com/RediSearch/RediSearch/pull/10251).

**Main objects this PR modified**
1. Background result loader and result-count reporting.
2. Deterministic multithreaded aggregate flow test.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

`FT.AGGREGATE` no longer returns null/empty rows when a matching document is re-indexed while its
fields are being loaded by a query worker.


[MOD-17472]: https://redislabs.atlassian.net/browse/MOD-17472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ