### PR TITLE
CI: stop nightly and lint churning the Actions cache budget

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -82,6 +82,15 @@ inputs:
     description: "key for Swatinem/rust-cache (caller-computed so miri can key differently from build/test)."
     required: false
     default: ""
+  rust-cache-read-only:
+    description: |
+      "'true' to restore the cache but never write it, on top of the
+      default-branch gate below. For default-branch runs that build far more
+      platforms than the merge queue needs: saving every one of them would
+      exhaust the 10 GB repository budget and evict the caches that are actually
+      on the critical path.
+    required: false
+    default: "false"
 
   # --- Setup Rust test dependencies -------------------------------------------
   rust-test-deps:
@@ -206,7 +215,7 @@ runs:
         # `gh-readonly-queue/*` or `refs/pull/*/merge` ref is also scoped to a
         # ref no later run shares, whereas the default branch is readable by all
         # of them.
-        save-if: ${{ github.ref == 'refs/heads/master' }}
+        save-if: ${{ inputs.rust-cache-read-only != 'true' && github.ref == 'refs/heads/master' }}
 
     - name: Setup Rust test dependencies
       # Wrapped in retry-command (5 attempts) to survive cargo-binstall's

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -36,6 +36,11 @@ jobs:
       job-test-config: '{"test": "", "coverage": "", "sanitize": ""}'
       options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,sanitize' }}
       rejson-branch: master
+      # This runs on the default branch, so it would otherwise be allowed to save
+      # a Rust cache for every platform above — roughly the entire 10 GB the
+      # repository gets, evicting the merge-queue platforms' caches in the
+      # process. Nightly latency does not matter; theirs does.
+      rust-cache-read-only: true
 
   micro-benchmarks:
     permissions:

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -43,6 +43,10 @@ on:
         type: boolean
         default: false
         description: "Run coordinator tests in a separate parallel job per platform"
+      rust-cache-read-only:
+        type: boolean
+        default: false
+        description: "If true, restore the Rust cache but never write it. Set by callers that sweep every platform, whose saves would evict the caches on the merge-queue critical path."
 
   workflow_dispatch:
     inputs:
@@ -166,3 +170,4 @@ jobs:
       san: ${{ matrix.job-type == 'sanitize' && 'address' || matrix.job-type == 'ubsan' && 'alignment' || '' }}
       fail-fast: ${{ contains(inputs.options, 'fail-fast') || inputs.fail-fast == true }}
       skip-tests: ${{ contains(inputs.options, 'skip-tests') }}
+      rust-cache-read-only: ${{ inputs.rust-cache-read-only || false }}

--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -107,6 +107,14 @@ jobs:
           # relative to the `$workspace` and defaults to "target" if not explicitly given.
           # default: ". -> target"
           workspaces: "src/redisearch_rs -> ../../bin/redisearch_rs"
+          # Restore-only off the default branch, matching setup-build-env's
+          # rust-cache. This job does not go through that action, so it needs its
+          # own copy of the gate — and it is the single largest writer in the
+          # repo at ~800 MB, on every PR push and every merge-queue entry, which
+          # on its own kept evicting the caches the other jobs depend on. The
+          # nightly flow runs this job on the default branch, so the cache still
+          # gets written once a day.
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Hakari
         run: cargo install cargo-hakari --locked
       - name: Cargo deny

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -62,6 +62,10 @@ on:
         type: boolean
         default: false
         description: "If true, build the module for this platform but skip all test steps."
+      rust-cache-read-only:
+        type: boolean
+        default: false
+        description: "If true, restore the Rust cache but never write it. For callers that sweep far more platforms than the merge queue needs, whose saves would evict the caches on the critical path."
 
 env:
   REJSON: ${{ inputs.rejson && 1 || 0 }} # convert the boolean input to numeric
@@ -244,6 +248,7 @@ jobs:
           install-script: 'true'
           rust-cache: 'true'
           rust-cache-key: ${{ inputs.platform }}-${{ inputs.architecture }}-${{ inputs.san }}-${{ inputs.coverage && 'cov' || '' }}
+          rust-cache-read-only: ${{ inputs.rust-cache-read-only }}
           rust-test-deps: 'true'
           github-token: ${{ github.token }}
           python-test-deps: 'true'


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: #10890 makes the Rust cache restore-only off the default branch, but two writers escape that gate and can each still consume the whole 10 GB repository budget. `task-lint` calls `Swatinem/rust-cache` directly instead of through `setup-build-env`, so it keeps saving ~800 MB on every PR push and every merge-queue entry — the largest single writer in the repo. And the nightly flow runs *on* the default branch across every platform, so the gate happily lets it save ~20 target dirs in one go.
2. Change: `task-lint` gets the same default-branch gate. `flow-test` and `task-test` gain a `rust-cache-read-only` input, which the nightly flow sets, so its all-platform sweep restores caches but never writes them.
3. Outcome: internal-only, nothing user-visible. It leaves the periodic master validation as the effective writer — ~9 caches, roughly 5 GB against the 10 GB cap — so the platforms on the merge-queue critical path keep a cache that survives long enough to be restored, which is what makes #10890's `save-if` worth anything. Without this, one nightly run could evict it.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `task-lint.yml` — its direct `rust-cache` call gains `save-if`, with the nightly lint job (which runs on the default branch) left as the seeder so the cache is still written daily.
2. `setup-build-env` — new `rust-cache-read-only` input, ANDed with the existing default-branch gate.
3. `flow-test.yml` / `task-test.yml` — plumb that input through; it defaults to false, so the merge-queue and master-validation callers are unaffected.
4. `event-nightly.yml` — sets it, because nightly latency does not matter and the caches it would evict do.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
