### PR TITLE
[MOD-17488] Cursor reads now report a timeout that expires while iterators are revalidated

### DIFF
--- a/docs/design/sound_iterator_revalidation.md
+++ b/docs/design/sound_iterator_revalidation.md
@@ -68,8 +68,16 @@ typedef enum ValidateStatus {
     VALIDATE_OK,      // Iterator still valid, same position
     VALIDATE_MOVED,   // Iterator still valid, but moved forward
     VALIDATE_ABORTED, // Iterator invalid, must be freed
+    VALIDATE_TIMEOUT, // Deadline expired mid-revalidation; iterator invalid, must be freed
 } ValidateStatus;
 ```
+
+`VALIDATE_TIMEOUT` has the same consequence for the iterator as `VALIDATE_ABORTED` — a
+revalidation that fails leaves its fix-up half-applied, so the iterator is unusable and gets freed.
+The two differ only in what the caller reports: an abort lets the query end as if the index were
+exhausted, while a timeout means the results are partial, so the result processor returns
+`RS_RESULT_TIMEDOUT` and the client is told. Composite iterators must therefore propagate it rather
+than folding it into an abort.
 
 Composite iterators handle these per child:
 

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -3347,6 +3347,38 @@ DEBUG_COMMAND(VecSimMockTimeout) {
 }
 
 /**
+ * FT.DEBUG MOCK_REVALIDATE_TIMEOUT <enable|disable|status>
+ * Make every iterator revalidation report VALIDATE_TIMEOUT, globally
+ * enable - every revalidation reports a timeout, as if the query ran out of time while re-seeking
+ *          the index after a concurrent change
+ * disable - restore normal behavior
+ * status - show whether the switch is currently on. Nothing resets it, so a test that dies before
+ *          disabling it leaves every later cursor resume reporting a timeout
+ */
+DEBUG_COMMAND(MockRevalidateTimeout) {
+  if (!debugCommandsEnabled(ctx)) {
+    return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
+  }
+  if (argc != 3) {
+    return RedisModule_WrongArity(ctx);
+  }
+  const char *op = RedisModule_StringPtrLen(argv[2], NULL);
+  if (!strcmp("enable", op)) {
+    RQEIterators_SetMockRevalidateTimeout(true);
+  } else if (!strcmp("disable", op)) {
+    RQEIterators_SetMockRevalidateTimeout(false);
+  } else if (!strcmp("status", op)) {
+    return RedisModule_ReplyWithSimpleString(
+        ctx, RQEIterators_GetMockRevalidateTimeout() ? "Mock revalidation timeout: enabled"
+                                                     : "Mock revalidation timeout: disabled");
+  } else {
+    return RedisModule_ReplyWithError(
+        ctx, "Invalid command for 'MOCK_REVALIDATE_TIMEOUT'. Use: enable, disable, or status");
+  }
+  return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+/**
  * FT.DEBUG DISK_IO_CONTROL <enable|disable|status>
  *
  * Control async disk I/O behavior for testing and debugging.
@@ -3592,6 +3624,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"QUERY_CONTROLLER", queryController},
                                {"DUMP_SCHEMA", DumpSchema},
                                {"VECSIM_MOCK_TIMEOUT", VecSimMockTimeout},
+                               {"MOCK_REVALIDATE_TIMEOUT", MockRevalidateTimeout},
                                {"GET_MAX_DOC_ID", GetMaxDocId},
                                {"DUMP_DELETED_IDS", DumpDeletedIds},
                                {"NUMERIC_BUCKET_MAP", NumericBucketMap},

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -3429,6 +3429,38 @@ DEBUG_COMMAND(VecSimMockTimeout) {
 }
 
 /**
+ * FT.DEBUG MOCK_REVALIDATE_TIMEOUT <enable|disable|status>
+ * Make every iterator revalidation report VALIDATE_TIMEOUT, globally
+ * enable - every revalidation reports a timeout, as if the query ran out of time while re-seeking
+ *          the index after a concurrent change
+ * disable - restore normal behavior
+ * status - show whether the switch is currently on. Nothing resets it, so a test that dies before
+ *          disabling it leaves every later cursor resume reporting a timeout
+ */
+DEBUG_COMMAND(MockRevalidateTimeout) {
+  if (!debugCommandsEnabled(ctx)) {
+    return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
+  }
+  if (argc != 3) {
+    return RedisModule_WrongArity(ctx);
+  }
+  const char *op = RedisModule_StringPtrLen(argv[2], NULL);
+  if (!strcmp("enable", op)) {
+    RQEIterators_SetMockRevalidateTimeout(true);
+  } else if (!strcmp("disable", op)) {
+    RQEIterators_SetMockRevalidateTimeout(false);
+  } else if (!strcmp("status", op)) {
+    return RedisModule_ReplyWithSimpleString(
+        ctx, RQEIterators_GetMockRevalidateTimeout() ? "Mock revalidation timeout: enabled"
+                                                     : "Mock revalidation timeout: disabled");
+  } else {
+    return RedisModule_ReplyWithError(
+        ctx, "Invalid command for 'MOCK_REVALIDATE_TIMEOUT'. Use: enable, disable, or status");
+  }
+  return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+/**
  * FT.DEBUG DISK_IO_CONTROL <enable|disable|status>
  *
  * Control async disk I/O behavior for testing and debugging.
@@ -3675,6 +3707,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"QUERY_CONTROLLER", queryController},
                                {"DUMP_SCHEMA", DumpSchema},
                                {"VECSIM_MOCK_TIMEOUT", VecSimMockTimeout},
+                               {"MOCK_REVALIDATE_TIMEOUT", MockRevalidateTimeout},
                                {"GET_MAX_DOC_ID", GetMaxDocId},
                                {"DUMP_DELETED_IDS", DumpDeletedIds},
                                {"NUMERIC_BUCKET_MAP", NumericBucketMap},

--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -598,12 +598,16 @@ static QueryIterator* HybridIteratorReducer(HybridIteratorParams *hParams) {
 
 // Revalidate the hybrid iterator.
 // If we already have the results prepared, we are OK, and if not, we didn't execute the query yet so we are also OK.
-// Only if we have a child iterator, and it aborted, we need to abort the hybrid iterator.
+// Only if we have a child iterator, and it aborted or timed out, we need to give up on the hybrid
+// iterator - propagating the child's status, since the two are handled differently upstream.
 // If the child iterator is OK or MOVED, we are OK whether we have results prepared or not.
 static ValidateStatus HR_Revalidate(QueryIterator *ctx, struct IndexSpec *spec) {
   HybridIterator *hr = (HybridIterator *)ctx;
-  if (hr->child && hr->child->Revalidate(hr->child, spec) == VALIDATE_ABORTED) {
-    return VALIDATE_ABORTED;
+  if (hr->child) {
+    ValidateStatus childStatus = hr->child->Revalidate(hr->child, spec);
+    if (childStatus == VALIDATE_ABORTED || childStatus == VALIDATE_TIMEOUT) {
+      return childStatus;
+    }
   }
   hr->checkFieldExpiration = hr->sctx && hr->filterCtx.field.index != RS_INVALID_FIELD_INDEX &&
                              hr->sctx->spec->docs.ttl;

--- a/src/iterators/iterator_api.h
+++ b/src/iterators/iterator_api.h
@@ -33,6 +33,11 @@ typedef enum ValidateStatus {
   VALIDATE_MOVED,   // The iterator is still valid but lastDocID changed, and `current` is a new valid result or
                     // at EOF. If not at EOF, the `current` result should be used before the next read, or it will be overwritten.
   VALIDATE_ABORTED, // The iterator is no longer valid, and should not be used or rewound. Should be freed.
+                    // The result set is still reported as complete: the query ends normally.
+  VALIDATE_TIMEOUT, // The deadline expired while revalidating. The iterator is no longer valid and
+                    // should be freed, exactly as for `VALIDATE_ABORTED`. The two differ only in
+                    // what the caller reports: a timeout leaves the result set INCOMPLETE, so the
+                    // caller must surface it (`RS_RESULT_TIMEDOUT`) rather than end-of-results.
 } ValidateStatus;
 
 /* An abstract interface used by readers / intersectors / uniones etc.
@@ -91,6 +96,9 @@ typedef struct QueryIterator {
    * @return VALIDATE_OK if the iterator is still valid
    * @return VALIDATE_MOVED if the iterator is still valid, but the lastDocId has changed (moved forward)
    * @return VALIDATE_ABORTED if the iterator is no longer valid
+   * @return VALIDATE_TIMEOUT if the deadline expired mid-revalidation. Composite iterators must
+   *         propagate it to their caller rather than folding it into VALIDATE_ABORTED: freeing is
+   *         a single act at the root for both, but only a timeout says the results are partial.
    */
   ValidateStatus (*Revalidate)(struct QueryIterator *self, struct IndexSpec *spec);
 

--- a/src/iterators/optimizer_reader.c
+++ b/src/iterators/optimizer_reader.c
@@ -61,10 +61,20 @@ static size_t OPT_NumEstimated(const QueryIterator *self) {
 // TODO: handle MOVED better
 static ValidateStatus OPT_Validate(QueryIterator *self, struct IndexSpec *spec) {
   OptimizerIterator *opt = (OptimizerIterator *)self;
-  if (opt->child->Revalidate(opt->child, spec) != VALIDATE_OK) {
+  ValidateStatus childStatus = opt->child->Revalidate(opt->child, spec);
+  // A timeout is passed up as such: unlike an abort, it says the query ran out of time and its
+  // results are partial, which only the caller can report.
+  if (childStatus == VALIDATE_TIMEOUT) {
+    return VALIDATE_TIMEOUT;
+  }
+  if (childStatus != VALIDATE_OK) {
     return VALIDATE_ABORTED;
   }
-  if (opt->numericIter->Revalidate(opt->numericIter, spec) != VALIDATE_OK) {
+  ValidateStatus numericStatus = opt->numericIter->Revalidate(opt->numericIter, spec);
+  if (numericStatus == VALIDATE_TIMEOUT) {
+    return VALIDATE_TIMEOUT;
+  }
+  if (numericStatus != VALIDATE_OK) {
     return VALIDATE_ABORTED;
   }
   return VALIDATE_OK;

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/debug.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/debug.rs
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Debug-only knobs over the iterator tree, driven by `FT.DEBUG` subcommands.
+
+use rqe_iterators::interop::{mock_revalidate_timeout, set_mock_revalidate_timeout};
+
+/// Make every subsequent iterator revalidation report `VALIDATE_TIMEOUT`, as if the query had run
+/// out of time while re-seeking the index, until this is called again with `false`.
+///
+/// Backs `FT.DEBUG MOCK_REVALIDATE_TIMEOUT enable|disable`. The switch is process-wide, like the
+/// `VECSIM_MOCK_TIMEOUT` one it mirrors, so a test that enables it must disable it again.
+#[unsafe(no_mangle)]
+pub extern "C" fn RQEIterators_SetMockRevalidateTimeout(enabled: bool) {
+    set_mock_revalidate_timeout(enabled);
+}
+
+/// Report whether [`RQEIterators_SetMockRevalidateTimeout`] is currently on.
+///
+/// Backs `FT.DEBUG MOCK_REVALIDATE_TIMEOUT status`. A server left with the switch on reports a
+/// timeout on every cursor resume, which is worth being able to see directly: a test that dies
+/// between `enable` and its teardown would otherwise turn every later query in the file into a
+/// confusing failure.
+#[unsafe(no_mangle)]
+pub extern "C" fn RQEIterators_GetMockRevalidateTimeout() -> bool {
+    mock_revalidate_timeout()
+}

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/lib.rs
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+pub mod debug;
 pub mod deferred;
 pub mod empty;
 pub mod geo_shape;

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -690,6 +690,25 @@ void Profile_AddIters(QueryIterator * *root);
 void Profile_PrintIterators(struct RedisModuleCtx *ctx, const QueryIterator *root, bool limited, bool print_profile_clock);
 
 /**
+ * Report whether [`RQEIterators_SetMockRevalidateTimeout`] is currently on.
+ *
+ * Backs `FT.DEBUG MOCK_REVALIDATE_TIMEOUT status`. A server left with the switch on reports a
+ * timeout on every cursor resume, which is worth being able to see directly: a test that dies
+ * between `enable` and its teardown would otherwise turn every later query in the file into a
+ * confusing failure.
+ */
+bool RQEIterators_GetMockRevalidateTimeout(void);
+
+/**
+ * Make every subsequent iterator revalidation report `VALIDATE_TIMEOUT`, as if the query had run
+ * out of time while re-seeking the index, until this is called again with `false`.
+ *
+ * Backs `FT.DEBUG MOCK_REVALIDATE_TIMEOUT enable|disable`. The switch is process-wide, like the
+ * `VECSIM_MOCK_TIMEOUT` one it mirrors, so a test that enables it must disable it again.
+ */
+void RQEIterators_SetMockRevalidateTimeout(bool enabled);
+
+/**
  * Sets the [`RLookupKeyHandle`] for this metric iterator.
  *
  * # Safety

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -160,6 +160,15 @@ QueryIterator *NewEmptyIterator(void);
 QueryIterator *NewWildcardIterator_NonOptimized(t_docId max_id, double weight);
 
 /**
+ * Make every subsequent iterator revalidation report `VALIDATE_TIMEOUT`, as if the query had run
+ * out of time while re-seeking the index, until this is called again with `false`.
+ *
+ * Backs `FT.DEBUG MOCK_REVALIDATE_TIMEOUT enable|disable`. The switch is process-wide, like the
+ * `VECSIM_MOCK_TIMEOUT` one it mirrors, so a test that enables it must disable it again.
+ */
+void RQEIterators_SetMockRevalidateTimeout(bool enabled);
+
+/**
  *
  * # Safety
  *
@@ -195,6 +204,16 @@ QueryIterator *NewSortedIdListIterator(t_docId *ids, uint64_t num, double weight
  * 2. `iter` must not be aliased.
  */
 QueryIterator *IntoProfiled(QueryIterator *iter);
+
+/**
+ * Report whether [`RQEIterators_SetMockRevalidateTimeout`] is currently on.
+ *
+ * Backs `FT.DEBUG MOCK_REVALIDATE_TIMEOUT status`. A server left with the switch on reports a
+ * timeout on every cursor resume, which is worth being able to see directly: a test that dies
+ * between `enable` and its teardown would otherwise turn every later query in the file into a
+ * confusing failure.
+ */
+bool RQEIterators_GetMockRevalidateTimeout(void);
 
 /**
  * Creates a new metric iterator sorted by ID.

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -12,7 +12,7 @@
 use ffi::{
     IteratorStatus_ITERATOR_EOF, IteratorStatus_ITERATOR_NOTFOUND, IteratorStatus_ITERATOR_OK,
     IteratorStatus_ITERATOR_TIMEOUT, QueryIterator, ValidateStatus_VALIDATE_ABORTED,
-    ValidateStatus_VALIDATE_MOVED, ValidateStatus_VALIDATE_OK,
+    ValidateStatus_VALIDATE_MOVED, ValidateStatus_VALIDATE_OK, ValidateStatus_VALIDATE_TIMEOUT,
 };
 use rqe_core::DocId;
 
@@ -306,6 +306,9 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
         let status = unsafe { callback(self.header.as_ptr(), spec.as_mut_ptr()) };
         #[expect(non_upper_case_globals)]
         let status = match status {
+            // A timed-out child is reported the same way as one that timed out during a read or a
+            // skip: as an error, which a Rust parent propagates to the root of the tree.
+            ValidateStatus_VALIDATE_TIMEOUT => return Err(RQEIteratorError::TimedOut),
             ValidateStatus_VALIDATE_ABORTED => RQEValidateStatus::Aborted,
             ValidateStatus_VALIDATE_MOVED => RQEValidateStatus::Moved {
                 current: self.current(),

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -11,9 +11,11 @@ use ffi::{
     IteratorStatus, IteratorStatus_ITERATOR_EOF, IteratorStatus_ITERATOR_NOTFOUND,
     IteratorStatus_ITERATOR_OK, IteratorStatus_ITERATOR_TIMEOUT, QueryIterator, ValidateStatus,
     ValidateStatus_VALIDATE_ABORTED, ValidateStatus_VALIDATE_MOVED, ValidateStatus_VALIDATE_OK,
+    ValidateStatus_VALIDATE_TIMEOUT,
 };
 use index_result::RSIndexResult;
 use rqe_core::DocId;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::{
     RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, profile_print::ProfilePrint,
@@ -282,6 +284,26 @@ extern "C" fn skip_to<'index, I: RQEIterator<'index> + 'index>(
     }
 }
 
+/// Debug switch behind `FT.DEBUG MOCK_REVALIDATE_TIMEOUT`: when set, every revalidation reports a
+/// timeout without touching the iterator underneath.
+///
+/// A revalidation timeout is otherwise hard to stage from a test. It needs a deadline that expires
+/// between two cursor reads *and* an index change that makes a composite re-seek its children, and
+/// the blocked-client deadline that tests can fire on demand is the same flag the result processor
+/// checks right after revalidating - so it hides the very case under test. This switch stands in
+/// for the deadline so the flow tests can exercise what C does with the status.
+static MOCK_REVALIDATE_TIMEOUT: AtomicBool = AtomicBool::new(false);
+
+/// Set the [`MOCK_REVALIDATE_TIMEOUT`] debug switch.
+pub fn set_mock_revalidate_timeout(enabled: bool) {
+    MOCK_REVALIDATE_TIMEOUT.store(enabled, Ordering::Relaxed);
+}
+
+/// Read the [`MOCK_REVALIDATE_TIMEOUT`] debug switch.
+pub fn mock_revalidate_timeout() -> bool {
+    MOCK_REVALIDATE_TIMEOUT.load(Ordering::Relaxed)
+}
+
 extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
     base: *mut QueryIterator,
     spec: *mut ffi::IndexSpec,
@@ -289,6 +311,12 @@ extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
     debug_assert!(!base.is_null());
     debug_assert!(base.is_aligned());
     debug_assert!(!spec.is_null());
+
+    // Revalidation runs once per query resume, never in the read loop, so the load costs nothing
+    // worth measuring.
+    if MOCK_REVALIDATE_TIMEOUT.load(Ordering::Relaxed) {
+        return ValidateStatus_VALIDATE_TIMEOUT;
+    }
 
     // SAFETY: Guaranteed by invariant 1. in [`RQEIteratorWrapper`].
     let wrapper = unsafe { RQEIteratorWrapper::<I>::mut_ref_from_header_ptr(base) };
@@ -314,7 +342,12 @@ extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
             ValidateStatus_VALIDATE_MOVED
         }
         Ok(RQEValidateStatus::Aborted) => ValidateStatus_VALIDATE_ABORTED,
-        Err(_) => ValidateStatus_VALIDATE_ABORTED,
+        // Both errors leave the iterator in an indeterminate state, so C frees it either way. They
+        // are reported apart because they say different things about the result set: a timeout
+        // makes it partial and has to reach the client, an I/O error kills this subtree in a query
+        // that still has time left.
+        Err(RQEIteratorError::TimedOut) => ValidateStatus_VALIDATE_TIMEOUT,
+        Err(RQEIteratorError::IoError(_)) => ValidateStatus_VALIDATE_ABORTED,
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -219,6 +219,21 @@ pub trait RQEIterator<'index> {
     /// The iterator should check if it is still valid by comparing its stored state
     /// against the current index state.
     ///
+    /// # Errors
+    ///
+    /// Revalidation re-reads and seeks the index to restore the position, so it can fail with an
+    /// [`RQEIteratorError`] — [`TimedOut`](RQEIteratorError::TimedOut) or
+    /// [`IoError`](RQEIteratorError::IoError) — which is distinct from
+    /// [`Aborted`](RQEValidateStatus::Aborted). On `Err` the fix-up is left half-applied: children
+    /// may have been repositioned or dropped while the state derived from them was never re-synced.
+    /// The iterator is therefore in an indeterminate state, and the caller must drop it rather than
+    /// read from it or revalidate it again. This mirrors [`RQESuspendedIterator::resume`], which
+    /// consumes the iterator and drops it on the same failure.
+    ///
+    /// At the FFI boundary the two errors are reported apart: `TimedOut` becomes
+    /// `VALIDATE_TIMEOUT`, which tells the C caller the result set is incomplete, while `IoError`
+    /// becomes `VALIDATE_ABORTED`, a dead subtree in a query that still has time left.
+    ///
     /// # Locking
     ///
     /// The caller must hold the spec read lock, represented by [`IndexSpecReadGuard`].

--- a/src/redisearch_rs/rqe_iterators/tests/integration/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/interop.rs
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Tests for the revalidation status crossing the C ABI, in both directions.
+//!
+//! A revalidation that fails is unrecoverable either way, so C frees the iterator whichever error
+//! it was. What the status has to preserve is the *report*: a timeout leaves the result set partial
+//! and has to reach the client, while an abort lets the query end as if the index were exhausted.
+//! Collapsing the two, as this boundary used to, turns a timed-out query into a successful one.
+
+use ffi::{
+    QueryIterator, ValidateStatus, ValidateStatus_VALIDATE_ABORTED, ValidateStatus_VALIDATE_OK,
+    ValidateStatus_VALIDATE_TIMEOUT,
+};
+use rqe_iterators::{
+    RQEIterator, RQEIteratorError, c2rust::CRQEIterator, interop::RQEIteratorWrapper,
+    intersection::Intersection,
+};
+use rqe_iterators_test_utils::MockContext;
+
+use crate::utils::{Mock, MockRevalidateResult};
+
+/// Call the C `Revalidate` callback on a Rust iterator lowered to the C ABI, then free it.
+fn revalidate_through_c_abi(outcome: MockRevalidateResult) -> ValidateStatus {
+    let ctx = MockContext::new(100, 10);
+    let mock = Mock::new([1, 2, 3]);
+    mock.data().set_revalidate_result(outcome);
+
+    let it: *mut QueryIterator = RQEIteratorWrapper::boxed_new(mock);
+    // SAFETY: `sctx` is a valid `RedisSearchCtx` owned by the mock context, and its `spec` is the
+    // spec the iterator is revalidated against. `boxed_new` populates every callback.
+    let status = unsafe {
+        let spec = (*ctx.sctx().as_ptr()).spec;
+        let revalidate = (*it).Revalidate.expect("Revalidate must be populated");
+        revalidate(it, spec)
+    };
+    // SAFETY: `it` is the owning pointer returned by `boxed_new` and is not used afterwards.
+    unsafe { ((*it).Free.expect("Free must be populated"))(it) };
+
+    status
+}
+
+#[test]
+fn timed_out_revalidation_is_reported_as_a_timeout() {
+    assert_eq!(
+        revalidate_through_c_abi(MockRevalidateResult::TimedOut),
+        ValidateStatus_VALIDATE_TIMEOUT,
+        "a deadline that expires mid-revalidation must reach C as a timeout: reported as an abort, \
+         the query ends as if the index were exhausted and the client is handed a truncated result \
+         set labelled complete",
+    );
+}
+
+#[test]
+fn failed_revalidation_is_reported_as_an_abort() {
+    assert_eq!(
+        revalidate_through_c_abi(MockRevalidateResult::IoError),
+        ValidateStatus_VALIDATE_ABORTED,
+        "an I/O error kills the subtree in a query that still has time left, so it stays an abort",
+    );
+}
+
+#[test]
+fn aborted_revalidation_is_reported_as_an_abort() {
+    assert_eq!(
+        revalidate_through_c_abi(MockRevalidateResult::Abort),
+        ValidateStatus_VALIDATE_ABORTED,
+    );
+}
+
+#[test]
+fn successful_revalidation_is_reported_as_ok() {
+    assert_eq!(
+        revalidate_through_c_abi(MockRevalidateResult::Ok),
+        ValidateStatus_VALIDATE_OK,
+    );
+}
+
+#[test]
+fn a_c_child_that_times_out_hands_its_rust_parent_an_error() {
+    let ctx = MockContext::new(100, 10);
+    let guard = ctx.spec_read();
+
+    let mock = Mock::new([1, 2, 3]);
+    mock.data()
+        .set_revalidate_result(MockRevalidateResult::TimedOut);
+    // Lowering the mock to the C ABI and adopting it back puts both mappings in the path, so this
+    // covers the round trip: `Err(TimedOut)` -> `VALIDATE_TIMEOUT` -> `Err(TimedOut)`.
+    let mut child = CRQEIterator::from_rust_leaf(mock);
+
+    let err = child
+        .revalidate(&guard)
+        .expect_err("a timed-out child must surface as an error, not as a status");
+    assert!(
+        matches!(err, RQEIteratorError::TimedOut),
+        "expected a timeout, got {err:?}: a Rust composite propagates this to the root of the \
+         tree, exactly as it does for a child that times out during a read or a skip",
+    );
+}
+
+#[test]
+fn a_child_timeout_reaches_c_as_a_timeout_through_a_composite() {
+    let ctx = MockContext::new(100, 10);
+    let healthy = Mock::new([1, 2, 3]);
+    let timing_out = Mock::new([1, 2, 3]);
+    timing_out
+        .data()
+        .set_revalidate_result(MockRevalidateResult::TimedOut);
+
+    // Children go through the C ABI, as they do in a real query plan, so the child's timeout is
+    // mapped twice on its way up: to `VALIDATE_TIMEOUT` and back to an error for the parent.
+    let intersection = Intersection::new(
+        vec![
+            CRQEIterator::from_rust_leaf(healthy),
+            CRQEIterator::from_rust_leaf(timing_out),
+        ],
+        1.0,
+        false,
+    );
+    let it: *mut QueryIterator = RQEIteratorWrapper::boxed_new_compound(intersection);
+
+    // SAFETY: as in `revalidate_through_c_abi`.
+    let status = unsafe {
+        let spec = (*ctx.sctx().as_ptr()).spec;
+        ((*it).Revalidate.expect("Revalidate must be populated"))(it, spec)
+    };
+    // SAFETY: `it` is the owning pointer returned by `boxed_new_compound` and is not used after.
+    unsafe { ((*it).Free.expect("Free must be populated"))(it) };
+
+    assert_eq!(
+        status, ValidateStatus_VALIDATE_TIMEOUT,
+        "a composite propagates a child's failure with `?`, so the timeout has to survive the whole \
+         way up to the root of the tree - that is the one iterator C revalidates",
+    );
+}
+
+// Relies on nextest's process-per-test isolation: the switch is process-global, so a shared-process
+// runner could leak it into another test's revalidation.
+#[cfg(not(miri))]
+#[test]
+fn the_debug_switch_reports_a_timeout_without_consulting_the_iterator() {
+    let ctx = MockContext::new(100, 10);
+    let mock = Mock::new([1, 2, 3]);
+    let data = mock.data();
+    let it: *mut QueryIterator = RQEIteratorWrapper::boxed_new(mock);
+
+    rqe_iterators::interop::set_mock_revalidate_timeout(true);
+    // SAFETY: as in `revalidate_through_c_abi`.
+    let status = unsafe {
+        let spec = (*ctx.sctx().as_ptr()).spec;
+        ((*it).Revalidate.expect("Revalidate must be populated"))(it, spec)
+    };
+    rqe_iterators::interop::set_mock_revalidate_timeout(false);
+    // SAFETY: `it` is the owning pointer returned by `boxed_new` and is not used afterwards.
+    unsafe { ((*it).Free.expect("Free must be populated"))(it) };
+
+    assert_eq!(status, ValidateStatus_VALIDATE_TIMEOUT);
+    assert_eq!(
+        data.revalidate_count(),
+        0,
+        "the switch stands in for an expired deadline, so it must short-circuit rather than let \
+         the iterator revalidate and then discard the outcome",
+    );
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/main.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/main.rs
@@ -39,6 +39,7 @@ mod empty;
 mod format_g;
 mod geo_shape;
 mod id_list;
+mod interop;
 mod intersection;
 mod inverted_index;
 mod maybe_empty;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/main.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/main.rs
@@ -40,6 +40,7 @@ mod empty;
 mod format_g;
 mod geo_shape;
 mod id_list;
+mod interop;
 mod intersection;
 mod inverted_index;
 mod maybe_empty;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -312,6 +312,26 @@ pub enum MockRevalidateResult {
     Ok,
     Abort,
     Move,
+    /// Revalidation ran out of time, e.g. while re-seeking the index after a GC cycle.
+    TimedOut,
+    /// Revalidation failed to read from the index.
+    IoError,
+}
+
+impl MockRevalidateResult {
+    /// The error this outcome stands for, or `None` if it is one of the successful ones.
+    ///
+    /// Both revalidation and resume report a failure the same way — as an `Err` that leaves the
+    /// iterator unusable — so both paths funnel their failing outcomes through here.
+    fn as_error(self) -> Option<rqe_iterators::RQEIteratorError> {
+        match self {
+            Self::TimedOut => Some(rqe_iterators::RQEIteratorError::TimedOut),
+            Self::IoError => Some(rqe_iterators::RQEIteratorError::IoError(
+                std::io::Error::other("mock revalidation failure"),
+            )),
+            Self::Ok | Self::Abort | Self::Move => None,
+        }
+    }
 }
 
 impl<'index, const N: usize> Mock<'index, N> {
@@ -499,6 +519,12 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
             (data.revalidate_result, data.revalidate_reseeks_to)
         };
 
+        // A failing outcome ends the call before any of the repositioning below: it leaves the
+        // iterator indeterminate, which is exactly what the caller is told by the `Err`.
+        if let Some(err) = revalidate_result.as_error() {
+            return Err(err);
+        }
+
         // Rewind-and-re-seek takes precedence: it describes the whole outcome,
         // including where the mock ends up. See
         // [`MockData::set_revalidate_reseeks_to`].
@@ -537,6 +563,9 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
                     self.next_index = past_end_cursor(N);
                     rqe_iterators::RQEValidateStatus::Moved { current: None }
                 }
+            }
+            MockRevalidateResult::TimedOut | MockRevalidateResult::IoError => {
+                unreachable!("failing outcomes returned above")
             }
         })
     }
@@ -665,6 +694,11 @@ impl<'query, const N: usize> rqe_iterators::RQESuspendedIterator<'query> for Moc
         if let Some(err) = resume_error {
             return Err(err.into_rqe_iterator_error());
         }
+        // A failing revalidation outcome means the same thing on this path: consume the suspended
+        // mock and report the error, materializing no active iterator.
+        if let Some(err) = revalidate_result.as_error() {
+            return Err(err);
+        }
         if reseeks_past_end {
             // Reproduce `RawInvIndIterator::resume_in_place` on a GC-invalidated
             // offset whose re-seek finds nothing: rewind, then end up at EOF with
@@ -714,6 +748,9 @@ impl<'query, const N: usize> rqe_iterators::RQESuspendedIterator<'query> for Moc
             }
             // Unrecoverable: drop the suspended mock, materialize no active iterator.
             MockRevalidateResult::Abort => return Ok(rqe_iterators::ResumeOutcome::Aborted),
+            MockRevalidateResult::TimedOut | MockRevalidateResult::IoError => {
+                unreachable!("failing outcomes returned above")
+            }
         };
         let raw = Box::into_raw(self);
         // SAFETY: layout-identical (see [`Mock::suspend`]).
@@ -886,6 +923,12 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
             data.revalidate_result
         };
 
+        // See `Mock::revalidate`: a failing outcome ends the call, leaving the iterator
+        // indeterminate.
+        if let Some(err) = revalidate_result.as_error() {
+            return Err(err);
+        }
+
         let n = self.doc_ids.len();
         Ok(match revalidate_result {
             MockRevalidateResult::Ok => rqe_iterators::RQEValidateStatus::Ok,
@@ -902,6 +945,9 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
                     self.next_index = past_end_cursor(n);
                     rqe_iterators::RQEValidateStatus::Moved { current: None }
                 }
+            }
+            MockRevalidateResult::TimedOut | MockRevalidateResult::IoError => {
+                unreachable!("failing outcomes returned above")
             }
         })
     }
@@ -1008,6 +1054,11 @@ impl<'query> rqe_iterators::RQESuspendedIterator<'query> for MockVecSuspended {
         if let Some(err) = resume_error {
             return Err(err.into_rqe_iterator_error());
         }
+        // A failing revalidation outcome means the same thing on this path: consume the suspended
+        // mock and report the error, materializing no active iterator.
+        if let Some(err) = revalidate_result.as_error() {
+            return Err(err);
+        }
         let moved = match revalidate_result {
             MockRevalidateResult::Ok => false,
             MockRevalidateResult::Move => {
@@ -1026,6 +1077,9 @@ impl<'query> rqe_iterators::RQESuspendedIterator<'query> for MockVecSuspended {
             }
             // Unrecoverable: drop the suspended mock, materialize no active iterator.
             MockRevalidateResult::Abort => return Ok(rqe_iterators::ResumeOutcome::Aborted),
+            MockRevalidateResult::TimedOut | MockRevalidateResult::IoError => {
+                unreachable!("failing outcomes returned above")
+            }
         };
         let raw = Box::into_raw(self);
         // SAFETY: layout-identical (see [`MockVec::suspend`]).

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -250,9 +250,19 @@ static inline void SearchResult_BufferIndexResult(ResultProcessor *rp, SearchRes
   }
 }
 
+typedef enum {
+  REVALIDATE_CONTINUE,         // Proceed with a normal read
+  REVALIDATE_VALIDATE_CURRENT, // The iterator moved: use its current result before reading again
+  REVALIDATE_TIMEDOUT,         // The deadline expired mid-revalidation: report a timeout
+} RevalidateOutcome;
+
 /**
  * Handle initial spec lock and iterator revalidation.
- * Returns true if we should goto validate_current (VALIDATE_MOVED case).
+ *
+ * On VALIDATE_ABORTED and VALIDATE_TIMEOUT alike the iterator is unusable and gets replaced by an
+ * empty one, so the pipeline stays safe if it reads again. The two part ways in what the caller
+ * reports: an abort lets the query end as if the index were exhausted, while a timeout means the
+ * results are partial and must be returned as `RS_RESULT_TIMEDOUT`.
  *
  * * For disk indexes, we skip the lock acquisition because:
  * 1. All in-memory structure accesses (terms Trie, suffix Trie, stats) happen
@@ -261,33 +271,36 @@ static inline void SearchResult_BufferIndexResult(ResultProcessor *rp, SearchRes
  *    consistency for disk reads without needing to hold the lock.
  * 3. This avoids blocking the main thread during disk IO operations.
  */
-static bool handleSpecLockAndRevalidate(RPQueryIterator *self) {
+static RevalidateOutcome handleSpecLockAndRevalidate(RPQueryIterator *self) {
   RedisSearchCtx *sctx = self->sctx;
 
   // For disk indexes, return immediately, since we don't need to acquire the
   // lock, nor to revalidate the iterators.
   if (sctx->spec->diskSpec) {
-    return false;
+    return REVALIDATE_CONTINUE;
   }
 
   QueryIterator *it = self->iterator;
 
   if (sctx->lock_state != SPEC_LOCK_UNSET) {
-    return false;
+    return REVALIDATE_CONTINUE;
   }
 
   RedisSearchCtx_LockSpecRead(sctx);
 
   ValidateStatus rc = it->Revalidate(it, sctx->spec);
 
-  if (rc == VALIDATE_ABORTED) {
+  if (rc == VALIDATE_ABORTED || rc == VALIDATE_TIMEOUT) {
     self->iterator->Free(self->iterator);
     self->iterator = NewEmptyIterator();
+    if (rc == VALIDATE_TIMEOUT) {
+      return REVALIDATE_TIMEDOUT;
+    }
   } else if (rc == VALIDATE_MOVED && !it->atEOF) {
-    return true;  // Caller should validate current
+    return REVALIDATE_VALIDATE_CURRENT;
   }
 
-  return false;
+  return REVALIDATE_CONTINUE;
 }
 
 /* Next implementation for sync disk and regular (in-memory) flow */
@@ -298,7 +311,11 @@ static int rpQueryItNext(ResultProcessor *base, SearchResult *res) {
   IndexSpec* spec = sctx->spec;
   const RSDocumentMetadata *dmd;
   // Handle spec lock and revalidation
-  bool needToValidateCurrent = handleSpecLockAndRevalidate(self);
+  RevalidateOutcome revalidateOutcome = handleSpecLockAndRevalidate(self);
+  if (revalidateOutcome == REVALIDATE_TIMEDOUT) {
+    return UnlockSpec_and_ReturnRPResult(sctx, RS_RESULT_TIMEDOUT);
+  }
+  bool needToValidateCurrent = (revalidateOutcome == REVALIDATE_VALIDATE_CURRENT);
 
   // Always update it after revalidation as iterator may have been replaced
   it = self->iterator;
@@ -357,9 +374,14 @@ static int rpQueryItNext_AsyncDisk(ResultProcessor *base, SearchResult *res) {
   QueryIterator *it = self->iterator;
   RedisSearchCtx *sctx = self->sctx;
 
-  // Handle spec lock and revalidation
-  // no need store the return value since validate current result is not needed for async disk path
-  handleSpecLockAndRevalidate(self);
+  // Handle spec lock and revalidation.
+  // Neither outcome is reachable today: this processor is only installed for disk specs, and those
+  // return before revalidating at all. A moved iterator would need no special handling here anyway,
+  // but the timeout is answered defensively, so that a disk spec which one day does revalidate
+  // reports the timeout instead of reading past it as end-of-results.
+  if (handleSpecLockAndRevalidate(self) == REVALIDATE_TIMEDOUT) {
+    return UnlockSpec_and_ReturnRPResult(sctx, RS_RESULT_TIMEDOUT);
+  }
 
   // Always update it after revalidation as iterator may have been replaced
   it = self->iterator;

--- a/tests/cpptests/test_cpp_hybrid_reader_disk.cpp
+++ b/tests/cpptests/test_cpp_hybrid_reader_disk.cpp
@@ -298,6 +298,30 @@ TEST_F(HybridReaderDiskTest, TimeoutReturnsTimedOut) {
     vecsimTimeoutCallback = saved;
 }
 
+// The hybrid iterator gives up on an aborted child and on a timed-out one alike, but it has to say
+// which: both free the tree, and only a timeout tells the caller the result set is partial. Folding
+// the timeout into VALIDATE_ABORTED ends the query as if the index were exhausted.
+TEST_F(HybridReaderDiskTest, RevalidateReportsChildTimeoutApartFromAbort) {
+    // A fresh iterator per case: VALIDATE_TIMEOUT and VALIDATE_ABORTED both mean the iterator is
+    // finished and must be freed, so revalidating the same one again would exercise a sequence the
+    // API forbids.
+    const std::pair<ValidateStatus, const char *> cases[] = {
+        {VALIDATE_TIMEOUT, "a timed-out child must stay a timeout, not degrade to an abort"},
+        {VALIDATE_ABORTED, "an aborted child must stay an abort"},
+        {VALIDATE_OK, "a child that is still valid leaves the hybrid iterator usable"},
+    };
+
+    for (const auto &[childStatus, why] : cases) {
+        auto h = makeNormalIterator({{1, 0.5}}, {1}, 1);
+        ASSERT_NE(h.iter, nullptr);
+        auto *hr = (HybridIterator *)h.iter;
+        // `MockIterator` starts with its `QueryIterator base`, so the child pointer is the mock.
+        reinterpret_cast<MockIterator *>(hr->child)->SetRevalidateResult(childStatus);
+
+        EXPECT_EQ(h.iter->Revalidate(h.iter, &mockCtx->spec), childStatus) << why;
+    }
+}
+
 // Pins the CURRENT, unresolved hybrid KNN behavior (see expiration-semantics.md):
 // expired fields are dropped at yield with no refill, so a live candidate just below
 // the top-k is lost and the query under-fills k. Flip the expectation if refill is adopted.

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -76,6 +76,7 @@ class TestDebugCommands(object):
             'QUERY_CONTROLLER',
             'DUMP_SCHEMA',
             'VECSIM_MOCK_TIMEOUT',
+            'MOCK_REVALIDATE_TIMEOUT',
             'GET_MAX_DOC_ID',
             'DUMP_DELETED_IDS',
             'NUMERIC_BUCKET_MAP',

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -75,6 +75,7 @@ class TestDebugCommands(object):
             'QUERY_CONTROLLER',
             'DUMP_SCHEMA',
             'VECSIM_MOCK_TIMEOUT',
+            'MOCK_REVALIDATE_TIMEOUT',
             'GET_MAX_DOC_ID',
             'DUMP_DELETED_IDS',
             'NUMERIC_BUCKET_MAP',

--- a/tests/pytests/test_iterators.py
+++ b/tests/pytests/test_iterators.py
@@ -273,3 +273,106 @@ class TestIteratorsRevalidate:
 
         # No remaining results since we deleted all matching documents
         self.env.assertEqual(remaining_docs, [])
+
+
+class TestIteratorsRevalidateTimeout:
+    """
+    A query whose deadline expires while the iterator tree is being revalidated must be reported as
+    timed out, not as a query that ran to completion.
+
+    Revalidation only happens when a query resumes after releasing the spec lock, so the deadline
+    has to expire in that narrow window. `MOCK_REVALIDATE_TIMEOUT` stands in for it: the timeout
+    sources a test can drive directly are the same flags the result processor checks immediately
+    after revalidating, which hides the very case under test.
+    """
+
+    def __init__(self):
+        skipTest(cluster=True)
+        self.env = Env(protocol=3,
+                       moduleArgs='FORK_GC_CLEAN_THRESHOLD 1 FORK_GC_RUN_INTERVAL 99999999999999999')
+
+    def setUp(self):
+        self.env.expect('FT.CREATE', 'idx', 'SCHEMA', 'text', 'TEXT').ok()
+        with self.env.getClusterConnectionIfNeeded() as conn:
+            for i in range(1, 6):
+                conn.execute_command('HSET', f'doc:{i}', 'text', 'apple')
+        self.prev_policy = self.env.cmd('CONFIG', 'GET', ON_TIMEOUT_CONFIG)[ON_TIMEOUT_CONFIG]
+
+    def tearDown(self):
+        self.env.cmd(debug_cmd(), 'MOCK_REVALIDATE_TIMEOUT', 'disable')
+        self.env.cmd('CONFIG', 'SET', ON_TIMEOUT_CONFIG, self.prev_policy)
+        self.env.flush()
+
+    def open_cursor(self, on_timeout):
+        """Open a cursor under `on_timeout`, then stage a revalidation that will time out.
+
+        The policy is frozen onto the cursor when it is created, so it has to be set first.
+
+        The delete and the GC cycle are what make revalidation do real work in production - the
+        iterators re-seek an index whose blocks moved under them, which is where the deadline would
+        actually expire. The mock reports the timeout before any of that runs, so this setup does
+        not affect the assertions; it is here to keep the sequence recognisable as the production
+        one, not to drive the timeout.
+        """
+        self.env.expect('CONFIG', 'SET', ON_TIMEOUT_CONFIG, on_timeout).ok()
+        res, cursor = self.env.cmd('FT.AGGREGATE', 'idx', 'apple', 'LOAD', '1', '@__key',
+                                   'WITHCURSOR', 'COUNT', '1')
+        self.env.assertEqual(len(res['results']), 1)
+        self.env.assertNotEqual(cursor, 0, message="the cursor must still have results to read")
+
+        with self.env.getClusterConnectionIfNeeded() as conn:
+            self.env.assertEqual(conn.execute_command('DEL', 'doc:2'), 1)
+        forceInvokeGC(self.env)
+
+        self.env.expect(debug_cmd(), 'MOCK_REVALIDATE_TIMEOUT', 'enable').ok()
+        return cursor
+
+    def test_status_reports_whether_the_switch_is_on(self):
+        """`status` makes a server left with the switch on diagnosable rather than baffling."""
+        self.env.expect(debug_cmd(), 'MOCK_REVALIDATE_TIMEOUT', 'status').equal(
+            'Mock revalidation timeout: disabled')
+
+        self.env.expect(debug_cmd(), 'MOCK_REVALIDATE_TIMEOUT', 'enable').ok()
+        self.env.expect(debug_cmd(), 'MOCK_REVALIDATE_TIMEOUT', 'status').equal(
+            'Mock revalidation timeout: enabled')
+
+        self.env.expect(debug_cmd(), 'MOCK_REVALIDATE_TIMEOUT', 'disable').ok()
+        self.env.expect(debug_cmd(), 'MOCK_REVALIDATE_TIMEOUT', 'status').equal(
+            'Mock revalidation timeout: disabled')
+
+        self.env.expect(debug_cmd(), 'MOCK_REVALIDATE_TIMEOUT', 'bogus').error().contains(
+            'Use: enable, disable, or status')
+
+    def test_fail_policy_errors_on_revalidation_timeout(self):
+        """Under ON_TIMEOUT FAIL the read is an error, not a silently truncated result set."""
+        cursor = self.open_cursor('fail')
+
+        self.env.expect('FT.CURSOR', 'READ', 'idx', cursor).error().contains(
+            'Timeout limit was reached')
+
+    def test_return_policy_warns_and_drops_the_tree(self):
+        """Under ON_TIMEOUT RETURN the read warns instead of ending cleanly, and the tree is gone.
+
+        Both halves matter. The warning is the fix: the client is told the results are partial
+        rather than complete. The empty tail is the cost that comes with it - a timed-out
+        revalidation leaves the iterators indeterminate, so they are freed exactly as an aborted
+        revalidation frees them, and the cursor has nothing left to serve even once the deadline is
+        out of the way.
+        """
+        cursor = self.open_cursor('return')
+
+        res, cursor = self.env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
+        self.env.assertNotEqual(cursor, 0,
+                                message="RETURN keeps the cursor alive across a timeout; a cursor "
+                                        "depleted here means the read ended as if the index were "
+                                        "exhausted")
+        self.env.assertEqual(res['results'], [],
+                             message="the timeout lands before any result is read")
+        VerifyTimeoutWarningResp3(self.env, res,
+                                  message="a revalidation timeout must reach the client")
+
+        self.env.expect(debug_cmd(), 'MOCK_REVALIDATE_TIMEOUT', 'disable').ok()
+        while cursor != 0:
+            res, cursor = self.env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
+            self.env.assertEqual(res['results'], [],
+                                 message="the tree was freed, so no further results can arrive")


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `ValidateStatus` has no way to say the deadline expired, so the FFI boundary collapsed every `Err` from `revalidate` into `VALIDATE_ABORTED`. The result processor then freed the iterator tree, swapped in an empty iterator, and the query ended as `RS_RESULT_EOF` — the client got a truncated result set labelled complete, with no warning and no error.
2. **Change**: Add `VALIDATE_TIMEOUT`. It frees the iterator exactly as an abort does and differs only in the report: the results are partial, so the caller returns `RS_RESULT_TIMEDOUT`. The hybrid and optimizer readers propagate it instead of folding it into an abort, and `c2rust` maps it back to `Err(TimedOut)` for a C child under a Rust composite.
3. **Outcome**: A timeout during revalidation surfaces as a timeout warning under `ON_TIMEOUT RETURN` and a `SEARCH_TIMEOUT` error under `FAIL`, instead of a silently truncated result set.

Freeing on timeout stays correct: a failed revalidation leaves the fix-up half-applied — children repositioned or dropped, the state derived from them never re-synced — and the `resume` API that replaces `revalidate` already consumes and drops the iterator on `Err`.

Revalidation only runs when a query resumes after releasing the spec lock, and the blocked-client deadline a test can fire on demand is the same flag the result processor checks immediately afterwards — which hides the case under test. The new debug-only `FT.DEBUG MOCK_REVALIDATE_TIMEOUT enable|disable` stands in for the expired deadline, following the `VECSIM_MOCK_TIMEOUT` precedent. Both flow tests were confirmed to fail without the fix.

#### Which additional issues this PR fixes
1. MOD-17488

#### Main objects this PR modified
1. `src/iterators/iterator_api.h` — the `ValidateStatus` contract
2. `src/result_processor.c` — `handleSpecLockAndRevalidate`
3. `src/redisearch_rs/rqe_iterators/src/interop.rs`, `c2rust.rs` — the two status mappings
4. `src/iterators/hybrid_reader.c`, `optimizer_reader.c` — propagation through the C composites
5. `src/debug_commands.c` — `MOCK_REVALIDATE_TIMEOUT` (debug-only)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
