### PR TITLE
[MOD-17519] SpellcheckDictionary - automaton-backed queries

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2862,7 +2862,6 @@ dependencies = [
  "proptest",
  "rstest",
  "string_utils",
- "strsim",
  "trie_rs",
  "workspace_hack",
 ]
@@ -2897,12 +2896,6 @@ checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
 dependencies = [
  "vte",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -214,7 +214,6 @@ rustc-hash = "2.1.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 smallvec = "1.15.1"
-strsim = "0.11.1"
 strum = { version = "0.27.2", features = ["derive"] }
 syn = "2"
 # need "unstable" for the "default_log_filter" attribute allowing to override the default level (info).

--- a/src/redisearch_rs/spellcheck_dictionary/Cargo.toml
+++ b/src/redisearch_rs/spellcheck_dictionary/Cargo.toml
@@ -10,7 +10,6 @@ workspace = true
 
 [dependencies]
 ffi.workspace = true
-strsim.workspace = true
 string_utils.workspace = true
 trie_rs.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/spellcheck_dictionary/src/lib.rs
+++ b/src/redisearch_rs/spellcheck_dictionary/src/lib.rs
@@ -14,12 +14,14 @@
 //!
 //! Terms are stored verbatim. [`SpellCheckDictionary::contains`] and
 //! [`SpellCheckDictionary::fuzzy_matches`] are case-insensitive — the query
-//! and each candidate are lowercased via [`unicode::tolower_cow`] before comparison
-//! — but [`SpellCheckDictionary::remove`] matches verbatim and is therefore
+//! and each candidate are lowercased per-codepoint before comparison — but
+//! [`SpellCheckDictionary::remove`] matches verbatim and is therefore
 //! case-sensitive.
 //!
-//! Because matching lowercases verbatim-stored keys, those two queries scan
-//! every stored term rather than exploiting the trie's prefix structure.
+//! Both queries run as streaming-automaton trie descents (see
+//! [`StrTrieMap::case_insensitive_iter`] and [`StrTrieMap::fuzzy_iter`]),
+//! folding stored codepoints during the walk and pruning subtrees that can
+//! no longer match.
 
 // Public methods link the private length constants rather than duplicate their
 // rationale in prose.
@@ -109,9 +111,7 @@ impl SpellCheckDictionary {
         let Some(needle) = unicode::tolower_capped(term, TRIE_MAX_PREFIX) else {
             return false;
         };
-        self.trie
-            .iter()
-            .any(|(key, _)| *unicode::tolower_cow(&key) == *needle)
+        self.trie.case_insensitive_iter(&needle).next().is_some()
     }
 
     /// Find stored terms within Levenshtein edit distance `max_dist`
@@ -121,12 +121,9 @@ impl SpellCheckDictionary {
     /// Returns an iterator over the matching terms, each in its stored case.
     pub fn fuzzy_matches(&self, term: &str, max_dist: u32) -> impl Iterator<Item = String> + '_ {
         let needle = unicode::tolower_capped(term, TRIE_MAX_PREFIX);
-        needle.into_iter().flat_map(move |needle| {
-            self.trie.iter().filter_map(move |(key, _)| {
-                let dist = strsim::levenshtein(&unicode::tolower_cow(&key), &needle) as u32;
-                (dist <= max_dist).then_some(key)
-            })
-        })
+        needle
+            .into_iter()
+            .flat_map(move |needle| self.trie.fuzzy_iter(&needle, max_dist).map(|(key, _)| key))
     }
 }
 


### PR DESCRIPTION
Performance is out of scope for this PR, will be handled later.

## Describe the changes in the pull request

1. **Current**: `SpellCheckDictionary::contains` and `SpellCheckDictionary::fuzzy_matches` were
   full-corpus scans. Every stored key was materialized and case-folded on every query, so cost
   grew with the size of the dictionary rather than with the part of it that could possibly match.
2. **Change**: Both are rewritten as pruned automaton descents over the `StrTrieMap` — `contains`
   through `case_insensitive_iter`, `fuzzy_matches` through `fuzzy_iter` — folding stored
   codepoints during the walk and cutting off subtrees that can no longer match. The `strsim`
   dependency goes away with the scan.
3. **Outcome**: Query cost now tracks the visited subtree instead of the whole corpus, with no
   change in observable behavior.

This is a refactor, not a behavior change. Matching was already defined in codepoints on both
sides: `tolower_cow` folds per codepoint, and the edit distance it fed counted `char` edits, which
is what the automatons do. The tests pinning those semantics are untouched by this PR — the
proptest oracle cross-checks against an independent naive Levenshtein over codepoints, and the
non-ASCII unit tests cover per-codepoint lowering and the lowercased-length cutoff.

The crate is workspace-only at this point (no FFI or C consumer yet), so there is no user-visible
surface either way.

#### Which additional issues this PR fixes
1. None

#### Main objects this PR modified
1. `SpellCheckDictionary::contains` and `SpellCheckDictionary::fuzzy_matches`
   (`src/redisearch_rs/spellcheck_dictionary/src/lib.rs`)
2. Workspace dependencies: `strsim` removed (`src/redisearch_rs/Cargo.toml`, `Cargo.lock`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
