### PR TITLE
perf(numeric): let the child filter drive batch materialization

### DIFF
--- a/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
+++ b/src/redisearch_rs/numeric_score_source/src/range_iterator.rs
@@ -16,13 +16,14 @@
 //! Each chunk is materialized into a doc-id-ordered [`NumericScoreBatch`], so a
 //! batch is *value-bucketed across* the stream yet *doc-id-sorted within*.
 
-use std::collections::HashSet;
+use std::{cmp::Ordering, collections::HashSet};
 
 use index_result::RSIndexResult;
-use inverted_index::{FilterNumericReader, IndexReader as _, NumericFilter};
+use inverted_index::{FilterNumericReader, IndexReader, NumericFilter};
 use numeric_range_tree::{NumericRange, NumericRangeTree, RangeWindow};
 use rqe_core::DocId;
 use rqe_iterators::{RQEIteratorError, utils::TimeoutContext};
+use top_k::ChildCursor;
 
 use crate::score_batch::NumericScoreBatch;
 
@@ -112,6 +113,36 @@ impl<'index> NumericRangeIterator<'index> {
         n: usize,
         timeout: &mut impl TimeoutContext,
     ) -> Result<Option<NumericScoreBatch>, RQEIteratorError> {
+        self.next_n_inner(n, None, timeout)
+    }
+
+    /// Like [`next_n`](Self::next_n), but keeping only the documents `child`
+    /// also holds.
+    ///
+    /// Each range is leapfrogged against `child` instead of read end to end, so
+    /// the blocks that hold no candidate are never decoded. The batch is a
+    /// subset of what [`next_n`](Self::next_n) would have produced, which the
+    /// caller's own intersection would have reduced to the same set anyway.
+    ///
+    /// A multivalue field falls back to the full read: taking a document's
+    /// first record in a range is not the same as taking its best-scored one,
+    /// and only a full read lets [`merge_ranges`] coalesce them.
+    pub fn next_n_filtered(
+        &mut self,
+        n: usize,
+        child: &mut dyn ChildCursor,
+        timeout: &mut impl TimeoutContext,
+    ) -> Result<Option<NumericScoreBatch>, RQEIteratorError> {
+        let child = self.emitted.is_none().then_some(child);
+        self.next_n_inner(n, child, timeout)
+    }
+
+    fn next_n_inner(
+        &mut self,
+        n: usize,
+        child: Option<&mut dyn ChildCursor>,
+        timeout: &mut impl TimeoutContext,
+    ) -> Result<Option<NumericScoreBatch>, RQEIteratorError> {
         if self.pos >= self.ranges.len() {
             return Ok(None);
         }
@@ -120,6 +151,7 @@ impl<'index> NumericRangeIterator<'index> {
             &self.ranges[self.pos..end],
             self.filter,
             self.emitted.as_mut(),
+            child,
             timeout,
         )?;
         self.pos = end;
@@ -160,6 +192,7 @@ fn merge_ranges(
     ranges: &[&NumericRange],
     filter: NumericFilter,
     emitted: Option<&mut HashSet<DocId>>,
+    mut child: Option<&mut dyn ChildCursor>,
     timeout: &mut impl TimeoutContext,
 ) -> Result<NumericScoreBatch, RQEIteratorError> {
     let capacity = ranges.iter().map(|r| r.num_docs() as usize).sum();
@@ -171,18 +204,22 @@ fn merge_ranges(
     for range in ranges {
         let run_start = items.len();
         let mut reader = FilterNumericReader::new(filter, range.reader());
-        while reader.next_record(&mut record)? {
-            timeout.check_timeout()?;
-            if emitted
-                .as_ref()
-                .is_some_and(|emitted| emitted.contains(&record.doc_id))
-            {
-                continue;
+        if let Some(child) = &mut child {
+            leapfrog_range(&mut reader, &mut **child, &mut record, &mut items, timeout)?;
+        } else {
+            while reader.next_record(&mut record)? {
+                timeout.check_timeout()?;
+                if emitted
+                    .as_ref()
+                    .is_some_and(|emitted| emitted.contains(&record.doc_id))
+                {
+                    continue;
+                }
+                let score = record
+                    .as_numeric()
+                    .expect("numeric range yields numeric records");
+                items.push((record.doc_id, score));
             }
-            let score = record
-                .as_numeric()
-                .expect("numeric range yields numeric records");
-            items.push((record.doc_id, score));
         }
         runs += usize::from(items.len() > run_start);
     }
@@ -201,6 +238,70 @@ fn merge_ranges(
         "a batch must hold one strictly-increasing entry per doc id"
     );
     Ok(NumericScoreBatch::new(items))
+}
+
+/// Append the documents `range` and `child` have in common to `items`, in
+/// increasing doc-id order.
+///
+/// Both sides are doc-id ordered, so the walk alternates seeks: whichever side
+/// is behind jumps to the other's position. Each seek on the reader skips whole
+/// index blocks, so a selective child leaves most of the range undecoded — the
+/// saving this exists for.
+///
+/// `child` is rewound first: ranges are value-disjoint but each spans the whole
+/// doc-id space, so every range restarts the same child.
+fn leapfrog_range<'index>(
+    reader: &mut impl IndexReader<'index>,
+    child: &mut dyn ChildCursor,
+    record: &mut RSIndexResult<'index>,
+    items: &mut Vec<(DocId, f64)>,
+    timeout: &mut impl TimeoutContext,
+) -> Result<(), RQEIteratorError> {
+    child.rewind();
+    // Doc ids start at 1, and `advance_to` needs a target past the child's
+    // just-reset position.
+    let Some(mut child_doc) = child.advance_to(1)? else {
+        return Ok(());
+    };
+    if !reader.seek_record(child_doc, record)? {
+        return Ok(());
+    }
+    let mut reader_doc = record.doc_id;
+
+    loop {
+        timeout.check_timeout()?;
+        match reader_doc.cmp(&child_doc) {
+            Ordering::Equal => {
+                let score = record
+                    .as_numeric()
+                    .expect("numeric range yields numeric records");
+                items.push((reader_doc, score));
+                // Advance the child first: seeking the reader to where it
+                // already sits would step over the record just consumed.
+                let Some(next) = child.advance_to(child_doc + 1)? else {
+                    break;
+                };
+                child_doc = next;
+                if !reader.seek_record(child_doc, record)? {
+                    break;
+                }
+                reader_doc = record.doc_id;
+            }
+            Ordering::Less => {
+                if !reader.seek_record(child_doc, record)? {
+                    break;
+                }
+                reader_doc = record.doc_id;
+            }
+            Ordering::Greater => {
+                let Some(next) = child.advance_to(reader_doc)? else {
+                    break;
+                };
+                child_doc = next;
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Collapse each run of equal doc ids in a doc-id-sorted `items` to one entry,

--- a/src/redisearch_rs/numeric_score_source/src/source.rs
+++ b/src/redisearch_rs/numeric_score_source/src/source.rs
@@ -20,7 +20,7 @@ use rqe_iterators::{
     ExpirationChecker, NoOpChecker, RQEIteratorError,
     utils::{NoTimeoutChecker, TimeoutContext},
 };
-use top_k::{BatchStrategy, ScoreSource};
+use top_k::{BatchStrategy, ChildCursor, ScoreSource};
 
 use crate::range_iterator::NumericRangeIterator;
 use crate::score_batch::NumericScoreBatch;
@@ -360,6 +360,35 @@ impl<'index, V: DocValidity, E: ExpirationChecker, T: TimeoutContext>
         self.ascending
     }
 
+    /// Drop entries that must not reach the bounded top-k, where they could
+    /// displace a live document: documents deleted or whole-doc expired, and
+    /// records whose sort field has expired. The range tree only sheds either at
+    /// GC time. Each gate keeps the common no-filtering case free of its
+    /// per-record check.
+    fn drop_stale(
+        &mut self,
+        batch: NumericScoreBatch,
+    ) -> Result<NumericScoreBatch, RQEIteratorError> {
+        let filter_validity = self.validity.may_filter();
+        let filter_expiration = self.expiration.has_expiration();
+        if !filter_validity && !filter_expiration {
+            return Ok(batch);
+        }
+        batch.retain(|doc_id, score| {
+            self.timeout.check_timeout()?;
+            if filter_validity && !self.validity.is_valid(doc_id) {
+                return Ok(false);
+            }
+            if filter_expiration {
+                let record = RSIndexResult::build_numeric(score).doc_id(doc_id).build();
+                if self.expiration.is_expired(&record) {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        })
+    }
+
     /// Hit ratio of the window just consumed: results collected from it over the
     /// window's limit. Returns `0.0` when the limit is `0`, guarding the
     /// division.
@@ -432,29 +461,20 @@ impl<'index, V: DocValidity, E: ExpirationChecker, T: TimeoutContext> ScoreSourc
         else {
             return Ok(None);
         };
-        // Drop stale entries pre-heap so they never displace a live document from
-        // the bounded top-k: document-level validity (deletion, whole-doc expiry)
-        // and field-level TTL, the two the range tree only sheds at GC time. Each
-        // gate keeps the common no-filtering case free of its per-record check.
-        let filter_validity = self.validity.may_filter();
-        let filter_expiration = self.expiration.has_expiration();
-        if !filter_validity && !filter_expiration {
-            return Ok(Some(batch));
-        }
-        let batch = batch.retain(|doc_id, score| {
-            self.timeout.check_timeout()?;
-            if filter_validity && !self.validity.is_valid(doc_id) {
-                return Ok(false);
-            }
-            if filter_expiration {
-                let record = RSIndexResult::build_numeric(score).doc_id(doc_id).build();
-                if self.expiration.is_expired(&record) {
-                    return Ok(false);
-                }
-            }
-            Ok(true)
-        })?;
-        Ok(Some(batch))
+        self.drop_stale(batch).map(Some)
+    }
+
+    fn next_batch_with_child(
+        &mut self,
+        child: &mut dyn ChildCursor,
+    ) -> Result<Option<Self::Batch>, RQEIteratorError> {
+        let Some(batch) =
+            self.ranges
+                .next_n_filtered(self.range_batch_size, child, &mut self.timeout)?
+        else {
+            return Ok(None);
+        };
+        self.drop_stale(batch).map(Some)
     }
 
     fn lookup_score(&mut self, _doc_id: DocId) -> Option<f64> {

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -9,7 +9,7 @@
 
 //! [`TopKIterator`] — the generic top-k state machine.
 
-use std::{cmp::Ordering, mem::ManuallyDrop, num::NonZeroUsize};
+use std::{cmp::Ordering, marker::PhantomData, mem::ManuallyDrop, num::NonZeroUsize};
 
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
@@ -23,7 +23,7 @@ use rqe_iterators::{
 
 use crate::{
     heap::{HeapResult, ScoredResult, TopKHeap},
-    traits::{BatchStrategy, ScoreBatch, ScoreSource},
+    traits::{BatchStrategy, ChildCursor, ScoreBatch, ScoreSource},
 };
 
 /// Determines which collection algorithm [`TopKIterator`] uses.
@@ -278,7 +278,20 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
     /// Collect results by intersecting score-ordered batches with the child filter.
     fn collect_batches(&mut self) -> Result<(), RQEIteratorError> {
         loop {
-            let Some(mut batch) = self.source.next_batch()? else {
+            // Offer the child to the source, which may use it to skip records
+            // this loop would discard anyway. `source` and `child` are distinct
+            // fields, so the two borrows do not overlap.
+            let batch = match &mut self.child {
+                Some(child) => {
+                    let mut cursor = SeekingChildCursor {
+                        child,
+                        _index: PhantomData,
+                    };
+                    self.source.next_batch_with_child(&mut cursor)?
+                }
+                None => self.source.next_batch()?,
+            };
+            let Some(mut batch) = batch else {
                 break;
             };
             self.metrics.num_batches += 1;
@@ -673,6 +686,25 @@ fn capture_child_metrics<'index>(record: &RSIndexResult<'index>) -> RSIndexResul
         .build();
     owned.metrics = record.metrics.clone();
     owned
+}
+
+/// The iterator's child, seen through the narrow [`ChildCursor`] view a source
+/// gets during [`ScoreSource::next_batch_with_child`].
+struct SeekingChildCursor<'a, 'index, C: RQEIterator<'index> + 'index> {
+    child: &'a mut C,
+    _index: PhantomData<&'index ()>,
+}
+
+impl<'index, C: RQEIterator<'index> + 'index> ChildCursor for SeekingChildCursor<'_, 'index, C> {
+    fn advance_to(&mut self, target: DocId) -> Result<Option<DocId>, RQEIteratorError> {
+        Ok(self.child.skip_to(target)?.map(|outcome| match outcome {
+            SkipToOutcome::Found(r) | SkipToOutcome::NotFound(r) => r.doc_id,
+        }))
+    }
+
+    fn rewind(&mut self) {
+        self.child.rewind();
+    }
 }
 
 /// Intersect one score-ordered batch with a child filter iterator,

--- a/src/redisearch_rs/top_k/src/lib.rs
+++ b/src/redisearch_rs/top_k/src/lib.rs
@@ -34,4 +34,4 @@ pub mod mock;
 
 pub use heap::{HeapResult, ScoredResult, TopKHeap};
 pub use iterator::{TopKIterator, TopKMode, TopKSourceProfile};
-pub use traits::{BatchStrategy, ScoreBatch, ScoreSource};
+pub use traits::{BatchStrategy, ChildCursor, ScoreBatch, ScoreSource};

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -36,6 +36,25 @@ pub trait ScoreBatch {
     fn skip_to(&mut self, target: DocId) -> Option<(DocId, f64)>;
 }
 
+/// The doc ids a batch will be intersected with, for sources that can skip
+/// records the filter child cannot match.
+///
+/// Handed to [`ScoreSource::next_batch_with_child`] as the source's view of the
+/// [`TopKIterator`]'s child. It exposes only forward seeking and rewinding, the
+/// two operations a source needs to leapfrog its own reader against the child;
+/// the records themselves stay with the iterator, which does the authoritative
+/// intersection afterwards.
+///
+/// [`TopKIterator`]: crate::TopKIterator
+pub trait ChildCursor {
+    /// Position the cursor at the smallest doc id `>= target` the child can
+    /// produce, and return it. `None` means the child has none.
+    fn advance_to(&mut self, target: DocId) -> Result<Option<DocId>, RQEIteratorError>;
+
+    /// Restart the cursor from the child's first doc id.
+    fn rewind(&mut self);
+}
+
 /// Decision returned by [`ScoreSource::batch_strategy`] after each batch,
 /// telling [`TopKIterator`] how to proceed in Batches mode.
 ///
@@ -102,6 +121,26 @@ pub trait ScoreSource {
     /// [`TopKMode::Unfiltered`]: crate::TopKMode::Unfiltered
     /// [`TopKIterator`]: crate::TopKIterator
     fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError>;
+
+    /// Fetch the next score-ordered batch, given the child the batch will be
+    /// intersected with.
+    ///
+    /// Called instead of [`next_batch`](Self::next_batch) whenever the
+    /// [`TopKIterator`] has a filter child. A source that can seek its own
+    /// reader may use `child` to skip records the intersection would discard;
+    /// the default ignores it, so the returned batch is the same either way and
+    /// the iterator still performs the intersection.
+    ///
+    /// `child`'s position on return is unspecified — the iterator rewinds it
+    /// before intersecting.
+    ///
+    /// [`TopKIterator`]: crate::TopKIterator
+    fn next_batch_with_child(
+        &mut self,
+        _child: &mut dyn ChildCursor,
+    ) -> Result<Option<Self::Batch>, RQEIteratorError> {
+        self.next_batch()
+    }
 
     /// Single-shot query returning all results directly, without a heap.
     ///


### PR DESCRIPTION
- built on top of https://github.com/RediSearch/RediSearch/pull/10874

   | benchmark | change |
   | --------- | -----: |
   | filtered n10k k10     | **−37.4%** |
   | filtered n10k k100    | **−37.4%** |
   | filtered n100k k10    | **−40.3%** |
   | filtered n100k k100   | **−39.2%** |
   | selectivity 1%        | **−34.7%** |
   | selectivity 10%       | **−39.2%** |
   | selectivity 50%       | **−15.5%** |
   | expensive child 1%    | −13.5% |
   | expensive child 10%   | −14.0% |
   | expensive child 50%   | **+16.9%** |
   | unfiltered (4 configs) | −1.6% to +0.7% |

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  
