### PR TITLE
[Iterator Revalidation] Aggregate rebuild machinery for suspended composites

### DIFF
--- a/src/redisearch_rs/index_result/src/aggregate.rs
+++ b/src/redisearch_rs/index_result/src/aggregate.rs
@@ -7,7 +7,9 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use ref_mode::{Active, Ref, SharedPtr};
+use std::ptr::NonNull;
+
+use ref_mode::{Active, Ref, SharedPtr, Suspended};
 use thin_vec::SmallThinVec;
 
 use super::core::{RSIndexResult, RawIndexResult};
@@ -449,6 +451,59 @@ impl<'query, R: Ref> RawAggregateResult<'query, R> {
             Self::Borrowed(agg) => agg.reset(),
             Self::Owned(agg) => agg.reset(),
         }
+    }
+}
+
+impl<'query> RawBorrowedAggregateResult<'query, Suspended> {
+    /// Append an entry for `child`, taking its provenance from that live
+    /// reference — the push counterpart of
+    /// [`push_borrowed`](RSBorrowedAggregateResult::push_borrowed), for a caller
+    /// holding a [`Suspended`] aggregate and an [`Active`] child.
+    ///
+    /// # Why a suspended aggregate needs this
+    ///
+    /// Every entry is a pointer derived from a `&` to a child's own
+    /// [`RawIndexResult`]. A resume re-narrows them all in one whole-allocation
+    /// cast, which the addresses survive — the children never leave their slots
+    /// — but their *provenance* does not: transitioning a child hands its
+    /// allocation through a by-value `Box<Self>`, and that retag invalidates the
+    /// borrow each entry was derived from. Rebuilding the list while the result
+    /// is still suspended writes every entry from a reference that post-dates
+    /// the retag.
+    ///
+    /// # What the caller still owes
+    ///
+    /// [`reset`](RawBorrowedAggregateResult::reset) drops the kind mask with the
+    /// records and this rebuilds it, but `freq` and `field_mask` live on the
+    /// enclosing [`RawIndexResult`] and are the caller's to re-accumulate.
+    /// `metrics` are not: [`RSIndexResult::push_borrowed`] **moves** them out of
+    /// the children when the aggregate is first built, so there is nothing to
+    /// re-accumulate and they must be carried across untouched.
+    ///
+    /// The lifetime tie does not keep the child *alive*, since the stored
+    /// pointer is raw — that stays [`RawIndexResult::into_active`]'s
+    /// preconditions (3) and (4), along with taking no `&mut` to the child
+    /// before the result is re-narrowed.
+    ///
+    /// # Why the child is tied to `'query`
+    ///
+    /// A child admitted at a shorter lifetime would have its query-pipeline
+    /// pointers — the [`RLookupKey`](ffi::RLookupKey) in its `metrics`, a term
+    /// record's borrowed query term — silently widened to `'query`.
+    /// [`RawIndexResult::into_active`] excludes exactly those from the caller's
+    /// obligations because the `'query: 'a` bound already covers them, so
+    /// widening would remove the only thing that clause rests on, in safe code
+    /// and with no diagnostic. A composite whose children sit at a shorter `'a`
+    /// narrows its *result* to `'a` instead — the sound direction, which `&mut`
+    /// invariance stops the compiler from taking on its own.
+    pub fn push_borrowed_ptr_from_ref(&mut self, child: &RSIndexResult<'query>) {
+        // The cast is between the two `Ref` modes of one `#[repr(C)]` type,
+        // proven layout-identical in `core`, and changes neither address nor
+        // provenance.
+        let live = NonNull::from_ref(child).cast::<RawIndexResult<'query, Suspended>>();
+        self.records.push(SharedPtr::from_non_null(live));
+
+        self.kind_mask |= child.kind();
     }
 }
 

--- a/src/redisearch_rs/index_result/tests/integration/aggregate.rs
+++ b/src/redisearch_rs/index_result/tests/integration/aggregate.rs
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Tests for [`RawAggregateResult::push_borrowed_ptr_from_ref`], the primitive a
+//! suspended composite uses to rebuild its borrowed entries with fresh
+//! provenance before it re-narrows them.
+//!
+//! Run these under miri: the property under test is a Stacked Borrows one, and
+//! outside miri a re-narrowed entry with a dead borrow reads back perfectly
+//! well.
+//!
+//! [`RawAggregateResult::push_borrowed_ptr_from_ref`]: index_result::RawAggregateResult::push_borrowed_ptr_from_ref
+
+use index_result::{MetricsVec, RSIndexResult};
+
+/// Hands `child`'s allocation through a by-value [`Box`], reproducing what
+/// transitioning a child does to it: the function-entry retag invalidates every
+/// borrow taken from that allocation before the call, which is precisely how a
+/// composite's aggregate entries lose their provenance across a suspend/resume
+/// cycle.
+#[inline(never)]
+fn retag<T>(child: Box<T>) -> Box<T> {
+    child
+}
+
+/// Borrows `child` into `parent`'s aggregate the way a composite iterator does:
+/// through a raw pointer, because the child is owned by a sibling field and the
+/// borrow checker cannot see that it outlives the aggregate.
+fn push_borrowed<'a>(
+    parent: &mut RSIndexResult<'a>,
+    child: &RSIndexResult<'a>,
+    metrics: MetricsVec<'a>,
+) {
+    let child: *const RSIndexResult<'a> = child;
+    // SAFETY: every caller below keeps the child alive for as long as `parent`,
+    // moving it only through the deliberate `retag` above (which preserves its
+    // address).
+    let child = unsafe { &*child };
+    parent.push_borrowed(child, metrics);
+}
+
+/// The property the primitive exists for: after every child has been retagged,
+/// rebuilding the entries from those children makes the aggregate readable
+/// again — and leaves the metrics alone, which is the part a rebuild cannot put
+/// back.
+#[test]
+fn rebuilt_entries_survive_the_children_being_retagged() {
+    let child0 = Box::new(
+        RSIndexResult::build_numeric(1.0)
+            .doc_id(7)
+            .frequency(3)
+            .build(),
+    );
+    let child1 = Box::new(
+        RSIndexResult::build_numeric(2.0)
+            .doc_id(7)
+            .frequency(5)
+            .build(),
+    );
+
+    let mut parent = RSIndexResult::build_intersect(2).build();
+    let mut metrics = MetricsVec::new();
+    metrics.push_without_key(0.5);
+    push_borrowed(&mut parent, &child0, metrics);
+    push_borrowed(&mut parent, &child1, MetricsVec::new());
+
+    let (doc_id, freq, field_mask) = (parent.doc_id, parent.freq, parent.field_mask);
+    assert_eq!(freq, 8, "the frequencies of both children accumulated");
+
+    let mut suspended = parent.into_suspended();
+    let child0 = retag(child0);
+    let child1 = retag(child1);
+
+    let aggregate = suspended
+        .as_aggregate_mut()
+        .and_then(|agg| agg.as_borrowed_mut())
+        .expect("an intersection result carries a borrowed aggregate");
+    let kind_mask = aggregate.kind_mask();
+    aggregate.reset();
+    aggregate.push_borrowed_ptr_from_ref(&child0);
+    aggregate.push_borrowed_ptr_from_ref(&child1);
+    assert_eq!(
+        aggregate.len(),
+        2,
+        "one entry per child that was pushed back",
+    );
+    assert_eq!(
+        aggregate.kind_mask(),
+        kind_mask,
+        "`reset` drops the kind mask and the pushes rebuild it",
+    );
+
+    // SAFETY: both entries were just written from live children that are still
+    // alive and at the same address, and the result holds nothing else that
+    // suspension weakened.
+    let parent = unsafe { suspended.into_active() };
+
+    assert_eq!(
+        parent.get(0).expect("first entry").doc_id,
+        7,
+        "the first entry reaches its child",
+    );
+    assert_eq!(
+        parent.get(1).expect("second entry").doc_id,
+        7,
+        "the second entry reaches its child",
+    );
+    assert_eq!(
+        (parent.doc_id, parent.freq, parent.field_mask),
+        (doc_id, freq, field_mask),
+        "the primitive writes entries; the position and scalars are the \
+         caller's to maintain",
+    );
+    assert_eq!(
+        parent.metrics.get(0).map(|m| m.value()),
+        Some(0.5),
+        "the metrics moved out of the children when the aggregate was first \
+         built are still here — `reset_aggregate` would have lost them",
+    );
+}
+
+/// A rebuild is free to come out shorter than it went in: the entries are
+/// whatever the caller pushes, so a child that no longer qualifies simply is not
+/// pushed, and no bookkeeping has to recognise its absence.
+#[test]
+fn a_rebuild_can_drop_a_child_by_not_pushing_it() {
+    let survivor = Box::new(RSIndexResult::build_numeric(1.0).doc_id(7).build());
+    let departing = Box::new(RSIndexResult::build_numeric(2.0).doc_id(7).build());
+
+    let mut parent = RSIndexResult::build_intersect(2).build();
+    push_borrowed(&mut parent, &survivor, MetricsVec::new());
+    push_borrowed(&mut parent, &departing, MetricsVec::new());
+
+    let mut suspended = parent.into_suspended();
+    let survivor = retag(survivor);
+    drop(departing);
+
+    let aggregate = suspended
+        .as_aggregate_mut()
+        .and_then(|agg| agg.as_borrowed_mut())
+        .expect("an intersection result carries a borrowed aggregate");
+    aggregate.reset();
+    aggregate.push_borrowed_ptr_from_ref(&survivor);
+    assert_eq!(
+        aggregate.len(),
+        1,
+        "the departed child left no trace to clean up",
+    );
+
+    // SAFETY: the only entry was just written from a live child, and the
+    // dropped one was never written back.
+    let parent = unsafe { suspended.into_active() };
+    assert_eq!(parent.get(0).expect("the surviving entry").doc_id, 7);
+    assert!(parent.get(1).is_none(), "nothing stale was left behind");
+}
+
+/// An owned aggregate keeps its children in its own allocation, so there is no
+/// borrowed payload to push onto — the split between the two aggregate types
+/// makes that a compile-time distinction rather than a runtime check, and
+/// `as_borrowed_mut` returning `None` is how a rebuild recognises it.
+#[test]
+fn an_owned_aggregate_has_no_borrowed_payload() {
+    let parent = RSIndexResult::build_hybrid_metric().build();
+    let mut suspended = parent.into_suspended();
+    let aggregate = suspended
+        .as_aggregate_mut()
+        .expect("a hybrid metric result carries an aggregate");
+    assert!(
+        aggregate.as_borrowed_mut().is_none(),
+        "an owned aggregate has no borrowed payload to push onto",
+    );
+}

--- a/src/redisearch_rs/index_result/tests/integration/main.rs
+++ b/src/redisearch_rs/index_result/tests/integration/main.rs
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+mod aggregate;

--- a/src/redisearch_rs/rqe_iterators/.skills/rqe-iterator-suspend-resume/SKILL.md
+++ b/src/redisearch_rs/rqe_iterators/.skills/rqe-iterator-suspend-resume/SKILL.md
@@ -124,6 +124,73 @@ After the child slot is transitioned, `Box::from_raw(raw.cast())` the wrapper.
 The wrapper must be `#[repr(C)]` with the child slot plus only `Rf`-free fields
 and the ZST `PhantomData<Rf>`.
 
+### Transition *every* child, exhausted ones included
+
+A composite that holds several children (a `Vec<I>`, a fixed pair, …) walks all of
+them. Not the active region, not the ones still in its heap — **every slot it
+owns**, including the ones it parked as spent. This is not an optimisation
+opportunity; skipping the inactive ones is wrong twice over:
+
+1. **The cast retypes the whole buffer at once.** After
+   `Box::from_raw(raw.cast())` every slot is typed `S::Resumed<'a>`, so one left
+   holding an `S` is read at the wrong type by anything that touches it —
+   `Drop` included. There is no per-slot opt-out: it is transition-all or
+   transition-none.
+2. **`rewind` re-admits all of them.** A composite's `rewind` resets
+   `num_active` to `children.len()` (or rebuilds its heap) and rewinds each
+   child, so exhaustion is not out-of-reach — it is one `rewind` away. A child
+   skipped on the grounds that it was spent is a suspended iterator the very next
+   rewind rewinds and reads.
+
+The only child that leaves the collection is one whose `resume` reported
+`Aborted` or `Err`: the helper consumed it, so the composite removes or compacts
+over its slot, exactly as `revalidate` drops an aborted child. Whatever it does
+there, the buffer must stay in a shape the teardown path can describe — for a
+`Vec` of children, compacting survivors down keeps it a resumed prefix followed
+by a suspended suffix, which is the split a teardown after a mid-walk `Err` needs.
+
+Removing a child *does* invalidate any active/parked partition or index-keyed
+side table (`num_active`, a heap of `child_idx` entries), so rebuild those after
+the walk — and say that is why, not the reason ruled out in the next section.
+Rebuild them **before** rebuilding the aggregate, not after: a side-table
+rebuild that touches children mutably undoes the entries' provenance. See
+"Call it last" below.
+
+### Exhaustion is terminal: assume it, don't compensate for it
+
+`RQEIterator::at_eof` owns the rule: once it is `true` it stays `true` until
+`rewind`, across `revalidate` and `resume` alike. A composite relies on it:
+
+- a child suspended at `at_eof` resumes at `at_eof`;
+- a child dropped from the active set *because* it hit EOF cannot re-enter it
+  behind the parent's position.
+
+A leaf that restores its position with `rewind()` + `skip_to` has to take care
+here: the `rewind` clears the past-the-end state, so an iterator that was *at*
+EOF must have that position restored explicitly rather than re-sought.
+
+So **do not carry recovery code for a resurrected child**. Where a "child landed
+behind us" path is still structurally reachable for some *other* reason — a
+`QUICK_EXIT` union's own early return strands a live sibling — gate the recovery
+on that reason and `debug_assert!` the rest, so a broken child is surfaced rather
+than quietly absorbed. Both unions do exactly this:
+
+```rust
+if min_doc_id < original_last_doc_id {
+    debug_assert!(
+        QUICK_EXIT,
+        "a full union's child moved behind the union's position: …",
+    );
+```
+
+Enforcement is already in the harness — lean on it rather than re-deriving it.
+`rqe_iterators_test_utils::revalidate_via_resume` is the funnel every resume test
+goes through, and it asserts across the cycle that an at-EOF iterator stays at
+EOF, that the position never moves backwards, and that `Ok` means an unchanged
+position; `ContractChecker` asserts the `RQEIterator` half. A test that reaches a
+state the rules forbid asserts the **panic** (`#[should_panic]` +
+`#[cfg(debug_assertions)]`) rather than the compensation.
+
 ### The child slot: use a `#[repr(C)]` enum, not `Option<I>`
 
 When the child slot must express **"present or absent"** (or "either the child or
@@ -222,35 +289,53 @@ The direction asymmetry is the crux:
   re-narrowing. Leaves do exactly this in their `resume_in_place` (refresh the
   reader, promote the result).
 
-**Virtual sentinels are the trap.** An iterator whose result is a virtual
-sentinel (`RSIndexResult::build_virt()`, `kind() == Virtual`) has no `Rf`-borrows
-in `data`, so resume needs to re-validate nothing. But note two things:
+### Aggregates: rebuild the entries, never merely re-narrow them
 
-1. Because `current()` hands the result out **mutably**, "still virtual" is an
-   *unenforced* runtime invariant — a consumer *could* replace `data` with a real
-   payload. So it must be **checked at the resume boundary, not assumed**:
-   `kind() == Virtual` is the whole condition (`dmd`/`metrics` are not
-   `Rf`-parametrized, so they don't affect the reinterpretation).
-2. An owner of a *sentinel* has no index backing to re-validate a foreign payload
-   against — it cannot recover a non-virtual result. So on violation it must
-   **refuse to reinterpret** stale pointers as live — never silently continue.
-   The approved pattern makes this check on `&self` **before** `Box::into_raw`
-   opens the raw-pointer critical section, and returns `Ok(ResumeOutcome::Aborted)`
-   so the box simply drops. It must **not** be surfaced as `Err`: a sentinel
-   violation is a recoverable unsafe-to-resume state that callers already handle
-   via `ResumeOutcome::Aborted`, and `RQEIteratorError` is reserved for genuine
-   `TimedOut`/`IoError` failures — turning this into an `Err` would raise a
-   user-visible error where none is warranted.
+An **aggregate** result holds one borrowed entry per contributing child, each
+derived from a borrow of that child's result. Transitioning a child hands its
+allocation through a by-value `Box<Self>`, and that retag kills the borrow the
+entry came from, even though the child never moves. The address survives, the
+provenance does not — so the whole-box cast alone leaves entries that are
+well-addressed and UB to read, which is what a scorer walking `current()` after
+an `Ok` resume does.
 
-Worked examples:
+Discharge it by **rebuilding the entry list** while the result is still
+suspended: reset the aggregate's records, then push one entry per contributor
+through `index_result::RawAggregateResult::push_borrowed_ptr_from_ref`.
 
-- `optional.rs` — `Optional`'s `resume` checks `self.result.kind() != Virtual`
-  on `&self`, **before** `Box::into_raw`, and returns `Ok(ResumeOutcome::Aborted)`
-  on violation (the box just drops). It cannot re-validate an index-backed payload
-  it did not create, so it refuses to reinterpret rather than erroring.
-- `maybe_empty.rs` — `MaybeEmpty` owns **no** result, so it has no virtual
-  fallback: a child that aborts on resume aborts the whole wrapper (the consumed
-  `Some(I)` slot is rewritten to `None(Empty)` before the box is dropped).
+**Recompute the contributor set; do not recognise it.** An entry records only an
+address, so matching entries back to children breaks as soon as a composite
+compacts over a dropped slot, and cannot tell a survivor that moved onto that
+address from the one always there. Every composite already knows the rule it
+chose contributors by — a union takes every child on its document, an
+intersection publishes only once all of them agree — so evaluate that rule again
+over the survivors, in the composite's own module.
+
+**Recompute `freq` and `field_mask`; carry `metrics` and `doc_id` across.** The
+first two are copies of what each contributor holds. Metrics are *moved* out of
+the children when the aggregate is first built, so there is nothing to
+re-accumulate and resetting them drops `__vector_score` for good — which is why
+`reset_aggregate` is the wrong clearing tool, since it takes all four. Reset the
+records alone, and read `doc_id` before you do.
+
+**Narrow the result, never widen the children.** Entries are stored at the
+composite's `'query` while its resumed children sit at the shorter `'a`.
+Admitting an `'a` child into a `'query` slot silently widens its query-pipeline
+pointers, which `into_active` excludes from the caller's obligations precisely
+because the `'query: 'a` bound covers them. `push_borrowed_ptr_from_ref` ties its
+child to `'query` so that is rejected; `&mut` is invariant, so narrowing the
+result takes an explicit re-cast of the pointer.
+
+**Call it last** — after the child walk, after any side-table rebuild, with no
+`&mut` taken to a child afterwards: each entry is a shared reborrow whose tag a
+later `read`, `skip_to`, `iter_mut` or `swap_remove` pops. `&mut` to the
+composite itself is fine.
+
+**Act on the outcome**, behind a `#[must_use]` type phrased as the composite
+means it — a union needs one child behind its document, an intersection needs
+all of them. Coming up short is safe to re-narrow and unsafe to publish: return
+`ResumeOutcome::Aborted` unless the path rebuilds anyway (a union's settle, an
+intersection's `skip_to`) or is gated on `is_eof`.
 
 ## Layout-invariant enforcement (compile-time)
 
@@ -305,6 +390,15 @@ teardown. Any bespoke in-place transition code must reproduce this.
       `from_raw`); never rebuilt with `Box::new`.
 - [ ] Generic children are transitioned via `suspend_child_slot_in_place` /
       `resume_child_slot_in_place`, **never** whole-box cast directly.
+- [ ] **Every** child slot is transitioned — the parked and exhausted ones too,
+      not just the active region — and only an `Aborted`/`Err` child leaves the
+      collection. Any active/parked partition or index-keyed side table is
+      rebuilt afterwards *because a removal invalidated it*, not because a child
+      can come back.
+- [ ] No resurrection compensation: a child at `at_eof` before the cycle is
+      assumed at `at_eof` after it. A "child landed behind us" recovery is gated
+      on a reason other than resurrection (e.g. `QUICK_EXIT`) and
+      `debug_assert!`ed otherwise.
 - [ ] A child slot that can be absent uses a **`#[repr(C)]` enum** (e.g.
       `OptionalChild`/`MaybeEmptyOption`), **never** `Option<I>` (niche layout is
       not transmute-stable across `I → I::Suspended`).
@@ -324,6 +418,11 @@ teardown. Any bespoke in-place transition code must reproduce this.
       the resume **refuses to reinterpret** on violation — returning
       `ResumeOutcome::Aborted` (never `Err`: the state is recoverable, and
       `RQEIteratorError` is only for `TimedOut`/`IoError`).
+- [ ] If the iterator owns an **aggregate**, `resume` rebuilds its entries from
+      the transitioned children — recomputing the contributor set rather than
+      matching by address, recomputing `freq`/`field_mask` with it, carrying
+      `metrics`/`doc_id` across, narrowing the result to the children's lifetime
+      rather than widening theirs, and acting on the `#[must_use]` outcome.
 - [ ] Panic window is covered (the shared helpers already do; bespoke in-place
       code must arm its own abort guard).
 - [ ] `// SAFETY:` comments cite the invariant; no compiler-enforced fact is


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: a composite iterator's aggregate result borrows its children — every entry is a pointer derived from a reference into a child's own result. Suspending the composite hands each child's allocation through a by-value `Box<Self>`, which retags it and pops the tag the entry was derived from, so re-narrowing the aggregate at the end of `resume` yields entries that are undefined to read through even though nothing was dropped, moved or written (this is what Miri's Stacked Borrows flags).
2. Change: adds the primitive that discharges it. `RawAggregateResult<Suspended>::push_borrowed_from_live` writes an entry from a live child with provenance that post-dates the child's transition, so a composite can clear its records and push one entry per contributor while still suspended. The contributor set is recomputed from the rule the composite used to choose it in the first place, rather than matching entries back to children by address.
3. Outcome: no user-visible change, and no caller yet. It exists so Intersection and the two union variants can implement `resume` soundly in their own branches.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `RawAggregateResult<'query, Suspended>::push_borrowed_from_live` — the primitive. It writes entries and rebuilds the kind mask; `freq` and `field_mask` are the caller's to re-accumulate.
2. Why `metrics` are not: the read path *moves* each child's metrics into the aggregate, so the children hold none by the time a resume runs. A rebuild has nothing to re-accumulate and must carry them across untouched — which is also why `reset_aggregate` is the wrong clearing tool, since it takes `doc_id`, `freq`, `field_mask` and `metrics` with it. This is the main design decision to review.
3. Why rebuilding beats refreshing entries in place: an entry records only an address, so recognising which child it came from stops working the moment a composite compacts over a dropped child's slot, and cannot distinguish a survivor that moved onto that address from the one always there. Recomputing sidesteps the question entirely.
4. `.skills/rqe-iterator-suspend-resume/SKILL.md` — when a composite must rebuild, what to recompute, what to carry across, and why the rebuild has to be the last thing that touches a child.
5. `index_result/tests/integration/aggregate.rs` — run these under Miri; the property is a Stacked Borrows one, and outside Miri a re-narrowed entry with a dead borrow reads back perfectly well.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
