### PR TITLE
Return runes from Trie_CollectFuzzy

### DIFF
--- a/src/suggest.c
+++ b/src/suggest.c
@@ -353,7 +353,13 @@ parse_error:
     TrieSearchResult *e;
     Vector_Get(res, i, &e);
 
-    RedisModule_ReplyWithStringBuffer(ctx, e->str, e->len);
+    size_t slen;
+    // Keys are bounded by the trie iterator's own buffer, well under the runesToStr limit.
+    char *str = runesToStr(e->rstr, e->rlen, &slen);
+    RS_LOG_ASSERT(str, "suggestion key exceeded the rune-to-UTF-8 conversion limit");
+    RedisModule_ReplyWithStringBuffer(ctx, str, slen);
+    rm_free(str);
+
     if (options.withScores) {
       RedisModule_ReplyWithDouble(ctx, e->score);
     }

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -188,13 +188,21 @@ static TrieDecrResult Trie_DecrementNumDocsRunes(Trie *t, const rune *runes, siz
 }
 
 void TrieSearchResult_Free(TrieSearchResult *e) {
-  if (e->str) {
-    rm_free(e->str);
-    e->str = NULL;
+  if (e->rstr) {
+    rm_free(e->rstr);
+    e->rstr = NULL;
   }
   e->payload = NULL;
   e->plen = 0;
   rm_free(e);
+}
+
+/* Copy the iterator's current key into the result. The iterator hands out a pointer into
+ * the buffer it reuses for the whole walk, so the key has to be taken before stepping. */
+static void TrieSearchResult_SetKey(TrieSearchResult *e, const rune *rstr, t_len slen) {
+  e->rstr = rm_malloc(slen * sizeof(rune));
+  memcpy(e->rstr, rstr, slen * sizeof(rune));
+  e->rlen = slen;
 }
 
 static int cmpEntries(const void *p1, const void *p2, const void *udata) {
@@ -261,7 +269,7 @@ Vector *Trie_CollectFuzzy(const Trie *t, const char *str, size_t len, size_t num
   while (TrieIterator_Next(it, &rstr, &slen, &payload, &score, NULL, &dist)) {
     if (pooledEntry == NULL) {
       pooledEntry = rm_malloc(sizeof(TrieSearchResult));
-      pooledEntry->str = NULL;
+      pooledEntry->rstr = NULL;
       pooledEntry->payload = NULL;
       pooledEntry->plen = 0;
     }
@@ -279,7 +287,7 @@ Vector *Trie_CollectFuzzy(const Trie *t, const char *str, size_t len, size_t num
     }
 
     if (heap_count(pq) < heap_size(pq)) {
-      ent->str = runesToStr(rstr, slen, &ent->len);
+      TrieSearchResult_SetKey(ent, rstr, slen);
       ent->payload = payload.data;
       ent->plen = payload.len;
       heap_offerx(pq, ent);
@@ -293,9 +301,9 @@ Vector *Trie_CollectFuzzy(const Trie *t, const char *str, size_t len, size_t num
     } else {
       if (ent->score > it->kthBestScore) {
         pooledEntry = heap_poll(pq);
-        rm_free(pooledEntry->str);
-        pooledEntry->str = NULL;
-        ent->str = runesToStr(rstr, slen, &ent->len);
+        rm_free(pooledEntry->rstr);
+        pooledEntry->rstr = NULL;
+        TrieSearchResult_SetKey(ent, rstr, slen);
         ent->payload = payload.data;
         ent->plen = payload.len;
         heap_offerx(pq, ent);

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -27,9 +27,13 @@ extern RedisModuleType *TrieType;
 
 typedef struct Trie Trie;
 
+/* A single Trie_CollectFuzzy match. `rstr` is a copy owned by the result, since the
+ * iterator reuses its own buffer across steps; `payload` is borrowed from the trie
+ * node and stays valid only as long as the node does. Release with
+ * TrieSearchResult_Free. */
 typedef struct {
-  char *str;
-  size_t len;
+  rune *rstr;
+  t_len rlen;
   float score;
   char *payload;
   size_t plen;

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -1309,10 +1309,45 @@ TEST_F(TrieTest, testSearchTrimDropsTail) {
 
   TrieSearchResult *e;
   ASSERT_EQ(1, Vector_Get(res, 0, &e));
-  ASSERT_EQ(2, e->len);
-  ASSERT_EQ(0, memcmp(e->str, "ha", 2));
+  const rune expected[] = {'h', 'a'};
+  ASSERT_EQ(2, e->rlen);
+  ASSERT_EQ(0, memcmp(e->rstr, expected, sizeof(expected)));
   TrieSearchResult_Free(e);
   Vector_Free(res);
+
+  TrieType_Free(t);
+}
+
+// Each result owns a copy of its key: the iterator hands out a pointer into the single
+// buffer it reuses for the whole walk, so aliasing it would leave every result showing
+// the last key visited. Multibyte keys of differing lengths make such aliasing visible.
+TEST_F(TrieTest, testCollectFuzzyKeysOutliveIterator) {
+  Trie *t = NewTrie(NULL, Trie_Sort_Score);
+
+  trieInsertByScore(t, "på", 3.0f);
+  trieInsertByScore(t, "påske", 2.0f);
+  trieInsertByScore(t, "påskeägg", 1.0f);
+
+  Vector *res = Trie_CollectFuzzy(t, "på", strlen("på"), 10, 0, TRIE_MATCH_PREFIX, 0, 0);
+  ASSERT_TRUE(res != NULL);
+  ASSERT_EQ(3, Vector_Size(res));
+
+  std::set<std::string> keys;
+  for (size_t i = 0; i < Vector_Size(res); i++) {
+    TrieSearchResult *e;
+    ASSERT_EQ(1, Vector_Get(res, i, &e));
+
+    size_t utflen;
+    char *str = runesToStr(e->rstr, e->rlen, &utflen);
+    ASSERT_TRUE(str != NULL);
+    keys.insert(std::string(str, utflen));
+    rm_free(str);
+
+    TrieSearchResult_Free(e);
+  }
+  Vector_Free(res);
+
+  ASSERT_EQ(std::set<std::string>({"på", "påske", "påskeägg"}), keys);
 
   TrieType_Free(t);
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: every trie iteration entry point hands back rune keys and leaves the UTF-8
   encoding to the caller — except `Trie_CollectFuzzy`, which called `runesToStr` internally
   and returned `char *` in `TrieSearchResult`. That call was doing two jobs at once:
   encoding, and copying the key out of the buffer `TrieIterator` reuses across the whole
   walk.
2. **Change**: `TrieSearchResult` now carries `rune *rstr` / `t_len rlen`. The copy-out is
   explicit, in a new `TrieSearchResult_SetKey` shared by both heap branches, and the single
   consumer (`FT.SUGGET`, in `src/suggest.c`) encodes at the reply. A regression test pins
   the ownership rule: results must outlive the iterator's buffer.
3. **Outcome**: the trie's output side is uniform — rune in, rune out, conversion owned by
   callers. No behavior change; `FT.SUGGET` replies are byte-identical.

`Trie_CollectFuzzy` and `TrieSearchResult` have no callers outside `src/suggest.c`, in this
repo or in RediSearchEnterprise.

#### Which additional issues this PR fixes

None.

#### Main objects this PR modified

1. `TrieSearchResult` (`src/trie/trie.h`) — rune-typed key, plus a doc comment stating what
   the result owns and what it borrows
2. `Trie_CollectFuzzy` / `TrieSearchResult_Free` / `TrieSearchResult_SetKey` (`src/trie/trie.c`)
3. `FT.SUGGET` reply loop (`src/suggest.c`)
4. `tests/cpptests/test_cpp_trie.cpp` — `testCollectFuzzyKeysOutliveIterator`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
