### PR TITLE
Refactor `CTrieRef` into `TermsTrie` and `SuffixTrie`

### DIFF
--- a/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
@@ -13,8 +13,9 @@
 
 use std::{
     ffi::{c_char, c_int, c_void},
+    marker::PhantomData,
     ops::ControlFlow,
-    ptr::NonNull,
+    ptr,
 };
 
 use ffi::{
@@ -22,7 +23,7 @@ use ffi::{
     SuffixType_SUFFIX_TYPE_WILDCARD,
 };
 
-/// Which side(s) of a term a [`CTrieRef::iterate_suffix`] walk anchors on.
+/// Which side(s) of a term a [`SuffixTrie::iterate_contains`] walk anchors on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SuffixMode {
     /// Match terms that end with the pattern (`*llo`).
@@ -55,7 +56,7 @@ impl From<SuffixMode> for SuffixType {
 ///   case `runes` is ignored).
 ///
 /// Both hold when the trie invokes this through the function pointer installed
-/// by [`CTrieRef::iterate_contains`] or [`CTrieRef::iterate_wildcard`].
+/// by [`TermsTrie::iterate_contains`] or [`TermsTrie::iterate_wildcard`].
 unsafe extern "C" fn range_trampoline<F>(
     runes: *const ffi::rune,
     len: usize,
@@ -97,8 +98,8 @@ where
 /// - `s` must point to `len` valid bytes, or `len` must be `0`.
 ///
 /// Both hold when the suffix trie invokes this through the function pointer
-/// installed by [`CTrieRef::iterate_suffix`] or
-/// [`CTrieRef::iterate_suffix_wildcard`].
+/// installed by [`SuffixTrie::iterate_contains`] or
+/// [`SuffixTrie::iterate_wildcard`].
 unsafe extern "C" fn suffix_trampoline<F>(
     s: *const c_char,
     len: usize,
@@ -135,8 +136,10 @@ where
 /// type owns that layout instead of leaving each call site to remember it.
 #[derive(Debug)]
 pub struct LoweredPattern {
-    /// The content runes followed by one zero sentinel, so `len()` is
+    /// The content runes followed by one zero sentinel, so [`len`] is
     /// `runes.len() - 1`.
+    ///
+    /// [`len`]: LoweredPattern::len
     runes: Vec<ffi::rune>,
 }
 
@@ -178,7 +181,7 @@ impl LoweredPattern {
     }
 }
 
-/// Outcome of [`CTrieRef::iterate_suffix_wildcard`].
+/// Outcome of [`SuffixTrie::iterate_wildcard`].
 ///
 /// Neither variant is a failure: declining a pattern the suffix trie cannot
 /// anchor on is a routine handover to the primary terms trie. The distinction is
@@ -195,14 +198,14 @@ pub enum SuffixWalk {
     /// The pattern held no literal run to anchor on, so nothing was visited.
     ///
     /// The pattern comes back ready for a fallback walk over the primary terms
-    /// trie with [`iterate_wildcard`](CTrieRef::iterate_wildcard).
+    /// trie with [`TermsTrie::iterate_wildcard`].
     NoAnchor(LoweredPattern),
 }
 
-/// Result of a decrement operation on the C Trie.
+/// Outcome of [`TermsTrie::decrement_num_docs`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::FromRepr)]
 #[repr(u32)]
-pub enum CTrieDecrResult {
+pub enum TermsTrieDecrResult {
     /// Term not found in the trie.
     NotFound = 0,
     /// numDocs decremented, term still has documents.
@@ -213,28 +216,51 @@ pub enum CTrieDecrResult {
     Unsupported = 3,
 }
 
-/// Wrapper around the C Trie pointer for safe FFI operations.
-///
-/// This struct does NOT own the C Trie - it's just a wrapper for
-/// calling FFI functions. The caller is responsible for managing
-/// the lifetime of the C Trie.
+/// A safe wrapper around a C [`ffi::Trie`] holding an index's terms.
 #[derive(Debug)]
-pub struct CTrieRef {
-    ptr: *mut ffi::Trie,
+#[repr(transparent)]
+pub struct TermsTrie {
+    inner: ffi::Trie,
+    // `ffi::Trie` is an opaque ZST, which would make `TermsTrie` `Send + Sync` by
+    // default. The C trie is neither: it is mutated under the owning spec's lock.
+    // This `PhantomData` removes the auto traits.
+    _phantom: PhantomData<*mut ffi::Trie>,
 }
 
-impl CTrieRef {
-    /// Create a new wrapper around an existing C Trie pointer.
+impl TermsTrie {
+    /// Borrow an existing C Terms Trie pointer as a shared reference.
     ///
     /// # Safety
     ///
-    /// The caller must ensure that:
-    /// - `ptr` is a valid pointer to a C `Trie` struct
-    /// - The C Trie outlives this wrapper
-    /// - No other code frees the C Trie while this wrapper exists
-    pub unsafe fn from_raw(ptr: *mut ffi::Trie) -> Self {
+    /// 1. `ptr` must be a valid, non-null pointer to an [`ffi::Trie`], must
+    ///    remain live for `'a`, and must not be mutated for the duration.
+    pub const unsafe fn from_raw<'a>(ptr: *const ffi::Trie) -> &'a Self {
         debug_assert!(!ptr.is_null(), "C Trie pointer cannot be null");
-        Self { ptr }
+        // SAFETY: guaranteed by caller (1.)
+        unsafe { &*ptr.cast::<Self>() }
+    }
+
+    /// Borrow an existing C Terms Trie pointer as an exclusive reference.
+    ///
+    /// # Safety
+    ///
+    /// 1. `ptr` must be a valid, non-null pointer to an [`ffi::Trie`], must
+    ///    remain live for `'a`, and must have no other aliasing references for
+    ///    the duration.
+    pub const unsafe fn from_raw_mut<'a>(ptr: *mut ffi::Trie) -> &'a mut Self {
+        debug_assert!(!ptr.is_null(), "C Trie pointer cannot be null");
+        // SAFETY: guaranteed by caller (1.)
+        unsafe { &mut *ptr.cast::<Self>() }
+    }
+
+    /// Return a raw const pointer to the underlying [`ffi::Trie`].
+    pub const fn as_ptr(&self) -> *const ffi::Trie {
+        ptr::from_ref(self).cast::<ffi::Trie>()
+    }
+
+    /// Return a raw mutable pointer to the underlying [`ffi::Trie`].
+    pub const fn as_mut_ptr(&mut self) -> *mut ffi::Trie {
+        ptr::from_mut(self).cast::<ffi::Trie>()
     }
 
     /// Decrement the numDocs count for a term in the C Trie.
@@ -246,30 +272,22 @@ impl CTrieRef {
     ///
     /// # Returns
     ///
-    /// * `CTrieDecrResult::NotFound` - Term not found in trie
-    /// * `CTrieDecrResult::Updated` - numDocs decremented, still > 0
-    /// * `CTrieDecrResult::Deleted` - numDocs reached 0, term deleted
-    /// * `CTrieDecrResult::Unsupported` - term too long/unconvertible; never inserted
-    ///
-    /// # Safety
-    ///
-    /// This function is safe to call if the `CTrieRef` was created safely.
-    /// The C function handles UTF-8 to rune conversion internally.
-    pub fn decrement_num_docs(&mut self, term: &[u8], delta: u64) -> CTrieDecrResult {
-        // SAFETY: We're calling the C function with valid parameters.
-        // The term is passed as a UTF-8 byte slice, and the C function
-        // handles the conversion to runes internally via runeBufFill.
-        // The C function mutates the Trie by decrementing numDocs and
-        // potentially deleting nodes.
+    /// * `TermsTrieDecrResult::NotFound` - Term not found in trie
+    /// * `TermsTrieDecrResult::Updated` - numDocs decremented, still > 0
+    /// * `TermsTrieDecrResult::Deleted` - numDocs reached 0, term deleted
+    /// * `TermsTrieDecrResult::Unsupported` - term too long/unconvertible; never inserted
+    pub fn decrement_num_docs(&mut self, term: &[u8], delta: u64) -> TermsTrieDecrResult {
+        // SAFETY: `self` borrows a valid `ffi::Trie`, and `term`/`term.len()`
+        // describe a readable byte slice for the duration of the call.
         let result = unsafe {
             ffi::Trie_DecrementNumDocs(
-                self.ptr,
+                self.as_mut_ptr(),
                 term.as_ptr() as *const c_char,
                 term.len(),
                 delta as usize,
             )
         };
-        CTrieDecrResult::from_repr(result).unwrap_or(CTrieDecrResult::NotFound)
+        TermsTrieDecrResult::from_repr(result).unwrap_or(TermsTrieDecrResult::NotFound)
     }
 
     /// Number of documents indexed under `term`, or `0` if the term is absent
@@ -282,10 +300,6 @@ impl CTrieRef {
     /// Returns `0` for input that cannot correspond to a stored term — invalid
     /// UTF-8, or a term longer than the trie can hold — since such a term can
     /// never have been inserted.
-    ///
-    /// # Safety
-    ///
-    /// This function is safe to call if the `CTrieRef` was created safely.
     pub fn num_docs(&self, term: &[u8]) -> usize {
         // Terms longer than the trie can store are never present, so report zero
         // without a lookup (mirrors the C insertion/decrement guards). This also
@@ -317,12 +331,13 @@ impl CTrieRef {
                 runes.len(),
             )
         };
-        // SAFETY: `self.ptr` is a valid `Trie` (`CTrieRef` invariant); `runes`/
-        // `rlen` describe a valid rune slice, and `rlen <= term.len()` fits
-        // `t_len` (guarded above).
+        // SAFETY: `self` borrows a valid `ffi::Trie`; `runes`/`rlen` describe a
+        // valid rune slice, and `rlen <= term.len()` fits `t_len` (guarded above).
+        // `Trie_GetNode` takes a non-const `Trie *` but only traverses it, so
+        // nothing is written through the shared pointer.
         let node = unsafe {
             ffi::Trie_GetNode(
-                self.ptr,
+                self.as_ptr().cast_mut(),
                 runes.as_ptr(),
                 rlen as ffi::t_len,
                 true,
@@ -357,25 +372,12 @@ impl CTrieRef {
     ///
     /// `timeout` bounds the walk: `Some(deadline)` aborts it once the deadline
     /// passes, while `None` runs it to completion with no deadline.
-    ///
-    /// # Safety
-    ///
-    /// - A `Some` `timeout` must point to a valid [`timespec`](ffi::timespec)
-    ///   that stays valid, and is not mutated (including by another thread), for
-    ///   the duration of the call. The walk reads `*timeout` unsynchronized, so a
-    ///   concurrent write to the pointee is a data race.
-    /// - The wrapped trie must not be mutated, freed, or iterated again for the
-    ///   duration of the call — including from within `callback`. The walk caches
-    ///   raw node and child pointers and reuses them after each callback
-    ///   invocation, so mutating the trie (e.g. deleting a term, or decrementing
-    ///   one to zero, through another handle) can free a node mid-walk and leave
-    ///   those pointers dangling.
-    pub unsafe fn iterate_contains<F>(
+    pub fn iterate_contains<F>(
         &self,
         pattern: &[ffi::rune],
         prefix: bool,
         suffix: bool,
-        timeout: Option<NonNull<ffi::timespec>>,
+        mut timeout: Option<ffi::timespec>,
         mut callback: F,
     ) where
         F: FnMut(&[ffi::rune], usize) -> ControlFlow<()>,
@@ -393,17 +395,17 @@ impl CTrieRef {
         // The iterator only honours a deadline when timeout checks are enabled,
         // and treats a null deadline as already-expired, so the two must move
         // together: a deadline enables the checks, its absence disables them.
-        let (timeout, skip_timeout_checks) = match timeout {
-            Some(deadline) => (deadline.as_ptr(), false),
-            None => (std::ptr::null_mut(), true),
+        let (timeout, skip_timeout_checks) = match &mut timeout {
+            Some(timeout) => (ptr::from_mut(timeout), false),
+            None => (ptr::null_mut(), true),
         };
-        // SAFETY: `self.ptr` is a valid `Trie` (`CTrieRef` invariant); `pattern`
-        // points to `pattern.len()` runes; `&mut callback` stays alive for the
-        // whole call, so the `ctx` the trampoline reconstitutes is valid; and
-        // `timeout` is null or the valid pointer the caller supplied.
+        // SAFETY: `self` borrows a valid `ffi::Trie`; `pattern` points to
+        // `pattern.len()` runes; `&mut callback` stays alive for the whole
+        // call, so the `ctx` the trampoline reconstitutes is valid; and
+        // `timeout` is null or points to a valid `timeout` argument.
         unsafe {
             ffi::Trie_IterateContains(
-                self.ptr,
+                self.as_ptr(),
                 pattern.as_ptr(),
                 pattern.len() as c_int,
                 prefix,
@@ -415,32 +417,72 @@ impl CTrieRef {
             );
         }
     }
+}
+
+/// A safe wrapper around a C [`ffi::Trie`] used as a *suffix* index: its keys
+/// are the suffixes of the indexed terms, and each node's payload lists the
+/// terms carrying that suffix.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct SuffixTrie {
+    inner: ffi::Trie,
+    // `ffi::Trie` is an opaque ZST, which would make `SuffixTrie` `Send + Sync`
+    // by default. The C trie is neither: it is mutated under the owning spec's lock.
+    // This `PhantomData` removes the auto traits.
+    _phantom: PhantomData<*mut ffi::Trie>,
+}
+
+impl SuffixTrie {
+    /// Borrow an existing C Suffix Trie pointer as a shared reference.
+    ///
+    /// # Safety
+    ///
+    /// 1. `ptr` must be a valid, non-null pointer to an [`ffi::Trie`], must
+    ///    remain live for `'a`, and must not be mutated for the duration.
+    /// 2. Every node payload in that trie must be a valid `suffixData`.
+    pub const unsafe fn from_raw<'a>(ptr: *const ffi::Trie) -> &'a Self {
+        debug_assert!(!ptr.is_null(), "C Suffix Trie pointer cannot be null");
+        // SAFETY: guaranteed by caller (1., 2.)
+        unsafe { &*ptr.cast::<Self>() }
+    }
+
+    /// Borrow an existing C Suffix Trie pointer as an exclusive reference.
+    ///
+    /// # Safety
+    ///
+    /// 1. `ptr` must be a valid, non-null pointer to an [`ffi::Trie`], must
+    ///    remain live for `'a`, and must have no other aliasing references for
+    ///    the duration.
+    /// 2. Every node payload in that trie must be a valid `suffixData`.
+    /// 3. The trie's free callback must point to [`ffi::suffixTrie_freeCallback`].
+    pub const unsafe fn from_raw_mut<'a>(ptr: *mut ffi::Trie) -> &'a mut Self {
+        debug_assert!(!ptr.is_null(), "C Suffix Trie pointer cannot be null");
+        // SAFETY: guaranteed by caller (1., 2., 3.)
+        unsafe { &mut *ptr.cast::<Self>() }
+    }
+
+    /// Return a raw const pointer to the underlying [`ffi::Trie`].
+    pub const fn as_ptr(&self) -> *const ffi::Trie {
+        ptr::from_ref(self).cast::<ffi::Trie>()
+    }
+
+    /// Return a raw mutable pointer to the underlying [`ffi::Trie`].
+    pub const fn as_mut_ptr(&mut self) -> *mut ffi::Trie {
+        ptr::from_mut(self).cast::<ffi::Trie>()
+    }
 
     /// Visit every term matched by `pattern` through the *suffix* trie, which
     /// indexes terms by their suffixes to answer contains/suffix queries without
     /// a full scan.
     ///
-    /// `self` must wrap a suffix trie, not the primary terms trie. `pattern` is
-    /// the rune key and `mode` selects a suffix or contains match. Each matching
-    /// term is delivered to `callback` as a UTF-8 byte string — already converted
-    /// from runes by the suffix trie — with no document count; the callback
-    /// returns [`ControlFlow`] to continue or stop.
+    /// `pattern` is the rune key and `mode` selects a suffix or contains match.
+    /// Each matching term is delivered to `callback` as a UTF-8 byte string —
+    /// already converted from runes by the suffix trie — with no document count;
+    /// the callback returns [`ControlFlow`] to continue or stop.
     ///
     /// The suffix-trie walk is recursive and does not check for a timeout, so
     /// this method takes no deadline. An empty `pattern` visits nothing.
-    ///
-    /// # Safety
-    ///
-    /// - `self` must wrap a suffix trie, whose nodes carry a suffix-data payload.
-    ///   The iterator reinterprets each visited node's payload as that type and
-    ///   dereferences it, so passing the primary terms trie (or any trie with a
-    ///   different payload) is type confusion and undefined behavior.
-    /// - The wrapped trie must not be mutated, freed, or iterated again for the
-    ///   duration of the call — including from within `callback`. The walk caches
-    ///   raw node and child pointers and reuses them after each callback
-    ///   invocation, so mutating the trie through another handle can free a node
-    ///   mid-walk and leave those pointers dangling.
-    pub unsafe fn iterate_suffix<F>(&self, pattern: &[ffi::rune], mode: SuffixMode, mut callback: F)
+    pub fn iterate_contains<F>(&self, pattern: &[ffi::rune], mode: SuffixMode, mut callback: F)
     where
         F: FnMut(&[u8]) -> ControlFlow<()>,
     {
@@ -456,7 +498,9 @@ impl CTrieRef {
             return;
         }
         let mut suffix_ctx = SuffixCtx {
-            trie: self.ptr,
+            // `SuffixCtx` types this field `*mut Trie`, but the walk only reads
+            // the trie, so nothing is written through the shared pointer.
+            trie: self.as_ptr().cast_mut(),
             rune: pattern.as_ptr().cast_mut(),
             runelen: pattern.len(),
             type_: mode.into(),
@@ -467,14 +511,16 @@ impl CTrieRef {
             skipTimeoutChecks: false,
         };
         // SAFETY: every `suffix_ctx` field is initialised above with a valid
-        // value — `self.ptr` is a valid suffix `Trie` (caller contract), the
-        // pattern pointer/len describe a live rune slice, and the callback
-        // closure outlives the call.
+        // value, `self` borrows a valid `ffi::Trie` whose payloads the walk may
+        // cast to `suffixData`, the pattern pointer/len describe a live rune
+        // slice, and the callback closure outlives the call.
         unsafe {
             ffi::Suffix_IterateContains(std::ptr::from_mut(&mut suffix_ctx));
         }
     }
+}
 
+impl TermsTrie {
     /// Visit every term matching a wildcard `pattern` — one admitting `*` (any
     /// run of characters) and `?` (exactly one) — by walking the primary terms
     /// trie.
@@ -496,22 +542,10 @@ impl CTrieRef {
     ///
     /// [`Break`]: ControlFlow::Break
     ///
-    /// # Safety
-    ///
-    /// - A `Some` `timeout` must point to a valid [`timespec`](ffi::timespec)
-    ///   that stays valid, and is not mutated (including by another thread), for
-    ///   the duration of the call. The walk reads `*timeout` unsynchronized, so a
-    ///   concurrent write to the pointee is a data race.
-    /// - The wrapped trie must not be mutated, freed, or iterated again for the
-    ///   duration of the call — including from within `callback`. The walk caches
-    ///   raw node and child pointers and reuses them after each callback
-    ///   invocation, so mutating the trie (e.g. deleting a term, or decrementing
-    ///   one to zero, through another handle) can free a node mid-walk and leave
-    ///   those pointers dangling.
-    pub unsafe fn iterate_wildcard<F>(
+    pub fn iterate_wildcard<F>(
         &self,
         pattern: &LoweredPattern,
-        timeout: Option<NonNull<ffi::timespec>>,
+        mut timeout: Option<ffi::timespec>,
         mut callback: F,
     ) where
         F: FnMut(&[ffi::rune], usize) -> ControlFlow<()>,
@@ -525,18 +559,18 @@ impl CTrieRef {
         // As in `iterate_contains`: the walk only honours a deadline when timeout
         // checks are enabled and treats a null deadline as already-expired, so the
         // two must move together.
-        let (timeout, skip_timeout_checks) = match timeout {
-            Some(deadline) => (deadline.as_ptr(), false),
-            None => (std::ptr::null_mut(), true),
+        let (timeout, skip_timeout_checks) = match &mut timeout {
+            Some(timeout) => (ptr::from_mut(timeout), false),
+            None => (ptr::null_mut(), true),
         };
-        // SAFETY: `self.ptr` is a valid `Trie` (`CTrieRef` invariant); `pattern`
-        // addresses its content runes followed by the readable zero sentinel the
-        // matcher requires (`LoweredPattern` invariant); `&mut callback` stays
-        // alive for the whole call, so the `ctx` the trampoline reconstitutes is
-        // valid; and `timeout` is null or the valid pointer the caller supplied.
+        // SAFETY: `self` borrows a valid `ffi::Trie`; `pattern` addresses its
+        // content runes followed by the readable zero sentinel the matcher
+        // requires (`LoweredPattern` invariant); `&mut callback` stays alive for
+        // the whole call, so the `ctx` the trampoline reconstitutes is valid; and
+        // `timeout` is null or points to a valid `timeout` argument.
         unsafe {
             ffi::Trie_IterateWildcard(
-                self.ptr,
+                self.as_ptr(),
                 pattern.runes.as_ptr(),
                 pattern.len() as c_int,
                 Some(range_trampoline::<F>),
@@ -546,63 +580,51 @@ impl CTrieRef {
             );
         }
     }
+}
 
+impl SuffixTrie {
     /// Visit every term matching a wildcard `pattern` through the *suffix* trie,
     /// which indexes terms by their suffixes so a pattern that is not
     /// front-anchored can be answered without a full scan.
     ///
-    /// `self` must wrap a suffix trie, not the primary terms trie. Each matching
-    /// term is delivered to `callback` as a byte string — already converted from
-    /// runes by the suffix trie — with no document count; the callback returns
-    /// [`ControlFlow`] to continue or stop. A term reachable under several
-    /// matching suffix keys is delivered once per key, so `callback` may see
-    /// duplicates.
+    /// Each matching term is delivered to `callback` as a byte string — already
+    /// converted from runes by the suffix trie — with no document count; the
+    /// callback returns [`ControlFlow`] to continue or stop. A term reachable
+    /// under several matching suffix keys is delivered once per key, so
+    /// `callback` may see duplicates.
     ///
     /// A [`Break`](ControlFlow::Break) carries the same weak guarantee as in
-    /// [`iterate_wildcard`](Self::iterate_wildcard): it is honoured outright only
-    /// when the anchor token the walk settles on is `*`-terminated, and otherwise
-    /// ends just the current suffix key's terms. Which token is chosen is not the
-    /// caller's to predict, so treat the weaker guarantee as the contract.
+    /// [`TermsTrie::iterate_wildcard`]: it is honoured outright only when the
+    /// anchor token the walk settles on is `*`-terminated, and otherwise ends just
+    /// the current suffix key's terms. Which token is chosen is not the caller's
+    /// to predict, so treat the weaker guarantee as the contract.
     ///
     /// The suffix trie can only answer a pattern that contains a literal run to
     /// anchor on. When it does not, nothing is visited and the pattern is handed
     /// back as [`SuffixWalk::NoAnchor`] so the caller can fall back to
-    /// [`iterate_wildcard`](Self::iterate_wildcard) over the primary terms trie.
+    /// [`TermsTrie::iterate_wildcard`].
     ///
     /// `pattern` is consumed so that a declined walk can hand it back through
     /// [`SuffixWalk::NoAnchor`] for the fallback.
     ///
-    /// `timeout` bounds the walk, as for [`iterate_wildcard`](Self::iterate_wildcard).
-    ///
-    /// # Safety
-    ///
-    /// - `self` must wrap a suffix trie, whose nodes carry a suffix-data payload.
-    ///   The iterator reinterprets each visited node's payload as that type and
-    ///   dereferences it, so passing the primary terms trie (or any trie with a
-    ///   different payload) is type confusion and undefined behavior.
-    /// - A `Some` `timeout` must satisfy the same validity and no-concurrent-write
-    ///   requirement as in [`iterate_wildcard`](Self::iterate_wildcard).
-    /// - The wrapped trie must not be mutated, freed, or iterated again for the
-    ///   duration of the call — including from within `callback` — for the same
-    ///   dangling-pointer reason as [`iterate_wildcard`](Self::iterate_wildcard).
-    ///   A `callback` that consults the *primary* trie is fine; it is a separate
-    ///   trie.
-    pub unsafe fn iterate_suffix_wildcard<F>(
+    /// `timeout` bounds the walk, as for [`TermsTrie::iterate_wildcard`].
+    pub fn iterate_wildcard<F>(
         &self,
         mut pattern: LoweredPattern,
-        timeout: Option<NonNull<ffi::timespec>>,
+        mut timeout: Option<ffi::timespec>,
         mut callback: F,
     ) -> SuffixWalk
     where
         F: FnMut(&[u8]) -> ControlFlow<()>,
     {
-        let (timeout_ptr, skip_timeout_checks) = match timeout {
-            Some(deadline) => (deadline.as_ptr(), false),
-            None => (std::ptr::null_mut(), true),
+        let (timeout_ptr, skip_timeout_checks) = match &mut timeout {
+            Some(timeout) => (ptr::from_mut(timeout), false),
+            None => (ptr::null_mut(), true),
         };
 
         let mut suffix_ctx = SuffixCtx {
-            trie: self.ptr,
+            // As in `iterate_contains`: typed `*mut Trie`, only read.
+            trie: self.as_ptr().cast_mut(),
             rune: pattern.runes.as_mut_ptr(),
             runelen: pattern.len(),
             // The wildcard walk never reads this back, but a stale `Contains`
@@ -614,22 +636,16 @@ impl CTrieRef {
             skipTimeoutChecks: skip_timeout_checks,
         };
         // SAFETY: every `suffix_ctx` field is initialised above with a valid
-        // value — `self.ptr` is a valid suffix `Trie` (caller contract), the rune
-        // pointer describes a live pattern followed by the sentinel the walk
-        // reads (`LoweredPattern` invariant), the callback closure outlives the
-        // call, and `timeout` is null or the valid pointer the caller supplied.
+        // value — `self` borrows a valid `ffi::Trie` whose payloads the walk may
+        // cast to `suffixData`, the rune pointer describes a live pattern
+        // followed by the sentinel the walk reads (`LoweredPattern` invariant),
+        // the callback closure outlives the call, and `timeout` is null or
+        // points to a valid `timeout` argument.
         let used = unsafe { ffi::Suffix_IterateWildcard(std::ptr::from_mut(&mut suffix_ctx)) };
         if used == 0 {
             SuffixWalk::NoAnchor(pattern)
         } else {
             SuffixWalk::Walked
         }
-    }
-
-    /// Get the raw pointer to the C Trie.
-    ///
-    /// This is useful when you need to pass the pointer to other C functions.
-    pub const fn as_ptr(&self) -> *mut ffi::Trie {
-        self.ptr
     }
 }

--- a/src/redisearch_rs/c_wrappers/c_trie/tests/iterate.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/tests/iterate.rs
@@ -7,10 +7,11 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Integration tests for the trie-iteration API of [`CTrieRef`].
+//! Integration tests for the trie-iteration APIs of [`TermsTrie`] and
+//! [`SuffixTrie`].
 //!
 //! Each test builds a live C trie through the linked static library, wraps it in
-//! a [`CTrieRef`], and exercises one of the iteration methods.
+//! a [`TermsTrie`] or [`SuffixTrie`], and exercises one of the iteration methods.
 
 // Links the Rust-provided and C-provided symbols of the whole module.
 extern crate redisearch_rs;
@@ -22,10 +23,10 @@ use std::{
     ffi::{c_char, c_void},
     mem,
     ops::ControlFlow,
-    ptr::{self, NonNull},
+    ptr,
 };
 
-use c_trie::{CTrieRef, LoweredPattern, SuffixMode, SuffixWalk};
+use c_trie::{LoweredPattern, SuffixMode, SuffixTrie, SuffixWalk, TermsTrie};
 use ffi::{SuffixType, SuffixType_SUFFIX_TYPE_CONTAINS, SuffixType_SUFFIX_TYPE_SUFFIX};
 
 /// Convert an ASCII/UTF-8 string to the trie's rune (`u16`) key.
@@ -55,17 +56,17 @@ fn runes_to_string(runes: &[ffi::rune]) -> String {
 
 /// Build a terms trie holding `terms`, each keyed with `numDocs == term length`
 /// (so tests can assert the document count flows through), run `f`, then free it.
-fn with_terms_trie(terms: &[&str], f: impl FnOnce(&CTrieRef)) {
+fn with_terms_trie(terms: &[&str], f: impl FnOnce(&TermsTrie)) {
     // SAFETY: `NewTrie` returns a fresh, valid, empty terms trie; a terms trie
     // stores no payload, so a null free callback is correct.
-    let ptr = unsafe { ffi::NewTrie(None, ffi::TrieSortMode_Trie_Sort_Lex) };
-    assert!(!ptr.is_null(), "NewTrie returned null");
+    let trie_ptr = unsafe { ffi::NewTrie(None, ffi::TrieSortMode_Trie_Sort_Lex) };
+    assert!(!trie_ptr.is_null(), "NewTrie returned null");
     for term in terms {
-        // SAFETY: `ptr` is the live trie just created; `term` points to
+        // SAFETY: `trie_ptr` is the live trie just created; `term` points to
         // `term.len()` valid UTF-8 bytes; a null payload is accepted.
         unsafe {
             ffi::Trie_InsertStringBuffer(
-                ptr,
+                trie_ptr,
                 term.as_ptr().cast::<c_char>(),
                 term.len(),
                 1.0,
@@ -75,38 +76,39 @@ fn with_terms_trie(terms: &[&str], f: impl FnOnce(&CTrieRef)) {
             );
         }
     }
-    // SAFETY: `ptr` is a valid trie that stays alive for the whole closure and
-    // is not freed until after it returns.
-    let trie = unsafe { CTrieRef::from_raw(ptr) };
-    f(&trie);
-    // SAFETY: `ptr` was produced by `NewTrie` and is freed exactly once here,
-    // after the last use of `trie`.
-    unsafe { ffi::TrieType_Free(ptr.cast::<c_void>()) };
+    // SAFETY: `trie_ptr` is a valid trie that stays alive for the whole closure
+    // and is not freed until after it returns. No other handle to it exists.
+    let trie = unsafe { TermsTrie::from_raw(trie_ptr) };
+    f(trie);
+    // SAFETY: `trie_ptr` was produced by `NewTrie` and is freed exactly once
+    // here, after the last use of `trie`.
+    unsafe { ffi::TrieType_Free(trie_ptr.cast::<c_void>()) };
 }
 
 /// Build a *suffix* trie holding `terms` (and all their suffixes), run `f`, then
 /// free it. `terms` must be non-empty strings — `addSuffixTrie` asserts on empty.
-fn with_suffix_trie(terms: &[&str], f: impl FnOnce(&CTrieRef)) {
+fn with_suffix_trie(terms: &[&str], f: impl FnOnce(&SuffixTrie)) {
     // SAFETY: `NewTrie` returns a fresh, valid trie; `suffixTrie_freeCallback` is
     // the matching free callback for the payloads `addSuffixTrie` inserts.
-    let ptr = unsafe {
+    let trie_ptr = unsafe {
         ffi::NewTrie(
             Some(ffi::suffixTrie_freeCallback),
             ffi::TrieSortMode_Trie_Sort_Lex,
         )
     };
-    assert!(!ptr.is_null(), "NewTrie returned null");
+    assert!(!trie_ptr.is_null(), "NewTrie returned null");
     for term in terms {
         assert!(!term.is_empty(), "addSuffixTrie rejects empty strings");
-        // SAFETY: `ptr` is the live suffix trie; `term` points to `term.len()`
-        // valid, non-empty UTF-8 bytes.
-        unsafe { ffi::addSuffixTrie(ptr, term.as_ptr().cast::<c_char>(), term.len() as u32) };
+        // SAFETY: `trie_ptr` is the live suffix trie; `term` points to
+        // `term.len()` valid, non-empty UTF-8 bytes.
+        unsafe { ffi::addSuffixTrie(trie_ptr, term.as_ptr().cast::<c_char>(), term.len() as u32) };
     }
-    // SAFETY: as in `with_terms_trie` — `ptr` outlives the closure.
-    let trie = unsafe { CTrieRef::from_raw(ptr) };
-    f(&trie);
+    // SAFETY: `trie_ptr` is a valid trie that stays alive for the whole closure
+    // and is not freed until after it returns. No other handle to it exists.
+    let trie = unsafe { SuffixTrie::from_raw(trie_ptr) };
+    f(trie);
     // SAFETY: freed exactly once after the last use of `trie`.
-    unsafe { ffi::TrieType_Free(ptr.cast::<c_void>()) };
+    unsafe { ffi::TrieType_Free(trie_ptr.cast::<c_void>()) };
 }
 
 /// Render a rune slice as text, for corpora that are not pure ASCII. Runes are
@@ -119,7 +121,7 @@ fn runes_to_text(runes: &[ffi::rune]) -> String {
         .collect()
 }
 
-/// Build a wildcard pattern from an ASCII/UTF-8 string. Every corpus here is
+/// Build a wildcard pattern from an ASCII/UTF-8 string. Every pattern here is
 /// lowercase already, so no case folding is needed on the way in.
 fn pattern(s: &str) -> LoweredPattern {
     LoweredPattern::new(&to_runes(s)).expect("pattern is short enough to convert")
@@ -158,14 +160,10 @@ fn iterate_contains_prefix_anchor_reports_terms_and_num_docs() {
     with_terms_trie(CORPUS, |trie| {
         let runes = to_runes("ap");
         let mut got: HashSet<(String, usize)> = HashSet::new();
-        // SAFETY: `trie` wraps a live terms trie that is not mutated during the
-        // walk; the timeout is `None`; the closure does not touch the trie.
-        unsafe {
-            trie.iterate_contains(&runes, true, false, None, |term, num_docs| {
-                got.insert((runes_to_string(term), num_docs));
-                ControlFlow::Continue(())
-            });
-        }
+        trie.iterate_contains(&runes, true, false, None, |term, num_docs| {
+            got.insert((runes_to_string(term), num_docs));
+            ControlFlow::Continue(())
+        });
         // Prefix `ap`: only terms starting with it, and `numDocs` == char length.
         let expected: HashSet<(String, usize)> =
             [("apple".to_owned(), 5), ("apricot".to_owned(), 7)]
@@ -184,13 +182,10 @@ fn iterate_contains_suffix_anchor() {
     with_terms_trie(CORPUS, |trie| {
         let runes = to_runes("ple");
         let mut got = HashSet::new();
-        // SAFETY: live, un-mutated terms trie; `None` timeout.
-        unsafe {
-            trie.iterate_contains(&runes, false, true, None, |term, _| {
-                got.insert(runes_to_string(term));
-                ControlFlow::Continue(())
-            });
-        }
+        trie.iterate_contains(&runes, false, true, None, |term, _| {
+            got.insert(runes_to_string(term));
+            ControlFlow::Continue(())
+        });
         assert_eq!(got, set(&["apple", "maple"]));
     });
 }
@@ -204,13 +199,10 @@ fn iterate_contains_contains_anchor() {
     with_terms_trie(CORPUS, |trie| {
         let runes = to_runes("ap");
         let mut got = HashSet::new();
-        // SAFETY: live, un-mutated terms trie; `None` timeout.
-        unsafe {
-            trie.iterate_contains(&runes, true, true, None, |term, _| {
-                got.insert(runes_to_string(term));
-                ControlFlow::Continue(())
-            });
-        }
+        trie.iterate_contains(&runes, true, true, None, |term, _| {
+            got.insert(runes_to_string(term));
+            ControlFlow::Continue(())
+        });
         // Every corpus term contains `ap`.
         assert_eq!(got, set(CORPUS));
     });
@@ -225,18 +217,15 @@ fn iterate_contains_break_stops_walk_early() {
     with_terms_trie(CORPUS, |trie| {
         let runes = to_runes("ap");
         let mut count = 0_usize;
-        // SAFETY: live, un-mutated terms trie; `None` timeout.
-        unsafe {
-            trie.iterate_contains(&runes, true, true, None, |_, _| {
-                count += 1;
-                // Stop after the second match even though five would match.
-                if count >= 2 {
-                    ControlFlow::Break(())
-                } else {
-                    ControlFlow::Continue(())
-                }
-            });
-        }
+        trie.iterate_contains(&runes, true, true, None, |_, _| {
+            count += 1;
+            // Stop after the second match even though five would match.
+            if count >= 2 {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        });
         assert_eq!(count, 2, "Break must stop the walk at the second match");
     });
 }
@@ -249,13 +238,10 @@ fn iterate_contains_break_stops_walk_early() {
 fn iterate_contains_empty_pattern_in_suffix_mode_visits_nothing() {
     with_terms_trie(CORPUS, |trie| {
         let mut count = 0_usize;
-        // SAFETY: live, un-mutated terms trie; `None` timeout; empty pattern.
-        unsafe {
-            trie.iterate_contains(&[], false, true, None, |_, _| {
-                count += 1;
-                ControlFlow::Continue(())
-            });
-        }
+        trie.iterate_contains(&[], false, true, None, |_, _| {
+            count += 1;
+            ControlFlow::Continue(())
+        });
         assert_eq!(count, 0);
     });
 }
@@ -269,45 +255,32 @@ fn iterate_contains_some_and_none_timeout_agree() {
     // `RS_IsMock` is true in this test binary (`RedisModule_CreateTimer` is
     // unbound), so an actual deadline never fires — deadline *enforcement* is
     // covered by the C and Python suites. This exercises both branches of the
-    // wrapper's timeout mapping (`None` → skip checks; `Some` → a valid, live
-    // deadline pointer) and confirms they accept input and return the same set.
+    // wrapper's timeout mapping (`None` → skip checks; `Some` → a deadline the
+    // walk copies in) and confirms they accept input and return the same set.
     with_terms_trie(CORPUS, |trie| {
         let runes = to_runes("ap");
 
         let mut none_hits = HashSet::new();
-        // SAFETY: live, un-mutated terms trie; `None` timeout.
-        unsafe {
-            trie.iterate_contains(&runes, true, true, None, |term, _| {
-                none_hits.insert(runes_to_string(term));
-                ControlFlow::Continue(())
-            });
-        }
+        trie.iterate_contains(&runes, true, true, None, |term, _| {
+            none_hits.insert(runes_to_string(term));
+            ControlFlow::Continue(())
+        });
 
         // SAFETY: `timespec` is a plain-old-data struct; an all-zero value is valid.
         let mut deadline: ffi::timespec = unsafe { mem::zeroed() };
         deadline.tv_sec = 1_i64 << 40; // far in the future
         let mut some_hits = HashSet::new();
-        // SAFETY: live, un-mutated terms trie; `deadline` is a valid `timespec`
-        // that outlives the call.
-        unsafe {
-            trie.iterate_contains(
-                &runes,
-                true,
-                true,
-                Some(NonNull::from(&mut deadline)),
-                |term, _| {
-                    some_hits.insert(runes_to_string(term));
-                    ControlFlow::Continue(())
-                },
-            );
-        }
+        trie.iterate_contains(&runes, true, true, Some(deadline), |term, _| {
+            some_hits.insert(runes_to_string(term));
+            ControlFlow::Continue(())
+        });
 
         assert_eq!(none_hits, set(CORPUS));
         assert_eq!(some_hits, none_hits);
     });
 }
 
-// --- `iterate_suffix` (suffix trie) -----------------------------------------
+// --- `iterate_contains` (suffix trie) ---------------------------------------
 
 #[test]
 #[cfg_attr(
@@ -318,14 +291,10 @@ fn iterate_suffix_suffix_anchor() {
     with_suffix_trie(CORPUS, |trie| {
         let runes = to_runes("ple");
         let mut got = HashSet::new();
-        // SAFETY: `trie` wraps a live suffix trie (matching payload/free
-        // callback) that is not mutated during the walk.
-        unsafe {
-            trie.iterate_suffix(&runes, SuffixMode::Suffix, |bytes| {
-                got.insert(String::from_utf8_lossy(bytes).into_owned());
-                ControlFlow::Continue(())
-            });
-        }
+        trie.iterate_contains(&runes, SuffixMode::Suffix, |bytes| {
+            got.insert(String::from_utf8_lossy(bytes).into_owned());
+            ControlFlow::Continue(())
+        });
         assert_eq!(got, set(&["apple", "maple"]));
     });
 }
@@ -339,13 +308,10 @@ fn iterate_suffix_contains_anchor() {
     with_suffix_trie(CORPUS, |trie| {
         let runes = to_runes("ap");
         let mut got = HashSet::new();
-        // SAFETY: live, un-mutated suffix trie.
-        unsafe {
-            trie.iterate_suffix(&runes, SuffixMode::Contains, |bytes| {
-                got.insert(String::from_utf8_lossy(bytes).into_owned());
-                ControlFlow::Continue(())
-            });
-        }
+        trie.iterate_contains(&runes, SuffixMode::Contains, |bytes| {
+            got.insert(String::from_utf8_lossy(bytes).into_owned());
+            ControlFlow::Continue(())
+        });
         assert_eq!(got, set(CORPUS));
     });
 }
@@ -359,13 +325,10 @@ fn iterate_suffix_break_stops_walk_early() {
     with_suffix_trie(CORPUS, |trie| {
         let runes = to_runes("ap");
         let mut count = 0_usize;
-        // SAFETY: live, un-mutated suffix trie.
-        unsafe {
-            trie.iterate_suffix(&runes, SuffixMode::Contains, |_| {
-                count += 1;
-                ControlFlow::Break(())
-            });
-        }
+        trie.iterate_contains(&runes, SuffixMode::Contains, |_| {
+            count += 1;
+            ControlFlow::Break(())
+        });
         assert_eq!(count, 1, "Break must stop after the first match");
     });
 }
@@ -378,13 +341,10 @@ fn iterate_suffix_break_stops_walk_early() {
 fn iterate_suffix_empty_pattern_visits_nothing() {
     with_suffix_trie(CORPUS, |trie| {
         let mut count = 0_usize;
-        // SAFETY: live, un-mutated suffix trie; empty pattern.
-        unsafe {
-            trie.iterate_suffix(&[], SuffixMode::Contains, |_| {
-                count += 1;
-                ControlFlow::Continue(())
-            });
-        }
+        trie.iterate_contains(&[], SuffixMode::Contains, |_| {
+            count += 1;
+            ControlFlow::Continue(())
+        });
         assert_eq!(count, 0);
     });
 }
@@ -461,14 +421,10 @@ fn lowered_pattern_declines_a_pattern_holding_a_zero_rune() {
 fn iterate_wildcard_reports_terms_and_num_docs() {
     with_terms_trie(CORPUS, |trie| {
         let mut got: HashSet<(String, usize)> = HashSet::new();
-        // SAFETY: `trie` wraps a live terms trie that is not mutated during the
-        // walk; the timeout is `None`; the closure does not touch the trie.
-        unsafe {
-            trie.iterate_wildcard(&pattern("ap*"), None, |term, num_docs| {
-                got.insert((runes_to_string(term), num_docs));
-                ControlFlow::Continue(())
-            });
-        }
+        trie.iterate_wildcard(&pattern("ap*"), None, |term, num_docs| {
+            got.insert((runes_to_string(term), num_docs));
+            ControlFlow::Continue(())
+        });
         // `numDocs` == char length, as inserted by `with_terms_trie`.
         let expected: HashSet<(String, usize)> =
             [("apple".to_owned(), 5), ("apricot".to_owned(), 7)]
@@ -486,13 +442,10 @@ fn iterate_wildcard_reports_terms_and_num_docs() {
 fn iterate_wildcard_matches_a_star_that_is_not_front_anchored() {
     with_terms_trie(CORPUS, |trie| {
         let mut got = HashSet::new();
-        // SAFETY: live, un-mutated terms trie; `None` timeout.
-        unsafe {
-            trie.iterate_wildcard(&pattern("*ple"), None, |term, _| {
-                got.insert(runes_to_string(term));
-                ControlFlow::Continue(())
-            });
-        }
+        trie.iterate_wildcard(&pattern("*ple"), None, |term, _| {
+            got.insert(runes_to_string(term));
+            ControlFlow::Continue(())
+        });
         assert_eq!(got, set(&["apple", "maple"]));
     });
 }
@@ -505,13 +458,10 @@ fn iterate_wildcard_matches_a_star_that_is_not_front_anchored() {
 fn iterate_wildcard_question_mark_matches_exactly_one_rune() {
     with_terms_trie(CORPUS, |trie| {
         let mut got = HashSet::new();
-        // SAFETY: live, un-mutated terms trie; `None` timeout.
-        unsafe {
-            trie.iterate_wildcard(&pattern("m?p"), None, |term, _| {
-                got.insert(runes_to_string(term));
-                ControlFlow::Continue(())
-            });
-        }
+        trie.iterate_wildcard(&pattern("m?p"), None, |term, _| {
+            got.insert(runes_to_string(term));
+            ControlFlow::Continue(())
+        });
         // `map` only: `maple` is longer, and `?` does not span two runes.
         assert_eq!(got, set(&["map"]));
     });
@@ -527,13 +477,10 @@ fn iterate_wildcard_matches_a_multibyte_pattern() {
     // hides. `?` here is one *rune*, so it spans the two-byte `é`.
     with_terms_trie(&["héllo", "hallo", "hxyllo"], |trie| {
         let mut got = HashSet::new();
-        // SAFETY: live, un-mutated terms trie; `None` timeout.
-        unsafe {
-            trie.iterate_wildcard(&pattern("h?llo"), None, |term, _| {
-                got.insert(runes_to_text(term));
-                ControlFlow::Continue(())
-            });
-        }
+        trie.iterate_wildcard(&pattern("h?llo"), None, |term, _| {
+            got.insert(runes_to_text(term));
+            ControlFlow::Continue(())
+        });
         assert_eq!(got, set(&["héllo", "hallo"]));
     });
 }
@@ -547,13 +494,10 @@ fn iterate_wildcard_empty_pattern_visits_nothing() {
     with_terms_trie(CORPUS, |trie| {
         let empty = LoweredPattern::new(&[]).expect("an empty pattern converts");
         let mut count = 0_usize;
-        // SAFETY: live, un-mutated terms trie; `None` timeout; empty pattern.
-        unsafe {
-            trie.iterate_wildcard(&empty, None, |_, _| {
-                count += 1;
-                ControlFlow::Continue(())
-            });
-        }
+        trie.iterate_wildcard(&empty, None, |_, _| {
+            count += 1;
+            ControlFlow::Continue(())
+        });
         // The walk underneath would read the byte before the pattern to decide
         // whether it ends in `*`, so this must not reach it.
         assert_eq!(count, 0);
@@ -568,13 +512,10 @@ fn iterate_wildcard_empty_pattern_visits_nothing() {
 fn iterate_wildcard_break_stops_a_trailing_star_walk_early() {
     with_terms_trie(CORPUS, |trie| {
         let mut count = 0_usize;
-        // SAFETY: live, un-mutated terms trie; `None` timeout.
-        unsafe {
-            trie.iterate_wildcard(&pattern("ap*"), None, |_, _| {
-                count += 1;
-                ControlFlow::Break(())
-            });
-        }
+        trie.iterate_wildcard(&pattern("ap*"), None, |_, _| {
+            count += 1;
+            ControlFlow::Break(())
+        });
         assert_eq!(count, 1, "Break must stop after the first match");
     });
 }
@@ -590,13 +531,10 @@ fn iterate_wildcard_break_is_ignored_without_a_trailing_star() {
     // the caller must make every further callback a no-op itself.
     with_terms_trie(CORPUS, |trie| {
         let mut count = 0_usize;
-        // SAFETY: live, un-mutated terms trie; `None` timeout.
-        unsafe {
-            trie.iterate_wildcard(&pattern("*ple"), None, |_, _| {
-                count += 1;
-                ControlFlow::Break(())
-            });
-        }
+        trie.iterate_wildcard(&pattern("*ple"), None, |_, _| {
+            count += 1;
+            ControlFlow::Break(())
+        });
         assert_eq!(count, 2, "both matches are still delivered");
     });
 }
@@ -612,54 +550,39 @@ fn iterate_wildcard_some_and_none_timeout_agree() {
     // than deadline enforcement.
     with_terms_trie(CORPUS, |trie| {
         let mut none_hits = HashSet::new();
-        // SAFETY: live, un-mutated terms trie; `None` timeout.
-        unsafe {
-            trie.iterate_wildcard(&pattern("ap*"), None, |term, _| {
-                none_hits.insert(runes_to_string(term));
-                ControlFlow::Continue(())
-            });
-        }
+        trie.iterate_wildcard(&pattern("ap*"), None, |term, _| {
+            none_hits.insert(runes_to_string(term));
+            ControlFlow::Continue(())
+        });
 
         // SAFETY: `timespec` is a plain-old-data struct; an all-zero value is valid.
         let mut deadline: ffi::timespec = unsafe { mem::zeroed() };
         deadline.tv_sec = 1_i64 << 40; // far in the future
         let mut some_hits = HashSet::new();
-        // SAFETY: live, un-mutated terms trie; `deadline` is a valid `timespec`
-        // that outlives the call.
-        unsafe {
-            trie.iterate_wildcard(
-                &pattern("ap*"),
-                Some(NonNull::from(&mut deadline)),
-                |term, _| {
-                    some_hits.insert(runes_to_string(term));
-                    ControlFlow::Continue(())
-                },
-            );
-        }
+        trie.iterate_wildcard(&pattern("ap*"), Some(deadline), |term, _| {
+            some_hits.insert(runes_to_string(term));
+            ControlFlow::Continue(())
+        });
 
         assert_eq!(none_hits, set(&["apple", "apricot"]));
         assert_eq!(some_hits, none_hits);
     });
 }
 
-// --- `iterate_suffix_wildcard` (suffix trie) --------------------------------
+// --- `iterate_wildcard` (suffix trie) ---------------------------------------
 
 #[test]
 #[cfg_attr(
     miri,
     ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
 )]
-fn iterate_suffix_wildcard_anchors_on_the_pattern_literal() {
+fn suffix_iterate_wildcard_anchors_on_the_pattern_literal() {
     with_suffix_trie(CORPUS, |trie| {
         let mut got = HashSet::new();
-        // SAFETY: `trie` wraps a live suffix trie (matching payload/free
-        // callback) that is not mutated during the walk; `None` timeout.
-        let outcome = unsafe {
-            trie.iterate_suffix_wildcard(pattern("*ple"), None, |bytes| {
-                got.insert(String::from_utf8_lossy(bytes).into_owned());
-                ControlFlow::Continue(())
-            })
-        };
+        let outcome = trie.iterate_wildcard(pattern("*ple"), None, |bytes| {
+            got.insert(String::from_utf8_lossy(bytes).into_owned());
+            ControlFlow::Continue(())
+        });
         assert!(
             matches!(outcome, SuffixWalk::Walked),
             "`ple` is a literal the suffix trie can use"
@@ -673,19 +596,16 @@ fn iterate_suffix_wildcard_anchors_on_the_pattern_literal() {
     miri,
     ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
 )]
-fn iterate_suffix_wildcard_anchor_token_may_absorb_a_trailing_star() {
+fn suffix_iterate_wildcard_anchor_token_may_absorb_a_trailing_star() {
     // The chosen anchor token `ma` is followed by `*`, so the walk extends the
     // token to cover it and scans the whole sub-tree under `ma` — the only walk
     // shape that honours an early stop.
     with_suffix_trie(CORPUS, |trie| {
         let mut got = HashSet::new();
-        // SAFETY: live, un-mutated suffix trie; `None` timeout.
-        let outcome = unsafe {
-            trie.iterate_suffix_wildcard(pattern("ma*"), None, |bytes| {
-                got.insert(String::from_utf8_lossy(bytes).into_owned());
-                ControlFlow::Continue(())
-            })
-        };
+        let outcome = trie.iterate_wildcard(pattern("ma*"), None, |bytes| {
+            got.insert(String::from_utf8_lossy(bytes).into_owned());
+            ControlFlow::Continue(())
+        });
         assert!(matches!(outcome, SuffixWalk::Walked));
         assert_eq!(got, set(&["maple", "map"]));
     });
@@ -696,19 +616,16 @@ fn iterate_suffix_wildcard_anchor_token_may_absorb_a_trailing_star() {
     miri,
     ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
 )]
-fn iterate_suffix_wildcard_matches_a_multibyte_pattern() {
+fn suffix_iterate_wildcard_matches_a_multibyte_pattern() {
     // A multibyte pattern separates rune count from byte count; the walk operates
     // rune-wise throughout, and every ASCII pattern leaves the two equal and so
     // could not tell.
     with_suffix_trie(&["héllo", "hallo"], |trie| {
         let mut got = HashSet::new();
-        // SAFETY: live, un-mutated suffix trie; `None` timeout.
-        let outcome = unsafe {
-            trie.iterate_suffix_wildcard(pattern("*éllo"), None, |bytes| {
-                got.insert(String::from_utf8_lossy(bytes).into_owned());
-                ControlFlow::Continue(())
-            })
-        };
+        let outcome = trie.iterate_wildcard(pattern("*éllo"), None, |bytes| {
+            got.insert(String::from_utf8_lossy(bytes).into_owned());
+            ControlFlow::Continue(())
+        });
         assert!(matches!(outcome, SuffixWalk::Walked));
         assert_eq!(got, set(&["héllo"]));
     });
@@ -719,16 +636,13 @@ fn iterate_suffix_wildcard_matches_a_multibyte_pattern() {
     miri,
     ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
 )]
-fn iterate_suffix_wildcard_declines_a_pattern_with_no_literal_to_anchor_on() {
+fn suffix_iterate_wildcard_declines_a_pattern_with_no_literal_to_anchor_on() {
     with_suffix_trie(CORPUS, |trie| {
         let mut count = 0_usize;
-        // SAFETY: live, un-mutated suffix trie; `None` timeout.
-        let outcome = unsafe {
-            trie.iterate_suffix_wildcard(pattern("**"), None, |_| {
-                count += 1;
-                ControlFlow::Continue(())
-            })
-        };
+        let outcome = trie.iterate_wildcard(pattern("**"), None, |_| {
+            count += 1;
+            ControlFlow::Continue(())
+        });
         let SuffixWalk::NoAnchor(returned) = outcome else {
             panic!("a pattern of only `*` has no token to anchor on");
         };
@@ -744,17 +658,14 @@ fn iterate_suffix_wildcard_declines_a_pattern_with_no_literal_to_anchor_on() {
     miri,
     ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
 )]
-fn iterate_suffix_wildcard_declines_an_empty_pattern() {
+fn suffix_iterate_wildcard_declines_an_empty_pattern() {
     with_suffix_trie(CORPUS, |trie| {
         let empty = LoweredPattern::new(&[]).expect("an empty pattern converts");
         let mut count = 0_usize;
-        // SAFETY: live, un-mutated suffix trie; `None` timeout; empty pattern.
-        let outcome = unsafe {
-            trie.iterate_suffix_wildcard(empty, None, |_| {
-                count += 1;
-                ControlFlow::Continue(())
-            })
-        };
+        let outcome = trie.iterate_wildcard(empty, None, |_| {
+            count += 1;
+            ControlFlow::Continue(())
+        });
         let SuffixWalk::NoAnchor(returned) = outcome else {
             panic!("an empty pattern has no token to anchor on");
         };
@@ -768,18 +679,15 @@ fn iterate_suffix_wildcard_declines_an_empty_pattern() {
     miri,
     ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
 )]
-fn iterate_suffix_wildcard_break_stops_a_star_terminated_anchor_early() {
+fn suffix_iterate_wildcard_break_stops_a_star_terminated_anchor_early() {
     // `ma*` extends its anchor token to include the `*`, which is what puts the
     // walk on the sub-tree path — the only path that honours a stop request.
     with_suffix_trie(CORPUS, |trie| {
         let mut count = 0_usize;
-        // SAFETY: live, un-mutated suffix trie; `None` timeout.
-        let outcome = unsafe {
-            trie.iterate_suffix_wildcard(pattern("ma*"), None, |_| {
-                count += 1;
-                ControlFlow::Break(())
-            })
-        };
+        let outcome = trie.iterate_wildcard(pattern("ma*"), None, |_| {
+            count += 1;
+            ControlFlow::Break(())
+        });
         assert!(matches!(outcome, SuffixWalk::Walked));
         assert_eq!(count, 1, "Break must stop after the first match");
     });
@@ -790,7 +698,7 @@ fn iterate_suffix_wildcard_break_stops_a_star_terminated_anchor_early() {
     miri,
     ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
 )]
-fn iterate_suffix_wildcard_break_is_ignored_for_an_anchor_without_a_trailing_star() {
+fn suffix_iterate_wildcard_break_is_ignored_for_an_anchor_without_a_trailing_star() {
     // The documented caveat, pinned. `*p?e` anchors on `p?e`, which is not
     // `*`-terminated, so the walk is not on the sub-tree path and discards the
     // stop request — it only truncates the matches under the node it is on, then
@@ -800,13 +708,10 @@ fn iterate_suffix_wildcard_break_is_ignored_for_an_anchor_without_a_trailing_sta
     // matching key would hide this, since `Break` does end that key's own list.
     with_suffix_trie(&["apple", "pie"], |trie| {
         let mut count = 0_usize;
-        // SAFETY: live, un-mutated suffix trie; `None` timeout.
-        let outcome = unsafe {
-            trie.iterate_suffix_wildcard(pattern("*p?e"), None, |_| {
-                count += 1;
-                ControlFlow::Break(())
-            })
-        };
+        let outcome = trie.iterate_wildcard(pattern("*p?e"), None, |_| {
+            count += 1;
+            ControlFlow::Break(())
+        });
         assert!(matches!(outcome, SuffixWalk::Walked));
         assert_eq!(
             count, 2,

--- a/src/redisearch_rs/query_eval/src/nodes/prefix.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/prefix.rs
@@ -9,9 +9,9 @@
 
 //! Evaluation of `QN_PREFIX` query nodes.
 
-use std::{ops::ControlFlow, ptr::NonNull};
+use std::ops::ControlFlow;
 
-use c_trie::{CTrieRef, SuffixMode};
+use c_trie::{SuffixMode, SuffixTrie, TermsTrie};
 use query::WildcardMode;
 use query_error::QueryErrorCode;
 use query_types::QueryNodeType;
@@ -97,7 +97,7 @@ pub(crate) fn eval<'index>(
     // Resolved here, with every other read of `ctx`, because `Expansion` borrows
     // it mutably for the rest of the expansion.
     let time = &ctx.sctx().time;
-    let timeout = (!time.skipTimeoutChecks).then(|| NonNull::from(&time.timeout));
+    let timeout = (!time.skipTimeoutChecks).then_some(time.timeout);
 
     let expansion = Expansion {
         ctx,
@@ -111,14 +111,14 @@ pub(crate) fn eval<'index>(
     debug_assert!(!terms_trie.is_null(), "terms trie should be initialized");
     // SAFETY: `terms_trie` is the spec's terms `Trie`, valid for and unmutated
     // during the query (`QueryEvalContext` invariants 1/2).
-    let terms = unsafe { CTrieRef::from_raw(terms_trie) };
+    let terms = unsafe { TermsTrie::from_raw(terms_trie) };
 
     let children = if match_suffix && !suffix_trie.is_null() {
         // The spec maintains a suffix trie for this pattern's fields: expand
         // through it.
         // SAFETY: `suffix_trie` is non-null (checked above) and is the spec's
         // suffix `Trie`, valid for and unmutated during the query.
-        let suffix = unsafe { CTrieRef::from_raw(suffix_trie) };
+        let suffix = unsafe { SuffixTrie::from_raw(suffix_trie) };
         expansion.expand_via_suffix_trie(
             suffix,
             terms,
@@ -171,8 +171,8 @@ impl Expansion<'_> {
     /// suffix trie, a `Generic` error is set and no reader is returned.
     fn expand_via_suffix_trie(
         mut self,
-        suffix: CTrieRef,
-        terms: CTrieRef,
+        suffix: &SuffixTrie,
+        terms: &TermsTrie,
         pattern: &[ffi::rune],
         contains: bool,
         node_field_mask: FieldMask,
@@ -212,15 +212,7 @@ impl Expansion<'_> {
             };
             self.push_child(num_docs, term_bytes)
         };
-        // SAFETY: `suffix` wraps the spec's valid suffix `Trie`, whose nodes carry
-        // the suffix-data payload the walk expects (caller contract); the suffix
-        // walk carries no timeout. The trie is not mutated or re-iterated for the
-        // duration of the call: `on_term` only opens per-term readers (which read
-        // the spec's inverted indexes) and, on the disk path, looks up the
-        // separate primary terms trie — never the suffix trie being walked.
-        unsafe {
-            suffix.iterate_suffix(pattern, suffix_mode, on_term);
-        }
+        suffix.iterate_contains(pattern, suffix_mode, on_term);
         self.children
     }
 
@@ -232,11 +224,11 @@ impl Expansion<'_> {
     /// bounds it (`None` runs it to completion).
     fn expand_via_terms_trie(
         mut self,
-        terms: CTrieRef,
+        terms: &TermsTrie,
         pattern: &[ffi::rune],
         match_prefix: bool,
         match_suffix: bool,
-        timeout: Option<NonNull<ffi::timespec>>,
+        timeout: Option<ffi::timespec>,
     ) -> Vec<CRQEIterator> {
         // The primary trie hands terms back as runes (with their document count, used
         // for the disk IDF), which must be encoded back into the term's key, byte for
@@ -249,14 +241,7 @@ impl Expansion<'_> {
             };
             self.push_child(num_docs, &key)
         };
-        // SAFETY: `terms` wraps the spec's valid primary terms `Trie`; `timeout`,
-        // if set, points to the sctx's live timeout `timespec`. The trie is not
-        // mutated or re-iterated for the duration of the call: `on_runes` only
-        // opens per-term readers, which read the spec's inverted indexes rather
-        // than the terms trie being walked.
-        unsafe {
-            terms.iterate_contains(pattern, match_prefix, match_suffix, timeout, on_runes);
-        }
+        terms.iterate_contains(pattern, match_prefix, match_suffix, timeout, on_runes);
         self.children
     }
 }

--- a/src/redisearch_rs/query_eval/src/nodes/token.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/token.rs
@@ -11,7 +11,7 @@
 
 use std::ptr::NonNull;
 
-use c_trie::CTrieRef;
+use c_trie::TermsTrie;
 use field::FieldMaskOrIndex;
 use query_term::RSQueryTerm;
 use query_types::QueryNodeOptions;
@@ -139,9 +139,9 @@ fn eval_disk<'index>(
     // below relies on it.
     debug_assert!(term_bytes.is_some(), "token string should not be null");
 
-    // SAFETY: `spec.terms` is a valid `Trie` (checked non-null above) that
+    // SAFETY: `spec.terms` is a valid terms `Trie` (checked non-null above) that
     // outlives this lookup.
-    let terms = unsafe { CTrieRef::from_raw(spec.terms) };
+    let terms = unsafe { TermsTrie::from_raw(spec.terms) };
     // The lookup refuses a term that is not valid UTF-8. These bytes are query
     // text rather than a stored key, and a disk index only stages terms whose
     // bytes are valid UTF-8, so zero is the true count for such a term rather

--- a/src/redisearch_rs/query_eval/src/nodes/wildcard_query.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/wildcard_query.rs
@@ -9,9 +9,9 @@
 
 //! Evaluation of `QN_WILDCARD_QUERY` query nodes.
 
-use std::{ops::ControlFlow, ptr::NonNull};
+use std::ops::ControlFlow;
 
-use c_trie::{CTrieRef, LoweredPattern, SuffixWalk};
+use c_trie::{LoweredPattern, SuffixTrie, SuffixWalk, TermsTrie};
 use query_error::QueryErrorCode;
 use query_types::QueryNodeType;
 use rqe_iterators::union_opaque::build_union_with_q_str;
@@ -84,7 +84,7 @@ pub(crate) fn eval<'index>(
     // Resolved here, with every other read of `ctx`, because `Expansion` borrows
     // it mutably for the rest of the expansion.
     let time = &ctx.sctx().time;
-    let timeout = (!time.skipTimeoutChecks).then(|| NonNull::from(&time.timeout));
+    let timeout = (!time.skipTimeoutChecks).then_some(time.timeout);
 
     let mut expansion = Expansion {
         ctx,
@@ -98,7 +98,7 @@ pub(crate) fn eval<'index>(
     debug_assert!(!terms_trie.is_null(), "terms trie should be initialized");
     // SAFETY: `terms_trie` is the spec's terms `Trie`, valid for and unmutated
     // during the query (`QueryEvalContext` invariants 1/2).
-    let terms = unsafe { CTrieRef::from_raw(terms_trie) };
+    let terms = unsafe { TermsTrie::from_raw(terms_trie) };
 
     // A spec with a suffix trie may only answer a pattern when every queried field
     // is covered by it. An unsupported field set is an error that does *not* fall
@@ -141,19 +141,18 @@ pub(crate) fn eval<'index>(
             // suffix `Trie`, whose nodes carry the suffix-data payload the walk
             // expects; it is valid for and unmutated during the query
             // (`QueryEvalContext` invariants 1/2).
-            let suffix = unsafe { CTrieRef::from_raw(suffix_trie) };
-            brute_force = match expansion
-                .expand_wildcard_via_suffix_trie(&suffix, &terms, pattern, timeout)
-            {
-                // The walk answered the pattern, and consumed it doing so.
-                SuffixWalk::Walked => None,
-                // Nothing to anchor on, so the pattern is still un-walked and the
-                // brute-force scan below has to answer it instead.
-                SuffixWalk::NoAnchor(pattern) => Some(pattern),
-            };
+            let suffix = unsafe { SuffixTrie::from_raw(suffix_trie) };
+            brute_force =
+                match expansion.expand_wildcard_via_suffix_trie(suffix, terms, pattern, timeout) {
+                    // The walk answered the pattern, and consumed it doing so.
+                    SuffixWalk::Walked => None,
+                    // Nothing to anchor on, so the pattern is still un-walked and the
+                    // brute-force scan below has to answer it instead.
+                    SuffixWalk::NoAnchor(pattern) => Some(pattern),
+                };
         }
         if let Some(pattern) = brute_force {
-            expansion.expand_wildcard_via_terms_trie(&terms, &pattern, timeout);
+            expansion.expand_wildcard_via_terms_trie(terms, &pattern, timeout);
         }
     }
     // A pattern `LoweredPattern::new` declines falls through to an empty union.
@@ -203,10 +202,10 @@ impl Expansion<'_> {
     /// results.
     fn expand_wildcard_via_suffix_trie(
         &mut self,
-        suffix: &CTrieRef,
-        terms: &CTrieRef,
+        suffix: &SuffixTrie,
+        terms: &TermsTrie,
         pattern: LoweredPattern,
-        timeout: Option<NonNull<ffi::timespec>>,
+        timeout: Option<ffi::timespec>,
     ) -> SuffixWalk {
         // The suffix trie hands terms back already as stored key bytes but carries
         // no document count, so on the disk path the term's count is looked up in
@@ -229,14 +228,7 @@ impl Expansion<'_> {
             };
             self.push_child(num_docs, term_bytes)
         };
-        // SAFETY: `suffix` wraps the spec's valid suffix `Trie`, whose nodes carry
-        // the suffix-data payload the walk expects (caller contract), and `timeout`,
-        // if set, points to the sctx's live timeout `timespec`. The trie is not
-        // mutated or re-iterated for the duration of the call: `on_term` only opens
-        // per-term readers (which read the spec's inverted indexes) and, on the disk
-        // path, looks up the separate primary terms trie — never the suffix trie
-        // being walked.
-        unsafe { suffix.iterate_suffix_wildcard(pattern, timeout, on_term) }
+        suffix.iterate_wildcard(pattern, timeout, on_term)
     }
 
     /// Brute-force expand a wildcard `pattern` over the primary terms trie,
@@ -246,9 +238,9 @@ impl Expansion<'_> {
     /// (`None` runs it to completion).
     fn expand_wildcard_via_terms_trie(
         &mut self,
-        terms: &CTrieRef,
+        terms: &TermsTrie,
         pattern: &LoweredPattern,
-        timeout: Option<NonNull<ffi::timespec>>,
+        timeout: Option<ffi::timespec>,
     ) {
         // The primary trie hands terms back as runes (with their document count,
         // used for the disk IDF), which must be encoded back into the term's key,
@@ -267,13 +259,6 @@ impl Expansion<'_> {
             };
             self.push_child(num_docs, &key)
         };
-        // SAFETY: `terms` wraps the spec's valid primary terms `Trie`; `timeout`, if
-        // set, points to the sctx's live timeout `timespec`. The trie is not mutated
-        // or re-iterated for the duration of the call: `on_runes` only opens per-term
-        // readers, which read the spec's inverted indexes rather than the terms trie
-        // being walked.
-        unsafe {
-            terms.iterate_wildcard(pattern, timeout, on_runes);
-        }
+        terms.iterate_wildcard(pattern, timeout, on_runes);
     }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `CTrieRef` wraps a bare `*mut ffi::Trie` with no lifetime and no notion of
   which kind of trie it holds. Handing a suffix walk the primary terms trie is type
   confusion the compiler cannot catch, and the rule that a trie must not be mutated
   while a walk is in progress can only be stated in prose — so all four iteration
   methods are `unsafe fn`.
2. Change: `CTrieRef` becomes two `#[repr(transparent)]` types, `TermsTrie` and
   `SuffixTrie`, borrowed as `&`/`&mut` rather than owned. The trie kind is now part of
   the type, mutators take `&mut self` while walks take `&self`, and `timeout` is passed
   by value instead of as a caller-owned pointer.
3. Outcome: internal only, no behavior change. Four `unsafe fn` leave the public surface
   because the borrow checker now enforces what their safety sections asked for, and the
   terms/suffix mix-up becomes a compile error.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `c_trie::TermsTrie` / `c_trie::SuffixTrie` — replace `CTrieRef`; construction moves to
   `from_raw` / `from_raw_mut`, which carry the validity obligations.
2. The four walks (`iterate_contains`, `iterate_wildcard` on each type) — now safe.
3. `as_ptr` / `as_mut_ptr` — split, so a shared borrow can no longer hand C a pointer to
   mutate through.
4. `query_eval::nodes::{prefix, token, wildcard_query}` — the only call sites.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes