### PR TITLE
[MOD-14885] rs_token: add `RSTokenMut`, an exclusive handle for in-place token rewrites

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2501,8 +2501,8 @@ dependencies = [
  "redis-module",
  "redis_mock",
  "redisearch_rs",
+ "rqe_wildcard",
  "rs_token",
- "thiserror",
  "workspace_hack",
 ]
 

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2502,6 +2502,7 @@ dependencies = [
  "redis_mock",
  "redisearch_rs",
  "rs_token",
+ "thiserror",
  "workspace_hack",
 ]
 

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2491,6 +2491,7 @@ dependencies = [
  "redis_mock",
  "redisearch_rs",
  "rs_token",
+ "thiserror",
  "workspace_hack",
 ]
 

--- a/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
@@ -150,7 +150,12 @@ pub unsafe extern "C" fn queryNeedsOffsets(
 /// 1. `q` must be a non-null pointer to a valid [`QueryEvalCtx`] that satisfies
 ///    all the invariants documented on [`QueryEvalContext::new`] and remains
 ///    valid for the lifetime of the returned iterator.
-/// 2. `n` must be a non-null pointer to a valid [`RSQueryNode`].
+/// 2. `n` must be a non-null pointer to a valid [`RSQueryNode`]. Evaluation
+///    rewrites some tokens in place, so every node in the subtree that carries a
+///    rewritable one — see [`QueryNodeMut::token_mut`] — must additionally satisfy
+///    invariant (4) of [`QueryNodeMut::new`]. A parser-produced AST does; one
+///    assembled by hand, with a token borrowing a read-only or length-delimited
+///    string, does not.
 /// 3. `eval_config` must be a non-null [`EvalConfig`](ffi::EvalConfig) handle
 ///    pointing to a valid [`Config`] that stays valid for the duration of the
 ///    call — the snapshot [`QAST_Iterate`] loaded and threaded through the C
@@ -176,7 +181,9 @@ pub unsafe extern "C" fn Query_EvalNode_Rs(
     // borrowed only for the duration of this call. Evaluation owns the subtree
     // exclusively: the C dispatcher hands each node to exactly one evaluator and
     // waits for it to return, and query evaluation is single-threaded, so no
-    // other wrapper or reference into this subtree is live for the call.
+    // other wrapper or reference into this subtree — nor into any token string it
+    // points at — is live for the call. Precondition 2 also carries the token
+    // buffers' own requirements.
     let node = unsafe { QueryNodeMut::new(n) };
 
     // SAFETY: `config` is non-null (checked) and points to a valid `Config`
@@ -202,7 +209,9 @@ pub unsafe extern "C" fn Query_EvalNode_Rs(
 ///
 /// 1. `qast` must be a non-null pointer to a valid [`QueryAST`] whose `root` is
 ///    a valid [`RSQueryNode`]; it (and its `metricRequests`/`config` fields)
-///    must stay valid and exclusively borrowed for the duration of the call.
+///    must stay valid and exclusively borrowed for the duration of the call. The
+///    root's subtree must meet the token-buffer requirement of
+///    [`Query_EvalNode_Rs`]'s precondition 2, for the same reason.
 /// 2. `opts` must be a non-null pointer to a valid [`RSSearchOptions`].
 /// 3. `sctx` must be a non-null pointer to a valid [`RedisSearchCtx`] whose
 ///    `spec` is a valid, non-null [`IndexSpec`](ffi::IndexSpec).
@@ -263,7 +272,9 @@ pub unsafe extern "C" fn QAST_Iterate(
     let mut ctx = unsafe { QueryEvalContext::new(q) };
     // SAFETY: `root` is a valid `RSQueryNode` and the whole AST is borrowed
     // exclusively for the duration of this call (precondition 1), so evaluation
-    // owns the tree: no other wrapper or reference into it is live.
+    // owns the tree: no other wrapper or reference into it, or into any token
+    // string it points at, is live. Precondition 1 also carries the token buffers'
+    // own requirements.
     let node = unsafe { QueryNodeMut::new(root) };
 
     let config = eval_config(ctx.config());

--- a/src/redisearch_rs/c_wrappers/query/src/mock/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/mock/mod.rs
@@ -17,4 +17,4 @@ mod query_eval_ctx;
 mod query_node_ref;
 
 pub use query_eval_ctx::MockQueryEvalCtx;
-pub use query_node_ref::MockQueryNode;
+pub use query_node_ref::{MockQueryNode, TokenNodeType};

--- a/src/redisearch_rs/c_wrappers/query/src/mock/query_node_ref.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/mock/query_node_ref.rs
@@ -176,15 +176,26 @@ impl MockQueryNode {
     }
 
     /// Set the `str`/`len` fields of the token-node union variant
-    /// ([`ffi::RSToken`]).
+    /// ([`ffi::RSToken`]), whose layout the prefix, fuzzy and verbatim payloads
+    /// each begin with.
     ///
     /// The caller must keep `str_` valid for `len` bytes for as long as the
     /// node is used (e.g. by owning the backing buffer alongside the node).
     /// The token's `flags`/`expanded` bitfields keep their zeroed defaults.
+    ///
+    /// A node whose token [`QueryNodeMut::token_mut`] hands out needs more than
+    /// that, because such a token is rewritten in place — see invariant (4) of
+    /// [`QueryNodeMut::new`]. Wrapping a node backed by a read-only, shorter, or
+    /// unterminated buffer in a [`QueryNodeMut`] is unsound even though every call
+    /// involved is safe.
+    ///
+    /// [`QueryNodeMut`]: crate::QueryNodeMut
+    /// [`QueryNodeMut::new`]: crate::QueryNodeMut::new
+    /// [`QueryNodeMut::token_mut`]: crate::QueryNodeMut::token_mut
     pub fn set_token(&mut self, str_: *mut c_char, len: usize) {
         // SAFETY: `self.node` is valid and exclusively owned; the caller
-        // guarantees the node type is Token so the `tn` (`RSToken`) variant is
-        // active.
+        // guarantees the node type is one whose payload begins with an
+        // `RSToken` — `tn` itself, or the prefix, fuzzy or verbatim struct.
         unsafe {
             let union_ptr = &raw mut (*self.node).__bindgen_anon_1;
             let tok = &mut *union_ptr.cast::<ffi::RSToken>();

--- a/src/redisearch_rs/c_wrappers/query/src/mock/query_node_ref.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/mock/query_node_ref.rs
@@ -57,6 +57,52 @@ fn alloc_zeroed_aux<T>() -> (*mut T, AuxAlloc) {
     (ptr.cast::<T>(), AuxAlloc { ptr, layout })
 }
 
+/// Allocate a writable, NUL-terminated copy of `content` on the heap.
+///
+/// The allocation spans one byte more than `content`: the copy, then the
+/// terminator an in-place token rewrite reads past the end and re-writes at the
+/// shortened end. Allocated raw rather than as a [`Vec`] so the pointer handed to
+/// the node has provenance over the whole buffer, matching how the node itself is
+/// stored (see [`MockQueryNode`]).
+///
+/// The returned [`AuxAlloc`] both keeps the allocation alive and addresses it,
+/// through its [`ptr`](AuxAlloc::ptr).
+fn alloc_token_aux(content: &[u8]) -> AuxAlloc {
+    let layout = Layout::array::<c_char>(content.len() + 1).expect("token layout must be valid");
+    // SAFETY: the layout is never zero-sized — the terminator alone accounts for a
+    // byte — and zeroing it leaves that terminator in place.
+    let ptr = unsafe { alloc_zeroed(layout) };
+    assert!(!ptr.is_null());
+    // SAFETY: `ptr` owns `content.len() + 1` writable bytes and cannot overlap a
+    // caller's slice, so the copy fits and leaves the zeroed final byte untouched.
+    unsafe { std::ptr::copy_nonoverlapping(content.as_ptr(), ptr, content.len()) };
+    AuxAlloc { ptr, layout }
+}
+
+/// A [`QueryNodeType`] whose union payload begins with an [`ffi::RSToken`].
+///
+/// These four are exactly the node types [`MockQueryNode::with_token`] accepts:
+/// [`Token`](QueryNodeType::Token)'s payload *is* a token, and the prefix, fuzzy
+/// and verbatim payloads each start with one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenNodeType {
+    Token,
+    Prefix,
+    Fuzzy,
+    WildcardQuery,
+}
+
+impl From<TokenNodeType> for QueryNodeType {
+    fn from(type_: TokenNodeType) -> Self {
+        match type_ {
+            TokenNodeType::Token => Self::Token,
+            TokenNodeType::Prefix => Self::Prefix,
+            TokenNodeType::Fuzzy => Self::Fuzzy,
+            TokenNodeType::WildcardQuery => Self::WildcardQuery,
+        }
+    }
+}
+
 impl Drop for MockQueryNode {
     fn drop(&mut self) {
         // SAFETY: `self.node` is a valid, owned allocation. If `children` is
@@ -175,33 +221,43 @@ impl MockQueryNode {
         }
     }
 
-    /// Set the `str`/`len` fields of the token-node union variant
-    /// ([`ffi::RSToken`]), whose layout the prefix, fuzzy and verbatim payloads
-    /// each begin with.
+    /// Build a token-carrying node whose [`ffi::RSToken`] addresses a writable,
+    /// NUL-terminated copy of `content` that the node owns.
     ///
-    /// The caller must keep `str_` valid for `len` bytes for as long as the
-    /// node is used (e.g. by owning the backing buffer alongside the node).
+    /// A query-node token is not read-only — evaluation rewrites some in place —
+    /// so a mock token needs backing that is writable, terminated one byte past
+    /// its content, and alive for as long as the node. Rather than leave those to
+    /// a caller's `unsafe` promise, this owns the buffer and copies into it, and
+    /// takes a [`TokenNodeType`] so the payload it writes through is the active
+    /// union variant by construction. That is the whole of what
+    /// [`QueryNodeMut::token_mut`] needs from a node, discharged by the types.
+    ///
+    /// `content` is the string *without* a terminator, and is taken as bytes
+    /// rather than a [`CStr`](std::ffi::CStr) because a token is binary data: an
+    /// interior NUL is legal content, and merely ends the string as far as C is
+    /// concerned.
+    ///
     /// The token's `flags`/`expanded` bitfields keep their zeroed defaults.
     ///
-    /// A node whose token [`QueryNodeMut::token_mut`] hands out needs more than
-    /// that, because such a token is rewritten in place — see invariant (4) of
-    /// [`QueryNodeMut::new`]. Wrapping a node backed by a read-only, shorter, or
-    /// unterminated buffer in a [`QueryNodeMut`] is unsound even though every call
-    /// involved is safe.
-    ///
-    /// [`QueryNodeMut`]: crate::QueryNodeMut
-    /// [`QueryNodeMut::new`]: crate::QueryNodeMut::new
     /// [`QueryNodeMut::token_mut`]: crate::QueryNodeMut::token_mut
-    pub fn set_token(&mut self, str_: *mut c_char, len: usize) {
-        // SAFETY: `self.node` is valid and exclusively owned; the caller
-        // guarantees the node type is one whose payload begins with an
-        // `RSToken` — `tn` itself, or the prefix, fuzzy or verbatim struct.
+    pub fn with_token(type_: TokenNodeType, content: impl AsRef<[u8]>) -> Self {
+        let content = content.as_ref();
+        let alloc = alloc_token_aux(content);
+        let str_ = alloc.ptr.cast::<c_char>();
+        let mut this = Self::new(type_.into());
+        this._aux.push(alloc);
+
+        // SAFETY: `self.node` is valid and exclusively owned, and `type_` is a
+        // token-carrying type, so the union's active member either is an `RSToken`
+        // or begins with one.
         unsafe {
-            let union_ptr = &raw mut (*self.node).__bindgen_anon_1;
+            let union_ptr = &raw mut (*this.node).__bindgen_anon_1;
             let tok = &mut *union_ptr.cast::<ffi::RSToken>();
             tok.str_ = str_;
-            tok.len = len;
+            tok.len = content.len();
         }
+
+        this
     }
 
     /// Allocate a children array and populate it with the given child pointers.

--- a/src/redisearch_rs/c_wrappers/query/src/query_node_ref.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_node_ref.rs
@@ -14,7 +14,7 @@ use std::{marker::PhantomData, ops::Deref, ptr::NonNull};
 use inverted_index::NumericFilter;
 use query_types::{QueryNodeOptions, QueryNodeType};
 use rqe_core::{DocId, FieldMask};
-use rs_token::{RSTokenRef, RSTokenRefNulTerminated};
+use rs_token::{RSTokenMut, RSTokenRef, RSTokenRefNulTerminated};
 
 /// The wildcard expansion mode for a [`QueryNode::Prefix`] node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -440,10 +440,88 @@ impl QueryNodeMut<'_> {
     ///    wrappers to the same node can be minted from safe code (e.g.
     ///    [`child`](QueryNodeRef::child)) and because C holds its own pointers
     ///    into the AST; upholding it is the caller's responsibility.
+    /// 3. That exclusivity extends to a token's separately allocated string, not
+    ///    just to the node structs: a rewrite such as the ones
+    ///    [`token_mut`](Self::token_mut) exposes writes to a buffer the node only
+    ///    points at, so nothing else in the subtree's lifetime may read or write
+    ///    those bytes either.
+    /// 4. The token of every node [`token_mut`](Self::token_mut) hands one out for
+    ///    must meet the string requirements of
+    ///    [`RSTokenMut::from_nul_terminated_ffi`]. Both shapes the parser produces
+    ///    do: a query literal is copied into an explicitly terminated allocation,
+    ///    and a query parameter into a zeroed one a byte longer than its value.
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
     pub const unsafe fn new(ptr: NonNull<ffi::RSQueryNode>) -> Self {
         Self(ptr, PhantomData)
+    }
+
+    /// Borrow this node's token for in-place rewriting, or `None` when the node
+    /// carries no rewritable one.
+    ///
+    /// The returned handle borrows `*self`, so the node cannot be read or mutated
+    /// while it is live, and it is the only way to reach the token — which is what
+    /// [`RSTokenMut`]'s constructor demands, established here by the borrow checker
+    /// rather than by a second `unsafe` assertion.
+    ///
+    /// The token's string requirements come from invariant (4) of
+    /// [`QueryNodeMut::new`]; its exclusivity, from invariant (3).
+    ///
+    /// # Which nodes carry one
+    ///
+    /// The prefix, fuzzy and wildcard-query payloads each begin with a token, and
+    /// this is the accessor for all three: gating one method on three discriminants
+    /// keeps a caller from having to know which payload struct it is reading
+    /// through. Every other node type yields `None`.
+    ///
+    /// [`QueryNodeType::Token`] is deliberately not among them, even though its
+    /// payload *is* a token: an expanded one may borrow a length-delimited string
+    /// that is neither NUL-terminated nor writable, so it cannot satisfy invariant
+    /// (4). That is also why [`QueryNode::Token`] alone carries an [`RSTokenRef`]
+    /// with no NUL-termination typestate.
+    ///
+    /// The check is not optional — the payload is a union, so handing out a token
+    /// from a variant carrying none would reinterpret unrelated bytes as one, and
+    /// it has to live here because a token pointer carries no evidence of which
+    /// variant produced it. Reporting it as `None` rather than a panic is what lets
+    /// a caller check the node type exactly once.
+    pub fn token_mut(&mut self) -> Option<RSTokenMut<'_>> {
+        // As in `and_field_mask`, `&mut self` plus invariant (2) of
+        // `QueryNodeMut::new` rule out any aliasing wrapper or reference — here
+        // including the token's separately allocated string, per invariant (3).
+        // Everything below goes through raw pointers, never forming an
+        // intermediate reference to the node.
+        //
+        // SAFETY: the node is valid, so a raw pointer to its payload union is in
+        // bounds.
+        let union_ptr = unsafe { &raw mut (*self.0.as_ptr()).__bindgen_anon_1 };
+
+        // Each arm addresses the `tok` field of the payload the discriminant named,
+        // rather than casting straight to a token because all three happen to start
+        // with one.
+        let tok = match self.as_ref().node_type() {
+            // SAFETY: `type_` is `Prefix`, so the union's active member is a
+            // `QueryPrefixNode`, whose `tok` field this addresses.
+            QueryNodeType::Prefix => unsafe {
+                &raw mut (*union_ptr.cast::<ffi::QueryPrefixNode>()).tok
+            },
+            // SAFETY: `type_` is `Fuzzy`, so the union's active member is a
+            // `QueryFuzzyNode`, whose `tok` field this addresses.
+            QueryNodeType::Fuzzy => unsafe {
+                &raw mut (*union_ptr.cast::<ffi::QueryFuzzyNode>()).tok
+            },
+            // SAFETY: `type_` is `WildcardQuery`, so the union's active member is a
+            // `QueryVerbatimNode`, whose `tok` field this addresses.
+            QueryNodeType::WildcardQuery => unsafe {
+                &raw mut (*union_ptr.cast::<ffi::QueryVerbatimNode>()).tok
+            },
+            _ => return None,
+        };
+
+        // SAFETY: `tok` addresses the node's valid token, exclusively owned for the
+        // returned handle's lifetime by the borrow of `*self`, and its string meets
+        // the constructor's requirements per invariant (4).
+        Some(unsafe { RSTokenMut::from_nul_terminated_ffi(tok) })
     }
 
     /// Intersect `mask` into this node's [field mask](QueryNodeOptions::field_mask).

--- a/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::ffi::c_char;
+
 use inverted_index::NumericFilter;
 use query::{QueryNode, QueryNodeMut, QueryNodeRef, WildcardMode, mock::MockQueryNode};
 use query_types::QueryNodeType;
@@ -273,4 +275,81 @@ fn query_node_mut_child_out_of_bounds_panics() {
     // live.
     let mut node = unsafe { QueryNodeMut::new(mock.as_non_null()) };
     let _ = node.child_mut(0);
+}
+
+#[test]
+fn token_mut_reads_the_nodes_own_token() {
+    // Every node type that carries a rewritable token reaches the same field
+    // through a different payload struct, so each is exercised.
+    for node_type in [
+        QueryNodeType::Prefix,
+        QueryNodeType::Fuzzy,
+        QueryNodeType::WildcardQuery,
+    ] {
+        let mut buf: Vec<c_char> = b"he?l*o\0".iter().map(|&b| b as c_char).collect();
+        let mut mock = MockQueryNode::new(node_type);
+        mock.set_token(buf.as_mut_ptr(), 6);
+        // SAFETY: sole wrapper to a valid node; `buf` outlives it and is writable
+        // for its 6 content bytes with a terminator at `buf[6]`, per invariants (3)
+        // and (4).
+        let mut node = unsafe { QueryNodeMut::new(mock.as_non_null()) };
+        let tok = node.token_mut().expect("node type carries a token");
+        assert_eq!(tok.as_ref().as_c_str(), Some(c"he?l*o"), "{node_type:?}");
+    }
+}
+
+// This test rewrites through the C `Wildcard_RemoveEscape`, so it cannot run under
+// miri.
+#[cfg(not(miri))]
+#[test]
+fn token_mut_rewrites_the_nodes_own_token() {
+    // The handle must address the node's own token, not a copy: a rewrite through
+    // it has to be visible to every later read of the node. Reading the result back
+    // through `as_enum` — a path that never saw the handle — is what shows that.
+    // `w'a\*b\?c'`: seven content bytes plus the terminator the token contract
+    // requires at `buf[7]`.
+    let pattern = br"a\*b\?c";
+    let mut buf: Vec<c_char> = pattern
+        .iter()
+        .map(|&b| b as c_char)
+        .chain(std::iter::once(0))
+        .collect();
+    let mut mock = MockQueryNode::new(QueryNodeType::WildcardQuery);
+    mock.set_token(buf.as_mut_ptr(), pattern.len());
+    // SAFETY: sole wrapper to a valid node; `buf` outlives it and is writable for
+    // its `pattern.len()` content bytes with a terminator at `buf[pattern.len()]`,
+    // per invariants (3) and (4).
+    let mut node = unsafe { QueryNodeMut::new(mock.as_non_null()) };
+
+    node.token_mut()
+        .expect("a wildcard-query node carries a token")
+        .remove_wildcard_escapes()
+        .expect("token is short enough to rewrite");
+
+    // The handle is dead, so the node is readable again — and shows the rewrite.
+    let QueryNode::WildcardQuery { tok } = node.as_ref().as_enum() else {
+        panic!("node is a wildcard query");
+    };
+    assert_eq!(tok.len(), 5);
+    assert_eq!(tok.as_bytes(), Some(&b"a*b?c"[..]));
+    assert_eq!(tok.as_c_str(), Some(c"a*b?c"));
+}
+
+#[test]
+fn token_mut_declines_node_types_without_a_rewritable_token() {
+    // The payload is a union, so handing out a token from a node that carries none
+    // would reinterpret unrelated bytes as one. `Token` is here because it is the
+    // near miss: its payload *is* a token, but an expanded one may be neither
+    // writable nor NUL-terminated, so it cannot meet invariant (4).
+    for node_type in [
+        QueryNodeType::Token,
+        QueryNodeType::Union,
+        QueryNodeType::Wildcard,
+        QueryNodeType::Null,
+    ] {
+        let mock = MockQueryNode::new(node_type);
+        // SAFETY: sole wrapper to a valid leaf node.
+        let mut node = unsafe { QueryNodeMut::new(mock.as_non_null()) };
+        assert!(node.token_mut().is_none(), "{node_type:?}");
+    }
 }

--- a/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
@@ -296,9 +296,6 @@ fn token_mut_reads_the_nodes_own_token() {
     }
 }
 
-// This test rewrites through the C `Wildcard_RemoveEscape`, so it cannot run under
-// miri.
-#[cfg(not(miri))]
 #[test]
 fn token_mut_rewrites_the_nodes_own_token() {
     // The handle must address the node's own token, not a copy: a rewrite through
@@ -311,8 +308,7 @@ fn token_mut_rewrites_the_nodes_own_token() {
 
     node.token_mut()
         .expect("a wildcard-query node carries a token")
-        .remove_wildcard_escapes()
-        .expect("token is short enough to rewrite");
+        .remove_wildcard_escapes();
 
     // The handle is dead, so the node is readable again — and shows the rewrite.
     let QueryNode::WildcardQuery { tok } = node.as_ref().as_enum() else {

--- a/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
@@ -7,10 +7,11 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::ffi::c_char;
-
 use inverted_index::NumericFilter;
-use query::{QueryNode, QueryNodeMut, QueryNodeRef, WildcardMode, mock::MockQueryNode};
+use query::{
+    QueryNode, QueryNodeMut, QueryNodeRef, WildcardMode,
+    mock::{MockQueryNode, TokenNodeType},
+};
 use query_types::QueryNodeType;
 
 #[test]
@@ -282,16 +283,13 @@ fn token_mut_reads_the_nodes_own_token() {
     // Every node type that carries a rewritable token reaches the same field
     // through a different payload struct, so each is exercised.
     for node_type in [
-        QueryNodeType::Prefix,
-        QueryNodeType::Fuzzy,
-        QueryNodeType::WildcardQuery,
+        TokenNodeType::Prefix,
+        TokenNodeType::Fuzzy,
+        TokenNodeType::WildcardQuery,
     ] {
-        let mut buf: Vec<c_char> = b"he?l*o\0".iter().map(|&b| b as c_char).collect();
-        let mut mock = MockQueryNode::new(node_type);
-        mock.set_token(buf.as_mut_ptr(), 6);
-        // SAFETY: sole wrapper to a valid node; `buf` outlives it and is writable
-        // for its 6 content bytes with a terminator at `buf[6]`, per invariants (3)
-        // and (4).
+        let mock = MockQueryNode::with_token(node_type, b"he?l*o");
+        // SAFETY: sole wrapper to a valid node; the mock owns writable, terminated
+        // token backing that outlives it, per invariants (3) and (4).
         let mut node = unsafe { QueryNodeMut::new(mock.as_non_null()) };
         let tok = node.token_mut().expect("node type carries a token");
         assert_eq!(tok.as_ref().as_c_str(), Some(c"he?l*o"), "{node_type:?}");
@@ -306,19 +304,9 @@ fn token_mut_rewrites_the_nodes_own_token() {
     // The handle must address the node's own token, not a copy: a rewrite through
     // it has to be visible to every later read of the node. Reading the result back
     // through `as_enum` — a path that never saw the handle — is what shows that.
-    // `w'a\*b\?c'`: seven content bytes plus the terminator the token contract
-    // requires at `buf[7]`.
-    let pattern = br"a\*b\?c";
-    let mut buf: Vec<c_char> = pattern
-        .iter()
-        .map(|&b| b as c_char)
-        .chain(std::iter::once(0))
-        .collect();
-    let mut mock = MockQueryNode::new(QueryNodeType::WildcardQuery);
-    mock.set_token(buf.as_mut_ptr(), pattern.len());
-    // SAFETY: sole wrapper to a valid node; `buf` outlives it and is writable for
-    // its `pattern.len()` content bytes with a terminator at `buf[pattern.len()]`,
-    // per invariants (3) and (4).
+    let mock = MockQueryNode::with_token(TokenNodeType::WildcardQuery, br"a\*b\?c");
+    // SAFETY: sole wrapper to a valid node; the mock owns writable, terminated
+    // token backing that outlives it, per invariants (3) and (4).
     let mut node = unsafe { QueryNodeMut::new(mock.as_non_null()) };
 
     node.token_mut()

--- a/src/redisearch_rs/c_wrappers/rs_token/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/rs_token/Cargo.toml
@@ -20,6 +20,7 @@ build_utils.workspace = true
 ffi.workspace = true
 query_term.workspace = true
 redis-module.workspace = true
+thiserror.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]

--- a/src/redisearch_rs/c_wrappers/rs_token/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/rs_token/Cargo.toml
@@ -20,7 +20,7 @@ build_utils.workspace = true
 ffi.workspace = true
 query_term.workspace = true
 redis-module.workspace = true
-thiserror.workspace = true
+rqe_wildcard.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]

--- a/src/redisearch_rs/c_wrappers/rs_token/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/rs_token/Cargo.toml
@@ -19,6 +19,7 @@ build_utils.workspace = true
 [dependencies]
 ffi.workspace = true
 query_term.workspace = true
+thiserror.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]

--- a/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
@@ -15,6 +15,7 @@ use std::{
 };
 
 use query_term::RSTokenFlags;
+use rqe_wildcard::remove_escape_in_place;
 
 /// The most bytes the C `strToLowerRunes` decoder (`nu_utf8_read`) reads past a
 /// multibyte lead byte. A UTF-8 sequence is at most four bytes, so the decoder
@@ -339,22 +340,6 @@ pub struct RSTokenMut<'a> {
     tok: &'a mut ffi::RSToken,
 }
 
-/// A token too long to be rewritten in place, returned by
-/// [`RSTokenMut::remove_wildcard_escapes`].
-///
-/// The escape converter walks the string with `int` cursors, which a length past
-/// [`i32::MAX`] overflows into negative indices — reads and writes outside the
-/// allocation. Nothing upstream caps a token at that: a query parameter is bounded
-/// only by `proto-max-bulk-len`, which an operator may raise further. The length is
-/// therefore user-controlled, so the refusal has to be one a query can report
-/// rather than a panic reaching an `extern "C"` frame.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[error("token length {len} exceeds maximum {}", i32::MAX)]
-pub struct TokenTooLong {
-    /// The token's length, in bytes.
-    pub len: usize,
-}
-
 impl<'a> RSTokenMut<'a> {
     /// Wrap a raw pointer to an [`ffi::RSToken`] for in-place rewriting.
     ///
@@ -370,8 +355,9 @@ impl<'a> RSTokenMut<'a> {
     /// - A non-null `str_` must address `len` initialized bytes that are
     ///   **writable**, and the allocation must extend one byte further: `str_[len]`
     ///   must be readable and equal to `0`. A rewrite writes only within
-    ///   `str_[0..len]`; the extra byte is what it reads when an escape has nothing
-    ///   after it.
+    ///   `str_[0..len]`, re-terminating the string at its new end; the extra byte
+    ///   is what already terminates it when a rewrite leaves the length alone, and
+    ///   what [`as_ref`](Self::as_ref)'s NUL-terminated handle rests on throughout.
     /// - A null `str_` implies `len == 0`, since a rewrite dereferences the string
     ///   whenever `len` is non-zero.
     pub unsafe fn from_nul_terminated_ffi(tok: *mut ffi::RSToken) -> Self {
@@ -415,7 +401,10 @@ impl<'a> RSTokenMut<'a> {
     ///
     /// A token is binary data, not text, so the rewrite works on bytes. One
     /// consequence is that an interior NUL ends the pattern, escape or no escape:
-    /// `a\0b` searches for `a`. Only a query parameter can carry such a token.
+    /// `a\0b` searches for `a`. Only a query parameter can carry such a token. The
+    /// rules are [`remove_escape_in_place`]'s; this adds the token bookkeeping
+    /// around them — the new length, and the terminator at the new end that keeps
+    /// the string readable as a C string.
     ///
     /// Escape removal is single-level and destructive, which makes this method
     /// **not idempotent**: it must be applied at most once per token — `a\\b`
@@ -423,44 +412,30 @@ impl<'a> RSTokenMut<'a> {
     /// keeps two handles from each applying it, but not one handle from applying it
     /// twice, so a token reachable from more than one evaluation path must be
     /// unescaped by exactly one of them.
-    ///
-    /// # Errors
-    ///
-    /// [`TokenTooLong`] if the token is too long for the converter to address,
-    /// leaving it untouched. Checking the bound here rather than adding it to the
-    /// constructor's contract is what keeps a caller from reaching the overflow
-    /// without first passing a check.
-    pub fn remove_wildcard_escapes(&mut self) -> Result<(), TokenTooLong> {
+    pub fn remove_wildcard_escapes(&mut self) {
         let len = self.tok.len;
 
-        // Handed the empty token, the converter would write a terminator past the
-        // one-byte allocation an empty query parameter produces. It guards this
-        // itself, but guarding here too keeps this method's soundness off the far
-        // side of the FFI boundary — and makes a token carrying no string, which
-        // the constructor's contract makes an empty one, a no-op rather than a null
-        // dereference.
+        // A token carrying no string is an empty one, per the constructor's
+        // contract, so returning here is what keeps the slice below off a null
+        // pointer. An empty token has nothing to unescape either way.
         if len == 0 {
-            return Ok(());
-        }
-
-        // Checked before the string is touched, so a refused token is left exactly
-        // as it was.
-        if len > i32::MAX as usize {
-            return Err(TokenTooLong { len });
+            return;
         }
 
         let str_ = self.tok.str_;
         debug_assert!(!str_.is_null(), "a non-empty token always carries a string");
 
-        // SAFETY: per the constructor's contract, `str_` is writable for `len`
-        // bytes and readable one further, where the terminator sits. `len` is
-        // within the range the converter's `int` cursors address, as just checked.
-        // `Wildcard_RemoveEscape` reads at most that terminator and writes only
-        // within `str_[0..len]`, so every access stays inside the allocation.
-        let new_len = unsafe { ffi::Wildcard_RemoveEscape(str_, len) };
+        // SAFETY: per the constructor's contract, `str_` addresses `len`
+        // initialized, writable bytes, and this handle is the only way to reach
+        // them, so the exclusive slice is sound.
+        let pattern = unsafe { std::slice::from_raw_parts_mut(str_.cast::<u8>(), len) };
+        // A shortened string comes back re-terminated at its new end; an unshortened
+        // one still ends at the terminator the constructor's contract requires. So
+        // the string stays readable as a C string either way, and nothing writes
+        // past `str_[len - 1]`.
+        let new_len = remove_escape_in_place(pattern);
         debug_assert!(new_len <= len, "escape removal must not lengthen the token");
         self.tok.len = new_len;
-        Ok(())
     }
 }
 

--- a/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
@@ -319,6 +319,151 @@ impl<'a> RSTokenRef<'a, true> {
     }
 }
 
+/// Safe, exclusive handle to an [`ffi::RSToken`] whose string may be rewritten in
+/// place.
+///
+/// This is the mutating counterpart to [`RSTokenRef`], and the two split a
+/// token's lifecycle between them: a shared handle's `'a` is a window in which no
+/// mutation can be expressed (see [its docs](RSTokenRef#why-the-accessors-are-safe)),
+/// and this handle is how a mutation is expressed outside every such window. It is
+/// deliberately **not** [`Copy`]: the rewrites below are
+/// [not idempotent](Self::remove_wildcard_escapes), and two handles to the same
+/// token, each able to apply one, is precisely the hazard the exclusive borrow
+/// rules out.
+///
+/// Unlike [`RSTokenRef`], this type carries no NUL-termination typestate. Every
+/// in-place rewrite shortens the string and re-terminates it at its new end, so
+/// all of them need the terminator — requiring it unconditionally at construction
+/// leaves one contract to satisfy instead of two.
+pub struct RSTokenMut<'a> {
+    tok: &'a mut ffi::RSToken,
+}
+
+/// A token too long to be rewritten in place, returned by
+/// [`RSTokenMut::remove_wildcard_escapes`].
+///
+/// The escape converter walks the string with `int` cursors, which a length past
+/// [`i32::MAX`] overflows into negative indices — reads and writes outside the
+/// allocation. Nothing upstream caps a token at that: a query parameter is bounded
+/// only by `proto-max-bulk-len`, which an operator may raise further. The length is
+/// therefore user-controlled, so the refusal has to be one a query can report
+/// rather than a panic reaching an `extern "C"` frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("token length {len} exceeds maximum {}", i32::MAX)]
+pub struct TokenTooLong {
+    /// The token's length, in bytes.
+    pub len: usize,
+}
+
+impl<'a> RSTokenMut<'a> {
+    /// Wrap a raw pointer to an [`ffi::RSToken`] for in-place rewriting.
+    ///
+    /// # Safety
+    ///
+    /// - `tok` must be non-null and point to a valid [`ffi::RSToken`] that stays
+    ///   allocated for the whole of the handle's `'a` lifetime.
+    /// - The handle must be the **only** way to reach the token for `'a`: no other
+    ///   handle, reference, or C-side pointer may read or write either the token
+    ///   or the bytes its `str_` addresses while it is live. `'a` must be chosen to
+    ///   make that true — in practice by deriving it from an exclusive borrow of
+    ///   whatever owns the token, such as a query node.
+    /// - A non-null `str_` must address `len` initialized bytes that are
+    ///   **writable**, and the allocation must extend one byte further: `str_[len]`
+    ///   must be readable and equal to `0`. A rewrite writes only within
+    ///   `str_[0..len]`; the extra byte is what it reads when an escape has nothing
+    ///   after it.
+    /// - A null `str_` implies `len == 0`, since a rewrite dereferences the string
+    ///   whenever `len` is non-zero.
+    pub unsafe fn from_nul_terminated_ffi(tok: *mut ffi::RSToken) -> Self {
+        debug_assert!(!tok.is_null(), "token pointer must not be null");
+        // SAFETY: the caller guarantees `tok` is non-null, points to a valid
+        // `RSToken`, and that nothing else reaches it for `'a`, which is what the
+        // exclusive reference asserts.
+        let tok = unsafe { &mut *tok };
+        // In debug builds, sanity-check the NUL-termination the caller promised.
+        #[cfg(debug_assertions)]
+        if !tok.str_.is_null() {
+            // SAFETY: the caller guarantees `str_` is a NUL-terminated string of
+            // content length `len`, so `str_.add(len)` is the in-bounds terminator
+            // address.
+            let terminator_ptr = unsafe { tok.str_.add(tok.len) };
+            // SAFETY: `terminator_ptr` addresses the in-bounds terminator byte.
+            let terminator = unsafe { *terminator_ptr };
+            assert!(terminator == 0, "token string must be NUL-terminated");
+        }
+        Self { tok }
+    }
+
+    /// Reborrow this handle as a shared, read-only [`RSTokenRef`].
+    ///
+    /// The result borrows `*self`, so the token cannot be rewritten while it — or
+    /// anything derived from it — is live. That is the no-mutation window
+    /// [`RSTokenRef`]'s accessors rest on, established here by the borrow checker
+    /// rather than by an `unsafe` assertion.
+    pub const fn as_ref(&self) -> RSTokenRefNulTerminated<'_> {
+        // SAFETY: the constructor's contract guarantees a valid, NUL-terminated
+        // token, and `&self` is what keeps it unmutated for the result's lifetime.
+        unsafe { RSTokenRef::from_nul_terminated_ffi(std::ptr::from_ref(self.tok)) }
+    }
+
+    /// Collapse `\x` escapes in this token's wildcard pattern, in place,
+    /// shortening its length to match.
+    ///
+    /// The pattern is unescaped in the token itself rather than in a copy because
+    /// the unescaped string is also what a query reports as the pattern it ran
+    /// when it is profiled — a copy would leave `w'a\*b'` profiling as `a\*b`.
+    ///
+    /// A token is binary data, not text, so the rewrite works on bytes. One
+    /// consequence is that an interior NUL ends the pattern, escape or no escape:
+    /// `a\0b` searches for `a`. Only a query parameter can carry such a token.
+    ///
+    /// Escape removal is single-level and destructive, which makes this method
+    /// **not idempotent**: it must be applied at most once per token — `a\\b`
+    /// becomes `a\b`, and applying it again would yield `ab`. The exclusive borrow
+    /// keeps two handles from each applying it, but not one handle from applying it
+    /// twice, so a token reachable from more than one evaluation path must be
+    /// unescaped by exactly one of them.
+    ///
+    /// # Errors
+    ///
+    /// [`TokenTooLong`] if the token is too long for the converter to address,
+    /// leaving it untouched. Checking the bound here rather than adding it to the
+    /// constructor's contract is what keeps a caller from reaching the overflow
+    /// without first passing a check.
+    pub fn remove_wildcard_escapes(&mut self) -> Result<(), TokenTooLong> {
+        let len = self.tok.len;
+
+        // Handed the empty token, the converter would write a terminator past the
+        // one-byte allocation an empty query parameter produces. It guards this
+        // itself, but guarding here too keeps this method's soundness off the far
+        // side of the FFI boundary — and makes a token carrying no string, which
+        // the constructor's contract makes an empty one, a no-op rather than a null
+        // dereference.
+        if len == 0 {
+            return Ok(());
+        }
+
+        // Checked before the string is touched, so a refused token is left exactly
+        // as it was.
+        if len > i32::MAX as usize {
+            return Err(TokenTooLong { len });
+        }
+
+        let str_ = self.tok.str_;
+        debug_assert!(!str_.is_null(), "a non-empty token always carries a string");
+
+        // SAFETY: per the constructor's contract, `str_` is writable for `len`
+        // bytes and readable one further, where the terminator sits. `len` is
+        // within the range the converter's `int` cursors address, as just checked.
+        // `Wildcard_RemoveEscape` reads at most that terminator and writes only
+        // within `str_[0..len]`, so every access stays inside the allocation.
+        let new_len = unsafe { ffi::Wildcard_RemoveEscape(str_, len) };
+        debug_assert!(new_len <= len, "escape removal must not lengthen the token");
+        self.tok.len = new_len;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
@@ -318,6 +318,151 @@ impl<'a> RSTokenRef<'a, true> {
     }
 }
 
+/// Safe, exclusive handle to an [`ffi::RSToken`] whose string may be rewritten in
+/// place.
+///
+/// This is the mutating counterpart to [`RSTokenRef`], and the two split a
+/// token's lifecycle between them: a shared handle's `'a` is a window in which no
+/// mutation can be expressed (see [its docs](RSTokenRef#why-the-accessors-are-safe)),
+/// and this handle is how a mutation is expressed outside every such window. It is
+/// deliberately **not** [`Copy`]: the rewrites below are
+/// [not idempotent](Self::remove_wildcard_escapes), and two handles to the same
+/// token, each able to apply one, is precisely the hazard the exclusive borrow
+/// rules out.
+///
+/// Unlike [`RSTokenRef`], this type carries no NUL-termination typestate. Every
+/// in-place rewrite shortens the string and re-terminates it at its new end, so
+/// all of them need the terminator — requiring it unconditionally at construction
+/// leaves one contract to satisfy instead of two.
+pub struct RSTokenMut<'a> {
+    tok: &'a mut ffi::RSToken,
+}
+
+/// A token too long to be rewritten in place, returned by
+/// [`RSTokenMut::remove_wildcard_escapes`].
+///
+/// The escape converter walks the string with `int` cursors, which a length past
+/// [`i32::MAX`] overflows into negative indices — reads and writes outside the
+/// allocation. Nothing upstream caps a token at that: a query parameter is bounded
+/// only by `proto-max-bulk-len`, which an operator may raise further. The length is
+/// therefore user-controlled, so the refusal has to be one a query can report
+/// rather than a panic reaching an `extern "C"` frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("token length {len} exceeds maximum {}", i32::MAX)]
+pub struct TokenTooLong {
+    /// The token's length, in bytes.
+    pub len: usize,
+}
+
+impl<'a> RSTokenMut<'a> {
+    /// Wrap a raw pointer to an [`ffi::RSToken`] for in-place rewriting.
+    ///
+    /// # Safety
+    ///
+    /// - `tok` must be non-null and point to a valid [`ffi::RSToken`] that stays
+    ///   allocated for the whole of the handle's `'a` lifetime.
+    /// - The handle must be the **only** way to reach the token for `'a`: no other
+    ///   handle, reference, or C-side pointer may read or write either the token
+    ///   or the bytes its `str_` addresses while it is live. `'a` must be chosen to
+    ///   make that true — in practice by deriving it from an exclusive borrow of
+    ///   whatever owns the token, such as a query node.
+    /// - A non-null `str_` must address `len` initialized bytes that are
+    ///   **writable**, and the allocation must extend one byte further: `str_[len]`
+    ///   must be readable and equal to `0`. A rewrite writes only within
+    ///   `str_[0..len]`; the extra byte is what it reads when an escape has nothing
+    ///   after it.
+    /// - A null `str_` implies `len == 0`, since a rewrite dereferences the string
+    ///   whenever `len` is non-zero.
+    pub unsafe fn from_nul_terminated_ffi(tok: *mut ffi::RSToken) -> Self {
+        debug_assert!(!tok.is_null(), "token pointer must not be null");
+        // SAFETY: the caller guarantees `tok` is non-null, points to a valid
+        // `RSToken`, and that nothing else reaches it for `'a`, which is what the
+        // exclusive reference asserts.
+        let tok = unsafe { &mut *tok };
+        // In debug builds, sanity-check the NUL-termination the caller promised.
+        #[cfg(debug_assertions)]
+        if !tok.str_.is_null() {
+            // SAFETY: the caller guarantees `str_` is a NUL-terminated string of
+            // content length `len`, so `str_.add(len)` is the in-bounds terminator
+            // address.
+            let terminator_ptr = unsafe { tok.str_.add(tok.len) };
+            // SAFETY: `terminator_ptr` addresses the in-bounds terminator byte.
+            let terminator = unsafe { *terminator_ptr };
+            assert!(terminator == 0, "token string must be NUL-terminated");
+        }
+        Self { tok }
+    }
+
+    /// Reborrow this handle as a shared, read-only [`RSTokenRef`].
+    ///
+    /// The result borrows `*self`, so the token cannot be rewritten while it — or
+    /// anything derived from it — is live. That is the no-mutation window
+    /// [`RSTokenRef`]'s accessors rest on, established here by the borrow checker
+    /// rather than by an `unsafe` assertion.
+    pub const fn as_ref(&self) -> RSTokenRefNulTerminated<'_> {
+        // SAFETY: the constructor's contract guarantees a valid, NUL-terminated
+        // token, and `&self` is what keeps it unmutated for the result's lifetime.
+        unsafe { RSTokenRef::from_nul_terminated_ffi(std::ptr::from_ref(self.tok)) }
+    }
+
+    /// Collapse `\x` escapes in this token's wildcard pattern, in place,
+    /// shortening its length to match.
+    ///
+    /// The pattern is unescaped in the token itself rather than in a copy because
+    /// the unescaped string is also what a query reports as the pattern it ran
+    /// when it is profiled — a copy would leave `w'a\*b'` profiling as `a\*b`.
+    ///
+    /// A token is binary data, not text, so the rewrite works on bytes. One
+    /// consequence is that an interior NUL ends the pattern, escape or no escape:
+    /// `a\0b` searches for `a`. Only a query parameter can carry such a token.
+    ///
+    /// Escape removal is single-level and destructive, which makes this method
+    /// **not idempotent**: it must be applied at most once per token — `a\\b`
+    /// becomes `a\b`, and applying it again would yield `ab`. The exclusive borrow
+    /// keeps two handles from each applying it, but not one handle from applying it
+    /// twice, so a token reachable from more than one evaluation path must be
+    /// unescaped by exactly one of them.
+    ///
+    /// # Errors
+    ///
+    /// [`TokenTooLong`] if the token is too long for the converter to address,
+    /// leaving it untouched. Checking the bound here rather than adding it to the
+    /// constructor's contract is what keeps a caller from reaching the overflow
+    /// without first passing a check.
+    pub fn remove_wildcard_escapes(&mut self) -> Result<(), TokenTooLong> {
+        let len = self.tok.len;
+
+        // Handed the empty token, the converter would write a terminator past the
+        // one-byte allocation an empty query parameter produces. It guards this
+        // itself, but guarding here too keeps this method's soundness off the far
+        // side of the FFI boundary — and makes a token carrying no string, which
+        // the constructor's contract makes an empty one, a no-op rather than a null
+        // dereference.
+        if len == 0 {
+            return Ok(());
+        }
+
+        // Checked before the string is touched, so a refused token is left exactly
+        // as it was.
+        if len > i32::MAX as usize {
+            return Err(TokenTooLong { len });
+        }
+
+        let str_ = self.tok.str_;
+        debug_assert!(!str_.is_null(), "a non-empty token always carries a string");
+
+        // SAFETY: per the constructor's contract, `str_` is writable for `len`
+        // bytes and readable one further, where the terminator sits. `len` is
+        // within the range the converter's `int` cursors address, as just checked.
+        // `Wildcard_RemoveEscape` reads at most that terminator and writes only
+        // within `str_[0..len]`, so every access stays inside the allocation.
+        let new_len = unsafe { ffi::Wildcard_RemoveEscape(str_, len) };
+        debug_assert!(new_len <= len, "escape removal must not lengthen the token");
+        self.tok.len = new_len;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/redisearch_rs/c_wrappers/rs_token/tests/tests.rs
+++ b/src/redisearch_rs/c_wrappers/rs_token/tests/tests.rs
@@ -11,7 +11,7 @@
 use std::ffi::c_char;
 
 use query_term::RSTokenFlags;
-use rs_token::RSTokenRef;
+use rs_token::{RSTokenMut, RSTokenRef, TokenTooLong};
 
 // Install the mock Redis allocator so the C `strToLowerRunes` can allocate, and
 // force the combined C bundle to be linked into the test binary.
@@ -227,6 +227,45 @@ fn handle_reflects_mutation_between_borrows() {
     assert_eq!(tok.as_bytes(), Some(&b"hel"[..]));
 }
 
+/// Back a token's string with a mutable, NUL-terminated buffer — the way the
+/// query parser does — apply `f` to an [`RSTokenMut`] over it, and report what the
+/// rewrite left behind.
+///
+/// `content` is the string *without* its terminator, so `len` is the content
+/// length and `str_[len]` is the terminator. Returns the token's resulting bytes
+/// alongside the whole backing buffer, so a caller can also inspect the byte past
+/// the token's new end.
+///
+/// The handle is confined to an inner scope: it is the only way to reach the token
+/// while it is live, and the buffer is read again only after it is dropped.
+fn rewrite(
+    content: &[u8],
+    f: impl FnOnce(&mut RSTokenMut) -> Result<(), TokenTooLong>,
+) -> (Vec<u8>, Vec<c_char>) {
+    let mut buf: Vec<c_char> = content
+        .iter()
+        .map(|&b| b as c_char)
+        .chain(std::iter::once(0))
+        .collect();
+    // SAFETY: `RSToken` is plain data whose all-zero bit pattern is a valid,
+    // empty token.
+    let mut raw: ffi::RSToken = unsafe { std::mem::zeroed() };
+    raw.str_ = buf.as_mut_ptr();
+    raw.len = content.len();
+    {
+        // SAFETY: `raw` is a valid token that outlives the handle, and its `str_`
+        // addresses `buf`'s `len` writable content bytes followed by the terminator
+        // at `str_[len]`. Nothing else reaches the token or the buffer for the
+        // handle's lifetime, which ends with this scope.
+        let mut tok = unsafe { RSTokenMut::from_nul_terminated_ffi(&raw mut raw) };
+        // None of these fixtures is anywhere near the length limit, so a refusal
+        // here would mean the bound check fired on a token it should not have.
+        f(&mut tok).expect("token is short enough to rewrite");
+    }
+    let bytes = buf[..raw.len].iter().map(|&c| c as u8).collect();
+    (bytes, buf)
+}
+
 /// A non-NUL-terminated string handed to [`RSTokenRef::from_nul_terminated_ffi`]
 /// trips the debug-only termination check. The check compiles out of release
 /// builds, so this test only runs when debug assertions are enabled.
@@ -246,4 +285,171 @@ fn non_nul_terminated_string_trips_debug_assert() {
     // is in bounds and readable, so the debug check's dereference is sound — it
     // observes the missing terminator and panics.
     let _ = unsafe { RSTokenRef::from_nul_terminated_ffi(&raw const raw) };
+}
+
+/// The same check on the mutating handle, which repeats it rather than sharing
+/// [`RSTokenRef`]'s: its constructor takes `*mut`, so it cannot go through the
+/// shared one to get it.
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "token string must be NUL-terminated")]
+fn non_nul_terminated_string_trips_debug_assert_on_mut_handle() {
+    // As above: `str_[len]` is `b'X'` — in bounds and readable, so the check's own
+    // dereference is sound, but non-zero, so the assertion fails.
+    let mut buf: Vec<c_char> = b"abcX".iter().map(|&b| b as c_char).collect();
+    // SAFETY: `RSToken` is plain data whose all-zero bit pattern is a valid,
+    // empty token.
+    let mut raw: ffi::RSToken = unsafe { std::mem::zeroed() };
+    raw.str_ = buf.as_mut_ptr();
+    raw.len = 3;
+    // SAFETY: `raw.str_`/`raw.len` describe a valid 3-byte writable range whose
+    // next byte is in bounds and readable, so the debug check's dereference is
+    // sound — it observes the missing terminator and panics. Nothing else reaches
+    // `raw` or `buf` for the handle's lifetime.
+    let _ = unsafe { RSTokenMut::from_nul_terminated_ffi(&raw mut raw) };
+}
+
+#[test]
+fn mut_handle_accepts_a_token_carrying_no_string() {
+    // A null `str_` is an empty token, per the constructor's contract: the
+    // termination check has nothing to inspect, the shared reborrow reports no
+    // string, and a rewrite is a no-op rather than a null dereference. The
+    // `rewrite` helper always allocates a buffer, so this shape is built by hand.
+    //
+    // No FFI is reached — `remove_wildcard_escapes` returns on the empty case
+    // before the converter — so this needs no `miri` exemption.
+    let mut raw = build_raw(None, 0);
+    {
+        // SAFETY: `raw` is a valid token that outlives the handle and carries no
+        // string, so `len` is zero as the contract requires. Nothing else reaches
+        // it for the handle's lifetime, which ends with this scope.
+        let mut tok = unsafe { RSTokenMut::from_nul_terminated_ffi(&raw mut raw) };
+        assert!(tok.as_ref().is_empty());
+        assert_eq!(tok.as_ref().as_bytes(), None);
+        assert_eq!(tok.as_ref().as_c_str(), None);
+        assert_eq!(tok.remove_wildcard_escapes(), Ok(()));
+        assert!(tok.as_ref().is_empty());
+    }
+    assert!(raw.str_.is_null(), "the token must be left untouched");
+    assert_eq!(raw.len, 0);
+}
+
+#[test]
+fn mut_handle_reads_through_as_ref() {
+    // The shared reborrow is how a rewrite's result is read back, so it must see
+    // the same string and length the handle holds.
+    let (_bytes, _buf) = rewrite(b"he?l*o", |tok| {
+        assert_eq!(tok.as_ref().len(), 6);
+        assert_eq!(tok.as_ref().as_bytes(), Some(&b"he?l*o"[..]));
+        assert_eq!(tok.as_ref().as_c_str(), Some(c"he?l*o"));
+        Ok(())
+    });
+}
+
+#[test]
+fn remove_wildcard_escapes_leaves_an_empty_token_alone() {
+    // An empty query parameter reaches the AST as a one-byte allocation holding
+    // only the terminator. The empty case returns before the converter is called
+    // at all, which is what keeps the write off the end of that single byte —
+    // hence no FFI here, and no reason to skip this under `miri`.
+    let (bytes, buf) = rewrite(b"", |tok| tok.remove_wildcard_escapes());
+    assert_eq!(bytes, b"");
+    assert_eq!(buf, vec![0 as c_char], "the buffer must be left untouched");
+}
+
+// These tests call the C `Wildcard_RemoveEscape`, so they cannot run under miri.
+#[cfg(not(miri))]
+mod remove_wildcard_escapes {
+    use super::*;
+
+    #[test]
+    fn collapses_escapes_in_place() {
+        // `w'a\*b\?c'` — the escaped `*` and `?` are literals, so both backslashes
+        // go and the token shortens by two.
+        let (bytes, buf) = rewrite(br"a\*b\?c", |tok| tok.remove_wildcard_escapes());
+        assert_eq!(bytes, b"a*b?c");
+        assert_eq!(
+            buf[bytes.len()],
+            0,
+            "the token must be re-terminated in place"
+        );
+    }
+
+    #[test]
+    fn leaves_an_unescaped_token_alone() {
+        let (bytes, _buf) = rewrite(b"he?l*o", |tok| tok.remove_wildcard_escapes());
+        assert_eq!(bytes, b"he?l*o");
+    }
+
+    #[test]
+    fn collapses_one_level_only() {
+        // `w'a\\b'` — the escaped backslash collapses to a single literal one, which
+        // is left as-is. Removal is single-level, so a second application would eat
+        // that backslash too; the token must only ever be unescaped once.
+        let (bytes, _buf) = rewrite(br"a\\b", |tok| tok.remove_wildcard_escapes());
+        assert_eq!(bytes, br"a\b");
+    }
+
+    #[test]
+    fn collapses_a_leading_escape() {
+        // The escape sits at the very start, so the copy begins at the token's first
+        // byte rather than partway through it.
+        let (bytes, _buf) = rewrite(br"\*abc", |tok| tok.remove_wildcard_escapes());
+        assert_eq!(bytes, b"*abc");
+    }
+
+    #[test]
+    fn collapses_a_token_that_is_all_escapes() {
+        // Every byte pair is an escape, so the token halves — the largest shrink a
+        // non-empty pattern can produce.
+        let (bytes, buf) = rewrite(br"\*\?", |tok| tok.remove_wildcard_escapes());
+        assert_eq!(bytes, b"*?");
+        assert_eq!(
+            buf[bytes.len()],
+            0,
+            "the token must be re-terminated in place"
+        );
+    }
+
+    #[test]
+    fn drops_a_trailing_backslash() {
+        // The escape has nothing after it, so the converter copies the terminator
+        // into its place and stops. This is the only shape that reads the byte past
+        // the token's content, which is why the buffer must stay NUL-terminated.
+        let (bytes, buf) = rewrite(b"abc\\", |tok| tok.remove_wildcard_escapes());
+        assert_eq!(bytes, b"abc");
+        assert_eq!(
+            buf[bytes.len()],
+            0,
+            "the token must be re-terminated in place"
+        );
+    }
+
+    #[test]
+    fn handles_a_non_utf8_token() {
+        // A pattern reaching the AST through a query parameter is binary data, so the
+        // rewrite has to work on bytes: `0xff` is not valid UTF-8 in any position.
+        let (bytes, _buf) = rewrite(b"a\\\xffb", |tok| tok.remove_wildcard_escapes());
+        assert_eq!(bytes, b"a\xffb");
+    }
+
+    #[test]
+    fn truncates_at_an_interior_nul() {
+        // An interior NUL ends the pattern even though there is no escape to collapse,
+        // so the token is cut there rather than kept whole.
+        let (bytes, _buf) = rewrite(b"a\0b", |tok| tok.remove_wildcard_escapes());
+        assert_eq!(bytes, b"a");
+    }
+
+    #[test]
+    fn shortened_token_still_reads_as_a_c_str() {
+        // The rewrite re-terminates at the new end, so a handle taken afterwards
+        // still yields a NUL-terminated string rather than running on into the
+        // bytes the collapse left stranded.
+        let (_bytes, _buf) = rewrite(br"a\*b\?c", |tok| {
+            tok.remove_wildcard_escapes()?;
+            assert_eq!(tok.as_ref().as_c_str(), Some(c"a*b?c"));
+            Ok(())
+        });
+    }
 }

--- a/src/redisearch_rs/c_wrappers/rs_token/tests/tests.rs
+++ b/src/redisearch_rs/c_wrappers/rs_token/tests/tests.rs
@@ -11,7 +11,7 @@
 use std::ffi::c_char;
 
 use query_term::RSTokenFlags;
-use rs_token::{RSTokenMut, RSTokenRef, TokenTooLong};
+use rs_token::{RSTokenMut, RSTokenRef};
 
 // Install the mock Redis allocator so the C `strToLowerRunes` can allocate, and
 // force the combined C bundle to be linked into the test binary.
@@ -238,10 +238,7 @@ fn handle_reflects_mutation_between_borrows() {
 ///
 /// The handle is confined to an inner scope: it is the only way to reach the token
 /// while it is live, and the buffer is read again only after it is dropped.
-fn rewrite(
-    content: &[u8],
-    f: impl FnOnce(&mut RSTokenMut) -> Result<(), TokenTooLong>,
-) -> (Vec<u8>, Vec<c_char>) {
+fn rewrite(content: &[u8], f: impl FnOnce(&mut RSTokenMut)) -> (Vec<u8>, Vec<c_char>) {
     let mut buf: Vec<c_char> = content
         .iter()
         .map(|&b| b as c_char)
@@ -258,9 +255,7 @@ fn rewrite(
         // at `str_[len]`. Nothing else reaches the token or the buffer for the
         // handle's lifetime, which ends with this scope.
         let mut tok = unsafe { RSTokenMut::from_nul_terminated_ffi(&raw mut raw) };
-        // None of these fixtures is anywhere near the length limit, so a refusal
-        // here would mean the bound check fired on a token it should not have.
-        f(&mut tok).expect("token is short enough to rewrite");
+        f(&mut tok);
     }
     let bytes = buf[..raw.len].iter().map(|&c| c as u8).collect();
     (bytes, buf)
@@ -316,8 +311,6 @@ fn mut_handle_accepts_a_token_carrying_no_string() {
     // string, and a rewrite is a no-op rather than a null dereference. The
     // `rewrite` helper always allocates a buffer, so this shape is built by hand.
     //
-    // No FFI is reached — `remove_wildcard_escapes` returns on the empty case
-    // before the converter — so this needs no `miri` exemption.
     let mut raw = build_raw(None, 0);
     {
         // SAFETY: `raw` is a valid token that outlives the handle and carries no
@@ -327,7 +320,7 @@ fn mut_handle_accepts_a_token_carrying_no_string() {
         assert!(tok.as_ref().is_empty());
         assert_eq!(tok.as_ref().as_bytes(), None);
         assert_eq!(tok.as_ref().as_c_str(), None);
-        assert_eq!(tok.remove_wildcard_escapes(), Ok(()));
+        tok.remove_wildcard_escapes();
         assert!(tok.as_ref().is_empty());
     }
     assert!(raw.str_.is_null(), "the token must be left untouched");
@@ -342,23 +335,19 @@ fn mut_handle_reads_through_as_ref() {
         assert_eq!(tok.as_ref().len(), 6);
         assert_eq!(tok.as_ref().as_bytes(), Some(&b"he?l*o"[..]));
         assert_eq!(tok.as_ref().as_c_str(), Some(c"he?l*o"));
-        Ok(())
     });
 }
 
 #[test]
 fn remove_wildcard_escapes_leaves_an_empty_token_alone() {
     // An empty query parameter reaches the AST as a one-byte allocation holding
-    // only the terminator. The empty case returns before the converter is called
-    // at all, which is what keeps the write off the end of that single byte —
-    // hence no FFI here, and no reason to skip this under `miri`.
+    // only the terminator. The empty case returns before the string is touched at
+    // all, which is what keeps the write off the end of that single byte.
     let (bytes, buf) = rewrite(b"", |tok| tok.remove_wildcard_escapes());
     assert_eq!(bytes, b"");
     assert_eq!(buf, vec![0 as c_char], "the buffer must be left untouched");
 }
 
-// These tests call the C `Wildcard_RemoveEscape`, so they cannot run under miri.
-#[cfg(not(miri))]
 mod remove_wildcard_escapes {
     use super::*;
 
@@ -447,9 +436,8 @@ mod remove_wildcard_escapes {
         // still yields a NUL-terminated string rather than running on into the
         // bytes the collapse left stranded.
         let (_bytes, _buf) = rewrite(br"a\*b\?c", |tok| {
-            tok.remove_wildcard_escapes()?;
+            tok.remove_wildcard_escapes();
             assert_eq!(tok.as_ref().as_c_str(), Some(c"a*b?c"));
-            Ok(())
         });
     }
 }

--- a/src/redisearch_rs/headers/query_eval_ffi.h
+++ b/src/redisearch_rs/headers/query_eval_ffi.h
@@ -46,7 +46,9 @@ extern "C" {
  *
  * 1. `qast` must be a non-null pointer to a valid [`QueryAST`] whose `root` is
  *    a valid [`RSQueryNode`]; it (and its `metricRequests`/`config` fields)
- *    must stay valid and exclusively borrowed for the duration of the call.
+ *    must stay valid and exclusively borrowed for the duration of the call. The
+ *    root's subtree must meet the token-buffer requirement of
+ *    [`Query_EvalNode_Rs`]'s precondition 2, for the same reason.
  * 2. `opts` must be a non-null pointer to a valid [`RSSearchOptions`].
  * 3. `sctx` must be a non-null pointer to a valid [`RedisSearchCtx`] whose
  *    `spec` is a valid, non-null [`IndexSpec`](ffi::IndexSpec).
@@ -71,7 +73,12 @@ QueryIterator *QAST_Iterate(QueryAST *qast, const RSSearchOptions *opts, RedisSe
  * 1. `q` must be a non-null pointer to a valid [`QueryEvalCtx`] that satisfies
  *    all the invariants documented on [`QueryEvalContext::new`] and remains
  *    valid for the lifetime of the returned iterator.
- * 2. `n` must be a non-null pointer to a valid [`RSQueryNode`].
+ * 2. `n` must be a non-null pointer to a valid [`RSQueryNode`]. Evaluation
+ *    rewrites some tokens in place, so every node in the subtree that carries a
+ *    rewritable one — see [`QueryNodeMut::token_mut`] — must additionally satisfy
+ *    invariant (4) of [`QueryNodeMut::new`]. A parser-produced AST does; one
+ *    assembled by hand, with a token borrowing a read-only or length-delimited
+ *    string, does not.
  * 3. `eval_config` must be a non-null [`EvalConfig`](ffi::EvalConfig) handle
  *    pointing to a valid [`Config`] that stays valid for the duration of the
  *    call — the snapshot [`QAST_Iterate`] loaded and threaded through the C

--- a/src/redisearch_rs/headers/query_eval_ffi.h
+++ b/src/redisearch_rs/headers/query_eval_ffi.h
@@ -69,7 +69,12 @@ bool queryNeedsOffsets(const char *scorer_name, const struct QueryNodeOptions *o
  * 1. `q` must be a non-null pointer to a valid [`QueryEvalCtx`] that satisfies
  *    all the invariants documented on [`QueryEvalContext::new`] and remains
  *    valid for the lifetime of the returned iterator.
- * 2. `n` must be a non-null pointer to a valid [`RSQueryNode`].
+ * 2. `n` must be a non-null pointer to a valid [`RSQueryNode`]. Evaluation
+ *    rewrites some tokens in place, so every node in the subtree that carries a
+ *    rewritable one — see [`QueryNodeMut::token_mut`] — must additionally satisfy
+ *    invariant (4) of [`QueryNodeMut::new`]. A parser-produced AST does; one
+ *    assembled by hand, with a token borrowing a read-only or length-delimited
+ *    string, does not.
  * 3. `eval_config` must be a non-null [`EvalConfig`](ffi::EvalConfig) handle
  *    pointing to a valid [`Config`] that stays valid for the duration of the
  *    call — the snapshot [`QAST_Iterate`] loaded and threaded through the C
@@ -89,7 +94,9 @@ QueryIterator *Query_EvalNode_Rs(QueryEvalCtx *q, RSQueryNode *n, const EvalConf
  *
  * 1. `qast` must be a non-null pointer to a valid [`QueryAST`] whose `root` is
  *    a valid [`RSQueryNode`]; it (and its `metricRequests`/`config` fields)
- *    must stay valid and exclusively borrowed for the duration of the call.
+ *    must stay valid and exclusively borrowed for the duration of the call. The
+ *    root's subtree must meet the token-buffer requirement of
+ *    [`Query_EvalNode_Rs`]'s precondition 2, for the same reason.
  * 2. `opts` must be a non-null pointer to a valid [`RSSearchOptions`].
  * 3. `sctx` must be a non-null pointer to a valid [`RedisSearchCtx`] whose
  *    `spec` is a valid, non-null [`IndexSpec`](ffi::IndexSpec).

--- a/src/redisearch_rs/query_eval/tests/integration/prefix.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/prefix.rs
@@ -19,14 +19,11 @@
 //! cannot execute.
 #![cfg(not(miri))]
 
-use std::ffi::CString;
-
 use index_result::{RSIndexResult, RSOffsetSlice};
-use query::mock::MockQueryNode;
+use query::mock::{MockQueryNode, TokenNodeType};
 use query_error::QueryErrorCode;
 use query_eval::{Config, EvalResult, QueryEvalContext, QueryNodeMut, eval_node};
 use query_term::RSQueryTerm;
-use query_types::QueryNodeType;
 use rqe_core::{FieldMask, RS_FIELDMASK_ALL};
 use rqe_iterators::{IteratorType, RQEIterator};
 use rqe_iterators_test_utils::{GlobalGuard, TestContext};
@@ -138,9 +135,6 @@ struct PrefixFixture {
     /// prefix-expansion knobs ([`Config::max_prefix_expansions`],
     /// [`Config::min_term_prefix`], ...).
     config: Config,
-    /// Backs the token's string pointer in [`node`](Self::node), which borrows
-    /// it as a raw pointer; must outlive it.
-    _token: CString,
 }
 
 impl PrefixFixture {
@@ -194,11 +188,9 @@ impl PrefixFixture {
         // exclusively owned by this fixture.
         let ctx = unsafe { QueryEvalContext::new(qctx) };
 
-        let token = CString::new(token).expect("token must not contain a NUL byte");
-        let mut node = MockQueryNode::new(QueryNodeType::Prefix);
+        let mut node = MockQueryNode::with_token(TokenNodeType::Prefix, token);
         node.opts_mut().weight = opts.weight;
         node.opts_mut().field_mask = opts.field_mask;
-        node.set_token(token.as_ptr().cast_mut(), token.as_bytes().len());
         node.set_prefix_mode(prefix, suffix);
 
         Self {
@@ -207,7 +199,6 @@ impl PrefixFixture {
             ctx,
             node,
             config,
-            _token: token,
         }
     }
 

--- a/src/redisearch_rs/query_eval/tests/integration/token.rs
+++ b/src/redisearch_rs/query_eval/tests/integration/token.rs
@@ -17,17 +17,14 @@
 //! cannot execute.
 #![cfg(not(miri))]
 
-use std::ffi::CString;
-
 use ffi::{
     IndexFlags_Index_StoreByteOffsets, IndexFlags_Index_StoreFieldFlags,
     IndexFlags_Index_StoreFreqs, IndexFlags_Index_StoreTermOffsets,
 };
 use index_result::{RSIndexResult, RSOffsetSlice};
-use query::mock::MockQueryNode;
+use query::mock::{MockQueryNode, TokenNodeType};
 use query_eval::{Config, EvalResult, QueryEvalContext, QueryNodeMut, eval_node};
 use query_term::RSQueryTerm;
-use query_types::QueryNodeType;
 use rqe_core::{FieldMask, RS_FIELDMASK_ALL};
 use rqe_iterators::{IteratorType, RQEIterator};
 use rqe_iterators_test_utils::{GlobalGuard, TestContext};
@@ -38,15 +35,14 @@ use rqe_iterators_test_utils::{GlobalGuard, TestContext};
 const INDEXED_TERM: &str = "term";
 
 /// Owns everything a `QN_TOKEN` evaluation borrows — the FFI `TestContext`, the
-/// [`QueryEvalContext`], the node, and the token's backing string — so
-/// [`eval`](Self::eval) can hand the evaluated iterator back to the caller.
+/// [`QueryEvalContext`], and the node, which owns the token's backing string in
+/// turn — so [`eval`](Self::eval) can hand the evaluated iterator back to the
+/// caller.
 struct TokenFixture {
     _guard: GlobalGuard,
     _context: TestContext,
     ctx: QueryEvalContext,
     node: MockQueryNode,
-    // Backs the token's `str`/`len` pointer; must outlive `node`.
-    _token: CString,
 }
 
 impl TokenFixture {
@@ -92,18 +88,15 @@ impl TokenFixture {
         // exclusively owned by this fixture.
         let ctx = unsafe { QueryEvalContext::new(qctx) };
 
-        let token = CString::new(token).expect("token must not contain a NUL byte");
-        let mut node = MockQueryNode::new(QueryNodeType::Token);
+        let mut node = MockQueryNode::with_token(TokenNodeType::Token, token);
         node.opts_mut().weight = 1.0;
         node.opts_mut().field_mask = RS_FIELDMASK_ALL;
-        node.set_token(token.as_ptr().cast_mut(), token.as_bytes().len());
 
         Self {
             _guard,
             _context: context,
             ctx,
             node,
-            _token: token,
         }
     }
 

--- a/src/redisearch_rs/rqe_wildcard/src/lib.rs
+++ b/src/redisearch_rs/rqe_wildcard/src/lib.rs
@@ -14,8 +14,6 @@
 //! You can create a [`WildcardPattern`] from a pattern using [`WildcardPattern::parse`] and
 //! then rely on [`WildcardPattern::matches`] to determine if a string matches the pattern.
 
-use std::borrow::Cow;
-
 use memchr::arch::all::is_prefix;
 
 mod fmt;
@@ -361,33 +359,81 @@ impl<'pattern> WildcardPattern<'pattern> {
     }
 }
 
-/// Remove backslash escape sequences from a wildcard pattern.
+/// The index [`remove_escape_in_place`] starts rewriting at, or [`None`] when the
+/// pattern needs no rewriting at all.
 ///
-/// Returns [`Cow::Borrowed`] when no escapes are present (zero-copy fast
-/// path), or [`Cow::Owned`] with escapes removed.
-pub fn remove_escape(s: &str) -> Cow<'_, str> {
-    let bytes = s.as_bytes();
-    let Some(first_escape) = bytes.iter().position(|&b| b == b'\\') else {
-        return Cow::Borrowed(s);
+/// Nothing before the first escape moves, so that is where a rewrite begins — and
+/// a NUL ends the pattern, so that is where one begins too. The asymmetry is that
+/// a NUL only counts from index 1 onwards: this scan tests it as a
+/// continue-condition *after* advancing, so a pattern that starts with one is
+/// carried past it and keeps it. That is inherited from the C original, whose
+/// `do { … } while (++i < len && str[i] != '\0')` has the same shape, and it is
+/// only reachable through a query parameter.
+///
+/// Empty patterns are the caller's business; this indexes byte 0 unconditionally.
+fn rewrite_start(pattern: &[u8]) -> Option<usize> {
+    let mut i = 0;
+    loop {
+        if pattern[i] == b'\\' {
+            return Some(i);
+        }
+        i += 1;
+        if i == pattern.len() {
+            return None;
+        }
+        if pattern[i] == 0 {
+            return Some(i);
+        }
+    }
+}
+
+/// Collapse backslash escape sequences in a wildcard pattern, in place,
+/// returning the unescaped length.
+///
+/// Removal is **single-level and destructive**: `a\\b` becomes `a\b`, and
+/// applying this again would yield `ab`. Apply it at most once per pattern.
+///
+/// A NUL byte ends the pattern, escaped or not, so `a\0b` unescapes to `a` — with
+/// the one exception [`rewrite_start`] describes. That the pattern ends there at
+/// all is a consequence of working on what is ultimately a C string: a query token
+/// carries an explicit length, but everything downstream of the unescaping reads
+/// it up to its terminator.
+///
+/// A shortened pattern is re-terminated at its new end, so the result reads as a
+/// C string without the caller writing anything. A pattern that did not shorten is
+/// returned untouched: its end is where it always was, and the byte after it lies
+/// outside `pattern` — so a caller wanting a C string in that case needs its buffer
+/// to have been terminated already. Bytes beyond the terminator are unspecified
+/// scratch.
+pub fn remove_escape_in_place(pattern: &mut [u8]) -> usize {
+    if pattern.is_empty() {
+        return 0;
+    }
+    let Some(mut read) = rewrite_start(pattern) else {
+        return pattern.len();
     };
 
-    let mut result = Vec::with_capacity(bytes.len() - 1);
-    result.extend_from_slice(&bytes[..first_escape]);
-
-    let mut read = first_escape;
-    while read < bytes.len() {
-        if bytes[read] == b'\\' {
+    let mut write = read;
+    while read < pattern.len() {
+        if pattern[read] == b'\\' {
             read += 1;
-            if read >= bytes.len() {
+            // A trailing backslash escapes nothing: the pattern ends before it.
+            if read == pattern.len() {
                 break;
             }
         }
-        result.push(bytes[read]);
+        if pattern[read] == 0 {
+            break;
+        }
+        pattern[write] = pattern[read];
         read += 1;
+        write += 1;
     }
 
-    // SAFETY: removing `\` (0x5C, a single-byte ASCII character) before
-    // another byte cannot break a multi-byte UTF-8 sequence, so the
-    // output is valid UTF-8 whenever the input is.
-    Cow::Owned(String::from_utf8(result).expect("invalid UTF-8 in wildcard pattern"))
+    // In bounds because reaching here means the pattern shortened: every way out
+    // of the loop above consumes at least one byte more than it emits, and the
+    // unshortened case returned before it.
+    pattern[write] = 0;
+
+    write
 }

--- a/src/redisearch_rs/rqe_wildcard/tests/integration/remove_escape.rs
+++ b/src/redisearch_rs/rqe_wildcard/tests/integration/remove_escape.rs
@@ -7,110 +7,188 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::borrow::Cow;
+use rqe_wildcard::remove_escape_in_place;
 
-use rqe_wildcard::remove_escape;
+/// Unescape `pattern` in place and return the prefix the new length covers.
+///
+/// The bytes past that length are the terminator and then scratch, so a caller
+/// only ever looks at the prefix — and so does this. [`terminates_a_shortened_pattern`]
+/// covers the terminator separately.
+fn unescape(pattern: &[u8]) -> Vec<u8> {
+    let mut buf = pattern.to_vec();
+    let len = remove_escape_in_place(&mut buf);
+    buf.truncate(len);
+    buf
+}
+
+#[test]
+fn terminates_a_shortened_pattern() {
+    // Shortening frees the byte the terminator goes in, so the result reads as a
+    // C string with nothing more from the caller.
+    for pattern in [&br"a\*b"[..], br"abc\", b"a\0b", br"\\"] {
+        let mut buf = pattern.to_vec();
+        let len = remove_escape_in_place(&mut buf);
+        assert!(len < pattern.len(), "{pattern:?} should have shortened");
+        assert_eq!(buf[len], 0, "{pattern:?} must be terminated at its new end");
+    }
+}
+
+#[test]
+fn leaves_an_unshortened_pattern_untouched() {
+    // Nothing to re-terminate, and nowhere to do it: the byte after the pattern is
+    // past the end of the slice. The buffer must come back exactly as it went in.
+    for pattern in [&b"abc"[..], b"\0a", b"a?b*c"] {
+        let mut buf = pattern.to_vec();
+        let len = remove_escape_in_place(&mut buf);
+        assert_eq!(len, pattern.len(), "{pattern:?} should not have shortened");
+        assert_eq!(buf, pattern, "{pattern:?} must be left alone");
+    }
+}
+
+#[test]
+fn empty_pattern_is_left_alone() {
+    assert_eq!(unescape(b""), b"");
+}
 
 #[test]
 fn no_escapes() {
-    let result = remove_escape("foo");
-    assert!(matches!(result, Cow::Borrowed(_)));
-    assert_eq!(result, "foo");
+    assert_eq!(unescape(b"foo"), b"foo");
 }
 
-#[test]
-fn empty() {
-    let result = remove_escape("");
-    assert!(matches!(result, Cow::Borrowed(_)));
-    assert_eq!(result, "");
-}
-
-// ── beginning of string ──
+// ── beginning of pattern ──
 
 #[test]
 fn escape_at_beginning() {
-    assert_eq!(remove_escape("\\foo"), "foo");
+    assert_eq!(unescape(br"\foo"), b"foo");
 }
 
 #[test]
 fn double_escape_at_beginning() {
-    assert_eq!(remove_escape("\\\\foo"), "\\foo");
+    assert_eq!(unescape(br"\\foo"), br"\foo");
 }
 
 #[test]
 fn escaped_quote_at_beginning() {
-    assert_eq!(remove_escape("\\'foo"), "'foo");
+    assert_eq!(unescape(br"\'foo"), b"'foo");
 }
 
 #[test]
 fn double_escaped_quote_at_beginning() {
     // \\' → escaped backslash + literal quote
-    assert_eq!(remove_escape("\\\\'foo"), "\\'foo");
+    assert_eq!(unescape(br"\\'foo"), br"\'foo");
 }
 
-// ── mid string ──
+// ── mid pattern ──
 
 #[test]
 fn escape_mid() {
-    assert_eq!(remove_escape("f\\oo"), "foo");
+    assert_eq!(unescape(br"f\oo"), b"foo");
 }
 
 #[test]
 fn double_escape_mid() {
-    assert_eq!(remove_escape("f\\\\oo"), "f\\oo");
+    assert_eq!(unescape(br"f\\oo"), br"f\oo");
 }
 
 #[test]
 fn escaped_quote_mid() {
-    assert_eq!(remove_escape("f\\'oo"), "f'oo");
+    assert_eq!(unescape(br"f\'oo"), b"f'oo");
 }
 
 #[test]
 fn double_escaped_quote_mid() {
-    assert_eq!(remove_escape("f\\\\'oo"), "f\\'oo");
+    assert_eq!(unescape(br"f\\'oo"), br"f\'oo");
 }
 
-// ── end of string ──
+// ── end of pattern ──
 
 #[test]
 fn escape_at_end() {
-    assert_eq!(remove_escape("foo\\"), "foo");
+    assert_eq!(unescape(br"foo\"), b"foo");
 }
 
 #[test]
 fn double_escape_at_end() {
-    assert_eq!(remove_escape("foo\\\\"), "foo\\");
+    assert_eq!(unescape(br"foo\\"), br"foo\");
 }
 
 #[test]
 fn escaped_quote_at_end() {
-    assert_eq!(remove_escape("foo\\'"), "foo'");
+    assert_eq!(unescape(br"foo\'"), b"foo'");
 }
 
 #[test]
 fn double_escaped_quote_at_end() {
-    assert_eq!(remove_escape("foo\\\\'"), "foo\\'");
+    assert_eq!(unescape(br"foo\\'"), br"foo\'");
 }
 
 // ── extra edge cases ──
 
 #[test]
 fn consecutive_escapes() {
-    assert_eq!(remove_escape("\\a\\b\\c"), "abc");
+    assert_eq!(unescape(br"\a\b\c"), b"abc");
 }
 
 #[test]
 fn only_backslashes() {
     // \\ → second \, then trailing \ is dropped
-    assert_eq!(remove_escape("\\\\\\"), "\\");
+    assert_eq!(unescape(br"\\\"), br"\");
 }
 
-// ── remove_escape vs ffi::Wildcard_RemoveEscape ────────
+#[test]
+fn collapses_wildcard_escapes() {
+    assert_eq!(unescape(br"a\*b\?c"), b"a*b?c");
+}
+
+#[test]
+fn collapses_one_level_only() {
+    // A second application would eat the surviving backslash, which is why the
+    // routine must be applied at most once per pattern.
+    assert_eq!(unescape(br"a\\b"), br"a\b");
+}
+
+#[test]
+fn handles_a_non_utf8_pattern() {
+    // A pattern reaching the AST through a query parameter is binary data, so the
+    // routine works on bytes: `0xff` is not valid UTF-8 in any position.
+    assert_eq!(unescape(b"a\\\xffb"), b"a\xffb");
+}
+
+// ── NUL handling ──
+
+#[test]
+fn ends_the_pattern_at_a_nul() {
+    // Everything downstream reads the unescaped pattern up to its terminator, so
+    // an interior NUL ends it — even with no escape anywhere to trigger a rewrite.
+    assert_eq!(unescape(b"a\0b"), b"a");
+    assert_eq!(unescape(b"abc"), b"abc");
+}
+
+#[test]
+fn ends_the_pattern_at_an_escaped_nul() {
+    // Escaping does not rescue a NUL: it is still where the pattern stops.
+    assert_eq!(unescape(b"a\\\0b"), b"a");
+}
+
+#[test]
+fn keeps_a_leading_nul() {
+    // The exception: the scan only notices a NUL from index 1 onwards, so one at
+    // index 0 does not end the pattern. It survives a later rewrite too, since the
+    // copy starts at the escape that triggered it.
+    assert_eq!(unescape(b"\0"), b"\0");
+    assert_eq!(unescape(b"\0a"), b"\0a");
+    assert_eq!(unescape(b"\0a\\b"), b"\0ab");
+    // A second NUL is at index 1, so it ends the pattern as usual.
+    assert_eq!(unescape(b"\0\0a"), b"\0");
+}
+
+// ── remove_escape_in_place vs ffi::Wildcard_RemoveEscape ────────
 
 #[cfg(not(miri))]
 mod ffi_comparison {
     use proptest::prelude::*;
-    use rqe_wildcard::remove_escape;
+
+    use super::unescape;
 
     fn c_wildcard_remove_escape(input: &[u8]) -> Vec<u8> {
         let mut buf = input.to_vec();
@@ -122,110 +200,122 @@ mod ffi_comparison {
         buf
     }
 
-    fn assert_matches_c(input: &str) {
-        let c_result = c_wildcard_remove_escape(input.as_bytes());
-        let rust_result = remove_escape(input);
+    fn assert_matches_c(input: &[u8]) {
+        let c_result = c_wildcard_remove_escape(input);
+        let rust_result = unescape(input);
         assert_eq!(
-            rust_result.as_bytes(),
-            c_result.as_slice(),
-            "mismatch for input {:?}: rust={:?}, c={:?}",
-            input,
-            rust_result,
-            String::from_utf8_lossy(&c_result),
+            rust_result, c_result,
+            "mismatch for input {input:?}: rust={rust_result:?}, c={c_result:?}",
         );
     }
 
     #[test]
     fn ffi_no_escapes() {
-        assert_matches_c("foo");
+        assert_matches_c(b"foo");
     }
 
     #[test]
     fn ffi_empty() {
-        assert_matches_c("");
+        assert_matches_c(b"");
     }
 
     #[test]
     fn ffi_escape_at_beginning() {
-        assert_matches_c("\\foo");
+        assert_matches_c(br"\foo");
     }
 
     #[test]
     fn ffi_double_escape_at_beginning() {
-        assert_matches_c("\\\\foo");
+        assert_matches_c(br"\\foo");
     }
 
     #[test]
     fn ffi_escaped_quote_at_beginning() {
-        assert_matches_c("\\'foo");
+        assert_matches_c(br"\'foo");
     }
 
     #[test]
     fn ffi_double_escaped_quote_at_beginning() {
-        assert_matches_c("\\\\'foo");
+        assert_matches_c(br"\\'foo");
     }
 
     #[test]
     fn ffi_escape_mid() {
-        assert_matches_c("f\\oo");
+        assert_matches_c(br"f\oo");
     }
 
     #[test]
     fn ffi_double_escape_mid() {
-        assert_matches_c("f\\\\oo");
+        assert_matches_c(br"f\\oo");
     }
 
     #[test]
     fn ffi_escaped_quote_mid() {
-        assert_matches_c("f\\'oo");
+        assert_matches_c(br"f\'oo");
     }
 
     #[test]
     fn ffi_double_escaped_quote_mid() {
-        assert_matches_c("f\\\\'oo");
+        assert_matches_c(br"f\\'oo");
     }
 
     #[test]
     fn ffi_escape_at_end() {
-        assert_matches_c("foo\\");
+        assert_matches_c(br"foo\");
     }
 
     #[test]
     fn ffi_double_escape_at_end() {
-        assert_matches_c("foo\\\\");
+        assert_matches_c(br"foo\\");
     }
 
     #[test]
     fn ffi_escaped_quote_at_end() {
-        assert_matches_c("foo\\'");
+        assert_matches_c(br"foo\'");
     }
 
     #[test]
     fn ffi_double_escaped_quote_at_end() {
-        assert_matches_c("foo\\\\'");
+        assert_matches_c(br"foo\\'");
     }
 
     #[test]
     fn ffi_consecutive_escapes() {
-        assert_matches_c("\\a\\b\\c");
+        assert_matches_c(br"\a\b\c");
     }
 
     #[test]
     fn ffi_only_backslashes() {
-        assert_matches_c("\\\\\\");
+        assert_matches_c(br"\\\");
     }
 
-    fn wildcard_str() -> impl Strategy<Value = String> {
+    #[test]
+    fn ffi_nul_ends_the_pattern() {
+        assert_matches_c(b"a\0b");
+    }
+
+    #[test]
+    fn ffi_leading_nul_is_kept() {
+        assert_matches_c(b"\0a\\b");
+    }
+
+    /// Weighted toward the bytes that drive the branches: the escape, the NUL that
+    /// ends a pattern, and a byte that is not valid UTF-8 anywhere. Every other
+    /// byte is opaque to the routine, so one printable range stands in for them
+    /// all. Both special bytes are reachable through a query parameter.
+    fn wildcard_bytes() -> impl Strategy<Value = Vec<u8>> {
         let byte = prop_oneof![
             3 => Just(b'\\'),
-            7 => 0x20..=0x7Eu8,
+            1 => Just(0u8),
+            1 => Just(0xffu8),
+            5 => 0x20..=0x7Eu8,
         ];
-        proptest::collection::vec(byte, 1..128).prop_map(|v| String::from_utf8(v).unwrap())
+        proptest::collection::vec(byte, 1..128)
     }
 
     proptest! {
         #[test]
-        fn ffi_matches_rust(input in wildcard_str()) {
+        fn ffi_matches_rust(input in wildcard_bytes()) {
             assert_matches_c(&input);
         }
     }


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current.** A `QN_WILDCARD_QUERY` node reaches the AST with its pattern still
   escaped: `w'a\*b'` carries the token `a\*b`, where the backslash marks the `*`
   as a literal rather than a wildcard. `RSTokenRef`, the only handle the Rust
   wrappers have on a token, is shared, `Copy` and read-only — its whole safety
   argument is that its lifetime is a window in which no mutation of the token can
   be expressed — so nothing can collapse those escapes, and the pattern cannot be
   handed to the trie walks.

2. **Change.** Add **`RSTokenMut`**, the mutating counterpart, and hand it out from
   `QueryNodeMut::wildcard_token_mut`.

   A mutating method cannot live on `RSTokenRef`: two copies of a `Copy` handle
   could each apply one, and the rewrites are destructive and single-level, so
   applying one twice is not the same as applying it once. `RSTokenMut` expresses a
   mutation *outside* every such window — it holds an exclusive borrow, is
   deliberately not `Copy`, and reborrows as an `RSTokenRef` for reading, so the
   no-mutation window the shared accessors rest on is established by the borrow
   checker rather than by another `unsafe` assertion.

   It carries **no NUL-termination typestate**, unlike `RSTokenRef`. Every in-place
   rewrite shortens the string and re-terminates it at its new end, so all of them
   need the terminator; requiring it unconditionally at construction leaves one
   contract to satisfy instead of two. That contract is also where the
   **writability** requirement belongs — it is a property of the token buffer, not
   of whatever structure points at it.

   The first rewrite is `remove_wildcard_escapes`. It lands **in the token rather
   than in a copy** because the unescaped string is also what a query reports as
   the pattern it ran when profiled — a copy would leave `w'a\*b'` profiling as
   `a\*b`.

   An **empty token** returns before the string is inspected at all. That keeps the
   write off the end of the one-byte allocation an empty query parameter produces,
   and leaves a token that carries no string a no-op rather than a debug-build
   panic.

   A token longer than **`INT_MAX`** is refused with a `TokenTooLong` **error**,
   leaving it untouched. The converter walks the string with `int` cursors, which
   such a length overflows into negative indices — reads and writes outside the
   allocation. Nothing on the way there caps a token: a query parameter is bounded
   only by `proto-max-bulk-len`, which an operator may raise past `INT_MAX`.

   The bound is checked in the safe method rather than added to the constructor's
   contract, because a caller holding a parameter-derived token has no way to
   discharge such an obligation — leaving it there would relabel the overflow
   rather than close it. It is an error rather than a panic for the same reason the
   length is worth checking at all: it is user-controlled, and this runs under an
   `extern "C"` evaluator, where a panic aborts the server instead of failing the
   query.

   `QueryNodeMut::token_mut` is how a node hands one out. The **prefix, fuzzy and
   wildcard-query** payloads each begin with a token, and this is the accessor for
   all three: their rewrites are the same operations on the same field, so gating
   one method on three discriminants keeps a caller from having to know which
   payload struct it is reading through. A **token node** is deliberately not among
   them, even though its payload *is* a token — an expanded one may borrow a
   length-delimited string from `ExpandToken`, which is neither NUL-terminated nor
   writable, and that is the same reason `QueryNode::Token` alone carries a
   non-NUL-terminated `RSTokenRef`.

   It returns **`None`** rather than panicking on the other node types, which keeps
   the discriminant checked exactly once: a caller matches the result instead of
   asserting the type in the accessor and re-testing it on the way to reading the
   token back. The check itself is not optional — the payload is a union, so
   handing out a token from a variant that carries none would reinterpret unrelated
   bytes as one, and it has to live on the node because a token pointer carries no
   evidence of which variant produced it. Everything else the handle needs comes
   from the borrow of the node.

   Since the write reaches a buffer the node only points at, the exclusivity
   `QueryNodeMut::new` demands now covers a token's separately allocated string
   too, and it additionally requires that string to be writable for `len + 1` bytes
   with a terminator at `len`. Both shapes the parser produces satisfy that: a
   query literal is copied into an explicitly terminated allocation, and a query
   parameter into a zeroed one a byte longer than its value.

   Two properties of the rewrite are **documented and pinned by tests** rather than
   left to be rediscovered: it is single-level and destructive, so it is *not
   idempotent* and must be applied at most once per token (`a\\b` → `a\b`, and
   again → `ab`); and it works on bytes, so a token is truncated at an interior NUL
   whether or not it holds an escape, and need not be valid UTF-8.

3. **Outcome.** The unescaped pattern becomes available to the upcoming
   `QN_WILDCARD_QUERY` evaluator. Nothing calls the method yet, so there is no
   runtime behavior change in this PR.

#### Which additional issues this PR fixes
1. MOD-14885

#### Main objects this PR modified
1. `RSTokenMut` — new: exclusive token handle, `from_nul_terminated_ffi`, `as_ref`,
   `remove_wildcard_escapes`
2. `TokenTooLong` — new: the error `remove_wildcard_escapes` returns for a token
   past `INT_MAX`
3. `QueryNodeMut::token_mut` — new: hands out an `RSTokenMut` for a prefix, fuzzy
   or wildcard-query node, `None` otherwise
4. `QueryNodeMut::new` — safety contract extended to a token's backing buffer, and
   to that buffer being writable and NUL-terminated through `len + 1`
5. `MockQueryNode::set_token` — documented as applying to the prefix, fuzzy and
   verbatim payloads too, and as insufficient on its own for a node wrapped in a
   `QueryNodeMut`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
