### PR TITLE
tests: stop crash-log assertions failing on non-UTF-8 log bytes

### DIFF
--- a/tests/pytests/test_crash.py
+++ b/tests/pytests/test_crash.py
@@ -45,7 +45,9 @@ def extract_query_crash_output(env, expected_fragments, doc_count=10, crash_in_r
     results = {fragment: None for fragment in expected_fragments}
     pos = 0  # Track position in expected_fragments to enforce ordering
 
-    with open(logFilePath) as logFile:
+    # A crash report can carry raw memory bytes, so the log is not necessarily
+    # valid UTF-8. The fragments below are ASCII, so decode lossily.
+    with open(logFilePath, encoding="utf-8", errors="replace") as logFile:
         for line in logFile:
             # Only look for the next expected fragment (enforces ordering)
             if pos < len(expected_fragments):

--- a/tests/pytests/test_tracing.py
+++ b/tests/pytests/test_tracing.py
@@ -11,7 +11,7 @@ def _log_has_init_message(env):
     logFileName = env.cmd("CONFIG", "GET", "logfile")[1]
     logFilePath = os.path.join(logDir, logFileName)
     try:
-        with open(logFilePath) as f:
+        with open(logFilePath, encoding="utf-8", errors="replace") as f:
             return any(INIT_MESSAGE in line for line in f)
     except FileNotFoundError:
         return False


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `test_crash.py` and `test_tracing.py` read the server log file with
   `open(path)` — the default strict UTF-8 decode. A crash report, and any log line
   interleaved with it while the crash handler runs, can contain raw memory bytes, so
   the log is not guaranteed to be valid UTF-8. A single invalid byte anywhere in the
   file aborts the read, and the test errors out before it can assert anything:

   ```
   UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb8 in position 3286: invalid start byte
     test_crash.py, line 81, in test_query_thread_crash
     test_crash.py, line 49, in extract_query_crash_output  ->  for line in logFile:
   ```

   This was hit in CI by `test_crash:test_query_thread_crash`, where a background thread
   logged the raw bytes of a pointer while the crash handler was running its memory test:

   ```
   *** Preparing to test memory region ffe4933ac000 (8192 bytes)
   .O.O.O.O.O.O.O.O.O.# Compress error -2: \xb8\x9b6\x92\xe4\xff
   ```

   The failure has nothing to do with the fragments the test is looking for — those were
   all present and correct in that same log.

2. **Change:** read the log with `encoding="utf-8", errors="replace"` at both call sites.
   Both only match ASCII fragments, so a lossy decode cannot change what they find.
   Pinning the encoding also stops the decode depending on the runner's locale.

3. **Outcome:** the crash tests assert on the crash report's contents instead of failing
   on unrelated bytes elsewhere in the log. Replaying `extract_query_crash_output`'s
   parser over the log that failed in CI now finds all eight expected fragments in order
   and satisfies every assertion in `test_query_thread_crash`
   (`search_number_of_docs: 10`, `max_doc_id=10`, `num_terms=2`, `inverted_size > 0`).

#### Which additional issues this PR fixes

1. None.

#### Main objects this PR modified

1. `tests/pytests/test_crash.py` — `extract_query_crash_output()`
2. `tests/pytests/test_tracing.py` — `_log_has_init_message()`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
