### PR TITLE
[MOD-17648] Remove `keysDict` null-handling test workaround from production code

### DIFF
--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -374,20 +374,8 @@ impl<'lock> IndexSpecReadGuard<'lock> {
         unsafe { TermsTrie::from_raw(self.0.terms) }
     }
 
-    /// Returns whether the keys dictionary is available.
-    ///
-    /// The keys dictionary maps TEXT terms to their inverted indexes.
-    pub const fn has_keys_dict(&self) -> bool {
-        !self.0.keysDict.is_null()
-    }
-
     /// Returns a pointer to the keys dictionary.
-    ///
-    /// # Panics
-    ///
-    /// Panics in debug builds if keys_dict is null. Use `has_keys_dict()` to check first.
-    pub fn keys_dict(&self) -> *mut ffi::dict {
-        debug_assert!(!self.0.keysDict.is_null(), "keys_dict is null");
+    pub const fn keys_dict(&self) -> *mut ffi::dict {
         self.0.keysDict
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index/term.rs
@@ -122,12 +122,6 @@ where
     /// The raw pointers inside `spec` (e.g. `keysDict`) must be valid and
     /// dereferenceable for the duration of the call.
     fn should_abort(&self, spec: &IndexSpecReadGuard) -> bool {
-        // Redis_OpenInvertedIndex() relies on keysDict to open the II.
-        // It should always be set in production flows but some tests do not set up a full spec.
-        if !spec.has_keys_dict() {
-            return false;
-        }
-
         let term = self
             .it
             .result

--- a/src/spec.c
+++ b/src/spec.c
@@ -2333,7 +2333,7 @@ void InvIndFreeCb(void *privdata, void *val) {
   InvertedIndex_Free(idx);
 }
 
-static dictType invIdxDictType = {
+dictType invIdxDictType = {
   .hashFunction = CharBuf_HashFunction,
   .keyDup = CharBuf_KeyDup,
   .valDup = NULL, // Taking and owning the InvertedIndex pointer

--- a/src/spec.h
+++ b/src/spec.h
@@ -599,6 +599,9 @@ RedisModuleString *IndexSpec_LegacyGetFormattedKey(IndexSpec *sp, const FieldSpe
  */
 void IndexSpec_MakeKeyless(IndexSpec *sp);
 
+/* The dictType used for IndexSpec.keysDict: CharBuf keys, InvertedIndex* values. */
+extern dictType invIdxDictType;
+
 /* The dictType used for IndexSpec.missingFieldDict: HiddenString keys, InvertedIndex* values. */
 extern dictType missingFieldDictType;
 

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -9,6 +9,7 @@
 
 extern "C" {
 #include "hiredis/sds.h"
+#include "util/dict.h"
 }
 
 #include "buffer/buffer.h"
@@ -636,8 +637,11 @@ TEST_F(IndexTest, testHybridVector) {
   queryParams.hnswRuntimeParams.efRuntime = max_id;
   FieldMaskOrIndex fieldMaskOrIndex = {.index_tag = FieldMaskOrIndex_Index, .index = RS_INVALID_FIELD_INDEX};
   FieldFilterContext filterCtx = {.field = fieldMaskOrIndex, .predicate = FIELD_EXPIRATION_PREDICATE_DEFAULT};
-  // Create a mock context for timeout configuration
+  // Revalidation looks up the term through the spec's keys dictionary, as it does in production.
   MockQueryEvalCtx mockQctx(max_id, max_id);
+  mockQctx.spec.keysDict = dictCreate(&invIdxDictType, nullptr);
+  CharBuf termKey = {.buf = const_cast<char *>("term"), .len = 4};
+  dictAdd(mockQctx.spec.keysDict, &termKey, w);
   // Run simple top k query.
   HybridIteratorParams hParams = {.sctx=&mockQctx.sctx,
                                   .index = index,
@@ -764,7 +768,7 @@ TEST_F(IndexTest, testHybridVector) {
   }
   hybridIt->Free(hybridIt);
 
-  InvertedIndex_Free(w);
+  dictRelease(mockQctx.spec.keysDict);
   VecSimIndex_Free(index);
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Production term revalidation contains special null handling solely because `testHybridVector` supplies an incomplete `IndexSpec` without a `keysDict`. This makes production code accommodate a test-only state while allowing the test to bypass the real inverted-index lookup.
2. Change: Remove the `keysDict` presence check and its production revalidation workaround. Initialize the test's `keysDict` and register the expected term and inverted index.
3. Outcome: Production revalidation follows the actual `IndexSpec` invariant without test-specific behavior, while the test now exercises the real dictionary lookup and index-pointer validation path.

#### Which additional issues this PR fixes

1. N/A

#### Main objects this PR modified

1. `IndexSpecReadGuard` — removes the test-driven `keysDict` presence API.
2. Term iterator revalidation — removes the null-dictionary workaround.
3. Hybrid vector C++ tests — provides the dictionary state required by production revalidation.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes