### PR TITLE
Require executed sanitizer repros for memory-safety claims in review skills

### DIFF
--- a/.skills/adversarial-review/SKILL.md
+++ b/.skills/adversarial-review/SKILL.md
@@ -106,6 +106,11 @@ interface were updated together.
 You are read-only: do not run ./build.sh, make, or cargo — another agent may be building
 concurrently, and verification is not your job. Reason from the code.
 
+Because you run nothing, any runtime outcome you describe — a sanitizer report, a crash,
+a wrong query result — is a prediction. State it as one ("this should produce ..."), name
+the command that would confirm it, and never quote a report you did not observe as though
+it ran. The requester is responsible for executing it.
+
 Report your findings sorted by severity, each with file and line, the problem, and a
 concrete failure scenario. State explicitly where you could not determine whether
 something is a problem, rather than resolving it in the change's favour.

--- a/.skills/adversarial-review/SKILL.md
+++ b/.skills/adversarial-review/SKILL.md
@@ -106,10 +106,14 @@ interface were updated together.
 You are read-only: do not run ./build.sh, make, or cargo — another agent may be building
 concurrently, and verification is not your job. Reason from the code.
 
-Because you run nothing, any runtime outcome you describe — a sanitizer report, a crash,
-a wrong query result — is a prediction. State it as one ("this should produce ..."), name
-the command that would confirm it, and never quote a report you did not observe as though
-it ran. The requester is responsible for executing it.
+Because you run nothing, a runtime outcome you inferred from reading the code — a
+sanitizer report, a crash, a wrong query result — is a prediction. State it as one ("this
+should produce ..."), name the command that would confirm it, and never present it as
+though you had run it. The requester is responsible for executing it.
+
+An outcome you read out of a CI log or a run artifact is an observation, not a
+prediction: quote it and cite where it came from (job, log path). That is the strongest
+evidence available to you — do not hedge it into a prediction.
 
 Report your findings sorted by severity, each with file and line, the problem, and a
 concrete failure scenario. State explicitly where you could not determine whether

--- a/.skills/verify/SKILL.md
+++ b/.skills/verify/SKILL.md
@@ -42,21 +42,8 @@ Required for changes to command handlers, query execution, indexing pipeline, or
 ./build.sh RUN_UNIT_TESTS SAN=address
 ```
 
-When the change claims to fix a memory-safety bug (out-of-bounds access, use-after-free),
-also demonstrate the bug once on the pre-fix code with an *executed* sanitizer repro —
-a predicted report is not verification. The cheap form needs no ASan build tree: extract
-the affected file at the pre-fix commit and compile a standalone repro against it, e.g.
-
-```bash
-git show <fix-commit>^:src/<file>.c > /tmp/before_fix.c
-clang -fsanitize=address -g -O0 <repro.c> /tmp/before_fix.c -o repro && ./repro
-```
-
-Most `src/` files won't compile standalone as-is: expect to add `-I` paths and stub out
-heavyweight includes (`rm_malloc`, `RS_ABORT`, module headers) with minimal definitions
-in the repro's own directory. That stubbing is usually minutes of work, not hours.
-
-Expect the sanitizer report on the pre-fix build and a clean run on the fixed one.
+If the change claims to fix a memory-safety bug, also follow
+*Memory-safety fixes (either language)* below.
 
 #### 5. Coordinator Tests (if `coord/` code was modified)
 
@@ -95,9 +82,42 @@ cargo nextest run --manifest-path src/redisearch_rs/Cargo.toml
 ```
 All Rust tests must pass.
 
+If the change claims to fix a memory-safety bug, also follow
+*Memory-safety fixes (either language)* below.
+
 ### If both C and Rust were modified
 
 Run all checks from both sections above.
+
+### Memory-safety fixes (either language)
+
+When the change claims to fix a memory-safety bug (out-of-bounds access, use-after-free),
+demonstrate the bug once on the pre-fix code with an *executed* sanitizer repro —
+a predicted report is not verification. Expect the sanitizer report on the pre-fix code
+and a clean run on the fixed one.
+
+For C, the cheap form needs no ASan build tree: extract the affected file at the pre-fix
+revision and compile a standalone repro against it, e.g.
+
+```bash
+git show HEAD:src/<file>.c > /tmp/before_fix.c           # fix not yet committed (the usual case)
+git show <fix-commit>^:src/<file>.c > /tmp/before_fix.c  # fix already committed
+clang -fsanitize=address -g -O0 <repro.c> /tmp/before_fix.c -o repro && ./repro
+```
+
+Most `src/` files won't compile standalone as-is: expect to add `-I` paths and stub out
+heavyweight includes (`rm_malloc`, `RS_ABORT`, module headers) with minimal definitions
+in the repro's own directory. That stubbing is usually minutes of work, not hours.
+
+The repro must build against a consistent pre-fix baseline. If the fix also touches a
+header, macro, or inline helper the extracted file depends on, extract those at the same
+pre-fix revision — compiling a pre-fix `.c` against post-fix headers tests a mixed
+program that can hide the bug or fail for an unrelated reason. When the dependency set
+grows past a few files, a worktree checked out at the pre-fix revision is simpler.
+
+For Rust, run the failing case on the pre-fix code under Miri
+(`cargo +nightly miri test --manifest-path src/redisearch_rs/Cargo.toml -p <crate>`);
+for bugs Miri cannot reach (FFI, foreign memory), use an ASan build of the affected test.
 
 ### Behavioral Tests (for significant changes in either language)
 ```bash

--- a/.skills/verify/SKILL.md
+++ b/.skills/verify/SKILL.md
@@ -118,6 +118,19 @@ grows past a few files, a worktree checked out at the pre-fix revision is simple
 For Rust, run the failing case on the pre-fix code under Miri
 (`cargo +nightly miri test --manifest-path src/redisearch_rs/Cargo.toml -p <crate>`);
 for bugs Miri cannot reach (FFI, foreign memory), use an ASan build of the affected test.
+Single-file extraction does not work here — cargo builds the whole crate — and the
+current checkout already contains the fix, so a Miri run in it only shows the *fixed*
+code is clean. Check out a pre-fix tree first:
+
+```bash
+git worktree add --detach /tmp/prefix_tree HEAD           # fix not yet committed (the usual case)
+git worktree add --detach /tmp/prefix_tree <fix-commit>^  # fix already committed
+```
+
+If the failing test was added alongside the fix, copy the test (and only the test) into
+that tree. Run Miri or ASan with `--manifest-path` pointing at the worktree, expect the
+failure there and a clean run in the fixed checkout, then clean up with
+`git worktree remove --force /tmp/prefix_tree`.
 
 ### Behavioral Tests (for significant changes in either language)
 ```bash

--- a/.skills/verify/SKILL.md
+++ b/.skills/verify/SKILL.md
@@ -42,6 +42,22 @@ Required for changes to command handlers, query execution, indexing pipeline, or
 ./build.sh RUN_UNIT_TESTS SAN=address
 ```
 
+When the change claims to fix a memory-safety bug (out-of-bounds access, use-after-free),
+also demonstrate the bug once on the pre-fix code with an *executed* sanitizer repro —
+a predicted report is not verification. The cheap form needs no ASan build tree: extract
+the affected file at the pre-fix commit and compile a standalone repro against it, e.g.
+
+```bash
+git show <fix-commit>^:src/<file>.c > /tmp/before_fix.c
+clang -fsanitize=address -g -O0 <repro.c> /tmp/before_fix.c -o repro && ./repro
+```
+
+Most `src/` files won't compile standalone as-is: expect to add `-I` paths and stub out
+heavyweight includes (`rm_malloc`, `RS_ABORT`, module headers) with minimal definitions
+in the repro's own directory. That stubbing is usually minutes of work, not hours.
+
+Expect the sanitizer report on the pre-fix build and a clean run on the fixed one.
+
 #### 5. Coordinator Tests (if `coord/` code was modified)
 
 Changes to the coordinator (`src/coord/`), distributed hybrid (`src/coord/hybrid/`), or


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: the review process allows a memory-safety claim to pass review without anyone ever running a sanitizer. An adversarial reviewer is read-only, so any sanitizer report it describes is a prediction — but nothing requires labeling it as one, and a verifier can accept the predicted report as evidence. This gap is part of how the empty-wildcard-pattern out-of-bounds write fixed by #10704 survived review.
2. Change: the adversarial-review skill template now requires any runtime outcome the reviewer describes — a sanitizer report, a crash, a wrong query result — to be stated as a prediction together with the command that would confirm it. The verify skill now requires executing a pre-fix sanitizer repro for any memory-safety fix instead of accepting a predicted report, and sketches how to build one cheaply.
3. Outcome: process-only change; no runtime behavior is affected.

#### Which additional issues this PR fixes

1. N/A

#### Main objects this PR modified

1. `.skills/adversarial-review/SKILL.md`
2. `.skills/verify/SKILL.md`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
