### PR TITLE
[MOD-17631] Add a hide_user_data_from_log accessor to global_config

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -879,6 +879,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "global_config"
+version = "0.0.1"
+dependencies = [
+ "ffi",
+ "workspace_hack",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1200,7 @@ dependencies = [
  "cheadergen",
  "ffi",
  "field",
+ "global_config",
  "index_result",
  "index_spec",
  "inverted_index",
@@ -1835,6 +1844,7 @@ name = "query_eval_ffi"
 version = "0.0.1"
 dependencies = [
  "ffi",
+ "global_config",
  "query_eval",
  "query_types",
  "rqe_iterators",
@@ -2080,6 +2090,7 @@ name = "redis_mock"
 version = "0.0.1"
 dependencies = [
  "ffi",
+ "global_config",
  "libc",
  "redis-module",
  "tracing",
@@ -2143,6 +2154,7 @@ dependencies = [
  "build_utils",
  "bumpalo",
  "ffi",
+ "global_config",
  "indexmap",
  "itertools 0.15.0",
  "min-max-heap",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -123,6 +123,7 @@ fnv = { path = "./fnv" }
 fork_gc = { path = "./fork_gc" }
 generational_slab = { path = "./generational_slab" }
 geo = { path = "./geo" }
+global_config = { path = "./c_wrappers/global_config" }
 hidden_string = { path = "./c_wrappers/hidden_string" }
 hyperloglog = { path = "./hyperloglog" }
 idf = { path = "./idf" }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
@@ -23,6 +23,7 @@ bench = false
 cheadergen.workspace = true
 ffi.workspace = true
 field.workspace = true
+global_config.workspace = true
 index_result.workspace = true
 index_spec.workspace = true
 inverted_index.workspace = true

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/intersection.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/intersection.rs
@@ -93,8 +93,7 @@ pub unsafe extern "C" fn NewIntersectionIterator(
     } else {
         Some(max_slop as u32)
     };
-    // SAFETY: `ffi::RSGlobalConfig` is the global config instance, read-only here.
-    let prioritize_union_children = unsafe { ffi::RSGlobalConfig.prioritizeIntersectUnionChildren };
+    let prioritize_union_children = global_config::get().prioritizeIntersectUnionChildren;
     let wrapper = match new_intersection_iterator(children) {
         NewIntersectionIterator::Empty => NewEmptyIterator(),
         NewIntersectionIterator::Single(child) => child.into_raw().as_ptr(),

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/intersection.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/intersection.rs
@@ -93,7 +93,7 @@ pub unsafe extern "C" fn NewIntersectionIterator(
     } else {
         Some(max_slop as u32)
     };
-    let prioritize_union_children = global_config::get().prioritizeIntersectUnionChildren;
+    let prioritize_union_children = global_config::prioritize_intersect_union_children();
     let wrapper = match new_intersection_iterator(children) {
         NewIntersectionIterator::Empty => NewEmptyIterator(),
         NewIntersectionIterator::Single(child) => child.into_raw().as_ptr(),

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
@@ -9,7 +9,7 @@
 
 use std::ptr::{self, NonNull};
 
-use ffi::{GeoFilter, RSGlobalConfig};
+use ffi::GeoFilter;
 use rqe_iterators::{IteratorsConfig, build_geo_range_iterator, free_geo_numeric_filters};
 
 /// Creates an iterator over all geo-encoded index entries within the radius specified by `gf`.
@@ -41,8 +41,7 @@ pub unsafe extern "C" fn NewGeoRangeIterator(
     let sctx = unsafe { NonNull::new_unchecked(ctx as *mut ffi::RedisSearchCtx) };
     // SAFETY: 4. guarantees config is valid and non-null.
     let min_union_iter_heap = unsafe { (*config).min_union_iter_heap } as usize;
-    // SAFETY: `RSGlobalConfig` is initialised by the time any index is created.
-    let compress = unsafe { RSGlobalConfig.numericCompress };
+    let compress = global_config::get().numericCompress;
 
     // SAFETY: preconditions 1–3 map directly to those of `build_geo_range_iterator`.
     unsafe { build_geo_range_iterator(sctx, geo, min_union_iter_heap, compress) }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/geo.rs
@@ -41,7 +41,7 @@ pub unsafe extern "C" fn NewGeoRangeIterator(
     let sctx = unsafe { NonNull::new_unchecked(ctx as *mut ffi::RedisSearchCtx) };
     // SAFETY: 4. guarantees config is valid and non-null.
     let min_union_iter_heap = unsafe { (*config).min_union_iter_heap } as usize;
-    let compress = global_config::get().numericCompress;
+    let compress = global_config::numeric_compress();
 
     // SAFETY: preconditions 1–3 map directly to those of `build_geo_range_iterator`.
     unsafe { build_geo_range_iterator(sctx, geo, min_union_iter_heap, compress) }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -9,7 +9,7 @@
 
 use std::ptr::{self, NonNull};
 
-use ffi::{FieldSpec, RSGlobalConfig};
+use ffi::FieldSpec;
 use field::FieldFilterContext;
 use inverted_index::NumericFilter;
 use rqe_iterators::{IteratorsConfig, open_numeric_or_geo_index};
@@ -32,8 +32,7 @@ pub unsafe extern "C" fn openNumericOrGeoIndex(
     // SAFETY: 2. guarantees fs is valid and non-null.
     let fs = unsafe { &mut *fs };
 
-    // SAFETY: RSGlobalConfig is initialised by the time any index is created.
-    let compress = unsafe { RSGlobalConfig.numericCompress };
+    let compress = global_config::get().numericCompress;
     // SAFETY: 1. and 2. are forwarded from this function's safety contract.
     match unsafe { open_numeric_or_geo_index(spec, fs, create_if_missing, compress) } {
         Some(tree) => std::ptr::from_mut(tree).cast::<ffi::NumericRangeTree>(),
@@ -81,8 +80,7 @@ pub unsafe extern "C" fn NewNumericFilterIterator(
     let sctx = unsafe { &*ctx };
     // SAFETY: 5. guarantees filter_ctx is valid and non-null.
     let field_ctx = unsafe { &*filter_ctx };
-    // SAFETY: `RSGlobalConfig` is initialised by the time any index is created.
-    let compress = unsafe { RSGlobalConfig.numericCompress };
+    let compress = global_config::get().numericCompress;
 
     // SAFETY: preconditions 1–3/5 map directly to those of
     // `build_numeric_filter_iterator`.

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/inverted_index/numeric.rs
@@ -32,7 +32,7 @@ pub unsafe extern "C" fn openNumericOrGeoIndex(
     // SAFETY: 2. guarantees fs is valid and non-null.
     let fs = unsafe { &mut *fs };
 
-    let compress = global_config::get().numericCompress;
+    let compress = global_config::numeric_compress();
     // SAFETY: 1. and 2. are forwarded from this function's safety contract.
     match unsafe { open_numeric_or_geo_index(spec, fs, create_if_missing, compress) } {
         Some(tree) => std::ptr::from_mut(tree).cast::<ffi::NumericRangeTree>(),
@@ -80,7 +80,7 @@ pub unsafe extern "C" fn NewNumericFilterIterator(
     let sctx = unsafe { &*ctx };
     // SAFETY: 5. guarantees filter_ctx is valid and non-null.
     let field_ctx = unsafe { &*filter_ctx };
-    let compress = global_config::get().numericCompress;
+    let compress = global_config::numeric_compress();
 
     // SAFETY: preconditions 1–3/5 map directly to those of
     // `build_numeric_filter_iterator`.

--- a/src/redisearch_rs/c_entrypoint/query_eval_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/query_eval_ffi/Cargo.toml
@@ -15,6 +15,7 @@ bench = false
 
 [dependencies]
 ffi.workspace = true
+global_config.workspace = true
 query_eval.workspace = true
 query_types.workspace = true
 rqe_iterators.workspace = true

--- a/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
@@ -28,26 +28,20 @@ use rqe_iterators::IteratorsConfig;
 
 /// Snapshot the evaluator's configuration.
 ///
-/// Fields that have no per-query snapshot are read from the process-wide
-/// [`ffi::RSGlobalConfig`]. Anything covered by [`IteratorsConfig`] is instead
-/// taken from `iterators` rather than the live global.
+/// Fields that have no per-query snapshot are read from the process-wide config, in a
+/// single [`global_config::get`] so that they are consistent with one another. Anything
+/// covered by [`IteratorsConfig`] is instead taken from `iterators` rather than the live
+/// global.
 ///
 /// This is the single point where the query evaluator reads the global config;
-/// the resulting [`Config`] is threaded through evaluation as a parameter.
+/// the resulting [`Config`] is threaded through evaluation as a parameter, so a
+/// query cannot observe a setting changing underneath it.
 fn eval_config(iterators: &IteratorsConfig) -> Config {
-    // SAFETY: `RSGlobalConfig` is the process-wide config instance, fully
-    // initialised before any query is evaluated, and read-only here. Each field
-    // is a `Copy` scalar read directly out of the static, without forming a
-    // reference to it.
-    let numeric_compress = unsafe { ffi::RSGlobalConfig.numericCompress };
-    // SAFETY: as above.
-    let prioritize_intersect_union_children =
-        unsafe { ffi::RSGlobalConfig.prioritizeIntersectUnionChildren };
-    // SAFETY: as above. `defaultScorer` is a `Copy` pointer to the process-wide
-    // default scorer name, null when unset. It is read (not retained) here to
-    // resolve the built-in `Scorer` once, so `Config` carries no raw pointer.
-    let default_scorer_ptr = unsafe { ffi::RSGlobalConfig.defaultScorer };
-    let default_scorer = NonNull::new(default_scorer_ptr.cast_mut()).and_then(|ptr| {
+    let global = global_config::get();
+
+    // `defaultScorer` names the process-wide default scorer, and is null when unset. It is
+    // resolved (not retained) here, so `Config` carries no raw pointer.
+    let default_scorer = NonNull::new(global.defaultScorer.cast_mut()).and_then(|ptr| {
         // SAFETY: `defaultScorer` is non-null here and points to a valid
         // NUL-terminated C string owned by the process-wide config.
         let name = unsafe { CStr::from_ptr(ptr.as_ptr()) };
@@ -57,8 +51,8 @@ fn eval_config(iterators: &IteratorsConfig) -> Config {
     });
 
     Config {
-        numeric_compress,
-        prioritize_intersect_union_children,
+        numeric_compress: global.numericCompress,
+        prioritize_intersect_union_children: global.prioritizeIntersectUnionChildren,
         default_scorer,
         min_term_prefix: iterators.min_term_prefix,
         max_prefix_expansions: iterators.max_prefix_expansions as usize,
@@ -79,9 +73,7 @@ fn eval_config(iterators: &IteratorsConfig) -> Config {
 unsafe fn resolve_scorer(scorer_name: *const c_char) -> Option<BuiltInScorer> {
     // A null scorer name means "use the configured default scorer".
     let name = if scorer_name.is_null() {
-        // SAFETY: `RSGlobalConfig` is the process-wide config, read-only here;
-        // `defaultScorer` is a `Copy` pointer read directly out of the static.
-        unsafe { ffi::RSGlobalConfig.defaultScorer }
+        global_config::get().defaultScorer
     } else {
         scorer_name
     };

--- a/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
@@ -28,21 +28,19 @@ use rqe_iterators::IteratorsConfig;
 
 /// Snapshot the evaluator's configuration.
 ///
-/// Fields that have no per-query snapshot are read from the process-wide config, in a
-/// single [`global_config::get`] rather than one read per field. Anything covered by
-/// [`IteratorsConfig`] is instead taken from `iterators` rather than the live global.
+/// Fields that have no per-query snapshot are read from the process-wide config, each
+/// through its [`global_config`] accessor. Anything covered by [`IteratorsConfig`] is
+/// instead taken from `iterators` rather than the live global.
 ///
 /// The resulting [`Config`] is threaded through evaluation as a parameter, so evaluation
 /// itself never re-reads the global. [`resolve_scorer`] does, on the path that decides
 /// whether a query needs term offsets, so a `CONFIG SET` landing between the two can still
 /// leave that decision and this snapshot disagreeing.
 fn eval_config(iterators: &IteratorsConfig) -> Config {
-    let global = global_config::get();
-
-    // `defaultScorer` names the process-wide default scorer, and is null when unset. It is
-    // resolved (not retained) here, so `Config` carries no raw pointer.
-    let default_scorer = NonNull::new(global.defaultScorer.cast_mut()).and_then(|ptr| {
-        // SAFETY: `defaultScorer` is non-null here and points to a valid
+    // The default scorer is resolved (not retained) here, so `Config` carries no pointer
+    // into config memory that a later `CONFIG SET` can free.
+    let default_scorer = global_config::default_scorer().and_then(|ptr| {
+        // SAFETY: `ptr` points to the configured default scorer name, a valid
         // NUL-terminated C string owned by the process-wide config.
         let name = unsafe { CStr::from_ptr(ptr.as_ptr()) };
         // A non-UTF-8 or custom (non-built-in) default resolves to `None`, which
@@ -51,8 +49,8 @@ fn eval_config(iterators: &IteratorsConfig) -> Config {
     });
 
     Config {
-        numeric_compress: global.numericCompress,
-        prioritize_intersect_union_children: global.prioritizeIntersectUnionChildren,
+        numeric_compress: global_config::numeric_compress(),
+        prioritize_intersect_union_children: global_config::prioritize_intersect_union_children(),
         default_scorer,
         min_term_prefix: iterators.min_term_prefix,
         max_prefix_expansions: iterators.max_prefix_expansions as usize,
@@ -73,15 +71,15 @@ fn eval_config(iterators: &IteratorsConfig) -> Config {
 unsafe fn resolve_scorer(scorer_name: *const c_char) -> Option<BuiltInScorer> {
     // A null scorer name means "use the configured default scorer".
     let name = if scorer_name.is_null() {
-        global_config::get().defaultScorer
+        global_config::default_scorer()
     } else {
-        scorer_name
+        NonNull::new(scorer_name.cast_mut())
     };
 
-    NonNull::new(name.cast_mut()).and_then(|ptr| {
-        // SAFETY: `name` is non-null here and points to a valid NUL-terminated C
-        // string: either `scorer_name` (by this function's contract) or, in the
-        // default branch, `RSGlobalConfig.defaultScorer`, which the config layer
+    name.and_then(|ptr| {
+        // SAFETY: `ptr` is non-null and points to a valid NUL-terminated C string:
+        // either `scorer_name` (by this function's contract) or, in the default
+        // branch, the configured default scorer name, which the config layer
         // guarantees is a valid NUL-terminated C string.
         BuiltInScorer::from_c_str(unsafe { CStr::from_ptr(ptr.as_ptr()) })
     })

--- a/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_eval_ffi/src/lib.rs
@@ -29,13 +29,13 @@ use rqe_iterators::IteratorsConfig;
 /// Snapshot the evaluator's configuration.
 ///
 /// Fields that have no per-query snapshot are read from the process-wide config, in a
-/// single [`global_config::get`] so that they are consistent with one another. Anything
-/// covered by [`IteratorsConfig`] is instead taken from `iterators` rather than the live
-/// global.
+/// single [`global_config::get`] rather than one read per field. Anything covered by
+/// [`IteratorsConfig`] is instead taken from `iterators` rather than the live global.
 ///
-/// This is the single point where the query evaluator reads the global config;
-/// the resulting [`Config`] is threaded through evaluation as a parameter, so a
-/// query cannot observe a setting changing underneath it.
+/// The resulting [`Config`] is threaded through evaluation as a parameter, so evaluation
+/// itself never re-reads the global. [`resolve_scorer`] does, on the path that decides
+/// whether a query needs term offsets, so a `CONFIG SET` landing between the two can still
+/// leave that decision and this snapshot disagreeing.
 fn eval_config(iterators: &IteratorsConfig) -> Config {
     let global = global_config::get();
 

--- a/src/redisearch_rs/c_wrappers/global_config/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/global_config/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "global_config"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+ffi.workspace = true
+workspace_hack.workspace = true

--- a/src/redisearch_rs/c_wrappers/global_config/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/global_config/src/lib.rs
@@ -68,6 +68,12 @@ config_accessors! {
     /// Whether an intersection iterator orders its children by factoring out unions rather
     /// than by estimated result count (`_PRIORITIZE_INTERSECT_UNION_CHILDREN`).
     prioritize_intersect_union_children() -> bool = prioritizeIntersectUnionChildren;
+
+    /// Whether user data — index, field and key names, and query terms — must be obfuscated
+    /// before it is written to the log. Mirrors the `hide-user-data-from-log` Redis server
+    /// configuration, which the module tracks through the config-change event rather than
+    /// through `FT.CONFIG`.
+    hide_user_data_from_log() -> bool = hideUserDataFromLog;
 }
 
 /// The name of the configured default scorer (`DEFAULT_SCORER`), or [`None`] when unset.

--- a/src/redisearch_rs/c_wrappers/global_config/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/global_config/src/lib.rs
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Safe read access to [`ffi::RSGlobalConfig`], the process-wide RediSearch configuration
+//! defined in `src/config.c`.
+
+/// Copies the process-wide configuration.
+///
+/// A copy rather than a `&'static ffi::RSConfig`, which would assert that nothing writes the
+/// static while it lives — `FT.CONFIG SET` does, from client threads. The read is
+/// unsynchronised, as it is on the C side, so it can tear against a concurrent write, and any
+/// pointer field can be freed by a later one.
+///
+/// Take one snapshot per operation rather than one per field, so that an operation cannot
+/// observe a setting changing halfway through.
+pub fn get() -> ffi::RSConfig {
+    // SAFETY: `RSGlobalConfig` is a statically initialised C global that lives for the whole
+    // process, and `RSConfig` is `Copy`, so the value is read out without forming a reference.
+    unsafe { ffi::RSGlobalConfig }
+}

--- a/src/redisearch_rs/c_wrappers/global_config/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/global_config/src/lib.rs
@@ -26,7 +26,8 @@
 //! The reads are unsynchronised, which is the one thing that argument does not establish:
 //! `CONFIG SET` writes these fields from client threads, so a read can race with a write.
 //! This crate exists to replace the C readers of the same fields rather than to change what
-//! they do; closing the race needs the C side to store the fields atomically.
+//! they do; closing the race needs the C side to store the fields atomically and both the C
+//! and Rust side to load them atomically.
 
 use std::{
     ffi::{c_char, c_int},

--- a/src/redisearch_rs/c_wrappers/global_config/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/global_config/src/lib.rs
@@ -9,25 +9,75 @@
 
 //! Safe read access to [`ffi::RSGlobalConfig`], the process-wide RediSearch configuration
 //! defined in `src/config.c`.
+//!
+//! Every setting is read through its own accessor, each one load out of the static. There
+//! is deliberately no whole-struct accessor: copying [`ffi::RSConfig`] is not atomic, so it
+//! would not make the fields it copies agree with one another, while costing a large copy
+//! and handing out owned pointers the caller never asked for. An operation that needs
+//! several settings to agree resolves them into its own snapshot once, up front, and
+//! passes that around.
+//!
+//! # Safety of these reads
+//!
+//! [`ffi::RSGlobalConfig`] is a statically initialised C global that lives for the whole
+//! process, and every field read here is [`Copy`], so a value is read out without forming a
+//! reference to the static. That is what makes these accessors safe to call.
+//!
+//! The reads are unsynchronised, which is the one thing that argument does not establish:
+//! `CONFIG SET` writes these fields from client threads, so a read can race with a write.
+//! This crate exists to replace the C readers of the same fields rather than to change what
+//! they do; closing the race needs the C side to store the fields atomically.
 
-/// Copies the process-wide configuration.
+use std::{
+    ffi::{c_char, c_int},
+    ptr::NonNull,
+};
+
+/// Defines one accessor per configuration field, reading it out of [`ffi::RSGlobalConfig`].
 ///
-/// A copy rather than a `&'static `[`ffi::RSConfig`], which would assert that nothing writes
-/// the static while it lives — `CONFIG SET` does, from client threads. Any pointer field can
-/// also be freed by a later write.
+/// Every field declared here must be [`Copy`] and must not point at memory the caller
+/// outlives, so that the module-level safety argument covers it without per-accessor
+/// reasoning. A field that needs more than that — [`default_scorer`] — is written out
+/// instead of declared here.
+macro_rules! config_accessors {
+    ($($(#[$doc:meta])* $name:ident() -> $ty:ty = $field:ident;)*) => {
+        $(
+            $(#[$doc])*
+            #[inline]
+            pub fn $name() -> $ty {
+                // SAFETY: see this module's *Safety of these reads*.
+                unsafe { ffi::RSGlobalConfig.$field }
+            }
+        )*
+    };
+}
+
+config_accessors! {
+    /// The Redis server version reported at module load, for gating features that need a
+    /// minimum server.
+    server_version() -> c_int = serverVersion;
+
+    /// The cap on the number of results `FT.AGGREGATE` may return
+    /// (`MAXAGGREGATERESULTS`).
+    max_aggregate_results() -> usize = maxAggregateResults;
+
+    /// Whether numeric indexes store doubles compressed to floats (`_NUMERIC_COMPRESS`).
+    numeric_compress() -> bool = numericCompress;
+
+    /// Whether an intersection iterator orders its children by factoring out unions rather
+    /// than by estimated result count (`_PRIORITIZE_INTERSECT_UNION_CHILDREN`).
+    prioritize_intersect_union_children() -> bool = prioritizeIntersectUnionChildren;
+}
+
+/// The name of the configured default scorer (`DEFAULT_SCORER`), or [`None`] when unset.
 ///
-/// Take one snapshot per operation rather than one per field: a struct copy is not atomic, so
-/// this narrows the window in which an operation sees a setting change halfway through, but
-/// does not close it.
+/// Reading the pointer is safe; dereferencing it is not. `FT.CONFIG SET DEFAULT_SCORER`
+/// frees the old name before installing the new one, so the string can be freed while a
+/// caller still holds this pointer. A caller that needs the name beyond the immediate read
+/// must copy it rather than retain the pointer.
 #[inline]
-pub fn get() -> ffi::RSConfig {
-    // SAFETY: `RSGlobalConfig` is a statically initialised C global that lives for the whole
-    // process, and `RSConfig` is `Copy`, so the value is read out without forming a reference.
-    //
-    // The read is deliberately unsynchronised, which is the one precondition this argument
-    // does not establish: `CONFIG SET` writes these fields from client threads, so the copy
-    // can race and tear. That is the behaviour of the C readers of the same fields, which
-    // this wrapper exists to replace rather than to change; removing the race needs the C
-    // side to store the fields atomically.
-    unsafe { ffi::RSGlobalConfig }
+pub fn default_scorer() -> Option<NonNull<c_char>> {
+    // SAFETY: see this module's *Safety of these reads*. Only the pointer is read here;
+    // the string it points at is not.
+    NonNull::new(unsafe { ffi::RSGlobalConfig.defaultScorer }.cast_mut())
 }

--- a/src/redisearch_rs/c_wrappers/global_config/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/global_config/src/lib.rs
@@ -12,15 +12,22 @@
 
 /// Copies the process-wide configuration.
 ///
-/// A copy rather than a `&'static ffi::RSConfig`, which would assert that nothing writes the
-/// static while it lives — `FT.CONFIG SET` does, from client threads. The read is
-/// unsynchronised, as it is on the C side, so it can tear against a concurrent write, and any
-/// pointer field can be freed by a later one.
+/// A copy rather than a `&'static `[`ffi::RSConfig`], which would assert that nothing writes
+/// the static while it lives — `CONFIG SET` does, from client threads. Any pointer field can
+/// also be freed by a later write.
 ///
-/// Take one snapshot per operation rather than one per field, so that an operation cannot
-/// observe a setting changing halfway through.
+/// Take one snapshot per operation rather than one per field: a struct copy is not atomic, so
+/// this narrows the window in which an operation sees a setting change halfway through, but
+/// does not close it.
+#[inline]
 pub fn get() -> ffi::RSConfig {
     // SAFETY: `RSGlobalConfig` is a statically initialised C global that lives for the whole
     // process, and `RSConfig` is `Copy`, so the value is read out without forming a reference.
+    //
+    // The read is deliberately unsynchronised, which is the one precondition this argument
+    // does not establish: `CONFIG SET` writes these fields from client threads, so the copy
+    // can race and tear. That is the behaviour of the C readers of the same fields, which
+    // this wrapper exists to replace rather than to change; removing the race needs the C
+    // side to store the fields atomically.
     unsafe { ffi::RSGlobalConfig }
 }

--- a/src/redisearch_rs/redis_mock/Cargo.toml
+++ b/src/redisearch_rs/redis_mock/Cargo.toml
@@ -12,6 +12,7 @@ bench = false
 
 [dependencies]
 ffi.workspace = true
+global_config.workspace = true
 tracing.workspace = true
 value.workspace = true
 redis-module.workspace = true

--- a/src/redisearch_rs/redis_mock/src/globals.rs
+++ b/src/redisearch_rs/redis_mock/src/globals.rs
@@ -18,7 +18,7 @@ pub fn is_crdt() -> bool {
 
 /// Returns the Redis server version as an integer.
 pub fn get_server_version() -> i32 {
-    global_config::get().serverVersion
+    global_config::server_version()
 }
 
 /// Returns true if the Redis server has the Scan Key API feature.

--- a/src/redisearch_rs/redis_mock/src/globals.rs
+++ b/src/redisearch_rs/redis_mock/src/globals.rs
@@ -18,9 +18,7 @@ pub fn is_crdt() -> bool {
 
 /// Returns the Redis server version as an integer.
 pub fn get_server_version() -> i32 {
-    // Safety: We access the global config, which is setup during module initialization, we readonly access the serverVersion field here.
-    // which is safe as it is never changed after initialization.
-    unsafe { ffi::RSGlobalConfig.serverVersion }
+    global_config::get().serverVersion
 }
 
 /// Returns true if the Redis server has the Scan Key API feature.

--- a/src/redisearch_rs/reducers/Cargo.toml
+++ b/src/redisearch_rs/reducers/Cargo.toml
@@ -14,6 +14,7 @@ unittest = []
 [dependencies]
 bumpalo.workspace = true
 ffi.workspace = true
+global_config.workspace = true
 indexmap = "2.14.0"
 itertools.workspace = true
 min-max-heap = "1.3.0"

--- a/src/redisearch_rs/reducers/src/collect/storage.rs
+++ b/src/redisearch_rs/reducers/src/collect/storage.rs
@@ -115,9 +115,7 @@ impl<D: Ord> Storage<D> {
             (_, Some((o, c))) => (o as usize, c as usize),
             // Without an explicit LIMIT the unranked path falls back to the
             // global cap, the ranked path to DEFAULT_LIMIT.
-            // SAFETY: `RSGlobalConfig` is the module-global config initialised
-            // once at load; we only read a single `usize` field.
-            (false, None) => (0, unsafe { ffi::RSGlobalConfig.maxAggregateResults }),
+            (false, None) => (0, global_config::get().maxAggregateResults),
             (true, None) => (0, DEFAULT_LIMIT as usize),
         };
         if sortby {

--- a/src/redisearch_rs/reducers/src/collect/storage.rs
+++ b/src/redisearch_rs/reducers/src/collect/storage.rs
@@ -115,7 +115,7 @@ impl<D: Ord> Storage<D> {
             (_, Some((o, c))) => (o as usize, c as usize),
             // Without an explicit LIMIT the unranked path falls back to the
             // global cap, the ranked path to DEFAULT_LIMIT.
-            (false, None) => (0, global_config::get().maxAggregateResults),
+            (false, None) => (0, global_config::max_aggregate_results()),
             (true, None) => (0, DEFAULT_LIMIT as usize),
         };
         if sortby {


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `global_config` (#10915) covers the settings Rust already read, but not `hideUserDataFromLog` — the flag that decides whether index, field and key names and query terms are obfuscated before they reach the log. Every one of its ~40 readers is still in C.
2. Change: adds a `hide_user_data_from_log()` accessor alongside the existing ones. It is a plain `bool` field, so it goes through the same macro and inherits the crate's shared safety argument.
3. Outcome: internal-only — nothing reads it yet. It is the prerequisite for porting a logging path to Rust without either a raw read of the static or a C helper to ask.

#### Which additional issues this PR fixes

1. MOD-17631

#### Main objects this PR modified

1. `global_config` — one new entry in the `config_accessors!` invocation.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

#### Worth a reviewer's attention

Unlike the settings already exposed, this one is not an `FT.CONFIG` knob: it is the
`hide-user-data-from-log` Redis server configuration, which `onUpdatedHideUserDataFromLogs`
mirrors into `RSGlobalConfig` from the config-change event. The doc comment says so, so that a
reader does not go looking for it in `FT.CONFIG GET`.

Stacked on #10915; review that one first, and this diff on its own is six lines.
