### PR TITLE
Pin rust-cache to an exact release tag to fix zizmor ref-version-mismatch

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -176,7 +176,7 @@ runs:
     # Cache Rust packages
     - name: Cache Rust packages
       if: ${{ inputs.rust-cache == 'true' }}
-      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
         prefix-key: ${{ inputs.rust-cache-prefix-key }}
         key: ${{ inputs.rust-cache-key }}

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -98,7 +98,7 @@ jobs:
           command: .install/test_deps/install_rust_deps.sh ${{ steps.mode.outputs.mode }}
           github_token: ${{ github.token }}
       # Cache Rust packages and binaries
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           prefix-key: "v1-rust"
           # The cargo workspaces and target directory configuration.


### PR DESCRIPTION

## Describe the changes in the pull request

The `zizmor` gate ([`task-zizmor.yml`](.github/workflows/task-zizmor.yml)) started failing
on PRs that do not touch CI at all — e.g.
[this run on #10766](https://github.com/RediSearch/RediSearch/actions/runs/31078084200/job/92548441952),
which is a cursor-deadline change.

1. **Current:** both `Swatinem/rust-cache` pins referenced commit `e18b4977`, which is
   **not a tagged release**, carrying a bare `# v2` trailing comment. zizmor's
   `ref-version-mismatch` audit resolves that comment against the *live* tag. Upstream
   published v2.9.2 at 06:23Z today and the moving `v2` tag advanced to `6323deb1`, so the
   comment stopped matching the pinned SHA and the audit began reporting two `medium`
   findings — above the gate's `min-severity: informational` / `min-confidence: medium`
   floor, so `zizmor` exits 13.

   Worth noting this is a **latent** failure, not something #10766 introduced: it is
   triggered purely by an upstream release, so it will hit every open PR until fixed.
   It also did not reproduce locally at first — `ref-version-mismatch` is an *online*
   audit and is silently skipped without a GitHub token.

2. **Change:** pin both call sites to **v2.9.1** (`c1937114`) with an exact version
   comment. The SHA pin is retained, as `unpinned-uses` in
   [`.github/zizmor.yml`](.github/zizmor.yml) requires `hash-pin` for `*`; what changes is
   that the comment now names an **immutable** tag, so unlike `# v2` it cannot drift when
   upstream releases again.

   v2.9.1 rather than the newest v2.9.2 for two reasons:
   - The previously pinned commit was *v2.9.1 plus a `CHANGELOG.md`-only edit*
     (`+4/-0`, verified via the compare API), so this is a **behavioural no-op**.
   - v2.9.2 is hours old and would contradict the deliberate 7-day `cooldown` in
     [`.github/dependabot.yml`](.github/dependabot.yml) ("Don't adopt a release the moment
     it is published"). Dependabot will move these pins forward on its own schedule once
     that cooldown expires.

3. **Outcome:** `zizmor` passes at the exact gate thresholds. Verified locally with
   `GH_TOKEN` set so the online audits actually run:

   ```
   $ zizmor --min-severity informational --min-confidence medium \
       .github/workflows .github/actions .github/dependabot.yml
   No findings to report. Good job! (126 ignored, 231 suppressed)
   EXIT: 0
   ```

   (Before the change, the same command reported `2 medium` and exited 13.)

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `.github/workflows/task-lint.yml` — rust-cache pin (1 line)
2. `.github/actions/setup-build-env/action.yml` — rust-cache pin (1 line)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI-internal only: no user-facing behaviour changes, and the pinned action is
functionally identical to the one it replaces.
