### PR TITLE
Ignore raw LLVM coverage profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ compile_commands.json
 # Per-run memtier_benchmark result files dropped in the repo root by
 # `redisbench-admin run-local` (named <setup>-<timestamp>--<test>.json).
 oss-*--*.json
+# Raw LLVM coverage profiles, written wherever an instrumented process runs
+*.profraw


### PR DESCRIPTION
## Describe the changes in the pull request

Adds `*.profraw` to `.gitignore`.

An instrumented binary writes one `.profraw` per process into its working directory. With `LLVM_PROFILE_FILE` unset the filenames are LLVM's default pattern, so an instrumented `cargo test` / `cargo nextest` run scatters them through `src/redisearch_rs/` and its crate directories rather than into an ignored build tree. A single run left ~38,000 in my checkout, which buries `git status` and makes `git add -A` dangerous.

The pattern is unanchored deliberately: a `.profraw` lands in whichever directory the instrumented process happened to run in, so anchoring it to the Rust workspace would miss the C/C++ and flow-test cases. Nothing tracked matches it, and `git check-ignore -v` attributes the match to this new line, so no existing rule already covered it.

#### Which additional issues this PR fixes

None — ad-hoc change.

#### Main objects this PR modified

1. `.gitignore`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
