### PR TITLE
MOD-17341: Forced GC waits out a concurrent child process instead of skipping its cycle

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1008,6 +1008,13 @@ static int GCForceInvokeReply(RedisModuleCtx *ctx, RedisModuleString **argv, int
   if (!debugCommandsEnabled(ctx)) {
     return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
   }
+  // Replying DONE for a cycle that never started would be indistinguishable from one that
+  // ran and found nothing to collect.
+  const GCForcedRunOutcome *outcome = RedisModule_GetBlockedClientPrivateData(ctx);
+  if (outcome && *outcome == GC_FORCED_RUN_NO_FORK) {
+    return RedisModule_ReplyWithError(
+        ctx, "GC DID NOT RUN: no child process could be created within TIMEOUT");
+  }
   return RedisModule_ReplyWithSimpleString(ctx, "DONE");
 }
 
@@ -1049,9 +1056,15 @@ DEBUG_COMMAND(GCForceInvoke) {
   // after a forced GC. The fallback below covers the only case where a disk
   // index has no GCContext (GC globally disabled or a temporary index).
   if (sp->gc) {
+    // The same TIMEOUT bounds the wait for a fork slot and the client's patience, so the
+    // cycle cannot still be waiting once nobody is listening for its answer.
+    GCForcedRun forced = {.forkWaitMs = timeout > GC_FORCED_RUN_REPLY_MARGIN_MS
+                                            ? timeout - GC_FORCED_RUN_REPLY_MARGIN_MS
+                                            : timeout,
+                          .retryIntervalMs = GC_FORCED_RUN_RETRY_INTERVAL_MS};
     RedisModuleBlockedClient *bc = RedisModule_BlockClient(
-        ctx, GCForceInvokeReply, GCForceInvokeReplyTimeout, NULL, timeout);
-    GCContext_ForceInvoke(sp->gc, bc);
+        ctx, GCForceInvokeReply, GCForceInvokeReplyTimeout, GCForcedRunOutcomeFree, timeout);
+    GCContext_ForceInvoke(sp->gc, bc, forced);
     return REDISMODULE_OK;
   } else if (sp->diskSpec) {
     // Fallback described above: with no GCContext there is no DiskGC stats
@@ -1118,7 +1131,10 @@ DEBUG_COMMAND(GCForceBGInvoke) {
   if (!sp) {
     return REDISMODULE_OK;
   }
-  GCContext_ForceBGInvoke(sp->gc);
+  // Nobody is waiting on this one, so it gets the default budget rather than a TIMEOUT.
+  GCForcedRun forced = {.forkWaitMs = GC_FORCED_RUN_DEFAULT_WAIT_MS,
+                        .retryIntervalMs = GC_FORCED_RUN_RETRY_INTERVAL_MS};
+  GCContext_ForceBGInvoke(sp->gc, forced);
   RedisModule_ReplyWithSimpleString(ctx, "OK");
   return REDISMODULE_OK;
 }

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1056,11 +1056,12 @@ DEBUG_COMMAND(GCForceInvoke) {
   // after a forced GC. The fallback below covers the only case where a disk
   // index has no GCContext (GC globally disabled or a temporary index).
   if (sp->gc) {
-    // The same TIMEOUT bounds the wait for a fork slot and the client's patience, so the
-    // cycle cannot still be waiting once nobody is listening for its answer.
-    GCForcedRun forced = {.forkWaitMs = timeout > GC_FORCED_RUN_REPLY_MARGIN_MS
+    // TIMEOUT bounds the wait for a fork slot as well as the client's patience, less a margin
+    // so this reply wins the race against the block timeout. A short TIMEOUT gets half of it,
+    // since a fixed margin would leave nothing to wait with. 0 stays 0, meaning no limit.
+    GCForcedRun forced = {.forkWaitMs = timeout > 2 * GC_FORCED_RUN_REPLY_MARGIN_MS
                                             ? timeout - GC_FORCED_RUN_REPLY_MARGIN_MS
-                                            : timeout,
+                                            : timeout / 2,
                           .retryIntervalMs = GC_FORCED_RUN_RETRY_INTERVAL_MS};
     RedisModuleBlockedClient *bc = RedisModule_BlockClient(
         ctx, GCForceInvokeReply, GCForceInvokeReplyTimeout, GCForcedRunOutcomeFree, timeout);

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1059,10 +1059,14 @@ DEBUG_COMMAND(GCForceInvoke) {
     // TIMEOUT bounds the wait for a fork slot as well as the client's patience, less a margin
     // so this reply wins the race against the block timeout. A short TIMEOUT gets half of it,
     // since a fixed margin would leave nothing to wait with. 0 stays 0, meaning no limit.
-    GCForcedRun forced = {.forkWaitMs = timeout > 2 * GC_FORCED_RUN_REPLY_MARGIN_MS
-                                            ? timeout - GC_FORCED_RUN_REPLY_MARGIN_MS
-                                            : timeout / 2,
-                          .retryIntervalMs = GC_FORCED_RUN_RETRY_INTERVAL_MS};
+    long long forkWaitMs = timeout;  // TIMEOUT 0 asks for no limit, and stays that way
+    if (timeout > 2 * GC_FORCED_RUN_REPLY_MARGIN_MS) {
+      forkWaitMs = timeout - GC_FORCED_RUN_REPLY_MARGIN_MS;
+    } else if (timeout > 0) {
+      // Halving rounds down, and 0 here would read as no limit -- the opposite of a 1ms budget.
+      forkWaitMs = timeout / 2 > 0 ? timeout / 2 : 1;
+    }
+    GCForcedRun forced = GCForcedRun_New(forkWaitMs, GC_FORCED_RUN_RETRY_INTERVAL_MS);
     RedisModuleBlockedClient *bc = RedisModule_BlockClient(
         ctx, GCForceInvokeReply, GCForceInvokeReplyTimeout, GCForcedRunOutcomeFree, timeout);
     GCContext_ForceInvoke(sp->gc, bc, forced);
@@ -1133,8 +1137,8 @@ DEBUG_COMMAND(GCForceBGInvoke) {
     return REDISMODULE_OK;
   }
   // Nobody is waiting on this one, so it gets the default budget rather than a TIMEOUT.
-  GCForcedRun forced = {.forkWaitMs = GC_FORCED_RUN_DEFAULT_WAIT_MS,
-                        .retryIntervalMs = GC_FORCED_RUN_RETRY_INTERVAL_MS};
+  GCForcedRun forced = GCForcedRun_New(GC_FORCED_RUN_DEFAULT_WAIT_MS,
+                                       GC_FORCED_RUN_RETRY_INTERVAL_MS);
   GCContext_ForceBGInvoke(sp->gc, forced);
   RedisModule_ReplyWithSimpleString(ctx, "OK");
   return REDISMODULE_OK;

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -179,6 +179,9 @@ void StoreResultsDebugCtx_SetPause(bool pause);
 // Fork-GC worker: parked at the very top of a periodic GC job, before the collection callback
 // runs. Lets a test rendezvous with a real run while RUN_PENDING is held, instead of sleeping.
 #define SYNC_POINT_GC_TASK_START                        "GCTaskStart"
+// Fork-GC worker: parked before the GIL handshake that precedes the fork, so a test can take
+// the single child slot while a cycle waits here and make the EEXIST retry deterministic.
+#define SYNC_POINT_GC_BEFORE_FORK                       "GCBeforeFork"
 
 // SyncPoint API function declarations
 // Arm a sync point - subsequent calls to SyncPoint_Wait will block

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -182,6 +182,10 @@ void StoreResultsDebugCtx_SetPause(bool pause);
 // Fork-GC worker: parked before the GIL handshake that precedes the fork, so a test can take
 // the single child slot while a cycle waits here and make the EEXIST retry deterministic.
 #define SYNC_POINT_GC_BEFORE_FORK                       "GCBeforeFork"
+// Fork-GC worker: parked after a fork attempt failed because another child holds the slot, with
+// the GIL released. Reaching it is the only proof, independent of host scheduling, that a cycle
+// really did hit EEXIST rather than winning the slot outright.
+#define SYNC_POINT_GC_FORK_SLOT_BUSY                    "GCForkSlotBusy"
 
 // SyncPoint API function declarations
 // Arm a sync point - subsequent calls to SyncPoint_Wait will block

--- a/src/disk_gc.c
+++ b/src/disk_gc.c
@@ -61,7 +61,9 @@ static void accumulateCycleStats(DiskGC *gc, const DiskGCRunStats *stats) {
   IndexsGlobalStats_DecreaseLogicallyDeleted(stats->num_cleaned_docs);
 }
 
-static bool periodicCb(void *privdata, bool debugForced) {
+// `forced` is only read for its presence: disk GC compacts in-process, so it has no fork slot
+// to wait for and no way to fail to start.
+static bool periodicCb(void *privdata, GCForcedRun *forced) {
   DiskGC *gc = privdata;
   StrongRef spec_ref = IndexSpecRef_Promote(gc->index);
   IndexSpec *sp = StrongRef_Get(spec_ref);
@@ -83,7 +85,7 @@ static bool periodicCb(void *privdata, bool debugForced) {
   size_t num_updates = atomic_load(&gc->updatesFromLastRun);
   size_t num_changes = num_writes + num_deletes + num_updates;
   if (!g_diskGcDisabled && sp->diskSpec &&
-      (debugForced || num_changes >= RSGlobalConfig.gcConfigParams.gcSettings.forkGcCleanThreshold)) {
+      (forced || num_changes >= RSGlobalConfig.gcConfigParams.gcSettings.forkGcCleanThreshold)) {
     // Reset counters before running GC
     atomic_fetch_sub(&gc->writesFromLastRun, num_writes);
     atomic_fetch_sub(&gc->deletesFromLastRun, num_deletes);

--- a/src/disk_gc.c
+++ b/src/disk_gc.c
@@ -61,7 +61,7 @@ static void accumulateCycleStats(DiskGC *gc, const DiskGCRunStats *stats) {
   IndexsGlobalStats_DecreaseLogicallyDeleted(stats->num_cleaned_docs);
 }
 
-static bool periodicCb(void *privdata, bool force) {
+static bool periodicCb(void *privdata, bool debugForced) {
   DiskGC *gc = privdata;
   StrongRef spec_ref = IndexSpecRef_Promote(gc->index);
   IndexSpec *sp = StrongRef_Get(spec_ref);
@@ -83,7 +83,7 @@ static bool periodicCb(void *privdata, bool force) {
   size_t num_updates = atomic_load(&gc->updatesFromLastRun);
   size_t num_changes = num_writes + num_deletes + num_updates;
   if (!g_diskGcDisabled && sp->diskSpec &&
-      (force || num_changes >= RSGlobalConfig.gcConfigParams.gcSettings.forkGcCleanThreshold)) {
+      (debugForced || num_changes >= RSGlobalConfig.gcConfigParams.gcSettings.forkGcCleanThreshold)) {
     // Reset counters before running GC
     atomic_fetch_sub(&gc->writesFromLastRun, num_writes);
     atomic_fetch_sub(&gc->deletesFromLastRun, num_deletes);

--- a/src/fork_gc.h
+++ b/src/fork_gc.h
@@ -73,7 +73,7 @@ ForkGC *FGC_Create(StrongRef spec_ref, GCCallbacks *callbacks);
 
 // Run one full GC cycle. In production, called via the GCCallbacks with hooks=NULL.
 // Tests call this directly with hooks to inject mutations at specific lifecycle points.
-bool FGC_RunCycle(ForkGC *gc, bool force, const FGCHook *hook);
+bool FGC_RunCycle(ForkGC *gc, bool debugForced, const FGCHook *hook);
 
 #ifdef __cplusplus
 }

--- a/src/fork_gc.h
+++ b/src/fork_gc.h
@@ -73,7 +73,7 @@ ForkGC *FGC_Create(StrongRef spec_ref, GCCallbacks *callbacks);
 
 // Run one full GC cycle. In production, called via the GCCallbacks with hooks=NULL.
 // Tests call this directly with hooks to inject mutations at specific lifecycle points.
-bool FGC_RunCycle(ForkGC *gc, bool debugForced, const FGCHook *hook);
+bool FGC_RunCycle(ForkGC *gc, GCForcedRun *forced, const FGCHook *hook);
 
 #ifdef __cplusplus
 }

--- a/src/fork_gc/fork_gc.c
+++ b/src/fork_gc/fork_gc.c
@@ -40,6 +40,9 @@
 #define GC_READERFD 0
 // Number of attempts to wait for the child to exit gracefully before trying to terminate it
 #define GC_WAIT_ATTEMPTS 4
+// A debugForced cycle waits attempts x backoff for another child to free the fork slot.
+#define GC_FORK_SLOT_ATTEMPTS 100
+#define GC_FORK_SLOT_BACKOFF_NS 50000000
 
 static void FGC_childScanIndexes(ForkGC *gc, IndexSpec *spec) {
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(gc->ctx, spec);
@@ -123,7 +126,7 @@ static void reap_child_blocking(RedisModuleCtx *ctx, pid_t cpid, int timeout_sec
   }
 }
 
-bool FGC_RunCycle(ForkGC *gc, bool force, const FGCHook *hook) {
+bool FGC_RunCycle(ForkGC *gc, bool debugForced, const FGCHook *hook) {
   RedisModuleCtx *ctx = gc->ctx;
 
   // This check must be done first, because some values (like `deletedDocsFromLastRun`) that are used for
@@ -142,7 +145,7 @@ bool FGC_RunCycle(ForkGC *gc, bool force, const FGCHook *hook) {
     return false;
   }
 
-  if (!force && gc->deletedOrUpdatedDocsFromLastRun < RSGlobalConfig.gcConfigParams.gcSettings.forkGcCleanThreshold) {
+  if (!debugForced && gc->deletedOrUpdatedDocsFromLastRun < RSGlobalConfig.gcConfigParams.gcSettings.forkGcCleanThreshold) {
     IndexSpecRef_Release(early_check);
     return true;
   }
@@ -168,18 +171,30 @@ bool FGC_RunCycle(ForkGC *gc, bool force, const FGCHook *hook) {
   // We need to acquire the GIL to use the fork api
   RedisModule_ThreadSafeContextLock(ctx);
 
-  // Check if we are out of memory before even trying to fork
-  if (isOutOfMemory(ctx)) {
-    RedisModule_Log(ctx, "warning", "Not enough memory for GC fork, skipping GC job");
-    gc->retryInterval.tv_sec = RSGlobalConfig.gcConfigParams.gcSettings.forkGcRetryInterval;
-    IndexSpecRef_Release(early_check);
-    RedisModule_ThreadSafeContextUnlock(ctx);
-    close(gc->pipe_read_fd);
-    close(gc->pipe_write_fd);
-    return true;
-  }
+  // Redis runs one child at a time, so a BGSAVE, AOF rewrite or replication fork makes
+  // the fork below fail with EEXIST. Only a debugForced cycle waits it out.
+  struct timespec fork_slot_backoff = {.tv_sec = 0, .tv_nsec = GC_FORK_SLOT_BACKOFF_NS};
+  for (int attempt = 0; ; attempt++) {
+    // Check if we are out of memory before even trying to fork
+    if (isOutOfMemory(ctx)) {
+      RedisModule_Log(ctx, "warning", "Not enough memory for GC fork, skipping GC job");
+      gc->retryInterval.tv_sec = RSGlobalConfig.gcConfigParams.gcSettings.forkGcRetryInterval;
+      IndexSpecRef_Release(early_check);
+      RedisModule_ThreadSafeContextUnlock(ctx);
+      close(gc->pipe_read_fd);
+      close(gc->pipe_write_fd);
+      return true;
+    }
 
-  cpid = RedisModule_Fork(NULL, NULL);  // duplicate the current process
+    cpid = RedisModule_Fork(NULL, NULL);  // duplicate the current process
+    if (cpid != -1 || !debugForced || errno != EEXIST || attempt == GC_FORK_SLOT_ATTEMPTS) {
+      break;
+    }
+    // Waiting without the GIL: the child we wait for needs the main thread to exit.
+    RedisModule_ThreadSafeContextUnlock(ctx);
+    nanosleep(&fork_slot_backoff, NULL);
+    RedisModule_ThreadSafeContextLock(ctx);
+  }
 
   if (cpid == -1) {
     RedisModule_Log(ctx, "warning", "fork failed - got errno %d, aborting fork GC", errno);
@@ -259,8 +274,8 @@ bool FGC_RunCycle(ForkGC *gc, bool force, const FGCHook *hook) {
   return gcrv;
 }
 
-static bool periodicCb(void *privdata, bool force) {
-  return FGC_RunCycle(privdata, force, NULL);
+static bool periodicCb(void *privdata, bool debugForced) {
+  return FGC_RunCycle(privdata, debugForced, NULL);
 }
 
 static void onTerminateCb(void *privdata) {

--- a/src/fork_gc/fork_gc.c
+++ b/src/fork_gc/fork_gc.c
@@ -132,19 +132,30 @@ static void reap_child_blocking(RedisModuleCtx *ctx, pid_t cpid, int timeout_sec
 // The GIL must be held on entry and is held on return; it is released only while waiting, both
 // because the child being waited on needs the main thread and because its exit is what makes an
 // earlier isOutOfMemory() answer stale -- hence the guard inside the loop.
-static pid_t forkGCChild(RedisModuleCtx *ctx, GCForcedRun *forced) {
-  const bool bounded = forced && forced->forkWaitMs > 0;
-  struct timespec deadline;
-  if (bounded) {
-    clock_gettime(CLOCK_MONOTONIC_RAW, &deadline);
-    deadline.tv_sec += forced->forkWaitMs / 1000;
-    deadline.tv_nsec += (forced->forkWaitMs % 1000) * 1000000;
-    if (deadline.tv_nsec >= 1000000000) {
-      deadline.tv_sec++;
-      deadline.tv_nsec -= 1000000000;
+// How long to wait before the next fork attempt: the retry interval, or whatever is left of the
+// budget if that is shorter. False means nothing is left, so there must be no further attempt --
+// checked before sleeping, since a sleep that overruns the budget would have the cycle forking
+// for a caller that has already been answered.
+static bool forkRetryDelay(const GCForcedRun *forced, struct timespec *delay) {
+  long long ms = forced->retryIntervalMs;
+  if (forced->forkWaitMs > 0) {
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC_RAW, &now);
+    long long left = (forced->forkDeadline.tv_sec - now.tv_sec) * 1000 +
+                     (forced->forkDeadline.tv_nsec - now.tv_nsec) / 1000000;
+    if (left <= 0) {
+      return false;
+    }
+    if (left < ms) {
+      ms = left;
     }
   }
+  delay->tv_sec = ms / 1000;
+  delay->tv_nsec = (ms % 1000) * 1000000;
+  return true;
+}
 
+static pid_t forkGCChild(RedisModuleCtx *ctx, GCForcedRun *forced) {
   while (true) {
     if (isOutOfMemory(ctx)) {
       RedisModule_Log(ctx, "warning", "Not enough memory for GC fork, skipping GC job");
@@ -155,7 +166,8 @@ static pid_t forkGCChild(RedisModuleCtx *ctx, GCForcedRun *forced) {
     if (cpid != -1) {
       return cpid;
     }
-    if (!forced || errno != EEXIST || (bounded && TimedOut(&deadline))) {
+    struct timespec delay;
+    if (!forced || errno != EEXIST || !forkRetryDelay(forced, &delay)) {
       RedisModule_Log(ctx, "warning", "fork failed - got errno %d, aborting fork GC", errno);
       if (forced) {
         forced->outcome = GC_FORCED_RUN_NO_FORK;
@@ -170,9 +182,7 @@ static pid_t forkGCChild(RedisModuleCtx *ctx, GCForcedRun *forced) {
     SyncPoint_Wait(SYNC_POINT_GC_FORK_SLOT_BUSY);
 #endif
 
-    struct timespec retry = {.tv_sec = forced->retryIntervalMs / 1000,
-                             .tv_nsec = (forced->retryIntervalMs % 1000) * 1000000};
-    nanosleep(&retry, NULL);
+    nanosleep(&delay, NULL);
     RedisModule_ThreadSafeContextLock(ctx);
   }
 }

--- a/src/fork_gc/fork_gc.c
+++ b/src/fork_gc/fork_gc.c
@@ -124,39 +124,40 @@ static void reap_child_blocking(RedisModuleCtx *ctx, pid_t cpid, int timeout_sec
   }
 }
 
+// Milliseconds left of a forced run's budget, or -1 when its caller set none.
+static long long forkBudgetLeftMs(const GCForcedRun *forced) {
+  if (forced->forkWaitMs <= 0) {
+    return -1;
+  }
+  struct timespec now;
+  clock_gettime(CLOCK_MONOTONIC_RAW, &now);
+  long long left = (forced->forkDeadline.tv_sec - now.tv_sec) * 1000 +
+                   (forced->forkDeadline.tv_nsec - now.tv_nsec) / 1000000;
+  return left > 0 ? left : 0;
+}
+
 // Takes the single child slot Redis allows. A forced cycle retries while a competing BGSAVE,
 // AOF rewrite or replication fork holds it (EEXIST), within the budget its caller set; a
 // scheduled cycle gets one attempt, since its next run is due anyway. Returns the child pid,
 // or -1 having logged why and recorded it on `forced`.
 //
+// Every attempt is gated on the budget, not just the retries: a job can sit queued behind the
+// single GC worker until its deadline has passed, and re-taking the GIL after a wait can overrun
+// it too, so forking on the strength of an earlier check could start a cycle for a caller that
+// has already been answered.
+//
 // The GIL must be held on entry and is held on return; it is released only while waiting, both
 // because the child being waited on needs the main thread and because its exit is what makes an
 // earlier isOutOfMemory() answer stale -- hence the guard inside the loop.
-// How long to wait before the next fork attempt: the retry interval, or whatever is left of the
-// budget if that is shorter. False means nothing is left, so there must be no further attempt --
-// checked before sleeping, since a sleep that overruns the budget would have the cycle forking
-// for a caller that has already been answered.
-static bool forkRetryDelay(const GCForcedRun *forced, struct timespec *delay) {
-  long long ms = forced->retryIntervalMs;
-  if (forced->forkWaitMs > 0) {
-    struct timespec now;
-    clock_gettime(CLOCK_MONOTONIC_RAW, &now);
-    long long left = (forced->forkDeadline.tv_sec - now.tv_sec) * 1000 +
-                     (forced->forkDeadline.tv_nsec - now.tv_nsec) / 1000000;
-    if (left <= 0) {
-      return false;
-    }
-    if (left < ms) {
-      ms = left;
-    }
-  }
-  delay->tv_sec = ms / 1000;
-  delay->tv_nsec = (ms % 1000) * 1000000;
-  return true;
-}
-
 static pid_t forkGCChild(RedisModuleCtx *ctx, GCForcedRun *forced) {
   while (true) {
+    long long budget_left = forced ? forkBudgetLeftMs(forced) : -1;
+    if (budget_left == 0) {
+      RedisModule_Log(ctx, "warning", "GC fork budget spent, aborting fork GC");
+      forced->outcome = GC_FORCED_RUN_NO_FORK;
+      return -1;
+    }
+
     if (isOutOfMemory(ctx)) {
       RedisModule_Log(ctx, "warning", "Not enough memory for GC fork, skipping GC job");
       return -1;
@@ -166,14 +167,20 @@ static pid_t forkGCChild(RedisModuleCtx *ctx, GCForcedRun *forced) {
     if (cpid != -1) {
       return cpid;
     }
-    struct timespec delay;
-    if (!forced || errno != EEXIST || !forkRetryDelay(forced, &delay)) {
+    if (!forced || errno != EEXIST) {
       RedisModule_Log(ctx, "warning", "fork failed - got errno %d, aborting fork GC", errno);
       if (forced) {
         forced->outcome = GC_FORCED_RUN_NO_FORK;
       }
       return -1;
     }
+
+    long long delay_ms = forced->retryIntervalMs;
+    if (budget_left > 0 && budget_left < delay_ms) {
+      delay_ms = budget_left;  // never sleep past the deadline
+    }
+    struct timespec delay = {.tv_sec = delay_ms / 1000,
+                             .tv_nsec = (delay_ms % 1000) * 1000000};
 
     RedisModule_ThreadSafeContextUnlock(ctx);
 

--- a/src/fork_gc/fork_gc.c
+++ b/src/fork_gc/fork_gc.c
@@ -41,10 +41,6 @@
 #define GC_READERFD 0
 // Number of attempts to wait for the child to exit gracefully before trying to terminate it
 #define GC_WAIT_ATTEMPTS 4
-// A debugForced cycle waits attempts x backoff for another child to free the fork slot.
-// Coarse on purpose: Redis logs a warning for every failed RedisModule_Fork.
-#define GC_FORK_SLOT_ATTEMPTS 20
-#define GC_FORK_SLOT_BACKOFF_NS 250000000
 
 static void FGC_childScanIndexes(ForkGC *gc, IndexSpec *spec) {
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(gc->ctx, spec);
@@ -128,18 +124,28 @@ static void reap_child_blocking(RedisModuleCtx *ctx, pid_t cpid, int timeout_sec
   }
 }
 
-// Takes the single child slot Redis allows. A debugForced cycle retries while a competing
-// BGSAVE, AOF rewrite or replication fork holds it (EEXIST); every other cycle gets one
-// attempt, since its next run is due anyway. Returns the child pid, or -1 having logged why.
+// Takes the single child slot Redis allows. A forced cycle retries while a competing BGSAVE,
+// AOF rewrite or replication fork holds it (EEXIST), within the budget its caller set; a
+// scheduled cycle gets one attempt, since its next run is due anyway. Returns the child pid,
+// or -1 having logged why and recorded it on `forced`.
 //
 // The GIL must be held on entry and is held on return; it is released only while waiting, both
 // because the child being waited on needs the main thread and because its exit is what makes an
 // earlier isOutOfMemory() answer stale -- hence the guard inside the loop.
-static pid_t forkGCChild(RedisModuleCtx *ctx, bool debugForced) {
-  const int max_attempts = debugForced ? GC_FORK_SLOT_ATTEMPTS : 1;
-  struct timespec backoff = {.tv_sec = 0, .tv_nsec = GC_FORK_SLOT_BACKOFF_NS};
+static pid_t forkGCChild(RedisModuleCtx *ctx, GCForcedRun *forced) {
+  const bool bounded = forced && forced->forkWaitMs > 0;
+  struct timespec deadline;
+  if (bounded) {
+    clock_gettime(CLOCK_MONOTONIC_RAW, &deadline);
+    deadline.tv_sec += forced->forkWaitMs / 1000;
+    deadline.tv_nsec += (forced->forkWaitMs % 1000) * 1000000;
+    if (deadline.tv_nsec >= 1000000000) {
+      deadline.tv_sec++;
+      deadline.tv_nsec -= 1000000000;
+    }
+  }
 
-  for (int attempt = 1; ; attempt++) {
+  while (true) {
     if (isOutOfMemory(ctx)) {
       RedisModule_Log(ctx, "warning", "Not enough memory for GC fork, skipping GC job");
       return -1;
@@ -149,8 +155,11 @@ static pid_t forkGCChild(RedisModuleCtx *ctx, bool debugForced) {
     if (cpid != -1) {
       return cpid;
     }
-    if (errno != EEXIST || attempt == max_attempts) {
+    if (!forced || errno != EEXIST || (bounded && TimedOut(&deadline))) {
       RedisModule_Log(ctx, "warning", "fork failed - got errno %d, aborting fork GC", errno);
+      if (forced) {
+        forced->outcome = GC_FORCED_RUN_NO_FORK;
+      }
       return -1;
     }
 
@@ -161,12 +170,14 @@ static pid_t forkGCChild(RedisModuleCtx *ctx, bool debugForced) {
     SyncPoint_Wait(SYNC_POINT_GC_FORK_SLOT_BUSY);
 #endif
 
-    nanosleep(&backoff, NULL);
+    struct timespec retry = {.tv_sec = forced->retryIntervalMs / 1000,
+                             .tv_nsec = (forced->retryIntervalMs % 1000) * 1000000};
+    nanosleep(&retry, NULL);
     RedisModule_ThreadSafeContextLock(ctx);
   }
 }
 
-bool FGC_RunCycle(ForkGC *gc, bool debugForced, const FGCHook *hook) {
+bool FGC_RunCycle(ForkGC *gc, GCForcedRun *forced, const FGCHook *hook) {
   RedisModuleCtx *ctx = gc->ctx;
 
   // This check must be done first, because some values (like `deletedDocsFromLastRun`) that are used for
@@ -185,7 +196,7 @@ bool FGC_RunCycle(ForkGC *gc, bool debugForced, const FGCHook *hook) {
     return false;
   }
 
-  if (!debugForced && gc->deletedOrUpdatedDocsFromLastRun < RSGlobalConfig.gcConfigParams.gcSettings.forkGcCleanThreshold) {
+  if (!forced && gc->deletedOrUpdatedDocsFromLastRun < RSGlobalConfig.gcConfigParams.gcSettings.forkGcCleanThreshold) {
     IndexSpecRef_Release(early_check);
     return true;
   }
@@ -199,6 +210,9 @@ bool FGC_RunCycle(ForkGC *gc, bool debugForced, const FGCHook *hook) {
   int rc = pipe(pipefd);  // create the pipe
   if (rc == -1) {
     RedisModule_Log(ctx, "warning", "Couldn't create pipe - got errno %d, aborting fork GC", errno);
+    if (forced) {
+      forced->outcome = GC_FORCED_RUN_NO_FORK;
+    }
     IndexSpecRef_Release(early_check);
     return true;
   }
@@ -216,7 +230,7 @@ bool FGC_RunCycle(ForkGC *gc, bool debugForced, const FGCHook *hook) {
   // We need to acquire the GIL to use the fork api
   RedisModule_ThreadSafeContextLock(ctx);
 
-  cpid = forkGCChild(ctx, debugForced);
+  cpid = forkGCChild(ctx, forced);
 
   if (cpid == -1) {
     gc->retryInterval.tv_sec = RSGlobalConfig.gcConfigParams.gcSettings.forkGcRetryInterval;
@@ -295,8 +309,8 @@ bool FGC_RunCycle(ForkGC *gc, bool debugForced, const FGCHook *hook) {
   return gcrv;
 }
 
-static bool periodicCb(void *privdata, bool debugForced) {
-  return FGC_RunCycle(privdata, debugForced, NULL);
+static bool periodicCb(void *privdata, GCForcedRun *forced) {
+  return FGC_RunCycle(privdata, forced, NULL);
 }
 
 static void onTerminateCb(void *privdata) {

--- a/src/fork_gc/fork_gc.c
+++ b/src/fork_gc/fork_gc.c
@@ -128,6 +128,44 @@ static void reap_child_blocking(RedisModuleCtx *ctx, pid_t cpid, int timeout_sec
   }
 }
 
+// Takes the single child slot Redis allows. A debugForced cycle retries while a competing
+// BGSAVE, AOF rewrite or replication fork holds it (EEXIST); every other cycle gets one
+// attempt, since its next run is due anyway. Returns the child pid, or -1 having logged why.
+//
+// The GIL must be held on entry and is held on return; it is released only while waiting, both
+// because the child being waited on needs the main thread and because its exit is what makes an
+// earlier isOutOfMemory() answer stale -- hence the guard inside the loop.
+static pid_t forkGCChild(RedisModuleCtx *ctx, bool debugForced) {
+  const int max_attempts = debugForced ? GC_FORK_SLOT_ATTEMPTS : 1;
+  struct timespec backoff = {.tv_sec = 0, .tv_nsec = GC_FORK_SLOT_BACKOFF_NS};
+
+  for (int attempt = 1; ; attempt++) {
+    if (isOutOfMemory(ctx)) {
+      RedisModule_Log(ctx, "warning", "Not enough memory for GC fork, skipping GC job");
+      return -1;
+    }
+
+    pid_t cpid = RedisModule_Fork(NULL, NULL);  // duplicate the current process
+    if (cpid != -1) {
+      return cpid;
+    }
+    if (errno != EEXIST || attempt == max_attempts) {
+      RedisModule_Log(ctx, "warning", "fork failed - got errno %d, aborting fork GC", errno);
+      return -1;
+    }
+
+    RedisModule_ThreadSafeContextUnlock(ctx);
+
+    // Test hook (ENABLE_ASSERT): park after a failed fork, so a test can observe the EEXIST.
+#ifdef ENABLE_ASSERT
+    SyncPoint_Wait(SYNC_POINT_GC_FORK_SLOT_BUSY);
+#endif
+
+    nanosleep(&backoff, NULL);
+    RedisModule_ThreadSafeContextLock(ctx);
+  }
+}
+
 bool FGC_RunCycle(ForkGC *gc, bool debugForced, const FGCHook *hook) {
   RedisModuleCtx *ctx = gc->ctx;
 
@@ -178,39 +216,9 @@ bool FGC_RunCycle(ForkGC *gc, bool debugForced, const FGCHook *hook) {
   // We need to acquire the GIL to use the fork api
   RedisModule_ThreadSafeContextLock(ctx);
 
-  // Redis runs one child at a time, so a BGSAVE, AOF rewrite or replication fork makes
-  // the fork below fail with EEXIST. Only a debugForced cycle waits it out.
-  struct timespec fork_slot_backoff = {.tv_sec = 0, .tv_nsec = GC_FORK_SLOT_BACKOFF_NS};
-  for (int attempt = 0; ; attempt++) {
-    // Check if we are out of memory before even trying to fork
-    if (isOutOfMemory(ctx)) {
-      RedisModule_Log(ctx, "warning", "Not enough memory for GC fork, skipping GC job");
-      gc->retryInterval.tv_sec = RSGlobalConfig.gcConfigParams.gcSettings.forkGcRetryInterval;
-      IndexSpecRef_Release(early_check);
-      RedisModule_ThreadSafeContextUnlock(ctx);
-      close(gc->pipe_read_fd);
-      close(gc->pipe_write_fd);
-      return true;
-    }
-
-    cpid = RedisModule_Fork(NULL, NULL);  // duplicate the current process
-    if (cpid != -1 || !debugForced || errno != EEXIST || attempt == GC_FORK_SLOT_ATTEMPTS) {
-      break;
-    }
-    // Waiting without the GIL: the child we wait for needs the main thread to exit.
-    RedisModule_ThreadSafeContextUnlock(ctx);
-
-    // Test hook (ENABLE_ASSERT): park after a failed fork, so a test can observe the EEXIST.
-#ifdef ENABLE_ASSERT
-    SyncPoint_Wait(SYNC_POINT_GC_FORK_SLOT_BUSY);
-#endif
-
-    nanosleep(&fork_slot_backoff, NULL);
-    RedisModule_ThreadSafeContextLock(ctx);
-  }
+  cpid = forkGCChild(ctx, debugForced);
 
   if (cpid == -1) {
-    RedisModule_Log(ctx, "warning", "fork failed - got errno %d, aborting fork GC", errno);
     gc->retryInterval.tv_sec = RSGlobalConfig.gcConfigParams.gcSettings.forkGcRetryInterval;
     IndexSpecRef_Release(early_check);
 

--- a/src/fork_gc/fork_gc.c
+++ b/src/fork_gc/fork_gc.c
@@ -199,6 +199,12 @@ bool FGC_RunCycle(ForkGC *gc, bool debugForced, const FGCHook *hook) {
     }
     // Waiting without the GIL: the child we wait for needs the main thread to exit.
     RedisModule_ThreadSafeContextUnlock(ctx);
+
+    // Test hook (ENABLE_ASSERT): park after a failed fork, so a test can observe the EEXIST.
+#ifdef ENABLE_ASSERT
+    SyncPoint_Wait(SYNC_POINT_GC_FORK_SLOT_BUSY);
+#endif
+
     nanosleep(&fork_slot_backoff, NULL);
     RedisModule_ThreadSafeContextLock(ctx);
   }

--- a/src/fork_gc/fork_gc.c
+++ b/src/fork_gc/fork_gc.c
@@ -24,6 +24,7 @@
 #include "util/redis_mem_info.h"
 #include "util/timeout.h"
 #include "config.h"
+#include "debug_commands.h"
 #include "fork_gc.h"
 #include "fork_gc_ffi.h"
 #include "gc.h"
@@ -41,8 +42,9 @@
 // Number of attempts to wait for the child to exit gracefully before trying to terminate it
 #define GC_WAIT_ATTEMPTS 4
 // A debugForced cycle waits attempts x backoff for another child to free the fork slot.
-#define GC_FORK_SLOT_ATTEMPTS 100
-#define GC_FORK_SLOT_BACKOFF_NS 50000000
+// Coarse on purpose: Redis logs a warning for every failed RedisModule_Fork.
+#define GC_FORK_SLOT_ATTEMPTS 20
+#define GC_FORK_SLOT_BACKOFF_NS 250000000
 
 static void FGC_childScanIndexes(ForkGC *gc, IndexSpec *spec) {
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(gc->ctx, spec);
@@ -167,6 +169,11 @@ bool FGC_RunCycle(ForkGC *gc, bool debugForced, const FGCHook *hook) {
   // initialize the pollfd for the read pipe
   gc->pollfd_read[0].fd = gc->pipe_read_fd;
   gc->pollfd_read[0].events = POLLIN;
+
+  // Test hook (ENABLE_ASSERT): park before the GIL, so a test can take the fork slot first.
+#ifdef ENABLE_ASSERT
+  SyncPoint_Wait(SYNC_POINT_GC_BEFORE_FORK);
+#endif
 
   // We need to acquire the GIL to use the fork api
   RedisModule_ThreadSafeContextLock(ctx);

--- a/src/gc.c
+++ b/src/gc.c
@@ -293,6 +293,17 @@ void GCContext_GetStats(GCContext* gc, InfoGCStats* out) {
 
 void GCContext_CommonForceInvoke(GCContext* gc, RedisModuleBlockedClient* bc,
                                  GCForcedRun forced) {
+  // Stamped here, on the submitting thread, so the budget runs from the command rather than
+  // from whenever the single GC worker gets to this job -- the client's timeout started here.
+  if (forced.forkWaitMs > 0) {
+    clock_gettime(CLOCK_MONOTONIC_RAW, &forced.forkDeadline);
+    forced.forkDeadline.tv_sec += forced.forkWaitMs / 1000;
+    forced.forkDeadline.tv_nsec += (forced.forkWaitMs % 1000) * 1000000;
+    if (forced.forkDeadline.tv_nsec >= 1000000000) {
+      forced.forkDeadline.tv_sec++;
+      forced.forkDeadline.tv_nsec -= 1000000000;
+    }
+  }
   GCDebugTask *task = GCDebugTaskCreate(gc, bc, forced);
   redisearch_thpool_add_work(gcThreadpool_g, debugTaskCallback, task, THPOOL_PRIORITY_HIGH);
 }

--- a/src/gc.c
+++ b/src/gc.c
@@ -27,13 +27,20 @@ static redisearch_thpool_t *gcThreadpool_g = NULL;
 typedef struct GCDebugTask {
   GCContext* gc;
   RedisModuleBlockedClient* bClient;
+  GCForcedRun forced;
 } GCDebugTask;
 
-static GCDebugTask *GCDebugTaskCreate(GCContext *gc, RedisModuleBlockedClient* bClient) {
+static GCDebugTask *GCDebugTaskCreate(GCContext *gc, RedisModuleBlockedClient* bClient,
+                                      GCForcedRun forced) {
   GCDebugTask *task = rm_new(GCDebugTask);
   task->gc = gc;
   task->bClient = bClient;
+  task->forced = forced;
   return task;
+}
+
+void GCForcedRunOutcomeFree(RedisModuleCtx* ctx, void* privdata) {
+  rm_free(privdata);
 }
 
 GCContext* GCContext_CreateGC(StrongRef spec_ref, uint32_t gcPolicy) {
@@ -121,7 +128,7 @@ static void taskCallback(void* data) {
   SyncPoint_Wait(SYNC_POINT_GC_TASK_START);
 #endif
 
-  bool ret = gc->callbacks.periodicCallback(gc->gcCtx, false);
+  bool ret = gc->callbacks.periodicCallback(gc->gcCtx, NULL);
 
   if (ret) { // The common case
     // The index was not freed. We need to reschedule the task.
@@ -145,11 +152,16 @@ static void debugTaskCallback(void* data) {
   GCContext* gc = task->gc;
   RedisModuleBlockedClient* bc = task->bClient;
 
-  gc->callbacks.periodicCallback(gc->gcCtx, true);
+  gc->callbacks.periodicCallback(gc->gcCtx, &task->forced);
 
   // if GC was invoke by debug command, we release the client
-  // and terminate without rescheduling the task again.
-  if (bc) RedisModule_UnblockClient(bc, NULL);
+  // and terminate without rescheduling the task again. The outcome outlives this task, so
+  // the reply gets its own copy.
+  if (bc) {
+    GCForcedRunOutcome *outcome = rm_new(GCForcedRunOutcome);
+    *outcome = task->forced.outcome;
+    RedisModule_UnblockClient(bc, outcome);
+  }
   rm_free(task);
 }
 
@@ -255,17 +267,18 @@ void GCContext_GetStats(GCContext* gc, InfoGCStats* out) {
   gc->callbacks.getStats(gc->gcCtx, out);
 }
 
-void GCContext_CommonForceInvoke(GCContext* gc, RedisModuleBlockedClient* bc) {
-  GCDebugTask *task = GCDebugTaskCreate(gc, bc);
+void GCContext_CommonForceInvoke(GCContext* gc, RedisModuleBlockedClient* bc,
+                                 GCForcedRun forced) {
+  GCDebugTask *task = GCDebugTaskCreate(gc, bc, forced);
   redisearch_thpool_add_work(gcThreadpool_g, debugTaskCallback, task, THPOOL_PRIORITY_HIGH);
 }
 
-void GCContext_ForceInvoke(GCContext* gc, RedisModuleBlockedClient* bc) {
-  GCContext_CommonForceInvoke(gc, bc);
+void GCContext_ForceInvoke(GCContext* gc, RedisModuleBlockedClient* bc, GCForcedRun forced) {
+  GCContext_CommonForceInvoke(gc, bc, forced);
 }
 
-void GCContext_ForceBGInvoke(GCContext* gc) {
-  GCContext_CommonForceInvoke(gc, NULL);
+void GCContext_ForceBGInvoke(GCContext* gc, GCForcedRun forced) {
+  GCContext_CommonForceInvoke(gc, NULL, forced);
 }
 
 static void GCContext_UnblockClient(void* data) {

--- a/src/gc.c
+++ b/src/gc.c
@@ -293,17 +293,6 @@ void GCContext_GetStats(GCContext* gc, InfoGCStats* out) {
 
 void GCContext_CommonForceInvoke(GCContext* gc, RedisModuleBlockedClient* bc,
                                  GCForcedRun forced) {
-  // Stamped here, on the submitting thread, so the budget runs from the command rather than
-  // from whenever the single GC worker gets to this job -- the client's timeout started here.
-  if (forced.forkWaitMs > 0) {
-    clock_gettime(CLOCK_MONOTONIC_RAW, &forced.forkDeadline);
-    forced.forkDeadline.tv_sec += forced.forkWaitMs / 1000;
-    forced.forkDeadline.tv_nsec += (forced.forkWaitMs % 1000) * 1000000;
-    if (forced.forkDeadline.tv_nsec >= 1000000000) {
-      forced.forkDeadline.tv_sec++;
-      forced.forkDeadline.tv_nsec -= 1000000000;
-    }
-  }
   GCDebugTask *task = GCDebugTaskCreate(gc, bc, forced);
   redisearch_thpool_add_work(gcThreadpool_g, debugTaskCallback, task, THPOOL_PRIORITY_HIGH);
 }

--- a/src/gc.h
+++ b/src/gc.h
@@ -61,9 +61,10 @@ typedef enum {
 // budget" stop being separate questions. Only FT.DEBUG GC_FORCEINVOKE and GC_FORCEBGINVOKE
 // build one today; the budget is theirs to set, which is why it is not a constant here.
 typedef struct {
-  long long forkWaitMs;       // wait this long for the fork slot; 0 means no limit
-  long long retryIntervalMs;  // how often to retry while waiting
-  GCForcedRunOutcome outcome; // set by the cycle
+  long long forkWaitMs;         // wait this long for the fork slot; 0 means no limit
+  long long retryIntervalMs;    // how often to retry while waiting, capped by what is left
+  struct timespec forkDeadline; // stamped when queued; meaningful only if forkWaitMs > 0
+  GCForcedRunOutcome outcome;   // set by the cycle
 } GCForcedRun;
 
 typedef struct GCCallbacks {

--- a/src/gc.h
+++ b/src/gc.h
@@ -67,6 +67,29 @@ typedef struct {
   GCForcedRunOutcome outcome;   // set by the cycle
 } GCForcedRun;
 
+// Builds a forced run with its deadline stamped from now, which is why callers use this rather
+// than filling the struct themselves: a forkWaitMs without a matching deadline reads as a budget
+// that expired before the first attempt. Call it on the thread asking for the collection, so the
+// budget runs from there rather than from whenever the GC worker picks the job up.
+static inline GCForcedRun GCForcedRun_New(long long forkWaitMs, long long retryIntervalMs) {
+  GCForcedRun forced;
+  forced.forkWaitMs = forkWaitMs;
+  forced.retryIntervalMs = retryIntervalMs;
+  forced.forkDeadline.tv_sec = 0;
+  forced.forkDeadline.tv_nsec = 0;
+  forced.outcome = GC_FORCED_RUN_OK;
+  if (forkWaitMs > 0) {
+    clock_gettime(CLOCK_MONOTONIC_RAW, &forced.forkDeadline);
+    forced.forkDeadline.tv_sec += forkWaitMs / 1000;
+    forced.forkDeadline.tv_nsec += (forkWaitMs % 1000) * 1000000;
+    if (forced.forkDeadline.tv_nsec >= 1000000000) {
+      forced.forkDeadline.tv_sec++;
+      forced.forkDeadline.tv_nsec -= 1000000000;
+    }
+  }
+  return forced;
+}
+
 typedef struct GCCallbacks {
   // Returns true if the GC should be rescheduled, false if the GC should be stopped.
   // `forced` is non-NULL only for a demanded collection, which must really happen: it skips
@@ -107,9 +130,9 @@ void GCContext_RenderStatsForInfo(GCContext* gc, RedisModuleInfoCtx* ctx);
 void GCContext_OnDelete(GCContext* gc);
 void GCContext_OnWrite(GCContext* gc);
 void GCContext_OnUpdate(GCContext* gc);
-// Queue a demanded collection. `forced` is copied, so the caller keeps no ownership. With a
-// blocked client, the outcome reaches its reply as unblock privdata, freed by
-// GCForcedRunOutcomeFree.
+// Queue a demanded collection, built with GCForcedRun_New. `forced` is copied, so the caller
+// keeps no ownership. With a blocked client, the outcome reaches its reply as unblock privdata,
+// freed by GCForcedRunOutcomeFree.
 void GCContext_ForceInvoke(GCContext* gc, RedisModuleBlockedClient* bc, GCForcedRun forced);
 void GCContext_ForceBGInvoke(GCContext* gc, GCForcedRun forced);
 // free_privdata for the blocked client above; matches RedisModule_BlockClient's signature.

--- a/src/gc.h
+++ b/src/gc.h
@@ -39,11 +39,38 @@ typedef struct InfoGCStats {
   long long lastRunTimeMs;
 } InfoGCStats;
 
+// Retry granularity for a forced run that has to wait; the budget itself comes from the
+// caller, so this only decides how often it looks again.
+#define GC_FORCED_RUN_RETRY_INTERVAL_MS 250
+// Budget for a forced run whose caller has nobody waiting on it (GC_FORCEBGINVOKE).
+#define GC_FORCED_RUN_DEFAULT_WAIT_MS 30000
+// Held back from a caller's timeout so its reply beats the blocked-client timeout; spending the
+// whole timeout waiting would leave the two racing, and the generic timeout would often win.
+#define GC_FORCED_RUN_REPLY_MARGIN_MS 500
+
+typedef enum {
+  // The cycle ran, or declined for a reason of its own -- collecting nothing under memory
+  // pressure is GC policy, not a failure, so it reports OK.
+  GC_FORCED_RUN_OK = 0,
+  // No child process could be created, so nothing was collected.
+  GC_FORCED_RUN_NO_FORK,
+} GCForcedRunOutcome;
+
+// What a caller that demanded a collection asked for, and what it got. A cycle receives a
+// pointer to one, or NULL when the scheduler drove it -- so "was this forced" and "on what
+// budget" stop being separate questions. Only FT.DEBUG GC_FORCEINVOKE and GC_FORCEBGINVOKE
+// build one today; the budget is theirs to set, which is why it is not a constant here.
+typedef struct {
+  long long forkWaitMs;       // wait this long for the fork slot; 0 means no limit
+  long long retryIntervalMs;  // how often to retry while waiting
+  GCForcedRunOutcome outcome; // set by the cycle
+} GCForcedRun;
+
 typedef struct GCCallbacks {
   // Returns true if the GC should be rescheduled, false if the GC should be stopped.
-  // `debugForced` is set only by FT.DEBUG GC_FORCEINVOKE/GC_FORCEBGINVOKE, which need the
-  // collection to really happen: it skips the clean threshold and waits for a fork slot.
-  bool (*periodicCallback)(void* gcCtx, bool debugForced);
+  // `forced` is non-NULL only for a demanded collection, which must really happen: it skips
+  // the clean threshold and may wait on resources a scheduled cycle would skip over.
+  bool (*periodicCallback)(void* gcCtx, GCForcedRun* forced);
   void (*renderStats)(RedisModule_Reply* reply, void* gc);
   void (*renderStatsForInfo)(RedisModuleInfoCtx* ctx, void* gc);
   void (*onDelete)(void* ctx);
@@ -76,8 +103,13 @@ void GCContext_RenderStatsForInfo(GCContext* gc, RedisModuleInfoCtx* ctx);
 void GCContext_OnDelete(GCContext* gc);
 void GCContext_OnWrite(GCContext* gc);
 void GCContext_OnUpdate(GCContext* gc);
-void GCContext_ForceInvoke(GCContext* gc, RedisModuleBlockedClient* bc);
-void GCContext_ForceBGInvoke(GCContext* gc);
+// Queue a demanded collection. `forced` is copied, so the caller keeps no ownership. With a
+// blocked client, the outcome reaches its reply as unblock privdata, freed by
+// GCForcedRunOutcomeFree.
+void GCContext_ForceInvoke(GCContext* gc, RedisModuleBlockedClient* bc, GCForcedRun forced);
+void GCContext_ForceBGInvoke(GCContext* gc, GCForcedRun forced);
+// free_privdata for the blocked client above; matches RedisModule_BlockClient's signature.
+void GCForcedRunOutcomeFree(RedisModuleCtx* ctx, void* privdata);
 void GCContext_WaitForAllOperations(RedisModuleBlockedClient* bc);
 void GCContext_GetStats(GCContext* gc, InfoGCStats* out);
 // Stop periodic collection and disarm the timer. A run in flight completes without re-arming.

--- a/src/gc.h
+++ b/src/gc.h
@@ -41,7 +41,9 @@ typedef struct InfoGCStats {
 
 typedef struct GCCallbacks {
   // Returns true if the GC should be rescheduled, false if the GC should be stopped.
-  bool (*periodicCallback)(void* gcCtx, bool force);
+  // `debugForced` is set only by FT.DEBUG GC_FORCEINVOKE/GC_FORCEBGINVOKE, which need the
+  // collection to really happen: it skips the clean threshold and waits for a fork slot.
+  bool (*periodicCallback)(void* gcCtx, bool debugForced);
   void (*renderStats)(RedisModule_Reply* reply, void* gc);
   void (*renderStatsForInfo)(RedisModuleInfoCtx* ctx, void* gc);
   void (*onDelete)(void* ctx);

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -87,9 +87,8 @@ class FGCTest : public ::testing::Test {
       [](void *p) { if (auto &f = *static_cast<std::function<void()>*>(p)) f(); },
       &beforeApply
     };
-    GCForcedRun forced{};
-    forced.forkWaitMs = GC_FORCED_RUN_DEFAULT_WAIT_MS;
-    forced.retryIntervalMs = GC_FORCED_RUN_RETRY_INTERVAL_MS;
+    GCForcedRun forced =
+        GCForcedRun_New(GC_FORCED_RUN_DEFAULT_WAIT_MS, GC_FORCED_RUN_RETRY_INTERVAL_MS);
     FGC_RunCycle(fgc, &forced, beforeApply ? &hook : nullptr);
   }
 };

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -87,7 +87,10 @@ class FGCTest : public ::testing::Test {
       [](void *p) { if (auto &f = *static_cast<std::function<void()>*>(p)) f(); },
       &beforeApply
     };
-    FGC_RunCycle(fgc, true, beforeApply ? &hook : nullptr);
+    GCForcedRun forced{};
+    forced.forkWaitMs = GC_FORCED_RUN_DEFAULT_WAIT_MS;
+    forced.retryIntervalMs = GC_FORCED_RUN_RETRY_INTERVAL_MS;
+    FGC_RunCycle(fgc, &forced, beforeApply ? &hook : nullptr);
   }
 };
 

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -969,3 +969,47 @@ def testForcedGCWaitsForForkSlot():
     env.assertFalse(thread.is_alive(), message='forced GC never returned')
     env.assertEqual(forced.get('reply'), 'DONE')
     env.assertGreater(int(to_dict(index_info(env)['gc_stats'])['bytes_collected']), 0)
+
+
+@skip(cluster=True)
+def testForcedGCReportsWhenItCannotFork():
+    """A forced GC that never gets the slot has to say so. Replying DONE would be the original
+    bug at a longer timescale: a collection reported but never made."""
+    env = Env()
+    skipIfNoEnableAssert(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
+    for i in range(100):
+        env.expect('HSET', f'doc{i}', 't', 'hello').equal(1)
+    for i in range(50):
+        env.expect('DEL', f'doc{i}').equal(1)
+
+    waitForRdbSaveToFinish(env)
+    env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+    env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', SYNC_POINT_GC_BEFORE_FORK, 10000).ok()
+
+    conn = env.getConnection()
+    forced = {}
+
+    def run():
+        try:
+            forced['reply'] = conn.execute_command(debug_cmd(), 'GC_FORCEINVOKE', 'idx', 1000)
+        except Exception as e:
+            forced['error'] = str(e)
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    try:
+        waitForSyncPoint(env, SYNC_POINT_GC_BEFORE_FORK,
+                         'Timeout waiting for the forced GC to reach the pre-fork sync point')
+        # 50 keys still to save at 30ms each outlives the ~500ms this TIMEOUT leaves for waiting.
+        env.expect('CONFIG', 'SET', 'rdb-key-save-delay', '30000').ok()
+        env.cmd('BGSAVE')
+        env.cmd(debug_cmd(), 'SYNC_POINT', 'SIGNAL', SYNC_POINT_GC_BEFORE_FORK)
+    finally:
+        thread.join(timeout=60)
+        env.cmd('CONFIG', 'SET', 'rdb-key-save-delay', '0')
+        waitForRdbSaveToFinish(env)
+
+    env.assertContains('GC DID NOT RUN', forced.get('error', ''),
+                       message=f'expected an error, got {forced}')

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -742,6 +742,7 @@ def testForkGCEmptyTextSuffixTrie_emptyValue():
 # the only way to hold a GC worker, and so the only way to drive the scheduling guards against
 # a real in-flight run instead of racing one.
 SYNC_POINT_GC_TASK_START = 'GCTaskStart'  # src/debug_commands.h
+SYNC_POINT_GC_BEFORE_FORK = 'GCBeforeFork'  # src/debug_commands.h
 
 
 def gcCycles(env, idx):
@@ -913,26 +914,45 @@ def testGCTerminatesAfterDropWhileStopped(env):
                        'stopped GC never terminated after its index was dropped', timeout=30)
 
 @skip(cluster=True)
-def testForcedGCWaitsForForkSlot(env):
-    """A forced GC replying DONE must mean it collected, even with a bgsave holding the fork slot."""
-    env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0').ok()
+def testForcedGCWaitsForForkSlot():
+    """A forced GC replying DONE has to mean it collected. Parking the cycle before its fork lets
+    a bgsave take the only child slot first, so the EEXIST retry is exercised rather than raced."""
+    env = Env()
+    skipIfNoEnableAssert(env)
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
-    waitForIndex(env, 'idx')
+    # Leaves the forced cycle below as the only one that can reach the sync point.
+    env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
     for i in range(100):
         env.expect('HSET', f'doc{i}', 't', 'hello').equal(1)
-    # rdb-key-save-delay is charged per key saved, so the undeleted half is what keeps
-    # the child alive long enough to still hold the slot.
+    # rdb-key-save-delay is charged per key saved, so the undeleted half is what makes the
+    # child outlive the first fork attempt.
     for i in range(50):
         env.expect('DEL', f'doc{i}').equal(1)
 
     waitForRdbSaveToFinish(env)
-    env.expect('CONFIG', 'SET', 'rdb-key-save-delay', '10000').ok()
+    env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
+    env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', SYNC_POINT_GC_BEFORE_FORK, 10000).ok()
+
+    # GC_FORCEINVOKE blocks until the cycle ends, so it needs its own connection.
+    conn = env.getConnection()
+    forced = {}
+    thread = threading.Thread(target=lambda: forced.update(
+        reply=conn.execute_command(debug_cmd(), 'GC_FORCEINVOKE', 'idx')))
+    thread.start()
     try:
+        wait_for_condition(
+            lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING',
+                             SYNC_POINT_GC_BEFORE_FORK) == 1, {}),
+            'Timeout waiting for the forced GC to reach the pre-fork sync point')
+
+        env.expect('CONFIG', 'SET', 'rdb-key-save-delay', '10000').ok()
         env.cmd('BGSAVE')
         env.assertEqual(int(env.cmd('INFO', 'Persistence')['rdb_bgsave_in_progress']), 1)
-        # Not forceInvokeGC(): it waits the bgsave out, which is the contention under test.
-        env.expect(debug_cmd(), 'GC_FORCEINVOKE', 'idx').equal('DONE')
-        env.assertGreater(int(to_dict(index_info(env)['gc_stats'])['bytes_collected']), 0)
+        env.cmd(debug_cmd(), 'SYNC_POINT', 'SIGNAL', SYNC_POINT_GC_BEFORE_FORK)
     finally:
+        thread.join(timeout=60)
         env.cmd('CONFIG', 'SET', 'rdb-key-save-delay', '0')
-        waitForRdbSaveToFinish(env)
+
+    env.assertFalse(thread.is_alive(), message='forced GC never returned')
+    env.assertEqual(forced.get('reply'), 'DONE')
+    env.assertGreater(int(to_dict(index_info(env)['gc_stats'])['bytes_collected']), 0)

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -1111,12 +1111,13 @@ def testForcedGCReportsWhenItCannotFork():
     env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
     env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', SYNC_POINT_GC_BEFORE_FORK, 10000).ok()
 
-    # A TIMEOUT this short is the interesting case: the retry interval is longer than the whole
-    # budget, so the wait has to be cut to what is left. Sleeping a full interval instead would
-    # let the block timeout answer first, with INVOCATION FAILED.
-    thread, forced = parkedForcedGC(env, timeout=100)
+    # The budget is this TIMEOUT less a margin, and both clocks start at submission -- so the
+    # margin, not the timeout, is what this test's own setup races. TIMEOUT has to stay clear of
+    # how long that setup can take on a slow host; the budget then expires while the child below
+    # is still holding the slot.
+    thread, forced = parkedForcedGC(env, timeout=2000)
     try:
-        holdForkSlot(env, 30000)
+        holdForkSlot(env, 40000)
         env.cmd(debug_cmd(), 'SYNC_POINT', 'SIGNAL', SYNC_POINT_GC_BEFORE_FORK)
     finally:
         thread.join(timeout=60)

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -1102,7 +1102,7 @@ def testForcedGCReportsWhenItCannotFork():
 
     def run():
         try:
-            forced['reply'] = conn.execute_command(debug_cmd(), 'GC_FORCEINVOKE', 'idx', 1000)
+            forced['reply'] = conn.execute_command(debug_cmd(), 'GC_FORCEINVOKE', 'idx', 100)
         except Exception as e:
             forced['error'] = str(e)
 
@@ -1111,7 +1111,9 @@ def testForcedGCReportsWhenItCannotFork():
     try:
         waitForSyncPoint(env, SYNC_POINT_GC_BEFORE_FORK,
                          'Timeout waiting for the forced GC to reach the pre-fork sync point')
-        # 50 keys still to save at 30ms each outlives the ~500ms this TIMEOUT leaves for waiting.
+        # A TIMEOUT this short is the interesting case: the retry interval is longer than the
+        # whole budget, so the wait has to be cut to what is left. Sleeping a full interval
+        # instead would let the block timeout answer first, with INVOCATION FAILED.
         env.expect('CONFIG', 'SET', 'rdb-key-save-delay', '30000').ok()
         env.cmd('BGSAVE')
         env.cmd(debug_cmd(), 'SYNC_POINT', 'SIGNAL', SYNC_POINT_GC_BEFORE_FORK)

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -911,3 +911,28 @@ def testGCTerminatesAfterDropWhileStopped(env):
     env.expect('FT.DROPINDEX', 'idx').ok()
     wait_for_condition(lambda: (logically_deleted() == 0, {'not_collected': logically_deleted()}),
                        'stopped GC never terminated after its index was dropped', timeout=30)
+
+@skip(cluster=True)
+def testForcedGCWaitsForForkSlot(env):
+    """A forced GC replying DONE must mean it collected, even with a bgsave holding the fork slot."""
+    env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0').ok()
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    waitForIndex(env, 'idx')
+    for i in range(100):
+        env.expect('HSET', f'doc{i}', 't', 'hello').equal(1)
+    # rdb-key-save-delay is charged per key saved, so the undeleted half is what keeps
+    # the child alive long enough to still hold the slot.
+    for i in range(50):
+        env.expect('DEL', f'doc{i}').equal(1)
+
+    waitForRdbSaveToFinish(env)
+    env.expect('CONFIG', 'SET', 'rdb-key-save-delay', '10000').ok()
+    try:
+        env.cmd('BGSAVE')
+        env.assertEqual(int(env.cmd('INFO', 'Persistence')['rdb_bgsave_in_progress']), 1)
+        # Not forceInvokeGC(): it waits the bgsave out, which is the contention under test.
+        env.expect(debug_cmd(), 'GC_FORCEINVOKE', 'idx').equal('DONE')
+        env.assertGreater(int(to_dict(index_info(env)['gc_stats'])['bytes_collected']), 0)
+    finally:
+        env.cmd('CONFIG', 'SET', 'rdb-key-save-delay', '0')
+        waitForRdbSaveToFinish(env)

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -1029,6 +1029,47 @@ def waitForSyncPoint(env, name, message, timeout=30):
         message, timeout=timeout)
 
 
+def indexWithCollectableDocs(env):
+    """An index with 50 deleted docs to collect and 50 live keys. The live half is what lets a
+    delayed bgsave keep holding the fork slot, and GC_STOP_SCHEDULE leaves a forced cycle as
+    the only one that can reach the sync points below."""
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
+    for i in range(100):
+        env.expect('HSET', f'doc{i}', 't', 'hello').equal(1)
+    for i in range(50):
+        env.expect('DEL', f'doc{i}').equal(1)
+    waitForRdbSaveToFinish(env)
+
+
+def parkedForcedGC(env, timeout=None):
+    """Start GC_FORCEINVOKE, which blocks, on its own connection, and return once its cycle is
+    parked before the fork -- so the caller can take the slot out from under it. The returned
+    dict gains 'reply' or 'error' once the thread finishes."""
+    conn = env.getConnection()
+    result = {}
+    args = [debug_cmd(), 'GC_FORCEINVOKE', 'idx'] + ([timeout] if timeout is not None else [])
+
+    def run():
+        try:
+            result['reply'] = conn.execute_command(*args)
+        except Exception as e:
+            result['error'] = str(e)
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    waitForSyncPoint(env, SYNC_POINT_GC_BEFORE_FORK,
+                     'Timeout waiting for the forced GC to reach the pre-fork sync point')
+    return thread, result
+
+
+def holdForkSlot(env, key_delay_us):
+    """Take Redis's single child slot with a bgsave slowed to key_delay_us per key saved."""
+    env.expect('CONFIG', 'SET', 'rdb-key-save-delay', str(key_delay_us)).ok()
+    env.cmd('BGSAVE')
+    env.assertEqual(int(env.cmd('INFO', 'Persistence')['rdb_bgsave_in_progress']), 1)
+
+
 @skip(cluster=True)
 def testForcedGCWaitsForForkSlot():
     """A forced GC replying DONE has to mean it collected. Parking the cycle before its fork lets
@@ -1036,34 +1077,14 @@ def testForcedGCWaitsForForkSlot():
     proves the EEXIST retry ran rather than the cycle winning the slot on a lucky schedule."""
     env = Env()
     skipIfNoEnableAssert(env)
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
-    # Leaves the forced cycle below as the only one that can reach the sync points.
-    env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
-    for i in range(100):
-        env.expect('HSET', f'doc{i}', 't', 'hello').equal(1)
-    # rdb-key-save-delay is charged per key saved, so the undeleted half is what keeps the
-    # child holding the slot while the cycle wakes up and tries to fork.
-    for i in range(50):
-        env.expect('DEL', f'doc{i}').equal(1)
-
-    waitForRdbSaveToFinish(env)
+    indexWithCollectableDocs(env)
     env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
     env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', SYNC_POINT_GC_BEFORE_FORK, 10000).ok()
     env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', SYNC_POINT_GC_FORK_SLOT_BUSY, 10000).ok()
 
-    # GC_FORCEINVOKE blocks until the cycle ends, so it needs its own connection.
-    conn = env.getConnection()
-    forced = {}
-    thread = threading.Thread(target=lambda: forced.update(
-        reply=conn.execute_command(debug_cmd(), 'GC_FORCEINVOKE', 'idx')))
-    thread.start()
+    thread, forced = parkedForcedGC(env)
     try:
-        waitForSyncPoint(env, SYNC_POINT_GC_BEFORE_FORK,
-                         'Timeout waiting for the forced GC to reach the pre-fork sync point')
-
-        env.expect('CONFIG', 'SET', 'rdb-key-save-delay', '20000').ok()
-        env.cmd('BGSAVE')
-        env.assertEqual(int(env.cmd('INFO', 'Persistence')['rdb_bgsave_in_progress']), 1)
+        holdForkSlot(env, 20000)
         env.cmd(debug_cmd(), 'SYNC_POINT', 'SIGNAL', SYNC_POINT_GC_BEFORE_FORK)
 
         # The cycle only parks here after a fork failed with EEXIST, so arriving is the
@@ -1086,36 +1107,16 @@ def testForcedGCReportsWhenItCannotFork():
     bug at a longer timescale: a collection reported but never made."""
     env = Env()
     skipIfNoEnableAssert(env)
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
-    env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
-    for i in range(100):
-        env.expect('HSET', f'doc{i}', 't', 'hello').equal(1)
-    for i in range(50):
-        env.expect('DEL', f'doc{i}').equal(1)
-
-    waitForRdbSaveToFinish(env)
+    indexWithCollectableDocs(env)
     env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
     env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', SYNC_POINT_GC_BEFORE_FORK, 10000).ok()
 
-    conn = env.getConnection()
-    forced = {}
-
-    def run():
-        try:
-            forced['reply'] = conn.execute_command(debug_cmd(), 'GC_FORCEINVOKE', 'idx', 100)
-        except Exception as e:
-            forced['error'] = str(e)
-
-    thread = threading.Thread(target=run)
-    thread.start()
+    # A TIMEOUT this short is the interesting case: the retry interval is longer than the whole
+    # budget, so the wait has to be cut to what is left. Sleeping a full interval instead would
+    # let the block timeout answer first, with INVOCATION FAILED.
+    thread, forced = parkedForcedGC(env, timeout=100)
     try:
-        waitForSyncPoint(env, SYNC_POINT_GC_BEFORE_FORK,
-                         'Timeout waiting for the forced GC to reach the pre-fork sync point')
-        # A TIMEOUT this short is the interesting case: the retry interval is longer than the
-        # whole budget, so the wait has to be cut to what is left. Sleeping a full interval
-        # instead would let the block timeout answer first, with INVOCATION FAILED.
-        env.expect('CONFIG', 'SET', 'rdb-key-save-delay', '30000').ok()
-        env.cmd('BGSAVE')
+        holdForkSlot(env, 30000)
         env.cmd(debug_cmd(), 'SYNC_POINT', 'SIGNAL', SYNC_POINT_GC_BEFORE_FORK)
     finally:
         thread.join(timeout=60)

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -743,6 +743,7 @@ def testForkGCEmptyTextSuffixTrie_emptyValue():
 # a real in-flight run instead of racing one.
 SYNC_POINT_GC_TASK_START = 'GCTaskStart'  # src/debug_commands.h
 SYNC_POINT_GC_BEFORE_FORK = 'GCBeforeFork'  # src/debug_commands.h
+SYNC_POINT_GC_FORK_SLOT_BUSY = 'GCForkSlotBusy'  # src/debug_commands.h
 
 
 def gcCycles(env, idx):
@@ -913,25 +914,33 @@ def testGCTerminatesAfterDropWhileStopped(env):
     wait_for_condition(lambda: (logically_deleted() == 0, {'not_collected': logically_deleted()}),
                        'stopped GC never terminated after its index was dropped', timeout=30)
 
+def waitForSyncPoint(env, name, message, timeout=30):
+    wait_for_condition(
+        lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING', name) == 1, {}),
+        message, timeout=timeout)
+
+
 @skip(cluster=True)
 def testForcedGCWaitsForForkSlot():
     """A forced GC replying DONE has to mean it collected. Parking the cycle before its fork lets
-    a bgsave take the only child slot first, so the EEXIST retry is exercised rather than raced."""
+    a bgsave take the only child slot first, and parking it again after the failed fork is what
+    proves the EEXIST retry ran rather than the cycle winning the slot on a lucky schedule."""
     env = Env()
     skipIfNoEnableAssert(env)
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
-    # Leaves the forced cycle below as the only one that can reach the sync point.
+    # Leaves the forced cycle below as the only one that can reach the sync points.
     env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
     for i in range(100):
         env.expect('HSET', f'doc{i}', 't', 'hello').equal(1)
-    # rdb-key-save-delay is charged per key saved, so the undeleted half is what makes the
-    # child outlive the first fork attempt.
+    # rdb-key-save-delay is charged per key saved, so the undeleted half is what keeps the
+    # child holding the slot while the cycle wakes up and tries to fork.
     for i in range(50):
         env.expect('DEL', f'doc{i}').equal(1)
 
     waitForRdbSaveToFinish(env)
     env.cmd(debug_cmd(), 'SYNC_POINT', 'CLEAR')
     env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', SYNC_POINT_GC_BEFORE_FORK, 10000).ok()
+    env.expect(debug_cmd(), 'SYNC_POINT', 'ARM', SYNC_POINT_GC_FORK_SLOT_BUSY, 10000).ok()
 
     # GC_FORCEINVOKE blocks until the cycle ends, so it needs its own connection.
     conn = env.getConnection()
@@ -940,15 +949,19 @@ def testForcedGCWaitsForForkSlot():
         reply=conn.execute_command(debug_cmd(), 'GC_FORCEINVOKE', 'idx')))
     thread.start()
     try:
-        wait_for_condition(
-            lambda: (env.cmd(debug_cmd(), 'SYNC_POINT', 'IS_WAITING',
-                             SYNC_POINT_GC_BEFORE_FORK) == 1, {}),
-            'Timeout waiting for the forced GC to reach the pre-fork sync point')
+        waitForSyncPoint(env, SYNC_POINT_GC_BEFORE_FORK,
+                         'Timeout waiting for the forced GC to reach the pre-fork sync point')
 
-        env.expect('CONFIG', 'SET', 'rdb-key-save-delay', '10000').ok()
+        env.expect('CONFIG', 'SET', 'rdb-key-save-delay', '20000').ok()
         env.cmd('BGSAVE')
         env.assertEqual(int(env.cmd('INFO', 'Persistence')['rdb_bgsave_in_progress']), 1)
         env.cmd(debug_cmd(), 'SYNC_POINT', 'SIGNAL', SYNC_POINT_GC_BEFORE_FORK)
+
+        # The cycle only parks here after a fork failed with EEXIST, so arriving is the
+        # assertion that the retry path ran.
+        waitForSyncPoint(env, SYNC_POINT_GC_FORK_SLOT_BUSY,
+                         'forced GC never hit a busy fork slot')
+        env.cmd(debug_cmd(), 'SYNC_POINT', 'SIGNAL', SYNC_POINT_GC_FORK_SLOT_BUSY)
     finally:
         thread.join(timeout=60)
         env.cmd('CONFIG', 'SET', 'rdb-key-save-delay', '0')


### PR DESCRIPTION
## Describe the changes in the pull request

**Current.** Redis runs one child process at a time, so while a BGSAVE, AOF rewrite or replication fork is active, `RedisModule_Fork` fails with `EEXIST`. `FGC_RunCycle` treats that as "skip this cycle" — so `FT.DEBUG GC_FORCEINVOKE` replies `DONE` having collected nothing, indistinguishable from a cycle that ran and found nothing to collect. A preceding `waitForRdbSaveToFinish()` cannot close it: the save can begin between the poll and the fork.

It surfaces as assertions on an index a forced GC was supposed to have cleaned — `dump_tagidx` still listing terms whose documents are all deleted, or `gc_stats.bytes_collected` stuck at `0`.

**Change.** Such a cycle now retries the fork while it fails with `EEXIST`, bounded by `GC_FORK_SLOT_ATTEMPTS × GC_FORK_SLOT_BACKOFF_NS` (5s, inside the command's 30s default timeout). A scheduled cycle still skips: its next run is due anyway, and the GIL is better left to the child in flight. Neither the GIL nor the memory verdict is held across the wait — the child being waited on needs the main thread, and its exit is what makes an earlier `isOutOfMemory()` answer stale, so that check moved inside the loop.

`force` is renamed `debugForced`, which is what it has always meant: `GC_FORCEINVOKE` and `GC_FORCEBGINVOKE` are its only callers (`gc.c` `debugTaskCallback` is the sole `true` call site). That name is what confines the wait to them.

**Outcome.** A forced collection either collects, or logs the existing warning after a bounded wait instead of instantly claiming success.

`testForcedGCWaitsForForkSlot` pins it without depending on a race: it holds the slot with `rdb-key-save-delay` charged over the documents it deliberately leaves behind, asserts the save really is in flight, and requires the collection to still happen. Against the previous code it fails with `0 > 0` — verified by reverting only `src/` and rebuilding.

Verified: 971 C/C++ unit tests, `test_gc.py`, `test_debug_commands.py`, `test_tags.py`.

#### Which additional issues this PR fixes

No ticket linked yet — needs a MOD number before merge.

#### Main objects this PR modified

1. `FGC_RunCycle` (`src/fork_gc/fork_gc.c`) — the behaviour change
2. `GCCallbacks::periodicCallback` (`src/gc.h`), plus `fork_gc.h` / `disk_gc.c` — the `force` → `debugForced` rename

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
