### PR TITLE
[8.4] [MOD-17316] Fix FT.HYBRID replying success with bogus warnings when a depleter loses the index lock

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -553,6 +553,8 @@ static void _replyWarnings(AREQ *req, RedisModule_Reply *reply, int rc) {
     ProfileWarnings_Add(&profileCtx->warnings, PROFILE_WARNING_TYPE_TIMEOUT);
   } else if (rc == RS_RESULT_ERROR) {
     // Non-fatal error
+    RS_LOG_ASSERT(!QueryError_IsOk(qctx->err),
+                  "RS_RESULT_ERROR reached the warning path without a QueryError set");
     RedisModule_Reply_SimpleString(reply, QueryError_GetUserError(qctx->err));
   }
   if (QueryError_HasReachedMaxPrefixExpansionsWarning(qctx->err)) {

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -56,6 +56,7 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   if (HasWithCount(nc->areq) && IsAggregate(nc->areq)) {
     ShardResponseBarrier *barrier = shardResponseBarrier_New();
     if (!barrier) {
+      QueryError_SetCode(nc->base.parent->err, QUERY_EGENERIC);
       return RS_RESULT_ERROR;
     }
     nc->shardResponseBarrier = barrier;
@@ -81,6 +82,7 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
       shardResponseBarrier_Free(nc->shardResponseBarrier);
       nc->shardResponseBarrier = NULL;
     }
+    QueryError_SetCode(nc->base.parent->err, QUERY_EGENERIC);
     return RS_RESULT_ERROR;
   }
 

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -82,6 +82,8 @@ static inline HybridWarningMask handleAndReplyWarning(RedisModule_Reply *reply, 
     return HYBRID_WARNING_TIMEOUT;
   } else if (returnCode == RS_RESULT_ERROR) {
     // Non-fatal error - convert to warning
+    RS_LOG_ASSERT(!QueryError_IsOk(err),
+                  "RS_RESULT_ERROR reached the warning path without a QueryError set");
     ReplyWarning(reply, QueryError_GetUserError(err), suffix);
     QueryError_ClearError(err);
   } else if (QueryError_HasReachedMaxPrefixExpansionsWarning(err)) {

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -213,7 +213,7 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
     rs_wall_clock_init(&now);
 
     // Initialize error tracking for each individual request
-    hybridReq->errors = array_new(QueryError, nrequests);
+    hybridReq->errors = array_newlen(QueryError, nrequests);
     memset(hybridReq->errors, 0, nrequests * sizeof(QueryError));
 
     // Initialize return codes array for tracking subqueries final states

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1415,6 +1415,11 @@ ResultProcessor *RPVectorNormalizer_New(VectorNormFunction normFunc, const RLook
  *  NOTE: Currently the recommended number of upstreams is 2. Using more may
  *  induce performance issues, until a more robust mechanism is implemented.
  *******************************************************************************************************************/
+
+#define SAFE_DEPLETER_LOCK_FAILURE_MSG                                                            \
+  "Failed to acquire index lock for background depletion. A write operation may be in progress. " \
+  "Please retry."
+
 typedef struct {
   ResultProcessor base;                // Base result processor struct
   // We require separate contexts because we have different threads.
@@ -1525,6 +1530,8 @@ static void RPSafeDepleter_DepleteFromUpstream(RPSafeDepleter *self, DepleterSyn
       // Failed to acquire lock - likely a writer is waiting
       // Set error status and return without depleting
       self->last_rc = RS_RESULT_ERROR;
+      QueryError_SetError(self->base.parent->err, QUERY_ESAFEDEPLETERFAILURE,
+                          SAFE_DEPLETER_LOCK_FAILURE_MSG);
       // Signal that we're skipping the lock phase (for WaitForDepletionToStart)
       atomic_fetch_add(&sync->num_skipped_lock, 1);
       return;
@@ -1834,8 +1841,7 @@ int RPSafeDepleter_DepleteAll(arrayof(ResultProcessor*) safeDepleters, QueryErro
   for (size_t i = 0; i < count; i++) {
     const RPSafeDepleter *safeDepleter = (RPSafeDepleter *)safeDepleters[i];
     if (safeDepleter->last_rc == RS_RESULT_ERROR) {
-      QueryError_SetWithoutUserDataFmt(status, QUERY_ESAFEDEPLETERFAILURE,
-        "Failed to acquire index lock for background depletion. A write operation may be in progress. Please retry.");
+      QueryError_SetError(status, QUERY_ESAFEDEPLETERFAILURE, SAFE_DEPLETER_LOCK_FAILURE_MSG);
       return RS_RESULT_ERROR;
     } else if (safeDepleter->last_rc == RS_RESULT_TIMEDOUT) {
       anyTimedOut = true;
@@ -1998,6 +2004,8 @@ static int RPHybridMerger_Yield(ResultProcessor *rp, SearchResult *r) {
 
   SearchResult *mergedResult = mergeSearchResults(hybridResult, self->hybridScoringCtx, self->lookupCtx);
   if (!mergedResult) {
+    QueryError_SetError(rp->parent->err, QUERY_EGENERIC,
+                        "Failed to merge hybrid subquery results");
     return RS_RESULT_ERROR;
   }
 


### PR DESCRIPTION
## Describe the changes in the pull request

Manual backport of #10658 to `8.4`. The automated backport failed to cherry-pick.

1. **Current**: `FT.HYBRID`'s background depleters take a non-blocking spec read lock. When that try-lock loses the race to a queued writer, the failure was recorded only in `last_rc`. Plain `FT.HYBRID` depletes through `Next`, so the merger saw a bare `RS_RESULT_ERROR` with an unset `QueryError`, which stringifies to its OK default — the command answered **successfully with `total_results: 0`** and bogus warnings.
2. **Change**: record the failure on the subquery pipeline's `QueryError` at the point of loss, with debug-build assertions at both reply sites pinning the invariant that `RS_RESULT_ERROR` carries a message. Also fixes a leak of `hreq->errors[i]` messages (`array_new` -> `array_newlen`, so `array_free_ex` iterates the elements).
3. **Outcome**: standalone `FT.HYBRID` returns a retryable error instead of a silently empty success. Try-lock behaviour itself is unchanged.

The defect is present on this branch: `result_processor.c:1532` sets `last_rc = RS_RESULT_ERROR` with no `QueryError`, and `hybrid_exec.c` gates the error reply on `ShouldReplyWithError(QueryError_GetCode(&err), ...)`.

## Original PR

https://github.com/RediSearch/RediSearch/pull/10658 (merge commit `34dcfb241afbaabbe4ad6e087cc1624af76854ce`)

## Changes from original

**`QueryError` predates the Rust port on this branch**, so the codes keep their pre-rename spellings: `QUERY_ESAFEDEPLETERFAILURE` and `QUERY_EGENERIC` (master: `QUERY_ERROR_CODE_SAFE_DEPLETER_FAILURE` / `QUERY_ERROR_CODE_GENERIC`). `QueryError_SetError`, `QueryError_SetCode` and `QueryError_IsOk` all exist here with identical signatures, so the change itself ports directly.

**The user-visible reply differs from master.** 8.4's table entry is `X(QUERY_ESAFEDEPLETERFAILURE, "Depletion failed")` with no `SEARCH_` prefix emitted, so clients on this branch get the bare `Failed to acquire index lock for background depletion. ...` message rather than master's `SEARCH_SAFE_DEPLETER_FAILURE <msg>`. `tests/pytests/test_asm.py` on this branch already matches on the message substring, so no test accommodation is needed.

**The `array_newlen` fix is not optional here.** `errors[]` is built with `array_new` (`hybrid_request.c:216`) and torn down with `array_free_ex` (`:293`), which iterates `array_len` — zero. Nothing writes those slots today, so nothing leaks today; this change starts writing them, so the leak fix must land with it.

**The regression test is not included.** `test_hybrid_depleter_lock_failure_replies_error` drives the mechanism through the `BeforeHybridResultsClaim` sync point, and this branch has no `SYNC_POINT` framework at all. The `@skip(musl=True)` predicate and the `MUSL` flag are omitted with it, so `tests/pytests/` is untouched. (This branch does have a usable pause RP — `RPPauseAfterCount` / `PAUSE_BEFORE_RP_N` — but it is not wired into `_FT.DEBUG FT.HYBRID`, which accepts only `TIMEOUT_AFTER_N_*`. Wiring it up would be a separate, test-only change.)

**`src/coord/dist_aggregate.c` hand-ported.** Master extracted `rpnetCreateIterator()`; this branch still builds and dispatches the iterator inline in `rpnetNext_Start`, which has *two* `RS_RESULT_ERROR` exits (barrier allocation and iterator creation) rather than master's one. `QueryError_SetCode` is set on both.

### Testing

Built with `ENABLE_ASSERT=1` (assertion string confirmed present in the built `redisearch.so`), then:

- `TEST=test_asm.py` — 42/42 pass. This is the suite that exercises the depleter lock-failure path, so it is the evidence that the two new `RS_LOG_ASSERT`s do not fire on a reachable path — the main risk in backporting them this far.
- `TEST=test_hybrid_multithread.py` — 1/1 pass (the branch's pre-existing test).

Note for anyone reproducing locally on macOS: this branch does not build with llvm@21 as-is — vendored `fmt` fails with `use of undeclared identifier 'malloc'` in `fmt/format.h`. Confirmed pre-existing by building pristine `origin/8.4`, which fails identically. Worked around locally by force-including `<cstdlib>` in the fetched (untracked) header; nothing in this PR touches it.

#### Which additional issues this PR fixes
1. MOD-17316

#### Main objects this PR modified
1. `RPSafeDepleter_DepleteFromUpstream` — records `QUERY_ESAFEDEPLETERFAILURE`; message shared with `RPSafeDepleter_DepleteAll`
2. `HybridRequest_New` — `array_newlen` so `errors[]` are cleared on free
3. `handleAndReplyWarning` (`hybrid_exec.c`) and `_replyWarnings` (`aggregate_exec.c`) — assert that `RS_RESULT_ERROR` carries a message
4. `RPHybridMerger_Yield`, `rpnetNext_Start` — record a message before returning `RS_RESULT_ERROR`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
