### PR TITLE
Expose `TermsTrie` and `SuffixTrie` on `IndexSpec`

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1083,6 +1083,7 @@ dependencies = [
 name = "index_spec"
 version = "0.0.1"
 dependencies = [
+ "c_trie",
  "dict",
  "document",
  "ffi",

--- a/src/redisearch_rs/c_wrappers/index_spec/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/index_spec/Cargo.toml
@@ -9,6 +9,7 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+c_trie.workspace = true
 dict.workspace = true
 ffi.workspace = true
 field_spec.workspace = true

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -364,7 +364,7 @@ impl<'lock> IndexSpecReadGuard<'lock> {
         unsafe { Dict::from_raw(self.0.missingFieldDict) }
     }
 
-    /// Returns the trie of all TEXT terms.
+    /// Returns the terms trie.
     pub fn terms(&self) -> &TermsTrie {
         debug_assert!(!self.0.terms.is_null(), "terms trie must not be null");
         // SAFETY: `terms` is a valid, non-null `Trie` for a properly initialised IndexSpec,

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -18,6 +18,7 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
+use c_trie::{SuffixTrie, TermsTrie};
 use dict::{Dict, MissingFieldDictType};
 use field_spec::FieldSpec;
 use inverted_index::opaque::InvertedIndex;
@@ -214,6 +215,31 @@ impl<'lock> IndexSpecWriteGuard<'lock> {
         unsafe { slice::from_raw_parts_mut(self.0.fields.cast::<FieldSpec>(), len) }
     }
 
+    /// Returns the terms trie.
+    pub fn terms_mut(&mut self) -> &mut TermsTrie {
+        debug_assert!(!self.0.terms.is_null(), "terms trie must not be null");
+        // SAFETY: `terms` is a valid, non-null `Trie` for a properly initialised IndexSpec,
+        // and it lives as long as the spec, which outlives this guard's borrow. We hold the
+        // write lock, which every other reader and writer of the trie — Rust or C — must
+        // acquire, so the exclusive borrow is not aliased.
+        unsafe { TermsTrie::from_raw_mut(self.0.terms) }
+    }
+
+    /// Returns the suffix trie.
+    ///
+    /// `None` when no field in the schema was declared `WITHSUFFIXTRIE`: the trie is
+    /// only allocated once some field opts in.
+    pub const fn suffix_mut(&mut self) -> Option<&mut SuffixTrie> {
+        if self.0.suffix.is_null() {
+            return None;
+        }
+        // SAFETY: `suffix` is non-null (checked above) and, once allocated, stays valid
+        // for the life of the spec, which outlives this guard's borrow. We hold the write
+        // lock, which every other reader and writer of the trie must acquire, so the
+        // exclusive borrow is not aliased.
+        Some(unsafe { SuffixTrie::from_raw_mut(self.0.suffix) })
+    }
+
     /// Return the spec's `missingFieldDict` as a typed [`Dict`].
     pub fn missing_field_dict_mut(&mut self) -> &mut Dict<MissingFieldDictType> {
         debug_assert!(
@@ -336,6 +362,16 @@ impl<'lock> IndexSpecReadGuard<'lock> {
         // dictTypeHeapHiddenStrings (MissingFieldDictType::as_ptr()), so
         // interpreting it as Dict<MissingFieldDictType> is sound.
         unsafe { Dict::from_raw(self.0.missingFieldDict) }
+    }
+
+    /// Returns the trie of all TEXT terms.
+    pub fn terms(&self) -> &TermsTrie {
+        debug_assert!(!self.0.terms.is_null(), "terms trie must not be null");
+        // SAFETY: `terms` is a valid, non-null `Trie` for a properly initialised IndexSpec,
+        // and it lives as long as the spec, which outlives this guard's borrow. The guard
+        // holds the spec's read lock, which every writer of the terms trie must not hold
+        // concurrently, so the trie is not mutated for that borrow either.
+        unsafe { TermsTrie::from_raw(self.0.terms) }
     }
 
     /// Returns whether the keys dictionary is available.


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `IndexSpec`'s `terms` and `suffix` tries are only reachable as raw
   `*mut ffi::Trie` fields. Rust callers that need them — the terms scanner being
   ported next — would each have to hand-roll the null check, the pointer cast, and
   the safety argument that the spec lock is what makes the borrow sound.
2. **Change:** Adds accessors on the spec lock guards: `terms()` on
   `IndexSpecReadGuard`, and `terms_mut()` / `suffix_mut()` on
   `IndexSpecWriteGuard`. They hand back the typed `TermsTrie` / `SuffixTrie`
   wrappers introduced in #10886. The suffix accessor returns `Option`, since the
   suffix trie is only allocated once some field is declared `WITHSUFFIXTRIE`.
3. **Outcome:** Internal-only. Trie access is now tied to the lock guard by the type
   system — shared access through the read guard, exclusive through the write one —
   so the aliasing argument lives in one place instead of at every call site. This
   unblocks porting the terms scanner without new `unsafe` in the caller.

#### Which additional issues this PR fixes

1. N/A
2. N/A

#### Main objects this PR modified

1. `IndexSpecReadGuard` — new `terms()` returning `&TermsTrie`.
2. `IndexSpecWriteGuard` — new `terms_mut()` returning `&mut TermsTrie`, and
   `suffix_mut()` returning `Option<&mut SuffixTrie>`.
3. `index_spec` crate manifest — now depends on `c_trie` for the two trie wrappers.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes