### PR TITLE
[MOD-17498] Turn off ASan leak detection when the runtime does not support it

### DIFF
--- a/sbin/unit-tests
+++ b/sbin/unit-tests
@@ -56,10 +56,18 @@ END
 #------------------------------------------------------------------------------
 # Configure sanitizer options for memory error detection
 #------------------------------------------------------------------------------
+
 setup_sanitizer() {
     if [[ $SAN == "address" ]]; then
         ASAN_LOG=${LOGS_DIR}/${TEST_NAME}.asan.log
-        export ASAN_OPTIONS="detect_odr_violation=0:alloc_dealloc_mismatch=0:halt_on_error=0:detect_leaks=1:log_path=${ASAN_LOG}:verbosity=0"
+        # Apple's ASan runtime has no LeakSanitizer: with detect_leaks=1 every
+        # instrumented process aborts before main ("detect_leaks is not
+        # supported on this platform").
+        local detect_leaks=1
+        if [[ $(uname) == Darwin ]]; then
+            detect_leaks=0
+        fi
+        export ASAN_OPTIONS="detect_odr_violation=0:alloc_dealloc_mismatch=0:halt_on_error=0:detect_leaks=${detect_leaks}:log_path=${ASAN_LOG}:verbosity=0"
         export LSAN_OPTIONS="suppressions=$ROOT_DIR/tests/memcheck/asan.supp:verbosity=0"
     elif [[ $SAN == "alignment" ]]; then
         export UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1"

--- a/sbin/unit-tests
+++ b/sbin/unit-tests
@@ -60,14 +60,15 @@ END
 setup_sanitizer() {
     if [[ $SAN == "address" ]]; then
         ASAN_LOG=${LOGS_DIR}/${TEST_NAME}.asan.log
-        # Apple's ASan runtime — linked from under Xcode.app or
-        # CommandLineTools — has no LeakSanitizer: with detect_leaks=1 every
-        # instrumented process aborts before main ("detect_leaks is not
-        # supported on this platform"). Other runtimes, like Homebrew LLVM's,
-        # support it, so key off the runtime the binary links, not the OS.
+        # Apple's ASan runtime — linked from under an .xctoolchain (any Xcode
+        # bundle, however renamed) or CommandLineTools — has no LeakSanitizer:
+        # with detect_leaks=1 every instrumented process aborts before main
+        # ("detect_leaks is not supported on this platform"). Other runtimes,
+        # like Homebrew LLVM's, support it, so key off the runtime the binary
+        # links, not the OS.
         if [[ -z $DETECT_LEAKS ]]; then
             DETECT_LEAKS=1
-            if otool -l "$BINDIR/tests/cpptests/rstest" 2> /dev/null | grep -qE 'Xcode\.app|CommandLineTools'; then
+            if otool -l "$BINDIR/tests/cpptests/rstest" 2> /dev/null | grep -qE '\.xctoolchain|CommandLineTools'; then
                 DETECT_LEAKS=0
                 echo "Disabling ASan leak detection: Apple's runtime does not support it"
             fi

--- a/sbin/unit-tests
+++ b/sbin/unit-tests
@@ -60,14 +60,19 @@ END
 setup_sanitizer() {
     if [[ $SAN == "address" ]]; then
         ASAN_LOG=${LOGS_DIR}/${TEST_NAME}.asan.log
-        # Apple's ASan runtime has no LeakSanitizer: with detect_leaks=1 every
+        # Apple's ASan runtime — linked from under Xcode.app or
+        # CommandLineTools — has no LeakSanitizer: with detect_leaks=1 every
         # instrumented process aborts before main ("detect_leaks is not
-        # supported on this platform").
-        local detect_leaks=1
-        if [[ $(uname) == Darwin ]]; then
-            detect_leaks=0
+        # supported on this platform"). Other runtimes, like Homebrew LLVM's,
+        # support it, so key off the runtime the binary links, not the OS.
+        if [[ -z $DETECT_LEAKS ]]; then
+            DETECT_LEAKS=1
+            if otool -l "$BINDIR/tests/cpptests/rstest" 2> /dev/null | grep -qE 'Xcode\.app|CommandLineTools'; then
+                DETECT_LEAKS=0
+                echo "Disabling ASan leak detection: Apple's runtime does not support it"
+            fi
         fi
-        export ASAN_OPTIONS="detect_odr_violation=0:alloc_dealloc_mismatch=0:halt_on_error=0:detect_leaks=${detect_leaks}:log_path=${ASAN_LOG}:verbosity=0"
+        export ASAN_OPTIONS="detect_odr_violation=0:alloc_dealloc_mismatch=0:halt_on_error=0:detect_leaks=${DETECT_LEAKS}:log_path=${ASAN_LOG}:verbosity=0"
         export LSAN_OPTIONS="suppressions=$ROOT_DIR/tests/memcheck/asan.supp:verbosity=0"
     elif [[ $SAN == "alignment" ]]; then
         export UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1"

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -157,8 +157,15 @@ setup_clang_sanitizer() {
 	# --no-output-catch --exit-on-failure --check-exitcode
 	RLTEST_SAN_ARGS="--sanitizer $SAN"
 	if [[ $SAN == addr || $SAN == address ]]; then
+		# Apple's ASan runtime has no LeakSanitizer: with detect_leaks=1
+		# every instrumented process aborts before main ("detect_leaks is
+		# not supported on this platform").
+		local detect_leaks=1
+		if [[ $(uname) == Darwin ]]; then
+			detect_leaks=0
+		fi
 		# RLTest places log file details in ASAN_OPTIONS
-		export ASAN_OPTIONS="detect_odr_violation=0:halt_on_error=0:detect_leaks=1:verbosity=0"
+		export ASAN_OPTIONS="detect_odr_violation=0:halt_on_error=0:detect_leaks=${detect_leaks}:verbosity=0"
 		export LSAN_OPTIONS="suppressions=$ROOT/tests/memcheck/asan.supp:print_suppressions=0:verbosity=0"
 		# :use_tls=0
 

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -157,14 +157,14 @@ setup_clang_sanitizer() {
 	# --no-output-catch --exit-on-failure --check-exitcode
 	RLTEST_SAN_ARGS="--sanitizer $SAN"
 	if [[ $SAN == addr || $SAN == address ]]; then
-		# Apple's ASan runtime — linked from under Xcode.app or
-		# CommandLineTools — has no LeakSanitizer: with detect_leaks=1
-		# every instrumented process aborts before main ("detect_leaks is
-		# not supported on this platform"). Other runtimes, like Homebrew
-		# LLVM's, support it, so key off the runtime the module links, not
-		# the OS.
+		# Apple's ASan runtime — linked from under an .xctoolchain (any
+		# Xcode bundle, however renamed) or CommandLineTools — has no
+		# LeakSanitizer: with detect_leaks=1 every instrumented process
+		# aborts before main ("detect_leaks is not supported on this
+		# platform"). Other runtimes, like Homebrew LLVM's, support it, so
+		# key off the runtime the module links, not the OS.
 		local detect_leaks=1
-		if otool -l "$MODULE" 2> /dev/null | grep -qE 'Xcode\.app|CommandLineTools'; then
+		if otool -l "$MODULE" 2> /dev/null | grep -qE '\.xctoolchain|CommandLineTools'; then
 			detect_leaks=0
 			echo "Disabling ASan leak detection: Apple's runtime does not support it"
 		fi

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -157,12 +157,16 @@ setup_clang_sanitizer() {
 	# --no-output-catch --exit-on-failure --check-exitcode
 	RLTEST_SAN_ARGS="--sanitizer $SAN"
 	if [[ $SAN == addr || $SAN == address ]]; then
-		# Apple's ASan runtime has no LeakSanitizer: with detect_leaks=1
+		# Apple's ASan runtime — linked from under Xcode.app or
+		# CommandLineTools — has no LeakSanitizer: with detect_leaks=1
 		# every instrumented process aborts before main ("detect_leaks is
-		# not supported on this platform").
+		# not supported on this platform"). Other runtimes, like Homebrew
+		# LLVM's, support it, so key off the runtime the module links, not
+		# the OS.
 		local detect_leaks=1
-		if [[ $(uname) == Darwin ]]; then
+		if otool -l "$MODULE" 2> /dev/null | grep -qE 'Xcode\.app|CommandLineTools'; then
 			detect_leaks=0
+			echo "Disabling ASan leak detection: Apple's runtime does not support it"
 		fi
 		# RLTest places log file details in ASAN_OPTIONS
 		export ASAN_OPTIONS="detect_odr_violation=0:halt_on_error=0:detect_leaks=${detect_leaks}:verbosity=0"


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: both test runners (`setup_sanitizer` in `sbin/unit-tests`, `setup_clang_sanitizer` in `tests/pytests/runtests.sh`) unconditionally set `detect_leaks=1`. Apple's ASan runtime has no LeakSanitizer, so every instrumented process aborts before `main` with "detect_leaks is not supported on this platform" — a local macOS `SAN=address` run never gets past startup. Whether the flag works depends on the runtime the binary links, not the OS: Homebrew LLVM's runtime has a working LeakSanitizer on macOS.
2. Change: detect Apple's runtime from the binary's load commands — clang adds an `LC_RPATH` entry pointing at its own runtime directory, which for Apple's toolchain always lives under `Xcode.app` or `CommandLineTools`. The runners check a representative instrumented artifact with `otool` (the gtest binary for unit tests, the module `.so` for flow tests) and set `detect_leaks=0` on a match, printing one line since that changes what the run verifies. Verified against executables and shared libraries built with both Apple clang and Homebrew LLVM 22 (including a working leak report from LLVM's runtime on macOS arm64).
3. Outcome: local macOS `SAN=address` runs work with Apple's toolchain (without leak detection, announced) and keep leak detection with an LLVM toolchain. When the check cannot tell — missing binary, no `otool`, including Linux where `otool` does not exist — leak detection stays on, so the `sanitize` CI job is unchanged; a wrong "on" with Apple's runtime fails loudly at startup rather than silently dropping coverage.

#### Which additional issues this PR fixes

1. N/A

#### Main objects this PR modified

1. `setup_sanitizer` (sbin/unit-tests)
2. `setup_clang_sanitizer` (tests/pytests/runtests.sh)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
