### PR TITLE
[MOD-17684] Give OptimizedWildcard a suspended counterpart

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/mod.rs
@@ -29,4 +29,4 @@ pub use numeric::{
 
 pub use tag::{Tag, TagLookup};
 pub use term::{Term, TermIndexReader, build_term_iterator};
-pub use wildcard::Wildcard;
+pub use wildcard::{RawWildcard, Wildcard};

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/wildcard.rs
@@ -50,9 +50,7 @@ pub struct RawWildcard<
     // to the `Active` reader regardless of `Rf` (see `RawInvIndIterator`'s `RA`).
     RA = RawIndexReaderCore<Active<'query>, E>,
 > {
-    // `pub(crate)` so the top-level `OptimizedWildcard` wrapper can drive the
-    // inner iterator's `resume_in_place` on its inline variants.
-    pub(crate) it: RawInvIndIterator<'query, Rf, RawIndexReaderCore<Rf, E>, NoOpChecker, RA>,
+    it: RawInvIndIterator<'query, Rf, RawIndexReaderCore<Rf, E>, NoOpChecker, RA>,
 }
 
 /// Alias for an [`Active`] [`RawWildcard`] — the only instantiation with an
@@ -76,10 +74,7 @@ where
     /// 1. `spec.existingDocs`, when non-null, must point to an opaque
     ///    [`InvertedIndex`](inverted_index::InvertedIndex) whose encoding
     ///    variant matches `E`.
-    ///
-    /// `pub(crate)` so the top-level `OptimizedWildcard` wrapper can run the
-    /// identity check on its inline inverted-index wildcard variants.
-    pub(crate) fn should_abort(&self, spec: &IndexSpecReadGuard) -> bool {
+    fn should_abort(&self, spec: &IndexSpecReadGuard) -> bool {
         // the garbage collector may set existing_docs to NULL after garbage collecting all documents
         let Some(existing_docs) = spec.existing_docs() else {
             return true;

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -285,16 +285,59 @@ pub enum NewWildcardIterator<'index> {
     Disk(DiskWildcardIterator<'index>),
 }
 
-/// An optimized wildcard iterator over the `existingDocs` inverted index.
+/// Payload of [`RawOptimizedWildcard::DocIdsOnly`]: an inverted-index wildcard
+/// over a [`DocIdsOnly`]-encoded `existingDocs`. `Rf` flows into the reader,
+/// which weakens on suspend; the reader-dispatch slot is left at its default,
+/// which freezes it to the **active** reader in both modes — see
+/// [`crate::inverted_index::RawWildcard`].
+type DocIdsOnlyArm<'query, Rf> = crate::inverted_index::RawWildcard<'query, Rf, DocIdsOnly>;
+
+/// Payload of [`RawOptimizedWildcard::RawDocIdsOnly`] — [`DocIdsOnlyArm`] over
+/// the [`RawDocIdsOnly`] encoding instead.
+type RawDocIdsOnlyArm<'query, Rf> = crate::inverted_index::RawWildcard<'query, Rf, RawDocIdsOnly>;
+
+/// An optimized wildcard iterator over the `existingDocs` inverted index,
+/// parameterised over a [`Ref`] mode.
 ///
 /// The encoding may be either [`DocIdsOnly`] or [`RawDocIdsOnly`], depending on
 /// the index configuration.
-pub enum OptimizedWildcard<'index> {
+///
+/// See [`OptimizedWildcard`] for the [`Active`] instantiation that implements
+/// [`RQEIterator`], and [`OptimizedWildcardSuspended`] for its passive carrier
+/// across a lock release/reacquire cycle.
+///
+/// # Invariants
+///
+/// 1. **Layout compatibility across modes.** `OptimizedWildcard<'query>` and
+///    `OptimizedWildcardSuspended<'query>` are layout-identical, so
+///    [`suspend`](RQEIteratorBoxed::suspend) /
+///    [`resume`](RQESuspendedIterator::resume) can transition each payload in
+///    place and then reinterpret the owning `Box` between the two. Being a
+///    single `#[repr(C, u8)]` generic, the two share a tag encoding and variant
+///    order by construction; the per-arm payload correspondence and layout
+///    identity are enforced by the `const _` proof below.
+///
+///    `#[repr(C, u8)]` is load-bearing, not decorative: under the default
+///    `repr(Rust)` both the tag encoding and the payload offsets are
+///    unspecified, and the compiler is free to pick differently for the two
+///    instantiations — the tag could even be niche-encoded into one of the
+///    payload's [`NonNull`] fields.
+#[repr(C, u8)]
+pub enum RawOptimizedWildcard<'query, Rf: Ref> {
     /// Optimized wildcard with [`DocIdsOnly`] encoding.
-    DocIdsOnly(crate::inverted_index::Wildcard<'index, DocIdsOnly>),
+    DocIdsOnly(DocIdsOnlyArm<'query, Rf>),
     /// Optimized wildcard with [`RawDocIdsOnly`] encoding.
-    RawDocIdsOnly(crate::inverted_index::Wildcard<'index, RawDocIdsOnly>),
+    RawDocIdsOnly(RawDocIdsOnlyArm<'query, Rf>),
 }
+
+/// Alias for an [`Active`] [`RawOptimizedWildcard`] — the only instantiation
+/// with an [`RQEIterator`] impl.
+pub type OptimizedWildcard<'index> = RawOptimizedWildcard<'index, Active<'index>>;
+
+/// [`Suspended`]-mode counterpart of [`OptimizedWildcard`], used as its
+/// [`RQEIteratorBoxed::Suspended`] type. Retains the `'query` lifetime so
+/// query-attached borrows stay valid across the suspend/resume cycle.
+pub type OptimizedWildcardSuspended<'query> = RawOptimizedWildcard<'query, Suspended>;
 
 /// Delegates each [`RQEIterator`] method to the active variant.
 macro_rules! delegate_rqe_iterator {
@@ -367,6 +410,217 @@ impl crate::profile_print::ProfilePrint for OptimizedWildcard<'_> {
         match self {
             Self::DocIdsOnly(it) => it.print_profile(map, ctx),
             Self::RawDocIdsOnly(it) => it.print_profile(map, ctx),
+        }
+    }
+}
+
+// Compile-time proof of invariant 1 on `RawOptimizedWildcard`: a
+// `Box<OptimizedWildcard>` can be reinterpreted as a
+// `Box<OptimizedWildcardSuspended>` and back, as `suspend`/`resume` below do.
+// Because both are instantiations of the *same* `#[repr(C, u8)]` enum, the
+// variant order and tag encoding agree by construction and need no assertion.
+// What remains to be proven:
+//
+// (a) **Arm correspondence.** `suspend` fills each payload slot with
+//     `<active arm as RQEIteratorBoxed>::Suspended` — see
+//     [`crate::boxed::suspend_child_slot_in_place`] — and only then relabels the
+//     owning box. That is sound only if the suspended enum's matching arm *is*
+//     that projection. Asserted below as a type equality rather than a layout
+//     comparison: it is the property the reinterpretation actually needs, and a
+//     mismatch becomes a build error instead of a silently mistyped payload.
+//
+// (b) **Per-arm payload layout identity.** Implied by (a) together with
+//     invariant 1 on `RawInvIndIterator` (proven in `inverted_index/core.rs`),
+//     which `inverted_index::RawWildcard` is a `#[repr(C)]` newtype over.
+//     Asserted per arm anyway so a regression names the arm that broke, and
+//     because under `#[repr(C, u8)]` each payload sits at an offset derived
+//     from *that payload's* alignment — per-arm alignment equality, not the
+//     enum's, is what pins the payload offsets. (`offset_of!` into enum
+//     variants is not yet stable, so the offsets cannot be asserted directly.)
+//
+// (c) **Enum size/alignment equality.** Needed on its own by `resume`'s
+//     abort/error paths, which free an allocation created for the active enum
+//     using `Layout::new::<OptimizedWildcardSuspended>()`.
+//
+// A module-level `const _` is evaluated even though neither type is ever
+// instantiated here, which a `const {}` inside a generic function would not be.
+const _: () = {
+    use std::mem::{align_of, size_of};
+
+    /// Witnesses that `Self` and `T` are the same type: the blanket impl is the
+    /// only one, so a `A: IsSame<B>` bound holds exactly when `A` *is* `B`.
+    trait IsSame<T> {}
+    impl<T> IsSame<T> for T {}
+
+    /// (a) — fails to compile unless suspending `A` yields exactly `S`.
+    const fn assert_suspends_to<A, S>()
+    where
+        A: RQEIteratorBoxed<'static>,
+        A::Suspended: IsSame<S>,
+    {
+    }
+
+    assert_suspends_to::<DocIdsOnlyArm<'static, Active<'static>>, DocIdsOnlyArm<'static, Suspended>>(
+    );
+    assert_suspends_to::<
+        RawDocIdsOnlyArm<'static, Active<'static>>,
+        RawDocIdsOnlyArm<'static, Suspended>,
+    >();
+
+    // (b)
+    assert!(
+        size_of::<DocIdsOnlyArm<'static, Active<'static>>>()
+            == size_of::<DocIdsOnlyArm<'static, Suspended>>()
+    );
+    assert!(
+        align_of::<DocIdsOnlyArm<'static, Active<'static>>>()
+            == align_of::<DocIdsOnlyArm<'static, Suspended>>()
+    );
+    assert!(
+        size_of::<RawDocIdsOnlyArm<'static, Active<'static>>>()
+            == size_of::<RawDocIdsOnlyArm<'static, Suspended>>()
+    );
+    assert!(
+        align_of::<RawDocIdsOnlyArm<'static, Active<'static>>>()
+            == align_of::<RawDocIdsOnlyArm<'static, Suspended>>()
+    );
+
+    // (c)
+    assert!(
+        size_of::<OptimizedWildcard<'static>>() == size_of::<OptimizedWildcardSuspended<'static>>()
+    );
+    assert!(
+        align_of::<OptimizedWildcard<'static>>()
+            == align_of::<OptimizedWildcardSuspended<'static>>()
+    );
+};
+
+impl<'index> RQEIteratorBoxed<'index> for OptimizedWildcard<'index> {
+    type Suspended = OptimizedWildcardSuspended<'index>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Transition the payload in place, arm by arm. Both enums are the same
+        // `#[repr(C, u8)]` generic at different `Rf`, so they share a tag
+        // encoding and variant order; the helper writes exactly the arm's
+        // `Suspended` projection, which invariant 1's proof (a) pins to the
+        // matching suspended arm. Together those make the final whole-box cast
+        // sound. The tag byte itself is untouched.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+        // initialised, exclusively owned); the `&mut` borrow is confined to the
+        // match.
+        match unsafe { &mut *raw } {
+            RawOptimizedWildcard::DocIdsOnly(it) => {
+                // SAFETY: `it` is the valid, exclusively-owned payload; the
+                // helper reinitialises the slot as its `Suspended` form in place.
+                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+            }
+            RawOptimizedWildcard::RawDocIdsOnly(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+            }
+        }
+        // SAFETY: the payload now holds its `Suspended` form at the same offset,
+        // and the tag encodes the same variant in both enums. `Box::from_raw`
+        // reuses the same allocation, so the box address is preserved.
+        unsafe { Box::from_raw(raw.cast::<OptimizedWildcardSuspended<'index>>()) }
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for OptimizedWildcardSuspended<'query> {
+    type Resumed<'a>
+        = OptimizedWildcard<'a>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        spec: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let raw = Box::into_raw(self);
+        // Resume the payload in place, arm by arm — the tag byte is untouched,
+        // so the whole-box cast below lands on the same variant of the active
+        // enum (same `#[repr(C, u8)]` generic at a different `Rf`; arm
+        // correspondence and per-arm layout identity are invariant 1's const
+        // proof above). The arm's own `resume` owns the abort decision — the
+        // garbage collector may have nulled out or replaced `existingDocs` — so
+        // it is stated in exactly one place, shared with the arm's legacy
+        // `revalidate`.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+        // initialised, exclusively owned); the `&mut` borrow is confined to the
+        // match. On `Unchanged`/`Moved` the helper rewrites the payload as its
+        // resumed form; on `Aborted`/`Err` it consumes the payload, leaving it
+        // uninitialised (handled below).
+        let outcome = match unsafe { &mut *raw } {
+            RawOptimizedWildcard::DocIdsOnly(it) => {
+                // SAFETY: `it` is the valid, exclusively-owned payload.
+                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, spec) }
+            }
+            RawOptimizedWildcard::RawDocIdsOnly(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, spec) }
+            }
+        };
+
+        match outcome {
+            Ok(crate::boxed::ResumeSlotOutcome::Unchanged) => {
+                // SAFETY: the payload holds its resumed form at the same offset
+                // and the tag is unchanged; `Box::from_raw` reuses the same
+                // allocation, so the box address — and the FFI's cached
+                // `header.current` into the payload's result — stay valid.
+                let active = unsafe { Box::from_raw(raw.cast::<OptimizedWildcard<'a>>()) };
+                Ok(ResumeOutcome::Ok(active))
+            }
+            Ok(crate::boxed::ResumeSlotOutcome::Moved) => {
+                // SAFETY: as above.
+                let active = unsafe { Box::from_raw(raw.cast::<OptimizedWildcard<'a>>()) };
+                Ok(ResumeOutcome::Moved(active))
+            }
+            Ok(crate::boxed::ResumeSlotOutcome::Aborted) => {
+                // The payload was consumed; the allocation holds only the tag
+                // and an uninitialised payload, so it must be freed without
+                // dropping anything.
+                // SAFETY: `raw` was allocated by `Box` with exactly this layout;
+                // nothing in it is live any more.
+                unsafe {
+                    std::alloc::dealloc(
+                        raw.cast::<u8>(),
+                        std::alloc::Layout::new::<OptimizedWildcardSuspended<'query>>(),
+                    )
+                };
+                Ok(ResumeOutcome::Aborted)
+            }
+            Err(e) => {
+                // As `Aborted`: the payload was consumed; free the allocation
+                // without dropping it.
+                // SAFETY: as above.
+                unsafe {
+                    std::alloc::dealloc(
+                        raw.cast::<u8>(),
+                        std::alloc::Layout::new::<OptimizedWildcardSuspended<'query>>(),
+                    )
+                };
+                Err(e)
+            }
+        }
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        match self {
+            RawOptimizedWildcard::DocIdsOnly(it) => RQESuspendedIterator::last_doc_id(it),
+            RawOptimizedWildcard::RawDocIdsOnly(it) => RQESuspendedIterator::last_doc_id(it),
+        }
+    }
+
+    fn num_estimated(&self) -> usize {
+        match self {
+            RawOptimizedWildcard::DocIdsOnly(it) => RQESuspendedIterator::num_estimated(it),
+            RawOptimizedWildcard::RawDocIdsOnly(it) => RQESuspendedIterator::num_estimated(it),
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/wildcard.rs
@@ -297,3 +297,284 @@ fn wildcard_upholds_current_contract() {
     assert_eq!(assert_current_contract(&mut it), [1, 2, 3, 4, 5]);
     assert_current_contract_via_skip_to(&mut it, 6);
 }
+
+/// Suspend/resume coverage for [`OptimizedWildcard`], the enum that stands in
+/// for the `existingDocs`-backed wildcard once the encoding is known.
+///
+/// [`OptimizedWildcard`] adds no behaviour of its own — every method forwards
+/// to the inverted-index wildcard inside, which `inverted_index::wildcard`
+/// already covers, and the resume decision (abort / moved / unchanged) is the
+/// arm's own. What it adds is the per-arm in-place transition plus a whole-box
+/// reinterpretation between itself and [`OptimizedWildcardSuspended`], so these
+/// tests are about the enum's *layout* surviving the round trip, per variant.
+mod via_resume {
+    use ffi::IndexFlags_Index_DocIdsOnly;
+    use index_result::RSIndexResult;
+    use inverted_index::{
+        DecodedBy, Encoder, InvertedIndex, doc_ids_only::DocIdsOnly, opaque,
+        opaque::OpaqueEncoding, raw_doc_ids_only::RawDocIdsOnly,
+    };
+    use rqe_core::{DocId, RS_FIELDMASK_ALL};
+    use rqe_iterators::{
+        RQEIterator, RQEIteratorBoxed, RQESuspendedIterator, ResumeOutcome,
+        inverted_index::Wildcard as InvIdxWildcard,
+        wildcard::{OptimizedWildcard, OptimizedWildcardSuspended},
+    };
+    use rqe_iterators_test_utils::MockContext;
+
+    const DOC_IDS: [DocId; 5] = [1, 3, 5, 7, 9];
+
+    /// An `existingDocs` inverted index wired into a [`MockContext`]'s spec.
+    ///
+    /// The wiring is the point: resume opens with an identity check against
+    /// `spec.existingDocs`, so a fixture that leaves the spec's pointer null
+    /// (like `optional_optimized`'s `WildcardIndex`) can only ever produce
+    /// `Aborted`. The index is held behind a raw pointer so the spec's view of
+    /// it and the reader's view of it are derived from the same provenance.
+    struct ExistingDocs {
+        ctx: MockContext,
+        index: *mut opaque::InvertedIndex,
+    }
+
+    impl Drop for ExistingDocs {
+        fn drop(&mut self) {
+            self.ctx
+                .spec_write()
+                .set_existing_docs_ptr(std::ptr::null_mut());
+            // SAFETY: `index` came from `Box::into_raw` in `new` and every
+            // borrow handed out is tied to `&self`, so none outlives this.
+            unsafe { drop(Box::from_raw(self.index)) };
+        }
+    }
+
+    fn populate<E: Encoder>(ii: &mut InvertedIndex<E>) {
+        for doc_id in DOC_IDS {
+            let record = RSIndexResult::build_virt()
+                .doc_id(doc_id)
+                .field_mask(RS_FIELDMASK_ALL)
+                .frequency(1)
+                .build();
+            ii.add_record(&record).expect("failed to add record");
+        }
+    }
+
+    impl ExistingDocs {
+        fn new(index: opaque::InvertedIndex) -> Self {
+            let ctx = MockContext::new(0, 0);
+            let index = Box::into_raw(Box::new(index));
+            ctx.spec_write().set_existing_docs_ptr(index.cast());
+            Self { ctx, index }
+        }
+
+        fn doc_ids_only() -> Self {
+            let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+            populate(&mut ii);
+            Self::new(opaque::InvertedIndex::DocIdsOnly(ii))
+        }
+
+        fn raw_doc_ids_only() -> Self {
+            let mut ii = InvertedIndex::<RawDocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+            populate(&mut ii);
+            Self::new(opaque::InvertedIndex::RawDocIdsOnly(ii))
+        }
+
+        /// The typed index the spec's `existingDocs` points at.
+        fn typed<E>(&self) -> &InvertedIndex<E>
+        where
+            E: DecodedBy + OpaqueEncoding<Storage = InvertedIndex<E>>,
+        {
+            // SAFETY: `index` is a live, exclusively-owned allocation for as
+            // long as `self` is; the returned borrow is tied to `&self`.
+            E::from_opaque(unsafe { &*self.index })
+        }
+
+        /// Garbage-collect `doc_id` out of the index, the way the fork GC does.
+        ///
+        /// Takes `&self` so it can run while an iterator built from
+        /// [`typed`](Self::typed) is still alive — which is the whole point of
+        /// the scenario, and also why the caller has to be miri-ignored: the
+        /// exclusive access below overlaps a shared borrow that outlives it.
+        /// The existing `inverted_index::wildcard` revalidation tests take the
+        /// same shortcut for the same reason.
+        fn remove_document<E>(&self, doc_id: DocId)
+        where
+            E: Encoder + DecodedBy + OpaqueEncoding<Storage = InvertedIndex<E>>,
+        {
+            // SAFETY: `index` is a live, exclusively-owned allocation; see the
+            // aliasing caveat above for the borrow that overlaps this one.
+            let ii = E::from_mut_opaque(unsafe { &mut *self.index });
+            let delta = ii
+                .scan_gc(
+                    |d| d != doc_id,
+                    None::<fn(&RSIndexResult, &inverted_index::RepairContext<'_>)>,
+                )
+                .expect("scan GC failed")
+                .expect("no GC scan delta");
+            assert_eq!(ii.apply_gc(delta).entries_removed, 1);
+        }
+    }
+
+    /// E: the round trip, for both encodings.
+    ///
+    /// The `matches!` assertions are the interesting ones: they check that the
+    /// whole-box cast landed on the *same* variant, which is what a disagreeing
+    /// tag encoding between the two instantiations would break, and it can
+    /// disagree per variant — so covering only the first would prove little.
+    ///
+    /// It is worth being precise about what this does *not* establish. The
+    /// guarantee that the two instantiations agree comes from `#[repr(C, u8)]`,
+    /// not from here: with the attribute removed, `repr(Rust)` happens to pick
+    /// the same layout on the current toolchain and target, and this test still
+    /// passes (checked under miri). It is a regression test for the *cast* —
+    /// the addresses, the tag, and the position — and it will catch a layout
+    /// divergence if one ever materialises, but the attribute is what stops one
+    /// from materialising in the first place.
+    #[rstest::rstest]
+    #[case::doc_ids_only(false)]
+    #[case::raw_doc_ids_only(true)]
+    fn resume_round_trip_per_variant(#[case] raw: bool) {
+        let fixture = if raw {
+            ExistingDocs::raw_doc_ids_only()
+        } else {
+            ExistingDocs::doc_ids_only()
+        };
+        let guard = fixture.ctx.spec_read();
+        let mut it = Box::new(if raw {
+            OptimizedWildcard::RawDocIdsOnly(InvIdxWildcard::new(
+                fixture.typed::<RawDocIdsOnly>().reader(),
+                1.0,
+            ))
+        } else {
+            OptimizedWildcard::DocIdsOnly(InvIdxWildcard::new(
+                fixture.typed::<DocIdsOnly>().reader(),
+                1.0,
+            ))
+        });
+
+        assert_eq!(it.read().unwrap().unwrap().doc_id, DOC_IDS[0]);
+        let box_addr = &*it as *const _ as usize;
+
+        let suspended = it.suspend();
+        assert_eq!(
+            &*suspended as *const _ as usize, box_addr,
+            "suspend must reuse the allocation",
+        );
+        let tag_survived = if raw {
+            matches!(&*suspended, OptimizedWildcardSuspended::RawDocIdsOnly(_))
+        } else {
+            matches!(&*suspended, OptimizedWildcardSuspended::DocIdsOnly(_))
+        };
+        assert!(tag_survived, "suspend must land on the same variant");
+        assert_eq!(RQESuspendedIterator::last_doc_id(&*suspended), DOC_IDS[0]);
+
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(a) => a,
+            ResumeOutcome::Moved(_) => panic!("expected Ok, got Moved"),
+            ResumeOutcome::Aborted => panic!("expected Ok, got Aborted"),
+        };
+        assert_eq!(
+            &*active as *const _ as usize, box_addr,
+            "resume must reuse the allocation",
+        );
+        let tag_survived = if raw {
+            matches!(&*active, OptimizedWildcard::RawDocIdsOnly(_))
+        } else {
+            matches!(&*active, OptimizedWildcard::DocIdsOnly(_))
+        };
+        assert!(tag_survived, "resume must land on the same variant");
+        assert_eq!(active.read().unwrap().unwrap().doc_id, DOC_IDS[1]);
+    }
+
+    /// F1: the GC nulled `existingDocs` out from under the iterator.
+    #[test]
+    fn resume_aborts_when_existing_docs_is_nulled() {
+        let fixture = ExistingDocs::doc_ids_only();
+        let mut it = Box::new(OptimizedWildcard::DocIdsOnly(InvIdxWildcard::new(
+            fixture.typed::<DocIdsOnly>().reader(),
+            1.0,
+        )));
+        assert_eq!(it.read().unwrap().unwrap().doc_id, DOC_IDS[0]);
+
+        fixture
+            .ctx
+            .spec_write()
+            .set_existing_docs_ptr(std::ptr::null_mut());
+
+        // Taken after the write, as the production sequence does: the read lock
+        // is re-acquired once the GC's write lock has been released.
+        let guard = fixture.ctx.spec_read();
+        assert!(matches!(
+            it.suspend().resume(&guard).expect("resume failed"),
+            ResumeOutcome::Aborted
+        ));
+    }
+
+    /// F2: the GC replaced `existingDocs` with a fresh allocation, so the
+    /// reader's pointer is stale even though the spec's is not null.
+    #[test]
+    fn resume_aborts_when_existing_docs_is_replaced() {
+        let fixture = ExistingDocs::doc_ids_only();
+        let mut it = Box::new(OptimizedWildcard::DocIdsOnly(InvIdxWildcard::new(
+            fixture.typed::<DocIdsOnly>().reader(),
+            1.0,
+        )));
+        assert_eq!(it.read().unwrap().unwrap().doc_id, DOC_IDS[0]);
+
+        let replacement = Box::into_raw(Box::new(opaque::InvertedIndex::DocIdsOnly(
+            InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly),
+        )));
+        let original = fixture.ctx.spec_read().existing_docs_ptr();
+        fixture
+            .ctx
+            .spec_write()
+            .set_existing_docs_ptr(replacement.cast());
+
+        // Taken after the write — see `resume_aborts_when_existing_docs_is_nulled`.
+        let guard = fixture.ctx.spec_read();
+        assert!(matches!(
+            it.suspend().resume(&guard).expect("resume failed"),
+            ResumeOutcome::Aborted
+        ));
+
+        fixture.ctx.spec_write().set_existing_docs_ptr(original);
+        // SAFETY: `replacement` came from `Box::into_raw` and the spec no
+        // longer points at it.
+        unsafe { drop(Box::from_raw(replacement)) };
+    }
+
+    /// F3: the document the iterator sits on is collected while it is
+    /// suspended, so the resume re-seeks past it and reports `Moved`.
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "GC mutates the index through `&mut` while the reader's pointer into it is still live, which Stacked Borrows rejects"
+    )]
+    fn resume_reports_moved_when_the_current_document_is_collected() {
+        let fixture = ExistingDocs::doc_ids_only();
+        let mut it = Box::new(OptimizedWildcard::DocIdsOnly(InvIdxWildcard::new(
+            fixture.typed::<DocIdsOnly>().reader(),
+            1.0,
+        )));
+        assert_eq!(it.read().unwrap().unwrap().doc_id, DOC_IDS[0]);
+        assert_eq!(it.read().unwrap().unwrap().doc_id, DOC_IDS[1]);
+
+        let suspended = it.suspend();
+        fixture.remove_document::<DocIdsOnly>(DOC_IDS[1]);
+
+        let guard = fixture.ctx.spec_read();
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Moved(a) => a,
+            ResumeOutcome::Ok(_) => panic!("expected Moved, got Ok"),
+            ResumeOutcome::Aborted => panic!("expected Moved, got Aborted"),
+        };
+        assert_eq!(
+            active
+                .current()
+                .expect("a moved iterator answers `current`")
+                .doc_id,
+            DOC_IDS[2],
+            "the resume settles on the next surviving document",
+        );
+        assert_eq!(active.read().unwrap().unwrap().doc_id, DOC_IDS[3]);
+    }
+}


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `OptimizedWildcard` — the wildcard iterator reading the existing-docs inverted index — has no suspended counterpart, so neither it nor the enums that wrap it can be held across a release of the index spec read lock.
2. Change: it implements `RQEIteratorBoxed::suspend` / `RQESuspendedIterator::resume`. The enum is re-shaped into a `Ref`-mode-parametrized `RawOptimizedWildcard`, so suspending is a layout-preserving reinterpretation of the same allocation rather than a rebuild, with each arm's inverted-index wildcard transitioned in place. Same shape as #10894's `RawNumericIteratorVariant`; the legacy `revalidate` is unchanged.
3. Outcome: no user-visible change — the pipeline does not suspend iterators yet. This is a per-iterator prerequisite for that wiring, and it unblocks the rest of the wildcard family (`DiskWildcardIterator`, `NewWildcardIterator`) and any composite over wildcard children.

#### Which additional issues this PR fixes

1. MOD-17684

#### Main objects this PR modified

1. `RawOptimizedWildcard<'query, Rf>` plus the `OptimizedWildcard` / `OptimizedWildcardSuspended` aliases — one generic enum rather than a hand-maintained pair, so variant order and tag encoding agree by construction. The `const` proof asserts what is left: arm correspondence (an `IsSame` witness that suspending an arm yields exactly the matching arm) and per-arm plus whole-enum layout identity.
2. `suspend` / `resume` on the enum — reuse the heap allocation so external borrows into the iterator's interior stay valid, and drive each arm through the shared child-slot helpers.
3. The revalidation decision, which stays the arm's own: abort when the GC nulled out or replaced `existingDocs`, `Moved` when the current document was collected, `Ok` otherwise. Stating it in the wrapper as well is what would let the two drift apart.
4. `inverted_index` visibility — `core`, and `RawWildcard`'s `it` field and `should_abort`, go back to private now that the wrapper reaches the arm through its trait impl instead of past it.
5. `tests/integration/wildcard.rs` — round trip per variant (box-address stability, and that the cast lands on the same variant), plus the nulled, replaced, and current-document-collected cases against a real existing-docs index.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
