### PR TITLE
[MOD-17377] Prevent crashes when deleting deep suffix-trie entries

### DIFF
--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -25,6 +25,7 @@
 #include "trie/rune_util.h"
 #include "trie/trie_node.h"
 #include "util/arr/arr.h"
+#include "util/likely.h"
 #include "wildcard/wildcard.h"
 
 struct timespec;
@@ -652,19 +653,20 @@ int TrieNode_Delete(TrieNode *n, const rune *str, t_len len, TrieFreeCallback fr
   int rc = 0;
 
   while (n && offset < len) {
-    if (stackPos == stackCap) {
+    if (unlikely(stackPos == stackCap)) {
       size_t newStackCap = stackCap * 2;
       TrieNode **newStack = NULL;
-      if (stack == localStack) {
+      if (likely(stack == localStack)) {
         newStack = rm_malloc(newStackCap * sizeof(*newStack));
+        if (!newStack) {
+          goto end;
+        }
+        memcpy(newStack, stack, stackPos * sizeof(*stack));
       } else {
         newStack = rm_realloc(stack, newStackCap * sizeof(*newStack));
-      }
-      if (!newStack) {
-        goto end;
-      }
-      if (stack == localStack) {
-        memcpy(newStack, stack, stackPos * sizeof(*stack));
+        if (!newStack) {
+          goto end;
+        }
       }
       stack = newStack;
       stackCap = newStackCap;

--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -645,13 +645,29 @@ static int __trieNode_optimizeChildren(TrieNode *n, TrieFreeCallback freecb) {
 
 int TrieNode_Delete(TrieNode *n, const rune *str, t_len len, TrieFreeCallback freecb) {
   t_len offset = 0;
-  TrieNode *stack[TRIE_INITIAL_STRING_LEN];
-  int stackPos = 0;
+  TrieNode *localStack[TRIE_INITIAL_STRING_LEN];
+  TrieNode **stack = localStack;
+  size_t stackCap = TRIE_INITIAL_STRING_LEN;
+  size_t stackPos = 0;
   int rc = 0;
 
   while (n && offset < len) {
-    if (stackPos == TRIE_INITIAL_STRING_LEN) {
-      goto end;
+    if (stackPos == stackCap) {
+      size_t newStackCap = stackCap * 2;
+      TrieNode **newStack = NULL;
+      if (stack == localStack) {
+        newStack = rm_malloc(newStackCap * sizeof(*newStack));
+      } else {
+        newStack = rm_realloc(stack, newStackCap * sizeof(*newStack));
+      }
+      if (!newStack) {
+        goto end;
+      }
+      if (stack == localStack) {
+        memcpy(newStack, stack, stackPos * sizeof(*stack));
+      }
+      stack = newStack;
+      stackCap = newStackCap;
     }
     stack[stackPos++] = n;
     t_len localOffset = 0;
@@ -699,8 +715,12 @@ int TrieNode_Delete(TrieNode *n, const rune *str, t_len len, TrieFreeCallback fr
 
 end:
 
-  while (stackPos--) {
+  while (stackPos) {
+    --stackPos;
     __trieNode_optimizeChildren(stack[stackPos], freecb);
+  }
+  if (stack != localStack) {
+    rm_free(stack);
   }
   return rc;
 }

--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -655,18 +655,12 @@ int TrieNode_Delete(TrieNode *n, const rune *str, t_len len, TrieFreeCallback fr
   while (n && offset < len) {
     if (unlikely(stackPos == stackCap)) {
       size_t newStackCap = stackCap * 2;
-      TrieNode **newStack = NULL;
+      TrieNode **newStack;
       if (likely(stack == localStack)) {
         newStack = rm_malloc(newStackCap * sizeof(*newStack));
-        if (!newStack) {
-          goto end;
-        }
         memcpy(newStack, stack, stackPos * sizeof(*stack));
       } else {
         newStack = rm_realloc(stack, newStackCap * sizeof(*newStack));
-        if (!newStack) {
-          goto end;
-        }
       }
       stack = newStack;
       stackCap = newStackCap;

--- a/tests/ctests/test_trie.c
+++ b/tests/ctests/test_trie.c
@@ -29,6 +29,12 @@
 size_t __trieNode_Sizeof(t_len numChildren, t_len slen);
 
 int count = 0;
+static size_t freedTriePayloads = 0;
+
+static void countTriePayloadFree(void *payload) {
+  (void)payload;
+  ++freedTriePayloads;
+}
 
 static size_t alignUp(size_t value, size_t alignment) {
   size_t remainder = value % alignment;
@@ -1145,6 +1151,37 @@ int testTrieNodeSizeof() {
   return 0;
 }
 
+int testDeleteRunesDeepSuffixTrieUsesDynamicStack() {
+  freedTriePayloads = 0;
+  Trie *t = NewTrie(countTriePayloadFree, Trie_Sort_Lex);
+  ASSERT(t != NULL);
+
+  enum { keyLen = TRIE_INITIAL_STRING_LEN * 2 + 16 };
+  rune key[keyLen];
+  for (size_t i = 0; i < keyLen; ++i) {
+    key[i] = 'a';
+  }
+
+  RSPayload payload = {.data = "payload", .len = strlen("payload")};
+
+  // Match repeated addSuffixTrie() full-word inserts: Trie_InsertRuneNoSize()
+  // bypasses the normal length guard, and overlapping terms split the trie into
+  // a traversal path that exceeds the local stack and its first heap growth.
+  for (size_t len = 1; len <= keyLen; ++len) {
+    int rc = Trie_InsertRuneNoSize(t, key, len, 1, 0, &payload, 0);
+    ASSERT_EQUAL(TRIE_OK_NEW, rc);
+  }
+  ASSERT_EQUAL(0, freedTriePayloads);
+
+  ASSERT_EQUAL(1, Trie_DeleteRunes(t, key, keyLen));
+  ASSERT(Trie_GetNode(t, key, keyLen, true, NULL) == NULL);
+  ASSERT(Trie_GetNode(t, key, keyLen - 1, true, NULL) != NULL);
+  ASSERT_EQUAL(1, freedTriePayloads);
+
+  TrieType_Free(t);
+  return 0;
+}
+
 TEST_MAIN({
   RMUTil_InitAlloc();
   TESTFUNC(testRuneUtil);
@@ -1158,4 +1195,5 @@ TEST_MAIN({
   TESTFUNC(testDecrementNumDocsComplex);
   TESTFUNC(testDecrementNumDocsNonTerminal);
   TESTFUNC(testTrieNodeSizeof);
+  TESTFUNC(testDeleteRunesDeepSuffixTrieUsesDynamicStack);
 });

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -317,16 +317,14 @@ def testContainsGCDeepSuffixTrie(env):
     pipe.execute()
     waitForIndex(env, 'idx')
 
-    suffix_terms = env.cmd(debug_cmd(), 'DUMP_SUFFIX_TRIE', 'idx')
-    env.assertContains('a' * max_len, suffix_terms)
+    # DUMP_SUFFIX_TRIE uses TrieIterator's fixed traversal stack, so use suffix
+    # queries here to cover deep delete behavior instead of debug enumeration.
     env.expect('FT.SEARCH', 'idx', '*' + ('a' * max_len), 'LIMIT', 0, 0).equal([1])
     env.expect('FT.SEARCH', 'idx', '*aa', 'LIMIT', 0, 0).equal([max_len - 1])
 
     conn.execute_command('DEL', f'doc:{max_len}')
     forceInvokeGC(env, 'idx')
 
-    suffix_terms = env.cmd(debug_cmd(), 'DUMP_SUFFIX_TRIE', 'idx')
-    env.assertNotContains('a' * max_len, suffix_terms)
     env.expect('FT.SEARCH', 'idx', '*' + ('a' * max_len), 'LIMIT', 0, 0).equal([0])
     env.expect('FT.SEARCH', 'idx', '*' + ('a' * (max_len - 1)), 'LIMIT', 0, 0).equal([1])
     env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', 0, 0).equal([max_len - 1])

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -296,37 +296,41 @@ def testContainsGC(env):
 
 @skip(cluster=True)
 def testContainsGCDeepSuffixTrie(env):
-  env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', 0).ok()
-  env.expect(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', 1000000).ok()
+  max_prefix_expansions = env.cmd(config_cmd(), 'GET', 'MAXPREFIXEXPANSIONS')[0][1]
+  try:
+    env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', 0).ok()
+    env.expect(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', 1000000).ok()
 
-  conn = getConnectionByEnv(env)
-  conn.execute_command('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'doc:',
-                       'STOPWORDS', '0', 'SCHEMA', 't', 'TEXT', 'NOSTEM',
-                       'WITHSUFFIXTRIE')
+    conn = getConnectionByEnv(env)
+    conn.execute_command('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'doc:',
+                         'STOPWORDS', '0', 'SCHEMA', 't', 'TEXT', 'NOSTEM',
+                         'WITHSUFFIXTRIE')
 
-  # 528 exceeds twice TrieNode_Delete's initial stack cap (256), covering the
-  # heap realloc path in addition to the first local-to-heap stack growth.
-  max_len = 528
-  pipe = conn.pipeline()
-  for n in range(1, max_len + 1):
-    pipe.execute_command('HSET', f'doc:{n}', 't', 'a' * n)
-    if n % 50 == 0:
-      pipe.execute()
-  pipe.execute()
-  waitForIndex(env, 'idx')
+    # 528 exceeds twice TrieNode_Delete's initial stack cap (256), covering the
+    # heap realloc path in addition to the first local-to-heap stack growth.
+    max_len = 528
+    pipe = conn.pipeline()
+    for n in range(1, max_len + 1):
+      pipe.execute_command('HSET', f'doc:{n}', 't', 'a' * n)
+      if n % 50 == 0:
+        pipe.execute()
+    pipe.execute()
+    waitForIndex(env, 'idx')
 
-  suffix_terms = env.cmd(debug_cmd(), 'DUMP_SUFFIX_TRIE', 'idx')
-  env.assertContains('a' * max_len, suffix_terms)
-  env.expect('FT.SEARCH', 'idx', '*aa', 'LIMIT', 0, 0).equal([max_len - 1])
+    suffix_terms = env.cmd(debug_cmd(), 'DUMP_SUFFIX_TRIE', 'idx')
+    env.assertContains('a' * max_len, suffix_terms)
+    env.expect('FT.SEARCH', 'idx', '*aa', 'LIMIT', 0, 0).equal([max_len - 1])
 
-  conn.execute_command('DEL', f'doc:{max_len}')
-  forceInvokeGC(env, 'idx')
+    conn.execute_command('DEL', f'doc:{max_len}')
+    forceInvokeGC(env, 'idx')
 
-  suffix_terms = env.cmd(debug_cmd(), 'DUMP_SUFFIX_TRIE', 'idx')
-  env.assertNotContains('a' * max_len, suffix_terms)
-  env.assertContains('a' * (max_len - 1), suffix_terms)
-  env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', 0, 0).equal([max_len - 1])
-  env.expect('FT.SEARCH', 'idx', '*aa', 'LIMIT', 0, 0).equal([max_len - 2])
+    suffix_terms = env.cmd(debug_cmd(), 'DUMP_SUFFIX_TRIE', 'idx')
+    env.assertNotContains('a' * max_len, suffix_terms)
+    env.assertContains('a' * (max_len - 1), suffix_terms)
+    env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', 0, 0).equal([max_len - 1])
+    env.expect('FT.SEARCH', 'idx', '*aa', 'LIMIT', 0, 0).equal([max_len - 2])
+  finally:
+    env.expect(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', max_prefix_expansions).ok()
 
 @skip(cluster=True)
 def testContainsGCTag(env):

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -295,6 +295,40 @@ def testContainsGC(env):
                   sorted(['d', 'ld', 'orld', 'rld', 'world']))
 
 @skip(cluster=True)
+def testContainsGCDeepSuffixTrie(env):
+  env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', 0).ok()
+  env.expect(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', 1000000).ok()
+
+  conn = getConnectionByEnv(env)
+  conn.execute_command('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', 'doc:',
+                       'STOPWORDS', '0', 'SCHEMA', 't', 'TEXT', 'NOSTEM',
+                       'WITHSUFFIXTRIE')
+
+  # 528 exceeds twice TrieNode_Delete's initial stack cap (256), covering the
+  # heap realloc path in addition to the first local-to-heap stack growth.
+  max_len = 528
+  pipe = conn.pipeline()
+  for n in range(1, max_len + 1):
+    pipe.execute_command('HSET', f'doc:{n}', 't', 'a' * n)
+    if n % 50 == 0:
+      pipe.execute()
+  pipe.execute()
+  waitForIndex(env, 'idx')
+
+  suffix_terms = env.cmd(debug_cmd(), 'DUMP_SUFFIX_TRIE', 'idx')
+  env.assertContains('a' * max_len, suffix_terms)
+  env.expect('FT.SEARCH', 'idx', '*aa', 'LIMIT', 0, 0).equal([max_len - 1])
+
+  conn.execute_command('DEL', f'doc:{max_len}')
+  forceInvokeGC(env, 'idx')
+
+  suffix_terms = env.cmd(debug_cmd(), 'DUMP_SUFFIX_TRIE', 'idx')
+  env.assertNotContains('a' * max_len, suffix_terms)
+  env.assertContains('a' * (max_len - 1), suffix_terms)
+  env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', 0, 0).equal([max_len - 1])
+  env.expect('FT.SEARCH', 'idx', '*aa', 'LIMIT', 0, 0).equal([max_len - 2])
+
+@skip(cluster=True)
 def testContainsGCTag(env):
   env.expect(config_cmd() + ' set FORK_GC_CLEAN_THRESHOLD 0').ok()
 

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -319,6 +319,7 @@ def testContainsGCDeepSuffixTrie(env):
 
     suffix_terms = env.cmd(debug_cmd(), 'DUMP_SUFFIX_TRIE', 'idx')
     env.assertContains('a' * max_len, suffix_terms)
+    env.expect('FT.SEARCH', 'idx', '*' + ('a' * max_len), 'LIMIT', 0, 0).equal([1])
     env.expect('FT.SEARCH', 'idx', '*aa', 'LIMIT', 0, 0).equal([max_len - 1])
 
     conn.execute_command('DEL', f'doc:{max_len}')
@@ -326,7 +327,8 @@ def testContainsGCDeepSuffixTrie(env):
 
     suffix_terms = env.cmd(debug_cmd(), 'DUMP_SUFFIX_TRIE', 'idx')
     env.assertNotContains('a' * max_len, suffix_terms)
-    env.assertContains('a' * (max_len - 1), suffix_terms)
+    env.expect('FT.SEARCH', 'idx', '*' + ('a' * max_len), 'LIMIT', 0, 0).equal([0])
+    env.expect('FT.SEARCH', 'idx', '*' + ('a' * (max_len - 1)), 'LIMIT', 0, 0).equal([1])
     env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', 0, 0).equal([max_len - 1])
     env.expect('FT.SEARCH', 'idx', '*aa', 'LIMIT', 0, 0).equal([max_len - 2])
   finally:


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `TrieNode_Delete()` stops at the fixed traversal stack limit for deep suffix-trie paths, which can leave accepted suffix-trie entries undeleted.
2. Change: Grow the traversal stack dynamically after the local buffer is exhausted, then continue normal delete cleanup.
3. Outcome: Deep suffix-trie entries can be deleted and cleaned up without abandoning traversal at the fixed limit.

#### Which additional issues this PR fixes
1. MOD-17377

#### Main objects this PR modified
1. `src/trie/trie_node.c`
2. `tests/ctests/test_trie.c`
3. `tests/pytests/test_contains.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Validation:
- `git diff --check`
- `python3 -m py_compile tests/pytests/test_contains.py`
- `cc -fsyntax-only ... src/trie/trie_node.c`
- `cc -fsyntax-only ... tests/ctests/test_trie.c`

Note: Full build/test runs were not completed in this local environment.
