### PR TITLE
[MOD-17448] Raise GC_FORCEINVOKE default timeout to 60s for disk indexes

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1026,16 +1026,18 @@ DEBUG_COMMAND(GCForceInvoke) {
   if (argc < 3 || argc > 4) {
     return RedisModule_WrongArity(ctx);
   }
-  long long timeout = 30000;
-
-  if (argc == 4) {
-    RedisModule_StringToLongLong(argv[3], &timeout);
-  }
   StrongRef ref = Indexes_LoadIndexSpecUnsafe(RedisModule_StringPtrLen(argv[2], NULL));
   IndexSpec *sp = StrongRef_Get(ref);
   if (!sp) {
     const char *idx = RedisModule_StringPtrLen(argv[2], NULL);
     return RedisModule_ReplyWithErrorFormat(ctx, "%s: %s", QueryError_Strerror(QUERY_ERROR_CODE_NO_INDEX), idx);
+  }
+
+  // Disk GC cycles (SpeedB compaction) take longer than fork GC, so disk
+  // indexes get a higher default timeout.
+  long long timeout = sp->diskSpec ? 60000 : 30000;
+  if (argc == 4) {
+    RedisModule_StringToLongLong(argv[3], &timeout);
   }
 
   // Indexes normally own a GCContext (`sp->gc`). Routing the forced invoke

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1036,8 +1036,9 @@ DEBUG_COMMAND(GCForceInvoke) {
   // Disk GC cycles (SpeedB compaction) take longer than fork GC, so disk
   // indexes get a higher default timeout.
   long long timeout = sp->diskSpec ? 60000 : 30000;
-  if (argc == 4) {
-    RedisModule_StringToLongLong(argv[3], &timeout);
+  if (argc == 4 &&
+      (RedisModule_StringToLongLong(argv[3], &timeout) != REDISMODULE_OK || timeout < 0)) {
+    return RedisModule_ReplyWithError(ctx, "Invalid TIMEOUT value");
   }
 
   // Indexes normally own a GCContext (`sp->gc`). Routing the forced invoke

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -24,6 +24,11 @@ class TestDebugCommands(object):
         self.env.expect(debug_cmd(), 'GC_FORCEINVOKE', 'invalid_idx').error().contains('SEARCH_INDEX_NOT_FOUND')
         self.env.expect(debug_cmd(), 'SET_MONITOR_EXPIRATION', 'invalid_idx').error().contains('SEARCH_INDEX_NOT_FOUND')
 
+    def testGcForceInvokeTimeoutArg(self):
+        self.env.expect(debug_cmd(), 'GC_FORCEINVOKE', 'idx', '30000').equal('DONE')
+        self.env.expect(debug_cmd(), 'GC_FORCEINVOKE', 'idx', 'notanumber').error().contains('Invalid TIMEOUT value')
+        self.env.expect(debug_cmd(), 'GC_FORCEINVOKE', 'idx', '-1').error().contains('Invalid TIMEOUT value')
+
     def testDebugHelp(self):
         err_msg = 'wrong number of arguments'
         help_list = [


### PR DESCRIPTION

## Describe the changes in the pull request

1. Current: `FT.DEBUG GC_FORCEINVOKE` uses the same default timeout of 30000 ms for RAM and disk indexes when no explicit `TIMEOUT` argument is given, and a malformed explicit `TIMEOUT` is silently ignored in favor of the default.
2. Change: Disk indexes (`sp->diskSpec`) now default to 60000 ms; RAM indexes keep 30000 ms. An explicit `TIMEOUT` argument still overrides the default for both, and a non-integer or negative `TIMEOUT` is now rejected with an error.
3. Outcome: Forced GC invocations on disk indexes, whose GC cycles (SpeedB compaction) take longer than fork GC, get twice the time to complete before the blocked client times out with `INVOCATION FAILED`.

#### Which additional issues this PR fixes
1. MOD-17448
2. #...

#### Main objects this PR modified
1. `GCForceInvoke` in `src/debug_commands.c`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
