### PR TITLE
Add characterization tests for the three rune-keyed tries

### DIFF
--- a/tests/pytests/test_dict_trie_encoding.py
+++ b/tests/pytests/test_dict_trie_encoding.py
@@ -1,0 +1,281 @@
+# -*- coding: utf-8 -*-
+
+from common import *
+
+'''
+Behavioral tests for how the spellcheck dictionary (FT.DICTADD / FT.DICTDEL /
+FT.DICTDUMP) handles the full spectrum of byte inputs.
+
+Pipeline under test (src/dictionary.c -> src/trie/trie.c -> src/trie/rune_util.c):
+  DICTADD:  bytes --strToRunesN/nu_utf8_read--> uint16 runes --> rune trie
+  DICTDUMP: runes --runesToStr/nu_utf8_write--> UTF-8 bytes
+
+Current (lenient) semantics demonstrated here:
+  * The UTF-8 decoder (libnu nu_utf8_read) performs NO validation. Invalid
+    sequences are decoded blindly from the lead byte's bit pattern; nothing
+    is ever rejected.
+  * Runes are uint16: codepoints above U+FFFF (astral plane) are silently
+    truncated to their low 16 bits, so distinct emoji can collide.
+  * Decoding stops at the first NUL codepoint: embedded NULs truncate terms.
+  * DICTDUMP re-encodes stored runes as UTF-8, so for any non-canonical input
+    the dumped bytes differ from the added bytes. The conversion is
+    deterministic, so DICTDEL with the same original bytes still deletes.
+  * DICTDUMP can even emit invalid UTF-8 (lone surrogates survive the
+    round-trip), so clients must treat replies as binary.
+  * Dictionary NAMES take a different path from dictionary terms: they never
+    reach the trie, and are keyed as C strings.
+
+Deliberately NOT skipped on cluster: every command here carries binary
+arguments, so running the same assertions against a coordinator also pins
+that fan-out preserves argument lengths rather than truncating at the first
+NUL.
+'''
+
+
+def dump_raw(env, dict_name):
+    '''DICTDUMP without response decoding: replies may be arbitrary bytes.'''
+    return sorted(env.cmd('ft.dictdump', dict_name, **{NEVER_DECODE: []}))
+
+
+# ============================ VALID UTF-8 ============================
+# Input that decodes cleanly: every codepoint <= U+FFFF round-trips.
+
+def testValidAsciiRoundtrip(env):
+    env.expect('ft.dictadd', 'dict', 'hello', 'world').equal(2)
+    env.assertEqual(dump_raw(env, 'dict'), [b'hello', b'world'])
+    env.expect('ft.dictdel', 'dict', 'hello', 'world').equal(2)
+
+def testValidBmpMultibyteRoundtrip(env):
+    # 2-byte (é), 3-byte (日) sequences: all codepoints <= U+FFFF round-trip.
+    terms = ['café', 'über', '日本語', 'привет']
+    env.expect('ft.dictadd', 'dict', *terms).equal(4)
+    env.assertEqual(dump_raw(env, 'dict'), sorted(t.encode() for t in terms))
+    env.expect('ft.dictdel', 'dict', *terms).equal(4)
+
+def testValidCaseSensitive(env):
+    # The dictionary trie does not case-fold: FOO and foo are distinct.
+    env.expect('ft.dictadd', 'dict', 'FOO', 'foo').equal(2)
+    env.assertEqual(dump_raw(env, 'dict'), [b'FOO', b'foo'])
+
+def testValidDuplicateCounting(env):
+    env.expect('ft.dictadd', 'dict', 'term').equal(1)
+    env.expect('ft.dictadd', 'dict', 'term').equal(0)
+
+
+# ==================== ASTRAL PLANE (valid UTF-8) ====================
+# Valid input, mangled anyway: runes are uint16, codepoints > U+FFFF are
+# truncated to their low 16 bits (strToRunesN's `(rune)cp` cast).
+
+def testAstralCodepointTruncated(env):
+    # U+1F600 (grinning face) is stored as U+F600: DICTDUMP returns a
+    # different (BMP, private-use) character than what was added.
+    env.expect('ft.dictadd', 'dict', '\U0001F600').equal(1)
+    env.assertEqual(dump_raw(env, 'dict'), ['\uf600'.encode()])
+
+def testAstralCodepointCollision(env):
+    # U+1F600 and U+2F600 share low 16 bits -> same trie entry.
+    env.expect('ft.dictadd', 'dict', '\U0001F600').equal(1)
+    env.expect('ft.dictadd', 'dict', '\U0002F600').equal(0)
+    # Deleting via either spelling removes the single shared entry.
+    env.expect('ft.dictdel', 'dict', '\U0002F600').equal(1)
+    env.expect('ft.dictdump', 'dict').equal([])
+
+
+# =================== CURRENT LENIENT BEHAVIOR =======================
+# Everything below feeds bytes that are NOT valid UTF-8 (or contain NULs):
+# every such call is accepted, and the stored entry is whatever the decoder
+# made of the input.
+
+def testEmbeddedNulTruncates(env):
+    # Decoding stops at the first NUL codepoint: 'foo\0bar' is stored as 'foo'.
+    env.expect('ft.dictadd', 'dict', b'foo\x00bar').equal(1)
+    env.assertEqual(dump_raw(env, 'dict'), [b'foo'])
+    # Everything after the NUL is ignored, so 'foo\0baz' is a duplicate...
+    env.expect('ft.dictadd', 'dict', b'foo\x00baz').equal(0)
+    # ...and any 'foo\0<suffix>' deletes the shared 'foo' entry.
+    env.expect('ft.dictdel', 'dict', b'foo\x00qux').equal(1)
+    env.expect('ft.dictdump', 'dict').equal([])
+
+def testLoneNulNotAdded(env):
+    # A term that decodes to zero runes is silently dropped (reply 0, no error).
+    env.expect('ft.dictadd', 'dict', b'\x00').equal(0)
+    env.expect('ft.dictdump', 'dict').equal([])
+
+def testOverlongNulTruncates(env):
+    # 0xC0 0x80 is an (invalid) overlong encoding of NUL. The decoder does not
+    # reject it; it decodes to codepoint 0 and truncates, like a real NUL.
+    env.expect('ft.dictadd', 'dict', b'ab\xc0\x80cd').equal(1)
+    env.assertEqual(dump_raw(env, 'dict'), [b'ab'])
+
+def testInvalid2ByteSequenceDecodedBlindly(env):
+    # 0xC3 0x28 is invalid ('(' is not a continuation byte). The decoder
+    # combines the payload bits anyway: (0xC3 & 0x03) << 6 | (0x28 & 0x3F)
+    # = U+00E8 'è'. Both bytes are consumed as one bogus codepoint.
+    env.expect('ft.dictadd', 'dict', b'\xc3\x28').equal(1)
+    env.assertEqual(dump_raw(env, 'dict'), ['è'.encode()])
+    # The conversion is deterministic, so the original bytes still delete it.
+    env.expect('ft.dictdel', 'dict', b'\xc3\x28').equal(1)
+
+def testLoneContinuationByteSwallowsNextByte(env):
+    # 0x80 is a bare continuation byte. The decoder misreads it as a 2-byte
+    # lead and consumes the following 'a' with it: (0x80 & 0x03) << 6 |
+    # (0x61 & 0x3F) = U+0021 '!'. Input '\x80abc' is stored as '!bc'.
+    env.expect('ft.dictadd', 'dict', b'\x80abc').equal(1)
+    env.assertEqual(dump_raw(env, 'dict'), [b'!bc'])
+
+def testUndefinedLeadByteSwallowsThreeBytes(env):
+    # 0xFF is not a legal lead byte; the decoder treats anything >= 0xF0 as a
+    # 4-byte sequence, consuming 0xFF plus 'abc' as one codepoint (which is
+    # then also > U+FFFF and truncated to uint16). Only 'd' survives intact.
+    env.expect('ft.dictadd', 'dict', b'\xffabcd').equal(1)
+    dumped = dump_raw(env, 'dict')
+    env.assertEqual(len(dumped), 1)
+    # One mangled leading character followed by the surviving 'd'.
+    env.assertTrue(dumped[0].endswith(b'd'))
+    env.assertNotEqual(dumped[0], b'\xffabcd')
+
+def testTruncatedSequenceAtEndOfTerm(env):
+    # A 2-byte lead as the last byte makes the decoder read one byte past the
+    # term (hitting the sds NUL terminator): 0xC3 0x00 decodes to U+00C0 'À'.
+    env.expect('ft.dictadd', 'dict', b'ab\xc3').equal(1)
+    env.assertEqual(dump_raw(env, 'dict'), ['abÀ'.encode()])
+
+def testSurrogateMakesDumpReplyInvalidUtf8(env):
+    # 0xED 0xA0 0x80 encodes lone surrogate U+D800 (invalid UTF-8). It is
+    # stored as rune 0xD800 and DICTDUMP re-encodes it verbatim: the reply
+    # itself is invalid UTF-8. Clients decoding replies as UTF-8 will fail.
+    env.expect('ft.dictadd', 'dict', b'\xed\xa0\x80').equal(1)
+    dumped = dump_raw(env, 'dict')
+    env.assertEqual(dumped, [b'\xed\xa0\x80'])
+    try:
+        dumped[0].decode('utf-8')
+        env.assertTrue(False, message='expected invalid UTF-8 in DICTDUMP reply')
+    except UnicodeDecodeError:
+        pass
+
+
+# ========================= LENGTH LIMITS ============================
+# Independent of encoding, but part of the same silent-drop surface:
+# over-long and empty terms are neither added nor reported as errors.
+
+def testTermLengthLimits(env):
+    # Trie_InsertStringBuffer drops terms > 512 bytes (TRIE_INITIAL_STRING_LEN
+    # * sizeof(rune)) and Trie_InsertRune drops terms >= 256 runes.
+    env.expect('ft.dictadd', 'dict', 'a' * 255).equal(1)
+    env.expect('ft.dictadd', 'dict', 'b' * 256).equal(0)   # 256 runes: dropped
+    env.expect('ft.dictadd', 'dict', 'c' * 600).equal(0)   # 600 bytes: dropped
+    env.assertEqual(dump_raw(env, 'dict'), [b'a' * 255])
+
+def testMultibyteTermLengthGateIsBytes(env):
+    # The byte gate is applied to the raw input, before decoding, so it binds
+    # long before the rune limit for multibyte input: 200 three-byte
+    # characters are 600 bytes but only 200 runes, and are still dropped.
+    env.expect('ft.dictadd', 'dict', '日' * 200).equal(0)
+    env.expect('ft.dictadd', 'dict', '日' * 100).equal(1)
+    env.assertEqual(dump_raw(env, 'dict'), [('日' * 100).encode()])
+
+def testEmptyTermNotAdded(env):
+    # Zero-length input is the lower end of the same silent-drop surface: the
+    # trie rejects an empty key, DICTADD reports 0 added rather than an error.
+    env.expect('ft.dictadd', 'dict', '').equal(0)
+    env.expect('ft.dictdump', 'dict').equal([])
+
+
+# ========================= DICTIONARY NAMES =========================
+# Terms are binary-safe-ish (mangled but length-preserving); the name that
+# selects the dictionary is not binary-safe at all.
+
+def testDictNameTruncatedAtNul(env):
+    # Names are read with RedisModule_StringPtrLen(argv[1], NULL) and stored
+    # as C-string keys of the global dictionary map, so everything from the
+    # first NUL byte on is invisible: two distinct names collide.
+    env.expect('ft.dictadd', b'a\x00b', 'hello').equal(1)
+    env.assertEqual(dump_raw(env, 'a'), [b'hello'])
+    # Adding under the name's visible prefix hits the same dictionary.
+    env.expect('ft.dictadd', 'a', 'hello').equal(0)
+    env.expect('ft.dictdel', b'a\x00c', 'hello').equal(1)
+
+
+# ==================== RDB PERSISTENCE ROUND-TRIP ====================
+# Aux save (SpellCheckDictAuxSave -> TrieType_GenericSave) re-encodes the
+# stored runes to UTF-8 via runesToStr; aux load decodes them back with the
+# same blind decoder. Encoding and decoding are exact inverses for every
+# uint16 rune value -- including surrogates -- so whatever the trie holds
+# after DICTADD survives an RDB cycle byte-identically. All mangling happens
+# at DICTADD time; persistence adds no further loss.
+
+def testRdbRoundtripValidTerms(env):
+    terms = ['hello', 'café', '日本語', 'FOO', 'foo']
+    env.expect('ft.dictadd', 'dict', *terms).equal(5)
+    before = dump_raw(env, 'dict')
+    env.dumpAndReload()
+    env.assertEqual(dump_raw(env, 'dict'), before)
+    env.expect('ft.dictdel', 'dict', *terms).equal(5)
+
+def testRdbRoundtripMangledTerms(env):
+    # Stored-state round-trip for every lenient-decode shape above: truncated
+    # astral rune (U+F600), blindly-decoded invalid sequences, and an entry
+    # truncated by an embedded NUL.
+    env.expect('ft.dictadd', 'dict', '\U0001F600').equal(1)  # -> U+F600
+    env.expect('ft.dictadd', 'dict', b'\xc3\x28').equal(1)   # -> 'è'
+    env.expect('ft.dictadd', 'dict', b'\x80abc').equal(1)    # -> '!bc'
+    env.expect('ft.dictadd', 'dict', b'foo\x00bar').equal(1) # -> 'foo'
+    before = dump_raw(env, 'dict')
+    env.assertEqual(len(before), 4)
+    env.dumpAndReload()
+    env.assertEqual(dump_raw(env, 'dict'), before)
+    # Entries are still addressable post-reload via the original raw bytes.
+    env.expect('ft.dictdel', 'dict', b'\xc3\x28').equal(1)
+    env.expect('ft.dictdel', 'dict', b'foo\x00baz').equal(1)
+
+def testRdbRoundtripSurrogateRune(env):
+    # The nastiest case: rune 0xD800 serializes to RDB as the same invalid
+    # UTF-8 bytes (ED A0 80) that DICTDUMP emits, and the blind loader
+    # restores it verbatim. Persistence of invalid UTF-8 is thus durable
+    # across restarts, not just an in-memory artifact.
+    env.expect('ft.dictadd', 'dict', b'\xed\xa0\x80').equal(1)
+    env.dumpAndReload()
+    env.assertEqual(dump_raw(env, 'dict'), [b'\xed\xa0\x80'])
+    env.expect('ft.dictdel', 'dict', b'\xed\xa0\x80').equal(1)
+
+
+# ================== SPELLCHECK USES THE SAME TRIE ====================
+
+def testSpellCheckSuggestionFromMultibyteDict(env):
+    # Suggestions surface through the same runesToStr re-encoding, so valid
+    # BMP dictionary terms come back byte-identical via FT.SPELLCHECK too.
+    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 't', 'TEXT')
+    env.cmd('ft.dictadd', 'dict', 'café')
+    res = env.cmd('ft.spellcheck', 'idx', 'cafe', 'TERMS', 'INCLUDE', 'dict')
+    env.assertEqual(res, [['TERM', 'cafe', [['0', 'café']]]])
+
+def testSpellCheckIncludeSurfacesMangledEntry(env):
+    # DICTADD b'\x80abc' stores '!bc' (lone continuation byte swallows 'a').
+    # A fuzzy INCLUDE match against query term 'abc' (one substitution away)
+    # surfaces the mangled entry as a suggestion: the user-visible correction
+    # never matches the bytes that were added to the dictionary.
+    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 't', 'TEXT')
+    env.cmd('ft.dictadd', 'dict', b'\x80abc')
+    res = env.cmd('ft.spellcheck', 'idx', 'abc', 'TERMS', 'INCLUDE', 'dict')
+    env.assertEqual(res, [['TERM', 'abc', [['0', '!bc']]]])
+
+def testSpellCheckIncludeSurrogateMakesReplyInvalidUtf8(env):
+    # A lone-surrogate dictionary entry (rune 0xD800, one edit away from any
+    # single-char query term) is re-encoded verbatim into the FT.SPELLCHECK
+    # reply: like DICTDUMP, the reply itself becomes invalid UTF-8.
+    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 't', 'TEXT')
+    env.cmd('ft.dictadd', 'dict', b'\xed\xa0\x80')
+    res = env.cmd('ft.spellcheck', 'idx', 'x', 'TERMS', 'INCLUDE', 'dict',
+                  **{NEVER_DECODE: []})
+    env.assertEqual(res, [[b'TERM', b'x', [[b'0', b'\xed\xa0\x80']]]])
+
+def testSpellCheckExcludeMatchesNulTruncatedEntry(env):
+    # DICTADD b'foo\x00bar' stores 'foo'. The EXCLUDE lookup is an exact
+    # (distance-0) match on the stored runes, so query term 'foo' -- which the
+    # user never added -- is treated as correct and omitted from the reply.
+    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 't', 'TEXT')
+    env.cmd('ft.dictadd', 'dict', b'foo\x00bar')
+    env.expect('ft.spellcheck', 'idx', 'foo', 'TERMS', 'EXCLUDE', 'dict').equal([])
+    # Sanity: without the exclude dict the term does get spellcheck treatment.
+    res = env.cmd('ft.spellcheck', 'idx', 'foo')
+    env.assertEqual(res, [['TERM', 'foo', []]])

--- a/tests/pytests/test_suffix_trie_encoding.py
+++ b/tests/pytests/test_suffix_trie_encoding.py
@@ -1,0 +1,285 @@
+# -*- coding: utf-8 -*-
+
+from common import *
+
+'''
+Behavioral tests for how the WITHSUFFIXTRIE suffix trie of a TEXT field
+handles the full spectrum of byte inputs arriving through document indexing.
+
+The store is spec->suffix, a rune-keyed Trie (src/suffix.c: addSuffixTrie).
+Every term is decoded into uint16 runes, and one entry is inserted per suffix
+of the rune sequence. The PAYLOAD (suffixData) holds the original term BYTES,
+so candidates handed back to the inverted index escape the rune round-trip --
+but the KEYS are runes and are therefore lossy above U+FFFF, exactly like
+spec->terms.
+
+Current semantics demonstrated here (readout via FT.DEBUG DUMP_SUFFIX_TRIE,
+which replies with the runesToStr-re-encoded trie KEYS, and via
+contains/suffix queries):
+  * Keys are truncated above U+FFFF while the payload keeps the real bytes:
+    contains and suffix queries reach an astral term that prefix queries
+    (terms-trie driven) cannot, and a query for the truncated BMP codepoint
+    reaches it too.
+  * That divergence is one-sided. Suffix_CB_Wildcard deliberately skips
+    candidates containing a supplementary codepoint so the suffix-trie path
+    stays result-identical with the brute-force scan; Suffix_IterateContains
+    has no such filter, so contains/suffix return documents the brute-force
+    path never returns.
+  * Terms are identified inside the suffix trie by their RUNE key, so two
+    byte-distinct terms that truncate to the same runes collide: the term
+    indexed second is dropped from the store entirely, and every contains or
+    suffix query answers with the first one. Both remain exactly searchable
+    through the (byte-keyed) inverted index.
+  * The insert path applies its length gate to the suffixes only, so the
+    full-word entry is stored at any length. A long term is therefore
+    reachable by a query spelling it out in full, and by shorter suffixes of
+    it, but not by the suffixes in between.
+  * The query-side minimum length (MINPREFIX) counts BYTES, so a one-character
+    pattern is rejected or accepted depending on how that character encodes.
+'''
+
+# U+1F600 GRINNING FACE. Valid UTF-8, four bytes, above the uint16 rune range.
+ASTRAL = '\U0001F600'
+# The rune the suffix trie actually stores for ASTRAL: the low 16 bits.
+BMP_TWIN = chr(0xF600)
+
+# 300 runes of plain ASCII: past the 256-rune insert gate, well under the
+# 512-byte one, so the rune gate is the only thing that fires.
+LONG = ''.join(chr(ord('a') + (i * 7) % 26) for i in range(300))
+# 255 runes of the same alphabet: the longest term the terms trie accepts.
+LONG_255 = LONG[:255]
+
+
+def create_index(env, with_suffix_trie=True):
+    env.skipOnCluster()
+    schema = ['t', 'TEXT', 'NOSTEM'] + (['WITHSUFFIXTRIE'] if with_suffix_trie else [])
+    env.expect('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', *schema).ok()
+
+def add_doc(env, key, value):
+    with env.getClusterConnectionIfNeeded() as r:
+        env.assertEqual(r.execute_command('hset', key, 't', value), 1)
+    waitForIndex(env, 'idx')
+
+def dump_suffix_raw(env):
+    '''DUMP_SUFFIX_TRIE without response decoding: keys may be arbitrary bytes.'''
+    return sorted(env.cmd(debug_cmd(), 'DUMP_SUFFIX_TRIE', 'idx',
+                          **{NEVER_DECODE: []}))
+
+def ids(env, query):
+    return sorted(env.cmd('ft.search', 'idx', query, 'NOCONTENT')[1:])
+
+def num_results(env, query):
+    return env.cmd('ft.search', 'idx', query, 'NOCONTENT')[0]
+
+
+# ============ RUNE KEYS, BYTE PAYLOAD (valid UTF-8 input) ============
+# The suffix trie stores every term twice over: as rune keys, and as the
+# original bytes inside the payload. Above U+FFFF the two disagree.
+
+def testSuffixKeysAreRunesPayloadIsOriginalBytes(env):
+    create_index(env)
+    add_doc(env, 'doc1', 'w' + ASTRAL + 'y')
+    # One entry per suffix of the 3-rune term, each key re-encoded from the
+    # truncated runes.
+    env.assertEqual(dump_suffix_raw(env),
+                    sorted([('w' + BMP_TWIN + 'y').encode(),
+                            (BMP_TWIN + 'y').encode(),
+                            b'y']))
+    # The payload kept the real bytes, so the candidate looked up in the
+    # inverted index is the term as indexed, not the re-encoded key.
+    env.assertEqual(ids(env, '*' + ASTRAL + '*'), ['doc1'])
+    env.assertEqual(ids(env, '*' + ASTRAL + 'y'), ['doc1'])
+    # Prefix queries resolve candidates through the terms trie instead, and
+    # that store has no byte-preserving payload to fall back on.
+    env.assertEqual(num_results(env, 'w' + ASTRAL + '*'), 0)
+
+def testTruncatedRuneQueryReachesAstralTerm(env):
+    create_index(env)
+    add_doc(env, 'doc1', 'w' + ASTRAL + 'y')
+    # The query pattern is converted to runes by the same lossy path, so a
+    # query for U+F600 lands on the node holding U+1F600 and returns a
+    # document that does not contain the requested codepoint at all.
+    env.assertEqual(ids(env, '*' + BMP_TWIN + '*'), ['doc1'])
+    env.assertEqual(ids(env, '*' + BMP_TWIN + 'y'), ['doc1'])
+
+def testSuffixTrieChangesResultsForAstralTerms(env):
+    create_index(env, with_suffix_trie=False)
+    add_doc(env, 'doc1', 'w' + ASTRAL + 'y')
+    # Without the suffix trie, contains and suffix queries brute-force the
+    # terms trie and re-encode each candidate, so they miss the real key.
+    # WITHSUFFIXTRIE is documented as an optimization, but for these terms it
+    # decides whether the document is found at all.
+    env.assertEqual(num_results(env, '*' + ASTRAL + '*'), 0)
+    env.assertEqual(num_results(env, '*' + BMP_TWIN + '*'), 0)
+    env.assertEqual(num_results(env, 'w' + ASTRAL + 'y'), 1)
+    # Wildcard is the half of the divergence that does NOT change: these same
+    # queries answer 0 with the suffix trie too.
+    env.assertEqual(num_results(env, "w'*" + ASTRAL + "*'"), 0)
+    env.assertEqual(num_results(env, "w'*" + BMP_TWIN + "*'"), 0)
+
+def testWildcardSkipsAstralCandidates(env):
+    create_index(env)
+    add_doc(env, 'doc1', 'w' + ASTRAL + 'y')
+    # Suffix_CB_Wildcard drops any candidate holding a supplementary
+    # codepoint, matching the no-suffix-trie answers pinned in
+    # testSuffixTrieChangesResultsForAstralTerms. Suffix_IterateContains has
+    # no such filter, hence the split verdict below.
+    env.assertEqual(num_results(env, "w'*" + ASTRAL + "*'"), 0)
+    env.assertEqual(num_results(env, "w'*" + BMP_TWIN + "*'"), 0)
+    env.assertEqual(num_results(env, '*' + ASTRAL + '*'), 1)
+
+
+# ======================== RUNE-KEY COLLISIONS ========================
+# addSuffixTrie asks the trie whether the term's rune key already carries a
+# term and returns early if it does. The check cannot distinguish two terms
+# that truncate to the same runes.
+
+def testTwoTermsShareSuffixNodeWithoutCollision(env):
+    create_index(env)
+    add_doc(env, 'doc_a', 'zqay')
+    add_doc(env, 'doc_b', 'zqby')
+    # Baseline: distinct rune keys, so both terms are stored and a shared
+    # suffix node reports both documents.
+    env.assertEqual(ids(env, '*zq*'), ['doc_a', 'doc_b'])
+
+def testRuneCollisionDropsSecondTerm(env):
+    create_index(env)
+    add_doc(env, 'doc_bmp', 'x' + BMP_TWIN + 'y')
+    add_doc(env, 'doc_astral', 'x' + ASTRAL + 'y')
+    # The second term found a node that already carries a term and returned
+    # without adding itself -- not even to that node's candidate array. The
+    # store looks exactly as it would with the first document alone.
+    env.assertEqual(dump_suffix_raw(env),
+                    sorted([('x' + BMP_TWIN + 'y').encode(),
+                            (BMP_TWIN + 'y').encode(),
+                            b'y']))
+    # Every contains or suffix query therefore answers with the first term,
+    # whichever of the two codepoints was asked for.
+    env.assertEqual(ids(env, '*' + ASTRAL + '*'), ['doc_bmp'])
+    env.assertEqual(ids(env, '*' + BMP_TWIN + '*'), ['doc_bmp'])
+    # Both documents stay exactly searchable: the inverted index is keyed by
+    # the term bytes and never collapses the pair.
+    env.assertEqual(ids(env, 'x' + ASTRAL + 'y'), ['doc_astral'])
+    env.assertEqual(ids(env, 'x' + BMP_TWIN + 'y'), ['doc_bmp'])
+
+def testRuneCollisionSurvivorIsTheTermIndexedFirst(env):
+    create_index(env)
+    add_doc(env, 'doc_astral', 'x' + ASTRAL + 'y')
+    add_doc(env, 'doc_bmp', 'x' + BMP_TWIN + 'y')
+    # Same pair, reversed indexing order: now the astral term is the one
+    # stored, so the same two queries answer with the other document. Which
+    # document a contains query returns depends on indexing order alone --
+    # including the order documents are re-indexed in after a reload.
+    env.assertEqual(dump_suffix_raw(env),
+                    sorted([('x' + BMP_TWIN + 'y').encode(),
+                            (BMP_TWIN + 'y').encode(),
+                            b'y']))
+    env.assertEqual(ids(env, '*' + ASTRAL + '*'), ['doc_astral'])
+    env.assertEqual(ids(env, '*' + BMP_TWIN + '*'), ['doc_astral'])
+
+def testRuneCollisionDeletingWinnerHidesLoser(env):
+    create_index(env)
+    add_doc(env, 'doc_bmp', 'x' + BMP_TWIN + 'y')
+    add_doc(env, 'doc_astral', 'x' + ASTRAL + 'y')
+    with env.getClusterConnectionIfNeeded() as r:
+        env.assertEqual(r.execute_command('del', 'doc_bmp'), 1)
+    # Suffix entries are removed by the fork GC.
+    forceInvokeGC(env, 'idx')
+    # The deleted document's term was the only one ever stored, so the whole
+    # trie goes with it -- and the surviving document, whose term was dropped
+    # at indexing time, is now unreachable by contains or suffix while still
+    # being indexed and exactly searchable.
+    env.assertEqual(dump_suffix_raw(env), [])
+    env.assertEqual(num_results(env, '*' + ASTRAL + '*'), 0)
+    env.assertEqual(ids(env, 'x' + ASTRAL + 'y'), ['doc_astral'])
+
+
+# ===================== INSERT-SIDE LENGTH GATES ======================
+# addSuffixTrie inserts the full word with Trie_InsertRuneNoSize (no length
+# guard) and every proper suffix with Trie_InsertRune (guarded at
+# TRIE_INITIAL_STRING_LEN runes). Reachability is therefore not monotonic in
+# the length of the queried pattern.
+#
+# None of these tests dump the trie: TrieIterator caps the key it rebuilds at
+# TRIE_INITIAL_STRING_LEN runes, and a term this long walks straight into
+# that cap.
+
+def testLongTermReachableOnlyThroughTheSuffixTrie(env):
+    create_index(env)
+    add_doc(env, 'doc1', LONG)
+    add_doc(env, 'doc2', LONG_255)
+    # The terms trie takes the 255-rune term and rejects the 300-rune one, so
+    # prefix expansion sees only the shorter document.
+    env.assertEqual(ids(env, LONG[:20] + '*'), ['doc2'])
+    # Both are exactly searchable, and the suffix trie reaches both.
+    env.assertEqual(ids(env, LONG), ['doc1'])
+    env.assertEqual(ids(env, '*' + LONG[-10:]), ['doc1'])
+    env.assertEqual(ids(env, '*' + LONG_255[-10:]), ['doc2'])
+
+def testSuffixEntriesStopBelowTheFullWordEntry(env):
+    create_index(env)
+    add_doc(env, 'doc1', LONG)
+    # Suffixes up to the insert limit are stored...
+    env.assertEqual(num_results(env, '*' + LONG[-254:]), 1)
+    env.assertEqual(num_results(env, '*' + LONG[-255:]), 1)
+    # ...longer ones are silently dropped...
+    env.assertEqual(num_results(env, '*' + LONG[-256:]), 0)
+    env.assertEqual(num_results(env, '*' + LONG[-260:]), 0)
+    # ...yet the full word, inserted through the unguarded entry point, is
+    # there: asking for a longer suffix succeeds where a shorter one failed.
+    env.assertEqual(num_results(env, '*' + LONG), 1)
+
+def testContainsWalksIntoTheFullWordEntry(env):
+    create_index(env)
+    add_doc(env, 'doc1', LONG)
+    # A contains pattern is matched against key prefixes rather than whole
+    # keys, so it reaches the full-word entry and is unaffected by the gate
+    # that hides the long suffixes.
+    env.assertEqual(num_results(env, '*' + LONG[140:150] + '*'), 1)
+    env.assertEqual(num_results(env, '*' + LONG[:260] + '*'), 1)
+
+
+# =============== QUERY-SIDE MINIMUM LENGTH (IN BYTES) ================
+# Contains and suffix patterns shorter than MINPREFIX are answered with an
+# empty result rather than an error. The comparison is against the pattern's
+# byte length, so it is really a limit on encoded size.
+
+def testMinimumPatternLengthCountsBytesNotCharacters(env):
+    create_index(env)
+    add_doc(env, 'doc1', 'wéz x日y')
+    # One ASCII character is one byte: below the default MINPREFIX of 2.
+    env.assertEqual(num_results(env, '*z'), 0)
+    env.assertEqual(num_results(env, '*x*'), 0)
+    # One non-ASCII character is two or three bytes, so the identical query
+    # shape passes the gate.
+    env.assertEqual(ids(env, '*é*'), ['doc1'])
+    env.assertEqual(ids(env, '*日*'), ['doc1'])
+
+
+# ================= RDB RELOAD (RE-INDEXING) =========================
+# The suffix trie is not serialized: it is rebuilt from the documents by the
+# same indexing path that filled it originally. What survives a reload is
+# therefore whatever that path is deterministic about.
+
+def testGatesReproduceAcrossReload(env):
+    create_index(env)
+    add_doc(env, 'doc1', LONG)
+    env.dumpAndReload()
+    env.assertEqual(num_results(env, '*' + LONG[-10:]), 1)
+    env.assertEqual(num_results(env, '*' + LONG[-256:]), 0)
+    env.assertEqual(num_results(env, '*' + LONG), 1)
+
+def testCollisionSurvivesReloadWithoutAgreeingOnAWinner(env):
+    create_index(env)
+    add_doc(env, 'doc_bmp', 'x' + BMP_TWIN + 'y')
+    add_doc(env, 'doc_astral', 'x' + ASTRAL + 'y')
+    env.dumpAndReload()
+    # Documents are re-indexed in keyspace order, which is not the order they
+    # were added in, so which term wins the collision is not pinned here --
+    # only that one of them does, and that both queries agree on it.
+    winner = ids(env, '*' + ASTRAL + '*')
+    env.assertEqual(len(winner), 1)
+    env.assertEqual(ids(env, '*' + BMP_TWIN + '*'), winner)
+    # Exact search is unaffected by which one that is.
+    env.assertEqual(ids(env, 'x' + ASTRAL + 'y'), ['doc_astral'])
+    env.assertEqual(ids(env, 'x' + BMP_TWIN + 'y'), ['doc_bmp'])

--- a/tests/pytests/test_terms_trie_encoding.py
+++ b/tests/pytests/test_terms_trie_encoding.py
@@ -1,0 +1,275 @@
+# -*- coding: utf-8 -*-
+
+from common import *
+
+'''
+Behavioral tests for how the index term trie (spec->terms) handles the full
+spectrum of byte inputs arriving through document indexing.
+
+Pipeline under test:
+  HSET value --toksep (src/toksep.h)--> raw tokens
+             --DefaultNormalize (src/tokenize.c): strips isblank/iscntrl-->
+             --unicode_tolower (src/util/strconv.h): blind nu_utf8_read decode
+               to uint32 codepoints, lowercase, re-encode as UTF-8-->
+             normalized term bytes, which land in TWO stores:
+               1. the inverted index, keyed by the term BYTES (lossless), and
+               2. spec->terms via IndexSpec_AddTerm -> Trie_InsertStringBuffer
+                  (src/spec.c) -- re-decoded into uint16 runes, which is LOSSY
+                  above U+FFFF and silently drops over-long terms.
+
+Current semantics demonstrated here (readout via FT.DEBUG DUMP_TERMS, which
+re-encodes trie runes with runesToStr, and via FT.SEARCH):
+  * toksep iterates with a C-string loop: tokenization STOPS at the first
+    NUL byte; the rest of the field value is silently never indexed.
+  * Other control bytes are stripped from tokens by DefaultNormalize.
+  * Invalid UTF-8 is never rejected: unicode_tolower blind-decodes it and
+    re-encodes valid UTF-8, so garbage bytes are "laundered" into real
+    codepoints consistently in both the inverted index and the terms trie.
+  * Lone surrogates survive laundering (blind decode+encode are inverses),
+    so both stores can hold invalid UTF-8, and replies built from either
+    (DUMP_TERMS, FT.SPELLCHECK suggestions) can be invalid UTF-8.
+  * Astral codepoints (valid UTF-8!) diverge between the two stores: the
+    inverted index keeps the real 4-byte sequence, the trie truncates each
+    codepoint to uint16. Exact search works (index lookup by bytes) while
+    expansion driven by the terms trie (prefix, fuzzy, wildcard) rebuilds the
+    WRONG bytes and finds nothing. WITHSUFFIXTRIE is the exception: the
+    suffix trie carries the original term bytes as a payload, so contains and
+    suffix queries survive what prefix queries lose
+    (test_suffix_trie_encoding.py).
+  * Terms longer than the trie's insert limit are dropped from the trie but
+    still indexed: another way for a searchable term to be invisible to
+    every trie-driven expansion.
+'''
+
+
+def dump_terms_raw(env, idx='idx'):
+    '''DUMP_TERMS without response decoding: replies may be arbitrary bytes.'''
+    return sorted(env.cmd(debug_cmd(), 'DUMP_TERMS', idx, **{NEVER_DECODE: []}))
+
+def create_index(env):
+    env.skipOnCluster()
+    env.expect('ft.create', 'idx', 'ON', 'HASH',
+               'SCHEMA', 't', 'TEXT', 'NOSTEM').ok()
+
+def add_doc(env, key, value):
+    with env.getClusterConnectionIfNeeded() as r:
+        env.assertEqual(r.execute_command('hset', key, 't', value), 1)
+    waitForIndex(env, 'idx')
+
+def num_results(env, query):
+    return env.cmd('ft.search', 'idx', query, 'NOCONTENT')[0]
+
+
+# ============================ VALID UTF-8 ============================
+# Field values that decode cleanly: every codepoint <= U+FFFF round-trips.
+
+def testValidTermsCaseFoldedRoundtrip(env):
+    create_index(env)
+    add_doc(env, 'doc1', 'Hello Café 日本語')
+    # Terms are case-folded on the way in, by unicode_tolower.
+    env.assertEqual(dump_terms_raw(env),
+                    sorted(['café'.encode(), b'hello', '日本語'.encode()]))
+    env.assertEqual(num_results(env, 'hello'), 1)
+    env.assertEqual(num_results(env, 'café'), 1)
+    env.assertEqual(num_results(env, '日本語'), 1)
+
+
+# ==================== ASTRAL PLANE (valid UTF-8) ====================
+# The normalized term bytes keep the real 4-byte sequences (unicode_tolower
+# works on uint32 codepoints), so the inverted index key is intact. But the
+# terms-trie insert truncates each codepoint to uint16, so the trie holds
+# U+F600 instead of U+1F600 -- and every query path that goes through the
+# trie rebuilds the wrong bytes.
+
+def testAstralExactSearchWorks(env):
+    create_index(env)
+    add_doc(env, 'doc1', '\U0001F600\U0001F600')
+    # Exact term search hits the inverted index by bytes: lossless.
+    env.assertEqual(num_results(env, '\U0001F600\U0001F600'), 1)
+
+def testAstralTermTrieTruncated(env):
+    create_index(env)
+    add_doc(env, 'doc1', '\U0001F600\U0001F600')
+    # The trie stored truncated runes: DUMP_TERMS shows U+F600 U+F600.
+    env.assertEqual(dump_terms_raw(env), ['\uf600\uf600'.encode()])
+
+def testAstralPrefixSearchFindsNothing(env):
+    create_index(env)
+    add_doc(env, 'doc1', '\U0001F600\U0001F600')
+    # Prefix expansion walks the trie (truncated runes match fine), then
+    # re-encodes each candidate with runesToStr -> U+F600 bytes -> inverted
+    # index lookup misses the real U+1F600 key. Valid-UTF-8 input, zero hits.
+    env.assertEqual(num_results(env, '\U0001F600*'), 0)
+    # Same divergence in reverse: querying by the truncated rune the trie
+    # actually stores DOES match in the trie, but the re-encoded candidate
+    # term has no inverted-index entry either.
+    env.assertEqual(num_results(env, '\uf600*'), 0)
+
+def testAstralFuzzyAndWildcardFindNothing(env):
+    create_index(env)
+    add_doc(env, 'doc1', '\U0001F600\U0001F600')
+    # Prefix is not a special case: every expansion that resolves candidates
+    # through the terms trie re-encodes them with runesToStr and misses the
+    # real inverted-index key the same way.
+    env.assertEqual(num_results(env, '%\U0001F600\U0001F600%'), 0)
+    env.assertEqual(num_results(env, "w'\U0001F600*'"), 0)
+
+
+# =================== CURRENT LENIENT BEHAVIOR =======================
+# Invalid bytes and NULs in document field values: never rejected, always
+# rewritten into whatever the decoder makes of them.
+
+def testNulStopsTokenization(env):
+    create_index(env)
+    # toksep's scan loop is NUL-terminated: 'bar' after the NUL is never seen.
+    add_doc(env, 'doc1', b'foo\x00bar')
+    env.assertEqual(dump_terms_raw(env), [b'foo'])
+    env.assertEqual(num_results(env, 'foo'), 1)
+    env.assertEqual(num_results(env, 'bar'), 0)
+
+def testControlCharsStrippedFromToken(env):
+    create_index(env)
+    # In contrast to NUL, other control bytes are stripped by
+    # DefaultNormalize's iscntrl() filter and tokenization continues:
+    # 'a\x01b' indexes as a single term 'ab'.
+    add_doc(env, 'doc1', b'a\x01b')
+    env.assertEqual(dump_terms_raw(env), [b'ab'])
+    env.assertEqual(num_results(env, 'ab'), 1)
+
+def testInvalidBytesLaunderedIntoValidTerm(env):
+    create_index(env)
+    # 0xC3 0xC3 is invalid (0xC3 is not a continuation byte). The blind
+    # decoder reads it as (0xC3 & 0x03) << 6 | (0xC3 & 0x3F) = U+00C3 'Ã',
+    # which then case-folds to 'ã'. Both the inverted index and the trie
+    # agree on the laundered term, so it is searchable -- but only by bytes
+    # the user never wrote.
+    add_doc(env, 'doc1', b'\xc3\xc3')
+    env.assertEqual(dump_terms_raw(env), ['ã'.encode()])
+    env.assertEqual(num_results(env, 'ã'), 1)
+
+def testSurrogateBytesIndexedVerbatim(env):
+    create_index(env)
+    # 0xED 0xA0 0x80 (lone surrogate U+D800, invalid UTF-8) survives the
+    # normalize pipeline verbatim: blind decode to 0xD800, no case mapping,
+    # re-encode to the same three bytes. Both stores hold invalid UTF-8.
+    add_doc(env, 'doc1', b'\xed\xa0\x80')
+    env.assertEqual(dump_terms_raw(env), [b'\xed\xa0\x80'])
+
+def testSurrogateTermSurfacesInSpellCheckReply(env):
+    create_index(env)
+    # FT.SPELLCHECK suggestions come from spec->terms (no dictionaries
+    # involved): the surrogate term is one edit from 'x', its re-encoded
+    # bytes hit the inverted index (so it gets a real score), and the reply
+    # contains invalid UTF-8.
+    add_doc(env, 'doc1', b'\xed\xa0\x80')
+    res = env.cmd('ft.spellcheck', 'idx', 'x', **{NEVER_DECODE: []})
+    env.assertEqual(res, [[b'TERM', b'x', [[b'1', b'\xed\xa0\x80']]]])
+
+
+# ================= INVALID UTF-8 ABOVE THE BMP ======================
+# The blind decoder sizes a sequence from its lead byte alone, so invalid
+# bytes can decode ABOVE U+FFFF and hit the astral truncation from the
+# other side. There the damage compounds: F5 80 80 80 decodes to U+140000,
+# whose low 16 bits are ZERO, and strToRunesN stops at a zero codepoint.
+# The trie entry is therefore CUT SHORT at the offending character, leaving
+# a phantom prefix behind that no document ever contained -- unlike the
+# valid-astral case, where the trie holds a wrong term of the right length.
+
+def testAboveBmpInvalidBytesCutTermShortInTrie(env):
+    create_index(env)
+    add_doc(env, 'doc1', b'caf\xf5\x80\x80\x80e')
+    # Everything from the truncated codepoint onwards is gone from the trie.
+    env.assertEqual(dump_terms_raw(env), [b'caf'])
+    # The inverted index is keyed by the laundered bytes, which are intact,
+    # so exact search - which never consults the trie - still finds the doc.
+    env.assertEqual(num_results(env, b'caf\xf5\x80\x80\x80e'), 1)
+
+def testAboveBmpPhantomTermMatchesNothing(env):
+    create_index(env)
+    add_doc(env, 'doc1', b'caf\xf5\x80\x80\x80e')
+    # 'caf' is in the trie but names no inverted index entry, so it is not
+    # a searchable term, and prefix expansion resolves to it and nothing else.
+    env.assertEqual(num_results(env, 'caf'), 0)
+    env.assertEqual(num_results(env, 'caf*'), 0)
+
+def testAboveBmpPrefixReachesOnlyBmpSibling(env):
+    create_index(env)
+    add_doc(env, 'doc1', b'caf\xf5\x80\x80\x80e')
+    # E9 41 42 is invalid too, but decodes to U+9042 - inside the BMP, so it
+    # survives the rune round-trip and stays reachable.
+    add_doc(env, 'doc2', b'caf\xe9\x41\x42')
+    env.assertEqual(dump_terms_raw(env), [b'caf', 'caf遂'.encode()])
+    # One prefix, two trie hits, one reachable document.
+    env.assertEqual(num_results(env, 'caf*'), 1)
+
+
+# ================ SUFFIX TRIE KEEPS THE ORIGINAL BYTES ==============
+# WITHSUFFIXTRIE keeps the original term bytes, so contains and suffix queries
+# escape the astral loss the prefix path suffers. Only that contrast with
+# spec->terms is pinned here; test_suffix_trie_encoding.py owns the suffix
+# store's own characteristics.
+
+def testSuffixQueriesReachAstralTerm(env):
+    env.skipOnCluster()
+    env.expect('ft.create', 'idx', 'ON', 'HASH',
+               'SCHEMA', 't', 'TEXT', 'NOSTEM', 'WITHSUFFIXTRIE').ok()
+    add_doc(env, 'doc1', 'x\U0001F600y')
+    # The terms trie holds the truncated rune, as it does without a suffix trie.
+    env.assertEqual(dump_terms_raw(env), ['x\uf600y'.encode()])
+    # Contains and suffix queries resolve candidates from the suffix trie
+    # payload and hit the real inverted-index key...
+    env.assertEqual(num_results(env, '*\U0001F600*'), 1)
+    env.assertEqual(num_results(env, '*\U0001F600y'), 1)
+    # ...while the prefix query for the same document still finds nothing:
+    # prefixes are resolved through the terms trie, which lost the codepoint.
+    env.assertEqual(num_results(env, 'x\U0001F600*'), 0)
+
+
+# ========================== LENGTH LIMITS ===========================
+# The inverted index has no length gate, the terms trie does: terms above the
+# limit are indexed and exactly searchable, yet absent from the trie. Same
+# observable shape as the above-BMP case, reached without any invalid input.
+
+def testLongTermIndexedButMissingFromTrie(env):
+    create_index(env)
+    add_doc(env, 'doc1', 'a' * 255)
+    # Trie_InsertStringBuffer rejects terms longer than 512 bytes and
+    # IndexSpec_AddTerm discards that rejection without logging or counting it.
+    add_doc(env, 'doc2', 'b' * 600)
+    env.assertEqual(dump_terms_raw(env), [b'a' * 255])
+    env.assertEqual(num_results(env, 'b' * 600), 1)
+    env.assertEqual(num_results(env, 'bbb*'), 0)
+
+def testLongMultibyteTermGateIsBytes(env):
+    create_index(env)
+    # The gate counts raw bytes, not runes, so a multibyte term is dropped at
+    # well under 256 runes: 200 three-byte characters are 600 bytes.
+    add_doc(env, 'doc1', '日' * 200)
+    env.assertEqual(dump_terms_raw(env), [])
+    env.assertEqual(num_results(env, '日' * 200), 1)
+
+
+# ===================== RDB RELOAD (RE-INDEXING) =====================
+# spec->terms of a regular in-memory index is NOT serialized to RDB
+# (IndexSpec_RdbSave only writes the terms trie for
+# disk/SST-backed specs; the other TrieType_GenericLoad site is the legacy
+# pre-2.0 path). On load, documents fire 'loaded' keyspace notifications and
+# every doc re-runs the full tokenize -> normalize -> trie pipeline. The
+# reload equality below therefore holds because that pipeline is
+# DETERMINISTIC, not because the trie bytes round-trip: truncated-astral and
+# surrogate terms are re-created from the (binary-safe) hash values.
+
+def testRdbRoundtripTermsTrie(env):
+    create_index(env)
+    add_doc(env, 'doc1', 'Hello')
+    add_doc(env, 'doc2', '\U0001F600\U0001F600')
+    add_doc(env, 'doc3', b'\xed\xa0\x80')
+    before = dump_terms_raw(env)
+    env.assertEqual(len(before), 3)
+    env.dumpAndReload()
+    waitForIndex(env, 'idx')
+    env.assertEqual(dump_terms_raw(env), before)
+    # Re-indexing also rebuilds the bytes-keyed inverted index: exact astral
+    # search still works, and the trie/index divergence is reproduced too.
+    env.assertEqual(num_results(env, '\U0001F600\U0001F600'), 1)
+    env.assertEqual(num_results(env, '\U0001F600*'), 0)


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** three separate stores are rune-keyed `Trie`s — the FT.DICTADD
   spellcheck dictionaries, `spec->terms`, and a TEXT field's `spec->suffix`
   (WITHSUFFIXTRIE). All three decode their input into `uint16` runes with a
   decoder that never validates, and re-encode on the way out. Nothing in the
   test suite stated what that round-trip does to invalid UTF-8, to embedded
   NULs, to codepoints above U+FFFF, or to input past each store's length gate.
2. **Change:** three characterization test files, one per store, pinning the
   current behavior only — `tests/pytests/test_dict_trie_encoding.py`,
   `test_terms_trie_encoding.py`, `test_suffix_trie_encoding.py`. No production
   code is touched.
3. **Outcome:** the encoding behavior of all three stores is now covered, so a
   change to rune width, to input validation, or to the length gates fails a
   test instead of silently changing results. Notable characteristics pinned:
   - Astral codepoints truncate to their low 16 bits, so byte-distinct terms
     can collide on one rune key.
   - For `spec->terms` that truncation splits the two stores: exact search hits
     the byte-keyed inverted index and works, while every trie-driven expansion
     (prefix, fuzzy, wildcard) rebuilds the wrong bytes and finds nothing.
   - WITHSUFFIXTRIE is the exception — its payload keeps the original term
     bytes, so contains/suffix queries reach terms prefix queries cannot. That
     makes it more than an optimization for astral terms: `Suffix_IterateContains`
     returns documents the brute-force path does not, while `Suffix_CB_Wildcard`
     filters supplementary codepoints and stays in agreement.
   - Terms past a length gate are indexed but absent from the trie, and the
     suffix-trie gate applies to the suffixes only, not the full-word entry.
   - Invalid UTF-8 and NULs are never rejected; the blind decoder launders them
     into real codepoints, and DICTDUMP/DUMP_TERMS replies can be invalid UTF-8.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `tests/pytests/test_dict_trie_encoding.py` (new)
2. `tests/pytests/test_terms_trie_encoding.py` (new)
3. `tests/pytests/test_suffix_trie_encoding.py` (new)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
