### PR TITLE
[MOD-16715] TopKIterator: suspend/resume, and drop the Box<dyn> child

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3203,6 +3203,7 @@ dependencies = [
  "redis_mock",
  "redis_reply",
  "redisearch_rs",
+ "ref_mode",
  "rqe_core",
  "rqe_iterator_type",
  "rqe_iterators",

--- a/src/redisearch_rs/rqe_iterators/src/boxed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/boxed.rs
@@ -235,7 +235,7 @@ impl<'query> TypeErasedRQESuspendedIterator<'query> {
 /// Call it in a `const {}` block so the check runs at monomorphization: a
 /// mismatch fails to compile instead of causing undefined behaviour when the
 /// suspend/resume helpers reinterpret an allocation from `A` to `B`.
-pub(crate) const fn assert_layout_compatible<A, B>() {
+pub const fn assert_layout_compatible<A, B>() {
     assert!(
         std::mem::size_of::<A>() == std::mem::size_of::<B>(),
         "size mismatch across suspend/resume transition: active and suspended representations must have identical size"
@@ -329,7 +329,7 @@ where
 /// Outcome of [`resume_child_slot_in_place`], mirroring the recoverable
 /// discriminants of [`ResumeOutcome`] but *without* carrying the iterator —
 /// the resumed child is written back into the slot instead.
-pub(crate) enum ResumeSlotOutcome {
+pub enum ResumeSlotOutcome {
     /// The child resumed at the same position; the slot now holds the active child.
     Unchanged,
     /// The child resumed but its position moved forward; the slot now holds the
@@ -376,7 +376,7 @@ pub(crate) enum ResumeSlotOutcome {
 /// implementations and could panic; as in [`suspend_child_slot_in_place`], a
 /// panic is converted into a process abort rather than an unwind through the
 /// uninitialised slot.
-pub(crate) unsafe fn resume_child_slot_in_place<'query, 'a, S>(
+pub unsafe fn resume_child_slot_in_place<'query, 'a, S>(
     slot: *mut S,
     guard: &IndexSpecReadGuard<'a>,
 ) -> Result<ResumeSlotOutcome, RQEIteratorError>

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -65,7 +65,7 @@ pub mod wildcard;
 
 pub use boxed::{
     RQEDynIterator, RQEDynSuspendedIterator, RQEIteratorBoxed, RQESuspendedIterator,
-    TypeErasedRQEIterator, TypeErasedRQESuspendedIterator,
+    TypeErasedRQEIterator, TypeErasedRQESuspendedIterator, assert_layout_compatible,
 };
 pub use config::IteratorsConfig;
 pub use empty::Empty;

--- a/src/redisearch_rs/top_k/Cargo.toml
+++ b/src/redisearch_rs/top_k/Cargo.toml
@@ -24,6 +24,7 @@ index_result.workspace = true
 index_spec.workspace = true
 inverted_index.workspace = true
 redis_reply.workspace = true
+ref_mode.workspace = true
 rqe_core.workspace = true
 rqe_iterator_type.workspace = true
 rqe_iterators.workspace = true

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -9,15 +9,21 @@
 
 //! [`TopKIterator`] — the generic top-k state machine.
 
-use std::{cmp::Ordering, mem::ManuallyDrop, num::NonZeroUsize};
+use std::{cmp::Ordering, marker::PhantomData, mem::ManuallyDrop, num::NonZeroUsize};
 
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use redis_reply::MapBuilder;
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 use rqe_iterator_type::IteratorType;
 use rqe_iterators::{
-    RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome,
+    RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator, RQEValidateStatus,
+    ResumeOutcome, SkipToOutcome,
+    boxed::{
+        ResumeSlotOutcome, assert_layout_compatible, resume_child_slot_in_place,
+        suspend_child_slot_in_place,
+    },
     profile_print::{ProfilePrint, ProfilePrintCtx},
 };
 
@@ -98,18 +104,52 @@ enum Phase {
 /// Implements the execution mode described in the design doc:
 /// [`Unfiltered`](TopKMode::Unfiltered), [`Batches`](TopKMode::Batches),
 /// and [`AdhocBF`](TopKMode::AdhocBF).
-pub struct TopKIterator<
-    'index,
-    S: ScoreSource,
-    C: RQEIterator<'index> + 'index = Box<dyn RQEIterator<'index> + 'index>,
-> {
+///
+/// Parameterised over a [`Ref`] mode: [`TopKIterator`] is the [`Active`]
+/// instantiation that implements [`RQEIterator`], and
+/// `RawTopK<'query, Suspended, S, I::Suspended>` its suspended counterpart (see
+/// [`RQEIteratorBoxed::suspend`]).
+///
+/// # Invariants
+///
+/// 1. **Layout compatibility across modes.** `RawTopK` is `#[repr(C)]`, and the
+///    only field whose type varies with the mode is the `child` slot — a
+///    `#[repr(C)]` `TopKChild`, layout-compatible between `I` and
+///    `I::Suspended` (enforced at monomorphization by
+///    [`suspend_child_slot_in_place`]). Every other field has the *same* type in
+///    both instantiations, and `Rf` is carried by the zero-sized `_marker`
+///    alone. The `const` block below proves this for a representative
+///    instantiation, which is what lets [`suspend`](RQEIteratorBoxed::suspend)
+///    and [`resume`](RQESuspendedIterator::resume) reinterpret the owning `Box`
+///    in place rather than rebuilding it.
+/// 2. **The result buffers hold no index-backed payload.** `heap`, `results` and
+///    `current` are typed [`Active`] in *both* modes, which is only sound
+///    because the records parked in them borrow nothing from the index: they are
+///    produced exclusively by `capture_child_record` (whose
+///    [`to_owned`](RSIndexResult::to_owned) copies the offset bytes and
+///    deep-copies aggregate children), by `capture_child_metrics` (a
+///    metric-only result), or by [`ScoreSource::build_result`], whose contract
+///    obliges every source to return such a record. What survives is
+///    the child's borrowed `RSQueryTerm`s, the query's `RLookupKey`-backed
+///    metrics and the `dmd` pointer — none of which a mode transition weakens or
+///    re-narrows. `carries_no_index_borrow` states the property in code;
+///    because neither that trait contract nor the `&mut` handout from
+///    [`current`](RQEIterator::current) can be enforced statically, it is
+///    *checked* — not assumed — at the boundary that re-narrows
+///    ([`resume`](RQESuspendedIterator::resume)), which aborts on violation.
+/// 3. **The heap is empty outside collection.** `collect` runs to completion
+///    within a single [`read`](RQEIterator::read) — draining the heap into
+///    `results` on success, clearing it on error — so every externally
+///    observable state, suspension included, has an empty heap.
+#[repr(C)]
+pub struct RawTopK<'query, Rf: Ref, S: ScoreSource, I> {
     source: S,
     mode: TopKMode,
-    /// Preserved so [`rewind`](Self::rewind) can restore the original mode.
+    /// Preserved so [`rewind`](RQEIterator::rewind) can restore the original mode.
     initial_mode: TopKMode,
     /// Captured child records alias `child`, so `heap`, `results`, and `current`
     /// are [`ManuallyDrop`] and freed by the [`Drop`] impl before `child`.
-    heap: ManuallyDrop<TopKHeap<'index>>,
+    heap: ManuallyDrop<TopKHeap<'query>>,
     /// Holds the in-progress batch for the Unfiltered path.
     direct_batch: Option<S::Batch>,
     k: NonZeroUsize,
@@ -122,22 +162,202 @@ pub struct TopKIterator<
     phase: Phase,
     /// Heap contents drained into score order for yielding. In filtered modes
     /// each entry carries the child's record captured at match time.
-    results: ManuallyDrop<Vec<HeapResult<'index>>>,
+    results: ManuallyDrop<Vec<HeapResult<'query>>>,
     yield_pos: usize,
-    current: ManuallyDrop<Option<RSIndexResult<'index>>>,
-    child: Option<C>,
+    current: ManuallyDrop<Option<RSIndexResult<'query>>>,
+    child: TopKChild<I>,
     last_doc_id: DocId,
     at_eof: bool,
-    /// Diagnostic counters — not reset on [`rewind`](Self::rewind).
+    /// Diagnostic counters — not reset on [`rewind`](RQEIterator::rewind).
     pub metrics: TopKMetrics,
+    _marker: PhantomData<Rf>,
 }
 
-impl<'index, S: ScoreSource, C: RQEIterator<'index> + 'index> Drop for TopKIterator<'index, S, C> {
+/// Alias for an [`Active`] [`RawTopK`] — the only instantiation with an
+/// [`RQEIterator`] impl.
+pub type TopKIterator<'index, S, C = Box<dyn RQEIterator<'index> + 'index>> =
+    RawTopK<'index, Active<'index>, S, C>;
+
+/// Child-filter slot for [`RawTopK`].
+///
+/// A dedicated `#[repr(C)]` enum rather than `Option<I>`, whose niche layout
+/// depends on `I` and is therefore not transmute-stable across the
+/// `I` → `I::Suspended` swap that the whole-box cast performs. The `I`-free
+/// [`Absent`](TopKChild::Absent) variant doubles as the teardown target when a
+/// child is consumed by an aborted resume. Mirrors
+/// [`rqe_iterators::optional`]'s `OptionalChild` for the same reasons.
+#[repr(C)]
+enum TopKChild<I> {
+    /// No child filter — the [`Unfiltered`](TopKMode::Unfiltered) path, or a
+    /// child consumed during teardown.
+    Absent,
+    /// The filter child provided at construction.
+    Present(I),
+}
+
+impl<I> TopKChild<I> {
+    /// Shared reference to the child, if present.
+    #[inline(always)]
+    const fn as_ref(&self) -> Option<&I> {
+        match self {
+            Self::Absent => None,
+            Self::Present(i) => Some(i),
+        }
+    }
+
+    /// Mutable reference to the child, if present.
+    #[inline(always)]
+    const fn as_mut(&mut self) -> Option<&mut I> {
+        match self {
+            Self::Absent => None,
+            Self::Present(i) => Some(i),
+        }
+    }
+
+    /// Whether the slot holds no child.
+    #[inline(always)]
+    const fn is_none(&self) -> bool {
+        matches!(self, Self::Absent)
+    }
+
+    /// Whether the slot holds a child.
+    #[inline(always)]
+    const fn is_some(&self) -> bool {
+        matches!(self, Self::Present(_))
+    }
+
+    /// Move the child out, leaving the slot [`Absent`](TopKChild::Absent).
+    #[inline(always)]
+    fn take(&mut self) -> Option<I> {
+        match std::mem::replace(self, Self::Absent) {
+            Self::Absent => None,
+            Self::Present(i) => Some(i),
+        }
+    }
+}
+
+impl<I> From<Option<I>> for TopKChild<I> {
+    fn from(child: Option<I>) -> Self {
+        match child {
+            None => Self::Absent,
+            Some(i) => Self::Present(i),
+        }
+    }
+}
+
+// Compile-time proof of invariant 1 on `RawTopK`: for a representative
+// instantiation, the `Active` and `Suspended` forms agree on every field offset,
+// on size and on alignment. Module consts cannot be generic, so the proof fixes
+// one source and one child; that is enough because `S`, `S::Batch` and every
+// buffer type are *the same types* in both modes (only `child` and the ZST
+// `_marker` vary), and the child slot's own compatibility is enforced for every
+// implementer by `suspend_child_slot_in_place`. `Wildcard` is a representative
+// child whose `Active`/`Suspended` forms differ but stay layout-compatible.
+const _: () = {
+    use rqe_iterators::Wildcard;
+    use std::mem::{align_of, offset_of, size_of};
+
+    /// A do-nothing [`ScoreSource`] standing in for every source: the proof
+    /// only needs `S` to be *some* concrete type, since it is identical across
+    /// modes.
+    struct ProofSource;
+
+    impl ScoreBatch for ProofSource {
+        fn next(&mut self) -> Option<(DocId, f64)> {
+            None
+        }
+
+        fn skip_to(&mut self, _target: DocId) -> Option<(DocId, f64)> {
+            None
+        }
+    }
+
+    impl ScoreSource for ProofSource {
+        type Batch = Self;
+
+        fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
+            Ok(None)
+        }
+
+        fn lookup_score(&mut self, _doc_id: DocId) -> Option<f64> {
+            None
+        }
+
+        fn num_estimated(&self) -> usize {
+            0
+        }
+
+        fn rewind(&mut self) {}
+
+        fn build_result<'r>(&self, doc_id: DocId, _score: f64) -> RSIndexResult<'r>
+        where
+            Self: 'r,
+        {
+            RSIndexResult::build_virt().doc_id(doc_id).build()
+        }
+
+        fn attach_score_metric<'r>(&self, _result: &mut RSIndexResult<'r>, _score: f64)
+        where
+            Self: 'r,
+        {
+        }
+
+        fn yields_child_record(&self) -> bool {
+            false
+        }
+
+        fn batch_strategy(&mut self, _heap_count: usize, _k: usize) -> BatchStrategy {
+            BatchStrategy::Stop
+        }
+
+        fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+            Ok(())
+        }
+
+        fn iterator_type(&self) -> IteratorType {
+            IteratorType::Mock
+        }
+    }
+
+    type AChild = Wildcard<'static>;
+    type SChild = <Wildcard<'static> as RQEIteratorBoxed<'static>>::Suspended;
+    type A = RawTopK<'static, Active<'static>, ProofSource, AChild>;
+    type S = RawTopK<'static, Suspended, ProofSource, SChild>;
+
+    assert!(offset_of!(A, source) == offset_of!(S, source));
+    assert!(offset_of!(A, mode) == offset_of!(S, mode));
+    assert!(offset_of!(A, initial_mode) == offset_of!(S, initial_mode));
+    assert!(offset_of!(A, heap) == offset_of!(S, heap));
+    assert!(offset_of!(A, direct_batch) == offset_of!(S, direct_batch));
+    assert!(offset_of!(A, k) == offset_of!(S, k));
+    assert!(offset_of!(A, compare) == offset_of!(S, compare));
+    assert!(offset_of!(A, can_trim_deep_results) == offset_of!(S, can_trim_deep_results));
+    assert!(offset_of!(A, phase) == offset_of!(S, phase));
+    assert!(offset_of!(A, results) == offset_of!(S, results));
+    assert!(offset_of!(A, yield_pos) == offset_of!(S, yield_pos));
+    assert!(offset_of!(A, current) == offset_of!(S, current));
+    assert!(offset_of!(A, child) == offset_of!(S, child));
+    assert!(offset_of!(A, last_doc_id) == offset_of!(S, last_doc_id));
+    assert!(offset_of!(A, at_eof) == offset_of!(S, at_eof));
+    assert!(offset_of!(A, metrics) == offset_of!(S, metrics));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
+impl<'query, Rf: Ref, S: ScoreSource, I> Drop for RawTopK<'query, Rf, S, I> {
     fn drop(&mut self) {
         // `heap`, `results`, and `current` hold child records captured via
         // `capture_child_record`, whose term borrows alias data owned by `child`.
         // Freeing them here — before the compiler's field glue drops `child` —
         // keeps those borrows valid regardless of field declaration order.
+        //
+        // This also covers the *suspended* instantiation, including the teardown
+        // path where an aborted child resume already consumed `child` and left
+        // the slot `Absent`: dropping a captured record frees its owned offset
+        // copies and its boxed aggregate children, and never dereferences the
+        // borrowed query term, so a record whose term has already gone away is
+        // still safe to drop.
+        //
         // SAFETY: each buffer is dropped exactly once and never touched again.
         unsafe {
             ManuallyDrop::drop(&mut self.heap);
@@ -176,7 +396,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
         Self {
             heap: ManuallyDrop::new(TopKHeap::new(k, compare)),
             source,
-            child,
+            child: child.into(),
             mode,
             initial_mode: mode,
             direct_batch: None,
@@ -190,6 +410,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             last_doc_id: 0,
             at_eof: false,
             metrics: TopKMetrics::default(),
+            _marker: PhantomData,
         }
     }
 
@@ -251,7 +472,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             // prepare_unfiltered_direct resume from its cursor rather than the start.
             *self.heap = TopKHeap::new(self.k, self.compare);
             self.source.rewind();
-            if let Some(child) = &mut self.child {
+            if let Some(child) = self.child.as_mut() {
                 child.rewind();
             }
         }
@@ -287,7 +508,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             // Borrow-checker split: we can't hold `&mut self.child` and call
             // `self.heap.push` at the same time.  Pass fields explicitly.
             let can_trim_deep_results = self.can_trim_deep_results;
-            if let Some(child) = &mut self.child {
+            if let Some(child) = self.child.as_mut() {
                 intersect_batch_with_child(
                     child,
                     &mut batch,
@@ -333,7 +554,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
                     // The source already re-resolved itself to the next disjoint
                     // window, so the heap stays valid and keeps accumulating.
                     // Only the child is rewound for re-intersection.
-                    if let Some(child) = &mut self.child {
+                    if let Some(child) = self.child.as_mut() {
                         child.rewind();
                     }
                     continue;
@@ -590,7 +811,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> RQEIterat
     ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         // Only a child abort aborts us. Results come from our own score-ordered
         // buffer, so a moved child does not move our cursor: collapse it to Ok.
-        if let Some(child) = &mut self.child {
+        if let Some(child) = self.child.as_mut() {
             match child.revalidate(spec)? {
                 RQEValidateStatus::Aborted => return Ok(RQEValidateStatus::Aborted),
                 RQEValidateStatus::Ok | RQEValidateStatus::Moved { .. } => {}
@@ -605,7 +826,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> RQEIterat
         self.results.clear();
         *self.current = None;
         self.source.rewind();
-        if let Some(child) = &mut self.child {
+        if let Some(child) = self.child.as_mut() {
             child.rewind();
         }
         self.mode = self.initial_mode;
@@ -621,7 +842,7 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> RQEIterat
         let estimate = self.k.get().min(self.source.num_estimated());
         // A filtered query yields the intersection, so the child's own upper
         // bound caps ours: a selective filter must not be masked by a large `k`.
-        match &self.child {
+        match self.child.as_ref() {
             Some(child) => estimate.min(child.num_estimated()),
             None => estimate,
         }
@@ -646,6 +867,262 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> RQEIterat
     fn intersection_sort_weight(&self, _: bool) -> f64 {
         1.0
     }
+}
+
+impl<'index, S: ScoreSource + 'index, I: RQEIteratorBoxed<'index>> RQEIteratorBoxed<'index>
+    for TopKIterator<'index, S, I>
+{
+    type Suspended = RawTopK<'index, Suspended, S, I::Suspended>;
+
+    fn suspend(mut self: Box<Self>) -> Box<Self::Suspended> {
+        // Invariant 1 covers every field but the child slot, whose `I` is only
+        // known per instantiation. `suspend_child_slot_in_place` checks it — but
+        // only when a child is *there*, and an unfiltered top-k has none, so on
+        // that path nothing would bind `I` to `I::Suspended` before the whole
+        // box is cast. `TopKChild<I>` sizes with `I` whether the variant is
+        // `Present` or `Absent`, so a mismatch is just as fatal either way.
+        assert_layout_compatible::<I, I::Suspended>();
+
+        // The source is the one part of us the `Ref` split does not describe: it
+        // is carried across identically, so anything index-backed inside it
+        // would outlive the read guard it was made under. Hand it the chance to
+        // let go before the lock drops.
+        self.source.release_index_handles();
+
+        // Nothing else is touched: the yield position (`phase`, `results`,
+        // `yield_pos`, `direct_batch`) is what `resume` must preserve, and the
+        // buffered records carry no index-backed payload (invariant 2), so they
+        // survive the lock release untouched — exactly as they do across the
+        // legacy `revalidate`, which also leaves them alone.
+        // Weakening a borrow is sound whatever the buffers hold, so this is an
+        // early warning, not a guard: the release-mode guarantee is the same
+        // check at the resume boundary, which is where the borrows are
+        // re-narrowed and where a violation would actually be unsound.
+        debug_assert!(
+            self.buffers_carry_no_index_borrows(),
+            "a record parked for yielding borrows index data, or the heap \
+             survived collection (invariants 2/3): it cannot survive the lock \
+             release this suspend is preparing for",
+        );
+
+        let raw = Box::into_raw(self);
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+        // initialised, exclusively owned), so `&raw mut` can form a pointer to
+        // the child slot without creating a reference to the whole value.
+        let child_slot = unsafe { &raw mut (*raw).child };
+        // SAFETY: `child_slot` is valid and exclusively owned, so `&mut` is a
+        // sound unique borrow of the slot.
+        if let Some(child) = unsafe { &mut *child_slot }.as_mut() {
+            // Route the transition through the trait: a dyn-erased child swaps
+            // its vtable, which a byte reinterpretation of the slot would not.
+            //
+            // SAFETY: `child` is a valid, exclusively-owned `I`; the helper
+            // leaves the slot holding a valid `I::Suspended`.
+            unsafe { suspend_child_slot_in_place(child as *mut I) };
+        }
+        // SAFETY: the child slot (if occupied) now holds `I::Suspended` and
+        // `TopKChild::Absent` is `I`-free, so the allocation is a valid
+        // `RawTopK<'index, Suspended, S, I::Suspended>` — layout-identical to the
+        // active form by invariant 1 (const proof above), with the child slot's
+        // `I`/`I::Suspended` size and alignment match statically enforced by
+        // `suspend_child_slot_in_place`. `Box::from_raw` reuses the same
+        // allocation, so every interior address survives the cycle.
+        unsafe { Box::from_raw(raw.cast::<RawTopK<'index, Suspended, S, I::Suspended>>()) }
+    }
+}
+
+impl<'query, S: ScoreSource + 'query, IS: RQESuspendedIterator<'query>> RQESuspendedIterator<'query>
+    for RawTopK<'query, Suspended, S, IS>
+{
+    type Resumed<'index>
+        = RawTopK<'index, Active<'index>, S, IS::Resumed<'index>>
+    where
+        'query: 'index;
+
+    fn resume<'index>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'index>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'index>>>, RQEIteratorError>
+    where
+        'query: 'index,
+    {
+        /// Outcome of resuming the child, captured so the `&mut` borrow of the
+        /// child slot is released before the slot is touched as a raw pointer.
+        enum ChildResume {
+            /// No child to resume (unfiltered mode).
+            NoChild,
+            /// Child resumed in place.
+            Active,
+            /// Child aborted and was consumed; forward `Aborted`.
+            Aborted,
+            /// Child resume failed; forward the error.
+            Failed(RQEIteratorError),
+        }
+
+        // As on suspend: the child slot's layout is the one part invariant 1
+        // cannot state, and the slot helper only checks it when a child is
+        // present.
+        assert_layout_compatible::<IS::Resumed<'index>, IS>();
+
+        // Resume is the direction that *re-narrows*: the cast below asserts the
+        // parked records' payloads are live `&'index` borrows again. Invariant 2
+        // says they hold none — but neither half of that invariant is statically
+        // enforceable (`ScoreSource::build_result` only promises to return an
+        // index-free record, and `current()` hands the parked record out `&mut`),
+        // so it is checked here rather than assumed. Unlike a leaf, we have
+        // nothing to re-validate a foreign payload against: these records are our
+        // own collected output, not a position in the index we could re-read. So
+        // on violation we refuse to reinterpret and abort — `Ok(Aborted)`, not
+        // `Err`, since the state is recoverable and `RQEIteratorError` is for
+        // genuine `TimedOut`/`IoError` failures. Checked on `&self`, before
+        // `Box::into_raw` opens the raw-pointer critical section, so a violation
+        // simply drops the box.
+        //
+        // The cost is `O(k)` in the collected set, plus each record's subtree.
+        // That is real, but resume only runs on a concurrent index change and `k`
+        // is the top-k bound, so it is worth paying for a release-mode guarantee.
+        // Suspend keeps the same check as a `debug_assert!` early warning
+        // instead: weakening a borrow is sound whatever the buffers hold.
+        if !self.buffers_carry_no_index_borrows() {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        let raw = Box::into_raw(self);
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+        // initialised, exclusively owned); `&raw mut` forms a field pointer to
+        // the child slot without creating a reference to the whole value.
+        let child_slot = unsafe { &raw mut (*raw).child };
+
+        // Resume the child in place. The `&mut` borrow of the slot is confined
+        // to this block so the raw `child_slot` write below never aliases it.
+        // SAFETY: `child_slot` is valid and exclusively owned, so `&mut` is a
+        // sound unique borrow of the slot.
+        let step = match unsafe { &mut *child_slot }.as_mut() {
+            None => ChildResume::NoChild,
+            Some(child) => {
+                // SAFETY: `child` is the valid, exclusively-owned suspended
+                // child. On Unchanged/Moved the helper rewrites the slot as a
+                // valid `IS::Resumed<'index>`; on Aborted/Err it consumes the
+                // child, leaving the slot uninitialised (handled below).
+                match unsafe { resume_child_slot_in_place(child as *mut IS, guard) } {
+                    // A moved child does not move *our* cursor — see the outcome
+                    // note below — so `Unchanged` and `Moved` are the same to us.
+                    Ok(ResumeSlotOutcome::Unchanged | ResumeSlotOutcome::Moved) => {
+                        ChildResume::Active
+                    }
+                    Ok(ResumeSlotOutcome::Aborted) => ChildResume::Aborted,
+                    Err(e) => ChildResume::Failed(e),
+                }
+            }
+        };
+
+        // An aborted child aborts the whole top-k: the filter it applied is
+        // unrecoverable, so the collected set can no longer be trusted. This
+        // mirrors `RQEIterator::revalidate`, which reports `Aborted` for exactly
+        // this case.
+        match step {
+            ChildResume::NoChild | ChildResume::Active => {}
+            ChildResume::Aborted | ChildResume::Failed(_) => {
+                // The child was consumed → its slot is uninitialised. Overwrite
+                // it with the `IS`-free `Absent` variant so the box is a valid
+                // owned value again, then drop it (see the `Drop` impl for why
+                // the buffered records outliving their terms is fine).
+                //
+                // SAFETY: `child_slot` is valid and exclusively owned;
+                // `ptr::write` does not drop the moved-from payload.
+                unsafe { child_slot.write(TopKChild::Absent) };
+                // SAFETY: `raw` is again a valid, exclusively-owned
+                // `RawTopK<'query, Suspended, S, IS>`; reclaim and drop it,
+                // freeing the allocation.
+                drop(unsafe { Box::from_raw(raw) });
+                return match step {
+                    ChildResume::Failed(e) => Err(e),
+                    _ => Ok(ResumeOutcome::Aborted),
+                };
+            }
+        }
+
+        // Reinterpret the owning box, reusing the allocation so the inline child
+        // — which `read()` delegates into, and whose own `resume` preserved its
+        // interior addresses — is not moved, and so the pointer the FFI wrapper
+        // caches into this iterator stays valid.
+        //
+        // SAFETY: `RawTopK<'query, Suspended, S, IS>` and
+        // `RawTopK<'index, Active<'index>, S, IS::Resumed<'index>>` are
+        // layout-identical by invariant 1 (const proof above): the child slot's
+        // `IS`/`IS::Resumed` size and alignment match is enforced by
+        // `resume_child_slot_in_place`, and every other field has the same type
+        // in both forms. Re-narrowing the buffered records' `'query` to the
+        // shorter `'index` is sound because they hold no index-backed payload —
+        // invariant 2, just verified above — and their query-pipeline borrows
+        // outlive `'index` by the `'query: 'index` bound. `Box::from_raw` reuses
+        // the same allocation.
+        let active = unsafe {
+            Box::from_raw(raw.cast::<RawTopK<'index, Active<'index>, S, IS::Resumed<'index>>>())
+        };
+
+        // Always `Ok`, never `Moved`: our position is `yield_pos` into our own
+        // score-ordered buffer, which the suspension left untouched, so the
+        // document `current()` reports is still the one the caller last read.
+        // `RQEIterator::revalidate` collapses a moved child the same way.
+        Ok(ResumeOutcome::Ok(active))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.last_doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        // Mode-independent — mirrors the active `num_estimated`; neither `k` nor
+        // `source` carries mode-dependent state.
+        self.k.get().min(self.source.num_estimated())
+    }
+}
+
+impl<'query, Rf: Ref, S: ScoreSource, I> RawTopK<'query, Rf, S, I> {
+    /// Whether every record parked for yielding satisfies invariant 2.
+    ///
+    /// Gates [`resume`](RQESuspendedIterator::resume) in every build, and backs
+    /// the `debug_assert!` early warning at the suspend boundary.
+    fn buffers_carry_no_index_borrows(&self) -> bool {
+        // The heap is drained into `results` by the end of `collect`, so it is
+        // empty at every point a caller can suspend us (invariant 3). Its
+        // emptiness *is* how it is covered here: there is nothing to walk, and a
+        // heap that somehow survived collection is a state this check must not
+        // wave through either.
+        self.heap.is_empty()
+            && self
+                .results
+                .iter()
+                .filter_map(|entry| entry.record.as_ref())
+                .chain(self.current.as_ref())
+                .all(carries_no_index_borrow)
+    }
+}
+
+/// Whether `record` carries no index-backed payload, recursively — the property
+/// invariant 2 on [`RawTopK`] rests on.
+///
+/// The index-backed payloads an [`Active`] result can hold are a term record's
+/// borrowed offset slice and an aggregate's borrowed entries; a captured record
+/// has neither, since [`RSIndexResult::to_owned`] copies the offsets and
+/// deep-copies the children.
+fn carries_no_index_borrow(record: &RSIndexResult<'_>) -> bool {
+    if let Some(term) = record.as_term()
+        && !term.is_copy()
+    {
+        return false;
+    }
+    if let Some(aggregate) = record.as_aggregate() {
+        // Borrowed entries point at a child's live result, which the release
+        // invalidates; only the owned representation can be carried across, and
+        // then only if its boxed children are index-free too.
+        let Some(owned) = aggregate.as_owned() else {
+            return false;
+        };
+        return (0..owned.len()).all(|i| owned.get(i).is_some_and(carries_no_index_borrow));
+    }
+    true
 }
 
 /// Deep-copy the child's current record, widening the borrowed query-term
@@ -824,7 +1301,215 @@ impl<'index, S: ScoreSource + 'index> rqe_iterators::interop::ProfileChildren<'i
         self.child = self
             .child
             .take()
-            .map(rqe_iterators::c2rust::CRQEIterator::into_profiled);
+            .map(rqe_iterators::c2rust::CRQEIterator::into_profiled)
+            .into();
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use index_result::RSOffsetSlice;
+    use rqe_iterators::Empty;
+    use rqe_iterators_test_utils::MockContext;
+
+    use super::*;
+
+    /// Encoded offset bytes standing in for a run owned by the inverted index —
+    /// the kind of buffer that a lock release can free underneath a parked
+    /// record.
+    static INDEX_OFFSETS: [u8; 3] = [1, 2, 3];
+
+    /// A single-entry [`ScoreBatch`].
+    struct OneDocBatch(Option<(DocId, f64)>);
+
+    impl ScoreBatch for OneDocBatch {
+        fn next(&mut self) -> Option<(DocId, f64)> {
+            self.0.take()
+        }
+
+        fn skip_to(&mut self, target: DocId) -> Option<(DocId, f64)> {
+            self.0.take_if(|(doc_id, _)| *doc_id >= target)
+        }
+    }
+
+    /// A [`ScoreSource`] that breaks [`ScoreSource::build_result`]'s obligation:
+    /// its record borrows its offsets from [`INDEX_OFFSETS`] instead of owning a
+    /// copy, so `carries_no_index_borrow` rejects it.
+    struct IndexBorrowingSource;
+
+    impl ScoreSource for IndexBorrowingSource {
+        type Batch = OneDocBatch;
+
+        fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
+            Ok(Some(OneDocBatch(Some((1, 1.0)))))
+        }
+
+        fn lookup_score(&mut self, _doc_id: DocId) -> Option<f64> {
+            None
+        }
+
+        fn num_estimated(&self) -> usize {
+            1
+        }
+
+        fn rewind(&mut self) {}
+
+        fn build_result<'r>(&self, doc_id: DocId, _score: f64) -> RSIndexResult<'r>
+        where
+            Self: 'r,
+        {
+            RSIndexResult::build_term()
+                .doc_id(doc_id)
+                .borrowed_record(None, RSOffsetSlice::from_slice(&INDEX_OFFSETS))
+                .build()
+        }
+
+        fn attach_score_metric<'r>(&self, _result: &mut RSIndexResult<'r>, _score: f64)
+        where
+            Self: 'r,
+        {
+        }
+
+        fn yields_child_record(&self) -> bool {
+            false
+        }
+
+        fn batch_strategy(&mut self, _heap_count: usize, _k: usize) -> BatchStrategy {
+            BatchStrategy::Stop
+        }
+
+        fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+            Ok(())
+        }
+
+        fn iterator_type(&self) -> IteratorType {
+            IteratorType::Mock
+        }
+    }
+
+    /// A [`ScoreSource`] that records whether the suspend boundary asked it to
+    /// let go of its index-backed state.
+    #[derive(Default)]
+    struct HandleTrackingSource {
+        released: std::rc::Rc<std::cell::Cell<bool>>,
+    }
+
+    impl ScoreSource for HandleTrackingSource {
+        type Batch = OneDocBatch;
+
+        fn next_batch(&mut self) -> Result<Option<Self::Batch>, RQEIteratorError> {
+            Ok(Some(OneDocBatch(Some((1, 1.0)))))
+        }
+
+        fn lookup_score(&mut self, _doc_id: DocId) -> Option<f64> {
+            None
+        }
+
+        fn num_estimated(&self) -> usize {
+            1
+        }
+
+        fn rewind(&mut self) {}
+
+        fn build_result<'r>(&self, doc_id: DocId, _score: f64) -> RSIndexResult<'r>
+        where
+            Self: 'r,
+        {
+            RSIndexResult::build_virt().doc_id(doc_id).build()
+        }
+
+        fn attach_score_metric<'r>(&self, _result: &mut RSIndexResult<'r>, _score: f64)
+        where
+            Self: 'r,
+        {
+        }
+
+        fn yields_child_record(&self) -> bool {
+            false
+        }
+
+        fn batch_strategy(&mut self, _heap_count: usize, _k: usize) -> BatchStrategy {
+            BatchStrategy::Stop
+        }
+
+        fn check_timeout(&mut self) -> Result<(), RQEIteratorError> {
+            Ok(())
+        }
+
+        fn iterator_type(&self) -> IteratorType {
+            IteratorType::Mock
+        }
+
+        fn release_index_handles(&mut self) {
+            self.released.set(true);
+        }
+    }
+
+    /// The source rides across the lock release untouched by the `Ref` split, so
+    /// whatever index state it holds is only released because `suspend` asks.
+    /// The case that makes this load-bearing is a VecSim batch iterator, which
+    /// dereferences its index pointer when *freed* — so a suspended top-k that
+    /// still owned one would fault on the drop path alone, never mind a read.
+    #[test]
+    fn suspend_asks_the_source_to_release_its_index_handles() {
+        let released = std::rc::Rc::new(std::cell::Cell::new(false));
+        let source = HandleTrackingSource {
+            released: std::rc::Rc::clone(&released),
+        };
+        let it = Box::new(TopKIterator::<_, Empty>::new_with_mode(
+            source,
+            None,
+            NonZeroUsize::new(1).unwrap(),
+            f64::total_cmp,
+            TopKMode::Unfiltered,
+        ));
+
+        assert!(!released.get(), "nothing released before the suspend");
+        let _suspended = it.suspend();
+        assert!(
+            released.get(),
+            "suspend must give the source the chance to drop index-backed state",
+        );
+    }
+
+    /// A parked record that borrows index data must abort the resume.
+    ///
+    /// Invariant 2 rests on two things no compiler checks: that
+    /// [`ScoreSource::build_result`] honours its obligation, and that no
+    /// consumer installs an index-backed payload through the `&mut` handed out
+    /// by [`current`](RQEIterator::current). Either can put a violating record
+    /// in front of the resume boundary in a release build, where the
+    /// suspend-side `debug_assert!` is compiled out — and re-narrowing it would
+    /// assert `&'index` borrows into memory the lock release may have freed.
+    #[test]
+    fn resume_aborts_when_a_parked_record_borrows_index_data() {
+        let mock_ctx = MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let mut it = Box::new(TopKIterator::<_, Empty>::new_with_mode(
+            IndexBorrowingSource,
+            None,
+            NonZeroUsize::new(1).unwrap(),
+            f64::total_cmp,
+            TopKMode::Unfiltered,
+        ));
+        assert_eq!(it.read().unwrap().expect("expected a doc").doc_id, 1);
+
+        // The offending record now sits in `current`, exactly where the yield
+        // path put it. Park it aside across the suspend boundary: this is a
+        // debug build, so the `debug_assert!` there would fire first, and what
+        // this test pins is the *release-mode* guarantee — which only the
+        // resume-side check provides.
+        let offending = it.current.take();
+        let mut suspended = it.suspend();
+        *suspended.current = offending;
+
+        let outcome = suspended
+            .resume(&guard)
+            .expect("an unsafe-to-resume state is recoverable, not an error");
+        assert!(
+            matches!(outcome, ResumeOutcome::Aborted),
+            "a record borrowing index data must abort the resume",
+        );
     }
 }

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -211,7 +211,26 @@ pub trait ScoreSource {
     /// [`attach_score_metric`](Self::attach_score_metric) instead — unless the
     /// source opts out via [`yields_child_record`](Self::yields_child_record).
     ///
+    /// # Obligation: no index-backed payload
+    ///
+    /// The returned record must carry **no index-backed payload**: no borrowed
+    /// term-offset slice and no borrowed aggregate entries. Build them owned
+    /// instead (a metric-only result, or a term record whose offsets were copied
+    /// — see [`RSIndexResult::to_owned`]).
+    ///
+    /// [`TopKIterator`] parks the record it yields in a buffer that survives a
+    /// suspend/resume cycle, across which the index lock is released and any
+    /// index-backed bytes may be freed underneath it. This obligation is what
+    /// makes those buffers safe to keep (invariant 2 on
+    /// [`RawTopK`](crate::iterator::RawTopK)).
+    ///
+    /// It cannot be enforced statically, so it is checked at the resume
+    /// boundary: a violating record makes the whole iterator abort
+    /// ([`ResumeOutcome::Aborted`]) rather than re-narrow pointers into freed
+    /// index memory — the query loses its results, but stays sound.
+    ///
     /// [`TopKIterator`]: crate::TopKIterator
+    /// [`ResumeOutcome::Aborted`]: rqe_iterators::ResumeOutcome::Aborted
     fn build_result<'r>(&self, doc_id: DocId, score: f64) -> RSIndexResult<'r>
     where
         Self: 'r;
@@ -266,4 +285,28 @@ pub trait ScoreSource {
     ///
     /// [`TopKIterator`]: crate::TopKIterator
     fn iterator_type(&self) -> IteratorType;
+
+    /// Release any state this source borrows from the index, so it can survive
+    /// a release of the index spec read lock.
+    ///
+    /// A source is carried across a suspend/resume cycle untouched — it is not
+    /// [`Ref`](ref_mode::Ref)-mode parametrised, so nothing about the transition
+    /// weakens what it holds. Anything index-backed inside it therefore outlives
+    /// the guarantee it was created under, and a concurrent writer or a dropped
+    /// index leaves it dangling — including on the `Drop` path, which is the
+    /// part that bites: a VecSim batch iterator dereferences its index pointer
+    /// when freed, so merely *discarding* a suspended top-k would fault.
+    ///
+    /// Called by [`TopKIterator::suspend`] before the lock is released. Only
+    /// reachable with collection finished or not yet started —
+    /// [`Phase::Collecting`] never survives a `read` — so a source may drop such
+    /// state outright rather than trying to preserve it; there is no batch
+    /// sequence left to continue.
+    ///
+    /// The default is a no-op, which is right for any source holding nothing
+    /// index-backed.
+    ///
+    /// [`TopKIterator::suspend`]: crate::TopKIterator
+    /// [`Phase::Collecting`]: crate::TopKIterator
+    fn release_index_handles(&mut self) {}
 }

--- a/src/redisearch_rs/top_k/tests/integration/revalidation.rs
+++ b/src/redisearch_rs/top_k/tests/integration/revalidation.rs
@@ -7,16 +7,20 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Integration tests for [`TopKIterator::revalidate`].
+//! Integration tests for [`TopKIterator::revalidate`] and its suspend/resume
+//! successor ([`RQEIteratorBoxed::suspend`] / [`RQESuspendedIterator::resume`]).
 
 use std::{cmp::Ordering, num::NonZeroUsize};
 
 use index_result::RSIndexResult;
 use index_spec::IndexSpecReadGuard;
 use rqe_core::DocId;
-use rqe_iterators::{RQEIterator, RQEValidateStatus};
-use rqe_iterators_test_utils::ContractChecker;
-use top_k::{BatchStrategy, TopKIterator, mock::MockScoreSource};
+use rqe_iterators::{
+    IdList, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome, TypeErasedRQEIterator,
+};
+use rqe_iterators_test_utils::{ContractChecker, ResumeOutcomeExt, revalidate_via_resume};
+use top_k::{BatchStrategy, TopKIterator, TopKMode, mock::MockScoreSource};
 
 /// Ascending comparator: lower score is better (e.g. vector distance).
 const fn asc() -> fn(a: &f64, b: &f64) -> Ordering {
@@ -217,4 +221,455 @@ fn moved_child_collapses_to_ok() {
     ));
     let status = it.revalidate(&mock_ctx.spec_read()).unwrap();
     assert_eq!(status, RQEValidateStatus::Ok);
+}
+
+// ── suspend / resume ──────────────────────────────────────────────────────────
+
+/// Which outcome [`SteerableChild`] reports from `revalidate` and `resume`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChildOutcome {
+    Ok,
+    Moved,
+    Aborted,
+    Failed,
+}
+
+/// Child iterator over a fixed doc-id list whose `revalidate` *and* `resume`
+/// both report a caller-chosen [`ChildOutcome`].
+///
+/// The public iterators cover neither `Aborted` nor `Failed` on the resume path,
+/// and driving both paths from the *same* knob is what makes the differential
+/// test below meaningful.
+struct SteerableChild<'index> {
+    docs: Vec<DocId>,
+    /// Index of the next doc to yield.
+    pos: usize,
+    /// The record handed out by `read`/`current`; a virtual sentinel whose
+    /// `doc_id` is rewritten in place, so it borrows nothing.
+    current: RSIndexResult<'index>,
+    /// Whether `current` holds a document the caller has been handed.
+    positioned: bool,
+    outcome: ChildOutcome,
+}
+
+impl<'index> SteerableChild<'index> {
+    fn new(docs: impl Into<Vec<DocId>>, outcome: ChildOutcome) -> Self {
+        Self {
+            docs: docs.into(),
+            pos: 0,
+            current: RSIndexResult::build_virt().build(),
+            positioned: false,
+            outcome,
+        }
+    }
+
+    /// Position on `docs[pos]` and hand it out, or report depletion.
+    fn yield_at_pos(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        match self.docs.get(self.pos) {
+            Some(&doc_id) => {
+                self.pos += 1;
+                self.current.doc_id = doc_id;
+                self.positioned = true;
+                Some(&mut self.current)
+            }
+            None => {
+                self.positioned = false;
+                None
+            }
+        }
+    }
+}
+
+impl<'index> RQEIterator<'index> for SteerableChild<'index> {
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        if self.positioned {
+            Some(&mut self.current)
+        } else {
+            None
+        }
+    }
+
+    fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
+        Ok(self.yield_at_pos())
+    }
+
+    fn skip_to(
+        &mut self,
+        doc_id: DocId,
+    ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
+        self.pos += self.docs[self.pos..].partition_point(|&id| id < doc_id);
+        let Some(found) = self.yield_at_pos() else {
+            return Ok(None);
+        };
+        Ok(Some(if found.doc_id == doc_id {
+            SkipToOutcome::Found(found)
+        } else {
+            SkipToOutcome::NotFound(found)
+        }))
+    }
+
+    fn revalidate(
+        &mut self,
+        _spec: &IndexSpecReadGuard,
+    ) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        match self.outcome {
+            ChildOutcome::Ok => Ok(RQEValidateStatus::Ok),
+            ChildOutcome::Moved => Ok(RQEValidateStatus::Moved {
+                current: self.current(),
+            }),
+            ChildOutcome::Aborted => Ok(RQEValidateStatus::Aborted),
+            ChildOutcome::Failed => Err(RQEIteratorError::TimedOut),
+        }
+    }
+
+    fn rewind(&mut self) {
+        self.pos = 0;
+        self.positioned = false;
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.docs.len()
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        if self.positioned {
+            self.current.doc_id
+        } else {
+            0
+        }
+    }
+
+    fn at_eof(&self) -> bool {
+        self.pos >= self.docs.len()
+    }
+
+    fn type_(&self) -> rqe_iterator_type::IteratorType {
+        rqe_iterator_type::IteratorType::Mock
+    }
+
+    fn intersection_sort_weight(&self, _: bool) -> f64 {
+        1.0
+    }
+}
+
+impl<'index> RQEIteratorBoxed<'index> for SteerableChild<'index> {
+    type Suspended = Self;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        // Nothing to weaken: the held record is a virtual sentinel.
+        self
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for SteerableChild<'query> {
+    type Resumed<'index>
+        = SteerableChild<'index>
+    where
+        'query: 'index;
+
+    fn resume<'index>(
+        self: Box<Self>,
+        _guard: &IndexSpecReadGuard<'index>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'index>>>, RQEIteratorError>
+    where
+        'query: 'index,
+    {
+        let outcome = self.outcome;
+        if outcome == ChildOutcome::Failed {
+            return Err(RQEIteratorError::TimedOut);
+        }
+        if outcome == ChildOutcome::Aborted {
+            // Consumed and dropped, as an aborted resume must be.
+            return Ok(ResumeOutcome::Aborted);
+        }
+        // SAFETY: the only lifetime-carrying field is a virtual sentinel that
+        // borrows nothing, so re-labelling `'query` as the shorter `'index`
+        // narrows a claim nothing relies on. The allocation is reused, as every
+        // resume must.
+        let resumed =
+            unsafe { Box::from_raw(Box::into_raw(self).cast::<SteerableChild<'index>>()) };
+        Ok(if outcome == ChildOutcome::Moved {
+            ResumeOutcome::Moved(resumed)
+        } else {
+            ResumeOutcome::Ok(resumed)
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        RQEIterator::last_doc_id(self)
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.docs.len()
+    }
+}
+
+/// A source emitting one batch of `(doc_id, score)` pairs, ascending in score so
+/// the yield order matches the doc order.
+fn source_over(docs: &[DocId]) -> MockScoreSource {
+    let batch: Vec<_> = docs
+        .iter()
+        .enumerate()
+        .map(|(i, &doc_id)| (doc_id, i as f64))
+        .collect();
+    MockScoreSource::new(vec![batch], vec![], |_, _| BatchStrategy::Continue)
+}
+
+/// Unwrapping a [`ResumeOutcome`] that still carries its *concrete* iterator.
+///
+/// [`ResumeOutcomeExt`] covers only the type-erased form; the tests below resume
+/// a concrete [`TopKIterator`] and keep reading through it.
+trait ExpectOkConcrete<T> {
+    /// Unwrap the resumed iterator, panicking unless the outcome is
+    /// [`ResumeOutcome::Ok`].
+    fn expect_ok_concrete(self) -> T;
+}
+
+impl<T> ExpectOkConcrete<T> for ResumeOutcome<T> {
+    #[track_caller]
+    fn expect_ok_concrete(self) -> T {
+        match self {
+            ResumeOutcome::Ok(it) => it,
+            ResumeOutcome::Moved(_) => panic!("expected ResumeOutcome::Ok, got Moved"),
+            ResumeOutcome::Aborted => panic!("expected ResumeOutcome::Ok, got Aborted"),
+        }
+    }
+}
+
+/// Read every remaining result, collecting the doc ids.
+fn drain<'index>(it: &mut impl RQEIterator<'index>) -> Vec<DocId> {
+    let mut seen = Vec::new();
+    while let Some(result) = it.read().expect("read failed") {
+        seen.push(result.doc_id);
+    }
+    seen
+}
+
+/// A top-k iterator resumed mid-yield must carry on from where it stopped.
+///
+/// Its results come from its own score-ordered buffer, which the suspension
+/// leaves untouched — so restarting collection would re-hand the caller
+/// documents it already received, and truncating would silently lose the tail.
+#[test]
+fn resume_mid_yield_continues_the_sequence() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let guard = mock_ctx.spec_read();
+    let child = IdList::<true>::new(vec![1, 2, 3, 4]);
+    let mut it = Box::new(TopKIterator::new(
+        source_over(&[1, 2, 3, 4]),
+        child,
+        NonZeroUsize::new(4).unwrap(),
+        asc(),
+    ));
+
+    let mut seen = vec![
+        it.read().unwrap().expect("expected doc").doc_id,
+        it.read().unwrap().expect("expected doc").doc_id,
+    ];
+    assert_eq!(seen, vec![1, 2]);
+
+    let mut active = it
+        .suspend()
+        .resume(&guard)
+        .expect("resume failed")
+        .expect_ok_concrete();
+
+    assert_eq!(
+        active.current().map(|r| r.doc_id),
+        Some(2),
+        "resume must leave the caller on the document it last read",
+    );
+    seen.extend(drain(&mut *active));
+    assert_eq!(
+        seen,
+        vec![1, 2, 3, 4],
+        "the resumed iterator must neither restart nor repeat",
+    );
+}
+
+/// The suspend/resume cycle must reuse the allocation: the FFI wrapper caches a
+/// raw pointer into the iterator, and a rebuilt box would dangle it.
+#[test]
+fn resume_preserves_box_address() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let guard = mock_ctx.spec_read();
+    let mut it = Box::new(TopKIterator::new(
+        source_over(&[1, 2]),
+        IdList::<true>::new(vec![1, 2]),
+        NonZeroUsize::new(2).unwrap(),
+        asc(),
+    ));
+    assert_eq!(it.read().unwrap().expect("expected doc").doc_id, 1);
+    let addr_before = &*it as *const _ as usize;
+
+    let suspended = it.suspend();
+    assert_eq!(
+        &*suspended as *const _ as usize, addr_before,
+        "suspend must reuse the allocation",
+    );
+    let active = suspended
+        .resume(&guard)
+        .expect("resume failed")
+        .expect_ok_concrete();
+    assert_eq!(
+        &*active as *const _ as usize, addr_before,
+        "resume must reuse the allocation",
+    );
+}
+
+/// A type-erased child crosses the suspend boundary through a vtable swap, not a
+/// byte cast — the active and suspended erased forms are different `dyn` types.
+/// A concrete-child round trip cannot catch a wrong-vtable bug; this one (also
+/// run under miri) can. The whole iterator is erased too, as the production FFI
+/// path erases it.
+#[test]
+fn resume_with_a_type_erased_child_survives() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let guard = mock_ctx.spec_read();
+    let child = TypeErasedRQEIterator::new(Box::new(IdList::<true>::new(vec![1, 2, 3])));
+    let mut it = TopKIterator::new(
+        source_over(&[1, 2, 3]),
+        child,
+        NonZeroUsize::new(3).unwrap(),
+        asc(),
+    );
+    assert_eq!(it.read().unwrap().expect("expected doc").doc_id, 1);
+
+    let mut active = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(it)), &guard)
+        .expect("resume failed")
+        .expect_ok();
+
+    assert_eq!(drain(&mut active), vec![2, 3]);
+}
+
+/// An unfiltered top-k has no child to transition, so its resume is the
+/// wrapper's own round trip — and it keeps streaming its batch.
+#[test]
+fn resume_without_a_child_keeps_streaming_the_batch() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let guard = mock_ctx.spec_read();
+    let mut it = Box::new(TopKIterator::<_, SteerableChild<'_>>::new_with_mode(
+        source_over(&[1, 2, 3]),
+        None,
+        NonZeroUsize::new(3).unwrap(),
+        asc(),
+        TopKMode::Unfiltered,
+    ));
+    assert_eq!(it.read().unwrap().expect("expected doc").doc_id, 1);
+
+    let mut active = it
+        .suspend()
+        .resume(&guard)
+        .expect("resume failed")
+        .expect_ok_concrete();
+    assert_eq!(drain(&mut *active), vec![2, 3]);
+}
+
+/// An aborted child aborts the whole top-k — the filter it applied is
+/// unrecoverable, so the collected set can no longer be trusted. The reused box
+/// is torn down without dropping the consumed child slot (miri covers that).
+#[test]
+fn resume_with_an_aborting_child_aborts() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let guard = mock_ctx.spec_read();
+    let mut it = Box::new(TopKIterator::new(
+        source_over(&[1, 2]),
+        SteerableChild::new([1, 2], ChildOutcome::Aborted),
+        NonZeroUsize::new(2).unwrap(),
+        asc(),
+    ));
+    assert_eq!(it.read().unwrap().expect("expected doc").doc_id, 1);
+
+    let outcome = it
+        .suspend()
+        .resume(&guard)
+        .expect("an aborted child is not an error");
+    assert!(matches!(outcome, ResumeOutcome::Aborted));
+}
+
+/// A child that fails to resume surfaces its error, and the reused box is torn
+/// down the same way as on `Aborted`.
+#[test]
+fn resume_propagates_a_child_error() {
+    let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+    let guard = mock_ctx.spec_read();
+    let mut it = Box::new(TopKIterator::new(
+        source_over(&[1, 2]),
+        SteerableChild::new([1, 2], ChildOutcome::Failed),
+        NonZeroUsize::new(2).unwrap(),
+        asc(),
+    ));
+    assert_eq!(it.read().unwrap().expect("expected doc").doc_id, 1);
+
+    assert!(matches!(
+        it.suspend().resume(&guard),
+        Err(RQEIteratorError::TimedOut)
+    ));
+}
+
+/// The legacy `revalidate` and the new `resume` must stay behaviourally
+/// identical while both exist: same outcome for the same child outcome, and the
+/// same results read afterwards.
+#[test]
+fn revalidate_and_resume_agree_on_every_child_outcome() {
+    /// The outcome shape the two paths share.
+    #[derive(Debug, PartialEq, Eq)]
+    enum Outcome {
+        Ok,
+        Moved,
+        Aborted,
+        Failed,
+    }
+
+    for child_outcome in [
+        ChildOutcome::Ok,
+        ChildOutcome::Moved,
+        ChildOutcome::Aborted,
+        ChildOutcome::Failed,
+    ] {
+        // Both paths start from the same state: two of the four collected
+        // results already handed out.
+        let build = || {
+            let mut it = Box::new(TopKIterator::new(
+                source_over(&[1, 2, 3, 4]),
+                SteerableChild::new([1, 2, 3, 4], child_outcome),
+                NonZeroUsize::new(4).unwrap(),
+                asc(),
+            ));
+            assert_eq!(it.read().unwrap().expect("expected doc").doc_id, 1);
+            assert_eq!(it.read().unwrap().expect("expected doc").doc_id, 2);
+            it
+        };
+
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+
+        let mut legacy = build();
+        let legacy_outcome = match legacy.revalidate(&guard) {
+            Ok(RQEValidateStatus::Ok) => Outcome::Ok,
+            Ok(RQEValidateStatus::Moved { .. }) => Outcome::Moved,
+            Ok(RQEValidateStatus::Aborted) => Outcome::Aborted,
+            Err(_) => Outcome::Failed,
+        };
+        let legacy_tail = match legacy_outcome {
+            Outcome::Ok | Outcome::Moved => drain(&mut *legacy),
+            Outcome::Aborted | Outcome::Failed => Vec::new(),
+        };
+
+        let (resumed_outcome, resumed_tail) = match build().suspend().resume(&guard) {
+            Ok(ResumeOutcome::Ok(mut it)) => (Outcome::Ok, drain(&mut *it)),
+            Ok(ResumeOutcome::Moved(mut it)) => (Outcome::Moved, drain(&mut *it)),
+            Ok(ResumeOutcome::Aborted) => (Outcome::Aborted, Vec::new()),
+            Err(_) => (Outcome::Failed, Vec::new()),
+        };
+
+        assert_eq!(
+            legacy_outcome, resumed_outcome,
+            "child {child_outcome:?}: the two paths disagree on the outcome",
+        );
+        assert_eq!(
+            legacy_tail, resumed_tail,
+            "child {child_outcome:?}: the two paths disagree on what is read afterwards",
+        );
+    }
 }

--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -564,6 +564,30 @@ impl<'index, E: ExpirationChecker> ScoreSource for VectorScoreSource<'index, E> 
             BatchStrategy::Continue
         }
     }
+    fn release_index_handles(&mut self) {
+        // The batch iterator is the one thing here that outlives its guarantee:
+        // it stores a raw VecSim index pointer and dereferences it on `next`
+        // *and* on `Drop`, so carrying it across a lock release makes even
+        // discarding the suspended top-k a use-after-free if the index went
+        // away. Dropping it costs nothing at this point — a suspend can only
+        // happen with collection finished or not yet started, so there is no
+        // batch sequence left to continue, and `rewind` would clear it anyway.
+        self.batch_iter = None;
+
+        // The adhoc paths hold index state too — tiered-index shared locks, or a
+        // one-shot disk context — but only between `begin_adhoc` and
+        // `end_adhoc`, both of which run inside a single collection call. If one
+        // is live here, collection did not finish and the caller suspended from
+        // a state that should not exist.
+        debug_assert!(
+            match &self.adhoc_state {
+                AdhocPathState::Ram { guard } => guard.is_none(),
+                AdhocPathState::Disk { ctx } => ctx.is_none(),
+            },
+            "adhoc index state is live at a suspend boundary: collection left it \
+             un-ended",
+        );
+    }
 }
 
 /// Smoothed update of the child-results estimate, averaging the previous


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `TopKIterator` cannot be suspended across a release of the index spec read lock, and it is the last consumer of the `Box<dyn RQEIterator>` child erasure that the rest of the iterator tree has already moved off.
2. Change: it is re-shaped into a `Ref`-mode-parametrized `RawTopK` (mirroring `Profile`) and implements `RQEIteratorBoxed::suspend` / `RQESuspendedIterator::resume`, reusing its allocation; the child moves from `Option<Box<dyn RQEIterator>>` to a concrete `Option<I>`. Resume preserves the yield position — phase, collected results, yield cursor and direct batch all survive — rather than restarting collection.
3. Outcome: no user-visible change; nothing suspends iterators yet. Beyond unblocking that wiring, dropping the last `dyn` child lets the blanket erasure impl be deleted in a later PR. Stacked on #10892.

#### Which additional issues this PR fixes

1. MOD-16715
2. #10892

#### Main objects this PR modified

1. `RawTopK<'index, Rf, S, I>` and the `TopKIterator` alias — the `Ref`-mode split, plus the `RawIndexResult<Rf>` + `has_current` sentinel holding the current result.
2. The held-record invariant at the resume boundary: buffered and parked records must carry no index-backed payload. `resume` checks it and returns `Aborted` rather than re-narrowing such a payload — the suspend-side `debug_assert!` is compiled out in release, so this check is the actual guarantee, and there is a test that drives exactly that state.
3. `resume`'s `ChildResume` staging — the child's outcome is captured so the `&mut` borrow of the slot is released before the slot is touched as a raw pointer.
4. `ResumeSlotOutcome` and `resume_child_slot_in_place` widened from `pub(crate)` to `pub` — `top_k` is a separate crate and needs the child-slot helpers. No external (command, reply, format) surface changes.
5. `top_k/tests/integration/revalidation.rs` — resume round trips alongside the existing revalidate cases.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
