### PR TITLE
[MOD-17681] UnionTrimmed: refuse suspend/resume

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
@@ -46,10 +46,13 @@
 //! accessible even though they are inactive.
 
 use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
-use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+};
 use index_spec::IndexSpecReadGuard;
 
 /// Union iterator that drains children sequentially in reverse order.
@@ -72,6 +75,9 @@ use index_spec::IndexSpecReadGuard;
 /// - [`revalidate`](RQEIterator::revalidate): trimmed unions run in a
 ///   single, short-lived read path that does not interleave with GC cycles,
 ///   so revalidation should never be needed.
+/// - [`suspend`](RQEIteratorBoxed::suspend) and
+///   [`resume`](RQESuspendedIterator::resume): the suspend/resume successors of
+///   [`revalidate`](RQEIterator::revalidate), unreachable for the same reason.
 ///
 /// # Type Parameters
 ///
@@ -332,5 +338,70 @@ where
         } else {
             1.0
         }
+    }
+}
+
+impl<'index, I> RQEIteratorBoxed<'index> for UnionTrimmed<'index, I>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawUnionTrimmed<'index, Suspended, I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        // Unreachable for the reason `RQEIterator::revalidate` documents: the
+        // partial-range pipeline never releases the spec read lock underneath a
+        // trimmed union. A trimmed union is also always the *root* iterator —
+        // `QOptimizer_Iterators` only trims when the AST root is a numeric node
+        // whose iterator is the union itself — so no composite parent has to
+        // transition it as a child slot either.
+        //
+        // On top of being unnecessary, implementing the transition would be
+        // pointless: the only thing to do with a suspended trimmed union is
+        // resume it, and `resume` cannot exist (see its own panic). Refusing
+        // here reports the misuse at the call that requested it, one lock cycle
+        // before `resume` would.
+        unreachable!(
+            "suspend is not supported on UnionTrimmed — trimmed unions are not subject to GC"
+        );
+    }
+}
+
+/// Suspended counterpart of the [`RQEIteratorBoxed`] impl above. It exists only
+/// to name a type satisfying that trait's
+/// [`Suspended`](RQEIteratorBoxed::Suspended) bound — no value of it can be
+/// built, since [`suspend`](RQEIteratorBoxed::suspend) panics instead of
+/// producing one.
+impl<'query, S> RQESuspendedIterator<'query> for RawUnionTrimmed<'query, Suspended, S>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = UnionTrimmed<'a, S::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        _guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // This is a design constraint, not a gap to be filled later: a trimmed
+        // union yields documents out of doc-id order and its `skip_to` panics,
+        // so there is no position to re-derive once the children have moved.
+        // That is also why `suspend` — the only way to obtain a `self` to call
+        // this on — refuses to run.
+        unreachable!(
+            "resume is not supported on UnionTrimmed — a trimmed union has no position to re-derive"
+        );
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.num_estimated
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
@@ -9,8 +9,10 @@
 
 //! Integration tests for [`UnionTrimmed`].
 
-use crate::utils::{MockVec, create_mock_3, drain_doc_ids};
-use rqe_iterators::{IteratorType, RQEIterator, UnionTrimmed};
+use crate::utils::{Mock, MockVec, create_mock_3, drain_doc_ids};
+use rqe_iterators::{
+    IteratorType, RQEIterator, RQEIteratorBoxed, TypeErasedRQEIterator, UnionTrimmed,
+};
 use rqe_iterators_test_utils::ContractChecker;
 
 /// Helper: create a vec of boxed MockVec children from doc_id slices.
@@ -483,4 +485,29 @@ fn into_trimmed_reuses_all_children() {
         [13, 14, 15, 10, 11, 12, 7, 8, 9, 4, 5, 6, 1, 2, 3],
         "previously trimmed children are now active"
     );
+}
+
+// =============================================================================
+// suspend()
+// =============================================================================
+
+/// `suspend` panics, so it is the whole of the suspend/resume surface that can
+/// be exercised: `resume`'s companion panic is unreachable from any value this
+/// crate can build, since `suspend` is the only thing that could have produced
+/// the suspended form to call it on.
+///
+/// Children are type-erased because that is the shape production hands the
+/// union — the refusal must not depend on the child type.
+#[test]
+#[should_panic(expected = "suspend is not supported on UnionTrimmed")]
+fn suspend_panics() {
+    let children = (1..=3)
+        .map(|doc_id| {
+            let child: Mock<'_, 1> = Mock::new([doc_id]);
+            TypeErasedRQEIterator::new(Box::new(child))
+        })
+        .collect();
+    let union = UnionTrimmed::new(children, usize::MAX, true);
+
+    let _ = Box::new(union).suspend();
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `UnionTrimmed` is the one iterator whose `revalidate` panics — trimmed unions are only built for the partial-range (numeric `SORTBY`) optimization, whose pipeline drains all upstream results inside a single locked `sendChunk` call, so the spec read lock is never released underneath one. It has no place in the suspend/resume hierarchy yet.
2. Change: it joins the hierarchy, but **both** transitions refuse to run. `resume` cannot be implemented at all: a trimmed union yields documents out of doc-id order and its `skip_to` panics, so there is no position to re-derive after the children move. With no resume, suspending would only manufacture a state nothing can consume — so `suspend` panics too, at the call that requested the unsupported transition rather than one lock cycle later. A trimmed union is also always the *root* iterator (`QOptimizer_Iterators` only trims when the AST root is a numeric node whose iterator is the union itself), so no composite parent has to transition it as a child slot either.
3. Outcome: no user-visible change. `UnionTrimmed` now satisfies the `RQEIteratorBoxed` bound that suspendable parents are generic over, without pretending to support a cycle it cannot complete.

#### Which additional issues this PR fixes

1. MOD-16713

#### Main objects this PR modified

1. `UnionTrimmed::suspend` — panics, mirroring the existing `revalidate`. The comment carries the two independent reasons (never suspended in practice; nothing could be done with the result) and defers the pipeline argument to `revalidate`, which owns it.
2. `RawUnionTrimmed<Suspended, _>`'s `RQESuspendedIterator` impl — kept only to name a type satisfying `RQEIteratorBoxed::Suspended`'s bound; no value of it can be built, so `resume` panics and the two accessors stay plain field reads.
3. No `const` layout-invariant proof and no `unsafe`: with neither transition reinterpreting an allocation, there is no cast whose soundness a proof would guard.
4. `tests/integration/union_trimmed.rs` — one `suspend_panics` test over type-erased children (the shape production hands the union) replaces the suspend round-trip, child-window, box-address, and suspended-accessor tests. `resume`'s panic is not reachable from any value the crate can build, so it is untestable by construction.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
