### PR TITLE
[MOD-14883] c_trie: add iterate_fuzzy walk over the terms trie

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -41,6 +41,7 @@
 #include "cursor.h"
 #include "debug_commands.h"
 #include "spell_check.h"
+#include "trie/levenshtein.h"
 #include "query_param.h"
 #include "dictionary.h"
 #include "suggest.h"
@@ -338,7 +339,6 @@ int SpellCheckCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
 #define DICT_INITIAL_SIZE 5
 #define DEFAULT_LEV_DISTANCE 1
-#define MAX_LEV_DISTANCE 4
 
   if (argc < 3) {
     return RedisModule_WrongArity(ctx);

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2505,6 +2505,7 @@ dependencies = [
  "redisearch_rs",
  "rqe_wildcard",
  "rs_token",
+ "string_utils",
  "workspace_hack",
 ]
 

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -204,7 +204,9 @@ dependencies = [
  "ffi",
  "redis_mock",
  "redisearch_rs",
+ "string_utils",
  "strum",
+ "thiserror",
  "workspace_hack",
 ]
 

--- a/src/redisearch_rs/c_wrappers/c_trie/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/c_trie/Cargo.toml
@@ -18,7 +18,9 @@ build_utils.workspace = true
 
 [dependencies]
 ffi.workspace = true
+string_utils.workspace = true
 strum.workspace = true
+thiserror.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]

--- a/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
@@ -221,56 +221,18 @@ pub enum FuzzyWalk {
     PatternRejected,
 }
 
-/// An edit distance a [`TermsTrie::iterate_fuzzy`] walk can be asked for.
+/// Error returned by [`TermsTrie::iterate_fuzzy`] when the distance it was asked
+/// for is outside `0..=`[`MAX_LEV_DISTANCE`](ffi::MAX_LEV_DISTANCE).
 ///
 /// The distance reaches C as the size of a stack variable-length array, so a
 /// negative one is a negative-length allocation and a large one exhausts the
 /// stack before the walk begins — both before any bound the caller could apply
-/// afterwards. Making those unrepresentable is what this type is for: every
-/// value that can be constructed is one the automaton can be built for.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct FuzzyDistance(u8);
-
-impl FuzzyDistance {
-    /// The largest distance that can be constructed, which is the largest one
-    /// the automaton may be built for — see
-    /// [`MAX_LEV_DISTANCE`](ffi::MAX_LEV_DISTANCE) for why it stops there.
-    pub const MAX: i32 = ffi::MAX_LEV_DISTANCE as i32;
-
-    /// Wrap `distance`.
-    ///
-    /// Takes an [`i32`] because that is the width the distance travels at in a
-    /// parsed query, so a caller checks the range here rather than twice.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`InvalidFuzzyDistance`] if `distance` is negative or above
-    /// [`MAX`](Self::MAX).
-    pub const fn new(distance: i32) -> Result<Self, InvalidFuzzyDistance> {
-        if distance < 0 || distance > Self::MAX {
-            return Err(InvalidFuzzyDistance(distance));
-        }
-        Ok(Self(distance as u8))
-    }
-
-    /// The wrapped distance.
-    pub const fn get(self) -> i32 {
-        self.0 as i32
-    }
-}
-
-impl TryFrom<i32> for FuzzyDistance {
-    type Error = InvalidFuzzyDistance;
-
-    fn try_from(distance: i32) -> Result<Self, Self::Error> {
-        Self::new(distance)
-    }
-}
-
-/// Error returned by [`FuzzyDistance::new`] when the value is outside
-/// `0..=`[`FuzzyDistance::MAX`].
+/// afterwards. Refusing them up front is what keeps the walk from being asked
+/// for an automaton that cannot be built.
+///
+/// The offending value is carried so a caller can name it when reporting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[error("fuzzy distance must be in 0..={max}, got {value}", value = .0, max = FuzzyDistance::MAX)]
+#[error("fuzzy distance must be in 0..={max}, got {value}", value = .0, max = ffi::MAX_LEV_DISTANCE)]
 pub struct InvalidFuzzyDistance(i32);
 
 /// Outcome of [`TermsTrie::decrement_num_docs`].
@@ -509,6 +471,15 @@ impl TermsTrie {
     /// insertion, so it exists only as an inverted index and a caller that wants
     /// it has to open that index itself.
     ///
+    /// `max_dist` is taken as an [`i32`] because that is the width it travels at
+    /// in a parsed query, so the range is checked once, here, rather than at
+    /// every call site.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidFuzzyDistance`], having walked nothing, if `max_dist` is
+    /// negative or above [`MAX_LEV_DISTANCE`](ffi::MAX_LEV_DISTANCE).
+    ///
     /// # Safety
     ///
     /// The wrapped trie must not be mutated, freed, or iterated again for the
@@ -519,18 +490,24 @@ impl TermsTrie {
     pub unsafe fn iterate_fuzzy<F>(
         &self,
         pattern: &[u8],
-        max_dist: FuzzyDistance,
+        max_dist: i32,
         mut callback: F,
-    ) -> FuzzyWalk
+    ) -> Result<FuzzyWalk, InvalidFuzzyDistance>
     where
         F: FnMut(&[ffi::rune], usize) -> ControlFlow<()>,
     {
+        // Checked before anything else: an out-of-range distance is a stack VLA
+        // C cannot allocate, so it must not reach the automaton at all.
+        if max_dist < 0 || max_dist > ffi::MAX_LEV_DISTANCE as i32 {
+            return Err(InvalidFuzzyDistance(max_dist));
+        }
+
         // Reject an over-long pattern before copying it. This bounds the padded
         // copy below, which would otherwise duplicate the whole token before C
         // had looked at its length.
         const MAX_UTF8_SEQUENCE_LEN: usize = 4;
         if pattern.len() > ffi::TRIE_MAX_PREFIX as usize * MAX_UTF8_SEQUENCE_LEN {
-            return FuzzyWalk::PatternRejected;
+            return Ok(FuzzyWalk::PatternRejected);
         }
 
         // The trie lowercases the pattern with `strToLowerRunes`, whose decoder
@@ -576,7 +553,7 @@ impl TermsTrie {
                 self.as_ptr().cast_mut(),
                 pattern_ptr.cast::<c_char>(),
                 pattern.len(),
-                max_dist.get(),
+                max_dist,
                 ffi::TrieMatchMode_TRIE_MATCH_EDIT_DISTANCE,
             )
         };
@@ -584,7 +561,7 @@ impl TermsTrie {
         // referenced afterwards, so the copy has served its purpose here.
         drop(padded);
         let Some(it) = NonNull::new(it) else {
-            return FuzzyWalk::PatternRejected;
+            return Ok(FuzzyWalk::PatternRejected);
         };
         // The loop below is driven from Rust rather than from a C trampoline, so
         // an unwinding panic in `callback` would otherwise skip the free and leak
@@ -641,7 +618,7 @@ impl TermsTrie {
         }
 
         drop(it);
-        FuzzyWalk::Walked
+        Ok(FuzzyWalk::Walked)
     }
 }
 

--- a/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
@@ -228,18 +228,14 @@ pub enum FuzzyWalk {
 /// stack before the walk begins — both before any bound the caller could apply
 /// afterwards. Making those unrepresentable is what this type is for: every
 /// value that can be constructed is one the automaton can be built for.
-///
-/// [`MAX`](Self::MAX) is the widest distance any command accepts, not a limit of
-/// the walk itself: `FT.SPELLCHECK`'s `DISTANCE` argument is checked against it
-/// when the command is parsed, and the query grammar stops lower still — it
-/// spells the distance as the number of `%` delimiters and has productions for
-/// only one, two and three.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FuzzyDistance(u8);
 
 impl FuzzyDistance {
-    /// The largest distance that can be constructed.
-    pub const MAX: i32 = 4;
+    /// The largest distance that can be constructed, which is the largest one
+    /// the automaton may be built for — see
+    /// [`MAX_LEV_DISTANCE`](ffi::MAX_LEV_DISTANCE) for why it stops there.
+    pub const MAX: i32 = ffi::MAX_LEV_DISTANCE as i32;
 
     /// Wrap `distance`.
     ///

--- a/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
@@ -15,13 +15,14 @@ use std::{
     ffi::{c_char, c_int, c_void},
     marker::PhantomData,
     ops::ControlFlow,
-    ptr,
+    ptr::{self, NonNull},
 };
 
 use ffi::{
     SuffixCtx, SuffixType, SuffixType_SUFFIX_TYPE_CONTAINS, SuffixType_SUFFIX_TYPE_SUFFIX,
     SuffixType_SUFFIX_TYPE_WILDCARD,
 };
+use string_utils::libnu::{NU_MAX_READAHEAD, tail_may_overread};
 
 /// Which side(s) of a term a [`SuffixTrie::iterate_contains`] walk anchors on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -201,6 +202,80 @@ pub enum SuffixWalk {
     /// trie with [`TermsTrie::iterate_wildcard`].
     NoAnchor(LoweredPattern),
 }
+
+/// Outcome of [`TermsTrie::iterate_fuzzy`].
+///
+/// Neither variant is a failure: a pattern the trie will not walk is a routine
+/// answer, not an error. The distinction matters to the caller because the two
+/// are not interchangeable — a walk that visited nothing has *answered* the
+/// pattern (no term is within the distance), while a rejected one never asked.
+#[derive(Debug)]
+#[must_use = "a rejected pattern was never walked, and treating it as an empty \
+              walk claims the index holds no term within the distance"]
+pub enum FuzzyWalk {
+    /// The walk ran and every term within the distance was delivered to the
+    /// callback (up to an early [`ControlFlow::Break`]).
+    Walked,
+    /// The pattern could not start a walk and nothing was visited, because it
+    /// exceeds [`TRIE_MAX_PREFIX`](ffi::TRIE_MAX_PREFIX) runes once decoded.
+    PatternRejected,
+}
+
+/// An edit distance a [`TermsTrie::iterate_fuzzy`] walk can be asked for.
+///
+/// The distance reaches C as the size of a stack variable-length array, so a
+/// negative one is a negative-length allocation and a large one exhausts the
+/// stack before the walk begins — both before any bound the caller could apply
+/// afterwards. Making those unrepresentable is what this type is for: every
+/// value that can be constructed is one the automaton can be built for.
+///
+/// [`MAX`](Self::MAX) is the widest distance any command accepts, not a limit of
+/// the walk itself: `FT.SPELLCHECK`'s `DISTANCE` argument is checked against it
+/// when the command is parsed, and the query grammar stops lower still — it
+/// spells the distance as the number of `%` delimiters and has productions for
+/// only one, two and three.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FuzzyDistance(u8);
+
+impl FuzzyDistance {
+    /// The largest distance that can be constructed.
+    pub const MAX: i32 = 4;
+
+    /// Wrap `distance`.
+    ///
+    /// Takes an [`i32`] because that is the width the distance travels at in a
+    /// parsed query, so a caller checks the range here rather than twice.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidFuzzyDistance`] if `distance` is negative or above
+    /// [`MAX`](Self::MAX).
+    pub const fn new(distance: i32) -> Result<Self, InvalidFuzzyDistance> {
+        if distance < 0 || distance > Self::MAX {
+            return Err(InvalidFuzzyDistance(distance));
+        }
+        Ok(Self(distance as u8))
+    }
+
+    /// The wrapped distance.
+    pub const fn get(self) -> i32 {
+        self.0 as i32
+    }
+}
+
+impl TryFrom<i32> for FuzzyDistance {
+    type Error = InvalidFuzzyDistance;
+
+    fn try_from(distance: i32) -> Result<Self, Self::Error> {
+        Self::new(distance)
+    }
+}
+
+/// Error returned by [`FuzzyDistance::new`] when the value is outside
+/// `0..=`[`FuzzyDistance::MAX`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("fuzzy distance must be in 0..={max}, got {value}", value = .0, max = FuzzyDistance::MAX)]
+pub struct InvalidFuzzyDistance(i32);
 
 /// Outcome of [`TermsTrie::decrement_num_docs`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::FromRepr)]
@@ -416,6 +491,161 @@ impl TermsTrie {
                 skip_timeout_checks,
             );
         }
+    }
+
+    /// Visit every term within `max_dist` edits of `pattern`, in the trie's
+    /// iteration order.
+    ///
+    /// `pattern` is the raw token bytes — it need not be valid UTF-8: unlike the
+    /// rune-keyed walks above, the trie decodes and lowercases them itself, the
+    /// same way the indexer stored the terms, and it is also there that the
+    /// length limit is applied — a pattern longer than
+    /// [`TRIE_MAX_PREFIX`](ffi::TRIE_MAX_PREFIX) runes yields
+    /// [`FuzzyWalk::PatternRejected`] and visits nothing. The distance is a
+    /// Levenshtein distance counted in runes, so a multibyte pattern is measured
+    /// by what it decodes to rather than by its byte length.
+    ///
+    /// For each match the callback receives the term's runes and the number of
+    /// documents indexed under it, and returns [`ControlFlow`] to continue or
+    /// stop the walk early (e.g. once an expansion cap is reached).
+    ///
+    /// The walk never yields the empty term: a zero-length key is refused on
+    /// insertion, so it exists only as an inverted index and a caller that wants
+    /// it has to open that index itself.
+    ///
+    /// # Safety
+    ///
+    /// The wrapped trie must not be mutated, freed, or iterated again for the
+    /// duration of the call — including from within `callback`. The walk holds a
+    /// stack of raw node pointers across callback invocations, so mutating the
+    /// trie (e.g. deleting a term, or decrementing one to zero, through another
+    /// handle) can free a node mid-walk and leave those pointers dangling.
+    pub unsafe fn iterate_fuzzy<F>(
+        &self,
+        pattern: &[u8],
+        max_dist: FuzzyDistance,
+        mut callback: F,
+    ) -> FuzzyWalk
+    where
+        F: FnMut(&[ffi::rune], usize) -> ControlFlow<()>,
+    {
+        // Reject an over-long pattern before copying it. This bounds the padded
+        // copy below, which would otherwise duplicate the whole token before C
+        // had looked at its length.
+        const MAX_UTF8_SEQUENCE_LEN: usize = 4;
+        if pattern.len() > ffi::TRIE_MAX_PREFIX as usize * MAX_UTF8_SEQUENCE_LEN {
+            return FuzzyWalk::PatternRejected;
+        }
+
+        // The trie lowercases the pattern with `strToLowerRunes`, whose decoder
+        // (`nu_utf8_read`) reads a fixed 2–4 bytes from a multibyte lead byte
+        // with no bounds check — so a pattern ending in a truncated sequence
+        // (e.g. a lone `0xF0`) would read past the end. A token is a byte string
+        // that nothing validates as UTF-8, so that is reachable input. Where it
+        // can happen, hand C a private copy padded with `NU_MAX_READAHEAD`
+        // trailing zero bytes instead; the length passed stays the pattern's own,
+        // so the decode, and with it the rune-length threshold, is unchanged.
+        //
+        // The common case needs no copy: `tail_may_overread` is exact, so every
+        // well-formed pattern is decoded in place.
+        let padded = tail_may_overread(pattern).then(|| {
+            let mut buf = Vec::with_capacity(pattern.len() + NU_MAX_READAHEAD);
+            buf.extend_from_slice(pattern);
+            buf.resize(pattern.len() + NU_MAX_READAHEAD, 0);
+            buf
+        });
+        // An empty slice carries no allocation, so its pointer is a well-aligned
+        // dangling address rather than one into an object. C forms `str + len`
+        // to bound its decode loops before testing that the loop is empty, and
+        // that arithmetic is only defined on a pointer into an object — so hand
+        // it a real one. Nothing is read through it: the length passed is still
+        // zero, so every such loop compares equal at the first test.
+        static EMPTY_PATTERN: [u8; 1] = [0];
+        let pattern_ptr = if pattern.is_empty() {
+            EMPTY_PATTERN.as_ptr()
+        } else {
+            padded.as_deref().unwrap_or(pattern).as_ptr()
+        };
+
+        // SAFETY: `self` borrows a valid `ffi::Trie` and
+        // `pattern_ptr`/`pattern.len()` describe a live byte slice, which the
+        // call only reads (it decodes it into an owned filter). Its decoder can
+        // read up to `NU_MAX_READAHEAD` bytes past a truncated trailing sequence,
+        // which the padding above put inside the allocation. The returned
+        // iterator is owned by us and freed below. `Trie_IterateFuzzy` takes a
+        // non-const `Trie *` but only traverses it, so nothing is written
+        // through the shared pointer.
+        let it = unsafe {
+            ffi::Trie_IterateFuzzy(
+                self.as_ptr().cast_mut(),
+                pattern_ptr.cast::<c_char>(),
+                pattern.len(),
+                max_dist.get(),
+                ffi::TrieMatchMode_TRIE_MATCH_EDIT_DISTANCE,
+            )
+        };
+        // The pattern is decoded into the filter during the call above and not
+        // referenced afterwards, so the copy has served its purpose here.
+        drop(padded);
+        let Some(it) = NonNull::new(it) else {
+            return FuzzyWalk::PatternRejected;
+        };
+        // The loop below is driven from Rust rather than from a C trampoline, so
+        // an unwinding panic in `callback` would otherwise skip the free and leak
+        // the iterator together with its edit-distance filter.
+        struct OwnedIterator(NonNull<ffi::TrieIterator>);
+        impl Drop for OwnedIterator {
+            fn drop(&mut self) {
+                // SAFETY: we own the iterator returned by `Trie_IterateFuzzy`,
+                // it is freed exactly once here and not used afterwards.
+                unsafe { ffi::TrieIterator_Free(self.0.as_ptr()) };
+            }
+        }
+        let it = OwnedIterator(it);
+
+        let mut runes: *mut ffi::rune = std::ptr::null_mut();
+        let mut len: ffi::t_len = 0;
+        // Written on every match whether or not anyone wants it, so it needs a
+        // slot; a fuzzy expansion scores its terms through their readers, not
+        // through the trie, so the value is dropped.
+        let mut score: f32 = 0.0;
+        let mut num_docs: usize = 0;
+
+        loop {
+            // SAFETY: `it` is the live iterator returned above; the out-params
+            // are valid, exclusively borrowed slots. The payload and the
+            // per-match context are optional and passed as null, which the
+            // iterator and the edit-distance filter both check for before
+            // writing.
+            let has_match = unsafe {
+                ffi::TrieIterator_Next(
+                    it.0.as_ptr(),
+                    &mut runes,
+                    &mut len,
+                    std::ptr::null_mut(),
+                    &mut score,
+                    &mut num_docs,
+                    std::ptr::null_mut(),
+                )
+            };
+            if has_match == 0 {
+                break;
+            }
+            let matched = if len == 0 {
+                // The pointer may be dangling for a zero-length key.
+                &[][..]
+            } else {
+                // SAFETY: a match writes `runes`/`len` as the iterator's buffer
+                // and the number of valid runes in it.
+                unsafe { std::slice::from_raw_parts(runes, len as usize) }
+            };
+            if callback(matched, num_docs).is_break() {
+                break;
+            }
+        }
+
+        drop(it);
+        FuzzyWalk::Walked
     }
 }
 

--- a/src/redisearch_rs/c_wrappers/c_trie/tests/iterate.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/tests/iterate.rs
@@ -26,7 +26,9 @@ use std::{
     ptr,
 };
 
-use c_trie::{LoweredPattern, SuffixMode, SuffixTrie, SuffixWalk, TermsTrie};
+use c_trie::{
+    FuzzyDistance, FuzzyWalk, LoweredPattern, SuffixMode, SuffixTrie, SuffixWalk, TermsTrie,
+};
 use ffi::{SuffixType, SuffixType_SUFFIX_TYPE_CONTAINS, SuffixType_SUFFIX_TYPE_SUFFIX};
 
 /// Convert an ASCII/UTF-8 string to the trie's rune (`u16`) key.
@@ -277,6 +279,330 @@ fn iterate_contains_some_and_none_timeout_agree() {
 
         assert_eq!(none_hits, set(CORPUS));
         assert_eq!(some_hits, none_hits);
+    });
+}
+
+// --- `FuzzyDistance` --------------------------------------------------------
+
+#[test]
+fn fuzzy_distance_admits_exactly_the_representable_range() {
+    // Both ends reach C as the size of a stack VLA, so what this type refuses is
+    // what the automaton could not be built for: below zero it is a
+    // negative-length allocation, above the cap it exhausts the stack.
+    for d in [-1, i32::MIN, FuzzyDistance::MAX + 1, i32::MAX] {
+        assert!(FuzzyDistance::new(d).is_err(), "{d} is out of range");
+        assert!(FuzzyDistance::try_from(d).is_err(), "{d} is out of range");
+    }
+
+    for d in 0..=FuzzyDistance::MAX {
+        assert_eq!(
+            FuzzyDistance::new(d).map(FuzzyDistance::get),
+            Ok(d),
+            "an in-range distance round-trips unchanged"
+        );
+        assert_eq!(FuzzyDistance::try_from(d), FuzzyDistance::new(d));
+    }
+
+    // The rejected value is carried, so a caller can name it when reporting.
+    assert_eq!(
+        FuzzyDistance::new(9).unwrap_err().to_string(),
+        format!(
+            "fuzzy distance must be in 0..={}, got 9",
+            FuzzyDistance::MAX
+        )
+    );
+}
+
+// --- `iterate_fuzzy` (terms trie) -------------------------------------------
+
+/// Corpus for the edit-distance walks: `map`, `maps` and `mop` all sit within
+/// one edit of each other while `grape` is far outside them, so moving the
+/// distance by one changes the answer.
+const FUZZY_CORPUS: &[&str] = &["map", "maps", "mop", "grape"];
+
+/// Wrap a distance the test knows is in range.
+fn dist(d: i32) -> FuzzyDistance {
+    FuzzyDistance::new(d).expect("test distance is in range")
+}
+
+/// Collect every term `iterate_fuzzy` yields for `pattern` at `max_dist`,
+/// asserting the walk was not rejected.
+fn fuzzy_terms(trie: &TermsTrie, pattern: &[u8], max_dist: i32) -> HashSet<String> {
+    let max_dist = dist(max_dist);
+    let mut got = HashSet::new();
+    // SAFETY: `trie` wraps a live terms trie that is not mutated during the
+    // walk; the closure only collects the terms it is handed.
+    let walk = unsafe {
+        trie.iterate_fuzzy(pattern, max_dist, |term, _| {
+            got.insert(runes_to_string(term));
+            ControlFlow::Continue(())
+        })
+    };
+    assert!(
+        matches!(walk, FuzzyWalk::Walked),
+        "the pattern must be short enough to walk"
+    );
+    got
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_fuzzy_reports_terms_within_the_distance_and_num_docs() {
+    with_terms_trie(FUZZY_CORPUS, |trie| {
+        let mut got: HashSet<(String, usize)> = HashSet::new();
+        // SAFETY: live, un-mutated terms trie; the closure only collects.
+        let walk = unsafe {
+            trie.iterate_fuzzy(b"map", dist(1), |term, num_docs| {
+                got.insert((runes_to_string(term), num_docs));
+                ControlFlow::Continue(())
+            })
+        };
+        assert!(matches!(walk, FuzzyWalk::Walked));
+        // One edit from `map`: itself, `maps` (insert) and `mop` (substitute);
+        // `grape` is far outside. `numDocs` is the term's char length.
+        let expected: HashSet<(String, usize)> = [
+            ("map".to_owned(), 3),
+            ("maps".to_owned(), 4),
+            ("mop".to_owned(), 3),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(got, expected);
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_fuzzy_distance_bounds_the_walk() {
+    with_terms_trie(FUZZY_CORPUS, |trie| {
+        // `mops` is two edits from `map` (substitute `a`, insert `s`), so it is
+        // out at distance 1 and in at distance 2 — the bound is honoured in both
+        // directions rather than being open-ended.
+        assert_eq!(fuzzy_terms(trie, b"mops", 1), set(&["maps", "mop"]));
+        assert_eq!(fuzzy_terms(trie, b"mops", 2), set(&["map", "maps", "mop"]));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_fuzzy_lowercases_the_pattern() {
+    with_terms_trie(FUZZY_CORPUS, |trie| {
+        // The trie holds folded keys and folds the pattern itself, so an
+        // upper-case pattern is not three substitutions away from its own term.
+        assert_eq!(fuzzy_terms(trie, b"MAP", 1), set(&["map", "maps", "mop"]));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_fuzzy_no_match_walks_without_visiting_anything() {
+    with_terms_trie(FUZZY_CORPUS, |trie| {
+        // Nothing is within one edit of `zzzzzz`, which is still a walk that ran
+        // — not a rejected pattern.
+        assert_eq!(fuzzy_terms(trie, b"zzzzzz", 1), HashSet::new());
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_fuzzy_empty_pattern_walks_every_term_within_the_distance_of_nothing() {
+    with_terms_trie(FUZZY_CORPUS, |trie| {
+        // An empty pattern is a walk like any other rather than a rejection: the
+        // automaton accepts at the root, so every term reachable in `max_dist`
+        // insertions matches — that is, every term no longer than the distance.
+        assert_eq!(fuzzy_terms(trie, b"", 3), set(&["map", "mop"]));
+        assert_eq!(
+            fuzzy_terms(trie, b"", FuzzyDistance::MAX),
+            set(&["map", "maps", "mop"])
+        );
+
+        // At distance 0 the only term that could match is the empty one, which
+        // no trie holds — insertion refuses a zero-length key — so the walk runs
+        // and yields nothing rather than yielding a zero-length term.
+        assert_eq!(fuzzy_terms(trie, b"", 0), HashSet::new());
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_fuzzy_break_stops_walk_early() {
+    with_terms_trie(FUZZY_CORPUS, |trie| {
+        let mut count = 0_usize;
+        // SAFETY: live, un-mutated terms trie; the closure only counts.
+        let walk = unsafe {
+            trie.iterate_fuzzy(b"map", dist(1), |_, _| {
+                count += 1;
+                // Stop at the first match even though three would match.
+                ControlFlow::Break(())
+            })
+        };
+        assert!(matches!(walk, FuzzyWalk::Walked));
+        assert_eq!(count, 1, "Break must stop the walk at the first match");
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_fuzzy_rejects_a_pattern_over_the_rune_limit() {
+    with_terms_trie(FUZZY_CORPUS, |trie| {
+        let limit = ffi::TRIE_MAX_PREFIX as usize;
+        let mut visited = false;
+        // SAFETY: live, un-mutated terms trie; the closure only records.
+        let walk = unsafe {
+            trie.iterate_fuzzy(&b"a".repeat(limit + 1), dist(1), |_, _| {
+                visited = true;
+                ControlFlow::Continue(())
+            })
+        };
+        assert!(
+            matches!(walk, FuzzyWalk::PatternRejected),
+            "a pattern over the rune limit starts no walk"
+        );
+        assert!(!visited, "a rejected pattern visits nothing");
+
+        // One rune shorter, the walk does run: the limit is an inclusive bound
+        // and not an off-by-one that rejects the longest accepted pattern.
+        // SAFETY: as above.
+        let walk = unsafe {
+            trie.iterate_fuzzy(&b"a".repeat(limit), dist(1), |_, _| ControlFlow::Break(()))
+        };
+        assert!(matches!(walk, FuzzyWalk::Walked));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_fuzzy_measures_the_limit_in_runes_not_bytes() {
+    with_terms_trie(FUZZY_CORPUS, |trie| {
+        // The limit applies to the decoded pattern, so a multibyte pattern well
+        // over the limit in bytes but under it in runes is still walked. A byte
+        // length check would reject it.
+        let pattern = "é".repeat(ffi::TRIE_MAX_PREFIX as usize / 2 + 1);
+        assert!(pattern.len() > ffi::TRIE_MAX_PREFIX as usize);
+        // SAFETY: live, un-mutated terms trie; the closure does nothing.
+        let walk = unsafe {
+            trie.iterate_fuzzy(
+                pattern.as_bytes(),
+                dist(1),
+                |_, _| ControlFlow::Continue(()),
+            )
+        };
+        assert!(matches!(walk, FuzzyWalk::Walked));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_fuzzy_accepts_a_pattern_with_a_truncated_multibyte_tail() {
+    with_terms_trie(FUZZY_CORPUS, |trie| {
+        // A token is a byte string that nothing validates, so a pattern can end
+        // mid-sequence. The C decoder reads a fixed 2-4 bytes from a lead byte
+        // without checking the input has that many left, so this is the input
+        // class that would read past the pattern; under a sanitizer it is what
+        // catches an unpadded decode.
+        for pattern in [
+            &b"ma\xF0"[..],
+            b"ma\xF0\x9F",
+            b"ma\xE0",
+            b"ma\xC3",
+            b"ma\x80",
+        ] {
+            // What the truncated tail decodes to through the zero padding is not
+            // uniform: `ma\xF0`, `ma\xE0` and `ma\x80` pad out to codepoint 0,
+            // which stops the length pass, so they fold to the two runes `ma`;
+            // `ma\xC3` and `ma\xF0\x9F` pad out to a non-zero codepoint and fold
+            // to three. Either way `map` is the only term within one edit — an
+            // insertion after `ma`, a substitution of the third rune — so what
+            // each of these must do is walk and yield it rather than read out of
+            // bounds.
+            assert_eq!(
+                fuzzy_terms(trie, pattern, 1),
+                set(&["map"]),
+                "a truncated tail must be walked, not read past"
+            );
+        }
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_fuzzy_byte_cap_admits_the_longest_pattern_that_fits_in_runes() {
+    with_terms_trie(FUZZY_CORPUS, |trie| {
+        // The over-long pattern is refused on byte length before it is copied,
+        // and the widest rune is four bytes — so the densest pattern that still
+        // fits the rune limit sits exactly on that byte bound. If the cap were
+        // off by one, or measured in anything but the widest rune, this pattern
+        // would be refused here despite being one the trie accepts.
+        let pattern = "\u{1D11E}".repeat(ffi::TRIE_MAX_PREFIX as usize);
+        assert_eq!(pattern.len(), ffi::TRIE_MAX_PREFIX as usize * 4);
+        // SAFETY: live, un-mutated terms trie; the closure does nothing.
+        let walk = unsafe {
+            trie.iterate_fuzzy(
+                pattern.as_bytes(),
+                dist(1),
+                |_, _| ControlFlow::Continue(()),
+            )
+        };
+        assert!(
+            matches!(walk, FuzzyWalk::Walked),
+            "the byte cap must not refuse a pattern the rune limit admits"
+        );
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_fuzzy_refuses_an_over_long_truncated_tail_before_padding_it() {
+    with_terms_trie(FUZZY_CORPUS, |trie| {
+        // A truncated trailing sequence is what forces the padded copy, and the
+        // token it pads is attacker-supplied and unbounded. Over the byte cap
+        // the pattern is refused first, so nothing proportional to it is copied
+        // — the same answer C gives, which refuses it on rune length.
+        let mut pattern = b"m".repeat(ffi::TRIE_MAX_PREFIX as usize * 4);
+        pattern.push(0xF0);
+        let mut visited = false;
+        // SAFETY: live, un-mutated terms trie; the closure only records.
+        let walk = unsafe {
+            trie.iterate_fuzzy(&pattern, dist(1), |_, _| {
+                visited = true;
+                ControlFlow::Continue(())
+            })
+        };
+        assert!(matches!(walk, FuzzyWalk::PatternRejected));
+        assert!(!visited, "a refused pattern visits nothing");
     });
 }
 

--- a/src/redisearch_rs/c_wrappers/c_trie/tests/iterate.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/tests/iterate.rs
@@ -26,9 +26,7 @@ use std::{
     ptr,
 };
 
-use c_trie::{
-    FuzzyDistance, FuzzyWalk, LoweredPattern, SuffixMode, SuffixTrie, SuffixWalk, TermsTrie,
-};
+use c_trie::{FuzzyWalk, LoweredPattern, SuffixMode, SuffixTrie, SuffixWalk, TermsTrie};
 use ffi::{SuffixType, SuffixType_SUFFIX_TYPE_CONTAINS, SuffixType_SUFFIX_TYPE_SUFFIX};
 
 /// Convert an ASCII/UTF-8 string to the trie's rune (`u16`) key.
@@ -282,37 +280,6 @@ fn iterate_contains_some_and_none_timeout_agree() {
     });
 }
 
-// --- `FuzzyDistance` --------------------------------------------------------
-
-#[test]
-fn fuzzy_distance_admits_exactly_the_representable_range() {
-    // Both ends reach C as the size of a stack VLA, so what this type refuses is
-    // what the automaton could not be built for: below zero it is a
-    // negative-length allocation, above the cap it exhausts the stack.
-    for d in [-1, i32::MIN, FuzzyDistance::MAX + 1, i32::MAX] {
-        assert!(FuzzyDistance::new(d).is_err(), "{d} is out of range");
-        assert!(FuzzyDistance::try_from(d).is_err(), "{d} is out of range");
-    }
-
-    for d in 0..=FuzzyDistance::MAX {
-        assert_eq!(
-            FuzzyDistance::new(d).map(FuzzyDistance::get),
-            Ok(d),
-            "an in-range distance round-trips unchanged"
-        );
-        assert_eq!(FuzzyDistance::try_from(d), FuzzyDistance::new(d));
-    }
-
-    // The rejected value is carried, so a caller can name it when reporting.
-    assert_eq!(
-        FuzzyDistance::new(9).unwrap_err().to_string(),
-        format!(
-            "fuzzy distance must be in 0..={}, got 9",
-            FuzzyDistance::MAX
-        )
-    );
-}
-
 // --- `iterate_fuzzy` (terms trie) -------------------------------------------
 
 /// Corpus for the edit-distance walks: `map`, `maps` and `mop` all sit within
@@ -320,15 +287,9 @@ fn fuzzy_distance_admits_exactly_the_representable_range() {
 /// distance by one changes the answer.
 const FUZZY_CORPUS: &[&str] = &["map", "maps", "mop", "grape"];
 
-/// Wrap a distance the test knows is in range.
-fn dist(d: i32) -> FuzzyDistance {
-    FuzzyDistance::new(d).expect("test distance is in range")
-}
-
 /// Collect every term `iterate_fuzzy` yields for `pattern` at `max_dist`,
-/// asserting the walk was not rejected.
+/// asserting the distance was accepted and the walk was not rejected.
 fn fuzzy_terms(trie: &TermsTrie, pattern: &[u8], max_dist: i32) -> HashSet<String> {
-    let max_dist = dist(max_dist);
     let mut got = HashSet::new();
     // SAFETY: `trie` wraps a live terms trie that is not mutated during the
     // walk; the closure only collects the terms it is handed.
@@ -337,7 +298,8 @@ fn fuzzy_terms(trie: &TermsTrie, pattern: &[u8], max_dist: i32) -> HashSet<Strin
             got.insert(runes_to_string(term));
             ControlFlow::Continue(())
         })
-    };
+    }
+    .expect("test distance is in range");
     assert!(
         matches!(walk, FuzzyWalk::Walked),
         "the pattern must be short enough to walk"
@@ -350,17 +312,59 @@ fn fuzzy_terms(trie: &TermsTrie, pattern: &[u8], max_dist: i32) -> HashSet<Strin
     miri,
     ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
 )]
+fn iterate_fuzzy_admits_exactly_the_distances_the_automaton_can_be_built_for() {
+    let max = ffi::MAX_LEV_DISTANCE as i32;
+    with_terms_trie(FUZZY_CORPUS, |trie| {
+        // Both ends reach C as the size of a stack VLA, so what the walk refuses
+        // is what the automaton could not be built for: below zero it is a
+        // negative-length allocation, above the cap it exhausts the stack. The
+        // refusal has to come before the walk, so nothing is visited either.
+        for d in [-1, i32::MIN, max + 1, i32::MAX] {
+            let mut visited = false;
+            // SAFETY: live, un-mutated terms trie; the closure only records.
+            let walk = unsafe {
+                trie.iterate_fuzzy(b"map", d, |_, _| {
+                    visited = true;
+                    ControlFlow::Continue(())
+                })
+            };
+            assert_eq!(
+                walk.unwrap_err().to_string(),
+                format!("fuzzy distance must be in 0..={max}, got {d}"),
+                "{d} is out of range, and the error must name it"
+            );
+            assert!(!visited, "a refused distance visits nothing");
+        }
+
+        // Every distance in range is walked rather than refused — the cap is an
+        // inclusive bound and not an off-by-one that rejects the widest one.
+        for d in 0..=max {
+            // SAFETY: as above.
+            let walk = unsafe { trie.iterate_fuzzy(b"map", d, |_, _| ControlFlow::Continue(())) };
+            assert!(
+                matches!(walk, Ok(FuzzyWalk::Walked)),
+                "{d} is in range and must be walked"
+            );
+        }
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
 fn iterate_fuzzy_reports_terms_within_the_distance_and_num_docs() {
     with_terms_trie(FUZZY_CORPUS, |trie| {
         let mut got: HashSet<(String, usize)> = HashSet::new();
         // SAFETY: live, un-mutated terms trie; the closure only collects.
         let walk = unsafe {
-            trie.iterate_fuzzy(b"map", dist(1), |term, num_docs| {
+            trie.iterate_fuzzy(b"map", 1, |term, num_docs| {
                 got.insert((runes_to_string(term), num_docs));
                 ControlFlow::Continue(())
             })
         };
-        assert!(matches!(walk, FuzzyWalk::Walked));
+        assert!(matches!(walk, Ok(FuzzyWalk::Walked)));
         // One edit from `map`: itself, `maps` (insert) and `mop` (substitute);
         // `grape` is far outside. `numDocs` is the term's char length.
         let expected: HashSet<(String, usize)> = [
@@ -427,7 +431,7 @@ fn iterate_fuzzy_empty_pattern_walks_every_term_within_the_distance_of_nothing()
         // insertions matches — that is, every term no longer than the distance.
         assert_eq!(fuzzy_terms(trie, b"", 3), set(&["map", "mop"]));
         assert_eq!(
-            fuzzy_terms(trie, b"", FuzzyDistance::MAX),
+            fuzzy_terms(trie, b"", ffi::MAX_LEV_DISTANCE as i32),
             set(&["map", "maps", "mop"])
         );
 
@@ -448,13 +452,13 @@ fn iterate_fuzzy_break_stops_walk_early() {
         let mut count = 0_usize;
         // SAFETY: live, un-mutated terms trie; the closure only counts.
         let walk = unsafe {
-            trie.iterate_fuzzy(b"map", dist(1), |_, _| {
+            trie.iterate_fuzzy(b"map", 1, |_, _| {
                 count += 1;
                 // Stop at the first match even though three would match.
                 ControlFlow::Break(())
             })
         };
-        assert!(matches!(walk, FuzzyWalk::Walked));
+        assert!(matches!(walk, Ok(FuzzyWalk::Walked)));
         assert_eq!(count, 1, "Break must stop the walk at the first match");
     });
 }
@@ -470,13 +474,13 @@ fn iterate_fuzzy_rejects_a_pattern_over_the_rune_limit() {
         let mut visited = false;
         // SAFETY: live, un-mutated terms trie; the closure only records.
         let walk = unsafe {
-            trie.iterate_fuzzy(&b"a".repeat(limit + 1), dist(1), |_, _| {
+            trie.iterate_fuzzy(&b"a".repeat(limit + 1), 1, |_, _| {
                 visited = true;
                 ControlFlow::Continue(())
             })
         };
         assert!(
-            matches!(walk, FuzzyWalk::PatternRejected),
+            matches!(walk, Ok(FuzzyWalk::PatternRejected)),
             "a pattern over the rune limit starts no walk"
         );
         assert!(!visited, "a rejected pattern visits nothing");
@@ -484,10 +488,9 @@ fn iterate_fuzzy_rejects_a_pattern_over_the_rune_limit() {
         // One rune shorter, the walk does run: the limit is an inclusive bound
         // and not an off-by-one that rejects the longest accepted pattern.
         // SAFETY: as above.
-        let walk = unsafe {
-            trie.iterate_fuzzy(&b"a".repeat(limit), dist(1), |_, _| ControlFlow::Break(()))
-        };
-        assert!(matches!(walk, FuzzyWalk::Walked));
+        let walk =
+            unsafe { trie.iterate_fuzzy(&b"a".repeat(limit), 1, |_, _| ControlFlow::Break(())) };
+        assert!(matches!(walk, Ok(FuzzyWalk::Walked)));
     });
 }
 
@@ -504,14 +507,9 @@ fn iterate_fuzzy_measures_the_limit_in_runes_not_bytes() {
         let pattern = "é".repeat(ffi::TRIE_MAX_PREFIX as usize / 2 + 1);
         assert!(pattern.len() > ffi::TRIE_MAX_PREFIX as usize);
         // SAFETY: live, un-mutated terms trie; the closure does nothing.
-        let walk = unsafe {
-            trie.iterate_fuzzy(
-                pattern.as_bytes(),
-                dist(1),
-                |_, _| ControlFlow::Continue(()),
-            )
-        };
-        assert!(matches!(walk, FuzzyWalk::Walked));
+        let walk =
+            unsafe { trie.iterate_fuzzy(pattern.as_bytes(), 1, |_, _| ControlFlow::Continue(())) };
+        assert!(matches!(walk, Ok(FuzzyWalk::Walked)));
     });
 }
 
@@ -566,15 +564,10 @@ fn iterate_fuzzy_byte_cap_admits_the_longest_pattern_that_fits_in_runes() {
         let pattern = "\u{1D11E}".repeat(ffi::TRIE_MAX_PREFIX as usize);
         assert_eq!(pattern.len(), ffi::TRIE_MAX_PREFIX as usize * 4);
         // SAFETY: live, un-mutated terms trie; the closure does nothing.
-        let walk = unsafe {
-            trie.iterate_fuzzy(
-                pattern.as_bytes(),
-                dist(1),
-                |_, _| ControlFlow::Continue(()),
-            )
-        };
+        let walk =
+            unsafe { trie.iterate_fuzzy(pattern.as_bytes(), 1, |_, _| ControlFlow::Continue(())) };
         assert!(
-            matches!(walk, FuzzyWalk::Walked),
+            matches!(walk, Ok(FuzzyWalk::Walked)),
             "the byte cap must not refuse a pattern the rune limit admits"
         );
     });
@@ -596,12 +589,12 @@ fn iterate_fuzzy_refuses_an_over_long_truncated_tail_before_padding_it() {
         let mut visited = false;
         // SAFETY: live, un-mutated terms trie; the closure only records.
         let walk = unsafe {
-            trie.iterate_fuzzy(&pattern, dist(1), |_, _| {
+            trie.iterate_fuzzy(&pattern, 1, |_, _| {
                 visited = true;
                 ControlFlow::Continue(())
             })
         };
-        assert!(matches!(walk, FuzzyWalk::PatternRejected));
+        assert!(matches!(walk, Ok(FuzzyWalk::PatternRejected)));
         assert!(!visited, "a refused pattern visits nothing");
     });
 }

--- a/src/redisearch_rs/c_wrappers/rs_token/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/rs_token/Cargo.toml
@@ -21,6 +21,7 @@ ffi.workspace = true
 query_term.workspace = true
 redis-module.workspace = true
 rqe_wildcard.workspace = true
+string_utils.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]

--- a/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/rs_token/src/lib.rs
@@ -16,13 +16,7 @@ use std::{
 
 use query_term::RSTokenFlags;
 use rqe_wildcard::remove_escape_in_place;
-
-/// The most bytes the C `strToLowerRunes` decoder (`nu_utf8_read`) reads past a
-/// multibyte lead byte. A UTF-8 sequence is at most four bytes, so the decoder
-/// touches at most three bytes beyond the lead — and it does so without any
-/// bounds check. Padding a decoder input with this many trailing zero bytes
-/// keeps a truncated trailing lead byte from reading out of bounds.
-const NU_MAX_READAHEAD: usize = 3;
+use string_utils::libnu::{NU_MAX_READAHEAD, tail_may_overread};
 
 /// Upper bound on how many token bytes are copied for a rune conversion. A term
 /// is stored under at most [`ffi::MAX_RUNE_STR_LEN`] runes, and every UTF-8
@@ -32,42 +26,6 @@ const NU_MAX_READAHEAD: usize = 3;
 /// way, so capping the copy here keeps a huge token from forcing an equally huge
 /// transient allocation before that rejection.
 const MAX_DECODE_BYTES: usize = 4 * (ffi::MAX_RUNE_STR_LEN as usize + 1);
-
-/// How many bytes the C decoder (`nu_utf8_read`) consumes for the lead byte `b`,
-/// mirroring its branches exactly — including that it treats a stray
-/// continuation byte (`0x80..=0xBF`) as a two-byte lead rather than rejecting it.
-const fn nu_seq_len(b: u8) -> usize {
-    match b {
-        0x00..=0x7F => 1,
-        0x80..=0xDF => 2,
-        0xE0..=0xEF => 3,
-        0xF0..=0xFF => 4,
-    }
-}
-
-/// Whether handing `bytes` to the C decoder would read past its end.
-///
-/// The decoder walks the input one sequence at a time, reading [`nu_seq_len`]
-/// bytes from each position it lands on without checking that many remain. This
-/// replays that same walk — the lengths alone decide where it lands, so no
-/// decoding is needed — and reports whether any step would run off the end. It
-/// is exact rather than conservative: a well-formed input, whatever its last
-/// character, never trips it, and only a genuinely truncated trailing sequence
-/// does.
-///
-/// `false` means no read can escape `bytes`, so it may be decoded in place; the
-/// padded copy is only needed when this returns `true`.
-fn tail_may_overread(bytes: &[u8]) -> bool {
-    let mut pos = 0;
-    while pos < bytes.len() {
-        let seq_len = nu_seq_len(bytes[pos]);
-        if pos + seq_len > bytes.len() {
-            return true;
-        }
-        pos += seq_len;
-    }
-    false
-}
 
 /// Safe, read-only, [`Copy`] handle borrowing a query-node's [`ffi::RSToken`].
 ///
@@ -436,42 +394,5 @@ impl<'a> RSTokenMut<'a> {
         let new_len = remove_escape_in_place(pattern);
         debug_assert!(new_len <= len, "escape removal must not lengthen the token");
         self.tok.len = new_len;
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn well_formed_input_needs_no_padding() {
-        // Nothing here can over-read, so all of it decodes in place: ASCII, and
-        // sequences of every width sitting flush against the end.
-        assert!(!tail_may_overread(b""));
-        assert!(!tail_may_overread(b"hello"));
-        assert!(!tail_may_overread(b"ab\0cd"));
-        assert!(!tail_may_overread("é".as_bytes()));
-        assert!(!tail_may_overread("日本".as_bytes()));
-        assert!(!tail_may_overread("ab😀".as_bytes()));
-    }
-
-    #[test]
-    fn truncated_trailing_sequence_needs_padding() {
-        // A lead byte announcing more bytes than remain: the decoder would read
-        // past the end, so these must take the padded-copy path.
-        assert!(tail_may_overread(b"ab\xF0"));
-        assert!(tail_may_overread(b"ab\xF0\x9F"));
-        assert!(tail_may_overread(b"ab\xF0\x9F\x98"));
-        assert!(tail_may_overread(b"ab\xE0"));
-        assert!(tail_may_overread(b"ab\xC3"));
-        // A stray continuation byte at the end is read as a two-byte lead.
-        assert!(tail_may_overread(b"ab\x80"));
-    }
-
-    #[test]
-    fn earlier_malformed_bytes_do_not_force_padding() {
-        // The damage is mid-string: the walk resynchronises past it and still
-        // lands inside the input, so no over-read is possible.
-        assert!(!tail_may_overread(b"\xC3(ab"));
     }
 }

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -401,6 +401,12 @@ const HEADERS: &[HeaderAllowlist] = &[
         vars: &[],
     },
     HeaderAllowlist {
+        path: "src/trie/levenshtein.h",
+        fns: &[],
+        types: &["TrieMatchMode"],
+        vars: &[],
+    },
+    HeaderAllowlist {
         path: "src/trie/rune_util.h",
         fns: &["runesToStr", "strToLowerRunes", "strToRunes"],
         types: &[],
@@ -414,6 +420,7 @@ const HEADERS: &[HeaderAllowlist] = &[
             "Trie_GetNode",
             "Trie_InsertStringBuffer",
             "Trie_IterateContains",
+            "Trie_IterateFuzzy",
             "Trie_IterateWildcard",
             "TrieType_Free",
         ],
@@ -422,8 +429,8 @@ const HEADERS: &[HeaderAllowlist] = &[
     },
     HeaderAllowlist {
         path: "src/trie/trie_node.h",
-        fns: &["TrieNode_NumDocs"],
-        types: &["TrieRangeCallback", "TrieSuffixCallback"],
+        fns: &["TrieIterator_Free", "TrieIterator_Next", "TrieNode_NumDocs"],
+        types: &["TrieIterator", "TrieRangeCallback", "TrieSuffixCallback"],
         vars: &[],
     },
     HeaderAllowlist {

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -404,7 +404,7 @@ const HEADERS: &[HeaderAllowlist] = &[
         path: "src/trie/levenshtein.h",
         fns: &[],
         types: &["TrieMatchMode"],
-        vars: &[],
+        vars: &["MAX_LEV_DISTANCE"],
     },
     HeaderAllowlist {
         path: "src/trie/rune_util.h",

--- a/src/redisearch_rs/string_utils/src/lib.rs
+++ b/src/redisearch_rs/string_utils/src/lib.rs
@@ -10,8 +10,10 @@
 //! Shared string utility functions.
 //!
 //! These are pure-Rust replacements for C helpers that were previously
-//! implemented using `libnu` for Unicode operations.
+//! implemented using `libnu` for Unicode operations, plus — in [`libnu`] — the
+//! guards a caller still handing bytes to one of the remaining C helpers needs.
 
+pub mod libnu;
 pub mod runes;
 pub mod tag;
 pub mod unicode;

--- a/src/redisearch_rs/string_utils/src/libnu.rs
+++ b/src/redisearch_rs/string_utils/src/libnu.rs
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Guards for the unbounded read-ahead of the vendored `libnu` UTF-8 decoder.
+//!
+//! Several C helpers — `strToLowerRunes` and the trie's fuzzy pattern folding
+//! among them — decode their input with `nu_utf8_read` (`deps/libnu/utf8.h`),
+//! which consumes a fixed 1–4 bytes from whatever lead byte it lands on without
+//! checking that many bytes remain. Any caller handing such a helper a byte
+//! string that is not known to be well-formed UTF-8 — a query token, say — has
+//! to keep that read inside its own allocation.
+//!
+//! This module models that read-ahead once, for every caller that needs it:
+//! [`tail_may_overread`] says whether an input can trip it, and
+//! [`NU_MAX_READAHEAD`] says how many trailing zero bytes a padded copy needs
+//! when it can.
+
+/// The most bytes the C decoder (`nu_utf8_read`) reads past a multibyte lead
+/// byte. A UTF-8 sequence is at most four bytes, so the decoder touches at most
+/// three bytes beyond the lead — and it does so without any bounds check.
+/// Padding a decoder input with this many trailing zero bytes keeps a truncated
+/// trailing lead byte from reading out of bounds.
+pub const NU_MAX_READAHEAD: usize = 3;
+
+/// How many bytes the C decoder (`nu_utf8_read`) consumes for the lead byte `b`,
+/// mirroring its branches exactly — including that it treats a stray
+/// continuation byte (`0x80..=0xBF`) as a two-byte lead rather than rejecting it.
+pub const fn nu_seq_len(b: u8) -> usize {
+    match b {
+        0x00..=0x7F => 1,
+        0x80..=0xDF => 2,
+        0xE0..=0xEF => 3,
+        0xF0..=0xFF => 4,
+    }
+}
+
+/// Whether handing `bytes` to the C decoder would read past its end.
+///
+/// The decoder walks the input one sequence at a time, reading [`nu_seq_len`]
+/// bytes from each position it lands on without checking that many remain. This
+/// replays that same walk — the lengths alone decide where it lands, so no
+/// decoding is needed — and reports whether any step would run off the end. It
+/// is exact rather than conservative: a well-formed input, whatever its last
+/// character, never trips it, and only a genuinely truncated trailing sequence
+/// does.
+///
+/// `false` means no read can escape `bytes`, so it may be decoded in place; the
+/// padded copy is only needed when this returns `true`.
+pub fn tail_may_overread(bytes: &[u8]) -> bool {
+    let mut pos = 0;
+    while pos < bytes.len() {
+        let seq_len = nu_seq_len(bytes[pos]);
+        if pos + seq_len > bytes.len() {
+            return true;
+        }
+        pos += seq_len;
+    }
+    false
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn well_formed_input_needs_no_padding() {
+        // Nothing here can over-read, so all of it decodes in place: ASCII, and
+        // sequences of every width sitting flush against the end.
+        assert!(!tail_may_overread(b""));
+        assert!(!tail_may_overread(b"hello"));
+        assert!(!tail_may_overread(b"ab\0cd"));
+        assert!(!tail_may_overread("é".as_bytes()));
+        assert!(!tail_may_overread("日本".as_bytes()));
+        assert!(!tail_may_overread("ab😀".as_bytes()));
+    }
+
+    #[test]
+    fn truncated_trailing_sequence_needs_padding() {
+        // A lead byte announcing more bytes than remain: the decoder would read
+        // past the end, so these must take the padded-copy path.
+        assert!(tail_may_overread(b"ab\xF0"));
+        assert!(tail_may_overread(b"ab\xF0\x9F"));
+        assert!(tail_may_overread(b"ab\xF0\x9F\x98"));
+        assert!(tail_may_overread(b"ab\xE0"));
+        assert!(tail_may_overread(b"ab\xC3"));
+        // A stray continuation byte at the end is read as a two-byte lead.
+        assert!(tail_may_overread(b"ab\x80"));
+    }
+
+    #[test]
+    fn earlier_malformed_bytes_do_not_force_padding() {
+        // The damage is mid-string: the walk resynchronises past it and still
+        // lands inside the input, so no over-read is possible.
+        assert!(!tail_may_overread(b"\xC3(ab"));
+    }
+}

--- a/src/trie/levenshtein.h
+++ b/src/trie/levenshtein.h
@@ -53,6 +53,9 @@ typedef struct {
     int max;
 } SparseAutomaton;
 
+/* The largest edit distance an automaton may be built for. */
+#define MAX_LEV_DISTANCE 4
+
 struct dfaEdge;
 
 /* dfaNode is DFA graph node constructed using the Levenshtein automaton */


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: `c_trie` wraps the terms trie's prefix, contains and suffix walks for
   Rust callers, but not its edit-distance walk. The port of `Query_EvalFuzzyNode` needs
   that walk, and has no way to reach it. Separately, the guards around libnu's decoder —
   how far past the end of a sequence it reads (`NU_MAX_READAHEAD`, `nu_seq_len`,
   `tail_may_overread`) — live as private items inside `rs_token`, which is the only
   caller today.

2. **Change**: two commits, split out of #10860 so the wrapper lands on its own:
   - `string_utils: share the libnu read-ahead model out of rs_token` — move the
     read-ahead model into `string_utils::libnu` and have `rs_token` use it from there.
     No behaviour change; the items are the same, only their home is.
   - `c_trie: add iterate_fuzzy walk over the terms trie` — wrap the
     `Trie_IterateFuzzy` / `TrieIterator_Next` / `TrieIterator_Free` pull loop and hand
     each match to a callback, matching the shape of the `iterate_contains` and
     `iterate_suffix` walks already there.

   Two things the wrapper has to get right, and which the tests pin:
   - The pattern is passed as raw token bytes rather than runes, because
     `Trie_IterateFuzzy` lowercases and decodes them itself and is also where the
     `TRIE_MAX_PREFIX` limit is applied. A pattern over that limit starts *no* walk,
     which the returned `FuzzyWalk` reports separately from a walk that ran and matched
     nothing — the caller has to yield no iterator for the first and an empty union for
     the second, so the two must not collapse.
   - The distance is a `FuzzyDistance`, not a bare `int`. It reaches C as the size of a
     stack variable-length array, so a negative one is a negative-length allocation and
     a large one exhausts the stack before the walk starts — neither is checkable after
     the fact. C bounds it at its entry points instead (structurally in the grammar,
     and against `MAX_LEV_DISTANCE` when `FT.SPELLCHECK` is parsed); a public Rust
     wrapper is the first place the value can arrive unbounded, so the type carries the
     bound.
   - A token is a byte string that nothing validates as UTF-8, so a pattern can end
     mid-sequence, and the C decoder reads a fixed 2–4 bytes off a lead byte without
     checking how many are left. Where that can happen the pattern is handed to C as a
     private zero-padded copy; the length passed stays the pattern's own, so the decode
     and the rune-length threshold are unchanged. Well-formed patterns are decoded in
     place, and an over-long pattern is refused on byte length before anything
     proportional to it is copied.

3. **Outcome**: the edit-distance walk is reachable from Rust behind a documented safe
   shape, with the read-ahead model stated once instead of twice. No user-visible change
   — nothing calls the new wrapper yet; #10860 is the caller.

#### Which additional issues this PR fixes
1. MOD-14883

#### Main objects this PR modified
1. `src/redisearch_rs/c_wrappers/c_trie/src/lib.rs` — `CTrieRef::iterate_fuzzy`, `FuzzyWalk`, `FuzzyDistance`
2. `src/redisearch_rs/c_wrappers/c_trie/tests/iterate.rs`
3. `src/redisearch_rs/string_utils/src/libnu.rs` (new), `src/redisearch_rs/c_wrappers/rs_token/src/lib.rs`
4. `src/redisearch_rs/ffi/build.rs`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
