### PR TITLE
[MOD-17476] Skip per-candidate rune conversion for wildcard patterns without `?`

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -671,16 +671,13 @@ static QueryIterator *Query_EvalWildcardQueryNode(QueryEvalCtx *q, QueryNode *qn
     // all modifier fields are supported
     if (qn->opts.fieldMask == RS_FIELDMASK_ALL ||
        (spec->suffixMask & qn->opts.fieldMask) == qn->opts.fieldMask) {
-      // TEXT terms are stored lowercased, so recheck against the lowercased
-      // pattern (Suffix_CB_Wildcard matches cstr) to stay case-insensitive.
-      size_t lcstrlen;
-      char *lcstr = runesToStr(str, nstr, &lcstrlen);
+      // TEXT terms are stored lowercased and `str` holds the lowercased
+      // pattern runes, so the candidate recheck in Suffix_CB_Wildcard stays
+      // case-insensitive.
       SuffixCtx sufCtx = {
         .trie = spec->suffix,
         .rune = str,
         .runelen = nstr,
-        .cstr = lcstr,
-        .cstrlen = lcstrlen,
         .type = SUFFIX_TYPE_WILDCARD,
         .callback = charIterCb, // the difference is weather the function receives char or rune
         .cbCtx = &ctx,
@@ -691,7 +688,6 @@ static QueryIterator *Query_EvalWildcardQueryNode(QueryEvalCtx *q, QueryNode *qn
         // if suffix trie cannot be used, use brute force
         fallbackBruteForce = true;
       }
-      rm_free(lcstr);
     } else {
       QueryError_SetError(q->status, QUERY_ERROR_CODE_GENERIC, "Contains query on fields without WITHSUFFIXTRIE support");
     }

--- a/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
@@ -384,6 +384,8 @@ impl CTrieRef {
             // The suffix walk ignores these; keep them zeroed.
             timeout: std::ptr::null_mut(),
             skipTimeoutChecks: false,
+            cstr: std::ptr::null_mut(),
+            cstrlen: 0,
         };
         // SAFETY: every `suffix_ctx` field is initialised above with a valid
         // value — `self.ptr` is a valid suffix `Trie` (caller contract), the

--- a/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
@@ -378,8 +378,6 @@ impl CTrieRef {
             trie: self.ptr,
             rune: pattern.as_ptr().cast_mut(),
             runelen: pattern.len(),
-            cstr: std::ptr::null(),
-            cstrlen: 0,
             type_: mode.into(),
             callback: Some(suffix_trampoline::<F>),
             cbCtx: std::ptr::from_mut(&mut callback).cast(),

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -301,7 +301,7 @@ int Suffix_ChooseToken_rune(const rune *str, size_t len, size_t *tokenIdx, size_
   int retidx = REDISEARCH_UNINITIALIZED;
   for (int i = 0; i < runner; ++i) {
     // 1. long string are likely to have less results
-    // 2. tokens at end of pattern are likely to be more relevant
+    // 2. score ties are broken in favor of the later token (`>=` below)
     int curScore = tokenLen[i] + 1;
 
     // iterating all children is demanding

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -361,11 +361,15 @@ int Suffix_IterateWildcard(SuffixCtx *sufCtx) {
     return 0;
   }
 
-  rune *token = sufCtx->rune + idx[useIdx];
   size_t toklen = lens[useIdx];
-  if (token[toklen] == (rune)'*') {
+  if (sufCtx->rune[idx[useIdx] + toklen] == (rune)'*') {
     toklen++;
   }
+  // The trie walk wants a NUL-terminated token, but the pattern buffer must
+  // stay intact: Suffix_CB_Wildcard re-filters every candidate against
+  // sufCtx->rune while the iteration is running. Terminate a copy instead.
+  rune token[toklen + 1];
+  memcpy(token, sufCtx->rune + idx[useIdx], toklen * sizeof(rune));
   token[toklen] = (rune)'\0';
 
   Trie_IterateWildcard(sufCtx->trie, token, toklen, Suffix_CB_Wildcard, sufCtx, sufCtx->timeout,

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -325,6 +325,17 @@ int Suffix_ChooseToken_rune(const rune *str, size_t len, size_t *tokenIdx, size_
   return retidx;
 }
 
+// True if the UTF-8 string contains a supplementary-plane codepoint
+// (> U+FFFF, i.e. a 4-byte sequence, lead byte 0xF0..0xF4).
+static bool containsSupplementaryCodepoint(const char *str, size_t len) {
+  for (size_t i = 0; i < len; ++i) {
+    if ((unsigned char)str[i] >= 0xF0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 int Suffix_CB_Wildcard(const rune *keyRunes, size_t keyLen, void *p, void *payload,
                        size_t numDocsInTerm) {
   SuffixCtx *sufCtx = p;
@@ -336,9 +347,16 @@ int Suffix_CB_Wildcard(const rune *keyRunes, size_t keyLen, void *p, void *paylo
   suffixData *data = (suffixData *)TriePayload_Data(pl);
   arrayof(char *) array = data->array;
   for (int i = 0; i < array_len(array); ++i) {
+    size_t termLen = strlen(array[i]);
+    // The brute-force scan over the terms trie can never return terms with
+    // supplementary-plane codepoints: the 16-bit rune representation
+    // truncates them, so the inverted-index key it derives no longer exists.
+    // Skip such candidates to keep both paths result-identical.
+    if (containsSupplementaryCodepoint(array[i], termLen)) {
+      continue;
+    }
     // Match rune-wise so `?` consumes one codepoint, keeping results
     // identical to the brute-force scan over the terms trie.
-    size_t termLen = strlen(array[i]);
     runeBuf buf;
     size_t termRuneLen;
     rune *termRunes = runeBufFill(array[i], termLen, &buf, &termRuneLen);

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -338,13 +338,14 @@ int Suffix_CB_Wildcard(const rune *keyRunes, size_t keyLen, void *p, void *paylo
   for (int i = 0; i < array_len(array); ++i) {
     // Match rune-wise so `?` consumes one codepoint, keeping results
     // identical to the brute-force scan over the terms trie.
+    size_t termLen = strlen(array[i]);
     runeBuf buf;
     size_t termRuneLen;
-    rune *termRunes = runeBufFill(array[i], strlen(array[i]), &buf, &termRuneLen);
+    rune *termRunes = runeBufFill(array[i], termLen, &buf, &termRuneLen);
     match_t match = Wildcard_MatchRune(sufCtx->rune, sufCtx->runelen, termRunes, termRuneLen);
     runeBufFree(&buf);
     if (match == FULL_MATCH) {
-      if (sufCtx->callback(array[i], strlen(array[i]), sufCtx->cbCtx, NULL) != REDISMODULE_OK) {
+      if (sufCtx->callback(array[i], termLen, sufCtx->cbCtx, NULL) != REDISMODULE_OK) {
         return REDISEARCH_ERR;
       }
     }

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -325,7 +325,8 @@ int Suffix_ChooseToken_rune(const rune *str, size_t len, size_t *tokenIdx, size_
   return retidx;
 }
 
-int Suffix_CB_Wildcard(const rune *rune, size_t len, void *p, void *payload, size_t numDocsInTerm) {
+int Suffix_CB_Wildcard(const rune *keyRunes, size_t keyLen, void *p, void *payload,
+                       size_t numDocsInTerm) {
   SuffixCtx *sufCtx = p;
   TriePayload *pl = payload;
   if (!pl) {
@@ -335,8 +336,14 @@ int Suffix_CB_Wildcard(const rune *rune, size_t len, void *p, void *payload, siz
   suffixData *data = (suffixData *)TriePayload_Data(pl);
   arrayof(char *) array = data->array;
   for (int i = 0; i < array_len(array); ++i) {
-    if (Wildcard_MatchChar(sufCtx->cstr, sufCtx->cstrlen, array[i], strlen(array[i]))
-            == FULL_MATCH) {
+    // Match rune-wise so `?` consumes one codepoint, keeping results
+    // identical to the brute-force scan over the terms trie.
+    runeBuf buf;
+    size_t termRuneLen;
+    rune *termRunes = runeBufFill(array[i], strlen(array[i]), &buf, &termRuneLen);
+    match_t match = Wildcard_MatchRune(sufCtx->rune, sufCtx->runelen, termRunes, termRuneLen);
+    runeBufFree(&buf);
+    if (match == FULL_MATCH) {
       if (sufCtx->callback(array[i], strlen(array[i]), sufCtx->cbCtx, NULL) != REDISMODULE_OK) {
         return REDISEARCH_ERR;
       }
@@ -346,8 +353,8 @@ int Suffix_CB_Wildcard(const rune *rune, size_t len, void *p, void *payload, siz
 }
 
 int Suffix_IterateWildcard(SuffixCtx *sufCtx) {
-  size_t idx[sufCtx->cstrlen];
-  size_t lens[sufCtx->cstrlen];
+  size_t idx[sufCtx->runelen];
+  size_t lens[sufCtx->runelen];
   int useIdx = Suffix_ChooseToken_rune(sufCtx->rune, sufCtx->runelen, idx, lens);
 
   if (useIdx == REDISEARCH_UNINITIALIZED) {

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -355,13 +355,20 @@ int Suffix_CB_Wildcard(const rune *keyRunes, size_t keyLen, void *p, void *paylo
     if (containsSupplementaryCodepoint(array[i], termLen)) {
       continue;
     }
-    // Match rune-wise so `?` consumes one codepoint, keeping results
-    // identical to the brute-force scan over the terms trie.
-    runeBuf buf;
-    size_t termRuneLen;
-    rune *termRunes = runeBufFill(array[i], termLen, &buf, &termRuneLen);
-    match_t match = Wildcard_MatchRune(sufCtx->rune, sufCtx->runelen, termRunes, termRuneLen);
-    runeBufFree(&buf);
+    match_t match;
+    if (sufCtx->cstr) {
+      // The pattern has no `?`, the only construct whose byte-wise and
+      // rune-wise readings differ, so match the stored bytes directly.
+      match = Wildcard_MatchChar(sufCtx->cstr, sufCtx->cstrlen, array[i], termLen);
+    } else {
+      // Match rune-wise so `?` consumes one codepoint, keeping results
+      // identical to the brute-force scan over the terms trie.
+      runeBuf buf;
+      size_t termRuneLen;
+      rune *termRunes = runeBufFill(array[i], termLen, &buf, &termRuneLen);
+      match = Wildcard_MatchRune(sufCtx->rune, sufCtx->runelen, termRunes, termRuneLen);
+      runeBufFree(&buf);
+    }
     if (match == FULL_MATCH) {
       if (sufCtx->callback(array[i], termLen, sufCtx->cbCtx, NULL) != REDISMODULE_OK) {
         return REDISEARCH_ERR;
@@ -391,8 +398,26 @@ int Suffix_IterateWildcard(SuffixCtx *sufCtx) {
   memcpy(token, sufCtx->rune + idx[useIdx], toklen * sizeof(rune));
   token[toklen] = (rune)'\0';
 
+  // A pattern without `?` matches identically byte-wise and rune-wise, so
+  // materialize its byte form once and let Suffix_CB_Wildcard match the
+  // stored terms directly instead of rune-converting each candidate.
+  sufCtx->cstr = NULL;
+  sufCtx->cstrlen = 0;
+  bool hasQuestionMark = false;
+  for (size_t i = 0; i < sufCtx->runelen; ++i) {
+    if (sufCtx->rune[i] == (rune)'?') {
+      hasQuestionMark = true;
+      break;
+    }
+  }
+  if (!hasQuestionMark) {
+    sufCtx->cstr = runesToStr(sufCtx->rune, sufCtx->runelen, &sufCtx->cstrlen);
+  }
+
   Trie_IterateWildcard(sufCtx->trie, token, toklen, Suffix_CB_Wildcard, sufCtx, sufCtx->timeout,
                        sufCtx->skipTimeoutChecks);
+  rm_free(sufCtx->cstr);
+  sufCtx->cstr = NULL;
   return 1;
 }
 

--- a/src/suffix.h
+++ b/src/suffix.h
@@ -30,8 +30,6 @@ typedef struct SuffixCtx {
     Trie *trie;
     rune *rune;
     size_t runelen;
-    const char *cstr;
-    size_t cstrlen;
     SuffixType type;
     TrieSuffixCallback *callback;
     void *cbCtx;

--- a/src/suffix.h
+++ b/src/suffix.h
@@ -35,6 +35,11 @@ typedef struct SuffixCtx {
     void *cbCtx;
     struct timespec *timeout;
     bool skipTimeoutChecks;  // flag to skip timeout checks in trie iteration
+    // Byte form of the pattern, owned by Suffix_IterateWildcard. Set only
+    // when the pattern contains no `?`, enabling Suffix_CB_Wildcard to match
+    // candidates byte-wise without a per-term rune conversion; NULL otherwise.
+    char *cstr;
+    size_t cstrlen;
 } SuffixCtx;
 
 typedef struct suffixData {

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -577,7 +577,7 @@ def testWildcardQuestionMarkMultibyteWithSuffixTrie():
     env.assertEqual(res, [2, 'doc1', 'doc2'])
 
 @skip(cluster=True)
-def testWildcardStarredNonFinalAnchorWithSuffixTrie():
+def testWildcardStarredNonFinalAnchor():
     """On the suffix-trie path, a pattern whose best anchor token is starred
     and non-final (in w'verylongtoken*a', 'verylongtoken' out-scores the tail
     token 'a' despite the starred-anchor penalty) must return the same result
@@ -586,12 +586,15 @@ def testWildcardStarredNonFinalAnchorWithSuffixTrie():
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
 
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'WITHSUFFIXTRIE').ok()
+    env.expect('FT.CREATE', 'idx_plain', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect('FT.CREATE', 'idx_suffix', 'SCHEMA', 't', 'TEXT', 'WITHSUFFIXTRIE').ok()
     conn.execute_command('HSET', 'doc1', 't', 'verylongtokenxa')
     conn.execute_command('HSET', 'doc2', 't', 'verylongtokenxb')
 
-    res = env.cmd('FT.SEARCH', 'idx', "w'verylongtoken*a'", 'NOCONTENT')
-    env.assertEqual(res, [1, 'doc1'])
+    res_plain = env.cmd('FT.SEARCH', 'idx_plain', "w'verylongtoken*a'", 'NOCONTENT')
+    res_suffix = env.cmd('FT.SEARCH', 'idx_suffix', "w'verylongtoken*a'", 'NOCONTENT')
+    env.assertEqual(res_plain, [1, 'doc1'])
+    env.assertEqual(res_suffix, res_plain)
 
 @skip(cluster=True)
 def testWildcardSupplementaryPlaneParity():

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -542,3 +542,34 @@ def testWildcardSuffixTrieMaxPrefixExpansions():
         _assertMaxExpansionsWarning(env, res)
     finally:
         env.expect(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', previous).ok()
+
+@skip(cluster=True)
+def testWildcardQuestionMarkMultibyteWithoutSuffixTrie():
+    """Without WITHSUFFIXTRIE, a wildcard query is evaluated by brute force over
+    the rune terms trie (Wildcard_MatchRune), where `?` consumes one codepoint —
+    so w'entr?' matches 'entré' ('é' is two UTF-8 bytes but one codepoint)."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    conn.execute_command('HSET', 'doc1', 't', 'entré')
+    conn.execute_command('HSET', 'doc2', 't', 'entrx')
+
+    res = env.cmd('FT.SEARCH', 'idx', "w'entr?'", 'NOCONTENT')
+    env.assertEqual(res, [2, 'doc1', 'doc2'])
+
+@skip(cluster=True)
+def testWildcardQuestionMarkMultibyteWithSuffixTrie():
+    """With WITHSUFFIXTRIE, the candidate terms found via the suffix trie are
+    re-filtered rune-wise (Suffix_CB_Wildcard -> Wildcard_MatchRune), where `?`
+    consumes one codepoint — so w'entr?' matches 'entré', the same result the
+    brute-force path produces without the suffix trie."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'WITHSUFFIXTRIE').ok()
+    conn.execute_command('HSET', 'doc1', 't', 'entré')
+    conn.execute_command('HSET', 'doc2', 't', 'entrx')
+
+    res = env.cmd('FT.SEARCH', 'idx', "w'entr?'", 'NOCONTENT')
+    env.assertEqual(res, [2, 'doc1', 'doc2'])

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -592,3 +592,27 @@ def testWildcardStarredNonFinalAnchorWithSuffixTrie():
 
     res = env.cmd('FT.SEARCH', 'idx', "w'verylongtoken*a'", 'NOCONTENT')
     env.assertEqual(res, [1, 'doc1'])
+
+@skip(cluster=True)
+def testWildcardSupplementaryPlaneParity():
+    """Terms containing supplementary-plane codepoints (4-byte UTF-8, above
+    U+FFFF, e.g. emoji) are never returned by the brute-force wildcard path:
+    the 16-bit rune representation truncates the codepoint, so the
+    inverted-index key derived from it no longer exists. The suffix-trie path
+    keeps the original term bytes and would find them, so it must skip such
+    candidates — WITHSUFFIXTRIE is an optimization and may never change the
+    result set."""
+    # DEFAULT_DIALECT 2 because w'...' syntax needs dialect 2 or above.
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx_plain', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect('FT.CREATE', 'idx_suffix', 'SCHEMA', 't', 'TEXT', 'WITHSUFFIXTRIE').ok()
+    conn.execute_command('HSET', 'doc1', 't', 'hello💩')
+    conn.execute_command('HSET', 'doc2', 't', '💩')
+
+    for query in ["w'hello?'", "w'hello*'", "w'?'", "w'*💩'"]:
+        res_plain = env.cmd('FT.SEARCH', 'idx_plain', query, 'NOCONTENT')
+        res_suffix = env.cmd('FT.SEARCH', 'idx_suffix', query, 'NOCONTENT')
+        env.assertEqual(res_plain, [0], message=query)
+        env.assertEqual(res_suffix, res_plain, message=query)

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -548,6 +548,7 @@ def testWildcardQuestionMarkMultibyteWithoutSuffixTrie():
     """Without WITHSUFFIXTRIE, a wildcard query is evaluated by brute force over
     the rune terms trie (Wildcard_MatchRune), where `?` consumes one codepoint —
     so w'entr?' matches 'entré' ('é' is two UTF-8 bytes but one codepoint)."""
+    # DEFAULT_DIALECT 2 because w'...' syntax needs dialect 2 or above.
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
 
@@ -564,6 +565,7 @@ def testWildcardQuestionMarkMultibyteWithSuffixTrie():
     re-filtered rune-wise (Suffix_CB_Wildcard -> Wildcard_MatchRune), where `?`
     consumes one codepoint — so w'entr?' matches 'entré', the same result the
     brute-force path produces without the suffix trie."""
+    # DEFAULT_DIALECT 2 because w'...' syntax needs dialect 2 or above.
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
 
@@ -580,6 +582,7 @@ def testWildcardStarredNonFinalAnchorWithSuffixTrie():
     and non-final (in w'verylongtoken*a', 'verylongtoken' out-scores the tail
     token 'a' despite the starred-anchor penalty) must return the same result
     as the brute-force path."""
+    # DEFAULT_DIALECT 2 because w'...' syntax needs dialect 2 or above.
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
 

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -573,3 +573,19 @@ def testWildcardQuestionMarkMultibyteWithSuffixTrie():
 
     res = env.cmd('FT.SEARCH', 'idx', "w'entr?'", 'NOCONTENT')
     env.assertEqual(res, [2, 'doc1', 'doc2'])
+
+@skip(cluster=True)
+def testWildcardStarredNonFinalAnchorWithSuffixTrie():
+    """On the suffix-trie path, a pattern whose best anchor token is starred
+    and non-final (in w'verylongtoken*a', 'verylongtoken' out-scores the tail
+    token 'a' despite the starred-anchor penalty) must return the same result
+    as the brute-force path."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'WITHSUFFIXTRIE').ok()
+    conn.execute_command('HSET', 'doc1', 't', 'verylongtokenxa')
+    conn.execute_command('HSET', 'doc2', 't', 'verylongtokenxb')
+
+    res = env.cmd('FT.SEARCH', 'idx', "w'verylongtoken*a'", 'NOCONTENT')
+    env.assertEqual(res, [1, 'doc1'])


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Since the codepoint `?` fix (#10752), the suffix-trie wildcard re-filter (`Suffix_CB_Wildcard`) converts every candidate term to runes on every visited suffix node — a full UTF-8 decode plus a heap allocation for terms longer than 127 bytes, repeated for the same term once per node whose entry list carries it. This cost is paid by *all* wildcard patterns, although `?` is the only wildcard construct whose byte-wise and codepoint-wise readings differ (escapes are removed by `Wildcard_RemoveEscape` before the pattern reaches the suffix path).
2. Change: `Suffix_IterateWildcard` scans the pattern runes once for `?`. When absent, it materializes the lowered pattern's byte form into `SuffixCtx` (owned by the iteration, freed on exit) and `Suffix_CB_Wildcard` matches the stored term bytes directly with `Wildcard_MatchChar`. Patterns carrying `?` keep the rune-wise re-filter. The `c_trie` Rust wrapper zero-initializes the new fields (its suffix/contains modes never take the wildcard path).
3. Outcome: Patterns of literals and `*` — the common shape — regain the allocation-free byte match the pre-#10752 path had, with identical results; only `?`-carrying patterns pay for rune conversion. No behavior change, so the existing wildcard flow tests (which exercise both pattern shapes on the suffix path) cover it.

Stacked on #10752.

#### Which additional issues this PR fixes

1. MOD-17476

#### Main objects this PR modified

1. `Suffix_IterateWildcard`, `Suffix_CB_Wildcard`, `SuffixCtx` (`src/suffix.c`, `src/suffix.h`)
2. `src/redisearch_rs/c_wrappers/c_trie/src/lib.rs`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
