### PR TITLE
[MOD-14885] c_trie: stop rejecting term keys that are not valid UTF-8

### DIFF
--- a/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
@@ -118,6 +118,34 @@ where
     }
 }
 
+/// Whether every byte sequence in `bytes` ends within it, so decoding it to runes
+/// reads nothing past the end.
+///
+/// The decoder derives each sequence's length from its lead byte and never
+/// re-checks that length against the byte count it was given, so this has to walk
+/// from the start exactly as it does. A sequence that begins inside `bytes` and
+/// promises more bytes than remain is the only thing that makes it over-read —
+/// and it can do so without ever landing on the last byte, having swallowed it as
+/// a continuation.
+///
+/// Deliberately *not* a UTF-8 validity check. A term key is not always valid
+/// UTF-8: a lone surrogate — what truncating a non-BMP codepoint to a rune at
+/// index time produces — is encoded into the three-byte form UTF-8 forbids, and
+/// decodes straight back to the rune it came from.
+fn decodes_within(bytes: &[u8]) -> bool {
+    let mut i = 0usize;
+    while i < bytes.len() {
+        i += match bytes[i] {
+            0x00..=0x7F => 1,
+            0x80..=0xDF => 2,
+            0xE0..=0xEF => 3,
+            0xF0..=0xFF => 4,
+        };
+    }
+    // The walk overshoots exactly when the last sequence runs off the end.
+    i == bytes.len()
+}
+
 /// Result of a decrement operation on the C Trie.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::FromRepr)]
 #[repr(u32)]
@@ -194,13 +222,35 @@ impl CTrieRef {
     /// Number of documents indexed under `term`, or `0` if the term is absent
     /// from the trie.
     ///
-    /// `term` is UTF-8 encoded; it is converted to runes internally and looked
-    /// up as an exact match. Used to compute a term's inverse document
-    /// frequency (IDF).
+    /// `term` is decoded back to runes internally and looked up as an exact
+    /// match. Used to compute a term's inverse document frequency (IDF).
     ///
-    /// Returns `0` for input that cannot correspond to a stored term — invalid
-    /// UTF-8, or a term longer than the trie can hold — since such a term can
-    /// never have been inserted.
+    /// The bytes are not validated as UTF-8, because a stored key is not always
+    /// valid UTF-8: a rune that is a lone surrogate — what truncating a non-BMP
+    /// codepoint to a rune at index time produces — is encoded into the
+    /// three-byte form UTF-8 forbids, and decodes straight back to the rune it
+    /// came from. Rejecting those would report no documents for exactly the terms
+    /// such a codepoint creates. Callers pass both stored keys (an expansion
+    /// looking up what it matched) and arbitrary query text (a token lookup), so
+    /// no shape can be assumed.
+    ///
+    /// Returns `0` for a term longer than the trie can hold, which can never have
+    /// been inserted.
+    ///
+    /// # A term this cannot find
+    ///
+    /// A key whose *last* multibyte sequence is cut short by its own end — say a
+    /// three-byte lead with only two bytes left — is stored under a rune decoded
+    /// partly from the byte that followed the term at index time, which is not
+    /// part of the term and is not recoverable from `term` alone. Insertion sees
+    /// a NUL there only when the tokenizer copied the token; otherwise it is the
+    /// separator that ended the token, or whatever the document buffer holds.
+    ///
+    /// This lookup decodes as though that byte were a NUL, so it finds such a
+    /// term when it was stored from a copied token and misses it otherwise. That
+    /// is a pre-existing property of the C indexing path — the stored rune
+    /// genuinely depends on a byte outside the term — not something this lookup
+    /// can repair.
     ///
     /// # Safety
     ///
@@ -214,23 +264,45 @@ impl CTrieRef {
             return 0;
         }
 
-        // The rune conversion decodes UTF-8 without bounds-checking multibyte
-        // sequences against the slice end, so a truncated or invalid sequence
-        // could read past `term`. Reject non-UTF-8 input up front; such a term
-        // cannot match a stored (rune-decoded) term anyway.
-        if std::str::from_utf8(term).is_err() {
-            return 0;
-        }
+        // The decode takes each sequence's length from its lead byte alone and
+        // never re-checks it against the byte count it was given, so a sequence
+        // the term's last byte cuts short is read up to three bytes past the end.
+        //
+        // A term whose sequences all end within it — every well-formed one,
+        // multibyte or not — never triggers that, so it can be decoded in place.
+        // Only a ragged tail needs a copy, and then the zero padding both bounds
+        // the over-read and stands in for the byte that followed the term at index
+        // time. See the doc comment for when that substitution is right and when
+        // it is not.
+        //
+        // Whether the tail is ragged has to be decided by walking from the *start*,
+        // the way the decode does: it takes each sequence's length from its lead
+        // byte, so it can consume the term's final bytes as continuations of a
+        // sequence that began earlier and run off the end without ever landing on
+        // the last byte. Judging by that byte alone would miss `E6 61`, whose lead
+        // promises three bytes from index 0 and so reads one past a two-byte term.
+        const OVERREAD_PAD: usize = 3;
+        let padded: Option<Vec<u8>> = if decodes_within(term) {
+            None
+        } else {
+            let mut p = Vec::with_capacity(term.len() + OVERREAD_PAD);
+            p.extend_from_slice(term);
+            p.resize(term.len() + OVERREAD_PAD, 0);
+            Some(p)
+        };
+        let src = padded.as_deref().unwrap_or(term);
 
-        // A UTF-8 string yields at most as many runes as bytes; the extra slot
+        // A byte string yields at most as many runes as bytes; the extra slot
         // leaves room for the conversion to write a trailing rune.
         let mut runes = vec![0 as ffi::rune; term.len() + 1];
-        // SAFETY: `term` is valid UTF-8 of `term.len()` bytes, so the decode
-        // stays within the slice, and `runes` has room for `term.len() + 1`
-        // runes, so the conversion writes within bounds.
+        // SAFETY: the decode is told to consume `term.len()` bytes and reads at
+        // most three past that. `src` either carries that much zero padding, or is
+        // `term` itself in the cases above where the decode stops on its last
+        // byte — so the read stays inside `src` either way. It emits at most one
+        // rune per byte consumed, so `runes` has room for every rune it writes.
         let rlen = unsafe {
             ffi::strToRunesN(
-                term.as_ptr() as *const c_char,
+                src.as_ptr() as *const c_char,
                 term.len(),
                 runes.as_mut_ptr(),
             )
@@ -401,5 +473,33 @@ impl CTrieRef {
     /// This is useful when you need to pass the pointer to other C functions.
     pub const fn as_ptr(&self) -> *mut ffi::Trie {
         self.ptr
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decodes_within;
+
+    #[test]
+    fn well_formed_sequences_decode_within_bounds() {
+        assert!(decodes_within(b""));
+        assert!(decodes_within(b"apple"));
+        assert!(decodes_within("héllo".as_bytes()));
+        assert!(decodes_within("日本".as_bytes()));
+        assert!(decodes_within("𝄞".as_bytes())); // four-byte sequence
+        // A lone surrogate is a complete three-byte sequence, however invalid.
+        assert!(decodes_within(b"a\xED\xA0\x80b"));
+    }
+
+    #[test]
+    fn a_sequence_running_off_the_end_does_not() {
+        // The lead is the last byte.
+        assert!(!decodes_within(b"\xC3"));
+        assert!(!decodes_within(b"apple\xE6"));
+        // The lead is *not* the last byte: it swallows the ASCII bytes after it as
+        // continuations and still overshoots. A check that looked only at the final
+        // byte would wrongly pass these.
+        assert!(!decodes_within(b"\xE6a"));
+        assert!(!decodes_within(b"x\xF0ab"));
     }
 }

--- a/src/redisearch_rs/c_wrappers/c_trie/tests/num_docs.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/tests/num_docs.rs
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Integration tests for [`CTrieRef::num_docs`].
+//!
+//! Each test builds a live C trie through the linked static library, inserts
+//! terms the way the indexer does, and looks their document count back up.
+
+// Links the Rust-provided and C-provided symbols of the whole module.
+extern crate redisearch_rs;
+// Provides the Redis allocator (and stubs) the C trie code relies on.
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
+use std::{
+    ffi::{c_char, c_void},
+    ptr,
+};
+
+use c_trie::CTrieRef;
+
+/// A term to index: its bytes, the byte that followed it in the buffer
+/// insertion decoded from, and the document count to store it under.
+///
+/// The trailing byte matters because the decode reads past a term whose last
+/// multibyte sequence is cut short by its own end, and what it finds there
+/// becomes part of the stored key. The indexer supplies a NUL only when the
+/// tokenizer copied the token; otherwise it is the separator that ended the
+/// token.
+struct Term {
+    bytes: &'static [u8],
+    next_byte: u8,
+    num_docs: usize,
+}
+
+/// Build a terms trie holding `terms`, run `f`, then free it.
+///
+/// Each term is laid out as its own bytes, then `next_byte`, then enough zeros
+/// that the decode's over-read — up to three bytes past the length it is given —
+/// always lands inside the allocation.
+fn with_terms_trie(terms: &[Term], f: impl FnOnce(&CTrieRef)) {
+    // SAFETY: `NewTrie` returns a fresh, valid, empty terms trie; a terms trie
+    // stores no payload, so a null free callback is correct.
+    let ptr = unsafe { ffi::NewTrie(None, ffi::TrieSortMode_Trie_Sort_Lex) };
+    assert!(!ptr.is_null(), "NewTrie returned null");
+    for term in terms {
+        let mut buf = term.bytes.to_vec();
+        buf.push(term.next_byte);
+        buf.resize(term.bytes.len() + 3, 0);
+        // SAFETY: `ptr` is the live trie just created; `buf` holds the term's
+        // `bytes.len()` bytes followed by padding covering the over-read; a null
+        // payload is accepted.
+        unsafe {
+            ffi::Trie_InsertStringBuffer(
+                ptr,
+                buf.as_ptr().cast::<c_char>(),
+                term.bytes.len(),
+                1.0,
+                0,
+                ptr::null_mut(),
+                term.num_docs,
+            );
+        }
+    }
+    // SAFETY: `ptr` is a valid trie that stays alive for the whole closure and is
+    // not freed until after it returns.
+    let trie = unsafe { CTrieRef::from_raw(ptr) };
+    f(&trie);
+    // SAFETY: `ptr` was produced by `NewTrie` and is freed exactly once here,
+    // after the last use of `trie`.
+    unsafe { ffi::TrieType_Free(ptr.cast::<c_void>()) };
+}
+
+/// A plain ASCII term, as the indexer stores one, ending at a separator.
+const fn ascii(bytes: &'static [u8], num_docs: usize) -> Term {
+    Term {
+        bytes,
+        next_byte: b' ',
+        num_docs,
+    }
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn reports_the_stored_count() {
+    with_terms_trie(&[ascii(b"apple", 5), ascii(b"apricot", 7)], |trie| {
+        assert_eq!(trie.num_docs(b"apple"), 5);
+        assert_eq!(trie.num_docs(b"apricot"), 7);
+        assert_eq!(trie.num_docs(b"pear"), 0, "absent term");
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn finds_a_key_that_is_not_valid_utf8() {
+    // `ED A0 80` is rune `0xD800`, a lone surrogate — what truncating a non-BMP
+    // codepoint to a rune at index time produces. It is a *complete* three-byte
+    // sequence, so nothing is read past the term and the key round-trips exactly;
+    // validating it as UTF-8 would report zero documents for precisely the terms
+    // such a codepoint creates, inflating their IDF.
+    const SURROGATE: &[u8] = b"a\xED\xA0\x80b";
+    with_terms_trie(&[ascii(b"plain", 1), ascii(SURROGATE, 2)], |trie| {
+        assert_eq!(trie.num_docs(b"plain"), 1);
+        assert_eq!(trie.num_docs(SURROGATE), 2);
+    });
+}
+
+/// A three-byte lead with only two bytes left before the term ends, so the
+/// decode consumes the byte that follows the term.
+const TRUNCATED: &[u8] = b"a\xE6\x97";
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn finds_a_truncated_key_stored_from_a_copied_token() {
+    // The tokenizer copies a token whenever normalization allocated, and the copy
+    // is NUL-terminated — so insertion decoded `E6 97 00`. The lookup pads with
+    // zeros and reaches the same rune.
+    with_terms_trie(
+        &[
+            ascii(b"plain", 1),
+            Term {
+                bytes: TRUNCATED,
+                next_byte: 0,
+                num_docs: 2,
+            },
+        ],
+        |trie| {
+            assert_eq!(trie.num_docs(b"plain"), 1);
+            assert_eq!(trie.num_docs(TRUNCATED), 2);
+        },
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn misses_a_truncated_key_stored_from_an_uncopied_token() {
+    // The limit, pinned so it is not mistaken for covered. On the path where the
+    // tokenizer does not copy, the token points into the document buffer and the
+    // byte after it is the separator that ended it — so insertion decoded
+    // `E6 97 20` and stored a different rune than any byte-only lookup can name.
+    // The stored key genuinely depends on a byte outside the term.
+    with_terms_trie(
+        &[
+            ascii(b"plain", 1),
+            Term {
+                bytes: TRUNCATED,
+                next_byte: b' ',
+                num_docs: 2,
+            },
+        ],
+        |trie| {
+            assert_eq!(trie.num_docs(b"plain"), 1);
+            assert_eq!(
+                trie.num_docs(TRUNCATED),
+                0,
+                "not reachable by its own bytes"
+            );
+        },
+    );
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn reports_zero_for_a_truncated_key_that_was_never_stored() {
+    with_terms_trie(&[ascii(b"apple", 5)], |trie| {
+        assert_eq!(trie.num_docs(b"apple\xC3"), 0);
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn empty_term_is_absent() {
+    with_terms_trie(&[ascii(b"apple", 5)], |trie| {
+        assert_eq!(trie.num_docs(b""), 0);
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn reports_zero_for_a_lead_byte_that_swallows_the_last_byte() {
+    // `E6` promises three bytes from index 0, so the decode consumes the trailing
+    // `a` as a continuation and runs one past a two-byte term — without ever
+    // landing on that last byte. Judging the tail by its final byte alone would
+    // call this safe to decode in place and read out of bounds.
+    with_terms_trie(&[ascii(b"apple", 5)], |trie| {
+        assert_eq!(trie.num_docs(b"\xE6a"), 0);
+        assert_eq!(trie.num_docs(b"x\xF0ab"), 0);
+    });
+}


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current.** `CTrieRef::num_docs` rejects any key that is not valid UTF-8 and
   reports zero documents for it. A **lone surrogate** — what truncating a
   non-BMP codepoint to a `rune` at index time produces — is encoded into the
   three-byte form UTF-8 forbids, so every term such a codepoint creates is
   reported absent. The count becomes a term's IDF on the search-on-disk path, so
   an expansion that matched one scores it as if it had never been seen.

   The guard was not arbitrary: `strToRunesN` takes each sequence's length from
   its lead byte and never re-checks it against the byte count it was given, so a
   sequence the term's last byte cuts short is read up to three bytes past the
   end. UTF-8 validity is far stricter than needed to prevent that.

2. **Change.** Stop validating. A term whose sequences all end within it —
   every well-formed one, multibyte or not — cannot trigger the over-read and is
   decoded in place, so the common path allocates nothing. Only a ragged tail is
   copied, into a buffer with three zero bytes after it.

   Whether the tail is ragged is decided by walking from the *start*, the way the
   decode does. Judging by the final byte alone is not enough: a lead byte can
   swallow the term's last bytes as continuations and run off the end without the
   walk ever landing on them, so `E6 61` over-reads despite ending in ASCII.

3. **Outcome.** A lone-surrogate key is found with its real document count. That
   case round-trips exactly: `ED A0 80` is a *complete* three-byte sequence, so
   nothing is read past the term.

### What this does not fix

A key whose **last multibyte sequence is cut short by its own end** is a
different matter, and the tests say so rather than implying coverage.

Insertion decodes through the very same converter, so such a key is stored under
a rune built partly from the byte that *followed the term* at index time. That is
a NUL only when the tokenizer copied the token — `ForwardIndex_HandleToken`
(`forward_index.c:197-201`) keeps a pointer into the document buffer unless
`DefaultNormalize` allocated (`tokenize.c:129-131`), and `toksep` does not write
a terminator, so otherwise it is the separator that ended the token.

Padding with zeros reproduces the copied-token case and not the other. The stored
key's identity genuinely depends on a byte outside the term, which is a property
of the C indexing path rather than something a lookup can repair. Two tests pin
both sides — `finds_a_truncated_key_stored_from_a_copied_token` and
`misses_a_truncated_key_stored_from_an_uncopied_token`.

**Scope.** The regression is confined to the ongoing C-to-Rust port: neither
`CTrieRef::num_docs` nor any Rust expansion evaluator exists on `8.8` or `8.10`,
so this has never shipped and there is nothing to backport.

#### Which additional issues this PR fixes
1. MOD-14885

#### Main objects this PR modified
1. `CTrieRef::num_docs` — decode in place, or via a zero-padded copy for a ragged tail
2. `c_trie/tests/num_docs.rs` — new; tests moved out of the iteration test file

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
