### PR TITLE
[MOD-17489] Cursor reads no longer time out against a deadline that belonged to an earlier read

### DIFF
--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/geo_shape.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/geo_shape.rs
@@ -80,7 +80,9 @@ impl MemTracker for ExternalCounter {
 ///
 /// 1. `sctx` must be a non-null pointer to a valid [`RedisSearchCtx`] whose
 ///    `spec` is a valid [`IndexSpec`](ffi::IndexSpec); both must outlive the
-///    returned iterator.
+///    returned iterator, and `sctx` must stay at a stable address for that
+///    whole window: the iterator reads `sctx.time.timeout` back on every
+///    timeout probe. No write to that deadline may overlap a probe.
 /// 2. `filter_ctx` must be a non-null pointer to a valid [`FieldFilterContext`].
 /// 3. `ids` must be null, or point to `num` initialized [`DocId`]s allocated via
 ///    `RedisModule_Alloc`. Ownership is transferred to the iterator. When `ids`

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/geo_shape.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/geo_shape.rs
@@ -98,8 +98,6 @@ pub unsafe extern "C" fn NewGeometryQueryIterator(
     allocated: *mut usize,
 ) -> *mut QueryIterator {
     let sctx_nn = NonNull::new(sctx as *mut RedisSearchCtx).expect("sctx must be non-null");
-    // SAFETY: precondition 1.
-    let sctx_ref = unsafe { sctx_nn.as_ref() };
 
     let filter_ctx_nn =
         NonNull::new(filter_ctx as *mut FieldFilterContext).expect("filter_ctx must be non-null");
@@ -115,7 +113,10 @@ pub unsafe extern "C" fn NewGeometryQueryIterator(
     // SAFETY: precondition 1 guarantees `sctx` and `sctx.spec` are valid and outlive the returned iterator.
     let expiration_checker = unsafe { FieldExpirationChecker::new(sctx_nn, filter, 0) };
 
-    let timeout_ctx = AnyTimeoutContext::from_sctx(sctx_ref, TIMEOUT_CHECK_GRANULARITY);
+    // SAFETY: precondition 1 guarantees `sctx` is valid and outlives the returned iterator, which
+    // is what `from_sctx` requires in order to read the deadline back on each probe. Writes to the
+    // deadline never overlap a probe (see `TimeoutContextDeadline::new`).
+    let timeout_ctx = unsafe { AnyTimeoutContext::from_sctx(sctx_nn, TIMEOUT_CHECK_GRANULARITY) };
 
     let ids_list = if !ids.is_null() {
         // SAFETY: precondition 3.

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/not.rs
@@ -9,7 +9,7 @@
 
 use std::ptr::NonNull;
 
-use ffi::{AREQ, QueryIterator, timespec};
+use ffi::{AREQ, QueryIterator};
 use rqe_core::DocId;
 use rqe_iterators::{
     NewWildcardIterator, RQEIterator,
@@ -18,10 +18,7 @@ use rqe_iterators::{
     not::Not,
     not_optimized::NotOptimized,
     not_reducer::{NewNotIterator, TIMEOUT_CHECK_GRANULARITY, new_not_iterator},
-    utils::{
-        AnyTimeoutContext, DeadlineTimeoutChecker, NoTimeoutChecker, TimeoutContextBlockedClient,
-        duration_from_redis_timespec,
-    },
+    utils::{AnyTimeoutContext, TimeoutContextBlockedClient},
 };
 
 type NotFfi<'index> = Not<'index, CRQEIterator, AnyTimeoutContext>;
@@ -171,7 +168,6 @@ impl<'index> rqe_iterators::interop::ProfileChildren<'index> for NotIteratorEnum
 /// must uphold the [`TimeoutContextBlockedClient::new`] safety contract for
 /// as long as the returned context (and any iterator built from it) is used.
 unsafe fn build_timeout_context(
-    timeout: timespec,
     bc_timeout_areq: *mut AREQ,
     q: NonNull<ffi::QueryEvalCtx>,
 ) -> AnyTimeoutContext {
@@ -185,18 +181,13 @@ unsafe fn build_timeout_context(
         None => {
             // SAFETY: caller guarantees q is valid (3).
             let q_ref = unsafe { q.as_ref() };
-            // SAFETY: caller guarantees q.sctx is valid (4).
-            let sctx = unsafe { &*q_ref.sctx };
-            if sctx.time.skipTimeoutChecks {
-                return AnyTimeoutContext::NoTimeout(NoTimeoutChecker);
-            }
-            match duration_from_redis_timespec(timeout) {
-                Some(duration) => AnyTimeoutContext::Clock(DeadlineTimeoutChecker::new(
-                    duration,
-                    TIMEOUT_CHECK_GRANULARITY,
-                )),
-                None => AnyTimeoutContext::NoTimeout(NoTimeoutChecker),
-            }
+            let sctx = NonNull::new(q_ref.sctx).expect("q.sctx must be non-null (precondition 4)");
+            // The deadline comes from `sctx` and is read back on every probe: cursor reads re-arm
+            // it, and an iterator that captured it once would answer with the first read's
+            // deadline forever after. `from_sctx` also decides whether there is a deadline at all.
+            // SAFETY: caller guarantees `q.sctx` is valid (4) for as long as the returned context
+            // and any iterator built from it are used.
+            unsafe { AnyTimeoutContext::from_sctx(sctx, TIMEOUT_CHECK_GRANULARITY) }
         }
     }
 }
@@ -208,11 +199,13 @@ unsafe fn build_timeout_context(
 ///
 /// `bc_timeout_areq` selects the timeout source. When non-null, the Blocked
 /// Client Timeout path is used: every iterator timeout probe forwards to
-/// `AREQ_CheckTimedOut` and `timeout` / `skipTimeoutChecks` are ignored.
-/// When null, the Clock Based Timeout path is used: `timeout` is the
-/// deadline and `skipTimeoutChecks` (read from `q.sctx.time`) disables the
-/// check entirely. The C caller is expected to pre-filter the owning
-/// request via `AREQ_TimeoutAreqOrNull` before passing it here.
+/// `AREQ_CheckTimedOut` and `q.sctx.time` is ignored.
+/// When null, the Clock Based Timeout path is used, driven entirely by `q.sctx.time`:
+/// `timeout` is the deadline, read back on every probe so that a re-armed deadline is
+/// honoured, and `skipTimeoutChecks` disables the check entirely. There is deliberately no
+/// deadline parameter — a caller wanting a different deadline sets `q.sctx.time.timeout`,
+/// which is the only value the iterator will ever consult. The C caller is expected to
+/// pre-filter the owning request via `AREQ_TimeoutAreqOrNull` before passing it here.
 ///
 /// # Safety
 ///
@@ -221,7 +214,10 @@ unsafe fn build_timeout_context(
 /// 2. When non-null, `child` must not be aliased.
 /// 3. `q` must be a valid non-null pointer to a [`QueryEvalCtx`](ffi::QueryEvalCtx).
 /// 4. `q.sctx` must be a non-null pointer to a valid
-///    [`RedisSearchCtx`](ffi::RedisSearchCtx).
+///    [`RedisSearchCtx`](ffi::RedisSearchCtx), which must stay valid and at a stable
+///    address for the lifetime of the returned iterator: on the Clock Based Timeout path
+///    the iterator reads `q.sctx.time.timeout` back on every probe. No write to that
+///    deadline may overlap a probe.
 /// 5. `q.sctx.spec` must be a non-null pointer to a valid
 ///    [`IndexSpec`](ffi::IndexSpec).
 /// 6. `q.sctx.spec.rule`, when non-null, must point to a valid
@@ -236,14 +232,13 @@ pub unsafe extern "C" fn NewNotIterator(
     child: *mut QueryIterator,
     max_doc_id: DocId,
     weight: f64,
-    timeout: timespec,
     bc_timeout_areq: *mut AREQ,
     q: *mut ffi::QueryEvalCtx,
 ) -> *mut QueryIterator {
     let query = NonNull::new(q).expect("q must be non-null");
 
     // SAFETY: caller upholds preconditions (3, 4, 8).
-    let timeout_ctx = unsafe { build_timeout_context(timeout, bc_timeout_areq, query) };
+    let timeout_ctx = unsafe { build_timeout_context(bc_timeout_areq, query) };
 
     // Handle null child: reduce with Empty directly (always becomes wildcard).
     let Some(child_ptr) = NonNull::new(child) else {

--- a/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
@@ -54,6 +54,12 @@ impl QueryEvalContext {
     /// 2. All pointer fields within the [`ffi::QueryEvalCtx`] (`sctx`, `opts`,
     ///    `status`, `metricRequestsP`, `docTable`, `config`) and the nested
     ///    `sctx.spec` pointer must themselves be valid, non-null pointers.
+    ///    `sctx` must additionally stay valid, and at a stable address, for the
+    ///    lifetime of every timeout context and iterator derived from this
+    ///    context (e.g. via
+    ///    [`build_timeout_context`](QueryEvalContext::build_timeout_context)):
+    ///    a clock-based timeout context reads `sctx.time.timeout` back on every
+    ///    probe rather than capturing it.
     ///    The nested `sctx.spec.diskSpec` pointer may be null (in-memory mode);
     ///    when non-null it must point to a valid
     ///    [`RedisSearchDiskIndexSpec`](ffi::RedisSearchDiskIndexSpec).
@@ -277,7 +283,10 @@ impl QueryEvalContext {
     /// # Safety
     ///
     /// The returned context, and any iterator built from it, must not be used
-    /// after the `AREQ` behind `bcTimeoutAreq` is freed.
+    /// after the `AREQ` behind `bcTimeoutAreq` is freed — nor after `sctx` is
+    /// freed or moved, since the clock-based variant reads the deadline out of
+    /// it on every probe. No write to `sctx.time.timeout` may overlap a probe;
+    /// see [`TimeoutContextDeadline::new`](rqe_iterators::utils::TimeoutContextDeadline::new).
     ///
     /// A Blocked Client Timeout context holds that `AREQ` as a raw pointer with
     /// no lifetime, so nothing enforces the precondition at compile time:
@@ -303,7 +312,14 @@ impl QueryEvalContext {
             }
             // No Blocked Client Timeout source: derive the Clock Based Timeout
             // (or `NoTimeoutChecker`) from `sctx.time`.
-            None => AnyTimeoutContext::from_sctx(self.sctx(), TIMEOUT_CHECK_GRANULARITY),
+            None => {
+                let sctx = NonNull::new(self.sctx_ptr().cast_mut()).expect("sctx must be non-null");
+                // SAFETY: invariant (2) of `new` guarantees `sctx` stays valid for the lifetime of
+                // every timeout context and iterator derived from this one, which is what
+                // `from_sctx` needs to read the deadline back on each probe. Writes to the
+                // deadline never overlap a probe (see `TimeoutContextDeadline::new`).
+                unsafe { AnyTimeoutContext::from_sctx(sctx, TIMEOUT_CHECK_GRANULARITY) }
+            }
         }
     }
 }

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -677,11 +677,13 @@ QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagInd
  *
  * `bc_timeout_areq` selects the timeout source. When non-null, the Blocked
  * Client Timeout path is used: every iterator timeout probe forwards to
- * `AREQ_CheckTimedOut` and `timeout` / `skipTimeoutChecks` are ignored.
- * When null, the Clock Based Timeout path is used: `timeout` is the
- * deadline and `skipTimeoutChecks` (read from `q.sctx.time`) disables the
- * check entirely. The C caller is expected to pre-filter the owning
- * request via `AREQ_TimeoutAreqOrNull` before passing it here.
+ * `AREQ_CheckTimedOut` and `q.sctx.time` is ignored.
+ * When null, the Clock Based Timeout path is used, driven entirely by `q.sctx.time`:
+ * `timeout` is the deadline, read back on every probe so that a re-armed deadline is
+ * honoured, and `skipTimeoutChecks` disables the check entirely. There is deliberately no
+ * deadline parameter — a caller wanting a different deadline sets `q.sctx.time.timeout`,
+ * which is the only value the iterator will ever consult. The C caller is expected to
+ * pre-filter the owning request via `AREQ_TimeoutAreqOrNull` before passing it here.
  *
  * # Safety
  *
@@ -690,7 +692,10 @@ QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagInd
  * 2. When non-null, `child` must not be aliased.
  * 3. `q` must be a valid non-null pointer to a [`QueryEvalCtx`](ffi::QueryEvalCtx).
  * 4. `q.sctx` must be a non-null pointer to a valid
- *    [`RedisSearchCtx`](ffi::RedisSearchCtx).
+ *    [`RedisSearchCtx`](ffi::RedisSearchCtx), which must stay valid and at a stable
+ *    address for the lifetime of the returned iterator: on the Clock Based Timeout path
+ *    the iterator reads `q.sctx.time.timeout` back on every probe. No write to that
+ *    deadline may overlap a probe.
  * 5. `q.sctx.spec` must be a non-null pointer to a valid
  *    [`IndexSpec`](ffi::IndexSpec).
  * 6. `q.sctx.spec.rule`, when non-null, must point to a valid
@@ -701,7 +706,7 @@ QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagInd
  *    [`TimeoutContextBlockedClient::new`] safety contract and remain
  *    valid for the lifetime of the returned iterator.
  */
-QueryIterator *NewNotIterator(QueryIterator *child, t_docId max_doc_id, double weight, timespec timeout, AREQ *bc_timeout_areq, QueryEvalCtx *q);
+QueryIterator *NewNotIterator(QueryIterator *child, t_docId max_doc_id, double weight, AREQ *bc_timeout_areq, QueryEvalCtx *q);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -496,7 +496,9 @@ void Optimus_PrintProfile(const QueryIterator *self_, struct MapBuilder *map, st
  *
  * 1. `sctx` must be a non-null pointer to a valid [`RedisSearchCtx`] whose
  *    `spec` is a valid [`IndexSpec`](ffi::IndexSpec); both must outlive the
- *    returned iterator.
+ *    returned iterator, and `sctx` must stay at a stable address for that
+ *    whole window: the iterator reads `sctx.time.timeout` back on every
+ *    timeout probe. No write to that deadline may overlap a probe.
  * 2. `filter_ctx` must be a non-null pointer to a valid [`FieldFilterContext`].
  * 3. `ids` must be null, or point to `num` initialized [`DocId`]s allocated via
  *    `RedisModule_Alloc`. Ownership is transferred to the iterator. When `ids`

--- a/src/redisearch_rs/query_eval/src/nodes/not.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/not.rs
@@ -44,10 +44,12 @@ pub(crate) fn eval<'index>(
     let child = eval_child_iterator(ctx, node.child_mut(0), config);
     ctx.set_in_not_sub_tree(prev_in_not_sub_tree);
 
-    // SAFETY: invariant (2) of `QueryEvalContext::new` guarantees `bcTimeoutAreq`
-    // outlives every timeout context derived from `ctx`, and the returned context
-    // is handed straight to `new_not_iterator` below (never retained past this
-    // query), so it cannot be used after the `AREQ` is freed.
+    // SAFETY: invariant (2) of `QueryEvalContext::new` guarantees that both things the
+    // returned context may point at — `bcTimeoutAreq` and `sctx` — outlive every timeout
+    // context derived from `ctx`, and the returned context is handed straight to
+    // `new_not_iterator` below (never retained past this query), so it cannot be used after
+    // either is freed. Writes to `sctx.time.timeout` never overlap a probe (see
+    // `TimeoutContextDeadline::new`).
     let timeout_ctx = unsafe { ctx.build_timeout_context() };
 
     // SAFETY: the preconditions of `new_not_iterator` map to

--- a/src/redisearch_rs/rqe_iterators/src/utils/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/mod.rs
@@ -18,7 +18,7 @@ mod timespec;
 pub use self::owned_slice::OwnedSlice;
 pub use min_heap::{DocIdMinHeap, HeapEntry};
 pub use timeout::{
-    AnyTimeoutContext, DeadlineTimeoutChecker, NoTimeoutChecker, TimeoutContext,
-    TimeoutContextBlockedClient,
+    AnyTimeoutContext, DeadlineTimeoutChecker, NoTimeoutChecker, TimeoutCheckResult,
+    TimeoutChecker, TimeoutContext, TimeoutContextBlockedClient, TimeoutContextDeadline,
 };
-pub use timespec::duration_from_redis_timespec;
+pub use timespec::{deadline_passed, duration_from_redis_timespec};

--- a/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
@@ -12,15 +12,21 @@ use std::ptr::NonNull;
 use ffi::{AREQ, AREQ_CheckTimedOut, RedisSearchCtx};
 pub use timeout::{DeadlineTimeoutChecker, NoTimeoutChecker, TimeoutCheckResult, TimeoutChecker};
 
-use crate::{RQEIteratorError, utils::duration_from_redis_timespec};
+use crate::{
+    RQEIteratorError,
+    utils::{duration_from_redis_timespec, timespec::deadline_passed},
+};
 
 /// Abstraction over the different ways a query iterator can detect that the
 /// surrounding query has run out of time.
 ///
 /// Three implementations exist:
 /// * [`NoTimeoutChecker`] — zero-sized no-op used when the query has no deadline.
-/// * [`DeadlineTimeoutChecker`] — Clock Based Timeout: amortized clock check
-///   used when no Blocked Client Timeout is in play.
+/// * [`TimeoutContextDeadline`] — Clock Based Timeout: amortized clock check against the
+///   deadline owned by the query's search context, used when no Blocked Client Timeout is in
+///   play. ([`DeadlineTimeoutChecker`] is the same check against a deadline captured up front;
+///   it is not what a query iterator gets, because a query's deadline moves — see
+///   [`TimeoutContextDeadline`].)
 /// * [`TimeoutContextBlockedClient`] — Blocked Client Timeout: reads the
 ///   AREQ atomic flag (set by the Blocked Client Timeout main-thread
 ///   callback) via the [`AREQ_CheckTimedOut`] C symbol.
@@ -59,6 +65,80 @@ impl<TC: TimeoutChecker> TimeoutContext for TC {
 
     fn reset_counter(&mut self) {
         TimeoutChecker::reset_counter(self)
+    }
+}
+
+/// [`TimeoutContext`] backed by the deadline living inside a query's [`RedisSearchCtx`].
+///
+/// The deadline is *read through the pointer on every probe* rather than captured once. That
+/// matters because the deadline moves: `runCursor` calls `SearchCtx_UpdateTime` before each cursor
+/// read, giving the read its own budget. An iterator tree, by contrast, is built once and reused
+/// for the whole life of the cursor, so a captured deadline is the one belonging to the *first*
+/// read, and every later read starts out already expired against it — the iterators would report a
+/// timeout for a deadline the pipeline around them had just extended.
+///
+/// Like [`TimeoutContextBlockedClient`], the pointer carries no lifetime; keeping the search
+/// context alive is a runtime invariant the caller upholds, documented on [`new`](Self::new).
+///
+/// Probing still costs a clock read, so it is amortized the same way
+/// [`DeadlineTimeoutChecker`] amortizes: only every `limit`-th call looks at the clock.
+pub struct TimeoutContextDeadline {
+    /// Deadline owned by the query's search context, re-read on every probe.
+    deadline: NonNull<ffi::timespec>,
+    /// Calls since the last clock probe.
+    counter: u32,
+    /// Probe the clock once every `limit` calls.
+    limit: u32,
+}
+
+impl TimeoutContextDeadline {
+    /// Build a context reading the deadline at `deadline`.
+    ///
+    /// # Safety
+    ///
+    /// * `deadline` must point to a valid [`timespec`](ffi::timespec) — in practice
+    ///   `sctx.time.timeout` — that stays valid, and at a stable address, for as long as this
+    ///   context (and any iterator holding it) is used. A request assigns its search context once,
+    ///   in `AREQ_ApplyContext`, and later cursor reads update the deadline in place, so the
+    ///   address holds for the whole request.
+    /// * The deadline must not be written concurrently with a probe. C *does* write to it — that
+    ///   is the point of reading it back — from every `SearchCtx_UpdateTime` call site, and
+    ///   directly from `RPTimeoutAfterCount_SimulateTimeout`. Each of those either runs before the
+    ///   pipeline for that read starts (`runCursor`, `buildPipelineAndExecute`, the hybrid and
+    ///   coordinator entry points) or runs inside the pipeline on the thread that would be
+    ///   probing, so no write overlaps a probe. A new write site has to preserve that.
+    #[inline(always)]
+    pub const unsafe fn new(deadline: NonNull<ffi::timespec>, limit: u32) -> Self {
+        Self {
+            deadline,
+            counter: 0,
+            limit,
+        }
+    }
+}
+
+impl TimeoutChecker for TimeoutContextDeadline {
+    #[inline(always)]
+    fn check_timeout(&mut self) -> TimeoutCheckResult {
+        self.counter += 1;
+        if self.counter < self.limit {
+            return TimeoutCheckResult::Ok;
+        }
+        self.counter = 0;
+
+        // SAFETY: the constructor contract guarantees `deadline` points to a valid `timespec` that
+        // outlives this context, and that no write to it overlaps this read.
+        let deadline = unsafe { self.deadline.read() };
+        if deadline_passed(deadline) {
+            TimeoutCheckResult::TimedOut
+        } else {
+            TimeoutCheckResult::Ok
+        }
+    }
+
+    #[inline(always)]
+    fn reset_counter(&mut self) {
+        self.counter = 0;
     }
 }
 
@@ -132,16 +212,18 @@ impl TimeoutChecker for TimeoutContextBlockedClient {
 ///
 /// [`check_timeout`]: TimeoutContext::check_timeout
 ///
-/// The [`BlockedClient`](Self::BlockedClient) variant holds its [`AREQ`] as a
-/// raw pointer with no lifetime (see [`TimeoutContextBlockedClient`]); the other
-/// two borrow nothing. The type is therefore `'static`, and keeping the request
-/// alive while the context is used is a runtime invariant its constructor
-/// documents.
+/// Two of the three variants hold a raw pointer with no lifetime:
+/// [`BlockedClient`](Self::BlockedClient) an [`AREQ`] (see
+/// [`TimeoutContextBlockedClient`]), and [`Clock`](Self::Clock) the deadline inside a
+/// [`RedisSearchCtx`] (see [`TimeoutContextDeadline`]). Only
+/// [`NoTimeout`](Self::NoTimeout) borrows nothing. The type is therefore `'static`, and keeping
+/// whatever a variant points at alive while the context is used is a runtime invariant its
+/// constructor documents — that obligation applies to `Clock` just as much as to `BlockedClient`.
 pub enum AnyTimeoutContext {
     /// No timeout source: every probe is a no-op.
     NoTimeout(NoTimeoutChecker),
-    /// Clock Based Timeout: amortized clock check.
-    Clock(DeadlineTimeoutChecker),
+    /// Clock Based Timeout: amortized clock check against the search context's live deadline.
+    Clock(TimeoutContextDeadline),
     /// Blocked Client Timeout: relaxed atomic load against the AREQ flag.
     BlockedClient(TimeoutContextBlockedClient),
 }
@@ -150,19 +232,45 @@ impl AnyTimeoutContext {
     /// Builds the timeout context from a search context's time settings.
     ///
     /// `skipTimeoutChecks` (or the absence of a deadline) opts out of timeout
-    /// checks entirely, yielding [`NoTimeoutChecker`]; otherwise the deadline drives an
-    /// amortized [`DeadlineTimeoutChecker`] that probes the clock once every
-    /// `granularity` checks. A search context carries no Blocked Client Timeout
+    /// checks entirely, yielding [`NoTimeoutChecker`]; otherwise the context borrows the
+    /// deadline out of `sctx` and probes the clock against it once every `granularity`
+    /// checks. A search context carries no Blocked Client Timeout
     /// source, so the [`BlockedClient`](Self::BlockedClient) variant is never
     /// produced here.
-    pub fn from_sctx(sctx: &RedisSearchCtx, granularity: u32) -> Self {
-        if sctx.time.skipTimeoutChecks {
+    ///
+    /// # Safety
+    ///
+    /// Both preconditions of [`TimeoutContextDeadline::new`] are forwarded to the caller:
+    ///
+    /// * `sctx` must stay valid, and at a stable address, for as long as the returned context and
+    ///   any iterator built from it are used — not merely for this call. The deadline is read back
+    ///   through a pointer on every probe.
+    /// * No write to `sctx.time.timeout` may overlap a probe.
+    ///
+    /// Note that `skipTimeoutChecks` is read once, here, while the deadline is read live. A
+    /// request that flips the flag after its iterators are built (only `TIMEOUT_AFTER_N` does,
+    /// via `AREQ_SetSkipTimeoutChecks`) keeps whichever variant this chose.
+    pub unsafe fn from_sctx(sctx: NonNull<RedisSearchCtx>, granularity: u32) -> Self {
+        // Read the two construction-time inputs through short-lived raw reads rather than holding
+        // a reference: C writes the deadline through this same location while the context lives.
+        // SAFETY: the caller guarantees `sctx` is valid.
+        let time = unsafe { &raw const (*sctx.as_ptr()).time };
+        // SAFETY: `time` points into the valid `sctx`.
+        if unsafe { (*time).skipTimeoutChecks } {
             return Self::NoTimeout(NoTimeoutChecker);
         }
-        match duration_from_redis_timespec(sctx.time.timeout) {
-            Some(duration) => Self::Clock(DeadlineTimeoutChecker::new(duration, granularity)),
-            None => Self::NoTimeout(NoTimeoutChecker),
+        // A deadline that is absent *now* stays absent: `SearchCtx_UpdateTime` only ever re-arms a
+        // timeout that the request was configured with, so a request without one never gains one.
+        // SAFETY: as above.
+        if duration_from_redis_timespec(unsafe { (*time).timeout }).is_none() {
+            return Self::NoTimeout(NoTimeoutChecker);
         }
+        // SAFETY: `time` points into the valid `sctx`, so projecting the field is in bounds. The
+        // result stays valid for as long as the caller keeps `sctx` alive.
+        let deadline = unsafe { &raw const (*time).timeout }.cast_mut();
+        let deadline = NonNull::new(deadline).expect("projected from a non-null pointer");
+        // SAFETY: forwarded to the caller by this method's own safety contract, both clauses.
+        Self::Clock(unsafe { TimeoutContextDeadline::new(deadline, granularity) })
     }
 }
 
@@ -238,13 +346,103 @@ mod tests {
         }
     }
 
+    /// A deadline `secs` from now, in the same monotonic clock the checker reads.
+    fn deadline_in(secs: i64) -> ffi::timespec {
+        let mut ts = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        // SAFETY: `&mut ts` is a valid, writable `libc::timespec` and the clock id is valid.
+        unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC_RAW, &mut ts) };
+        ffi::timespec {
+            tv_sec: ts.tv_sec + secs,
+            tv_nsec: ts.tv_nsec,
+        }
+    }
+
     #[test]
+    #[cfg_attr(miri, ignore = "miri has no clock_gettime(CLOCK_MONOTONIC_RAW)")]
     fn any_timeout_context_dispatches_to_clock_variant() {
-        let inner = DeadlineTimeoutChecker::new(Duration::from_secs(60), 1);
+        let mut deadline = deadline_in(60);
+        // SAFETY: `deadline` outlives `checker`, and nothing writes to it concurrently.
+        let inner = unsafe { TimeoutContextDeadline::new(NonNull::from(&mut deadline), 1) };
         let mut checker = AnyTimeoutContext::Clock(inner);
         assert!(TimeoutContext::check_timeout(&mut checker).is_ok());
         TimeoutContext::reset_counter(&mut checker);
         assert!(TimeoutContext::check_timeout(&mut checker).is_ok());
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "miri has no clock_gettime(CLOCK_MONOTONIC_RAW)")]
+    fn deadline_context_times_out_once_the_deadline_passes() {
+        let mut deadline = deadline_in(-1);
+        // SAFETY: as above.
+        let mut checker = unsafe { TimeoutContextDeadline::new(NonNull::from(&mut deadline), 1) };
+        assert!(matches!(
+            TimeoutChecker::check_timeout(&mut checker),
+            TimeoutCheckResult::TimedOut
+        ));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "miri has no clock_gettime(CLOCK_MONOTONIC_RAW)")]
+    fn deadline_context_follows_a_deadline_that_moves() {
+        // The case this type exists for: a cursor read re-arms the deadline while the iterator
+        // tree - and this context with it - lives on from the previous read. A context that
+        // captured the deadline once would keep reporting the expired one.
+        let mut deadline = deadline_in(-1);
+        let ptr = NonNull::from(&mut deadline);
+        // SAFETY: as above.
+        let mut checker = unsafe { TimeoutContextDeadline::new(ptr, 1) };
+        assert!(matches!(
+            TimeoutChecker::check_timeout(&mut checker),
+            TimeoutCheckResult::TimedOut
+        ));
+
+        // Stand in for `SearchCtx_UpdateTime`, which re-arms the deadline in place.
+        // SAFETY: `ptr` points at `deadline`, still alive here, and no probe overlaps this write.
+        unsafe { ptr.as_ptr().write(deadline_in(60)) };
+        assert!(
+            matches!(
+                TimeoutChecker::check_timeout(&mut checker),
+                TimeoutCheckResult::Ok
+            ),
+            "the extended deadline must be picked up, not the one from construction",
+        );
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "miri has no clock_gettime(CLOCK_MONOTONIC_RAW)")]
+    fn deadline_context_amortizes_via_limit() {
+        let mut deadline = deadline_in(-1);
+        // SAFETY: as above.
+        let mut checker = unsafe { TimeoutContextDeadline::new(NonNull::from(&mut deadline), 100) };
+        // The first 99 calls must not probe the clock, so they report Ok despite the deadline.
+        for _ in 0..99 {
+            assert!(matches!(
+                TimeoutChecker::check_timeout(&mut checker),
+                TimeoutCheckResult::Ok
+            ));
+        }
+        assert!(matches!(
+            TimeoutChecker::check_timeout(&mut checker),
+            TimeoutCheckResult::TimedOut
+        ));
+    }
+
+    #[test]
+    fn deadline_context_never_times_out_on_the_no_timeout_sentinel() {
+        #[cfg_attr(target_env = "musl", expect(deprecated))]
+        let mut deadline = ffi::timespec {
+            tv_sec: libc::time_t::MAX,
+            tv_nsec: 0,
+        };
+        // SAFETY: as above.
+        let mut checker = unsafe { TimeoutContextDeadline::new(NonNull::from(&mut deadline), 1) };
+        assert!(matches!(
+            TimeoutChecker::check_timeout(&mut checker),
+            TimeoutCheckResult::Ok
+        ));
     }
 
     // The `BlockedClient` variant is a thin wrapper around the C symbol

--- a/src/redisearch_rs/rqe_iterators/src/utils/timespec.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/timespec.rs
@@ -36,6 +36,21 @@ pub fn duration_from_redis_timespec(deadline: ffi::timespec) -> Option<Duration>
     Some(timespec_sub_to_duration(deadline, now))
 }
 
+/// Report whether `deadline` has been reached, reading the clock now.
+///
+/// The Redis sentinel meaning "no timeout" never counts as reached, so a deadline that is cleared
+/// between two probes stops expiring rather than expiring forever.
+pub fn deadline_passed(deadline: ffi::timespec) -> bool {
+    // Same sentinel check as `duration_from_redis_timespec`; see the note there on musl.
+    #[cfg_attr(target_env = "musl", expect(deprecated))]
+    let time_t_max = libc::time_t::MAX;
+    if deadline.tv_sec >= time_t_max - 1 {
+        return false;
+    }
+
+    timespec_le(deadline, monotonic_now_timespec())
+}
+
 const fn timespec_le(a: ffi::timespec, b: ffi::timespec) -> bool {
     a.tv_sec < b.tv_sec || (a.tv_sec == b.tv_sec && a.tv_nsec <= b.tv_nsec)
 }
@@ -75,5 +90,65 @@ fn monotonic_now_timespec() -> ffi::timespec {
     ffi::timespec {
         tv_sec: ts.tv_sec,
         tv_nsec: ts.tv_nsec,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A deadline `secs` away from now, on the clock `deadline_passed` reads.
+    fn deadline_in(secs: i64) -> ffi::timespec {
+        let now = monotonic_now_timespec();
+        ffi::timespec {
+            tv_sec: now.tv_sec + secs,
+            tv_nsec: now.tv_nsec,
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "miri has no clock_gettime(CLOCK_MONOTONIC_RAW)")]
+    fn a_future_deadline_has_not_passed() {
+        assert!(!deadline_passed(deadline_in(60)));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "miri has no clock_gettime(CLOCK_MONOTONIC_RAW)")]
+    fn a_past_deadline_has_passed() {
+        assert!(deadline_passed(deadline_in(-1)));
+    }
+
+    #[test]
+    fn the_no_timeout_sentinel_never_passes() {
+        // A request without a deadline must never be reported as out of time, however long it
+        // runs — the sentinel is not a very distant deadline, it is the absence of one.
+        #[cfg_attr(target_env = "musl", expect(deprecated))]
+        let sentinel = ffi::timespec {
+            tv_sec: libc::time_t::MAX,
+            tv_nsec: 0,
+        };
+        assert!(!deadline_passed(sentinel));
+
+        #[cfg_attr(target_env = "musl", expect(deprecated))]
+        let off_by_one = ffi::timespec {
+            tv_sec: libc::time_t::MAX - 1,
+            tv_nsec: 0,
+        };
+        assert!(
+            !deadline_passed(off_by_one),
+            "the sentinel check is `>= MAX - 1`, so this value is a sentinel too",
+        );
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "miri has no clock_gettime(CLOCK_MONOTONIC_RAW)")]
+    fn agrees_with_duration_from_redis_timespec() {
+        // The two share a sentinel rule; a deadline that converts to a zero remaining duration is
+        // exactly one that has passed.
+        assert_eq!(
+            duration_from_redis_timespec(deadline_in(-1)),
+            Some(std::time::Duration::ZERO)
+        );
+        assert!(deadline_passed(deadline_in(-1)));
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/main.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/main.rs
@@ -54,6 +54,7 @@ mod profilable;
 mod profile;
 #[cfg(not(miri))]
 mod profile_print;
+mod timeout_context;
 #[macro_use]
 mod union_common;
 mod union_flat;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/timeout_context.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/timeout_context.rs
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Tests for the timeout context an iterator gets from a search context.
+//!
+//! These build the context the way production does — through
+//! [`AnyTimeoutContext::from_sctx`] against a real [`RedisSearchCtx`] — rather than constructing
+//! the checker directly, so they cover the pointer shape the FFI callers actually produce.
+
+use std::ptr::NonNull;
+
+use rqe_iterators::utils::{
+    AnyTimeoutContext, TimeoutCheckResult, TimeoutChecker, TimeoutContext, TimeoutContextDeadline,
+};
+use rqe_iterators_test_utils::MockContext;
+
+/// Overwrite the deadline in `ctx`'s search context, as `SearchCtx_UpdateTime` does.
+fn set_deadline(ctx: &MockContext, secs_from_now: i64) {
+    let mut now = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: `&mut now` is a valid, writable `libc::timespec`; the clock id is valid.
+    unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC_RAW, &mut now) };
+    // SAFETY: the mock owns a valid `RedisSearchCtx` for as long as it is alive.
+    unsafe {
+        (*ctx.sctx().as_ptr()).time.timeout = ffi::timespec {
+            tv_sec: now.tv_sec + secs_from_now,
+            tv_nsec: now.tv_nsec,
+        };
+    }
+}
+
+/// Probe `granularity` times, so an amortized checker reaches its clock read.
+fn probe(checker: &mut AnyTimeoutContext, granularity: u32) -> Result<(), String> {
+    for _ in 0..granularity {
+        checker.check_timeout().map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg_attr(miri, ignore = "miri has no clock_gettime(CLOCK_MONOTONIC_RAW)")]
+#[test]
+fn tracks_a_deadline_that_moves_after_construction() {
+    // The regression this exists for. An iterator tree is built once and reused for the whole life
+    // of a cursor, while each cursor read re-arms the deadline. A context that captured the
+    // deadline at construction reports every later read as timed out.
+    let ctx = MockContext::new(100, 10);
+    set_deadline(&ctx, -1);
+
+    // SAFETY: `ctx` outlives `checker`, and nothing writes the deadline while a probe runs.
+    let mut checker = unsafe { AnyTimeoutContext::from_sctx(ctx.sctx(), 1) };
+    assert!(
+        probe(&mut checker, 1).is_err(),
+        "an expired deadline must be reported",
+    );
+
+    set_deadline(&ctx, 60);
+    assert!(
+        probe(&mut checker, 1).is_ok(),
+        "the re-armed deadline must be picked up; a captured one would keep reporting the \
+         expired deadline for the rest of the cursor's life",
+    );
+}
+
+#[cfg_attr(miri, ignore = "miri has no clock_gettime(CLOCK_MONOTONIC_RAW)")]
+#[test]
+fn a_live_deadline_that_expires_is_reported() {
+    let ctx = MockContext::new(100, 10);
+    set_deadline(&ctx, 60);
+
+    // SAFETY: as above.
+    let mut checker = unsafe { AnyTimeoutContext::from_sctx(ctx.sctx(), 1) };
+    assert!(probe(&mut checker, 1).is_ok());
+
+    set_deadline(&ctx, -1);
+    assert!(
+        probe(&mut checker, 1).is_err(),
+        "reading the deadline live must catch an expiry as well as an extension",
+    );
+}
+
+#[cfg_attr(miri, ignore = "miri has no clock_gettime(CLOCK_MONOTONIC_RAW)")]
+#[test]
+fn probes_are_amortized_across_the_granularity() {
+    let ctx = MockContext::new(100, 10);
+    set_deadline(&ctx, -1);
+
+    // SAFETY: as above.
+    let mut checker = unsafe { AnyTimeoutContext::from_sctx(ctx.sctx(), 100) };
+    for _ in 0..99 {
+        assert!(
+            checker.check_timeout().is_ok(),
+            "the first 99 probes must not read the clock at all",
+        );
+    }
+    assert!(checker.check_timeout().is_err());
+}
+
+#[cfg_attr(miri, ignore = "miri has no clock_gettime(CLOCK_MONOTONIC_RAW)")]
+#[test]
+fn skip_timeout_checks_opts_out_entirely() {
+    let ctx = MockContext::new(100, 10);
+    set_deadline(&ctx, -1);
+    // SAFETY: the mock owns a valid `RedisSearchCtx`.
+    unsafe { (*ctx.sctx().as_ptr()).time.skipTimeoutChecks = true };
+
+    // SAFETY: as above.
+    let mut checker = unsafe { AnyTimeoutContext::from_sctx(ctx.sctx(), 1) };
+    assert!(
+        matches!(checker, AnyTimeoutContext::NoTimeout(_)),
+        "skipTimeoutChecks must win over an expired deadline",
+    );
+    assert!(probe(&mut checker, 1).is_ok());
+}
+
+#[test]
+fn the_no_timeout_sentinel_yields_no_checker() {
+    let ctx = MockContext::new(100, 10);
+    // SAFETY: the mock owns a valid `RedisSearchCtx`.
+    #[cfg_attr(target_env = "musl", expect(deprecated))]
+    unsafe {
+        (*ctx.sctx().as_ptr()).time.timeout = ffi::timespec {
+            tv_sec: libc::time_t::MAX,
+            tv_nsec: 0,
+        };
+    }
+
+    // SAFETY: as above.
+    let checker = unsafe { AnyTimeoutContext::from_sctx(ctx.sctx(), 1) };
+    assert!(
+        matches!(checker, AnyTimeoutContext::NoTimeout(_)),
+        "a request configured without a deadline must not pay for clock probes",
+    );
+}
+
+#[test]
+fn a_probe_reads_the_deadline_out_of_the_search_context() {
+    // Deliberately *not* miri-ignored. The sentinel short-circuits before any clock read, so this
+    // exercises the part miri can actually check: the probe dereferencing a pointer projected out
+    // of a live `RedisSearchCtx`, the same way `from_sctx` projects it. The clock-reading tests
+    // above have to sit out under miri, which would otherwise leave that read uncovered there.
+    let ctx = MockContext::new(100, 10);
+    // SAFETY: the mock owns a valid `RedisSearchCtx` for as long as it is alive.
+    let deadline = unsafe { &raw mut (*ctx.sctx().as_ptr()).time.timeout };
+    #[cfg_attr(target_env = "musl", expect(deprecated))]
+    // SAFETY: `deadline` was just projected out of the valid search context.
+    unsafe {
+        deadline.write(ffi::timespec {
+            tv_sec: libc::time_t::MAX,
+            tv_nsec: 0,
+        })
+    };
+
+    let ptr = NonNull::new(deadline).expect("projected from a non-null pointer");
+    // SAFETY: `ctx` outlives `checker`, and nothing writes the deadline while the probe runs.
+    let mut checker = unsafe { TimeoutContextDeadline::new(ptr, 1) };
+    assert!(matches!(
+        TimeoutChecker::check_timeout(&mut checker),
+        TimeoutCheckResult::Ok
+    ));
+}

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -294,7 +294,7 @@ TEST_F(IndexTest, testNot) {
   MockQueryEvalCtx mockQctx(16, 16);
   irs[0] = NewInvIndIterator_TermQuery(w, &mockQctx.sctx, f, makeTestQueryTerm(), 1);
   MockQueryEvalCtx mockQctx2(10, 10);
-  irs[1] = NewNotIterator(NewInvIndIterator_TermQuery(w2, &mockQctx2.sctx, f, makeTestQueryTerm(), 1), InvertedIndex_LastId(w2), 1, {0}, NULL, &ctx->qctx);
+  irs[1] = NewNotIterator(NewInvIndIterator_TermQuery(w2, &mockQctx2.sctx, f, makeTestQueryTerm(), 1), InvertedIndex_LastId(w2), 1, NULL, &ctx->qctx);
 
   QueryIterator *ui = NewIntersectionIterator(irs, 2, -1, 0, 1);
   int expected[] = {1, 2, 4, 5, 7, 8, 10, 11, 13, 14, 16};
@@ -316,7 +316,7 @@ TEST_F(IndexTest, testPureNot) {
   auto ctx = std::make_unique<MockQueryEvalCtx>();
   FieldMaskOrIndex f = {.mask_tag = FieldMaskOrIndex_Mask, .mask = RS_FIELDMASK_ALL};
   MockQueryEvalCtx mockQctx(10, 10);
-  QueryIterator *ir = NewNotIterator(NewInvIndIterator_TermQuery(w, &mockQctx.sctx, f, makeTestQueryTerm(), 1), InvertedIndex_LastId(w) + 5, 1, {0}, NULL, &ctx->qctx);
+  QueryIterator *ir = NewNotIterator(NewInvIndIterator_TermQuery(w, &mockQctx.sctx, f, makeTestQueryTerm(), 1), InvertedIndex_LastId(w) + 5, 1, NULL, &ctx->qctx);
 
   RSIndexResult *h = NULL;
   int expected[] = {1,  2,  4,  5,  7,  8,  10, 11, 13, 14, 16, 17, 19,

--- a/tests/pytests/test_timeout.py
+++ b/tests/pytests/test_timeout.py
@@ -74,3 +74,63 @@ def test_aggregate_debug_zero_params_count():
     env.expect(debug_cmd(), 'FT.AGGREGATE', 'idx', '*',
                'TIMEOUT_AFTER_N', '100',
                'DEBUG_PARAMS_COUNT', '0').error().contains('Invalid DEBUG_PARAMS_COUNT count')
+
+
+@skip(cluster=True)
+def testCursorDeadlineIsNotStaleOnResume():
+    """A cursor read is measured against its own deadline, not an earlier read's.
+
+    `runCursor` re-arms `sctx->time.timeout` before every read. Before this fix the clock-based
+    timeout checker captured its deadline when the iterator tree was built, so from the second
+    read onwards the iterators measured against the *first* read's deadline and reported a
+    timeout for one the pipeline had just extended - and because the NOT iterator latches itself
+    to EOF on timeout, the cursor then ended, dropping the documents it still owed.
+
+    Only the clock checker was affected. FAIL and RETURN_STRICT poll the blocked-client flag,
+    re-read on every probe, and those are exactly the policies for which `runCursor` skips the
+    re-arm - so RETURN was both the only policy that re-armed and the only one that captured.
+
+    Reaching it needs an iterator that probes the clock (NOT, NOT-optimized, geo-shape) and a run
+    of skipped documents long enough to reach the amortization limit, which is why it went
+    unnoticed on small indexes.
+    """
+    env = Env(protocol=3, moduleArgs='ON_TIMEOUT RETURN')
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'text', 'TEXT').ok()
+
+    # doc:0 matches `-common` straight away, so the first page is served without scanning.
+    # The 6000 documents after it are all skipped by the NOT iterator on the *second* page, which
+    # is more than the 5000-probe amortization limit, so the second page is the one that consults
+    # the clock. The two trailing documents are the results the second page owes.
+    skipped = 6000
+    with conn.pipeline(transaction=False) as p:
+        p.execute_command('HSET', 'doc:0', 'text', 'rare')
+        for i in range(1, skipped + 1):
+            p.execute_command('HSET', f'doc:{i}', 'text', 'common')
+        p.execute_command('HSET', f'doc:{skipped + 1}', 'text', 'rare')
+        p.execute_command('HSET', f'doc:{skipped + 2}', 'text', 'rare')
+        p.execute()
+
+    # Generous enough that scanning the skipped run cannot legitimately exhaust it on a loaded
+    # runner or an instrumented build - a real timeout here would be indistinguishable from the
+    # regression. The sleep below scales with it, so the pre-fix deadline is expired either way.
+    query_timeout_ms = 2000
+    res, cursor = env.cmd('FT.AGGREGATE', 'idx', '-common', 'LOAD', '1', '@__key',
+                          'WITHCURSOR', 'COUNT', '1', 'TIMEOUT', query_timeout_ms)
+    env.assertEqual([d['extra_attributes']['__key'] for d in res['results']], ['doc:0'])
+    env.assertNotEqual(cursor, 0)
+
+    # Outlive the deadline this request started with. The pipeline re-arms its own deadline for the
+    # next read, so the read below has its full budget - only a captured deadline would be expired.
+    time.sleep(query_timeout_ms / 1000 * 1.5)
+
+    remaining = []
+    while cursor != 0:
+        res, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
+        env.assertEqual(res.get('warning', []), [],
+                        message="a cursor read gets a fresh deadline, so nothing should time out")
+        remaining.extend(d['extra_attributes']['__key'] for d in res['results'])
+
+    env.assertEqual(remaining, [f'doc:{skipped + 1}', f'doc:{skipped + 2}'],
+                    message="documents past the skipped run must still be served")


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: the clock-based timeout checker captures its deadline when the iterator tree is built. A tree is built once and reused for the whole life of a cursor, while `runCursor` calls `SearchCtx_UpdateTime` before each read to give that read its own budget. From the second read onwards the two disagree — the iterators measure against the *first* read's deadline, long past, and report a timeout for a deadline the pipeline around them has just extended.
2. **Change**: the clock checker now holds a pointer to the deadline owned by the query's `RedisSearchCtx` and reads it back on each probe, instead of capturing an `Instant` at construction. Probing stays amortized — only every `limit`-th call reads the clock.
3. **Outcome**: a cursor read is measured against its own deadline, so it returns the documents it owes instead of an empty page with a timeout warning.

Under `ON_TIMEOUT RETURN` the bug loses data, not just accuracy: the read returns no rows with a timeout warning, and because the NOT iterator latches itself to EOF on timeout, the cursor then ends and silently drops every document it had left to serve.

Only the clock checker was affected. FAIL and RETURN_STRICT poll the blocked-client flag, which is re-read on every probe, and those are exactly the policies for which `runCursor` skips the re-arm — so RETURN was both the only policy that re-armed the deadline and the only one that captured it.

Reaching it needs an iterator that probes the clock (NOT, NOT-optimized, geo-shape) **and** a run of skipped documents long enough to reach the 5000-probe amortization limit, which is why it has gone unnoticed on small indexes. `testCursorDeadlineIsNotStaleOnResume` builds exactly that shape; it fails on master with `['Timeout limit was reached'] == []` and two documents never served.

The pointer is safe to hold: `req->sctx` is assigned once, in `AREQ_ApplyContext`, and cursor reads update the deadline in place, so the address is stable for the whole request — the same assumption `TimeoutContextBlockedClient` already makes about its `AREQ`. C writes the deadline from `runCursor`, before that read's pipeline runs and on the same thread, so no write overlaps a probe.

Independent of #10763 (which makes a revalidation timeout reportable); the two touch different files and can land in either order.

Affects 8.6, 8.6-rse and 8.8, which carry the same captured deadline (the type is named `TimeoutContext` there) together with the clock-probing NOT iterator and the per-read re-arm. 8.4 predates the Rust NOT iterator and is unaffected. The fix does not cherry-pick cleanly onto those branches - the surrounding types differ - so each backport needs adapting.

#### Which additional issues this PR fixes
1. MOD-17489

#### Main objects this PR modified
1. `src/redisearch_rs/rqe_iterators/src/utils/timeout.rs` — new `TimeoutContextDeadline`, now behind `AnyTimeoutContext::Clock`
2. `src/redisearch_rs/rqe_iterators/src/utils/timespec.rs` — `deadline_passed`
3. `src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs`, `iterators_ffi/src/geo_shape.rs`, `iterators_ffi/src/not.rs` — construction sites

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
