### PR TITLE
[8.6] [MOD-16334] Remove write-only errorIndexes from the FT.INFO reducer

### DIFF
--- a/src/coord/info_command.c
+++ b/src/coord/info_command.c
@@ -104,7 +104,6 @@ typedef struct {
   MRReply *indexDef;
   MRReply *indexSchema;
   MRReply *indexOptions;
-  size_t *errorIndexes;
   InfoValue toplevelValues[NUM_FIELDS_SPEC];
   AggregatedFieldSpecInfo *fieldSpecInfo_arr;
   IndexError indexError;
@@ -309,7 +308,6 @@ static void cleanInfoReply(InfoFields *fields) {
     fields->fieldSpecInfo_arr = NULL;
   }
   IndexError_Clear(fields->indexError);
-  rm_free(fields->errorIndexes);
 }
 
 static void replyKvArray(RedisModule_Reply *reply, InfoFields *fields, InfoValue *values,
@@ -411,10 +409,6 @@ int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies) {
   for (size_t ii = 0; ii < count; ++ii) {
     int type = MRReply_Type(replies[ii]);
     if (type == MR_REPLY_ERROR) {
-      if (!fields.errorIndexes) {
-        fields.errorIndexes = rm_calloc(count, sizeof(*fields.errorIndexes));
-      }
-      fields.errorIndexes[ii] = 1;
       numErrored++;
       if (!firstError) {
         firstError = replies[ii];


### PR DESCRIPTION
# Description
Backport of #10810 to `8.6`.

## Describe the changes in the pull request

1. **Current:** The coordinator's `InfoReplyReducer` lazily allocates a per-reply flag array on the first shard error, sets a flag for each errored reply, and frees it at the end:

   ```c
   if (type == MR_REPLY_ERROR) {
     if (!fields.errorIndexes) {
       fields.errorIndexes = rm_calloc(count, sizeof(*fields.errorIndexes));
     }
     fields.errorIndexes[ii] = 1;
     ...
   ```

   Nothing ever reads it — not in `generateFieldsReply`, which builds the successful reply, and nowhere else in the repo. Declared, allocated, written, freed, never consulted.

2. **Change:** Remove the member, the allocation, the write, and the `rm_free`.

3. **Outcome:** One less heap allocation on the shard-error path, and one less struct member implying a capability that does not exist.

`errorIndexes` has been write-only since it arrived with the original RSCoordinator import (`f812351861`, #2366). The shape — a flag per reply, sized `count`, allocated only once an error appears — suggests it was groundwork for reporting *which* shards failed, which was never built. Indexing by position in `replies[]` could not have named the failing shard anyway, since replies land in arrival order (`ctx->replies[ctx->numReplied++]`).

**No behavior change.** The error path still counts `numErrored`, still keeps the first error, and still aggregates the remaining shards. `FT.INFO` replies are byte-identical before and after.

#### Which additional issues this PR fixes
1. MOD-16334 (groundwork — the behavior change is stacked on top of this PR)

#### Main objects this PR modified
1. `InfoFields` — `errorIndexes` member removed, `src/coord/info_command.c`
2. `cleanInfoReply`, `InfoReplyReducer` — allocation, write and free removed

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

## Testing

No new tests: this is a pure dead-code removal with no observable behavior.

- Cluster, `SHARDS=3`: `test_coordinator.py test_info.py` — 21 passed, 0 failed.

