### PR TITLE
CI: surface Rust module panic payloads in nightly failure triage

### DIFF
--- a/.github/actions/ci-failure-context/action.yml
+++ b/.github/actions/ci-failure-context/action.yml
@@ -26,9 +26,12 @@ inputs:
       traceback or an RLTest `[FAIL]` summary far above the tail) survives
       truncation. The default targets common RediSearch CI failure signatures;
       pass an empty string to disable. Note that Rust panics need both
-      `panicked at` (std's default hook, used by test binaries) and
-      `A panic occurred in the Rust code` (the module's replacement hook
-      installed by `RustPanicHook_Init`, which is what a loaded module emits).
+      spellings. `RustPanicHook_Init` chains a `tracing` hook ahead of std's,
+      so a panic inside a loaded module emits both — but only the `tracing`
+      one, `A panic occurred in the Rust code`, routes through
+      `RedisModule_Log` into the redis logfile these patterns are applied to.
+      std's `panicked at` goes to stderr, which RLTest pipes and never reads,
+      and so only ever shows up for test binaries that log to the console.
     required: false
     default: |
       Traceback \(most recent call last\):
@@ -214,7 +217,10 @@ runs:
           # prefix, GH-Actions/Python-logger/redis-server timestamps and hex
           # addresses, so a message repeated on many lines collapses to one entry
           # even when each repetition carries a different pid, clock reading or
-          # pointer value; head: bound total volume.
+          # pointer value; head: bound total volume. The redis-server prefix is
+          # matched unanchored because the console copy of a line carries an
+          # ANSI colour escape ahead of it, and spelled out to the month name so
+          # an unanchored match cannot land mid-message.
           grep -nE -f "$PAT_FILE" failed-logs.txt 2>/dev/null \
             | cut -c1-500 \
             | awk '{
@@ -222,7 +228,7 @@ runs:
                 sub(/^[0-9]+:/, "", key)
                 gsub(/[0-9]+-[0-9]+-[0-9]+T[0-9:.]+Z/, "", key)
                 gsub(/[0-9]+-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+,[0-9]+/, "", key)
-                gsub(/[0-9]+:[A-Za-z] [0-9]+ [A-Za-z]+ [0-9]+ [0-9:.]+/, "", key)
+                gsub(/[0-9]+:[A-Za-z] [0-9]+ (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]+ [0-9]+:[0-9]+:[0-9]+\.[0-9]+/, "", key)
                 gsub(/0x[0-9a-fA-F]+/, "", key)
                 if (!seen[key]++) print
               }' \

--- a/.github/actions/ci-failure-context/action.yml
+++ b/.github/actions/ci-failure-context/action.yml
@@ -25,7 +25,10 @@ inputs:
       a `KEY FAILURE LINES` banner, so a root cause buried mid-log (e.g. a Python
       traceback or an RLTest `[FAIL]` summary far above the tail) survives
       truncation. The default targets common RediSearch CI failure signatures;
-      pass an empty string to disable.
+      pass an empty string to disable. Note that Rust panics need both
+      `panicked at` (std's default hook, used by test binaries) and
+      `A panic occurred in the Rust code` (the module's replacement hook
+      installed by `RustPanicHook_Init`, which is what a loaded module emits).
     required: false
     default: |
       Traceback \(most recent call last\):
@@ -40,6 +43,8 @@ inputs:
       Segmentation fault
       SUMMARY: .*Sanitizer
       panicked at
+      A panic occurred in the Rust code
+      crashed by signal:
       RDB CHECKSUM ERROR
   max-key-lines:
     description: >
@@ -206,8 +211,10 @@ runs:
           KEY_FILE="$(mktemp)"
           # -n: keep line numbers for locatability; cut: bound pathological long
           # lines; awk: dedupe preserving order after stripping the line-number
-          # prefix and GH-Actions/Python-logger timestamps, so a message repeated
-          # on many lines collapses to one entry; head: bound total volume.
+          # prefix, GH-Actions/Python-logger/redis-server timestamps and hex
+          # addresses, so a message repeated on many lines collapses to one entry
+          # even when each repetition carries a different pid, clock reading or
+          # pointer value; head: bound total volume.
           grep -nE -f "$PAT_FILE" failed-logs.txt 2>/dev/null \
             | cut -c1-500 \
             | awk '{
@@ -215,6 +222,8 @@ runs:
                 sub(/^[0-9]+:/, "", key)
                 gsub(/[0-9]+-[0-9]+-[0-9]+T[0-9:.]+Z/, "", key)
                 gsub(/[0-9]+-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+,[0-9]+/, "", key)
+                gsub(/[0-9]+:[A-Za-z] [0-9]+ [A-Za-z]+ [0-9]+ [0-9:.]+/, "", key)
+                gsub(/0x[0-9a-fA-F]+/, "", key)
                 if (!seen[key]++) print
               }' \
             | head -n "$MAX_KEY_LINES" > "$KEY_FILE"


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: before capping `failed-logs.txt` to 200KB, `ci-failure-context` greps the whole log for "key failure lines" and pins them at the top so they survive truncation. That grep list looks for `panicked at`, which a module panic never puts in the collected log — `RustPanicHook_Init` chains a `tracing` hook ahead of std's, and only the `tracing` one (`A panic occurred in the Rust code panic.payload=… panic.location=…`) routes through `RedisModule_Log` into the redis logfile; std's copy goes to a stderr pipe RLTest never reads. So the one line naming the failing Rust file and line was dropped, while ~90 unsymbolized backtrace frames survived the cap. Separately, the dedupe strips ISO and Python-logger timestamps but not redis-server's `<pid>:M <date>` prefix or hex addresses, so the same crash repeated across N tests consumed N of the 150 available slots.
2. Change: add the `tracing` hook's wording and `crashed by signal:` to the pattern list, and normalize the redis-server log prefix and hex addresses before deduplicating.
3. Outcome: internal-only — no module behavior changes. Nightly and periodic-master-validation triage (Codex → Slack) now receives the panic payload and source location instead of backtrace noise. Against the artifacts of [run 31388520069](https://github.com/RediSearch/RediSearch/actions/runs/31388520069), the same 9 crashes reduce from 18 key lines to 2, one of which names `c_entrypoint/triemap_ffi/src/iter_types.rs:39`.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `ci-failure-context` action — `highlight-patterns` default gains the module's `tracing` panic wording and `crashed by signal:`.
2. Same action's dedupe pass — normalizes redis-server `<pid>:M <date>` prefixes and `0x…` addresses so repeats of one crash collapse to a single key line.

Consumers are `event-nightly.yml` and `event-periodic-master-validation.yml`. Note this does not reach the `flow-test.yml` → `task-test.yml` lane, which never invokes this action; making a crash visible in the job log itself is separate work.

The redis-prefix pattern is deliberately unanchored, because the console copy of a redis line carries an ANSI colour escape ahead of the prefix. It spells the month out so that an unanchored match cannot land mid-message.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
