### PR TITLE
build: exclude no-op lib test/bench targets that fail to link

### DIFF
--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/Cargo.toml
@@ -6,8 +6,6 @@ license-file.workspace = true
 publish.workspace = true
 
 [lib]
-# This crate has no lib tests nor benches (its tests live in `tests/`).
-# Compiling a no-op bench/test binary can cause linking issues with C.
 test = false
 bench = false
 

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+# This crate has no lib tests nor benches (its tests live in `tests/`).
+# Compiling a no-op bench/test binary can cause linking issues with C.
+test = false
+bench = false
+
 [lints]
 workspace = true
 

--- a/src/redisearch_rs/search_result/Cargo.toml
+++ b/src/redisearch_rs/search_result/Cargo.toml
@@ -6,7 +6,6 @@ license-file.workspace = true
 publish.workspace = true
 
 [lib]
-# Compiling a no-op bench/test binary can cause linking issues with C.
 test = false
 bench = false
 

--- a/src/redisearch_rs/search_result/Cargo.toml
+++ b/src/redisearch_rs/search_result/Cargo.toml
@@ -6,7 +6,9 @@ license-file.workspace = true
 publish.workspace = true
 
 [lib]
+# Compiling a no-op bench/test binary can cause linking issues with C.
 test = false
+bench = false
 
 [dependencies]
 ffi.workspace = true


### PR DESCRIPTION
## Describe the changes in the pull request

`cargo bench --workspace` — the command the **Trigger Rust Micro Benchmarks** CI job runs
(`.github/workflows/flow-rust-micro-benchmarks.yml`) — fails to link, so the job never
produces benchmark numbers.

1. **Current:** two crates get a lib test/bench harness built that cannot link:

   ```
   rust-lld: error: undefined symbol: RSSortingVector_ClearAndDeAlloc
     >>> referenced by doc_table.c:381 ... in libredisearch_c_bundle.a
   rust-lld: error: undefined symbol: RSOffsetVector_FreeData
   error: could not compile `search_result` (lib test)
   ```

   Linking a lib test/bench harness pulls in `libredisearch_c_bundle.a`, whose C objects
   reference Rust FFI symbols owned by crates like `sorting_vector_ffi` and `types_ffi`.
   Those crates are not in either crate's dependency graph, so the symbols are undefined.

   This is a known hazard that the 20 `c_entrypoint/` crates already document and avoid by
   pairing both flags:

   ```toml
   [lib]
   # This crate has no tests nor benches.
   # Compiling a no-op bench/test binary can cause linking issues with C.
   test = false
   bench = false
   ```

   Two crates missed it:

   - **`search_result`** set only `test = false`. `bench` still defaults to `true`, so
     `cargo bench` builds the very target that flag was added to avoid. This is the
     failure CI reports.
   - **`triemap_ffi`** has no `[lib]` section at all, unlike every sibling. Its lib
     harness fails to link locally under both `cargo bench` and `cargo test`.

2. **Change:** add `bench = false` to `search_result` and the standard `[lib]` block to
   `triemap_ffi`.

3. **Outcome:** `cargo bench --no-run --workspace` goes from failing on both crates to
   exiting 0, so the micro-benchmark job can actually run the benchmarks.

**Only empty, unbuildable targets are removed — no test coverage is lost:**

- `search_result` has no benchmarks at all; its only files are `Cargo.toml` and
  `src/lib.rs`.
- `triemap_ffi` has no lib unit tests (checked all five `src/*.rs` files). Its 8 tests
  live in `tests/trie.rs`, a separate target that `[lib] test = false` does not affect —
  `cargo nextest list -p triemap_ffi` still discovers all 8.

Verified in a worktree with a complete C build (`./build.sh DEBUG=1`, `BINDIR` set):
`cargo bench --no-run --workspace` exits 0, and `triemap_ffi` now also links under the
test profile, where it previously failed.

#### Which additional issues this PR fixes

1. None.

#### Main objects this PR modified

1. `src/redisearch_rs/search_result/Cargo.toml` — added `bench = false`.
2. `src/redisearch_rs/c_entrypoint/triemap_ffi/Cargo.toml` — added the `[lib]`
   `test = false` / `bench = false` block used by its 20 sibling crates.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Build-configuration only. No product code, no user-visible behavior change.
