### PR TITLE
[MOD-14806] Add GROUPBY COLLECT DISTINCT benchmarks

### DIFF
--- a/tests/benchmarks/scripts/generate_groupby_collect_dataset.py
+++ b/tests/benchmarks/scripts/generate_groupby_collect_dataset.py
@@ -59,6 +59,13 @@ GROUP_DISTRIBUTIONS = {
 
 SORT_ARGS = ["@target", "DESC", "@dueDate", "ASC", "@eventId", "ASC"]
 
+# Low-cardinality projection used by the DISTINCT variants. The default
+# projections all include a per-document unique field (@eventId, or @recordId
+# and @payload via `FIELDS *`), so DISTINCT would deduplicate nothing there.
+# type/target/processed have 3/2/2 values, collapsing a group to 12 rows.
+TAG_FIELDS = ["@type", "@target", "@processed"]
+TAG_SORT = ["@type", "ASC", "@target", "ASC", "@processed", "ASC"]
+
 QUERY_VARIANTS = {
     "collect-fields-1-k50": {
         "load": ["@entityName", "@eventId", "@target", "@dueDate"],
@@ -98,6 +105,31 @@ QUERY_VARIANTS = {
         "load": "*",
         "fields": "*",
         "limit": (500, 50),
+    },
+    # Baseline for the DISTINCT variants below: same projection and sort, no
+    # DISTINCT. The pair is what makes the DISTINCT number interpretable.
+    "collect-fields-tags-k50": {
+        "load": ["@entityName", *TAG_FIELDS],
+        "fields": TAG_FIELDS,
+        "sort": TAG_SORT,
+        "limit": (0, 50),
+    },
+    # Heavy dedup: 12 distinct tuples per group regardless of group size.
+    "collect-fields-tags-distinct-k50": {
+        "load": ["@entityName", *TAG_FIELDS],
+        "fields": TAG_FIELDS,
+        "sort": TAG_SORT,
+        "limit": (0, 50),
+        "distinct": True,
+    },
+    # Light dedup: adding @dueDate (3681 values) leaves most rows unique, so
+    # this measures the DISTINCT machinery when it removes little.
+    "collect-fields-tags-duedate-distinct-k50": {
+        "load": ["@entityName", *TAG_FIELDS, "@dueDate"],
+        "fields": [*TAG_FIELDS, "@dueDate"],
+        "sort": [*TAG_SORT, "@dueDate", "ASC"],
+        "limit": (0, 50),
+        "distinct": True,
     },
 }
 
@@ -223,9 +255,13 @@ def collect_args_for_variant(variant):
     else:
         collect_args = ["FIELDS", str(len(fields)), *fields]
 
+    sort_args = variant.get("sort", SORT_ARGS)
     offset, count = variant["limit"]
-    collect_args.extend(["SORTBY", str(len(SORT_ARGS)), *SORT_ARGS])
+    collect_args.extend(["SORTBY", str(len(sort_args)), *sort_args])
     collect_args.extend(["LIMIT", str(offset), str(count)])
+    if variant.get("distinct"):
+        # Trailing flag, counted in the COLLECT arg count by the caller.
+        collect_args.append("DISTINCT")
     return collect_args
 
 

--- a/tests/benchmarks/scripts/generate_groupby_collect_dataset.py
+++ b/tests/benchmarks/scripts/generate_groupby_collect_dataset.py
@@ -106,15 +106,18 @@ QUERY_VARIANTS = {
         "fields": "*",
         "limit": (500, 50),
     },
-    # Baseline for the DISTINCT variants below: same projection and sort, no
-    # DISTINCT. The pair is what makes the DISTINCT number interpretable.
+    # The DISTINCT variants come in pairs: each has a no-DISTINCT twin with the
+    # identical projection and sort, so the only difference between the two is
+    # the flag. Comparing across projections instead would conflate DISTINCT
+    # with the cost of loading, hashing and sorting a different field set.
+    #
+    # Heavy-dedup pair: 12 distinct tuples per group regardless of group size.
     "collect-fields-tags-k50": {
         "load": ["@entityName", *TAG_FIELDS],
         "fields": TAG_FIELDS,
         "sort": TAG_SORT,
         "limit": (0, 50),
     },
-    # Heavy dedup: 12 distinct tuples per group regardless of group size.
     "collect-fields-tags-distinct-k50": {
         "load": ["@entityName", *TAG_FIELDS],
         "fields": TAG_FIELDS,
@@ -122,8 +125,14 @@ QUERY_VARIANTS = {
         "limit": (0, 50),
         "distinct": True,
     },
-    # Light dedup: adding @dueDate (3681 values) leaves most rows unique, so
-    # this measures the DISTINCT machinery when it removes little.
+    # Light-dedup pair: adding @dueDate (3681 values) leaves most rows unique,
+    # so DISTINCT does the work but removes little.
+    "collect-fields-tags-duedate-k50": {
+        "load": ["@entityName", *TAG_FIELDS, "@dueDate"],
+        "fields": [*TAG_FIELDS, "@dueDate"],
+        "sort": [*TAG_SORT, "@dueDate", "ASC"],
+        "limit": (0, 50),
+    },
     "collect-fields-tags-duedate-distinct-k50": {
         "load": ["@entityName", *TAG_FIELDS, "@dueDate"],
         "fields": [*TAG_FIELDS, "@dueDate"],

--- a/tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-tags-distinct-k50.yml
+++ b/tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-tags-distinct-k50.yml
@@ -1,0 +1,40 @@
+version: 0.5
+name: "search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-tags-distinct-k50"
+description: "GROUPBY + COLLECT HASH benchmark with DISTINCT over low-cardinality tags (heavy dedup: 12 distinct tuples per group)."
+
+metadata:
+  component: "search"
+  query_type: "groupby-collect"
+  backend: "hash"
+  projection: "fields-tags-distinct"
+  window: "0-50"
+
+timeout_seconds: 1800
+
+setups:
+  - oss-standalone
+  - oss-cluster-02-primaries
+
+dbconfig:
+  - dataset_name: "groupby-collect-entity-events-10K-heavy-hash"
+  - dataset_load_timeout_secs: 1800
+  - init_commands:
+    - '"CONFIG" "SET" "search-enable-unstable-features" "yes"'
+    - '"FT.CREATE" "idx:entity_events" "ON" "HASH" "PREFIX" "1" "entity:" "SCHEMA" "recordId" "NUMERIC" "SORTABLE" "entityName" "TEXT" "SORTABLE" "event_id" "AS" "eventId" "NUMERIC" "SORTABLE" "event_type" "AS" "type" "TAG" "event_target" "AS" "target" "TAG" "SORTABLE" "event_hasNotes" "AS" "hasNotes" "TAG" "event_processed" "AS" "processed" "TAG" "event_dueDate" "AS" "dueDate" "TEXT" "SORTABLE" "event_payload" "AS" "payload" "TEXT" "NOINDEX"'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-hash/groupby-collect-entity-events-10K-heavy-hash.redisearch.commands.SETUP.csv"
+  - check:
+      keyspacelen: 10000
+
+clientconfig:
+  - benchmark_type: "read-only"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 16
+    - requests: 100000
+    - reporting-period: 1s
+    - duration: 120s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-hash/groupby-collect-entity-events-10K-heavy-hash.redisearch.commands.BENCH.QUERY_collect-fields-tags-distinct-k50.csv"

--- a/tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-tags-duedate-distinct-k50.yml
+++ b/tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-tags-duedate-distinct-k50.yml
@@ -1,0 +1,40 @@
+version: 0.5
+name: "search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-tags-duedate-distinct-k50"
+description: "GROUPBY + COLLECT HASH benchmark with DISTINCT over tags plus @dueDate (light dedup: most rows survive)."
+
+metadata:
+  component: "search"
+  query_type: "groupby-collect"
+  backend: "hash"
+  projection: "fields-tags-duedate-distinct"
+  window: "0-50"
+
+timeout_seconds: 1800
+
+setups:
+  - oss-standalone
+  - oss-cluster-02-primaries
+
+dbconfig:
+  - dataset_name: "groupby-collect-entity-events-10K-heavy-hash"
+  - dataset_load_timeout_secs: 1800
+  - init_commands:
+    - '"CONFIG" "SET" "search-enable-unstable-features" "yes"'
+    - '"FT.CREATE" "idx:entity_events" "ON" "HASH" "PREFIX" "1" "entity:" "SCHEMA" "recordId" "NUMERIC" "SORTABLE" "entityName" "TEXT" "SORTABLE" "event_id" "AS" "eventId" "NUMERIC" "SORTABLE" "event_type" "AS" "type" "TAG" "event_target" "AS" "target" "TAG" "SORTABLE" "event_hasNotes" "AS" "hasNotes" "TAG" "event_processed" "AS" "processed" "TAG" "event_dueDate" "AS" "dueDate" "TEXT" "SORTABLE" "event_payload" "AS" "payload" "TEXT" "NOINDEX"'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-hash/groupby-collect-entity-events-10K-heavy-hash.redisearch.commands.SETUP.csv"
+  - check:
+      keyspacelen: 10000
+
+clientconfig:
+  - benchmark_type: "read-only"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 16
+    - requests: 100000
+    - reporting-period: 1s
+    - duration: 120s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-hash/groupby-collect-entity-events-10K-heavy-hash.redisearch.commands.BENCH.QUERY_collect-fields-tags-duedate-distinct-k50.csv"

--- a/tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-tags-duedate-k50.yml
+++ b/tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-tags-duedate-k50.yml
@@ -1,0 +1,40 @@
+version: 0.5
+name: "search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-tags-duedate-k50"
+description: "GROUPBY + COLLECT HASH benchmark projecting tags plus @dueDate, no DISTINCT. Twin of the light-dedup DISTINCT variant."
+
+metadata:
+  component: "search"
+  query_type: "groupby-collect"
+  backend: "hash"
+  projection: "fields-tags-duedate"
+  window: "0-50"
+
+timeout_seconds: 1800
+
+setups:
+  - oss-standalone
+  - oss-cluster-02-primaries
+
+dbconfig:
+  - dataset_name: "groupby-collect-entity-events-10K-heavy-hash"
+  - dataset_load_timeout_secs: 1800
+  - init_commands:
+    - '"CONFIG" "SET" "search-enable-unstable-features" "yes"'
+    - '"FT.CREATE" "idx:entity_events" "ON" "HASH" "PREFIX" "1" "entity:" "SCHEMA" "recordId" "NUMERIC" "SORTABLE" "entityName" "TEXT" "SORTABLE" "event_id" "AS" "eventId" "NUMERIC" "SORTABLE" "event_type" "AS" "type" "TAG" "event_target" "AS" "target" "TAG" "SORTABLE" "event_hasNotes" "AS" "hasNotes" "TAG" "event_processed" "AS" "processed" "TAG" "event_dueDate" "AS" "dueDate" "TEXT" "SORTABLE" "event_payload" "AS" "payload" "TEXT" "NOINDEX"'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-hash/groupby-collect-entity-events-10K-heavy-hash.redisearch.commands.SETUP.csv"
+  - check:
+      keyspacelen: 10000
+
+clientconfig:
+  - benchmark_type: "read-only"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 16
+    - requests: 100000
+    - reporting-period: 1s
+    - duration: 120s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-hash/groupby-collect-entity-events-10K-heavy-hash.redisearch.commands.BENCH.QUERY_collect-fields-tags-duedate-k50.csv"

--- a/tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-tags-k50.yml
+++ b/tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-tags-k50.yml
@@ -1,0 +1,40 @@
+version: 0.5
+name: "search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-tags-k50"
+description: "GROUPBY + COLLECT HASH benchmark projecting only low-cardinality tags, no DISTINCT. Baseline for the DISTINCT variants."
+
+metadata:
+  component: "search"
+  query_type: "groupby-collect"
+  backend: "hash"
+  projection: "fields-tags"
+  window: "0-50"
+
+timeout_seconds: 1800
+
+setups:
+  - oss-standalone
+  - oss-cluster-02-primaries
+
+dbconfig:
+  - dataset_name: "groupby-collect-entity-events-10K-heavy-hash"
+  - dataset_load_timeout_secs: 1800
+  - init_commands:
+    - '"CONFIG" "SET" "search-enable-unstable-features" "yes"'
+    - '"FT.CREATE" "idx:entity_events" "ON" "HASH" "PREFIX" "1" "entity:" "SCHEMA" "recordId" "NUMERIC" "SORTABLE" "entityName" "TEXT" "SORTABLE" "event_id" "AS" "eventId" "NUMERIC" "SORTABLE" "event_type" "AS" "type" "TAG" "event_target" "AS" "target" "TAG" "SORTABLE" "event_hasNotes" "AS" "hasNotes" "TAG" "event_processed" "AS" "processed" "TAG" "event_dueDate" "AS" "dueDate" "TEXT" "SORTABLE" "event_payload" "AS" "payload" "TEXT" "NOINDEX"'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-hash/groupby-collect-entity-events-10K-heavy-hash.redisearch.commands.SETUP.csv"
+  - check:
+      keyspacelen: 10000
+
+clientconfig:
+  - benchmark_type: "read-only"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 16
+    - requests: 100000
+    - reporting-period: 1s
+    - duration: 120s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/groupby-collect-entity-events-10K-heavy-hash/groupby-collect-entity-events-10K-heavy-hash.redisearch.commands.BENCH.QUERY_collect-fields-tags-k50.csv"


### PR DESCRIPTION
## Describe the changes in the pull request

**Current:** `REDUCE COLLECT ... DISTINCT` (#10233) has no benchmark coverage, and the existing variants cannot provide it — each projects a per-document unique field (`@eventId`, or `@recordId`/`@payload` via `FIELDS *`), so DISTINCT would dedup 0% of rows and measure only overhead.

**Change:** add four query variants over low-cardinality tag projections, forming two pairs that differ only in the DISTINCT flag — heavy dedup (12 distinct tuples per group) and light dedup (`@dueDate` added, so most rows stay unique) — plus one HASH benchmark each. Pairing is what makes a DISTINCT timing attributable; comparing across projections would conflate the flag with the cost of a different field set.

**Outcome:** DISTINCT is measured against a same-projection baseline in both dedup regimes. All four run green on `oss-cluster-02-primaries`.

The generator change is additive — `sort` and `distinct` are optional per-variant keys, so the five pre-existing variants render unchanged and the CSVs already in S3 stay valid. The four new BENCH query streams are uploaded; the SETUP stream is reused as-is.

`master`/`8.10` only; `8.8` has no DISTINCT support.

#### Which additional issues this PR fixes
1. MOD-14806

#### Main objects this PR modified
1. `tests/benchmarks/scripts/generate_groupby_collect_dataset.py` — four new query variants, optional `sort`/`distinct` keys
2. `tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-tags{,-distinct}-k50.yml`
3. `tests/benchmarks/search-groupby-collect-10K-entity-events-hash-cached-sortby-fields-tags-duedate{,-distinct}-k50.yml`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
