### PR TITLE
Align Clang and Rust target triples for LTO

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -415,7 +415,9 @@ prepare_cmake_arguments() {
     # 1. Use CC/CXX/LD if set by user
     # 2. Otherwise, try clang-$VERSION matching Rust's LLVM version
     # 3. Otherwise, fall back to clang/clang++/lld
-    RUSTC_LLVM_VERSION=$(rustc --version --verbose | grep "LLVM version" | awk '{print $3}' | cut -d. -f1)
+    RUSTC_VERBOSE_VERSION=$(rustc --version --verbose)
+    RUSTC_LLVM_VERSION=$(echo "$RUSTC_VERBOSE_VERSION" | sed -n 's/^LLVM version: \([0-9]*\).*/\1/p')
+    RUST_TARGET_TRIPLE=${CARGO_BUILD_TARGET:-$(echo "$RUSTC_VERBOSE_VERSION" | sed -n 's/^host: //p')}
     if [[ -z "$CC" ]]; then
       if command -v "clang-$RUSTC_LLVM_VERSION" &>/dev/null; then
         C_COMPILER="clang-$RUSTC_LLVM_VERSION"
@@ -466,11 +468,12 @@ prepare_cmake_arguments() {
     # Use 'sed -E' for compatibility with both GNU sed and BSD sed
     CLANG_LLVM_VERSION=$($C_COMPILER --version | head -n1 | sed -En 's/.*version ([0-9]+).*/\1/p' | head -n1)
 
-    if [[ -z "$RUSTC_LLVM_VERSION" || -z "$CLANG_LLVM_VERSION" ]]; then
+    if [[ -z "$RUSTC_LLVM_VERSION" || -z "$CLANG_LLVM_VERSION" || -z "$RUST_TARGET_TRIPLE" ]]; then
         echo "Error: Could not detect LLVM versions for rustc and clang."
         echo "Cross-language LTO requires matching LLVM major versions."
         echo "Rust LLVM version: $RUSTC_LLVM_VERSION"
         echo "Clang LLVM version: $CLANG_LLVM_VERSION"
+        echo "Rust target triple: $RUST_TARGET_TRIPLE"
         exit 1
     fi
 
@@ -560,8 +563,13 @@ prepare_cmake_arguments() {
     # branch always compiles with clang, which flags those as
     # -Wunknown-warning-option — a hard error in vendored targets that add
     # -Werror (e.g. VectorSimilarity spaces). Silence that diagnostic.
-    export CFLAGS="${CFLAGS:+${CFLAGS} }-Wno-unknown-warning-option ${GCC_COMMON_FLAGS}"
-    export CXXFLAGS="${CXXFLAGS:+${CXXFLAGS} }-Wno-unknown-warning-option ${GCC_COMMON_FLAGS}${GCC_CXX_FLAGS:+ ${GCC_CXX_FLAGS}}"
+    # LLVM warns once per imported module if the C/C++ and Rust bitcode use
+    # semantically equivalent but differently spelled target triples (for
+    # example, Clang's x86_64-pc-linux-gnu versus Rust's
+    # x86_64-unknown-linux-gnu). Use Rust's effective target for every Clang
+    # invocation, including those issued by Rust `cc` build scripts.
+    export CFLAGS="${CFLAGS:+${CFLAGS} }--target=${RUST_TARGET_TRIPLE} -Wno-unknown-warning-option ${GCC_COMMON_FLAGS}"
+    export CXXFLAGS="${CXXFLAGS:+${CXXFLAGS} }--target=${RUST_TARGET_TRIPLE} -Wno-unknown-warning-option ${GCC_COMMON_FLAGS}${GCC_CXX_FLAGS:+ ${GCC_CXX_FLAGS}}"
     # Export CC/CXX so that Rust's cc crate also uses clang, matching the
     # clang-specific flags in CFLAGS/CXXFLAGS (e.g. --gcc-install-dir).
     export CC="$C_COMPILER"

--- a/build.sh
+++ b/build.sh
@@ -469,8 +469,8 @@ prepare_cmake_arguments() {
     CLANG_LLVM_VERSION=$($C_COMPILER --version | head -n1 | sed -En 's/.*version ([0-9]+).*/\1/p' | head -n1)
 
     if [[ -z "$RUSTC_LLVM_VERSION" || -z "$CLANG_LLVM_VERSION" || -z "$RUST_TARGET_TRIPLE" ]]; then
-        echo "Error: Could not detect LLVM versions for rustc and clang."
-        echo "Cross-language LTO requires matching LLVM major versions."
+        echo "Error: Could not detect LLVM versions or the Rust target triple."
+        echo "Cross-language LTO requires matching LLVM major versions and a Rust target triple."
         echo "Rust LLVM version: $RUSTC_LLVM_VERSION"
         echo "Clang LLVM version: $CLANG_LLVM_VERSION"
         echo "Rust target triple: $RUST_TARGET_TRIPLE"


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Cross-language LTO compiles Rust bitcode for `x86_64-unknown-linux-gnu` while Clang defaults C/C++ bitcode to `x86_64-pc-linux-gnu`. LLD consequently emits a target-triple warning for each imported module.
2. Change: Detect Rust's effective target triple once and pass it to every Clang invocation through `CFLAGS` and `CXXFLAGS`.
3. Outcome: Rust and C/C++ bitcode use the same target triple, removing more than one thousand redundant warnings from LTO builds.

#### Which additional issues this PR fixes

1. N/A

#### Main objects this PR modified

1. Cross-language LTO compiler configuration in `build.sh`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

This is an internal build-system correction with no user-visible behavior change.

#### Verification

- `bash -O extglob -n build.sh`
- `git diff --check`
- [`make build LTO=1`](https://github.com/RediSearch/RediSearch/actions/runs/31178276291/job/92865188033) completed successfully in CI with `--target=x86_64-unknown-linux-gnu` in both `CFLAGS` and `CXXFLAGS`, and with zero "Linking two modules of different target triples" warnings (down from 1,041).
- The subsequent benchmark stage failed independently because `vector_top_k_hybrid.rs` imports the private `RedisModule_Alloc` static; the LTO build step was already complete and green.
