### PR TITLE
[MOD-14883] query_eval: evaluate QN_FUZZY in Rust

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -286,6 +286,10 @@ QueryNode *NewWildcardNode_WithParams(QueryParseCtx *q, QueryToken *qt) {
 }
 
 QueryNode *NewFuzzyNode_WithParams(QueryParseCtx *q, QueryToken *qt, int maxDist) {
+  // The distance sizes a stack array in the edit-distance automaton
+  // (`SparseAutomaton_Start`), so an out-of-range one is undefined behaviour
+  // rather than an empty expansion. The grammar only ever spells 1, 2 or 3.
+  RS_ASSERT(maxDist >= 0 && maxDist <= MAX_LEV_DISTANCE);
   QueryNode *ret = NewQueryNode(QN_FUZZY);
   q->numTokens++;
 

--- a/src/query.c
+++ b/src/query.c
@@ -533,86 +533,6 @@ static void QueryNode_Expand(RSQueryTokenExpander expander, RSQueryExpanderCtx *
   }
 }
 
-static inline void addTerm(char *str, size_t tok_len, size_t numDocsInTerm, QueryEvalCtx *q,
-  QueryNodeOptions *opts, QueryIterator ***its, size_t *itsSz, size_t *itsCap) {
-  // Create a token for the reader
-  RSToken tok = (RSToken){
-      .expanded = 0,
-      .flags = 0,
-      .len = tok_len,
-      .str = str
-  };
-
-  QueryIterator *ir = NULL;
-
-  if (q->sctx->spec->diskSpec) {
-    double idf = CalculateIDF(q->sctx->spec->stats.scoring.numDocuments, numDocsInTerm);
-    double bm25_idf = CalculateIDF_BM25(q->sctx->spec->stats.scoring.numDocuments, numDocsInTerm);
-    bool needsOffsets = queryNeedsOffsets(q->opts->scorerName, opts);
-    ir = SearchDisk_NewTermIterator(q->sctx->spec->diskSpec, q->sctx, &tok, q->tokenId++, q->opts->fieldmask & opts->fieldMask, 1, idf, bm25_idf, needsOffsets, q->status);
-  } else {
-    // Open an index reader
-    ir = Redis_OpenReader(q->sctx, &tok, q->tokenId++, &q->sctx->spec->docs,
-                                        q->opts->fieldmask & opts->fieldMask, 1);
-  }
-
-  if (!ir) {
-    return;
-  }
-
-  (*its)[(*itsSz)++] = ir;
-  if (*itsSz == *itsCap) {
-    *itsCap *= 2;
-    *its = rm_realloc(*its, (*itsCap) * sizeof(*its));
-  }
-}
-
-static QueryIterator *iterateExpandedTerms(QueryEvalCtx *q, Trie *terms, const char *str,
-                                           size_t len, int maxDist, TrieMatchMode mode,
-                                           QueryNodeOptions *opts) {
-  TrieIterator *it = Trie_IterateFuzzy(terms, str, len, maxDist, mode);
-  if (!it) return NULL;
-
-  size_t itsSz = 0, itsCap = 8;
-  QueryIterator **its = rm_calloc(itsCap, sizeof(*its));
-
-  rune *rstr = NULL;
-  char *target_str = NULL;
-  size_t tok_len = 0;
-  t_len slen = 0;
-  float score = 0;
-  int dist = 0;
-
-  // an upper limit on the number of expansions is enforced to avoid stuff like "*"
-  int hasNext;
-  size_t numDocsInTerm = 0;
-  while ((hasNext = TrieIterator_Next(it, &rstr, &slen, NULL, &score, &numDocsInTerm, &dist)) &&
-         (itsSz < q->config->maxPrefixExpansions)) {
-    target_str = runesToStr(rstr, slen, &tok_len);
-    addTerm(target_str, tok_len, numDocsInTerm, q, opts, &its, &itsSz, &itsCap);
-    rm_free(target_str);
-  }
-  TrieIterator_Free(it);
-
-  if (hasNext && itsSz == q->config->maxPrefixExpansions) {
-    QueryError_SetReachedMaxPrefixExpansionsWarning(q->status);
-  }
-
-  // Add an iterator over the inverted index of the empty string for fuzzy search
-  if (mode == TRIE_MATCH_EDIT_DISTANCE && q->sctx->apiVersion >= 2 && len <= maxDist) {
-    size_t rlen = 0;
-    runeBuf buf;
-    rune *runes = runeBufFill("", 1, &buf, &rlen);
-    TrieNode *emptyNode = Trie_GetNode(terms, runes, rlen, true, NULL);
-    runeBufFree(&buf);
-    size_t numDocsInEmpty = emptyNode ? TrieNode_NumDocs(emptyNode) : 0;
-    addTerm("", 0, numDocsInEmpty, q, opts, &its, &itsSz, &itsCap);
-  }
-
-  QueryNodeType type = mode == TRIE_MATCH_PREFIX ? QN_PREFIX : QN_FUZZY;
-  return NewUnionIterator(its, itsSz, true, opts->weight, type, str, q->config);
-}
-
 static const char *PrefixNode_GetTypeString(const QueryPrefixNode *pfx) {
   if (pfx->prefix && pfx->suffix) {
     return "INFIX";
@@ -621,17 +541,6 @@ static const char *PrefixNode_GetTypeString(const QueryPrefixNode *pfx) {
   } else {
     return "SUFFIX";
   }
-}
-
-static QueryIterator *Query_EvalFuzzyNode(QueryEvalCtx *q, QueryNode *qn) {
-  RS_LOG_ASSERT(qn->type == QN_FUZZY, "query node type should be fuzzy");
-
-  Trie *terms = q->sctx->spec->terms;
-
-  if (!terms) return NULL;
-
-  return iterateExpandedTerms(q, terms, qn->pfx.tok.str, strlen(qn->pfx.tok.str), qn->fz.maxDist,
-                              TRIE_MATCH_EDIT_DISTANCE, &qn->opts);
 }
 
 // Probe the Blocked Client Timeout flag for a query iterator. Called from
@@ -1047,12 +956,11 @@ QueryIterator *Query_EvalNode(QueryEvalCtx *q, QueryNode *n, const EvalConfig *e
     case QN_GEOMETRY:
     case QN_PREFIX:
     case QN_WILDCARD_QUERY:
+    case QN_FUZZY:
       // These node types have been ported to Rust.
       return Query_EvalNode_Rs(q, n, evalConfig);
     case QN_TAG:
       return Query_EvalTagNode(q, n);
-    case QN_FUZZY:
-      return Query_EvalFuzzyNode(q, n);
     case QN_VECTOR:
       return Query_EvalVectorNode(q, n, evalConfig);
     case QN_MAX: // LCOV_EXCL_LINE — exhaustive switch: all valid QN types handled above

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1772,6 +1772,7 @@ name = "query"
 version = "0.0.1"
 dependencies = [
  "build_utils",
+ "c_trie",
  "ffi",
  "inverted_index",
  "query",

--- a/src/redisearch_rs/c_wrappers/c_trie/src/terms.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/terms.rs
@@ -190,10 +190,20 @@ impl TermsTrie {
     /// up as an exact match. Used to compute a term's inverse document
     /// frequency (IDF).
     ///
-    /// Returns `0` for input that cannot correspond to a stored term — invalid
-    /// UTF-8, or a term longer than the trie can hold — since such a term can
+    /// Returns `0` for input that cannot correspond to a stored term — empty,
+    /// invalid UTF-8, or longer than the trie can hold — since such a term can
     /// never have been inserted.
     pub fn num_docs(&self, term: &[u8]) -> usize {
+        // A zero-length key is refused on insertion, so the trie cannot hold the
+        // empty term and the lookup could only answer zero. Skipping it also
+        // keeps an empty slice's pointer — which need not point into an
+        // allocation — away from the decode below, which forms `src + slen`
+        // before testing that the decode loop is empty. That arithmetic is only
+        // defined on a pointer into an object.
+        if term.is_empty() {
+            return 0;
+        }
+
         // Terms longer than the trie can store are never present, so report zero
         // without a lookup (mirrors the C insertion/decrement guards). This also
         // bounds the rune count to `term.len()`, keeping it within `t_len` so the

--- a/src/redisearch_rs/c_wrappers/c_trie/tests/terms.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/tests/terms.rs
@@ -107,6 +107,40 @@ fn set(items: &[&str]) -> HashSet<String> {
     items.iter().map(|s| (*s).to_owned()).collect()
 }
 
+// --- `num_docs` -------------------------------------------------------------
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn num_docs_reports_the_stored_count_and_zero_for_absent_terms() {
+    with_terms_trie(CORPUS, |trie| {
+        // The corpus stores each term's char length as its document count.
+        assert_eq!(trie.num_docs(b"apple"), 5);
+        assert_eq!(trie.num_docs(b"map"), 3);
+        assert_eq!(trie.num_docs(b"pear"), 0);
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn num_docs_of_the_empty_term_is_zero_without_a_lookup() {
+    // A zero-length key is refused on insertion, so no trie can answer anything
+    // but zero here — and the lookup is skipped rather than handing C an empty
+    // slice's pointer to do arithmetic on.
+    with_terms_trie(CORPUS, |trie| {
+        assert_eq!(trie.num_docs(b""), 0);
+    });
+    // Including for a trie that was never given any term at all.
+    with_terms_trie(&[], |trie| {
+        assert_eq!(trie.num_docs(b""), 0);
+    });
+}
+
 // --- `iterate_contains` -----------------------------------------------------
 
 #[test]

--- a/src/redisearch_rs/c_wrappers/query/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/query/Cargo.toml
@@ -14,6 +14,7 @@ unittest = []
 build_utils.workspace = true
 
 [dependencies]
+c_trie.workspace = true
 ffi.workspace = true
 redis-module.workspace = true
 inverted_index.workspace = true

--- a/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
@@ -11,6 +11,7 @@
 
 use std::{ffi::CStr, ptr::NonNull};
 
+use c_trie::TermsTrie;
 use query_flags::QEFlags;
 use rlookup::MetricRequest;
 use rqe_core::DocId;
@@ -60,6 +61,14 @@ impl QueryEvalContext {
     ///    [`build_timeout_context`](QueryEvalContext::build_timeout_context)):
     ///    a clock-based timeout context reads `sctx.time.timeout` back on every
     ///    probe rather than capturing it.
+    ///    The nested `sctx.spec.terms` pointer — the index's primary terms trie
+    ///    — must be valid and non-null: every path that creates an
+    ///    [`IndexSpec`](ffi::IndexSpec) installs a terms trie, unconditionally
+    ///    and regardless of whether the schema has any text field, before the
+    ///    spec can answer a query. Loading a legacy spec is the one path that
+    ///    leaves the field null for a while, and it fills it in — or releases
+    ///    the half-built spec — before handing the spec out, so no queryable
+    ///    spec has a null trie.
     ///    The nested `sctx.spec.diskSpec` pointer may be null (in-memory mode);
     ///    when non-null it must point to a valid
     ///    [`RedisSearchDiskIndexSpec`](ffi::RedisSearchDiskIndexSpec).
@@ -114,6 +123,44 @@ impl QueryEvalContext {
         // SAFETY: invariant (2) of `new` guarantees `sctx.spec` is a valid,
         // non-null pointer.
         unsafe { &*self.sctx().spec }
+    }
+
+    /// The index's primary terms trie, the one every term lookup and pattern
+    /// expansion walks.
+    ///
+    /// The trie is always there, per invariant (2) of [`new`](Self::new), which
+    /// also says why. The assertion below states that here rather than leaving
+    /// each caller to assume it: a spec that broke the invariant would otherwise
+    /// be a null dereference in whichever one ran first, with nothing naming
+    /// what went wrong.
+    ///
+    /// `'index` is chosen by the caller and tied to nothing, because the
+    /// borrow this hands out is not one the type system can see: the trie is
+    /// owned by the spec rather than by the context, so binding it to `&self`
+    /// would say the trie is borrowed *from the context* — and then a caller
+    /// could not hold it while borrowing the context exclusively, which is
+    /// exactly what an expanding node type does across a walk that records
+    /// expansions back into the context. Erasing the lifetime is what buys that,
+    /// and it is why this is `unsafe`: nothing left in the signature stops the
+    /// reference outliving the trie.
+    ///
+    /// # Safety
+    ///
+    /// The returned reference must not outlive the query being evaluated. The
+    /// spec that owns the trie stays alive for the whole query (invariant (2)
+    /// of [`new`](Self::new)), so any `'index` within that span is sound, and
+    /// `'static` — or any lifetime reaching past the query — is not.
+    pub unsafe fn terms_trie<'index>(&self) -> &'index TermsTrie {
+        let terms = self.spec().terms;
+        debug_assert!(
+            !terms.is_null(),
+            "the spec of a query being evaluated must have a terms trie"
+        );
+        // SAFETY: `terms` is the spec's terms `Trie`: non-null, valid, and
+        // neither mutated nor freed for the duration of the query (invariants
+        // (1)/(2) of `new`). The caller's own contract above keeps `'index`
+        // inside that span.
+        unsafe { TermsTrie::from_raw(terms) }
     }
 
     /// The search options controlling field masks, scorer, query flags, etc.

--- a/src/redisearch_rs/query_eval/src/expansion.rs
+++ b/src/redisearch_rs/query_eval/src/expansion.rs
@@ -180,10 +180,12 @@ fn open_expanded_term_reader(
 /// A single pattern expansion in progress: the inputs every walk shares, the
 /// context they open readers against, and the readers opened so far.
 ///
-/// Built once per `QN_PREFIX` or `QN_WILDCARD_QUERY` evaluation. The prefix walks
-/// consume it and hand back the accumulated readers; the wildcard walks take
-/// `&mut self`, since a declined suffix walk falls back to the terms-trie walk
-/// with both accumulating into the same `children`.
+/// Built once per `QN_PREFIX`, `QN_WILDCARD_QUERY` or `QN_FUZZY` evaluation. The
+/// prefix walks consume it and hand back the accumulated readers; the wildcard
+/// and fuzzy walks take `&mut self`, since both have something left to do after
+/// the walk — a declined suffix walk falls back to the terms-trie walk, and a
+/// fuzzy expansion may append the empty term — with everything accumulating into
+/// the same `children`.
 pub(super) struct Expansion<'a> {
     /// The evaluation context readers are opened against, and where the
     /// expansion-cap warning and the unsupported-fields error are recorded.
@@ -213,6 +215,21 @@ impl Expansion<'_> {
         if self.cap_reached() {
             return ControlFlow::Break(());
         }
+        self.push_child_ignoring_cap(num_docs, term_bytes);
+        ControlFlow::Continue(())
+    }
+
+    /// Open a reader for `term_bytes` and push it as a union child **without**
+    /// consulting the expansion cap, so no warning is recorded either.
+    ///
+    /// For an expansion that is not one of the terms a walk found and so is not
+    /// what the cap bounds — the fuzzy empty term, which is appended after the
+    /// walk and admitted even when the cap is full. Every walk-driven expansion
+    /// goes through [`push_child`](Self::push_child) instead.
+    ///
+    /// `num_docs` is the term's document count, used only on the disk path for
+    /// the IDF.
+    pub(crate) fn push_child_ignoring_cap(&mut self, num_docs: usize, term_bytes: &[u8]) {
         if let Some(it) = open_expanded_term_reader(
             self.ctx,
             term_bytes,
@@ -222,7 +239,6 @@ impl Expansion<'_> {
         ) {
             self.children.push(it);
         }
-        ControlFlow::Continue(())
     }
 
     /// Whether the expansion cap has been reached, recording the "reached max

--- a/src/redisearch_rs/query_eval/src/lib.rs
+++ b/src/redisearch_rs/query_eval/src/lib.rs
@@ -44,7 +44,7 @@ mod nodes;
 pub use config::Config;
 
 use nodes::{
-    geo, geometry, ids, missing, not, null, numeric, optional, phrase, prefix, token, union,
+    fuzzy, geo, geometry, ids, missing, not, null, numeric, optional, phrase, prefix, token, union,
     wildcard, wildcard_query,
 };
 
@@ -198,6 +198,7 @@ pub fn eval_node<'index>(
         QueryNode::Token { tok } => token::eval(ctx, &node, tok, config),
         QueryNode::Geometry { geomq } => geometry::eval(ctx, geomq),
         QueryNode::Prefix { tok, mode } => prefix::eval(ctx, &node, tok, mode, config),
+        QueryNode::Fuzzy { tok, max_dist } => fuzzy::eval(ctx, &node, tok, max_dist, config),
         // Binds nothing, so the node stays free to be passed on by value —
         // evaluation rewrites its token.
         QueryNode::WildcardQuery { .. } => wildcard_query::eval(ctx, node, config),

--- a/src/redisearch_rs/query_eval/src/nodes/fuzzy.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/fuzzy.rs
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Evaluation of `QN_FUZZY` query nodes.
+
+use std::ops::ControlFlow;
+
+use c_trie::{FuzzyWalk, InvalidFuzzyDistance, TermsTrie};
+use query_types::QueryNodeType;
+use rqe_iterators::union_opaque::build_union_with_q_str;
+use rs_token::RSTokenRefNulTerminated;
+use string_utils::runes::runes_to_bytes;
+
+use crate::{
+    Config, Evaluated, QueryEvalContext, QueryNodeRef, expansion::Expansion,
+    expansion_needs_offsets,
+};
+
+/// The `apiVersion` from which a fuzzy expansion also covers the empty term.
+/// Below it the empty term is never expanded to, whatever the distance.
+const EMPTY_TERM_API_VERSION: u32 = 2;
+
+/// `QN_FUZZY` — expand a token to every term within `max_dist` edits of it over
+/// the spec's terms trie, and union the per-term readers.
+///
+/// The distance is a Levenshtein distance counted in runes, and the pattern is
+/// lowercased before the walk, since the trie stores folded keys.
+///
+/// Returns `None`, and sets no error, when the pattern is too long for the trie
+/// to walk: a fuzzy query that names nothing is well-formed and simply matches
+/// nothing, unlike an over-long prefix pattern, which is reported as an error.
+/// Every other outcome yields a union, empty if no term is within the distance.
+/// The number of expansions is capped by the configured
+/// [`Config::max_prefix_expansions`], with the empty term below exempt from it.
+///
+/// A `max_dist` the walk refuses with [`InvalidFuzzyDistance`] is a caller bug
+/// rather than a query the grammar can express — it spells the distance as the
+/// number of `%` delimiters and has productions for only one, two and three — so
+/// it trips a debug assertion first, and only a release build reaches the `None`
+/// it otherwise returns for it.
+pub(crate) fn eval<'index>(
+    ctx: &'index mut QueryEvalContext,
+    node: &QueryNodeRef,
+    tok: RSTokenRefNulTerminated,
+    max_dist: i32,
+    config: Config,
+) -> Option<Evaluated<'index>> {
+    // The reader field mask narrows the node's mask to the query-wide one.
+    let node_field_mask = node.opts().field_mask;
+    let weight = node.opts().weight;
+    let field_mask = node_field_mask & ctx.opts().fieldmask;
+    let is_disk = !ctx.spec().diskSpec.is_null();
+    let needs_offsets = expansion_needs_offsets(ctx, node.opts(), config);
+    // Read with every other use of `ctx`, because `Expansion` borrows it mutably
+    // for the rest of the expansion.
+    let api_version = ctx.sctx().apiVersion;
+    let terms_trie = ctx.spec().terms;
+
+    debug_assert!(!terms_trie.is_null(), "terms trie should be initialized");
+    // SAFETY: `terms_trie` is the spec's terms `Trie`, valid for and unmutated
+    // during the query (`QueryEvalContext` invariants 1/2).
+    let terms = unsafe { TermsTrie::from_raw(terms_trie) };
+
+    let q_str = tok.as_c_str().expect("fuzzy token must carry a string");
+    let pattern = q_str.to_bytes();
+
+    let mut expansion = Expansion {
+        ctx,
+        children: Vec::new(),
+        field_mask,
+        is_disk,
+        needs_offsets,
+        max_expansions: config.max_prefix_expansions,
+    };
+
+    match expansion.expand_via_fuzzy_walk(terms, pattern, max_dist) {
+        Ok(FuzzyWalk::Walked) => {}
+        // A pattern the trie declines was never walked, so nothing is known
+        // about what the index holds within the distance: yield no iterator at
+        // all, rather than the empty union a walk that found nothing produces.
+        Ok(FuzzyWalk::PatternRejected) => return None,
+        // The distance reaches C as the size of a stack allocation, so the walk
+        // bounds it rather than trusting it the whole way down. Nothing a query
+        // can express is refused here.
+        Err(err) => {
+            debug_assert!(false, "{err}");
+            return None;
+        }
+    }
+
+    // A token no longer than the distance could be deleted entirely and still be
+    // within budget, so it also matches the empty term — which no walk can find,
+    // since a zero-length key is refused on insertion and an indexed empty value
+    // exists only as an inverted index.
+    //
+    // The gate measures the token in bytes even though the distance counts
+    // runes, so a single multibyte character does not reach the empty term at
+    // distance 1.
+    if api_version >= EMPTY_TERM_API_VERSION && pattern.len() <= max_dist as usize {
+        // Structurally zero: the trie cannot hold a zero-length key, so the
+        // lookup has nothing to find. Only the disk path consumes the count, for
+        // the term's IDF, so the in-memory path does not pay for it.
+        let num_docs = if is_disk { terms.num_docs(b"") } else { 0 };
+        expansion.push_child_ignoring_cap(num_docs, b"");
+    }
+
+    let children = expansion.children;
+
+    // Fuzzy unions always take the quick-exit path — they only need the matching
+    // id set, never per-child scores — and carry the pattern token as their
+    // profiling query string.
+    //
+    // SAFETY: the union iterator retains the `CStr`, escaping the handle's
+    // borrow, so the token's string must stay put for as long as the iterator
+    // does. A `QN_FUZZY` token is written once when the node is built (or when
+    // its query parameter is resolved) and never rewritten afterwards — the one
+    // evaluator that rewrites a token in place belongs to the tag expansion,
+    // which is dispatched separately and never re-enters this one. Both the
+    // token and the iterator are owned by the query AST, so the string also
+    // outlives the iterator.
+    let iter = unsafe {
+        build_union_with_q_str(
+            children,
+            true,
+            config.min_union_iter_heap,
+            QueryNodeType::Fuzzy,
+            q_str,
+            weight,
+        )
+    };
+    Some(Evaluated::RustCompound(iter))
+}
+
+impl Expansion<'_> {
+    /// Walk the primary terms trie for every term within `max_dist` edits of
+    /// `pattern`, accumulating one reader per term.
+    ///
+    /// `terms` wraps the spec's primary terms trie and `pattern` is the raw token
+    /// bytes, which the trie lowercases and decodes itself.
+    ///
+    /// The walk carries no deadline and cannot be interrupted — matching the
+    /// behaviour it replaces, and unlike the prefix walk, which threads a
+    /// timeout through. The edit-distance filter prunes the trie but is no bound
+    /// on the work: as `max_dist` approaches the pattern's rune length the
+    /// automaton accepts an ever larger share of it. The only thing that cuts
+    /// the walk short is the expansion cap, via
+    /// [`push_child`](Self::push_child) breaking — and that bounds the readers
+    /// opened, not the terms visited, since a term with no inverted index
+    /// consumes no cap slot.
+    ///
+    /// [`FuzzyWalk::PatternRejected`] is not an empty expansion — the walk never
+    /// ran — so a caller must not answer it with the empty union it would build
+    /// for a walk that matched nothing. The same holds of
+    /// [`InvalidFuzzyDistance`], which the walk returns without visiting
+    /// anything.
+    fn expand_via_fuzzy_walk(
+        &mut self,
+        terms: &TermsTrie,
+        pattern: &[u8],
+        max_dist: i32,
+    ) -> Result<FuzzyWalk, InvalidFuzzyDistance> {
+        // The trie hands terms back as runes (with their document count, used for
+        // the disk IDF), which must be encoded back into the term's key, byte for
+        // byte as the index stored it — WTF-8 rather than UTF-8 where a rune is a
+        // lone surrogate.
+        let on_runes = |runes: &[ffi::rune], num_docs: usize| {
+            let Ok(key) = runes_to_bytes(runes) else {
+                // The term key cannot be reconstructed; skip this expansion.
+                return ControlFlow::Continue(());
+            };
+            self.push_child(num_docs, &key)
+        };
+        // SAFETY: `terms` wraps the spec's valid primary terms `Trie`, which is
+        // not mutated or re-iterated for the duration of the call: `on_runes`
+        // only opens per-term readers, which read the spec's inverted indexes
+        // rather than the terms trie being walked.
+        unsafe { terms.iterate_fuzzy(pattern, max_dist, on_runes) }
+    }
+}

--- a/src/redisearch_rs/query_eval/src/nodes/fuzzy.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/fuzzy.rs
@@ -102,11 +102,11 @@ pub(crate) fn eval<'index>(
     // runes, so a single multibyte character does not reach the empty term at
     // distance 1.
     if api_version >= EMPTY_TERM_API_VERSION && pattern.len() <= max_dist as usize {
-        // Structurally zero: the trie cannot hold a zero-length key, so the
-        // lookup has nothing to find. Only the disk path consumes the count, for
-        // the term's IDF, so the in-memory path does not pay for it.
-        let num_docs = if is_disk { terms.num_docs(b"") } else { 0 };
-        expansion.push_child_ignoring_cap(num_docs, b"");
+        // The document count the disk path scores the term by is zero without a
+        // lookup: a zero-length key is refused on insertion, so the terms trie
+        // cannot hold one and could only answer zero. The empty term is scored
+        // as one never seen, whatever its inverted index holds.
+        expansion.push_child_ignoring_cap(0, b"");
     }
 
     let children = expansion.children;

--- a/src/redisearch_rs/query_eval/src/nodes/fuzzy.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/fuzzy.rs
@@ -39,11 +39,13 @@ const EMPTY_TERM_API_VERSION: u32 = 2;
 /// The number of expansions is capped by the configured
 /// [`Config::max_prefix_expansions`], with the empty term below exempt from it.
 ///
-/// A `max_dist` the walk refuses with [`InvalidFuzzyDistance`] is a caller bug
-/// rather than a query the grammar can express — it spells the distance as the
-/// number of `%` delimiters and has productions for only one, two and three — so
-/// it trips a debug assertion first, and only a release build reaches the `None`
-/// it otherwise returns for it.
+/// # Panics
+///
+/// Panics if the walk refuses `max_dist` with [`InvalidFuzzyDistance`]. That is
+/// a caller bug rather than a query the grammar can express — it spells the
+/// distance as the number of `%` delimiters and has productions for only one,
+/// two and three — and no expansion the node could stand for is known at that
+/// point, so there is no result to return in its place.
 pub(crate) fn eval<'index>(
     ctx: &'index mut QueryEvalContext,
     node: &QueryNodeRef,
@@ -87,11 +89,10 @@ pub(crate) fn eval<'index>(
         Ok(FuzzyWalk::PatternRejected) => return None,
         // The distance reaches C as the size of a stack allocation, so the walk
         // bounds it rather than trusting it the whole way down. Nothing a query
-        // can express is refused here.
-        Err(err) => {
-            debug_assert!(false, "{err}");
-            return None;
-        }
+        // can express is refused here, and the node builder asserts the range
+        // too, so a refusal means the AST was built by something that does not
+        // respect the grammar's distances.
+        Err(err) => panic!("{err}"),
     }
 
     // A token no longer than the distance could be deleted entirely and still be

--- a/src/redisearch_rs/query_eval/src/nodes/fuzzy.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/fuzzy.rs
@@ -62,12 +62,10 @@ pub(crate) fn eval<'index>(
     // Read with every other use of `ctx`, because `Expansion` borrows it mutably
     // for the rest of the expansion.
     let api_version = ctx.sctx().apiVersion;
-    let terms_trie = ctx.spec().terms;
-
-    debug_assert!(!terms_trie.is_null(), "terms trie should be initialized");
-    // SAFETY: `terms_trie` is the spec's terms `Trie`, valid for and unmutated
-    // during the query (`QueryEvalContext` invariants 1/2).
-    let terms = unsafe { TermsTrie::from_raw(terms_trie) };
+    // SAFETY: the reference is confined to this evaluation — the walk below and
+    // the empty-term lookup after it — which the query, and so the spec owning
+    // the trie, outlives.
+    let terms = unsafe { ctx.terms_trie() };
 
     let q_str = tok.as_c_str().expect("fuzzy token must carry a string");
     let pattern = q_str.to_bytes();

--- a/src/redisearch_rs/query_eval/src/nodes/mod.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/mod.rs
@@ -14,6 +14,7 @@
 //! [`Evaluated`](crate::Evaluated) outcome type, and the helpers for evaluating
 //! a child node — lives at the crate root rather than here.
 
+pub(crate) mod fuzzy;
 pub(crate) mod geo;
 pub(crate) mod geometry;
 pub(crate) mod ids;

--- a/src/redisearch_rs/query_eval/src/nodes/prefix.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/prefix.rs
@@ -91,7 +91,10 @@ pub(crate) fn eval<'index>(
 
     let suffix_trie = ctx.spec().suffix;
     let suffix_mask = ctx.spec().suffixMask;
-    let terms_trie = ctx.spec().terms;
+    // SAFETY: the reference is confined to this evaluation — whichever of the
+    // two walks below answers the pattern — which the query, and so the spec
+    // owning the trie, outlives.
+    let terms = unsafe { ctx.terms_trie() };
     // Enforce the search deadline unless timeout checks are disabled for this
     // request, in which case the brute-force walk below runs to completion.
     // Resolved here, with every other read of `ctx`, because `Expansion` borrows
@@ -107,11 +110,6 @@ pub(crate) fn eval<'index>(
         needs_offsets,
         max_expansions: config.max_prefix_expansions,
     };
-
-    debug_assert!(!terms_trie.is_null(), "terms trie should be initialized");
-    // SAFETY: `terms_trie` is the spec's terms `Trie`, valid for and unmutated
-    // during the query (`QueryEvalContext` invariants 1/2).
-    let terms = unsafe { TermsTrie::from_raw(terms_trie) };
 
     let children = if match_suffix && !suffix_trie.is_null() {
         // The spec maintains a suffix trie for this pattern's fields: expand

--- a/src/redisearch_rs/query_eval/src/nodes/token.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/token.rs
@@ -11,7 +11,6 @@
 
 use std::ptr::NonNull;
 
-use c_trie::TermsTrie;
 use field::FieldMaskOrIndex;
 use query_term::RSQueryTerm;
 use query_types::QueryNodeOptions;
@@ -129,25 +128,22 @@ fn eval_disk<'index>(
     effective_field_mask: FieldMask,
     config: Config,
 ) -> Option<Evaluated<'index>> {
-    let spec = ctx.spec();
     // Look up the term's document count in the terms trie to compute IDF, then
     // build a disk term iterator through the enterprise API.
-    // SAFETY: in search-on-disk mode the terms trie is always initialised.
-    debug_assert!(!spec.terms.is_null(), "terms trie should be initialized");
     let term_bytes = tok.as_bytes();
     // A `QN_TOKEN` node always carries a non-null term string; the term lookup
     // below relies on it.
     debug_assert!(term_bytes.is_some(), "token string should not be null");
 
-    // SAFETY: `spec.terms` is a valid terms `Trie` (checked non-null above) that
-    // outlives this lookup.
-    let terms = unsafe { TermsTrie::from_raw(spec.terms) };
+    // SAFETY: the reference is confined to the document-count lookup below,
+    // which the query, and so the spec owning the trie, outlives.
+    let terms = unsafe { ctx.terms_trie() };
     // The lookup refuses a term that is not valid UTF-8. These bytes are query
     // text rather than a stored key, and a disk index only stages terms whose
     // bytes are valid UTF-8, so zero is the true count for such a term rather
     // than a lost one.
     let num_docs_in_term = terms.num_docs(term_bytes.unwrap_or_default());
-    let num_documents = spec.stats.scoring.numDocuments;
+    let num_documents = ctx.spec().stats.scoring.numDocuments;
     term.set_idfs(num_documents, num_docs_in_term);
 
     let needs_offsets = expansion_needs_offsets(ctx, opts, config);

--- a/src/redisearch_rs/query_eval/src/nodes/wildcard_query.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/wildcard_query.rs
@@ -80,7 +80,10 @@ pub(crate) fn eval<'index>(
 
     let suffix_trie = ctx.spec().suffix;
     let suffix_mask = ctx.spec().suffixMask;
-    let terms_trie = ctx.spec().terms;
+    // SAFETY: the reference is confined to this evaluation — the suffix-trie
+    // walk and the terms-trie fallback below — which the query, and so the spec
+    // owning the trie, outlives.
+    let terms = unsafe { ctx.terms_trie() };
     // Resolved here, with every other read of `ctx`, because `Expansion` borrows
     // it mutably for the rest of the expansion.
     let time = &ctx.sctx().time;
@@ -94,11 +97,6 @@ pub(crate) fn eval<'index>(
         needs_offsets,
         max_expansions: config.max_prefix_expansions,
     };
-
-    debug_assert!(!terms_trie.is_null(), "terms trie should be initialized");
-    // SAFETY: `terms_trie` is the spec's terms `Trie`, valid for and unmutated
-    // during the query (`QueryEvalContext` invariants 1/2).
-    let terms = unsafe { TermsTrie::from_raw(terms_trie) };
 
     // A spec with a suffix trie may only answer a pattern when every queried field
     // is covered by it. An unsupported field set is an error that does *not* fall


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `QN_FUZZY` is one of the last node types still evaluated by the C
   dispatcher. `src/query.c` routes it to `Query_EvalFuzzyNode`, which calls the
   C-only helpers `iterateExpandedTerms` and `addTerm` — the last surviving callers
   of both, since `QN_PREFIX` was ported and now expands through
   `query_eval::expansion::Expansion`. The expansion logic therefore exists twice,
   in C and in Rust, and can drift.

2. **Change:** Port `Query_EvalFuzzyNode` to Rust, following the pattern the
   already-ported node types use.

   - New `query_eval/src/nodes/fuzzy.rs`, reusing the shared `Expansion`
     accumulator rather than adding a second expansion path.
   - New `CTrieRef::iterate_fuzzy` in `c_trie`, keeping the `Trie_IterateFuzzy` /
     `TrieIterator_Next` / `TrieIterator_Free` pull loop and the `DFAFilter` it owns
     inside the wrapper, and handing each match to a
     `FnMut(&[rune], usize) -> ControlFlow<()>` — the shape the existing
     `iterate_contains` / `iterate_suffix` walks already use.
   - A `#[must_use] FuzzyWalk { Walked, PatternRejected }` so "the trie declined the
     pattern" (yield no iterator) stays distinguishable from "the walk matched
     nothing" (yield an empty union). Prefix expansion never has to make that
     distinction; fuzzy does.
   - `Expansion::push_child_ignoring_cap`, because the empty-term expansion must be
     appended even when the expansion cap is full, and without falsely recording the
     reached-max warning.
   - `iterateExpandedTerms`, `addTerm` and `Query_EvalFuzzyNode` deleted from
     `src/query.c`; `QN_FUZZY` moved into the Rust-dispatched arm.

   The deliberate departures from the C, and why each was taken, are spelled out
   in the port commit's message.

3. **Outcome:** No user-visible change. `%word%` / `%%word%%` queries keep the same
   expansion set, document order, union semantics, `reached max prefix expansions`
   warning, the same (absent) error on an over-long pattern, and the same
   `FUZZY - <term>` profile string. One behaviour changes for an input production
   cannot construct — a negative `maxDist`, reachable only from the test harness,
   where the empty-term gate is now widened to `i64` so the comparison cannot wrap.

This PR is stacked on #10869 and targets its branch.

The invariant is the 22 `query_eval` integration tests added in #10869.
They were written and reviewed **before** the port, pass against the C
implementation, and pass unchanged against the Rust one. The existing end-to-end
`test_fuzzy` suite also passes against the port.

#### Which additional issues this PR fixes
1. MOD-14883

#### Main objects this PR modified
1. `src/query.c` — `Query_EvalFuzzyNode`, `iterateExpandedTerms`, `addTerm` deleted; `QN_FUZZY` dispatch moved
2. `src/redisearch_rs/query_eval/src/nodes/fuzzy.rs` — the ported evaluator
3. `src/redisearch_rs/query_eval/src/expansion.rs` — `push_child_ignoring_cap`
4. `src/redisearch_rs/c_wrappers/c_trie/src/lib.rs` — `CTrieRef::iterate_fuzzy`, `FuzzyWalk`
5. `src/redisearch_rs/string_utils/src/libnu.rs` — UTF-8 read-ahead helpers, shared instead of duplicated
6. `src/redisearch_rs/ffi/build.rs` — bindgen allowlist for the trie iterator symbols

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal C-to-Rust port with no user-visible behaviour change.


