### PR TITLE
[Iterator Revalidation][MOD-17393] Keep exhaustion terminal across revalidate and resume

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -138,8 +138,7 @@ pub trait RQESuspendedIterator<'query> {
     /// up cannot recover its own position from it.
     ///
     /// Exhaustion must also survive the cycle: an iterator suspended at
-    /// [`at_eof`](RQEIterator::at_eof) must resume at it, for the reasons — and with
-    /// the same re-seek trap — spelled out on [`RQEIterator::revalidate`].
+    /// [`at_eof`](RQEIterator::at_eof) must resume at it.
     ///
     /// Resume re-reads/seeks the index to restore position (mirroring
     /// [`RQEIterator::revalidate`]), so it can fail with an

--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -137,6 +137,10 @@ pub trait RQESuspendedIterator<'query> {
     /// stale position that made the resume necessary — and a composite one level
     /// up cannot recover its own position from it.
     ///
+    /// Exhaustion must also survive the cycle: an iterator suspended at
+    /// [`at_eof`](RQEIterator::at_eof) must resume at it, for the reasons — and with
+    /// the same re-seek trap — spelled out on [`RQEIterator::revalidate`].
+    ///
     /// Resume re-reads/seeks the index to restore position (mirroring
     /// [`RQEIterator::revalidate`]), so it can fail with an
     /// [`RQEIteratorError`] (e.g. [`IoError`](RQEIteratorError::IoError) or

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -457,22 +457,83 @@ where
         // If there has been a GC cycle on this key while we were suspended, the offset might not be valid
         // anymore. This means that we need to seek the last docId we were at
         let last_doc_id = self.last_doc_id();
+        let was_at_eos = self.at_eos;
+        let result_doc_id = self.result.doc_id;
         // Reset the state of the reader
         self.rewind();
+
+        if was_at_eos {
+            // Exhaustion is terminal until `rewind` — see [`RQEIterator::at_eof`]. The re-seek
+            // below would re-find `last_doc_id`, the document we already yielded, and hand this
+            // iterator back to its parent as live; a composite that had dropped it on EOF would
+            // then re-admit it far behind the position it has moved on to.
+            //
+            // The `rewind` above still has to happen: it is the only thing that refreshes the
+            // reader's `gc_marker` and repoints it at a valid block, and
+            // [`ResumableReader::refresh_pointers`] deliberately leaves the buffer pointer stale
+            // on the GC path precisely because a rewind is coming. So we rewind and then restore
+            // the past-the-end position on top of it.
+            self.at_eos = true;
+            self.last_doc_id = last_doc_id;
+            // Skipping the re-seek also skips the re-decode that would have rebuilt the result's
+            // borrowed offsets against the live buffer, so drop them here instead. We only get
+            // this far when `needs_revalidation` fired, i.e. GC ran, and
+            // [`RefreshOutcome::NeedsReseek`] spells out that an `RSOffsetSlice` borrowed from
+            // the old buffer does not survive that. Nothing reads them through the trait —
+            // `current()` answers `None` while `at_eos` — but they sit behind an [`Active`]
+            // `SharedPtr` whose invariant says the referent is live, and a dangling pointer is
+            // not something to leave behind an invariant that denies it. The resume path clears
+            // them for the same reason, just before its own cast.
+            //
+            // Only `Borrowed` points into the index; the other variants own their offsets.
+            if let Some(RawTermRecord::Borrowed { offsets, .. }) = self.result.as_term_mut() {
+                *offsets = RawOffsetSlice::empty();
+            }
+            // Composites cache raw pointers into a child's result, so leave the id the last yield
+            // put there rather than the zero `rewind` wrote.
+            self.result.doc_id = result_doc_id;
+            return Ok(RQEValidateStatus::Ok);
+        }
 
         if last_doc_id == 0 {
             // No need to skip if we're starting from the very beginning.
             return Ok(RQEValidateStatus::Ok);
         }
 
+        /// Which of the three re-seek outcomes we landed on, as a plain tag: the borrow
+        /// [`skip_to`](RQEIterator::skip_to) hands back has to end before `self` can be
+        /// touched again.
+        enum Reseek {
+            /// Landed back on the document we held.
+            Found,
+            /// Landed on a later document.
+            Moved,
+            /// Nothing left at or after the document we held.
+            Exhausted,
+        }
+
         // Try jumping to the last docId
-        let res = match self.skip_to(last_doc_id)? {
-            Some(SkipToOutcome::Found(_)) => RQEValidateStatus::Ok,
-            Some(SkipToOutcome::NotFound(doc)) => RQEValidateStatus::Moved { current: Some(doc) },
-            None => RQEValidateStatus::Moved { current: None },
+        let reseek = match self.skip_to(last_doc_id)? {
+            Some(SkipToOutcome::Found(_)) => Reseek::Found,
+            Some(SkipToOutcome::NotFound(_)) => Reseek::Moved,
+            None => Reseek::Exhausted,
         };
 
-        Ok(res)
+        match reseek {
+            Reseek::Found => Ok(RQEValidateStatus::Ok),
+            Reseek::Moved => Ok(RQEValidateStatus::Moved {
+                current: self.current(),
+            }),
+            Reseek::Exhausted => {
+                // The document we were sitting on is gone and there is nothing after it, so we
+                // are now past the end. An exhausted iterator still reports the position its
+                // last yield left it at (see [`RQEIterator::last_doc_id`]) — the `rewind` above
+                // zeroed it, and `skip_to` leaves it alone when it carries no result, so restore
+                // it rather than claiming we never read anything.
+                self.last_doc_id = last_doc_id;
+                Ok(RQEValidateStatus::Moved { current: None })
+            }
+        }
     }
 
     #[inline(always)]
@@ -565,6 +626,11 @@ where
         // while a freshly-created iterator is suspended, resume would reseek to that first
         // doc and report Ok, causing the next read() to skip the first result.
         let last_doc_id = self.last_doc_id;
+        // Read before the `Suspended → Active` cast below: both are mode-independent, and the
+        // re-seek in step 3 has to know whether it is restoring a live position or a
+        // past-the-end one.
+        let was_at_eos = self.at_eos;
+        let result_doc_id = self.result.doc_id;
 
         // Step 1: refresh reader pointers *on the suspended form*. This never
         // materializes a `&'a` borrow of any potentially-dangling field — the
@@ -619,6 +685,20 @@ where
             RefreshOutcome::NeedsReseek => {
                 active.rewind();
 
+                if was_at_eos {
+                    // Exhaustion is terminal until `rewind` — the same restore
+                    // [`RQEIterator::revalidate`] performs, and for the same reason: the re-seek
+                    // below would re-find the document we already yielded and report this
+                    // iterator as live to a composite that had written it off. The `rewind` above
+                    // still has to run — it is what repoints the reader at a valid block and
+                    // refreshes its `gc_marker` after `refresh_pointers` deliberately left the
+                    // buffer pointer stale.
+                    active.at_eos = true;
+                    active.last_doc_id = last_doc_id;
+                    active.result.doc_id = result_doc_id;
+                    return Ok(ResumeStatus::Unchanged);
+                }
+
                 if last_doc_id == 0 {
                     // We hadn't returned anything yet, so there's nothing to
                     // re-seek; a fresh `read()` will produce the right next doc.
@@ -627,7 +707,14 @@ where
 
                 Ok(match active.skip_to(last_doc_id)? {
                     Some(SkipToOutcome::Found(_)) => ResumeStatus::Unchanged,
-                    Some(SkipToOutcome::NotFound(_)) | None => ResumeStatus::Moved,
+                    Some(SkipToOutcome::NotFound(_)) => ResumeStatus::Moved,
+                    None => {
+                        // Past the end now. Restore the position the last yield left, which the
+                        // `rewind` above zeroed — see the matching arm in
+                        // [`RQEIterator::revalidate`].
+                        active.last_doc_id = last_doc_id;
+                        ResumeStatus::Moved
+                    }
                 })
             }
         }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/core.rs
@@ -463,34 +463,29 @@ where
         self.rewind();
 
         if was_at_eos {
-            // Exhaustion is terminal until `rewind` — see [`RQEIterator::at_eof`]. The re-seek
-            // below would re-find `last_doc_id`, the document we already yielded, and hand this
-            // iterator back to its parent as live; a composite that had dropped it on EOF would
-            // then re-admit it far behind the position it has moved on to.
+            // Restore the past-the-end position rather than re-seek to it. Exhaustion is
+            // terminal (see [`RQEIterator::at_eof`]), and re-seeking would end it silently: the
+            // `rewind` clears `at_eos`, and the seek then *finds* the document we already
+            // yielded, so we would come back live on a result our parent has consumed.
             //
-            // The `rewind` above still has to happen: it is the only thing that refreshes the
-            // reader's `gc_marker` and repoints it at a valid block, and
-            // [`ResumableReader::refresh_pointers`] deliberately leaves the buffer pointer stale
-            // on the GC path precisely because a rewind is coming. So we rewind and then restore
-            // the past-the-end position on top of it.
+            // The `rewind` above still has to run: it is the only thing that refreshes the
+            // reader's `gc_marker` and repoints it at a valid block, which is why
+            // [`ResumableReader::refresh_pointers`] leaves the buffer pointer stale on the GC
+            // path.
             self.at_eos = true;
             self.last_doc_id = last_doc_id;
-            // Skipping the re-seek also skips the re-decode that would have rebuilt the result's
-            // borrowed offsets against the live buffer, so drop them here instead. We only get
-            // this far when `needs_revalidation` fired, i.e. GC ran, and
-            // [`RefreshOutcome::NeedsReseek`] spells out that an `RSOffsetSlice` borrowed from
-            // the old buffer does not survive that. Nothing reads them through the trait —
-            // `current()` answers `None` while `at_eos` — but they sit behind an [`Active`]
-            // `SharedPtr` whose invariant says the referent is live, and a dangling pointer is
-            // not something to leave behind an invariant that denies it. The resume path clears
-            // them for the same reason, just before its own cast.
-            //
-            // Only `Borrowed` points into the index; the other variants own their offsets.
+            // Skipping the re-seek also skips the re-decode that would have rebuilt these
+            // against the live buffer, and [`RefreshOutcome::NeedsReseek`] — the only way here —
+            // says an `RSOffsetSlice` borrowed from the old buffer does not survive GC. Nothing
+            // reads them (`current()` answers `None` while `at_eos`), but they sit behind an
+            // [`Active`] `SharedPtr` whose invariant says the referent is live. Only `Borrowed`
+            // points into the index.
             if let Some(RawTermRecord::Borrowed { offsets, .. }) = self.result.as_term_mut() {
                 *offsets = RawOffsetSlice::empty();
             }
             // Composites cache raw pointers into a child's result, so leave the id the last yield
-            // put there rather than the zero `rewind` wrote.
+            // put there rather than the zero `rewind` wrote. Only reachable through those cached
+            // pointers, so no Rust-side test observes it.
             self.result.doc_id = result_doc_id;
             return Ok(RQEValidateStatus::Ok);
         }
@@ -504,11 +499,8 @@ where
         /// [`skip_to`](RQEIterator::skip_to) hands back has to end before `self` can be
         /// touched again.
         enum Reseek {
-            /// Landed back on the document we held.
             Found,
-            /// Landed on a later document.
             Moved,
-            /// Nothing left at or after the document we held.
             Exhausted,
         }
 
@@ -521,9 +513,14 @@ where
 
         match reseek {
             Reseek::Found => Ok(RQEValidateStatus::Ok),
-            Reseek::Moved => Ok(RQEValidateStatus::Moved {
-                current: self.current(),
-            }),
+            Reseek::Moved => {
+                let current = self.current();
+                // The re-seek carried a result, so it left us on a document. Asserted rather
+                // than assumed: a `None` here would quietly downgrade this to
+                // `Moved { current: None }`, which reads as exhausted.
+                debug_assert!(current.is_some());
+                Ok(RQEValidateStatus::Moved { current })
+            }
             Reseek::Exhausted => {
                 // The document we were sitting on is gone and there is nothing after it, so we
                 // are now past the end. An exhausted iterator still reports the position its
@@ -686,13 +683,9 @@ where
                 active.rewind();
 
                 if was_at_eos {
-                    // Exhaustion is terminal until `rewind` — the same restore
-                    // [`RQEIterator::revalidate`] performs, and for the same reason: the re-seek
-                    // below would re-find the document we already yielded and report this
-                    // iterator as live to a composite that had written it off. The `rewind` above
-                    // still has to run — it is what repoints the reader at a valid block and
-                    // refreshes its `gc_marker` after `refresh_pointers` deliberately left the
-                    // buffer pointer stale.
+                    // The same restore, for the same reasons — including why the `rewind` above
+                    // still has to run — as the [`RQEIterator::revalidate`] twin. The offsets it
+                    // clears there are cleared on this path already, ahead of the cast above.
                     active.at_eos = true;
                     active.last_doc_id = last_doc_id;
                     active.result.doc_id = result_doc_id;

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -219,6 +219,22 @@ pub trait RQEIterator<'index> {
     /// The iterator should check if it is still valid by comparing its stored state
     /// against the current index state.
     ///
+    /// # Exhaustion is terminal
+    ///
+    /// An implementation that was at [`at_eof`](Self::at_eof) on entry must still be
+    /// at it on return — only [`rewind`](Self::rewind) restarts an iterator, and
+    /// [`Moved`](RQEValidateStatus::Moved)`{ current: Some(_) }` out of the exhausted
+    /// state is forbidden outright. Callers act on exhaustion irreversibly: a
+    /// composite drops the children that report it, so one that comes back alive
+    /// re-enters a parent that has already moved on without it, replaying documents
+    /// from behind the position that parent now holds.
+    ///
+    /// The trap is restoring a position by re-seeking: [`rewind`](Self::rewind) clears
+    /// the past-the-end state, and a re-seek to the last yielded document *finds* it,
+    /// so an exhausted iterator silently becomes a live one sitting on a result it has
+    /// already handed out. Restore the exhausted position instead of seeking back to
+    /// it. The same requirement applies to [`RQESuspendedIterator::resume`].
+    ///
     /// # Errors
     ///
     /// Revalidation re-reads and seeks the index to restore the position, so it can fail with an

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -221,19 +221,10 @@ pub trait RQEIterator<'index> {
     ///
     /// # Exhaustion is terminal
     ///
-    /// An implementation that was at [`at_eof`](Self::at_eof) on entry must still be
-    /// at it on return — only [`rewind`](Self::rewind) restarts an iterator, and
-    /// [`Moved`](RQEValidateStatus::Moved)`{ current: Some(_) }` out of the exhausted
-    /// state is forbidden outright. Callers act on exhaustion irreversibly: a
-    /// composite drops the children that report it, so one that comes back alive
-    /// re-enters a parent that has already moved on without it, replaying documents
-    /// from behind the position that parent now holds.
-    ///
-    /// The trap is restoring a position by re-seeking: [`rewind`](Self::rewind) clears
-    /// the past-the-end state, and a re-seek to the last yielded document *finds* it,
-    /// so an exhausted iterator silently becomes a live one sitting on a result it has
-    /// already handed out. Restore the exhausted position instead of seeking back to
-    /// it. The same requirement applies to [`RQESuspendedIterator::resume`].
+    /// An implementation that was at [`at_eof`](Self::at_eof) on entry must still be at
+    /// it on return, and [`Moved`](RQEValidateStatus::Moved)`{ current: Some(_) }` out
+    /// of the exhausted state is forbidden outright — see [`at_eof`](Self::at_eof),
+    /// which owns the rule and why callers cannot undo acting on it.
     ///
     /// # Errors
     ///
@@ -303,6 +294,15 @@ pub trait RQEIterator<'index> {
     /// strict negations, for an implementation that materialises its result only
     /// on a read: [`current`](Self::current) already answers `None` there while
     /// this is still `false`, as its `# Usage` describes.
+    ///
+    /// # Exhaustion is terminal
+    ///
+    /// Once this is `true` it stays `true` until [`rewind`](Self::rewind), across
+    /// [`revalidate`](Self::revalidate) and [`resume`](RQESuspendedIterator::resume)
+    /// included. Callers act on exhaustion irreversibly: a composite drops the children
+    /// that report it, so one that comes back alive re-enters a parent that has already
+    /// moved on without it, replaying documents from behind the position that parent
+    /// now holds.
     fn at_eof(&self) -> bool;
 
     /// Returns the [`IteratorType`] of this iterator.

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -357,9 +357,12 @@ where
 
         // 3. If the wildcard moved, sync state.
         if matches!(wcii_status, RQEValidateStatus::Moved { .. }) {
-            // Sync the EOF flag with the wildcard iterator. This clears a
-            // previously-set forced_eof so the iterator can recover.
-            self.forced_eof = self.wcii.at_eof();
+            // Sync the EOF flag with the wildcard iterator. Latched, never assigned: a
+            // wildcard that has run out means we have too, and clearing the flag would
+            // let a wildcard that recovered documents revive an iterator this one had
+            // already reported as exhausted. `OptionalOptimized` latches the same way,
+            // for the same reason — `rewind` is what restarts an iterator.
+            self.forced_eof |= self.wcii.at_eof();
             // Track whether we land on a valid NOT result. Starts true
             // when wcii is not at EOF (we have a candidate position).
             //
@@ -369,7 +372,15 @@ where
             // loop and `skip_to`, because each publishes a wildcard position of
             // its own. Without it, a concurrent index change could hand a native
             // parent `Moved { current: Some(_) }` with an out-of-range id.
-            let mut have_valid_pos = !self.forced_eof && self.wcii.last_doc_id() <= self.max_doc_id;
+            //
+            // `past_end` joins the guard because exhaustion is terminal until `rewind`
+            // (see [`RQEIterator::at_eof`]): an iterator that entered revalidation past
+            // its end must not leave it holding a position again. `forced_eof` alone is
+            // not enough — [`read`](RQEIterator::read) recomputes `past_end` from
+            // `read_inner`, so a `past_end` set without it would be dropped on the next
+            // read.
+            let mut have_valid_pos =
+                !self.past_end && !self.forced_eof && self.wcii.last_doc_id() <= self.max_doc_id;
             if have_valid_pos {
                 self.result.doc_id = self.wcii.last_doc_id();
 
@@ -407,8 +418,8 @@ where
             // Keep the has-current state in step with what we are about to
             // report: a `Moved { current: None }` must leave `current()` — and
             // `at_eof()`, its negation — agreeing with it, rather than handing
-            // back the stale pre-revalidation result. Landing on a valid position
-            // clears the flag, mirroring the `forced_eof` recovery above.
+            // back the stale pre-revalidation result. This only ever sets the flag:
+            // `have_valid_pos` is false whenever it was already set, per the guard above.
             self.past_end = !have_valid_pos;
 
             Ok(RQEValidateStatus::Moved {

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -357,10 +357,12 @@ where
 
         // 3. If the wildcard moved, sync state.
         if matches!(wcii_status, RQEValidateStatus::Moved { .. }) {
-            // Sync the EOF flag with the wildcard iterator. Latched, never assigned: a
-            // wildcard that has run out means we have too, and clearing the flag would
-            // revive an iterator already reported as exhausted (see
-            // [`RQEIterator::at_eof`]). `OptionalOptimized` latches the same way.
+            // Latched, never assigned. The two flags do not record the same fact: besides
+            // the wildcard running out, `forced_eof` marks this iterator's `max_doc_id`
+            // window closing, which `skip_to` sets with the wildcard still live on a
+            // document. Assigning would clear it there, and the next `read` would resume
+            // an iterator already reported as exhausted — terminal until `rewind`, see
+            // [`RQEIterator::at_eof`]. `OptionalOptimized` latches the same way.
             self.forced_eof |= self.wcii.at_eof();
             // Track whether we land on a valid NOT result. Starts true
             // when wcii is not at EOF (we have a candidate position).
@@ -372,10 +374,10 @@ where
             // its own. Without it, a concurrent index change could hand a native
             // parent `Moved { current: Some(_) }` with an out-of-range id.
             //
-            // `past_end` joins the guard because exhaustion is terminal. `forced_eof`
-            // alone is not enough: [`read`](RQEIterator::read) recomputes `past_end`
-            // from `read_inner`, so a `past_end` set without it would be dropped on the
-            // next read.
+            // `past_end` guards the answer this call gives; the latch above guards the
+            // next [`read`](RQEIterator::read). Neither covers for the other: `past_end`
+            // is not sticky, and it can be set while `forced_eof` is clear — a position
+            // already sitting on `max_doc_id`.
             let mut have_valid_pos =
                 !self.past_end && !self.forced_eof && self.wcii.last_doc_id() <= self.max_doc_id;
             if have_valid_pos {

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -52,8 +52,6 @@ pub struct RawNotOptimized<'query, Rf: Ref, W, I, TC> {
     child: MaybeEmpty<I>,
     /// The maximum document ID (used as upper bound guard).
     max_doc_id: DocId,
-    /// Sticky EOF flag, set when iteration completes.
-    forced_eof: bool,
     /// A reusable result object to avoid allocations on each [`read`](RQEIterator::read) call.
     result: RawIndexResult<'query, Rf>,
     /// Whether the iterator has run *past* its last result, i.e. a
@@ -63,8 +61,11 @@ pub struct RawNotOptimized<'query, Rf: Ref, W, I, TC> {
     /// [`at_eof`](RQEIterator::at_eof). It cannot be folded into `result.doc_id`:
     /// that field *is* [`last_doc_id`](RQEIterator::last_doc_id).
     ///
-    /// Unlike [`Self::forced_eof`] this is not sticky; see
-    /// [`read`](RQEIterator::read) for why.
+    /// Sticky: only [`rewind`](RQEIterator::rewind) clears it, because exhaustion is
+    /// terminal (see [`at_eof`](RQEIterator::at_eof)). That is what lets it also serve
+    /// as [`has_next`](Self::has_next)'s guard, so the reason the iterator stopped —
+    /// the wildcard running out, or this iterator's `max_doc_id` window closing — does
+    /// not need a flag of its own.
     past_end: bool,
     /// Tracks the execution deadline for this iterator. Pass
     /// [`NoTimeoutChecker`](timeout::NoTimeoutChecker) to opt out of timeout checks
@@ -96,7 +97,6 @@ where
             wcii,
             child: MaybeEmpty::new(child),
             max_doc_id,
-            forced_eof: false,
             past_end: false,
             result: RSIndexResult::build_virt()
                 .weight(weight)
@@ -112,15 +112,15 @@ where
         self.timeout_ctx.check_timeout()
     }
 
-    /// Advance the wildcard iterator and set [`forced_eof`](Self::forced_eof)
-    /// if it is exhausted.
+    /// Advance the wildcard iterator and set [`past_end`](Self::past_end) if it is
+    /// exhausted.
     ///
     /// Returns `Ok(true)` if the wildcard iterator produced a new document,
     /// `Ok(false)` if it reached EOF.
     #[inline(always)]
     fn advance_wcii_or_eof(&mut self) -> Result<bool, RQEIteratorError> {
         if self.wcii.read()?.is_none() {
-            self.forced_eof = true;
+            self.past_end = true;
             return Ok(false);
         }
         Ok(true)
@@ -131,14 +131,14 @@ where
         self.child.as_ref()
     }
 
-    /// Whether there is another result to yield: iteration has not completed and
-    /// the wildcard has not run out.
+    /// Whether there is another result to yield: the iterator has not run past its
+    /// end, and its position is still inside the `max_doc_id` window.
     ///
-    /// Goes `false` one step before [`Self::past_end`] is set, while the final
-    /// result is still current.
+    /// The second term goes `false` one step before [`Self::past_end`] is set, while
+    /// the final result is still current.
     #[inline(always)]
     const fn has_next(&self) -> bool {
-        !self.forced_eof && self.result.doc_id < self.max_doc_id
+        !self.past_end && self.result.doc_id < self.max_doc_id
     }
 
     /// Check whether the child iterator is positionally past `doc_id`
@@ -162,9 +162,12 @@ where
     ///
     /// Returns `Ok(true)` if a valid result was found (stored in
     /// `self.result.doc_id`), `Ok(false)` if EOF was reached.
+    ///
+    /// Every `Ok(false)` leaves [`past_end`](Self::past_end) set, so callers report
+    /// exhaustion by relaying the answer rather than re-deriving it.
     fn read_inner(&mut self) -> Result<bool, RQEIteratorError> {
         if !self.has_next() {
-            self.forced_eof = true;
+            self.past_end = true;
             return Ok(false);
         }
 
@@ -186,7 +189,7 @@ where
             // Checked here rather than beside the assignment below, because Case 2
             // re-advances the wildcard and loops back round.
             if wcii_last > self.max_doc_id {
-                self.forced_eof = true;
+                self.past_end = true;
                 return Ok(false);
             }
 
@@ -236,10 +239,7 @@ where
 
     #[inline(always)]
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
-        let found = self.read_inner()?;
-        self.past_end = !found;
-
-        if found {
+        if self.read_inner()? {
             Ok(Some(&mut self.result))
         } else {
             Ok(None)
@@ -258,14 +258,12 @@ where
             return Ok(None);
         }
         if doc_id > self.max_doc_id {
-            self.forced_eof = true;
             self.past_end = true;
             return Ok(None);
         }
 
         // Skip wcii to docId.
         if self.wcii.skip_to(doc_id)?.is_none() {
-            self.forced_eof = true;
             self.past_end = true;
             return Ok(None);
         }
@@ -279,7 +277,6 @@ where
         // Checked before the child is synced to it, and before it is published as
         // this iterator's position.
         if wcii_last > self.max_doc_id {
-            self.forced_eof = true;
             self.past_end = true;
             return Ok(None);
         }
@@ -292,18 +289,16 @@ where
         // If child landed at the same position, the document is in the
         // child. Advance to find the next valid NOT result.
         if self.child.last_doc_id() == wcii_last {
-            let found = self.read_inner()?;
-            self.past_end = !found;
-
-            if found {
+            if self.read_inner()? {
                 return Ok(Some(SkipToOutcome::NotFound(&mut self.result)));
             } else {
                 return Ok(None);
             }
         }
 
-        // Child is ahead or depleted: wcii_last is a valid result.
-        self.past_end = false;
+        // Child is ahead or depleted: wcii_last is a valid result. `past_end` needs no
+        // clearing — reaching here means `has_next()` was true above, so it is already
+        // `false`, and nothing but `rewind` may clear it anyway.
         self.result.doc_id = wcii_last;
         if self.result.doc_id == doc_id {
             Ok(Some(SkipToOutcome::Found(&mut self.result)))
@@ -314,7 +309,6 @@ where
 
     #[inline(always)]
     fn rewind(&mut self) {
-        self.forced_eof = false;
         self.past_end = false;
         self.result.doc_id = 0;
         self.wcii.rewind();
@@ -357,13 +351,11 @@ where
 
         // 3. If the wildcard moved, sync state.
         if matches!(wcii_status, RQEValidateStatus::Moved { .. }) {
-            // Latched, never assigned. The two flags do not record the same fact: besides
-            // the wildcard running out, `forced_eof` marks this iterator's `max_doc_id`
-            // window closing, which `skip_to` sets with the wildcard still live on a
-            // document. Assigning would clear it there, and the next `read` would resume
-            // an iterator already reported as exhausted — terminal until `rewind`, see
-            // [`RQEIterator::at_eof`]. `OptionalOptimized` latches the same way.
-            self.forced_eof |= self.wcii.at_eof();
+            // Latched, never assigned: exhaustion is terminal, and this iterator's own
+            // reasons for reaching it — the `max_doc_id` window closing, which `skip_to`
+            // records with the wildcard still live on a document — outlive whatever the
+            // wildcard now answers. Assigning would drop them.
+            self.past_end |= self.wcii.at_eof();
             // Track whether we land on a valid NOT result. Starts true
             // when wcii is not at EOF (we have a candidate position).
             //
@@ -373,13 +365,7 @@ where
             // loop and `skip_to`, because each publishes a wildcard position of
             // its own. Without it, a concurrent index change could hand a native
             // parent `Moved { current: Some(_) }` with an out-of-range id.
-            //
-            // `past_end` guards the answer this call gives; the latch above guards the
-            // next [`read`](RQEIterator::read). Neither covers for the other: `past_end`
-            // is not sticky, and it can be set while `forced_eof` is clear — a position
-            // already sitting on `max_doc_id`.
-            let mut have_valid_pos =
-                !self.past_end && !self.forced_eof && self.wcii.last_doc_id() <= self.max_doc_id;
+            let mut have_valid_pos = !self.past_end && self.wcii.last_doc_id() <= self.max_doc_id;
             if have_valid_pos {
                 self.result.doc_id = self.wcii.last_doc_id();
 
@@ -417,9 +403,10 @@ where
             // Keep the has-current state in step with what we are about to
             // report: a `Moved { current: None }` must leave `current()` — and
             // `at_eof()`, its negation — agreeing with it, rather than handing
-            // back the stale pre-revalidation result. This only ever sets the flag:
-            // `have_valid_pos` is false whenever it was already set, per the guard above.
-            self.past_end = !have_valid_pos;
+            // back the stale pre-revalidation result.
+            if !have_valid_pos {
+                self.past_end = true;
+            }
 
             Ok(RQEValidateStatus::Moved {
                 current: if have_valid_pos {
@@ -454,7 +441,6 @@ where
             wcii: self.wcii,
             child: self.child.map(crate::c2rust::CRQEIterator::into_profiled),
             max_doc_id: self.max_doc_id,
-            forced_eof: self.forced_eof,
             result: self.result,
             past_end: self.past_end,
             timeout_ctx: self.timeout_ctx,

--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -359,9 +359,8 @@ where
         if matches!(wcii_status, RQEValidateStatus::Moved { .. }) {
             // Sync the EOF flag with the wildcard iterator. Latched, never assigned: a
             // wildcard that has run out means we have too, and clearing the flag would
-            // let a wildcard that recovered documents revive an iterator this one had
-            // already reported as exhausted. `OptionalOptimized` latches the same way,
-            // for the same reason — `rewind` is what restarts an iterator.
+            // revive an iterator already reported as exhausted (see
+            // [`RQEIterator::at_eof`]). `OptionalOptimized` latches the same way.
             self.forced_eof |= self.wcii.at_eof();
             // Track whether we land on a valid NOT result. Starts true
             // when wcii is not at EOF (we have a candidate position).
@@ -373,12 +372,10 @@ where
             // its own. Without it, a concurrent index change could hand a native
             // parent `Moved { current: Some(_) }` with an out-of-range id.
             //
-            // `past_end` joins the guard because exhaustion is terminal until `rewind`
-            // (see [`RQEIterator::at_eof`]): an iterator that entered revalidation past
-            // its end must not leave it holding a position again. `forced_eof` alone is
-            // not enough — [`read`](RQEIterator::read) recomputes `past_end` from
-            // `read_inner`, so a `past_end` set without it would be dropped on the next
-            // read.
+            // `past_end` joins the guard because exhaustion is terminal. `forced_eof`
+            // alone is not enough: [`read`](RQEIterator::read) recomputes `past_end`
+            // from `read_inner`, so a `past_end` set without it would be dropped on the
+            // next read.
             let mut have_valid_pos =
                 !self.past_end && !self.forced_eof && self.wcii.last_doc_id() <= self.max_doc_id;
             if have_valid_pos {

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -604,7 +604,9 @@ where
         let mut any_change = false;
 
         // Revalidate ALL children (including exhausted ones past num_active) and remove aborted ones.
-        // Exhausted children must be revalidated because they may become active again after revalidation.
+        // The exhausted ones still hold index references, and an aborted one has to go either way —
+        // but they cannot come back active, since exhaustion is terminal (see
+        // [`RQEIterator::at_eof`]).
         // We use index-based iteration because we need to remove elements while iterating.
         let mut i = 0;
         while i < self.children.len() {

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -676,14 +676,18 @@ where
         // and `Not::revalidate` asserts that of its child — which is where a
         // `QUICK_EXIT` union usually sits.
         //
-        // Both modes can see one. With `QUICK_EXIT` it is the mode's own early
-        // return: `skip_to_quick` stops on the first exact match, so a later sibling
-        // keeps an earlier round's id, or answers 0 having never been read at all.
-        // Without it there is exactly one way: a child that ran out and was dropped
-        // can *resurrect* during the revalidation above — an inverted-index leaf
-        // rewinds and re-seeks the position it held, and rewinding clears the
-        // past-the-end state — so it re-enters the active set far behind a union
-        // that carried on without it.
+        // With `QUICK_EXIT` this is the mode's own early return, and routine:
+        // `skip_to_quick` stops on the first exact match, so a later sibling keeps an
+        // earlier round's id, or answers 0 having never been read at all.
+        //
+        // A full union reaches this only if a child broke the contract, since
+        // `advance_and_find_min` leaves no active child behind the union and exhaustion
+        // is terminal across a revalidation (see [`RQEIterator::at_eof`]), so a child
+        // dropped on EOF cannot re-enter the active set behind us. Children include
+        // `CRQEIterator` wrapping a C implementation and the enterprise disk iterators,
+        // neither of which this crate can vouch for, so the recovery below stays rather
+        // than becoming an assertion — it is covered by
+        // `revalidate_resurrected_child_does_not_drag_a_full_union_backwards`.
         if min_doc_id < original_last_doc_id {
             // A child still sitting on the union's document backs the position as it
             // stands: republish from it (the result holds raw pointers into children

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -680,15 +680,18 @@ where
         // `skip_to_quick` stops on the first exact match, so a later sibling keeps an
         // earlier round's id, or answers 0 having never been read at all.
         //
-        // A full union reaches this only if a child broke the contract, since
-        // `advance_and_find_min` leaves no active child behind the union and exhaustion
-        // is terminal across a revalidation (see [`RQEIterator::at_eof`]), so a child
-        // dropped on EOF cannot re-enter the active set behind us. Children include
-        // `CRQEIterator` wrapping a C implementation and the enterprise disk iterators,
-        // neither of which this crate can vouch for, so the recovery below stays rather
-        // than becoming an assertion — it is covered by
-        // `revalidate_resurrected_child_does_not_drag_a_full_union_backwards`.
+        // A full union cannot get here: `advance_and_find_min` leaves no active child
+        // behind the union, and exhaustion is terminal across a revalidation (see
+        // [`RQEIterator::at_eof`]), so a child dropped on EOF cannot re-enter the active
+        // set behind us. Asserted rather than compensated for — the recovery below is
+        // quick mode's, and a full union arriving in it means a child is broken.
         if min_doc_id < original_last_doc_id {
+            debug_assert!(
+                QUICK_EXIT,
+                "a full union's child moved behind the union's position: doc {min_doc_id} \
+                 comes before doc {original_last_doc_id}",
+            );
+
             // A child still sitting on the union's document backs the position as it
             // stands: republish from it (the result holds raw pointers into children
             // that may have moved or been dropped) and report `Ok`, with no reads

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -572,15 +572,19 @@ where
         // never been read and an earlier round's id for one that
         // `advance_lagging_children` left in the heap when it returned on an exact match.
         //
-        // A full union reaches this only if a child broke the contract, since
-        // `advance_matching_children` leaves no active child behind the union and
-        // exhaustion is terminal across a revalidation (see [`RQEIterator::at_eof`]), so
-        // a child dropped on EOF cannot be re-admitted by `rebuild_heap` behind us.
-        // Children include `CRQEIterator` wrapping a C implementation and the enterprise
-        // disk iterators, neither of which this crate can vouch for, so the recovery
-        // below stays rather than becoming an assertion — it is covered by
-        // `revalidate_resurrected_child_does_not_drag_a_full_union_backwards`.
+        // A full union cannot get here: `advance_matching_children` leaves no active
+        // child behind the union, and exhaustion is terminal across a revalidation (see
+        // [`RQEIterator::at_eof`]), so a child dropped on EOF cannot be re-admitted by
+        // `rebuild_heap` behind us. Asserted rather than compensated for — the recovery
+        // below is quick mode's, and a full union arriving in it means a child is broken.
         if min.doc_id < original_last_doc_id {
+            debug_assert!(
+                QUICK_EXIT,
+                "a full union's child moved behind the union's position: doc {} comes \
+                 before doc {original_last_doc_id}",
+                min.doc_id,
+            );
+
             // A child still sitting on the union's document backs the position as it
             // stands: republish from it (the result holds raw pointers into children
             // that may have moved or been dropped) and report `Ok`, with no reads

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -567,15 +567,19 @@ where
         // and `Not::revalidate` asserts that of its child — which is where a
         // `QUICK_EXIT` union usually sits.
         //
-        // Both modes can see one. With `QUICK_EXIT` it is the mode's own early
-        // return: `rebuild_heap` keys on `last_doc_id()`, which answers 0 for a child
-        // that has never been read and an earlier round's id for one that
-        // `advance_lagging_children` left in the heap when it returned on an exact
-        // match. Without it there is exactly one way: a child that ran out and was
-        // dropped can *resurrect* during the revalidation above — an inverted-index
-        // leaf rewinds and re-seeks the position it held, and rewinding clears the
-        // past-the-end state — so `rebuild_heap` re-admits it far behind a union that
-        // carried on without it.
+        // With `QUICK_EXIT` this is the mode's own early return, and routine:
+        // `rebuild_heap` keys on `last_doc_id()`, which answers 0 for a child that has
+        // never been read and an earlier round's id for one that
+        // `advance_lagging_children` left in the heap when it returned on an exact match.
+        //
+        // A full union reaches this only if a child broke the contract, since
+        // `advance_matching_children` leaves no active child behind the union and
+        // exhaustion is terminal across a revalidation (see [`RQEIterator::at_eof`]), so
+        // a child dropped on EOF cannot be re-admitted by `rebuild_heap` behind us.
+        // Children include `CRQEIterator` wrapping a C implementation and the enterprise
+        // disk iterators, neither of which this crate can vouch for, so the recovery
+        // below stays rather than becoming an assertion — it is covered by
+        // `revalidate_resurrected_child_does_not_drag_a_full_union_backwards`.
         if min.doc_id < original_last_doc_id {
             // A child still sitting on the union's document backs the position as it
             // stands: republish from it (the result holds raw pointers into children

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/missing.rs
@@ -150,6 +150,15 @@ mod not_miri {
     }
 
     #[test]
+    fn missing_revalidate_at_eof_after_gc() {
+        let test = MissingRevalidateTest::new(10);
+        let mut it = ContractChecker::new(test.create_iterator());
+        let ii = DocIdsOnly::from_mut_opaque(test.test.context.missing_inverted_index());
+
+        test.test.revalidate_at_eof_after_gc(&mut it, ii);
+    }
+
+    #[test]
     fn missing_revalidate_after_index_disappears() {
         let test = MissingRevalidateTest::new(10);
         let mut it = ContractChecker::new(test.create_iterator());
@@ -268,7 +277,8 @@ mod not_miri {
     mod via_resume {
         use super::*;
         use crate::inverted_index::utils::via_resume::{
-            revalidate_after_document_deleted, revalidate_at_eof, revalidate_basic,
+            revalidate_after_document_deleted, revalidate_at_eof, revalidate_at_eof_after_gc,
+            revalidate_basic,
         };
         use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator};
         use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
@@ -285,6 +295,15 @@ mod not_miri {
             let test = MissingRevalidateTest::new(10);
             let it = test.create_iterator();
             revalidate_at_eof(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn missing_revalidate_at_eof_after_gc() {
+            let test = MissingRevalidateTest::new(10);
+            let it = test.create_iterator();
+            let ii = DocIdsOnly::from_mut_opaque(test.test.context.missing_inverted_index());
+
+            revalidate_at_eof_after_gc(&test.test, Box::new(it), ii);
         }
 
         #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -1107,6 +1107,15 @@ mod not_miri {
     }
 
     #[test]
+    fn numeric_revalidate_at_eof_after_gc() {
+        let test = NumericRevalidateTest::new(10);
+        let mut it = ContractChecker::new(test.create_iterator());
+        let ii = test.test.context.numeric_inverted_index();
+
+        test.test.revalidate_numeric_at_eof_after_gc(&mut it, ii);
+    }
+
+    #[test]
     fn numeric_revalidate_after_index_disappears() {
         let test = NumericRevalidateTest::new(10);
         let mut it = ContractChecker::new(test.create_iterator());
@@ -1158,6 +1167,7 @@ mod not_miri {
         use super::*;
         use crate::inverted_index::utils::via_resume::{
             revalidate_at_eof, revalidate_basic, revalidate_numeric_after_document_deleted,
+            revalidate_numeric_at_eof_after_gc,
         };
         use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator};
         use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
@@ -1174,6 +1184,15 @@ mod not_miri {
             let test = NumericRevalidateTest::new(10);
             let it = test.create_iterator();
             revalidate_at_eof(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn numeric_revalidate_at_eof_after_gc() {
+            let test = NumericRevalidateTest::new(10);
+            let it = test.create_iterator();
+            let ii = test.test.context.numeric_inverted_index();
+
+            revalidate_numeric_at_eof_after_gc(&test.test, Box::new(it), ii);
         }
 
         #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/tag.rs
@@ -178,6 +178,15 @@ mod not_miri {
     }
 
     #[test]
+    fn tag_revalidate_at_eof_after_gc() {
+        let test = TagRevalidateTest::new(10);
+        let mut it = ContractChecker::new(test.create_iterator());
+        let ii = DocIdsOnly::from_mut_opaque(test.test.context.tag_inverted_index());
+
+        test.test.revalidate_at_eof_after_gc(&mut it, ii);
+    }
+
+    #[test]
     fn tag_revalidate_after_index_disappears() {
         let test = TagRevalidateTest::new(10);
         let mut it = ContractChecker::new(test.create_iterator());
@@ -294,7 +303,8 @@ mod not_miri {
     mod via_resume {
         use super::*;
         use crate::inverted_index::utils::via_resume::{
-            revalidate_after_document_deleted, revalidate_at_eof, revalidate_basic,
+            revalidate_after_document_deleted, revalidate_at_eof, revalidate_at_eof_after_gc,
+            revalidate_basic,
         };
         use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator};
         use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
@@ -311,6 +321,15 @@ mod not_miri {
             let test = TagRevalidateTest::new(10);
             let it = test.create_iterator();
             revalidate_at_eof(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn tag_revalidate_at_eof_after_gc() {
+            let test = TagRevalidateTest::new(10);
+            let it = test.create_iterator();
+            let ii = DocIdsOnly::from_mut_opaque(test.test.context.tag_inverted_index());
+
+            revalidate_at_eof_after_gc(&test.test, Box::new(it), ii);
         }
 
         #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -352,6 +352,18 @@ mod not_miri {
         test.test.revalidate_at_eof(&mut it);
     }
 
+    #[test]
+    fn term_revalidate_at_eof_after_gc() {
+        let test = TermRevalidateTest::new(10);
+        let mut it = ContractChecker::new(test.create_iterator());
+        let ii = {
+            use inverted_index::{full::Full, opaque::OpaqueEncoding};
+            Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut()
+        };
+
+        test.test.revalidate_at_eof_after_gc(&mut it, ii);
+    }
+
     /// Driven bare, deliberately: this test reaches for `swap_index`, which
     /// swaps the index out from under the iterator by `&mut self`. The checker
     /// deliberately hands out no mutable access to what it wraps — a mutation it
@@ -450,7 +462,8 @@ mod not_miri {
     mod via_resume {
         use super::*;
         use crate::inverted_index::utils::via_resume::{
-            revalidate_after_document_deleted, revalidate_at_eof, revalidate_basic,
+            revalidate_after_document_deleted, revalidate_at_eof, revalidate_at_eof_after_gc,
+            revalidate_basic,
         };
         use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator};
         use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
@@ -467,6 +480,18 @@ mod not_miri {
             let test = TermRevalidateTest::new(10);
             let it = test.create_iterator();
             revalidate_at_eof(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn term_revalidate_at_eof_after_gc() {
+            let test = TermRevalidateTest::new(10);
+            let it = test.create_iterator();
+            let ii = {
+                use inverted_index::{full::Full, opaque::OpaqueEncoding};
+                Full::from_mut_opaque(test.test.context.term_inverted_index_mut()).inner_mut()
+            };
+
+            revalidate_at_eof_after_gc(&test.test, Box::new(it), ii);
         }
 
         #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -534,6 +534,12 @@ impl RevalidateTest {
             "exhaustion must survive a revalidation that re-seeks"
         );
         assert_eq!(it.last_doc_id(), last_doc_id);
+        // The flags say exhausted; the reader was rewound to the head of the index. Only
+        // a read proves the two agree.
+        assert!(
+            it.read().expect("failed to read").is_none(),
+            "an exhausted iterator must stay exhausted until it is rewound"
+        );
     }
 
     /// [`revalidate_at_eof_after_gc`](Self::revalidate_at_eof_after_gc) for a numeric index.
@@ -772,7 +778,7 @@ pub mod via_resume {
         test.remove_document(ii, test.doc_ids[0]);
 
         let guard = test.context.spec_read();
-        let it = revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+        let mut it = revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
             .expect("resume should not fail in this test")
             .expect_ok();
         assert!(
@@ -780,6 +786,12 @@ pub mod via_resume {
             "exhaustion must survive a resume that re-seeks"
         );
         assert_eq!(it.last_doc_id(), last_doc_id);
+        // See the `revalidate` twin: only a read proves the restored flags and the
+        // rewound reader agree.
+        assert!(
+            it.read().expect("failed to read").is_none(),
+            "an exhausted iterator must stay exhausted until it is rewound"
+        );
     }
 
     /// [`revalidate_at_eof_after_gc`] for a numeric index.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -500,6 +500,53 @@ impl RevalidateTest {
         assert_eq!(status, RQEValidateStatus::Ok);
     }
 
+    /// test that exhaustion survives a revalidation which has to re-seek.
+    ///
+    /// [`revalidate_at_eof`](Self::revalidate_at_eof) leaves the index untouched, so
+    /// `needs_revalidation()` is false and `revalidate` returns before it restores the
+    /// position at all. Removing a document first bumps the GC marker and forces the
+    /// rewind-and-re-seek path — the one that has to keep the past-the-end state rather
+    /// than handing a parent back a child it had already written off.
+    pub fn revalidate_at_eof_after_gc<'index, I, E: Encoder + DecodedBy>(
+        &self,
+        it: &mut I,
+        ii: &mut InvertedIndex<E>,
+    ) where
+        I: for<'iterator> RQEIterator<'index>,
+    {
+        // Read all documents to reach EOF
+        while let Some(_record) = it.read().expect("failed to read") {}
+        assert!(it.at_eof());
+        let last_doc_id = it.last_doc_id();
+
+        // Remove a document the iterator has already passed, so the re-seek to
+        // `last_doc_id` still finds its target. That is what makes a resurrection
+        // observable: removing the *last* document instead would leave the re-seek
+        // empty-handed and land on the past-the-end state by accident.
+        self.remove_document(ii, self.doc_ids[0]);
+
+        let status = it
+            .revalidate(&*self.context.spec_read())
+            .expect("revalidate failed");
+        assert_eq!(status, RQEValidateStatus::Ok);
+        assert!(
+            it.at_eof(),
+            "exhaustion must survive a revalidation that re-seeks"
+        );
+        assert_eq!(it.last_doc_id(), last_doc_id);
+    }
+
+    /// [`revalidate_at_eof_after_gc`](Self::revalidate_at_eof_after_gc) for a numeric index.
+    pub fn revalidate_numeric_at_eof_after_gc<'index, I>(&self, it: &mut I, ii: &mut NumericIndex)
+    where
+        I: for<'iterator> RQEIterator<'index>,
+    {
+        match ii {
+            NumericIndex::Uncompressed(ii) => self.revalidate_at_eof_after_gc(it, ii.inner_mut()),
+            NumericIndex::Compressed(ii) => self.revalidate_at_eof_after_gc(it, ii.inner_mut()),
+        }
+    }
+
     /// Remove the document with the given id from the inverted index.
     pub fn remove_document<E: Encoder + DecodedBy>(
         &self,
@@ -646,6 +693,9 @@ impl RevalidateTest {
             .expect("revalidate failed");
         assert!(matches!(res, RQEValidateStatus::Moved { current: None }));
         assert!(it.at_eof());
+        // Running past the end does not erase where the last yield left the position, even
+        // when the document it named is the one that was just removed.
+        assert_eq!(it.last_doc_id(), last_doc_id);
     }
 }
 
@@ -696,6 +746,54 @@ pub mod via_resume {
             .expect("resume should not fail in this test")
             .expect_ok();
         assert!(it.at_eof());
+    }
+
+    /// test that exhaustion survives a resume which has to re-seek.
+    ///
+    /// The resume-path twin of
+    /// [`RevalidateTest::revalidate_at_eof_after_gc`], and the same reasoning applies:
+    /// without the GC step `refresh_pointers` reports
+    /// [`RefreshOutcome::Ok`](inverted_index::RefreshOutcome::Ok) and `resume_in_place`
+    /// never reaches the rewind-and-re-seek path this covers.
+    pub fn revalidate_at_eof_after_gc<'a, I, E: Encoder + DecodedBy>(
+        test: &'a RevalidateTest,
+        mut it: Box<I>,
+        ii: &mut InvertedIndex<E>,
+    ) where
+        I: RQEIteratorBoxed<'a> + 'a,
+    {
+        // Read all documents to reach EOF
+        while let Some(_record) = it.read().expect("failed to read") {}
+        assert!(it.at_eof());
+        let last_doc_id = it.last_doc_id();
+
+        // See `RevalidateTest::revalidate_at_eof_after_gc` for why this is the first
+        // document rather than the last one.
+        test.remove_document(ii, test.doc_ids[0]);
+
+        let guard = test.context.spec_read();
+        let it = revalidate_via_resume(TypeErasedRQEIterator::new(it), &guard)
+            .expect("resume should not fail in this test")
+            .expect_ok();
+        assert!(
+            it.at_eof(),
+            "exhaustion must survive a resume that re-seeks"
+        );
+        assert_eq!(it.last_doc_id(), last_doc_id);
+    }
+
+    /// [`revalidate_at_eof_after_gc`] for a numeric index.
+    pub fn revalidate_numeric_at_eof_after_gc<'a, I>(
+        test: &'a RevalidateTest,
+        it: Box<I>,
+        ii: &mut NumericIndex,
+    ) where
+        I: RQEIteratorBoxed<'a> + 'a,
+    {
+        match ii {
+            NumericIndex::Uncompressed(ii) => revalidate_at_eof_after_gc(test, it, ii.inner_mut()),
+            NumericIndex::Compressed(ii) => revalidate_at_eof_after_gc(test, it, ii.inner_mut()),
+        }
     }
 
     /// test revalidate returns `Moved` when the document at the iterator position is deleted from the index.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/wildcard.rs
@@ -133,6 +133,15 @@ mod not_miri {
     }
 
     #[test]
+    fn wildcard_revalidate_at_eof_after_gc() {
+        let test = WildcardRevalidateTest::new(10);
+        let mut it = ContractChecker::new(test.create_iterator());
+        let ii = DocIdsOnly::from_mut_opaque(test.test.context.wildcard_inverted_index());
+
+        test.test.revalidate_at_eof_after_gc(&mut it, ii);
+    }
+
+    #[test]
     fn wildcard_revalidate_after_index_disappears() {
         let test = WildcardRevalidateTest::new(10);
         let mut it = ContractChecker::new(test.create_iterator());
@@ -234,7 +243,8 @@ mod not_miri {
     mod via_resume {
         use super::*;
         use crate::inverted_index::utils::via_resume::{
-            revalidate_after_document_deleted, revalidate_at_eof, revalidate_basic,
+            revalidate_after_document_deleted, revalidate_at_eof, revalidate_at_eof_after_gc,
+            revalidate_basic,
         };
         use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator};
         use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
@@ -251,6 +261,15 @@ mod not_miri {
             let test = WildcardRevalidateTest::new(10);
             let it = test.create_iterator();
             revalidate_at_eof(&test.test, Box::new(it));
+        }
+
+        #[test]
+        fn wildcard_revalidate_at_eof_after_gc() {
+            let test = WildcardRevalidateTest::new(10);
+            let it = test.create_iterator();
+            let ii = DocIdsOnly::from_mut_opaque(test.test.context.wildcard_inverted_index());
+
+            revalidate_at_eof_after_gc(&test.test, Box::new(it), ii);
         }
 
         #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -811,6 +811,44 @@ mod revalidate {
         it.read().unwrap().unwrap();
     }
 
+    /// A wildcard that resurrects itself must not resurrect the `NOT` above it.
+    ///
+    /// The mock deliberately breaks the contract here — it reports `Moved` back onto a
+    /// document *behind* the position it held while past its end, which no conforming
+    /// iterator does. That is the point: `W` is a type parameter, and among the things
+    /// it can be is a [`CRQEIterator`](rqe_iterators::c2rust::CRQEIterator) wrapping a C
+    /// implementation this crate cannot vouch for. Exhaustion has to be terminal because
+    /// this iterator latches it, not because every possible wildcard is well-behaved.
+    #[test]
+    fn revalidate_stays_exhausted_when_wildcard_resurrects() {
+        let (_guard, context) = make_revalidate_context();
+
+        let wcii = Mock::new([1, 5, 10]);
+        let mut wc_data = wcii.data();
+        // Out of range of the wildcard, so every wildcard document is a NOT result.
+        let child = Mock::new([1000]);
+        let mut it =
+            ContractChecker::new(NotOptimized::new(wcii, child, 100, 1.0, NoTimeoutChecker));
+
+        // Drain: the wildcard running out is what exhausts this iterator.
+        while it.read().unwrap().is_some() {}
+        assert!(it.at_eof());
+
+        // The wildcard comes back live on a document it had already yielded.
+        wc_data.set_revalidate_reseeks_to(Some(5));
+
+        let status = it.revalidate(&*context.spec_read()).unwrap();
+        assert!(matches!(status, RQEValidateStatus::Moved { current: None }));
+        assert!(
+            it.at_eof(),
+            "a resurrected wildcard must not revive the NOT above it",
+        );
+
+        // And it stays exhausted: nothing the wildcard recovered leaks out on a read.
+        assert!(it.read().unwrap().is_none());
+        assert!(it.at_eof());
+    }
+
     /// Wildcard moves to the same position as child after revalidation.
     #[test]
     fn revalidate_wc_moves_to_same_id_as_child() {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -815,10 +815,9 @@ mod revalidate {
     ///
     /// The mock deliberately breaks the contract here — it reports `Moved` back onto a
     /// document *behind* the position it held while past its end, which no conforming
-    /// iterator does. That is the point: `W` is a type parameter, and among the things
-    /// it can be is a [`CRQEIterator`](rqe_iterators::c2rust::CRQEIterator) wrapping a C
-    /// implementation this crate cannot vouch for. Exhaustion has to be terminal because
-    /// this iterator latches it, not because every possible wildcard is well-behaved.
+    /// iterator does. That is the only way to reach the latch, and what it pins down:
+    /// this iterator's exhaustion is its own state, not something inherited from
+    /// whatever the wildcard answers.
     #[test]
     fn revalidate_stays_exhausted_when_wildcard_resurrects() {
         let (_guard, context) = make_revalidate_context();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -848,6 +848,51 @@ mod revalidate {
         assert!(it.at_eof());
     }
 
+    /// The latch is a fix, not hardening: a *conforming* wildcard reaches it.
+    ///
+    /// `skip_to` past `max_doc_id` ends this iterator without touching the wildcard,
+    /// which is left live on a document. The wildcard then moving forward under GC is
+    /// what any conforming iterator does — but assigning `forced_eof` from
+    /// `wcii.at_eof()` would read that as "not at EOF" and clear a flag set for an
+    /// unrelated reason, handing the next `read` an iterator that already reported it
+    /// had nothing left.
+    #[test]
+    fn revalidate_after_skip_past_max_doc_id_does_not_revive_the_iterator() {
+        let (_guard, context) = make_revalidate_context();
+
+        let wcii = Mock::new([5, 10, 50, 60]);
+        let mut wc_data = wcii.data();
+        // Out of range of the wildcard, so every wildcard document is a NOT result.
+        let child = Mock::new([1000]);
+        let mut it =
+            ContractChecker::new(NotOptimized::new(wcii, child, 100, 1.0, NoTimeoutChecker));
+
+        assert_eq!(it.read().unwrap().unwrap().doc_id, 5);
+        assert_eq!(it.read().unwrap().unwrap().doc_id, 10);
+
+        // Past the bound: this ends the iterator, and returns before the wildcard is
+        // asked anything — so the wildcard is still sitting on doc 10, not at EOF.
+        assert!(it.skip_to(101).unwrap().is_none());
+        assert!(it.at_eof());
+
+        // GC drops doc 10; the wildcard moves forward onto 50. Forward is the only
+        // direction it may move, so nothing about this breaks the contract.
+        wc_data.set_revalidate_result(MockRevalidateResult::Move);
+
+        let status = it.revalidate(&*context.spec_read()).unwrap();
+        assert!(matches!(status, RQEValidateStatus::Moved { current: None }));
+        assert!(it.at_eof());
+
+        // 60 is still in range and absent from the child, so it is only the latch that
+        // keeps it from being yielded by an iterator that is done.
+        assert!(
+            it.read().unwrap().is_none(),
+            "a skip past max_doc_id ends the iterator for good, whatever the wildcard \
+             recovers afterwards",
+        );
+        assert!(it.at_eof());
+    }
+
     /// Wildcard moves to the same position as child after revalidation.
     #[test]
     fn revalidate_wc_moves_to_same_id_as_child() {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -1046,8 +1046,9 @@ macro_rules! union_common_tests {
 
         /// Only the `QUICK_EXIT` variants are instantiated: a lagging *live* sibling
         /// is quick mode's own doing (the early return on an exact match). A full
-        /// union's children only get behind it by resurrecting from EOF, covered by
-        /// [`revalidate_resurrected_child_does_not_drag_a_full_union_backwards`].
+        /// union's children only get behind it by breaking the contract, which it
+        /// asserts on — see
+        /// [`revalidate_asserts_when_a_resurrected_child_lands_behind_a_full_union`].
         #[test]
         #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_child_behind_union_position_is_kept() {
@@ -1262,16 +1263,19 @@ macro_rules! union_common_tests {
             );
         }
 
-        /// A full union may not adopt a minimum behind its own position, and the
-        /// child that can put one there is an *exhausted* one coming back to life.
+        /// A child that comes back from EOF behind a full union is a broken child, and
+        /// the union says so instead of absorbing it.
         ///
-        /// A leaf's revalidation rewinds before re-seeking to the position it held,
-        /// and rewinding clears the past-the-end state. So a child dropped from the
-        /// active set at doc 30, while the union carried on to 100 without it, is
-        /// re-admitted at 30 — forward of nothing it owns, but far behind the union.
+        /// Exhaustion is terminal across a revalidation
+        /// ([`at_eof`](rqe_iterators::RQEIterator::at_eof)), so no conforming child can
+        /// put a minimum behind the union: one dropped from the active set at doc 30,
+        /// while the union carried on to 100 without it, stays dropped. The mock breaks
+        /// that on purpose — it is the only way to reach the assertion.
         #[test]
+        #[cfg(debug_assertions)]
         #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
-        fn revalidate_resurrected_child_does_not_drag_a_full_union_backwards() {
+        #[should_panic(expected = "moved behind the union's position")]
+        fn revalidate_asserts_when_a_resurrected_child_lands_behind_a_full_union() {
             let child0: Mock<'static, 2> = Mock::new([10, 30]);
             let child1: Mock<'static, 3> = Mock::new([20, 100, 200]);
 
@@ -1293,25 +1297,15 @@ macro_rules! union_common_tests {
             assert!(exhausted.at_eof(), "child0 ran past its last document");
             assert_eq!(exhausted.last_doc_id(), 30);
 
-            // GC forces a revalidation. child0 rewinds, re-seeks to 30 and finds it
-            // still there — so it comes back live on 30, well behind the union's 100.
+            // The contract violation: child0 comes back live on 30, well behind the
+            // union's 100.
             data0.set_revalidate_reseeks_to(Some(30));
             // Some other child has to move, or revalidation returns before ever
             // looking at the resurrected one.
             data1.set_revalidate_result(MockRevalidateResult::Move);
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-            let status = format!(
-                "{:?}",
-                union.revalidate(&*mock_ctx.spec_read()).expect("revalidate failed"),
-            );
-
-            assert!(
-                union.last_doc_id() >= 100,
-                "the union must not fall back onto a document it already delivered, \
-                 got {} (status {status})",
-                union.last_doc_id(),
-            );
+            let _ = union.revalidate(&*mock_ctx.spec_read());
         }
 
         // =============================================================================

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/contract_checker.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/contract_checker.rs
@@ -131,7 +131,10 @@ enum RevalidateSummary<'index> {
 /// The checker verifies the [`RQEIterator`] surface only. It does not
 /// implement the suspend/resume machinery
 /// ([`RQEIteratorBoxed`](rqe_iterators::RQEIteratorBoxed)), so tests
-/// exercising that path still drive the unwrapped iterator.
+/// exercising that path still drive the unwrapped iterator. The cross-cycle
+/// guarantees are asserted by
+/// [`revalidate_via_resume`](crate::revalidate_via_resume) instead, which every
+/// resume test funnels through.
 #[expect(rustdoc::private_intra_doc_links)]
 pub struct ContractChecker<I> {
     inner: I,

--- a/src/redisearch_rs/rqe_iterators_test_utils/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators_test_utils/src/lib.rs
@@ -205,10 +205,32 @@ fn assert_eof_agrees_with_current<'index, I: RQEIterator<'index>>(
 /// migration away from `RQEIterator::revalidate`.
 ///
 /// See [`ResumeOutcomeExt`] for `expect_ok` / `expect_moved`.
+///
+/// # Contract checks
+///
+/// [`ContractChecker`] verifies the [`RQEIterator`] surface but not the
+/// suspend/resume machinery, so the cross-cycle guarantees are asserted here
+/// instead — this is the single funnel every resume test goes through. On any
+/// outcome that hands an iterator back, it checks that
+///
+/// - exhaustion survived the cycle: an iterator that was at
+///   [`at_eof`](RQEIterator::at_eof) is still at it afterwards. A composite drops
+///   children that report EOF, so one that comes back live re-enters a parent
+///   that has already moved on without it;
+/// - the position did not move backwards, which would replay documents; and
+/// - [`ResumeOutcome::Ok`] means exactly that — same position, same EOF answer —
+///   matching the promise its [`RQEValidateStatus::Ok`] counterpart makes on the
+///   `revalidate` side.
+///
+/// [`ContractChecker`]: crate::contract_checker::ContractChecker
+/// [`RQEValidateStatus::Ok`]: rqe_iterators::RQEValidateStatus::Ok
 pub fn revalidate_via_resume<'borrow, 'index>(
     it: TypeErasedRQEIterator<'index>,
     spec: &'borrow IndexSpecReadGuard<'index>,
 ) -> Result<ResumeOutcome<TypeErasedRQEIterator<'index>>, rqe_iterators::RQEIteratorError> {
+    let was_at_eof = it.at_eof();
+    let previous_last_doc_id = it.last_doc_id();
+
     let suspended =
         <TypeErasedRQEIterator<'index> as rqe_iterators::RQEIteratorBoxed<'index>>::suspend(
             Box::new(it),
@@ -219,7 +241,38 @@ pub fn revalidate_via_resume<'borrow, 'index>(
     // restore position and can fail with an `RQEIteratorError` (e.g. timeout);
     // propagate it like the production path.
     let TypeErasedRQESuspendedIterator(inner) = *suspended;
-    inner.resume(spec)
+    let outcome = inner.resume(spec)?;
+
+    // `Aborted` yields no iterator to inspect; every other outcome does.
+    if let ResumeOutcome::Ok(it) | ResumeOutcome::Moved(it) = &outcome {
+        if was_at_eof {
+            assert!(
+                it.at_eof(),
+                "resume: an iterator that had run past its last result cannot come back \
+                 without a rewind",
+            );
+        }
+        assert!(
+            it.last_doc_id() >= previous_last_doc_id,
+            "resume: must not move the position backwards, but doc {} comes before doc {}",
+            it.last_doc_id(),
+            previous_last_doc_id,
+        );
+        if matches!(outcome, ResumeOutcome::Ok(_)) {
+            assert_eq!(
+                it.last_doc_id(),
+                previous_last_doc_id,
+                "resume: Ok promises the same position, but last_doc_id() changed",
+            );
+            assert_eq!(
+                it.at_eof(),
+                was_at_eof,
+                "resume: Ok promises the same position, but at_eof() changed",
+            );
+        }
+    }
+
+    Ok(outcome)
 }
 
 /// Test-only ergonomic accessors on [`ResumeOutcome`].


### PR DESCRIPTION
## Describe the changes in the pull request

**Current.** An iterator that has run past its last result must stay there until `rewind`: composites drop children that report EOF and cannot take them back. Inverted-index leaves broke that. `revalidate` and `resume_in_place` restored position by rewinding and re-seeking, and the rewind clears the past-the-end state — so an exhausted leaf came back live on a document it had already yielded. Both unions carried compensation code naming this exact cause, and `interop.rs` left C and Rust disagreeing about whether a child was still alive. `NotOptimized` reached the same end by its own route: `skip_to` past `max_doc_id` ends it without touching its wildcard, and it then re-derived its EOF flag from that wildcard — so any later forward move by the wildcard cleared it.

**Change.** Exhaustion is terminal on both paths: leaves restore the past-the-end position instead of seeking back to it, and `NotOptimized` latches its EOF flag. Full unions now assert that no child sits behind them rather than absorbing one that does. New tests cover all five leaves on both paths — the existing at-EOF tests never dirtied the index, so `revalidate` returned before reaching the rewind, which is how this survived a harness built to catch it.

**Outcome.** A resurrected child can no longer replay documents into a parent that has moved on, enforced by assertions and tests rather than by parents compensating. Each fix was confirmed red before green.

### Notes for reviewers

- **There is a behaviour change, narrower than a release note usually covers.** When documents were indexed after a leaf exhausted *and* GC ran on that index, the old re-seek reported `Moved` and the leaf went on to yield those newer documents. It no longer does. I read that as bringing the GC path in line with the no-GC path, where such documents were never picked up. Flip the release-notes box if you disagree — the title would then need to state the user impact.
- **Unions assert in debug and still recover in release**, so a contract violation is impossible to miss in CI without crashing a live query.
- **The `NotOptimized` latch fixes a reachable case**, not a theoretical one, and it needs no misbehaving child to get there: a wildcard moving forward under GC is all a conforming one ever does. That is the second half of the release-notes call above — the symptom is an iterator yielding again after reporting it had nothing left. `revalidate_after_skip_past_max_doc_id_does_not_revive_the_iterator` covers it; with the old assignment restored, `ContractChecker` fails it with *"an exhausted iterator must keep returning None, but it yielded doc 60"*.

**Verification.** `cargo nextest run`, `make lint`, `make fmt CHECK=1` green on the current head. Miri (528) and `./build.sh RUN_PYTEST` were green on the first commit — 61 pre-existing environmental failures, none touching query iteration — and no commit since adds `unsafe`.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `RawInvIndIterator::{revalidate, resume_in_place}` — `rqe_iterators/src/inverted_index/core.rs`
2. `NotOptimized::revalidate` — `rqe_iterators/src/not_optimized.rs`
3. `UnionFlat`/`UnionHeap` revalidate — assertion in place of the compensation
4. `revalidate_via_resume`, `ContractChecker`, and `revalidate_at_eof_after_gc` across the five leaves
5. `RQEIterator::at_eof`, which now owns the exhaustion contract

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

