### PR TITLE
[MOD-17394] UnionHeap: clear the heap before the initial child reads

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -220,18 +220,26 @@ where
     }
 
     /// Performs initial read on all children and builds the heap.
+    ///
+    /// Clears the heap first: a `revalidate` before the first read runs
+    /// [`Self::rebuild_heap`] while every child is still at `last_doc_id() == 0`,
+    /// and those doc-0 entries would otherwise sort ahead of every real id.
     fn initialize_children(&mut self) -> Result<(), RQEIteratorError> {
+        self.heap.clear();
         for (idx, child) in self.children.iter_mut().enumerate() {
             if child.last_doc_id() == 0 && !child.at_eof() {
                 if child.read()?.is_some() {
                     self.heap.push(child.last_doc_id(), idx);
-                } else {
-                    self.num_active -= 1;
                 }
             } else if child.last_doc_id() > 0 {
                 self.heap.push(child.last_doc_id(), idx);
             }
         }
+        // Derived here rather than adjusted, for the same reason the heap is:
+        // a `rebuild_heap` before the first read counts only the children it kept,
+        // and this pass can seed the heap with one it dropped. Leaving the count
+        // alone would let the per-child decrements below run past zero.
+        self.num_active = self.heap.len();
         Ok(())
     }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_heap.rs
@@ -19,7 +19,7 @@ mod common {
     union_common_tests!(UnionFullHeap, UnionQuickHeap);
 }
 
-use crate::utils::{create_mock_2, create_mock_3};
+use crate::utils::{Mock, MockRevalidateResult, create_mock_2, create_mock_3};
 use rqe_iterators::{RQEIterator, UnionFullHeap, UnionQuickHeap};
 
 // =============================================================================
@@ -136,4 +136,98 @@ fn into_trimmed_quick_heap_trims_desc() {
     }
     // Active window [1..3), reads in reverse: child[2] then child[1].
     assert_eq!(docs, [5, 6, 3, 4]);
+}
+
+/// The same stale-entry problem with children that all have documents, which is
+/// the damaging shape: the union emits doc 0, advances the child whose stale
+/// entry it just consumed — dropping a document that child had already produced
+/// during heap setup — and never converges, because a duplicate entry keeps
+/// matching the id just yielded.
+///
+/// One child has to still be unread when the rebuild runs, so only the sibling
+/// reports `Moved` (which advances a `Mock` onto its first document).
+///
+/// The drain is bounded so a regression fails on the assertion below rather than
+/// spinning until the harness kills it.
+#[test]
+#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+fn revalidate_before_first_read_keeps_every_document_of_non_empty_children() {
+    let moved: Mock<'static, 2> = Mock::new([5, 7]);
+    let mut moved_data = moved.data();
+    let untouched: Mock<'static, 2> = Mock::new([6, 8]);
+
+    let children: Vec<Box<dyn RQEIterator<'static>>> = vec![Box::new(moved), Box::new(untouched)];
+    let mut it = UnionFullHeap::new(children);
+
+    // `Moved` triggers the rebuild and leaves this child on doc 5, while the
+    // sibling stays at `last_doc_id() == 0` — the entry that would go stale.
+    moved_data.set_revalidate_result(MockRevalidateResult::Move);
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let _ = it
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate should not fail");
+
+    // One more than the 4 documents on offer, so an iterator that fails to
+    // converge is caught rather than drained forever.
+    const MAX_READS: usize = 5;
+    let mut doc_ids = Vec::new();
+    for _ in 0..MAX_READS {
+        match it.read().expect("read should not fail") {
+            Some(result) => doc_ids.push(result.doc_id),
+            None => break,
+        }
+    }
+
+    assert_eq!(
+        doc_ids,
+        vec![5, 6, 7, 8],
+        "the union must yield both children in full: no doc 0 ahead of them, no \
+         document dropped by a stale entry advancing a child twice, and no id \
+         repeated by a duplicate entry",
+    );
+}
+
+/// The active-child count is derived from the same pass that seeds the heap.
+///
+/// A pre-read revalidation can move a child onto its last document, which under a
+/// look-ahead `at_eof()` excludes it from `rebuild_heap` and from the count taken
+/// from that heap — while the reseed below legitimately puts it back. A count left
+/// over from the smaller heap then runs past zero as children exhaust, which
+/// panics in debug and wraps into a nonsense sort weight in release.
+#[test]
+#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+fn revalidate_before_first_read_keeps_the_active_count_in_step_with_the_heap() {
+    // One document, so `Moved` leaves this child on its last one.
+    let moved: Mock<'static, 1> = Mock::new([5]);
+    let mut moved_data = moved.data();
+    let other: Mock<'static, 2> = Mock::new([6, 8]);
+
+    let children: Vec<Box<dyn RQEIterator<'static>>> = vec![Box::new(moved), Box::new(other)];
+    let mut it = UnionFullHeap::new(children);
+    assert_eq!(it.num_children_active(), 2);
+
+    moved_data.set_revalidate_result(MockRevalidateResult::Move);
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let _ = it
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate should not fail");
+
+    // One more than the 3 documents on offer, so a non-converging iterator is
+    // caught rather than drained forever.
+    const MAX_READS: usize = 4;
+    let mut doc_ids = Vec::new();
+    for _ in 0..MAX_READS {
+        match it.read().expect("read should not fail") {
+            Some(result) => doc_ids.push(result.doc_id),
+            None => break,
+        }
+    }
+
+    assert_eq!(doc_ids, vec![5, 6, 8], "every document, once, in order");
+    assert_eq!(
+        it.num_children_active(),
+        0,
+        "both children are exhausted, and the count reached zero by counting them \
+         rather than by wrapping past it",
+    );
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `UnionHeap` populates its child heap from two places.
   `rebuild_heap` (after a revalidation) clears the heap first;
   `initialize_children` (before the first read) does not. So a revalidation that
   ran *before* the first read would leave one entry per child at doc 0 — every
   child still at `last_doc_id() == 0`, reporting `at_eof() == false` — and the
   first read would then push a second entry per child on top of them.
   `DocIdMinHeap::push` is a plain append with no de-duplication, so both would
   survive.
2. **Change:** `initialize_children` clears the heap before seeding it, so the
   entries it creates are the only ones present — and derives `num_active` from
   the same pass instead of adjusting it, so the count cannot be left over from a
   heap the reseed has replaced.
3. **Outcome:** The invariant is local and checked — whichever of the two sites
   runs, the heap holds exactly one entry per live child.

### The active-child count had to move with it

Fixing the heap alone is not enough, and this is worth spelling out because the
first symptom was hiding the second.

`revalidate` sets `num_active` from the heap `rebuild_heap` just built. A
pre-read revalidation that moves a child onto its last document has that child
report `at_eof() == true` under the look-ahead reading, so `rebuild_heap` drops it
and the count omits it — while the reseed legitimately puts it back through the
`last_doc_id() > 0` branch. The count then sits below the number of children in
the heap, and the per-child decrements run past zero as they exhaust: `attempt to
subtract with overflow` in debug, and in release a wrapped
`num_children_active()`, which feeds `intersection_sort_weight` and would corrupt
`Intersection`'s pivot ordering.

The stale-entry bug was masking this: a union that never converges never
exhausts its children, so the decrements never ran out. Clearing the heap without
also deriving the count would have traded the spin for a panic — the added test
below fails exactly that way against a fix that stops at the `clear()`.

### This is latent, not a live bug

**No query appears to reach the state, and this PR is not fixing user-visible
behaviour.** `handleSpecLockAndRevalidate` revalidates only when the spec lock is
unheld:

```c
if (sctx->lock_state != SPEC_LOCK_UNSET) {
  return false;
}
```

The query path takes the read lock *before* `prepareExecutionPlan` builds the
iterator tree (`aggregate_exec.c`, "released in `AREQ_Free`") and holds it across
the first read, so the first `rpQueryItNext` skips revalidation altogether. Later
revalidations do occur once a yield has released the lock — but by then the union
has read, so `last_doc_id() != 0` and `read_full` goes to
`advance_matching_children`, never `initialize_children`. The two populate sites
therefore never both run.

We did not find a path that enters the window. The nearest candidate is a cursor
whose first chunk reads nothing from the union (`AREQ_StartCursor` releases the
lock after `sendChunk`, so a later `FT.CURSOR READ` does revalidate before
reading), but we did not confirm that such a first chunk leaves the union unread.

Accordingly: **no user impact, and no backport.**

### What it would cost if the state were entered

Recorded because the fix is otherwise hard to motivate, and because the
reachability argument above rests on lock and yield ordering elsewhere in the
pipeline rather than on anything local to `union_heap.rs`:

- **The union stops converging.** A duplicate entry keeps matching the id just
  yielded, so `advance_matching_children` re-advances the same child. The test
  below returns `[6, 6, 6, 6, 6]` without the fix.
- **A document is lost.** Consuming a stale doc-0 entry advances a child that
  `initialize_children` had already advanced, so that child's first document never
  reaches the union.
- **A doc id no document has.** When the stale entry is the minimum, the union
  reports doc 0, which C skips once `DocTable_Borrow` fails.

None of it would be visible to the caller: the revalidation decides between `Ok`
and `Moved` by comparing `last_doc_id()` before and after, and both are 0.

`UnionFlat` is unaffected either way — it recomputes its minimum from scratch and
keeps no persistent structure between rounds.

#### Which additional issues this PR fixes
1. None. Found while reviewing `#10730`, which is stacked on top of this fix; its
   `at_eof` change widens the set of children that would reach the same path, so
   the guard belongs underneath it rather than inside it.

#### Main objects this PR modified
1. `UnionHeap::initialize_children` — clears the heap before seeding it, and
   derives `num_active` from the result.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal-only: a latent invariant fix with no reachable user-visible behaviour, as
above.

#### Testing

Two tests, each verified to fail against the code without its half of the fix.

`revalidate_before_first_read_keeps_every_document_of_non_empty_children` drives
the state directly: two children with documents, one reporting `Moved` so its
sibling is still unread when the rebuild runs. It asserts the full expected
sequence `[5, 6, 7, 8]`, which catches all three symptoms — a leading doc 0, a
dropped document, and a repeated id. Without the fix it returns
`[6, 6, 6, 6, 6]`. The drain is bounded so a regression fails on the assertion
rather than spinning until the harness kills the test.

`revalidate_before_first_read_keeps_the_active_count_in_step_with_the_heap` covers
the count: a one-document child that `Moved` leaves on its last document, plus a
two-document sibling. It asserts `[5, 6, 8]` and `num_children_active() == 0` at
the end. Without the count fix it panics with `attempt to subtract with overflow`.
