### PR TITLE
[MOD-17546] Fan out the master merge-queue ubuntu lane to cut queue latency

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -54,9 +54,52 @@ jobs:
       options: skip-tests,fail-fast
       rejson-branch: master
 
-  test-ubuntu:
+  # ------------------------------------------------------------------
+  # The ubuntu test lane, in two mutually exclusive flavours.
+  #
+  # master goes through flow-pr-pipeline.yml: one build, then unit +
+  # standalone + coordinator as separate concurrent jobs off a single
+  # artifact. Release branches keep the task-test.yml monolith, where the
+  # build and every suite run as sequential steps on one runner.
+  #
+  # Both feed the same `pr-validation` aggregate, and a skipped job reports
+  # `skipped` (which that gate treats as passing), so the required check name
+  # is identical for either branch family.
+  #
+  # Only the release-branch lane passes `fail-fast`. In the monolith it saves
+  # real time by skipping the test steps that follow a failure; in the fan-out
+  # those steps are already-running sibling jobs, and `pr-validation` waits for
+  # every job regardless — so cancelling them would buy no wall time and cost
+  # the full failure picture, which is what a queue eviction needs.
+  # ------------------------------------------------------------------
+
+  test-ubuntu-master:
     # Always run tests for merge queue submissions, including text-only PRs.
     needs: get-latest-redis-tag
+    if: ${{ github.event.merge_group.base_ref == 'refs/heads/master' }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # OIDC role assumption for sccache S3 (used inside flow-pr-pipeline.yml)
+      actions: write  # Swatinem/rust-cache read/write of GH cache (used inside flow-pr-pipeline.yml)
+    uses: ./.github/workflows/flow-pr-pipeline.yml
+    secrets: inherit
+    with:
+      job-type: basic-test
+      platform: ubuntu:noble
+      architecture: x86_64
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      test-config: QUICK=1
+      rejson-branch: master
+      # This lane only runs tests, so the LTO link is dead weight on the queue's
+      # critical path. LTO codegen is still covered on master by
+      # event-periodic-master-validation.yml and event-nightly.yml, both of
+      # which build ubuntu:noble with the platform default.
+      enable-lto: '0'
+
+  test-ubuntu-release-branch:
+    needs: get-latest-redis-tag
+    if: ${{ github.event.merge_group.base_ref != 'refs/heads/master' }}
     permissions:
       contents: read
       packages: write
@@ -83,7 +126,8 @@ jobs:
       - get-latest-redis-tag
       - lint
       - build-unique-oses
-      - test-ubuntu
+      - test-ubuntu-master
+      - test-ubuntu-release-branch
     runs-on: ubuntu-slim
     if: ${{ !cancelled() }}
     steps:

--- a/.github/workflows/event-periodic-master-validation.yml
+++ b/.github/workflows/event-periodic-master-validation.yml
@@ -180,8 +180,12 @@ jobs:
       platform: 'ubuntu:noble,macos-26,!macos-26~x86_64,alpine:3.23,intel'
       architecture: all
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      job-test-config: '{"test": "", "coverage": "", "sanitize": ""}'
-      options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,sanitize' }}
+      job-test-config: '{"test": "", "coverage": "", "sanitize": "", "ubsan": ""}'
+      options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize,ubsan' || 'unit-tests,coordinator,standalone,rejson,sanitize,ubsan' }}
+      # Full alignment UBSan currently exposes unrelated pre-existing UB in the
+      # C/C++ suite. Keep this lane focused on the trie regression until those
+      # findings are fixed separately.
+      ubsan-unit-test-filter: 'TrieTest\.test.*ScansPackedChildKeys'
       rejson-branch: master
 
   notify-cie-failure:

--- a/.github/workflows/flow-pr-pipeline.yml
+++ b/.github/workflows/flow-pr-pipeline.yml
@@ -3,7 +3,8 @@ name: PR Pipeline (one job-type)
 # Documentation: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3967844669/RediSearch+CI+refactor
 #
 # Reusable workflow that encapsulates the full build → test fan-out for a
-# single job-type (basic-test / coverage / sanitize) on the Linux PR matrix.
+# single job-type (basic-test / coverage / sanitize) on one Linux platform.
+# Used by the pull-request flow and by the master merge queue.
 # Platform configuration and the prebuilt container image are resolved ONCE
 # here (get-config + build-image) and passed down to the build / test-unit /
 # test-flow jobs as inputs — so the per-task workflows don't redo that setup.
@@ -38,6 +39,13 @@ on:
       test-timeout:
         type: number
         default: 120
+      enable-lto:
+        description: >-
+          Override the platform's enable_lto ('0' or '1'). Empty keeps whatever
+          task-get-config.yml resolves for the platform. Callers that only run
+          tests (and never ship the binary) can turn LTO off to skip the link.
+        type: string
+        default: ''
 
 jobs:
   get-config:
@@ -93,7 +101,7 @@ jobs:
       install-mode: ${{ needs.get-config.outputs.install_mode }}
       setup-script: ${{ needs.get-config.outputs.setup_script }}
       post-setup-script: ${{ needs.get-config.outputs.post_setup_script }}
-      enable-lto: ${{ needs.get-config.outputs.enable_lto }}
+      enable-lto: ${{ inputs.enable-lto != '' && inputs.enable-lto || needs.get-config.outputs.enable_lto }}
       image: ${{ needs.build-image.outputs.image }}
       image-built: ${{ needs.build-image.outputs.succeeded }}
 
@@ -167,7 +175,7 @@ jobs:
       image-built: ${{ needs.build-image.outputs.succeeded }}
 
   test-flow-coordinator:
-    name: ${{ inputs.job-type }} (Coordinator ${{ matrix.shard }}/${{ inputs.job-type == 'basic-test' && 3 || 4 }})
+    name: ${{ inputs.job-type }} (Coordinator ${{ matrix.shard }}/${{ strategy.job-total }})
     needs: [get-config, build-image, build]
     if: ${{ !cancelled() && needs.build.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
     # Coordinator tests are the slowest flow suite (cluster setup, inter-shard
@@ -193,7 +201,8 @@ jobs:
       test-config: ${{ inputs.test-config }}
       test-mode: coordinator
       shard-index: ${{ matrix.shard }}
-      shard-total: ${{ inputs.job-type == 'basic-test' && 3 || 4 }}
+      # Derived from the matrix so the total can never drift from the shard list.
+      shard-total: ${{ strategy.job-total }}
       coverage: ${{ inputs.job-type == 'coverage' }}
       san: ${{ inputs.job-type == 'sanitize' && 'address' || '' }}
       rejson-branch: ${{ inputs.rejson-branch }}


### PR DESCRIPTION
## Describe the changes in the pull request

The PR flow was refactored to be highly parallel; the merge queue never got the same treatment. This brings the **master** merge queue onto the same build-once/fan-out pipeline. Merge queues targeting release branches (`8.x`) are deliberately left exactly as they are.

1. **Current**: `event-merge-to-queue.yml`'s ubuntu lane routes through `flow-test.yml` → `task-test.yml`, whose `common-flow` job is the pre-refactor monolith — build, C/C++ unit, Rust, standalone flow and coordinator flow all run as *sequential steps on one runner*. With `separate-coordinator-job: true` plus the ubsan entry, the module is built **three times**, and none of the builds share an artifact or the nextest archive. The build is also an LTO build, because `ubuntu:noble` carries `enable_lto: '1'` while the PR flow's `ubuntu:latest` is `'0'`.

2. **Change**: the master queue now calls `flow-pr-pipeline.yml` — one build, then unit + standalone + 3 coordinator shards as separate concurrent jobs off a single uploaded artifact. Shard counts are inherited from the PR flow rather than newly invented. The lane builds with LTO off, since it only runs tests and never ships the binary. The UBSan entry (a whole dedicated alignment-sanitizer build for one gtest filter) moves to `event-periodic-master-validation.yml`.

   Branch scoping is a job-level `if:` on `github.event.merge_group.base_ref`, so `pr-validation` keeps its name and **no ruleset / branch-protection changes are needed**. Release branches keep the old `flow-test.yml` lane verbatim, ubsan included.

3. **Outcome**: three builds collapse to one, the suites run concurrently instead of sequentially, and the LTO link leaves the queue's critical path. LTO codegen and the multi-OS sweep remain covered on master by `event-periodic-master-validation.yml` (every ~3h) and `event-nightly.yml`.

### Measurements

Sampled the 5 most recent successful `merge_group` runs on master. **Total wall time today: 57–65 min.**

| Job | Duration |
|---|---|
| `test-ubuntu` (Standalone) — build + unit + Rust + standalone flow, serial | **56–64m** ← the pole |
| `test-ubuntu` (Coordinator-only) — build + coordinator flow, serial | 34–41m |
| `build-unique-oses` alpine aarch64 (slowest of the sweep) | 14–15m |
| `lint` | 8–11m |
| `build-unique-oses` macos-26 / intel | 6–11m / 8m |
| `test-ubuntu` (ubsan) | 6m |

Two consequences, both of which shaped this PR:

- **`build-unique-oses` is deliberately left untouched.** At 15m worst case against a ~35m post-change lane it is free, so there is nothing to win by trimming it — including `intel`, despite its EC2 start/teardown sitting inside the reusable workflow.
- **Standalone is not worth sharding.** In the PR flow it is 13m, hiding behind a 19m build, and the 3-way coordinator split already brings coordinator (10/11/14m) to rough parity. The existing shard counts are well tuned, which is why this PR inherits them rather than inventing new ones.

**Projected post-change lane: ~33–38 min** — build (19–24m) + max(unit 6m, standalone 13m, coordinator/3 ~14m).

### Validated by a live run of the new lane

`merge_group` has no manual trigger, so the lane was exercised via the `flow-temp.yml` scratch harness mirroring `test-ubuntu-master` exactly. All jobs green on `ubuntu:noble` with `LTO=0`: build 24m, unit 6m, standalone 9m, coordinator shards 11m / 15m. (A third coordinator shard hung 27m in `Free up disk space (container)`, a pre-existing `rm -rf` over host bind-mounts present in 6 workflows — it never reached the tests.) The harness has since been reverted, so it is not part of this diff.

The 24m build there is a **cold** `sccache` key (33/516 hits, vs 514/516 on the warm `ubuntu:latest` key) — not evidence that LTO-off is slower. It self-heals once the queue has run a few times.

### Known, pre-existing, out of scope

`Swatinem/rust-cache` reports "No cache found" on *every* build job, including `ubuntu:latest` on every PR: its caches are written to `refs/pull/<N>/merge`, and Actions cache scoping only allows reads from the same ref or the default branch. The identical key `v2-rust-ubuntu:latest-x86_64---common-flow-Linux-x64-a6a664cd-b00ffcb3` currently exists on 5 separate PR refs. The Redis build cache misses for the same reason. So all Rust is recompiled from scratch on every build, in every PR and every queue entry. Worth its own change.


#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `.github/workflows/event-merge-to-queue.yml` — `test-ubuntu` split into `test-ubuntu-master` (fan-out) and `test-ubuntu-release-branch` (unchanged monolith)
2. `.github/workflows/flow-pr-pipeline.yml` — new optional `enable-lto` override; coordinator `shard-total` derived from `strategy.job-total` instead of restating the count
3. `.github/workflows/event-periodic-master-validation.yml` — gains the UBSan entry and its trie filter

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

CI-only change: no user-facing behavior, commands, or serialization are affected.
