### PR TITLE
perf(numeric): skip the in-batch deduplication pass for single-valued fields

### DIFF
--- a/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
+++ b/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
@@ -140,9 +140,12 @@ impl<'index> NumericRangeIterator<'index> {
 /// times with different scores. Occurrences within this batch's ranges are
 /// coalesced to a single entry carrying the doc's best score for the sort
 /// direction; occurrences already handed out by an earlier batch (tracked in
-/// `emitted`) are dropped, since their better value was scored there. An
-/// `emitted` of `None` states that no doc spans several values, so only the
-/// within-batch coalescing is needed.
+/// `emitted`) are dropped, since their better value was scored there.
+///
+/// `emitted` is the single statement of whether the field is multivalued at all:
+/// `None` says no document carries more than one value, so a doc id cannot
+/// repeat — within a batch or across batches — and both de-duplication steps are
+/// skipped.
 ///
 /// `timeout` is polled once per record and once more before the sort, so a
 /// large batch stays deadline-aware across its ordering pass. The amortized
@@ -174,10 +177,14 @@ fn merge_ranges(
     }
     timeout.check_timeout()?;
     items.sort_unstable_by_key(|(doc_id, _)| *doc_id);
-    coalesce_by_doc_id(&mut items, filter.ascending);
     if let Some(emitted) = emitted {
+        coalesce_by_doc_id(&mut items, filter.ascending);
         emitted.extend(items.iter().map(|(doc_id, _)| *doc_id));
     }
+    debug_assert!(
+        items.windows(2).all(|w| w[0].0 < w[1].0),
+        "a batch must hold one strictly-increasing entry per doc id"
+    );
     Ok(NumericScoreBatch::new(items))
 }
 


### PR DESCRIPTION
- built on top of https://github.com/RediSearch/RediSearch/pull/10746
- next: https://github.com/RediSearch/RediSearch/pull/10874

   | benchmark | change |
   | --------- | -----: |
   | filtered n10k k10     | −0.9% |
   | filtered n10k k100    | −1.9% |
   | filtered n100k k10    | −0.9% |
   | filtered n100k k100   | −0.5% |
   | unfiltered n10k k10   | −1.5% |
   | unfiltered n10k k100  | −6.2% |
   | unfiltered n100k k10  | −1.2% |
   | unfiltered n100k k100 | −2.3% |
   | selectivity 1%        | −0.8% |
   | selectivity 10%       | −0.1% |
   | selectivity 50%       | −0.1% |
   | expensive child 1%    | −1.7% |
   | expensive child 10%   | −1.8% |
   | expensive child 50%   | −0.2% |

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
