### PR TITLE
[8.10] [MOD-6430][MOD-6416] Re-arm the cursor idle-sweep timer on the main thread for cluster FT.CURSOR GC

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -13,6 +13,7 @@
 #include <assert.h>
 #include "rmutil/rm_assert.h"
 #include <err.h>
+#include "info/info_redis/threads/main_thread.h"
 
 #define Cursor_IsIdle(cur) ((cur)->pos != -1)
 
@@ -223,6 +224,24 @@ static void Cursors_RescheduleSweepLocked(CursorList *cl) {
   if (RS_IsMock) {
     return;
   }
+
+  // `RedisModule_StopTimer` / `RedisModule_CreateTimer` below mutate the
+  // server's event-loop timer state, so they must only be reached from the main
+  // thread. Any caller that can run elsewhere must post
+  // `Cursors_RequestRescheduleSweep` instead of re-arming inline. Which callers
+  // those are depends on how each command is dispatched: `Cursor_Pause` runs on
+  // a worker whenever `FT.CURSOR READ` is handed to the workers pool, and
+  // `Cursors_CollectIdle` does whenever a cluster serves `FT.CURSOR GC` off the
+  // main thread. This assertion is the enforcement, so the rule holds without
+  // having to re-derive the dispatch path of every caller.
+  //
+  // `MainThread_GetBlockedQueries` is a proxy for "am I the thread that ran
+  // `RediSearch_InitModuleInternal`": the TLS slot is populated there and is
+  // NULL on every other thread. It is therefore only a valid main-thread test
+  // after module init, which is guaranteed for any cursor operation.
+  RS_LOG_ASSERT(MainThread_GetBlockedQueries() != NULL,
+                "Cursors_RescheduleSweepLocked must run on the main thread; "
+                "use Cursors_RequestRescheduleSweep from worker threads");
 
   if (cl->idleSweepTimerId != IDLE_SWEEP_TIMER_NONE) {
     RedisModule_StopTimer(RSDummyContext, cl->idleSweepTimerId, NULL);

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -813,3 +813,69 @@ def test_cursor_gc_edge_cases(env: Env):
     # Test with only external cursors
     env.expect(debug_cmd(), 'DELETE_LOCAL_CURSORS').ok()
     env.expect('_FT.CURSOR', 'GC', 'idx', '0').equal(0)
+
+
+@skip(cluster=False)
+def test_cursor_gc_reschedules_sweep_on_main_thread():
+    """
+    `FT.CURSOR GC` can re-arm the cursor idle-sweep timer, so that re-arming
+    must happen on the main thread.
+
+    `Cursors_CollectIdle` re-arms the timer, and re-arming calls
+    `RedisModule_StopTimer` / `RedisModule_CreateTimer`, which mutate the
+    server's event-loop timer state. That is main-thread-only work: a caller
+    that may run elsewhere has to post `Cursors_RequestRescheduleSweep` instead
+    of re-arming inline.
+
+    This test drives the user-facing `FT.CURSOR GC` on a multi-shard cluster,
+    the configuration in which the coordinator may serve that command from a
+    worker pool rather than on the main thread. Whether it actually does so is
+    an implementation detail that differs between branches; what must hold
+    everywhere is that the timer is only ever re-armed from the main thread. In
+    `ENABLE_ASSERT` builds the assertion in `Cursors_RescheduleSweepLocked`
+    makes a violation a hard failure here instead of a silent data race.
+
+    `test_cursor_gc_edge_cases` above only drives the shard-local
+    `_FT.CURSOR GC`, which runs on the main thread, so it does not exercise
+    this path.
+    """
+    env = Env(shardsCount=3)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    with env.getClusterConnectionIfNeeded() as con:
+        for i in range(100 * env.shardsCount):
+            con.execute_command('HSET', f'doc{i}', 't', 'hello')
+
+    # Phase 1 — drive the GC path while a cursor is definitely idle, so the sweep
+    # timer is armed and every GC below has a reason to re-arm it. MAXIDLE is far
+    # longer than the whole test, so the cursor cannot expire mid-loop on any
+    # host: nothing here depends on how fast the loop runs.
+    _, cid = env.cmd('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', '1',
+                     'MAXIDLE', '60000')
+    # Fail here rather than timing out below if the cursor was never created.
+    env.assertNotEqual(0, cid)
+    with TimeLimit(10, "cursors were not created"):
+        while getCursorStats(env)['global_total'] < 1:
+            sleep(0.01)
+
+    for _ in range(30):
+        env.cmd('FT.CURSOR', 'GC', 'idx', '0')
+
+    # Holds on every host, fast or slow: MAXIDLE is 60s, so the cursor is still
+    # registered and the GC calls above provably ran against an armed timer.
+    env.assertNotEqual(0, getCursorStats(env)['global_total'])
+
+    # Phase 2 — the sweep timer must still fire after all that re-arming. Release
+    # the long-lived cursor, then let a short-MAXIDLE one expire on its own with
+    # no further traffic. Both waits below only require "eventually, within a
+    # generous bound", so a slow host is slower but never wrong.
+    env.cmd('FT.CURSOR', 'DEL', 'idx', cid)
+    with TimeLimit(10, "FT.CURSOR DEL did not release the cursor"):
+        while getCursorStats(env)['global_total']:
+            sleep(0.05)
+
+    _, cid2 = env.cmd('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', '1',
+                      'MAXIDLE', '200')
+    env.assertNotEqual(0, cid2)
+    with TimeLimit(10, "idle cursor was not reaped at MAXIDLE after cluster FT.CURSOR GC"):
+        while getCursorStats(env)['global_total']:
+            sleep(0.05)


### PR DESCRIPTION
## Describe the changes in the pull request

> **Draft, deliberately red at this commit.** The first commit is the backport of #10774 (assertion + cluster test) *without* the fix, so CI is expected to fail here. That failure is the point: it demonstrates the test actually detects the bug on this branch before the fix is added in a follow-up commit. Do not review for merge until the second commit is pushed and CI is green.

1. **Current**: `Cursors_CollectIdle` re-arms the cursor idle-sweep timer by calling `Cursors_RescheduleSweepLocked` inline, which calls `RedisModule_StopTimer` / `RedisModule_CreateTimer`. Those mutate the server's event-loop timer state and are main-thread-only.

   On this branch, a multi-shard cluster serves the user-facing `FT.CURSOR GC` from `DIST_THREADPOOL` (`CursorCommand` falls through to `ConcurrentSearch_HandleRedisCommandEx` whenever `NumShards != 1`), and `threadHandleCommand` does not take the GIL — `CMDCTX_NO_GIL` no longer exists here. So an operator running `FT.CURSOR GC` on a multi-shard cluster mutates Redis timer state from a worker thread, concurrently with the main event loop.

   `master` is not affected: it serves `DEL` / `GC` inline on the main thread and only blocks for `READ`, a split introduced in `664bfc3fd` on 2026-04-27, ten days before #9425 merged. That is why the flaw is latent in #9425 and only reachable on the release branches.

2. **Change**: commit 1 backports #10774 — the `ENABLE_ASSERT`-only main-thread assertion in `Cursors_RescheduleSweepLocked` plus `test_cursor_gc_reschedules_sweep_on_main_thread`. Commit 2 (to follow) makes `Cursors_CollectIdle` post `Cursors_RequestRescheduleSweep` instead of re-arming inline, which is the same event-loop one-shot `Cursor_Pause` already uses for exactly this reason.

3. **Outcome**: the timer is only ever re-armed on the main thread, so cluster `FT.CURSOR GC` stops racing the event loop. Worth noting that `FT.CURSOR GC` is only ever operator-issued, so the exposed user is precisely the operator running it to reclaim idle-cursor memory.

#### Which additional issues this PR fixes
1. MOD-6430, MOD-6416 — follow-up to #9425, found while backporting it.
2. #10774 (master), #9425 (original)

#### Main objects this PR modified
1. `src/cursor.c` — main-thread assertion, and (commit 2) `Cursors_CollectIdle` posting the one-shot.
2. `tests/pytests/test_cursors.py` — cluster test `test_cursor_gc_reschedules_sweep_on_main_thread`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

User impact: `FT.CURSOR GC` on a multi-shard cluster no longer manipulates Redis event-loop timer state from a worker thread, removing a data race that an operator could trigger while reclaiming idle cursor memory.

#### Backport notes

- Cherry-pick of `ec8c345` conflicted only in the include block; resolved by keeping `#include <err.h>` and adding `#include "info/info_redis/threads/main_thread.h"`.
- Same fix is needed on 8.8, 8.8-rse, 8.6, 8.4 and 8.2, all of which have the identical vulnerable call. 8.6-rse will need it once #10842 lands.
