### PR TITLE
[8.6] [MOD-17475] Prevent coordinator crash when FT.HYBRID times out before cursor reads start

### DIFF
--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -604,7 +604,8 @@ void MRIteratorCallback_Done(MRIteratorCallbackCtx *ctx, int error) {
       "depleted(should be false): %d, Pending: (%d), inProcess: %d, itRefCount: %d, channel size: "
       "%zu, target_shard_idx: %hu, target_shard: %s",
       ctx->cmd.depleted, ctx->it->ctx.pending, ctx->it->ctx.inProcess, ctx->it->ctx.itRefCount,
-      MRChannel_Size(ctx->it->ctx.chan), ctx->cmd.targetShardIdx, ctx->cmd.targetShard);
+      MRChannel_Size(ctx->it->ctx.chan), ctx->cmd.targetShardIdx,
+      ctx->cmd.targetShard ? ctx->cmd.targetShard : "(none)");
   ctx->cmd.depleted = true;
   short pending = --ctx->it->ctx.pending; // Decrease `pending` before decreasing `inProcess`
   RS_ASSERT(pending >= 0);
@@ -712,10 +713,8 @@ void iterCursorMappingCb(void *p) {
   WeakRef_Release(data->privateDataRef);
   CursorMappings *vsimOrSearch = StrongRef_Get(mappingsRef);
   if (!vsimOrSearch) {
-    // Cursor mappings have been freed - cannot proceed with command dispatch.
-    // Release the iterator to decrement its reference count and trigger cleanup.
-    // This handles the case where we abort before sending commands to any shards.
-    MRIterator_Release(it);
+    // Complete the provisional callback now that no shard commands will be dispatched.
+    MRIteratorCallback_Done(&it->cbxs[0], 1);
     rm_free(data);
     return;
   }


### PR DESCRIPTION
Backport of #10749 to 8.6.

## Original PR

https://github.com/RediSearch/RediSearch/pull/10749

## Changes from original

1. Current: An FT.HYBRID timeout can release cursor mappings before the queued UV initializer runs, leaving provisional iterator state that can trigger a target-less `_FT.CURSOR DEL` and crash the coordinator.
2. Change: Complete the provisional callback when cursor-mapping promotion fails. The master-only deterministic timeout/debug instrumentation and regression test are omitted because this release branch lacks the required infrastructure.
3. Outcome: Timed-out hybrid requests no longer issue a target-less cursor delete or leak I/O runtime pending-work capacity.

Validation: clean build and all C/C++ unit tests passed (113/113).

#### Which additional issues this PR fixes

1. MOD-17475

#### Main objects this PR modified

1. Hybrid cursor-mapping iterator cancellation
2. Coordinator I/O runtime request accounting

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

Prevents a coordinator crash when FT.HYBRID times out before its shard cursor reads are initialized.
