### PR TITLE
[MOD-16714] DiskWildcardIterator and NewWildcardIterator: suspend/resume

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -913,3 +913,104 @@ impl ProfilePrint for NewWildcardIterator<'_> {
         }
     }
 }
+
+/// Suspended counterpart of [`DiskWildcardIterator`], used as its
+/// [`RQEIteratorBoxed::Suspended`] type.
+///
+/// Wraps the **same trait object** as [`DiskWildcardIterator`] — `dyn
+/// RQEIteratorPrintable`, at the same lifetime. Two things about that are
+/// load-bearing:
+///
+/// * **Same trait.** A `dyn Sub` and a `dyn Super` do *not* share a vtable —
+///   vtable layout is unspecified, and upcasting is a coercion that may load a
+///   different pointer — so a wrapper typed at the [`RQEIterator`] supertrait
+///   would leave the value carrying metadata for the wrong trait.
+/// * **Same lifetime.** The disk iterator is opaque: unlike every other
+///   suspended type in this crate, there is no `Rf` mode to weaken its
+///   index-derived state to raw pointers, so its borrow of the disk spec
+///   necessarily stays live for the whole suspend/resume cycle. That is exactly
+///   what `'query` denotes here (see [`RQESuspendedIterator`]) — borrows that
+///   survive the cycle rather than being re-derived from the guard on resume.
+///   Erasing it to `'static` instead would let safe code suspend an iterator,
+///   drop the disk spec it borrows, and then drop the suspended box, running
+///   the backend's destructor against dangling borrows.
+///
+/// This makes [`suspend`](RQEIteratorBoxed::suspend) a pure newtype wrap with
+/// no lifetime change at all; only [`resume`](RQESuspendedIterator::resume)
+/// adjusts one, shortening `'query` to the guard's lifetime.
+#[repr(transparent)]
+pub struct DiskWildcardSuspended<'query>(pub(crate) Box<dyn RQEIteratorPrintable<'query> + 'query>);
+
+impl<'index> RQEIteratorBoxed<'index> for DiskWildcardIterator<'index> {
+    type Suspended = DiskWildcardSuspended<'index>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // SAFETY: `DiskWildcardIterator<'index>` *is*
+        // `Box<dyn RQEIteratorPrintable<'index> + 'index>` (a type alias), and
+        // `DiskWildcardSuspended<'index>` is a `#[repr(transparent)]` newtype
+        // over that very type — same trait, same lifetime — so this is a
+        // newtype wrap rather than any reinterpretation of the value.
+        // `Box::from_raw` reuses the same heap allocation.
+        unsafe { Box::from_raw(raw as *mut DiskWildcardSuspended<'index>) }
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for DiskWildcardSuspended<'query> {
+    type Resumed<'a>
+        = DiskWildcardIterator<'a>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        spec: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let raw = Box::into_raw(self);
+        // SAFETY: unwraps the `#[repr(transparent)]` newtype and shortens the
+        // inner trait object's lifetime from `'query` to the caller's `'a`,
+        // which `'query: 'a` permits. The cast is needed because `'index`
+        // appears behind `&mut` in [`RQEIterator::current`]'s return type, which
+        // makes `dyn RQEIteratorPrintable<'index>` invariant and so blocks the
+        // implicit coercion; shortening is nonetheless sound, since a value
+        // valid for `'query` is valid for any shorter `'a`.
+        // `Box::from_raw` reuses the same heap allocation.
+        let mut active = unsafe { Box::from_raw(raw as *mut DiskWildcardIterator<'a>) };
+        // Drive validity recovery through the inner trait object's
+        // `revalidate` callback — the same path the legacy
+        // `Suspendable::resume` used. Reduce the borrowing `RQEValidateStatus`
+        // to a `Copy` status discriminant first so the mutable borrow of
+        // `active` ends before we move it into the outcome; propagate a
+        // revalidate error (e.g. timeout) rather than masking it.
+        let status = match active.revalidate(spec)? {
+            RQEValidateStatus::Ok => ffi::ValidateStatus_VALIDATE_OK,
+            RQEValidateStatus::Moved { .. } => ffi::ValidateStatus_VALIDATE_MOVED,
+            RQEValidateStatus::Aborted => ffi::ValidateStatus_VALIDATE_ABORTED,
+        };
+        Ok(match status {
+            ffi::ValidateStatus_VALIDATE_OK => ResumeOutcome::Ok(active),
+            ffi::ValidateStatus_VALIDATE_MOVED => ResumeOutcome::Moved(active),
+            // `Aborted`: `active` is not moved into the outcome, so the inner
+            // trait object drops here.
+            _ => ResumeOutcome::Aborted,
+        })
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        // Forwards into the backend iterator, which `'query` keeps borrow-checked
+        // for the whole suspend window, so the dispatch and the receiver are both
+        // sound. What is *not* type-enforced is that the backend answers from
+        // cached state: `RQEIterator` does not require it, and a backend that
+        // recomputed this from the disk spec would be reading it with the index
+        // spec lock released. Every implementation in the workspace caches.
+        RQEIterator::last_doc_id(&*self.0)
+    }
+
+    fn num_estimated(&self) -> usize {
+        // Cached count — see `last_doc_id`, including the caveat.
+        RQEIterator::num_estimated(&*self.0)
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -274,6 +274,24 @@ impl<'index> WildcardIterator<'index> for crate::TypeErasedRQEIterator<'index> {
 
 /// The result of [`new_wildcard_iterator`], representing the different kinds of
 /// wildcard iterators that can be created depending on the index configuration.
+///
+/// # Invariants
+///
+/// 1. **Layout compatibility with [`NewWildcardSuspended`].** The two are
+///    layout-identical, so [`suspend`](RQEIteratorBoxed::suspend) /
+///    [`resume`](RQESuspendedIterator::resume) can transition each payload in
+///    place and then reinterpret the owning `Box`, preserving every interior
+///    address across the cycle. `#[repr(C, u8)]` on **both** is what pins the
+///    tag encoding and the payload offsets — under the default `repr(Rust)`
+///    each enum picks its own, and the tag may even be niche-encoded into a
+///    payload pointer. The `const _` proof beside `NewWildcardSuspended`
+///    discharges the rest.
+///
+/// Unlike [`RawOptimizedWildcard`], this pair cannot collapse into a single
+/// `Rf`-parametrized enum: the [`Disk`](Self::Disk) arm's active and suspended
+/// forms are genuinely different types — a `Box<dyn …>` and the
+/// [`DiskWildcardSuspended`] newtype — rather than one type at two modes.
+#[repr(C, u8)]
 pub enum NewWildcardIterator<'index> {
     /// Non-optimized wildcard: yields all document ids from 1 to `maxDocId`.
     NotOptimized(Wildcard<'index>),
@@ -702,6 +720,253 @@ impl<'index> RQEIterator<'index> for NewWildcardIterator<'index> {
 }
 
 impl<'index> WildcardIterator<'index> for NewWildcardIterator<'index> {}
+
+/// [`Suspended`]-mode counterpart of [`NewWildcardIterator`] used as
+/// its [`RQEIteratorBoxed::Suspended`] type. Each variant holds the
+/// `Suspended` form of the corresponding active variant, retaining the
+/// `'query` lifetime so query-attached borrows stay valid across the
+/// suspend/resume cycle.
+///
+/// `#[repr(C, u8)]` is required here for the same reason it is on
+/// [`NewWildcardIterator`] — see invariant 1 there.
+#[repr(C, u8)]
+pub enum NewWildcardSuspended<'query> {
+    /// Suspended counterpart of [`NewWildcardIterator::NotOptimized`].
+    NotOptimized(RawWildcard<'query, Suspended>),
+    /// Suspended counterpart of [`NewWildcardIterator::Optimized`].
+    Optimized(OptimizedWildcardSuspended<'query>),
+    /// Suspended counterpart of [`NewWildcardIterator::Empty`].
+    Empty(Empty),
+    /// Suspended counterpart of [`NewWildcardIterator::Disk`].
+    Disk(DiskWildcardSuspended<'query>),
+}
+
+// Compile-time proof of invariant 1 on the
+// `NewWildcardIterator`/`NewWildcardSuspended` pair, which the whole-box casts
+// in `suspend` and `resume` below rely on.
+//
+// Both enums are `#[repr(C, u8)]` with the same four variants in the same
+// order, which fixes the tag encoding (a `u8` counting from 0 in declaration
+// order) and puts each payload at an offset derived from that payload's own
+// alignment. That is a guarantee of the repr, so it needs stating rather than
+// asserting. What remains:
+//
+// (a) **Arm correspondence.** `suspend` fills each payload slot with
+//     `<active arm as RQEIteratorBoxed>::Suspended` — see
+//     [`crate::boxed::suspend_child_slot_in_place`] — and only then relabels the
+//     owning box, so the suspended enum's matching arm must *be* that
+//     projection. Asserted as a type equality: that is the property the
+//     reinterpretation needs, and a mismatch becomes a build error rather than
+//     a silently mistyped payload.
+//
+// (b) **Per-arm payload layout identity.** Implied by (a) plus each arm's own
+//     invariant (`RawWildcard`'s proof above, `RawOptimizedWildcard`'s proof in
+//     this module, `Empty` being a ZST in both modes, and `DiskWildcardSuspended`
+//     being a `#[repr(transparent)]` newtype over the same trait object).
+//     Asserted per arm anyway so a regression names the arm that broke — under
+//     `#[repr(C, u8)]` it is *per-arm* alignment, not the enum's, that pins the
+//     payload offsets. (`offset_of!` into enum variants is not yet stable.)
+//
+// (c) **Enum size/alignment equality.** Needed on its own by `resume`'s
+//     abort/error paths, which free an allocation created for the active enum
+//     using `Layout::new::<NewWildcardSuspended>()`.
+const _: () = {
+    use std::mem::{align_of, size_of};
+
+    /// Witnesses that `Self` and `T` are the same type: the blanket impl is the
+    /// only one, so an `A: IsSame<B>` bound holds exactly when `A` *is* `B`.
+    trait IsSame<T> {}
+    impl<T> IsSame<T> for T {}
+
+    /// (a) — fails to compile unless suspending `A` yields exactly `S`.
+    const fn assert_suspends_to<A, S>()
+    where
+        A: RQEIteratorBoxed<'static>,
+        A::Suspended: IsSame<S>,
+    {
+    }
+
+    assert_suspends_to::<Wildcard<'static>, RawWildcard<'static, Suspended>>();
+    assert_suspends_to::<OptimizedWildcard<'static>, OptimizedWildcardSuspended<'static>>();
+    assert_suspends_to::<Empty, Empty>();
+    assert_suspends_to::<DiskWildcardIterator<'static>, DiskWildcardSuspended<'static>>();
+
+    // (b)
+    assert!(size_of::<Wildcard<'static>>() == size_of::<RawWildcard<'static, Suspended>>());
+    assert!(align_of::<Wildcard<'static>>() == align_of::<RawWildcard<'static, Suspended>>());
+    assert!(
+        size_of::<OptimizedWildcard<'static>>() == size_of::<OptimizedWildcardSuspended<'static>>()
+    );
+    assert!(
+        align_of::<OptimizedWildcard<'static>>()
+            == align_of::<OptimizedWildcardSuspended<'static>>()
+    );
+    assert!(
+        size_of::<DiskWildcardIterator<'static>>() == size_of::<DiskWildcardSuspended<'static>>()
+    );
+    assert!(
+        align_of::<DiskWildcardIterator<'static>>() == align_of::<DiskWildcardSuspended<'static>>()
+    );
+
+    // (c)
+    assert!(
+        size_of::<NewWildcardIterator<'static>>() == size_of::<NewWildcardSuspended<'static>>()
+    );
+    assert!(
+        align_of::<NewWildcardIterator<'static>>() == align_of::<NewWildcardSuspended<'static>>()
+    );
+};
+
+impl<'index> RQEIteratorBoxed<'index> for NewWildcardIterator<'index> {
+    type Suspended = NewWildcardSuspended<'index>;
+
+    fn suspend(self: Box<Self>) -> Box<Self::Suspended> {
+        let raw = Box::into_raw(self);
+        // Transition the payload in place, arm by arm, then relabel the box.
+        // Rebuilding instead — moving the arm out and `Box::new`-ing a fresh
+        // enum — would relocate both the wrapper and the arm's payload, and
+        // this is the type the FFI wrapper boxes, so the interior addresses it
+        // hands to C (`header.current`) have to survive. The tag byte is
+        // untouched, so the cast lands on the matching variant.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+        // initialised, exclusively owned); the `&mut` borrow is confined to the
+        // match.
+        match unsafe { &mut *raw } {
+            NewWildcardIterator::NotOptimized(it) => {
+                // SAFETY: `it` is the valid, exclusively-owned payload; the
+                // helper reinitialises the slot as its `Suspended` form in place.
+                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+            }
+            NewWildcardIterator::Optimized(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+            }
+            NewWildcardIterator::Empty(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+            }
+            NewWildcardIterator::Disk(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::suspend_child_slot_in_place(it as *mut _) }
+            }
+        }
+        // SAFETY: every payload now holds its `Suspended` form at the same
+        // offset and the tag encodes the same variant in both enums (invariant
+        // 1, const proof above). `Box::from_raw` reuses the same allocation, so
+        // the box address is preserved.
+        unsafe { Box::from_raw(raw.cast::<NewWildcardSuspended<'index>>()) }
+    }
+}
+
+impl<'query> RQESuspendedIterator<'query> for NewWildcardSuspended<'query> {
+    type Resumed<'a>
+        = NewWildcardIterator<'a>
+    where
+        'query: 'a;
+
+    fn resume<'a>(
+        self: Box<Self>,
+        guard: &IndexSpecReadGuard<'a>,
+    ) -> Result<ResumeOutcome<Box<Self::Resumed<'a>>>, RQEIteratorError>
+    where
+        'query: 'a,
+    {
+        let raw = Box::into_raw(self);
+        // Resume the payload in place, arm by arm — mirroring `suspend`, so the
+        // allocation and every interior address survive the full cycle. The tag
+        // is untouched, so the cast below lands on the matching variant of the
+        // active enum. An aborting arm aborts the whole wrapper: this enum owns
+        // no result of its own to fall back to.
+        //
+        // SAFETY: `raw` came from `Box::into_raw` (non-null, aligned,
+        // initialised, exclusively owned); the `&mut` borrow is confined to the
+        // match. On `Unchanged`/`Moved` the helper rewrites the payload as its
+        // resumed form; on `Aborted`/`Err` it consumes the payload, leaving it
+        // uninitialised (handled below).
+        let outcome = match unsafe { &mut *raw } {
+            NewWildcardSuspended::NotOptimized(it) => {
+                // SAFETY: `it` is the valid, exclusively-owned payload.
+                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, guard) }
+            }
+            NewWildcardSuspended::Optimized(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, guard) }
+            }
+            NewWildcardSuspended::Empty(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, guard) }
+            }
+            NewWildcardSuspended::Disk(it) => {
+                // SAFETY: as above.
+                unsafe { crate::boxed::resume_child_slot_in_place(it as *mut _, guard) }
+            }
+        };
+
+        /// Frees the reused allocation after an arm consumed its payload,
+        /// without dropping the uninitialised slot.
+        ///
+        /// # Safety
+        ///
+        /// `raw` must come from `Box::into_raw` on a `NewWildcardSuspended`
+        /// whose payload has been consumed, leaving only the tag live.
+        unsafe fn dealloc_after_arm_gone(raw: *mut NewWildcardSuspended<'_>) {
+            // SAFETY: allocated by `Box` with exactly this layout, and nothing
+            // in it is live any more.
+            unsafe {
+                std::alloc::dealloc(
+                    raw.cast::<u8>(),
+                    std::alloc::Layout::new::<NewWildcardSuspended<'_>>(),
+                )
+            };
+        }
+
+        match outcome {
+            Ok(crate::boxed::ResumeSlotOutcome::Unchanged) => {
+                // SAFETY: the payload holds its resumed form at the same offset
+                // and the tag is unchanged; `Box::from_raw` reuses the same
+                // allocation, so the box address — and any pointer the FFI
+                // wrapper cached into the payload — stay valid.
+                let active = unsafe { Box::from_raw(raw.cast::<NewWildcardIterator<'a>>()) };
+                Ok(ResumeOutcome::Ok(active))
+            }
+            Ok(crate::boxed::ResumeSlotOutcome::Moved) => {
+                // SAFETY: as above.
+                let active = unsafe { Box::from_raw(raw.cast::<NewWildcardIterator<'a>>()) };
+                Ok(ResumeOutcome::Moved(active))
+            }
+            Ok(crate::boxed::ResumeSlotOutcome::Aborted) => {
+                // SAFETY: the arm consumed the payload; only the tag is left.
+                unsafe { dealloc_after_arm_gone(raw) };
+                Ok(ResumeOutcome::Aborted)
+            }
+            Err(e) => {
+                // As `Aborted` — the arm consumed the payload.
+                // SAFETY: as above.
+                unsafe { dealloc_after_arm_gone(raw) };
+                Err(e)
+            }
+        }
+    }
+
+    fn last_doc_id(&self) -> DocId {
+        match self {
+            NewWildcardSuspended::NotOptimized(it) => RQESuspendedIterator::last_doc_id(it),
+            NewWildcardSuspended::Optimized(it) => RQESuspendedIterator::last_doc_id(it),
+            NewWildcardSuspended::Empty(it) => RQESuspendedIterator::last_doc_id(it),
+            NewWildcardSuspended::Disk(it) => RQESuspendedIterator::last_doc_id(it),
+        }
+    }
+
+    fn num_estimated(&self) -> usize {
+        match self {
+            NewWildcardSuspended::NotOptimized(it) => RQESuspendedIterator::num_estimated(it),
+            NewWildcardSuspended::Optimized(it) => RQESuspendedIterator::num_estimated(it),
+            NewWildcardSuspended::Empty(it) => RQESuspendedIterator::num_estimated(it),
+            NewWildcardSuspended::Disk(it) => RQESuspendedIterator::num_estimated(it),
+        }
+    }
+}
 
 /// Create a [`WildcardIterator`] for an index whose spec has
 /// [`SchemaRule`](ffi::SchemaRule)`.index_all` set.

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -1245,8 +1245,7 @@ impl<'query> RQESuspendedIterator<'query> for DiskWildcardSuspended<'query> {
         // `Box::from_raw` reuses the same heap allocation.
         let mut active = unsafe { Box::from_raw(raw as *mut DiskWildcardIterator<'a>) };
         // Drive validity recovery through the inner trait object's
-        // `revalidate` callback — the same path the legacy
-        // `Suspendable::resume` used. Reduce the borrowing `RQEValidateStatus`
+        // `revalidate` callback. Reduce the borrowing `RQEValidateStatus`
         // to a `Copy` status discriminant first so the mutable borrow of
         // `active` ends before we move it into the outcome; propagate a
         // revalidate error (e.g. timeout) rather than masking it.

--- a/src/redisearch_rs/rqe_iterators/tests/integration/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/wildcard.rs
@@ -578,3 +578,104 @@ mod via_resume {
         assert_eq!(active.read().unwrap().unwrap().doc_id, DOC_IDS[3]);
     }
 }
+
+/// Suspend/resume coverage for [`DiskWildcardIterator`] — the type-erased
+/// wildcard the enterprise disk backend hands back.
+///
+/// Unlike the other wildcards this one is a `Box<dyn RQEIteratorPrintable>`,
+/// so its suspended form cannot weaken anything: the payload is opaque. Two
+/// properties are therefore worth pinning, and neither is visible from a
+/// concrete-child test:
+///
+/// * The cast keeps the **same trait object**. `DiskWildcardSuspended` holds
+///   `dyn RQEIteratorPrintable`, not the `dyn RQEIterator` supertrait — a
+///   `dyn Sub` and a `dyn Super` do not share a vtable, so a wrapper typed at
+///   the supertrait would carry a vtable for the wrong trait. The suspended
+///   accessors below dispatch through that vtable, which is what makes this
+///   observable at all; under miri the mismatch is caught earlier still, at the
+///   point the value is constructed.
+/// * The `'static` in the suspended type is a lifetime lie, so the round trip
+///   has to end with a usable iterator at the guard's lifetime rather than one
+///   that merely type-checks.
+mod disk_via_resume {
+    use rqe_iterators::{
+        NewWildcardIterator, RQEIterator, RQEIteratorBoxed, RQESuspendedIterator, ResumeOutcome,
+        wildcard::new_wildcard_iterator_on_disk,
+    };
+    use rqe_iterators_test_utils::MockContext;
+
+    use crate::utils::{MOCK_DISK_WILDCARD_TOP_ID, init_enterprise_iterators};
+
+    /// A disk wildcard from the mock enterprise backend.
+    ///
+    /// The mock ignores both the disk spec and the snapshot, so a null cell and
+    /// a dangling sentinel are enough — all the production path checks is that
+    /// they are non-null. `disk_spec` is borrowed from the caller's frame
+    /// rather than leaked so that it outlives the iterator, which is what the
+    /// `'index` lifetime claims.
+    fn disk_wildcard<'index>(
+        ctx: &MockContext,
+        disk_spec: &'index mut ffi::RedisSearchDiskIndexSpec,
+    ) -> Box<rqe_iterators::wildcard::DiskWildcardIterator<'index>> {
+        init_enterprise_iterators();
+        ctx.set_dummy_disk_snapshot();
+
+        let snapshot = std::ptr::NonNull::<ffi::RedisSearchDiskSnapshot>::dangling();
+
+        // SAFETY: `SEARCH_ENTERPRISE_ITERATORS` is initialised just above;
+        // `disk_spec` and `snapshot` are non-null and never dereferenced by the
+        // mock; `status` is null, which the factory accepts.
+        let it = unsafe {
+            new_wildcard_iterator_on_disk(disk_spec, 1.0, snapshot, std::ptr::null_mut())
+        };
+        let NewWildcardIterator::Disk(disk) = it else {
+            panic!("the mock enterprise backend must produce the Disk variant");
+        };
+        Box::new(disk)
+    }
+
+    /// The round trip, end to end: the box address survives, the suspended
+    /// accessors answer through the preserved vtable, and the resumed iterator
+    /// still reads.
+    #[test]
+    fn resume_round_trip() {
+        let ctx = MockContext::new(0, 0);
+        // Declared before the iterator so it outlives it.
+        let mut disk_spec: ffi::RedisSearchDiskIndexSpec = std::ptr::null();
+        let mut it = disk_wildcard(&ctx, &mut disk_spec);
+
+        assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
+        let box_addr = &*it as *const _ as usize;
+
+        let suspended = it.suspend();
+        assert_eq!(
+            &*suspended as *const _ as usize, box_addr,
+            "suspend must reuse the allocation",
+        );
+        // Dispatched through the inner trait object while suspended. A wrapper
+        // typed at the wrong trait would read these out of the wrong vtable
+        // slots; the mock's sentinel `top_id` makes a wrong answer obvious.
+        assert_eq!(
+            RQESuspendedIterator::num_estimated(&*suspended),
+            MOCK_DISK_WILDCARD_TOP_ID as usize,
+            "the suspended form must answer from the mock's wildcard",
+        );
+        assert_eq!(RQESuspendedIterator::last_doc_id(&*suspended), 1);
+
+        let guard = ctx.spec_read();
+        let mut active = match suspended.resume(&guard).expect("resume failed") {
+            ResumeOutcome::Ok(a) => a,
+            ResumeOutcome::Moved(_) => panic!("expected Ok, got Moved"),
+            ResumeOutcome::Aborted => panic!("expected Ok, got Aborted"),
+        };
+        assert_eq!(
+            &*active as *const _ as usize, box_addr,
+            "resume must reuse the allocation",
+        );
+        assert_eq!(
+            active.read().unwrap().unwrap().doc_id,
+            2,
+            "the resumed iterator continues where it left off",
+        );
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/tests/integration/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/wildcard.rs
@@ -331,8 +331,8 @@ mod via_resume {
     /// (like `optional_optimized`'s `WildcardIndex`) can only ever produce
     /// `Aborted`. The index is held behind a raw pointer so the spec's view of
     /// it and the reader's view of it are derived from the same provenance.
-    struct ExistingDocs {
-        ctx: MockContext,
+    pub(super) struct ExistingDocs {
+        pub(super) ctx: MockContext,
         index: *mut opaque::InvertedIndex,
     }
 
@@ -366,7 +366,7 @@ mod via_resume {
             Self { ctx, index }
         }
 
-        fn doc_ids_only() -> Self {
+        pub(super) fn doc_ids_only() -> Self {
             let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
             populate(&mut ii);
             Self::new(opaque::InvertedIndex::DocIdsOnly(ii))
@@ -379,7 +379,7 @@ mod via_resume {
         }
 
         /// The typed index the spec's `existingDocs` points at.
-        fn typed<E>(&self) -> &InvertedIndex<E>
+        pub(super) fn typed<E>(&self) -> &InvertedIndex<E>
         where
             E: DecodedBy + OpaqueEncoding<Storage = InvertedIndex<E>>,
         {
@@ -613,7 +613,7 @@ mod disk_via_resume {
     /// they are non-null. `disk_spec` is borrowed from the caller's frame
     /// rather than leaked so that it outlives the iterator, which is what the
     /// `'index` lifetime claims.
-    fn disk_wildcard<'index>(
+    pub(super) fn disk_wildcard<'index>(
         ctx: &MockContext,
         disk_spec: &'index mut ffi::RedisSearchDiskIndexSpec,
     ) -> Box<rqe_iterators::wildcard::DiskWildcardIterator<'index>> {
@@ -677,5 +677,155 @@ mod disk_via_resume {
             2,
             "the resumed iterator continues where it left off",
         );
+    }
+}
+
+/// Suspend/resume coverage for [`NewWildcardIterator`] — the enum
+/// `new_wildcard_iterator` returns, and the type the FFI wrapper actually
+/// boxes and hands to C.
+///
+/// That last point is what these tests are really about. Because
+/// `RQEIteratorWrapper` caches a raw pointer into the boxed iterator
+/// (`header.current`), the cycle has to preserve addresses: not just the
+/// wrapper's allocation but the arm's position inside it. Rebuilding — moving
+/// the arm out and `Box::new`-ing a fresh enum — type-checks and passes a
+/// naive round-trip test while relocating everything, so every case below
+/// asserts the box address explicitly rather than only checking the values
+/// that came back.
+///
+/// The four arms are spelled out separately: each is a distinct payload pair
+/// with its own `suspend`/`resume` instantiation, so one passing says nothing
+/// about the others. Between them they cover every branch of the wrapper's
+/// `suspend` and `resume` — three arms through the `Ok` path and the fourth
+/// through `Aborted`, which is the one that exercises the teardown that frees
+/// the reused allocation without dropping the consumed payload.
+mod new_wildcard_via_resume {
+    use rqe_iterators::{
+        Empty, NewWildcardIterator, RQEIterator, RQEIteratorBoxed, RQESuspendedIterator,
+        ResumeOutcome,
+        inverted_index::Wildcard as InvIdxWildcard,
+        wildcard::{NewWildcardSuspended, OptimizedWildcard, Wildcard},
+    };
+    use rqe_iterators_test_utils::MockContext;
+
+    use super::disk_via_resume::disk_wildcard;
+    use super::via_resume::ExistingDocs;
+    use crate::utils::MOCK_DISK_WILDCARD_TOP_ID;
+
+    /// Round trip through the `NotOptimized` arm: a plain counter wildcard,
+    /// which resumes unconditionally because it borrows nothing from the index.
+    #[test]
+    fn not_optimized_round_trip_preserves_the_allocation() {
+        let ctx = MockContext::new(0, 0);
+        let mut it = Box::new(NewWildcardIterator::NotOptimized(Wildcard::new(10, 1.0)));
+
+        assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
+        let box_addr = &*it as *const _ as usize;
+
+        let suspended = it.suspend();
+        assert_eq!(&*suspended as *const _ as usize, box_addr);
+        assert!(matches!(&*suspended, NewWildcardSuspended::NotOptimized(_)));
+        assert_eq!(RQESuspendedIterator::last_doc_id(&*suspended), 1);
+
+        let guard = ctx.spec_read();
+        let ResumeOutcome::Ok(mut active) = suspended.resume(&guard).expect("resume failed") else {
+            panic!("expected Ok");
+        };
+        assert_eq!(
+            &*active as *const _ as usize, box_addr,
+            "resume must reuse the allocation",
+        );
+        assert!(matches!(&*active, NewWildcardIterator::NotOptimized(_)));
+        assert_eq!(active.read().unwrap().unwrap().doc_id, 2);
+    }
+
+    /// Round trip through the `Empty` arm. The payload is a ZST, so this is the
+    /// case where a tag mix-up would be invisible in the payload bytes and only
+    /// the variant assertions catch it.
+    #[test]
+    fn empty_round_trip_preserves_the_allocation() {
+        let ctx = MockContext::new(0, 0);
+        let it = Box::new(NewWildcardIterator::Empty(Empty));
+        let box_addr = &*it as *const _ as usize;
+
+        let suspended = it.suspend();
+        assert_eq!(&*suspended as *const _ as usize, box_addr);
+        assert!(matches!(&*suspended, NewWildcardSuspended::Empty(_)));
+
+        let guard = ctx.spec_read();
+        let ResumeOutcome::Ok(mut active) = suspended.resume(&guard).expect("resume failed") else {
+            panic!("expected Ok");
+        };
+        assert_eq!(&*active as *const _ as usize, box_addr);
+        assert!(matches!(&*active, NewWildcardIterator::Empty(_)));
+        assert!(active.read().unwrap().is_none());
+    }
+
+    /// Round trip through the `Disk` arm — the only arm whose payload is a
+    /// trait object, so the one where the wrapper's cast has to leave a vtable
+    /// intact as well as a position.
+    #[test]
+    fn disk_round_trip_preserves_the_allocation() {
+        let ctx = MockContext::new(0, 0);
+        // Declared before the iterator so it outlives it.
+        let mut disk_spec: ffi::RedisSearchDiskIndexSpec = std::ptr::null();
+        let mut it = Box::new(NewWildcardIterator::Disk(*disk_wildcard(
+            &ctx,
+            &mut disk_spec,
+        )));
+
+        assert_eq!(it.read().unwrap().unwrap().doc_id, 1);
+        let box_addr = &*it as *const _ as usize;
+
+        let suspended = it.suspend();
+        assert_eq!(&*suspended as *const _ as usize, box_addr);
+        assert!(matches!(&*suspended, NewWildcardSuspended::Disk(_)));
+        assert_eq!(
+            RQESuspendedIterator::num_estimated(&*suspended),
+            MOCK_DISK_WILDCARD_TOP_ID as usize,
+            "the suspended accessor must reach the mock's wildcard through the arm",
+        );
+
+        let guard = ctx.spec_read();
+        let ResumeOutcome::Ok(mut active) = suspended.resume(&guard).expect("resume failed") else {
+            panic!("expected Ok");
+        };
+        assert_eq!(&*active as *const _ as usize, box_addr);
+        assert!(matches!(&*active, NewWildcardIterator::Disk(_)));
+        assert_eq!(active.read().unwrap().unwrap().doc_id, 2);
+    }
+
+    /// The `Optimized` arm, driven to `Aborted`: the GC nulls `existingDocs`
+    /// while the wrapper is suspended, the arm refuses to resume, and the
+    /// wrapper must free the reused allocation *without* dropping the payload
+    /// the arm already consumed. A double drop or a mismatched deallocation
+    /// layout here is exactly what miri is watching for.
+    #[test]
+    fn optimized_arm_abort_tears_down_the_reused_allocation() {
+        let fixture = ExistingDocs::doc_ids_only();
+        let mut it = Box::new(NewWildcardIterator::Optimized(
+            OptimizedWildcard::DocIdsOnly(InvIdxWildcard::new(
+                fixture
+                    .typed::<inverted_index::doc_ids_only::DocIdsOnly>()
+                    .reader(),
+                1.0,
+            )),
+        ));
+        assert!(it.read().unwrap().is_some());
+
+        let suspended = it.suspend();
+        assert!(matches!(&*suspended, NewWildcardSuspended::Optimized(_)));
+
+        fixture
+            .ctx
+            .spec_write()
+            .set_existing_docs_ptr(std::ptr::null_mut());
+
+        // Taken after the write, as the production sequence does.
+        let guard = fixture.ctx.spec_read();
+        assert!(matches!(
+            suspended.resume(&guard).expect("resume failed"),
+            ResumeOutcome::Aborted
+        ));
     }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `DiskWildcardIterator` — the type-erased wildcard the enterprise disk backend returns — and `NewWildcardIterator`, the enum `new_wildcard_iterator` produces and the FFI wrapper boxes, have no suspended counterpart. Neither can be held across a release of the index spec read lock, which leaves the wildcard family half-migrated after #10896.
2. Change: both implement `RQEIteratorBoxed::suspend` / `RQESuspendedIterator::resume`. `NewWildcardIterator` gains a layout-paired suspended twin and transitions each arm in place, so suspending reinterprets the existing allocation rather than rebuilding it; the disk wrapper keeps the same trait object across the cycle and changes only its lifetime. The legacy `revalidate` is unchanged.
3. Outcome: no user-visible change — the pipeline does not suspend iterators yet. This completes the per-iterator prerequisites for the wildcard family.

#### Which additional issues this PR fixes

1. MOD-16714

#### Main objects this PR modified

1. `NewWildcardIterator` / `NewWildcardSuspended` — a `#[repr(C, u8)]` pair whose `suspend`/`resume` reuse the box and drive each of the four arms through the shared child-slot helpers. Address stability is the point, not an optimisation: this is the type the FFI wrapper boxes, and it caches a raw pointer into the iterator (`header.current`), so relocating the arm inside the enum would dangle it.
2. The `Aborted`/`Err` teardown on that resume — the arm consumes its payload and leaves the slot uninitialised, so the reused allocation is freed without dropping it.
3. `DiskWildcardSuspended` — holds `dyn RQEIteratorPrintable`, the *same* trait object as the active form, so the cast is a pure lifetime operation. A `dyn Sub` and a `dyn Super` do not share a vtable, so a wrapper typed at the supertrait would carry metadata for the wrong trait.
4. The `const _` proofs — an `IsSame` witness that each arm's `RQEIteratorBoxed::Suspended` really is the matching suspended arm, plus per-arm and whole-enum size/align. Per-arm alignment is what pins the payload offsets under `#[repr(C, u8)]`.
5. `tests/integration/wildcard.rs` — a round trip per arm asserting the box address survives, the disk arm's suspended accessors dispatching through the preserved vtable, and the `Optimized` arm driven to `Aborted` to exercise the teardown.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
