### PR TITLE
[MOD-16334] FT.INFO PARTIAL to opt back into per-shard tolerance

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -305,6 +305,13 @@
         "name": "index",
         "type": "string",
         "summary": "Specifies the name of the index. The index must be created using `FT.CREATE`."
+      },
+      {
+        "name": "partial",
+        "type": "pure-token",
+        "token": "PARTIAL",
+        "optional": true,
+        "summary": "On a cluster, aggregate the shards that can report on the index instead of failing when one of them cannot. The reply then describes a subset of the shards."
       }
     ],
     "since": "1.0.0",

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -323,9 +323,16 @@ int SetFtInfoInfo(RedisModuleCommand *cmd) {
         .summary = "Specifies the name of the index. The index must be created using `FT.CREATE`.",
         .type = REDISMODULE_ARG_TYPE_STRING,
       },
+      {
+        .name = "partial",
+        .token = "PARTIAL",
+        .summary = "On a cluster, aggregate the shards that can report on the index instead of failing when one of them cannot. The reply then describes a subset of the shards.",
+        .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+      },
       {0}
     },
-    .arity = 2,
+    .arity = -2,
     .since = "1.0.0",
     .tips = "dont_cache",
   };

--- a/src/coord/info_command.c
+++ b/src/coord/info_command.c
@@ -410,7 +410,6 @@ static void generateFieldsReply(InfoFields *fields, RedisModule_Reply *reply, bo
 int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies) {
   // Summarize all aggregate replies
   InfoFields fields = { .indexError = IndexError_Init() };
-  size_t numErrored = 0;
   MRReply *firstError = NULL;
   RedisModuleCtx *ctx = MRCtx_GetRedisCtx(mc);
 
@@ -421,13 +420,10 @@ int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies) {
   RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
   QueryError error = QueryError_Default();
 
-  for (size_t ii = 0; ii < count; ++ii) {
+  for (size_t ii = 0; ii < count && !firstError; ++ii) {
     int type = MRReply_Type(replies[ii]);
     if (type == MR_REPLY_ERROR) {
-      numErrored++;
-      if (!firstError) {
-        firstError = replies[ii];
-      }
+      firstError = replies[ii];
       continue;
     }
 
@@ -444,7 +440,7 @@ int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies) {
   }
 
   // Now we've received all the replies.
-  if (numErrored == count) {
+  if (firstError) {
     // Reply with error
     MR_ReplyWithMRReply(reply, firstError);
   } else if (QueryError_HasError(&error)) {

--- a/src/coord/info_command.c
+++ b/src/coord/info_command.c
@@ -407,10 +407,11 @@ static void generateFieldsReply(InfoFields *fields, RedisModule_Reply *reply, bo
   RedisModule_Reply_MapEnd(reply);
 }
 
-int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies) {
+static int infoReplyReducer(struct MRCtx *mc, int count, MRReply **replies, bool partial) {
   // Summarize all aggregate replies
   InfoFields fields = { .indexError = IndexError_Init() };
   MRReply *firstError = NULL;
+  size_t numErrored = 0;
   RedisModuleCtx *ctx = MRCtx_GetRedisCtx(mc);
 
   if (count == 0) {
@@ -420,10 +421,13 @@ int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies) {
   RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
   QueryError error = QueryError_Default();
 
-  for (size_t ii = 0; ii < count && !firstError; ++ii) {
+  for (size_t ii = 0; ii < count && (partial || !firstError); ++ii) {
     int type = MRReply_Type(replies[ii]);
     if (type == MR_REPLY_ERROR) {
-      firstError = replies[ii];
+      if (!firstError) {
+        firstError = replies[ii];
+      }
+      numErrored++;
       continue;
     }
 
@@ -439,8 +443,9 @@ int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies) {
     }
   }
 
-  // Now we've received all the replies.
-  if (firstError) {
+  // Now we've received all the replies. In partial mode a shard that could not report is
+  // tolerated, so only an all-shards failure is fatal.
+  if (firstError && (!partial || numErrored == count)) {
     // Reply with error
     MR_ReplyWithMRReply(reply, firstError);
   } else if (QueryError_HasError(&error)) {
@@ -454,4 +459,12 @@ int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies) {
   cleanInfoReply(&fields);
   RedisModule_EndReply(reply);
   return REDISMODULE_OK;
+}
+
+int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies) {
+  return infoReplyReducer(mc, count, replies, false);
+}
+
+int InfoReplyReducerPartial(struct MRCtx *mc, int count, MRReply **replies) {
+  return infoReplyReducer(mc, count, replies, true);
 }

--- a/src/coord/info_command.h
+++ b/src/coord/info_command.h
@@ -14,3 +14,7 @@
 #include "rmr/reply.h"
 
 int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies);
+
+/* Reducer for FT.INFO ... PARTIAL: a shard that cannot report on the index is skipped and the
+ * remaining shards are aggregated. Only an all-shards failure is fatal. */
+int InfoReplyReducerPartial(struct MRCtx *mc, int count, MRReply **replies);

--- a/src/module.c
+++ b/src/module.c
@@ -4122,8 +4122,8 @@ int TagValsCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
 
 
 int InfoCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  if (argc != 2) {
-    // FT.INFO {index}
+  if (argc < 2 || argc > 3) {
+    // FT.INFO {index} [PARTIAL]
     return RedisModule_WrongArity(ctx);
   } else if (!SearchCluster_Ready()) {
     // Check that the cluster state is valid
@@ -4131,22 +4131,34 @@ int InfoCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
   }
   RS_AutoMemory(ctx);
 
+  bool partial = false;
+  if (argc == 3) {
+    const char *opt = RedisModule_StringPtrLen(argv[2], NULL);
+    if (strcasecmp(opt, "PARTIAL")) {
+      return RedisModule_ReplyWithErrorFormat(ctx, "Unknown argument `%s`", opt);
+    }
+    partial = true;
+  }
+
   VERIFY_ACL(ctx, argv[1])
 
   if (NumShards == 1) {
     // There is only one shard in the cluster. We can handle the command locally.
-    return IndexInfoCommand(ctx, argv, argc);
+    // Nothing is aggregated, so PARTIAL has nothing to tolerate.
+    return IndexInfoCommand(ctx, argv, 2);
   } else if (cannotBlockCtx(ctx)) {
     return ReplyBlockDeny(ctx, argv[0]);
   }
 
-  MRCommand cmd = MR_NewCommandFromRedisStrings(argc, argv);
+  // Only the index name goes to the shards: `_FT.INFO` reads WITH_INDEX_ERROR_TIME
+  // positionally from argv[2], so forwarding PARTIAL there would displace it.
+  MRCommand cmd = MR_NewCommandFromRedisStrings(2, argv);
   MRCommand_Append(&cmd, WITH_INDEX_ERROR_TIME, strlen(WITH_INDEX_ERROR_TIME));
   MRCommand_SetProtocol(&cmd, ctx);
   MRCommand_SetPrefix(&cmd, "_FT");
 
   struct MRCtx *mctx = MR_CreateCtx(ctx, 0, NULL, NumShards);
-  MR_Fanout(mctx, InfoReplyReducer, cmd, true);
+  MR_Fanout(mctx, partial ? InfoReplyReducerPartial : InfoReplyReducer, cmd, true);
   return REDISMODULE_OK;
 }
 

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -228,6 +228,39 @@ def test_index_missing_on_one_shard(env):
     env.expect('FT.MGET', index_name, 'doc1').error().contains(error_msg)
     env.expect('FT.DROP', index_name).error().contains(error_msg)
 
+@skip(cluster=False, min_shards=2)
+def test_info_partial(env):
+    """FT.INFO PARTIAL aggregates the shards that can report on the index instead of
+    failing when one of them cannot."""
+
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    for i in range(20):
+        conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}')
+
+    total_docs = int(index_info(env, 'idx')['num_docs'])
+    env.assertEqual(total_docs, 20)
+
+    last_conn = env.getConnection(0)
+    last_conn.execute_command('DEBUG', 'MARK-INTERNAL-CLIENT')
+    last_conn.execute_command('_FT.DROPINDEX', 'idx')
+
+    error_msg = 'SEARCH_INDEX_NOT_FOUND Index not found: idx'
+    env.expect('FT.INFO', 'idx').error().contains(error_msg)
+
+    # PARTIAL tolerates the shard that lost the index, and the counters shrink to match
+    # the shards that answered.
+    partial = to_dict(env.cmd('FT.INFO', 'idx', 'PARTIAL'))
+    env.assertLess(int(partial['num_docs']), total_docs)
+
+    # The index error section is still populated, i.e. the shard command keeps carrying
+    # its positional _WITH_INDEX_ERROR_TIME marker.
+    env.assertEqual(to_dict(partial['Index Errors'])['indexing failures'], 0)
+
+    env.expect('FT.INFO', 'idx', 'partial').noError()
+    env.expect('FT.INFO', 'idx', 'BOGUS').error().contains('Unknown argument')
+    env.expect('FT.INFO', 'idx', 'PARTIAL', 'EXTRA').error()
+
 @skip(cluster=False)
 def test_timeout():
     """Tests that timeouts are handled properly by the coordinator.

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -208,6 +208,7 @@ def test_index_missing_on_one_shard(env):
         env.assertContains(error_msg, str(e))
 
     # Query via the cluster connection
+    env.expect('FT.INFO', index_name).error().contains(error_msg)
     env.expect('FT.SEARCH', index_name, '*').error().contains(error_msg)
     env.expect('FT.AGGREGATE', index_name, '*').error().contains(error_msg)
     env.expect('FT.HYBRID', index_name, 'SEARCH', '*',


### PR DESCRIPTION
> **Stacked on #10771.** Base is `itzik-mod-16334-info-shard-coverage`, so the diff here is the opt-out alone. Review/merge #10771 first.

## Describe the changes in the pull request

1. **Current:** after #10771, `FT.INFO` fails whenever any shard cannot report on the index. That is the right default — a partial aggregate is indistinguishable from a complete one — but it is a breaking change for callers that would rather have the numbers from the shards that did answer.

2. **Change:** add an optional `PARTIAL` token — `FT.INFO {index} [PARTIAL]` — that restores the previous behavior: shards replying with an error are skipped, the rest are aggregated, and only an all-shards failure is fatal.

3. **Outcome:** the strict default stands, and callers who need the old semantics opt in explicitly rather than being broken by the upgrade.

```
FT.INFO idx            → error, if any shard is missing the index
FT.INFO idx PARTIAL    → aggregated reply from the shards that answered
```

The two modes are separate reducers over one shared implementation, so the flag needs no plumbing through `MRCtx`.

**One trap worth a reviewer's eye:** `PARTIAL` is deliberately *not* forwarded to the shards. `_FT.INFO` reads its `_WITH_INDEX_ERROR_TIME` marker positionally from `argv[2]` ([info/info_command.c:411](../blob/master/src/info/info_command.c#L411)), so forwarding the token would displace the marker and silently drop index-error timestamps from the reply. The shard command is built from the index name alone, and the test asserts the error section survives.

Single-shard clusters answer from the local reply builder, where nothing is aggregated, so `PARTIAL` has nothing to tolerate there.

#### Which additional issues this PR fixes
1. MOD-16334

#### Main objects this PR modified
1. `InfoCommandHandler` — argument parsing, reducer selection, `src/module.c`
2. `infoReplyReducer` / `InfoReplyReducerPartial` — `src/coord/info_command.{c,h}`
3. `SetFtInfoInfo` — arity `2` → `-2`, optional arg declared, `src/command_info/command_info.c`
4. `commands.json` — `PARTIAL` argument (pinned by `test_command_info.py`)

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

## Open question for reviewers

Is `PARTIAL` permanent, or a migration bridge tied to the target-version decision on MOD-16334? It matters, because whoever hits the new error first will reach for this flag, and if it is meant to be temporary that needs saying in the docs and the release note now rather than later.

Name is also up for debate — `ON_SHARD_ERROR FAIL|IGNORE` would match the existing `ON_TIMEOUT FAIL|RETURN` convention more closely, at the cost of verbosity. Renaming is a one-line change in three places.

## Testing

New `test_info_partial`: 3-shard cluster, index dropped on one shard, then asserts

- `FT.INFO` errors,
- `FT.INFO ... PARTIAL` succeeds with `num_docs` below the pre-drop total,
- the `Index Errors` section is still populated (the positional-`argv[2]` regression guard),
- the token is case-insensitive, an unknown token errors, and a trailing extra argument errors.

- Cluster, `SHARDS=3`: `test_coordinator.py test_resp3.py test_info.py test_info_modules.py test_command_info.py` — 103 passed, 0 failed.
- Standalone: `test_coordinator.py test_resp3.py test_info.py test_command_info.py` — 64 passed, 0 failed.
