### PR TITLE
[MOD-17585] Port the LIMIT paging result processor to Rust

### DIFF
--- a/src/redisearch_rs/c_entrypoint/result_processor_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/result_processor_ffi/Cargo.toml
@@ -17,7 +17,9 @@ workspace_hack.workspace = true
 [dev-dependencies]
 # Crate required to invoke C symbols
 result_processor_ffi = { path = ".", features = ["unittest"] }
-redisearch_rs = { path = "../redisearch_rs" }
+# `mock_allocator` disables the `RedisAlloc` global allocator so the mock's
+# `RedisModule_Alloc` routes to the system allocator instead of recursing.
+redisearch_rs = { path = "../redisearch_rs", features = ["mock_allocator"] }
 redis_mock.workspace = true
 
 [lints]

--- a/src/redisearch_rs/c_entrypoint/result_processor_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/result_processor_ffi/src/lib.rs
@@ -9,3 +9,4 @@
 
 pub mod counter;
 pub mod crash;
+pub mod pager;

--- a/src/redisearch_rs/c_entrypoint/result_processor_ffi/src/pager.rs
+++ b/src/redisearch_rs/c_entrypoint/result_processor_ffi/src/pager.rs
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use result_processor::{ResultProcessorWrapper, pager::Pager};
+
+/// Create a new heap-allocated `Pager` result processor. `offset` and `limit` are taken from the
+/// user's `LIMIT` clause.
+///
+/// # Safety
+///
+/// - The caller must never move the allocated result processor from its original allocation.
+/// - The caller must ensure to call the `Free` VTable function to properly destroy the type.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn RPPager_New(offset: usize, limit: usize) -> *mut ffi::ResultProcessor {
+    // The C pager stored both in `uint32_t` fields, truncating the same way.
+    let rp = Box::pin(ResultProcessorWrapper::new(Pager::new(
+        offset as u32,
+        limit as u32,
+    )));
+
+    // Safety: The safety contract requires the caller to treat the returned pointer as pinned
+    unsafe { ResultProcessorWrapper::into_ptr(rp) }
+        .cast()
+        .as_ptr()
+}

--- a/src/redisearch_rs/c_entrypoint/result_processor_ffi/src/pager.rs
+++ b/src/redisearch_rs/c_entrypoint/result_processor_ffi/src/pager.rs
@@ -24,7 +24,7 @@ pub unsafe extern "C" fn RPPager_New(offset: usize, limit: usize) -> *mut ffi::R
         limit as u32,
     )));
 
-    // Safety: The safety contract requires the caller to treat the returned pointer as pinned
+    // SAFETY: The safety contract requires the caller to treat the returned pointer as pinned
     unsafe { ResultProcessorWrapper::into_ptr(rp) }
         .cast()
         .as_ptr()

--- a/src/redisearch_rs/c_entrypoint/result_processor_ffi/tests/pager.rs
+++ b/src/redisearch_rs/c_entrypoint/result_processor_ffi/tests/pager.rs
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! This file contains tests to ensure the FFI functions behave as expected.
+
+// Link both Rust-provided and C-provided symbols
+extern crate redisearch_rs;
+// Mock or stub the ones that aren't provided by the line above
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
+use result_processor_ffi::pager::*;
+
+/// Construct a pager, hand it to `check`, then tear it down through its `Free` VTable entry the
+/// way the C pipeline does.
+///
+/// Every test needs that create/inspect/destroy triple, and leaving the `Free` out would leak, so
+/// the unsafe FFI dance lives here once instead of in each test.
+fn with_pager(offset: usize, limit: usize, check: impl FnOnce(*mut ffi::ResultProcessor)) {
+    // SAFETY: `RPPager_New` returns a freshly heap-allocated processor. We never move out of the
+    // returned pointer, and we hand it to `Free` exactly once below, satisfying its contract.
+    let pager = unsafe { RPPager_New(offset, limit) };
+    assert!(!pager.is_null(), "RPPager_New returned a null pointer");
+
+    check(pager);
+
+    // SAFETY: `pager` is the non-null pointer just returned by `RPPager_New` and has not been
+    // freed yet, so its VTable is initialised and readable.
+    let free_fn =
+        unsafe { (*pager).Free }.expect("Rust result processor must have a free function");
+
+    // SAFETY: `free_fn` is this processor's own destructor, and `pager` has not been freed yet, so
+    // calling it exactly once here is sound.
+    unsafe { free_fn(pager) };
+}
+
+#[test]
+fn rp_pager_new_returns_valid_pointer() {
+    // The non-null assertion lives in `with_pager`; reaching the closure at all proves it held.
+    with_pager(4, 10, |_| {});
+}
+
+#[test]
+fn rp_pager_new_sets_correct_type() {
+    with_pager(4, 10, |pager| {
+        // SAFETY: `pager` is a valid, live processor for the duration of this closure.
+        let ty = unsafe { (*pager).type_ };
+        assert_eq!(
+            ty,
+            ffi::ResultProcessorType_RP_PAGER_LIMITER,
+            "Pager should set type `ffi::ResultProcessorType_RP_PAGER_LIMITER`"
+        );
+    });
+}
+
+#[test]
+fn rp_pager_new_sets_vtable_entries() {
+    with_pager(0, 10, |pager| {
+        // SAFETY: `pager` is a valid, live processor for the duration of this closure.
+        let next = unsafe { (*pager).Next };
+        // SAFETY: as above.
+        let free = unsafe { (*pager).Free };
+        assert!(next.is_some(), "Next function should be set");
+        assert!(free.is_some(), "Free function should be set");
+    });
+}
+
+#[test]
+fn rp_pager_new_creates_unique_instances() {
+    with_pager(0, 10, |first| {
+        with_pager(0, 10, |second| {
+            assert_ne!(first, second, "Should create unique instances");
+        });
+    });
+}

--- a/src/redisearch_rs/headers/result_processor_ffi.h
+++ b/src/redisearch_rs/headers/result_processor_ffi.h
@@ -59,6 +59,17 @@ void CrashInRust(void);
  */
 ResultProcessor *RPCounter_New(void);
 
+/**
+ * Create a new heap-allocated `Pager` result processor. `offset` and `limit` are taken from the
+ * user's `LIMIT` clause.
+ *
+ * # Safety
+ *
+ * - The caller must never move the allocated result processor from its original allocation.
+ * - The caller must ensure to call the `Free` VTable function to properly destroy the type.
+ */
+ResultProcessor *RPPager_New(size_t offset, size_t limit);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/src/redisearch_rs/result_processor/Cargo.toml
+++ b/src/redisearch_rs/result_processor/Cargo.toml
@@ -15,7 +15,9 @@ search_result.workspace = true
 [dev-dependencies]
 # Crate required to invoke C symbols
 result_processor = { path = ".", features = ["unittest"] }
-redisearch_rs = { path = "../c_entrypoint/redisearch_rs" }
+# `mock_allocator` disables the `RedisAlloc` global allocator so the mock's
+# `RedisModule_Alloc` routes to the system allocator instead of recursing.
+redisearch_rs = { path = "../c_entrypoint/redisearch_rs", features = ["mock_allocator"] }
 redis_mock.workspace = true
 
 [build-dependencies]

--- a/src/redisearch_rs/result_processor/src/lib.rs
+++ b/src/redisearch_rs/result_processor/src/lib.rs
@@ -152,10 +152,10 @@ impl Context<'_> {
     /// Kept private: the narrow accessors below are the supported way for a processor to mutate
     /// pipeline-wide state, so a processor cannot reach the `rootProc`/`endProc` links through here.
     const fn parent_mut(&mut self) -> Option<&mut ffi::QueryProcessingCtx> {
-        // Safety: We trust that this result processor's pointer is valid.
+        // SAFETY: We trust that this result processor's pointer is valid.
         let parent = unsafe { self.ptr.as_ref() }.parent.cast_mut();
 
-        // Safety: the parent pointer, if non-null, is the `QueryProcessingCtx` the C pipeline
+        // SAFETY: the parent pointer, if non-null, is the `QueryProcessingCtx` the C pipeline
         // installed on this result processor; it outlives the processor, the chain runs on a single
         // thread, and the C pipeline mutates these same fields. Provenance comes from the raw
         // pointer C provided, so writing through it is sound. The returned borrow is tied to
@@ -181,8 +181,11 @@ impl Context<'_> {
     /// The number of results the pipeline is currently allowed to produce for this chunk
     /// (`QueryProcessingCtx::resultLimit`).
     ///
-    /// A processor may lower this to cap how much its *upstream* produces, but must restore the
-    /// original value before returning, so the limit looks untouched to everything downstream.
+    /// A processor may lower this to cap how much its *upstream* produces. If it goes on to yield a
+    /// result, it must restore the original value first, so the limit looks untouched to everything
+    /// downstream. A processor that instead ends iteration — returning EOF or an error — may leave
+    /// the lowered value in place, because nothing downstream will read it again;
+    /// [`crate::pager::Pager`] does exactly that.
     ///
     /// Returns `None` when the processor has no parent.
     pub fn result_limit(&mut self) -> Option<u32> {

--- a/src/redisearch_rs/result_processor/src/lib.rs
+++ b/src/redisearch_rs/result_processor/src/lib.rs
@@ -18,6 +18,7 @@
 //! the database indexes.
 
 pub mod counter;
+pub mod pager;
 /// Test harness (`Chain`, `from_iter`, `ResultRP`) for driving result processors in pure Rust.
 ///
 /// Exposed behind the `test-utils` feature so other crates (e.g. `redisearch_disk`) can build
@@ -146,6 +147,22 @@ impl Context<'_> {
         unsafe { query_processing_context_ptr.as_ref() }
     }
 
+    /// Returns the owning [`ffi::QueryProcessingCtx`] of the pipeline, mutably.
+    ///
+    /// Kept private: the narrow accessors below are the supported way for a processor to mutate
+    /// pipeline-wide state, so a processor cannot reach the `rootProc`/`endProc` links through here.
+    const fn parent_mut(&mut self) -> Option<&mut ffi::QueryProcessingCtx> {
+        // Safety: We trust that this result processor's pointer is valid.
+        let parent = unsafe { self.ptr.as_ref() }.parent.cast_mut();
+
+        // Safety: the parent pointer, if non-null, is the `QueryProcessingCtx` the C pipeline
+        // installed on this result processor; it outlives the processor, the chain runs on a single
+        // thread, and the C pipeline mutates these same fields. Provenance comes from the raw
+        // pointer C provided, so writing through it is sound. The returned borrow is tied to
+        // `&mut self`, so no two live `&mut` to the parent can be handed out at once.
+        unsafe { parent.as_mut() }
+    }
+
     /// Decrease the pipeline's running total result count by `n`.
     ///
     /// A result is counted (`totalResults++`) by the index processor as soon as it is produced
@@ -155,18 +172,29 @@ impl Context<'_> {
     /// document (non-resident key, or a docid that changed under the query).
     ///
     /// No-op when the processor has no parent.
-    pub fn subtract_total_results(&mut self, n: u32) {
-        // Safety: the parent pointer, if non-null, is the `QueryProcessingCtx` the C pipeline
-        // installed on this result processor; it outlives the processor, the chain runs on a single
-        // thread, and the C pipeline mutates this same field. Provenance comes from the raw pointer
-        // C provided, so writing through it is sound.
-        let parent = unsafe { self.ptr.as_ref() }.parent.cast_mut();
-        if !parent.is_null() {
-            // SAFETY: `parent` is non-null (checked above) and points to the `QueryProcessingCtx`
-            // the C pipeline installed on this processor; it outlives the processor and the chain
-            // runs on a single thread, so taking a transient `&mut` to update `totalResults` is sound.
-            let parent = unsafe { &mut *parent };
+    pub const fn subtract_total_results(&mut self, n: u32) {
+        if let Some(parent) = self.parent_mut() {
             parent.totalResults = parent.totalResults.saturating_sub(n);
+        }
+    }
+
+    /// The number of results the pipeline is currently allowed to produce for this chunk
+    /// (`QueryProcessingCtx::resultLimit`).
+    ///
+    /// A processor may lower this to cap how much its *upstream* produces, but must restore the
+    /// original value before returning, so the limit looks untouched to everything downstream.
+    ///
+    /// Returns `None` when the processor has no parent.
+    pub fn result_limit(&mut self) -> Option<u32> {
+        self.parent_mut().map(|parent| parent.resultLimit)
+    }
+
+    /// Set the pipeline's per-chunk result limit. See [`Self::result_limit`].
+    ///
+    /// No-op when the processor has no parent.
+    pub const fn set_result_limit(&mut self, limit: u32) {
+        if let Some(parent) = self.parent_mut() {
+            parent.resultLimit = limit;
         }
     }
 }

--- a/src/redisearch_rs/result_processor/src/pager.rs
+++ b/src/redisearch_rs/result_processor/src/pager.rs
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! The paging processor, implementing the `LIMIT <offset> <num>` clause.
+
+use crate::ResultProcessor;
+use search_result::SearchResult;
+
+// The C symbols this crate's tests need are linked and stubbed once, in `counter.rs`.
+
+/// Which half of the `LIMIT <offset> <num>` window the pager is currently working on.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum Phase {
+    /// Discarding the first `offset` results.
+    Skip,
+    /// Forwarding results until `remaining` hits zero.
+    Limit,
+}
+
+/// A processor yielding only the results in the `LIMIT <offset> <num>` window.
+///
+/// The sorter upstream builds a heap of `offset + num` results; the pager takes results
+/// `offset..offset + num` out of it. For `LIMIT 40 10` the sorter builds a heap of 50 and the pager
+/// discards the first 40, yielding just 10.
+///
+/// The two are separate processors so that the sorter's heap can later be cached and paged again
+/// without re-running the whole query.
+#[derive(Debug)]
+pub struct Pager {
+    /// How many results are still to be discarded before yielding any.
+    offset: u32,
+    /// How many results may still be yielded.
+    remaining: u32,
+    phase: Phase,
+}
+
+impl ResultProcessor for Pager {
+    const TYPE: ffi::ResultProcessorType = ffi::ResultProcessorType_RP_PAGER_LIMITER;
+
+    fn next(
+        &mut self,
+        mut cx: crate::Context,
+        res: &mut SearchResult<'_>,
+    ) -> Result<Option<()>, crate::Error> {
+        if self.phase == Phase::Skip {
+            // The skip phase may bail out early, in which case we stay in it and retry the
+            // remaining offset on the next call.
+            if self.skip(&mut cx, res)?.is_none() {
+                return Ok(None);
+            }
+            self.phase = Phase::Limit;
+        }
+
+        // If we've reached LIMIT:
+        if self.remaining == 0 {
+            return Ok(None);
+        }
+
+        let mut upstream = cx
+            .upstream()
+            .expect("There is no processor upstream of this pager.");
+
+        let result = upstream.next(res)?;
+        // Account for the result only if we got one.
+        if result.is_some() {
+            self.remaining -= 1;
+        }
+
+        Ok(result)
+    }
+}
+
+impl Pager {
+    /// Create a new pager. `offset` and `limit` are taken from the user's `LIMIT` clause.
+    pub const fn new(offset: u32, limit: u32) -> Self {
+        Self {
+            offset,
+            remaining: limit,
+            phase: Phase::Skip,
+        }
+    }
+
+    /// Pull and discard the first `offset` results.
+    ///
+    /// Returns `Ok(Some(()))` once the whole offset has been skipped, and `Ok(None)` if upstream hit
+    /// EOF first. In the `Ok(None)` and `Err(_)` cases `self.offset` still holds what is left to
+    /// skip, so the caller stays in [`Phase::Skip`].
+    fn skip(
+        &mut self,
+        cx: &mut crate::Context,
+        res: &mut SearchResult<'_>,
+    ) -> Result<Option<()>, crate::Error> {
+        // A pager is never called more than offset+limit times, because the whole pipeline —
+        // upstream and downstream — is limited to offset+limit.
+        let downstream_limit = cx
+            .result_limit()
+            .expect("This pager has no parent QueryProcessingCtx.");
+        let limit = self.remaining.min(downstream_limit);
+        // Matches the C pager's unsigned arithmetic. Both operands come from a user-supplied
+        // `LIMIT`, which the request parser caps well below `u32::MAX`.
+        cx.set_result_limit(self.offset.wrapping_add(limit));
+
+        while self.offset > 0 {
+            let mut upstream = cx
+                .upstream()
+                .expect("There is no processor upstream of this pager.");
+
+            if upstream.next(res)?.is_none() {
+                // Deliberately leaves `resultLimit` at the lowered value, as the C pager does: the
+                // query is over, so nothing downstream will read it again.
+                return Ok(None);
+            }
+
+            // Re-read rather than tracking the limit locally: the C pager decrements whatever the
+            // upstream left behind, so an upstream that lowers the limit itself is respected.
+            // Cannot underflow — the limit starts at `offset + limit` and is decremented at most
+            // `offset` times — but wrap like C rather than panicking if that ever stops holding.
+            if let Some(limit) = cx.result_limit() {
+                cx.set_result_limit(limit.wrapping_sub(1));
+            }
+            self.offset -= 1;
+
+            res.clear();
+        }
+
+        // Restore the limit, so that it seems untouched to the downstream.
+        cx.set_result_limit(downstream_limit);
+
+        Ok(Some(()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test_utils::{Chain, from_iter};
+    use std::iter;
+
+    /// Build a chain of `upstream_results` dummy results feeding a `Pager::new(offset, limit)`,
+    /// then drain the pager and return the number of results it yielded.
+    fn run(offset: u32, limit: u32, upstream_results: usize) -> (usize, Chain) {
+        let mut chain = Chain::new();
+        chain.append(from_iter(
+            iter::from_fn(|| Some(SearchResult::default())).take(upstream_results),
+        ));
+        chain.append(Pager::new(offset, limit));
+
+        let mut yielded = 0;
+        loop {
+            let (cx, rp) = chain.last_as_context_and_inner::<Pager>();
+            let mut res = SearchResult::default();
+            match rp.next(cx, &mut res) {
+                Ok(Some(())) => {
+                    yielded += 1;
+                    res.clear();
+                }
+                _ => break,
+            }
+        }
+
+        (yielded, chain)
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+    )]
+    fn yields_the_limit_window() {
+        // 10 upstream results, LIMIT 4 3 -> results 4, 5, 6.
+        let (yielded, _chain) = run(4, 3, 10);
+        assert_eq!(yielded, 3);
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+    )]
+    fn zero_offset_yields_from_the_start() {
+        let (yielded, _chain) = run(0, 3, 10);
+        assert_eq!(yielded, 3);
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+    )]
+    fn zero_limit_yields_nothing() {
+        let (yielded, _chain) = run(0, 0, 10);
+        assert_eq!(yielded, 0);
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+    )]
+    fn stops_at_upstream_eof_inside_the_window() {
+        // Only 6 results upstream but the window asks for 4..14, so we get 6 - 4 = 2.
+        let (yielded, _chain) = run(4, 10, 6);
+        assert_eq!(yielded, 2);
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+    )]
+    fn offset_past_upstream_eof_yields_nothing() {
+        let (yielded, _chain) = run(20, 10, 6);
+        assert_eq!(yielded, 0);
+    }
+
+    /// The skip phase lowers `resultLimit` to cap its upstream, then has to put it back so the
+    /// downstream sees the value it set.
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+    )]
+    fn restores_the_downstream_result_limit() {
+        let mut chain = Chain::new();
+        chain.append(from_iter(
+            iter::from_fn(|| Some(SearchResult::default())).take(10),
+        ));
+        chain.append(Pager::new(4, 3));
+        chain.set_result_limit(7);
+
+        let (cx, rp) = chain.last_as_context_and_inner::<Pager>();
+        let mut res = SearchResult::default();
+        assert_eq!(rp.next(cx, &mut res), Ok(Some(())));
+        res.clear();
+
+        assert_eq!(chain.result_limit(), 7);
+    }
+
+    /// The pager must not re-run its skip phase once it has been completed.
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+    )]
+    fn skips_only_once() {
+        let mut chain = Chain::new();
+        chain.append(from_iter(
+            iter::from_fn(|| Some(SearchResult::default())).take(10),
+        ));
+        chain.append(Pager::new(4, 3));
+
+        for _ in 0..3 {
+            let (cx, rp) = chain.last_as_context_and_inner::<Pager>();
+            let mut res = SearchResult::default();
+            assert_eq!(rp.next(cx, &mut res), Ok(Some(())));
+            res.clear();
+        }
+
+        let (cx, rp) = chain.last_as_context_and_inner::<Pager>();
+        assert_eq!(rp.offset, 0);
+        assert_eq!(rp.remaining, 0);
+        assert_eq!(rp.next(cx, &mut SearchResult::default()), Ok(None));
+    }
+}

--- a/src/redisearch_rs/result_processor/src/test_utils.rs
+++ b/src/redisearch_rs/result_processor/src/test_utils.rs
@@ -168,6 +168,19 @@ impl Chain {
             .totalResults = n;
     }
 
+    /// The pipeline's current per-chunk `resultLimit` (from [`ffi::QueryProcessingCtx`]).
+    ///
+    /// Used in tests to verify that a processor which lowers the limit to cap its upstream
+    /// restores it before returning.
+    pub fn result_limit(&self) -> u32 {
+        self.query_processing_context.resultLimit
+    }
+
+    /// Set the pipeline's per-chunk `resultLimit` directly (test-only).
+    pub fn set_result_limit(&mut self, n: u32) {
+        self.query_processing_context.as_mut().get_mut().resultLimit = n;
+    }
+
     /// Return a [`Context`] and mutable reference to the inner [`ResultProcessor`] implementation
     /// from the last result processor in the chain.
     ///

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -886,69 +886,8 @@ ResultProcessor *RPSorter_NewByScore(size_t maxresults, const RLookupKey *scoreT
  * without re-executing the entire query
  *******************************************************************************************************************/
 
-typedef struct {
-  ResultProcessor base;
-  uint32_t offset;
-  uint32_t remaining;
-} RPPager;
-
-static int rppagerNext_Limit(ResultProcessor *base, SearchResult *r) {
-  RPPager *self = (RPPager *)base;
-
-  // If we've reached LIMIT:
-  if (!self->remaining) {
-    return RS_RESULT_EOF;
-  }
-
-  int ret = base->upstream->Next(base->upstream, r);
-  // Account for the result only if we got one.
-  if (ret == RS_RESULT_OK) self->remaining--;
-  return ret;
-}
-
-static int rppagerNext_Skip(ResultProcessor *base, SearchResult *r) {
-  RPPager *self = (RPPager *)base;
-
-  // Currently a pager is never called more than offset+limit times.
-  // We limit the entire pipeline to offset+limit (upstream and downstream).
-  uint32_t limit = MIN(self->remaining, base->parent->resultLimit);
-  // Save the previous limit, so that it will seem untouched to the downstream
-  uint32_t downstreamLimit = base->parent->resultLimit;
-  base->parent->resultLimit = self->offset + limit;
-
-  // If we've not reached the offset
-  while (self->offset) {
-    int rc = base->upstream->Next(base->upstream, r);
-    if (rc != RS_RESULT_OK) {
-      return rc;
-    }
-    base->parent->resultLimit--;
-    self->offset--;
-    SearchResult_Clear(r);
-  }
-
-  base->parent->resultLimit = downstreamLimit;
-
-  base->Next = rppagerNext_Limit; // switch to second phase
-  return base->Next(base, r);
-}
-
-static void rppagerFree(ResultProcessor *base) {
-  rm_free(base);
-}
-
-/* Create a new pager. The offset and limit are taken from the user request */
-ResultProcessor *RPPager_New(size_t offset, size_t limit) {
-  RPPager *ret = rm_calloc(1, sizeof(*ret));
-  ret->offset = offset;
-  ret->remaining = limit;
-
-  ret->base.type = RP_PAGER_LIMITER;
-  ret->base.Next = rppagerNext_Skip;
-  ret->base.Free = rppagerFree;
-
-  return &ret->base;
-}
+/* Implemented in Rust; see `RPPager_New` in `result_processor_ffi.h` and the `pager` module of the
+ * `result_processor` crate. */
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -189,8 +189,6 @@ ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys
  */
 ResultProcessor *RPSorter_NewByScore(size_t maxresults, const RLookupKey *scoreTieBreakKey);
 
-ResultProcessor *RPPager_New(size_t offset, size_t limit);
-
 /*******************************************************************************************************************
  *  Loading Processor
  *


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `RPPager` — the result processor behind `LIMIT <offset> <num>` — is still in C. It is the next self-contained processor after the already-ported `Counter`, and it carries a pattern worth retiring: it switches between its two phases by overwriting its own `Next` vtable pointer mid-flight, so the state machine is invisible at the type level.
2. **Change:** Port it to the `result_processor` crate as `Pager`, with the phase switch expressed as an enum. `RPPager_New` keeps its exact signature, so the three call sites in `pipeline_construction.c` are untouched and the `RP_PAGER_LIMITER` tag that `profile.c` reads is unchanged.
3. **Outcome:** Internal-only — no user-visible change, `LIMIT` behaves exactly as before. It advances the result-processor migration (MOD-9884) and adds unit coverage for paging edge cases that had none: offset past EOF, EOF inside the window, zero limit, and that the pipeline's `resultLimit` is restored for the downstream.

Two C behaviours are replicated deliberately rather than "fixed", both commented where they happen — `offset + limit` wraps like the original unsigned arithmetic, and an upstream that stops early during the skip phase leaves `resultLimit` at the lowered value, because the C pager never restored it on that path either.

The first commit is a separable pre-existing fix. `result_processor` and `result_processor_ffi` were the only `redis_mock` consumers not enabling `redisearch_rs/mock_allocator`, so the global allocator stayed `RedisAlloc` and routed every allocation through `RedisModule_Alloc` — the symbol the mock defines in terms of `alloc::alloc::alloc`. Mutual recursion with no base case: every test binary in both crates overflowed its stack inside `std::rt::init` and died with SIGSEGV before reaching `main`. Reproduced on a clean tree to confirm it predates this work. The fix matches the fifteen other crates that already pair the two, and is what makes the existing `Counter` tests run for the first time.

#### Which additional issues this PR fixes

1. MOD-17585
2. N/A

#### Main objects this PR modified

1. `result_processor` crate — new `pager` module (`Pager`, `Phase`), 7 unit tests over the existing `Chain` harness.
2. `result_processor::Context` — narrow `result_limit`/`set_result_limit` accessors over a new private `parent_mut`; `subtract_total_results` refactored onto the same helper. `parent_mut` stays private so a processor still cannot reach `rootProc`/`endProc`.
3. `result_processor_ffi` — `RPPager_New` entry point, regenerated into `result_processor_ffi.h` with a byte-identical signature.
4. `src/result_processor.c` / `.h` — C pager implementation and declaration removed.
5. Both crates' `Cargo.toml` — `mock_allocator` dev-dependency feature (the allocator-recursion fix above).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
