### PR TITLE
Stop a periodic RDB save from silently skipping the forced GC in test_indexes_logically_deleted_docs

### DIFF
--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -665,6 +665,12 @@ def test_indexes_logically_deleted_docs(env):
   # is > 8h (5 minutes is the hard limit for a test).
   env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0').ok()
   env.expect(config_cmd(), 'SET', 'FORK_GC_RUN_INTERVAL', '30000').ok()
+
+  # Redis refuses a module fork while it still has an unreaped child, and a forced GC cycle that
+  # cannot fork collects nothing while GC_FORCEINVOKE still replies DONE. Disable the periodic save
+  # so no bgsave child can race the forced cycle at the end of this test.
+  env.expect('CONFIG', 'SET', 'save', '').ok()
+
   set_doc = lambda doc_id: env.expect('HSET', doc_id, 'text', 'some text', 'tag', 'tag1', 'num', 1)
   get_logically_deleted_docs = lambda: env.cmd('INFO', 'MODULES')['search_gc_total_docs_not_collected']
 


### PR DESCRIPTION
## Describe the changes in the pull request

`test_info_modules:test_indexes_logically_deleted_docs` fails intermittently in CI on its last
assertion:

```
❌ (FAIL):	1 == 0	test_info_modules.py:706
```

**1. Current.** The test forces a GC cycle and asserts the one logically-deleted doc left in `idx2`
is then collected:

```python
forceInvokeGC(env, idx='idx2')
env.assertEqual(get_logically_deleted_docs(), 0)
```

In the observed failure the forced cycle never ran. From the server log of the failing test, in the
6ms around the forced GC:

```
41.052  Killing running module fork child: 24327      <- previous (idx1) GC child
41.052  GC 0x...140: Self-Terminating. Index was freed.
41.054  1 changes in 3600 seconds. Saving...          <- periodic save policy fires
41.055  Background saving started by pid 24330
41.058  ForkGC - used memory ratio: 0.000000          <- forced GC on idx2 starts
41.058  Can't fork for module: File exists
41.058  fork failed - got errno 17, aborting fork GC  <- EEXIST
```

`RedisModule_Fork` refuses to fork while Redis still has an unreaped child, and a child counts as
active from `fork(2)` until Redis reaps it in `serverCron` — after the RDB has been written. On that
path `FGC_RunCycle` returns before it captures `deletedOrUpdatedDocsFromLastRun`, so
`search_gc_total_docs_not_collected` keeps its value, and `GC_FORCEINVOKE` still replies `DONE`.
Nothing retries.

The test's existing guard cannot cover this: `forceInvokeGC` calls `waitForRdbSaveToFinish`, which
only waits for a save already in progress. Here the save policy fired *after* that poll.

This reproduces deterministically by holding a child open with `rdb-key-save-delay`:

```
== force GC while an RDB child is alive ==
  rdb_bgsave_in_progress:1
  GC_FORCEINVOKE reply: DONE
  after forced GC: search_gc_total_docs_not_collected:1     <- nothing collected
    # Can't fork for module: File exists
    # <search> fork failed - got errno 17, aborting fork GC

== force GC again once the child is reaped ==
  GC_FORCEINVOKE reply: DONE
  after forced GC: search_gc_total_docs_not_collected:0
```

**2. Change.** Disable the periodic save policy in this test, so the forced cycle at the end cannot
race a bgsave child. This is the same reason — and the same one-line remedy — as
`test_async.py:test_yield_while_bg_indexing_mod4745`, which disables it so a bgsave fork cannot race
the key load.

**3. Outcome.** The test no longer depends on where in its brief runtime the save policy happens to
fire. It is worth knowing how narrow that window is: across the 1851 standalone server logs of the CI
run this failure came from, 135 hit the periodic save, and in 2 of those it collided with a GC fork —
this test, and `test_gc:testTagGC`, which survived only because it forces GC repeatedly.

Not explained here, and not something the fix depends on: the `save 3600 1` rule matches ~110ms into
a freshly started server, so `lastsave` is evidently not being set to the start time on this build.
Whatever the reason, the periodic save has nothing to do for a test server, and this test should not
be sensitive to it.

#### Which additional issues this PR fixes
1. MOD-...: none
2. #...: none

#### Main objects this PR modified
1. `tests/pytests/test_info_modules.py` — `test_indexes_logically_deleted_docs`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

## Follow-up, not fixed here

The underlying hook is still able to lie: `FT.DEBUG GC_FORCEINVOKE` replies `DONE` when
`FGC_RunCycle` aborted without forking, so *any* test relying on a forced cycle can silently get
nothing. Making a forced cycle retry when the fork is refused would fix the class rather than this
instance, but it has to release the GIL while waiting for Redis to reap the blocking child, so it
belongs in its own change rather than in a test fix.

## Testing

```
MODULE=<redisearch.so> REDIS_STANDALONE=1 REJSON=0 \
  TEST=test_info_modules.py:test_indexes_logically_deleted_docs tests/pytests/runtests.sh
```

Passes, and no server log from those runs contains `changes in 3600 seconds. Saving...`.
