### PR TITLE
[MOD-17476] TermSuffixIndex - match wildcard `?` per codepoint, not per byte

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3020,7 +3020,6 @@ dependencies = [
  "ffi",
  "itertools 0.15.0",
  "proptest",
- "rqe_wildcard",
  "rstest",
  "string_utils",
  "trie_rs",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3025,7 +3025,6 @@ dependencies = [
  "ffi",
  "itertools 0.15.0",
  "proptest",
- "rqe_wildcard",
  "rstest",
  "string_utils",
  "trie_rs",

--- a/src/redisearch_rs/c_entrypoint/term_suffix_index_ffi/src/iter_callback.rs
+++ b/src/redisearch_rs/c_entrypoint/term_suffix_index_ffi/src/iter_callback.rs
@@ -129,8 +129,8 @@ pub unsafe extern "C" fn TermSuffixIndex_IterateSuffix(
 
 /// Invoke `cb` once per member term matching the wildcard pattern
 /// `(pattern, len)` (`*` matches any run of characters, `?` exactly one
-/// byte); a term may be reported more than once. Iteration stops early
-/// when the callback returns a non-zero value.
+/// codepoint); a term may be reported more than once. Iteration stops
+/// early when the callback returns a non-zero value.
 ///
 /// When `should_stop` is non-NULL it is polled periodically while the
 /// candidate set is scanned; once it returns `true` the scan is abandoned

--- a/src/redisearch_rs/c_entrypoint/term_suffix_index_ffi/tests/term_suffix_index.rs
+++ b/src/redisearch_rs/c_entrypoint/term_suffix_index_ffi/tests/term_suffix_index.rs
@@ -122,6 +122,19 @@ fn iterate_wildcard_yields_matching_terms() {
 }
 
 #[test]
+fn iterate_wildcard_question_mark_matches_one_codepoint() {
+    // `?` consumes one codepoint, not one byte: `é` (U+00E9, two UTF-8
+    // bytes) satisfies the trailing `?` just like the ASCII `x` does,
+    // while `entrée` has two codepoints left after `r` and is rejected.
+    with_index(&["entré", "entrx", "entrée"], |t| {
+        let (rc, actual) = collect_wildcard(t, "ent*r?");
+
+        assert_eq!(rc, 1, "'ent' anchors the search");
+        assert_eq!(actual, to_set(&["entré", "entrx"]));
+    });
+}
+
+#[test]
 fn iterate_wildcard_without_anchor_returns_zero() {
     with_index(&["bike"], |t| {
         // Every `*`-separated token contains `?`, so none can seed a

--- a/src/redisearch_rs/headers/term_suffix_index_ffi.h
+++ b/src/redisearch_rs/headers/term_suffix_index_ffi.h
@@ -252,8 +252,8 @@ size_t TermSuffixIndex_MemUsage(const struct TermSuffixIndex *tsi);
 /**
  * Invoke `cb` once per member term matching the wildcard pattern
  * `(pattern, len)` (`*` matches any run of characters, `?` exactly one
- * byte); a term may be reported more than once. Iteration stops early
- * when the callback returns a non-zero value.
+ * codepoint); a term may be reported more than once. Iteration stops
+ * early when the callback returns a non-zero value.
  *
  * When `should_stop` is non-NULL it is polled periodically while the
  * candidate set is scanned; once it returns `true` the scan is abandoned

--- a/src/redisearch_rs/headers/term_suffix_index_ffi.h
+++ b/src/redisearch_rs/headers/term_suffix_index_ffi.h
@@ -208,8 +208,8 @@ void TermSuffixIndex_IterateSuffix(const struct TermSuffixIndex *tsi, const char
 /**
  * Invoke `cb` once per member term matching the wildcard pattern
  * `(pattern, len)` (`*` matches any run of characters, `?` exactly one
- * byte); a term may be reported more than once. Iteration stops early
- * when the callback returns a non-zero value.
+ * codepoint); a term may be reported more than once. Iteration stops
+ * early when the callback returns a non-zero value.
  *
  * When `should_stop` is non-NULL it is polled periodically while the
  * candidate set is scanned; once it returns `true` the scan is abandoned

--- a/src/redisearch_rs/term_suffix_index/Cargo.toml
+++ b/src/redisearch_rs/term_suffix_index/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 [dependencies]
 ffi.workspace = true
 itertools.workspace = true
-rqe_wildcard.workspace = true
 string_utils.workspace = true
 trie_rs.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -195,7 +195,7 @@ impl TermSuffixIndex {
     /// any run of codepoints and `?` exactly one codepoint. Matching is
     /// [case-insensitive](crate#case-insensitivity). Returns `None` when no
     /// token in the pattern can seed the search (every token is empty or
-    /// contains `?`).
+    /// contains `?` or `\`).
     /// A term may be yielded more than once (once per matching suffix entry).
     ///
     /// `?` matches a whole character even in multibyte terms — `entr?`

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -198,7 +198,7 @@ impl TermSuffixIndex {
     /// any run of codepoints and `?` exactly one codepoint. Matching is
     /// [case-insensitive](crate#case-insensitivity). Returns `None` when no
     /// token in the pattern can seed the search (every token is empty or
-    /// contains `?`).
+    /// contains `?` or `\`).
     /// A term may be yielded more than once (once per matching suffix entry).
     ///
     /// `?` matches a whole character even in multibyte terms — `entr?`

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -38,10 +38,9 @@ use std::{
     sync::Arc,
 };
 
-use rqe_wildcard::{MatchOutcome, WildcardPattern};
 use string_utils::unicode;
 use term_refs::{Outcome, TermRefs};
-use trie_rs::str_trie_map::StrTrieMap;
+use trie_rs::{automaton::CodepointWildcard, str_trie_map::StrTrieMap};
 
 /// Score handicap for anchor tokens followed by `*`: matching them
 /// scans a whole subtree instead of a single exact entry, so they
@@ -196,21 +195,15 @@ impl TermSuffixIndex {
     }
 
     /// Iterate over the members matching the glob `pattern`, where `*` matches
-    /// any run of characters and `?` any single byte. Matching is
+    /// any run of codepoints and `?` exactly one codepoint. Matching is
     /// [case-insensitive](crate#case-insensitivity). Returns `None` when no
     /// token in the pattern can seed the search (every token is empty or
     /// contains `?`).
     /// A term may be yielded more than once (once per matching suffix entry).
     ///
-    /// `?` matches a single *byte*, not a codepoint. The final filter runs
-    /// [`WildcardPattern`] over the raw UTF-8, and that matcher advances one
-    /// byte per `?` — it is the same byte-granular matcher the wider query
-    /// engine uses for wildcard search (the Rust counterpart of C's
-    /// `Wildcard_MatchChar`). So against a multibyte term, `?` lines up with a
-    /// single byte of a codepoint, not the whole character: `entr?` will not
-    /// match `entré`. This is not an approximation introduced here — it is the
-    /// engine's pre-existing `?` behavior, which we deliberately reuse rather
-    /// than diverge from with a second, codepoint-aware matcher.
+    /// `?` matches a whole character even in multibyte terms — `entr?`
+    /// matches `entré`. The final filter runs [`CodepointWildcard`] over each
+    /// candidate term.
     ///
     /// `should_stop` is polled once per [`TIMEOUT_COUNTER_LIMIT`] candidates
     /// examined; when it returns `true` the scan is abandoned early, yielding
@@ -236,7 +229,7 @@ impl TermSuffixIndex {
             (None, self.inner.get(token))
         };
 
-        let wildcard = WildcardPattern::parse(lowered.as_bytes());
+        let wildcard = CodepointWildcard::parse(&lowered);
         let limit = TIMEOUT_COUNTER_LIMIT as usize;
         let matches = subtree
             .into_iter()
@@ -246,7 +239,7 @@ impl TermSuffixIndex {
             .enumerate()
             .take_while(|&(i, _)| !((i + 1).is_multiple_of(limit) && should_stop()))
             .map(|(_, term)| term)
-            .filter(|term| wildcard.matches(term.as_bytes()) == MatchOutcome::Match)
+            .filter(|term| wildcard.matches(term))
             .cloned()
             .collect_vec();
         Some(matches.into_iter())

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -38,10 +38,9 @@ use std::{
     sync::Arc,
 };
 
-use rqe_wildcard::{MatchOutcome, WildcardPattern};
 use string_utils::unicode;
 use term_refs::{Outcome, TermRefs};
-use trie_rs::str_trie_map::StrTrieMap;
+use trie_rs::{automaton::CodepointWildcard, str_trie_map::StrTrieMap};
 
 /// Score handicap for anchor tokens followed by `*`: matching them
 /// scans a whole subtree instead of a single exact entry, so they
@@ -193,21 +192,15 @@ impl TermSuffixIndex {
     }
 
     /// Iterate over the members matching the glob `pattern`, where `*` matches
-    /// any run of characters and `?` any single byte. Matching is
+    /// any run of codepoints and `?` exactly one codepoint. Matching is
     /// [case-insensitive](crate#case-insensitivity). Returns `None` when no
     /// token in the pattern can seed the search (every token is empty or
     /// contains `?`).
     /// A term may be yielded more than once (once per matching suffix entry).
     ///
-    /// `?` matches a single *byte*, not a codepoint. The final filter runs
-    /// [`WildcardPattern`] over the raw UTF-8, and that matcher advances one
-    /// byte per `?` — it is the same byte-granular matcher the wider query
-    /// engine uses for wildcard search (the Rust counterpart of C's
-    /// `Wildcard_MatchChar`). So against a multibyte term, `?` lines up with a
-    /// single byte of a codepoint, not the whole character: `entr?` will not
-    /// match `entré`. This is not an approximation introduced here — it is the
-    /// engine's pre-existing `?` behavior, which we deliberately reuse rather
-    /// than diverge from with a second, codepoint-aware matcher.
+    /// `?` matches a whole character even in multibyte terms — `entr?`
+    /// matches `entré`. The final filter runs [`CodepointWildcard`] over each
+    /// candidate term.
     ///
     /// `should_stop` is polled once per [`TIMEOUT_COUNTER_LIMIT`] candidates
     /// examined; when it returns `true` the scan is abandoned early, yielding
@@ -233,7 +226,7 @@ impl TermSuffixIndex {
             (None, self.inner.get(token))
         };
 
-        let wildcard = WildcardPattern::parse(lowered.as_bytes());
+        let wildcard = CodepointWildcard::parse(&lowered);
         let limit = TIMEOUT_COUNTER_LIMIT as usize;
         let matches = subtree
             .into_iter()
@@ -243,7 +236,7 @@ impl TermSuffixIndex {
             .enumerate()
             .take_while(|&(i, _)| !((i + 1).is_multiple_of(limit) && should_stop()))
             .map(|(_, term)| term)
-            .filter(|term| wildcard.matches(term.as_bytes()) == MatchOutcome::Match)
+            .filter(|term| wildcard.matches(term))
             .cloned()
             .collect_vec();
         Some(matches.into_iter())

--- a/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
@@ -241,11 +241,9 @@ fn iter_wildcard_multibyte_anchor_matches() {
 }
 
 #[test]
-fn iter_wildcard_question_mark_is_byte_wise_for_multibyte() {
-    // The matcher is byte-wise, so `?` consumes one *byte*, not one
-    // codepoint. `é` (U+00E9) is two UTF-8 bytes: `ab*c?` matches only its
-    // first byte, the second has nothing to pair with, and the term is
-    // dropped. This is the accepted approximation — an ASCII tail matches.
+fn iter_wildcard_question_mark_is_codepoint_wise_for_multibyte() {
+    // `?` consumes one *codepoint*, not one byte: `é` (U+00E9, two UTF-8
+    // bytes) satisfies the trailing `?` just like an ASCII `d` does.
     let corpus = ["abxc\u{e9}", "abxcd"]
         .into_iter()
         .map(String::from)
@@ -257,8 +255,8 @@ fn iter_wildcard_question_mark_is_byte_wise_for_multibyte() {
             .expect("'ab' is anchorable"),
     );
 
-    // The ASCII-tailed term matches; the `é`-tailed one is missed.
-    assert_eq!(actual, HashSet::from(["abxcd".to_string()]));
+    let expected = HashSet::from(["abxc\u{e9}".to_string(), "abxcd".to_string()]);
+    assert_eq!(actual, expected);
 }
 
 #[test]
@@ -501,18 +499,18 @@ mod fuzz {
             corpus in proptest::collection::vec(term_strategy(), 1..=20),
             pattern in "[ab*?]{0,8}",
         ) {
-            use rqe_wildcard::{MatchOutcome, WildcardPattern};
+            use trie_rs::automaton::CodepointWildcard;
 
             let sut = build_index(&corpus);
 
             // `None` requests the fallback scan — out of scope here. The
-            // oracle uses the same byte-wise matcher iter_wildcard does, so
-            // this pins the anchor-selection logic, not the matcher itself.
+            // oracle uses the same codepoint-wise matcher iter_wildcard does,
+            // so this pins the anchor-selection logic, not the matcher itself.
             if let Some(matches) = sut.iter_wildcard(&pattern, || false) {
-                let parsed = WildcardPattern::parse(pattern.as_bytes());
+                let parsed = CodepointWildcard::parse(&pattern);
                 let expected = corpus
                     .iter()
-                    .filter(|t| parsed.matches(t.as_bytes()) == MatchOutcome::Match)
+                    .filter(|t| parsed.matches(t))
                     .cloned()
                     .collect::<HashSet<_>>();
 

--- a/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
@@ -243,8 +243,9 @@ fn iter_wildcard_multibyte_anchor_matches() {
 #[test]
 fn iter_wildcard_question_mark_is_codepoint_wise_for_multibyte() {
     // `?` consumes one *codepoint*, not one byte: `é` (U+00E9, two UTF-8
-    // bytes) satisfies the trailing `?` just like an ASCII `d` does.
-    let corpus = ["abxc\u{e9}", "abxcd"]
+    // bytes) satisfies the trailing `?` just like an ASCII `d` does,
+    // while `abxc\u{e9}d` has two codepoints after `c` and is rejected.
+    let corpus = ["abxc\u{e9}", "abxc\u{e9}d", "abxcd"]
         .into_iter()
         .map(String::from)
         .collect::<Vec<_>>();


### PR DESCRIPTION
This is the Rust-side follow-up to
- #10752

## Describe the changes in the pull request

1. Current: `TermSuffixIndex::iter_wildcard` filters candidate terms with `rqe_wildcard::WildcardPattern`, whose `?` consumes a single byte, so `entr?` fails to match `entré` — the same byte-vs-codepoint mismatch fixed on the C suffix-trie path in the companion PR.
2. Change: Switch the final filter to `trie_rs::automaton::CodepointWildcard`, which advances one codepoint per `?`. The same tokenizer is reused, so escape handling and `*` normalization are unchanged. The now-unused `rqe_wildcard` dependency is dropped from the crate.
3. Outcome: The Rust term suffix index matches wildcard `?` per codepoint, consistent with the rune-trie semantics of the C TEXT path it ports.

#### Which additional issues this PR fixes

1. MOD-17476

#### Main objects this PR modified

1. `TermSuffixIndex::iter_wildcard` (`src/redisearch_rs/term_suffix_index/src/lib.rs`)
2. `src/redisearch_rs/term_suffix_index/Cargo.toml`, `Cargo.lock`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
