### PR TITLE
[8.6] [MOD-16334] FT.INFO fails when a shard is missing the index

### DIFF
--- a/src/coord/info_command.c
+++ b/src/coord/info_command.c
@@ -395,7 +395,6 @@ static void generateFieldsReply(InfoFields *fields, RedisModule_Reply *reply, bo
 int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies) {
   // Summarize all aggregate replies
   InfoFields fields = { .indexError = IndexError_Init() };
-  size_t numErrored = 0;
   MRReply *firstError = NULL;
   RedisModuleCtx *ctx = MRCtx_GetRedisCtx(mc);
 
@@ -406,13 +405,10 @@ int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies) {
   RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
   QueryError error = QueryError_Default();
 
-  for (size_t ii = 0; ii < count; ++ii) {
+  for (size_t ii = 0; ii < count && !firstError; ++ii) {
     int type = MRReply_Type(replies[ii]);
     if (type == MR_REPLY_ERROR) {
-      numErrored++;
-      if (!firstError) {
-        firstError = replies[ii];
-      }
+      firstError = replies[ii];
       continue;
     }
 
@@ -429,7 +425,7 @@ int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies) {
   }
 
   // Now we've received all the replies.
-  if (numErrored == count) {
+  if (firstError) {
     // Reply with error
     MR_ReplyWithMRReply(reply, firstError);
   } else if (QueryError_HasError(&error)) {

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -127,6 +127,48 @@ def test_error_propagation_from_shards(env):
     #   2. The scorer requested in the command.
     #   3. Parameters evaluation
 
+@skip(cluster=False, min_shards=2)
+def test_info_index_missing_on_one_shard(env):
+    """Tests that `FT.INFO` fails when a single shard is missing the index,
+    instead of replying with counters summed over the remaining shards.
+    """
+
+    first_conn = env.getConnection(0)
+
+    # Create an index on all shards
+    index_name = 'idx'
+    env.expect('FT.CREATE', index_name, 'SCHEMA', 'n', 'NUMERIC', 't', 'TEXT').ok()
+
+    # Drop the index on only one shard (without recreating it)
+    first_conn.execute_command('DEBUG', 'MARK-INTERNAL-CLIENT')
+    first_conn.execute_command('_FT.DROPINDEX', index_name)
+
+    # The shard that lost the index rejects the internal command
+    shard_error = 'Unknown index name'
+    try:
+        first_conn.execute_command('_FT.INFO', index_name)
+        env.assertTrue(False) # Should not reach this point
+    except Exception as e:
+        env.assertContains(shard_error, str(e))
+
+    # Should fail regardless of which shard is the coordinator. A coordinator that
+    # lost the index itself rejects the command before the fanout; one that still
+    # has it must propagate the error of the shard that does not, rather than
+    # replying with the counters of the shards that answered.
+    local_error = f'{index_name}: no such index'
+    propagated = 0
+    for shard in range(1, env.shardsCount + 1):
+        shard_conn = env.getConnection(shard)
+        try:
+            shard_conn.execute_command('FT.INFO', index_name)
+            env.assertTrue(False, message=f'FT.INFO should have failed on shard {shard}')
+        except Exception as e:
+            if shard_error in str(e):
+                propagated += 1
+            else:
+                env.assertContains(local_error, str(e))
+    env.assertGreater(propagated, 0)
+
 @skip(cluster=False)
 def test_timeout():
     """Tests that timeouts are handled properly by the coordinator.


### PR DESCRIPTION
# Description

Backport of #10771 to `8.6`. The bot could not cherry-pick it (see the failure comments on #10771), so this was done manually.

## Describe the changes in the pull request

1. **Current:** On a cluster, a shard whose index is missing replies to `_FT.INFO` with an error, and `InfoReplyReducer` skips it — the guard only propagates an error when *every* shard failed. An index lost on a subset of the shards therefore produces a reply that looks complete, while its counters (`num_docs`, `num_records`, …) sum only the shards that still have the index.

2. **Change:** Fail the command as soon as any shard replies with an error, returning that shard's error.

3. **Outcome:** A missing index surfaces as an error instead of a plausible-looking partial answer.

This matches how the reducer already treats the *other* per-shard inconsistency: when shards disagree on their schema, `handleFieldStatistics` fails the whole command with `"Inconsistent index state"` rather than aggregating a subset.

**Scope:** only shards that *answered*. A shard the fanout could not send to never enters `replies[]` and is unaffected; the all-shards-unreachable case remains covered by `count == 0` → `CLUSTER_NO_RESPONSES`.

## ⚠️ Breaking change

**`FT.INFO` now returns an error where it previously returned data**, for any caller polling a cluster where at least one shard is missing the index, or where any shard's `_FT.INFO` errors for any other reason. Monitoring and health checks will error during the degraded window instead of reporting shrunken counters. Standalone and single-shard clusters are unaffected — they answer from the local reply builder and never reach this reducer.

Since this lands on a maintenance branch, the target-version decision raised on MOD-16334 applies here as well.

## Differences from the original PR

The `src/coord/info_command.c` change is identical to master. The test differs, because this branch predates the unified error messages (#7417):

- `test_index_missing_on_one_shard` does not exist on `8.6` — it arrived with the unified messages — so the cherry-pick could not extend it. This PR adds a new `test_info_index_missing_on_one_shard` scoped to `FT.INFO`, rather than importing the whole master test and the unrelated `FT.SYNUPDATE`/`FT.ALTER`/`FT.TAGVALS`/`FT.MGET`/`FT.DROP`/`FT.HYBRID` assertions that belong to #7417.
- There is no `SEARCH_INDEX_NOT_FOUND` on this branch. The test asserts what `8.6` actually replies: the shard's `Unknown index name` when a healthy shard coordinates, and `<index>: no such index` from `VERIFY_ACL` when the coordinator is itself the shard that lost the index. Both are errors, which is the behavior this fix is about; the test also requires at least one shard to surface the *propagated* shard error, which is what regresses without the fix.

#### Which additional issues this PR fixes
1. MOD-16334

#### Main objects this PR modified
1. `InfoReplyReducer` — `src/coord/info_command.c`
2. `test_info_index_missing_on_one_shard` — `tests/pytests/test_coordinator.py`

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

## Testing

- Cluster, `SHARDS=3`: `test_coordinator.py test_info.py` — 19 passed, 0 failed.
- Negative check: with `src/coord/info_command.c` reverted to the pre-fix reducer, the new test fails as expected — `FT.INFO` still succeeded on the shards that kept the index (`FT.INFO should have failed on shard 1`, `shard 2`).

## Notes

- Requires #10858 (merged), the `8.6` backport of #10810, which removed the dead `errorIndexes` bookkeeping from this error path. That missing prerequisite is why the bot's cherry-pick of #10771 conflicted here.
