### PR TITLE
Fix generated header ordering

### DIFF
--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -25,8 +25,6 @@ typedef struct timespec timespec;
 typedef struct AREQ AREQ;
 
 
-typedef struct RedisModuleCtx RedisModuleCtx;
-
 /**
  * Smart pointer handle for [`RLookupKey`] that can be
  * invalidated when the iterator that owns the key is freed.
@@ -108,6 +106,8 @@ typedef struct InvertedIndex InvertedIndex;
 typedef struct NumericRangeTree NumericRangeTree;
 
 typedef struct RLookupKey RLookupKey;
+
+typedef struct RedisModuleCtx RedisModuleCtx;
 
 /**
  * Results returned by a [`ProduceResultsFn`].

--- a/src/redisearch_rs/headers/numeric_range_tree_ffi.h
+++ b/src/redisearch_rs/headers/numeric_range_tree_ffi.h
@@ -33,12 +33,12 @@ typedef enum ApplyGcEntryStatus {
   DeserializationError,
 } ApplyGcEntryStatus;
 
-typedef struct RedisModuleCtx RedisModuleCtx;
-
 /**
  * Filter details to apply to numeric values
  */
 typedef struct NumericFilter NumericFilter;
+
+typedef struct RedisModuleCtx RedisModuleCtx;
 
 /**
  * An opaque inverted index reader structure. The actual implementation is determined at runtime

--- a/src/redisearch_rs/headers/rlookup_ffi.h
+++ b/src/redisearch_rs/headers/rlookup_ffi.h
@@ -10,8 +10,6 @@
 #include "search_result_rs.h"
 #include "rlookup.h"
 
-typedef struct RedisModuleKey RedisModuleKey;
-
 /**
  * The C version of a [`SharedValue`](value::SharedValue)
  */
@@ -23,6 +21,8 @@ typedef struct RSValue RSValue;
  * and a list of fields loaded by the chain
  */
 typedef struct SearchResult SearchResult;
+
+typedef struct RedisModuleKey RedisModuleKey;
 
 typedef struct QueryError QueryError;
 

--- a/src/redisearch_rs/headers/value_ffi.h
+++ b/src/redisearch_rs/headers/value_ffi.h
@@ -26,8 +26,6 @@ typedef enum RSValueType {
   RSValueType_Map = 8,
 } RSValueType;
 
-typedef struct RedisModuleString RedisModuleString;
-
 /**
  * Opaque map structure used during map construction.
  * Holds uninitialized entries that are populated via [`RSValue_MapBuilderSetEntry`]
@@ -39,6 +37,8 @@ typedef struct RSValueMapBuilder RSValueMapBuilder;
  * The C version of a [`SharedValue`](value::SharedValue)
  */
 typedef struct RSValue RSValue;
+
+typedef struct RedisModuleString RedisModuleString;
 
 typedef struct QueryError QueryError;
 


### PR DESCRIPTION
## Describe the changes in the pull request

After commit `b331c68d3e6c26d24a2e9282fd1e3d6b3793351d` ([MOD-15021] Don't have the Rust FFI crate duplicate the redismodule.h definitions) some of the generated headers were not in the order cheadergen would output.

Regenerate the headers so they are corrected.

How this happened and, more importantly, how this slipped through is yet unclear.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


[MOD-15021]: https://redislabs.atlassian.net/browse/MOD-15021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ