### PR TITLE
cargo: consolidate the musl `redis-module` feature selection

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1160,7 +1160,6 @@ dependencies = [
  "inverted_index",
  "itertools 0.15.0",
  "query_term",
- "redis-module",
  "redis_mock",
  "rqe_core",
  "workspace_hack",
@@ -1524,7 +1523,6 @@ dependencies = [
  "inverted_index",
  "inverted_index_ffi",
  "numeric_range_tree",
- "redis-module",
  "redis_mock",
  "rmp-serde",
  "rqe_core",
@@ -3032,7 +3030,6 @@ dependencies = [
 name = "term_suffix_index_ffi"
 version = "0.0.1"
 dependencies = [
- "redis-module",
  "redis_mock",
  "redisearch_rs",
  "term_suffix_index",
@@ -3355,7 +3352,6 @@ dependencies = [
  "ffi",
  "field",
  "libc",
- "redis-module",
  "redis_mock",
  "rqe_core",
  "thin_vec",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -242,6 +242,12 @@ xxhash-rust = "0.8"
 [workspace.dependencies.redis-module]
 git = "https://github.com/RedisLabsModules/redismodule-rs.git"
 rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710"
+# `default-features = false` is load-bearing. Members declare a plain
+# `redis-module.workspace = true` and rely on it contributing no features, so that
+# c_entrypoint/redisearch_rs/Cargo.toml is the only hand-written place choosing
+# between `bindgen-static` and `bindgen-runtime`. Enabling the defaults here would
+# turn on `bindgen-runtime` for every member and break the Alpine (musl) build; see
+# the comment on that crate's `redis-module` target blocks.
 default-features = false
 
 [profile.release]

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/Cargo.toml
@@ -30,14 +30,6 @@ workspace_hack.workspace = true
 serde.workspace = true
 rmp-serde.workspace = true
 
-[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
-workspace = true
-default-features = false
-features = ["min-redis-compatibility-version-7-2"]
-
-[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
-workspace = true
-
 [dev-dependencies]
 redis_mock.workspace = true
 

--- a/src/redisearch_rs/c_entrypoint/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/redisearch_rs/Cargo.toml
@@ -59,6 +59,18 @@ module_init_ffi = { path = "../module_init_ffi" }
 search_result_ffi = { path = "../search_result_ffi" }
 query_eval_ffi = { path = "../query_eval_ffi" }
 
+# This is the only hand-written place in the workspace that picks `redis-module`'s
+# libclang linking mode. `ffi/Cargo.toml` does the same for `bindgen`'s own
+# `static`/`runtime` build-dependency feature.
+#
+# Every other member that needs `redis-module` declares a plain
+# `redis-module.workspace = true`, which inherits `default-features = false` from
+# `[workspace.dependencies]` and so contributes no features of its own. Builds that
+# include this crate union its choice directly; a single-crate build that excludes it
+# (say `cargo build -p rdb_io`) gets the choice from `workspace_hack`, which every
+# member depends on. That fallback needs `workspace_hack` kept regenerated (`cargo
+# hakari generate`, gated by CI) and only covers the triples in .config/hakari.toml;
+# on any other triple the build fails outright.
 [target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
 # Statically link to the libclang on aarch64-unknown-linux-musl,
 # necessary on Alpine.

--- a/src/redisearch_rs/c_entrypoint/term_suffix_index_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/term_suffix_index_ffi/Cargo.toml
@@ -23,15 +23,3 @@ redis_mock.workspace = true
 
 [target.'cfg(miri)'.dependencies]
 redis_mock.workspace = true
-
-[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
-# Statically link to the libclang on aarch64-unknown-linux-musl,
-# necessary on Alpine.
-# See https://github.com/rust-lang/rust-bindgen/issues/2360
-features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
-workspace = true
-default-features = false
-
-[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
-workspace = true
-default-features = true

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/Cargo.toml
@@ -16,6 +16,7 @@ libc.workspace = true
 thin_vec.workspace = true
 trie_rs = { workspace = true }
 rqe_wildcard = { workspace = true }
+redis-module.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]
@@ -23,15 +24,3 @@ redis_mock.workspace = true
 
 [target.'cfg(miri)'.dependencies]
 redis_mock.workspace = true
-
-[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
-# Statically link to the libclang on aarch64-unknown-linux-musl,
-# necessary on Alpine.
-# See https://github.com/rust-lang/rust-bindgen/issues/2360
-features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
-workspace = true
-default-features = false
-
-[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
-workspace = true
-default-features = true

--- a/src/redisearch_rs/c_entrypoint/ttl_table_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/ttl_table_ffi/Cargo.toml
@@ -24,15 +24,3 @@ ttl_table = { workspace = true , features = ["test-utils"] }
 
 [target.'cfg(miri)'.dependencies]
 redis_mock.workspace = true
-
-[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
-# Statically link to the libclang on aarch64-unknown-linux-musl,
-# necessary on Alpine.
-# See https://github.com/rust-lang/rust-bindgen/issues/2360
-features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
-workspace = true
-default-features = false
-
-[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
-workspace = true
-default-features = true

--- a/src/redisearch_rs/c_wrappers/document_metadata/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/document_metadata/Cargo.toml
@@ -10,16 +10,5 @@ workspace = true
 
 [dependencies]
 ffi.workspace = true
+redis-module.workspace = true
 workspace_hack.workspace = true
-
-[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
-# Statically link to the libclang on aarch64-unknown-linux-musl,
-# necessary on Alpine.
-# See https://github.com/rust-lang/rust-bindgen/issues/2360
-features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
-workspace = true
-default-features = false
-
-[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
-workspace = true
-default-features = true

--- a/src/redisearch_rs/inverted_index_bencher/Cargo.toml
+++ b/src/redisearch_rs/inverted_index_bencher/Cargo.toml
@@ -35,15 +35,3 @@ query_term.workspace = true
 itertools.workspace = true
 redis_mock.workspace = true
 workspace_hack.workspace = true
-
-[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
-# Statically link to the libclang on aarch64-unknown-linux-musl,
-# necessary on Alpine.
-# See https://github.com/rust-lang/rust-bindgen/issues/2360
-features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
-workspace = true
-default-features = false
-
-[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
-workspace = true
-default-features = true

--- a/src/redisearch_rs/rdb_io/Cargo.toml
+++ b/src/redisearch_rs/rdb_io/Cargo.toml
@@ -12,16 +12,5 @@ bench = false
 workspace = true
 
 [dependencies]
+redis-module.workspace = true
 workspace_hack.workspace = true
-
-[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
-# Statically link to the libclang on aarch64-unknown-linux-musl,
-# necessary on Alpine.
-# See https://github.com/rust-lang/rust-bindgen/issues/2360
-features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
-workspace = true
-default-features = false
-
-[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
-workspace = true
-default-features = true

--- a/src/redisearch_rs/redis_json_api/Cargo.toml
+++ b/src/redisearch_rs/redis_json_api/Cargo.toml
@@ -11,21 +11,10 @@ doctest = false
 [dependencies]
 ffi.workspace = true
 thiserror.workspace = true
+redis-module.workspace = true
 workspace_hack.workspace = true
 lending-iterator.workspace = true
 serde_json = { workspace = true, optional = true }
-
-[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
-# Statically link to the libclang on aarch64-unknown-linux-musl,
-# necessary on Alpine.
-# See https://github.com/rust-lang/rust-bindgen/issues/2360
-features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
-workspace = true
-default-features = false
-
-[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
-workspace = true
-default-features = true
 
 [features]
 test-mock = ["dep:serde_json"]

--- a/src/redisearch_rs/redis_mock/Cargo.toml
+++ b/src/redisearch_rs/redis_mock/Cargo.toml
@@ -14,20 +14,9 @@ bench = false
 ffi.workspace = true
 tracing.workspace = true
 value.workspace = true
+redis-module.workspace = true
 workspace_hack.workspace = true
 libc.workspace = true
-
-[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
-# Statically link to the libclang on aarch64-unknown-linux-musl,
-# necessary on Alpine.
-# See https://github.com/rust-lang/rust-bindgen/issues/2360
-features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
-workspace = true
-default-features = false
-
-[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
-workspace = true
-default-features = true
 
 [lints]
 workspace = true

--- a/src/redisearch_rs/rlookup/Cargo.toml
+++ b/src/redisearch_rs/rlookup/Cargo.toml
@@ -32,18 +32,6 @@ tracing.workspace = true
 itertools.workspace = true
 lending-iterator.workspace = true
 
-[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
-# Statically link to the libclang on aarch64-unknown-linux-musl,
-# necessary on Alpine.
-# See https://github.com/rust-lang/rust-bindgen/issues/2360
-features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
-workspace = true
-default-features = false
-
-[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
-workspace = true
-default-features = true
-
 [dev-dependencies]
 pretty_assertions.workspace = true
 proptest = { workspace = true, features = ["std"] }

--- a/src/redisearch_rs/value/Cargo.toml
+++ b/src/redisearch_rs/value/Cargo.toml
@@ -12,6 +12,7 @@ ffi.workspace = true
 libc.workspace = true
 query_error.workspace = true
 nul_terminated_bytes.workspace = true
+redis-module.workspace = true
 workspace_hack.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
@@ -21,18 +22,6 @@ tracing_assert.workspace = true
 [dev-dependencies]
 redisearch_rs = { workspace = true, features = ["mock_allocator"] }
 redis_mock.workspace = true
-
-[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
-# Statically link to the libclang on aarch64-unknown-linux-musl,
-# necessary on Alpine.
-# See https://github.com/rust-lang/rust-bindgen/issues/2360
-features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
-workspace = true
-default-features = false
-
-[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
-workspace = true
-default-features = true
 
 [lints]
 workspace = true

--- a/src/redisearch_rs/workspace_hack/Cargo.toml
+++ b/src/redisearch_rs/workspace_hack/Cargo.toml
@@ -138,7 +138,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "static"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0"] }
 
 [target.x86_64-unknown-linux-musl.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["static"] }
@@ -146,7 +146,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "static"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0"] }
 
 [target.aarch64-unknown-linux-musl.dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["static"] }
@@ -154,7 +154,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "static"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0"] }
 
 [target.aarch64-unknown-linux-musl.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["static"] }
@@ -162,6 +162,6 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "static"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
## Describe the changes in the pull request

**Current.** Twelve manifests in `src/redisearch_rs/` each carried a copy of the same pair of blocks, selecting `redis-module`'s libclang linking mode per libc — eleven identical, the twelfth drifted (see below):

```toml
[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
# Statically link to the libclang on aarch64-unknown-linux-musl,
# necessary on Alpine.
# See https://github.com/rust-lang/rust-bindgen/issues/2360
features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
workspace = true
default-features = false

[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
workspace = true
default-features = true
```

Eleven of those copies were already redundant. `[workspace.dependencies]` sets `default-features = false`, so a plain `redis-module.workspace = true` contributes no features; Cargo unions features across the build graph; and `workspace_hack` — which every member depends on — propagates the choice to members whose own graph excludes the declaring crate. `fork_gc` demonstrated this before this PR: it declared `redis-module` plainly, with no cfg blocks, and resolved identically to the crates that had them. The workspace already relies on the same pattern for `bindgen` itself, in `build_utils`, `top_k_bencher` and `rqe_iterators_bencher`.

The blocks cannot move into `[workspace.dependencies]`, because Cargo only accepts `cfg()` target tables in member manifests — there is no `[workspace.target.'cfg(…)'.dependencies]` form.

**Change.** Keep the pair in `c_entrypoint/redisearch_rs/Cargo.toml` only. Seven members end up with a plain `redis-module.workspace = true` — six gain that line, while `rlookup` already had it alongside the blocks and so only sheds them. Four members — `inverted_index_bencher`, `term_suffix_index_ffi`, `ttl_table_ffi`, `numeric_range_tree_ffi` — lose the dependency outright, as none of them reference `redis_module` anywhere in `src/`, `tests/`, `benches/` or under `cfg(miri)`. Comments were added in two places recording why `default-features = false` is load-bearing and the three conditions under which the `workspace_hack` fallback holds.

**Outcome.** The eleven members shed 128 lines of duplicated manifest and gain 6 plain declarations back, a net −122 there; the PR as a whole is +28 / −136 across 15 files, the additions being the two explanatory comments and the regenerated `workspace_hack`. One place to change the linking mode, and one latent platform divergence removed (below).

### ⚠️ This is not a pure dedup: it changes the musl compatibility level

`numeric_range_tree_ffi`'s copy of the block had drifted since the crate was introduced. It omitted `bindgen-static` — the entire point of the musl branch — and instead added `min-redis-compatibility-version-7-2`, which nothing else requested:

```toml
[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
workspace = true
default-features = false
features = ["min-redis-compatibility-version-7-2"]
```

Because features are additive, that single line propagated to **every** crate, but only on musl. So Alpine builds compiled `redis-module` against the 7.2 API surface while glibc builds used 6.0. This PR makes musl match glibc at 6.0.

Evidence that the removal is safe:

- The only 7.2-gated API surface is `BlockingCallOptions`, `CallOptionsBuilder::build_blocking` and `Context::call_blocking`. Nothing in the workspace references any of them.
- With both `6-0` and `7-2` enabled, the two mutually exclusive `cfg` arms of `redis-module`'s `register_commands` *both* compiled out, so that symbol did not exist on musl at all. Removing `7-2` restores it. It is also unused here.
- `redis-module`'s build script never reads the compatibility feature, so the bindgen-generated `raw` bindings are unaffected either way.

### Verification

- **Resolution equivalence.** `cargo tree --target` across all 103 workspace members × `x86_64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, before and after: **zero** changed rows on gnu; on both musl triples the only difference is the dropped `min-redis-compatibility-version-7-2`. `bindgen-static` is preserved for all 103 members on both musl triples.
- **Hakari.** `cargo hakari generate --diff`, `cargo hakari verify` ("workspace_hack works correctly") and `cargo hakari manage-deps --dry-run` all clean — the same checks CI's *Workspace hack check* job runs.
- **glibc.** `./build.sh DEBUG=1` green; all four crates that lost the dependency compile, `redisearch.so` links.
- **musl.** `./build.sh DEBUG=1` green inside an `alpine:3.23` container built from this repo's `Dockerfile` (`--build-arg BASE_IMAGE=alpine:3.23`, `RUST_DYN_CRT=1`), on a clean tree. Native host triple there is `x86_64-unknown-linux-musl`, and `redis-module` resolves natively to exactly `bindgen-static, min-redis-compatibility-version-6-0`, with `clang-sys` carrying `static` and `libloading` (the dlopen/runtime-linking marker) absent entirely.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `src/redisearch_rs/c_entrypoint/redisearch_rs/Cargo.toml` — now the sole hand-written site selecting `redis-module`'s libclang linking mode, with the rationale documented.
2. `src/redisearch_rs/Cargo.toml` — comment recording that `default-features = false` on the workspace `redis-module` entry is load-bearing.
3. `src/redisearch_rs/workspace_hack/Cargo.toml` — regenerated; the four musl entries keep `bindgen-static` and lose `min-redis-compatibility-version-7-2`.
4. Eleven member manifests — `value`, `rlookup`, `redis_mock`, `redis_json_api`, `rdb_io`, `document_metadata`, `triemap_ffi` reduced to a plain dependency; `inverted_index_bencher`, `term_suffix_index_ffi`, `ttl_table_ffi`, `numeric_range_tree_ffi` dropped it.
5. `src/redisearch_rs/Cargo.lock` — reflects the four removals.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal build-configuration change only. The musl compatibility-level change above alters which `redis-module` items are compiled, but every affected item is unused in this workspace, so the shipped module is functionally identical on all platforms.
