### PR TITLE
[MOD-17924] Resolve required-field reply keys once per request

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -199,6 +199,12 @@ typedef struct AREQ {
 
   const char** requiredFields;
 
+  // Reply-time cache of `requiredFields` resolved against the plan's last
+  // lookup, so serialization does not repeat the by-name lookup for every row.
+  // Entries point into the plan's lookup and stay valid for the request's
+  // lifetime; the array itself is owned by the request.
+  const RLookupKey** requiredFieldsKeys;
+
   struct QOptimizer *optimizer;        // Hold parameters for query optimizer
 
   // Currently we need both because maxSearchResults limits the OFFSET also in

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -64,6 +64,15 @@ typedef struct {
   uint32_t chunkSize;   // Number of results per cursor read (from COUNT parameter)
 } CursorConfig;
 
+// A field the coordinator requires in each reply row (`_REQUIRED_FIELDS`), paired with its
+// reply-time key. `name` is borrowed from the request arguments; `key` points into the plan's
+// last lookup and is resolved lazily during serialization — NULL until the name resolves, and
+// retried while NULL because loading documents may create the key on a later row.
+typedef struct {
+  const char *name;
+  const RLookupKey *key;
+} RequiredField;
+
 // Context structure for parseAggPlan to reduce parameter count
 typedef struct {
   AGGPlan *plan;                    // Aggregation plan
@@ -72,7 +81,7 @@ typedef struct {
   RSSearchOptions *searchopts;      // Search options
   size_t *prefixesOffset;           // Prefixes offset
   CursorConfig *cursorConfig;       // Cursor configuration
-  const char ***requiredFields;     // Required fields
+  RequiredField **requiredFields;   // Required fields
   size_t *maxSearchResults;         // Maximum search results
   size_t *maxAggregateResults;      // Maximum aggregate results
   const RedisModuleSlotRangeArray **querySlots; // Slots requested (referenced from AREQ)
@@ -197,13 +206,7 @@ typedef struct AREQ {
   /** Profile variables */
   ProfileClocks profileClocks;
 
-  const char** requiredFields;
-
-  // Reply-time cache of `requiredFields` resolved against the plan's last
-  // lookup, so serialization does not repeat the by-name lookup for every row.
-  // Entries point into the plan's lookup and stay valid for the request's
-  // lifetime; the array itself is owned by the request.
-  const RLookupKey** requiredFieldsKeys;
+  RequiredField* requiredFields;
 
   struct QOptimizer *optimizer;        // Hold parameters for query optimizer
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -225,22 +225,19 @@ static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchR
     // Sortkey is the first key to reply on the required fields, if we already replied it, continue to the next one.
     size_t currentField = options & QEXEC_F_SEND_SORTKEYS ? 1 : 0;
     size_t requiredFieldsCount = array_len(req->requiredFields);
-    if (!req->requiredFieldsKeys) {
-      req->requiredFieldsKeys = rm_calloc(requiredFieldsCount, sizeof(*req->requiredFieldsKeys));
-    }
     RSValue *rsv = NULL;
     bool need_map = has_map && currentField < requiredFieldsCount;
     if (need_map) {
       RedisModule_ReplyKV_Map(reply, "required_fields"); // >required_fields
     }
     for(; currentField < requiredFieldsCount; currentField++) {
-      const RLookupKey *rlk = req->requiredFieldsKeys[currentField];
-      if (!rlk) {
+      RequiredField *field = &req->requiredFields[currentField];
+      if (!field->key) {
         // A name can be unresolvable for early rows and resolve later (loading
         // documents may create keys), so NULL entries are retried per row.
-        rlk = RLookup_GetKey_Read(cv->lastLookup, req->requiredFields[currentField], RLOOKUP_F_NOFLAGS);
-        req->requiredFieldsKeys[currentField] = rlk;
+        field->key = RLookup_GetKey_Read(cv->lastLookup, field->name, RLOOKUP_F_NOFLAGS);
       }
+      const RLookupKey *rlk = field->key;
       const RSValue *v = rlk ? getReplyKey(rlk, r) : NULL;
       if (RSValue_IsTrio(v)) {
         // For duo value, we use the left value here (not the right value)
@@ -257,7 +254,7 @@ static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchR
         v = rsv;
       }
       if (need_map) {
-        RedisModule_Reply_CString(reply, req->requiredFields[currentField]); // key name
+        RedisModule_Reply_CString(reply, field->name); // key name
       }
       reeval_key(reply, v);
     }

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -225,13 +225,22 @@ static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchR
     // Sortkey is the first key to reply on the required fields, if we already replied it, continue to the next one.
     size_t currentField = options & QEXEC_F_SEND_SORTKEYS ? 1 : 0;
     size_t requiredFieldsCount = array_len(req->requiredFields);
+    if (!req->requiredFieldsKeys) {
+      req->requiredFieldsKeys = rm_calloc(requiredFieldsCount, sizeof(*req->requiredFieldsKeys));
+    }
     RSValue *rsv = NULL;
     bool need_map = has_map && currentField < requiredFieldsCount;
     if (need_map) {
       RedisModule_ReplyKV_Map(reply, "required_fields"); // >required_fields
     }
     for(; currentField < requiredFieldsCount; currentField++) {
-      const RLookupKey *rlk = RLookup_GetKey_Read(cv->lastLookup, req->requiredFields[currentField], RLOOKUP_F_NOFLAGS);
+      const RLookupKey *rlk = req->requiredFieldsKeys[currentField];
+      if (!rlk) {
+        // A name can be unresolvable for early rows and resolve later (loading
+        // documents may create keys), so NULL entries are retried per row.
+        rlk = RLookup_GetKey_Read(cv->lastLookup, req->requiredFields[currentField], RLOOKUP_F_NOFLAGS);
+        req->requiredFieldsKeys[currentField] = rlk;
+      }
       const RSValue *v = rlk ? getReplyKey(rlk, r) : NULL;
       if (RSValue_IsTrio(v)) {
         // For duo value, we use the left value here (not the right value)

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -195,7 +195,7 @@ static int parseCursorSettings(uint32_t *reqflags, CursorConfig *cursorConfig, A
   return REDISMODULE_OK;
 }
 
-static int parseRequiredFields(const char ***requiredFields, ArgsCursor *ac, QueryError *status){
+static int parseRequiredFields(RequiredField **requiredFields, ArgsCursor *ac, QueryError *status){
 
   ArgsCursor args = {0};
   int rv = AC_GetVarArgs(ac, &args);
@@ -204,17 +204,16 @@ static int parseRequiredFields(const char ***requiredFields, ArgsCursor *ac, Que
     return REDISMODULE_ERR;
   }
   int requiredFieldNum = AC_NumArgs(&args);
-  // This array contains shallow copy of the required fields names. Those copies are to use only for lookup.
-  // If we need to use them in reply we should make a copy of those strings.
-  const char** reqFields = array_new(const char*, requiredFieldNum);
+  // The names are shallow copies, to use only for lookup. If we need to use them in reply we
+  // should make a copy of those strings. Keys are resolved lazily at serialization time.
+  RequiredField* reqFields = array_new(RequiredField, requiredFieldNum);
   for(size_t i=0; i < requiredFieldNum; i++) {
-    const char *s = AC_GetStringNC(&args, NULL); {
-      if(!s) {
-        array_free(reqFields);
-        return REDISMODULE_ERR;
-      }
+    const char *s = AC_GetStringNC(&args, NULL);
+    if(!s) {
+      array_free(reqFields);
+      return REDISMODULE_ERR;
     }
-    array_append(reqFields, s);
+    array_append(reqFields, ((RequiredField){.name = s, .key = NULL}));
   }
 
   *requiredFields = reqFields;
@@ -1900,9 +1899,6 @@ void AREQ_Free(AREQ *req) {
   FieldList_Free(&req->outFields);
   if(req->requiredFields) {
     array_free(req->requiredFields);
-  }
-  if (req->requiredFieldsKeys) {
-    rm_free(req->requiredFieldsKeys);
   }
   // Free parsed vector data
   if (req->parsedVectorData) {

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1901,6 +1901,9 @@ void AREQ_Free(AREQ *req) {
   if(req->requiredFields) {
     array_free(req->requiredFields);
   }
+  if (req->requiredFieldsKeys) {
+    rm_free(req->requiredFieldsKeys);
+  }
   // Free parsed vector data
   if (req->parsedVectorData) {
     ParsedVectorData_Free(req->parsedVectorData);

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -224,17 +224,12 @@ impl<'a> RLookup<'a> {
 
         let name = name.into();
 
-        // Return the existing key if there is one. The reference is routed
-        // through a raw pointer because the borrow checker rejects returning
-        // it directly out of the `if let` while later arms mutate `self`
-        // (NLL problem case #3, rust-lang/rust#54663); the round-trip keeps
-        // this a single scan of the key list.
-        if let Some(found) = self.keys.find_by_name(&name).and_then(Cursor::into_current) {
-            let found = NonNull::from(found);
-            // SAFETY: `found` points into `self.keys`, whose keys are pinned
-            // and outlive `self`'s borrow, and nothing touches the list
-            // between the lookup above and this reborrow.
-            return Some(unsafe { found.as_ref() });
+        let available = self.keys.find_by_name(&name).is_some();
+        if available {
+            // FIXME: We cannot use let-some above because of a borrow-checker false positive.
+            // This duplication might have performance implications.
+            // See <https://github.com/rust-lang/rust/issues/54663>
+            return self.keys.find_by_name(&name).unwrap().into_current();
         }
 
         // If we didn't find the key at the lookup table, check if it exists in

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -224,12 +224,17 @@ impl<'a> RLookup<'a> {
 
         let name = name.into();
 
-        let available = self.keys.find_by_name(&name).is_some();
-        if available {
-            // FIXME: We cannot use let-some above because of a borrow-checker false positive.
-            // This duplication might have performance implications.
-            // See <https://github.com/rust-lang/rust/issues/54663>
-            return self.keys.find_by_name(&name).unwrap().into_current();
+        // Return the existing key if there is one. The reference is routed
+        // through a raw pointer because the borrow checker rejects returning
+        // it directly out of the `if let` while later arms mutate `self`
+        // (NLL problem case #3, rust-lang/rust#54663); the round-trip keeps
+        // this a single scan of the key list.
+        if let Some(found) = self.keys.find_by_name(&name).and_then(Cursor::into_current) {
+            let found = NonNull::from(found);
+            // SAFETY: `found` points into `self.keys`, whose keys are pinned
+            // and outlive `self`'s borrow, and nothing touches the list
+            // between the lookup above and this reborrow.
+            return Some(unsafe { found.as_ref() });
         }
 
         // If we didn't find the key at the lookup table, check if it exists in

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -95,6 +95,36 @@ def test_required_fields(env):
     # Field is not in Rlookup, will not load
     env.expect('ft.search', 'idx', 'hello', 'nocontent', '_REQUIRED_FIELDS', '1', 't').equal([1, '0', None])
 
+@skip(cluster=True)
+def test_required_fields_key_cache(env):
+    """The shard-side `_REQUIRED_FIELDS` key cache: a key resolved on one row is reused on
+    later rows (cache hit), a name unresolvable on early rows resolves once a later
+    document's load creates its key (the NULL retry), and a NULL entry left by one cursor
+    chunk is still retried on later `FT.CURSOR READ` chunks."""
+    env.expect('ft.create', 'idx', 'schema', 't', 'text').ok()
+    # doc1 lacks `dyn`; doc2 carries it. Without sorting, reply order is docId
+    # (insertion) order, so doc1 serializes first.
+    env.cmd('HSET', 'doc1', 't', 'hello')
+    env.cmd('HSET', 'doc2', 't', 'hello', 'dyn', 'world')
+
+    # Content loading creates each document's keys just before its row is serialized:
+    # `t` resolves on row 1 and must be served from the cache on row 2, while `dyn` is
+    # unresolvable on row 1 (doc1's load did not create it) and must resolve on row 2.
+    env.expect('ft.search', 'idx', 'hello', '_REQUIRED_FIELDS', '2', 't', 'dyn').equal(
+        [2, 'doc1', '$hello', None, ['t', 'hello'],
+            'doc2', '$hello', '$world', ['t', 'hello', 'dyn', 'world']])
+
+    # Same late resolution across cursor chunks: chunk 1 serializes only doc1, leaving
+    # `dyn` unresolved in the cached request; the next chunk's `LOAD *` row creates the
+    # key, and the retained NULL entry must be retried rather than frozen.
+    res, cursor = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '*',
+                          '_REQUIRED_FIELDS', '1', 'dyn', 'WITHCURSOR', 'COUNT', '1')
+    env.assertEqual(res, [1, None, ['t', 'hello']], message=res)
+    res, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
+    env.assertEqual(res, [1, '$world', ['t', 'hello', 'dyn', 'world']], message=res)
+    if cursor:
+        env.cmd('FT.CURSOR', 'DEL', 'idx', cursor)
+
 
 def check_info_commandstats(env, cmd):
     res = env.cmd('INFO', 'COMMANDSTATS')


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: The `_REQUIRED_FIELDS` reply block — the shard side of every cluster query that carries sort keys — resolves its keys by name with `RLookup_GetKey_Read` on **every row**: a key-list scan with string compares per field per row.
2. Change: Each parsed required field carries its resolved key alongside its name — `RequiredField {name, key}` entries in the existing request-owned array, no second allocation. Keys are filled lazily during serialization: a name can be unresolvable for early rows and resolve later (loading documents may create keys), so NULL entries are retried per row while resolved keys are reused for the rest of the request, including across cursor reads.
3. Outcome: Internal-only; no reply change. Per-row, per-field name resolution drops to one per request in the common case — steady-state rows skip the name lookup and its FFI call entirely. This holds independently of how the lookup resolves names internally (linear scan or hash), so the cache composes with, rather than depends on, the RLookup storage work in #10932.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `AREQ.requiredFields` — now an array of `RequiredField {name, key}` (was `const char**`); keys point into the plan's lookup and live as long as the request
2. `parseRequiredFields` (aggregate_request.c) — builds the entries with `key = NULL`
3. `serializeResult` required-fields block (aggregate_exec.c) — resolves through the entry, retrying only while it is NULL

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
