### PR TITLE
[MOD-16713] Extract the shared union settle decision point

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/union.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union.rs
@@ -18,9 +18,88 @@
 //! - If `true`, returns after finding the first matching child without aggregating.
 //! - If `false`, collects results from all children with the same document.
 
+use index_result::RSIndexResult;
+
+use crate::{RQEValidateStatus, ResumeOutcome};
+
 pub use crate::union_flat::UnionFlat;
 pub use crate::union_heap::UnionHeap;
 pub use crate::union_trimmed::UnionTrimmed;
+
+/// Where settling left a union, after its children moved underneath it.
+///
+/// Both union variants settle through a single decision point, shared by the
+/// legacy [`RQEIterator::revalidate`] and the `Box<Self>`
+/// [`resume`](crate::RQESuspendedIterator::resume) path, and report the result
+/// as one of these three. Neither path matches on them directly:
+/// [`into_validate_status`](Self::into_validate_status) and
+/// [`into_resume_outcome`](Self::into_resume_outcome) below own the two
+/// mappings, so a variant cannot come to mean one thing on one path and
+/// something else on the other.
+///
+/// | `SettleOutcome` | `RQEValidateStatus`         | `ResumeOutcome` |
+/// |-----------------|-----------------------------|-----------------|
+/// | `Unchanged`     | `Ok`                        | `Ok`            |
+/// | `Moved`         | `Moved { current: Some(_) }`| `Moved`         |
+/// | `Eof`           | `Moved { current: None }`   | `Moved`         |
+///
+/// The two disagree on `Eof` for a reason: `RQEValidateStatus` distinguishes
+/// "moved, and here is the new current" from "moved, and there is no current",
+/// while `ResumeOutcome` carries the iterator itself and lets the caller ask.
+///
+/// [`RQEIterator::revalidate`]: crate::RQEIterator::revalidate
+#[expect(
+    dead_code,
+    reason = "The variants that funnel through it land in later revisions"
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SettleOutcome {
+    /// The union is still on the document it was on, and that document is still backed
+    /// by an active child.
+    Unchanged,
+    /// The union advanced, and its result describes the new position.
+    Moved,
+    /// The union ran out of documents while settling; it is now at EOF and has no
+    /// current result.
+    Eof,
+}
+
+#[expect(
+    dead_code,
+    reason = "The variants that funnel through it land in later revisions"
+)]
+impl SettleOutcome {
+    /// Map onto the legacy [`RQEIterator::revalidate`] outcome, publishing
+    /// `result` as the new current where there is one.
+    ///
+    /// [`RQEIterator::revalidate`]: crate::RQEIterator::revalidate
+    pub(crate) const fn into_validate_status<'a, 'index>(
+        self,
+        result: &'a mut RSIndexResult<'index>,
+    ) -> RQEValidateStatus<'a, 'index> {
+        match self {
+            Self::Unchanged => RQEValidateStatus::Ok,
+            Self::Moved => RQEValidateStatus::Moved {
+                current: Some(result),
+            },
+            // At EOF the union publishes no current, so the borrow goes unused.
+            Self::Eof => RQEValidateStatus::Moved { current: None },
+        }
+    }
+
+    /// Map onto the `Box<Self>` [`resume`](crate::RQESuspendedIterator::resume)
+    /// outcome, handing `it` back either way.
+    ///
+    /// `Eof` joins `Moved` here rather than splitting off as it does for
+    /// `revalidate`: both leave the union somewhere other than where it was, and
+    /// `Eof` has already set `is_eof`, so the caller sees no current from either.
+    pub(crate) const fn into_resume_outcome<T>(self, it: T) -> ResumeOutcome<T> {
+        match self {
+            Self::Unchanged => ResumeOutcome::Ok(it),
+            Self::Moved | Self::Eof => ResumeOutcome::Moved(it),
+        }
+    }
+}
 
 // ============================================================================
 // Type aliases for convenient access


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: both union variants settle through the same decision point, but each maps its outcome onto `RQEValidateStatus` (legacy `revalidate`) and `ResumeOutcome` (the boxed path) with its own `match`. Whichever of the flat and heap variants landed first would have had to introduce that shared vocabulary, making the other depend on it for no reason.
2. Change: roughly 90 lines in `union.rs` — the `SettleOutcome` enum and the two conversions that own its mappings, `into_validate_status` and `into_resume_outcome`. No behaviour change, and nothing calls them yet, so it ships with an `#[expect(dead_code)]` that its first caller removes.
3. Outcome: no user-visible change. It exists so `UnionFlat` and `UnionHeap` can implement suspend/resume in independent branches without one depending on the other. Stacked on #10892.

#### Which additional issues this PR fixes

1. MOD-16713
2. #10892

#### Main objects this PR modified

1. `union::SettleOutcome` — `Unchanged` / `Moved` / `Eof`, the return type of both variants' settle step.
2. `into_validate_status` / `into_resume_outcome` — the two mappings, owned here rather than repeated at four call sites. This is what makes the shared vocabulary worth having: the variants cannot come to mean one thing on the legacy path and something else on the boxed one, which a shared enum alone would not prevent.
3. The mapping table in the enum's doc comment, including why the two paths disagree on `Eof`: `RQEValidateStatus` distinguishes "moved, here is the new current" from "moved, no current", while `ResumeOutcome` carries the iterator and lets the caller ask.
4. Nothing else. If this PR contains anything beyond the enum, its conversions and their documentation, that is a mistake worth flagging.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
