### PR TITLE
Add characterization tests for `StopWordList` fold, order and RDB round trip

### DIFF
--- a/tests/cpptests/test_cpp_rdb.cpp
+++ b/tests/cpptests/test_cpp_rdb.cpp
@@ -552,6 +552,77 @@ TEST_F(RdbMockTest, testSynonymMapRdbLoadValidGroupIds) {
     EXPECT_EQ(2, array_len(td->groupIds));
 }
 
+TEST_F(RdbMockTest, testStopWordListRdbRoundTrip) {
+    // A stopword list is written as a count followed by the already-folded
+    // keys, and read back without folding again — so a round trip is only an
+    // identity if the saved order and the exact key bytes both survive.
+    // Insertion order here is deliberately unsorted and mixed-script.
+    const char *terms[] = {"zebra", "apple", "שלום", "Mango"};
+    const size_t nterms = sizeof(terms) / sizeof(const char *);
+    StopWordList *sl = NewStopWordListCStr(terms, nterms);
+    ASSERT_TRUE(sl != nullptr);
+    std::unique_ptr<StopWordList, std::function<void(StopWordList *)>> slPtr(sl, [](StopWordList *sl) {
+        StopWordList_Unref(sl);
+    });
+
+    RedisModuleIO *io = RMCK_CreateRdbIO();
+    ASSERT_TRUE(io != nullptr);
+    std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+        RMCK_FreeRdbIO(io);
+    });
+
+    StopWordList_RdbSave(io, sl);
+    EXPECT_EQ(0, RMCK_IsIOError(io));
+
+    io->read_pos = 0;
+    StopWordList *loaded = StopWordList_RdbLoad(io, INDEX_CURRENT_VERSION);
+    ASSERT_TRUE(loaded != nullptr);
+    std::unique_ptr<StopWordList, std::function<void(StopWordList *)>> loadedPtr(loaded, [](StopWordList *sl) {
+        StopWordList_Unref(sl);
+    });
+    EXPECT_EQ(0, RMCK_IsIOError(io));
+
+    // Membership survives, including the folded form of the mixed-case term.
+    EXPECT_TRUE(StopWordList_Contains(loaded, "zebra", 5));
+    EXPECT_TRUE(StopWordList_Contains(loaded, "apple", 5));
+    EXPECT_TRUE(StopWordList_Contains(loaded, "mango", 5));
+    EXPECT_TRUE(StopWordList_Contains(loaded, "שלום", strlen("שלום")));
+    EXPECT_FALSE(StopWordList_Contains(loaded, "pear", 4));
+
+    // The INFO render is the observable projection of both the key bytes and
+    // their order, so comparing it either way pins the round trip whole.
+    RedisModuleInfoCtx before, after;
+    AddStopWordsListToInfo(&before, sl);
+    AddStopWordsListToInfo(&after, loaded);
+    ASSERT_EQ(before.fields.size(), 1);
+    ASSERT_EQ(after.fields.size(), 1);
+    EXPECT_EQ(before.fields[0].second, after.fields[0].second);
+}
+
+TEST_F(RdbMockTest, testStopWordListRdbLoadTruncated) {
+    // The count promises two keys but only one follows, so the read fails after
+    // the list already holds an entry. Unlike
+    // testStopWordListRdbLoadExceedsLimit, which bails before allocating
+    // anything, this reaches the cleanup path with a partially built list to
+    // free — the leak is only visible under a sanitizer, so the assertion here
+    // is just that load reports failure.
+    RedisModuleIO *io = RMCK_CreateRdbIO();
+    ASSERT_TRUE(io != nullptr);
+    std::unique_ptr<RedisModuleIO, std::function<void(RedisModuleIO *)>> ioPtr(io, [](RedisModuleIO *io) {
+        RMCK_FreeRdbIO(io);
+    });
+
+    RMCK_SaveUnsigned(io, 2);
+    const char *term = "foo";
+    RMCK_SaveStringBuffer(io, term, strlen(term));
+
+    io->read_pos = 0;
+
+    StopWordList *loaded = StopWordList_RdbLoad(io, INDEX_CURRENT_VERSION);
+    EXPECT_TRUE(loaded == nullptr) << "Expected RDB load to fail when the payload is short";
+    EXPECT_EQ(1, RMCK_IsIOError(io));
+}
+
 TEST_F(RdbMockTest, testTrieRdbLoadMoreThan65535Elements) {
     // Test that a trie with more than 65535 (UINT16_MAX) elements can be
     // saved and loaded correctly from RDB.

--- a/tests/cpptests/test_cpp_stopwords.cpp
+++ b/tests/cpptests/test_cpp_stopwords.cpp
@@ -68,6 +68,27 @@ TEST_F(StopwordsInfoTest, testInfoTerm) {
   StopWordList_Unref(sl);
 }
 
+TEST_F(StopwordsInfoTest, testInfoUnsortedInsert) {
+  // The rendered list is in lexicographic order, not insertion order — the
+  // underlying container is ordered, and clients read this field as a stable
+  // list. Every other stopword test happens to insert in an order that hides
+  // the difference.
+  const char *terms[] = {"zebra", "apple", "mango"};
+  StopWordList *sl = NewStopWordListCStr(terms, 3);
+  ASSERT_TRUE(sl != nullptr);
+
+  dirtyRenderBufferBlocks();
+
+  RedisModuleInfoCtx info;
+  AddStopWordsListToInfo(&info, sl);
+
+  ASSERT_EQ(info.fields.size(), 1);
+  ASSERT_EQ(info.fields[0].first, "stop_words");
+  ASSERT_EQ(info.fields[0].second, "\"apple\",\"mango\",\"zebra\"");
+
+  StopWordList_Unref(sl);
+}
+
 TEST_F(StopwordsInfoTest, testInfoNullList) {
   RedisModuleInfoCtx info;
   AddStopWordsListToInfo(&info, NULL);

--- a/tests/ctests/test_stopwords.c
+++ b/tests/ctests/test_stopwords.c
@@ -89,11 +89,68 @@ int testStopwordListACEmpty() {
   return 0;
 }
 
+int testStopwordListEmbeddedNul() {
+
+  // Case folding stops at an embedded NUL and shortens the length, so the key
+  // actually stored is only the prefix before it. Reaching that state needs a
+  // cursor type that carries an explicit length: AC_TYPE_CHAR derives the
+  // length with strlen, while AC_TYPE_SDS (here) and AC_TYPE_RSTRING (the
+  // FT.CREATE path in production) both pass the length through untouched.
+  sds terms[] = {sdsnewlen("foo\0bar", 7)};
+
+  ArgsCursor ac;
+  ArgsCursor_InitSDS(&ac, terms, 1);
+
+  StopWordList *sl = NewStopWordListAC(&ac);
+  ASSERT(sl != NULL);
+
+  // Add and lookup fold through the same code, so both truncate identically:
+  // the full term matches, and so does the bare prefix.
+  ASSERT(StopWordList_Contains(sl, "foo\0bar", 7));
+  ASSERT(StopWordList_Contains(sl, "foo", 3));
+  // Truncation is lossy — anything sharing the prefix collides.
+  ASSERT(StopWordList_Contains(sl, "foo\0baz", 7));
+  ASSERT(!StopWordList_Contains(sl, "fo", 2));
+  ASSERT(!StopWordList_Contains(sl, "bar", 3));
+
+  StopWordList_Free(sl);
+  sdsfree(terms[0]);
+  return 0;
+}
+
+int testStopwordListInvalidUtf8() {
+
+  // The folding decoder never validates its input: a lead byte consumes its
+  // continuation bytes whatever they hold, mapping invalid sequences onto some
+  // arbitrary key instead of rejecting them. What that key is does not matter
+  // here; what matters is that add and lookup mangle a term the same way, so a
+  // stopword given as invalid UTF-8 still suppresses the identical bytes at
+  // query time.
+  // Each sequence ends in a non-hex-digit character so the preceding \x escape
+  // cannot swallow it.
+  const char *terms[] = {"\xC3\x28z", "\xE0\x80q"};
+  const size_t nterms = sizeof(terms) / sizeof(const char *);
+
+  StopWordList *sl = NewStopWordListCStr(terms, nterms);
+  ASSERT(sl != NULL);
+
+  for (size_t i = 0; i < nterms; i++) {
+    ASSERT(StopWordList_Contains(sl, terms[i], strlen(terms[i])));
+  }
+
+  ASSERT(!StopWordList_Contains(sl, "\xC3\x28y", 3));
+
+  StopWordList_Free(sl);
+  return 0;
+}
+
 TEST_MAIN({
   RMUTil_InitAlloc();
   TESTFUNC(testStopwordList);
   TESTFUNC(testStopwordListAC);
   TESTFUNC(testStopwordListACEmpty);
+  TESTFUNC(testStopwordListEmbeddedNul);
+  TESTFUNC(testStopwordListInvalidUtf8);
   TESTFUNC(testDefaultStopwords);
   StopWordList_FreeGlobals();
 });

--- a/tests/ctests/test_stopwords.c
+++ b/tests/ctests/test_stopwords.c
@@ -110,7 +110,7 @@ int testStopwordListEmbeddedNul() {
   ASSERT(StopWordList_Contains(sl, "foo", 3));
   // Truncation is lossy — anything sharing the prefix collides.
   ASSERT(StopWordList_Contains(sl, "foo\0baz", 7));
-  ASSERT(!StopWordList_Contains(sl, "fo", 2));
+  ASSERT(!StopWordList_Contains(sl, "f", 1));
   ASSERT(!StopWordList_Contains(sl, "bar", 3));
 
   StopWordList_Free(sl);


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: several `StopWordList` behaviours that callers rely on have no test pinning them. Case folding truncates a term at an embedded NUL and mangles invalid UTF-8 instead of rejecting it; the `stop_words` `INFO` field renders in lexicographic rather than insertion order; and an RDB save/load pair is assumed to be an identity on both the stored key bytes and their order. Each of these could change silently today without a test failing.
2. Change: five tests, no production code. Two cover the folding behaviour, one the `INFO` ordering, and two the RDB paths — a full round trip plus a truncated payload.
3. Outcome: internal-only, no user-visible change. It makes the current behaviour a fixed point, so a later change to folding, to the ordered container behind the list, or to the RDB encoding has to either preserve it or declare itself a behaviour change.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `StopWordList` case folding — add path and lookup path asserted to transform a term identically, rather than against a predicted output.
2. `AddStopWordsListToInfo` — first test to insert terms out of order, so the rendered order is now constrained.
3. `StopWordList_RdbSave` / `StopWordList_RdbLoad` — round trip pinned on key bytes and order; a truncated payload covers the load failure that happens after the list already holds an entry.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
