### PR TITLE
[MOD-17649] Fix data race on `missingFieldDict` incremental rehashing

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -664,6 +664,15 @@ static void writeMissingFieldDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx,
       iiMissingDocs = NewInvertedIndex(Index_DocIdsOnly, &index_size);
       aCtx->spec->stats.invertedSize += index_size;
       dictAdd(spec->missingFieldDict, (void*)fs->fieldName, iiMissingDocs);
+      // Complete any rehashing this insert started, else later reads on different
+      // threads could end up mutating the dict simultaneously, corrupting it.
+      //
+      // Cheap because this dict contains just IndexSpec's INDEXMISSING fields.
+      //
+      // dictRehash migrates a bounded number of buckets per call and returns
+      // non-zero while more remain, so loop until it reports done.
+      while (dictRehash(spec->missingFieldDict, 100)) {
+      }
     }
     // Add docId to inverted index
     t_docId docId = aCtx->doc->docId;


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** `spec->missingFieldDict` maps each `INDEXMISSING` field to the
   inverted index of documents lacking that field. It is read on query threads
   holding only the spec **read** lock, in two places: when an `ismissing()`
   node is evaluated to build its iterator, and again on every revalidation
   after the pipeline drops and re-takes the lock. Both go through
   `RS_dictFetchValue`, which performs an incremental rehash step whenever the
   dict is mid-rehash — so a *read* mutates the dict. A read lock admits several
   threads at once, so two concurrent `ismissing()` queries can rehash it
   simultaneously.
2. **Change:** Drain the rehash at the only point one can begin — the single
   `dictAdd` in `indexer.c` that registers a field in `missingFieldDict`, which
   runs under the spec write lock. `RS_dictExpand` is the sole function that
   starts a rehash and is reachable only from the insert path, so completing it
   there means readers never find one in progress. Draining is cheap here: the
   dict holds one entry per `INDEXMISSING` field.
3. **Outcome:** Concurrent `ismissing()` queries can no longer corrupt the
   missing-fields index. The removed failure modes range from lost or duplicated
   dict entries — wrong `ismissing()` results — to a use-after-free, since the
   final rehash step frees the old hash table while another thread may still be
   indexing into it.

**On testing:** no test accompanies this fix. Triggering it needs the dict
mid-rehash *and* two reader threads interleaving inside `_dictRehashStep`, and
there is no harness for controlling either.

#### Which additional issues this PR fixes

1. N/A

#### Main objects this PR modified

1. `src/indexer.c` — the `INDEXMISSING` indexing path: after adding a field's
   inverted index to `missingFieldDict`, drain the rehash to completion.
2. `spec->missingFieldDict` — now guaranteed fully rehashed whenever the spec
   write lock is released, so the two query-side readers never step it.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
