### PR TITLE
Sort generated header declarations by name to stop ordering churn

### DIFF
--- a/src/redisearch_rs/cheadergen.toml
+++ b/src/redisearch_rs/cheadergen.toml
@@ -1,5 +1,6 @@
 pragma_once = true
 usize_is_size_t = true
+sort_by = "name"
 
 [package.ffi]
 types = "skip"

--- a/src/redisearch_rs/headers/fnv_ffi.h
+++ b/src/redisearch_rs/headers/fnv_ffi.h
@@ -13,18 +13,6 @@ extern "C" {
 #endif // __cplusplus
 
 /**
- * Returns the 32-bit [FNV-1a hash] of `buf` of length `len` using an [offset basis] `hval`.
- *
- * # Safety
- *
- * 1. `buf` must point to a valid region of memory of length `len`.
- *
- * [FNV-1a hash]: http://www.isthe.com/chongo/tech/comp/fnv/#FNV-1a
- * [offset basis]: http://www.isthe.com/chongo/tech/comp/fnv/#FNV-param
- */
-uint32_t rs_fnv_32a_buf(const void *buf, size_t len, uint32_t hval);
-
-/**
  * Returns the 64-bit [FNV-1a hash] of `buf` of length `len` using an [offset basis] `hval`.
  *
  * # Safety
@@ -35,6 +23,18 @@ uint32_t rs_fnv_32a_buf(const void *buf, size_t len, uint32_t hval);
  * [offset basis]: http://www.isthe.com/chongo/tech/comp/fnv/#FNV-param
  */
 uint64_t fnv_64a_buf(const void *buf, size_t len, uint64_t hval);
+
+/**
+ * Returns the 32-bit [FNV-1a hash] of `buf` of length `len` using an [offset basis] `hval`.
+ *
+ * # Safety
+ *
+ * 1. `buf` must point to a valid region of memory of length `len`.
+ *
+ * [FNV-1a hash]: http://www.isthe.com/chongo/tech/comp/fnv/#FNV-1a
+ * [offset basis]: http://www.isthe.com/chongo/tech/comp/fnv/#FNV-param
+ */
+uint32_t rs_fnv_32a_buf(const void *buf, size_t len, uint32_t hval);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/fork_gc_ffi.h
+++ b/src/redisearch_rs/headers/fork_gc_ffi.h
@@ -41,28 +41,6 @@ extern "C" {
 #endif // __cplusplus
 
 /**
- * Collect GC delta data for every numeric and geo field in the spec and send
- * it to the parent process over the pipe.
- *
- * For each NUMERIC or GEO field whose tree has been initialised, sends the
- * field name and unique ID as a header, followed by one entry per tree node
- * with GC work, then a per-field terminator. A final terminator is sent once
- * all fields have been processed.
- *
- * # Panic
- *
- * Panics if `pipe_write_fd` on `gc` is an invalid or closed writable file descriptor.
- *
- * # Safety
- *
- * 1. `gc` must point to a valid [`ffi::ForkGC`].
- * 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`].
- * 3. `sctx.spec` must be a non-null pointer to a valid [`ffi::IndexSpec`].
- * 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
- */
-void FGC_childCollectNumeric(ForkGC *gc, RedisSearchCtx *sctx);
-
-/**
  * Collect GC delta data for the spec's `existingDocs` inverted index and
  * send it to the parent process over the pipe.
  *
@@ -106,19 +84,38 @@ void FGC_childCollectExistingDocs(ForkGC *gc, RedisSearchCtx *sctx);
 void FGC_childCollectMissingDocs(ForkGC *gc, RedisSearchCtx *sctx);
 
 /**
- * Write exactly `len` bytes from `buff` to the FGC pipe.
+ * Collect GC delta data for every numeric and geo field in the spec and send
+ * it to the parent process over the pipe.
  *
- * On error, logs the failure and terminates the child process via
- * `RedisModule_ExitFromChild(1)`.
+ * For each NUMERIC or GEO field whose tree has been initialised, sends the
+ * field name and unique ID as a header, followed by one entry per tree node
+ * with GC work, then a per-field terminator. A final terminator is sent once
+ * all fields have been processed.
+ *
+ * # Panic
+ *
+ * Panics if `pipe_write_fd` on `gc` is an invalid or closed writable file descriptor.
  *
  * # Safety
  *
- * 1. `fgc` must point to a valid `ForkGC` whose `pipe_write_fd` is an open,
- *    writable file descriptor.
- * 2. `buff` must point to a readable region of at least `len` bytes.
- * 3. `len` must be greater than zero.
+ * 1. `gc` must point to a valid [`ffi::ForkGC`].
+ * 2. `sctx` must point to a valid [`ffi::RedisSearchCtx`].
+ * 3. `sctx.spec` must be a non-null pointer to a valid [`ffi::IndexSpec`].
+ * 4. This function should only be called when it has exclusive access to the [`ffi::IndexSpec`].
  */
-void FGC_sendFixed(ForkGC *fgc, const void *buff, size_t len);
+void FGC_childCollectNumeric(ForkGC *gc, RedisSearchCtx *sctx);
+
+/**
+ * Free a buffer previously returned by [`FGC_recvBuffer`] or [`recvFieldHeader`].
+ *
+ * No-ops for null pointers (returned for both the terminator and empty-frame cases).
+ *
+ * # Safety
+ *
+ * 1. `buf` and `len` must be the pointer and length returned by a prior call to
+ *    [`FGC_recvBuffer`] or [`recvFieldHeader`], and must not have been freed before.
+ */
+void FGC_freeBuffer(void *buf, size_t len);
 
 /**
  * Receive and apply the GC delta for the spec's `existingDocs` inverted index.
@@ -161,52 +158,6 @@ enum FGCError FGC_parentHandleExistingDocs(ForkGC *gc);
 enum FGCError FGC_parentHandleMissingDocs(ForkGC *gc);
 
 /**
- * Write a length-prefixed buffer frame: a native-endian `size_t` header
- * followed by `len` payload bytes.
- *
- * On error, logs the failure and terminates the child process via
- * `RedisModule_ExitFromChild(1)`.
- *
- * # Safety
- *
- * 1. `fgc` must point to a valid `ForkGC` whose `pipe_write_fd` is an open,
- *    writable file descriptor.
- * 2. If `len > 0`, `buff` must point to a readable region of at least
- *    `len` bytes. When `len == 0`, `buff` is unused and may be anything
- *    (including NULL).
- */
-void FGC_sendBuffer(ForkGC *fgc, const void *buff, size_t len);
-
-/**
- * Write the end-of-stream sentinel, signalling to the parent reader
- * that no more buffers will follow.
- *
- * On error, logs the failure and terminates the child process via
- * `RedisModule_ExitFromChild(1)`.
- *
- * # Safety
- *
- * 1. `fgc` must point to a valid `ForkGC` whose `pipe_write_fd` is an open,
- *    writable file descriptor.
- */
-void FGC_sendTerminator(ForkGC *fgc);
-
-/**
- * Read exactly `len` bytes from the FGC pipe into `buf`.
- *
- * Polls the pipe fd with a 3-minute timeout and retries on `EINTR`. On
- * timeout, read error, or unexpected EOF, logs a detailed warning
- * (matching the original C format) and returns `REDISMODULE_ERR`.
- *
- * # Safety
- *
- * 1. `fgc` must point to a valid `ForkGC` whose `pipe_read_fd` is an open,
- *    readable file descriptor.
- * 2. `buf` must point to a writable region of at least `len` bytes.
- */
-int FGC_recvFixed(ForkGC *fgc, void *buf, size_t len);
-
-/**
  * Read a length-prefixed buffer frame from the FGC pipe.
  *
  * On receipt of a `SIZE_MAX` length prefix (end-of-stream terminator), writes
@@ -230,6 +181,67 @@ int FGC_recvFixed(ForkGC *fgc, void *buf, size_t len);
 int FGC_recvBuffer(ForkGC *fgc, void * *buf, size_t *len);
 
 /**
+ * Read exactly `len` bytes from the FGC pipe into `buf`.
+ *
+ * Polls the pipe fd with a 3-minute timeout and retries on `EINTR`. On
+ * timeout, read error, or unexpected EOF, logs a detailed warning
+ * (matching the original C format) and returns `REDISMODULE_ERR`.
+ *
+ * # Safety
+ *
+ * 1. `fgc` must point to a valid `ForkGC` whose `pipe_read_fd` is an open,
+ *    readable file descriptor.
+ * 2. `buf` must point to a writable region of at least `len` bytes.
+ */
+int FGC_recvFixed(ForkGC *fgc, void *buf, size_t len);
+
+/**
+ * Write a length-prefixed buffer frame: a native-endian `size_t` header
+ * followed by `len` payload bytes.
+ *
+ * On error, logs the failure and terminates the child process via
+ * `RedisModule_ExitFromChild(1)`.
+ *
+ * # Safety
+ *
+ * 1. `fgc` must point to a valid `ForkGC` whose `pipe_write_fd` is an open,
+ *    writable file descriptor.
+ * 2. If `len > 0`, `buff` must point to a readable region of at least
+ *    `len` bytes. When `len == 0`, `buff` is unused and may be anything
+ *    (including NULL).
+ */
+void FGC_sendBuffer(ForkGC *fgc, const void *buff, size_t len);
+
+/**
+ * Write exactly `len` bytes from `buff` to the FGC pipe.
+ *
+ * On error, logs the failure and terminates the child process via
+ * `RedisModule_ExitFromChild(1)`.
+ *
+ * # Safety
+ *
+ * 1. `fgc` must point to a valid `ForkGC` whose `pipe_write_fd` is an open,
+ *    writable file descriptor.
+ * 2. `buff` must point to a readable region of at least `len` bytes.
+ * 3. `len` must be greater than zero.
+ */
+void FGC_sendFixed(ForkGC *fgc, const void *buff, size_t len);
+
+/**
+ * Write the end-of-stream sentinel, signalling to the parent reader
+ * that no more buffers will follow.
+ *
+ * On error, logs the failure and terminates the child process via
+ * `RedisModule_ExitFromChild(1)`.
+ *
+ * # Safety
+ *
+ * 1. `fgc` must point to a valid `ForkGC` whose `pipe_write_fd` is an open,
+ *    writable file descriptor.
+ */
+void FGC_sendTerminator(ForkGC *fgc);
+
+/**
  * Receive a field header (field name + unique id).
  *
  * Returns `FGC_COLLECTED` on success, `FGC_DONE` when no more fields remain,
@@ -246,18 +258,6 @@ int FGC_recvBuffer(ForkGC *fgc, void * *buf, size_t *len);
  * 3. `id_ptr` must point to a writable `uint64_t` location.
  */
 enum FGCError recvFieldHeader(ForkGC *fgc, char * *field_name, size_t *field_name_len, uint64_t *id_ptr);
-
-/**
- * Free a buffer previously returned by [`FGC_recvBuffer`] or [`recvFieldHeader`].
- *
- * No-ops for null pointers (returned for both the terminator and empty-frame cases).
- *
- * # Safety
- *
- * 1. `buf` and `len` must be the pointer and length returned by a prior call to
- *    [`FGC_recvBuffer`] or [`recvFieldHeader`], and must not have been freed before.
- */
-void FGC_freeBuffer(void *buf, size_t len);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/geo_ffi.h
+++ b/src/redisearch_rs/headers/geo_ffi.h
@@ -17,9 +17,9 @@
 typedef struct QueryError QueryError;
 
 /**
- * The number of geohash ranges: the center cell plus its 8 neighbors.
+ * WGS-84 latitude upper bound (EPSG:900913).
  */
-#define GEO_RANGE_COUNT 9
+#define GEO_LAT_MAX 85.051128779999999
 
 /**
  * WGS-84 latitude lower bound (EPSG:900913).
@@ -27,9 +27,9 @@ typedef struct QueryError QueryError;
 #define GEO_LAT_MIN -85.051128779999999
 
 /**
- * WGS-84 latitude upper bound (EPSG:900913).
+ * WGS-84 longitude upper bound.
  */
-#define GEO_LAT_MAX 85.051128779999999
+#define GEO_LONG_MAX 180.0
 
 /**
  * WGS-84 longitude lower bound.
@@ -37,22 +37,13 @@ typedef struct QueryError QueryError;
 #define GEO_LONG_MIN -180.0
 
 /**
- * WGS-84 longitude upper bound.
+ * The number of geohash ranges: the center cell plus its 8 neighbors.
  */
-#define GEO_LONG_MAX 180.0
+#define GEO_RANGE_COUNT 9
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
-
-/**
- * Encode longitude and latitude into a 52-bit-aligned geohash score,
- * or return `INVALID_GEOHASH` (`-1.0`) on invalid coordinates.
- *
- * Valid geohash scores are non-negative, so any negative return value
- * signals an error.
- */
-double encodeGeo(double lon, double lat);
 
 /**
  * Decode a geohash `f64` back into a `[longitude, latitude]` pair.
@@ -65,6 +56,15 @@ double encodeGeo(double lon, double lat);
  * - `xy` must be a valid, non-null pointer to a writable `[f64; 2]`.
  */
 void decodeGeo(double bits, double *xy);
+
+/**
+ * Encode longitude and latitude into a 52-bit-aligned geohash score,
+ * or return `INVALID_GEOHASH` (`-1.0`) on invalid coordinates.
+ *
+ * Valid geohash scores are non-negative, so any negative return value
+ * signals an error.
+ */
+double encodeGeo(double lon, double lat);
 
 /**
  * Calculate the haversine great-circle distance between two WGS-84 points.

--- a/src/redisearch_rs/headers/inverted_index_ffi.h
+++ b/src/redisearch_rs/headers/inverted_index_ffi.h
@@ -82,105 +82,208 @@ extern "C" {
 #endif // __cplusplus
 
 /**
- * Create a new inverted index instance based on the provided flags and options. `raw_doc_encoding`
- * controls whether document IDs only encoding should use raw encoding (true) or varint encoding
- * (false). `compress_floats` controls whether numeric encoding should have its floating point
- * numbers compressed (true) or not (false). Compressing floating point numbers saves memory
- * but lowers precision.
- *
- * The output parameter `mem_size` will be set to the memory usage of the created index. The
- * inverted index should be freed using [`InvertedIndex_Free`] when no longer needed.
+ * Get the index of the last block in the GC delta.
  *
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `mem_size` must be a valid pointer to a `usize`.
- *
- * # Panics
- * This function will panic if the provided flags does not set at least one of the following
- * storage flags:
- * - `StoreFreqs`
- * - `StoreFieldFlags`
- * - `StoreTermOffsets`
- * - `StoreNumeric`
- * - `DocIdsOnly`
+ * - `gc_scan_delta` must be a valid, non NULL, pointer to a `GcScanDelta` instance.
  */
-struct InvertedIndex *NewInvertedIndex_Ex(IndexFlags flags, bool raw_doc_id_encoding, bool compress_floats, size_t *mem_size);
+size_t GcScanDelta_LastBlockIdx(const struct InvertedIndexGcDelta *gc_scan_delta);
 
 /**
- * Free the memory associated with an inverted index instance created using [`NewInvertedIndex_Ex`].
+ * Get a pointer to the raw data of the index block. This is used by some C tests.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
+ */
+const char *IndexBlock_Data(const struct IndexBlock *ib);
+
+/**
+ * Get ID of the first document in the index block. This is used by some C tests.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
+ */
+t_docId IndexBlock_FirstId(const struct IndexBlock *ib);
+
+/**
+ * Get ID of the last document in the index block. This is used by some C tests.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
+ */
+t_docId IndexBlock_LastId(const struct IndexBlock *ib);
+
+/**
+ * Get the number of entries in the index block. This is used by some C tests.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
+ */
+uint16_t IndexBlock_NumEntries(const struct IndexBlock *ib);
+
+/**
+ * Get the flags used to create the inverted index of the reader.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ */
+IndexFlags IndexReader_Flags(const struct IndexReader *ir);
+
+/**
+ * Free the memory associated with an index reader instance created using [`NewIndexReader`].
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance created using
+ *   [`NewIndexReader`].
+ */
+void IndexReader_Free(struct IndexReader *ir);
+
+/**
+ * Check if the index reader can return multiple entries for the same document ID.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ */
+bool IndexReader_HasMulti(const struct IndexReader *ir);
+
+/**
+ * Check if the index reader can read from the given inverted index. This is true if the index
+ * reader was created for the same type of index as the given inverted index.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ * - `ii` must be either NULL or a valid pointer to an `InvertedIndex` instance.
+ */
+bool IndexReader_IsIndex(const struct IndexReader *ir, const struct InvertedIndex *ii);
+
+/**
+ * Advance the index reader to the next entry in the index. If there is a next entry, it will be
+ * written to the output parameter `res` and the function will return true. If there are no more
+ * entries, the function will return false.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ * - `res` must be a valid pointer to an `RSIndexResult` instance.
+ */
+bool IndexReader_Next(struct IndexReader *ir, RSIndexResult *res);
+
+/**
+ * Get the estimated number of documents in the index reader.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ */
+uint64_t IndexReader_NumEstimated(const struct IndexReader *ir);
+
+/**
+ * Get a pointer to the numeric filter used by the index reader. If the index reader does not use
+ * a numeric filter, the function will return NULL.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ */
+const struct NumericFilter *IndexReader_NumericFilter(const struct IndexReader *ir);
+
+/**
+ * Reset the index reader to the beginning of the index.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ */
+void IndexReader_Reset(struct IndexReader *ir);
+
+/**
+ * Revalidate the index reader against its inverted index. This is only needed if the inverted index
+ * has been modified since the last time the reader was used. The function returns true if the
+ * reader needs revalidation, false otherwise.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ */
+bool IndexReader_Revalidate(struct IndexReader *ir);
+
+/**
+ * Seek the index reader to the entry with the given document ID. If such an entry exists, it will be
+ * written to the output parameter `res` and the function will return true. If there is no entry
+ * with the given document ID, but there are entries with higher document IDs, the next higher
+ * entry will be written to `res` and the function will return true. If there are no more entries
+ * with document IDs greater than or equal to the given document ID, the function will return false.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ * - `res` must be a valid pointer to an `RSIndexResult` instance.
+ */
+bool IndexReader_Seek(struct IndexReader *ir, t_docId doc_id, RSIndexResult *res);
+
+/**
+ * Skip the internal block of the inverted index reader to the block that may contain the given
+ * document ID. If such a block exists, the function returns true and the next call to
+ * `IndexReader_Seek` will return the entry for the given document ID or the next higher document
+ * ID. If the document ID is beyond the last document in the index, the function returns false.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ */
+bool IndexReader_SkipTo(struct IndexReader *ir, t_docId doc_id);
+
+/**
+ * Apply a GC delta to the inverted index. The output parameter `apply_info` will be set to
+ * information about the applied delta — in particular, `apply_info.block_count_delta` carries
+ * the signed change in block count, which callers maintaining per-spec totals should add to
+ * their counter.
+ *
+ * This will take ownership of the `deltas` pointer and free it. Therefore, it should not be
+ * used or freed after calling this function.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+ * - `deltas` must be a valid, non NULL, pointer to a `GcScanDelta` instance created using
+ *   [`InvertedIndex_GcDelta_Read`].
+ * - `apply_info` must be a valid, non NULL, pointer to a `GcApplyInfo` instance.
+ */
+void InvertedIndex_ApplyGCDelta(struct InvertedIndex *ii, struct InvertedIndexGcDelta *deltas, struct II_GCScanStats *apply_info);
+
+/**
+ * Get a reference to the block at the specified index. Returns NULL if the index is out of bounds.
+ * This is used by some C tests.
  *
  * # Safety
  * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance created using
- *   [`NewInvertedIndex_Ex`] or `NewInvertedIndex`.
- */
-void InvertedIndex_Free(struct InvertedIndex *ii);
-
-/**
- * Get the memory usage of the inverted index instance in bytes.
- *
- * # Safety
- * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and must not be NULL.
- */
-size_t InvertedIndex_MemUsage(const struct InvertedIndex *ii);
-
-/**
- * Write a new numeric entry to the inverted index. This is only valid for numeric indexes
- * created with the `StoreNumeric` flag. Returns an [`AddRecordOutcome`] reporting the memory
- * growth and the number of new index blocks created.
- *
- * # Safety
  * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
  */
-struct AddRecordOutcome InvertedIndex_WriteNumericEntry(struct InvertedIndex *ii, t_docId doc_id, double value);
-
-/**
- * Write a new entry to the inverted index. Returns an [`AddRecordOutcome`] reporting the
- * memory growth and the number of new index blocks created.
- *
- * # Safety
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
- * - `record` must be a valid pointer to an `RSIndexResult` instance and cannot be NULL.
- */
-struct AddRecordOutcome InvertedIndex_WriteEntryGeneric(struct InvertedIndex *ii, const RSIndexResult *record);
-
-/**
- * Return the number of blocks in the inverted index.
- *
- * # Safety
- * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
- */
-size_t InvertedIndex_NumBlocks(const struct InvertedIndex *ii);
-
-/**
- * Get the flags used to create the inverted index.
- *
- * # Safety
- * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
- */
-IndexFlags InvertedIndex_Flags(const struct InvertedIndex *ii);
-
-/**
- * Get the number of unique documents in the inverted index.
- *
- * # Safety
- * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
- */
-uint32_t InvertedIndex_NumDocs(const struct InvertedIndex *ii);
-
-/**
- * Get a summary of the inverted index for debugging purposes.
- *
- * # Safety
- * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
- */
-struct IISummary InvertedIndex_Summary(const struct InvertedIndex *ii);
+const struct IndexBlock *InvertedIndex_BlockRef(const struct InvertedIndex *ii, size_t block_idx);
 
 /**
  * Get an array of summaries of all blocks in the inverted index. The output parameter `count` will
@@ -217,34 +320,61 @@ void InvertedIndex_BlocksSummaryFree(struct IIBlockSummary *blocks, size_t count
 t_fieldMask InvertedIndex_FieldMask(const struct InvertedIndex *ii);
 
 /**
- * Get the number of entries in the inverted index. This is only valid for numeric indexes created
- * with the `StoreNumeric` flag. For other index types, this function will return 0.
+ * Get the flags used to create the inverted index.
  *
  * # Safety
  * The following invariant must be upheld when calling this function:
  * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
  */
-size_t InvertedIndex_NumEntries(const struct InvertedIndex *ii);
+IndexFlags InvertedIndex_Flags(const struct InvertedIndex *ii);
 
 /**
- * Get a reference to the block at the specified index. Returns NULL if the index is out of bounds.
- * This is used by some C tests.
+ * Free the memory associated with an inverted index instance created using [`NewInvertedIndex_Ex`].
  *
  * # Safety
  * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+ * - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance created using
+ *   [`NewInvertedIndex_Ex`] or `NewInvertedIndex`.
  */
-const struct IndexBlock *InvertedIndex_BlockRef(const struct InvertedIndex *ii, size_t block_idx);
+void InvertedIndex_Free(struct InvertedIndex *ii);
 
 /**
- * Get ID of the last document in the index. Returns 0 if the index is empty.
- * This is used by some C tests.
+ * Free the memory associated with a GC delta instance created using [`InvertedIndex_GcDelta_Read`].
  *
  * # Safety
+ *
  * The following invariant must be upheld when calling this function:
- * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+ * - `deltas` must be a valid pointer to a `GcScanDelta` instance created using
+ *   [`InvertedIndex_GcDelta_Read`], or NULL.
  */
-t_docId InvertedIndex_LastId(const struct InvertedIndex *ii);
+void InvertedIndex_GcDelta_Free(struct InvertedIndexGcDelta *deltas);
+
+/**
+ * Read a GC delta from the provided reader. The returned pointer must be freed using
+ * [`InvertedIndex_GcDelta_Free`] or should be passed to [`InvertedIndex_ApplyGCDelta`].
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `rd` must be a valid, non NULL, pointer to an `InvertedIndexGCReader` instance.
+ */
+struct InvertedIndexGcDelta *InvertedIndex_GcDelta_Read(struct II_GCReader *rd);
+
+/**
+ * Scan the inverted index for garbage and write the GC delta to the provided writer. The function
+ * returns true if the scan was successful and false otherwise.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `wr` must be a valid, non NULL, pointer to an `InvertedIndexGCWriter` instance.
+ * - `sctx` must be a valid, non NULL, pointer to a `RedisSearchCtx` instance.
+ * - `idx` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+ * - `cb` must be a valid, non NULL, pointer to an `InvertedIndexGCCallback` instance.
+ * - The `spec` field of the `RedisSearchCtx` must be a valid, non NULL, pointer to an
+ *   `IndexSpec` instance.
+ */
+bool InvertedIndex_GcDelta_Scan(struct II_GCWriter *wr, RedisSearchCtx *sctx, struct InvertedIndex *idx, struct II_GCCallback *cb);
 
 /**
  * Get the garbage collector marker of the inverted index. This is used by some C tests.
@@ -267,111 +397,80 @@ uint32_t InvertedIndex_GcMarker(const struct InvertedIndex *ii);
 void InvertedIndex_GcMarkerInc(struct InvertedIndex *ii);
 
 /**
- * Scan the inverted index for garbage and write the GC delta to the provided writer. The function
- * returns true if the scan was successful and false otherwise.
+ * Get ID of the last document in the index. Returns 0 if the index is empty.
+ * This is used by some C tests.
  *
  * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `wr` must be a valid, non NULL, pointer to an `InvertedIndexGCWriter` instance.
- * - `sctx` must be a valid, non NULL, pointer to a `RedisSearchCtx` instance.
- * - `idx` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
- * - `cb` must be a valid, non NULL, pointer to an `InvertedIndexGCCallback` instance.
- * - The `spec` field of the `RedisSearchCtx` must be a valid, non NULL, pointer to an
- *   `IndexSpec` instance.
- */
-bool InvertedIndex_GcDelta_Scan(struct II_GCWriter *wr, RedisSearchCtx *sctx, struct InvertedIndex *idx, struct II_GCCallback *cb);
-
-/**
- * Read a GC delta from the provided reader. The returned pointer must be freed using
- * [`InvertedIndex_GcDelta_Free`] or should be passed to [`InvertedIndex_ApplyGCDelta`].
- *
- * # Safety
- *
  * The following invariant must be upheld when calling this function:
- * - `rd` must be a valid, non NULL, pointer to an `InvertedIndexGCReader` instance.
+ * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
  */
-struct InvertedIndexGcDelta *InvertedIndex_GcDelta_Read(struct II_GCReader *rd);
+t_docId InvertedIndex_LastId(const struct InvertedIndex *ii);
 
 /**
- * Free the memory associated with a GC delta instance created using [`InvertedIndex_GcDelta_Read`].
+ * Get the memory usage of the inverted index instance in bytes.
  *
  * # Safety
- *
  * The following invariant must be upheld when calling this function:
- * - `deltas` must be a valid pointer to a `GcScanDelta` instance created using
- *   [`InvertedIndex_GcDelta_Read`], or NULL.
+ * - `ii` must be a valid pointer to an `InvertedIndex` instance and must not be NULL.
  */
-void InvertedIndex_GcDelta_Free(struct InvertedIndexGcDelta *deltas);
+size_t InvertedIndex_MemUsage(const struct InvertedIndex *ii);
 
 /**
- * Apply a GC delta to the inverted index. The output parameter `apply_info` will be set to
- * information about the applied delta — in particular, `apply_info.block_count_delta` carries
- * the signed change in block count, which callers maintaining per-spec totals should add to
- * their counter.
- *
- * This will take ownership of the `deltas` pointer and free it. Therefore, it should not be
- * used or freed after calling this function.
+ * Return the number of blocks in the inverted index.
  *
  * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
- * - `deltas` must be a valid, non NULL, pointer to a `GcScanDelta` instance created using
- *   [`InvertedIndex_GcDelta_Read`].
- * - `apply_info` must be a valid, non NULL, pointer to a `GcApplyInfo` instance.
- */
-void InvertedIndex_ApplyGCDelta(struct InvertedIndex *ii, struct InvertedIndexGcDelta *deltas, struct II_GCScanStats *apply_info);
-
-/**
- * Get the index of the last block in the GC delta.
- *
- * # Safety
- *
  * The following invariant must be upheld when calling this function:
- * - `gc_scan_delta` must be a valid, non NULL, pointer to a `GcScanDelta` instance.
+ * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
  */
-size_t GcScanDelta_LastBlockIdx(const struct InvertedIndexGcDelta *gc_scan_delta);
+size_t InvertedIndex_NumBlocks(const struct InvertedIndex *ii);
 
 /**
- * Get ID of the first document in the index block. This is used by some C tests.
+ * Get the number of unique documents in the inverted index.
  *
  * # Safety
- *
  * The following invariant must be upheld when calling this function:
- * - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
+ * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
  */
-t_docId IndexBlock_FirstId(const struct IndexBlock *ib);
+uint32_t InvertedIndex_NumDocs(const struct InvertedIndex *ii);
 
 /**
- * Get ID of the last document in the index block. This is used by some C tests.
+ * Get the number of entries in the inverted index. This is only valid for numeric indexes created
+ * with the `StoreNumeric` flag. For other index types, this function will return 0.
  *
  * # Safety
- *
  * The following invariant must be upheld when calling this function:
- * - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
+ * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
  */
-t_docId IndexBlock_LastId(const struct IndexBlock *ib);
+size_t InvertedIndex_NumEntries(const struct InvertedIndex *ii);
 
 /**
- * Get the number of entries in the index block. This is used by some C tests.
+ * Get a summary of the inverted index for debugging purposes.
  *
  * # Safety
- *
  * The following invariant must be upheld when calling this function:
- * - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
+ * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
  */
-uint16_t IndexBlock_NumEntries(const struct IndexBlock *ib);
+struct IISummary InvertedIndex_Summary(const struct InvertedIndex *ii);
 
 /**
- * Get a pointer to the raw data of the index block. This is used by some C tests.
+ * Write a new entry to the inverted index. Returns an [`AddRecordOutcome`] reporting the
+ * memory growth and the number of new index blocks created.
  *
  * # Safety
- *
- * The following invariant must be upheld when calling this function:
- * - `ib` must be a valid pointer to an `IndexBlock` instance and cannot be NULL.
+ * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+ * - `record` must be a valid pointer to an `RSIndexResult` instance and cannot be NULL.
  */
-const char *IndexBlock_Data(const struct IndexBlock *ib);
+struct AddRecordOutcome InvertedIndex_WriteEntryGeneric(struct InvertedIndex *ii, const RSIndexResult *record);
+
+/**
+ * Write a new numeric entry to the inverted index. This is only valid for numeric indexes
+ * created with the `StoreNumeric` flag. Returns an [`AddRecordOutcome`] reporting the memory
+ * growth and the number of new index blocks created.
+ *
+ * # Safety
+ * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
+ */
+struct AddRecordOutcome InvertedIndex_WriteNumericEntry(struct InvertedIndex *ii, t_docId doc_id, double value);
 
 /**
  * Create a new inverted index reader for the given inverted index and filter. The returned pointer
@@ -388,129 +487,30 @@ const char *IndexBlock_Data(const struct IndexBlock *ib);
 struct IndexReader *NewIndexReader(const struct InvertedIndex *ii, union IndexDecoderCtx ctx);
 
 /**
- * Free the memory associated with an index reader instance created using [`NewIndexReader`].
+ * Create a new inverted index instance based on the provided flags and options. `raw_doc_encoding`
+ * controls whether document IDs only encoding should use raw encoding (true) or varint encoding
+ * (false). `compress_floats` controls whether numeric encoding should have its floating point
+ * numbers compressed (true) or not (false). Compressing floating point numbers saves memory
+ * but lowers precision.
+ *
+ * The output parameter `mem_size` will be set to the memory usage of the created index. The
+ * inverted index should be freed using [`InvertedIndex_Free`] when no longer needed.
  *
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance created using
- *   [`NewIndexReader`].
+ * - `mem_size` must be a valid pointer to a `usize`.
+ *
+ * # Panics
+ * This function will panic if the provided flags does not set at least one of the following
+ * storage flags:
+ * - `StoreFreqs`
+ * - `StoreFieldFlags`
+ * - `StoreTermOffsets`
+ * - `StoreNumeric`
+ * - `DocIdsOnly`
  */
-void IndexReader_Free(struct IndexReader *ir);
-
-/**
- * Reset the index reader to the beginning of the index.
- *
- * # Safety
- *
- * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
- */
-void IndexReader_Reset(struct IndexReader *ir);
-
-/**
- * Get the estimated number of documents in the index reader.
- *
- * # Safety
- *
- * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
- */
-uint64_t IndexReader_NumEstimated(const struct IndexReader *ir);
-
-/**
- * Check if the index reader can read from the given inverted index. This is true if the index
- * reader was created for the same type of index as the given inverted index.
- *
- * # Safety
- * The following invariants must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
- * - `ii` must be either NULL or a valid pointer to an `InvertedIndex` instance.
- */
-bool IndexReader_IsIndex(const struct IndexReader *ir, const struct InvertedIndex *ii);
-
-/**
- * Advance the index reader to the next entry in the index. If there is a next entry, it will be
- * written to the output parameter `res` and the function will return true. If there are no more
- * entries, the function will return false.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
- * - `res` must be a valid pointer to an `RSIndexResult` instance.
- */
-bool IndexReader_Next(struct IndexReader *ir, RSIndexResult *res);
-
-/**
- * Skip the internal block of the inverted index reader to the block that may contain the given
- * document ID. If such a block exists, the function returns true and the next call to
- * `IndexReader_Seek` will return the entry for the given document ID or the next higher document
- * ID. If the document ID is beyond the last document in the index, the function returns false.
- *
- * # Safety
- *
- * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
- */
-bool IndexReader_SkipTo(struct IndexReader *ir, t_docId doc_id);
-
-/**
- * Seek the index reader to the entry with the given document ID. If such an entry exists, it will be
- * written to the output parameter `res` and the function will return true. If there is no entry
- * with the given document ID, but there are entries with higher document IDs, the next higher
- * entry will be written to `res` and the function will return true. If there are no more entries
- * with document IDs greater than or equal to the given document ID, the function will return false.
- *
- * # Safety
- * The following invariants must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
- * - `res` must be a valid pointer to an `RSIndexResult` instance.
- */
-bool IndexReader_Seek(struct IndexReader *ir, t_docId doc_id, RSIndexResult *res);
-
-/**
- * Check if the index reader can return multiple entries for the same document ID.
- *
- * # Safety
- *
- * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
- */
-bool IndexReader_HasMulti(const struct IndexReader *ir);
-
-/**
- * Get the flags used to create the inverted index of the reader.
- *
- * # Safety
- *
- * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
- */
-IndexFlags IndexReader_Flags(const struct IndexReader *ir);
-
-/**
- * Get a pointer to the numeric filter used by the index reader. If the index reader does not use
- * a numeric filter, the function will return NULL.
- *
- * # Safety
- *
- * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
- */
-const struct NumericFilter *IndexReader_NumericFilter(const struct IndexReader *ir);
-
-/**
- * Revalidate the index reader against its inverted index. This is only needed if the inverted index
- * has been modified since the last time the reader was used. The function returns true if the
- * reader needs revalidation, false otherwise.
- *
- * # Safety
- *
- * The following invariant must be upheld when calling this function:
- * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
- */
-bool IndexReader_Revalidate(struct IndexReader *ir);
+struct InvertedIndex *NewInvertedIndex_Ex(IndexFlags flags, bool raw_doc_id_encoding, bool compress_floats, size_t *mem_size);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/iterators_ffi.h
+++ b/src/redisearch_rs/headers/iterators_ffi.h
@@ -152,36 +152,57 @@ extern "C" {
 #endif // __cplusplus
 
 /**
- * Creates a new empty iterator.
- */
-QueryIterator *NewEmptyIterator(void);
-
-/**
- * Creates a new non-optimized wildcard iterator over the `[0, max_id]` document id range.
- */
-QueryIterator *NewWildcardIterator_NonOptimized(t_docId max_id, double weight);
-
-/**
+ * Append a new child iterator to the intersection.
+ *
+ * Transfers ownership of `child` to the intersection. Updates the estimated result count
+ * if the new child has a lower estimate than the current minimum.
+ *
+ * # Note
+ *
+ * Unlike the constructor, this method does **not** re-sort the child list after insertion.
  *
  * # Safety
  *
- * 1. `spec` must be a valid non-null pointer to an [`ffi::IndexSpec`].
- * 2. `fs` must be a valid non-null pointer to a [`FieldSpec`] for a numeric or geo field.
+ * 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator()`].
+ * 2. `child` must be a valid non-null pointer to a `QueryIterator`, not aliased.
  */
-NumericRangeTree *openNumericOrGeoIndex(IndexSpec *spec, FieldSpec *fs, bool create_if_missing);
+void AddIntersectionIteratorChild(QueryIterator *header, QueryIterator *child);
 
 /**
- * Creates a new iterator over a list of sorted document IDs.
+ * Frees the `numericFilters` array that [`NewGeoRangeIterator`] populated on a
+ * `GeoFilter`, together with the per-range `NumericFilter`s it owns.
+ *
+ * The array is allocated in Rust (`build_geo_numeric_filters` boxes it), so it
+ * must be released with the Rust allocator.
  *
  * # Safety
  *
- * 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
- *    The array must be sorted in ascending order.
- * 2. The caller must ensure that `ids` is not null unless `num` is zero.
- * 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
- *    so the caller must ensure that the pointer was allocated in a compatible manner.
+ * `filters` must be NULL, or the array stored in `gf.numericFilters` by
+ * [`NewGeoRangeIterator`] (i.e. by `build_geo_numeric_filters`) and not yet
+ * freed.
  */
-QueryIterator *NewSortedIdListIterator(t_docId *ids, uint64_t num, double weight);
+void GeoFilter_FreeNumericFilters(NumericFilter * *filters);
+
+/**
+ * Get a mutable reference to the [`RLookupKey`] stored inside this metric iterator.
+ *
+ * # Safety
+ *
+ * 1. `header` is a valid non-null pointer to a [`QueryIterator`].
+ * 2. `header` was built via [`NewMetricIteratorSortedByScore`] or [`NewMetricIteratorSortedById`].
+ */
+RLookupKey * *GetMetricOwnKeyRef(QueryIterator *header);
+
+/**
+ * `PrintProfile` vtable entry for Hybrid (vector search) iterators.
+ *
+ * # Safety
+ *
+ * 1. `self_` must be a valid pointer to a Hybrid iterator.
+ * 2. `map` must be a valid pointer to a [`redis_reply::MapBuilder`].
+ * 3. `ctx` must be a valid pointer to a [`ProfilePrintCtx`].
+ */
+void Hybrid_PrintProfile(const QueryIterator *self_, struct MapBuilder *map, struct ProfilePrintCtx *ctx);
 
 /**
  * Profile-wrap an iterator and its entire subtree.
@@ -199,18 +220,18 @@ QueryIterator *NewSortedIdListIterator(t_docId *ids, uint64_t num, double weight
 QueryIterator *IntoProfiled(QueryIterator *iter);
 
 /**
- * Creates a new metric iterator sorted by ID.
+ * Returns `true` if `it` is a wildcard iterator (either optimized or non-optimized).
  *
  * # Safety
  *
- * 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
- *    The array must be sorted in ascending order.
- * 2. `metric_list` must be a valid pointer to an array of `f64` with at least `num` elements.
- * 3. The caller must ensure that `ids` and `metric_list` are not null unless `num` is zero.
- * 4. The memory pointed to by `ids` and `metric_list` will be freed using `RedisModule_Free`,
- *    so the caller must ensure that these pointers were allocated in a compatible manner.
+ * `it`, when non-null, must point to a valid [`QueryIterator`].
  */
-QueryIterator *NewMetricIteratorSortedById(t_docId *ids, double *metric_list, size_t num, enum MetricType type_);
+bool IsWildcardIterator(const QueryIterator *it);
+
+/**
+ * Creates a new empty iterator.
+ */
+QueryIterator *NewEmptyIterator(void);
 
 /**
  * Creates an iterator over all geo-encoded index entries within the radius specified by `gf`.
@@ -232,269 +253,6 @@ QueryIterator *NewMetricIteratorSortedById(t_docId *ids, double *metric_list, si
  * 4. `config` must be a valid non-NULL pointer to an `IteratorsConfig`.
  */
 QueryIterator *NewGeoRangeIterator(const RedisSearchCtx *ctx, GeoFilter *gf, const struct IteratorsConfig *config);
-
-/**
- * Create an optional iterator over `child`, applying shortcircuit reductions where possible.
- *
- * - If `child` is null or an empty iterator, a wildcard iterator is returned instead (all results will be virtual hits).
- * - If `child` is a wildcard iterator, it is returned as-is with `weight` applied.
- * - Otherwise, an [`Optional`](rqe_iterators::optional::Optional) or [`OptionalOptimized`](rqe_iterators::optional_optimized::OptionalOptimized)
- *   iterator is constructed based on whether `q.sctx.spec.rule.index_all` is set.
- *
- * # Safety
- *
- * 1. `child`, when non-null, must be a valid owning pointer to a C query iterator that is not aliased.
- * 2. `q` must be a valid non-null pointer to a [`QueryEvalCtx`] satisfying all preconditions of
- *    [`new_optional_iterator`].
- */
-QueryIterator *NewOptionalIterator(QueryIterator *child, QueryEvalCtx *q, t_docId max_doc_id, double weight);
-
-/**
- * Returns `true` if `it` is a wildcard iterator (either optimized or non-optimized).
- *
- * # Safety
- *
- * `it`, when non-null, must point to a valid [`QueryIterator`].
- */
-bool IsWildcardIterator(const QueryIterator *it);
-
-/**
- * `PrintProfile` vtable entry for Hybrid (vector search) iterators.
- *
- * # Safety
- *
- * 1. `self_` must be a valid pointer to a Hybrid iterator.
- * 2. `map` must be a valid pointer to a [`redis_reply::MapBuilder`].
- * 3. `ctx` must be a valid pointer to a [`ProfilePrintCtx`].
- */
-void Hybrid_PrintProfile(const QueryIterator *self_, struct MapBuilder *map, struct ProfilePrintCtx *ctx);
-
-/**
- * Creates a new missing-field inverted index iterator.
- *
- * # Parameters
- *
- * * `idx` - Pointer to the missing-field inverted index (DocIdsOnly or RawDocIdsOnly encoded).
- * * `sctx` - Pointer to the Redis search context.
- * * `field_index` - The index of the field in `spec.fields` whose missing documents are tracked.
- *
- * # Returns
- *
- * A pointer to a `QueryIterator` that can be used from C code.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- *
- * 1. `idx` must be a valid pointer to an `InvertedIndex` and cannot be NULL.
- * 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
- *    mechanism detects when the index has been replaced via `spec.missingFieldDict`
- *    lookup.
- * 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
- * 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
- * 5. `field_index` must be a valid index into `sctx.spec.fields`.
- * 6. `sctx.spec.missingFieldDict` must be a non-null, valid dict pointer.
- */
-QueryIterator *NewInvIndIterator_MissingQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, t_fieldIndex field_index);
-
-/**
- * Creates a new iterator over a list of unsorted document IDs.
- *
- * # Safety
- *
- * 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
- * 2. The caller must ensure that `ids` is not null unless `num` is zero.
- * 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
- *    so the caller must ensure that the pointer was allocated in a compatible manner.
- */
-QueryIterator *NewUnsortedIdListIterator(t_docId *ids, uint64_t num, double weight);
-
-/**
- * Creates a new term inverted index iterator for querying term fields.
- *
- * # Parameters
- *
- * * `idx` - Pointer to the inverted index to query.
- * * `sctx` - Pointer to the Redis search context.
- * * `field_mask_or_index` - Field mask or field index to filter on.
- * * `term` - Pointer to the query term. Ownership is transferred to the iterator.
- * * `weight` - Weight to apply to the term results.
- *
- * # Returns
- *
- * A pointer to a `QueryIterator` that can be used from C code.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- *
- * 1. `idx` must be a valid pointer to a term `InvertedIndex` and cannot be NULL.
- * 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
- *    mechanism detects when the index has been replaced via `Redis_OpenInvertedIndex()`
- *    pointer comparison.
- * 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
- * 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
- * 5. `term` must be a valid pointer to a heap-allocated `RSQueryTerm` (e.g. created by
- *    `NewQueryTerm`) and cannot be NULL. Ownership is transferred to the iterator.
- */
-QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, union FieldMaskOrIndex field_mask_or_index, struct RSQueryTerm *term, double weight);
-
-/**
- * Add profile iterators to all nodes in the iterator tree.
- *
- * Wraps the root as a [`CRQEIterator`], calls
- * [`CRQEIterator::into_profiled`](rqe_iterators::c2rust::CRQEIterator::into_profiled)
- * (which recursively profiles
- * all descendants), then writes the result back as a `QueryIterator*`.
- *
- * # Safety
- *
- * 1. `root` must be a valid non-null pointer to a `*mut QueryIterator`.
- * 2. `*root` must be null or a valid non-null, non-aliased pointer to a `QueryIterator`.
- */
-void Profile_AddIters(QueryIterator * *root);
-
-/**
- * Creates a new metric iterator sorted by score.
- *
- * # Safety
- *
- * 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
- * 2. `metric_list` must be a valid pointer to an array of `f64` with at least `num` elements.
- * 3. The caller must ensure that `ids` and `metric_list` are not null unless `num` is zero.
- * 4. The memory pointed to by `ids` and `metric_list` will be freed using `RedisModule_Free`,
- *    so the caller must ensure that these pointers were allocated in a compatible manner.
- */
-QueryIterator *NewMetricIteratorSortedByScore(t_docId *ids, double *metric_list, size_t num, enum MetricType type_);
-
-/**
- * Create a new intersection iterator.
- *
- * Takes ownership of both the `its` array and all child iterators it contains.
- * Applies reduction rules before
- * constructing the iterator:
- *
- * 0. No children → empty iterator.
- * 1. Strip wildcard children. All wildcards → return the last one.
- * 2. Any empty child → free all, return empty iterator.
- * 3. Exactly one real child → return it directly.
- * 4. Two or more real children → build a full intersection.
- *
- * # Safety
- *
- * 1. `its` must be a valid non-null pointer to an array of `num` `QueryIterator*` values,
- *    allocated with the Redis allocator (`rm_malloc`). Ownership is transferred to this function.
- * 2. Every non-null pointer in `its` must be a valid `QueryIterator` whose callbacks are set.
- * 3. Null entries in `its` are treated as empty iterators.
- */
-QueryIterator *NewIntersectionIterator(QueryIterator * *its, size_t num, int32_t max_slop, bool in_order, double weight);
-
-/**
- * Frees the `numericFilters` array that [`NewGeoRangeIterator`] populated on a
- * `GeoFilter`, together with the per-range `NumericFilter`s it owns.
- *
- * The array is allocated in Rust (`build_geo_numeric_filters` boxes it), so it
- * must be released with the Rust allocator.
- *
- * # Safety
- *
- * `filters` must be NULL, or the array stored in `gf.numericFilters` by
- * [`NewGeoRangeIterator`] (i.e. by `build_geo_numeric_filters`) and not yet
- * freed.
- */
-void GeoFilter_FreeNumericFilters(NumericFilter * *filters);
-
-/**
- * Opens the numeric/geo index and creates an iterator over all matching sub-ranges.
- *
- * # Returns
- *
- * - `NULL` if the index doesn't exist for this field (i.e., no documents have been indexed
- *   for it yet).
- * - `NULL` if no sub-ranges in the tree match the filter.
- * - A single iterator if exactly one sub-range matches.
- * - A union iterator over all matching sub-ranges otherwise.
- *
- * # Safety
- *
- * 1. `ctx` must be a valid non-NULL pointer to a [`ffi::RedisSearchCtx`], remaining valid
- *    for the lifetime of the returned iterator.
- * 2. `ctx.spec` must be a valid non-NULL pointer to an [`ffi::IndexSpec`].
- * 3. `flt` must be a valid non-NULL pointer to a [`NumericFilter`] whose `field_spec` field
- *    is a valid non-NULL pointer to a [`FieldSpec`], remaining valid for the lifetime of the
- *    returned iterator.
- * 4. `config` must be a valid non-NULL pointer to an [`IteratorsConfig`].
- * 5. `filter_ctx` must be a valid non-NULL pointer to a [`FieldFilterContext`] with a field
- *    index (not a field mask).
- */
-QueryIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const struct NumericFilter *flt, FieldType _for_type, const struct IteratorsConfig *config, const struct FieldFilterContext *filter_ctx);
-
-/**
- * Creates a new union iterator, applying reduction rules and choosing between
- * flat and heap variants based on the number of children.
- *
- * Takes ownership of both the `its` array and all child iterators it contains.
- *
- * # Safety
- *
- * 1. `its` must be a valid non-null pointer to an array of `num`
- *    `QueryIterator*` values, allocated with the Redis allocator (`rm_malloc`).
- *    Ownership is transferred to this function.
- * 2. Every non-null pointer in `its` must be a valid `QueryIterator` whose
- *    callbacks are set.
- * 3. Null entries in `its` are treated as empty iterators.
- * 4. `config` must be a valid non-null pointer to an [`IteratorsConfig`].
- * 5. `q_str` must be null or a valid, NUL-terminated C string that outlives
- *    the returned iterator — the requirement of [`build_union`].
- */
-QueryIterator *NewUnionIterator(QueryIterator * *its, int32_t num, bool quick_exit, double weight, QueryNodeType type_, const char *q_str, const struct IteratorsConfig *config);
-
-/**
- * Creates a new wildcard iterator from a query evaluation context.
- *
- * There are three possible code paths:
- *
- * 1. **Disk index** — when [`spec.diskSpec`](ffi::IndexSpec::diskSpec) is non-null, delegates to
- *    the enterprise iterator API via
- *    [`rqe_iterators::wildcard::new_wildcard_iterator_on_disk`].
- * 2. **[`index_all`](ffi::SchemaRule::index_all) optimized** — when [`SchemaRule`](ffi::SchemaRule)`.index_all` is set, delegates to
- *    [`rqe_iterators::wildcard::new_wildcard_iterator_optimized`].
- * 3. **Fallback** — creates a simple [`Wildcard`] iterator that yields all
- *    document ids up to [`docTable.maxDocId`](ffi::DocTable::maxDocId).
- *
- * # Safety
- *
- * 1. `q` must be a non-null pointer to a valid [`QueryEvalCtx`](ffi::QueryEvalCtx)
- *    that remains valid for the lifetime of the returned iterator.
- * 2. `q.sctx` must be a non-null pointer to a valid
- *    [`RedisSearchCtx`](ffi::RedisSearchCtx) that remains valid for the lifetime
- *    of the returned iterator.
- * 3. `q.sctx.spec` must be a non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec) that
- *    remains valid for the lifetime of the returned iterator.
- * 4. `q.sctx.spec.rule`, when non-null, must point to a valid [`SchemaRule`](ffi::SchemaRule).
- * 5. When [`SchemaRule`](ffi::SchemaRule)`.index_all` is true, the preconditions of
- *    [`rqe_iterators::wildcard::new_wildcard_iterator_optimized`] must also hold.
- * 6. `q.docTable` must be a non-null pointer to a valid [`DocTable`](ffi::DocTable).
- * 7. `q.sctx.spec.diskSpec`, when non-null, must point to a valid
- *    [`RedisSearchDiskIndexSpec`](ffi::RedisSearchDiskIndexSpec) that remains valid for the
- *    lifetime of the returned iterator, and the disk iterator backend must be initialized.
- * 8. When `q.sctx.spec.diskSpec` is non-null, `q.sctx.diskSnapshot` must be a **non-null**
- *    [`RedisSearchDiskSnapshot`](ffi::RedisSearchDiskSnapshot) handle for `q.sctx.spec.diskSpec`
- *    that remains valid for the lifetime of the returned iterator. The disk path requires a
- *    point-in-time view: a null snapshot alongside a non-null `diskSpec` makes the call panic.
- */
-QueryIterator *NewWildcardIterator(const QueryEvalCtx *q, double weight);
-
-/**
- * `PrintProfile` vtable entry for Optimus (optimizer) iterators.
- *
- * # Safety
- *
- * 1. `self_` must be a valid pointer to an Optimus iterator.
- * 2. `map` must be a valid pointer to a [`redis_reply::MapBuilder`].
- * 3. `ctx` must be a valid pointer to a [`ProfilePrintCtx`].
- */
-void Optimus_PrintProfile(const QueryIterator *self_, struct MapBuilder *map, struct ProfilePrintCtx *ctx);
 
 /**
  * Creates a new geometry-query iterator over a list of matching document IDs.
@@ -526,100 +284,35 @@ void Optimus_PrintProfile(const QueryIterator *self_, struct MapBuilder *map, st
 QueryIterator *NewGeometryQueryIterator(const RedisSearchCtx *sctx, const struct FieldFilterContext *filter_ctx, t_docId *ids, size_t num, size_t *allocated);
 
 /**
- * Sets the [`RLookupKeyHandle`] for this metric iterator.
+ * Create a new intersection iterator.
+ *
+ * Takes ownership of both the `its` array and all child iterators it contains.
+ * Applies reduction rules before
+ * constructing the iterator:
+ *
+ * 0. No children → empty iterator.
+ * 1. Strip wildcard children. All wildcards → return the last one.
+ * 2. Any empty child → free all, return empty iterator.
+ * 3. Exactly one real child → return it directly.
+ * 4. Two or more real children → build a full intersection.
  *
  * # Safety
  *
- * 1. `header` is a valid non-null pointer to a [`QueryIterator`].
- * 2. `header` was built via [`NewMetricIteratorSortedByScore`] or [`NewMetricIteratorSortedById`].
- * 3. `key_handle` is either a null pointer or a valid non-null pointer to a [`RLookupKeyHandle`] instance.
+ * 1. `its` must be a valid non-null pointer to an array of `num` `QueryIterator*` values,
+ *    allocated with the Redis allocator (`rm_malloc`). Ownership is transferred to this function.
+ * 2. Every non-null pointer in `its` must be a valid `QueryIterator` whose callbacks are set.
+ * 3. Null entries in `its` are treated as empty iterators.
  */
-void SetMetricRLookupHandle(QueryIterator *header, RLookupKeyHandle *key_handle);
+QueryIterator *NewIntersectionIterator(QueryIterator * *its, size_t num, int32_t max_slop, bool in_order, double weight);
 
 /**
- * Creates a lazily-evaluated vector range iterator.
- *
- * Unlike [`NewMetricIteratorSortedById`](crate::metric::NewMetricIteratorSortedById) and the
- * other ID-list/metric constructors, the matching documents are **not** computed here. Instead
- * the `produce` callback runs the underlying vector range query on the first `Read`/`SkipTo`,
- * after which the resulting iterator behaves exactly like an eagerly-built metric (when
- * `yields_metric`) or ID-list iterator. Deferring the query lets the caller release the spec
- * lock before it executes, so writes can proceed concurrently (see MOD-16437).
- *
- * `sorted_by_id` selects between the by-ID and by-score variants; `num_estimated` is the
- * upper-bound estimate reported until the query runs; `type_` is the metric type (only used
- * when `yields_metric`).
- *
- * # Safety
- *
- * 1. `produce` must run the query against `ctx` and return a valid [`VectorRangeResults`]
- *    (arrays allocated with the Redis allocator, or `timed_out`); it must not free `ctx`.
- * 2. `free_ctx` must free `ctx` and be safe to call exactly once.
- * 3. `ctx` must remain valid until the iterator is freed; ownership transfers to the iterator.
- */
-QueryIterator *NewLazyVectorRangeIterator(ProduceResultsFn produce, FreeProducerCtxFn free_ctx, void *ctx, bool yields_metric, bool sorted_by_id, size_t num_estimated, enum MetricType type_);
-
-/**
- * Append a new child iterator to the intersection.
- *
- * Transfers ownership of `child` to the intersection. Updates the estimated result count
- * if the new child has a lower estimate than the current minimum.
- *
- * # Note
- *
- * Unlike the constructor, this method does **not** re-sort the child list after insertion.
- *
- * # Safety
- *
- * 1. `header` must be a valid non-null pointer created via [`NewIntersectionIterator()`].
- * 2. `child` must be a valid non-null pointer to a `QueryIterator`, not aliased.
- */
-void AddIntersectionIteratorChild(QueryIterator *header, QueryIterator *child);
-
-/**
- * Trims a union iterator for the LIMIT optimizer, then switches to unsorted
- * sequential read mode.
- *
- * # Safety
- *
- * 1. `it` must be a valid non-null pointer to a non-reduced union iterator
- *    created via [`NewUnionIterator`].
- */
-void TrimUnionIterator(QueryIterator *it, size_t limit, bool asc);
-
-/**
- * Print iterator profile tree as a Redis reply.
- *
- * This is the FFI entry point called from C `Profile_PrintCommon`.
+ * Creates a new missing-field inverted index iterator.
  *
  * # Parameters
  *
- * - `ctx`: The Redis module context used to emit reply protocol.
- * - `root`: The root of the profile-wrapped iterator tree to print.
- *   May be null, in which case the function returns immediately.
- * - `limited`: When `true`, non-`UNION` union iterators collapse their
- *   children into a summary count instead of printing each child
- *   individually. Corresponds to `FT.PROFILE ... LIMITED`.
- * - `print_profile_clock`: When `true`, include wall-clock timing
- *   (`"Time"`) in each profile entry. Corresponds to
- *   `PROFILE_VERBOSE` / `_FT.DEBUG PROFILE_VERBOSE`.
- *
- * # Safety
- *
- * 1. `ctx` must be a valid [`RedisModuleCtx`] pointer.
- * 2. `root` must be null or a valid pointer to a [`QueryIterator`] tree
- *    that has been profile-wrapped via `Profile_AddIters`.
- */
-void Profile_PrintIterators(struct RedisModuleCtx *ctx, const QueryIterator *root, bool limited, bool print_profile_clock);
-
-/**
- * Creates a new wildcard inverted index iterator for querying all existing documents.
- *
- * # Parameters
- *
- * * `idx` - Pointer to the existingDocs inverted index (DocIdsOnly or RawDocIdsOnly encoded).
+ * * `idx` - Pointer to the missing-field inverted index (DocIdsOnly or RawDocIdsOnly encoded).
  * * `sctx` - Pointer to the Redis search context.
- * * `weight` - Weight to apply to all results.
+ * * `field_index` - The index of the field in `spec.fields` whose missing documents are tracked.
  *
  * # Returns
  *
@@ -631,22 +324,14 @@ void Profile_PrintIterators(struct RedisModuleCtx *ctx, const QueryIterator *roo
  *
  * 1. `idx` must be a valid pointer to an `InvertedIndex` and cannot be NULL.
  * 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
- *    mechanism detects when the index has been replaced via `spec.existingDocs` pointer
- *    comparison.
+ *    mechanism detects when the index has been replaced via `spec.missingFieldDict`
+ *    lookup.
  * 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
  * 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
+ * 5. `field_index` must be a valid index into `sctx.spec.fields`.
+ * 6. `sctx.spec.missingFieldDict` must be a non-null, valid dict pointer.
  */
-QueryIterator *NewInvIndIterator_WildcardQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, double weight);
-
-/**
- * Get a mutable reference to the [`RLookupKey`] stored inside this metric iterator.
- *
- * # Safety
- *
- * 1. `header` is a valid non-null pointer to a [`QueryIterator`].
- * 2. `header` was built via [`NewMetricIteratorSortedByScore`] or [`NewMetricIteratorSortedById`].
- */
-RLookupKey * *GetMetricOwnKeyRef(QueryIterator *header);
+QueryIterator *NewInvIndIterator_MissingQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, t_fieldIndex field_index);
 
 /**
  * Creates a new tag inverted index iterator.
@@ -686,6 +371,112 @@ RLookupKey * *GetMetricOwnKeyRef(QueryIterator *header);
 QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagIndex *tag_idx, const RedisSearchCtx *sctx, union FieldMaskOrIndex field_mask_or_index, struct RSQueryTerm *term, double weight);
 
 /**
+ * Creates a new term inverted index iterator for querying term fields.
+ *
+ * # Parameters
+ *
+ * * `idx` - Pointer to the inverted index to query.
+ * * `sctx` - Pointer to the Redis search context.
+ * * `field_mask_or_index` - Field mask or field index to filter on.
+ * * `term` - Pointer to the query term. Ownership is transferred to the iterator.
+ * * `weight` - Weight to apply to the term results.
+ *
+ * # Returns
+ *
+ * A pointer to a `QueryIterator` that can be used from C code.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ *
+ * 1. `idx` must be a valid pointer to a term `InvertedIndex` and cannot be NULL.
+ * 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
+ *    mechanism detects when the index has been replaced via `Redis_OpenInvertedIndex()`
+ *    pointer comparison.
+ * 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
+ * 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
+ * 5. `term` must be a valid pointer to a heap-allocated `RSQueryTerm` (e.g. created by
+ *    `NewQueryTerm`) and cannot be NULL. Ownership is transferred to the iterator.
+ */
+QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, union FieldMaskOrIndex field_mask_or_index, struct RSQueryTerm *term, double weight);
+
+/**
+ * Creates a new wildcard inverted index iterator for querying all existing documents.
+ *
+ * # Parameters
+ *
+ * * `idx` - Pointer to the existingDocs inverted index (DocIdsOnly or RawDocIdsOnly encoded).
+ * * `sctx` - Pointer to the Redis search context.
+ * * `weight` - Weight to apply to all results.
+ *
+ * # Returns
+ *
+ * A pointer to a `QueryIterator` that can be used from C code.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ *
+ * 1. `idx` must be a valid pointer to an `InvertedIndex` and cannot be NULL.
+ * 2. `idx` must remain valid between `revalidate()` calls, since the revalidation
+ *    mechanism detects when the index has been replaced via `spec.existingDocs` pointer
+ *    comparison.
+ * 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
+ * 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
+ */
+QueryIterator *NewInvIndIterator_WildcardQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, double weight);
+
+/**
+ * Creates a lazily-evaluated vector range iterator.
+ *
+ * Unlike [`NewMetricIteratorSortedById`](crate::metric::NewMetricIteratorSortedById) and the
+ * other ID-list/metric constructors, the matching documents are **not** computed here. Instead
+ * the `produce` callback runs the underlying vector range query on the first `Read`/`SkipTo`,
+ * after which the resulting iterator behaves exactly like an eagerly-built metric (when
+ * `yields_metric`) or ID-list iterator. Deferring the query lets the caller release the spec
+ * lock before it executes, so writes can proceed concurrently (see MOD-16437).
+ *
+ * `sorted_by_id` selects between the by-ID and by-score variants; `num_estimated` is the
+ * upper-bound estimate reported until the query runs; `type_` is the metric type (only used
+ * when `yields_metric`).
+ *
+ * # Safety
+ *
+ * 1. `produce` must run the query against `ctx` and return a valid [`VectorRangeResults`]
+ *    (arrays allocated with the Redis allocator, or `timed_out`); it must not free `ctx`.
+ * 2. `free_ctx` must free `ctx` and be safe to call exactly once.
+ * 3. `ctx` must remain valid until the iterator is freed; ownership transfers to the iterator.
+ */
+QueryIterator *NewLazyVectorRangeIterator(ProduceResultsFn produce, FreeProducerCtxFn free_ctx, void *ctx, bool yields_metric, bool sorted_by_id, size_t num_estimated, enum MetricType type_);
+
+/**
+ * Creates a new metric iterator sorted by ID.
+ *
+ * # Safety
+ *
+ * 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
+ *    The array must be sorted in ascending order.
+ * 2. `metric_list` must be a valid pointer to an array of `f64` with at least `num` elements.
+ * 3. The caller must ensure that `ids` and `metric_list` are not null unless `num` is zero.
+ * 4. The memory pointed to by `ids` and `metric_list` will be freed using `RedisModule_Free`,
+ *    so the caller must ensure that these pointers were allocated in a compatible manner.
+ */
+QueryIterator *NewMetricIteratorSortedById(t_docId *ids, double *metric_list, size_t num, enum MetricType type_);
+
+/**
+ * Creates a new metric iterator sorted by score.
+ *
+ * # Safety
+ *
+ * 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
+ * 2. `metric_list` must be a valid pointer to an array of `f64` with at least `num` elements.
+ * 3. The caller must ensure that `ids` and `metric_list` are not null unless `num` is zero.
+ * 4. The memory pointed to by `ids` and `metric_list` will be freed using `RedisModule_Free`,
+ *    so the caller must ensure that these pointers were allocated in a compatible manner.
+ */
+QueryIterator *NewMetricIteratorSortedByScore(t_docId *ids, double *metric_list, size_t num, enum MetricType type_);
+
+/**
  * Creates a NOT iterator, choosing between non-optimized and optimized based
  * on the query evaluation context.
  *
@@ -719,6 +510,215 @@ QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagInd
  *    valid for the lifetime of the returned iterator.
  */
 QueryIterator *NewNotIterator(QueryIterator *child, t_docId max_doc_id, double weight, timespec timeout, AREQ *bc_timeout_areq, QueryEvalCtx *q);
+
+/**
+ * Opens the numeric/geo index and creates an iterator over all matching sub-ranges.
+ *
+ * # Returns
+ *
+ * - `NULL` if the index doesn't exist for this field (i.e., no documents have been indexed
+ *   for it yet).
+ * - `NULL` if no sub-ranges in the tree match the filter.
+ * - A single iterator if exactly one sub-range matches.
+ * - A union iterator over all matching sub-ranges otherwise.
+ *
+ * # Safety
+ *
+ * 1. `ctx` must be a valid non-NULL pointer to a [`ffi::RedisSearchCtx`], remaining valid
+ *    for the lifetime of the returned iterator.
+ * 2. `ctx.spec` must be a valid non-NULL pointer to an [`ffi::IndexSpec`].
+ * 3. `flt` must be a valid non-NULL pointer to a [`NumericFilter`] whose `field_spec` field
+ *    is a valid non-NULL pointer to a [`FieldSpec`], remaining valid for the lifetime of the
+ *    returned iterator.
+ * 4. `config` must be a valid non-NULL pointer to an [`IteratorsConfig`].
+ * 5. `filter_ctx` must be a valid non-NULL pointer to a [`FieldFilterContext`] with a field
+ *    index (not a field mask).
+ */
+QueryIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const struct NumericFilter *flt, FieldType _for_type, const struct IteratorsConfig *config, const struct FieldFilterContext *filter_ctx);
+
+/**
+ * Create an optional iterator over `child`, applying shortcircuit reductions where possible.
+ *
+ * - If `child` is null or an empty iterator, a wildcard iterator is returned instead (all results will be virtual hits).
+ * - If `child` is a wildcard iterator, it is returned as-is with `weight` applied.
+ * - Otherwise, an [`Optional`](rqe_iterators::optional::Optional) or [`OptionalOptimized`](rqe_iterators::optional_optimized::OptionalOptimized)
+ *   iterator is constructed based on whether `q.sctx.spec.rule.index_all` is set.
+ *
+ * # Safety
+ *
+ * 1. `child`, when non-null, must be a valid owning pointer to a C query iterator that is not aliased.
+ * 2. `q` must be a valid non-null pointer to a [`QueryEvalCtx`] satisfying all preconditions of
+ *    [`new_optional_iterator`].
+ */
+QueryIterator *NewOptionalIterator(QueryIterator *child, QueryEvalCtx *q, t_docId max_doc_id, double weight);
+
+/**
+ * Creates a new iterator over a list of sorted document IDs.
+ *
+ * # Safety
+ *
+ * 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
+ *    The array must be sorted in ascending order.
+ * 2. The caller must ensure that `ids` is not null unless `num` is zero.
+ * 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
+ *    so the caller must ensure that the pointer was allocated in a compatible manner.
+ */
+QueryIterator *NewSortedIdListIterator(t_docId *ids, uint64_t num, double weight);
+
+/**
+ * Creates a new union iterator, applying reduction rules and choosing between
+ * flat and heap variants based on the number of children.
+ *
+ * Takes ownership of both the `its` array and all child iterators it contains.
+ *
+ * # Safety
+ *
+ * 1. `its` must be a valid non-null pointer to an array of `num`
+ *    `QueryIterator*` values, allocated with the Redis allocator (`rm_malloc`).
+ *    Ownership is transferred to this function.
+ * 2. Every non-null pointer in `its` must be a valid `QueryIterator` whose
+ *    callbacks are set.
+ * 3. Null entries in `its` are treated as empty iterators.
+ * 4. `config` must be a valid non-null pointer to an [`IteratorsConfig`].
+ * 5. `q_str` must be null or a valid, NUL-terminated C string that outlives
+ *    the returned iterator — the requirement of [`build_union`].
+ */
+QueryIterator *NewUnionIterator(QueryIterator * *its, int32_t num, bool quick_exit, double weight, QueryNodeType type_, const char *q_str, const struct IteratorsConfig *config);
+
+/**
+ * Creates a new iterator over a list of unsorted document IDs.
+ *
+ * # Safety
+ *
+ * 1. `ids` must be a valid pointer to an array of `DocId` with at least `num` elements.
+ * 2. The caller must ensure that `ids` is not null unless `num` is zero.
+ * 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
+ *    so the caller must ensure that the pointer was allocated in a compatible manner.
+ */
+QueryIterator *NewUnsortedIdListIterator(t_docId *ids, uint64_t num, double weight);
+
+/**
+ * Creates a new wildcard iterator from a query evaluation context.
+ *
+ * There are three possible code paths:
+ *
+ * 1. **Disk index** — when [`spec.diskSpec`](ffi::IndexSpec::diskSpec) is non-null, delegates to
+ *    the enterprise iterator API via
+ *    [`rqe_iterators::wildcard::new_wildcard_iterator_on_disk`].
+ * 2. **[`index_all`](ffi::SchemaRule::index_all) optimized** — when [`SchemaRule`](ffi::SchemaRule)`.index_all` is set, delegates to
+ *    [`rqe_iterators::wildcard::new_wildcard_iterator_optimized`].
+ * 3. **Fallback** — creates a simple [`Wildcard`] iterator that yields all
+ *    document ids up to [`docTable.maxDocId`](ffi::DocTable::maxDocId).
+ *
+ * # Safety
+ *
+ * 1. `q` must be a non-null pointer to a valid [`QueryEvalCtx`](ffi::QueryEvalCtx)
+ *    that remains valid for the lifetime of the returned iterator.
+ * 2. `q.sctx` must be a non-null pointer to a valid
+ *    [`RedisSearchCtx`](ffi::RedisSearchCtx) that remains valid for the lifetime
+ *    of the returned iterator.
+ * 3. `q.sctx.spec` must be a non-null pointer to a valid [`IndexSpec`](ffi::IndexSpec) that
+ *    remains valid for the lifetime of the returned iterator.
+ * 4. `q.sctx.spec.rule`, when non-null, must point to a valid [`SchemaRule`](ffi::SchemaRule).
+ * 5. When [`SchemaRule`](ffi::SchemaRule)`.index_all` is true, the preconditions of
+ *    [`rqe_iterators::wildcard::new_wildcard_iterator_optimized`] must also hold.
+ * 6. `q.docTable` must be a non-null pointer to a valid [`DocTable`](ffi::DocTable).
+ * 7. `q.sctx.spec.diskSpec`, when non-null, must point to a valid
+ *    [`RedisSearchDiskIndexSpec`](ffi::RedisSearchDiskIndexSpec) that remains valid for the
+ *    lifetime of the returned iterator, and the disk iterator backend must be initialized.
+ * 8. When `q.sctx.spec.diskSpec` is non-null, `q.sctx.diskSnapshot` must be a **non-null**
+ *    [`RedisSearchDiskSnapshot`](ffi::RedisSearchDiskSnapshot) handle for `q.sctx.spec.diskSpec`
+ *    that remains valid for the lifetime of the returned iterator. The disk path requires a
+ *    point-in-time view: a null snapshot alongside a non-null `diskSpec` makes the call panic.
+ */
+QueryIterator *NewWildcardIterator(const QueryEvalCtx *q, double weight);
+
+/**
+ * Creates a new non-optimized wildcard iterator over the `[0, max_id]` document id range.
+ */
+QueryIterator *NewWildcardIterator_NonOptimized(t_docId max_id, double weight);
+
+/**
+ * `PrintProfile` vtable entry for Optimus (optimizer) iterators.
+ *
+ * # Safety
+ *
+ * 1. `self_` must be a valid pointer to an Optimus iterator.
+ * 2. `map` must be a valid pointer to a [`redis_reply::MapBuilder`].
+ * 3. `ctx` must be a valid pointer to a [`ProfilePrintCtx`].
+ */
+void Optimus_PrintProfile(const QueryIterator *self_, struct MapBuilder *map, struct ProfilePrintCtx *ctx);
+
+/**
+ * Add profile iterators to all nodes in the iterator tree.
+ *
+ * Wraps the root as a [`CRQEIterator`], calls
+ * [`CRQEIterator::into_profiled`](rqe_iterators::c2rust::CRQEIterator::into_profiled)
+ * (which recursively profiles
+ * all descendants), then writes the result back as a `QueryIterator*`.
+ *
+ * # Safety
+ *
+ * 1. `root` must be a valid non-null pointer to a `*mut QueryIterator`.
+ * 2. `*root` must be null or a valid non-null, non-aliased pointer to a `QueryIterator`.
+ */
+void Profile_AddIters(QueryIterator * *root);
+
+/**
+ * Print iterator profile tree as a Redis reply.
+ *
+ * This is the FFI entry point called from C `Profile_PrintCommon`.
+ *
+ * # Parameters
+ *
+ * - `ctx`: The Redis module context used to emit reply protocol.
+ * - `root`: The root of the profile-wrapped iterator tree to print.
+ *   May be null, in which case the function returns immediately.
+ * - `limited`: When `true`, non-`UNION` union iterators collapse their
+ *   children into a summary count instead of printing each child
+ *   individually. Corresponds to `FT.PROFILE ... LIMITED`.
+ * - `print_profile_clock`: When `true`, include wall-clock timing
+ *   (`"Time"`) in each profile entry. Corresponds to
+ *   `PROFILE_VERBOSE` / `_FT.DEBUG PROFILE_VERBOSE`.
+ *
+ * # Safety
+ *
+ * 1. `ctx` must be a valid [`RedisModuleCtx`] pointer.
+ * 2. `root` must be null or a valid pointer to a [`QueryIterator`] tree
+ *    that has been profile-wrapped via `Profile_AddIters`.
+ */
+void Profile_PrintIterators(struct RedisModuleCtx *ctx, const QueryIterator *root, bool limited, bool print_profile_clock);
+
+/**
+ * Sets the [`RLookupKeyHandle`] for this metric iterator.
+ *
+ * # Safety
+ *
+ * 1. `header` is a valid non-null pointer to a [`QueryIterator`].
+ * 2. `header` was built via [`NewMetricIteratorSortedByScore`] or [`NewMetricIteratorSortedById`].
+ * 3. `key_handle` is either a null pointer or a valid non-null pointer to a [`RLookupKeyHandle`] instance.
+ */
+void SetMetricRLookupHandle(QueryIterator *header, RLookupKeyHandle *key_handle);
+
+/**
+ * Trims a union iterator for the LIMIT optimizer, then switches to unsorted
+ * sequential read mode.
+ *
+ * # Safety
+ *
+ * 1. `it` must be a valid non-null pointer to a non-reduced union iterator
+ *    created via [`NewUnionIterator`].
+ */
+void TrimUnionIterator(QueryIterator *it, size_t limit, bool asc);
+
+/**
+ *
+ * # Safety
+ *
+ * 1. `spec` must be a valid non-null pointer to an [`ffi::IndexSpec`].
+ * 2. `fs` must be a valid non-null pointer to a [`FieldSpec`] for a numeric or geo field.
+ */
+NumericRangeTree *openNumericOrGeoIndex(IndexSpec *spec, FieldSpec *fs, bool create_if_missing);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/metrics_ffi.h
+++ b/src/redisearch_rs/headers/metrics_ffi.h
@@ -16,6 +16,28 @@ extern "C" {
 #endif // __cplusplus
 
 /**
+ * Resets aggregate-specific fields on an `RSIndexResult`: doc_id, freq,
+ * field_mask, child records, and metrics.
+ *
+ * # Safety
+ *
+ * 1. `r` must point to a valid `RSIndexResult` and cannot be null.
+ */
+void IndexResult_ResetAggregate(RSIndexResult *r);
+
+/**
+ * Returns a read-only slice view of the metrics collection for zero-copy
+ * iteration from C.
+ *
+ * # Safety
+ *
+ * 1. `metrics` must point to a valid `MetricsVec` (e.g. `&result.metrics`).
+ * 2. The returned slice borrows from the `MetricsVec`; the caller must
+ *    not mutate or free the `MetricsVec` while the slice is in use.
+ */
+struct MetricsSlice MetricsVec_AsSlice(const MetricsVec *metrics);
+
+/**
  * Creates an empty metrics collection. Does not allocate.
  *
  * Use this to initialize the `metrics` field when constructing an
@@ -26,6 +48,17 @@ extern "C" {
  * `NULL`.
  */
 MetricsVec MetricsVec_New(void);
+
+/**
+ * Finds the first metric whose key matches `key` (pointer equality) and
+ * replaces its value.
+ *
+ * # Safety
+ *
+ * 1. `metrics` must point to a valid `MetricsVec` (e.g. `&result.metrics`).
+ * 2. `key` must point to a valid `RLookupKey`. Compared by pointer identity.
+ */
+void MetricsVec_UpdateValue(MetricsVec *metrics, const RLookupKey *key, double new_value);
 
 /**
  * Moves all metrics from `child` into `parent`, leaving `child` empty.
@@ -56,39 +89,6 @@ void ResultMetrics_Add(RSIndexResult *r, const RLookupKey *key, double val);
  * 1. `r` must point to a valid `RSIndexResult` and cannot be null.
  */
 void ResultMetrics_Reset(RSIndexResult *r);
-
-/**
- * Resets aggregate-specific fields on an `RSIndexResult`: doc_id, freq,
- * field_mask, child records, and metrics.
- *
- * # Safety
- *
- * 1. `r` must point to a valid `RSIndexResult` and cannot be null.
- */
-void IndexResult_ResetAggregate(RSIndexResult *r);
-
-/**
- * Returns a read-only slice view of the metrics collection for zero-copy
- * iteration from C.
- *
- * # Safety
- *
- * 1. `metrics` must point to a valid `MetricsVec` (e.g. `&result.metrics`).
- * 2. The returned slice borrows from the `MetricsVec`; the caller must
- *    not mutate or free the `MetricsVec` while the slice is in use.
- */
-struct MetricsSlice MetricsVec_AsSlice(const MetricsVec *metrics);
-
-/**
- * Finds the first metric whose key matches `key` (pointer equality) and
- * replaces its value.
- *
- * # Safety
- *
- * 1. `metrics` must point to a valid `MetricsVec` (e.g. `&result.metrics`).
- * 2. `key` must point to a valid `RLookupKey`. Compared by pointer identity.
- */
-void MetricsVec_UpdateValue(MetricsVec *metrics, const RLookupKey *key, double new_value);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/module_init_ffi.h
+++ b/src/redisearch_rs/headers/module_init_ffi.h
@@ -18,6 +18,23 @@ extern "C" {
 #endif // __cplusplus
 
 /**
+ * Add the current backtrace as a new section to the report printed
+ * by RediSearch's INFO command.
+ *
+ * # Safety
+ *
+ * `ctx` must be a valid pointer to a `RedisModuleInfoCtx`.
+ */
+void AddToInfo_RustBacktrace(struct RedisModuleInfoCtx *ctx);
+
+/**
+ * Initialize RediSearch's panic hook, without replaacing the pre-existing panic hook (if any).
+ *
+ * Panic messages will be logged through `tracing` at the `ERROR` level.
+ */
+void RustPanicHook_Init(void);
+
+/**
  * Initializes a global subscriber that reports Rust `tracing` traces through `redismodule` logging.
  *
  * `level` is the initial redis `loglevel` config value the filter is set to.
@@ -37,23 +54,6 @@ void TracingRedisModule_Init(struct RedisModuleCtx *ctx, const char *level);
  * `level` must point to a valid, null-terminated C string.
  */
 void TracingRedisModule_SetLogLevel(const char *level);
-
-/**
- * Initialize RediSearch's panic hook, without replaacing the pre-existing panic hook (if any).
- *
- * Panic messages will be logged through `tracing` at the `ERROR` level.
- */
-void RustPanicHook_Init(void);
-
-/**
- * Add the current backtrace as a new section to the report printed
- * by RediSearch's INFO command.
- *
- * # Safety
- *
- * `ctx` must be a valid pointer to a `RedisModuleInfoCtx`.
- */
-void AddToInfo_RustBacktrace(struct RedisModuleInfoCtx *ctx);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/numeric_range_tree_ffi.h
+++ b/src/redisearch_rs/headers/numeric_range_tree_ffi.h
@@ -99,32 +99,16 @@ extern "C" {
 #endif // __cplusplus
 
 /**
- * Get the revision ID of the tree.
+ * Create a new [`NumericRangeTree`].
  *
- * The revision ID changes whenever the tree structure is modified (nodes split, etc.).
- * This is used by iterators to detect concurrent modifications.
+ * Returns an opaque pointer to the newly created tree.
+ * To free the tree, use [`NumericRangeTree_Free`].
  *
- * # Safety
- *
- * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+ * If `compress_floats` is true, the tree will use float compression which
+ * attempts to store f64 values as f32 when precision loss is acceptable (< 0.01).
+ * This corresponds to the `RSGlobalConfig.numericCompress` setting.
  */
-uint32_t NumericRangeTree_GetRevisionId(const struct NumericRangeTree *t);
-
-/**
- * Create a new iterator over all nodes in the tree.
- *
- * The iterator performs a depth-first traversal, visiting each node exactly once.
- * Use [`NumericRangeTreeIterator_Next`] to advance the iterator.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid [`NumericRangeTree`] obtained from
- *   [`crate::NewNumericRangeTree`] and cannot be NULL.
- * - `t` must not be freed while the iterator lives.
- * - The tree must not be mutated while the iterator lives.
- */
-NumericRangeTreeIterator *NumericRangeTreeIterator_New(const struct NumericRangeTree *t);
+struct NumericRangeTree *NewNumericRangeTree(bool compress_floats);
 
 /**
  * Get the [`NumericRange`] from a node, if present.
@@ -145,85 +129,45 @@ NumericRangeTreeIterator *NumericRangeTreeIterator_New(const struct NumericRange
 const struct NumericRange *NumericRangeNode_GetRange(const struct NumericRangeNode *node);
 
 /**
- * Reply with a summary of the numeric range tree (for NUMIDX_SUMMARY).
+ * Free a [`NumericRangeTreeFindResult`].
  *
- * This outputs the tree statistics in the format expected by FT.DEBUG NUMIDX_SUMMARY.
- * When `t` is NULL (index not yet created), all values are reported as zero.
- *
- * # Safety
- *
- * - `ctx` must be a valid Redis module context.
- * - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
- */
-void NumericRangeTree_DebugSummary(struct RedisModuleCtx *ctx, const struct NumericRangeTree *t);
-
-/**
- * Conditionally trim empty leaves and compact the node slab.
- *
- * Checks if the number of empty leaves exceeds half the total number of
- * leaves. If so, trims empty leaves, compacts the slab to reclaim freed
- * slots, and returns the number of bytes freed. Returns 0 if no trimming
- * was needed.
+ * This frees the array allocation but NOT the ranges themselves (they are
+ * owned by the tree).
  *
  * # Safety
  *
- * - `t` must point to a valid mutable [`NumericRangeTree`] and cannot be NULL.
- * - No iterators should be active on this tree while calling this function.
+ * - `result` must have been obtained from [`NumericRangeTree_Find`].
+ * - After calling this function, the result must not be used again.
  */
-struct CompactIfSparseResult NumericRangeTree_CompactIfSparse(struct NumericRangeTree *t);
+void NumericRangeTreeFindResult_Free(struct NumericRangeTreeFindResult result);
 
 /**
- * Get the estimated cardinality (number of distinct values) for a range.
- *
- * This uses HyperLogLog estimation and may have some error margin.
+ * Free a [`NumericRangeTreeIterator`].
  *
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
- * - `range` must point to a valid [`NumericRange`] obtained from
- *   [`crate::node::NumericRangeNode_GetRange`] and cannot be NULL.
- * - The tree from which this range came must still be valid.
+ * - `it` must point to a valid [`NumericRangeTreeIterator`] obtained from
+ *   [`NumericRangeTreeIterator_New`], or be NULL (in which case this is a no-op).
+ * - After calling this function, `it` must not be used again.
  */
-size_t NumericRange_GetCardinality(const struct NumericRange *range);
+void NumericRangeTreeIterator_Free(NumericRangeTreeIterator *it);
 
 /**
- * Get the minimum value in a range.
+ * Create a new iterator over all nodes in the tree.
+ *
+ * The iterator performs a depth-first traversal, visiting each node exactly once.
+ * Use [`NumericRangeTreeIterator_Next`] to advance the iterator.
  *
  * # Safety
  *
- * - `range` must point to a valid [`NumericRange`] and cannot be NULL.
+ * The following invariants must be upheld when calling this function:
+ * - `t` must point to a valid [`NumericRangeTree`] obtained from
+ *   [`crate::NewNumericRangeTree`] and cannot be NULL.
+ * - `t` must not be freed while the iterator lives.
+ * - The tree must not be mutated while the iterator lives.
  */
-double NumericRange_MinVal(const struct NumericRange *range);
-
-/**
- * Increment the revision ID.
- *
- * This method is never needed in production code: the tree
- * revision ID is automatically incremented when the tree structure changes.
- *
- * This method is provided primarily for testing purposes—e.g. to force the invalidation
- * of an iterator built on top of this tree in GC tests.
- *
- * # Safety
- *
- * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
- * - The caller must have unique access to `t`.
- */
-uint32_t NumericRangeTree_IncrementRevisionId(struct NumericRangeTree *t);
-
-/**
- * Reply with a dump of the numeric index entries (for DUMP_NUMIDX).
- *
- * This outputs all entries from all ranges in the tree. If `with_headers` is true,
- * each range's entries are prefixed with header information (numDocs, numEntries, etc).
- * When `t` is NULL (index not yet created), an empty array is returned.
- *
- * # Safety
- *
- * - `ctx` must be a valid Redis module context.
- * - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
- */
-void NumericRangeTree_DebugDumpIndex(struct RedisModuleCtx *ctx, const struct NumericRangeTree *t, bool with_headers);
+NumericRangeTreeIterator *NumericRangeTreeIterator_New(const struct NumericRangeTree *t);
 
 /**
  * Advance the iterator and return the next node.
@@ -242,102 +186,6 @@ void NumericRangeTree_DebugDumpIndex(struct RedisModuleCtx *ctx, const struct Nu
  * - The tree from which this iterator was created must still be valid.
  */
 const struct NumericRangeNode *NumericRangeTreeIterator_Next(NumericRangeTreeIterator *it);
-
-/**
- * Get the maximum value in a range.
- *
- * # Safety
- *
- * - `range` must point to a valid [`NumericRange`] and cannot be NULL.
- */
-double NumericRange_MaxVal(const struct NumericRange *range);
-
-/**
- * Get the unique ID of the tree.
- *
- * # Safety
- *
- * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
- */
-uint32_t NumericRangeTree_GetUniqueId(const struct NumericRangeTree *t);
-
-/**
- * Get the inverted index size in bytes.
- *
- * # Safety
- *
- * - `range` must point to a valid [`NumericRange`] and cannot be NULL.
- */
-size_t NumericRange_InvertedIndexSize(const struct NumericRange *range);
-
-/**
- * Get the number of entries in the tree.
- *
- * # Safety
- *
- * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
- */
-size_t NumericRangeTree_GetNumEntries(const struct NumericRangeTree *t);
-
-/**
- * Reply with a dump of the numeric index tree structure (for DUMP_NUMIDXTREE).
- *
- * This outputs the tree structure as a nested map. If `minimal` is true,
- * range entry details are omitted (only tree structure is shown).
- * When `t` is NULL (index not yet created), all values are zero with an empty root.
- *
- * # Safety
- *
- * - `ctx` must be a valid Redis module context.
- * - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
- */
-void NumericRangeTree_DebugDumpTree(struct RedisModuleCtx *ctx, const struct NumericRangeTree *t, bool minimal);
-
-/**
- * Free a [`NumericRangeTreeIterator`].
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `it` must point to a valid [`NumericRangeTreeIterator`] obtained from
- *   [`NumericRangeTreeIterator_New`], or be NULL (in which case this is a no-op).
- * - After calling this function, `it` must not be used again.
- */
-void NumericRangeTreeIterator_Free(NumericRangeTreeIterator *it);
-
-/**
- * Get the number of ranges in the tree.
- *
- * # Safety
- *
- * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
- */
-size_t NumericRangeTree_GetNumRanges(const struct NumericRangeTree *t);
-
-/**
- * Get the inverted index entries from a range.
- *
- * Returns a pointer to the [`InvertedIndexNumeric`] (which is a `NumericIndex` enum)
- * stored inside the range. The returned pointer is valid until the tree is modified or freed.
- *
- * # Safety
- *
- * - `range` must point to a valid [`NumericRange`] and cannot be NULL.
- * - The returned pointer points to memory owned by the range; do not free it.
- */
-const struct InvertedIndexNumeric *NumericRange_GetEntries(const struct NumericRange *range);
-
-/**
- * Create a new [`NumericRangeTree`].
- *
- * Returns an opaque pointer to the newly created tree.
- * To free the tree, use [`NumericRangeTree_Free`].
- *
- * If `compress_floats` is true, the tree will use float compression which
- * attempts to store f64 values as f32 when precision loss is acceptable (< 0.01).
- * This corresponds to the `RSGlobalConfig.numericCompress` setting.
- */
-struct NumericRangeTree *NewNumericRangeTree(bool compress_floats);
 
 /**
  * Parse a serialized GC entry and apply it to the specified node.
@@ -359,6 +207,98 @@ struct NumericRangeTree *NewNumericRangeTree(bool compress_floats);
 struct ApplyGcEntryResult NumericRangeTree_ApplyGcEntry(struct NumericRangeTree *tree, uint32_t node_position, uint32_t node_generation, const uint8_t *entry_data, size_t entry_len);
 
 /**
+ * Get the base size of a NumericRangeTree struct (not including contents).
+ *
+ * This is used for memory overhead calculations.
+ */
+size_t NumericRangeTree_BaseSize(void);
+
+/**
+ * Conditionally trim empty leaves and compact the node slab.
+ *
+ * Checks if the number of empty leaves exceeds half the total number of
+ * leaves. If so, trims empty leaves, compacts the slab to reclaim freed
+ * slots, and returns the number of bytes freed. Returns 0 if no trimming
+ * was needed.
+ *
+ * # Safety
+ *
+ * - `t` must point to a valid mutable [`NumericRangeTree`] and cannot be NULL.
+ * - No iterators should be active on this tree while calling this function.
+ */
+struct CompactIfSparseResult NumericRangeTree_CompactIfSparse(struct NumericRangeTree *t);
+
+/**
+ * Reply with a dump of the numeric index entries (for DUMP_NUMIDX).
+ *
+ * This outputs all entries from all ranges in the tree. If `with_headers` is true,
+ * each range's entries are prefixed with header information (numDocs, numEntries, etc).
+ * When `t` is NULL (index not yet created), an empty array is returned.
+ *
+ * # Safety
+ *
+ * - `ctx` must be a valid Redis module context.
+ * - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
+ */
+void NumericRangeTree_DebugDumpIndex(struct RedisModuleCtx *ctx, const struct NumericRangeTree *t, bool with_headers);
+
+/**
+ * Reply with a dump of the numeric index tree structure (for DUMP_NUMIDXTREE).
+ *
+ * This outputs the tree structure as a nested map. If `minimal` is true,
+ * range entry details are omitted (only tree structure is shown).
+ * When `t` is NULL (index not yet created), all values are zero with an empty root.
+ *
+ * # Safety
+ *
+ * - `ctx` must be a valid Redis module context.
+ * - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
+ */
+void NumericRangeTree_DebugDumpTree(struct RedisModuleCtx *ctx, const struct NumericRangeTree *t, bool minimal);
+
+/**
+ * Reply with a summary of the numeric range tree (for NUMIDX_SUMMARY).
+ *
+ * This outputs the tree statistics in the format expected by FT.DEBUG NUMIDX_SUMMARY.
+ * When `t` is NULL (index not yet created), all values are reported as zero.
+ *
+ * # Safety
+ *
+ * - `ctx` must be a valid Redis module context.
+ * - `t` must be either NULL or a valid pointer to a [`NumericRangeTree`].
+ */
+void NumericRangeTree_DebugSummary(struct RedisModuleCtx *ctx, const struct NumericRangeTree *t);
+
+/**
+ * Find all numeric ranges that match the given filter.
+ *
+ * Returns a [`NumericRangeTreeFindResult`] containing pointers to the matching
+ * ranges. The ranges are owned by the tree and must not be freed individually.
+ * The result itself must be freed using [`NumericRangeTreeFindResult_Free`].
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `t` must point to a valid [`NumericRangeTree`] obtained from
+ *   [`NewNumericRangeTree`] and cannot be NULL.
+ * - `nf` must point to a valid [`NumericFilter`] and cannot be NULL.
+ */
+struct NumericRangeTreeFindResult NumericRangeTree_Find(const struct NumericRangeTree *t, const struct NumericFilter *nf);
+
+/**
+ * Free a [`NumericRangeTree`] and all its contents.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `t` must point to a valid [`NumericRangeTree`] obtained from
+ *   [`NewNumericRangeTree`], or be NULL (in which case this is a no-op).
+ * - After calling this function, `t` must not be used again.
+ * - Any iterators obtained from this tree must be freed before calling this.
+ */
+void NumericRangeTree_Free(struct NumericRangeTree *t);
+
+/**
  * Get the total size of inverted indexes in the tree.
  *
  * # Safety
@@ -368,20 +308,34 @@ struct ApplyGcEntryResult NumericRangeTree_ApplyGcEntry(struct NumericRangeTree 
 size_t NumericRangeTree_GetInvertedIndexesSize(const struct NumericRangeTree *t);
 
 /**
- * Add a (docId, value) pair to the tree.
- *
- * If `isMulti` is non-zero, duplicate document IDs are allowed.
- * `maxDepthRange` specifies the maximum depth at which to retain ranges on inner nodes.
- *
- * Returns information about what changed during the add operation.
+ * Get the number of entries in the tree.
  *
  * # Safety
  *
- * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid [`NumericRangeTree`] obtained from
- *   [`NewNumericRangeTree`] and cannot be NULL.
+ * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
  */
-struct AddResult _NumericRangeTree_Add(struct NumericRangeTree *t, t_docId doc_id, double value, bool has_field_expiration, int isMulti, size_t maxDepthRange);
+size_t NumericRangeTree_GetNumEntries(const struct NumericRangeTree *t);
+
+/**
+ * Get the number of ranges in the tree.
+ *
+ * # Safety
+ *
+ * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+ */
+size_t NumericRangeTree_GetNumRanges(const struct NumericRangeTree *t);
+
+/**
+ * Get the revision ID of the tree.
+ *
+ * The revision ID changes whenever the tree structure is modified (nodes split, etc.).
+ * This is used by iterators to detect concurrent modifications.
+ *
+ * # Safety
+ *
+ * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+ */
+uint32_t NumericRangeTree_GetRevisionId(const struct NumericRangeTree *t);
 
 /**
  * Get the root node of the tree.
@@ -392,6 +346,111 @@ struct AddResult _NumericRangeTree_Add(struct NumericRangeTree *t, t_docId doc_i
  * - The returned pointer is valid until the tree is modified or freed.
  */
 const struct NumericRangeNode *NumericRangeTree_GetRoot(const struct NumericRangeTree *t);
+
+/**
+ * Get the unique ID of the tree.
+ *
+ * # Safety
+ *
+ * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+ */
+uint32_t NumericRangeTree_GetUniqueId(const struct NumericRangeTree *t);
+
+/**
+ * Increment the revision ID.
+ *
+ * This method is never needed in production code: the tree
+ * revision ID is automatically incremented when the tree structure changes.
+ *
+ * This method is provided primarily for testing purposes—e.g. to force the invalidation
+ * of an iterator built on top of this tree in GC tests.
+ *
+ * # Safety
+ *
+ * - `t` must point to a valid [`NumericRangeTree`] and cannot be NULL.
+ * - The caller must have unique access to `t`.
+ */
+uint32_t NumericRangeTree_IncrementRevisionId(struct NumericRangeTree *t);
+
+/**
+ * Get the total memory usage of the tree in bytes.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `t` must point to a valid [`NumericRangeTree`] obtained from
+ *   [`NewNumericRangeTree`] and cannot be NULL.
+ */
+size_t NumericRangeTree_MemUsage(const struct NumericRangeTree *t);
+
+/**
+ * Trim empty leaves from the tree (garbage collection).
+ *
+ * Removes leaf nodes that have no documents and prunes the tree structure
+ * accordingly.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `t` must point to a valid [`NumericRangeTree`] obtained from
+ *   [`NewNumericRangeTree`] and cannot be NULL.
+ * - No iterators should be active on this tree while calling this function.
+ */
+struct TrimEmptyLeavesResult NumericRangeTree_TrimEmptyLeaves(struct NumericRangeTree *t);
+
+/**
+ * Get the estimated cardinality (number of distinct values) for a range.
+ *
+ * This uses HyperLogLog estimation and may have some error margin.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `range` must point to a valid [`NumericRange`] obtained from
+ *   [`crate::node::NumericRangeNode_GetRange`] and cannot be NULL.
+ * - The tree from which this range came must still be valid.
+ */
+size_t NumericRange_GetCardinality(const struct NumericRange *range);
+
+/**
+ * Get the inverted index entries from a range.
+ *
+ * Returns a pointer to the [`InvertedIndexNumeric`] (which is a `NumericIndex` enum)
+ * stored inside the range. The returned pointer is valid until the tree is modified or freed.
+ *
+ * # Safety
+ *
+ * - `range` must point to a valid [`NumericRange`] and cannot be NULL.
+ * - The returned pointer points to memory owned by the range; do not free it.
+ */
+const struct InvertedIndexNumeric *NumericRange_GetEntries(const struct NumericRange *range);
+
+/**
+ * Get the inverted index size in bytes.
+ *
+ * # Safety
+ *
+ * - `range` must point to a valid [`NumericRange`] and cannot be NULL.
+ */
+size_t NumericRange_InvertedIndexSize(const struct NumericRange *range);
+
+/**
+ * Get the maximum value in a range.
+ *
+ * # Safety
+ *
+ * - `range` must point to a valid [`NumericRange`] and cannot be NULL.
+ */
+double NumericRange_MaxVal(const struct NumericRange *range);
+
+/**
+ * Get the minimum value in a range.
+ *
+ * # Safety
+ *
+ * - `range` must point to a valid [`NumericRange`] and cannot be NULL.
+ */
+double NumericRange_MinVal(const struct NumericRange *range);
 
 /**
  * Create an [`IndexReader`] for iterating over a [`NumericRange`]'s entries.
@@ -415,20 +474,12 @@ const struct NumericRangeNode *NumericRangeTree_GetRoot(const struct NumericRang
 struct IndexReader *NumericRange_NewIndexReader(const struct NumericRange *range, const struct NumericFilter *filter);
 
 /**
- * Free a [`NumericRangeTree`] and all its contents.
+ * Add a (docId, value) pair to the tree.
  *
- * # Safety
+ * If `isMulti` is non-zero, duplicate document IDs are allowed.
+ * `maxDepthRange` specifies the maximum depth at which to retain ranges on inner nodes.
  *
- * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid [`NumericRangeTree`] obtained from
- *   [`NewNumericRangeTree`], or be NULL (in which case this is a no-op).
- * - After calling this function, `t` must not be used again.
- * - Any iterators obtained from this tree must be freed before calling this.
- */
-void NumericRangeTree_Free(struct NumericRangeTree *t);
-
-/**
- * Get the total memory usage of the tree in bytes.
+ * Returns information about what changed during the add operation.
  *
  * # Safety
  *
@@ -436,58 +487,7 @@ void NumericRangeTree_Free(struct NumericRangeTree *t);
  * - `t` must point to a valid [`NumericRangeTree`] obtained from
  *   [`NewNumericRangeTree`] and cannot be NULL.
  */
-size_t NumericRangeTree_MemUsage(const struct NumericRangeTree *t);
-
-/**
- * Find all numeric ranges that match the given filter.
- *
- * Returns a [`NumericRangeTreeFindResult`] containing pointers to the matching
- * ranges. The ranges are owned by the tree and must not be freed individually.
- * The result itself must be freed using [`NumericRangeTreeFindResult_Free`].
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid [`NumericRangeTree`] obtained from
- *   [`NewNumericRangeTree`] and cannot be NULL.
- * - `nf` must point to a valid [`NumericFilter`] and cannot be NULL.
- */
-struct NumericRangeTreeFindResult NumericRangeTree_Find(const struct NumericRangeTree *t, const struct NumericFilter *nf);
-
-/**
- * Free a [`NumericRangeTreeFindResult`].
- *
- * This frees the array allocation but NOT the ranges themselves (they are
- * owned by the tree).
- *
- * # Safety
- *
- * - `result` must have been obtained from [`NumericRangeTree_Find`].
- * - After calling this function, the result must not be used again.
- */
-void NumericRangeTreeFindResult_Free(struct NumericRangeTreeFindResult result);
-
-/**
- * Trim empty leaves from the tree (garbage collection).
- *
- * Removes leaf nodes that have no documents and prunes the tree structure
- * accordingly.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid [`NumericRangeTree`] obtained from
- *   [`NewNumericRangeTree`] and cannot be NULL.
- * - No iterators should be active on this tree while calling this function.
- */
-struct TrimEmptyLeavesResult NumericRangeTree_TrimEmptyLeaves(struct NumericRangeTree *t);
-
-/**
- * Get the base size of a NumericRangeTree struct (not including contents).
- *
- * This is used for memory overhead calculations.
- */
-size_t NumericRangeTree_BaseSize(void);
+struct AddResult _NumericRangeTree_Add(struct NumericRangeTree *t, t_docId doc_id, double value, bool has_field_expiration, int isMulti, size_t maxDepthRange);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/query_error_ffi.h
+++ b/src/redisearch_rs/headers/query_error_ffi.h
@@ -50,59 +50,28 @@ extern "C" {
 #endif // __cplusplus
 
 /**
- * Returns the default [`QueryError`].
- */
-struct QueryError QueryError_Default(void);
-
-/**
- * Returns true if `query_error` has no error code set.
+ * Clears any error set on a [`QueryErrorCode`].
+ *
+ * This is equivalent to resetting `query_error` to the value returned by
+ * [`QueryError_Default`].
  *
  * # Safety
  *
- * `query_error` must have been created by [`QueryError_Default`].
+ * - `query_error` must have been created by [`QueryError_Default`].
  */
-bool QueryError_IsOk(const struct QueryError *query_error);
+void QueryError_ClearError(struct QueryError *query_error);
 
 /**
- * Returns true if `query_error` has an error code set.
+ * Clones the `src` [`QueryError`] into `dest`.
+ *
+ * This does nothing if `dest` already has an error set.
  *
  * # Safety
  *
- * `query_error` must have been created by [`QueryError_Default`].
+ * - `src` must have been created by [`QueryError_Default`].
+ * - `dest` must have been created by [`QueryError_Default`].
  */
-bool QueryError_HasError(const struct QueryError *query_error);
-
-/**
- * Returns the full default error string for a [`QueryErrorCode`] (prefix + message).
- *
- * This function should always return without a panic for any value provided.
- * It is unique among the `QueryError_*` API as the only function which allows
- * an invalid [`QueryErrorCode`] to be provided.
- */
-const char *QueryError_Strerror(uint8_t maybe_code);
-
-/**
- * Returns only the error prefix string for a [`QueryErrorCode`] (e.g. `"SEARCH_TIMEOUT: "`).
- *
- * Returns an empty string for `Ok` and `"Unknown status code"` for invalid codes.
- */
-const char *QueryError_StrerrorPrefix(uint8_t maybe_code);
-
-/**
- * Returns only the default message for a [`QueryErrorCode`] (without the prefix).
- *
- * Returns `"Unknown status code"` for invalid codes.
- */
-const char *QueryError_StrerrorDefaultMessage(uint8_t maybe_code);
-
-/**
- * Returns a human-readable string representing the provided [`QueryWarningCode`].
- *
- * This function should always return without a panic for any value provided.
- * It is unique among the `QueryWarning_*` API as the only function which allows
- * an invalid [`QueryWarningCode`] to be provided.
- */
-const char *QueryWarning_Strwarning(uint8_t maybe_code);
+void QueryError_CloneFrom(const struct QueryError *src, struct QueryError *dest);
 
 /**
  * Returns the maximum valid numeric value for [`QueryErrorCode`].
@@ -111,6 +80,20 @@ const char *QueryWarning_Strwarning(uint8_t maybe_code);
  * hardcoding the current "last" variant.
  */
 uint8_t QueryError_CodeMaxValue(void);
+
+/**
+ * Returns the default [`QueryError`].
+ */
+struct QueryError QueryError_Default(void);
+
+/**
+ * Returns the [`QueryErrorCode`] set for a [`QueryError`].
+ *
+ * # Safety
+ *
+ * - `query_error` must have been created by [`QueryError_Default`].
+ */
+QueryErrorCode QueryError_GetCode(const struct QueryError *query_error);
 
 /**
  * Returns a [`QueryErrorCode`] given an error message.
@@ -132,14 +115,74 @@ uint8_t QueryError_CodeMaxValue(void);
 QueryErrorCode QueryError_GetCodeFromMessage(const char *message);
 
 /**
- * Sets the [`QueryErrorCode`] and error message for a [`QueryError`].
+ * Returns an message of a [`QueryError`].
  *
- * The public message is stored as-is (for obfuscated display).
- * The private message is stored with the error code prefix prepended
- * (e.g. `"SEARCH_TIMEOUT: "` + message), so that Redis error stats
- * can track errors by their unique prefix.
+ * This preferentially returns the private message if any, or the public
+ * message if any, lastly defaulting to the error code's string error.
  *
- * This does not mutate `query_error` if it already has an error set.
+ * If `obfuscate` is set, the private message is not returned. The public
+ * message is returned, if any, defaulting to the error code's string error.
+ *
+ * # Safety
+ *
+ * - `query_error` must have been created by [`QueryError_Default`].
+ */
+const char *QueryError_GetDisplayableError(const struct QueryError *query_error, bool obfuscate);
+
+/**
+ * Returns the private message set for a [`QueryError`]. If no private message
+ * is set, this returns the string error message for the code that is set,
+ * like [`QueryError_Strerror`].
+ *
+ * # Safety
+ *
+ * - `query_error` must have been created by [`QueryError_Default`].
+ */
+const char *QueryError_GetUserError(const struct QueryError *query_error);
+
+/**
+ * Returns true if `query_error` has an error code set.
+ *
+ * # Safety
+ *
+ * `query_error` must have been created by [`QueryError_Default`].
+ */
+bool QueryError_HasError(const struct QueryError *query_error);
+
+/**
+ * Returns whether the [`QueryError`] has the `out_of_memory` warning set.
+ *
+ * # Safety
+ *
+ * - `query_error` must have been created by [`QueryError_Default`].
+ */
+bool QueryError_HasQueryOOMWarning(const struct QueryError *query_error);
+
+/**
+ * Returns whether the [`QueryError`] has the `reached_max_prefix_expansions`
+ * warning set.
+ *
+ * # Safety
+ *
+ * - `query_error` must have been created by [`QueryError_Default`].
+ */
+bool QueryError_HasReachedMaxPrefixExpansionsWarning(const struct QueryError *query_error);
+
+/**
+ * Returns true if `query_error` has no error code set.
+ *
+ * # Safety
+ *
+ * `query_error` must have been created by [`QueryError_Default`].
+ */
+bool QueryError_IsOk(const struct QueryError *query_error);
+
+/**
+ * Sets the [`QueryErrorCode`] for a [`QueryError`].
+ *
+ * This does not mutate `query_error` if it already has an error set, or
+ * if the private message is set. This differs from [`QueryError_SetCode`],
+ * as that function does not care if the private message is set.
  *
  * # Panics
  *
@@ -148,9 +191,8 @@ QueryErrorCode QueryError_GetCodeFromMessage(const char *message);
  * # Safety
  *
  * - `query_error` must have been created by [`QueryError_Default`].
- * - `message` must be a valid C string or a NULL pointer.
  */
-void QueryError_SetError(struct QueryError *query_error, uint8_t code, const char *message);
+void QueryError_MaybeSetCode(struct QueryError *query_error, uint8_t code);
 
 /**
  * Sets the [`QueryErrorCode`] for a [`QueryError`].
@@ -178,70 +220,14 @@ void QueryError_SetCode(struct QueryError *query_error, uint8_t code);
 void QueryError_SetDetail(struct QueryError *query_error, const char *detail);
 
 /**
- * Clones the `src` [`QueryError`] into `dest`.
+ * Sets the [`QueryErrorCode`] and error message for a [`QueryError`].
  *
- * This does nothing if `dest` already has an error set.
+ * The public message is stored as-is (for obfuscated display).
+ * The private message is stored with the error code prefix prepended
+ * (e.g. `"SEARCH_TIMEOUT: "` + message), so that Redis error stats
+ * can track errors by their unique prefix.
  *
- * # Safety
- *
- * - `src` must have been created by [`QueryError_Default`].
- * - `dest` must have been created by [`QueryError_Default`].
- */
-void QueryError_CloneFrom(const struct QueryError *src, struct QueryError *dest);
-
-/**
- * Returns the private message set for a [`QueryError`]. If no private message
- * is set, this returns the string error message for the code that is set,
- * like [`QueryError_Strerror`].
- *
- * # Safety
- *
- * - `query_error` must have been created by [`QueryError_Default`].
- */
-const char *QueryError_GetUserError(const struct QueryError *query_error);
-
-/**
- * Returns an message of a [`QueryError`].
- *
- * This preferentially returns the private message if any, or the public
- * message if any, lastly defaulting to the error code's string error.
- *
- * If `obfuscate` is set, the private message is not returned. The public
- * message is returned, if any, defaulting to the error code's string error.
- *
- * # Safety
- *
- * - `query_error` must have been created by [`QueryError_Default`].
- */
-const char *QueryError_GetDisplayableError(const struct QueryError *query_error, bool obfuscate);
-
-/**
- * Returns the [`QueryErrorCode`] set for a [`QueryError`].
- *
- * # Safety
- *
- * - `query_error` must have been created by [`QueryError_Default`].
- */
-QueryErrorCode QueryError_GetCode(const struct QueryError *query_error);
-
-/**
- * Clears any error set on a [`QueryErrorCode`].
- *
- * This is equivalent to resetting `query_error` to the value returned by
- * [`QueryError_Default`].
- *
- * # Safety
- *
- * - `query_error` must have been created by [`QueryError_Default`].
- */
-void QueryError_ClearError(struct QueryError *query_error);
-
-/**
- * Sets the [`QueryErrorCode`] for a [`QueryError`].
- *
- * This does not mutate `query_error` if it already has an error set, or
- * if the private message is set. This differs from [`QueryError_SetCode`],
- * as that function does not care if the private message is set.
+ * This does not mutate `query_error` if it already has an error set.
  *
  * # Panics
  *
@@ -250,18 +236,18 @@ void QueryError_ClearError(struct QueryError *query_error);
  * # Safety
  *
  * - `query_error` must have been created by [`QueryError_Default`].
+ * - `message` must be a valid C string or a NULL pointer.
  */
-void QueryError_MaybeSetCode(struct QueryError *query_error, uint8_t code);
+void QueryError_SetError(struct QueryError *query_error, uint8_t code, const char *message);
 
 /**
- * Returns whether the [`QueryError`] has the `reached_max_prefix_expansions`
- * warning set.
+ * Sets the `out_of_memory` warning on the [`QueryError`].
  *
  * # Safety
  *
  * - `query_error` must have been created by [`QueryError_Default`].
  */
-bool QueryError_HasReachedMaxPrefixExpansionsWarning(const struct QueryError *query_error);
+void QueryError_SetQueryOOMWarning(struct QueryError *query_error);
 
 /**
  * Sets the `reached_max_prefix_expansions` warning on the [`QueryError`].
@@ -273,22 +259,27 @@ bool QueryError_HasReachedMaxPrefixExpansionsWarning(const struct QueryError *qu
 void QueryError_SetReachedMaxPrefixExpansionsWarning(struct QueryError *query_error);
 
 /**
- * Returns whether the [`QueryError`] has the `out_of_memory` warning set.
+ * Returns the full default error string for a [`QueryErrorCode`] (prefix + message).
  *
- * # Safety
- *
- * - `query_error` must have been created by [`QueryError_Default`].
+ * This function should always return without a panic for any value provided.
+ * It is unique among the `QueryError_*` API as the only function which allows
+ * an invalid [`QueryErrorCode`] to be provided.
  */
-bool QueryError_HasQueryOOMWarning(const struct QueryError *query_error);
+const char *QueryError_Strerror(uint8_t maybe_code);
 
 /**
- * Sets the `out_of_memory` warning on the [`QueryError`].
+ * Returns only the default message for a [`QueryErrorCode`] (without the prefix).
  *
- * # Safety
- *
- * - `query_error` must have been created by [`QueryError_Default`].
+ * Returns `"Unknown status code"` for invalid codes.
  */
-void QueryError_SetQueryOOMWarning(struct QueryError *query_error);
+const char *QueryError_StrerrorDefaultMessage(uint8_t maybe_code);
+
+/**
+ * Returns only the error prefix string for a [`QueryErrorCode`] (e.g. `"SEARCH_TIMEOUT: "`).
+ *
+ * Returns an empty string for `Ok` and `"Unknown status code"` for invalid codes.
+ */
+const char *QueryError_StrerrorPrefix(uint8_t maybe_code);
 
 /**
  * Returns a [`QueryWarningCode`] given an warnings message.
@@ -304,6 +295,15 @@ void QueryError_SetQueryOOMWarning(struct QueryError *query_error);
  * - `message` must be a valid C string or a NULL pointer.
  */
 QueryWarningCode QueryWarningCode_GetCodeFromMessage(const char *message);
+
+/**
+ * Returns a human-readable string representing the provided [`QueryWarningCode`].
+ *
+ * This function should always return without a panic for any value provided.
+ * It is unique among the `QueryWarning_*` API as the only function which allows
+ * an invalid [`QueryWarningCode`] to be provided.
+ */
+const char *QueryWarning_Strwarning(uint8_t maybe_code);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/query_eval_ffi.h
+++ b/src/redisearch_rs/headers/query_eval_ffi.h
@@ -35,49 +35,6 @@ extern "C" {
 #endif // __cplusplus
 
 /**
- * Whether the scorer named `scorer_name` needs term offset data.
- *
- * A null `scorer_name` falls back to the configured default scorer
- * ([`ffi::RSGlobalConfig`]'s `defaultScorer`), and a custom or
- * otherwise unrecognised name conservatively needs offsets.
- *
- * # Safety
- *
- * `scorer_name` must be null or a valid NUL-terminated C string.
- */
-bool scorerNeedsOffsets(const char *scorer_name);
-
-/**
- * Whether a query node needs term offset data.
- *
- * # Safety
- *
- * `scorer_name` must be null or a valid NUL-terminated C string; `opts` must be
- * null or point to a valid [`QueryNodeOptions`].
- */
-bool queryNeedsOffsets(const char *scorer_name, const struct QueryNodeOptions *opts);
-
-/**
- * Evaluate a single query AST node, producing the corresponding
- * [`QueryIterator`].
- *
- * Returns a null pointer when the node produces no results (e.g. a
- * missing-field node for a field that has no missing values).
- *
- * # Safety
- *
- * 1. `q` must be a non-null pointer to a valid [`QueryEvalCtx`] that satisfies
- *    all the invariants documented on [`QueryEvalContext::new`] and remains
- *    valid for the lifetime of the returned iterator.
- * 2. `n` must be a non-null pointer to a valid [`RSQueryNode`].
- * 3. `eval_config` must be a non-null [`EvalConfig`](ffi::EvalConfig) handle
- *    pointing to a valid [`Config`] that stays valid for the duration of the
- *    call — the snapshot [`QAST_Iterate`] loaded and threaded through the C
- *    dispatcher.
- */
-QueryIterator *Query_EvalNode_Rs(QueryEvalCtx *q, RSQueryNode *n, const EvalConfig *eval_config);
-
-/**
  * Build the executable iterator tree for a parsed query AST and return its
  * root [`QueryIterator`].
  *
@@ -101,6 +58,49 @@ QueryIterator *Query_EvalNode_Rs(QueryEvalCtx *q, RSQueryNode *n, const EvalConf
  * the lifetime of the returned iterator.
  */
 QueryIterator *QAST_Iterate(QueryAST *qast, const RSSearchOptions *opts, RedisSearchCtx *sctx, uint32_t reqflags, AREQ *areq, QueryError *status);
+
+/**
+ * Evaluate a single query AST node, producing the corresponding
+ * [`QueryIterator`].
+ *
+ * Returns a null pointer when the node produces no results (e.g. a
+ * missing-field node for a field that has no missing values).
+ *
+ * # Safety
+ *
+ * 1. `q` must be a non-null pointer to a valid [`QueryEvalCtx`] that satisfies
+ *    all the invariants documented on [`QueryEvalContext::new`] and remains
+ *    valid for the lifetime of the returned iterator.
+ * 2. `n` must be a non-null pointer to a valid [`RSQueryNode`].
+ * 3. `eval_config` must be a non-null [`EvalConfig`](ffi::EvalConfig) handle
+ *    pointing to a valid [`Config`] that stays valid for the duration of the
+ *    call — the snapshot [`QAST_Iterate`] loaded and threaded through the C
+ *    dispatcher.
+ */
+QueryIterator *Query_EvalNode_Rs(QueryEvalCtx *q, RSQueryNode *n, const EvalConfig *eval_config);
+
+/**
+ * Whether a query node needs term offset data.
+ *
+ * # Safety
+ *
+ * `scorer_name` must be null or a valid NUL-terminated C string; `opts` must be
+ * null or point to a valid [`QueryNodeOptions`].
+ */
+bool queryNeedsOffsets(const char *scorer_name, const struct QueryNodeOptions *opts);
+
+/**
+ * Whether the scorer named `scorer_name` needs term offset data.
+ *
+ * A null `scorer_name` falls back to the configured default scorer
+ * ([`ffi::RSGlobalConfig`]'s `defaultScorer`), and a custom or
+ * otherwise unrecognised name conservatively needs offsets.
+ *
+ * # Safety
+ *
+ * `scorer_name` must be null or a valid NUL-terminated C string.
+ */
+bool scorerNeedsOffsets(const char *scorer_name);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/query_term_ffi.h
+++ b/src/redisearch_rs/headers/query_term_ffi.h
@@ -42,27 +42,6 @@ extern "C" {
 struct RSQueryTerm *NewQueryTerm(const RSToken *tok, int id);
 
 /**
- * Free an [`RSQueryTerm`] previously allocated by [`NewQueryTerm`].
- *
- * # Safety
- *
- * - `t` may be NULL (in which case this is a no-op).
- * - If non-NULL, `t` must have been allocated by [`NewQueryTerm`].
- * - After this call, `t` is dangling and must not be used.
- */
-void Term_Free(struct RSQueryTerm *t);
-
-/**
- * Get the IDF (inverse document frequency) value from a query term.
- *
- * # Safety
- *
- * `term` must be a valid, non-null pointer to an [`RSQueryTerm`] previously
- * allocated by [`NewQueryTerm`].
- */
-double QueryTerm_GetIDF(const struct RSQueryTerm *term);
-
-/**
  * Get the BM25 IDF value from a query term.
  *
  * # Safety
@@ -71,18 +50,6 @@ double QueryTerm_GetIDF(const struct RSQueryTerm *term);
  * allocated by [`NewQueryTerm`].
  */
 double QueryTerm_GetBM25_IDF(const struct RSQueryTerm *term);
-
-/**
- * Set both IDF values (TF-IDF and BM25) on a query term.
- *
- * This is a convenience function for setting both values at once.
- *
- * # Safety
- *
- * `term` must be a valid, non-null pointer to an [`RSQueryTerm`] previously
- * allocated by [`NewQueryTerm`].
- */
-void QueryTerm_SetIDFs(struct RSQueryTerm *term, double idf, double bm25_idf);
 
 /**
  * Get the term ID.
@@ -95,6 +62,16 @@ void QueryTerm_SetIDFs(struct RSQueryTerm *term, double idf, double bm25_idf);
  * allocated by [`NewQueryTerm`].
  */
 int QueryTerm_GetID(const struct RSQueryTerm *term);
+
+/**
+ * Get the IDF (inverse document frequency) value from a query term.
+ *
+ * # Safety
+ *
+ * `term` must be a valid, non-null pointer to an [`RSQueryTerm`] previously
+ * allocated by [`NewQueryTerm`].
+ */
+double QueryTerm_GetIDF(const struct RSQueryTerm *term);
 
 /**
  * Get the term string length in bytes.
@@ -117,6 +94,29 @@ size_t QueryTerm_GetLen(const struct RSQueryTerm *term);
  * - `out_len` must be a valid pointer to write the length to
  */
 const char *QueryTerm_GetStrAndLen(const struct RSQueryTerm *term, size_t *out_len);
+
+/**
+ * Set both IDF values (TF-IDF and BM25) on a query term.
+ *
+ * This is a convenience function for setting both values at once.
+ *
+ * # Safety
+ *
+ * `term` must be a valid, non-null pointer to an [`RSQueryTerm`] previously
+ * allocated by [`NewQueryTerm`].
+ */
+void QueryTerm_SetIDFs(struct RSQueryTerm *term, double idf, double bm25_idf);
+
+/**
+ * Free an [`RSQueryTerm`] previously allocated by [`NewQueryTerm`].
+ *
+ * # Safety
+ *
+ * - `t` may be NULL (in which case this is a no-op).
+ * - If non-NULL, `t` must have been allocated by [`NewQueryTerm`].
+ * - After this call, `t` is dangling and must not be used.
+ */
+void Term_Free(struct RSQueryTerm *t);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/query_types.h
+++ b/src/redisearch_rs/headers/query_types.h
@@ -499,49 +499,14 @@ typedef struct QueryNodeOptions {
 } QueryNodeOptions;
 
 /**
- * Default query expander (`DEFAULT`). Used when a query does not request one.
- */
-#define DEFAULT_EXPANDER_NAME "DEFAULT"
-
-/**
- * Phonetic-matching query expander (`PHONETIC`).
- */
-#define PHONETIC_EXPENDER_NAME "PHONETIC"
-
-/**
- * TF-IDF scorer (`TFIDF`). Uses term proximity, so it needs term offsets.
- */
-#define TFIDF_SCORER_NAME "TFIDF"
-
-/**
- * Synonym-expansion query expander (`SYNONYM`).
- */
-#define SYNONYMS_EXPENDER_NAME "SYNONYM"
-
-/**
- * Document-normalized TF-IDF scorer (`TFIDF.DOCNORM`).
- */
-#define TFIDF_DOCNORM_SCORER_NAME "TFIDF.DOCNORM"
-
-/**
- * Stemming query expander (`SBSTEM`).
- */
-#define STEMMER_EXPENDER_NAME "SBSTEM"
-
-/**
- * Disjunction-max scorer (`DISMAX`).
- */
-#define DISMAX_SCORER_NAME "DISMAX"
-
-/**
  * Legacy BM25 scorer (`BM25`).
  */
 #define BM25_SCORER_NAME "BM25"
 
 /**
- * Standard BM25 scorer (`BM25STD`). The default scorer.
+ * Standard BM25 scorer with max normalization (`BM25STD.NORM`).
  */
-#define BM25_STD_SCORER_NAME "BM25STD"
+#define BM25_STD_NORMALIZED_MAX_SCORER_NAME "BM25STD.NORM"
 
 /**
  * Standard BM25 scorer with tanh normalization (`BM25STD.TANH`).
@@ -549,9 +514,28 @@ typedef struct QueryNodeOptions {
 #define BM25_STD_NORMALIZED_TANH_SCORER_NAME "BM25STD.TANH"
 
 /**
- * Standard BM25 scorer with max normalization (`BM25STD.NORM`).
+ * Standard BM25 scorer (`BM25STD`). The default scorer.
  */
-#define BM25_STD_NORMALIZED_MAX_SCORER_NAME "BM25STD.NORM"
+#define BM25_STD_SCORER_NAME "BM25STD"
+
+/**
+ * Default query expander (`DEFAULT`). Used when a query does not request one.
+ */
+#define DEFAULT_EXPANDER_NAME "DEFAULT"
+
+/**
+ * Name of the scorer used when a query does not request one explicitly.
+ *
+ * This is the standard BM25 scorer. It is spelled out as a literal, matching
+ * [`BM25_STD_SCORER_NAME`], because the C header generator only exports literal
+ * string constants.
+ */
+#define DEFAULT_SCORER_NAME "BM25STD"
+
+/**
+ * Disjunction-max scorer (`DISMAX`).
+ */
+#define DISMAX_SCORER_NAME "DISMAX"
 
 /**
  * Document-score scorer (`DOCSCORE`).
@@ -564,10 +548,26 @@ typedef struct QueryNodeOptions {
 #define HAMMINGDISTANCE_SCORER "HAMMING"
 
 /**
- * Name of the scorer used when a query does not request one explicitly.
- *
- * This is the standard BM25 scorer. It is spelled out as a literal, matching
- * [`BM25_STD_SCORER_NAME`], because the C header generator only exports literal
- * string constants.
+ * Phonetic-matching query expander (`PHONETIC`).
  */
-#define DEFAULT_SCORER_NAME "BM25STD"
+#define PHONETIC_EXPENDER_NAME "PHONETIC"
+
+/**
+ * Stemming query expander (`SBSTEM`).
+ */
+#define STEMMER_EXPENDER_NAME "SBSTEM"
+
+/**
+ * Synonym-expansion query expander (`SYNONYM`).
+ */
+#define SYNONYMS_EXPENDER_NAME "SYNONYM"
+
+/**
+ * Document-normalized TF-IDF scorer (`TFIDF.DOCNORM`).
+ */
+#define TFIDF_DOCNORM_SCORER_NAME "TFIDF.DOCNORM"
+
+/**
+ * TF-IDF scorer (`TFIDF`). Uses term proximity, so it needs term offsets.
+ */
+#define TFIDF_SCORER_NAME "TFIDF"

--- a/src/redisearch_rs/headers/reducers_ffi.h
+++ b/src/redisearch_rs/headers/reducers_ffi.h
@@ -40,6 +40,23 @@ extern "C" {
 #endif // __cplusplus
 
 /**
+ * Create a local COLLECT reducer; free it with [`collectLocalFree`].
+ *
+ * # Safety
+ *
+ * 1. `input_key` must be a [valid] pointer to an [`RLookupKey`] that remains
+ *    alive for the lifetime of the returned reducer.
+ * 2. If `field_names_len > 0`, `field_names` must point to an array of at
+ *    least `field_names_len` valid, NUL-terminated C strings. Ignored when
+ *    `load_all` is `true`.
+ * 3. If `sort_names_len > 0`, `sort_names` must point to an array of at
+ *    least `sort_names_len` valid, NUL-terminated C strings.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+Reducer *CollectReducer_CreateLocal(const RLookupKey *input_key, const char *const *field_names, size_t field_names_len, bool load_all, const char *const *sort_names, size_t sort_names_len, uint64_t sort_asc_map, bool has_limit, uint64_t limit_offset, uint64_t limit_count, bool distinct);
+
+/**
  * Creates a new [`RemoteCollectReducer`] from pre-parsed configuration and
  * returns a pointer to its base [`ffi::Reducer`] with the vtable fully wired.
  *
@@ -63,32 +80,60 @@ extern "C" {
 Reducer *CollectReducer_CreateRemote(const RLookupKey *const *field_keys, size_t field_keys_len, const RLookup *srclookup, const RLookupKey *const *sort_keys, size_t sort_keys_len, uint64_t sort_asc_map, bool has_limit, uint64_t limit_offset, uint64_t limit_count, bool is_internal, bool distinct);
 
 /**
- * Create a local COLLECT reducer; free it with [`collectLocalFree`].
- *
  * # Safety
  *
- * 1. `input_key` must be a [valid] pointer to an [`RLookupKey`] that remains
- *    alive for the lifetime of the returned reducer.
- * 2. If `field_names_len > 0`, `field_names` must point to an array of at
- *    least `field_names_len` valid, NUL-terminated C strings. Ignored when
- *    `load_all` is `true`.
- * 3. If `sort_names_len > 0`, `sort_names` must point to an array of at
- *    least `sort_names_len` valid, NUL-terminated C strings.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ * `r` must point to a valid [`RemoteCollectReducer`] originally created by
+ * `CollectReducer_CreateRemote`.
  */
-Reducer *CollectReducer_CreateLocal(const RLookupKey *input_key, const char *const *field_names, size_t field_names_len, bool load_all, const char *const *sort_names, size_t sort_names_len, uint64_t sort_asc_map, bool has_limit, uint64_t limit_offset, uint64_t limit_count, bool distinct);
+size_t CollectReducer_GetFieldKeysLen(const Reducer *r);
 
 /**
- * Creates a new per-group shard collect reducer instance.
- *
  * # Safety
  *
- * 1. `r` must point to a [valid] `ShardCollectReducer` masquerading as a `ffi::Reducer`.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ * `r` must point to a valid [`RemoteCollectReducer`] originally created by
+ * `CollectReducer_CreateRemote`.
  */
-void *collectRemoteNewInstance(Reducer *r);
+uint64_t CollectReducer_GetLimitCount(const Reducer *r);
+
+/**
+ * # Safety
+ *
+ * `r` must point to a valid [`RemoteCollectReducer`] originally created by
+ * `CollectReducer_CreateRemote`.
+ */
+uint64_t CollectReducer_GetLimitOffset(const Reducer *r);
+
+/**
+ * # Safety
+ *
+ * `r` must point to a valid [`RemoteCollectReducer`] originally created by
+ * `CollectReducer_CreateRemote`.
+ */
+uint64_t CollectReducer_GetSortAscMap(const Reducer *r);
+
+/**
+ * # Safety
+ *
+ * `r` must point to a valid [`RemoteCollectReducer`] originally created by
+ * `CollectReducer_CreateRemote`.
+ */
+size_t CollectReducer_GetSortKeysLen(const Reducer *r);
+
+/**
+ * # Safety
+ *
+ * `r` must point to a valid [`RemoteCollectReducer`] originally created by
+ * `CollectReducer_CreateRemote`.
+ */
+bool CollectReducer_HasLimit(const Reducer *r);
+
+/**
+ * # Safety
+ *
+ * `r` must point to a valid [`RemoteCollectReducer`] originally created by
+ * `CollectReducer_CreateRemote`.
+ */
+bool CollectReducer_IsLoadAll(const Reducer *r);
 
 /**
  * # Safety
@@ -102,21 +147,32 @@ bool CollectReducer_IsLocalLoadAll(const Reducer *r);
  * # Safety
  *
  * 1. `r` must point to a [valid] `LocalCollectReducer` masquerading as a `ffi::Reducer`.
+ * 2. `ctx` must point to a [valid] `CoordCollectCtx` masquerading as a void pointer.
+ * 3. `srcrow` must point to a [valid] `ffi::RLookupRow`.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-void *collectLocalNewInstance(Reducer *r);
+int collectLocalAdd(Reducer *r, void *ctx, const RLookupRow *srcrow);
 
 /**
- * Frees a per-group shard collect reducer instance.
- *
  * # Safety
  *
- * 1. `ctx` must point to a [valid] `ShardCollectCtx` masquerading as a void pointer.
+ * 1. `r` must point to a [valid] `LocalCollectReducer` masquerading as a `ffi::Reducer`.
+ * 2. `ctx` must point to a [valid] `CoordCollectCtx` masquerading as a void pointer.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-void collectRemoteFreeInstance(Reducer *_r, void *ctx);
+RSValue *collectLocalFinalize(Reducer *r, void *ctx);
+
+/**
+ * # Safety
+ *
+ * 1. `r` must point to a [valid] `CoordCollectReducer` masquerading as a `ffi::Reducer`,
+ *    originally created by [`CollectReducer_CreateLocal`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void collectLocalFree(Reducer *r);
 
 /**
  * # Safety
@@ -126,6 +182,15 @@ void collectRemoteFreeInstance(Reducer *_r, void *ctx);
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void collectLocalFreeInstance(Reducer *_r, void *ctx);
+
+/**
+ * # Safety
+ *
+ * 1. `r` must point to a [valid] `LocalCollectReducer` masquerading as a `ffi::Reducer`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void *collectLocalNewInstance(Reducer *r);
 
 /**
  * Processes the provided [`ffi::RLookupRow`] and document id with the shard
@@ -142,17 +207,6 @@ void collectLocalFreeInstance(Reducer *_r, void *ctx);
 int collectRemoteAddWithDocId(Reducer *r, void *ctx, const RLookupRow *srcrow, t_docId doc_id);
 
 /**
- * # Safety
- *
- * 1. `r` must point to a [valid] `LocalCollectReducer` masquerading as a `ffi::Reducer`.
- * 2. `ctx` must point to a [valid] `CoordCollectCtx` masquerading as a void pointer.
- * 3. `srcrow` must point to a [valid] `ffi::RLookupRow`.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-int collectLocalAdd(Reducer *r, void *ctx, const RLookupRow *srcrow);
-
-/**
  * Finalizes the shard collect reducer instance result into an `RSValue`.
  *
  * # Safety
@@ -163,16 +217,6 @@ int collectLocalAdd(Reducer *r, void *ctx, const RLookupRow *srcrow);
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 RSValue *collectRemoteFinalize(Reducer *r, void *ctx);
-
-/**
- * # Safety
- *
- * 1. `r` must point to a [valid] `LocalCollectReducer` masquerading as a `ffi::Reducer`.
- * 2. `ctx` must point to a [valid] `CoordCollectCtx` masquerading as a void pointer.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-RSValue *collectLocalFinalize(Reducer *r, void *ctx);
 
 /**
  * Frees the provided shard collect reducer (the global struct, not a
@@ -188,70 +232,26 @@ RSValue *collectLocalFinalize(Reducer *r, void *ctx);
 void collectRemoteFree(Reducer *r);
 
 /**
+ * Frees a per-group shard collect reducer instance.
+ *
  * # Safety
  *
- * 1. `r` must point to a [valid] `CoordCollectReducer` masquerading as a `ffi::Reducer`,
- *    originally created by [`CollectReducer_CreateLocal`].
+ * 1. `ctx` must point to a [valid] `ShardCollectCtx` masquerading as a void pointer.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-void collectLocalFree(Reducer *r);
+void collectRemoteFreeInstance(Reducer *_r, void *ctx);
 
 /**
+ * Creates a new per-group shard collect reducer instance.
+ *
  * # Safety
  *
- * `r` must point to a valid [`RemoteCollectReducer`] originally created by
- * `CollectReducer_CreateRemote`.
- */
-size_t CollectReducer_GetFieldKeysLen(const Reducer *r);
-
-/**
- * # Safety
+ * 1. `r` must point to a [valid] `ShardCollectReducer` masquerading as a `ffi::Reducer`.
  *
- * `r` must point to a valid [`RemoteCollectReducer`] originally created by
- * `CollectReducer_CreateRemote`.
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-bool CollectReducer_IsLoadAll(const Reducer *r);
-
-/**
- * # Safety
- *
- * `r` must point to a valid [`RemoteCollectReducer`] originally created by
- * `CollectReducer_CreateRemote`.
- */
-size_t CollectReducer_GetSortKeysLen(const Reducer *r);
-
-/**
- * # Safety
- *
- * `r` must point to a valid [`RemoteCollectReducer`] originally created by
- * `CollectReducer_CreateRemote`.
- */
-uint64_t CollectReducer_GetSortAscMap(const Reducer *r);
-
-/**
- * # Safety
- *
- * `r` must point to a valid [`RemoteCollectReducer`] originally created by
- * `CollectReducer_CreateRemote`.
- */
-bool CollectReducer_HasLimit(const Reducer *r);
-
-/**
- * # Safety
- *
- * `r` must point to a valid [`RemoteCollectReducer`] originally created by
- * `CollectReducer_CreateRemote`.
- */
-uint64_t CollectReducer_GetLimitOffset(const Reducer *r);
-
-/**
- * # Safety
- *
- * `r` must point to a valid [`RemoteCollectReducer`] originally created by
- * `CollectReducer_CreateRemote`.
- */
-uint64_t CollectReducer_GetLimitCount(const Reducer *r);
+void *collectRemoteNewInstance(Reducer *r);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/rlookup_ffi.h
+++ b/src/redisearch_rs/headers/rlookup_ffi.h
@@ -115,73 +115,27 @@ extern "C" {
 #endif // __cplusplus
 
 /**
- * Returns a newly created [`RLookupRow`].
- */
-struct RLookupRow RLookupRow_New(void);
-
-/**
- * Writes a key to the row but increments the value reference count before writing it thus having shared ownership.
+ * Retrieves an item from the given `RLookupRow` based on the provided `RLookupKey`.
+ *
+ * The function first checks for dynamic values, and if not found, it checks the sorting vector
+ * if the `SvSrc` flag is set in the key.
+ *
+ * If the item is not found in either location, it returns a NULL pointer.
  *
  * # Safety
  *
  * 1. `key` must be a [valid], non-null pointer to an [`RLookupKey`].
  * 2. `row` must be a [valid], non-null pointer to an [`RLookupRow`].
- * 3. `value` must be a [valid], non-null pointer to an [`RSValue`].
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-void RLookup_WriteKey(const RLookupKey *key, struct RLookupRow *row, struct RSValue *value);
+struct RSValue *RLookupRow_Get(const RLookupKey *key, const struct RLookupRow *row);
 
 /**
- * Add all non-overridden keys from `src` to `dest`.
+ * Returns a borrowed view of the sorting vector for the row.
  *
- * For each key in `src`, check if it already exists *by name*.
- * - If it does, the `flag` argument controls the behaviour (skip with `RLookupKeyFlags::empty()`, override with `RLookupKeyFlag::Override`).
- * - If it doesn't, a new key will be created.
- *
- * Flag handling:
- * - Preserves persistent source key properties (F_SVSRC, F_HIDDEN, F_EXPLICITRETURN, etc.)
- * - Filters out transient flags from source keys (F_OVERRIDE, F_FORCE_LOAD)
- * - Respects caller's control flags for behavior (F_OVERRIDE, F_FORCE_LOAD, etc.)
- * - Target flags = caller_flags | (source_flags & ~RLOOKUP_TRANSIENT_FLAGS)
- *
- * # Safety
- *
- * 1. `src` must be a [valid], non-null pointer to an [`RLookup`]
- * 2. `dest` must be a [valid], non-null pointer to an [`RLookup`]
- * 3. `src` and `dest` must not point to the same [`RLookup`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void RLookup_AddKeysFrom(const struct RLookup *src, struct RLookup *dest, uint32_t flags);
-
-/**
- * Writes a key to the row without incrementing the value reference count, thus taking ownership of the value.
- *
- * # Safety
- *
- * 1. `key` must be a [valid], non-null pointer to an [`RLookupKey`].
- * 2. `row` must be a [valid], non-null pointer to an [`RLookupRow`].
- * 3. `value` must be a [valid], non-null pointer to an [`RSValue`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void RLookup_WriteOwnKey(const RLookupKey *key, struct RLookupRow *row, struct RSValue *value);
-
-/**
- * Disables the given set of `RLookup` options.
- *
- * # Safety
- *
- * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
- * 2. All bits set in `options` must correspond to a value of the `RLookupOptions` enum.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void RLookup_DisableOptions(struct RLookup *lookup, uint32_t options);
-
-/**
- * Wipes a RLookupRow by decrementing all values and resetting the row.
+ * If the row has no sorting vector, returns a slice with `len == 0` and a dangling `values`
+ * pointer. Callers must check `len`, not `values`, to detect the empty case.
  *
  * # Safety
  *
@@ -189,32 +143,7 @@ void RLookup_DisableOptions(struct RLookup *lookup, uint32_t options);
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-void RLookupRow_Wipe(struct RLookupRow *row);
-
-/**
- * Enables the given set of `RLookup` options.
- *
- * # Safety
- *
- * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
- * 2. All bits set in `options` must correspond to a value of the `RLookupOptions` enum.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void RLookup_EnableOptions(struct RLookup *lookup, uint32_t options);
-
-/**
- * Resets a RLookupRow by wiping it (see [`RLookupRow_Wipe`]) and deallocating the memory of the dynamic values.
- *
- * This does not affect the sorting vector.
- *
- * # Safety
- *
- * 1. `row` must be a [valid], non-null pointer to an [`RLookupRow`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void RLookupRow_Reset(struct RLookupRow *row);
+struct RSSortingVectorSlice RLookupRow_GetSortingVector(const struct RLookupRow *row);
 
 /**
  * Move data from the source row to the destination row. The source row is cleared.
@@ -231,47 +160,46 @@ void RLookupRow_Reset(struct RLookupRow *row);
 void RLookupRow_MoveFieldsFrom(const struct RLookup *lookup, struct RLookupRow *src_row, struct RLookupRow *dst_row);
 
 /**
- * Find a field in the index spec cache of the lookup.
- *
- * # Safety
- *
- * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
- * 2. The memory pointed to by `name` must contain a valid nul terminator at the
- *    end of the string.
- * 3. `name` must be [valid] for reads of bytes up to and including the nul terminator.
- *    This means in particular:
- *     1. The entire memory range of this cstr must be contained within a single allocation!
- *     2. `name` must be non-null even for a zero-length cstr.
- * 4. The nul terminator must be within `isize::MAX` from `name`
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ * Returns a newly created [`RLookupRow`].
  */
-const FieldSpec *RLookup_FindFieldInSpecCache(const struct RLookup *lookup, const char *name);
+struct RLookupRow RLookupRow_New(void);
 
 /**
- * Get an RLookup key for a given name.
+ * Resets a RLookupRow by wiping it (see [`RLookupRow_Wipe`]) and deallocating the memory of the dynamic values.
  *
- * A key is returned only if it's already in the lookup table (available from the
- * pipeline upstream), it is part of the index schema and is sortable (and then it is created), or
- * if the lookup table accepts unresolved keys.
+ * This does not affect the sorting vector.
  *
  * # Safety
  *
- * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
- * 2. The memory pointed to by `name` must contain a valid nul terminator at the
- *    end of the string.
- * 3. `name` must be [valid] for reads of bytes up to and including the nul terminator.
- *    This means in particular:
- *     1. The entire memory range of this `CStr` must be contained within a single allocation!
- *     2. `name` must be non-null even for a zero-length cstr.
- * 4. The memory referenced by the returned `CStr` must not be mutated for
- *    the lifetime of the returned key.
- * 5. The nul terminator must be within `isize::MAX` from `name`
- * 6. All bits set in `flags` must correspond to a value of the enum.
+ * 1. `row` must be a [valid], non-null pointer to an [`RLookupRow`].
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-RLookupKey *RLookup_GetKey_Read(struct RLookup *lookup, const char *name, uint32_t flags);
+void RLookupRow_Reset(struct RLookupRow *row);
+
+/**
+ * Sets the sorting vector for the row.
+ *
+ * # Safety
+ *
+ * 1. `row` must be a [valid], non-null pointer to an [`RLookupRow`].
+ * 2. `sv` must be either null or a [valid] pointer to an [`sorting_vector::RSSortingVector`].
+ *    The pointed-to vector must remain valid for the lifetime of the row.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RLookupRow_SetSortingVector(struct RLookupRow *row, const RSSortingVector *sv);
+
+/**
+ * Wipes a RLookupRow by decrementing all values and resetting the row.
+ *
+ * # Safety
+ *
+ * 1. `row` must be a [valid], non-null pointer to an [`RLookupRow`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RLookupRow_Wipe(struct RLookupRow *row);
 
 /**
  * Write a value by-name to the lookup table. This is useful for 'dynamic' keys
@@ -300,32 +228,6 @@ RLookupKey *RLookup_GetKey_Read(struct RLookup *lookup, const char *name, uint32
 void RLookupRow_WriteByName(struct RLookup *lookup, const char *name, size_t name_len, struct RLookupRow *row, struct RSValue *value);
 
 /**
- * Get an RLookup key for a given name.
- *
- * A key is returned only if it's already in the lookup table (available from the
- * pipeline upstream), it is part of the index schema and is sortable (and then it is created), or
- * if the lookup table accepts unresolved keys.
- *
- * # Safety
- *
- * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
- * 2. The memory pointed to by `name` must contain a valid nul terminator at the
- *    end of the string.
- * 3. `name` must be [valid] for reads of `name_len` bytes up to and including the nul terminator.
- *    This means in particular:
- *     1. `name_len` must be same as `strlen(name)`
- *     2. The entire memory range of this `CStr` must be contained within a single allocation!
- *     3. `name` must be non-null even for a zero-length cstr.
- * 4. The memory referenced by the returned `CStr` must not be mutated for
- *    the lifetime of the returned key.
- * 5. The nul terminator must be within `isize::MAX` from `name`
- * 6. All bits set in `flags` must correspond to a value of the enum.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-RLookupKey *RLookup_GetKey_ReadEx(struct RLookup *lookup, const char *name, size_t name_len, uint32_t flags);
-
-/**
  * Write a value by-name to the lookup table. This is useful for 'dynamic' keys
  * for which it is not necessary to use the boilerplate of getting an explicit
  * key.
@@ -352,30 +254,6 @@ RLookupKey *RLookup_GetKey_ReadEx(struct RLookup *lookup, const char *name, size
 void RLookupRow_WriteByNameOwned(struct RLookup *lookup, const char *name, size_t name_len, struct RLookupRow *row, struct RSValue *value);
 
 /**
- * Get an RLookup key for a given name.
- *
- * A key is created and returned only if it's NOT in the lookup table, unless the
- * override flag is set.
- *
- * # Safety
- *
- * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
- * 2. The memory pointed to by `name` must contain a valid nul terminator at the
- *    end of the string.
- * 3. `name` must be [valid] for reads of bytes up to and including the nul terminator.
- *    This means in particular:
- *     1. The entire memory range of this `CStr` must be contained within a single allocation!
- *     2. `name` must be non-null even for a zero-length cstr.
- * 4. The memory referenced by the returned `CStr` must not be mutated for
- *    the lifetime of the returned key.
- * 5. The nul terminator must be within `isize::MAX` from `name`
- * 6. All bits set in `flags` must correspond to a value of the enum.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-RLookupKey *RLookup_GetKey_Write(struct RLookup *lookup, const char *name, uint32_t flags);
-
-/**
  * Write fields from a source row into this row.
  *
  * Iterate through the source lookup keys, if it finds a corresponding key in the destination
@@ -400,46 +278,83 @@ RLookupKey *RLookup_GetKey_Write(struct RLookup *lookup, const char *name, uint3
 void RLookupRow_WriteFieldsFrom(const struct RLookupRow *src_row, const struct RLookup *src_lookup, struct RLookupRow *dst_row, struct RLookup *dst_lookup, bool create_missing_keys);
 
 /**
- * Get an RLookup key for a given name.
+ * Add all non-overridden keys from `src` to `dest`.
  *
- * A key is created and returned only if it's NOT in the lookup table, unless the
- * override flag is set.
+ * For each key in `src`, check if it already exists *by name*.
+ * - If it does, the `flag` argument controls the behaviour (skip with `RLookupKeyFlags::empty()`, override with `RLookupKeyFlag::Override`).
+ * - If it doesn't, a new key will be created.
+ *
+ * Flag handling:
+ * - Preserves persistent source key properties (F_SVSRC, F_HIDDEN, F_EXPLICITRETURN, etc.)
+ * - Filters out transient flags from source keys (F_OVERRIDE, F_FORCE_LOAD)
+ * - Respects caller's control flags for behavior (F_OVERRIDE, F_FORCE_LOAD, etc.)
+ * - Target flags = caller_flags | (source_flags & ~RLOOKUP_TRANSIENT_FLAGS)
+ *
+ * # Safety
+ *
+ * 1. `src` must be a [valid], non-null pointer to an [`RLookup`]
+ * 2. `dest` must be a [valid], non-null pointer to an [`RLookup`]
+ * 3. `src` and `dest` must not point to the same [`RLookup`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RLookup_AddKeysFrom(const struct RLookup *src, struct RLookup *dest, uint32_t flags);
+
+/**
+ * Releases any resources created by this lookup object. Note that if there are
+ * lookup keys created with RLOOKUP_F_NOINCREF, those keys will no longer be
+ * valid after this call!
+ *
+ * # Safety
+ *
+ * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
+ * 2. `lookup` **must not** be used again after this function is called.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RLookup_Cleanup(struct RLookup *lookup);
+
+/**
+ * Disables the given set of `RLookup` options.
+ *
+ * # Safety
+ *
+ * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
+ * 2. All bits set in `options` must correspond to a value of the `RLookupOptions` enum.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RLookup_DisableOptions(struct RLookup *lookup, uint32_t options);
+
+/**
+ * Enables the given set of `RLookup` options.
+ *
+ * # Safety
+ *
+ * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
+ * 2. All bits set in `options` must correspond to a value of the `RLookupOptions` enum.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RLookup_EnableOptions(struct RLookup *lookup, uint32_t options);
+
+/**
+ * Find a field in the index spec cache of the lookup.
  *
  * # Safety
  *
  * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
  * 2. The memory pointed to by `name` must contain a valid nul terminator at the
  *    end of the string.
- * 3. `name` must be [valid] for reads of `name_len` bytes up to and including the nul terminator.
+ * 3. `name` must be [valid] for reads of bytes up to and including the nul terminator.
  *    This means in particular:
- *     1. `name_len` must be same as `strlen(name)`
- *     2. The entire memory range of this `CStr` must be contained within a single allocation!
- *     3. `name` must be non-null even for a zero-length cstr.
- * 4. The memory referenced by the returned `CStr` must not be mutated for
- *    the lifetime of the returned key.
- * 5. The nul terminator must be within `isize::MAX` from `name`
- * 6. All bits set in `flags` must correspond to a value of the enum.
+ *     1. The entire memory range of this cstr must be contained within a single allocation!
+ *     2. `name` must be non-null even for a zero-length cstr.
+ * 4. The nul terminator must be within `isize::MAX` from `name`
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-RLookupKey *RLookup_GetKey_WriteEx(struct RLookup *lookup, const char *name, size_t name_len, uint32_t flags);
-
-/**
- * Retrieves an item from the given `RLookupRow` based on the provided `RLookupKey`.
- *
- * The function first checks for dynamic values, and if not found, it checks the sorting vector
- * if the `SvSrc` flag is set in the key.
- *
- * If the item is not found in either location, it returns a NULL pointer.
- *
- * # Safety
- *
- * 1. `key` must be a [valid], non-null pointer to an [`RLookupKey`].
- * 2. `row` must be a [valid], non-null pointer to an [`RLookupRow`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-struct RSValue *RLookupRow_Get(const RLookupKey *key, const struct RLookupRow *row);
+const FieldSpec *RLookup_FindFieldInSpecCache(const struct RLookup *lookup, const char *name);
 
 /**
  * Get an RLookup key for a given name.
@@ -466,33 +381,6 @@ struct RSValue *RLookupRow_Get(const RLookupKey *key, const struct RLookupRow *r
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 RLookupKey *RLookup_GetKey_Load(struct RLookup *lookup, const char *name, const char *field_name, uint32_t flags);
-
-/**
- * Returns a borrowed view of the sorting vector for the row.
- *
- * If the row has no sorting vector, returns a slice with `len == 0` and a dangling `values`
- * pointer. Callers must check `len`, not `values`, to detect the empty case.
- *
- * # Safety
- *
- * 1. `row` must be a [valid], non-null pointer to an [`RLookupRow`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-struct RSSortingVectorSlice RLookupRow_GetSortingVector(const struct RLookupRow *row);
-
-/**
- * Sets the sorting vector for the row.
- *
- * # Safety
- *
- * 1. `row` must be a [valid], non-null pointer to an [`RLookupRow`].
- * 2. `sv` must be either null or a [valid] pointer to an [`sorting_vector::RSSortingVector`].
- *    The pointed-to vector must remain valid for the lifetime of the row.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void RLookupRow_SetSortingVector(struct RLookupRow *row, const RSSortingVector *sv);
 
 /**
  * Get an RLookup key for a given name.
@@ -522,20 +410,104 @@ void RLookupRow_SetSortingVector(struct RLookupRow *row, const RSSortingVector *
 RLookupKey *RLookup_GetKey_LoadEx(struct RLookup *lookup, const char *name, size_t name_len, const char *field_name, uint32_t flags);
 
 /**
- * Compares two search results by the given sort keys, returning a negative, zero, or positive
- * value.
+ * Get an RLookup key for a given name.
  *
- * The comparison loop runs entirely in Rust via [`cmp_fields`], avoiding per-key FFI
- * crossings for value lookups. When all fields are equal, breaks the tie by document ID using
- * the last key's ascending flag.
+ * A key is returned only if it's already in the lookup table (available from the
+ * pipeline upstream), it is part of the index schema and is sortable (and then it is created), or
+ * if the lookup table accepts unresolved keys.
  *
  * # Safety
  *
- * 1. `keys` must point to an array of at least `nkeys` valid, non-null `RLookupKey` pointers.
- * 2. `h1` and `h2` must be valid, non-null pointers to a `SearchResult`.
- * 3. `qerr`, when non-null, must be a valid, writable pointer to a `QueryError`.
+ * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
+ * 2. The memory pointed to by `name` must contain a valid nul terminator at the
+ *    end of the string.
+ * 3. `name` must be [valid] for reads of bytes up to and including the nul terminator.
+ *    This means in particular:
+ *     1. The entire memory range of this `CStr` must be contained within a single allocation!
+ *     2. `name` must be non-null even for a zero-length cstr.
+ * 4. The memory referenced by the returned `CStr` must not be mutated for
+ *    the lifetime of the returned key.
+ * 5. The nul terminator must be within `isize::MAX` from `name`
+ * 6. All bits set in `flags` must correspond to a value of the enum.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-int SearchResult_CmpByFields(const RLookupKey *const *keys, size_t nkeys, const struct SearchResult *h1, const struct SearchResult *h2, uint64_t ascend_map, struct QueryError *qerr);
+RLookupKey *RLookup_GetKey_Read(struct RLookup *lookup, const char *name, uint32_t flags);
+
+/**
+ * Get an RLookup key for a given name.
+ *
+ * A key is returned only if it's already in the lookup table (available from the
+ * pipeline upstream), it is part of the index schema and is sortable (and then it is created), or
+ * if the lookup table accepts unresolved keys.
+ *
+ * # Safety
+ *
+ * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
+ * 2. The memory pointed to by `name` must contain a valid nul terminator at the
+ *    end of the string.
+ * 3. `name` must be [valid] for reads of `name_len` bytes up to and including the nul terminator.
+ *    This means in particular:
+ *     1. `name_len` must be same as `strlen(name)`
+ *     2. The entire memory range of this `CStr` must be contained within a single allocation!
+ *     3. `name` must be non-null even for a zero-length cstr.
+ * 4. The memory referenced by the returned `CStr` must not be mutated for
+ *    the lifetime of the returned key.
+ * 5. The nul terminator must be within `isize::MAX` from `name`
+ * 6. All bits set in `flags` must correspond to a value of the enum.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+RLookupKey *RLookup_GetKey_ReadEx(struct RLookup *lookup, const char *name, size_t name_len, uint32_t flags);
+
+/**
+ * Get an RLookup key for a given name.
+ *
+ * A key is created and returned only if it's NOT in the lookup table, unless the
+ * override flag is set.
+ *
+ * # Safety
+ *
+ * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
+ * 2. The memory pointed to by `name` must contain a valid nul terminator at the
+ *    end of the string.
+ * 3. `name` must be [valid] for reads of bytes up to and including the nul terminator.
+ *    This means in particular:
+ *     1. The entire memory range of this `CStr` must be contained within a single allocation!
+ *     2. `name` must be non-null even for a zero-length cstr.
+ * 4. The memory referenced by the returned `CStr` must not be mutated for
+ *    the lifetime of the returned key.
+ * 5. The nul terminator must be within `isize::MAX` from `name`
+ * 6. All bits set in `flags` must correspond to a value of the enum.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+RLookupKey *RLookup_GetKey_Write(struct RLookup *lookup, const char *name, uint32_t flags);
+
+/**
+ * Get an RLookup key for a given name.
+ *
+ * A key is created and returned only if it's NOT in the lookup table, unless the
+ * override flag is set.
+ *
+ * # Safety
+ *
+ * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
+ * 2. The memory pointed to by `name` must contain a valid nul terminator at the
+ *    end of the string.
+ * 3. `name` must be [valid] for reads of `name_len` bytes up to and including the nul terminator.
+ *    This means in particular:
+ *     1. `name_len` must be same as `strlen(name)`
+ *     2. The entire memory range of this `CStr` must be contained within a single allocation!
+ *     3. `name` must be non-null even for a zero-length cstr.
+ * 4. The memory referenced by the returned `CStr` must not be mutated for
+ *    the lifetime of the returned key.
+ * 5. The nul terminator must be within `isize::MAX` from `name`
+ * 6. All bits set in `flags` must correspond to a value of the enum.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+RLookupKey *RLookup_GetKey_WriteEx(struct RLookup *lookup, const char *name, size_t name_len, uint32_t flags);
 
 /**
  * Returns the number of visible fields in this RLookupRow.
@@ -563,25 +535,6 @@ size_t RLookup_GetLength(const struct RLookup *lookup, const struct RLookupRow *
 uint32_t RLookup_GetRowLen(const struct RLookup *lookup);
 
 /**
- * Returns a newly created [`RLookup`].
- */
-struct RLookup RLookup_New(void);
-
-/**
- * Sets the [`ffi::IndexSpecCache`] of the lookup. If spcache is provided, then it will be used as an
- * alternate source for lookups whose fields are absent.
- *
- * # Safety
- *
- * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
- * 2. `spcache` must be a [valid] pointer to a [`ffi::IndexSpecCache`]
- * 3. The [`ffi::IndexSpecCache`] being pointed MUST NOT get mutated
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void RLookup_SetCache(struct RLookup *lookup, IndexSpecCache *spcache);
-
-/**
  * Returns `true` if this `RLookup` has an associated [`IndexSpecCache`].
  *
  * # Safety
@@ -593,43 +546,31 @@ void RLookup_SetCache(struct RLookup *lookup, IndexSpecCache *spcache);
 bool RLookup_HasIndexSpecCache(const struct RLookup *lookup);
 
 /**
- * Releases any resources created by this lookup object. Note that if there are
- * lookup keys created with RLOOKUP_F_NOINCREF, those keys will no longer be
- * valid after this call!
+ * Return an iterator over an [`RLookup`]'s key list.
  *
  * # Safety
  *
  * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
- * 2. `lookup` **must not** be used again after this function is called.
+ * 2. The returned iterator must only be used as long as the `lookup` remains valid.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-void RLookup_Cleanup(struct RLookup *lookup);
+struct RLookupIterator RLookup_Iter(const struct RLookup *lookup);
 
 /**
- * Initialize the lookup with fields from a Redis hash.
+ * Return an iterator over an [`RLookup`]'s key list with editing operations.
  *
  * # Safety
  *
- * 1. `search_ctx` must be a [valid], non-null pointer to an `ffi::RedisSearchCtx` that is properly initialized.
- * 2. `lookup` must be a [valid], non-null pointer to an `RLookup` that is properly initialized.
- * 3. `dst_row` must be a [valid], non-null pointer to an `RLookupRow` that is properly initialized.
- * 4. `index_spec` must be a [valid], non-null pointer to an `ffi::IndexSpec` that is properly initialized.
- *    This also applies to any of its subfields.
- * 5. The memory pointed to by `key` must contain a valid nul terminator at the
- *    end of the string.
- * 6. `key` must be [valid] for reads of bytes up to and including the nul terminator.
- *    This means in particular:
- *     1. The entire memory range of this `CStr` must be contained within a single allocation!
- *     2. `key` must be non-null even for a zero-length cstr.
- * 7. The nul terminator must be within `isize::MAX` from `key`
- * 8. `open_key`, if non-null, must be a valid, already-open `redis_module::RedisModuleKey` handle for
- *    `key` that outlives this call. It is borrowed, not closed here. Pass null to open by name.
- * 9. `status` must be a [valid], non-null pointer to an `ffi::QueryError` that is properly initialized.
+ * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
+ * 2. The returned iterator must only be used as long as the `lookup` remains valid.
+ * 3. The caller must treat the returned `current` pointer as pinned. Specifically
+ *    a. Not move (memcpy/memmove) out of the pointer.
+ *    b. The pointed-to value must remain at its original address in memory and never be relocated.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-int32_t RLookup_LoadRuleFields(RedisSearchCtx *search_ctx, struct RLookup *lookup, struct RLookupRow *dst_row, IndexSpec *index_spec, const char *key, struct RedisModuleKey *open_key, struct QueryError *status);
+struct RLookupIteratorMut RLookup_IterMut(struct RLookup *lookup);
 
 /**
  * Load values from the document `dmd` into `dst_row`
@@ -667,31 +608,90 @@ int RLookup_LoadDocumentAll(struct RLookup *lookup, struct RLookupRow *dst_row, 
 int RLookup_LoadDocumentIndividual(struct RLookup *lookup, struct RLookupRow *dst_row, struct LoadIndividualKeysOptions *opts);
 
 /**
- * Return an iterator over an [`RLookup`]'s key list.
+ * Initialize the lookup with fields from a Redis hash.
  *
  * # Safety
  *
- * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
- * 2. The returned iterator must only be used as long as the `lookup` remains valid.
+ * 1. `search_ctx` must be a [valid], non-null pointer to an `ffi::RedisSearchCtx` that is properly initialized.
+ * 2. `lookup` must be a [valid], non-null pointer to an `RLookup` that is properly initialized.
+ * 3. `dst_row` must be a [valid], non-null pointer to an `RLookupRow` that is properly initialized.
+ * 4. `index_spec` must be a [valid], non-null pointer to an `ffi::IndexSpec` that is properly initialized.
+ *    This also applies to any of its subfields.
+ * 5. The memory pointed to by `key` must contain a valid nul terminator at the
+ *    end of the string.
+ * 6. `key` must be [valid] for reads of bytes up to and including the nul terminator.
+ *    This means in particular:
+ *     1. The entire memory range of this `CStr` must be contained within a single allocation!
+ *     2. `key` must be non-null even for a zero-length cstr.
+ * 7. The nul terminator must be within `isize::MAX` from `key`
+ * 8. `open_key`, if non-null, must be a valid, already-open `redis_module::RedisModuleKey` handle for
+ *    `key` that outlives this call. It is borrowed, not closed here. Pass null to open by name.
+ * 9. `status` must be a [valid], non-null pointer to an `ffi::QueryError` that is properly initialized.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-struct RLookupIterator RLookup_Iter(const struct RLookup *lookup);
+int32_t RLookup_LoadRuleFields(RedisSearchCtx *search_ctx, struct RLookup *lookup, struct RLookupRow *dst_row, IndexSpec *index_spec, const char *key, struct RedisModuleKey *open_key, struct QueryError *status);
 
 /**
- * Return an iterator over an [`RLookup`]'s key list with editing operations.
+ * Returns a newly created [`RLookup`].
+ */
+struct RLookup RLookup_New(void);
+
+/**
+ * Sets the [`ffi::IndexSpecCache`] of the lookup. If spcache is provided, then it will be used as an
+ * alternate source for lookups whose fields are absent.
  *
  * # Safety
  *
  * 1. `lookup` must be a [valid], non-null pointer to an `RLookup`.
- * 2. The returned iterator must only be used as long as the `lookup` remains valid.
- * 3. The caller must treat the returned `current` pointer as pinned. Specifically
- *    a. Not move (memcpy/memmove) out of the pointer.
- *    b. The pointed-to value must remain at its original address in memory and never be relocated.
+ * 2. `spcache` must be a [valid] pointer to a [`ffi::IndexSpecCache`]
+ * 3. The [`ffi::IndexSpecCache`] being pointed MUST NOT get mutated
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-struct RLookupIteratorMut RLookup_IterMut(struct RLookup *lookup);
+void RLookup_SetCache(struct RLookup *lookup, IndexSpecCache *spcache);
+
+/**
+ * Writes a key to the row but increments the value reference count before writing it thus having shared ownership.
+ *
+ * # Safety
+ *
+ * 1. `key` must be a [valid], non-null pointer to an [`RLookupKey`].
+ * 2. `row` must be a [valid], non-null pointer to an [`RLookupRow`].
+ * 3. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RLookup_WriteKey(const RLookupKey *key, struct RLookupRow *row, struct RSValue *value);
+
+/**
+ * Writes a key to the row without incrementing the value reference count, thus taking ownership of the value.
+ *
+ * # Safety
+ *
+ * 1. `key` must be a [valid], non-null pointer to an [`RLookupKey`].
+ * 2. `row` must be a [valid], non-null pointer to an [`RLookupRow`].
+ * 3. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RLookup_WriteOwnKey(const RLookupKey *key, struct RLookupRow *row, struct RSValue *value);
+
+/**
+ * Compares two search results by the given sort keys, returning a negative, zero, or positive
+ * value.
+ *
+ * The comparison loop runs entirely in Rust via [`cmp_fields`], avoiding per-key FFI
+ * crossings for value lookups. When all fields are equal, breaks the tie by document ID using
+ * the last key's ascending flag.
+ *
+ * # Safety
+ *
+ * 1. `keys` must point to an array of at least `nkeys` valid, non-null `RLookupKey` pointers.
+ * 2. `h1` and `h2` must be valid, non-null pointers to a `SearchResult`.
+ * 3. `qerr`, when non-null, must be a valid, writable pointer to a `QueryError`.
+ */
+int SearchResult_CmpByFields(const RLookupKey *const *keys, size_t nkeys, const struct SearchResult *h1, const struct SearchResult *h2, uint64_t ascend_map, struct QueryError *qerr);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/search_result_ffi.h
+++ b/src/redisearch_rs/headers/search_result_ffi.h
@@ -18,23 +18,17 @@ extern "C" {
 #endif // __cplusplus
 
 /**
- * Returns a newly created [`SearchResult`].
- */
-SearchResult SearchResult_New(void);
-
-/**
- * Overrides the contents of `dst` with those from `src` taking ownership of `src`.
- * Ensures proper cleanup of any existing data in `dst`.
+ * Moves the contents the [`SearchResult`] pointed to by `res` into a new heap allocation.
+ * This method takes ownership of the search result, therefore the pointer must **must not** be used again after this function is called.
  *
  * # Safety
  *
- * 1. `dst` must be a [valid], non-null pointer to a [`SearchResult`].
- * 2. `src` must be a [valid], non-null pointer to a [`SearchResult`].
- * 3. `src` must not be used again.
+ * 1. `res` must be a [valid], non-null pointer to a [`SearchResult`].
+ * 2. `res` **must not** be used again after this function is called.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-void SearchResult_Override(SearchResult *dst, SearchResult *src);
+SearchResult *SearchResult_AllocateMove(SearchResult *res);
 
 /**
  * Clears the [`SearchResult`] pointed to by `res`, removing all values from its [`RLookupRow`][ffi::RLookupRow].
@@ -59,20 +53,7 @@ void SearchResult_Clear(SearchResult *res);
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-void SearchResult_Destroy(SearchResult *res);
-
-/**
- * Moves the contents the [`SearchResult`] pointed to by `res` into a new heap allocation.
- * This method takes ownership of the search result, therefore the pointer must **must not** be used again after this function is called.
- *
- * # Safety
- *
- * 1. `res` must be a [valid], non-null pointer to a [`SearchResult`].
- * 2. `res` **must not** be used again after this function is called.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-SearchResult *SearchResult_AllocateMove(SearchResult *res);
+void SearchResult_DeallocateDestroy(SearchResult *res);
 
 /**
  * Destroys the [`SearchResult`] pointed to by `res` releasing any resources owned by it.
@@ -85,7 +66,26 @@ SearchResult *SearchResult_AllocateMove(SearchResult *res);
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-void SearchResult_DeallocateDestroy(SearchResult *res);
+void SearchResult_Destroy(SearchResult *res);
+
+/**
+ * Returns a newly created [`SearchResult`].
+ */
+SearchResult SearchResult_New(void);
+
+/**
+ * Overrides the contents of `dst` with those from `src` taking ownership of `src`.
+ * Ensures proper cleanup of any existing data in `dst`.
+ *
+ * # Safety
+ *
+ * 1. `dst` must be a [valid], non-null pointer to a [`SearchResult`].
+ * 2. `src` must be a [valid], non-null pointer to a [`SearchResult`].
+ * 3. `src` must not be used again.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void SearchResult_Override(SearchResult *dst, SearchResult *src);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/slots_tracker_ffi.h
+++ b/src/redisearch_rs/headers/slots_tracker_ffi.h
@@ -34,17 +34,11 @@ extern "C" {
 #endif // __cplusplus
 
 /**
- * Sets the local slot ranges this shard is responsible for.
+ * Checks if all requested slots are available and returns version information.
  *
- * This function updates the "local slots" set to match the provided ranges.
- * If the ranges differ from the current configuration:
- * - Updates "local slots" to the new ranges
- * - Removes any overlapping slots from "fully available slots" and "partially available slots"
- * - Increments the version counter
- *
- * If the ranges are identical to the current configuration, no changes are made.
- *
- * Returns the current version after the operation.
+ * Return values (via OptionSlotTrackerVersion):
+ * - `is_some = false`: Required slots are not available. Query should be rejected.
+ * - `is_some = true`: Slots available; Store the returned `version` and compare it (equality check) with the tracker's version.
  *
  * # Safety
  *
@@ -53,7 +47,53 @@ extern "C" {
  * The ranges array must contain `num_ranges` valid elements.
  * All ranges must be sorted and have start <= end, with values in [0, 16383].
  */
-uint32_t slots_tracker_set_local_slots(const struct RedisModuleSlotRangeArray *ranges);
+struct OptionSlotTrackerVersion slots_tracker_check_availability(const struct RedisModuleSlotRangeArray *ranges);
+
+/**
+ * Returns the current local slot ranges as a newly allocated array.
+ *
+ * The returned array is allocated with the Rust global allocator, which in the
+ * RediSearch module build forwards to `RedisModule_Alloc`. The caller owns the
+ * returned pointer and must free it with `RedisModule_Free` (`rm_free`).
+ *
+ * # Safety
+ *
+ * This function must be called from the main thread only.
+ */
+struct RedisModuleSlotRangeArray *slots_tracker_get_local_slots(void);
+
+/**
+ * Checks if there is any overlap between the given slot ranges and the fully available slots.
+ *
+ * This function checks if any of the provided slot ranges overlap with "fully available slots".
+ * Returns true if there is at least one overlapping slot, false otherwise.
+ *
+ * # Safety
+ *
+ * This function must be called from the main thread only.
+ * The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
+ * The ranges array must contain `num_ranges` valid elements.
+ * All ranges must be sorted and have start <= end, with values in [0, 16383].
+ */
+bool slots_tracker_has_fully_available_overlap(const struct RedisModuleSlotRangeArray *ranges);
+
+/**
+ * Marks the given slot ranges as fully available non-owned.
+ *
+ * This function updates the "fully available slots" set by adding the provided ranges.
+ * It also removes the given slots from "local slots".
+ *
+ * Note: This does NOT increment the version counter (slots availability is unchanged).
+ * It also does NOT remove from "partially available slots".
+ *
+ * # Safety
+ *
+ * This function must be called from the main thread only.
+ * The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
+ * The ranges array must contain `num_ranges` valid elements.
+ * All ranges must be sorted and have start <= end, with values in [0, 16383].
+ */
+void slots_tracker_mark_fully_available_slots(const struct RedisModuleSlotRangeArray *ranges);
 
 /**
  * Marks the given slot ranges as partially available.
@@ -94,24 +134,6 @@ uint32_t slots_tracker_mark_partially_available_slots(const struct RedisModuleSl
 void slots_tracker_promote_to_local_slots(const struct RedisModuleSlotRangeArray *ranges);
 
 /**
- * Marks the given slot ranges as fully available non-owned.
- *
- * This function updates the "fully available slots" set by adding the provided ranges.
- * It also removes the given slots from "local slots".
- *
- * Note: This does NOT increment the version counter (slots availability is unchanged).
- * It also does NOT remove from "partially available slots".
- *
- * # Safety
- *
- * This function must be called from the main thread only.
- * The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
- * The ranges array must contain `num_ranges` valid elements.
- * All ranges must be sorted and have start <= end, with values in [0, 16383].
- */
-void slots_tracker_mark_fully_available_slots(const struct RedisModuleSlotRangeArray *ranges);
-
-/**
  * Removes deleted slot ranges from the partially available slots.
  *
  * This function removes the given slot ranges from "partially available slots" only.
@@ -127,50 +149,6 @@ void slots_tracker_mark_fully_available_slots(const struct RedisModuleSlotRangeA
 void slots_tracker_remove_deleted_slots(const struct RedisModuleSlotRangeArray *ranges);
 
 /**
- * Checks if there is any overlap between the given slot ranges and the fully available slots.
- *
- * This function checks if any of the provided slot ranges overlap with "fully available slots".
- * Returns true if there is at least one overlapping slot, false otherwise.
- *
- * # Safety
- *
- * This function must be called from the main thread only.
- * The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
- * The ranges array must contain `num_ranges` valid elements.
- * All ranges must be sorted and have start <= end, with values in [0, 16383].
- */
-bool slots_tracker_has_fully_available_overlap(const struct RedisModuleSlotRangeArray *ranges);
-
-/**
- * Returns the current local slot ranges as a newly allocated array.
- *
- * The returned array is allocated with the Rust global allocator, which in the
- * RediSearch module build forwards to `RedisModule_Alloc`. The caller owns the
- * returned pointer and must free it with `RedisModule_Free` (`rm_free`).
- *
- * # Safety
- *
- * This function must be called from the main thread only.
- */
-struct RedisModuleSlotRangeArray *slots_tracker_get_local_slots(void);
-
-/**
- * Checks if all requested slots are available and returns version information.
- *
- * Return values (via OptionSlotTrackerVersion):
- * - `is_some = false`: Required slots are not available. Query should be rejected.
- * - `is_some = true`: Slots available; Store the returned `version` and compare it (equality check) with the tracker's version.
- *
- * # Safety
- *
- * This function must be called from the main thread only.
- * The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
- * The ranges array must contain `num_ranges` valid elements.
- * All ranges must be sorted and have start <= end, with values in [0, 16383].
- */
-struct OptionSlotTrackerVersion slots_tracker_check_availability(const struct RedisModuleSlotRangeArray *ranges);
-
-/**
  * Resets the tracker to its initial state.
  *
  * This function is intended for testing purposes only. It resets the tracker
@@ -181,6 +159,28 @@ struct OptionSlotTrackerVersion slots_tracker_check_availability(const struct Re
  * This function must be called from the main thread only.
  */
 void slots_tracker_reset(void);
+
+/**
+ * Sets the local slot ranges this shard is responsible for.
+ *
+ * This function updates the "local slots" set to match the provided ranges.
+ * If the ranges differ from the current configuration:
+ * - Updates "local slots" to the new ranges
+ * - Removes any overlapping slots from "fully available slots" and "partially available slots"
+ * - Increments the version counter
+ *
+ * If the ranges are identical to the current configuration, no changes are made.
+ *
+ * Returns the current version after the operation.
+ *
+ * # Safety
+ *
+ * This function must be called from the main thread only.
+ * The `ranges` pointer must be valid and point to a properly initialized RedisModuleSlotRangeArray.
+ * The ranges array must contain `num_ranges` valid elements.
+ * All ranges must be sorted and have start <= end, with values in [0, 16383].
+ */
+uint32_t slots_tracker_set_local_slots(const struct RedisModuleSlotRangeArray *ranges);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/sorting_vector_ffi.h
+++ b/src/redisearch_rs/headers/sorting_vector_ffi.h
@@ -29,6 +29,21 @@ extern "C" {
 #endif // __cplusplus
 
 /**
+ * Deallocates the inner values buffer of an [`RSSortingVector`] and zeros the struct.
+ *
+ * Each [`RSValue`] element is dropped (decrementing its refcount) and the heap buffer is freed.
+ * After this call the pointed-to struct is in the same state as [`RSSortingVector::empty()`].
+ * Passing a null pointer is a no-op.
+ *
+ * # Safety
+ *
+ * 1. `vec` must be either null or a [valid] pointer to an [`RSSortingVector`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RSSortingVector_ClearAndDeAlloc(RSSortingVector *vec);
+
+/**
  * Initializes an empty `RSSortingVector`.
  *
  * No heap allocation is performed.
@@ -47,6 +62,30 @@ RSSortingVector RSSortingVector_Empty(void);
 size_t RSSortingVector_GetMemorySize(const RSSortingVector *vec);
 
 /**
+ * Creates a new `RSSortingVector` with the given length, returned by value.
+ *
+ * # Panics
+ *
+ * Panics if `len` is greater than [`RS_SORTABLES_MAX`].
+ */
+RSSortingVector RSSortingVector_New(size_t len);
+
+/**
+ * Puts a null at the given index in the sorting vector.  If a out of bounds occurs it returns silently.
+ *
+ * # Panics
+ *
+ * Panics if the `idx` is out of bounds for the vector.
+ *
+ * # Safety
+ *
+ * 1. The pointer must be a [valid] pointer to an [`RSSortingVector`] created by [`RSSortingVector_New`] or equivalent.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RSSortingVector_PutNull(RSSortingVector *vec, size_t idx);
+
+/**
  * Puts a number (double) at the given index in the sorting vector. If a out of bounds occurs it returns silently.
  *
  * # Panics
@@ -60,6 +99,22 @@ size_t RSSortingVector_GetMemorySize(const RSSortingVector *vec);
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void RSSortingVector_PutNum(RSSortingVector *vec, size_t idx, double num);
+
+/**
+ * Puts a value at the given index in the sorting vector. If a out of bounds occurs it returns silently.
+ *
+ * # Panics
+ *
+ * Panics if the `idx` is out of bounds for the vector.
+ *
+ * # Safety
+ *
+ * 1. `vec` must be a [valid], non-null pointer to an [`RSSortingVector`] created by [`RSSortingVector_New`] or equivalent.
+ * 2. `val` must be a [valid], non-null pointer must point to a `RSValue`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RSSortingVector_PutRSVal(RSSortingVector *vec, size_t idx, struct RSValue *val);
 
 /**
  * Puts a string at the given index in the sorting vector.
@@ -96,61 +151,6 @@ void RSSortingVector_PutStr(RSSortingVector *vec, size_t idx, const char *str);
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool RSSortingVector_PutStrNormalize(RSSortingVector *vec, size_t idx, const char *str, struct QueryError *status);
-
-/**
- * Puts a value at the given index in the sorting vector. If a out of bounds occurs it returns silently.
- *
- * # Panics
- *
- * Panics if the `idx` is out of bounds for the vector.
- *
- * # Safety
- *
- * 1. `vec` must be a [valid], non-null pointer to an [`RSSortingVector`] created by [`RSSortingVector_New`] or equivalent.
- * 2. `val` must be a [valid], non-null pointer must point to a `RSValue`.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void RSSortingVector_PutRSVal(RSSortingVector *vec, size_t idx, struct RSValue *val);
-
-/**
- * Puts a null at the given index in the sorting vector.  If a out of bounds occurs it returns silently.
- *
- * # Panics
- *
- * Panics if the `idx` is out of bounds for the vector.
- *
- * # Safety
- *
- * 1. The pointer must be a [valid] pointer to an [`RSSortingVector`] created by [`RSSortingVector_New`] or equivalent.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void RSSortingVector_PutNull(RSSortingVector *vec, size_t idx);
-
-/**
- * Creates a new `RSSortingVector` with the given length, returned by value.
- *
- * # Panics
- *
- * Panics if `len` is greater than [`RS_SORTABLES_MAX`].
- */
-RSSortingVector RSSortingVector_New(size_t len);
-
-/**
- * Deallocates the inner values buffer of an [`RSSortingVector`] and zeros the struct.
- *
- * Each [`RSValue`] element is dropped (decrementing its refcount) and the heap buffer is freed.
- * After this call the pointed-to struct is in the same state as [`RSSortingVector::empty()`].
- * Passing a null pointer is a no-op.
- *
- * # Safety
- *
- * 1. `vec` must be either null or a [valid] pointer to an [`RSSortingVector`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void RSSortingVector_ClearAndDeAlloc(RSSortingVector *vec);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/term_suffix_index_ffi.h
+++ b/src/redisearch_rs/headers/term_suffix_index_ffi.h
@@ -47,10 +47,73 @@ extern "C" {
 #endif // __cplusplus
 
 /**
- * Create a new, empty [`TermSuffixIndex`]. Must be freed with
- * [`TermSuffixIndex_Free`].
+ * Free an iterator obtained from [`TermSuffixIndex_IterateAll`].
+ * Invalidates any string pointer previously returned by
+ * [`TermSuffixIndexIterator_Next`].
+ *
+ * # Safety
+ *
+ * 1. `it` must be a [valid], non-null pointer to a live
+ *    [`TermSuffixIndexIterator`].
+ * 2. `it` must not be used after this call.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-struct TermSuffixIndex *TermSuffixIndex_New(void);
+void TermSuffixIndexIterator_Free(struct TermSuffixIndexIterator *it);
+
+/**
+ * Advance the iterator. Returns 1 and points `*str`/`*len` at the next
+ * string — borrowed from the iterator, not copied into caller-provided
+ * storage — if there is one, or returns 0 once exhausted.
+ *
+ * Returning 0 does not free the iterator; it must still be released
+ * with [`TermSuffixIndexIterator_Free`].
+ *
+ * The string `*str` points at is NOT NUL-terminated, owned by the
+ * iterator, and only valid until the next call to
+ * [`TermSuffixIndexIterator_Next`] or [`TermSuffixIndexIterator_Free`].
+ *
+ * # Safety
+ *
+ * 1. `it` must be a [valid], non-null pointer to a live
+ *    [`TermSuffixIndexIterator`], not advanced or freed concurrently
+ *    from another thread.
+ * 2. `str` and `len` must be [valid], non-null pointers to writable
+ *    locations.
+ * 3. The [`TermSuffixIndex`] the iterator was obtained from must still
+ *    be alive, with no mutating call ([`TermSuffixIndex_Add`],
+ *    [`TermSuffixIndex_Remove`], [`TermSuffixIndex_Free`]) running
+ *    concurrently. Concurrent read-only calls are allowed.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+int TermSuffixIndexIterator_Next(struct TermSuffixIndexIterator *it, const char * *str, size_t *len);
+
+/**
+ * Add `term` (`len` UTF-8 bytes) to the index. Adding an existing or
+ * empty term is a no-op, as is adding a term whose lowercased form
+ * exceeds `u16::MAX` bytes — the trie cannot represent such a key.
+ *
+ * Matching is case-insensitive: `term` is lowercased before insertion,
+ * so subsequent lookups and removals are case-insensitive too.
+ *
+ * # Safety
+ *
+ * 1. `tsi` must be a [valid], non-null pointer obtained from
+ *    [`TermSuffixIndex_New`].
+ * 2. No other access to `tsi` may occur concurrently with this call —
+ *    neither another mutator nor a read-only call such as
+ *    [`TermSuffixIndex_MemUsage`], and no iterator obtained from `tsi`
+ *    may be alive.
+ * 3. `term` must point to a [valid] byte sequence of length `len`.
+ *
+ * # Panics
+ *
+ * Panics if `term` is not valid UTF-8.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void TermSuffixIndex_Add(struct TermSuffixIndex *tsi, const char *term, size_t len);
 
 /**
  * Free a [`TermSuffixIndex`] and all terms it owns.
@@ -116,60 +179,6 @@ struct TermSuffixIndexIterator *TermSuffixIndex_IterateAll(const struct TermSuff
 void TermSuffixIndex_IterateContains(const struct TermSuffixIndex *tsi, const char *needle, size_t len, TermSuffixIterateCallback cb, void *ctx);
 
 /**
- * Add `term` (`len` UTF-8 bytes) to the index. Adding an existing or
- * empty term is a no-op, as is adding a term whose lowercased form
- * exceeds `u16::MAX` bytes — the trie cannot represent such a key.
- *
- * Matching is case-insensitive: `term` is lowercased before insertion,
- * so subsequent lookups and removals are case-insensitive too.
- *
- * # Safety
- *
- * 1. `tsi` must be a [valid], non-null pointer obtained from
- *    [`TermSuffixIndex_New`].
- * 2. No other access to `tsi` may occur concurrently with this call —
- *    neither another mutator nor a read-only call such as
- *    [`TermSuffixIndex_MemUsage`], and no iterator obtained from `tsi`
- *    may be alive.
- * 3. `term` must point to a [valid] byte sequence of length `len`.
- *
- * # Panics
- *
- * Panics if `term` is not valid UTF-8.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void TermSuffixIndex_Add(struct TermSuffixIndex *tsi, const char *term, size_t len);
-
-/**
- * Advance the iterator. Returns 1 and points `*str`/`*len` at the next
- * string — borrowed from the iterator, not copied into caller-provided
- * storage — if there is one, or returns 0 once exhausted.
- *
- * Returning 0 does not free the iterator; it must still be released
- * with [`TermSuffixIndexIterator_Free`].
- *
- * The string `*str` points at is NOT NUL-terminated, owned by the
- * iterator, and only valid until the next call to
- * [`TermSuffixIndexIterator_Next`] or [`TermSuffixIndexIterator_Free`].
- *
- * # Safety
- *
- * 1. `it` must be a [valid], non-null pointer to a live
- *    [`TermSuffixIndexIterator`], not advanced or freed concurrently
- *    from another thread.
- * 2. `str` and `len` must be [valid], non-null pointers to writable
- *    locations.
- * 3. The [`TermSuffixIndex`] the iterator was obtained from must still
- *    be alive, with no mutating call ([`TermSuffixIndex_Add`],
- *    [`TermSuffixIndex_Remove`], [`TermSuffixIndex_Free`]) running
- *    concurrently. Concurrent read-only calls are allowed.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-int TermSuffixIndexIterator_Next(struct TermSuffixIndexIterator *it, const char * *str, size_t *len);
-
-/**
  * Invoke `cb` once per member term ending with the UTF-8 needle
  * `(needle, len)`; each matching term is reported exactly once. Iteration
  * stops early when the callback returns a non-zero value. An empty
@@ -193,61 +202,6 @@ int TermSuffixIndexIterator_Next(struct TermSuffixIndexIterator *it, const char 
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 void TermSuffixIndex_IterateSuffix(const struct TermSuffixIndex *tsi, const char *needle, size_t len, TermSuffixIterateCallback cb, void *ctx);
-
-/**
- * Remove `term` (`len` UTF-8 bytes) from the index. Removing an absent
- * or empty term is a no-op.
- *
- * Matching is case-insensitive: `term` is lowercased before lookup, so
- * it matches the entry regardless of the case it was added with.
- *
- * # Safety
- *
- * 1. `tsi` must be a [valid], non-null pointer obtained from
- *    [`TermSuffixIndex_New`].
- * 2. No other access to `tsi` may occur concurrently with this call —
- *    neither another mutator nor a read-only call such as
- *    [`TermSuffixIndex_MemUsage`], and no iterator obtained from `tsi`
- *    may be alive.
- * 3. `term` must point to a [valid] byte sequence of length `len`.
- *
- * # Panics
- *
- * Panics if `term` is not valid UTF-8.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void TermSuffixIndex_Remove(struct TermSuffixIndex *tsi, const char *term, size_t len);
-
-/**
- * Free an iterator obtained from [`TermSuffixIndex_IterateAll`].
- * Invalidates any string pointer previously returned by
- * [`TermSuffixIndexIterator_Next`].
- *
- * # Safety
- *
- * 1. `it` must be a [valid], non-null pointer to a live
- *    [`TermSuffixIndexIterator`].
- * 2. `it` must not be used after this call.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void TermSuffixIndexIterator_Free(struct TermSuffixIndexIterator *it);
-
-/**
- * Estimated heap memory currently held by the index, in bytes.
- *
- * # Safety
- *
- * 1. `tsi` must be a [valid], non-null pointer obtained from
- *    [`TermSuffixIndex_New`].
- * 2. No mutating call ([`TermSuffixIndex_Add`], [`TermSuffixIndex_Remove`],
- *    [`TermSuffixIndex_Free`]) may run concurrently with this call.
- *    Concurrent read-only calls are allowed.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-size_t TermSuffixIndex_MemUsage(const struct TermSuffixIndex *tsi);
 
 /**
  * Invoke `cb` once per member term matching the wildcard pattern
@@ -286,6 +240,52 @@ size_t TermSuffixIndex_MemUsage(const struct TermSuffixIndex *tsi);
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 int TermSuffixIndex_IterateWildcard(const struct TermSuffixIndex *tsi, const char *pattern, size_t len, TermSuffixIterateCallback cb, void *ctx, TermSuffixShouldStop should_stop, void *stop_ctx);
+
+/**
+ * Estimated heap memory currently held by the index, in bytes.
+ *
+ * # Safety
+ *
+ * 1. `tsi` must be a [valid], non-null pointer obtained from
+ *    [`TermSuffixIndex_New`].
+ * 2. No mutating call ([`TermSuffixIndex_Add`], [`TermSuffixIndex_Remove`],
+ *    [`TermSuffixIndex_Free`]) may run concurrently with this call.
+ *    Concurrent read-only calls are allowed.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+size_t TermSuffixIndex_MemUsage(const struct TermSuffixIndex *tsi);
+
+/**
+ * Create a new, empty [`TermSuffixIndex`]. Must be freed with
+ * [`TermSuffixIndex_Free`].
+ */
+struct TermSuffixIndex *TermSuffixIndex_New(void);
+
+/**
+ * Remove `term` (`len` UTF-8 bytes) from the index. Removing an absent
+ * or empty term is a no-op.
+ *
+ * Matching is case-insensitive: `term` is lowercased before lookup, so
+ * it matches the entry regardless of the case it was added with.
+ *
+ * # Safety
+ *
+ * 1. `tsi` must be a [valid], non-null pointer obtained from
+ *    [`TermSuffixIndex_New`].
+ * 2. No other access to `tsi` may occur concurrently with this call —
+ *    neither another mutator nor a read-only call such as
+ *    [`TermSuffixIndex_MemUsage`], and no iterator obtained from `tsi`
+ *    may be alive.
+ * 3. `term` must point to a [valid] byte sequence of length `len`.
+ *
+ * # Panics
+ *
+ * Panics if `term` is not valid UTF-8.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void TermSuffixIndex_Remove(struct TermSuffixIndex *tsi, const char *term, size_t len);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/triemap_ffi.h
+++ b/src/redisearch_rs/headers/triemap_ffi.h
@@ -95,6 +95,138 @@ extern "C" {
 extern void *TRIEMAP_NOTFOUND;
 
 /**
+ * Create a new [`TrieMap`]. Returns an opaque pointer to the newly created trie.
+ *
+ * To free the trie, use [`TrieMap_Free`].
+ */
+struct TrieMap *NewTrieMap(void);
+
+/**
+ * Free a trie iterator
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `it` must point to a valid [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
+ *   [`TrieMap_IterateWithFilter`] and cannot be NULL.
+ */
+void TrieMapIterator_Free(struct TrieMapIterator *it);
+
+/**
+ * Iterate to the next matching entry in the trie. Returns 1 if we can continue,
+ * or 0 if we're done and should exit
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `it` must point to a valid [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
+ *   [`TrieMap_IterateWithFilter`] and cannot be NULL.
+ * - `ptr` must point to a valid pointer to a byte sequence, which will be set to the current key. This
+ *   pointer is invalidated upon calling [`TrieMapIterator_Next`] again.
+ * - `len` must point to a valid `tm_len_t` which will be set to the length of the current key.
+ * - `value` must point to a valid pointer, which will be set to the value of the current key.
+ */
+int TrieMapIterator_Next(struct TrieMapIterator *it, char * *ptr, tm_len_t *len, void * *value);
+
+/**
+ * Set timeout limit used for affix queries. This timeout is checked in
+ * [`TrieMapIterator_Next`], which will return `0` if the timeout is reached.
+ *
+ * If the provided timeout is 0, it's interpreted as unlimited.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `it` must point to a valid [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
+ *   [`TrieMap_IterateWithFilter`] and cannot be NULL.
+ */
+void TrieMapIterator_SetTimeout(struct TrieMapIterator *it, timespec timeout);
+
+/**
+ * Free the [`TrieMapResultBuf`] and its contents.
+ */
+void TrieMapResultBuf_Free(TrieMapResultBuf buf);
+
+/**
+ * Retrieve an element from the buffer, via a 0-initialized index.
+ *
+ * It returns `NULL` if the index is out of bounds.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `buf` must point to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
+ */
+void *TrieMapResultBuf_GetByIndex(TrieMapResultBuf *buf, size_t index);
+
+/**
+ * Get the length of the TrieMapResultBuf.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `buf` must point to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
+ */
+size_t TrieMapResultBuf_Len(TrieMapResultBuf *buf);
+
+/**
+ * Add a new string to a trie. Returns 1 if the key is new to the trie or 0 if
+ * it already existed.
+ *
+ * If `cb` is given, instead of replacing and freeing the value using `rm_free`,
+ * we call the callback with the old and new value, and the function should return the value to set in the
+ * node, and take care of freeing any unwanted pointers. The returned value
+ * can be NULL and doesn't have to be either the old or new value.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ *  - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ *  - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
+ *  - `len` can be 0. If so, `str` is regarded as an empty string.
+ *  - `value` holds a pointer to the value of the record, which can be NULL
+ *  - `cb` must not free the value it returns
+ *  - The Redis allocator must be initialized before calling this function,
+ *    and `RedisModule_Free` must not get mutated while running this function.
+ */
+int TrieMap_Add(struct TrieMap *t, const char *str, tm_len_t len, void *value, TrieMapReplaceFunc cb);
+
+/**
+ * Mark a node as deleted. It also optimizes the trie by merging nodes if
+ * needed. If freeCB is given, it will be used to free the value (not the node)
+ * of the deleted node. If it doesn't, we simply call free().
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ * - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
+ * - `len` can be 0. If so, `str` is regarded as an empty string.
+ * - if `func` is not NULL, it must be a valid function pointer of the type [`freeCB`].
+ */
+int TrieMap_Delete(struct TrieMap *t, const char *str, tm_len_t len, freeCB func);
+
+/**
+ * Find the entry with a given string and length, and return its value, even if
+ * that was NULL.
+ *
+ * Returns the tree root if the key is empty.
+ *
+ * NOTE: If the key does not exist in the trie, we return the special
+ * constant value [`TRIEMAP_NOTFOUND`], so checking if the key exists is done by
+ * comparing to it, because NULL can be a valid result.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ * - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
+ * - `len` can be 0. If so, `str` is regarded as an empty string.
+ * - The value behind the returned pointer must not be destroyed by the caller.
+ *   Use [`TrieMap_Delete`] to remove it instead.
+ * - In case [`TRIEMAP_NOTFOUND`] is returned, the key does not exist in the trie,
+ *   and the pointer must not be dereferenced.
+ */
+void *TrieMap_Find(const struct TrieMap *t, const char *str, tm_len_t len);
+
+/**
  * Find nodes that have a given prefix. Results are placed in an array.
  * The `results` buffer is initialized by this function using the Redis allocator
  * and should be freed by calling [`TrieMapResultBuf_Free`].
@@ -111,11 +243,29 @@ extern void *TRIEMAP_NOTFOUND;
 TrieMapResultBuf TrieMap_FindPrefixes(const struct TrieMap *t, const char *str, tm_len_t len);
 
 /**
- * Create a new [`TrieMap`]. Returns an opaque pointer to the newly created trie.
+ * Free the trie's root and all its children recursively. If freeCB is given, we
+ * call it to free individual payload values (not the nodes). If not, free() is used instead.
  *
- * To free the trie, use [`TrieMap_Free`].
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `func` must either be NULL or a valid pointer to a function of type [`freeCB`].
+ * - The Redis allocator must be initialized before calling this function,
+ *   and `RedisModule_Free` must not get mutated while running this function.
  */
-struct TrieMap *NewTrieMap(void);
+void TrieMap_Free(struct TrieMap *t, freeCB func);
+
+/**
+ * Iterate over all the entries stored in the trie.
+ *
+ * Invoke [`TrieMapIterator_Next`] to get the results from the iteration. If there are no entries,
+ * the first call to next will return 0.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ * - `t` must not be freed while the iterator lives.
+ */
+struct TrieMapIterator *TrieMap_Iterate(struct TrieMap *t);
 
 /**
  * Iterate the trie within the specified key range.
@@ -144,58 +294,6 @@ struct TrieMap *NewTrieMap(void);
 void TrieMap_IterateRange(const struct TrieMap *trie, const char *min, int minlen, bool includeMin, const char *max, int maxlen, bool includeMax, TrieMapRangeCallback callback, void *ctx);
 
 /**
- * Iterate over all the entries stored in the trie.
- *
- * Invoke [`TrieMapIterator_Next`] to get the results from the iteration. If there are no entries,
- * the first call to next will return 0.
- *
- * # Safety
- * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
- * - `t` must not be freed while the iterator lives.
- */
-struct TrieMapIterator *TrieMap_Iterate(struct TrieMap *t);
-
-/**
- * Free the [`TrieMapResultBuf`] and its contents.
- */
-void TrieMapResultBuf_Free(TrieMapResultBuf buf);
-
-/**
- * Add a new string to a trie. Returns 1 if the key is new to the trie or 0 if
- * it already existed.
- *
- * If `cb` is given, instead of replacing and freeing the value using `rm_free`,
- * we call the callback with the old and new value, and the function should return the value to set in the
- * node, and take care of freeing any unwanted pointers. The returned value
- * can be NULL and doesn't have to be either the old or new value.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- *  - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
- *  - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
- *  - `len` can be 0. If so, `str` is regarded as an empty string.
- *  - `value` holds a pointer to the value of the record, which can be NULL
- *  - `cb` must not free the value it returns
- *  - The Redis allocator must be initialized before calling this function,
- *    and `RedisModule_Free` must not get mutated while running this function.
- */
-int TrieMap_Add(struct TrieMap *t, const char *str, tm_len_t len, void *value, TrieMapReplaceFunc cb);
-
-/**
- * Retrieve an element from the buffer, via a 0-initialized index.
- *
- * It returns `NULL` if the index is out of bounds.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `buf` must point to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
- */
-void *TrieMapResultBuf_GetByIndex(TrieMapResultBuf *buf, size_t index);
-
-/**
  * Iterate over the trie entries that match the given predicate.
  *
  * Depending on `iter_mode`, they can either be:
@@ -218,104 +316,6 @@ void *TrieMapResultBuf_GetByIndex(TrieMapResultBuf *buf, size_t index);
 struct TrieMapIterator *TrieMap_IterateWithFilter(struct TrieMap *t, const char *prefix, tm_len_t prefix_len, enum tm_iter_mode iter_mode);
 
 /**
- * Get the length of the TrieMapResultBuf.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `buf` must point to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
- */
-size_t TrieMapResultBuf_Len(TrieMapResultBuf *buf);
-
-/**
- * Set timeout limit used for affix queries. This timeout is checked in
- * [`TrieMapIterator_Next`], which will return `0` if the timeout is reached.
- *
- * If the provided timeout is 0, it's interpreted as unlimited.
- *
- * # Safety
- * The following invariants must be upheld when calling this function:
- * - `it` must point to a valid [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
- *   [`TrieMap_IterateWithFilter`] and cannot be NULL.
- */
-void TrieMapIterator_SetTimeout(struct TrieMapIterator *it, timespec timeout);
-
-/**
- * Find the entry with a given string and length, and return its value, even if
- * that was NULL.
- *
- * Returns the tree root if the key is empty.
- *
- * NOTE: If the key does not exist in the trie, we return the special
- * constant value [`TRIEMAP_NOTFOUND`], so checking if the key exists is done by
- * comparing to it, because NULL can be a valid result.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
- * - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
- * - `len` can be 0. If so, `str` is regarded as an empty string.
- * - The value behind the returned pointer must not be destroyed by the caller.
- *   Use [`TrieMap_Delete`] to remove it instead.
- * - In case [`TRIEMAP_NOTFOUND`] is returned, the key does not exist in the trie,
- *   and the pointer must not be dereferenced.
- */
-void *TrieMap_Find(const struct TrieMap *t, const char *str, tm_len_t len);
-
-/**
- * Free a trie iterator
- *
- * # Safety
- * The following invariants must be upheld when calling this function:
- * - `it` must point to a valid [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
- *   [`TrieMap_IterateWithFilter`] and cannot be NULL.
- */
-void TrieMapIterator_Free(struct TrieMapIterator *it);
-
-/**
- * Iterate to the next matching entry in the trie. Returns 1 if we can continue,
- * or 0 if we're done and should exit
- *
- * # Safety
- * The following invariants must be upheld when calling this function:
- * - `it` must point to a valid [`TrieMapIterator`] obtained from [`TrieMap_Iterate`] or
- *   [`TrieMap_IterateWithFilter`] and cannot be NULL.
- * - `ptr` must point to a valid pointer to a byte sequence, which will be set to the current key. This
- *   pointer is invalidated upon calling [`TrieMapIterator_Next`] again.
- * - `len` must point to a valid `tm_len_t` which will be set to the length of the current key.
- * - `value` must point to a valid pointer, which will be set to the value of the current key.
- */
-int TrieMapIterator_Next(struct TrieMapIterator *it, char * *ptr, tm_len_t *len, void * *value);
-
-/**
- * Mark a node as deleted. It also optimizes the trie by merging nodes if
- * needed. If freeCB is given, it will be used to free the value (not the node)
- * of the deleted node. If it doesn't, we simply call free().
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
- * - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
- * - `len` can be 0. If so, `str` is regarded as an empty string.
- * - if `func` is not NULL, it must be a valid function pointer of the type [`freeCB`].
- */
-int TrieMap_Delete(struct TrieMap *t, const char *str, tm_len_t len, freeCB func);
-
-/**
- * Free the trie's root and all its children recursively. If freeCB is given, we
- * call it to free individual payload values (not the nodes). If not, free() is used instead.
- *
- * # Safety
- * The following invariants must be upheld when calling this function:
- * - `func` must either be NULL or a valid pointer to a function of type [`freeCB`].
- * - The Redis allocator must be initialized before calling this function,
- *   and `RedisModule_Free` must not get mutated while running this function.
- */
-void TrieMap_Free(struct TrieMap *t, freeCB func);
-
-/**
  * Determines the amount of memory used by the trie in bytes.
  *
  * # Safety
@@ -323,16 +323,6 @@ void TrieMap_Free(struct TrieMap *t, freeCB func);
  * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
  */
 size_t TrieMap_MemUsage(struct TrieMap *t);
-
-/**
- * The number of unique keys stored in the provided triemap.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
- */
-size_t TrieMap_NUniqueKeys(const struct TrieMap *t);
 
 /**
  * The number of nodes stored in the provided triemap.
@@ -345,6 +335,16 @@ size_t TrieMap_NUniqueKeys(const struct TrieMap *t);
  * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
  */
 size_t TrieMap_NNodes(const struct TrieMap *t);
+
+/**
+ * The number of unique keys stored in the provided triemap.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+ */
+size_t TrieMap_NUniqueKeys(const struct TrieMap *t);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/ttl_table.h
+++ b/src/redisearch_rs/headers/ttl_table.h
@@ -34,28 +34,84 @@ extern "C" {
 #endif // __cplusplus
 
 /**
- * Lazy-initialize a [`TimeToLiveTable`] at `*table`. No-op if `*table` is
- * already non-null. `max_size` is the fixed modulus for the slot formula
- * so it must be ≥ 1.
- *
- * # Panics
- * `max_size` must be ≥ 1, otherwise the function panics
- *
- * # Safety
- *  - `table` must be a valid, writable `*mut *mut TimeToLiveTable`.
+ * Return empty FieldExpirationSlice
  */
-void TimeToLiveTable_VerifyInit(struct TimeToLiveTable * *table, size_t max_size);
+struct FieldExpirationSlice FieldExpirationsSlice_Empty(void);
 
 /**
- * Destroy the [`TimeToLiveTable`] at `*table` and write `NULL` back to it.
- * No-op if `*table` is already null.
+ * Borrow the entries of an owned [`FieldExpirations`] value without taking
+ * ownership.
+ *
+ * Returns an empty slice for a null pointer. The returned pointer is
+ * invalidated by any later mutation/drop of `fields` and must not be freed by
+ * the caller.
  *
  * # Safety
- *  - `table` must be a valid, writable `*mut *mut TimeToLiveTable`.
- *  - If `*table` is non-null, it must point to a value previously returned
- *    by [`TimeToLiveTable_VerifyInit`] and not yet destroyed.
+ *  - `fields`, when non-null, must point to a valid [`FieldExpirations`].
  */
-void TimeToLiveTable_Destroy(struct TimeToLiveTable * *table);
+struct FieldExpirationSlice FieldExpirations_AsSlice(const FieldExpirations *fields);
+
+/**
+ * Construct an empty [`FieldExpirations`].
+ *
+ * No heap allocation is performed until the first insertion.
+ */
+FieldExpirations FieldExpirations_Empty(void);
+
+/**
+ * Drop the [`FieldExpirations`] at `*v` and leave it in an empty,
+ * reusable state.
+ *
+ * Use on the abandon path — when a `FieldExpirations` is built but
+ * never handed to [`TimeToLiveTable_Add`]. Two such paths exist on the
+ * C side today:
+ * - `Document_Free` (`src/document_basic.c`) releasing a discarded
+ *   document.
+ * - `DocTable_UpdateExpiration` (`src/doc_table.c`) discarding an
+ *   empty list rather than registering it.
+ *
+ * After this call `*v` is logically the same as a fresh
+ * [`FieldExpirations_Empty`] result and is safe to reuse or to drop
+ * again.
+ *
+ * # Safety
+ *  - `v` must be non-null.
+ *  - `*v` must be either an initialized [`FieldExpirations`] (returned by a
+ *    constructor in this module).
+ *  - No other reference to `*v` may exist for the duration of the call.
+ */
+void FieldExpirations_Free(FieldExpirations *v);
+
+/**
+ * Number of [`FieldExpiration`] entries currently stored in `*v`.
+ *
+ * # Safety
+ *  - `v` must be non-null.
+ *  - `*v` must be either an initialized [`FieldExpirations`] (returned by a
+ *    constructor in this module).
+ */
+size_t FieldExpirations_Len(const FieldExpirations *v);
+
+/**
+ * Append `fe` to the end of `*v` without searching for the insertion
+ * point.
+ *
+ * Use when the caller already knows that `fe.index` is strictly greater
+ * than every index currently in `*v` — typically when building the
+ * list from an already-sorted source iterator.
+ *
+ * # Safety
+ *  - `v` must be a non-null pointer to an initialized [`FieldExpirations`].
+ *  - `fe.index` must be strictly greater than the `index` of every entry
+ *    already present in `*v`.
+ */
+void FieldExpirations_Push(FieldExpirations *v, struct FieldExpiration fe);
+
+/**
+ * Construct a [`FieldExpirations`] with backing storage pre-sized for at
+ * least `cap` entries.
+ */
+FieldExpirations FieldExpirations_WithCapacity(size_t cap);
 
 /**
  * Insert a document's per-field expirations. Ownership of `field_expirations`
@@ -73,67 +129,15 @@ void TimeToLiveTable_Destroy(struct TimeToLiveTable * *table);
 void TimeToLiveTable_Add(struct TimeToLiveTable *table, t_docId doc_id, FieldExpirations field_expirations);
 
 /**
- * Remove the entry for `doc_id`, if any. No-op if absent.
+ * Destroy the [`TimeToLiveTable`] at `*table` and write `NULL` back to it.
+ * No-op if `*table` is already null.
  *
  * # Safety
- *  - `table` must point to a valid, initialized [`TimeToLiveTable`] with
- *    no other live references.
+ *  - `table` must be a valid, writable `*mut *mut TimeToLiveTable`.
+ *  - If `*table` is non-null, it must point to a value previously returned
+ *    by [`TimeToLiveTable_VerifyInit`] and not yet destroyed.
  */
-void TimeToLiveTable_Remove(struct TimeToLiveTable *table, t_docId doc_id);
-
-/**
- * Returns whether the table holds no entries.
- *
- * # Safety
- *  - `table` must point to a valid, initialized [`TimeToLiveTable`].
- */
-bool TimeToLiveTable_IsEmpty(const struct TimeToLiveTable *table);
-
-/**
- * Borrow the per-field expiration list stored for `doc_id`.
- *
- * Returns a [`FieldExpirationSlice`] borrowing storage owned by the table.
- * On miss, both `ptr` and `len` are zero. The returned pointer is invalidated
- * by any subsequent `_Add` / `_Remove` / `_Destroy` for this table and must
- * not be freed by the caller.
- *
- * # Safety
- *  - `table` must point to a valid, initialized [`TimeToLiveTable`].
- */
-struct FieldExpirationSlice TimeToLiveTable_GetFieldExpirations(const struct TimeToLiveTable *table, t_docId doc_id);
-
-/**
- * Borrow the entries of an owned [`FieldExpirations`] value without taking
- * ownership.
- *
- * Returns an empty slice for a null pointer. The returned pointer is
- * invalidated by any later mutation/drop of `fields` and must not be freed by
- * the caller.
- *
- * # Safety
- *  - `fields`, when non-null, must point to a valid [`FieldExpirations`].
- */
-struct FieldExpirationSlice FieldExpirations_AsSlice(const FieldExpirations *fields);
-
-/**
- * Single-field expiration check.
- *
- * # Returns
- * `true` if the field's state satisfies `predicate` at `expiration_point`,
- * `false` otherwise. Specifically:
- * - With [`FieldExpirationPredicate::Default`], returns `true` iff the
- *   field is not expired (untracked fields and documents with no entry are
- *   treated as not expired).
- * - With [`FieldExpirationPredicate::Missing`], returns `true` iff the
- *   field is expired.
- *
- * Documents with no entry trivially satisfy any predicate and return `true`.
- *
- * # Safety
- *  - `table` must point to a valid, initialized [`TimeToLiveTable`].
- *  - `expiration_point` must be a valid `*const t_expirationTimePoint`.
- */
-bool TimeToLiveTable_FieldSatisfiesPredicate(const struct TimeToLiveTable *table, t_docId doc_id, uint16_t field_index, enum FieldExpirationPredicate predicate, const t_expirationTimePoint *expiration_point);
+void TimeToLiveTable_Destroy(struct TimeToLiveTable * *table);
 
 /**
  * Field-mask expiration check.
@@ -165,6 +169,47 @@ bool TimeToLiveTable_FieldSatisfiesPredicate(const struct TimeToLiveTable *table
 bool TimeToLiveTable_FieldMaskSatisfiesPredicate(const struct TimeToLiveTable *table, t_docId doc_id, t_fieldMask field_mask, enum FieldExpirationPredicate predicate, const t_expirationTimePoint *expiration_point, const uint16_t *ft_id_to_field_index, bool wide);
 
 /**
+ * Single-field expiration check.
+ *
+ * # Returns
+ * `true` if the field's state satisfies `predicate` at `expiration_point`,
+ * `false` otherwise. Specifically:
+ * - With [`FieldExpirationPredicate::Default`], returns `true` iff the
+ *   field is not expired (untracked fields and documents with no entry are
+ *   treated as not expired).
+ * - With [`FieldExpirationPredicate::Missing`], returns `true` iff the
+ *   field is expired.
+ *
+ * Documents with no entry trivially satisfy any predicate and return `true`.
+ *
+ * # Safety
+ *  - `table` must point to a valid, initialized [`TimeToLiveTable`].
+ *  - `expiration_point` must be a valid `*const t_expirationTimePoint`.
+ */
+bool TimeToLiveTable_FieldSatisfiesPredicate(const struct TimeToLiveTable *table, t_docId doc_id, uint16_t field_index, enum FieldExpirationPredicate predicate, const t_expirationTimePoint *expiration_point);
+
+/**
+ * Borrow the per-field expiration list stored for `doc_id`.
+ *
+ * Returns a [`FieldExpirationSlice`] borrowing storage owned by the table.
+ * On miss, both `ptr` and `len` are zero. The returned pointer is invalidated
+ * by any subsequent `_Add` / `_Remove` / `_Destroy` for this table and must
+ * not be freed by the caller.
+ *
+ * # Safety
+ *  - `table` must point to a valid, initialized [`TimeToLiveTable`].
+ */
+struct FieldExpirationSlice TimeToLiveTable_GetFieldExpirations(const struct TimeToLiveTable *table, t_docId doc_id);
+
+/**
+ * Returns whether the table holds no entries.
+ *
+ * # Safety
+ *  - `table` must point to a valid, initialized [`TimeToLiveTable`].
+ */
+bool TimeToLiveTable_IsEmpty(const struct TimeToLiveTable *table);
+
+/**
  * Test-only: number of buckets currently allocated.
  *
  * Number of buckets currently allocated (lazy-growth high-water mark).
@@ -181,71 +226,26 @@ bool TimeToLiveTable_FieldMaskSatisfiesPredicate(const struct TimeToLiveTable *t
 size_t TimeToLiveTable_NAllocatedBuckets(const struct TimeToLiveTable *table);
 
 /**
- * Construct an empty [`FieldExpirations`].
- *
- * No heap allocation is performed until the first insertion.
- */
-FieldExpirations FieldExpirations_Empty(void);
-
-/**
- * Construct a [`FieldExpirations`] with backing storage pre-sized for at
- * least `cap` entries.
- */
-FieldExpirations FieldExpirations_WithCapacity(size_t cap);
-
-/**
- * Append `fe` to the end of `*v` without searching for the insertion
- * point.
- *
- * Use when the caller already knows that `fe.index` is strictly greater
- * than every index currently in `*v` — typically when building the
- * list from an already-sorted source iterator.
+ * Remove the entry for `doc_id`, if any. No-op if absent.
  *
  * # Safety
- *  - `v` must be a non-null pointer to an initialized [`FieldExpirations`].
- *  - `fe.index` must be strictly greater than the `index` of every entry
- *    already present in `*v`.
+ *  - `table` must point to a valid, initialized [`TimeToLiveTable`] with
+ *    no other live references.
  */
-void FieldExpirations_Push(FieldExpirations *v, struct FieldExpiration fe);
+void TimeToLiveTable_Remove(struct TimeToLiveTable *table, t_docId doc_id);
 
 /**
- * Number of [`FieldExpiration`] entries currently stored in `*v`.
+ * Lazy-initialize a [`TimeToLiveTable`] at `*table`. No-op if `*table` is
+ * already non-null. `max_size` is the fixed modulus for the slot formula
+ * so it must be ≥ 1.
+ *
+ * # Panics
+ * `max_size` must be ≥ 1, otherwise the function panics
  *
  * # Safety
- *  - `v` must be non-null.
- *  - `*v` must be either an initialized [`FieldExpirations`] (returned by a
- *    constructor in this module).
+ *  - `table` must be a valid, writable `*mut *mut TimeToLiveTable`.
  */
-size_t FieldExpirations_Len(const FieldExpirations *v);
-
-/**
- * Drop the [`FieldExpirations`] at `*v` and leave it in an empty,
- * reusable state.
- *
- * Use on the abandon path — when a `FieldExpirations` is built but
- * never handed to [`TimeToLiveTable_Add`]. Two such paths exist on the
- * C side today:
- * - `Document_Free` (`src/document_basic.c`) releasing a discarded
- *   document.
- * - `DocTable_UpdateExpiration` (`src/doc_table.c`) discarding an
- *   empty list rather than registering it.
- *
- * After this call `*v` is logically the same as a fresh
- * [`FieldExpirations_Empty`] result and is safe to reuse or to drop
- * again.
- *
- * # Safety
- *  - `v` must be non-null.
- *  - `*v` must be either an initialized [`FieldExpirations`] (returned by a
- *    constructor in this module).
- *  - No other reference to `*v` may exist for the duration of the call.
- */
-void FieldExpirations_Free(FieldExpirations *v);
-
-/**
- * Return empty FieldExpirationSlice
- */
-struct FieldExpirationSlice FieldExpirationsSlice_Empty(void);
+void TimeToLiveTable_VerifyInit(struct TimeToLiveTable * *table, size_t max_size);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/types_ffi.h
+++ b/src/redisearch_rs/headers/types_ffi.h
@@ -68,61 +68,181 @@ extern "C" {
 #endif // __cplusplus
 
 /**
- * Check if the given value matches the numeric filter.
+ * Add a child to a result if it is an aggregate result.
+ *
+ * If the `parent` is not an aggregate kind, then this is a no-op.
+ *
+ * **Owned (copy) aggregates:** When `parent.is_copy()` is true, the parent
+ * takes ownership of `child` (via `Box::from_raw`). The caller must not
+ * access or free `child` afterward.
+ *
+ * **Borrowed aggregates:** When `parent.is_copy()` is false, the parent
+ * stores a borrowed reference to `child`. The caller retains ownership
+ * and must ensure `child` remains valid for the lifetime of `parent`.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `parent` must point to a valid `RSIndexResult` and cannot be NULL.
+ * - `child` must point to a valid `RSIndexResult` and cannot be NULL.
+ */
+void AggregateResult_AddChild(RSIndexResult *parent, RSIndexResult *child);
+
+/**
+ * Get the capacity of the aggregate result.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ */
+size_t AggregateResult_Capacity(const RSAggregateResult *agg);
+
+/**
+ * Take ownership of a `RSAggregateResult` to free any heap memory it owns. This function will not
+ * free the individual children pointers, but rather the heap allocations owned by the aggregate
+ * result itself (such as the internal vector buffer). The caller is responsible for managing the
+ * memory of the children pointers before this call if needed.
+ *
+ * The `agg` parameter should have been created with [`AggregateResult_New`].
+ */
+void AggregateResult_Free(RSAggregateResult agg);
+
+/**
+ * Get the result at the specified index in the aggregate result. This will return a `NULL` pointer
+ * if the index is out of bounds.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ */
+const RSIndexResult *AggregateResult_Get(const RSAggregateResult *agg, size_t index);
+
+/**
+ * Get a mutable result at the specified index in the aggregate result, without checking bounds.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * 1. `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ * 2. `index` must be lower than the length of the aggregate result children vector.
+ * 3. `agg` must be of the `Owned` variant.
+ */
+RSIndexResult *AggregateResult_GetMutUnchecked(RSAggregateResult *agg, size_t index);
+
+/**
+ * Get a view of the records stored inside the aggregate result.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ */
+struct AggregateRecordsSlice AggregateResult_GetRecordsSlice(const RSAggregateResult *agg);
+
+/**
+ * Get the result at the specified index in the aggregate result, without checking bounds.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * 1. `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ * 2. `index` must be lower than the length of the aggregate result children vector.
+ */
+const RSIndexResult *AggregateResult_GetUnchecked(const RSAggregateResult *agg, size_t index);
+
+/**
+ * Get the kind mask of the aggregate result.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ */
+uint8_t AggregateResult_KindMask(const RSAggregateResult *agg);
+
+/**
+ * Create a new aggregate result with the specified capacity. This function will make the result
+ * in Rust memory, but the ownership ends up being transferred to C's memory space. This ownership
+ * should return to Rust to free up any heap memory using [`AggregateResult_Free`].
+ */
+RSAggregateResult AggregateResult_New(size_t cap);
+
+/**
+ * Get the element count of the aggregate result.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ */
+size_t AggregateResult_NumChildren(const RSAggregateResult *agg);
+
+/**
+ * Get the aggregate result reference if the result is an aggregate result. If the result is
+ * not an aggregate, this function will return a `NULL` pointer.
  *
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `filter` must point to a valid `NumericFilter` and cannot be NULL.
+ * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
  */
-bool NumericFilter_Match(const struct NumericFilter *filter, double value);
+const RSAggregateResult *IndexResult_AggregateRef(const RSIndexResult *result);
 
 /**
- * Allocate a new intersect result with a given capacity and weight. This result should be freed
- * using [`IndexResult_Free`].
- */
-RSIndexResult *NewIntersectResult(size_t cap, double weight);
-
-/**
- * Allocate a new union result with a given capacity and weight. This result should be freed using
- * [`IndexResult_Free`].
- */
-RSIndexResult *NewUnionResult(size_t cap, double weight);
-
-/**
- * Allocate a new virtual result with a given weight and field mask. This result should be freed
- * using [`IndexResult_Free`].
- */
-RSIndexResult *NewVirtualResult(double weight, t_fieldMask field_mask);
-
-/**
- * Allocate a new numeric result. This result should be freed using [`IndexResult_Free`].
- */
-RSIndexResult *NewNumericResult(void);
-
-/**
- * Allocate a new metric result. This result should be freed using [`IndexResult_Free`].
- */
-RSIndexResult *NewMetricResult(void);
-
-/**
- * Allocate a new hybrid result. This result should be freed using [`IndexResult_Free`].
+ * Get a mutable aggregate result reference without performing a runtime check
+ * on the enum discriminant.
  *
- * This constructor is only used by the hydrid reader which will pushed owned copies to it.
- * Therefore, this also returns an owned `RSIndexResult`.
- */
-RSIndexResult *NewHybridResult(void);
-
-/**
- * Allocate a new token record with a given term and weight. This result should be freed using
- * [`IndexResult_Free`].
+ * Use this method if and only if you've already checked the enum
+ * discriminant in C code and you don't want to incur the (small)
+ * performance penalty of an additional redundant check.
  *
  * # Safety
  *
- * `term` must be a heap-allocated `RSQueryTerm` (e.g. created by `NewQueryTerm`) and the
- * caller transfers ownership — it must not be freed separately.
+ * The following invariant must be upheld when calling this function:
+ * 1. `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ * 2. `result`'s data payload must be of the aggregate kind
  */
-RSIndexResult *NewTokenRecord(struct RSQueryTerm *term, double weight);
+RSAggregateResult *IndexResult_AggregateRefMutUnchecked(RSIndexResult *result);
+
+/**
+ * Get the aggregate result reference without performing a runtime check
+ * on the enum discriminant.
+ *
+ * Use this method if and only if you've already checked the enum
+ * discriminant in C code and you don't want to incur the (small)
+ * performance penalty of an additional redundant check.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * 1. `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ * 2. `result`'s data payload must be of the aggregate kind
+ */
+const RSAggregateResult *IndexResult_AggregateRefUnchecked(const RSIndexResult *result);
+
+/**
+ * Reset the result if it is an aggregate result. This will clear the children vector
+ * and reset the kind mask.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ */
+void IndexResult_AggregateReset(RSIndexResult *result);
+
+/**
+ * Create a deep copy of the results that is totally thread safe. This is very slow so use it with
+ * caution.
+ *
+ * The created copy should be freed using [`IndexResult_Free`].
+ *
+ * # Safety
+ * The following invariant must be upheld when calling this function:
+ * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ */
+RSIndexResult *IndexResult_DeepCopy(const RSIndexResult *source);
 
 /**
  * Free an index result's internal allocations and also free the result itself.
@@ -141,18 +261,6 @@ RSIndexResult *NewTokenRecord(struct RSQueryTerm *term, double weight);
  *   - [`IndexResult_DeepCopy`]
  */
 void IndexResult_Free(RSIndexResult *result);
-
-/**
- * Create a deep copy of the results that is totally thread safe. This is very slow so use it with
- * caution.
- *
- * The created copy should be freed using [`IndexResult_Free`].
- *
- * # Safety
- * The following invariant must be upheld when calling this function:
- * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
- */
-RSIndexResult *IndexResult_DeepCopy(const RSIndexResult *source);
 
 /**
  * Check if the result is an aggregate result.
@@ -176,17 +284,6 @@ bool IndexResult_IsAggregate(const RSIndexResult *result);
 double IndexResult_NumValue(const RSIndexResult *result);
 
 /**
- * Set the numeric value of the result if it is a numeric result. If the result is not numeric,
- * this function will do nothing.
- *
- * # Safety
- *
- * The following invariant must be upheld when calling this function:
- * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
- */
-void IndexResult_SetNumValue(RSIndexResult *result, double value);
-
-/**
  * Get the query term from a result if it is a term result. If the result is not a term, then
  * this function will return a `NULL` pointer.
  *
@@ -196,6 +293,17 @@ void IndexResult_SetNumValue(RSIndexResult *result, double value);
  * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
  */
 struct RSQueryTerm *IndexResult_QueryTermRef(const RSIndexResult *result);
+
+/**
+ * Set the numeric value of the result if it is a numeric result. If the result is not numeric,
+ * this function will do nothing.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ */
+void IndexResult_SetNumValue(RSIndexResult *result, double value);
 
 /**
  * Get the term offsets from a result if it is a term result. If the result is not a term, then
@@ -209,212 +317,61 @@ struct RSQueryTerm *IndexResult_QueryTermRef(const RSIndexResult *result);
 const RSOffsetSlice *IndexResult_TermOffsetsRef(const RSIndexResult *result);
 
 /**
- * Get the aggregate result reference if the result is an aggregate result. If the result is
- * not an aggregate, this function will return a `NULL` pointer.
+ * Allocate a new hybrid result. This result should be freed using [`IndexResult_Free`].
+ *
+ * This constructor is only used by the hydrid reader which will pushed owned copies to it.
+ * Therefore, this also returns an owned `RSIndexResult`.
+ */
+RSIndexResult *NewHybridResult(void);
+
+/**
+ * Allocate a new intersect result with a given capacity and weight. This result should be freed
+ * using [`IndexResult_Free`].
+ */
+RSIndexResult *NewIntersectResult(size_t cap, double weight);
+
+/**
+ * Allocate a new metric result. This result should be freed using [`IndexResult_Free`].
+ */
+RSIndexResult *NewMetricResult(void);
+
+/**
+ * Allocate a new numeric result. This result should be freed using [`IndexResult_Free`].
+ */
+RSIndexResult *NewNumericResult(void);
+
+/**
+ * Allocate a new token record with a given term and weight. This result should be freed using
+ * [`IndexResult_Free`].
+ *
+ * # Safety
+ *
+ * `term` must be a heap-allocated `RSQueryTerm` (e.g. created by `NewQueryTerm`) and the
+ * caller transfers ownership — it must not be freed separately.
+ */
+RSIndexResult *NewTokenRecord(struct RSQueryTerm *term, double weight);
+
+/**
+ * Allocate a new union result with a given capacity and weight. This result should be freed using
+ * [`IndexResult_Free`].
+ */
+RSIndexResult *NewUnionResult(size_t cap, double weight);
+
+/**
+ * Allocate a new virtual result with a given weight and field mask. This result should be freed
+ * using [`IndexResult_Free`].
+ */
+RSIndexResult *NewVirtualResult(double weight, t_fieldMask field_mask);
+
+/**
+ * Check if the given value matches the numeric filter.
  *
  * # Safety
  *
  * The following invariant must be upheld when calling this function:
- * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ * - `filter` must point to a valid `NumericFilter` and cannot be NULL.
  */
-const RSAggregateResult *IndexResult_AggregateRef(const RSIndexResult *result);
-
-/**
- * Get the aggregate result reference without performing a runtime check
- * on the enum discriminant.
- *
- * Use this method if and only if you've already checked the enum
- * discriminant in C code and you don't want to incur the (small)
- * performance penalty of an additional redundant check.
- *
- * # Safety
- *
- * The following invariant must be upheld when calling this function:
- * 1. `result` must point to a valid `RSIndexResult` and cannot be NULL.
- * 2. `result`'s data payload must be of the aggregate kind
- */
-const RSAggregateResult *IndexResult_AggregateRefUnchecked(const RSIndexResult *result);
-
-/**
- * Get a mutable aggregate result reference without performing a runtime check
- * on the enum discriminant.
- *
- * Use this method if and only if you've already checked the enum
- * discriminant in C code and you don't want to incur the (small)
- * performance penalty of an additional redundant check.
- *
- * # Safety
- *
- * The following invariant must be upheld when calling this function:
- * 1. `result` must point to a valid `RSIndexResult` and cannot be NULL.
- * 2. `result`'s data payload must be of the aggregate kind
- */
-RSAggregateResult *IndexResult_AggregateRefMutUnchecked(RSIndexResult *result);
-
-/**
- * Reset the result if it is an aggregate result. This will clear the children vector
- * and reset the kind mask.
- *
- * # Safety
- *
- * The following invariant must be upheld when calling this function:
- * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
- */
-void IndexResult_AggregateReset(RSIndexResult *result);
-
-/**
- * Get the result at the specified index in the aggregate result. This will return a `NULL` pointer
- * if the index is out of bounds.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
- */
-const RSIndexResult *AggregateResult_Get(const RSAggregateResult *agg, size_t index);
-
-/**
- * Get the result at the specified index in the aggregate result, without checking bounds.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * 1. `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
- * 2. `index` must be lower than the length of the aggregate result children vector.
- */
-const RSIndexResult *AggregateResult_GetUnchecked(const RSAggregateResult *agg, size_t index);
-
-/**
- * Get a mutable result at the specified index in the aggregate result, without checking bounds.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * 1. `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
- * 2. `index` must be lower than the length of the aggregate result children vector.
- * 3. `agg` must be of the `Owned` variant.
- */
-RSIndexResult *AggregateResult_GetMutUnchecked(RSAggregateResult *agg, size_t index);
-
-/**
- * Get the element count of the aggregate result.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
- */
-size_t AggregateResult_NumChildren(const RSAggregateResult *agg);
-
-/**
- * Get the capacity of the aggregate result.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
- */
-size_t AggregateResult_Capacity(const RSAggregateResult *agg);
-
-/**
- * Get the kind mask of the aggregate result.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
- */
-uint8_t AggregateResult_KindMask(const RSAggregateResult *agg);
-
-/**
- * Create a new aggregate result with the specified capacity. This function will make the result
- * in Rust memory, but the ownership ends up being transferred to C's memory space. This ownership
- * should return to Rust to free up any heap memory using [`AggregateResult_Free`].
- */
-RSAggregateResult AggregateResult_New(size_t cap);
-
-/**
- * Take ownership of a `RSAggregateResult` to free any heap memory it owns. This function will not
- * free the individual children pointers, but rather the heap allocations owned by the aggregate
- * result itself (such as the internal vector buffer). The caller is responsible for managing the
- * memory of the children pointers before this call if needed.
- *
- * The `agg` parameter should have been created with [`AggregateResult_New`].
- */
-void AggregateResult_Free(RSAggregateResult agg);
-
-/**
- * Add a child to a result if it is an aggregate result.
- *
- * If the `parent` is not an aggregate kind, then this is a no-op.
- *
- * **Owned (copy) aggregates:** When `parent.is_copy()` is true, the parent
- * takes ownership of `child` (via `Box::from_raw`). The caller must not
- * access or free `child` afterward.
- *
- * **Borrowed aggregates:** When `parent.is_copy()` is false, the parent
- * stores a borrowed reference to `child`. The caller retains ownership
- * and must ensure `child` remains valid for the lifetime of `parent`.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `parent` must point to a valid `RSIndexResult` and cannot be NULL.
- * - `child` must point to a valid `RSIndexResult` and cannot be NULL.
- */
-void AggregateResult_AddChild(RSIndexResult *parent, RSIndexResult *child);
-
-/**
- * Get a view of the records stored inside the aggregate result.
- *
- * # Safety
- * The following invariants must be upheld when calling this function:
- * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
- */
-struct AggregateRecordsSlice AggregateResult_GetRecordsSlice(const RSAggregateResult *agg);
-
-/**
- * Retrieve the offsets array from an offset vector.
- *
- * Set the array length into the `len` pointer.
- * The returned array is borrowed and should not be modified.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `offsets` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
- *   and cannot be NULL.
- * - `len` cannot be NULL and must point to an allocated memory big enough to hold an u32.
- */
-const char *RSOffsetVector_GetData(const RSOffsetSlice *offsets, uint32_t *len);
-
-/**
- * Set the offsets array on an offset vector.
- *
- * The vector will borrow the passed array so it's up to the caller to
- * ensure it stays alive during its lifetime.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `offsets` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
- *   and cannot be NULL.
- * - `data` must point to an array of `len` offsets.
- * - if `data` is NULL then `len` should be 0.
- */
-void RSOffsetVector_SetData(RSOffsetSlice *offsets, const char *data, uint32_t len);
-
-/**
- * Free the data inside an offset vector.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `offsets` must point to a valid [`RSOffsetVector`] and cannot be NULL.
- * - The data pointer of `offsets` had been allocated via the global allocator
- *   and points to an array matching the length of `offsets`.
- */
-void RSOffsetVector_FreeData(RSOffsetVector *offsets);
+bool NumericFilter_Match(const struct NumericFilter *filter, double value);
 
 /**
  * Copy the data from one offset vector to another.
@@ -433,6 +390,33 @@ void RSOffsetVector_FreeData(RSOffsetVector *offsets);
 void RSOffsetVector_CopyData(RSOffsetVector *dest, const RSOffsetSlice *src);
 
 /**
+ * Free the data inside an offset vector.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `offsets` must point to a valid [`RSOffsetVector`] and cannot be NULL.
+ * - The data pointer of `offsets` had been allocated via the global allocator
+ *   and points to an array matching the length of `offsets`.
+ */
+void RSOffsetVector_FreeData(RSOffsetVector *offsets);
+
+/**
+ * Retrieve the offsets array from an offset vector.
+ *
+ * Set the array length into the `len` pointer.
+ * The returned array is borrowed and should not be modified.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `offsets` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
+ *   and cannot be NULL.
+ * - `len` cannot be NULL and must point to an allocated memory big enough to hold an u32.
+ */
+const char *RSOffsetVector_GetData(const RSOffsetSlice *offsets, uint32_t *len);
+
+/**
  * Retrieve the number of offsets in an offset vector.
  *
  * # Safety
@@ -442,6 +426,22 @@ void RSOffsetVector_CopyData(RSOffsetVector *dest, const RSOffsetSlice *src);
  *   and cannot be NULL.
  */
 uint32_t RSOffsetVector_Len(const RSOffsetSlice *offsets);
+
+/**
+ * Set the offsets array on an offset vector.
+ *
+ * The vector will borrow the passed array so it's up to the caller to
+ * ensure it stays alive during its lifetime.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `offsets` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
+ *   and cannot be NULL.
+ * - `data` must point to an array of `len` offsets.
+ * - if `data` is NULL then `len` should be 0.
+ */
+void RSOffsetVector_SetData(RSOffsetSlice *offsets, const char *data, uint32_t len);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/value_ffi.h
+++ b/src/redisearch_rs/headers/value_ffi.h
@@ -47,6 +47,85 @@ extern "C" {
 #endif // __cplusplus
 
 /**
+ * Returns a pointer to the element at `index` in an array [`RSValue`].
+ *
+ * If `value` is not an array, returns a null pointer. The returned pointer
+ * is borrowed from the array and must not be freed by the caller.
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ *
+ * # Panics
+ *
+ * Panics if `index` greater than or equal to the array length.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+struct RSValue *RSValue_ArrayItem(const struct RSValue *value, uint32_t index);
+
+/**
+ * Returns the number of elements in an array [`RSValue`].
+ *
+ * If `value` is not an array, returns `0`.
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+uint32_t RSValue_ArrayLen(const struct RSValue *value);
+
+/**
+ * Test whether an [`RSValue`] is "truthy".
+ *
+ * Returns `true` for non-zero numbers, non-empty strings, and non-empty arrays.
+ * All other variants (including [`Value::Null`] and [`Value::Map`])
+ * evaluate to `false`. References are followed via
+ * [`Value::fully_dereferenced_ref`].
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+bool RSValue_BoolTest(const struct RSValue *value);
+
+/**
+ * Resets `value` to [`Value::Undefined`], dropping whatever it previously held.
+ *
+ * # Panic
+ *
+ * Panics if more than 1 reference exists to this [`RSValue`] object.
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RSValue_Clear(const struct RSValue *value);
+
+/**
+ * Compare two [`RSValue`]s, returning `-1` if `v1 < v2`, `0` if `v1 == v2`,
+ * or `1` if `v1 > v2`.
+ *
+ * When `status` is null, mixed number/string comparisons fall back to
+ * string-based comparison. When `status` is non-null and string-to-number
+ * conversion fails, a [`QueryError`] is written to `status`.
+ *
+ * # Safety
+ *
+ * 1. `v1` and `v2` must be [valid], non-null pointers to [`RSValue`]s.
+ * 2. `status`, when non-null, must be a [valid], writable pointer to a [`QueryError`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+int RSValue_Cmp(const struct RSValue *v1, const struct RSValue *v2, struct QueryError *status);
+
+/**
  * Decrement the reference count of the provided [`RSValue`] object. If this was
  * the last available reference, it frees the data.
  *
@@ -60,39 +139,31 @@ extern "C" {
 void RSValue_DecrRef(const struct RSValue *value);
 
 /**
- * Allocates an array of null pointers with space for `len` [`RSValue`] pointers.
+ * Follows [`Value::Ref`] indirections and returns a pointer to the
+ * innermost non-[`Ref`](Value::Ref) [`Value`].
  *
- * The returned buffer must be populated and then passed to [`RSValue_NewArrayFromBuilder`]
- * to produce an array value.
- *
- * # Safety
- *
- * 1. The caller must eventually pass the returned pointer to [`RSValue_NewArrayFromBuilder`].
- */
-struct RSValue * *RSValue_NewArrayBuilder(uint32_t len);
-
-/**
- * Creates and returns a new [`RSValue`] of type [`Value::Undefined`].
- *
- * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
- * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
- * transferred through other `RSValue_` functions before that happens.
- */
-struct RSValue *RSValue_NewUndefined(void);
-
-/**
- * Convert the [`RSValue`] to a number. Returns `true` when this value is a number
- * or a numeric string that can be converted and writes the number to `d`. If
- * the value cannot be converted `false` is returned and nothing is written to `d`.
+ * The returned pointer borrows from the same allocation as `value`; no new
+ * ownership is created.
  *
  * # Safety
  *
- * 1. `value` must be a [valid] pointer to an [`RSValue`], or null.
- * 2. `d` must be a [valid], non-null pointer to a `c_double`.
+ * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-bool RSValue_ToNumber(const struct RSValue *value, double *d);
+struct RSValue *RSValue_Dereference(const struct RSValue *value);
+
+/**
+ * Like [`RSValue_Dereference`], but also follows [`Value::Trio`]
+ * indirections by recursing into the left element of each trio.
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+struct RSValue *RSValue_DereferenceRefAndTrio(const struct RSValue *value);
 
 /**
  * Writes the debug representation of an [`RSValue`] into an SDS string.
@@ -111,19 +182,16 @@ bool RSValue_ToNumber(const struct RSValue *value, double *d);
 sds RSValue_DumpSds(const struct RSValue *value, sds sds, bool obfuscate);
 
 /**
- * Gets the numeric value from an [`RSValue`].
- *
- * # Panic
- *
- * Panics if the value is not a [`Value::Number`].
+ * Check whether two [`RSValue`]s are equal, returning `true` if they are and
+ * `false` otherwise.
  *
  * # Safety
  *
- * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ * 1. `v1` and `v2` must be [valid], non-null pointers to [`RSValue`]s.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-double RSValue_Number_Get(const struct RSValue *value);
+bool RSValue_Equal(const struct RSValue *v1, const struct RSValue *v2, struct QueryError *_status);
 
 /**
  * Computes a HashDoS-resistant 64-bit hash of an [`RSValue`], mixing in `hval` so that
@@ -146,128 +214,6 @@ double RSValue_Number_Get(const struct RSValue *value);
 uint64_t RSValue_Hash(const struct RSValue *value, uint64_t hval);
 
 /**
- * Converts an [`RSValue`] to a number type in-place.
- *
- * This clears the existing value and sets it to Number with the given value.
- *
- * # Panic
- *
- * Panics if more than 1 reference exists to this [`RSValue`] object.
- *
- * # Safety
- *
- * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
- * 2. `value` **must not** be used or freed after this call, as this function takes ownership.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void RSValue_SetNumber(struct RSValue *value, double n);
-
-/**
- * Compare two [`RSValue`]s, returning `-1` if `v1 < v2`, `0` if `v1 == v2`,
- * or `1` if `v1 > v2`.
- *
- * When `status` is null, mixed number/string comparisons fall back to
- * string-based comparison. When `status` is non-null and string-to-number
- * conversion fails, a [`QueryError`] is written to `status`.
- *
- * # Safety
- *
- * 1. `v1` and `v2` must be [valid], non-null pointers to [`RSValue`]s.
- * 2. `status`, when non-null, must be a [valid], writable pointer to a [`QueryError`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-int RSValue_Cmp(const struct RSValue *v1, const struct RSValue *v2, struct QueryError *status);
-
-/**
- * Allocates a new, uninitialized [`RSValueMapBuilder`] with space for `len` entries.
- *
- * The map entries are uninitialized and must be set using [`RSValue_MapBuilderSetEntry`]
- * before being finalized into an [`RSValue`] via [`RSValue_NewMapFromBuilder`].
- *
- * # Safety
- *
- * 1. All entries must be initialized via [`RSValue_MapBuilderSetEntry`] before
- *    passing the map to [`RSValue_NewMapFromBuilder`].
- */
-struct RSValueMapBuilder *RSValue_NewMapBuilder(uint32_t len);
-
-/**
- * Creates and returns a new [`RSValue`] of type [`Value::Null`].
- *
- * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
- * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
- * transferred through other `RSValue_` functions before that happens.
- */
-struct RSValue *RSValue_NewNull(void);
-
-/**
- * Returns the type of the given [`RSValue`].
- *
- * # Safety
- *
- * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-enum RSValueType RSValue_Type(const struct RSValue *value);
-
-/**
- * Follows [`Value::Ref`] indirections and returns a pointer to the
- * innermost non-[`Ref`](Value::Ref) [`Value`].
- *
- * The returned pointer borrows from the same allocation as `value`; no new
- * ownership is created.
- *
- * # Safety
- *
- * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-struct RSValue *RSValue_Dereference(const struct RSValue *value);
-
-/**
- * Creates a heap-allocated array [`RSValue`] from existing values.
- *
- * Takes ownership of the `values` buffer and all [`RSValue`] pointers within it.
- * The values will be freed when the array is freed.
- *
- * # Safety
- *
- * 1. `values` must have been allocated via [`RSValue_NewArrayBuilder`] with
- *    a capacity equal to `len`.
- * 2. All `len` entries in `values` must have been filled with valid [`RSValue`] pointers.
- */
-struct RSValue *RSValue_NewArrayFromBuilder(struct RSValue * *values, uint32_t len);
-
-/**
- * Creates and returns a new [`RSValue`] of type [`Value::Number`]
- * containing the given numeric value.
- *
- * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
- * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
- * transferred through other `RSValue_` functions before that happens.
- */
-struct RSValue *RSValue_NewNumber(double value);
-
-/**
- * Borrows an immutable reference to the left value of a trio.
- *
- * # Panic
- *
- * Panics if the value is not a [`Value::Trio`].
- *
- * # Safety
- *
- * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-const struct RSValue *RSValue_Trio_GetLeft(const struct RSValue *value);
-
-/**
  * Computes a deterministic 64-bit hash of an [`RSValue`], mixing in `hval` as
  * described in [`RSValue_Hash`].
  *
@@ -287,22 +233,121 @@ const struct RSValue *RSValue_Trio_GetLeft(const struct RSValue *value);
 uint64_t RSValue_HashStable(const struct RSValue *value, uint64_t hval);
 
 /**
- * Converts an [`RSValue`] to null type in-place.
+ * Increments the reference count of `value` and returns a new owned pointer
+ * to the same allocation.
  *
- * This clears the existing value and sets it to Null.
- *
- * # Panic
- *
- * Panics if more than 1 reference exists to this [`RSValue`] object.
+ * The caller must ensure the returned pointer is eventually passed to
+ * [`RSValue_DecrRef`].
  *
  * # Safety
  *
  * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
- * 2. `value` **must not** be used or freed after this call, as this function takes ownership.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-void RSValue_SetNull(struct RSValue *value);
+struct RSValue *RSValue_IncrRef(const struct RSValue *value);
+
+/**
+ * Returns whether the given [`RSValue`] is an array type, or `false` if `value` is NULL.
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid] pointer to an [`RSValue`], or null.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+bool RSValue_IsArray(const struct RSValue *value);
+
+/**
+ * Returns whether the given [`RSValue`] is a null pointer, a null type, or a reference to a null type.
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid] pointer to an [`RSValue`], or null.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+bool RSValue_IsNull(const struct RSValue *value);
+
+/**
+ * Returns whether the given [`RSValue`] is a number type, or `false` if `value` is NULL.
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid] pointer to an [`RSValue`], or null.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+bool RSValue_IsNumber(const struct RSValue *value);
+
+/**
+ * Returns whether the given [`RSValue`] is a reference type, or `false` if `value` is NULL.
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid] pointer to an [`RSValue`], or null.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+bool RSValue_IsReference(const struct RSValue *value);
+
+/**
+ * Returns whether the given [`RSValue`] is a string type (any string variant), or `false` if `value` is NULL.
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid] pointer to an [`RSValue`], or null.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+bool RSValue_IsString(const struct RSValue *value);
+
+/**
+ * Returns whether the given [`RSValue`] is a trio type, or `false` if `value` is NULL.
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid] pointer to an [`RSValue`], or null.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+bool RSValue_IsTrio(const struct RSValue *value);
+
+/**
+ * Like [`RSValue_MakeReference`], but **takes ownership** of `src` instead of
+ * incrementing its reference count.
+ *
+ * After this call, `src` must not be used or freed by the caller.
+ *
+ * # Panic
+ *
+ * Panics if more than 1 reference exists to the `dst` [`RSValue`] object.
+ *
+ * # Safety
+ *
+ * 1. `dst` must be a [valid], non-null pointer to an [`RSValue`].
+ * 2. `src` must be a [valid], non-null pointer to an [`RSValue`]. Ownership is transferred to `dst`.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RSValue_MakeOwnReference(const struct RSValue *dst, const struct RSValue *src);
+
+/**
+ * Replaces the content of `dst` with an [`Value::Ref`] pointing to `src`.
+ *
+ * `src`'s reference count is incremented; `dst`'s previous content is dropped.
+ *
+ * # Panic
+ *
+ * Panics if more than 1 reference exists to the `dst` [`RSValue`] object.
+ *
+ * # Safety
+ *
+ * 1. `dst` and `src` must be [valid], non-null pointers to [`RSValue`]s.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RSValue_MakeReference(const struct RSValue *dst, const struct RSValue *src);
 
 /**
  * Sets a key-value pair at a specific index in the map.
@@ -324,28 +369,237 @@ void RSValue_SetNull(struct RSValue *value);
 void RSValue_MapBuilderSetEntry(struct RSValueMapBuilder *map, size_t index, struct RSValue *key, struct RSValue *value);
 
 /**
- * Like [`RSValue_Dereference`], but also follows [`Value::Trio`]
- * indirections by recursing into the left element of each trio.
+ * Retrieves a key-value pair from a map [`RSValue`] at a specific index.
+ *
+ * The returned key and value pointers are borrowed from the map and must
+ * not be freed by the caller.
  *
  * # Safety
  *
- * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ * 1. `map` must be a [valid], non-null pointer to an [`RSValue`].
+ * 2. `key` and `value` must be valid, non-null pointers to writable
+ *    `*mut RSValue` locations.
+ *
+ * # Panics
+ *
+ * - Panics if `map` is not a map value.
+ * - Panics if `index` is greater or equal to the map length.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-struct RSValue *RSValue_DereferenceRefAndTrio(const struct RSValue *value);
+void RSValue_Map_GetEntry(const struct RSValue *map, uint32_t index, struct RSValue * *key, struct RSValue * *value);
 
 /**
- * Check whether two [`RSValue`]s are equal, returning `true` if they are and
- * `false` otherwise.
+ * Returns the number of key-value pairs in a map [`RSValue`].
  *
  * # Safety
  *
- * 1. `v1` and `v2` must be [valid], non-null pointers to [`RSValue`]s.
+ * 1. `map` must be a [valid], non-null pointer to an [`RSValue`].
+ *
+ * # Panics
+ *
+ * Panics if `map` is not a map value.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-bool RSValue_Equal(const struct RSValue *v1, const struct RSValue *v2, struct QueryError *_status);
+uint32_t RSValue_Map_Len(const struct RSValue *map);
+
+/**
+ * Allocates an array of null pointers with space for `len` [`RSValue`] pointers.
+ *
+ * The returned buffer must be populated and then passed to [`RSValue_NewArrayFromBuilder`]
+ * to produce an array value.
+ *
+ * # Safety
+ *
+ * 1. The caller must eventually pass the returned pointer to [`RSValue_NewArrayFromBuilder`].
+ */
+struct RSValue * *RSValue_NewArrayBuilder(uint32_t len);
+
+/**
+ * Creates a heap-allocated array [`RSValue`] from existing values.
+ *
+ * Takes ownership of the `values` buffer and all [`RSValue`] pointers within it.
+ * The values will be freed when the array is freed.
+ *
+ * # Safety
+ *
+ * 1. `values` must have been allocated via [`RSValue_NewArrayBuilder`] with
+ *    a capacity equal to `len`.
+ * 2. All `len` entries in `values` must have been filled with valid [`RSValue`] pointers.
+ */
+struct RSValue *RSValue_NewArrayFromBuilder(struct RSValue * *values, uint32_t len);
+
+/**
+ * Creates and returns a new [`RSValue`] of type [`Value::String`],
+ * borrowing the given string buffer without taking ownership.
+ *
+ * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
+ * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
+ * transferred through other `RSValue_` functions before that happens.
+ *
+ * # Safety
+ *
+ * 1. `str` must be a [valid], non-null pointer to a buffer of `len+1` bytes.
+ * 2. A nul-terminator is expected in memory at `str+len`.
+ * 3. The size determined by `len` excludes the nul-terminator.
+ * 4. The memory pointed to by `str` must remain valid and not be mutated for the entire
+ *    lifetime of the returned [`RSValue`] and any clones of it.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+struct RSValue *RSValue_NewBorrowedString(const char *str, uint32_t len);
+
+/**
+ * Creates and returns a new [`RSValue`] of type [`Value::String`],
+ * copying `len` bytes from the given string buffer into a new Rust-allocated [`Box<CStr>`].
+ *
+ * The caller retains ownership of `str`.
+ *
+ * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
+ * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
+ * transferred through other `RSValue_` functions before that happens.
+ *
+ * # Safety
+ *
+ * 1. `str` must be a [valid], non-null pointer to a string buffer.
+ * 2. `str` must be [valid] for reads of `len` bytes.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+struct RSValue *RSValue_NewCopiedString(const char *str, uint32_t len);
+
+/**
+ * Allocates a new, uninitialized [`RSValueMapBuilder`] with space for `len` entries.
+ *
+ * The map entries are uninitialized and must be set using [`RSValue_MapBuilderSetEntry`]
+ * before being finalized into an [`RSValue`] via [`RSValue_NewMapFromBuilder`].
+ *
+ * # Safety
+ *
+ * 1. All entries must be initialized via [`RSValue_MapBuilderSetEntry`] before
+ *    passing the map to [`RSValue_NewMapFromBuilder`].
+ */
+struct RSValueMapBuilder *RSValue_NewMapBuilder(uint32_t len);
+
+/**
+ * Creates a heap-allocated map [`RSValue`] from an [`RSValueMapBuilder`].
+ *
+ * Takes ownership of the map structure and all its entries. The [`RSValueMapBuilder`]
+ * pointer is consumed and must not be used after this call.
+ *
+ * # Safety
+ *
+ * 1. `map` must be a valid pointer to an [`RSValueMapBuilder`] created by
+ *    [`RSValue_NewMapBuilder`].
+ * 2. All entries in the map must have been initialized via [`RSValue_MapBuilderSetEntry`].
+ */
+struct RSValue *RSValue_NewMapFromBuilder(struct RSValueMapBuilder *map);
+
+/**
+ * Creates and returns a new [`RSValue`] of type [`Value::Null`].
+ *
+ * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
+ * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
+ * transferred through other `RSValue_` functions before that happens.
+ */
+struct RSValue *RSValue_NewNull(void);
+
+/**
+ * Creates and returns a new [`RSValue`] of type [`Value::Number`]
+ * containing the given numeric value.
+ *
+ * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
+ * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
+ * transferred through other `RSValue_` functions before that happens.
+ */
+struct RSValue *RSValue_NewNumber(double value);
+
+/**
+ * Creates and returns a new [`RSValue`] of type [`Value::Number`] from an `i64`.
+ *
+ * The `i64` is cast to `f64`, which may lose precision for values outside
+ * the exact representable range of `f64`.
+ *
+ * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
+ * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
+ * transferred through other `RSValue_` functions before that happens.
+ */
+struct RSValue *RSValue_NewNumberFromInt64(int64_t number);
+
+/**
+ * Creates and returns a new [`RSValue`] of type [`Value::Number`] by parsing the given
+ * string as a floating-point number. Returns a null pointer if the string
+ * cannot be parsed.
+ *
+ * The caller retains ownership of `value`.
+ *
+ * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
+ * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
+ * transferred through other `RSValue_` functions before that happens.
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid], non-null pointer to a string buffer.
+ * 2. `value` must be [valid] for reads of `len` bytes.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+struct RSValue *RSValue_NewParsedNumber(const char *value, size_t len);
+
+/**
+ * Creates and returns a new [`RSValue`] of type [`Value::String`],
+ * taking ownership of the given [`RedisModuleString`].
+ *
+ * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
+ * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
+ * transferred through other `RSValue_` functions before that happens.
+ *
+ * # Safety
+ *
+ * 1. `str` must be a [valid], non-null pointer to a [`RedisModuleString`].
+ * 2. `str` **must not** be used or freed after this function is called, as this function
+ *    takes ownership of the string.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+struct RSValue *RSValue_NewRedisString(struct RedisModuleString *str);
+
+/**
+ * Creates and returns a new [`RSValue`] of type [`Value::Ref`] that points to `src`.
+ *
+ * `src`'s reference count is incremented; the caller retains ownership of `src`.
+ *
+ * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
+ * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
+ * transferred through other `RSValue_` functions before that happens.
+ *
+ * # Safety
+ *
+ * 1. `src` must point to a valid [`RSValue`].
+ */
+struct RSValue *RSValue_NewReference(const struct RSValue *src);
+
+/**
+ * Creates and returns a new [`RSValue`] of type [`Value::String`],
+ * taking ownership of the given `RedisModule_Alloc`-allocated buffer.
+ *
+ * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
+ * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
+ * transferred through other `RSValue_` functions before that happens.
+ *
+ * # Safety
+ *
+ * 1. `str` must be a [valid], non-null pointer to a buffer of `len+1` bytes
+ *    allocated by `RedisModule_Alloc`.
+ * 2. A nul-terminator is expected in memory at `str+len`.
+ * 3. The size determined by `len` excludes the nul-terminator.
+ * 4. `str` **must not** be used or freed after this function is called, as this function
+ *    takes ownership of the allocation.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+struct RSValue *RSValue_NewString(char *str, uint32_t len);
 
 /**
  * Creates and returns a new [`RSValue`] of type [`Value::Trio`] from three [`RSValue`]s.
@@ -367,6 +621,29 @@ bool RSValue_Equal(const struct RSValue *v1, const struct RSValue *v2, struct Qu
 struct RSValue *RSValue_NewTrio(struct RSValue *left, struct RSValue *middle, struct RSValue *right);
 
 /**
+ * Creates and returns a new [`RSValue`] of type [`Value::Undefined`].
+ *
+ * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
+ * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
+ * transferred through other `RSValue_` functions before that happens.
+ */
+struct RSValue *RSValue_NewUndefined(void);
+
+/**
+ * Returns a pointer to the static [`Value::Null`].
+ *
+ * Unlike [`RSValue_NewNull`], this does **not** heap-allocate; it returns a
+ * pointer to a shared static value managed by [`SharedValue::null_static`].
+ * The returned pointer must still be passed to
+ * [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef) for symmetry.
+ *
+ * # Safety
+ *
+ * The returned pointer must not be mutated.
+ */
+struct RSValue *RSValue_NullStatic(void);
+
+/**
  * Formats the numeric value of a [`Value::Number`] as a string into the
  * caller-provided buffer and returns the number of bytes written.
  *
@@ -384,35 +661,11 @@ struct RSValue *RSValue_NewTrio(struct RSValue *left, struct RSValue *middle, st
 size_t RSValue_NumToString(const struct RSValue *value, char *buf, size_t buflen);
 
 /**
- * Returns whether the given [`RSValue`] is a reference type, or `false` if `value` is NULL.
- *
- * # Safety
- *
- * 1. `value` must be a [valid] pointer to an [`RSValue`], or null.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-bool RSValue_IsReference(const struct RSValue *value);
-
-/**
- * Returns the number of elements in an array [`RSValue`].
- *
- * If `value` is not an array, returns `0`.
- *
- * # Safety
- *
- * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-uint32_t RSValue_ArrayLen(const struct RSValue *value);
-
-/**
- * Borrows an immutable reference to the middle value of a trio.
+ * Gets the numeric value from an [`RSValue`].
  *
  * # Panic
  *
- * Panics if the value is not a [`Value::Trio`].
+ * Panics if the value is not a [`Value::Number`].
  *
  * # Safety
  *
@@ -420,10 +673,58 @@ uint32_t RSValue_ArrayLen(const struct RSValue *value);
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-const struct RSValue *RSValue_Trio_GetMiddle(const struct RSValue *value);
+double RSValue_Number_Get(const struct RSValue *value);
 
 /**
- * Resets `value` to [`Value::Undefined`], dropping whatever it previously held.
+ * Returns a read only reference to the underlying [`RedisModuleString`] of an [`RSValue`].
+ *
+ * The returned reference borrows from the [`RSValue`] and must not outlive it.
+ *
+ * # Panic
+ *
+ * Panics if the value is not a [`Value::RedisString`].
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+const struct RedisModuleString *RSValue_RedisString_Get(const struct RSValue *value);
+
+/**
+ * Returns the current reference count of `value`.
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+uint16_t RSValue_Refcount(const struct RSValue *value);
+
+/**
+ * Replaces the pointer at `*dstpp` with a new clone of `src`.
+ *
+ * The previous value at `*dstpp` is decremented (and potentially freed).
+ * `src`'s reference count is incremented.
+ *
+ * # Safety
+ *
+ * 1. `dstpp` must be a [valid], non-null pointer to an `*mut RSValue`.
+ * 2. `*dstpp` must be a [valid], non-null pointer to an [`RSValue`] (it will be consumed).
+ * 3. `src` must be a [valid], non-null pointer to an [`RSValue`].
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RSValue_Replace(struct RSValue * *dstpp, const struct RSValue *src);
+
+/**
+ * Converts an [`RSValue`] to a string type in-place, borrowing the given string buffer
+ * without taking ownership.
+ *
+ * This clears the existing value and sets it to a [`String`] of kind `Borrowed`
+ * with the given buffer.
  *
  * # Panic
  *
@@ -432,35 +733,52 @@ const struct RSValue *RSValue_Trio_GetMiddle(const struct RSValue *value);
  * # Safety
  *
  * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ * 2. `value` **must not** be used or freed after this call, as this function takes ownership.
+ * 3. `str` must be a [valid], non-null pointer to a buffer of `len+1` bytes.
+ * 4. A nul-terminator is expected in memory at `str+len`.
+ * 5. The size determined by `len` excludes the nul-terminator.
+ * 6. The memory pointed to by `str` must remain valid and not be mutated for the entire
+ *    lifetime of the returned [`RSValue`] and any clones of it.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-void RSValue_Clear(const struct RSValue *value);
+void RSValue_SetConstString(struct RSValue *value, const char *str, uint32_t len);
 
 /**
- * Creates a heap-allocated map [`RSValue`] from an [`RSValueMapBuilder`].
+ * Converts an [`RSValue`] to null type in-place.
  *
- * Takes ownership of the map structure and all its entries. The [`RSValueMapBuilder`]
- * pointer is consumed and must not be used after this call.
+ * This clears the existing value and sets it to Null.
+ *
+ * # Panic
+ *
+ * Panics if more than 1 reference exists to this [`RSValue`] object.
  *
  * # Safety
  *
- * 1. `map` must be a valid pointer to an [`RSValueMapBuilder`] created by
- *    [`RSValue_NewMapBuilder`].
- * 2. All entries in the map must have been initialized via [`RSValue_MapBuilderSetEntry`].
- */
-struct RSValue *RSValue_NewMapFromBuilder(struct RSValueMapBuilder *map);
-
-/**
- * Returns whether the given [`RSValue`] is a number type, or `false` if `value` is NULL.
- *
- * # Safety
- *
- * 1. `value` must be a [valid] pointer to an [`RSValue`], or null.
+ * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ * 2. `value` **must not** be used or freed after this call, as this function takes ownership.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-bool RSValue_IsNumber(const struct RSValue *value);
+void RSValue_SetNull(struct RSValue *value);
+
+/**
+ * Converts an [`RSValue`] to a number type in-place.
+ *
+ * This clears the existing value and sets it to Number with the given value.
+ *
+ * # Panic
+ *
+ * Panics if more than 1 reference exists to this [`RSValue`] object.
+ *
+ * # Safety
+ *
+ * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ * 2. `value` **must not** be used or freed after this call, as this function takes ownership.
+ *
+ * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void RSValue_SetNumber(struct RSValue *value, double n);
 
 /**
  * Converts an [`RSValue`] to a string type in-place, taking ownership of the given
@@ -489,168 +807,23 @@ bool RSValue_IsNumber(const struct RSValue *value);
 void RSValue_SetString(struct RSValue *value, char *str, uint32_t len);
 
 /**
- * Test whether an [`RSValue`] is "truthy".
+ * Returns a pointer to the string data of an [`RSValue`] and optionally writes the string
+ * length to `len_ptr`.
  *
- * Returns `true` for non-zero numbers, non-empty strings, and non-empty arrays.
- * All other variants (including [`Value::Null`] and [`Value::Map`])
- * evaluate to `false`. References are followed via
- * [`Value::fully_dereferenced_ref`].
+ * Unlike [`RSValue_String_Get`], this function handles all string variants (including
+ * `RedisString`) and automatically dereferences `Ref` values and follows through the left
+ * element of `Trio` values. Returns null for non-string variants.
  *
- * # Safety
- *
- * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-bool RSValue_BoolTest(const struct RSValue *value);
-
-/**
- * Borrows an immutable reference to the right value of a trio.
- *
- * # Panic
- *
- * Panics if the value is not a [`Value::Trio`].
+ * The returned pointer borrows from the [`RSValue`] and must not outlive it.
  *
  * # Safety
  *
  * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
+ * 2. `len_ptr` must be either null or a [valid], non-null pointer to a `size_t`.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-const struct RSValue *RSValue_Trio_GetRight(const struct RSValue *value);
-
-/**
- * Increments the reference count of `value` and returns a new owned pointer
- * to the same allocation.
- *
- * The caller must ensure the returned pointer is eventually passed to
- * [`RSValue_DecrRef`].
- *
- * # Safety
- *
- * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-struct RSValue *RSValue_IncrRef(const struct RSValue *value);
-
-/**
- * Returns whether the given [`RSValue`] is a string type (any string variant), or `false` if `value` is NULL.
- *
- * # Safety
- *
- * 1. `value` must be a [valid] pointer to an [`RSValue`], or null.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-bool RSValue_IsString(const struct RSValue *value);
-
-/**
- * Returns a pointer to the element at `index` in an array [`RSValue`].
- *
- * If `value` is not an array, returns a null pointer. The returned pointer
- * is borrowed from the array and must not be freed by the caller.
- *
- * # Safety
- *
- * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
- *
- * # Panics
- *
- * Panics if `index` greater than or equal to the array length.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-struct RSValue *RSValue_ArrayItem(const struct RSValue *value, uint32_t index);
-
-/**
- * Creates and returns a new [`RSValue`] of type [`Value::String`],
- * taking ownership of the given `RedisModule_Alloc`-allocated buffer.
- *
- * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
- * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
- * transferred through other `RSValue_` functions before that happens.
- *
- * # Safety
- *
- * 1. `str` must be a [valid], non-null pointer to a buffer of `len+1` bytes
- *    allocated by `RedisModule_Alloc`.
- * 2. A nul-terminator is expected in memory at `str+len`.
- * 3. The size determined by `len` excludes the nul-terminator.
- * 4. `str` **must not** be used or freed after this function is called, as this function
- *    takes ownership of the allocation.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-struct RSValue *RSValue_NewString(char *str, uint32_t len);
-
-/**
- * Returns the number of key-value pairs in a map [`RSValue`].
- *
- * # Safety
- *
- * 1. `map` must be a [valid], non-null pointer to an [`RSValue`].
- *
- * # Panics
- *
- * Panics if `map` is not a map value.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-uint32_t RSValue_Map_Len(const struct RSValue *map);
-
-/**
- * Returns whether the given [`RSValue`] is an array type, or `false` if `value` is NULL.
- *
- * # Safety
- *
- * 1. `value` must be a [valid] pointer to an [`RSValue`], or null.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-bool RSValue_IsArray(const struct RSValue *value);
-
-/**
- * Converts an [`RSValue`] to a string type in-place, borrowing the given string buffer
- * without taking ownership.
- *
- * This clears the existing value and sets it to a [`String`] of kind `Borrowed`
- * with the given buffer.
- *
- * # Panic
- *
- * Panics if more than 1 reference exists to this [`RSValue`] object.
- *
- * # Safety
- *
- * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
- * 2. `value` **must not** be used or freed after this call, as this function takes ownership.
- * 3. `str` must be a [valid], non-null pointer to a buffer of `len+1` bytes.
- * 4. A nul-terminator is expected in memory at `str+len`.
- * 5. The size determined by `len` excludes the nul-terminator.
- * 6. The memory pointed to by `str` must remain valid and not be mutated for the entire
- *    lifetime of the returned [`RSValue`] and any clones of it.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void RSValue_SetConstString(struct RSValue *value, const char *str, uint32_t len);
-
-/**
- * Replaces the content of `dst` with an [`Value::Ref`] pointing to `src`.
- *
- * `src`'s reference count is incremented; `dst`'s previous content is dropped.
- *
- * # Panic
- *
- * Panics if more than 1 reference exists to the `dst` [`RSValue`] object.
- *
- * # Safety
- *
- * 1. `dst` and `src` must be [valid], non-null pointers to [`RSValue`]s.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void RSValue_MakeReference(const struct RSValue *dst, const struct RSValue *src);
+const char *RSValue_StringPtrLen(const struct RSValue *value, size_t *len_ptr);
 
 /**
  * Returns a pointer to the string data of an [`RSValue`] and optionally writes the string
@@ -672,113 +845,40 @@ void RSValue_MakeReference(const struct RSValue *dst, const struct RSValue *src)
 const char *RSValue_String_Get(const struct RSValue *value, uint32_t *lenp);
 
 /**
- * Creates and returns a new [`RSValue`] of type [`Value::String`],
- * borrowing the given string buffer without taking ownership.
- *
- * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
- * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
- * transferred through other `RSValue_` functions before that happens.
- *
- * # Safety
- *
- * 1. `str` must be a [valid], non-null pointer to a buffer of `len+1` bytes.
- * 2. A nul-terminator is expected in memory at `str+len`.
- * 3. The size determined by `len` excludes the nul-terminator.
- * 4. The memory pointed to by `str` must remain valid and not be mutated for the entire
- *    lifetime of the returned [`RSValue`] and any clones of it.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-struct RSValue *RSValue_NewBorrowedString(const char *str, uint32_t len);
-
-/**
- * Returns whether the given [`RSValue`] is a trio type, or `false` if `value` is NULL.
+ * Convert the [`RSValue`] to a number. Returns `true` when this value is a number
+ * or a numeric string that can be converted and writes the number to `d`. If
+ * the value cannot be converted `false` is returned and nothing is written to `d`.
  *
  * # Safety
  *
  * 1. `value` must be a [valid] pointer to an [`RSValue`], or null.
+ * 2. `d` must be a [valid], non-null pointer to a `c_double`.
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-bool RSValue_IsTrio(const struct RSValue *value);
+bool RSValue_ToNumber(const struct RSValue *value, double *d);
 
 /**
- * Retrieves a key-value pair from a map [`RSValue`] at a specific index.
- *
- * The returned key and value pointers are borrowed from the map and must
- * not be freed by the caller.
- *
- * # Safety
- *
- * 1. `map` must be a [valid], non-null pointer to an [`RSValue`].
- * 2. `key` and `value` must be valid, non-null pointers to writable
- *    `*mut RSValue` locations.
- *
- * # Panics
- *
- * - Panics if `map` is not a map value.
- * - Panics if `index` is greater or equal to the map length.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void RSValue_Map_GetEntry(const struct RSValue *map, uint32_t index, struct RSValue * *key, struct RSValue * *value);
-
-/**
- * Like [`RSValue_MakeReference`], but **takes ownership** of `src` instead of
- * incrementing its reference count.
- *
- * After this call, `src` must not be used or freed by the caller.
+ * Borrows an immutable reference to the left value of a trio.
  *
  * # Panic
  *
- * Panics if more than 1 reference exists to the `dst` [`RSValue`] object.
+ * Panics if the value is not a [`Value::Trio`].
  *
  * # Safety
  *
- * 1. `dst` must be a [valid], non-null pointer to an [`RSValue`].
- * 2. `src` must be a [valid], non-null pointer to an [`RSValue`]. Ownership is transferred to `dst`.
+ * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-void RSValue_MakeOwnReference(const struct RSValue *dst, const struct RSValue *src);
+const struct RSValue *RSValue_Trio_GetLeft(const struct RSValue *value);
 
 /**
- * Returns whether the given [`RSValue`] is a null pointer, a null type, or a reference to a null type.
- *
- * # Safety
- *
- * 1. `value` must be a [valid] pointer to an [`RSValue`], or null.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-bool RSValue_IsNull(const struct RSValue *value);
-
-/**
- * Creates and returns a new [`RSValue`] of type [`Value::String`],
- * taking ownership of the given [`RedisModuleString`].
- *
- * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
- * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
- * transferred through other `RSValue_` functions before that happens.
- *
- * # Safety
- *
- * 1. `str` must be a [valid], non-null pointer to a [`RedisModuleString`].
- * 2. `str` **must not** be used or freed after this function is called, as this function
- *    takes ownership of the string.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-struct RSValue *RSValue_NewRedisString(struct RedisModuleString *str);
-
-/**
- * Returns a read only reference to the underlying [`RedisModuleString`] of an [`RSValue`].
- *
- * The returned reference borrows from the [`RSValue`] and must not outlive it.
+ * Borrows an immutable reference to the middle value of a trio.
  *
  * # Panic
  *
- * Panics if the value is not a [`Value::RedisString`].
+ * Panics if the value is not a [`Value::Trio`].
  *
  * # Safety
  *
@@ -786,64 +886,14 @@ struct RSValue *RSValue_NewRedisString(struct RedisModuleString *str);
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-const struct RedisModuleString *RSValue_RedisString_Get(const struct RSValue *value);
+const struct RSValue *RSValue_Trio_GetMiddle(const struct RSValue *value);
 
 /**
- * Replaces the pointer at `*dstpp` with a new clone of `src`.
+ * Borrows an immutable reference to the right value of a trio.
  *
- * The previous value at `*dstpp` is decremented (and potentially freed).
- * `src`'s reference count is incremented.
+ * # Panic
  *
- * # Safety
- *
- * 1. `dstpp` must be a [valid], non-null pointer to an `*mut RSValue`.
- * 2. `*dstpp` must be a [valid], non-null pointer to an [`RSValue`] (it will be consumed).
- * 3. `src` must be a [valid], non-null pointer to an [`RSValue`].
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-void RSValue_Replace(struct RSValue * *dstpp, const struct RSValue *src);
-
-/**
- * Creates and returns a new [`RSValue`] of type [`Value::String`],
- * copying `len` bytes from the given string buffer into a new Rust-allocated [`Box<CStr>`].
- *
- * The caller retains ownership of `str`.
- *
- * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
- * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
- * transferred through other `RSValue_` functions before that happens.
- *
- * # Safety
- *
- * 1. `str` must be a [valid], non-null pointer to a string buffer.
- * 2. `str` must be [valid] for reads of `len` bytes.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-struct RSValue *RSValue_NewCopiedString(const char *str, uint32_t len);
-
-/**
- * Returns a pointer to the string data of an [`RSValue`] and optionally writes the string
- * length to `len_ptr`.
- *
- * Unlike [`RSValue_String_Get`], this function handles all string variants (including
- * `RedisString`) and automatically dereferences `Ref` values and follows through the left
- * element of `Trio` values. Returns null for non-string variants.
- *
- * The returned pointer borrows from the [`RSValue`] and must not outlive it.
- *
- * # Safety
- *
- * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
- * 2. `len_ptr` must be either null or a [valid], non-null pointer to a `size_t`.
- *
- * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
- */
-const char *RSValue_StringPtrLen(const struct RSValue *value, size_t *len_ptr);
-
-/**
- * Returns the current reference count of `value`.
+ * Panics if the value is not a [`Value::Trio`].
  *
  * # Safety
  *
@@ -851,68 +901,18 @@ const char *RSValue_StringPtrLen(const struct RSValue *value, size_t *len_ptr);
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-uint16_t RSValue_Refcount(const struct RSValue *value);
+const struct RSValue *RSValue_Trio_GetRight(const struct RSValue *value);
 
 /**
- * Creates and returns a new [`RSValue`] of type [`Value::Number`] by parsing the given
- * string as a floating-point number. Returns a null pointer if the string
- * cannot be parsed.
- *
- * The caller retains ownership of `value`.
- *
- * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
- * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
- * transferred through other `RSValue_` functions before that happens.
+ * Returns the type of the given [`RSValue`].
  *
  * # Safety
  *
- * 1. `value` must be a [valid], non-null pointer to a string buffer.
- * 2. `value` must be [valid] for reads of `len` bytes.
+ * 1. `value` must be a [valid], non-null pointer to an [`RSValue`].
  *
  * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
-struct RSValue *RSValue_NewParsedNumber(const char *value, size_t len);
-
-/**
- * Creates and returns a new [`RSValue`] of type [`Value::Number`] from an `i64`.
- *
- * The `i64` is cast to `f64`, which may lose precision for values outside
- * the exact representable range of `f64`.
- *
- * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
- * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
- * transferred through other `RSValue_` functions before that happens.
- */
-struct RSValue *RSValue_NewNumberFromInt64(int64_t number);
-
-/**
- * Creates and returns a new [`RSValue`] of type [`Value::Ref`] that points to `src`.
- *
- * `src`'s reference count is incremented; the caller retains ownership of `src`.
- *
- * The returned [`RSValue`] is heap-allocated. The caller must ensure it is eventually
- * passed to [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef). Ownership may be
- * transferred through other `RSValue_` functions before that happens.
- *
- * # Safety
- *
- * 1. `src` must point to a valid [`RSValue`].
- */
-struct RSValue *RSValue_NewReference(const struct RSValue *src);
-
-/**
- * Returns a pointer to the static [`Value::Null`].
- *
- * Unlike [`RSValue_NewNull`], this does **not** heap-allocate; it returns a
- * pointer to a shared static value managed by [`SharedValue::null_static`].
- * The returned pointer must still be passed to
- * [`RSValue_DecrRef`](crate::shared::RSValue_DecrRef) for symmetry.
- *
- * # Safety
- *
- * The returned pointer must not be mutated.
- */
-struct RSValue *RSValue_NullStatic(void);
+enum RSValueType RSValue_Type(const struct RSValue *value);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/headers/varint_ffi.h
+++ b/src/redisearch_rs/headers/varint_ffi.h
@@ -65,11 +65,9 @@ uint32_t ReadVarint(BufferReader *b);
 t_fieldMask ReadVarintFieldMask(BufferReader *b);
 
 /**
- * Delta-encode an integer and write it into the vector.
+ * Free the memory allocated for the [`VectorWriter`].
  *
- * # Return value
- *
- * The varint's actual size, if the operation is successful. 0 in case of failure.
+ * After calling this function, the pointer is invalidated and should not be used.
  *
  * # Safety
  *
@@ -77,41 +75,7 @@ t_fieldMask ReadVarintFieldMask(BufferReader *b);
  * 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
  * 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
  */
-size_t VVW_Write(struct VarintVectorWriter *writer, uint32_t value);
-
-/**
- * Write a varint-encoded value into the given buffer writer.
- * It returns the number of bytes that have been added to the capacity of
- * the underlying buffer.
- *
- * # Panics
- *
- * Panics if the buffer can't grow its capacity to fit the encoded field value.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * 1. `writer` must point to a valid `BufferWriter` instance and cannot be NULL.
- * 2. The caller must have exclusive access to the buffer writer.
- */
-size_t WriteVarint(uint32_t value, BufferWriter *writer);
-
-/**
- * Write a varint-encoded field mask into the given buffer writer.
- * It returns the number of bytes that have been added to the capacity of
- * the underlying buffer.
- *
- * # Panics
- *
- * Panics if the buffer can't grow its capacity to fit the encoded field mask.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * 1. `writer` must point to a valid `BufferWriter` instance and cannot be NULL.
- * 2. The caller must have exclusive access to the buffer writer.
- */
-size_t WriteVarintFieldMask(t_fieldMask value, BufferWriter *writer);
+void VVW_Free(struct VarintVectorWriter *writer);
 
 /**
  * Get a reference to the underlying byte buffer.
@@ -160,17 +124,18 @@ size_t VVW_GetCount(const struct VarintVectorWriter *writer);
 void VVW_Reset(struct VarintVectorWriter *writer);
 
 /**
- * Free the memory allocated for the [`VectorWriter`].
- *
- * After calling this function, the pointer is invalidated and should not be used.
+ * Take ownership of the byte buffer stored in the vector.
+ * After this call, `len` will be set to the length of the byte buffer while `writer`
+ * will be left holding a fresh empty buffer.
  *
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
  * 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
  * 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
+ * 3. The caller must have exclusive access to `len`.
  */
-void VVW_Free(struct VarintVectorWriter *writer);
+uint8_t *VVW_TakeByteData(struct VarintVectorWriter *writer, size_t *len);
 
 /**
  * Resize the vector, dropping any excess capacity.
@@ -184,18 +149,53 @@ void VVW_Free(struct VarintVectorWriter *writer);
 size_t VVW_Truncate(struct VarintVectorWriter *writer);
 
 /**
- * Take ownership of the byte buffer stored in the vector.
- * After this call, `len` will be set to the length of the byte buffer while `writer`
- * will be left holding a fresh empty buffer.
+ * Delta-encode an integer and write it into the vector.
+ *
+ * # Return value
+ *
+ * The varint's actual size, if the operation is successful. 0 in case of failure.
  *
  * # Safety
  *
  * The following invariants must be upheld when calling this function:
  * 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`] and cannot be NULL.
  * 2. The caller must have exclusive access to the [`VectorWriter`] pointed to by `writer`.
- * 3. The caller must have exclusive access to `len`.
  */
-uint8_t *VVW_TakeByteData(struct VarintVectorWriter *writer, size_t *len);
+size_t VVW_Write(struct VarintVectorWriter *writer, uint32_t value);
+
+/**
+ * Write a varint-encoded value into the given buffer writer.
+ * It returns the number of bytes that have been added to the capacity of
+ * the underlying buffer.
+ *
+ * # Panics
+ *
+ * Panics if the buffer can't grow its capacity to fit the encoded field value.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * 1. `writer` must point to a valid `BufferWriter` instance and cannot be NULL.
+ * 2. The caller must have exclusive access to the buffer writer.
+ */
+size_t WriteVarint(uint32_t value, BufferWriter *writer);
+
+/**
+ * Write a varint-encoded field mask into the given buffer writer.
+ * It returns the number of bytes that have been added to the capacity of
+ * the underlying buffer.
+ *
+ * # Panics
+ *
+ * Panics if the buffer can't grow its capacity to fit the encoded field mask.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * 1. `writer` must point to a valid `BufferWriter` instance and cannot be NULL.
+ * 2. The caller must have exclusive access to the buffer writer.
+ */
+size_t WriteVarintFieldMask(t_fieldMask value, BufferWriter *writer);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: cheadergen emits declarations in `source_order`, which sorts by rustdoc span `(line, column)` without a file component. Declarations from multi-file crates interleave by line number, so any unrelated code movement (refactors, added functions, reformatting) reshuffles the generated headers, producing spurious diffs and "stale headers" CI failures with no semantic change.
2. Change: set `sort_by = "name"` in `src/redisearch_rs/cheadergen.toml` and regenerate the headers. Ordering becomes a pure function of the declaration names — stable under refactoring and machine-independent.
3. Outcome: 23 headers reordered; every changed file is a pure line reorder (verified by per-file sorted-line comparison), and a full build passes. Function, static, and constant declaration order carries no semantics in C. Type definitions are not covered by this option (cheadergen 0.3.1 hardcodes them to topologically-sorted source order), so typedef-order flips like #10788 remain possible until that is fixed upstream.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. `src/redisearch_rs/cheadergen.toml` — added top-level `sort_by = "name"`
2. `src/redisearch_rs/headers/*.h` — regenerated (pure reordering)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
