### PR TITLE
[8.8-rse] MOD-17092 FT.HYBRID: forward PARAMS/TIMEOUT from parsed state, not argv re-scan

### DIFF
--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -31,9 +31,19 @@
 #include "info/info_redis/threads/current_thread.h"
 #include "aggregate/reply_empty.h"
 #include "aggregate/aggregate_exec_common.h"
+#include "param.h"
 
 // We mainly need the resp protocol to be three in order to easily extract the "score" key from the response
 #define HYBRID_RESP_PROTOCOL_VERSION 3
+
+// Scratch buffer for formatting one numeric argument before appending it to an
+// MRCommand. 25 is the exact minimum: the widest output below, plus its NUL.
+//   %.17g  -DBL_MAX   "-1.7976931348623157e+308"  24  RRF CONSTANT, LINEAR ALPHA/BETA
+//   %lld   INT64_MIN  "-9223372036854775808"      20  TIMEOUT
+//   %zu    SIZE_MAX   "18446744073709551615"      20  WINDOW
+//   %lu    ULONG_MAX  "18446744073709551615"      20  PARAMS count
+//   %d     (literal)  "8"                          1  COMBINE argument count
+#define HYBRID_NUM_BUF_SIZE 25
 
 /**
  * Appends all SEARCH-related arguments to MR command.
@@ -234,12 +244,13 @@ static void MRCommand_appendVsim(MRCommand *xcmd, RedisModuleString **argv,
 // present) counted inside the block, so shards of any version parse it and never
 // fall back on their own (possibly different) defaults.
 static void MRCommand_appendCombine(MRCommand *xcmd, const HybridCombineWireParams *cp) {
-  if (!cp || !cp->scoringCtx) {
+  RS_ASSERT(cp != NULL);
+  if (!cp->scoringCtx) {
     return;
   }
   const HybridScoringContext *sc = cp->scoringCtx;
   const bool hasAlias = cp->scoreAlias != NULL;
-  char numBuf[32];
+  char numBuf[HYBRID_NUM_BUF_SIZE];
   const size_t numBufSize = sizeof(numBuf);
   int n;
 
@@ -276,28 +287,56 @@ static void MRCommand_appendCombine(MRCommand *xcmd, const HybridCombineWirePara
   }
 }
 
-// The function transforms FT.HYBRID index SEARCH query VSIM field vector
-// into _FT.HYBRID index SEARCH query VSIM field vector WITHCURSOR
-// _NUM_SSTRING _INDEX_PREFIXES ...
-// stores the index of the K value argument in the MRCommand (for later
-// modification by the command modifier callback in SHARD_K_RATIO optimization).
+/**
+ * Reconstructs the PARAMS clause from the resolved parameter dictionary rather
+ * than re-scanning argv for the "PARAMS" keyword. The emitted order is the
+ * dict-iteration order, which is not necessarily the client's original argument
+ * order; this is safe because parameters are referenced by name.
+ *
+ * @param xcmd - destination MR command to append arguments to
+ * @param params - resolved parameter dictionary (key: name, value: RedisModuleString)
+ */
+static void MRCommand_appendParams(MRCommand *xcmd, dict *params) {
+  if (!params) {
+    return;
+  }
+  unsigned long n = dictSize(params);
+  if (n == 0) {
+    return;
+  }
+  char numBuf[HYBRID_NUM_BUF_SIZE];
+  MRCommand_Append(xcmd, "PARAMS", strlen("PARAMS"));
+  int len = snprintf(numBuf, sizeof(numBuf), "%lu", n * 2);
+  MRCommand_Append(xcmd, numBuf, len);
+
+  dictIterator *it = dictGetIterator(params);
+  const dictEntry *entry;
+  while ((entry = dictNext(it))) {
+    const char *name = dictGetKey(entry);
+    MRCommand_Append(xcmd, name, strlen(name));
+    const RedisModuleString *value = dictGetVal(entry);
+    size_t valueLen;
+    const char *valueData = RedisModule_StringPtrLen(value, &valueLen);
+    MRCommand_Append(xcmd, valueData, valueLen);
+  }
+  dictReleaseIterator(it);
+}
+
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
-                            ProfileOptions profileOptions,
-                            bool sendExplainScore,
-                            const HybridCombineWireParams *combineParams,
-                            MRCommand *xcmd, arrayof(char*) serialized,
-                            IndexSpec *sp, int *outKArgIndex) {
+                                  const HybridShardWireParams *shardWireParams,
+                                  MRCommand *xcmd,
+                                  arrayof(char *) serialized, IndexSpec *sp, int *outKArgIndex) {
+  RS_ASSERT(shardWireParams != NULL);
   RS_ASSERT(outKArgIndex != NULL);
-  int argOffset;
   const char *index_name = RedisModule_StringPtrLen(argv[1], NULL);
 
   int cmdArgCount = 2;
   const char *cmdArgs[5] = {"_FT.HYBRID", index_name};
 
-  if (profileOptions != EXEC_NO_FLAGS) {
+  if (shardWireParams->profileOptions != EXEC_NO_FLAGS) {
     cmdArgs[0] = "_FT.PROFILE";
     cmdArgs[cmdArgCount++] = "HYBRID";
-    if (profileOptions & EXEC_WITH_PROFILE_LIMITED) {
+    if (shardWireParams->profileOptions & EXEC_WITH_PROFILE_LIMITED) {
       cmdArgs[cmdArgCount++] = "LIMITED";
     }
     cmdArgs[cmdArgCount++] = "QUERY";
@@ -324,7 +363,7 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
   // each shard falling back on its own (possibly changed) defaults. This also
   // normalizes the positional YIELD_SCORE_AS form and a zero argument count
   // into the counted form that all shard versions accept.
-  MRCommand_appendCombine(xcmd, combineParams);
+  MRCommand_appendCombine(xcmd, &shardWireParams->combine);
 
   if (serialized) {
     for (size_t ii = 0; ii < array_len(serialized); ++ii) {
@@ -333,49 +372,20 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
     }
   }
 
-  // Add PARAMS arguments if present
-  argOffset = RMUtil_ArgIndex("PARAMS", argv + vsimOffset, argc - vsimOffset);
-  argOffset = argOffset != -1 ? argOffset + vsimOffset : -1;
-  if (argOffset != -1) {
-    long long nargs;
-    int rc = RedisModule_StringToLongLong(argv[argOffset + 1], &nargs);
+  // Reconstruct the PARAMS clause from the resolved parameter dictionary.
+  MRCommand_appendParams(xcmd, shardWireParams->params);
 
-    // PARAMS keyword and count - treat as string
-    MRCommand_AppendRstr(xcmd, argv[argOffset]);
-    MRCommand_AppendRstr(xcmd, argv[argOffset + 1]);
-
-    // append params string including PARAMS keyword and nargs
-    for (int i = 2; i < nargs + 2; ++i) {
-      if (i % 2 == 0) {
-        // Parameter name - treat as string
-        MRCommand_AppendRstr(xcmd, argv[argOffset + i]);
-      } else {
-        // Parameter value - could be binary, treat as binary
-        size_t valueLen;
-        const char *valueData = RedisModule_StringPtrLen(argv[argOffset + i], &valueLen);
-        MRCommand_Append(xcmd, valueData, valueLen);
-      }
-    }
-  }
-
-  // check for timeout argument and append it to the command.
-  // If TIMEOUT exists, it was already validated at AREQ_Compile.
-  argOffset = RMUtil_ArgIndex("TIMEOUT", argv, argc);
-  if (argOffset != -1) {
-    MRCommand_AppendRstr(xcmd, argv[argOffset]);
-    MRCommand_AppendRstr(xcmd, argv[argOffset + 1]);
-  }
-
-  // Add DIALECT arguments if present
-  argOffset = RMUtil_ArgIndex("DIALECT", argv, argc);
-  if (argOffset != -1) {
-    MRCommand_AppendRstr(xcmd, argv[argOffset]);
-    MRCommand_AppendRstr(xcmd, argv[argOffset + 1]);
+  // Forward the client's query timeout when TIMEOUT was set.
+  if (shardWireParams->forwardTimeout) {
+    char numBuf[HYBRID_NUM_BUF_SIZE];
+    MRCommand_Append(xcmd, "TIMEOUT", strlen("TIMEOUT"));
+    int len = snprintf(numBuf, sizeof(numBuf), "%lld", shardWireParams->timeoutMS);
+    MRCommand_Append(xcmd, numBuf, len);
   }
 
   // Forward EXPLAINSCORE so the shard's text scorer produces an RSScoreExplain
   // tree and the shard's merger wraps it.
-  if (sendExplainScore) {
+  if (shardWireParams->sendExplainScore) {
     MRCommand_Append(xcmd, "EXPLAINSCORE", strlen("EXPLAINSCORE"));
   }
 
@@ -724,14 +734,20 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
     setupCoordinatorArrangeSteps(hreq->requests[SEARCH_INDEX], hreq->requests[VECTOR_INDEX], &hybridParams);
     RLookup *lookups[HYBRID_REQUEST_NUM_SUBQUERIES] = {0};
 
-    // Capture the resolved COMBINE parameters now, before BuildDistributedPipeline
-    // hands scoringCtx ownership to the merger and nulls the local pointer. The
-    // scoring context object itself is kept alive by the merger, so borrowing it
-    // here is safe. Used to reconstruct an old-shard-compatible COMBINE clause
-    // when building the per-shard command below.
-    HybridCombineWireParams combineParams = {
-        .scoringCtx = hybridParams.scoringCtx,
-        .scoreAlias = hybridParams.aggregationParams.common.scoreAlias,
+    // Capture the parsed state forwarded to the shards, used to build the
+    // per-shard command below. This must happen here, before
+    // BuildDistributedPipeline hands scoringCtx ownership to the merger and nulls
+    // the local pointer: `combine` reconstructs an old-shard-compatible COMBINE
+    // clause from it. The scoring context object itself is kept alive by the
+    // merger, so borrowing it here is safe.
+    HybridShardWireParams shardWireParams = {
+        .profileOptions = profileOptions,
+        .sendExplainScore = (hreq->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) != 0,
+        .combine = {.scoringCtx = hybridParams.scoringCtx,
+                    .scoreAlias = hybridParams.aggregationParams.common.scoreAlias},
+        .params = cmd.search->searchopts.params,
+        .forwardTimeout = cmd.timeoutSpecified,
+        .timeoutMS = cmd.clientTimeoutMS,
     };
 
     arrayof(char*) serialized = HybridRequest_BuildDistributedPipeline(hreq, &hybridParams, lookups, status);
@@ -740,11 +756,10 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq,
       return REDISMODULE_ERR;
     }
 
-    // Construct the command string
+    // Construct the command string.
     MRCommand xcmd;
-    bool sendExplainScore = (hreq->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) != 0;
-    HybridRequest_buildMRCommand(argv, argc, profileOptions, sendExplainScore,
-                                 &combineParams, &xcmd, serialized, sp, &hreq->kArgIndex);
+    HybridRequest_buildMRCommand(argv, argc, &shardWireParams, &xcmd, serialized, sp,
+                                 &hreq->kArgIndex);
 
     xcmd.protocol = HYBRID_RESP_PROTOCOL_VERSION;
     xcmd.forCursor = hreq->reqflags & QEXEC_F_IS_CURSOR;

--- a/src/coord/hybrid/dist_hybrid.h
+++ b/src/coord/hybrid/dist_hybrid.h
@@ -40,13 +40,38 @@ int DistHybridTimeoutFailCallback(RedisModuleCtx *ctx, RedisModuleString **argv,
 int DistHybridTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int DistHybridReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
-// For testing purposes
+struct dict;  // forward decl (see util/dict/dict.h): the resolved PARAMS dict
+
+// Coordinator-resolved state that HybridRequest_buildMRCommand forwards to the
+// shards.
+typedef struct {
+  ProfileOptions profileOptions;
+  bool sendExplainScore;
+  HybridCombineWireParams combine;
+  // Resolved parameter dictionary, or NULL when the client supplied no PARAMS.
+  struct dict *params;
+  // TIMEOUT forwarding: when forwardTimeout is true, TIMEOUT <timeoutMS> is
+  // appended.
+  bool forwardTimeout;
+  long long timeoutMS;
+} HybridShardWireParams;
+
+// Builds the per-shard MR command from the coordinator's parsed hybrid request.
+// The function transforms
+//   FT.HYBRID index SEARCH query VSIM field vector
+// into
+//   _FT.HYBRID index SEARCH query VSIM field vector WITHCURSOR _NUM_SSTRING
+//   _INDEX_PREFIXES ...
+// and stores the index of the K value argument in the MRCommand (via
+// outKArgIndex) for later modification by the command modifier callback in the
+// SHARD_K_RATIO optimization.
+//
+// argv/argc are the raw client command; `shardWireParams` (required, non-NULL) carries the
+// parsed state to forward. DIALECT is never forwarded (FT.HYBRID rejects it at
+// parse time).
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
-                            ProfileOptions profileOptions,
-                            bool sendExplainScore,
-                            const HybridCombineWireParams *combineParams,
-                            MRCommand *xcmd, arrayof(char*) serialized,
-                            IndexSpec *sp, int *outKArgIndex);
+                                  const HybridShardWireParams *shardWireParams, MRCommand *xcmd,
+                                  arrayof(char *) serialized, IndexSpec *sp, int *outKArgIndex);
 
 #ifdef __cplusplus
 }

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -861,6 +861,12 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
     goto error;
   }
 
+  // Record whether TIMEOUT was explicitly given, and capture the client's value
+  // BEFORE the foreground-timeout cap below, so the coordinator can forward the
+  // exact client timeout to shards without re-scanning argv.
+  parsedCmdCtx->timeoutSpecified = (hybridParseCtx.specifiedArgs & SPECIFIED_ARG_TIMEOUT) != 0;
+  parsedCmdCtx->clientTimeoutMS = parsedCmdCtx->reqConfig->queryTimeoutMS;
+
   // Cap the effective query timeout to search-_max-foreground-timeout-limit
   // when the limit is active. The hybrid request shares a single reqConfig
   // that is later copied into both subqueries through copyHybridConfigToSubquery.

--- a/src/hybrid/parse_hybrid.h
+++ b/src/hybrid/parse_hybrid.h
@@ -37,6 +37,10 @@ typedef struct ParseHybridCommandCtx {
     RequestConfig* reqConfig;
     CursorConfig* cursorConfig;
     rs_wall_clock_ns_t *coordDispatchTime; // Coordinator dispatch time for internal commands
+
+    // Whether the client explicitly supplied TIMEOUT, and the value it gave.
+    bool timeoutSpecified;
+    long long clientTimeoutMS;
 } ParseHybridCommandCtx;
 
 // Function for parsing hybrid command arguments - exposed for testing

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -15,12 +15,117 @@
 
 #include "dist_hybrid.h"
 #include "hybrid/hybrid_scoring.h"
+#include "param.h"
 
 #include <string>
 #include <string_view>
 #include <vector>
+#include <set>
+#include <utility>
 
 #define TEST_BLOB_DATA "AQIDBAUGBwgJCg=="
+
+using ParamList = std::vector<std::pair<std::string, std::string>>;
+using PairSet = std::set<std::pair<std::string, std::string>>;
+
+// Copy an MRCommand's args into a binary-safe token vector (each token carries
+// its explicit length, so embedded NULs survive).
+static std::vector<std::string> toTokens(const MRCommand *cmd) {
+  std::vector<std::string> toks;
+  toks.reserve(cmd->num);
+  for (int i = 0; i < cmd->num; i++) toks.emplace_back(cmd->strs[i], cmd->lens[i]);
+  return toks;
+}
+
+// Count output tokens exactly matching `tok` (case-insensitive).
+static int countTok(const std::vector<std::string> &toks, std::string_view tok) {
+  int n = 0;
+  for (const auto &t : toks) {
+    if (t.size() == tok.size() && strncasecmp(t.data(), tok.data(), t.size()) == 0) n++;
+  }
+  return n;
+}
+
+// Collect the {name, value} pairs of the PARAMS clause whose "PARAMS" keyword is
+// at toks[start]; toks[start + 1] is the declared token count (2 * #pairs).
+// *outCount, when non-NULL, receives that count. Values are copied verbatim, so
+// a token vector built from length-delimited wire data stays binary-safe.
+// Centralizes the "PARAMS n k v k v ..." decoding shared by the assertions below.
+static PairSet collectParamsPairs(const std::vector<std::string> &toks, size_t start,
+                                  long *outCount) {
+  long count = (start + 1 < toks.size()) ? atol(toks[start + 1].c_str()) : 0;
+  if (outCount) *outCount = count;
+  PairSet pairs;
+  for (long j = 0; j + 1 < count && start + 3 + (size_t)j < toks.size(); j += 2) {
+    pairs.emplace(toks[start + 2 + j], toks[start + 3 + j]);
+  }
+  return pairs;
+}
+
+// Assert the built command carries exactly the PARAMS clause described by
+// `expected` (as an order-independent set of pairs, with count == 2*N), or no
+// PARAMS clause at all when `expected` is empty.
+static void expectParamsBlock(const std::vector<std::string> &toks, const ParamList &expected) {
+  bool found = false;
+  long count = -1;
+  PairSet got;
+  for (size_t i = 0; i + 1 < toks.size(); i++) {
+    if (toks[i] == "PARAMS") {
+      found = true;
+      got = collectParamsPairs(toks, i, &count);
+      break;
+    }
+  }
+  if (expected.empty()) {
+    EXPECT_FALSE(found) << "expected no PARAMS clause";
+    return;
+  }
+  EXPECT_TRUE(found) << "expected a PARAMS clause";
+  EXPECT_EQ(count, (long)expected.size() * 2) << "PARAMS count must be 2 * number of pairs";
+  PairSet want(expected.begin(), expected.end());
+  EXPECT_EQ(got, want);
+}
+
+// Return the token following the first occurrence of `clause`, or "" if absent.
+static std::string valueAfter(const std::vector<std::string> &toks, const char *clause) {
+  for (size_t i = 0; i + 1 < toks.size(); i++) {
+    if (toks[i] == clause) return toks[i + 1];
+  }
+  return "";
+}
+
+// Verify the reconstructed PARAMS and TIMEOUT clauses on an output token stream.
+// A parameter value may itself spell "TIMEOUT"; such occurrences live inside the
+// PARAMS block and must not be counted as the top-level clause, so the expected
+// TIMEOUT token count is (forwarded ? 1 : 0) + (# param values == TIMEOUT).
+static void expectParamsAndTimeout(const std::vector<std::string> &toks,
+                                   const ParamList &expectedPairs,
+                                   bool forwardTimeout, long long timeoutMS) {
+  expectParamsBlock(toks, expectedPairs);
+  int timeoutInParams = 0;
+  for (const auto &[name, value] : expectedPairs) {
+    if (strcasecmp(value.c_str(), "TIMEOUT") == 0) timeoutInParams++;
+  }
+  EXPECT_EQ(countTok(toks, "TIMEOUT"), (forwardTimeout ? 1 : 0) + timeoutInParams);
+  if (forwardTimeout && timeoutInParams == 0) {
+    EXPECT_EQ(valueAfter(toks, "TIMEOUT"), std::to_string(timeoutMS));
+  }
+}
+
+// Build a parameter dict from a flat name,value,... list, recording the
+// expected pairs. Returns NULL for an empty list (the no-PARAMS case). The
+// returned dict is owned by the caller (free with Param_DictFree).
+dict *makeParamsDict(const std::vector<std::string>& paramsKV, ParamList &expectedPairs) {
+  dict *params = paramsKV.empty() ? nullptr : Param_DictCreate();
+  QueryError status = QueryError_Default();
+  for (size_t i = 0; i + 1 < paramsKV.size(); i += 2) {
+    const std::string &name = paramsKV[i];
+    const std::string &value = paramsKV[i + 1];
+    Param_DictAdd(params, name.c_str(), value.data(), value.size(), &status);
+    expectedPairs.emplace_back(name, value);
+  }
+  return params;
+}
 
 // Format a double exactly as MRCommand_appendCombine does for the wire
 // (round-trip-safe "%.17g"). Tests use this so expectations can be written
@@ -82,12 +187,46 @@ static HybridCombineWireParams linearWireParams(HybridScoringContext *sc, double
   return HybridCombineWireParams{sc, alias};
 }
 
+// Advance `ii` past a client-supplied COMBINE clause - COMBINE + method + count
+// + N args, plus a trailing positional YIELD_SCORE_AS <alias>.
+// No-op when the client supplied no COMBINE.
+static void skipClientCombineClause(const std::vector<const char *> &inputArgs, size_t &ii) {
+  if (strcasecmp(inputArgs[ii], "COMBINE") != 0) {
+    return;
+  }
+  ii += 2;                             // COMBINE, method
+  const long n = atol(inputArgs[ii]);  // count
+  ii += 1 + (size_t)n;                 // count token + its args
+  if (ii < inputArgs.size() && strcasecmp(inputArgs[ii], "YIELD_SCORE_AS") == 0) {
+    ii += 2;                           // positional YIELD_SCORE_AS <alias>
+  }
+}
+
+// Assert the output PARAMS clause at `oi` carries exactly the pairs of the input
+// PARAMS clause at `ii`, then advance both indices past their clause.
+static void verifyParamsClause(const MRCommand *xcmd, const std::vector<const char *> &inputArgs,
+                               size_t &ii, int &oi) {
+  const std::vector<std::string> inToks(inputArgs.begin(), inputArgs.end());
+  long inCount = 0;
+  PairSet want = collectParamsPairs(inToks, ii, &inCount);
+  ii += 2 + (size_t)inCount;
+
+  EXPECT_LT(oi + 1, xcmd->num) << "output should carry a reconstructed PARAMS clause";
+  EXPECT_STREQ(xcmd->strs[oi], "PARAMS") << "PARAMS clause expected at output index " << oi;
+  long outCount = 0;
+  PairSet got = collectParamsPairs(toTokens(xcmd), oi, &outCount);
+  EXPECT_EQ(outCount, inCount) << "PARAMS count must equal 2 * number of parsed params";
+  EXPECT_EQ(got, want)
+      << "reconstructed PARAMS pairs must match the client's (order-independent)";
+  oi += 2 + (size_t)outCount;
+}
+
 // Assert every input arg is preserved by position in the output. The
 // coordinator always inserts one reconstructed COMBINE clause after the VSIM
 // block; the oracle spots it in the output (COMBINE followed by a scoring
 // method - a PARAMS-value COMBINE never is) and, if the client supplied its own
 // COMBINE clause, drops that clause from the input side since the reconstructed
-// form replaces it. Returns the output index just past the matched prefix.
+// form replaces it.
 static int verifyArgsPreservedWithReconstructedCombine(
     const MRCommand *xcmd, const std::vector<const char *> &inputArgs,
     const HybridCombineWireParams *cp) {
@@ -107,22 +246,17 @@ static int verifyArgsPreservedWithReconstructedCombine(
         oi++;
       }
       reconstructedMatched = true;
-      // If the client supplied its own COMBINE clause at this position, drop it
-      // from the input stream: COMBINE + method + count + N args.
-      if (strcasecmp(inputArgs[ii], "COMBINE") == 0) {
-        ii += 2;                          // COMBINE, method
-        long n = atol(inputArgs[ii]);     // count
-        ii += 1 + (size_t)n;              // count token + its args
-        if (ii < inputArgs.size() && strcasecmp(inputArgs[ii], "YIELD_SCORE_AS") == 0) {
-          ii += 2;                        // positional YIELD_SCORE_AS <alias>
-        }
-      }
-      continue;
+      skipClientCombineClause(inputArgs, ii);
+    } else if (strcasecmp(inputArgs[ii], "PARAMS") == 0) {
+      verifyParamsClause(xcmd, inputArgs, ii, oi);
+    } else {
+      EXPECT_STREQ(xcmd->strs[oi], inputArgs[ii])
+          << "Argument at input index " << ii << " should be preserved";
+      EXPECT_EQ(xcmd->lens[oi], strlen(inputArgs[ii]))
+          << "Recorded length at output index " << oi << " should match the arg bytes";
+      oi++;
+      ii++;
     }
-    EXPECT_STREQ(xcmd->strs[oi], inputArgs[ii])
-        << "Argument at input index " << ii << " should be preserved";
-    oi++;
-    ii++;
   }
   return oi;
 }
@@ -226,15 +360,20 @@ protected:
         // Borrow the resolved scoring context (as the coordinator does before
         // the merger takes ownership) so the reconstructed COMBINE clause is
         // forwarded to the shard.
-        HybridCombineWireParams combineParams{hybridParams.scoringCtx,
-                                              hybridParams.aggregationParams.common.scoreAlias};
+        HybridShardWireParams shardWireParams = {};
+        shardWireParams.combine = HybridCombineWireParams{
+            hybridParams.scoringCtx,
+            hybridParams.aggregationParams.common.scoreAlias
+        };
+        shardWireParams.params = cmd.search->searchopts.params;
+        shardWireParams.forwardTimeout = cmd.timeoutSpecified;
+        shardWireParams.timeoutMS = cmd.clientTimeoutMS;
 
         // Build MR command - now returns kArgIndex instead of calculating effectiveK
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, &combineParams, &xcmd,
-                                     nullptr, testIndexSpec, &kArgIndex);
+        HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr,
+                                     testIndexSpec, &kArgIndex);
 
         // Verify the command was built correctly
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
@@ -310,14 +449,19 @@ protected:
             return out;
         }
 
-        HybridCombineWireParams cp{hybridParams.scoringCtx,
-                                   hybridParams.aggregationParams.common.scoreAlias};
+        HybridShardWireParams shardWireParams = {};
+        shardWireParams.combine = HybridCombineWireParams{
+            hybridParams.scoringCtx,
+            hybridParams.aggregationParams.common.scoreAlias
+        };
+        shardWireParams.params = cmd.search->searchopts.params;
+        shardWireParams.forwardTimeout = cmd.timeoutSpecified;
+        shardWireParams.timeoutMS = cmd.clientTimeoutMS;
 
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, &cp, &xcmd,
-                                     nullptr, testIndexSpec, &kArgIndex);
+        HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr,
+                                     testIndexSpec, &kArgIndex);
 
         // Assert the parse-driven path also preserves every non-COMBINE arg by
         // position (this is what verifies the PARAMS block - including any
@@ -326,7 +470,7 @@ protected:
         // additionally pins the extracted clause against a literal vector, so the
         // two oracles stay independent.
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
-        verifyArgsPreservedWithReconstructedCombine(&xcmd, inputArgs, &cp);
+        verifyArgsPreservedWithReconstructedCombine(&xcmd, inputArgs, &shardWireParams.combine);
 
         for (int i = 0; i < xcmd.num; i++) {
             if (xcmd.lens[i] == strlen("COMBINE") &&
@@ -365,75 +509,107 @@ protected:
     // Helper function to test command transformation
     void testCommandTransformationWithoutIndexSpec(const std::vector<const char*>& inputArgs,
                                                    const HybridCombineWireParams *combineParams = nullptr) {
-        // Access the global NumShards variable
-        extern size_t NumShards;
-
-        // Convert vector to array for ArgvList constructor
-        std::vector<const char*> argsWithNull = inputArgs;
-        argsWithNull.push_back(nullptr);  // ArgvList expects null-terminated
-
-        // Create ArgvList from input
-        RMCK::ArgvList args(ctx, argsWithNull.data(), inputArgs.size());
-
-        // Build MR command
-        MRCommand xcmd;
-        int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, combineParams, &xcmd,
-                                     nullptr, nullptr, &kArgIndex);
-
-        // Verify transformation: FT.HYBRID -> _FT.HYBRID
-        EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
-
-        // Verify original args are preserved, with the COMBINE clause replaced by
-        // its reconstructed (old-shard-compatible) form.
-        verifyArgsPreservedWithReconstructedCombine(&xcmd, inputArgs, combineParams);
-
-        // Verify WITHCURSOR, WITHSCORES, _NUM_SSTRING, _COORD_DISPATCH_TIME are added at the end
-        // Note: _COORD_DISPATCH_TIME and its placeholder value (2 args) are added after _NUM_SSTRING
-        EXPECT_STREQ(xcmd.strs[xcmd.num - 7], "WITHCURSOR") << "WITHCURSOR should be seventh to last";
-        EXPECT_STREQ(xcmd.strs[xcmd.num - 6], "WITHSCORES") << "WITHSCORES should be sixth to last";
-        EXPECT_STREQ(xcmd.strs[xcmd.num - 5], "_NUM_SSTRING") << "_NUM_SSTRING should be fifth to last";
-        EXPECT_STREQ(xcmd.strs[xcmd.num - 2], "_COORD_DISPATCH_TIME") << "_COORD_DISPATCH_TIME should be second to last";
-        EXPECT_STREQ(xcmd.strs[xcmd.num - 1], "") << "Dispatch time placeholder should be last (empty)";
-
-        MRCommand_Free(&xcmd);
+        testCommandTransformationWithoutIndexSpecWithParams(inputArgs, /*paramsKV=*/{},
+                                                            /*timeoutMS=*/-1, combineParams);
     }
 
     // Helper function to test command transformation
     void testCommandTransformationWithIndexSpec(const std::vector<const char*>& inputArgs,
                                                 const HybridCombineWireParams *combineParams = nullptr) {
-      // Access the global NumShards variable
-      extern size_t NumShards;
+        testCommandTransformationWithIndexSpecAndParams(inputArgs, /*paramsKV=*/{},
+                                                        /*timeoutMS=*/-1, combineParams);
+    }
 
-      // Convert vector to array for ArgvList constructor
-      std::vector<const char*> argsWithNull = inputArgs;
-      argsWithNull.push_back(nullptr);  // ArgvList expects null-terminated
+  void testCommandTransformationWithoutIndexSpecWithParams(
+          const std::vector<const char*>& baseArgs,
+          const std::vector<std::string>& paramsKV,
+          long long timeoutMS,
+          const HybridCombineWireParams *combineParams = nullptr) {
+      ASSERT_EQ(paramsKV.size() % 2, 0u) << "paramsKV must be name,value pairs";
 
-      // Create ArgvList from input
-      RMCK::ArgvList args(ctx, argsWithNull.data(), inputArgs.size());
+      ParamList expectedPairs;
+      dict *params = makeParamsDict(paramsKV, expectedPairs);
+      const bool forwardTimeout = timeoutMS >= 0;
+
+      std::vector<const char*> argsWithNull = baseArgs;
+      argsWithNull.push_back(nullptr);
+      RMCK::ArgvList args(ctx, argsWithNull.data(), baseArgs.size());
+
+      HybridShardWireParams shardWireParams = {};
+      if (combineParams) shardWireParams.combine = *combineParams;
+      shardWireParams.params = params;
+      shardWireParams.forwardTimeout = forwardTimeout;
+      shardWireParams.timeoutMS = forwardTimeout ? timeoutMS : 0;
+
+      MRCommand xcmd;
+      int kArgIndex = -1;
+      HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr, nullptr,
+                                   &kArgIndex);
+      if (params) Param_DictFree(params);
+
+      // FT.HYBRID -> _FT.HYBRID, and the base args (no PARAMS/TIMEOUT) preserved
+      // with the COMBINE clause reconstructed.
+      EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
+      verifyArgsPreservedWithReconstructedCombine(&xcmd, baseArgs, combineParams);
+
+      // Check the reconstructed PARAMS/TIMEOUT clauses on the token stream.
+      std::vector<std::string> toks = toTokens(&xcmd);
+      expectParamsAndTimeout(toks, expectedPairs, forwardTimeout, timeoutMS);
+
+      // The fixed trailing block is unaffected by PARAMS/TIMEOUT length.
+      EXPECT_STREQ(xcmd.strs[xcmd.num - 7], "WITHCURSOR") << "WITHCURSOR should be seventh to last";
+      EXPECT_STREQ(xcmd.strs[xcmd.num - 6], "WITHSCORES") << "WITHSCORES should be sixth to last";
+      EXPECT_STREQ(xcmd.strs[xcmd.num - 5], "_NUM_SSTRING") << "_NUM_SSTRING should be fifth to last";
+      EXPECT_STREQ(xcmd.strs[xcmd.num - 2], "_COORD_DISPATCH_TIME") << "_COORD_DISPATCH_TIME should be second to last";
+      EXPECT_STREQ(xcmd.strs[xcmd.num - 1], "") << "Dispatch time placeholder should be last (empty)";
+
+      MRCommand_Free(&xcmd);
+  }
+
+  void testCommandTransformationWithIndexSpecAndParams(
+          const std::vector<const char*>& baseArgs,
+          const std::vector<std::string>& paramsKV,
+          long long timeoutMS,
+          const HybridCombineWireParams *combineParams = nullptr) {
+      ASSERT_EQ(paramsKV.size() % 2, 0u) << "paramsKV must be name,value pairs";
+
+      ParamList expectedPairs;
+      dict *params = makeParamsDict(paramsKV, expectedPairs);
+      const bool forwardTimeout = timeoutMS >= 0;
+
+      std::vector<const char*> argsWithNull = baseArgs;
+      argsWithNull.push_back(nullptr);
+      RMCK::ArgvList args(ctx, argsWithNull.data(), baseArgs.size());
       RefManager *ism = createSpec(ctx, {"prefix1", "prefix2"});
-
-      // Get the IndexSpec from the RefManager
       IndexSpec *sp = get_spec(ism);
       ASSERT_NE(sp, nullptr) << "IndexSpec should be accessible from RefManager";
       ASSERT_NE(sp->rule, nullptr) << "IndexSpec should have a rule";
       ASSERT_NE(sp->rule->prefixes, nullptr) << "IndexSpec rule should have prefixes";
       ASSERT_EQ(array_len(sp->rule->prefixes), 2) << "IndexSpec rule should have 2 prefixes";
 
-      // Build MR command (not testing SHARD_K_RATIO here)
+      HybridShardWireParams shardWireParams = {};
+      if (combineParams) shardWireParams.combine = *combineParams;
+      shardWireParams.params = params;
+      shardWireParams.forwardTimeout = forwardTimeout;
+      shardWireParams.timeoutMS = forwardTimeout ? timeoutMS : 0;
+
       MRCommand xcmd;
       int kArgIndex = -1;
-      HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                   /*sendExplainScore=*/false, combineParams, &xcmd,
-                                   nullptr, sp, &kArgIndex);
-      // Verify transformation: FT.HYBRID -> _FT.HYBRID
+      HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr, sp,
+                                   &kArgIndex);
+      if (params) Param_DictFree(params);
+
+      // FT.HYBRID -> _FT.HYBRID, base args preserved, COMBINE reconstructed.
       EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
-      // Verify original args are preserved, with the COMBINE clause replaced by
-      // its reconstructed (old-shard-compatible) form.
-      verifyArgsPreservedWithReconstructedCombine(&xcmd, inputArgs, combineParams);
-      // Verify WITHCURSOR, WITHSCORES, _NUM_SSTRING, SLOTS, _COORD_DISPATCH_TIME, _INDEX_PREFIXES, and prefixes are added at the end
-      // Order: ... WITHCURSOR WITHSCORES _NUM_SSTRING _SLOTS <slots_blob> _COORD_DISPATCH_TIME <placeholder> _INDEX_PREFIXES 2 prefix1 prefix2
+      verifyArgsPreservedWithReconstructedCombine(&xcmd, baseArgs, combineParams);
+
+      // PARAMS/TIMEOUT are emitted before the spec trailing block, so they are
+      // asserted the same way regardless of the spec.
+      std::vector<std::string> toks = toTokens(&xcmd);
+      expectParamsAndTimeout(toks, expectedPairs, forwardTimeout, timeoutMS);
+
+      // Spec-dependent trailing block:
+      // ... WITHCURSOR WITHSCORES _NUM_SSTRING _SLOTS <blob> _COORD_DISPATCH_TIME <placeholder> _INDEX_PREFIXES 2 prefix1 prefix2
       EXPECT_STREQ(xcmd.strs[xcmd.num - 11], "WITHCURSOR") << "WITHCURSOR should be 11th to last";
       EXPECT_STREQ(xcmd.strs[xcmd.num - 10], "WITHSCORES") << "WITHSCORES should be 10th to last";
       EXPECT_STREQ(xcmd.strs[xcmd.num - 9], "_NUM_SSTRING") << "_NUM_SSTRING should be 9th to last";
@@ -446,7 +622,6 @@ protected:
       EXPECT_STREQ(xcmd.strs[xcmd.num - 2], "prefix1") << "First prefix should be 2nd to last";
       EXPECT_STREQ(xcmd.strs[xcmd.num - 1], "prefix2") << "Second prefix should be last";
 
-      // Clean up
       MRCommand_Free(&xcmd);
       freeSpec(ism);
   }
@@ -462,44 +637,27 @@ TEST_F(HybridBuildMRCommandTest, testBasicCommandTransformation) {
     });
 }
 
-// Test command with PARAMS
+// Test command with PARAMS (supplied separately, as parse would produce them).
 TEST_F(HybridBuildMRCommandTest, testCommandWithParams) {
-    testCommandTransformationWithoutIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-        "VSIM", "@vector_field", "$BLOB",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA
-    });
-    testCommandTransformationWithIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-        "VSIM", "@vector_field", "$BLOB",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA
-    });
+    const std::vector<const char*> baseArgs = {
+        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)", "VSIM", "@vector_field", "$BLOB"};
+    const std::vector<std::string> paramsKV = {"param1", "hello", "BLOB", TEST_BLOB_DATA};
+    testCommandTransformationWithoutIndexSpecWithParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
+    testCommandTransformationWithIndexSpecAndParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
 }
 
-// Test command with TIMEOUT
+// Test command with TIMEOUT (no params).
 TEST_F(HybridBuildMRCommandTest, testCommandWithTimeout) {
-    testCommandTransformationWithoutIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "hello",
-        "VSIM", "@vector_field", TEST_BLOB_DATA,
-        "TIMEOUT", "5000"
-    });
-    testCommandTransformationWithIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "hello",
-        "VSIM", "@vector_field", TEST_BLOB_DATA,
-        "TIMEOUT", "5000"
-    });
+    const std::vector<const char*> baseArgs = {
+        "FT.HYBRID", "test_idx", "SEARCH", "hello", "VSIM", "@vector_field", TEST_BLOB_DATA};
+    testCommandTransformationWithoutIndexSpecWithParams(baseArgs, /*paramsKV=*/{}, /*timeoutMS=*/5000);
+    testCommandTransformationWithIndexSpecAndParams(baseArgs, /*paramsKV=*/{}, /*timeoutMS=*/5000);
 }
 
-// Test command with DIALECT
-TEST_F(HybridBuildMRCommandTest, testCommandWithDialect) {
-    testCommandTransformationWithoutIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "hello",
-        "VSIM", "@vector_field", TEST_BLOB_DATA,
-        "DIALECT", "2"
-    });
-}
+// Note: there is no DIALECT test - FT.HYBRID rejects DIALECT at parse time, so
+// it is never forwarded to shards
 
-// Test command with DIALECT
+// Test command with COMBINE
 TEST_F(HybridBuildMRCommandTest, testCommandWithCombine) {
     HybridScoringContext sc = {};
     double w[2];
@@ -507,14 +665,12 @@ TEST_F(HybridBuildMRCommandTest, testCommandWithCombine) {
     testCommandTransformationWithoutIndexSpec({
         "FT.HYBRID", "test_idx", "SEARCH", "hello",
         "VSIM", "@vector_field", TEST_BLOB_DATA, "FILTER", "@tag:{invalid_tag}",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "DIALECT", "2"
+        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3"
     }, &cp);
     testCommandTransformationWithIndexSpec({
         "FT.HYBRID", "test_idx", "SEARCH", "hello",
         "VSIM", "@vector_field", TEST_BLOB_DATA, "FILTER", "@tag:{invalid_tag}",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "DIALECT", "2"
+        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3"
     }, &cp);
 }
 
@@ -568,48 +724,28 @@ TEST_F(HybridBuildMRCommandTest, testFilterWithPolicyBatchSizeAndCombine) {
     }, &cp);
 }
 
-// Test complex command with all optional parameters
+// Test complex command with COMBINE + PARAMS + TIMEOUT together.
 TEST_F(HybridBuildMRCommandTest, testComplexCommandWithAllParams) {
     HybridScoringContext sc = {};
     double w[2];
     HybridCombineWireParams cp = linearWireParams(&sc, w, 0.7, 0.3, HYBRID_DEFAULT_WINDOW);
-    testCommandTransformationWithoutIndexSpec({
+    const std::vector<const char*> baseArgs = {
         "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
         "VSIM", "@vector_field", "$BLOB",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA,
-        "TIMEOUT", "3000", "DIALECT", "2"
-    }, &cp);
-    testCommandTransformationWithIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-        "VSIM", "@vector_field", "$BLOB",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA,
-        "TIMEOUT", "3000", "DIALECT", "2"
-    }, &cp);
+        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3"};
+    const std::vector<std::string> paramsKV = {"param1", "hello", "BLOB", TEST_BLOB_DATA};
+    testCommandTransformationWithoutIndexSpecWithParams(baseArgs, paramsKV, /*timeoutMS=*/3000, &cp);
+    testCommandTransformationWithIndexSpecAndParams(baseArgs, paramsKV, /*timeoutMS=*/3000, &cp);
 }
 
-// Test complex command with all optional parameters
-TEST_F(HybridBuildMRCommandTest, testComplexCommandParamsAfterTimeout) {
-    HybridScoringContext sc = {};
-    double w[2];
-    HybridCombineWireParams cp = linearWireParams(&sc, w, 0.7, 0.3, HYBRID_DEFAULT_WINDOW);
-    testCommandTransformationWithoutIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-        "VSIM", "@vector_field", "$BLOB",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA,
-        "TIMEOUT", "3000",
-        "DIALECT", "2"
-    }, &cp);
-    testCommandTransformationWithIndexSpec({
-        "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-        "VSIM", "@vector_field", "$BLOB",
-        "COMBINE", "LINEAR", "4", "ALPHA", "0.7", "BETA", "0.3",
-        "PARAMS", "4", "param1", "hello", "BLOB", TEST_BLOB_DATA,
-        "TIMEOUT", "3000",
-        "DIALECT", "2"
-    }, &cp);
+// A parameter *value* that spells a top-level keyword is carried inside the PARAMS
+// block, never mistaken for that clause (the value happens to be "TIMEOUT" here).
+TEST_F(HybridBuildMRCommandTest, testCommandWithParamValueSpellingKeyword) {
+    const std::vector<const char*> baseArgs = {
+        "FT.HYBRID", "test_idx", "SEARCH", "@title:($p)", "VSIM", "@vector_field", "$BLOB"};
+    const std::vector<std::string> paramsKV = {"p", "TIMEOUT", "BLOB", TEST_BLOB_DATA};
+    testCommandTransformationWithoutIndexSpecWithParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
+    testCommandTransformationWithIndexSpecAndParams(baseArgs, paramsKV, /*timeoutMS=*/-1);
 }
 
 // Test minimal command
@@ -626,50 +762,48 @@ TEST_F(HybridBuildMRCommandTest, testMinimalCommand) {
 // option, not by argv text. A SEARCH query token or PARAMS value equal to
 // "EXPLAINSCORE" must not trigger forwarding; sendExplainScore=true must.
 TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
-    auto countToken = [](const MRCommand *cmd, std::string_view tok) {
-        int n = 0;
-        for (int i = 0; i < cmd->num; i++) {
-            if (cmd->lens[i] == tok.size() &&
-                strncasecmp(cmd->strs[i], tok.data(), tok.size()) == 0) {
-                n++;
-            }
-        }
-        return n;
-    };
-
     {
         std::vector<const char *> input = {
             "FT.HYBRID", "test_idx", "SEARCH", "EXPLAINSCORE",
             "VSIM", "@vector_field", TEST_BLOB_DATA, nullptr};
         RMCK::ArgvList args(ctx, input.data(), input.size() - 1);
 
+        HybridShardWireParams shardWireParams = {};  // no COMBINE, no PARAMS, no TIMEOUT
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, /*combineParams=*/nullptr, &xcmd,
-                                     nullptr, nullptr, &kArgIndex);
+        HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr, nullptr,
+                                     &kArgIndex);
 
-        EXPECT_EQ(countToken(&xcmd, "EXPLAINSCORE"), 1)
+        EXPECT_EQ(countTok(toTokens(&xcmd), "EXPLAINSCORE"), 1)
             << "EXPLAINSCORE in the search query must not be re-appended as a "
                "top-level shard option";
         MRCommand_Free(&xcmd);
     }
 
+    // A PARAMS *value* equal to "EXPLAINSCORE" is carried inside the PARAMS
+    // block (reconstructed from the parsed dict) and must not be re-appended as
+    // a top-level shard option when the parsed flag is unset. It therefore
+    // appears exactly once - as the param value.
     {
         std::vector<const char *> input = {
             "FT.HYBRID", "test_idx", "SEARCH", "@title:($param1)",
-            "VSIM", "@vector_field", "$BLOB",
-            "PARAMS", "4", "param1", "EXPLAINSCORE", "BLOB", TEST_BLOB_DATA,
-            nullptr};
+            "VSIM", "@vector_field", "$BLOB", nullptr};
         RMCK::ArgvList args(ctx, input.data(), input.size() - 1);
+
+        ParamList expectedPairs;
+        dict *params = makeParamsDict({"param1", "EXPLAINSCORE", "BLOB", TEST_BLOB_DATA},
+                                      expectedPairs);
+
+        HybridShardWireParams shardWireParams = {};
+        shardWireParams.params = params;
 
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/false, /*combineParams=*/nullptr, &xcmd,
-                                     nullptr, nullptr, &kArgIndex);
+        HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr, nullptr,
+                                     &kArgIndex);
+        Param_DictFree(params);
 
-        EXPECT_EQ(countToken(&xcmd, "EXPLAINSCORE"), 1)
+        EXPECT_EQ(countTok(toTokens(&xcmd), "EXPLAINSCORE"), 1)
             << "EXPLAINSCORE as a PARAMS value must not be re-appended as a "
                "top-level shard option";
         MRCommand_Free(&xcmd);
@@ -681,13 +815,15 @@ TEST_F(HybridBuildMRCommandTest, testExplainScoreNotForwardedFromArgvText) {
             "VSIM", "@vector_field", TEST_BLOB_DATA, nullptr};
         RMCK::ArgvList args(ctx, input.data(), input.size() - 1);
 
+        HybridShardWireParams shardWireParams = {};
+        shardWireParams.sendExplainScore = true;
+
         MRCommand xcmd;
         int kArgIndex = -1;
-        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS,
-                                     /*sendExplainScore=*/true, /*combineParams=*/nullptr, &xcmd,
-                                     nullptr, nullptr, &kArgIndex);
+        HybridRequest_buildMRCommand(args, args.size(), &shardWireParams, &xcmd, nullptr, nullptr,
+                                     &kArgIndex);
 
-        EXPECT_EQ(countToken(&xcmd, "EXPLAINSCORE"), 1)
+        EXPECT_EQ(countTok(toTokens(&xcmd), "EXPLAINSCORE"), 1)
             << "EXPLAINSCORE should be appended exactly once when the parsed "
                "flag is set";
         MRCommand_Free(&xcmd);

--- a/tests/pytests/test_hybrid_yield.py
+++ b/tests/pytests/test_hybrid_yield.py
@@ -274,6 +274,40 @@ def test_hybrid_combine_yield_score_as_both_forms():
     env.assertEqual(counted, positional,
                     message="Counted and positional YIELD_SCORE_AS must be equivalent")
 
+def test_hybrid_yield_score_as_keyword_alias():
+    """A YIELD_SCORE_AS alias that collides with a top-level keyword
+    (PARAMS/TIMEOUT/DIALECT) must not confuse the coordinator when it builds the
+    per-shard command."""
+    env = Env()
+    setup_basic_index(env)
+    query_vector = np.array([1.2, 0.3]).astype(np.float32).tobytes()
+
+    for alias in ('PARAMS', 'TIMEOUT', 'DIALECT', 'YIELD_SCORE_AS'):
+        # Counted form: count 4 covers CONSTANT 60 YIELD_SCORE_AS <alias>
+        counted, _ = get_results_from_hybrid_response(env.cmd(
+            'FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', '$BLOB',
+            # initQueryTimeout() detects the keyword TIMEOUT by arg scanning,
+            # so we need to place it before the COMBINE clause to avoid confusion.
+            # Remove this once MOD-17165 is implemented.
+            'TIMEOUT', '1000',
+            'COMBINE', 'RRF', '4', 'CONSTANT', '60', 'YIELD_SCORE_AS', alias,
+            'PARAMS', '2', 'BLOB', query_vector))
+
+        # Positional form: count 2 covers CONSTANT 60, YIELD_SCORE_AS follows
+        positional, _ = get_results_from_hybrid_response(env.cmd(
+            'FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', '$BLOB',
+            'TIMEOUT', '1000',
+            'COMBINE', 'RRF', '2', 'CONSTANT', '60', 'YIELD_SCORE_AS', alias,
+            'PARAMS', '2', 'BLOB', query_vector))
+
+        env.assertGreater(len(counted.keys()), 0, message=f"alias={alias}")
+        for results in (counted, positional):
+            for doc_key in results:
+                env.assertTrue(alias in results[doc_key], message=f"alias={alias}")
+                env.assertGreater(float(results[doc_key][alias]), 0, message=f"alias={alias}")
+        env.assertEqual(counted, positional,
+                        message=f"Counted and positional YIELD_SCORE_AS must be equivalent (alias={alias})")
+
 def test_hybrid_combine_duplicate_yield_score_as_error():
     """A duplicate YIELD_SCORE_AS after the COMBINE clause is rejected."""
     env = Env()


### PR DESCRIPTION
Backport of #10566 to `8.8-rse`.

## Original PR
- Title: MOD-17092 FT.HYBRID: forward PARAMS/TIMEOUT from parsed state, not argv re-scan
- Link: https://github.com/RediSearch/RediSearch/pull/10566
- Merge commit: `e049d9452b58204152b2c4808db006b663814f46`

## Cherry-pick result
Resolved 7 conflict(s) across 3 files — see Conflict Log below.

`8.8-rse` is missing one master-only change that this PR builds on top of, which
is the root cause of every C conflict:

| Missing on `8.8-rse` | Effect on the backport |
| --- | --- |
| Binary-length-aware coordinator fanout (`MR_NewCommandArgvLen`, `cmdLens[]`, `MRCommand_AppendLiteral`) | Kept the target's `MR_NewCommandArgv` / `strlen`-based command assembly; dropped one master-only test |

`src/coord/hybrid/dist_hybrid.h`, `src/hybrid/parse_hybrid.c` and
`src/hybrid/parse_hybrid.h` applied cleanly, so the `HybridShardWireParams`
refactor (including `sendExplainScore`), the `int *outKArgIndex` signature and
the parsed-state capture in front of the foreground query-timeout cap are all
backported verbatim.

The functional core of the PR — reconstructing `PARAMS` from the resolved
parameter dictionary and forwarding `TIMEOUT` from parsed state instead of
re-scanning `argv` — is backported in full.

Verified: `./build.sh TESTS` exit 0; `RUN_UNIT_TESTS` 944/944 (141/141 coordinator
C++); `test_hybrid_yield.py` 19/19 standalone and 19/19 cluster; 95/95 across
`test_hybrid`, `_timeout`, `_dialect`, `_explainscore`, `_profile`, `_dist`,
`_shard_k_ratio` and `_internal` in cluster mode.

## Conflict Log

The conflicts span `dist_hybrid.c`, `test_cpp_hybrid_build_mr_cmd.cpp` and
`test_hybrid_yield.py`. Most resolved mechanically — keep the target's command assembly,
take everything else from the PR. Two were incidental: `param.h` was added to the target's
existing include list rather than master's reorganised one, and the `_FT.PROFILE` block
follows the same assembly decision as the prologue. The decisions worth recording:

- **Length-aware command assembly dropped** — `dist_hybrid.c`. The incoming prologue and
  `_FT.PROFILE` block carry a `size_t cmdLens[5]` recorded alongside `cmdArgs[]` and capture
  `index_name_len`. Kept the target's `cmdArgs[cmdArgCount++]` assembly and its
  `RedisModule_StringPtrLen(argv[1], NULL)` call. The emitted wire tokens are identical;
  only the length bookkeeping, which `MR_NewCommandArgv` derives via `strlen`, is absent.

- **`EXPLAINSCORE` still forwarded, through `MRCommand_Append`** — `dist_hybrid.c:389`. The
  incoming side calls `MRCommand_AppendLiteral`, which does not exist on this branch, so the
  append was rewritten as `MRCommand_Append(xcmd, "EXPLAINSCORE", strlen("EXPLAINSCORE"))`.
  Unlike the `8.6`/`8.6-rse` backports, `sendExplainScore` stays in `HybridShardWireParams`
  and `testExplainScoreNotForwardedFromArgvText` is retained — this branch does forward
  `QEXEC_F_SEND_SCOREEXPLAIN` to shards.

- **The PR's new `lens[oi]` assertion was taken** — `test_cpp_hybrid_build_mr_cmd.cpp:255`.
  The PR replaces the verifier's unconditional tail with PARAMS-aware branching that adds
  `EXPECT_EQ(xcmd->lens[oi], strlen(inputArgs[ii]))`; the target's shorter tail had no such
  assertion, so the deletion did not match and the old block was left behind. Kept the PR's
  branching block and removed the leftover tail. The assertion holds without the length-aware
  assembly because `MR_NewCommandArgv` populates `lens` through `assignCstr` → `strlen` and
  every oracle input is a NUL-terminated C string. Confirmed passing.

- **`testBinaryArgsForwardedAtFullLength` dropped** — the PR only updates this test's call
  site to the new signature, but the test itself is master-only and unportable here: it
  asserts a full byte length for an index name containing an embedded NUL, which
  `MR_NewCommandArgv` truncates at `strlen`. Every other test the PR touches or adds is
  retained, including the PARAMS/TIMEOUT and keyword-collision cases and the new
  `...WithParams` / `...WithIndexSpecAndParams` fixture helpers.

- **Pytest query vector** — `test_hybrid_yield.py:253`. Both sides fix the same tie-breaking
  flakiness in `test_hybrid_combine_yield_score_as_both_forms`; kept the target's
  `[0.0, 0.25]` and its explanatory comment over the PR's `[1.2, 0.3]`. The PR's new
  `test_hybrid_yield_score_as_keyword_alias` merged cleanly.

## Release notes
- [x] This PR requires release notes
- [ ] This PR does not require release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
