### PR TITLE
[Iterator Revalidation] Intersection: suspend/resume

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/src/intersection.rs
@@ -14,13 +14,18 @@
 //! - `in_order`: Require terms to appear in order
 
 use crate::{
-    IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+    boxed::{
+        ResumeSlotOutcome, assert_layout_compatible, resume_child_slot_in_place,
+        suspend_child_slot_in_place,
+    },
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 
-use index_result::{RSIndexResult, RawIndexResult};
+use index_result::{RSIndexResult, RSResultKind, RawIndexResult};
 use index_spec::IndexSpecReadGuard;
-use ref_mode::{Active, Ref};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
 /// Yields documents appearing in ALL child iterators using a merge (AND) algorithm.
@@ -58,6 +63,92 @@ pub struct RawIntersection<'query, Rf: Ref, I> {
 /// Alias for an [`Active`] [`RawIntersection`] — the only instantiation
 /// with an [`RQEIterator`] impl today.
 pub type Intersection<'index, I> = RawIntersection<'index, Active<'index>, I>;
+
+// Compile-time proof of invariant 1 on `RawIntersection`: for a representative
+// concrete child, the `Active` and `Suspended` instantiations are
+// layout-identical. The child elements' own compatibility is their invariant 1
+// (enforced generically by the slot helpers); `result` is layout-compatible
+// across `Rf` (proven in `index_result`); the remaining fields are `Rf`-free.
+const _: () = {
+    use crate::Wildcard;
+    use std::mem::{align_of, offset_of, size_of};
+    type AChild = Wildcard<'static>;
+    type SChild = <Wildcard<'static> as RQEIteratorBoxed<'static>>::Suspended;
+    type A = RawIntersection<'static, Active<'static>, AChild>;
+    type S = RawIntersection<'static, Suspended, SChild>;
+    assert!(offset_of!(A, children) == offset_of!(S, children));
+    assert!(offset_of!(A, last_doc_id) == offset_of!(S, last_doc_id));
+    assert!(offset_of!(A, num_expected) == offset_of!(S, num_expected));
+    assert!(offset_of!(A, is_eof) == offset_of!(S, is_eof));
+    assert!(offset_of!(A, max_slop) == offset_of!(S, max_slop));
+    assert!(offset_of!(A, in_order) == offset_of!(S, in_order));
+    assert!(offset_of!(A, result) == offset_of!(S, result));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
+/// Frees a suspended [`RawIntersection`]'s reused allocation after the in-place
+/// resume consumed the child at `consumed`: drops every other child in place —
+/// resumed forms before it, still-suspended ones after it — empties the `Vec` so
+/// it frees only its buffer, then drops the box (freeing the still-suspended
+/// `result` and the allocation).
+///
+/// A panic out of one of the element drops aborts nothing here: every element is
+/// either dropped exactly once before the unwind or leaked with the box, so no
+/// double-drop is possible.
+///
+/// # Safety
+///
+/// * `raw` must be exclusively owned and have come from `Box::into_raw`.
+/// * `children[..consumed]` must hold valid `S::Resumed<'a>` values,
+///   `children[consumed]` must be moved-from (it is not touched), and
+///   `children[consumed + 1..]` must hold valid `S` values — the exact state the
+///   in-place resume loop leaves behind when the helper reports
+///   `Aborted`/`Err` for element `consumed`.
+unsafe fn free_after_consumed_child<'query, 'a, S>(
+    raw: *mut RawIntersection<'query, Suspended, S>,
+    consumed: usize,
+) where
+    S: RQESuspendedIterator<'query>,
+    'query: 'a,
+{
+    // The prefix is dropped through `S::Resumed<'a>` while the `Vec`'s element
+    // type is still `S`, so that cast needs the same size/alignment guarantee
+    // `resume_child_slot_in_place` enforces for its own `ptr::write`. Assert it
+    // here too rather than inheriting it: a mismatched implementer must fail to
+    // compile at *this* cast, not only at the one that produced the slots.
+    const { assert_layout_compatible::<S, S::Resumed<'a>>() };
+
+    // SAFETY: `raw` is exclusively owned (caller contract); the borrow is used
+    // only to reach the buffer pointer, the length, and `set_len`.
+    let children: &mut Vec<S> = unsafe { &mut (*raw).children };
+    let len = children.len();
+    let base = children.as_mut_ptr();
+    for i in 0..len {
+        if i == consumed {
+            continue;
+        }
+        // SAFETY: `i` is in bounds of the children buffer.
+        let slot = unsafe { base.add(i) };
+        if i < consumed {
+            // SAFETY: the slot holds a valid resumed child; drop it through the
+            // resumed type (same size/alignment, enforced by the const guard at
+            // the top of this function).
+            unsafe { std::ptr::drop_in_place(slot.cast::<S::Resumed<'a>>()) };
+        } else {
+            // SAFETY: the slot still holds a valid suspended child.
+            unsafe { std::ptr::drop_in_place(slot) };
+        }
+    }
+    // SAFETY: every element was dropped (or consumed by the failed resume);
+    // zeroing the length keeps the `Vec` from dropping them again — it frees
+    // only its buffer.
+    unsafe { children.set_len(0) };
+    // SAFETY: `raw` is a well-formed suspended intersection again (empty
+    // children, still-suspended `result`, `Rf`-free scalars); reclaim the
+    // allocation and drop it.
+    drop(unsafe { Box::from_raw(raw) });
+}
 
 /// Result of attempting to get all children to agree on a target document ID.
 enum AgreeResult {
@@ -579,6 +670,422 @@ where
 
     fn intersection_sort_weight(&self, _prioritize_union_children: bool) -> f64 {
         1.0 / self.children.len().max(1) as f64
+    }
+}
+
+impl<'index, I> RQEIteratorBoxed<'index> for Intersection<'index, I>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawIntersection<'index, Suspended, I::Suspended>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Walk children: dispatch each child's `suspend` through the trait so
+        // dyn-erased `I` (e.g. [`TypeErasedRQEIterator`](crate::TypeErasedRQEIterator),
+        // whose active and suspended forms carry different vtables) correctly
+        // transitions. For concrete-typed `I` this is the same whole-box cast
+        // that the outer composite would otherwise have done, just per-child
+        // instead of per-composite. Either way the inner concrete iterator's
+        // heap address is preserved; only the wrapper bytes (which nothing
+        // external points at) are re-typed.
+        //
+        // The buffer pointer and length are taken up front, mirroring `resume`:
+        // no typed `&mut Vec<I>` stays live across the loop that retypes the
+        // slots it would describe.
+        let (base, len) = {
+            // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+            // initialised, exclusively owned); the borrow is used only to reach
+            // the buffer pointer and length.
+            let children: &mut Vec<I> = unsafe { &mut (*raw).children };
+            (children.as_mut_ptr(), children.len())
+        };
+        for i in 0..len {
+            // SAFETY: `i` is in bounds of the children buffer.
+            let slot = unsafe { base.add(i) };
+            // SAFETY: `slot` holds a valid, owned `I`; the helper leaves it in
+            // a valid `I::Suspended` state.
+            unsafe { suspend_child_slot_in_place(slot) };
+        }
+        // SAFETY: every child slot now holds its suspended form at its original
+        // address, so the aggregate's entries — pointers into those slots'
+        // result objects — still refer to live objects; the remaining fields
+        // are `Rf`-free. Layout-identical to the active form by invariant 1 on
+        // `RawIntersection` (const proof above), whose child-slot half — the
+        // `I`/`I::Suspended` size and alignment match — is statically enforced
+        // by `suspend_child_slot_in_place`. `Box::from_raw` reuses the same
+        // allocation, so the box and every interior address survive the cycle.
+        unsafe { Box::from_raw(raw as *mut RawIntersection<'index, Suspended, I::Suspended>) }
+    }
+}
+
+/// Whether every child still backs the rebuilt aggregate.
+///
+/// An intersection publishes a document only when *all* of its children agree on
+/// it, so — unlike a union, which is content with one — anything short of a full
+/// house means the result no longer describes a consensus.
+///
+/// `#[must_use]` sits on the type so it covers every producer: an
+/// [`Incomplete`](Self::Incomplete) that nobody looks at is a consensus
+/// published without the children that were supposed to have reached it.
+#[must_use = "an incomplete aggregate no longer describes a consensus; the \
+              caller must rebuild it or abort the resume"]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RebuildOutcome {
+    /// Every child answered, so the aggregate borrows all of them. The result
+    /// stands as a description of its document, and re-narrowing it is sound.
+    Complete,
+    /// At least one child no longer publishes a result on the intersection's
+    /// document, so the aggregate came out short. Re-narrowing it is still sound
+    /// — every entry it does hold was taken from a live child — but it no longer
+    /// describes a consensus, so the intersection must rebuild it before
+    /// publishing it or report [`ResumeOutcome::Aborted`] instead.
+    Incomplete,
+}
+
+/// Rebuild a suspended intersection's borrowed entries from its just-resumed
+/// children.
+///
+/// The aggregate borrows one entry per child, and each entry is a pointer
+/// derived from a borrow of that child's result. Transitioning a child hands its
+/// allocation through a by-value `Box<Self>`, whose retag invalidates that
+/// borrow even though nothing was dropped, moved or written — so every entry has
+/// to be written afresh before the intersection's own allocation is re-narrowed.
+/// This is that step, and it is not optional.
+///
+/// # Why rebuild rather than re-derive
+///
+/// The alternative is to keep the entry list and refresh each entry in place,
+/// matching entries to children by address. An intersection has no use for that
+/// machinery, because it already knows the answer: it publishes a document only
+/// once [`agree_on_doc_id`](RawIntersection::agree_on_doc_id) reports that
+/// *every* child sits on it, so
+/// [`build_aggregate_result`](RawIntersection::build_aggregate_result) pushes
+/// one entry per child, in slot order, and a child never leaves its slot — an
+/// aborting child aborts the whole intersection rather than being compacted
+/// over. Entry *i* is child *i*, by construction, for as long as the result
+/// lives.
+///
+/// Matching by address would therefore re-derive a mapping that is already
+/// positional, at a cost the shape of an intersection makes worst-case: every
+/// child is on the document, so a scan of the entries per live child is
+/// quadratic in the full fan-out on every resume, where pushing them back is
+/// linear.
+///
+/// # What is recomputed, and what is carried across
+///
+/// `freq` and `field_mask` are recomputed. They are copies of what each child
+/// holds, so they are functions of the same child set as the entries;
+/// recomputing them together is what keeps the two from disagreeing.
+///
+/// `metrics` are carried across untouched, because they are *not* a function of
+/// the children: [`RSIndexResult::push_borrowed`] **moves** a child's metrics
+/// into the intersection when the aggregate is first built, leaving the child
+/// with none. There is nothing to re-accumulate, so resetting them would discard
+/// them for good — a KNN child's `__vector_score` vanishing from the reply.
+///
+/// `doc_id` is likewise untouched: it is the document the rebuild is *for*, and
+/// the input to the per-child test rather than an output of it. It is read
+/// before anything is cleared, so the clearing step cannot quietly become the
+/// one that takes it away.
+///
+/// # Call it last
+///
+/// Not merely "before the cast": **after** the child walk, and with no `&mut`
+/// taken to a child afterwards. Each entry is derived from a shared reborrow of
+/// a `&mut` to its child, so any later mutable access to that child — a `read`,
+/// a `skip_to`, another `current`, an `iter_mut` over the children — pops the
+/// tag it carries. `&mut` to the intersection itself is fine; the entries point
+/// into the *children's* allocations.
+fn rebuild_borrowed_entries<'a, R>(
+    result: &mut RawIndexResult<'a, Suspended>,
+    children: &mut [R],
+) -> RebuildOutcome
+where
+    R: RQEIterator<'a>,
+{
+    let expected = children.len();
+    let doc_id = result.doc_id;
+    let Some(aggregate) = result
+        .as_aggregate_mut()
+        .and_then(|aggregate| aggregate.as_borrowed_mut())
+    else {
+        // Nothing borrowed here: not an aggregate at all, or an owned one whose
+        // children live in the result's own allocation. Either way there is
+        // nothing to rebuild
+        // and nothing for the caller to make good. `Incomplete` here would
+        // oblige it to abort a resume that never had entries at stake.
+        return RebuildOutcome::Complete;
+    };
+    if aggregate.is_empty() {
+        // Nothing borrowed, so again nothing to rebuild, and no reason to touch
+        // a single child. This is the intersection that was suspended before its
+        // first read: its result is an empty aggregate on document 0, which no
+        // child would answer for.
+        return RebuildOutcome::Complete;
+    }
+
+    // Drops the records and the kind mask; `push_borrowed_ptr_from_ref` rebuilds
+    // both, entry by entry. Deliberately not `reset_aggregate`, which would also
+    // take `doc_id` — read above, and what the loop below tests each child
+    // against — and the metrics, which cannot be put back. See
+    // `# What is recomputed` above.
+    aggregate.reset();
+    result.freq = 0;
+    result.field_mask = 0;
+
+    let mut backing = 0;
+    for child in children.iter_mut() {
+        // A child at EOF publishes no result, and one whose own resume carried
+        // it off the agreed document no longer backs the consensus. Either way
+        // the aggregate comes out short, which is what the caller is told.
+        let Some(current) = child.current() else {
+            continue;
+        };
+        if current.doc_id != doc_id {
+            continue;
+        }
+        // The entry is taken from a shared reborrow, so the tag it carries stays
+        // valid for as long as nothing takes `&mut` to this child again. The
+        // loop only ever moves on to a *different* child, and the intersection
+        // takes none after this call returns.
+        let current: &RSIndexResult<'a> = &*current;
+
+        result.freq += current.freq;
+        result.field_mask |= current.field_mask;
+        result
+            .as_aggregate_mut()
+            .and_then(|aggregate| aggregate.as_borrowed_mut())
+            .expect("the result borrowed an aggregate a handful of statements ago")
+            .push_borrowed_ptr_from_ref(current);
+        backing += 1;
+    }
+
+    if backing == expected {
+        RebuildOutcome::Complete
+    } else {
+        RebuildOutcome::Incomplete
+    }
+}
+
+impl<'query, S> RQESuspendedIterator<'query> for RawIntersection<'query, Suspended, S>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = Intersection<'a, S::Resumed<'a>>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // `current()` hands the result out mutably, so "still the intersection's
+        // own aggregate" is a runtime invariant rather than an enforced one — a
+        // consumer could have replaced it with a result the intersection never
+        // built. Nothing below would notice: `rebuild_borrowed_entries` has
+        // nothing to rebuild for a payload that borrows no children, so it
+        // reports success, and the cast would then re-narrow whatever suspended
+        // pointers the substitute holds without re-validating them. An
+        // intersection has no way to re-validate a payload it did not build, so
+        // it refuses, on `&self`, before `Box::into_raw` opens the raw-pointer
+        // section — the same shape `Optional` and `NotOptimized` use for their
+        // virtual sentinels.
+        //
+        // The kind alone is not enough. An aggregate of kind `Intersection` can
+        // be the *owned* representation, whose children are boxed into the
+        // result's own allocation and are never transitioned. Safe code can
+        // build one — `to_owned()` on an intersection result, `push_boxed` an
+        // index-backed term into it, assign it through `current()` — and a boxed
+        // child's `data` can be index-backed and suspended, so re-narrowing it
+        // would promote pointers nothing re-validated. Demanding the borrowed
+        // representation is what closes that.
+        let is_borrowed_intersection = self.result.kind() == RSResultKind::Intersection
+            && self
+                .result
+                .as_aggregate()
+                .is_some_and(|aggregate| aggregate.as_borrowed().is_some());
+        if !is_borrowed_intersection {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        let raw = Box::into_raw(self);
+
+        // Resume every child *in place*, mirroring `Intersection::revalidate`'s
+        // walk: any child aborting aborts the whole intersection (an
+        // intersection missing a child yields nothing); otherwise track whether
+        // anything moved and the furthest live position.
+        //
+        // The children never leave their slots, so the suspended aggregate's
+        // weakened pointers still designate their result objects afterwards —
+        // but only the addresses survive a child's transition, so the entries are
+        // re-derived from the resumed children below before the box is
+        // reinterpreted; their *contents* can be stale too, and the
+        // revalidate-mirroring decisions further down re-derive those. A panic
+        // between slot transitions leaks the allocation (memory-safe); the slot
+        // helper guards its own moved-out window.
+        //
+        let (base, len) = {
+            // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+            // initialised, exclusively owned); the borrow is used only to reach
+            // the buffer pointer and length.
+            let children: &mut Vec<S> = unsafe { &mut (*raw).children };
+            (children.as_mut_ptr(), children.len())
+        };
+
+        let mut any_child_moved = false;
+        let mut max_child_doc_id: DocId = 0;
+        let mut moved_to_eof = false;
+        for i in 0..len {
+            // SAFETY: `i` is in bounds of the children buffer.
+            let elem = unsafe { base.add(i) };
+            // SAFETY: `elem` holds a valid, owned `S`; the helper rewrites it as
+            // a valid `S::Resumed<'a>` on `Unchanged`/`Moved`, and consumes it
+            // on `Aborted`/`Err` (torn down below).
+            match unsafe { resume_child_slot_in_place(elem, guard) } {
+                Ok(ResumeSlotOutcome::Unchanged) => {}
+                Ok(ResumeSlotOutcome::Moved) => {
+                    any_child_moved = true;
+                    // `revalidate` reads the post-move position out of the
+                    // `RQEValidateStatus::Moved { current }` payload; the slot
+                    // helper hands back no result, so it is read off the resumed
+                    // child instead. The two are equivalent by the
+                    // `current()`/`at_eof()` contract: `current()` is `None`
+                    // exactly when the child is at EOF.
+                    //
+                    // Testing `at_eof()` *before* `last_doc_id()` is what makes
+                    // that equivalence hold. A child whose re-seek ran past the
+                    // end reports `last_doc_id() == 0`, so reading the position
+                    // first would fold it into `max_child_doc_id` as "moved
+                    // nowhere" instead of ending the intersection.
+                    //
+                    // SAFETY: the helper just rewrote the slot as a valid
+                    // `S::Resumed<'a>`.
+                    let resumed = unsafe { &*elem.cast::<S::Resumed<'a>>().cast_const() };
+                    if resumed.at_eof() {
+                        moved_to_eof = true;
+                    } else {
+                        max_child_doc_id = max_child_doc_id.max(resumed.last_doc_id());
+                    }
+                }
+                Ok(ResumeSlotOutcome::Aborted) => {
+                    // SAFETY: slots before `i` are resumed, slot `i` was
+                    // consumed, slots after it are still suspended — the exact
+                    // state the teardown documents; `raw` is exclusively owned.
+                    unsafe { free_after_consumed_child::<S>(raw, i) };
+                    return Ok(ResumeOutcome::Aborted);
+                }
+                Err(e) => {
+                    // SAFETY: as above.
+                    unsafe { free_after_consumed_child::<S>(raw, i) };
+                    return Err(e);
+                }
+            }
+        }
+
+        // Every child now sits in its slot in its resumed form, so the aggregate
+        // can be rebuilt from them — the step that makes its entries usable
+        // again, rather than merely re-narrowed, and the last one before the
+        // cast. Every child is offered and every child is expected to answer:
+        // an intersection publishes a document only once all of them agree on
+        // it, so anything short of a full house is a consensus it can no longer
+        // show.
+        let rebuilt = {
+            // SAFETY: `base` addresses `len` consecutive slots, each rewritten by
+            // the loop above as a valid `S::Resumed<'a>` — same size and
+            // alignment as the `S` the buffer was allocated for, statically
+            // enforced by `resume_child_slot_in_place` — and `raw` is
+            // exclusively owned, so the slice is unaliased.
+            let children =
+                unsafe { std::slice::from_raw_parts_mut(base.cast::<S::Resumed<'a>>(), len) };
+            // Viewed at `'a` rather than at `'query`. Narrowing a query lifetime
+            // is the safe direction — `'query: 'a` — but `&mut` is invariant, so
+            // the compiler will not do it for us and the pointer is re-cast
+            // instead. It is what lets the rebuild tie each entry to the same
+            // lifetime the children carry, rather than widening theirs to
+            // `'query`.
+            //
+            // SAFETY: `raw` is exclusively owned and `result` is a valid
+            // suspended result in a field disjoint from the children buffer; the
+            // borrow is confined to this block. `RawIndexResult` differs between
+            // the two lifetimes only in the query-pipeline pointers it claims,
+            // and `'query: 'a` makes every one of them valid for `'a`.
+            //
+            // SAFETY: `raw` is exclusively owned and non-null, so projecting to
+            // its `result` field is in bounds; no reference is created here.
+            let result_ptr = unsafe { &raw mut (*raw).result };
+            // SAFETY: the projection above is valid, aligned and initialised, and
+            // the two lifetimes differ only in the claim described above.
+            let result: &mut RawIndexResult<'a, Suspended> =
+                unsafe { &mut *result_ptr.cast::<RawIndexResult<'a, Suspended>>() };
+            rebuild_borrowed_entries(result, children)
+        };
+
+        // SAFETY: every child slot holds its resumed form at its original
+        // address, and the aggregate's entries have just been rebuilt from
+        // those resumed children, so re-narrowing them yields
+        // references that are both live and usable (contents re-derived below
+        // where they can have changed); the remaining fields are `Rf`-free.
+        // Layout-identical to the suspended form by invariant 1 on
+        // `RawIntersection` (const proof above). `Box::from_raw` reuses the same
+        // allocation, so the FFI's cached `header.current` and any parent's
+        // pointer into `result` stay valid across the cycle.
+        let mut active = unsafe { Box::from_raw(raw.cast::<Intersection<'a, S::Resumed<'a>>>()) };
+
+        // From here on, mirror `revalidate` decision for decision. Nothing moved
+        // (or the intersection had already ended): the children still sit on the
+        // positions the aggregate describes, so it stands as-is.
+        if !any_child_moved || active.is_eof {
+            // Unless it does not. An incomplete aggregate keeps the position but
+            // can no longer show every child behind it, and this is the one path
+            // that hands the result straight back — there is no re-seek below it
+            // to rebuild what came out short. An intersection that cannot
+            // account for one of its children could not have agreed on the
+            // document anyway, so it aborts rather than publish a consensus it
+            // can no longer show. (An intersection already at EOF publishes no
+            // `current`, so a short aggregate has no observer there and
+            // `revalidate`'s `Ok` is still the faithful answer.)
+            //
+            // Believed unreachable with conforming children on the non-EOF arm,
+            // and asserted rather than assumed: every child reported `Unchanged`
+            // and none can leave its slot, so each still sits on the document
+            // they had agreed on. Coming out short means a child broke
+            // `Unchanged`'s promise to hold its position.
+            debug_assert!(
+                active.is_eof || rebuilt == RebuildOutcome::Complete,
+                "an intersection whose children all resumed unchanged cannot lose one",
+            );
+            if rebuilt == RebuildOutcome::Incomplete && !active.is_eof {
+                return Ok(ResumeOutcome::Aborted);
+            }
+            return Ok(ResumeOutcome::Ok(active));
+        }
+
+        // At least one child moved past its end — the intersection can't continue.
+        // `is_eof` suppresses `current`, so a short aggregate stays unobserved.
+        if moved_to_eof {
+            active.is_eof = true;
+            return Ok(ResumeOutcome::Moved(active));
+        }
+
+        // Some children moved forward. Advance to the furthest one and find the
+        // next common document from there; `skip_to` republishes the aggregate —
+        // which is also what makes an `Incomplete` harmless here — and an `Err`
+        // propagates exactly as it does out of `revalidate`.
+        active.skip_to(max_child_doc_id)?;
+        Ok(ResumeOutcome::Moved(active))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.last_doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.num_expected
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/intersection.rs
@@ -558,9 +558,9 @@ fn many_children() {
 fn revalidate_ok() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     // Create mock children with const generic arrays
-    let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
-    let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
-    let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+    let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+    let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
 
     // Set all children to return OK on revalidate (default, but explicit)
     child0
@@ -601,9 +601,9 @@ fn revalidate_ok() {
 #[test]
 fn revalidate_aborted() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
-    let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
-    let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+    let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+    let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
 
     // Child 1 will abort
     child0
@@ -636,9 +636,9 @@ fn revalidate_aborted() {
 #[test]
 fn revalidate_moved() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
-    let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
-    let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+    let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+    let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
 
     // All children will move (advance by one document)
     child0
@@ -682,9 +682,9 @@ fn revalidate_moved() {
 #[test]
 fn revalidate_mixed_results() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
-    let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
-    let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+    let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+    let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
 
     // Mixed: OK, MOVED, OK
     child0
@@ -719,9 +719,9 @@ fn revalidate_mixed_results() {
 fn revalidate_after_eof() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
     // Pre-set children to return MOVE on revalidate
-    let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
-    let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
-    let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+    let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+    let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
 
     child0
         .data()
@@ -768,10 +768,10 @@ fn revalidate_some_children_moved_to_eof() {
     // Child 0 and 2 have normal data, child 1 is small (only 2 elements: [10, 20])
     // When we read doc 10 and then call Move, child 1 moves to 20 and the next Move
     // would go to EOF
-    let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
     // Child 1 has only doc 10 - after reading it, Move will result in EOF
-    let child1: Mock<'static, 1> = Mock::new([10]);
-    let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+    let child1: Mock<'_, 1> = Mock::new([10]);
+    let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
 
     // Child 0: OK, Child 1: moves (to EOF since only 1 element), Child 2: OK
     child0
@@ -934,9 +934,9 @@ fn overlapping_children_ids() {
 #[test]
 fn revalidate_before_read() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
-    let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
-    let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+    let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+    let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
 
     // All children return OK on revalidate
     child0
@@ -972,9 +972,9 @@ fn revalidate_before_read() {
 #[test]
 fn revalidate_move_before_read() {
     let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
-    let child0: Mock<'static, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
-    let child1: Mock<'static, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
-    let child2: Mock<'static, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+    let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+    let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
 
     // All children will move
     child0
@@ -1107,9 +1107,9 @@ fn revalidate_moved_skip_to_returns_none() {
     // - child0 has no doc >= 18, so it goes EOF
     // - Result: None
 
-    let child0: Mock<'static, 2> = Mock::new([10, 15]);
-    let child1: Mock<'static, 2> = Mock::new([10, 18]);
-    let child2: Mock<'static, 2> = Mock::new([10, 22]);
+    let child0: Mock<'_, 2> = Mock::new([10, 15]);
+    let child1: Mock<'_, 2> = Mock::new([10, 18]);
+    let child2: Mock<'_, 2> = Mock::new([10, 22]);
 
     // All children will move
     child0
@@ -1156,6 +1156,928 @@ fn revalidate_moved_skip_to_returns_none() {
     assert!(matches!(ii.read(), Ok(None)));
 }
 
+mod via_resume {
+    use super::*;
+    use rqe_iterators::{ResumeOutcome, TypeErasedRQEIterator};
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    fn boxed_children<'spec, const N0: usize, const N1: usize, const N2: usize>(
+        c0: Mock<'spec, N0>,
+        c1: Mock<'spec, N1>,
+        c2: Mock<'spec, N2>,
+    ) -> Vec<TypeErasedRQEIterator<'spec>> {
+        vec![
+            TypeErasedRQEIterator::new(Box::new(c0)),
+            TypeErasedRQEIterator::new(Box::new(c1)),
+            TypeErasedRQEIterator::new(Box::new(c2)),
+        ]
+    }
+
+    #[test]
+    fn revalidate_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+        let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+        let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = boxed_children(child0, child1, child2);
+        let mut ii = Intersection::new(children, 1.0, false);
+
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 10);
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 20);
+
+        let guard = mock_ctx.spec_read();
+        let mut ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 30);
+    }
+
+    /// An aborting child tears the reused allocation down through
+    /// `free_after_consumed_child`, whose loop splits at the consumed index:
+    /// slots before it are dropped as *resumed* children, slots after it as
+    /// still-*suspended* ones. Aborting at index 0 leaves the resumed prefix
+    /// empty and at the last index leaves the suspended suffix empty — the two
+    /// off-by-one shapes that a single middle-child case never reaches. The
+    /// mocks' `Rc<RefCell<..>>` state makes a missed or duplicated drop
+    /// observable to miri.
+    #[test]
+    fn revalidate_aborted() {
+        for aborting in 0..3 {
+            let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+            let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+            let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+            let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+            for (i, data) in [child0.data(), child1.data(), child2.data()]
+                .iter_mut()
+                .enumerate()
+            {
+                data.set_revalidate_result(if i == aborting {
+                    MockRevalidateResult::Abort
+                } else {
+                    MockRevalidateResult::Ok
+                });
+            }
+
+            let children = boxed_children(child0, child1, child2);
+            let mut ii = Intersection::new(children, 1.0, false);
+
+            let result = ii.read().expect("read").unwrap();
+            assert_eq!(result.doc_id, 10);
+
+            let guard = mock_ctx.spec_read();
+            let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+                .expect("resume failed");
+            assert!(
+                matches!(outcome, ResumeOutcome::Aborted),
+                "child {aborting} aborting must abort the intersection",
+            );
+        }
+    }
+
+    /// `resume` hands the aggregate back across the cycle rather than rebuilding
+    /// it, so every entry must still *reach* its child afterwards. Every other
+    /// `Ok`-path test calls `read()` first, which resets and rebuilds the
+    /// aggregate, so a broken entry would be overwritten before anything read it.
+    /// Dereference every entry here instead, in the window between the resume and
+    /// the next read — the window a scorer walking `current()` occupies in
+    /// production.
+    ///
+    /// Run under miri this is also the regression test for the entries'
+    /// *provenance*, which is the half a plain read cannot see: the addresses
+    /// survive a child's transition on their own, the borrows they were derived
+    /// from do not, and only `resume`'s re-derivation of the entries makes them
+    /// usable rather than merely well-addressed.
+    #[test]
+    fn resume_ok_leaves_the_aggregate_pointing_at_live_children() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+        let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+        let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+        // Nothing moves, so `resume` carries the aggregate across untouched —
+        // the case its liveness obligation rests on entirely.
+        for data in [child0.data(), child1.data(), child2.data()].iter_mut() {
+            data.set_revalidate_result(MockRevalidateResult::Ok);
+        }
+
+        let children = boxed_children(child0, child1, child2);
+        let mut ii = Intersection::new(children, 1.0, false);
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let current = ii
+            .current()
+            .expect("an unchanged intersection is still positioned");
+        assert_eq!(current.doc_id, 10);
+        let aggregate = current
+            .as_aggregate()
+            .expect("an intersection publishes an aggregate result");
+        assert_eq!(aggregate.len(), 3, "one entry per child");
+        for i in 0..aggregate.len() {
+            let entry = aggregate.get(i).expect("index below len");
+            assert_eq!(
+                entry.doc_id, 10,
+                "entry {i} must still reach its child's live result",
+            );
+        }
+
+        // Only now let a read rebuild the aggregate from scratch.
+        let next = ii.read().expect("read").unwrap();
+        assert_eq!(next.doc_id, 20);
+    }
+
+    /// The rebuild recomputes `freq` and `field_mask` from the children it
+    /// re-pushes, so a published intersection never claims a frequency or a set
+    /// of fields that its own entries do not account for. `field_mask` is the
+    /// one that bites if it drifts — it decides field filtering and
+    /// field-weighted scoring, so an over-broad mask lets a document through a
+    /// filter no live child matches.
+    ///
+    /// Asserted as agreement between the result and its entries rather than
+    /// against literals, because that is the invariant: whatever the children
+    /// hold, the two must say the same thing. The entry count is asserted
+    /// against the child count for the same reason — an intersection's result is
+    /// backed by *every* child, not by some of them.
+    #[test]
+    fn resume_leaves_the_aggregate_agreeing_with_its_entries() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 3> = Mock::new([10, 20, 30]);
+        let child1: Mock<'_, 3> = Mock::new([10, 20, 40]);
+        let child2: Mock<'_, 3> = Mock::new([10, 20, 50]);
+        for data in [child0.data(), child1.data(), child2.data()].iter_mut() {
+            data.set_revalidate_result(MockRevalidateResult::Ok);
+        }
+
+        let mut ii = Intersection::new(boxed_children(child0, child1, child2), 1.0, false);
+        assert_eq!(ii.read().expect("read").unwrap().doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let current = ii
+            .current()
+            .expect("an unchanged intersection is still positioned");
+        let aggregate = current
+            .as_aggregate()
+            .expect("an intersection publishes an aggregate result");
+        assert_eq!(
+            aggregate.len(),
+            3,
+            "every child backs the consensus, so every child has an entry",
+        );
+
+        let mut freq = 0;
+        let mut field_mask = 0;
+        for i in 0..aggregate.len() {
+            let entry = aggregate.get(i).expect("index below len");
+            assert_eq!(entry.doc_id, 10, "entry {i} is on the agreed document");
+            freq += entry.freq;
+            field_mask |= entry.field_mask;
+        }
+        assert_eq!(current.freq, freq, "freq must be the sum over the entries");
+        assert_eq!(
+            current.field_mask, field_mask,
+            "field_mask must be the union over the entries",
+        );
+    }
+
+    /// Metrics survive the rebuild, because they cannot be rebuilt.
+    ///
+    /// Unlike `freq` and `field_mask`, which are copied from each child,
+    /// `RSIndexResult::push_borrowed` **moves** a child's metrics into the
+    /// aggregate — so by the time a resume runs, the children hold none and
+    /// there is nothing to re-accumulate. The rebuild therefore clears the
+    /// records alone and carries `metrics` across; reaching for
+    /// `reset_aggregate` instead would read as tidier and would discard them for
+    /// good, taking `__vector_score` out of a hybrid query's reply on every
+    /// suspend/resume cycle.
+    #[test]
+    fn resume_keeps_the_metrics_the_aggregate_gathered() {
+        use rqe_iterators::metric::MetricSortedById;
+
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let scored = MetricSortedById::new(vec![100u64], vec![0.5]);
+        let sibling: Mock<'_, 2> = Mock::new([100, 200]);
+        sibling
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(scored)),
+            TypeErasedRQEIterator::new(Box::new(sibling)),
+        ];
+        let mut ii = Intersection::new(children, 1.0, false);
+        let first = ii.read().expect("read").expect("doc 100");
+        assert_eq!(first.doc_id, 100);
+        assert_eq!(
+            first.metrics.len(),
+            1,
+            "the aggregate gathered the scored child's metric",
+        );
+
+        let guard = mock_ctx.spec_read();
+        let mut ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let current = ii.current().expect("still on doc 100");
+        assert_eq!(current.doc_id, 100);
+        assert_eq!(
+            current.metrics.len(),
+            1,
+            "the metric must survive a rebuild of the document it was gathered for",
+        );
+    }
+
+    /// An intersection that no longer holds the aggregate it built cannot
+    /// resume: it has no way to re-validate a payload it did not create, so it
+    /// refuses rather than re-narrow the substitute's suspended pointers. The
+    /// intersection counterpart of
+    /// `union_flat::via_resume::resume_aborts_when_the_result_is_no_longer_a_union`.
+    ///
+    /// The owned `Intersection` is the case a kind check alone cannot reject:
+    /// same `kind()`, but its children are boxed into the result's own
+    /// allocation and are never transitioned, so re-narrowing would promote
+    /// whatever index-backed pointers they hold. Safe code can build one with
+    /// `to_owned()` and assign it through `current()`.
+    #[test]
+    fn resume_aborts_when_the_result_is_no_longer_an_intersection() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+
+        let borrowed_src = index_result::RSIndexResult::build_intersect(1).build();
+        let owned_intersection = borrowed_src.to_owned();
+        for substitute in [
+            index_result::RSIndexResult::build_numeric(1.0).build(),
+            index_result::RSIndexResult::build_hybrid_metric().build(),
+            owned_intersection,
+        ] {
+            let child0: Mock<'_, 2> = Mock::new([10, 30]);
+            let child1: Mock<'_, 2> = Mock::new([10, 30]);
+            let child2: Mock<'_, 2> = Mock::new([10, 30]);
+            let mut ii = Box::new(Intersection::new(
+                boxed_children(child0, child1, child2),
+                1.0,
+                false,
+            ));
+
+            let current = ii.read().expect("read").expect("doc 10");
+            assert_eq!(current.doc_id, 10);
+            // A consumer swaps what `current()` handed out for something the
+            // intersection never built.
+            let kind = substitute.kind();
+            *current = substitute;
+
+            let suspended = <Intersection<'_, _> as rqe_iterators::RQEIteratorBoxed>::suspend(ii);
+            assert!(
+                matches!(
+                    rqe_iterators::RQESuspendedIterator::resume(suspended, &guard)
+                        .expect("no error"),
+                    ResumeOutcome::Aborted
+                ),
+                "a {kind:?} result must abort the resume, not be re-narrowed",
+            );
+        }
+    }
+
+    /// The suspend/resume cycle must reuse the allocation: the FFI wrapper and
+    /// delegating parents cache raw pointers into the iterator's storage, and a
+    /// rebuilt box would dangle them.
+    #[test]
+    fn resume_preserves_box_address() {
+        use rqe_iterators::{RQEIteratorBoxed, RQESuspendedIterator};
+
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let children = vec![Mock::new([1u64, 2, 3]), Mock::new([2u64, 3, 9])];
+        let mut it = Box::new(Intersection::new(children, 1.0, false));
+        let result = it.read().expect("read failed").expect("expected doc");
+        assert_eq!(result.doc_id, 2);
+        let addr_before = &*it as *const _ as usize;
+
+        let suspended = it.suspend();
+        assert_eq!(
+            &*suspended as *const _ as usize, addr_before,
+            "suspend must reuse the allocation",
+        );
+        // Callers inspect a suspended iterator's position and estimate *without*
+        // resuming it, so the suspended accessors must keep reporting the
+        // pre-suspend values rather than defaulting to zero.
+        assert_eq!(
+            RQESuspendedIterator::last_doc_id(&*suspended),
+            2,
+            "the suspended form remembers where the intersection stood",
+        );
+        assert_eq!(
+            RQESuspendedIterator::num_estimated(&*suspended),
+            3,
+            "the estimate is the smallest child's, unchanged by suspending",
+        );
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(a) => a,
+            ResumeOutcome::Moved(_) => panic!("expected Ok, got Moved"),
+            ResumeOutcome::Aborted => panic!("expected Ok, got Aborted"),
+        };
+        assert_eq!(
+            &*active as *const _ as usize, addr_before,
+            "resume must reuse the allocation",
+        );
+
+        let result = active.read().expect("read failed").expect("expected doc");
+        assert_eq!(result.doc_id, 3, "the intersection carries on where it was");
+    }
+
+    /// A child whose resume fails propagates the error, and the reused
+    /// allocation is freed without touching the consumed slot — the mixed-mode
+    /// teardown that only miri can meaningfully vet (resumed children before the
+    /// failed one, still-suspended ones after it).
+    #[test]
+    fn resume_child_error_propagates_and_frees_the_shell() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child0: Mock<'_, 3> = Mock::new([10, 20, 30]);
+        let child1: Mock<'_, 3> = Mock::new([10, 20, 40]);
+        let child2: Mock<'_, 3> = Mock::new([10, 20, 50]);
+        child1
+            .data()
+            .set_error_on_resume(Some(crate::utils::MockIteratorError::TimeoutError(None)));
+
+        let children = boxed_children(child0, child1, child2);
+        let mut ii = Intersection::new(children, 1.0, false);
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 10);
+
+        let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard);
+        assert!(
+            outcome.is_err(),
+            "the failing child's error must reach the caller",
+        );
+    }
+
+    #[test]
+    fn revalidate_moved() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+        let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+        let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = boxed_children(child0, child1, child2);
+        let mut ii = Intersection::new(children, 1.0, false);
+
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert_eq!(ii.last_doc_id(), 20);
+    }
+
+    #[test]
+    fn revalidate_mixed_results() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+        let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+        let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = boxed_children(child0, child1, child2);
+        let mut ii = Intersection::new(children, 1.0, false);
+
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert_eq!(ii.last_doc_id(), 20);
+    }
+
+    #[test]
+    fn revalidate_after_eof() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+        let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+        let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = boxed_children(child0, child1, child2);
+        let mut ii = Intersection::new(children, 1.0, false);
+
+        while ii.read().expect("read").is_some() {}
+        assert!(ii.at_eof());
+
+        let guard = mock_ctx.spec_read();
+        let mut ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+        assert!(ii.at_eof());
+        assert!(matches!(ii.read(), Ok(None)));
+    }
+
+    #[test]
+    fn revalidate_some_children_moved_to_eof() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+        let child1: Mock<'_, 1> = Mock::new([10]);
+        let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = boxed_children(child0, child1, child2);
+        let mut ii = Intersection::new(children, 1.0, false);
+
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert!(ii.at_eof());
+        assert!(matches!(ii.read(), Ok(None)));
+    }
+
+    #[test]
+    fn revalidate_before_read() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+        let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+        let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = boxed_children(child0, child1, child2);
+        let ii = Intersection::new(children, 1.0, false);
+
+        let guard = mock_ctx.spec_read();
+        let mut ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 10);
+    }
+
+    #[test]
+    fn revalidate_move_before_read() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 10> = Mock::new([10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+        let child1: Mock<'_, 11> = Mock::new([5, 10, 18, 20, 28, 30, 38, 40, 48, 50, 60]);
+        let child2: Mock<'_, 11> = Mock::new([2, 10, 12, 20, 22, 30, 32, 40, 42, 50, 70]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = boxed_children(child0, child1, child2);
+        let ii = Intersection::new(children, 1.0, false);
+
+        let guard = mock_ctx.spec_read();
+        let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed");
+        assert!(
+            matches!(outcome, ResumeOutcome::Ok(_) | ResumeOutcome::Moved(_)),
+            "Revalidate before read with Move should return OK or MOVED"
+        );
+    }
+
+    #[test]
+    fn revalidate_moved_skip_to_returns_none() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 2> = Mock::new([10, 15]);
+        let child1: Mock<'_, 2> = Mock::new([10, 18]);
+        let child2: Mock<'_, 2> = Mock::new([10, 22]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = boxed_children(child0, child1, child2);
+        let mut ii = Intersection::new(children, 1.0, false);
+
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 10);
+        assert!(!ii.at_eof());
+
+        let guard = mock_ctx.spec_read();
+        let mut ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert!(
+            ii.at_eof(),
+            "Intersection should be at EOF after no consensus"
+        );
+        assert!(matches!(ii.read(), Ok(None)));
+    }
+
+    /// The proximity configuration has never been resumed: the slop/order tests
+    /// build their children as `Box<dyn RQEIterator>`, which is not
+    /// `RQEIteratorBoxed` and so cannot suspend at all. That leaves `resume`'s
+    /// post-loop `skip_to` untested in the one configuration where it routes
+    /// through the relevancy check and reads term offsets straight out of
+    /// just-resumed children — the case `MockSuspended::resume` rebuilds the
+    /// whole term record for, and which nothing else calls.
+    ///
+    /// `in_order` also suppresses the sort, so `foo` stays the first child.
+    #[test]
+    fn resume_rechecks_relevancy_when_proximity_is_constrained() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // doc 1: foo@1 bar@2 — adjacent and in order, relevant.
+        // doc 5: foo@1 bar@5 — in order but too far apart for slop 1.
+        // doc 9: foo@1 bar@2 — relevant again.
+        let foo: Mock<'_, 3> = Mock::new_with_positions([1, 5, 9], [1, 1, 1]);
+        let bar: Mock<'_, 3> = Mock::new_with_positions([1, 5, 9], [2, 5, 2]);
+        foo.data().set_revalidate_result(MockRevalidateResult::Move);
+        bar.data().set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(foo)),
+            TypeErasedRQEIterator::new(Box::new(bar)),
+        ];
+        let mut ii = Intersection::new_with_slop_order(children, 1.0, false, Some(1), true);
+
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 1);
+
+        let guard = mock_ctx.spec_read();
+        let mut ii = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+
+        // Both children moved onto doc 5, whose offsets fail the slop check, so
+        // the post-loop `skip_to` had to carry on to the next relevant document.
+        assert_eq!(ii.last_doc_id(), 9);
+        assert_eq!(ii.current().expect("positioned").doc_id, 9);
+        assert!(matches!(ii.read(), Ok(None)));
+    }
+
+    /// Every child resumes cleanly and it is the *post-loop* consensus read that
+    /// fails. A different teardown from the aborting-child cases: the box has
+    /// already been re-narrowed to its fully-active form and drops as such, so
+    /// `free_after_consumed_child` never runs.
+    #[test]
+    fn resume_post_move_consensus_error_propagates() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // Every child moves, but the laggard has nothing past 20, so the
+        // consensus skip to 30 runs it past its end — where the failure sits.
+        let child0: Mock<'_, 2> = Mock::new([10, 20]);
+        let child1: Mock<'_, 2> = Mock::new([10, 30]);
+        let child2: Mock<'_, 2> = Mock::new([10, 30]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move)
+            .set_error_at_done(Some(crate::utils::MockIteratorError::TimeoutError(None)));
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child2
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = boxed_children(child0, child1, child2);
+        let mut ii = Intersection::new(children, 1.0, false);
+        let result = ii.read().expect("read").unwrap();
+        assert_eq!(result.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(ii)), &guard);
+        assert!(
+            outcome.is_err(),
+            "a consensus read failing after every child resumed must reach the caller",
+        );
+    }
+
+    /// The address the aggregate's entries depend on is the *child slot's*, not
+    /// the outer box's, and the shipping configuration erases the child — so an
+    /// outer-box assertion over concrete children would miss a slot that moved.
+    /// Pin both, with the erased children the composites actually carry.
+    #[test]
+    fn resume_preserves_erased_child_slot_addresses() {
+        use rqe_iterators::{RQEIteratorBoxed, RQESuspendedIterator};
+
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let children = boxed_children(
+            Mock::new([1u64, 2, 3]),
+            Mock::new([2u64, 3, 9]),
+            Mock::new([2u64, 3, 11]),
+        );
+        let mut it = Box::new(Intersection::new(children, 1.0, false));
+        let result = it.read().expect("read failed").expect("expected doc");
+        assert_eq!(result.doc_id, 2);
+
+        let box_before = &*it as *const _ as usize;
+        let slots_before: Vec<usize> = (0..it.num_children())
+            .map(|i| it.child_at(i) as *const _ as usize)
+            .collect();
+
+        let active = match it.suspend().resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(a) => a,
+            ResumeOutcome::Moved(_) => panic!("expected Ok, got Moved"),
+            ResumeOutcome::Aborted => panic!("expected Ok, got Aborted"),
+        };
+        assert_eq!(
+            &*active as *const _ as usize, box_before,
+            "the cycle must reuse the allocation",
+        );
+        for (i, &before) in slots_before.iter().enumerate() {
+            assert_eq!(
+                active.child_at(i) as *const _ as usize,
+                before,
+                "child slot {i} moved; the aggregate's entries point into it",
+            );
+        }
+    }
+
+    /// An intersection with no children is born at EOF with a zero estimate, so
+    /// its resume degenerates to an empty loop plus the "nothing moved" return —
+    /// the only shape where the child loop's body never runs.
+    #[test]
+    fn resume_of_a_childless_intersection() {
+        use rqe_iterators::{RQEIteratorBoxed, RQESuspendedIterator};
+
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let children: Vec<TypeErasedRQEIterator<'static>> = Vec::new();
+        let it = Box::new(Intersection::new(children, 1.0, false));
+        assert!(it.at_eof());
+
+        let suspended = it.suspend();
+        assert_eq!(RQESuspendedIterator::last_doc_id(&*suspended), 0);
+        assert_eq!(RQESuspendedIterator::num_estimated(&*suspended), 0);
+
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(a) => a,
+            ResumeOutcome::Moved(_) => panic!("expected Ok, got Moved"),
+            ResumeOutcome::Aborted => panic!("expected Ok, got Aborted"),
+        };
+        assert!(active.at_eof());
+        assert_eq!(active.num_estimated(), 0);
+        assert!(matches!(active.read(), Ok(None)));
+    }
+
+    /// The outcome shape the legacy and resume paths share, for the differential
+    /// tests below.
+    #[derive(Debug, PartialEq, Eq)]
+    enum Outcome {
+        Ok,
+        Moved,
+        Aborted,
+        Failed,
+    }
+
+    /// Read `it` to completion, collecting the doc ids it yields.
+    fn drain<'index>(it: &mut impl RQEIterator<'index>) -> Vec<DocId> {
+        let mut seen = Vec::new();
+        while let Some(doc) = it.read().expect("read failed") {
+            seen.push(doc.doc_id);
+        }
+        seen
+    }
+
+    /// Drive `build()` through the legacy `revalidate` and through
+    /// `suspend`/`resume`, and require both to agree on the outcome *and* on
+    /// everything read afterwards. `what` names the scenario in the failure.
+    fn assert_paths_agree<'index>(
+        what: &str,
+        guard: &index_spec::IndexSpecReadGuard<'index>,
+        build: impl Fn() -> Box<Intersection<'index, TypeErasedRQEIterator<'index>>>,
+    ) {
+        use rqe_iterators::{RQEIteratorBoxed, RQESuspendedIterator};
+
+        let mut legacy = build();
+        let legacy_outcome = match legacy.revalidate(guard) {
+            Ok(RQEValidateStatus::Ok) => Outcome::Ok,
+            Ok(RQEValidateStatus::Moved { .. }) => Outcome::Moved,
+            Ok(RQEValidateStatus::Aborted) => Outcome::Aborted,
+            Err(_) => Outcome::Failed,
+        };
+        // An aborted or failed iterator is dropped rather than used, so there is
+        // nothing left to read on either path.
+        let legacy_tail = match legacy_outcome {
+            Outcome::Ok | Outcome::Moved => drain(&mut *legacy),
+            Outcome::Aborted | Outcome::Failed => Vec::new(),
+        };
+
+        let (resumed_outcome, resumed_tail) = match build().suspend().resume(guard) {
+            Ok(ResumeOutcome::Ok(mut it)) => (Outcome::Ok, drain(&mut *it)),
+            Ok(ResumeOutcome::Moved(mut it)) => (Outcome::Moved, drain(&mut *it)),
+            Ok(ResumeOutcome::Aborted) => (Outcome::Aborted, Vec::new()),
+            Err(_) => (Outcome::Failed, Vec::new()),
+        };
+
+        assert_eq!(
+            legacy_outcome, resumed_outcome,
+            "{what}: the two paths disagree on the outcome",
+        );
+        assert_eq!(
+            legacy_tail, resumed_tail,
+            "{what}: the two paths disagree on what is read afterwards",
+        );
+    }
+
+    /// While the legacy `revalidate` and the new `resume` both exist they are
+    /// two spellings of one transition, and sibling iterators in this stack have
+    /// already drifted between them — a child outcome absorbed on one path and
+    /// forwarded on the other, or a re-seek done only once. Drive both over
+    /// every child outcome at every position, error outcomes included; the
+    /// position matters because the abort/error teardown splits the child list
+    /// at the failing index.
+    #[test]
+    fn revalidate_and_resume_agree_on_every_child_outcome() {
+        let outcomes = [
+            MockRevalidateResult::Ok,
+            MockRevalidateResult::Move,
+            MockRevalidateResult::Abort,
+            MockRevalidateResult::TimedOut,
+        ];
+        for position in 0..3 {
+            for outcome in outcomes {
+                let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+                let guard = mock_ctx.spec_read();
+                let build = || {
+                    let child0: Mock<'_, 4> = Mock::new([10, 20, 30, 40]);
+                    let child1: Mock<'_, 4> = Mock::new([10, 20, 35, 40]);
+                    let child2: Mock<'_, 4> = Mock::new([10, 20, 38, 40]);
+                    for (i, data) in [child0.data(), child1.data(), child2.data()]
+                        .iter_mut()
+                        .enumerate()
+                    {
+                        data.set_revalidate_result(if i == position {
+                            outcome
+                        } else {
+                            MockRevalidateResult::Ok
+                        });
+                    }
+                    let mut it = Box::new(Intersection::new(
+                        boxed_children(child0, child1, child2),
+                        1.0,
+                        false,
+                    ));
+                    let doc = it.read().expect("read failed").expect("expected doc");
+                    assert_eq!(doc.doc_id, 10);
+                    it
+                };
+                assert_paths_agree(
+                    &format!("child {position} reports {outcome:?}"),
+                    &guard,
+                    build,
+                );
+            }
+        }
+    }
+
+    /// The shapes where the composite's *own* post-loop work runs. `revalidate`
+    /// and `resume` reach it by different routes — the `Moved { current }`
+    /// payload versus the resumed child's `at_eof()`/`last_doc_id()` — so this
+    /// is where the two are likeliest to drift.
+    #[test]
+    fn revalidate_and_resume_agree_on_the_post_move_consensus() {
+        // Every child moves to a different document, so consensus has to be
+        // re-established from the furthest one.
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        assert_paths_agree("every child moves", &guard, || {
+            let child0: Mock<'_, 3> = Mock::new([10, 20, 50]);
+            let child1: Mock<'_, 3> = Mock::new([10, 30, 50]);
+            let child2: Mock<'_, 3> = Mock::new([10, 40, 50]);
+            for data in [child0.data(), child1.data(), child2.data()].iter_mut() {
+                data.set_revalidate_result(MockRevalidateResult::Move);
+            }
+            let mut it = Box::new(Intersection::new(
+                boxed_children(child0, child1, child2),
+                1.0,
+                false,
+            ));
+            let doc = it.read().expect("read failed").expect("expected doc");
+            assert_eq!(doc.doc_id, 10);
+            it
+        });
+
+        // The same shape, but the laggard has nothing left, so the consensus
+        // skip runs it past its end — where the failure is injected.
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        assert_paths_agree("the consensus skip fails", &guard, || {
+            let child0: Mock<'_, 2> = Mock::new([10, 20]);
+            let child1: Mock<'_, 2> = Mock::new([10, 30]);
+            let child2: Mock<'_, 2> = Mock::new([10, 30]);
+            child0
+                .data()
+                .set_revalidate_result(MockRevalidateResult::Move)
+                .set_error_at_done(Some(crate::utils::MockIteratorError::TimeoutError(None)));
+            child1
+                .data()
+                .set_revalidate_result(MockRevalidateResult::Move);
+            child2
+                .data()
+                .set_revalidate_result(MockRevalidateResult::Move);
+            let mut it = Box::new(Intersection::new(
+                boxed_children(child0, child1, child2),
+                1.0,
+                false,
+            ));
+            let doc = it.read().expect("read failed").expect("expected doc");
+            assert_eq!(doc.doc_id, 10);
+            it
+        });
+
+        // A child whose move runs off the end ends the intersection outright,
+        // with no consensus skip at all — the branch that only reads correctly
+        // because `at_eof()` is consulted before `last_doc_id()`.
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        assert_paths_agree("a child moves past its end", &guard, || {
+            let child0: Mock<'_, 3> = Mock::new([10, 20, 30]);
+            let child1: Mock<'_, 1> = Mock::new([10]);
+            let child2: Mock<'_, 3> = Mock::new([10, 20, 30]);
+            child1
+                .data()
+                .set_revalidate_result(MockRevalidateResult::Move);
+            let mut it = Box::new(Intersection::new(
+                boxed_children(child0, child1, child2),
+                1.0,
+                false,
+            ));
+            let doc = it.read().expect("read failed").expect("expected doc");
+            assert_eq!(doc.doc_id, 10);
+            it
+        });
+    }
+}
+
 // =============================================================================
 // Slop and InOrder tests
 // (Slop, InOrder, SlopAndOrder test cases)
@@ -1182,8 +2104,8 @@ mod slop_and_order {
         max_slop: Option<u32>,
         in_order: bool,
     ) -> Intersection<'static, Box<dyn RQEIterator<'static> + 'static>> {
-        let foo: Mock<'static, 4> = Mock::new_with_positions([1, 2, 3, 4], [1, 1, 2, 1]);
-        let bar: Mock<'static, 3> = Mock::new_with_positions([1, 3, 4], [2, 1, 3]);
+        let foo: Mock<'_, 4> = Mock::new_with_positions([1, 2, 3, 4], [1, 1, 2, 1]);
+        let bar: Mock<'_, 3> = Mock::new_with_positions([1, 3, 4], [2, 1, 3]);
         Intersection::new_with_slop_order(
             vec![Box::new(foo), Box::new(bar)],
             1.0,
@@ -1349,8 +2271,8 @@ mod slop_and_order {
     ///   bar@1 comes before foo@3; foo then tries doc 2, but bar has no doc ≥ 2 → EOF.
     #[test]
     fn relevancy_retry_hits_eof_in_second_consensus() {
-        let foo: Mock<'static, 2> = Mock::new_with_positions([1, 2], [3, 1]);
-        let bar: Mock<'static, 1> = Mock::new_with_positions([1], [1]);
+        let foo: Mock<'_, 2> = Mock::new_with_positions([1, 2], [3, 1]);
+        let bar: Mock<'_, 1> = Mock::new_with_positions([1], [1]);
         let mut ii = ContractChecker::new(Intersection::new_with_slop_order(
             vec![
                 Box::new(foo) as Box<dyn RQEIterator<'static> + 'static>,


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `Intersection` can only be revalidated in place, so it cannot be held while the index spec read lock is released. Being an aggregate-owning composite, it is also the first iterator to need the entry-rebuild primitive added in its base branch.
2. Change: it implements `RQEIteratorBoxed::suspend` / `RQESuspendedIterator::resume`. Children are transitioned inside the `Vec`'s own buffer, the aggregate's borrowed entries are rebuilt from the resumed children while the result is still suspended, and only then is the allocation re-narrowed. The legacy `revalidate` is unchanged.
3. Outcome: no user-visible change — the query pipeline does not suspend iterators yet. Stacked on #10892; review that first, since the base commit is where the rebuild primitive is defined.

#### Which additional issues this PR fixes

1. #10892

#### Main objects this PR modified

1. `Intersection::suspend` / `RawIntersection<Suspended>::resume` and the `const` layout proof pairing them — the allocation is reused, so a child's interior address survives the cycle.
2. `free_after_consumed_child` — teardown for a resume that fails partway: one child has already been consumed by its own `resume`, so the shell holds a hole and cannot simply be dropped or cast.
3. `rebuild_borrowed_entries` — shaped for what an intersection actually is. `agree_on_doc_id` only reports agreement once *every* child sits on the target, and an aborting child aborts the whole intersection rather than being compacted over, so entry *i* is child *i* by construction: there is no address matching, no relocation to handle, and no separate clear path. The outcome it reports is `Complete` / `Incomplete` rather than a union's "is anything still behind this" — an intersection needs all of its children, and the one arm that publishes without a re-seek now asserts it.
4. `freq` and `field_mask` are recomputed with the entries; `metrics` and `doc_id` are carried across, because metrics are *moved* out of the children when the aggregate is first built and cannot be re-accumulated.
5. Post-move consensus: after any child reports `Moved`, the intersection re-establishes agreement and (when proximity is constrained) re-checks relevancy before reporting its own outcome.
6. `tests/integration/intersection.rs` — resume-side counterparts of the revalidate matrix, plus the aggregate-points-at-live-children, erased-child-slot-address and childless cases, and two for the rebuild: the result agreeing with its own entries, and the metrics surviving it.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
