### PR TITLE
[MOD-17537] Bound the rune decode by its output capacity

### DIFF
--- a/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
@@ -303,17 +303,18 @@ impl CTrieRef {
             return 0;
         }
 
-        // A UTF-8 string yields at most as many runes as bytes; the extra slot
-        // leaves room for the conversion to write a trailing rune.
+        // A UTF-8 string yields at most as many runes as bytes, so the decode
+        // cannot truncate and `rlen` below indexes within `runes`. The extra
+        // slot keeps the pointer non-dangling for an empty term.
         let mut runes = vec![0 as ffi::rune; term.len() + 1];
         // SAFETY: `term` is valid UTF-8 of `term.len()` bytes, so the decode
-        // stays within the slice, and `runes` has room for `term.len() + 1`
-        // runes, so the conversion writes within bounds.
+        // stays within the slice, and `runes.len()` bounds the write.
         let rlen = unsafe {
-            ffi::strToRunesN(
+            ffi::strToRunes(
                 term.as_ptr() as *const c_char,
                 term.len(),
                 runes.as_mut_ptr(),
+                runes.len(),
             )
         };
         // SAFETY: `self.ptr` is a valid `Trie` (`CTrieRef` invariant); `runes`/

--- a/src/redisearch_rs/c_wrappers/c_trie/tests/iterate.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/tests/iterate.rs
@@ -30,12 +30,19 @@ use ffi::{SuffixType, SuffixType_SUFFIX_TYPE_CONTAINS, SuffixType_SUFFIX_TYPE_SU
 
 /// Convert an ASCII/UTF-8 string to the trie's rune (`u16`) key.
 fn to_runes(s: &str) -> Vec<ffi::rune> {
-    // A UTF-8 string decodes to at most as many runes as bytes; the extra slot
-    // gives the conversion room for a trailing rune.
-    let mut buf = vec![0 as ffi::rune; s.len() + 1];
+    // A UTF-8 string decodes to at most as many runes as bytes, so the decode
+    // cannot truncate and `n` is a valid truncation point.
+    let mut buf = vec![0 as ffi::rune; s.len()];
     // SAFETY: `s` is valid UTF-8 of `s.len()` bytes, so the decode stays within
-    // the slice, and `buf` has room for `s.len() + 1` runes.
-    let n = unsafe { ffi::strToRunesN(s.as_ptr().cast::<c_char>(), s.len(), buf.as_mut_ptr()) };
+    // the slice, and `buf.len()` bounds the write.
+    let n = unsafe {
+        ffi::strToRunes(
+            s.as_ptr().cast::<c_char>(),
+            s.len(),
+            buf.as_mut_ptr(),
+            buf.len(),
+        )
+    };
     buf.truncate(n);
     buf
 }

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -403,7 +403,7 @@ const HEADERS: &[HeaderAllowlist] = &[
     },
     HeaderAllowlist {
         path: "src/trie/rune_util.h",
-        fns: &["runesToStr", "strToLowerRunes", "strToRunesN"],
+        fns: &["runesToStr", "strToLowerRunes", "strToRunes"],
         types: &[],
         vars: &["MAX_RUNE_STR_LEN"],
     },

--- a/src/trie/rune_util.c
+++ b/src/trie/rune_util.c
@@ -127,7 +127,7 @@ rune *strToSingleCodepointFoldedRunes(const char *str, size_t utf8_len, size_t *
   return ret;
 }
 
-size_t strToRunesN(const char *src, size_t slen, rune *out) {
+size_t strToRunes(const char *src, size_t slen, rune *out, size_t outcap) {
   const char *end = src + slen;
   size_t nout = 0;
   while (src < end) {
@@ -136,7 +136,11 @@ size_t strToRunesN(const char *src, size_t slen, rune *out) {
     if (cp == 0) {
       break;
     }
-    out[nout++] = (rune)cp;
+    // Keep counting past `outcap` so the caller can detect truncation.
+    if (nout < outcap) {
+      out[nout] = (rune)cp;
+    }
+    nout++;
   }
   return nout;
 }

--- a/src/trie/rune_util.h
+++ b/src/trie/rune_util.h
@@ -67,8 +67,11 @@ rune *strToLowerRunes(const char *str, size_t utf8_len, size_t *unicode_len);
  *   May be NULL. */
 rune *strToSingleCodepointFoldedRunes(const char *str, size_t utf8_len, size_t *len);
 
-/* Decode a string to a rune in-place */
-size_t strToRunesN(const char *s, size_t slen, rune *outbuf);
+/* Decode `slen` bytes of UTF-8 from `src` into the caller-supplied `out`,
+ * writing at most `outcap` runes and never NUL-terminating. Decoding stops
+ * early at an embedded NUL. Returns the input's full rune count, which exceeds
+ * `outcap` when the output was truncated. */
+size_t strToRunes(const char *src, size_t slen, rune *out, size_t outcap);
 
 static inline rune *runeBufFill(const char *s, size_t n, runeBuf *buf, size_t *len) {
   /**
@@ -83,7 +86,7 @@ static inline rune *runeBufFill(const char *s, size_t n, runeBuf *buf, size_t *l
     buf->isDynamic = 0;
     target = buf->u.s;
   }
-  *len = strToRunesN(s, n, target);
+  *len = strToRunes(s, n, target, n);
   target[*len] = 0;
   return target;
 }

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <functional>
 #include <cstdint>
+#include <iterator>  // std::size
 
 typedef std::set<std::string> ElemSet;
 
@@ -65,8 +66,8 @@ static ElemSet trieIterRange(Trie *t, const char *begin, size_t nbegin, const ch
   rune *r1Ptr = r1;
   rune *r2Ptr = r2;
 
-  nr1 = strToRunes(begin, nbegin, r1, sizeof(r1) / sizeof(*r1));
-  nr2 = strToRunes(end, nend, r2, sizeof(r2) / sizeof(*r2));
+  nr1 = strToRunes(begin, nbegin, r1, std::size(r1));
+  nr2 = strToRunes(end, nend, r2, std::size(r2));
 
   if (!begin) {
     r1Ptr = NULL;

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -65,8 +65,8 @@ static ElemSet trieIterRange(Trie *t, const char *begin, size_t nbegin, const ch
   rune *r1Ptr = r1;
   rune *r2Ptr = r2;
 
-  nr1 = strToRunesN(begin, nbegin, r1);
-  nr2 = strToRunesN(end, nend, r2);
+  nr1 = strToRunes(begin, nbegin, r1, sizeof(r1) / sizeof(*r1));
+  nr2 = strToRunes(end, nend, r2, sizeof(r2) / sizeof(*r2));
 
   if (!begin) {
     r1Ptr = NULL;


### PR DESCRIPTION
## Describe the changes in the pull request

~> Stacked on #10830 — review that one first; this PR's diff is the single commit on top.~
> Followed by #10832

1. **Current**: `strToRunesN(src, slen, out)` decoded into a caller-supplied buffer with
   no capacity argument. The requirement that `out` hold at least `slen` runes lived only
   in prose — restated in two Rust `SAFETY` comments and absent at the C++ call site,
   where `trieIterRange` decoded caller-supplied bytes into a fixed 256-rune stack array.
   The declaration's comment read "Decode a string to a rune in-place", which was never
   true: source and destination are distinct buffers of different element types.
2. **Change**: add an `outcap` parameter with `snprintf` semantics — write at most
   `outcap` runes, return the input's full rune count so truncation is detectable. Take
   the plain name `strToRunes`, freed by the parent PR; the `N` suffix followed libnu's
   convention of bounding the *source* (`nu_readnstr`, `nu_strnlen`) and would have read
   as the opposite of the new destination bound. The arity changed from 3 to 4, so any
   caller missed by the rename fails to compile rather than silently changing meaning.
   Replace the wrong comment with the actual contract.
3. **Outcome**: the output buffer cannot overflow, and the capacity contract is enforced
   by the signature rather than by comments at each call site.

Verified against RediSearchEnterprise: no references to the old name there.

#### Which additional issues this PR fixes
1. MOD-17537

#### Main objects this PR modified
1. `strToRunes` — `src/trie/rune_util.c`, `src/trie/rune_util.h`
2. `runeBufFill` — `src/trie/rune_util.h`
3. `c_trie` — `src/redisearch_rs/c_wrappers/c_trie/`
4. `src/redisearch_rs/ffi/build.rs`
5. `tests/cpptests/test_cpp_trie.cpp`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
