### PR TITLE
[MOD-15685] Delete orphaned legacy index keys when they are restored

### DIFF
--- a/src/legacy_types.c
+++ b/src/legacy_types.c
@@ -9,6 +9,9 @@
 
 #include "legacy_types.h"
 
+#include <stdbool.h>
+
+#include "notifications.h"
 #include <stddef.h>
 
 #include "util/misc.h"
@@ -20,6 +23,25 @@
 // RDB load callback cannot return NULL, as it indicates an error
 void *dummyNonNull = (void*)0xDEADBEEF;
 
+// Retained so the cleanup below recognises a key by type rather than by name - an untrusted payload
+// does not have to respect any naming convention.
+static RedisModuleType *LegacyInvertedIndexType = NULL;
+static RedisModuleType *LegacyNumericIndexType = NULL;
+static RedisModuleType *LegacyTagIndexType = NULL;
+
+
+// Called whenever a legacy key is deserialized, from the type callbacks below.
+//
+// Subscribing to keyspace events here rather than at module load is what keeps this free for everyone
+// else: a database that never deserializes one of these keys never starts listening. It has to happen
+// in the loader because the subscription is otherwise lazy - Initialize_KeyspaceNotifications runs
+// only when an index is created or loaded, so a database with no index has no subscriber at all and
+// the `restore` event this cleanup depends on would never reach us. That is exactly the shape of the
+// database this was reported on: ~101k legacy keys and search_number_of_indexes:0.
+static void noteLegacyKeyLoaded(void) {
+  Initialize_KeyspaceNotifications();
+}
+
 // Dummy no-op functions for type methods
 void GenericType_DummyRdbSave(RedisModuleIO *rdb, void *value) {
   RS_ABORT("Attempted to save a legacy type to RDB");
@@ -29,10 +51,11 @@ void GenericType_DummyFree(void *value) {
   RS_ASSERT(value == dummyNonNull);
 }
 
-// Consume an inverted index type from RDB
-void *InvertedIndex_RdbLoad_Consume(RedisModuleIO *rdb, int encver) {
+// Consume an inverted index payload. Separate from the type callback because the tag loader consumes
+// one of these per tag, and a tag is not a key - counting them would inflate the load count.
+static bool consumeInvertedIndex(RedisModuleIO *rdb, int encver) {
   if (encver > LEGACY_ENC_VER) {
-    return NULL;
+    return false;
   }
 
   RedisModule_LoadUnsigned(rdb); // Consume the flags of the index
@@ -46,6 +69,14 @@ void *InvertedIndex_RdbLoad_Consume(RedisModuleIO *rdb, int encver) {
     RedisModule_LoadUnsigned(rdb); // Consume the number of entries in the block
     RedisModule_Free(RedisModule_LoadStringBuffer(rdb, NULL)); // Consume the buffer of the block
   }
+  return true;
+}
+
+void *InvertedIndex_RdbLoad_Consume(RedisModuleIO *rdb, int encver) {
+  if (!consumeInvertedIndex(rdb, encver)) {
+    return NULL;
+  }
+  noteLegacyKeyLoaded();
   return dummyNonNull;
 }
 
@@ -69,6 +100,7 @@ void *NumericIndexType_RdbLoad_Consume(RedisModuleIO *rdb, int encver) {
     }
   }
 
+  noteLegacyKeyLoaded();
   return dummyNonNull;
 }
 
@@ -78,10 +110,91 @@ void *TagIndex_RdbLoad_Consume(RedisModuleIO *rdb, int encver) {
 
   for (size_t i = 0; i < n_tags; i++) {
     RedisModule_Free(RedisModule_LoadStringBuffer(rdb, NULL)); // Consume the tag value
-    InvertedIndex_RdbLoad_Consume(rdb, encver); // Consume the inverted index for the tag
+    consumeInvertedIndex(rdb, encver); // Consume the inverted index for the tag
   }
+  noteLegacyKeyLoaded();
   return dummyNonNull;
 }
+
+/* ---------------------------------------------------------------------------------------------
+ * Cleanup of orphaned legacy keys. See legacy_types.h for why they exist at all.
+ * ------------------------------------------------------------------------------------------- */
+
+// True when `kp` holds one of our legacy types *and* the sentinel. Both halves matter: the type alone
+// would match a future non-sentinel value, and the sentinel alone is just an integer.
+static bool isOrphanedLegacyKey(RedisModuleKey *kp) {
+  if (kp == NULL || RedisModule_KeyType(kp) != REDISMODULE_KEYTYPE_MODULE) {
+    return false;
+  }
+  RedisModuleType *type = RedisModule_ModuleTypeGetType(kp);
+  if (type != LegacyInvertedIndexType && type != LegacyNumericIndexType &&
+      type != LegacyTagIndexType) {
+    return false;
+  }
+  return RedisModule_ModuleTypeGetValue(kp) == dummyNonNull;
+}
+
+static bool isOrphanedLegacyKeyByName(RedisModuleCtx *ctx, RedisModuleString *key) {
+  RedisModuleKey *kp = RedisModule_OpenKey(ctx, key, REDISMODULE_READ);
+  const bool orphaned = isOrphanedLegacyKey(kp);
+  if (kp != NULL) {
+    RedisModule_CloseKey(kp);
+  }
+  return orphaned;
+}
+
+static void deleteWithPropagation(RedisModuleCtx *ctx, RedisModuleString *key) {
+  RedisModuleCallReply *rep = RedisModule_Call(ctx, "DEL", "!s", key);
+  if (rep != NULL) {
+    RedisModule_FreeCallReply(rep);
+  }
+}
+
+static void freeOwnedKey(void *pd) {
+  // Created with a NULL context, so it is ours to release.
+  RedisModule_FreeString(NULL, (RedisModuleString *)pd);
+}
+
+// Writing from inside a keyspace notification is not allowed, so the delete happens here, once Redis
+// says writes are safe. The value is re-checked first: a post-notification job runs after the whole
+// execution unit, so `MULTI; RESTORE k <legacy>; SET k valuable; EXEC` would otherwise lose
+// `valuable`.
+//
+// The key arrives as owned privdata rather than through the per-key job variant, because
+// RedisModule_AddPostNotificationJobForKey exists only in the Enterprise build - against OSS Redis
+// that pointer is NULL and calling it crashes the server.
+static void deleteOrphanedLegacyKey(RedisModuleCtx *ctx, void *pd) {
+  RedisModuleString *key = pd;
+  if (isOrphanedLegacyKeyByName(ctx, key)) {
+    deleteWithPropagation(ctx, key);
+  }
+}
+
+void LegacyTypes_CleanupRestoredKey(RedisModuleCtx *ctx, RedisModuleString *key) {
+  // Only a primary may delete. A replica keeps the key until the primary's DEL arrives - deleting
+  // locally would diverge from a primary that still holds it, and post-notification jobs are rejected
+  // on read-only replicas anyway. Tested positively: if the role is somehow unknown, doing nothing is
+  // the safe outcome.
+  if (!(RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_MASTER)) {
+    return;
+  }
+  if (!isOrphanedLegacyKeyByName(ctx, key)) {
+    return;
+  }
+  // The notification's key is not ours to retain, so hand the job an owned copy.
+  RedisModuleString *owned = RedisModule_CreateStringFromString(NULL, key);
+  if (RedisModule_AddPostNotificationJob(ctx, deleteOrphanedLegacyKey, owned, freeOwnedKey) !=
+      REDISMODULE_OK) {
+    RedisModule_FreeString(NULL, owned);
+    RedisModule_Log(ctx, "warning",
+                    "Could not schedule cleanup of a restored legacy index key; it will remain until "
+                    "the next load or a manual UNLINK");
+  }
+}
+
+
+
+
 
 int RegisterLegacyTypes(RedisModuleCtx *ctx) {
 
@@ -94,19 +207,22 @@ int RegisterLegacyTypes(RedisModuleCtx *ctx) {
 
   // Register the inverted index type
   tm.rdb_load = InvertedIndex_RdbLoad_Consume;
-  if (!RedisModule_CreateDataType(ctx, "ft_invidx", LEGACY_ENC_VER, &tm)) {
+  LegacyInvertedIndexType = RedisModule_CreateDataType(ctx, "ft_invidx", LEGACY_ENC_VER, &tm);
+  if (!LegacyInvertedIndexType) {
     return REDISMODULE_ERR;
   }
 
   // Register the numeric index type
   tm.rdb_load = NumericIndexType_RdbLoad_Consume;
-  if (!RedisModule_CreateDataType(ctx, "numericdx", LEGACY_ENC_VER, &tm)) {
+  LegacyNumericIndexType = RedisModule_CreateDataType(ctx, "numericdx", LEGACY_ENC_VER, &tm);
+  if (!LegacyNumericIndexType) {
     return REDISMODULE_ERR;
   }
 
   // Register the tag index type
   tm.rdb_load = TagIndex_RdbLoad_Consume;
-  if (!RedisModule_CreateDataType(ctx, "ft_tagidx", LEGACY_ENC_VER, &tm)) {
+  LegacyTagIndexType = RedisModule_CreateDataType(ctx, "ft_tagidx", LEGACY_ENC_VER, &tm);
+  if (!LegacyTagIndexType) {
     return REDISMODULE_ERR;
   }
 

--- a/src/legacy_types.h
+++ b/src/legacy_types.h
@@ -12,3 +12,17 @@
 #include "redismodule.h"
 
 int RegisterLegacyTypes(RedisModuleCtx *ctx);
+
+/* Cleanup of orphaned legacy index keys.
+ *
+ * A pre-2.0 index key is consumed and discarded on load, but the loader must return a non-NULL value
+ * because NULL means load failure to Redis - so the key survives holding only a sentinel. The upgrade
+ * sweep in indexes_scan.c deletes these, but only for indexes it can reach through a loaded spec and
+ * a matching `UPGRADE_INDEX` argument, so keys arriving any other way are orphaned with nothing to
+ * collect them. The entry points below cover the two ways they arrive. */
+
+/* Delete `key` if it is an orphaned legacy key. Call from the `restore` keyspace notification:
+ * `RESTORE` is how these keys reach a running server (Enterprise import replays RESTORE rather than
+ * handing an RDB to Redis) and it fires no loading event. A no-op unless the key really is one. */
+void LegacyTypes_CleanupRestoredKey(RedisModuleCtx *ctx, RedisModuleString *key);
+

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -17,6 +17,7 @@
 
 #include "config.h"
 #include "notifications.h"
+#include "legacy_types.h"
 #include "spec.h"
 #include "indexes.h"
 #include "doc_types.h"
@@ -254,6 +255,10 @@ int HandleKeyspaceNotification(RedisModuleCtx *ctx, int type, enum RedisCmd redi
       break;
 
     case restore_cmd:
+      // RESTORE is how a pre-2.0 index key reaches a running server - Enterprise import
+      // replays RESTORE rather than handing an RDB to Redis, so no loading event fires for it.
+      LegacyTypes_CleanupRestoredKey(ctx, key);
+      /* fallthrough */
     case copy_to_cmd:
       Indexes_UpdateMatchingWithSchemaRules(ctx, key, getDocTypeFromString(key), hashFields);
       break;

--- a/tests/pytests/test_legacy_cleanup.py
+++ b/tests/pytests/test_legacy_cleanup.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2006-Present, Redis Ltd.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+# GNU Affero General Public License v3 (AGPLv3).
+
+import struct
+import time
+
+import redis
+
+from includes import *
+from common import *
+from RLTest import Env
+
+# Coverage for the cleanup of orphaned pre-2.0 index keys (ft_invidx / numericdx / ft_tagidx).
+#
+# Such a key can only be created by deserializing an old payload, so RESTORE is the only way to get
+# one into a live server - which is also how they reach production, since Redis Enterprise import
+# forwards RESTORE commands rather than handing an RDB to Redis, and therefore fires no loading event
+# for any load-time sweep to hang off. See MOD-15685.
+#
+# The payload builder is duplicated from test_legacy_module_types.py on the serialization-fix branch;
+# fold the two together once that lands.
+
+LEGACY_ENC_VER = 1
+
+RDB_TYPE_MODULE_2 = 7
+RDB_MODULE_OPCODE_EOF = 0
+RDB_MODULE_OPCODE_UINT = 2
+
+RDB_6BITLEN = 0
+RDB_14BITLEN = 1
+RDB_32BITLEN = 0x80
+RDB_64BITLEN = 0x81
+
+# Redis's module type ids pack 9 six-bit characters plus a 10-bit encoding version.
+_MODULE_TYPE_CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'
+
+
+def _binary_conn(env, db=None):
+    """A connection that does not decode replies. DUMP returns arbitrary bytes, which the default
+    RLTest client tries to decode as UTF-8."""
+    kwargs = dict(env.getConnection().connection_pool.connection_kwargs)
+    kwargs['decode_responses'] = False
+    if db is not None:
+        kwargs['db'] = db
+    # A pool built for a unix socket reports it as `path`, but the client constructor takes
+    # `unix_socket_path`. Forwarding the pool's kwargs verbatim breaks under UNIX=1.
+    if 'path' in kwargs:
+        kwargs['unix_socket_path'] = kwargs.pop('path')
+    return redis.Redis(**kwargs)
+
+
+def _as_text(value):
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value)
+
+
+def _waitForAofRewrite(env, conn, timeout=60):
+    """`waitForRdbSaveToFinish` only polls rdb_bgsave_in_progress, so it returns immediately here and
+    DEBUG LOADAOF would race a rewrite that is still running or merely scheduled."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        # redis-py applies its own INFO response callback, so this comes back already parsed into a
+        # dict; the raw-text branch is only for a client that has that callback disabled.
+        info = conn.execute_command('INFO', 'persistence')
+        if isinstance(info, dict):
+            fields = {_as_text(k): _as_text(v) for k, v in info.items()}
+        else:
+            fields = dict(line.split(':', 1)
+                          for line in _as_text(info).splitlines() if ':' in line)
+        if (fields.get('aof_rewrite_in_progress', '0').strip() == '0'
+                and fields.get('aof_rewrite_scheduled', '0').strip() == '0'):
+            return
+        time.sleep(0.1)
+    env.assertTrue(False, message='AOF rewrite did not finish within {}s'.format(timeout))
+
+
+def _expect_restore_error(env, conn, key, payload, message):
+    try:
+        conn.execute_command('RESTORE', key, 0, payload)
+        env.assertTrue(False, message='expected RESTORE to be rejected: ' + message)
+    except redis.exceptions.ResponseError:
+        pass
+    env.assertEqual(conn.execute_command('EXISTS', key), 0, message=message)
+
+
+def _crc64(data):
+    # Reflected form of the Jones polynomial Redis uses, init 0, no final xor.
+    # testDumpPayloadHelperMatchesRedis proves this matches the server rather than assuming it.
+    poly = 0x95AC9329AC4BC9B5
+    crc = 0
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            crc = (crc >> 1) ^ poly if crc & 1 else crc >> 1
+    return crc
+
+
+def _save_len(n):
+    if n < (1 << 6):
+        return bytes([(RDB_6BITLEN << 6) | n])
+    if n < (1 << 14):
+        return bytes([(RDB_14BITLEN << 6) | (n >> 8), n & 0xFF])
+    if n <= 0xFFFFFFFF:
+        return bytes([RDB_32BITLEN]) + struct.pack('>I', n)
+    return bytes([RDB_64BITLEN]) + struct.pack('>Q', n)
+
+
+def _module_type_id(name, encver):
+    assert len(name) == 9, 'module type names are exactly 9 characters'
+    packed = 0
+    for ch in name:
+        packed = (packed << 6) | _MODULE_TYPE_CHARSET.index(ch)
+    return (packed << 10) | encver
+
+
+def _module_uint(value):
+    return _save_len(RDB_MODULE_OPCODE_UINT) + _save_len(value)
+
+
+def _rdb_version(conn):
+    # Take the version from a payload the server produced, so we never guess a value it would reject.
+    conn.execute_command('SET', '_probe', 'x')
+    dumped = conn.execute_command('DUMP', '_probe')
+    conn.execute_command('DEL', '_probe')
+    return struct.unpack('<H', dumped[-10:-8])[0]
+
+
+def _dump_payload(conn, type_name, body, encver=LEGACY_ENC_VER):
+    """Build a RESTORE-able payload for a module value of `type_name` whose body is `body`."""
+    obj = (bytes([RDB_TYPE_MODULE_2])
+           + _save_len(_module_type_id(type_name, encver))
+           + body
+           + _save_len(RDB_MODULE_OPCODE_EOF))
+    blob = obj + struct.pack('<H', _rdb_version(conn))
+    return blob + struct.pack('<Q', _crc64(blob))
+
+
+# The minimal bodies the fix emits, expressed independently of the C code so that a change to either
+# side has to be reflected here deliberately.
+def _legacy_bodies():
+    return {
+        'ft_invidx': _module_uint(0) * 4,  # flags, lastId, numDocs, n_blocks
+        'numericdx': _module_uint(0),      # v1 terminator, also a zero count under v0
+        'ft_tagidx': _module_uint(0),      # n_tags
+    }
+
+
+@skip(cluster=True)
+def testDumpPayloadHelperMatchesRedis(env):
+    """Guard the builder. A wrong CRC or length encoding would make every test below fail with
+    'Bad data format', which is a confusing way to learn the fixture is broken rather than the code."""
+    skipOnExistingEnv(env)
+    conn = _binary_conn(env)
+
+    conn.execute_command('SET', 'plain', 'hello')
+    dumped = conn.execute_command('DUMP', 'plain')
+    env.assertEqual(struct.unpack('<Q', dumped[-8:])[0], _crc64(dumped[:-8]),
+                    message='our crc64 does not match the one Redis wrote')
+
+
+@skip(cluster=True)
+def testRestoredLegacyKeyIsRemoved(env):
+    """A legacy key restored onto a writable primary must not survive the command. This is the path
+    that produced ~101k orphans in production, where nothing ever cleaned them up."""
+    skipOnExistingEnv(env)
+    conn = _binary_conn(env)
+
+    for type_name, body in _legacy_bodies().items():
+        key = 'legacy:' + type_name
+        conn.execute_command('RESTORE', key, 0, _dump_payload(conn, type_name, body))
+        # The post-notification job runs before the next command is served, so it is already gone.
+        env.assertEqual(conn.execute_command('EXISTS', key), 0, message=key)
+
+    env.assertEqual(conn.execute_command('DBSIZE'), 0)
+    env.assertTrue(env.isUp())
+
+
+@skip(cluster=True)
+def testCleanupDoesNotDeleteAReplacementValue(env):
+    """The delete is deferred to a post-notification job, which runs after the whole execution unit.
+    Inside MULTI the legacy value can be replaced before the job runs, so the job must re-check the
+    value rather than trusting the key name it was queued with."""
+    skipOnExistingEnv(env)
+    conn = _binary_conn(env)
+
+    key = 'replaced'
+    payload = _dump_payload(conn, 'ft_invidx', _legacy_bodies()['ft_invidx'])
+
+    pipe = conn.pipeline(transaction=True)
+    pipe.execute_command('RESTORE', key, 0, payload)
+    pipe.execute_command('SET', key, 'valuable')
+    pipe.execute()
+
+    env.assertEqual(conn.execute_command('GET', key), b'valuable',
+                    message='cleanup deleted a value written after the legacy key')
+    env.assertTrue(env.isUp())
+
+
+@skip(cluster=True)
+def testCleanupLeavesOrdinaryKeysAlone(env):
+    """The match is on module type plus sentinel, not on key naming, so ordinary keys - including ones
+    named like a legacy index key - must be untouched."""
+    skipOnExistingEnv(env)
+    conn = _binary_conn(env)
+
+    conn.execute_command('SET', 'ft:idx/term', 'not-a-legacy-key')
+    conn.execute_command('HSET', 'doc:1', 'title', 'hello')
+
+    dumped = conn.execute_command('DUMP', 'ft:idx/term')
+    conn.execute_command('RESTORE', 'ft:idx/term:copy', 0, dumped)
+
+    env.assertEqual(conn.execute_command('GET', 'ft:idx/term'), b'not-a-legacy-key')
+    env.assertEqual(conn.execute_command('GET', 'ft:idx/term:copy'), b'not-a-legacy-key')
+    env.assertEqual(conn.execute_command('EXISTS', 'doc:1'), 1)
+    env.assertTrue(env.isUp())


### PR DESCRIPTION
## Describe the changes in the pull request

> **Stacked.** This is the base of a two-PR stack. The follow-up, cleanup of keys arriving through a
> genuine RDB load, targets this branch. Independent of #10817 (which makes these keys *saveable*);
> both touch `src/legacy_types.c`, so expect a small conflict whichever lands second.

**1. Current** — a pre-2.0 index key is consumed and discarded on load, but the loader must return a
non-NULL value because NULL means load failure to Redis, so the key survives holding only the
`dummyNonNull` sentinel. The 2.0 upgrade sweep removes these only for indexes it can reach through a
loaded spec plus a matching `UPGRADE_INDEX` argument, so keys arriving any other way are orphaned with
nothing to collect them. One production database accumulated ~101k (ZD 168121).

**2. Change** — hook the existing `restore` keyspace notification, which is how these keys reach a
running server: Enterprise import replays `RESTORE` per key through an external RDB parser rather than
handing an RDB to Redis, so no loading event fires and nothing hung off one can help.

- Recognise the key by module **type and sentinel**, not by name — an untrusted payload need not
  respect any naming convention.
- Defer the delete to a post-notification job (writing from a notification callback is not allowed)
  and **re-check the value inside the job**: jobs run after the whole execution unit, so
  `MULTI; RESTORE k <legacy>; SET k valuable; EXEC` would otherwise delete `valuable`.
- Delete only from a writable primary, tested positively on `CTX_FLAGS_MASTER` so an unknown role means
  doing nothing, and **propagate** the `DEL` so replicas converge. Deleting locally on a replica would
  diverge from a primary that still holds the key.

Two defects found by running it, not by reading it:

- **The keyspace subscription is lazy.** `Initialize_KeyspaceNotifications` runs only when an index is
  created or loaded, so a database with no index has no subscriber and the `restore` event never
  arrives. The reported database had `search_number_of_indexes:0` — this cleanup would have been inert
  on exactly the database that needed it. The loaders now subscribe when they materialize a legacy key,
  which keeps it free for every database that never sees one.
- **`RedisModule_AddPostNotificationJobForKey` only exists in the Enterprise build** (declared in our
  `redismodule.h`, used in `notifications.c` solely under `SearchDisk_IsEnabled()`). Against OSS Redis
  the pointer is unavailable and calling it segfaults. Uses the portable
  `RedisModule_AddPostNotificationJob` with an owned key copy.

**3. Outcome** — a legacy key restored onto a writable primary is removed before the next command is
served, and replicas converge via the propagated `DEL`.

#### Which additional issues this PR fixes
1. MOD-15685
2. ZD 168121

#### Main objects this PR modified
1. `src/legacy_types.c` — orphan detection and the restore-path cleanup
2. `src/notifications.c` — dispatch the `restore` event
3. `tests/pytests/test_legacy_cleanup.py` — restore path, `MULTI` replacement value, ordinary keys untouched

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
