### PR TITLE
[MOD-15685] Clean up legacy index keys that arrive through an RDB load

### DIFF
--- a/src/indexes.c
+++ b/src/indexes.c
@@ -28,6 +28,7 @@
 
 #include "spec.h"
 #include "indexes.h"
+#include "legacy_types.h"
 #include "indexes_scan.h"
 #include "document.h"
 #include "util/likely.h"
@@ -992,6 +993,7 @@ void Indexes_List(RedisModule_Reply* reply, bool obfuscate) {
 }
 
 void Indexes_StartRDBLoadingEvent(RedisModuleCtx* ctx) {
+  LegacyTypes_ResetLoadedCount();
   Indexes_Free(ctx, specDict_g, false);
   if (!SearchDisk_IsEnabled()) {
     if (legacySpecDict) {
@@ -1016,6 +1018,10 @@ void Indexes_EndRDBLoadingEvent(RedisModuleCtx *ctx) {
   if (hasLegacyIndexes) {
     Indexes_ScanAndReindex();
   }
+
+  // Last on purpose: the sweep above removes the legacy keys it can reach through a loaded spec, so
+  // anything still present here had no spec to reach it.
+  LegacyTypes_SweepOrphansAfterLoad(ctx);
 }
 
 void Indexes_EndLoading() {

--- a/src/legacy_types.c
+++ b/src/legacy_types.c
@@ -11,6 +11,7 @@
 
 #include <stdbool.h>
 
+#include "rmalloc.h"
 #include "notifications.h"
 #include <stddef.h>
 
@@ -29,6 +30,10 @@ static RedisModuleType *LegacyInvertedIndexType = NULL;
 static RedisModuleType *LegacyNumericIndexType = NULL;
 static RedisModuleType *LegacyTagIndexType = NULL;
 
+// How many legacy keys the load in progress materialized. Only the loaders below touch it, so it
+// stays zero for every database that has never held one - which is what keeps the post-load sweep
+// free for everyone else.
+static size_t legacyKeysLoaded = 0;
 
 // Called whenever a legacy key is deserialized, from the type callbacks below.
 //
@@ -39,6 +44,7 @@ static RedisModuleType *LegacyTagIndexType = NULL;
 // the `restore` event this cleanup depends on would never reach us. That is exactly the shape of the
 // database this was reported on: ~101k legacy keys and search_number_of_indexes:0.
 static void noteLegacyKeyLoaded(void) {
+  legacyKeysLoaded++;
   Initialize_KeyspaceNotifications();
 }
 
@@ -192,9 +198,71 @@ void LegacyTypes_CleanupRestoredKey(RedisModuleCtx *ctx, RedisModuleString *key)
   }
 }
 
+void LegacyTypes_ResetLoadedCount(void) {
+  legacyKeysLoaded = 0;
+}
 
+typedef struct {
+  RedisModuleString **keys;
+  size_t len;
+  size_t cap;
+} OrphanedKeys;
 
+// Collect rather than delete inline: mutating the keyspace while `RedisModule_Scan` walks it is not
+// something the API promises to tolerate.
+static void collectOrphanedLegacyKey(RedisModuleCtx *ctx, RedisModuleString *keyname,
+                                     RedisModuleKey *key, void *privdata) {
+  if (!isOrphanedLegacyKey(key)) {
+    return;
+  }
+  OrphanedKeys *found = privdata;
+  if (found->len == found->cap) {
+    found->cap = found->cap ? found->cap * 2 : 64;
+    found->keys = rm_realloc(found->keys, found->cap * sizeof(*found->keys));
+  }
+  found->keys[found->len++] = RedisModule_HoldString(ctx, keyname);
+}
 
+void LegacyTypes_SweepOrphansAfterLoad(RedisModuleCtx *ctx) {
+  const size_t counted = legacyKeysLoaded;
+  legacyKeysLoaded = 0;
+  if (counted == 0) {
+    return;
+  }
+
+  if (!(RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_MASTER)) {
+    // During a full sync only the replica is loading; the primary is not. Deleting here would diverge
+    // from a primary that still holds these keys, so wait for its DEL.
+    RedisModule_Log(ctx, "notice",
+                    "Loaded %zu legacy index keys without being a writable primary; leaving them for "
+                    "the primary to clean up", counted);
+    return;
+  }
+
+  OrphanedKeys found = {0};
+  RedisModuleScanCursor *cursor = RedisModule_ScanCursorCreate();
+  while (RedisModule_Scan(ctx, cursor, collectOrphanedLegacyKey, &found)) {
+  }
+  RedisModule_ScanCursorDestroy(cursor);
+
+  size_t deleted = 0;
+  for (size_t i = 0; i < found.len; i++) {
+    // Re-check: the spec-driven upgrade sweep ran before this and may already have removed the key,
+    // and an AOF can replay `RESTORE k <legacy>` followed by `SET k valuable`.
+    if (isOrphanedLegacyKeyByName(ctx, found.keys[i])) {
+      deleteWithPropagation(ctx, found.keys[i]);
+      deleted++;
+    }
+    RedisModule_FreeString(ctx, found.keys[i]);
+  }
+  rm_free(found.keys);
+
+  // `counted` exceeding `deleted` is normal rather than a failure: the upgrade sweep removes the keys
+  // it knows about first. Report both so the difference is attributable instead of alarming.
+  RedisModule_Log(ctx, "notice",
+                  "Removed %zu orphaned legacy index keys (%zu were loaded; the rest had already been "
+                  "cleaned up by the index upgrade)", deleted, counted);
+}
 
 int RegisterLegacyTypes(RedisModuleCtx *ctx) {
 

--- a/src/legacy_types.h
+++ b/src/legacy_types.h
@@ -26,3 +26,10 @@ int RegisterLegacyTypes(RedisModuleCtx *ctx);
  * handing an RDB to Redis) and it fires no loading event. A no-op unless the key really is one. */
 void LegacyTypes_CleanupRestoredKey(RedisModuleCtx *ctx, RedisModuleString *key);
 
+/* Forget any legacy keys counted so far. Call at the start of an RDB load, and on failure. */
+void LegacyTypes_ResetLoadedCount(void);
+
+/* Delete legacy keys left behind by the load that just finished. Returns immediately when the load
+ * produced none, which is every load on a database that has never held one. Call *after* the
+ * spec-driven upgrade sweep, so keys it already removed are not counted as failures. */
+void LegacyTypes_SweepOrphansAfterLoad(RedisModuleCtx *ctx);


### PR DESCRIPTION
## Describe the changes in the pull request

> **Stacked on #10849.** Targets that branch, not `master`, so the diff here is only the delta. GitHub
> will retarget this to `master` automatically when #10849 merges. Review #10849 first.

**1. Current** — #10849 cleans up legacy index keys that arrive via `RESTORE`. It cannot cover keys
materialized by a genuine RDB load — startup from a pre-2.0 file, or a native replica full sync —
because no `restore` notification fires during a load.

**2. Change** — the loaders count what they materialize, and the count gates the work:

- At end-of-load a count of **zero returns immediately**, so a database that has never held one of
  these keys pays a single integer comparison and no scan. This is the whole reason for the counter.
- A non-zero count scans by type and deletes what it finds.
- The scan runs **after** the spec-driven upgrade sweep, and reports removed against loaded, because
  that sweep legitimately removes some of them first — a shortfall is normal, not a failure.
- Each candidate is re-checked immediately before deletion, since an AOF can replay
  `RESTORE k <legacy>` followed by `SET k valuable`.
- Deletes and propagates only from a writable primary. That matters more here than on the restore
  path: during a native full sync **only the replica is loading**, so a replica deleting locally would
  diverge from a primary that still holds the keys. Replicas log and wait for the propagated `DEL`.

**3. Outcome** — legacy keys arriving through a load are removed on a writable primary, with no cost to
any database that has never held one.

### Known gap — why this is stacked rather than folded into #10849

**There is no test for this path.** Once the restore-path cleanup is live, a legacy key is deleted as
soon as it is restored, so a dataset containing one cannot be built and then reloaded. Covering it needs
a hand-built RDB **file** carrying legacy records. The test helpers in #10849 already produce valid
module-value payloads with correct framing and CRC — verified against a footer the server itself wrote —
so the remaining work is the RDB file envelope.

Reviewers should weigh that: the mechanism is small and reasoned, but it is verified by reading only,
and the window it covers is narrow (a pre-2.0 RDB, without `UPGRADE_INDEX`, and without a legacy `idx:`
key — since one of those without the argument fails the whole load).

#### Which additional issues this PR fixes
1. MOD-15685

#### Main objects this PR modified
1. `src/legacy_types.c` — the load counter and the post-load sweep
2. `src/indexes.c` — reset at load start, sweep after the upgrade sweep

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
