### PR TITLE
Bump redis-module for the vendored swap-prefetch API

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "redis-module"
 version = "2.0.8"
-source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=7fb620f1ef42453dea4e22c9358d0d25d4224710#7fb620f1ef42453dea4e22c9358d0d25d4224710"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=f4d68b97520aafc9baa2a946d42652415c4df002#f4d68b97520aafc9baa2a946d42652415c4df002"
 dependencies = [
  "backtrace",
  "bindgen",
@@ -2044,7 +2044,7 @@ dependencies = [
 [[package]]
 name = "redis-module-common"
 version = "0.1.1"
-source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=7fb620f1ef42453dea4e22c9358d0d25d4224710#7fb620f1ef42453dea4e22c9358d0d25d4224710"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=f4d68b97520aafc9baa2a946d42652415c4df002#f4d68b97520aafc9baa2a946d42652415c4df002"
 dependencies = [
  "serde",
 ]
@@ -2052,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "redis-module-macros-internals"
 version = "2.0.8"
-source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=7fb620f1ef42453dea4e22c9358d0d25d4224710#7fb620f1ef42453dea4e22c9358d0d25d4224710"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=f4d68b97520aafc9baa2a946d42652415c4df002#f4d68b97520aafc9baa2a946d42652415c4df002"
 dependencies = [
  "lazy_static",
  "proc-macro2",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -240,7 +240,7 @@ xxhash-rust = "0.8"
 
 [workspace.dependencies.redis-module]
 git = "https://github.com/RedisLabsModules/redismodule-rs.git"
-rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710"
+rev = "f4d68b97520aafc9baa2a946d42652415c4df002"
 # `default-features = false` is load-bearing. Members declare a plain
 # `redis-module.workspace = true` and rely on it contributing no features, so that
 # c_entrypoint/redisearch_rs/Cargo.toml is the only hand-written place choosing

--- a/src/redisearch_rs/workspace_hack/Cargo.toml
+++ b/src/redisearch_rs/workspace_hack/Cargo.toml
@@ -74,7 +74,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f4d68b97520aafc9baa2a946d42652415c4df002" }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -82,7 +82,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f4d68b97520aafc9baa2a946d42652415c4df002" }
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -90,7 +90,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f4d68b97520aafc9baa2a946d42652415c4df002" }
 
 [target.aarch64-unknown-linux-gnu.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -98,7 +98,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f4d68b97520aafc9baa2a946d42652415c4df002" }
 
 [target.x86_64-apple-darwin.dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -106,7 +106,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f4d68b97520aafc9baa2a946d42652415c4df002" }
 
 [target.x86_64-apple-darwin.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -114,7 +114,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f4d68b97520aafc9baa2a946d42652415c4df002" }
 
 [target.aarch64-apple-darwin.dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -122,7 +122,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f4d68b97520aafc9baa2a946d42652415c4df002" }
 
 [target.aarch64-apple-darwin.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -130,7 +130,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f4d68b97520aafc9baa2a946d42652415c4df002" }
 
 [target.x86_64-unknown-linux-musl.dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["static"] }
@@ -138,7 +138,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "static"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0"] }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f4d68b97520aafc9baa2a946d42652415c4df002", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0"] }
 
 [target.x86_64-unknown-linux-musl.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["static"] }
@@ -146,7 +146,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "static"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0"] }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f4d68b97520aafc9baa2a946d42652415c4df002", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0"] }
 
 [target.aarch64-unknown-linux-musl.dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["static"] }
@@ -154,7 +154,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "static"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0"] }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f4d68b97520aafc9baa2a946d42652415c4df002", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0"] }
 
 [target.aarch64-unknown-linux-musl.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["static"] }
@@ -162,6 +162,6 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "static"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0"] }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f4d68b97520aafc9baa2a946d42652415c4df002", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** the `redis-module` pin sits at `7fb620f1ef42453dea4e22c9358d0d25d4224710`. That revision's vendored `redismodule.h` does not declare the bigredis swap-prefetch API, so a consumer that needs it has to hand-declare the function pointers itself. RediSearchEnterprise does exactly that today, in its disk async loader.
2. **Change:** repin `redis-module` onto `f4d68b97520aafc9baa2a946d42652415c4df002`, the merge commit of RedisLabsModules/redismodule-rs#478, which vendors `RedisModule_SwapPrefetchKey`, `RedisModule_IsKeyInRam`, the `RedisModuleSwapPrefetchCB` typedef and the `REDISMODULE_SWAP_PREFETCH_FLAG_*` constants into that crate's header. It also adds a bindgen `int_macro` mapping there so the flag constants emit as `c_int` rather than bindgen's default `u32`, matching the `int flags` parameter they feed.
3. **Outcome:** the declarations are available from `redis_module::raw` and the downstream hand-declarations can be deleted. Nothing in this workspace uses the new symbols yet, so this is a no-op for RediSearch itself beyond the pin move.

The range also picks up redismodule-rs#475, which swaps `to_str().unwrap()` for `to_string_lossy()` in `redis_command!` and `redis_event_handler!`. No crate in this workspace uses either macro, so it is inert here.

Two notes for review:

- The rev is repeated across all 12 target sections of `workspace_hack/Cargo.toml`, which `cargo-hakari` generates. No manifest changed upstream between the two revisions, so feature unification is unaffected and the update is a pure rev substitution. Verified clean with `cargo hakari generate --diff`, `cargo hakari manage-deps --dry-run` and `cargo hakari verify` at 0.9.38 — note the lint job installs `cargo-hakari` unpinned while `.install/test_deps/install_rust_deps.sh` pins 0.9.37.
- RediSearchEnterprise pins this same dependency and the two rev strings must stay byte-identical. Cargo derives source identity from the literal rev text, so abbreviating one side would resolve the same commit through two distinct sources, pull in two copies of the crate, and break the type identity between `ffi`'s re-exported types and `redis_module::raw`'s. The companion RediSearchEnterprise branch uses the same full 40-character SHA.

#### Which additional issues this PR fixes

None — no ticket, this is an ad-hoc change. For context it follows on from #9142, which stopped the `ffi` crate from generating its own `redismodule.h` bindings; the swap-prefetch symbols were the one gap that left a downstream consumer hand-declaring instead.

#### Main objects this PR modified

1. `src/redisearch_rs/Cargo.toml` — the `redis-module` workspace dependency rev
2. `src/redisearch_rs/Cargo.lock` — re-resolved onto the new rev
3. `src/redisearch_rs/workspace_hack/Cargo.toml` — hakari-generated duplicate of the rev

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal dependency bump with no behaviour change in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
