### PR TITLE
Clean the Rust target dir and stray coverage profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,8 +172,10 @@ Build:
                        Set to 0 on pre-Armv8.1-a cores (Cortex-A72,
                        Graviton1, Raspberry Pi 4) to avoid SIGILL on load.
 
-  make clean         Remove build artifacts
-    ALL=1              Remove entire artifacts directory
+  make clean         Remove build artifacts and stray *.profraw files
+    ALL=1              Also remove the whole artifacts directory, which holds
+                       the cargo target dir, plus any stray
+                       src/redisearch_rs/target
 
 Testing:
   make test          Run all tests
@@ -266,11 +268,18 @@ verify-deps:
 clean:
 ifeq ($(ALL),1)
 	@echo "Cleaning all build artifacts..."
-	@rm -rf $(ROOT)/bin
+	@rm -rf $(ROOT)/bin $(ROOT)/src/redisearch_rs/target
 else
 	@echo "Cleaning build artifacts..."
 	@rm -rf $(ROOT)/bin/*/search-*
 endif
+# An instrumented binary drops one .profraw per process into its working
+# directory. cargo-llvm-cov keeps its own under the cargo target dir, which
+# src/redisearch_rs/.cargo/config.toml points into bin/, but an ad-hoc
+# instrumented cargo run scatters them through the source tree instead.
+# Best-effort: an unwritable leftover must not fail the target.
+	@echo "Removing stray LLVM coverage profiles..."
+	@-find $(ROOT) -name '*.profraw' -type f -delete
 
 test: $(BUILD_SCRIPT)
 	@echo "Running all tests..."


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `make clean` removes `bin/*/search-*`, or all of `bin/` under `ALL=1`. Two things survive it. Stray `*.profraw` files: an instrumented binary writes one per process into its working directory, and while cargo-llvm-cov keeps its own under the cargo target dir (which `src/redisearch_rs/.cargo/config.toml` points into `bin/`), an ad-hoc instrumented `cargo test` scatters them through the source tree instead. ~38,000 had accumulated in my checkout. And `src/redisearch_rs/target`, which no target ever removed — 13 GB in mine.
2. **Change:** sweep stray `*.profraw` in both branches of the target, and have `ALL=1` also remove `src/redisearch_rs/target`.
3. **Outcome:** `make clean` no longer leaves tens of thousands of untracked files behind, and `ALL=1` reclaims the Rust artifacts too.

On the Rust target directory: normally those artifacts live under `bin/` and the existing `rm -rf bin` already gets them. But cargo resolves `[build] target-dir` relative to the working directory rather than the manifest, so invoking it from the repo root with `--manifest-path` — the form `.claude/skills/check-rust-coverage` documents — creates `src/redisearch_rs/target` instead. That is where mine came from.

The sweep is `@-find` rather than `find`: it exits non-zero on anything it cannot delete, and a best-effort cleanup should not fail the target. The `-` keeps the error visible while ignoring it. Verified both branches with `make -n clean` and `make -n clean ALL=1`, and confirmed the ignored-failure behaviour with a real unwritable file.

Safety: no tracked `*.profraw` exists in this repo or any nested submodule, `-type f` prevents a directory match, and `find` defaults to `-P` so it cannot leave the tree via a symlink. Nothing in CI, `.install/`, `sbin/`, `build.sh` or the skills invokes `make clean`, and no cache is keyed on `src/redisearch_rs/target` surviving one.

#### Which additional issues this PR fixes

None — no ticket, this is an ad-hoc change.

#### Main objects this PR modified

1. `Makefile` — the `clean` target and its help text

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

Build tooling only; no behaviour change in the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
