### PR TITLE
AGENTS.md: state comment rules in Code Style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,25 @@ Rules:
 
 ## Code Style
 
+### Comments
+
+Applies to every language here — C, C++, Rust, Python — and to test code as much
+as production code.
+
+- **Focus on why, not how.** Don't restate what the code plainly does. Document
+  non-obvious choices, invariants that are hard to infer, and constraints a
+  maintainer would otherwise miss.
+- **Prefer code-enforced invariants over prose.** If an assertion, type, enum, or
+  test can express the constraint, add that instead — comments drift, code mostly
+  doesn't.
+- **State each fact in exactly one place** — the definition, the interface, or the
+  implementation, whichever is canonical. Elsewhere refer to it by name rather
+  than restating it.
+- **Never reference line numbers or line ranges** — they go stale. If a note must
+  attach to a specific spot, put a line comment at that spot.
+- Full rules, including which layer owns which fact:
+  [/docs-guidelines](.skills/docs-guidelines/SKILL.md).
+
 ### C
 
 - `.clang-format` is the authoritative formatting spec; run `clang-format` before committing C changes
@@ -121,6 +140,10 @@ Rules:
 ### Rust
 - Edition 2024
 - Document all `unsafe` blocks with `// SAFETY:` comments
+- Doc comments: intra-doc link every symbol mentioned, constants included — never
+  hard-code a constant's value into another item's docs. Full rules:
+  [/rust-docs-guidelines](.skills/rust-docs-guidelines/SKILL.md),
+  [/rust-tests-guidelines](.skills/rust-tests-guidelines/SKILL.md)
 - Use `#[expect(...)]` over `#[allow(...)]` for lint suppressions
 - Use `tracing` macros for logging (debug!, info!, warn!, error!)
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: the comment guidelines are unreachable from the always-loaded agent context. `.skills/docs-guidelines/SKILL.md` holds the general rules — focus on why not how, prefer code-enforced invariants over prose, state each fact once, plus the placement model for which layer owns which fact — but `AGENTS.md` never references it. The only pointer to any of this is one line under Common Workflows, "Follow /rust-docs-guidelines when writing documentation for Rust code", which is gated on *writing documentation* so it does not fire during ordinary coding, and sits ~200 lines below Code Style where a reader would look for a comment rule. Net effect: `## Code Style` says nothing about comments beyond `// SAFETY:`, so agents writing code never see the rules.

2. **Change**: add a `### Comments` subsection at the top of `## Code Style` carrying the four rules that hold in every language here, and link `/docs-guidelines` for the full set including the placement model. Add the rustdoc intra-doc-link rule under `### Rust`, next to the existing `// SAFETY:` bullet — Rust-only mechanics stay out of the language-neutral section.

3. **Outcome**: the rules an agent most often violates are in context on every edit, without depending on a skill being invoked. Docs only; no code, build, or test changes.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `AGENTS.md` (+23 lines; `CLAUDE.md` is a symlink to it, so both are covered)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
