### PR TITLE
CI: fix the Rust cache thrash, gate the disk cleanup, split the build artifact

### DIFF
--- a/.github/actions/free-container-disk-space/action.yml
+++ b/.github/actions/free-container-disk-space/action.yml
@@ -1,0 +1,57 @@
+name: Free up container disk space
+description: |
+  Reclaim the host toolchain directories (dotnet, android, ghc, CodeQL) that the
+  runner images ship but our builds never use, for jobs running inside a
+  container. The caller's `container.options` bind-mounts them under /host_usr
+  and /host_opt; this action deletes through those mounts.
+
+  Reclaiming them unlinks millions of small files across a mounted overlay, which
+  costs minutes on the large runners, so it is only worth paying when a build
+  would otherwise risk filling the disk — hence `min-free-gb`.
+
+  This action MUST run after `actions/checkout` (a local action only exists on
+  disk once the repo is checked out) but before the build, test or artifact-
+  download steps that actually consume the space.
+
+  Non-container jobs keep their own inline copy, unconditional and pre-checkout.
+  That is where a local action cannot reach, and it was left alone rather than
+  relocated because it is not on the merge-queue critical path: every Linux
+  distro platform sets `container`, macOS is excluded by that step's own `if`,
+  so the only job it applies to is `intel` — a self-hosted EC2 runner.
+
+inputs:
+  min-free-gb:
+    description: |
+      Skip the cleanup when at least this many GB are already free on the
+      filesystem holding the workspace. A full build with tests peaks near 25G,
+      so the default leaves ample headroom before the cleanup is worth its cost.
+    required: false
+    default: "40"
+
+runs:
+  using: composite
+  steps:
+    - name: Reclaim host toolchain directories
+      shell: bash
+      env:
+        MIN_FREE_GB: ${{ inputs.min-free-gb }}
+      run: |
+        df -h
+        # -P keeps each mount on one line (long device names wrap otherwise) and
+        # -k fixes the block size, so field 4 is portably the free 1K-blocks.
+        # `|| true` and the `:-0` below are both load-bearing: composite `bash`
+        # runs with `-eo pipefail`, so without them a df that failed or printed
+        # something unparsable would abort the step and fail the job over an
+        # optimisation. Treat an unknown figure as "no space" and clean instead.
+        FREE_GB=$(df -Pk . 2>/dev/null | awk 'NR==2 {print int($4 / 1048576)}' || true)
+        if [ "${FREE_GB:-0}" -ge "$MIN_FREE_GB" ]; then
+          echo "${FREE_GB}G free (threshold ${MIN_FREE_GB}G): skipping host toolchain cleanup."
+          exit 0
+        fi
+        echo "${FREE_GB}G free (threshold ${MIN_FREE_GB}G): reclaiming host toolchain directories."
+        rm -rf /host_usr/dotnet/* 2>/dev/null || true
+        rm -rf /host_usr/android/* 2>/dev/null || true
+        rm -rf /host_opt/ghc/* 2>/dev/null || true
+        rm -rf /host_opt/hostedtoolcache/CodeQL/* 2>/dev/null || true
+        echo "After cleanup:"
+        df -h

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -82,6 +82,15 @@ inputs:
     description: "key for Swatinem/rust-cache (caller-computed so miri can key differently from build/test)."
     required: false
     default: ""
+  rust-cache-read-only:
+    description: |
+      "'true' to restore the cache but never write it, on top of the
+      default-branch gate below. For default-branch runs that build far more
+      platforms than the merge queue needs: saving every one of them would
+      exhaust the 10 GB repository budget and evict the caches that are actually
+      on the critical path.
+    required: false
+    default: "false"
 
   # --- Setup Rust test dependencies -------------------------------------------
   rust-test-deps:
@@ -179,6 +188,13 @@ runs:
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
         prefix-key: ${{ inputs.rust-cache-prefix-key }}
+        # rust-cache folds the *calling job's id* into the key alongside this
+        # value. Only the default branch writes the cache (see save-if below), so
+        # the run that seeds it — task-test.yml, via the periodic master
+        # validation — and the merge-queue run that restores it must agree on
+        # both. They do because each declares the same rust-cache-key and both
+        # name their job `common-flow`; renaming either job silently stops the
+        # merge-queue build finding a cache, with no failure to point at it.
         key: ${{ inputs.rust-cache-key }}
         # The cargo workspaces and target directory configuration.
         # These entries are separated by newlines and have the form
@@ -190,6 +206,16 @@ runs:
         # compiled artifacts. Without this, cache is never populated on
         # platforms with high failure rates (e.g. macOS x86_64).
         cache-on-failure: true
+        # Only pushes to the default branch write the cache; every other run is
+        # restore-only. GitHub caps a repository at 10 GB of caches and evicts
+        # least-recently-used, while one CI run saves a ~450 MB target dir per
+        # platform. With every PR and merge-queue run saving, the whole budget
+        # churned in minutes and nothing survived long enough to be restored —
+        # so every Rust build compiled from cold. A cache written on a
+        # `gh-readonly-queue/*` or `refs/pull/*/merge` ref is also scoped to a
+        # ref no later run shares, whereas the default branch is readable by all
+        # of them.
+        save-if: ${{ inputs.rust-cache-read-only != 'true' && github.ref == 'refs/heads/master' }}
 
     - name: Setup Rust test dependencies
       # Wrapped in retry-command (5 attempts) to survive cargo-binstall's

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -36,6 +36,11 @@ jobs:
       job-test-config: '{"test": "", "coverage": "", "sanitize": ""}'
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,sanitize' }}
       rejson-branch: master
+      # This runs on the default branch, so it would otherwise be allowed to save
+      # a Rust cache for every platform above — roughly the entire 10 GB the
+      # repository gets, evicting the merge-queue platforms' caches in the
+      # process. Nightly latency does not matter; theirs does.
+      rust-cache-read-only: true
 
   micro-benchmarks:
     permissions:

--- a/.github/workflows/flow-pr-pipeline.yml
+++ b/.github/workflows/flow-pr-pipeline.yml
@@ -97,6 +97,7 @@ jobs:
       # rerun and would otherwise collide with the existing artifact). Test
       # jobs below consume needs.build.outputs.artifact-name, not this literal.
       artifact-name: pr-build-${{ inputs.job-type }}-${{ github.run_id }}-${{ github.run_attempt }}
+      rust-tests-artifact-name: pr-rust-tests-${{ inputs.job-type }}-${{ github.run_id }}-${{ github.run_attempt }}
       # Resolved platform config — task-build.yml no longer reruns get-config.
       name: ${{ needs.get-config.outputs.name }}
       container: ${{ needs.get-config.outputs.container }}
@@ -185,6 +186,7 @@ jobs:
       # artifact keeps the original attempt's name. Reconstructing here would
       # look for an artifact that was never produced.
       artifact-name: ${{ needs.build.outputs.artifact-name }}
+      rust-tests-artifact-name: ${{ needs.build.outputs.rust-tests-artifact-name }}
       name: ${{ needs.get-config.outputs.name }}
       container: ${{ needs.get-config.outputs.container }}
       env: ${{ needs.get-config.outputs.env }}

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -43,6 +43,10 @@ on:
         type: boolean
         default: false
         description: "Run coordinator tests in a separate parallel job per platform"
+      rust-cache-read-only:
+        type: boolean
+        default: false
+        description: "If true, restore the Rust cache but never write it. Set by callers that sweep every platform, whose saves would evict the caches on the merge-queue critical path."
 
   workflow_dispatch:
     inputs:
@@ -166,3 +170,4 @@ jobs:
       san: ${{ matrix.job-type == 'sanitize' && 'address' || matrix.job-type == 'ubsan' && 'alignment' || '' }}
       fail-fast: ${{ contains(inputs.options, 'fail-fast') || inputs.fail-fast == true }}
       skip-tests: ${{ contains(inputs.options, 'skip-tests') }}
+      rust-cache-read-only: ${{ inputs.rust-cache-read-only || false }}

--- a/.github/workflows/task-build-rejson.yml
+++ b/.github/workflows/task-build-rejson.yml
@@ -116,20 +116,6 @@ jobs:
         shell: sh -l -eo pipefail {0}
         run: ${{ format(env.SETUP_RETRY_LOOP, 'apk add bash') }}
 
-      # On a cache miss this job compiles RedisJSON from source (cargo), so it
-      # needs real disk headroom — unlike task-build-redis.yml, which restores or
-      # makes a small C build.
-      - name: Free up disk space (container)
-        if: ${{ inputs.container }}
-        run: |
-          echo "Before cleanup:"
-          df -h
-          rm -rf /host_usr/dotnet/* 2>/dev/null || true
-          rm -rf /host_usr/android/* 2>/dev/null || true
-          rm -rf /host_opt/ghc/* 2>/dev/null || true
-          rm -rf /host_opt/hostedtoolcache/CodeQL/* 2>/dev/null || true
-          echo "After cleanup:"
-          df -h
       - name: Free up disk space (non-container)
         if: ${{ !inputs.container && !contains(inputs.env, 'macos') }}
         run: |
@@ -176,6 +162,12 @@ jobs:
         # .rust-nightly and tests/deps/setup_rejson.sh. RedisJSON and its own
         # submodules are cloned by that script.
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      # On a cache miss this job compiles RedisJSON from source (cargo), so it
+      # needs real disk headroom — unlike task-build-redis.yml, which restores or
+      # makes a small C build.
+      - name: Free up disk space (container)
+        if: ${{ inputs.container }}
+        uses: ./.github/actions/free-container-disk-space
 
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env

--- a/.github/workflows/task-build.yml
+++ b/.github/workflows/task-build.yml
@@ -32,6 +32,10 @@ on:
         description: 'Name of the workflow artifact uploaded with the contents of bin/.'
         type: string
         required: true
+      rust-tests-artifact-name:
+        description: 'Name of the workflow artifact uploaded with the Rust nextest archive. Kept separate from artifact-name because only the unit-test job needs it.'
+        type: string
+        required: true
       # Resolved platform config — produced by task-get-config.yml at the
       # pipeline level so this workflow doesn't redo it. Caller must supply.
       name:
@@ -69,6 +73,9 @@ on:
         # Reusable-workflow outputs must map from a job output, not directly
         # from inputs — otherwise validation can reject it / it evaluates empty.
         value: ${{ jobs.common-flow.outputs.artifact-name }}
+      rust-tests-artifact-name:
+        description: 'Name of the uploaded Rust nextest archive artifact.'
+        value: ${{ jobs.common-flow.outputs.rust-tests-artifact-name }}
 
 env:
   COV: ${{ inputs.coverage && 1 || 0 }} # convert the boolean input to numeric
@@ -98,6 +105,7 @@ jobs:
     name: Build ${{ inputs.name }}
     outputs:
       artifact-name: ${{ inputs.artifact-name }}
+      rust-tests-artifact-name: ${{ inputs.rust-tests-artifact-name }}
     runs-on: ${{ inputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     container: ${{
       inputs.container
@@ -128,18 +136,6 @@ jobs:
         shell: sh -l -eo pipefail {0}
         run: ${{ format(env.SETUP_RETRY_LOOP, 'apk add bash') }}
 
-      - name: Free up disk space (container)
-        # For container jobs - delete mounted host directories
-        if: ${{ inputs.container }}
-        run: |
-          echo "Before cleanup:"
-          df -h
-          rm -rf /host_usr/dotnet/* 2>/dev/null || true
-          rm -rf /host_usr/android/* 2>/dev/null || true
-          rm -rf /host_opt/ghc/* 2>/dev/null || true
-          rm -rf /host_opt/hostedtoolcache/CodeQL/* 2>/dev/null || true
-          echo "After cleanup:"
-          df -h
       - name: Free up disk space (non-container)
         # For non-container jobs - delete directly with sudo
         # Skip macOS - it doesn't have these directories
@@ -200,6 +196,9 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
+      - name: Free up disk space (container)
+        if: ${{ inputs.container }}
+        uses: ./.github/actions/free-container-disk-space
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env
         with:
@@ -322,8 +321,18 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact-name }}
-          path: |
-            bin.tar.gz
-            nextest-archive.tar.zst
+          path: bin.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Rust test archive
+        # Separate artifact, because only the unit-test job runs Rust tests. The
+        # archive carries 138 test binaries with debuginfo and dwarfs bin/ (GBs
+        # vs ~100 MB), so bundling the two made every flow-test shard pull the
+        # archive down only to leave it on disk untouched.
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.rust-tests-artifact-name }}
+          path: nextest-archive.tar.zst
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -107,6 +107,14 @@ jobs:
           # relative to the `$workspace` and defaults to "target" if not explicitly given.
           # default: ". -> target"
           workspaces: "src/redisearch_rs -> ../../bin/redisearch_rs"
+          # Restore-only off the default branch, matching setup-build-env's
+          # rust-cache. This job does not go through that action, so it needs its
+          # own copy of the gate — and it is the single largest writer in the
+          # repo at ~800 MB, on every PR push and every merge-queue entry, which
+          # on its own kept evicting the caches the other jobs depend on. The
+          # nightly flow runs this job on the default branch, so the cache still
+          # gets written once a day.
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Hakari
         run: cargo install cargo-hakari --locked
       - name: Cargo deny

--- a/.github/workflows/task-miri.yml
+++ b/.github/workflows/task-miri.yml
@@ -105,17 +105,6 @@ jobs:
         shell: sh -l -eo pipefail {0}
         run: ${{ format(env.SETUP_RETRY_LOOP, 'apk add bash') }}
 
-      - name: Free up disk space (container)
-        if: ${{ needs.get-config.outputs.container }}
-        run: |
-          echo "Before cleanup:"
-          df -h
-          rm -rf /host_usr/dotnet/* 2>/dev/null || true
-          rm -rf /host_usr/android/* 2>/dev/null || true
-          rm -rf /host_opt/ghc/* 2>/dev/null || true
-          rm -rf /host_opt/hostedtoolcache/CodeQL/* 2>/dev/null || true
-          echo "After cleanup:"
-          df -h
       - name: Free up disk space (non-container)
         if: ${{ !needs.get-config.outputs.container && !contains(needs.get-config.outputs.env, 'macos') }}
         run: |
@@ -152,6 +141,9 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
+      - name: Free up disk space (container)
+        if: ${{ needs.get-config.outputs.container }}
+        uses: ./.github/actions/free-container-disk-space
 
       # MIRI runs `make rust-tests` which goes through build.sh's full flow,
       # including the C build that produces libredisearch_all.a. Sccache keeps

--- a/.github/workflows/task-test-flow.yml
+++ b/.github/workflows/task-test-flow.yml
@@ -157,17 +157,6 @@ jobs:
         shell: sh -l -eo pipefail {0}
         run: ${{ format(env.SETUP_RETRY_LOOP, 'apk add bash') }}
 
-      - name: Free up disk space (container)
-        if: ${{ inputs.container }}
-        run: |
-          echo "Before cleanup:"
-          df -h
-          rm -rf /host_usr/dotnet/* 2>/dev/null || true
-          rm -rf /host_usr/android/* 2>/dev/null || true
-          rm -rf /host_opt/ghc/* 2>/dev/null || true
-          rm -rf /host_opt/hostedtoolcache/CodeQL/* 2>/dev/null || true
-          echo "After cleanup:"
-          df -h
       - name: Free up disk space (non-container)
         if: ${{ !inputs.container && !contains(inputs.env, 'macos') }}
         run: |
@@ -222,6 +211,9 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
+      - name: Free up disk space (container)
+        if: ${{ inputs.container }}
+        uses: ./.github/actions/free-container-disk-space
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env
         with:

--- a/.github/workflows/task-test-unit.yml
+++ b/.github/workflows/task-test-unit.yml
@@ -39,6 +39,10 @@ on:
         description: 'Workflow artifact name to download (produced by task-build.yml).'
         type: string
         required: true
+      rust-tests-artifact-name:
+        description: 'Workflow artifact holding the Rust nextest archive (produced by task-build.yml). This job is the only consumer, which is why it ships separately from artifact-name.'
+        type: string
+        required: true
       # Resolved platform config — produced by task-get-config.yml at the
       # pipeline level so this workflow doesn't redo it. Caller must supply.
       name:
@@ -119,17 +123,6 @@ jobs:
         shell: sh -l -eo pipefail {0}
         run: ${{ format(env.SETUP_RETRY_LOOP, 'apk add bash') }}
 
-      - name: Free up disk space (container)
-        if: ${{ inputs.container }}
-        run: |
-          echo "Before cleanup:"
-          df -h
-          rm -rf /host_usr/dotnet/* 2>/dev/null || true
-          rm -rf /host_usr/android/* 2>/dev/null || true
-          rm -rf /host_opt/ghc/* 2>/dev/null || true
-          rm -rf /host_opt/hostedtoolcache/CodeQL/* 2>/dev/null || true
-          echo "After cleanup:"
-          df -h
       - name: Free up disk space (non-container)
         if: ${{ !inputs.container && !contains(inputs.env, 'macos') }}
         run: |
@@ -184,6 +177,9 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
+      - name: Free up disk space (container)
+        if: ${{ inputs.container }}
+        uses: ./.github/actions/free-container-disk-space
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env
         with:
@@ -199,7 +195,13 @@ jobs:
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: ${{ inputs.artifact-name }}
-          # bin.tar.gz + nextest-archive.tar.zst land in the working directory.
+          # bin.tar.gz lands in the working directory.
+
+      - name: Download Rust test archive
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: ${{ inputs.rust-tests-artifact-name }}
+          # nextest-archive.tar.zst lands in the working directory.
 
       - name: Unpack build artifact
         # Untar instead of relying on the artifact's zip layout so executable

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -62,6 +62,10 @@ on:
         type: boolean
         default: false
         description: "If true, build the module for this platform but skip all test steps."
+      rust-cache-read-only:
+        type: boolean
+        default: false
+        description: "If true, restore the Rust cache but never write it. For callers that sweep far more platforms than the merge queue needs, whose saves would evict the caches on the critical path."
 
 env:
   REJSON: ${{ inputs.rejson && 1 || 0 }} # convert the boolean input to numeric
@@ -164,18 +168,6 @@ jobs:
         shell: sh -l -eo pipefail {0}
         run: ${{ format(env.SETUP_RETRY_LOOP, 'apk add bash') }}
 
-      - name: Free up disk space (container)
-        # For container jobs - delete mounted host directories
-        if: ${{ needs.get-config.outputs.container }}
-        run: |
-          echo "Before cleanup:"
-          df -h
-          rm -rf /host_usr/dotnet/* 2>/dev/null || true
-          rm -rf /host_usr/android/* 2>/dev/null || true
-          rm -rf /host_opt/ghc/* 2>/dev/null || true
-          rm -rf /host_opt/hostedtoolcache/CodeQL/* 2>/dev/null || true
-          echo "After cleanup:"
-          df -h
       - name: Free up disk space (non-container)
         # For non-container jobs - delete directly with sudo
         # Skip macOS - it doesn't have these directories
@@ -237,6 +229,9 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: recursive
+      - name: Free up disk space (container)
+        if: ${{ needs.get-config.outputs.container }}
+        uses: ./.github/actions/free-container-disk-space
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env
         with:
@@ -253,6 +248,7 @@ jobs:
           install-script: 'true'
           rust-cache: 'true'
           rust-cache-key: ${{ inputs.platform }}-${{ inputs.architecture }}-${{ inputs.san }}-${{ inputs.coverage && 'cov' || '' }}
+          rust-cache-read-only: ${{ inputs.rust-cache-read-only }}
           rust-test-deps: 'true'
           github-token: ${{ github.token }}
           python-test-deps: 'true'


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: merge-queue validation of a master PR takes 28–40 min ([this run](https://github.com/RediSearch/RediSearch/actions/runs/31604461084) was 27m53s, near the floor). Its critical path is only two jobs — the Ubuntu Noble build, then the slowest coordinator flow shard — and three items on that path are overhead rather than work.
2. Change: (a) only pushes to the default branch write the Rust cache, so the ~450 MB × ~20 platforms saved on every run stop churning a 10 GB LRU budget that nothing was surviving long enough to be restored from. (b) The container disk cleanup now runs only when free space is actually low. (c) `bin/` and the 2.8 GB nextest archive ship as separate artifacts.
3. Outcome: internal-only, nothing user-visible. It removes ~4 min of measured overhead from the critical path — the cleanup was spending 175s in the build job and 65s per flow shard to free 17G on a disk that already had 82G free, and the flow shards were each downloading the nextest archive only to leave it untouched. It also unblocks the larger win: once master seeds a cache, the build job's ~6 min of cold Rust compilation stops starting from zero.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `setup-build-env` — rust-cache gains `save-if`, making every non-default-branch run restore-only, plus a `rust-cache-read-only` input for default-branch runs that must not write. Worth a look: the key coupling documented alongside it is what decides whether a cache is ever found again.
2. `task-lint.yml` / `event-nightly.yml` — the two writers that escape a plain `save-if`. Lint calls rust-cache directly and was the largest single writer (~800 MB per run); nightly runs *on* the default branch across every platform, so it would have saved ~20 target dirs at once and evicted the platforms the merge queue waits on. That leaves the periodic master validation as the writer, at ~9 caches and ~5 GB against the cap.
3. `free-container-disk-space` (new action) — the cleanup, gated on a free-space threshold that now lives in exactly one place.
4. `task-build.yml` / `task-test-unit.yml` — the nextest archive moves to its own artifact, fetched only by the one job that runs Rust tests.
5. Six `task-*.yml` workflows — the inline container cleanup becomes a call to the new action, which must sit *after* checkout since a local action does not exist on disk before it. Two copies stay inline on purpose, each commented in place: the non-container variant, and `task-redis-build-sanity.yml`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
