### PR TITLE
[MOD-14885] c_trie: expose the wildcard trie walks

### DIFF
--- a/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
@@ -17,7 +17,10 @@ use std::{
     ptr::NonNull,
 };
 
-use ffi::{SuffixCtx, SuffixType, SuffixType_SUFFIX_TYPE_CONTAINS, SuffixType_SUFFIX_TYPE_SUFFIX};
+use ffi::{
+    SuffixCtx, SuffixType, SuffixType_SUFFIX_TYPE_CONTAINS, SuffixType_SUFFIX_TYPE_SUFFIX,
+    SuffixType_SUFFIX_TYPE_WILDCARD,
+};
 
 /// Which side(s) of a term a [`CTrieRef::iterate_suffix`] walk anchors on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -52,7 +55,7 @@ impl From<SuffixMode> for SuffixType {
 ///   case `runes` is ignored).
 ///
 /// Both hold when the trie invokes this through the function pointer installed
-/// by [`CTrieRef::iterate_contains`].
+/// by [`CTrieRef::iterate_contains`] or [`CTrieRef::iterate_wildcard`].
 unsafe extern "C" fn range_trampoline<F>(
     runes: *const ffi::rune,
     len: usize,
@@ -94,7 +97,8 @@ where
 /// - `s` must point to `len` valid bytes, or `len` must be `0`.
 ///
 /// Both hold when the suffix trie invokes this through the function pointer
-/// installed by [`CTrieRef::iterate_suffix`].
+/// installed by [`CTrieRef::iterate_suffix`] or
+/// [`CTrieRef::iterate_suffix_wildcard`].
 unsafe extern "C" fn suffix_trampoline<F>(
     s: *const c_char,
     len: usize,
@@ -116,6 +120,118 @@ where
         ControlFlow::Continue(()) => 0,
         ControlFlow::Break(()) => 1,
     }
+}
+
+/// A lowercased wildcard pattern, in both encodings the wildcard walks need.
+///
+/// The lowercasing is the *caller's* job and is not checked here. A pattern
+/// built from unfolded runes matches case-sensitively rather than erroring,
+/// because the tries store folded keys and nothing on the way in can tell an
+/// already-folded rune from one that was never folded.
+///
+/// The walks read one element *past* the pattern — its value decides the match
+/// for a pattern ending in `*` — and [`iterate_suffix_wildcard`] also writes a
+/// terminator there. So both encodings carry a zero sentinel past their content,
+/// which a plain `Vec` of the converted pattern would not have. This type owns
+/// that layout instead of leaving each call site to remember it, and derives the
+/// byte form from the rune form so the two cannot disagree.
+///
+/// [`iterate_suffix_wildcard`]: CTrieRef::iterate_suffix_wildcard
+#[derive(Debug)]
+pub struct LoweredPattern {
+    /// The content runes followed by one zero sentinel, so `len()` is
+    /// `runes.len() - 1`.
+    runes: Vec<ffi::rune>,
+    /// The same pattern as bytes, followed by one zero sentinel.
+    bytes: Vec<u8>,
+}
+
+impl LoweredPattern {
+    /// Build a pattern from its lowercased runes, appending the sentinel to both
+    /// encodings.
+    ///
+    /// `runes` must hold only the content — the sentinel is added here.
+    ///
+    /// Returns [`None`], which every caller treats as matching nothing, rather
+    /// than building a pattern that could not name a stored term or could not be
+    /// walked safely:
+    ///
+    /// - a rune slice longer than [`MAX_RUNE_STR_LEN`](ffi::MAX_RUNE_STR_LEN),
+    ///   which the byte conversion declines. A pattern that *is* built therefore
+    ///   fits the `int` length the walks take;
+    /// - a slice holding a zero rune. The byte conversion stops there while the
+    ///   rune form keeps the rest, so the two encodings would describe different
+    ///   patterns — and [`iterate_suffix_wildcard`](CTrieRef::iterate_suffix_wildcard)
+    ///   picks its anchor from the runes but filters candidates by the bytes,
+    ///   which would then report matches the full pattern rejects. The shorter
+    ///   byte form also undersizes that walk's stack scratch space.
+    pub fn new(runes: &[ffi::rune]) -> Option<Self> {
+        // The length check below does not subsume this: enough multibyte runes
+        // before the zero keep the truncated byte form longer than the rune one.
+        if runes.contains(&0) {
+            return None;
+        }
+
+        let mut len: usize = 0;
+        // SAFETY: `runes` is a valid slice of `runes.len()` runes. `runesToStr`
+        // returns a freshly allocated, NUL-terminated buffer of `len` bytes, or
+        // NULL when the slice exceeds `MAX_RUNE_STR_LEN`.
+        let ptr = unsafe { ffi::runesToStr(runes.as_ptr(), runes.len(), &mut len) };
+        let ptr = NonNull::new(ptr)?;
+        // SAFETY: `ptr` addresses `len` bytes written by the call above.
+        let bytes = unsafe { std::slice::from_raw_parts(ptr.as_ptr().cast::<u8>(), len) }.to_vec();
+        // SAFETY: `RedisModule_Free` is set during module init and not mutated
+        // afterwards.
+        let rm_free = unsafe { ffi::RedisModule_Free.expect("Redis allocator not available") };
+        // SAFETY: `ptr` was allocated by the module allocator inside `runesToStr`.
+        unsafe { rm_free(ptr.as_ptr().cast::<c_void>()) };
+
+        let mut runes = runes.to_vec();
+        runes.push(0);
+        let mut bytes = bytes;
+        bytes.push(0);
+
+        // Implied by the zero-rune rejection above, but kept as a backstop:
+        // violating the scratch-space invariant overflows a stack buffer rather
+        // than giving a wrong answer.
+        if bytes.len() < runes.len() {
+            return None;
+        }
+
+        Some(Self { runes, bytes })
+    }
+
+    /// The number of content runes, excluding the sentinel.
+    pub const fn len(&self) -> usize {
+        self.runes.len() - 1
+    }
+
+    /// Whether the pattern has no content.
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Outcome of [`CTrieRef::iterate_suffix_wildcard`].
+///
+/// Neither variant is a failure: declining a pattern the suffix trie cannot
+/// anchor on is a routine handover to the primary terms trie. The distinction is
+/// carried in the type because it also decides who owns the pattern afterwards.
+#[derive(Debug)]
+#[must_use = "a declined walk leaves the pattern un-walked, and dropping it here \
+              silently skips the terms-trie fallback"]
+pub enum SuffixWalk {
+    /// The walk ran and every matching term was delivered to the callback.
+    ///
+    /// The pattern is not returned: the walk terminates its anchor token in
+    /// place, so what remains no longer describes what the caller asked for.
+    Walked,
+    /// The pattern held no literal run to anchor on, so nothing was visited.
+    ///
+    /// The pattern comes back intact — that decision is made before any write —
+    /// ready for a fallback walk over the primary terms trie with
+    /// [`iterate_wildcard`](CTrieRef::iterate_wildcard).
+    NoAnchor(LoweredPattern),
 }
 
 /// Result of a decrement operation on the C Trie.
@@ -280,9 +396,8 @@ impl CTrieRef {
     ///
     /// - A `Some` `timeout` must point to a valid [`timespec`](ffi::timespec)
     ///   that stays valid, and is not mutated (including by another thread), for
-    ///   the duration of the call. The walk reads `*timeout` unsynchronized on
-    ///   every deadline check, so a concurrent write to the pointee is a data
-    ///   race.
+    ///   the duration of the call. The walk reads `*timeout` unsynchronized, so a
+    ///   concurrent write to the pointee is a data race.
     /// - The wrapped trie must not be mutated, freed, or iterated again for the
     ///   duration of the call — including from within `callback`. The walk caches
     ///   raw node and child pointers and reuses them after each callback
@@ -393,6 +508,171 @@ impl CTrieRef {
         // closure outlives the call.
         unsafe {
             ffi::Suffix_IterateContains(std::ptr::from_mut(&mut suffix_ctx));
+        }
+    }
+
+    /// Visit every term matching a wildcard `pattern` — one admitting `*` (any
+    /// run of characters) and `?` (exactly one) — by walking the primary terms
+    /// trie.
+    ///
+    /// For each match the callback receives the term's runes and the number of
+    /// documents indexed under it, and returns [`ControlFlow`] to continue or stop
+    /// the walk early (e.g. once an expansion cap is reached). The walk honours a
+    /// [`Break`] only on the sub-tree path it takes for a pattern ending in `*`;
+    /// otherwise it keeps visiting terms, so a caller enforcing a cap must make
+    /// every further callback a no-op itself.
+    ///
+    /// An empty pattern visits nothing: it can match only the empty term, which
+    /// this trie never holds — a zero-length key is refused on insertion, so an
+    /// indexed empty value exists only as an inverted index. A caller that wants
+    /// to match it has to open that index itself.
+    ///
+    /// `timeout` bounds the walk: `Some(deadline)` aborts it once the deadline
+    /// passes, while `None` runs it to completion with no deadline.
+    ///
+    /// [`Break`]: ControlFlow::Break
+    ///
+    /// # Safety
+    ///
+    /// - A `Some` `timeout` must point to a valid [`timespec`](ffi::timespec)
+    ///   that stays valid, and is not mutated (including by another thread), for
+    ///   the duration of the call. The walk reads `*timeout` unsynchronized, so a
+    ///   concurrent write to the pointee is a data race.
+    /// - The wrapped trie must not be mutated, freed, or iterated again for the
+    ///   duration of the call — including from within `callback`. The walk caches
+    ///   raw node and child pointers and reuses them after each callback
+    ///   invocation, so mutating the trie (e.g. deleting a term, or decrementing
+    ///   one to zero, through another handle) can free a node mid-walk and leave
+    ///   those pointers dangling.
+    pub unsafe fn iterate_wildcard<F>(
+        &self,
+        pattern: &LoweredPattern,
+        timeout: Option<NonNull<ffi::timespec>>,
+        mut callback: F,
+    ) where
+        F: FnMut(&[ffi::rune], usize) -> ControlFlow<()>,
+    {
+        // An empty pattern can match only the empty term, which this trie never
+        // holds (see the doc comment), so skip the walk rather than have it
+        // discover that.
+        if pattern.is_empty() {
+            return;
+        }
+        // As in `iterate_contains`: the walk only honours a deadline when timeout
+        // checks are enabled and treats a null deadline as already-expired, so the
+        // two must move together.
+        let (timeout, skip_timeout_checks) = match timeout {
+            Some(deadline) => (deadline.as_ptr(), false),
+            None => (std::ptr::null_mut(), true),
+        };
+        // SAFETY: `self.ptr` is a valid `Trie` (`CTrieRef` invariant); `pattern`
+        // addresses its content runes followed by the readable zero sentinel the
+        // matcher requires (`LoweredPattern` invariant); `&mut callback` stays
+        // alive for the whole call, so the `ctx` the trampoline reconstitutes is
+        // valid; and `timeout` is null or the valid pointer the caller supplied.
+        unsafe {
+            ffi::Trie_IterateWildcard(
+                self.ptr,
+                pattern.runes.as_ptr(),
+                pattern.len() as c_int,
+                Some(range_trampoline::<F>),
+                std::ptr::from_mut(&mut callback).cast(),
+                timeout,
+                skip_timeout_checks,
+            );
+        }
+    }
+
+    /// Visit every term matching a wildcard `pattern` through the *suffix* trie,
+    /// which indexes terms by their suffixes so a pattern that is not
+    /// front-anchored can be answered without a full scan.
+    ///
+    /// `self` must wrap a suffix trie, not the primary terms trie. Each matching
+    /// term is delivered to `callback` as a byte string — already converted from
+    /// runes by the suffix trie — with no document count; the callback returns
+    /// [`ControlFlow`] to continue or stop. A term reachable under several
+    /// matching suffix keys is delivered once per key, so `callback` may see
+    /// duplicates.
+    ///
+    /// A [`Break`](ControlFlow::Break) carries the same weak guarantee as in
+    /// [`iterate_wildcard`](Self::iterate_wildcard): it is honoured outright only
+    /// when the anchor token the walk settles on is `*`-terminated, and otherwise
+    /// ends just the current suffix key's terms. Which token is chosen is not the
+    /// caller's to predict, so treat the weaker guarantee as the contract.
+    ///
+    /// The suffix trie can only answer a pattern that contains a literal run to
+    /// anchor on. When it does not, nothing is visited and the pattern is handed
+    /// back as [`SuffixWalk::NoAnchor`] so the caller can fall back to
+    /// [`iterate_wildcard`](Self::iterate_wildcard) over the primary terms trie.
+    ///
+    /// `pattern` is consumed because a walk that *does* happen corrupts it:
+    /// terminating the anchor token overwrites whatever followed it — the
+    /// sentinel for a token ending at the pattern's end, but a content rune
+    /// otherwise.
+    ///
+    /// `timeout` bounds the walk, as for [`iterate_wildcard`](Self::iterate_wildcard).
+    ///
+    /// # Safety
+    ///
+    /// - `self` must wrap a suffix trie, whose nodes carry a suffix-data payload.
+    ///   The iterator reinterprets each visited node's payload as that type and
+    ///   dereferences it, so passing the primary terms trie (or any trie with a
+    ///   different payload) is type confusion and undefined behavior.
+    /// - A `Some` `timeout` must satisfy the same validity and no-concurrent-write
+    ///   requirement as in [`iterate_wildcard`](Self::iterate_wildcard).
+    /// - The wrapped trie must not be mutated, freed, or iterated again for the
+    ///   duration of the call — including from within `callback` — for the same
+    ///   dangling-pointer reason as [`iterate_wildcard`](Self::iterate_wildcard).
+    ///   A `callback` that consults the *primary* trie is fine; it is a separate
+    ///   trie.
+    pub unsafe fn iterate_suffix_wildcard<F>(
+        &self,
+        mut pattern: LoweredPattern,
+        timeout: Option<NonNull<ffi::timespec>>,
+        mut callback: F,
+    ) -> SuffixWalk
+    where
+        F: FnMut(&[u8]) -> ControlFlow<()>,
+    {
+        // An empty pattern has no token to anchor on, which is the answer the walk
+        // itself would give — but it would first size a stack array from the byte
+        // length, so answer it here.
+        if pattern.is_empty() {
+            return SuffixWalk::NoAnchor(pattern);
+        }
+
+        let (timeout_ptr, skip_timeout_checks) = match timeout {
+            Some(deadline) => (deadline.as_ptr(), false),
+            None => (std::ptr::null_mut(), true),
+        };
+
+        let mut suffix_ctx = SuffixCtx {
+            trie: self.ptr,
+            rune: pattern.runes.as_mut_ptr(),
+            runelen: pattern.len(),
+            cstr: pattern.bytes.as_ptr().cast::<c_char>(),
+            cstrlen: pattern.bytes.len() - 1,
+            // The wildcard walk never reads this back, but a stale `Contains`
+            // would misdescribe the context in a debugger.
+            type_: SuffixType_SUFFIX_TYPE_WILDCARD,
+            callback: Some(suffix_trampoline::<F>),
+            cbCtx: std::ptr::from_mut(&mut callback).cast(),
+            timeout: timeout_ptr,
+            skipTimeoutChecks: skip_timeout_checks,
+        };
+        // SAFETY: every `suffix_ctx` field is initialised above with a valid
+        // value — `self.ptr` is a valid suffix `Trie` (caller contract), the rune
+        // and byte pointers describe the same live pattern, each followed by the
+        // sentinel the walk reads and writes (`LoweredPattern` invariant), the
+        // callback closure outlives the call, and `timeout` is null or the valid
+        // pointer the caller supplied.
+        let used = unsafe { ffi::Suffix_IterateWildcard(std::ptr::from_mut(&mut suffix_ctx)) };
+        if used == 0 {
+            // Nothing was visited and, because that decision precedes every write,
+            // the pattern is still intact.
+            SuffixWalk::NoAnchor(pattern)
+        } else {
+            SuffixWalk::Walked
         }
     }
 

--- a/src/redisearch_rs/c_wrappers/c_trie/tests/iterate.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/tests/iterate.rs
@@ -25,7 +25,7 @@ use std::{
     ptr::{self, NonNull},
 };
 
-use c_trie::{CTrieRef, SuffixMode};
+use c_trie::{CTrieRef, LoweredPattern, SuffixMode, SuffixWalk};
 use ffi::{SuffixType, SuffixType_SUFFIX_TYPE_CONTAINS, SuffixType_SUFFIX_TYPE_SUFFIX};
 
 /// Convert an ASCII/UTF-8 string to the trie's rune (`u16`) key.
@@ -100,6 +100,22 @@ fn with_suffix_trie(terms: &[&str], f: impl FnOnce(&CTrieRef)) {
     f(&trie);
     // SAFETY: freed exactly once after the last use of `trie`.
     unsafe { ffi::TrieType_Free(ptr.cast::<c_void>()) };
+}
+
+/// Render a rune slice as text, for corpora that are not pure ASCII. Runes are
+/// UTF-16 code units and every corpus term stays inside the BMP, so each rune is
+/// its own `char`.
+fn runes_to_text(runes: &[ffi::rune]) -> String {
+    runes
+        .iter()
+        .map(|&r| char::from_u32(u32::from(r)).expect("corpus runes are BMP scalars"))
+        .collect()
+}
+
+/// Build a wildcard pattern from an ASCII/UTF-8 string. Every corpus here is
+/// lowercase already, so no case folding is needed on the way in.
+fn pattern(s: &str) -> LoweredPattern {
+    LoweredPattern::new(&to_runes(s)).expect("pattern is short enough to convert")
 }
 
 /// Corpus used across the anchoring tests. Every term contains `"ap"`; only
@@ -363,5 +379,450 @@ fn iterate_suffix_empty_pattern_visits_nothing() {
             });
         }
         assert_eq!(count, 0);
+    });
+}
+
+// --- `LoweredPattern` -------------------------------------------------------
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn lowered_pattern_length_excludes_the_sentinel() {
+    let p = pattern("he?l*o");
+    assert_eq!(p.len(), 6);
+    assert!(!p.is_empty());
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn lowered_pattern_from_no_runes_is_empty() {
+    // The sentinel is still appended, but it does not count as content.
+    let p = LoweredPattern::new(&[]).expect("an empty pattern converts");
+    assert_eq!(p.len(), 0);
+    assert!(p.is_empty());
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn lowered_pattern_length_is_in_runes_not_bytes() {
+    // A multibyte pattern separates the two encodings, which every ASCII pattern
+    // leaves the same length. The byte form must be the longer one — it is what
+    // the suffix walk sizes its scratch space by.
+    let p = pattern("hé*");
+    assert_eq!(p.len(), 3, "three runes: h, é, *");
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn lowered_pattern_declines_a_pattern_longer_than_max_rune_str_len() {
+    // The byte conversion declines anything over `MAX_RUNE_STR_LEN` runes; such a
+    // pattern can name no stored term, so there is nothing to walk with.
+    let runes = vec![ffi::rune::from(b'a'); ffi::MAX_RUNE_STR_LEN as usize + 1];
+    assert!(LoweredPattern::new(&runes).is_none());
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn lowered_pattern_declines_a_pattern_holding_a_zero_rune() {
+    // Violates the no-zero-rune contract: the byte conversion stops at the zero
+    // while the rune form keeps what follows, so the two encodings would describe
+    // different patterns. Declined rather than built.
+    assert!(LoweredPattern::new(&[ffi::rune::from(b'a'), 0, ffi::rune::from(b'b')]).is_none());
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn lowered_pattern_declines_a_zero_rune_the_length_check_cannot_catch() {
+    // Enough multibyte runes *before* the zero and the truncated byte form is
+    // still longer than the rune form, so a `bytes.len() < runes.len()` test
+    // passes while the two encodings describe different patterns. That is not a
+    // narrower match but a wrong one: the suffix walk picks its anchor from the
+    // rune form and filters candidates with the byte form, so the truncated
+    // `éé*` would admit terms the full pattern rejects.
+    let e = ffi::rune::from(0x00E9u16); // 'é' — two bytes, one rune
+    let runes = [e, e, ffi::rune::from(b'*'), 0, ffi::rune::from(b'a')];
+    // The check the explicit rejection replaces would have let this through.
+    assert!(LoweredPattern::new(&runes).is_none());
+}
+
+// --- `iterate_wildcard` (terms trie) ----------------------------------------
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_wildcard_reports_terms_and_num_docs() {
+    with_terms_trie(CORPUS, |trie| {
+        let mut got: HashSet<(String, usize)> = HashSet::new();
+        // SAFETY: `trie` wraps a live terms trie that is not mutated during the
+        // walk; the timeout is `None`; the closure does not touch the trie.
+        unsafe {
+            trie.iterate_wildcard(&pattern("ap*"), None, |term, num_docs| {
+                got.insert((runes_to_string(term), num_docs));
+                ControlFlow::Continue(())
+            });
+        }
+        // `numDocs` == char length, as inserted by `with_terms_trie`.
+        let expected: HashSet<(String, usize)> =
+            [("apple".to_owned(), 5), ("apricot".to_owned(), 7)]
+                .into_iter()
+                .collect();
+        assert_eq!(got, expected);
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_wildcard_matches_a_star_that_is_not_front_anchored() {
+    with_terms_trie(CORPUS, |trie| {
+        let mut got = HashSet::new();
+        // SAFETY: live, un-mutated terms trie; `None` timeout.
+        unsafe {
+            trie.iterate_wildcard(&pattern("*ple"), None, |term, _| {
+                got.insert(runes_to_string(term));
+                ControlFlow::Continue(())
+            });
+        }
+        assert_eq!(got, set(&["apple", "maple"]));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_wildcard_question_mark_matches_exactly_one_rune() {
+    with_terms_trie(CORPUS, |trie| {
+        let mut got = HashSet::new();
+        // SAFETY: live, un-mutated terms trie; `None` timeout.
+        unsafe {
+            trie.iterate_wildcard(&pattern("m?p"), None, |term, _| {
+                got.insert(runes_to_string(term));
+                ControlFlow::Continue(())
+            });
+        }
+        // `map` only: `maple` is longer, and `?` does not span two runes.
+        assert_eq!(got, set(&["map"]));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_wildcard_matches_a_multibyte_pattern() {
+    // A pattern whose byte and rune lengths differ, which every ASCII pattern
+    // hides. `?` here is one *rune*, so it spans the two-byte `é`.
+    with_terms_trie(&["héllo", "hallo", "hxyllo"], |trie| {
+        let mut got = HashSet::new();
+        // SAFETY: live, un-mutated terms trie; `None` timeout.
+        unsafe {
+            trie.iterate_wildcard(&pattern("h?llo"), None, |term, _| {
+                got.insert(runes_to_text(term));
+                ControlFlow::Continue(())
+            });
+        }
+        assert_eq!(got, set(&["héllo", "hallo"]));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_wildcard_empty_pattern_visits_nothing() {
+    with_terms_trie(CORPUS, |trie| {
+        let empty = LoweredPattern::new(&[]).expect("an empty pattern converts");
+        let mut count = 0_usize;
+        // SAFETY: live, un-mutated terms trie; `None` timeout; empty pattern.
+        unsafe {
+            trie.iterate_wildcard(&empty, None, |_, _| {
+                count += 1;
+                ControlFlow::Continue(())
+            });
+        }
+        // The walk underneath would read the byte before the pattern to decide
+        // whether it ends in `*`, so this must not reach it.
+        assert_eq!(count, 0);
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_wildcard_break_stops_a_trailing_star_walk_early() {
+    with_terms_trie(CORPUS, |trie| {
+        let mut count = 0_usize;
+        // SAFETY: live, un-mutated terms trie; `None` timeout.
+        unsafe {
+            trie.iterate_wildcard(&pattern("ap*"), None, |_, _| {
+                count += 1;
+                ControlFlow::Break(())
+            });
+        }
+        assert_eq!(count, 1, "Break must stop after the first match");
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_wildcard_break_is_ignored_without_a_trailing_star() {
+    // The documented caveat: the walk only honours `Break` on the sub-tree path
+    // it takes for a pattern ending in `*`. Otherwise it keeps visiting terms and
+    // the caller must make every further callback a no-op itself.
+    with_terms_trie(CORPUS, |trie| {
+        let mut count = 0_usize;
+        // SAFETY: live, un-mutated terms trie; `None` timeout.
+        unsafe {
+            trie.iterate_wildcard(&pattern("*ple"), None, |_, _| {
+                count += 1;
+                ControlFlow::Break(())
+            });
+        }
+        assert_eq!(count, 2, "both matches are still delivered");
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_wildcard_some_and_none_timeout_agree() {
+    // As in `iterate_contains_some_and_none_timeout_agree`: a deadline never
+    // fires in this binary, so this covers the wrapper's timeout mapping rather
+    // than deadline enforcement.
+    with_terms_trie(CORPUS, |trie| {
+        let mut none_hits = HashSet::new();
+        // SAFETY: live, un-mutated terms trie; `None` timeout.
+        unsafe {
+            trie.iterate_wildcard(&pattern("ap*"), None, |term, _| {
+                none_hits.insert(runes_to_string(term));
+                ControlFlow::Continue(())
+            });
+        }
+
+        // SAFETY: `timespec` is a plain-old-data struct; an all-zero value is valid.
+        let mut deadline: ffi::timespec = unsafe { mem::zeroed() };
+        deadline.tv_sec = 1_i64 << 40; // far in the future
+        let mut some_hits = HashSet::new();
+        // SAFETY: live, un-mutated terms trie; `deadline` is a valid `timespec`
+        // that outlives the call.
+        unsafe {
+            trie.iterate_wildcard(
+                &pattern("ap*"),
+                Some(NonNull::from(&mut deadline)),
+                |term, _| {
+                    some_hits.insert(runes_to_string(term));
+                    ControlFlow::Continue(())
+                },
+            );
+        }
+
+        assert_eq!(none_hits, set(&["apple", "apricot"]));
+        assert_eq!(some_hits, none_hits);
+    });
+}
+
+// --- `iterate_suffix_wildcard` (suffix trie) --------------------------------
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_suffix_wildcard_anchors_on_the_pattern_literal() {
+    with_suffix_trie(CORPUS, |trie| {
+        let mut got = HashSet::new();
+        // SAFETY: `trie` wraps a live suffix trie (matching payload/free
+        // callback) that is not mutated during the walk; `None` timeout.
+        let outcome = unsafe {
+            trie.iterate_suffix_wildcard(pattern("*ple"), None, |bytes| {
+                got.insert(String::from_utf8_lossy(bytes).into_owned());
+                ControlFlow::Continue(())
+            })
+        };
+        assert!(
+            matches!(outcome, SuffixWalk::Walked),
+            "`ple` is a literal the suffix trie can use"
+        );
+        assert_eq!(got, set(&["apple", "maple"]));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_suffix_wildcard_anchor_token_may_absorb_a_trailing_star() {
+    // The delicate case `LoweredPattern` exists for. The chosen anchor token
+    // `ma` is followed by `*`, so the walk extends the token to cover it and then
+    // terminates it *past* its end — writing the sentinel, at the index one
+    // beyond the pattern's last rune.
+    with_suffix_trie(CORPUS, |trie| {
+        let mut got = HashSet::new();
+        // SAFETY: live, un-mutated suffix trie; `None` timeout.
+        let outcome = unsafe {
+            trie.iterate_suffix_wildcard(pattern("ma*"), None, |bytes| {
+                got.insert(String::from_utf8_lossy(bytes).into_owned());
+                ControlFlow::Continue(())
+            })
+        };
+        assert!(matches!(outcome, SuffixWalk::Walked));
+        assert_eq!(got, set(&["maple", "map"]));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_suffix_wildcard_matches_a_multibyte_pattern() {
+    // Separates the pattern's byte length from its rune length, which is what the
+    // walk sizes its stack scratch arrays by. Every ASCII pattern leaves the two
+    // equal and so cannot tell the sizing apart.
+    with_suffix_trie(&["héllo", "hallo"], |trie| {
+        let mut got = HashSet::new();
+        // SAFETY: live, un-mutated suffix trie; `None` timeout.
+        let outcome = unsafe {
+            trie.iterate_suffix_wildcard(pattern("*éllo"), None, |bytes| {
+                got.insert(String::from_utf8_lossy(bytes).into_owned());
+                ControlFlow::Continue(())
+            })
+        };
+        assert!(matches!(outcome, SuffixWalk::Walked));
+        assert_eq!(got, set(&["héllo"]));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_suffix_wildcard_declines_a_pattern_with_no_literal_to_anchor_on() {
+    with_suffix_trie(CORPUS, |trie| {
+        let mut count = 0_usize;
+        // SAFETY: live, un-mutated suffix trie; `None` timeout.
+        let outcome = unsafe {
+            trie.iterate_suffix_wildcard(pattern("**"), None, |_| {
+                count += 1;
+                ControlFlow::Continue(())
+            })
+        };
+        let SuffixWalk::NoAnchor(returned) = outcome else {
+            panic!("a pattern of only `*` has no token to anchor on");
+        };
+        assert_eq!(count, 0);
+        // The decision precedes every write, so the pattern comes back usable for
+        // the caller's fallback over the primary terms trie.
+        assert_eq!(returned.len(), 2);
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_suffix_wildcard_declines_an_empty_pattern() {
+    with_suffix_trie(CORPUS, |trie| {
+        let empty = LoweredPattern::new(&[]).expect("an empty pattern converts");
+        let mut count = 0_usize;
+        // SAFETY: live, un-mutated suffix trie; `None` timeout; empty pattern.
+        let outcome = unsafe {
+            trie.iterate_suffix_wildcard(empty, None, |_| {
+                count += 1;
+                ControlFlow::Continue(())
+            })
+        };
+        let SuffixWalk::NoAnchor(returned) = outcome else {
+            panic!("an empty pattern has no token to anchor on");
+        };
+        assert_eq!(count, 0);
+        assert!(returned.is_empty());
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_suffix_wildcard_break_stops_a_star_terminated_anchor_early() {
+    // `ma*` extends its anchor token to include the `*`, which is what puts the
+    // walk on the sub-tree path — the only path that honours a stop request.
+    with_suffix_trie(CORPUS, |trie| {
+        let mut count = 0_usize;
+        // SAFETY: live, un-mutated suffix trie; `None` timeout.
+        let outcome = unsafe {
+            trie.iterate_suffix_wildcard(pattern("ma*"), None, |_| {
+                count += 1;
+                ControlFlow::Break(())
+            })
+        };
+        assert!(matches!(outcome, SuffixWalk::Walked));
+        assert_eq!(count, 1, "Break must stop after the first match");
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_suffix_wildcard_break_is_ignored_for_an_anchor_without_a_trailing_star() {
+    // The documented caveat, pinned. `*p?e` anchors on `p?e`, which is not
+    // `*`-terminated, so the walk is not on the sub-tree path and discards the
+    // stop request — it only truncates the matches under the node it is on, then
+    // moves to the next matching node.
+    //
+    // Two suffix keys match `p?e` here: `ple` (from `apple`) and `pie`. One
+    // matching key would hide this, since `Break` does end that key's own list.
+    with_suffix_trie(&["apple", "pie"], |trie| {
+        let mut count = 0_usize;
+        // SAFETY: live, un-mutated suffix trie; `None` timeout.
+        let outcome = unsafe {
+            trie.iterate_suffix_wildcard(pattern("*p?e"), None, |_| {
+                count += 1;
+                ControlFlow::Break(())
+            })
+        };
+        assert!(matches!(outcome, SuffixWalk::Walked));
+        assert_eq!(
+            count, 2,
+            "one callback per matching suffix key, despite Break"
+        );
     });
 }

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -442,6 +442,7 @@ const HEADERS: &[HeaderAllowlist] = &[
         path: "src/suffix.h",
         fns: &[
             "Suffix_IterateContains",
+            "Suffix_IterateWildcard",
             "addSuffixTrie",
             "suffixTrie_freeCallback",
         ],
@@ -468,6 +469,7 @@ const HEADERS: &[HeaderAllowlist] = &[
             "Trie_GetNode",
             "Trie_InsertStringBuffer",
             "Trie_IterateContains",
+            "Trie_IterateWildcard",
             "TrieType_Free",
         ],
         types: &[],


### PR DESCRIPTION
> Stacked on #10744 — base that PR first. The diff below is this commit only.

## Describe the changes in the pull request

1. **Current.** The two C trie walks that expand a *verbatim wildcard* pattern —
   `Trie_IterateWildcard` over the primary terms trie, and
   `Suffix_IterateWildcard` over the suffix trie when the pattern has a literal
   run to anchor on — have no Rust wrapper, so `QN_WILDCARD_QUERY` cannot be
   ported.

2. **Change.** Wrap both as `CTrieRef::iterate_wildcard` and
   `CTrieRef::iterate_suffix_wildcard`.

   The pattern is not passed as a slice. Both matchers read one element *past*
   it, and the suffix walk also **writes** there; they get away with it in C
   because the converters over-allocate by one and zero it, which a pattern
   arriving as a plain `Vec` does not. So the argument is a `LoweredPattern`,
   which owns that layout for the rune and byte encodings alike and keeps the raw
   pointers crate-private, rather than leaving each call site to remember it.

   `iterate_suffix_wildcard` takes the pattern **by value** and hands it back
   only in the `Err` case, because a walk that actually happens overwrites part
   of it — for a token that does not end the pattern, a content rune rather than
   the sentinel. `Err` means the suffix trie found nothing to anchor on and the
   caller should fall back to the terms-trie walk; the pattern comes back intact
   because that decision precedes every write.

   Neither walk honours a stop request in general, and both now say so. The
   trie only consults the callback's verdict on the sub-tree path it takes for a
   `*`-terminated pattern; on any other path it discards it and keeps visiting.
   A caller enforcing an expansion cap therefore has to make its own callbacks
   no-ops rather than trust `Break`. Tests pin it — the suffix one needs *two*
   matching suffix keys to show the gap, since `Break` does end the term list
   under a single key.

3. **Outcome.** The walks become available to the `QN_WILDCARD_QUERY` evaluator.
   Nothing calls them yet, so there is no runtime behavior change in this PR.

### One deliberate departure from the C

An empty pattern visits nothing rather than being handed to the walk. C reads
`str[nstr - 1]` before checking anything (`trie_node.c:1400`), so an empty
pattern reads out of bounds — and if that byte happens to be `*`, `r->prefix` is
set, the root full-matches, and `rangeIterateSubTree` returns **every term in the
index**.

#### Which additional issues this PR fixes
1. MOD-14885

#### Main objects this PR modified
1. `LoweredPattern` — new; owns the sentinel layout both walks require
2. `CTrieRef::iterate_wildcard` — new
3. `CTrieRef::iterate_suffix_wildcard` — new
4. `ffi/build.rs` — allowlists `Trie_IterateWildcard` and `Suffix_IterateWildcard`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
