### PR TITLE
TermSuffixIndex - small changes

### DIFF
--- a/src/redisearch_rs/c_entrypoint/term_suffix_index_ffi/src/index.rs
+++ b/src/redisearch_rs/c_entrypoint/term_suffix_index_ffi/src/index.rs
@@ -43,7 +43,9 @@ pub unsafe extern "C" fn TermSuffixIndex_Free(tsi: *mut TermSuffixIndex) {
 
 /// Add `term` (`len` UTF-8 bytes) to the index. Adding an existing or
 /// empty term is a no-op, as is adding a term whose lowercased form
-/// exceeds `u16::MAX` bytes — the trie cannot represent such a key.
+/// exceeds `u16::MAX` bytes: it is skipped rather than inserted, since
+/// a single trie node label holds at most that many bytes and insertion
+/// would otherwise risk a panic.
 ///
 /// Matching is case-insensitive: `term` is lowercased before insertion,
 /// so subsequent lookups and removals are case-insensitive too.

--- a/src/redisearch_rs/headers/term_suffix_index_ffi.h
+++ b/src/redisearch_rs/headers/term_suffix_index_ffi.h
@@ -92,7 +92,9 @@ int TermSuffixIndexIterator_Next(struct TermSuffixIndexIterator *it, const char 
 /**
  * Add `term` (`len` UTF-8 bytes) to the index. Adding an existing or
  * empty term is a no-op, as is adding a term whose lowercased form
- * exceeds `u16::MAX` bytes — the trie cannot represent such a key.
+ * exceeds `u16::MAX` bytes: it is skipped rather than inserted, since
+ * a single trie node label holds at most that many bytes and insertion
+ * would otherwise risk a panic.
  *
  * Matching is case-insensitive: `term` is lowercased before insertion,
  * so subsequent lookups and removals are case-insensitive too.

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -187,10 +187,10 @@ impl TermSuffixIndex {
     /// Matching is [case-insensitive](crate#case-insensitivity). Empty
     /// `needle` yields nothing.
     pub fn iter_suffix(&self, needle: &str) -> impl Iterator<Item = &str> {
-        let lowered = unicode::tolower_cow(needle);
-        let data = if lowered.is_empty() {
+        let data = if needle.is_empty() {
             None
         } else {
+            let lowered = unicode::tolower_cow(needle);
             self.inner.get(&lowered)
         };
         data.into_iter()

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -103,7 +103,7 @@ impl TermSuffixIndex {
         }
 
         let lowered = unicode::tolower_cow(term);
-        let term: &str = &lowered;
+        let term = &lowered;
 
         if term.len() > MAX_TERM_BYTE_LEN {
             return;
@@ -113,7 +113,7 @@ impl TermSuffixIndex {
             return;
         }
 
-        let owner = Arc::from(term);
+        let owner = Arc::from(term as &str);
         self.inner.insert_with(term, |existing| {
             TermRefs::upsert_full_term(existing, Arc::clone(&owner))
         });

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -57,9 +57,12 @@ const _: () = assert!(
     "the poll window divides the candidate count"
 );
 
-/// Longest addable term, in bytes, after lowercasing. The underlying
-/// trie stores node labels with `u16` lengths, so a longer key cannot
-/// be represented and would panic on insert.
+/// Longest addable term, in bytes, after lowercasing. The bound is on
+/// the term, not on the trie: node labels carry a `u16` length and a
+/// label is always a substring of some inserted key, so a term within
+/// this bound can never force an oversized label. A longer term can,
+/// depending on which keys are already stored, and insertion would
+/// panic the moment one node had to hold more than `u16::MAX` bytes.
 const MAX_TERM_BYTE_LEN: usize = u16::MAX as usize;
 
 #[derive(Default)]
@@ -91,7 +94,9 @@ impl TermSuffixIndex {
     /// queryable suffix. [Lowercased on entry](crate#case-insensitivity);
     /// re-adding an existing term, or adding an empty one, is a no-op.
     /// So is adding a term whose lowercased form exceeds `u16::MAX`
-    /// bytes — the trie cannot represent such a key.
+    /// bytes: it is skipped rather than inserted, since a single trie
+    /// node label holds at most that many bytes and insertion would
+    /// otherwise risk a panic.
     pub fn add(&mut self, term: &str) {
         if term.is_empty() {
             return;

--- a/src/redisearch_rs/term_suffix_index/src/lib.rs
+++ b/src/redisearch_rs/term_suffix_index/src/lib.rs
@@ -169,8 +169,6 @@ impl TermSuffixIndex {
     /// `needle` yields nothing. A term may be yielded more than once
     /// (once per matching suffix entry).
     pub fn iter_contains(&self, needle: &str) -> impl Iterator<Item = &str> {
-        // An empty needle denotes no term here, but to the trie it is a
-        // prefix of every key.
         let subtree = if needle.is_empty() {
             None
         } else {

--- a/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
+++ b/src/redisearch_rs/term_suffix_index/tests/integration/term_suffix_index.rs
@@ -30,8 +30,8 @@ fn add_promotes_existing_suffix_only_node_to_full_term() {
 #[test]
 #[cfg_attr(miri, ignore = "Takes too long with Miri, causing CI to timeout")]
 fn add_term_longer_than_u16_max_bytes_is_noop() {
-    // Trie node labels store their length as `u16`; an unrepresentable
-    // term must be skipped, not panic.
+    // Trie node labels store their length as `u16`; a term that could
+    // force an oversized label must be skipped, not panic.
     let mut sut = TermSuffixIndex::new();
 
     sut.add(&"a".repeat(u16::MAX as usize + 1));


### PR DESCRIPTION
Some small non-behavioral changes for `TermSuffixIndex`.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
