### PR TITLE
[MOD-17394] tests: verify the RQEIterator contract on every operation via a ContractChecker wrapper

### DIFF
--- a/src/redisearch_rs/rqe_iterators/tests/integration/contract_checker.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/contract_checker.rs
@@ -14,6 +14,8 @@
 //! The violations are staged through [`Misbehaving`], a minimal sorted-id-list
 //! iterator that misbehaves in exactly one configurable way per instance.
 
+use std::cell::Cell;
+
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use rqe_core::DocId;
@@ -97,6 +99,13 @@ enum Fault {
     NeverAtEof,
     /// `last_doc_id()` lags behind the result `read` just yielded.
     LaggingLastDocId,
+    /// `last_doc_id()` answers truthfully once after each yield and reports 0
+    /// from then on — a stale self-report that must not be able to license a
+    /// backward `skip_to`.
+    ForgetfulLastDocId,
+    /// `at_eof()` is true while unread, which claims the iterator can yield
+    /// nothing whatever the data, yet it yields all the same.
+    EofWhileUnread,
     /// An exhausted iterator starts yielding results again.
     YieldsAfterExhaustion,
     /// A `skip_to` that found nothing records the probed id as its position.
@@ -109,8 +118,17 @@ enum Fault {
     ForeignCurrent,
     /// `num_estimated()` under-reports the number of results.
     UnderEstimates,
+    /// `num_estimated()` collapses to 0 once the iterator has run dry, below
+    /// the number of results it already handed out.
+    ShrinkingEstimate,
     /// `revalidate` aborts the iterator.
     AbortsOnRevalidate,
+    /// `revalidate` drops the iterator to EOF while reporting `Ok`, which
+    /// promises the position did not change.
+    LosesPositionOnOkRevalidate,
+    /// `revalidate` reports `Moved` onto a document *behind* the position the
+    /// iterator held.
+    MovesBackwardsOnRevalidate,
 }
 
 /// A minimal sorted-id-list iterator committing exactly one [`Fault`].
@@ -124,6 +142,9 @@ struct Misbehaving<'index> {
     result: RSIndexResult<'index>,
     /// A second result object, handed out by [`Fault::ForeignCurrent`].
     spare: RSIndexResult<'index>,
+    /// Set by every yield, cleared by the next `last_doc_id()` query — the
+    /// window in which [`Fault::ForgetfulLastDocId`] still tells the truth.
+    just_yielded: Cell<bool>,
     fault: Fault,
 }
 
@@ -134,6 +155,7 @@ impl Misbehaving<'_> {
             offset: 0,
             result: RSIndexResult::build_virt().build(),
             spare: RSIndexResult::build_virt().build(),
+            just_yielded: Cell::new(false),
             fault,
         }
     }
@@ -169,6 +191,7 @@ impl<'index> RQEIterator<'index> for Misbehaving<'index> {
         };
         self.offset += 1;
         self.result.doc_id = id;
+        self.just_yielded.set(true);
         Ok(Some(&mut self.result))
     }
 
@@ -180,6 +203,7 @@ impl<'index> RQEIterator<'index> for Misbehaving<'index> {
             self.offset += 1;
             if id >= doc_id {
                 self.result.doc_id = id;
+                self.just_yielded.set(true);
                 let found = id == doc_id && self.fault != Fault::NotFoundOnExactMatch;
                 return Ok(Some(if found {
                     SkipToOutcome::Found(&mut self.result)
@@ -204,6 +228,17 @@ impl<'index> RQEIterator<'index> for Misbehaving<'index> {
             Fault::MovedOnRevalidate => RQEValidateStatus::Moved {
                 current: self.current(),
             },
+            Fault::LosesPositionOnOkRevalidate => {
+                self.offset = self.ids.len() + 1;
+                RQEValidateStatus::Ok
+            }
+            Fault::MovesBackwardsOnRevalidate => {
+                self.offset = 1;
+                self.result.doc_id = self.ids[0];
+                RQEValidateStatus::Moved {
+                    current: Some(&mut self.result),
+                }
+            }
             _ => RQEValidateStatus::Ok,
         })
     }
@@ -217,23 +252,27 @@ impl<'index> RQEIterator<'index> for Misbehaving<'index> {
     }
 
     fn num_estimated(&self) -> usize {
-        if self.fault == Fault::UnderEstimates {
-            self.ids.len() - 1
-        } else {
-            self.ids.len()
+        match self.fault {
+            Fault::UnderEstimates => self.ids.len() - 1,
+            Fault::ShrinkingEstimate if self.past_end() => 0,
+            _ => self.ids.len(),
         }
     }
 
     fn last_doc_id(&self) -> DocId {
-        if self.fault == Fault::LaggingLastDocId && self.offset > 0 {
-            self.result.doc_id.saturating_sub(1)
-        } else {
-            self.result.doc_id
+        match self.fault {
+            Fault::LaggingLastDocId if self.offset > 0 => self.result.doc_id.saturating_sub(1),
+            Fault::ForgetfulLastDocId if !self.just_yielded.replace(false) => 0,
+            _ => self.result.doc_id,
         }
     }
 
     fn at_eof(&self) -> bool {
-        self.fault != Fault::NeverAtEof && self.past_end()
+        match self.fault {
+            Fault::NeverAtEof => false,
+            Fault::EofWhileUnread => self.offset == 0 || self.past_end(),
+            _ => self.past_end(),
+        }
     }
 
     fn type_(&self) -> IteratorType {
@@ -311,6 +350,47 @@ fn catches_yield_after_exhaustion() {
 }
 
 #[test]
+#[should_panic(expected = "broke the precondition")]
+fn catches_backward_skip_licensed_by_a_stale_last_doc_id() {
+    let mut it = ContractChecker::new(Misbehaving::new(
+        vec![10, 20, 30],
+        Fault::ForgetfulLastDocId,
+    ));
+    assert!(matches!(it.skip_to(30), Ok(Some(SkipToOutcome::Found(_)))));
+    // The iterator now under-reports `last_doc_id()` as 0, which would license
+    // this backward probe if the checker took its word for where it stands. It
+    // tracks doc 30 itself, so the probe is rejected regardless.
+    let _ = it.skip_to(20);
+}
+
+#[test]
+#[should_panic(expected = "last_doc_id() must still report")]
+fn catches_stale_last_doc_id_before_a_forward_skip() {
+    let mut it = ContractChecker::new(Misbehaving::new(
+        vec![10, 20, 30],
+        Fault::ForgetfulLastDocId,
+    ));
+    assert!(matches!(it.skip_to(30), Ok(Some(SkipToOutcome::Found(_)))));
+    // The probe itself is well-formed; the iterator having forgotten its
+    // position is the violation.
+    let _ = it.skip_to(40);
+}
+
+#[test]
+#[should_panic(expected = "cannot yield anything by construction")]
+fn catches_read_from_an_iterator_that_reports_eof_while_unread() {
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::EofWhileUnread));
+    let _ = it.read();
+}
+
+#[test]
+#[should_panic(expected = "cannot yield anything by construction")]
+fn catches_skip_from_an_iterator_that_reports_eof_while_unread() {
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::EofWhileUnread));
+    let _ = it.skip_to(2);
+}
+
+#[test]
 #[should_panic(expected = "must not claim the probed id")]
 fn catches_skip_claiming_probed_id() {
     let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::ClaimsProbedId));
@@ -348,6 +428,52 @@ fn catches_underestimating_num_estimated() {
 }
 
 #[test]
+#[should_panic(expected = "must be an upper bound")]
+fn catches_estimate_shrinking_below_the_results_already_yielded() {
+    // The estimate is a valid upper bound at every yield and only collapses
+    // afterwards, so it takes reading it to catch this.
+    let it = drain(Fault::ShrinkingEstimate);
+    let _ = it.num_estimated();
+}
+
+#[test]
+#[should_panic(expected = "revalidate (ok): at_eof() must be false")]
+fn catches_revalidate_ok_losing_the_position() {
+    let mock_ctx = MockContext::new(0, 0);
+    let mut it = ContractChecker::new(Misbehaving::new(
+        vec![1, 2],
+        Fault::LosesPositionOnOkRevalidate,
+    ));
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
+    // `last_doc_id()` still answers 1, so only re-checking the rest of the
+    // position surfaces the drop to EOF.
+    let _ = it.revalidate(&*mock_ctx.spec_read());
+}
+
+#[test]
+#[should_panic(expected = "must not move the position backwards")]
+fn catches_revalidate_moving_backwards() {
+    let mock_ctx = MockContext::new(0, 0);
+    let mut it = ContractChecker::new(Misbehaving::new(
+        vec![10, 20, 30],
+        Fault::MovesBackwardsOnRevalidate,
+    ));
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 10);
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 20);
+    // The reported position is self-consistent — every accessor agrees on doc
+    // 10 — but adopting it would replay documents the caller already saw.
+    let _ = it.revalidate(&*mock_ctx.spec_read());
+}
+
+#[test]
+#[should_panic(expected = "cannot move back onto a document without a rewind")]
+fn catches_revalidate_resurrecting_an_exhausted_iterator() {
+    let mock_ctx = MockContext::new(0, 0);
+    let mut it = drain(Fault::MovesBackwardsOnRevalidate);
+    let _ = it.revalidate(&*mock_ctx.spec_read());
+}
+
+#[test]
 #[should_panic(expected = "must be dropped, not used")]
 fn catches_use_after_abort() {
     let mock_ctx = MockContext::new(0, 0);
@@ -355,4 +481,15 @@ fn catches_use_after_abort() {
     let status = it.revalidate(&*mock_ctx.spec_read()).unwrap();
     assert!(matches!(status, RQEValidateStatus::Aborted));
     let _ = it.read();
+}
+
+#[test]
+#[should_panic(expected = "must be dropped, not used")]
+fn catches_num_estimated_after_abort() {
+    let mock_ctx = MockContext::new(0, 0);
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::AbortsOnRevalidate));
+    let status = it.revalidate(&*mock_ctx.spec_read()).unwrap();
+    assert!(matches!(status, RQEValidateStatus::Aborted));
+    // A planning-time accessor is no exception: the iterator is gone.
+    let _ = it.num_estimated();
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/contract_checker.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/contract_checker.rs
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Tests for [`ContractChecker`] itself: a well-behaved iterator passes every
+//! check transparently, and each way an iterator (or its driver) can break the
+//! [`RQEIterator`] contract is caught at the operation that commits it.
+//!
+//! The violations are staged through [`Misbehaving`], a minimal sorted-id-list
+//! iterator that misbehaves in exactly one configurable way per instance.
+
+use index_result::RSIndexResult;
+use index_spec::IndexSpecReadGuard;
+use rqe_core::DocId;
+use rqe_iterators::{
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    id_list::{IdListSorted, IdListUnsorted},
+};
+use rqe_iterators_test_utils::{
+    ContractChecker, MockContext, assert_current_contract, assert_current_contract_via_skip_to,
+};
+
+#[test]
+fn well_behaved_iterator_passes_transparently() {
+    let mut it = ContractChecker::new(IdListSorted::new(vec![10, 20, 30, 50, 80]));
+
+    // The fixed contract drains compose with the checker.
+    assert_eq!(assert_current_contract(&mut it), [10, 20, 30, 50, 80]);
+    assert_current_contract_via_skip_to(&mut it, 81);
+
+    // A mixed read/skip drive passes every per-operation check.
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 10);
+    assert!(matches!(it.skip_to(30), Ok(Some(SkipToOutcome::Found(_)))));
+    assert!(matches!(
+        it.skip_to(40),
+        Ok(Some(SkipToOutcome::NotFound(_)))
+    ));
+    assert_eq!(it.last_doc_id(), 50);
+    assert_eq!(it.current().unwrap().doc_id, 50);
+    assert!(matches!(it.skip_to(90), Ok(None)));
+    assert!(it.at_eof());
+}
+
+#[test]
+fn unordered_checker_accepts_out_of_order_ids() {
+    let mut it = ContractChecker::new_unordered(IdListUnsorted::new(vec![5, 3, 8, 1]));
+    assert_eq!(assert_current_contract(&mut it), [5, 3, 8, 1]);
+}
+
+#[test]
+#[should_panic(expected = "doc ids must strictly ascend")]
+fn catches_out_of_order_ids() {
+    let mut it = ContractChecker::new(IdListUnsorted::new(vec![5, 3, 8, 1]));
+    let _ = assert_current_contract(&mut it);
+}
+
+#[test]
+#[should_panic(expected = "broke the precondition")]
+fn catches_caller_skipping_backwards() {
+    let mut it = ContractChecker::new(IdListSorted::new(vec![10, 20, 30]));
+    assert!(matches!(it.skip_to(30), Ok(Some(_))));
+    // The bug under test sits in the *driver*: `skip_to` requires
+    // `last_doc_id() < doc_id`, and the checker enforces it on the caller's
+    // behalf before forwarding.
+    let _ = it.skip_to(20);
+}
+
+#[test]
+fn revalidate_ok_passes() {
+    let mock_ctx = MockContext::new(0, 0);
+    let mut it = ContractChecker::new(IdListSorted::new(vec![1, 2, 3]));
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
+    let status = it
+        .revalidate(&*mock_ctx.spec_read())
+        .expect("revalidate failed");
+    assert_eq!(status, RQEValidateStatus::Ok);
+    // The drive continues cleanly after an in-place revalidation.
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 2);
+}
+
+/// A single misbehaviour for [`Misbehaving`] to commit; everything else about
+/// the iterator stays correct so the checker's panic can be pinned to it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Fault {
+    /// Behave correctly, except that `revalidate` answers `Moved` in place —
+    /// benign, used to exercise the checker's `Moved` agreement checks.
+    MovedOnRevalidate,
+    /// `current()` keeps handing out the stale result after running past the
+    /// end.
+    StaleCurrentPastEnd,
+    /// `at_eof()` never turns true.
+    NeverAtEof,
+    /// `last_doc_id()` lags behind the result `read` just yielded.
+    LaggingLastDocId,
+    /// An exhausted iterator starts yielding results again.
+    YieldsAfterExhaustion,
+    /// A `skip_to` that found nothing records the probed id as its position.
+    ClaimsProbedId,
+    /// `skip_to` answers `NotFound` even on an exact match.
+    NotFoundOnExactMatch,
+    /// `rewind` leaves the exhausted state latched.
+    LatchedRewind,
+    /// `current()` returns a different result object than `read` yielded.
+    ForeignCurrent,
+    /// `num_estimated()` under-reports the number of results.
+    UnderEstimates,
+    /// `revalidate` aborts the iterator.
+    AbortsOnRevalidate,
+}
+
+/// A minimal sorted-id-list iterator committing exactly one [`Fault`].
+///
+/// Position is encoded like `IdList`'s: `offset` is the index of the next id
+/// to yield, so `offset == ids.len()` is still a live position (on the last
+/// id) and one step further means the iterator ran past its end.
+struct Misbehaving<'index> {
+    ids: Vec<DocId>,
+    offset: usize,
+    result: RSIndexResult<'index>,
+    /// A second result object, handed out by [`Fault::ForeignCurrent`].
+    spare: RSIndexResult<'index>,
+    fault: Fault,
+}
+
+impl Misbehaving<'_> {
+    fn new(ids: Vec<DocId>, fault: Fault) -> Self {
+        Self {
+            ids,
+            offset: 0,
+            result: RSIndexResult::build_virt().build(),
+            spare: RSIndexResult::build_virt().build(),
+            fault,
+        }
+    }
+
+    fn past_end(&self) -> bool {
+        self.offset > self.ids.len()
+    }
+}
+
+impl<'index> RQEIterator<'index> for Misbehaving<'index> {
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        if self.past_end() {
+            return (self.fault == Fault::StaleCurrentPastEnd).then_some(&mut self.result);
+        }
+        if self.fault == Fault::ForeignCurrent {
+            self.spare.doc_id = self.result.doc_id;
+            return Some(&mut self.spare);
+        }
+        Some(&mut self.result)
+    }
+
+    fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
+        if self.past_end() {
+            if self.fault == Fault::YieldsAfterExhaustion {
+                self.result.doc_id = self.ids[0];
+                return Ok(Some(&mut self.result));
+            }
+            return Ok(None);
+        }
+        let Some(&id) = self.ids.get(self.offset) else {
+            self.offset = self.ids.len() + 1;
+            return Ok(None);
+        };
+        self.offset += 1;
+        self.result.doc_id = id;
+        Ok(Some(&mut self.result))
+    }
+
+    fn skip_to(
+        &mut self,
+        doc_id: DocId,
+    ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
+        while let Some(&id) = self.ids.get(self.offset) {
+            self.offset += 1;
+            if id >= doc_id {
+                self.result.doc_id = id;
+                let found = id == doc_id && self.fault != Fault::NotFoundOnExactMatch;
+                return Ok(Some(if found {
+                    SkipToOutcome::Found(&mut self.result)
+                } else {
+                    SkipToOutcome::NotFound(&mut self.result)
+                }));
+            }
+        }
+        self.offset = self.ids.len() + 1;
+        if self.fault == Fault::ClaimsProbedId {
+            self.result.doc_id = doc_id;
+        }
+        Ok(None)
+    }
+
+    fn revalidate(
+        &mut self,
+        _spec: &IndexSpecReadGuard,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        Ok(match self.fault {
+            Fault::AbortsOnRevalidate => RQEValidateStatus::Aborted,
+            Fault::MovedOnRevalidate => RQEValidateStatus::Moved {
+                current: self.current(),
+            },
+            _ => RQEValidateStatus::Ok,
+        })
+    }
+
+    fn rewind(&mut self) {
+        if self.fault == Fault::LatchedRewind && self.past_end() {
+            return;
+        }
+        self.offset = 0;
+        self.result.doc_id = 0;
+    }
+
+    fn num_estimated(&self) -> usize {
+        if self.fault == Fault::UnderEstimates {
+            self.ids.len() - 1
+        } else {
+            self.ids.len()
+        }
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        if self.fault == Fault::LaggingLastDocId && self.offset > 0 {
+            self.result.doc_id.saturating_sub(1)
+        } else {
+            self.result.doc_id
+        }
+    }
+
+    fn at_eof(&self) -> bool {
+        self.fault != Fault::NeverAtEof && self.past_end()
+    }
+
+    fn type_(&self) -> IteratorType {
+        IteratorType::IdListSorted
+    }
+
+    fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
+        1.0
+    }
+}
+
+/// Wrap a [`Misbehaving`] iterator and drain it through the checker.
+fn drain(fault: Fault) -> ContractChecker<Misbehaving<'static>> {
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], fault));
+    while it.read().expect("read must not fail").is_some() {}
+    it
+}
+
+#[test]
+fn misbehaving_without_fault_passes() {
+    // `MovedOnRevalidate` is the benign configuration: it proves the mock
+    // itself upholds the contract, so the `catches_*` panics below can only
+    // come from each test's single fault.
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::MovedOnRevalidate));
+    assert_eq!(assert_current_contract(&mut it), [1, 2]);
+    assert_current_contract_via_skip_to(&mut it, 3);
+}
+
+#[test]
+fn revalidate_moved_agreement_is_verified() {
+    let mock_ctx = MockContext::new(0, 0);
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::MovedOnRevalidate));
+
+    // Moved onto a concrete document: the checker verifies the accessors
+    // agree with the reported position, then the drive continues.
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
+    let status = it.revalidate(&*mock_ctx.spec_read()).unwrap();
+    assert!(matches!(
+        status,
+        RQEValidateStatus::Moved { current: Some(_) }
+    ));
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 2);
+
+    // Moved while past the end: the `current` carried by the status must be
+    // `None`, matching the exhausted position.
+    assert!(it.read().unwrap().is_none());
+    let status = it.revalidate(&*mock_ctx.spec_read()).unwrap();
+    assert!(matches!(status, RQEValidateStatus::Moved { current: None }));
+}
+
+#[test]
+#[should_panic(expected = "current() must be None")]
+fn catches_stale_current_past_end() {
+    drain(Fault::StaleCurrentPastEnd);
+}
+
+#[test]
+#[should_panic(expected = "at_eof() must be true")]
+fn catches_eof_never_reported() {
+    drain(Fault::NeverAtEof);
+}
+
+#[test]
+#[should_panic(expected = "last_doc_id() must track")]
+fn catches_lagging_last_doc_id() {
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::LaggingLastDocId));
+    let _ = it.read();
+}
+
+#[test]
+#[should_panic(expected = "must keep returning None")]
+fn catches_yield_after_exhaustion() {
+    let mut it = drain(Fault::YieldsAfterExhaustion);
+    let _ = it.read();
+}
+
+#[test]
+#[should_panic(expected = "must not claim the probed id")]
+fn catches_skip_claiming_probed_id() {
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::ClaimsProbedId));
+    let _ = it.skip_to(5);
+}
+
+#[test]
+#[should_panic(expected = "NotFound promises")]
+fn catches_not_found_on_exact_match() {
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::NotFoundOnExactMatch));
+    let _ = it.skip_to(2);
+}
+
+#[test]
+#[should_panic(expected = "an exhausted state must not latch")]
+fn catches_latched_rewind() {
+    let mut it = drain(Fault::LatchedRewind);
+    it.rewind();
+}
+
+#[test]
+#[should_panic(expected = "same result object")]
+fn catches_foreign_current() {
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::ForeignCurrent));
+    let _ = it.read();
+}
+
+#[test]
+#[should_panic(expected = "must be an upper bound")]
+fn catches_underestimating_num_estimated() {
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2, 3], Fault::UnderEstimates));
+    for _ in 0..3 {
+        let _ = it.read();
+    }
+}
+
+#[test]
+#[should_panic(expected = "must be dropped, not used")]
+fn catches_use_after_abort() {
+    let mock_ctx = MockContext::new(0, 0);
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::AbortsOnRevalidate));
+    let status = it.revalidate(&*mock_ctx.spec_read()).unwrap();
+    assert!(matches!(status, RQEValidateStatus::Aborted));
+    let _ = it.read();
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/contract_checker.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/contract_checker.rs
@@ -92,9 +92,17 @@ enum Fault {
     /// Behave correctly, except that `revalidate` answers `Moved` in place —
     /// benign, used to exercise the checker's `Moved` agreement checks.
     MovedOnRevalidate,
+    /// Every fallible operation reports a timeout — benign, and the checker
+    /// must hand the error back untouched rather than read it as a violation.
+    TimesOut,
     /// `current()` keeps handing out the stale result after running past the
     /// end.
     StaleCurrentPastEnd,
+    /// `current()` is `None` while the iterator is positioned on a result.
+    NoCurrentWhilePositioned,
+    /// `current()` hands back the result once after each yield and answers
+    /// `None` from then on.
+    ForgetfulCurrent,
     /// `at_eof()` never turns true.
     NeverAtEof,
     /// `last_doc_id()` lags behind the result `read` just yielded.
@@ -110,6 +118,8 @@ enum Fault {
     YieldsAfterExhaustion,
     /// A `skip_to` that found nothing records the probed id as its position.
     ClaimsProbedId,
+    /// A `skip_to` that failed records the probed id as its position.
+    ClaimsProbedIdOnTimeout,
     /// `skip_to` answers `NotFound` even on an exact match.
     NotFoundOnExactMatch,
     /// `rewind` leaves the exhausted state latched.
@@ -126,6 +136,12 @@ enum Fault {
     /// `revalidate` drops the iterator to EOF while reporting `Ok`, which
     /// promises the position did not change.
     LosesPositionOnOkRevalidate,
+    /// `revalidate` rewinds the iterator back to its first id while reporting
+    /// `Ok`, undoing the exhaustion the caller already observed.
+    RewindsOnOkRevalidate,
+    /// `revalidate` republishes through `current()` the result the iterator
+    /// yielded before it ran dry, while reporting `Ok`.
+    StaleCurrentAfterOkRevalidate,
     /// `revalidate` reports `Moved` onto a document *behind* the position the
     /// iterator held.
     MovesBackwardsOnRevalidate,
@@ -142,9 +158,13 @@ struct Misbehaving<'index> {
     result: RSIndexResult<'index>,
     /// A second result object, handed out by [`Fault::ForeignCurrent`].
     spare: RSIndexResult<'index>,
-    /// Set by every yield, cleared by the next `last_doc_id()` query — the
-    /// window in which [`Fault::ForgetfulLastDocId`] still tells the truth.
+    /// Set by every yield, cleared by the next query that consumes it — the
+    /// window in which [`Fault::ForgetfulLastDocId`] and
+    /// [`Fault::ForgetfulCurrent`] still tell the truth.
     just_yielded: Cell<bool>,
+    /// Set by the `revalidate` of [`Fault::StaleCurrentAfterOkRevalidate`],
+    /// from which point `current()` republishes the stale result.
+    resurrected: bool,
     fault: Fault,
 }
 
@@ -156,6 +176,7 @@ impl Misbehaving<'_> {
             result: RSIndexResult::build_virt().build(),
             spare: RSIndexResult::build_virt().build(),
             just_yielded: Cell::new(false),
+            resurrected: false,
             fault,
         }
     }
@@ -168,16 +189,25 @@ impl Misbehaving<'_> {
 impl<'index> RQEIterator<'index> for Misbehaving<'index> {
     fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
         if self.past_end() {
-            return (self.fault == Fault::StaleCurrentPastEnd).then_some(&mut self.result);
+            let stale = self.fault == Fault::StaleCurrentPastEnd
+                || (self.fault == Fault::StaleCurrentAfterOkRevalidate && self.resurrected);
+            return stale.then_some(&mut self.result);
         }
-        if self.fault == Fault::ForeignCurrent {
-            self.spare.doc_id = self.result.doc_id;
-            return Some(&mut self.spare);
+        match self.fault {
+            Fault::NoCurrentWhilePositioned => None,
+            Fault::ForgetfulCurrent if !self.just_yielded.replace(false) => None,
+            Fault::ForeignCurrent => {
+                self.spare.doc_id = self.result.doc_id;
+                Some(&mut self.spare)
+            }
+            _ => Some(&mut self.result),
         }
-        Some(&mut self.result)
     }
 
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
+        if self.fault == Fault::TimesOut {
+            return Err(RQEIteratorError::TimedOut);
+        }
         if self.past_end() {
             if self.fault == Fault::YieldsAfterExhaustion {
                 self.result.doc_id = self.ids[0];
@@ -199,6 +229,13 @@ impl<'index> RQEIterator<'index> for Misbehaving<'index> {
         &mut self,
         doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
+        if self.fault == Fault::TimesOut {
+            return Err(RQEIteratorError::TimedOut);
+        }
+        if self.fault == Fault::ClaimsProbedIdOnTimeout {
+            self.result.doc_id = doc_id;
+            return Err(RQEIteratorError::TimedOut);
+        }
         while let Some(&id) = self.ids.get(self.offset) {
             self.offset += 1;
             if id >= doc_id {
@@ -223,6 +260,9 @@ impl<'index> RQEIterator<'index> for Misbehaving<'index> {
         &mut self,
         _spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        if self.fault == Fault::TimesOut {
+            return Err(RQEIteratorError::TimedOut);
+        }
         Ok(match self.fault {
             Fault::AbortsOnRevalidate => RQEValidateStatus::Aborted,
             Fault::MovedOnRevalidate => RQEValidateStatus::Moved {
@@ -230,6 +270,16 @@ impl<'index> RQEIterator<'index> for Misbehaving<'index> {
             },
             Fault::LosesPositionOnOkRevalidate => {
                 self.offset = self.ids.len() + 1;
+                RQEValidateStatus::Ok
+            }
+            Fault::RewindsOnOkRevalidate => {
+                // `result` is left alone, so `last_doc_id()` keeps answering as
+                // it did — only the rest of the position gives the rewind away.
+                self.offset = 0;
+                RQEValidateStatus::Ok
+            }
+            Fault::StaleCurrentAfterOkRevalidate => {
+                self.resurrected = true;
                 RQEValidateStatus::Ok
             }
             Fault::MovesBackwardsOnRevalidate => {
@@ -324,6 +374,38 @@ fn revalidate_moved_agreement_is_verified() {
 }
 
 #[test]
+fn revalidate_moved_is_not_direction_checked_when_unordered() {
+    let mock_ctx = MockContext::new(0, 0);
+    let mut it =
+        ContractChecker::new_unordered(Misbehaving::new(vec![1, 2], Fault::MovedOnRevalidate));
+
+    // An iterator whose ids need not ascend gives the checker nothing to
+    // compare a `Moved` position against, so only the accessor agreement is
+    // verified.
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
+    let status = it.revalidate(&*mock_ctx.spec_read()).unwrap();
+    assert!(matches!(
+        status,
+        RQEValidateStatus::Moved { current: Some(_) }
+    ));
+}
+
+#[test]
+fn errors_are_handed_back_untouched() {
+    let mock_ctx = MockContext::new(0, 0);
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::TimesOut));
+
+    // A failed operation is not a contract violation: the checker forwards the
+    // error and leaves its record of the position alone.
+    assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
+    assert!(matches!(it.skip_to(5), Err(RQEIteratorError::TimedOut)));
+    assert!(matches!(
+        it.revalidate(&*mock_ctx.spec_read()),
+        Err(RQEIteratorError::TimedOut)
+    ));
+}
+
+#[test]
 #[should_panic(expected = "current() must be None")]
 fn catches_stale_current_past_end() {
     drain(Fault::StaleCurrentPastEnd);
@@ -391,9 +473,37 @@ fn catches_skip_from_an_iterator_that_reports_eof_while_unread() {
 }
 
 #[test]
+#[should_panic(expected = "current: must be None on an iterator that reports at_eof()")]
+fn catches_current_on_an_iterator_that_reports_eof_while_unread() {
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::EofWhileUnread));
+    // Nothing has been read yet, so the only result the iterator could be
+    // holding is one it promised it does not have.
+    let _ = it.current();
+}
+
+#[test]
+#[should_panic(expected = "revalidate (ok): current() must be None on an iterator")]
+fn catches_revalidate_ok_keeping_a_current_while_eof_and_unread() {
+    let mock_ctx = MockContext::new(0, 0);
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::EofWhileUnread));
+    // `Ok` re-runs the checks for the unread position, so the phantom result is
+    // caught even though no read or skip has happened.
+    let _ = it.revalidate(&*mock_ctx.spec_read());
+}
+
+#[test]
 #[should_panic(expected = "must not claim the probed id")]
 fn catches_skip_claiming_probed_id() {
     let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::ClaimsProbedId));
+    let _ = it.skip_to(5);
+}
+
+#[test]
+#[should_panic(expected = "must not claim the probed id")]
+fn catches_failed_skip_claiming_probed_id() {
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::ClaimsProbedIdOnTimeout));
+    // A skip that fails carries no result either, so it is under the same
+    // obligation not to leave the probed id behind as its position.
     let _ = it.skip_to(5);
 }
 
@@ -416,6 +526,26 @@ fn catches_latched_rewind() {
 fn catches_foreign_current() {
     let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::ForeignCurrent));
     let _ = it.read();
+}
+
+#[test]
+#[should_panic(expected = "read: current() must be Some")]
+fn catches_missing_current_on_a_yield() {
+    let mut it = ContractChecker::new(Misbehaving::new(
+        vec![1, 2],
+        Fault::NoCurrentWhilePositioned,
+    ));
+    let _ = it.read();
+}
+
+#[test]
+#[should_panic(expected = "current: must be Some")]
+fn catches_current_dropped_after_a_yield() {
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::ForgetfulCurrent));
+    // The result was there when `read` handed it out, so it takes a second
+    // query to catch the iterator letting go of it.
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
+    let _ = it.current();
 }
 
 #[test]
@@ -447,6 +577,37 @@ fn catches_revalidate_ok_losing_the_position() {
     assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
     // `last_doc_id()` still answers 1, so only re-checking the rest of the
     // position surfaces the drop to EOF.
+    let _ = it.revalidate(&*mock_ctx.spec_read());
+}
+
+#[test]
+#[should_panic(expected = "revalidate (ok): current() must be Some")]
+fn catches_revalidate_ok_dropping_the_current_result() {
+    let mock_ctx = MockContext::new(0, 0);
+    let mut it = ContractChecker::new(Misbehaving::new(vec![1, 2], Fault::ForgetfulCurrent));
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
+    // Both `last_doc_id()` and `at_eof()` still describe doc 1; the position
+    // `Ok` promised to have kept is only half there.
+    let _ = it.revalidate(&*mock_ctx.spec_read());
+}
+
+#[test]
+#[should_panic(expected = "revalidate (ok): at_eof() must be true")]
+fn catches_revalidate_ok_rewinding_the_iterator() {
+    let mock_ctx = MockContext::new(0, 0);
+    let mut it = drain(Fault::RewindsOnOkRevalidate);
+    // The caller has already been told the iterator ran dry, so quietly
+    // undoing that is a move, not an `Ok`.
+    let _ = it.revalidate(&*mock_ctx.spec_read());
+}
+
+#[test]
+#[should_panic(expected = "revalidate (ok): current() must be None once")]
+fn catches_revalidate_ok_resurrecting_the_stale_current() {
+    let mock_ctx = MockContext::new(0, 0);
+    let mut it = drain(Fault::StaleCurrentAfterOkRevalidate);
+    // `at_eof()` and `last_doc_id()` both still say the iterator is past its
+    // end; only `current()` hands the exhausted position a result again.
     let _ = it.revalidate(&*mock_ctx.spec_read());
 }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/id_list.rs
@@ -13,23 +13,24 @@ use rqe_iterators::{
     IteratorType, RQEIterator, RQEValidateStatus, SkipToOutcome,
     id_list::{IdListSorted, IdListUnsorted},
 };
+use rqe_iterators_test_utils::ContractChecker;
 use rstest_reuse::apply;
 
 #[test]
 fn type_sorted() {
-    let it = IdListSorted::new(vec![1, 2, 3]);
+    let it = ContractChecker::new(IdListSorted::new(vec![1, 2, 3]));
     assert_eq!(it.type_(), IteratorType::IdListSorted);
 }
 
 #[test]
 fn type_unsorted() {
-    let it = IdListUnsorted::new(vec![3, 1, 2]);
+    let it = ContractChecker::new_unordered(IdListUnsorted::new(vec![3, 1, 2]));
     assert_eq!(it.type_(), IteratorType::IdListUnsorted);
 }
 
 #[test]
 fn empty_initialization_works() {
-    let mut i = IdListSorted::new(vec![]);
+    let mut i = ContractChecker::new(IdListSorted::new(vec![]));
 
     let result = i.current().unwrap();
     assert_eq!(0, result.doc_id);
@@ -52,7 +53,7 @@ fn unsorted_initialization_of_sorted_variant_panics() {
 
 #[test]
 fn unsorted_initialization_of_unsorted_variant_works() {
-    let mut it = IdListUnsorted::new(vec![5, 3, 1, 4, 2]);
+    let mut it = ContractChecker::new_unordered(IdListUnsorted::new(vec![5, 3, 1, 4, 2]));
 
     let result = it.current().unwrap();
     assert_eq!(0, result.doc_id);
@@ -62,7 +63,7 @@ fn unsorted_initialization_of_unsorted_variant_works() {
 #[test]
 #[should_panic(expected = "Can't skip when working with unsorted document ids")]
 fn unsorted_variant_cannot_skip() {
-    let mut i = IdListUnsorted::new(vec![5, 3, 1, 4, 2]);
+    let mut i = ContractChecker::new_unordered(IdListUnsorted::new(vec![5, 3, 1, 4, 2]));
     let _ = i.skip_to(3);
 }
 
@@ -74,7 +75,7 @@ fn duplicate_initialization() {
 
 #[apply(id_cases)]
 fn read(#[case] case: &[u64]) {
-    let mut it = IdListSorted::new(case.to_vec());
+    let mut it = ContractChecker::new(IdListSorted::new(case.to_vec()));
 
     assert_eq!(it.num_estimated(), case.len());
     assert!(!it.at_eof());
@@ -102,7 +103,7 @@ fn read(#[case] case: &[u64]) {
 #[apply(id_cases)]
 #[cfg_attr(miri, ignore = "Takes too long with Miri, causing CI to timeout")]
 fn skip_to(#[case] case: &[u64]) {
-    let mut it = IdListSorted::new(case.to_vec());
+    let mut it = ContractChecker::new(IdListSorted::new(case.to_vec()));
 
     // Read first element
     let first_doc = it.read().unwrap().unwrap();
@@ -173,7 +174,7 @@ fn skip_between_any_pair(#[case] case: &[u64]) {
         return;
     }
 
-    let mut it = IdListSorted::new(case.to_vec());
+    let mut it = ContractChecker::new(IdListSorted::new(case.to_vec()));
 
     for from_idx in 0..case.len() - 1 {
         for to_idx in from_idx + 1..case.len() {
@@ -205,7 +206,7 @@ fn skip_between_any_pair(#[case] case: &[u64]) {
 
 #[apply(id_cases)]
 fn rewind(#[case] case: &[u64]) {
-    let mut it = IdListSorted::new(case.to_vec());
+    let mut it = ContractChecker::new(IdListSorted::new(case.to_vec()));
 
     // Skip to each doc ID, verify, then rewind and check reset
     for &id in case {
@@ -240,7 +241,7 @@ fn rewind(#[case] case: &[u64]) {
 #[test]
 fn revalidate() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let mut it = IdListSorted::new(vec![1, 2, 3]);
+    let mut it = ContractChecker::new(IdListSorted::new(vec![1, 2, 3]));
     let status = it
         .revalidate(&*mock_ctx.spec_read())
         .expect("revalidate failed");
@@ -265,7 +266,7 @@ mod via_resume {
 #[test]
 fn id_list_sorted_upholds_current_contract() {
     use rqe_iterators_test_utils::{assert_current_contract, assert_current_contract_via_skip_to};
-    let mut it = IdListSorted::new(vec![10, 20, 30, 50, 80]);
+    let mut it = ContractChecker::new(IdListSorted::new(vec![10, 20, 30, 50, 80]));
     assert_eq!(assert_current_contract(&mut it), [10, 20, 30, 50, 80]);
     assert_current_contract_via_skip_to(&mut it, 81);
 }
@@ -273,6 +274,6 @@ fn id_list_sorted_upholds_current_contract() {
 #[test]
 fn id_list_unsorted_upholds_current_contract() {
     use rqe_iterators_test_utils::assert_current_contract;
-    let mut it = IdListUnsorted::new(vec![10, 20, 30, 50, 80]);
+    let mut it = ContractChecker::new_unordered(IdListUnsorted::new(vec![10, 20, 30, 50, 80]));
     assert_eq!(assert_current_contract(&mut it), [10, 20, 30, 50, 80]);
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/main.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/main.rs
@@ -33,6 +33,7 @@ use rstest_reuse::template;
 fn id_cases(#[case] case: &[u64]) {}
 
 mod c2rust;
+mod contract_checker;
 mod deferred;
 mod empty;
 #[cfg(not(miri))]

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/contract_checker.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/contract_checker.rs
@@ -74,23 +74,31 @@ enum RevalidateSummary<'index> {
 ///   [`current`](RQEIterator::current) is `None` (not the stale last result),
 ///   and the exhausted state holds until [`rewind`](RQEIterator::rewind) — an
 ///   exhausted iterator must keep returning `None`.
+/// - An iterator that reports [`at_eof`](RQEIterator::at_eof) while unread
+///   cannot yield anything *by construction*, so it must never produce a
+///   result before a [`rewind`](RQEIterator::rewind) — or after one.
 /// - [`skip_to`](RQEIterator::skip_to): `Found` carries the requested id,
 ///   `NotFound` carries a strictly greater one, and a skip that found nothing
 ///   must not claim the probed id as its position. The *caller* precondition
 ///   `last_doc_id() < doc_id` is asserted too, so a misbehaving driver (e.g. a
-///   parent iterator skipping backwards) is caught as well.
+///   parent iterator skipping backwards) is caught as well — against the
+///   checker's own [`Position`] record, so an iterator that under-reports
+///   [`last_doc_id`](RQEIterator::last_doc_id) cannot license a backward probe.
 /// - [`rewind`](RQEIterator::rewind) restores the
 ///   [`at_eof`](RQEIterator::at_eof) answer observed at construction: the
 ///   exhausted state must not latch.
-/// - [`revalidate`](RQEIterator::revalidate): `Ok` keeps
-///   [`last_doc_id`](RQEIterator::last_doc_id) unchanged, `Moved` lands on a
-///   position the accessors agree on, and any use after `Aborted` panics —
-///   an aborted iterator must be dropped.
+/// - [`revalidate`](RQEIterator::revalidate): `Ok` leaves every accessor
+///   answering exactly as it did before the call — it promises the position did
+///   not change; `Moved` lands on a position the accessors agree on, never
+///   behind the previous one and never resurrecting an exhausted iterator; and
+///   any use after `Aborted` panics — an aborted iterator must be dropped.
 /// - Doc ids strictly ascend between rewinds, unless constructed with
 ///   [`new_unordered`](Self::new_unordered).
 /// - The number of results yielded between rewinds never exceeds
 ///   [`num_estimated`](RQEIterator::num_estimated), which is documented as an
-///   upper bound.
+///   upper bound — checked both as results come out and whenever a caller reads
+///   the estimate, since an estimate that shrinks below the count already
+///   handed out breaks the bound just as much.
 ///
 /// # Assumptions
 ///
@@ -221,6 +229,18 @@ impl<'index, I: RQEIterator<'index>> ContractChecker<I> {
         yielded: *const RSIndexResult<'index>,
     ) -> &mut RSIndexResult<'index> {
         self.yielded += 1;
+        self.assert_estimate_bounds_yields(op);
+        self.assert_positioned_on(op, id, yielded)
+    }
+
+    /// The yield-count bound: results handed out since the last
+    /// [`rewind`](RQEIterator::rewind) may never exceed
+    /// [`num_estimated`](RQEIterator::num_estimated), documented as an upper
+    /// bound. Checked as each result comes out *and* whenever a caller reads
+    /// the estimate — an estimate that shrinks below the count already handed
+    /// out breaks the bound wherever it is observed.
+    #[track_caller]
+    fn assert_estimate_bounds_yields(&self, op: &str) -> usize {
         let estimated = self.inner.num_estimated();
         assert!(
             self.yielded <= estimated,
@@ -228,7 +248,76 @@ impl<'index, I: RQEIterator<'index>> ContractChecker<I> {
              {estimated}, which must be an upper bound",
             self.yielded,
         );
-        self.assert_positioned_on(op, id, yielded)
+        estimated
+    }
+
+    /// Panic if an iterator that reported [`at_eof`](RQEIterator::at_eof) while
+    /// unread produced a result anyway. That answer is reserved for iterators
+    /// that cannot yield anything *by construction*, whatever the data, so it
+    /// is a promise about every position — not a state a read can talk its way
+    /// out of.
+    #[track_caller]
+    fn assert_may_yield_while_unread(&self, op: &str, previous: Position, id: DocId) {
+        if previous == Position::Unread {
+            assert!(
+                !self.at_eof_when_unread,
+                "{op}: an iterator that reports at_eof() while unread cannot yield anything by \
+                 construction, but it produced doc {id}",
+            );
+        }
+    }
+
+    /// Re-check that every accessor still answers as the tracked
+    /// [`Position`] says, for an operation that promised not to move the
+    /// iterator.
+    #[track_caller]
+    fn assert_position_unchanged(&mut self, op: &str) {
+        match self.position {
+            Position::Unread => {
+                let at_eof = self.inner.at_eof();
+                assert_eq!(
+                    at_eof, self.at_eof_when_unread,
+                    "{op}: at_eof() changed from {} to {at_eof}, but the iterator has not moved",
+                    self.at_eof_when_unread,
+                );
+                if at_eof {
+                    assert!(
+                        self.inner.current().is_none(),
+                        "{op}: current() must be None on an iterator that reports at_eof() while \
+                         unread",
+                    );
+                }
+            }
+            Position::On(id) => {
+                assert_eq!(
+                    self.inner.last_doc_id(),
+                    id,
+                    "{op}: last_doc_id() must still report the result last yielded (doc {id})",
+                );
+                assert!(
+                    !self.inner.at_eof(),
+                    "{op}: at_eof() must be false while positioned on doc {id}",
+                );
+                let current = self.inner.current().unwrap_or_else(|| {
+                    panic!("{op}: current() must be Some while positioned on doc {id}")
+                });
+                assert_eq!(
+                    current.doc_id, id,
+                    "{op}: current() must still return the result last yielded (doc {id})",
+                );
+            }
+            Position::PastEnd => {
+                assert!(
+                    self.inner.at_eof(),
+                    "{op}: at_eof() must be true once the iterator has run past its last result",
+                );
+                assert!(
+                    self.inner.current().is_none(),
+                    "{op}: current() must be None once the iterator has run past its last result \
+                     — not the stale last result",
+                );
+            }
+        }
     }
 
     /// Checks shared by every operation that ran the iterator past its last
@@ -321,6 +410,7 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for ContractChecker<I> 
                     "read: an exhausted iterator must keep returning None, but it yielded doc \
                      {id}",
                 );
+                self.assert_may_yield_while_unread("read", previous, id);
                 if self.ordered
                     && let Position::On(previous_id) = previous
                 {
@@ -342,13 +432,29 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for ContractChecker<I> 
         doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
         self.assert_usable("skip_to");
-        let last = self.inner.last_doc_id();
+        let previous = self.position;
+        // The precondition is checked against the checker's own record of where
+        // the iterator stands, not the iterator's self-report: an implementation
+        // that under-reports `last_doc_id()` must not be able to license a probe
+        // that walks the position backwards, which would then let a lower
+        // document through every downstream check.
+        let last = match previous {
+            Position::On(id) => id,
+            Position::Unread | Position::PastEnd => self.inner.last_doc_id(),
+        };
         assert!(
             last < doc_id,
             "skip_to({doc_id}): the caller broke the precondition last_doc_id() < doc_id — \
              last_doc_id() is {last}",
         );
-        let previous = self.position;
+        if let Position::On(id) = previous {
+            assert_eq!(
+                self.inner.last_doc_id(),
+                id,
+                "skip_to({doc_id}): last_doc_id() must still report the result last yielded (doc \
+                 {id})",
+            );
+        }
         let outcome = match self.inner.skip_to(doc_id) {
             Ok(outcome) => outcome,
             Err(error) => {
@@ -387,6 +493,7 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for ContractChecker<I> 
                     "skip_to({doc_id}): an iterator that had run past its last result must keep \
                      finding nothing, but it produced doc {id}",
                 );
+                self.assert_may_yield_while_unread("skip_to", previous, id);
                 if found {
                     assert_eq!(
                         id, doc_id,
@@ -416,6 +523,7 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for ContractChecker<I> 
         spec: &IndexSpecReadGuard,
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         self.assert_usable("revalidate");
+        let previous = self.position;
         let previous_last = self.inner.last_doc_id();
         let summary = match self.inner.revalidate(spec)? {
             RQEValidateStatus::Ok => RevalidateSummary::Ok,
@@ -431,12 +539,39 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for ContractChecker<I> 
                     previous_last,
                     "revalidate: Ok promises the same position, but last_doc_id() changed",
                 );
+                // `Ok` is a promise about the whole position, not just the id:
+                // an iterator that quietly dropped to EOF (or swapped its
+                // current result) while leaving `last_doc_id()` alone reports
+                // `Moved`, or it lies here.
+                self.assert_position_unchanged("revalidate (ok)");
                 Ok(RQEValidateStatus::Ok)
             }
             RevalidateSummary::Moved(Some((id, yielded))) => {
                 // Moved onto a concrete document: the same agreement rules as
                 // any other yield apply, but it is a reposition rather than a
                 // new result, so it does not count against `num_estimated`.
+                //
+                // `Moved` also promises the position did not move *back*
+                // (`iterator_api.h` documents it as moving forward), and a
+                // caller emits `current` in place of a read before resuming
+                // from there — so a move backwards replays documents, and one
+                // out of the exhausted state resurrects an iterator that owes
+                // nothing until a `rewind`. Landing on the same document is
+                // accepted: an iterator may report `Moved` purely to hand back
+                // a republished result object for the position it kept.
+                self.assert_may_yield_while_unread("revalidate (moved)", previous, id);
+                match previous {
+                    Position::PastEnd => panic!(
+                        "revalidate: an iterator that had run past its last result cannot move \
+                         back onto a document without a rewind, but Moved reported doc {id}",
+                    ),
+                    Position::On(previous_id) if self.ordered => assert!(
+                        id >= previous_id,
+                        "revalidate: Moved must not move the position backwards, but doc {id} \
+                         comes before doc {previous_id}",
+                    ),
+                    Position::Unread | Position::On(_) => {}
+                }
                 let current = self.assert_positioned_on("revalidate (moved)", id, yielded);
                 Ok(RQEValidateStatus::Moved {
                     current: Some(current),
@@ -468,8 +603,10 @@ impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for ContractChecker<I> 
         );
     }
 
+    #[track_caller]
     fn num_estimated(&self) -> usize {
-        self.inner.num_estimated()
+        self.assert_usable("num_estimated");
+        self.assert_estimate_bounds_yields("num_estimated")
     }
 
     #[track_caller]

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/contract_checker.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/contract_checker.rs
@@ -1,0 +1,523 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! A wrapper that verifies the [`RQEIterator`] contract on every operation.
+//!
+//! [`assert_current_contract`](crate::assert_current_contract) and friends
+//! drive an iterator through a *fixed* scenario and assert the contract along
+//! the way. [`ContractChecker`] turns that inside out: it sits between the
+//! test and the iterator under test, so *whatever* scenario the test drives —
+//! including scenarios the fixed drains never reach — is checked on every
+//! single operation, at the operation that commits the violation.
+
+use index_result::RSIndexResult;
+use index_spec::IndexSpecReadGuard;
+use rqe_core::DocId;
+use rqe_iterators::{
+    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, c2rust,
+};
+
+/// Where the checker believes the wrapped iterator stands, updated on every
+/// operation that can move it.
+///
+/// This is the checker's independent copy of the one piece of state the
+/// [`RQEIterator`] contract revolves around; each subsequent operation is
+/// checked against it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Position {
+    /// No [`read`](RQEIterator::read)/[`skip_to`](RQEIterator::skip_to)
+    /// outcome observed since construction or the last
+    /// [`rewind`](RQEIterator::rewind).
+    Unread,
+    /// The last operation yielded a result with this doc id.
+    On(DocId),
+    /// An operation found nothing: the iterator ran past its last result.
+    PastEnd,
+}
+
+/// [`RQEValidateStatus`] with the borrowed result reduced to its doc id and
+/// address, so the checker can release the borrow, interrogate the iterator,
+/// and only then rebuild the status to hand out.
+enum RevalidateSummary<'index> {
+    Ok,
+    Moved(Option<(DocId, *const RSIndexResult<'index>)>),
+    Aborted,
+}
+
+/// An [`RQEIterator`] wrapper that forwards every operation to the wrapped
+/// iterator and panics on the first contract violation.
+///
+/// Wrap the iterator under test right after constructing it, then drive the
+/// wrapper exactly as you would have driven the iterator — the checks are a
+/// side effect of normal use, so the test's assertions stay about *behaviour*
+/// (which doc ids come out) while the wrapper owns the *contract* (how the
+/// accessors must agree along the way).
+///
+/// # What is checked
+///
+/// Every rule below comes from the [`RQEIterator`] method contracts; the
+/// wrapper holds its own [`Position`] record and checks each operation against
+/// it.
+///
+/// - [`read`](RQEIterator::read)/[`skip_to`](RQEIterator::skip_to) yielding a
+///   result: [`last_doc_id`](RQEIterator::last_doc_id) tracks it,
+///   [`at_eof`](RQEIterator::at_eof) is `false`, and
+///   [`current`](RQEIterator::current) returns the *same* result object.
+/// - [`read`](RQEIterator::read)/[`skip_to`](RQEIterator::skip_to) finding
+///   nothing: [`at_eof`](RQEIterator::at_eof) is `true`,
+///   [`current`](RQEIterator::current) is `None` (not the stale last result),
+///   and the exhausted state holds until [`rewind`](RQEIterator::rewind) — an
+///   exhausted iterator must keep returning `None`.
+/// - [`skip_to`](RQEIterator::skip_to): `Found` carries the requested id,
+///   `NotFound` carries a strictly greater one, and a skip that found nothing
+///   must not claim the probed id as its position. The *caller* precondition
+///   `last_doc_id() < doc_id` is asserted too, so a misbehaving driver (e.g. a
+///   parent iterator skipping backwards) is caught as well.
+/// - [`rewind`](RQEIterator::rewind) restores the
+///   [`at_eof`](RQEIterator::at_eof) answer observed at construction: the
+///   exhausted state must not latch.
+/// - [`revalidate`](RQEIterator::revalidate): `Ok` keeps
+///   [`last_doc_id`](RQEIterator::last_doc_id) unchanged, `Moved` lands on a
+///   position the accessors agree on, and any use after `Aborted` panics —
+///   an aborted iterator must be dropped.
+/// - Doc ids strictly ascend between rewinds, unless constructed with
+///   [`new_unordered`](Self::new_unordered).
+/// - The number of results yielded between rewinds never exceeds
+///   [`num_estimated`](RQEIterator::num_estimated), which is documented as an
+///   upper bound.
+///
+/// # Assumptions
+///
+/// - The iterator is wrapped *before* its first operation; the checker
+///   calibrates its unread-state expectations at construction.
+/// - The test does not change `doc_id` through the `&mut RSIndexResult`
+///   references handed out; the checker records yielded ids and would
+///   misattribute such a mutation to the iterator.
+///
+/// # Limitations
+///
+/// The checker verifies the [`RQEIterator`] surface only. It does not
+/// implement the suspend/resume machinery
+/// ([`RQEIteratorBoxed`](rqe_iterators::RQEIteratorBoxed)), so tests
+/// exercising that path still drive the unwrapped iterator.
+#[expect(rustdoc::private_intra_doc_links)]
+pub struct ContractChecker<I> {
+    inner: I,
+    position: Position,
+    /// The [`at_eof`](RQEIterator::at_eof) answer observed at construction.
+    /// [`rewind`](RQEIterator::rewind) must restore it, and it must not drift
+    /// while [`Position::Unread`]: `false` for almost every iterator, `true`
+    /// only for those that cannot yield anything *by construction* (e.g.
+    /// [`Empty`](rqe_iterators::Empty)).
+    at_eof_when_unread: bool,
+    /// Results yielded since construction or the last
+    /// [`rewind`](RQEIterator::rewind), to check against
+    /// [`num_estimated`](RQEIterator::num_estimated).
+    yielded: usize,
+    /// Whether yielded doc ids must strictly ascend between rewinds.
+    ordered: bool,
+    /// Set once [`revalidate`](RQEIterator::revalidate) returns
+    /// [`Aborted`](RQEValidateStatus::Aborted); every operation afterwards is
+    /// a contract violation.
+    aborted: bool,
+}
+
+impl<'index, I: RQEIterator<'index>> ContractChecker<I> {
+    /// Wrap a freshly-constructed iterator whose doc ids ascend strictly
+    /// between rewinds — the normal case, relied upon by every composite.
+    pub fn new(inner: I) -> Self {
+        Self::with_ordering(inner, true)
+    }
+
+    /// Wrap a freshly-constructed iterator that legitimately yields doc ids
+    /// out of order (e.g.
+    /// [`IdListUnsorted`](rqe_iterators::id_list::IdListUnsorted)), skipping
+    /// the ascending-ids check.
+    pub fn new_unordered(inner: I) -> Self {
+        Self::with_ordering(inner, false)
+    }
+
+    fn with_ordering(inner: I, ordered: bool) -> Self {
+        let at_eof_when_unread = inner.at_eof();
+        Self {
+            inner,
+            position: Position::Unread,
+            at_eof_when_unread,
+            yielded: 0,
+            ordered,
+            aborted: false,
+        }
+    }
+
+    /// Consume the checker, returning the wrapped iterator.
+    pub fn into_inner(self) -> I {
+        self.inner
+    }
+
+    /// Panic if the iterator was aborted by a
+    /// [`revalidate`](RQEIterator::revalidate): the contract demands it be
+    /// dropped, not used.
+    #[track_caller]
+    fn assert_usable(&self, op: &str) {
+        assert!(
+            !self.aborted,
+            "{op}: the iterator reported Aborted from revalidate — it must be dropped, not used",
+        );
+    }
+
+    /// Checks shared by every operation that lands the iterator on a result:
+    /// the position accessors must agree with the doc id just handed out, and
+    /// [`current`](RQEIterator::current) must return the very same result
+    /// object (`yielded` is its address). Returns that result, re-borrowed,
+    /// for the caller to hand out.
+    #[track_caller]
+    fn assert_positioned_on(
+        &mut self,
+        op: &str,
+        id: DocId,
+        yielded: *const RSIndexResult<'index>,
+    ) -> &mut RSIndexResult<'index> {
+        assert_eq!(
+            self.inner.last_doc_id(),
+            id,
+            "{op}: last_doc_id() must track the result just handed out (doc {id})",
+        );
+        assert!(
+            !self.inner.at_eof(),
+            "{op}: at_eof() must be false while positioned on doc {id}, including on the last \
+             result",
+        );
+        self.position = Position::On(id);
+        let current = self
+            .inner
+            .current()
+            .unwrap_or_else(|| panic!("{op}: current() must be Some while positioned on doc {id}"));
+        assert_eq!(
+            current.doc_id, id,
+            "{op}: current() must agree with the result just handed out (doc {id})",
+        );
+        assert!(
+            std::ptr::eq(yielded, current),
+            "{op}: current() must hand back the same result object the operation returned, not a \
+             different one",
+        );
+        current
+    }
+
+    /// [`assert_positioned_on`](Self::assert_positioned_on) plus the
+    /// yield-count bound, for operations that yield a *new* result rather
+    /// than re-report the current one.
+    #[track_caller]
+    fn after_yield(
+        &mut self,
+        op: &str,
+        id: DocId,
+        yielded: *const RSIndexResult<'index>,
+    ) -> &mut RSIndexResult<'index> {
+        self.yielded += 1;
+        let estimated = self.inner.num_estimated();
+        assert!(
+            self.yielded <= estimated,
+            "{op}: {} results yielded since the last rewind exceeds num_estimated() = \
+             {estimated}, which must be an upper bound",
+            self.yielded,
+        );
+        self.assert_positioned_on(op, id, yielded)
+    }
+
+    /// Checks shared by every operation that ran the iterator past its last
+    /// result: both EOF oracles must report it.
+    #[track_caller]
+    fn after_exhaustion(&mut self, op: &str) {
+        assert!(
+            self.inner.at_eof(),
+            "{op}: at_eof() must be true once the operation has found nothing",
+        );
+        assert!(
+            self.inner.current().is_none(),
+            "{op}: current() must be None once the iterator has run past its last result — not \
+             the stale last result",
+        );
+        self.position = Position::PastEnd;
+    }
+}
+
+impl<'index, I: RQEIterator<'index>> RQEIterator<'index> for ContractChecker<I> {
+    #[track_caller]
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        self.assert_usable("current");
+        match self.position {
+            Position::Unread => {
+                let at_eof = self.inner.at_eof();
+                assert_eq!(
+                    at_eof, self.at_eof_when_unread,
+                    "current: at_eof() changed from {} to {at_eof} without any read or skip_to",
+                    self.at_eof_when_unread,
+                );
+                let current = self.inner.current();
+                if at_eof {
+                    // Only an iterator that is empty by construction is at EOF
+                    // while unread, and such an iterator has nothing current.
+                    assert!(
+                        current.is_none(),
+                        "current: must be None on an iterator that reports at_eof() while unread",
+                    );
+                }
+                current
+            }
+            Position::On(id) => {
+                assert!(
+                    !self.inner.at_eof(),
+                    "current: at_eof() must be false while positioned on doc {id}",
+                );
+                let current = self.inner.current().unwrap_or_else(|| {
+                    panic!("current: must be Some while positioned on doc {id}")
+                });
+                assert_eq!(
+                    current.doc_id, id,
+                    "current: must still return the result last yielded (doc {id})",
+                );
+                Some(current)
+            }
+            Position::PastEnd => {
+                assert!(
+                    self.inner.at_eof(),
+                    "current: at_eof() must be true once the iterator has run past its last \
+                     result",
+                );
+                assert!(
+                    self.inner.current().is_none(),
+                    "current: must be None once the iterator has run past its last result — not \
+                     the stale last result",
+                );
+                None
+            }
+        }
+    }
+
+    #[track_caller]
+    fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
+        self.assert_usable("read");
+        let previous = self.position;
+        let outcome = self
+            .inner
+            .read()?
+            .map(|result| (result.doc_id, result as *const RSIndexResult<'index>));
+        match outcome {
+            None => {
+                self.after_exhaustion("read");
+                Ok(None)
+            }
+            Some((id, yielded)) => {
+                assert_ne!(
+                    previous,
+                    Position::PastEnd,
+                    "read: an exhausted iterator must keep returning None, but it yielded doc \
+                     {id}",
+                );
+                if self.ordered
+                    && let Position::On(previous_id) = previous
+                {
+                    assert!(
+                        id > previous_id,
+                        "read: doc ids must strictly ascend between rewinds, but {id} follows \
+                         {previous_id} — wrap deliberately unordered iterators with \
+                         `ContractChecker::new_unordered`",
+                    );
+                }
+                Ok(Some(self.after_yield("read", id, yielded)))
+            }
+        }
+    }
+
+    #[track_caller]
+    fn skip_to(
+        &mut self,
+        doc_id: DocId,
+    ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
+        self.assert_usable("skip_to");
+        let last = self.inner.last_doc_id();
+        assert!(
+            last < doc_id,
+            "skip_to({doc_id}): the caller broke the precondition last_doc_id() < doc_id — \
+             last_doc_id() is {last}",
+        );
+        let previous = self.position;
+        let outcome = match self.inner.skip_to(doc_id) {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                assert_ne!(
+                    self.inner.last_doc_id(),
+                    doc_id,
+                    "skip_to({doc_id}): a skip that carries no result must not claim the probed \
+                     id as its position",
+                );
+                return Err(error);
+            }
+        };
+        let summary = outcome.map(|outcome| match outcome {
+            SkipToOutcome::Found(result) => {
+                (true, result.doc_id, result as *const RSIndexResult<'index>)
+            }
+            SkipToOutcome::NotFound(result) => {
+                (false, result.doc_id, result as *const RSIndexResult<'index>)
+            }
+        });
+        match summary {
+            None => {
+                assert_ne!(
+                    self.inner.last_doc_id(),
+                    doc_id,
+                    "skip_to({doc_id}): a skip that found nothing must not claim the probed id \
+                     as its position — a parent reads that as \"the child holds this document\"",
+                );
+                self.after_exhaustion("skip_to");
+                Ok(None)
+            }
+            Some((found, id, yielded)) => {
+                assert_ne!(
+                    previous,
+                    Position::PastEnd,
+                    "skip_to({doc_id}): an iterator that had run past its last result must keep \
+                     finding nothing, but it produced doc {id}",
+                );
+                if found {
+                    assert_eq!(
+                        id, doc_id,
+                        "skip_to({doc_id}): Found promises a result at the requested id, got \
+                         {id}",
+                    );
+                } else {
+                    assert!(
+                        id > doc_id,
+                        "skip_to({doc_id}): NotFound promises the first result *greater* than \
+                         the requested id, got {id}",
+                    );
+                }
+                let current = self.after_yield("skip_to", id, yielded);
+                Ok(Some(if found {
+                    SkipToOutcome::Found(current)
+                } else {
+                    SkipToOutcome::NotFound(current)
+                }))
+            }
+        }
+    }
+
+    #[track_caller]
+    fn revalidate(
+        &mut self,
+        spec: &IndexSpecReadGuard,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        self.assert_usable("revalidate");
+        let previous_last = self.inner.last_doc_id();
+        let summary = match self.inner.revalidate(spec)? {
+            RQEValidateStatus::Ok => RevalidateSummary::Ok,
+            RQEValidateStatus::Moved { current } => RevalidateSummary::Moved(
+                current.map(|result| (result.doc_id, result as *const RSIndexResult<'index>)),
+            ),
+            RQEValidateStatus::Aborted => RevalidateSummary::Aborted,
+        };
+        match summary {
+            RevalidateSummary::Ok => {
+                assert_eq!(
+                    self.inner.last_doc_id(),
+                    previous_last,
+                    "revalidate: Ok promises the same position, but last_doc_id() changed",
+                );
+                Ok(RQEValidateStatus::Ok)
+            }
+            RevalidateSummary::Moved(Some((id, yielded))) => {
+                // Moved onto a concrete document: the same agreement rules as
+                // any other yield apply, but it is a reposition rather than a
+                // new result, so it does not count against `num_estimated`.
+                let current = self.assert_positioned_on("revalidate (moved)", id, yielded);
+                Ok(RQEValidateStatus::Moved {
+                    current: Some(current),
+                })
+            }
+            RevalidateSummary::Moved(None) => {
+                self.after_exhaustion("revalidate (moved to EOF)");
+                Ok(RQEValidateStatus::Moved { current: None })
+            }
+            RevalidateSummary::Aborted => {
+                self.aborted = true;
+                Ok(RQEValidateStatus::Aborted)
+            }
+        }
+    }
+
+    #[track_caller]
+    fn rewind(&mut self) {
+        self.assert_usable("rewind");
+        self.inner.rewind();
+        self.position = Position::Unread;
+        self.yielded = 0;
+        assert_eq!(
+            self.inner.at_eof(),
+            self.at_eof_when_unread,
+            "rewind: must restore the at_eof() answer the iterator gave when freshly constructed \
+             ({}) — an exhausted state must not latch",
+            self.at_eof_when_unread,
+        );
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.inner.num_estimated()
+    }
+
+    #[track_caller]
+    fn last_doc_id(&self) -> DocId {
+        self.assert_usable("last_doc_id");
+        let last = self.inner.last_doc_id();
+        if let Position::On(id) = self.position {
+            assert_eq!(
+                last, id,
+                "last_doc_id: must report the id of the result last yielded",
+            );
+        }
+        last
+    }
+
+    #[track_caller]
+    fn at_eof(&self) -> bool {
+        self.assert_usable("at_eof");
+        let at_eof = self.inner.at_eof();
+        match self.position {
+            Position::Unread => assert_eq!(
+                at_eof, self.at_eof_when_unread,
+                "at_eof: changed from {} to {at_eof} without any read or skip_to",
+                self.at_eof_when_unread,
+            ),
+            Position::On(id) => assert!(
+                !at_eof,
+                "at_eof: must be false while positioned on doc {id}, including on the last \
+                 result",
+            ),
+            Position::PastEnd => assert!(
+                at_eof,
+                "at_eof: must be true once the iterator has run past its last result",
+            ),
+        }
+        at_eof
+    }
+
+    fn type_(&self) -> IteratorType {
+        self.inner.type_()
+    }
+
+    fn as_c_iterator(&self) -> Option<&c2rust::CRQEIterator> {
+        self.inner.as_c_iterator()
+    }
+
+    fn intersection_sort_weight(&self, prioritize_union_children: bool) -> f64 {
+        self.inner
+            .intersection_sort_weight(prioritize_union_children)
+    }
+}

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/lib.rs
@@ -12,6 +12,7 @@
 //! This module provides utilities for testing iterators, including contexts
 //! for setting up test environments.
 
+pub mod contract_checker;
 #[expect(clippy::undocumented_unsafe_blocks)]
 #[expect(clippy::multiple_unsafe_ops_per_block)]
 pub mod mock_context;
@@ -20,6 +21,7 @@ pub mod mock_expiration;
 #[expect(clippy::multiple_unsafe_ops_per_block)]
 pub mod test_context;
 
+pub use contract_checker::ContractChecker;
 use index_spec::IndexSpecReadGuard;
 pub use mock_context::MockContext;
 pub use mock_expiration::MockExpirationChecker;


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: the `RQEIterator` contract is asserted by fixed drains in `rqe_iterators_test_utils` (`assert_current_contract`, `assert_current_contract_via_skip_to`), which check the contract only along the specific scenario they drive.
2. **Change**: adds `ContractChecker<I>`, a wrapper that implements `RQEIterator`, forwards every operation to the wrapped iterator, and asserts the contract against an independently tracked position before handing over each result — accessor agreement on/past the last result (including the same-result-object rule for `current()`), `skip_to` `Found`/`NotFound` semantics and the never-claim-the-probed-id rule, the caller-side `skip_to` precondition, exhaustion persisting until `rewind` without latching past it, `revalidate` `Ok`/`Moved`/`Aborted` semantics, strictly-ascending doc ids (with an opt-out for the unsorted id list), and `num_estimated` as an upper bound. The IdList integration tests now drive the iterator under test through the wrapper, as the first adoption.
3. **Outcome**: whatever scenario a test drives is contract-checked as a side effect, and a violation panics at the operation that commits it. The checker's own tests stage each violation through a single-fault mock and pin every panic to its invariant. Adoption by the remaining iterator kinds can follow incrementally; if any iterator turns out to legitimately diverge from one of the encoded invariants, that check gets revisited then.

Stacked on #10741 (`union-flat-unread-children`), because the checker encodes the `current()`/`at_eof()` contract finalized there — against `master`'s semantics the wrapped IdList tests would fail.

The boxed suspend/resume machinery (`RQEIteratorBoxed`) is out of the checker's scope for now; tests exercising that path keep driving the unwrapped iterator.

#### Which additional issues this PR fixes
1. N/A

#### Main objects this PR modified
1. `rqe_iterators_test_utils::ContractChecker` (new)
2. `rqe_iterators/tests/integration/contract_checker.rs` (new — single-fault `Misbehaving` mock + positive/negative coverage of every check)
3. `rqe_iterators/tests/integration/id_list.rs` (iterators under test wrapped in the checker)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
