### PR TITLE
[MOD-17309] GC: separate "collection enabled" from the live timer ID

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1089,6 +1089,24 @@ DEBUG_COMMAND(DiskFlush) {
   return REDISMODULE_OK;
 }
 
+// Resolves argv[2] to a spec that owns a GCContext, replying with the error and returning NULL
+// if it names no index or one without a GC (a TEMPORARY index, or any index under NOGC).
+static IndexSpec *debugSpecWithGC(RedisModuleCtx *ctx, RedisModuleString **argv) {
+  StrongRef ref = Indexes_LoadIndexSpecUnsafe(RedisModule_StringPtrLen(argv[2], NULL));
+  IndexSpec *sp = StrongRef_Get(ref);
+  if (!sp) {
+    const char *idx = RedisModule_StringPtrLen(argv[2], NULL);
+    RedisModule_ReplyWithErrorFormat(ctx, "%s: %s",
+                                     QueryError_Strerror(QUERY_ERROR_CODE_NO_INDEX), idx);
+    return NULL;
+  }
+  if (!sp->gc) {
+    RedisModule_ReplyWithError(ctx, "GC is not available for this index");
+    return NULL;
+  }
+  return sp;
+}
+
 DEBUG_COMMAND(GCForceBGInvoke) {
   if (!debugCommandsEnabled(ctx)) {
     return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
@@ -1096,11 +1114,9 @@ DEBUG_COMMAND(GCForceBGInvoke) {
   if (argc < 3) {
     return RedisModule_WrongArity(ctx);
   }
-  StrongRef ref = Indexes_LoadIndexSpecUnsafe(RedisModule_StringPtrLen(argv[2], NULL));
-  IndexSpec *sp = StrongRef_Get(ref);
+  IndexSpec *sp = debugSpecWithGC(ctx, argv);
   if (!sp) {
-    const char *idx = RedisModule_StringPtrLen(argv[2], NULL);
-    return RedisModule_ReplyWithErrorFormat(ctx, "%s: %s", QueryError_Strerror(QUERY_ERROR_CODE_NO_INDEX), idx);
+    return REDISMODULE_OK;
   }
   GCContext_ForceBGInvoke(sp->gc);
   RedisModule_ReplyWithSimpleString(ctx, "OK");
@@ -1114,16 +1130,11 @@ DEBUG_COMMAND(GCStopFutureRuns) {
   if (argc < 3) {
     return RedisModule_WrongArity(ctx);
   }
-  StrongRef ref = Indexes_LoadIndexSpecUnsafe(RedisModule_StringPtrLen(argv[2], NULL));
-  IndexSpec *sp = StrongRef_Get(ref);
+  IndexSpec *sp = debugSpecWithGC(ctx, argv);
   if (!sp) {
-    const char *idx = RedisModule_StringPtrLen(argv[2], NULL);
-    return RedisModule_ReplyWithErrorFormat(ctx, "%s: %s", QueryError_Strerror(QUERY_ERROR_CODE_NO_INDEX), idx);
+    return REDISMODULE_OK;
   }
-  // Make sure there is no pending timer
-  RedisModule_StopTimer(RSDummyContext, sp->gc->timerID, NULL);
-  // mark as stopped. This will prevent the GC from scheduling itself again if it was already running.
-  sp->gc->timerID = 0;
+  GCContext_StopFutureRuns(sp->gc);
   RedisModule_Log(ctx, "verbose", "Stopped GC %p periodic run for index %s", sp->gc, IndexSpec_FormatName(sp, RSGlobalConfig.hideUserDataFromLog));
   return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
@@ -1135,13 +1146,11 @@ DEBUG_COMMAND(GCContinueFutureRuns) {
   if (argc < 3) {
     return RedisModule_WrongArity(ctx);
   }
-  StrongRef ref = Indexes_LoadIndexSpecUnsafe(RedisModule_StringPtrLen(argv[2], NULL));
-  IndexSpec *sp = StrongRef_Get(ref);
+  IndexSpec *sp = debugSpecWithGC(ctx, argv);
   if (!sp) {
-    const char *idx = RedisModule_StringPtrLen(argv[2], NULL);
-    return RedisModule_ReplyWithErrorFormat(ctx, "%s: %s", QueryError_Strerror(QUERY_ERROR_CODE_NO_INDEX), idx);
+    return REDISMODULE_OK;
   }
-  if (sp->gc->timerID) {
+  if (GCContext_IsEnabled(sp->gc)) {
     return RedisModule_ReplyWithError(ctx, "GC is already running periodically");
   }
   GCContext_StartNow(sp->gc);

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -174,6 +174,9 @@ void StoreResultsDebugCtx_SetPause(bool pause);
 // the key inside the async swap window so the callback hits the docid-mismatch / expired-doc path,
 // and lets a test hold the load past the query timeout to exercise the ON_TIMEOUT policy.
 #define SYNC_POINT_AFTER_PREFETCH_ISSUE                 "AfterPrefetchIssue"
+// Fork-GC worker: parked at the very top of a periodic GC job, before the collection callback
+// runs. Lets a test rendezvous with a real run while RUN_PENDING is held, instead of sleeping.
+#define SYNC_POINT_GC_TASK_START                        "GCTaskStart"
 
 // SyncPoint API function declarations
 // Arm a sync point - subsequent calls to SyncPoint_Wait will block

--- a/src/gc.c
+++ b/src/gc.c
@@ -182,6 +182,22 @@ void GCContext_Start(GCContext* gc) {
   GCContext_ArmTimer(gc);
 }
 
+void GCContext_ScheduleTermination(GCContext* gc) {
+  // The mock harness has no GC pool, and `IndexSpec_Free` frees the GC there directly -- so by
+  // now `gc` is already gone. Must be checked before touching it.
+  if (RS_IsMock) {
+    return;
+  }
+  // `IndexSpec_Free` does not free the GC; it relies on a run discovering the drop and
+  // self-terminating. A GC stopped by GC_STOP_SCHEDULE has neither a timer nor a queued run,
+  // so nothing would ever discover it. Re-enable and queue one.
+  gc->enabled = true;
+  // A queued run must not coexist with an armed timer: this run frees the context, and the
+  // timer would then fire on it.
+  GCContext_DisarmTimer(gc);
+  GCContext_QueueRun(gc);  // declines if a run already owns this context; that one will do it
+}
+
 void GCContext_StopFutureRuns(GCContext* gc) {
   gc->enabled = false;
   GCContext_DisarmTimer(gc);

--- a/src/gc.c
+++ b/src/gc.c
@@ -187,17 +187,21 @@ bool GCContext_BeginDrop(GCContext* gc) {
   if (RS_IsMock) {
     return false;
   }
-  // An armed timer or a run in flight will discover the drop on its own, which is the mechanism
-  // `IndexSpec_Free` already relies on -- leave those alone. A run in flight additionally frees
-  // this context itself, on the GC thread and without the GIL, as soon as the unlink makes its
-  // promote fail, so it must not be touched after the unlink either. Reading the bit is safe:
-  // that run's tail clears it under the GIL, and only the main thread ever sets it.
+  // Re-enable unconditionally, before deciding anything else. A run in flight is about to
+  // choose whether to re-arm, and if this GC was stopped that choice is the difference between
+  // the timer eventually discovering the drop and nothing ever doing so. A no-op when already
+  // enabled, which is why it cannot disturb the ordinary path below.
+  gc->enabled = true;
+  // An armed timer, or a run in flight (which now re-arms), will discover the drop on its own --
+  // the mechanism `IndexSpec_Free` already relies on. Leave those alone: a run in flight also
+  // frees this context itself, on the GC thread and without the GIL, as soon as the unlink makes
+  // its promote fail, so it must not be touched after the unlink either. Reading the bit is
+  // safe: that run's tail clears it under the GIL, and only the main thread ever sets it.
   if (gc->timerID != 0 || GCContext_RunPending(gc)) {
     return false;
   }
-  // Neither exists, so nothing would ever discover the drop -- the state `GC_STOP_SCHEDULE`
-  // leaves behind. Re-enable so the run queued after the unlink is allowed to start.
-  gc->enabled = true;
+  // Neither exists, so nothing would discover the drop -- the state `GC_STOP_SCHEDULE` leaves
+  // behind once its run has finished. Queue one after the unlink.
   return true;
 }
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -182,20 +182,29 @@ void GCContext_Start(GCContext* gc) {
   GCContext_ArmTimer(gc);
 }
 
-void GCContext_ScheduleTermination(GCContext* gc) {
-  // The mock harness has no GC pool, and `IndexSpec_Free` frees the GC there directly -- so by
-  // now `gc` is already gone. Must be checked before touching it.
+bool GCContext_BeginDrop(GCContext* gc) {
+  // The mock harness has no GC pool and frees the GC inside `IndexSpec_Free`.
   if (RS_IsMock) {
-    return;
+    return false;
   }
   // `IndexSpec_Free` does not free the GC; it relies on a run discovering the drop and
-  // self-terminating. A GC stopped by GC_STOP_SCHEDULE has neither a timer nor a queued run,
-  // so nothing would ever discover it. Re-enable and queue one.
+  // self-terminating. A GC stopped by GC_STOP_SCHEDULE has neither a timer nor a queued run, so
+  // nothing would ever discover it -- hence re-enabling here.
   gc->enabled = true;
+  // A run already in flight owns this context and frees it, without the GIL, the moment the
+  // unlink makes its promote fail. So the caller must not touch `gc` after the unlink: report
+  // that. Such a run re-arms instead if it outlives the drop, now that collection is enabled,
+  // and that timer's run is what discovers the drop -- the "schedule another run soon" case
+  // `IndexSpec_Free` describes. Reading the bit is safe against that run's tail, which clears
+  // it under the GIL, and nothing can set it behind us: only the main thread queues runs.
+  return !GCContext_RunPending(gc);
+}
+
+void GCContext_FinishDrop(GCContext* gc) {
   // A queued run must not coexist with an armed timer: this run frees the context, and the
   // timer would then fire on it.
   GCContext_DisarmTimer(gc);
-  GCContext_QueueRun(gc);  // declines if a run already owns this context; that one will do it
+  GCContext_QueueRun(gc);
 }
 
 void GCContext_StopFutureRuns(GCContext* gc) {

--- a/src/gc.c
+++ b/src/gc.c
@@ -187,23 +187,23 @@ bool GCContext_BeginDrop(GCContext* gc) {
   if (RS_IsMock) {
     return false;
   }
-  // `IndexSpec_Free` does not free the GC; it relies on a run discovering the drop and
-  // self-terminating. A GC stopped by GC_STOP_SCHEDULE has neither a timer nor a queued run, so
-  // nothing would ever discover it -- hence re-enabling here.
+  // An armed timer or a run in flight will discover the drop on its own, which is the mechanism
+  // `IndexSpec_Free` already relies on -- leave those alone. A run in flight additionally frees
+  // this context itself, on the GC thread and without the GIL, as soon as the unlink makes its
+  // promote fail, so it must not be touched after the unlink either. Reading the bit is safe:
+  // that run's tail clears it under the GIL, and only the main thread ever sets it.
+  if (gc->timerID != 0 || GCContext_RunPending(gc)) {
+    return false;
+  }
+  // Neither exists, so nothing would ever discover the drop -- the state `GC_STOP_SCHEDULE`
+  // leaves behind. Re-enable so the run queued after the unlink is allowed to start.
   gc->enabled = true;
-  // A run already in flight owns this context and frees it, without the GIL, the moment the
-  // unlink makes its promote fail. So the caller must not touch `gc` after the unlink: report
-  // that. Such a run re-arms instead if it outlives the drop, now that collection is enabled,
-  // and that timer's run is what discovers the drop -- the "schedule another run soon" case
-  // `IndexSpec_Free` describes. Reading the bit is safe against that run's tail, which clears
-  // it under the GIL, and nothing can set it behind us: only the main thread queues runs.
-  return !GCContext_RunPending(gc);
+  return true;
 }
 
 void GCContext_FinishDrop(GCContext* gc) {
-  // A queued run must not coexist with an armed timer: this run frees the context, and the
-  // timer would then fire on it.
-  GCContext_DisarmTimer(gc);
+  // `GCContext_BeginDrop` returned true, so there is no timer to collide with: it established
+  // `timerID == 0`, and only the main thread -- us, without yielding since -- arms one.
   GCContext_QueueRun(gc);
 }
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -20,6 +20,7 @@
 #include "util/logging.h"
 #include "redisearch.h"
 #include "result_processor.h"
+#include "debug_commands.h"
 
 static redisearch_thpool_t *gcThreadpool_g = NULL;
 
@@ -52,6 +53,11 @@ GCContext* GCContext_CreateGC(StrongRef spec_ref, uint32_t gcPolicy) {
 }
 
 static void timerCallback(RedisModuleCtx* ctx, void* data);
+static void taskCallback(void* data);
+
+static bool GCContext_RunPending(GCContext* gc) {
+  return (RS_AtomicUintLoadRelaxed(&gc->schedFlags) & GC_SCHED_RUN_PENDING) != 0;
+}
 
 static long long getNextPeriod(GCContext* gc) {
   struct timespec interval = gc->callbacks.getInterval(gc->gcCtx);
@@ -70,24 +76,64 @@ static RedisModuleTimerID scheduleNext(GCContext *gc) {
   return RedisModule_CreateTimer(RSDummyContext, period, timerCallback, gc);
 }
 
+// Requires the GIL. Callable blindly, so callers need not repeat the guards; the invariant
+// that a queued or executing run implies no armed timer is enforced by GCContext_QueueRun
+// declining and by timerCallback zeroing timerID, not by the RunPending check here.
+static void GCContext_ArmTimer(GCContext* gc) {
+  if (!gc->enabled || gc->timerID || GCContext_RunPending(gc)) {
+    return;
+  }
+  gc->timerID = scheduleNext(gc);
+  if (gc->timerID == 0) {
+    RedisModule_Log(RSDummyContext, "warning", "GC did not schedule next collection");
+  }
+}
+
+static void GCContext_DisarmTimer(GCContext* gc) {
+  if (gc->timerID) {
+    RedisModule_StopTimer(RSDummyContext, gc->timerID, NULL);
+    gc->timerID = 0;
+  }
+}
+
+// Claims RUN_PENDING and queues a run, or does nothing if a run already holds this context --
+// two runs behind one bit would let the first one's tail clear it while the second is still
+// queued, and every guard that reads RUN_PENDING would be void from then on.
+static void GCContext_QueueRun(GCContext* gc) {
+  if (RS_AtomicUintFetchOrRelaxed(&gc->schedFlags, GC_SCHED_RUN_PENDING) & GC_SCHED_RUN_PENDING) {
+    return;  // that run's tail re-arms
+  }
+  if (redisearch_thpool_add_work(gcThreadpool_g, taskCallback, gc, THPOOL_PRIORITY_HIGH) != 0) {
+    // Nothing else would clear the bit, and no run is coming to re-arm -- so without both of
+    // these this index loses collection for the life of the process.
+    RS_AtomicUintFetchAndRelaxed(&gc->schedFlags, ~(unsigned)GC_SCHED_RUN_PENDING);
+    GCContext_ArmTimer(gc);
+  }
+}
+
 static void taskCallback(void* data) {
   GCContext* gc = data;
+
+  // Test hook (ENABLE_ASSERT): park before the pass starts, with RUN_PENDING held and no GIL --
+  // this pass only takes the GIL later, to re-arm. Lets a test drive the scheduling guards
+  // against a real in-flight run rather than racing one.
+#ifdef ENABLE_ASSERT
+  SyncPoint_Wait(SYNC_POINT_GC_TASK_START);
+#endif
 
   bool ret = gc->callbacks.periodicCallback(gc->gcCtx, false);
 
   if (ret) { // The common case
     // The index was not freed. We need to reschedule the task.
     RedisModule_ThreadSafeContextLock(RSDummyContext);
-    if (gc->timerID) {
-      gc->timerID = scheduleNext(gc);
-    } else {
-      // ... unless the GC was stopped by a debug command.
-      RedisModule_Log(RSDummyContext, REDISMODULE_LOGLEVEL_DEBUG, "GC %p: Not scheduling next collection", gc);
-    }
+    RS_AtomicUintFetchAndRelaxed(&gc->schedFlags, ~(unsigned)GC_SCHED_RUN_PENDING);
+    GCContext_ArmTimer(gc);
     RedisModule_ThreadSafeContextUnlock(RSDummyContext);
   } else {
     // The index was freed. There is no need to reschedule the task.
-    // We need to free the task and the GC.
+    // We need to free the task and the GC. RUN_PENDING was set for this run, so no timer is
+    // armed and no second periodic run is queued. Debug tasks (GC_FORCEBGINVOKE) hold `gc`
+    // outside this model and are not covered by it.
     RedisModule_Log(RSDummyContext, REDISMODULE_LOGLEVEL_VERBOSE, "GC %p: Self-Terminating. Index was freed.", gc);
     gc->callbacks.onTerm(gc->gcCtx);
     rm_free(gc);
@@ -108,28 +154,41 @@ static void debugTaskCallback(void* data) {
 }
 
 static void timerCallback(RedisModuleCtx* ctx, void* data) {
+  GCContext* gc = data;
+  gc->timerID = 0;  // the timer that just fired is gone
+
+  if (!gc->enabled) {
+    return;
+  }
   if (RedisModule_AvoidReplicaTraffic && RedisModule_AvoidReplicaTraffic()) {
     // If slave traffic is not allowed it means that there is a state machine running
     // we do not want to run any GC which might cause a FORK process to start for example.
     // Its better to just avoid it.
-    GCContext* gc = data;
-    gc->timerID = scheduleNext(gc);
+    GCContext_ArmTimer(gc);
     return;
   }
-  redisearch_thpool_add_work(gcThreadpool_g, taskCallback, data, THPOOL_PRIORITY_HIGH);
+  GCContext_QueueRun(gc);
 }
 
 void GCContext_StartNow(GCContext* gc) {
-  RS_LOG_ASSERT_FMT(gc->timerID == 0, "GC %p: StartNow called while GC is already running", gc);
-  gc->timerID = 1; // Set to non-zero value to indicate the GC to reschedule itself.
-  redisearch_thpool_add_work(gcThreadpool_g, taskCallback, gc, THPOOL_PRIORITY_HIGH);
+  RS_LOG_ASSERT_FMT(!gc->enabled && gc->timerID == 0,
+                    "GC %p: StartNow called while GC is already running", gc);
+  gc->enabled = true;
+  GCContext_QueueRun(gc);
 }
 
 void GCContext_Start(GCContext* gc) {
-  gc->timerID = scheduleNext(gc);
-  if (gc->timerID == 0) {
-    RedisModule_Log(RSDummyContext, "warning", "GC did not schedule next collection");
-  }
+  gc->enabled = true;
+  GCContext_ArmTimer(gc);
+}
+
+void GCContext_StopFutureRuns(GCContext* gc) {
+  gc->enabled = false;
+  GCContext_DisarmTimer(gc);
+}
+
+bool GCContext_IsEnabled(const GCContext* gc) {
+  return gc->enabled;
 }
 
 void GCContext_StopMock(GCContext* gc) {

--- a/src/gc.h
+++ b/src/gc.h
@@ -81,9 +81,13 @@ void GCContext_GetStats(GCContext* gc, InfoGCStats* out);
 // Stop periodic collection and disarm the timer. A run in flight completes without re-arming.
 // Requires the GIL, as does GCContext_IsEnabled: both touch GIL-guarded scheduling state.
 void GCContext_StopFutureRuns(GCContext* gc);
-// Call when the index is being dropped: guarantees a run happens so the GC discovers the drop
-// and frees itself, even if scheduling was stopped. Requires the GIL.
-void GCContext_ScheduleTermination(GCContext* gc);
+// Drop-time hand-off, in two phases because a run already in flight frees this context without
+// the GIL as soon as the unlink lands. Both require the GIL.
+// Call before unlinking the spec; returns true if the context is still the caller's to schedule.
+bool GCContext_BeginDrop(GCContext* gc);
+// Call after unlinking the spec, only when GCContext_BeginDrop returned true. Queues the run
+// that discovers the drop and frees the context.
+void GCContext_FinishDrop(GCContext* gc);
 bool GCContext_IsEnabled(const GCContext* gc);
 
 static inline void InfoGCStats_Add(InfoGCStats* dst, const InfoGCStats* src) {

--- a/src/gc.h
+++ b/src/gc.h
@@ -15,6 +15,7 @@
 #include "redismodule.h"
 #include "util/dllist.h"
 #include "util/references.h"
+#include "util/rs_atomic.h"
 #include <time.h>
 
 #ifdef __cplusplus
@@ -22,6 +23,11 @@ extern "C" {
 #endif
 
 #define GC_THREAD_POOL_SIZE 1
+
+// Bits of GCContext.schedFlags.
+typedef enum {
+  GC_SCHED_RUN_PENDING = 0x01,  // a run is queued on the GC pool, or executing
+} GCSchedFlags;
 
 typedef struct InfoGCStats {
   // Total bytes collected by the GCs
@@ -48,7 +54,12 @@ typedef struct GCCallbacks {
 
 typedef struct GCContext {
   void* gcCtx;
-  RedisModuleTimerID timerID;  // Guarded by the GIL
+  RedisModuleTimerID timerID;  // a live timer, or 0. Never a sentinel. Guarded by the GIL
+  bool enabled;                // periodic collection wanted. Guarded by the GIL
+  // Shared with the GC thread, though every access today is also under the GIL -- correctness
+  // rests on that, not on the atomic. A bit set so a bit added later can be tested against
+  // RUN_PENDING in one read-modify-write; separate relaxed accesses would not be ordered.
+  RS_Atomic(unsigned) schedFlags;
   GCCallbacks callbacks;
 } GCContext;
 
@@ -67,6 +78,10 @@ void GCContext_ForceInvoke(GCContext* gc, RedisModuleBlockedClient* bc);
 void GCContext_ForceBGInvoke(GCContext* gc);
 void GCContext_WaitForAllOperations(RedisModuleBlockedClient* bc);
 void GCContext_GetStats(GCContext* gc, InfoGCStats* out);
+// Stop periodic collection and disarm the timer. A run in flight completes without re-arming.
+// Requires the GIL, as does GCContext_IsEnabled: both touch GIL-guarded scheduling state.
+void GCContext_StopFutureRuns(GCContext* gc);
+bool GCContext_IsEnabled(const GCContext* gc);
 
 static inline void InfoGCStats_Add(InfoGCStats* dst, const InfoGCStats* src) {
   dst->totalCollectedBytes += src->totalCollectedBytes;

--- a/src/gc.h
+++ b/src/gc.h
@@ -81,6 +81,9 @@ void GCContext_GetStats(GCContext* gc, InfoGCStats* out);
 // Stop periodic collection and disarm the timer. A run in flight completes without re-arming.
 // Requires the GIL, as does GCContext_IsEnabled: both touch GIL-guarded scheduling state.
 void GCContext_StopFutureRuns(GCContext* gc);
+// Call when the index is being dropped: guarantees a run happens so the GC discovers the drop
+// and frees itself, even if scheduling was stopped. Requires the GIL.
+void GCContext_ScheduleTermination(GCContext* gc);
 bool GCContext_IsEnabled(const GCContext* gc);
 
 static inline void InfoGCStats_Add(InfoGCStats* dst, const InfoGCStats* src) {

--- a/src/indexes.c
+++ b/src/indexes.c
@@ -144,12 +144,20 @@ void Spec_AddToDict(RefManager *rm) {
 // This function consumes the Strong reference it gets.
 void Indexes_RemoveSpecFromGlobals(StrongRef spec_ref, bool removeActive) {
   IndexSpec *spec = StrongRef_Get(spec_ref);
+  // Survives the unlink below: IndexSpec_Free deliberately does not free the GC.
+  GCContext *gc = spec->gc;
   // Remove spec from the global index registry (by name and by specId)
   dictDelete(specDict_g, spec->specName);
   dictDelete(specIdDict_g, (void *)(uintptr_t)spec->specId);
 
   // Unwind the spec's remaining global state and consume the reference.
   IndexSpec_Unlink(spec_ref, removeActive);
+
+  // Only after the unlink, so the run below cannot promote the spec and mistake this for an
+  // ordinary cycle -- it has to observe the drop and free itself.
+  if (gc) {
+    GCContext_ScheduleTermination(gc);
+  }
 }
 
 // Look up a spec by name (or alias) in the global registry - the specDict_g

--- a/src/indexes.c
+++ b/src/indexes.c
@@ -144,8 +144,10 @@ void Spec_AddToDict(RefManager *rm) {
 // This function consumes the Strong reference it gets.
 void Indexes_RemoveSpecFromGlobals(StrongRef spec_ref, bool removeActive) {
   IndexSpec *spec = StrongRef_Get(spec_ref);
-  // Survives the unlink below: IndexSpec_Free deliberately does not free the GC.
+  // The GC survives the unlink -- IndexSpec_Free deliberately does not free it -- unless a run
+  // is already in flight, which frees it itself. GCContext_BeginDrop tells us which.
   GCContext *gc = spec->gc;
+  const bool ownGCAfterUnlink = gc && GCContext_BeginDrop(gc);
   // Remove spec from the global index registry (by name and by specId)
   dictDelete(specDict_g, spec->specName);
   dictDelete(specIdDict_g, (void *)(uintptr_t)spec->specId);
@@ -153,10 +155,10 @@ void Indexes_RemoveSpecFromGlobals(StrongRef spec_ref, bool removeActive) {
   // Unwind the spec's remaining global state and consume the reference.
   IndexSpec_Unlink(spec_ref, removeActive);
 
-  // Only after the unlink, so the run below cannot promote the spec and mistake this for an
-  // ordinary cycle -- it has to observe the drop and free itself.
-  if (gc) {
-    GCContext_ScheduleTermination(gc);
+  // Only after the unlink, so this run cannot promote the spec and mistake the drop for an
+  // ordinary cycle -- below the clean threshold it would re-arm instead of terminating.
+  if (ownGCAfterUnlink) {
+    GCContext_FinishDrop(gc);
   }
 }
 

--- a/src/util/rs_atomic.h
+++ b/src/util/rs_atomic.h
@@ -21,12 +21,22 @@
 #define RS_AtomicIntLoadRelaxed(p) (((std::atomic<int> *)(p))->load(std::memory_order_relaxed))
 #define RS_AtomicIntStoreRelaxed(p, v) \
   (((std::atomic<int> *)(p))->store((v), std::memory_order_relaxed))
+#define RS_AtomicUintLoadRelaxed(p) \
+  (((std::atomic<unsigned> *)(p))->load(std::memory_order_relaxed))
+#define RS_AtomicUintFetchOrRelaxed(p, v) \
+  (((std::atomic<unsigned> *)(p))->fetch_or((v), std::memory_order_relaxed))
+#define RS_AtomicUintFetchAndRelaxed(p, v) \
+  (((std::atomic<unsigned> *)(p))->fetch_and((v), std::memory_order_relaxed))
 #else
 #define RS_Atomic(T) _Atomic(T)
 #define RS_AtomicBoolLoadRelaxed(p) __atomic_load_n((bool *)(p), __ATOMIC_RELAXED)
 #define RS_AtomicBoolStoreRelaxed(p, v) __atomic_store_n((bool *)(p), (v), __ATOMIC_RELAXED)
 #define RS_AtomicIntLoadRelaxed(p) __atomic_load_n((int *)(p), __ATOMIC_RELAXED)
 #define RS_AtomicIntStoreRelaxed(p, v) __atomic_store_n((int *)(p), (v), __ATOMIC_RELAXED)
+#define RS_AtomicUintLoadRelaxed(p) __atomic_load_n((unsigned *)(p), __ATOMIC_RELAXED)
+#define RS_AtomicUintFetchOrRelaxed(p, v) __atomic_fetch_or((unsigned *)(p), (v), __ATOMIC_RELAXED)
+#define RS_AtomicUintFetchAndRelaxed(p, v) \
+  __atomic_fetch_and((unsigned *)(p), (v), __ATOMIC_RELAXED)
 #endif
 
 #endif  // RS_ATOMIC_H__

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -271,6 +271,12 @@ class TestDebugCommands(object):
         self.env.expect(debug_cmd(), 'GC_CONTINUE_SCHEDULE', 'idx').error().contains('GC is already running periodically')
         self.env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
         self.env.expect(debug_cmd(), 'GC_CONTINUE_SCHEDULE', 'idx').ok()
+        # CONTINUE must leave the GC enabled, not merely reply OK.
+        self.env.expect(debug_cmd(), 'GC_CONTINUE_SCHEDULE', 'idx').error().contains('GC is already running periodically')
+        # STOP is idempotent.
+        self.env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
+        self.env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
+        self.env.expect(debug_cmd(), 'GC_CONTINUE_SCHEDULE', 'idx').ok()
 
     def testTTLcommands(self):
         num_indexes = len(self.env.cmd('FT._LIST'))

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -880,3 +880,29 @@ def testGCContinueScheduleDuringRun_MOD_17309():
                     message=f'GC_CONTINUE_SCHEDULE queued a duplicate run: '
                             f'{before} -> {completed}')
     env.expect('PING').equal(True)
+
+
+@skip(cluster=True)
+def testGCTerminatesAfterDropWhileStopped(env):
+    """A GC stopped by GC_STOP_SCHEDULE still has to terminate when its index is dropped.
+    IndexSpec_Free does not free the GCContext -- it waits for a run to discover the drop --
+    and a stopped GC has neither a timer nor a queued run, so nothing ever would. The context
+    and its detached thread-safe context would leak for the life of the process.
+
+    onTerm is what returns this index's logically-deleted docs to the global counter, so the
+    counter dropping back to 0 is evidence the GC actually terminated."""
+    logically_deleted = lambda: env.cmd('INFO', 'MODULES')['search_gc_total_docs_not_collected']
+
+    # The GC INFO section is only rendered while at least one index exists, so keep one that is
+    # never dropped -- otherwise the counter we assert on disappears just as it reaches 0. Give
+    # both a prefix so only 'idx' indexes the document, and the count is unambiguously its own.
+    env.expect('FT.CREATE', 'keep', 'PREFIX', 1, 'keep:', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect('FT.CREATE', 'idx', 'PREFIX', 1, 'doc:', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
+    env.cmd('HSET', 'doc:1', 't', 'hello')
+    env.expect('DEL', 'doc:1').equal(1)
+    env.assertEqual(logically_deleted(), 1)
+
+    env.expect('FT.DROPINDEX', 'idx').ok()
+    wait_for_condition(lambda: (logically_deleted() == 0, {'not_collected': logically_deleted()}),
+                       'stopped GC never terminated after its index was dropped', timeout=30)

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -868,14 +868,19 @@ def testGCContinueScheduleDuringRun_MOD_17309():
     before = gcCycles(env, 'idx')
     env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
     env.expect(debug_cmd(), 'GC_CONTINUE_SCHEDULE', 'idx').ok()
+    # Whether CONTINUE queued a duplicate was already decided above. Stopping again before the
+    # parked run is released leaves it unable to re-arm, so no timer can fire during the
+    # assertion below -- a second cycle can then only mean a duplicate run.
+    env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
 
     # Release the parked run. SIGNAL also disarms, so nothing parks again.
     env.cmd(debug_cmd(), 'SYNC_POINT', 'SIGNAL', SYNC_POINT_GC_TASK_START)
 
-    # Exactly one run was in flight, so exactly one cycle completes from it. A second queued
-    # run would land a second cycle immediately -- the pool is single-threaded and both would
-    # already be queued, whereas the next timer-driven cycle is a full interval away.
-    completed = waitForGCCycles(env, 'idx', before, timeout=30)
+    # GC_WAIT_FOR_JOBS queues a marker at the end of the single-threaded pool and blocks until
+    # it runs, so it drains the parked run and any duplicate queued behind it. That is a
+    # barrier rather than a wall-clock window: no poll can be descheduled past a stray cycle.
+    env.cmd(debug_cmd(), 'GC_WAIT_FOR_JOBS')
+    completed = gcCycles(env, 'idx')
     env.assertEqual(completed, before + 1,
                     message=f'GC_CONTINUE_SCHEDULE queued a duplicate run: '
                             f'{before} -> {completed}')

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -735,3 +735,148 @@ def testForkGCEmptyTextSuffixTrie_emptyValue():
     env.expect('DEL', 'doc1').equal(1)
     forceInvokeGC(env, 'idx')
     env.expect('PING').equal(True)
+
+
+# Periodic-GC scheduling tests. They assert on the per-index gc_stats cycle counter, and the
+# ones that need to act on a run already in flight park it on the GCTaskStart sync point --
+# the only way to hold a GC worker, and so the only way to drive the scheduling guards against
+# a real in-flight run instead of racing one.
+SYNC_POINT_GC_TASK_START = 'GCTaskStart'  # src/debug_commands.h
+
+
+def gcCycles(env, idx):
+    return int(to_dict(index_info(env, idx)['gc_stats'])['total_cycles'])
+
+
+def waitForGCCycles(env, idx, base, count=1, timeout=60):
+    """Wait for `idx` to complete `count` cycles past `base`, returning the counter value that
+    was actually observed. Callers assert on that value rather than re-reading: a re-read can
+    pick up a later timer-driven cycle and turn an exact-count assertion into a flake."""
+    seen = {}
+
+    def check():
+        seen['total_cycles'] = gcCycles(env, idx)
+        return seen['total_cycles'] >= base + count, {'index': idx, 'base': base, **seen}
+
+    wait_for_condition(check, f'GC stopped collecting for {idx}', timeout=timeout)
+    return seen['total_cycles']
+
+
+def armParkedGCRun(env):
+    """Park the next periodic GC job at the top of taskCallback, returning once it is parked --
+    so the caller knows RUN_PENDING is held and that index has no timer armed."""
+    env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+    # Auto-release after 10s: a stalled runner must not leave a GC worker parked for the rest of
+    # the file, since the GC pool has a single thread and every other test here shares it.
+    env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', SYNC_POINT_GC_TASK_START, 10000).ok()
+    wait_for_condition(
+        lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING',
+                         SYNC_POINT_GC_TASK_START) == 1, {}),
+        'Timeout waiting for a GC job to reach the sync point')
+
+
+@skip(cluster=True)
+def testGCPeriodicScheduleStopAndResume():
+    """The periodic GC re-arms itself, stops on GC_STOP_SCHEDULE, and resumes on
+    GC_CONTINUE_SCHEDULE. Almost every other GC test drives collection with FORCE_INVOKE,
+    which never re-arms, so nothing else notices if the chain stops after its first pass."""
+    # No garbage on purpose: a GC that finds nothing still has to re-arm. CLEAN_THRESHOLD 0
+    # keeps those empty passes from short-circuiting ahead of the total_cycles counter.
+    env = Env(moduleArgs='FORK_GC_RUN_INTERVAL 1 FORK_GC_CLEAN_THRESHOLD 0')
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    # A second index nobody stops, used to time the negative window below instead of sleeping.
+    # It is what keeps that window from passing for the wrong reason: a runner slow enough to
+    # delay 'idx' past a fixed sleep delays 'ctl' just as much, so the window stretches with
+    # the host rather than expiring before the timer it is meant to catch.
+    env.expect('FT.CREATE', 'ctl', 'SCHEMA', 't', 'TEXT').ok()
+
+    # Two cycles, not one: the second is the one that can only come from the chain re-arming.
+    waitForGCCycles(env, 'idx', gcCycles(env, 'idx'), 2)
+
+    env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
+    env.cmd(debug_cmd(), 'GC_WAIT_FOR_JOBS')  # let the run already in flight finish
+    stopped_at = gcCycles(env, 'idx')
+    # Two cycles of the control index: direct evidence that GC timers did fire during this
+    # window, so a flat counter on 'idx' can only mean its own scheduling stopped.
+    waitForGCCycles(env, 'ctl', gcCycles(env, 'ctl'), 2)
+    after_stop = gcCycles(env, 'idx')
+    env.assertEqual(after_stop, stopped_at,
+                    message=f'GC ran after GC_STOP_SCHEDULE: {stopped_at} -> {after_stop}')
+
+    env.expect(debug_cmd(), 'GC_CONTINUE_SCHEDULE', 'idx').ok()
+    waitForGCCycles(env, 'idx', stopped_at)
+
+
+@skip(cluster=True)
+def testGCScheduleCommandsOnIndexWithoutGC(env):
+    """A TEMPORARY index gets no GCContext, and the GC commands must reject it rather than
+    dereference the missing context. NOGC reaches the same branch in IndexSpec_StartGC."""
+    env.expect('FT.CREATE', 'tmp_idx', 'TEMPORARY', 3600, 'SCHEMA', 't', 'TEXT').ok()
+
+    for sub in ('GC_STOP_SCHEDULE', 'GC_CONTINUE_SCHEDULE', 'GC_FORCEBGINVOKE',
+                'GC_FORCEINVOKE'):
+        env.expect(debug_cmd(), sub, 'tmp_idx').error().contains(
+            'GC is not available for this index')
+
+    # A normal index in the same server still works, so the guard is not over-broad.
+    env.expect('FT.CREATE', 'idx2', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx2').ok()
+    env.expect(debug_cmd(), 'GC_CONTINUE_SCHEDULE', 'idx2').ok()
+
+
+@skip(cluster=True)
+def testGCStopScheduleDuringRun():
+    """GC_STOP_SCHEDULE while a run is in flight: the completing run's own re-arm has to notice
+    that collection was disabled under it. Nothing disarms a timer armed from there, so the
+    chain would outlive the stop -- and after a drop it would arm one over a freed context."""
+    env = Env(moduleArgs='FORK_GC_RUN_INTERVAL 1 FORK_GC_CLEAN_THRESHOLD 0')
+    skipIfNoEnableAssert(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+
+    armParkedGCRun(env)
+    before = gcCycles(env, 'idx')
+    env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
+
+    # Release the parked run into its re-arm, which now has to decline. SIGNAL also disarms the
+    # sync point, so nothing parks again.
+    env.cmd(debug_cmd(), 'SYNC_POINT', 'SIGNAL', SYNC_POINT_GC_TASK_START)
+    stopped_at = waitForGCCycles(env, 'idx', before, timeout=30)
+    env.assertEqual(stopped_at, before + 1,
+                    message=f'more than the parked run completed: {before} -> {stopped_at}')
+
+    # Created after the sync point was disarmed, so this one never parks. Its cycles time the
+    # window below -- evidence that GC timers fired in it while 'idx' stayed flat.
+    env.expect('FT.CREATE', 'ctl', 'SCHEMA', 't', 'TEXT').ok()
+    waitForGCCycles(env, 'ctl', gcCycles(env, 'ctl'), 2)
+    after_stop = gcCycles(env, 'idx')
+    env.assertEqual(after_stop, stopped_at,
+                    message=f'the completing run re-armed despite the stop: '
+                            f'{stopped_at} -> {after_stop}')
+    env.expect('PING').equal(True)
+
+
+@skip(cluster=True)
+def testGCContinueScheduleDuringRun_MOD_17309():
+    """GC_CONTINUE_SCHEDULE must not queue a second run while one is already in flight: two
+    runs behind one RUN_PENDING bit let the first one's tail arm a timer while the second is
+    still queued, and a second run that finds the index dropped then frees the GC under it."""
+    env = Env(moduleArgs='FORK_GC_RUN_INTERVAL 1 FORK_GC_CLEAN_THRESHOLD 0')
+    skipIfNoEnableAssert(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+
+    armParkedGCRun(env)
+    before = gcCycles(env, 'idx')
+    env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
+    env.expect(debug_cmd(), 'GC_CONTINUE_SCHEDULE', 'idx').ok()
+
+    # Release the parked run. SIGNAL also disarms, so nothing parks again.
+    env.cmd(debug_cmd(), 'SYNC_POINT', 'SIGNAL', SYNC_POINT_GC_TASK_START)
+
+    # Exactly one run was in flight, so exactly one cycle completes from it. A second queued
+    # run would land a second cycle immediately -- the pool is single-threaded and both would
+    # already be queued, whereas the next timer-driven cycle is a full interval away.
+    completed = waitForGCCycles(env, 'idx', before, timeout=30)
+    env.assertEqual(completed, before + 1,
+                    message=f'GC_CONTINUE_SCHEDULE queued a duplicate run: '
+                            f'{before} -> {completed}')
+    env.expect('PING').equal(True)


### PR DESCRIPTION
## Describe the changes in the pull request

**1. Current.** `GCContext` has no stated ownership model, and `timerID` carries two meanings. It is a live Redis timer ID, *and* it is the sentinel `1` that `GCContext_StartNow` writes to mean "periodic collection is wanted", so a caller wanting the second question has to test the first and cannot tell them apart. `timerID` also keeps the ID of a timer that has already fired, since nothing clears it in `timerCallback` — so "is a timer armed?" is not answerable either.

Two live bugs follow, both reachable through `FT.DEBUG`:

- **Use-after-free.** `GC_STOP_SCHEDULE` makes `StopTimer` fail on the stale ID and sets `timerID = 0`; `GC_CONTINUE_SCHEDULE`'s `if (sp->gc->timerID)` guard therefore passes even while a periodic run is in flight, and `GCContext_StartNow` queues a **second** run. The first run's tail sees the sentinel and arms a timer; if the second finds the index dropped it frees the `GCContext` while that timer is still armed, and the timer fires on freed memory.
- **Leak.** `IndexSpec_Free` deliberately does not free the `GCContext` — its comment states the contract: *"It will free itself when it discovers that the index was freed. On the worst case, it just finishes the current run and will schedule another run soon."* That requires every live GC to hold an armed timer or a queued run. `GC_STOP_SCHEDULE` leaves neither, so for a stopped GC nothing ever discovers the drop, `onTerm` never runs, and the context plus the detached thread-safe context `FGC_Create` holds are leaked for the life of the process.

**2. Change.** Give the scheduling state one meaning per field and one owner at a time.

| | |
|---|---|
| `timerID` | a live timer, or `0`. Never a sentinel. |
| `enabled` | whether periodic collection is wanted. |
| `GC_SCHED_RUN_PENDING` | a run is queued on the GC pool, or executing. A bit in a new atomic `schedFlags` word. |

`GCContext_ArmTimer` gates on all three and is callable blindly. `GCContext_QueueRun` claims `RUN_PENDING` with a single read-modify-write and **declines when a run already holds the context**, leaving that run's tail to re-arm; it rolls the bit back and arms a timer if `redisearch_thpool_add_work` fails, since a stuck bit would stop collection for the life of the process. `timerCallback` zeroes `timerID` when the timer fires. Together those give the invariant:

> a queued or executing periodic run implies no armed timer

which is what makes the free on the self-terminating path safe: nothing else points at the context.

The declining is load-bearing, not an optimisation. `RUN_PENDING` is a bit, not a count, so queueing unconditionally would put two runs behind one bit and the first one's tail would clear it while the second was still queued — from there every guard reading it is void and the invariant never re-converges.

**Drop-time termination.** `Indexes_RemoveSpecFromGlobals` now hands the context off across the unlink, in two phases because a run in flight frees it on the GC thread *without the GIL* the moment the unlink makes its promote fail:

- `GCContext_BeginDrop`, before the unlink, re-enables collection unconditionally — a run in flight is about to choose whether to re-arm, and for a stopped GC that choice is the difference between a timer eventually discovering the drop and nothing ever doing so. It then reports whether the context is still the caller's, which it is only when no timer is armed and no run is pending.
- `GCContext_FinishDrop`, after the unlink, queues the run that discovers the drop. After, not before: below `FORK_GC_CLEAN_THRESHOLD` a run that promoted the spec successfully returns true and re-arms rather than terminating.

`FT.DEBUG GC_STOP_SCHEDULE` / `GC_CONTINUE_SCHEDULE` go through `GCContext_StopFutureRuns` / `GCContext_IsEnabled` instead of writing `timerID`, and the GC debug commands reject an index with no `GCContext` — a `TEMPORARY` index, or any index under `NOGC` — through a shared `debugSpecWithGC` helper. `GC_FORCEBGINVOKE` had that NULL hole too; `GC_FORCEINVOKE` already handled it.

**3. Outcome.** The scheduling state is answerable rather than inferred, one owner holds a context at a time, and every runtime drop path ends in `onTerm`.

## What is still open, and why

Stated plainly so the invariant above is not over-read.

- **Termination can be deferred by up to one GC interval.** When the drop lands while a run is in flight, that run re-arms and the *next* run discovers the drop. A process exiting inside that window still has the context allocated at exit. Harmless operationally, but LeakSanitizer sees it.
- **`GCDebugTask` sits outside this model entirely.** The task queued by `GC_FORCEBGINVOKE` holds a raw `GCContext*` with no ownership token, so `GC_FORCEBGINVOKE` followed by `FT.DROPINDEX` can still have the periodic run free the context before the debug task runs on it. Pre-existing and byte-for-byte unchanged here.
- **`timerCallback`'s `!gc->enabled` early return is defensive, not a fix.** `GC_STOP_SCHEDULE` disarms the timer and clears `enabled` in the same GIL-held section, so I could not construct an interleaving that reaches it, and I am not claiming one. It is kept because it is free and because #10587 adds a `schedFlags` bit that makes the shape reachable.

Both of the first two close the same way: move the free onto a main-thread one-shot and drain pending terminations in `GC_ThreadPoolDestroy` after it joins the pool — at which point no new termination can be posted, so the drain is complete. That also collapses `BeginDrop`/`FinishDrop` into a single call. It is deliberately **not** in this PR: it changes module shutdown ordering, which does not belong in a scheduling-state refactor.

## Why this is a separate PR

Groundwork, extracted so neither consumer carries it:

- **#10728 (MOD-17309)** moves the GC re-arm off the GC thread onto a main-thread one-shot. Its CI hit an ASan use-after-free of exactly the shape above: the deferred one-shot tests `if (gc->timerID)` meaning "is collection wanted", cannot distinguish the sentinel from a live timer, and arms a timer for a GC that already has a job queued. `RUN_PENDING` is the predicate it needs.
- **#10587 (MOD-17197)** needs the same model for its disk consistency window and adds a second `schedFlags` bit, `GC_SCHED_PAUSED`.

That is why `schedFlags` is a one-bit word rather than a `bool`: #10587's pause/resume handshake tests its bit against `RUN_PENDING` in one read-modify-write, because two independent relaxed accesses across threads are not ordered. Note every `schedFlags` access today is also under the GIL, so correctness currently rests on the GIL rather than the atomic.

## Tests

- `testGCPeriodicScheduleStopAndResume` — the chain re-arms itself with no `FORCE_INVOKE`, freezes across `GC_STOP_SCHEDULE`, resumes on `GC_CONTINUE_SCHEDULE`. The negative window is timed by a second index whose GC is never stopped: two of its cycles are positive evidence that GC timers fired while the stopped index stayed flat, so a slow host stretches the window instead of expiring it.
- `testGCStopScheduleDuringRun` — `GC_STOP_SCHEDULE` against a run parked on the `GCTaskStart` sync point; the completing run's own re-arm has to notice collection was disabled under it.
- `testGCContinueScheduleDuringRun_MOD_17309` — the `QueueRun` decline, which is the load-bearing half of the use-after-free fix. Stops scheduling again before releasing the parked run so no timer can fire during the assertion, then uses `GC_WAIT_FOR_JOBS` as a barrier rather than polling: it queues a marker at the end of the single-threaded pool, so a duplicate would necessarily complete ahead of it. **Verified by negative control** — removing the decline fails it `0 -> 2`.
- `testGCTerminatesAfterDropWhileStopped` — the leak, observed without a sanitizer via `search_gc_total_docs_not_collected` returning to 0, since `onTerm` is what restores it. **Verified by negative control** — stubbing `BeginDrop` to return false fails it. Keeps a second index alive because the GC INFO section only renders while one exists, and prefixes both so the count is unambiguously the dropped index's.
- `testGCScheduleCommandsOnIndexWithoutGC` — the four GC debug commands reject a `TEMPORARY` index instead of crashing, and a normal index in the same server still works. Segfaults without the change.
- `testGCStopAndContinueSchedule` extended — `CONTINUE` leaves the GC enabled rather than merely replying OK, and `STOP` is idempotent.

**Not covered:** the drop landing while a run is in flight *and* collection disabled — the sync point can park a run, but nothing drives `FT.DROPINDEX` into that window. `QueueRun`'s rollback branch (`rm_malloc` maps to `RedisModule_Alloc`, which aborts rather than returning NULL, so it is unreachable in production). `timerCallback`'s two early returns. `GCContext_ArmTimer`'s failed-to-arm branch is not reachable from a flow test either — `RM_CreateTimer` never returns 0 — but it *is* executed by every cpptest, where `RS_IsMock` makes `scheduleNext` return 0.

## Validation

- Build clean with `DEBUG=1 ENABLE_ASSERT=1`; no new warnings in the changed files.
- Unit tests: 978 passed, 0 failed.
- Flow tests: `test_gc` 26, `test_debug_commands` 93, `test_info_modules` 34, `test_issues` 80, `test_existing` 5 — 0 failures. `test_blocked_client_timeout` 55/55 in cluster mode, which is the suite that caught an earlier over-reach here.
- Both negative controls above.
- `clang-format` checked against the changed lines only; these files are not format-clean on master and were deliberately not reformatted wholesale.

Not validated locally: anything requiring a sanitizer. The local `redis-server` is not ASan-instrumented, so the module does not load under `SAN=address` — the `sanitize` lane is the real check, and it found two problems in this PR that local runs did not.

#### Which additional issues this PR fixes
1. Groundwork for MOD-17309 (#10728) and MOD-17197 (#10587); fixes neither on its own.
2. Closes two `FT.DEBUG`-reachable defects that predate both: the stop/continue double-queue use-after-free, and the leak of a stopped GC whose index is dropped.
3. Closes the NULL `GCContext` dereference on a `TEMPORARY`/`NOGC` index.

#### Main objects this PR modified
1. `GCContext` scheduling state — `timerID` / `enabled` split, `schedFlags` bit set (`src/gc.h`)
2. Timer arm/disarm, single-owner run queueing, drop-time hand-off (`src/gc.c`)
3. Drop path calls the hand-off around the spec unlink (`src/indexes.c`)
4. GC `FT.DEBUG` subcommands — shared `debugSpecWithGC` resolution plus NULL rejection (`src/debug_commands.c`)
5. `unsigned` relaxed atomic load / fetch_or / fetch_and helpers (`src/util/rs_atomic.h`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal refactor of GC scheduling state. The defects it closes are reachable only through
`FT.DEBUG` subcommands, which are gated behind `DEBUG` being enabled and are not a supported
user surface.
