### PR TITLE
Extend `TermsTrie` and `SuffixTrie` with whole trie `iterator` and term `delete`

### DIFF
--- a/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
@@ -20,5 +20,7 @@ mod terms;
 mod util;
 
 pub use suffix::{SuffixMode, SuffixTrie, SuffixWalk};
-pub use terms::{FuzzyWalk, InvalidFuzzyDistance, TermsTrie, TermsTrieDecrResult};
+pub use terms::{
+    FuzzyWalk, InvalidFuzzyDistance, TermsTrie, TermsTrieAllIterator, TermsTrieDecrResult,
+};
 pub use util::LoweredPattern;

--- a/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/lib.rs
@@ -12,8 +12,8 @@
 //! This crate provides a safe Rust interface to the C Trie implementation, one
 //! module per trie kind: [`TermsTrie`] for the primary term index and
 //! [`SuffixTrie`] for the suffix index that answers queries which are not
-//! front-anchored. [`LoweredPattern`], the wildcard pattern both kinds walk
-//! with, sits alongside them.
+//! front-anchored. [`TrieTerm`] represents terms valid for trie operations,
+//! while [`LoweredPattern`] carries the wildcard patterns they walk.
 
 mod suffix;
 mod terms;
@@ -23,4 +23,4 @@ pub use suffix::{SuffixMode, SuffixTrie, SuffixWalk};
 pub use terms::{
     FuzzyWalk, InvalidFuzzyDistance, TermsTrie, TermsTrieAllIterator, TermsTrieDecrResult,
 };
-pub use util::LoweredPattern;
+pub use util::{LoweredPattern, TrieTerm};

--- a/src/redisearch_rs/c_wrappers/c_trie/src/suffix.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/suffix.rs
@@ -22,7 +22,7 @@ use ffi::{
     SuffixType_SUFFIX_TYPE_WILDCARD,
 };
 
-use crate::LoweredPattern;
+use crate::{LoweredPattern, TrieTerm};
 
 /// Which side(s) of a term a [`SuffixTrie::iterate_contains`] walk anchors on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -268,18 +268,18 @@ impl SuffixTrie {
         }
     }
 
-    /// Remove `term` and all of its suffixes from the suffix trie.
-    pub fn delete(&mut self, term: &[u8]) {
-        let Ok(term_len) = u32::try_from(term.len()) else {
-            // The C API takes a `uint32_t` length. A term this long was never
-            // inserted, and truncating would delete an unrelated entry.
-            return;
-        };
+    /// Remove `term` and all of its registered suffixes.
+    pub fn delete(&mut self, term: &TrieTerm) {
+        let term = term.as_bytes();
+        // A valid `TrieTerm` decodes to fewer than
+        // `TRIE_INITIAL_STRING_LEN` runes, each consuming at most four bytes.
+        let term_len = u32::try_from(term.len()).expect("a valid trie term length fits in u32");
 
         // SAFETY: `self` borrows a valid `ffi::Trie` whose payloads are `suffixData`
         // and whose free callback releases them, so unregistering the term and
-        // freeing the nodes it empties is sound. `term`/`term_len` describe a
-        // readable byte slice for the call.
+        // freeing the nodes it empties is sound. `TrieTerm` guarantees that the
+        // C decoder can consume `term` without reading beyond the slice or
+        // treating an interior zero codepoint as its end.
         unsafe {
             ffi::deleteSuffixTrie(self.as_mut_ptr(), term.as_ptr() as *const c_char, term_len);
         }

--- a/src/redisearch_rs/c_wrappers/c_trie/src/suffix.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/suffix.rs
@@ -267,4 +267,21 @@ impl SuffixTrie {
             SuffixWalk::Walked
         }
     }
+
+    /// Remove `term` and all of its suffixes from the suffix trie.
+    pub fn delete(&mut self, term: &[u8]) {
+        let Ok(term_len) = u32::try_from(term.len()) else {
+            // The C API takes a `uint32_t` length. A term this long was never
+            // inserted, and truncating would delete an unrelated entry.
+            return;
+        };
+
+        // SAFETY: `self` borrows a valid `ffi::Trie` whose payloads are `suffixData`
+        // and whose free callback releases them, so unregistering the term and
+        // freeing the nodes it empties is sound. `term`/`term_len` describe a
+        // readable byte slice for the call.
+        unsafe {
+            ffi::deleteSuffixTrie(self.as_mut_ptr(), term.as_ptr() as *const c_char, term_len);
+        }
+    }
 }

--- a/src/redisearch_rs/c_wrappers/c_trie/src/suffix.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/suffix.rs
@@ -270,7 +270,6 @@ impl SuffixTrie {
 
     /// Remove `term` and all of its registered suffixes.
     pub fn delete(&mut self, term: &TrieTerm) {
-        let term = term.as_bytes();
         // A valid `TrieTerm` decodes to fewer than
         // `TRIE_INITIAL_STRING_LEN` runes, each consuming at most four bytes.
         let term_len = u32::try_from(term.len()).expect("a valid trie term length fits in u32");

--- a/src/redisearch_rs/c_wrappers/c_trie/src/terms.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/terms.rs
@@ -564,7 +564,6 @@ impl TermsTrie {
     ///
     /// Returns whether an entry was actually removed.
     pub fn delete(&mut self, term: &TrieTerm) -> bool {
-        let term = term.as_bytes();
         // SAFETY: `self` borrows a valid `ffi::Trie`; `TrieTerm` guarantees that
         // the C decoder can consume `term` without reading beyond the slice or
         // treating an interior zero codepoint as its end.

--- a/src/redisearch_rs/c_wrappers/c_trie/src/terms.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/terms.rs
@@ -21,7 +21,7 @@ use string_utils::{
     runes::runes_to_bytes,
 };
 
-use crate::LoweredPattern;
+use crate::{LoweredPattern, TrieTerm};
 
 /// Adapts a [`ffi::TrieRangeCallback`] to a Rust closure handed back through
 /// the opaque `ctx` pointer for every matching term.
@@ -563,16 +563,11 @@ impl TermsTrie {
     /// Remove `term` from the trie.
     ///
     /// Returns whether an entry was actually removed.
-    pub fn delete(&mut self, term: &[u8]) -> bool {
-        // Terms longer than the trie can store are never present, so report a
-        // miss without a lookup. The C function applies the same cap, but only
-        // after the rune conversion below has already run.
-        if term.len() > ffi::TRIE_INITIAL_STRING_LEN as usize * std::mem::size_of::<ffi::rune>() {
-            return false;
-        }
-
-        // SAFETY: `self` borrows a valid `ffi::Trie`, and `term`/`term.len()`
-        // describe a readable byte slice for the duration of the call.
+    pub fn delete(&mut self, term: &TrieTerm) -> bool {
+        let term = term.as_bytes();
+        // SAFETY: `self` borrows a valid `ffi::Trie`; `TrieTerm` guarantees that
+        // the C decoder can consume `term` without reading beyond the slice or
+        // treating an interior zero codepoint as its end.
         let removed = unsafe {
             ffi::Trie_Delete(
                 self.as_mut_ptr(),
@@ -642,7 +637,7 @@ impl<'a> TermsTrieAllIterator<'a> {
 }
 
 impl Iterator for TermsTrieAllIterator<'_> {
-    type Item = Vec<u8>;
+    type Item = TrieTerm;
 
     fn next(&mut self) -> Option<Self::Item> {
         let runes = self.advance()?;
@@ -650,12 +645,15 @@ impl Iterator for TermsTrieAllIterator<'_> {
         // runes, well inside the `MAX_RUNE_STR_LEN` which `runes_to_bytes`
         // requires, so every key this iterator yields converts.
         let bytes = runes_to_bytes(runes).expect("a stored trie key fits within MAX_RUNE_STR_LEN");
-        Some(bytes)
+        // SAFETY: the iterator only yields non-empty keys accepted by the terms
+        // trie. `runes_to_bytes` emits a complete encoding of every rune, with
+        // no zero rune, and the key is shorter than `TRIE_INITIAL_STRING_LEN`.
+        Some(unsafe { TrieTerm::from_bytes_unchecked(bytes.into_boxed_slice()) })
     }
 }
 
 impl<'a> IntoIterator for &'a TermsTrie {
-    type Item = Vec<u8>;
+    type Item = TrieTerm;
     type IntoIter = TermsTrieAllIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/src/redisearch_rs/c_wrappers/c_trie/src/terms.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/terms.rs
@@ -16,7 +16,10 @@ use std::{
     ptr::{self, NonNull},
 };
 
-use string_utils::libnu::{NU_MAX_READAHEAD, tail_may_overread};
+use string_utils::{
+    libnu::{NU_MAX_READAHEAD, tail_may_overread},
+    runes::runes_to_bytes,
+};
 
 use crate::LoweredPattern;
 
@@ -549,5 +552,121 @@ impl TermsTrie {
                 skip_timeout_checks,
             );
         }
+    }
+
+    /// Iterate every term in the trie, in the trie's natural iteration order,
+    /// with no filter or distance constraint.
+    pub fn iterate_all(&self) -> TermsTrieAllIterator<'_> {
+        TermsTrieAllIterator::new(self)
+    }
+
+    /// Remove `term` from the trie.
+    ///
+    /// Returns whether an entry was actually removed.
+    pub fn delete(&mut self, term: &[u8]) -> bool {
+        // Terms longer than the trie can store are never present, so report a
+        // miss without a lookup. The C function applies the same cap, but only
+        // after the rune conversion below has already run.
+        if term.len() > ffi::TRIE_INITIAL_STRING_LEN as usize * std::mem::size_of::<ffi::rune>() {
+            return false;
+        }
+
+        // SAFETY: `self` borrows a valid `ffi::Trie`, and `term`/`term.len()`
+        // describe a readable byte slice for the duration of the call.
+        let removed = unsafe {
+            ffi::Trie_Delete(
+                self.as_mut_ptr(),
+                term.as_ptr() as *const c_char,
+                term.len(),
+            )
+        };
+
+        removed != 0
+    }
+}
+
+/// Iterator over every term in a trie.
+///
+/// Reached through [`TermsTrie::iterate_all`], the public entry point.
+pub struct TermsTrieAllIterator<'a> {
+    ptr: NonNull<ffi::TrieIterator>,
+    _borrow: PhantomData<&'a TermsTrie>,
+}
+
+impl<'a> TermsTrieAllIterator<'a> {
+    fn new(trie: &'a TermsTrie) -> Self {
+        // SAFETY: `trie` borrows a valid `ffi::Trie`. `Trie_IterateAll` takes a
+        // non-const `Trie *` but only reads it to seed the iterator's own stack,
+        // so nothing is written through the shared pointer.
+        let ptr = unsafe { ffi::Trie_IterateAll(trie.as_ptr().cast_mut()) };
+        Self {
+            // `Trie_IterateAll` allocates via `rm_calloc`, which aborts the
+            // process on allocation failure rather than returning null.
+            ptr: NonNull::new(ptr).expect("Trie_IterateAll returned null"),
+            _borrow: PhantomData,
+        }
+    }
+
+    /// Advance the walk, returning the next term's rune key, or `None` once
+    /// every term has been visited.
+    fn advance(&mut self) -> Option<&[ffi::rune]> {
+        let mut ptr: *mut ffi::rune = std::ptr::null_mut();
+        let mut len: ffi::t_len = 0;
+        let mut score: f32 = 0.0;
+
+        // SAFETY: `self.ptr` is a valid, non-exhausted `TrieIterator`. `score`
+        // is a valid `&mut f32` the C function may write through unconditionally
+        // on a match; `numDocs`, `payload` and `matchCtx` are unused, and the C
+        // side skips each of them when null.
+        let has_next = unsafe {
+            ffi::TrieIterator_Next(
+                self.ptr.as_ptr(),
+                &mut ptr,
+                &mut len,
+                std::ptr::null_mut(),
+                &mut score,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+
+        if has_next == 0 {
+            return None;
+        }
+
+        // SAFETY: on a match, the C function sets `ptr`/`len` to describe
+        // `len` valid, contiguous runes owned by the iterator's internal
+        // buffer, borrowed for `self`'s lifetime until the next call.
+        Some(unsafe { std::slice::from_raw_parts(ptr, len as usize) })
+    }
+}
+
+impl Iterator for TermsTrieAllIterator<'_> {
+    type Item = Vec<u8>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let runes = self.advance()?;
+        // terms trie insertion caps a trie key at `TRIE_INITIAL_STRING_LEN`
+        // runes, well inside the `MAX_RUNE_STR_LEN` which `runes_to_bytes`
+        // requires, so every key this iterator yields converts.
+        let bytes = runes_to_bytes(runes).expect("a stored trie key fits within MAX_RUNE_STR_LEN");
+        Some(bytes)
+    }
+}
+
+impl<'a> IntoIterator for &'a TermsTrie {
+    type Item = Vec<u8>;
+    type IntoIter = TermsTrieAllIterator<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iterate_all()
+    }
+}
+
+impl Drop for TermsTrieAllIterator<'_> {
+    fn drop(&mut self) {
+        // SAFETY: `self.ptr` was allocated by `Trie_IterateAll` and has not
+        // been freed yet (owned exclusively by this iterator).
+        unsafe { ffi::TrieIterator_Free(self.ptr.as_ptr()) };
     }
 }

--- a/src/redisearch_rs/c_wrappers/c_trie/src/util.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/util.rs
@@ -7,6 +7,37 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+/// An owned byte sequence that is valid input to the trie wrapper.
+///
+/// # Validity invariants
+///
+/// Validity is about whether the legacy C trie functions can safely consume the
+/// bytes. The bytes must encode a non-empty key, the decoder must not read beyond
+/// the initialized byte sequence or stop at an interior zero codepoint, and the
+/// decoded key must fit the primary trie. This permits invalid UTF-8 encodings
+/// that the trie accepts.
+#[derive(Clone, Debug)]
+pub struct TrieTerm {
+    bytes: Box<[u8]>,
+}
+
+impl TrieTerm {
+    /// Construct a term without validating `bytes`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `bytes` satisfies the
+    /// [validity invariants](Self#validity-invariants).
+    pub const unsafe fn from_bytes_unchecked(bytes: Box<[u8]>) -> Self {
+        Self { bytes }
+    }
+
+    /// Return the term's byte representation.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
 /// A lowercased wildcard pattern, in both encodings the wildcard walks need.
 ///
 /// The lowercasing is the *caller's* job and is not checked here. A pattern

--- a/src/redisearch_rs/c_wrappers/c_trie/src/util.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/src/util.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::ops::Deref;
+
 /// An owned byte sequence that is valid input to the trie wrapper.
 ///
 /// # Validity invariants
@@ -32,9 +34,22 @@ impl TrieTerm {
         Self { bytes }
     }
 
+    /// Consume the term, returning the buffer it owns.
+    pub fn into_bytes(self) -> Box<[u8]> {
+        self.bytes
+    }
+
     /// Return the term's byte representation.
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes
+    }
+}
+
+impl Deref for TrieTerm {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_bytes()
     }
 }
 

--- a/src/redisearch_rs/c_wrappers/c_trie/tests/suffix.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/tests/suffix.rs
@@ -23,8 +23,14 @@ use std::{
     ops::ControlFlow,
 };
 
-use c_trie::{LoweredPattern, SuffixMode, SuffixTrie, SuffixWalk};
+use c_trie::{LoweredPattern, SuffixMode, SuffixTrie, SuffixWalk, TrieTerm};
 use ffi::{SuffixType, SuffixType_SUFFIX_TYPE_CONTAINS, SuffixType_SUFFIX_TYPE_SUFFIX};
+
+fn trie_term(term: &str) -> TrieTerm {
+    // SAFETY: every test input is the complete byte representation of a
+    // non-empty key accepted by the primary terms trie.
+    unsafe { TrieTerm::from_bytes_unchecked(Box::from(term.as_bytes())) }
+}
 
 /// Convert an ASCII/UTF-8 string to the trie's rune (`u16`) key.
 fn to_runes(s: &str) -> Vec<ffi::rune> {
@@ -346,7 +352,7 @@ fn suffix_delete_removes_the_term_from_every_suffix_it_registered() {
             "both terms end in `ple` to start with"
         );
 
-        trie.delete(b"apple");
+        trie.delete(&trie_term("apple"));
 
         assert_eq!(
             suffix_matches(trie, "ple", SuffixMode::Suffix),
@@ -370,7 +376,7 @@ fn suffix_delete_ignores_an_absent_term() {
     // The suffix trie is shared by every TEXT field in an index, including those
     // that never contributed to it, so a miss is expected rather than an error.
     with_suffix_trie(&["apple"], |trie| {
-        trie.delete(b"grape");
+        trie.delete(&trie_term("grape"));
         assert_eq!(
             suffix_matches(trie, "ple", SuffixMode::Suffix),
             set(&["apple"]),

--- a/src/redisearch_rs/c_wrappers/c_trie/tests/suffix.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/tests/suffix.rs
@@ -51,9 +51,10 @@ fn pattern(s: &str) -> LoweredPattern {
     LoweredPattern::new(&to_runes(s)).expect("pattern is short enough to convert")
 }
 
-/// Build a *suffix* trie holding `terms` (and all their suffixes), run `f`, then
-/// free it. `terms` must be non-empty strings — `addSuffixTrie` asserts on empty.
-fn with_suffix_trie(terms: &[&str], f: impl FnOnce(&SuffixTrie)) {
+/// Build a *suffix* trie holding `terms` (and all their suffixes), run `f`
+/// against an exclusive handle, then free it. `terms` must be non-empty strings
+/// — `addSuffixTrie` asserts on empty.
+fn with_suffix_trie(terms: &[&str], f: impl FnOnce(&mut SuffixTrie)) {
     // SAFETY: `NewTrie` returns a fresh, valid trie; `suffixTrie_freeCallback` is
     // the matching free callback for the payloads `addSuffixTrie` inserts.
     let trie_ptr = unsafe {
@@ -71,10 +72,21 @@ fn with_suffix_trie(terms: &[&str], f: impl FnOnce(&SuffixTrie)) {
     }
     // SAFETY: `trie_ptr` is a valid trie that stays alive for the whole closure
     // and is not freed until after it returns. No other handle to it exists.
-    let trie = unsafe { SuffixTrie::from_raw(trie_ptr) };
+    let trie = unsafe { SuffixTrie::from_raw_mut(trie_ptr) };
     f(trie);
     // SAFETY: freed exactly once after the last use of `trie`.
     unsafe { ffi::TrieType_Free(trie_ptr.cast::<c_void>()) };
+}
+
+/// Every term a suffix trie reports for `pattern` under `mode`.
+fn suffix_matches(trie: &SuffixTrie, pattern: &str, mode: SuffixMode) -> HashSet<String> {
+    let runes = to_runes(pattern);
+    let mut found = HashSet::new();
+    trie.iterate_contains(&runes, mode, |term| {
+        found.insert(String::from_utf8_lossy(term).into_owned());
+        ControlFlow::Continue(())
+    });
+    found
 }
 
 /// Corpus used across the anchoring tests. Every term contains `"ap"`; only
@@ -315,6 +327,54 @@ fn suffix_iterate_wildcard_break_is_ignored_for_an_anchor_without_a_trailing_sta
         assert_eq!(
             count, 2,
             "one callback per matching suffix key, despite Break"
+        );
+    });
+}
+
+// --- `delete` ---------------------------------------------------------------
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "calling the C trie's foreign functions is not supported by Miri"
+)]
+fn suffix_delete_removes_the_term_from_every_suffix_it_registered() {
+    with_suffix_trie(&["apple", "maple"], |trie| {
+        assert_eq!(
+            suffix_matches(trie, "ple", SuffixMode::Suffix),
+            set(&["apple", "maple"]),
+            "both terms end in `ple` to start with"
+        );
+
+        trie.delete(b"apple");
+
+        assert_eq!(
+            suffix_matches(trie, "ple", SuffixMode::Suffix),
+            set(&["maple"]),
+            "only the deleted term is gone"
+        );
+        assert_eq!(
+            suffix_matches(trie, "pp", SuffixMode::Contains),
+            HashSet::new(),
+            "a suffix unique to the deleted term matches nothing"
+        );
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "calling the C trie's foreign functions is not supported by Miri"
+)]
+fn suffix_delete_ignores_an_absent_term() {
+    // The suffix trie is shared by every TEXT field in an index, including those
+    // that never contributed to it, so a miss is expected rather than an error.
+    with_suffix_trie(&["apple"], |trie| {
+        trie.delete(b"grape");
+        assert_eq!(
+            suffix_matches(trie, "ple", SuffixMode::Suffix),
+            set(&["apple"]),
+            "the trie is left untouched"
         );
     });
 }

--- a/src/redisearch_rs/c_wrappers/c_trie/tests/terms.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/tests/terms.rs
@@ -109,7 +109,7 @@ fn with_terms_trie(terms: &[&str], f: impl FnOnce(&mut TermsTrie)) {
 /// Every term currently stored in a terms trie.
 fn terms_of(trie: &TermsTrie) -> HashSet<String> {
     trie.iterate_all()
-        .map(|term| String::from_utf8(term.as_bytes().to_vec()).expect("term is valid UTF-8"))
+        .map(|term| String::from_utf8(term.into_bytes().into_vec()).expect("term is valid UTF-8"))
         .collect()
 }
 
@@ -616,7 +616,7 @@ fn iterate_all_visits_every_term() {
     with_terms_trie(CORPUS, |trie| {
         let got: HashSet<String> = trie
             .iterate_all()
-            .map(|term| String::from_utf8(term.as_bytes().to_vec()).expect("terms are ASCII"))
+            .map(|term| String::from_utf8(term.into_bytes().into_vec()).expect("terms are ASCII"))
             .collect();
         assert_eq!(got, set(CORPUS));
     });
@@ -643,7 +643,7 @@ fn into_iter_visits_every_term() {
     with_terms_trie(CORPUS, |trie| {
         let mut got = HashSet::new();
         for term in &*trie {
-            got.insert(String::from_utf8(term.as_bytes().to_vec()).expect("terms are ASCII"));
+            got.insert(String::from_utf8(term.into_bytes().into_vec()).expect("terms are ASCII"));
         }
         assert_eq!(got, set(CORPUS));
     });

--- a/src/redisearch_rs/c_wrappers/c_trie/tests/terms.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/tests/terms.rs
@@ -69,8 +69,9 @@ fn pattern(s: &str) -> LoweredPattern {
 }
 
 /// Build a terms trie holding `terms`, each keyed with `numDocs == term length`
-/// (so tests can assert the document count flows through), run `f`, then free it.
-fn with_terms_trie(terms: &[&str], f: impl FnOnce(&TermsTrie)) {
+/// (so tests can assert the document count flows through), run `f` against an
+/// exclusive handle, then free it.
+fn with_terms_trie(terms: &[&str], f: impl FnOnce(&mut TermsTrie)) {
     // SAFETY: `NewTrie` returns a fresh, valid, empty terms trie; a terms trie
     // stores no payload, so a null free callback is correct.
     let trie_ptr = unsafe { ffi::NewTrie(None, ffi::TrieSortMode_Trie_Sort_Lex) };
@@ -92,11 +93,18 @@ fn with_terms_trie(terms: &[&str], f: impl FnOnce(&TermsTrie)) {
     }
     // SAFETY: `trie_ptr` is a valid trie that stays alive for the whole closure
     // and is not freed until after it returns. No other handle to it exists.
-    let trie = unsafe { TermsTrie::from_raw(trie_ptr) };
+    let trie = unsafe { TermsTrie::from_raw_mut(trie_ptr) };
     f(trie);
     // SAFETY: `trie_ptr` was produced by `NewTrie` and is freed exactly once
     // here, after the last use of `trie`.
     unsafe { ffi::TrieType_Free(trie_ptr.cast::<c_void>()) };
+}
+
+/// Every term currently stored in a terms trie.
+fn terms_of(trie: &TermsTrie) -> HashSet<String> {
+    trie.iterate_all()
+        .map(|term| String::from_utf8(term).expect("term is valid UTF-8"))
+        .collect()
 }
 
 /// Corpus used across the anchoring tests. Every term contains `"ap"`; only
@@ -591,6 +599,50 @@ fn iterate_fuzzy_refuses_an_over_long_truncated_tail_before_padding_it() {
     });
 }
 
+// --- `iterate_all` ----------------------------------------------------------
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_all_visits_every_term() {
+    with_terms_trie(CORPUS, |trie| {
+        let got: HashSet<String> = trie
+            .iterate_all()
+            .map(|term| String::from_utf8(term).expect("terms are ASCII"))
+            .collect();
+        assert_eq!(got, set(CORPUS));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn iterate_all_empty_trie_visits_nothing() {
+    with_terms_trie(&[], |trie| {
+        assert_eq!(trie.iterate_all().count(), 0);
+    });
+}
+
+/// `for term in &trie` reaches the same walk as `iterate_all`.
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn into_iter_visits_every_term() {
+    with_terms_trie(CORPUS, |trie| {
+        let mut got = HashSet::new();
+        for term in &*trie {
+            got.insert(String::from_utf8(term).expect("terms are ASCII"));
+        }
+        assert_eq!(got, set(CORPUS));
+    });
+}
+
 // --- `iterate_wildcard` -----------------------------------------------------
 
 #[test]
@@ -746,5 +798,100 @@ fn iterate_wildcard_some_and_none_timeout_agree() {
 
         assert_eq!(none_hits, set(&["apple", "apricot"]));
         assert_eq!(some_hits, none_hits);
+    });
+}
+
+// --- `delete` ---------------------------------------------------------------
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "calling the C trie's foreign functions is not supported by Miri"
+)]
+fn delete_removes_a_stored_term() {
+    with_terms_trie(&["apple", "maple", "grape"], |trie| {
+        assert!(trie.delete(b"maple"), "a stored term is removed");
+        assert_eq!(terms_of(trie), set(&["apple", "grape"]));
+        assert_eq!(trie.num_docs(b"maple"), 0);
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "calling the C trie's foreign functions is not supported by Miri"
+)]
+fn delete_removes_a_term_that_still_has_documents() {
+    // Unlike `decrement_num_docs`, `delete` does not care about the doc count:
+    // the term goes away in one step.
+    with_terms_trie(&["apple"], |trie| {
+        assert_eq!(trie.num_docs(b"apple"), 5, "inserted with numDocs == 5");
+        assert!(trie.delete(b"apple"));
+        assert_eq!(terms_of(trie), HashSet::new());
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "calling the C trie's foreign functions is not supported by Miri"
+)]
+fn delete_reports_a_miss_for_an_absent_term() {
+    with_terms_trie(&["apple"], |trie| {
+        let removed = trie.delete(b"apricot");
+        assert!(!removed, "term was never inserted");
+        assert_eq!(terms_of(trie), set(&["apple"]), "trie is left untouched");
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "calling the C trie's foreign functions is not supported by Miri"
+)]
+fn delete_reports_a_miss_for_a_prefix_of_a_stored_term() {
+    with_terms_trie(&["apple"], |trie| {
+        let removed = trie.delete(b"app");
+        assert!(!removed, "a prefix is not an exact match");
+        assert_eq!(terms_of(trie), set(&["apple"]));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "calling the C trie's foreign functions is not supported by Miri"
+)]
+fn delete_reports_a_miss_for_an_empty_term() {
+    // `TrieNode_Add` no-ops on a zero-length key, so the trie can never hold one.
+    with_terms_trie(&["apple"], |trie| {
+        assert!(!trie.delete(b""));
+        assert_eq!(terms_of(trie), set(&["apple"]));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "calling the C trie's foreign functions is not supported by Miri"
+)]
+fn delete_reports_a_miss_for_an_over_long_term() {
+    let too_long = "a".repeat(ffi::TRIE_INITIAL_STRING_LEN as usize * size_of::<ffi::rune>() + 1);
+    with_terms_trie(&["apple"], |trie| {
+        let removed = trie.delete(too_long.as_bytes());
+        assert!(!removed, "longer than the trie holds");
+        assert_eq!(terms_of(trie), set(&["apple"]));
+    });
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "calling the C trie's foreign functions is not supported by Miri"
+)]
+fn delete_of_a_multibyte_term_round_trips() {
+    with_terms_trie(&["héllo", "wörld"], |trie| {
+        assert!(trie.delete("héllo".as_bytes()));
+        assert_eq!(terms_of(trie), set(&["wörld"]));
     });
 }

--- a/src/redisearch_rs/c_wrappers/c_trie/tests/terms.rs
+++ b/src/redisearch_rs/c_wrappers/c_trie/tests/terms.rs
@@ -25,7 +25,13 @@ use std::{
     ptr,
 };
 
-use c_trie::{FuzzyWalk, LoweredPattern, TermsTrie};
+use c_trie::{FuzzyWalk, LoweredPattern, TermsTrie, TrieTerm};
+
+fn trie_term(term: &str) -> TrieTerm {
+    // SAFETY: every test input is the complete byte representation of a
+    // non-empty key accepted by the primary terms trie.
+    unsafe { TrieTerm::from_bytes_unchecked(Box::from(term.as_bytes())) }
+}
 
 /// Convert an ASCII/UTF-8 string to the trie's rune (`u16`) key.
 fn to_runes(s: &str) -> Vec<ffi::rune> {
@@ -103,7 +109,7 @@ fn with_terms_trie(terms: &[&str], f: impl FnOnce(&mut TermsTrie)) {
 /// Every term currently stored in a terms trie.
 fn terms_of(trie: &TermsTrie) -> HashSet<String> {
     trie.iterate_all()
-        .map(|term| String::from_utf8(term).expect("term is valid UTF-8"))
+        .map(|term| String::from_utf8(term.as_bytes().to_vec()).expect("term is valid UTF-8"))
         .collect()
 }
 
@@ -610,7 +616,7 @@ fn iterate_all_visits_every_term() {
     with_terms_trie(CORPUS, |trie| {
         let got: HashSet<String> = trie
             .iterate_all()
-            .map(|term| String::from_utf8(term).expect("terms are ASCII"))
+            .map(|term| String::from_utf8(term.as_bytes().to_vec()).expect("terms are ASCII"))
             .collect();
         assert_eq!(got, set(CORPUS));
     });
@@ -637,7 +643,7 @@ fn into_iter_visits_every_term() {
     with_terms_trie(CORPUS, |trie| {
         let mut got = HashSet::new();
         for term in &*trie {
-            got.insert(String::from_utf8(term).expect("terms are ASCII"));
+            got.insert(String::from_utf8(term.as_bytes().to_vec()).expect("terms are ASCII"));
         }
         assert_eq!(got, set(CORPUS));
     });
@@ -810,7 +816,7 @@ fn iterate_wildcard_some_and_none_timeout_agree() {
 )]
 fn delete_removes_a_stored_term() {
     with_terms_trie(&["apple", "maple", "grape"], |trie| {
-        assert!(trie.delete(b"maple"), "a stored term is removed");
+        assert!(trie.delete(&trie_term("maple")), "a stored term is removed");
         assert_eq!(terms_of(trie), set(&["apple", "grape"]));
         assert_eq!(trie.num_docs(b"maple"), 0);
     });
@@ -826,7 +832,7 @@ fn delete_removes_a_term_that_still_has_documents() {
     // the term goes away in one step.
     with_terms_trie(&["apple"], |trie| {
         assert_eq!(trie.num_docs(b"apple"), 5, "inserted with numDocs == 5");
-        assert!(trie.delete(b"apple"));
+        assert!(trie.delete(&trie_term("apple")));
         assert_eq!(terms_of(trie), HashSet::new());
     });
 }
@@ -838,7 +844,7 @@ fn delete_removes_a_term_that_still_has_documents() {
 )]
 fn delete_reports_a_miss_for_an_absent_term() {
     with_terms_trie(&["apple"], |trie| {
-        let removed = trie.delete(b"apricot");
+        let removed = trie.delete(&trie_term("apricot"));
         assert!(!removed, "term was never inserted");
         assert_eq!(terms_of(trie), set(&["apple"]), "trie is left untouched");
     });
@@ -851,35 +857,8 @@ fn delete_reports_a_miss_for_an_absent_term() {
 )]
 fn delete_reports_a_miss_for_a_prefix_of_a_stored_term() {
     with_terms_trie(&["apple"], |trie| {
-        let removed = trie.delete(b"app");
+        let removed = trie.delete(&trie_term("app"));
         assert!(!removed, "a prefix is not an exact match");
-        assert_eq!(terms_of(trie), set(&["apple"]));
-    });
-}
-
-#[test]
-#[cfg_attr(
-    miri,
-    ignore = "calling the C trie's foreign functions is not supported by Miri"
-)]
-fn delete_reports_a_miss_for_an_empty_term() {
-    // `TrieNode_Add` no-ops on a zero-length key, so the trie can never hold one.
-    with_terms_trie(&["apple"], |trie| {
-        assert!(!trie.delete(b""));
-        assert_eq!(terms_of(trie), set(&["apple"]));
-    });
-}
-
-#[test]
-#[cfg_attr(
-    miri,
-    ignore = "calling the C trie's foreign functions is not supported by Miri"
-)]
-fn delete_reports_a_miss_for_an_over_long_term() {
-    let too_long = "a".repeat(ffi::TRIE_INITIAL_STRING_LEN as usize * size_of::<ffi::rune>() + 1);
-    with_terms_trie(&["apple"], |trie| {
-        let removed = trie.delete(too_long.as_bytes());
-        assert!(!removed, "longer than the trie holds");
         assert_eq!(terms_of(trie), set(&["apple"]));
     });
 }
@@ -891,7 +870,7 @@ fn delete_reports_a_miss_for_an_over_long_term() {
 )]
 fn delete_of_a_multibyte_term_round_trips() {
     with_terms_trie(&["héllo", "wörld"], |trie| {
-        assert!(trie.delete("héllo".as_bytes()));
+        assert!(trie.delete(&trie_term("héllo")));
         assert_eq!(terms_of(trie), set(&["wörld"]));
     });
 }

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -389,6 +389,7 @@ const HEADERS: &[HeaderAllowlist] = &[
             "Suffix_IterateContains",
             "Suffix_IterateWildcard",
             "addSuffixTrie",
+            "deleteSuffixTrie",
             "suffixTrie_freeCallback",
         ],
         types: &["SuffixCtx", "SuffixType"],
@@ -417,8 +418,10 @@ const HEADERS: &[HeaderAllowlist] = &[
         fns: &[
             "NewTrie",
             "Trie_DecrementNumDocs",
+            "Trie_Delete",
             "Trie_GetNode",
             "Trie_InsertStringBuffer",
+            "Trie_IterateAll",
             "Trie_IterateContains",
             "Trie_IterateFuzzy",
             "Trie_IterateWildcard",


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: the wrappers can look up a term and walk terms matching a pattern, but cannot
   enumerate a trie or remove an entry — both of which the Rust terms scanner needs.
2. Change: `TermsTrie::iterate_all` (with `IntoIterator` for `&TermsTrie`),
   `TermsTrie::delete`, and `SuffixTrie::delete`, which unregisters a term from every
   suffix it was indexed under.
3. Outcome: internal only. Unblocks porting the terms scanner to Rust; nothing calls the
   new methods yet.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `TermsTrieAllIterator` — borrows the trie for its lifetime, so the trie cannot be
   mutated while a walk is open.
2. `TermsTrie::delete` / `SuffixTrie::delete` — take `&mut self`, which excludes a walk in
   progress.
3. `SuffixTrie::from_raw_mut` — gains the free-callback obligation, now that deletion can
   free payload-carrying nodes.
4. `ffi/build.rs` — `Trie_Delete`, `Trie_IterateAll`, `TrieIterator*` and
   `deleteSuffixTrie` join the allowlist.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes