### PR TITLE
[MOD-17924] Sort keys with embedded NUL bytes are no longer truncated in replies

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -199,6 +199,12 @@ typedef struct AREQ {
 
   const char** requiredFields;
 
+  // Reply-time cache of `requiredFields` resolved against the plan's last
+  // lookup, so serialization does not repeat the by-name lookup for every row.
+  // Entries point into the plan's lookup and stay valid for the request's
+  // lifetime; the array itself is owned by the request.
+  const RLookupKey** requiredFieldsKeys;
+
   struct QOptimizer *optimizer;        // Hold parameters for query optimizer
 
   // Currently we need both because maxSearchResults limits the OFFSET also in

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -64,6 +64,15 @@ typedef struct {
   uint32_t chunkSize;   // Number of results per cursor read (from COUNT parameter)
 } CursorConfig;
 
+// A field the coordinator requires in each reply row (`_REQUIRED_FIELDS`), paired with its
+// reply-time key. `name` is borrowed from the request arguments; `key` points into the plan's
+// last lookup and is resolved lazily during serialization — NULL until the name resolves, and
+// retried while NULL because loading documents may create the key on a later row.
+typedef struct {
+  const char *name;
+  const RLookupKey *key;
+} RequiredField;
+
 // Context structure for parseAggPlan to reduce parameter count
 typedef struct {
   AGGPlan *plan;                    // Aggregation plan
@@ -72,7 +81,7 @@ typedef struct {
   RSSearchOptions *searchopts;      // Search options
   size_t *prefixesOffset;           // Prefixes offset
   CursorConfig *cursorConfig;       // Cursor configuration
-  const char ***requiredFields;     // Required fields
+  RequiredField **requiredFields;   // Required fields
   size_t *maxSearchResults;         // Maximum search results
   size_t *maxAggregateResults;      // Maximum aggregate results
   const RedisModuleSlotRangeArray **querySlots; // Slots requested (referenced from AREQ)
@@ -197,13 +206,7 @@ typedef struct AREQ {
   /** Profile variables */
   ProfileClocks profileClocks;
 
-  const char** requiredFields;
-
-  // Reply-time cache of `requiredFields` resolved against the plan's last
-  // lookup, so serialization does not repeat the by-name lookup for every row.
-  // Entries point into the plan's lookup and stay valid for the request's
-  // lifetime; the array itself is owned by the request.
-  const RLookupKey** requiredFieldsKeys;
+  RequiredField* requiredFields;
 
   struct QOptimizer *optimizer;        // Hold parameters for query optimizer
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -150,13 +150,9 @@ static void reeval_key(RedisModule_Reply *reply, const RSValue *key) {
     return;
   }
 
-  // Serialize a string by prepending "$" to it, assembled length-aware in the
-  // reply's scratch buffer: embedded NUL bytes survive the round trip and no
-  // per-value allocation happens.
-  char *tmp = RedisModule_Reply_ScratchBuffer(reply, n + 1);
-  tmp[0] = '$';
-  memcpy(tmp + 1, s, n);
-  RedisModule_Reply_StringBuffer(reply, tmp, n + 1);
+  // Serialize a string by prepending "$" to it, assembled length-aware so
+  // embedded NUL bytes survive the round trip.
+  RedisModule_Reply_PrefixedStringBuffer(reply, '$', s, n);
 }
 
 static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchResult *r,

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -225,22 +225,19 @@ static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchR
     // Sortkey is the first key to reply on the required fields, if we already replied it, continue to the next one.
     size_t currentField = options & QEXEC_F_SEND_SORTKEYS ? 1 : 0;
     size_t requiredFieldsCount = array_len(req->requiredFields);
-    if (!req->requiredFieldsKeys) {
-      req->requiredFieldsKeys = rm_calloc(requiredFieldsCount, sizeof(*req->requiredFieldsKeys));
-    }
     RSValue *rsv = NULL;
     bool need_map = has_map && currentField < requiredFieldsCount;
     if (need_map) {
       RedisModule_ReplyKV_Map(reply, "required_fields"); // >required_fields
     }
     for(; currentField < requiredFieldsCount; currentField++) {
-      const RLookupKey *rlk = req->requiredFieldsKeys[currentField];
-      if (!rlk) {
+      RequiredField *field = &req->requiredFields[currentField];
+      if (!field->key) {
         // A name can be unresolvable for early rows and resolve later (loading
         // documents may create keys), so NULL entries are retried per row.
-        rlk = RLookup_GetKey_Read(cv->lastLookup, req->requiredFields[currentField], RLOOKUP_F_NOFLAGS);
-        req->requiredFieldsKeys[currentField] = rlk;
+        field->key = RLookup_GetKey_Read(cv->lastLookup, field->name, RLOOKUP_F_NOFLAGS);
       }
+      const RLookupKey *rlk = field->key;
       const RSValue *v = rlk ? getReplyKey(rlk, r) : NULL;
       if (RSValue_IsTrio(v)) {
         // For duo value, we use the left value here (not the right value)
@@ -257,7 +254,7 @@ static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchR
         v = rsv;
       }
       if (need_map) {
-        RedisModule_Reply_CString(reply, req->requiredFields[currentField]); // key name
+        RedisModule_Reply_CString(reply, field->name); // key name
       }
       reeval_key(reply, v);
     }

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -225,13 +225,22 @@ static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchR
     // Sortkey is the first key to reply on the required fields, if we already replied it, continue to the next one.
     size_t currentField = options & QEXEC_F_SEND_SORTKEYS ? 1 : 0;
     size_t requiredFieldsCount = array_len(req->requiredFields);
+    if (!req->requiredFieldsKeys) {
+      req->requiredFieldsKeys = rm_calloc(requiredFieldsCount, sizeof(*req->requiredFieldsKeys));
+    }
     RSValue *rsv = NULL;
     bool need_map = has_map && currentField < requiredFieldsCount;
     if (need_map) {
       RedisModule_ReplyKV_Map(reply, "required_fields"); // >required_fields
     }
     for(; currentField < requiredFieldsCount; currentField++) {
-      const RLookupKey *rlk = RLookup_GetKey_Read(cv->lastLookup, req->requiredFields[currentField], RLOOKUP_F_NOFLAGS);
+      const RLookupKey *rlk = req->requiredFieldsKeys[currentField];
+      if (!rlk) {
+        // A name can be unresolvable for early rows and resolve later (loading
+        // documents may create keys), so NULL entries are retried per row.
+        rlk = RLookup_GetKey_Read(cv->lastLookup, req->requiredFields[currentField], RLOOKUP_F_NOFLAGS);
+        req->requiredFieldsKeys[currentField] = rlk;
+      }
       const RSValue *v = rlk ? getReplyKey(rlk, r) : NULL;
       if (RSValue_IsTrio(v)) {
         // For duo value, we use the left value here (not the right value)

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -150,17 +150,13 @@ static void reeval_key(RedisModule_Reply *reply, const RSValue *key) {
     return;
   }
 
-  // Serialize a string by prepending "$" to it. Copied length-aware into a
-  // scratch buffer (stack for the common short case), so embedded NUL bytes
-  // survive the round trip.
-  char stackbuf[128];
-  char *tmp = (n < sizeof(stackbuf)) ? stackbuf : rm_malloc(n + 1);
+  // Serialize a string by prepending "$" to it, assembled length-aware in the
+  // reply's scratch buffer: embedded NUL bytes survive the round trip and no
+  // per-value allocation happens.
+  char *tmp = RedisModule_Reply_ScratchBuffer(reply, n + 1);
   tmp[0] = '$';
   memcpy(tmp + 1, s, n);
   RedisModule_Reply_StringBuffer(reply, tmp, n + 1);
-  if (tmp != stackbuf) {
-    rm_free(tmp);
-  }
 }
 
 static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchResult *r,

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -8,6 +8,7 @@
 */
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 #include <strings.h>
 #include <sys/param.h>
@@ -99,48 +100,66 @@ static const RSValue *getReplyKey(const RLookupKey *kk, const SearchResult *r) {
 
 
 
+// Serialize a double by prepending "#" to the number, so the coordinator/client
+// can tell it's a double and not just a numeric string value.
+static void reply_sortable_number(RedisModule_Reply *reply, double d) {
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "#%.17g", d);
+  // "#" + %.17g is at most 26 bytes; a truncating snprintf would return the
+  // untruncated length and over-read below.
+  RS_LOG_ASSERT(len > 0 && len < (int)sizeof(buf), "sortable number overflowed its buffer");
+  RedisModule_Reply_StringBuffer(reply, buf, len);
+}
+
 static void reeval_key(RedisModule_Reply *reply, const RSValue *key) {
-  RedisModuleCtx *outctx = reply->ctx;
-  RedisModuleString *rskey = NULL;
   if (!key) {
     RedisModule_Reply_Null(reply);
+    return;
   }
-  else {
-    if (RSValue_IsReference(key)) {
-      key = RSValue_Dereference(key);
-    } else if (RSValue_IsTrio(key)) {
-      key = RSValue_Trio_GetLeft(key);
-    }
+  if (RSValue_IsReference(key)) {
+    key = RSValue_Dereference(key);
+  } else if (RSValue_IsTrio(key)) {
+    key = RSValue_Trio_GetLeft(key);
+  }
 
-    switch (RSValue_Type(key)) {
-      case RSValueType_Number:
-        // Serialize double - by prepending "#" to the number, so the coordinator/client can
-        // tell it's a double and not just a numeric string value
-        rskey = RedisModule_CreateStringPrintf(outctx, "#%.17g", RSValue_Number_Get(key));
-        break;
-      case RSValueType_String:
-        // Serialize string - by prepending "$" to it
-        rskey = RedisModule_CreateStringPrintf(outctx, "$%s", RSValue_String_Get(key, NULL));
-        break;
-      case RSValueType_RedisString:
-        rskey = RedisModule_CreateStringPrintf(outctx, "$%s",
-          RedisModule_StringPtrLen(RSValue_RedisString_Get(key), NULL));
-        break;
-      case RSValueType_Null:
-      case RSValueType_Undef:
-      case RSValueType_Array:
-      case RSValueType_Map:
-      case RSValueType_Reference:
-      case RSValueType_Trio:
-        break;
+  const char *s = NULL;
+  size_t n = 0;
+  switch (RSValue_Type(key)) {
+    case RSValueType_Number:
+      reply_sortable_number(reply, RSValue_Number_Get(key));
+      return;
+    case RSValueType_String: {
+      uint32_t sn = 0;
+      s = RSValue_String_Get(key, &sn);
+      n = sn;
+      break;
     }
+    case RSValueType_RedisString:
+      s = RedisModule_StringPtrLen(RSValue_RedisString_Get(key), &n);
+      break;
+    case RSValueType_Null:
+    case RSValueType_Undef:
+    case RSValueType_Array:
+    case RSValueType_Map:
+    case RSValueType_Reference:
+    case RSValueType_Trio:
+      break;
+  }
+  if (!s) {
+    RedisModule_Reply_Null(reply);
+    return;
+  }
 
-    if (rskey) {
-      RedisModule_Reply_String(reply, rskey);
-      RedisModule_FreeString(outctx, rskey);
-    } else {
-      RedisModule_Reply_Null(reply);
-    }
+  // Serialize a string by prepending "$" to it. Copied length-aware into a
+  // scratch buffer (stack for the common short case), so embedded NUL bytes
+  // survive the round trip.
+  char stackbuf[128];
+  char *tmp = (n < sizeof(stackbuf)) ? stackbuf : rm_malloc(n + 1);
+  tmp[0] = '$';
+  memcpy(tmp + 1, s, n);
+  RedisModule_Reply_StringBuffer(reply, tmp, n + 1);
+  if (tmp != stackbuf) {
+    rm_free(tmp);
   }
 }
 
@@ -225,7 +244,6 @@ static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchR
     // Sortkey is the first key to reply on the required fields, if we already replied it, continue to the next one.
     size_t currentField = options & QEXEC_F_SEND_SORTKEYS ? 1 : 0;
     size_t requiredFieldsCount = array_len(req->requiredFields);
-    RSValue *rsv = NULL;
     bool need_map = has_map && currentField < requiredFieldsCount;
     if (need_map) {
       RedisModule_ReplyKV_Map(reply, "required_fields"); // >required_fields
@@ -243,27 +261,22 @@ static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchR
         // For duo value, we use the left value here (not the right value)
         v = RSValue_Trio_GetLeft(v);
       }
-      if (rlk && (RLookupKey_GetFlags(rlk) & RLOOKUP_F_NUMERIC) && v && !RSValue_IsNumber(v) && !RSValue_IsNull(v)) {
-        double d = 0.0;
-        RSValue_ToNumber(v, &d);
-        if (rsv == NULL) {
-          rsv = RSValue_NewNumber(d);
-        } else {
-          RSValue_SetNumber(rsv, d);
-        }
-        v = rsv;
-      }
       if (need_map) {
         RedisModule_Reply_CString(reply, field->name); // key name
       }
-      reeval_key(reply, v);
+      if (rlk && (RLookupKey_GetFlags(rlk) & RLOOKUP_F_NUMERIC) && v && !RSValue_IsNumber(v) && !RSValue_IsNull(v)) {
+        // A numeric field whose row value is not a number (e.g. loaded as a
+        // string): coerce and serialize the double directly, with no scratch
+        // RSValue.
+        double d = 0.0;
+        RSValue_ToNumber(v, &d);
+        reply_sortable_number(reply, d);
+      } else {
+        reeval_key(reply, v);
+      }
     }
     if (need_map) {
       RedisModule_Reply_MapEnd(reply); // >required_fields
-    }
-    if (rsv) {
-      RSValue_DecrRef(rsv);
-      rsv = NULL;
     }
   }
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -195,7 +195,7 @@ static int parseCursorSettings(uint32_t *reqflags, CursorConfig *cursorConfig, A
   return REDISMODULE_OK;
 }
 
-static int parseRequiredFields(const char ***requiredFields, ArgsCursor *ac, QueryError *status){
+static int parseRequiredFields(RequiredField **requiredFields, ArgsCursor *ac, QueryError *status){
 
   ArgsCursor args = {0};
   int rv = AC_GetVarArgs(ac, &args);
@@ -204,17 +204,16 @@ static int parseRequiredFields(const char ***requiredFields, ArgsCursor *ac, Que
     return REDISMODULE_ERR;
   }
   int requiredFieldNum = AC_NumArgs(&args);
-  // This array contains shallow copy of the required fields names. Those copies are to use only for lookup.
-  // If we need to use them in reply we should make a copy of those strings.
-  const char** reqFields = array_new(const char*, requiredFieldNum);
+  // The names are shallow copies, to use only for lookup. If we need to use them in reply we
+  // should make a copy of those strings. Keys are resolved lazily at serialization time.
+  RequiredField* reqFields = array_new(RequiredField, requiredFieldNum);
   for(size_t i=0; i < requiredFieldNum; i++) {
-    const char *s = AC_GetStringNC(&args, NULL); {
-      if(!s) {
-        array_free(reqFields);
-        return REDISMODULE_ERR;
-      }
+    const char *s = AC_GetStringNC(&args, NULL);
+    if(!s) {
+      array_free(reqFields);
+      return REDISMODULE_ERR;
     }
-    array_append(reqFields, s);
+    array_append(reqFields, ((RequiredField){.name = s, .key = NULL}));
   }
 
   *requiredFields = reqFields;
@@ -1900,9 +1899,6 @@ void AREQ_Free(AREQ *req) {
   FieldList_Free(&req->outFields);
   if(req->requiredFields) {
     array_free(req->requiredFields);
-  }
-  if (req->requiredFieldsKeys) {
-    rm_free(req->requiredFieldsKeys);
   }
   // Free parsed vector data
   if (req->parsedVectorData) {

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1901,6 +1901,9 @@ void AREQ_Free(AREQ *req) {
   if(req->requiredFields) {
     array_free(req->requiredFields);
   }
+  if (req->requiredFieldsKeys) {
+    rm_free(req->requiredFieldsKeys);
+  }
   // Free parsed vector data
   if (req->parsedVectorData) {
     ParsedVectorData_Free(req->parsedVectorData);

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -224,17 +224,12 @@ impl<'a> RLookup<'a> {
 
         let name = name.into();
 
-        // Return the existing key if there is one. The reference is routed
-        // through a raw pointer because the borrow checker rejects returning
-        // it directly out of the `if let` while later arms mutate `self`
-        // (NLL problem case #3, rust-lang/rust#54663); the round-trip keeps
-        // this a single scan of the key list.
-        if let Some(found) = self.keys.find_by_name(&name).and_then(Cursor::into_current) {
-            let found = NonNull::from(found);
-            // SAFETY: `found` points into `self.keys`, whose keys are pinned
-            // and outlive `self`'s borrow, and nothing touches the list
-            // between the lookup above and this reborrow.
-            return Some(unsafe { found.as_ref() });
+        let available = self.keys.find_by_name(&name).is_some();
+        if available {
+            // FIXME: We cannot use let-some above because of a borrow-checker false positive.
+            // This duplication might have performance implications.
+            // See <https://github.com/rust-lang/rust/issues/54663>
+            return self.keys.find_by_name(&name).unwrap().into_current();
         }
 
         // If we didn't find the key at the lookup table, check if it exists in

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -224,12 +224,17 @@ impl<'a> RLookup<'a> {
 
         let name = name.into();
 
-        let available = self.keys.find_by_name(&name).is_some();
-        if available {
-            // FIXME: We cannot use let-some above because of a borrow-checker false positive.
-            // This duplication might have performance implications.
-            // See <https://github.com/rust-lang/rust/issues/54663>
-            return self.keys.find_by_name(&name).unwrap().into_current();
+        // Return the existing key if there is one. The reference is routed
+        // through a raw pointer because the borrow checker rejects returning
+        // it directly out of the `if let` while later arms mutate `self`
+        // (NLL problem case #3, rust-lang/rust#54663); the round-trip keeps
+        // this a single scan of the key list.
+        if let Some(found) = self.keys.find_by_name(&name).and_then(Cursor::into_current) {
+            let found = NonNull::from(found);
+            // SAFETY: `found` points into `self.keys`, whose keys are pinned
+            // and outlive `self`'s borrow, and nothing touches the list
+            // between the lookup above and this reborrow.
+            return Some(unsafe { found.as_ref() });
         }
 
         // If we didn't find the key at the lookup table, check if it exists in

--- a/src/reply.c
+++ b/src/reply.c
@@ -525,9 +525,6 @@ int RedisModule_Reply_RSValue(RedisModule_Reply *reply, const RSValue *v, SendRe
 
     case RSValueType_Number: {
       if (!(flags & SENDREPLY_FLAG_EXPAND)) {
-        char buf[32];
-        size_t len = RSValue_NumToString(v, buf, sizeof(buf));
-
         if (flags & SENDREPLY_FLAG_TYPED) {
           if (reply->resp3) {
             return RedisModule_Reply_Double(reply, RSValue_Number_Get(v));
@@ -535,9 +532,13 @@ int RedisModule_Reply_RSValue(RedisModule_Reply *reply, const RSValue *v, SendRe
              // In RESP2, RM_ReplyWithDouble() does not tag the response as
              // double, it's just a plain string. So we send it as simple string
              // that is converted to double by MRReply_ToValue().
+            char buf[32];
+            RSValue_NumToString(v, buf, sizeof(buf));
             return RedisModule_Reply_Error(reply, buf);
           }
         } else {
+          char buf[32];
+          size_t len = RSValue_NumToString(v, buf, sizeof(buf));
           return RedisModule_Reply_StringBuffer(reply, buf, len);
         }
       } else {

--- a/src/reply.c
+++ b/src/reply.c
@@ -146,7 +146,14 @@ int RedisModule_EndReply(RedisModule_Reply *reply) {
   return REDISMODULE_OK;
 }
 
-char *RedisModule_Reply_ScratchBuffer(RedisModule_Reply *reply, size_t len) {
+// Retention bound for the reply-owned scratch buffer. Values that fit reuse one
+// retained allocation (power-of-two growth capped by this bound); larger values
+// take an exact-sized temporary freed right after emission, so a huge field can
+// neither be rounded up by the geometric growth nor stay pinned until EndReply.
+#define REPLY_SCRATCH_RETAIN_MAX 4096
+
+static char *reply_ScratchBuffer(RedisModule_Reply *reply, size_t len) {
+  RS_LOG_ASSERT(len <= REPLY_SCRATCH_RETAIN_MAX, "scratch request above retention bound");
   if (reply->scratch_cap < len) {
     size_t cap = reply->scratch_cap ? reply->scratch_cap : 128;
     while (cap < len) {
@@ -156,6 +163,21 @@ char *RedisModule_Reply_ScratchBuffer(RedisModule_Reply *reply, size_t len) {
     reply->scratch_cap = cap;
   }
   return reply->scratch;
+}
+
+int RedisModule_Reply_PrefixedStringBuffer(RedisModule_Reply *reply, char prefix, const char *s,
+                                           size_t n) {
+  RS_LOG_ASSERT(n < SIZE_MAX, "prefixed string length overflow");
+  const size_t total = n + 1;
+  char *buf = total <= REPLY_SCRATCH_RETAIN_MAX ? reply_ScratchBuffer(reply, total)
+                                                : rm_malloc(total);
+  buf[0] = prefix;
+  memcpy(buf + 1, s, n);
+  int rc = RedisModule_Reply_StringBuffer(reply, buf, total);
+  if (buf != reply->scratch) {
+    rm_free(buf);
+  }
+  return rc;
 }
 
 static void _RedisModule_Reply_Next(RedisModule_Reply *reply) {

--- a/src/reply.c
+++ b/src/reply.c
@@ -118,11 +118,11 @@ static inline void json_add_close(RedisModule_Reply *reply, const char *s) {}
 
 RedisModule_Reply RedisModule_NewReply(RedisModuleCtx *ctx) {
 #ifdef REDISMODULE_REPLY_DEBUG
-  RedisModule_Reply reply = { ctx, is_resp3(ctx), 0, NULL, NULL };
+  RedisModule_Reply reply = { ctx, is_resp3(ctx), 0, NULL, NULL, 0, NULL };
   reply.json = array_new(char, 1);
   *reply.json = '\0';
 #else
-  RedisModule_Reply reply = { ctx, is_resp3(ctx), 0, NULL };
+  RedisModule_Reply reply = { ctx, is_resp3(ctx), 0, NULL, NULL, 0 };
 #endif
   return reply;
 }
@@ -132,6 +132,11 @@ int RedisModule_EndReply(RedisModule_Reply *reply) {
   if (reply->stack) {
     array_free(reply->stack);
   }
+  if (reply->scratch) {
+    rm_free(reply->scratch);
+    reply->scratch = NULL;
+    reply->scratch_cap = 0;
+  }
 #ifdef REDISMODULE_REPLY_DEBUG
   if (reply->json) {
     array_free(reply->json);
@@ -139,6 +144,18 @@ int RedisModule_EndReply(RedisModule_Reply *reply) {
 #endif
   reply->stack = 0;
   return REDISMODULE_OK;
+}
+
+char *RedisModule_Reply_ScratchBuffer(RedisModule_Reply *reply, size_t len) {
+  if (reply->scratch_cap < len) {
+    size_t cap = reply->scratch_cap ? reply->scratch_cap : 128;
+    while (cap < len) {
+      cap *= 2;
+    }
+    reply->scratch = rm_realloc(reply->scratch, cap);
+    reply->scratch_cap = cap;
+  }
+  return reply->scratch;
 }
 
 static void _RedisModule_Reply_Next(RedisModule_Reply *reply) {

--- a/src/reply.h
+++ b/src/reply.h
@@ -36,7 +36,7 @@ typedef struct RedisModule_Reply {
   bool resp3;
   int count;
   arrayof(struct RedisModule_Reply_StackEntry) stack;
-  char *scratch;  // see RedisModule_Reply_ScratchBuffer
+  char *scratch;  // see RedisModule_Reply_PrefixedStringBuffer
   size_t scratch_cap;
 #ifdef REDISMODULE_REPLY_DEBUG
   arrayof(char) json;
@@ -68,11 +68,11 @@ int RedisModule_Reply_SimpleString(RedisModule_Reply *reply, const char *val);
 int RedisModule_Reply_CString(RedisModule_Reply *reply, const char *val);
 int RedisModule_Reply_StringBuffer(RedisModule_Reply *reply, const char *val, size_t len);
 
-/* Return a reply-owned scratch buffer of at least `len` bytes, for values that must be
- * assembled before a single bulk-string emission (e.g. tag-prefixed sort keys). Every call
- * returns the same buffer, possibly grown, so the contents only survive until the next call;
- * the buffer is reused across rows and freed by RedisModule_EndReply. */
-char *RedisModule_Reply_ScratchBuffer(RedisModule_Reply *reply, size_t len);
+/* Emit `prefix` followed by the `n` bytes of `s` as one bulk string (e.g. tag-prefixed
+ * sort keys), without a per-value allocation for typical sizes: small values are assembled
+ * in a bounded reply-owned scratch buffer reused across rows and freed by
+ * RedisModule_EndReply; larger values use an exact-sized temporary freed before returning. */
+int RedisModule_Reply_PrefixedStringBuffer(RedisModule_Reply *reply, char prefix, const char *s, size_t n);
 int RedisModule_Reply_Stringf(RedisModule_Reply *reply, const char *fmt, ...);
 int RedisModule_Reply_SimpleStringf(RedisModule_Reply *reply, const char *fmt, ...);
 int RedisModule_Reply_String(RedisModule_Reply *reply, const RedisModuleString *val);

--- a/src/reply.h
+++ b/src/reply.h
@@ -36,6 +36,8 @@ typedef struct RedisModule_Reply {
   bool resp3;
   int count;
   arrayof(struct RedisModule_Reply_StackEntry) stack;
+  char *scratch;  // see RedisModule_Reply_ScratchBuffer
+  size_t scratch_cap;
 #ifdef REDISMODULE_REPLY_DEBUG
   arrayof(char) json;
 #endif
@@ -65,6 +67,12 @@ int RedisModule_Reply_Double(RedisModule_Reply *reply, double val);
 int RedisModule_Reply_SimpleString(RedisModule_Reply *reply, const char *val);
 int RedisModule_Reply_CString(RedisModule_Reply *reply, const char *val);
 int RedisModule_Reply_StringBuffer(RedisModule_Reply *reply, const char *val, size_t len);
+
+/* Return a reply-owned scratch buffer of at least `len` bytes, for values that must be
+ * assembled before a single bulk-string emission (e.g. tag-prefixed sort keys). Every call
+ * returns the same buffer, possibly grown, so the contents only survive until the next call;
+ * the buffer is reused across rows and freed by RedisModule_EndReply. */
+char *RedisModule_Reply_ScratchBuffer(RedisModule_Reply *reply, size_t len);
 int RedisModule_Reply_Stringf(RedisModule_Reply *reply, const char *fmt, ...);
 int RedisModule_Reply_SimpleStringf(RedisModule_Reply *reply, const char *fmt, ...);
 int RedisModule_Reply_String(RedisModule_Reply *reply, const RedisModuleString *val);

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -95,6 +95,36 @@ def test_required_fields(env):
     # Field is not in Rlookup, will not load
     env.expect('ft.search', 'idx', 'hello', 'nocontent', '_REQUIRED_FIELDS', '1', 't').equal([1, '0', None])
 
+@skip(cluster=True)
+def test_required_fields_key_cache(env):
+    """The shard-side `_REQUIRED_FIELDS` key cache: a key resolved on one row is reused on
+    later rows (cache hit), a name unresolvable on early rows resolves once a later
+    document's load creates its key (the NULL retry), and a NULL entry left by one cursor
+    chunk is still retried on later `FT.CURSOR READ` chunks."""
+    env.expect('ft.create', 'idx', 'schema', 't', 'text').ok()
+    # doc1 lacks `dyn`; doc2 carries it. Without sorting, reply order is docId
+    # (insertion) order, so doc1 serializes first.
+    env.cmd('HSET', 'doc1', 't', 'hello')
+    env.cmd('HSET', 'doc2', 't', 'hello', 'dyn', 'world')
+
+    # Content loading creates each document's keys just before its row is serialized:
+    # `t` resolves on row 1 and must be served from the cache on row 2, while `dyn` is
+    # unresolvable on row 1 (doc1's load did not create it) and must resolve on row 2.
+    env.expect('ft.search', 'idx', 'hello', '_REQUIRED_FIELDS', '2', 't', 'dyn').equal(
+        [2, 'doc1', '$hello', None, ['t', 'hello'],
+            'doc2', '$hello', '$world', ['t', 'hello', 'dyn', 'world']])
+
+    # Same late resolution across cursor chunks: chunk 1 serializes only doc1, leaving
+    # `dyn` unresolved in the cached request; the next chunk's `LOAD *` row creates the
+    # key, and the retained NULL entry must be retried rather than frozen.
+    res, cursor = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '*',
+                          '_REQUIRED_FIELDS', '1', 'dyn', 'WITHCURSOR', 'COUNT', '1')
+    env.assertEqual(res, [1, None, ['t', 'hello']], message=res)
+    res, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
+    env.assertEqual(res, [1, '$world', ['t', 'hello', 'dyn', 'world']], message=res)
+    if cursor:
+        env.cmd('FT.CURSOR', 'DEL', 'idx', cursor)
+
 
 def check_info_commandstats(env, cmd):
     res = env.cmd('INFO', 'COMMANDSTATS')

--- a/tests/pytests/test_sortby.py
+++ b/tests/pytests/test_sortby.py
@@ -315,3 +315,21 @@ def testSortableTagInvalidUtf8DoesNotCrash(env):
 
     # and the offeding document is not included in search results
     env.expect("FT.SEARCH", "idx_tag", "*", "NOCONTENT").equal([1, "doc1"])
+
+
+def testSortkeyWithEmbeddedNul(env):
+    """WITHSORTKEYS serializes string sort keys length-aware: a value with an
+    embedded NUL byte is returned in full instead of being cut at the NUL.
+    The field is deliberately not SORTABLE, so the sorter loads the raw
+    document value per row (the sorting-vector path truncates at the NUL
+    while indexing, before serialization is involved). Both docs share the
+    bytes before the NUL and differ only after it, so the ASC order also
+    proves the full key is what gets compared — on a cluster that comparison
+    is the coordinator's cross-shard merge of the serialized keys."""
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx_nul', 'SCHEMA', 't', 'TAG').ok()
+    conn.execute_command('HSET', 'doc:nul:1', 't', 'a\x00b')
+    conn.execute_command('HSET', 'doc:nul:2', 't', 'a\x00a')
+
+    res = env.cmd('FT.SEARCH', 'idx_nul', '*', 'SORTBY', 't', 'ASC', 'WITHSORTKEYS', 'NOCONTENT')
+    env.assertEqual(res, [2, 'doc:nul:2', '$a\x00a', 'doc:nul:1', '$a\x00b'])


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Serializing a sortkey or required field allocates per value per row: `reeval_key` builds a `RedisModuleString` with `CreateStringPrintf` and frees it right after the reply copies it out, and the required-fields numeric coercion allocates a scratch `RSValue` to carry a plain double. The `$`-prefixed string path also goes through printf `%s`, so a string sort key containing an embedded NUL byte is silently truncated — which can mis-order coordinator-side merges for binary values.
2. Change: Numbers render into a stack buffer; strings get their `$` prefix via a length-aware copy (stack buffer for the common short case, heap only past 127 bytes); the coerced double goes straight to the number emitter with no RSValue detour. `Reply_RSValue` also stops pre-formatting numbers it then discards on the RESP3 typed path.
3. Outcome: Sort-key values containing embedded NUL bytes are returned in full (previously cut at the first NUL) — visible in `FT.SEARCH ... WITHSORTKEYS` and in the internal cluster sortkey/required-fields replies. Sortkey serialization no longer heap-allocates per row.

Two notes for reviewers:
- **Rolling upgrade:** during a mixed-version window an old shard still truncates while a new shard does not, so cross-shard ordering of binary sort keys is transiently inconsistent (previously it was consistent-but-truncated). Numeric sort keys are byte-identical before and after. Version-gating was considered and rejected: the coordinator protocol has no shard-capability negotiation to gate on, the coordinator's merge compare is length-aware so both encodings are handled safely, and the affected values were silently corrupted everywhere before this fix — the window is transient and self-heals when the last shard upgrades.
- The fix is observable through the loaded-field sort path (the new flow test sorts by a non-SORTABLE field). SORTABLE fields truncate embedded NULs at **indexing** time in the sorting-vector path — a separate, pre-existing issue not addressed here.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `reeval_key` / `reply_sortable_number` (aggregate_exec.c) — stack-buffer emission, binary-safe `$` prefixing
2. `serializeResult` required-fields coercion (aggregate_exec.c) — scratch `RSValue` removed
3. `RedisModule_Reply_RSValue` (reply.c) — number formatting moved into the branches that use it

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

