### PR TITLE
[MOD-17394] Fix NOT queries leaking excluded documents or dropping results after a concurrent index change

### DIFF
--- a/src/iterators/iterator_api.h
+++ b/src/iterators/iterator_api.h
@@ -87,6 +87,11 @@ typedef struct QueryIterator {
    *  On a successful read, the iterator must:
    *  1. Set its `lastDocId` member to the new current result id
    *  2. Set its `current` pointer to its current result, for the caller to access if desired
+   *  On ITERATOR_EOF it must instead set `atEOF` and clear `current` to NULL, leaving
+   *  `lastDocId` on the last result it yielded: there is nothing to point at, and an
+   *  iterator that owns its result frees it on the way past the end.
+   *  On ITERATOR_TIMEOUT both `current` and `lastDocId` are untouched — the iterator has
+   *  not moved, and a later call may still find a result where it stands.
    *  @returns ITERATOR_OK on normal operation, or any other `IteratorStatus` except `ITERATOR_NOTFOUND`
    */
   IteratorStatus (*Read)(struct QueryIterator *self);
@@ -99,7 +104,10 @@ typedef struct QueryIterator {
    *  A read is successful if the iterator has a valid result to yield.
    *  @returns ITERATOR_OK if the iterator has found `docId`.
    *  @returns ITERATOR_NOTFOUND if the iterator has only found a result greater than `docId`.
-   *  In any other case, `current` and `lastDocId` should be untouched, and the relevant IteratorStatus is returned.
+   *  Otherwise the relevant IteratorStatus is returned, under the same post-conditions as
+   *  `Read`: ITERATOR_EOF sets `atEOF` and clears `current` to NULL while leaving
+   *  `lastDocId` where the last yield left it — never on `docId`, which the iterator has no
+   *  result to back — and ITERATOR_TIMEOUT touches neither.
    */
   IteratorStatus (*SkipTo)(struct QueryIterator *self, t_docId docId);
 
@@ -109,7 +117,10 @@ typedef struct QueryIterator {
    *
    * @param spec The index spec, provided by the caller (result processor).
    * @return VALIDATE_OK if the iterator is still valid
-   * @return VALIDATE_MOVED if the iterator is still valid, but the lastDocId has changed (moved forward)
+   * @return VALIDATE_MOVED if the iterator is still valid, but the lastDocId has changed
+   * (moved forward). A move that landed on a document publishes it in `current`; one that
+   * ran past the end sets `atEOF` and clears `current` to NULL, which is how a caller tells
+   * the two apart.
    * @return VALIDATE_ABORTED if the iterator is no longer valid
    */
   ValidateStatus (*Revalidate)(struct QueryIterator *self, struct IndexSpec *spec);

--- a/src/iterators/iterator_api.h
+++ b/src/iterators/iterator_api.h
@@ -57,7 +57,27 @@ typedef struct QueryIterator {
   // the last docId read. Initially should be 0.
   t_docId lastDocId;
 
-  // Current result. Should always point to a valid current result, except when `lastDocId` is 0
+  // Current result: the document the iterator is positioned on, or NULL when it is
+  // positioned on none.
+  //
+  // Non-NULL after a `Read` or `SkipTo` returning ITERATOR_OK or ITERATOR_NOTFOUND, and
+  // after a `Revalidate` returning VALIDATE_MOVED with a result.
+  //
+  // NULL before the first read (`lastDocId` is 0), and again once an operation has
+  // reported that there is nothing to point at: an ITERATOR_EOF, or a VALIDATE_MOVED
+  // that landed past the end. The two answers are the same state, so the field is the C
+  // face of Rust's `RQEIterator::current`, which returns `None` in exactly these cases —
+  // that is what lets a caller distinguish "moved onto a document" from "moved past the
+  // end" after a revalidation. Clearing it is also what keeps the pointer safe: an
+  // iterator that owns the result it hands out frees it on the way past the end, so a
+  // pointer left behind would dangle rather than merely go stale.
+  //
+  // Caveat, until the port completes: `OptimizerIterator` and `HybridIterator` are still
+  // implemented in C and do not clear this field, so after they report EOF it keeps
+  // pointing at the last result they yielded. Both are slated to be replaced by the Rust
+  // `TopKIterator`, which clears it like every other Rust iterator; until then, a caller
+  // that inspects this field after a non-OK status may get a document it has already
+  // consumed instead of NULL. Check the status, not this field.
   RSIndexResult *current;
 
   /** Return an upper-bound estimation for the number of results the iterator is going to yield */

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -245,13 +245,6 @@ extern "C" fn read<'index, I: RQEIterator<'index> + 'index>(
         }
         Ok(None) => {
             wrapper.header.atEOF = true;
-            // The Rust side owes no result here, so the header must not keep
-            // pointing at the last one. Iterators that own their current result
-            // — `TopKIterator` holds it in an `Option` and drops it on the way
-            // out — leave that pointer dangling otherwise, and the ones that
-            // reuse a fixed result slot would hand a consumer a document it has
-            // already seen. `current()` reports `None` past the end on the Rust
-            // side; this is the same answer, in the shape C reads.
             wrapper.header.current = std::ptr::null_mut();
             IteratorStatus_ITERATOR_EOF
         }
@@ -285,7 +278,6 @@ extern "C" fn skip_to<'index, I: RQEIterator<'index> + 'index>(
         }
         Ok(None) => {
             wrapper.header.atEOF = true;
-            // See `read`: no result to point at, so the header says so too.
             wrapper.header.current = std::ptr::null_mut();
             IteratorStatus_ITERATOR_EOF
         }
@@ -320,9 +312,6 @@ extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
                 wrapper.header.lastDocId = result.doc_id;
             } else {
                 wrapper.header.atEOF = true;
-                // A move that landed past the end has no result to publish; see
-                // `read`. Detecting exactly this is what `current()` returning
-                // `None` at EOF is for, so the header must not contradict it.
                 wrapper.header.current = std::ptr::null_mut();
             }
             ValidateStatus_VALIDATE_MOVED

--- a/src/redisearch_rs/rqe_iterators/src/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/src/interop.rs
@@ -245,6 +245,14 @@ extern "C" fn read<'index, I: RQEIterator<'index> + 'index>(
         }
         Ok(None) => {
             wrapper.header.atEOF = true;
+            // The Rust side owes no result here, so the header must not keep
+            // pointing at the last one. Iterators that own their current result
+            // — `TopKIterator` holds it in an `Option` and drops it on the way
+            // out — leave that pointer dangling otherwise, and the ones that
+            // reuse a fixed result slot would hand a consumer a document it has
+            // already seen. `current()` reports `None` past the end on the Rust
+            // side; this is the same answer, in the shape C reads.
+            wrapper.header.current = std::ptr::null_mut();
             IteratorStatus_ITERATOR_EOF
         }
     }
@@ -277,6 +285,8 @@ extern "C" fn skip_to<'index, I: RQEIterator<'index> + 'index>(
         }
         Ok(None) => {
             wrapper.header.atEOF = true;
+            // See `read`: no result to point at, so the header says so too.
+            wrapper.header.current = std::ptr::null_mut();
             IteratorStatus_ITERATOR_EOF
         }
     }
@@ -310,6 +320,10 @@ extern "C" fn revalidate<'index, I: RQEIterator<'index> + 'index>(
                 wrapper.header.lastDocId = result.doc_id;
             } else {
                 wrapper.header.atEOF = true;
+                // A move that landed past the end has no result to publish; see
+                // `read`. Detecting exactly this is what `current()` returning
+                // `None` at EOF is for, so the header must not contradict it.
+                wrapper.header.current = std::ptr::null_mut();
             }
             ValidateStatus_VALIDATE_MOVED
         }

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -223,6 +223,20 @@ pub trait RQEIterator<'index> {
     ///
     /// The caller must hold the spec read lock, represented by [`IndexSpecReadGuard`].
     /// The lock ensures the spec remains valid and unchanged during this call.
+    ///
+    /// # Errors
+    ///
+    /// An error is terminal. It interrupts a fix-up that is already half applied —
+    /// children repositioned or dropped, the state derived from them never re-synced —
+    /// so [`current`](Self::current), [`at_eof`](Self::at_eof) and
+    /// [`last_doc_id`](Self::last_doc_id) stop describing anything, and there is no
+    /// earlier state to roll back to either: the position they would be restored to
+    /// belongs to an index the iterator no longer sits in.
+    ///
+    /// Calling any of them afterwards is therefore meaningless rather than merely
+    /// stale, and so is [`rewind`](Self::rewind). Drop the iterator instead. Composites
+    /// propagate the error rather than handling it, and the C boundary reports
+    /// `VALIDATE_ABORTED`, on which the result processor frees the whole tree.
     fn revalidate(
         &mut self,
         spec: &IndexSpecReadGuard,

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -236,10 +236,6 @@ where
 
     #[inline(always)]
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
-        // Assigned rather than only set, because `revalidate` can leave the flag
-        // raised on an iterator it also allowed to recover: a scan that failed
-        // there has no position to report, yet clears `forced_eof` so a later
-        // read can try again. Landing on a result here is that retry succeeding.
         let found = self.read_inner()?;
         self.past_end = !found;
 
@@ -389,16 +385,17 @@ where
                 // result is in the child and invalid for NOT. Advance to
                 // the next valid position.
                 if self.child.last_doc_id() == self.result.doc_id {
-                    match self.read_inner() {
-                        Ok(found) => have_valid_pos = found,
-                        Err(_) => {
-                            // A timeout during revalidation should not
-                            // permanently terminate the iterator, but we
-                            // have no valid position to return.
-                            self.forced_eof = false;
-                            have_valid_pos = false;
-                        }
-                    }
+                    // A failing scan leaves nothing to report, and neither answer
+                    // available here would be true: `Moved { current: None }` says
+                    // exhausted, which every composite acts on — `Intersection`
+                    // ends, `OptionalOptimized` latches `past_end`, both unions drop
+                    // the child — so a later `read` finding a document would be
+                    // resurrecting past a parent that has already written this
+                    // iterator off. The error goes to the caller instead, which
+                    // aborts the iterator rather than trusting a position that does
+                    // not exist. Same trade `UnionFlat` makes when catching up a
+                    // lagging child fails.
+                    have_valid_pos = self.read_inner()?;
                 }
             }
 

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -373,12 +373,17 @@ where
             if have_valid_pos {
                 self.result.doc_id = self.wcii.last_doc_id();
 
-                // If child is behind, skip it forward.
-                // Errors are intentionally ignored: a timeout here should
-                // not abort the iterator, since we are already committed
-                // to returning Moved.
+                // If child is behind, skip it forward — the only thing that makes
+                // the membership test below mean anything.
+                //
+                // A failure here must not be swallowed. The contract forbids a
+                // skip that carries no result from leaving the child's position
+                // *on* the target, exactly so a parent cannot mistake it for a
+                // hit — so the test below would read the failure as "not in the
+                // child" and publish a document this iterator exists to exclude.
+                // Undecided is not the same as absent.
                 if self.child.last_doc_id() < self.result.doc_id {
-                    let _ = self.child.skip_to(self.result.doc_id);
+                    let _ = self.child.skip_to(self.result.doc_id)?;
                 }
 
                 // If child landed on the same position, the current

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -72,11 +72,15 @@ pub struct RawOptional<'query, Rf: Ref, I> {
 
     /// Whether the iterator has run *past* its last result, i.e. a
     /// `read`/`skip_to` found nothing beyond `max_doc_id` — the state behind
-    /// [`current`](RQEIterator::current) and [`at_eof`](RQEIterator::at_eof).
+    /// [`current`](RQEIterator::current) and [`at_eof`](RQEIterator::at_eof),
+    /// and the *only* record of it: both entry points check it before anything
+    /// else, so an exhausted iterator stays exhausted until
+    /// [`rewind`](RQEIterator::rewind) whatever the position says.
     ///
     /// It cannot be folded into `result.doc_id`: that field *is*
-    /// [`last_doc_id`](RQEIterator::last_doc_id), so pushing it past
-    /// `max_doc_id` would misreport the position.
+    /// [`last_doc_id`](RQEIterator::last_doc_id), so moving it to record
+    /// exhaustion — past `max_doc_id`, or onto it when a skip overshoots —
+    /// would report a position never yielded.
     past_end: bool,
 }
 
@@ -195,6 +199,24 @@ where
     const fn has_next(&self) -> bool {
         self.result.doc_id < self.max_doc_id
     }
+
+    /// Whether this iterator owes no further result, recording it if the
+    /// position has just reached `max_doc_id`.
+    ///
+    /// The single gate on both entry points: once
+    /// [`past_end`](Self::past_end) is set, only a
+    /// [`rewind`](RQEIterator::rewind) clears it. Checking it before
+    /// [`Self::has_next`] is what lets an overshooting
+    /// [`skip_to`](RQEIterator::skip_to) leave the position alone — the position
+    /// then sits below `max_doc_id` while the iterator owes nothing.
+    #[inline(always)]
+    const fn exhausted(&mut self) -> bool {
+        if self.past_end || !self.has_next() {
+            self.past_end = true;
+            return true;
+        }
+        false
+    }
 }
 
 impl<'index, I> RQEIterator<'index> for Optional<'index, I>
@@ -217,8 +239,7 @@ where
     }
 
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
-        if !self.has_next() {
-            self.past_end = true;
+        if self.exhausted() {
             return Ok(None);
         }
 
@@ -259,10 +280,19 @@ where
         &mut self,
         doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
+        // Checked before the precondition below, so a probe arriving after this
+        // iterator ran out is answered rather than asserted on: the position it
+        // holds is the last result it yielded, which such a probe legitimately
+        // sits above.
+        if self.exhausted() {
+            return Ok(None);
+        }
+
         debug_assert!(doc_id > self.result.doc_id);
 
-        if doc_id > self.max_doc_id || !self.has_next() {
-            self.result.doc_id = self.max_doc_id;
+        if doc_id > self.max_doc_id {
+            // Beyond the last document: this skip carries no result, so it may
+            // not move the position. `past_end` is what records the step.
             self.past_end = true;
             return Ok(None);
         }

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -190,31 +190,19 @@ where
         self.child.as_ref()
     }
 
-    /// Whether there is another result to yield: `max_doc_id` has not been
-    /// reached yet.
-    ///
-    /// Goes `false` one step before [`Self::past_end`] is set, while
-    /// `max_doc_id` is still the current result. Says nothing on its own about
-    /// an iterator a skip has already run off the end — that one can still be
-    /// sitting below `max_doc_id` — so [`Self::past_end`] is checked first, by
-    /// [`Self::exhausted`].
-    #[inline(always)]
-    const fn has_next(&self) -> bool {
-        self.result.doc_id < self.max_doc_id
-    }
-
     /// Whether this iterator owes no further result, recording it if the
     /// position has just reached `max_doc_id`.
     ///
-    /// The single gate on both entry points: once
-    /// [`past_end`](Self::past_end) is set, only a
-    /// [`rewind`](RQEIterator::rewind) clears it. Checking it before
-    /// [`Self::has_next`] is what lets an overshooting
+    /// The single gate on both entry points, and the only predicate either of
+    /// them needs: once [`past_end`](Self::past_end) is set, only a
+    /// [`rewind`](RQEIterator::rewind) clears it. It is checked before the
+    /// position, which is what lets an overshooting
     /// [`skip_to`](RQEIterator::skip_to) leave the position alone — the position
-    /// then sits below `max_doc_id` while the iterator owes nothing.
+    /// then sits below `max_doc_id` while the iterator owes nothing, so the
+    /// comparison alone would answer that there is more to come.
     #[inline(always)]
     const fn exhausted(&mut self) -> bool {
-        if self.past_end || !self.has_next() {
+        if self.past_end || self.result.doc_id >= self.max_doc_id {
             self.past_end = true;
             return true;
         }

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -194,7 +194,10 @@ where
     /// reached yet.
     ///
     /// Goes `false` one step before [`Self::past_end`] is set, while
-    /// `max_doc_id` is still the current result.
+    /// `max_doc_id` is still the current result. Says nothing on its own about
+    /// an iterator a skip has already run off the end — that one can still be
+    /// sitting below `max_doc_id` — so [`Self::past_end`] is checked first, by
+    /// [`Self::exhausted`].
     #[inline(always)]
     const fn has_next(&self) -> bool {
         self.result.doc_id < self.max_doc_id

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -111,7 +111,10 @@ impl Wildcard<'_> {
     ///
     /// The single gate on both entry points: once
     /// [`past_end`](Self::past_end) is set, only a
-    /// [`rewind`](RQEIterator::rewind) clears it.
+    /// [`rewind`](RQEIterator::rewind) clears it. Checking it before
+    /// [`Self::has_next`] is what lets an overshooting
+    /// [`skip_to`](RQEIterator::skip_to) leave the position alone — the position
+    /// then sits below `top_id` while the iterator owes nothing.
     #[inline(always)]
     const fn exhausted(&mut self) -> bool {
         if self.past_end || !self.has_next() {

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -93,31 +93,19 @@ impl Wildcard<'_> {
         }
     }
 
-    /// Whether there is another result to yield: `top_id` has not been reached
-    /// yet.
-    ///
-    /// Goes `false` one step before [`Self::past_end`] is set, while `top_id` is
-    /// still the current result. Says nothing on its own about an iterator a
-    /// skip has already run off the end — that one can still be sitting below
-    /// `top_id` — so [`Self::past_end`] is checked first, by
-    /// [`Self::exhausted`].
-    #[inline(always)]
-    const fn has_next(&self) -> bool {
-        self.result.doc_id < self.top_id
-    }
-
     /// Whether this iterator owes no further result, recording it if the
     /// position has just reached `top_id`.
     ///
-    /// The single gate on both entry points: once
-    /// [`past_end`](Self::past_end) is set, only a
-    /// [`rewind`](RQEIterator::rewind) clears it. Checking it before
-    /// [`Self::has_next`] is what lets an overshooting
+    /// The single gate on both entry points, and the only predicate either of
+    /// them needs: once [`past_end`](Self::past_end) is set, only a
+    /// [`rewind`](RQEIterator::rewind) clears it. It is checked before the
+    /// position, which is what lets an overshooting
     /// [`skip_to`](RQEIterator::skip_to) leave the position alone — the position
-    /// then sits below `top_id` while the iterator owes nothing.
+    /// then sits below `top_id` while the iterator owes nothing, so the
+    /// comparison alone would answer that there is more to come.
     #[inline(always)]
     const fn exhausted(&mut self) -> bool {
-        if self.past_end || !self.has_next() {
+        if self.past_end || self.result.doc_id >= self.top_id {
             self.past_end = true;
             return true;
         }

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -41,15 +41,21 @@ pub struct RawWildcard<'query, Rf: Ref> {
     /// A reusable result object to avoid allocations on each `read` call.
     result: RawIndexResult<'query, Rf>,
 
-    /// Whether the iterator has run *past* `top_id`, i.e. a `read`/`skip_to`
-    /// found nothing.
+    /// Whether the iterator has run *past* its last result, i.e. a
+    /// `read`/`skip_to` found nothing.
     ///
     /// The state behind [`current`](RQEIterator::current) and
-    /// [`at_eof`](RQEIterator::at_eof).
+    /// [`at_eof`](RQEIterator::at_eof), and the *only* record of it: both
+    /// entry points check it before anything else, so an exhausted iterator
+    /// stays exhausted until [`rewind`](RQEIterator::rewind) whatever the
+    /// position says.
     ///
     /// It cannot be folded into `result.doc_id`: that field *is*
     /// [`last_doc_id`](RQEIterator::last_doc_id), which parents use to choose
-    /// skip targets, so pushing it past `top_id` would misreport the position.
+    /// skip targets, so moving it to record exhaustion — past `top_id`, or onto
+    /// it when a skip overshoots — would report a position never yielded.
+    /// [`InvIndIterator`](crate::inverted_index::InvIndIterator) splits the two
+    /// the same way, with `at_eos` beside an untouched `last_doc_id`.
     past_end: bool,
 }
 
@@ -91,10 +97,28 @@ impl Wildcard<'_> {
     /// yet.
     ///
     /// Goes `false` one step before [`Self::past_end`] is set, while `top_id` is
-    /// still the current result.
+    /// still the current result. Says nothing on its own about an iterator a
+    /// skip has already run off the end — that one can still be sitting below
+    /// `top_id` — so [`Self::past_end`] is checked first, by
+    /// [`Self::exhausted`].
     #[inline(always)]
     const fn has_next(&self) -> bool {
         self.result.doc_id < self.top_id
+    }
+
+    /// Whether this iterator owes no further result, recording it if the
+    /// position has just reached `top_id`.
+    ///
+    /// The single gate on both entry points: once
+    /// [`past_end`](Self::past_end) is set, only a
+    /// [`rewind`](RQEIterator::rewind) clears it.
+    #[inline(always)]
+    const fn exhausted(&mut self) -> bool {
+        if self.past_end || !self.has_next() {
+            self.past_end = true;
+            return true;
+        }
+        false
     }
 }
 
@@ -108,8 +132,7 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
     }
 
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
-        if !self.has_next() {
-            self.past_end = true;
+        if self.exhausted() {
             return Ok(None);
         }
 
@@ -121,15 +144,15 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
         &mut self,
         doc_id: DocId,
     ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
-        if !self.has_next() {
-            self.past_end = true;
+        if self.exhausted() {
             return Ok(None);
         }
         debug_assert!(self.last_doc_id() < doc_id);
 
         if doc_id > self.top_id {
-            // skip beyond range - set to EOF
-            self.result.doc_id = self.top_id;
+            // Beyond the last document: this skip carries no result, so it may
+            // not move the position. `past_end` is what records the step, and
+            // the position stays where the last yield left it.
             self.past_end = true;
             return Ok(None);
         }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -889,11 +889,13 @@ mod revalidate {
         assert!(it.at_eof());
     }
 
-    /// A revalidation whose scan fails has no position to report, but it also
-    /// clears `forced_eof` so a later read can retry. The EOF it reports in the
-    /// meantime must not outlive that retry succeeding.
+    /// A revalidation whose scan fails has no position to report, and neither
+    /// status it could return would be true — so the error goes to the caller,
+    /// which aborts the iterator. Reporting `Moved { current: None }` instead
+    /// would say "exhausted" to a parent that acts on it, leaving any later read
+    /// to resurrect behind its back.
     #[test]
-    fn revalidate_scan_error_does_not_latch_eof() {
+    fn revalidate_scan_error_propagates() {
         let (_guard, context) = make_revalidate_context();
         let ii = DocIdsOnly::from_opaque(context.wildcard_inverted_index());
         let wcii = rqe_iterators::inverted_index::Wildcard::new(ii.reader(), 1.0);
@@ -914,30 +916,17 @@ mod revalidate {
         // GC doc 5, so the wildcard moves onto 10 — which the child holds, so
         // the iterator scans for the next valid result and the scan fails.
         gc_document(&context, 5);
-        let status = it.revalidate(&*context.spec_read()).unwrap();
+        let error = it
+            .revalidate(&*context.spec_read())
+            .expect_err("a failing revalidation scan must reach the caller");
         assert!(
-            matches!(status, RQEValidateStatus::Moved { current: None }),
-            "expected Moved {{ current: None }}, got {status:?}"
+            matches!(error, RQEIteratorError::TimedOut),
+            "the child's error must be propagated as it stands, got {error:?}",
         );
-        assert!(it.at_eof(), "nothing to report yet, so at EOF for now");
 
-        // The failure was transient, and the wildcard still holds documents past
-        // 10, so the retry finds one.
-        child_data.set_error_at_done(None);
-        let doc_id = it
-            .read()
-            .expect("read must be able to retry after a failed revalidation scan")
-            .expect("the wildcard has documents beyond 10")
-            .doc_id;
-
-        assert!(
-            !it.at_eof(),
-            "at_eof() must be false while positioned on doc {doc_id}",
-        );
-        assert!(
-            it.current().is_some(),
-            "current() must return the result read() just yielded (doc {doc_id})",
-        );
+        // Nothing further is asserted, and nothing may be: an `Err` from
+        // `revalidate` reaches the C boundary as `VALIDATE_ABORTED`, and an
+        // aborted iterator is dropped rather than used.
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -889,6 +889,49 @@ mod revalidate {
         assert!(it.at_eof());
     }
 
+    /// Catching the child up to the wildcard's new position is what makes the
+    /// membership test that follows it mean anything. A failure there leaves
+    /// membership *undecided* — and since the contract keeps a failed skip from
+    /// parking the child on the probed id, the test would read it as "absent"
+    /// and publish a document the NOT exists to exclude. So the error goes to
+    /// the caller instead.
+    #[test]
+    fn revalidate_child_skip_error_propagates() {
+        // A sparse wildcard, so GC-ing its first document makes it jump far
+        // enough forward to leave the child behind — the only shape in which the
+        // catch-up skip runs at all.
+        let (_guard, context) = (
+            GlobalGuard::default(),
+            TestContext::wildcard([1, 50].iter().copied()),
+        );
+        let ii = DocIdsOnly::from_opaque(context.wildcard_inverted_index());
+        let wcii = rqe_iterators::inverted_index::Wildcard::new(ii.reader(), 1.0);
+        // The child holds 50 — the id the wildcard lands on below — so the
+        // membership that cannot be decided is one where the answer is "present",
+        // and guessing is wrong rather than merely unlucky.
+        let child = Mock::<2>::new([3, 50]);
+        let mut child_data = child.data();
+        child_data.set_revalidate_result(MockRevalidateResult::Ok);
+        let mut it = NotOptimized::new(wcii, child, 100, 1.0, NoTimeoutChecker);
+
+        // Doc 1. Catching the child up to it stops on 3, behind the wildcard's
+        // remaining document.
+        assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
+
+        // From here the child cannot be caught up.
+        child_data.set_error_on_skip_to(Some(MockIteratorError::TimeoutError(None)));
+
+        // GC doc 1, so the wildcard moves onto 50, past the child at 3.
+        gc_document(&context, 1);
+        let error = it
+            .revalidate(&*context.spec_read())
+            .expect_err("a child that cannot be caught up must reach the caller");
+        assert!(
+            matches!(error, RQEIteratorError::TimedOut),
+            "the child's error must be propagated as it stands, got {error:?}",
+        );
+    }
+
     /// A revalidation whose scan fails has no position to report, and neither
     /// status it could return would be true — so the error goes to the caller,
     /// which aborts the iterator. Reporting `Moved { current: None }` instead

--- a/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/optional.rs
@@ -472,6 +472,35 @@ mod optional_iterator_with_empty_child_test {
         Optional::new(MAX_DOC_ID, WEIGHT, child)
     }
 
+    /// A skip past `max_doc_id` carries no result, so it must not adopt one as
+    /// the position — `max_doc_id` least of all, which a parent would read as
+    /// "this iterator is sitting on the last document".
+    #[test]
+    fn skip_to_beyond_max_doc_id_keeps_the_last_yielded_position() {
+        let mut it = setup_optional_iterator_with_empty_child();
+
+        for expected_id in 1..=3 {
+            assert_eq!(it.read().unwrap().unwrap().doc_id, expected_id);
+        }
+
+        assert!(matches!(it.skip_to(MAX_DOC_ID + 1), Ok(None)));
+        assert!(it.at_eof());
+        assert_eq!(it.last_doc_id(), 3);
+        assert!(it.current().is_none());
+
+        // Exhaustion is recorded on its own, so it holds even though the position
+        // (3) is far below `max_doc_id` and a forward probe is well-formed.
+        assert!(matches!(it.skip_to(4), Ok(None)));
+        assert!(matches!(it.read(), Ok(None)));
+        assert!(it.at_eof());
+        assert_eq!(it.last_doc_id(), 3);
+
+        // Only a rewind revives it.
+        it.rewind();
+        assert!(!it.at_eof());
+        assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
+    }
+
     #[test]
     fn test_read_all_virtual_results() {
         let mut it = setup_optional_iterator_with_empty_child();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -137,6 +137,7 @@ impl MockData {
             validation_count: 0,
             read_count: 0,
             error_at_done: None,
+            error_on_skip_to: None,
             resume_error: None,
             delays: Vec::new(),
             force_read_none: false,
@@ -209,6 +210,22 @@ impl MockData {
         self
     }
 
+    /// Configure an error that [`RQEIterator::skip_to`] returns in place of
+    /// seeking, while the iterator still holds documents at or past the target.
+    ///
+    /// [`set_error_at_done`](Self::set_error_at_done) only fires once the
+    /// documents run out, which is the case where a caller guessing "not here"
+    /// happens to be right. This one models the interesting failure — a leaf
+    /// hitting the query deadline or an IO error mid-seek — so a parent that
+    /// swallows the error is caught guessing about a document that *is* present.
+    ///
+    /// The position is left untouched, as the contract requires of a skip that
+    /// carries no result.
+    pub fn set_error_on_skip_to(&mut self, maybe_err: Option<MockIteratorError>) -> &mut Self {
+        self.0.borrow_mut().error_on_skip_to = maybe_err;
+        self
+    }
+
     /// Configure an error that the suspended counterpart's
     /// [`RQESuspendedIterator::resume`](rqe_iterators::RQESuspendedIterator::resume)
     /// will return instead of resuming.
@@ -272,6 +289,9 @@ struct MockDataInternal {
     validation_count: usize,
     read_count: usize,
     error_at_done: Option<MockIteratorError>,
+    /// Error returned by `skip_to` in place of seeking, *without* running out
+    /// of documents. See [`MockData::set_error_on_skip_to`].
+    error_on_skip_to: Option<MockIteratorError>,
     /// Error returned by the suspended counterpart's `resume` instead of
     /// resuming. See [`MockData::set_error_on_resume`].
     resume_error: Option<MockIteratorError>,
@@ -462,6 +482,13 @@ impl<'index, const N: usize> RQEIterator<'index> for Mock<'index, N> {
             self.last_doc_id() < doc_id,
             "skip_to called with a target at or below the current position"
         );
+
+        // Fails the seek without moving: the documents are still there, the
+        // iterator just could not reach them. See
+        // [`MockData::set_error_on_skip_to`].
+        if let Some(err) = data.error_on_skip_to {
+            return Err(err.into_rqe_iterator_error());
+        }
 
         if self.no_more_docs() {
             return if let Some(err) = data.error_at_done {
@@ -848,6 +875,11 @@ impl<'index> RQEIterator<'index> for MockVec<'index> {
             self.last_doc_id() < doc_id,
             "skip_to called with a target at or below the current position"
         );
+
+        // See `Mock::skip_to` and [`MockData::set_error_on_skip_to`].
+        if let Some(err) = data.error_on_skip_to {
+            return Err(err.into_rqe_iterator_error());
+        }
 
         let n = self.doc_ids.len();
         if self.no_more_docs() {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/wildcard.rs
@@ -122,9 +122,44 @@ fn skip_to_beyond_range() {
     assert!(outcome.is_none());
     assert!(it.at_eof());
 
+    // The skip carried no result, so it left no position behind: nothing was
+    // ever yielded, and `last_doc_id` still says so.
+    assert_eq!(it.last_doc_id(), 0);
+    assert!(it.current().is_none());
+
     // Subsequent reads should return None
     let result = it.read().unwrap();
     assert!(result.is_none());
+}
+
+#[test]
+fn skip_to_beyond_range_keeps_the_last_yielded_position() {
+    let mut it = Wildcard::new(10, 1.);
+
+    for expected_id in 1..=3 {
+        assert_eq!(it.read().unwrap().unwrap().doc_id, expected_id);
+    }
+
+    // Overshooting reports EOF without adopting a position the iterator never
+    // handed out — `top_id` least of all, which a parent would read as "doc 10
+    // is this iterator's current result".
+    assert!(matches!(it.skip_to(11), Ok(None)));
+    assert!(it.at_eof());
+    assert_eq!(it.last_doc_id(), 3);
+    assert!(it.current().is_none());
+
+    // Exhaustion is recorded on its own, so it holds even though the position
+    // (3) is still below `top_id` and a forward probe is still well-formed.
+    assert!(matches!(it.skip_to(4), Ok(None)));
+    assert!(matches!(it.read(), Ok(None)));
+    assert!(it.at_eof());
+    assert_eq!(it.last_doc_id(), 3);
+
+    // Only a rewind revives it.
+    it.rewind();
+    assert!(!it.at_eof());
+    assert_eq!(it.last_doc_id(), 0);
+    assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
 }
 
 #[test]
@@ -192,11 +227,14 @@ fn skip_to_after_eof() {
     assert!(result.is_ok());
     assert!(it.at_eof());
 
-    // Try to skip to a valid target while at EOF
+    // Try to skip to a valid target while at EOF. The overshoot above left the
+    // position at 0, so this is a well-formed forward probe — it just finds
+    // nothing, because exhaustion holds until a rewind.
     let result = it.skip_to(5);
     let outcome = result.unwrap();
     assert!(outcome.is_none());
     assert!(it.at_eof());
+    assert_eq!(it.last_doc_id(), 0);
 }
 
 #[test]

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -466,6 +466,11 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
         loop {
             if self.yield_pos >= self.results.len() {
                 self.at_eof = true;
+                // Cleared alongside the flag, as `advance_unfiltered_direct` does:
+                // `current()` is the negation of `at_eof()`, so leaving the last
+                // yielded record here would hand a caller a document it has
+                // already consumed.
+                *self.current = None;
                 return Ok(None);
             }
             let entry = &mut self.results[self.yield_pos];
@@ -500,8 +505,10 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
                 let Some(mut record) = record else {
                     // A rich filtered-mode entry must always carry its captured
                     // record; a missing one would indicate a collection-side bug.
-                    // Treat as EOF rather than panicking.
+                    // Treat as EOF rather than panicking — and report it as EOF
+                    // fully, with no stale current left behind.
                     self.at_eof = true;
+                    *self.current = None;
                     return Ok(None);
                 };
                 if self.source.is_expired(&record) {

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -140,6 +140,32 @@ fn eof_set_after_results_exhausted() {
     assert!(it.at_eof());
 }
 
+/// Both yield paths must report exhaustion the same way: `current()` is the
+/// negation of `at_eof()`, so the read that finds nothing has to drop the record
+/// it was holding rather than leave a consumed document visible.
+#[test]
+fn filtered_path_clears_current_once_exhausted() {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {
+        BatchStrategy::Continue
+    });
+    let mut it = TopKIterator::new(
+        source,
+        make_child(vec![1, 2]),
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    );
+
+    assert!(it.read().unwrap().is_some());
+    assert!(it.read().unwrap().is_some());
+    assert!(it.read().unwrap().is_none(), "two documents, then EOF");
+
+    assert!(it.at_eof());
+    assert!(
+        it.current().is_none(),
+        "the filtered path must not leave the last yielded record current",
+    );
+}
+
 #[test]
 fn last_doc_id_starts_at_zero_tracks_reads_and_resets_on_rewind() {
     let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0)]], vec![], |_, _| {


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: five query iterators answer `last_doc_id()`, `at_eof()` or `current()`
   with something they never yielded, or guess past a failure they cannot recover from.
   Two of those are reachable by a user query; three are latent.
2. **Change**: each iterator records exhaustion where exhaustion belongs — in the flag
   that `at_eof()` reports — instead of inferring it from a position it moved on purpose,
   and a revalidation that cannot establish where it stands says so instead of inventing
   an answer.
3. **Outcome**: no query returns a document a `NOT` clause excludes, or silently loses the
   tail of a result set, because a child timed out while the index changed underneath it.

### What is user-visible today

Both live bugs are in `NotOptimized`, the `NOT` iterator used when `index_all` is enabled,
and both need a concurrent index change plus a child that times out or hits an IO error
during the revalidation that follows:

- **Excluded documents can be returned.** Catching the child up to the wildcard's new
  position is what makes the membership test after it meaningful. The error from that skip
  was dropped, and since the contract forbids a failed skip from parking the child on the
  probed id, the test then read the failure as "not in the child" and published the
  document — one the `NOT` exists to exclude.
- **Results can be silently truncated.** A failing post-move scan reported
  `Moved { current: None }` while clearing its sticky-EOF flag, so it claimed to be
  exhausted and expected a later `read` to recover. No parent honours that:
  `Intersection::revalidate` turns a child's `Moved { current: None }` into `is_eof` for
  the whole intersection, `OptionalOptimized` latches its own `past_end` from it, and both
  unions drop a child reporting `at_eof()`. Everything after that point was lost.

Both now propagate the error, which the C boundary already turns into
`VALIDATE_ABORTED` — the same trade `UnionFlat` makes when catching up a lagging child
fails.

### What is latent

The other three are contract conformance whose symptoms are currently masked, included
here because they are the same mistake and the fix is two lines each:

- `Wildcard` and `Optional` parked their position on `top_id`/`max_doc_id` when a skip
  overshot, reporting a document they never yielded. The saturation was load-bearing —
  both inferred "exhausted" from `position < bound` — so both now gate on the `past_end`
  flag they already had. `Optional`'s is the sharper of the two: its
  `debug_assert!(doc_id > self.result.doc_id)` ran *before* the EOF early-return, so a
  parent probing a legal in-range id after an overshoot panicked in debug builds.
- `TopKIterator`'s filtered yield path left the last record visible through `current()`
  after reporting EOF, while its unfiltered path cleared it. Root-only iterator, so the
  reader is the result-processor pipeline rather than a parent.

Each fix carries a test that fails without it; all five were verified that way.

### How they were found

By wrapping the iterators' existing tests in a `ContractChecker` — a wrapper that asserts
the `RQEIterator` contract on every operation (#10758). The adoption itself is a separate,
test-only PR that stacks on that one; these fixes are split out here because they stand on
their own and should not wait on test infrastructure review.

The swallowed `skip_to` error is the exception: the checker cannot see it, since a false
hit is a wrong answer rather than a malformed one. It turned up while reading the function
that the checker had already flagged for the truncation bug.

#### Which additional issues this PR fixes
1. MOD-17394

#### Main objects this PR modified
1. `rqe_iterators::not_optimized::NotOptimized` (revalidation error handling)
2. `rqe_iterators::wildcard::Wildcard`, `rqe_iterators::optional::Optional` (exhaustion
   recorded in `past_end` rather than in the position)
3. `top_k::TopKIterator` (filtered yield path clears `current` at EOF)
4. `MockData::set_error_on_skip_to` (new: fails a seek while documents remain, which
   `set_error_at_done` cannot express)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
