### PR TITLE
[MOD-16713] UnionFlat: suspend/resume

### DIFF
--- a/src/redisearch_rs/rqe_iterators/.skills/rqe-iterator-suspend-resume/SKILL.md
+++ b/src/redisearch_rs/rqe_iterators/.skills/rqe-iterator-suspend-resume/SKILL.md
@@ -450,5 +450,12 @@ teardown. Any bespoke in-place transition code must reproduce this.
 - `maybe_empty.rs` — wrapper with **no result of its own**: `#[repr(C)]`
   `MaybeEmptyOption` newtype, child-abort propagation, delegating suspended
   accessors.
+- `union_flat.rs` — worked example of a **many-child** composite: the walk over
+  every child slot, compaction over aborted ones, a `FreeSuspendedShell` RAII
+  guard owning the half-transitioned buffer (the region boundaries live in the
+  guard, so the teardown reads them rather than being handed indices), a
+  `rebuild_borrowed_entries` that recomputes the contributor set instead of
+  matching entries by address, and a settle step shared with the legacy
+  `revalidate` so the two paths cannot drift.
 - `numeric.rs`, `term.rs` — newtype-over-inner leaves that cite the inner's
   invariant.

--- a/src/redisearch_rs/rqe_iterators/src/union.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union.rs
@@ -48,10 +48,6 @@ pub use crate::union_trimmed::UnionTrimmed;
 /// while `ResumeOutcome` carries the iterator itself and lets the caller ask.
 ///
 /// [`RQEIterator::revalidate`]: crate::RQEIterator::revalidate
-#[expect(
-    dead_code,
-    reason = "The variants that funnel through it land in later revisions"
-)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SettleOutcome {
     /// The union is still on the document it was on, and that document is still backed
@@ -64,10 +60,6 @@ pub(crate) enum SettleOutcome {
     Eof,
 }
 
-#[expect(
-    dead_code,
-    reason = "The variants that funnel through it land in later revisions"
-)]
 impl SettleOutcome {
     /// Map onto the legacy [`RQEIterator::revalidate`] outcome, publishing
     /// `result` as the new current where there is one.

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -12,6 +12,7 @@
 use index_result::{RSIndexResult, RSResultKind, RawIndexResult};
 use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
+use std::marker::PhantomData;
 
 use crate::union::SettleOutcome;
 use crate::{
@@ -118,54 +119,90 @@ const _: () = {
     assert!(align_of::<A>() == align_of::<S>());
 };
 
-/// Frees a suspended [`RawUnionFlat`]'s reused allocation after the in-place
-/// resume consumed the child at `consumed`: drops the compacted resumed prefix
-/// `children[..kept]` in place and the still-suspended tail past `consumed`,
-/// skips the holes in between (moved-from or consumed), empties the `Vec` so it
-/// frees only its buffer, then drops the box (freeing the still-suspended
-/// `result` and the allocation).
+/// RAII guard owning a suspended [`RawUnionFlat`]'s shell while its children
+/// buffer is part-resumed and part-suspended.
 ///
-/// # Safety
+/// The buffer is three regions during `resume`, and the guard's fields *are*
+/// their boundaries: [`kept`](Self::kept) resumed survivors compacted to the
+/// front, vacated slots up to [`cursor`](Self::cursor) — moved left by the
+/// compaction, or consumed by a child that aborted or failed — and
+/// still-suspended children from there to [`len`](Self::len). `resume` advances
+/// the boundaries as it walks, so the drop reads the state that actually holds
+/// rather than being handed indices that have to agree with it.
 ///
-/// * `raw` must be exclusively owned and have come from `Box::into_raw`.
-/// * `children[..kept]` must hold valid `IndexedChild<S::Resumed<'a>>` values,
-///   `children[kept..=consumed]` must be moved-from or consumed (they are not
-///   touched), and `children[consumed + 1..]` must hold valid `IndexedChild<S>`
-///   values — the exact state the in-place resume loop leaves behind when the
-///   slot helper reports `Err` for element `consumed`.
-unsafe fn free_after_consumed_child<'query, 'a, S, const QUICK_EXIT: bool>(
-    raw: *mut RawUnionFlat<'query, Suspended, S, QUICK_EXIT>,
-    kept: usize,
-    consumed: usize,
-) where
+/// On drop — an early return or a panic — it drops the prefix at the resumed
+/// type, drops the suspended tail, leaves the vacated middle alone, empties the
+/// `Vec` so it frees only its buffer, and drops the shell (freeing the
+/// still-suspended `result` and the allocation). Disarmed with
+/// [`std::mem::forget`] once the buffer is whole again and the cast is about to
+/// run.
+struct FreeSuspendedShell<'query, 'a, S, const QUICK_EXIT: bool>
+where
     S: RQESuspendedIterator<'query>,
     'query: 'a,
 {
-    // SAFETY: `raw` is exclusively owned (caller contract); the borrow is used
-    // only to reach the buffer pointer, the length, and `set_len`.
-    let children: &mut Vec<IndexedChild<S>> = unsafe { &mut (*raw).children };
-    let len = children.len();
-    let base = children.as_mut_ptr();
-    for i in 0..kept {
-        // SAFETY: `i` is in bounds of the children buffer.
-        let slot = unsafe { base.add(i) };
-        // SAFETY: the slot holds a valid resumed child (caller contract); drop
-        // it through the resumed type (same size/alignment, enforced by the
-        // slot helper's const guard).
-        unsafe { std::ptr::drop_in_place(slot.cast::<IndexedChild<S::Resumed<'a>>>()) };
+    /// The shell, still owned here. Came from `Box::into_raw`.
+    raw: *mut RawUnionFlat<'query, Suspended, S, QUICK_EXIT>,
+    /// `children[..kept]` hold resumed survivors.
+    kept: usize,
+    /// `children[kept..cursor]` are vacated and must not be dropped.
+    cursor: usize,
+    /// `children[cursor..len]` still hold suspended children.
+    len: usize,
+    /// The type the prefix must be dropped at. Never materialised, so it adds
+    /// no drop glue of its own.
+    _resumed: PhantomData<fn() -> S::Resumed<'a>>,
+}
+
+impl<'query, 'a, S, const QUICK_EXIT: bool> Drop for FreeSuspendedShell<'query, 'a, S, QUICK_EXIT>
+where
+    S: RQESuspendedIterator<'query>,
+    'query: 'a,
+{
+    fn drop(&mut self) {
+        debug_assert!(!self.raw.is_null(), "the shell must still be owned here");
+        // The whole teardown rests on this ordering and nothing else checks it.
+        // The way to break it is to move `cursor`'s advance in `resume` to
+        // *after* the slot helper call — which reads like a tidy-up, since every
+        // other field is advanced after its work — leaving a consumed slot
+        // inside the suspended tail for the loop below to drop a second time.
+        debug_assert!(
+            self.kept <= self.cursor && self.cursor <= self.len,
+            "region boundaries out of order: kept={}, cursor={}, len={}",
+            self.kept,
+            self.cursor,
+            self.len,
+        );
+        // SAFETY: `raw` is exclusively owned by this guard; the borrow reaches
+        // the buffer pointer and the length, and is confined to this function.
+        let children: &mut Vec<IndexedChild<S>> = unsafe { &mut (*self.raw).children };
+        debug_assert!(
+            self.len <= children.capacity(),
+            "the recorded length outruns the buffer it indexes",
+        );
+        let base = children.as_mut_ptr();
+        for i in 0..self.kept {
+            // SAFETY: `i < kept <= len`, in bounds of the children buffer.
+            let slot = unsafe { base.add(i) };
+            // SAFETY: the slot holds a resumed survivor; drop it through the
+            // resumed type, which shares `S`'s size and alignment (statically
+            // enforced by the slot helper's const guard).
+            unsafe { std::ptr::drop_in_place(slot.cast::<IndexedChild<S::Resumed<'a>>>()) };
+        }
+        for i in self.cursor..self.len {
+            // SAFETY: `i < len`, in bounds of the children buffer.
+            let slot = unsafe { base.add(i) };
+            // SAFETY: the slot still holds a valid suspended child.
+            unsafe { std::ptr::drop_in_place(slot) };
+        }
+        // SAFETY: every element has been dropped, moved or consumed; zeroing the
+        // length keeps the `Vec` from dropping them again, so it frees only its
+        // buffer.
+        unsafe { children.set_len(0) };
+        // SAFETY: the shell is a well-formed suspended union again (empty
+        // children, still-suspended `result`, `Rf`-free scalars).
+        drop(unsafe { Box::from_raw(self.raw) });
     }
-    for i in (consumed + 1)..len {
-        // SAFETY: `i` is in bounds of the children buffer.
-        let slot = unsafe { base.add(i) };
-        // SAFETY: the slot still holds a valid suspended child.
-        unsafe { std::ptr::drop_in_place(slot) };
-    }
-    // SAFETY: every element was dropped, moved, or consumed; zeroing the length
-    // keeps the `Vec` from dropping them again — it frees only its buffer.
-    unsafe { children.set_len(0) };
-    // SAFETY: `raw` is a well-formed suspended union again (empty children,
-    // still-suspended `result`, `Rf`-free scalars); reclaim and drop it.
-    drop(unsafe { Box::from_raw(raw) });
 }
 
 // Methods used in both modes.
@@ -1181,7 +1218,22 @@ where
         // early return for one and reports success, leaving boxed children whose
         // own `data` may still be index-backed and suspended — a case no union
         // is equipped to re-validate. This is what keeps it unreachable.
-        if self.result.kind() != RSResultKind::Union {
+        //
+        // The kind alone is not enough: an aggregate of kind `Union` can be the
+        // *owned* representation, whose children are boxed into the result's own
+        // allocation and are never transitioned. Safe code can build one —
+        // `to_owned()` on a union result, `push_boxed` an index-backed term into
+        // it, assign it through `current()` — and a boxed child's `data` can be
+        // index-backed and suspended, so re-narrowing it would promote pointers
+        // nothing re-validated. The rebuild cannot catch it either: an owned
+        // aggregate borrows nothing, so it has nothing to rebuild and reports
+        // success. Demanding the borrowed representation is what closes that.
+        let is_borrowed_union = self.result.kind() == RSResultKind::Union
+            && self
+                .result
+                .as_aggregate()
+                .is_some_and(|aggregate| aggregate.as_borrowed().is_some());
+        if !is_borrowed_union {
             return Ok(ResumeOutcome::Aborted);
         }
 
@@ -1216,7 +1268,7 @@ where
         // pulling still-suspended children out of the tail and re-entering slots
         // the walk has already transitioned, so the buffer would no longer be a
         // resumed prefix followed by a suspended suffix — the split
-        // `free_after_consumed_child` relies on to tear the allocation down.
+        // [`FreeSuspendedShell`] relies on to tear the allocation down.
         // Compacting is the deliberate choice.
         //
         // Whatever the walk does to the children, the suspended aggregate's
@@ -1234,9 +1286,24 @@ where
             let children: &mut Vec<IndexedChild<S>> = unsafe { &mut (*raw).children };
             (children.as_mut_ptr(), children.len())
         };
+        // From here until the cast, the buffer is part-resumed and part-suspended
+        // and `shell` owns it: every early return below, and any panic, frees it
+        // through the guard's drop rather than through a call the exit has to
+        // remember to make.
+        let mut shell = FreeSuspendedShell::<'query, 'a, S, QUICK_EXIT> {
+            raw,
+            kept: 0,
+            cursor: 0,
+            len,
+            _resumed: PhantomData,
+        };
         let mut any_change = false;
-        let mut kept = 0usize;
         for i in 0..len {
+            // Slot `i` counts as vacated for as long as the helper owns its
+            // contents, so the boundary moves *before* the call, not after: on
+            // `Err` the child is consumed and the guard must already know not to
+            // drop it.
+            shell.cursor = i + 1;
             // SAFETY: `i` is in bounds of the children buffer.
             let elem = unsafe { base.add(i) };
             // SAFETY: `elem` holds a valid `IndexedChild`; `&raw mut` forms a
@@ -1245,63 +1312,46 @@ where
             // SAFETY: `inner` holds a valid, owned `S`; the helper rewrites it as
             // a valid `S::Resumed<'a>` on `Unchanged`/`Moved`, and consumes it on
             // `Aborted`/`Err`.
-            match unsafe { resume_child_slot_in_place(inner, guard) } {
-                Ok(outcome) => {
-                    match outcome {
-                        ResumeSlotOutcome::Unchanged => {}
-                        ResumeSlotOutcome::Moved => any_change = true,
-                        ResumeSlotOutcome::Aborted => {
-                            // Dropped from the union, as `revalidate` drops an
-                            // aborted child; the hole is compacted over by later
-                            // survivors.
-                            any_change = true;
-                            continue;
-                        }
-                    }
-                    if kept < i {
-                        // SAFETY: `kept < i < len`, both in bounds.
-                        let dst = unsafe { base.add(kept) };
-                        // SAFETY: slot `kept` was vacated (its element moved left
-                        // or was consumed) and `elem` holds a resumed child, so
-                        // this is a single-element move between disjoint,
-                        // in-bounds slots. `copy_nonoverlapping` is a move — the
-                        // source is treated as vacated from here on.
-                        unsafe {
-                            std::ptr::copy_nonoverlapping(
-                                elem.cast::<IndexedChild<S::Resumed<'a>>>().cast_const(),
-                                dst.cast::<IndexedChild<S::Resumed<'a>>>(),
-                                1,
-                            )
-                        };
-                    }
-                    kept += 1;
-                }
-                Err(e) => {
-                    // The one place resume cannot match `revalidate`, and it is
-                    // structural rather than a choice. A spent union — `is_eof`,
-                    // nothing left to read — makes `revalidate` return `Ok`
-                    // before it looks at a child, so a child that would time out
-                    // is never asked and the union survives. Resume has to ask
-                    // every child before it can hand any of them back, and
-                    // `S::resume` takes the child *by value*: once it answers
-                    // `Err` the child is gone, so there is no walking past it to
-                    // reach the `is_eof` exit below. The union is torn down and
-                    // the error reaches the caller, where `revalidate` would have
-                    // reported `Ok`.
-                    //
-                    // Pinned by `resume_of_a_spent_union_surfaces_a_child_error`
-                    // rather than left to be rediscovered.
-                    //
-                    // SAFETY: `children[..kept]` holds compacted resumed
-                    // survivors, `children[kept..=i]` holes or the consumed
-                    // element, `children[i + 1..]` still-suspended children — the
-                    // exact state the teardown documents; `raw` is exclusively
-                    // owned.
-                    unsafe { free_after_consumed_child::<S, QUICK_EXIT>(raw, kept, i) };
-                    return Err(e);
+            //
+            // An `Err` returns through `?`, dropping `shell`. That is the one
+            // place resume cannot match `revalidate`, and it is structural rather
+            // than a choice: a spent union — `is_eof`, nothing left to read —
+            // makes `revalidate` return `Ok` before it looks at a child, so a
+            // child that would time out is never asked. Resume has to ask every
+            // child before it can hand any of them back, and `S::resume` takes
+            // the child *by value*, so once it answers `Err` there is nothing
+            // left to walk past to reach the `is_eof` exit below. Pinned by
+            // `resume_of_a_spent_union_surfaces_a_child_error`.
+            match unsafe { resume_child_slot_in_place(inner, guard) }? {
+                ResumeSlotOutcome::Unchanged => {}
+                ResumeSlotOutcome::Moved => any_change = true,
+                ResumeSlotOutcome::Aborted => {
+                    // Dropped from the union, as `revalidate` drops an aborted
+                    // child; the hole is compacted over by later survivors.
+                    any_change = true;
+                    continue;
                 }
             }
+            if shell.kept < i {
+                // SAFETY: `shell.kept < i < len`, both in bounds.
+                let dst = unsafe { base.add(shell.kept) };
+                // SAFETY: slot `shell.kept` was vacated (its element moved left
+                // or was consumed) and `elem` holds a resumed child, so this is a
+                // single-element move between disjoint, in-bounds slots.
+                // `copy_nonoverlapping` is a move — the source is treated as
+                // vacated from here on, which is what the guard's vacated middle
+                // already covers.
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        elem.cast::<IndexedChild<S::Resumed<'a>>>().cast_const(),
+                        dst.cast::<IndexedChild<S::Resumed<'a>>>(),
+                        1,
+                    )
+                };
+            }
+            shell.kept += 1;
         }
+        let kept = shell.kept;
         // SAFETY: `raw` is exclusively owned; the borrow is confined to this
         // statement.
         let children = unsafe { &mut (*raw).children };
@@ -1357,6 +1407,14 @@ where
                 children.iter_mut().map(|c| &mut c.inner),
             )
         };
+
+        // The buffer is whole again and the next statement takes ownership of the
+        // allocation, so the guard is disarmed here and not before: it stayed
+        // armed across the `set_len` and the aggregate work above, where the
+        // elements are still *typed* as suspended while holding resumed children,
+        // and an unwind out of either would otherwise have dropped them at the
+        // wrong type.
+        std::mem::forget(shell);
 
         // SAFETY: every surviving child slot holds its resumed form inside the
         // `Vec`'s untouched buffer, and the aggregate's entries have just been

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -9,11 +9,16 @@
 
 //! Flat array variant of the union iterator with O(n) min-finding.
 
-use index_result::{RSIndexResult, RawIndexResult};
-use ref_mode::{Active, Ref};
+use index_result::{RSIndexResult, RSResultKind, RawIndexResult};
+use ref_mode::{Active, Ref, Suspended};
 use rqe_core::DocId;
 
-use crate::{IteratorType, RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
+use crate::union::SettleOutcome;
+use crate::{
+    IteratorType, RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator,
+    RQEValidateStatus, ResumeOutcome, SkipToOutcome,
+    boxed::{ResumeSlotOutcome, resume_child_slot_in_place},
+};
 use index_spec::IndexSpecReadGuard;
 
 /// A child iterator paired with its original insertion index.
@@ -89,6 +94,79 @@ pub struct RawUnionFlat<'query, Rf: Ref, I, const QUICK_EXIT: bool> {
 /// [`RQEIterator`] impl today.
 pub type UnionFlat<'index, I, const QUICK_EXIT: bool> =
     RawUnionFlat<'index, Active<'index>, I, QUICK_EXIT>;
+
+// Compile-time proof of invariant 1 on `RawUnionFlat`: for a representative
+// concrete child, the `Active` and `Suspended` instantiations are
+// layout-identical. The child elements' own compatibility is their invariant 1
+// (enforced generically by the slot helpers), carried through the `#[repr(C)]`
+// `IndexedChild`; `result` is layout-compatible across `Rf` (proven in
+// `index_result`); the remaining fields are `Rf`-free. `QUICK_EXIT` never
+// affects layout.
+const _: () = {
+    use crate::Wildcard;
+    use std::mem::{align_of, offset_of, size_of};
+    type AChild = Wildcard<'static>;
+    type SChild = <Wildcard<'static> as RQEIteratorBoxed<'static>>::Suspended;
+    type A = RawUnionFlat<'static, Active<'static>, AChild, false>;
+    type S = RawUnionFlat<'static, Suspended, SChild, false>;
+    assert!(offset_of!(A, children) == offset_of!(S, children));
+    assert!(offset_of!(A, num_active) == offset_of!(S, num_active));
+    assert!(offset_of!(A, num_estimated) == offset_of!(S, num_estimated));
+    assert!(offset_of!(A, is_eof) == offset_of!(S, is_eof));
+    assert!(offset_of!(A, result) == offset_of!(S, result));
+    assert!(size_of::<A>() == size_of::<S>());
+    assert!(align_of::<A>() == align_of::<S>());
+};
+
+/// Frees a suspended [`RawUnionFlat`]'s reused allocation after the in-place
+/// resume consumed the child at `consumed`: drops the compacted resumed prefix
+/// `children[..kept]` in place and the still-suspended tail past `consumed`,
+/// skips the holes in between (moved-from or consumed), empties the `Vec` so it
+/// frees only its buffer, then drops the box (freeing the still-suspended
+/// `result` and the allocation).
+///
+/// # Safety
+///
+/// * `raw` must be exclusively owned and have come from `Box::into_raw`.
+/// * `children[..kept]` must hold valid `IndexedChild<S::Resumed<'a>>` values,
+///   `children[kept..=consumed]` must be moved-from or consumed (they are not
+///   touched), and `children[consumed + 1..]` must hold valid `IndexedChild<S>`
+///   values — the exact state the in-place resume loop leaves behind when the
+///   slot helper reports `Err` for element `consumed`.
+unsafe fn free_after_consumed_child<'query, 'a, S, const QUICK_EXIT: bool>(
+    raw: *mut RawUnionFlat<'query, Suspended, S, QUICK_EXIT>,
+    kept: usize,
+    consumed: usize,
+) where
+    S: RQESuspendedIterator<'query>,
+    'query: 'a,
+{
+    // SAFETY: `raw` is exclusively owned (caller contract); the borrow is used
+    // only to reach the buffer pointer, the length, and `set_len`.
+    let children: &mut Vec<IndexedChild<S>> = unsafe { &mut (*raw).children };
+    let len = children.len();
+    let base = children.as_mut_ptr();
+    for i in 0..kept {
+        // SAFETY: `i` is in bounds of the children buffer.
+        let slot = unsafe { base.add(i) };
+        // SAFETY: the slot holds a valid resumed child (caller contract); drop
+        // it through the resumed type (same size/alignment, enforced by the
+        // slot helper's const guard).
+        unsafe { std::ptr::drop_in_place(slot.cast::<IndexedChild<S::Resumed<'a>>>()) };
+    }
+    for i in (consumed + 1)..len {
+        // SAFETY: `i` is in bounds of the children buffer.
+        let slot = unsafe { base.add(i) };
+        // SAFETY: the slot still holds a valid suspended child.
+        unsafe { std::ptr::drop_in_place(slot) };
+    }
+    // SAFETY: every element was dropped, moved, or consumed; zeroing the length
+    // keeps the `Vec` from dropping them again — it frees only its buffer.
+    unsafe { children.set_len(0) };
+    // SAFETY: `raw` is a well-formed suspended union again (empty children,
+    // still-suspended `result`, `Rf`-free scalars); reclaim and drop it.
+    drop(unsafe { Box::from_raw(raw) });
+}
 
 // Methods used in both modes.
 impl<'index, I, const QUICK_EXIT: bool> UnionFlat<'index, I, QUICK_EXIT>
@@ -169,6 +247,192 @@ where
         (children.len() >= 3).then(|| super::UnionTrimmed::new(children, limit, asc))
     }
 
+    /// Settles the union's position after its children have moved, and reports where
+    /// that leaves it.
+    ///
+    /// The single place that decides a union's post-change position, shared by
+    /// [`RQEIterator::revalidate`] and
+    /// [`RQESuspendedIterator::resume`] so the two
+    /// cannot drift apart — the legacy and the `Box<Self>` path must make the same
+    /// re-seek and moved-versus-unchanged decisions, and a divergence between them is a
+    /// bug. Each caller re-admits every child first (`num_active = children.len()`),
+    /// because removing an aborted child invalidates the active/parked partition —
+    /// not because a parked child can come back. The scan below re-parks the ones
+    /// that are still exhausted.
+    ///
+    /// `original_last_doc_id` is the position the union held before the children moved.
+    fn settle_after_children_changed(
+        &mut self,
+        original_last_doc_id: DocId,
+    ) -> Result<SettleOutcome, RQEIteratorError> {
+        // Only a child that has run past its last result is dropped: one that has
+        // merely returned its final document still owes it, and dropping it would
+        // lose that document — or report EOF for the whole union, if it was the
+        // last active child.
+        let mut min_doc_id: DocId = DocId::MAX;
+        let mut min_child_idx: usize = 0;
+        let mut i = 0;
+        while i < self.num_active {
+            let child = &self.children[i];
+            if child.at_eof() {
+                self.swap_remove_child(i);
+                // Don't increment i - check the swapped-in child
+            } else {
+                let child_doc_id = child.last_doc_id();
+                if child_doc_id < min_doc_id {
+                    min_doc_id = child_doc_id;
+                    min_child_idx = i;
+                }
+                i += 1;
+            }
+        }
+
+        // Every remaining child is at EOF.
+        if self.num_active == 0 {
+            self.is_eof = true;
+            return Ok(SettleOutcome::Eof);
+        }
+
+        // A minimum *behind* the union is not a position to move to — adopting it
+        // would replay documents, because a reported move has the caller emit
+        // `current` in place of a read and the read after that resumes from there.
+        // `iterator_api.h` says `VALIDATE_MOVED` means the position moved
+        // *forward*, and `Not::revalidate` asserts that of its child — which is
+        // where a `QUICK_EXIT` union usually sits.
+        //
+        // With `QUICK_EXIT` this is the mode's own early return, and routine:
+        // `skip_to_quick` stops on the first exact match, so a later sibling keeps
+        // an earlier round's id, or answers 0 having never been read at all.
+        //
+        // A full union cannot get here: `advance_and_find_min` leaves no active
+        // child behind the union, and exhaustion is terminal across a revalidation
+        // *and* a resume (see [`RQEIterator::at_eof`]), so a child dropped on EOF
+        // cannot re-enter the active set behind us on either path. Asserted rather
+        // than compensated for — the recovery below is quick mode's, and a full
+        // union arriving in it means a child is broken.
+        if min_doc_id < original_last_doc_id {
+            debug_assert!(
+                QUICK_EXIT,
+                "a full union's child moved behind the union's position: doc {min_doc_id} \
+                 comes before doc {original_last_doc_id}",
+            );
+
+            // A child still sitting on the union's document backs the position as
+            // it stands: republish from it (the result holds raw pointers into
+            // children that may have moved or been dropped) and report no change,
+            // with no reads spent. `min_child_idx` cannot serve — that is the
+            // lagging child just rejected. Quick mode only: its laggers are
+            // ordinary state for the next `read`/`skip_to` to seek past, while a
+            // full union must catch them up below either way —
+            // `advance_and_find_min` relies on no active child sitting behind the
+            // union.
+            if QUICK_EXIT
+                && let Some(idx) = self.children[..self.num_active]
+                    .iter()
+                    .position(|c| c.last_doc_id() == original_last_doc_id)
+            {
+                self.quick_set_from_child(idx);
+
+                debug_assert_eq!(
+                    self.last_doc_id(),
+                    original_last_doc_id,
+                    "staying put must leave the position untouched",
+                );
+
+                return Ok(SettleOutcome::Unchanged);
+            }
+
+            // Nothing already sits on the union's document, but a lagging child
+            // may still *hold* it: `skip_to_quick`'s early return strands a
+            // sibling without consuming its position. The union may not step over
+            // the document before asking — under a `NOT`, its position is not a
+            // delivered result but the next id the `NOT` has yet to exclude, and
+            // stepping over it would let that document into the result set. So
+            // every lagger is seeked to the abandoned position itself, not past
+            // it.
+            //
+            // These reads cannot be avoided. An `Err` here reaches the caller as
+            // `VALIDATE_ABORTED`, freeing the iterator and substituting an empty
+            // one — blunt, but better than handing out a position no child backs.
+            let mut i = 0;
+            while i < self.num_active {
+                if self.children[i].last_doc_id() >= original_last_doc_id {
+                    i += 1;
+                    continue;
+                }
+                match self.children[i].skip_to(original_last_doc_id)? {
+                    Some(SkipToOutcome::Found(_)) => {
+                        if QUICK_EXIT {
+                            // Still matched after all: the union stays on it,
+                            // backed by this child; remaining laggers wait for the
+                            // next call.
+                            self.quick_set_from_child(i);
+
+                            debug_assert_eq!(
+                                self.last_doc_id(),
+                                original_last_doc_id,
+                                "staying put must leave the position untouched",
+                            );
+
+                            return Ok(SettleOutcome::Unchanged);
+                        }
+                        i += 1;
+                    }
+                    Some(SkipToOutcome::NotFound(_)) => {
+                        i += 1;
+                    }
+                    None => {
+                        // The seek exhausted the child. Don't increment i — the
+                        // swapped-in element needs to be checked.
+                        self.swap_remove_child(i);
+                    }
+                }
+            }
+
+            // Seeking the laggers forward can run the union out of documents.
+            if self.num_active == 0 {
+                self.is_eof = true;
+                return Ok(SettleOutcome::Eof);
+            }
+
+            // Every active child now sits at or past the abandoned position, so
+            // the minimum is a position again: equal to it when children still
+            // match the document (full mode only — quick mode returned above),
+            // later otherwise.
+            min_doc_id = DocId::MAX;
+            for (i, child) in self.children[..self.num_active].iter().enumerate() {
+                let child_doc_id = child.last_doc_id();
+                if child_doc_id < min_doc_id {
+                    min_doc_id = child_doc_id;
+                    min_child_idx = i;
+                }
+            }
+
+            debug_assert!(
+                min_doc_id >= original_last_doc_id,
+                "every lagging child was just seeked to the union's position",
+            );
+        }
+
+        // Rebuild result at the new minimum doc_id
+        if QUICK_EXIT {
+            self.quick_set_from_child(min_child_idx);
+        } else {
+            self.build_aggregate_result(min_doc_id);
+        }
+
+        if self.last_doc_id() == original_last_doc_id {
+            return Ok(SettleOutcome::Unchanged);
+        }
+
+        debug_assert!(
+            self.last_doc_id() > original_last_doc_id,
+            "a reported move must be forward",
+        );
+
+        Ok(SettleOutcome::Moved)
+    }
+
     /// Swap-removes an exhausted child at `idx` by swapping it with the last active child.
     #[inline]
     fn swap_remove_child(&mut self, idx: usize) {
@@ -211,10 +475,14 @@ where
     /// Returns the minimum doc_id among active children, or `DocId::MAX` if all are exhausted.
     ///
     /// Only [`Self::read_full`] calls this, so no child can be *behind* `current_id`:
-    /// full-mode `read`/`skip_to` advance every active child, and `revalidate`
-    /// re-seeks any child a child revalidation resurrected behind the union. A child
-    /// behind would become the minimum and hand back a document already delivered,
-    /// so the invariant is asserted rather than handled.
+    /// full-mode [`read`](RQEIterator::read)/[`skip_to`](RQEIterator::skip_to)
+    /// advance every active child, and neither
+    /// [`revalidate`](RQEIterator::revalidate) nor
+    /// [`resume`](RQESuspendedIterator::resume) can leave one behind the union — a child dropped
+    /// on EOF stays dropped, since exhaustion is terminal
+    /// ([`at_eof`](RQEIterator::at_eof)). A child behind would become the minimum
+    /// and hand back a document already delivered, so the invariant is asserted
+    /// rather than handled.
     fn advance_and_find_min(&mut self, current_id: DocId) -> Result<DocId, RQEIteratorError> {
         if QUICK_EXIT {
             panic!("a quick union reads through skip_to instead");
@@ -639,174 +907,14 @@ where
             return Ok(RQEValidateStatus::Ok);
         }
 
-        // Sync num_active and find minimum doc_id.
-        // Use swap_remove_child to move EOF children out of the active region.
+        // Removing an aborted child pulls an arbitrary other one into its slot, so
+        // the active/parked split no longer describes anything: rebuild it from
+        // scratch and let the settle re-park the children that are still exhausted.
         self.num_active = self.children.len();
 
-        // Only a child that has run past its last result is dropped: one that has
-        // merely returned its final document still owes it, and dropping it would
-        // lose that document — or report EOF for the whole union, if it was the
-        // last active child.
-        let mut min_doc_id: DocId = DocId::MAX;
-        let mut min_child_idx: usize = 0;
-        let mut i = 0;
-        while i < self.num_active {
-            let child = &self.children[i];
-            if child.at_eof() {
-                self.swap_remove_child(i);
-                // Don't increment i - check the swapped-in child
-            } else {
-                let child_doc_id = child.last_doc_id();
-                if child_doc_id < min_doc_id {
-                    min_doc_id = child_doc_id;
-                    min_child_idx = i;
-                }
-                i += 1;
-            }
-        }
-
-        // Check if all remaining children are at EOF
-        if self.num_active == 0 {
-            self.is_eof = true;
-            return Ok(RQEValidateStatus::Moved { current: None });
-        }
-
-        // A minimum *behind* the union is not a position to move to — adopting it
-        // would replay documents, because `VALIDATE_MOVED` has the caller emit
-        // `current` in place of a read and the read after that resumes from there.
-        // `iterator_api.h` says `VALIDATE_MOVED` means the position moved *forward*,
-        // and `Not::revalidate` asserts that of its child — which is where a
-        // `QUICK_EXIT` union usually sits.
-        //
-        // With `QUICK_EXIT` this is the mode's own early return, and routine:
-        // `skip_to_quick` stops on the first exact match, so a later sibling keeps an
-        // earlier round's id, or answers 0 having never been read at all.
-        //
-        // A full union cannot get here: `advance_and_find_min` leaves no active child
-        // behind the union, and exhaustion is terminal across a revalidation (see
-        // [`RQEIterator::at_eof`]), so a child dropped on EOF cannot re-enter the active
-        // set behind us. Asserted rather than compensated for — the recovery below is
-        // quick mode's, and a full union arriving in it means a child is broken.
-        if min_doc_id < original_last_doc_id {
-            debug_assert!(
-                QUICK_EXIT,
-                "a full union's child moved behind the union's position: doc {min_doc_id} \
-                 comes before doc {original_last_doc_id}",
-            );
-
-            // A child still sitting on the union's document backs the position as it
-            // stands: republish from it (the result holds raw pointers into children
-            // that may have moved or been dropped) and report `Ok`, with no reads
-            // spent. `min_child_idx` cannot serve — that is the lagging child just
-            // rejected. Quick mode only: its laggers are ordinary state for the next
-            // `read`/`skip_to` to seek past, while a full union must catch them up
-            // below either way — `advance_and_find_min` relies on no active child
-            // sitting behind the union.
-            if QUICK_EXIT
-                && let Some(idx) = self.children[..self.num_active]
-                    .iter()
-                    .position(|c| c.last_doc_id() == original_last_doc_id)
-            {
-                self.quick_set_from_child(idx);
-
-                debug_assert_eq!(
-                    self.last_doc_id(),
-                    original_last_doc_id,
-                    "staying put must leave the position untouched",
-                );
-
-                return Ok(RQEValidateStatus::Ok);
-            }
-
-            // Nothing already sits on the union's document, but a lagging child may
-            // still *hold* it: `skip_to_quick`'s early return strands a sibling
-            // without consuming its position. The union may not step over the
-            // document before asking — under a `NOT`, its position is not a
-            // delivered result but the next id the `NOT` has yet to exclude, and
-            // stepping over it would let that document into the result set. So every
-            // lagger is seeked to the abandoned position itself, not past it.
-            //
-            // These reads cannot be avoided. An `Err` here reaches the caller as
-            // `VALIDATE_ABORTED`, freeing the iterator and substituting an empty one
-            // — blunt, but better than handing out a position no child backs.
-            let mut i = 0;
-            while i < self.num_active {
-                if self.children[i].last_doc_id() >= original_last_doc_id {
-                    i += 1;
-                    continue;
-                }
-                match self.children[i].skip_to(original_last_doc_id)? {
-                    Some(SkipToOutcome::Found(_)) => {
-                        if QUICK_EXIT {
-                            // Still matched after all: the union stays on it, backed
-                            // by this child; remaining laggers wait for the next call.
-                            self.quick_set_from_child(i);
-
-                            debug_assert_eq!(
-                                self.last_doc_id(),
-                                original_last_doc_id,
-                                "staying put must leave the position untouched",
-                            );
-
-                            return Ok(RQEValidateStatus::Ok);
-                        }
-                        i += 1;
-                    }
-                    Some(SkipToOutcome::NotFound(_)) => {
-                        i += 1;
-                    }
-                    None => {
-                        // The seek exhausted the child. Don't increment i — the
-                        // swapped-in element needs to be checked.
-                        self.swap_remove_child(i);
-                    }
-                }
-            }
-
-            // Seeking the laggers forward can run the union out of documents.
-            if self.num_active == 0 {
-                self.is_eof = true;
-                return Ok(RQEValidateStatus::Moved { current: None });
-            }
-
-            // Every active child now sits at or past the abandoned position, so the
-            // minimum is a position again: equal to it when children still match the
-            // document (full mode only — quick mode returned above), later otherwise.
-            min_doc_id = DocId::MAX;
-            for (i, child) in self.children[..self.num_active].iter().enumerate() {
-                let child_doc_id = child.last_doc_id();
-                if child_doc_id < min_doc_id {
-                    min_doc_id = child_doc_id;
-                    min_child_idx = i;
-                }
-            }
-
-            debug_assert!(
-                min_doc_id >= original_last_doc_id,
-                "every lagging child was just seeked to the union's position",
-            );
-        }
-
-        // Rebuild result at the new minimum doc_id
-        if QUICK_EXIT {
-            self.quick_set_from_child(min_child_idx);
-        } else {
-            self.build_aggregate_result(min_doc_id);
-        }
-
-        // Return MOVED only if lastDocId changed
-        if self.last_doc_id() == original_last_doc_id {
-            return Ok(RQEValidateStatus::Ok);
-        }
-
-        debug_assert!(
-            self.last_doc_id() > original_last_doc_id,
-            "a reported move must be forward",
-        );
-
-        Ok(RQEValidateStatus::Moved {
-            current: Some(&mut self.result),
-        })
+        Ok(self
+            .settle_after_children_changed(original_last_doc_id)?
+            .into_validate_status(&mut self.result))
     }
 
     #[inline(always)]
@@ -820,6 +928,527 @@ where
         } else {
             1.0
         }
+    }
+}
+
+impl<'index, I, const QUICK_EXIT: bool> RQEIteratorBoxed<'index>
+    for UnionFlat<'index, I, QUICK_EXIT>
+where
+    I: RQEIteratorBoxed<'index>,
+{
+    type Suspended = RawUnionFlat<'index, Suspended, I::Suspended, QUICK_EXIT>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Walk children: dispatch each child's `suspend` through the trait
+        // so dyn-erased `I` (e.g. [`TypeErasedRQEIterator`](crate::TypeErasedRQEIterator))
+        // correctly transitions its vtable. For concrete-typed `I` this is
+        // the same whole-box cast that would otherwise happen at the outer
+        // level, just per-child.
+        //
+        // Walked through the buffer pointer rather than `iter_mut`, as `resume`
+        // does: each transition retypes a slot from `I` to `I::Suspended`, so a
+        // typed `IterMut<IndexedChild<I>>` would still be describing the buffer
+        // as `IndexedChild<I>` after the first one. Nothing here re-reads a
+        // transitioned slot, so that iterator would not actually be misused —
+        // but the borrow claims something that stops being true half way
+        // through, and every other caller of the slot helper already hands it a
+        // raw pointer.
+        let (base, len) = {
+            // SAFETY: `raw` came from `Box::into_raw` and is exclusively owned
+            // for the rest of this function, so the children Vec is reachable
+            // and unaliased. The borrow is used only to reach the buffer pointer
+            // and length, and ends here.
+            let children: &mut Vec<IndexedChild<I>> = unsafe { &mut (*raw).children };
+            (children.as_mut_ptr(), children.len())
+        };
+        for i in 0..len {
+            // SAFETY: `i` is in bounds of the children buffer.
+            let elem = unsafe { base.add(i) };
+            // SAFETY: `elem` addresses a valid `IndexedChild`; `&raw mut` forms
+            // a pointer to its `inner` slot without going through a reference.
+            let inner = unsafe { &raw mut (*elem).inner };
+            // SAFETY: `inner` holds a valid, owned `I`; the helper leaves the
+            // slot holding a valid `I::Suspended`.
+            unsafe { crate::boxed::suspend_child_slot_in_place(inner) };
+        }
+        // SAFETY: `RawUnionFlat` is `#[repr(C)]` over `Vec<IndexedChild<I>>`
+        // (now byte-rewritten with `I::Suspended` payloads) and
+        // `result: RawIndexResult<Rf>` (layout-compatible via `SharedPtr`).
+        unsafe {
+            Box::from_raw(raw as *mut RawUnionFlat<'index, Suspended, I::Suspended, QUICK_EXIT>)
+        }
+    }
+}
+
+/// Whether the rebuilt aggregate still has a child behind it.
+///
+/// `#[must_use]` sits on the type so it covers every producer: an
+/// [`Unbacked`](Self::Unbacked) that nobody looks at is a result published with
+/// nothing backing the document it claims.
+#[must_use = "an unbacked aggregate no longer describes a document; the caller \
+              must rebuild it or abort the resume"]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RebuildOutcome {
+    /// At least one survivor sits on the result's document, and the aggregate
+    /// now borrows exactly those survivors. The result stands as a description
+    /// of that document, and re-narrowing it is sound.
+    Backed,
+    /// No survivor sits on the result's document, so the aggregate came out
+    /// empty. Re-narrowing it is still sound — it points nowhere — but it no
+    /// longer describes a document, so the composite must rebuild it before
+    /// publishing it or report [`ResumeOutcome::Aborted`] instead.
+    Unbacked,
+}
+
+/// Rebuild a suspended union's borrowed entries from its just-resumed children.
+///
+/// A union's aggregate borrows one entry per child sitting on the union's
+/// document, and each entry is a pointer derived from a borrow of that child's
+/// result. Transitioning a child hands its allocation through a by-value
+/// `Box<Self>`, whose retag invalidates that borrow even though nothing was
+/// dropped, moved or written — so every entry has to be written afresh before
+/// the union's own allocation is re-narrowed. This is that step, and it is not
+/// optional.
+///
+/// # Why rebuild rather than re-derive
+///
+/// The alternative is to keep the entry list and refresh each entry in place,
+/// which means recognising which child an entry came from — and an entry
+/// records only an address, so the only handle available is "the survivor that
+/// still lives at that address". That handle is weak in both directions: it
+/// stops identifying anything once a dropped child's slot has been compacted
+/// over, and it cannot distinguish the child that moved onto that address from
+/// the one that was always there.
+///
+/// A union does not need the handle. Its contributor set is a *function* of the
+/// children — every child whose `current()` sits on the union's document, which
+/// is exactly what [`build_aggregate_result`](RawUnionFlat::build_aggregate_result)
+/// evaluates on the read path — so it can be recomputed from the survivors in
+/// one forward pass, and the entries never have to be identified at all.
+///
+/// The read path narrows that scan to the active region and this one does not,
+/// which comes to the same set: a child parked past `num_active` is one that ran
+/// out, and an exhausted child publishes no `current()` to be counted.
+///
+/// # What is recomputed, and what is carried across
+///
+/// `freq` and `field_mask` are recomputed. They are copies of what each
+/// contributing child holds, so they are functions of the same contributor set
+/// as the entries; recomputing them together is what keeps the two from
+/// disagreeing. Preserving them across a rebuild that lost a contributor would
+/// leave the result claiming a frequency and — worse — a set of fields that no
+/// surviving entry accounts for, and `field_mask` decides field filtering and
+/// field-weighted scoring.
+///
+/// `metrics` are carried across untouched, because they are *not* a function of
+/// the children: [`RSIndexResult::push_borrowed`] **moves** a child's metrics
+/// into the union when the aggregate is first built, leaving the child with
+/// none. There is nothing to re-accumulate, so resetting them would discard
+/// them for good — a KNN child's `__vector_score` vanishing from the reply. The
+/// cost of keeping them is that a metric contributed by a child that has since
+/// been dropped stays; the alternative loses the surviving children's metrics
+/// too, to remove it.
+///
+/// `doc_id` is likewise untouched: it is the document the rebuild is *for*, and
+/// the input to the contributor test rather than an output of it. It is read
+/// before anything is cleared, so the clearing step cannot quietly become the
+/// one that takes it away.
+///
+/// # Quick mode
+///
+/// A `QUICK_EXIT` union reports a single child rather than aggregating, so the
+/// rebuild stops at the first contributor. Which child that is need not be the
+/// one the union picked before suspending — it picks by scan order over the
+/// active region, this picks by slot over every survivor — but any child on the
+/// document backs the position equally, which is the same latitude
+/// [`settle_after_children_changed`](RawUnionFlat::settle_after_children_changed)
+/// already takes when it re-picks a backer after its children moved.
+///
+/// # Call it last
+///
+/// Not merely "before the cast": **after** the child walk, **after** any
+/// side-table rebuild, and with no `&mut` taken to a child afterwards. Each
+/// entry is derived from a shared reborrow of a `&mut` to its child, so any
+/// later mutable access to that child — a `read`, a `skip_to`, another
+/// `current`, an `iter_mut` over the children, a `swap_remove`, a sort — pops
+/// the tag it carries. `&mut` to the union itself is fine; the entries point
+/// into the *children's* allocations.
+fn rebuild_borrowed_entries<'a, 'child, R, const QUICK_EXIT: bool>(
+    result: &mut RawIndexResult<'a, Suspended>,
+    children: impl IntoIterator<Item = &'child mut R>,
+) -> RebuildOutcome
+where
+    R: RQEIterator<'a> + 'child,
+{
+    let doc_id = result.doc_id;
+    let Some(aggregate) = result
+        .as_aggregate_mut()
+        .and_then(|aggregate| aggregate.as_borrowed_mut())
+    else {
+        // Nothing borrowed here: not an aggregate at all, or an owned one whose
+        // children live in the result's own allocation. Either way there is
+        // nothing to rebuild
+        // and nothing for the caller to make good. `Unbacked` here would oblige
+        // it to abort a resume that never had entries at stake.
+        return RebuildOutcome::Backed;
+    };
+    if aggregate.is_empty() {
+        // Nothing borrowed, so again nothing to rebuild, and no reason to touch
+        // a single child. This is the union that was suspended before its first
+        // read: its result is an empty aggregate on document 0, which no child
+        // would answer for.
+        return RebuildOutcome::Backed;
+    }
+
+    // Drops the records and the kind mask; `push_borrowed_ptr_from_ref` rebuilds
+    // both, entry by entry. Deliberately not `reset_aggregate`, which would also
+    // take `doc_id` — read above, and what the loop below tests each child
+    // against — and the metrics, which cannot be put back. See
+    // `# What is recomputed` above.
+    aggregate.reset();
+    result.freq = 0;
+    result.field_mask = 0;
+
+    let mut contributors = 0;
+    for child in children {
+        // A child at EOF publishes no result, and one whose own resume carried
+        // it past the union's document no longer describes that document.
+        let Some(current) = child.current() else {
+            continue;
+        };
+        if current.doc_id != doc_id {
+            continue;
+        }
+        // The entry is taken from a shared reborrow, so the tag it carries stays
+        // valid for as long as nothing takes `&mut` to this child again. The
+        // loop only ever moves on to a *different* child, and the union takes
+        // none after this call returns.
+        let current: &RSIndexResult<'a> = &*current;
+
+        result.freq += current.freq;
+        result.field_mask |= current.field_mask;
+        result
+            .as_aggregate_mut()
+            .and_then(|aggregate| aggregate.as_borrowed_mut())
+            .expect("the result borrowed an aggregate a handful of statements ago")
+            .push_borrowed_ptr_from_ref(current);
+        contributors += 1;
+
+        if QUICK_EXIT {
+            break;
+        }
+    }
+
+    if contributors == 0 {
+        RebuildOutcome::Unbacked
+    } else {
+        RebuildOutcome::Backed
+    }
+}
+
+impl<'query, S, const QUICK_EXIT: bool> RQESuspendedIterator<'query>
+    for RawUnionFlat<'query, Suspended, S, QUICK_EXIT>
+where
+    S: RQESuspendedIterator<'query>,
+{
+    type Resumed<'a>
+        = UnionFlat<'a, S::Resumed<'a>, QUICK_EXIT>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        // `current()` hands the result out mutably, so "still a union result" is
+        // a runtime invariant rather than an enforced one — a consumer could
+        // have replaced it with an index-backed result of another kind. Nothing
+        // below would notice: `rebuild_borrowed_entries` has nothing to rebuild
+        // for a result that borrows nothing, and the cast would
+        // then re-narrow whatever suspended pointers the substitute holds
+        // without re-validating them. A union has no way to re-validate a
+        // payload it did not build, so it refuses, on `&self`, before
+        // `Box::into_raw` opens the raw-pointer section — the same shape
+        // `Optional` and `NotOptimized` use for their virtual sentinels.
+        //
+        // The test is the exact kind, not `is_aggregate()`: that also admits
+        // `HybridMetric`, whose children are *owned* boxes rather than borrowed
+        // entries. `rebuild_borrowed_entries` takes its "nothing borrowed"
+        // early return for one and reports success, leaving boxed children whose
+        // own `data` may still be index-backed and suspended — a case no union
+        // is equipped to re-validate. This is what keeps it unreachable.
+        if self.result.kind() != RSResultKind::Union {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        // The pre-resume position, read off the suspended form. Unlike
+        // `revalidate` there is no is-EOF return before the walk: the suspended
+        // children must be transitioned regardless of the outcome.
+        let original_last_doc_id = self.result.doc_id;
+
+        let raw = Box::into_raw(self);
+
+        // Resume every child *in place* — including the exhausted tail past
+        // `num_active`, which is not optional. The cast below retypes the whole
+        // buffer at once, so a slot left suspended would be read as an
+        // `S::Resumed<'a>`, and even dropping it would be undefined behaviour.
+        // Exhaustion also does not put a child beyond reach: [`rewind`] re-admits
+        // every one of them, so a child skipped here on the grounds that it was
+        // spent would be a suspended iterator the very next rewind rewinds and
+        // reads. Aborted children are removed, like `revalidate`'s aborted
+        // children: survivors are compacted down over the holes.
+        //
+        // [`rewind`]: RQEIterator::rewind
+        //
+        // The compaction preserves the survivors' relative order where
+        // `revalidate` uses `swap_remove`, which pulls the last child into the
+        // hole instead. The surviving *set* is the same and `original_index`
+        // keeps each child identifiable, so the two orders differ only in the
+        // shared settle's tie-breaks between children sitting on the *same*
+        // document (`min_child_idx` takes the first, and `QUICK_EXIT`'s
+        // `position(..)` likewise): the union's document sequence is identical
+        // either way, only which of several equally-matching children backs a
+        // `QUICK_EXIT` payload can differ. Matching `swap_remove` here would mean
+        // pulling still-suspended children out of the tail and re-entering slots
+        // the walk has already transitioned, so the buffer would no longer be a
+        // resumed prefix followed by a suspended suffix — the split
+        // `free_after_consumed_child` relies on to tear the allocation down.
+        // Compacting is the deliberate choice.
+        //
+        // Whatever the walk does to the children, the suspended aggregate's
+        // entries are dealt with before the cast — the one step that turns
+        // pointers whose addresses happen to have survived into usable
+        // references. Which way round that goes is decided below, and hinges on
+        // whether the compaction ran.
+        //
+        // A panic between slot transitions leaks the allocation (memory-safe);
+        // the slot helper guards its own moved-out window.
+        let (base, len) = {
+            // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+            // initialised, exclusively owned); the borrow is used only to reach
+            // the buffer pointer and length.
+            let children: &mut Vec<IndexedChild<S>> = unsafe { &mut (*raw).children };
+            (children.as_mut_ptr(), children.len())
+        };
+        let mut any_change = false;
+        let mut kept = 0usize;
+        for i in 0..len {
+            // SAFETY: `i` is in bounds of the children buffer.
+            let elem = unsafe { base.add(i) };
+            // SAFETY: `elem` holds a valid `IndexedChild`; `&raw mut` forms a
+            // pointer to its `inner` slot.
+            let inner = unsafe { &raw mut (*elem).inner };
+            // SAFETY: `inner` holds a valid, owned `S`; the helper rewrites it as
+            // a valid `S::Resumed<'a>` on `Unchanged`/`Moved`, and consumes it on
+            // `Aborted`/`Err`.
+            match unsafe { resume_child_slot_in_place(inner, guard) } {
+                Ok(outcome) => {
+                    match outcome {
+                        ResumeSlotOutcome::Unchanged => {}
+                        ResumeSlotOutcome::Moved => any_change = true,
+                        ResumeSlotOutcome::Aborted => {
+                            // Dropped from the union, as `revalidate` drops an
+                            // aborted child; the hole is compacted over by later
+                            // survivors.
+                            any_change = true;
+                            continue;
+                        }
+                    }
+                    if kept < i {
+                        // SAFETY: `kept < i < len`, both in bounds.
+                        let dst = unsafe { base.add(kept) };
+                        // SAFETY: slot `kept` was vacated (its element moved left
+                        // or was consumed) and `elem` holds a resumed child, so
+                        // this is a single-element move between disjoint,
+                        // in-bounds slots. `copy_nonoverlapping` is a move — the
+                        // source is treated as vacated from here on.
+                        unsafe {
+                            std::ptr::copy_nonoverlapping(
+                                elem.cast::<IndexedChild<S::Resumed<'a>>>().cast_const(),
+                                dst.cast::<IndexedChild<S::Resumed<'a>>>(),
+                                1,
+                            )
+                        };
+                    }
+                    kept += 1;
+                }
+                Err(e) => {
+                    // The one place resume cannot match `revalidate`, and it is
+                    // structural rather than a choice. A spent union — `is_eof`,
+                    // nothing left to read — makes `revalidate` return `Ok`
+                    // before it looks at a child, so a child that would time out
+                    // is never asked and the union survives. Resume has to ask
+                    // every child before it can hand any of them back, and
+                    // `S::resume` takes the child *by value*: once it answers
+                    // `Err` the child is gone, so there is no walking past it to
+                    // reach the `is_eof` exit below. The union is torn down and
+                    // the error reaches the caller, where `revalidate` would have
+                    // reported `Ok`.
+                    //
+                    // Pinned by `resume_of_a_spent_union_surfaces_a_child_error`
+                    // rather than left to be rediscovered.
+                    //
+                    // SAFETY: `children[..kept]` holds compacted resumed
+                    // survivors, `children[kept..=i]` holes or the consumed
+                    // element, `children[i + 1..]` still-suspended children — the
+                    // exact state the teardown documents; `raw` is exclusively
+                    // owned.
+                    unsafe { free_after_consumed_child::<S, QUICK_EXIT>(raw, kept, i) };
+                    return Err(e);
+                }
+            }
+        }
+        // SAFETY: `raw` is exclusively owned; the borrow is confined to this
+        // statement.
+        let children = unsafe { &mut (*raw).children };
+        // SAFETY: `children[..kept]` holds the compacted, initialised survivors
+        // and everything past it is vacated, so shrinking to `kept` describes
+        // exactly the live elements; `set_len` never drops, so the vacated tail
+        // is left alone. The stale `num_active` is clamped right after the cast
+        // below.
+        unsafe { children.set_len(kept) };
+
+        // Every survivor now sits in its resumed form, and the aggregate has to be
+        // dealt with before the cast — the step that makes its entries usable
+        // again, rather than merely re-narrowed.
+        //
+        // Every survivor is offered, including any parked past `num_active`: the
+        // rebuild decides membership by asking each child where it sits, and a
+        // parked child is exactly one that will decline. Which is also why the
+        // compaction above needs no special handling here — nothing is matched
+        // against a slot, so nothing is confused by a survivor having moved into
+        // a dropped child's slot.
+        let rebuilt = {
+            // Viewed at `'a` rather than at `'query`. Narrowing a query lifetime
+            // is the safe direction — `'query: 'a` — but `&mut` is invariant, so
+            // the compiler will not do it for us and the pointer is re-cast
+            // instead. It is what lets the rebuild tie each entry to the same
+            // lifetime the children carry, rather than widening theirs to
+            // `'query`.
+            //
+            // SAFETY: `raw` is exclusively owned and `result` is a valid
+            // suspended result in a field disjoint from the children buffer; the
+            // borrow is confined to this block. `RawIndexResult` differs between
+            // the two lifetimes only in the query-pipeline pointers it claims,
+            // and `'query: 'a` makes every one of them valid for `'a`.
+            //
+            // SAFETY: `raw` is exclusively owned and non-null, so projecting to
+            // its `result` field is in bounds; no reference is created here.
+            let result_ptr = unsafe { &raw mut (*raw).result };
+            // SAFETY: the projection above is valid, aligned and initialised, and
+            // the two lifetimes differ only in the claim described above.
+            let result: &mut RawIndexResult<'a, Suspended> =
+                unsafe { &mut *result_ptr.cast::<RawIndexResult<'a, Suspended>>() };
+            // SAFETY: `base` addresses the `kept` survivors, each a valid
+            // `IndexedChild<S::Resumed<'a>>` — same size and alignment as the
+            // `IndexedChild<S>` the buffer was allocated for, by `#[repr(C)]`
+            // over a child slot whose halves the slot helper statically
+            // enforces — and `raw` is exclusively owned, so the slice is
+            // unaliased.
+            let children = unsafe {
+                std::slice::from_raw_parts_mut(base.cast::<IndexedChild<S::Resumed<'a>>>(), kept)
+            };
+            rebuild_borrowed_entries::<_, QUICK_EXIT>(
+                result,
+                children.iter_mut().map(|c| &mut c.inner),
+            )
+        };
+
+        // SAFETY: every surviving child slot holds its resumed form inside the
+        // `Vec`'s untouched buffer, and the aggregate's entries have just been
+        // re-derived from those survivors or dropped outright, so no entry is
+        // re-narrowed onto a freed, relocated, or merely retagged result; the
+        // remaining fields are `Rf`-free. Layout-identical
+        // to the suspended form by invariant 1 on `RawUnionFlat` (const proof
+        // above). `Box::from_raw` reuses the same allocation, so the FFI's cached
+        // `header.current` and any parent's pointer into `result` stay valid
+        // across the cycle.
+        let mut active =
+            unsafe { Box::from_raw(raw.cast::<UnionFlat<'a, S::Resumed<'a>, QUICK_EXIT>>()) };
+        // Aborted children shrank the vec; the active region cannot outgrow it.
+        active.num_active = active.num_active.min(active.children.len());
+
+        // From here on, mirror `revalidate` decision for decision — including
+        // the order the two questions are asked in. An already-finished union
+        // stays finished, whatever its children now report: `revalidate` returns
+        // before it looks at a single one, so asking "did they all abort?" first
+        // would tear down a spent union that `revalidate` leaves alone. Its
+        // position is preserved (`result.doc_id` rode along in the cast), exactly
+        // as `revalidate` leaves it. The children were still transitioned above —
+        // the one structural difference from `revalidate`, which never touches
+        // them.
+        //
+        // That difference is observable, and only through `rewind`. The walk
+        // above dropped every child that answered `Aborted`, where `revalidate`
+        // left them in place having never asked; a later `rewind` re-admits what
+        // is there, so the two paths yield different documents from that point
+        // on. Not a defect to fix: an aborted child's state is unrecoverable, so
+        // the ones this path drops are exactly the ones `revalidate` would go on
+        // to rewind and read *after* their index went away. Pinned by
+        // `resume_of_a_spent_union_drops_children_that_revalidate_would_rewind`,
+        // because the differential harness cannot see it — it never rewinds.
+        if active.is_eof {
+            return Ok(ResumeOutcome::Ok(active));
+        }
+
+        // All children aborted → the union aborts (a union of nothing is
+        // nothing). `revalidate` also sets `is_eof` before reporting `Aborted`;
+        // here the box is dropped instead of handed back, so the flag has no
+        // observer.
+        if active.children.is_empty() {
+            return Ok(ResumeOutcome::Aborted);
+        }
+
+        // Nothing moved or aborted: the children still sit on the positions the
+        // aggregate describes, so it stands as-is.
+        if !any_change {
+            // Unless the aggregate could not be re-derived. This is the only exit
+            // that hands a live position back with no rebuild under it, so a union
+            // that can no longer say which children back that position aborts
+            // rather than publish one that describes nothing. (The `is_eof` exit
+            // above needs no such guard: it publishes no `current`, so a cleared
+            // aggregate has no observer there and `revalidate`'s `Ok` stays the
+            // faithful answer.)
+            //
+            // Believed unreachable with conforming children, and asserted rather
+            // than assumed. On this arm every child reported `Unchanged` and none
+            // was dropped, so the children that backed the union's document
+            // before the suspend are all still there, still publishing a
+            // `current()`, and still on that document — at least one contributor,
+            // since the union was sitting on a document it had read. Coming out
+            // unbacked means a child broke `Unchanged`'s promise to hold its
+            // position.
+            debug_assert_ne!(
+                rebuilt,
+                RebuildOutcome::Unbacked,
+                "a union whose children all resumed unchanged cannot lose its aggregate",
+            );
+            if rebuilt == RebuildOutcome::Unbacked {
+                return Ok(ResumeOutcome::Aborted);
+            }
+            return Ok(ResumeOutcome::Ok(active));
+        }
+
+        // As in `revalidate`: the compaction over an aborted child moved survivors
+        // between the active region and the parked tail, so the split describes
+        // nothing until it is rebuilt. The settle re-parks the children that are
+        // still exhausted — every one that was, since resume cannot revive them —
+        // and re-derives the union's position.
+        active.num_active = active.children.len();
+        let settled = active.settle_after_children_changed(original_last_doc_id)?;
+        Ok(settled.into_resume_outcome(active))
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        self.result.doc_id
+    }
+
+    fn num_estimated(&self) -> usize {
+        self.num_estimated
     }
 }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_flat.rs
@@ -216,3 +216,1178 @@ fn revalidate_with_an_unread_sibling_does_not_move_the_union_backwards() {
         "the unread sibling's 15 is still owed and must not be skipped: {seen:?}",
     );
 }
+
+mod via_resume {
+    use crate::utils::{Mock, MockIteratorError, MockRevalidateResult};
+    use rqe_core::DocId;
+    use rqe_iterators::{
+        RQEIterator, RQEIteratorBoxed, RQEIteratorError, RQESuspendedIterator, RQEValidateStatus,
+        ResumeOutcome, TypeErasedRQEIterator, UnionFlat, UnionFullFlat, UnionQuickFlat,
+    };
+    use rqe_iterators_test_utils::{ResumeOutcomeExt, revalidate_via_resume};
+
+    /// Read `it` to completion, collecting the doc ids it yields.
+    fn drain<'index>(it: &mut impl RQEIterator<'index>) -> Vec<DocId> {
+        let mut seen = Vec::new();
+        while let Some(doc) = it.read().expect("read failed") {
+            seen.push(doc.doc_id);
+        }
+        seen
+    }
+
+    /// Wrap three mocks as the type-erased children a composite really holds:
+    /// their active and suspended forms carry different vtables, which a
+    /// concrete-child test cannot exercise.
+    fn boxed_children<'spec, const N0: usize, const N1: usize, const N2: usize>(
+        c0: Mock<'spec, N0>,
+        c1: Mock<'spec, N1>,
+        c2: Mock<'spec, N2>,
+    ) -> Vec<TypeErasedRQEIterator<'spec>> {
+        vec![
+            TypeErasedRQEIterator::new(Box::new(c0)),
+            TypeErasedRQEIterator::new(Box::new(c1)),
+            TypeErasedRQEIterator::new(Box::new(c2)),
+        ]
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 15);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 20);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_moved() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        // After Move, children advance — last_doc_id should reflect new min.
+        assert!(union.last_doc_id() > 10);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_single_child_aborts() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        // One child aborted, the other survives — the union carries on from the
+        // survivor's position. Asserting the exact sequence, rather than just
+        // "the next id is not behind us", is what distinguishes a correctly
+        // repartitioned union from one that resurrects the aborted child: the
+        // latter would hand back 20, 30, 40, 50 interleaved with the survivor's.
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert_eq!(
+            union.last_doc_id(),
+            15,
+            "the union settles on the surviving child's document",
+        );
+        assert_eq!(drain(&mut union), [25, 35, 45, 55]);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_all_children_abort() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let outcome = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed");
+        assert!(matches!(outcome, ResumeOutcome::Aborted));
+    }
+
+    /// Phase 3.15 regression: when no child moved, the aggregate must be
+    /// rebuilt at `saved_last_doc_id` so subsequent reads continue from the
+    /// same logical position.
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_minimum_unchanged_returns_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 3> = Mock::new([10, 30, 50]);
+        let child1: Mock<'_, 3> = Mock::new([10, 40, 60]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        // Union must continue producing the remaining children's docs.
+        let r = union.read().unwrap().unwrap();
+        assert!(r.doc_id > 10, "expected next doc_id > 10, got {}", r.doc_id);
+    }
+
+    /// `resume` hands the aggregate back across the cycle rather than rebuilding
+    /// it, so every entry must still *reach* its child afterwards. Every other
+    /// `Ok`-path test reads first, which resets and rebuilds the aggregate, so a
+    /// broken entry would be overwritten before anything read it. Dereference
+    /// every entry here instead, in the window between the resume and the next
+    /// read — the window a scorer walking `current()` occupies in production.
+    ///
+    /// Run under miri this is also the regression test for the entries'
+    /// *provenance*, which is the half a plain read cannot see: the addresses
+    /// survive a child's transition on their own, the borrows they were derived
+    /// from do not, and only `resume`'s re-derivation of the entries makes them
+    /// usable rather than merely well-addressed. A full union is the interesting
+    /// shape for this: its aggregate carries one entry per child sitting on the
+    /// document, so the count varies with the data rather than being fixed at
+    /// one per child.
+    #[test]
+    fn resume_ok_leaves_the_aggregate_pointing_at_live_children() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // All three children start on 10, so all three back the aggregate.
+        let child0: Mock<'_, 3> = Mock::new([10, 40, 70]);
+        let child1: Mock<'_, 3> = Mock::new([10, 50, 80]);
+        let child2: Mock<'_, 3> = Mock::new([10, 60, 90]);
+        // Nothing moves, so `resume` carries the aggregate across untouched —
+        // the case its liveness obligation rests on entirely.
+        for data in [child0.data(), child1.data(), child2.data()].iter_mut() {
+            data.set_revalidate_result(MockRevalidateResult::Ok);
+        }
+
+        let mut union = UnionFullFlat::new(boxed_children(child0, child1, child2));
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let current = union
+            .current()
+            .expect("an unchanged union is still positioned");
+        assert_eq!(current.doc_id, 10);
+        let aggregate = current
+            .as_aggregate()
+            .expect("a full union publishes an aggregate result");
+        assert_eq!(aggregate.len(), 3, "one entry per child on the document");
+        for i in 0..aggregate.len() {
+            let entry = aggregate.get(i).expect("index below len");
+            assert_eq!(
+                entry.doc_id, 10,
+                "entry {i} must still reach its child's live result",
+            );
+        }
+
+        // Only now let a read rebuild the aggregate from scratch.
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 40);
+    }
+
+    /// Phase 5b.5 regression: an EOF child swap-removed into the dead tail must
+    /// NOT be re-included as a live child by resume — that would yield its
+    /// already-read max doc_id forever.
+    #[test]
+    #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
+    fn revalidate_swap_removed_dead_tail_not_yielded_again() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // Child 0 has a small doc set; child 1 has more docs.
+        // Read past child 0's EOF so it's swap-removed into the dead tail.
+        let child0: Mock<'_, 2> = Mock::new([10, 20]);
+        let child1: Mock<'_, 5> = Mock::new([5, 15, 25, 35, 45]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+
+        // Drain child0: 5 (c1), 10 (c0), 15 (c1), 20 (c0) — c0 now at EOF and
+        // gets swap_remove_child'd next time `read()` advances past 20.
+        let mut docs = Vec::new();
+        for _ in 0..4 {
+            docs.push(union.read().unwrap().unwrap().doc_id);
+        }
+        assert_eq!(docs, [5, 10, 15, 20]);
+        // The next read trims child0 to the dead tail.
+        let r = union.read().unwrap().unwrap();
+        assert_eq!(r.doc_id, 25);
+
+        // Now resume: child0 is in the dead tail. It must NOT re-emerge as live.
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        // Continue reading: must surface the rest of child1 and never repeat 20.
+        let remaining: Vec<_> =
+            std::iter::from_fn(|| union.read().unwrap().map(|r| r.doc_id)).collect();
+        assert_eq!(remaining, [35, 45]);
+    }
+
+    /// The rebuild recomputes `freq` and `field_mask` from the children it
+    /// re-pushes, so a published union never claims a frequency or a set of
+    /// fields that its own entries do not account for. `field_mask` is the one
+    /// that bites if it drifts — it decides field filtering and field-weighted
+    /// scoring, so an over-broad mask lets a document through a filter no live
+    /// child matches.
+    ///
+    /// Asserted as agreement between the result and its entries rather than
+    /// against literals, because that is the invariant: whatever the children
+    /// hold, the two must say the same thing.
+    #[test]
+    fn resume_leaves_the_aggregate_agreeing_with_its_entries() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // Two children on the union's document and one past it, so the rebuild
+        // has to *select* rather than re-push everything it is handed.
+        let child0: Mock<'_, 2> = Mock::new([10, 40]);
+        let child1: Mock<'_, 2> = Mock::new([10, 50]);
+        let child2: Mock<'_, 2> = Mock::new([20, 60]);
+        for data in [child0.data(), child1.data(), child2.data()].iter_mut() {
+            data.set_revalidate_result(MockRevalidateResult::Ok);
+        }
+
+        let mut union = UnionFullFlat::new(boxed_children(child0, child1, child2));
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let current = union
+            .current()
+            .expect("an unchanged union is still positioned");
+        let aggregate = current
+            .as_aggregate()
+            .expect("a full union publishes an aggregate result");
+        assert_eq!(
+            aggregate.len(),
+            2,
+            "only the children sitting on doc 10 back the result",
+        );
+
+        let mut freq = 0;
+        let mut field_mask = 0;
+        for i in 0..aggregate.len() {
+            let entry = aggregate.get(i).expect("index below len");
+            assert_eq!(entry.doc_id, 10, "entry {i} is on the union's document");
+            freq += entry.freq;
+            field_mask |= entry.field_mask;
+        }
+        assert_eq!(current.freq, freq, "freq must be the sum over the entries");
+        assert_eq!(
+            current.field_mask, field_mask,
+            "field_mask must be the union over the entries",
+        );
+    }
+
+    /// Metrics survive the rebuild, because they cannot be rebuilt.
+    ///
+    /// Unlike `freq` and `field_mask`, which are copied from each child,
+    /// `RSIndexResult::push_borrowed` **moves** a child's metrics into the
+    /// aggregate — so by the time a resume runs, the children hold none and
+    /// there is nothing to re-accumulate. The rebuild therefore clears the
+    /// records alone and carries `metrics` across; reaching for
+    /// `reset_aggregate` instead would read as tidier and would discard them for
+    /// good, taking `__vector_score` out of a hybrid query's reply on every
+    /// suspend/resume cycle.
+    #[test]
+    fn resume_keeps_the_metrics_the_aggregate_gathered() {
+        use rqe_iterators::metric::MetricSortedById;
+
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let scored = MetricSortedById::new(vec![100u64], vec![0.5]);
+        let sibling: Mock<'_, 2> = Mock::new([100, 200]);
+        sibling
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Ok);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(scored)),
+            TypeErasedRQEIterator::new(Box::new(sibling)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+        let first = union.read().expect("read failed").expect("doc 100");
+        assert_eq!(first.doc_id, 100);
+        assert_eq!(
+            first.metrics.len(),
+            1,
+            "the aggregate gathered the scored child's metric",
+        );
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let current = union.current().expect("still on doc 100");
+        assert_eq!(current.doc_id, 100);
+        assert_eq!(
+            current.metrics.len(),
+            1,
+            "the metric must survive a rebuild of the document it was gathered for",
+        );
+    }
+
+    /// A quick union reports a single child, so the rebuild stops at the first
+    /// one it finds on the union's document rather than aggregating every match.
+    ///
+    /// Which child that is deliberately goes unasserted: the rebuild picks by
+    /// slot over every survivor where the read path picks by scan order over the
+    /// active region, and any child on the
+    /// document backs the position equally — the same latitude the settle takes
+    /// when it re-picks a backer after its children moved. What must hold is
+    /// that there is exactly one entry and it is on the union's document.
+    #[test]
+    fn quick_resume_republishes_a_single_backer() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        // All three on doc 10, so a rebuild that aggregated would show three.
+        let child0: Mock<'_, 2> = Mock::new([10, 40]);
+        let child1: Mock<'_, 2> = Mock::new([10, 50]);
+        let child2: Mock<'_, 2> = Mock::new([10, 60]);
+        for data in [child0.data(), child1.data(), child2.data()].iter_mut() {
+            data.set_revalidate_result(MockRevalidateResult::Ok);
+        }
+
+        let mut union = UnionQuickFlat::new(boxed_children(child0, child1, child2));
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        let current = union
+            .current()
+            .expect("an unchanged union is still positioned");
+        assert_eq!(current.doc_id, 10);
+        let aggregate = current
+            .as_aggregate()
+            .expect("a quick union still publishes an aggregate result");
+        assert_eq!(aggregate.len(), 1, "quick mode reports one child, not all");
+        assert_eq!(
+            aggregate.get(0).expect("one entry").doc_id,
+            10,
+            "the backer must sit on the union's document",
+        );
+    }
+
+    /// The suspend/resume cycle must reuse the allocation: the FFI wrapper and
+    /// delegating parents cache raw pointers into the iterator's storage, and a
+    /// rebuilt box would dangle them.
+    #[test]
+    fn resume_preserves_box_address() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let children = vec![Mock::new([10u64, 30]), Mock::new([20u64, 40])];
+        let mut union = Box::new(UnionFullFlat::new(children));
+        let r = union.read().expect("read failed").expect("expected doc");
+        assert_eq!(r.doc_id, 10);
+        let addr_before = &*union as *const _ as usize;
+
+        let suspended = union.suspend();
+        assert_eq!(
+            &*suspended as *const _ as usize, addr_before,
+            "suspend must reuse the allocation",
+        );
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(a) => a,
+            ResumeOutcome::Moved(_) => panic!("expected Ok, got Moved"),
+            ResumeOutcome::Aborted => panic!("expected Ok, got Aborted"),
+        };
+        assert_eq!(
+            &*active as *const _ as usize, addr_before,
+            "resume must reuse the allocation",
+        );
+
+        let r = active.read().expect("read failed").expect("expected doc");
+        assert_eq!(r.doc_id, 20, "the union carries on where it was");
+    }
+
+    /// A finished union is finished whatever its children now say:
+    /// `revalidate` tests `is_eof` before it looks at a single child, so it
+    /// reports `Ok` without asking them. `resume` has to transition the
+    /// children regardless, but must still reach the same verdict — asking
+    /// "did every child abort?" first turns a no-op revalidation of a
+    /// spent union into a tear-down of the whole subtree.
+    #[test]
+    fn resume_of_a_finished_union_whose_children_all_abort_is_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 2> = Mock::new([10, 30]);
+        let child1: Mock<'_, 2> = Mock::new([20, 40]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+        let seen: Vec<_> = std::iter::from_fn(|| union.read().unwrap().map(|r| r.doc_id)).collect();
+        assert_eq!(seen, [10, 20, 30, 40]);
+        assert!(union.at_eof());
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+        assert!(union.at_eof());
+        assert!(matches!(union.read(), Ok(None)));
+    }
+
+    /// A union over no children at all is a supported construction — it
+    /// starts at EOF — and `revalidate` reports `Ok` for it. `resume` must
+    /// not mistake "no children" for "every child aborted".
+    #[test]
+    fn resume_of_an_empty_union_is_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let union = UnionFullFlat::new(Vec::<TypeErasedRQEIterator<'_>>::new());
+        assert!(union.at_eof());
+
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+        assert!(union.at_eof());
+        assert!(matches!(union.read(), Ok(None)));
+    }
+
+    /// A child whose resume *fails* takes the union down the
+    /// `free_after_consumed_child` teardown, the most delicate unsafe in this
+    /// file: it drops the compacted resumed prefix, leaves the consumed slot
+    /// alone, and drops the still-suspended tail. Get the `kept`/`consumed`
+    /// boundary wrong and it is a double free or a leak, both of which miri
+    /// sees through the mocks' reference-counted state.
+    ///
+    /// This is the plain shape: no child aborted first, so `kept == consumed`
+    /// and the buffer is a resumed prefix followed directly by a suspended
+    /// tail.
+    #[test]
+    fn resume_child_error_frees_a_shell_with_a_suspended_tail() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child0: Mock<'_, 3> = Mock::new([10, 40, 70]);
+        let child1: Mock<'_, 3> = Mock::new([20, 50, 80]);
+        let child2: Mock<'_, 3> = Mock::new([30, 60, 90]);
+        child1
+            .data()
+            .set_error_on_resume(Some(MockIteratorError::TimeoutError(None)));
+
+        let mut union = UnionFullFlat::new(boxed_children(child0, child1, child2));
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        match revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard) {
+            Err(e) => assert!(matches!(e, RQEIteratorError::TimedOut)),
+            Ok(_) => panic!("the failing child's error must reach the caller"),
+        }
+    }
+
+    /// The same teardown, but with a hole in the middle: child 0 aborts before
+    /// child 2 fails, so the survivor is compacted down to slot 0 and `kept`
+    /// (1) trails `consumed` (2). Slot 1 is then a vacated hole that the
+    /// teardown must skip — the clause the plain shape never reaches.
+    #[test]
+    fn resume_child_error_frees_a_shell_with_a_hole_in_it() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child0: Mock<'_, 3> = Mock::new([10, 40, 70]);
+        let child1: Mock<'_, 3> = Mock::new([20, 50, 80]);
+        let child2: Mock<'_, 3> = Mock::new([30, 60, 90]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+        child2
+            .data()
+            .set_error_on_resume(Some(MockIteratorError::TimeoutError(None)));
+
+        let mut union = UnionFullFlat::new(boxed_children(child0, child1, child2));
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        match revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard) {
+            Err(e) => assert!(matches!(e, RQEIteratorError::TimedOut)),
+            Ok(_) => panic!("the failing child's error must reach the caller"),
+        }
+    }
+
+    /// The abort path — `copy_nonoverlapping` compacting survivors down over
+    /// the hole, `set_len` shrinking the vector, and the whole-box cast that
+    /// must not re-narrow the aggregate onto the child it just freed — with
+    /// **concrete** children, so miri can see all of it.
+    ///
+    /// Concrete children are also what makes the relocation half of that
+    /// hazard real: an `IndexedChild<Mock<..>>` lives inline in the vector's
+    /// buffer, so compaction moves the survivor's result object to a new
+    /// address, where a boxed child's would have stayed put.
+    #[test]
+    fn resume_compacts_over_an_aborted_concrete_child() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child0 = Mock::new([10u64, 40, 70]);
+        let child1 = Mock::new([20u64, 50, 80]);
+        let child2 = Mock::new([30u64, 60, 90]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+
+        let mut union = Box::new(UnionFullFlat::new(vec![child0, child1, child2]));
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        let mut active = match union.suspend().resume(&guard).expect("resume failed") {
+            ResumeOutcome::Moved(a) => a,
+            ResumeOutcome::Ok(_) => panic!("expected Moved, got Ok"),
+            ResumeOutcome::Aborted => panic!("expected Moved, got Aborted"),
+        };
+        assert_eq!(
+            active.num_children_total(),
+            2,
+            "the aborted child is gone from the vector",
+        );
+        assert_eq!(active.last_doc_id(), 20);
+        assert_eq!(
+            drain(&mut *active),
+            [30, 50, 60, 80, 90],
+            "nothing of the aborted child's may survive in the sequence",
+        );
+    }
+
+    /// A middle child aborting drags the *dead tail* into the active region:
+    /// child 2 is parked past `num_active` when the abort of child 1 compacts
+    /// child 2 down into slot 1, which the re-admission then treats as live.
+    /// The settle has to re-park it. If it does not, the exhausted child's last
+    /// document becomes the union's minimum and is handed out again — the
+    /// `num_active`-invariant bug class.
+    #[test]
+    fn resume_reparks_a_dead_tail_pulled_forward_by_a_middle_abort() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child0: Mock<'_, 3> = Mock::new([10, 40, 70]);
+        let child1: Mock<'_, 3> = Mock::new([20, 50, 80]);
+        let child2: Mock<'_, 1> = Mock::new([30]);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+
+        let mut union = UnionFullFlat::new(boxed_children(child0, child1, child2));
+        let seen: Vec<_> = (0..4)
+            .map(|_| union.read().unwrap().unwrap().doc_id)
+            .collect();
+        assert_eq!(
+            seen,
+            [10, 20, 30, 40],
+            "reading past 30 parks child2 in the dead tail",
+        );
+
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+        assert_eq!(
+            union.last_doc_id(),
+            40,
+            "the surviving child still backs the union's position",
+        );
+        assert_eq!(
+            drain(&mut union),
+            [70],
+            "child2's 30 was already delivered and must not come back",
+        );
+    }
+
+    /// A child that lands behind a *full* union is a broken child on the resume
+    /// path exactly as it is on the legacy one, and the shared settle says so
+    /// instead of absorbing it — the resume twin of
+    /// `revalidate_asserts_when_a_resurrected_child_lands_behind_a_full_union`.
+    ///
+    /// A conforming child cannot get there. `advance_and_find_min` leaves no
+    /// active child behind the union, and exhaustion is terminal across the cycle
+    /// ([`at_eof`](RQEIterator::at_eof)), so one dropped from the active set stays
+    /// dropped. The mock breaks that on purpose, and its lever is
+    /// [`MockData::set_force_read_none`]: a `read` that answers `None` while the
+    /// child is neither exhausted nor out of documents, leaving it parked on a
+    /// live, lagging position. (The legacy twin uses
+    /// [`MockData::set_revalidate_reseeks_to`], which only `revalidate` honours.)
+    ///
+    /// [`MockData::set_force_read_none`]: crate::utils::MockData::set_force_read_none
+    /// [`MockData::set_revalidate_reseeks_to`]: crate::utils::MockData::set_revalidate_reseeks_to
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "moved behind the union's position")]
+    fn resume_asserts_when_a_lagging_child_lands_behind_a_full_union() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child0: Mock<'_, 3> = Mock::new([10, 30, 40]);
+        let child1: Mock<'_, 3> = Mock::new([20, 100, 200]);
+        let mut data0 = child0.data();
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionFullFlat::new(children);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        // The contract violation: child0 answers `None` while still sitting on 10,
+        // so the union parks it in the dead tail with a live, lagging position.
+        data0.set_force_read_none(true);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 20);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 100);
+
+        // child1 has to move, or resume returns before the parked child is ever
+        // re-admitted.
+        let _ = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard);
+    }
+
+    /// Every child is transitioned, exhausted ones included, so a `rewind` after a
+    /// resume brings the whole union back — the behavioural half of that rule
+    /// (the other half is that a skipped slot would be undefined behaviour, which
+    /// no test can observe).
+    ///
+    /// child1 is spent and parked in the dead tail before the suspend, so a resume
+    /// that walked only the active region would leave it suspended, and the rewind
+    /// below would rewind and read it in that state.
+    #[test]
+    fn resume_then_rewind_revives_the_exhausted_children_too() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child0: Mock<'_, 3> = Mock::new([10, 40, 70]);
+        let child1: Mock<'_, 1> = Mock::new([20]);
+        let child2: Mock<'_, 2> = Mock::new([30, 60]);
+
+        let mut union = UnionFullFlat::new(boxed_children(child0, child1, child2));
+        assert_eq!(
+            (0..4)
+                .map(|_| union.read().unwrap().unwrap().doc_id)
+                .collect::<Vec<_>>(),
+            [10, 20, 30, 40],
+            "reading past 20 parks child1 in the dead tail",
+        );
+
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+
+        union.rewind();
+        assert_eq!(
+            drain(&mut union),
+            [10, 20, 30, 40, 60, 70],
+            "the rewind must revive every child, including the one parked as spent",
+        );
+    }
+
+    // =========================================================================
+    // `UnionQuickFlat` coverage: `QUICK_EXIT = true` is a separate
+    // monomorphization with its own settle branches, and every test above uses
+    // `UnionFullFlat`.
+    // =========================================================================
+
+    #[test]
+    fn quick_revalidate_ok() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionQuickFlat::new(children);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+        assert_eq!(union.last_doc_id(), 10);
+        assert_eq!(drain(&mut union), [15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    }
+
+    #[test]
+    fn quick_revalidate_moved() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionQuickFlat::new(children);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert_eq!(union.last_doc_id(), 20);
+        assert_eq!(drain(&mut union), [25, 30, 35, 40, 45, 50, 55]);
+    }
+
+    /// The settle's `min_doc_id < original_last_doc_id` recovery, reached the only
+    /// way a conforming union can reach it: `skip_to_quick` returns on the first
+    /// exact match, stranding a live sibling behind the union. That makes the
+    /// block quick mode's alone, which is what the `debug_assert!(QUICK_EXIT, ..)`
+    /// above it claims and
+    /// `resume_asserts_when_a_lagging_child_lands_behind_a_full_union` checks from
+    /// the other side.
+    #[test]
+    fn quick_resume_keeps_a_child_stranded_behind_the_union() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+        let child0: Mock<'_, 3> = Mock::new([5, 100, 300]);
+        let child1: Mock<'_, 3> = Mock::new([10, 50, 200]);
+        // The lagger moves — to 50, still behind the union — which both gets the
+        // resume past its `!any_change` early return and keeps child0 on 100.
+        child1
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Move);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionQuickFlat::new(children);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 5);
+
+        // An exact match on child0, so the quick path returns without ever
+        // reaching child1 — which stays on 10, behind the union's 100.
+        assert!(union.skip_to(100).expect("skip_to failed").is_some());
+        assert_eq!(union.last_doc_id(), 100);
+
+        // 50 is behind the already-delivered 100, so it is not a position to move
+        // to: the union stays put, republished from child0, which still holds it.
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_ok();
+        assert_eq!(
+            union.last_doc_id(),
+            100,
+            "the union must not fall back onto the stranded child's position",
+        );
+        assert_eq!(
+            drain(&mut union),
+            [200, 300],
+            "the stranded child is caught up rather than dropped, so its 200 shows up",
+        );
+    }
+
+    /// A quick union losing a child exercises the compaction and the
+    /// `quick_set_from_child` republish that a full union never reaches.
+    #[test]
+    fn quick_revalidate_single_child_aborts() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let child0: Mock<'_, 5> = Mock::new([10, 20, 30, 40, 50]);
+        let child1: Mock<'_, 5> = Mock::new([15, 25, 35, 45, 55]);
+        child0
+            .data()
+            .set_revalidate_result(MockRevalidateResult::Abort);
+
+        let children = vec![
+            TypeErasedRQEIterator::new(Box::new(child0)),
+            TypeErasedRQEIterator::new(Box::new(child1)),
+        ];
+        let mut union = UnionQuickFlat::new(children);
+        assert_eq!(union.read().unwrap().unwrap().doc_id, 10);
+
+        let guard = mock_ctx.spec_read();
+        let mut union = revalidate_via_resume(TypeErasedRQEIterator::new(Box::new(union)), &guard)
+            .expect("resume failed")
+            .expect_moved();
+        assert_eq!(union.last_doc_id(), 15);
+        assert_eq!(drain(&mut union), [25, 35, 45, 55]);
+    }
+
+    // =========================================================================
+    // Differential: the legacy `revalidate` and the new `resume` are two
+    // spellings of one transition and must not drift.
+    // =========================================================================
+
+    /// The outcome shape the legacy and resume paths share.
+    #[derive(Debug, PartialEq, Eq)]
+    enum Outcome {
+        Ok,
+        Moved,
+        Aborted,
+        Failed,
+    }
+
+    /// Drive `build()` through the legacy `revalidate` and through
+    /// `suspend`/`resume`, and require both to agree on the outcome *and* on
+    /// everything read afterwards. `what` names the scenario in the failure.
+    #[track_caller]
+    fn assert_paths_agree<'index, const QUICK_EXIT: bool>(
+        what: &str,
+        guard: &index_spec::IndexSpecReadGuard<'index>,
+        build: impl Fn() -> Box<UnionFlat<'index, TypeErasedRQEIterator<'index>, QUICK_EXIT>>,
+    ) {
+        let mut legacy = build();
+        let legacy_outcome = match legacy.revalidate(guard) {
+            Ok(RQEValidateStatus::Ok) => Outcome::Ok,
+            Ok(RQEValidateStatus::Moved { .. }) => Outcome::Moved,
+            Ok(RQEValidateStatus::Aborted) => Outcome::Aborted,
+            Err(_) => Outcome::Failed,
+        };
+        // An aborted or failed iterator is dropped rather than used, so there is
+        // nothing left to read on either path.
+        let legacy_tail = match legacy_outcome {
+            Outcome::Ok | Outcome::Moved => drain(&mut *legacy),
+            Outcome::Aborted | Outcome::Failed => Vec::new(),
+        };
+
+        let (resumed_outcome, resumed_tail) = match build().suspend().resume(guard) {
+            Ok(ResumeOutcome::Ok(mut it)) => (Outcome::Ok, drain(&mut *it)),
+            Ok(ResumeOutcome::Moved(mut it)) => (Outcome::Moved, drain(&mut *it)),
+            Ok(ResumeOutcome::Aborted) => (Outcome::Aborted, Vec::new()),
+            Err(_) => (Outcome::Failed, Vec::new()),
+        };
+
+        assert_eq!(
+            legacy_outcome, resumed_outcome,
+            "{what}: the two paths disagree on the outcome",
+        );
+        assert_eq!(
+            legacy_tail, resumed_tail,
+            "{what}: the two paths disagree on what is read afterwards",
+        );
+    }
+
+    /// Every child outcome at every position, for both modes. The position
+    /// matters because the abort/error teardown splits the child list at the
+    /// failing index, and the mode matters because `QUICK_EXIT` takes settle
+    /// branches the full union cannot reach.
+    #[test]
+    fn revalidate_and_resume_agree_on_every_child_outcome() {
+        let outcomes = [
+            MockRevalidateResult::Ok,
+            MockRevalidateResult::Move,
+            MockRevalidateResult::Abort,
+            MockRevalidateResult::TimedOut,
+        ];
+        for position in 0..3 {
+            for outcome in outcomes {
+                let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+                let guard = mock_ctx.spec_read();
+                let build = || {
+                    let child0: Mock<'_, 4> = Mock::new([10, 20, 40, 70]);
+                    let child1: Mock<'_, 4> = Mock::new([10, 30, 50, 80]);
+                    let child2: Mock<'_, 4> = Mock::new([10, 35, 60, 90]);
+                    for (i, data) in [child0.data(), child1.data(), child2.data()]
+                        .iter_mut()
+                        .enumerate()
+                    {
+                        data.set_revalidate_result(if i == position {
+                            outcome
+                        } else {
+                            MockRevalidateResult::Ok
+                        });
+                    }
+                    (child0, child1, child2)
+                };
+                let what = format!("child {position} reports {outcome:?}");
+                assert_paths_agree(&format!("full: {what}"), &guard, || {
+                    let (c0, c1, c2) = build();
+                    let mut it = Box::new(UnionFullFlat::new(boxed_children(c0, c1, c2)));
+                    assert_eq!(it.read().expect("read failed").expect("doc").doc_id, 10);
+                    it
+                });
+                assert_paths_agree(&format!("quick: {what}"), &guard, || {
+                    let (c0, c1, c2) = build();
+                    let mut it = Box::new(UnionQuickFlat::new(boxed_children(c0, c1, c2)));
+                    assert_eq!(it.read().expect("read failed").expect("doc").doc_id, 10);
+                    it
+                });
+            }
+        }
+    }
+
+    /// The two exits `revalidate` reaches *before* it looks at any child, and
+    /// which `resume` has to reproduce even though it must transition the
+    /// children regardless: a union that has already finished, and a union that
+    /// never had a child to begin with.
+    ///
+    /// `MockRevalidateResult::TimedOut` is deliberately not in the loop below —
+    /// it is the one child outcome the two paths cannot agree on, pinned by
+    /// [`resume_of_a_spent_union_surfaces_a_child_error`] instead.
+    #[test]
+    fn revalidate_and_resume_agree_on_a_spent_or_empty_union() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+
+        for outcome in [MockRevalidateResult::Ok, MockRevalidateResult::Abort] {
+            assert_paths_agree(
+                &format!("full, spent, children {outcome:?}"),
+                &guard,
+                || {
+                    let child0: Mock<'_, 2> = Mock::new([10, 30]);
+                    let child1: Mock<'_, 2> = Mock::new([20, 40]);
+                    for data in [child0.data(), child1.data()].iter_mut() {
+                        data.set_revalidate_result(outcome);
+                    }
+                    let mut it = Box::new(UnionFullFlat::new(vec![
+                        TypeErasedRQEIterator::new(Box::new(child0)),
+                        TypeErasedRQEIterator::new(Box::new(child1)),
+                    ]));
+                    assert_eq!(drain(&mut *it), [10, 20, 30, 40]);
+                    it
+                },
+            );
+        }
+
+        assert_paths_agree("full, empty", &guard, || {
+            Box::new(UnionFullFlat::new(Vec::new()))
+        });
+        assert_paths_agree("quick, empty", &guard, || {
+            Box::new(UnionQuickFlat::new(Vec::new()))
+        });
+    }
+
+    /// A union that no longer holds the aggregate it built cannot resume: it has
+    /// no way to re-validate a payload it did not create, so it refuses rather
+    /// than re-narrow the substitute's suspended pointers. The union counterpart
+    /// of `optional::via_resume::resume_aborts_when_result_no_longer_virtual`.
+    ///
+    /// The three substitutes cover the three ways a payload can slip a looser
+    /// gate. `Numeric` is not an aggregate at all. `HybridMetric` *is* one, so
+    /// `is_aggregate()` would admit it. And an owned `Union` has the right kind
+    /// too, so even an exact-kind check would admit it — all three borrow no
+    /// entries, which is precisely why the rebuild reports success for them
+    /// without re-validating a thing.
+    #[test]
+    fn resume_aborts_when_the_result_is_no_longer_a_union() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+
+        for substitute in [
+            index_result::RSIndexResult::build_numeric(1.0).build(),
+            index_result::RSIndexResult::build_hybrid_metric().build(),
+        ] {
+            let child0: Mock<'_, 2> = Mock::new([10, 30]);
+            let child1: Mock<'_, 2> = Mock::new([10, 40]);
+            let mut union = Box::new(UnionFullFlat::new(vec![
+                TypeErasedRQEIterator::new(Box::new(child0)),
+                TypeErasedRQEIterator::new(Box::new(child1)),
+            ]));
+
+            let current = union.read().unwrap().unwrap();
+            assert_eq!(current.doc_id, 10);
+            // A consumer swaps what `current()` handed out for something the
+            // union never built.
+            let kind = substitute.kind();
+            *current = substitute;
+
+            assert!(
+                matches!(
+                    union.suspend().resume(&guard).expect("no error"),
+                    ResumeOutcome::Aborted
+                ),
+                "a {kind:?} result must abort the resume, not be re-narrowed",
+            );
+        }
+    }
+
+    /// The other known divergence, and the one the differential harness cannot
+    /// see: it compares outcomes and the documents read afterwards, never what a
+    /// `rewind` brings back.
+    ///
+    /// `revalidate` returns before it looks at a child when the union is spent,
+    /// so a child that would abort is never asked and stays in the list; a later
+    /// `rewind` re-admits it. `resume` has to transition every child, so it
+    /// learns about the abort and drops it, and the rewind has one fewer child
+    /// to revive.
+    ///
+    /// Deliberate, not a defect. An aborted child's underlying state is
+    /// unrecoverable, so the ones `resume` drops here are precisely the ones
+    /// `revalidate` would go on to rewind and read after their index had gone
+    /// away. The mock cannot show that — its "aborted" child stays perfectly
+    /// readable — which is exactly why the difference is asserted here rather
+    /// than left for the harness to trip over.
+    #[test]
+    fn resume_of_a_spent_union_drops_children_that_revalidate_would_rewind() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+
+        let build = || {
+            let child0: Mock<'_, 2> = Mock::new([10, 30]);
+            let child1: Mock<'_, 2> = Mock::new([20, 40]);
+            child1
+                .data()
+                .set_revalidate_result(MockRevalidateResult::Abort);
+            let mut it = Box::new(UnionFullFlat::new(vec![
+                TypeErasedRQEIterator::new(Box::new(child0)),
+                TypeErasedRQEIterator::new(Box::new(child1)),
+            ]));
+            assert_eq!(drain(&mut *it), [10, 20, 30, 40], "the union is spent");
+            it
+        };
+
+        let mut legacy = build();
+        assert!(matches!(
+            legacy.revalidate(&guard),
+            Ok(RQEValidateStatus::Ok)
+        ));
+        legacy.rewind();
+        assert_eq!(
+            drain(&mut *legacy),
+            [10, 20, 30, 40],
+            "the legacy path never asked, so the aborting child is still there",
+        );
+
+        let mut resumed = revalidate_via_resume(TypeErasedRQEIterator::new(build()), &guard)
+            .expect("resume failed")
+            .expect_ok();
+        resumed.rewind();
+        assert_eq!(
+            drain(&mut resumed),
+            [10, 30],
+            "resume asked, learned of the abort, and dropped the child for good",
+        );
+    }
+
+    /// The single outcome on which the legacy and resume paths are known to
+    /// disagree, asserted so it stays a known quantity.
+    ///
+    /// A spent union sends `revalidate` home with `Ok` before it looks at a
+    /// child, so a child that would time out is never asked. Resume has to
+    /// transition every child before it can hand any of them back, and
+    /// [`resume`](rqe_iterators::RQESuspendedIterator::resume) consumes the child
+    /// *by value* — once it answers `Err` the child no longer exists, so there is
+    /// nothing to carry on to the `is_eof` exit with. The difference is
+    /// structural, not a missing branch.
+    ///
+    /// A timeout is transient (the child is intact, the resume just ran out of
+    /// budget), so the cost is a query-level error where the legacy path would
+    /// have finished quietly.
+    #[test]
+    fn resume_of_a_spent_union_surfaces_a_child_error() {
+        let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
+        let guard = mock_ctx.spec_read();
+
+        let build = || {
+            let child0: Mock<'_, 2> = Mock::new([10, 30]);
+            let child1: Mock<'_, 2> = Mock::new([20, 40]);
+            for data in [child0.data(), child1.data()].iter_mut() {
+                data.set_revalidate_result(MockRevalidateResult::TimedOut);
+            }
+            let mut it = Box::new(UnionFullFlat::new(vec![
+                TypeErasedRQEIterator::new(Box::new(child0)),
+                TypeErasedRQEIterator::new(Box::new(child1)),
+            ]));
+            assert_eq!(drain(&mut *it), [10, 20, 30, 40], "the union is spent");
+            it
+        };
+
+        assert!(
+            matches!(build().revalidate(&guard), Ok(RQEValidateStatus::Ok)),
+            "the legacy path never reaches the timing-out child",
+        );
+        assert!(
+            build().suspend().resume(&guard).is_err(),
+            "resume must ask every child, and a consumed child cannot be walked past",
+        );
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_flat.rs
@@ -751,13 +751,13 @@ mod via_resume {
     }
 
     /// A child whose resume *fails* takes the union down the
-    /// `free_after_consumed_child` teardown, the most delicate unsafe in this
-    /// file: it drops the compacted resumed prefix, leaves the consumed slot
-    /// alone, and drops the still-suspended tail. Get the `kept`/`consumed`
+    /// `FreeSuspendedShell` teardown, the most delicate unsafe in this
+    /// guard: it drops the compacted resumed prefix, leaves the consumed slot
+    /// alone, and drops the still-suspended tail. Get the `kept`/`cursor`
     /// boundary wrong and it is a double free or a leak, both of which miri
     /// sees through the mocks' reference-counted state.
     ///
-    /// This is the plain shape: no child aborted first, so `kept == consumed`
+    /// This is the plain shape: no child aborted first, so `kept == cursor - 1`
     /// and the buffer is a resumed prefix followed directly by a suspended
     /// tail.
     #[test]
@@ -782,7 +782,7 @@ mod via_resume {
 
     /// The same teardown, but with a hole in the middle: child 0 aborts before
     /// child 2 fails, so the survivor is compacted down to slot 0 and `kept`
-    /// (1) trails `consumed` (2). Slot 1 is then a vacated hole that the
+    /// (1) trails the cursor (2). Slot 1 is then a vacated hole that the
     /// teardown must skip — the clause the plain shape never reaches.
     #[test]
     fn resume_child_error_frees_a_shell_with_a_hole_in_it() {
@@ -1262,9 +1262,17 @@ mod via_resume {
         let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
         let guard = mock_ctx.spec_read();
 
+        // An *owned* Union is the case the kind alone cannot reject: same
+        // `kind()`, but its children are boxed into the result's own allocation
+        // and never transitioned, so re-narrowing would promote whatever
+        // index-backed pointers they hold. Safe code can build one and assign it
+        // through `current()`.
+        let borrowed_src = index_result::RSIndexResult::build_union(1).build();
+        let owned_union = borrowed_src.to_owned();
         for substitute in [
             index_result::RSIndexResult::build_numeric(1.0).build(),
             index_result::RSIndexResult::build_hybrid_metric().build(),
+            owned_union,
         ] {
             let child0: Mock<'_, 2> = Mock::new([10, 30]);
             let child1: Mock<'_, 2> = Mock::new([10, 40]);


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `UnionFlat` can only be revalidated in place, so it cannot be held while the index spec read lock is released. Its existing revalidation logic also lives inline, with nothing shared with the heap variant.
2. Change: it implements `RQEIteratorBoxed::suspend` / `RQESuspendedIterator::resume`, reusing the allocation; children are transitioned inside the `Vec`'s buffer and the aggregate's borrowed entries rebuilt from the survivors before the cast. The existing revalidation logic is restructured into `settle_after_children_changed`, now shared by the legacy `revalidate` and by `resume`.
3. Outcome: no user-visible change — nothing suspends iterators yet, and the legacy path is meant to behave exactly as before. Stacked on #10899.

#### Which additional issues this PR fixes

1. MOD-16713
2. #10899

#### Main objects this PR modified

1. `settle_after_children_changed` — the restructured settling logic, and the place to look hardest: it now serves both revalidation paths, so any accidental change to legacy `revalidate` behaviour would show up here.
2. `num_active` handling across resume — the live/dead partition must not be flattened. Every child is re-admitted because removing an aborted one invalidates the active/parked partition — not because a parked child can come back; exhaustion is terminal across the cycle. The stale count is clamped immediately after the cast, before anything reads it.
3. `FreeSuspendedShell` — an RAII guard owning the shell while the children buffer is part-resumed and part-suspended. The three region boundaries are its fields, advanced as `resume` walks, so the teardown reads the state that holds rather than being handed indices that must agree with it; it covers every early return and stays armed across the aggregate work.
4. `rebuild_borrowed_entries` — the aggregate step, recomputing the contributor set instead of matching entries to children by address. A union aggregates every child sitting on its document, which is what the read path already evaluates, so it can be evaluated again over the survivors in one forward pass — which is also why the compaction over an aborted child needs no special handling here. `freq` and `field_mask` are recomputed with the entries; `metrics` and `doc_id` are carried across, because metrics are *moved* out of the children when the aggregate is first built and cannot be re-accumulated. In quick mode the rebuild stops at the first contributor, which need not be the child picked before suspending — it picks by scan order over the active region, the rebuild picks by slot, and any child on the document backs the position equally.
5. `RawUnionFlat`'s layout invariant — the whole-struct proof that licenses reinterpreting the allocation between the two `Ref` modes.
6. `tests/integration/union_flat.rs` — the resume matrix, with type-erased children (the shape production uses), plus three for the rebuild: the result agreeing with its own entries, the metrics surviving it, and quick mode republishing a single backer.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
