### PR TITLE
[MOD-17476] Trie - Fix wildcard `?` matching per byte instead of per codepoint on WITHSUFFIXTRIE TEXT fields

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -686,16 +686,13 @@ static QueryIterator *Query_EvalWildcardQueryNode(QueryEvalCtx *q, QueryNode *qn
   bool fallbackBruteForce = false;
   // spec support using suffix trie
   if (spec->suffix) {
-    // TEXT terms are stored lowercased, so recheck against the lowercased
-    // pattern (Suffix_CB_Wildcard matches cstr) to stay case-insensitive.
-    size_t lcstrlen;
-    char *lcstr = runesToStr(str, nstr, &lcstrlen);
+    // TEXT terms are stored lowercased and `str` holds the lowercased
+    // pattern runes, so the candidate recheck in Suffix_CB_Wildcard stays
+    // case-insensitive.
     SuffixCtx sufCtx = {
       .trie = spec->suffix,
       .rune = str,
       .runelen = nstr,
-      .cstr = lcstr,
-      .cstrlen = lcstrlen,
       .type = SUFFIX_TYPE_WILDCARD,
       .callback = charIterCb, // the difference is weather the function receives char or rune
       .cbCtx = &ctx,
@@ -706,7 +703,6 @@ static QueryIterator *Query_EvalWildcardQueryNode(QueryEvalCtx *q, QueryNode *qn
       // if suffix trie cannot be used, use brute force
       fallbackBruteForce = true;
     }
-    rm_free(lcstr);
   }
 
   if (!spec->suffix || fallbackBruteForce) {

--- a/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
@@ -493,8 +493,6 @@ impl CTrieRef {
             trie: self.ptr,
             rune: pattern.as_ptr().cast_mut(),
             runelen: pattern.len(),
-            cstr: std::ptr::null(),
-            cstrlen: 0,
             type_: mode.into(),
             callback: Some(suffix_trampoline::<F>),
             cbCtx: std::ptr::from_mut(&mut callback).cast(),

--- a/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
@@ -130,75 +130,41 @@ where
 /// already-folded rune from one that was never folded.
 ///
 /// The walks read one element *past* the pattern — its value decides the match
-/// for a pattern ending in `*` — and [`iterate_suffix_wildcard`] also writes a
-/// terminator there. So both encodings carry a zero sentinel past their content,
-/// which a plain `Vec` of the converted pattern would not have. This type owns
-/// that layout instead of leaving each call site to remember it, and derives the
-/// byte form from the rune form so the two cannot disagree.
-///
-/// [`iterate_suffix_wildcard`]: CTrieRef::iterate_suffix_wildcard
+/// for a pattern ending in `*` — so the runes carry a zero sentinel past their
+/// content, which a plain `Vec` of the converted pattern would not have. This
+/// type owns that layout instead of leaving each call site to remember it.
 #[derive(Debug)]
 pub struct LoweredPattern {
     /// The content runes followed by one zero sentinel, so `len()` is
     /// `runes.len() - 1`.
     runes: Vec<ffi::rune>,
-    /// The same pattern as bytes, followed by one zero sentinel.
-    bytes: Vec<u8>,
 }
 
 impl LoweredPattern {
-    /// Build a pattern from its lowercased runes, appending the sentinel to both
-    /// encodings.
+    /// Build a pattern from its lowercased runes, appending the sentinel.
     ///
     /// `runes` must hold only the content — the sentinel is added here.
     ///
     /// Returns [`None`], which every caller treats as matching nothing, rather
-    /// than building a pattern that could not name a stored term or could not be
-    /// walked safely:
+    /// than building a pattern that could not name a stored term:
     ///
     /// - a rune slice longer than [`MAX_RUNE_STR_LEN`](ffi::MAX_RUNE_STR_LEN),
-    ///   which the byte conversion declines. A pattern that *is* built therefore
-    ///   fits the `int` length the walks take;
-    /// - a slice holding a zero rune. The byte conversion stops there while the
-    ///   rune form keeps the rest, so the two encodings would describe different
-    ///   patterns — and [`iterate_suffix_wildcard`](CTrieRef::iterate_suffix_wildcard)
-    ///   picks its anchor from the runes but filters candidates by the bytes,
-    ///   which would then report matches the full pattern rejects. The shorter
-    ///   byte form also undersizes that walk's stack scratch space.
+    ///   which term insertion declines the same way. A pattern that *is* built
+    ///   therefore fits the `int` length the walks take;
+    /// - a slice holding a zero rune, which collides with the sentinel layout
+    ///   this type guarantees — a consumer scanning for the zero would see a
+    ///   truncated pattern — and which no stored term contains.
     pub fn new(runes: &[ffi::rune]) -> Option<Self> {
-        // The length check below does not subsume this: enough multibyte runes
-        // before the zero keep the truncated byte form longer than the rune one.
         if runes.contains(&0) {
             return None;
         }
-
-        let mut len: usize = 0;
-        // SAFETY: `runes` is a valid slice of `runes.len()` runes. `runesToStr`
-        // returns a freshly allocated, NUL-terminated buffer of `len` bytes, or
-        // NULL when the slice exceeds `MAX_RUNE_STR_LEN`.
-        let ptr = unsafe { ffi::runesToStr(runes.as_ptr(), runes.len(), &mut len) };
-        let ptr = NonNull::new(ptr)?;
-        // SAFETY: `ptr` addresses `len` bytes written by the call above.
-        let bytes = unsafe { std::slice::from_raw_parts(ptr.as_ptr().cast::<u8>(), len) }.to_vec();
-        // SAFETY: `RedisModule_Free` is set during module init and not mutated
-        // afterwards.
-        let rm_free = unsafe { ffi::RedisModule_Free.expect("Redis allocator not available") };
-        // SAFETY: `ptr` was allocated by the module allocator inside `runesToStr`.
-        unsafe { rm_free(ptr.as_ptr().cast::<c_void>()) };
-
-        let mut runes = runes.to_vec();
-        runes.push(0);
-        let mut bytes = bytes;
-        bytes.push(0);
-
-        // Implied by the zero-rune rejection above, but kept as a backstop:
-        // violating the scratch-space invariant overflows a stack buffer rather
-        // than giving a wrong answer.
-        if bytes.len() < runes.len() {
+        if runes.len() > ffi::MAX_RUNE_STR_LEN as usize {
             return None;
         }
 
-        Some(Self { runes, bytes })
+        let mut runes = runes.to_vec();
+        runes.push(0);
+        Some(Self { runes })
     }
 
     /// The number of content runes, excluding the sentinel.
@@ -223,14 +189,13 @@ impl LoweredPattern {
 pub enum SuffixWalk {
     /// The walk ran and every matching term was delivered to the callback.
     ///
-    /// The pattern is not returned: the walk terminates its anchor token in
-    /// place, so what remains no longer describes what the caller asked for.
+    /// The pattern is not returned: the walk answered it, so the caller has
+    /// nothing left to do with it.
     Walked,
     /// The pattern held no literal run to anchor on, so nothing was visited.
     ///
-    /// The pattern comes back intact — that decision is made before any write —
-    /// ready for a fallback walk over the primary terms trie with
-    /// [`iterate_wildcard`](CTrieRef::iterate_wildcard).
+    /// The pattern comes back ready for a fallback walk over the primary terms
+    /// trie with [`iterate_wildcard`](CTrieRef::iterate_wildcard).
     NoAnchor(LoweredPattern),
 }
 
@@ -603,10 +568,8 @@ impl CTrieRef {
     /// back as [`SuffixWalk::NoAnchor`] so the caller can fall back to
     /// [`iterate_wildcard`](Self::iterate_wildcard) over the primary terms trie.
     ///
-    /// `pattern` is consumed because a walk that *does* happen corrupts it:
-    /// terminating the anchor token overwrites whatever followed it — the
-    /// sentinel for a token ending at the pattern's end, but a content rune
-    /// otherwise.
+    /// `pattern` is consumed so that a declined walk can hand it back through
+    /// [`SuffixWalk::NoAnchor`] for the fallback.
     ///
     /// `timeout` bounds the walk, as for [`iterate_wildcard`](Self::iterate_wildcard).
     ///
@@ -632,13 +595,6 @@ impl CTrieRef {
     where
         F: FnMut(&[u8]) -> ControlFlow<()>,
     {
-        // An empty pattern has no token to anchor on, which is the answer the walk
-        // itself would give — but it would first size a stack array from the byte
-        // length, so answer it here.
-        if pattern.is_empty() {
-            return SuffixWalk::NoAnchor(pattern);
-        }
-
         let (timeout_ptr, skip_timeout_checks) = match timeout {
             Some(deadline) => (deadline.as_ptr(), false),
             None => (std::ptr::null_mut(), true),
@@ -648,8 +604,6 @@ impl CTrieRef {
             trie: self.ptr,
             rune: pattern.runes.as_mut_ptr(),
             runelen: pattern.len(),
-            cstr: pattern.bytes.as_ptr().cast::<c_char>(),
-            cstrlen: pattern.bytes.len() - 1,
             // The wildcard walk never reads this back, but a stale `Contains`
             // would misdescribe the context in a debugger.
             type_: SuffixType_SUFFIX_TYPE_WILDCARD,
@@ -660,14 +614,11 @@ impl CTrieRef {
         };
         // SAFETY: every `suffix_ctx` field is initialised above with a valid
         // value — `self.ptr` is a valid suffix `Trie` (caller contract), the rune
-        // and byte pointers describe the same live pattern, each followed by the
-        // sentinel the walk reads and writes (`LoweredPattern` invariant), the
-        // callback closure outlives the call, and `timeout` is null or the valid
-        // pointer the caller supplied.
+        // pointer describes a live pattern followed by the sentinel the walk
+        // reads (`LoweredPattern` invariant), the callback closure outlives the
+        // call, and `timeout` is null or the valid pointer the caller supplied.
         let used = unsafe { ffi::Suffix_IterateWildcard(std::ptr::from_mut(&mut suffix_ctx)) };
         if used == 0 {
-            // Nothing was visited and, because that decision precedes every write,
-            // the pattern is still intact.
             SuffixWalk::NoAnchor(pattern)
         } else {
             SuffixWalk::Walked

--- a/src/redisearch_rs/c_wrappers/c_trie/tests/iterate.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/tests/iterate.rs
@@ -413,9 +413,9 @@ fn lowered_pattern_from_no_runes_is_empty() {
     ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
 )]
 fn lowered_pattern_length_is_in_runes_not_bytes() {
-    // A multibyte pattern separates the two encodings, which every ASCII pattern
-    // leaves the same length. The byte form must be the longer one — it is what
-    // the suffix walk sizes its scratch space by.
+    // A multibyte pattern separates rune count from source-byte count, which
+    // every ASCII pattern leaves equal. `len()` must count runes — it is what
+    // the walks take as the pattern length.
     let p = pattern("hé*");
     assert_eq!(p.len(), 3, "three runes: h, é, *");
 }
@@ -426,8 +426,8 @@ fn lowered_pattern_length_is_in_runes_not_bytes() {
     ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
 )]
 fn lowered_pattern_declines_a_pattern_longer_than_max_rune_str_len() {
-    // The byte conversion declines anything over `MAX_RUNE_STR_LEN` runes; such a
-    // pattern can name no stored term, so there is nothing to walk with.
+    // Term insertion declines anything over `MAX_RUNE_STR_LEN` runes, so such a
+    // pattern can name no stored term and there is nothing to walk with.
     let runes = vec![ffi::rune::from(b'a'); ffi::MAX_RUNE_STR_LEN as usize + 1];
     assert!(LoweredPattern::new(&runes).is_none());
 }
@@ -438,28 +438,10 @@ fn lowered_pattern_declines_a_pattern_longer_than_max_rune_str_len() {
     ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
 )]
 fn lowered_pattern_declines_a_pattern_holding_a_zero_rune() {
-    // Violates the no-zero-rune contract: the byte conversion stops at the zero
-    // while the rune form keeps what follows, so the two encodings would describe
-    // different patterns. Declined rather than built.
+    // An interior zero collides with the sentinel layout the type guarantees —
+    // a consumer scanning for the zero would see only `a`. Declined rather than
+    // built.
     assert!(LoweredPattern::new(&[ffi::rune::from(b'a'), 0, ffi::rune::from(b'b')]).is_none());
-}
-
-#[test]
-#[cfg_attr(
-    miri,
-    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
-)]
-fn lowered_pattern_declines_a_zero_rune_the_length_check_cannot_catch() {
-    // Enough multibyte runes *before* the zero and the truncated byte form is
-    // still longer than the rune form, so a `bytes.len() < runes.len()` test
-    // passes while the two encodings describe different patterns. That is not a
-    // narrower match but a wrong one: the suffix walk picks its anchor from the
-    // rune form and filters candidates with the byte form, so the truncated
-    // `éé*` would admit terms the full pattern rejects.
-    let e = ffi::rune::from(0x00E9u16); // 'é' — two bytes, one rune
-    let runes = [e, e, ffi::rune::from(b'*'), 0, ffi::rune::from(b'a')];
-    // The check the explicit rejection replaces would have let this through.
-    assert!(LoweredPattern::new(&runes).is_none());
 }
 
 // --- `iterate_wildcard` (terms trie) ----------------------------------------
@@ -685,10 +667,9 @@ fn iterate_suffix_wildcard_anchors_on_the_pattern_literal() {
     ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
 )]
 fn iterate_suffix_wildcard_anchor_token_may_absorb_a_trailing_star() {
-    // The delicate case `LoweredPattern` exists for. The chosen anchor token
-    // `ma` is followed by `*`, so the walk extends the token to cover it and then
-    // terminates it *past* its end — writing the sentinel, at the index one
-    // beyond the pattern's last rune.
+    // The chosen anchor token `ma` is followed by `*`, so the walk extends the
+    // token to cover it and scans the whole sub-tree under `ma` — the only walk
+    // shape that honours an early stop.
     with_suffix_trie(CORPUS, |trie| {
         let mut got = HashSet::new();
         // SAFETY: live, un-mutated suffix trie; `None` timeout.
@@ -709,9 +690,9 @@ fn iterate_suffix_wildcard_anchor_token_may_absorb_a_trailing_star() {
     ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
 )]
 fn iterate_suffix_wildcard_matches_a_multibyte_pattern() {
-    // Separates the pattern's byte length from its rune length, which is what the
-    // walk sizes its stack scratch arrays by. Every ASCII pattern leaves the two
-    // equal and so cannot tell the sizing apart.
+    // A multibyte pattern separates rune count from byte count; the walk operates
+    // rune-wise throughout, and every ASCII pattern leaves the two equal and so
+    // could not tell.
     with_suffix_trie(&["héllo", "hallo"], |trie| {
         let mut got = HashSet::new();
         // SAFETY: live, un-mutated suffix trie; `None` timeout.
@@ -745,8 +726,8 @@ fn iterate_suffix_wildcard_declines_a_pattern_with_no_literal_to_anchor_on() {
             panic!("a pattern of only `*` has no token to anchor on");
         };
         assert_eq!(count, 0);
-        // The decision precedes every write, so the pattern comes back usable for
-        // the caller's fallback over the primary terms trie.
+        // The pattern comes back usable for the caller's fallback over the
+        // primary terms trie.
         assert_eq!(returned.len(), 2);
     });
 }

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -301,7 +301,7 @@ int Suffix_ChooseToken_rune(const rune *str, size_t len, size_t *tokenIdx, size_
   int retidx = REDISEARCH_UNINITIALIZED;
   for (int i = 0; i < runner; ++i) {
     // 1. long string are likely to have less results
-    // 2. tokens at end of pattern are likely to be more relevant
+    // 2. score ties are broken in favor of the later token (`>=` below)
     int curScore = tokenLen[i] + 1;
 
     // iterating all children is demanding

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -365,11 +365,15 @@ int Suffix_IterateWildcard(SuffixCtx *sufCtx) {
     return 0;
   }
 
-  rune *token = sufCtx->rune + idx[useIdx];
   size_t toklen = lens[useIdx];
-  if (token[toklen] == (rune)'*') {
+  if (sufCtx->rune[idx[useIdx] + toklen] == (rune)'*') {
     toklen++;
   }
+  // The trie walk wants a NUL-terminated token, but the pattern buffer must
+  // stay intact: Suffix_CB_Wildcard re-filters every candidate against
+  // sufCtx->rune while the iteration is running. Terminate a copy instead.
+  rune token[toklen + 1];
+  memcpy(token, sufCtx->rune + idx[useIdx], toklen * sizeof(rune));
   token[toklen] = (rune)'\0';
 
   Trie_IterateWildcard(sufCtx->trie, token, toklen, Suffix_CB_Wildcard, sufCtx, sufCtx->timeout,

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -325,7 +325,8 @@ int Suffix_ChooseToken_rune(const rune *str, size_t len, size_t *tokenIdx, size_
   return retidx;
 }
 
-int Suffix_CB_Wildcard(const rune *rune, size_t len, void *p, void *payload, size_t numDocsInTerm) {
+int Suffix_CB_Wildcard(const rune *keyRunes, size_t keyLen, void *p, void *payload,
+                       size_t numDocsInTerm) {
   SuffixCtx *sufCtx = p;
   TriePayload *pl = payload;
   if (!pl) {
@@ -335,8 +336,14 @@ int Suffix_CB_Wildcard(const rune *rune, size_t len, void *p, void *payload, siz
   suffixData *data = (suffixData *)TriePayload_Data(pl);
   arrayof(char *) array = data->array;
   for (int i = 0; i < array_len(array); ++i) {
-    if (Wildcard_MatchChar(sufCtx->cstr, sufCtx->cstrlen, array[i], strlen(array[i]))
-            == FULL_MATCH) {
+    // Match rune-wise so `?` consumes one codepoint, keeping results
+    // identical to the brute-force scan over the terms trie.
+    runeBuf buf;
+    size_t termRuneLen;
+    rune *termRunes = runeBufFill(array[i], strlen(array[i]), &buf, &termRuneLen);
+    match_t match = Wildcard_MatchRune(sufCtx->rune, sufCtx->runelen, termRunes, termRuneLen);
+    runeBufFree(&buf);
+    if (match == FULL_MATCH) {
       if (sufCtx->callback(array[i], strlen(array[i]), sufCtx->cbCtx, NULL) != REDISMODULE_OK) {
         return REDISEARCH_ERR;
       }
@@ -347,11 +354,11 @@ int Suffix_CB_Wildcard(const rune *rune, size_t len, void *p, void *payload, siz
 
 int Suffix_IterateWildcard(SuffixCtx *sufCtx) {
   // An empty pattern has no token to anchor on, and the arrays below require a positive length
-  if (sufCtx->cstrlen == 0) {
+  if (sufCtx->runelen == 0) {
     return 0;
   }
-  size_t idx[sufCtx->cstrlen];
-  size_t lens[sufCtx->cstrlen];
+  size_t idx[sufCtx->runelen];
+  size_t lens[sufCtx->runelen];
   int useIdx = Suffix_ChooseToken_rune(sufCtx->rune, sufCtx->runelen, idx, lens);
 
   if (useIdx == REDISEARCH_UNINITIALIZED) {

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -325,6 +325,17 @@ int Suffix_ChooseToken_rune(const rune *str, size_t len, size_t *tokenIdx, size_
   return retidx;
 }
 
+// True if the UTF-8 string contains a supplementary-plane codepoint
+// (> U+FFFF, i.e. a 4-byte sequence, lead byte 0xF0..0xF4).
+static bool containsSupplementaryCodepoint(const char *str, size_t len) {
+  for (size_t i = 0; i < len; ++i) {
+    if ((unsigned char)str[i] >= 0xF0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 int Suffix_CB_Wildcard(const rune *keyRunes, size_t keyLen, void *p, void *payload,
                        size_t numDocsInTerm) {
   SuffixCtx *sufCtx = p;
@@ -336,9 +347,16 @@ int Suffix_CB_Wildcard(const rune *keyRunes, size_t keyLen, void *p, void *paylo
   suffixData *data = (suffixData *)TriePayload_Data(pl);
   arrayof(char *) array = data->array;
   for (int i = 0; i < array_len(array); ++i) {
+    size_t termLen = strlen(array[i]);
+    // The brute-force scan over the terms trie can never return terms with
+    // supplementary-plane codepoints: the 16-bit rune representation
+    // truncates them, so the inverted-index key it derives no longer exists.
+    // Skip such candidates to keep both paths result-identical.
+    if (containsSupplementaryCodepoint(array[i], termLen)) {
+      continue;
+    }
     // Match rune-wise so `?` consumes one codepoint, keeping results
     // identical to the brute-force scan over the terms trie.
-    size_t termLen = strlen(array[i]);
     runeBuf buf;
     size_t termRuneLen;
     rune *termRunes = runeBufFill(array[i], termLen, &buf, &termRuneLen);

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -338,13 +338,14 @@ int Suffix_CB_Wildcard(const rune *keyRunes, size_t keyLen, void *p, void *paylo
   for (int i = 0; i < array_len(array); ++i) {
     // Match rune-wise so `?` consumes one codepoint, keeping results
     // identical to the brute-force scan over the terms trie.
+    size_t termLen = strlen(array[i]);
     runeBuf buf;
     size_t termRuneLen;
-    rune *termRunes = runeBufFill(array[i], strlen(array[i]), &buf, &termRuneLen);
+    rune *termRunes = runeBufFill(array[i], termLen, &buf, &termRuneLen);
     match_t match = Wildcard_MatchRune(sufCtx->rune, sufCtx->runelen, termRunes, termRuneLen);
     runeBufFree(&buf);
     if (match == FULL_MATCH) {
-      if (sufCtx->callback(array[i], strlen(array[i]), sufCtx->cbCtx, NULL) != REDISMODULE_OK) {
+      if (sufCtx->callback(array[i], termLen, sufCtx->cbCtx, NULL) != REDISMODULE_OK) {
         return REDISEARCH_ERR;
       }
     }

--- a/src/suffix.h
+++ b/src/suffix.h
@@ -30,8 +30,6 @@ typedef struct SuffixCtx {
     Trie *trie;
     rune *rune;
     size_t runelen;
-    const char *cstr;
-    size_t cstrlen;
     SuffixType type;
     TrieSuffixCallback *callback;
     void *cbCtx;

--- a/tests/cpptests/test_cpp_suffix.cpp
+++ b/tests/cpptests/test_cpp_suffix.cpp
@@ -185,8 +185,6 @@ TEST_F(WildcardEmptyPatternTest, suffixTrieIterateSignalsUnusable) {
   ctx.trie = t;
   ctx.rune = emptyPattern;
   ctx.runelen = 0;
-  ctx.cstr = "";
-  ctx.cstrlen = 0;
   ctx.type = SUFFIX_TYPE_WILDCARD;
   ctx.callback = countSuffixHit;
   ctx.cbCtx = &hits;
@@ -201,8 +199,6 @@ TEST_F(WildcardEmptyPatternTest, suffixTrieIterateSignalsUnusable) {
   runeBuf buf;
   ctx.rune = runeBufFill("*b*", 3, &buf, &rlen);
   ctx.runelen = rlen;
-  ctx.cstr = "*b*";
-  ctx.cstrlen = 3;
   EXPECT_EQ(Suffix_IterateWildcard(&ctx), 1);
   EXPECT_GT(hits, 0);
   runeBufFree(&buf);

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -626,7 +626,7 @@ def testWildcardQuestionMarkMultibyteWithSuffixTrie():
     env.assertEqual(res, [2, 'doc1', 'doc2'])
 
 @skip(cluster=True)
-def testWildcardStarredNonFinalAnchorWithSuffixTrie():
+def testWildcardStarredNonFinalAnchor():
     """On the suffix-trie path, a pattern whose best anchor token is starred
     and non-final (in w'verylongtoken*a', 'verylongtoken' out-scores the tail
     token 'a' despite the starred-anchor penalty) must return the same result
@@ -635,12 +635,15 @@ def testWildcardStarredNonFinalAnchorWithSuffixTrie():
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
 
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'WITHSUFFIXTRIE').ok()
+    env.expect('FT.CREATE', 'idx_plain', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect('FT.CREATE', 'idx_suffix', 'SCHEMA', 't', 'TEXT', 'WITHSUFFIXTRIE').ok()
     conn.execute_command('HSET', 'doc1', 't', 'verylongtokenxa')
     conn.execute_command('HSET', 'doc2', 't', 'verylongtokenxb')
 
-    res = env.cmd('FT.SEARCH', 'idx', "w'verylongtoken*a'", 'NOCONTENT')
-    env.assertEqual(res, [1, 'doc1'])
+    res_plain = env.cmd('FT.SEARCH', 'idx_plain', "w'verylongtoken*a'", 'NOCONTENT')
+    res_suffix = env.cmd('FT.SEARCH', 'idx_suffix', "w'verylongtoken*a'", 'NOCONTENT')
+    env.assertEqual(res_plain, [1, 'doc1'])
+    env.assertEqual(res_suffix, res_plain)
 
 @skip(cluster=True)
 def testWildcardSupplementaryPlaneParity():

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -622,3 +622,19 @@ def testWildcardQuestionMarkMultibyteWithSuffixTrie():
 
     res = env.cmd('FT.SEARCH', 'idx', "w'entr?'", 'NOCONTENT')
     env.assertEqual(res, [2, 'doc1', 'doc2'])
+
+@skip(cluster=True)
+def testWildcardStarredNonFinalAnchorWithSuffixTrie():
+    """On the suffix-trie path, a pattern whose best anchor token is starred
+    and non-final (in w'verylongtoken*a', 'verylongtoken' out-scores the tail
+    token 'a' despite the starred-anchor penalty) must return the same result
+    as the brute-force path."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'WITHSUFFIXTRIE').ok()
+    conn.execute_command('HSET', 'doc1', 't', 'verylongtokenxa')
+    conn.execute_command('HSET', 'doc2', 't', 'verylongtokenxb')
+
+    res = env.cmd('FT.SEARCH', 'idx', "w'verylongtoken*a'", 'NOCONTENT')
+    env.assertEqual(res, [1, 'doc1'])

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -591,3 +591,34 @@ def testEmptyWildcardPattern():
         env.assertEqual(res, [1, 'doc2'], message=idx)
         res = env.cmd('FT.SEARCH', idx, '@tag:{""}', 'NOCONTENT')
         env.assertEqual(res, [1, 'doc2'], message=idx)
+
+@skip(cluster=True)
+def testWildcardQuestionMarkMultibyteWithoutSuffixTrie():
+    """Without WITHSUFFIXTRIE, a wildcard query is evaluated by brute force over
+    the rune terms trie (Wildcard_MatchRune), where `?` consumes one codepoint —
+    so w'entr?' matches 'entré' ('é' is two UTF-8 bytes but one codepoint)."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    conn.execute_command('HSET', 'doc1', 't', 'entré')
+    conn.execute_command('HSET', 'doc2', 't', 'entrx')
+
+    res = env.cmd('FT.SEARCH', 'idx', "w'entr?'", 'NOCONTENT')
+    env.assertEqual(res, [2, 'doc1', 'doc2'])
+
+@skip(cluster=True)
+def testWildcardQuestionMarkMultibyteWithSuffixTrie():
+    """With WITHSUFFIXTRIE, the candidate terms found via the suffix trie are
+    re-filtered rune-wise (Suffix_CB_Wildcard -> Wildcard_MatchRune), where `?`
+    consumes one codepoint — so w'entr?' matches 'entré', the same result the
+    brute-force path produces without the suffix trie."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'WITHSUFFIXTRIE').ok()
+    conn.execute_command('HSET', 'doc1', 't', 'entré')
+    conn.execute_command('HSET', 'doc2', 't', 'entrx')
+
+    res = env.cmd('FT.SEARCH', 'idx', "w'entr?'", 'NOCONTENT')
+    env.assertEqual(res, [2, 'doc1', 'doc2'])

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -641,3 +641,27 @@ def testWildcardStarredNonFinalAnchorWithSuffixTrie():
 
     res = env.cmd('FT.SEARCH', 'idx', "w'verylongtoken*a'", 'NOCONTENT')
     env.assertEqual(res, [1, 'doc1'])
+
+@skip(cluster=True)
+def testWildcardSupplementaryPlaneParity():
+    """Terms containing supplementary-plane codepoints (4-byte UTF-8, above
+    U+FFFF, e.g. emoji) are never returned by the brute-force wildcard path:
+    the 16-bit rune representation truncates the codepoint, so the
+    inverted-index key derived from it no longer exists. The suffix-trie path
+    keeps the original term bytes and would find them, so it must skip such
+    candidates — WITHSUFFIXTRIE is an optimization and may never change the
+    result set."""
+    # DEFAULT_DIALECT 2 because w'...' syntax needs dialect 2 or above.
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx_plain', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect('FT.CREATE', 'idx_suffix', 'SCHEMA', 't', 'TEXT', 'WITHSUFFIXTRIE').ok()
+    conn.execute_command('HSET', 'doc1', 't', 'hello💩')
+    conn.execute_command('HSET', 'doc2', 't', '💩')
+
+    for query in ["w'hello?'", "w'hello*'", "w'?'", "w'*💩'"]:
+        res_plain = env.cmd('FT.SEARCH', 'idx_plain', query, 'NOCONTENT')
+        res_suffix = env.cmd('FT.SEARCH', 'idx_suffix', query, 'NOCONTENT')
+        env.assertEqual(res_plain, [0], message=query)
+        env.assertEqual(res_suffix, res_plain, message=query)

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -597,6 +597,7 @@ def testWildcardQuestionMarkMultibyteWithoutSuffixTrie():
     """Without WITHSUFFIXTRIE, a wildcard query is evaluated by brute force over
     the rune terms trie (Wildcard_MatchRune), where `?` consumes one codepoint —
     so w'entr?' matches 'entré' ('é' is two UTF-8 bytes but one codepoint)."""
+    # DEFAULT_DIALECT 2 because w'...' syntax needs dialect 2 or above.
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
 
@@ -613,6 +614,7 @@ def testWildcardQuestionMarkMultibyteWithSuffixTrie():
     re-filtered rune-wise (Suffix_CB_Wildcard -> Wildcard_MatchRune), where `?`
     consumes one codepoint — so w'entr?' matches 'entré', the same result the
     brute-force path produces without the suffix trie."""
+    # DEFAULT_DIALECT 2 because w'...' syntax needs dialect 2 or above.
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
 
@@ -629,6 +631,7 @@ def testWildcardStarredNonFinalAnchorWithSuffixTrie():
     and non-final (in w'verylongtoken*a', 'verylongtoken' out-scores the tail
     token 'a' despite the starred-anchor penalty) must return the same result
     as the brute-force path."""
+    # DEFAULT_DIALECT 2 because w'...' syntax needs dialect 2 or above.
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: On a TEXT field with `WITHSUFFIXTRIE`, the wildcard `?` consumes one byte instead of one codepoint: the suffix-trie-accelerated path re-filters candidate terms with the byte-wise `Wildcard_MatchChar`, so `w'entr?'` does not match `entré` (é is two UTF-8 bytes). The same query matches on the brute-force path over the rune terms trie (`Wildcard_MatchRune`), so enabling the acceleration silently changes query results.
2. Change: `Suffix_CB_Wildcard` now converts each candidate term to runes and matches with `Wildcard_MatchRune` against the pattern runes already carried by `SuffixCtx`. The now-unused byte-form pattern fields (`cstr`/`cstrlen`) are dropped from `SuffixCtx` together with the `runesToStr` round-trip that fed them. A follow-up commit keeps the pattern rune buffer intact during the trie walk: `Suffix_IterateWildcard` NUL-terminated the chosen anchor token in place inside that buffer, which would have corrupted the pattern for the new re-filter when the anchor is a starred non-final token.
3. Outcome: Wildcard `?` matches exactly one codepoint on TEXT fields whether or not the field has a suffix trie; both paths return the same results. TAG fields are byte-keyed and unchanged. New flow tests cover the multibyte `?` query on both paths and the starred non-final anchor shape.

#### Which additional issues this PR fixes

1. MOD-17476

#### Main objects this PR modified

1. `Suffix_CB_Wildcard`, `Suffix_IterateWildcard`, `SuffixCtx` (`src/suffix.c`, `src/suffix.h`)
2. `Query_EvalWildcardQueryNode` (`src/query.c`)
3. `tests/pytests/test_wildcard.py`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
