### PR TITLE
[MOD-16991] Cursors own their request through the wrapper; park/free runs at end of cycle on the main thread

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -55,8 +55,8 @@ typedef struct {
  * ## Cursor ↔ AREQ Ownership
  *
  * **Cursor owns AREQ** (not vice versa):
- * - cursor->execState points to the AREQ
- * - Cursor_FreeInternal calls AREQ_DecrRef(cur->execState)
+ * - cursor->query points to the AREQ's wrapper
+ * - Cursor_FreeInternal releases the wrapper reference
  *
  * **AREQ does NOT own Cursor**:
  * - The `cursor` field below is a NON-OWNING handle.
@@ -407,6 +407,16 @@ struct BlockedRequestCtx {
   // Destroyed at EndCycle (per cycle) and, idempotently, in
   // BlockedRequestCtx_Free as a safety net.
   ChunkReplyState reply;
+  /* Cursor disposition for this cycle. The point that decides the cursor's
+   * fate — the BG worker at cycle end, or the main-thread reply path once
+   * finishSendChunk has set QEXEC_S_ITERDONE — records it here instead of
+   * pausing/freeing directly; OnFree, the single park-or-free point, executes
+   * it under the cursor-list lock after the reply/timeout callback ran. This
+   * is what makes a cursor unreachable to other clients until the cycle fully
+   * ended (no park-before-OnFree overlap). NULL when the cycle has no cursor
+   * or on inline execution (brc->bc == NULL), which still disposes directly. */
+  struct Cursor *cursor;
+  bool cursor_dispose_free;
 
   /* ===== TRANSITIONAL(MOD-16691) — refactor scaffolding =====
    * Every field below is temporary bloat: each one bridges a gap that a later

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -408,13 +408,11 @@ struct BlockedRequestCtx {
   // BlockedRequestCtx_Free as a safety net.
   ChunkReplyState reply;
   /* Cursor disposition for this cycle. The point that decides the cursor's
-   * fate — the BG worker at cycle end, or the main-thread reply path once
-   * finishSendChunk has set QEXEC_S_ITERDONE — records it here instead of
-   * pausing/freeing directly; OnFree, the single park-or-free point, executes
-   * it under the cursor-list lock after the reply/timeout callback ran. This
-   * is what makes a cursor unreachable to other clients until the cycle fully
-   * ended (no park-before-OnFree overlap). NULL when the cycle has no cursor
-   * or on inline execution (brc->bc == NULL), which still disposes directly. */
+   * fate (the BG worker at cycle end, or the reply path once finishSendChunk
+   * set QEXEC_S_ITERDONE) records it here; OnFree — the single park-or-free
+   * point — executes it, so a cycle's cursor stays unreachable to other
+   * clients until the cycle fully ended. NULL when the cycle has no cursor;
+   * inline execution (brc->bc == NULL) disposes directly. */
   struct Cursor *cursor;
   bool cursor_dispose_free;
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -2160,7 +2160,7 @@ int AREQ_StartCursor(AREQ *r, RedisModule_Reply *reply, StrongRef spec_ref, Quer
  * blocked-client cycle (brc->bc set) the disposition is only recorded here and
  * executed by BlockedRequestCtx_OnFree on the main thread, so the cursor stays
  * unreachable to other clients until the cycle fully ended. Outside a cycle
- * (inline execution) it executes immediately, as before. */
+ * (inline execution) it executes immediately. */
 static void cursorEndOfCycle(AREQ *req, Cursor *cursor, bool free_it) {
   if (req->brc->bc) {
     req->brc->cursor = cursor;

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -82,6 +82,7 @@ typedef struct {
 } blockedClientReqCtx;
 
 static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num);
+static void cursorEndOfCycle(AREQ *req, Cursor *cursor, bool free_it);
 static int prepareExecutionPlan(AREQ *req, QueryError *status);
 static int QueryReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
@@ -1770,12 +1771,10 @@ void AREQ_ReplyWithStoredResults(RedisModuleCtx *ctx, AREQ *req) {
   // Handle cursor lifecycle now that QEXEC_S_ITERDONE has been set by finishSendChunk.
   // runCursor stored the cursor handle here instead of pausing/freeing it immediately,
   // because finishSendChunk (which sets QEXEC_S_ITERDONE) runs in the reply_callback.
+  // Inside a blocked-client cycle this records the disposition for OnFree;
+  // inline callers execute it immediately.
   if (stored->cursor) {
-    if (req->stateflags & QEXEC_S_ITERDONE) {
-      Cursor_Free(stored->cursor);
-    } else {
-      Cursor_Pause(stored->cursor);
-    }
+    cursorEndOfCycle(req, stored->cursor, req->stateflags & QEXEC_S_ITERDONE);
     stored->cursor = NULL;
   }
 }
@@ -2144,7 +2143,7 @@ int AREQ_StartCursor(AREQ *r, RedisModule_Reply *reply, StrongRef spec_ref, Quer
   if (cursor == NULL) {
     return REDISMODULE_ERR;
   }
-  cursor->execState = r;
+  cursor->query = r->brc;
   // Cache timeout config on the Cursor so subsequent FT.CURSOR READs use the
   // values from the originating FT.AGGREGATE, regardless of any later
   // `search-on-timeout` config change. Written before the first Cursor_Pause.
@@ -2156,9 +2155,26 @@ int AREQ_StartCursor(AREQ *r, RedisModule_Reply *reply, StrongRef spec_ref, Quer
   return REDISMODULE_OK;
 }
 
+/* Dispose of `cursor` at the end of a read/creation cycle: park it back into
+ * the idle list, or free it when the query is exhausted / timed out. Inside a
+ * blocked-client cycle (brc->bc set) the disposition is only recorded here and
+ * executed by BlockedRequestCtx_OnFree on the main thread, so the cursor stays
+ * unreachable to other clients until the cycle fully ended. Outside a cycle
+ * (inline execution) it executes immediately, as before. */
+static void cursorEndOfCycle(AREQ *req, Cursor *cursor, bool free_it) {
+  if (req->brc->bc) {
+    req->brc->cursor = cursor;
+    req->brc->cursor_dispose_free = free_it;
+  } else if (free_it) {
+    Cursor_Free(cursor);
+  } else {
+    Cursor_Pause(cursor);
+  }
+}
+
 // Assumes that the cursor has a strong ref to the relevant spec and that it is already locked.
 static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num) {
-  AREQ *req = cursor->execState;
+  AREQ *req = Cursor_AREQ(cursor);
   AREQ_ProfilePrinterCtx(req)->cursor_reads++;
   // Re-apply the foreground cap on every READ: the limit / WORKERS knobs may
   // change between cursor creation and this read, and the AREQ's reqConfig is
@@ -2210,41 +2226,35 @@ static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num) {
       // cursor 0. Keep cursor ownership consistent with the depleted id already
       // returned to the caller.
       req->brc->reply.cursor = NULL;
-      if ((AREQ_RequestFlags(req) & QEXEC_F_IS_AGGREGATE) ||
-          shouldSetCursorDone(req, RS_RESULT_TIMEDOUT)) {
-        Cursor_Free(cursor);
-      } else {
-        Cursor_Pause(cursor);
-      }
+      cursorEndOfCycle(req, cursor,
+                       (AREQ_RequestFlags(req) & QEXEC_F_IS_AGGREGATE) ||
+                           shouldSetCursorDone(req, RS_RESULT_TIMEDOUT));
       return;
     }
-    // Disposal of the stashed cursor is owned by AREQ_ReplyWithStoredResults.
+    // Disposal of the stashed cursor is owned by AREQ_ReplyWithStoredResults
+    // (only it knows QEXEC_S_ITERDONE, set by finishSendChunk on main) — or by
+    // EndCycle's leftover-stash drain when the timeout replied without it.
     return;
   }
 
-  if (req->stateflags & QEXEC_S_ITERDONE) {
-    Cursor_Free(cursor);
-  } else {
-    // Update the idle timeout
-    Cursor_Pause(cursor);
-  }
+  cursorEndOfCycle(req, cursor, req->stateflags & QEXEC_S_ITERDONE);
 }
 
 static QueryProcessingCtx *prepareForCursorRead(Cursor *cursor, bool *hasLoader, bool *initClock, QEFlags *reqFlags, QueryError *status) {
-  AREQ *req = cursor->execState;
+  AREQ *req = Cursor_AREQ(cursor);
   QueryProcessingCtx *qctx = NULL;
   if (req) {
-    qctx = AREQ_QueryProcessingCtx(cursor->execState);
+    qctx = AREQ_QueryProcessingCtx(req);
     AREQ_RemoveRequestFlags(req, QEXEC_F_IS_AGGREGATE); // Second read was not triggered by FT.AGGREGATE
     *reqFlags = AREQ_RequestFlags(req);
     *hasLoader = HasLoader(req);
     *initClock = IsProfile(req) || !IsInternal(req);
   } else {
     // Single-cursor hybrid fallback: only reachable via
-    // HybridRequest_StartSingleCursor (execState NULL, hybrid_ref set),
-    // i.e. user-facing FT.HYBRID WITHCURSOR — currently not supported.
-    // _FT.HYBRID WITHCURSOR sub-cursors always carry an execState and take
-    // the if branch above.
+    // HybridRequest_StartSingleCursor (no cursor-carried wrapper, hybrid_ref
+    // set), i.e. user-facing FT.HYBRID WITHCURSOR — currently not supported.
+    // _FT.HYBRID WITHCURSOR sub-cursors always carry their sub-AREQ's wrapper
+    // and take the if branch above.
     HybridRequest *hreq = StrongRef_Get(cursor->hybrid_ref);
     *reqFlags = hreq->reqflags;
     qctx = &hreq->tailPipeline->qctx;
@@ -2263,8 +2273,8 @@ static void cursorRead(RedisModuleCtx *ctx, Cursor *cursor, size_t count, bool b
   QEFlags reqFlags = 0;
   bool hasLoader = false;
   bool initClock = false;
-  AREQ *req = cursor->execState;
-  RS_LOG_ASSERT(req, "cursorRead reached with execState==NULL");
+  AREQ *req = Cursor_AREQ(cursor);
+  RS_LOG_ASSERT(req, "cursorRead reached with no cursor-carried AREQ");
   QueryProcessingCtx *qctx = prepareForCursorRead(cursor, &hasLoader, &initClock, &reqFlags, &status);
   StrongRef execution_ref;
   bool has_spec = cursor_HasSpecWeakRef(cursor);
@@ -2274,11 +2284,11 @@ static void cursorRead(RedisModuleCtx *ctx, Cursor *cursor, size_t count, bool b
     if (!StrongRef_Get(execution_ref)) {
       QueryError_SetWithoutUserDataFmt(&status, QUERY_ERROR_CODE_DROPPED_BACKGROUND,
                                        "The index was dropped while the cursor was idle");
-      // Reply before Free: on non-reqCtx paths the cursor holds the
-      // only AREQ ref, so freeing first would UAF the req->useReplyCallback
-      // read inside AREQ_ReplyOrStoreError.
+      // Reply before disposing: the cursor may hold the only wrapper ref, so
+      // freeing first would UAF the req->useReplyCallback read inside
+      // AREQ_ReplyOrStoreError.
       AREQ_ReplyOrStoreError(req, ctx, &status);
-      Cursor_Free(cursor);
+      cursorEndOfCycle(req, cursor, true);
       return;
     }
 
@@ -2329,7 +2339,7 @@ static void cursorRead_ctx(CursorReadCtx *cr_ctx) {
   // we were queued, FAIL already replied and can close the cursor immediately.
   // RETURN_STRICT still runs the read so it can store a cursor-shaped timeout
   // reply and park/free the cursor before the timeout callback replies.
-  AREQ *req = cr_ctx->cursor->execState;
+  AREQ *req = Cursor_AREQ(cr_ctx->cursor);
   RS_ASSERT(req);
   // Picked up from the job queue: a timeout from here on is attributed to PIPELINE
   // (no-op if already timed out while queued, via the SetExecutionStage freeze).
@@ -2340,7 +2350,7 @@ static void cursorRead_ctx(CursorReadCtx *cr_ctx) {
   if (!AREQ_TimedOut(req) || AREQ_RequiresThreadsSyncResults(req)) {
     cursorRead(ctx, cr_ctx->cursor, cr_ctx->count, true);
   } else {
-    Cursor_Free(cr_ctx->cursor);
+    cursorEndOfCycle(req, cr_ctx->cursor, true);
   }
   RedisModule_FreeThreadSafeContext(ctx);
   RedisModule_BlockedClientMeasureTimeEnd(cr_ctx->bc);
@@ -2358,7 +2368,7 @@ static void coordCursorRead_ctx(void *p) {
   CursorReadCtx *cr_ctx = p;
   RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(cr_ctx->bc);
   Cursor *cursor = cr_ctx->cursor;
-  AREQ *req = cursor->execState;
+  AREQ *req = Cursor_AREQ(cursor);
   RS_ASSERT(req);
   // Picked up from the job queue: a timeout from here on is attributed to
   // PIPELINE (no-op if already timed out while queued, via the freeze).
@@ -2369,7 +2379,7 @@ static void coordCursorRead_ctx(void *p) {
     // RETURN_STRICT: the timeout callback fired before this job was dequeued,
     // won the owner latch, and already replied with a depleted cursor. Free
     // the taken cursor; store nothing (nobody is waiting).
-    Cursor_Free(cursor);
+    cursorEndOfCycle(req, cursor, true);
   } else if (!AREQ_TimedOut(req) || AREQ_RequiresThreadsSyncResults(req)) {
     // RETURN (no timer) always runs the read and replies inline through the
     // thread-safe ctx; FAIL bails and drops the cursor if the timer already
@@ -2378,7 +2388,7 @@ static void coordCursorRead_ctx(void *p) {
     // the cursor.
     cursorRead(ctx, cursor, cr_ctx->count, false);
   } else {
-    Cursor_Free(cursor);
+    cursorEndOfCycle(req, cursor, true);
   }
   RedisModule_FreeThreadSafeContext(ctx);
   RedisModule_BlockedClientMeasureTimeEnd(cr_ctx->bc);
@@ -2394,7 +2404,7 @@ static void coordCursorRead_ctx(void *p) {
 static int cursorReadDispatchTaken(RedisModuleCtx *ctx, Cursor *cursor, long long count,
                                    RedisModuleCmdFunc reply_cb, RedisModuleCmdFunc timeout_cb,
                                    rs_wall_clock_ms_t timeout_ms, int poolType) {
-  AREQ *req = cursor->execState;
+  AREQ *req = Cursor_AREQ(cursor);
   RS_ASSERT(req);
   // If a timeout is armed, both callbacks must be provided (mirrors the shard
   // Block helpers). RETURN passes no callbacks and no timer.
@@ -2493,9 +2503,9 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
       !(RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_DENY_BLOCKING)) {
     // Coordinator cursor: the read pulls from the shards over the network, so
     // it is always dispatched to the coordinator pool, independent of the
-    // WORKERS config. execState is always set — the only execState-less
-    // cursors (single-cursor hybrid) are not user-reachable.
-    AREQ *req = cursor->execState;
+    // WORKERS config. The cursor always carries its request's wrapper — the
+    // only wrapper-less cursors (single-cursor hybrid) are not user-reachable.
+    AREQ *req = Cursor_AREQ(cursor);
     RS_ASSERT(req != NULL);
     // Reused cursor AREQ: a prior read left the marker at PIPELINE/REPLY, so
     // reset it to QUEUE for the queued re-read; the BG job advances it back
@@ -2533,8 +2543,8 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
   if (RunInThread(ctx)) {
     // Shard/standalone path: block and dispatch to worker. Non-RETURN policies arm
     // the blocked-client timer with reply/timeout callbacks.
-    RS_ASSERT(cursor->execState != NULL);
-    AREQ *req = cursor->execState;
+    AREQ *req = Cursor_AREQ(cursor);
+    RS_ASSERT(req != NULL);
     // Reused cursor AREQ: a prior read left the marker at PIPELINE/REPLY, so reset
     // it to QUEUE for the queued re-read; cursorRead_ctx advances it back to
     // PIPELINE at pickup. (A timed-out RETURN_STRICT read depletes its cursor, so
@@ -2577,7 +2587,7 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     // Disk (flex) shard cursors must not resume inline: the async-loader
     // pipeline blocks on prefetch completions delivered by the main thread, so
     // a main-thread read would deadlock.
-    if (cursor->execState && cursorIsDiskBacked(cursor)) {
+    if (Cursor_AREQ(cursor) && cursorIsDiskBacked(cursor)) {
       // Keep the cursor valid for a later blockable read; only this read is
       // rejected.
       Cursor_Pause(cursor);
@@ -2587,9 +2597,10 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
           "supported in Redis Flex");
     }
 
-    if (cursor->execState) {
+    AREQ *inline_req = Cursor_AREQ(cursor);
+    if (inline_req) {
       // Reply inline via ctx; clear stale useReplyCallback.
-      cursor->execState->useReplyCallback = false;
+      inline_req->useReplyCallback = false;
     }
     cursorRead(ctx, cursor, count, false);
   }
@@ -2616,7 +2627,7 @@ int RSCursorProfileCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     return RedisModule_ReplyWithErrorFormat(ctx, "Cursor not found, id: %d", cid);
   }
 
-  AREQ *req = cursor->execState;
+  AREQ *req = Cursor_AREQ(cursor);
   if (!IsProfile(req)) {
     Cursor_Pause(cursor); // Pause the cursor again since we are not going to use it, but it's still valid.
     return RedisModule_ReplyWithErrorFormat(ctx, "cursor request is not profile, id: %d", cid);

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1201,7 +1201,7 @@ void BlockedRequestCtx_Free(BlockedRequestCtx *brc) {
   pthread_cond_destroy(&brc->aggregateResultsCond);
   // Idempotent after EndCycle; kept as a safety net for wrappers freed
   // outside a cycle. Must run while the owned request is alive: disposing a
-  // stashed cursor clears its execState.
+  // stashed cursor clears its wrapper handle.
   ChunkReplyState_Destroy(&brc->reply);
 
   if (brc->kind == REQUEST_KIND_AREQ) {
@@ -1805,9 +1805,10 @@ void ChunkReplyState_Destroy(ChunkReplyState *state) {
 
   // Timeout edge case: cursor wasn't handled by reply_callback.
   // See ChunkReplyState ownership model in aggregate.h for full explanation.
-  // We must clear execState before Cursor_Free to prevent the AREQ_DecrRef loop.
+  // We must clear the cursor's wrapper handle before Cursor_Free to prevent
+  // the wrapper-release loop (this destroy runs from the wrapper's own free).
   if (state->cursor) {
-    state->cursor->execState = NULL;
+    state->cursor->query = NULL;
     Cursor_Free(state->cursor);
     state->cursor = NULL;
   }

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -90,8 +90,9 @@ static void Cursor_FreeInternal(Cursor *cur) {
   RS_LOG_ASSERT(kh_get(cursors, cl->lookup, cur->id) == kh_end(cl->lookup),
                                                     "Failed to delete cursor");
   if (cur->hybrid_ref.rm) {
-    // The sub-AREQ (and its wrapper) is freed by the hybrid request free
-    // function; the cursor's hold rides the StrongRef (until Step 2b-ii).
+    // TRANSITIONAL(MOD-16691): the sub-AREQ (and its wrapper) is freed by the
+    // hybrid container; the cursor's hold rides the StrongRef until the
+    // container-handoff step.
     StrongRef_Release(cur->hybrid_ref);
     cur->query = NULL;
   } else if (cur->query) {

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -90,12 +90,13 @@ static void Cursor_FreeInternal(Cursor *cur) {
   RS_LOG_ASSERT(kh_get(cursors, cl->lookup, cur->id) == kh_end(cl->lookup),
                                                     "Failed to delete cursor");
   if (cur->hybrid_ref.rm) {
-    // The AREQ will be free by the hybrid request free function.
+    // The sub-AREQ (and its wrapper) is freed by the hybrid request free
+    // function; the cursor's hold rides the StrongRef (until Step 2b-ii).
     StrongRef_Release(cur->hybrid_ref);
-    cur->execState = NULL;
-  } else if (cur->execState) {
-    AREQ_DecrRef(cur->execState);
-    cur->execState = NULL;
+    cur->query = NULL;
+  } else if (cur->query) {
+    BlockedRequestCtx_DecrRef(cur->query);
+    cur->query = NULL;
   }
   // if There's a spec associated with the cursor
   if(cur->spec_ref.rm) {
@@ -322,8 +323,9 @@ static uint64_t CursorList_GenerateId(CursorList *curlist) {
 }
 
 static void cursorMarkASMInaccuracyCb(CursorList *cl, Cursor *cur, void *arg) {
-  if (cur->execState) {
-    cur->execState->stateflags |= QEXEC_S_ASM_TRIMMING_DELAY_TIMEOUT;
+  AREQ *req = Cursor_AREQ(cur);
+  if (req) {
+    req->stateflags |= QEXEC_S_ASM_TRIMMING_DELAY_TIMEOUT;
   }
 }
 

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -37,8 +37,13 @@ typedef struct Cursor {
    */
   StrongRef hybrid_ref;
 
-  /** Execution state. Opaque to the cursor - managed by consumer */
-  AREQ *execState;
+  /** The parked request's wrapper. Holds one wrapper reference, released by
+   * Cursor_FreeInternal (hybrid sub-cursors are the exception: the hybrid
+   * container owns the sub-AREQ, so their reference rides hybrid_ref instead —
+   * retired in Step 2b-ii). Ownership of the cursor (and with it the wrapper)
+   * belongs to the idle list while parked and to the executing cycle while
+   * taken. NULL only for the hybrid single-cursor fallback. */
+  BlockedRequestCtx *query;
 
   /** Time when this cursor will no longer be valid, in nanos */
   uint64_t nextTimeoutNs;
@@ -71,6 +76,13 @@ typedef struct Cursor {
    *  Should only be accessed under cursor list lock */
   bool delete_mark;
 } Cursor;
+
+/* The AREQ carried by this cursor's wrapper: the parked request for plain
+ * cursors, the sub-AREQ for hybrid sub-cursors. NULL for the hybrid
+ * single-cursor fallback (no wrapper). */
+static inline AREQ *Cursor_AREQ(const Cursor *cur) {
+  return cur->query && cur->query->kind == REQUEST_KIND_AREQ ? cur->query->query.areq : NULL;
+}
 
 KHASH_MAP_INIT_INT64(cursors, Cursor *);
 /**

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -80,7 +80,11 @@ typedef struct Cursor {
  * cursors, the sub-AREQ for hybrid sub-cursors. NULL for the hybrid
  * single-cursor fallback (no wrapper). */
 static inline AREQ *Cursor_AREQ(const Cursor *cur) {
-  return cur->query && cur->query->kind == REQUEST_KIND_AREQ ? cur->query->query.areq : NULL;
+  if (!cur->query) {
+    return NULL;
+  }
+  RS_ASSERT(cur->query->kind == REQUEST_KIND_AREQ);
+  return cur->query->query.areq;
 }
 
 KHASH_MAP_INIT_INT64(cursors, Cursor *);

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -37,12 +37,11 @@ typedef struct Cursor {
    */
   StrongRef hybrid_ref;
 
-  /** The parked request's wrapper. Holds one wrapper reference, released by
-   * Cursor_FreeInternal (hybrid sub-cursors are the exception: the hybrid
-   * container owns the sub-AREQ, so their reference rides hybrid_ref instead —
-   * retired in Step 2b-ii). Ownership of the cursor (and with it the wrapper)
-   * belongs to the idle list while parked and to the executing cycle while
-   * taken. NULL only for the hybrid single-cursor fallback. */
+  /** The parked request's wrapper — the cursor is the request's owner between
+   * cycles, holding one wrapper reference released by Cursor_FreeInternal.
+   * NULL only for the hybrid single-cursor fallback.
+   * TRANSITIONAL(MOD-16691): hybrid sub-cursors hold their reference through
+   * hybrid_ref instead, until the container-handoff step retires it. */
   BlockedRequestCtx *query;
 
   /** Time when this cursor will no longer be valid, in nanos */

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -837,8 +837,9 @@ int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, Q
       // FT.CURSOR READ cycles run the claim/done-latch handshake against the read
       // AREQ's wrapper (req->brc), at per-sub-AREQ granularity. Ownership is
       // unchanged — the hybrid request still owns the sub-AREQ, and the wrapper is
-      // freed with it (HybridRequest_Free -> AREQ_DecrRef -> BlockedRequestCtx_Free);
-      // the cursor's own hold rides hybrid_ref (until Step 2b-ii).
+      // freed with it (HybridRequest_Free -> AREQ_DecrRef -> BlockedRequestCtx_Free).
+      // TRANSITIONAL(MOD-16691): the cursor's own hold rides hybrid_ref until
+      // the container-handoff step.
       BlockedRequestCtx_NewAREQ(areq);
       // The cursor lifetime will determine the hybrid request lifetime
       cursor->query = areq->brc;

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -762,7 +762,7 @@ static inline void replyWithCursors(RedisModuleCtx *replyCtx, arrayof(Cursor*) c
     RedisModule_Reply_Map(reply);
     for (size_t i = 0; i < array_len(cursors); i++) {
       Cursor *cursor = cursors[i];
-      AREQ *areq = cursor->execState;
+      AREQ *areq = Cursor_AREQ(cursor);
       if (IsHybridSearchSubquery(areq)) {
         RedisModule_ReplyKV_LongLong(reply, "SEARCH", cursor->id);
       } else if (IsHybridVectorSubquery(areq)) {
@@ -833,15 +833,16 @@ int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, Q
       if (!cursor) {
         break;
       }
-      // The cursor lifetime will determine the hybrid request lifetime
-      cursor->execState = areq;
-      cursor->hybrid_ref = StrongRef_Clone(hybrid_ref);
       // A cursor-backing sub-AREQ needs its own heap BlockedRequestCtx: RETURN_STRICT
       // FT.CURSOR READ cycles run the claim/done-latch handshake against the read
       // AREQ's wrapper (req->brc), at per-sub-AREQ granularity. Ownership is
       // unchanged — the hybrid request still owns the sub-AREQ, and the wrapper is
-      // freed with it (HybridRequest_Free -> AREQ_DecrRef -> BlockedRequestCtx_Free).
+      // freed with it (HybridRequest_Free -> AREQ_DecrRef -> BlockedRequestCtx_Free);
+      // the cursor's own hold rides hybrid_ref (until Step 2b-ii).
       BlockedRequestCtx_NewAREQ(areq);
+      // The cursor lifetime will determine the hybrid request lifetime
+      cursor->query = areq->brc;
+      cursor->hybrid_ref = StrongRef_Clone(hybrid_ref);
       cursor->queryTimeoutMS = (size_t)areq->reqConfig.queryTimeoutMS;
       cursor->queryTimeoutPolicy = areq->reqConfig.timeoutPolicy;
       areq->cursor_id = cursor->id;

--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -81,12 +81,11 @@ void BlockedRequestCtx_OnFree(RedisModuleCtx *ctx, void *privdata) {
   // free_privdata fired without blocking the main thread in the callback.
   BlockedRequestOnFreeDebug_Increment();
 #endif
-  // Snapshot the cursor disposition before EndCycle clears the per-cycle
-  // fields, then execute it: OnFree is the single park-or-free point, so a
-  // parked cursor only becomes reachable to other clients once this cycle has
-  // fully ended (closing the park-before-OnFree overlap window). Cursor_Pause
-  // converts park to free when CURSOR DEL marked the cursor mid-cycle
-  // (delete_mark), under the cursor-list lock.
+  // Execute the cycle's cursor disposition (snapshot first — EndCycle clears
+  // the per-cycle fields). Parking here, after the reply/timeout callback, is
+  // what keeps a cycle's cursor unreachable to other clients mid-cycle.
+  // Cursor_Pause converts park to free when CURSOR DEL marked the cursor
+  // mid-cycle (delete_mark).
   struct Cursor *cursor = brc->cursor;
   bool dispose_free = brc->cursor_dispose_free;
   BlockedRequestCtx_EndCycle(brc);

--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -24,11 +24,10 @@
 void BlockedRequestCtx_BeginCycle(BlockedRequestCtx *brc, RedisModuleBlockedClient *bc,
                                   RedisModuleCmdFunc reply_cb) {
   // No overlapping cycles: the previous cycle's OnFree must have run before a
-  // new cycle may begin on the same wrapper.
-  // TRANSITIONAL(MOD-16691): until the cursor-ownership step moves cursor
-  // park/free from the BG thread to OnFree, there is a narrow window where a
-  // concurrent FT.CURSOR READ can reach a paused cursor before the previous
-  // cycle's OnFree ran — this assert makes that overlap loud in debug builds.
+  // new cycle may begin on the same wrapper. This holds structurally for
+  // blocked cursor cycles — the cursor is only parked back into the idle list
+  // by OnFree (cursorEndOfCycle records the disposition; OnFree executes it),
+  // so no other client can take it before the cycle fully ended.
   RS_ASSERT(brc->bc == NULL && brc->registry_node == NULL);
   // The cycle's hold on the wrapper: keeps the wrapper (and the owned request)
   // alive until OnFree, so the reply/timeout callbacks may dereference the
@@ -54,10 +53,10 @@ void BlockedRequestCtx_EndCycle(BlockedRequestCtx *brc) {
     brc->registry_node = NULL;
   }
   // Dispose a stashed cursor reference-releasingly BEFORE the generic destroy:
-  // AREQ_CleanUpStoredCursor frees the cursor with execState intact, so
-  // Cursor_FreeInternal releases the cursor's wrapper reference. Skipping this
-  // and letting ChunkReplyState_Destroy handle the stash would leak that
-  // reference (it deliberately clears execState first — correct only in the
+  // AREQ_CleanUpStoredCursor frees the cursor with its wrapper handle intact,
+  // so Cursor_FreeInternal releases the cursor's wrapper reference. Skipping
+  // this and letting ChunkReplyState_Destroy handle the stash would leak that
+  // reference (it deliberately clears the handle first — correct only in the
   // refcount==0 context of BlockedRequestCtx_Free). Disposing the stash here is
   // also what prevents the RETURN_STRICT preempt path from leaking the cursor
   // reserved by an initial WITHCURSOR query.
@@ -71,6 +70,8 @@ void BlockedRequestCtx_EndCycle(BlockedRequestCtx *brc) {
   brc->reply.hasStoredResults = false;
   brc->bc = NULL;
   brc->deferred_reply = false;
+  brc->cursor = NULL;
+  brc->cursor_dispose_free = false;
 }
 
 void BlockedRequestCtx_OnFree(RedisModuleCtx *ctx, void *privdata) {
@@ -80,7 +81,22 @@ void BlockedRequestCtx_OnFree(RedisModuleCtx *ctx, void *privdata) {
   // free_privdata fired without blocking the main thread in the callback.
   BlockedRequestOnFreeDebug_Increment();
 #endif
+  // Snapshot the cursor disposition before EndCycle clears the per-cycle
+  // fields, then execute it: OnFree is the single park-or-free point, so a
+  // parked cursor only becomes reachable to other clients once this cycle has
+  // fully ended (closing the park-before-OnFree overlap window). Cursor_Pause
+  // converts park to free when CURSOR DEL marked the cursor mid-cycle
+  // (delete_mark), under the cursor-list lock.
+  struct Cursor *cursor = brc->cursor;
+  bool dispose_free = brc->cursor_dispose_free;
   BlockedRequestCtx_EndCycle(brc);
+  if (cursor) {
+    if (dispose_free) {
+      Cursor_Free(cursor);
+    } else {
+      Cursor_Pause(cursor);
+    }
+  }
   BlockedRequestCtx_DecrRef(brc);
 }
 
@@ -116,7 +132,7 @@ RedisModuleBlockedClient *BlockCursorClientWithTimeout(RedisModuleCtx *ctx, Curs
                                                        RedisModuleCmdFunc reply_cb,
                                                        RedisModuleCmdFunc timeout_cb,
                                                        rs_wall_clock_ms_t timeout_ms) {
-  RS_ASSERT(cursor->execState != NULL);
+  RS_ASSERT(cursor->query != NULL);
   RS_ASSERT(timeout_ms == 0 || (timeout_cb != NULL && reply_cb != NULL));
 
   BlockedQueries *blockedQueries = MainThread_GetBlockedQueries();


### PR DESCRIPTION
## Describe the changes in the pull request

Next step of the blocked-client / cross-thread ownership refactor (#9426): make the blocked-request wrapper the cursor's single handle and move cursor park/free to the end of the blocked-client cycle.

Replaces #10689, which GitHub auto-marked as merged (its head became an ancestor of its then-base branch during a stack reorder). This PR is the same change, now based directly on master; #10699 (held command argv) is stacked on top of it.

1. **Current:** a cursor borrows a raw `AREQ *execState` and holds its own AREQ reference; the BG worker parks or frees the cursor directly at the end of a read, *before* the blocked client is processed on the main thread. That leaves a window where a concurrent `FT.CURSOR READ` from another client can take the parked cursor and begin a new wrapper cycle before the previous cycle's `OnFree` ran — guarded only by a debug assert (the TRANSITIONAL(MOD-16691) note on `BeginCycle`, flagged by review bots on both #10553 and #10515). Worker-side disposal also means the last owner of a request can drop it off the main thread.
2. **Change:**
   - `Cursor.execState` → `BlockedRequestCtx *query`: the cursor carries the parked request's **wrapper** and `Cursor_FreeInternal` releases the wrapper reference. `Cursor_AREQ()` is the kind-checked accessor. (Hybrid sub-cursors still ride `hybrid_ref`; retired in the container-handoff step of this ticket.)
   - Cursor disposal becomes a **per-cycle disposition on the wrapper**: the point that decides the cursor's fate (the worker at cycle end via `cursorEndOfCycle`, or `AREQ_ReplyWithStoredResults` on main once `finishSendChunk` set ITERDONE) records park-or-free; `BlockedRequestCtx_OnFree` executes it under the cursor-list lock after the reply/timeout callback ran. Since FT.CURSOR READ is unified (#10515), every blocking read — coordinator included — runs inside a wrapper cycle and gets this; only inline execution (`brc->bc == NULL`) still disposes directly, on the main thread by definition.
3. **Outcome:** a blocked-cycle cursor is unreachable to other clients until its cycle fully ended — the park-before-OnFree overlap window is closed structurally, and the `BeginCycle` no-overlap assert becomes a real invariant. Cursor-driven frees (including the hybrid drain chain through `hybrid_ref`) now run on the main thread, which the held-argv PR stacked on top (#10699) relies on: the module-string references it introduces must only be released on main. Remaining work under this ticket: §3.6 hybrid container handoff, then `hybrid_ref` and wrapper-refcount retirement.

Verified on this tip (workers enabled; cluster runs with `REDIS_STANDALONE=0`): full C/C++ unit-test run green; `test_cursors.py` + `test_blocked_client_timeout.py` + `test_hybrid.py` + `test_hybrid_timeout.py`: 140/140 standalone; the same plus `test_hybrid_dist.py`: 184/184 oss-cluster.

#### Which additional issues this PR fixes
1. MOD-16991 (part of the query-lifetime refactor; design: MOD-15430)
2. Design: #9426

#### Main objects this PR modified
1. `Cursor` (`execState` → `query` wrapper handle; `Cursor_AREQ()` accessor)
2. `BlockedRequestCtx` (per-cycle `cursor`/`cursor_dispose_free` disposition; `OnFree` executes it)
3. `src/aggregate/aggregate_exec.c` (`cursorEndOfCycle()` at every park/free decision point)
4. `src/hybrid/hybrid_exec.c` (sub-cursors carry the sub-AREQ's wrapper)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
