### PR TITLE
[MOD-16714] CRQEIterator: suspend/resume, and propagate a revalidation timeout

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -84,6 +84,16 @@ pub trait RQEIteratorBoxed<'index>: RQEIterator<'index> + 'index {
     type Suspended: RQESuspendedIterator<'index> + 'index;
 
     /// Transition to the suspended state.
+    ///
+    /// # Precondition
+    ///
+    /// The spec read lock must still be held for the duration of the call — suspending is the
+    /// step that *earns* the right to release it, not something to do afterwards. Most
+    /// implementations only re-type Rust-owned state and would not notice, but
+    /// [`CRQEIterator`](c2rust::CRQEIterator) reads its estimate off the C iterator underneath,
+    /// which may deref index-owned memory. A generic caller such as
+    /// [`suspend_child_slot_in_place`] cannot tell from the type whether the subtree it is
+    /// suspending holds such a child, so the obligation is on every caller.
     fn suspend(self: Box<Self>) -> Box<Self::Suspended>;
 }
 

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -587,13 +587,18 @@ impl<'query> RQESuspendedIterator<'query> for CRQEIterator {
         // the C-side callback is safe to call per invariant 4., and
         // `spec.as_mut_ptr()` is valid for the duration of the call.
         let status = unsafe { callback(self.header.as_ptr(), spec.as_mut_ptr()) };
-        // On `ABORTED` the C `Revalidate` reports the status and leaves disposal to the owner:
-        // `Free` is a separate vtable entry the owner calls (see `iterator_api.h`), and
-        // `RQESuspendedIterator::resume` promises the same — the outcome hands back no active
-        // iterator. `self` is not moved into it, so it drops here and its `Free` callback runs
-        // exactly once.
+        // On `ABORTED`, and on a timeout, the C `Revalidate` reports the status and leaves disposal
+        // to the owner: `Free` is a separate vtable entry the owner calls (see `iterator_api.h`),
+        // and `RQESuspendedIterator::resume` promises the same — neither outcome hands back an
+        // active iterator. `self` is not moved into either, so it drops here and its `Free`
+        // callback runs exactly once.
         #[expect(non_upper_case_globals)]
         Ok(match status {
+            // Reported as an error, exactly as the `revalidate` impl above reports it: a Rust
+            // parent propagates it to the root of the tree, where it makes the result set partial
+            // instead of ending the query as if the index were exhausted. Returning early rather
+            // than producing an outcome is what drops `self`.
+            ValidateStatus_VALIDATE_TIMEOUT => return Err(RQEIteratorError::TimedOut),
             ValidateStatus_VALIDATE_ABORTED => ResumeOutcome::Aborted,
             ValidateStatus_VALIDATE_MOVED => ResumeOutcome::Moved(self),
             ValidateStatus_VALIDATE_OK => ResumeOutcome::Ok(self),

--- a/src/redisearch_rs/rqe_iterators/src/c2rust.rs
+++ b/src/redisearch_rs/rqe_iterators/src/c2rust.rs
@@ -17,9 +17,9 @@ use ffi::{
 use rqe_core::DocId;
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
-    interop::RQEIteratorWrapper, intersection::Intersection, profile_print,
-    profile_print::ProfilePrint,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome, interop::RQEIteratorWrapper,
+    intersection::Intersection, profile_print, profile_print::ProfilePrint,
 };
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
@@ -52,7 +52,13 @@ use std::{
 /// It is not a given that the underlying iterator is written in C!
 /// It might be a Rust iterator, wrapped to obey the C API, being passed into
 /// a Rust composite iterator.
-#[repr(transparent)]
+///
+/// It was `#[repr(transparent)]` over [`header`](Self::header) until
+/// [`num_estimated_snapshot`](Self::num_estimated_snapshot) gave it a second field. `#[repr(C)]`
+/// keeps the layout fixed, in line with the crate's other suspendable iterators, but nothing
+/// depends on the field *order*: no code reaches a field through a cast of the struct, so fields
+/// may be added or reordered freely.
+#[repr(C)]
 pub struct CRQEIterator {
     /// # Safety invariants
     ///
@@ -65,6 +71,19 @@ pub struct CRQEIterator {
     /// 4. All callbacks can be safely called, when the right aliasing conditions are
     ///    in place
     header: NonNull<QueryIterator>,
+    /// The estimate this iterator reported when it was last suspended, and the answer
+    /// [`RQESuspendedIterator::num_estimated`] serves.
+    ///
+    /// A suspended iterator is consulted with the spec read lock released, whereas the C
+    /// `NumEstimated` callbacks read index-owned memory that GC may have freed by then:
+    /// [`RQEIteratorWrapper`]'s forwards to the *active* Rust iterator underneath (e.g.
+    /// `InvIndIterator::num_estimated`, a deref of the `InvertedIndex`), and
+    /// `HR_NumEstimated`/`OPT_NumEstimated` recurse into their children the same way. The estimate
+    /// is display-only, so a value snapshotted while the lock was still held is enough.
+    ///
+    /// Meaningless until [`RQEIteratorBoxed::suspend`] fills it in — the active
+    /// [`num_estimated`](RQEIterator::num_estimated) asks the C side directly.
+    num_estimated_snapshot: usize,
 }
 
 impl AsRef<QueryIterator> for CRQEIterator {
@@ -143,7 +162,10 @@ impl CRQEIterator {
     ///    in place
     pub unsafe fn new(header: NonNull<QueryIterator>) -> Self {
         // SAFETY: the caller is required to uphold `Self::header` field invariants.
-        let self_ = Self { header };
+        let self_ = Self {
+            header,
+            num_estimated_snapshot: 0,
+        };
         debug_assert!(
             self_.Free.is_some(),
             "The `Free` callback is a NULL function pointer"
@@ -518,5 +540,76 @@ impl profile_print::ProfilePrint for CRQEIterator {
         // entry was set at construction time by RQEIteratorWrapper::boxed_new
         // or by the C iterator constructor.
         unsafe { call_print_profile(ptr, map, ctx) };
+    }
+}
+
+impl<'index> RQEIteratorBoxed<'index> for CRQEIterator {
+    /// `CRQEIterator` wraps an opaque C handle that owns its own validity
+    /// state, so the suspended counterpart is the same type: there is no set of
+    /// index references to weaken, and hence nothing to flip between modes.
+    ///
+    /// It has to stay the same type, in fact. A composite over concrete `CRQEIterator` children
+    /// re-types each child slot of its `Vec` in place, which
+    /// [`suspend_child_slot_in_place`](crate::boxed::suspend_child_slot_in_place) only permits
+    /// between representations of identical size and alignment — a separate suspended struct would
+    /// fail to compile the moment such a composite is suspended.
+    type Suspended = CRQEIterator;
+
+    fn suspend(mut self: Box<Self>) -> Box<Self::Suspended> {
+        // Ask the C side for its estimate now, while the caller still holds the read lock — see
+        // the field.
+        self.num_estimated_snapshot = <Self as RQEIterator<'index>>::num_estimated(&self);
+        self
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for CRQEIterator {
+    type Resumed<'a>
+        = CRQEIterator
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        spec: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // Delegate validity recovery to the C-side `Revalidate` vtable
+        // entry. Whatever convention the C iterator uses to refresh stale
+        // pointers, restart cursors, etc. is its own concern — we just
+        // call its callback under the held read lock.
+        // SAFETY: invariant 3. of [`CRQEIterator::header`] guarantees the
+        // callback is non-null.
+        let callback = unsafe { self.Revalidate.unwrap_unchecked() };
+        // SAFETY: the handle is unique (consumed by value into `self`),
+        // the C-side callback is safe to call per invariant 4., and
+        // `spec.as_mut_ptr()` is valid for the duration of the call.
+        let status = unsafe { callback(self.header.as_ptr(), spec.as_mut_ptr()) };
+        // On `ABORTED` the C `Revalidate` reports the status and leaves disposal to the owner:
+        // `Free` is a separate vtable entry the owner calls (see `iterator_api.h`), and
+        // `RQESuspendedIterator::resume` promises the same — the outcome hands back no active
+        // iterator. `self` is not moved into it, so it drops here and its `Free` callback runs
+        // exactly once.
+        #[expect(non_upper_case_globals)]
+        Ok(match status {
+            ValidateStatus_VALIDATE_ABORTED => ResumeOutcome::Aborted,
+            ValidateStatus_VALIDATE_MOVED => ResumeOutcome::Moved(self),
+            ValidateStatus_VALIDATE_OK => ResumeOutcome::Ok(self),
+            _ => unreachable!("`Revalidate` returned an unexpected status, {status}"),
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        // `lastDocId` is a plain field of the `QueryIterator` allocation this handle owns, so
+        // reading it touches no index memory and needs no lock.
+        self.lastDocId
+    }
+
+    fn num_estimated(&self) -> usize {
+        // The snapshot `suspend` took, rather than a fresh call into the C `NumEstimated`
+        // callback — see the field for why calling it here would be a use-after-free.
+        self.num_estimated_snapshot
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_opaque.rs
@@ -316,13 +316,12 @@ unsafe extern "C" fn union_profile_children(base: *mut QueryIterator) -> *mut Qu
         // SAFETY: `it` is a valid, uniquely-owned C iterator; it is consumed
         // here and replaced below, so it is neither leaked nor double-freed.
         let profiled = unsafe { CRQEIterator::new(it) }.into_profiled();
-        // `CRQEIterator` is `#[repr(transparent)]` over `NonNull<QueryIterator>`,
-        // so a `&mut CRQEIterator` can be viewed as a `*mut *mut QueryIterator`
-        // slot for in-place replacement.
-        let slot = child as *mut CRQEIterator as *mut *mut QueryIterator;
-        // SAFETY: `slot` is a valid, writable pointer; store the profiled
-        // iterator back in place.
-        unsafe { *slot = profiled.into_raw().as_ptr() };
+        // SAFETY: `child` is a valid, aligned, exclusively borrowed slot. `ptr::write` overwrites
+        // it *without* dropping what was there, which is what this needs: the value still in the
+        // slot names the same `QueryIterator` the profiled wrapper now owns, so running its `Drop`
+        // would `Free` a live iterator. Writing the whole struct rather than its first field also
+        // keeps the replacement independent of `CRQEIterator`'s field layout.
+        unsafe { std::ptr::write(child, profiled) };
     }
     base
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/interop.rs
@@ -18,13 +18,16 @@ use ffi::{
     QueryIterator, ValidateStatus, ValidateStatus_VALIDATE_ABORTED, ValidateStatus_VALIDATE_OK,
     ValidateStatus_VALIDATE_TIMEOUT,
 };
+use rqe_core::DocId;
 use rqe_iterators::{
-    RQEIterator, RQEIteratorError, c2rust::CRQEIterator, interop::RQEIteratorWrapper,
+    RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator, RQEValidateStatus,
+    ResumeOutcome, TypeErasedRQEIterator, c2rust::CRQEIterator, interop::RQEIteratorWrapper,
     intersection::Intersection,
 };
-use rqe_iterators_test_utils::MockContext;
+use rqe_iterators_test_utils::{MockContext, ResumeOutcomeExt, revalidate_via_resume};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
-use crate::utils::{Mock, MockRevalidateResult};
+use crate::utils::{Mock, MockData, MockRevalidateResult, drain_doc_ids};
 
 /// Call the C `Revalidate` callback on a Rust iterator lowered to the C ABI, then free it.
 fn revalidate_through_c_abi(outcome: MockRevalidateResult) -> ValidateStatus {
@@ -44,6 +47,336 @@ fn revalidate_through_c_abi(outcome: MockRevalidateResult) -> ValidateStatus {
     unsafe { ((*it).Free.expect("Free must be populated"))(it) };
 
     status
+}
+
+/// What a `resume` reported, flattened so it can be inspected once the read guard is gone.
+///
+/// [`CRQEIterator`] carries no lifetime, so the resumed iterator would outlive the guard it was
+/// resumed under; the helpers below read everything a test needs off it and drop it while the
+/// context is still alive.
+#[derive(Debug, PartialEq, Eq)]
+enum ResumeReport {
+    Ok,
+    /// A move publishes its new position in `current`, or `None` once it ran past the end.
+    Moved(Option<DocId>),
+    Aborted,
+}
+
+/// Drive a full `suspend` → `resume` cycle over a Rust mock lowered to the C ABI.
+///
+/// The suspended `CRQEIterator` has no Rust-side state of its own, so its `resume` is a plain call
+/// into the C `Revalidate` vtable entry — the same callback `revalidate_through_c_abi` exercises.
+/// Returning the mock's [`MockData`] lets a caller assert on the disposal that only this path
+/// performs: `resume` consumes the suspended iterator, so an `Aborted` or `Err` has to free it.
+fn resume_through_c_abi(
+    outcome: MockRevalidateResult,
+) -> (Result<ResumeReport, RQEIteratorError>, MockData) {
+    let ctx = MockContext::new(100, 10);
+    let guard = ctx.spec_read();
+
+    let mock = Mock::new([1, 2, 3]);
+    let data = mock.data();
+    mock.data().set_revalidate_result(outcome);
+
+    let suspended = RQEIteratorBoxed::suspend(Box::new(CRQEIterator::from_rust_leaf(mock)));
+    let report = RQESuspendedIterator::resume(suspended, &guard).map(|outcome| match outcome {
+        ResumeOutcome::Ok(_) => ResumeReport::Ok,
+        ResumeOutcome::Moved(mut it) => {
+            ResumeReport::Moved(RQEIterator::current(&mut *it).map(|r| r.doc_id))
+        }
+        ResumeOutcome::Aborted => ResumeReport::Aborted,
+    });
+
+    (report, data)
+}
+
+/// Drive the legacy [`RQEIterator::revalidate`] over the same lowered mock, reported the same way,
+/// so the two revalidation paths can be diffed against each other.
+fn revalidate_c_iterator(
+    outcome: MockRevalidateResult,
+) -> (Result<ResumeReport, RQEIteratorError>, MockData) {
+    let ctx = MockContext::new(100, 10);
+    let guard = ctx.spec_read();
+
+    let mock = Mock::new([1, 2, 3]);
+    let data = mock.data();
+    mock.data().set_revalidate_result(outcome);
+
+    let mut it = CRQEIterator::from_rust_leaf(mock);
+    let report = it.revalidate(&guard).map(|status| match status {
+        RQEValidateStatus::Ok => ResumeReport::Ok,
+        RQEValidateStatus::Moved { current } => ResumeReport::Moved(current.map(|r| r.doc_id)),
+        RQEValidateStatus::Aborted => ResumeReport::Aborted,
+    });
+
+    (report, data)
+}
+
+/// The two revalidation paths report failures as [`RQEIteratorError`], which is not comparable
+/// (it wraps an [`std::io::Error`]). Fold both into one comparable value.
+#[derive(Debug, PartialEq, Eq)]
+enum FlatReport {
+    Ok,
+    Moved(Option<DocId>),
+    Aborted,
+    TimedOut,
+    IoError,
+}
+
+fn flatten(report: Result<ResumeReport, RQEIteratorError>) -> FlatReport {
+    match report {
+        Ok(ResumeReport::Ok) => FlatReport::Ok,
+        Ok(ResumeReport::Moved(position)) => FlatReport::Moved(position),
+        Ok(ResumeReport::Aborted) => FlatReport::Aborted,
+        Err(RQEIteratorError::TimedOut) => FlatReport::TimedOut,
+        Err(RQEIteratorError::IoError(_)) => FlatReport::IoError,
+    }
+}
+
+#[test]
+fn a_resume_that_fails_to_read_the_index_is_reported_as_an_abort() {
+    let (report, data) = resume_through_c_abi(MockRevalidateResult::IoError);
+
+    assert_eq!(
+        report.expect("an I/O error has no C status of its own, so it arrives as an abort"),
+        ResumeReport::Aborted,
+        "the C `Revalidate` contract has no I/O status: the error is deliberately collapsed into \
+         `VALIDATE_ABORTED` on the way out and cannot be recovered on the way back in",
+    );
+    assert_eq!(
+        data.drop_count(),
+        1,
+        "`Aborted` materializes no active iterator, so the suspended one is freed here - exactly \
+         once, since nothing else holds it",
+    );
+}
+
+#[test]
+fn an_aborted_resume_is_reported_as_an_abort() {
+    let (report, data) = resume_through_c_abi(MockRevalidateResult::Abort);
+
+    assert_eq!(
+        report.expect("an abort is a status, not an error"),
+        ResumeReport::Aborted
+    );
+    assert_eq!(
+        data.drop_count(),
+        1,
+        "the C `Revalidate` reports the abort and leaves disposal to the owner, so `resume` has to \
+         free the iterator it consumed - once, not twice",
+    );
+}
+
+#[test]
+fn a_successful_resume_hands_back_the_iterator() {
+    let (report, data) = resume_through_c_abi(MockRevalidateResult::Ok);
+
+    assert_eq!(
+        report.expect("a successful resume is not an error"),
+        ResumeReport::Ok
+    );
+    assert_eq!(
+        data.drop_count(),
+        1,
+        "the resumed iterator is dropped by the helper, and only then: an outcome that hands one \
+         back must not have freed it already",
+    );
+}
+
+#[test]
+fn a_resume_that_moves_publishes_its_new_position() {
+    let (report, _) = resume_through_c_abi(MockRevalidateResult::Move);
+
+    assert_eq!(
+        report.expect("a move is a status, not an error"),
+        // The mock was never read, so its move lands on the first document it holds.
+        ResumeReport::Moved(Some(1)),
+        "a `Moved` that does not publish the position it moved to hands its caller the stale \
+         pre-suspend result instead, and a composite one level up cannot recover its own position \
+         from it",
+    );
+}
+
+#[test]
+fn a_resume_that_moves_past_the_end_reports_no_position() {
+    let ctx = MockContext::new(100, 10);
+    let guard = ctx.spec_read();
+
+    let mock = Mock::new([1, 2, 3]);
+    mock.data()
+        .set_revalidate_result(MockRevalidateResult::Move);
+    let mut it = Box::new(CRQEIterator::from_rust_leaf(mock));
+    // Exhaust the mock first, so its move has nowhere left to go. `Moved` then carries no
+    // position, which is a distinct outcome from `Moved(Some(_))`: it travels through the C ABI as
+    // `atEOF` plus a NULL `current` rather than as a fresh result pointer.
+    assert_eq!(drain_doc_ids(&mut *it), vec![1, 2, 3]);
+
+    let suspended = RQEIteratorBoxed::suspend(it);
+    let mut resumed = match RQESuspendedIterator::resume(suspended, &guard) {
+        Ok(ResumeOutcome::Moved(it)) => it,
+        other => panic!(
+            "expected a move, got {:?}",
+            other.map(|_| "a different outcome")
+        ),
+    };
+
+    assert_eq!(
+        RQEIterator::current(&mut *resumed).map(|r| r.doc_id),
+        None,
+        "a move past the end must not keep answering with the last result the iterator yielded: a \
+         parent that reads a position here would re-emit a document the child no longer holds",
+    );
+    assert!(
+        RQEIterator::at_eof(&*resumed),
+        "the C side records the exhaustion in `atEOF`, which is what a parent checks before \
+         reading the child again",
+    );
+}
+
+#[test]
+fn a_suspended_iterator_reports_the_position_it_was_suspended_at() {
+    let mut it = Box::new(CRQEIterator::from_rust_leaf(Mock::new([1, 2, 3])));
+    assert_eq!(
+        RQEIterator::read(&mut *it).unwrap().map(|r| r.doc_id),
+        Some(1)
+    );
+
+    let suspended = RQEIteratorBoxed::suspend(it);
+
+    assert_eq!(
+        RQESuspendedIterator::last_doc_id(&*suspended),
+        1,
+        "a composite decides where to re-seek its children from the positions they report while \
+         suspended, so the suspended accessor has to carry the pre-suspend position over rather \
+         than reset it",
+    );
+}
+
+#[test]
+fn suspend_and_resume_leave_the_iterator_where_c_cached_it() {
+    let ctx = MockContext::new(100, 10);
+    let guard = ctx.spec_read();
+
+    let it = Box::new(CRQEIterator::from_rust_leaf(Mock::new([1, 2, 3])));
+    let header = it.as_raw();
+    let handle = std::ptr::from_ref(&*it);
+
+    let suspended = RQEIteratorBoxed::suspend(it);
+    assert_eq!(
+        suspended.as_raw(),
+        header,
+        "the C side caches pointers into the `QueryIterator` allocation (`header.current` among \
+         them), so suspend must hand the same allocation on rather than rebuild it",
+    );
+
+    let resumed = match RQESuspendedIterator::resume(suspended, &guard) {
+        Ok(ResumeOutcome::Ok(it)) => it,
+        other => panic!(
+            "expected a plain resume, got {:?}",
+            other.map(|_| "a different outcome")
+        ),
+    };
+    assert_eq!(
+        resumed.as_raw(),
+        header,
+        "resume must give the same allocation back"
+    );
+    assert_eq!(
+        std::ptr::from_ref(&*resumed),
+        handle,
+        "the box holding the handle must not move either: a composite that suspended this child \
+         in place expects to find it in the same slot",
+    );
+}
+
+/// Number of times [`count_num_estimated_calls`] was invoked.
+static NUM_ESTIMATED_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+/// Stand-in `NumEstimated` callback: records that it was called at all.
+extern "C" fn count_num_estimated_calls(_it: *const QueryIterator) -> usize {
+    NUM_ESTIMATED_CALLS.fetch_add(1, Ordering::Relaxed);
+    usize::MAX
+}
+
+#[test]
+fn a_suspended_iterator_serves_a_snapshot_rather_than_calling_into_c() {
+    let mock = Mock::new([1, 2, 3]);
+    let it = Box::new(CRQEIterator::from_rust_leaf(mock));
+    let estimate = RQEIterator::num_estimated(&*it);
+
+    let suspended = RQEIteratorBoxed::suspend(it);
+    // Standing in for the hazard this guards against: while suspended, the spec read lock is
+    // released, so the C `NumEstimated` callbacks may be reading index memory that GC has freed
+    // since - `RQEIteratorWrapper`'s forwards to the active Rust iterator underneath, and the
+    // hybrid and optimizer readers recurse into their children the same way. A callback that must
+    // not be called is easier to observe than a use-after-free.
+    // SAFETY: `suspended` owns the header and no reference into it is live across this call.
+    unsafe {
+        rqe_iterators::interop::patch_vtable(suspended.as_raw().as_ptr(), |h| {
+            h.NumEstimated = Some(count_num_estimated_calls)
+        })
+    };
+
+    assert_eq!(
+        RQESuspendedIterator::num_estimated(&*suspended),
+        estimate,
+        "the suspended form has to answer from the snapshot `suspend` took while the lock was still \
+         held",
+    );
+    assert_eq!(
+        NUM_ESTIMATED_CALLS.load(Ordering::Relaxed),
+        0,
+        "asking the C side again is what makes this a use-after-free waiting to happen; the \
+         estimate is display-only, so a snapshot is the whole point of the suspended accessor",
+    );
+}
+
+#[test]
+fn a_c_iterator_resumes_through_the_type_erased_bridge() {
+    let ctx = MockContext::new(100, 10);
+    let guard = ctx.spec_read();
+    let mock = Mock::new([1, 2, 3]);
+    let data = mock.data();
+
+    // The erased bridge is the path composites take: their children are `TypeErasedRQEIterator`s,
+    // whose suspended form is a *different* `Box<dyn …>` with a different vtable.
+    let it = TypeErasedRQEIterator::new(Box::new(CRQEIterator::from_rust_leaf(mock)));
+    let mut resumed = revalidate_via_resume(it, &guard)
+        .expect("a successful resume is not an error")
+        .expect_ok();
+
+    assert_eq!(
+        data.revalidate_count(),
+        1,
+        "the resume must reach the iterator underneath"
+    );
+    assert_eq!(
+        drain_doc_ids(&mut resumed),
+        vec![1, 2, 3],
+        "the resumed iterator has to be usable: dispatching through the suspended vtable instead \
+         of the active one is undefined behaviour that a mere round-trip would not notice",
+    );
+}
+
+#[test]
+fn revalidate_and_resume_report_the_same_outcome() {
+    for outcome in [
+        MockRevalidateResult::Ok,
+        MockRevalidateResult::Move,
+        MockRevalidateResult::Abort,
+        MockRevalidateResult::IoError,
+    ] {
+        let (legacy, _) = revalidate_c_iterator(outcome);
+        let (resumed, _) = resume_through_c_abi(outcome);
+
+        assert_eq!(
+            flatten(resumed),
+            flatten(legacy),
+            "`resume` supersedes `revalidate` on the same C `Revalidate` callback, so for {outcome:?} \
+             the two have to agree: while both paths are live, any divergence is a bug in whichever \
+             one the caller happens to take",
+        );
+    }
 }
 
 #[test]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/interop.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/interop.rs
@@ -134,6 +134,28 @@ fn flatten(report: Result<ResumeReport, RQEIteratorError>) -> FlatReport {
 }
 
 #[test]
+fn a_resume_that_times_out_is_reported_as_an_error() {
+    let (report, data) = resume_through_c_abi(MockRevalidateResult::TimedOut);
+
+    let err = report.expect_err(
+        "`VALIDATE_TIMEOUT` is a first-class status of the C `Revalidate` contract, which every \
+         Rust iterator lowered to the C ABI reports and `FT.DEBUG MOCK_REVALIDATE_TIMEOUT` can \
+         force: `resume` must map it to an error like `revalidate` does, not treat it as \
+         unreachable",
+    );
+    assert!(
+        matches!(err, RQEIteratorError::TimedOut),
+        "expected a timeout, got {err:?}: reported as an abort instead, the query would end as if \
+         the index were exhausted and hand the client a truncated result set labelled complete",
+    );
+    assert_eq!(
+        data.drop_count(),
+        1,
+        "an `Err` consumes the suspended iterator, so its `Free` callback must run exactly once",
+    );
+}
+
+#[test]
 fn a_resume_that_fails_to_read_the_index_is_reported_as_an_abort() {
     let (report, data) = resume_through_c_abi(MockRevalidateResult::IoError);
 
@@ -194,6 +216,42 @@ fn a_resume_that_moves_publishes_its_new_position() {
         "a `Moved` that does not publish the position it moved to hands its caller the stale \
          pre-suspend result instead, and a composite one level up cannot recover its own position \
          from it",
+    );
+}
+
+// Relies on nextest's process-per-test isolation, as the legacy twin above does: the switch is
+// process-global, so a shared-process runner could leak it into another test's resume.
+#[cfg(not(miri))]
+#[test]
+fn the_debug_switch_makes_a_resume_time_out_without_consulting_the_iterator() {
+    let ctx = MockContext::new(100, 10);
+    let guard = ctx.spec_read();
+    let mock = Mock::new([1, 2, 3]);
+    let data = mock.data();
+    let suspended = RQEIteratorBoxed::suspend(Box::new(CRQEIterator::from_rust_leaf(mock)));
+
+    rqe_iterators::interop::set_mock_revalidate_timeout(true);
+    let report = RQESuspendedIterator::resume(suspended, &guard);
+    rqe_iterators::interop::set_mock_revalidate_timeout(false);
+
+    let err = report.err().expect(
+        "this switch is how the flow tests drive a revalidation timeout, so `resume` has to survive \
+         being handed one",
+    );
+    assert!(
+        matches!(err, RQEIteratorError::TimedOut),
+        "expected a timeout, got {err:?}"
+    );
+    assert_eq!(
+        data.revalidate_count(),
+        0,
+        "the switch stands in for an expired deadline, so it must short-circuit rather than let \
+         the iterator revalidate and then discard the outcome",
+    );
+    assert_eq!(
+        data.drop_count(),
+        1,
+        "the error consumed the suspended iterator"
     );
 }
 
@@ -359,11 +417,37 @@ fn a_c_iterator_resumes_through_the_type_erased_bridge() {
 }
 
 #[test]
+fn a_timed_out_resume_through_the_type_erased_bridge_stays_a_timeout() {
+    let ctx = MockContext::new(100, 10);
+    let guard = ctx.spec_read();
+    let mock = Mock::new([1, 2, 3]);
+    let data = mock.data();
+    mock.data()
+        .set_revalidate_result(MockRevalidateResult::TimedOut);
+
+    let it = TypeErasedRQEIterator::new(Box::new(CRQEIterator::from_rust_leaf(mock)));
+    let err = revalidate_via_resume(it, &guard)
+        .err()
+        .expect("the erased bridge forwards the error rather than swallowing it");
+
+    assert!(
+        matches!(err, RQEIteratorError::TimedOut),
+        "expected a timeout, got {err:?}"
+    );
+    assert_eq!(
+        data.drop_count(),
+        1,
+        "the error consumed the erased suspended iterator, which owns the C one underneath",
+    );
+}
+
+#[test]
 fn revalidate_and_resume_report_the_same_outcome() {
     for outcome in [
         MockRevalidateResult::Ok,
         MockRevalidateResult::Move,
         MockRevalidateResult::Abort,
+        MockRevalidateResult::TimedOut,
         MockRevalidateResult::IoError,
     ] {
         let (legacy, _) = revalidate_c_iterator(outcome);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/utils/mock_iterator.rs
@@ -143,6 +143,7 @@ impl MockData {
             force_read_none: false,
             resume_reseeks_past_end: false,
             revalidate_reseeks_to: None,
+            drop_count: 0,
         })))
     }
 
@@ -261,6 +262,21 @@ impl MockData {
         self.0.borrow().validation_count
     }
 
+    /// Number of [`Mock`] values that have been dropped.
+    ///
+    /// The handle outlives the iterator (the state is reference counted), so a test can assert on
+    /// disposal after the fact: `1` for a mock freed exactly once, `0` for one that leaked, and
+    /// more than `1` for a double free. This is what makes the paths that *consume* an iterator —
+    /// [`RQESuspendedIterator::resume`](rqe_iterators::RQESuspendedIterator::resume) reporting
+    /// `Aborted` or an error, or a C `Free` callback — checkable.
+    ///
+    /// Only the active [`Mock`] is counted: `suspend` relabels the allocation as
+    /// [`MockSuspended`], whose drop glue is a different one, so a mock dropped while suspended
+    /// does not register here.
+    pub fn drop_count(&self) -> usize {
+        self.0.borrow().drop_count
+    }
+
     /// Force the next call to `read()` to return `None` even if not at EOF.
     ///
     /// This simulates an iterator that reports `None` from `read()` while it still
@@ -305,6 +321,8 @@ struct MockDataInternal {
     /// Document `revalidate` rewinds and re-seeks onto — see
     /// [`MockData::set_revalidate_reseeks_to`].
     revalidate_reseeks_to: Option<DocId>,
+    /// Number of [`Mock`] values dropped — see [`MockData::drop_count`].
+    drop_count: usize,
 }
 
 impl MockDataInternal {
@@ -386,10 +404,11 @@ impl<'index, const N: usize> Mock<'index, N> {
             positions.iter().all(|&p| (1..=127).contains(&p)),
             "positions must be in 1..=127 (single-byte varint range)"
         );
-        Self {
-            positions: Some(positions),
-            ..Self::new(doc_ids)
-        }
+        // Written as a mutation rather than `..Self::new(doc_ids)`: struct update syntax moves the
+        // remaining fields out of the base value, which `Drop for Mock` forbids.
+        let mut mock = Self::new(doc_ids);
+        mock.positions = Some(positions);
+        mock
     }
 
     /// Return a handle to the shared [`MockData`] of this iterator.
@@ -435,6 +454,12 @@ impl<'index, const N: usize> Mock<'index, N> {
     /// from [`Self::past_end`].
     fn no_more_docs(&self) -> bool {
         self.next_index >= N
+    }
+}
+
+impl<const N: usize> Drop for Mock<'_, N> {
+    fn drop(&mut self) {
+        self.data.0.borrow_mut().drop_count += 1;
     }
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `CRQEIterator` — the Rust-side handle for an iterator living behind the C `QueryIterator` ABI, which is also how a Rust leaf reaches a Rust composite — has no boxed suspend path. And on the `resume` path being added here, the C `Revalidate` callback's `VALIDATE_TIMEOUT` status would fall into a `_ => unreachable!()`: that status is a documented first-class return (`iterator_api.h`), `interop::revalidate` produces it for every Rust iterator lowered to the C ABI, `FT.DEBUG MOCK_REVALIDATE_TIMEOUT` forces it, and `optimizer_reader.c` and `hybrid_reader.c` both propagate it.
2. Change: `CRQEIterator` implements `RQEIteratorBoxed::suspend` / `RQESuspendedIterator::resume` (the suspended counterpart is deliberately the same type, since composites re-type child slots in place and require identical size and alignment), and `resume` maps `VALIDATE_TIMEOUT` to `Err(RQEIteratorError::TimedOut)` as the legacy `revalidate` on the same callback already does. Suspending also snapshots the C-side estimate, so the suspended `num_estimated` answers from the snapshot instead of calling into C with the lock released.
3. Outcome: no user-visible change today — `resume` does not exist in `master`, so the `unreachable!` this fixes is not reachable from a released build. It matters because that panic would have unwound out of an `extern "C"` frame, and because a deadline expiring mid-revalidation must make the result set partial rather than end the query as if the index were exhausted. Prerequisite for wiring suspension into the query pipeline.

#### Which additional issues this PR fixes

1. MOD-16714

#### Main objects this PR modified

1. `CRQEIterator::suspend` / `resume` — why `type Suspended = CRQEIterator` is forced by in-place child-slot re-typing, and why the struct moves from `#[repr(transparent)]` to `#[repr(C)]`.
2. `num_estimated_snapshot` — filled in only at `suspend`, read only by the suspended `num_estimated`; the active path still asks C directly.
3. The `VALIDATE_TIMEOUT` arm — mapped to `RQEIteratorError::TimedOut`, and the ownership note that goes with it: like `ABORTED`, a timeout hands back no active iterator, and returning early is what drops `self` so its `Free` callback runs exactly once.
4. `tests/integration/interop.rs` and the mock iterator — cover the timeout arm and the suspend/resume round trip through the C ABI.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
