### PR TITLE
[MOD-17537] Make the runesToStr output-length contract consistent

### DIFF
--- a/src/trie/rune_util.c
+++ b/src/trie/rune_util.c
@@ -35,7 +35,7 @@ rune runeFold(rune r) {
 
 char *runesToStr(const rune *in, size_t len, size_t *utflen) {
   if (len > MAX_RUNE_STR_LEN) {
-    if (utflen) *utflen = 0;
+    *utflen = 0;
     return NULL;
   }
 

--- a/src/trie/rune_util.h
+++ b/src/trie/rune_util.h
@@ -41,7 +41,13 @@ typedef rune (*runeTransform)(rune r);
 /* fold rune: assumes rune is of the correct size */
 rune runeFold(rune r);
 
-/* Convert a rune string to utf-8 characters */
+/* Convert a rune string to utf-8 characters. The caller owns the returned
+ * buffer. Returns NULL for an input longer than MAX_RUNE_STR_LEN runes.
+ * Parameters:
+ * - in: The input runes.
+ * - len: The number of runes in `in`.
+ * - utflen: A pointer to a size_t where the byte length of the result is
+ *   written. Must be non-NULL; it is set to 0 when NULL is returned. */
 char *runesToStr(const rune *in, size_t len, size_t *utflen);
 
 /* Convert a string to runes, lowercase them and return the transformed runes.


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `runesToStr` writes the byte length of its result through `utflen` on
   three paths. The over-length rejection guarded the pointer with `if (utflen)`; the
   allocation-failure path and the success path did not. A caller passing `NULL` would
   therefore survive the rejection and crash on the normal path — so the guard protected
   nothing while implying the parameter was optional.
2. **Change**: drop the guard and state the contract on the declaration instead, in the
   parameter-list style `strToLowerRunes` already uses: the caller owns the returned
   buffer, `NULL` comes back for an input longer than `MAX_RUNE_STR_LEN` runes, and
   `utflen` must be non-`NULL` and reads 0 when `NULL` is returned. No caller passes
   `NULL`.
3. **Outcome**: one stated contract instead of two contradictory ones.

#### Which additional issues this PR fixes
1. MOD-17537

#### Main objects this PR modified
1. `runesToStr` — `src/trie/rune_util.c`, `src/trie/rune_util.h`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
