### PR TITLE
[CI] Rebalance 16-primary weekly benchmarks

### DIFF
--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -334,7 +334,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        member_id: [1, 2, 3]
+        member_id: [1, 2, 3, 4]
     uses: ./.github/workflows/benchmark-flow.yml
     secrets: inherit
     with:

--- a/tests/benchmarks/search-expire-doc-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-doc-10-milliseconds.yml
@@ -4,6 +4,7 @@ description: |
   TTL table benchmark for document expiration under heavy lookup pressure.
   This variant focuses on lazy expiration by disabling active expiration so
   documents stay in the dataset while expiration metadata churns.
+timeout_seconds: 2700
 
 metadata:
   component: "search"

--- a/tests/benchmarks/search-expire-doc-1000-seconds.yml
+++ b/tests/benchmarks/search-expire-doc-1000-seconds.yml
@@ -4,6 +4,7 @@ description: |
   TTL table benchmark for document expiration with long TTL values.
   This keeps keys in the dataset and stresses lookup behavior while expiration
   metadata is updated continuously.
+timeout_seconds: 3000
 
 metadata:
   component: "search"

--- a/tests/benchmarks/search-expire-numeric-field-10-milliseconds.yml
+++ b/tests/benchmarks/search-expire-numeric-field-10-milliseconds.yml
@@ -4,6 +4,7 @@ description: |
   TTL table benchmark for field-level expiration under heavy lookup pressure.
   This variant focuses on lazy expiration by disabling active expiration so
   indexed keys remain while field expiration metadata churns.
+timeout_seconds: 2100
 
 metadata:
   component: "search"

--- a/tests/benchmarks/search-expire-numeric-field-1000-seconds.yml
+++ b/tests/benchmarks/search-expire-numeric-field-1000-seconds.yml
@@ -4,6 +4,7 @@ description: |
   TTL table benchmark for field-level expiration with long TTL values.
   This keeps keys available to search and stresses lookup behavior while
   field expiration metadata is updated continuously.
+timeout_seconds: 2700
 
 metadata:
   component: "search"


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: The weekly 16-primary benchmark splits files across three runners without accounting for topology applicability or observed duration. One shard recently ran past its calculated remote-infrastructure lifetime and lost SSH connectivity near the end.
2. Change: Split the 16-primary search benchmarks across four runners and give four observed long-running expiration scenarios realistic infrastructure timeout budgets.
3. Outcome: Reduce per-shard work and keep remote benchmark hosts alive long enough for the expensive expiration scenarios to finish.

### Successful Run
https://github.com/RediSearch/RediSearch/actions/runs/31359920082

#### Which additional issues this PR fixes
1. None.

#### Main objects this PR modified
1. The 16-primary benchmark runner matrix.
2. Remote infrastructure timeout metadata for long-running expiration benchmarks.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
