### PR TITLE
Drop the hand-counted pointer total from the API-table comment

### DIFF
--- a/src/redismodule_api.c
+++ b/src/redismodule_api.c
@@ -26,14 +26,13 @@
  * builds add references to their own runtimes, which those builds always link.)
  *
  * Note the final artifacts hold more than one copy of the table: the `redis-module`
- * crate compiles its own from the header it vendors, which predates the
+ * crate compiles its own from the header it vendors, which lacks the
  * `REDISMODULE_MAIN` gate and so defines the table in every file that includes it.
  * The copies merge rather than collide because both sides emit *common* symbols --
  * `redismodule.h` tags every pointer with `REDISMODULE_ATTR_COMMON`
  * (`__attribute__((__common__))`, on GNU-compatible C compilers) and the vendored
- * header does the same. Should either side start emitting ordinary definitions,
- * the 394 pointers the two headers have in common become duplicate-definition
- * errors.
+ * header does the same. Should both sides start emitting ordinary definitions, every
+ * pointer the two headers have in common becomes a duplicate-definition error.
  */
 
 #define REDISMODULE_MAIN


### PR DESCRIPTION
## Describe the changes in the pull request

Comment-only, in `src/redismodule_api.c`'s header comment.

The comment says 394 pointers are common to `redismodule.h` and the header `redis-module` vendors. That is correct today but pin-dependent — it becomes 396 once the pin picks up the swap-prefetch API, and moves again whenever either header gains a pointer. Nothing reads it, so drop it rather than chase it.

Two fixes in the same paragraph:

- It takes **both** sides emitting ordinary definitions to collide, not either — ELF lets one ordinary definition absorb any number of commons, so `common + ordinary` links fine.
- The vendored header **lacks** the `REDISMODULE_MAIN` gate rather than predating it. It never had one, and it is not simply the older copy: it declares two pointers RediSearch's does not.

#### Which additional issues this PR fixes

None — ad-hoc change.

#### Main objects this PR modified

1. `src/redismodule_api.c` — header comment only, no code.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
