### PR TITLE
Coordinator fanout preserves binary argument lengths

### DIFF
--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -507,45 +507,59 @@ static bool extractKnnOptimizationContext(specialCaseCtx *knnCtx, ProfileOptions
 static void buildMRCommand(RedisModuleString **argv, int argc, ProfileOptions profileOptions,
                            AREQDIST_UpstreamInfo *us, MRCommand *xcmd, IndexSpec *sp) {
   // We need to prepend the array with the command, index, and query that
-  // we want to use.
+  // we want to use. Lengths ride along so binary-capable arguments (the query,
+  // user-defined names) reach the shards without strlen truncation.
   const char **tmparr = array_new(const char *, array_len(us->serialized));
+  size_t *tmplens = array_new(size_t, array_len(us->serialized));
+#define APPEND_ARG(s, l)      \
+  do {                        \
+    array_append(tmparr, (s)); \
+    array_append(tmplens, (l)); \
+  } while (0)
+// The "" concatenation rejects anything that is not a string literal.
+#define APPEND_LITERAL(lit) APPEND_ARG((lit), sizeof("" lit "") - 1)
 
-  const char *index_name = RedisModule_StringPtrLen(argv[1], NULL);
+  size_t index_name_len;
+  const char *index_name = RedisModule_StringPtrLen(argv[1], &index_name_len);
 
   int profileArgs = getProfileArgs(profileOptions);
   if (profileOptions == EXEC_NO_FLAGS) {
-    array_append(tmparr, RS_AGGREGATE_CMD);                         // Command
-    array_append(tmparr, index_name);  // Index name
+    APPEND_LITERAL(RS_AGGREGATE_CMD);                 // Command
+    APPEND_ARG(index_name, index_name_len);        // Index name
   } else {
-    array_append(tmparr, RS_PROFILE_CMD);
-    array_append(tmparr, index_name);  // Index name
-    array_append(tmparr, "AGGREGATE");
+    APPEND_LITERAL(RS_PROFILE_CMD);
+    APPEND_ARG(index_name, index_name_len);        // Index name
+    APPEND_LITERAL("AGGREGATE");
     if (profileOptions & EXEC_WITH_PROFILE_LIMITED) {
-      array_append(tmparr, "LIMITED");
+      APPEND_LITERAL("LIMITED");
     }
-    array_append(tmparr, "QUERY");
+    APPEND_LITERAL("QUERY");
   }
 
-  array_append(tmparr, RedisModule_StringPtrLen(argv[2 + profileArgs], NULL));  // Query
-  array_append(tmparr, "WITHCURSOR");
+  size_t query_len;
+  const char *query = RedisModule_StringPtrLen(argv[2 + profileArgs], &query_len);
+  APPEND_ARG(query, query_len);  // Query
+  APPEND_LITERAL("WITHCURSOR");
   // Numeric responses are encoded as simple strings.
-  array_append(tmparr, "_NUM_SSTRING");
+  APPEND_LITERAL("_NUM_SSTRING");
 
   int argOffset = 0;
   // Preserve WITHCOUNT flag from the original command
   argOffset  = RMUtil_ArgIndex("WITHCOUNT", argv + 3 + profileArgs, argc - 3 - profileArgs);
   if (argOffset != -1) {
-    array_append(tmparr, "WITHCOUNT");
+    APPEND_LITERAL("WITHCOUNT");
   }
 
   // Add the index prefixes to the command, for validation in the shard
-  array_append(tmparr, "_INDEX_PREFIXES");
+  APPEND_LITERAL("_INDEX_PREFIXES");
   arrayof(HiddenUnicodeString*) prefixes = sp->rule->prefixes;
   char *n_prefixes;
-  rm_asprintf(&n_prefixes, "%u", array_len(prefixes));
-  array_append(tmparr, n_prefixes);
+  int n_prefixes_len = rm_asprintf(&n_prefixes, "%u", array_len(prefixes));
+  APPEND_ARG(n_prefixes, (size_t)n_prefixes_len);
   for (uint32_t i = 0; i < array_len(prefixes); i++) {
-    array_append(tmparr, HiddenUnicodeString_GetUnsafe(prefixes[i], NULL));
+    size_t prefix_len;
+    const char *prefix = HiddenUnicodeString_GetUnsafe(prefixes[i], &prefix_len);
+    APPEND_ARG(prefix, prefix_len);
   }
 
   // Slots info will be added here
@@ -553,35 +567,43 @@ static void buildMRCommand(RedisModuleString **argv, int argc, ProfileOptions pr
 
   argOffset = RMUtil_ArgIndex("DIALECT", argv + 3 + profileArgs, argc - 3 - profileArgs);
   if (argOffset != -1 && argOffset + 3 + 1 + profileArgs < argc) {
-    array_append(tmparr, "DIALECT");
-    array_append(tmparr, RedisModule_StringPtrLen(argv[argOffset + 3 + 1 + profileArgs], NULL));  // the dialect
+    APPEND_LITERAL("DIALECT");
+    size_t dialect_len;
+    const char *dialect = RedisModule_StringPtrLen(argv[argOffset + 3 + 1 + profileArgs], &dialect_len);
+    APPEND_ARG(dialect, dialect_len);
   }
 
   argOffset = RMUtil_ArgIndex("FORMAT", argv + 3 + profileArgs, argc - 3 - profileArgs);
   if (argOffset != -1 && argOffset + 3 + 1 + profileArgs < argc) {
-    array_append(tmparr, "FORMAT");
-    array_append(tmparr, RedisModule_StringPtrLen(argv[argOffset + 3 + 1 + profileArgs], NULL));  // the format
+    APPEND_LITERAL("FORMAT");
+    size_t format_len;
+    const char *format = RedisModule_StringPtrLen(argv[argOffset + 3 + 1 + profileArgs], &format_len);
+    APPEND_ARG(format, format_len);
   }
 
   argOffset = RMUtil_ArgIndex("SCORER", argv + 3 + profileArgs, argc - 3 - profileArgs);
   if (argOffset != -1 && argOffset + 3 + 1 + profileArgs < argc) {
-    array_append(tmparr, "SCORER");
-    array_append(tmparr, RedisModule_StringPtrLen(argv[argOffset + 3 + 1 + profileArgs], NULL));  // the scorer
+    APPEND_LITERAL("SCORER");
+    size_t scorer_len;
+    const char *scorer = RedisModule_StringPtrLen(argv[argOffset + 3 + 1 + profileArgs], &scorer_len);
+    APPEND_ARG(scorer, scorer_len);
   }
 
   if (RMUtil_ArgIndex("ADDSCORES", argv + 3 + profileArgs, argc - 3 - profileArgs) != -1) {
-    array_append(tmparr, "ADDSCORES");
+    APPEND_LITERAL("ADDSCORES");
   }
 
   if (RMUtil_ArgIndex("VERBATIM", argv + 3 + profileArgs, argc - 3 - profileArgs) != -1) {
-    array_append(tmparr, "VERBATIM");
+    APPEND_LITERAL("VERBATIM");
   }
 
   for (size_t ii = 0; ii < array_len(us->serialized); ++ii) {
-    array_append(tmparr, us->serialized[ii]);
+    APPEND_ARG(us->serialized[ii], strlen(us->serialized[ii]));
   }
+#undef APPEND_LITERAL
+#undef APPEND_ARG
 
-  *xcmd = MR_NewCommandArgv(array_len(tmparr), tmparr);
+  *xcmd = MR_NewCommandArgvLen(array_len(tmparr), tmparr, tmplens);
 
   // Prepare command for slot info (Cluster mode)
   MRCommand_PrepareForSlotInfo(xcmd, slotsInfoPos);
@@ -620,6 +642,7 @@ static void buildMRCommand(RedisModuleString **argv, int argc, ProfileOptions pr
 
   rm_free(n_prefixes);
   array_free(tmparr);
+  array_free(tmplens);
 }
 
 

--- a/src/coord/dist_utils.c
+++ b/src/coord/dist_utils.c
@@ -198,25 +198,28 @@ static bool getCursorCommand(long long cursorId, MRCommand *cmd, MRIteratorCtx *
   bool timedout = MRIteratorCallback_GetTimedOut(ctx) || shardTimedOut;
 
   if (cmd->rootCommand == C_AGG) {
-    MRCommand newCmd;
     char buf[24]; // enough digits for a long long
-    snprintf(buf, sizeof(buf), "%lld", cursorId);
+    int bufLen = snprintf(buf, sizeof(buf), "%lld", cursorId);
     // AGGREGATE commands has the index name at position 1
-    const char *idx = MRCommand_ArgStringPtrLen(cmd, 1, NULL);
+    size_t idxLen;
+    const char *idx = MRCommand_ArgStringPtrLen(cmd, 1, &idxLen);
+    const char *verb;
+    size_t verbLen;
+    MRRootCommand root;
     // If we timed out and not in cursor mode, we want to send the shard a DEL
     // command instead of a READ command (here we know it has more results)
     if (timedout && cmd->forProfiling) {
-      newCmd = MR_NewCommand(4, "_FT.CURSOR", "PROFILE", idx, buf);
       // Internally we delete the cursor
-      newCmd.rootCommand = C_PROFILE;
+      verb = "PROFILE"; verbLen = sizeof("PROFILE") - 1; root = C_PROFILE;
     } else if (timedout && !cmd->forCursor) {
-      newCmd = MR_NewCommand(4, "_FT.CURSOR", "DEL", idx, buf);
-      // Mark that the last command was a DEL command
-      newCmd.rootCommand = C_DEL;
+      verb = "DEL"; verbLen = sizeof("DEL") - 1; root = C_DEL;
     } else {
-      newCmd = MR_NewCommand(4, "_FT.CURSOR", "READ", idx, buf);
-      newCmd.rootCommand = C_READ;
+      verb = "READ"; verbLen = sizeof("READ") - 1; root = C_READ;
     }
+    const char *argv[4] = {"_FT.CURSOR", verb, idx, buf};
+    const size_t lens[4] = {sizeof("_FT.CURSOR") - 1, verbLen, idxLen, (size_t)bufLen};
+    MRCommand newCmd = MR_NewCommandArgvLen(4, argv, lens);
+    newCmd.rootCommand = root;
 
     newCmd.targetShard = cmd->targetShard;
     newCmd.targetShardIdx = cmd->targetShardIdx;
@@ -239,7 +242,7 @@ static bool getCursorCommand(long long cursorId, MRCommand *cmd, MRIteratorCtx *
       // If we timed out and it's a profile command, we want to get the profile data
       if (cmd->forProfiling) {
         RS_LOG_ASSERT(!cmd->forCursor, "profile is not supported on a cursor command");
-        MRCommand_ReplaceArg(cmd, 1, "PROFILE", strlen("PROFILE"));
+        MRCommand_ReplaceArg(cmd, 1, "PROFILE", sizeof("PROFILE") - 1);
         cmd->rootCommand = C_PROFILE;
       } else if (!cmd->forCursor) {
         // If we timed out and not in cursor mode, we want to send the shard a DEL

--- a/src/coord/dist_utils.c
+++ b/src/coord/dist_utils.c
@@ -203,21 +203,27 @@ static bool getCursorCommand(long long cursorId, MRCommand *cmd, MRIteratorCtx *
     // AGGREGATE commands has the index name at position 1
     size_t idxLen;
     const char *idx = MRCommand_ArgStringPtrLen(cmd, 1, &idxLen);
-    const char *verb;
-    size_t verbLen;
+    const char *subcommand;
+    size_t subcommandLen;
     MRRootCommand root;
     // If we timed out and not in cursor mode, we want to send the shard a DEL
     // command instead of a READ command (here we know it has more results)
     if (timedout && cmd->forProfiling) {
       // Internally we delete the cursor
-      verb = "PROFILE"; verbLen = sizeof("PROFILE") - 1; root = C_PROFILE;
+      subcommand = "PROFILE";
+      subcommandLen = sizeof("PROFILE") - 1;
+      root = C_PROFILE;
     } else if (timedout && !cmd->forCursor) {
-      verb = "DEL"; verbLen = sizeof("DEL") - 1; root = C_DEL;
+      subcommand = "DEL";
+      subcommandLen = sizeof("DEL") - 1;
+      root = C_DEL;
     } else {
-      verb = "READ"; verbLen = sizeof("READ") - 1; root = C_READ;
+      subcommand = "READ";
+      subcommandLen = sizeof("READ") - 1;
+      root = C_READ;
     }
-    const char *argv[4] = {"_FT.CURSOR", verb, idx, buf};
-    const size_t lens[4] = {sizeof("_FT.CURSOR") - 1, verbLen, idxLen, (size_t)bufLen};
+    const char *argv[4] = {"_FT.CURSOR", subcommand, idx, buf};
+    const size_t lens[4] = {sizeof("_FT.CURSOR") - 1, subcommandLen, idxLen, (size_t)bufLen};
     MRCommand newCmd = MR_NewCommandArgvLen(4, argv, lens);
     newCmd.rootCommand = root;
 

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -322,20 +322,26 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             IndexSpec *sp, int *outKArgIndex) {
   RS_ASSERT(outKArgIndex != NULL);
   int argOffset;
-  const char *index_name = RedisModule_StringPtrLen(argv[1], NULL);
+  size_t index_name_len;
+  const char *index_name = RedisModule_StringPtrLen(argv[1], &index_name_len);
 
   int cmdArgCount = 2;
   const char *cmdArgs[5] = {"_FT.HYBRID", index_name};
+  size_t cmdLens[5] = {strlen("_FT.HYBRID"), index_name_len};
 
   if (profileOptions != EXEC_NO_FLAGS) {
     cmdArgs[0] = "_FT.PROFILE";
-    cmdArgs[cmdArgCount++] = "HYBRID";
+    cmdLens[0] = strlen("_FT.PROFILE");
+    cmdArgs[cmdArgCount] = "HYBRID";
+    cmdLens[cmdArgCount++] = strlen("HYBRID");
     if (profileOptions & EXEC_WITH_PROFILE_LIMITED) {
-      cmdArgs[cmdArgCount++] = "LIMITED";
+      cmdArgs[cmdArgCount] = "LIMITED";
+      cmdLens[cmdArgCount++] = strlen("LIMITED");
     }
-    cmdArgs[cmdArgCount++] = "QUERY";
+    cmdArgs[cmdArgCount] = "QUERY";
+    cmdLens[cmdArgCount++] = strlen("QUERY");
   }
-  *xcmd = MR_NewCommandArgv(cmdArgCount, cmdArgs);
+  *xcmd = MR_NewCommandArgvLen(cmdArgCount, cmdArgs, cmdLens);
 
   // Add all SEARCH-related arguments (SEARCH, query, optional SCORER, YIELD_SCORE_AS)
   int searchOffset = RMUtil_ArgIndex("SEARCH", argv, argc);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -276,35 +276,35 @@ static void MRCommand_appendCombine(MRCommand *xcmd, const HybridCombineWirePara
   const size_t numBufSize = sizeof(numBuf);
   int n;
 
-  MRCommand_Append(xcmd, "COMBINE", strlen("COMBINE"));
+  MRCommand_AppendLiteral(xcmd, "COMBINE");
   if (sc->scoringType == HYBRID_SCORING_RRF) {
     // COMBINE RRF <count> CONSTANT <c> WINDOW <w> [YIELD_SCORE_AS <alias>]
     n = snprintf(numBuf, numBufSize, "%d", hasAlias ? 6 : 4);
-    MRCommand_Append(xcmd, "RRF", strlen("RRF"));
+    MRCommand_AppendLiteral(xcmd, "RRF");
     MRCommand_Append(xcmd, numBuf, n);
-    MRCommand_Append(xcmd, "CONSTANT", strlen("CONSTANT"));
+    MRCommand_AppendLiteral(xcmd, "CONSTANT");
     n = snprintf(numBuf, numBufSize, "%.17g", sc->rrfCtx.constant);
     MRCommand_Append(xcmd, numBuf, n);
-    MRCommand_Append(xcmd, "WINDOW", strlen("WINDOW"));
+    MRCommand_AppendLiteral(xcmd, "WINDOW");
     n = snprintf(numBuf, numBufSize, "%zu", sc->rrfCtx.window);
     MRCommand_Append(xcmd, numBuf, n);
   } else {
     // COMBINE LINEAR <count> ALPHA <a> BETA <b> WINDOW <w> [YIELD_SCORE_AS <alias>]
     n = snprintf(numBuf, numBufSize, "%d", hasAlias ? 8 : 6);
-    MRCommand_Append(xcmd, "LINEAR", strlen("LINEAR"));
+    MRCommand_AppendLiteral(xcmd, "LINEAR");
     MRCommand_Append(xcmd, numBuf, n);
-    MRCommand_Append(xcmd, "ALPHA", strlen("ALPHA"));
+    MRCommand_AppendLiteral(xcmd, "ALPHA");
     n = snprintf(numBuf, numBufSize, "%.17g", sc->linearCtx.linearWeights[0]);
     MRCommand_Append(xcmd, numBuf, n);
-    MRCommand_Append(xcmd, "BETA", strlen("BETA"));
+    MRCommand_AppendLiteral(xcmd, "BETA");
     n = snprintf(numBuf, numBufSize, "%.17g", sc->linearCtx.linearWeights[1]);
     MRCommand_Append(xcmd, numBuf, n);
-    MRCommand_Append(xcmd, "WINDOW", strlen("WINDOW"));
+    MRCommand_AppendLiteral(xcmd, "WINDOW");
     n = snprintf(numBuf, numBufSize, "%zu", sc->linearCtx.window);
     MRCommand_Append(xcmd, numBuf, n);
   }
   if (hasAlias) {
-    MRCommand_Append(xcmd, "YIELD_SCORE_AS", strlen("YIELD_SCORE_AS"));
+    MRCommand_AppendLiteral(xcmd, "YIELD_SCORE_AS");
     MRCommand_Append(xcmd, cp->scoreAlias, strlen(cp->scoreAlias));
   }
 }
@@ -327,19 +327,19 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
 
   int cmdArgCount = 2;
   const char *cmdArgs[5] = {"_FT.HYBRID", index_name};
-  size_t cmdLens[5] = {strlen("_FT.HYBRID"), index_name_len};
+  size_t cmdLens[5] = {sizeof("_FT.HYBRID") - 1, index_name_len};
 
   if (profileOptions != EXEC_NO_FLAGS) {
     cmdArgs[0] = "_FT.PROFILE";
-    cmdLens[0] = strlen("_FT.PROFILE");
+    cmdLens[0] = sizeof("_FT.PROFILE") - 1;
     cmdArgs[cmdArgCount] = "HYBRID";
-    cmdLens[cmdArgCount++] = strlen("HYBRID");
+    cmdLens[cmdArgCount++] = sizeof("HYBRID") - 1;
     if (profileOptions & EXEC_WITH_PROFILE_LIMITED) {
       cmdArgs[cmdArgCount] = "LIMITED";
-      cmdLens[cmdArgCount++] = strlen("LIMITED");
+      cmdLens[cmdArgCount++] = sizeof("LIMITED") - 1;
     }
     cmdArgs[cmdArgCount] = "QUERY";
-    cmdLens[cmdArgCount++] = strlen("QUERY");
+    cmdLens[cmdArgCount++] = sizeof("QUERY") - 1;
   }
   *xcmd = MR_NewCommandArgvLen(cmdArgCount, cmdArgs, cmdLens);
 
@@ -415,15 +415,15 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
   // Forward EXPLAINSCORE so the shard's text scorer produces an RSScoreExplain
   // tree and the shard's merger wraps it.
   if (sendExplainScore) {
-    MRCommand_Append(xcmd, "EXPLAINSCORE", strlen("EXPLAINSCORE"));
+    MRCommand_AppendLiteral(xcmd, "EXPLAINSCORE");
   }
 
   // Add WITHCURSOR
-  MRCommand_Append(xcmd, "WITHCURSOR", strlen("WITHCURSOR"));
+  MRCommand_AppendLiteral(xcmd, "WITHCURSOR");
 
-  MRCommand_Append(xcmd, "WITHSCORES", strlen("WITHSCORES"));
+  MRCommand_AppendLiteral(xcmd, "WITHSCORES");
   // Numeric responses are encoded as simple strings.
-  MRCommand_Append(xcmd, "_NUM_SSTRING", strlen("_NUM_SSTRING"));
+  MRCommand_AppendLiteral(xcmd, "_NUM_SSTRING");
 
   // Prepare command for slot info (Cluster mode)
   MRCommand_PrepareForSlotInfo(xcmd, xcmd->num);
@@ -432,11 +432,11 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
   MRCommand_PrepareForDispatchTime(xcmd, xcmd->num);
 
   if (sp && sp->rule && sp->rule->prefixes && array_len(sp->rule->prefixes) > 0) {
-    MRCommand_Append(xcmd, "_INDEX_PREFIXES", strlen("_INDEX_PREFIXES"));
+    MRCommand_AppendLiteral(xcmd, "_INDEX_PREFIXES");
     arrayof(HiddenUnicodeString*) prefixes = sp->rule->prefixes;
     char *n_prefixes;
-    rm_asprintf(&n_prefixes, "%u", array_len(prefixes));
-    MRCommand_Append(xcmd, n_prefixes, strlen(n_prefixes));
+    int n_prefixes_len = rm_asprintf(&n_prefixes, "%u", array_len(prefixes));
+    MRCommand_Append(xcmd, n_prefixes, n_prefixes_len);
     rm_free(n_prefixes);
 
     for (uint32_t i = 0; i < array_len(prefixes); i++) {

--- a/src/coord/rmr/command.c
+++ b/src/coord/rmr/command.c
@@ -8,7 +8,6 @@
 */
 
 #include <string.h>
-#include <stdarg.h>
 #include <stdio.h>
 
 #include "command.h"
@@ -49,10 +48,6 @@ static void assignStr(MRCommand *cmd, size_t idx, const char *s, size_t n) {
   memcpy(news, s, n);
   // Drop the cached sds command representation if set
   dropCachedCmdIfNeeded(cmd);
-}
-
-static void assignCstr(MRCommand *cmd, size_t idx, const char *s) {
-  assignStr(cmd, idx, s, strlen(s));
 }
 
 static void copyStr(MRCommand *dst, size_t dstidx, const MRCommand *src, size_t srcidx) {
@@ -112,19 +107,6 @@ MRCommand MRCommand_Copy(const MRCommand *cmd) {
     copyStr(&ret, i, cmd, i);
   }
   return ret;
-}
-
-MRCommand MR_NewCommand(int argc, ...) {
-  MRCommand cmd = {0};
-  MRCommand_Init(&cmd, argc);
-
-  va_list ap;
-  va_start(ap, argc);
-  for (int i = 0; i < argc; i++) {
-    assignCstr(&cmd, i, va_arg(ap, const char *));
-  }
-  va_end(ap);
-  return cmd;
 }
 
 MRCommand MR_NewCommandFromRedisStrings(int argc, RedisModuleString **argv) {

--- a/src/coord/rmr/command.c
+++ b/src/coord/rmr/command.c
@@ -84,12 +84,12 @@ static void MRCommand_Init(MRCommand *cmd, size_t len) {
   cmd->coordStartTime = 0;
 }
 
-MRCommand MR_NewCommandArgv(int argc, const char **argv) {
+MRCommand MR_NewCommandArgvLen(int argc, const char **argv, const size_t *lens) {
   MRCommand cmd = {0};
   MRCommand_Init(&cmd, argc);
 
   for (int i = 0; i < argc; i++) {
-    assignCstr(&cmd, i, argv[i]);
+    assignStr(&cmd, i, argv[i], lens[i]);
   }
   return cmd;
 }

--- a/src/coord/rmr/command.h
+++ b/src/coord/rmr/command.h
@@ -73,8 +73,10 @@ typedef struct {
  * allocated on the stack */
 void MRCommand_Free(MRCommand *cmd);
 
-/* Create a new command from an argv list of strings */
-MRCommand MR_NewCommandArgv(int argc, const char **argv);
+/* Create a new command from an argv list with explicit per-argument lengths;
+ * binary-safe. Arguments whose bytes can come from a client (query text,
+ * user-defined names) must carry their true length — never strlen. */
+MRCommand MR_NewCommandArgvLen(int argc, const char **argv, const size_t *lens);
 /* Variadic creation of a command from a list of strings */
 MRCommand MR_NewCommand(int argc, ...);
 /* Create a command from a list of redis strings */

--- a/src/coord/rmr/command.h
+++ b/src/coord/rmr/command.h
@@ -77,8 +77,6 @@ void MRCommand_Free(MRCommand *cmd);
  * binary-safe. Arguments whose bytes can come from a client (query text,
  * user-defined names) must carry their true length — never strlen. */
 MRCommand MR_NewCommandArgvLen(int argc, const char **argv, const size_t *lens);
-/* Variadic creation of a command from a list of strings */
-MRCommand MR_NewCommand(int argc, ...);
 /* Create a command from a list of redis strings */
 MRCommand MR_NewCommandFromRedisStrings(int argc, RedisModuleString **argv);
 
@@ -141,6 +139,9 @@ static inline const char *MRCommand_ArgStringPtrLen(const MRCommand *cmd, size_t
 
 /** Copy from an argument of an existing command */
 void MRCommand_Append(MRCommand *cmd, const char *s, size_t len);
+/* Append a string literal; length computed at compile time. The "" concatenation
+ * rejects anything that is not a string literal. */
+#define MRCommand_AppendLiteral(cmd, lit) MRCommand_Append((cmd), (lit), sizeof("" lit "") - 1)
 void MRCommand_AppendRstr(MRCommand *cmd, RedisModuleString *rmstr);
 void MRCommand_Insert(MRCommand *cmd, int pos, const char *s, size_t n);
 

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -287,15 +287,16 @@ int rpnetNext_StartWithMappings(ResultProcessor *rp, SearchResult *r) {
 
     size_t idx_len;
     const char *idx = MRCommand_ArgStringPtrLen(&nc->cmd, 1, &idx_len);
-    char *idx_copy = rm_strndup(idx, idx_len);
+    // Build the cursor-read command before freeing the old command — idx points
+    // into its storage.
+    const char *argv[3] = {"_FT.CURSOR", "READ", idx};
+    const size_t lens[3] = {sizeof("_FT.CURSOR") - 1, sizeof("READ") - 1, idx_len};
+    MRCommand newCmd = MR_NewCommandArgvLen(3, argv, lens);
     MRCommand_Free(&nc->cmd);
-
-    // Create cursor read command using the copied index name
-    nc->cmd = MR_NewCommand(3, "_FT.CURSOR", "READ", idx_copy);
+    nc->cmd = newCmd;
     nc->cmd.rootCommand = C_READ;
     nc->cmd.forProfiling = IsProfile(nc->areq);
     nc->cmd.protocol = 3;
-    rm_free(idx_copy);
 
     nc->it = MR_IterateWithPrivateData(&nc->cmd, &(MRIteratorConfig){
       .successCB = netCursorCallback,

--- a/src/module.c
+++ b/src/module.c
@@ -4141,7 +4141,7 @@ int InfoCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
   }
 
   MRCommand cmd = MR_NewCommandFromRedisStrings(argc, argv);
-  MRCommand_Append(&cmd, WITH_INDEX_ERROR_TIME, strlen(WITH_INDEX_ERROR_TIME));
+  MRCommand_AppendLiteral(&cmd, WITH_INDEX_ERROR_TIME);
   MRCommand_SetProtocol(&cmd, ctx);
   MRCommand_SetPrefix(&cmd, "_FT");
 
@@ -4152,7 +4152,7 @@ int InfoCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
 void sendRequiredFields(const searchRequestCtx *req, MRCommand *cmd) {
   if(req->requiredFields) {
-    MRCommand_Append(cmd, "_REQUIRED_FIELDS", strlen("_REQUIRED_FIELDS"));
+    MRCommand_AppendLiteral(cmd, "_REQUIRED_FIELDS");
     int numberOfFields = array_len(req->requiredFields);
     char snum[8];
     int len = sprintf(snum, "%d", numberOfFields);
@@ -4219,8 +4219,8 @@ static int prepareCommand(MRCommand *cmd, const searchRequestCtx *req, int proto
     size_t k =0;
     MRCommand_ReplaceArg(cmd, limitIndex + 1, "0", 1);
     char buf[32];
-    snprintf(buf, sizeof(buf), "%lld", req->requestedResultsCount);
-    MRCommand_ReplaceArg(cmd, limitIndex + 2, buf, strlen(buf));
+    int bufLen = snprintf(buf, sizeof(buf), "%lld", req->requestedResultsCount);
+    MRCommand_ReplaceArg(cmd, limitIndex + 2, buf, bufLen);
   }
 
   /* Replace our own FT command with _FT. command */

--- a/tests/cpptests/coord_tests/test_cpp_command.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_command.cpp
@@ -185,13 +185,17 @@ TEST_F(MRCommandTest, testBasicCommandCreation) {
     MRCommand_Free(&cmd);
 }
 
-// Test command creation from argv
+// Test command creation from argv with explicit lengths; the query argument
+// carries an embedded NUL that a strlen-based construction would truncate.
 TEST_F(MRCommandTest, testCommandCreationFromArgv) {
-    const char* argv[] = {"FT.AGGREGATE", "myindex", "*", "GROUPBY", "1", "@category"};
-    MRCommand cmd = MR_NewCommandArgv(6, argv);
+    const std::string query("he\0llo", 6);
+    const char* argv[] = {"FT.AGGREGATE", "myindex", query.data(), "GROUPBY", "1", "@category"};
+    const size_t lens[] = {strlen("FT.AGGREGATE"), strlen("myindex"), query.length(),
+                           strlen("GROUPBY"),      strlen("1"),       strlen("@category")};
+    MRCommand cmd = MR_NewCommandArgvLen(6, argv, lens);
 
     EXPECT_EQ(cmd.num, 6);
-    EXPECT_TRUE(verifyCommandArgs(&cmd, {"FT.AGGREGATE", "myindex", "*", "GROUPBY", "1", "@category"}));
+    EXPECT_TRUE(verifyCommandArgs(&cmd, {"FT.AGGREGATE", "myindex", query, "GROUPBY", "1", "@category"}));
 
     MRCommand_Free(&cmd);
 }

--- a/tests/cpptests/coord_tests/test_cpp_command.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_command.cpp
@@ -48,14 +48,16 @@ void printMRCommand(const MRCommand* cmd) {
     printf("\n");
 }
 
-// Build a command from C strings, standing in for the deleted variadic
+// Build a command from strings, standing in for the deleted variadic
 // MR_NewCommand; production code must pass explicit lengths instead.
-MRCommand newCommand(std::initializer_list<const char*> args) {
-    std::vector<const char*> argv(args);
+MRCommand newCommand(std::initializer_list<std::string> args) {
+    std::vector<const char*> argv;
     std::vector<size_t> lens;
-    lens.reserve(argv.size());
-    for (const char* s : argv) {
-        lens.push_back(strlen(s));
+    argv.reserve(args.size());
+    lens.reserve(args.size());
+    for (const std::string& s : args) {
+        argv.push_back(s.data());
+        lens.push_back(s.size());
     }
     return MR_NewCommandArgvLen((int)argv.size(), argv.data(), lens.data());
 }
@@ -201,10 +203,7 @@ TEST_F(MRCommandTest, testBasicCommandCreation) {
 // carries an embedded NUL that a strlen-based construction would truncate.
 TEST_F(MRCommandTest, testCommandCreationFromArgv) {
     const std::string query("he\0llo", 6);
-    const char* argv[] = {"FT.AGGREGATE", "myindex", query.data(), "GROUPBY", "1", "@category"};
-    const size_t lens[] = {strlen("FT.AGGREGATE"), strlen("myindex"), query.length(),
-                           strlen("GROUPBY"),      strlen("1"),       strlen("@category")};
-    MRCommand cmd = MR_NewCommandArgvLen(6, argv, lens);
+    MRCommand cmd = newCommand({"FT.AGGREGATE", "myindex", query, "GROUPBY", "1", "@category"});
 
     EXPECT_EQ(cmd.num, 6);
     EXPECT_TRUE(verifyCommandArgs(&cmd, {"FT.AGGREGATE", "myindex", query, "GROUPBY", "1", "@category"}));

--- a/tests/cpptests/coord_tests/test_cpp_command.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_command.cpp
@@ -48,6 +48,18 @@ void printMRCommand(const MRCommand* cmd) {
     printf("\n");
 }
 
+// Build a command from C strings, standing in for the deleted variadic
+// MR_NewCommand; production code must pass explicit lengths instead.
+MRCommand newCommand(std::initializer_list<const char*> args) {
+    std::vector<const char*> argv(args);
+    std::vector<size_t> lens;
+    lens.reserve(argv.size());
+    for (const char* s : argv) {
+        lens.push_back(strlen(s));
+    }
+    return MR_NewCommandArgvLen((int)argv.size(), argv.data(), lens.data());
+}
+
 bool verifyCommandArgs(const MRCommand* cmd, const std::vector<std::string>& expected) {
     if (cmd->num != (int)expected.size()) {
         return false;
@@ -170,9 +182,9 @@ protected:
 // Command Building Tests
 // ============================================================================
 
-// Test basic command creation with MR_NewCommand
+// Test basic command creation
 TEST_F(MRCommandTest, testBasicCommandCreation) {
-    MRCommand cmd = MR_NewCommand(3, "FT.SEARCH", "test_index", "hello");
+    MRCommand cmd = newCommand({"FT.SEARCH", "test_index", "hello"});
 
     EXPECT_EQ(cmd.num, 3);
     EXPECT_TRUE(verifyCommandArgs(&cmd, {"FT.SEARCH", "test_index", "hello"}));
@@ -202,7 +214,7 @@ TEST_F(MRCommandTest, testCommandCreationFromArgv) {
 
 // Test command copying
 TEST_F(MRCommandTest, testCommandCopy) {
-    MRCommand original = MR_NewCommand(3, "FT.SEARCH", "test_index", "hello");
+    MRCommand original = newCommand({"FT.SEARCH", "test_index", "hello"});
     original.targetShard = rm_strdup("shard_1");
     original.targetShardIdx = 1;
     original.forCursor = true;
@@ -223,7 +235,7 @@ TEST_F(MRCommandTest, testCommandCopy) {
 
 // Test appending arguments to a command
 TEST_F(MRCommandTest, testCommandAppend) {
-    MRCommand cmd = MR_NewCommand(2, "FT.SEARCH", "myindex");
+    MRCommand cmd = newCommand({"FT.SEARCH", "myindex"});
 
     MRCommand_Append(&cmd, "hello", 5);
     MRCommand_Append(&cmd, "LIMIT", 5);
@@ -238,7 +250,7 @@ TEST_F(MRCommandTest, testCommandAppend) {
 
 // Test inserting arguments at specific positions
 TEST_F(MRCommandTest, testCommandInsert) {
-    MRCommand cmd = MR_NewCommand(3, "FT.SEARCH", "myindex", "hello");
+    MRCommand cmd = newCommand({"FT.SEARCH", "myindex", "hello"});
 
     // Insert LIMIT arguments at position 3
     MRCommand_Insert(&cmd, 3, "LIMIT", 5);
@@ -252,7 +264,7 @@ TEST_F(MRCommandTest, testCommandInsert) {
 
 // Test replacing arguments in a command
 TEST_F(MRCommandTest, testCommandReplaceArg) {
-    MRCommand cmd = MR_NewCommand(4, "FT.SEARCH", "myindex", "hello", "world");
+    MRCommand cmd = newCommand({"FT.SEARCH", "myindex", "hello", "world"});
     // Replace the query
     MRCommand_ReplaceArg(&cmd, 2, "goodbye", 7);
     EXPECT_TRUE(verifyCommandArgs(&cmd, {"FT.SEARCH", "myindex", "goodbye", "world"}));
@@ -261,7 +273,7 @@ TEST_F(MRCommandTest, testCommandReplaceArg) {
 
 // Test setting command prefix
 TEST_F(MRCommandTest, testCommandSetPrefix) {
-    MRCommand cmd = MR_NewCommand(3, "FT.SEARCH", "myindex", "hello");
+    MRCommand cmd = newCommand({"FT.SEARCH", "myindex", "hello"});
     MRCommand_SetPrefix(&cmd, "_FT");
     EXPECT_TRUE(verifyCommandArgs(&cmd, {"_FT.SEARCH", "myindex", "hello"}));
     MRCommand_Free(&cmd);
@@ -269,7 +281,7 @@ TEST_F(MRCommandTest, testCommandSetPrefix) {
 
 // Test replacing command prefix when one already exists
 TEST_F(MRCommandTest, testCommandReplacePrefixExisting) {
-    MRCommand cmd = MR_NewCommand(3, "_FT.SEARCH", "myindex", "hello");
+    MRCommand cmd = newCommand({"_FT.SEARCH", "myindex", "hello"});
     MRCommand_SetPrefix(&cmd, "NEW");
     EXPECT_TRUE(verifyCommandArgs(&cmd, {"NEW.SEARCH", "myindex", "hello"}));
     MRCommand_Free(&cmd);
@@ -282,7 +294,7 @@ TEST_F(MRCommandTest, testCommandReplacePrefixExisting) {
 // Test that slot range info is added to different types of commands
 TEST_F(MRCommandTest, testAddSlotRangeInfoToHybridCommand) {
     // Create a hybrid command
-    MRCommand cmd = MR_NewCommand(7, "_FT.HYBRID", "test_index", "SEARCH", "hello", "VSIM", "@vector", "data");
+    MRCommand cmd = newCommand({"_FT.HYBRID", "test_index", "SEARCH", "hello", "VSIM", "@vector", "data"});
     MRCommand_PrepareForSlotInfo(&cmd, 7); // Prepare for slot info insertion at the end
     MRCommand_SetSlotInfo(&cmd, testSlotArray);
     ASSERT_EQ(SlotRangeInfoIndex(&cmd), 7) << "Hybrid command should contain slot range information";
@@ -293,7 +305,7 @@ TEST_F(MRCommandTest, testAddSlotRangeInfoToHybridCommand) {
 TEST_F(MRCommandTest, testAddSlotRangeInfoToSearchCommand) {
     uint32_t insertPos = 3; // After index name and query
     // Create a FT.SEARCH command
-    MRCommand cmd = MR_NewCommand(5, "FT.SEARCH", "myindex", "hello", "LIMIT", "10");
+    MRCommand cmd = newCommand({"FT.SEARCH", "myindex", "hello", "LIMIT", "10"});
     MRCommand_PrepareForSlotInfo(&cmd, insertPos);
     MRCommand_SetSlotInfo(&cmd, testSlotArray);
     ASSERT_EQ(SlotRangeInfoIndex(&cmd), insertPos) << "FT.SEARCH command should contain slot range information";
@@ -312,7 +324,7 @@ TEST_F(MRCommandTest, testAddSlotRangeInfoToSearchCommand) {
 // Test that slot range info is added to FT.AGGREGATE commands
 TEST_F(MRCommandTest, testAddSlotRangeInfoToAggregateCommand) {
     // Create a FT.AGGREGATE command
-    MRCommand cmd = MR_NewCommand(6, "FT.AGGREGATE", "myindex", "*", "GROUPBY", "1", "@category");
+    MRCommand cmd = newCommand({"FT.AGGREGATE", "myindex", "*", "GROUPBY", "1", "@category"});
     MRCommand_PrepareForSlotInfo(&cmd, 4); // Insert before GROUPBY
     MRCommand_SetSlotInfo(&cmd, testSlotArray);
     ASSERT_EQ(SlotRangeInfoIndex(&cmd), 4) << "FT.AGGREGATE command should contain slot range information";
@@ -385,7 +397,7 @@ INSTANTIATE_TEST_SUITE_P(
 // Parameterized test for adding slot range info
 TEST_P(MRCommandSlotRangeTest, testAddSlotRangeInfo) {
     // Create a command
-    MRCommand cmd = MR_NewCommand(3, "FT.SEARCH", "test_index", "hello");
+    MRCommand cmd = newCommand({"FT.SEARCH", "test_index", "hello"});
     MRCommand_PrepareForSlotInfo(&cmd, 3); // Prepare for slot info insertion at position 3
     MRCommand_SetSlotInfo(&cmd, testSlotArray);
 
@@ -403,7 +415,7 @@ TEST_P(MRCommandSlotRangeTest, testAddSlotRangeInfo) {
 // Parameterized test for round-trip slot range serialization
 TEST_P(MRCommandSlotRangeTest, testSlotRangeRoundTrip) {
     // Create a command with slot range info
-    MRCommand cmd = MR_NewCommand(3, "FT.SEARCH", "test_index", "hello");
+    MRCommand cmd = newCommand({"FT.SEARCH", "test_index", "hello"});
     MRCommand_PrepareForSlotInfo(&cmd, 3); // Prepare for slot info insertion at position 3
     MRCommand_SetSlotInfo(&cmd, testSlotArray);
 

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -121,6 +121,8 @@ static int verifyArgsPreservedWithReconstructedCombine(
     }
     EXPECT_STREQ(xcmd->strs[oi], inputArgs[ii])
         << "Argument at input index " << ii << " should be preserved";
+    EXPECT_EQ(xcmd->lens[oi], strlen(inputArgs[ii]))
+        << "Recorded length at output index " << oi << " should match the arg bytes";
     oi++;
     ii++;
   }
@@ -620,6 +622,34 @@ TEST_F(HybridBuildMRCommandTest, testMinimalCommand) {
     testCommandTransformationWithIndexSpec({
         "FT.HYBRID", "idx", "SEARCH", "test", "VSIM", "@vec", "data"
     });
+}
+
+// Client-controlled arguments can carry embedded NULs; the builder must
+// forward each at its full byte length — a strlen-based assembly would
+// truncate them at the first NUL.
+TEST_F(HybridBuildMRCommandTest, testBinaryArgsForwardedAtFullLength) {
+    const std::string index("id\0x", 4);
+    const std::string query("he\0llo", 6);
+    const std::string vector("d\0ta", 4);
+    RMCK::ArgvList args(ctx, std::vector<std::string>{
+        "FT.HYBRID", index, "SEARCH", query, "VSIM", "@vec", vector});
+
+    MRCommand xcmd;
+    int kArgIndex = -1;
+    HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
+                                 /*sendExplainScore=*/false, nullptr, &xcmd,
+                                 nullptr, nullptr, &kArgIndex);
+
+    // _FT.HYBRID <index> SEARCH <query> VSIM @vec <vector> ...
+    ASSERT_GE(xcmd.num, 7);
+    EXPECT_EQ(xcmd.lens[1], index.size());
+    EXPECT_EQ(memcmp(xcmd.strs[1], index.data(), index.size()), 0);
+    EXPECT_EQ(xcmd.lens[3], query.size());
+    EXPECT_EQ(memcmp(xcmd.strs[3], query.data(), query.size()), 0);
+    EXPECT_EQ(xcmd.lens[6], vector.size());
+    EXPECT_EQ(memcmp(xcmd.strs[6], vector.data(), vector.size()), 0);
+
+    MRCommand_Free(&xcmd);
 }
 
 // EXPLAINSCORE forwarding to the shard is driven by the parsed top-level

--- a/tests/ctests/coord_tests/test_command.c
+++ b/tests/ctests/coord_tests/test_command.c
@@ -13,6 +13,13 @@
 
 // Test suite for MRCommand API functions
 
+// Build the shared three-argument test command around one variable argument.
+static MRCommand newTestCommand(const char *test_arg) {
+    const char *argv[] = {"FT.SEARCH", "myindex", test_arg};
+    const size_t lens[] = {sizeof("FT.SEARCH") - 1, sizeof("myindex") - 1, strlen(test_arg)};
+    return MR_NewCommandArgvLen(3, argv, lens);
+}
+
 // Test the fallback case when replacement string is longer than original
 // MRCommand_ReplaceArgSubstring has two code paths:
 // 1. Optimization: pad with spaces when newLen <= oldLen (no reallocation)
@@ -25,9 +32,7 @@ void testReplaceArgSubstringFallback() {
     const char *expected = "hgreetings world";
 
     // Create a command with a test argument
-    const char *argv[] = {"FT.SEARCH", "myindex", test_arg};
-    const size_t lens[] = {sizeof("FT.SEARCH") - 1, sizeof("myindex") - 1, strlen(test_arg)};
-    MRCommand cmd = MR_NewCommandArgvLen(3, argv, lens);
+    MRCommand cmd = newTestCommand(test_arg);
 
     int arg_index = 2;
     size_t pos = 1;
@@ -52,9 +57,7 @@ void testReplaceArgSubstringOptimization() {
     const char *expected = "hhi   world";
 
     // Create a command with a test argument
-    const char *argv[] = {"FT.SEARCH", "myindex", test_arg};
-    const size_t lens[] = {sizeof("FT.SEARCH") - 1, sizeof("myindex") - 1, strlen(test_arg)};
-    MRCommand cmd = MR_NewCommandArgvLen(3, argv, lens);
+    MRCommand cmd = newTestCommand(test_arg);
 
     int arg_index = 2;
     size_t pos = 1;

--- a/tests/ctests/coord_tests/test_command.c
+++ b/tests/ctests/coord_tests/test_command.c
@@ -25,7 +25,9 @@ void testReplaceArgSubstringFallback() {
     const char *expected = "hgreetings world";
 
     // Create a command with a test argument
-    MRCommand cmd = MR_NewCommand(3, "FT.SEARCH", "myindex", test_arg);
+    const char *argv[] = {"FT.SEARCH", "myindex", test_arg};
+    const size_t lens[] = {sizeof("FT.SEARCH") - 1, sizeof("myindex") - 1, strlen(test_arg)};
+    MRCommand cmd = MR_NewCommandArgvLen(3, argv, lens);
 
     int arg_index = 2;
     size_t pos = 1;
@@ -50,7 +52,9 @@ void testReplaceArgSubstringOptimization() {
     const char *expected = "hhi   world";
 
     // Create a command with a test argument
-    MRCommand cmd = MR_NewCommand(3, "FT.SEARCH", "myindex", test_arg);
+    const char *argv[] = {"FT.SEARCH", "myindex", test_arg};
+    const size_t lens[] = {sizeof("FT.SEARCH") - 1, sizeof("myindex") - 1, strlen(test_arg)};
+    MRCommand cmd = MR_NewCommandArgvLen(3, argv, lens);
 
     int arg_index = 2;
     size_t pos = 1;


### PR DESCRIPTION

## Describe the changes in the pull request

1. **Current**: `MR_NewCommandArgv` and the variadic `MR_NewCommand` rebuilt every argument with `strlen`, silently truncating any argument with an embedded NUL at fan-out time. The rest of the RMR layer is already binary-safe — `MRCommand` carries per-argument `lens`, `MRCommand_Append`/`MRCommand_AppendRstr` are length-aware, and the wire format (`redisFormatSdsCommandArgv`) writes explicit lengths — so these constructors were the only lossy funnels between the coordinator and the shards.
2. **Change**: Both strlen-based constructors are deleted; `MR_NewCommandArgvLen(argc, argv, lens)` replaces them and every caller passes explicit lengths end to end:
   - `buildMRCommand` (`src/coord/dist_aggregate.c`) carries a parallel `lens` array. Arguments whose bytes can come from a client — query text, index name, prefixes — take their true length from `RedisModule_StringPtrLen` / `HiddenUnicodeString_GetUnsafe`; literals use `sizeof(lit) - 1` via an `APPEND_LITERAL` macro whose `"" lit ""` concatenation rejects non-literals at compile time.
   - `HybridRequest_buildMRCommand` (`src/coord/hybrid/dist_hybrid.c`) builds the `_FT.HYBRID` base command with explicit lengths.
   - The `_FT.CURSOR READ/DEL/PROFILE` follow-ups of the aggregate fan-out (`getCursorCommand` in `src/coord/dist_utils.c`, `rpnetNext_StartWithMappings` in `src/coord/rpnet.c`) forward the index name at its recorded length instead of re-measuring it; the rpnet site also drops its defensive index-name copy by building the new command before freeing the old one.
   - A new `MRCommand_AppendLiteral` macro (compile-time length, literal-guarded like `APPEND_LITERAL`) replaces `strlen("...")` at every literal append across the fan-out builders, and formatted number buffers reuse the `snprintf`/`rm_asprintf` return value instead of `strlen`.
3. **Outcome**: The MRCommand layer contains no `strlen` at all, and the coordinator forwards every argument to the shards byte-for-byte at the length upstream chose. The remaining `strlen` calls at construction sites measure engine-internal C-string-typed values (`scoreAlias`, `requiredFields`, serialized plan tokens) whose producers discard the length by type — faithfulness for those is a producer-side change, out of scope here. Covered by a unit test constructing a fan-out command whose query argument contains an embedded NUL.

Note: this PR makes the fan-out length-faithful; it does not decide the query-blob truncation policy discussed on #10699. Whatever the parsing layer settles on (full length vs. first-NUL truncation), the fan-out now carries that choice unchanged instead of imposing its own.

#### Which additional issues this PR fixes

1. MOD-... (ticket pending)

#### Main objects this PR modified

1. `MR_NewCommandArgv`/`MR_NewCommand` → `MR_NewCommandArgvLen`, new `MRCommand_AppendLiteral` (`src/coord/rmr/command.{c,h}`)
2. `buildMRCommand` (`src/coord/dist_aggregate.c`)
3. `HybridRequest_buildMRCommand`, `MRCommand_appendCombine` (`src/coord/hybrid/dist_hybrid.c`)
4. `getCursorCommand` (`src/coord/dist_utils.c`), `rpnetNext_StartWithMappings` (`src/coord/rpnet.c`)
5. `sendRequiredFields`, `prepareCommand`, `InfoCommandHandler` (`src/module.c`)
6. `MRCommandTest` (`tests/cpptests/coord_tests/test_cpp_command.cpp`), `tests/ctests/coord_tests/test_command.c`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
