### PR TITLE
[MOD-14885] query_eval: document the UTF-8 term invariant at the disk lookups

### DIFF
--- a/src/redisearch_rs/query_eval/src/nodes/prefix.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/prefix.rs
@@ -199,6 +199,11 @@ impl Expansion<'_> {
         // The suffix trie hands terms back already as stored key bytes but carries
         // no document count, so on the disk path the term's count is looked up in the
         // primary terms trie for the IDF; the in-memory path ignores it.
+        //
+        // That lookup refuses a key that is not valid UTF-8, which here is the right
+        // answer rather than a lost count: a disk index only stages a term whose
+        // bytes are valid UTF-8, and the terms trie is only updated for terms that
+        // staged, so a refused key was never counted there in the first place.
         let on_term = |term_bytes: &[u8]| {
             let num_docs = if self.is_disk {
                 terms.num_docs(term_bytes)

--- a/src/redisearch_rs/query_eval/src/nodes/token.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/token.rs
@@ -142,6 +142,10 @@ fn eval_disk<'index>(
     // SAFETY: `spec.terms` is a valid `Trie` (checked non-null above) that
     // outlives this lookup.
     let terms = unsafe { CTrieRef::from_raw(spec.terms) };
+    // The lookup refuses a term that is not valid UTF-8. These bytes are query
+    // text rather than a stored key, and a disk index only stages terms whose
+    // bytes are valid UTF-8, so zero is the true count for such a term rather
+    // than a lost one.
     let num_docs_in_term = terms.num_docs(term_bytes.unwrap_or_default());
     let num_documents = spec.stats.scoring.numDocuments;
     term.set_idfs(num_documents, num_docs_in_term);


### PR DESCRIPTION
## Describe the changes in the pull request

Documentation only — comments, no code change.

1. **Current**: Both disk-path callers of the terms-trie document count — the prefix
   expansion in `nodes/prefix.rs` and the `QN_TOKEN` lookup in `nodes/token.rs` — feed
   that count straight into a term's IDF. `CTrieRef::num_docs` refuses a term that is not
   valid UTF-8, because the rune decode takes each sequence's length from its lead byte
   and never re-checks it against the byte count it was given, so a malformed tail would
   be read past. Nothing recorded whether the `0` that comes back is the term's true
   count or a lost one — and the indexing path offers no guarantee either way, since
   document values are binary-safe and the tokenizer's case-folding decoder neither
   rejects nor repairs a malformed sequence, so a term key genuinely can be any byte
   string.

2. **Change**: Record, at each caller, why `0` is the true count — the reason differs
   between them:

   - **`prefix.rs`** — the bytes are a *stored key* handed back by the suffix trie. A
     disk index only stages a term whose bytes are valid UTF-8, and the terms trie is
     only updated for terms that staged, so a refused key was never counted there in the
     first place.
   - **`token.rs`** — the bytes are *query text* rather than a stored key. By that same
     staging rule, no such term can exist in a disk index to be counted.

3. **Outcome**: The invariant is written down where it is relied upon, and attributed to
   the disk write gate rather than to the trie — which enforces nothing of the kind.

#### Which additional issues this PR fixes
1. MOD-14885

#### Main objects this PR modified
1. `expand_via_suffix_trie` — `src/redisearch_rs/query_eval/src/nodes/prefix.rs` (comment
   only)
2. `eval_disk` — `src/redisearch_rs/query_eval/src/nodes/token.rs` (comment only)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
