### PR TITLE
[MOD-17606] Pass the vector field's schema index to the disk storage layer

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -1197,10 +1197,10 @@ static int parseVectorField(IndexSpec *sp, StrongRef sp_ref, FieldSpec *fs, Args
         .storage = sp->diskSpec,
         .indexName = rm_strndup(namePtr, nameLen),
         .indexNameLen = nameLen,
-        .rerank = rerank,
         // The disk storage layer keys this field's data by the value it finds
         // here, so it has to stay stable for the life of the index.
         .userData = fs->index,
+        .rerank = rerank,
       };
     }
   } else if (STR_EQCASE(algStr, len, VECSIM_ALGORITHM_SVS)) {
@@ -2903,8 +2903,8 @@ static void IndexSpec_PopulateVectorDiskParams(IndexSpec *sp) {
       .storage = sp->diskSpec,
       .indexName = rm_strndup(namePtr, nameLen),
       .indexNameLen = nameLen,
-      .rerank = rerank,
       .userData = fs->index,
+      .rerank = rerank,
     };
   }
 }

--- a/src/spec.c
+++ b/src/spec.c
@@ -1198,6 +1198,9 @@ static int parseVectorField(IndexSpec *sp, StrongRef sp_ref, FieldSpec *fs, Args
         .indexName = rm_strndup(namePtr, nameLen),
         .indexNameLen = nameLen,
         .rerank = rerank,
+        // The disk storage layer keys this field's data by the value it finds
+        // here, so it has to stay stable for the life of the index.
+        .userData = fs->index,
       };
     }
   } else if (STR_EQCASE(algStr, len, VECSIM_ALGORITHM_SVS)) {
@@ -2901,6 +2904,7 @@ static void IndexSpec_PopulateVectorDiskParams(IndexSpec *sp) {
       .indexName = rm_strndup(namePtr, nameLen),
       .indexNameLen = nameLen,
       .rerank = rerank,
+      .userData = fs->index,
     };
   }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: a vector field's disk context carries the field's *name*. A disk storage backend that keeps several of an index's vector fields in one physical store needs a fixed-width identifier to keep their keys apart, and a variable-width name is a poor fit for a key prefix.
2. Change: `VecSimDiskContext` gains an opaque `userData` slot (see the VectorSimilarity bump), and both places that build a field's disk context fill it with `fs->index`.
3. Outcome: internal-only — no user-visible behavior changes. It unblocks the disk layer storing all of an index's vector fields in one column family instead of one per field, which is where the memory saving is.

`userData` is set before `rerank` to match the field order in `VecSimDiskContext`, whose members run widest-first. C is indifferent to designated-initializer order, but C++20 is not, so keeping the two in step avoids a trap for the next caller.

#### Which additional issues this PR fixes

1. MOD-17606

#### Main objects this PR modified

1. `parseVectorField` (`src/spec.c`) — fills `userData` when building a field's `VecSimDiskContext`.
2. `IndexSpec_PopulateVectorDiskParams` (`src/spec.c`) — same, on the RDB-load path.
3. `deps/VectorSimilarity` — gitlink bump for the `userData` slot (RedisAI/VectorSimilarity#1013, merged).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
