### PR TITLE
Move `runes_to_key` into `string_utils` as `runes_to_bytes`

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1823,6 +1823,7 @@ dependencies = [
  "rqe_iterators_test_utils",
  "rs_token",
  "search_disk",
+ "string_utils",
  "thiserror",
  "workspace_hack",
 ]
@@ -2885,6 +2886,7 @@ dependencies = [
  "redis-module",
  "redis_mock",
  "redisearch_rs",
+ "rstest",
  "string_utils",
  "thiserror",
  "workspace_hack",

--- a/src/redisearch_rs/query_eval/Cargo.toml
+++ b/src/redisearch_rs/query_eval/Cargo.toml
@@ -29,6 +29,7 @@ rqe_core.workspace = true
 rqe_iterators.workspace = true
 rs_token.workspace = true
 search_disk.workspace = true
+string_utils.workspace = true
 thiserror.workspace = true
 workspace_hack.workspace = true
 

--- a/src/redisearch_rs/query_eval/src/expansion.rs
+++ b/src/redisearch_rs/query_eval/src/expansion.rs
@@ -177,31 +177,6 @@ fn open_expanded_term_reader(
     Some(unsafe { CRQEIterator::new(nn) })
 }
 
-/// Encode a rune slice back into the term's stored key bytes, delegating to the
-/// C `runesToStr` so the reconstruction matches how the terms trie encoded the
-/// key at index time — byte for byte, including the WTF-8 form a lone surrogate
-/// takes.
-///
-/// Returns `None` when the slice is longer than
-/// [`MAX_RUNE_STR_LEN`](ffi::MAX_RUNE_STR_LEN) runes, the point at which the
-/// conversion declines and the expansion must be skipped.
-pub(crate) fn runes_to_key(runes: &[ffi::rune]) -> Option<Vec<u8>> {
-    let mut len: usize = 0;
-    // SAFETY: `runes` is a valid slice of `runes.len()` runes; `runesToStr`
-    // returns a freshly allocated, NUL-terminated buffer of `len` bytes, or NULL
-    // when the slice exceeds `MAX_RUNE_STR_LEN`.
-    let ptr = unsafe { ffi::runesToStr(runes.as_ptr(), runes.len(), &mut len) };
-    let ptr = NonNull::new(ptr)?;
-    // SAFETY: `ptr` points to `len` valid bytes written by the call above.
-    let key = unsafe { std::slice::from_raw_parts(ptr.as_ptr().cast::<u8>(), len) }.to_vec();
-    // SAFETY: `RedisModule_Free` is set during module init and not mutated
-    // afterwards.
-    let rm_free = unsafe { redis_module::RedisModule_Free.expect("Redis allocator not available") };
-    // SAFETY: `ptr` was allocated by the module allocator inside `runesToStr`.
-    unsafe { rm_free(ptr.as_ptr().cast::<std::ffi::c_void>()) };
-    Some(key)
-}
-
 /// A single pattern expansion in progress: the inputs every walk shares, the
 /// context they open readers against, and the readers opened so far.
 ///

--- a/src/redisearch_rs/query_eval/src/nodes/prefix.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/prefix.rs
@@ -18,10 +18,10 @@ use query_types::QueryNodeType;
 use rqe_core::FieldMask;
 use rqe_iterators::{c2rust::CRQEIterator, union_opaque::build_union_with_q_str};
 use rs_token::RSTokenRefNulTerminated;
+use string_utils::runes::runes_to_bytes;
 
 use crate::{
-    Config, Evaluated, QueryEvalContext, QueryNodeRef,
-    expansion::{Expansion, runes_to_key},
+    Config, Evaluated, QueryEvalContext, QueryNodeRef, expansion::Expansion,
     expansion_needs_offsets,
 };
 
@@ -243,7 +243,7 @@ impl Expansion<'_> {
         // byte as the index stored it — WTF-8 rather than UTF-8 where a rune is a
         // lone surrogate.
         let on_runes = |runes: &[ffi::rune], num_docs: usize| {
-            let Some(key) = runes_to_key(runes) else {
+            let Ok(key) = runes_to_bytes(runes) else {
                 // The term key cannot be reconstructed; skip this expansion.
                 return ControlFlow::Continue(());
             };

--- a/src/redisearch_rs/query_eval/src/nodes/wildcard_query.rs
+++ b/src/redisearch_rs/query_eval/src/nodes/wildcard_query.rs
@@ -15,10 +15,10 @@ use c_trie::{CTrieRef, LoweredPattern, SuffixWalk};
 use query_error::QueryErrorCode;
 use query_types::QueryNodeType;
 use rqe_iterators::union_opaque::build_union_with_q_str;
+use string_utils::runes::runes_to_bytes;
 
 use crate::{
-    Config, Evaluated, QueryEvalContext, QueryNodeMut,
-    expansion::{Expansion, runes_to_key},
+    Config, Evaluated, QueryEvalContext, QueryNodeMut, expansion::Expansion,
     expansion_needs_offsets,
 };
 
@@ -261,7 +261,7 @@ impl Expansion<'_> {
             if self.cap_reached() {
                 return ControlFlow::Break(());
             }
-            let Some(key) = runes_to_key(runes) else {
+            let Ok(key) = runes_to_bytes(runes) else {
                 // The term key cannot be reconstructed; skip this expansion.
                 return ControlFlow::Continue(());
             };

--- a/src/redisearch_rs/string_utils/Cargo.toml
+++ b/src/redisearch_rs/string_utils/Cargo.toml
@@ -29,6 +29,7 @@ workspace_hack.workspace = true
 
 [dev-dependencies]
 criterion = { workspace = true }
+rstest.workspace = true
 proptest = { workspace = true, features = ["std"] }
 redis_mock.workspace = true
 redisearch_rs = { workspace = true, features = ["mock_allocator"] }

--- a/src/redisearch_rs/string_utils/src/runes.rs
+++ b/src/redisearch_rs/string_utils/src/runes.rs
@@ -12,15 +12,40 @@
 //! A rune ([`u16`]) is a UTF-16 code unit; tries store and look up terms as
 //! rune arrays.
 
+use std::ptr::NonNull;
+
 /// Maximum number of runes (lowercased codepoints) allowed in a single conversion.
 pub const MAX_RUNE_STR_LEN: usize = ffi::MAX_RUNE_STR_LEN as usize;
 
-/// Error returned when the lowercased rune sequence exceeds
-/// [`MAX_RUNE_STR_LEN`].
+/// Error returned when a rune sequence exceeds [`MAX_RUNE_STR_LEN`].
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[error("lowercased rune length {len} exceeds maximum {MAX_RUNE_STR_LEN}")]
+#[error("rune length {len} exceeds maximum {MAX_RUNE_STR_LEN}")]
 pub struct RuneStrTooLong {
     pub len: usize,
+}
+
+/// Convert a rune slice into a byte slice using UFT-8 encoding mechanism
+/// without validating actual unicode code points.
+///
+/// Returns [`Err(`[`RuneStrTooLong`]`)`] if `runes` exceeds
+/// [`MAX_RUNE_STR_LEN`].
+pub fn runes_to_bytes(runes: &[ffi::rune]) -> Result<Vec<u8>, RuneStrTooLong> {
+    let mut len: usize = 0;
+    // SAFETY: `runes` is a valid slice of `runes.len()` runes; `runesToStr`
+    // returns a freshly allocated, NUL-terminated buffer of `len` bytes, or NULL
+    // when the slice exceeds `MAX_RUNE_STR_LEN`.
+    let ptr = unsafe { ffi::runesToStr(runes.as_ptr(), runes.len(), &mut len) };
+    let Some(ptr) = NonNull::new(ptr) else {
+        return Err(RuneStrTooLong { len: runes.len() });
+    };
+    // SAFETY: `ptr` points to `len` valid bytes written by the call above.
+    let bytes = unsafe { std::slice::from_raw_parts(ptr.as_ptr().cast::<u8>(), len) }.to_vec();
+    // SAFETY: `RedisModule_Free` is set during module init and not mutated
+    // afterwards.
+    let rm_free = unsafe { redis_module::RedisModule_Free.expect("Redis allocator not available") };
+    // SAFETY: `ptr` was allocated by the module allocator inside `runesToStr`.
+    unsafe { rm_free(ptr.as_ptr().cast::<std::ffi::c_void>()) };
+    Ok(bytes)
 }
 
 /// Convert a UTF-8 string to a lowercase array of runes ([`u16`]) for trie

--- a/src/redisearch_rs/string_utils/tests/integration/main.rs
+++ b/src/redisearch_rs/string_utils/tests/integration/main.rs
@@ -11,6 +11,7 @@
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 extern crate redisearch_rs;
 
+mod runes_to_bytes;
 mod str_to_lower_runes;
 mod tag_strtolower;
 mod unicode_tolower;

--- a/src/redisearch_rs/string_utils/tests/integration/runes_to_bytes.rs
+++ b/src/redisearch_rs/string_utils/tests/integration/runes_to_bytes.rs
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Disabled under Miri: [`runes_to_bytes`] delegates to the C `runesToStr`,
+#![cfg(not(miri))]
+
+use rstest::rstest;
+use string_utils::runes::{MAX_RUNE_STR_LEN, runes_to_bytes, str_to_lower_runes};
+
+#[test]
+fn roundtrips_ascii() {
+    let runes = str_to_lower_runes("apricot").unwrap();
+    assert_eq!(runes_to_bytes(&runes).unwrap(), b"apricot");
+}
+
+#[test]
+fn roundtrips_multibyte() {
+    let runes = str_to_lower_runes("é").unwrap();
+    assert_eq!(runes_to_bytes(&runes).unwrap(), "é".as_bytes());
+}
+
+#[test]
+fn empty_slice_returns_empty_vec() {
+    assert_eq!(runes_to_bytes(&[]).unwrap(), b"");
+}
+
+/// The byte-length boundaries of the encoding.
+#[rstest]
+#[case::one_byte_max(0x007F, &[0x7F])]
+#[case::two_byte_min(0x0080, &[0xC2, 0x80])]
+#[case::two_byte_max(0x07FF, &[0xDF, 0xBF])]
+#[case::three_byte_min(0x0800, &[0xE0, 0xA0, 0x80])]
+#[case::three_byte_max(0xFFFF, &[0xEF, 0xBF, 0xBF])]
+fn encodes_one_two_and_three_byte_runes(#[case] rune: u16, #[case] expected: &[u8]) {
+    assert_eq!(runes_to_bytes(&[rune]).unwrap(), expected);
+}
+
+/// A surrogate is encoded by its own scalar value, so a pair becomes two
+/// three-byte sequences rather than the four-byte form of the character it
+/// would denote in UTF-16.
+#[rstest]
+#[case::lone(&[0xD83D], &[0xED, 0xA0, 0xBD])]
+#[case::pair(&[0xD83D, 0xDE00], &[0xED, 0xA0, 0xBD, 0xED, 0xB8, 0x80])]
+fn surrogates_encode_as_wtf8_and_are_never_paired(#[case] runes: &[u16], #[case] expected: &[u8]) {
+    assert_eq!(runes_to_bytes(runes).unwrap(), expected);
+}
+
+/// early zero rune termination.
+#[rstest]
+#[case::leading(&[0, b'a' as u16], b"")]
+#[case::embedded(&[b'a' as u16, 0, b'b' as u16], b"a")]
+#[case::trailing(&[b'a' as u16, 0], b"a")]
+fn zero_rune_terminates_the_sequence(#[case] runes: &[u16], #[case] expected: &[u8]) {
+    assert_eq!(runes_to_bytes(runes).unwrap(), expected);
+}
+
+#[test]
+fn exactly_at_limit() {
+    let runes = vec![b'a' as u16; MAX_RUNE_STR_LEN];
+    assert_eq!(runes_to_bytes(&runes).unwrap().len(), MAX_RUNE_STR_LEN);
+}
+
+#[test]
+fn exceeds_limit() {
+    let runes = vec![b'a' as u16; MAX_RUNE_STR_LEN + 1];
+    let err = runes_to_bytes(&runes).unwrap_err();
+    assert_eq!(err.len, MAX_RUNE_STR_LEN + 1);
+}


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: the conversion that reconstructs a term's stored key from its runes lives in
   `query_eval`'s expansion module as a private `runes_to_key`, so the trie wrappers
   cannot reach it.
2. Change: it becomes `string_utils::runes::runes_to_bytes`, taking the
   `Result`/`RuneStrTooLong` shape the rest of that module uses. The body still delegates
   to the C `runesToStr`.
3. Outcome: internal only. Makes the conversion reusable and gives it direct test
   coverage it did not have before.

Here is the pure Rust replacement if you want to take a look: https://github.com/RediSearch/RediSearch/commit/092d8128e43eef4348affab0ae3d7651cf7070ae

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `string_utils::runes::runes_to_bytes` — new home for the conversion.
2. `string_utils::runes::RuneStrTooLong` — generalised now that a second function returns it.
3. `query_eval::expansion` — `runes_to_key` removed; both call sites switch over.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes