### PR TITLE
[CI] Follow Redis 8.8 releases

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -15,15 +15,10 @@ concurrency:
 
 jobs:
   get-latest-redis-tag:
-    # TODO: Switch to the latest 8.8 release/pre-release line once it is ready.
-    runs-on: ubuntu-slim
-    outputs:
-      tag: 3cd464263b03b425ffae2e23db24df3dc9346871
-    steps:
-      - run: echo "Dummy step to set output"
-    # uses: ./.github/workflows/task-get-latest-tag.yml
-    # with:
-    #   repo: redis/redis
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.8'
 
   lint:
     permissions:

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -10,6 +10,12 @@ on:
 # TODO: Use RedisJSON's `master` branch when testing on nightly
 
 jobs:
+  get-latest-redis-tag:
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.8'
+
   lint:
     permissions:
       contents: read
@@ -20,6 +26,7 @@ jobs:
     secrets: inherit
 
   test-all-platforms:
+    needs: [get-latest-redis-tag]
     permissions:
       contents: read
       packages: write
@@ -32,7 +39,7 @@ jobs:
       # problem is mitigated; macOS ARM still runs.
       platform: all,!macos-14~x86_64,!macos-15~x86_64,!macos-26~x86_64
       architecture: all
-      redis-ref: 3cd464263b03b425ffae2e23db24df3dc9346871
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,sanitize' }}
 

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -12,12 +12,10 @@ concurrency:
 
 jobs:
   get-latest-redis-tag:
-    # TODO: Switch to the latest 8.8 release/pre-release line once it is ready.
-    runs-on: ubuntu-slim
-    outputs:
-      tag: 3cd464263b03b425ffae2e23db24df3dc9346871
-    steps:
-      - run: echo "Dummy step to set output"
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.8'
 
   check-what-changed:
     uses: ./.github/workflows/task-check-changes.yml

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -49,12 +49,19 @@ on:
         default: false
 
 jobs:
+  get-latest-redis-tag:
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '8.8'
+
   setup:
+    needs: [get-latest-redis-tag]
     # Sets SHA and Validates the reference Input (branch or tag)
     runs-on: ubuntu-slim
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
-      redis-ref: ${{ steps.get-redis.outputs.tag }}
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       # beta-version not used for OSS builds by default
       beta-version: ${{ inputs.force_beta && steps.beta-version.outputs.BETA_VERSION || '' }}
       version-suffix: ${{ steps.beta-version.outputs.VERSION_SUFFIX }}
@@ -62,12 +69,6 @@ jobs:
       - uses: actions/checkout@v6
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-      - id: get-redis
-        shell: bash -l -eo pipefail {0}
-        run: |
-          # TAG=$(curl -sL --retry 5 https://api.github.com/repos/redis/redis/releases/latest | jq -er '.tag_name') && \
-          # echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "tag=3cd464263b03b425ffae2e23db24df3dc9346871" >> $GITHUB_OUTPUT
       - name: Generate Beta Version unique identifier
         id: beta-version
         run: |

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -83,7 +83,7 @@ on:
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable", or a commit sha)'
         type: string
-        default: 3cd464263b03b425ffae2e23db24df3dc9346871
+        default: '8.8.1'
       rejson-branch:
         type: string
         default: master

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -21,7 +21,7 @@ on:
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable")'
         type: string
-        default: 3cd464263b03b425ffae2e23db24df3dc9346871
+        default: '8.8.1'
       test-config:
         description: 'Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")'
         required: true


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: CI on the 8.8 branch is pinned to a Redis development commit from before the Redis 8.8 release line stabilized.
2. Change: Discover the latest Redis 8.8 release in PR, merge-queue, and nightly CI.
3. Outcome: The 8.8 branch automatically follows Redis 8.8 patch releases instead of retaining a raw development SHA.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. Redis selection in PR, merge-queue, and nightly workflows

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

