### PR TITLE
[MOD-16890] Fix stack-clash crash from unbounded field name in KNN query

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,24 @@ function(setup_cc_options)
         endif()
     endif()
 
+    # MOD-16890: harden against stack-clash attacks. Without this, the compiler
+    # emits a single `sub rsp, N` for large stack allocations (VLAs, big frames),
+    # which can jump over the guard page into an adjacent thread's stack. The flag
+    # forces page-by-page probing so any overflow hits the guard page and faults.
+    # Guarded because it is a GCC/Clang-on-Linux feature; Apple clang rejects it.
+    if(NOT APPLE)
+        include(CheckCCompilerFlag)
+        include(CheckCXXCompilerFlag)
+        check_c_compiler_flag("-fstack-clash-protection" _c_stack_clash_ok)
+        check_cxx_compiler_flag("-fstack-clash-protection" _cxx_stack_clash_ok)
+        if(_c_stack_clash_ok)
+            set(_common_c_flags "${_common_c_flags} -fstack-clash-protection")
+        endif()
+        if(_cxx_stack_clash_ok)
+            set(_common_cxx_flags "${_common_cxx_flags} -fstack-clash-protection")
+        endif()
+    endif()
+
     set(CMAKE_C_FLAGS   "${_common_c_flags}"   PARENT_SCOPE)
     set(CMAKE_CXX_FLAGS "${_common_cxx_flags}" PARENT_SCOPE)
 

--- a/src/query.c
+++ b/src/query.c
@@ -820,10 +820,14 @@ static QueryIterator *Query_EvalVectorNode(QueryEvalCtx *q, QueryNode *qn,
       // ...=>[KNN ...]=>{$YIELD_DISTANCE_AS:<dist_field>), we validate that we got it only once.
       size_t len;
       const char *fieldName = HiddenString_GetUnsafe(qn->vn.vq->field->fieldName, &len);
-      char default_score_field[len + 9];  // buffer for __<field>_score
-      sprintf(default_score_field, "__%s_score", fieldName);
+      // Build the default score field name on the heap. The field name length is
+      // attacker-controlled (no cap at FT.CREATE), so a stack VLA here would be a
+      // stack-clash primitive on the worker thread stack (MOD-16890).
+      char *default_score_field = VectorQuery_GetDefaultScoreFieldName(fieldName, len);
       // If the saved score field is NOT the default one, we return an error, otherwise, just override it.
-      if (strcasecmp(qn->vn.vq->scoreField, default_score_field) != 0) {
+      int isDefault = strcasecmp(qn->vn.vq->scoreField, default_score_field) == 0;
+      rm_free(default_score_field);
+      if (!isDefault) {
         QueryError_SetWithUserDataFmt(q->status, QUERY_ERROR_CODE_DUP_FIELD,
                                "Distance field was specified twice for vector query", ": %s and %s",
                                qn->vn.vq->scoreField, qn->opts.distField);

--- a/src/spec.c
+++ b/src/spec.c
@@ -1394,6 +1394,20 @@ static bool validateFieldNameAndPath(const char *fieldName, size_t namelen, cons
     QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "Field name cannot be empty");
     return false;
   }
+  // Cap the name/path length. An uncapped field name flows into stack buffers on the
+  // query path and is a stack-clash/DoS vector (MOD-16890).
+  if (namelen > SPEC_MAX_FIELD_NAME_LEN) {
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL,
+                                     "Field name is too long (max %d bytes)",
+                                     SPEC_MAX_FIELD_NAME_LEN);
+    return false;
+  }
+  if (fieldPath && pathlen > SPEC_MAX_FIELD_NAME_LEN) {
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL,
+                                     "Field path is too long (max %d bytes)",
+                                     SPEC_MAX_FIELD_NAME_LEN);
+    return false;
+  }
   if (memchr(fieldName, '\0', namelen) != NULL) {
     QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "Field name cannot contain null bytes");
     return false;

--- a/src/spec.h
+++ b/src/spec.h
@@ -118,6 +118,11 @@ struct IndexesScanner;
 
 #define SPEC_MAX_FIELDS 1024
 #define SPEC_MAX_FIELD_ID (sizeof(t_fieldMask) * 8)
+// Upper bound on a field name/path length (bytes) accepted by FT.CREATE / FT.ALTER.
+// Field names flow into stack buffers on the query path (e.g. the KNN score-field
+// name), so an uncapped length is a stack-clash/DoS vector (MOD-16890). 1024 bytes
+// is far beyond any legitimate schema field name or JSONPath.
+#define SPEC_MAX_FIELD_NAME_LEN 1024
 #define MAX_SYNONYM_TERMS 1000000     // reasonable limit for synonym map terms
 #define MAX_SYNONYM_GROUP_IDS 4096    // reasonable limit for group IDs per term
 

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -350,16 +350,22 @@ int Suffix_IterateWildcard(SuffixCtx *sufCtx) {
   if (sufCtx->cstrlen == 0) {
     return 0;
   }
-  size_t idx[sufCtx->cstrlen];
-  size_t lens[sufCtx->cstrlen];
+  // The pattern length is attacker-controlled, so allocate the per-token arrays on
+  // the heap rather than as stack VLAs to avoid a stack-clash overflow (MOD-16890).
+  size_t *idx = rm_malloc(sizeof(*idx) * sufCtx->cstrlen);
+  size_t *lens = rm_malloc(sizeof(*lens) * sufCtx->cstrlen);
   int useIdx = Suffix_ChooseToken_rune(sufCtx->rune, sufCtx->runelen, idx, lens);
 
   if (useIdx == REDISEARCH_UNINITIALIZED) {
+    rm_free(idx);
+    rm_free(lens);
     return 0;
   }
 
   rune *token = sufCtx->rune + idx[useIdx];
   size_t toklen = lens[useIdx];
+  rm_free(idx);
+  rm_free(lens);
   if (token[toklen] == (rune)'*') {
     toklen++;
   }
@@ -512,16 +518,22 @@ arrayof(char*) GetList_SuffixTrieMap_Wildcard(TrieMap *trie, const char *pattern
   if (len == 0) {
     return BAD_POINTER;
   }
-  size_t idx[len];
-  size_t lens[len];
+  // The pattern length is attacker-controlled, so allocate the per-token arrays on
+  // the heap rather than as stack VLAs to avoid a stack-clash overflow (MOD-16890).
+  size_t *idx = rm_malloc(sizeof(*idx) * len);
+  size_t *lens = rm_malloc(sizeof(*lens) * len);
   // find best token
   int useIdx = Suffix_ChooseToken(pattern, len, idx, lens);
   if (useIdx == REDISEARCH_UNINITIALIZED) {
+    rm_free(idx);
+    rm_free(lens);
     return BAD_POINTER;
   }
 
   size_t tokenidx = idx[useIdx];
   size_t tokenlen = lens[useIdx];
+  rm_free(idx);
+  rm_free(lens);
   // if token end with '*', we iterate all its children
   int prefix = pattern[tokenidx + tokenlen] == '*';
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2312,6 +2312,39 @@ def testHashFieldPathWithNullByteRejected(env):
     with env.assertResponseError(contained='Field path cannot contain null bytes'):
         conn.execute_command('FT.CREATE', 'idx_path_nul_embedded', 'SCHEMA', b'real\x00tail', 'AS', 'tag', 'TAG')
 
+def testOverlongFieldNameRejected(env):
+    # A field name whose length is unbounded flows into stack buffers on the query
+    # path (e.g. the KNN default score-field name) and was a stack-clash/DoS vector
+    # (MOD-16890). FT.CREATE / FT.ALTER must reject names past SPEC_MAX_FIELD_NAME_LEN
+    # (1024 bytes) instead of accepting them and crashing later.
+    long_name = 'v' * (1024 + 1)
+    # Plain field name.
+    env.expect('FT.CREATE', 'idx_long_name', 'SCHEMA', long_name, 'TAG') \
+        .error().contains('Field name is too long')
+    # Name supplied via an explicit AS alias.
+    env.expect('FT.CREATE', 'idx_long_alias', 'SCHEMA', 'p', 'AS', long_name, 'TAG') \
+        .error().contains('Field name is too long')
+    # Path (the schema token before AS) is capped as well.
+    env.expect('FT.CREATE', 'idx_long_path', 'SCHEMA', long_name, 'AS', 'p', 'TAG') \
+        .error().contains('Field path is too long')
+    # Added via FT.ALTER.
+    env.cmd('FT.CREATE', 'idx_long_alter', 'SCHEMA', 't', 'TAG')
+    env.expect('FT.ALTER', 'idx_long_alter', 'SCHEMA', 'ADD', long_name, 'TAG') \
+        .error().contains('Field name is too long')
+    # A name at exactly the limit is still accepted.
+    env.cmd('FT.CREATE', 'idx_max_name', 'SCHEMA', 'v' * 1024, 'TAG')
+
+def testOverlongVectorFieldNameNoStackClash(env):
+    # Regression for MOD-16890: the KNN duplicate-distance-field validation used to
+    # build the default score-field name in a stack VLA sized by the vector field
+    # name. Combined with the missing FT.CREATE length cap, a long name let the VLA
+    # jump the guard page. The name cap now rejects the FT.CREATE up front; the query
+    # path also builds the name on the heap. This must fail cleanly, never crash.
+    long_name = 'v' * (1024 + 1)
+    env.expect('FT.CREATE', 'idx_clash', 'SCHEMA', long_name,
+               'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2') \
+        .error().contains('Field name is too long')
+
 @skip(no_json=True)
 def testJsonFieldPathWithNullByteRejected(env):
     conn = env.getClusterConnectionIfNeeded()

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -351,6 +351,31 @@ def testContainsMixedWithSuffix(env):
     .contains('Contains query on fields without WITHSUFFIXTRIE support')
 
 @skip(cluster=True)
+@skip(cluster=True)
+def testLongWildcardTagPatternNoStackClash(env):
+  # Regression for MOD-16890: the TAG suffix-wildcard path allocated two arrays
+  # (idx/lens) as stack VLAs sized by the query pattern length. Because each byte
+  # of the pattern costs 16 bytes of stack, a ~512 KB pattern overflowed the 8 MB
+  # worker-thread stack, jumping the guard page (a stack-clash primitive). The
+  # arrays are now heap-allocated. A large pattern must be handled cleanly (empty
+  # result or error), and the server must stay up.
+  conn = getConnectionByEnv(env)
+  conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG', 'WITHSUFFIXTRIE')
+  conn.execute_command('HSET', 'doc1', 't', 'hello')
+  waitForIndex(env, 'idx')
+
+  # ~600 KB contains pattern: 16 * 600000 bytes would have overflowed the old VLA.
+  pattern = '*' + ('a' * 600000) + '*'
+  try:
+    conn.execute_command('FT.SEARCH', 'idx', '@t:{%s}' % pattern, 'NOCONTENT')
+  except Exception:
+    # A clean error (e.g. query too long) is acceptable; a crash is not.
+    pass
+
+  # Server survived: a normal query still works.
+  env.assertEqual(conn.execute_command('FT.SEARCH', 'idx', '@t:{*ell*}', 'NOCONTENT'),
+                  [1, 'doc1'])
+
 def testSuffixTrieIncludesShortTagValue(env):
   # A 1-char tag value is stored in the suffix triemap and removed cleanly
   # after the document is deleted and the GC runs.


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** Field names in `FT.CREATE`/`FT.ALTER` have no length cap. On a KNN query that specifies the distance field twice (`AS` + `YIELD_DISTANCE_AS`), the validation code built the default score-field name in a **stack VLA sized by the field name length** (`query.c`). An attacker could create a multi-megabyte field name and, on the search worker thread (8 MB stack, 4 KB guard page), the `sub rsp, N` jumped the guard page into an adjacent thread's stack — a stack-clash primitive (same class as CVE-2017-1000364), a guaranteed SIGSEGV. The TAG suffix-wildcard query path had the same VLA pattern sized by the query pattern length (16 bytes/char → a ~512 KB pattern overflows the stack). The module was also compiled without `-fstack-clash-protection`.
2. **Change:** Cap field name/path length at the source; remove the attacker-sized stack VLAs; harden the whole binary with the compiler mitigation.
3. **Outcome:** `FT.CREATE`/`FT.ALTER` reject over-long names with a clean error; the query paths allocate on the heap; and any remaining large stack allocation faults on the guard page instead of clobbering an adjacent stack.

#### Which additional issues this PR fixes
1. MOD-16890
2. HackerOne report 3658537

#### Main objects this PR modified
1. `src/spec.c` / `src/spec.h` — cap name & path at `SPEC_MAX_FIELD_NAME_LEN` (1024 bytes) in `validateFieldNameAndPath`.
2. `src/query.c` — `Query_EvalVectorNode`: build the default score-field name via `VectorQuery_GetDefaultScoreFieldName` (heap) instead of a stack VLA.
3. `src/suffix.c` — `Suffix_IterateWildcard` / `GetList_SuffixTrieMap_Wildcard`: heap-allocate the per-token `idx`/`lens` arrays.
4. `CMakeLists.txt` — compile with `-fstack-clash-protection` (guarded via `check_c_compiler_flag`, non-Apple).
5. Tests: `test.py` (length cap) and `test_contains.py` (long-pattern no-crash).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: fixes a remotely-triggerable server crash (DoS) reachable by any client with default `@read`/`@write` ACLs, via a long VECTOR/TAG field name in a search index. Field names and paths are now limited to 1024 bytes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
