### PR TITLE
unions: never report a revalidation move that goes backwards

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -697,44 +697,54 @@ where
         // `QUICK_EXIT` is a const generic, so a full union compiles this away entirely
         // rather than paying for a comparison that its invariant already rules out.
         if QUICK_EXIT && min_doc_id < original_last_doc_id {
-            // Stay put. The result still has to be republished, because it holds raw
-            // pointers into the children's own results: one that moved leaves it
-            // describing another document, and one that aborted was dropped above and
-            // leaves it dangling.
+            // The result has to be republished either way, because it holds raw pointers
+            // into the children's own results: one that moved leaves it describing
+            // another document, and one that aborted was dropped above and leaves it
+            // dangling. What it can be republished *from* decides the outcome.
             //
-            // Republished from a *single* child, as everywhere else in this mode — the
-            // full aggregate is what `QUICK_EXIT` exists to avoid. `min_child_idx`
-            // cannot be used for it: that is the lagging child just rejected, sitting
-            // at `min_doc_id`. So the child still on the current position is looked up
-            // instead. Every child in the active region has a `current` (the scan above
-            // dropped the rest), so finding one by position is enough.
-            //
-            // Nothing is lost by not advancing: the next `read`/`skip_to` seeks every
-            // child that has not moved past `last_doc_id()` — including the lagging
-            // one whose position was rejected here — so the true next document is
-            // found there, by code that can report a failure, rather than here, where
-            // an `Err` would reach the caller as `VALIDATE_ABORTED`.
-            match self.children[..self.num_active]
+            // From a *single* child, as everywhere else in this mode — the full aggregate
+            // is what `QUICK_EXIT` exists to avoid. `min_child_idx` cannot serve: that is
+            // the lagging child just rejected, sitting at `min_doc_id`. So the child
+            // still on the current position is looked up instead. Every child in the
+            // active region has a `current` (the scan above dropped the rest), so finding
+            // one by position is enough.
+            if let Some(idx) = self.children[..self.num_active]
                 .iter()
                 .position(|c| c.last_doc_id() == original_last_doc_id)
             {
-                Some(idx) => self.quick_set_from_child(idx),
-                None => {
-                    // Every child that was here has moved on. The caller gets `Ok`, so
-                    // it reads rather than consuming this; the result only has to be
-                    // free of the stale pointers `reset_aggregate` drops.
-                    self.result.reset_aggregate();
-                    self.result.doc_id = original_last_doc_id;
-                }
+                // Still backed, so the union has not moved and its current stands.
+                self.quick_set_from_child(idx);
+
+                debug_assert_eq!(
+                    self.last_doc_id(),
+                    original_last_doc_id,
+                    "staying put must leave the position untouched",
+                );
+
+                return Ok(RQEValidateStatus::Ok);
             }
 
-            debug_assert_eq!(
-                self.last_doc_id(),
-                original_last_doc_id,
-                "staying put must leave the position untouched",
-            );
-
-            return Ok(RQEValidateStatus::Ok);
+            // Nothing is left on the union's document: the child that supplied it has
+            // moved on too. Reporting `Ok` would promise a `current` that no child backs.
+            //
+            // So the union advances instead, which is what it would have done on the next
+            // read anyway — `read_quick` targets `last_doc_id() + 1` and seeks every
+            // lagging child past it, including the one whose position was rejected here.
+            // Skipping over the abandoned document costs nothing: it has already been
+            // delivered, and a quick union never promised to aggregate every child that
+            // holds it, so no contribution is dropped by leaving it behind.
+            //
+            // This is the one place a `QUICK_EXIT` revalidation reads. An `Err` here
+            // reaches the caller as `VALIDATE_ABORTED`, which frees the iterator and
+            // substitutes an empty one — the failure is reported, if bluntly, which beats
+            // publishing a result that describes nothing.
+            return match self.read_quick()? {
+                Some(result) => Ok(RQEValidateStatus::Moved {
+                    current: Some(result),
+                }),
+                // Seeking past the abandoned position ran the union out of documents.
+                None => Ok(RQEValidateStatus::Moved { current: None }),
+            };
         }
 
         // Rebuild result at the new minimum doc_id

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -198,10 +198,9 @@ where
 
 // Methods reachable only when `QUICK_EXIT` is `false`, grouped so that the full-mode
 // read path reads together. Each guards its mode at entry rather than being typed on
-// `UnionFlat<'index, I, false>`: the callers are the generic `RQEIterator` impl, which cannot
-// reach a method that exists for only one value of a const generic, and splitting that
-// impl in two would also strand the `ProfileChildren` impl, whose `RQEIterator`
-// supertrait bound is stated for a generic `QUICK_EXIT`.
+// `UnionFlat<'index, I, false>`: the caller is the generic `RQEIterator` impl, which
+// cannot reach a method that exists for only one value of a const generic (E0599),
+// and splitting that impl in two would strand its `ProfileChildren` dependant.
 impl<'index, I, const QUICK_EXIT: bool> UnionFlat<'index, I, QUICK_EXIT>
 where
     I: RQEIterator<'index>,
@@ -211,15 +210,11 @@ where
     ///
     /// Returns the minimum doc_id among active children, or `DocId::MAX` if all are exhausted.
     ///
-    /// Only [`Self::read_full`] calls this, so `QUICK_EXIT` is always `false` here and
-    /// no child can be *behind* `current_id`: a full union advances every child on
-    /// every `read`/`skip_to`, and its own `revalidate` re-seeks any child that came
-    /// back from a child revalidation behind the union — an exhausted leaf can
-    /// resurrect there — before it returns.
-    /// A child that were behind would have to be seeked rather than read — one read
-    /// need not clear `current_id` — and would otherwise become the minimum and hand
-    /// back a document already delivered. That case is asserted away rather than
-    /// handled, so it cannot be introduced silently.
+    /// Only [`Self::read_full`] calls this, so no child can be *behind* `current_id`:
+    /// full-mode `read`/`skip_to` advance every active child, and `revalidate`
+    /// re-seeks any child a child revalidation resurrected behind the union. A child
+    /// behind would become the minimum and hand back a document already delivered,
+    /// so the invariant is asserted rather than handled.
     fn advance_and_find_min(&mut self, current_id: DocId) -> Result<DocId, RQEIteratorError> {
         if QUICK_EXIT {
             panic!("a quick union reads through skip_to instead");
@@ -343,9 +338,6 @@ where
             return Ok(None);
         }
 
-        // The minimum is taken over children that were all advanced past
-        // `previous_id`, so it has to name a later document. Handing back one this
-        // union already delivered would have the caller emit it twice.
         debug_assert!(
             min_id > previous_id,
             "a read must move forward: {previous_id} -> {min_id}",
@@ -693,26 +685,19 @@ where
         // past-the-end state — so it re-enters the active set far behind a union
         // that carried on without it.
         if min_doc_id < original_last_doc_id {
-            // The result has to be republished either way, because it holds raw
-            // pointers into the children's own results: one that moved leaves it
-            // describing another document, and one that aborted was dropped above and
-            // leaves it dangling. What it can be republished *from* decides the
-            // outcome.
-            //
             // A child still sitting on the union's document backs the position as it
-            // stands: republish from that *single* child — the full aggregate is what
-            // `QUICK_EXIT` exists to avoid — and report `Ok`, with no reads spent.
-            // `min_child_idx` cannot serve: that is the lagging child just rejected.
-            // Only quick mode takes this exit, leaving its laggers behind as ordinary
-            // state for the next `read`/`skip_to` to seek past; a full union must
-            // catch them up below either way, because `advance_and_find_min` relies
-            // on no active child sitting behind the union.
+            // stands: republish from it (the result holds raw pointers into children
+            // that may have moved or been dropped) and report `Ok`, with no reads
+            // spent. `min_child_idx` cannot serve — that is the lagging child just
+            // rejected. Quick mode only: its laggers are ordinary state for the next
+            // `read`/`skip_to` to seek past, while a full union must catch them up
+            // below either way — `advance_and_find_min` relies on no active child
+            // sitting behind the union.
             if QUICK_EXIT
                 && let Some(idx) = self.children[..self.num_active]
                     .iter()
                     .position(|c| c.last_doc_id() == original_last_doc_id)
             {
-                // Still backed, so the union has not moved and its current stands.
                 self.quick_set_from_child(idx);
 
                 debug_assert_eq!(
@@ -732,10 +717,9 @@ where
             // stepping over it would let that document into the result set. So every
             // lagger is seeked to the abandoned position itself, not past it.
             //
-            // These are the reads a revalidation cannot avoid. An `Err` here reaches
-            // the caller as `VALIDATE_ABORTED`, which frees the iterator and
-            // substitutes an empty one — the failure is reported, if bluntly, which
-            // beats handing out a position no child backs.
+            // These reads cannot be avoided. An `Err` here reaches the caller as
+            // `VALIDATE_ABORTED`, freeing the iterator and substituting an empty one
+            // — blunt, but better than handing out a position no child backs.
             let mut i = 0;
             while i < self.num_active {
                 if self.children[i].last_doc_id() >= original_last_doc_id {
@@ -745,10 +729,8 @@ where
                 match self.children[i].skip_to(original_last_doc_id)? {
                     Some(SkipToOutcome::Found(_)) => {
                         if QUICK_EXIT {
-                            // The document is still matched after all: the union
-                            // stays on it, backed by the child that just landed
-                            // there. Remaining laggers are left for the next call,
-                            // as everywhere else in this mode.
+                            // Still matched after all: the union stays on it, backed
+                            // by this child; remaining laggers wait for the next call.
                             self.quick_set_from_child(i);
 
                             debug_assert_eq!(

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -90,6 +90,7 @@ pub struct RawUnionFlat<'query, Rf: Ref, I, const QUICK_EXIT: bool> {
 pub type UnionFlat<'index, I, const QUICK_EXIT: bool> =
     RawUnionFlat<'index, Active<'index>, I, QUICK_EXIT>;
 
+// Methods used in both modes.
 impl<'index, I, const QUICK_EXIT: bool> UnionFlat<'index, I, QUICK_EXIT>
 where
     I: RQEIterator<'index>,
@@ -167,16 +168,72 @@ where
         let children: Vec<I> = self.children.into_iter().map(|c| c.inner).collect();
         (children.len() >= 3).then(|| super::UnionTrimmed::new(children, limit, asc))
     }
-    /// Advances all active children whose `last_doc_id` equals `current_id` and finds the
-    /// minimum doc_id in a single pass.
+
+    /// Swap-removes an exhausted child at `idx` by swapping it with the last active child.
+    #[inline]
+    fn swap_remove_child(&mut self, idx: usize) {
+        debug_assert!(idx < self.num_active);
+        self.num_active -= 1;
+        if idx < self.num_active {
+            self.children.swap(idx, self.num_active);
+        }
+    }
+
+    /// Adds a single child's current result to the aggregate.
+    /// Assumes the aggregate has already been reset if needed.
+    fn add_child_to_result(&mut self, child_idx: usize) {
+        let child = &mut self.children[child_idx];
+        if let Some(child_result) = child.current() {
+            let drained_metrics = std::mem::take(&mut child_result.metrics);
+            let child_ptr: *const RSIndexResult<'index> = child_result;
+            // SAFETY: We need a raw pointer to decouple the borrow of the child's
+            // result from `&mut self.result`. This is sound because:
+            // 1. `self.children[i]` and `self.result` are disjoint fields — no aliasing.
+            // 2. The child is owned by `self`, so the 'index data remains valid.
+            let child_ref = unsafe { &*child_ptr };
+            self.result.push_borrowed(child_ref, drained_metrics);
+        }
+    }
+}
+
+// Methods reachable only when `QUICK_EXIT` is `false`, grouped so that the full-mode
+// read path reads together. Each guards its mode at entry rather than being typed on
+// `UnionFlat<'index, I, false>`: the callers are the generic `RQEIterator` impl, which cannot
+// reach a method that exists for only one value of a const generic, and splitting that
+// impl in two would also strand the `ProfileChildren` impl, whose `RQEIterator`
+// supertrait bound is stated for a generic `QUICK_EXIT`.
+impl<'index, I, const QUICK_EXIT: bool> UnionFlat<'index, I, QUICK_EXIT>
+where
+    I: RQEIterator<'index>,
+{
+    /// Advances all active children sitting on `current_id` and finds the minimum
+    /// doc_id in a single pass.
     ///
     /// Returns the minimum doc_id among active children, or `DocId::MAX` if all are exhausted.
+    ///
+    /// Only [`Self::read_full`] calls this, so `QUICK_EXIT` is always `false` here and
+    /// no child can be *behind* `current_id`: a full union advances every child on
+    /// every `read`/`skip_to`, and a child's own `revalidate` may only move it forward.
+    /// A child that were behind would have to be seeked rather than read — one read
+    /// need not clear `current_id` — and would otherwise become the minimum and hand
+    /// back a document already delivered. That case is asserted away rather than
+    /// handled, so it cannot be introduced silently.
     fn advance_and_find_min(&mut self, current_id: DocId) -> Result<DocId, RQEIteratorError> {
+        if QUICK_EXIT {
+            panic!("a quick union reads through skip_to instead");
+        }
+
         let mut min_id: DocId = DocId::MAX;
         let mut i = 0;
 
         while i < self.num_active {
             let child = &mut self.children[i];
+
+            debug_assert!(
+                child.last_doc_id() >= current_id,
+                "a full union's child cannot fall behind it: {} < {current_id}",
+                child.last_doc_id(),
+            );
 
             // Advance children that match the current doc_id
             if child.last_doc_id() == current_id {
@@ -203,42 +260,14 @@ where
         Ok(min_id)
     }
 
-    /// Swap-removes an exhausted child at `idx` by swapping it with the last active child.
-    #[inline]
-    fn swap_remove_child(&mut self, idx: usize) {
-        debug_assert!(idx < self.num_active);
-        self.num_active -= 1;
-        if idx < self.num_active {
-            self.children.swap(idx, self.num_active);
-        }
-    }
-
-    /// Builds the result from active children whose `last_doc_id` equals `min_id`.
-    /// Only used in Full mode - aggregates ALL matching children.
-    fn build_aggregate_result(&mut self, min_id: DocId) {
-        self.result.reset_aggregate();
-        self.result.doc_id = min_id;
-
-        for child in &mut self.children[..self.num_active] {
-            if child.last_doc_id() == min_id
-                && let Some(child_result) = child.current()
-            {
-                let drained_metrics = std::mem::take(&mut child_result.metrics);
-                let child_ptr: *const RSIndexResult<'index> = child_result;
-                // SAFETY: We need a raw pointer to decouple the borrow of the child's
-                // result from `&mut self.result`. This is sound because:
-                // 1. `self.children[i]` and `self.result` are disjoint fields — no aliasing.
-                // 2. The child is owned by `self`, so the 'index data remains valid.
-                let child_ref = unsafe { &*child_ptr };
-                self.result.push_borrowed(child_ref, drained_metrics);
-            }
-        }
-    }
-
     /// Performs initial read on all children to position them at their first document.
     /// Removes any children that are immediately exhausted (empty iterators).
     /// Returns the minimum doc_id among active children, or `DocId::MAX` if all are exhausted.
     fn initialize_children(&mut self) -> Result<DocId, RQEIteratorError> {
+        if QUICK_EXIT {
+            panic!("a quick union positions its children through skip_to instead");
+        }
+
         let mut min_id: DocId = DocId::MAX;
         let mut i = 0;
         while i < self.num_active {
@@ -268,12 +297,43 @@ where
         Ok(min_id)
     }
 
+    /// Builds the result from active children whose `last_doc_id` equals `min_id`.
+    /// Only used in Full mode - aggregates ALL matching children.
+    fn build_aggregate_result(&mut self, min_id: DocId) {
+        if QUICK_EXIT {
+            panic!("a quick union never aggregates; it reports a single child");
+        }
+
+        self.result.reset_aggregate();
+        self.result.doc_id = min_id;
+
+        for child in &mut self.children[..self.num_active] {
+            if child.last_doc_id() == min_id
+                && let Some(child_result) = child.current()
+            {
+                let drained_metrics = std::mem::take(&mut child_result.metrics);
+                let child_ptr: *const RSIndexResult<'index> = child_result;
+                // SAFETY: We need a raw pointer to decouple the borrow of the child's
+                // result from `&mut self.result`. This is sound because:
+                // 1. `self.children[i]` and `self.result` are disjoint fields — no aliasing.
+                // 2. The child is owned by `self`, so the 'index data remains valid.
+                let child_ref = unsafe { &*child_ptr };
+                self.result.push_borrowed(child_ref, drained_metrics);
+            }
+        }
+    }
+
     /// Full mode read - advances matching children and finds minimum in a single fused pass.
     fn read_full(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
-        let min_id = if self.last_doc_id() == 0 {
+        if QUICK_EXIT {
+            panic!("a quick union reads through read_quick");
+        }
+
+        let previous_id = self.last_doc_id();
+        let min_id = if previous_id == 0 {
             self.initialize_children()?
         } else {
-            self.advance_and_find_min(self.last_doc_id())?
+            self.advance_and_find_min(previous_id)?
         };
 
         if min_id == DocId::MAX {
@@ -281,17 +341,16 @@ where
             return Ok(None);
         }
 
+        // The minimum is taken over children that were all advanced past
+        // `previous_id`, so it has to name a later document. Handing back one this
+        // union already delivered would have the caller emit it twice.
+        debug_assert!(
+            min_id > previous_id,
+            "a read must move forward: {previous_id} -> {min_id}",
+        );
+
         self.build_aggregate_result(min_id);
         Ok(Some(&mut self.result))
-    }
-
-    /// Quick mode read - delegates to `skip_to(last_doc_id + 1)`.
-    fn read_quick(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
-        let next_id = self.last_doc_id().saturating_add(1);
-        match self.skip_to(next_id)? {
-            Some(SkipToOutcome::Found(r)) | Some(SkipToOutcome::NotFound(r)) => Ok(Some(r)),
-            None => Ok(None),
-        }
     }
 
     /// Full mode skip_to - scans all active children and aggregates all matches.
@@ -304,6 +363,10 @@ where
         &mut self,
         doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
+        if QUICK_EXIT {
+            panic!("a quick union skips through skip_to_quick");
+        }
+
         let mut min_id: DocId = DocId::MAX;
         let mut i = 0;
 
@@ -365,6 +428,25 @@ where
             Ok(Some(SkipToOutcome::NotFound(&mut self.result)))
         }
     }
+}
+
+// Methods reachable only when `QUICK_EXIT` is `true`. See the note above.
+impl<'index, I, const QUICK_EXIT: bool> UnionFlat<'index, I, QUICK_EXIT>
+where
+    I: RQEIterator<'index>,
+{
+    /// Quick mode read - delegates to `skip_to(last_doc_id + 1)`.
+    fn read_quick(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
+        if !QUICK_EXIT {
+            panic!("a full union reads through read_full");
+        }
+
+        let next_id = self.last_doc_id().saturating_add(1);
+        match self.skip_to(next_id)? {
+            Some(SkipToOutcome::Found(r)) | Some(SkipToOutcome::NotFound(r)) => Ok(Some(r)),
+            None => Ok(None),
+        }
+    }
 
     /// Quick mode skip_to - returns immediately on first exact match.
     /// Tracks minimum doc_id among non-matches for NotFound case.
@@ -372,6 +454,10 @@ where
         &mut self,
         doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
+        if !QUICK_EXIT {
+            panic!("a full union skips through skip_to_full");
+        }
+
         // Use MAX as sentinel like C uses DOCID_MAX - avoids Option overhead
         let mut min_id: DocId = DocId::MAX;
         let mut min_child_idx: usize = 0;
@@ -431,28 +517,16 @@ where
     /// Sets the union result from a single child: resets aggregate, sets doc_id, adds child.
     /// Used in Quick mode where we only need one matching child.
     fn quick_set_from_child(&mut self, child_idx: usize) {
+        if !QUICK_EXIT {
+            panic!("a full union aggregates every matching child instead");
+        }
+
         let child = &mut self.children[child_idx];
 
         self.result.reset_aggregate();
         self.result.doc_id = child.last_doc_id();
 
         self.add_child_to_result(child_idx);
-    }
-
-    /// Adds a single child's current result to the aggregate.
-    /// Assumes the aggregate has already been reset if needed.
-    fn add_child_to_result(&mut self, child_idx: usize) {
-        let child = &mut self.children[child_idx];
-        if let Some(child_result) = child.current() {
-            let drained_metrics = std::mem::take(&mut child_result.metrics);
-            let child_ptr: *const RSIndexResult<'index> = child_result;
-            // SAFETY: We need a raw pointer to decouple the borrow of the child's
-            // result from `&mut self.result`. This is sound because:
-            // 1. `self.children[i]` and `self.result` are disjoint fields — no aliasing.
-            // 2. The child is owned by `self`, so the 'index data remains valid.
-            let child_ref = unsafe { &*child_ptr };
-            self.result.push_borrowed(child_ref, drained_metrics);
-        }
     }
 }
 
@@ -601,6 +675,68 @@ where
             return Ok(RQEValidateStatus::Moved { current: None });
         }
 
+        // Without `QUICK_EXIT` no child can fall behind the union: every active child
+        // is advanced on every `read`/`skip_to`, and a child's own `revalidate` may only
+        // move it forward — one that has run past its end reports no `current` and was
+        // dropped by the scan above. So the minimum is at worst *equal* to the current
+        // position, which is simply a child still sitting on the document it supplied.
+        debug_assert!(
+            QUICK_EXIT || min_doc_id >= original_last_doc_id,
+            "a full union's child cannot fall behind it: {min_doc_id} < {original_last_doc_id}",
+        );
+
+        // With `QUICK_EXIT` it can: `skip_to_quick` returns on the first exact match, so
+        // a later sibling keeps an earlier round's id, or answers 0 having never been
+        // read at all. Such a minimum is not a position to move to — adopting it would
+        // replay documents, because `VALIDATE_MOVED` has the caller emit `current` in
+        // place of a read and the read after that resumes from there. `iterator_api.h`
+        // says `VALIDATE_MOVED` means the position moved *forward*, and
+        // `Not::revalidate` asserts that of its child — which is where a `QUICK_EXIT`
+        // union usually sits.
+        //
+        // `QUICK_EXIT` is a const generic, so a full union compiles this away entirely
+        // rather than paying for a comparison that its invariant already rules out.
+        if QUICK_EXIT && min_doc_id < original_last_doc_id {
+            // Stay put. The result still has to be republished, because it holds raw
+            // pointers into the children's own results: one that moved leaves it
+            // describing another document, and one that aborted was dropped above and
+            // leaves it dangling.
+            //
+            // Republished from a *single* child, as everywhere else in this mode — the
+            // full aggregate is what `QUICK_EXIT` exists to avoid. `min_child_idx`
+            // cannot be used for it: that is the lagging child just rejected, sitting
+            // at `min_doc_id`. So the child still on the current position is looked up
+            // instead. Every child in the active region has a `current` (the scan above
+            // dropped the rest), so finding one by position is enough.
+            //
+            // Nothing is lost by not advancing: the next `read`/`skip_to` seeks every
+            // child that has not moved past `last_doc_id()` — including the lagging
+            // one whose position was rejected here — so the true next document is
+            // found there, by code that can report a failure, rather than here, where
+            // an `Err` would reach the caller as `VALIDATE_ABORTED`.
+            match self.children[..self.num_active]
+                .iter()
+                .position(|c| c.last_doc_id() == original_last_doc_id)
+            {
+                Some(idx) => self.quick_set_from_child(idx),
+                None => {
+                    // Every child that was here has moved on. The caller gets `Ok`, so
+                    // it reads rather than consuming this; the result only has to be
+                    // free of the stale pointers `reset_aggregate` drops.
+                    self.result.reset_aggregate();
+                    self.result.doc_id = original_last_doc_id;
+                }
+            }
+
+            debug_assert_eq!(
+                self.last_doc_id(),
+                original_last_doc_id,
+                "staying put must leave the position untouched",
+            );
+
+            return Ok(RQEValidateStatus::Ok);
+        }
+
         // Rebuild result at the new minimum doc_id
         if QUICK_EXIT {
             self.quick_set_from_child(min_child_idx);
@@ -609,13 +745,18 @@ where
         }
 
         // Return MOVED only if lastDocId changed
-        if self.last_doc_id() != original_last_doc_id {
-            Ok(RQEValidateStatus::Moved {
-                current: Some(&mut self.result),
-            })
-        } else {
-            Ok(RQEValidateStatus::Ok)
+        if self.last_doc_id() == original_last_doc_id {
+            return Ok(RQEValidateStatus::Ok);
         }
+
+        debug_assert!(
+            self.last_doc_id() > original_last_doc_id,
+            "a reported move must be forward",
+        );
+
+        Ok(RQEValidateStatus::Moved {
+            current: Some(&mut self.result),
+        })
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -213,7 +213,9 @@ where
     ///
     /// Only [`Self::read_full`] calls this, so `QUICK_EXIT` is always `false` here and
     /// no child can be *behind* `current_id`: a full union advances every child on
-    /// every `read`/`skip_to`, and a child's own `revalidate` may only move it forward.
+    /// every `read`/`skip_to`, and its own `revalidate` re-seeks any child that came
+    /// back from a child revalidation behind the union — an exhausted leaf can
+    /// resurrect there — before it returns.
     /// A child that were behind would have to be seeked rather than read — one read
     /// need not clear `current_id` — and would otherwise become the minimum and hand
     /// back a document already delivered. That case is asserted away rather than
@@ -675,42 +677,40 @@ where
             return Ok(RQEValidateStatus::Moved { current: None });
         }
 
-        // Without `QUICK_EXIT` no child can fall behind the union: every active child
-        // is advanced on every `read`/`skip_to`, and a child's own `revalidate` may only
-        // move it forward — one that has run past its end reports no `current` and was
-        // dropped by the scan above. So the minimum is at worst *equal* to the current
-        // position, which is simply a child still sitting on the document it supplied.
-        debug_assert!(
-            QUICK_EXIT || min_doc_id >= original_last_doc_id,
-            "a full union's child cannot fall behind it: {min_doc_id} < {original_last_doc_id}",
-        );
-
-        // With `QUICK_EXIT` it can: `skip_to_quick` returns on the first exact match, so
-        // a later sibling keeps an earlier round's id, or answers 0 having never been
-        // read at all. Such a minimum is not a position to move to — adopting it would
-        // replay documents, because `VALIDATE_MOVED` has the caller emit `current` in
-        // place of a read and the read after that resumes from there. `iterator_api.h`
-        // says `VALIDATE_MOVED` means the position moved *forward*, and
-        // `Not::revalidate` asserts that of its child — which is where a `QUICK_EXIT`
-        // union usually sits.
+        // A minimum *behind* the union is not a position to move to — adopting it
+        // would replay documents, because `VALIDATE_MOVED` has the caller emit
+        // `current` in place of a read and the read after that resumes from there.
+        // `iterator_api.h` says `VALIDATE_MOVED` means the position moved *forward*,
+        // and `Not::revalidate` asserts that of its child — which is where a
+        // `QUICK_EXIT` union usually sits.
         //
-        // `QUICK_EXIT` is a const generic, so a full union compiles this away entirely
-        // rather than paying for a comparison that its invariant already rules out.
-        if QUICK_EXIT && min_doc_id < original_last_doc_id {
-            // The result has to be republished either way, because it holds raw pointers
-            // into the children's own results: one that moved leaves it describing
-            // another document, and one that aborted was dropped above and leaves it
-            // dangling. What it can be republished *from* decides the outcome.
+        // Both modes can see one. With `QUICK_EXIT` it is the mode's own early
+        // return: `skip_to_quick` stops on the first exact match, so a later sibling
+        // keeps an earlier round's id, or answers 0 having never been read at all.
+        // Without it there is exactly one way: a child that ran out and was dropped
+        // can *resurrect* during the revalidation above — an inverted-index leaf
+        // rewinds and re-seeks the position it held, and rewinding clears the
+        // past-the-end state — so it re-enters the active set far behind a union
+        // that carried on without it.
+        if min_doc_id < original_last_doc_id {
+            // The result has to be republished either way, because it holds raw
+            // pointers into the children's own results: one that moved leaves it
+            // describing another document, and one that aborted was dropped above and
+            // leaves it dangling. What it can be republished *from* decides the
+            // outcome.
             //
-            // From a *single* child, as everywhere else in this mode — the full aggregate
-            // is what `QUICK_EXIT` exists to avoid. `min_child_idx` cannot serve: that is
-            // the lagging child just rejected, sitting at `min_doc_id`. So the child
-            // still on the current position is looked up instead. Every child in the
-            // active region has a `current` (the scan above dropped the rest), so finding
-            // one by position is enough.
-            if let Some(idx) = self.children[..self.num_active]
-                .iter()
-                .position(|c| c.last_doc_id() == original_last_doc_id)
+            // A child still sitting on the union's document backs the position as it
+            // stands: republish from that *single* child — the full aggregate is what
+            // `QUICK_EXIT` exists to avoid — and report `Ok`, with no reads spent.
+            // `min_child_idx` cannot serve: that is the lagging child just rejected.
+            // Only quick mode takes this exit, leaving its laggers behind as ordinary
+            // state for the next `read`/`skip_to` to seek past; a full union must
+            // catch them up below either way, because `advance_and_find_min` relies
+            // on no active child sitting behind the union.
+            if QUICK_EXIT
+                && let Some(idx) = self.children[..self.num_active]
+                    .iter()
+                    .position(|c| c.last_doc_id() == original_last_doc_id)
             {
                 // Still backed, so the union has not moved and its current stands.
                 self.quick_set_from_child(idx);
@@ -724,27 +724,76 @@ where
                 return Ok(RQEValidateStatus::Ok);
             }
 
-            // Nothing is left on the union's document: the child that supplied it has
-            // moved on too. Reporting `Ok` would promise a `current` that no child backs.
+            // Nothing already sits on the union's document, but a lagging child may
+            // still *hold* it: `skip_to_quick`'s early return strands a sibling
+            // without consuming its position. The union may not step over the
+            // document before asking — under a `NOT`, its position is not a
+            // delivered result but the next id the `NOT` has yet to exclude, and
+            // stepping over it would let that document into the result set. So every
+            // lagger is seeked to the abandoned position itself, not past it.
             //
-            // So the union advances instead, which is what it would have done on the next
-            // read anyway — `read_quick` targets `last_doc_id() + 1` and seeks every
-            // lagging child past it, including the one whose position was rejected here.
-            // Skipping over the abandoned document costs nothing: it has already been
-            // delivered, and a quick union never promised to aggregate every child that
-            // holds it, so no contribution is dropped by leaving it behind.
-            //
-            // This is the one place a `QUICK_EXIT` revalidation reads. An `Err` here
-            // reaches the caller as `VALIDATE_ABORTED`, which frees the iterator and
-            // substitutes an empty one — the failure is reported, if bluntly, which beats
-            // publishing a result that describes nothing.
-            return match self.read_quick()? {
-                Some(result) => Ok(RQEValidateStatus::Moved {
-                    current: Some(result),
-                }),
-                // Seeking past the abandoned position ran the union out of documents.
-                None => Ok(RQEValidateStatus::Moved { current: None }),
-            };
+            // These are the reads a revalidation cannot avoid. An `Err` here reaches
+            // the caller as `VALIDATE_ABORTED`, which frees the iterator and
+            // substitutes an empty one — the failure is reported, if bluntly, which
+            // beats handing out a position no child backs.
+            let mut i = 0;
+            while i < self.num_active {
+                if self.children[i].last_doc_id() >= original_last_doc_id {
+                    i += 1;
+                    continue;
+                }
+                match self.children[i].skip_to(original_last_doc_id)? {
+                    Some(SkipToOutcome::Found(_)) => {
+                        if QUICK_EXIT {
+                            // The document is still matched after all: the union
+                            // stays on it, backed by the child that just landed
+                            // there. Remaining laggers are left for the next call,
+                            // as everywhere else in this mode.
+                            self.quick_set_from_child(i);
+
+                            debug_assert_eq!(
+                                self.last_doc_id(),
+                                original_last_doc_id,
+                                "staying put must leave the position untouched",
+                            );
+
+                            return Ok(RQEValidateStatus::Ok);
+                        }
+                        i += 1;
+                    }
+                    Some(SkipToOutcome::NotFound(_)) => {
+                        i += 1;
+                    }
+                    None => {
+                        // The seek exhausted the child. Don't increment i — the
+                        // swapped-in element needs to be checked.
+                        self.swap_remove_child(i);
+                    }
+                }
+            }
+
+            // Seeking the laggers forward can run the union out of documents.
+            if self.num_active == 0 {
+                self.is_eof = true;
+                return Ok(RQEValidateStatus::Moved { current: None });
+            }
+
+            // Every active child now sits at or past the abandoned position, so the
+            // minimum is a position again: equal to it when children still match the
+            // document (full mode only — quick mode returned above), later otherwise.
+            min_doc_id = DocId::MAX;
+            for (i, child) in self.children[..self.num_active].iter().enumerate() {
+                let child_doc_id = child.last_doc_id();
+                if child_doc_id < min_doc_id {
+                    min_doc_id = child_doc_id;
+                    min_child_idx = i;
+                }
+            }
+
+            debug_assert!(
+                min_doc_id >= original_last_doc_id,
+                "every lagging child was just seeked to the union's position",
+            );
         }
 
         // Rebuild result at the new minimum doc_id

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -200,7 +200,7 @@ where
 // read path reads together. Each guards its mode at entry rather than being typed on
 // `UnionFlat<'index, I, false>`: the caller is the generic `RQEIterator` impl, which
 // cannot reach a method that exists for only one value of a const generic (E0599),
-// and splitting that impl in two would strand its `ProfileChildren` dependant.
+// and splitting that impl in two would strand its `ProfileChildren` dependent.
 impl<'index, I, const QUICK_EXIT: bool> UnionFlat<'index, I, QUICK_EXIT>
 where
     I: RQEIterator<'index>,

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -221,8 +221,10 @@ where
     ///
     /// Only [`Self::read_full`] calls this, so `QUICK_EXIT` is always `false` here and
     /// the root can never be *behind* `current_id`: a full union advances every child in
-    /// the heap on every `read`/`skip_to`, and a child's own `revalidate` may only move
-    /// it forward. A root that were behind would have to be seeked rather than read —
+    /// the heap on every `read`/`skip_to`, and its own `revalidate` re-seeks any child
+    /// that came back from a child revalidation behind the union — an exhausted leaf
+    /// can resurrect there — before it returns.
+    /// A root that were behind would have to be seeked rather than read —
     /// one read need not clear `current_id` — and would otherwise stay the minimum and
     /// hand back a document already delivered. That case is asserted away rather than
     /// handled, so it cannot be introduced silently.
@@ -561,46 +563,47 @@ where
         self.rebuild_heap();
         self.num_active = self.heap.len();
 
-        let Some(min) = self.heap.peek() else {
+        let Some(mut min) = self.heap.peek() else {
             self.is_eof = true;
             return Ok(RQEValidateStatus::Moved { current: None });
         };
 
-        // Without `QUICK_EXIT` no child can fall behind the union: every child in the
-        // heap is advanced on every `read`/`skip_to`, and a child's own `revalidate` may
-        // only move it forward — one that has run past its end reports no `current` and
-        // is left out by `rebuild_heap`. So the minimum is at worst *equal* to the
-        // current position, which is simply a child still sitting on the document it
-        // supplied.
-        debug_assert!(
-            QUICK_EXIT || min.doc_id >= original_last_doc_id,
-            "a full union's child cannot fall behind it: {} < {original_last_doc_id}",
-            min.doc_id,
-        );
-
-        // With `QUICK_EXIT` it can: `rebuild_heap` keys on `last_doc_id()`, which answers
-        // 0 for a child that has never been read and an earlier round's id for one that
-        // `advance_lagging_children` left in the heap when it returned on an exact match.
-        // Such a minimum is not a position to move to — adopting it would replay
-        // documents, because `VALIDATE_MOVED` has the caller emit `current` in place of a
-        // read and the read after that resumes from there. `iterator_api.h` says
-        // `VALIDATE_MOVED` means the position moved *forward*, and `Not::revalidate`
-        // asserts that of its child — which is where a `QUICK_EXIT` union usually sits.
+        // A minimum *behind* the union is not a position to move to — adopting it
+        // would replay documents, because `VALIDATE_MOVED` has the caller emit
+        // `current` in place of a read and the read after that resumes from there.
+        // `iterator_api.h` says `VALIDATE_MOVED` means the position moved *forward*,
+        // and `Not::revalidate` asserts that of its child — which is where a
+        // `QUICK_EXIT` union usually sits.
         //
-        // The result has to be republished either way, because it holds raw pointers into
-        // the children's own results — one that moved leaves it describing another
-        // document, and one that aborted was dropped above and leaves it dangling. What
-        // it can be republished *from* decides the outcome. From a single child, as
-        // everywhere else in this mode: `min.child_idx` cannot serve, being the lagging
-        // child just rejected, so the one still on the current position is looked up.
-        //
-        // `QUICK_EXIT` is a const generic, so a full union compiles this away entirely
-        // rather than paying for a comparison that its invariant already rules out.
-        if QUICK_EXIT && min.doc_id < original_last_doc_id {
-            if let Some(idx) = self
-                .children
-                .iter()
-                .position(|c| !c.at_eof() && c.last_doc_id() == original_last_doc_id)
+        // Both modes can see one. With `QUICK_EXIT` it is the mode's own early
+        // return: `rebuild_heap` keys on `last_doc_id()`, which answers 0 for a child
+        // that has never been read and an earlier round's id for one that
+        // `advance_lagging_children` left in the heap when it returned on an exact
+        // match. Without it there is exactly one way: a child that ran out and was
+        // dropped can *resurrect* during the revalidation above — an inverted-index
+        // leaf rewinds and re-seeks the position it held, and rewinding clears the
+        // past-the-end state — so `rebuild_heap` re-admits it far behind a union that
+        // carried on without it.
+        if min.doc_id < original_last_doc_id {
+            // The result has to be republished either way, because it holds raw
+            // pointers into the children's own results — one that moved leaves it
+            // describing another document, and one that aborted was dropped above and
+            // leaves it dangling. What it can be republished *from* decides the
+            // outcome.
+            //
+            // A child still sitting on the union's document backs the position as it
+            // stands: republish from that *single* child — the full aggregate is what
+            // `QUICK_EXIT` exists to avoid — and report `Ok`, with no reads spent.
+            // `min.child_idx` cannot serve: that is the lagging child just rejected.
+            // Only quick mode takes this exit, leaving its laggers behind as ordinary
+            // state for the next `read`/`skip_to` to seek past; a full union must
+            // catch them up below either way, because `advance_matching_children` and
+            // `build_aggregate_result` rely on the root not sitting behind the union.
+            if QUICK_EXIT
+                && let Some(idx) = self
+                    .children
+                    .iter()
+                    .position(|c| !c.at_eof() && c.last_doc_id() == original_last_doc_id)
             {
                 // Still backed, so the union has not moved and its current stands.
                 self.quick_set_from_child(idx);
@@ -614,27 +617,53 @@ where
                 return Ok(RQEValidateStatus::Ok);
             }
 
-            // Nothing is left on the union's document: the child that supplied it has
-            // moved on too. Reporting `Ok` would promise a `current` that no child backs.
+            // Nothing already sits on the union's document, but a lagging child may
+            // still *hold* it: the early return that stranded it never consumed its
+            // position. The union may not step over the document before asking —
+            // under a `NOT`, its position is not a delivered result but the next id
+            // the `NOT` has yet to exclude, and stepping over it would let that
+            // document into the result set. So the laggers are seeked to the
+            // abandoned position itself, not past it — which is exactly
+            // `advance_lagging_children`, down to quick mode's early return on the
+            // child that lands there.
             //
-            // So the union advances instead, which is what it would have done on the next
-            // read anyway — `read_quick` targets `last_doc_id() + 1` and seeks every
-            // lagging child past it, including the one whose position was rejected here.
-            // Skipping over the abandoned document costs nothing: it has already been
-            // delivered, and a quick union never promised to aggregate every child that
-            // holds it, so no contribution is dropped by leaving it behind.
-            //
-            // This is the one place a `QUICK_EXIT` revalidation reads. An `Err` here
-            // reaches the caller as `VALIDATE_ABORTED`, which frees the iterator and
-            // substitutes an empty one — the failure is reported, if bluntly, which beats
-            // publishing a result that describes nothing.
-            return match self.read_quick()? {
-                Some(result) => Ok(RQEValidateStatus::Moved {
-                    current: Some(result),
-                }),
-                // Seeking past the abandoned position ran the union out of documents.
-                None => Ok(RQEValidateStatus::Moved { current: None }),
+            // These are the reads a revalidation cannot avoid. An `Err` here reaches
+            // the caller as `VALIDATE_ABORTED`, which frees the iterator and
+            // substitutes an empty one — the failure is reported, if bluntly, which
+            // beats handing out a position no child backs.
+            let early_match = self.advance_lagging_children(original_last_doc_id)?;
+            if QUICK_EXIT && early_match != usize::MAX {
+                // The document is still matched after all: the union stays on it,
+                // backed by the child that just landed there. Remaining laggers are
+                // left for the next call, as everywhere else in this mode.
+                self.quick_set_from_child(early_match);
+
+                debug_assert_eq!(
+                    self.last_doc_id(),
+                    original_last_doc_id,
+                    "staying put must leave the position untouched",
+                );
+
+                return Ok(RQEValidateStatus::Ok);
+            }
+
+            min = match self.heap.peek() {
+                Some(min) => min,
+                // Seeking the laggers forward ran the union out of documents.
+                None => {
+                    self.is_eof = true;
+                    return Ok(RQEValidateStatus::Moved { current: None });
+                }
             };
+
+            // Every child left in the heap now sits at or past the abandoned
+            // position, so the root is a position again: equal to it when children
+            // still match the document (full mode only — quick mode returned above),
+            // later otherwise.
+            debug_assert!(
+                min.doc_id >= original_last_doc_id,
+                "every lagging child was just seeked to the union's position",
+            );
         }
 
         if QUICK_EXIT {

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -59,6 +59,7 @@ pub struct RawUnionHeap<'query, Rf: Ref, I, const QUICK_EXIT: bool> {
 pub type UnionHeap<'index, I, const QUICK_EXIT: bool> =
     RawUnionHeap<'index, Active<'index>, I, QUICK_EXIT>;
 
+// Methods used in both modes.
 impl<'index, I, const QUICK_EXIT: bool> UnionHeap<'index, I, QUICK_EXIT>
 where
     I: RQEIterator<'index>,
@@ -124,6 +125,7 @@ where
     pub fn into_trimmed(self, limit: usize, asc: bool) -> Option<super::UnionTrimmed<'index, I>> {
         (self.children.len() >= 3).then(|| super::UnionTrimmed::new(self.children, limit, asc))
     }
+
     /// Rebuilds the heap from scratch based on current child positions.
     /// Used after revalidation when children may have moved arbitrarily.
     ///
@@ -138,114 +140,6 @@ where
                 self.heap.push(child.last_doc_id(), idx);
             }
         }
-    }
-
-    /// Advances children at the heap root whose `last_doc_id` equals `current_id`.
-    fn advance_matching_children(&mut self, current_id: DocId) -> Result<(), RQEIteratorError> {
-        if self.heap.is_empty() {
-            return Ok(());
-        }
-        loop {
-            let root = self.heap.peek().unwrap();
-            if root.doc_id != current_id {
-                break;
-            }
-
-            let child = &mut self.children[root.child_idx];
-            if child.read()?.is_some() {
-                self.heap.replace_root(child.last_doc_id(), root.child_idx);
-            } else {
-                self.heap.pop();
-                self.num_active -= 1;
-                if self.heap.is_empty() {
-                    return Ok(());
-                }
-            }
-        }
-        Ok(())
-    }
-
-    /// Aggregates results from all children whose `last_doc_id` equals `min_id`.
-    ///
-    /// Uses DFS over the heap array, pruning subtrees where `doc_id > min_id`
-    /// (heap property guarantees all descendants are also `>= doc_id`).
-    fn build_aggregate_result(&mut self, min_id: DocId) {
-        self.result.reset_aggregate();
-        self.result.doc_id = min_id;
-
-        // Borrow the heap data slice once so the compiler can hoist bounds
-        // checks out of the loop.
-        let heap_data = self.heap.as_slice();
-
-        if heap_data.is_empty() {
-            return;
-        }
-
-        // A 64-element stack is sufficient for a binary heap of up to 2^64 elements.
-        let mut stack = [0usize; 64];
-        let mut stack_len = 1;
-        stack[0] = 0;
-
-        while stack_len > 0 {
-            stack_len -= 1;
-            let heap_idx = stack[stack_len];
-
-            if heap_idx >= heap_data.len() {
-                continue;
-            }
-
-            let entry = heap_data[heap_idx];
-            if entry.doc_id != min_id {
-                continue;
-            }
-
-            if let Some(child_result) = self.children[entry.child_idx].current() {
-                let drained_metrics = std::mem::take(&mut child_result.metrics);
-                let child_ptr: *const RSIndexResult<'index> = child_result;
-                // SAFETY: We need a raw pointer to decouple the borrow of the child's
-                // result from `&mut self.result`. This is sound because:
-                // 1. `self.children[i]` and `self.result` are disjoint fields — no aliasing.
-                // 2. The child is owned by `self`, so the 'index data remains valid.
-                let child_ref = unsafe { &*child_ptr };
-                self.result.push_borrowed(child_ref, drained_metrics);
-            }
-            // both children of heap_idx are >= doc_id due to heap property
-            let left_heap_idx = 2 * heap_idx + 1;
-            let right_heap_idx = 2 * heap_idx + 2;
-
-            if left_heap_idx < heap_data.len() && stack_len < 64 {
-                stack[stack_len] = left_heap_idx;
-                stack_len += 1;
-            }
-            if right_heap_idx < heap_data.len() && stack_len < 64 {
-                stack[stack_len] = right_heap_idx;
-                stack_len += 1;
-            }
-        }
-    }
-
-    /// Performs initial read on all children and builds the heap.
-    ///
-    /// Clears the heap first: a `revalidate` before the first read runs
-    /// [`Self::rebuild_heap`] while every child is still at `last_doc_id() == 0`,
-    /// and those doc-0 entries would otherwise sort ahead of every real id.
-    fn initialize_children(&mut self) -> Result<(), RQEIteratorError> {
-        self.heap.clear();
-        for (idx, child) in self.children.iter_mut().enumerate() {
-            if child.last_doc_id() == 0 && !child.at_eof() {
-                if child.read()?.is_some() {
-                    self.heap.push(child.last_doc_id(), idx);
-                }
-            } else if child.last_doc_id() > 0 {
-                self.heap.push(child.last_doc_id(), idx);
-            }
-        }
-        // Derived here rather than adjusted, for the same reason the heap is:
-        // a `rebuild_heap` before the first read counts only the children it kept,
-        // and this pass can seed the heap with one it dropped. Leaving the count
-        // alone would let the per-child decrements below run past zero.
-        self.num_active = self.heap.len();
-        Ok(())
     }
 
     /// Advances all lagging children in the heap to at least `doc_id`.
@@ -311,13 +205,173 @@ where
             self.advance_lagging_children(doc_id)
         }
     }
+}
+
+// Methods reachable only when `QUICK_EXIT` is `false`, grouped so that the full-mode
+// read path reads together. Each guards its mode at entry rather than being typed on
+// `UnionHeap<'index, I, false>`: the callers are the generic `RQEIterator` impl, which cannot
+// reach a method that exists for only one value of a const generic, and splitting that
+// impl in two would also strand the `ProfileChildren` impl, whose `RQEIterator`
+// supertrait bound is stated for a generic `QUICK_EXIT`.
+impl<'index, I, const QUICK_EXIT: bool> UnionHeap<'index, I, QUICK_EXIT>
+where
+    I: RQEIterator<'index>,
+{
+    /// Advances the children at the heap root that are sitting on `current_id`.
+    ///
+    /// Only [`Self::read_full`] calls this, so `QUICK_EXIT` is always `false` here and
+    /// the root can never be *behind* `current_id`: a full union advances every child in
+    /// the heap on every `read`/`skip_to`, and a child's own `revalidate` may only move
+    /// it forward. A root that were behind would have to be seeked rather than read —
+    /// one read need not clear `current_id` — and would otherwise stay the minimum and
+    /// hand back a document already delivered. That case is asserted away rather than
+    /// handled, so it cannot be introduced silently.
+    fn advance_matching_children(&mut self, current_id: DocId) -> Result<(), RQEIteratorError> {
+        if QUICK_EXIT {
+            panic!("a quick union reads through skip_to instead");
+        }
+
+        if self.heap.is_empty() {
+            return Ok(());
+        }
+        loop {
+            let root = self.heap.peek().unwrap();
+            debug_assert!(
+                root.doc_id >= current_id,
+                "a full union's child cannot fall behind it: {} < {current_id}",
+                root.doc_id,
+            );
+            if root.doc_id != current_id {
+                break;
+            }
+
+            let child = &mut self.children[root.child_idx];
+            if child.read()?.is_some() {
+                self.heap.replace_root(child.last_doc_id(), root.child_idx);
+            } else {
+                self.heap.pop();
+                self.num_active -= 1;
+                if self.heap.is_empty() {
+                    return Ok(());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Aggregates results from all children whose `last_doc_id` equals `min_id`.
+    ///
+    /// Uses DFS over the heap array, pruning subtrees where `doc_id > min_id`
+    /// (heap property guarantees all descendants are also `>= doc_id`).
+    ///
+    /// `min_id` must be the heap's own minimum. The prune reads any mismatch as
+    /// "past `min_id`, and so is everything below", which only holds when nothing in
+    /// the heap sorts *below* `min_id` — pointed anywhere else, the descent stops at
+    /// the root and the aggregate comes back empty. Only `QUICK_EXIT == false` callers
+    /// reach here, and each passes `self.heap.peek()`, so that holds by construction.
+    fn build_aggregate_result(&mut self, min_id: DocId) {
+        if QUICK_EXIT {
+            panic!("a quick union never aggregates; it reports a single child");
+        }
+        debug_assert_eq!(
+            self.heap.peek().map(|min| min.doc_id),
+            Some(min_id),
+            "the descent's prune is only valid at the heap's minimum",
+        );
+
+        self.result.reset_aggregate();
+        self.result.doc_id = min_id;
+
+        // Borrow the heap data slice once so the compiler can hoist bounds
+        // checks out of the loop.
+        let heap_data = self.heap.as_slice();
+
+        if heap_data.is_empty() {
+            return;
+        }
+
+        // A 64-element stack is sufficient for a binary heap of up to 2^64 elements.
+        let mut stack = [0usize; 64];
+        let mut stack_len = 1;
+        stack[0] = 0;
+
+        while stack_len > 0 {
+            stack_len -= 1;
+            let heap_idx = stack[stack_len];
+
+            if heap_idx >= heap_data.len() {
+                continue;
+            }
+
+            let entry = heap_data[heap_idx];
+            if entry.doc_id != min_id {
+                continue;
+            }
+
+            if let Some(child_result) = self.children[entry.child_idx].current() {
+                let drained_metrics = std::mem::take(&mut child_result.metrics);
+                let child_ptr: *const RSIndexResult<'index> = child_result;
+                // SAFETY: We need a raw pointer to decouple the borrow of the child's
+                // result from `&mut self.result`. This is sound because:
+                // 1. `self.children[i]` and `self.result` are disjoint fields — no aliasing.
+                // 2. The child is owned by `self`, so the 'index data remains valid.
+                let child_ref = unsafe { &*child_ptr };
+                self.result.push_borrowed(child_ref, drained_metrics);
+            }
+            // both children of heap_idx are >= doc_id due to heap property
+            let left_heap_idx = 2 * heap_idx + 1;
+            let right_heap_idx = 2 * heap_idx + 2;
+
+            if left_heap_idx < heap_data.len() && stack_len < 64 {
+                stack[stack_len] = left_heap_idx;
+                stack_len += 1;
+            }
+            if right_heap_idx < heap_data.len() && stack_len < 64 {
+                stack[stack_len] = right_heap_idx;
+                stack_len += 1;
+            }
+        }
+    }
+
+    /// Performs initial read on all children and builds the heap.
+    ///
+    /// Clears the heap first: a `revalidate` before the first read runs
+    /// [`Self::rebuild_heap`] while every child is still at `last_doc_id() == 0`,
+    /// and those doc-0 entries would otherwise sort ahead of every real id.
+    fn initialize_children(&mut self) -> Result<(), RQEIteratorError> {
+        if QUICK_EXIT {
+            panic!("a quick union builds its heap through advance_to instead");
+        }
+
+        self.heap.clear();
+        for (idx, child) in self.children.iter_mut().enumerate() {
+            if child.last_doc_id() == 0 && !child.at_eof() {
+                if child.read()?.is_some() {
+                    self.heap.push(child.last_doc_id(), idx);
+                }
+            } else if child.last_doc_id() > 0 {
+                self.heap.push(child.last_doc_id(), idx);
+            }
+        }
+        // Derived here rather than adjusted, for the same reason the heap is:
+        // a `rebuild_heap` before the first read counts only the children it kept,
+        // and this pass can seed the heap with one it dropped. Leaving the count
+        // alone would let the per-child decrements below run past zero.
+        self.num_active = self.heap.len();
+        Ok(())
+    }
 
     /// Full mode read — advances matching children and finds minimum.
     fn read_full(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
-        if self.last_doc_id() == 0 {
+        if QUICK_EXIT {
+            panic!("a quick union reads through read_quick");
+        }
+
+        let previous_id = self.last_doc_id();
+        if previous_id == 0 {
             self.initialize_children()?;
         } else {
-            self.advance_matching_children(self.last_doc_id())?;
+            self.advance_matching_children(previous_id)?;
         }
 
         let Some(min) = self.heap.peek() else {
@@ -325,12 +379,31 @@ where
             return Ok(None);
         };
 
+        // The root was advanced past `previous_id`, so it has to name a later
+        // document. Handing back one this union already delivered would have the
+        // caller emit it twice.
+        debug_assert!(
+            min.doc_id > previous_id,
+            "a read must move forward: {previous_id} -> {}",
+            min.doc_id,
+        );
+
         self.build_aggregate_result(min.doc_id);
         Ok(Some(&mut self.result))
     }
+}
 
+// Methods reachable only when `QUICK_EXIT` is `true`. See the note above.
+impl<'index, I, const QUICK_EXIT: bool> UnionHeap<'index, I, QUICK_EXIT>
+where
+    I: RQEIterator<'index>,
+{
     /// Quick mode read — delegates to `skip_to(last_doc_id + 1)`.
     fn read_quick(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
+        if !QUICK_EXIT {
+            panic!("a full union reads through read_full");
+        }
+
         let next_id = self.last_doc_id().saturating_add(1);
         match self.skip_to(next_id)? {
             Some(SkipToOutcome::Found(r) | SkipToOutcome::NotFound(r)) => Ok(Some(r)),
@@ -340,6 +413,10 @@ where
 
     /// Sets the union result directly from the child at `child_idx`.
     fn quick_set_from_child(&mut self, child_idx: usize) {
+        if !QUICK_EXIT {
+            panic!("a full union aggregates every matching child instead");
+        }
+
         let child = &mut self.children[child_idx];
 
         self.result.reset_aggregate();
@@ -489,19 +566,86 @@ where
             return Ok(RQEValidateStatus::Moved { current: None });
         };
 
+        // Without `QUICK_EXIT` no child can fall behind the union: every child in the
+        // heap is advanced on every `read`/`skip_to`, and a child's own `revalidate` may
+        // only move it forward — one that has run past its end reports no `current` and
+        // is left out by `rebuild_heap`. So the minimum is at worst *equal* to the
+        // current position, which is simply a child still sitting on the document it
+        // supplied.
+        debug_assert!(
+            QUICK_EXIT || min.doc_id >= original_last_doc_id,
+            "a full union's child cannot fall behind it: {} < {original_last_doc_id}",
+            min.doc_id,
+        );
+
+        // With `QUICK_EXIT` it can: `rebuild_heap` keys on `last_doc_id()`, which answers
+        // 0 for a child that has never been read and an earlier round's id for one that
+        // `advance_lagging_children` left in the heap when it returned on an exact match.
+        // Such a minimum is not a position to move to — adopting it would replay
+        // documents, because `VALIDATE_MOVED` has the caller emit `current` in place of a
+        // read and the read after that resumes from there. `iterator_api.h` says
+        // `VALIDATE_MOVED` means the position moved *forward*, and `Not::revalidate`
+        // asserts that of its child — which is where a `QUICK_EXIT` union usually sits.
+        //
+        // Staying put loses nothing: the next `read`/`skip_to` seeks every child that
+        // has not moved past `last_doc_id()` — including the lagging one whose position
+        // was rejected here — and finds the true next document there, by code that can
+        // report a failure, rather than here, where an `Err` would reach the caller as
+        // `VALIDATE_ABORTED`.
+        //
+        // The result is still republished, at the unchanged position, because it holds
+        // raw pointers into the children's own results — one that moved leaves it
+        // describing another document, and one that aborted was dropped above and
+        // leaves it dangling. From a single child, as everywhere else in this mode:
+        // `min.child_idx` cannot be used for it, being the lagging child just rejected,
+        // so the one still on the current position is looked up instead.
+        //
+        // `QUICK_EXIT` is a const generic, so a full union compiles this away entirely
+        // rather than paying for a comparison that its invariant already rules out.
+        if QUICK_EXIT && min.doc_id < original_last_doc_id {
+            match self
+                .children
+                .iter()
+                .position(|c| !c.at_eof() && c.last_doc_id() == original_last_doc_id)
+            {
+                Some(idx) => self.quick_set_from_child(idx),
+                None => {
+                    // Every child that was here has moved on. The caller gets `Ok`, so
+                    // it reads rather than consuming this; the result only has to be
+                    // free of the stale pointers `reset_aggregate` drops.
+                    self.result.reset_aggregate();
+                    self.result.doc_id = original_last_doc_id;
+                }
+            }
+
+            debug_assert_eq!(
+                self.last_doc_id(),
+                original_last_doc_id,
+                "staying put must leave the position untouched",
+            );
+
+            return Ok(RQEValidateStatus::Ok);
+        }
+
         if QUICK_EXIT {
             self.quick_set_from_child(min.child_idx);
         } else {
             self.build_aggregate_result(min.doc_id);
         }
 
-        if self.last_doc_id() != original_last_doc_id {
-            Ok(RQEValidateStatus::Moved {
-                current: Some(&mut self.result),
-            })
-        } else {
-            Ok(RQEValidateStatus::Ok)
+        // Return MOVED only if lastDocId changed
+        if self.last_doc_id() == original_last_doc_id {
+            return Ok(RQEValidateStatus::Ok);
         }
+
+        debug_assert!(
+            self.last_doc_id() > original_last_doc_id,
+            "a reported move must be forward",
+        );
+
+        Ok(RQEValidateStatus::Moved {
+            current: Some(&mut self.result),
+        })
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -587,44 +587,54 @@ where
         // `VALIDATE_MOVED` means the position moved *forward*, and `Not::revalidate`
         // asserts that of its child — which is where a `QUICK_EXIT` union usually sits.
         //
-        // Staying put loses nothing: the next `read`/`skip_to` seeks every child that
-        // has not moved past `last_doc_id()` — including the lagging one whose position
-        // was rejected here — and finds the true next document there, by code that can
-        // report a failure, rather than here, where an `Err` would reach the caller as
-        // `VALIDATE_ABORTED`.
-        //
-        // The result is still republished, at the unchanged position, because it holds
-        // raw pointers into the children's own results — one that moved leaves it
-        // describing another document, and one that aborted was dropped above and
-        // leaves it dangling. From a single child, as everywhere else in this mode:
-        // `min.child_idx` cannot be used for it, being the lagging child just rejected,
-        // so the one still on the current position is looked up instead.
+        // The result has to be republished either way, because it holds raw pointers into
+        // the children's own results — one that moved leaves it describing another
+        // document, and one that aborted was dropped above and leaves it dangling. What
+        // it can be republished *from* decides the outcome. From a single child, as
+        // everywhere else in this mode: `min.child_idx` cannot serve, being the lagging
+        // child just rejected, so the one still on the current position is looked up.
         //
         // `QUICK_EXIT` is a const generic, so a full union compiles this away entirely
         // rather than paying for a comparison that its invariant already rules out.
         if QUICK_EXIT && min.doc_id < original_last_doc_id {
-            match self
+            if let Some(idx) = self
                 .children
                 .iter()
                 .position(|c| !c.at_eof() && c.last_doc_id() == original_last_doc_id)
             {
-                Some(idx) => self.quick_set_from_child(idx),
-                None => {
-                    // Every child that was here has moved on. The caller gets `Ok`, so
-                    // it reads rather than consuming this; the result only has to be
-                    // free of the stale pointers `reset_aggregate` drops.
-                    self.result.reset_aggregate();
-                    self.result.doc_id = original_last_doc_id;
-                }
+                // Still backed, so the union has not moved and its current stands.
+                self.quick_set_from_child(idx);
+
+                debug_assert_eq!(
+                    self.last_doc_id(),
+                    original_last_doc_id,
+                    "staying put must leave the position untouched",
+                );
+
+                return Ok(RQEValidateStatus::Ok);
             }
 
-            debug_assert_eq!(
-                self.last_doc_id(),
-                original_last_doc_id,
-                "staying put must leave the position untouched",
-            );
-
-            return Ok(RQEValidateStatus::Ok);
+            // Nothing is left on the union's document: the child that supplied it has
+            // moved on too. Reporting `Ok` would promise a `current` that no child backs.
+            //
+            // So the union advances instead, which is what it would have done on the next
+            // read anyway — `read_quick` targets `last_doc_id() + 1` and seeks every
+            // lagging child past it, including the one whose position was rejected here.
+            // Skipping over the abandoned document costs nothing: it has already been
+            // delivered, and a quick union never promised to aggregate every child that
+            // holds it, so no contribution is dropped by leaving it behind.
+            //
+            // This is the one place a `QUICK_EXIT` revalidation reads. An `Err` here
+            // reaches the caller as `VALIDATE_ABORTED`, which frees the iterator and
+            // substitutes an empty one — the failure is reported, if bluntly, which beats
+            // publishing a result that describes nothing.
+            return match self.read_quick()? {
+                Some(result) => Ok(RQEValidateStatus::Moved {
+                    current: Some(result),
+                }),
+                // Seeking past the abandoned position ran the union out of documents.
+                None => Ok(RQEValidateStatus::Moved { current: None }),
+            };
         }
 
         if QUICK_EXIT {

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -211,7 +211,7 @@ where
 // read path reads together. Each guards its mode at entry rather than being typed on
 // `UnionHeap<'index, I, false>`: the caller is the generic `RQEIterator` impl, which
 // cannot reach a method that exists for only one value of a const generic (E0599),
-// and splitting that impl in two would strand its `ProfileChildren` dependant.
+// and splitting that impl in two would strand its `ProfileChildren` dependent.
 impl<'index, I, const QUICK_EXIT: bool> UnionHeap<'index, I, QUICK_EXIT>
 where
     I: RQEIterator<'index>,

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -209,25 +209,20 @@ where
 
 // Methods reachable only when `QUICK_EXIT` is `false`, grouped so that the full-mode
 // read path reads together. Each guards its mode at entry rather than being typed on
-// `UnionHeap<'index, I, false>`: the callers are the generic `RQEIterator` impl, which cannot
-// reach a method that exists for only one value of a const generic, and splitting that
-// impl in two would also strand the `ProfileChildren` impl, whose `RQEIterator`
-// supertrait bound is stated for a generic `QUICK_EXIT`.
+// `UnionHeap<'index, I, false>`: the caller is the generic `RQEIterator` impl, which
+// cannot reach a method that exists for only one value of a const generic (E0599),
+// and splitting that impl in two would strand its `ProfileChildren` dependant.
 impl<'index, I, const QUICK_EXIT: bool> UnionHeap<'index, I, QUICK_EXIT>
 where
     I: RQEIterator<'index>,
 {
     /// Advances the children at the heap root that are sitting on `current_id`.
     ///
-    /// Only [`Self::read_full`] calls this, so `QUICK_EXIT` is always `false` here and
-    /// the root can never be *behind* `current_id`: a full union advances every child in
-    /// the heap on every `read`/`skip_to`, and its own `revalidate` re-seeks any child
-    /// that came back from a child revalidation behind the union — an exhausted leaf
-    /// can resurrect there — before it returns.
-    /// A root that were behind would have to be seeked rather than read —
-    /// one read need not clear `current_id` — and would otherwise stay the minimum and
-    /// hand back a document already delivered. That case is asserted away rather than
-    /// handled, so it cannot be introduced silently.
+    /// Only [`Self::read_full`] calls this, so the root can never be *behind*
+    /// `current_id`: full-mode `read`/`skip_to` advance every child in the heap, and
+    /// `revalidate` re-seeks any child a child revalidation resurrected behind the
+    /// union. A root behind would stay the minimum and hand back a document already
+    /// delivered, so the invariant is asserted rather than handled.
     fn advance_matching_children(&mut self, current_id: DocId) -> Result<(), RQEIteratorError> {
         if QUICK_EXIT {
             panic!("a quick union reads through skip_to instead");
@@ -381,9 +376,6 @@ where
             return Ok(None);
         };
 
-        // The root was advanced past `previous_id`, so it has to name a later
-        // document. Handing back one this union already delivered would have the
-        // caller emit it twice.
         debug_assert!(
             min.doc_id > previous_id,
             "a read must move forward: {previous_id} -> {}",
@@ -585,19 +577,13 @@ where
         // past-the-end state — so `rebuild_heap` re-admits it far behind a union that
         // carried on without it.
         if min.doc_id < original_last_doc_id {
-            // The result has to be republished either way, because it holds raw
-            // pointers into the children's own results — one that moved leaves it
-            // describing another document, and one that aborted was dropped above and
-            // leaves it dangling. What it can be republished *from* decides the
-            // outcome.
-            //
             // A child still sitting on the union's document backs the position as it
-            // stands: republish from that *single* child — the full aggregate is what
-            // `QUICK_EXIT` exists to avoid — and report `Ok`, with no reads spent.
-            // `min.child_idx` cannot serve: that is the lagging child just rejected.
-            // Only quick mode takes this exit, leaving its laggers behind as ordinary
-            // state for the next `read`/`skip_to` to seek past; a full union must
-            // catch them up below either way, because `advance_matching_children` and
+            // stands: republish from it (the result holds raw pointers into children
+            // that may have moved or been dropped) and report `Ok`, with no reads
+            // spent. `min.child_idx` cannot serve — that is the lagging child just
+            // rejected. Quick mode only: its laggers are ordinary state for the next
+            // `read`/`skip_to` to seek past, while a full union must catch them up
+            // below either way — `advance_matching_children` and
             // `build_aggregate_result` rely on the root not sitting behind the union.
             if QUICK_EXIT
                 && let Some(idx) = self
@@ -605,7 +591,6 @@ where
                     .iter()
                     .position(|c| !c.at_eof() && c.last_doc_id() == original_last_doc_id)
             {
-                // Still backed, so the union has not moved and its current stands.
                 self.quick_set_from_child(idx);
 
                 debug_assert_eq!(
@@ -627,15 +612,13 @@ where
             // `advance_lagging_children`, down to quick mode's early return on the
             // child that lands there.
             //
-            // These are the reads a revalidation cannot avoid. An `Err` here reaches
-            // the caller as `VALIDATE_ABORTED`, which frees the iterator and
-            // substitutes an empty one — the failure is reported, if bluntly, which
-            // beats handing out a position no child backs.
+            // These reads cannot be avoided. An `Err` here reaches the caller as
+            // `VALIDATE_ABORTED`, freeing the iterator and substituting an empty one
+            // — blunt, but better than handing out a position no child backs.
             let early_match = self.advance_lagging_children(original_last_doc_id)?;
             if QUICK_EXIT && early_match != usize::MAX {
-                // The document is still matched after all: the union stays on it,
-                // backed by the child that just landed there. Remaining laggers are
-                // left for the next call, as everywhere else in this mode.
+                // Still matched after all: the union stays on it, backed by this
+                // child; remaining laggers wait for the next call.
                 self.quick_set_from_child(early_match);
 
                 debug_assert_eq!(

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -905,14 +905,10 @@ macro_rules! union_common_tests {
         }
 
         /// A quick union whose children are all positioned reports a `Moved` normally:
-        /// the minimum lies ahead, so the stay-put clamp is not involved.
-        ///
-        /// The reading that makes this test interesting is that quick mode does *not*
-        /// leave a sibling behind here, even though its early return is what can. The
-        /// premise is asserted below rather than left to be inferred, because it is
-        /// easy to assume otherwise and conclude that this test contradicts the clamp.
-        /// [`revalidate_child_behind_union_position_is_kept`] is the case that does
-        /// strand a sibling, and it has to work for it: an exact match on the probe.
+        /// the minimum lies ahead, so the stay-put clamp is not involved. No sibling
+        /// lags here — asserted below, since assuming one makes this test look like it
+        /// contradicts the clamp. [`revalidate_child_behind_union_position_is_kept`]
+        /// is the case that does strand a sibling: an exact match on the probe.
         #[test]
         #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_quick_triggers_quick_exit() {
@@ -933,10 +929,8 @@ macro_rules! union_common_tests {
             let result = quick_iter.read().expect("read failed").unwrap();
             assert_eq!(result.doc_id, 10);
 
-            // Both children are positioned, and neither is a lagging sibling. A quick
-            // union's read targets `last_doc_id() + 1`, so this one probed doc 1, and
-            // the early return fires only on an *exact* match with the probe — which
-            // neither child holds. So both were seeked, to 10 and 20 respectively.
+            // The read probed doc 1, an exact match for neither child, so the early
+            // return could not fire and both children were seeked — no lagging sibling.
             assert_eq!(
                 quick_iter
                     .child_at(0)
@@ -951,8 +945,7 @@ macro_rules! union_common_tests {
                     .expect("child1 is still there")
                     .last_doc_id(),
                 20,
-                "child1 was seeked too: probing doc 1 matched neither child exactly, \
-                 so the quick path could not return before reaching it",
+                "child1 was seeked too — the probe matched neither child exactly",
             );
 
             data1.set_revalidate_result(MockRevalidateResult::Move);
@@ -961,17 +954,12 @@ macro_rules! union_common_tests {
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = quick_iter.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
 
-            // child0 moved 10 -> 30 and child1 stayed at 20, so the minimum is 20 —
-            // *ahead* of the union's 10. It is adopted, and the move is reported.
+            // child0 moved 10 -> 30 and child1 stayed at 20: the minimum is ahead.
             assert!(
                 matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
                 "the minimum lies ahead, so it is adopted, got {status:?}",
             );
-            assert_eq!(quick_iter.last_doc_id(), 20);
-            assert!(
-                quick_iter.last_doc_id() > 10,
-                "a reported move must be forward",
-            );
+            assert_eq!(quick_iter.last_doc_id(), 20, "a reported move must be forward");
 
             // And the union carries on from there, without re-delivering doc 20.
             let r = quick_iter.read().expect("read failed").unwrap();
@@ -1059,13 +1047,10 @@ macro_rules! union_common_tests {
             );
         }
 
-        /// Only the `QUICK_EXIT` variant is instantiated, because only it can put a
-        /// child behind the union: the full variants advance every child on every
-        /// `read`/`skip_to`, so their children are never behind the minimum they were
-        /// last asked for, and a child's own `revalidate` may only move it forward.
-        /// The full variants still run the same clamp — reached through
-        /// [`revalidate_minimum_unchanged_returns_ok`] — they just cannot reach it with
-        /// a candidate minimum that is strictly behind.
+        /// Only the `QUICK_EXIT` variants are instantiated: a lagging *live* sibling
+        /// is quick mode's own doing (the early return on an exact match). A full
+        /// union's children only get behind it by resurrecting from EOF, covered by
+        /// [`revalidate_resurrected_child_does_not_drag_a_full_union_backwards`].
         #[test]
         #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_child_behind_union_position_is_kept() {
@@ -1082,16 +1067,13 @@ macro_rules! union_common_tests {
             let r = union.read().expect("read failed").unwrap();
             assert_eq!(r.doc_id, 5);
 
-            // skip_to(100) probes a document child0 holds *exactly*, which is what
-            // strands a sibling: the quick path returns on that match and never reaches
-            // child1. Contrast [`revalidate_quick_triggers_quick_exit`], where the probe
-            // matches no child exactly and so every child gets seeked.
+            // skip_to(100) is an exact match on child0, so the quick path returns
+            // without ever reaching child1 — stranding it behind the union.
             let outcome = union.skip_to(100).expect("skip_to failed");
             assert!(matches!(outcome, Some(SkipToOutcome::Found(_))));
             assert_eq!(union.last_doc_id(), 100);
 
-            // The premise, asserted rather than assumed: child0 supplied doc 100 while
-            // child1 was left where its last read put it, behind the union.
+            // The premise, asserted rather than assumed:
             assert_eq!(
                 union
                     .child_at(0)
@@ -1110,29 +1092,23 @@ macro_rules! union_common_tests {
                 "child1 must be behind the union for this test to exercise anything",
             );
 
-            // Trigger Move on child1: the mock advances it to doc_ids[next_index] = 50 —
-            // forward, as a child's `revalidate` must, and still behind the union's 100.
+            // child1's revalidate moves it forward to 50 — still behind the union's 100.
             data1.set_revalidate_result(MockRevalidateResult::Move);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = union.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
 
-            // The lagging child's 50 is *behind* doc 100, which this union has already
-            // handed out, so it is not a position to move to. Reporting it would have
-            // the caller emit 50 in place of a read and then resume from there,
-            // re-delivering 100. The union stays where it is and reports `Ok`; the
-            // next read advances the lagging child on its way past 100.
+            // 50 is behind the already-delivered 100, so it is not a position to move
+            // to: the union stays put, backed by child0.
             assert!(
                 matches!(status, RQEValidateStatus::Ok),
                 "Expected Ok — the only candidate minimum is behind us, got {status:?}",
             );
             assert_eq!(union.last_doc_id(), 100, "the union must not move backwards");
 
-            // Staying put still has to rebuild the aggregate — it held raw pointers
-            // into children that have since moved — and rebuilding it at a position
-            // that is *not* the minimum is what the heap variant cannot do by
-            // descending its heap: the root sits at 50, fails the `!= min_id` prune
-            // and stops the descent before reaching child0, which is still on 100.
+            // Staying put still rebuilds the aggregate (it held raw pointers into
+            // children that have since moved) — and not via the heap descent, whose
+            // prune stops at the root (50) before ever reaching child0 on 100.
             let current = union
                 .current()
                 .expect("staying put leaves the union on its current document");
@@ -1156,18 +1132,12 @@ macro_rules! union_common_tests {
             assert!(union.at_eof());
         }
 
-        /// The sibling case to [`revalidate_child_behind_union_position_is_kept`]: there,
-        /// a child was still sitting on the union's document, so staying put left a
-        /// result that child backs. Here the child that supplied it has moved on too, so
-        /// there is nothing left to describe that position with.
-        ///
-        /// Staying put would then have to publish a result no child holds, while
-        /// reporting `Ok` — which tells the caller the current result is still valid. The
-        /// union advances to its next document and reports the move instead.
-        ///
-        /// Advancing past the old position loses nothing *because* this is `QUICK_EXIT`:
-        /// the document was already delivered, and a quick union never promised to
-        /// aggregate every child that holds it, so no contribution is dropped by moving on.
+        /// The sibling case to [`revalidate_child_behind_union_position_is_kept`]: here
+        /// the child that supplied the union's document has moved off it, so staying
+        /// put would publish a result no child holds while reporting `Ok`. The lagging
+        /// sibling does not hold the abandoned document either — contrast
+        /// [`revalidate_advance_keeps_a_document_a_lagging_child_still_matches`] —
+        /// so the union advances to its next document and reports the move.
         #[test]
         #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_advances_when_nothing_backs_the_current_position() {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -1017,6 +1017,13 @@ macro_rules! union_common_tests {
             );
         }
 
+        /// Only the `QUICK_EXIT` variant is instantiated, because only it can put a
+        /// child behind the union: the full variants advance every child on every
+        /// `read`/`skip_to`, so their children are never behind the minimum they were
+        /// last asked for, and a child's own `revalidate` may only move it forward.
+        /// The full variants still run the same clamp — reached through
+        /// [`revalidate_minimum_unchanged_returns_ok`] — they just cannot reach it with
+        /// a candidate minimum that is strictly behind.
         #[test]
         #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_child_behind_union_position_is_kept() {
@@ -1047,14 +1054,38 @@ macro_rules! union_common_tests {
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = union.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
-            assert!(
-                matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
-                "Expected Moved with a current result, got {status:?}",
-            );
-            assert_eq!(union.last_doc_id(), 50, "union should move to child1 (50)");
 
-            let r = union.read().expect("read failed").unwrap();
-            assert_eq!(r.doc_id, 100);
+            // The lagging child's 50 is *behind* doc 100, which this union has already
+            // handed out, so it is not a position to move to. Reporting it would have
+            // the caller emit 50 in place of a read and then resume from there,
+            // re-delivering 100. The union stays where it is and reports `Ok`; the
+            // next read advances the lagging child on its way past 100.
+            assert!(
+                matches!(status, RQEValidateStatus::Ok),
+                "Expected Ok — the only candidate minimum is behind us, got {status:?}",
+            );
+            assert_eq!(union.last_doc_id(), 100, "the union must not move backwards");
+
+            // Staying put still has to rebuild the aggregate — it held raw pointers
+            // into children that have since moved — and rebuilding it at a position
+            // that is *not* the minimum is what the heap variant cannot do by
+            // descending its heap: the root sits at 50, fails the `!= min_id` prune
+            // and stops the descent before reaching child0, which is still on 100.
+            let current = union
+                .current()
+                .expect("staying put leaves the union on its current document");
+            assert_eq!(current.doc_id, 100);
+            assert_eq!(
+                current
+                    .as_aggregate()
+                    .expect("a union result is an aggregate")
+                    .len(),
+                1,
+                "child0 is still on doc 100 and must be in the rebuilt aggregate",
+            );
+
+            // Nothing already delivered comes back, and the lagging child's remaining
+            // documents are still yielded.
             let r = union.read().expect("read failed").unwrap();
             assert_eq!(r.doc_id, 200, "child1's doc 200 must not be lost");
             let r = union.read().expect("read failed").unwrap();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -1156,6 +1156,73 @@ macro_rules! union_common_tests {
             assert!(union.at_eof());
         }
 
+        /// The sibling case to [`revalidate_child_behind_union_position_is_kept`]: there,
+        /// a child was still sitting on the union's document, so staying put left a
+        /// result that child backs. Here the child that supplied it has moved on too, so
+        /// there is nothing left to describe that position with.
+        ///
+        /// Staying put would then have to publish a result no child holds, while
+        /// reporting `Ok` — which tells the caller the current result is still valid. The
+        /// union advances to its next document and reports the move instead.
+        ///
+        /// Advancing past the old position loses nothing *because* this is `QUICK_EXIT`:
+        /// the document was already delivered, and a quick union never promised to
+        /// aggregate every child that holds it, so no contribution is dropped by moving on.
+        #[test]
+        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+        fn revalidate_advances_when_nothing_backs_the_current_position() {
+            let child0: Mock<'static, 3> = Mock::new([10, 20, 40]);
+            let child1: Mock<'static, 2> = Mock::new([15, 25]);
+
+            let mut data0 = child0.data();
+
+            let children: Vec<Box<dyn RQEIterator<'static>>> =
+                vec![Box::new(child0), Box::new(child1)];
+            let mut union = $UnionQuick::new(children);
+
+            // Positions both children: child0 on 10, child1 on 15.
+            let r = union.read().expect("read failed").unwrap();
+            assert_eq!(r.doc_id, 10);
+
+            // Probing a document child0 holds exactly strands child1 behind the union.
+            let outcome = union.skip_to(20).expect("skip_to failed");
+            assert!(matches!(outcome, Some(SkipToOutcome::Found(_))));
+            assert_eq!(union.last_doc_id(), 20);
+            assert_eq!(
+                union.child_at(1).expect("child1 is still there").last_doc_id(),
+                15,
+                "the early return left child1 behind the union",
+            );
+
+            // child0 supplied doc 20 and now moves off it, so nothing is left on 20.
+            data0.set_revalidate_result(MockRevalidateResult::Move);
+
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let status = union.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
+
+            // child1's 25 is the next document: child0 has gone to 40, and child1 is
+            // seeked past the abandoned position on the way.
+            let current = match &status {
+                RQEValidateStatus::Moved { current: Some(r) } => r,
+                other => panic!("expected a forward Moved, got {other:?}"),
+            };
+            assert_eq!(current.doc_id, 25, "the union's new position");
+            assert_eq!(
+                current
+                    .as_aggregate()
+                    .expect("a union result is an aggregate")
+                    .len(),
+                1,
+                "the reported result must be backed by the child that holds it",
+            );
+            assert_eq!(union.last_doc_id(), 25);
+
+            // And it carries on from there, with nothing re-delivered.
+            let r = union.read().expect("read failed").unwrap();
+            assert_eq!(r.doc_id, 40, "child0's moved-to document");
+            assert!(union.read().expect("read failed").is_none());
+            assert!(union.at_eof());
+        }
 
         // =============================================================================
         // skip_to edge cases (behavioral only, no read_count assertions)

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -904,6 +904,15 @@ macro_rules! union_common_tests {
             }
         }
 
+        /// A quick union whose children are all positioned reports a `Moved` normally:
+        /// the minimum lies ahead, so the stay-put clamp is not involved.
+        ///
+        /// The reading that makes this test interesting is that quick mode does *not*
+        /// leave a sibling behind here, even though its early return is what can. The
+        /// premise is asserted below rather than left to be inferred, because it is
+        /// easy to assume otherwise and conclude that this test contradicts the clamp.
+        /// [`revalidate_child_behind_union_position_is_kept`] is the case that does
+        /// strand a sibling, and it has to work for it: an exact match on the probe.
         #[test]
         #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_quick_triggers_quick_exit() {
@@ -924,16 +933,49 @@ macro_rules! union_common_tests {
             let result = quick_iter.read().expect("read failed").unwrap();
             assert_eq!(result.doc_id, 10);
 
+            // Both children are positioned, and neither is a lagging sibling. A quick
+            // union's read targets `last_doc_id() + 1`, so this one probed doc 1, and
+            // the early return fires only on an *exact* match with the probe — which
+            // neither child holds. So both were seeked, to 10 and 20 respectively.
+            assert_eq!(
+                quick_iter
+                    .child_at(0)
+                    .expect("child0 is still there")
+                    .last_doc_id(),
+                10,
+                "child0 supplied the union's current document",
+            );
+            assert_eq!(
+                quick_iter
+                    .child_at(1)
+                    .expect("child1 is still there")
+                    .last_doc_id(),
+                20,
+                "child1 was seeked too: probing doc 1 matched neither child exactly, \
+                 so the quick path could not return before reaching it",
+            );
+
             data1.set_revalidate_result(MockRevalidateResult::Move);
             data2.set_revalidate_result(MockRevalidateResult::Ok);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = quick_iter.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
-            assert!(matches!(
-                status,
-                RQEValidateStatus::Moved { current: Some(_) }
-            ));
+
+            // child0 moved 10 -> 30 and child1 stayed at 20, so the minimum is 20 —
+            // *ahead* of the union's 10. It is adopted, and the move is reported.
+            assert!(
+                matches!(status, RQEValidateStatus::Moved { current: Some(_) }),
+                "the minimum lies ahead, so it is adopted, got {status:?}",
+            );
             assert_eq!(quick_iter.last_doc_id(), 20);
+            assert!(
+                quick_iter.last_doc_id() > 10,
+                "a reported move must be forward",
+            );
+
+            // And the union carries on from there, without re-delivering doc 20.
+            let r = quick_iter.read().expect("read failed").unwrap();
+            assert_eq!(r.doc_id, 30, "child0's moved-to document comes next");
         }
 
         #[test]
@@ -1040,16 +1082,36 @@ macro_rules! union_common_tests {
             let r = union.read().expect("read failed").unwrap();
             assert_eq!(r.doc_id, 5);
 
-            // skip_to(100): in heap quick mode, advance_lagging_children finds
-            // child0 at the root (doc 5 < 100), skips child0 to 100 → Found.
-            // QUICK_EXIT returns immediately — child1 stays at doc 10.
+            // skip_to(100) probes a document child0 holds *exactly*, which is what
+            // strands a sibling: the quick path returns on that match and never reaches
+            // child1. Contrast [`revalidate_quick_triggers_quick_exit`], where the probe
+            // matches no child exactly and so every child gets seeked.
             let outcome = union.skip_to(100).expect("skip_to failed");
             assert!(matches!(outcome, Some(SkipToOutcome::Found(_))));
             assert_eq!(union.last_doc_id(), 100);
 
-            // State: union at 100.  child0 at 100.  child1 at 10 (never advanced).
-            // Trigger Move on child1: mock advances to doc_ids[next_index] = 50.
-            //   child1.last_doc_id() = 50  <  100 = union.last_doc_id()
+            // The premise, asserted rather than assumed: child0 supplied doc 100 while
+            // child1 was left where its last read put it, behind the union.
+            assert_eq!(
+                union
+                    .child_at(0)
+                    .expect("child0 is still there")
+                    .last_doc_id(),
+                100,
+                "child0 holds the probed document",
+            );
+            let lagging = union
+                .child_at(1)
+                .expect("child1 is still there")
+                .last_doc_id();
+            assert_eq!(lagging, 10, "the early return never advanced child1");
+            assert!(
+                lagging < union.last_doc_id(),
+                "child1 must be behind the union for this test to exercise anything",
+            );
+
+            // Trigger Move on child1: the mock advances it to doc_ids[next_index] = 50 —
+            // forward, as a child's `revalidate` must, and still behind the union's 100.
             data1.set_revalidate_result(MockRevalidateResult::Move);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -1224,6 +1224,127 @@ macro_rules! union_common_tests {
             assert!(union.at_eof());
         }
 
+        /// Advancing past the abandoned position is only free if nothing else
+        /// matches it. A `QUICK_EXIT` union is where a `NOT` puts its child, and a
+        /// `NOT` does not consume its child's position — it treats it as a lookahead
+        /// boundary it has not reached yet. So a document the union walks past is one
+        /// the `NOT` has still to exclude.
+        ///
+        /// Here doc 20 is held by both children. The union delivers it from child0
+        /// while child1 is left behind on 15, then child0 moves off 20. Nothing backs
+        /// 20 any more, but child1 still matches it, so the union may not step over it
+        /// without first asking child1.
+        #[test]
+        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+        fn revalidate_advance_keeps_a_document_a_lagging_child_still_matches() {
+            use rqe_iterators::{not::Not, utils::NoTimeoutChecker};
+
+            let child0: Mock<'static, 3> = Mock::new([10, 20, 40]);
+            // Unlike [`revalidate_advances_when_nothing_backs_the_current_position`],
+            // the lagging sibling holds the abandoned document itself.
+            let child1: Mock<'static, 3> = Mock::new([15, 20, 25]);
+
+            let mut data0 = child0.data();
+
+            let children: Vec<Box<dyn RQEIterator<'static>>> =
+                vec![Box::new(child0), Box::new(child1)];
+            let mut union = $UnionQuick::new(children);
+
+            // Positions both children: child0 on 10, child1 on 15.
+            let r = union.read().expect("read failed").unwrap();
+            assert_eq!(r.doc_id, 10);
+
+            // Probing a document child0 holds exactly strands child1 behind the union,
+            // still holding 20 itself.
+            let outcome = union.skip_to(20).expect("skip_to failed");
+            assert!(matches!(outcome, Some(SkipToOutcome::Found(_))));
+            assert_eq!(union.last_doc_id(), 20);
+            assert_eq!(
+                union.child_at(1).expect("child1 is still there").last_doc_id(),
+                15,
+                "the early return left child1 behind the union, short of its own 20",
+            );
+
+            // The union is where a NOT keeps its child: ahead of the NOT's own
+            // position, marking the next id the NOT must exclude.
+            let mut not = Not::new(union, 50, 1.0, NoTimeoutChecker);
+            let outcome = not.skip_to(12).expect("skip_to failed");
+            assert!(matches!(outcome, Some(SkipToOutcome::Found(_))));
+            assert_eq!(not.last_doc_id(), 12);
+            assert_eq!(
+                not.child().expect("the union is still there").last_doc_id(),
+                20,
+                "the NOT has not reached its child's position, so doc 20 is still owed",
+            );
+
+            // GC drops doc 20 from child0's postings: it moves on to 40, and nothing
+            // is left on the union's position — except child1, which has not been
+            // asked yet.
+            data0.set_revalidate_result(MockRevalidateResult::Move);
+
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let status = not.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed");
+            assert!(matches!(status, RQEValidateStatus::Ok));
+
+            let remaining = drain_doc_ids(&mut not);
+            assert!(
+                !remaining.contains(&20),
+                "doc 20 is still matched by child1, so the NOT must exclude it. Got: {remaining:?}",
+            );
+        }
+
+        /// A full union may not adopt a minimum behind its own position, and the
+        /// child that can put one there is an *exhausted* one coming back to life.
+        ///
+        /// A leaf's revalidation rewinds before re-seeking to the position it held,
+        /// and rewinding clears the past-the-end state. So a child dropped from the
+        /// active set at doc 30, while the union carried on to 100 without it, is
+        /// re-admitted at 30 — forward of nothing it owns, but far behind the union.
+        #[test]
+        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+        fn revalidate_resurrected_child_does_not_drag_a_full_union_backwards() {
+            let child0: Mock<'static, 2> = Mock::new([10, 30]);
+            let child1: Mock<'static, 3> = Mock::new([20, 100, 200]);
+
+            let mut data0 = child0.data();
+            let mut data1 = child1.data();
+
+            let children: Vec<Box<dyn RQEIterator<'static>>> =
+                vec![Box::new(child0), Box::new(child1)];
+            let mut union = $UnionFull::new(children);
+
+            for expected in [10, 20, 30, 100] {
+                let r = union.read().expect("read failed").unwrap();
+                assert_eq!(r.doc_id, expected);
+            }
+
+            // Reading past 30 exhausted child0, so the union dropped it and reached
+            // 100 on child1 alone.
+            let exhausted = union.child_at(0).expect("child0 is still there");
+            assert!(exhausted.at_eof(), "child0 ran past its last document");
+            assert_eq!(exhausted.last_doc_id(), 30);
+
+            // GC forces a revalidation. child0 rewinds, re-seeks to 30 and finds it
+            // still there — so it comes back live on 30, well behind the union's 100.
+            data0.set_revalidate_reseeks_to(Some(30));
+            // Some other child has to move, or revalidation returns before ever
+            // looking at the resurrected one.
+            data1.set_revalidate_result(MockRevalidateResult::Move);
+
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let status = format!(
+                "{:?}",
+                union.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed"),
+            );
+
+            assert!(
+                union.last_doc_id() >= 100,
+                "the union must not fall back onto a document it already delivered, \
+                 got {} (status {status})",
+                union.last_doc_id(),
+            );
+        }
+
         // =============================================================================
         // skip_to edge cases (behavioral only, no read_count assertions)
         // =============================================================================

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_flat.rs
@@ -19,7 +19,7 @@ mod common {
     union_common_tests!(UnionFullFlat, UnionQuickFlat);
 }
 
-use crate::utils::{create_mock_2, create_mock_3};
+use crate::utils::{Mock, MockRevalidateResult, create_mock_2, create_mock_3};
 use rqe_iterators::{RQEIterator, UnionFullFlat, UnionQuickFlat};
 
 // =============================================================================
@@ -144,4 +144,74 @@ fn union_full_flat_upholds_current_contract() {
     let mut it = UnionFullFlat::new(children);
     assert_eq!(assert_current_contract(&mut it), [1, 2, 3, 4]);
     assert_current_contract_via_skip_to(&mut it, 5);
+}
+
+/// `skip_to_quick` returns on the first exact match, so a later sibling can still
+/// be unread after many reads. A revalidation must not read that child's
+/// `last_doc_id() == 0` as a position: doc 0 sorts ahead of every real id, so the
+/// union would report a document no index holds and move *backwards*, handing a
+/// parent documents it has already been given.
+#[test]
+#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+fn revalidate_with_an_unread_sibling_does_not_move_the_union_backwards() {
+    // child0 holds the probe target, so the early return never reaches child1.
+    let matching: Mock<'static, 3> = Mock::new([10, 20, 30]);
+    let mut matching_data = matching.data();
+    let untouched: Mock<'static, 2> = Mock::new([15, 25]);
+    let untouched_data = untouched.data();
+
+    let children: Vec<Box<dyn RQEIterator<'static>>> =
+        vec![Box::new(matching), Box::new(untouched)];
+    let mut it = UnionQuickFlat::new(children);
+
+    let outcome = it
+        .skip_to(10)
+        .expect("skip_to must not fail")
+        .expect("10 is present");
+    match outcome {
+        rqe_iterators::SkipToOutcome::Found(r) | rqe_iterators::SkipToOutcome::NotFound(r) => {
+            assert_eq!(r.doc_id, 10)
+        }
+    }
+    assert_eq!(it.last_doc_id(), 10);
+    assert_eq!(
+        untouched_data.read_count(),
+        0,
+        "the early return is what leaves this child unread — the premise of the test",
+    );
+
+    matching_data.set_revalidate_result(MockRevalidateResult::Move);
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let status = it
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate must not fail");
+
+    // A `Moved` result is the union's current document and is consumed from here
+    // rather than by the next read, so it counts as delivered.
+    let mut seen = Vec::new();
+    if let rqe_iterators::RQEValidateStatus::Moved {
+        current: Some(result),
+    } = &status
+    {
+        assert_ne!(result.doc_id, 0, "doc 0 is not a document");
+        seen.push(result.doc_id);
+    }
+    assert!(
+        it.last_doc_id() >= 10,
+        "the union must not move behind the document it already yielded, got {}",
+        it.last_doc_id(),
+    );
+
+    // The unread sibling's documents are still owed, so none may be skipped over.
+    while let Some(r) = it.read().expect("read must not fail") {
+        seen.push(r.doc_id);
+    }
+    assert!(
+        seen.iter().all(|id| *id > 10),
+        "nothing already yielded may be handed back: {seen:?}",
+    );
+    assert!(
+        seen.contains(&15),
+        "the unread sibling's 15 is still owed and must not be skipped: {seen:?}",
+    );
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -141,6 +141,7 @@ impl MockData {
             delays: Vec::new(),
             force_read_none: false,
             resume_reseeks_past_end: false,
+            revalidate_reseeks_to: None,
         })))
     }
 
@@ -163,6 +164,25 @@ impl MockData {
     /// reports `Moved` with the iterator rewound and past its end.
     pub fn set_resume_reseeks_past_end(&mut self, reseeks_past_end: bool) -> &mut Self {
         self.0.borrow_mut().resume_reseeks_past_end = reseeks_past_end;
+        self
+    }
+
+    /// Make `revalidate` reproduce an inverted-index re-seek after a GC cycle.
+    ///
+    /// A plain [`MockRevalidateResult::Move`] models a revalidation that steps to
+    /// the next document. The inverted-index iterators do something else: when the
+    /// cached block offset may have been invalidated, `revalidate` *rewinds* and
+    /// then seeks back to the position it held. `rewind` clears the past-the-end
+    /// state, so this resurrects an *exhausted* iterator — it comes back live on
+    /// whatever the seek lands on. That landing is at or after the child's own old
+    /// position, but says nothing about where the parent composite moved to
+    /// meanwhile, which is what makes the state impossible to express with `Move`.
+    ///
+    /// `doc_id` is the document the seek lands on and must be one the mock holds.
+    /// Landing back on the pre-revalidation position reports `Ok` (the seek found
+    /// it); any other landing reports `Moved`.
+    pub fn set_revalidate_reseeks_to(&mut self, doc_id: Option<DocId>) -> &mut Self {
+        self.0.borrow_mut().revalidate_reseeks_to = doc_id;
         self
     }
 
@@ -262,6 +282,9 @@ struct MockDataInternal {
     /// If true, `resume` rewinds and reports `Moved` past the end — see
     /// [`MockData::set_resume_reseeks_past_end`].
     resume_reseeks_past_end: bool,
+    /// Document `revalidate` rewinds and re-seeks onto — see
+    /// [`MockData::set_revalidate_reseeks_to`].
+    revalidate_reseeks_to: Option<DocId>,
 }
 
 impl MockDataInternal {
@@ -470,11 +493,33 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
         &mut self,
         _spec: &index_spec::IndexSpecReadGuard,
     ) -> Result<rqe_iterators::RQEValidateStatus<'_, 'index>, rqe_iterators::RQEIteratorError> {
-        let revalidate_result = {
+        let (revalidate_result, reseeks_to) = {
             let mut data = self.data.0.borrow_mut();
             data.validation_count += 1;
-            data.revalidate_result
+            (data.revalidate_result, data.revalidate_reseeks_to)
         };
+
+        // Rewind-and-re-seek takes precedence: it describes the whole outcome,
+        // including where the mock ends up. See
+        // [`MockData::set_revalidate_reseeks_to`].
+        if let Some(target) = reseeks_to {
+            let index = self
+                .doc_ids
+                .iter()
+                .position(|&id| id == target)
+                .expect("the re-seek target must be one of the mock's documents");
+            let was_at = self.last_doc_id();
+            self.set_result(index);
+            self.next_index = index + 1;
+
+            return Ok(if target == was_at {
+                rqe_iterators::RQEValidateStatus::Ok
+            } else {
+                rqe_iterators::RQEValidateStatus::Moved {
+                    current: Some(&mut self.result),
+                }
+            });
+        }
 
         Ok(match revalidate_result {
             MockRevalidateResult::Ok => rqe_iterators::RQEValidateStatus::Ok,


### PR DESCRIPTION
## Describe the changes in the pull request

> Stacked on #10730. With `at_eof() == current().is_none()` holding for every iterator,
> the eviction of exhausted children in both unions' `revalidate` becomes correct by
> construction, so nothing here has to work around it.

1. **Current:** both union variants derive their post-revalidation position by taking
   the minimum `last_doc_id()` over their children — and that minimum can lie *behind*
   the union. In quick mode this is the mode's own early return: `skip_to_quick` /
   `advance_lagging_children` stop on the first exact match and leave later siblings
   where they were. In full mode there is exactly one way: a child that exhausted
   itself can *resurrect* during revalidation — an inverted-index leaf rewinds and
   re-seeks the position it held, and rewinding clears the past-the-end state — so it
   re-enters the active set far behind a union that carried on without it.
2. **Change:** a minimum behind the union is never adopted. If a child still sits on
   the union's position, the union stays put and reports `Ok` (no reads). Otherwise
   every lagging child is seeked to the abandoned position **itself**, not past it: a
   lagging sibling can still hold that very document. A child landing on it keeps the
   union in place, backed, reporting `Ok`; with none, every child now sits strictly
   ahead and the new minimum is adopted as a forward `Moved` (or EOF).
3. **Outcome:** a union never reports a `Moved` that goes backwards (so it cannot
   replay documents), never reports `Ok` over a `current` no child holds, and never
   steps over a document a lagging child still matches.

### What goes wrong without it

Adopting the backward minimum: `VALIDATE_MOVED` has the caller emit `current` in place
of a read (`result_processor.c`) and the next read resumes from there, so everything in
between comes back a second time — duplicate documents and an inflated count, not an
error. It is also forbidden by contract: `iterator_api.h` defines `VALIDATE_MOVED` as
the position having moved *forward*, and `Not::revalidate` asserts exactly that of its
child — which is where a `QUICK_EXIT` union usually sits, `quick_exit` being
`ctx.in_not_sub_tree() || weight == 0.0`.

Stepping over the abandoned document instead (an earlier revision of this branch) fails
differently: a `NOT` treats its child's position as the next document it has yet to
exclude, not as one already consumed. A lagging sibling that still holds that document
makes it leak into the `NOT`'s results.

### Review findings folded in

@gdesmott supplied two failing tests, both adopted as-is:

- `revalidate_advance_keeps_a_document_a_lagging_child_still_matches` — the `NOT` leak
  above. Fixed by seeking laggers to the abandoned position before advancing past it.
- `revalidate_resurrected_child_does_not_drag_a_full_union_backwards` — disproved this
  PR's original claim that only quick mode can see a backward minimum. Both the
  pre-port C `InvIndIterator_Revalidate` and the Rust port revalidate without an EOF
  guard: rewind, re-seek `last_doc_id`, and report `VALIDATE_OK` if the document
  survived GC — alive again at its old position. The clamp now runs in both modes
  (full mode republishes an aggregate rather than a single child), which also restores
  the no-child-behind invariant the full-mode read path asserts. The mock gained
  `set_revalidate_reseeks_to` to model the resurrection.

### Where a revalidation may read

Everywhere else this change avoids reads inside `revalidate`: an `Err` there reaches
the caller as `VALIDATE_ABORTED`, which frees the iterator and substitutes an empty one
— a repositioning failure surfaces as a quietly shorter result set rather than an
error. The one unavoidable read is seeking the laggers when nothing backs the current
position; the alternative is publishing a result no child holds while reporting `Ok`.
The heap variant reuses `advance_lagging_children` for it (its quick-mode early return
is exactly the landed-on-the-position case); the flat variant runs the equivalent loop
inline, since the union's own `skip_to` precondition forbids calling it at its own
position.

Relatedly, `UnionHeap::build_aggregate_result` prunes on the heap property and yields
an **empty** aggregate if pointed anywhere but the heap minimum. Every caller now
passes `self.heap.peek()`, so that holds by construction and is asserted.

### Making each mode's reach explicit

Private methods reachable in exactly one mode are now grouped into shared, full-only,
and quick-only blocks, each guarding its mode at entry the way `IdList` guards
`SORTED`. Typing the blocks on the const generic (`impl UnionFlat<'index, I, false>`)
does not work yet: the caller is the generic `RQEIterator` impl, which cannot reach a
method that exists for only one value of a const generic (E0599), and splitting that
impl in two would strand `ProfileChildren`, whose supertrait bound is stated for a
generic `QUICK_EXIT`.

### Reachability

Pre-existing, and not a porting regression: the pre-port C `UI_Revalidate` took the
same unguarded minimum with no forward check, and `UI_Skip_Quick_Flat` carried the same
*"child iterators lagging behind the union's last result"* caveat. Reaching a mid-query
revalidation in these states needs a cursor boundary plus a concurrent GC; we could not
construct a query that does it. So this is not proposed for backport and does not
require release notes.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

No end-to-end reproduction — see *Reachability* above.

#### Testing

- `revalidate_child_behind_union_position_is_kept` is master's own test, which
  asserted the old backward move. Its premise — a lagging child must not be dropped —
  is kept; it now pins that the union stays put, nothing already delivered comes back,
  and the republished result is backed (the assertion that catches the heap-descent
  pitfall above).
- `revalidate_advances_when_nothing_backs_the_current_position` — the advance case,
  reachable only when no lagging child still holds the abandoned document.
- The two review tests above cover the `NOT` leak and the full-union resurrection.
- `revalidate_with_an_unread_sibling_does_not_move_the_union_backwards` pins the
  never-read sibling (`last_doc_id() == 0`) case.

Verified at this revision: 2744/2744 across the workspace, `make lint` (clippy +
`cargo doc -Dwarnings`) clean, `cargo fmt --check` clean, and miri clean for
`rqe_iterators` (473 passed, 0 failed) on the nightly pinned in `.rust-nightly`.
