### PR TITLE
CI: build Redis and RedisJSON as their own jobs

### DIFF
--- a/.github/actions/build-rejson/action.yml
+++ b/.github/actions/build-rejson/action.yml
@@ -90,6 +90,13 @@ runs:
       shell: bash -leo pipefail {0}
       env:
         SAN: ${{ inputs.san }}
+        # RedisJSON's Makefile adds `-C instrument-coverage` under COV=1, and make
+        # imports the environment, so this genuinely changes the binary — which is
+        # why `cov` is in the cache key above. Set it from the input here rather
+        # than inheriting it from the caller's job env: a caller that keys an
+        # entry on cov=1 without exporting COV would otherwise write an
+        # uninstrumented binary under the instrumented key.
+        COV: ${{ inputs.cov }}
         # Build the resolved SHA (not the moving branch ref) so the produced
         # binary always matches the cache key.
         REJSON_BRANCH: ${{ steps.resolve.outputs.sha }}

--- a/.github/workflows/flow-pr-pipeline.yml
+++ b/.github/workflows/flow-pr-pipeline.yml
@@ -9,6 +9,11 @@ name: PR Pipeline (one job-type)
 # here (get-config + build-image) and passed down to the build / test-unit /
 # test-flow jobs as inputs — so the per-task workflows don't redo that setup.
 #
+# The three binaries the flow tests need are produced by three concurrent jobs —
+# the RediSearch module (build), redis-server (build-redis) and the RedisJSON
+# module (build-rejson) — each uploading its own artifact. The unit tests need
+# only the first, so they start as soon as it lands.
+#
 # MIRI is NOT part of this pipeline. It's dispatched as its own top-level job
 # (task-miri.yml) from event-pull_request.yml because it can't share the
 # nextest archive and would otherwise gate the other test jobs.
@@ -86,10 +91,8 @@ jobs:
     with:
       platform: ${{ inputs.platform }}
       architecture: ${{ inputs.architecture }}
-      redis-ref: ${{ inputs.redis-ref }}
       coverage: ${{ inputs.job-type == 'coverage' }}
       san: ${{ inputs.job-type == 'sanitize' && 'address' || '' }}
-      rejson-branch: ${{ inputs.rejson-branch }}
       # run_attempt keeps the name unique on a *full* re-run (where build does
       # rerun and would otherwise collide with the existing artifact). Test
       # jobs below consume needs.build.outputs.artifact-name, not this literal.
@@ -102,6 +105,59 @@ jobs:
       setup-script: ${{ needs.get-config.outputs.setup_script }}
       post-setup-script: ${{ needs.get-config.outputs.post_setup_script }}
       enable-lto: ${{ inputs.enable-lto != '' && inputs.enable-lto || needs.get-config.outputs.enable_lto }}
+      image: ${{ needs.build-image.outputs.image }}
+      image-built: ${{ needs.build-image.outputs.succeeded }}
+
+  # redis-server and RedisJSON are external to this repo but must be built with
+  # the same toolchain as the module (sanitizer builds in particular). They are
+  # independent of the module build, so they run concurrently with it rather than
+  # inside it; both are cache-restored on the common path.
+  build-redis:
+    name: Build Redis (${{ inputs.job-type }})
+    needs: [get-config, build-image]
+    # Same build-image guard as `build` above.
+    if: ${{ !cancelled() && needs.get-config.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/task-build-redis.yml
+    with:
+      redis-ref: ${{ inputs.redis-ref }}
+      coverage: ${{ inputs.job-type == 'coverage' }}
+      san: ${{ inputs.job-type == 'sanitize' && 'address' || '' }}
+      artifact-name: pr-redis-${{ inputs.job-type }}-${{ github.run_id }}-${{ github.run_attempt }}
+      # Resolved platform config — task-build-redis.yml doesn't rerun get-config.
+      name: ${{ needs.get-config.outputs.name }}
+      container: ${{ needs.get-config.outputs.container }}
+      env: ${{ needs.get-config.outputs.env }}
+      install-mode: ${{ needs.get-config.outputs.install_mode }}
+      setup-script: ${{ needs.get-config.outputs.setup_script }}
+      post-setup-script: ${{ needs.get-config.outputs.post_setup_script }}
+      image: ${{ needs.build-image.outputs.image }}
+      image-built: ${{ needs.build-image.outputs.succeeded }}
+
+  build-rejson:
+    name: Build RedisJSON (${{ inputs.job-type }})
+    needs: [get-config, build-image]
+    # Same build-image guard as `build` above.
+    if: ${{ !cancelled() && needs.get-config.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/task-build-rejson.yml
+    with:
+      platform: ${{ inputs.platform }}
+      coverage: ${{ inputs.job-type == 'coverage' }}
+      san: ${{ inputs.job-type == 'sanitize' && 'address' || '' }}
+      rejson-branch: ${{ inputs.rejson-branch }}
+      artifact-name: pr-rejson-${{ inputs.job-type }}-${{ github.run_id }}-${{ github.run_attempt }}
+      # Resolved platform config — task-build-rejson.yml doesn't rerun get-config.
+      name: ${{ needs.get-config.outputs.name }}
+      container: ${{ needs.get-config.outputs.container }}
+      env: ${{ needs.get-config.outputs.env }}
+      install-mode: ${{ needs.get-config.outputs.install_mode }}
+      setup-script: ${{ needs.get-config.outputs.setup_script }}
+      post-setup-script: ${{ needs.get-config.outputs.post_setup_script }}
       image: ${{ needs.build-image.outputs.image }}
       image-built: ${{ needs.build-image.outputs.succeeded }}
 
@@ -140,8 +196,8 @@ jobs:
 
   test-flow-standalone:
     name: ${{ inputs.job-type }} (Standalone)
-    needs: [get-config, build-image, build]
-    if: ${{ !cancelled() && needs.build.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
+    needs: [get-config, build-image, build, build-redis, build-rejson]
+    if: ${{ !cancelled() && needs.build.result == 'success' && needs.build-redis.result == 'success' && needs.build-rejson.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
     permissions:
       contents: read
       packages: write
@@ -165,6 +221,8 @@ jobs:
       # artifact keeps the original attempt's name. Reconstructing here would
       # look for an artifact that was never produced.
       artifact-name: ${{ needs.build.outputs.artifact-name }}
+      redis-artifact-name: ${{ needs.build-redis.outputs.artifact-name }}
+      rejson-artifact-name: ${{ needs.build-rejson.outputs.artifact-name }}
       name: ${{ needs.get-config.outputs.name }}
       container: ${{ needs.get-config.outputs.container }}
       env: ${{ needs.get-config.outputs.env }}
@@ -176,8 +234,8 @@ jobs:
 
   test-flow-coordinator:
     name: ${{ inputs.job-type }} (Coordinator ${{ matrix.shard }}/${{ strategy.job-total }})
-    needs: [get-config, build-image, build]
-    if: ${{ !cancelled() && needs.build.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
+    needs: [get-config, build-image, build, build-redis, build-rejson]
+    if: ${{ !cancelled() && needs.build.result == 'success' && needs.build-redis.result == 'success' && needs.build-rejson.result == 'success' && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') }}
     # Coordinator tests are the slowest flow suite (cluster setup, inter-shard
     # PINGs, 5-min timeouts), so split them across file-level shards. The
     # instrumented builds (coverage, sanitize) run noticeably slower, so give
@@ -213,6 +271,8 @@ jobs:
       # artifact keeps the original attempt's name. Reconstructing here would
       # look for an artifact that was never produced.
       artifact-name: ${{ needs.build.outputs.artifact-name }}
+      redis-artifact-name: ${{ needs.build-redis.outputs.artifact-name }}
+      rejson-artifact-name: ${{ needs.build-rejson.outputs.artifact-name }}
       name: ${{ needs.get-config.outputs.name }}
       container: ${{ needs.get-config.outputs.container }}
       env: ${{ needs.get-config.outputs.env }}

--- a/.github/workflows/task-build-redis.yml
+++ b/.github/workflows/task-build-redis.yml
@@ -1,0 +1,179 @@
+name: Common Flow for Building Redis
+
+# Documentation: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3967844669/RediSearch+CI+refactor
+#
+# Reusable workflow that produces the redis-server the flow tests run against and
+# uploads its install tree as a workflow artifact (`redis-install.tar.gz`).
+# `task-test-flow.yml` downloads and unpacks it; no test job builds Redis itself.
+#
+# The actual build is `.github/actions/build-redis`, cache-keyed on (Redis SHA,
+# platform, arch, sanitizer, coverage, TLS, compiler) — so on the common path
+# this job is a cache restore plus tar + upload.
+#
+# This runs on the same platform/container and with the same sanitizer/coverage
+# flags as `task-build.yml`, which is what keeps the server ABI-compatible with
+# the module under test: a gcc-built sanitizer redis-server aborts at startup
+# ("ASan runtime does not come first in initial library list"), so the toolchain
+# here must match the one that builds the module.
+
+on:
+  workflow_call:
+    inputs:
+      redis-ref:
+        description: 'Redis version to build (e.g. "7.2.3", "unstable", or a commit sha)'
+        type: string
+        default: '8.10.0'
+      san:
+        type: string
+      coverage:
+        type: boolean
+        default: false
+      artifact-name:
+        description: 'Name of the workflow artifact uploaded with redis-install.tar.gz.'
+        type: string
+        required: true
+      # Resolved platform config — produced by task-get-config.yml at the
+      # pipeline level so this workflow doesn't redo it. Caller must supply.
+      name:
+        type: string
+        default: ''
+      container:
+        type: string
+        default: ''
+      env:
+        type: string
+        default: ''
+      install-mode:
+        type: string
+        default: ''
+      setup-script:
+        type: string
+        default: ''
+      post-setup-script:
+        type: string
+        default: ''
+      # Prebuilt container image (task-build-cached-container.yml outputs).
+      image:
+        type: string
+        default: ''
+      image-built:
+        description: "'true' when the prebuilt image is available; falls back to inputs.container otherwise."
+        type: string
+        default: 'false'
+    outputs:
+      artifact-name:
+        description: 'Name of the uploaded Redis artifact.'
+        # Reusable-workflow outputs must map from a job output, not directly
+        # from inputs — otherwise validation can reject it / it evaluates empty.
+        value: ${{ jobs.build-redis.outputs.artifact-name }}
+
+env:
+  SETUP_RETRY_LOOP: |
+    SUCCESS=0
+    for i in 1 2 3 4 5; do
+      echo "Attempt $i of 5"
+      if {0}; then
+        echo "Setup succeeded"
+        SUCCESS=1
+        break
+      fi
+      if [ $i -lt 5 ]; then
+        echo "Setup failed, retrying in 30 seconds..."
+        sleep 30
+      fi
+    done
+    [ $SUCCESS -eq 1 ] || exit 1
+
+jobs:
+  build-redis:
+    name: Build Redis ${{ inputs.redis-ref }} on ${{ inputs.name }}
+    outputs:
+      artifact-name: ${{ inputs.artifact-name }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    container: ${{
+      inputs.container
+        && fromJSON(
+          format('{{"image":"{0}","options":"--user root -v /usr/share/dotnet:/host_usr/dotnet -v /usr/local/lib/android:/host_usr/android -v /opt/ghc:/host_opt/ghc -v /opt/hostedtoolcache:/host_opt/hostedtoolcache {1}"}}',
+            inputs.image-built == 'true' && inputs.image || inputs.container,
+            startsWith(inputs.container, 'alpine:') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '')
+        )
+      || null }}
+
+    permissions:
+      contents: read  # actions/checkout
+      packages: read  # pull container image from GHCR
+
+    defaults:
+      run:
+        shell: bash -l -eo pipefail {0}
+    steps:
+      - name: Install bash
+        if: startsWith(inputs.container, 'alpine:')
+        shell: sh -l -eo pipefail {0}
+        run: ${{ format(env.SETUP_RETRY_LOOP, 'apk add bash') }}
+
+      - name: Fix HOME Directory
+        if: ${{ inputs.image-built == 'true' && inputs.container }}
+        shell: bash
+        run: |
+          # Issue [HOME is overridden for containers](https://github.com/actions/runner/issues/863)
+          h=$(getent passwd "$(id -un)" | cut -d: -f6)
+          if [ "$h" = "$HOME" ]; then
+            echo "HOME fine: $HOME"
+            exit 0
+          fi
+          echo "HOME=$HOME was broken. Setting it to $h"
+          echo "HOME=$h" >> "$GITHUB_ENV"
+
+      - name: Setup Dependencies
+        # Hoist setup-script into an env var and `eval` it from the loop body
+        # rather than interpolating ${{ inputs.setup-script }} directly into
+        # the run script — avoids ${{ }} expansion injecting shell metachars.
+        if: inputs.image-built != 'true' && inputs.setup-script
+        env:
+          SETUP_SCRIPT: ${{ inputs.setup-script }}
+        run: ${{ format(env.SETUP_RETRY_LOOP, 'eval "$SETUP_SCRIPT"') }}
+
+      - name: Post-setup
+        if: inputs.post-setup-script
+        env:
+          POST_SETUP_SCRIPT: ${{ inputs.post-setup-script }}
+        run: eval "$POST_SETUP_SCRIPT"
+
+      - name: Checkout
+        # Shallow, submodule-free: this job only needs the install scripts and
+        # the two local actions below. Redis itself is cloned by build-redis.
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build-env
+        with:
+          install-mode: ${{ inputs.install-mode }}
+          image-built: ${{ inputs.image-built }}
+          san: ${{ inputs.san }}
+          install-script: 'true'
+          # A sanitizer redis-server must be built by the same clang that builds
+          # the module, so the LLVM setup has to run here too — build-redis
+          # refuses to build SAN=address with a non-clang CC.
+          sanitizer-setup: 'true'
+          build-redis: 'true'
+          redis-ref: ${{ inputs.redis-ref }}
+          coverage: ${{ inputs.coverage }}
+          redis-cache-platform-id: ${{ inputs.container || inputs.env }}
+
+      # tar (not the artifact zip) to preserve the executable bits on
+      # redis-server / redis-cli.
+      - name: Package Redis install tree
+        run: |
+          set -euo pipefail
+          tar -czf redis-install.tar.gz redis-install
+          echo "Redis tarball size:"
+          ls -lh redis-install.tar.gz
+
+      - name: Upload Redis artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: redis-install.tar.gz
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/task-build-rejson.yml
+++ b/.github/workflows/task-build-rejson.yml
@@ -1,0 +1,228 @@
+name: Common Flow for Building RedisJSON
+
+# Documentation: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3967844669/RediSearch+CI+refactor
+#
+# Reusable workflow that produces the RedisJSON module the flow tests load as a
+# side module, and uploads it as a workflow artifact (`rejson.so`).
+# `task-test-flow.yml` downloads it and points REJSON_PATH at it, so no test job
+# clones or builds RedisJSON itself.
+#
+# The actual build is `.github/actions/build-rejson`, cache-keyed on (RedisJSON
+# SHA, platform, arch, sanitizer, coverage, pinned nightly toolchain) — so on the
+# common path this job is a cache restore plus the upload.
+#
+# This runs on the same platform/container and with the same sanitizer flags as
+# `task-build.yml`, so the module is binary-compatible with the redis-server and
+# the RediSearch module it gets loaded next to.
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        description: 'Platform name (e.g., ubuntu:noble, macos-15). Part of the build cache key.'
+        type: string
+        required: true
+      san:
+        type: string
+      coverage:
+        type: boolean
+        default: false
+      rejson-branch:
+        description: 'RedisJSON git ref to build (branch, tag, or 40-char SHA).'
+        type: string
+        default: master
+      artifact-name:
+        description: 'Name of the workflow artifact uploaded with rejson.so.'
+        type: string
+        required: true
+      # Resolved platform config — produced by task-get-config.yml at the
+      # pipeline level so this workflow doesn't redo it. Caller must supply.
+      name:
+        type: string
+        default: ''
+      container:
+        type: string
+        default: ''
+      env:
+        type: string
+        default: ''
+      install-mode:
+        type: string
+        default: ''
+      setup-script:
+        type: string
+        default: ''
+      post-setup-script:
+        type: string
+        default: ''
+      # Prebuilt container image (task-build-cached-container.yml outputs).
+      image:
+        type: string
+        default: ''
+      image-built:
+        description: "'true' when the prebuilt image is available; falls back to inputs.container otherwise."
+        type: string
+        default: 'false'
+    outputs:
+      artifact-name:
+        description: 'Name of the uploaded RedisJSON artifact.'
+        # Reusable-workflow outputs must map from a job output, not directly
+        # from inputs — otherwise validation can reject it / it evaluates empty.
+        value: ${{ jobs.build-rejson.outputs.artifact-name }}
+
+env:
+  RUST_BACKTRACE: "full"
+  SETUP_RETRY_LOOP: |
+    SUCCESS=0
+    for i in 1 2 3 4 5; do
+      echo "Attempt $i of 5"
+      if {0}; then
+        echo "Setup succeeded"
+        SUCCESS=1
+        break
+      fi
+      if [ $i -lt 5 ]; then
+        echo "Setup failed, retrying in 30 seconds..."
+        sleep 30
+      fi
+    done
+    [ $SUCCESS -eq 1 ] || exit 1
+
+jobs:
+  build-rejson:
+    name: Build RedisJSON ${{ inputs.rejson-branch }} on ${{ inputs.name }}
+    outputs:
+      artifact-name: ${{ inputs.artifact-name }}
+    runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    container: ${{
+      inputs.container
+        && fromJSON(
+          format('{{"image":"{0}","options":"--user root -v /usr/share/dotnet:/host_usr/dotnet -v /usr/local/lib/android:/host_usr/android -v /opt/ghc:/host_opt/ghc -v /opt/hostedtoolcache:/host_opt/hostedtoolcache {1}"}}',
+            inputs.image-built == 'true' && inputs.image || inputs.container,
+            startsWith(inputs.container, 'alpine:') && '-v /opt:/opt:rw,rshared -v /opt:/__e/node20:ro,rshared -v /opt:/__e/node24:ro,rshared' || '')
+        )
+      || null }}
+
+    permissions:
+      contents: read  # actions/checkout
+      packages: read  # pull container image from GHCR
+
+    defaults:
+      run:
+        shell: bash -l -eo pipefail {0}
+    steps:
+      - name: Install bash
+        if: startsWith(inputs.container, 'alpine:')
+        shell: sh -l -eo pipefail {0}
+        run: ${{ format(env.SETUP_RETRY_LOOP, 'apk add bash') }}
+
+      # On a cache miss this job compiles RedisJSON from source (cargo), so it
+      # needs real disk headroom — unlike task-build-redis.yml, which restores or
+      # makes a small C build.
+      - name: Free up disk space (container)
+        if: ${{ inputs.container }}
+        run: |
+          echo "Before cleanup:"
+          df -h
+          rm -rf /host_usr/dotnet/* 2>/dev/null || true
+          rm -rf /host_usr/android/* 2>/dev/null || true
+          rm -rf /host_opt/ghc/* 2>/dev/null || true
+          rm -rf /host_opt/hostedtoolcache/CodeQL/* 2>/dev/null || true
+          echo "After cleanup:"
+          df -h
+      - name: Free up disk space (non-container)
+        if: ${{ !inputs.container && !contains(inputs.env, 'macos') }}
+        run: |
+          echo "Before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          sudo rm -rf /usr/local/share/boost || true
+          docker system prune -af 2>/dev/null || true
+          echo "After cleanup:"
+          df -h
+      - name: Fix HOME Directory
+        if: ${{ inputs.image-built == 'true' && inputs.container }}
+        shell: bash
+        run: |
+          # Issue [HOME is overridden for containers](https://github.com/actions/runner/issues/863)
+          h=$(getent passwd "$(id -un)" | cut -d: -f6)
+          if [ "$h" = "$HOME" ]; then
+            echo "HOME fine: $HOME"
+            exit 0
+          fi
+          echo "HOME=$HOME was broken. Setting it to $h"
+          echo "HOME=$h" >> "$GITHUB_ENV"
+
+      - name: Setup Dependencies
+        # Hoist setup-script into an env var and `eval` it from the loop body
+        # rather than interpolating ${{ inputs.setup-script }} directly into
+        # the run script — avoids ${{ }} expansion injecting shell metachars.
+        if: inputs.image-built != 'true' && inputs.setup-script
+        env:
+          SETUP_SCRIPT: ${{ inputs.setup-script }}
+        run: ${{ format(env.SETUP_RETRY_LOOP, 'eval "$SETUP_SCRIPT"') }}
+
+      - name: Post-setup
+        if: inputs.post-setup-script
+        env:
+          POST_SETUP_SCRIPT: ${{ inputs.post-setup-script }}
+        run: eval "$POST_SETUP_SCRIPT"
+
+      - name: Checkout
+        # Shallow, submodule-free: this job only needs the install scripts,
+        # .rust-nightly and tests/deps/setup_rejson.sh. RedisJSON and its own
+        # submodules are cloned by that script.
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build-env
+        with:
+          install-mode: ${{ inputs.install-mode }}
+          image-built: ${{ inputs.image-built }}
+          san: ${{ inputs.san }}
+          install-script: 'true'
+          # RedisJSON's readies-based Makefile drives its build through python3,
+          # which must come from the repo venv (PEP 668 blocks pip on system
+          # interpreters); setup_rejson.sh activates it.
+          python-test-deps: 'true'
+          # Not for the Rust test tooling: this is the only step that installs
+          # the nightly's rust-src component, which a SAN=address RedisJSON
+          # build needs (install_rust.sh provisions the nightly with
+          # rust-docs-json only). Without it, a sanitizer build on a runner
+          # without the prebuilt image — a fork PR, or a failed image build —
+          # fails on a RedisJSON cache miss.
+          rust-test-deps: 'true'
+          github-token: ${{ github.token }}
+          sanitizer-setup: 'true'
+
+      - name: Build RedisJSON (cached)
+        uses: ./.github/actions/build-rejson
+        with:
+          rejson-branch: ${{ inputs.rejson-branch }}
+          san: ${{ inputs.san }}
+          cov: ${{ inputs.coverage && '1' || '0' }}
+          cache_platform_id: ${{ inputs.platform }}
+
+      - name: Package RedisJSON module
+        # tar, not the artifact zip: Redis checks X_OK on a module file before
+        # loading it and rejects a non-executable one ("Module ... failed to
+        # load: It does not have execute permissions"), while the artifact zip
+        # round-trip drops the bit. Set the bit here rather than trusting
+        # RedisJSON's build output, so the consumer's assertion can only fire on
+        # a genuine packaging regression.
+        run: |
+          set -euo pipefail
+          chmod +x bin/rejson.so
+          tar -czf rejson.tar.gz -C bin rejson.so
+          ls -lh rejson.tar.gz
+
+      - name: Upload RedisJSON artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: rejson.tar.gz
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/task-build.yml
+++ b/.github/workflows/task-build.yml
@@ -6,6 +6,11 @@ name: Common Flow for Build
 # coordinator binaries) with `make build TESTS=1`, and uploads the contents of
 # `bin/` as a workflow artifact. Downstream test workflows
 # (`task-test-unit.yml`, `task-test-flow.yml`) consume that artifact.
+#
+# Only RediSearch is built here. The two external binaries the flow tests need —
+# redis-server and the RedisJSON module — are produced by `task-build-redis.yml`
+# and `task-build-rejson.yml`, which run as sibling jobs off the same resolved
+# platform config and ship their own artifacts.
 
 on:
   workflow_call:
@@ -23,18 +28,10 @@ on:
       coverage:
         type: boolean
         default: false
-      redis-ref:
-        description: 'Redis version to use (e.g. "7.2.3", "unstable")'
-        type: string
-        default: '8.10.0'
       artifact-name:
         description: 'Name of the workflow artifact uploaded with the contents of bin/.'
         type: string
         required: true
-      rejson-branch:
-        description: 'RedisJSON branch to build once here; the resulting rejson.so ships in the artifact so flow test jobs reuse it instead of rebuilding.'
-        type: string
-        default: master
       # Resolved platform config — produced by task-get-config.yml at the
       # pipeline level so this workflow doesn't redo it. Caller must supply.
       name:
@@ -98,7 +95,7 @@ env:
 
 jobs:
   common-flow:
-    name: Build ${{ inputs.name }}, Redis ${{ inputs.redis-ref }}
+    name: Build ${{ inputs.name }}
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
@@ -225,10 +222,6 @@ jobs:
           github-token: ${{ github.token }}
           python-test-deps: 'true'
           sanitizer-setup: 'true'
-          build-redis: 'true'
-          redis-ref: ${{ inputs.redis-ref }}
-          coverage: ${{ inputs.coverage }}
-          redis-cache-platform-id: ${{ inputs.container || inputs.env }}
 
       - name: Build (incl. Rust nextest archive)
         # `make build TESTS=1` builds redisearch.so + C test binaries; with
@@ -239,7 +232,6 @@ jobs:
         env:
           SAN: ${{ inputs.san }}
           COV: ${{ inputs.coverage && 1 || 0 }}
-          REDIS_VER: ${{ inputs.redis-ref }}
           ENABLE_ASSERT: 1
           ARCHIVE_RUST_TESTS: 1
           # Skip the Rust → C FFI header regeneration here; freshness is enforced
@@ -262,20 +254,6 @@ jobs:
 
       - name: Show sccache stats
         run: ${SCCACHE_PATH:-sccache} --show-stats || true
-
-      # RedisJSON is loaded as a side module by the flow tests. Build it once
-      # here (same sanitizer variant as the rest of the artifact) and drop
-      # rejson.so into bin/ so it ships in the build artifact; flow test jobs set
-      # REJSON_PATH to it and skip their own clone+build. The action caches it
-      # per (RedisJSON SHA, platform, arch, sanitizer) exactly like Redis, so an
-      # unchanged RedisJSON SHA under the same flags is restored, not rebuilt.
-      - name: Build RedisJSON module (cached)
-        uses: ./.github/actions/build-rejson
-        with:
-          rejson-branch: ${{ inputs.rejson-branch }}
-          san: ${{ inputs.san }}
-          cov: ${{ inputs.coverage && '1' || '0' }}
-          cache_platform_id: ${{ inputs.platform }}
 
       - name: Package build outputs
         # We package bin/ as a tarball for two reasons:
@@ -340,22 +318,6 @@ jobs:
           echo "Tarball size:"
           ls -lh bin.tar.gz
 
-      # Ship the Redis install tree alongside the module. The flow-test jobs used
-      # to obtain it from the shared Actions cache that the step above populates,
-      # but a cache miss there (eviction, a re-run after the entry aged out) made
-      # them build Redis themselves — with the default compiler rather than the
-      # sanitizer clang used here, producing a redis-server that aborts with
-      # "ASan runtime does not come first in initial library list". Shipping it in
-      # the artifact makes the toolchain match by construction, so the cache is a
-      # build-time optimisation only and can never change what the tests run.
-      # tar (not the artifact zip) to preserve the executable bits.
-      - name: Package Redis install tree
-        run: |
-          set -euo pipefail
-          tar -czf redis-install.tar.gz redis-install
-          echo "Redis tarball size:"
-          ls -lh redis-install.tar.gz
-
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -363,6 +325,5 @@ jobs:
           path: |
             bin.tar.gz
             nextest-archive.tar.zst
-            redis-install.tar.gz
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/task-test-flow.yml
+++ b/.github/workflows/task-test-flow.yml
@@ -5,7 +5,9 @@ name: Common Flow for Python Flow Tests
 # Reusable workflow that runs the Python flow tests (`make pytest`) against a
 # pre-built RediSearch module produced by `task-build.yml`. The build artifact
 # is downloaded into `bin/` and exactly one mode (`standalone` or `coordinator`)
-# is exercised per job invocation. No C/C++ or Rust compilation happens here.
+# is exercised per job invocation. No compilation happens here at all: the
+# redis-server and the RedisJSON module come from their own artifacts, uploaded
+# by `task-build-redis.yml` and `task-build-rejson.yml`.
 
 on:
   workflow_call:
@@ -42,7 +44,7 @@ on:
       rejson-branch:
         type: string
         default: master
-        description: "Branch to use when building RedisJSON for tests"
+        description: "RedisJSON ref the module in rejson-artifact-name was built from (reported by the test harness; nothing is built here)"
       test-timeout:
         type: number
         default: 120
@@ -59,6 +61,14 @@ on:
         default: 1
       artifact-name:
         description: 'Workflow artifact name to download (produced by task-build.yml).'
+        type: string
+        required: true
+      redis-artifact-name:
+        description: 'Workflow artifact holding redis-install.tar.gz (produced by task-build-redis.yml).'
+        type: string
+        required: true
+      rejson-artifact-name:
+        description: 'Workflow artifact holding rejson.so (produced by task-build-rejson.yml). Only downloaded when rejson is true.'
         type: string
         required: true
       # Resolved platform config — produced by task-get-config.yml at the
@@ -223,8 +233,8 @@ jobs:
           sanitizer-setup: 'true'
           # Flow tests only need the ASAN symbolizer, not CC/CXX/LD pinned to clang.
           llvm-full-config: 'false'
-          # No compilation happens in this job, Redis included: the build job
-          # ships its redis-install tree in the artifact and we unpack it below.
+          # No compilation happens in this job, Redis included: the Redis build
+          # job ships its install tree as an artifact and we unpack it below.
           build-redis: 'false'
 
       - name: Set Artifact Names
@@ -262,7 +272,13 @@ jobs:
           echo "Module binaries:"
           find bin -name 'redisearch.so' -o -name 'redisearch.dylib' 2>/dev/null
 
-      - name: Restore Redis from build artifact
+      - name: Download Redis artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: ${{ inputs.redis-artifact-name }}
+          # redis-install.tar.gz lands in the working directory; unpacked next.
+
+      - name: Restore Redis from artifact
         # Same install tree, same toolchain as the module under test. The
         # `--version` check mirrors what RLTest parses to decide the server
         # version (it wants a "v=<version>" field on stdout): assert it here so a
@@ -293,6 +309,31 @@ jobs:
             chmod 0644 /etc/profile.d/redis-prefix.sh
           fi
 
+      - name: Download RedisJSON artifact
+        if: ${{ inputs.rejson }}
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: ${{ inputs.rejson-artifact-name }}
+          # rejson.tar.gz lands in the working directory; unpacked next.
+
+      - name: Unpack RedisJSON module
+        # Into bin/, where REJSON_PATH points below. Runs after the bin/ unpack
+        # so that tarball can never clobber it. The execute bit is asserted, not
+        # assumed: Redis checks X_OK before loading a module and refuses a
+        # non-executable one, and every server in the job then fails to start —
+        # which surfaces as every test reporting "Connection refused" with the
+        # cause only visible in the per-server logs.
+        if: ${{ inputs.rejson }}
+        run: |
+          set -euo pipefail
+          tar -xzf rejson.tar.gz -C bin
+          rm rejson.tar.gz
+          ls -l bin/rejson.so
+          [[ -x bin/rejson.so ]] || {
+            echo "::error::bin/rejson.so is not executable; Redis will refuse to load it"
+            exit 1
+          }
+
       # Enumerate the suite (LIST=1 => RLTest --collect-only, one "<file>:<test>"
       # spec per line). Needed to shard and as the input to flaky filtering.
       # Runs whenever we shard (shard-total > 1) OR can filter (internal PRs); a
@@ -304,7 +345,7 @@ jobs:
           SAN: ${{ inputs.san }}
           REJSON: ${{ env.REJSON }}
           REJSON_BRANCH: ${{ inputs.rejson-branch }}
-          # rejson.so was prebuilt and restored from the artifact; point
+          # rejson.so came from the RedisJSON build job's artifact; point
           # setup_rejson.sh at it so enumeration doesn't clone+build RedisJSON.
           REJSON_PATH: ${{ github.workspace }}/bin/rejson.so
           # Enumerate in the same mode the shard runs in, so collection matches.
@@ -406,8 +447,8 @@ jobs:
           FAILEDFILE: .failed_standalone.txt
           REJSON: ${{ env.REJSON }}
           REJSON_BRANCH: ${{ inputs.rejson-branch }}
-          # rejson.so was prebuilt by the build job and restored from the artifact.
-          # Pointing REJSON_PATH at it makes setup_rejson.sh skip its clone+build.
+          # rejson.so came from the RedisJSON build job's artifact. Pointing
+          # REJSON_PATH at it makes setup_rejson.sh skip its clone+build.
           REJSON_PATH: ${{ github.workspace }}/bin/rejson.so
           ENABLE_ASSERT: 1
           TEST_CONFIG: ${{ inputs.test-config }}
@@ -430,8 +471,8 @@ jobs:
           FAILEDFILE: .failed_coordinator.txt
           REJSON: ${{ env.REJSON }}
           REJSON_BRANCH: ${{ inputs.rejson-branch }}
-          # rejson.so was prebuilt by the build job and restored from the artifact.
-          # Pointing REJSON_PATH at it makes setup_rejson.sh skip its clone+build.
+          # rejson.so came from the RedisJSON build job's artifact. Pointing
+          # REJSON_PATH at it makes setup_rejson.sh skip its clone+build.
           REJSON_PATH: ${{ github.workspace }}/bin/rejson.so
           ENABLE_ASSERT: 1
           TEST_CONFIG: ${{ inputs.test-config }}


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: the PR flow and the master merge queue build `redis-server` and the RedisJSON module as steps *inside* the RediSearch build job. Three independent builds are serialized on one runner, no test job can start until all of them finish, and the Redis install tree rides along in the module artifact — where the unit-test job downloads it and never unpacks it.
2. Change: Redis and RedisJSON each become their own job, uploading `redis-install.tar.gz` and `rejson.so` as separate artifacts that the flow-test jobs download. The release-branch lane (`task-test.yml`) is untouched: it builds and tests in a single job, so it has no separate consumer to hand an artifact to.
3. Outcome: internal-only, no module behavior change. It shortens the pipeline's critical path — the three builds now run concurrently and the unit tests no longer wait on binaries they never load — and gives a dependency build failure its own red check instead of burying it in the module build log.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `flow-pr-pipeline.yml` — new `build-redis` and `build-rejson` jobs alongside `build`, under the same `build-image` guard; only the two flow-test jobs gained them as dependencies.
2. `task-build-redis.yml` / `task-build-rejson.yml` (new) — thin wrappers around the existing cached `build-redis` / `build-rejson` composite actions plus an artifact upload. Same resolved platform config and sanitizer setup as the module build, which is what keeps the binaries ABI-compatible with it; checkout is submodule-free since neither needs the vendored deps.
3. `task-build.yml` — builds RediSearch only. Dropped both dependency builds, `redis-install.tar.gz` from the artifact, and the now-dead `redis-ref` / `rejson-branch` inputs. Side effect worth a look: RedisJSON no longer inherits this workflow's `RUSTFLAGS=-Dwarnings`, which it was picking up incidentally.
4. `task-test-flow.yml` — two new required artifact-name inputs and their downloads. `REJSON_PATH` and the Redis unpack/verify logic are unchanged, so what the tests run against is the same.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
