### PR TITLE
[MOD-17410] Introduce QueryRequest base state for aggregate and hybrid requests

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -234,9 +234,6 @@ typedef struct AREQ {
   // Every AREQ is wrapped at construction (hybrid sub-AREQs included).
   BlockedRequestCtx *brc;
 
-  // Flag to indicate whether to skip timeout checks using clock checks
-  bool skipTimeoutChecks;
-
   bool useReplyCallback;
 
 } AREQ;
@@ -716,13 +713,11 @@ bool BlockedRequestCtx_TimeoutPreemptSafeLoaderGIL(BlockedRequestCtx *sync);
 void AREQ_ResetForCursorReadReturnStrict(AREQ *req);
 
 static inline bool AREQ_ShouldCheckTimeout(AREQ *req) {
-  return !req->skipTimeoutChecks;
+  return QueryRequestTimeout_ShouldCheck(&req->base.timeout);
 }
 
 static inline void AREQ_SetSkipTimeoutChecks(AREQ *req, bool skipTimeoutChecks) {
-  req->base.timeout.skipTimeoutChecks = skipTimeoutChecks;
-  // TODO($$$): Remove the legacy field once consumers use QueryRequest.timeout.
-  req->skipTimeoutChecks = skipTimeoutChecks;
+  QueryRequestTimeout_SetSkipChecks(&req->base.timeout, skipTimeoutChecks);
   // TODO($$$): Remove the SearchTime mirror once consumers use QueryRequest.timeout.
   if (req->sctx) {
     req->sctx->time.skipTimeoutChecks = skipTimeoutChecks;
@@ -734,7 +729,7 @@ static inline void AREQ_SetSkipTimeoutChecks(AREQ *req, bool skipTimeoutChecks) 
 // in-pipeline clock-based timeout. `skipTimeoutChecks` is set by
 // `AREQ_ApplyContext` exactly when the BC callback is the active source.
 static inline AREQ *AREQ_TimeoutAreqOrNull(AREQ *req) {
-  return (req && req->skipTimeoutChecks) ? req : NULL;
+  return (req && !QueryRequestTimeout_ShouldCheck(&req->base.timeout)) ? req : NULL;
 }
 
 static inline bool RequestConfig_ApplyCoordinatorElapsedTime(RequestConfig *reqConfig,

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -244,9 +244,6 @@ typedef struct AREQ {
 /* Forward declaration; full type lives in hybrid_request.h. */
 struct HybridRequest;
 
-/* BlockedRequestCtx.queryOffset value meaning "no query argument". */
-#define QUERY_OFFSET_NONE UINT32_MAX
-
 /**
  * Heap-allocated owning wrapper around a top-level request (AREQ or
  * HybridRequest). It is the single owner of the query and holds the

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -257,24 +257,6 @@ struct BlockedRequestCtx {
     struct HybridRequest *hybrid;
   } query;
 
-  /* Held references to the command argv strings the owned request's plan
-   * borrows from; may be a superset of the parsed slice. Taken at
-   * construction, on the main thread (string refcounts are not thread safe);
-   * released in BlockedRequestCtx_Free, after the owned request. */
-  RedisModuleString **argv;
-  uint32_t argc;
-
-  /* The logical command length within argv — the extent parsing may
-   * read. Set with the holds at construction; the debug constructors lower
-   * it so the trailing debug params stay held but unparsed. */
-  uint32_t parseArgc;
-
-  /* Index of the owned request's query string within argv — the start
-   * of its parse slice. Set where the query is discovered (AREQ_Compile;
-   * setSubQueryArg for hybrid subs). QUERY_OFFSET_NONE means no query
-   * argument (a VSIM sub without FILTER, or the container). */
-  uint32_t queryOffset;
-
   /* Partial-timeout coordination. The CAS claim grants exclusive ownership of
    * the result-production phase: the BG-thread winner runs AggregateResults
    * and stores results, while the timeout-callback winner preempts BG (BG
@@ -360,15 +342,16 @@ struct BlockedRequestCtx {
 };
 
 /* The request's query string: the first argument of its parse slice, backed
- * by the wrapper's held argv. A request with no query argument (a hybrid
+ * by QueryRequest's held argv. A request with no query argument (a hybrid
  * VSIM sub-request without a FILTER) defaults to the match-all wildcard
  * query "*". */
 static inline const char *AREQ_Query(const AREQ *req, size_t *len) {
-  if (req->brc->queryOffset == QUERY_OFFSET_NONE) {
+  if (req->base.args.queryOffset == QUERY_OFFSET_NONE) {
     if (len) *len = 1;
     return "*";
   }
-  const char *query = RedisModule_StringPtrLen(req->brc->argv[req->brc->queryOffset], len);
+  const char *query =
+      RedisModule_StringPtrLen(req->base.args.argv[req->base.args.queryOffset], len);
   // TRANSITIONAL: report the C-string length, truncating at the first NUL, so a
   // query with embedded NULs behaves as it always has.
   // TODO: remove — the true length is what StringPtrLen already reported.
@@ -376,11 +359,10 @@ static inline const char *AREQ_Query(const AREQ *req, size_t *len) {
   return query;
 }
 
-/* Allocate a heap BlockedRequestCtx owning the request (refcount=1), wire the
- * `brc` back-pointer, and take the argv holds (see `argv`). Main-thread
- * only; `argv` must not be NULL. */
-BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **argv, uint32_t argc);
-BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid, RedisModuleString **argv, uint32_t argc);
+/* Allocate a heap BlockedRequestCtx owning the request (refcount=1) and wire
+ * the `brc` back-pointer. */
+BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq);
+BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid);
 
 /* TRANSITIONAL(MOD-16691): increment / decrement the wrapper's reference
  * count. DecrRef triggers BlockedRequestCtx_Free when the count drops to
@@ -446,11 +428,11 @@ void AREQ_DecrRef(AREQ *req);
  * 6) Free: This releases all resources consumed by the request
  */
 
-AREQ *AREQ_New(void);
+AREQ *AREQ_New(RedisModuleString **argv, uint32_t argc);
 
 /**
- * Compile the request from the wrapper's held argv, starting at `offset`
- * (the query token) and reading up to the wrapper's `parseArgc` — the holds are
+ * Compile the request from QueryRequest's held argv, starting at `offset`
+ * (the query token) and reading up to `args.parseArgc` — the holds are
  * the only string source by construction. This does not rely on
  * Redis-specific states and may be unit-tested. This largely just
  * compiles the options and parses the commands..

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -262,12 +262,6 @@ struct BlockedRequestCtx {
                        // true => BG stores results and the reply callback
                        // registered with RedisModule_BlockClient serializes
                        // them on main after UnblockClient
-  // Stored-reply slot for deferred (deferred_reply) cycles: the BG thread
-  // stores results/error here before UnblockClient; the reply or timeout
-  // callback reads it on main. One slot serves AREQ and hybrid cycles.
-  // Destroyed at EndCycle (per cycle) and, idempotently, in
-  // BlockedRequestCtx_Free as a safety net.
-  ChunkReplyState reply;
   /* Cursor disposition for this cycle. The point that decides the cursor's
    * fate (the BG worker at cycle end, or the reply path once finishSendChunk
    * set QEXEC_S_ITERDONE) records it here; OnFree — the single park-or-free
@@ -534,11 +528,11 @@ void sendChunk_ReplyOnly_EmptyResults(RedisModuleCtx *ctx, AREQ *req);
 
 
 /**
- * Free a cursor parked in `req->brc->reply.cursor`, if any.
+ * Free a cursor parked in `req->base.reply.cursor`, if any.
  * Used by cleanup paths to release a cursor left behind when the
  * blocked-client timeout fires before the reply callback runs and
  * drains it via `AREQ_ReplyWithStoredResults`.
- * No-op when `brc->reply.cursor` is NULL.
+ * No-op when `req->base.reply.cursor` is NULL.
  */
 void AREQ_CleanUpStoredCursor(AREQ *req);
 

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -234,8 +234,6 @@ typedef struct AREQ {
   // Every AREQ is wrapped at construction (hybrid sub-AREQs included).
   BlockedRequestCtx *brc;
 
-  bool useReplyCallback;
-
 } AREQ;
 
 /* Forward declaration; full type lives in hybrid_request.h. */

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -42,45 +42,6 @@ struct Cursor;
 // Forward declaration for the MR channel used by the abort-wake path.
 struct MRChannel;
 
-/** Cached variables to avoid serializeResult retrieving these each time */
-typedef struct {
-  RLookup *lastLookup;
-  const PLN_ArrangeStep *lastAstp;
-} cachedVars;
-
-/**
- * State needed for reply serialization in reply_callback path.
- * When using FAIL policy with workers, the background thread stores results here,
- * then calls UnblockClient. The reply_callback reads from here to build the reply.
- *
- * ## Cursor ↔ AREQ Ownership
- *
- * **Cursor owns AREQ** (not vice versa):
- * - cursor->query points to the AREQ's wrapper
- * - Cursor_FreeInternal releases the wrapper reference
- *
- * **AREQ does NOT own Cursor**:
- * - The `cursor` field below is a NON-OWNING handle.
- * - It exists solely so QueryReplyCallback knows which cursor to pause/free after
- *   finishSendChunk completes.
- * - In normal flow, QueryReplyCallback calls Cursor_Free/Cursor_Pause and clears this field.
- */
-typedef struct {
-  SearchResult **results;  // Aggregated results array (NULL if not aggregated yet)
-  int rc;                  // Pipeline return code (RS_RESULT_OK, RS_RESULT_EOF, etc.)
-  bool hasStoredResults;   // Flag to indicate results were stored for reply_callback
-  QueryError err;          // Query error state (copied from qctx->err after pipeline execution)
-  cachedVars cv;           // Cached lookup variables for result serialization
-  /**
-   * NON-OWNING cursor handle for reply_callback path.
-   * See ownership model above. This is set in runCursor() when useReplyCallback is true,
-   * and cleared by QueryReplyCallback after it handles cursor pause/free.
-   * If timeout fires first, ChunkReplyState_Destroy cleans this up.
-   */
-  struct Cursor *cursor;
-  size_t limit;            // Original limit passed to sendChunk (for RESP2 resultsLen calculation)
-} ChunkReplyState;
-
 /**
  * Clean up all resources held by a ChunkReplyState.
  * Handles the cursor ownership edge case (see struct documentation above).

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -262,19 +262,6 @@ struct BlockedRequestCtx {
                        // true => BG stores results and the reply callback
                        // registered with RedisModule_BlockClient serializes
                        // them on main after UnblockClient
-  /* ===== TRANSITIONAL(MOD-16691) — refactor scaffolding =====
-   * Every field below is temporary bloat: each one bridges a gap that a later
-   * step of the refactor (or the RETURN_STRICT flip follow-up) closes, and is
-   * deleted with it. The struct shrinks back accordingly. Grep for
-   * TRANSITIONAL(MOD-16691) to find all scaffolding. */
-
-  /* TRANSITIONAL(MOD-16691): reference count, until the cursor-ownership step
-   * makes the wrapper single-owner (cycle owns it via BeginCycle/OnFree, a
-   * parked cursor owns it between cycles). Starts at 1 (set by New);
-   * incremented by IncrRef, decremented by DecrRef; reaches 0 exactly once,
-   * triggering Free. ACQ_REL on decrement so the free path sees prior writes. */
-  RS_Atomic(int) refcount;
-
 };
 
 /* The request's query string: the first argument of its parse slice, backed
@@ -295,15 +282,13 @@ static inline const char *AREQ_Query(const AREQ *req, size_t *len) {
   return query;
 }
 
-/* Allocate a heap BlockedRequestCtx owning the request (refcount=1) and wire
- * the `brc` back-pointer. */
+/* Allocate a heap BlockedRequestCtx owning the request and wire the `brc`
+ * back-pointer. */
 BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq);
 BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid);
 
-/* TRANSITIONAL(MOD-16691): increment / decrement the wrapper's reference
- * count. DecrRef triggers BlockedRequestCtx_Free when the count drops to
- * zero. Deleted together with `refcount` once the cursor-ownership step makes
- * the wrapper single-owner. */
+/* Increment / decrement the owned QueryRequest's reference count. DecrRef
+ * triggers BlockedRequestCtx_Free when the count drops to zero. */
 BlockedRequestCtx *BlockedRequestCtx_IncrRef(BlockedRequestCtx *brc);
 void BlockedRequestCtx_DecrRef(BlockedRequestCtx *brc);
 
@@ -328,11 +313,10 @@ static inline struct HybridRequest *BlockedRequestCtx_GetHybrid(BlockedRequestCt
 
 /* Lifecycle helpers for AREQ objects. AREQ_Free destroys the AREQ directly
  * (no wrapper involved).
- * TRANSITIONAL(MOD-16691): AREQ_IncrRef / AREQ_DecrRef delegate to the owning
- * BlockedRequestCtx's refcount when one is present (req->brc != NULL);
+ * AREQ_IncrRef / AREQ_DecrRef delegate to the QueryRequest refcount through
+ * the owning BlockedRequestCtx when one is present (req->brc != NULL);
  * otherwise they call AREQ_Free directly (for unwrapped transient /
- * sub-AREQs). Deleted with the wrapper refcount once the cursor-ownership
- * step makes the wrapper single-owner. */
+ * sub-AREQs). */
 void AREQ_Free(AREQ *req);
 AREQ *AREQ_IncrRef(AREQ *req);
 void AREQ_DecrRef(AREQ *req);

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -262,15 +262,6 @@ struct BlockedRequestCtx {
                        // true => BG stores results and the reply callback
                        // registered with RedisModule_BlockClient serializes
                        // them on main after UnblockClient
-  /* Cursor disposition for this cycle. The point that decides the cursor's
-   * fate (the BG worker at cycle end, or the reply path once finishSendChunk
-   * set QEXEC_S_ITERDONE) records it here; OnFree — the single park-or-free
-   * point — executes it, so a cycle's cursor stays unreachable to other
-   * clients until the cycle fully ended. NULL when the cycle has no cursor;
-   * inline execution (brc->bc == NULL) disposes directly. */
-  struct Cursor *cursor;
-  bool cursor_dispose_free;
-
   /* ===== TRANSITIONAL(MOD-16691) — refactor scaffolding =====
    * Every field below is temporary bloat: each one bridges a gap that a later
    * step of the refactor (or the RETURN_STRICT flip follow-up) closes, and is

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -10,6 +10,7 @@
 #define RS_AGGREGATE_H__
 
 #include "query_flags.h"
+#include "query_request.h"
 #include "value_ffi.h"
 #include "query.h"
 #include "reducer.h"
@@ -253,6 +254,8 @@ static inline void RequestSyncState_Destroy(RequestSyncState *st) {
 }
 
 typedef struct AREQ {
+  QueryRequest base;
+
   /* Arguments converted to sds. Received on input */
   sds *args;
   size_t nargs;

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -720,8 +720,10 @@ static inline bool AREQ_ShouldCheckTimeout(AREQ *req) {
 }
 
 static inline void AREQ_SetSkipTimeoutChecks(AREQ *req, bool skipTimeoutChecks) {
+  req->base.timeout.skipTimeoutChecks = skipTimeoutChecks;
+  // TODO($$$): Remove the legacy field once consumers use QueryRequest.timeout.
   req->skipTimeoutChecks = skipTimeoutChecks;
-  // Also propagate to the SearchCtx's SearchTime for timeout functions that access it directly
+  // TODO($$$): Remove the SearchTime mirror once consumers use QueryRequest.timeout.
   if (req->sctx) {
     req->sctx->time.skipTimeoutChecks = skipTimeoutChecks;
   }

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -132,24 +132,12 @@ typedef enum {
 
 typedef enum { COMMAND_AGGREGATE, COMMAND_SEARCH, COMMAND_EXPLAIN, COMMAND_HYBRID } CommandType;
 
-/**
- * Identifies which concrete request type a heap BlockedRequestCtx wrapper owns.
- */
-typedef enum {
-  REQUEST_KIND_AREQ,
-  REQUEST_KIND_HYBRID,
-} RequestKind;
-
 /* Values of QueryRequestAsyncState.strictReadOwner. */
 typedef enum {
-  BRC_READ_OWNER_NONE = 0,
-  BRC_READ_OWNER_BG,
-  BRC_READ_OWNER_TIMEOUT,
-} BrcStrictReadOwner;
-
-/* Heap-allocated owning wrapper around a top-level request. Defined below the
- * AREQ struct (it references AREQ/HybridRequest only by pointer). */
-typedef struct BlockedRequestCtx BlockedRequestCtx;
+  QUERY_REQUEST_READ_OWNER_NONE = 0,
+  QUERY_REQUEST_READ_OWNER_BG,
+  QUERY_REQUEST_READ_OWNER_TIMEOUT,
+} QueryRequestStrictReadOwner;
 
 typedef struct AREQ {
   QueryRequest base;
@@ -229,40 +217,22 @@ typedef struct AREQ {
 
   ProfilePrinterCtx profileCtx;
 
-  // Non-owning back-pointer to the heap wrapper that owns this request.
-  // Every AREQ is wrapped at construction (hybrid sub-AREQs included).
-  BlockedRequestCtx *brc;
-
 } AREQ;
 
 /* Forward declaration; full type lives in hybrid_request.h. */
 struct HybridRequest;
 
-/**
- * Heap-allocated owning wrapper around a top-level request (AREQ or
- * HybridRequest). It is the single owner of the query and holds the remaining
- * blocked-client lifecycle state.
- */
-struct BlockedRequestCtx {
-  RequestKind kind;
-  union {
-    AREQ *areq;
-    struct HybridRequest *hybrid;
-  } query;
+#ifdef __cplusplus
+static_assert(offsetof(AREQ, base) == 0, "QueryRequest must be AREQ's first member");
+#else
+_Static_assert(offsetof(AREQ, base) == 0, "QueryRequest must be AREQ's first member");
+#endif
 
-  /* ===== Per-cycle fields =====
-   * A "cycle" is one blocked-client round trip: the initial query execution or
-   * a single cursor read. Bound on the main thread by
-   * BlockedRequestCtx_BeginCycle (after RedisModule_BlockClient returned `bc`,
-   * before dispatching BG work) and cleared by BlockedRequestCtx_EndCycle
-   * (called from BlockedRequestCtx_OnFree, the free_privdata callback).
-   * Between cycles these are NULL/zeroed and must not be read. */
-  RedisModuleBlockedClient *bc; // Redis-owned; valid for the cycle
-  bool deferred_reply; // false => BG replies inline via a thread-safe ctx;
-                       // true => BG stores results and the reply callback
-                       // registered with RedisModule_BlockClient serializes
-                       // them on main after UnblockClient
-};
+static inline AREQ *QueryRequest_GetAREQ(QueryRequest *request) {
+  RS_ASSERT(request != NULL);
+  RS_ASSERT(request->kind == QUERY_REQUEST_KIND_AREQ);
+  return (AREQ *)request;
+}
 
 /* The request's query string: the first argument of its parse slice, backed
  * by QueryRequest's held argv. A request with no query argument (a hybrid
@@ -282,41 +252,9 @@ static inline const char *AREQ_Query(const AREQ *req, size_t *len) {
   return query;
 }
 
-/* Allocate a heap BlockedRequestCtx owning the request and wire the `brc`
- * back-pointer. */
-BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq);
-BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid);
-
-/* Increment / decrement the owned QueryRequest's reference count. DecrRef
- * triggers BlockedRequestCtx_Free when the count drops to zero. */
-BlockedRequestCtx *BlockedRequestCtx_IncrRef(BlockedRequestCtx *brc);
-void BlockedRequestCtx_DecrRef(BlockedRequestCtx *brc);
-
-/* Free a heap BlockedRequestCtx: destroys the coordination state, frees the owned
- * request (AREQ_Free / HybridRequest_Free), then frees the wrapper itself. */
-void BlockedRequestCtx_Free(BlockedRequestCtx *brc);
-
-/* Kind-checked accessors for the owned request. Callers that know which kind
- * of request their cycle carries (e.g. per-kind reply/timeout callbacks) use
- * these instead of reaching into the union, so a mismatched callback fails
- * loudly in debug builds. */
-static inline AREQ *BlockedRequestCtx_GetAREQ(BlockedRequestCtx *brc) {
-  RS_ASSERT(brc->kind == REQUEST_KIND_AREQ);
-  RS_ASSERT(brc->query.areq != NULL);
-  return brc->query.areq;
-}
-static inline struct HybridRequest *BlockedRequestCtx_GetHybrid(BlockedRequestCtx *brc) {
-  RS_ASSERT(brc->kind == REQUEST_KIND_HYBRID);
-  RS_ASSERT(brc->query.hybrid != NULL);
-  return brc->query.hybrid;
-}
-
-/* Lifecycle helpers for AREQ objects. AREQ_Free destroys the AREQ directly
- * (no wrapper involved).
- * AREQ_IncrRef / AREQ_DecrRef delegate to the QueryRequest refcount through
- * the owning BlockedRequestCtx when one is present (req->brc != NULL);
- * otherwise they call AREQ_Free directly (for unwrapped transient /
- * sub-AREQs). */
+/* Lifecycle helpers for AREQ objects. AREQ_Free is the concrete destructor
+ * selected by the final QueryRequest release; ownership callers use
+ * AREQ_IncrRef / AREQ_DecrRef. */
 void AREQ_Free(AREQ *req);
 AREQ *AREQ_IncrRef(AREQ *req);
 void AREQ_DecrRef(AREQ *req);
@@ -582,9 +520,8 @@ bool AREQ_CheckTimedOut(AREQ *areq);
  * under RETURN_STRICT, and on shard/standalone AREQs for RETURN_STRICT
  * cursor reads; all other paths skip the protocol. */
 static inline bool AREQ_RequiresThreadsSyncResults(const AREQ *req) {
-  // Invariant: every AREQ reaching the strict-sync protocol is wrapped (the
-  // blocked client's privdata is the wrapper). Unwrapped sub-/transient AREQs
-  // never run it.
+  // Invariant: every AREQ reaching the strict-sync protocol is installed as a
+  // blocked client's private data. Sub-/transient AREQs never run it.
   return req->base.async.requiresAggregateResultsSync;
 }
 
@@ -595,12 +532,12 @@ bool AREQ_TryClaimAggregateResults(AREQ *req);
 
 /* CAS QueryRequestAsyncState.strictReadOwner NONE -> `owner`. Returns true if
  * this caller won the latch. */
-bool BlockedRequestCtx_TryOwnStrictRead(BlockedRequestCtx *brc, BrcStrictReadOwner owner);
+bool QueryRequest_TryOwnStrictRead(QueryRequest *request, QueryRequestStrictReadOwner owner);
 void AREQ_SignalAggregateResultsComplete(AREQ *req);
 void AREQ_WaitForAggregateResultsComplete(AREQ *req);
 
 /* RP_SAFE_LOADER GIL handshake (deadlock avoidance for RETURN_STRICT). Reached
- * only on the sync path: the loader links its brc only when
+ * only on the sync path: the loader links its request only when
  * requiresAggregateResultsSync is set, and the Preempt callers are the
  * RETURN_STRICT timeout callbacks, so no in-helper policy gate is needed.
  *
@@ -616,9 +553,9 @@ void AREQ_WaitForAggregateResultsComplete(AREQ *req);
  *   true if the worker is parked at the GIL gate, so the callback replies empty
  *   instead of deadlocking. The shared aggregateResultsLock makes EnterGIL and
  *   this check a race-free Dekker handshake. */
-bool BlockedRequestCtx_SafeLoaderEnterGIL(BlockedRequestCtx *sync);
-void BlockedRequestCtx_SafeLoaderExitGIL(BlockedRequestCtx *sync);
-bool BlockedRequestCtx_TimeoutPreemptSafeLoaderGIL(BlockedRequestCtx *sync);
+bool QueryRequest_SafeLoaderEnterGIL(QueryRequest *request);
+void QueryRequest_SafeLoaderExitGIL(QueryRequest *request);
+bool QueryRequest_TimeoutPreemptSafeLoaderGIL(QueryRequest *request);
 
 /* Reset the per-cursor-read sync state on a coordinator RETURN_STRICT cursor
  * read so the next chunk starts from a clean slate. Resets:

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -328,12 +328,6 @@ struct BlockedRequestCtx {
    * not care whether BG started). */
   RS_Atomic(int) strictReadOwner;
 
-  /* TRANSITIONAL(MOD-16691): per-cycle registry bridge, until Step 3 links
-   * the wrapper itself into BlockedQueries. The node created for this cycle,
-   * unlinked and freed in EndCycle. Kind-tagged because query and cursor
-   * nodes live in different lists. */
-  void *registry_node;
-  bool registry_node_is_cursor;
 };
 
 /* The request's query string: the first argument of its parse slice, backed

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -689,6 +689,8 @@ static inline bool AREQ_TimedOut(AREQ *req) {
   return RequestSyncState_GetTimedOut(&req->syncState);
 }
 static inline void AREQ_SetTimedOut(AREQ *req) {
+  QueryRequestTimeout_SetTimedOut(&req->base.timeout);
+  // TODO($$$): Remove the legacy timeout state once consumers use QueryRequest.timeout.
   RequestSyncState_SetTimedOut(&req->syncState);
 }
 // The pipeline stage the request had reached, used to attribute a timeout.
@@ -697,7 +699,10 @@ static inline QueryTimeoutStage AREQ_ExecutionStage(AREQ *req) {
 }
 // Advance the request's execution-phase marker (QUEUE -> PIPELINE -> REPLY).
 static inline void AREQ_SetExecutionStage(AREQ *req, QueryTimeoutStage stage) {
+  // TODO($$$): Remove the legacy execution phase once consumers use QueryRequest.async.
   RequestSyncState_SetExecutionStage(&req->syncState, stage);
+  QueryRequestAsyncState_SetExecutionPhase(
+      &req->base.async, RequestSyncState_GetExecutionStage(&req->syncState));
 }
 #ifdef ENABLE_ASSERT
 // SyncPointStopFn predicate adapter for AREQ_TimedOut. Pass the AREQ as `arg`

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -140,8 +140,7 @@ typedef enum {
   REQUEST_KIND_HYBRID,
 } RequestKind;
 
-/* TRANSITIONAL(MOD-16691): values of BlockedRequestCtx.strictReadOwner (see
- * the field's doc; deleted by the RETURN_STRICT flip). */
+/* Values of QueryRequestAsyncState.strictReadOwner. */
 typedef enum {
   BRC_READ_OWNER_NONE = 0,
   BRC_READ_OWNER_BG,
@@ -241,9 +240,8 @@ struct HybridRequest;
 
 /**
  * Heap-allocated owning wrapper around a top-level request (AREQ or
- * HybridRequest). It is the single owner of the query and holds the
- * top-level-only result-production coordination state (the TryClaim/Signal/Wait
- * handshake between the background reader and the timeout callback).
+ * HybridRequest). It is the single owner of the query and holds the remaining
+ * blocked-client lifecycle state.
  */
 struct BlockedRequestCtx {
   RequestKind kind;
@@ -251,30 +249,6 @@ struct BlockedRequestCtx {
     AREQ *areq;
     struct HybridRequest *hybrid;
   } query;
-
-  /* Partial-timeout coordination. The CAS claim grants exclusive ownership of
-   * the result-production phase: the BG-thread winner runs AggregateResults
-   * and stores results, while the timeout-callback winner preempts BG (BG
-   * bails at its post-claim check) and replies empty without running the
-   * pipeline. The loser waits for the winner's completion signal.
-   * Gated by `requiresAggregateResultsSync`.
-   * NOTE: a planned follow-up flips this mechanism so the timeout callback
-   * never waits on BG state (mark flag → serialize → drain a thread-safe
-   * results store), replacing the whole claim/latch/wait block. */
-  bool requiresAggregateResultsSync;     // Enable CAS/Signal/Wait around AggregateResults
-  RS_Atomic(bool) aggregatingResults;    // CAS claim: BG winner runs the pipeline; timeout-callback winner skips it and replies empty
-  bool aggregateResultsClaimLost;        // BG lost the CAS claim to the timeout callback
-  bool aggregateResultsDone;             // Set at completion; guarded by aggregateResultsLock
-  /* RP_SAFE_LOADER deadlock-avoidance handshake. Incremented by a BG worker just
-   * before it takes the GIL, decremented after it releases it; guarded by
-   * aggregateResultsLock. The timeout callback reads it (same lock) to detect a
-   * worker parked at the GIL gate and preempt it instead of deadlocking in Wait
-   * while holding the GIL. A count rather than a bool: a hybrid request's tail
-   * and subquery pipelines all share this wrapper, so several safe loaders can
-   * be inside the Enter/Exit window concurrently. */
-  int safeLoadersHoldingGIL;
-  pthread_mutex_t aggregateResultsLock;
-  pthread_cond_t aggregateResultsCond;
 
   /* ===== Per-cycle fields =====
    * A "cycle" is one blocked-client round trip: the initial query execution or
@@ -315,18 +289,6 @@ struct BlockedRequestCtx {
    * incremented by IncrRef, decremented by DecrRef; reaches 0 exactly once,
    * triggering Free. ACQ_REL on decrement so the free path sees prior writes. */
   RS_Atomic(int) refcount;
-
-  /* TRANSITIONAL(MOD-16691): "has the BG worker dequeued this cursor read?"
-   * latch for coord RETURN_STRICT cursor reads; per-cycle, reset by
-   * BeginCycle. The BG handler CASes NONE→BG at its entry; the RETURN_STRICT
-   * timeout callback CASes NONE→TIMEOUT after flipping the timeout flag. A
-   * timer that wins replies with a depleted empty cursor and never waits (the
-   * BG job may be queued behind a paused/saturated pool); a BG that loses
-   * frees the taken cursor and stores nothing. A timer that loses may wait: a
-   * started RETURN_STRICT read always stores a reply and signals completion.
-   * Deleted by the RETURN_STRICT flip (a never-waiting timeout callback does
-   * not care whether BG started). */
-  RS_Atomic(int) strictReadOwner;
 
 };
 
@@ -654,8 +616,7 @@ static inline bool AREQ_RequiresThreadsSyncResults(const AREQ *req) {
   // Invariant: every AREQ reaching the strict-sync protocol is wrapped (the
   // blocked client's privdata is the wrapper). Unwrapped sub-/transient AREQs
   // never run it.
-  RS_ASSERT(req->brc != NULL);
-  return req->brc->requiresAggregateResultsSync;
+  return req->base.async.requiresAggregateResultsSync;
 }
 
 /* TryClaim: atomic CAS on `aggregatingResults`; winner runs AggregateResults.
@@ -663,9 +624,8 @@ static inline bool AREQ_RequiresThreadsSyncResults(const AREQ *req) {
  * Exactly one of {BG thread, timeout callback} wins. */
 bool AREQ_TryClaimAggregateResults(AREQ *req);
 
-/* TRANSITIONAL(MOD-16691): CAS BlockedRequestCtx.strictReadOwner NONE ->
- * `owner`. Returns true if this caller won the latch (see the field's doc for
- * the protocol; deleted by the RETURN_STRICT flip). */
+/* CAS QueryRequestAsyncState.strictReadOwner NONE -> `owner`. Returns true if
+ * this caller won the latch. */
 bool BlockedRequestCtx_TryOwnStrictRead(BlockedRequestCtx *brc, BrcStrictReadOwner owner);
 void AREQ_SignalAggregateResultsComplete(AREQ *req);
 void AREQ_WaitForAggregateResultsComplete(AREQ *req);
@@ -693,9 +653,9 @@ bool BlockedRequestCtx_TimeoutPreemptSafeLoaderGIL(BlockedRequestCtx *sync);
 
 /* Reset the per-cursor-read sync state on a coordinator RETURN_STRICT cursor
  * read so the next chunk starts from a clean slate. Resets:
- *   - brc->aggregatingResults (CAS claim)
- *   - brc->aggregateResultsDone (signal latch)
- *   - brc->safeLoadersHoldingGIL (GIL-handshake latch)
+ *   - base.async.aggregatingResults (CAS claim)
+ *   - base.async.aggregateResultsDone (signal latch)
+ *   - base.async.safeLoadersHoldingGIL (GIL-handshake latch)
  *   - base.timeout.timedOut (timer latch from the previous chunk's timer)
  *   - RPNet::drainOnly on the root proc when it is RP_NETWORK (so the next
  *     read does not short-circuit to EOF on the first empty-channel observation).

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -150,70 +150,6 @@ typedef enum {
  * AREQ struct (it references AREQ/HybridRequest only by pointer). */
 typedef struct BlockedRequestCtx BlockedRequestCtx;
 
-/**
- * Per-request synchronization slot embedded in every AREQ and HybridRequest.
- * Holds only the state the timeout callback shares with the background reader
- * draining that specific (sub-)request: the timeout flag and the single-slot
- * abort-wake channel used to unblock a parked MR reader.
- *
- * Top-level result-production coordination lives on the owning BlockedRequestCtx
- * wrapper, not here (sub-AREQs never run that handshake).
- */
-typedef struct RequestSyncState {
-  // Timeout signaling flag set by the timeout callback on the main thread.
-  RS_Atomic(bool) timedOut;
-
-  // Execution-phase marker (QueryTimeoutStage values), advanced monotonically by
-  // the executing thread (QUEUE -> PIPELINE -> REPLY) and frozen once `timedOut` is
-  // set. The main-thread timeout callbacks only read it to attribute a timeout to
-  // the pipeline stage it occurred in.
-  RS_Atomic(int) execPhase;
-
-  /* Abort-wake registration (single-slot). BG reader registers its blocking MR
-   * channel; timeout callback broadcasts on it after flipping `timedOut`.
-   * `abortWakeLock` serializes register/unregister/wake. */
-  struct MRChannel *abortWakeChannel;
-  pthread_mutex_t abortWakeLock;
-} RequestSyncState;
-
-// Initialize a RequestSyncState with default values
-static inline void RequestSyncState_Init(RequestSyncState *st) {
-  st->timedOut = false;
-  st->execPhase = QUERY_TIMEOUT_STAGE_QUEUE;
-  st->abortWakeChannel = NULL;
-  pthread_mutex_init(&st->abortWakeLock, NULL);
-}
-
-static inline bool RequestSyncState_GetTimedOut(RequestSyncState *st) {
-  return RS_AtomicBoolLoadRelaxed(&st->timedOut);
-}
-static inline void RequestSyncState_SetTimedOut(RequestSyncState *st) {
-  RS_AtomicBoolStoreRelaxed(&st->timedOut, true);
-}
-static inline void RequestSyncState_ClearTimedOut(RequestSyncState *st) {
-  RS_AtomicBoolStoreRelaxed(&st->timedOut, false);
-}
-
-// Read the current execution phase as a QueryTimeoutStage. Used to attribute a
-// timeout to the stage the request had reached when the deadline fired.
-static inline QueryTimeoutStage RequestSyncState_GetExecutionStage(RequestSyncState *st) {
-  return (QueryTimeoutStage)RS_AtomicIntLoadRelaxed(&st->execPhase);
-}
-// Advance the execution phase (executing thread). Frozen once a timeout is signalled,
-// so the stage a main-thread callback reads cannot change underneath it.
-static inline void RequestSyncState_SetExecutionStage(RequestSyncState *st, QueryTimeoutStage stage) {
-  if (RequestSyncState_GetTimedOut(st)) {
-    return;
-  }
-  RS_AtomicIntStoreRelaxed(&st->execPhase, (int)stage);
-}
-
-// Release resources owned by a RequestSyncState. Must be called exactly once
-// per successful Init, from the request's free path.
-static inline void RequestSyncState_Destroy(RequestSyncState *st) {
-  pthread_mutex_destroy(&st->abortWakeLock);
-}
-
 typedef struct AREQ {
   QueryRequest base;
 
@@ -298,9 +234,6 @@ typedef struct AREQ {
   size_t prefixesOffset;
 
   ProfilePrinterCtx profileCtx;
-
-  // Per-request synchronization slot (timeout flag + abort-wake channel).
-  RequestSyncState syncState;
 
   // Non-owning back-pointer to the heap wrapper that owns this request.
   // Set for the top-level request; NULL for hybrid sub-AREQs.
@@ -686,23 +619,18 @@ void SetSearchCtx(RedisSearchCtx *sctx, const AREQ *req);
 int parseProfileArgs(RedisModuleString **argv, int argc, AREQ *r);
 
 static inline bool AREQ_TimedOut(AREQ *req) {
-  return RequestSyncState_GetTimedOut(&req->syncState);
+  return QueryRequestTimeout_GetTimedOut(&req->base.timeout);
 }
 static inline void AREQ_SetTimedOut(AREQ *req) {
   QueryRequestTimeout_SetTimedOut(&req->base.timeout);
-  // TODO($$$): Remove the legacy timeout state once consumers use QueryRequest.timeout.
-  RequestSyncState_SetTimedOut(&req->syncState);
 }
 // The pipeline stage the request had reached, used to attribute a timeout.
 static inline QueryTimeoutStage AREQ_ExecutionStage(AREQ *req) {
-  return RequestSyncState_GetExecutionStage(&req->syncState);
+  return (QueryTimeoutStage)QueryRequest_GetExecutionPhase(&req->base);
 }
 // Advance the request's execution-phase marker (QUEUE -> PIPELINE -> REPLY).
 static inline void AREQ_SetExecutionStage(AREQ *req, QueryTimeoutStage stage) {
-  // TODO($$$): Remove the legacy execution phase once consumers use QueryRequest.async.
-  RequestSyncState_SetExecutionStage(&req->syncState, stage);
-  QueryRequestAsyncState_SetExecutionPhase(
-      &req->base.async, RequestSyncState_GetExecutionStage(&req->syncState));
+  QueryRequest_SetExecutionPhase(&req->base, (int)stage);
 }
 #ifdef ENABLE_ASSERT
 // SyncPointStopFn predicate adapter for AREQ_TimedOut. Pass the AREQ as `arg`
@@ -765,20 +693,13 @@ bool BlockedRequestCtx_TimeoutPreemptSafeLoaderGIL(BlockedRequestCtx *sync);
  *   - brc->aggregatingResults (CAS claim)
  *   - brc->aggregateResultsDone (signal latch)
  *   - brc->safeLoadersHoldingGIL (GIL-handshake latch)
- *   - syncState.timedOut (timer latch from the previous chunk's timer)
+ *   - base.timeout.timedOut (timer latch from the previous chunk's timer)
  *   - RPNet::drainOnly on the root proc when it is RP_NETWORK (so the next
  *     read does not short-circuit to EOF on the first empty-channel observation).
  * Caller MUST hold the per-request setRequestLock so the timer cannot publish a
  * fresh TimedOut between the reset and SetRequest. Does NOT reset
  * RPSorter::base.Next: the Yield latch is load-bearing across reads. */
 void AREQ_ResetForCursorReadReturnStrict(AREQ *req);
-
-/* Abort-wake registration (single-slot). BG reader registers its blocking channel
- * before reading; timeout callback flips `timedOut` then broadcasts to wake it.
- * Operates on the embedded RequestSyncState so AREQ and HybridRequest can share. */
-void RequestSyncState_RegisterAbortWakeChannel(RequestSyncState *st, struct MRChannel *chan);
-void RequestSyncState_UnregisterAbortWakeChannel(RequestSyncState *st);
-void RequestSyncState_WakeAbortChannel(RequestSyncState *st);
 
 static inline bool AREQ_ShouldCheckTimeout(AREQ *req) {
   return !req->skipTimeoutChecks;

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -206,9 +206,6 @@ typedef struct AREQ {
   size_t maxSearchResults;
   size_t maxAggregateResults;
 
-  // Cursor id, if this is a cursor
-  uint64_t cursor_id;
-
   // Profiling function
   profiler_func profile;
 

--- a/src/aggregate/aggregate_debug.c
+++ b/src/aggregate/aggregate_debug.c
@@ -39,6 +39,7 @@ AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *statu
   }
 
   AREQ_Debug *debug_req = rm_realloc(AREQ_New(), sizeof(*debug_req));
+  QueryRequest_SetEndProcRef(&debug_req->r.base, &debug_req->r.pipeline.qctx.endProc);
 
   // Own a copy of the debug argv tail. The request may execute on a worker
   // thread (WORKERS > 0, always the case on flex), where parseAndCompileDebug

--- a/src/aggregate/aggregate_debug.c
+++ b/src/aggregate/aggregate_debug.c
@@ -38,7 +38,7 @@ AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *statu
     return NULL;
   }
 
-  AREQ_Debug *debug_req = rm_realloc(AREQ_New(), sizeof(*debug_req));
+  AREQ_Debug *debug_req = rm_realloc(AREQ_New(argv, argc), sizeof(*debug_req));
   QueryRequest_SetEndProcRef(&debug_req->r.base, &debug_req->r.pipeline.qctx.endProc);
 
   // Own a copy of the debug argv tail. The request may execute on a worker
@@ -57,10 +57,8 @@ AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *statu
   AREQ *r = &debug_req->r;
   // Holds the full argv; `parseArgc` excludes the debug tail so parsing stops
   // before it. Must be called after rm_realloc so r points to stable memory.
-  BlockedRequestCtx_NewAREQ(r, argv, argc);
-  // TODO($$$): Remove the legacy parse argc once consumers use QueryRequest.
-  r->brc->parseArgc = (uint32_t)(argc - debug_argv_count);
-  r->base.args.parseArgc = r->brc->parseArgc;
+  BlockedRequestCtx_NewAREQ(r);
+  r->base.args.parseArgc = (uint32_t)(argc - debug_argv_count);
   AREQ_AddRequestFlags(r, QEXEC_F_DEBUG);
 
   return debug_req;

--- a/src/aggregate/aggregate_debug.c
+++ b/src/aggregate/aggregate_debug.c
@@ -58,7 +58,9 @@ AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *statu
   // Holds the full argv; `parseArgc` excludes the debug tail so parsing stops
   // before it. Must be called after rm_realloc so r points to stable memory.
   BlockedRequestCtx_NewAREQ(r, argv, argc);
+  // TODO($$$): Remove the legacy parse argc once consumers use QueryRequest.
   r->brc->parseArgc = (uint32_t)(argc - debug_argv_count);
+  r->base.args.parseArgc = r->brc->parseArgc;
   AREQ_AddRequestFlags(r, QEXEC_F_DEBUG);
 
   return debug_req;

--- a/src/aggregate/aggregate_debug.c
+++ b/src/aggregate/aggregate_debug.c
@@ -57,7 +57,6 @@ AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *statu
   AREQ *r = &debug_req->r;
   // Holds the full argv; `parseArgc` excludes the debug tail so parsing stops
   // before it. Must be called after rm_realloc so r points to stable memory.
-  BlockedRequestCtx_NewAREQ(r);
   r->base.args.parseArgc = (uint32_t)(argc - debug_argv_count);
   AREQ_AddRequestFlags(r, QEXEC_F_DEBUG);
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -812,7 +812,7 @@ static void sendChunk_Resp2(AREQ *req, RedisModule_Reply *reply, size_t limit,
 
     startPipeline(req, rp, &state.results, &r, &rc);
 
-    if (req->useReplyCallback) {
+    if (QueryRequest_UsesReplyCallback(&req->base)) {
       if (req->brc->aggregateResultsClaimLost) {
         SearchResult_Destroy(&r);
         return;
@@ -1034,7 +1034,7 @@ static void sendChunk_Resp3(AREQ *req, RedisModule_Reply *reply, size_t limit,
 
     startPipeline(req, rp, &state.results, &r, &rc);
 
-    if (req->useReplyCallback) {
+    if (QueryRequest_UsesReplyCallback(&req->base)) {
       if (req->brc->aggregateResultsClaimLost) {
         SearchResult_Destroy(&r);
         return;
@@ -1288,7 +1288,7 @@ static void blockedClientReqCtx_destroy(blockedClientReqCtx *BCRctx) {
 // For FAIL policy (useReplyCallback=true): stores error for QueryReplyCallback to handle.
 // For RETURN policy: replies with error directly.
 void AREQ_ReplyOrStoreError(AREQ *req, RedisModuleCtx *ctx, QueryError *status) {
-  if (req->useReplyCallback) {
+  if (QueryRequest_UsesReplyCallback(&req->base)) {
     // Clear destination before cloning to avoid leaking any existing error strings.
     // Deep copy since QueryError contains heap-allocated strings.
     // QueryReplyCallback will clear the stored error after replying.
@@ -2002,8 +2002,6 @@ static int buildPipelineAndExecute(AREQ *r, RedisModuleCtx *ctx, QueryError *sta
       replyCallback = QueryReplyCallback;
       timeoutMS = r->reqConfig.queryTimeoutMS;
       QueryRequest_SetUseReplyCallback(&r->base, true);
-      // TODO($$$): Remove the legacy field once consumers use QueryRequest.
-      r->useReplyCallback = true;
     }
 
     RedisModuleBlockedClient* blockedClient = BlockQueryClientWithTimeout(
@@ -2223,7 +2221,7 @@ static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num) {
   // Skip when useReplyCallback is set (FAIL or RETURN_STRICT): the deadline is owned by
   // the blocked-client timer, armed by buildPipelineAndExecute (initial
   // WITHCURSOR) or CursorCommand (subsequent READ).
-  if (!req->useReplyCallback) {
+  if (!QueryRequest_UsesReplyCallback(&req->base)) {
     SearchCtx_UpdateTime(AREQ_SearchCtx(req), req->reqConfig.queryTimeoutMS);
   }
 
@@ -2244,7 +2242,7 @@ static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num) {
                       areq_timed_out, req);
 #endif
 
-  if (req->useReplyCallback) {
+  if (QueryRequest_UsesReplyCallback(&req->base)) {
     // Stash the cursor BEFORE sendChunk: sendChunk's signal can wake the
     // timeout_callback, which reads brc->reply.cursor to pause/free it.
     req->base.reply.cursor = cursor;
@@ -2258,7 +2256,7 @@ static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num) {
   // handed off, so the lock must be released here, on this worker thread.
   RedisSearchCtx_AssertLockNotHeld(AREQ_SearchCtx(req));
 
-  if (req->useReplyCallback) {
+  if (QueryRequest_UsesReplyCallback(&req->base)) {
     if (req->brc->aggregateResultsClaimLost) {
       // The strict timeout callback won the sync claim and already replied with
       // cursor 0. Keep cursor ownership consistent with the depleted id already
@@ -2325,7 +2323,7 @@ static void cursorRead(RedisModuleCtx *ctx, Cursor *cursor, size_t count, bool b
       QueryError_SetWithoutUserDataFmt(&status, QUERY_ERROR_CODE_DROPPED_BACKGROUND,
                                        "The index was dropped while the cursor was idle");
       // Reply before disposing: the cursor may hold the only wrapper ref, so
-      // freeing first would UAF the req->useReplyCallback read inside
+      // freeing first would UAF the QueryRequest reply-mode read inside
       // AREQ_ReplyOrStoreError.
       AREQ_ReplyOrStoreError(req, ctx, &status);
       cursorEndOfCycle(req, cursor, true);
@@ -2452,8 +2450,6 @@ static int cursorReadDispatchTaken(RedisModuleCtx *ctx, Cursor *cursor, long lon
   // Deferred (callback) reply iff a reply callback will serialize stored
   // results on main; RETURN replies inline from the BG job.
   QueryRequest_SetUseReplyCallback(&req->base, reply_cb != NULL);
-  // TODO($$$): Remove the legacy field once consumers use QueryRequest.
-  req->useReplyCallback = (reply_cb != NULL);
   RedisModuleBlockedClient *bc =
       RedisModule_BlockClient(ctx, reply_cb, timeout_cb, BlockedRequestCtx_OnFree, timeout_ms);
   // Safe against the just-armed timer: the timeout callback runs on this same
@@ -2613,14 +2609,10 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
                                                            : CursorReadTimeoutReturnStrictCallback;
       timeoutMS = (rs_wall_clock_ms_t)cursor->queryTimeoutMS;
       QueryRequest_SetUseReplyCallback(&req->base, true);
-      // TODO($$$): Remove the legacy field once consumers use QueryRequest.
-      req->useReplyCallback = true;
     } else {
       // RETURN: reply written inline; clear any stale useReplyCallback
       // from a prior callback-based cursor read so runCursor doesn't park the cursor.
       QueryRequest_SetUseReplyCallback(&req->base, false);
-      // TODO($$$): Remove the legacy field once consumers use QueryRequest.
-      req->useReplyCallback = false;
     }
     CursorReadCtx *cr_ctx = rm_new(CursorReadCtx);
     cr_ctx->bc = BlockCursorClientWithTimeout(ctx, cursor, count, req->brc, replyCallback,
@@ -2649,8 +2641,6 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     if (inline_req) {
       // Reply inline via ctx; clear stale useReplyCallback.
       QueryRequest_SetUseReplyCallback(&inline_req->base, false);
-      // TODO($$$): Remove the legacy field once consumers use QueryRequest.
-      inline_req->useReplyCallback = false;
     }
     cursorRead(ctx, cursor, count, false);
   }

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -461,11 +461,11 @@ static void startPipeline(AREQ *req, ResultProcessor *rp, SearchResult ***result
 /**
  * Store pipeline results for reply_callback path.
  * Called after startPipeline when using reply_callback mode (FAIL policy with workers).
- * Stores results in req->brc->reply so serializeAndReplyResults can be called
+ * Stores results in req->base.reply so serializeAndReplyResults can be called
  * from the reply_callback on the main thread.
  *
  * @param req The aggregate request
- * @param results Pipeline results (ownership transferred to brc->reply)
+ * @param results Pipeline results (ownership transferred to req->base.reply)
  * @param rc Pipeline return code
  * @param cv Cached variables for result serialization
  * @param limit Original limit passed to sendChunk (for RESP2 resultsLen calculation)
@@ -479,20 +479,10 @@ static void AREQ_StoreResults(AREQ *req, SearchResult **results, int rc, cachedV
   req->base.reply.limit = limit;
   req->base.reply.hasStoredResults = true;
 
-  // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
-  req->brc->reply.results = results;
-  req->brc->reply.rc = rc;
-  req->brc->reply.cv = cv;
-  req->brc->reply.limit = limit;
-  req->brc->reply.hasStoredResults = true;
-
   // Deep copy error state since qctx->err points to a local variable in the caller
   // which will go out of scope. QueryError contains heap-allocated strings.
   QueryError_ClearError(&req->base.reply.err);
   QueryError_CloneFrom(qctx->err, &req->base.reply.err);
-  // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
-  QueryError_ClearError(&req->brc->reply.err);
-  QueryError_CloneFrom(qctx->err, &req->brc->reply.err);
   QueryError_ClearError(qctx->err);
 }
 
@@ -1292,9 +1282,6 @@ void AREQ_ReplyOrStoreError(AREQ *req, RedisModuleCtx *ctx, QueryError *status) 
     // QueryReplyCallback will clear the stored error after replying.
     QueryError_ClearError(&req->base.reply.err);
     QueryError_CloneFrom(status, &req->base.reply.err);
-    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
-    QueryError_ClearError(&req->brc->reply.err);
-    QueryError_CloneFrom(status, &req->brc->reply.err);
     // Clear the original to avoid leaking heap-allocated strings.
     QueryError_ClearError(status);
     // Defensive: wake any RETURN_STRICT timer waiting on aggregateResultsDone.
@@ -1672,7 +1659,7 @@ void AREQ_SetCanYieldPartialResults(AREQ *req) {
       pipelineCanYieldPartialResults(req);
 }
 
-// Drain any queued partial results into `brc->reply.results` on the main
+// Drain any queued partial results into `base.reply.results` on the main
 // thread after the background pipeline has aborted. Shard pipelines need no
 // root-specific pre-drain setup (unlike the coordinator's RPNet drainOnly
 // flip), so this just gates and delegates the actual loop to the shared helper.
@@ -1728,11 +1715,9 @@ static int QueryTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleStri
   AREQ_WaitForAggregateResultsComplete(req);
 
   // BG signals only after AREQ_StoreResults
-  RS_ASSERT(req->brc->reply.hasStoredResults);
+  RS_ASSERT(req->base.reply.hasStoredResults);
   if (AREQ_RequestFlags(req) & QEXEC_F_IS_CURSOR) {
     req->base.reply.rc = RS_RESULT_TIMEDOUT;
-    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
-    req->brc->reply.rc = RS_RESULT_TIMEDOUT;
   }
 
   // Drain any results buffered post-timeout (e.g. RPSorter heap).
@@ -1749,7 +1734,7 @@ void AREQ_ReplyWithStoredResults(RedisModuleCtx *ctx, AREQ *req) {
   // Use stored state directly - no need to recompute cv, it was stored by AREQ_StoreResults
   QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(req);
   ResultProcessor *rp = qctx->endProc;
-  ChunkReplyState *stored = &req->brc->reply;
+  ChunkReplyState *stored = &req->base.reply;
 
   // Point qctx->err to the stored error so serializeAndReplyResults/finishSendChunk can access it.
   // This is the end of the request lifecycle, so no need to restore.
@@ -1779,9 +1764,6 @@ void AREQ_ReplyWithStoredResults(RedisModuleCtx *ctx, AREQ *req) {
   RedisModule_EndReply(reply);
 
   // Clear stored results pointer since ownership was transferred to state
-  req->base.reply.results = NULL;
-  req->base.reply.hasStoredResults = false;
-  // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
   stored->results = NULL;
   stored->hasStoredResults = false;
 
@@ -1795,15 +1777,13 @@ void AREQ_ReplyWithStoredResults(RedisModuleCtx *ctx, AREQ *req) {
   // inline callers execute it immediately.
   if (stored->cursor) {
     cursorEndOfCycle(req, stored->cursor, req->stateflags & QEXEC_S_ITERDONE);
-    req->base.reply.cursor = NULL;
-    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
     stored->cursor = NULL;
   }
 }
 
 // Reply callback for AREQ execution in Run in Threads mode (FAIL policy).
 // Called on the main thread when the background thread calls UnblockClient.
-// The background thread stored results in req->brc->reply, which we use to build the reply.
+// The background thread stored results in req->base.reply, which we use to build the reply.
 // Note: This callback is NOT called if timeout fired first (bc->client becomes NULL).
 // Reference counting: the cycle holds a wrapper reference released via BlockedRequestCtx_OnFree
 // after this callback.
@@ -1819,12 +1799,12 @@ static int QueryReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int
   AREQ *req = BlockedRequestCtx_GetAREQ(brc);
 
   // Check if results were stored (background thread completed successfully)
-  if (!req->brc->reply.hasStoredResults) {
+  if (!req->base.reply.hasStoredResults) {
     // Background thread didn't store results - some early error occurred.
     // Use the stored error if available, otherwise generic error.
-    if (QueryError_HasError(&req->brc->reply.err)) {
-      QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&req->brc->reply.err), 1, !IsInternal(req));
-      QueryError_ReplyAndClear(ctx, &req->brc->reply.err);
+    if (QueryError_HasError(&req->base.reply.err)) {
+      QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&req->base.reply.err), 1, !IsInternal(req));
+      QueryError_ReplyAndClear(ctx, &req->base.reply.err);
     } else {
       RedisModule_ReplyWithError(ctx, "ERR Internal error: no results stored");
     }
@@ -1893,15 +1873,13 @@ static int CursorReadTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModul
   // cursor-shaped reply and park/free the cursor before replying.
   AREQ_WaitForAggregateResultsComplete(req);
 
-  if (req->brc->reply.hasStoredResults) {
+  if (req->base.reply.hasStoredResults) {
     req->base.reply.rc = RS_RESULT_TIMEDOUT;
-    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
-    req->brc->reply.rc = RS_RESULT_TIMEDOUT;
     drainPartialResultsAfterTimeout(req);
     AREQ_ReplyWithStoredResults(ctx, req);
-  } else if (QueryError_HasError(&req->brc->reply.err)) {
-    QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&req->brc->reply.err), 1, !IsInternal(req));
-    QueryError_ReplyAndClear(ctx, &req->brc->reply.err);
+  } else if (QueryError_HasError(&req->base.reply.err)) {
+    QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&req->base.reply.err), 1, !IsInternal(req));
+    QueryError_ReplyAndClear(ctx, &req->base.reply.err);
   } else {
     RedisModule_ReplyWithError(ctx, "ERR Internal error: no results stored");
   }
@@ -1923,11 +1901,11 @@ static int CursorReadReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv
 
   AREQ *req = BlockedRequestCtx_GetAREQ(brc);
 
-  if (!req->brc->reply.hasStoredResults) {
+  if (!req->base.reply.hasStoredResults) {
     // Background thread didn't store results - some early error occurred.
-    if (QueryError_HasError(&req->brc->reply.err)) {
-      QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&req->brc->reply.err), 1, !IsInternal(req));
-      QueryError_ReplyAndClear(ctx, &req->brc->reply.err);
+    if (QueryError_HasError(&req->base.reply.err)) {
+      QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&req->base.reply.err), 1, !IsInternal(req));
+      QueryError_ReplyAndClear(ctx, &req->base.reply.err);
     } else {
       RedisModule_ReplyWithError(ctx, "ERR Internal error: no results stored");
     }
@@ -2240,10 +2218,8 @@ static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num) {
 
   if (QueryRequest_UsesReplyCallback(&req->base)) {
     // Stash the cursor BEFORE sendChunk: sendChunk's signal can wake the
-    // timeout_callback, which reads brc->reply.cursor to pause/free it.
+    // timeout_callback, which reads req->base.reply.cursor to pause/free it.
     req->base.reply.cursor = cursor;
-    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
-    req->brc->reply.cursor = cursor;
   }
 
   sendChunk(req, reply, num);
@@ -2258,8 +2234,6 @@ static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num) {
       // cursor 0. Keep cursor ownership consistent with the depleted id already
       // returned to the caller.
       req->base.reply.cursor = NULL;
-      // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
-      req->brc->reply.cursor = NULL;
       cursorEndOfCycle(req, cursor,
                        (AREQ_RequestFlags(req) & QEXEC_F_IS_AGGREGATE) ||
                            shouldSetCursorDone(req, RS_RESULT_TIMEDOUT));

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -473,7 +473,13 @@ static void startPipeline(AREQ *req, ResultProcessor *rp, SearchResult ***result
 static void AREQ_StoreResults(AREQ *req, SearchResult **results, int rc, cachedVars cv, size_t limit) {
   QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(req);
 
-  // Store results in AREQ for reply_callback to use
+  req->base.reply.results = results;
+  req->base.reply.rc = rc;
+  req->base.reply.cv = cv;
+  req->base.reply.limit = limit;
+  req->base.reply.hasStoredResults = true;
+
+  // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
   req->brc->reply.results = results;
   req->brc->reply.rc = rc;
   req->brc->reply.cv = cv;
@@ -482,6 +488,9 @@ static void AREQ_StoreResults(AREQ *req, SearchResult **results, int rc, cachedV
 
   // Deep copy error state since qctx->err points to a local variable in the caller
   // which will go out of scope. QueryError contains heap-allocated strings.
+  QueryError_ClearError(&req->base.reply.err);
+  QueryError_CloneFrom(qctx->err, &req->base.reply.err);
+  // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
   QueryError_ClearError(&req->brc->reply.err);
   QueryError_CloneFrom(qctx->err, &req->brc->reply.err);
   QueryError_ClearError(qctx->err);
@@ -1279,6 +1288,9 @@ void AREQ_ReplyOrStoreError(AREQ *req, RedisModuleCtx *ctx, QueryError *status) 
     // Clear destination before cloning to avoid leaking any existing error strings.
     // Deep copy since QueryError contains heap-allocated strings.
     // QueryReplyCallback will clear the stored error after replying.
+    QueryError_ClearError(&req->base.reply.err);
+    QueryError_CloneFrom(status, &req->base.reply.err);
+    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
     QueryError_ClearError(&req->brc->reply.err);
     QueryError_CloneFrom(status, &req->brc->reply.err);
     // Clear the original to avoid leaking heap-allocated strings.
@@ -1715,6 +1727,8 @@ static int QueryTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleStri
   // BG signals only after AREQ_StoreResults
   RS_ASSERT(req->brc->reply.hasStoredResults);
   if (AREQ_RequestFlags(req) & QEXEC_F_IS_CURSOR) {
+    req->base.reply.rc = RS_RESULT_TIMEDOUT;
+    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
     req->brc->reply.rc = RS_RESULT_TIMEDOUT;
   }
 
@@ -1762,6 +1776,9 @@ void AREQ_ReplyWithStoredResults(RedisModuleCtx *ctx, AREQ *req) {
   RedisModule_EndReply(reply);
 
   // Clear stored results pointer since ownership was transferred to state
+  req->base.reply.results = NULL;
+  req->base.reply.hasStoredResults = false;
+  // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
   stored->results = NULL;
   stored->hasStoredResults = false;
 
@@ -1775,6 +1792,8 @@ void AREQ_ReplyWithStoredResults(RedisModuleCtx *ctx, AREQ *req) {
   // inline callers execute it immediately.
   if (stored->cursor) {
     cursorEndOfCycle(req, stored->cursor, req->stateflags & QEXEC_S_ITERDONE);
+    req->base.reply.cursor = NULL;
+    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
     stored->cursor = NULL;
   }
 }
@@ -1872,6 +1891,8 @@ static int CursorReadTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModul
   AREQ_WaitForAggregateResultsComplete(req);
 
   if (req->brc->reply.hasStoredResults) {
+    req->base.reply.rc = RS_RESULT_TIMEDOUT;
+    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
     req->brc->reply.rc = RS_RESULT_TIMEDOUT;
     drainPartialResultsAfterTimeout(req);
     AREQ_ReplyWithStoredResults(ctx, req);
@@ -2213,6 +2234,8 @@ static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num) {
   if (req->useReplyCallback) {
     // Stash the cursor BEFORE sendChunk: sendChunk's signal can wake the
     // timeout_callback, which reads brc->reply.cursor to pause/free it.
+    req->base.reply.cursor = cursor;
+    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
     req->brc->reply.cursor = cursor;
   }
 
@@ -2227,6 +2250,8 @@ static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num) {
       // The strict timeout callback won the sync claim and already replied with
       // cursor 0. Keep cursor ownership consistent with the depleted id already
       // returned to the caller.
+      req->base.reply.cursor = NULL;
+      // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
       req->brc->reply.cursor = NULL;
       cursorEndOfCycle(req, cursor,
                        (AREQ_RequestFlags(req) & QEXEC_F_IS_AGGREGATE) ||

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -2170,9 +2170,6 @@ static void cursorEndOfCycle(AREQ *req, Cursor *cursor, bool free_it) {
     req->base.cursorInfo.cursor = cursor;
     req->base.cursorInfo.disposition =
         free_it ? CURSOR_DISPOSITION_FREE : CURSOR_DISPOSITION_PAUSE;
-    // TODO($$$): Remove the legacy cursor disposition once consumers use QueryRequest.cursorInfo.
-    req->brc->cursor = cursor;
-    req->brc->cursor_dispose_free = free_it;
   } else if (free_it) {
     Cursor_Free(cursor);
   } else {

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -2001,6 +2001,8 @@ static int buildPipelineAndExecute(AREQ *r, RedisModuleCtx *ctx, QueryError *sta
       }
       replyCallback = QueryReplyCallback;
       timeoutMS = r->reqConfig.queryTimeoutMS;
+      QueryRequest_SetUseReplyCallback(&r->base, true);
+      // TODO($$$): Remove the legacy field once consumers use QueryRequest.
       r->useReplyCallback = true;
     }
 
@@ -2449,6 +2451,8 @@ static int cursorReadDispatchTaken(RedisModuleCtx *ctx, Cursor *cursor, long lon
   RS_ASSERT(timeout_ms == 0 || (timeout_cb != NULL && reply_cb != NULL));
   // Deferred (callback) reply iff a reply callback will serialize stored
   // results on main; RETURN replies inline from the BG job.
+  QueryRequest_SetUseReplyCallback(&req->base, reply_cb != NULL);
+  // TODO($$$): Remove the legacy field once consumers use QueryRequest.
   req->useReplyCallback = (reply_cb != NULL);
   RedisModuleBlockedClient *bc =
       RedisModule_BlockClient(ctx, reply_cb, timeout_cb, BlockedRequestCtx_OnFree, timeout_ms);
@@ -2608,10 +2612,14 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
           cursor->queryTimeoutPolicy == TimeoutPolicy_Fail ? CursorReadTimeoutFailCallback
                                                            : CursorReadTimeoutReturnStrictCallback;
       timeoutMS = (rs_wall_clock_ms_t)cursor->queryTimeoutMS;
+      QueryRequest_SetUseReplyCallback(&req->base, true);
+      // TODO($$$): Remove the legacy field once consumers use QueryRequest.
       req->useReplyCallback = true;
     } else {
       // RETURN: reply written inline; clear any stale useReplyCallback
       // from a prior callback-based cursor read so runCursor doesn't park the cursor.
+      QueryRequest_SetUseReplyCallback(&req->base, false);
+      // TODO($$$): Remove the legacy field once consumers use QueryRequest.
       req->useReplyCallback = false;
     }
     CursorReadCtx *cr_ctx = rm_new(CursorReadCtx);
@@ -2640,6 +2648,8 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     AREQ *inline_req = Cursor_AREQ(cursor);
     if (inline_req) {
       // Reply inline via ctx; clear stale useReplyCallback.
+      QueryRequest_SetUseReplyCallback(&inline_req->base, false);
+      // TODO($$$): Remove the legacy field once consumers use QueryRequest.
       inline_req->useReplyCallback = false;
     }
     cursorRead(ctx, cursor, count, false);

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -445,7 +445,7 @@ static void startPipeline(AREQ *req, ResultProcessor *rp, SearchResult ***result
     }
     // We own the production phase: link the sync context into the safe loaders so
     // they perform the GIL deadlock-avoidance handshake with the timeout callback.
-    RPSafeLoader_SetSyncCtx(AREQ_QueryProcessingCtx(req), req->brc);
+    RPSafeLoader_SetSyncCtx(AREQ_QueryProcessingCtx(req), &req->base);
   }
 
   startPipelineCommon(&ctx, rp, results, r, rc);
@@ -1637,12 +1637,12 @@ static int QueryTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **arg
   UNUSED(argv);
   UNUSED(argc);
 
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
   // Installed by BeginCycle on the main thread before the command returned,
   // so no callback can observe missing privdata.
-  RS_ASSERT(brc != NULL);
+  RS_ASSERT(request != NULL);
 
-  AREQ *req = BlockedRequestCtx_GetAREQ(brc);
+  AREQ *req = QueryRequest_GetAREQ(request);
   // Signal timeout to background thread (will notice and skip storing results)
   AREQ_SetTimedOut(req);
   recordAREQTimeoutStage(req, /*isError=*/true);
@@ -1684,12 +1684,12 @@ static void drainPartialResultsAfterTimeout(AREQ *req) {
 //   - Otherwise BG owns the buffer; wait for it to finish AREQ_StoreResults,
 //     then drain anything still buffered (RPSorter heap) and reply.
 static int QueryTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
   // Installed by BeginCycle on the main thread before the command returned,
   // so no callback can observe missing privdata.
-  RS_ASSERT(brc != NULL);
+  RS_ASSERT(request != NULL);
 
-  AREQ *req = BlockedRequestCtx_GetAREQ(brc);
+  AREQ *req = QueryRequest_GetAREQ(request);
 
   // Signal timeout to background thread
   AREQ_SetTimedOut(req);
@@ -1706,7 +1706,7 @@ static int QueryTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleStri
   // Deadlock avoidance: if the BG worker is parked at the safe-loader GIL gate,
   // Wait would deadlock (it needs the GIL we hold). Preempt it and reply empty;
   // the worker finishes once we release the GIL. See aggregate.h.
-  if (BlockedRequestCtx_TimeoutPreemptSafeLoaderGIL(req->brc)) {
+  if (QueryRequest_TimeoutPreemptSafeLoaderGIL(&req->base)) {
     single_shard_common_query_reply_empty(ctx, argv, argc, 0, QUERY_ERROR_CODE_TIMED_OUT);
     return REDISMODULE_OK;
   }
@@ -1785,18 +1785,18 @@ void AREQ_ReplyWithStoredResults(RedisModuleCtx *ctx, AREQ *req) {
 // Called on the main thread when the background thread calls UnblockClient.
 // The background thread stored results in req->base.reply, which we use to build the reply.
 // Note: This callback is NOT called if timeout fired first (bc->client becomes NULL).
-// Reference counting: the cycle holds a wrapper reference released via BlockedRequestCtx_OnFree
+// Reference counting: the cycle holds a request reference released via QueryRequest_OnFree
 // after this callback.
 static int QueryReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   UNUSED(argv);
   UNUSED(argc);
 
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
   // Installed by BeginCycle on the main thread before the command returned,
   // so no callback can observe missing privdata.
-  RS_ASSERT(brc != NULL);
+  RS_ASSERT(request != NULL);
 
-  AREQ *req = BlockedRequestCtx_GetAREQ(brc);
+  AREQ *req = QueryRequest_GetAREQ(request);
 
   // Check if results were stored (background thread completed successfully)
   if (!req->base.reply.hasStoredResults) {
@@ -1813,8 +1813,7 @@ static int QueryReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int
 
   AREQ_ReplyWithStoredResults(ctx, req);
 
-  // No AREQ_DecrRef here - the cycle holds the wrapper reference, released via
-  // BlockedRequestCtx_OnFree.
+  // No AREQ_DecrRef here - QueryRequest_OnFree releases the cycle's reference.
   return REDISMODULE_OK;
 }
 
@@ -1825,12 +1824,12 @@ static int CursorReadTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString 
   UNUSED(argv);
   UNUSED(argc);
 
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
   // Installed by BeginCycle on the main thread before the command returned,
   // so no callback can observe missing privdata.
-  RS_ASSERT(brc != NULL);
+  RS_ASSERT(request != NULL);
 
-  AREQ *req = BlockedRequestCtx_GetAREQ(brc);
+  AREQ *req = QueryRequest_GetAREQ(request);
   // Signal timeout to background thread so it skips storing results.
   AREQ_SetTimedOut(req);
   recordAREQTimeoutStage(req, /*isError=*/true);
@@ -1846,12 +1845,12 @@ static int CursorReadTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModul
   UNUSED(argv);
   UNUSED(argc);
 
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
   // Installed by BeginCycle on the main thread before the command returned,
   // so no callback can observe missing privdata.
-  RS_ASSERT(brc != NULL);
+  RS_ASSERT(request != NULL);
 
-  AREQ *req = BlockedRequestCtx_GetAREQ(brc);
+  AREQ *req = QueryRequest_GetAREQ(request);
   AREQ_SetTimedOut(req);
   recordAREQTimeoutStage(req, /*isError=*/false);
 
@@ -1865,7 +1864,7 @@ static int CursorReadTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModul
   // Deadlock avoidance: if the BG worker is parked at the safe-loader GIL gate,
   // Wait would deadlock (it needs the GIL we hold). Preempt it and reply with an
   // exhausted cursor (id 0); the worker finishes once we release the GIL.
-  if (BlockedRequestCtx_TimeoutPreemptSafeLoaderGIL(req->brc)) {
+  if (QueryRequest_TimeoutPreemptSafeLoaderGIL(&req->base)) {
     return cursor_read_empty_reply_timeout(ctx, 0, IsInternal(req));
   }
 
@@ -1888,18 +1887,18 @@ static int CursorReadTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModul
 
 // Shard FT.CURSOR READ FAIL-path reply callback.
 // Mirrors QueryReplyCallback. Not invoked if the timeout fired first.
-// The cycle's wrapper reference is released by BlockedRequestCtx_OnFree after this callback.
+// QueryRequest_OnFree releases the cycle's request reference after this callback.
 // Can be consolidated with QueryReplyCallback - See MOD-15038.
 static int CursorReadReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   UNUSED(argv);
   UNUSED(argc);
 
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
   // Installed by BeginCycle on the main thread before the command returned,
   // so no callback can observe missing privdata.
-  RS_ASSERT(brc != NULL);
+  RS_ASSERT(request != NULL);
 
-  AREQ *req = BlockedRequestCtx_GetAREQ(brc);
+  AREQ *req = QueryRequest_GetAREQ(request);
 
   if (!req->base.reply.hasStoredResults) {
     // Background thread didn't store results - some early error occurred.
@@ -1979,7 +1978,7 @@ static int buildPipelineAndExecute(AREQ *r, RedisModuleCtx *ctx, QueryError *sta
     }
 
     RedisModuleBlockedClient* blockedClient = BlockQueryClientWithTimeout(
-        ctx, spec_ref, r->brc, replyCallback, timeoutCallback, timeoutMS);
+        ctx, spec_ref, &r->base, replyCallback, timeoutCallback, timeoutMS);
     blockedClientReqCtx *BCRctx = blockedClientReqCtx_New(r, blockedClient, spec_ref);
     // Mark the request as thread safe, so that the pipeline will be built in a thread safe manner
     AREQ_AddRequestFlags(r, QEXEC_F_RUN_IN_BACKGROUND);
@@ -2081,7 +2080,6 @@ int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
   }
 
   AREQ *r = AREQ_New(argv, argc);
-  BlockedRequestCtx_NewAREQ(r);
 
   if (prepareRequest(&r, ctx, type, profileOptions, &status) != REDISMODULE_OK) {
     RS_ASSERT(r == NULL);
@@ -2120,7 +2118,6 @@ int RSExecuteAggregateOrSearch(RedisModuleCtx *ctx, RedisModuleString **argv, in
 char *RS_GetExplainOutput(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                           QueryError *status) {
   AREQ *r = AREQ_New(argv, argc);
-  BlockedRequestCtx_NewAREQ(r);
   if (buildRequest(ctx, COMMAND_EXPLAIN, status, &r) != REDISMODULE_OK) {
     return NULL;
   }
@@ -2145,7 +2142,7 @@ int AREQ_StartCursor(AREQ *r, RedisModule_Reply *reply, StrongRef spec_ref, Quer
   if (cursor == NULL) {
     return REDISMODULE_ERR;
   }
-  cursor->query = r->brc;
+  cursor->query = &r->base;
   // Cache timeout config on the Cursor so subsequent FT.CURSOR READs use the
   // values from the originating FT.AGGREGATE, regardless of any later
   // `search-on-timeout` config change. Written before the first Cursor_Pause.
@@ -2161,12 +2158,12 @@ int AREQ_StartCursor(AREQ *r, RedisModule_Reply *reply, StrongRef spec_ref, Quer
 
 /* Dispose of `cursor` at the end of a read/creation cycle: park it back into
  * the idle list, or free it when the query is exhausted / timed out. Inside a
- * blocked-client cycle (brc->bc set) the disposition is only recorded here and
- * executed by BlockedRequestCtx_OnFree on the main thread, so the cursor stays
+ * blocked-client cycle the disposition is only recorded here and executed by
+ * QueryRequest_OnFree on the main thread, so the cursor stays
  * unreachable to other clients until the cycle fully ended. Outside a cycle
  * (inline execution) it executes immediately. */
 static void cursorEndOfCycle(AREQ *req, Cursor *cursor, bool free_it) {
-  if (req->brc->bc) {
+  if (req->base.blockedClientCycleActive) {
     req->base.cursorInfo.cursor = cursor;
     req->base.cursorInfo.disposition =
         free_it ? CURSOR_DISPOSITION_FREE : CURSOR_DISPOSITION_PAUSE;
@@ -2256,9 +2253,9 @@ static QueryProcessingCtx *prepareForCursorRead(Cursor *cursor, bool *hasLoader,
     *initClock = IsProfile(req) || !IsInternal(req);
   } else {
     // Single-cursor hybrid fallback: only reachable via
-    // HybridRequest_StartSingleCursor (no cursor-carried wrapper, hybrid_ref
+    // HybridRequest_StartSingleCursor (no cursor-carried request, hybrid_ref
     // set), i.e. user-facing FT.HYBRID WITHCURSOR — currently not supported.
-    // _FT.HYBRID WITHCURSOR sub-cursors always carry their sub-AREQ's wrapper
+    // _FT.HYBRID WITHCURSOR sub-cursors always carry their sub-AREQ
     // and take the if branch above.
     HybridRequest *hreq = StrongRef_Get(cursor->hybrid_ref);
     *reqFlags = hreq->reqflags;
@@ -2289,7 +2286,7 @@ static void cursorRead(RedisModuleCtx *ctx, Cursor *cursor, size_t count, bool b
     if (!StrongRef_Get(execution_ref)) {
       QueryError_SetWithoutUserDataFmt(&status, QUERY_ERROR_CODE_DROPPED_BACKGROUND,
                                        "The index was dropped while the cursor was idle");
-      // Reply before disposing: the cursor may hold the only wrapper ref, so
+      // Reply before disposing: the cursor may hold the only request ref, so
       // freeing first would UAF the QueryRequest reply-mode read inside
       // AREQ_ReplyOrStoreError.
       AREQ_ReplyOrStoreError(req, ctx, &status);
@@ -2380,7 +2377,7 @@ static void coordCursorRead_ctx(void *p) {
   AREQ_SetExecutionStage(req, QUERY_TIMEOUT_STAGE_PIPELINE);
   // The per-read RETURN_STRICT reset already ran on the main thread at dispatch.
   if (AREQ_RequiresThreadsSyncResults(req) &&
-      !BlockedRequestCtx_TryOwnStrictRead(req->brc, BRC_READ_OWNER_BG)) {
+      !QueryRequest_TryOwnStrictRead(&req->base, QUERY_REQUEST_READ_OWNER_BG)) {
     // RETURN_STRICT: the timeout callback fired before this job was dequeued,
     // won the owner latch, and already replied with a depleted cursor. Free
     // the taken cursor; store nothing (nobody is waiting).
@@ -2402,7 +2399,7 @@ static void coordCursorRead_ctx(void *p) {
   rm_free(cr_ctx);
 }
 
-/* Block the client with the taken cursor's wrapper as privdata and dispatch a
+/* Block the client with the taken cursor's request as private data and dispatch a
  * slim coordCursorRead_ctx job to `poolType`. FAIL/RETURN_STRICT pass
  * reply/timeout callbacks and a timer; RETURN passes none and the BG job
  * replies inline through a thread-safe ctx. */
@@ -2418,11 +2415,11 @@ static int cursorReadDispatchTaken(RedisModuleCtx *ctx, Cursor *cursor, long lon
   // results on main; RETURN replies inline from the BG job.
   QueryRequest_SetUseReplyCallback(&req->base, reply_cb != NULL);
   RedisModuleBlockedClient *bc =
-      RedisModule_BlockClient(ctx, reply_cb, timeout_cb, BlockedRequestCtx_OnFree, timeout_ms);
+      RedisModule_BlockClient(ctx, reply_cb, timeout_cb, QueryRequest_OnFree, timeout_ms);
   // Safe against the just-armed timer: the timeout callback runs on this same
   // thread.
-  BlockedRequestCtx_BeginCycle(req->brc, bc, reply_cb);
-  // Cursor cycles reuse the wrapper across reads: reset the per-read
+  QueryRequest_BeginCycle(&req->base, bc, reply_cb);
+  // Cursor cycles reuse the request across reads: reset the per-read
   // RETURN_STRICT claim/latch state so the new cycle starts from a clean
   // slate — safe because taking the cursor proves the previous read cycle's
   // BG work is done with it.
@@ -2508,8 +2505,8 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
       !(RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_DENY_BLOCKING)) {
     // Coordinator cursor: the read pulls from the shards over the network, so
     // it is always dispatched to the coordinator pool, independent of the
-    // WORKERS config. The cursor always carries its request's wrapper — the
-    // only wrapper-less cursors (single-cursor hybrid) are not user-reachable.
+    // WORKERS config. The cursor always carries its request — the only cursors
+    // without one (single-cursor hybrid) are not user-reachable.
     AREQ *req = Cursor_AREQ(cursor);
     RS_ASSERT(req != NULL);
     // Reused cursor AREQ: a prior read left the marker at PIPELINE/REPLY, so
@@ -2580,7 +2577,7 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
       QueryRequest_SetUseReplyCallback(&req->base, false);
     }
     CursorReadCtx *cr_ctx = rm_new(CursorReadCtx);
-    cr_ctx->bc = BlockCursorClientWithTimeout(ctx, cursor, count, req->brc, replyCallback,
+    cr_ctx->bc = BlockCursorClientWithTimeout(ctx, cursor, count, &req->base, replyCallback,
                                               timeoutCallback, timeoutMS);
     cr_ctx->cursor = cursor;
     cr_ctx->count = count;
@@ -2740,7 +2737,7 @@ int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   debug_params = debug_req->debug_params;
 
   debug_argv_count = debug_params.debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
-  // Parsing stops before the debug params: the constructor set the wrapper's
+  // Parsing stops before the debug params: the constructor set the request's
   // `parseArgc` below the debug tail (the holds still cover the full argv).
 
   if (prepareRequest(&r, ctx, type, profileOptions, &status) != REDISMODULE_OK) {

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -434,8 +434,6 @@ static void startPipeline(AREQ *req, ResultProcessor *rp, SearchResult ***result
       // already owns the reply. The caller must skip stored-result handling and
       // clean up the cursor in runCursor.
       req->base.async.aggregateResultsClaimLost = true;
-      // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-      req->brc->aggregateResultsClaimLost = true;
       *rc = RS_RESULT_TIMEDOUT;
       return;
     }
@@ -813,7 +811,7 @@ static void sendChunk_Resp2(AREQ *req, RedisModule_Reply *reply, size_t limit,
     startPipeline(req, rp, &state.results, &r, &rc);
 
     if (QueryRequest_UsesReplyCallback(&req->base)) {
-      if (req->brc->aggregateResultsClaimLost) {
+      if (req->base.async.aggregateResultsClaimLost) {
         SearchResult_Destroy(&r);
         return;
       }
@@ -1035,7 +1033,7 @@ static void sendChunk_Resp3(AREQ *req, RedisModule_Reply *reply, size_t limit,
     startPipeline(req, rp, &state.results, &r, &rc);
 
     if (QueryRequest_UsesReplyCallback(&req->base)) {
-      if (req->brc->aggregateResultsClaimLost) {
+      if (req->base.async.aggregateResultsClaimLost) {
         SearchResult_Destroy(&r);
         return;
       }
@@ -1995,8 +1993,6 @@ static int buildPipelineAndExecute(AREQ *r, RedisModuleCtx *ctx, QueryError *sta
         timeoutCallback = QueryTimeoutFailCallback;
       } else {
         r->base.async.requiresAggregateResultsSync = true;
-        // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-        r->brc->requiresAggregateResultsSync = true;
         timeoutCallback = QueryTimeoutReturnStrictCallback;
       }
       replyCallback = QueryReplyCallback;
@@ -2257,7 +2253,7 @@ static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num) {
   RedisSearchCtx_AssertLockNotHeld(AREQ_SearchCtx(req));
 
   if (QueryRequest_UsesReplyCallback(&req->base)) {
-    if (req->brc->aggregateResultsClaimLost) {
+    if (req->base.async.aggregateResultsClaimLost) {
       // The strict timeout callback won the sync claim and already replied with
       // cursor 0. Keep cursor ownership consistent with the depleted id already
       // returned to the caller.
@@ -2459,7 +2455,7 @@ static int cursorReadDispatchTaken(RedisModuleCtx *ctx, Cursor *cursor, long lon
   // RETURN_STRICT claim/latch state so the new cycle starts from a clean
   // slate — safe because taking the cursor proves the previous read cycle's
   // BG work is done with it.
-  if (req->brc->requiresAggregateResultsSync) {
+  if (req->base.async.requiresAggregateResultsSync) {
     AREQ_ResetForCursorReadReturnStrict(req);
   }
   RedisModule_BlockedClientMeasureTimeStart(bc);
@@ -2600,8 +2596,6 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
         // so opt into the same per-read worker/timeout claim handshake here.
         // BeginCycle performs the per-read reset.
         req->base.async.requiresAggregateResultsSync = true;
-        // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-        req->brc->requiresAggregateResultsSync = true;
       }
       replyCallback = CursorReadReplyCallback;
       timeoutCallback =

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -433,6 +433,8 @@ static void startPipeline(AREQ *req, ResultProcessor *rp, SearchResult ***result
       // The RETURN_STRICT timeout callback claimed the sync phase first and
       // already owns the reply. The caller must skip stored-result handling and
       // clean up the cursor in runCursor.
+      req->base.async.aggregateResultsClaimLost = true;
+      // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
       req->brc->aggregateResultsClaimLost = true;
       *rc = RS_RESULT_TIMEDOUT;
       return;
@@ -1989,6 +1991,8 @@ static int buildPipelineAndExecute(AREQ *r, RedisModuleCtx *ctx, QueryError *sta
       if (policy == TimeoutPolicy_Fail) {
         timeoutCallback = QueryTimeoutFailCallback;
       } else {
+        r->base.async.requiresAggregateResultsSync = true;
+        // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
         r->brc->requiresAggregateResultsSync = true;
         timeoutCallback = QueryTimeoutReturnStrictCallback;
       }
@@ -2588,6 +2592,8 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
         // Shard/standalone RETURN_STRICT cursor reads bypass coordCursorReadReturnStrict,
         // so opt into the same per-read worker/timeout claim handshake here.
         // BeginCycle performs the per-read reset.
+        req->base.async.requiresAggregateResultsSync = true;
+        // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
         req->brc->requiresAggregateResultsSync = true;
       }
       replyCallback = CursorReadReplyCallback;

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -2190,6 +2190,10 @@ int AREQ_StartCursor(AREQ *r, RedisModule_Reply *reply, StrongRef spec_ref, Quer
  * (inline execution) it executes immediately. */
 static void cursorEndOfCycle(AREQ *req, Cursor *cursor, bool free_it) {
   if (req->brc->bc) {
+    req->base.cursorInfo.cursor = cursor;
+    req->base.cursorInfo.disposition =
+        free_it ? CURSOR_DISPOSITION_FREE : CURSOR_DISPOSITION_PAUSE;
+    // TODO($$$): Remove the legacy cursor disposition once consumers use QueryRequest.cursorInfo.
     req->brc->cursor = cursor;
     req->brc->cursor_dispose_free = free_it;
   } else if (free_it) {

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -2150,7 +2150,9 @@ int AREQ_StartCursor(AREQ *r, RedisModule_Reply *reply, StrongRef spec_ref, Quer
   RS_ASSERT(cursor->hybrid_ref.rm == NULL); // assuming hybrid cursors don't reach here
   cursor->queryTimeoutMS = (size_t)r->reqConfig.queryTimeoutMS;
   cursor->queryTimeoutPolicy = r->reqConfig.timeoutPolicy;
+  // TODO($$$): Remove the legacy cursor fields once all consumers use QueryRequest.cursorInfo.
   r->cursor_id = cursor->id;
+  r->base.cursorInfo.id = cursor->id;
   runCursor(reply, cursor, 0);
   return REDISMODULE_OK;
 }
@@ -2499,7 +2501,7 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     return RedisModule_ReplyWithErrorFormat(ctx, "Cursor not found, id: %lld", cid);
   }
 
-  if (cursor->is_coord &&
+  if (CURSOR_IS_COORD(cursor->id) &&
       !(RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_DENY_BLOCKING)) {
     // Coordinator cursor: the read pulls from the shards over the network, so
     // it is always dispatched to the coordinator pool, independent of the
@@ -2646,7 +2648,9 @@ int RSCursorProfileCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     QueryError status = QueryError_Default();
     AREQ_QueryProcessingCtx(req)->err = &status;
     // Cursor is freed below; signal cursor exhaustion to the client.
+    // TODO($$$): Remove the legacy cursor fields once all consumers use QueryRequest.cursorInfo.
     req->cursor_id = 0;
+    req->base.cursorInfo.id = 0;
     sendChunk_ReplyOnly_EmptyResults(ctx, req);
     IndexSpecRef_Release(execution_ref);
   }

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1559,7 +1559,7 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
 
 static int buildRequest(RedisModuleCtx *ctx, int type, QueryError *status, AREQ **r) {
   int rc = REDISMODULE_ERR;
-  const char *indexname = RedisModule_StringPtrLen((*r)->brc->argv[1], NULL);
+  const char *indexname = RedisModule_StringPtrLen((*r)->base.args.argv[1], NULL);
   RedisSearchCtx *sctx = NULL;
   RedisModuleCtx *thctx = NULL;
 
@@ -1619,7 +1619,7 @@ static int prepareRequest(AREQ **r_ptr, RedisModuleCtx *ctx, CommandType type, P
   // If we got here, we know the command name (the first held argument) is a
   // valid registered command. If it starts with an underscore, it is an
   // internal command.
-  if (RedisModule_StringPtrLen(r->brc->argv[0], NULL)[0] == '_') {
+  if (RedisModule_StringPtrLen(r->base.args.argv[0], NULL)[0] == '_') {
     AREQ_AddRequestFlags(r, QEXEC_F_INTERNAL);
   }
 
@@ -2106,8 +2106,8 @@ int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
     return single_shard_common_query_reply_empty(ctx, argv, argc, profileOptions, QUERY_ERROR_CODE_OUT_OF_MEMORY);
   }
 
-  AREQ *r = AREQ_New();
-  BlockedRequestCtx_NewAREQ(r, argv, argc);
+  AREQ *r = AREQ_New(argv, argc);
+  BlockedRequestCtx_NewAREQ(r);
 
   if (prepareRequest(&r, ctx, type, profileOptions, &status) != REDISMODULE_OK) {
     RS_ASSERT(r == NULL);
@@ -2145,8 +2145,8 @@ int RSExecuteAggregateOrSearch(RedisModuleCtx *ctx, RedisModuleString **argv, in
 
 char *RS_GetExplainOutput(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                           QueryError *status) {
-  AREQ *r = AREQ_New();
-  BlockedRequestCtx_NewAREQ(r, argv, argc);
+  AREQ *r = AREQ_New(argv, argc);
+  BlockedRequestCtx_NewAREQ(r);
   if (buildRequest(ctx, COMMAND_EXPLAIN, status, &r) != REDISMODULE_OK) {
     return NULL;
   }

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -688,7 +688,7 @@ static void finishSendChunkReply_Resp2(AREQ *req, RedisModule_Reply *reply, bool
         req->profile(reply, req);
       }
     } else {
-      RedisModule_Reply_LongLong(reply, req->cursor_id);
+      RedisModule_Reply_LongLong(reply, req->base.cursorInfo.id);
       if (IsProfile(req)) {
         // If the cursor is still alive, don't print profile info to save bandwidth
         RedisModule_Reply_Null(reply);
@@ -946,7 +946,7 @@ static void finishSendChunkReply_Resp3(AREQ *req, RedisModule_Reply *reply,
     if (cursor_done) {
       RedisModule_Reply_LongLong(reply, 0);
     } else {
-      RedisModule_Reply_LongLong(reply, req->cursor_id);
+      RedisModule_Reply_LongLong(reply, req->base.cursorInfo.id);
     }
     RedisModule_Reply_ArrayEnd(reply);
   }
@@ -1164,7 +1164,7 @@ void sendChunk(AREQ *req, RedisModule_Reply *reply, size_t limit) {
     RedisModule_Reply_MapEnd(reply);
 
     if (AREQ_RequestFlags(req) & QEXEC_F_IS_CURSOR) {
-      RedisModule_Reply_LongLong(reply, req->cursor_id);
+      RedisModule_Reply_LongLong(reply, req->base.cursorInfo.id);
       RedisModule_Reply_ArrayEnd(reply);
     }
   } else {
@@ -1208,7 +1208,7 @@ void sendChunk(AREQ *req, RedisModule_Reply *reply, size_t limit) {
     }
 
     if (AREQ_RequestFlags(req) & QEXEC_F_IS_CURSOR) {
-      RedisModule_Reply_LongLong(reply, req->cursor_id);
+      RedisModule_Reply_LongLong(reply, req->base.cursorInfo.id);
       if (IsProfile(req)) {
         req->profile(reply, req);
       }
@@ -2149,8 +2149,6 @@ int AREQ_StartCursor(AREQ *r, RedisModule_Reply *reply, StrongRef spec_ref, Quer
   RS_ASSERT(cursor->hybrid_ref.rm == NULL); // assuming hybrid cursors don't reach here
   cursor->queryTimeoutMS = (size_t)r->reqConfig.queryTimeoutMS;
   cursor->queryTimeoutPolicy = r->reqConfig.timeoutPolicy;
-  // TODO($$$): Remove the legacy cursor fields once all consumers use QueryRequest.cursorInfo.
-  r->cursor_id = cursor->id;
   r->base.cursorInfo.id = cursor->id;
   runCursor(reply, cursor, 0);
   return REDISMODULE_OK;
@@ -2648,8 +2646,6 @@ int RSCursorProfileCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     QueryError status = QueryError_Default();
     AREQ_QueryProcessingCtx(req)->err = &status;
     // Cursor is freed below; signal cursor exhaustion to the client.
-    // TODO($$$): Remove the legacy cursor fields once all consumers use QueryRequest.cursorInfo.
-    req->cursor_id = 0;
     req->base.cursorInfo.id = 0;
     sendChunk_ReplyOnly_EmptyResults(ctx, req);
     IndexSpecRef_Release(execution_ref);

--- a/src/aggregate/aggregate_exec_common.c
+++ b/src/aggregate/aggregate_exec_common.c
@@ -201,7 +201,7 @@ static inline void debugCheckAndPauseAfterAggregateResult(AREQ *areq) {}
  }
 
  /**
-  * Drain results buffered post-timeout into `req->brc->reply.results`.
+  * Drain results buffered post-timeout into `req->base.reply.results`.
   * Only safe for pipelines classified as yielding partial results -- caller
   * must gate on `qctx->canYieldPartialResults` and perform any root-specific
   * pre-drain setup (such as flipping RPNet's `drainOnly` mode on the
@@ -231,8 +231,6 @@ static inline void debugCheckAndPauseAfterAggregateResult(AREQ *areq) {}
  }
 
  void AREQ_DrainStoredResultsAfterTimeout(AREQ *req) {
-   // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
    Pipeline_DrainStoredResultsAfterTimeout(AREQ_QueryProcessingCtx(req),
-                                           &req->brc->reply);
-   req->base.reply.results = req->brc->reply.results;
+                                           &req->base.reply);
  }

--- a/src/aggregate/aggregate_exec_common.c
+++ b/src/aggregate/aggregate_exec_common.c
@@ -231,6 +231,8 @@ static inline void debugCheckAndPauseAfterAggregateResult(AREQ *areq) {}
  }
 
  void AREQ_DrainStoredResultsAfterTimeout(AREQ *req) {
+   // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
    Pipeline_DrainStoredResultsAfterTimeout(AREQ_QueryProcessingCtx(req),
                                            &req->brc->reply);
+   req->base.reply.results = req->brc->reply.results;
  }

--- a/src/aggregate/aggregate_exec_common.h
+++ b/src/aggregate/aggregate_exec_common.h
@@ -98,7 +98,7 @@ bool pipelineCanYieldPartialResults(struct AREQ *r);
 void Pipeline_DrainStoredResultsAfterTimeout(QueryProcessingCtx *qctx, ChunkReplyState *stored);
 
 /**
- * Drain results buffered post-timeout into `req->brc->reply.results`.
+ * Drain results buffered post-timeout into `req->base.reply.results`.
  * Only safe for pipelines classified as yielding partial results -- caller
  * must gate on `qctx->canYieldPartialResults` and perform any root-specific
  * pre-drain setup (such as flipping RPNet's `drainOnly` mode on the

--- a/src/aggregate/aggregate_plan.h
+++ b/src/aggregate/aggregate_plan.h
@@ -95,7 +95,7 @@ typedef struct {
 } PLN_MapFilterStep;
 
 /** ARRANGE covers sort, limit, and so on */
-typedef struct {
+typedef struct PLN_ArrangeStep {
   PLN_BaseStep base;
   const RLookupKey **sortkeysLK;  // simple array
   const char **sortKeys;          // array_*

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1137,8 +1137,6 @@ AREQ *AREQ_New(void) {
   req->prefixesOffset = 0;
   req->keySpaceVersion = INVALID_KEYSPACE_VERSION;
   req->querySlots = NULL;
-  // TODO($$$): Remove RequestSyncState once consumers use QueryRequest timeout/async state.
-  RequestSyncState_Init(&req->syncState);
   req->brc = NULL;
   return req;
 }
@@ -1261,18 +1259,15 @@ void AREQ_WaitForAggregateResultsComplete(AREQ *req) {
   pthread_mutex_unlock(&req->brc->aggregateResultsLock);
 }
 
-/* Read the owned request's timeout flag through the wrapper. The flag lives on
- * the request's embedded RequestSyncState, not on the wrapper itself. */
-static bool BlockedRequestCtx_OwnedRequestTimedOut(BlockedRequestCtx *brc) {
-  if (brc->kind == REQUEST_KIND_AREQ) {
-    return RequestSyncState_GetTimedOut(&brc->query.areq->syncState);
-  }
-  return RequestSyncState_GetTimedOut(&brc->query.hybrid->syncState);
-}
-
 static QueryRequest *BlockedRequestCtx_QueryRequest(BlockedRequestCtx *brc) {
   return brc->kind == REQUEST_KIND_AREQ ? (QueryRequest *)brc->query.areq
                                        : (QueryRequest *)brc->query.hybrid;
+}
+
+/* Read the common base without coupling this path to a concrete request kind. */
+static bool BlockedRequestCtx_OwnedRequestTimedOut(BlockedRequestCtx *brc) {
+  QueryRequest *request = BlockedRequestCtx_QueryRequest(brc);
+  return QueryRequestTimeout_GetTimedOut(&request->timeout);
 }
 
 /* See aggregate.h for the full handshake contract. The aggregateResultsLock
@@ -1327,35 +1322,11 @@ void AREQ_ResetForCursorReadReturnStrict(AREQ *req) {
   req->brc->safeLoadersHoldingGIL = 0;
   pthread_mutex_unlock(&req->brc->aggregateResultsLock);
   QueryRequestTimeout_ClearTimedOut(&req->base.timeout);
-  // TODO($$$): Remove the legacy timeout state once consumers use QueryRequest.timeout.
-  RequestSyncState_ClearTimedOut(&req->syncState);
   ResultProcessor *root = AREQ_QueryProcessingCtx(req)->rootProc;
   if (root && root->type == RP_NETWORK) {
     ((RPNet *)root)->drainOnly = false;
   }
 }
-
-void RequestSyncState_RegisterAbortWakeChannel(RequestSyncState *st, struct MRChannel *chan) {
-  pthread_mutex_lock(&st->abortWakeLock);
-  st->abortWakeChannel = chan;
-  pthread_mutex_unlock(&st->abortWakeLock);
-}
-
-void RequestSyncState_UnregisterAbortWakeChannel(RequestSyncState *st) {
-  pthread_mutex_lock(&st->abortWakeLock);
-  st->abortWakeChannel = NULL;
-  pthread_mutex_unlock(&st->abortWakeLock);
-}
-
-void RequestSyncState_WakeAbortChannel(RequestSyncState *st) {
-  pthread_mutex_lock(&st->abortWakeLock);
-  if (st->abortWakeChannel) {
-    MRChannel_WakeAbort(st->abortWakeChannel);
-  }
-  pthread_mutex_unlock(&st->abortWakeLock);
-}
-
-
 
 int parseAggPlan(ParseAggPlanContext *papCtx, ArgsCursor *ac, bool isDiskIndex, QueryError *status) {
   while (!AC_IsAtEnd(ac)) {
@@ -1709,7 +1680,7 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   // Borrow the request's timed-out flag onto the sctx so pipeline RPs can
   // observe a RETURN-STRICT main-thread timeout without holding an AREQ
   // back-pointer (read via SearchTime_IsTimedOut).
-  sctx->time.timedOutFlag = &req->syncState.timedOut;
+  sctx->time.timedOutFlag = &req->base.timeout.timedOut;
 
   if (!IsIndexCoherent(req)) {
     QueryError_SetError(status, QUERY_ERROR_CODE_MISMATCH, NULL);
@@ -1956,8 +1927,6 @@ void AREQ_Free(AREQ *req) {
 
   rm_free(req->args);
 
-  // TODO($$$): Remove RequestSyncState once consumers use QueryRequest timeout/async state.
-  RequestSyncState_Destroy(&req->syncState);
   QueryRequest_Destroy(&req->base);
 
   rm_free(req);

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1137,6 +1137,7 @@ AREQ *AREQ_New(void) {
   req->prefixesOffset = 0;
   req->keySpaceVersion = INVALID_KEYSPACE_VERSION;
   req->querySlots = NULL;
+  // TODO($$$): Remove RequestSyncState once consumers use QueryRequest timeout/async state.
   RequestSyncState_Init(&req->syncState);
   req->brc = NULL;
   return req;
@@ -1325,6 +1326,8 @@ void AREQ_ResetForCursorReadReturnStrict(AREQ *req) {
   req->brc->aggregateResultsDone = false;
   req->brc->safeLoadersHoldingGIL = 0;
   pthread_mutex_unlock(&req->brc->aggregateResultsLock);
+  QueryRequestTimeout_ClearTimedOut(&req->base.timeout);
+  // TODO($$$): Remove the legacy timeout state once consumers use QueryRequest.timeout.
   RequestSyncState_ClearTimedOut(&req->syncState);
   ResultProcessor *root = AREQ_QueryProcessingCtx(req)->rootProc;
   if (root && root->type == RP_NETWORK) {
@@ -1953,6 +1956,7 @@ void AREQ_Free(AREQ *req) {
 
   rm_free(req->args);
 
+  // TODO($$$): Remove RequestSyncState once consumers use QueryRequest timeout/async state.
   RequestSyncState_Destroy(&req->syncState);
   QueryRequest_Destroy(&req->base);
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1118,9 +1118,9 @@ bool RunInThread(RedisModuleCtx *ctx) {
   return true;
 }
 
-AREQ *AREQ_New(void) {
+AREQ *AREQ_New(RedisModuleString **argv, uint32_t argc) {
   AREQ* req = rm_calloc(1, sizeof(AREQ));
-  QueryRequest_Init(&req->base, QUERY_REQUEST_KIND_AREQ);
+  QueryRequest_Init(&req->base, QUERY_REQUEST_KIND_AREQ, argv, argc);
   QueryRequest_SetEndProcRef(&req->base, &req->pipeline.qctx.endProc);
   /*
   unsigned int dialectVersion;
@@ -1154,8 +1154,6 @@ bool SearchTime_IsTimedOut(void *arg) {
 static BlockedRequestCtx *BlockedRequestCtx_NewCommon(RequestKind kind) {
   BlockedRequestCtx *brc = rm_calloc(1, sizeof(BlockedRequestCtx));
   brc->kind = kind;
-  // TODO($$$): Remove the legacy query offset once consumers use QueryRequest.
-  brc->queryOffset = QUERY_OFFSET_NONE;  // "no query argument" until parsing finds one
   brc->refcount = 1;
   // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
   brc->requiresAggregateResultsSync = false;
@@ -1182,66 +1180,21 @@ void BlockedRequestCtx_DecrRef(BlockedRequestCtx *brc) {
   }
 }
 
-/* Hold references to `argv` strings whose contents the wrapped request's
- * plan borrows (see BlockedRequestCtx.argv). Runs at construction, on
- * the main thread; released in BlockedRequestCtx_Free, also on main. */
-static void holdArgv(BlockedRequestCtx *brc, QueryRequest *request, RedisModuleString **argv,
-                     uint32_t argc) {
-  RS_ASSERT(argv != NULL);
-  RS_ASSERT(brc->argv == NULL);
-  // TODO($$$): Remove the legacy argv state once consumers use QueryRequest.
-  brc->argv = rm_malloc(argc * sizeof(*brc->argv));
-  brc->argc = argc;
-  brc->parseArgc = argc;  // debug constructors lower it to exclude the debug tail
-  for (uint32_t ii = 0; ii < argc; ++ii) {
-    brc->argv[ii] = RedisModule_HoldString(NULL, argv[ii]);
-    // Redis auto-trims (reallocates) retained argv right after the command
-    // callback returns — racing any thread already reading the string. Trim
-    // here instead, before any borrow exists or a worker can see it.
-    RedisModule_TrimStringAllocation(brc->argv[ii]);
-  }
-  request->args.argv = brc->argv;
-  request->args.argc = brc->argc;
-  request->args.parseArgc = brc->parseArgc;
-}
-
-/* Release an argv array taken by holdArgv: drop each string reference and
- * free the array. Main-thread only (string refcounts are not thread safe). */
-static void releaseArgv(RedisModuleString **argv, uint32_t argc) {
-  for (uint32_t ii = 0; ii < argc; ++ii) {
-    RedisModule_FreeString(NULL, argv[ii]);
-  }
-  rm_free(argv);
-}
-
-typedef struct {
-  RedisModuleString **argv;
-  uint32_t argc;
-} DeferredArgvRelease;
-
-static void releaseArgvOnMainThread(void *privdata) {
-  DeferredArgvRelease *deferred = privdata;
-  releaseArgv(deferred->argv, deferred->argc);
-  rm_free(deferred);
-}
-
-BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **argv, uint32_t argc) {
+BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq) {
   // Wrapping an already-wrapped request would silently leak the first wrapper.
   RS_ASSERT(areq->brc == NULL);
   BlockedRequestCtx *brc = BlockedRequestCtx_NewCommon(REQUEST_KIND_AREQ);
   brc->query.areq = areq;
   areq->brc = brc;
-  holdArgv(brc, &areq->base, argv, argc);
   return brc;
 }
 
-BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid, RedisModuleString **argv, uint32_t argc) {
+BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid) {
   // Wrapping an already-wrapped request would silently leak the first wrapper.
   RS_ASSERT(hybrid->brc == NULL);
   BlockedRequestCtx *brc = BlockedRequestCtx_NewCommon(REQUEST_KIND_HYBRID);
   brc->query.hybrid = hybrid;
   hybrid->brc = brc;
-  holdArgv(brc, &hybrid->base, argv, argc);
   return brc;
 }
 
@@ -1260,20 +1213,6 @@ void BlockedRequestCtx_Free(BlockedRequestCtx *brc) {
     AREQ_Free(brc->query.areq);
   } else {
     HybridRequest_Free(brc->query.hybrid);
-  }
-  // Every wrapper is born with its holds (construction invariant), released
-  // after the request: its plan borrows from these strings.
-  RS_ASSERT(brc->argv != NULL);
-  if (MainThread_Is()) {
-    releaseArgv(brc->argv, brc->argc);
-  } else {
-    // String references may only be released on the main thread; bounce the
-    // release to the main event loop.
-    DeferredArgvRelease *deferred = rm_new(DeferredArgvRelease);
-    *deferred = (DeferredArgvRelease){.argv = brc->argv, .argc = brc->argc};
-    int rc = RedisModule_EventLoopAddOneShot(releaseArgvOnMainThread, deferred);
-    RS_ASSERT(rc == REDISMODULE_OK);
-    (void)rc;
   }
   rm_free(brc);
 }
@@ -1468,19 +1407,17 @@ static bool shouldCheckInPipelineTimeout(RedisModuleCtx* ctx, AREQ *req) {
 }
 
 int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, uint32_t offset, bool isDiskIndex, QueryError *status) {
-  BlockedRequestCtx *brc = req->brc;
-  RS_ASSERT(brc != NULL);
-  RS_ASSERT(offset <= brc->parseArgc && brc->parseArgc <= brc->argc);
-  // TODO($$$): Remove the legacy query offset once consumers use QueryRequest.
-  brc->queryOffset = offset;
-  req->base.args.queryOffset = brc->queryOffset;
+  RS_ASSERT(req->brc != NULL);
+  RS_ASSERT(offset <= req->base.args.parseArgc &&
+            req->base.args.parseArgc <= req->base.args.argc);
+  req->base.args.queryOffset = offset;
 
   // Parse the query and basic keywords first..
   // The cursor covers the whole held command, pre-advanced to the parse
   // start: positions recorded off the cursor (syntax-error offsets,
   // prefixesOffset) are relative to the full command, not the parsed tail.
   ArgsCursor ac = {0};
-  ArgsCursor_InitRString(&ac, brc->argv, brc->parseArgc);
+  ArgsCursor_InitRString(&ac, req->base.args.argv, req->base.args.parseArgc);
   AC_AdvanceBy(&ac, offset);
 
   if (AC_IsAtEnd(&ac)) {
@@ -1662,7 +1599,7 @@ static bool IsIndexCoherent(AREQ *req) {
 
   // prefixesOffset indexes the full held command (recorded off the compile
   // cursor, which covers the whole command).
-  RedisModuleString **args = req->brc->argv;
+  RedisModuleString **args = req->base.args.argv;
   long long n_prefixes = 0;
   RedisModule_StringToLongLong(args[req->prefixesOffset + 1], &n_prefixes);
   // The first argument is at req->prefixesOffset + 2

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1140,7 +1140,6 @@ AREQ *AREQ_New(RedisModuleString **argv, uint32_t argc) {
   req->prefixesOffset = 0;
   req->keySpaceVersion = INVALID_KEYSPACE_VERSION;
   req->querySlots = NULL;
-  req->brc = NULL;
   return req;
 }
 
@@ -1151,66 +1150,6 @@ bool SearchTime_IsTimedOut(void *arg) {
                               memory_order_relaxed);
 }
 
-static BlockedRequestCtx *BlockedRequestCtx_NewCommon(RequestKind kind) {
-  BlockedRequestCtx *brc = rm_calloc(1, sizeof(BlockedRequestCtx));
-  brc->kind = kind;
-  return brc;
-}
-
-BlockedRequestCtx *BlockedRequestCtx_IncrRef(BlockedRequestCtx *brc) {
-  QueryRequest *request = brc->kind == REQUEST_KIND_AREQ ? (QueryRequest *)brc->query.areq
-                                                        : (QueryRequest *)brc->query.hybrid;
-  QueryRequest_IncrRef(request);
-  return brc;
-}
-
-void BlockedRequestCtx_DecrRef(BlockedRequestCtx *brc) {
-  if (!brc) {
-    return;
-  }
-  QueryRequest *request = brc->kind == REQUEST_KIND_AREQ ? (QueryRequest *)brc->query.areq
-                                                        : (QueryRequest *)brc->query.hybrid;
-  if (QueryRequest_DecrRef(request)) {
-    BlockedRequestCtx_Free(brc);
-  }
-}
-
-BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq) {
-  // Wrapping an already-wrapped request would silently leak the first wrapper.
-  RS_ASSERT(areq->brc == NULL);
-  BlockedRequestCtx *brc = BlockedRequestCtx_NewCommon(REQUEST_KIND_AREQ);
-  brc->query.areq = areq;
-  areq->brc = brc;
-  return brc;
-}
-
-BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid) {
-  // Wrapping an already-wrapped request would silently leak the first wrapper.
-  RS_ASSERT(hybrid->brc == NULL);
-  BlockedRequestCtx *brc = BlockedRequestCtx_NewCommon(REQUEST_KIND_HYBRID);
-  brc->query.hybrid = hybrid;
-  hybrid->brc = brc;
-  return brc;
-}
-
-void BlockedRequestCtx_Free(BlockedRequestCtx *brc) {
-  if (!brc) {
-    return;
-  }
-  // Idempotent after EndCycle; kept as a safety net for wrappers freed
-  // outside a cycle. Must run while the owned request is alive: disposing a
-  // stashed cursor clears its wrapper handle.
-
-  if (brc->kind == REQUEST_KIND_AREQ) {
-    AREQ_Free(brc->query.areq);
-  } else {
-    HybridRequest_Free(brc->query.hybrid);
-  }
-  rm_free(brc);
-}
-
-static QueryRequest *BlockedRequestCtx_QueryRequest(BlockedRequestCtx *brc);
-
 bool AREQ_TryClaimAggregateResults(AREQ *req) {
   bool expected = false;
   return atomic_compare_exchange_strong_explicit(&req->base.async.aggregatingResults, &expected,
@@ -1218,13 +1157,13 @@ bool AREQ_TryClaimAggregateResults(AREQ *req) {
                                                  memory_order_relaxed);
 }
 
-bool BlockedRequestCtx_TryOwnStrictRead(BlockedRequestCtx *brc, BrcStrictReadOwner owner) {
-  int expected = BRC_READ_OWNER_NONE;
+bool QueryRequest_TryOwnStrictRead(QueryRequest *request, QueryRequestStrictReadOwner owner) {
+  int expected = QUERY_REQUEST_READ_OWNER_NONE;
   // acq_rel: the winner's subsequent actions (BG running the read / the timer
   // replying depleted) must be ordered against the loser's observation.
   return atomic_compare_exchange_strong_explicit(
-      &BlockedRequestCtx_QueryRequest(brc)->async.strictReadOwner, &expected, (int)owner,
-      memory_order_acq_rel, memory_order_acquire);
+      &request->async.strictReadOwner, &expected, (int)owner, memory_order_acq_rel,
+      memory_order_acquire);
 }
 
 void AREQ_SignalAggregateResultsComplete(AREQ *req) {
@@ -1243,25 +1182,19 @@ void AREQ_WaitForAggregateResultsComplete(AREQ *req) {
   pthread_mutex_unlock(&req->base.async.aggregateResultsLock);
 }
 
-static QueryRequest *BlockedRequestCtx_QueryRequest(BlockedRequestCtx *brc) {
-  return brc->kind == REQUEST_KIND_AREQ ? (QueryRequest *)brc->query.areq
-                                       : (QueryRequest *)brc->query.hybrid;
-}
-
 /* Read the common base without coupling this path to a concrete request kind. */
-static bool BlockedRequestCtx_OwnedRequestTimedOut(BlockedRequestCtx *brc) {
-  QueryRequest *request = BlockedRequestCtx_QueryRequest(brc);
+static bool QueryRequest_OwnedRequestTimedOut(QueryRequest *request) {
   return QueryRequestTimeout_GetTimedOut(&request->timeout);
 }
 
 /* See aggregate.h for the full handshake contract. The aggregateResultsLock
  * serializes the worker's "set holding, then check timedOut" against the main
  * thread's "set timedOut, then check holding", making the two race-free. */
-bool BlockedRequestCtx_SafeLoaderEnterGIL(BlockedRequestCtx *sync) {
-  QueryRequestAsyncState *async = &BlockedRequestCtx_QueryRequest(sync)->async;
+bool QueryRequest_SafeLoaderEnterGIL(QueryRequest *request) {
+  QueryRequestAsyncState *async = &request->async;
   bool proceed;
   pthread_mutex_lock(&async->aggregateResultsLock);
-  if (BlockedRequestCtx_OwnedRequestTimedOut(sync)) {
+  if (QueryRequest_OwnedRequestTimedOut(request)) {
     // Timeout already fired: do not mark holding, bail instead of blocking on the
     // GIL the main thread holds while it waits.
     proceed = false;
@@ -1273,8 +1206,8 @@ bool BlockedRequestCtx_SafeLoaderEnterGIL(BlockedRequestCtx *sync) {
   return proceed;
 }
 
-void BlockedRequestCtx_SafeLoaderExitGIL(BlockedRequestCtx *sync) {
-  QueryRequestAsyncState *async = &BlockedRequestCtx_QueryRequest(sync)->async;
+void QueryRequest_SafeLoaderExitGIL(QueryRequest *request) {
+  QueryRequestAsyncState *async = &request->async;
   pthread_mutex_lock(&async->aggregateResultsLock);
   RS_LOG_ASSERT(async->safeLoadersHoldingGIL > 0,
                 "SafeLoaderExitGIL without matching EnterGIL");
@@ -1282,8 +1215,8 @@ void BlockedRequestCtx_SafeLoaderExitGIL(BlockedRequestCtx *sync) {
   pthread_mutex_unlock(&async->aggregateResultsLock);
 }
 
-bool BlockedRequestCtx_TimeoutPreemptSafeLoaderGIL(BlockedRequestCtx *sync) {
-  QueryRequestAsyncState *async = &BlockedRequestCtx_QueryRequest(sync)->async;
+bool QueryRequest_TimeoutPreemptSafeLoaderGIL(QueryRequest *request) {
+  QueryRequestAsyncState *async = &request->async;
   bool holding;
   pthread_mutex_lock(&async->aggregateResultsLock);
   holding = async->safeLoadersHoldingGIL > 0;
@@ -1381,7 +1314,6 @@ static bool shouldCheckInPipelineTimeout(RedisModuleCtx* ctx, AREQ *req) {
 }
 
 int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, uint32_t offset, bool isDiskIndex, QueryError *status) {
-  RS_ASSERT(req->brc != NULL);
   RS_ASSERT(offset <= req->base.args.parseArgc &&
             req->base.args.parseArgc <= req->base.args.argc);
   req->base.args.queryOffset = offset;
@@ -1795,8 +1727,8 @@ void ChunkReplyState_Destroy(ChunkReplyState *state) {
 
   // Timeout edge case: cursor wasn't handled by reply_callback.
   // See ChunkReplyState ownership model in aggregate.h for full explanation.
-  // We must clear the cursor's wrapper handle before Cursor_Free to prevent
-  // the wrapper-release loop (this destroy runs from the wrapper's own free).
+  // We must clear the cursor's request handle before Cursor_Free to prevent a
+  // recursive release while this request is already being destroyed.
   if (state->cursor) {
     state->cursor->query = NULL;
     Cursor_Free(state->cursor);
@@ -1808,20 +1740,13 @@ void ChunkReplyState_Destroy(ChunkReplyState *state) {
 }
 
 AREQ *AREQ_IncrRef(AREQ *req) {
-  RS_LOG_ASSERT(req->brc != NULL, "AREQ_IncrRef called on unwrapped (sub-)AREQ");
-  BlockedRequestCtx_IncrRef(req->brc);
+  QueryRequest_IncrRef(&req->base);
   return req;
 }
 
 void AREQ_DecrRef(AREQ *req) {
   if (!req) return;
-  if (req->brc) {
-    // Top-level wrapped AREQ: delegate to the wrapper's refcount.
-    BlockedRequestCtx_DecrRef(req->brc);
-  } else {
-    // Unwrapped transient / sub-AREQ (e.g. hybrid sub-query): free directly.
-    AREQ_Free(req);
-  }
+  QueryRequest_DecrRef(&req->base);
 }
 
 void AREQ_Free(AREQ *req) {

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1215,6 +1215,8 @@ void BlockedRequestCtx_Free(BlockedRequestCtx *brc) {
   rm_free(brc);
 }
 
+static QueryRequest *BlockedRequestCtx_QueryRequest(BlockedRequestCtx *brc);
+
 bool AREQ_TryClaimAggregateResults(AREQ *req) {
   bool expected = false;
   // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
@@ -1228,8 +1230,17 @@ bool BlockedRequestCtx_TryOwnStrictRead(BlockedRequestCtx *brc, BrcStrictReadOwn
   int expected = BRC_READ_OWNER_NONE;
   // acq_rel: the winner's subsequent actions (BG running the read / the timer
   // replying depleted) must be ordered against the loser's observation.
-  return atomic_compare_exchange_strong_explicit(&brc->strictReadOwner, &expected, (int)owner,
-                                                 memory_order_acq_rel, memory_order_acquire);
+  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
+  bool claimed = atomic_compare_exchange_strong_explicit(
+      &brc->strictReadOwner, &expected, (int)owner, memory_order_acq_rel, memory_order_acquire);
+  int currentOwner = claimed ? (int)owner : expected;
+  /* Transitional passive mirror only: the legacy CAS above remains the sole
+   * arbitration and synchronization point. This relaxed store does not carry
+   * its acquire-release contract; move the CAS itself here before consumers
+   * use QueryRequest.async.strictReadOwner for synchronization. */
+  RS_AtomicIntStoreRelaxed(
+      &BlockedRequestCtx_QueryRequest(brc)->async.strictReadOwner, currentOwner);
+  return claimed;
 }
 
 void AREQ_SignalAggregateResultsComplete(AREQ *req) {

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1920,6 +1920,7 @@ void AREQ_Free(AREQ *req) {
   rm_free(req->args);
 
   RequestSyncState_Destroy(&req->syncState);
+  QueryRequest_Destroy(&req->base);
 
   rm_free(req);
 }
@@ -1927,6 +1928,8 @@ void AREQ_Free(AREQ *req) {
 void AREQ_CleanUpStoredCursor(AREQ *req) {
   if (req->brc->reply.cursor) {
     Cursor *cursor = req->brc->reply.cursor;
+    req->base.reply.cursor = NULL;
+    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
     req->brc->reply.cursor = NULL;
     Cursor_Free(cursor);
   }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1155,14 +1155,6 @@ static BlockedRequestCtx *BlockedRequestCtx_NewCommon(RequestKind kind) {
   BlockedRequestCtx *brc = rm_calloc(1, sizeof(BlockedRequestCtx));
   brc->kind = kind;
   brc->refcount = 1;
-  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-  brc->requiresAggregateResultsSync = false;
-  brc->aggregatingResults = false;
-  brc->aggregateResultsClaimLost = false;
-  brc->aggregateResultsDone = false;
-  brc->safeLoadersHoldingGIL = 0;
-  pthread_mutex_init(&brc->aggregateResultsLock, NULL);
-  pthread_cond_init(&brc->aggregateResultsCond, NULL);
   brc->reply.err = QueryError_Default();
   return brc;
 }
@@ -1202,8 +1194,6 @@ void BlockedRequestCtx_Free(BlockedRequestCtx *brc) {
   if (!brc) {
     return;
   }
-  pthread_mutex_destroy(&brc->aggregateResultsLock);
-  pthread_cond_destroy(&brc->aggregateResultsCond);
   // Idempotent after EndCycle; kept as a safety net for wrappers freed
   // outside a cycle. Must run while the owned request is alive: disposing a
   // stashed cursor clears its wrapper handle.
@@ -1221,45 +1211,34 @@ static QueryRequest *BlockedRequestCtx_QueryRequest(BlockedRequestCtx *brc);
 
 bool AREQ_TryClaimAggregateResults(AREQ *req) {
   bool expected = false;
-  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-  bool claimed = atomic_compare_exchange_strong_explicit(
-      &req->brc->aggregatingResults, &expected, true, memory_order_relaxed, memory_order_relaxed);
-  RS_AtomicBoolStoreRelaxed(&req->base.async.aggregatingResults, true);
-  return claimed;
+  return atomic_compare_exchange_strong_explicit(&req->base.async.aggregatingResults, &expected,
+                                                 true, memory_order_relaxed,
+                                                 memory_order_relaxed);
 }
 
 bool BlockedRequestCtx_TryOwnStrictRead(BlockedRequestCtx *brc, BrcStrictReadOwner owner) {
   int expected = BRC_READ_OWNER_NONE;
   // acq_rel: the winner's subsequent actions (BG running the read / the timer
   // replying depleted) must be ordered against the loser's observation.
-  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-  bool claimed = atomic_compare_exchange_strong_explicit(
-      &brc->strictReadOwner, &expected, (int)owner, memory_order_acq_rel, memory_order_acquire);
-  int currentOwner = claimed ? (int)owner : expected;
-  /* Transitional passive mirror only: the legacy CAS above remains the sole
-   * arbitration and synchronization point. This relaxed store does not carry
-   * its acquire-release contract; move the CAS itself here before consumers
-   * use QueryRequest.async.strictReadOwner for synchronization. */
-  RS_AtomicIntStoreRelaxed(
-      &BlockedRequestCtx_QueryRequest(brc)->async.strictReadOwner, currentOwner);
-  return claimed;
+  return atomic_compare_exchange_strong_explicit(
+      &BlockedRequestCtx_QueryRequest(brc)->async.strictReadOwner, &expected, (int)owner,
+      memory_order_acq_rel, memory_order_acquire);
 }
 
 void AREQ_SignalAggregateResultsComplete(AREQ *req) {
-  pthread_mutex_lock(&req->brc->aggregateResultsLock);
+  pthread_mutex_lock(&req->base.async.aggregateResultsLock);
   req->base.async.aggregateResultsDone = true;
-  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-  req->brc->aggregateResultsDone = true;
-  pthread_cond_broadcast(&req->brc->aggregateResultsCond);
-  pthread_mutex_unlock(&req->brc->aggregateResultsLock);
+  pthread_cond_broadcast(&req->base.async.aggregateResultsCond);
+  pthread_mutex_unlock(&req->base.async.aggregateResultsLock);
 }
 
 void AREQ_WaitForAggregateResultsComplete(AREQ *req) {
-  pthread_mutex_lock(&req->brc->aggregateResultsLock);
-  while (!req->brc->aggregateResultsDone) {
-    pthread_cond_wait(&req->brc->aggregateResultsCond, &req->brc->aggregateResultsLock);
+  pthread_mutex_lock(&req->base.async.aggregateResultsLock);
+  while (!req->base.async.aggregateResultsDone) {
+    pthread_cond_wait(&req->base.async.aggregateResultsCond,
+                      &req->base.async.aggregateResultsLock);
   }
-  pthread_mutex_unlock(&req->brc->aggregateResultsLock);
+  pthread_mutex_unlock(&req->base.async.aggregateResultsLock);
 }
 
 static QueryRequest *BlockedRequestCtx_QueryRequest(BlockedRequestCtx *brc) {
@@ -1277,53 +1256,46 @@ static bool BlockedRequestCtx_OwnedRequestTimedOut(BlockedRequestCtx *brc) {
  * serializes the worker's "set holding, then check timedOut" against the main
  * thread's "set timedOut, then check holding", making the two race-free. */
 bool BlockedRequestCtx_SafeLoaderEnterGIL(BlockedRequestCtx *sync) {
+  QueryRequestAsyncState *async = &BlockedRequestCtx_QueryRequest(sync)->async;
   bool proceed;
-  pthread_mutex_lock(&sync->aggregateResultsLock);
+  pthread_mutex_lock(&async->aggregateResultsLock);
   if (BlockedRequestCtx_OwnedRequestTimedOut(sync)) {
     // Timeout already fired: do not mark holding, bail instead of blocking on the
     // GIL the main thread holds while it waits.
     proceed = false;
   } else {
-    BlockedRequestCtx_QueryRequest(sync)->async.safeLoadersHoldingGIL++;
-    // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-    sync->safeLoadersHoldingGIL++;
+    async->safeLoadersHoldingGIL++;
     proceed = true;
   }
-  pthread_mutex_unlock(&sync->aggregateResultsLock);
+  pthread_mutex_unlock(&async->aggregateResultsLock);
   return proceed;
 }
 
 void BlockedRequestCtx_SafeLoaderExitGIL(BlockedRequestCtx *sync) {
-  pthread_mutex_lock(&sync->aggregateResultsLock);
-  RS_LOG_ASSERT(sync->safeLoadersHoldingGIL > 0, "SafeLoaderExitGIL without matching EnterGIL");
-  BlockedRequestCtx_QueryRequest(sync)->async.safeLoadersHoldingGIL--;
-  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-  sync->safeLoadersHoldingGIL--;
-  pthread_mutex_unlock(&sync->aggregateResultsLock);
+  QueryRequestAsyncState *async = &BlockedRequestCtx_QueryRequest(sync)->async;
+  pthread_mutex_lock(&async->aggregateResultsLock);
+  RS_LOG_ASSERT(async->safeLoadersHoldingGIL > 0,
+                "SafeLoaderExitGIL without matching EnterGIL");
+  async->safeLoadersHoldingGIL--;
+  pthread_mutex_unlock(&async->aggregateResultsLock);
 }
 
 bool BlockedRequestCtx_TimeoutPreemptSafeLoaderGIL(BlockedRequestCtx *sync) {
+  QueryRequestAsyncState *async = &BlockedRequestCtx_QueryRequest(sync)->async;
   bool holding;
-  pthread_mutex_lock(&sync->aggregateResultsLock);
-  holding = sync->safeLoadersHoldingGIL > 0;
-  pthread_mutex_unlock(&sync->aggregateResultsLock);
+  pthread_mutex_lock(&async->aggregateResultsLock);
+  holding = async->safeLoadersHoldingGIL > 0;
+  pthread_mutex_unlock(&async->aggregateResultsLock);
   return holding;
 }
 
 void AREQ_ResetForCursorReadReturnStrict(AREQ *req) {
   RS_AtomicBoolStoreRelaxed(&req->base.async.aggregatingResults, false);
-  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-  RS_AtomicBoolStoreRelaxed(&req->brc->aggregatingResults, false);
   req->base.async.aggregateResultsClaimLost = false;
-  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-  req->brc->aggregateResultsClaimLost = false;
-  pthread_mutex_lock(&req->brc->aggregateResultsLock);
+  pthread_mutex_lock(&req->base.async.aggregateResultsLock);
   req->base.async.aggregateResultsDone = false;
   req->base.async.safeLoadersHoldingGIL = 0;
-  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-  req->brc->aggregateResultsDone = false;
-  req->brc->safeLoadersHoldingGIL = 0;
-  pthread_mutex_unlock(&req->brc->aggregateResultsLock);
+  pthread_mutex_unlock(&req->base.async.aggregateResultsLock);
   QueryRequestTimeout_ClearTimedOut(&req->base.timeout);
   ResultProcessor *root = AREQ_QueryProcessingCtx(req)->rootProc;
   if (root && root->type == RP_NETWORK) {

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1117,6 +1117,7 @@ bool RunInThread(RedisModuleCtx *ctx) {
 
 AREQ *AREQ_New(void) {
   AREQ* req = rm_calloc(1, sizeof(AREQ));
+  QueryRequest_Init(&req->base, QUERY_REQUEST_KIND_AREQ);
   /*
   unsigned int dialectVersion;
   long long queryTimeoutMS;

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1154,6 +1154,7 @@ bool SearchTime_IsTimedOut(void *arg) {
 static BlockedRequestCtx *BlockedRequestCtx_NewCommon(RequestKind kind) {
   BlockedRequestCtx *brc = rm_calloc(1, sizeof(BlockedRequestCtx));
   brc->kind = kind;
+  // TODO($$$): Remove the legacy query offset once consumers use QueryRequest.
   brc->queryOffset = QUERY_OFFSET_NONE;  // "no query argument" until parsing finds one
   brc->refcount = 1;
   // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
@@ -1184,9 +1185,11 @@ void BlockedRequestCtx_DecrRef(BlockedRequestCtx *brc) {
 /* Hold references to `argv` strings whose contents the wrapped request's
  * plan borrows (see BlockedRequestCtx.argv). Runs at construction, on
  * the main thread; released in BlockedRequestCtx_Free, also on main. */
-static void holdArgv(BlockedRequestCtx *brc, RedisModuleString **argv, uint32_t argc) {
+static void holdArgv(BlockedRequestCtx *brc, QueryRequest *request, RedisModuleString **argv,
+                     uint32_t argc) {
   RS_ASSERT(argv != NULL);
   RS_ASSERT(brc->argv == NULL);
+  // TODO($$$): Remove the legacy argv state once consumers use QueryRequest.
   brc->argv = rm_malloc(argc * sizeof(*brc->argv));
   brc->argc = argc;
   brc->parseArgc = argc;  // debug constructors lower it to exclude the debug tail
@@ -1197,6 +1200,9 @@ static void holdArgv(BlockedRequestCtx *brc, RedisModuleString **argv, uint32_t 
     // here instead, before any borrow exists or a worker can see it.
     RedisModule_TrimStringAllocation(brc->argv[ii]);
   }
+  request->args.argv = brc->argv;
+  request->args.argc = brc->argc;
+  request->args.parseArgc = brc->parseArgc;
 }
 
 /* Release an argv array taken by holdArgv: drop each string reference and
@@ -1225,7 +1231,7 @@ BlockedRequestCtx *BlockedRequestCtx_NewAREQ(AREQ *areq, RedisModuleString **arg
   BlockedRequestCtx *brc = BlockedRequestCtx_NewCommon(REQUEST_KIND_AREQ);
   brc->query.areq = areq;
   areq->brc = brc;
-  holdArgv(brc, argv, argc);
+  holdArgv(brc, &areq->base, argv, argc);
   return brc;
 }
 
@@ -1235,7 +1241,7 @@ BlockedRequestCtx *BlockedRequestCtx_NewHybrid(struct HybridRequest *hybrid, Red
   BlockedRequestCtx *brc = BlockedRequestCtx_NewCommon(REQUEST_KIND_HYBRID);
   brc->query.hybrid = hybrid;
   hybrid->brc = brc;
-  holdArgv(brc, argv, argc);
+  holdArgv(brc, &hybrid->base, argv, argc);
   return brc;
 }
 
@@ -1465,7 +1471,9 @@ int AREQ_Compile(AREQ *req, RedisModuleCtx *ctx, uint32_t offset, bool isDiskInd
   BlockedRequestCtx *brc = req->brc;
   RS_ASSERT(brc != NULL);
   RS_ASSERT(offset <= brc->parseArgc && brc->parseArgc <= brc->argc);
+  // TODO($$$): Remove the legacy query offset once consumers use QueryRequest.
   brc->queryOffset = offset;
+  req->base.args.queryOffset = brc->queryOffset;
 
   // Parse the query and basic keywords first..
   // The cursor covers the whole held command, pre-advanced to the parse

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1118,6 +1118,7 @@ bool RunInThread(RedisModuleCtx *ctx) {
 AREQ *AREQ_New(void) {
   AREQ* req = rm_calloc(1, sizeof(AREQ));
   QueryRequest_Init(&req->base, QUERY_REQUEST_KIND_AREQ);
+  QueryRequest_SetEndProcRef(&req->base, &req->pipeline.qctx.endProc);
   /*
   unsigned int dialectVersion;
   long long queryTimeoutMS;

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1159,14 +1159,30 @@ static BlockedRequestCtx *BlockedRequestCtx_NewCommon(RequestKind kind) {
 }
 
 BlockedRequestCtx *BlockedRequestCtx_IncrRef(BlockedRequestCtx *brc) {
+  QueryRequest *request = brc->kind == REQUEST_KIND_AREQ ? (QueryRequest *)brc->query.areq
+                                                        : (QueryRequest *)brc->query.hybrid;
+  atomic_fetch_add_explicit(&request->refcount, 1, memory_order_relaxed);
+  // TODO($$$): Remove the legacy BlockedRequestCtx refcount after all consumers
+  // use QueryRequest.refcount.
   atomic_fetch_add_explicit(&brc->refcount, 1, memory_order_relaxed);
   return brc;
 }
 
 void BlockedRequestCtx_DecrRef(BlockedRequestCtx *brc) {
+  if (!brc) {
+    return;
+  }
+  QueryRequest *request = brc->kind == REQUEST_KIND_AREQ ? (QueryRequest *)brc->query.areq
+                                                        : (QueryRequest *)brc->query.hybrid;
   // ACQ_REL: release ensures our writes are visible before decrement;
   // acquire ensures we see all prior writes when refcount reaches 0.
-  if (brc && atomic_fetch_sub_explicit(&brc->refcount, 1, memory_order_acq_rel) == 1) {
+  int requestRefcount =
+      atomic_fetch_sub_explicit(&request->refcount, 1, memory_order_acq_rel);
+  // TODO($$$): Remove the legacy BlockedRequestCtx refcount after all consumers
+  // use QueryRequest.refcount.
+  int brcRefcount = atomic_fetch_sub_explicit(&brc->refcount, 1, memory_order_acq_rel);
+  RS_ASSERT(requestRefcount == brcRefcount);
+  if (brcRefcount == 1) {
     BlockedRequestCtx_Free(brc);
   }
 }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1154,17 +1154,13 @@ bool SearchTime_IsTimedOut(void *arg) {
 static BlockedRequestCtx *BlockedRequestCtx_NewCommon(RequestKind kind) {
   BlockedRequestCtx *brc = rm_calloc(1, sizeof(BlockedRequestCtx));
   brc->kind = kind;
-  brc->refcount = 1;
   return brc;
 }
 
 BlockedRequestCtx *BlockedRequestCtx_IncrRef(BlockedRequestCtx *brc) {
   QueryRequest *request = brc->kind == REQUEST_KIND_AREQ ? (QueryRequest *)brc->query.areq
                                                         : (QueryRequest *)brc->query.hybrid;
-  atomic_fetch_add_explicit(&request->refcount, 1, memory_order_relaxed);
-  // TODO($$$): Remove the legacy BlockedRequestCtx refcount after all consumers
-  // use QueryRequest.refcount.
-  atomic_fetch_add_explicit(&brc->refcount, 1, memory_order_relaxed);
+  QueryRequest_IncrRef(request);
   return brc;
 }
 
@@ -1174,15 +1170,7 @@ void BlockedRequestCtx_DecrRef(BlockedRequestCtx *brc) {
   }
   QueryRequest *request = brc->kind == REQUEST_KIND_AREQ ? (QueryRequest *)brc->query.areq
                                                         : (QueryRequest *)brc->query.hybrid;
-  // ACQ_REL: release ensures our writes are visible before decrement;
-  // acquire ensures we see all prior writes when refcount reaches 0.
-  int requestRefcount =
-      atomic_fetch_sub_explicit(&request->refcount, 1, memory_order_acq_rel);
-  // TODO($$$): Remove the legacy BlockedRequestCtx refcount after all consumers
-  // use QueryRequest.refcount.
-  int brcRefcount = atomic_fetch_sub_explicit(&brc->refcount, 1, memory_order_acq_rel);
-  RS_ASSERT(requestRefcount == brcRefcount);
-  if (brcRefcount == 1) {
+  if (QueryRequest_DecrRef(request)) {
     BlockedRequestCtx_Free(brc);
   }
 }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1153,6 +1153,7 @@ static BlockedRequestCtx *BlockedRequestCtx_NewCommon(RequestKind kind) {
   BlockedRequestCtx *brc = rm_calloc(1, sizeof(BlockedRequestCtx));
   brc->kind = kind;
   brc->refcount = 1;
+  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
   brc->requiresAggregateResultsSync = false;
   brc->aggregatingResults = false;
   brc->aggregateResultsClaimLost = false;
@@ -1216,8 +1217,11 @@ void BlockedRequestCtx_Free(BlockedRequestCtx *brc) {
 
 bool AREQ_TryClaimAggregateResults(AREQ *req) {
   bool expected = false;
-  return atomic_compare_exchange_strong_explicit(&req->brc->aggregatingResults, &expected, true,
-                                                 memory_order_relaxed, memory_order_relaxed);
+  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
+  bool claimed = atomic_compare_exchange_strong_explicit(
+      &req->brc->aggregatingResults, &expected, true, memory_order_relaxed, memory_order_relaxed);
+  RS_AtomicBoolStoreRelaxed(&req->base.async.aggregatingResults, true);
+  return claimed;
 }
 
 bool BlockedRequestCtx_TryOwnStrictRead(BlockedRequestCtx *brc, BrcStrictReadOwner owner) {
@@ -1230,6 +1234,8 @@ bool BlockedRequestCtx_TryOwnStrictRead(BlockedRequestCtx *brc, BrcStrictReadOwn
 
 void AREQ_SignalAggregateResultsComplete(AREQ *req) {
   pthread_mutex_lock(&req->brc->aggregateResultsLock);
+  req->base.async.aggregateResultsDone = true;
+  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
   req->brc->aggregateResultsDone = true;
   pthread_cond_broadcast(&req->brc->aggregateResultsCond);
   pthread_mutex_unlock(&req->brc->aggregateResultsLock);
@@ -1252,6 +1258,11 @@ static bool BlockedRequestCtx_OwnedRequestTimedOut(BlockedRequestCtx *brc) {
   return RequestSyncState_GetTimedOut(&brc->query.hybrid->syncState);
 }
 
+static QueryRequest *BlockedRequestCtx_QueryRequest(BlockedRequestCtx *brc) {
+  return brc->kind == REQUEST_KIND_AREQ ? (QueryRequest *)brc->query.areq
+                                       : (QueryRequest *)brc->query.hybrid;
+}
+
 /* See aggregate.h for the full handshake contract. The aggregateResultsLock
  * serializes the worker's "set holding, then check timedOut" against the main
  * thread's "set timedOut, then check holding", making the two race-free. */
@@ -1263,6 +1274,8 @@ bool BlockedRequestCtx_SafeLoaderEnterGIL(BlockedRequestCtx *sync) {
     // GIL the main thread holds while it waits.
     proceed = false;
   } else {
+    BlockedRequestCtx_QueryRequest(sync)->async.safeLoadersHoldingGIL++;
+    // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
     sync->safeLoadersHoldingGIL++;
     proceed = true;
   }
@@ -1273,6 +1286,8 @@ bool BlockedRequestCtx_SafeLoaderEnterGIL(BlockedRequestCtx *sync) {
 void BlockedRequestCtx_SafeLoaderExitGIL(BlockedRequestCtx *sync) {
   pthread_mutex_lock(&sync->aggregateResultsLock);
   RS_LOG_ASSERT(sync->safeLoadersHoldingGIL > 0, "SafeLoaderExitGIL without matching EnterGIL");
+  BlockedRequestCtx_QueryRequest(sync)->async.safeLoadersHoldingGIL--;
+  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
   sync->safeLoadersHoldingGIL--;
   pthread_mutex_unlock(&sync->aggregateResultsLock);
 }
@@ -1286,9 +1301,16 @@ bool BlockedRequestCtx_TimeoutPreemptSafeLoaderGIL(BlockedRequestCtx *sync) {
 }
 
 void AREQ_ResetForCursorReadReturnStrict(AREQ *req) {
+  RS_AtomicBoolStoreRelaxed(&req->base.async.aggregatingResults, false);
+  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
   RS_AtomicBoolStoreRelaxed(&req->brc->aggregatingResults, false);
+  req->base.async.aggregateResultsClaimLost = false;
+  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
   req->brc->aggregateResultsClaimLost = false;
   pthread_mutex_lock(&req->brc->aggregateResultsLock);
+  req->base.async.aggregateResultsDone = false;
+  req->base.async.safeLoadersHoldingGIL = 0;
+  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
   req->brc->aggregateResultsDone = false;
   req->brc->safeLoadersHoldingGIL = 0;
   pthread_mutex_unlock(&req->brc->aggregateResultsLock);

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1155,7 +1155,6 @@ static BlockedRequestCtx *BlockedRequestCtx_NewCommon(RequestKind kind) {
   BlockedRequestCtx *brc = rm_calloc(1, sizeof(BlockedRequestCtx));
   brc->kind = kind;
   brc->refcount = 1;
-  brc->reply.err = QueryError_Default();
   return brc;
 }
 
@@ -1197,7 +1196,6 @@ void BlockedRequestCtx_Free(BlockedRequestCtx *brc) {
   // Idempotent after EndCycle; kept as a safety net for wrappers freed
   // outside a cycle. Must run while the owned request is alive: disposing a
   // stashed cursor clears its wrapper handle.
-  ChunkReplyState_Destroy(&brc->reply);
 
   if (brc->kind == REQUEST_KIND_AREQ) {
     AREQ_Free(brc->query.areq);
@@ -1906,11 +1904,9 @@ void AREQ_Free(AREQ *req) {
 }
 
 void AREQ_CleanUpStoredCursor(AREQ *req) {
-  if (req->brc->reply.cursor) {
-    Cursor *cursor = req->brc->reply.cursor;
+  if (req->base.reply.cursor) {
+    Cursor *cursor = req->base.reply.cursor;
     req->base.reply.cursor = NULL;
-    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
-    req->brc->reply.cursor = NULL;
     Cursor_Free(cursor);
   }
 }

--- a/src/aggregate/reply_empty.c
+++ b/src/aggregate/reply_empty.c
@@ -91,7 +91,7 @@ int coord_search_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **argv
 // Uses the common helper which compiles the query to get formatting requirements.
 int coord_aggregate_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, QueryErrorCode errCode) {
 
-    AREQ *req = AREQ_New();
+    AREQ *req = AREQ_New(argv, argc);
     QueryError status = QueryError_Default();
     AREQ_QueryProcessingCtx(req)->err = &status;
 
@@ -201,7 +201,7 @@ int single_shard_common_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString
 
     // Transient, unwrapped AREQ: only flows through the reply-only chunk sender
     // and AREQ_DecrRef, neither of which needs a BlockedRequestCtx.
-    AREQ *req = AREQ_New();
+    AREQ *req = AREQ_New(argv, argc);
     // Clock init required for profiling
     rs_wall_clock_init(&req->profileClocks.initClock);
     rs_wall_clock_init(&AREQ_QueryProcessingCtx(req)->initTime);
@@ -236,7 +236,7 @@ int single_shard_common_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString
 
 int cursor_read_empty_reply_timeout(RedisModuleCtx *ctx, long long cid, bool internal) {
     // Transient, unwrapped AREQ (see single_shard_common_query_reply_empty).
-    AREQ *req = AREQ_New();
+    AREQ *req = AREQ_New(NULL, 0);
     QueryError status = QueryError_Default();
     AREQ_QueryProcessingCtx(req)->err = &status;
 

--- a/src/aggregate/reply_empty.c
+++ b/src/aggregate/reply_empty.c
@@ -246,7 +246,9 @@ int cursor_read_empty_reply_timeout(RedisModuleCtx *ctx, long long cid, bool int
     if (internal) {
         AREQ_AddRequestFlags(req, QEXEC_F_INTERNAL);
     }
+    // TODO($$$): Remove the legacy cursor fields once all consumers use QueryRequest.cursorInfo.
     req->cursor_id = (uint64_t)cid;
+    req->base.cursorInfo.id = (uint64_t)cid;
 
     int ret = empty_sendChunk_common(ctx, req);
     QueryError_ClearError(&status);

--- a/src/aggregate/reply_empty.c
+++ b/src/aggregate/reply_empty.c
@@ -199,8 +199,8 @@ int coord_hybrid_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **argv
 // Uses the common helper which compiles the query and works for both command types.
 int single_shard_common_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int execOptions, QueryErrorCode errCode) {
 
-    // Transient, unwrapped AREQ: only flows through the reply-only chunk sender
-    // and AREQ_DecrRef, neither of which needs a BlockedRequestCtx.
+    // Transient AREQ with no blocked-client cycle: only flows through the reply-only chunk sender
+    // and AREQ_DecrRef, neither of which needs blocked-client cycle state.
     AREQ *req = AREQ_New(argv, argc);
     // Clock init required for profiling
     rs_wall_clock_init(&req->profileClocks.initClock);
@@ -235,7 +235,7 @@ int single_shard_common_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString
 }
 
 int cursor_read_empty_reply_timeout(RedisModuleCtx *ctx, long long cid, bool internal) {
-    // Transient, unwrapped AREQ (see single_shard_common_query_reply_empty).
+    // Transient AREQ with no blocked-client cycle (see single_shard_common_query_reply_empty).
     AREQ *req = AREQ_New(NULL, 0);
     QueryError status = QueryError_Default();
     AREQ_QueryProcessingCtx(req)->err = &status;

--- a/src/aggregate/reply_empty.c
+++ b/src/aggregate/reply_empty.c
@@ -96,7 +96,10 @@ int coord_aggregate_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **a
     AREQ_QueryProcessingCtx(req)->err = &status;
 
     int profileArgs = parseProfileArgs(argv, argc, req);
-    if (profileArgs == -1) return RedisModule_ReplyWithError(ctx, QueryError_GetUserError(&status));
+    if (profileArgs == -1) {
+        AREQ_DecrRef(req);
+        return QueryError_ReplyAndClear(ctx, &status);
+    }
 
     if (shallow_parse_query_args(argv + profileArgs, argc - profileArgs, req) != REDISMODULE_OK) {
         AREQ_DecrRef(req);

--- a/src/aggregate/reply_empty.c
+++ b/src/aggregate/reply_empty.c
@@ -246,8 +246,6 @@ int cursor_read_empty_reply_timeout(RedisModuleCtx *ctx, long long cid, bool int
     if (internal) {
         AREQ_AddRequestFlags(req, QEXEC_F_INTERNAL);
     }
-    // TODO($$$): Remove the legacy cursor fields once all consumers use QueryRequest.cursorInfo.
-    req->cursor_id = (uint64_t)cid;
     req->base.cursorInfo.id = (uint64_t)cid;
 
     int ret = empty_sendChunk_common(ctx, req);

--- a/src/concurrent_ctx.c
+++ b/src/concurrent_ctx.c
@@ -146,14 +146,14 @@ int ConcurrentSearch_HandleRedisCommandEx(int poolType, ConcurrentCmdHandler han
 
   cmdCtx->bc = RedisModule_BlockClient(ctx, handlerCtx->bcCtx.reply_callback,
                                        handlerCtx->bcCtx.timeout_callback,
-                                       handlerCtx->bcCtx.brc ? BlockedRequestCtx_OnFree : NULL,
+                                       handlerCtx->bcCtx.request ? QueryRequest_OnFree : NULL,
                                        handlerCtx->bcCtx.timeoutMS);
 
-  if (handlerCtx->bcCtx.brc) {
+  if (handlerCtx->bcCtx.request) {
     // Safe against the just-armed timer: the timeout callback runs on this
     // same thread.
-    BlockedRequestCtx_BeginCycle(handlerCtx->bcCtx.brc, cmdCtx->bc,
-                                 handlerCtx->bcCtx.reply_callback);
+    QueryRequest_BeginCycle(handlerCtx->bcCtx.request, cmdCtx->bc,
+                            handlerCtx->bcCtx.reply_callback);
   }
 
   cmdCtx->argc = argc;

--- a/src/concurrent_ctx.h
+++ b/src/concurrent_ctx.h
@@ -50,7 +50,7 @@ typedef void (*ConcurrentCmdHandler)(RedisModuleCtx *, RedisModuleString **, int
 
 // Context for concurrent search handler
 // Contains additional parameters passed to ConcurrentSearch_HandleRedisCommandEx
-struct BlockedRequestCtx;  // Forward declaration
+struct QueryRequest;       // Forward declaration
 struct Cursor;             // Forward declaration
 
 // Context for blocking client
@@ -58,11 +58,11 @@ typedef struct ConcurrentSearchBlockClientCtx {
   RedisModuleCmdFunc reply_callback;      // Callback when UnblockClient is called (FAIL policy)
   RedisModuleCmdFunc timeout_callback;    // Callback when timeout fires (FAIL policy)
   rs_wall_clock_ms_t timeoutMS;           // Timeout value in milliseconds (0 if no timeout)
-  // Wrapper owning the request executed by this command. Allocated on the main
-  // thread before blocking; becomes the blocked client's privdata (freed via
-  // BlockedRequestCtx_OnFree). ConcurrentSearch_HandleRedisCommandEx runs
-  // BlockedRequestCtx_BeginCycle on it right after blocking the client.
-  struct BlockedRequestCtx *brc;
+  // Request executed by this command. Allocated on the main thread before
+  // blocking and installed as the blocked client's private data.
+  // ConcurrentSearch_HandleRedisCommandEx begins its cycle immediately after
+  // blocking the client.
+  struct QueryRequest *request;
 } ConcurrentSearchBlockClientCtx;
 
 typedef struct ConcurrentSearchHandlerCtx {

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -788,8 +788,8 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
   // Compile parses the held argv — this job's argv copies die with the job,
   // the plan's borrows must not. The job argv mirrors the original, so the
   // offset computed on it indexes the holds too, and this view's length must
-  // match the wrapper's parse extent (the debug dispatcher trims both).
-  RS_ASSERT((uint32_t)argc == r->brc->parseArgc);
+  // match the request's parse extent (the debug dispatcher trims both).
+  RS_ASSERT((uint32_t)argc == r->base.args.parseArgc);
   rc = AREQ_Compile(r, ctx, ac.offset, SearchDisk_IsEnabledForValidation(), status);
   if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
 

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -866,9 +866,9 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
   SearchCtx_UpdateTime(r->sctx, r->reqConfig.queryTimeoutMS);
   // TODO($$$): Remove the SearchTime mirror once consumers use QueryRequest.timeout.
   // Propagate skipTimeoutChecks from request to sctx.
-  // AREQ_Compile set req->skipTimeoutChecks before sctx existed, so the flag
+  // AREQ_Compile set the request flag before sctx existed, so the flag
   // was not propagated. RPNet and startPipeline read from sctx->time.skipTimeoutChecks.
-  r->sctx->time.skipTimeoutChecks = r->skipTimeoutChecks;
+  r->sctx->time.skipTimeoutChecks = !QueryRequestTimeout_ShouldCheck(&r->base.timeout);
   // r->sctx->expanded should be received from shards
 
   AREQ_SetSkipTimeoutChecks(r, !shouldCheckInPipelineTimeoutCoord(r));

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -334,6 +334,8 @@ static int rpnetCreateIterator(RPNet *nc) {
   // Register the iterator's channel so the main-thread timeout callback can wake
   // this reader if it blocks in MRIterator_NextWithTimeout after AREQ timed out.
   // Paired with RequestSyncState_UnregisterAbortWakeChannel in rpnetFree.
+  nc->areq->base.async.abortWakeChannel = MRIterator_GetChannel(it);
+  // TODO($$$): Remove the legacy abort-wake state once consumers use QueryRequest.async.
   RequestSyncState_RegisterAbortWakeChannel(&nc->areq->syncState, MRIterator_GetChannel(it));
 #ifdef ENABLE_ASSERT
   // Expose the iterator to FT.DEBUG BG_PENDING_REPLIES; cleared in rpnetFree.

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -333,10 +333,9 @@ static int rpnetCreateIterator(RPNet *nc) {
   nc->it = it;
   // Register the iterator's channel so the main-thread timeout callback can wake
   // this reader if it blocks in MRIterator_NextWithTimeout after AREQ timed out.
-  // Paired with RequestSyncState_UnregisterAbortWakeChannel in rpnetFree.
-  nc->areq->base.async.abortWakeChannel = MRIterator_GetChannel(it);
-  // TODO($$$): Remove the legacy abort-wake state once consumers use QueryRequest.async.
-  RequestSyncState_RegisterAbortWakeChannel(&nc->areq->syncState, MRIterator_GetChannel(it));
+  // Paired with QueryRequestAsyncState_UnregisterAbortWakeChannel in rpnetFree.
+  QueryRequestAsyncState_RegisterAbortWakeChannel(&nc->areq->base.async,
+                                                  MRIterator_GetChannel(it));
 #ifdef ENABLE_ASSERT
   // Expose the iterator to FT.DEBUG BG_PENDING_REPLIES; cleared in rpnetFree.
   DebugBgIterator_Set(it);
@@ -1091,7 +1090,7 @@ int DistAggregateTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleStr
 
   // Losing TryClaim means BG owns the claim, it may be blocked in MRIterator_NextWithTimeout.
   // Wake it so it observes the Timeout and exits the pipeline promptly.
-  RequestSyncState_WakeAbortChannel(&req->syncState);
+  QueryRequestAsyncState_WakeAbortChannel(&req->base.async);
 
   // Sync with the background thread
   AREQ_WaitForAggregateResultsComplete(req);
@@ -1181,7 +1180,7 @@ int DistCursorReadTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleSt
 
   // Wake the abort channel — unblocks BG from
   // MRIterator_NextWithTimeout if it's mid-pipeline; no-op otherwise.
-  RequestSyncState_WakeAbortChannel(&req->syncState);
+  QueryRequestAsyncState_WakeAbortChannel(&req->base.async);
 
   // BG owns the read: a started RETURN_STRICT read always stores a
   // cursor-shaped reply, signals completion, and parks/frees the cursor.

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -864,6 +864,7 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
   *r->sctx = SEARCH_CTX_STATIC(ctx, NULL);
   r->sctx->apiVersion = dialect;
   SearchCtx_UpdateTime(r->sctx, r->reqConfig.queryTimeoutMS);
+  // TODO($$$): Remove the SearchTime mirror once consumers use QueryRequest.timeout.
   // Propagate skipTimeoutChecks from request to sctx.
   // AREQ_Compile set req->skipTimeoutChecks before sctx existed, so the flag
   // was not propagated. RPNet and startPipeline read from sctx->time.skipTimeoutChecks.

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -1097,6 +1097,8 @@ int DistAggregateTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleStr
   // BG signals only after AREQ_StoreResults
   RS_ASSERT(req->brc->reply.hasStoredResults);
   if (AREQ_RequestFlags(req) & QEXEC_F_IS_CURSOR) {
+    req->base.reply.rc = RS_RESULT_TIMEDOUT;
+    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
     req->brc->reply.rc = RS_RESULT_TIMEDOUT;
   }
 
@@ -1187,6 +1189,8 @@ int DistCursorReadTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleSt
     // Drain anything queued before the deadline, then serialize and dispose
     // the stashed cursor (Pause if more rows remain, Free on EOF) inside
     // AREQ_ReplyWithStoredResults.
+    req->base.reply.rc = RS_RESULT_TIMEDOUT;
+    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
     req->brc->reply.rc = RS_RESULT_TIMEDOUT;
     drainPartialResultsAfterTimeout(req);
     AREQ_ReplyWithStoredResults(ctx, req);

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -917,7 +917,7 @@ cleanup:
   }
   SpecialCaseCtx_Free(knnCtx);
   // Release the execution flow's reference (taken at shell allocation on the
-  // main thread); the cycle's reference is released by BlockedRequestCtx_OnFree.
+  // main thread); the cycle's reference is released by QueryRequest_OnFree.
   AREQ_DecrRef(r);
   RedisModule_EndReply(reply);
   return;
@@ -973,17 +973,16 @@ static int dispatchAggregateDeferred(AREQ *r, struct ConcurrentCmdCtx *cmdCtx,
 void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                          struct ConcurrentCmdCtx *cmdCtx) {
 
-  // The request shell and its wrapper were allocated on the main thread by the
-  // dispatcher; the wrapper is the blocked client's privdata. This thread only
-  // fills the request in place.
-  BlockedRequestCtx *brc =
+  // The request shell was allocated on the main thread by the dispatcher and
+  // installed as the blocked client's private data. This thread fills it in place.
+  QueryRequest *request =
       RedisModule_BlockClientGetPrivateData(ConcurrentCmdCtx_GetBlockedClient(cmdCtx));
-  AREQ *r = BlockedRequestCtx_GetAREQ(brc);
+  AREQ *r = QueryRequest_GetAREQ(request);
 
   if (AREQ_TimedOut(r)) {
     // Query timed out while this job was queued; the timeout callback already
     // replied. Release the execution flow's reference (the cycle's reference
-    // is released by BlockedRequestCtx_OnFree after the unblock).
+    // is released by QueryRequest_OnFree after the unblock).
     WeakRef_Release(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
     AREQ_DecrRef(r);
     return;
@@ -1054,18 +1053,17 @@ int DistAggregateTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **ar
   UNUSED(argv);
   UNUSED(argc);
 
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
   // Installed by BeginCycle on the main thread before the command returned,
   // so no callback can observe missing privdata.
-  RS_ASSERT(brc != NULL);
-
-  RS_ASSERT(brc->kind == REQUEST_KIND_AREQ);
+  RS_ASSERT(request != NULL);
+  AREQ *req = QueryRequest_GetAREQ(request);
 
   // Signal timeout to the background thread
-  AREQ_SetTimedOut(BlockedRequestCtx_GetAREQ(brc));
+  AREQ_SetTimedOut(req);
 
   // Record the per-stage breakdown at the stage the deadline caught the request.
-  recordCoordAREQTimeoutStage(BlockedRequestCtx_GetAREQ(brc), /*isError=*/true);
+  recordCoordAREQTimeoutStage(req, /*isError=*/true);
 
   // Reply with timeout error
   QueryErrorsGlobalStats_UpdateError(QUERY_ERROR_CODE_TIMED_OUT, 1, COORD_ERR_WARN);
@@ -1094,13 +1092,11 @@ static void drainPartialResultsAfterTimeout(AREQ *req) {
 // Called on the main thread when the blocking client times out (RETURN-STRICT policy only).
 int DistAggregateTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
   // Installed by BeginCycle on the main thread before the command returned,
   // so no callback can observe missing privdata.
-  RS_ASSERT(brc != NULL);
-
-  RS_ASSERT(brc->kind == REQUEST_KIND_AREQ);
-  AREQ *req = BlockedRequestCtx_GetAREQ(brc);
+  RS_ASSERT(request != NULL);
+  AREQ *req = QueryRequest_GetAREQ(request);
 
   // Signal timeout to the background thread
   AREQ_SetTimedOut(req);
@@ -1147,11 +1143,9 @@ int DistAggregateReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, in
   UNUSED(argv);
   UNUSED(argc);
 
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
-  RS_ASSERT(brc != NULL);
-
-  RS_ASSERT(brc->kind == REQUEST_KIND_AREQ);
-  AREQ *req = BlockedRequestCtx_GetAREQ(brc);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
+  RS_ASSERT(request != NULL);
+  AREQ *req = QueryRequest_GetAREQ(request);
 
   // Check if results were stored (background thread completed successfully)
   if (!req->base.reply.hasStoredResults) {
@@ -1176,7 +1170,7 @@ int DistAggregateReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, in
   // and the early-error branch above replies with it.
   AREQ_ReplyWithStoredResults(ctx, req);
 
-  // Note: No AREQ_DecrRef here - BlockedRequestCtx_OnFree releases the cycle's reference.
+  // QueryRequest_OnFree releases the cycle's request reference.
   return REDISMODULE_OK;
 }
 
@@ -1187,18 +1181,16 @@ int DistAggregateReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, in
 // bails are signaled via AREQ_ReplyOrStoreError. The timer waits and branches
 // on `hasStoredResults`.
 int DistCursorReadTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
-  RS_ASSERT(brc != NULL);
-  RS_ASSERT(brc->kind == REQUEST_KIND_AREQ);
-
-  AREQ *req = BlockedRequestCtx_GetAREQ(brc);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
+  RS_ASSERT(request != NULL);
+  AREQ *req = QueryRequest_GetAREQ(request);
   AREQ_SetTimedOut(req);
 
   // Record the per-stage breakdown at the stage the deadline caught the request
   // (QUEUE while BG has not dequeued the read yet).
   recordCoordAREQTimeoutStage(req, /*isError=*/false);
 
-  if (BlockedRequestCtx_TryOwnStrictRead(brc, BRC_READ_OWNER_TIMEOUT)) {
+  if (QueryRequest_TryOwnStrictRead(request, QUERY_REQUEST_READ_OWNER_TIMEOUT)) {
     // The BG worker has not dequeued the read job yet. Waiting here would
     // block the main thread on BG progress (deadlock if the pool is
     // paused/saturated); reply with a depleted cursor instead. The worker
@@ -1238,17 +1230,17 @@ int DistCursorReadTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleSt
 void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                          struct ConcurrentCmdCtx *cmdCtx) {
 
-  // The debug request shell (AREQ_Debug) and its wrapper were allocated on the
-  // main thread by the dispatcher; the wrapper is the blocked client's privdata.
-  BlockedRequestCtx *brc =
+  // The debug request shell (AREQ_Debug) was allocated on the main thread by
+  // the dispatcher and installed as the blocked client's private data.
+  QueryRequest *request =
       RedisModule_BlockClientGetPrivateData(ConcurrentCmdCtx_GetBlockedClient(cmdCtx));
-  AREQ *r = BlockedRequestCtx_GetAREQ(brc);
+  AREQ *r = QueryRequest_GetAREQ(request);
   AREQ_Debug *debug_req = (AREQ_Debug *)r;
 
   if (AREQ_TimedOut(r)) {
     // Query timed out while this job was queued; the timeout callback already
     // replied. Release the execution flow's reference (the cycle's reference
-    // is released by BlockedRequestCtx_OnFree after the unblock).
+    // is released by QueryRequest_OnFree after the unblock).
     WeakRef_Release(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
     AREQ_DecrRef(r);
     return;

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -1074,7 +1074,7 @@ int DistAggregateTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **ar
   return REDISMODULE_OK;
 }
 
-// Drain any queued partial results into `brc->reply.results` on the main
+// Drain any queued partial results into `base.reply.results` on the main
 // thread after the background pipeline has aborted. Flips RPNet to drainOnly
 // mode so the post-abort drain only pulls already-buffered shard replies, then
 // delegates the actual loop to the shared helper.
@@ -1127,11 +1127,9 @@ int DistAggregateTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleStr
   AREQ_WaitForAggregateResultsComplete(req);
 
   // BG signals only after AREQ_StoreResults
-  RS_ASSERT(req->brc->reply.hasStoredResults);
+  RS_ASSERT(req->base.reply.hasStoredResults);
   if (AREQ_RequestFlags(req) & QEXEC_F_IS_CURSOR) {
     req->base.reply.rc = RS_RESULT_TIMEDOUT;
-    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
-    req->brc->reply.rc = RS_RESULT_TIMEDOUT;
   }
 
   // Harvest any shard replies that landed in the channel before the deadline.
@@ -1144,7 +1142,7 @@ int DistAggregateTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleStr
 }
 
 // Main-thread reply callback for coord AREQ (FAIL / RETURN-STRICT). Reads results
-// stored by the BG thread in req->brc->reply. NOT called if timeout fired
+// stored by the BG thread in req->base.reply. NOT called if timeout fired
 int DistAggregateReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   UNUSED(argv);
   UNUSED(argc);
@@ -1156,11 +1154,11 @@ int DistAggregateReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, in
   AREQ *req = BlockedRequestCtx_GetAREQ(brc);
 
   // Check if results were stored (background thread completed successfully)
-  if (!req->brc->reply.hasStoredResults) {
+  if (!req->base.reply.hasStoredResults) {
     // Background thread didn't store results - some early error occurred.
-    if (QueryError_HasError(&req->brc->reply.err)) {
-      QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&req->brc->reply.err), 1, COORD_ERR_WARN);
-      QueryError_ReplyAndClear(ctx, &req->brc->reply.err);
+    if (QueryError_HasError(&req->base.reply.err)) {
+      QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&req->base.reply.err), 1, COORD_ERR_WARN);
+      QueryError_ReplyAndClear(ctx, &req->base.reply.err);
     } else {
       RedisModule_ReplyWithError(ctx, "Internal error: no results stored");
     }
@@ -1174,7 +1172,7 @@ int DistAggregateReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, in
   // still produces rc=TIMEDOUT is the coord's own deadline firing, which
   // routes through DistAggregateTimeoutReturnStrictCallback -- not this
   // callback. Under FAIL, a shard timeout still bails the coord pipeline
-  // early; the BG thread stores the resulting error in brc->reply.err
+  // early; the BG thread stores the resulting error in base.reply.err
   // and the early-error branch above replies with it.
   AREQ_ReplyWithStoredResults(ctx, req);
 
@@ -1217,20 +1215,18 @@ int DistCursorReadTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleSt
   // cursor-shaped reply, signals completion, and parks/frees the cursor.
   AREQ_WaitForAggregateResultsComplete(req);
 
-  if (req->brc->reply.hasStoredResults) {
+  if (req->base.reply.hasStoredResults) {
     // Drain anything queued before the deadline, then serialize and dispose
     // the stashed cursor (Pause if more rows remain, Free on EOF) inside
     // AREQ_ReplyWithStoredResults.
     req->base.reply.rc = RS_RESULT_TIMEDOUT;
-    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
-    req->brc->reply.rc = RS_RESULT_TIMEDOUT;
     drainPartialResultsAfterTimeout(req);
     AREQ_ReplyWithStoredResults(ctx, req);
   } else {
     // Pre-pipeline bail through AREQ_ReplyOrStoreError. Currently unreachable
     // on coord+RETURN_STRICT (coordinator cursors have a NULL spec_ref so the
     // only such bail in cursorRead can't fire); kept for forward-compat.
-    QueryError *err = &req->brc->reply.err;
+    QueryError *err = &req->base.reply.err;
     RS_ASSERT(QueryError_HasError(err));
     QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(err), 1, COORD_ERR_WARN);
     QueryError_ReplyAndClear(ctx, err);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -1311,13 +1311,13 @@ int DistHybridTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString
   }
 
   // Losing TryClaim means BG owns the claim; wait for it to finish writing
-  // `brc->reply` (the abort-channel wakes above let it exit promptly).
+  // `base.reply` (the abort-channel wakes above let it exit promptly).
   HybridRequest_WaitForAggregateResultsComplete(hreq);
 
   // The coordinator hybrid pipeline is not drainable: the tail merger and the
   // per-subquery depleters run on separate coord-pool threads, so a main-thread
   // drain would re-enter live upstream processors. Reply only with whatever the
-  // tail already accumulated into `brc->reply.results` before the deadline.
+  // tail already accumulated into `base.reply.results` before the deadline.
   RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
   serializeStoredResults_hybrid(hreq, reply);
   RedisModule_EndReply(reply);
@@ -1327,7 +1327,7 @@ int DistHybridTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString
 
 // Reply callback for Coordinator HybridRequest execution (FAIL policy).
 // Called on the main thread when the background thread calls UnblockClient.
-// The background thread stored results in hreq->brc->reply, which we use to build the reply.
+// The background thread stored results in hreq->base.reply, which we use to build the reply.
 // Note: This callback is NOT called if timeout fired first (bc->client becomes NULL).
 int DistHybridReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   UNUSED(argv);
@@ -1340,11 +1340,11 @@ int DistHybridReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   HybridRequest *hreq = BlockedRequestCtx_GetHybrid(brc);
 
   // Check if results were stored (background thread completed successfully)
-  if (!hreq->brc->reply.hasStoredResults) {
+  if (!hreq->base.reply.hasStoredResults) {
     // Background thread didn't store results - some early error occurred.
-    if (QueryError_HasError(&hreq->brc->reply.err)) {
-      QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&hreq->brc->reply.err), 1, COORD_ERR_WARN);
-      QueryError_ReplyAndClear(ctx, &hreq->brc->reply.err);
+    if (QueryError_HasError(&hreq->base.reply.err)) {
+      QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&hreq->base.reply.err), 1, COORD_ERR_WARN);
+      QueryError_ReplyAndClear(ctx, &hreq->base.reply.err);
     } else {
       RedisModule_ReplyWithError(ctx, "Internal error: no results stored");
     }

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -1074,7 +1074,7 @@ static void DistHybridCleanups(RedisModuleCtx *ctx,
       IndexSpecRef_Release(*strong_ref);
     }
     // Release the execution flow's reference (taken at shell allocation on the
-    // main thread); the cycle's reference is released by BlockedRequestCtx_OnFree.
+    // main thread); the cycle's reference is released by QueryRequest_OnFree.
     HybridRequest_DecrRef(hreq);
 }
 
@@ -1082,12 +1082,11 @@ static void DistHybridCleanups(RedisModuleCtx *ctx,
 void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                         struct ConcurrentCmdCtx *cmdCtx) {
 
-    // The hybrid request shell and its wrapper were allocated on the main
-    // thread by the dispatcher; the wrapper is the blocked client's privdata.
-    // This thread parses into the shell in place.
-    BlockedRequestCtx *brc =
+    // The hybrid request shell was allocated on the main thread by the
+    // dispatcher and installed as the blocked client's private data.
+    QueryRequest *request =
         RedisModule_BlockClientGetPrivateData(ConcurrentCmdCtx_GetBlockedClient(cmdCtx));
-    HybridRequest *hreq = BlockedRequestCtx_GetHybrid(brc);
+    HybridRequest *hreq = QueryRequest_GetHybrid(request);
     // The tail sctx's redisCtx was cleared at dispatch (it aliased the main
     // thread's command ctx); re-point it at this thread's ctx before any use.
     hreq->sctx->redisCtx = ctx;
@@ -1154,10 +1153,10 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
 void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                             struct ConcurrentCmdCtx *cmdCtx) {
 
-    // See RSExecDistHybrid: the shell + wrapper come from the main thread.
-    BlockedRequestCtx *brc =
+    // See RSExecDistHybrid: the shell comes from the main thread.
+    QueryRequest *request =
         RedisModule_BlockClientGetPrivateData(ConcurrentCmdCtx_GetBlockedClient(cmdCtx));
-    HybridRequest *hreq = BlockedRequestCtx_GetHybrid(brc);
+    HybridRequest *hreq = QueryRequest_GetHybrid(request);
     hreq->sctx->redisCtx = ctx;
 
     if (HybridRequest_TimedOut(hreq)) {
@@ -1251,13 +1250,11 @@ int DistHybridTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv,
   UNUSED(argv);
   UNUSED(argc);
 
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
   // Installed by BeginCycle on the main thread before the command returned,
   // so no callback can observe missing privdata.
-  RS_ASSERT(brc != NULL);
-
-  RS_ASSERT(brc->kind == REQUEST_KIND_HYBRID);
-  HybridRequest *hreq = BlockedRequestCtx_GetHybrid(brc);
+  RS_ASSERT(request != NULL);
+  HybridRequest *hreq = QueryRequest_GetHybrid(request);
 
   // Signal timeout to the background thread
   HybridRequest_SetTimedOut(hreq);
@@ -1279,13 +1276,11 @@ int DistHybridTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv,
 // Timeout callback for Coordinator HybridRequest execution
 // Called on the main thread when the blocking client times out (RETURN-STRICT policy only).
 int DistHybridTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
   // Installed by BeginCycle on the main thread before the command returned,
   // so no callback can observe missing privdata.
-  RS_ASSERT(brc != NULL);
-
-  RS_ASSERT(brc->kind == REQUEST_KIND_HYBRID);
-  HybridRequest *hreq = BlockedRequestCtx_GetHybrid(brc);
+  RS_ASSERT(request != NULL);
+  HybridRequest *hreq = QueryRequest_GetHybrid(request);
 
   // Signal timeout to the background thread
   HybridRequest_SetTimedOut(hreq);
@@ -1333,11 +1328,9 @@ int DistHybridReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   UNUSED(argv);
   UNUSED(argc);
 
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
-  RS_ASSERT(brc != NULL);
-
-  RS_ASSERT(brc->kind == REQUEST_KIND_HYBRID);
-  HybridRequest *hreq = BlockedRequestCtx_GetHybrid(brc);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
+  RS_ASSERT(request != NULL);
+  HybridRequest *hreq = QueryRequest_GetHybrid(request);
 
   // Check if results were stored (background thread completed successfully)
   if (!hreq->base.reply.hasStoredResults) {
@@ -1356,6 +1349,6 @@ int DistHybridReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   serializeStoredResults_hybrid(hreq, reply);
   RedisModule_EndReply(reply);
 
-  // Note: No HybridRequest_DecrRef here - BlockedRequestCtx_OnFree releases the cycle's reference.
+  // QueryRequest_OnFree releases the cycle's request reference.
   return REDISMODULE_OK;
 }

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -866,7 +866,8 @@ static int HybridRequest_prepareCursors(HybridRequest *hreq, QueryError *status)
     // DistHybridCleanups can reply with them.
     if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, knnCtx, status,
                                      oomPolicy, timeoutPolicy, &maxPrefixSearch, &maxPrefixVsim,
-                                     &shardTimedOutWarning, deadline, &hreq->syncState)) {
+                                     &shardTimedOutWarning, deadline, &hreq->syncState,
+                                     &hreq->base.async)) {
         // Handle error
         StrongRef_Release(searchMappingsRef);
         StrongRef_Release(vsimMappingsRef);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -866,7 +866,7 @@ static int HybridRequest_prepareCursors(HybridRequest *hreq, QueryError *status)
     // DistHybridCleanups can reply with them.
     if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef, knnCtx, status,
                                      oomPolicy, timeoutPolicy, &maxPrefixSearch, &maxPrefixVsim,
-                                     &shardTimedOutWarning, deadline, &hreq->syncState,
+                                     &shardTimedOutWarning, deadline, &hreq->base.timeout,
                                      &hreq->base.async)) {
         // Handle error
         StrongRef_Release(searchMappingsRef);
@@ -1228,10 +1228,10 @@ void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 // phase) or a subquery's channel (read phase); wake all of them.
 static void wakeHybridAbortChannels(HybridRequest *hreq) {
   if (!hreq) return;
-  RequestSyncState_WakeAbortChannel(&hreq->syncState);
+  QueryRequestAsyncState_WakeAbortChannel(&hreq->base.async);
   for (size_t i = 0; i < hreq->nrequests; i++) {
     if (hreq->requests[i]) {
-      RequestSyncState_WakeAbortChannel(&hreq->requests[i]->syncState);
+      QueryRequestAsyncState_WakeAbortChannel(&hreq->requests[i]->base.async);
     }
   }
 }

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -290,7 +290,7 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
                                  QueryError *status, const RSOomPolicy oomPolicy,
                                  const RSTimeoutPolicy timeoutPolicy, bool *maxPrefixSearch,
                                  bool *maxPrefixVsim, bool *shardTimedOutWarning,
-                                 const struct timespec *deadline, RequestSyncState *syncState,
+                                 const struct timespec *deadline, QueryRequestTimeout *timeout,
                                  QueryRequestAsyncState *asyncState) {
     CursorMappings *searchMappings = StrongRef_Get(searchMappingsRef);
     CursorMappings *vsimMappings = StrongRef_Get(vsimMappingsRef);
@@ -327,24 +327,20 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     }
 
     // Register the iterator's channel so an external abort - the coordinator timeout
-    // callback (RequestSyncState_WakeAbortChannel) or a client disconnect - can wake
+    // callback or a client disconnect can wake
     // this wait promptly. Unregistered below before the iterator is released.
-    asyncState->abortWakeChannel = MRIterator_GetChannel(it);
-    // TODO($$$): Remove the legacy abort-wake state once consumers use QueryRequest.async.
-    RequestSyncState_RegisterAbortWakeChannel(syncState, MRIterator_GetChannel(it));
+    QueryRequestAsyncState_RegisterAbortWakeChannel(asyncState, MRIterator_GetChannel(it));
 
     // Pass both the deadline and the abort flag: `deadline` is NULL under RETURN-STRICT /
     // disabled timeout checks, where the abort flag is the only wake (chan.c requires
     // at least one non-NULL).
     bool timedOut = false;
-    MRReply *r = MRIterator_NextWithTimeout(it, deadline, &syncState->timedOut, &timedOut);
+    MRReply *r = MRIterator_NextWithTimeout(it, deadline, &timeout->timedOut, &timedOut);
     RS_ASSERT(r == NULL);  // the callbacks never AddReply; a non-NULL reply is a bug
 
-    asyncState->abortWakeChannel = NULL;
-    // TODO($$$): Remove the legacy abort-wake state once consumers use QueryRequest.async.
-    RequestSyncState_UnregisterAbortWakeChannel(syncState);
+    QueryRequestAsyncState_UnregisterAbortWakeChannel(asyncState);
 
-    if (timedOut || RequestSyncState_GetTimedOut(syncState)) {
+    if (timedOut || QueryRequestTimeout_GetTimedOut(timeout)) {
         QueryError_SetCode(status, QUERY_ERROR_CODE_TIMED_OUT);
         MRIterator_Release(it);
         return false;

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -290,7 +290,8 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
                                  QueryError *status, const RSOomPolicy oomPolicy,
                                  const RSTimeoutPolicy timeoutPolicy, bool *maxPrefixSearch,
                                  bool *maxPrefixVsim, bool *shardTimedOutWarning,
-                                 const struct timespec *deadline, RequestSyncState *syncState) {
+                                 const struct timespec *deadline, RequestSyncState *syncState,
+                                 QueryRequestAsyncState *asyncState) {
     CursorMappings *searchMappings = StrongRef_Get(searchMappingsRef);
     CursorMappings *vsimMappings = StrongRef_Get(vsimMappingsRef);
     RS_ASSERT(array_len(searchMappings->mappings) == 0 && array_len(vsimMappings->mappings) == 0);
@@ -328,6 +329,8 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     // Register the iterator's channel so an external abort - the coordinator timeout
     // callback (RequestSyncState_WakeAbortChannel) or a client disconnect - can wake
     // this wait promptly. Unregistered below before the iterator is released.
+    asyncState->abortWakeChannel = MRIterator_GetChannel(it);
+    // TODO($$$): Remove the legacy abort-wake state once consumers use QueryRequest.async.
     RequestSyncState_RegisterAbortWakeChannel(syncState, MRIterator_GetChannel(it));
 
     // Pass both the deadline and the abort flag: `deadline` is NULL under RETURN-STRICT /
@@ -337,6 +340,8 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappingsR
     MRReply *r = MRIterator_NextWithTimeout(it, deadline, &syncState->timedOut, &timedOut);
     RS_ASSERT(r == NULL);  // the callbacks never AddReply; a non-NULL reply is a bug
 
+    asyncState->abortWakeChannel = NULL;
+    // TODO($$$): Remove the legacy abort-wake state once consumers use QueryRequest.async.
     RequestSyncState_UnregisterAbortWakeChannel(syncState);
 
     if (timedOut || RequestSyncState_GetTimedOut(syncState)) {

--- a/src/coord/hybrid/hybrid_cursor_mappings.h
+++ b/src/coord/hybrid/hybrid_cursor_mappings.h
@@ -18,6 +18,7 @@ extern "C" {
 #endif
 
 typedef struct QueryRequestAsyncState QueryRequestAsyncState;
+typedef struct QueryRequestTimeout QueryRequestTimeout;
 
 typedef enum  {
   TYPE_SEARCH,
@@ -38,7 +39,6 @@ typedef struct {
 // forward declaration of QueryError
 typedef struct QueryError QueryError;
 
-typedef struct RequestSyncState RequestSyncState;
 struct timespec;
 
 /**
@@ -70,9 +70,7 @@ typedef struct {
  * @param shardTimedOutWarning Output: set to true if a shard cursor-mapping reply reported timeout
  * @param deadline Absolute CLOCK_MONOTONIC_RAW deadline bounding the wait, or NULL
  *                 when timeout checks are disabled (e.g. RETURN-STRICT). When NULL,
- *                 the wait is unblocked only via `syncState`'s abort flag/channel.
- * @param syncState Per-request sync state whose `timedOut` flag is the abort signal and
- *                whose abort-wake channel slot is (un)registered around the wait.
+ *                 the wait is unblocked only via the request's timeout and abort-wake state.
  * @return true if processing completed (even with warnings), false on fatal errors; status will contain error/warning information
  */
 bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappings,
@@ -80,7 +78,7 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappings,
                                  QueryError *status, RSOomPolicy oomPolicy,
                                  RSTimeoutPolicy timeoutPolicy, bool *maxPrefixSearch,
                                  bool *maxPrefixVsim, bool *shardTimedOutWarning,
-                                 const struct timespec *deadline, RequestSyncState *syncState,
+                                 const struct timespec *deadline, QueryRequestTimeout *timeout,
                                  QueryRequestAsyncState *asyncState);
 
 /**

--- a/src/coord/hybrid/hybrid_cursor_mappings.h
+++ b/src/coord/hybrid/hybrid_cursor_mappings.h
@@ -17,6 +17,8 @@
 extern "C" {
 #endif
 
+typedef struct QueryRequestAsyncState QueryRequestAsyncState;
+
 typedef enum  {
   TYPE_SEARCH,
   TYPE_VSIM,
@@ -78,7 +80,8 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, StrongRef searchMappings,
                                  QueryError *status, RSOomPolicy oomPolicy,
                                  RSTimeoutPolicy timeoutPolicy, bool *maxPrefixSearch,
                                  bool *maxPrefixVsim, bool *shardTimedOutWarning,
-                                 const struct timespec *deadline, RequestSyncState *syncState);
+                                 const struct timespec *deadline, RequestSyncState *syncState,
+                                 QueryRequestAsyncState *asyncState);
 
 /**
  * Apply SHARD_K_RATIO optimization to an MRCommand based on the provided

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -172,7 +172,7 @@ int getNextReply(RPNet *nc) {
   }
 #endif
   MRReply *root = nc->areq
-    ? MRIterator_NextWithTimeout(nc->it, NULL, &nc->areq->syncState.timedOut, NULL)
+    ? MRIterator_NextWithTimeout(nc->it, NULL, &nc->areq->base.timeout.timedOut, NULL)
     : MRIterator_Next(nc->it);
 
   if (root == NULL) {
@@ -305,11 +305,10 @@ int rpnetNext_StartWithMappings(ResultProcessor *rp, SearchResult *r) {
 
     // Register the iterator's channel so the main-thread timeout callback can wake a
     // blocked reader after flipping AREQ's `timedOut` flag. Paired with
-    // RequestSyncState_UnregisterAbortWakeChannel in rpnetFree.
+    // QueryRequestAsyncState_UnregisterAbortWakeChannel in rpnetFree.
     if (nc->areq) {
-      nc->areq->base.async.abortWakeChannel = MRIterator_GetChannel(nc->it);
-      // TODO($$$): Remove the legacy abort-wake state once consumers use QueryRequest.async.
-      RequestSyncState_RegisterAbortWakeChannel(&nc->areq->syncState, MRIterator_GetChannel(nc->it));
+      QueryRequestAsyncState_RegisterAbortWakeChannel(&nc->areq->base.async,
+                                                      MRIterator_GetChannel(nc->it));
     }
 #ifdef ENABLE_ASSERT
     DebugBgIterator_Set(nc->it);
@@ -326,9 +325,7 @@ void rpnetFree(ResultProcessor *rp) {
     // Unregister the abort-wake channel before releasing the iterator, so the main
     // thread's timeout callback cannot observe a channel that is about to be freed.
     if (nc->areq) {
-      nc->areq->base.async.abortWakeChannel = NULL;
-      // TODO($$$): Remove the legacy abort-wake state once consumers use QueryRequest.async.
-      RequestSyncState_UnregisterAbortWakeChannel(&nc->areq->syncState);
+      QueryRequestAsyncState_UnregisterAbortWakeChannel(&nc->areq->base.async);
     }
 #ifdef ENABLE_ASSERT
     // Drop the FT.DEBUG BG_PENDING_REPLIES handle before releasing the iterator.

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -307,6 +307,8 @@ int rpnetNext_StartWithMappings(ResultProcessor *rp, SearchResult *r) {
     // blocked reader after flipping AREQ's `timedOut` flag. Paired with
     // RequestSyncState_UnregisterAbortWakeChannel in rpnetFree.
     if (nc->areq) {
+      nc->areq->base.async.abortWakeChannel = MRIterator_GetChannel(nc->it);
+      // TODO($$$): Remove the legacy abort-wake state once consumers use QueryRequest.async.
       RequestSyncState_RegisterAbortWakeChannel(&nc->areq->syncState, MRIterator_GetChannel(nc->it));
     }
 #ifdef ENABLE_ASSERT
@@ -324,6 +326,8 @@ void rpnetFree(ResultProcessor *rp) {
     // Unregister the abort-wake channel before releasing the iterator, so the main
     // thread's timeout callback cannot observe a channel that is about to be freed.
     if (nc->areq) {
+      nc->areq->base.async.abortWakeChannel = NULL;
+      // TODO($$$): Remove the legacy abort-wake state once consumers use QueryRequest.async.
       RequestSyncState_UnregisterAbortWakeChannel(&nc->areq->syncState);
     }
 #ifdef ENABLE_ASSERT

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -382,7 +382,8 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
   // Surface RETURN_STRICT timeouts on follow-up cursor reads where the channel
   // may already hold a buffered reply (the NULL-reply check below wouldn't fire
   // and we'd silently return rows). Skipped during the timer's own drain.
-  if (areq && areq->useReplyCallback && !nc->drainOnly && AREQ_TimedOut(nc->areq)) {
+  if (areq && QueryRequest_UsesReplyCallback(&areq->base) && !nc->drainOnly &&
+      AREQ_TimedOut(nc->areq)) {
     return RS_RESULT_TIMEDOUT;
   }
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -61,7 +61,7 @@ void CursorList_Init(CursorList *cl, bool is_coord) {
 }
 
 static void Cursor_RemoveFromIdle(Cursor *cur) {
-  CursorList *cl = getCursorList(cur->is_coord);
+  CursorList *cl = getCursorList(CURSOR_IS_COORD(cur->id));
   Array *idle = &cl->idle;
   Cursor **ll = ARRAY_GETARRAY_AS(idle, Cursor **);
   size_t n = ARRAY_GETSIZE_AS(idle, Cursor *);
@@ -81,7 +81,7 @@ static void Cursor_RemoveFromIdle(Cursor *cur) {
 
 /* Assumed to be called under the cursors global lock or upon server shut down. */
 static void Cursor_FreeInternal(Cursor *cur) {
-  CursorList *cl = getCursorList(cur->is_coord);
+  CursorList *cl = getCursorList(CURSOR_IS_COORD(cur->id));
   khiter_t khi = kh_get(cursors, cl->lookup, cur->id);
 
   /* Decrement the used count */
@@ -368,7 +368,6 @@ Cursor *Cursors_Reserve(CursorList *cl, StrongRef global_spec_ref, unsigned inte
   cur->id = CursorList_GenerateId(cl);
   cur->pos = -1;
   cur->timeoutIntervalMs = interval;
-  cur->is_coord = cl->is_coord;
   if(spec) {
     // Get a a weak reference to the spec out of the strong ref, and save it in the
     // cursor's struct.
@@ -385,7 +384,7 @@ done:
 }
 
 int Cursor_Pause(Cursor *cur) {
-  CursorList *cl = getCursorList(cur->is_coord);
+  CursorList *cl = getCursorList(CURSOR_IS_COORD(cur->id));
 
   CursorList_Lock(cl);
   CursorList_IncrCounter(cl);
@@ -468,7 +467,7 @@ int Cursors_Purge(CursorList *cl, uint64_t cid) {
 }
 
 int Cursor_Free(Cursor *cur) {
-  CursorList *cl = getCursorList(cur->is_coord);
+  CursorList *cl = getCursorList(CURSOR_IS_COORD(cur->id));
   CursorList_Lock(cl);
   CursorList_IncrCounter(cl);
   Cursor_FreeInternal(cur);

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -91,13 +91,13 @@ static void Cursor_FreeInternal(Cursor *cur) {
   RS_LOG_ASSERT(kh_get(cursors, cl->lookup, cur->id) == kh_end(cl->lookup),
                                                     "Failed to delete cursor");
   if (cur->hybrid_ref.rm) {
-    // TRANSITIONAL(MOD-16691): the sub-AREQ (and its wrapper) is freed by the
+    // TRANSITIONAL(MOD-16691): the sub-AREQ is freed by the
     // hybrid container; the cursor's hold rides the StrongRef until the
     // container-handoff step.
     StrongRef_Release(cur->hybrid_ref);
     cur->query = NULL;
   } else if (cur->query) {
-    BlockedRequestCtx_DecrRef(cur->query);
+    QueryRequest_DecrRef(cur->query);
     cur->query = NULL;
   }
   // if There's a spec associated with the cursor

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -37,12 +37,12 @@ typedef struct Cursor {
    */
   StrongRef hybrid_ref;
 
-  /** The parked request's wrapper — the cursor is the request's owner between
-   * cycles, holding one wrapper reference released by Cursor_FreeInternal.
+  /** The parked request — the cursor is its owner between cycles, holding one
+   * QueryRequest reference released by Cursor_FreeInternal.
    * NULL only for the hybrid single-cursor fallback.
    * TRANSITIONAL(MOD-16691): hybrid sub-cursors hold their reference through
    * hybrid_ref instead, until the container-handoff step retires it. */
-  BlockedRequestCtx *query;
+  QueryRequest *query;
 
   /** Time when this cursor will no longer be valid, in nanos */
   uint64_t nextTimeoutNs;
@@ -73,15 +73,14 @@ typedef struct Cursor {
   bool delete_mark;
 } Cursor;
 
-/* The AREQ carried by this cursor's wrapper: the parked request for plain
+/* The AREQ carried by this cursor: the parked request for plain
  * cursors, the sub-AREQ for hybrid sub-cursors. NULL for the hybrid
- * single-cursor fallback (no wrapper). */
+ * single-cursor fallback. */
 static inline AREQ *Cursor_AREQ(const Cursor *cur) {
   if (!cur->query) {
     return NULL;
   }
-  RS_ASSERT(cur->query->kind == REQUEST_KIND_AREQ);
-  return cur->query->query.areq;
+  return QueryRequest_GetAREQ(cur->query);
 }
 
 KHASH_MAP_INIT_INT64(cursors, Cursor *);

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -68,9 +68,6 @@ typedef struct Cursor {
    * Should only be accessed under cursor list lock */
   int pos;
 
-  /** Is it an internal coordinator cursor or a user cursor*/
-  bool is_coord;
-
   /** If true, a call to `Cursor_Pause` should drop it instead.
    *  Should only be accessed under cursor list lock */
   bool delete_mark;
@@ -136,8 +133,10 @@ typedef struct CursorList {
 extern CursorList g_CursorsList;
 extern CursorList g_CursorsListCoord;
 
+#define CURSOR_IS_COORD(cid) ((cid) % 2 == 1)
+
 static inline CursorList *GetGlobalCursor(uint64_t cid) {
-  return cid % 2 == 1 ? &g_CursorsListCoord : &g_CursorsList;
+  return CURSOR_IS_COORD(cid) ? &g_CursorsListCoord : &g_CursorsList;
 }
 
 /**

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -426,14 +426,14 @@ void HybridStoreCursorsDebugCtx_SetPause(bool pause) {
   atomic_store(&globalHybridStoreCursorsDebugCtx.pause, pause);
 }
 
-static atomic_uint_fast64_t g_blockedRequestOnFreeCount = 0;
+static atomic_uint_fast64_t g_queryRequestOnFreeCount = 0;
 
-void BlockedRequestOnFreeDebug_Increment(void) {
-  atomic_fetch_add_explicit(&g_blockedRequestOnFreeCount, 1, memory_order_relaxed);
+void QueryRequestOnFreeDebug_Increment(void) {
+  atomic_fetch_add_explicit(&g_queryRequestOnFreeCount, 1, memory_order_relaxed);
 }
 
-uint64_t BlockedRequestOnFreeDebug_GetCount(void) {
-  return atomic_load_explicit(&g_blockedRequestOnFreeCount, memory_order_relaxed);
+uint64_t QueryRequestOnFreeDebug_GetCount(void) {
+  return atomic_load_explicit(&g_queryRequestOnFreeCount, memory_order_relaxed);
 }
 #endif
 
@@ -2823,7 +2823,7 @@ DEBUG_COMMAND(getCoordReduceCount) {
 /**
  * FT.DEBUG QUERY_CONTROLLER GET_BLOCKED_REQUEST_ONFREE_COUNT
  */
-DEBUG_COMMAND(getBlockedRequestOnFreeCount) {
+DEBUG_COMMAND(getQueryRequestOnFreeCount) {
   if (!debugCommandsEnabled(ctx)) {
     return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
   }
@@ -2831,7 +2831,7 @@ DEBUG_COMMAND(getBlockedRequestOnFreeCount) {
     return RedisModule_WrongArity(ctx);
   }
 
-  return RedisModule_ReplyWithLongLong(ctx, (long long)BlockedRequestOnFreeDebug_GetCount());
+  return RedisModule_ReplyWithLongLong(ctx, (long long)QueryRequestOnFreeDebug_GetCount());
 }
 
 /**
@@ -3318,7 +3318,7 @@ DEBUG_COMMAND(queryController) {
     return getCoordReduceCount(ctx, argv + 1, argc - 1);
   }
   if (!strcmp("GET_BLOCKED_REQUEST_ONFREE_COUNT", op)) {
-    return getBlockedRequestOnFreeCount(ctx, argv + 1, argc - 1);
+    return getQueryRequestOnFreeCount(ctx, argv + 1, argc - 1);
   }
   // AggregateResults loop pause commands
   if (!strcmp("SET_PAUSE_AFTER_AGGREGATE_RESULT", op)) {

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -253,11 +253,11 @@ void HybridStoreCursorsDebugCtx_SetPauseAfterEnabled(bool enabled);
 bool HybridStoreCursorsDebugCtx_IsPaused(void);
 void HybridStoreCursorsDebugCtx_SetPause(bool pause);
 
-// Blocked-request OnFree counter. Bumped on every BlockedRequestCtx_OnFree so
+// Blocked-request OnFree counter. Bumped on every QueryRequest_OnFree so
 // tests can deterministically observe that free_privdata has fired without
 // blocking the main thread inside the callback.
-void BlockedRequestOnFreeDebug_Increment(void);
-uint64_t BlockedRequestOnFreeDebug_GetCount(void);
+void QueryRequestOnFreeDebug_Increment(void);
+uint64_t QueryRequestOnFreeDebug_GetCount(void);
 
 // Tracks the currently active coordinator MRIterator so tests can poll the
 // `pending` shard counter via FT.DEBUG BG_PENDING_REPLIES. Set after the

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -1217,6 +1217,8 @@ static int HybridRequest_BuildPipelineAndExecute(StrongRef hybrid_ref, HybridPip
           : HybridQueryReplyCallback;
 
       timeoutMS = hreq->reqConfig.queryTimeoutMS;
+      QueryRequest_SetUseReplyCallback(&hreq->base, true);
+      // TODO($$$): Remove the legacy field once consumers use QueryRequest.
       hreq->useReplyCallback = true;
 
       if (timeoutPolicy == TimeoutPolicy_Fail) {

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -1230,6 +1230,8 @@ static int HybridRequest_BuildPipelineAndExecute(StrongRef hybrid_ref, HybridPip
         timeoutCallback = internal
             ? HybridQueryCursorTimeoutReturnStrictCallback
             : HybridQueryTimeoutReturnStrictCallback;
+        hreq->base.async.requiresAggregateResultsSync = true;
+        // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
         hreq->brc->requiresAggregateResultsSync = true;
       }
     }

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -547,7 +547,12 @@ static inline void debugPauseHybridStoreCursors(HybridRequest *hreq, bool before
  * @param cv Cached variables for result serialization
  */
 void HREQ_StoreResults(HybridRequest *hreq, SearchResult **results, int rc, cachedVars cv) {
-  // Store results in hreq for reply_callback to use
+  hreq->base.reply.results = results;
+  hreq->base.reply.rc = rc;
+  hreq->base.reply.cv = cv;
+  hreq->base.reply.hasStoredResults = true;
+
+  // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
   hreq->brc->reply.results = results;
   hreq->brc->reply.rc = rc;
   hreq->brc->reply.cv = cv;
@@ -564,6 +569,9 @@ void HREQ_ReplyOrStoreError(HybridRequest *hreq, RedisModuleCtx *ctx, QueryError
   if (hreq->useReplyCallback) {
     // Deep copy since QueryError contains heap-allocated strings.
     // reply_callback will clear the stored error after replying.
+    QueryError_ClearError(&hreq->base.reply.err);
+    QueryError_CloneFrom(status, &hreq->base.reply.err);
+    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
     QueryError_ClearError(&hreq->brc->reply.err);
     QueryError_CloneFrom(status, &hreq->brc->reply.err);
     // Clear the original to avoid leaking heap-allocated strings.
@@ -667,6 +675,9 @@ void serializeStoredResults_hybrid(HybridRequest *hreq, RedisModule_Reply *reply
     serializeAndReplyResults_hybrid(hreq, reply, rp, qctx, rc, &stored->cv, &r, &results, &err);
 
     // Clear stored results pointer since ownership was transferred
+    hreq->base.reply.results = NULL;
+    hreq->base.reply.hasStoredResults = false;
+    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
     stored->results = NULL;
     stored->hasStoredResults = false;
 

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -488,7 +488,7 @@ static bool serializeAndReplyResults_hybrid(HybridRequest *hreq, RedisModule_Rep
 // (coordinator-dispatched) HybridRequests, and the default (BOTH) applies to all.
 static inline void debugPauseStoreResultsHybrid(HybridRequest *hreq, bool before) {
   // Only pause if we are using reply callback (otherwise we don't store results)
-  if (!hreq->useReplyCallback) {
+  if (!QueryRequest_UsesReplyCallback(&hreq->base)) {
     return;
   }
   bool enabled = before ? StoreResultsDebugCtx_IsPauseBeforeEnabled()
@@ -566,7 +566,7 @@ void HREQ_StoreResults(HybridRequest *hreq, SearchResult **results, int rc, cach
 //   timeout warning when the error is a non-fail-policy timeout (no result set
 //   was produced here), otherwise the error itself.
 void HREQ_ReplyOrStoreError(HybridRequest *hreq, RedisModuleCtx *ctx, QueryError *status) {
-  if (hreq->useReplyCallback) {
+  if (QueryRequest_UsesReplyCallback(&hreq->base)) {
     // Deep copy since QueryError contains heap-allocated strings.
     // reply_callback will clear the stored error after replying.
     QueryError_ClearError(&hreq->base.reply.err);
@@ -623,7 +623,7 @@ void sendChunk_hybrid(HybridRequest *hreq, RedisModule_Reply *reply, size_t limi
 
     startPipelineHybrid(hreq, rp, &results, &r, &rc);
 
-    if (hreq->useReplyCallback) {
+    if (QueryRequest_UsesReplyCallback(&hreq->base)) {
       // Store results for reply_callback (includes cv)
       debugPauseStoreResultsHybrid(hreq, true);  // pause before
       HREQ_StoreResults(hreq, results, rc, cv);
@@ -918,7 +918,7 @@ int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, Q
     // Pause after store cursors (hybrid cursors only)
     debugPauseHybridStoreCursors(req, false);
 
-    if (!req->useReplyCallback) {
+    if (!QueryRequest_UsesReplyCallback(&req->base)) {
       // If we are not using reply callback, we should reply with the cursors here
       replyWithCursors(replyCtx, req->cursors, req, depletionTimedOut);
       array_free(req->cursors);
@@ -1218,8 +1218,6 @@ static int HybridRequest_BuildPipelineAndExecute(StrongRef hybrid_ref, HybridPip
 
       timeoutMS = hreq->reqConfig.queryTimeoutMS;
       QueryRequest_SetUseReplyCallback(&hreq->base, true);
-      // TODO($$$): Remove the legacy field once consumers use QueryRequest.
-      hreq->useReplyCallback = true;
 
       if (timeoutPolicy == TimeoutPolicy_Fail) {
         timeoutCallback = HybridQueryTimeoutFailCallback;

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -751,6 +751,8 @@ int HybridRequest_StartSingleCursor(StrongRef hybrid_ref, RedisModule_Reply *rep
       return REDISMODULE_ERR;
     }
     cursor->hybrid_ref = hybrid_ref;
+    // TODO($$$): Stop mirroring Cursor fields once QueryRequest owns the cursor information.
+    req->base.cursorInfo.id = cursor->id;
     RedisModule_Reply_LongLong(reply, cursor->id);;
     return REDISMODULE_OK;
 }
@@ -846,7 +848,9 @@ int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, Q
       cursor->hybrid_ref = StrongRef_Clone(hybrid_ref);
       cursor->queryTimeoutMS = (size_t)areq->reqConfig.queryTimeoutMS;
       cursor->queryTimeoutPolicy = areq->reqConfig.timeoutPolicy;
+      // TODO($$$): Remove the legacy cursor fields once all consumers use QueryRequest.cursorInfo.
       areq->cursor_id = cursor->id;
+      areq->base.cursorInfo.id = cursor->id;
       array_ensure_append_1(cursors, cursor);
     }
 

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -260,23 +260,22 @@ static bool hreq_timeout_or_pending_spec_writers(void *arg) {
 #endif
 
 void HybridRequest_LinkReturnStrictSafeLoaderSyncCtx(HybridRequest *hreq) {
-  // The tail and every subquery pipeline link the top-level wrapper: sub-AREQs
-  // have no wrapper of their own, and the GIL-handshake state (a counter, so
-  // concurrent loaders keep it accurate) lives on the hybrid's BlockedRequestCtx.
-  RPSafeLoader_SetSyncCtx(&hreq->tailPipeline->qctx, hreq->brc);
+  // The tail and every subquery pipeline link the top-level request, whose
+  // GIL-handshake state is a counter shared by concurrent loaders.
+  RPSafeLoader_SetSyncCtx(&hreq->tailPipeline->qctx, &hreq->base);
 
   for (size_t i = 0; i < hreq->nrequests; i++) {
     AREQ *subquery = hreq->requests[i];
     if (subquery) {
-      RPSafeLoader_SetSyncCtx(AREQ_QueryProcessingCtx(subquery), hreq->brc);
+      RPSafeLoader_SetSyncCtx(AREQ_QueryProcessingCtx(subquery), &hreq->base);
     }
   }
 }
 
 bool HybridRequest_TimeoutPreemptSafeLoaderGIL(HybridRequest *hreq) {
-  // The tail and all subquery safe loaders share the top-level wrapper, so a
+  // The tail and all subquery safe loaders share the top-level request, so a
   // single check covers every pipeline.
-  return BlockedRequestCtx_TimeoutPreemptSafeLoaderGIL(hreq->brc);
+  return QueryRequest_TimeoutPreemptSafeLoaderGIL(&hreq->base);
 }
 
 static void startPipelineHybrid(HybridRequest *hreq, ResultProcessor *rp, SearchResult ***results, SearchResult *r, int *rc) {
@@ -835,12 +834,11 @@ int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, Q
       if (!cursor) {
         break;
       }
-      // FT.CURSOR READ cycles run against the read sub-AREQ's wrapper.
+      // FT.CURSOR READ cycles run against the read sub-AREQ.
       // TRANSITIONAL(MOD-16691): the cursor's own hold rides hybrid_ref until
       // the container-handoff step.
-      RS_ASSERT(areq->brc != NULL);
       // The cursor lifetime will determine the hybrid request lifetime
-      cursor->query = areq->brc;
+      cursor->query = &areq->base;
       cursor->hybrid_ref = StrongRef_Clone(hybrid_ref);
       cursor->queryTimeoutMS = (size_t)areq->reqConfig.queryTimeoutMS;
       cursor->queryTimeoutPolicy = areq->reqConfig.timeoutPolicy;
@@ -984,12 +982,12 @@ static int HybridQueryTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString
   UNUSED(argv);
   UNUSED(argc);
 
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
   // Installed by BeginCycle on the main thread before the command returned,
   // so no callback can observe missing privdata.
-  RS_ASSERT(brc != NULL);
+  RS_ASSERT(request != NULL);
 
-  HybridRequest *hreq = BlockedRequestCtx_GetHybrid(brc);
+  HybridRequest *hreq = QueryRequest_GetHybrid(request);
 
   // Signal timeout to background thread
   HybridRequest_SetTimedOut(hreq);
@@ -1026,12 +1024,12 @@ static int HybridQueryTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModu
   UNUSED(argv);
   UNUSED(argc);
 
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
   // Installed by BeginCycle on the main thread before the command returned,
   // so no callback can observe missing privdata.
-  RS_ASSERT(brc != NULL);
+  RS_ASSERT(request != NULL);
 
-  HybridRequest *hreq = BlockedRequestCtx_GetHybrid(brc);
+  HybridRequest *hreq = QueryRequest_GetHybrid(request);
 
   // Signal timeout to the worker and to all subquery depleters.
   HybridRequest_SetTimedOut(hreq);
@@ -1071,12 +1069,12 @@ static int HybridQueryCursorTimeoutReturnStrictCallback(RedisModuleCtx *ctx, Red
   UNUSED(argv);
   UNUSED(argc);
 
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
   // Installed by BeginCycle on the main thread before the command returned,
   // so no callback can observe missing privdata.
-  RS_ASSERT(brc != NULL);
+  RS_ASSERT(request != NULL);
 
-  HybridRequest *hreq = BlockedRequestCtx_GetHybrid(brc);
+  HybridRequest *hreq = QueryRequest_GetHybrid(request);
 
   // Signal timeout to background thread
   HybridRequest_SetTimedOut(hreq);
@@ -1111,12 +1109,12 @@ static int HybridQueryCursorReplyCallback(RedisModuleCtx *ctx, RedisModuleString
   UNUSED(argv);
   UNUSED(argc);
 
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
   // Installed by BeginCycle on the main thread before the command returned,
   // so no callback can observe missing privdata.
-  RS_ASSERT(brc != NULL);
+  RS_ASSERT(request != NULL);
 
-  HybridRequest *req = BlockedRequestCtx_GetHybrid(brc);
+  HybridRequest *req = QueryRequest_GetHybrid(request);
 
   if (QueryError_HasError(&req->base.reply.err)) {
     QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&req->base.reply.err), 1, SHARD_ERR_WARN);
@@ -1142,12 +1140,12 @@ static int HybridQueryReplyCallback(RedisModuleCtx *ctx, RedisModuleString **arg
   UNUSED(argv);
   UNUSED(argc);
 
-  BlockedRequestCtx *brc = RedisModule_GetBlockedClientPrivateData(ctx);
+  QueryRequest *request = RedisModule_GetBlockedClientPrivateData(ctx);
   // Installed by BeginCycle on the main thread before the command returned,
   // so no callback can observe missing privdata.
-  RS_ASSERT(brc != NULL);
+  RS_ASSERT(request != NULL);
 
-  HybridRequest *req = BlockedRequestCtx_GetHybrid(brc);
+  HybridRequest *req = QueryRequest_GetHybrid(request);
 
   // Check if results were stored (background thread completed successfully)
   if (!req->base.reply.hasStoredResults) {
@@ -1220,7 +1218,7 @@ static int HybridRequest_BuildPipelineAndExecute(StrongRef hybrid_ref, HybridPip
     }
 
     RedisModuleBlockedClient* blockedClient = BlockQueryClientWithTimeout(
-        ctx, spec_ref, hreq->brc, replyCallback, timeoutCallback, timeoutMS);
+        ctx, spec_ref, &hreq->base, replyCallback, timeoutCallback, timeoutMS);
 
     blockedClientHybridCtx *BCHCtx = blockedClientHybridCtx_New(StrongRef_Clone(hybrid_ref), hybridParams, blockedClient, spec_ref, internal);
 

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -1227,8 +1227,6 @@ static int HybridRequest_BuildPipelineAndExecute(StrongRef hybrid_ref, HybridPip
             ? HybridQueryCursorTimeoutReturnStrictCallback
             : HybridQueryTimeoutReturnStrictCallback;
         hreq->base.async.requiresAggregateResultsSync = true;
-        // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-        hreq->brc->requiresAggregateResultsSync = true;
       }
     }
 

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -538,11 +538,11 @@ static inline void debugPauseHybridStoreCursors(HybridRequest *hreq, bool before
 /**
  * Store pipeline results for reply_callback path (FAIL policy with workers).
  * Called after startPipelineHybrid when using reply_callback mode.
- * Stores results in hreq->brc->reply so serializeStoredResults_hybrid can be called
+ * Stores results in hreq->base.reply so serializeStoredResults_hybrid can be called
  * from the reply_callback on the main thread.
  *
  * @param hreq The hybrid request
- * @param results Pipeline results (ownership transferred to brc->reply)
+ * @param results Pipeline results (ownership transferred to hreq->base.reply)
  * @param rc Pipeline return code
  * @param cv Cached variables for result serialization
  */
@@ -552,11 +552,6 @@ void HREQ_StoreResults(HybridRequest *hreq, SearchResult **results, int rc, cach
   hreq->base.reply.cv = cv;
   hreq->base.reply.hasStoredResults = true;
 
-  // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
-  hreq->brc->reply.results = results;
-  hreq->brc->reply.rc = rc;
-  hreq->brc->reply.cv = cv;
-  hreq->brc->reply.hasStoredResults = true;
 }
 
 // Helper for error handling in coordinator HREQ execution.
@@ -571,9 +566,6 @@ void HREQ_ReplyOrStoreError(HybridRequest *hreq, RedisModuleCtx *ctx, QueryError
     // reply_callback will clear the stored error after replying.
     QueryError_ClearError(&hreq->base.reply.err);
     QueryError_CloneFrom(status, &hreq->base.reply.err);
-    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
-    QueryError_ClearError(&hreq->brc->reply.err);
-    QueryError_CloneFrom(status, &hreq->brc->reply.err);
     // Clear the original to avoid leaking heap-allocated strings.
     QueryError_ClearError(status);
   } else if (!ShouldReplyWithError(QueryError_GetCode(status),
@@ -653,7 +645,7 @@ done_err:
 void serializeStoredResults_hybrid(HybridRequest *hreq, RedisModule_Reply *reply) {
     QueryProcessingCtx *qctx = &hreq->tailPipeline->qctx;
     ResultProcessor *rp = qctx->endProc;
-    ChunkReplyState *stored = &hreq->brc->reply;
+    ChunkReplyState *stored = &hreq->base.reply;
 
     // Create a stack-allocated SearchResult for finishSendChunk_HREQ cleanup
     SearchResult r = SearchResult_New();
@@ -675,9 +667,6 @@ void serializeStoredResults_hybrid(HybridRequest *hreq, RedisModule_Reply *reply
     serializeAndReplyResults_hybrid(hreq, reply, rp, qctx, rc, &stored->cv, &r, &results, &err);
 
     // Clear stored results pointer since ownership was transferred
-    hreq->base.reply.results = NULL;
-    hreq->base.reply.hasStoredResults = false;
-    // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
     stored->results = NULL;
     stored->hasStoredResults = false;
 
@@ -1064,7 +1053,7 @@ static int HybridQueryTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModu
 
   HybridRequest_WaitForAggregateResultsComplete(hreq);
 
-  RS_ASSERT(hreq->brc->reply.hasStoredResults);
+  RS_ASSERT(hreq->base.reply.hasStoredResults);
 
   RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
   serializeStoredResults_hybrid(hreq, reply);
@@ -1129,9 +1118,9 @@ static int HybridQueryCursorReplyCallback(RedisModuleCtx *ctx, RedisModuleString
 
   HybridRequest *req = BlockedRequestCtx_GetHybrid(brc);
 
-  if (QueryError_HasError(&req->brc->reply.err)) {
-    QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&req->brc->reply.err), 1, SHARD_ERR_WARN);
-    QueryError_ReplyAndClear(ctx, &req->brc->reply.err);
+  if (QueryError_HasError(&req->base.reply.err)) {
+    QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&req->base.reply.err), 1, SHARD_ERR_WARN);
+    QueryError_ReplyAndClear(ctx, &req->base.reply.err);
     return REDISMODULE_OK;
   }
 
@@ -1161,11 +1150,11 @@ static int HybridQueryReplyCallback(RedisModuleCtx *ctx, RedisModuleString **arg
   HybridRequest *req = BlockedRequestCtx_GetHybrid(brc);
 
   // Check if results were stored (background thread completed successfully)
-  if (!req->brc->reply.hasStoredResults) {
+  if (!req->base.reply.hasStoredResults) {
     // Background thread didn't store results - some early error occurred.
-    if (QueryError_HasError(&req->brc->reply.err)) {
-      QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&req->brc->reply.err), 1, COORD_ERR_WARN);
-      QueryError_ReplyAndClear(ctx, &req->brc->reply.err);
+    if (QueryError_HasError(&req->base.reply.err)) {
+      QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&req->base.reply.err), 1, COORD_ERR_WARN);
+      QueryError_ReplyAndClear(ctx, &req->base.reply.err);
     } else {
       RedisModule_ReplyWithError(ctx, "Internal error: no results stored");
     }

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -842,8 +842,6 @@ int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, Q
       cursor->hybrid_ref = StrongRef_Clone(hybrid_ref);
       cursor->queryTimeoutMS = (size_t)areq->reqConfig.queryTimeoutMS;
       cursor->queryTimeoutPolicy = areq->reqConfig.timeoutPolicy;
-      // TODO($$$): Remove the legacy cursor fields once all consumers use QueryRequest.cursorInfo.
-      areq->cursor_id = cursor->id;
       areq->base.cursorInfo.id = cursor->id;
       array_ensure_append_1(cursors, cursor);
     }

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -315,8 +315,6 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
 
     // Initialize timeout coordination fields (embedded per-request slot only;
     // the aggregate-coord fields live on the heap BlockedRequestCtx wrapper).
-    // TODO($$$): Remove RequestSyncState once consumers use QueryRequest timeout/async state.
-    RequestSyncState_Init(&hybridReq->syncState);
     pthread_mutex_init(&hybridReq->cursorMutex, NULL);
 
 
@@ -429,8 +427,6 @@ void HybridRequest_Free(HybridRequest *req) {
 
     rm_free(req->debugParams);
 
-    // TODO($$$): Remove RequestSyncState once consumers use QueryRequest timeout/async state.
-    RequestSyncState_Destroy(&req->syncState);
     QueryRequest_Destroy(&req->base);
 
     if (req->args) {
@@ -560,10 +556,8 @@ void AddValidationErrorContext(AREQ *req, QueryError *status) {
 
 void HybridRequest_SetTimedOut(HybridRequest *req) {
   QueryRequestTimeout_SetTimedOut(&req->base.timeout);
-  // TODO($$$): Remove the legacy timeout state once consumers use QueryRequest.timeout.
-  RequestSyncState_SetTimedOut(&req->syncState);
   // Propagate to each subquery AREQ so its RPNet's MRChannel_PopWithTimeout
-  // abort flag (&areq->syncState.timedOut) is flipped. Without this the BG
+  // abort flag (&areq->base.timeout.timedOut) is flipped. Without this the BG
   // worker can stay parked on the channel even after the hybrid-level flag
   // is set.
   for (size_t i = 0; i < req->nrequests; i++) {

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -315,6 +315,7 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
 
     // Initialize timeout coordination fields (embedded per-request slot only;
     // the aggregate-coord fields live on the heap BlockedRequestCtx wrapper).
+    // TODO($$$): Remove RequestSyncState once consumers use QueryRequest timeout/async state.
     RequestSyncState_Init(&hybridReq->syncState);
     pthread_mutex_init(&hybridReq->cursorMutex, NULL);
 
@@ -428,6 +429,7 @@ void HybridRequest_Free(HybridRequest *req) {
 
     rm_free(req->debugParams);
 
+    // TODO($$$): Remove RequestSyncState once consumers use QueryRequest timeout/async state.
     RequestSyncState_Destroy(&req->syncState);
     QueryRequest_Destroy(&req->base);
 
@@ -557,6 +559,8 @@ void AddValidationErrorContext(AREQ *req, QueryError *status) {
 }
 
 void HybridRequest_SetTimedOut(HybridRequest *req) {
+  QueryRequestTimeout_SetTimedOut(&req->base.timeout);
+  // TODO($$$): Remove the legacy timeout state once consumers use QueryRequest.timeout.
   RequestSyncState_SetTimedOut(&req->syncState);
   // Propagate to each subquery AREQ so its RPNet's MRChannel_PopWithTimeout
   // abort flag (&areq->syncState.timedOut) is flipped. Without this the BG

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -308,29 +308,20 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
     // Initialize pipelines for each individual request
     for (size_t i = 0; i < nrequests; i++) {
         initializeAREQ(requests[i]);
-        // Each sub-AREQ gets its own wrapper, holding the whole command
-        // rather than its own slice: slice boundaries are only discovered
-        // while parsing, and sub pipelines borrow beyond their slice anyway
-        // (distributed tail steps like LOAD, PARAMS).
-        BlockedRequestCtx_NewAREQ(requests[i]);
         hybridReq->errors[i] = QueryError_Default();
         Pipeline_Initialize(&requests[i]->pipeline, requests[i]->reqConfig.timeoutPolicy, &hybridReq->errors[i]);
     }
     hybridReq->profileClocks.initClock = now;
 
-    // Initialize timeout coordination fields (embedded per-request slot only;
-    // the aggregate-coord fields live on the heap BlockedRequestCtx wrapper).
+    // Initialize timeout coordination fields.
     pthread_mutex_init(&hybridReq->cursorMutex, NULL);
 }
 
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests, RedisModuleString **argv, uint32_t argc) {
-    // The wrappers hold the full command; each sub takes its own holds — a
+    // The requests hold the full command; each sub takes its own holds — a
     // sub's borrows can outlive the container.
     HybridRequest *hybridReq = rm_calloc(1, sizeof(*hybridReq));
     HybridRequest_Init(hybridReq, sctx, requests, nrequests, argv, argc);
-    // Wrap the top-level hybrid request in its single-owner sync context.
-    // Sets hybridReq->brc; ownership is released via HybridRequest_DecrRef.
-    BlockedRequestCtx_NewHybrid(hybridReq);
     return hybridReq;
 }
 
@@ -430,17 +421,13 @@ void HybridRequest_Free(HybridRequest *req) {
 }
 
 HybridRequest *HybridRequest_IncrRef(HybridRequest *req) {
-  RS_LOG_ASSERT(req->brc != NULL, "HybridRequest_IncrRef called on unwrapped request");
-  BlockedRequestCtx_IncrRef(req->brc);
+  QueryRequest_IncrRef(&req->base);
   return req;
 }
 
 void HybridRequest_DecrRef(HybridRequest *req) {
   if (!req) return;
-  // Delegate to the wrapper: BlockedRequestCtx_DecrRef → 0 → BlockedRequestCtx_Free
-  // → HybridRequest_Free.
-  RS_LOG_ASSERT(req->brc != NULL, "HybridRequest_DecrRef called on unwrapped request");
-  BlockedRequestCtx_DecrRef(req->brc);
+  QueryRequest_DecrRef(&req->base);
 }
 
 static bool isSoftTailPipelineErrorCode(QueryErrorCode code) {

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -559,28 +559,25 @@ void HybridRequest_SetTimedOut(HybridRequest *req) {
 
 bool HybridRequest_TryClaimAggregateResults(HybridRequest *req) {
   bool expected = false;
-  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-  bool claimed = atomic_compare_exchange_strong_explicit(
-      &req->brc->aggregatingResults, &expected, true, memory_order_relaxed, memory_order_relaxed);
-  RS_AtomicBoolStoreRelaxed(&req->base.async.aggregatingResults, true);
-  return claimed;
+  return atomic_compare_exchange_strong_explicit(&req->base.async.aggregatingResults, &expected,
+                                                 true, memory_order_relaxed,
+                                                 memory_order_relaxed);
 }
 
 void HybridRequest_SignalAggregateResultsComplete(HybridRequest *req) {
-  pthread_mutex_lock(&req->brc->aggregateResultsLock);
+  pthread_mutex_lock(&req->base.async.aggregateResultsLock);
   req->base.async.aggregateResultsDone = true;
-  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-  req->brc->aggregateResultsDone = true;
-  pthread_cond_broadcast(&req->brc->aggregateResultsCond);
-  pthread_mutex_unlock(&req->brc->aggregateResultsLock);
+  pthread_cond_broadcast(&req->base.async.aggregateResultsCond);
+  pthread_mutex_unlock(&req->base.async.aggregateResultsLock);
 }
 
 void HybridRequest_WaitForAggregateResultsComplete(HybridRequest *req) {
-  pthread_mutex_lock(&req->brc->aggregateResultsLock);
-  while (!req->brc->aggregateResultsDone) {
-    pthread_cond_wait(&req->brc->aggregateResultsCond, &req->brc->aggregateResultsLock);
+  pthread_mutex_lock(&req->base.async.aggregateResultsLock);
+  while (!req->base.async.aggregateResultsDone) {
+    pthread_cond_wait(&req->base.async.aggregateResultsCond,
+                      &req->base.async.aggregateResultsLock);
   }
-  pthread_mutex_unlock(&req->brc->aggregateResultsLock);
+  pthread_mutex_unlock(&req->base.async.aggregateResultsLock);
 }
 
 #ifdef __cplusplus

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -303,6 +303,7 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
     AGPLN_Init(&hybridReq->tailPipeline->ap);
     hybridReq->tailPipelineError = QueryError_Default();
     Pipeline_Initialize(hybridReq->tailPipeline, hybridReq->reqConfig.timeoutPolicy, &hybridReq->tailPipelineError);
+    QueryRequest_SetEndProcRef(&hybridReq->base, &hybridReq->tailPipeline->qctx.endProc);
 
     // Initialize pipelines for each individual request
     for (size_t i = 0; i < nrequests; i++) {

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -279,6 +279,7 @@ int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params
  * @param nrequests Number of requests in the array
  */
 void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **requests, size_t nrequests) {
+    QueryRequest_Init(&hybridReq->base, QUERY_REQUEST_KIND_HYBRID);
     hybridReq->requests = requests;
     hybridReq->nrequests = nrequests;
     hybridReq->sctx = sctx;

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -571,12 +571,17 @@ void HybridRequest_SetTimedOut(HybridRequest *req) {
 
 bool HybridRequest_TryClaimAggregateResults(HybridRequest *req) {
   bool expected = false;
-  return atomic_compare_exchange_strong_explicit(&req->brc->aggregatingResults, &expected, true,
-                                                 memory_order_relaxed, memory_order_relaxed);
+  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
+  bool claimed = atomic_compare_exchange_strong_explicit(
+      &req->brc->aggregatingResults, &expected, true, memory_order_relaxed, memory_order_relaxed);
+  RS_AtomicBoolStoreRelaxed(&req->base.async.aggregatingResults, true);
+  return claimed;
 }
 
 void HybridRequest_SignalAggregateResultsComplete(HybridRequest *req) {
   pthread_mutex_lock(&req->brc->aggregateResultsLock);
+  req->base.async.aggregateResultsDone = true;
+  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
   req->brc->aggregateResultsDone = true;
   pthread_cond_broadcast(&req->brc->aggregateResultsCond);
   pthread_mutex_unlock(&req->brc->aggregateResultsLock);

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -279,7 +279,7 @@ int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params
  * @param nrequests Number of requests in the array
  */
 void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **requests, size_t nrequests, RedisModuleString **argv, uint32_t argc) {
-    QueryRequest_Init(&hybridReq->base, QUERY_REQUEST_KIND_HYBRID);
+    QueryRequest_Init(&hybridReq->base, QUERY_REQUEST_KIND_HYBRID, argv, argc);
     hybridReq->requests = requests;
     hybridReq->nrequests = nrequests;
     hybridReq->sctx = sctx;
@@ -312,7 +312,7 @@ void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **r
         // rather than its own slice: slice boundaries are only discovered
         // while parsing, and sub pipelines borrow beyond their slice anyway
         // (distributed tail steps like LOAD, PARAMS).
-        BlockedRequestCtx_NewAREQ(requests[i], argv, argc);
+        BlockedRequestCtx_NewAREQ(requests[i]);
         hybridReq->errors[i] = QueryError_Default();
         Pipeline_Initialize(&requests[i]->pipeline, requests[i]->reqConfig.timeoutPolicy, &hybridReq->errors[i]);
     }
@@ -330,17 +330,17 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
     HybridRequest_Init(hybridReq, sctx, requests, nrequests, argv, argc);
     // Wrap the top-level hybrid request in its single-owner sync context.
     // Sets hybridReq->brc; ownership is released via HybridRequest_DecrRef.
-    BlockedRequestCtx_NewHybrid(hybridReq, argv, argc);
+    BlockedRequestCtx_NewHybrid(hybridReq);
     return hybridReq;
 }
 
 void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, uint32_t argc) {
   // argc bounds the parse; the holds may cover a superset (debug flows).
-  RS_ASSERT(argc <= req->brc->argc);
+  RS_ASSERT(argc <= req->base.args.argc);
   // The cursor covers the whole held command, pre-advanced past the command
   // and index names: recorded positions (sub queryOffsets, syntax-error
   // offsets) are relative to the full command.
-  ArgsCursor_InitRString(ac, req->brc->argv, (int)argc);
+  ArgsCursor_InitRString(ac, req->base.args.argv, (int)argc);
   AC_AdvanceBy(ac, argc > 2 ? 2 : argc);
 }
 
@@ -499,8 +499,8 @@ static RedisSearchCtx* createThreadSafeSearchContext(RedisModuleCtx *ctx, const 
 
 HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx, RedisModuleString **argv, uint32_t argc) {
   extern size_t NumShards;  // Declared in module.c
-  AREQ *search = AREQ_New();
-  AREQ *vector = AREQ_New();
+  AREQ *search = AREQ_New(argv, argc);
+  AREQ *vector = AREQ_New(argv, argc);
   const char *indexName = HiddenString_GetUnsafe(sctx->spec->specName, NULL);
   search->sctx = createThreadSafeSearchContext(sctx->redisCtx, indexName);
   vector->sctx = createThreadSafeSearchContext(sctx->redisCtx, indexName);

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -428,6 +428,7 @@ void HybridRequest_Free(HybridRequest *req) {
     rm_free(req->debugParams);
 
     RequestSyncState_Destroy(&req->syncState);
+    QueryRequest_Destroy(&req->base);
 
     if (req->args) {
       for (size_t ii = 0; ii < req->nargs; ++ii) {

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -38,9 +38,6 @@ typedef struct HybridRequest {
     profiler_func profile;
     ProfilePrinterCtx profileCtx;
 
-    // Non-owning back-pointer to the heap wrapper that owns this request.
-    BlockedRequestCtx *brc;
-
     // State for reply_callback path (FAIL policy with workers in coordinator mode)
     // Background thread stores results here, then calls UnblockClient.
     // Mutex for synchronizing cursor creation with timeout callback.
@@ -71,6 +68,20 @@ typedef struct HybridRequest {
     // not applicable.
     int kArgIndex;
 } HybridRequest;
+
+#ifdef __cplusplus
+static_assert(offsetof(HybridRequest, base) == 0,
+              "QueryRequest must be HybridRequest's first member");
+#else
+_Static_assert(offsetof(HybridRequest, base) == 0,
+               "QueryRequest must be HybridRequest's first member");
+#endif
+
+static inline HybridRequest *QueryRequest_GetHybrid(QueryRequest *request) {
+  RS_ASSERT(request != NULL);
+  RS_ASSERT(request->kind == QUERY_REQUEST_KIND_HYBRID);
+  return (HybridRequest *)request;
+}
 
 // Timeout helper functions for HybridRequest (mirrors AREQ pattern)
 static inline bool HybridRequest_TimedOut(HybridRequest *req) {
@@ -145,9 +156,8 @@ typedef struct blockedClientHybridCtx {
  * @param sctx The main search context for the hybrid request - the redisCtx inside can change if moving to different thread
  * @param requests Array of AREQ pointers representing individual search requests, the hybrid request will take ownership of the array
  * @param nrequests Number of requests in the array
- * @param argv The command argv, not NULL; the container's and each
- *   sub-request's wrapper take holds on the full command (main-thread only —
- *   see QueryRequestArgs.argv)
+ * @param argv The command argv, not NULL; the container and every sub-request
+ *   hold the full command (main-thread only — see QueryRequestArgs.argv)
  * @param argc Number of strings in argv
 */
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests, RedisModuleString **argv, uint32_t argc);
@@ -160,8 +170,7 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
  * @param sctx The search context for the hybrid request
  * @param requests Array of AREQ pointers, the hybrid request takes ownership
  * @param nrequests Number of requests in the array
- * @param argv The full command argv each sub-request's wrapper holds
- *   (see HybridRequest_New); not NULL
+ * @param argv The full command argv each sub-request holds; not NULL
  * @param argc Number of strings in argv
  */
 void HybridRequest_Init(HybridRequest *hybridReq, RedisSearchCtx *sctx, AREQ **requests, size_t nrequests, RedisModuleString **argv, uint32_t argc);
@@ -255,22 +264,21 @@ int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params
 
 /**
  * Free a HybridRequest and all its associated resources directly.
- * Called by BlockedRequestCtx_Free when the QueryRequest refcount reaches zero.
- * Do not call directly; use HybridRequest_DecrRef instead.
+ * Called by the final QueryRequest release. Do not call directly; use
+ * HybridRequest_DecrRef instead.
  */
 void HybridRequest_Free(HybridRequest *req);
 
 /**
- * Increment the reference count of the owning BlockedRequestCtx wrapper.
+ * Increment the embedded QueryRequest reference count.
  * @param req the request to increment
  * @return the request (for chaining)
  */
 HybridRequest *HybridRequest_IncrRef(HybridRequest *req);
 
 /**
- * Decrement the reference count of the owning BlockedRequestCtx wrapper.
- * If the reference count reaches 0, BlockedRequestCtx_Free is called which
- * destroys the wrapper and the owned HybridRequest.
+ * Decrement the embedded QueryRequest reference count. The final release
+ * destroys the HybridRequest.
  * @param req the request to decrement
  */
 void HybridRequest_DecrRef(HybridRequest *req);

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -117,7 +117,7 @@ static inline void HybridRequest_SetSkipTimeoutChecks(HybridRequest *req, bool s
 }
 
 static inline bool HybridRequest_RequiresThreadsSyncResults(HybridRequest *req) {
-  return req->brc->requiresAggregateResultsSync;
+  return req->base.async.requiresAggregateResultsSync;
 }
 
 bool HybridRequest_TryClaimAggregateResults(HybridRequest *req);

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "aggregate/aggregate.h"
+#include "query_request.h"
 #include "pipeline/pipeline.h"
 #include "hybrid/hybrid_scoring.h"
 #include "hybrid/hybrid_debug.h"
@@ -21,6 +22,8 @@ struct Cursor;
 #define HYBRID_IMPLICIT_KEY_FIELD "__key"
 
 typedef struct HybridRequest {
+    QueryRequest base;
+
     /* Arguments converted to sds. Received on input */
     // We need to copy the arguments so rlookup keys can point to them
     // in short lifetime of the strings

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -41,9 +41,6 @@ typedef struct HybridRequest {
     // Non-owning back-pointer to the heap wrapper that owns this request.
     BlockedRequestCtx *brc;
 
-    // Flag to indicate whether to skip timeout checks using clock checks
-    bool skipTimeoutChecks;
-
     bool useReplyCallback;
 
     // State for reply_callback path (FAIL policy with workers in coordinator mode)
@@ -104,13 +101,11 @@ static inline void HybridRequest_UnlockCursors(HybridRequest *req) {
 }
 
 static inline bool HybridRequest_ShouldCheckTimeout(HybridRequest *req) {
-  return !req->skipTimeoutChecks;
+  return QueryRequestTimeout_ShouldCheck(&req->base.timeout);
 }
 
 static inline void HybridRequest_SetSkipTimeoutChecks(HybridRequest *req, bool skipTimeoutChecks) {
-  req->base.timeout.skipTimeoutChecks = skipTimeoutChecks;
-  // TODO($$$): Remove the legacy field once consumers use QueryRequest.timeout.
-  req->skipTimeoutChecks = skipTimeoutChecks;
+  QueryRequestTimeout_SetSkipChecks(&req->base.timeout, skipTimeoutChecks);
   // TODO($$$): Remove the SearchTime mirror once consumers use QueryRequest.timeout.
   if (req->sctx) {
     req->sctx->time.skipTimeoutChecks = skipTimeoutChecks;

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -44,10 +44,6 @@ typedef struct HybridRequest {
     profiler_func profile;
     ProfilePrinterCtx profileCtx;
 
-    // Synchronization context for timeout/reply callbacks.
-    // Holds the per-request timeout flag and abort-wake channel.
-    RequestSyncState syncState;
-
     // Non-owning back-pointer to the heap wrapper that owns this request.
     BlockedRequestCtx *brc;
 
@@ -89,18 +85,15 @@ typedef struct HybridRequest {
 
 // Timeout helper functions for HybridRequest (mirrors AREQ pattern)
 static inline bool HybridRequest_TimedOut(HybridRequest *req) {
-  return RequestSyncState_GetTimedOut(&req->syncState);
+  return QueryRequestTimeout_GetTimedOut(&req->base.timeout);
 }
 // The pipeline stage the hybrid request had reached, used to attribute a timeout.
 static inline QueryTimeoutStage HybridRequest_ExecutionStage(HybridRequest *req) {
-  return RequestSyncState_GetExecutionStage(&req->syncState);
+  return (QueryTimeoutStage)QueryRequest_GetExecutionPhase(&req->base);
 }
 // Advance the hybrid request's execution-phase marker (QUEUE -> PIPELINE -> REPLY).
 static inline void HybridRequest_SetExecutionStage(HybridRequest *req, QueryTimeoutStage stage) {
-  // TODO($$$): Remove the legacy execution phase once consumers use QueryRequest.async.
-  RequestSyncState_SetExecutionStage(&req->syncState, stage);
-  QueryRequestAsyncState_SetExecutionPhase(
-      &req->base.async, RequestSyncState_GetExecutionStage(&req->syncState));
+  QueryRequest_SetExecutionPhase(&req->base, (int)stage);
 }
 // Sets the hybrid request's timedOut flag and propagates it to every subquery
 // AREQ. Propagation flips each subquery's RPNet abort flag so a BG worker

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -255,7 +255,7 @@ int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params
 
 /**
  * Free a HybridRequest and all its associated resources directly.
- * Called by BlockedRequestCtx_Free when the wrapper's refcount reaches zero.
+ * Called by BlockedRequestCtx_Free when the QueryRequest refcount reaches zero.
  * Do not call directly; use HybridRequest_DecrRef instead.
  */
 void HybridRequest_Free(HybridRequest *req);

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -97,7 +97,10 @@ static inline QueryTimeoutStage HybridRequest_ExecutionStage(HybridRequest *req)
 }
 // Advance the hybrid request's execution-phase marker (QUEUE -> PIPELINE -> REPLY).
 static inline void HybridRequest_SetExecutionStage(HybridRequest *req, QueryTimeoutStage stage) {
+  // TODO($$$): Remove the legacy execution phase once consumers use QueryRequest.async.
   RequestSyncState_SetExecutionStage(&req->syncState, stage);
+  QueryRequestAsyncState_SetExecutionPhase(
+      &req->base.async, RequestSyncState_GetExecutionStage(&req->syncState));
 }
 // Sets the hybrid request's timedOut flag and propagates it to every subquery
 // AREQ. Propagation flips each subquery's RPNet abort flag so a BG worker

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -41,8 +41,6 @@ typedef struct HybridRequest {
     // Non-owning back-pointer to the heap wrapper that owns this request.
     BlockedRequestCtx *brc;
 
-    bool useReplyCallback;
-
     // State for reply_callback path (FAIL policy with workers in coordinator mode)
     // Background thread stores results here, then calls UnblockClient.
     // Mutex for synchronizing cursor creation with timeout callback.

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -108,8 +108,10 @@ static inline bool HybridRequest_ShouldCheckTimeout(HybridRequest *req) {
 }
 
 static inline void HybridRequest_SetSkipTimeoutChecks(HybridRequest *req, bool skipTimeoutChecks) {
+  req->base.timeout.skipTimeoutChecks = skipTimeoutChecks;
+  // TODO($$$): Remove the legacy field once consumers use QueryRequest.timeout.
   req->skipTimeoutChecks = skipTimeoutChecks;
-  // Propagate to the SearchCtx's SearchTime for timeout functions that access it directly
+  // TODO($$$): Remove the SearchTime mirror once consumers use QueryRequest.timeout.
   if (req->sctx) {
     req->sctx->time.skipTimeoutChecks = skipTimeoutChecks;
   }

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -152,7 +152,7 @@ typedef struct blockedClientHybridCtx {
  * @param nrequests Number of requests in the array
  * @param argv The command argv, not NULL; the container's and each
  *   sub-request's wrapper take holds on the full command (main-thread only —
- *   see BlockedRequestCtx.argv)
+ *   see QueryRequestArgs.argv)
  * @param argc Number of strings in argv
 */
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests, RedisModuleString **argv, uint32_t argc);

--- a/src/hybrid/parse/hybrid_optional_args.h
+++ b/src/hybrid/parse/hybrid_optional_args.h
@@ -58,7 +58,7 @@ typedef struct {
     QEFlags *reqFlags;                      // Request flags
     size_t *maxResults;                     // Maximum results
     /* Index prefixes from _INDEX_PREFIXES: a borrowed window into the
-     * request's held argv (see BlockedRequestCtx.argv). */
+     * request's held argv (see QueryRequestArgs.argv). */
     RedisModuleString **prefixes;
     size_t nprefixes;
     const RedisModuleSlotRangeArray **querySlots; // Slots requested from coordinator (referenced from AREQ)

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -56,7 +56,9 @@
 static void setSubQueryArg(AREQ *sub, uint32_t queryOffset) {
   BlockedRequestCtx *brc = sub->brc;
   RS_ASSERT(queryOffset < brc->argc);
+  // TODO($$$): Remove the legacy query offset once consumers use QueryRequest.
   brc->queryOffset = queryOffset;
+  sub->base.args.queryOffset = brc->queryOffset;
 }
 
 // Helper function to set error message with proper plural vs singular form

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -54,11 +54,8 @@
 // `queryOffset` is in root-cursor coordinates: for a slice cursor, the
 // caller adds the slice's base (the root offset recorded before AC_GetSlice).
 static void setSubQueryArg(AREQ *sub, uint32_t queryOffset) {
-  BlockedRequestCtx *brc = sub->brc;
-  RS_ASSERT(queryOffset < brc->argc);
-  // TODO($$$): Remove the legacy query offset once consumers use QueryRequest.
-  brc->queryOffset = queryOffset;
-  sub->base.args.queryOffset = brc->queryOffset;
+  RS_ASSERT(queryOffset < sub->base.args.argc);
+  sub->base.args.queryOffset = queryOffset;
 }
 
 // Helper function to set error message with proper plural vs singular form
@@ -541,7 +538,7 @@ final:
   // For RANGE queries without explicit FILTER, we also set skipFilterIntegration
   // so the vector node becomes the root directly (no PHRASE/intersection needed).
   // This preserves BY_SCORE ordering from the iterator.
-  if (vreq->brc->queryOffset == QUERY_OFFSET_NONE) {
+  if (vreq->base.args.queryOffset == QUERY_OFFSET_NONE) {
     // For RANGE without explicit filter, skip the filter integration
     // so the vector node is the root and returns results sorted by score.
     if (vq->type == VECSIM_QT_RANGE) {

--- a/src/info/global_stats.h
+++ b/src/info/global_stats.h
@@ -54,7 +54,7 @@ typedef struct {
 } FieldsGlobalStats;
 
 // The pipeline stage a timeout occurred in, used to break down the timeout metric.
-// Doubles as the execution-phase marker on RequestSyncState (QUEUE -> PIPELINE -> REPLY).
+// Doubles as the query request execution-phase marker (QUEUE -> PIPELINE -> REPLY).
 typedef enum {
   QUERY_TIMEOUT_STAGE_QUEUE = 0,    // before the result-processor pipeline started running
   QUERY_TIMEOUT_STAGE_PIPELINE = 1, // during result-processor pipeline execution

--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -66,7 +66,14 @@ void BlockedRequestCtx_EndCycle(BlockedRequestCtx *brc) {
   // Per-cycle reply-state teardown: dispose whatever the reply callback did
   // not consume (unconsumed stored results when the timeout replied first).
   // Idempotent; also runs in BlockedRequestCtx_Free as a safety net.
+  QueryRequest *request = brc->kind == REQUEST_KIND_AREQ
+                            ? (QueryRequest *)brc->query.areq
+                            : (QueryRequest *)brc->query.hybrid;
+  QueryRequest_ResetReply(request);
+
+  // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
   ChunkReplyState_Destroy(&brc->reply);
+  // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
   brc->reply.hasStoredResults = false;
   brc->bc = NULL;
   brc->deferred_reply = false;

--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -47,10 +47,7 @@ void BlockedRequestCtx_BeginCycle(BlockedRequestCtx *brc, RedisModuleBlockedClie
   // TODO($$$): Remove the legacy cycle marker once consumers use QueryRequest.blockedClientCycleActive.
   brc->bc = bc;
   brc->deferred_reply = (reply_cb != NULL);
-  RS_AtomicIntStoreRelaxed(
-      &BlockedRequestCtx_QueryRequest(brc)->async.strictReadOwner, BRC_READ_OWNER_NONE);
-  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-  atomic_store_explicit(&brc->strictReadOwner, BRC_READ_OWNER_NONE, memory_order_relaxed);
+  RS_AtomicIntStoreRelaxed(&request->async.strictReadOwner, BRC_READ_OWNER_NONE);
   RedisModule_BlockClientSetPrivateData(bc, brc);
 }
 
@@ -173,7 +170,7 @@ RedisModuleBlockedClient *BlockCursorClientWithTimeout(RedisModuleCtx *ctx, Curs
   // Cursor cycles reuse the wrapper across reads: reset the per-read
   // RETURN_STRICT claim/latch state so the new cycle starts from a clean
   // slate.
-  if (brc->requiresAggregateResultsSync) {
+  if (BlockedRequestCtx_QueryRequest(brc)->async.requiresAggregateResultsSync) {
     AREQ_ResetForCursorReadReturnStrict(BlockedRequestCtx_GetAREQ(brc));
   }
   BlockedRequestCtx_QueryRequest(brc)->registryInfo = (RegistryInfo) {

--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -28,12 +28,14 @@ static QueryRequest *BlockedRequestCtx_QueryRequest(BlockedRequestCtx *brc) {
 
 void BlockedRequestCtx_BeginCycle(BlockedRequestCtx *brc, RedisModuleBlockedClient *bc,
                                   RedisModuleCmdFunc reply_cb) {
+  QueryRequest *request = BlockedRequestCtx_QueryRequest(brc);
   // No overlapping cycles: the previous cycle's OnFree must have run before a
   // new cycle may begin on the same wrapper. This holds structurally for
   // blocked cursor cycles — the cursor is only parked back into the idle list
   // by OnFree (cursorEndOfCycle records the disposition; OnFree executes it),
   // so no other client can take it before the cycle fully ended.
-  RS_ASSERT(brc->bc == NULL && brc->registry_node == NULL);
+  RS_ASSERT(brc->bc == NULL && request->registryInfo.node == NULL &&
+            request->registryInfo.kind == REGISTRY_ENTRY_NONE);
   // The cycle's hold on the wrapper: keeps the wrapper (and the owned request)
   // alive until OnFree, so the reply/timeout callbacks may dereference the
   // privdata even if the BG worker released its own hold (e.g. a cursor freed
@@ -54,17 +56,15 @@ void BlockedRequestCtx_BeginCycle(BlockedRequestCtx *brc, RedisModuleBlockedClie
 
 void BlockedRequestCtx_EndCycle(BlockedRequestCtx *brc) {
   QueryRequest *request = BlockedRequestCtx_QueryRequest(brc);
-  // TODO($$$): Remove the legacy registry state once consumers use QueryRequest.registryInfo.
-  if (brc->registry_node) {
-    if (brc->registry_node_is_cursor) {
-      BlockedQueries_RemoveCursor(brc->registry_node);
+  if (request->registryInfo.node) {
+    if (request->registryInfo.kind == REGISTRY_ENTRY_CURSOR) {
+      BlockedQueries_RemoveCursor(request->registryInfo.node);
     } else {
-      BlockedQueries_RemoveQuery(brc->registry_node);
+      RS_ASSERT(request->registryInfo.kind == REGISTRY_ENTRY_QUERY);
+      BlockedQueries_RemoveQuery(request->registryInfo.node);
     }
-    rm_free(brc->registry_node);
-    brc->registry_node = NULL;
+    rm_free(request->registryInfo.node);
   }
-  brc->registry_node_is_cursor = false;
   request->registryInfo.node = NULL;
   request->registryInfo.kind = REGISTRY_ENTRY_NONE;
   // Dispose a stashed cursor reference-releasingly BEFORE the generic destroy:
@@ -146,9 +146,6 @@ RedisModuleBlockedClient *BlockQueryClientWithTimeout(RedisModuleCtx *ctx, Stron
     .node = node,
     .kind = REGISTRY_ENTRY_QUERY,
   };
-  // TODO($$$): Remove the legacy registry state once consumers use QueryRequest.registryInfo.
-  brc->registry_node = node;
-  brc->registry_node_is_cursor = false;
   // report block client start time
   RedisModule_BlockedClientMeasureTimeStart(bc);
   return bc;
@@ -183,9 +180,6 @@ RedisModuleBlockedClient *BlockCursorClientWithTimeout(RedisModuleCtx *ctx, Curs
     .node = node,
     .kind = REGISTRY_ENTRY_CURSOR,
   };
-  // TODO($$$): Remove the legacy registry state once consumers use QueryRequest.registryInfo.
-  brc->registry_node = node;
-  brc->registry_node_is_cursor = true;
   // report block client start time
   RedisModule_BlockedClientMeasureTimeStart(bc);
   return bc;

--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -50,6 +50,8 @@ void BlockedRequestCtx_BeginCycle(BlockedRequestCtx *brc, RedisModuleBlockedClie
 }
 
 void BlockedRequestCtx_EndCycle(BlockedRequestCtx *brc) {
+  QueryRequest *request = BlockedRequestCtx_QueryRequest(brc);
+  // TODO($$$): Remove the legacy registry state once consumers use QueryRequest.registryInfo.
   if (brc->registry_node) {
     if (brc->registry_node_is_cursor) {
       BlockedQueries_RemoveCursor(brc->registry_node);
@@ -59,6 +61,9 @@ void BlockedRequestCtx_EndCycle(BlockedRequestCtx *brc) {
     rm_free(brc->registry_node);
     brc->registry_node = NULL;
   }
+  brc->registry_node_is_cursor = false;
+  request->registryInfo.node = NULL;
+  request->registryInfo.kind = REGISTRY_ENTRY_NONE;
   // Dispose a stashed cursor reference-releasingly BEFORE the generic destroy:
   // AREQ_CleanUpStoredCursor frees the cursor with its wrapper handle intact,
   // so Cursor_FreeInternal releases the cursor's wrapper reference. Skipping
@@ -73,7 +78,6 @@ void BlockedRequestCtx_EndCycle(BlockedRequestCtx *brc) {
   // Per-cycle reply-state teardown: dispose whatever the reply callback did
   // not consume (unconsumed stored results when the timeout replied first).
   // Idempotent; also runs in BlockedRequestCtx_Free as a safety net.
-  QueryRequest *request = BlockedRequestCtx_QueryRequest(brc);
   QueryRequest_ResetReply(request);
 
   // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
@@ -135,6 +139,11 @@ RedisModuleBlockedClient *BlockQueryClientWithTimeout(RedisModuleCtx *ctx, Stron
   RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, reply_cb, timeout_cb,
                                                          BlockedRequestCtx_OnFree, timeout_ms);
   BlockedRequestCtx_BeginCycle(brc, bc, reply_cb);
+  BlockedRequestCtx_QueryRequest(brc)->registryInfo = (RegistryInfo) {
+    .node = node,
+    .kind = REGISTRY_ENTRY_QUERY,
+  };
+  // TODO($$$): Remove the legacy registry state once consumers use QueryRequest.registryInfo.
   brc->registry_node = node;
   brc->registry_node_is_cursor = false;
   // report block client start time
@@ -167,6 +176,11 @@ RedisModuleBlockedClient *BlockCursorClientWithTimeout(RedisModuleCtx *ctx, Curs
   if (brc->requiresAggregateResultsSync) {
     AREQ_ResetForCursorReadReturnStrict(BlockedRequestCtx_GetAREQ(brc));
   }
+  BlockedRequestCtx_QueryRequest(brc)->registryInfo = (RegistryInfo) {
+    .node = node,
+    .kind = REGISTRY_ENTRY_CURSOR,
+  };
+  // TODO($$$): Remove the legacy registry state once consumers use QueryRequest.registryInfo.
   brc->registry_node = node;
   brc->registry_node_is_cursor = true;
   // report block client start time

--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -86,9 +86,6 @@ void BlockedRequestCtx_EndCycle(BlockedRequestCtx *brc) {
   brc->deferred_reply = false;
   request->cursorInfo.cursor = NULL;
   request->cursorInfo.disposition = CURSOR_DISPOSITION_NONE;
-  // TODO($$$): Remove the legacy cursor disposition once consumers use QueryRequest.cursorInfo.
-  brc->cursor = NULL;
-  brc->cursor_dispose_free = false;
 }
 
 void BlockedRequestCtx_OnFree(RedisModuleCtx *ctx, void *privdata) {
@@ -103,13 +100,15 @@ void BlockedRequestCtx_OnFree(RedisModuleCtx *ctx, void *privdata) {
   // what keeps a cycle's cursor unreachable to other clients mid-cycle.
   // Cursor_Pause converts park to free when CURSOR DEL marked the cursor
   // mid-cycle (delete_mark).
-  struct Cursor *cursor = brc->cursor;
-  bool dispose_free = brc->cursor_dispose_free;
+  QueryRequest *request = BlockedRequestCtx_QueryRequest(brc);
+  struct Cursor *cursor = request->cursorInfo.cursor;
+  CursorDisposition disposition = request->cursorInfo.disposition;
   BlockedRequestCtx_EndCycle(brc);
   if (cursor) {
-    if (dispose_free) {
+    if (disposition == CURSOR_DISPOSITION_FREE) {
       Cursor_Free(cursor);
     } else {
+      RS_ASSERT(disposition == CURSOR_DISPOSITION_PAUSE);
       Cursor_Pause(cursor);
     }
   }

--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -45,6 +45,9 @@ void BlockedRequestCtx_BeginCycle(BlockedRequestCtx *brc, RedisModuleBlockedClie
   // TODO($$$): Remove the legacy cycle marker once consumers use QueryRequest.blockedClientCycleActive.
   brc->bc = bc;
   brc->deferred_reply = (reply_cb != NULL);
+  RS_AtomicIntStoreRelaxed(
+      &BlockedRequestCtx_QueryRequest(brc)->async.strictReadOwner, BRC_READ_OWNER_NONE);
+  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
   atomic_store_explicit(&brc->strictReadOwner, BRC_READ_OWNER_NONE, memory_order_relaxed);
   RedisModule_BlockClientSetPrivateData(bc, brc);
 }

--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -84,6 +84,9 @@ void BlockedRequestCtx_EndCycle(BlockedRequestCtx *brc) {
   // TODO($$$): Remove the legacy cycle marker once consumers use QueryRequest.blockedClientCycleActive.
   brc->bc = NULL;
   brc->deferred_reply = false;
+  request->cursorInfo.cursor = NULL;
+  request->cursorInfo.disposition = CURSOR_DISPOSITION_NONE;
+  // TODO($$$): Remove the legacy cursor disposition once consumers use QueryRequest.cursorInfo.
   brc->cursor = NULL;
   brc->cursor_dispose_free = false;
 }

--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -21,6 +21,11 @@
 #include "rmalloc.h"
 #include "rmutil/rm_assert.h"
 
+static QueryRequest *BlockedRequestCtx_QueryRequest(BlockedRequestCtx *brc) {
+  return brc->kind == REQUEST_KIND_AREQ ? (QueryRequest *)brc->query.areq
+                                       : (QueryRequest *)brc->query.hybrid;
+}
+
 void BlockedRequestCtx_BeginCycle(BlockedRequestCtx *brc, RedisModuleBlockedClient *bc,
                                   RedisModuleCmdFunc reply_cb) {
   // No overlapping cycles: the previous cycle's OnFree must have run before a
@@ -36,6 +41,8 @@ void BlockedRequestCtx_BeginCycle(BlockedRequestCtx *brc, RedisModuleBlockedClie
   // TRANSITIONAL(MOD-16691): expressed through the refcount bridge until the
   // cursor-ownership step makes the cycle the single owner.
   BlockedRequestCtx_IncrRef(brc);
+  BlockedRequestCtx_QueryRequest(brc)->blockedClientCycleActive = true;
+  // TODO($$$): Remove the legacy cycle marker once consumers use QueryRequest.blockedClientCycleActive.
   brc->bc = bc;
   brc->deferred_reply = (reply_cb != NULL);
   atomic_store_explicit(&brc->strictReadOwner, BRC_READ_OWNER_NONE, memory_order_relaxed);
@@ -66,15 +73,15 @@ void BlockedRequestCtx_EndCycle(BlockedRequestCtx *brc) {
   // Per-cycle reply-state teardown: dispose whatever the reply callback did
   // not consume (unconsumed stored results when the timeout replied first).
   // Idempotent; also runs in BlockedRequestCtx_Free as a safety net.
-  QueryRequest *request = brc->kind == REQUEST_KIND_AREQ
-                            ? (QueryRequest *)brc->query.areq
-                            : (QueryRequest *)brc->query.hybrid;
+  QueryRequest *request = BlockedRequestCtx_QueryRequest(brc);
   QueryRequest_ResetReply(request);
 
   // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
   ChunkReplyState_Destroy(&brc->reply);
   // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
   brc->reply.hasStoredResults = false;
+  request->blockedClientCycleActive = false;
+  // TODO($$$): Remove the legacy cycle marker once consumers use QueryRequest.blockedClientCycleActive.
   brc->bc = NULL;
   brc->deferred_reply = false;
   brc->cursor = NULL;

--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -80,10 +80,6 @@ void BlockedRequestCtx_EndCycle(BlockedRequestCtx *brc) {
   // Idempotent; also runs in BlockedRequestCtx_Free as a safety net.
   QueryRequest_ResetReply(request);
 
-  // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
-  ChunkReplyState_Destroy(&brc->reply);
-  // TODO($$$): Remove the legacy reply state once all consumers use QueryRequest.reply.
-  brc->reply.hasStoredResults = false;
   request->blockedClientCycleActive = false;
   // TODO($$$): Remove the legacy cycle marker once consumers use QueryRequest.blockedClientCycleActive.
   brc->bc = NULL;

--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -21,38 +21,26 @@
 #include "rmalloc.h"
 #include "rmutil/rm_assert.h"
 
-static QueryRequest *BlockedRequestCtx_QueryRequest(BlockedRequestCtx *brc) {
-  return brc->kind == REQUEST_KIND_AREQ ? (QueryRequest *)brc->query.areq
-                                       : (QueryRequest *)brc->query.hybrid;
-}
-
-void BlockedRequestCtx_BeginCycle(BlockedRequestCtx *brc, RedisModuleBlockedClient *bc,
-                                  RedisModuleCmdFunc reply_cb) {
-  QueryRequest *request = BlockedRequestCtx_QueryRequest(brc);
+void QueryRequest_BeginCycle(QueryRequest *request, RedisModuleBlockedClient *bc,
+                             RedisModuleCmdFunc reply_cb) {
   // No overlapping cycles: the previous cycle's OnFree must have run before a
-  // new cycle may begin on the same wrapper. This holds structurally for
+  // new cycle may begin on the same request. This holds structurally for
   // blocked cursor cycles — the cursor is only parked back into the idle list
   // by OnFree (cursorEndOfCycle records the disposition; OnFree executes it),
   // so no other client can take it before the cycle fully ended.
-  RS_ASSERT(brc->bc == NULL && request->registryInfo.node == NULL &&
+  RS_ASSERT(!request->blockedClientCycleActive && request->registryInfo.node == NULL &&
             request->registryInfo.kind == REGISTRY_ENTRY_NONE);
-  // The cycle's hold on the wrapper: keeps the wrapper (and the owned request)
-  // alive until OnFree, so the reply/timeout callbacks may dereference the
-  // privdata even if the BG worker released its own hold (e.g. a cursor freed
-  // on ITERDONE) before the client was unblocked.
-  // TRANSITIONAL(MOD-16691): expressed through the refcount bridge until the
-  // cursor-ownership step makes the cycle the single owner.
-  BlockedRequestCtx_IncrRef(brc);
-  BlockedRequestCtx_QueryRequest(brc)->blockedClientCycleActive = true;
-  // TODO($$$): Remove the legacy cycle marker once consumers use QueryRequest.blockedClientCycleActive.
-  brc->bc = bc;
-  brc->deferred_reply = (reply_cb != NULL);
-  RS_AtomicIntStoreRelaxed(&request->async.strictReadOwner, BRC_READ_OWNER_NONE);
-  RedisModule_BlockClientSetPrivateData(bc, brc);
+  // The cycle's hold keeps the request alive until OnFree, so the reply/timeout
+  // callbacks may dereference the privdata even if the BG worker released its
+  // own hold (e.g. a cursor freed on ITERDONE) before the client was unblocked.
+  QueryRequest_IncrRef(request);
+  request->blockedClientCycleActive = true;
+  QueryRequest_SetUseReplyCallback(request, reply_cb != NULL);
+  RS_AtomicIntStoreRelaxed(&request->async.strictReadOwner, QUERY_REQUEST_READ_OWNER_NONE);
+  RedisModule_BlockClientSetPrivateData(bc, request);
 }
 
-void BlockedRequestCtx_EndCycle(BlockedRequestCtx *brc) {
-  QueryRequest *request = BlockedRequestCtx_QueryRequest(brc);
+void QueryRequest_EndCycle(QueryRequest *request) {
   if (request->registryInfo.node) {
     if (request->registryInfo.kind == REGISTRY_ENTRY_CURSOR) {
       BlockedQueries_RemoveCursor(request->registryInfo.node);
@@ -65,45 +53,41 @@ void BlockedRequestCtx_EndCycle(BlockedRequestCtx *brc) {
   request->registryInfo.node = NULL;
   request->registryInfo.kind = REGISTRY_ENTRY_NONE;
   // Dispose a stashed cursor reference-releasingly BEFORE the generic destroy:
-  // AREQ_CleanUpStoredCursor frees the cursor with its wrapper handle intact,
-  // so Cursor_FreeInternal releases the cursor's wrapper reference. Skipping
+  // AREQ_CleanUpStoredCursor frees the cursor with its request handle intact,
+  // so Cursor_FreeInternal releases the cursor's request reference. Skipping
   // this and letting ChunkReplyState_Destroy handle the stash would leak that
   // reference (it deliberately clears the handle first — correct only in the
-  // refcount==0 context of BlockedRequestCtx_Free). Disposing the stash here is
-  // also what prevents the RETURN_STRICT preempt path from leaking the cursor
+  // refcount==0 context of final request destruction). Disposing the stash
+  // here also prevents the RETURN_STRICT preempt path from leaking the cursor
   // reserved by an initial WITHCURSOR query.
-  if (brc->kind == REQUEST_KIND_AREQ) {
-    AREQ_CleanUpStoredCursor(brc->query.areq);
+  if (request->kind == QUERY_REQUEST_KIND_AREQ) {
+    AREQ_CleanUpStoredCursor(QueryRequest_GetAREQ(request));
   }
   // Per-cycle reply-state teardown: dispose whatever the reply callback did
   // not consume (unconsumed stored results when the timeout replied first).
-  // Idempotent; also runs in BlockedRequestCtx_Free as a safety net.
+  // Idempotent; base destruction also clears reply state as a safety net.
   QueryRequest_ResetReply(request);
 
   request->blockedClientCycleActive = false;
-  // TODO($$$): Remove the legacy cycle marker once consumers use QueryRequest.blockedClientCycleActive.
-  brc->bc = NULL;
-  brc->deferred_reply = false;
   request->cursorInfo.cursor = NULL;
   request->cursorInfo.disposition = CURSOR_DISPOSITION_NONE;
 }
 
-void BlockedRequestCtx_OnFree(RedisModuleCtx *ctx, void *privdata) {
-  BlockedRequestCtx *brc = privdata;
+void QueryRequest_OnFree(RedisModuleCtx *ctx, void *privdata) {
+  QueryRequest *request = privdata;
 #ifdef ENABLE_ASSERT
   // Debug-only counter so tests can deterministically observe that
   // free_privdata fired without blocking the main thread in the callback.
-  BlockedRequestOnFreeDebug_Increment();
+  QueryRequestOnFreeDebug_Increment();
 #endif
   // Execute the cycle's cursor disposition (snapshot first — EndCycle clears
   // the per-cycle fields). Parking here, after the reply/timeout callback, is
   // what keeps a cycle's cursor unreachable to other clients mid-cycle.
   // Cursor_Pause converts park to free when CURSOR DEL marked the cursor
   // mid-cycle (delete_mark).
-  QueryRequest *request = BlockedRequestCtx_QueryRequest(brc);
   struct Cursor *cursor = request->cursorInfo.cursor;
   CursorDisposition disposition = request->cursorInfo.disposition;
-  BlockedRequestCtx_EndCycle(brc);
+  QueryRequest_EndCycle(request);
   if (cursor) {
     if (disposition == CURSOR_DISPOSITION_FREE) {
       Cursor_Free(cursor);
@@ -112,11 +96,11 @@ void BlockedRequestCtx_OnFree(RedisModuleCtx *ctx, void *privdata) {
       Cursor_Pause(cursor);
     }
   }
-  BlockedRequestCtx_DecrRef(brc);
+  QueryRequest_DecrRef(request);
 }
 
 RedisModuleBlockedClient *BlockQueryClientWithTimeout(RedisModuleCtx *ctx, StrongRef spec_ref,
-                                                      BlockedRequestCtx *brc,
+                                                      QueryRequest *request,
                                                       RedisModuleCmdFunc reply_cb,
                                                       RedisModuleCmdFunc timeout_cb,
                                                       rs_wall_clock_ms_t timeout_ms) {
@@ -126,15 +110,15 @@ RedisModuleBlockedClient *BlockQueryClientWithTimeout(RedisModuleCtx *ctx, Stron
   BlockedQueries *blockedQueries = MainThread_GetBlockedQueries();
   RS_LOG_ASSERT(blockedQueries, "MainThread_InitBlockedQueries was not called, or function not called from main thread");
   // Registry bookkeeping only (FT.INFO / crash reports). The callbacks reach
-  // the request through the blocked client's privdata (the BlockedRequestCtx),
+  // the request through the blocked client's private data,
   // so the node carries no privdata and holds no reference. Unlinked in
-  // EndCycle; TRANSITIONAL(MOD-16691): Step 3 links the wrapper itself instead.
+  // EndCycle; TRANSITIONAL(MOD-16691): link the request itself instead.
   BlockedQueryNode *node = BlockedQueries_AddQuery(blockedQueries, spec_ref, NULL, NULL);
 
   RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, reply_cb, timeout_cb,
-                                                         BlockedRequestCtx_OnFree, timeout_ms);
-  BlockedRequestCtx_BeginCycle(brc, bc, reply_cb);
-  BlockedRequestCtx_QueryRequest(brc)->registryInfo = (RegistryInfo) {
+                                                         QueryRequest_OnFree, timeout_ms);
+  QueryRequest_BeginCycle(request, bc, reply_cb);
+  request->registryInfo = (RegistryInfo) {
     .node = node,
     .kind = REGISTRY_ENTRY_QUERY,
   };
@@ -145,11 +129,11 @@ RedisModuleBlockedClient *BlockQueryClientWithTimeout(RedisModuleCtx *ctx, Stron
 
 RedisModuleBlockedClient *BlockCursorClientWithTimeout(RedisModuleCtx *ctx, Cursor *cursor,
                                                        size_t count,
-                                                       BlockedRequestCtx *brc,
+                                                       QueryRequest *request,
                                                        RedisModuleCmdFunc reply_cb,
                                                        RedisModuleCmdFunc timeout_cb,
                                                        rs_wall_clock_ms_t timeout_ms) {
-  RS_ASSERT(cursor->query != NULL);
+  RS_ASSERT(cursor->query == request);
   RS_ASSERT(timeout_ms == 0 || (timeout_cb != NULL && reply_cb != NULL));
 
   BlockedQueries *blockedQueries = MainThread_GetBlockedQueries();
@@ -160,15 +144,15 @@ RedisModuleBlockedClient *BlockCursorClientWithTimeout(RedisModuleCtx *ctx, Curs
                                                      cursor->id, count, NULL, NULL);
 
   RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, reply_cb, timeout_cb,
-                                                         BlockedRequestCtx_OnFree, timeout_ms);
-  BlockedRequestCtx_BeginCycle(brc, bc, reply_cb);
-  // Cursor cycles reuse the wrapper across reads: reset the per-read
+                                                         QueryRequest_OnFree, timeout_ms);
+  QueryRequest_BeginCycle(request, bc, reply_cb);
+  // Cursor cycles reuse the request across reads: reset the per-read
   // RETURN_STRICT claim/latch state so the new cycle starts from a clean
   // slate.
-  if (BlockedRequestCtx_QueryRequest(brc)->async.requiresAggregateResultsSync) {
-    AREQ_ResetForCursorReadReturnStrict(BlockedRequestCtx_GetAREQ(brc));
+  if (request->async.requiresAggregateResultsSync) {
+    AREQ_ResetForCursorReadReturnStrict(QueryRequest_GetAREQ(request));
   }
-  BlockedRequestCtx_QueryRequest(brc)->registryInfo = (RegistryInfo) {
+  request->registryInfo = (RegistryInfo) {
     .node = node,
     .kind = REGISTRY_ENTRY_CURSOR,
   };

--- a/src/info/info_redis/block_client.h
+++ b/src/info/info_redis/block_client.h
@@ -18,61 +18,59 @@ extern "C" {
 
 struct IndexSpec;
 struct Cursor;
-struct BlockedRequestCtx;
+struct QueryRequest;
 
-/* Blocked-client cycle API for BlockedRequestCtx (see aggregate.h).
+/* Blocked-client cycle API for QueryRequest (see query_request.h).
  *
  * A cycle is one blocked-client round trip: the initial query execution or a
- * single cursor read. The wrapper is the blocked client's privdata for the
- * whole cycle; BlockedRequestCtx_OnFree is the free_privdata callback and the
+ * single cursor read. The request is the blocked client's private data for the
+ * whole cycle; QueryRequest_OnFree is the free_privdata callback and the
  * single main-thread teardown point. The canonical sequence at every
  * query-shaped call site is:
  *
- *   bc = BlockQueryClientWithTimeout(ctx, spec_ref, brc, reply_cb, timeout_cb,
+ *   bc = BlockQueryClientWithTimeout(ctx, spec_ref, request, reply_cb, timeout_cb,
  *                                    timeout_ms);
  *   <dispatch to worker pool>;
  *
  * (BlockCursorClientWithTimeout for cursor reads.) Both helpers call
  * RedisModule_BlockClient with OnFree registered, then
- * BlockedRequestCtx_BeginCycle to bind the per-cycle fields. */
+ * QueryRequest_BeginCycle to bind the per-cycle fields. */
 
-/* Bind the per-cycle fields on `brc`. Called on the main thread after
- * RedisModule_BlockClient returned `bc` (with BlockedRequestCtx_OnFree
+/* Bind the per-cycle fields on `request`. Called on the main thread after
+ * RedisModule_BlockClient returned `bc` (with QueryRequest_OnFree
  * registered as free_privdata) and before dispatching BG work. Takes the
- * cycle's reference on the wrapper (TRANSITIONAL(MOD-16691) refcount bridge
- * until the cursor-ownership step), sets `brc` as the blocked client's
+ * cycle's reference on the request, sets `request` as the blocked client's
  * privdata, and records the cycle's reply mode (`reply_cb` must be the value
  * that was passed to RedisModule_BlockClient). */
-void BlockedRequestCtx_BeginCycle(struct BlockedRequestCtx *brc, RedisModuleBlockedClient *bc,
-                                  RedisModuleCmdFunc reply_cb);
+void QueryRequest_BeginCycle(struct QueryRequest *request, RedisModuleBlockedClient *bc,
+                             RedisModuleCmdFunc reply_cb);
 
 /* Unlink the cycle's registry node and clear the per-cycle fields. Called from
  * OnFree; callable directly only in tests. */
-void BlockedRequestCtx_EndCycle(struct BlockedRequestCtx *brc);
+void QueryRequest_EndCycle(struct QueryRequest *request);
 
 /* The free_privdata callback registered with RedisModule_BlockClient. Runs on
  * the main thread after the reply or timeout callback, before the blocked
- * client is destroyed. Ends the cycle and releases the cycle's hold on the
- * wrapper. */
-void BlockedRequestCtx_OnFree(RedisModuleCtx *ctx, void *privdata);
+ * client is destroyed. Ends the cycle and releases the cycle's request hold. */
+void QueryRequest_OnFree(RedisModuleCtx *ctx, void *privdata);
 
-/* Block `ctx` for one query cycle of `brc`. Registers the cycle in
+/* Block `ctx` for one query cycle of `request`. Registers the cycle in
  * BlockedQueries, calls RedisModule_BlockClient(reply_cb, timeout_cb,
- * BlockedRequestCtx_OnFree, timeout_ms) and BeginCycle. `reply_cb`/`timeout_cb`
+ * QueryRequest_OnFree, timeout_ms) and BeginCycle. `reply_cb`/`timeout_cb`
  * may both be NULL (inline reply mode) but must be provided together with a
  * non-zero `timeout_ms`. */
 RedisModuleBlockedClient *BlockQueryClientWithTimeout(RedisModuleCtx *ctx, StrongRef spec_ref,
-                                                      struct BlockedRequestCtx *brc,
+                                                      struct QueryRequest *request,
                                                       RedisModuleCmdFunc reply_cb,
                                                       RedisModuleCmdFunc timeout_cb,
                                                       rs_wall_clock_ms_t timeout_ms);
 
 /* Same as BlockQueryClientWithTimeout for one cursor-read cycle; also resets
- * the per-read RETURN_STRICT claim/latch state (the wrapper is reused across
+ * the per-read RETURN_STRICT claim/latch state (the request is reused across
  * reads). */
 RedisModuleBlockedClient *BlockCursorClientWithTimeout(RedisModuleCtx *ctx, struct Cursor *cursor,
                                                        size_t count,
-                                                       struct BlockedRequestCtx *brc,
+                                                       struct QueryRequest *request,
                                                        RedisModuleCmdFunc reply_cb,
                                                        RedisModuleCmdFunc timeout_cb,
                                                        rs_wall_clock_ms_t timeout_ms);

--- a/src/module.c
+++ b/src/module.c
@@ -3908,8 +3908,6 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
         : DistAggregateTimeoutReturnStrictCallback;
     handlerCtx.bcCtx.timeoutMS = queryTimeoutMS;
     QueryRequest_SetUseReplyCallback(&r->base, true);
-    // TODO($$$): Remove the legacy field once consumers use QueryRequest.
-    r->useReplyCallback = true;
     if (policy == TimeoutPolicy_ReturnStrict) {
       r->base.async.requiresAggregateResultsSync = true;
       // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
@@ -4020,8 +4018,6 @@ int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int
         : DistHybridTimeoutReturnStrictCallback;
     handlerCtx.bcCtx.timeoutMS = queryTimeoutMS;
     QueryRequest_SetUseReplyCallback(&hreq->base, true);
-    // TODO($$$): Remove the legacy field once consumers use QueryRequest.
-    hreq->useReplyCallback = true;
   }
 
   return ConcurrentSearch_HandleRedisCommandEx(DIST_THREADPOOL, dist_callback, ctx, argv, argc,

--- a/src/module.c
+++ b/src/module.c
@@ -4325,7 +4325,7 @@ static void DistSearchCommandHandler(void* pd) {
     sCmdCtx->handlerCtx.coordQueueTime = rs_wall_clock_now_ns() - sCmdCtx->handlerCtx.coordStartTime;
   }
   // Dequeued by the coord: advance to PIPELINE (fan-out/reduce). Skipped once timed
-  // out while queued (freeze, mirroring RequestSyncState_SetExecutionStage).
+  // out while queued, preserving the phase where the timeout was observed.
   searchRequestCtx *sReq = MRCtx_GetPrivData(sCmdCtx->mrctx);
   if (sReq && !MRCtx_IsTimedOut(sCmdCtx->mrctx)) {
     searchReqCtx_SetExecutionStage(sReq, QUERY_TIMEOUT_STAGE_PIPELINE);
@@ -5113,7 +5113,7 @@ static void DEBUG_DistSearchCommandHandler(void* pd) {
     sCmdCtx->handlerCtx.coordQueueTime = rs_wall_clock_now_ns() - sCmdCtx->handlerCtx.coordStartTime;
   }
   // Dequeued by the coord: advance to PIPELINE (fan-out/reduce). Skipped once timed
-  // out while queued (freeze, mirroring RequestSyncState_SetExecutionStage).
+  // out while queued, preserving the phase where the timeout was observed.
   searchRequestCtx *sReq = MRCtx_GetPrivData(sCmdCtx->mrctx);
   if (sReq && !MRCtx_IsTimedOut(sCmdCtx->mrctx)) {
     searchReqCtx_SetExecutionStage(sReq, QUERY_TIMEOUT_STAGE_PIPELINE);

--- a/src/module.c
+++ b/src/module.c
@@ -3885,6 +3885,8 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     handlerCtx.bcCtx.timeoutMS = queryTimeoutMS;
     r->useReplyCallback = true;
     if (policy == TimeoutPolicy_ReturnStrict) {
+      r->base.async.requiresAggregateResultsSync = true;
+      // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
       r->brc->requiresAggregateResultsSync = true;
     }
   }
@@ -3970,6 +3972,8 @@ int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int
   sctx->redisCtx = NULL;
 
   RSTimeoutPolicy policy = hreq->reqConfig.timeoutPolicy;
+  hreq->base.async.requiresAggregateResultsSync = (policy == TimeoutPolicy_ReturnStrict);
+  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
   hreq->brc->requiresAggregateResultsSync = (policy == TimeoutPolicy_ReturnStrict);
 
   ConcurrentSearchHandlerCtx handlerCtx;

--- a/src/module.c
+++ b/src/module.c
@@ -3907,6 +3907,8 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
         ? DistAggregateTimeoutFailCallback
         : DistAggregateTimeoutReturnStrictCallback;
     handlerCtx.bcCtx.timeoutMS = queryTimeoutMS;
+    QueryRequest_SetUseReplyCallback(&r->base, true);
+    // TODO($$$): Remove the legacy field once consumers use QueryRequest.
     r->useReplyCallback = true;
     if (policy == TimeoutPolicy_ReturnStrict) {
       r->base.async.requiresAggregateResultsSync = true;
@@ -4017,6 +4019,8 @@ int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int
         ? DistHybridTimeoutFailCallback
         : DistHybridTimeoutReturnStrictCallback;
     handlerCtx.bcCtx.timeoutMS = queryTimeoutMS;
+    QueryRequest_SetUseReplyCallback(&hreq->base, true);
+    // TODO($$$): Remove the legacy field once consumers use QueryRequest.
     hreq->useReplyCallback = true;
   }
 

--- a/src/module.c
+++ b/src/module.c
@@ -3871,8 +3871,8 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     return QueryError_ReplyAndClear(ctx, &status);
   }
 
-  // Allocate the request shell and its owning wrapper before blocking the
-  // client, so the full context is already installed (as the blocked client's
+  // Allocate the request shell before blocking the client, so the full
+  // context is already installed (as the blocked client's
   // privdata) once the client is blocked. Parsing happens on the BG thread.
   AREQ *r;
   if (isDebug) {
@@ -3882,12 +3882,9 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
       QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&status), 1, COORD_ERR_WARN);
       return QueryError_ReplyAndClear(ctx, &status);
     }
-    // Already wrapped by AREQ_Debug_New (the wrapper can only be attached
-    // after its rm_realloc).
     r = &debug_req->r;
   } else {
     r = AREQ_New(argv, argc);
-    BlockedRequestCtx_NewAREQ(r);
   }
   // Either path took the argv holds here, on the main thread; the BG parse
   // borrows from them (the job's own argv copies die with the job).
@@ -3900,7 +3897,7 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   handlerCtx.numShards = NumShards;  // Capture NumShards from main thread for thread-safe access
 
   RSTimeoutPolicy policy = r->reqConfig.timeoutPolicy;
-  handlerCtx.bcCtx.brc = r->brc;
+  handlerCtx.bcCtx.request = &r->base;
   if (policy == TimeoutPolicy_Fail || policy == TimeoutPolicy_ReturnStrict) {
     handlerCtx.bcCtx.reply_callback = DistAggregateReplyCallback;
     handlerCtx.bcCtx.timeout_callback = (policy == TimeoutPolicy_Fail)
@@ -3982,8 +3979,8 @@ int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int
     return QueryError_ReplyAndClear(ctx, &status);
   }
 
-  // Allocate the hybrid request shell and its owning wrapper before blocking
-  // the client, so the full context is already installed (as the blocked
+  // Allocate the hybrid request shell before blocking the client, so the full
+  // context is already installed (as the blocked
   // client's privdata) once the client is blocked. Parsing happens on the BG
   // thread; the sub-AREQ contexts are detached thread-safe contexts.
   RedisSearchCtx *sctx = NewSearchCtxC(ctx, idx, true);
@@ -4005,7 +4002,7 @@ int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int
   handlerCtx.spec_ref = StrongRef_Demote(spec_ref);
   handlerCtx.numShards = NumShards;  // Capture NumShards from main thread for thread-safe access
 
-  handlerCtx.bcCtx.brc = hreq->brc;
+  handlerCtx.bcCtx.request = &hreq->base;
 
   if (policy != TimeoutPolicy_Return) {
     handlerCtx.bcCtx.reply_callback = DistHybridReplyCallback;

--- a/src/module.c
+++ b/src/module.c
@@ -3910,8 +3910,6 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     QueryRequest_SetUseReplyCallback(&r->base, true);
     if (policy == TimeoutPolicy_ReturnStrict) {
       r->base.async.requiresAggregateResultsSync = true;
-      // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-      r->brc->requiresAggregateResultsSync = true;
     }
   }
 
@@ -3999,8 +3997,6 @@ int DistHybridCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int
 
   RSTimeoutPolicy policy = hreq->reqConfig.timeoutPolicy;
   hreq->base.async.requiresAggregateResultsSync = (policy == TimeoutPolicy_ReturnStrict);
-  // TODO($$$): Remove the legacy async state once consumers use QueryRequest.async.
-  hreq->brc->requiresAggregateResultsSync = (policy == TimeoutPolicy_ReturnStrict);
 
   ConcurrentSearchHandlerCtx handlerCtx;
   ConcurrentSearchHandlerCtx_Init(&handlerCtx);

--- a/src/module.c
+++ b/src/module.c
@@ -3886,8 +3886,8 @@ int DistAggregateCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     // after its rm_realloc).
     r = &debug_req->r;
   } else {
-    r = AREQ_New();
-    BlockedRequestCtx_NewAREQ(r, argv, argc);
+    r = AREQ_New(argv, argc);
+    BlockedRequestCtx_NewAREQ(r);
   }
   // Either path took the argv holds here, on the main thread; the BG parse
   // borrows from them (the job's own argv copies die with the job).

--- a/src/module.h
+++ b/src/module.h
@@ -126,7 +126,7 @@ typedef struct {
   void *reducer;
   bool queryOOM;
   bool timedOut;
-  // QueryTimeoutStage marker for the FT.SEARCH MR coord path (no RequestSyncState).
+  // QueryTimeoutStage marker for the FT.SEARCH MR coordinator path.
   RS_Atomic(int) execPhase;
 
   struct searchReducerCtx *rctx;

--- a/src/query.h
+++ b/src/query.h
@@ -91,7 +91,7 @@ typedef struct {
   bool empty;
 
   /** The keys to limit to: a borrowed window into the request's held argv
-   * (see BlockedRequestCtx.argv). Not owned. */
+   * (see QueryRequestArgs.argv). Not owned. */
   RedisModuleString **keys;
   /** Pre-resolved document IDs (for SearchDisk, resolved on main thread). Same length as keys. (Not owned) */
   t_docId *docIds;

--- a/src/query_node.h
+++ b/src/query_node.h
@@ -80,7 +80,7 @@ typedef struct {
 
 typedef struct {
   /* The key names: a borrowed window into the request's held argv (see
-   * BlockedRequestCtx.argv), which outlives the AST. Not owned. */
+   * QueryRequestArgs.argv), which outlives the AST. Not owned. */
   RedisModuleString **keys;
   // Pre-resolved document IDs (for SearchDisk, resolved on main thread)
   t_docId *docIds;

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -10,6 +10,28 @@
 
 #include "coord/rmr/chan.h"
 #include "query_error_ffi.h"
+#include "redismodule.h"
+#include "rmalloc.h"
+#include "rmutil/rm_assert.h"
+#include "util/misc.h"
+
+static void QueryRequestArgs_Release(RedisModuleString **argv, uint32_t argc) {
+  for (uint32_t ii = 0; ii < argc; ++ii) {
+    RedisModule_FreeString(NULL, argv[ii]);
+  }
+  rm_free(argv);
+}
+
+typedef struct {
+  RedisModuleString **argv;
+  uint32_t argc;
+} DeferredArgsRelease;
+
+static void QueryRequestArgs_ReleaseOnMainThread(void *privdata) {
+  DeferredArgsRelease *deferred = privdata;
+  QueryRequestArgs_Release(deferred->argv, deferred->argc);
+  rm_free(deferred);
+}
 
 static inline void ChunkReplyState_Init(ChunkReplyState *state) {
   *state = (ChunkReplyState) {0};
@@ -36,7 +58,8 @@ static inline void QueryRequestAsyncState_Destroy(QueryRequestAsyncState *state)
   pthread_cond_destroy(&state->aggregateResultsCond);
 }
 
-void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind) {
+void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind, RedisModuleString **argv,
+                       uint32_t argc) {
   request->kind = kind;
   request->args = (QueryRequestArgs) {
     .queryOffset = QUERY_OFFSET_NONE,
@@ -48,6 +71,25 @@ void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind) {
   QueryRequestTimeout_ClearTimedOut(&request->timeout);
   QueryRequestAsyncState_Init(&request->async);
   QueryRequest_SetEndProcRef(request, NULL);
+  if (argv) {
+    QueryRequest_HoldArgs(request, argv, argc);
+  } else {
+    RS_ASSERT(argc == 0);
+  }
+}
+
+void QueryRequest_HoldArgs(QueryRequest *request, RedisModuleString **argv, uint32_t argc) {
+  RS_ASSERT(argv != NULL);
+  RS_ASSERT(request->args.argv == NULL);
+  request->args.argv = rm_malloc(argc * sizeof(*request->args.argv));
+  request->args.argc = argc;
+  request->args.parseArgc = argc;
+  for (uint32_t ii = 0; ii < argc; ++ii) {
+    request->args.argv[ii] = RedisModule_HoldString(NULL, argv[ii]);
+    // Redis auto-trims retained argv after the command callback returns. Trim
+    // before a worker can borrow the string storage.
+    RedisModule_TrimStringAllocation(request->args.argv[ii]);
+  }
 }
 
 void QueryRequest_ResetReply(QueryRequest *request) {
@@ -59,6 +101,21 @@ void QueryRequest_Destroy(QueryRequest *request) {
   QueryError_ClearError(&request->reply.err);
   QueryRequestAsyncState_Destroy(&request->async);
   QueryRequest_SetEndProcRef(request, NULL);
+  if (request->args.argv) {
+    if (MainThread_Is()) {
+      QueryRequestArgs_Release(request->args.argv, request->args.argc);
+    } else {
+      DeferredArgsRelease *deferred = rm_new(DeferredArgsRelease);
+      *deferred = (DeferredArgsRelease) {
+        .argv = request->args.argv,
+        .argc = request->args.argc,
+      };
+      int rc = RedisModule_EventLoopAddOneShot(QueryRequestArgs_ReleaseOnMainThread, deferred);
+      RS_ASSERT(rc == REDISMODULE_OK);
+      (void)rc;
+    }
+    request->args = (QueryRequestArgs) {.queryOffset = QUERY_OFFSET_NONE};
+  }
 }
 
 void QueryRequestAsyncState_RegisterAbortWakeChannel(QueryRequestAsyncState *state,

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -68,6 +68,7 @@ void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind, RedisModule
   request->cursorInfo = (CursorInfo) {0};
   request->registryInfo = (RegistryInfo) {0};
   ChunkReplyState_Init(&request->reply);
+  QueryRequest_SetUseReplyCallback(request, false);
   QueryRequestTimeout_ClearTimedOut(&request->timeout);
   QueryRequestTimeout_SetSkipChecks(&request->timeout, false);
   QueryRequestAsyncState_Init(&request->async);

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -10,7 +10,9 @@
 
 #include <stdatomic.h>
 
+#include "aggregate/aggregate.h"
 #include "coord/rmr/chan.h"
+#include "hybrid/hybrid_request.h"
 #include "query_error_ffi.h"
 #include "redismodule.h"
 #include "rmalloc.h"
@@ -65,8 +67,26 @@ QueryRequest *QueryRequest_IncrRef(QueryRequest *request) {
   return request;
 }
 
-bool QueryRequest_DecrRef(QueryRequest *request) {
-  return atomic_fetch_sub_explicit(&request->refcount, 1, memory_order_acq_rel) == 1;
+void QueryRequest_DecrRef(QueryRequest *request) {
+  if (!request) {
+    return;
+  }
+  int previous = atomic_fetch_sub_explicit(&request->refcount, 1, memory_order_acq_rel);
+  RS_LOG_ASSERT_ALWAYS(previous > 0, "QueryRequest reference count underflow");
+  if (previous != 1) {
+    return;
+  }
+
+  switch (request->kind) {
+    case QUERY_REQUEST_KIND_AREQ:
+      AREQ_Free((AREQ *)request);
+      return;
+    case QUERY_REQUEST_KIND_HYBRID:
+      HybridRequest_Free((HybridRequest *)request);
+      return;
+    default:
+      RS_ABORT_ALWAYS("Invalid query request kind");
+  }
 }
 
 void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind, RedisModuleString **argv,

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -38,6 +38,9 @@ static inline void QueryRequestAsyncState_Destroy(QueryRequestAsyncState *state)
 
 void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind) {
   request->kind = kind;
+  request->args = (QueryRequestArgs) {
+    .queryOffset = QUERY_OFFSET_NONE,
+  };
   request->blockedClientCycleActive = false;
   request->cursorInfo = (CursorInfo) {0};
   request->registryInfo = (RegistryInfo) {0};

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -61,6 +61,7 @@ static inline void QueryRequestAsyncState_Destroy(QueryRequestAsyncState *state)
 void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind, RedisModuleString **argv,
                        uint32_t argc) {
   request->kind = kind;
+  RS_AtomicIntStoreRelaxed(&request->refcount, 1);
   request->args = (QueryRequestArgs) {
     .queryOffset = QUERY_OFFSET_NONE,
   };

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -21,6 +21,7 @@ static inline void QueryRequestAsyncState_Init(QueryRequestAsyncState *state) {
   state->aggregateResultsClaimLost = false;
   state->aggregateResultsDone = false;
   state->safeLoadersHoldingGIL = 0;
+  state->strictReadOwner = 0;
   pthread_mutex_init(&state->aggregateResultsLock, NULL);
   pthread_cond_init(&state->aggregateResultsCond, NULL);
 }

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -8,6 +8,8 @@
  */
 #include "query_request.h"
 
+#include <stdatomic.h>
+
 #include "coord/rmr/chan.h"
 #include "query_error_ffi.h"
 #include "redismodule.h"
@@ -56,6 +58,15 @@ static inline void QueryRequestAsyncState_Destroy(QueryRequestAsyncState *state)
   pthread_mutex_destroy(&state->abortWakeLock);
   pthread_mutex_destroy(&state->aggregateResultsLock);
   pthread_cond_destroy(&state->aggregateResultsCond);
+}
+
+QueryRequest *QueryRequest_IncrRef(QueryRequest *request) {
+  atomic_fetch_add_explicit(&request->refcount, 1, memory_order_relaxed);
+  return request;
+}
+
+bool QueryRequest_DecrRef(QueryRequest *request) {
+  return atomic_fetch_sub_explicit(&request->refcount, 1, memory_order_acq_rel) == 1;
 }
 
 void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind, RedisModuleString **argv,

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -8,6 +8,7 @@
  */
 #include "query_request.h"
 
+#include "coord/rmr/chan.h"
 #include "query_error_ffi.h"
 
 static inline void ChunkReplyState_Init(ChunkReplyState *state) {
@@ -55,4 +56,25 @@ void QueryRequest_Destroy(QueryRequest *request) {
   QueryError_ClearError(&request->reply.err);
   QueryRequestAsyncState_Destroy(&request->async);
   QueryRequest_SetEndProcRef(request, NULL);
+}
+
+void QueryRequestAsyncState_RegisterAbortWakeChannel(QueryRequestAsyncState *state,
+                                                     struct MRChannel *channel) {
+  pthread_mutex_lock(&state->abortWakeLock);
+  state->abortWakeChannel = channel;
+  pthread_mutex_unlock(&state->abortWakeLock);
+}
+
+void QueryRequestAsyncState_UnregisterAbortWakeChannel(QueryRequestAsyncState *state) {
+  pthread_mutex_lock(&state->abortWakeLock);
+  state->abortWakeChannel = NULL;
+  pthread_mutex_unlock(&state->abortWakeLock);
+}
+
+void QueryRequestAsyncState_WakeAbortChannel(QueryRequestAsyncState *state) {
+  pthread_mutex_lock(&state->abortWakeLock);
+  if (state->abortWakeChannel) {
+    MRChannel_WakeAbort(state->abortWakeChannel);
+  }
+  pthread_mutex_unlock(&state->abortWakeLock);
 }

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -22,11 +22,15 @@ static inline void QueryRequestAsyncState_Init(QueryRequestAsyncState *state) {
   state->aggregateResultsDone = false;
   state->safeLoadersHoldingGIL = 0;
   state->strictReadOwner = 0;
+  QueryRequestAsyncState_SetExecutionPhase(state, 0);
+  state->abortWakeChannel = NULL;
+  pthread_mutex_init(&state->abortWakeLock, NULL);
   pthread_mutex_init(&state->aggregateResultsLock, NULL);
   pthread_cond_init(&state->aggregateResultsCond, NULL);
 }
 
 static inline void QueryRequestAsyncState_Destroy(QueryRequestAsyncState *state) {
+  pthread_mutex_destroy(&state->abortWakeLock);
   pthread_mutex_destroy(&state->aggregateResultsLock);
   pthread_cond_destroy(&state->aggregateResultsCond);
 }
@@ -37,6 +41,7 @@ void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind) {
   request->cursorInfo = (CursorInfo) {0};
   request->registryInfo = (RegistryInfo) {0};
   ChunkReplyState_Init(&request->reply);
+  QueryRequestTimeout_ClearTimedOut(&request->timeout);
   QueryRequestAsyncState_Init(&request->async);
   QueryRequest_SetEndProcRef(request, NULL);
 }

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -13,6 +13,7 @@
 void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind) {
   request->kind = kind;
   request->cursorInfo.id = 0;
+  QueryRequest_SetEndProcRef(request, NULL);
   request->reply = (ChunkReplyState) {0};
   request->reply.err = QueryError_Default();
 }
@@ -25,4 +26,5 @@ void QueryRequest_ResetReply(QueryRequest *request) {
 
 void QueryRequest_Destroy(QueryRequest *request) {
   QueryError_ClearError(&request->reply.err);
+  QueryRequest_SetEndProcRef(request, NULL);
 }

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -5,5 +5,10 @@
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
  * GNU Affero General Public License v3 (AGPLv3).
-*/
+ */
 #include "query_request.h"
+
+void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind) {
+  request->kind = kind;
+  request->cursorInfo.id = 0;
+}

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -127,12 +127,12 @@ void QueryRequest_HoldArgs(QueryRequest *request, RedisModuleString **argv, uint
 }
 
 void QueryRequest_ResetReply(QueryRequest *request) {
-  QueryError_ClearError(&request->reply.err);
+  ChunkReplyState_Destroy(&request->reply);
   ChunkReplyState_Init(&request->reply);
 }
 
 void QueryRequest_Destroy(QueryRequest *request) {
-  QueryError_ClearError(&request->reply.err);
+  QueryRequest_ResetReply(request);
   QueryRequestAsyncState_Destroy(&request->async);
   QueryRequest_SetEndProcRef(request, NULL);
   if (request->args.argv) {

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -69,6 +69,7 @@ void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind, RedisModule
   request->registryInfo = (RegistryInfo) {0};
   ChunkReplyState_Init(&request->reply);
   QueryRequestTimeout_ClearTimedOut(&request->timeout);
+  request->timeout.skipTimeoutChecks = false;
   QueryRequestAsyncState_Init(&request->async);
   QueryRequest_SetEndProcRef(request, NULL);
   if (argv) {

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -8,7 +8,21 @@
  */
 #include "query_request.h"
 
+#include "query_error_ffi.h"
+
 void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind) {
   request->kind = kind;
   request->cursorInfo.id = 0;
+  request->reply = (ChunkReplyState) {0};
+  request->reply.err = QueryError_Default();
+}
+
+void QueryRequest_ResetReply(QueryRequest *request) {
+  QueryError_ClearError(&request->reply.err);
+  request->reply = (ChunkReplyState) {0};
+  request->reply.err = QueryError_Default();
+}
+
+void QueryRequest_Destroy(QueryRequest *request) {
+  QueryError_ClearError(&request->reply.err);
 }

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -69,7 +69,7 @@ void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind, RedisModule
   request->registryInfo = (RegistryInfo) {0};
   ChunkReplyState_Init(&request->reply);
   QueryRequestTimeout_ClearTimedOut(&request->timeout);
-  request->timeout.skipTimeoutChecks = false;
+  QueryRequestTimeout_SetSkipChecks(&request->timeout, false);
   QueryRequestAsyncState_Init(&request->async);
   QueryRequest_SetEndProcRef(request, NULL);
   if (argv) {

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -32,6 +32,7 @@ static inline void QueryRequestAsyncState_Destroy(QueryRequestAsyncState *state)
 
 void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind) {
   request->kind = kind;
+  request->blockedClientCycleActive = false;
   request->cursorInfo = (CursorInfo) {0};
   ChunkReplyState_Init(&request->reply);
   QueryRequestAsyncState_Init(&request->async);

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+#include "query_request.h"

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -10,21 +10,41 @@
 
 #include "query_error_ffi.h"
 
+static inline void ChunkReplyState_Init(ChunkReplyState *state) {
+  *state = (ChunkReplyState) {0};
+  state->err = QueryError_Default();
+}
+
+static inline void QueryRequestAsyncState_Init(QueryRequestAsyncState *state) {
+  state->requiresAggregateResultsSync = false;
+  state->aggregatingResults = false;
+  state->aggregateResultsClaimLost = false;
+  state->aggregateResultsDone = false;
+  state->safeLoadersHoldingGIL = 0;
+  pthread_mutex_init(&state->aggregateResultsLock, NULL);
+  pthread_cond_init(&state->aggregateResultsCond, NULL);
+}
+
+static inline void QueryRequestAsyncState_Destroy(QueryRequestAsyncState *state) {
+  pthread_mutex_destroy(&state->aggregateResultsLock);
+  pthread_cond_destroy(&state->aggregateResultsCond);
+}
+
 void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind) {
   request->kind = kind;
-  request->cursorInfo.id = 0;
+  request->cursorInfo = (CursorInfo) {0};
+  ChunkReplyState_Init(&request->reply);
+  QueryRequestAsyncState_Init(&request->async);
   QueryRequest_SetEndProcRef(request, NULL);
-  request->reply = (ChunkReplyState) {0};
-  request->reply.err = QueryError_Default();
 }
 
 void QueryRequest_ResetReply(QueryRequest *request) {
   QueryError_ClearError(&request->reply.err);
-  request->reply = (ChunkReplyState) {0};
-  request->reply.err = QueryError_Default();
+  ChunkReplyState_Init(&request->reply);
 }
 
 void QueryRequest_Destroy(QueryRequest *request) {
   QueryError_ClearError(&request->reply.err);
+  QueryRequestAsyncState_Destroy(&request->async);
   QueryRequest_SetEndProcRef(request, NULL);
 }

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -34,6 +34,7 @@ void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind) {
   request->kind = kind;
   request->blockedClientCycleActive = false;
   request->cursorInfo = (CursorInfo) {0};
+  request->registryInfo = (RegistryInfo) {0};
   ChunkReplyState_Init(&request->reply);
   QueryRequestAsyncState_Init(&request->async);
   QueryRequest_SetEndProcRef(request, NULL);

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -89,6 +89,20 @@ void QueryRequest_DecrRef(QueryRequest *request) {
   }
 }
 
+static void QueryRequest_HoldArgs(QueryRequestArgs *args, RedisModuleString **argv, uint32_t argc) {
+  RS_ASSERT(argv != NULL);
+  RS_ASSERT(args->argv == NULL);
+  args->argv = rm_malloc(argc * sizeof(*args->argv));
+  args->argc = argc;
+  args->parseArgc = argc;
+  for (uint32_t ii = 0; ii < argc; ++ii) {
+    args->argv[ii] = RedisModule_HoldString(NULL, argv[ii]);
+    // Redis auto-trims retained argv after the command callback returns. Trim
+    // before a worker can borrow the string storage.
+    RedisModule_TrimStringAllocation(args->argv[ii]);
+  }
+}
+
 void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind, RedisModuleString **argv,
                        uint32_t argc) {
   request->kind = kind;
@@ -109,20 +123,6 @@ void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind, RedisModule
     QueryRequest_HoldArgs(&request->args, argv, argc);
   } else {
     RS_ASSERT(argc == 0);
-  }
-}
-
-void QueryRequest_HoldArgs(QueryRequestArgs *args, RedisModuleString **argv, uint32_t argc) {
-  RS_ASSERT(argv != NULL);
-  RS_ASSERT(args->argv == NULL);
-  args->argv = rm_malloc(argc * sizeof(*args->argv));
-  args->argc = argc;
-  args->parseArgc = argc;
-  for (uint32_t ii = 0; ii < argc; ++ii) {
-    args->argv[ii] = RedisModule_HoldString(NULL, argv[ii]);
-    // Redis auto-trims retained argv after the command callback returns. Trim
-    // before a worker can borrow the string storage.
-    RedisModule_TrimStringAllocation(args->argv[ii]);
   }
 }
 

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -106,23 +106,23 @@ void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind, RedisModule
   QueryRequestAsyncState_Init(&request->async);
   QueryRequest_SetEndProcRef(request, NULL);
   if (argv) {
-    QueryRequest_HoldArgs(request, argv, argc);
+    QueryRequest_HoldArgs(&request->args, argv, argc);
   } else {
     RS_ASSERT(argc == 0);
   }
 }
 
-void QueryRequest_HoldArgs(QueryRequest *request, RedisModuleString **argv, uint32_t argc) {
+void QueryRequest_HoldArgs(QueryRequestArgs *args, RedisModuleString **argv, uint32_t argc) {
   RS_ASSERT(argv != NULL);
-  RS_ASSERT(request->args.argv == NULL);
-  request->args.argv = rm_malloc(argc * sizeof(*request->args.argv));
-  request->args.argc = argc;
-  request->args.parseArgc = argc;
+  RS_ASSERT(args->argv == NULL);
+  args->argv = rm_malloc(argc * sizeof(*args->argv));
+  args->argc = argc;
+  args->parseArgc = argc;
   for (uint32_t ii = 0; ii < argc; ++ii) {
-    request->args.argv[ii] = RedisModule_HoldString(NULL, argv[ii]);
+    args->argv[ii] = RedisModule_HoldString(NULL, argv[ii]);
     // Redis auto-trims retained argv after the command callback returns. Trim
     // before a worker can borrow the string storage.
-    RedisModule_TrimStringAllocation(request->args.argv[ii]);
+    RedisModule_TrimStringAllocation(args->argv[ii]);
   }
 }
 

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -5,17 +5,31 @@
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
  * GNU Affero General Public License v3 (AGPLv3).
-*/
+ */
 #ifndef QUERY_REQUEST_H__
 #define QUERY_REQUEST_H__
+
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+typedef enum {
+  QUERY_REQUEST_KIND_AREQ,
+  QUERY_REQUEST_KIND_HYBRID,
+} QueryRequestKind;
+
+typedef struct {
+  uint64_t id;
+} CursorInfo;
+
 typedef struct QueryRequest {
-  unsigned char reserved;
+  QueryRequestKind kind;
+  CursorInfo cursorInfo;
 } QueryRequest;
+
+void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind);
 
 #ifdef __cplusplus
 }

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -40,7 +40,7 @@ typedef struct {
 /**
  * State retained while results wait for the main-thread reply callback.
  *
- * The cursor owns its request through the request wrapper, not vice versa.
+ * The cursor owns a request reference, not vice versa.
  * The cursor pointer stored here is non-owning and exists only so the reply
  * callback can pause or free it after serialization determines whether the
  * cursor is depleted. It must be cleared after the cursor is handled.
@@ -187,8 +187,7 @@ typedef struct QueryRequest {
   QueryRequestArgs args;
   /* A blocked-client cycle is one initial query execution or cursor read.
    * This is set after RedisModule_BlockClient returns and cleared by OnFree;
-   * per-cycle state must not be read while it is false.
-   * TODO($$$): Temporary marker intended to replace BlockedRequestCtx.bc. */
+   * per-cycle state must not be read while it is false. */
   bool blockedClientCycleActive;
   CursorInfo cursorInfo;
   RegistryInfo registryInfo;
@@ -212,8 +211,9 @@ typedef struct QueryRequest {
 
 QueryRequest *QueryRequest_IncrRef(QueryRequest *request);
 
-/* Returns true when the caller released the final reference. */
-bool QueryRequest_DecrRef(QueryRequest *request);
+/* Release one reference. The final release destroys the concrete request
+ * selected by `kind`. */
+void QueryRequest_DecrRef(QueryRequest *request);
 
 static inline void QueryRequest_SetEndProcRef(QueryRequest *request,
                                               ResultProcessor **endProcRef) {

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -181,11 +181,8 @@ void QueryRequestAsyncState_WakeAbortChannel(QueryRequestAsyncState *state);
 
 typedef struct QueryRequest {
   QueryRequestKind kind;
-  /* TRANSITIONAL(MOD-16691): reference count copied from BlockedRequestCtx
-   * while ownership moves onto QueryRequest. Starts at 1; ACQ_REL on the final
-   * decrement ensures destruction observes prior writes.
-   * TODO($$$): Remove the legacy BlockedRequestCtx refcount after all consumers
-   * use this field. */
+  /* Starts at 1. ACQ_REL on the final decrement ensures destruction observes
+   * prior writes from every owner. */
   RS_Atomic(int) refcount;
   QueryRequestArgs args;
   /* A blocked-client cycle is one initial query execution or cursor read.
@@ -212,6 +209,11 @@ typedef struct QueryRequest {
    */
   ResultProcessor **endProcRef;
 } QueryRequest;
+
+QueryRequest *QueryRequest_IncrRef(QueryRequest *request);
+
+/* Returns true when the caller released the final reference. */
+bool QueryRequest_DecrRef(QueryRequest *request);
 
 static inline void QueryRequest_SetEndProcRef(QueryRequest *request,
                                               ResultProcessor **endProcRef) {

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -181,6 +181,12 @@ void QueryRequestAsyncState_WakeAbortChannel(QueryRequestAsyncState *state);
 
 typedef struct QueryRequest {
   QueryRequestKind kind;
+  /* TRANSITIONAL(MOD-16691): reference count copied from BlockedRequestCtx
+   * while ownership moves onto QueryRequest. Starts at 1; ACQ_REL on the final
+   * decrement ensures destruction observes prior writes.
+   * TODO($$$): Remove the legacy BlockedRequestCtx refcount after all consumers
+   * use this field. */
+  RS_Atomic(int) refcount;
   QueryRequestArgs args;
   /* A blocked-client cycle is one initial query execution or cursor read.
    * This is set after RedisModule_BlockClient returns and cleared by OnFree;

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -117,6 +117,15 @@ static inline void QueryRequestTimeout_ClearTimedOut(QueryRequestTimeout *timeou
   RS_AtomicBoolStoreRelaxed(&timeout->timedOut, false);
 }
 
+static inline bool QueryRequestTimeout_ShouldCheck(const QueryRequestTimeout *timeout) {
+  return !timeout->skipTimeoutChecks;
+}
+
+static inline void QueryRequestTimeout_SetSkipChecks(QueryRequestTimeout *timeout,
+                                                     bool skipTimeoutChecks) {
+  timeout->skipTimeoutChecks = skipTimeoutChecks;
+}
+
 /**
  * Timeout-only synchronization between query workers and main-thread callbacks.
  * TODO($$$): Remove this temporary state after MOD-17486 is merged.

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -68,6 +68,10 @@ typedef enum {
 
 typedef struct {
   uint64_t id;
+  /* Cursor disposition for this cycle. The point that decides the cursor's
+   * fate records it here; OnFree executes it, keeping the cursor unreachable
+   * to other clients until the cycle has fully ended. The pointer is NULL when
+   * the cycle has no cursor; inline execution disposes the cursor directly. */
   struct Cursor *cursor;
   CursorDisposition disposition;
 } CursorInfo;
@@ -79,6 +83,9 @@ typedef enum {
 } RegistryEntryKind;
 
 typedef struct {
+  /* TRANSITIONAL(MOD-16691): per-cycle registry bridge, until the request is
+   * linked directly into BlockedQueries. The node is unlinked and freed at the
+   * end of the cycle; its kind identifies the registry list that owns it. */
   void *node;
   RegistryEntryKind kind;
 } RegistryInfo;
@@ -131,17 +138,29 @@ static inline void QueryRequestTimeout_SetSkipChecks(QueryRequestTimeout *timeou
  * TODO($$$): Remove this temporary state after MOD-17486 is merged.
  */
 typedef struct QueryRequestAsyncState {
-  bool requiresAggregateResultsSync;
-  RS_Atomic(bool) aggregatingResults;
-  bool aggregateResultsClaimLost;
-  bool aggregateResultsDone;
+  /* The CAS claim grants exclusive ownership of result production: the BG
+   * winner runs the pipeline and stores results, while the timeout-callback
+   * winner preempts BG and replies empty. The loser waits for completion.
+   * Gated by requiresAggregateResultsSync. MOD-17486 replaces this claim/wait
+   * protocol with a timeout callback that never waits on BG state. */
+  bool requiresAggregateResultsSync;   // Enable CAS/Signal/Wait around result production
+  RS_Atomic(bool) aggregatingResults;  // CAS claim shared by BG and timeout callback
+  bool aggregateResultsClaimLost;      // BG lost the claim to the timeout callback
+  bool aggregateResultsDone;           // Completion latch guarded by aggregateResultsLock
+  /* RP_SAFE_LOADER deadlock-avoidance handshake. A BG worker increments this
+   * before taking the GIL and decrements it after release, under
+   * aggregateResultsLock. The timeout callback uses it to avoid waiting while
+   * holding the GIL. This is a count because hybrid pipelines share the state. */
   int safeLoadersHoldingGIL;
-  // Per-cycle CAS owner for coordinator RETURN_STRICT cursor reads.
+  /* TRANSITIONAL(MOD-16691): per-cycle dequeue latch for coordinator
+   * RETURN_STRICT cursor reads. BG and the timeout callback race to claim it;
+   * a timeout winner replies without waiting, while a timeout loser may wait
+   * because a started read always stores a reply and signals completion.
+   * Deleted by the RETURN_STRICT flip. */
   RS_Atomic(int) strictReadOwner;
   RS_Atomic(int) execPhase;
   struct MRChannel *abortWakeChannel;
   pthread_mutex_t abortWakeLock;
-  // TODO($$$): Plug both primitives into the async synchronization paths later in this PR.
   pthread_mutex_t aggregateResultsLock;
   pthread_cond_t aggregateResultsCond;
 } QueryRequestAsyncState;
@@ -163,11 +182,19 @@ void QueryRequestAsyncState_WakeAbortChannel(QueryRequestAsyncState *state);
 typedef struct QueryRequest {
   QueryRequestKind kind;
   QueryRequestArgs args;
-  // TODO($$$): Temporary marker intended to replace BlockedRequestCtx.bc.
+  /* A blocked-client cycle is one initial query execution or cursor read.
+   * This is set after RedisModule_BlockClient returns and cleared by OnFree;
+   * per-cycle state must not be read while it is false.
+   * TODO($$$): Temporary marker intended to replace BlockedRequestCtx.bc. */
   bool blockedClientCycleActive;
   CursorInfo cursorInfo;
   RegistryInfo registryInfo;
+  /* Stored results and errors written by BG before UnblockClient and consumed
+   * by the main-thread reply or timeout callback. Reset at the end of each
+   * cycle and again during request destruction as a safety net. */
   ChunkReplyState reply;
+  /* false: BG replies inline through a thread-safe context; true: BG stores
+   * results and the Redis reply callback serializes them on the main thread. */
   bool useReplyCallback;
   QueryRequestTimeout timeout;
   QueryRequestAsyncState async;

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -9,11 +9,13 @@
 #ifndef QUERY_REQUEST_H__
 #define QUERY_REQUEST_H__
 
+#include <pthread.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #include "query_error.h"
+#include "util/rs_atomic.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,10 +60,26 @@ typedef struct {
   uint64_t id;
 } CursorInfo;
 
+/**
+ * Timeout-only synchronization between query workers and main-thread callbacks.
+ * TODO($$$): Remove this temporary state after MOD-17486 is merged.
+ */
+typedef struct {
+  bool requiresAggregateResultsSync;
+  RS_Atomic(bool) aggregatingResults;
+  bool aggregateResultsClaimLost;
+  bool aggregateResultsDone;
+  int safeLoadersHoldingGIL;
+  // TODO($$$): Plug both primitives into the async synchronization paths later in this PR.
+  pthread_mutex_t aggregateResultsLock;
+  pthread_cond_t aggregateResultsCond;
+} QueryRequestAsyncState;
+
 typedef struct QueryRequest {
   QueryRequestKind kind;
   CursorInfo cursorInfo;
   ChunkReplyState reply;
+  QueryRequestAsyncState async;
   /**
    * Transitional reference to the legacy QueryProcessingCtx.endProc slot.
    * The extra indirection makes changes to that slot immediately visible here,

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -77,6 +77,8 @@ typedef struct {
 
 typedef struct QueryRequest {
   QueryRequestKind kind;
+  // TODO($$$): Temporary marker intended to replace BlockedRequestCtx.bc.
+  bool blockedClientCycleActive;
   CursorInfo cursorInfo;
   ChunkReplyState reply;
   QueryRequestAsyncState async;

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -56,8 +56,16 @@ typedef enum {
   QUERY_REQUEST_KIND_HYBRID,
 } QueryRequestKind;
 
+typedef enum {
+  CURSOR_DISPOSITION_NONE,   // No cursor is awaiting end-of-cycle handling.
+  CURSOR_DISPOSITION_PAUSE,  // Return the cursor to the idle list for another read.
+  CURSOR_DISPOSITION_FREE,   // Destroy the cursor when the active cycle ends.
+} CursorDisposition;
+
 typedef struct {
   uint64_t id;
+  struct Cursor *cursor;
+  CursorDisposition disposition;
 } CursorInfo;
 
 /**

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -9,11 +9,44 @@
 #ifndef QUERY_REQUEST_H__
 #define QUERY_REQUEST_H__
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+
+#include "query_error.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+typedef struct RLookup RLookup;
+typedef struct PLN_ArrangeStep PLN_ArrangeStep;
+typedef struct SearchResult SearchResult;
+struct Cursor;
+
+/** Cached variables used while serializing stored results. */
+typedef struct {
+  RLookup *lastLookup;
+  const PLN_ArrangeStep *lastAstp;
+} cachedVars;
+
+/**
+ * State retained while results wait for the main-thread reply callback.
+ *
+ * The cursor owns its request through the request wrapper, not vice versa.
+ * The cursor pointer stored here is non-owning and exists only so the reply
+ * callback can pause or free it after serialization determines whether the
+ * cursor is depleted. It must be cleared after the cursor is handled.
+ */
+typedef struct {
+  SearchResult **results;  // Aggregated results array (NULL if not stored)
+  int rc;                  // Pipeline return code (RS_RESULT_OK, RS_RESULT_EOF, etc.)
+  bool hasStoredResults;   // Whether results are available to the reply callback
+  QueryError err;          // Error copied from the pipeline's temporary QueryError
+  cachedVars cv;           // Cached lookup variables used during serialization
+  struct Cursor *cursor;   // Non-owning cursor handle for the reply callback
+  size_t limit;            // Original limit, used to calculate the RESP2 result length
+} ChunkReplyState;
 
 typedef enum {
   QUERY_REQUEST_KIND_AREQ,
@@ -27,9 +60,12 @@ typedef struct {
 typedef struct QueryRequest {
   QueryRequestKind kind;
   CursorInfo cursorInfo;
+  ChunkReplyState reply;
 } QueryRequest;
 
 void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind);
+void QueryRequest_ResetReply(QueryRequest *request);
+void QueryRequest_Destroy(QueryRequest *request);
 
 #ifdef __cplusplus
 }

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -84,8 +84,8 @@ typedef struct {
 } RegistryInfo;
 
 typedef struct {
-  // Held command arguments borrowed by the request plan. The owning wrapper
-  // retains their Redis string references until after the request is freed.
+  // Held command arguments borrowed by the request plan. QueryRequest retains
+  // their Redis string references until the request is destroyed.
   RedisModuleString **argv;
 
   // Number of held arguments; may include a trailing debug-only section.
@@ -190,7 +190,9 @@ static inline void QueryRequest_SetExecutionPhase(QueryRequest *request, int pha
   }
 }
 
-void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind);
+void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind, RedisModuleString **argv,
+                       uint32_t argc);
+void QueryRequest_HoldArgs(QueryRequest *request, RedisModuleString **argv, uint32_t argc);
 void QueryRequest_ResetReply(QueryRequest *request);
 void QueryRequest_Destroy(QueryRequest *request);
 

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -21,6 +21,7 @@ extern "C" {
 
 typedef struct RLookup RLookup;
 typedef struct PLN_ArrangeStep PLN_ArrangeStep;
+typedef struct ResultProcessor ResultProcessor;
 typedef struct SearchResult SearchResult;
 struct Cursor;
 
@@ -61,7 +62,23 @@ typedef struct QueryRequest {
   QueryRequestKind kind;
   CursorInfo cursorInfo;
   ChunkReplyState reply;
+  /**
+   * Transitional reference to the legacy QueryProcessingCtx.endProc slot.
+   * The extra indirection makes changes to that slot immediately visible here,
+   * without mirroring every pipeline mutation.
+   * TODO($$$): Once QueryRequest owns endProc, replace this with ResultProcessor *.
+   */
+  ResultProcessor **endProcRef;
 } QueryRequest;
+
+static inline void QueryRequest_SetEndProcRef(QueryRequest *request,
+                                              ResultProcessor **endProcRef) {
+  request->endProcRef = endProcRef;
+}
+
+static inline ResultProcessor *QueryRequest_GetEndProc(const QueryRequest *request) {
+  return request->endProcRef ? *request->endProcRef : NULL;
+}
 
 void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind);
 void QueryRequest_ResetReply(QueryRequest *request);

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -26,6 +26,7 @@ typedef struct PLN_ArrangeStep PLN_ArrangeStep;
 typedef struct ResultProcessor ResultProcessor;
 typedef struct SearchResult SearchResult;
 struct Cursor;
+struct MRChannel;
 
 /** Cached variables used while serializing stored results. */
 typedef struct {
@@ -79,11 +80,27 @@ typedef struct {
   RegistryEntryKind kind;
 } RegistryInfo;
 
+typedef struct {
+  RS_Atomic(bool) timedOut;
+} QueryRequestTimeout;
+
+static inline bool QueryRequestTimeout_GetTimedOut(const QueryRequestTimeout *timeout) {
+  return RS_AtomicBoolLoadRelaxed(&timeout->timedOut);
+}
+
+static inline void QueryRequestTimeout_SetTimedOut(QueryRequestTimeout *timeout) {
+  RS_AtomicBoolStoreRelaxed(&timeout->timedOut, true);
+}
+
+static inline void QueryRequestTimeout_ClearTimedOut(QueryRequestTimeout *timeout) {
+  RS_AtomicBoolStoreRelaxed(&timeout->timedOut, false);
+}
+
 /**
  * Timeout-only synchronization between query workers and main-thread callbacks.
  * TODO($$$): Remove this temporary state after MOD-17486 is merged.
  */
-typedef struct {
+typedef struct QueryRequestAsyncState {
   bool requiresAggregateResultsSync;
   RS_Atomic(bool) aggregatingResults;
   bool aggregateResultsClaimLost;
@@ -91,10 +108,23 @@ typedef struct {
   int safeLoadersHoldingGIL;
   // Per-cycle CAS owner for coordinator RETURN_STRICT cursor reads.
   RS_Atomic(int) strictReadOwner;
+  RS_Atomic(int) execPhase;
+  struct MRChannel *abortWakeChannel;
+  // TODO($$$): Plug this primitive into the abort-wake paths later in this PR.
+  pthread_mutex_t abortWakeLock;
   // TODO($$$): Plug both primitives into the async synchronization paths later in this PR.
   pthread_mutex_t aggregateResultsLock;
   pthread_cond_t aggregateResultsCond;
 } QueryRequestAsyncState;
+
+static inline int QueryRequestAsyncState_GetExecutionPhase(const QueryRequestAsyncState *state) {
+  return RS_AtomicIntLoadRelaxed(&state->execPhase);
+}
+
+static inline void QueryRequestAsyncState_SetExecutionPhase(QueryRequestAsyncState *state,
+                                                            int phase) {
+  RS_AtomicIntStoreRelaxed(&state->execPhase, phase);
+}
 
 typedef struct QueryRequest {
   QueryRequestKind kind;
@@ -104,6 +134,7 @@ typedef struct QueryRequest {
   // TODO($$$): Replace the legacy BRC registry node and type flag with this field.
   RegistryInfo registryInfo;
   ChunkReplyState reply;
+  QueryRequestTimeout timeout;
   QueryRequestAsyncState async;
   /**
    * Transitional reference to the legacy QueryProcessingCtx.endProc slot.

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -22,11 +22,14 @@ extern "C" {
 #endif
 
 typedef struct RLookup RLookup;
+typedef struct RedisModuleString RedisModuleString;
 typedef struct PLN_ArrangeStep PLN_ArrangeStep;
 typedef struct ResultProcessor ResultProcessor;
 typedef struct SearchResult SearchResult;
 struct Cursor;
 struct MRChannel;
+
+#define QUERY_OFFSET_NONE UINT32_MAX
 
 /** Cached variables used while serializing stored results. */
 typedef struct {
@@ -80,6 +83,23 @@ typedef struct {
   RegistryEntryKind kind;
 } RegistryInfo;
 
+typedef struct {
+  // Held command arguments borrowed by the request plan. The owning wrapper
+  // retains their Redis string references until after the request is freed.
+  RedisModuleString **argv;
+
+  // Number of held arguments; may include a trailing debug-only section.
+  uint32_t argc;
+
+  // Logical command length available to parsing. Debug requests lower this
+  // while keeping the excluded trailing arguments held in argv.
+  uint32_t parseArgc;
+
+  // Index of this request's query string in argv. QUERY_OFFSET_NONE denotes a
+  // request without a query argument, such as a filterless VSIM subquery.
+  uint32_t queryOffset;
+} QueryRequestArgs;
+
 typedef struct QueryRequestTimeout {
   RS_Atomic(bool) timedOut;
 } QueryRequestTimeout;
@@ -132,6 +152,7 @@ void QueryRequestAsyncState_WakeAbortChannel(QueryRequestAsyncState *state);
 
 typedef struct QueryRequest {
   QueryRequestKind kind;
+  QueryRequestArgs args;
   // TODO($$$): Temporary marker intended to replace BlockedRequestCtx.bc.
   bool blockedClientCycleActive;
   CursorInfo cursorInfo;

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+#ifndef QUERY_REQUEST_H__
+#define QUERY_REQUEST_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct QueryRequest {
+  unsigned char reserved;
+} QueryRequest;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -166,7 +166,6 @@ typedef struct QueryRequest {
   // TODO($$$): Temporary marker intended to replace BlockedRequestCtx.bc.
   bool blockedClientCycleActive;
   CursorInfo cursorInfo;
-  // TODO($$$): Replace the legacy BRC registry node and type flag with this field.
   RegistryInfo registryInfo;
   ChunkReplyState reply;
   bool useReplyCallback;

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -102,6 +102,7 @@ typedef struct {
 
 typedef struct QueryRequestTimeout {
   RS_Atomic(bool) timedOut;
+  bool skipTimeoutChecks;
 } QueryRequestTimeout;
 
 static inline bool QueryRequestTimeout_GetTimedOut(const QueryRequestTimeout *timeout) {

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -80,7 +80,7 @@ typedef struct {
   RegistryEntryKind kind;
 } RegistryInfo;
 
-typedef struct {
+typedef struct QueryRequestTimeout {
   RS_Atomic(bool) timedOut;
 } QueryRequestTimeout;
 
@@ -110,7 +110,6 @@ typedef struct QueryRequestAsyncState {
   RS_Atomic(int) strictReadOwner;
   RS_Atomic(int) execPhase;
   struct MRChannel *abortWakeChannel;
-  // TODO($$$): Plug this primitive into the abort-wake paths later in this PR.
   pthread_mutex_t abortWakeLock;
   // TODO($$$): Plug both primitives into the async synchronization paths later in this PR.
   pthread_mutex_t aggregateResultsLock;
@@ -125,6 +124,11 @@ static inline void QueryRequestAsyncState_SetExecutionPhase(QueryRequestAsyncSta
                                                             int phase) {
   RS_AtomicIntStoreRelaxed(&state->execPhase, phase);
 }
+
+void QueryRequestAsyncState_RegisterAbortWakeChannel(QueryRequestAsyncState *state,
+                                                     struct MRChannel *channel);
+void QueryRequestAsyncState_UnregisterAbortWakeChannel(QueryRequestAsyncState *state);
+void QueryRequestAsyncState_WakeAbortChannel(QueryRequestAsyncState *state);
 
 typedef struct QueryRequest {
   QueryRequestKind kind;
@@ -152,6 +156,17 @@ static inline void QueryRequest_SetEndProcRef(QueryRequest *request,
 
 static inline ResultProcessor *QueryRequest_GetEndProc(const QueryRequest *request) {
   return request->endProcRef ? *request->endProcRef : NULL;
+}
+
+static inline int QueryRequest_GetExecutionPhase(const QueryRequest *request) {
+  return QueryRequestAsyncState_GetExecutionPhase(&request->async);
+}
+
+// Preserve the phase where a timeout was first observed.
+static inline void QueryRequest_SetExecutionPhase(QueryRequest *request, int phase) {
+  if (!QueryRequestTimeout_GetTimedOut(&request->timeout)) {
+    QueryRequestAsyncState_SetExecutionPhase(&request->async, phase);
+  }
 }
 
 void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind);

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -89,6 +89,8 @@ typedef struct {
   bool aggregateResultsClaimLost;
   bool aggregateResultsDone;
   int safeLoadersHoldingGIL;
+  // Per-cycle CAS owner for coordinator RETURN_STRICT cursor reads.
+  RS_Atomic(int) strictReadOwner;
   // TODO($$$): Plug both primitives into the async synchronization paths later in this PR.
   pthread_mutex_t aggregateResultsLock;
   pthread_cond_t aggregateResultsCond;

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -169,6 +169,7 @@ typedef struct QueryRequest {
   // TODO($$$): Replace the legacy BRC registry node and type flag with this field.
   RegistryInfo registryInfo;
   ChunkReplyState reply;
+  bool useReplyCallback;
   QueryRequestTimeout timeout;
   QueryRequestAsyncState async;
   /**
@@ -187,6 +188,14 @@ static inline void QueryRequest_SetEndProcRef(QueryRequest *request,
 
 static inline ResultProcessor *QueryRequest_GetEndProc(const QueryRequest *request) {
   return request->endProcRef ? *request->endProcRef : NULL;
+}
+
+static inline bool QueryRequest_UsesReplyCallback(const QueryRequest *request) {
+  return request->useReplyCallback;
+}
+
+static inline void QueryRequest_SetUseReplyCallback(QueryRequest *request, bool useReplyCallback) {
+  request->useReplyCallback = useReplyCallback;
 }
 
 static inline int QueryRequest_GetExecutionPhase(const QueryRequest *request) {

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -68,6 +68,17 @@ typedef struct {
   CursorDisposition disposition;
 } CursorInfo;
 
+typedef enum {
+  REGISTRY_ENTRY_NONE,    // The request has no active registry entry.
+  REGISTRY_ENTRY_QUERY,   // The node belongs to the blocked-query registry.
+  REGISTRY_ENTRY_CURSOR,  // The node belongs to the blocked-cursor registry.
+} RegistryEntryKind;
+
+typedef struct {
+  void *node;
+  RegistryEntryKind kind;
+} RegistryInfo;
+
 /**
  * Timeout-only synchronization between query workers and main-thread callbacks.
  * TODO($$$): Remove this temporary state after MOD-17486 is merged.
@@ -88,6 +99,8 @@ typedef struct QueryRequest {
   // TODO($$$): Temporary marker intended to replace BlockedRequestCtx.bc.
   bool blockedClientCycleActive;
   CursorInfo cursorInfo;
+  // TODO($$$): Replace the legacy BRC registry node and type flag with this field.
+  RegistryInfo registryInfo;
   ChunkReplyState reply;
   QueryRequestAsyncState async;
   /**

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -245,7 +245,7 @@ static inline void QueryRequest_SetExecutionPhase(QueryRequest *request, int pha
 
 void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind, RedisModuleString **argv,
                        uint32_t argc);
-void QueryRequest_HoldArgs(QueryRequest *request, RedisModuleString **argv, uint32_t argc);
+void QueryRequest_HoldArgs(QueryRequestArgs *args, RedisModuleString **argv, uint32_t argc);
 void QueryRequest_ResetReply(QueryRequest *request);
 void QueryRequest_Destroy(QueryRequest *request);
 

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -245,7 +245,6 @@ static inline void QueryRequest_SetExecutionPhase(QueryRequest *request, int pha
 
 void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind, RedisModuleString **argv,
                        uint32_t argc);
-void QueryRequest_HoldArgs(QueryRequestArgs *args, RedisModuleString **argv, uint32_t argc);
 void QueryRequest_ResetReply(QueryRequest *request);
 void QueryRequest_Destroy(QueryRequest *request);
 

--- a/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
@@ -241,9 +241,7 @@ pub unsafe extern "C" fn QAST_Iterate(
     // the clock-based timeout instead.
     // SAFETY: `areq`, when non-null (checked first), is a valid `AREQ`
     // (precondition 5).
-    let bc_timeout_areq = if !areq.is_null()
-        && unsafe { !QueryRequestTimeout_ShouldCheck(&raw const (*areq).base.timeout) }
-    {
+    let bc_timeout_areq = if !areq.is_null() && unsafe { (*areq).base.timeout.skipTimeoutChecks } {
         areq
     } else {
         std::ptr::null_mut()

--- a/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
@@ -241,7 +241,9 @@ pub unsafe extern "C" fn QAST_Iterate(
     // the clock-based timeout instead.
     // SAFETY: `areq`, when non-null (checked first), is a valid `AREQ`
     // (precondition 5).
-    let bc_timeout_areq = if !areq.is_null() && unsafe { (*areq).skipTimeoutChecks } {
+    let bc_timeout_areq = if !areq.is_null()
+        && unsafe { !QueryRequestTimeout_ShouldCheck(&raw const (*areq).base.timeout) }
+    {
         areq
     } else {
         std::ptr::null_mut()

--- a/src/redisearch_rs/c_wrappers/query/src/mock/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/mock/query_eval_ctx.rs
@@ -182,14 +182,14 @@ impl MockQueryEvalCtx {
     /// Blocked Client Timeout source is selected (simulating a
     /// background-executed request).
     ///
-    /// The allocation is owned by this mock and freed on drop. It is zeroed,
-    /// so its `RequestSyncState::timedOut` flag reads as "not timed out": a code
-    /// path that probes the timeout (via `AREQ_CheckTimedOut`) sees a valid,
-    /// non-expired request.
+    /// The allocation is owned by this mock and freed on drop. Its zeroed
+    /// `QueryRequestTimeout::timedOut` flag reads as "not timed out", so
+    /// `AREQ_CheckTimedOut` sees a non-expired request.
     pub fn enable_blocked_client_timeout(&mut self) {
-        // SAFETY: `ffi::AREQ` is a `#[repr(C)]` POD struct, so an all-zero bit
-        // pattern is a valid (non-expired) instance; the allocation is checked
-        // non-null and stored for cleanup in `Drop`.
+        // SAFETY: the allocation has the size and alignment of `ffi::AREQ` and
+        // is checked non-null. This mock only exposes it to `AREQ_CheckTimedOut`,
+        // which reads the zeroed atomic timeout flag; it never uses uninitialized
+        // request resources. The allocation is retained for cleanup in `Drop`.
         unsafe {
             if self.areq.is_null() {
                 let areq = alloc_zeroed(Layout::new::<ffi::AREQ>()).cast::<ffi::AREQ>();

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -590,6 +590,7 @@ const BLOCKLIST_TYPES: &[&str] = &[
     "QASTValidationFlagsSet",
     "QueryNodeOptions",
     "QueryProcessingCtx", // defined directly in `ffi/src/lib.rs`
+    "RedisModuleString",
     "RSQueryTerm",
     "RSTokenFlags",
 ];

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -338,9 +338,8 @@ const HEADERS: &[HeaderAllowlist] = &[
             "AsyncPollResult",
             "AsyncReadResult",
             "BasicDiskAPI",
-            // RETURN_STRICT GIL handshake ctx; kept opaque (forward-declared
-            // here, defined in `aggregate.h`).
-            "BlockedRequestCtx",
+            // RETURN_STRICT GIL handshake context.
+            "QueryRequest",
             "DocTableDiskAPI",
             "IndexDiskAPI",
             "MetricsDiskAPI",
@@ -679,11 +678,6 @@ fn main() {
     // `_GNU_SOURCE` makes `<stdio.h>` declare `asprintf`/`vasprintf`, which
     // `deps/rmalloc/rmalloc.h` uses.
     bindings = bindings.clang_arg("-D_GNU_SOURCE");
-
-    // `BlockedRequestCtx` is only forward-declared in `search_disk_api.h`, but its full
-    // definition (aggregate.h) is pulled in transitively through `AREQ_CheckTimedOut`. Force it
-    // opaque so Rust callers only ever get a pointer, never its (Rust-unsafe-to-model) C internals.
-    bindings = bindings.opaque_type("BlockedRequestCtx");
 
     for ty in BLOCKLIST_TYPES {
         bindings = bindings.blocklist_type(ty);

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -679,6 +679,10 @@ fn main() {
     // `deps/rmalloc/rmalloc.h` uses.
     bindings = bindings.clang_arg("-D_GNU_SOURCE");
 
+    // `QueryRequest` is only passed across this FFI boundary by pointer. Keep its
+    // C-owned internals out of the generated Rust surface.
+    bindings = bindings.opaque_type("QueryRequest");
+
     for ty in BLOCKLIST_TYPES {
         bindings = bindings.blocklist_type(ty);
     }

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -679,10 +679,6 @@ fn main() {
     // `deps/rmalloc/rmalloc.h` uses.
     bindings = bindings.clang_arg("-D_GNU_SOURCE");
 
-    // `QueryRequest` is only passed across this FFI boundary by pointer. Keep its
-    // C-owned internals out of the generated Rust surface.
-    bindings = bindings.opaque_type("QueryRequest");
-
     for ty in BLOCKLIST_TYPES {
         bindings = bindings.blocklist_type(ty);
     }

--- a/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
+++ b/src/redisearch_rs/rqe_iterators/src/utils/timeout.rs
@@ -93,8 +93,8 @@ impl TimeoutContextBlockedClient {
     ///   iterator holding it) is used. The pointer is stored without a
     ///   lifetime, so the caller is fully responsible for not using the context
     ///   past the [`AREQ`]'s lifetime.
-    /// * The `RequestSyncState::timedOut` flag inside the [`AREQ`] must be safe
-    ///   to read with relaxed semantics from any thread.
+    /// * The `QueryRequestTimeout::timedOut` flag in the [`AREQ`]'s embedded
+    ///   `QueryRequest` must be safe to read with relaxed semantics from any thread.
     #[inline(always)]
     pub const unsafe fn new(areq: NonNull<AREQ>) -> Self {
         Self { areq }

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1165,7 +1165,7 @@ typedef struct RPSafeLoader {
   // Request sync context; non-NULL only for RETURN_STRICT requests that use the
   // aggregate-results sync. When set, the loader performs the GIL deadlock-
   // avoidance handshake around the GIL (see aggregate.h).
-  BlockedRequestCtx *brc;
+  QueryRequest *request;
 } RPSafeLoader;
 
 /************************* Safe Loader private functions *************************/
@@ -1347,10 +1347,10 @@ static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
   SyncPoint_WaitUntil(SYNC_POINT_BEFORE_SAFE_LOADER_GIL_LOCK, SearchTime_IsTimedOut, &sctx->time);
 #endif
 
-  // Deadlock-avoidance handshake (brc non-NULL only for RETURN_STRICT). Mark
+  // Deadlock-avoidance handshake (request non-NULL only for RETURN_STRICT). Mark
   // that we are about to take the GIL so the timeout callback can preempt us; if
   // it already timed out, bail instead of blocking. See aggregate.h.
-  if (self->brc && !BlockedRequestCtx_SafeLoaderEnterGIL(self->brc)) {
+  if (self->request && !QueryRequest_SafeLoaderEnterGIL(self->request)) {
     return RS_RESULT_TIMEDOUT;
   }
 
@@ -1371,8 +1371,8 @@ static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
   // closes the race where a timeout landing in the unlock->clear gap sees a
   // stale safeLoadersHoldingGIL count and preempts, dropping already-loaded
   // results. See aggregate.h.
-  if (self->brc) {
-    BlockedRequestCtx_SafeLoaderExitGIL(self->brc);
+  if (self->request) {
+    QueryRequest_SafeLoaderExitGIL(self->request);
   }
 
   // Done loading. Unlock Redis
@@ -1429,7 +1429,7 @@ static ResultProcessor *RPSafeLoader_New(RedisSearchCtx *sctx, RLookup *lk,
 
   sl->last_buffered_rc = RS_RESULT_OK;
   sl->sctx = sctx;
-  sl->brc = NULL;
+  sl->request = NULL;
 
   sl->base_loader.base.Next = rpSafeLoaderNext_Accumulate;
   sl->base_loader.base.Free = rpSafeLoaderFree;
@@ -1548,7 +1548,7 @@ static ResultProcessor *RPSafeLoader_New_FromPlainLoader(RPLoader *loader) {
   sl->curr_result_index = 0;
 
   sl->last_buffered_rc = RS_RESULT_OK;
-  sl->brc = NULL;
+  sl->request = NULL;
 
   sl->base_loader.base.Next = rpSafeLoaderNext_Accumulate;
   sl->base_loader.base.Free = rpSafeLoaderFree;
@@ -1585,13 +1585,13 @@ void SetLoadersForBG(QueryProcessingCtx *qctx) {
 //
 // The disk async loader (Rust `redisearch_disk` crate) uses the same handshake via
 // `SearchDisk_AsyncLoader_SetSyncCtx` (see aggregate.h).
-void RPSafeLoader_SetSyncCtx(QueryProcessingCtx *qctx, struct BlockedRequestCtx *sync) {
+void RPSafeLoader_SetSyncCtx(QueryProcessingCtx *qctx, QueryRequest *request) {
   ResultProcessor *rp = qctx->endProc;
   while (rp) {
     if (rp->type == RP_SAFE_LOADER) {
-      ((RPSafeLoader *)rp)->brc = sync;
+      ((RPSafeLoader *)rp)->request = request;
     } else if (rp->type == RP_DISK_ASYNC_LOADER) {
-      SearchDisk_AsyncLoader_SetSyncCtx(rp, sync);
+      SearchDisk_AsyncLoader_SetSyncCtx(rp, request);
     }
     rp = rp->upstream;
   }

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -206,7 +206,7 @@ ResultProcessor *RPPager_New(size_t offset, size_t limit);
  *
  *******************************************************************************************************************/
 struct AREQ;
-struct BlockedRequestCtx;
+struct QueryRequest;
 ResultProcessor *RPLoader_New(RedisSearchCtx *sctx, uint32_t reqflags, RLookup *lk, const RLookupKey **keys, size_t nkeys, bool forceLoad, uint32_t *outStateflags);
 void RPLoader_ReplyProfileFields(RedisModule_Reply *reply, const ResultProcessor *base);
 
@@ -216,7 +216,7 @@ void SetLoadersForMainThread(QueryProcessingCtx *qctx);
 /* Link the request sync context into every RP_SAFE_LOADER and RP_DISK_ASYNC_LOADER in the
  * pipeline so they can perform the RETURN_STRICT GIL deadlock-avoidance handshake (see
  * aggregate.h). No-op for pipelines without safe/disk loaders. */
-void RPSafeLoader_SetSyncCtx(QueryProcessingCtx *qctx, struct BlockedRequestCtx *sync);
+void RPSafeLoader_SetSyncCtx(QueryProcessingCtx *qctx, struct QueryRequest *request);
 
 /** Creates a new Highlight processor */
 ResultProcessor *RPHighlighter_New(RSLanguage language, const FieldList *fields,

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -232,9 +232,9 @@ ResultProcessor *SearchDisk_NewAsyncLoaderResultProcessor(RedisSearchCtx *sctx, 
                                                      outStateFlags);
 }
 
-void SearchDisk_AsyncLoader_SetSyncCtx(ResultProcessor *rp, BlockedRequestCtx *brc) {
+void SearchDisk_AsyncLoader_SetSyncCtx(ResultProcessor *rp, QueryRequest *request) {
     RS_ASSERT(disk);
-    disk->basic.asyncLoaderSetSyncCtx(rp, brc);
+    disk->basic.asyncLoaderSetSyncCtx(rp, request);
 }
 
 void SearchDisk_UpdateLogObfuscation() {

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -199,9 +199,9 @@ ResultProcessor *SearchDisk_NewAsyncLoaderResultProcessor(RedisSearchCtx *sctx, 
  * `RPSafeLoader_SetSyncCtx`'s pipeline walk when it reaches an `RP_DISK_ASYNC_LOADER` node.
  *
  * @param rp  The disk async-loader ResultProcessor, from SearchDisk_NewAsyncLoaderResultProcessor
- * @param brc `BlockedRequestCtx *`, or NULL to clear
+ * @param request `QueryRequest *`, or NULL to clear
  */
-void SearchDisk_AsyncLoader_SetSyncCtx(ResultProcessor *rp, BlockedRequestCtx *brc);
+void SearchDisk_AsyncLoader_SetSyncCtx(ResultProcessor *rp, QueryRequest *request);
 
 // Index API wrappers
 

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -32,7 +32,7 @@ typedef struct RLookupKey RLookupKey;
 typedef struct HiddenString HiddenString;
 
 // Forward declaration for the RETURN_STRICT GIL handshake context (aggregate.h).
-typedef struct BlockedRequestCtx BlockedRequestCtx;
+typedef struct QueryRequest QueryRequest;
 
 // Helper opaque types for the disk API
 typedef const void* RedisSearchDisk;
@@ -336,15 +336,15 @@ typedef struct BasicDiskAPI {
   /**
    * Hand the disk async-loader result processor its request sync context, so it can perform
    * the same RETURN_STRICT GIL deadlock-avoidance handshake as RP_SAFE_LOADER (see
-   * `BlockedRequestCtx_SafeLoaderEnterGIL` / `ExitGIL` in aggregate.h).
+   * `QueryRequest_SafeLoaderEnterGIL` / `ExitGIL` in aggregate.h).
    *
    * @param rp  The disk async-loader ResultProcessor, previously returned by
    *            `newAsyncLoaderResultProcessor`.
-   * @param brc `BlockedRequestCtx *`, or NULL to clear.
+   * @param request `QueryRequest *`, or NULL to clear.
    *
    * Note: keep this field last in `BasicDiskAPI` (C and Rust build this struct together).
    */
-  void (*asyncLoaderSetSyncCtx)(ResultProcessor *rp, BlockedRequestCtx *brc);
+  void (*asyncLoaderSetSyncCtx)(ResultProcessor *rp, QueryRequest *request);
 } BasicDiskAPI;
 
 typedef struct IndexDiskAPI {

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -96,7 +96,7 @@ typedef struct {
   t_fieldMask fieldmask;
   int slop;
 
-  /* Borrowed from the request's held argv (see BlockedRequestCtx.argv) */
+  /* Borrowed from the request's held argv (see QueryRequestArgs.argv) */
   RedisModuleString **inkeys;
   size_t ninkeys;
 
@@ -107,7 +107,7 @@ typedef struct {
   struct {
     LegacyNumericFilter **filters;
     LegacyGeoFilter **geo_filters;
-    /* Borrowed from the request's held argv (see BlockedRequestCtx.argv) */
+    /* Borrowed from the request's held argv (see QueryRequestArgs.argv) */
     RedisModuleString **infields;
     size_t ninfields;
   } legacy;

--- a/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
@@ -81,7 +81,6 @@ protected:
     QueryError qerr = QueryError_Default();
     AREQ *r = AREQ_New(rmArgs, rmArgs.size());
     AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR);
-    BlockedRequestCtx_NewAREQ(r);
     int rc = AREQ_Compile(r, ctx, 0, false, &qerr);
     EXPECT_EQ(rc, REDISMODULE_OK) << QueryError_GetUserError(&qerr);
     if (rc != REDISMODULE_OK) {

--- a/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
@@ -79,9 +79,9 @@ protected:
     RMCK::ArgvList rmArgs(ctx, argv);
 
     QueryError qerr = QueryError_Default();
-    AREQ *r = AREQ_New();
+    AREQ *r = AREQ_New(rmArgs, rmArgs.size());
     AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR);
-    BlockedRequestCtx_NewAREQ(r, rmArgs, rmArgs.size());
+    BlockedRequestCtx_NewAREQ(r);
     int rc = AREQ_Compile(r, ctx, 0, false, &qerr);
     EXPECT_EQ(rc, REDISMODULE_OK) << QueryError_GetUserError(&qerr);
     if (rc != REDISMODULE_OK) {

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -56,9 +56,9 @@ TEST_F(AggTest, testBasic) {
   RedisModule_CloseKey(kk);
   RedisModule_FreeString(ctx, vtmp);
 
-  AREQ *rr = AREQ_New();
   RMCK::ArgvList aggArgs(ctx, "*");
-  BlockedRequestCtx_NewAREQ(rr, aggArgs, aggArgs.size());
+  AREQ *rr = AREQ_New(aggArgs, aggArgs.size());
+  BlockedRequestCtx_NewAREQ(rr);
   rv = AREQ_Compile(rr, ctx, 0, false, &qerr);
   ASSERT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);
   ASSERT_FALSE(QueryError_HasError(&qerr));
@@ -306,10 +306,10 @@ TEST_F(AggTest, AvoidingCompleteResultStructOpt) {
 
   auto scenario = [&](QEFlags flags, auto... args) -> bool {
     QueryError qerr = QueryError_Default();
-    AREQ *rr = AREQ_New();
-    AREQ_AddRequestFlags(rr, flags);
     RMCK::ArgvList aggArgs(ctx, "*", args...);
-    BlockedRequestCtx_NewAREQ(rr, aggArgs, aggArgs.size());
+    AREQ *rr = AREQ_New(aggArgs, aggArgs.size());
+    AREQ_AddRequestFlags(rr, flags);
+    BlockedRequestCtx_NewAREQ(rr);
     int rv = AREQ_Compile(rr, ctx, 0, false, &qerr);
     EXPECT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);
     bool res = rr->searchopts.flags & Search_CanSkipRichResults;

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -58,7 +58,6 @@ TEST_F(AggTest, testBasic) {
 
   RMCK::ArgvList aggArgs(ctx, "*");
   AREQ *rr = AREQ_New(aggArgs, aggArgs.size());
-  BlockedRequestCtx_NewAREQ(rr);
   rv = AREQ_Compile(rr, ctx, 0, false, &qerr);
   ASSERT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);
   ASSERT_FALSE(QueryError_HasError(&qerr));
@@ -309,7 +308,6 @@ TEST_F(AggTest, AvoidingCompleteResultStructOpt) {
     RMCK::ArgvList aggArgs(ctx, "*", args...);
     AREQ *rr = AREQ_New(aggArgs, aggArgs.size());
     AREQ_AddRequestFlags(rr, flags);
-    BlockedRequestCtx_NewAREQ(rr);
     int rv = AREQ_Compile(rr, ctx, 0, false, &qerr);
     EXPECT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);
     bool res = rr->searchopts.flags & Search_CanSkipRichResults;

--- a/tests/cpptests/test_cpp_areq_compile.cpp
+++ b/tests/cpptests/test_cpp_areq_compile.cpp
@@ -132,7 +132,6 @@ TEST_P(AREQBinarySlotRangeTest, testBinarySlotRangeParsing) {
 
     // Test AREQ_Compile
     QueryRequest_HoldArgs(&req->base, argv.data(), argv.size());
-    BlockedRequestCtx_NewAREQ(req);
     int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed for: " << test_data.description;
@@ -224,7 +223,6 @@ TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
 
     // Test AREQ_Compile
     QueryRequest_HoldArgs(&req->base, argv.data(), argv.size());
-    BlockedRequestCtx_NewAREQ(req);
     int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";
@@ -261,7 +259,6 @@ TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
 
     // Test AREQ_Compile - should fail due to insufficient arguments
     QueryRequest_HoldArgs(&req->base, argv.data(), argv.size());
-    BlockedRequestCtx_NewAREQ(req);
     int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_ERR) << "AREQ_Compile should fail with insufficient arguments";
@@ -305,7 +302,6 @@ TEST_F(AREQTest, testComplexAggregateWithCursorAndSlotRanges) {
 
     // Test AREQ_Compile
     QueryRequest_HoldArgs(&req->base, argv.data(), argv.size());
-    BlockedRequestCtx_NewAREQ(req);
     int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";

--- a/tests/cpptests/test_cpp_areq_compile.cpp
+++ b/tests/cpptests/test_cpp_areq_compile.cpp
@@ -112,7 +112,7 @@ class AREQBinarySlotRangeTest : public AREQTest, public ::testing::WithParamInte
 TEST_P(AREQBinarySlotRangeTest, testBinarySlotRangeParsing) {
     const auto& test_data = GetParam();
 
-    AREQ* req = AREQ_New();
+    AREQ* req = AREQ_New(NULL, 0);
     ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
 
     // Mark req as internal to bypass checks
@@ -131,7 +131,8 @@ TEST_P(AREQBinarySlotRangeTest, testBinarySlotRangeParsing) {
     argv.push_back(createBinaryString(binary_data));
 
     // Test AREQ_Compile
-    BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());
+    QueryRequest_HoldArgs(&req->base, argv.data(), argv.size());
+    BlockedRequestCtx_NewAREQ(req);
     int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed for: " << test_data.description;
@@ -202,7 +203,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 // Test binary slot range parsing with single range
 TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
-    AREQ* req = AREQ_New();
+    AREQ* req = AREQ_New(NULL, 0);
     ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
 
     // Mark req as internal to bypass checks
@@ -222,7 +223,8 @@ TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
     argv.push_back(createBinaryString(binary_data));
 
     // Test AREQ_Compile
-    BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());
+    QueryRequest_HoldArgs(&req->base, argv.data(), argv.size());
+    BlockedRequestCtx_NewAREQ(req);
     int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";
@@ -244,7 +246,7 @@ TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
 
 // Test error handling for insufficient arguments
 TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
-    AREQ* req = AREQ_New();
+    AREQ* req = AREQ_New(NULL, 0);
     ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
 
     // Mark req as internal to bypass checks
@@ -258,7 +260,8 @@ TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
     argv.push_back(RedisModule_CreateString(ctx, SLOTS_STR, strlen(SLOTS_STR)));
 
     // Test AREQ_Compile - should fail due to insufficient arguments
-    BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());
+    QueryRequest_HoldArgs(&req->base, argv.data(), argv.size());
+    BlockedRequestCtx_NewAREQ(req);
     int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_ERR) << "AREQ_Compile should fail with insufficient arguments";
@@ -274,7 +277,7 @@ TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
 
 // Test complex aggregate query with cursor, scorer, and slot ranges
 TEST_F(AREQTest, testComplexAggregateWithCursorAndSlotRanges) {
-    AREQ* req = AREQ_New();
+    AREQ* req = AREQ_New(NULL, 0);
     ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
 
     // Mark req as internal to bypass checks
@@ -301,7 +304,8 @@ TEST_F(AREQTest, testComplexAggregateWithCursorAndSlotRanges) {
     argv.push_back(RedisModule_CreateString(ctx, "@__score", 8));
 
     // Test AREQ_Compile
-    BlockedRequestCtx_NewAREQ(req, argv.data(), argv.size());
+    QueryRequest_HoldArgs(&req->base, argv.data(), argv.size());
+    BlockedRequestCtx_NewAREQ(req);
     int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";

--- a/tests/cpptests/test_cpp_areq_compile.cpp
+++ b/tests/cpptests/test_cpp_areq_compile.cpp
@@ -112,12 +112,6 @@ class AREQBinarySlotRangeTest : public AREQTest, public ::testing::WithParamInte
 TEST_P(AREQBinarySlotRangeTest, testBinarySlotRangeParsing) {
     const auto& test_data = GetParam();
 
-    AREQ* req = AREQ_New(NULL, 0);
-    ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
-
-    // Mark req as internal to bypass checks
-    req->reqflags = QEXEC_F_INTERNAL;
-
     QueryError status = QueryError_Default();
 
     // Create test slot ranges from parameter
@@ -130,8 +124,12 @@ TEST_P(AREQBinarySlotRangeTest, testBinarySlotRangeParsing) {
     argv.push_back(RedisModule_CreateString(ctx, SLOTS_STR, strlen(SLOTS_STR)));
     argv.push_back(createBinaryString(binary_data));
 
+    AREQ* req = AREQ_New(argv.data(), argv.size());
+    ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
+    // Mark req as internal to bypass checks
+    req->reqflags = QEXEC_F_INTERNAL;
+
     // Test AREQ_Compile
-    QueryRequest_HoldArgs(&req->base.args, argv.data(), argv.size());
     int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed for: " << test_data.description;
@@ -202,12 +200,6 @@ INSTANTIATE_TEST_SUITE_P(
 
 // Test binary slot range parsing with single range
 TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
-    AREQ* req = AREQ_New(NULL, 0);
-    ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
-
-    // Mark req as internal to bypass checks
-    req->reqflags = QEXEC_F_INTERNAL;
-
     QueryError status = QueryError_Default();
 
     // Create test slot range - single range covering all slots
@@ -221,8 +213,12 @@ TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
     argv.push_back(RedisModule_CreateString(ctx, SLOTS_STR, strlen(SLOTS_STR)));
     argv.push_back(createBinaryString(binary_data));
 
+    AREQ* req = AREQ_New(argv.data(), argv.size());
+    ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
+    // Mark req as internal to bypass checks
+    req->reqflags = QEXEC_F_INTERNAL;
+
     // Test AREQ_Compile
-    QueryRequest_HoldArgs(&req->base.args, argv.data(), argv.size());
     int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";
@@ -244,12 +240,6 @@ TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
 
 // Test error handling for insufficient arguments
 TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
-    AREQ* req = AREQ_New(NULL, 0);
-    ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
-
-    // Mark req as internal to bypass checks
-    req->reqflags = QEXEC_F_INTERNAL;
-
     QueryError status = QueryError_Default();
 
     // Create argument list with missing binary data
@@ -257,8 +247,12 @@ TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
     argv.push_back(RedisModule_CreateString(ctx, "hello", 5));  // query
     argv.push_back(RedisModule_CreateString(ctx, SLOTS_STR, strlen(SLOTS_STR)));
 
+    AREQ* req = AREQ_New(argv.data(), argv.size());
+    ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
+    // Mark req as internal to bypass checks
+    req->reqflags = QEXEC_F_INTERNAL;
+
     // Test AREQ_Compile - should fail due to insufficient arguments
-    QueryRequest_HoldArgs(&req->base.args, argv.data(), argv.size());
     int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_ERR) << "AREQ_Compile should fail with insufficient arguments";
@@ -274,12 +268,6 @@ TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
 
 // Test complex aggregate query with cursor, scorer, and slot ranges
 TEST_F(AREQTest, testComplexAggregateWithCursorAndSlotRanges) {
-    AREQ* req = AREQ_New(NULL, 0);
-    ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
-
-    // Mark req as internal to bypass checks
-    req->reqflags = QEXEC_F_INTERNAL;
-
     QueryError status = QueryError_Default();
 
     // Create argument list matching the MRCommand
@@ -300,8 +288,12 @@ TEST_F(AREQTest, testComplexAggregateWithCursorAndSlotRanges) {
     argv.push_back(RedisModule_CreateString(ctx, "@__key", 6));
     argv.push_back(RedisModule_CreateString(ctx, "@__score", 8));
 
+    AREQ* req = AREQ_New(argv.data(), argv.size());
+    ASSERT_NE(req, nullptr) << "AREQ_New should return a valid pointer";
+    // Mark req as internal to bypass checks
+    req->reqflags = QEXEC_F_INTERNAL;
+
     // Test AREQ_Compile
-    QueryRequest_HoldArgs(&req->base.args, argv.data(), argv.size());
     int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";

--- a/tests/cpptests/test_cpp_areq_compile.cpp
+++ b/tests/cpptests/test_cpp_areq_compile.cpp
@@ -131,7 +131,7 @@ TEST_P(AREQBinarySlotRangeTest, testBinarySlotRangeParsing) {
     argv.push_back(createBinaryString(binary_data));
 
     // Test AREQ_Compile
-    QueryRequest_HoldArgs(&req->base, argv.data(), argv.size());
+    QueryRequest_HoldArgs(&req->base.args, argv.data(), argv.size());
     int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed for: " << test_data.description;
@@ -222,7 +222,7 @@ TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
     argv.push_back(createBinaryString(binary_data));
 
     // Test AREQ_Compile
-    QueryRequest_HoldArgs(&req->base, argv.data(), argv.size());
+    QueryRequest_HoldArgs(&req->base.args, argv.data(), argv.size());
     int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";
@@ -258,7 +258,7 @@ TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
     argv.push_back(RedisModule_CreateString(ctx, SLOTS_STR, strlen(SLOTS_STR)));
 
     // Test AREQ_Compile - should fail due to insufficient arguments
-    QueryRequest_HoldArgs(&req->base, argv.data(), argv.size());
+    QueryRequest_HoldArgs(&req->base.args, argv.data(), argv.size());
     int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_ERR) << "AREQ_Compile should fail with insufficient arguments";
@@ -301,7 +301,7 @@ TEST_F(AREQTest, testComplexAggregateWithCursorAndSlotRanges) {
     argv.push_back(RedisModule_CreateString(ctx, "@__score", 8));
 
     // Test AREQ_Compile
-    QueryRequest_HoldArgs(&req->base, argv.data(), argv.size());
+    QueryRequest_HoldArgs(&req->base.args, argv.data(), argv.size());
     int result = AREQ_Compile(req, ctx, 0, false, &status);
 
     EXPECT_EQ(result, REDISMODULE_OK) << "AREQ_Compile should succeed";

--- a/tests/cpptests/test_cpp_hybrid.cpp
+++ b/tests/cpptests/test_cpp_hybrid.cpp
@@ -21,8 +21,8 @@ TEST_F(HybridRequestBasicTest, testHybridRequestCreationBasic) {
   // Test basic HybridRequest creation without Redis dependencies
   AREQ **requests = array_new(AREQ*, 2);
   // Initialize the AREQ structures
-  AREQ *req1 = AREQ_New();
-  AREQ *req2 = AREQ_New();
+  AREQ *req1 = AREQ_New(NULL, 0);
+  AREQ *req2 = AREQ_New(NULL, 0);
 
   requests = array_ensure_append_1(requests, req1);
   requests = array_ensure_append_1(requests, req2);

--- a/tests/cpptests/test_distagg.cpp
+++ b/tests/cpptests/test_distagg.cpp
@@ -44,7 +44,6 @@ static void testAverage() {
   );
   AREQ *r = AREQ_New(vv, vv.size());
   QueryError status{QueryErrorCode(0)};
-  BlockedRequestCtx_NewAREQ(r);
   int rc = AREQ_Compile(r, ctx, 0, false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
@@ -104,7 +103,6 @@ static void testCountDistinct() {
   AREQ *r = AREQ_New(vv, vv.size());
   AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR); // mark for coordinator pipeline
   QueryError status{QueryErrorCode(0)};
-  BlockedRequestCtx_NewAREQ(r);
   int rc = AREQ_Compile(r, ctx, 0, false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
@@ -143,7 +141,6 @@ static void testSplit() {
   AREQ *r = AREQ_New(vv, vv.size());
   AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR); // mark for coordinator pipeline
   QueryError status{QueryErrorCode(0)};
-  BlockedRequestCtx_NewAREQ(r);
   int rc = AREQ_Compile(r, ctx, 0, false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));

--- a/tests/cpptests/test_distagg.cpp
+++ b/tests/cpptests/test_distagg.cpp
@@ -35,7 +35,6 @@ static int my_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 //        'SORTBY', '2', '@avg_price', 'DESC']
 
 static void testAverage() {
-  AREQ *r = AREQ_New();
   RMCK::Context ctx{};
   RMCK::ArgvList vv(ctx, "sony",                                        // nl
                     "GROUPBY", "1", "@brand",                           // nl
@@ -43,8 +42,9 @@ static void testAverage() {
                     "REDUCE", "count", "0",                             // nl
                     "sortby", "2", "@avg_price", "DESC"                 // nl
   );
+  AREQ *r = AREQ_New(vv, vv.size());
   QueryError status{QueryErrorCode(0)};
-  BlockedRequestCtx_NewAREQ(r, vv, vv.size());
+  BlockedRequestCtx_NewAREQ(r);
   int rc = AREQ_Compile(r, ctx, 0, false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
@@ -95,16 +95,16 @@ static void testAverage() {
                ]
  */
 static void testCountDistinct() {
-  AREQ *r = AREQ_New();
-  AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR); // mark for coordinator pipeline
   RMCK::Context ctx{};
   RMCK::ArgvList vv(ctx, "*",                                                                  // nl
                     "GROUPBY", "1", "@brand",                                                  // nl
                     "REDUCE", "COUNT_DISTINCT", "1", "@title", "AS", "count_distinct(title)",  // nl
                     "REDUCE", "COUNT", "0"                                                     // nl
   );
+  AREQ *r = AREQ_New(vv, vv.size());
+  AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR); // mark for coordinator pipeline
   QueryError status{QueryErrorCode(0)};
-  BlockedRequestCtx_NewAREQ(r, vv, vv.size());
+  BlockedRequestCtx_NewAREQ(r);
   int rc = AREQ_Compile(r, ctx, 0, false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));
@@ -134,16 +134,16 @@ static void testCountDistinct() {
   AREQ_DecrRef(r);
 }
 static void testSplit() {
-  AREQ *r = AREQ_New();
-  AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR); // mark for coordinator pipeline
   RMCK::Context ctx{};
   RMCK::ArgvList vv(ctx, "*",                                                                  // nl
                     "GROUPBY", "1", "@brand",                                                  // nl
                     "REDUCE", "COUNT_DISTINCT", "1", "@title", "AS", "count_distinct(title)",  // nl
                     "REDUCE", "COUNT", "0"                                                     // nl
   );
+  AREQ *r = AREQ_New(vv, vv.size());
+  AREQ_AddRequestFlags(r, QEXEC_F_IS_COORDINATOR); // mark for coordinator pipeline
   QueryError status{QueryErrorCode(0)};
-  BlockedRequestCtx_NewAREQ(r, vv, vv.size());
+  BlockedRequestCtx_NewAREQ(r);
   int rc = AREQ_Compile(r, ctx, 0, false, &status);
   if (rc != REDISMODULE_OK) {
     printf("Couldn't compile: %s\n", QueryError_GetUserError(&status));

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -82,7 +82,7 @@ def _setup_return_strict_cursor_state(env, chunk_size=10, agg_steps=None):
     return prev_on_timeout_policy, cursor_id, baseline_cursor_total, before_info, base_warn_coord, res
 
 def _get_blocked_request_onfree_count(env):
-    """Read the coordinator BlockedRequestCtx_OnFree invocation counter (debug builds)."""
+    """Read the coordinator QueryRequest_OnFree invocation counter (debug builds)."""
     return int(env.cmd(debug_cmd(), 'QUERY_CONTROLLER', 'GET_BLOCKED_REQUEST_ONFREE_COUNT'))
 
 def _assert_return_strict_cursor_timeout_reply(env, res_pair, expected_cid,
@@ -4710,7 +4710,7 @@ class TestCoordinatorTimeout:
             env, result[0], cursor_id, expected_results=0,
             message_prefix='RETURN_STRICT no-stale-free read 1 timeout')
 
-        # Wait until BlockedRequestCtx_OnFree has fired for read 1's BC privdata.
+        # Wait until QueryRequest_OnFree has fired for read 1's BC private data.
         # The counter is bumped by the BC tear-down on the main thread after
         # the worker job completes; polling avoids a deadlock that a sync-point
         # in the free callback would cause.


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Aggregate and hybrid requests duplicate blocked-client, cursor, reply, pipeline, registry, timeout, and asynchronous coordination state across request-specific structures.
2. Change: Introduce a first-member `QueryRequest` base for AREQ and HybridRequest, and passively mirror the relevant legacy state into typed cursor, reply, registry, timeout, and async substructures.
3. Outcome: Establish a shared request abstraction that can incrementally replace `BlockedRequestCtx` without changing current consumers or synchronization behavior in this PR.

The mirrored legacy assignments are intentionally retained and marked with searchable `TODO($$$)` comments. The temporary async state is expected to be consolidated after MOD-17486.

#### Which additional issues this PR fixes

1. [MOD-17410](https://redislabs.atlassian.net/browse/MOD-17410)

#### Main objects this PR modified

1. `QueryRequest`, `QueryRequestTimeout`, and `QueryRequestAsyncState`
2. `AREQ` and `HybridRequest`
3. Cursor/reply/registry and coordinator abort-wake mirror paths

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Internal refactoring only; existing request state remains authoritative and consumed by current code paths.

#### Validation

- Focused C syntax checks for the new request source and hybrid cursor mapping source
- `git diff --check`
- Full build was attempted earlier but was blocked during Rust FFI header generation by an environment database error.


[MOD-17410]: https://redislabs.atlassian.net/browse/MOD-17410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ