### PR TITLE
[MOD-15685] Fix crash when a legacy index spec is restored on a running server

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -3229,6 +3229,16 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   if (encver < LEGACY_INDEX_MIN_VERSION || encver > LEGACY_INDEX_MAX_VERSION) {
     return NULL;
   }
+  // Upgrading a legacy spec only makes sense while an RDB load is in progress. Both the UPGRADE_INDEX
+  // rules and the registry of legacy specs are built for the duration of a load and released at the end
+  // of it, so outside one - a RESTORE of a legacy payload on a running server, say - they are NULL and
+  // the lookups below would dereference NULL. Refuse instead: the caller sees a load failure, which for
+  // RESTORE surfaces as a command error.
+  if (legacySpecRules == NULL || legacySpecDict == NULL) {
+    RedisModule_LogIOError(rdb, "warning",
+                           "Refusing to load a legacy index outside of an RDB load");
+    return NULL;
+  }
   RS_LOG_ASSERT(!SearchDisk_IsEnabled(), "Legacy indexes are not supported on disk");
   char *legacyName = RedisModule_LoadStringBuffer(rdb, NULL);
 

--- a/tests/pytests/test_legacy_module_types.py
+++ b/tests/pytests/test_legacy_module_types.py
@@ -162,3 +162,28 @@ def testLegacyEmptyPayloadRoundTrips(env):
     env.assertEqual(conn.execute_command('DBSIZE'), expected)
     for type_name in _legacy_bodies():
         env.assertEqual(conn.execute_command('TYPE', 'legacy:' + type_name), type_name.encode())
+
+
+@skip(cluster=True)
+def testLegacyIndexSpecRestoreIsRefused(env):
+    """A legacy index *spec* key (`ft_index0`) can only be upgraded during an RDB load: the
+    `UPGRADE_INDEX` rules and the legacy-spec registry are built for the duration of a load and released
+    at the end of it. Restoring one on a running server used to reach `dictFetchValue` on those NULL
+    globals and segfault, so this test failing looks like a dead server rather than an assertion.
+    MOD-15685 finding #71."""
+    skipOnExistingEnv(env)
+    conn = _binary_conn(env)
+
+    # Any body will do: the guard refuses before reading a byte. LEGACY_INDEX_MAX_VERSION is 16, and
+    # anything in 2..16 routes to the legacy spec loader.
+    for encver in (2, 9, 16):
+        key = 'idx:legacy:{}'.format(encver)
+        payload = _dump_payload(conn, 'ft_index0', _module_uint(0), encver=encver)
+        # Assert on the message, not merely that something was raised: `Query` catches every
+        # exception, so a bare `.error()` would also be satisfied by the `ConnectionError` of the
+        # crash this test exists to catch - and by the 'payload version or checksum are wrong' of a
+        # drifted helper.
+        env.expect('RESTORE', key, 0, payload).error().contains('Bad data format')
+        env.assertEqual(conn.execute_command('EXISTS', key), 0, message=key)
+
+    env.assertTrue(env.isUp())


### PR DESCRIPTION
## Describe the changes in the pull request

Closes the second half of MOD-15685. Finding **#29** (legacy keys could not be persisted) was fixed in
#10817; this is finding **#71**, and with it the ticket can be closed.

**1. Current** — a legacy index spec can only be upgraded while an RDB load is in progress. Both the
`UPGRADE_INDEX` rules (`legacySpecRules`) and the registry of legacy specs (`legacySpecDict`) are built
for the duration of a load and released at the end of it — `src/rules.c` and `src/indexes.c` set both to
NULL. But `IndexSpec_LegacyRdbLoad` looks them up unconditionally:

```c
SchemaRuleArgs *rule_args = dictFetchValue(legacySpecRules, sp->specName);
```

So a `RESTORE` of a legacy `ft_index0` payload on a running server reaches `dictFetchValue` on a NULL
dict, which dereferences it in `dictSize` and **segfaults**. Reachable by any client holding `RESTORE`.

**2. Change** — refuse the load when either global is absent, before anything is read from the payload:

```c
if (legacySpecRules == NULL || legacySpecDict == NULL) {
  RedisModule_LogIOError(rdb, "warning",
                         "Refusing to load a legacy index outside of an RDB load");
  return NULL;
}
```

Returning NULL is how a module reports a failed load, which for `RESTORE` surfaces as a command error.
Placing the check before any read means a crafted payload needs no valid body to be rejected.

**3. Outcome** — restoring a legacy index spec is a clean command error instead of a dead shard. The
genuine upgrade path is untouched: during a real RDB load both globals exist, so the check passes.

### Verification

The new test asserts `RESTORE` is refused for encoding versions 2, 9 and 16 (the legacy spec range is
`LEGACY_INDEX_MIN_VERSION`..`LEGACY_INDEX_MAX_VERSION`, 2..16) and that the server is still up. I then
removed the guard again and re-ran it: the server dies and the test reports `Connection refused`. So it
fails when the bug is present rather than passing for the wrong reason.

#### Which additional issues this PR fixes
1. MOD-15685 — with this, both #29 and #71 are addressed and the ticket can close

#### Main objects this PR modified
1. `src/spec.c` — `IndexSpec_LegacyRdbLoad` guard
2. `tests/pytests/test_legacy_module_types.py` — RESTORE of a legacy spec is refused

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
