### PR TITLE
[MOD-17545] Fix GC scheduling test flake caused by automatic RDB snapshots

### DIFF
--- a/tests/pytests/redis-test.conf
+++ b/tests/pytests/redis-test.conf
@@ -1,0 +1,7 @@
+# redis-server config for every server the pytest suite starts (see runtests.sh).
+
+# An unreachable save point instead of Redis's defaults: automatic snapshots otherwise take
+# Redis's single child slot from the fork GC. Not `save ""`, because the final snapshot on
+# SIGTERM only happens while a save point is configured and RLTest's restart-based reload
+# needs it.
+save 86400 1000000000

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -55,6 +55,8 @@ help() {
 		REDIS_SERVER=path     Location of redis-server
 		REDIS_PORT=n          Redis server port
 		CONFIG_FILE=file      Path to config file
+		REDIS_TEST_CONFIG=f   redis-server config for every server started, empty for Redis
+		                      defaults (default: redis-test.conf)
 
 		EXT=1|run             Test on existing env (1=running; run=start redis-server)
 		EXT_HOST=addr         Address of existing env (default: 127.0.0.1)
@@ -221,6 +223,7 @@ run_env() {
 	cat <<-EOF > $rltest_config
 		--env-only
 		--oss-redis-path=$REDIS_SERVER
+		--redis-config-file=$REDIS_TEST_CONFIG
 		--module $MODULE
 		--module-args '$MODARGS'
 		$RLTEST_ARGS
@@ -277,6 +280,7 @@ run_tests() {
 		if [[ $RLEC != 1 ]]; then
 			cat <<-EOF > $rltest_config
 				--oss-redis-path=$REDIS_SERVER
+				--redis-config-file=$REDIS_TEST_CONFIG
 				--module $MODULE
 				--module-args '$MODARGS'
 				$RLTEST_ARGS
@@ -301,10 +305,14 @@ run_tests() {
 			if [[ $REJSON_MODULE ]]; then
 				XREDIS_REJSON_ARGS="loadmodule $REJSON_MODULE $REJSON_ARGS"
 			fi
+			if [[ -n $REDIS_TEST_CONFIG ]]; then
+				XREDIS_INCLUDE="include $REDIS_TEST_CONFIG"
+			fi
 
 			xredis_conf=$(mktemp "${TMPDIR:-/tmp}/xredis_conf.XXXXXXX")
 			rm -f $xredis_conf
 			cat <<-EOF > $xredis_conf
+				$XREDIS_INCLUDE
 				loadmodule $MODULE $MODARGS
 				$XREDIS_REJSON_ARGS
 				EOF
@@ -393,6 +401,12 @@ RLEC_PORT=${RLEC_PORT:-12000}
 
 EXT_HOST=${EXT_HOST:-127.0.0.1}
 EXT_PORT=${EXT_PORT:-6379}
+
+# Absolute: RLTest starts each server in that test's db directory, not here.
+REDIS_TEST_CONFIG=${REDIS_TEST_CONFIG-$HERE/redis-test.conf}
+if [[ -n $REDIS_TEST_CONFIG ]] && ! is_abspath "$REDIS_TEST_CONFIG"; then
+	REDIS_TEST_CONFIG="$ROOT/$REDIS_TEST_CONFIG"
+fi
 
 PID=$$
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: Redis allows one child process at a time, and every pytest server runs with
   Redis's default save points. On a build whose `lastsave` starts stale, the first save point
   matches as soon as anything is written, so an automatic BGSAVE starts a fraction of a second
   after the server accepts connections and holds the child slot for the length of the save.

   A fork GC pass that reaches its fork inside that window fails with EEXIST (`Can't fork for
   module: File exists` / `fork failed - got errno 17`), collects nothing, and returns from
   `FGC_RunCycle` before `numCycles++`. A scheduled pass gets one attempt at the slot by design,
   since its next run is due anyway — but the GC scheduling tests disable collection *before*
   releasing the pass they are testing, so for them no later attempt is coming.
   `testGCStopScheduleDuringRun` then waits 30s on a counter that can no longer move, and
   `testGCContinueScheduleDuringRun_MOD_17309` reports a duplicate run that never happened
   (`0 -> 0`). The timing lines up badly on purpose: with `FORK_GC_RUN_INTERVAL 1` the first pass
   fires about a second after index creation, which is when the snapshot is in flight.

2. **Change**: `tests/pytests/redis-test.conf` (new) replaces the default save points with a
   single unreachable one (`save 86400 1000000000`), passed to redis-server by RLTest via
   `--redis-config-file` from every path in `runtests.sh` that starts a server, and overridable
   with `REDIS_TEST_CONFIG`.

   A billion changes is out of reach for a test, so no automatic save can start — and with that
   gone, nothing else in these standalone tests forks: no replica, no AOF, no explicit `SAVE`.
   The slot is per process, so servers running in parallel do not compete either.

   Deliberately **not** `save ""`: Redis writes the final snapshot on SIGTERM only while a save
   point is configured, and RLTest's restart-based reload relies on that snapshot. Explicit
   `SAVE`/`BGSAVE`/`DEBUG RELOAD` are unaffected, so the tests that stage fork contention on
   purpose (`testForcedGCWaitsForForkSlot`, `testForcedGCReportsWhenItCannotFork`) still do, and
   a test that wants automatic saves can set its own save points.

3. **Outcome**: no automatic snapshot competes with the module for the fork slot in any pytest
   server, in standalone or cluster mode. Test-environment change only — no product code.

**Verification** — against an `ENABLE_ASSERT=1` build, so the sync-point tests actually ran:
`test_gc.py` 31/31 and `test_resp3.py` 38/38 standalone, `test_resp3.py` 38/38 in cluster mode
(3 shards). Live servers report `CONFIG GET save` → `86400 1000000000`, confirmed on a
standalone server and on all three cluster shards, and 34 of 35 servers in the `test_gc.py` run
still logged `Saving the final RDB snapshot before exiting`, so the shutdown snapshot that
restart-based reload depends on is intact.

An earlier revision of this PR also added a `fork_failures` counter to `gc_stats` and had the
scheduling tests assert on cycles-plus-failures. Both are dropped: with automatic snapshots gone
there is no remaining competitor for the slot in those tests, and a permanent `gc_stats` field
named after the fork mechanism is not something to add as a passenger on a flake fix — metric
names outlive the mechanism they describe. Kept on MOD-17545 for whoever wants the observability
on its own terms.

#### Which additional issues this PR fixes
1. MOD-17545

#### Main objects this PR modified
1. `tests/pytests/redis-test.conf` (new) — the save-point policy and why it is what it is
2. `tests/pytests/runtests.sh` — `--redis-config-file` on the three server-starting paths, plus the `REDIS_TEST_CONFIG` override

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
