### PR TITLE
[CI] Follow released Redis versions

### DIFF
--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -31,11 +31,8 @@ on:
         description: "Branch to use as the comparison baseline. Empty falls back to the PR base branch."
       redis_ref:
         type: string
-        # TEMPORARY default, reset to "" once Redis 8.10 is GA and becomes the
-        # DB hosts' default: pinned to the same redis/redis commit the test CI
-        # uses (get-latest-redis-tag in event-pull_request.yml /
-        # event-merge-to-queue.yml) — keep in sync.
-        default: "3869512c920d4e865b54384bce5fcb6a4e06ae0d"
+        # Keep benchmarks independent of the Redis version preinstalled on the DB hosts.
+        default: "8.10.0"
         description: "redis/redis git ref (sha/branch/tag) to build and run the benchmarks against, instead of the redis preinstalled on the DB hosts. Empty uses the preinstalled default."
   workflow_call:
     inputs:
@@ -59,11 +56,8 @@ on:
         description: "Branch to use as the comparison baseline. Empty falls back to the PR base branch."
       redis_ref:
         type: string
-        # TEMPORARY default, reset to "" once Redis 8.10 is GA and becomes the
-        # DB hosts' default: pinned to the same redis/redis commit the test CI
-        # uses (get-latest-redis-tag in event-pull_request.yml /
-        # event-merge-to-queue.yml) — keep in sync.
-        default: "3869512c920d4e865b54384bce5fcb6a4e06ae0d"
+        # Keep benchmarks independent of the Redis version preinstalled on the DB hosts.
+        default: "8.10.0"
         description: "redis/redis git ref (sha/branch/tag) to build and run the benchmarks against, instead of the redis preinstalled on the DB hosts. Empty uses the preinstalled default."
 
 jobs:

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -18,20 +18,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # TODO: revert to calling task-get-latest-tag.yml once Redis 8.10 is released.
-  # Pinned to a redis/redis unstable commit (the redis/redis#15350 merge) because the module
-  # requires RedisModule_GetClusterNodeSlotRanges (MOD-15868) and
-  # RedisModuleEvent_ClusterTopologyChange (MOD-15870), neither of which is in any Redis release yet.
   get-latest-redis-tag:
-    permissions: {} # echoes a pinned SHA
-    # uses: ./.github/workflows/task-get-latest-tag.yml
-    # with:
-    #   repo: redis/redis
-    runs-on: ubuntu-slim
-    outputs:
-      tag: 8897348030c20bcd26841bc7d3ec7227f8187aeb
-    steps:
-      - run: echo "Using pinned redis/redis unstable commit instead of the latest release tag"
+    permissions: {}
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
 
   lint:
     permissions:

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -156,22 +156,13 @@ jobs:
         run: |
           echo "Covered PRs: ${{ steps.check.outputs.covered-prs }}"
 
-  # TODO: revert to calling task-get-latest-tag.yml once Redis 8.10 is released.
-  # Pinned to a redis/redis unstable commit (the redis/redis#15350 merge) because the module
-  # requires RedisModule_GetClusterNodeSlotRanges (MOD-15868) and
-  # RedisModuleEvent_ClusterTopologyChange (MOD-15870), neither of which is in any Redis release yet.
   get-latest-redis-tag:
-    permissions: {} # echoes a pinned SHA
+    permissions: {}
     needs: should-run
     if: ${{ needs.should-run.outputs.run-validation == 'true' }}
-    # uses: ./.github/workflows/task-get-latest-tag.yml
-    # with:
-    #   repo: redis/redis
-    runs-on: ubuntu-slim
-    outputs:
-      tag: 8897348030c20bcd26841bc7d3ec7227f8187aeb
-    steps:
-      - run: echo "Using pinned redis/redis unstable commit instead of the latest release tag"
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
 
   test-selected-platforms:
     needs: [should-run, get-latest-redis-tag]

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -21,20 +21,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # TODO: revert to calling task-get-latest-tag.yml once Redis 8.10 is released.
-  # Pinned to a redis/redis unstable commit (the redis/redis#15350 merge) because the module
-  # requires RedisModule_GetClusterNodeSlotRanges (MOD-15868) and
-  # RedisModuleEvent_ClusterTopologyChange (MOD-15870), neither of which is in any Redis release yet.
   get-latest-redis-tag:
-    permissions: {} # echoes a pinned SHA
-    # uses: ./.github/workflows/task-get-latest-tag.yml
-    # with:
-    #   repo: redis/redis
-    runs-on: ubuntu-slim
-    outputs:
-      tag: 8897348030c20bcd26841bc7d3ec7227f8187aeb
-    steps:
-      - run: echo "Using pinned redis/redis unstable commit instead of the latest release tag"
+    permissions: {}
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
 
   check-what-changed:
     permissions: # actions/checkout

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -54,7 +54,6 @@ on:
 
 jobs:
   get-latest-redis-tag:
-    permissions: {}
     uses: ./.github/workflows/task-get-latest-tag.yml
     with:
       repo: redis/redis

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -53,14 +53,21 @@ on:
         default: false
 
 jobs:
+  get-latest-redis-tag:
+    permissions: {}
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+
   setup:
+    needs: [get-latest-redis-tag]
     permissions: # actions/checkout
       contents: read
     # Sets SHA and Validates the reference Input (branch or tag)
     runs-on: ubuntu-slim
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
-      redis-ref: ${{ steps.get-redis.outputs.tag }}
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       # beta-version not used for OSS builds by default
       beta-version: ${{ inputs.force_beta && steps.beta-version.outputs.BETA_VERSION || '' }}
       version-suffix: ${{ steps.beta-version.outputs.VERSION_SUFFIX }}
@@ -68,12 +75,6 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-      - id: get-redis
-        shell: bash -l -eo pipefail {0}
-        run: |
-          # TAG=$(curl -sL --retry 5 https://api.github.com/repos/redis/redis/releases/latest | jq -er '.tag_name') && \
-          # echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "tag=8897348030c20bcd26841bc7d3ec7227f8187aeb" >> $GITHUB_OUTPUT
       - name: Generate Beta Version unique identifier
         id: beta-version
         # Expanded through env rather than into the script body: a ref name is

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -87,7 +87,7 @@ on:
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable", or a commit sha)'
         type: string
-        default: 8897348030c20bcd26841bc7d3ec7227f8187aeb
+        default: '8.10.0'
       rejson-branch:
         type: string
         default: master

--- a/.github/workflows/task-build.yml
+++ b/.github/workflows/task-build.yml
@@ -26,7 +26,7 @@ on:
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable")'
         type: string
-        default: 3cd464263b03b425ffae2e23db24df3dc9346871
+        default: '8.10.0'
       artifact-name:
         description: 'Name of the workflow artifact uploaded with the contents of bin/.'
         type: string
@@ -366,4 +366,3 @@ jobs:
             redis-install.tar.gz
           if-no-files-found: error
           retention-days: 1
-

--- a/.github/workflows/task-test-flow.yml
+++ b/.github/workflows/task-test-flow.yml
@@ -26,7 +26,7 @@ on:
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable")'
         type: string
-        default: 3cd464263b03b425ffae2e23db24df3dc9346871
+        default: '8.10.0'
       test-config:
         description: 'Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")'
         required: true

--- a/.github/workflows/task-test-unit.yml
+++ b/.github/workflows/task-test-unit.yml
@@ -27,7 +27,7 @@ on:
       redis-ref:
         description: 'Redis version to use (only consumed by setup steps that key caches on it).'
         type: string
-        default: 3cd464263b03b425ffae2e23db24df3dc9346871
+        default: '8.10.0'
       test-timeout:
         type: number
         default: 120
@@ -367,4 +367,3 @@ jobs:
           flags: unit
           fail_ci_if_error: ${{ env.IS_FORK_PR != 'true' }}
           token: ${{ secrets.CODECOV_TOKEN }}
-

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -21,7 +21,7 @@ on:
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable")'
         type: string
-        default: 8897348030c20bcd26841bc7d3ec7227f8187aeb
+        default: '8.10.0'
       test-config:
         description: 'Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")'
         required: true

--- a/pack/ramp-community.yml
+++ b/pack/ramp-community.yml
@@ -7,7 +7,7 @@ homepage: http://redisearch.io
 license:  Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
 compatible_redis_version: "99.99"
-min_redis_version: "8.9"
+min_redis_version: "8.10"
 min_redis_pack_version: "8.0"
 config_command: "_FT.CONFIG SET"
 capabilities:

--- a/pack/ramp-enterprise.yml
+++ b/pack/ramp-enterprise.yml
@@ -7,9 +7,8 @@ homepage: 'http://redisearch.io'
 license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
 compatible_redis_version: "99.99"
-# Minimal Redis (engine) version. 8.9 is the 8.10 pre-release line, the first with
-# RedisModule_GetClusterNodeSlotRanges (MOD-15868). TODO: set to "8.10" once released.
-min_redis_version: "8.9"
+# Minimal Redis (engine) version with RedisModule_GetClusterNodeSlotRanges.
+min_redis_version: "8.10"
 # Minimal Redis Enterprise (cluster) version - independent of the engine version above.
 min_redis_pack_version: "8.0"
 config_command: "_FT.CONFIG SET"


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Regular CI is pinned to a pre-release Redis commit even though Redis 8.10 is released. Benchmarks also use a raw Redis SHA.
2. Change: Restore latest Redis release discovery for PR, merge-queue, and periodic CI; pin benchmarks to the `8.10.0` tag; update package metadata from the temporary 8.9 development baseline to Redis 8.10.
3. Outcome: CI automatically follows the latest stable Redis release while nightly continues covering `unstable`, and benchmarks run against an explicit compatible Redis release.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. Redis selection in PR, merge-queue, periodic, and benchmark workflows
2. Community and enterprise package Redis compatibility metadata

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

