### PR TITLE
[MOD-6430][MOD-6416] Assert the cursor idle-sweep timer is re-armed only on the main thread

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -235,10 +235,13 @@ static void Cursors_RescheduleSweepLocked(CursorList *cl) {
 
   // `RedisModule_StopTimer` / `RedisModule_CreateTimer` below mutate the
   // server's event-loop timer state, so they must only be reached from the main
-  // thread. Any caller that may run on a worker (e.g. `Cursor_Pause` when
-  // `FT.CURSOR READ` is dispatched to the workers pool, or `Cursors_CollectIdle`
-  // when `FT.CURSOR GC` is dispatched to `DIST_THREADPOOL` on a multi-shard
-  // cluster) must go through `Cursors_RequestRescheduleSweep` instead.
+  // thread. Any caller that can run elsewhere must post
+  // `Cursors_RequestRescheduleSweep` instead of re-arming inline. Which callers
+  // those are depends on how each command is dispatched: `Cursor_Pause` runs on
+  // a worker whenever `FT.CURSOR READ` is handed to the workers pool, and
+  // `Cursors_CollectIdle` does whenever a cluster serves `FT.CURSOR GC` off the
+  // main thread. This assertion is the enforcement, so the rule holds without
+  // having to re-derive the dispatch path of every caller.
   //
   // `MainThread_GetBlockedQueries` is a proxy for "am I the thread that ran
   // `RediSearch_InitModuleInternal`": the TLS slot is populated there and is

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -13,6 +13,7 @@
 
 #include "module.h"
 #include "rmutil/rm_assert.h"
+#include "info/info_redis/threads/main_thread.h"
 #include "query_error.h"
 #include "query_error_ffi.h"
 #include "redisearch.h"
@@ -231,6 +232,21 @@ static void Cursors_RescheduleSweepLocked(CursorList *cl) {
   if (RS_IsMock) {
     return;
   }
+
+  // `RedisModule_StopTimer` / `RedisModule_CreateTimer` below mutate the
+  // server's event-loop timer state, so they must only be reached from the main
+  // thread. Any caller that may run on a worker (e.g. `Cursor_Pause` when
+  // `FT.CURSOR READ` is dispatched to the workers pool, or `Cursors_CollectIdle`
+  // when `FT.CURSOR GC` is dispatched to `DIST_THREADPOOL` on a multi-shard
+  // cluster) must go through `Cursors_RequestRescheduleSweep` instead.
+  //
+  // `MainThread_GetBlockedQueries` is a proxy for "am I the thread that ran
+  // `RediSearch_InitModuleInternal`": the TLS slot is populated there and is
+  // NULL on every other thread. It is therefore only a valid main-thread test
+  // after module init, which is guaranteed for any cursor operation.
+  RS_LOG_ASSERT(MainThread_GetBlockedQueries() != NULL,
+                "Cursors_RescheduleSweepLocked must run on the main thread; "
+                "use Cursors_RequestRescheduleSweep from worker threads");
 
   if (cl->idleSweepTimerId != IDLE_SWEEP_TIMER_NONE) {
     RedisModule_StopTimer(RSDummyContext, cl->idleSweepTimerId, NULL);

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -852,9 +852,14 @@ def test_cursor_gc_reschedules_sweep_on_main_thread():
         for i in range(100 * env.shardsCount):
             con.execute_command('HSET', f'doc{i}', 't', 'hello')
 
-    # Leave a coordinator cursor idle with a short MAXIDLE, so the sweep timer
-    # is armed and every GC below has a reason to re-arm it.
-    env.cmd('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', '1', 'MAXIDLE', '600')
+    # Leave a coordinator cursor idle, so the sweep timer is armed and every GC
+    # below has a reason to re-arm it. MAXIDLE has to comfortably outlast the GC
+    # loop below, or the cursor is reaped mid-loop and the reap assertion at the
+    # end becomes vacuous.
+    _, cid = env.cmd('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', '1',
+                     'MAXIDLE', '1500')
+    # Fail here rather than timing out below if the cursor was never created.
+    env.assertNotEqual(0, cid)
     with TimeLimit(2, "cursors were not created"):
         while getCursorStats(env)['global_total'] < 1:
             sleep(0.01)
@@ -862,6 +867,10 @@ def test_cursor_gc_reschedules_sweep_on_main_thread():
     # Drive the coordinator GC repeatedly; each call re-arms the sweep timer.
     for _ in range(30):
         env.cmd('FT.CURSOR', 'GC', 'idx', '0')
+
+    # The loop must finish inside MAXIDLE, otherwise the cursor is already gone
+    # and the wait below would succeed without proving anything.
+    env.assertNotEqual(0, getCursorStats(env)['global_total'])
 
     # Reaping must still happen at MAXIDLE, i.e. the timer survived the re-arms.
     with TimeLimit(5, "idle cursor was not reaped after cluster FT.CURSOR GC"):

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -824,3 +824,46 @@ def test_cursor_gc_edge_cases(env: Env):
     # Test with only external cursors
     env.expect(debug_cmd(), 'DELETE_LOCAL_CURSORS').ok()
     env.expect('_FT.CURSOR', 'GC', 'idx', '0').equal(0)
+
+
+@skip(cluster=False)
+def test_cursor_gc_reschedules_sweep_on_main_thread():
+    """
+    Pins the invariant that re-arming the cursor idle-sweep timer only ever
+    happens on the main thread.
+
+    `Cursors_RescheduleSweepLocked` calls `RedisModule_StopTimer` /
+    `RedisModule_CreateTimer`, which mutate the server's event-loop timer state
+    and are therefore main-thread only; off-thread callers must instead post
+    `Cursors_RequestRescheduleSweep`. On a multi-shard cluster the user-facing
+    `FT.CURSOR GC` is dispatched to `DIST_THREADPOOL` and `threadHandleCommand`
+    does not take the GIL, so a `Cursors_CollectIdle` that re-arms the timer
+    inline violates that invariant. Under `ENABLE_ASSERT` builds the assertion
+    in `Cursors_RescheduleSweepLocked` turns that into a hard failure here
+    rather than a silent data race.
+
+    `test_cursor_gc_edge_cases` above only drives the shard-local
+    `_FT.CURSOR GC`, which already runs on the main thread, so it does not
+    reach this path.
+    """
+    env = Env(shardsCount=3)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    with env.getClusterConnectionIfNeeded() as con:
+        for i in range(100 * env.shardsCount):
+            con.execute_command('HSET', f'doc{i}', 't', 'hello')
+
+    # Leave a coordinator cursor idle with a short MAXIDLE, so the sweep timer
+    # is armed and every GC below has a reason to re-arm it.
+    env.cmd('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', '1', 'MAXIDLE', '600')
+    with TimeLimit(2, "cursors were not created"):
+        while getCursorStats(env)['global_total'] < 1:
+            sleep(0.01)
+
+    # Drive the coordinator GC repeatedly; each call re-arms the sweep timer.
+    for _ in range(30):
+        env.cmd('FT.CURSOR', 'GC', 'idx', '0')
+
+    # Reaping must still happen at MAXIDLE, i.e. the timer survived the re-arms.
+    with TimeLimit(5, "idle cursor was not reaped after cluster FT.CURSOR GC"):
+        while getCursorStats(env)['global_total']:
+            sleep(0.05)

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -852,27 +852,37 @@ def test_cursor_gc_reschedules_sweep_on_main_thread():
         for i in range(100 * env.shardsCount):
             con.execute_command('HSET', f'doc{i}', 't', 'hello')
 
-    # Leave a coordinator cursor idle, so the sweep timer is armed and every GC
-    # below has a reason to re-arm it. MAXIDLE has to comfortably outlast the GC
-    # loop below, or the cursor is reaped mid-loop and the reap assertion at the
-    # end becomes vacuous.
+    # Phase 1 — drive the GC path while a cursor is definitely idle, so the sweep
+    # timer is armed and every GC below has a reason to re-arm it. MAXIDLE is far
+    # longer than the whole test, so the cursor cannot expire mid-loop on any
+    # host: nothing here depends on how fast the loop runs.
     _, cid = env.cmd('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', '1',
-                     'MAXIDLE', '1500')
+                     'MAXIDLE', '60000')
     # Fail here rather than timing out below if the cursor was never created.
     env.assertNotEqual(0, cid)
-    with TimeLimit(2, "cursors were not created"):
+    with TimeLimit(10, "cursors were not created"):
         while getCursorStats(env)['global_total'] < 1:
             sleep(0.01)
 
-    # Drive the coordinator GC repeatedly; each call re-arms the sweep timer.
     for _ in range(30):
         env.cmd('FT.CURSOR', 'GC', 'idx', '0')
 
-    # The loop must finish inside MAXIDLE, otherwise the cursor is already gone
-    # and the wait below would succeed without proving anything.
+    # Holds on every host, fast or slow: MAXIDLE is 60s, so the cursor is still
+    # registered and the GC calls above provably ran against an armed timer.
     env.assertNotEqual(0, getCursorStats(env)['global_total'])
 
-    # Reaping must still happen at MAXIDLE, i.e. the timer survived the re-arms.
-    with TimeLimit(5, "idle cursor was not reaped after cluster FT.CURSOR GC"):
+    # Phase 2 — the sweep timer must still fire after all that re-arming. Release
+    # the long-lived cursor, then let a short-MAXIDLE one expire on its own with
+    # no further traffic. Both waits below only require "eventually, within a
+    # generous bound", so a slow host is slower but never wrong.
+    env.cmd('FT.CURSOR', 'DEL', 'idx', cid)
+    with TimeLimit(10, "FT.CURSOR DEL did not release the cursor"):
+        while getCursorStats(env)['global_total']:
+            sleep(0.05)
+
+    _, cid2 = env.cmd('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', '1',
+                      'MAXIDLE', '200')
+    env.assertNotEqual(0, cid2)
+    with TimeLimit(10, "idle cursor was not reaped at MAXIDLE after cluster FT.CURSOR GC"):
         while getCursorStats(env)['global_total']:
             sleep(0.05)

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -829,22 +829,26 @@ def test_cursor_gc_edge_cases(env: Env):
 @skip(cluster=False)
 def test_cursor_gc_reschedules_sweep_on_main_thread():
     """
-    Pins the invariant that re-arming the cursor idle-sweep timer only ever
-    happens on the main thread.
+    `FT.CURSOR GC` can re-arm the cursor idle-sweep timer, so that re-arming
+    must happen on the main thread.
 
-    `Cursors_RescheduleSweepLocked` calls `RedisModule_StopTimer` /
-    `RedisModule_CreateTimer`, which mutate the server's event-loop timer state
-    and are therefore main-thread only; off-thread callers must instead post
-    `Cursors_RequestRescheduleSweep`. On a multi-shard cluster the user-facing
-    `FT.CURSOR GC` is dispatched to `DIST_THREADPOOL` and `threadHandleCommand`
-    does not take the GIL, so a `Cursors_CollectIdle` that re-arms the timer
-    inline violates that invariant. Under `ENABLE_ASSERT` builds the assertion
-    in `Cursors_RescheduleSweepLocked` turns that into a hard failure here
-    rather than a silent data race.
+    `Cursors_CollectIdle` re-arms the timer, and re-arming calls
+    `RedisModule_StopTimer` / `RedisModule_CreateTimer`, which mutate the
+    server's event-loop timer state. That is main-thread-only work: a caller
+    that may run elsewhere has to post `Cursors_RequestRescheduleSweep` instead
+    of re-arming inline.
+
+    This test drives the user-facing `FT.CURSOR GC` on a multi-shard cluster,
+    the configuration in which the coordinator may serve that command from a
+    worker pool rather than on the main thread. Whether it actually does so is
+    an implementation detail that differs between branches; what must hold
+    everywhere is that the timer is only ever re-armed from the main thread. In
+    `ENABLE_ASSERT` builds the assertion in `Cursors_RescheduleSweepLocked`
+    makes a violation a hard failure here instead of a silent data race.
 
     `test_cursor_gc_edge_cases` above only drives the shard-local
-    `_FT.CURSOR GC`, which already runs on the main thread, so it does not
-    reach this path.
+    `_FT.CURSOR GC`, which runs on the main thread, so it does not exercise
+    this path.
     """
     env = Env(shardsCount=3)
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `Cursors_RescheduleSweepLocked` calls `RedisModule_StopTimer` / `RedisModule_CreateTimer`, which mutate the server's event-loop timer state and must therefore only be reached from the main thread. Callers that may run on a worker thread are expected to post `Cursors_RequestRescheduleSweep` instead (as `Cursor_Pause` does), but nothing enforces that, so a future off-thread caller regresses silently into a data race.

2. **Change**: Add an `ENABLE_ASSERT`-only assertion for that invariant, using `MainThread_GetBlockedQueries() != NULL` as the main-thread predicate (the TLS slot is populated in `RediSearch_InitModuleInternal` and is NULL on every other thread). The assertion sits after the existing `RS_IsMock` guard, so cpptests are unaffected, and it compiles to a NOP without `ENABLE_ASSERT`.

   Also add `test_cursor_gc_reschedules_sweep_on_main_thread`, a cluster test on `Env(shardsCount=3)` that drives the user-facing `FT.CURSOR GC` against an idle coordinator cursor and then asserts MAXIDLE reaping still works. On a multi-shard cluster that command is dispatched to `DIST_THREADPOOL`, and `threadHandleCommand` does not take the GIL, so this is the path where the invariant can be violated. The existing `test_cursor_gc_edge_cases` only drives the shard-local `_FT.CURSOR GC`, which already runs on the main thread, so it does not reach it.

3. **Outcome**: No behaviour change on `master`. Every caller of `Cursors_RescheduleSweepLocked` here is already main-thread — the idle-sweep timer callback, the event-loop one-shot callback, and `Cursors_CollectIdle`, whose only callers are `RSCursorGCCommand` reached inline from `CursorCommand` (master blocks only for `READ`). The assertion and test are added here first so the same commit can be backported to the release branches, where cluster `FT.CURSOR GC` *is* dispatched to a worker and the violation should fail deterministically instead of racing on timer state.

#### Which additional issues this PR fixes
1. MOD-6430, MOD-6416 — follow-up hardening for #9425, found while backporting it to 8.2 / 8.4 / 8.6.
2. #9425

#### Main objects this PR modified
1. `src/cursor.c` — main-thread assertion in `Cursors_RescheduleSweepLocked`; added the `info/info_redis/threads/main_thread.h` include.
2. `tests/pytests/test_cursors.py` — new cluster test `test_cursor_gc_reschedules_sweep_on_main_thread`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal-only: a debug-build assertion plus test coverage, with no user-visible behaviour change on `master`.



## Context

Found while backporting the `MAXIDLE` cursor-reaping fix (#9425, MOD-6430 / MOD-6416) for **MOD-17447**, where a customer cluster went OOM during a reshard with roughly 146 GB of leaked idle coordinator cursors across 13 masters.

`master` is not affected: `CursorCommand` serves `FT.CURSOR GC` inline on the main thread, because the subcommand split in `664bfc3fd` (MOD-14284 / MOD-14998) landed ten days before #9425. The release branches still dispatch it to `DIST_THREADPOOL` without the GIL, so the assertion and test added here are what make that failure deterministic once backported, and each backport pairs them with the one-line fix.

Related:
- **MOD-17447** — customer incident, cluster nodes OOM during reshard.
- **MOD-17479** — coordinator cursors are created with a NULL spec so `INDEX_CURSOR_LIMIT` never applies and the coordinator cursor list is unbounded. Still open, master included.
