### PR TITLE
[MOD-17503] Catch all ASAN AddressSanitizer reports

### DIFF
--- a/sbin/memcheck-summary
+++ b/sbin/memcheck-summary
@@ -57,13 +57,14 @@ sanitizer_check() {
 
 sanitizer_summary() {
 	local logdir="$ROOT/tests/$DIR/logs"
-	if ! TYPE="leaks" sanitizer_check "Direct leak"; then
-		TYPE="leaks" sanitizer_check "detected memory leaks"
-	fi
-	TYPE="buffer overflow" sanitizer_check "dynamic-stack-buffer-overflow"
-	TYPE="memory errors" sanitizer_check "memcpy-param-overlap"
-	TYPE="stack use after scope" sanitizer_check "stack-use-after-scope"
-	TYPE="use after free" sanitizer_check "heap-use-after-free"
+	# Every leak report opens with "ERROR: LeakSanitizer", whether the leaks are
+	# direct or only indirect — one grep covers both.
+	TYPE="leaks" sanitizer_check "ERROR: LeakSanitizer"
+	# Every ASan report opens with an "ERROR: AddressSanitizer" header line,
+	# whatever the report type — matching that catches all of them
+	# (heap-buffer-overflow, use-after-free, SEGV, ...) instead of a per-type
+	# whitelist that goes stale.
+	TYPE="memory errors" sanitizer_check "ERROR: AddressSanitizer"
 	TYPE="signal 11" sanitizer_check "caught signal 11"
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `sanitizer_summary` in `sbin/memcheck-summary` — the post-run check that turns sanitizer findings into a red CI job — matches a whitelist of report types that misses `heap-buffer-overflow`, `global-buffer-overflow`, and plain `stack-buffer-overflow`, among others. Since the unit-test ASan options set `halt_on_error=0`, a report of an unlisted type lands in the log file and nothing reads it: an out-of-bounds write that corrupts no test assertion passes the `sanitize` job silently. The empty-wildcard-pattern write fixed by #10704 was exactly this shape — its `heap-buffer-overflow` report would not have failed CI.
2. Change: match `ERROR: AddressSanitizer`, the prefix every ASan report line carries regardless of type, instead of enumerating types.
3. The leak check had the same problem plus an unreachable fallback: `sanitizer_check` always returns 0, so the `if !`-guarded second grep for "detected memory leaks" never ran, and a LeakSanitizer report containing only indirect leaks passed silently. Both greps are replaced by the report header `ERROR: LeakSanitizer` — the same catch-all shape as the AddressSanitizer check. The `### Sanitizer: leaks detected:` output label is unchanged, so `collect_nightly_results.py` parsing is unaffected.
4. Outcome: any AddressSanitizer or LeakSanitizer report in a unit-test or flow-test log fails the `sanitize` job, including report types added by future ASan versions. Verified against a fabricated `heap-buffer-overflow` log (exit 1, previously exit 0), an indirect-only leak log (exit 1, previously exit 0), and a clean logs directory (exit 0). If master currently produces a tolerated report of a previously unlisted type, this job turns red — that is the intended effect. Note the exposure is staged: this PR's own `sanitize` run and the merge queue use `QUICK=1`, while nightly runs the full suite, so a tolerated report in a non-QUICK test would first turn red at nightly after merge.

#### Which additional issues this PR fixes

1. N/A

#### Main objects this PR modified

1. `sanitizer_summary`, `sanitizer_check` (sbin/memcheck-summary)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
