### PR TITLE
[MOD-15592] Fix server crash on write when index FILTER references no schema fields

### DIFF
--- a/src/redisearch_rs/c_wrappers/schema_rule/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/schema_rule/src/lib.rs
@@ -30,6 +30,9 @@ impl SchemaRule {
     ///    1. If `lang_field` is non-null, it points to a valid C string.
     ///    2. If `score_field` is non-null, it points to a valid C string.
     ///    3. If `payload_field` is non-null, it points to a valid C string.
+    ///    4. If `filter_fields` is non-null, it is an array (`util/arr.h`) of pointers to
+    ///       valid C strings, and `filter_fields_index` is non-null and points to at least
+    ///       as many `i32`s as `filter_fields` has elements.
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
     pub const unsafe fn from_raw<'a>(ptr: *const ffi::SchemaRule) -> &'a Self {
@@ -46,6 +49,9 @@ impl SchemaRule {
     ///    1. If `lang_field` is non-null, it points to a valid C string.
     ///    2. If `score_field` is non-null, it points to a valid C string.
     ///    3. If `payload_field` is non-null, it points to a valid C string.
+    ///    4. If `filter_fields` is non-null, it is an array (`util/arr.h`) of pointers to
+    ///       valid C strings, and `filter_fields_index` is non-null and points to at least
+    ///       as many `i32`s as `filter_fields` has elements.
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
     pub const unsafe fn from_raw_mut<'a>(ptr: *mut ffi::SchemaRule) -> &'a mut Self {

--- a/src/redisearch_rs/c_wrappers/schema_rule/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/schema_rule/src/lib.rs
@@ -71,31 +71,42 @@ impl SchemaRule {
         unsafe { maybe_cstr_from_ptr(self.0.payload_field) }
     }
 
-    /// Expose the underlying `filter_fields` as a [`Vec`] of &[`CStr`].
+    /// Expose the underlying `filter_fields` as an iterator of &[`CStr`].
+    ///
+    /// A rule whose filter expression references no schema fields keeps the
+    /// underlying array null; that is exposed as an empty iterator.
     pub fn filter_fields(&self) -> impl ExactSizeIterator<Item = &CStr> {
-        debug_assert!(
-            !self.0.filter_fields.is_null(),
-            "filter_fields must not be null"
-        );
+        let fields = if self.0.filter_fields.is_null() {
+            &[]
+        } else {
+            // Safety: (1.) due to creation with `SchemaRule::from_raw`
+            let len = unsafe { ffi::array_len_func(self.0.filter_fields as ffi::array_t) }
+                .try_into()
+                .expect("array_len must not exceed usize");
 
-        // Safety: (1.) due to creation with `SchemaRule::from_raw`
-        let len = unsafe { ffi::array_len_func(self.0.filter_fields as ffi::array_t) }
-            .try_into()
-            .expect("array_len must not exceed usize");
+            // Safety: (1.) due to creation with `SchemaRule::from_raw`
+            unsafe { slice::from_raw_parts(self.0.filter_fields, len) }
+        };
 
-        // Safety: (1.) due to creation with `SchemaRule::from_raw`
-        unsafe { slice::from_raw_parts(self.0.filter_fields, len) }
+        fields
             .iter()
+            // Safety: (1.) due to creation with `SchemaRule::from_raw`
             .map(|ptr| unsafe { CStr::from_ptr(*ptr) })
     }
 
     /// Expose the underlying `filter_fields_index` as a slice of ints.
+    ///
+    /// Null (a filter expression referencing no schema fields) is exposed as
+    /// an empty slice.
     pub fn filter_fields_index(&self) -> &[i32] {
         // These two arrays are assumed to be of the same length.
         let len = self.filter_fields().len();
+        if len == 0 {
+            return &[];
+        }
         debug_assert!(
             !self.0.filter_fields_index.is_null(),
-            "filter_fields_index must not be null"
+            "filter_fields_index must not be null when filter_fields is non-empty"
         );
         // Safety: (1.) due to creation with `SchemaRule::from_raw`
         unsafe { slice::from_raw_parts(self.0.filter_fields_index, len) }

--- a/src/redisearch_rs/c_wrappers/schema_rule/tests/tests.rs
+++ b/src/redisearch_rs/c_wrappers/schema_rule/tests/tests.rs
@@ -72,5 +72,5 @@ fn null_fields_and_indices_are_empty() {
     let sut = unsafe { SchemaRule::from_raw(ptr::from_ref(&schema_rule)) };
 
     assert_eq!(sut.filter_fields().len(), 0);
-    assert_eq!(sut.filter_fields_index(), []);
+    assert!(sut.filter_fields_index().is_empty());
 }

--- a/src/redisearch_rs/c_wrappers/schema_rule/tests/tests.rs
+++ b/src/redisearch_rs/c_wrappers/schema_rule/tests/tests.rs
@@ -62,3 +62,15 @@ fn fields_and_indices() {
         ffi::array_free(schema_rule.filter_fields_index.cast());
     }
 }
+
+/// A filter expression that references no schema fields (e.g. `FILTER '1 == 1'`)
+/// keeps both arrays null; the accessors must expose that as empty.
+#[test]
+fn null_fields_and_indices_are_empty() {
+    let schema_rule = unsafe { mem::zeroed::<ffi::SchemaRule>() };
+
+    let sut = unsafe { SchemaRule::from_raw(ptr::from_ref(&schema_rule)) };
+
+    assert_eq!(sut.filter_fields().len(), 0);
+    assert_eq!(sut.filter_fields_index(), []);
+}

--- a/tests/pytests/test_filter_no_field_refs.py
+++ b/tests/pytests/test_filter_no_field_refs.py
@@ -6,7 +6,6 @@
 
 from includes import *
 from common import *
-from RLTest import Env
 
 
 def testFilterConstantBoolean(env):
@@ -14,10 +13,10 @@ def testFilterConstantBoolean(env):
     Redis on a matching key write."""
     conn = getConnectionByEnv(env)
 
-    env.cmd('FT.CREATE', 'idx_const', 'ON', 'HASH',
-            'PREFIX', '1', 'doc:',
-            'FILTER', '1 == 1',
-            'SCHEMA', 'name', 'TEXT')
+    env.expect('FT.CREATE', 'idx_const', 'ON', 'HASH',
+               'PREFIX', '1', 'doc:',
+               'FILTER', '1 == 1',
+               'SCHEMA', 'name', 'TEXT').ok()
 
     conn.execute_command('HSET', 'doc:1', 'name', 'hello')
 
@@ -29,13 +28,13 @@ def testFilterConstantBoolean(env):
 
 def testFilterLiteralOnlyFunction(env):
     """FILTER over a function call whose arguments are all literals also has
-    zero property references and hits the same NULL filter_fields path."""
+    zero property references and hits the same empty filter-fields path."""
     conn = getConnectionByEnv(env)
 
-    env.cmd('FT.CREATE', 'idx_litfn', 'ON', 'HASH',
-            'PREFIX', '1', 'doc:',
-            'FILTER', 'startswith("foo", "fo")',
-            'SCHEMA', 'name', 'TEXT')
+    env.expect('FT.CREATE', 'idx_litfn', 'ON', 'HASH',
+               'PREFIX', '1', 'doc:',
+               'FILTER', 'startswith("bar", "b")',
+               'SCHEMA', 'name', 'TEXT').ok()
 
     conn.execute_command('HSET', 'doc:2', 'name', 'world')
 
@@ -46,14 +45,14 @@ def testFilterLiteralOnlyFunction(env):
 
 
 def testFilterAlwaysFalseConstant(env):
-    """A constant FILTER that evaluates to false should reject the doc without
-    crashing -- exercises the same NULL slice construction on the reject path."""
+    """A constant FILTER that evaluates to false must reject the document
+    without crashing -- same empty filter-fields load, reject branch after."""
     conn = getConnectionByEnv(env)
 
-    env.cmd('FT.CREATE', 'idx_false', 'ON', 'HASH',
-            'PREFIX', '1', 'doc:',
-            'FILTER', '1 == 2',
-            'SCHEMA', 'name', 'TEXT')
+    env.expect('FT.CREATE', 'idx_false', 'ON', 'HASH',
+               'PREFIX', '1', 'doc:',
+               'FILTER', '1 == 2',
+               'SCHEMA', 'name', 'TEXT').ok()
 
     conn.execute_command('HSET', 'doc:3', 'name', 'ignored')
 

--- a/tests/pytests/test_filter_no_field_refs.py
+++ b/tests/pytests/test_filter_no_field_refs.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+# A FILTER expression that references no schema fields leaves the rule's
+# filter-field arrays empty; writes to a matching prefix must still be
+# indexed or rejected without crashing the server.
+
+from includes import *
+from common import *
+from RLTest import Env
+
+
+def testFilterConstantBoolean(env):
+    """Constant FILTER expression with no @field references must not crash
+    Redis on a matching key write."""
+    conn = getConnectionByEnv(env)
+
+    env.cmd('FT.CREATE', 'idx_const', 'ON', 'HASH',
+            'PREFIX', '1', 'doc:',
+            'FILTER', '1 == 1',
+            'SCHEMA', 'name', 'TEXT')
+
+    conn.execute_command('HSET', 'doc:1', 'name', 'hello')
+
+    env.assertTrue(env.isUp(), message='server died after HSET into a prefix with a constant FILTER')
+
+    env.expect('FT.SEARCH', 'idx_const', 'hello') \
+       .equal([1, 'doc:1', ['name', 'hello']])
+
+
+def testFilterLiteralOnlyFunction(env):
+    """FILTER over a function call whose arguments are all literals also has
+    zero property references and hits the same NULL filter_fields path."""
+    conn = getConnectionByEnv(env)
+
+    env.cmd('FT.CREATE', 'idx_litfn', 'ON', 'HASH',
+            'PREFIX', '1', 'doc:',
+            'FILTER', 'startswith("foo", "fo")',
+            'SCHEMA', 'name', 'TEXT')
+
+    conn.execute_command('HSET', 'doc:2', 'name', 'world')
+
+    env.assertTrue(env.isUp(), message='server died after HSET into a prefix with a literal-only FILTER function')
+
+    env.expect('FT.SEARCH', 'idx_litfn', 'world') \
+       .equal([1, 'doc:2', ['name', 'world']])
+
+
+def testFilterAlwaysFalseConstant(env):
+    """A constant FILTER that evaluates to false should reject the doc without
+    crashing -- exercises the same NULL slice construction on the reject path."""
+    conn = getConnectionByEnv(env)
+
+    env.cmd('FT.CREATE', 'idx_false', 'ON', 'HASH',
+            'PREFIX', '1', 'doc:',
+            'FILTER', '1 == 2',
+            'SCHEMA', 'name', 'TEXT')
+
+    conn.execute_command('HSET', 'doc:3', 'name', 'ignored')
+
+    env.assertTrue(env.isUp(), message='server died after HSET when constant FILTER evaluated to false')
+
+    env.expect('FT.SEARCH', 'idx_false', 'ignored').equal([0])


### PR DESCRIPTION
This is the fix to the following issue found by the Codex audit in May
- https://redislabs.atlassian.net/browse/MOD-15592

## Describe the changes in the pull request

1. Current: `FT.CREATE` with a `FILTER` expression that references no schema fields (e.g. `FILTER '1 == 1'`) leaves `SchemaRule.filter_fields` and `SchemaRule.filter_fields_index` null. Any subsequent write into a matching prefix reaches the Rust `SchemaRule` wrapper, which asserts the arrays are non-null and constructs `slice::from_raw_parts(NULL, 0)`. On builds with debug assertions enabled (`DEBUG=1` and the `optimised_test` profile used by every pytest configuration) the panic aborts the server; on release builds it is library-level undefined behavior.
2. Change: the wrapper accessors now expose null `filter_fields` / `filter_fields_index` as an empty iterator / empty slice, matching the C semantics of `array_len(NULL) == 0`. Added a Rust unit test for the null case and Python flow tests covering constant, literal-only-function, and always-false filters.
3. Outcome: writes into a prefix guarded by a field-less `FILTER` index (or reject) the document without crashing the server.

#### Which additional issues this PR fixes
1. MOD-15592

#### Main objects this PR modified
1. `SchemaRule::filter_fields` / `SchemaRule::filter_fields_index` (`src/redisearch_rs/c_wrappers/schema_rule/src/lib.rs`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
