### PR TITLE
skills: focus PR bodies on user-visible outcomes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,26 +1,70 @@
+<!--
+Keep this description skimmable — a reviewer should get the point in ~30 seconds.
+
+- Title: `[MOD-xyz] concise user-facing summary`
+- Write for someone who has not read the diff and will not read all of it
+- Describe outcomes and behavior, not an implementation play-by-play — the diff
+  is authoritative for *how*; this body owns *what* and *why*
+- Link the ticket, design doc, or discussion instead of restating background
+- Keep every section, including ones that do not apply — write "N/A" instead of
+  deleting them
+-->
 
 ## Describe the changes in the pull request
 
-A clear and concise description of what the PR is solving, including:
-1. Current: The current state briefly
-2. Change: What is the change
-3. Outcome: Adding the outcome
+<!--
+1-3 sentences each. No file-by-file walkthrough, no restating what the code does.
+
+- Current: the behavior or limitation today, and why it is worth changing now
+- Change: what is different, in user- or API-visible terms
+- Outcome: what a user, operator, or caller can observe that they could not before
+
+For internal-only work (refactor, CI, test, dependency), say so plainly in
+"Outcome" and state what it enables or unblocks instead of inventing user impact.
+-->
+
+1. Current:
+2. Change:
+3. Outcome:
 
 #### Which additional issues this PR fixes
+
+<!-- Ticket and issue links only. Write "N/A" if there are none. -->
+
 1. MOD-...
 2. #...
 
 #### Main objects this PR modified
+
+<!--
+3-5 entries. The subsystems, commands, or types a reviewer should look at first,
+each with a few words on what changed there. Not a file list — `git diff --stat`
+already says which files moved, and it says it more accurately.
+-->
+
 1. ...
 
 #### Mark if applicable
+
+<!--
+Tick these on the observable surface, not the intent: a changed reply shape,
+error string, or default is an API change even when the code change is small.
+If either box is ticked, the description above must say what breaks, what the
+compatibility story is, and whether a migration or version gate is needed.
+-->
 
 - [ ] This PR introduces API changes
 - [ ] This PR introduces serialization changes
 
 #### Release Notes
 
+<!--
+Exactly one box — CI fails on zero or two. "Requires" for anything a user can
+observe: new commands or options, behavior changes, bug fixes, performance
+changes. "Does not require" for internal-only work.
+-->
+
 - [ ] This PR requires release notes
 - [ ] This PR does not require release notes
 
-If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
+If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

--- a/.skills/open-pr/SKILL.md
+++ b/.skills/open-pr/SKILL.md
@@ -205,7 +205,55 @@ are required, the title must describe the **user impact** — that is what the r
 are generated from.
 
 **Body.** Use `.github/PULL_REQUEST_TEMPLATE.md` and keep every template section,
-including ones that do not apply.
+including ones that do not apply — write "N/A" rather than deleting one. The template's
+HTML comments carry the per-section budgets; they are the spec, not decoration. Do not
+strip them from the file, and do not leave them in the PR body you submit.
+
+The failure mode to avoid is a body that narrates the diff. It is the easiest thing to
+write from a change you just made — every function you touched is fresh in mind — and the
+least useful thing to read, because the diff already says it, more accurately, and stays
+correct when the PR is amended. Write instead for a reviewer who has not read the diff and
+will read only part of it: what changes for a user of the module, and what they should
+look at first.
+
+Concretely:
+
+- **Length is a constraint, not a target.** Three sentences that say what changed beat
+  three paragraphs that say how. If a section wants to grow past its budget, that usually
+  means the PR should be split, or that the detail belongs in a code comment or the ticket.
+- **Lead with the observable.** A reader should be able to tell, from *Outcome* alone,
+  whether this PR affects them. Reply shapes, error messages, defaults, limits, latency,
+  memory — those are outcomes. "Extracted a helper", "renamed the struct", "added a null
+  check" are not.
+- **Link rather than restate.** The ticket, the design doc, and the discussion thread hold
+  the background; a paragraph re-deriving them here goes stale independently of them.
+- **Say "internal-only" when it is true.** Refactors, CI changes, test additions and
+  dependency bumps have no user impact, and manufacturing one reads as noise. State what
+  the change unblocks instead — that is the real justification.
+- **Do not list routine verification.** `./build.sh`, the test suites, `make lint` and the
+  CI jobs are assumed and visible in the checks. Mention verification only where it was
+  manual, environment-specific, or covers something automation cannot reach — a
+  reproduction that only fires under a specific cluster shape, a benchmark run, a
+  hand-checked RDB upgrade.
+- **Flag what a reviewer would otherwise miss.** Tradeoffs taken knowingly, invariants
+  that are hard to see locally, fail-closed or hot-path behavior, wire-format and
+  migration impact, follow-up work deliberately left out. This is the one place extra
+  words earn their keep — but only for things not already obvious from the diff.
+
+A concrete contrast, for the same change:
+
+> **Too verbose** — *Change:* This PR modifies `RQEIterator::revalidate` in
+> `src/redisearch_rs/rqe_iterators/src/lib.rs` to add a default implementation that
+> panics. It also updates `WildcardIterator` and `DiskWildcardIterator` in their
+> respective modules to implement `RQEIteratorBoxed`, adds a new `RQESuspendedIterator`
+> trait, changes the signature of `resume` to return a `Result`, and threads the timeout
+> value through `CRQEIterator::resume` by adding a new field to the struct…
+
+> **Right** — *Current:* Iterators cannot be suspended across a yield point, so long
+> queries hold the GIL for their whole run. *Change:* Wildcard iterators can now suspend
+> and revalidate; revalidation reports a timeout instead of blocking. *Outcome:* No
+> user-visible change yet — this is the last prerequisite for MOD-1234, which lets
+> `FT.SEARCH` yield mid-query.
 
 **Release notes.** Exactly one of these must be ticked — CI enforces it and will fail the
 PR otherwise:
@@ -227,6 +275,9 @@ After creating the PR, inspect it with `gh pr view` and confirm:
 - base branch is correct
 - head branch or bookmark is correct
 - body follows the PR template, with exactly one release-notes checkbox ticked
+- no template HTML comments survived into the submitted body, and no section was dropped
+- each section is within its budget, and *Outcome* states an observable effect (or says
+  the change is internal-only) rather than summarizing the diff
 - all intended commits are included
 
 If the body does not match what you requested, fix it immediately instead of


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: The PR template's placeholder prose ("A clear and concise description of what the PR is solving") and `/open-pr`'s body rules set no length budget and never say what to leave *out*. Descriptions written against them — especially agent-written ones — default to narrating the diff: long, implementation-heavy, and stale the moment the branch is amended.
2. Change: Every section and checkbox stays exactly as it is. Each one now carries an explicit budget and an outcomes-not-implementation rule, and `/open-pr` gains a worked verbose-vs-tight contrast on the same change. Deliberately out of scope: `/code-review` § 2l still only checks the release-notes boxes and does not review body quality.
3. Outcome: Internal-only — no module behavior changes. Future PR descriptions should be readable in ~30 seconds and say what a reader can observe rather than which functions moved. This body is written to the new rules, so it doubles as the first test of them.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `.github/PULL_REQUEST_TEMPLATE.md` — placeholder prose replaced by per-section guidance: 1-3 sentences per Current/Change/Outcome, "not a file list" for *Main objects*, tick API/serialization on observable surface and owe a compatibility story.
2. `.skills/open-pr/SKILL.md` § *Title and body* — names the diff-narration failure mode and why it is tempting, then six rules. The one most likely to change output: routine `./build.sh` / test-suite / lint / CI runs do not belong in a PR body, only verification automation could not reach.
3. `.skills/open-pr/SKILL.md` § *Verify after creation* — the post-create checklist now also catches leaked HTML comments, dropped sections, and an *Outcome* that summarizes the diff instead of stating an observable effect.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
