### PR TITLE
[MOD-17201] shrink groupby-collect hash explicit benchmark to 10K

### DIFF
--- a/tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-explicit-k50.yml
+++ b/tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-explicit-k50.yml
@@ -1,5 +1,5 @@
 version: 0.5
-name: "search-groupby-collect-100K-entity-events-hash-cached-sortby-fields-explicit-k50"
+name: "search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-explicit-k50"
 description: "GROUPBY + COLLECT HASH benchmark with explicit projected fields and LIMIT 0 50."
 
 metadata:
@@ -16,7 +16,7 @@ setups:
   - oss-cluster-02-primaries
 
 dbconfig:
-  - dataset_name: "groupby-collect-entity-events-100K-heavy-hash"
+  - dataset_name: "groupby-collect-entity-events-10K-heavy-hash"
   - dataset_load_timeout_secs: 1800
   - init_commands:
     - '"CONFIG" "SET" "search-enable-unstable-features" "yes"'
@@ -25,9 +25,9 @@ dbconfig:
   - parameters:
     - workers: 64
     - reporting-period: 1s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-100K-heavy-hash/groupby-collect-entity-events-100K-heavy-hash.redisearch.commands.SETUP.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-hash/groupby-collect-entity-events-10K-heavy-hash.redisearch.commands.SETUP.csv"
   - check:
-      keyspacelen: 100000
+      keyspacelen: 10000
 
 clientconfig:
   - benchmark_type: "read-only"
@@ -37,4 +37,4 @@ clientconfig:
     - requests: 100000
     - reporting-period: 1s
     - duration: 120s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-100K-heavy-hash/groupby-collect-entity-events-100K-heavy-hash.redisearch.commands.BENCH.QUERY_collect-fields-explicit-k50.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-hash/groupby-collect-entity-events-10K-heavy-hash.redisearch.commands.BENCH.QUERY_collect-fields-explicit-k50.csv"


### PR DESCRIPTION
## Describe the changes in the pull request

**Current:** the 100K hash explicit COLLECT benchmark fails in CI. It is the last `groupby-collect` variant still at 100K.

**Change:** repoint it at the existing 10K hash dataset — rename, `dataset_name`, both `input` URLs, `keyspacelen`. Query shape unchanged.

**Outcome:** all four `groupby-collect` variants run at 10K.

No new data required; the 10K hash SETUP and explicit BENCH CSVs are already in S3.

#### Which additional issues this PR fixes
1. MOD-17201

#### Main objects this PR modified
1. `tests/benchmarks/search-groupby-collect-100K-entity-events-hash-cached-sortby-fields-explicit-k50.yml` — renamed to `10K` and repointed

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
