### PR TITLE
ForkGC: Generalize scanner logic

### DIFF
--- a/src/fork_gc/pipe.h
+++ b/src/fork_gc/pipe.h
@@ -66,12 +66,9 @@ void FGC_updateStats(ForkGC *gc, RedisSearchCtx *sctx,
 void FGC_childCollectTerms(ForkGC *gc, RedisSearchCtx *sctx);
 FGCError FGC_parentHandleTerms(ForkGC *gc);
 
-void FGC_childCollectNumeric(ForkGC *gc, RedisSearchCtx *sctx);
 FGCError FGC_parentHandleNumeric(ForkGC *gc);
 
 void FGC_childCollectTags(ForkGC *gc, RedisSearchCtx *sctx);
 FGCError FGC_parentHandleTags(ForkGC *gc);
-
-FGCError FGC_parentHandleMissingDocs(ForkGC *gc);
 
 #endif /* FORK_GC_PIPE_H_ */

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
@@ -8,8 +8,8 @@
 */
 
 use fork_gc::{
-    ForkGC,
-    existing_docs::{HandleError, HandleOutcome, collect_existing_docs, handle_existing_docs},
+    ForkGC, HandleError, HandleOutcome,
+    existing_docs::{ExistingDocsDeleted, collect_existing_docs, handle_existing_docs},
     io_result_ext::IoResultExt,
 };
 use index_spec::IndexSpecReadGuard;
@@ -69,8 +69,12 @@ pub unsafe extern "C" fn FGC_parentHandleExistingDocs(gc: *mut ffi::ForkGC) -> F
     match handle_existing_docs(fgc) {
         Ok(HandleOutcome::Collected) => FGCError::Collected,
         Ok(HandleOutcome::Done) => FGCError::Done,
-        Err(HandleError::ChildError) => FGCError::ChildError,
+        Err(
+            HandleError::PipeReadError(_)
+            | HandleError::DeserializationFailed(_)
+            | HandleError::UnexpectedFrame,
+        ) => FGCError::ChildError,
         Err(HandleError::SpecDeleted) => FGCError::SpecDeleted,
-        Err(HandleError::ExistingDocsDeleted) => FGCError::ChildError,
+        Err(HandleError::Custom(ExistingDocsDeleted)) => FGCError::ParentError,
     }
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
@@ -8,13 +8,13 @@
 */
 
 use fork_gc::{
-    ForkGC, HandleError, HandleOutcome,
-    existing_docs::{ExistingDocsDeleted, collect_existing_docs, handle_existing_docs},
+    ForkGC,
+    existing_docs::{collect_existing_docs, handle_existing_docs},
     io_result_ext::IoResultExt,
 };
 use index_spec::IndexSpecReadGuard;
 
-use crate::FGCError;
+use crate::{FGCError, util::into_fgc_error};
 
 /// Collect GC delta data for the spec's `existingDocs` inverted index and
 /// send it to the parent process over the pipe.
@@ -73,11 +73,5 @@ pub unsafe extern "C" fn FGC_parentHandleExistingDocs(gc: *mut ffi::ForkGC) -> F
     // SAFETY: caller guarantees (1).
     let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
 
-    match handle_existing_docs(fgc) {
-        Ok(HandleOutcome::Collected) => FGCError::Collected,
-        Ok(HandleOutcome::Done) => FGCError::Done,
-        Err(HandleError::Codec { .. }) => FGCError::ChildError,
-        Err(HandleError::SpecDeleted) => FGCError::SpecDeleted,
-        Err(HandleError::Custom(ExistingDocsDeleted)) => FGCError::ParentError,
-    }
+    into_fgc_error(handle_existing_docs(fgc), "existing docs")
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
@@ -69,11 +69,7 @@ pub unsafe extern "C" fn FGC_parentHandleExistingDocs(gc: *mut ffi::ForkGC) -> F
     match handle_existing_docs(fgc) {
         Ok(HandleOutcome::Collected) => FGCError::Collected,
         Ok(HandleOutcome::Done) => FGCError::Done,
-        Err(
-            HandleError::PipeReadError(_)
-            | HandleError::DeserializationFailed(_)
-            | HandleError::UnexpectedFrame,
-        ) => FGCError::ChildError,
+        Err(HandleError::Codec { .. }) => FGCError::ChildError,
         Err(HandleError::SpecDeleted) => FGCError::SpecDeleted,
         Err(HandleError::Custom(ExistingDocsDeleted)) => FGCError::ParentError,
     }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/existing_docs.rs
@@ -23,12 +23,16 @@ use crate::FGCError;
 /// only the terminator is sent.  Otherwise an empty header followed by the
 /// serialised GC delta is sent before the terminator.
 ///
+/// # Panic
+///
+/// Panics if `pipe_write_fd` on `gc` is an invalid or closed writable file descriptor.
+///
 /// # Safety
 ///
-/// 1. `gc` must point to a valid [`ffi::ForkGC`] whose `pipe_write_fd` is an open,
-///    writable file descriptor.
-/// 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`] whose `spec` field is
-///    a non-null `IndexSpec`.
+/// 1. `gc` must point to a valid [`ffi::ForkGC`].
+/// 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`].
+/// 3. `sctx.spec` must be a non-null pointer to a valid [`ffi::IndexSpec`].
+/// 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_childCollectExistingDocs(
     gc: *mut ffi::ForkGC,
@@ -36,15 +40,14 @@ pub unsafe extern "C" fn FGC_childCollectExistingDocs(
 ) {
     // SAFETY: caller guarantees (1).
     let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
-
-    // SAFETY: caller guarantees (2); sctx is a valid non-null pointer.
+    // SAFETY: caller guarantees (2).
     let spec_ptr = unsafe { (*sctx).spec };
-    // SAFETY: caller guarantees (2); sctx.spec is a valid non-null IndexSpec.
+    // SAFETY: caller guarantees (3).
     let spec = unsafe { &*spec_ptr };
 
-    // SAFETY: We don't actually hold a read lock, but when the Fork GC code runs it holds the Redis GIL
-    // (so no other thread would be touching any shared Redis state), then forks and the child has
-    // only one thread with exclusive access to the index spec.
+    // SAFETY: caller guarantees (4). We don't actually hold a read lock, but when the Fork GC code
+    // runs it holds the Redis GIL (so no other thread would be touching any shared Redis state),
+    // then forks and the child has only one thread with exclusive access to the index spec.
     let guard = unsafe { IndexSpecReadGuard::from_locked(spec) };
 
     collect_existing_docs(&mut fgc.writer(), &guard).unwrap_or_exit();
@@ -57,10 +60,14 @@ pub unsafe extern "C" fn FGC_childCollectExistingDocs(
 /// [`FGCError::Collected`] after successfully applying a delta, or an
 /// error variant on pipe or spec failure.
 ///
+/// # Panic
+///
+/// Panics if `pipe_write_fd` on `gc` is an invalid or closed writable file descriptor.
+///
 /// # Safety
 ///
-/// 1. `gc` must point to a valid [`ffi::ForkGC`] whose `pipe_read_fd` is an
-///    open, readable file descriptor.
+/// 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
+///    alive for the duration of this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_parentHandleExistingDocs(gc: *mut ffi::ForkGC) -> FGCError {
     // SAFETY: caller guarantees (1).

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
@@ -8,13 +8,13 @@
 */
 
 use fork_gc::{
-    ForkGC, HandleError, HandleOutcome,
+    ForkGC,
     io_result_ext::IoResultExt,
-    missing_docs::{FieldNotFound, collect_missing_docs, handle_missing_docs},
+    missing_docs::{collect_missing_docs, handle_missing_docs},
 };
 use index_spec::IndexSpecReadGuard;
 
-use crate::FGCError;
+use crate::{FGCError, util::into_fgc_error};
 
 /// Collect GC delta data for every entry in the spec's `missingFieldDict` and
 /// send it to the parent process over the pipe.
@@ -76,11 +76,5 @@ pub unsafe extern "C" fn FGC_parentHandleMissingDocs(gc: *mut ffi::ForkGC) -> FG
     // SAFETY: caller guarantees (1).
     let fgc = unsafe { ForkGC::from_ptr_mut(gc) };
 
-    match handle_missing_docs(fgc) {
-        Ok(HandleOutcome::Collected) => FGCError::Collected,
-        Ok(HandleOutcome::Done) => FGCError::Done,
-        Err(HandleError::Codec { .. }) => FGCError::ChildError,
-        Err(HandleError::SpecDeleted) => FGCError::SpecDeleted,
-        Err(HandleError::Custom(FieldNotFound)) => FGCError::ParentError,
-    }
+    into_fgc_error(handle_missing_docs(fgc), "missing docs")
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
@@ -69,7 +69,8 @@ pub unsafe extern "C" fn FGC_childCollectMissingDocs(
 ///
 /// # Safety
 ///
-/// 1. `gc` must point to a valid [`ffi::ForkGC`].
+/// 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
+///    alive for the duration of this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn FGC_parentHandleMissingDocs(gc: *mut ffi::ForkGC) -> FGCError {
     // SAFETY: caller guarantees (1).

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
@@ -78,11 +78,7 @@ pub unsafe extern "C" fn FGC_parentHandleMissingDocs(gc: *mut ffi::ForkGC) -> FG
     match handle_missing_docs(fgc) {
         Ok(HandleOutcome::Collected) => FGCError::Collected,
         Ok(HandleOutcome::Done) => FGCError::Done,
-        Err(
-            HandleError::PipeReadError(_)
-            | HandleError::DeserializationFailed(_)
-            | HandleError::UnexpectedFrame,
-        ) => FGCError::ChildError,
+        Err(HandleError::Codec { .. }) => FGCError::ChildError,
         Err(HandleError::SpecDeleted) => FGCError::SpecDeleted,
         Err(HandleError::Custom(FieldNotFound)) => FGCError::ParentError,
     }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/missing_docs.rs
@@ -8,9 +8,9 @@
 */
 
 use fork_gc::{
-    ForkGC,
+    ForkGC, HandleError, HandleOutcome,
     io_result_ext::IoResultExt,
-    missing_docs::{HandleError, HandleOutcome, collect_missing_docs, handle_missing_docs},
+    missing_docs::{FieldNotFound, collect_missing_docs, handle_missing_docs},
 };
 use index_spec::IndexSpecReadGuard;
 
@@ -78,10 +78,12 @@ pub unsafe extern "C" fn FGC_parentHandleMissingDocs(gc: *mut ffi::ForkGC) -> FG
     match handle_missing_docs(fgc) {
         Ok(HandleOutcome::Collected) => FGCError::Collected,
         Ok(HandleOutcome::Done) => FGCError::Done,
-        Err(HandleError::PipeReadError(_)) => FGCError::ChildError,
-        Err(HandleError::DeserializationFailed(_)) => FGCError::ChildError,
-        Err(HandleError::UnexpectedFrame) => FGCError::ChildError,
+        Err(
+            HandleError::PipeReadError(_)
+            | HandleError::DeserializationFailed(_)
+            | HandleError::UnexpectedFrame,
+        ) => FGCError::ChildError,
         Err(HandleError::SpecDeleted) => FGCError::SpecDeleted,
-        Err(HandleError::FieldNotFound) => FGCError::ParentError,
+        Err(HandleError::Custom(FieldNotFound)) => FGCError::ParentError,
     }
 }

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/numeric.rs
@@ -18,6 +18,10 @@ use index_spec::IndexSpecReadGuard;
 /// with GC work, then a per-field terminator. A final terminator is sent once
 /// all fields have been processed.
 ///
+/// # Panic
+///
+/// Panics if `pipe_write_fd` on `gc` is an invalid or closed writable file descriptor.
+///
 /// # Safety
 ///
 /// 1. `gc` must point to a valid [`ffi::ForkGC`].

--- a/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/util.rs
+++ b/src/redisearch_rs/c_entrypoint/fork_gc_ffi/src/util.rs
@@ -7,10 +7,14 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::{ffi::c_void, ptr};
+use std::{error::Error, ffi::c_void, ptr};
 
-use fork_gc::Frame;
+use fork_gc::{Frame, HandleError, HandleOutcome};
 use nul_terminated_bytes::NulTerminatedBytes;
+use tracing::Level;
+use tracing_log_error::log_error;
+
+use crate::FGCError;
 
 /// Consume the frame, producing the `(buf, len)` pair that the C
 /// `FGC_recvBuffer` and `recvFieldHeader` API exposes through its
@@ -29,6 +33,29 @@ pub(crate) fn frame_into_c_buffer(frame: Frame<NulTerminatedBytes>) -> (*mut c_v
         Frame::Data(data) => {
             let (ptr, len) = data.into_inner().into_raw_parts();
             (ptr.cast(), len)
+        }
+    }
+}
+
+/// Convert a scanner's parent-side handler result into the [`FGCError`] the C
+/// caller expects, logging the failures that warrant it.
+///
+/// `scanner` names the scanner in the log line, for example `"existing docs"`.
+pub(crate) fn into_fgc_error<C: Error>(
+    result: Result<HandleOutcome, HandleError<C>>,
+    scanner: &str,
+) -> FGCError {
+    match result {
+        Ok(HandleOutcome::Collected) => FGCError::Collected,
+        Ok(HandleOutcome::Done) => FGCError::Done,
+        Err(e @ HandleError::Codec { .. }) => {
+            log_error!(e, level: Level::WARN, "ForkGC: {scanner}: codec error");
+            FGCError::ChildError
+        }
+        Err(HandleError::SpecDeleted) => FGCError::SpecDeleted,
+        Err(e @ HandleError::Custom(_)) => {
+            log_error!(e, level: Level::WARN, "ForkGC: {scanner}: apply error");
+            FGCError::ParentError
         }
     }
 }

--- a/src/redisearch_rs/fork_gc/src/existing_docs.rs
+++ b/src/redisearch_rs/fork_gc/src/existing_docs.rs
@@ -124,15 +124,9 @@ pub fn apply_existing_docs(
 pub fn handle_existing_docs(
     fgc: &mut ForkGC,
 ) -> Result<HandleOutcome, HandleError<ExistingDocsDeleted>> {
-    let Some(delta) = receive_existing_docs(&mut fgc.reader())? else {
-        return Ok(HandleOutcome::Done);
-    };
-
-    let mut spec_ref = fgc.index_spec().promote().ok_or(HandleError::SpecDeleted)?;
-    let mut guard = spec_ref.write();
-
-    let stats = apply_existing_docs(delta, &mut guard)?;
-    stats.apply(fgc, &mut guard);
-
-    Ok(HandleOutcome::Collected)
+    crate::util::handle_one(
+        fgc,
+        |reader| receive_existing_docs(reader),
+        apply_existing_docs,
+    )
 }

--- a/src/redisearch_rs/fork_gc/src/existing_docs.rs
+++ b/src/redisearch_rs/fork_gc/src/existing_docs.rs
@@ -15,26 +15,13 @@ use index_spec::{IndexSpecReadGuard, IndexSpecWriteGuard};
 use inverted_index::GcScanDelta;
 use serde::Serialize as _;
 
-use crate::{ForkGC, Frame, HandleError, HandleOutcome};
+use crate::{ForkGC, Frame, GcApplyStats, HandleError, HandleOutcome};
 
 /// The `existingDocs` inverted index was removed between the child's scan and
 /// the parent's apply (a race between GC and a concurrent index drop).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 #[error("the existingDocs inverted index was removed before the delta could be applied")]
 pub struct ExistingDocsDeleted;
-
-/// Statistics produced by [`apply_existing_docs`], forwarded by
-/// [`handle_existing_docs`] to [`ForkGC::update_gc_stats`].
-pub struct ApplyInfo {
-    /// Added block count
-    pub added_block_count: i64,
-    /// Bytes freed by this GC pass.
-    pub bytes_freed: usize,
-    /// Bytes allocated during compaction (new block overhead).
-    pub bytes_allocated: usize,
-    /// Whether the last block was skipped to avoid data races.
-    pub ignored_last_block: bool,
-}
 
 /// Collect the GC delta for the spec's `existingDocs` inverted index and write
 /// it to `writer`.
@@ -90,8 +77,8 @@ pub fn receive_existing_docs(
 
 /// Apply a pre-decoded GC delta to the spec's `existingDocs` inverted index.
 ///
-/// Returns [`ApplyInfo`] with counters the caller can forward to
-/// [`ForkGC::update_gc_stats`].
+/// Returns [`GcApplyStats`] the caller flushes to the spec and the GC via
+/// [`GcApplyStats::apply`].
 ///
 /// Returns `Err(HandleError::Custom(ExistingDocsDeleted))` when the spec has no
 /// `existingDocs` index, which can happen if the index was removed between
@@ -99,7 +86,7 @@ pub fn receive_existing_docs(
 pub fn apply_existing_docs(
     delta: GcScanDelta,
     guard: &mut IndexSpecWriteGuard<'_>,
-) -> Result<ApplyInfo, HandleError<ExistingDocsDeleted>> {
+) -> Result<GcApplyStats, HandleError<ExistingDocsDeleted>> {
     let Some(ii) = guard.existing_docs_mut() else {
         return Err(HandleError::Custom(ExistingDocsDeleted));
     };
@@ -115,28 +102,15 @@ pub fn apply_existing_docs(
         (0, 0)
     };
 
-    Ok(ApplyInfo {
-        added_block_count: info.block_count_delta - remaining_blocks as i64,
-        bytes_freed: info.bytes_freed + extra,
+    Ok(GcApplyStats {
+        // `records_removed` is 0: existingDocs entries are not counted on insertion
+        // (they are internal duplicates), so we do not count them on removal either.
+        records_removed: 0,
+        bytes_collected: info.bytes_freed + extra,
         bytes_allocated: info.bytes_allocated,
-        ignored_last_block: info.ignored_last_block,
+        block_count_delta: info.block_count_delta - remaining_blocks as i64,
+        blocks_denied: info.ignored_last_block as u64,
     })
-}
-
-/// Update both the spec-level and GC-level statistics after applying a GC delta.
-///
-/// Combines the spec stats update (done under the write lock) and the GC stats
-/// update that always go together after a successful [`apply_existing_docs`] call.
-pub fn update_stats(info: &ApplyInfo, guard: &mut IndexSpecWriteGuard<'_>, fgc: &mut ForkGC) {
-    guard.add_block_count(info.added_block_count);
-    // entries_removed is 0: existingDocs entries are not counted on insertion
-    // (they are internal duplicates), so we do not count them on removal either.
-    guard.update_gc_stats(0, info.bytes_freed, info.bytes_allocated);
-    fgc.update_gc_stats(
-        info.bytes_freed,
-        info.bytes_allocated,
-        info.ignored_last_block,
-    );
 }
 
 /// Parent-side handler for the `existingDocs` GC protocol.
@@ -157,8 +131,8 @@ pub fn handle_existing_docs(
     let mut spec_ref = fgc.index_spec().promote().ok_or(HandleError::SpecDeleted)?;
     let mut guard = spec_ref.write();
 
-    let info = apply_existing_docs(delta, &mut guard)?;
-    update_stats(&info, &mut guard, fgc);
+    let stats = apply_existing_docs(delta, &mut guard)?;
+    stats.apply(fgc, &mut guard);
 
     Ok(HandleOutcome::Collected)
 }

--- a/src/redisearch_rs/fork_gc/src/existing_docs.rs
+++ b/src/redisearch_rs/fork_gc/src/existing_docs.rs
@@ -71,10 +71,20 @@ pub fn collect_existing_docs(writer: &mut impl Write, spec: &IndexSpecReadGuard)
 pub fn receive_existing_docs(
     reader: &mut impl Read,
 ) -> Result<Option<GcScanDelta>, HandleError<ExistingDocsDeleted>> {
-    match Frame::decode(reader)? {
-        Frame::Empty => Ok(Some(rmp_serde::from_read::<_, GcScanDelta>(reader)?)),
+    let frame = Frame::decode(reader)
+        .map_err(|e| HandleError::codec("reading the existing-docs header frame", e))?;
+
+    match frame {
+        Frame::Empty => {
+            let delta = rmp_serde::from_read::<_, GcScanDelta>(reader)
+                .map_err(|e| HandleError::codec("decoding the existing-docs delta", e))?;
+            Ok(Some(delta))
+        }
         Frame::Terminator => Ok(None),
-        Frame::Data(_) => Err(HandleError::UnexpectedFrame),
+        Frame::Data(_) => Err(HandleError::codec(
+            "expected an empty or terminator frame for existing-docs",
+            "got a data frame",
+        )),
     }
 }
 

--- a/src/redisearch_rs/fork_gc/src/existing_docs.rs
+++ b/src/redisearch_rs/fork_gc/src/existing_docs.rs
@@ -15,29 +15,13 @@ use index_spec::{IndexSpecReadGuard, IndexSpecWriteGuard};
 use inverted_index::GcScanDelta;
 use serde::Serialize as _;
 
-use crate::{ForkGC, Frame};
+use crate::{ForkGC, Frame, HandleError, HandleOutcome};
 
-/// Successful outcome of [`handle_existing_docs`].
-pub enum HandleOutcome {
-    /// Delta received and applied; iteration may continue.
-    Collected,
-    /// Child sent no data; iteration is complete.
-    Done,
-}
-
-/// Error returned by [`handle_existing_docs`] and its sub-functions.
-///
-/// Mapped to `FGCError` variants at the FFI layer.
-#[derive(Debug)]
-pub enum HandleError {
-    /// Pipe read failed; child likely crashed.
-    ChildError,
-    /// The index spec was deleted before the delta could be applied.
-    SpecDeleted,
-    /// The `existingDocs` inverted index was removed between the child's scan
-    /// and the parent's apply (race between GC and a concurrent index drop).
-    ExistingDocsDeleted,
-}
+/// The `existingDocs` inverted index was removed between the child's scan and
+/// the parent's apply (a race between GC and a concurrent index drop).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("the existingDocs inverted index was removed before the delta could be applied")]
+pub struct ExistingDocsDeleted;
 
 /// Statistics produced by [`apply_existing_docs`], forwarded by
 /// [`handle_existing_docs`] to [`ForkGC::update_gc_stats`].
@@ -83,14 +67,14 @@ pub fn collect_existing_docs(writer: &mut impl Write, spec: &IndexSpecReadGuard)
 ///
 /// Returns `Ok(Some(delta))` when the child sent a GC delta to apply,
 /// `Ok(None)` when the child sent only a terminator (nothing to collect),
-/// or `Err(HandleError::ChildError)` on any read or deserialisation failure.
-pub fn receive_existing_docs(reader: &mut impl Read) -> Result<Option<GcScanDelta>, HandleError> {
-    match Frame::decode(reader) {
-        Ok(Frame::Empty) => rmp_serde::from_read::<_, GcScanDelta>(reader)
-            .map(Some)
-            .map_err(|_| HandleError::ChildError),
-        Ok(Frame::Terminator) => Ok(None),
-        _ => Err(HandleError::ChildError),
+/// or an error variant on any read, decode, or unexpected-frame failure.
+pub fn receive_existing_docs(
+    reader: &mut impl Read,
+) -> Result<Option<GcScanDelta>, HandleError<ExistingDocsDeleted>> {
+    match Frame::decode(reader)? {
+        Frame::Empty => Ok(Some(rmp_serde::from_read::<_, GcScanDelta>(reader)?)),
+        Frame::Terminator => Ok(None),
+        Frame::Data(_) => Err(HandleError::UnexpectedFrame),
     }
 }
 
@@ -99,15 +83,15 @@ pub fn receive_existing_docs(reader: &mut impl Read) -> Result<Option<GcScanDelt
 /// Returns [`ApplyInfo`] with counters the caller can forward to
 /// [`ForkGC::update_gc_stats`].
 ///
-/// Returns `Err(HandleError::ExistingDocsDeleted)` when the spec has no
+/// Returns `Err(HandleError::Custom(ExistingDocsDeleted))` when the spec has no
 /// `existingDocs` index, which can happen if the index was removed between
 /// the child's scan and the parent's apply.
 pub fn apply_existing_docs(
     delta: GcScanDelta,
     guard: &mut IndexSpecWriteGuard<'_>,
-) -> Result<ApplyInfo, HandleError> {
+) -> Result<ApplyInfo, HandleError<ExistingDocsDeleted>> {
     let Some(ii) = guard.existing_docs_mut() else {
-        return Err(HandleError::ExistingDocsDeleted);
+        return Err(HandleError::Custom(ExistingDocsDeleted));
     };
 
     let info = ii.apply_gc(delta);
@@ -153,7 +137,9 @@ pub fn update_stats(info: &ApplyInfo, guard: &mut IndexSpecWriteGuard<'_>, fgc: 
 ///
 /// Returns `Ok(HandleOutcome::Done)` when the child sent no data (empty
 /// index or no GC needed).
-pub fn handle_existing_docs(fgc: &mut ForkGC) -> Result<HandleOutcome, HandleError> {
+pub fn handle_existing_docs(
+    fgc: &mut ForkGC,
+) -> Result<HandleOutcome, HandleError<ExistingDocsDeleted>> {
     let Some(delta) = receive_existing_docs(&mut fgc.reader())? else {
         return Ok(HandleOutcome::Done);
     };

--- a/src/redisearch_rs/fork_gc/src/fork_gc.rs
+++ b/src/redisearch_rs/fork_gc/src/fork_gc.rs
@@ -105,17 +105,15 @@ impl ForkGC {
     }
 
     /// Update the GC-level statistics after applying a garbage collection delta.
-    ///
-    /// This is the GC-side half of `FGC_updateStats`.
     pub const fn update_gc_stats(
         &mut self,
         bytes_collected: usize,
         bytes_allocated: usize,
-        ignored_last_block: bool,
+        blocks_denied: u64,
     ) {
         self.0.stats.totalCollected += bytes_collected as isize;
         self.0.stats.totalCollected -= bytes_allocated as isize;
-        self.0.stats.gcBlocksDenied += ignored_last_block as u64;
+        self.0.stats.gcBlocksDenied += blocks_denied;
     }
 }
 

--- a/src/redisearch_rs/fork_gc/src/handle.rs
+++ b/src/redisearch_rs/fork_gc/src/handle.rs
@@ -11,10 +11,10 @@
 //!
 //! Every scanner's parent-side handler returns the same [`HandleOutcome`] and a
 //! [`HandleError`] that differs only in its scanner-specific failures. The
-//! frame-protocol failures common to all scanners are captured as dedicated
-//! variants; the rest go in [`HandleError::Custom`].
+//! frame-protocol failures common to all scanners collapse into
+//! [`HandleError::Codec`]; the rest go in [`HandleError::Custom`].
 
-use std::io;
+use std::error::Error;
 
 /// Successful outcome of a scanner's parent-side handler.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,22 +27,23 @@ pub enum HandleOutcome {
 
 /// Error returned by a scanner's parent-side handler and its sub-functions.
 ///
-/// The failure modes shared by every scanner are captured as dedicated variants.
-/// A scanner's own failure modes live in [`HandleError::Custom`], parameterised
-/// by a scanner-specific type `C`.
+/// Every way the child's frame stream can fail us is a [`HandleError::Codec`].
+/// [`HandleError::SpecDeleted`] covers the index being dropped before the parent
+/// could apply the delta, which every scanner can hit. A scanner's own failure
+/// modes live in [`HandleError::Custom`], parameterised by a scanner-specific
+/// type `C`.
 #[derive(Debug, thiserror::Error)]
 pub enum HandleError<C> {
-    /// Reading a frame from the child's pipe failed; the child likely crashed.
-    #[error("pipe read error")]
-    PipeReadError(#[from] io::Error),
-
-    /// A frame's MessagePack payload could not be decoded; the child likely crashed.
-    #[error("deserialisation failed")]
-    DeserializationFailed(#[from] rmp_serde::decode::Error),
-
-    /// A valid frame of an unexpected kind arrived where a specific frame was required.
-    #[error("child sent a valid frame of an unexpected kind")]
-    UnexpectedFrame,
+    /// The child's frame stream could not be read or decoded; the child likely
+    /// crashed or is speaking a different protocol.
+    #[error("{msg}")]
+    Codec {
+        /// The step that failed, phrased for a log line.
+        msg: &'static str,
+        /// The underlying failure, type-erased.
+        #[source]
+        source: Box<dyn Error + Send + Sync>,
+    },
 
     /// The weak spec reference could not be promoted; the index was dropped before apply.
     #[error("the index spec was deleted before the delta could be applied")]
@@ -51,4 +52,18 @@ pub enum HandleError<C> {
     /// A scanner-specific failure.
     #[error(transparent)]
     Custom(C),
+}
+
+impl<C> HandleError<C> {
+    /// Build a [`HandleError::Codec`] from the step that failed and its cause.
+    ///
+    /// `source` takes anything convertible into a boxed error, which includes
+    /// `&'static str` — use that for protocol violations we detect ourselves
+    /// and that have no underlying error to wrap.
+    pub fn codec(msg: &'static str, source: impl Into<Box<dyn Error + Send + Sync>>) -> Self {
+        Self::Codec {
+            msg,
+            source: source.into(),
+        }
+    }
 }

--- a/src/redisearch_rs/fork_gc/src/handle.rs
+++ b/src/redisearch_rs/fork_gc/src/handle.rs
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Shared outcome and error types for the fork-GC scanners.
+//!
+//! Every scanner's parent-side handler returns the same [`HandleOutcome`] and a
+//! [`HandleError`] that differs only in its scanner-specific failures. The
+//! frame-protocol failures common to all scanners are captured as dedicated
+//! variants; the rest go in [`HandleError::Custom`].
+
+use std::io;
+
+/// Successful outcome of a scanner's parent-side handler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HandleOutcome {
+    /// A unit of GC data was received and applied; iteration may continue.
+    Collected,
+    /// The child sent the terminator; iteration is complete.
+    Done,
+}
+
+/// Error returned by a scanner's parent-side handler and its sub-functions.
+///
+/// The failure modes shared by every scanner are captured as dedicated variants.
+/// A scanner's own failure modes live in [`HandleError::Custom`], parameterised
+/// by a scanner-specific type `C`.
+#[derive(Debug, thiserror::Error)]
+pub enum HandleError<C> {
+    /// Reading a frame from the child's pipe failed; the child likely crashed.
+    #[error("pipe read error")]
+    PipeReadError(#[from] io::Error),
+
+    /// A frame's MessagePack payload could not be decoded; the child likely crashed.
+    #[error("deserialisation failed")]
+    DeserializationFailed(#[from] rmp_serde::decode::Error),
+
+    /// A valid frame of an unexpected kind arrived where a specific frame was required.
+    #[error("child sent a valid frame of an unexpected kind")]
+    UnexpectedFrame,
+
+    /// The weak spec reference could not be promoted; the index was dropped before apply.
+    #[error("the index spec was deleted before the delta could be applied")]
+    SpecDeleted,
+
+    /// A scanner-specific failure.
+    #[error(transparent)]
+    Custom(C),
+}

--- a/src/redisearch_rs/fork_gc/src/lib.rs
+++ b/src/redisearch_rs/fork_gc/src/lib.rs
@@ -18,6 +18,7 @@
 pub mod existing_docs;
 pub mod fork_gc;
 pub mod frame;
+pub mod handle;
 pub mod io_result_ext;
 pub mod missing_docs;
 pub mod numeric;
@@ -25,3 +26,4 @@ pub mod util;
 
 pub use fork_gc::ForkGC;
 pub use frame::Frame;
+pub use handle::{HandleError, HandleOutcome};

--- a/src/redisearch_rs/fork_gc/src/lib.rs
+++ b/src/redisearch_rs/fork_gc/src/lib.rs
@@ -22,8 +22,10 @@ pub mod handle;
 pub mod io_result_ext;
 pub mod missing_docs;
 pub mod numeric;
+pub mod stats;
 pub mod util;
 
 pub use fork_gc::ForkGC;
 pub use frame::Frame;
 pub use handle::{HandleError, HandleOutcome};
+pub use stats::GcApplyStats;

--- a/src/redisearch_rs/fork_gc/src/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/src/missing_docs.rs
@@ -12,46 +12,17 @@
 use std::ffi::{CStr, CString};
 use std::io::{self, Read, Write};
 
-use crate::{ForkGC, Frame};
+use crate::{ForkGC, Frame, HandleError, HandleOutcome};
 use hidden_string::OwnedHiddenString;
 use index_spec::{IndexSpecReadGuard, IndexSpecWriteGuard};
 use inverted_index::GcScanDelta;
 use serde::Serialize as _;
 
-/// Successful outcome of [`handle_missing_docs`].
-#[derive(Debug, Clone, Copy)]
-pub enum HandleOutcome {
-    /// Delta received and applied; iteration may continue.
-    Collected,
-    /// Child sent a terminator; all missing-docs entries have been processed.
-    Done,
-}
-
-/// Error returned by [`handle_missing_docs`] and its sub-functions.
-///
-/// Mapped to `FGCError` variants at the FFI layer.
-#[derive(Debug, thiserror::Error)]
-pub enum HandleError {
-    /// Reading a frame from the child's pipe failed; the child likely crashed.
-    #[error("pipe read error")]
-    PipeReadError(#[from] io::Error),
-
-    /// A frame's MessagePack payload could not be decoded into a [`GcScanDelta`]; the child likely crashed.
-    #[error("deserialisation failed")]
-    DeserializationFailed(#[from] rmp_serde::decode::Error),
-
-    /// An empty frame arrived where a field-name [`Frame::Data`] or [`Frame::Terminator`] was required.
-    #[error("child sent a valid frame of an unexpected kind")]
-    UnexpectedFrame,
-
-    /// The weak spec reference could not be promoted; the index was dropped before apply.
-    #[error("the index spec was deleted before the delta could be applied")]
-    SpecDeleted,
-
-    /// The field was removed from `missingFieldDict` between the child's scan and the parent's apply.
-    #[error("the field was removed from missingFieldDict before the delta could be applied")]
-    FieldNotFound,
-}
+/// The field was removed from `missingFieldDict` between the child's scan and
+/// the parent's apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("the field was removed from missingFieldDict before the delta could be applied")]
+pub struct FieldNotFound;
 
 /// Statistics produced by [`apply_missing_docs`], forwarded by
 /// [`handle_missing_docs`] to [`update_stats`].
@@ -103,7 +74,7 @@ pub fn collect_missing_docs(writer: &mut impl Write, spec: &IndexSpecReadGuard) 
 /// Decode one missing-docs message from `reader`.
 pub fn receive_missing_docs(
     reader: &mut impl Read,
-) -> Result<Option<(CString, GcScanDelta)>, HandleError> {
+) -> Result<Option<(CString, GcScanDelta)>, HandleError<FieldNotFound>> {
     match Frame::decode_nul_terminated(reader)? {
         Frame::Terminator => Ok(None),
         Frame::Data(field_name) => {
@@ -114,7 +85,7 @@ pub fn receive_missing_docs(
                 .expect("child always sends a field name that is a valid C string");
             Ok(Some((field_name, delta)))
         }
-        Frame::Empty => Err(HandleError::UnexpectedFrame),
+        Frame::Empty => Err(HandleError::Custom(FieldNotFound)),
     }
 }
 
@@ -127,11 +98,11 @@ pub fn apply_missing_docs(
     field_name: &CStr,
     delta: GcScanDelta,
     guard: &mut IndexSpecWriteGuard<'_>,
-) -> Result<ApplyInfo, HandleError> {
+) -> Result<ApplyInfo, HandleError<FieldNotFound>> {
     let hidden = OwnedHiddenString::new(field_name);
 
     let Some(ii) = guard.missing_field_dict_mut().fetch_mut(&hidden) else {
-        return Err(HandleError::FieldNotFound);
+        return Err(HandleError::Custom(FieldNotFound));
     };
 
     let gc_info = ii.apply_gc(delta);
@@ -184,7 +155,7 @@ pub fn update_stats(info: &ApplyInfo, guard: &mut IndexSpecWriteGuard<'_>, fgc: 
 /// - A [`Frame::Terminator`] → all fields processed, returns `Ok(HandleOutcome::Done)`.
 ///
 /// Errors map to corresponding `FGCError` variants at the FFI layer.
-pub fn handle_missing_docs(fgc: &mut ForkGC) -> Result<HandleOutcome, HandleError> {
+pub fn handle_missing_docs(fgc: &mut ForkGC) -> Result<HandleOutcome, HandleError<FieldNotFound>> {
     let Some((field_name, delta)) = receive_missing_docs(&mut fgc.reader())? else {
         return Ok(HandleOutcome::Done);
     };

--- a/src/redisearch_rs/fork_gc/src/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/src/missing_docs.rs
@@ -12,7 +12,7 @@
 use std::ffi::{CStr, CString};
 use std::io::{self, Read, Write};
 
-use crate::{ForkGC, Frame, HandleError, HandleOutcome};
+use crate::{ForkGC, Frame, GcApplyStats, HandleError, HandleOutcome};
 use hidden_string::OwnedHiddenString;
 use index_spec::{IndexSpecReadGuard, IndexSpecWriteGuard};
 use inverted_index::GcScanDelta;
@@ -23,21 +23,6 @@ use serde::Serialize as _;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 #[error("the field was removed from missingFieldDict before the delta could be applied")]
 pub struct FieldNotFound;
-
-/// Statistics produced by [`apply_missing_docs`], forwarded by
-/// [`handle_missing_docs`] to [`update_stats`].
-pub struct ApplyInfo {
-    /// Net change in block count for this GC pass.
-    pub added_block_count: i64,
-    /// Bytes freed by this GC pass.
-    pub bytes_freed: usize,
-    /// Bytes allocated during compaction (new block overhead).
-    pub bytes_allocated: usize,
-    /// Number of entries removed from the inverted index.
-    pub entries_removed: usize,
-    /// Whether the last block was skipped to avoid data races.
-    pub ignored_last_block: bool,
-}
 
 /// Collect GC deltas for every entry in the spec's `missingFieldDict` and write
 /// them to the parent process.
@@ -100,12 +85,13 @@ pub fn receive_missing_docs(
 ///
 /// The field's inverted index is removed from the dict once it has no unique docs left.
 ///
-/// Returns [`ApplyInfo`] with counters the caller can forward to [`update_stats`].
+/// Returns [`GcApplyStats`] the caller flushes to the spec and the GC via
+/// [`GcApplyStats::apply`].
 pub fn apply_missing_docs(
     field_name: &CStr,
     delta: GcScanDelta,
     guard: &mut IndexSpecWriteGuard<'_>,
-) -> Result<ApplyInfo, HandleError<FieldNotFound>> {
+) -> Result<GcApplyStats, HandleError<FieldNotFound>> {
     let hidden = OwnedHiddenString::new(field_name);
 
     let Some(ii) = guard.missing_field_dict_mut().fetch_mut(&hidden) else {
@@ -123,35 +109,16 @@ pub fn apply_missing_docs(
         (0, 0)
     };
 
-    Ok(ApplyInfo {
-        added_block_count: gc_info
-            .block_count_delta
-            .checked_sub(remaining_blocks as i64)
-            .expect("block count delta should never underflow/overflow"),
-        bytes_freed: gc_info
-            .bytes_freed
-            .checked_add(extra)
-            .expect("freed bytes should never overflow"),
+    Ok(GcApplyStats {
+        // `records_removed` is 0: missingFieldDict entries are not counted
+        // on insertion (they are internal bookkeeping), so we do not count
+        // them on removal either.
+        records_removed: 0,
+        bytes_collected: gc_info.bytes_freed + extra,
         bytes_allocated: gc_info.bytes_allocated,
-        entries_removed: gc_info.entries_removed,
-        ignored_last_block: gc_info.ignored_last_block,
+        block_count_delta: gc_info.block_count_delta - remaining_blocks as i64,
+        blocks_denied: gc_info.ignored_last_block as u64,
     })
-}
-
-/// Update both the spec-level and GC-level statistics after applying a GC delta.
-///
-/// Combines the spec stats update (done under the write lock) and the GC stats
-/// update that always go together after a successful [`apply_missing_docs`] call.
-pub fn update_stats(info: &ApplyInfo, guard: &mut IndexSpecWriteGuard<'_>, fgc: &mut ForkGC) {
-    guard.add_block_count(info.added_block_count);
-    // entries_removed is 0: existingDocs entries are not counted on insertion
-    // (they are internal duplicates), so we do not count them on removal either.
-    guard.update_gc_stats(0, info.bytes_freed, info.bytes_allocated);
-    fgc.update_gc_stats(
-        info.bytes_freed,
-        info.bytes_allocated,
-        info.ignored_last_block,
-    );
 }
 
 /// Parent-side handler for one iteration of the missing-docs GC protocol.
@@ -170,8 +137,8 @@ pub fn handle_missing_docs(fgc: &mut ForkGC) -> Result<HandleOutcome, HandleErro
     let mut spec_ref = fgc.index_spec().promote().ok_or(HandleError::SpecDeleted)?;
     let mut guard = spec_ref.write();
 
-    let info = apply_missing_docs(&field_name, delta, &mut guard)?;
-    update_stats(&info, &mut guard, fgc);
+    let stats = apply_missing_docs(&field_name, delta, &mut guard)?;
+    stats.apply(fgc, &mut guard);
 
     Ok(HandleOutcome::Collected)
 }

--- a/src/redisearch_rs/fork_gc/src/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/src/missing_docs.rs
@@ -130,15 +130,9 @@ pub fn apply_missing_docs(
 ///
 /// Errors map to corresponding `FGCError` variants at the FFI layer.
 pub fn handle_missing_docs(fgc: &mut ForkGC) -> Result<HandleOutcome, HandleError<FieldNotFound>> {
-    let Some((field_name, delta)) = receive_missing_docs(&mut fgc.reader())? else {
-        return Ok(HandleOutcome::Done);
-    };
-
-    let mut spec_ref = fgc.index_spec().promote().ok_or(HandleError::SpecDeleted)?;
-    let mut guard = spec_ref.write();
-
-    let stats = apply_missing_docs(&field_name, delta, &mut guard)?;
-    stats.apply(fgc, &mut guard);
-
-    Ok(HandleOutcome::Collected)
+    crate::util::handle_one(
+        fgc,
+        |reader| receive_missing_docs(reader),
+        |(field_name, delta), guard| apply_missing_docs(&field_name, delta, guard),
+    )
 }

--- a/src/redisearch_rs/fork_gc/src/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/src/missing_docs.rs
@@ -75,17 +75,24 @@ pub fn collect_missing_docs(writer: &mut impl Write, spec: &IndexSpecReadGuard) 
 pub fn receive_missing_docs(
     reader: &mut impl Read,
 ) -> Result<Option<(CString, GcScanDelta)>, HandleError<FieldNotFound>> {
-    match Frame::decode_nul_terminated(reader)? {
+    let frame = Frame::decode_nul_terminated(reader)
+        .map_err(|e| HandleError::codec("reading the missing-docs field-name frame", e))?;
+
+    match frame {
         Frame::Terminator => Ok(None),
         Frame::Data(field_name) => {
-            let delta = rmp_serde::from_read::<_, GcScanDelta>(reader)?;
+            let delta = rmp_serde::from_read::<_, GcScanDelta>(reader)
+                .map_err(|e| HandleError::codec("decoding the missing-docs delta", e))?;
             let field_name = field_name
                 .into_inner()
                 .into_c_string()
                 .expect("child always sends a field name that is a valid C string");
             Ok(Some((field_name, delta)))
         }
-        Frame::Empty => Err(HandleError::Custom(FieldNotFound)),
+        Frame::Empty => Err(HandleError::codec(
+            "expected a field-name or terminator frame for missing-docs",
+            "got an empty frame",
+        )),
     }
 }
 

--- a/src/redisearch_rs/fork_gc/src/stats.rs
+++ b/src/redisearch_rs/fork_gc/src/stats.rs
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Statistics accumulated by a fork-GC scanner while applying collected deltas.
+
+use index_spec::IndexSpecWriteGuard;
+
+use crate::ForkGC;
+
+/// Book-keeping produced by applying garbage-collection deltas to an inverted
+/// index.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct GcApplyStats {
+    /// Records removed from the inverted index. Decrements the spec's `numRecords`.
+    pub records_removed: usize,
+    /// Bytes freed by this GC pass. Lowers the spec's `invertedSize` and raises
+    /// the GC's `totalCollected`.
+    pub bytes_collected: usize,
+    /// Bytes allocated during compaction (new block overhead). Raises the spec's
+    /// `invertedSize` and lowers the GC's `totalCollected`.
+    pub bytes_allocated: usize,
+    /// Net change to the inverted-index block count. Applied to the spec's
+    /// `totalInvertedIndexBlocks`.
+    pub block_count_delta: i64,
+    /// Number of last blocks skipped to avoid data races. Increments the GC's
+    /// `gcBlocksDenied`.
+    pub blocks_denied: u64,
+}
+
+impl GcApplyStats {
+    /// Apply this delta to both the spec-level and GC-level statistics.
+    ///
+    /// Combines the spec stats update (done under the write lock) and the GC
+    /// stats update that always go together after applying a GC delta.
+    pub fn apply(&self, fgc: &mut ForkGC, guard: &mut IndexSpecWriteGuard<'_>) {
+        guard.update_gc_stats(
+            self.records_removed,
+            self.bytes_collected,
+            self.bytes_allocated,
+        );
+        guard.add_block_count(self.block_count_delta);
+        fgc.update_gc_stats(
+            self.bytes_collected,
+            self.bytes_allocated,
+            self.blocks_denied,
+        );
+    }
+}

--- a/src/redisearch_rs/fork_gc/src/util.rs
+++ b/src/redisearch_rs/fork_gc/src/util.rs
@@ -13,8 +13,38 @@ use std::{
     time::Duration,
 };
 
+use index_spec::IndexSpecWriteGuard;
 use nix::poll::{PollFd, PollFlags};
 use redis_module::raw::RedisModule_ExitFromChild;
+
+use crate::fork_gc::ForkGCPipeReader;
+use crate::{ForkGC, GcApplyStats, HandleError, HandleOutcome};
+
+/// Run the single-shot GC handler protocol shared by the per-index scanners
+/// that apply one message per call (existing-docs, missing-docs):
+///
+/// 1. `receive` one message from the pipe; a `None` means the child sent the
+///    terminator, so iteration is [`Done`](HandleOutcome::Done).
+/// 2. Promote and write-lock the spec (gone → [`HandleError::SpecDeleted`]).
+/// 3. `apply` the message, then flush the resulting [`GcApplyStats`] to both
+///    the spec and the fork GC via [`GcApplyStats::apply`].
+pub(crate) fn handle_one<M, C>(
+    fgc: &mut ForkGC,
+    receive: impl FnOnce(&mut ForkGCPipeReader<'_>) -> Result<Option<M>, HandleError<C>>,
+    apply: impl FnOnce(M, &mut IndexSpecWriteGuard<'_>) -> Result<GcApplyStats, HandleError<C>>,
+) -> Result<HandleOutcome, HandleError<C>> {
+    let Some(message) = receive(&mut fgc.reader())? else {
+        return Ok(HandleOutcome::Done);
+    };
+
+    let mut spec_ref = fgc.index_spec().promote().ok_or(HandleError::SpecDeleted)?;
+    let mut guard = spec_ref.write();
+
+    let stats = apply(message, &mut guard)?;
+    stats.apply(fgc, &mut guard);
+
+    Ok(HandleOutcome::Collected)
+}
 
 /// Log a write error and terminate the current process.
 pub(crate) fn exit_on_write_error(err: io::Error) -> ! {

--- a/src/redisearch_rs/fork_gc/tests/existing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/existing_docs.rs
@@ -11,9 +11,9 @@ use std::{io::Cursor, mem};
 
 use ffi::IndexFlags_Index_DocIdsOnly;
 use fork_gc::{
-    Frame,
+    Frame, HandleError,
     existing_docs::{
-        HandleError, apply_existing_docs, collect_existing_docs, receive_existing_docs,
+        ExistingDocsDeleted, apply_existing_docs, collect_existing_docs, receive_existing_docs,
     },
 };
 use index_result::RSIndexResult;
@@ -119,11 +119,11 @@ fn receive_terminator_returns_none() {
 }
 
 #[test]
-fn receive_malformed_frame_returns_child_error() {
+fn receive_malformed_frame_returns_pipe_read_error() {
     let mut cursor = Cursor::new(b"garbage");
     assert!(matches!(
         receive_existing_docs(&mut cursor),
-        Err(HandleError::ChildError)
+        Err(HandleError::PipeReadError(_))
     ));
 }
 
@@ -150,7 +150,7 @@ fn apply_returns_err_when_existing_docs_absent() {
     let mut guard = unsafe { IndexSpecWriteGuard::from_locked_mut(&mut apply_spec) };
     assert!(matches!(
         apply_existing_docs(delta, &mut *guard),
-        Err(HandleError::ExistingDocsDeleted)
+        Err(HandleError::Custom(ExistingDocsDeleted))
     ));
 }
 

--- a/src/redisearch_rs/fork_gc/tests/existing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/existing_docs.rs
@@ -179,8 +179,8 @@ fn roundtrip_all_docs_deleted_clears_index() {
     let delta = receive_existing_docs(&mut cursor).unwrap().unwrap();
 
     let mut write_guard = unsafe { IndexSpecWriteGuard::from_locked_mut(&mut spec) };
-    let info = apply_existing_docs(delta, &mut *write_guard).unwrap();
+    let stats = apply_existing_docs(delta, &mut *write_guard).unwrap();
 
     assert!(write_guard.existing_docs_mut().is_none());
-    assert!(info.bytes_freed > 0);
+    assert!(stats.bytes_collected > 0);
 }

--- a/src/redisearch_rs/fork_gc/tests/existing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/existing_docs.rs
@@ -119,11 +119,14 @@ fn receive_terminator_returns_none() {
 }
 
 #[test]
-fn receive_malformed_frame_returns_pipe_read_error() {
+fn receive_malformed_frame_returns_codec_error() {
     let mut cursor = Cursor::new(b"garbage");
     assert!(matches!(
         receive_existing_docs(&mut cursor),
-        Err(HandleError::PipeReadError(_))
+        Err(HandleError::Codec {
+            msg: "reading the existing-docs header frame",
+            ..
+        })
     ));
 }
 

--- a/src/redisearch_rs/fork_gc/tests/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/missing_docs.rs
@@ -13,8 +13,8 @@ use dict::MissingFieldDictType;
 use dict::OwnedDict;
 use ffi::IndexFlags_Index_DocIdsOnly;
 use fork_gc::{
-    Frame,
-    missing_docs::{HandleError, apply_missing_docs, collect_missing_docs, receive_missing_docs},
+    Frame, HandleError,
+    missing_docs::{FieldNotFound, apply_missing_docs, collect_missing_docs, receive_missing_docs},
 };
 use hidden_string::OwnedHiddenString;
 use index_result::RSIndexResult;
@@ -196,7 +196,7 @@ fn apply_returns_err_when_field_not_found() {
     let mut write_guard = unsafe { IndexSpecWriteGuard::from_locked_mut(&mut spec) };
     assert!(matches!(
         apply_missing_docs(c"nonexistent", delta, &mut *write_guard),
-        Err(HandleError::FieldNotFound)
+        Err(HandleError::Custom(FieldNotFound))
     ));
 }
 

--- a/src/redisearch_rs/fork_gc/tests/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/missing_docs.rs
@@ -211,9 +211,9 @@ fn apply_succeeds_and_keeps_entry_when_docs_remain() {
     let delta = GcScanDelta::empty_for_testing();
 
     let mut write_guard = unsafe { IndexSpecWriteGuard::from_locked_mut(&mut spec) };
-    let info = apply_missing_docs(c"age", delta, &mut *write_guard).unwrap();
+    let stats = apply_missing_docs(c"age", delta, &mut *write_guard).unwrap();
 
-    assert_eq!(info.entries_removed, 0);
+    assert_eq!(stats.records_removed, 0);
     let hidden = OwnedHiddenString::new(c"age");
     assert!(
         write_guard
@@ -243,7 +243,7 @@ fn roundtrip_all_docs_deleted_removes_entry() {
 
     // Parent side: apply.
     let mut write_guard = unsafe { IndexSpecWriteGuard::from_locked_mut(&mut spec) };
-    let info = apply_missing_docs(&field_name, delta, &mut *write_guard).unwrap();
+    let stats = apply_missing_docs(&field_name, delta, &mut *write_guard).unwrap();
 
     let hidden = OwnedHiddenString::new(c"age");
     assert!(
@@ -252,6 +252,6 @@ fn roundtrip_all_docs_deleted_removes_entry() {
             .fetch_mut(&hidden)
             .is_none()
     );
-    assert!(info.bytes_freed > 0);
-    assert!(info.entries_removed > 0);
+    assert!(stats.bytes_collected > 0);
+    assert_eq!(stats.records_removed, 0);
 }

--- a/src/redisearch_rs/fork_gc/tests/missing_docs.rs
+++ b/src/redisearch_rs/fork_gc/tests/missing_docs.rs
@@ -166,11 +166,14 @@ fn receive_terminator_returns_none() {
 }
 
 #[test]
-fn receive_malformed_frame_returns_pipe_read_error() {
+fn receive_malformed_frame_returns_codec_error() {
     let mut cursor = Cursor::new(b"garbage");
     assert!(matches!(
         receive_missing_docs(&mut cursor),
-        Err(HandleError::PipeReadError(_))
+        Err(HandleError::Codec {
+            msg: "reading the missing-docs field-name frame",
+            ..
+        })
     ));
 }
 

--- a/src/redisearch_rs/headers/fork_gc_ffi.h
+++ b/src/redisearch_rs/headers/fork_gc_ffi.h
@@ -49,6 +49,10 @@ extern "C" {
  * with GC work, then a per-field terminator. A final terminator is sent once
  * all fields have been processed.
  *
+ * # Panic
+ *
+ * Panics if `pipe_write_fd` on `gc` is an invalid or closed writable file descriptor.
+ *
  * # Safety
  *
  * 1. `gc` must point to a valid [`ffi::ForkGC`].
@@ -66,12 +70,16 @@ void FGC_childCollectNumeric(ForkGC *gc, RedisSearchCtx *sctx);
  * only the terminator is sent.  Otherwise an empty header followed by the
  * serialised GC delta is sent before the terminator.
  *
+ * # Panic
+ *
+ * Panics if `pipe_write_fd` on `gc` is an invalid or closed writable file descriptor.
+ *
  * # Safety
  *
- * 1. `gc` must point to a valid [`ffi::ForkGC`] whose `pipe_write_fd` is an open,
- *    writable file descriptor.
- * 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`] whose `spec` field is
- *    a non-null `IndexSpec`.
+ * 1. `gc` must point to a valid [`ffi::ForkGC`].
+ * 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`].
+ * 3. `sctx.spec` must be a non-null pointer to a valid [`ffi::IndexSpec`].
+ * 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
  */
 void FGC_childCollectExistingDocs(ForkGC *gc, RedisSearchCtx *sctx);
 
@@ -98,21 +106,6 @@ void FGC_childCollectExistingDocs(ForkGC *gc, RedisSearchCtx *sctx);
 void FGC_childCollectMissingDocs(ForkGC *gc, RedisSearchCtx *sctx);
 
 /**
- * Receive and apply the GC delta for the spec's `existingDocs` inverted index.
- *
- * Reads one protocol frame from the pipe. Returns [`FGCError::Done`] when
- * the child sent no data (index absent or nothing to collect),
- * [`FGCError::Collected`] after successfully applying a delta, or an
- * error variant on pipe or spec failure.
- *
- * # Safety
- *
- * 1. `gc` must point to a valid [`ffi::ForkGC`] whose `pipe_read_fd` is an
- *    open, readable file descriptor.
- */
-enum FGCError FGC_parentHandleExistingDocs(ForkGC *gc);
-
-/**
  * Write exactly `len` bytes from `buff` to the FGC pipe.
  *
  * On error, logs the failure and terminates the child process via
@@ -126,6 +119,25 @@ enum FGCError FGC_parentHandleExistingDocs(ForkGC *gc);
  * 3. `len` must be greater than zero.
  */
 void FGC_sendFixed(ForkGC *fgc, const void *buff, size_t len);
+
+/**
+ * Receive and apply the GC delta for the spec's `existingDocs` inverted index.
+ *
+ * Reads one protocol frame from the pipe. Returns [`FGCError::Done`] when
+ * the child sent no data (index absent or nothing to collect),
+ * [`FGCError::Collected`] after successfully applying a delta, or an
+ * error variant on pipe or spec failure.
+ *
+ * # Panic
+ *
+ * Panics if `pipe_write_fd` on `gc` is an invalid or closed writable file descriptor.
+ *
+ * # Safety
+ *
+ * 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
+ *    alive for the duration of this call.
+ */
+enum FGCError FGC_parentHandleExistingDocs(ForkGC *gc);
 
 /**
  * Receive and apply the GC delta for one field in the spec's `missingFieldDict`.
@@ -143,7 +155,8 @@ void FGC_sendFixed(ForkGC *fgc, const void *buff, size_t len);
  *
  * # Safety
  *
- * 1. `gc` must point to a valid [`ffi::ForkGC`].
+ * 1. `gc` must point to a valid [`ffi::ForkGC`], with no other reference to it
+ *    alive for the duration of this call.
  */
 enum FGCError FGC_parentHandleMissingDocs(ForkGC *gc);
 


### PR DESCRIPTION
## Describe the changes in the pull request

Generalize logic used by both existing scanners (existing docs and missing docs) and future scanners (numeric, tags, terms):
1. Generic `HandleOutcome` and `HandleError` enums for use in the parent side handlers.
2. Generic `Stats` struct returned by all parent side handlers.
3. `handle_one` function used by all current and future scanners, except the numeric scanner, which continues to require a custom setup.
4. Some docs cleanup.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
