### PR TITLE
[MOD-17549] Remove dead Trie_RandomKey and TrieNode_RandomWalk

### DIFF
--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -357,29 +357,6 @@ Vector *Trie_CollectFuzzy(const Trie *t, const char *str, size_t len, size_t num
   return ret;
 }
 
-int Trie_RandomKey(Trie *t, char **str, t_len *len, double *score) {
-  if (t->size == 0) {
-    return 0;
-  }
-
-  rune *rstr;
-  t_len rlen;
-
-  // TODO: deduce steps from cardinality properly
-  TrieNode *n =
-      TrieNode_RandomWalk(t->root, 2 + rand() % 8 + (int)round(logb(1 + t->size)), &rstr, &rlen);
-  if (!n) {
-    return 0;
-  }
-  size_t sz;
-  *str = runesToStr(rstr, rlen, &sz);
-  *len = sz;
-  rm_free(rstr);
-
-  *score = n->score;
-  return 1;
-}
-
 /***************************************************************
  *
  *                       Trie type methods

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -12,7 +12,6 @@
 #include <string.h>
 #include <limits.h>
 #include <stdint.h>
-#include <stdlib.h>
 
 #include "util/heap.h"
 #include "util/misc.h"

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -132,10 +132,6 @@ Vector *Trie_CollectFuzzy(const Trie *t, const char *str, size_t len, size_t num
 TrieIterator *Trie_IterateFuzzy(Trie *t, const char *str, size_t len, int maxDist,
                                 TrieMatchMode mode);
 
-/* Get a random key from the trie, and put the node's score in the score pointer. Returns 0 if the
- * trie is empty and we cannot do that */
-int Trie_RandomKey(Trie *t, char **str, t_len *len, double *score);
-
 /* Commands related to the redis TrieType registration */
 int TrieType_Register(RedisModuleCtx *ctx);
 void *TrieType_GenericLoad(RedisModuleIO *rdb, bool loadPayloads, bool loadNumDocs,

--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -945,67 +945,6 @@ int TrieIterator_Next(TrieIterator *it, rune **ptr, t_len *len, RSPayload *paylo
   return 0;
 }
 
-TrieNode *TrieNode_RandomWalk(TrieNode *n, int minSteps, rune **str, t_len *len) {
-  // create an iteration stack we walk up and down
-  minSteps = MAX(minSteps, 4);
-
-  size_t stackCap = minSteps;
-  size_t stackSz = 1;
-  TrieNode **stack = rm_calloc(stackCap, sizeof(TrieNode *));
-  stack[0] = n;
-
-  int bufCap = n->len;
-
-  int steps = 0;
-
-  while (steps < minSteps || !TrieNode_IsTerminal(stack[stackSz - 1])) {
-
-    n = stack[stackSz - 1];
-
-    /* select the next step - -1 means walk back up one level */
-    int rnd = (rand() % (n->numChildren + 1)) - 1;
-    if (rnd == -1) {
-      /* we can't walk up the top level */
-      if (stackSz > 1) {
-        steps++;
-        stackSz--;
-
-        bufCap -= n->len;
-      }
-      continue;
-    }
-    /* Push a child on the stack */
-    TrieNode *child = TrieNode_Children(n)[rnd];
-    stack[stackSz++] = child;
-
-    steps++;
-    if (stackSz == stackCap) {
-      stackCap += minSteps;
-      stack = rm_realloc(stack, stackCap * sizeof(TrieNode *));
-    }
-
-    bufCap += child->len;
-  }
-
-  /* Return the node at the top of the stack */
-
-  n = stack[stackSz - 1];
-
-  /* build the string by walking the stack and copying all node strings */
-  rune *buf = rm_calloc(bufCap + 1, sizeof(rune));
-
-  t_len bufSize = 0;
-  for (size_t i = 0; i < stackSz; i++) {
-    memcpy(&buf[bufSize], stack[i]->str, sizeof(rune) * stack[i]->len);
-    bufSize += stack[i]->len;
-  }
-
-  *str = buf;
-  *len = bufSize;
-  rm_free(stack);
-  return n;
-}
-
 typedef struct {
   const rune *r;
   uint16_t n;

--- a/src/trie/trie_node.h
+++ b/src/trie/trie_node.h
@@ -120,8 +120,6 @@ void TrieIterator_Free(TrieIterator *it);
 int TrieIterator_Next(TrieIterator *it, rune **ptr, t_len *len, RSPayload *payload, float *score,
                       size_t *numDocs, void *matchCtx);
 
-TrieNode *TrieNode_RandomWalk(TrieNode *n, int minSteps, rune **str, t_len *len);
-
 typedef int(TrieRangeCallback)(const rune *, size_t, void *, void *, size_t);
 typedef int(TrieSuffixCallback)(const char *, size_t, void *, void *);
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `Trie_RandomKey` returns a random key from a rune trie, sampled by `TrieNode_RandomWalk`, which descends and back-tracks at random until it lands on a terminal node. Neither function has a caller — not in RediSearch, its C/C++ unit tests, the Rust crates, or RediSearch Enterprise.
2. **Change**: Remove `Trie_RandomKey` and its only helper `TrieNode_RandomWalk`, along with their prototypes and doc comments. A second commit drops `<stdlib.h>` from `src/trie/trie.c`, whose last direct user was the `rand()` call in `Trie_RandomKey` (allocation there goes through `rmalloc.h`).
3. **Outcome**: 90 lines of unreachable trie code gone, including the unguarded `bufCap` push/pop arithmetic that sized the result buffer. No behavior change: nothing reached either function.

**History worth knowing.** These were the last remnants of the legacy GC's random-term sampling. `c1455bb16f` ("[RIP] Remove legacy GC", Sep 2022) deleted the only caller together with both functions and their `TrieMap` counterparts. Two commits then put the trie half back without a caller: `08a771b10c` ("put TrieNode_RandomWalk back", 2022-09-06) and `4b5048211a` ("put back function", 2022-09-13), which restored `Trie_RandomKey`. As of `4b5048211a` no file outside `trie_type.c`/`.h` referenced it — so this code has been unreachable ever since, not merely unused today. `TrieMap_RandomKey` / `TrieMapNode_RandomWalk` were never restored.

#### Which additional issues this PR fixes

1. MOD-17549

#### Main objects this PR modified

1. `Trie_RandomKey` (`src/trie/trie.c`, `src/trie/trie.h`)
2. `TrieNode_RandomWalk` (`src/trie/trie_node.c`, `src/trie/trie_node.h`)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
