### PR TITLE
[CI] Follow Redis 8.10 releases on 8.8-rse

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -14,18 +14,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # TODO: revert to calling task-get-latest-tag.yml once Redis 8.10 is released.
-  # Pinned to a redis/redis unstable commit because the module requires
-  # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any Redis release yet.
   get-latest-redis-tag:
-    # uses: ./.github/workflows/task-get-latest-tag.yml
-    # with:
-    #   repo: redis/redis
-    runs-on: ubuntu-slim
-    outputs:
-      tag: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
-    steps:
-      - run: echo "Using pinned redis/redis unstable commit instead of the latest release tag"
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.10'
 
   lint:
     permissions:

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -149,20 +149,13 @@ jobs:
         run: |
           echo "Covered PRs: ${{ steps.check.outputs.covered-prs }}"
 
-  # TODO: revert to calling task-get-latest-tag.yml once Redis 8.10 is released.
-  # Pinned to a redis/redis unstable commit because the module requires
-  # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any Redis release yet.
   get-latest-redis-tag:
     needs: should-run
     if: ${{ needs.should-run.outputs.run-validation == 'true' }}
-    # uses: ./.github/workflows/task-get-latest-tag.yml
-    # with:
-    #   repo: redis/redis
-    runs-on: ubuntu-slim
-    outputs:
-      tag: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
-    steps:
-      - run: echo "Using pinned redis/redis unstable commit instead of the latest release tag"
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.10'
 
   test-selected-platforms:
     needs: [should-run, get-latest-redis-tag]

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -11,18 +11,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # TODO: revert to calling task-get-latest-tag.yml once Redis 8.10 is released.
-  # Pinned to a redis/redis unstable commit because the module requires
-  # RedisModule_GetClusterNodeSlotRanges (MOD-15868), which is not in any Redis release yet.
   get-latest-redis-tag:
-    # uses: ./.github/workflows/task-get-latest-tag.yml
-    # with:
-    #   repo: redis/redis
-    runs-on: ubuntu-slim
-    outputs:
-      tag: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
-    steps:
-      - run: echo "Using pinned redis/redis unstable commit instead of the latest release tag"
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.10'
 
   check-what-changed:
     uses: ./.github/workflows/task-check-changes.yml

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -49,12 +49,19 @@ on:
         default: false
 
 jobs:
+  get-latest-redis-tag:
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.10'
+
   setup:
+    needs: [get-latest-redis-tag]
     # Sets SHA and Validates the reference Input (branch or tag)
     runs-on: ubuntu-slim
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
-      redis-ref: ${{ steps.get-redis.outputs.tag }}
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       # beta-version not used for OSS builds by default
       beta-version: ${{ inputs.force_beta && steps.beta-version.outputs.BETA_VERSION || '' }}
       version-suffix: ${{ steps.beta-version.outputs.VERSION_SUFFIX }}
@@ -62,12 +69,6 @@ jobs:
       - uses: actions/checkout@v6
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-      - id: get-redis
-        shell: bash -l -eo pipefail {0}
-        run: |
-          # TAG=$(curl -sL --retry 5 https://api.github.com/repos/redis/redis/releases/latest | jq -er '.tag_name') && \
-          # echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "tag=3869512c920d4e865b54384bce5fcb6a4e06ae0d" >> $GITHUB_OUTPUT
       - name: Generate Beta Version unique identifier
         id: beta-version
         run: |

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -83,7 +83,7 @@ on:
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable", or a commit sha)'
         type: string
-        default: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
+        default: '8.10.0'
       rejson-branch:
         type: string
         default: master

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -21,7 +21,7 @@ on:
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable")'
         type: string
-        default: 3869512c920d4e865b54384bce5fcb6a4e06ae0d
+        default: '8.10.0'
       test-config:
         description: 'Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")'
         required: true

--- a/pack/ramp-community.yml
+++ b/pack/ramp-community.yml
@@ -7,7 +7,7 @@ homepage: http://redisearch.io
 license:  Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
 compatible_redis_version: "99.99"
-min_redis_version: "8.9"
+min_redis_version: "8.10"
 min_redis_pack_version: "8.0"
 config_command: "_FT.CONFIG SET"
 capabilities:

--- a/pack/ramp-enterprise.yml
+++ b/pack/ramp-enterprise.yml
@@ -7,9 +7,8 @@ homepage: 'http://redisearch.io'
 license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
 compatible_redis_version: "99.99"
-# Minimal Redis (engine) version. 8.9 is the 8.10 pre-release line, the first with
-# RedisModule_GetClusterNodeSlotRanges (MOD-15868). TODO: set to "8.10" once released.
-min_redis_version: "8.9"
+# Minimal Redis (engine) version with RedisModule_GetClusterNodeSlotRanges.
+min_redis_version: "8.10"
 # Minimal Redis Enterprise (cluster) version - independent of the engine version above.
 min_redis_pack_version: "8.0"
 config_command: "_FT.CONFIG SET"


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: CI on the 8.8-rse branch is pinned to a Redis 8.10 development commit required by its module API usage.
2. Change: Discover the latest Redis 8.10 release in PR, merge-queue, and periodic CI, while retaining nightly `unstable` coverage; update package metadata from the temporary 8.9 development baseline to Redis 8.10.
3. Outcome: The branch keeps its required Redis 8.10 API baseline and automatically receives Redis 8.10 patch releases without following arbitrary unstable commits in regular CI.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. Redis selection in PR, merge-queue, and periodic workflows
2. Community and enterprise package Redis compatibility metadata

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

