### PR TITLE
[MOD-17393] NotOptimized: suspend/resume

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not_optimized.rs
@@ -9,12 +9,13 @@
 
 //! Supporting types for [`NotOptimized`].
 
-use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use index_result::{RSIndexResult, RSResultKind, RawIndexResult};
+use ref_mode::{Active, Ref, Suspended};
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
-    WildcardIterator,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome, WildcardIterator,
+    boxed::suspend_child_slot_in_place,
     maybe_empty::MaybeEmpty,
     profile_print::{ProfilePrint, ProfilePrintCtx},
     utils::TimeoutContext,
@@ -77,6 +78,30 @@ pub struct RawNotOptimized<'query, Rf: Ref, W, I, TC> {
 /// with an [`RQEIterator`] impl today.
 pub type NotOptimized<'index, W, I, TC> = RawNotOptimized<'index, Active<'index>, W, I, TC>;
 
+// Compile-time proof of invariant 1 on `RawNotOptimized`: for representative
+// concrete `wcii`/`child` types, the `Active` and `Suspended` instantiations are
+// layout-identical. The child slots' own compatibility is their invariant 1
+// (enforced generically by `suspend_child_slot_in_place`); `result` is
+// layout-compatible across `Rf` (proven in `index_result`); the remaining fields
+// are `Rf`-free.
+const _: () = {
+    use crate::Wildcard;
+    use crate::utils::NoTimeoutChecker;
+    use std::mem::{align_of, offset_of, size_of};
+    type AChild = Wildcard<'static>;
+    type SChild = <Wildcard<'static> as RQEIteratorBoxed<'static>>::Suspended;
+    type A = RawNotOptimized<'static, Active<'static>, AChild, AChild, NoTimeoutChecker>;
+    type S = RawNotOptimized<'static, Suspended, SChild, SChild, NoTimeoutChecker>;
+    assert!(offset_of!(A, wcii) == offset_of!(S, wcii));
+    assert!(offset_of!(A, child) == offset_of!(S, child));
+    assert!(offset_of!(A, max_doc_id) == offset_of!(S, max_doc_id));
+    assert!(offset_of!(A, result) == offset_of!(S, result));
+    assert!(offset_of!(A, past_end) == offset_of!(S, past_end));
+    assert!(offset_of!(A, timeout_ctx) == offset_of!(S, timeout_ctx));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
 impl<'index, W, I, TC> NotOptimized<'index, W, I, TC>
 where
     W: WildcardIterator<'index>,
@@ -105,7 +130,16 @@ where
             timeout_ctx,
         }
     }
+}
 
+impl<'index, W, I, TC> NotOptimized<'index, W, I, TC>
+where
+    // Helpers below only call generic `RQEIterator` methods on the wildcard
+    // base, so they don't need the `WildcardIterator` marker (enforced in `new`).
+    W: RQEIterator<'index>,
+    I: RQEIterator<'index>,
+    TC: TimeoutContext,
+{
     /// Wrapper around [`TimeoutContext::check_timeout`].
     #[inline(always)]
     fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
@@ -225,7 +259,8 @@ where
 
 impl<'index, W, I, TC> RQEIterator<'index> for NotOptimized<'index, W, I, TC>
 where
-    W: WildcardIterator<'index>,
+    // Marker enforced at construction (`new`); only generic methods used here.
+    W: RQEIterator<'index>,
     I: RQEIterator<'index>,
     TC: TimeoutContext,
 {
@@ -427,6 +462,248 @@ where
 
     fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
         1.0
+    }
+}
+
+impl<'index, W, I, TC> RQEIteratorBoxed<'index> for NotOptimized<'index, W, I, TC>
+where
+    // Marker enforced at construction (`new`), not on the suspend/resume path.
+    W: RQEIteratorBoxed<'index>,
+    I: RQEIteratorBoxed<'index>,
+    TC: TimeoutContext + 'index + 'static,
+{
+    type Suspended = RawNotOptimized<'index, Suspended, W::Suspended, I::Suspended, TC>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Dispatch each sub-iterator's own `suspend` in place. A whole-box cast
+        // alone is *not* enough: for a type-erased `wcii`/`child` the active and
+        // suspended forms carry different `dyn` vtables, so the transition must
+        // be dispatched through the child's own `suspend` (a no-op cast for
+        // concrete children, a vtable swap for erased ones). `child` is a
+        // `MaybeEmpty<I>`, itself an `RQEIteratorBoxed` that walks its own
+        // `Some(I)` arm.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned, initialised,
+        // exclusively owned); `&raw mut` forms a field pointer to `wcii`.
+        let wcii = unsafe { &raw mut (*raw).wcii };
+        // SAFETY: `wcii` points at a valid, owned `W`; the helper dispatches its
+        // `suspend` and reinitialises the slot as a valid `W::Suspended`.
+        unsafe { suspend_child_slot_in_place(wcii) };
+        // SAFETY: `&raw mut` forms a field pointer to `child`.
+        let child = unsafe { &raw mut (*raw).child };
+        // SAFETY: `child` points at a valid, owned `MaybeEmpty<I>`; the helper
+        // dispatches its `suspend` and reinitialises the slot as a valid
+        // `MaybeEmpty<I::Suspended>`.
+        unsafe { suspend_child_slot_in_place(child) };
+        // SAFETY: both sub-iterators now hold their `Suspended` forms;
+        // `result: RawIndexResult<Rf>` is layout-compatible across `Rf`, and the
+        // remaining fields are `Rf`-free — so the allocation is a valid suspended
+        // `RawNotOptimized`, layout-identical to the active form by invariant 1
+        // (const proof above). `Box::from_raw` reuses the same heap allocation.
+        unsafe {
+            Box::from_raw(
+                raw as *mut RawNotOptimized<'index, Suspended, W::Suspended, I::Suspended, TC>,
+            )
+        }
+    }
+}
+
+/// RAII guard used by [`RawNotOptimized`]'s `resume` while its two child slots
+/// are moved out into owned locals. It owns the leftover shell: on drop (an
+/// early return or a panic) it drops every field the shell still owns — the
+/// still-suspended `result` and the `timeout_ctx` — and frees the allocation. It
+/// never touches the moved-out `wcii`/`child` slots, so its behaviour is
+/// independent of how far the resume got. It is disarmed with
+/// [`std::mem::forget`] once the resumed children are written back.
+struct FreeSuspendedShell<'q, WS, IS, TC> {
+    raw: *mut RawNotOptimized<'q, Suspended, WS, IS, TC>,
+}
+
+impl<'q, WS, IS, TC> Drop for FreeSuspendedShell<'q, WS, IS, TC> {
+    fn drop(&mut self) {
+        // SAFETY: `raw` is a valid, exclusively-owned allocation; `&raw mut`
+        // forms a field pointer to the still-suspended `result`.
+        let result = unsafe { &raw mut (*self.raw).result };
+        // SAFETY: `result` is a valid, owned suspended result; drop it in place.
+        unsafe { std::ptr::drop_in_place(result) };
+        // `TC` is an unconstrained generic, so it may carry drop glue of its own
+        // even though no shipped [`TimeoutContext`] does today. Every other field
+        // besides `wcii`/`child` is a scalar.
+        //
+        // SAFETY: `&raw mut` forms a field pointer to the owned `timeout_ctx`.
+        let timeout_ctx = unsafe { &raw mut (*self.raw).timeout_ctx };
+        // SAFETY: `timeout_ctx` is a valid, owned `TC`; drop it in place.
+        unsafe { std::ptr::drop_in_place(timeout_ctx) };
+        // SAFETY: `raw` was allocated by `Box` with exactly this layout, and every
+        // field that owns anything has now been dropped except the moved-from
+        // `wcii`/`child` slots — the only ones that must *not* be. Free it.
+        unsafe {
+            std::alloc::dealloc(
+                self.raw.cast::<u8>(),
+                std::alloc::Layout::new::<RawNotOptimized<'q, Suspended, WS, IS, TC>>(),
+            )
+        };
+    }
+}
+
+impl<'query, WS, IS, TC> RQESuspendedIterator<'query>
+    for RawNotOptimized<'query, Suspended, WS, IS, TC>
+where
+    WS: RQESuspendedIterator<'query>,
+    IS: RQESuspendedIterator<'query>,
+    TC: TimeoutContext + 'static,
+{
+    type Resumed<'a>
+        = NotOptimized<'a, WS::Resumed<'a>, IS::Resumed<'a>, TC>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // `result` must still be a virtual sentinel. It is handed out mutably via
+        // `current()`/`read()`/`skip_to`, and on resume its `Suspended → Active`
+        // reinterpretation would assert index borrows this iterator cannot
+        // re-validate. `kind() == Virtual` is the whole condition (`data` is the
+        // only `Rf`-parametrized field). Checked safely via `&self`, before
+        // `Box::into_raw`, so a violation just drops `self`; recoverable, hence
+        // `Aborted` rather than `Err`.
+        if self.result.kind() != RSResultKind::Virtual {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        let raw = Box::into_raw(self);
+
+        // Move both children out into owned locals; their slots become
+        // uninitialised. `result` stays in place (it must keep its address — it
+        // is handed out via `current()`/`read()`/`skip_to`), as do the `Rf`-free
+        // scalar fields.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned, initialised,
+        // exclusively owned); `&raw const` forms a field pointer to `wcii`.
+        let wcii_ptr = unsafe { &raw const (*raw).wcii };
+        // SAFETY: move the owned suspended `wcii` out exactly once.
+        let wcii = unsafe { std::ptr::read(wcii_ptr) };
+        // SAFETY: field pointer to `child`.
+        let child_ptr = unsafe { &raw const (*raw).child };
+        // SAFETY: move the owned suspended `child` out exactly once.
+        let child = unsafe { std::ptr::read(child_ptr) };
+
+        // From here until success, `raw` is a shell whose child slots are
+        // moved-out. [`FreeSuspendedShell`] frees it on any early return or
+        // panic; the `wcii`/`child` locals clean themselves up via ownership.
+        let shell = FreeSuspendedShell { raw };
+
+        // Resume the wildcard base and act on its outcome *before* the child is
+        // touched, as `revalidate` does: if the base is unrecoverable there is
+        // nothing left to enumerate the complement over, so the whole iterator
+        // aborts and the child is never driven at all. The still-suspended
+        // `child` local drops by ownership on that early return. (`wcii` being a
+        // wildcard is enforced at construction, not by the bounds here — see the
+        // [`RQEIteratorBoxed`] impl above.)
+        let (wcii, wcii_moved) = match Box::new(wcii).resume(guard)? {
+            ResumeOutcome::Aborted => return Ok(ResumeOutcome::Aborted),
+            ResumeOutcome::Ok(w) => (w, false),
+            ResumeOutcome::Moved(w) => (w, true),
+        };
+        // An aborted query child collapses to `Empty` (mirroring the legacy
+        // behaviour); a moved child doesn't shift NOT's cursor.
+        let child: Box<MaybeEmpty<IS::Resumed<'a>>> = match Box::new(child).resume(guard)? {
+            ResumeOutcome::Aborted => Box::new(MaybeEmpty::new_empty()),
+            ResumeOutcome::Ok(c) | ResumeOutcome::Moved(c) => c,
+        };
+
+        // Success: disarm the guard and write the resumed children back into
+        // their original slots (preserving their addresses — and `result`'s,
+        // which never moved), then reinterpret the reused allocation as the
+        // active form. Everything between this `forget` and the two writes below
+        // is moves, pointer arithmetic and `const` assertions — none of it can
+        // unwind, so no unwind can observe the uninitialised slots.
+        std::mem::forget(shell);
+        // Statically enforce the size/alignment invariants the in-place writes
+        // below rely on, mirroring the guard inside the shared slot helpers. The
+        // whole-struct pair is asserted too: `FreeSuspendedShell` deallocates at
+        // the *suspended* layout and the cast below reclaims the same allocation
+        // at the *resumed* one, so a per-slot match alone is not enough. The
+        // standalone `const _` proof above covers only representative concrete
+        // children; this fires at the generics actually instantiated.
+        const { crate::boxed::assert_layout_compatible::<Self, Self::Resumed<'a>>() };
+        const { crate::boxed::assert_layout_compatible::<WS, WS::Resumed<'a>>() };
+        const { crate::boxed::assert_layout_compatible::<MaybeEmpty<IS>, MaybeEmpty<IS::Resumed<'a>>>() };
+        // SAFETY: the `wcii` slot is uninitialised; `&raw mut` forms a field
+        // pointer to it.
+        let wcii_slot = unsafe { &raw mut (*raw).wcii };
+        // SAFETY: write the resumed `wcii` back at the same offset, as its
+        // resumed type.
+        unsafe { std::ptr::write(wcii_slot.cast::<WS::Resumed<'a>>(), *wcii) };
+        // SAFETY: `&raw mut` forms a field pointer to the uninitialised `child`
+        // slot.
+        let child_slot = unsafe { &raw mut (*raw).child };
+        // SAFETY: write the resumed `child` back at the same offset.
+        unsafe { std::ptr::write(child_slot.cast::<MaybeEmpty<IS::Resumed<'a>>>(), *child) };
+
+        // SAFETY: both slots now hold their resumed forms and `result` is a valid
+        // (pointerless) virtual sentinel (checked above), so the allocation is a
+        // valid `NotOptimized<'a, …>` — layout-identical to the suspended form by
+        // invariant 1 on `RawNotOptimized` (const proof above), with `result`
+        // re-typing `Suspended → Active` soundly. `Box::from_raw` reuses the same
+        // allocation, so the FFI's cached `header.current` and any parent's
+        // pointer into `result` stay valid across the cycle.
+        let mut active = unsafe {
+            Box::from_raw(raw.cast::<NotOptimized<'a, WS::Resumed<'a>, IS::Resumed<'a>, TC>>())
+        };
+
+        if wcii_moved {
+            // Latched, never assigned, as in `revalidate` — which owns the reasoning
+            // for why this iterator's own path to exhaustion outlives whatever the
+            // wildcard now answers. That it must survive the cycle at all is
+            // `RQEIterator::at_eof`'s rule.
+            active.past_end |= active.wcii.at_eof();
+            // Bounded, as in `revalidate`: a wildcard that came back on a document
+            // beyond `max_doc_id` is out of this iterator's range, so there is no
+            // valid position to publish.
+            let mut have_valid_pos =
+                !active.past_end && active.wcii.last_doc_id() <= active.max_doc_id;
+            if have_valid_pos {
+                active.result.doc_id = active.wcii.last_doc_id();
+                // Catching the child up is the only thing that makes the
+                // membership test below mean anything, so a failure here must
+                // reach the caller rather than be read as "not in the child" —
+                // see `revalidate`, which spells out why undecided is not absent.
+                if active.child.last_doc_id() < active.result.doc_id {
+                    let _ = active.child.skip_to(active.result.doc_id)?;
+                }
+                if active.child.last_doc_id() == active.result.doc_id {
+                    // Likewise for a failing scan: neither outcome available here
+                    // would be true, and reporting `Moved` with no position says
+                    // "exhausted" to a parent that acts on it. See `revalidate`.
+                    have_valid_pos = active.read_inner()?;
+                }
+            }
+            // Mirrors `revalidate`: no valid position means the iterator has run past
+            // its end. Discarding this (as this path used to) left
+            // `current()`/`at_eof()` disagreeing with the outcome just reported.
+            if !have_valid_pos {
+                active.past_end = true;
+            }
+            return Ok(ResumeOutcome::Moved(active));
+        }
+
+        Ok(ResumeOutcome::Ok(active))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        // Mirrors the active `num_estimated`, which delegates to the wildcard base.
+        self.wcii.num_estimated()
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not_optimized.rs
@@ -1072,6 +1072,796 @@ mod revalidate {
         // `revalidate` reaches the C boundary as `VALIDATE_ABORTED`, and an
         // aborted iterator is dropped rather than used.
     }
+
+    /// The transitions covered by the enclosing module, driven through
+    /// `suspend`/`resume` instead of the legacy `revalidate`. These live inside
+    /// the miri gate because they need a real wildcard inverted index to move;
+    /// the mock-only resume coverage is in `resume_over_mocks`.
+    ///
+    /// `ContractChecker` does not implement the suspend/resume surface, so the
+    /// iterator is unwrapped to cross the cycle and re-wrapped on the other
+    /// side. That keeps the reads *after* the resume checked, as their legacy
+    /// twins are — which is where a resume that published a position the
+    /// iterator does not actually hold shows up.
+    mod via_resume {
+        use super::*;
+        use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator};
+        use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+        /// The resume twin of `revalidate_child_skip_error_propagates`.
+        ///
+        /// Catching the child up to the wildcard's new position is what makes
+        /// the membership test that follows it mean anything, and the contract
+        /// keeps a failed skip from parking the child on the probed id. Swallow
+        /// the failure and that test reads "undecided" as "absent", publishing a
+        /// document this iterator exists to exclude.
+        #[test]
+        fn resume_child_skip_error_propagates() {
+            let (_guard, context) = (
+                GlobalGuard::default(),
+                TestContext::wildcard([1, 50].iter().copied()),
+            );
+            let ii = DocIdsOnly::from_opaque(context.wildcard_inverted_index());
+            let wcii = rqe_iterators::inverted_index::Wildcard::new(ii.reader(), 1.0);
+            // The child holds 50 — the id the wildcard lands on below — so the
+            // membership that cannot be decided is one where the answer is
+            // "present".
+            let child = Mock::<2>::new([3, 50]);
+            let mut child_data = child.data();
+            child_data.set_revalidate_result(MockRevalidateResult::Ok);
+            let mut it = NotOptimized::new(wcii, child, 100, 1.0, NoTimeoutChecker);
+
+            // Doc 1. Catching the child up to it stops on 3, behind the
+            // wildcard's remaining document.
+            assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
+
+            // From here the child cannot be caught up.
+            child_data.set_error_on_skip_to(Some(MockIteratorError::TimeoutError(None)));
+
+            // GC doc 1, so the wildcard moves onto 50, past the child at 3.
+            gc_document(&context, 1);
+
+            let guard = context.spec_read();
+            match revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard) {
+                Err(RQEIteratorError::TimedOut) => {}
+                Err(other) => {
+                    panic!("the child's error must be propagated as it stands: {other:?}")
+                }
+                Ok(_) => panic!("a child that cannot be caught up must reach the caller"),
+            }
+        }
+
+        /// The resume twin of `revalidate_scan_error_propagates`.
+        ///
+        /// A failing scan leaves no position to report, and neither outcome the
+        /// resume could return would be true: `Moved` with no position says
+        /// "exhausted", which every composite acts on, so a later `read` finding
+        /// a document would resurrect this iterator behind a parent that has
+        /// already written it off.
+        #[test]
+        fn resume_scan_error_propagates() {
+            let (_guard, context) = make_revalidate_context();
+            let ii = DocIdsOnly::from_opaque(context.wildcard_inverted_index());
+            let wcii = rqe_iterators::inverted_index::Wildcard::new(ii.reader(), 1.0);
+            // A single child document, at the id the wildcard moves onto below —
+            // so the scan that move triggers reads the child past its end, which
+            // is where the failure is injected.
+            let child = Mock::<1>::new([10]);
+            let mut child_data = child.data();
+            child_data.set_revalidate_result(MockRevalidateResult::Ok);
+            let mut it = NotOptimized::new(wcii, child, 100, 1.0, NoTimeoutChecker);
+
+            it.read().unwrap().unwrap(); // doc 1
+            it.read().unwrap().unwrap(); // doc 5, pulling the child forward to 10
+            assert_eq!(it.last_doc_id(), 5);
+
+            child_data.set_error_at_done(Some(MockIteratorError::TimeoutError(None)));
+
+            // GC doc 5, so the wildcard moves onto 10 — which the child holds, so
+            // the iterator scans for the next valid result and the scan fails.
+            gc_document(&context, 5);
+
+            let guard = context.spec_read();
+            match revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard) {
+                Err(RQEIteratorError::TimedOut) => {}
+                Err(other) => {
+                    panic!("the child's error must be propagated as it stands: {other:?}")
+                }
+                Ok(_) => panic!("a failing resume scan must reach the caller"),
+            }
+        }
+
+        #[test]
+        fn revalidate_child_ok_wc_ok() {
+            let (_guard, context) = make_revalidate_context();
+            let (mut it, mut child_data) = create_not_optimized(&context);
+            child_data.set_revalidate_result(MockRevalidateResult::Ok);
+
+            it.read().unwrap().unwrap();
+            it.read().unwrap().unwrap();
+            let original = it.last_doc_id();
+
+            let guard = context.spec_read();
+            let mut it = ContractChecker::new(
+                revalidate_via_resume(
+                    TypeErasedRQEIterator::new(Box::new(it.into_inner())),
+                    &guard,
+                )
+                .expect("resume failed")
+                .expect_ok(),
+            );
+            assert_eq!(child_data.revalidate_count(), 1);
+            assert_eq!(it.last_doc_id(), original);
+            it.read().unwrap().unwrap();
+        }
+
+        #[test]
+        fn revalidate_child_aborted_wc_ok() {
+            let (_guard, context) = make_revalidate_context();
+            let (mut it, mut child_data) = create_not_optimized(&context);
+            child_data.set_revalidate_result(MockRevalidateResult::Abort);
+
+            it.read().unwrap().unwrap();
+            let original = it.last_doc_id();
+
+            let guard = context.spec_read();
+            let mut it = ContractChecker::new(
+                revalidate_via_resume(
+                    TypeErasedRQEIterator::new(Box::new(it.into_inner())),
+                    &guard,
+                )
+                .expect("resume failed")
+                .expect_ok(),
+            );
+            assert_eq!(it.last_doc_id(), original);
+            it.read().unwrap().unwrap();
+        }
+
+        #[test]
+        fn revalidate_child_moved_wc_ok() {
+            let (_guard, context) = make_revalidate_context();
+            let (mut it, mut child_data) = create_not_optimized(&context);
+            child_data.set_revalidate_result(MockRevalidateResult::Move);
+
+            it.read().unwrap().unwrap();
+            let original = it.last_doc_id();
+
+            let guard = context.spec_read();
+            let mut it = ContractChecker::new(
+                revalidate_via_resume(
+                    TypeErasedRQEIterator::new(Box::new(it.into_inner())),
+                    &guard,
+                )
+                .expect("resume failed")
+                .expect_ok(),
+            );
+            assert_eq!(child_data.revalidate_count(), 1);
+            assert_eq!(it.last_doc_id(), original);
+            it.read().unwrap().unwrap();
+        }
+
+        #[test]
+        fn revalidate_wc_aborted() {
+            let (_guard, context) = make_revalidate_context();
+            let (mut it, _child_data) = create_not_optimized(&context);
+
+            it.read().unwrap().unwrap();
+
+            let new_ii =
+                Box::into_raw(Box::new(inverted_index::opaque::InvertedIndex::DocIdsOnly(
+                    InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
+                )));
+            let old_existing_docs = context.spec_read().existing_docs_ptr();
+            context.spec_write().set_existing_docs_ptr(new_ii.cast());
+
+            let guard = context.spec_read();
+            let outcome = revalidate_via_resume(
+                TypeErasedRQEIterator::new(Box::new(it.into_inner())),
+                &guard,
+            )
+            .expect("resume failed");
+            assert!(matches!(outcome, ResumeOutcome::Aborted));
+
+            context
+                .spec_write()
+                .set_existing_docs_ptr(old_existing_docs);
+            // SAFETY: Dropping Box from raw pointer.
+            unsafe {
+                drop(Box::from_raw(new_ii));
+            }
+        }
+
+        #[test]
+        fn revalidate_child_ok_wc_moved() {
+            let (_guard, context) = make_revalidate_context();
+            let (mut it, mut child_data) = create_not_optimized(&context);
+            child_data.set_revalidate_result(MockRevalidateResult::Ok);
+
+            it.read().unwrap().unwrap();
+            let original = it.last_doc_id();
+            assert_eq!(original, 1);
+
+            gc_document(&context, 1);
+
+            let guard = context.spec_read();
+            let it = ContractChecker::new(
+                revalidate_via_resume(
+                    TypeErasedRQEIterator::new(Box::new(it.into_inner())),
+                    &guard,
+                )
+                .expect("resume failed")
+                .expect_moved(),
+            );
+            assert!(it.last_doc_id() > original);
+        }
+
+        #[test]
+        fn revalidate_child_aborted_wc_moved() {
+            let (_guard, context) = make_revalidate_context();
+            let (mut it, mut child_data) = create_not_optimized(&context);
+            child_data.set_revalidate_result(MockRevalidateResult::Abort);
+
+            it.read().unwrap().unwrap();
+            let original = it.last_doc_id();
+            assert_eq!(original, 1);
+
+            gc_document(&context, 1);
+
+            let guard = context.spec_read();
+            let it = ContractChecker::new(
+                revalidate_via_resume(
+                    TypeErasedRQEIterator::new(Box::new(it.into_inner())),
+                    &guard,
+                )
+                .expect("resume failed")
+                .expect_moved(),
+            );
+            assert!(it.last_doc_id() > original);
+        }
+
+        #[test]
+        fn revalidate_child_moved_wc_moved() {
+            let (_guard, context) = make_revalidate_context();
+            let (mut it, mut child_data) = create_not_optimized(&context);
+            child_data.set_revalidate_result(MockRevalidateResult::Move);
+
+            it.read().unwrap().unwrap();
+            let original = it.last_doc_id();
+            assert_eq!(original, 1);
+
+            gc_document(&context, 1);
+
+            let guard = context.spec_read();
+            let mut it = ContractChecker::new(
+                revalidate_via_resume(
+                    TypeErasedRQEIterator::new(Box::new(it.into_inner())),
+                    &guard,
+                )
+                .expect("resume failed")
+                .expect_moved(),
+            );
+            assert!(it.last_doc_id() > original);
+            it.read().unwrap().unwrap();
+        }
+
+        #[test]
+        fn revalidate_wc_moves_to_same_id_as_child() {
+            let (_guard, context) = make_revalidate_context();
+            let (mut it, mut child_data) = create_not_optimized(&context);
+            child_data.set_revalidate_result(MockRevalidateResult::Ok);
+
+            it.read().unwrap().unwrap();
+            it.read().unwrap().unwrap();
+            assert_eq!(it.last_doc_id(), 5);
+
+            gc_document(&context, 5);
+
+            let guard = context.spec_read();
+            let mut it = ContractChecker::new(
+                revalidate_via_resume(
+                    TypeErasedRQEIterator::new(Box::new(it.into_inner())),
+                    &guard,
+                )
+                .expect("resume failed")
+                .expect_moved(),
+            );
+            assert!(!it.at_eof());
+            assert_eq!(it.last_doc_id(), 15);
+            it.read().unwrap().unwrap();
+        }
+
+        #[test]
+        fn revalidate_wc_moved_to_eof() {
+            let (_guard, context) = (
+                GlobalGuard::default(),
+                TestContext::wildcard([1].iter().copied()),
+            );
+            let ii = DocIdsOnly::from_opaque(context.wildcard_inverted_index());
+            let wcii = rqe_iterators::inverted_index::Wildcard::new(ii.reader(), 1.0);
+            let child = Mock::<1>::new([100]);
+            let mut child_data = child.data();
+            child_data.set_revalidate_result(MockRevalidateResult::Ok);
+            let mut it = NotOptimized::new(wcii, child, 200, 1.0, NoTimeoutChecker);
+
+            let doc = it.read().unwrap().unwrap();
+            assert_eq!(doc.doc_id, 1);
+
+            gc_document(&context, 1);
+
+            let guard = context.spec_read();
+            let it = ContractChecker::new(
+                revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+                    .expect("resume failed")
+                    .expect_moved(),
+            );
+            assert!(it.at_eof());
+        }
+    }
+}
+
+/// Suspend/resume coverage that needs no real index: both sub-iterators are
+/// mocks and the lock comes from `MockContext`, so — unlike
+/// `revalidate::via_resume` — nothing here calls into FFI and miri runs all of
+/// it. That matters more for this iterator than for its siblings: its resume is
+/// the stack's only bespoke two-slot `ptr::read`/`ptr::write`/`dealloc`
+/// teardown, and miri is what validates it.
+mod resume_over_mocks {
+    use super::*;
+    use crate::utils::MockRevalidateResult;
+    use rqe_iterators::{
+        RQEIteratorBoxed, RQESuspendedIterator, RQEValidateStatus, ResumeOutcome,
+        TypeErasedRQEIterator,
+    };
+
+    /// The lock guard every test here resumes under.
+    fn mock_context() -> rqe_iterators_test_utils::MockContext {
+        rqe_iterators_test_utils::MockContext::new(0, 0)
+    }
+
+    /// The suspend/resume cycle must reuse the allocation: the FFI wrapper
+    /// and delegating parents cache raw pointers into the iterator's
+    /// storage, and a rebuilt box would dangle them.
+    #[test]
+    fn resume_preserves_box_address() {
+        let mock_ctx = mock_context();
+        let guard = mock_ctx.spec_read();
+        let wcii = Mock::new([1u64, 2, 3, 4, 5]);
+        let child = Mock::new([2u64, 4]);
+        let mut it = Box::new(NotOptimized::new(wcii, child, 5, 1.0, NoTimeoutChecker));
+        let doc = it.read().expect("read failed").expect("expected doc");
+        assert_eq!(doc.doc_id, 1);
+        let addr_before = &*it as *const _ as usize;
+
+        let suspended = it.suspend();
+        assert_eq!(
+            &*suspended as *const _ as usize, addr_before,
+            "suspend must reuse the allocation",
+        );
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(a) => a,
+            ResumeOutcome::Moved(_) => panic!("expected Ok, got Moved"),
+            ResumeOutcome::Aborted => panic!("expected Ok, got Aborted"),
+        };
+        assert_eq!(
+            &*active as *const _ as usize, addr_before,
+            "resume must reuse the allocation",
+        );
+
+        let doc = active.read().expect("read failed").expect("expected doc");
+        assert_eq!(doc.doc_id, 3, "the exclusion set survives the cycle");
+    }
+
+    /// Type-erased sub-iterators cross the suspend boundary through vtable
+    /// swaps, not byte casts — the active and suspended erased forms are
+    /// different `dyn` types. Erases both the wildcard base and the child.
+    #[test]
+    fn suspend_resume_with_type_erased_children_survives() {
+        let mock_ctx = mock_context();
+        let guard = mock_ctx.spec_read();
+        let wcii = TypeErasedRQEIterator::new(Box::new(Mock::new([1u64, 2, 3, 4, 5])));
+        let child = TypeErasedRQEIterator::new(Box::new(Mock::new([2u64, 4])));
+        let mut it = Box::new(NotOptimized::new(wcii, child, 5, 1.0, NoTimeoutChecker));
+        let doc = it.read().expect("read failed").expect("expected doc");
+        assert_eq!(doc.doc_id, 1);
+
+        let mut active = match it.suspend().resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(a) => a,
+            ResumeOutcome::Moved(_) => panic!("expected Ok, got Moved"),
+            ResumeOutcome::Aborted => panic!("expected Ok, got Aborted"),
+        };
+
+        let mut seen = vec![1];
+        while let Some(doc) = active.read().expect("read failed") {
+            seen.push(doc.doc_id);
+        }
+        assert_eq!(seen, vec![1, 3, 5]);
+    }
+
+    /// If the virtual sentinel is no longer virtual — a consumer replaced it
+    /// via the mutable `current()`/`read()`/`skip_to` handout — resume cannot
+    /// re-validate it, so it aborts the whole iterator (returns `Aborted`,
+    /// not an error), mirroring `Optional::resume`.
+    #[test]
+    fn resume_aborts_when_result_no_longer_virtual() {
+        let mock_ctx = mock_context();
+        let guard = mock_ctx.spec_read();
+        let wcii = Mock::new([1u64, 2, 3]);
+        let child = Mock::new([2u64]);
+        let mut it = Box::new(NotOptimized::new(wcii, child, 3, 1.0, NoTimeoutChecker));
+        let doc = it.read().expect("read failed").expect("expected doc");
+        assert_eq!(doc.doc_id, 1);
+        // Simulate a consumer swapping the sentinel for a real payload.
+        *doc = index_result::RSIndexResult::build_numeric(1.0).build();
+
+        let outcome = it
+            .suspend()
+            .resume(&guard)
+            .expect("resume must not surface an error");
+        assert!(
+            matches!(outcome, ResumeOutcome::Aborted),
+            "a non-virtual sentinel cannot be re-validated, so resume aborts",
+        );
+    }
+
+    /// A wildcard that resumes onto a document past `max_doc_id` is out of this
+    /// iterator's range, so the move carries no position — the same answer the
+    /// read loop, `skip_to` and `revalidate` all give when the wildcard steps
+    /// over the bound. Without the check the resumed iterator would publish that
+    /// out-of-range id as its current result.
+    #[test]
+    fn resume_wc_moved_past_max_doc_id_reports_no_position() {
+        let mock_ctx = mock_context();
+        let guard = mock_ctx.spec_read();
+        // The wildcard holds 1 and 50; `max_doc_id` is 10, so 50 is out of range.
+        let wcii = Mock::new([1u64, 50]);
+        wcii.data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        let child = Mock::new([100u64]); // never matches
+        let mut it = Box::new(NotOptimized::new(wcii, child, 10, 1.0, NoTimeoutChecker));
+
+        let doc = it.read().expect("read failed").expect("1 is in range");
+        assert_eq!(doc.doc_id, 1);
+
+        let mut active = match it.suspend().resume(&guard).expect("resume failed") {
+            ResumeOutcome::Moved(a) => a,
+            ResumeOutcome::Ok(_) => panic!("the wildcard moved, so the resume must report Moved"),
+            ResumeOutcome::Aborted => panic!("expected Moved, got Aborted"),
+        };
+        assert!(
+            active.at_eof(),
+            "50 is past max_doc_id, so there is nothing left in range",
+        );
+        assert!(active.current().is_none());
+        assert_eq!(
+            active.last_doc_id(),
+            1,
+            "the out-of-range id was never yielded, so it must not become the position",
+        );
+    }
+
+    /// A failing child resume leaves the child slot gone while the wildcard has
+    /// already been resumed into an owned local — the only shape in which
+    /// `FreeSuspendedShell` has to free the allocation with exactly one slot
+    /// live. A teardown that dropped a moved-from slot, or leaked the fields it
+    /// still owns, shows up here and only under miri.
+    #[test]
+    fn resume_propagates_child_error() {
+        let mock_ctx = mock_context();
+        let guard = mock_ctx.spec_read();
+        let wcii = Mock::new([1u64, 2, 3, 4, 5]);
+        let child = Mock::new([2u64, 4]);
+        child
+            .data()
+            .set_error_on_resume(Some(MockIteratorError::TimeoutError(None)));
+        let mut it = Box::new(NotOptimized::new(wcii, child, 5, 1.0, NoTimeoutChecker));
+
+        let doc = it.read().expect("read failed").expect("expected doc");
+        assert_eq!(doc.doc_id, 1);
+
+        assert!(
+            matches!(it.suspend().resume(&guard), Err(RQEIteratorError::TimedOut)),
+            "a child resume error must propagate out of NotOptimized::resume",
+        );
+    }
+
+    /// The mirror image: the wildcard fails first, so the child is still
+    /// suspended when the shell is torn down and has to be dropped in its
+    /// suspended form.
+    #[test]
+    fn resume_propagates_wildcard_error() {
+        let mock_ctx = mock_context();
+        let guard = mock_ctx.spec_read();
+        let wcii = Mock::new([1u64, 2, 3, 4, 5]);
+        wcii.data()
+            .set_error_on_resume(Some(MockIteratorError::TimeoutError(None)));
+        let child = Mock::new([2u64, 4]);
+        let mut it = Box::new(NotOptimized::new(wcii, child, 5, 1.0, NoTimeoutChecker));
+
+        let doc = it.read().expect("read failed").expect("expected doc");
+        assert_eq!(doc.doc_id, 1);
+
+        assert!(
+            matches!(it.suspend().resume(&guard), Err(RQEIteratorError::TimedOut)),
+            "a wildcard resume error must propagate out of NotOptimized::resume",
+        );
+    }
+
+    /// An aborting wildcard is the base going away, so the whole iterator aborts
+    /// — and, as in `revalidate`, that decision is taken before the child is
+    /// touched at all. It is also the abort path through `FreeSuspendedShell`,
+    /// which frees the allocation with both slots gone.
+    #[test]
+    fn resume_aborts_when_wildcard_aborts_without_touching_the_child() {
+        let mock_ctx = mock_context();
+        let guard = mock_ctx.spec_read();
+        let wcii = Mock::new([1u64, 2, 3, 4, 5]);
+        wcii.data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        let child = Mock::new([2u64, 4]);
+        let child_data = child.data();
+        let mut it = Box::new(NotOptimized::new(wcii, child, 5, 1.0, NoTimeoutChecker));
+
+        let doc = it.read().expect("read failed").expect("expected doc");
+        assert_eq!(doc.doc_id, 1);
+
+        let outcome = it
+            .suspend()
+            .resume(&guard)
+            .expect("an aborting wildcard is not an error");
+        assert!(matches!(outcome, ResumeOutcome::Aborted));
+        assert_eq!(
+            child_data.revalidate_count(),
+            0,
+            "the wildcard abort must short-circuit before the child is driven, as in revalidate",
+        );
+    }
+
+    /// FFI profile printing reads the suspended form's position and estimate
+    /// without resuming it, so those accessors must report what the active form
+    /// held rather than a default or a sub-iterator's own view.
+    #[test]
+    fn suspended_accessors_report_the_pre_suspend_position_and_estimate() {
+        let mock_ctx = mock_context();
+        let guard = mock_ctx.spec_read();
+        let wcii = Mock::new([1u64, 2, 3, 4, 5]);
+        let child = Mock::new([2u64, 4]);
+        let mut it = Box::new(NotOptimized::new(wcii, child, 5, 1.0, NoTimeoutChecker));
+
+        let doc = it.read().expect("read failed").expect("expected doc");
+        assert_eq!(doc.doc_id, 1);
+        assert_eq!(it.last_doc_id(), 1);
+        assert_eq!(it.num_estimated(), 5);
+
+        let suspended = it.suspend();
+        assert_eq!(
+            RQESuspendedIterator::last_doc_id(&*suspended),
+            1,
+            "the suspended form keeps NOT's own cursor, not a sub-iterator's",
+        );
+        assert_eq!(
+            RQESuspendedIterator::num_estimated(&*suspended),
+            5,
+            "the estimate still comes from the wildcard base",
+        );
+
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(a) => a,
+            ResumeOutcome::Moved(_) => panic!("expected Ok, got Moved"),
+            ResumeOutcome::Aborted => panic!("expected Ok, got Aborted"),
+        };
+        assert_eq!(active.last_doc_id(), 1);
+        let doc = active.read().expect("read failed").expect("expected doc");
+        assert_eq!(doc.doc_id, 3);
+    }
+
+    /// The outcome shape the legacy and resume paths share, for the differential
+    /// tests below.
+    #[derive(Debug, PartialEq, Eq)]
+    enum Outcome {
+        Ok,
+        Moved,
+        Aborted,
+        Failed,
+    }
+
+    /// Read `it` to completion, collecting the doc ids it yields.
+    fn drain<'index>(it: &mut impl RQEIterator<'index>) -> Vec<DocId> {
+        let mut seen = Vec::new();
+        while let Some(doc) = it.read().expect("read failed") {
+            seen.push(doc.doc_id);
+        }
+        seen
+    }
+
+    /// Drive `build()` through the legacy `revalidate` and through
+    /// `suspend`/`resume`, and require both to agree on the outcome *and* on
+    /// everything read afterwards. `what` names the scenario in the failure.
+    fn assert_paths_agree<'index, W, I>(
+        what: &str,
+        guard: &index_spec::IndexSpecReadGuard<'index>,
+        build: impl Fn() -> Box<NotOptimized<'index, W, I, NoTimeoutChecker>>,
+    ) where
+        W: RQEIteratorBoxed<'index>,
+        I: RQEIteratorBoxed<'index>,
+    {
+        let mut legacy = build();
+        let legacy_outcome = match legacy.revalidate(guard) {
+            Ok(RQEValidateStatus::Ok) => Outcome::Ok,
+            Ok(RQEValidateStatus::Moved { .. }) => Outcome::Moved,
+            Ok(RQEValidateStatus::Aborted) => Outcome::Aborted,
+            Err(_) => Outcome::Failed,
+        };
+        // An aborted or failed iterator is dropped rather than used, so there is
+        // nothing left to read on either path.
+        let legacy_tail = match legacy_outcome {
+            Outcome::Ok | Outcome::Moved => drain(&mut *legacy),
+            Outcome::Aborted | Outcome::Failed => Vec::new(),
+        };
+
+        let (resumed_outcome, resumed_tail) = match build().suspend().resume(guard) {
+            Ok(ResumeOutcome::Ok(mut it)) => (Outcome::Ok, drain(&mut *it)),
+            Ok(ResumeOutcome::Moved(mut it)) => (Outcome::Moved, drain(&mut *it)),
+            Ok(ResumeOutcome::Aborted) => (Outcome::Aborted, Vec::new()),
+            Err(_) => (Outcome::Failed, Vec::new()),
+        };
+
+        assert_eq!(
+            legacy_outcome, resumed_outcome,
+            "{what}: the two paths disagree on the outcome",
+        );
+        assert_eq!(
+            legacy_tail, resumed_tail,
+            "{what}: the two paths disagree on what is read afterwards",
+        );
+    }
+
+    /// While the legacy `revalidate` and the new `resume` both exist they are two
+    /// spellings of one transition, and sibling iterators in this stack have
+    /// already drifted between them — a sub-iterator outcome absorbed on one path
+    /// and forwarded on the other, or a re-read done only once. Drive both over
+    /// every wildcard × child outcome pair, error outcomes included.
+    #[test]
+    fn revalidate_and_resume_agree_on_every_outcome_pair() {
+        let outcomes = [
+            MockRevalidateResult::Ok,
+            MockRevalidateResult::Move,
+            MockRevalidateResult::Abort,
+            MockRevalidateResult::TimedOut,
+        ];
+        for wc_outcome in outcomes {
+            for child_outcome in outcomes {
+                let mock_ctx = mock_context();
+                let guard = mock_ctx.spec_read();
+                // NOT sits on doc 1 with the child pulled ahead to 3, so a
+                // wildcard move lands on a document the child already holds —
+                // the shape that exercises the catch-up and the re-scan.
+                let build = || {
+                    let wcii = Mock::new([1u64, 3, 5, 7]);
+                    wcii.data().set_revalidate_result(wc_outcome);
+                    let child = Mock::new([3u64, 7]);
+                    child.data().set_revalidate_result(child_outcome);
+                    let mut it =
+                        Box::new(NotOptimized::new(wcii, child, 10, 1.0, NoTimeoutChecker));
+                    let doc = it.read().expect("read failed").expect("expected doc");
+                    assert_eq!(doc.doc_id, 1);
+                    it
+                };
+                assert_paths_agree(
+                    &format!("wildcard {wc_outcome:?}, child {child_outcome:?}"),
+                    &guard,
+                    build,
+                );
+            }
+        }
+    }
+
+    /// The two ways the post-move sync can fail. Both leave membership
+    /// undecided, and both used to be swallowed on the resume path while
+    /// `revalidate` propagated them — a `NOT` publishing a document it exists to
+    /// exclude, and an "exhausted" report a later read could contradict.
+    #[test]
+    fn revalidate_and_resume_agree_when_the_post_move_sync_fails() {
+        // The wildcard's move jumps to 50, leaving the child behind on 3, so the
+        // catch-up skip runs — and fails.
+        let mock_ctx = mock_context();
+        let guard = mock_ctx.spec_read();
+        assert_paths_agree("catch-up skip fails", &guard, || {
+            let wcii = Mock::new([1u64, 50]);
+            wcii.data()
+                .set_revalidate_result(MockRevalidateResult::Move);
+            // The child holds 50, so the membership that cannot be decided is one
+            // whose true answer is "present".
+            let child = Mock::new([3u64, 50]);
+            child
+                .data()
+                .set_error_on_skip_to(Some(MockIteratorError::TimeoutError(None)));
+            let mut it = Box::new(NotOptimized::new(wcii, child, 100, 1.0, NoTimeoutChecker));
+            let doc = it.read().expect("read failed").expect("expected doc");
+            assert_eq!(doc.doc_id, 1);
+            it
+        });
+
+        // The wildcard's move lands *on* the child's position, so the scan for the
+        // next valid result runs — and reads the child past its end, where the
+        // failure is injected.
+        let mock_ctx = mock_context();
+        let guard = mock_ctx.spec_read();
+        assert_paths_agree("re-scan fails", &guard, || {
+            let wcii = Mock::new([1u64, 5, 10]);
+            wcii.data()
+                .set_revalidate_result(MockRevalidateResult::Move);
+            let child = Mock::new([5u64]);
+            child
+                .data()
+                .set_error_at_done(Some(MockIteratorError::TimeoutError(None)));
+            let mut it = Box::new(NotOptimized::new(wcii, child, 100, 1.0, NoTimeoutChecker));
+            let doc = it.read().expect("read failed").expect("expected doc");
+            assert_eq!(doc.doc_id, 1);
+            it
+        });
+    }
+
+    /// Exhaustion has to survive the cycle, and a *conforming* wildcard reaches
+    /// this: `skip_to` past `max_doc_id` ends the iterator without touching the
+    /// wildcard, which is left live on a document rather than at EOF. The wildcard
+    /// then moving forward under GC is all any conforming iterator does — but
+    /// assigning `past_end` from `wcii.at_eof()` reads that as "not at EOF" and
+    /// clears a flag set for an unrelated reason, handing back a resumed iterator
+    /// that had already reported it was done.
+    ///
+    /// The legacy twin is
+    /// `revalidate::revalidate_after_skip_past_max_doc_id_does_not_revive_the_iterator`.
+    /// Its sibling there — a wildcard that re-seeks *backwards* — has no resume
+    /// counterpart: `set_revalidate_reseeks_to` steers only `Mock::revalidate`.
+    #[test]
+    fn resume_after_skip_past_max_doc_id_does_not_revive_the_iterator() {
+        let mock_ctx = mock_context();
+        let guard = mock_ctx.spec_read();
+        let wcii = Mock::new([5u64, 10, 50, 60]);
+        wcii.data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        // Out of range of the wildcard, so every wildcard document is a NOT result.
+        let child = Mock::new([1000u64]);
+        let mut it = Box::new(NotOptimized::new(wcii, child, 100, 1.0, NoTimeoutChecker));
+
+        assert_eq!(
+            it.read()
+                .expect("read failed")
+                .expect("5 is in range")
+                .doc_id,
+            5
+        );
+        assert_eq!(
+            it.read()
+                .expect("read failed")
+                .expect("10 is in range")
+                .doc_id,
+            10
+        );
+
+        // Past the bound: this ends the iterator, and returns before the wildcard is
+        // asked anything — so the wildcard is still sitting on doc 10, not at EOF.
+        assert!(it.skip_to(101).expect("skip_to failed").is_none());
+        assert!(it.at_eof());
+
+        let mut active = match it.suspend().resume(&guard).expect("resume failed") {
+            ResumeOutcome::Moved(a) => a,
+            ResumeOutcome::Ok(_) => panic!("the wildcard moved, so the resume must report Moved"),
+            ResumeOutcome::Aborted => panic!("expected Moved, got Aborted"),
+        };
+        assert!(
+            active.at_eof(),
+            "a skip past max_doc_id ends the iterator for good, whatever the wildcard \
+             recovers afterwards",
+        );
+        // 60 is still in range and absent from the child, so it is only the latch
+        // that keeps it from being yielded by an iterator that is done.
+        assert!(
+            active.read().expect("read failed").is_none(),
+            "the resumed iterator must stay exhausted",
+        );
+        assert!(active.at_eof());
+    }
 }
 
 /// `skip_to` bounds its *target* against `max_doc_id`, but the wildcard can land


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `NotOptimized` (the `NOT` iterator, wildcard plus excluded child) can only be revalidated in place, so it cannot be held while the index spec read lock is dropped.
2. Change: it now implements `RQEIteratorBoxed::suspend` / `RQESuspendedIterator::resume` — the boxed iterator is weakened to a `Suspended` form, its wildcard and its child transitioned inside their own slots, and re-narrowed on resume in the same allocation. The legacy `revalidate` is left in place and unchanged.
3. Outcome: no user-visible change. Nothing in the query pipeline suspends iterators yet; this is one of the per-iterator prerequisites for the later PR that wires suspension into query execution.

#### Which additional issues this PR fixes

1. MOD-17393

#### Main objects this PR modified

1. `RawNotOptimized<Rf, W, I, TC>` — the `Ref`-mode-parametrized form, with the `const` layout-invariant proof that pairs its active and suspended instantiations.
2. `NotOptimized::suspend` — transitions both the wildcard slot and the child slot in place, routed through the trait so a type-erased child swaps its vtable.
3. `FreeSuspendedShell` — drop guard that tears down the half-transitioned shell when one of the two children aborts or errors mid-resume, so nothing gets re-narrowed onto a consumed child.
4. `resume`'s status combination: how the wildcard's and the child's outcomes fold into one `ResumeOutcome`, and the re-scan that finds the next non-excluded document when either moved.
5. `tests/integration/not_optimized.rs` — the resume matrix mirrors the existing revalidate matrix case for case, plus box-address preservation and type-erased children.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
