### PR TITLE
[MOD-17682] NumericIteratorVariant: suspend/resume

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/numeric.rs
@@ -26,7 +26,9 @@ use inverted_index::{
     FilterGeoReader, FilterNumericReader, IndexReader, NumericFilter, NumericReader,
     ResumableReader, SuspendableReader,
 };
-use numeric_range_tree::{NumericIndexReader, NumericRangeTree, RangeWindow};
+use numeric_range_tree::{
+    NumericIndexReader, NumericRangeTree, RangeWindow, RawNumericIndexReader,
+};
 use query_types::QueryNodeType;
 use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
@@ -387,20 +389,112 @@ pub unsafe fn open_numeric_or_geo_index<'a>(
     }
 }
 
-/// Selects the correct numeric reader variant based on the filter.
+/// Payload of [`RawNumericIteratorVariant::Unfiltered`]: a numeric leaf reading
+/// the range's entries directly. `Rf` flows into the reader (which weakens on
+/// suspend) but never into the frozen `RA` slot, which stays the **active**
+/// reader — see [`RawInvIndIterator`]'s `RA` parameter.
+type UnfilteredArm<'query, Rf> = RawNumeric<
+    'query,
+    Rf,
+    RawNumericIndexReader<Rf>,
+    FieldExpirationChecker,
+    NumericIndexReader<'query>,
+>;
+
+/// Payload of [`RawNumericIteratorVariant::Filtered`] — [`UnfilteredArm`]'s
+/// reader wrapped in a [`FilterNumericReader`].
+type FilteredArm<'query, Rf> = RawNumeric<
+    'query,
+    Rf,
+    FilterNumericReader<RawNumericIndexReader<Rf>>,
+    FieldExpirationChecker,
+    FilterNumericReader<NumericIndexReader<'query>>,
+>;
+
+/// Payload of [`RawNumericIteratorVariant::Geo`] — [`UnfilteredArm`]'s reader
+/// wrapped in a [`FilterGeoReader`].
+type GeoArm<'query, Rf> = RawNumeric<
+    'query,
+    Rf,
+    FilterGeoReader<RawNumericIndexReader<Rf>>,
+    FieldExpirationChecker,
+    FilterGeoReader<NumericIndexReader<'query>>,
+>;
+
+/// Selects the correct numeric reader variant based on the filter,
+/// parameterised over a [`Ref`] mode. See [`NumericIteratorVariant`] for the
+/// [`Active`] instantiation that implements [`RQEIterator`], and
+/// [`NumericIteratorVariantSuspended`] for its passive carrier across a lock
+/// release/reacquire cycle.
 ///
 /// - No filter → [`NumericIteratorVariant::Unfiltered`]
 /// - Numeric filter (no geo sub-filter) → [`NumericIteratorVariant::Filtered`]
 /// - Geo filter → [`NumericIteratorVariant::Geo`]
-pub enum NumericIteratorVariant<'index> {
+///
+/// # Invariants
+///
+/// 1. **Layout compatibility across modes.** `NumericIteratorVariant<'query>`
+///    and `NumericIteratorVariantSuspended<'query>` are layout-identical, so
+///    [`suspend`](RQEIteratorBoxed::suspend) /
+///    [`resume`](RQESuspendedIterator::resume) can transition each payload in
+///    place and then reinterpret the owning `Box` between the two. Being a single
+///    `#[repr(C, u8)]` generic, the two share a tag encoding and variant order by
+///    construction; the per-arm payload correspondence and layout identity are
+///    enforced by the `const _` proof below.
+#[repr(C, u8)]
+pub enum RawNumericIteratorVariant<'query, Rf: Ref> {
     /// No filter: iterates all entries in the range.
-    Unfiltered(Numeric<'index, NumericIndexReader<'index>, FieldExpirationChecker>),
+    Unfiltered(UnfilteredArm<'query, Rf>),
     /// Numeric filter: skips entries outside the filter's value range.
-    Filtered(
-        Numeric<'index, FilterNumericReader<NumericIndexReader<'index>>, FieldExpirationChecker>,
-    ),
+    Filtered(FilteredArm<'query, Rf>),
     /// Geo filter: skips entries that do not pass the geo predicate.
-    Geo(Numeric<'index, FilterGeoReader<NumericIndexReader<'index>>, FieldExpirationChecker>),
+    Geo(GeoArm<'query, Rf>),
+}
+
+/// Alias for an [`Active`] [`RawNumericIteratorVariant`] — the only
+/// instantiation with an [`RQEIterator`] impl.
+pub type NumericIteratorVariant<'index> = RawNumericIteratorVariant<'index, Active<'index>>;
+
+/// [`Suspended`]-mode counterpart of [`NumericIteratorVariant`], used as its
+/// [`RQEIteratorBoxed::Suspended`] type. Retains the `'query` lifetime so
+/// query-attached borrows stay valid across the suspend/resume cycle.
+pub type NumericIteratorVariantSuspended<'query> = RawNumericIteratorVariant<'query, Suspended>;
+
+impl<'query, Rf: Ref> RawNumericIteratorVariant<'query, Rf> {
+    /// Returns the cached flags of the underlying index reader.
+    ///
+    /// Available in every mode: the value is a construction-time snapshot
+    /// ([`RawInvIndIterator::flags`]), so a suspended variant answers the same
+    /// as the active one it came from.
+    pub const fn flags(&self) -> IndexFlags {
+        match self {
+            Self::Unfiltered(iter) => iter.flags(),
+            Self::Filtered(iter) => iter.flags(),
+            Self::Geo(iter) => iter.flags(),
+        }
+    }
+
+    /// Returns the minimum value of the numeric range (used for profiling).
+    ///
+    /// Mode-independent, for the same reason as [`Self::flags`].
+    pub const fn range_min(&self) -> f64 {
+        match self {
+            Self::Unfiltered(iter) => iter.range_min(),
+            Self::Filtered(iter) => iter.range_min(),
+            Self::Geo(iter) => iter.range_min(),
+        }
+    }
+
+    /// Returns the maximum value of the numeric range (used for profiling).
+    ///
+    /// Mode-independent, for the same reason as [`Self::flags`].
+    pub const fn range_max(&self) -> f64 {
+        match self {
+            Self::Unfiltered(iter) => iter.range_max(),
+            Self::Filtered(iter) => iter.range_max(),
+            Self::Geo(iter) => iter.range_max(),
+        }
+    }
 }
 
 impl<'index> NumericIteratorVariant<'index> {
@@ -535,33 +629,6 @@ impl<'index> NumericIteratorVariant<'index> {
                 };
                 Self::Geo(iter)
             }
-        }
-    }
-
-    /// Returns the cached flags of the underlying index reader.
-    pub const fn flags(&self) -> IndexFlags {
-        match self {
-            Self::Unfiltered(iter) => iter.flags(),
-            Self::Filtered(iter) => iter.flags(),
-            Self::Geo(iter) => iter.flags(),
-        }
-    }
-
-    /// Returns the minimum value of the numeric range (used for profiling).
-    pub const fn range_min(&self) -> f64 {
-        match self {
-            Self::Unfiltered(iter) => iter.range_min(),
-            Self::Filtered(iter) => iter.range_min(),
-            Self::Geo(iter) => iter.range_min(),
-        }
-    }
-
-    /// Returns the maximum value of the numeric range (used for profiling).
-    pub const fn range_max(&self) -> f64 {
-        match self {
-            Self::Unfiltered(iter) => iter.range_max(),
-            Self::Filtered(iter) => iter.range_max(),
-            Self::Geo(iter) => iter.range_max(),
         }
     }
 }
@@ -751,4 +818,235 @@ pub unsafe fn build_numeric_filter_iterator(
     let iter =
         crate::union_opaque::build_union(children, true, min_union_iter_heap, node_type, 1.0);
     Some(iter)
+}
+
+// Compile-time proof of invariant 1 on `RawNumericIteratorVariant`: a
+// `Box<NumericIteratorVariant>` can be reinterpreted as a
+// `Box<NumericIteratorVariantSuspended>` and back, as `suspend`/`resume` below
+// do. Because both are instantiations of the *same* `#[repr(C, u8)]` enum, the
+// variant order and tag encoding agree by construction and need no assertion.
+// What remains to be proven:
+//
+// (a) **Arm correspondence.** `suspend` fills each payload slot with
+//     `<active arm as RQEIteratorBoxed>::Suspended` — see
+//     [`crate::boxed::suspend_child_slot_in_place`] — and only then relabels the
+//     owning box. That is sound only if the suspended enum's matching arm *is*
+//     that projection. Asserted below as a type equality rather than a layout
+//     comparison: it is the property the reinterpretation actually needs, and a
+//     mismatch (e.g. a reader whose `SuspendableReader::Suspended` does not
+//     simply weaken `Rf`) becomes a build error instead of a silently
+//     mistyped payload.
+//
+// (b) **Per-arm payload layout identity.** Implied by (a) together with
+//     invariant 1 on `RawInvIndIterator` (proven in `core.rs` for a
+//     representative reader) and the reader-side layout invariants that back the
+//     `SuspendableReader`/`ResumableReader` impls of `RawNumericIndexReader`
+//     (const proof in `numeric_range_tree::index`), `FilterNumericReader` and
+//     `FilterGeoReader` (const proofs in `inverted_index`). Asserted per arm
+//     anyway so a regression names the arm that broke, and because under
+//     `#[repr(C, u8)]` each payload sits at an offset derived from *that
+//     payload's* alignment — per-arm alignment equality, not the enum's, is what
+//     pins the payload offsets. (`offset_of!` into enum variants is not yet
+//     stable, so the offsets cannot be asserted directly.)
+//
+// (c) **Enum size/alignment equality.** Needed on its own by `resume`'s
+//     abort/error paths, which free an allocation created for the active enum
+//     using `Layout::new::<NumericIteratorVariantSuspended>()`.
+const _: () = {
+    use std::mem::{align_of, size_of};
+
+    /// Witnesses that `Self` and `T` are the same type: the blanket impl is the
+    /// only one, so a `A: IsSame<B>` bound holds exactly when `A` *is* `B`.
+    trait IsSame<T> {}
+    impl<T> IsSame<T> for T {}
+
+    /// (a) — fails to compile unless suspending `A` yields exactly `S`.
+    const fn assert_suspends_to<A, S>()
+    where
+        A: RQEIteratorBoxed<'static>,
+        A::Suspended: IsSame<S>,
+    {
+    }
+
+    assert_suspends_to::<UnfilteredArm<'static, Active<'static>>, UnfilteredArm<'static, Suspended>>(
+    );
+    assert_suspends_to::<FilteredArm<'static, Active<'static>>, FilteredArm<'static, Suspended>>();
+    assert_suspends_to::<GeoArm<'static, Active<'static>>, GeoArm<'static, Suspended>>();
+
+    // (b)
+    assert!(
+        size_of::<UnfilteredArm<'static, Active<'static>>>()
+            == size_of::<UnfilteredArm<'static, Suspended>>()
+    );
+    assert!(
+        align_of::<UnfilteredArm<'static, Active<'static>>>()
+            == align_of::<UnfilteredArm<'static, Suspended>>()
+    );
+    assert!(
+        size_of::<FilteredArm<'static, Active<'static>>>()
+            == size_of::<FilteredArm<'static, Suspended>>()
+    );
+    assert!(
+        align_of::<FilteredArm<'static, Active<'static>>>()
+            == align_of::<FilteredArm<'static, Suspended>>()
+    );
+    assert!(
+        size_of::<GeoArm<'static, Active<'static>>>() == size_of::<GeoArm<'static, Suspended>>()
+    );
+    assert!(
+        align_of::<GeoArm<'static, Active<'static>>>() == align_of::<GeoArm<'static, Suspended>>()
+    );
+
+    // (c)
+    assert!(
+        size_of::<NumericIteratorVariant<'static>>()
+            == size_of::<NumericIteratorVariantSuspended<'static>>()
+    );
+    assert!(
+        align_of::<NumericIteratorVariant<'static>>()
+            == align_of::<NumericIteratorVariantSuspended<'static>>()
+    );
+};
+
+impl<'index> RQEIteratorBoxed<'index> for NumericIteratorVariant<'index> {
+    type Suspended = NumericIteratorVariantSuspended<'index>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Transition the payload in place, arm by arm. Both enums are the same
+        // `#[repr(C, u8)]` generic at different `Rf`, so they share a tag
+        // encoding and variant order; the helper writes exactly the arm's
+        // `Suspended` projection, which invariant 1's proof (a) pins to the
+        // matching suspended arm. Together those make the final whole-box cast
+        // sound. The tag byte itself is untouched.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+        // initialised, exclusively owned); the `&mut` borrow is confined to the
+        // match.
+        match unsafe { &mut *raw } {
+            NumericIteratorVariant::Unfiltered(it) => {
+                // SAFETY: `it` is the valid, exclusively-owned payload; the
+                // helper reinitialises the slot as its `Suspended` form in place.
+                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+            }
+            NumericIteratorVariant::Filtered(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+            }
+            NumericIteratorVariant::Geo(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+            }
+        }
+        // SAFETY: the payload now holds its `Suspended` form at the same offset,
+        // and the tag encodes the same variant in both enums. `Box::from_raw`
+        // reuses the same allocation, so the box address is preserved.
+        unsafe { Box::from_raw(raw.cast::<NumericIteratorVariantSuspended<'index>>()) }
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for NumericIteratorVariantSuspended<'query> {
+    type Resumed<'a>
+        = NumericIteratorVariant<'a>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let raw = Box::into_raw(self);
+        // Resume the payload in place, arm by arm — the tag byte is untouched,
+        // so the whole-box cast below lands on the same variant of the active
+        // enum (same `#[repr(C, u8)]` generic at a different `Rf`; arm
+        // correspondence and per-arm layout identity are invariant 1's const
+        // proof above).
+        //
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+        // initialised, exclusively owned); the `&mut` borrow is confined to the
+        // match. On `Unchanged`/`Moved` the helper rewrites the payload as its
+        // resumed form; on `Aborted`/`Err` it consumes the payload, leaving it
+        // uninitialised (handled below).
+        let outcome = match unsafe { &mut *raw } {
+            NumericIteratorVariantSuspended::Unfiltered(it) => {
+                // SAFETY: `it` is the valid, exclusively-owned payload.
+                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, guard) }
+            }
+            NumericIteratorVariantSuspended::Filtered(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, guard) }
+            }
+            NumericIteratorVariantSuspended::Geo(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, guard) }
+            }
+        };
+
+        match outcome {
+            Ok(crate::boxed::ResumeSlotOutcome::Unchanged) => {
+                // SAFETY: the payload holds its resumed form at the same offset
+                // and the tag is unchanged; `Box::from_raw` reuses the same
+                // allocation, so the box address — and the FFI's cached
+                // `header.current` into the payload's result — stay valid.
+                let active = unsafe { Box::from_raw(raw.cast::<NumericIteratorVariant<'a>>()) };
+                Ok(ResumeOutcome::Ok(active))
+            }
+            Ok(crate::boxed::ResumeSlotOutcome::Moved) => {
+                // SAFETY: as above.
+                let active = unsafe { Box::from_raw(raw.cast::<NumericIteratorVariant<'a>>()) };
+                Ok(ResumeOutcome::Moved(active))
+            }
+            Ok(crate::boxed::ResumeSlotOutcome::Aborted) => {
+                // The payload was consumed; the allocation holds only the tag
+                // and an uninitialised payload, so it must be freed without
+                // dropping anything.
+                // SAFETY: `raw` was allocated by `Box` with exactly this layout;
+                // nothing in it is live any more.
+                unsafe {
+                    std::alloc::dealloc(
+                        raw.cast::<u8>(),
+                        std::alloc::Layout::new::<NumericIteratorVariantSuspended<'query>>(),
+                    )
+                };
+                Ok(ResumeOutcome::Aborted)
+            }
+            Err(e) => {
+                // As `Aborted`: the payload was consumed; free the allocation
+                // without dropping it.
+                // SAFETY: as above.
+                unsafe {
+                    std::alloc::dealloc(
+                        raw.cast::<u8>(),
+                        std::alloc::Layout::new::<NumericIteratorVariantSuspended<'query>>(),
+                    )
+                };
+                Err(e)
+            }
+        }
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        match self {
+            NumericIteratorVariantSuspended::Unfiltered(it) => {
+                RQESuspendedIterator::last_doc_id(it)
+            }
+            NumericIteratorVariantSuspended::Filtered(it) => RQESuspendedIterator::last_doc_id(it),
+            NumericIteratorVariantSuspended::Geo(it) => RQESuspendedIterator::last_doc_id(it),
+        }
+    }
+
+    fn num_estimated(&self) -> usize {
+        match self {
+            NumericIteratorVariantSuspended::Unfiltered(it) => {
+                RQESuspendedIterator::num_estimated(it)
+            }
+            NumericIteratorVariantSuspended::Filtered(it) => {
+                RQESuspendedIterator::num_estimated(it)
+            }
+            NumericIteratorVariantSuspended::Geo(it) => RQESuspendedIterator::num_estimated(it),
+        }
+    }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -755,7 +755,7 @@ mod variant {
     use rqe_iterators::{FieldExpirationChecker, NumericIteratorVariant};
     use rqe_iterators_test_utils::MockContext;
 
-    fn make_expiration_checker(ctx: &MockContext) -> FieldExpirationChecker {
+    pub(super) fn make_expiration_checker(ctx: &MockContext) -> FieldExpirationChecker {
         // SAFETY:
         // - `ctx.sctx()` is a valid `RedisSearchCtx` pointer for the duration of this test.
         // - `ctx.sctx().spec` is set to a valid `IndexSpec` pointer by `MockContext::new`.
@@ -855,6 +855,874 @@ mod variant {
         assert_eq!(variant.range_min(), 1.0);
         assert_eq!(variant.range_max(), 5.0);
         assert_eq!(variant.flags(), IndexFlags_Index_StoreNumeric);
+    }
+}
+
+/// Suspend/resume coverage for `NumericIteratorVariant` — the `RQEIteratorBoxed`
+/// and `RQESuspendedIterator` impls on the variant enum itself, as opposed to the
+/// `Numeric` leaf instantiation that `NumericBuilder` produces.
+///
+/// Every scenario is spelled out once per arm instead of going through a shared
+/// helper: each arm is a distinct payload pair with its own `suspend`/`resume`
+/// instantiation, its own whole-box cast and its own teardown, so a passing
+/// `Unfiltered` test says nothing about `Filtered` or `Geo`. The tests drive the
+/// concrete `suspend`/`resume` pair rather than the type-erased
+/// `revalidate_via_resume` helper, because only the concrete form lets us assert
+/// *which* arm came back — the check that catches a tag/arm confusion.
+///
+/// Two things are deliberately not covered here:
+///
+/// * The `Err` arm of `resume`. It shares its body with `Aborted` (consume the
+///   payload, free the allocation without dropping it), and no numeric reader in
+///   the workspace can fail its pointer refresh, so reaching it would take a
+///   fault-injecting reader built for the purpose.
+/// * Miri execution of the `Aborted` and `Moved` paths. Both need the index
+///   fixture mutated behind the iterator's back — a range-tree revision bump or a
+///   GC pass — while the iterator holds a pointer derived from a `&` to it. That
+///   is the aliasing pattern already documented on
+///   `from_tree::non_null_field_spec_enables_revalidation`: intentional, but
+///   Stacked Borrows cannot model it.
+mod variant_resume {
+    use std::ptr;
+
+    use ffi::{GeoFilter, IndexFlags_Index_StoreNumeric};
+    use index_result::RSIndexResult;
+    use inverted_index::{DecodedBy, Encoder, InvertedIndex, NumericFilter, RepairContext};
+    use numeric_range_tree::{NumericIndex, NumericRangeTree};
+    use rqe_core::DocId;
+    use rqe_iterators::{
+        NumericIteratorVariant, RQEIterator, RQEIteratorBoxed, RQESuspendedIterator, ResumeOutcome,
+    };
+    use rqe_iterators_test_utils::MockContext;
+
+    use super::variant::make_expiration_checker;
+
+    /// Build a numeric index holding one record per `(doc_id, value)` pair.
+    fn make_index(entries: &[(DocId, f64)]) -> NumericIndex {
+        let mut idx = NumericIndex::new(false);
+        for (doc_id, value) in entries {
+            idx.add_record(&RSIndexResult::build_numeric(*value).doc_id(*doc_id).build());
+        }
+        idx
+    }
+
+    /// A numeric (non-geo) filter accepting every value the fixtures use.
+    fn passthrough_numeric_filter() -> NumericFilter {
+        NumericFilter {
+            min: 0.0,
+            max: 100.0,
+            min_inclusive: true,
+            max_inclusive: true,
+            ..Default::default()
+        }
+    }
+
+    /// A numeric filter accepting `0.0..=10.0`, so a fixture value outside that
+    /// window is rejected by the *reader* rather than by range selection. That is
+    /// what lets a re-seek land on a document the filter throws away.
+    fn narrow_numeric_filter() -> NumericFilter {
+        NumericFilter {
+            min: 0.0,
+            max: 10.0,
+            min_inclusive: true,
+            max_inclusive: true,
+            ..Default::default()
+        }
+    }
+
+    /// Encode a WGS-84 point the way the geo indexer does, so `isWithinRadius`
+    /// decodes the stored value back to `(lon, lat)`.
+    fn geo_score(lon: f64, lat: f64) -> f64 {
+        let coords =
+            geo::hash::WGS84Coordinates::from_f64(lon, lat).expect("coordinates must be in bounds");
+        geo::hash::encode_wgs84(coords, geo::hash::GEO_STEP_MAX).bits as f64
+    }
+
+    /// A [`GeoFilter`] centred on the null island, with a radius that accepts the
+    /// points a fraction of a degree away that the fixtures below use — and
+    /// rejects the deliberate outlier in
+    /// [`geo_moved_after_current_document_deleted`]. Unlike
+    /// [`super::geo_filter_stub`] this one is meant to be *matched against*, not
+    /// just to select the `Geo` arm.
+    fn wide_geo_filter() -> GeoFilter {
+        GeoFilter {
+            fieldSpec: ptr::null(),
+            lat: 0.0,
+            lon: 0.0,
+            radius: 1_000_000.0,
+            unitType: ffi::GeoDistance_GEO_DISTANCE_M,
+            numericFilters: ptr::null_mut(),
+        }
+    }
+
+    /// Remove `doc_id` from `idx` through a GC scan+apply cycle, the same way
+    /// [`super::super::utils::RevalidateTest`] does. This bumps the index's GC
+    /// marker, which is what makes a suspended reader report `NeedsReseek`.
+    fn remove_document(idx: &mut NumericIndex, doc_id: DocId) {
+        fn remove<E: Encoder + DecodedBy>(ii: &mut InvertedIndex<E>, doc_id: DocId) {
+            let delta = ii
+                .scan_gc(
+                    |d| d != doc_id,
+                    None::<fn(&RSIndexResult, &RepairContext<'_>)>,
+                )
+                .expect("scan GC failed")
+                .expect("no GC scan delta");
+            assert_eq!(ii.apply_gc(delta).entries_removed, 1);
+        }
+
+        match idx {
+            NumericIndex::Uncompressed(ii) => remove(ii.inner_mut(), doc_id),
+            NumericIndex::Compressed(ii) => remove(ii.inner_mut(), doc_id),
+        }
+    }
+
+    // ---- A/B/F/G: round trip, box-address stability, suspended accessors ----
+
+    #[test]
+    /// `Unfiltered` survives a suspend/resume cycle: same arm, same allocation,
+    /// same position, and the suspended form reports the same metadata.
+    fn unfiltered_round_trip() {
+        let ctx = MockContext::new(0, 0);
+        let idx = make_index(&[(1, 1.0), (3, 3.0), (5, 5.0)]);
+
+        let mut variant = NumericIteratorVariant::new(
+            idx.reader(),
+            None,
+            make_expiration_checker(&ctx),
+            None,
+            1.0,
+            5.0,
+        );
+        assert_eq!(
+            variant
+                .read()
+                .expect("read failed")
+                .expect("expected a doc")
+                .doc_id,
+            1
+        );
+
+        let range_min = variant.range_min();
+        let range_max = variant.range_max();
+        let flags = variant.flags();
+        let last_doc_id = variant.last_doc_id();
+        let num_estimated = variant.num_estimated();
+
+        let active = Box::new(variant);
+        let address = ptr::from_ref(&*active).addr();
+
+        let suspended = active.suspend();
+        assert_eq!(
+            ptr::from_ref(&*suspended).addr(),
+            address,
+            "suspend must reuse the allocation"
+        );
+        // The suspended form has no reader, so these must come from the
+        // construction-time snapshots — never called anywhere else today.
+        assert_eq!(RQESuspendedIterator::last_doc_id(&*suspended), last_doc_id);
+        assert_eq!(
+            RQESuspendedIterator::num_estimated(&*suspended),
+            num_estimated
+        );
+        assert_eq!(suspended.range_min(), range_min);
+        assert_eq!(suspended.range_max(), range_max);
+        assert_eq!(suspended.flags(), flags);
+
+        let guard = ctx.spec_read();
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(it) => it,
+            ResumeOutcome::Moved(_) => panic!("an untouched index cannot move the iterator"),
+            ResumeOutcome::Aborted => panic!("an untouched index cannot abort the iterator"),
+        };
+        assert_eq!(
+            ptr::from_ref(&*active).addr(),
+            address,
+            "resume must reuse the allocation"
+        );
+        assert!(
+            matches!(&*active, NumericIteratorVariant::Unfiltered(_)),
+            "the resumed value must be the same arm it was suspended from"
+        );
+        assert_eq!(active.range_min(), range_min);
+        assert_eq!(active.range_max(), range_max);
+        assert_eq!(active.flags(), flags);
+        // Reading continues where the uninterrupted iterator would have.
+        assert_eq!(
+            active
+                .read()
+                .expect("read failed")
+                .expect("expected a doc")
+                .doc_id,
+            3
+        );
+    }
+
+    #[test]
+    /// `Filtered` survives a suspend/resume cycle — see [`unfiltered_round_trip`].
+    fn filtered_round_trip() {
+        let ctx = MockContext::new(0, 0);
+        let filter = passthrough_numeric_filter();
+        let idx = make_index(&[(1, 1.0), (3, 3.0), (5, 5.0)]);
+
+        let mut variant = NumericIteratorVariant::new(
+            idx.reader(),
+            Some(&filter),
+            make_expiration_checker(&ctx),
+            None,
+            1.0,
+            5.0,
+        );
+        assert!(
+            matches!(&variant, NumericIteratorVariant::Filtered(_)),
+            "a numeric filter must select the Filtered arm"
+        );
+        assert_eq!(
+            variant
+                .read()
+                .expect("read failed")
+                .expect("expected a doc")
+                .doc_id,
+            1
+        );
+
+        let flags = variant.flags();
+        let last_doc_id = variant.last_doc_id();
+        let num_estimated = variant.num_estimated();
+
+        let active = Box::new(variant);
+        let address = ptr::from_ref(&*active).addr();
+
+        let suspended = active.suspend();
+        assert_eq!(ptr::from_ref(&*suspended).addr(), address);
+        assert_eq!(RQESuspendedIterator::last_doc_id(&*suspended), last_doc_id);
+        assert_eq!(
+            RQESuspendedIterator::num_estimated(&*suspended),
+            num_estimated
+        );
+        assert_eq!(suspended.range_min(), 1.0);
+        assert_eq!(suspended.range_max(), 5.0);
+        assert_eq!(suspended.flags(), flags);
+
+        let guard = ctx.spec_read();
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(it) => it,
+            ResumeOutcome::Moved(_) => panic!("an untouched index cannot move the iterator"),
+            ResumeOutcome::Aborted => panic!("an untouched index cannot abort the iterator"),
+        };
+        assert_eq!(ptr::from_ref(&*active).addr(), address);
+        assert!(
+            matches!(&*active, NumericIteratorVariant::Filtered(_)),
+            "the resumed value must be the same arm it was suspended from"
+        );
+        assert_eq!(
+            active
+                .read()
+                .expect("read failed")
+                .expect("expected a doc")
+                .doc_id,
+            3
+        );
+    }
+
+    #[test]
+    /// `Geo` survives a suspend/resume cycle.
+    ///
+    /// This one deliberately round-trips *before* the first read, so it can run
+    /// under Miri: `FilterGeoReader`'s radius check calls the C `isWithinRadius`,
+    /// which Miri cannot execute. The post-read continuation is covered by
+    /// [`geo_round_trip_after_read`].
+    fn geo_round_trip() {
+        let ctx = MockContext::new(0, 0);
+        let geo_filter = super::geo_filter_stub();
+        let filter = NumericFilter {
+            geo_filter: ptr::from_ref(&geo_filter).cast(),
+            ..Default::default()
+        };
+        let idx = make_index(&[(1, 1.0), (3, 3.0)]);
+
+        let variant = NumericIteratorVariant::new(
+            idx.reader(),
+            Some(&filter),
+            make_expiration_checker(&ctx),
+            None,
+            1.0,
+            5.0,
+        );
+        assert!(
+            matches!(&variant, NumericIteratorVariant::Geo(_)),
+            "a geo filter must select the Geo arm"
+        );
+
+        let flags = variant.flags();
+        let num_estimated = variant.num_estimated();
+
+        let active = Box::new(variant);
+        let address = ptr::from_ref(&*active).addr();
+
+        let suspended = active.suspend();
+        assert_eq!(ptr::from_ref(&*suspended).addr(), address);
+        // Nothing was read yet, so the position is still the initial one.
+        assert_eq!(RQESuspendedIterator::last_doc_id(&*suspended), 0);
+        assert_eq!(
+            RQESuspendedIterator::num_estimated(&*suspended),
+            num_estimated
+        );
+        assert_eq!(suspended.range_min(), 1.0);
+        assert_eq!(suspended.range_max(), 5.0);
+        assert_eq!(suspended.flags(), flags);
+
+        let guard = ctx.spec_read();
+        let active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(it) => it,
+            ResumeOutcome::Moved(_) => panic!("an untouched index cannot move the iterator"),
+            ResumeOutcome::Aborted => panic!("an untouched index cannot abort the iterator"),
+        };
+        assert_eq!(ptr::from_ref(&*active).addr(), address);
+        assert!(
+            matches!(&*active, NumericIteratorVariant::Geo(_)),
+            "the resumed value must be the same arm it was suspended from"
+        );
+        assert_eq!(active.flags(), flags);
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "FilterGeoReader's radius check calls the C `isWithinRadius`, which Miri cannot \
+                  execute"
+    )]
+    /// A positioned `Geo` iterator resumes onto the same arm and keeps reading
+    /// where an uninterrupted run would have.
+    fn geo_round_trip_after_read() {
+        let ctx = MockContext::new(0, 0);
+        let geo_filter = wide_geo_filter();
+        let filter = NumericFilter {
+            geo_filter: ptr::from_ref(&geo_filter).cast(),
+            ..Default::default()
+        };
+        let idx = make_index(&[
+            (1, geo_score(0.0, 0.0)),
+            (3, geo_score(0.1, 0.1)),
+            (5, geo_score(0.2, 0.2)),
+        ]);
+
+        let mut variant = NumericIteratorVariant::new(
+            idx.reader(),
+            Some(&filter),
+            make_expiration_checker(&ctx),
+            None,
+            1.0,
+            5.0,
+        );
+        assert_eq!(
+            variant
+                .read()
+                .expect("read failed")
+                .expect("expected a doc")
+                .doc_id,
+            1
+        );
+        let last_doc_id = variant.last_doc_id();
+
+        let suspended = Box::new(variant).suspend();
+        assert_eq!(RQESuspendedIterator::last_doc_id(&*suspended), last_doc_id);
+
+        let guard = ctx.spec_read();
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(it) => it,
+            ResumeOutcome::Moved(_) => panic!("an untouched index cannot move the iterator"),
+            ResumeOutcome::Aborted => panic!("an untouched index cannot abort the iterator"),
+        };
+        assert!(matches!(&*active, NumericIteratorVariant::Geo(_)));
+        assert_eq!(
+            active
+                .read()
+                .expect("read failed")
+                .expect("expected a doc")
+                .doc_id,
+            3
+        );
+    }
+
+    // ---- C: the `Aborted` teardown, once per arm ----
+    //
+    // The range tree is heap-allocated by hand in each of these because the
+    // iterator has to keep observing it while we bump its revision; see the
+    // module doc for why that keeps them off Miri.
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "bumping the tree revision behind the iterator's stored NonNull is UB under \
+                  Stacked Borrows; see the module doc"
+    )]
+    /// The `Unfiltered` arm aborts — and deallocates — cleanly when the range
+    /// tree it was built over is modified while suspended.
+    fn unfiltered_aborts_after_range_tree_modified() {
+        let ctx = MockContext::new(0, 0);
+        let tree_ptr: *mut NumericRangeTree = Box::into_raw(Box::new(NumericRangeTree::new(false)));
+        let idx = make_index(&[(1, 1.0), (3, 3.0)]);
+
+        let variant = NumericIteratorVariant::new(
+            idx.reader(),
+            None,
+            make_expiration_checker(&ctx),
+            // SAFETY: `tree_ptr` was just created by `Box::into_raw` and stays
+            // allocated until the end of this test.
+            Some(unsafe { &*tree_ptr }),
+            1.0,
+            5.0,
+        );
+        let guard = ctx.spec_read();
+
+        // A clean cycle first: the tree is untouched, so resume reports Ok.
+        let active = match Box::new(variant)
+            .suspend()
+            .resume(&guard)
+            .expect("resume failed")
+        {
+            ResumeOutcome::Ok(it) => it,
+            ResumeOutcome::Moved(_) => panic!("an untouched tree cannot move the iterator"),
+            ResumeOutcome::Aborted => panic!("an untouched tree cannot abort the iterator"),
+        };
+        assert!(matches!(&*active, NumericIteratorVariant::Unfiltered(_)));
+
+        let suspended = active.suspend();
+        // SAFETY: the iterator only ever holds a `NonNull` to the tree, so no
+        // live Rust reference to it exists here.
+        unsafe { (*tree_ptr).increment_revision() };
+
+        match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Aborted => {}
+            ResumeOutcome::Ok(_) | ResumeOutcome::Moved(_) => {
+                panic!("a bumped revision id must abort the resume")
+            }
+        }
+
+        // SAFETY: `tree_ptr` came from `Box::into_raw`; the aborted resume
+        // consumed the iterator, which never owned the tree.
+        unsafe { drop(Box::from_raw(tree_ptr)) };
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "bumping the tree revision behind the iterator's stored NonNull is UB under \
+                  Stacked Borrows; see the module doc"
+    )]
+    /// The `Filtered` arm aborts — and deallocates — cleanly. Its payload pair is
+    /// separate from `Unfiltered`'s, so it needs its own coverage.
+    fn filtered_aborts_after_range_tree_modified() {
+        let ctx = MockContext::new(0, 0);
+        let tree_ptr: *mut NumericRangeTree = Box::into_raw(Box::new(NumericRangeTree::new(false)));
+        let filter = passthrough_numeric_filter();
+        let idx = make_index(&[(1, 1.0), (3, 3.0)]);
+
+        let variant = NumericIteratorVariant::new(
+            idx.reader(),
+            Some(&filter),
+            make_expiration_checker(&ctx),
+            // SAFETY: as in `unfiltered_aborts_after_range_tree_modified`.
+            Some(unsafe { &*tree_ptr }),
+            1.0,
+            5.0,
+        );
+        let guard = ctx.spec_read();
+
+        let active = match Box::new(variant)
+            .suspend()
+            .resume(&guard)
+            .expect("resume failed")
+        {
+            ResumeOutcome::Ok(it) => it,
+            ResumeOutcome::Moved(_) => panic!("an untouched tree cannot move the iterator"),
+            ResumeOutcome::Aborted => panic!("an untouched tree cannot abort the iterator"),
+        };
+        assert!(matches!(&*active, NumericIteratorVariant::Filtered(_)));
+
+        let suspended = active.suspend();
+        // SAFETY: as in `unfiltered_aborts_after_range_tree_modified`.
+        unsafe { (*tree_ptr).increment_revision() };
+
+        match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Aborted => {}
+            ResumeOutcome::Ok(_) | ResumeOutcome::Moved(_) => {
+                panic!("a bumped revision id must abort the resume")
+            }
+        }
+
+        // SAFETY: as in `unfiltered_aborts_after_range_tree_modified`.
+        unsafe { drop(Box::from_raw(tree_ptr)) };
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "bumping the tree revision behind the iterator's stored NonNull is UB under \
+                  Stacked Borrows; see the module doc"
+    )]
+    /// The `Geo` arm aborts — and deallocates — cleanly. Its payload is the
+    /// largest of the three, since `FilterGeoReader` owns a boxed `GeoFilter` the
+    /// other two readers do not have, so it is the arm a mis-sized deallocation
+    /// or a leaked `Box` would show up on first.
+    fn geo_aborts_after_range_tree_modified() {
+        let ctx = MockContext::new(0, 0);
+        let tree_ptr: *mut NumericRangeTree = Box::into_raw(Box::new(NumericRangeTree::new(false)));
+        let geo_filter = super::geo_filter_stub();
+        let filter = NumericFilter {
+            geo_filter: ptr::from_ref(&geo_filter).cast(),
+            ..Default::default()
+        };
+        let idx = make_index(&[(1, 1.0), (3, 3.0)]);
+
+        let variant = NumericIteratorVariant::new(
+            idx.reader(),
+            Some(&filter),
+            make_expiration_checker(&ctx),
+            // SAFETY: as in `unfiltered_aborts_after_range_tree_modified`.
+            Some(unsafe { &*tree_ptr }),
+            1.0,
+            5.0,
+        );
+        let guard = ctx.spec_read();
+
+        let active = match Box::new(variant)
+            .suspend()
+            .resume(&guard)
+            .expect("resume failed")
+        {
+            ResumeOutcome::Ok(it) => it,
+            ResumeOutcome::Moved(_) => panic!("an untouched tree cannot move the iterator"),
+            ResumeOutcome::Aborted => panic!("an untouched tree cannot abort the iterator"),
+        };
+        assert!(matches!(&*active, NumericIteratorVariant::Geo(_)));
+
+        let suspended = active.suspend();
+        // SAFETY: as in `unfiltered_aborts_after_range_tree_modified`.
+        unsafe { (*tree_ptr).increment_revision() };
+
+        match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Aborted => {}
+            ResumeOutcome::Ok(_) | ResumeOutcome::Moved(_) => {
+                panic!("a bumped revision id must abort the resume")
+            }
+        }
+
+        // SAFETY: as in `unfiltered_aborts_after_range_tree_modified`.
+        unsafe { drop(Box::from_raw(tree_ptr)) };
+    }
+
+    // ---- D: the `Moved` path ----
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "running GC over the index behind the reader's shared borrow is UB under Stacked \
+                  Borrows; see the module doc"
+    )]
+    /// Deleting the document the iterator is parked on makes the resume land on
+    /// the next document and report `Moved`.
+    fn unfiltered_moved_after_current_document_deleted() {
+        let ctx = MockContext::new(0, 0);
+        // Owned by hand: the iterator must keep reading the index while GC
+        // rewrites it.
+        let idx_ptr: *mut NumericIndex = Box::into_raw(Box::new(make_index(&[
+            (1, 1.0),
+            (3, 3.0),
+            (5, 5.0),
+            (7, 7.0),
+        ])));
+
+        // SAFETY: `idx_ptr` was just created by `Box::into_raw` and outlives the
+        // iterator built from it.
+        let mut variant = NumericIteratorVariant::new(
+            unsafe { &*idx_ptr }.reader(),
+            None,
+            make_expiration_checker(&ctx),
+            None,
+            1.0,
+            7.0,
+        );
+        assert_eq!(
+            variant
+                .read()
+                .expect("read failed")
+                .expect("expected a doc")
+                .doc_id,
+            1
+        );
+        assert_eq!(
+            variant
+                .read()
+                .expect("read failed")
+                .expect("expected a doc")
+                .doc_id,
+            3
+        );
+
+        let suspended = Box::new(variant).suspend();
+        // SAFETY: the suspended iterator holds no live Rust reference into the
+        // index — that is the point of the `Suspended` mode.
+        remove_document(unsafe { &mut *idx_ptr }, 3);
+
+        let guard = ctx.spec_read();
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Moved(it) => it,
+            ResumeOutcome::Ok(_) => panic!("deleting the current document must report Moved"),
+            ResumeOutcome::Aborted => panic!("no range tree was attached, so nothing can abort"),
+        };
+        assert!(matches!(&*active, NumericIteratorVariant::Unfiltered(_)));
+        // `Moved` means "we are no longer where you left us"; the contract is
+        // that `current()` reports where we actually are.
+        assert_eq!(
+            active
+                .current()
+                .expect("a moved iterator is still positioned")
+                .doc_id,
+            5
+        );
+        assert_eq!(active.last_doc_id(), 5);
+        assert_eq!(
+            active
+                .read()
+                .expect("read failed")
+                .expect("expected a doc")
+                .doc_id,
+            7
+        );
+
+        drop(active);
+        // SAFETY: `idx_ptr` came from `Box::into_raw` and every borrow of it is
+        // dead by now.
+        unsafe { drop(Box::from_raw(idx_ptr)) };
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "running GC over the index behind the reader's shared borrow is UB under Stacked \
+                  Borrows; see the module doc"
+    )]
+    /// `Filtered` moves like `Unfiltered` when the document it is parked on is
+    /// deleted — but here the re-seek lands on a document the *filter* rejects,
+    /// so it has to keep going.
+    ///
+    /// That combination is what makes this test worth more than a copy of
+    /// [`unfiltered_moved_after_current_document_deleted`]: the re-seek is
+    /// `FilterNumericReader::seek_record`, which re-applies the predicate to the
+    /// record it landed on and falls through to its own filtering `next_record`
+    /// loop on rejection. The plain reader has no such fall-through, so no
+    /// `Unfiltered` fixture can exercise it.
+    fn filtered_moved_after_current_document_deleted() {
+        let ctx = MockContext::new(0, 0);
+        let filter = narrow_numeric_filter();
+        // Doc 5 carries a value outside the filter, so the re-seek aimed at the
+        // deleted doc 3 has to skip it and settle on doc 7.
+        // Owned by hand: the iterator must keep reading the index while GC
+        // rewrites it.
+        let idx_ptr: *mut NumericIndex = Box::into_raw(Box::new(make_index(&[
+            (1, 1.0),
+            (3, 3.0),
+            (5, 50.0),
+            (7, 7.0),
+            (9, 9.0),
+        ])));
+
+        // SAFETY: `idx_ptr` was just created by `Box::into_raw` and outlives the
+        // iterator built from it.
+        let mut variant = NumericIteratorVariant::new(
+            unsafe { &*idx_ptr }.reader(),
+            Some(&filter),
+            make_expiration_checker(&ctx),
+            None,
+            1.0,
+            9.0,
+        );
+        assert!(
+            matches!(&variant, NumericIteratorVariant::Filtered(_)),
+            "a numeric filter must select the Filtered arm"
+        );
+        assert_eq!(
+            variant
+                .read()
+                .expect("read failed")
+                .expect("expected a doc")
+                .doc_id,
+            1
+        );
+        assert_eq!(
+            variant
+                .read()
+                .expect("read failed")
+                .expect("expected a doc")
+                .doc_id,
+            3
+        );
+
+        let suspended = Box::new(variant).suspend();
+        // SAFETY: the suspended iterator holds no live Rust reference into the
+        // index — that is the point of the `Suspended` mode.
+        remove_document(unsafe { &mut *idx_ptr }, 3);
+
+        let guard = ctx.spec_read();
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Moved(it) => it,
+            ResumeOutcome::Ok(_) => panic!("deleting the current document must report Moved"),
+            ResumeOutcome::Aborted => panic!("no range tree was attached, so nothing can abort"),
+        };
+        assert!(matches!(&*active, NumericIteratorVariant::Filtered(_)));
+        // Doc 5 would be the answer without the filter; landing on 7 is the proof
+        // that the re-seek went through it.
+        assert_eq!(
+            active
+                .current()
+                .expect("a moved iterator is still positioned")
+                .doc_id,
+            7
+        );
+        assert_eq!(active.last_doc_id(), 7);
+        assert_eq!(
+            active
+                .read()
+                .expect("read failed")
+                .expect("expected a doc")
+                .doc_id,
+            9
+        );
+
+        drop(active);
+        // SAFETY: `idx_ptr` came from `Box::into_raw` and every borrow of it is
+        // dead by now.
+        unsafe { drop(Box::from_raw(idx_ptr)) };
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "running GC over the index behind the reader's shared borrow is UB under Stacked \
+                  Borrows (see the module doc), and FilterGeoReader's radius check calls the C \
+                  `isWithinRadius`, which Miri cannot execute"
+    )]
+    /// `Geo` moves over a point outside the radius — the geo twin of
+    /// [`filtered_moved_after_current_document_deleted`], and worth its own test
+    /// for the same reason: `FilterGeoReader::seek_record` has its own
+    /// reject-and-keep-going loop, and its predicate rewrites the record's value
+    /// in place while it runs.
+    fn geo_moved_after_current_document_deleted() {
+        let ctx = MockContext::new(0, 0);
+        let geo_filter = wide_geo_filter();
+        let filter = NumericFilter {
+            geo_filter: ptr::from_ref(&geo_filter).cast(),
+            ..Default::default()
+        };
+        // Doc 5 sits some 3000km from the filter's centre — outside its radius —
+        // so the re-seek aimed at the deleted doc 3 has to skip it.
+        // Owned by hand: the iterator must keep reading the index while GC
+        // rewrites it.
+        let idx_ptr: *mut NumericIndex = Box::into_raw(Box::new(make_index(&[
+            (1, geo_score(0.0, 0.0)),
+            (3, geo_score(0.1, 0.1)),
+            (5, geo_score(20.0, 20.0)),
+            (7, geo_score(0.2, 0.2)),
+            (9, geo_score(0.3, 0.3)),
+        ])));
+
+        // SAFETY: `idx_ptr` was just created by `Box::into_raw` and outlives the
+        // iterator built from it.
+        let mut variant = NumericIteratorVariant::new(
+            unsafe { &*idx_ptr }.reader(),
+            Some(&filter),
+            make_expiration_checker(&ctx),
+            None,
+            1.0,
+            9.0,
+        );
+        assert!(
+            matches!(&variant, NumericIteratorVariant::Geo(_)),
+            "a geo filter must select the Geo arm"
+        );
+        assert_eq!(
+            variant
+                .read()
+                .expect("read failed")
+                .expect("expected a doc")
+                .doc_id,
+            1
+        );
+        assert_eq!(
+            variant
+                .read()
+                .expect("read failed")
+                .expect("expected a doc")
+                .doc_id,
+            3
+        );
+
+        let suspended = Box::new(variant).suspend();
+        // SAFETY: the suspended iterator holds no live Rust reference into the
+        // index — that is the point of the `Suspended` mode.
+        remove_document(unsafe { &mut *idx_ptr }, 3);
+
+        let guard = ctx.spec_read();
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Moved(it) => it,
+            ResumeOutcome::Ok(_) => panic!("deleting the current document must report Moved"),
+            ResumeOutcome::Aborted => panic!("no range tree was attached, so nothing can abort"),
+        };
+        assert!(matches!(&*active, NumericIteratorVariant::Geo(_)));
+        // Doc 5 would be the answer without the radius check; landing on 7 is the
+        // proof that the re-seek went through it.
+        assert_eq!(
+            active
+                .current()
+                .expect("a moved iterator is still positioned")
+                .doc_id,
+            7
+        );
+        assert_eq!(active.last_doc_id(), 7);
+        assert_eq!(
+            active
+                .read()
+                .expect("read failed")
+                .expect("expected a doc")
+                .doc_id,
+            9
+        );
+
+        drop(active);
+        // SAFETY: `idx_ptr` came from `Box::into_raw` and every borrow of it is
+        // dead by now.
+        unsafe { drop(Box::from_raw(idx_ptr)) };
+    }
+
+    #[test]
+    /// The variant enum's flags accessor reports the underlying index's flags in
+    /// every arm and every mode — the value FFI introspection reads while the
+    /// iterator is suspended.
+    fn flags_survive_the_cycle() {
+        let ctx = MockContext::new(0, 0);
+        let idx = make_index(&[(1, 1.0)]);
+        let variant = NumericIteratorVariant::new(
+            idx.reader(),
+            None,
+            make_expiration_checker(&ctx),
+            None,
+            1.0,
+            5.0,
+        );
+        assert_eq!(variant.flags(), IndexFlags_Index_StoreNumeric);
+
+        let suspended = Box::new(variant).suspend();
+        assert_eq!(suspended.flags(), IndexFlags_Index_StoreNumeric);
+
+        let guard = ctx.spec_read();
+        let active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(it) => it,
+            ResumeOutcome::Moved(_) | ResumeOutcome::Aborted => {
+                panic!("an untouched index resumes as Ok")
+            }
+        };
+        assert_eq!(active.flags(), IndexFlags_Index_StoreNumeric);
     }
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: the numeric iterator variant enum (unfiltered / filtered / geo arms over the numeric range tree) can only be revalidated in place, so it cannot be held across a release of the index spec read lock.
2. Change: it implements `RQEIteratorBoxed::suspend` / `RQESuspendedIterator::resume`. The enum is re-shaped into a `Ref`-mode-parametrized `RawNumericIteratorVariant`, so suspending is a layout-preserving reinterpretation of the same allocation rather than a rebuild, with each arm's inner inverted-index reader transitioned in place. The legacy `revalidate` is unchanged.
3. Outcome: no user-visible change — the pipeline does not suspend iterators yet. This is a per-iterator prerequisite for that wiring.

#### Which additional issues this PR fixes

1. MOD-16714

#### Main objects this PR modified

1. `RawNumericIteratorVariant<'query, Rf>` plus the `NumericIteratorVariant` / `NumericIteratorVariantSuspended` aliases — the enum's active and suspended forms, with the layout proof (and an `IsSame` witness) that keeps the three arms in lockstep.
2. `suspend` / `resume` on the variant — reuses the heap allocation so external borrows into the iterator's interior stay valid, and delegates the abort decision to each arm's inner reader.
3. The revalidation decision per arm: abort when the numeric range tree was modified under us, `Moved` when the current document was collected, `Ok` otherwise — this is where the arms could most easily drift apart.
4. `tests/integration/inverted_index/numeric.rs` — all three scenarios spelled out once per arm against a real `NumericIndex`: the round trip (including one taken mid-read), the range-tree-modified abort, and the current-document-deleted `Moved`. The filtered and geo `Moved` cases deliberately put a document the filter *rejects* in the re-seek's path, so they exercise `FilterNumericReader`/`FilterGeoReader`'s reject-and-keep-going `seek_record` loop — a fall-through the unfiltered reader does not have, and which had no revalidation coverage on either the resume or the legacy path.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

