### PR TITLE
[MOD-16991] Retire the QueryRequest refcount: one owner at any time

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -249,12 +249,8 @@ static inline const char *AREQ_Query(const AREQ *req, size_t *len) {
   return query;
 }
 
-/* Lifecycle helpers for AREQ objects. AREQ_Free is the concrete destructor
- * selected by the final QueryRequest release; ownership callers use
- * AREQ_IncrRef / AREQ_DecrRef. */
+/* Destroy an AREQ. Owner-only: see the ownership contract on QueryRequest. */
 void AREQ_Free(AREQ *req);
-AREQ *AREQ_IncrRef(AREQ *req);
-void AREQ_DecrRef(AREQ *req);
 
 /**
  * Create a new aggregate request. The request's lifecycle consists of several
@@ -432,19 +428,11 @@ ResultProcessor *Grouper_GetRP(Grouper *gr);
  */
 void Grouper_AddReducer(Grouper *g, Reducer *r, RLookupKey *dst);
 
+/* Run the pipeline and reply. Never disposes the request — the caller owns disposal. */
 void AREQ_Execute(AREQ *req, RedisModuleCtx *outctx);
 void sendChunk(AREQ *req, RedisModule_Reply *reply, size_t limit);
 void sendChunk_ReplyOnly_EmptyResults(RedisModuleCtx *ctx, AREQ *req);
 
-
-/**
- * Free a cursor parked in `req->base.reply.cursor`, if any.
- * Used by cleanup paths to release a cursor left behind when the
- * blocked-client timeout fires before the reply callback runs and
- * drains it via `AREQ_ReplyWithStoredResults`.
- * No-op when `req->base.reply.cursor` is NULL.
- */
-void AREQ_CleanUpStoredCursor(AREQ *req);
 
 /**
  * Start the cursor on the current request
@@ -461,6 +449,13 @@ void AREQ_CleanUpStoredCursor(AREQ *req);
  * and must be freed manually.
  */
 int AREQ_StartCursor(AREQ *r, RedisModule_Reply *reply, StrongRef spec_ref, QueryError *status, bool coord);
+
+/* Dispose of `cursor` at the end of a read/creation cycle: park it back into
+ * the idle list, or free it when `free_it`. Inside a blocked-client cycle the
+ * disposition is only recorded and executed by QueryRequest_EndCycle on the
+ * main thread, so the cursor stays unreachable to other clients until the
+ * cycle fully ended. Outside a cycle it executes immediately. */
+void AREQ_CursorEndOfCycle(AREQ *req, struct Cursor *cursor, bool free_it);
 
 int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int RSCursorProfileCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -74,15 +74,13 @@
 
 // Multi threading data structure for background query execution.
 // This context is created on the main thread and passed to the background worker.
-// Ownership: The main thread transfers its AREQ reference (from AREQ_New) to this context.
 typedef struct {
-  AREQ *req;  // Owns transferred reference from main thread.
+  AREQ *req;  // Borrowed; the cycle owns the request (see QueryRequest).
   RedisModuleBlockedClient *blockedClient;
   WeakRef spec_ref;
 } blockedClientReqCtx;
 
 static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num);
-static void cursorEndOfCycle(AREQ *req, Cursor *cursor, bool free_it);
 static int prepareExecutionPlan(AREQ *req, QueryError *status);
 static int QueryReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
@@ -1222,14 +1220,10 @@ void AREQ_Execute(AREQ *req, RedisModuleCtx *ctx) {
   RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
   sendChunk(req, reply, UINT64_MAX);
   RedisModule_EndReply(reply);
-  // Release the spec read lock before dropping our reference to `req`.
   RedisSearchCtx_UnlockSpec(AREQ_SearchCtx(req));
   RedisSearchCtx_AssertLockNotHeld(AREQ_SearchCtx(req));
-  AREQ_DecrRef(req);
 }
 
-// Creates a new blockedClientReqCtx, taking ownership of the AREQ reference from the main thread.
-// Note: No AREQ_IncrRef here - ownership is transferred, not shared.
 static blockedClientReqCtx *blockedClientReqCtx_New(AREQ *req,
                                                     RedisModuleBlockedClient *blockedClient, StrongRef spec) {
   blockedClientReqCtx *ret = rm_new(blockedClientReqCtx);
@@ -1243,23 +1237,8 @@ static AREQ *blockedClientReqCtx_getRequest(const blockedClientReqCtx *BCRctx) {
   return BCRctx->req;
 }
 
-static void blockedClientReqCtx_setRequest(blockedClientReqCtx *BCRctx, AREQ *req) {
-  BCRctx->req = req;
-}
 
 static void blockedClientReqCtx_destroy(blockedClientReqCtx *BCRctx) {
-  // Release the owned AREQ reference if it has not already been released.
-  // On the normal success path, AREQ_Execute() releases the reference and
-  // the owner clears it via blockedClientReqCtx_setRequest(BCRctx, NULL),
-  // so this conditional avoids a double-decr while still handling error paths
-  // where AREQ_Execute() is never called.
-  // Must precede UnblockClient: once unblocked, the main thread may drop the
-  // cycle reference, making this release the final one — off the main thread.
-  if (BCRctx->req) {
-    AREQ_DecrRef(BCRctx->req);
-    BCRctx->req = NULL;
-  }
-
   RedisModule_BlockedClientMeasureTimeEnd(BCRctx->blockedClient);
   void *privdata = RedisModule_BlockClientGetPrivateData(BCRctx->blockedClient);
   RedisModule_UnblockClient(BCRctx->blockedClient, privdata);
@@ -1300,7 +1279,6 @@ void AREQ_Execute_Callback(blockedClientReqCtx *BCRctx) {
   // Check if timed out while in the job queue.
   if (AREQ_TimedOut(req)) {
     // Timeout callback already replied.
-    // blockedClientReqCtx_destroy will release the AREQ ref.
     blockedClientReqCtx_destroy(BCRctx);
     return;
   }
@@ -1378,11 +1356,6 @@ void AREQ_Execute_Callback(blockedClientReqCtx *BCRctx) {
     AREQ_Execute(req, outctx);
   }
 
-  // If the execution was successful, we either:
-  // 1. Freed the request (if it was a regular query)
-  // 2. Kept it as the cursor's state (if it was a cursor query)
-  // Either way, we don't want to free `req` here. we set it to NULL so that it won't be freed with the context.
-  blockedClientReqCtx_setRequest(BCRctx, NULL);
   goto cleanup;
 
 error:
@@ -1390,9 +1363,7 @@ error:
   // Return the ctx loan before `cleanup` frees outctx; the request may outlive
   // this cycle through the reply callback's reference.
   sctx->redisCtx = NULL;
-  // Both jumps here explicitly unlocked, and `req` is still owned by BCRctx.
-  // The success paths are checked inside AREQ_Execute / runCursor, where the
-  // request is still alive (it may already be freed once we reach `cleanup`).
+  // Both jumps here explicitly unlocked.
   RedisSearchCtx_AssertLockNotHeld(AREQ_SearchCtx(req));
 
 cleanup:
@@ -1582,7 +1553,7 @@ static int buildRequest(RedisModuleCtx *ctx, int type, QueryError *status, AREQ 
 
 done:
   if (rc != REDISMODULE_OK && *r) {
-    AREQ_DecrRef(*r);
+    AREQ_Free(*r);
     *r = NULL;
   }
   return rc;
@@ -1759,14 +1730,10 @@ void AREQ_ReplyWithStoredResults(RedisModuleCtx *ctx, AREQ *req) {
   // finishSendChunk handles cleanup and stats, and sets QEXEC_S_ITERDONE if cursor is done
   finishSendChunk(req, state.results, NULL, state.cursor_done);
 
-  // Handle cursor lifecycle now that QEXEC_S_ITERDONE has been set by finishSendChunk.
-  // runCursor stored the cursor handle here instead of pausing/freeing it immediately,
-  // because finishSendChunk (which sets QEXEC_S_ITERDONE) runs in the reply_callback.
-  // Inside a blocked-client cycle this records the disposition for OnFree;
-  // inline callers execute it immediately.
-  if (stored->cursor) {
-    cursorEndOfCycle(req, stored->cursor, req->stateflags & QEXEC_S_ITERDONE);
-    stored->cursor = NULL;
+  // Record the cursor resolution now that QEXEC_S_ITERDONE is known (set by
+  // finishSendChunk above).
+  if (req->base.cursorInfo.cursor) {
+    AREQ_CursorEndOfCycle(req, req->base.cursorInfo.cursor, req->stateflags & QEXEC_S_ITERDONE);
   }
 }
 
@@ -1774,8 +1741,6 @@ void AREQ_ReplyWithStoredResults(RedisModuleCtx *ctx, AREQ *req) {
 // Called on the main thread when the background thread calls UnblockClient.
 // The background thread stored results in req->base.reply, which we use to build the reply.
 // Note: This callback is NOT called if timeout fired first (bc->client becomes NULL).
-// Reference counting: the cycle holds a request reference released via QueryRequest_OnFree
-// after this callback.
 static int QueryReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   UNUSED(argv);
   UNUSED(argc);
@@ -1802,7 +1767,6 @@ static int QueryReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int
 
   AREQ_ReplyWithStoredResults(ctx, req);
 
-  // No AREQ_DecrRef here - QueryRequest_OnFree releases the cycle's reference.
   return REDISMODULE_OK;
 }
 
@@ -1876,7 +1840,6 @@ static int CursorReadTimeoutReturnStrictCallback(RedisModuleCtx *ctx, RedisModul
 
 // Shard FT.CURSOR READ FAIL-path reply callback.
 // Mirrors QueryReplyCallback. Not invoked if the timeout fired first.
-// QueryRequest_OnFree releases the cycle's request reference after this callback.
 // Can be consolidated with QueryReplyCallback - See MOD-15038.
 static int CursorReadReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   UNUSED(argv);
@@ -2023,6 +1986,7 @@ static int buildPipelineAndExecute(AREQ *r, RedisModuleCtx *ctx, QueryError *sta
       }
     } else {
       AREQ_Execute(r, ctx);
+      AREQ_Free(r);
     }
   }
 
@@ -2097,7 +2061,7 @@ error:
   QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&status), 1, GetNumShards_UnSafe() == 1);
 
   if (r) {
-    AREQ_DecrRef(r);
+    AREQ_Free(r);
   }
 
   return QueryError_ReplyAndClear(ctx, &status);
@@ -2118,12 +2082,12 @@ char *RS_GetExplainOutput(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
   // released in `AREQ_Free`.
   RedisSearchCtx_LockSpecRead(sctx);
   if (prepareExecutionPlan(r, status) != REDISMODULE_OK) {
-    AREQ_DecrRef(r);
+    AREQ_Free(r);
     CurrentThread_ClearIndexSpec();
     return NULL;
   }
   char *ret = QAST_DumpExplain(&r->ast, sctx->spec);
-  AREQ_DecrRef(r);
+  AREQ_Free(r);
   CurrentThread_ClearIndexSpec();
   return ret;
 }
@@ -2141,19 +2105,14 @@ int AREQ_StartCursor(AREQ *r, RedisModule_Reply *reply, StrongRef spec_ref, Quer
   cursor->queryTimeoutMS = (size_t)r->reqConfig.queryTimeoutMS;
   cursor->queryTimeoutPolicy = r->reqConfig.timeoutPolicy;
   r->base.cursorInfo.id = cursor->id;
+  r->base.cursorInfo.cursor = cursor;
   runCursor(reply, cursor, 0);
   return REDISMODULE_OK;
 }
 
-/* Dispose of `cursor` at the end of a read/creation cycle: park it back into
- * the idle list, or free it when the query is exhausted / timed out. Inside a
- * blocked-client cycle the disposition is only recorded here and executed by
- * QueryRequest_OnFree on the main thread, so the cursor stays
- * unreachable to other clients until the cycle fully ended. Outside a cycle
- * (inline execution) it executes immediately. */
-static void cursorEndOfCycle(AREQ *req, Cursor *cursor, bool free_it) {
+void AREQ_CursorEndOfCycle(AREQ *req, Cursor *cursor, bool free_it) {
   if (req->base.blockedClientCycleActive) {
-    req->base.cursorInfo.cursor = cursor;
+    RS_ASSERT(req->base.cursorInfo.cursor == cursor);
     req->base.cursorInfo.disposition =
         free_it ? CURSOR_DISPOSITION_FREE : CURSOR_DISPOSITION_PAUSE;
   } else if (free_it) {
@@ -2199,36 +2158,16 @@ static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num) {
                       areq_timed_out, req);
 #endif
 
-  if (QueryRequest_UsesReplyCallback(&req->base)) {
-    // Stash the cursor BEFORE sendChunk: sendChunk's signal can wake the
-    // timeout_callback, which reads req->base.reply.cursor to pause/free it.
-    req->base.reply.cursor = cursor;
-  }
-
   sendChunk(req, reply, num);
   RedisSearchCtx_UnlockSpec(AREQ_SearchCtx(req)); // Verify that we release the spec lock
   // Below this point the cursor (and with it `req`) may be freed, paused, or
   // handed off, so the lock must be released here, on this worker thread.
   RedisSearchCtx_AssertLockNotHeld(AREQ_SearchCtx(req));
 
-  if (QueryRequest_UsesReplyCallback(&req->base)) {
-    if (req->base.async.aggregateResultsClaimLost) {
-      // The strict timeout callback won the sync claim and already replied with
-      // cursor 0. Keep cursor ownership consistent with the depleted id already
-      // returned to the caller.
-      req->base.reply.cursor = NULL;
-      cursorEndOfCycle(req, cursor,
-                       (AREQ_RequestFlags(req) & QEXEC_F_IS_AGGREGATE) ||
-                           shouldSetCursorDone(req, RS_RESULT_TIMEDOUT));
-      return;
-    }
-    // Disposal of the stashed cursor is owned by AREQ_ReplyWithStoredResults
-    // (only it knows QEXEC_S_ITERDONE, set by finishSendChunk on main) — or by
-    // EndCycle's leftover-stash drain when the timeout replied without it.
-    return;
+  // With a reply callback, resolving the cursor is the main thread's job.
+  if (!QueryRequest_UsesReplyCallback(&req->base)) {
+    AREQ_CursorEndOfCycle(req, cursor, req->stateflags & QEXEC_S_ITERDONE);
   }
-
-  cursorEndOfCycle(req, cursor, req->stateflags & QEXEC_S_ITERDONE);
 }
 
 static QueryProcessingCtx *prepareForCursorRead(Cursor *cursor, bool *hasLoader, bool *initClock, QEFlags *reqFlags, QueryError *status) {
@@ -2265,7 +2204,7 @@ static void cursorRead(RedisModuleCtx *ctx, Cursor *cursor, size_t count, bool b
       // freeing first would UAF the QueryRequest reply-mode read inside
       // AREQ_ReplyOrStoreError.
       AREQ_ReplyOrStoreError(req, ctx, &status);
-      cursorEndOfCycle(req, cursor, true);
+      AREQ_CursorEndOfCycle(req, cursor, true);
       return;
     }
 
@@ -2332,7 +2271,7 @@ static void cursorRead_ctx(CursorReadCtx *cr_ctx) {
   if (!AREQ_TimedOut(req) || AREQ_RequiresThreadsSyncResults(req)) {
     cursorRead(ctx, cr_ctx->cursor, cr_ctx->count, true);
   } else {
-    cursorEndOfCycle(req, cr_ctx->cursor, true);
+    AREQ_CursorEndOfCycle(req, cr_ctx->cursor, true);
   }
   RedisModule_FreeThreadSafeContext(ctx);
   RedisModule_BlockedClientMeasureTimeEnd(cr_ctx->bc);
@@ -2361,7 +2300,7 @@ static void coordCursorRead_ctx(void *p) {
     // RETURN_STRICT: the timeout callback fired before this job was dequeued,
     // won the owner latch, and already replied with a depleted cursor. Free
     // the taken cursor; store nothing (nobody is waiting).
-    cursorEndOfCycle(req, cursor, true);
+    AREQ_CursorEndOfCycle(req, cursor, true);
   } else if (!AREQ_TimedOut(req) || AREQ_RequiresThreadsSyncResults(req)) {
     // RETURN (no timer) always runs the read and replies inline through the
     // thread-safe ctx; FAIL bails and drops the cursor if the timer already
@@ -2370,7 +2309,7 @@ static void coordCursorRead_ctx(void *p) {
     // the cursor.
     cursorRead(ctx, cursor, cr_ctx->count, false);
   } else {
-    cursorEndOfCycle(req, cursor, true);
+    AREQ_CursorEndOfCycle(req, cursor, true);
   }
   RedisModule_FreeThreadSafeContext(ctx);
   RedisModule_BlockedClientMeasureTimeEnd(cr_ctx->bc);
@@ -2399,6 +2338,8 @@ static int cursorReadDispatchTaken(RedisModuleCtx *ctx, Cursor *cursor, long lon
   // Safe against the just-armed timer: the timeout callback runs on this same
   // thread.
   QueryRequest_BeginCycle(&req->base, bc, reply_cb);
+  // Publish the cycle's cursor handle (see BlockCursorClientWithTimeout).
+  req->base.cursorInfo.cursor = cursor;
   // Cursor cycles reuse the request across reads: reset the per-read
   // RETURN_STRICT claim/latch state so the new cycle starts from a clean
   // slate — safe because taking the cursor proves the previous read cycle's
@@ -2738,7 +2679,7 @@ int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 
 error:
   if (r) {
-    AREQ_DecrRef(r);
+    AREQ_Free(r);
   }
   return QueryError_ReplyAndClear(ctx, &status);
 }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1724,28 +1724,8 @@ void ChunkReplyState_Destroy(ChunkReplyState *state) {
     state->results = NULL;
   }
 
-  // Timeout edge case: cursor wasn't handled by reply_callback.
-  // See ChunkReplyState ownership model in aggregate.h for full explanation.
-  // We must clear the cursor's request handle before Cursor_Free to prevent a
-  // recursive release while this request is already being destroyed.
-  if (state->cursor) {
-    state->cursor->query = NULL;
-    Cursor_Free(state->cursor);
-    state->cursor = NULL;
-  }
-
   // Clear stored error state
   QueryError_ClearError(&state->err);
-}
-
-AREQ *AREQ_IncrRef(AREQ *req) {
-  QueryRequest_IncrRef(&req->base);
-  return req;
-}
-
-void AREQ_DecrRef(AREQ *req) {
-  if (!req) return;
-  QueryRequest_DecrRef(&req->base);
 }
 
 void AREQ_Free(AREQ *req) {
@@ -1821,14 +1801,6 @@ void AREQ_Free(AREQ *req) {
   QueryRequest_Destroy(&req->base);
 
   rm_free(req);
-}
-
-void AREQ_CleanUpStoredCursor(AREQ *req) {
-  if (req->base.reply.cursor) {
-    Cursor *cursor = req->base.reply.cursor;
-    req->base.reply.cursor = NULL;
-    Cursor_Free(cursor);
-  }
 }
 
 AggregationPipelineParams AREQ_MakeAggregationPipelineParams(AREQ *req,

--- a/src/aggregate/reply_empty.c
+++ b/src/aggregate/reply_empty.c
@@ -57,7 +57,7 @@ static int empty_sendChunk_common(RedisModuleCtx *ctx, AREQ *req) {
 
     sendChunk_ReplyOnly_EmptyResults(ctx, req);
 
-    AREQ_DecrRef(req);
+    AREQ_Free(req);
     return REDISMODULE_OK;
 }
 
@@ -97,12 +97,12 @@ int coord_aggregate_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **a
 
     int profileArgs = parseProfileArgs(argv, argc, req);
     if (profileArgs == -1) {
-        AREQ_DecrRef(req);
+        AREQ_Free(req);
         return QueryError_ReplyAndClear(ctx, &status);
     }
 
     if (shallow_parse_query_args(argv + profileArgs, argc - profileArgs, req) != REDISMODULE_OK) {
-        AREQ_DecrRef(req);
+        AREQ_Free(req);
         return QueryError_ReplyAndClear(ctx, &status);
     }
 
@@ -203,7 +203,7 @@ int coord_hybrid_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **argv
 int single_shard_common_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int execOptions, QueryErrorCode errCode) {
 
     // Transient AREQ with no blocked-client cycle: only flows through the reply-only chunk sender
-    // and AREQ_DecrRef, neither of which needs blocked-client cycle state.
+    // and AREQ_Free, neither of which needs blocked-client cycle state.
     AREQ *req = AREQ_New(argv, argc);
     // Clock init required for profiling
     rs_wall_clock_init(&req->profileClocks.initClock);
@@ -220,7 +220,7 @@ int single_shard_common_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString
     ApplyProfileOptions(AREQ_QueryProcessingCtx(req), &req->reqflags, execOptions);
 
     if (shallow_parse_query_args(argv, argc, req) != REDISMODULE_OK) {
-        AREQ_DecrRef(req);
+        AREQ_Free(req);
         return QueryError_ReplyAndClear(ctx, &status);
     }
 

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -110,10 +110,9 @@ typedef struct {
 // context on the async WITHCOUNT path. They are set in dispatchAggregateDeferred
 // before MR_StartIterator and consumed by executeAggregateDeferred after the
 // IO thread posts the handoff. The AREQ's reader ref on the iterator keeps
-// iterCtx alive until executeAggregateDeferred calls AREQ_DecrRef (via
-// executePlan, or directly on the timeout / spec-dropped branch).
-// executeAggregateDeferred copies the fields to locals before releasing AREQ so
-// it never reads iterCtx after free.
+// iterCtx alive until the cycle's OnFree frees the AREQ (after
+// executeAggregateDeferred's unblock). executeAggregateDeferred copies the
+// fields to locals up front so it never reads iterCtx after that.
 //
 // The aggregate-specific callbacks below (withCountReplyCb / withCountErrorCb)
 // stay wired for the iterator's lifetime; they branch on cmd->rootCommand to
@@ -179,8 +178,8 @@ static void executeAggregateDeferred(void *arg);  // forward declaration
 // shard's success callback to netCursorCallback and clear the iterator's
 // errorCB (MRIterator_SwapCallbacks), so any straggler IO-thread event
 // takes the steady-state path and cannot re-enter the aggregate callbacks
-// after the worker has (possibly) freed iterCtx's deferred-execution fields
-// via AREQ_DecrRef. Runs only on the IO thread.
+// after the cycle's OnFree has (possibly) freed the AREQ and, through it,
+// iterCtx's deferred-execution fields. Runs only on the IO thread.
 static void dispatchDeferred(AggregateIteratorContext *iterCtx) {
   RS_ASSERT(iterCtx->bc);
   ConcurrentSearch_ThreadPoolRun(executeAggregateDeferred, iterCtx, DIST_THREADPOOL);
@@ -430,13 +429,11 @@ static void executeAggregateDeferred(void *arg) {
         AREQ_ReplyOrStoreError(r, replyCtx, &status);
         // Cursor reservation failed before runCursor could return the loan.
         r->sctx->redisCtx = NULL;
-        AREQ_DecrRef(r);
       }
     } else {
-      // Converge on the existing non-cursor path: sendChunk + AREQ_DecrRef.
+      // Converge on the existing non-cursor path.
       // executePlan always returns REDISMODULE_OK in the non-cursor branch.
       executePlan(r, spec_ref, reply, &status);
-      // r is freed by AREQ_DecrRef inside executePlan; do not access r after this.
     }
     RedisModule_EndReply(reply);
     RedisModule_FreeThreadSafeContext(replyCtx);
@@ -450,11 +447,9 @@ static void executeAggregateDeferred(void *arg) {
     AREQ_ReplyOrStoreError(r, replyCtx, &status);
     QueryError_ClearError(&status);
     RedisModule_FreeThreadSafeContext(replyCtx);
-    AREQ_DecrRef(r);
   } else {
-    // Timeout path skipped executePlan; release the AREQ ourselves so rpnetFree
-    // drops the iterator's reader ref and the iterator (and iterCtx) is freed.
-    AREQ_DecrRef(r);
+    // Timeout path skipped executePlan; the unblock below hands the request to
+    // OnFree, whose free lets rpnetFree drop the iterator's reader ref.
   }
 
   if (sp) {
@@ -891,7 +886,6 @@ static int executePlan(AREQ *r, StrongRef spec_ref, RedisModule_Reply *reply,
     }
   } else {
     sendChunk(r, reply, UINT64_MAX);
-    AREQ_DecrRef(r);
   }
   return REDISMODULE_OK;
 }
@@ -914,9 +908,9 @@ static void DistAggregateCleanups(RedisModuleCtx *ctx, struct ConcurrentCmdCtx *
   AREQ_ReplyOrStoreError(r, ctx, status);
 
 cleanup:
-  // Return the ctx loan on every error path — the cycle's reference may keep
-  // the request alive past the dispatcher's ctx (some paths bail before their
-  // own return of the loan, e.g. a dispatchAggregateDeferred failure).
+  // Return the ctx loan on every error path — the cycle-owned request outlives
+  // the dispatcher's ctx (some paths bail before their own return of the loan,
+  // e.g. a dispatchAggregateDeferred failure).
   if (r->sctx) {
     r->sctx->redisCtx = NULL;
   }
@@ -925,9 +919,6 @@ cleanup:
     IndexSpecRef_Release(*strong_ref);
   }
   SpecialCaseCtx_Free(knnCtx);
-  // Release the execution flow's reference (taken at shell allocation on the
-  // main thread); the cycle's reference is released by QueryRequest_OnFree.
-  AREQ_DecrRef(r);
   RedisModule_EndReply(reply);
   return;
 }
@@ -990,10 +981,8 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
 
   if (AREQ_TimedOut(r)) {
     // Query timed out while this job was queued; the timeout callback already
-    // replied. Release the execution flow's reference (the cycle's reference
-    // is released by QueryRequest_OnFree after the unblock).
+    // replied.
     WeakRef_Release(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
-    AREQ_DecrRef(r);
     return;
   }
   // Picked up by a coord thread: attribute a timeout from here on to PIPELINE.
@@ -1179,7 +1168,6 @@ int DistAggregateReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, in
   // and the early-error branch above replies with it.
   AREQ_ReplyWithStoredResults(ctx, req);
 
-  // QueryRequest_OnFree releases the cycle's request reference.
   return REDISMODULE_OK;
 }
 
@@ -1248,10 +1236,8 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
 
   if (AREQ_TimedOut(r)) {
     // Query timed out while this job was queued; the timeout callback already
-    // replied. Release the execution flow's reference (the cycle's reference
-    // is released by QueryRequest_OnFree after the unblock).
+    // replied.
     WeakRef_Release(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
-    AREQ_DecrRef(r);
     return;
   }
   // Picked up by a coord thread: attribute a timeout from here on to PIPELINE.

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -932,13 +932,9 @@ typedef struct {
 } HybridDispatchCtx;
 
 static void HybridDispatchCtx_Free(HybridDispatchCtx *dispatch) {
-    HybridRequest *hreq = dispatch->hreq;
     StrongRef indexSpecRef = dispatch->indexSpecRef;
     RedisModuleBlockedClient *bc = dispatch->bc;
 
-    if (hreq) {
-        HybridRequest_DecrRef(hreq);
-    }
     rm_free(dispatch);
     // The dispatcher thread already called CurrentThread_ClearIndexSpec() after
     // transferring strong_ref ownership here, so only release the strong ref.
@@ -1100,9 +1096,6 @@ static void DistHybridCleanups(RedisModuleCtx *ctx,
     if (sp) {
       IndexSpecRef_Release(*strong_ref);
     }
-    // Release the execution flow's reference (taken at shell allocation on the
-    // main thread); the cycle's reference is released by QueryRequest_OnFree.
-    HybridRequest_DecrRef(hreq);
 }
 
 
@@ -1120,9 +1113,8 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
 
     if (HybridRequest_TimedOut(hreq)) {
       // Query timed out while this job was queued; the timeout callback
-      // already replied. Release the execution flow's reference.
+      // already replied.
       WeakRef_Release(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
-      HybridRequest_DecrRef(hreq);
       return;
     }
     // Picked up by a coord thread: attribute a timeout from here on to PIPELINE.
@@ -1189,7 +1181,6 @@ void DEBUG_RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     if (HybridRequest_TimedOut(hreq)) {
       // Timed out while queued; the timeout callback already replied.
       WeakRef_Release(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
-      HybridRequest_DecrRef(hreq);
       return;
     }
     // Picked up by a coord thread: attribute a timeout from here on to PIPELINE.
@@ -1376,6 +1367,5 @@ int DistHybridReplyCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int a
   serializeStoredResults_hybrid(hreq, reply);
   RedisModule_EndReply(reply);
 
-  // QueryRequest_OnFree releases the cycle's request reference.
   return REDISMODULE_OK;
 }

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -97,8 +97,9 @@ static void Cursor_FreeInternal(Cursor *cur) {
   kh_del(cursors, cl->lookup, khi);
   RS_LOG_ASSERT(kh_get(cursors, cl->lookup, cur->id) == kh_end(cl->lookup),
                                                     "Failed to delete cursor");
+  RS_ASSERT(!cur->query || !cur->query->blockedClientCycleActive);
   if (cur->query) {
-    QueryRequest_DecrRef(cur->query);
+    QueryRequest_Free(cur->query);
     cur->query = NULL;
   }
   // if There's a spec associated with the cursor

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -206,7 +206,7 @@ static HybridRequest_Debug* HybridRequest_Debug_New(RedisModuleCtx *ctx, RedisMo
   int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, status, false, EXEC_NO_FLAGS);
   if (rc != REDISMODULE_OK) {
     HybridPipelineParams_Cleanup(&hybridParams);
-    HybridRequest_DecrRef(hreq);
+    HybridRequest_Free(hreq);
     return NULL;
   }
 
@@ -220,7 +220,7 @@ static HybridRequest_Debug* HybridRequest_Debug_New(RedisModuleCtx *ctx, RedisMo
   hreq->reqflags = hybridParams.aggregationParams.common.reqflags;
   if (HybridRequest_BuildPipeline(hreq, &hybridParams, false, status) != REDISMODULE_OK) {
     HybridPipelineParams_Cleanup(&hybridParams);
-    HybridRequest_DecrRef(hreq);
+    HybridRequest_Free(hreq);
     return NULL;
   }
 
@@ -237,7 +237,7 @@ static void HybridRequest_Debug_Free(HybridRequest_Debug *debug_req) {
   }
 
   if (debug_req->hreq) {
-    HybridRequest_DecrRef(debug_req->hreq);
+    HybridRequest_Free(debug_req->hreq);
   }
 
   rm_free(debug_req);

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -736,10 +736,6 @@ void HybridRequest_Execute(HybridRequest *hreq, RedisModuleCtx *ctx, RedisSearch
     RedisModule_EndReply(reply);
 }
 
-static void FreeHybridRequest(void *ptr) {
-  HybridRequest_DecrRef((HybridRequest *)ptr);
-}
-
 static inline void replyWithCursors(RedisModuleCtx *replyCtx, HybridRequest *hreq,
                                      bool timedOut) {
     RedisModule_Reply _reply = RedisModule_NewReply(replyCtx), *reply = &_reply;
@@ -821,8 +817,7 @@ int HybridRequest_ReserveSubCursors(HybridRequest *req, QueryError *status) {
     return REDISMODULE_OK;
 }
 
-int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, QueryError *status, bool backgroundDepletion) {
-    HybridRequest *req = StrongRef_Get(hybrid_ref);
+int HybridRequest_StartCursors(HybridRequest *req, RedisModuleCtx *replyCtx, QueryError *status, bool backgroundDepletion) {
     if (req->nrequests == 0) {
       QueryError_SetError(&req->tailPipelineError, QUERY_ERROR_CODE_GENERIC, "No subqueries in hybrid request");
       return REDISMODULE_ERR;
@@ -932,11 +927,10 @@ static void returnSpecReadLocks(HybridRequest *hreq) {
  * @param depleteInBackground Whether the pipeline should be built for asynchronous depletion
  * @return REDISMODULE_OK on success, REDISMODULE_ERR on error
 */
-static int buildPipelineAndExecute(StrongRef hybrid_ref, HybridPipelineParams *hybridParams,
+static int buildPipelineAndExecute(HybridRequest *hreq, HybridPipelineParams *hybridParams,
                                    RedisModuleCtx *ctx, RedisSearchCtx *sctx, QueryError *status,
                                    bool internal, bool depleteInBackground) {
   // Build the pipeline and execute
-  HybridRequest *hreq = StrongRef_Get(hybrid_ref);
   bool isCursor = hreq->reqflags & QEXEC_F_IS_CURSOR;
   int rc = REDISMODULE_ERR;
 
@@ -1029,7 +1023,7 @@ static int buildPipelineAndExecute(StrongRef hybrid_ref, HybridPipelineParams *h
       RPSafeDepleter_JoinAll(depleters);
       array_free(depleters);
     }
-  } else if (HybridRequest_StartCursors(hybrid_ref, ctx, status, depleteInBackground) != REDISMODULE_OK) {
+  } else if (HybridRequest_StartCursors(hreq, ctx, status, depleteInBackground) != REDISMODULE_OK) {
     goto done;
   }
   rc = REDISMODULE_OK;
@@ -1215,12 +1209,12 @@ static int HybridQueryReplyCallback(RedisModuleCtx *ctx, RedisModuleString **arg
 }
 
 // Background execution functions implementation
-static blockedClientHybridCtx *blockedClientHybridCtx_New(StrongRef hybrid_ref,
+static blockedClientHybridCtx *blockedClientHybridCtx_New(HybridRequest *hreq,
                                                    HybridPipelineParams *hybridParams,
                                                    RedisModuleBlockedClient *blockedClient,
                                                    StrongRef spec, bool internal) {
   blockedClientHybridCtx *ret = rm_new(blockedClientHybridCtx);
-  ret->hybrid_ref = hybrid_ref;
+  ret->hreq = hreq;
   ret->blockedClient = blockedClient;
   ret->spec_ref = StrongRef_Demote(spec);
   ret->hybridParams = hybridParams;
@@ -1228,12 +1222,11 @@ static blockedClientHybridCtx *blockedClientHybridCtx_New(StrongRef hybrid_ref,
   return ret;
 }
 
-// Build the pipeline and execute
-// if result is REDISMODULE_OK, the hreq and hybridParams are freed by the function thread
-// otherwise, the caller is responsible for freeing them
-static int HybridRequest_BuildPipelineAndExecute(StrongRef hybrid_ref, HybridPipelineParams *hybridParams, RedisModuleCtx *ctx,
+// Build the pipeline and execute.
+// On REDISMODULE_OK the request and hybridParams are consumed; on error the
+// caller still owns both.
+static int HybridRequest_BuildPipelineAndExecute(HybridRequest *hreq, HybridPipelineParams *hybridParams, RedisModuleCtx *ctx,
                     RedisSearchCtx *sctx, QueryError* status, bool internal) {
-  HybridRequest *hreq = StrongRef_Get(hybrid_ref);
   if (RunInThread(ctx)) {
     // Multi-threaded execution path
     StrongRef spec_ref = IndexSpec_GetStrongRefUnsafe(sctx->spec);
@@ -1265,7 +1258,7 @@ static int HybridRequest_BuildPipelineAndExecute(StrongRef hybrid_ref, HybridPip
     RedisModuleBlockedClient* blockedClient = BlockQueryClientWithTimeout(
         ctx, spec_ref, &hreq->base, replyCallback, timeoutCallback, timeoutMS);
 
-    blockedClientHybridCtx *BCHCtx = blockedClientHybridCtx_New(StrongRef_Clone(hybrid_ref), hybridParams, blockedClient, spec_ref, internal);
+    blockedClientHybridCtx *BCHCtx = blockedClientHybridCtx_New(hreq, hybridParams, blockedClient, spec_ref, internal);
 
     // Mark the hreq as running in the background
     hreq->reqflags |= QEXEC_F_RUN_IN_BACKGROUND;
@@ -1286,19 +1279,23 @@ static int HybridRequest_BuildPipelineAndExecute(StrongRef hybrid_ref, HybridPip
     return REDISMODULE_OK;
   } else {
     // Single-threaded execution path
-    return buildPipelineAndExecute(hybrid_ref, hybridParams, ctx, sctx, status, internal, false);
+    int rc = buildPipelineAndExecute(hreq, hybridParams, ctx, sctx, status, internal, false);
+    if (rc == REDISMODULE_OK) {
+      HybridRequest_Free(hreq);
+    }
+    return rc;
   }
 }
 
-static inline void DefaultCleanup(StrongRef hybrid_ref) {
-  StrongRef_Release(hybrid_ref);
+static inline void DefaultCleanup(HybridRequest *hreq) {
+  HybridRequest_Free(hreq);
   CurrentThread_ClearIndexSpec();
 }
 
 // We only want to free the hybrid params in case an error happened
-static inline int CleanupAndReplyStatus(RedisModuleCtx *ctx, StrongRef hybrid_ref, HybridPipelineParams *hybridParams, QueryError *status, bool internal) {
+static inline int CleanupAndReplyStatus(RedisModuleCtx *ctx, HybridRequest *hreq, HybridPipelineParams *hybridParams, QueryError *status, bool internal) {
     freeHybridParams(hybridParams);
-    DefaultCleanup(hybrid_ref);
+    DefaultCleanup(hreq);
     // Update global query errors, this path is only used for SA and internal
     QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(status), 1, !internal);
     return QueryError_ReplyAndClear(ctx, status);
@@ -1398,8 +1395,6 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     hybridRequest->debugParams = rm_malloc(sizeof(*debugParams));
     *hybridRequest->debugParams = *debugParams;
   }
-  StrongRef hybrid_ref = StrongRef_New(hybridRequest, &FreeHybridRequest);
-
   ParseHybridCommandCtx cmd = {0};
   cmd.search = hybridRequest->requests[SEARCH_INDEX];
   cmd.vector = hybridRequest->requests[VECTOR_INDEX];
@@ -1413,7 +1408,7 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   HybridRequest_InitArgsCursor(hybridRequest, &ac, argc);
 
   if (parseHybridCommand(ctx, &ac, sctx, &cmd, &status, internal, profileOptions) != REDISMODULE_OK) {
-    return CleanupAndReplyStatus(ctx, hybrid_ref, cmd.hybridParams, &status, internal);
+    return CleanupAndReplyStatus(ctx, hybridRequest, cmd.hybridParams, &status, internal);
   }
   hybridRequest->reqflags = cmd.hybridParams->aggregationParams.common.reqflags;
 
@@ -1421,7 +1416,7 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     if (RequestConfig_ApplyCoordinatorElapsedTime(
             &hybridRequest->reqConfig, hybridRequest->profileClocks.coordDispatchTime)) {
       freeHybridParams(cmd.hybridParams);
-      DefaultCleanup(hybrid_ref);
+      DefaultCleanup(hybridRequest);
       return replyForHybridPreExecutionTimeout(ctx, internal, profileOptions);
     }
     // Propagate adjusted timeout to sub-queries
@@ -1453,20 +1448,25 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   // limit failures surface before any background work is dispatched.
   if ((hybridRequest->reqflags & QEXEC_F_IS_CURSOR) &&
       HybridRequest_ReserveSubCursors(hybridRequest, &status) != REDISMODULE_OK) {
-    return CleanupAndReplyStatus(ctx, hybrid_ref, cmd.hybridParams, &status, internal);
+    return CleanupAndReplyStatus(ctx, hybridRequest, cmd.hybridParams, &status, internal);
   }
 
-  if (HybridRequest_BuildPipelineAndExecute(hybrid_ref, cmd.hybridParams, ctx, hybridRequest->sctx, &status, internal) != REDISMODULE_OK) {
+  // Capture before dispatch: on success the request is consumed and must not
+  // be read afterwards.
+  const unsigned int dialectVersion = hybridRequest->reqConfig.dialectVersion;
+  IndexSpec *spec = sctx->spec;
+
+  if (HybridRequest_BuildPipelineAndExecute(hybridRequest, cmd.hybridParams, ctx, hybridRequest->sctx, &status, internal) != REDISMODULE_OK) {
     HybridRequest_GetError(hybridRequest, &status);
     HybridRequest_ClearErrors(hybridRequest);
-    return CleanupAndReplyStatus(ctx, hybrid_ref, cmd.hybridParams, &status, internal);
+    return CleanupAndReplyStatus(ctx, hybridRequest, cmd.hybridParams, &status, internal);
   }
 
   // Update dialect statistics only after successful execution
-  SET_DIALECT(sctx->spec->used_dialects, hybridRequest->reqConfig.dialectVersion);
-  SET_DIALECT(RSGlobalStats.totalStats.used_dialects, hybridRequest->reqConfig.dialectVersion);
+  SET_DIALECT(spec->used_dialects, dialectVersion);
+  SET_DIALECT(RSGlobalStats.totalStats.used_dialects, dialectVersion);
 
-  DefaultCleanup(hybrid_ref);
+  CurrentThread_ClearIndexSpec();
   return REDISMODULE_OK;
 }
 
@@ -1476,7 +1476,6 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
  * @param BCHCtx The blocked client context to destroy
  */
 static void blockedClientHybridCtx_destroy(blockedClientHybridCtx *BCHCtx) {
-  StrongRef_Release(BCHCtx->hybrid_ref);
   freeHybridParams(BCHCtx->hybridParams);
   RedisModule_BlockedClientMeasureTimeEnd(BCHCtx->blockedClient);
   void *privdata = RedisModule_BlockClientGetPrivateData(BCHCtx->blockedClient);
@@ -1492,8 +1491,7 @@ static void blockedClientHybridCtx_destroy(blockedClientHybridCtx *BCHCtx) {
  * @param BCHCtx The blocked client context containing the request
  */
 static void HREQ_Execute_Callback(blockedClientHybridCtx *BCHCtx) {
-  StrongRef hybrid_ref = BCHCtx->hybrid_ref;
-  HybridRequest *hreq = StrongRef_Get(hybrid_ref);
+  HybridRequest *hreq = BCHCtx->hreq;
   // Picked up from the job queue: a timeout from here on is attributed to PIPELINE
   // (no-op if already timed out while queued, via the SetExecutionStage freeze).
   HybridRequest_SetExecutionStage(hreq, QUERY_TIMEOUT_STAGE_PIPELINE);
@@ -1529,7 +1527,7 @@ static void HREQ_Execute_Callback(blockedClientHybridCtx *BCHCtx) {
     AREQ_SearchCtx(hreq->requests[i])->redisCtx = subctx;
   }
 
-  if (buildPipelineAndExecute(hybrid_ref, hybridParams, outctx, sctx, &status, BCHCtx->internal, true) == REDISMODULE_OK) {
+  if (buildPipelineAndExecute(hreq, hybridParams, outctx, sctx, &status, BCHCtx->internal, true) == REDISMODULE_OK) {
     // Set hybridParams to NULL so they won't be freed in destroy
     BCHCtx->hybridParams = NULL;
   } else {
@@ -1551,8 +1549,7 @@ static void HREQ_Execute_Callback(blockedClientHybridCtx *BCHCtx) {
 
   RedisModule_FreeThreadSafeContext(outctx);
   IndexSpecRef_Release(execution_ref);
-  // The hybrid request is still alive here (destroy releases the StrongRef),
-  // and unblocking the client below may free it.
+  // Unblocking the client below may free the request; last touch before destroy.
   RedisSearchCtx_AssertLockNotHeld(HREQ_SearchCtx(hreq));
   blockedClientHybridCtx_destroy(BCHCtx);
 }

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -356,17 +356,13 @@ void HybridRequest_Free(HybridRequest *req) {
         // A parked sub never touches a ctx again; drop any foreground-cycle
         // borrow before the cursor takes over.
         AREQ_SearchCtx(sub)->redisCtx = NULL;
-        const bool publish =
-            sub->base.cursorInfo.disposition == CURSOR_DISPOSITION_PAUSE && !timedOut;
+        const bool free_it =
+            sub->base.cursorInfo.disposition != CURSOR_DISPOSITION_PAUSE || timedOut;
         sub->base.cursorInfo.cursor = NULL;
-        sub->base.cursorInfo.disposition = CURSOR_DISPOSITION_NONE;
-        if (publish) {
-          Cursor_Pause(cursor);
-        } else {
-          Cursor_Free(cursor);
-        }
+        sub->base.cursorInfo.disposition = CURSOR_DISPOSITION_FREE;
+        AREQ_CursorEndOfCycle(sub, cursor, free_it);
       } else {
-        AREQ_DecrRef(sub);
+        AREQ_Free(sub);
       }
     }
     array_free(req->requests);
@@ -396,15 +392,6 @@ void HybridRequest_Free(HybridRequest *req) {
     rm_free(req);
 }
 
-HybridRequest *HybridRequest_IncrRef(HybridRequest *req) {
-  QueryRequest_IncrRef(&req->base);
-  return req;
-}
-
-void HybridRequest_DecrRef(HybridRequest *req) {
-  if (!req) return;
-  QueryRequest_DecrRef(&req->base);
-}
 
 static bool isSoftTailPipelineErrorCode(QueryErrorCode code) {
     return code == QUERY_ERROR_CODE_NO_PROP_VAL;

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -114,11 +114,8 @@ void HybridRequest_WaitForAggregateResultsComplete(HybridRequest *req);
 
 // Blocked client context for HybridRequest background execution
 typedef struct blockedClientHybridCtx {
-  // The BG job's hold on the container, released in destroy (before
-  // UnblockClient; the cycle's wrapper reference carries the container to
-  // OnFree). TRANSITIONAL(MOD-16691): becomes a borrow once the wrapper is
-  // single-owner.
-  StrongRef hybrid_ref;
+  // Borrowed; the cycle owns the request (see QueryRequest).
+  HybridRequest *hreq;
   HybridPipelineParams *hybridParams;
   RedisModuleBlockedClient *blockedClient;
   WeakRef spec_ref;
@@ -239,25 +236,10 @@ void HybridPipelineParams_Cleanup(HybridPipelineParams *params);
 int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params, bool depleteInBackground, QueryError *status);
 
 /**
- * Free a HybridRequest and all its associated resources directly.
- * Called by the final QueryRequest release. Do not call directly; use
- * HybridRequest_DecrRef instead.
+ * Free a HybridRequest and all its associated resources.
+ * Owner-only: see the ownership contract on QueryRequest.
  */
 void HybridRequest_Free(HybridRequest *req);
-
-/**
- * Increment the embedded QueryRequest reference count.
- * @param req the request to increment
- * @return the request (for chaining)
- */
-HybridRequest *HybridRequest_IncrRef(HybridRequest *req);
-
-/**
- * Decrement the embedded QueryRequest reference count. The final release
- * destroys the HybridRequest.
- * @param req the request to decrement
- */
-void HybridRequest_DecrRef(HybridRequest *req);
 
 int HybridRequest_GetError(HybridRequest *req, QueryError *status);
 

--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -26,14 +26,10 @@ void QueryRequest_BeginCycle(QueryRequest *request, RedisModuleBlockedClient *bc
   // No overlapping cycles: the previous cycle's OnFree must have run before a
   // new cycle may begin on the same request. This holds structurally for
   // blocked cursor cycles — the cursor is only parked back into the idle list
-  // by OnFree (cursorEndOfCycle records the disposition; OnFree executes it),
-  // so no other client can take it before the cycle fully ended.
+  // at cycle end (AREQ_CursorEndOfCycle records the disposition; EndCycle executes
+  // it), so no other client can take it before the cycle fully ended.
   RS_ASSERT(!request->blockedClientCycleActive && request->registryInfo.node == NULL &&
             request->registryInfo.kind == REGISTRY_ENTRY_NONE);
-  // The cycle's hold keeps the request alive until OnFree, so the reply/timeout
-  // callbacks may dereference the privdata even if the BG worker released its
-  // own hold (e.g. a cursor freed on ITERDONE) before the client was unblocked.
-  QueryRequest_IncrRef(request);
   request->blockedClientCycleActive = true;
   QueryRequest_SetUseReplyCallback(request, reply_cb != NULL);
   RS_AtomicIntStoreRelaxed(&request->async.strictReadOwner, QUERY_REQUEST_READ_OWNER_NONE);
@@ -52,25 +48,30 @@ void QueryRequest_EndCycle(QueryRequest *request) {
   }
   request->registryInfo.node = NULL;
   request->registryInfo.kind = REGISTRY_ENTRY_NONE;
-  // Dispose a stashed cursor reference-releasingly BEFORE the generic destroy:
-  // AREQ_CleanUpStoredCursor frees the cursor with its request handle intact,
-  // so Cursor_FreeInternal releases the cursor's request reference. Skipping
-  // this and letting ChunkReplyState_Destroy handle the stash would leak that
-  // reference (it deliberately clears the handle first — correct only in the
-  // refcount==0 context of final request destruction). Disposing the stash
-  // here also prevents the RETURN_STRICT preempt path from leaking the cursor
-  // reserved by an initial WITHCURSOR query.
-  if (request->kind == QUERY_REQUEST_KIND_AREQ) {
-    AREQ_CleanUpStoredCursor(QueryRequest_GetAREQ(request));
-  }
   // Per-cycle reply-state teardown: dispose whatever the reply callback did
   // not consume (unconsumed stored results when the timeout replied first).
   // Idempotent; base destruction also clears reply state as a safety net.
   QueryRequest_ResetReply(request);
 
+  // Snapshot the disposition before clearing the per-cycle fields it lives in.
+  struct Cursor *cursor = request->cursorInfo.cursor;
+  CursorDisposition disposition = request->cursorInfo.disposition;
   request->blockedClientCycleActive = false;
   request->cursorInfo.cursor = NULL;
-  request->cursorInfo.disposition = CURSOR_DISPOSITION_NONE;
+  request->cursorInfo.disposition = CURSOR_DISPOSITION_FREE;
+
+  // Parking only here, at cycle end, is what keeps the cycle's cursor
+  // unreachable to other clients mid-cycle. Cursor_Pause converts park to
+  // free when CURSOR DEL marked the cursor mid-cycle (delete_mark).
+  if (cursor) {
+    if (disposition == CURSOR_DISPOSITION_PAUSE) {
+      Cursor_Pause(cursor);
+    } else {
+      Cursor_Free(cursor);
+    }
+  } else {
+    QueryRequest_Free(request);
+  }
 }
 
 void QueryRequest_OnFree(RedisModuleCtx *ctx, void *privdata) {
@@ -80,23 +81,7 @@ void QueryRequest_OnFree(RedisModuleCtx *ctx, void *privdata) {
   // free_privdata fired without blocking the main thread in the callback.
   QueryRequestOnFreeDebug_Increment();
 #endif
-  // Execute the cycle's cursor disposition (snapshot first — EndCycle clears
-  // the per-cycle fields). Parking here, after the reply/timeout callback, is
-  // what keeps a cycle's cursor unreachable to other clients mid-cycle.
-  // Cursor_Pause converts park to free when CURSOR DEL marked the cursor
-  // mid-cycle (delete_mark).
-  struct Cursor *cursor = request->cursorInfo.cursor;
-  CursorDisposition disposition = request->cursorInfo.disposition;
   QueryRequest_EndCycle(request);
-  if (cursor) {
-    if (disposition == CURSOR_DISPOSITION_FREE) {
-      Cursor_Free(cursor);
-    } else {
-      RS_ASSERT(disposition == CURSOR_DISPOSITION_PAUSE);
-      Cursor_Pause(cursor);
-    }
-  }
-  QueryRequest_DecrRef(request);
 }
 
 RedisModuleBlockedClient *BlockQueryClientWithTimeout(RedisModuleCtx *ctx, StrongRef spec_ref,
@@ -146,6 +131,10 @@ RedisModuleBlockedClient *BlockCursorClientWithTimeout(RedisModuleCtx *ctx, Curs
   RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, reply_cb, timeout_cb,
                                                          QueryRequest_OnFree, timeout_ms);
   QueryRequest_BeginCycle(request, bc, reply_cb);
+  // Publish the cycle's cursor handle up front, on the main thread. The
+  // disposition keeps its FREE default unless the cycle's reply exposes a
+  // live cursor id and records PAUSE.
+  request->cursorInfo.cursor = cursor;
   // Cursor cycles reuse the request across reads: reset the per-read
   // RETURN_STRICT claim/latch state so the new cycle starts from a clean
   // slate.

--- a/src/info/info_redis/block_client.h
+++ b/src/info/info_redis/block_client.h
@@ -38,20 +38,21 @@ struct QueryRequest;
 
 /* Bind the per-cycle fields on `request`. Called on the main thread after
  * RedisModule_BlockClient returned `bc` (with QueryRequest_OnFree
- * registered as free_privdata) and before dispatching BG work. Takes the
- * cycle's reference on the request, sets `request` as the blocked client's
- * privdata, and records the cycle's reply mode (`reply_cb` must be the value
- * that was passed to RedisModule_BlockClient). */
+ * registered as free_privdata) and before dispatching BG work. Takes
+ * ownership of the request (it becomes the blocked client's privdata — see
+ * the ownership contract on QueryRequest) and records the cycle's reply mode
+ * (`reply_cb` must be the value that was passed to RedisModule_BlockClient). */
 void QueryRequest_BeginCycle(struct QueryRequest *request, RedisModuleBlockedClient *bc,
                              RedisModuleCmdFunc reply_cb);
 
-/* Unlink the cycle's registry node and clear the per-cycle fields. Called from
- * OnFree; callable directly only in tests. */
+/* End the cycle: unlink the registry node, drain unconsumed per-cycle reply
+ * state, then dispose of the request — execute the recorded cursor
+ * disposition, or free it. Called from OnFree. */
 void QueryRequest_EndCycle(struct QueryRequest *request);
 
 /* The free_privdata callback registered with RedisModule_BlockClient. Runs on
  * the main thread after the reply or timeout callback, before the blocked
- * client is destroyed. Ends the cycle and releases the cycle's request hold. */
+ * client is destroyed; delegates to QueryRequest_EndCycle. */
 void QueryRequest_OnFree(RedisModuleCtx *ctx, void *privdata);
 
 /* Block `ctx` for one query cycle of `request`. Registers the cycle in

--- a/src/query_request.c
+++ b/src/query_request.c
@@ -62,21 +62,10 @@ static inline void QueryRequestAsyncState_Destroy(QueryRequestAsyncState *state)
   pthread_cond_destroy(&state->aggregateResultsCond);
 }
 
-QueryRequest *QueryRequest_IncrRef(QueryRequest *request) {
-  atomic_fetch_add_explicit(&request->refcount, 1, memory_order_relaxed);
-  return request;
-}
-
-void QueryRequest_DecrRef(QueryRequest *request) {
+void QueryRequest_Free(QueryRequest *request) {
   if (!request) {
     return;
   }
-  int previous = atomic_fetch_sub_explicit(&request->refcount, 1, memory_order_acq_rel);
-  RS_LOG_ASSERT_ALWAYS(previous > 0, "QueryRequest reference count underflow");
-  if (previous != 1) {
-    return;
-  }
-
   switch (request->kind) {
     case QUERY_REQUEST_KIND_AREQ:
       AREQ_Free((AREQ *)request);
@@ -106,7 +95,6 @@ static void QueryRequest_HoldArgs(QueryRequestArgs *args, RedisModuleString **ar
 void QueryRequest_Init(QueryRequest *request, QueryRequestKind kind, RedisModuleString **argv,
                        uint32_t argc) {
   request->kind = kind;
-  RS_AtomicIntStoreRelaxed(&request->refcount, 1);
   request->args = (QueryRequestArgs) {
     .queryOffset = QUERY_OFFSET_NONE,
   };

--- a/src/query_request.h
+++ b/src/query_request.h
@@ -39,11 +39,6 @@ typedef struct {
 
 /**
  * State retained while results wait for the main-thread reply callback.
- *
- * The cursor owns a request reference, not vice versa.
- * The cursor pointer stored here is non-owning and exists only so the reply
- * callback can pause or free it after serialization determines whether the
- * cursor is depleted. It must be cleared after the cursor is handled.
  */
 typedef struct {
   SearchResult **results;  // Aggregated results array (NULL if not stored)
@@ -56,7 +51,6 @@ typedef struct {
    * RETURN_STRICT flip wires every pipeline directly. */
   QueryError err;
   cachedVars cv;           // Cached lookup variables used during serialization
-  struct Cursor *cursor;   // Non-owning cursor handle for the reply callback
   size_t limit;            // Original limit, used to calculate the RESP2 result length
 } ChunkReplyState;
 
@@ -66,17 +60,20 @@ typedef enum {
 } QueryRequestKind;
 
 typedef enum {
-  CURSOR_DISPOSITION_NONE,   // No cursor is awaiting end-of-cycle handling.
+  /* Destroy the cursor when the active cycle ends. The per-cycle default: a
+   * cycle whose reply exposed no live cursor id must free, never park. */
+  CURSOR_DISPOSITION_FREE,
   CURSOR_DISPOSITION_PAUSE,  // Return the cursor to the idle list for another read.
-  CURSOR_DISPOSITION_FREE,   // Destroy the cursor when the active cycle ends.
 } CursorDisposition;
 
 typedef struct {
   uint64_t id;
-  /* Cursor disposition for this cycle. The point that decides the cursor's
-   * fate records it here; OnFree executes it, keeping the cursor unreachable
-   * to other clients until the cycle has fully ended. The pointer is NULL when
-   * the cycle has no cursor; inline execution disposes the cursor directly. */
+  /* The cycle's cursor, published when it becomes known (main thread at read
+   * dispatch; at reservation for the initial cycle); NULL when the cycle has
+   * no cursor. The path that replies a live cursor id records PAUSE;
+   * EndCycle executes the disposition, keeping the cursor unreachable to
+   * other clients until the cycle has fully ended. Inline execution disposes
+   * the cursor directly instead. */
   struct Cursor *cursor;
   CursorDisposition disposition;
 } CursorInfo;
@@ -184,11 +181,19 @@ void QueryRequestAsyncState_RegisterAbortWakeChannel(QueryRequestAsyncState *sta
 void QueryRequestAsyncState_UnregisterAbortWakeChannel(QueryRequestAsyncState *state);
 void QueryRequestAsyncState_WakeAbortChannel(QueryRequestAsyncState *state);
 
+/* Lifetime management.
+ *
+ * A QueryRequest has exactly one owner at any time — no reference counting.
+ * Construction hands it to the creating flow; QueryRequest_BeginCycle hands it
+ * to the blocked client (the privdata), whose OnFree ends the cycle by either
+ * executing the recorded cursor disposition (PAUSE hands ownership to the
+ * cursor; FREE frees through it) or freeing the request. A parked cursor owns
+ * its request (Cursor.query); taking the cursor for a read hands it to the new
+ * cycle. Workers and the reply/timeout callbacks borrow the privdata for the
+ * cycle's duration — safe because every flow calls UnblockClient after its
+ * last touch, and OnFree only runs after that. */
 typedef struct QueryRequest {
   QueryRequestKind kind;
-  /* Starts at 1. ACQ_REL on the final decrement ensures destruction observes
-   * prior writes from every owner. */
-  RS_Atomic(int) refcount;
   QueryRequestArgs args;
   /* A blocked-client cycle is one initial query execution or cursor read.
    * This is set after RedisModule_BlockClient returns and cleared by OnFree;
@@ -214,11 +219,9 @@ typedef struct QueryRequest {
   ResultProcessor **endProcRef;
 } QueryRequest;
 
-QueryRequest *QueryRequest_IncrRef(QueryRequest *request);
-
-/* Release one reference. The final release destroys the concrete request
- * selected by `kind`. */
-void QueryRequest_DecrRef(QueryRequest *request);
+/* Destroy the concrete request selected by `kind`. Owner-only: never call it
+ * on a borrowed request (see the ownership contract on QueryRequest). */
+void QueryRequest_Free(QueryRequest *request);
 
 static inline void QueryRequest_SetEndProcRef(QueryRequest *request,
                                               ResultProcessor **endProcRef) {

--- a/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_distribute_collect.cpp
@@ -72,7 +72,7 @@ protected:
   }
 
   // Compile + distribute. Sets *outPlan and returns the AREQ; caller frees
-  // the AREQ via AREQ_DecrRef when done. *outPlan is owned by the AREQ.
+  // the AREQ via AREQ_Free when done. *outPlan is owned by the AREQ.
   AREQ *compileAndDistribute(const std::vector<std::string> &collectTokens,
                              AGGPlan **outPlan) {
     auto argv = buildAggregateArgv(collectTokens);
@@ -84,7 +84,7 @@ protected:
     int rc = AREQ_Compile(r, ctx, 0, false, &qerr);
     EXPECT_EQ(rc, REDISMODULE_OK) << QueryError_GetUserError(&qerr);
     if (rc != REDISMODULE_OK) {
-      AREQ_DecrRef(r);
+      AREQ_Free(r);
       return nullptr;
     }
 
@@ -92,7 +92,7 @@ protected:
     rc = AGGPLN_Distribute(plan, &qerr);
     EXPECT_EQ(rc, REDISMODULE_OK) << QueryError_GetUserError(&qerr);
     if (rc != REDISMODULE_OK) {
-      AREQ_DecrRef(r);
+      AREQ_Free(r);
       return nullptr;
     }
 
@@ -176,7 +176,7 @@ TEST_F(DistributeCollectTest, FieldsList_NoSortBy_NoLimit) {
   ASSERT_NE(pair.remote->alias, nullptr);
   EXPECT_STREQ(pair.local->inputAlias, pair.remote->alias);
 
-  AREQ_DecrRef(r);
+  AREQ_Free(r);
 }
 
 TEST_F(DistributeCollectTest, FieldsList_SortByOnly_NoLimit) {
@@ -198,7 +198,7 @@ TEST_F(DistributeCollectTest, FieldsList_SortByOnly_NoLimit) {
   EXPECT_EQ(argsAsStrings(pair.remote), expected);
   EXPECT_EQ(argsAsStrings(pair.local), expected);
 
-  AREQ_DecrRef(r);
+  AREQ_Free(r);
 }
 
 TEST_F(DistributeCollectTest, FieldsList_NoSortBy_Limit_RewritesRemoteLimit) {
@@ -220,7 +220,7 @@ TEST_F(DistributeCollectTest, FieldsList_NoSortBy_Limit_RewritesRemoteLimit) {
             (std::vector<std::string>{"FIELDS", "1", "@name",
                                       "LIMIT", "2", "3"}));
 
-  AREQ_DecrRef(r);
+  AREQ_Free(r);
 }
 
 TEST_F(DistributeCollectTest, FieldsList_SortBy_Limit_RewritesRemoteLimit) {
@@ -244,7 +244,7 @@ TEST_F(DistributeCollectTest, FieldsList_SortBy_Limit_RewritesRemoteLimit) {
                                       "SORTBY", "2", "@price", "ASC",
                                       "LIMIT", "2", "3"}));
 
-  AREQ_DecrRef(r);
+  AREQ_Free(r);
 }
 
 // ----------------------------------------------------------------------------
@@ -265,7 +265,7 @@ TEST_F(DistributeCollectTest, FieldsStar_NoSortBy_NoLimit) {
   EXPECT_EQ(argsAsStrings(pair.local),
             (std::vector<std::string>{"FIELDS", "*"}));
 
-  AREQ_DecrRef(r);
+  AREQ_Free(r);
 }
 
 TEST_F(DistributeCollectTest, FieldsStar_SortByOnly_NoLimit) {
@@ -283,7 +283,7 @@ TEST_F(DistributeCollectTest, FieldsStar_SortByOnly_NoLimit) {
   EXPECT_EQ(argsAsStrings(pair.remote), expected);
   EXPECT_EQ(argsAsStrings(pair.local), expected);
 
-  AREQ_DecrRef(r);
+  AREQ_Free(r);
 }
 
 TEST_F(DistributeCollectTest, FieldsStar_NoSortBy_Limit_RewritesRemoteLimit) {
@@ -300,7 +300,7 @@ TEST_F(DistributeCollectTest, FieldsStar_NoSortBy_Limit_RewritesRemoteLimit) {
   EXPECT_EQ(argsAsStrings(pair.local),
             (std::vector<std::string>{"FIELDS", "*", "LIMIT", "1", "4"}));
 
-  AREQ_DecrRef(r);
+  AREQ_Free(r);
 }
 
 TEST_F(DistributeCollectTest, FieldsStar_SortBy_Limit_RewritesRemoteLimit) {
@@ -324,7 +324,7 @@ TEST_F(DistributeCollectTest, FieldsStar_SortBy_Limit_RewritesRemoteLimit) {
                                       "SORTBY", "2", "@price", "DESC",
                                       "LIMIT", "5", "10"}));
 
-  AREQ_DecrRef(r);
+  AREQ_Free(r);
 }
 
 // ----------------------------------------------------------------------------
@@ -345,7 +345,7 @@ TEST_F(DistributeCollectTest, KeywordCase_NormalizedOnRemote_VerbatimOnLocal) {
   EXPECT_EQ(argsAsStrings(pair.local),
             (std::vector<std::string>{"fields", "1", "@name"}));
 
-  AREQ_DecrRef(r);
+  AREQ_Free(r);
 }
 
 }  // namespace

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -349,7 +349,7 @@ protected:
             if (hybridParams.scoringCtx) {
                 HybridScoringContext_Free(hybridParams.scoringCtx);
             }
-            HybridRequest_DecrRef(hreq);
+            HybridRequest_Free(hreq);
             FAIL() << "Failed to parse hybrid command";
         }
 
@@ -410,7 +410,7 @@ protected:
         if (hybridParams.scoringCtx) {
             HybridScoringContext_Free(hybridParams.scoringCtx);
         }
-        HybridRequest_DecrRef(hreq);
+        HybridRequest_Free(hreq);
     }
 
     // Parse a full FT.HYBRID command, build the per-shard MR command as the
@@ -445,7 +445,7 @@ protected:
         EXPECT_EQ(rc, REDISMODULE_OK) << QueryError_GetDisplayableError(&status, false);
         if (rc != REDISMODULE_OK) {
             if (hybridParams.scoringCtx) HybridScoringContext_Free(hybridParams.scoringCtx);
-            HybridRequest_DecrRef(hreq);
+            HybridRequest_Free(hreq);
             return out;
         }
 
@@ -486,7 +486,7 @@ protected:
 
         MRCommand_Free(&xcmd);
         HybridScoringContext_Free(hybridParams.scoringCtx);
-        HybridRequest_DecrRef(hreq);
+        HybridRequest_Free(hreq);
         return out;
     }
 

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -93,7 +93,7 @@ TEST_F(AggTest, testBasic) {
   ASSERT_EQ(3, count);
 
   SearchResult_Destroy(&res);
-  AREQ_DecrRef(rr);
+  AREQ_Free(rr);
   IndexSpec_Free(spec);
   args.clear();
   aggArgs.clear();
@@ -312,7 +312,7 @@ TEST_F(AggTest, AvoidingCompleteResultStructOpt) {
     EXPECT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);
     bool res = rr->searchopts.flags & Search_CanSkipRichResults;
     QueryError_ClearError(&qerr);
-    AREQ_DecrRef(rr);
+    AREQ_Free(rr);
     return res;
   };
 

--- a/tests/cpptests/test_cpp_areq_compile.cpp
+++ b/tests/cpptests/test_cpp_areq_compile.cpp
@@ -157,7 +157,7 @@ TEST_P(AREQBinarySlotRangeTest, testBinarySlotRangeParsing) {
         RedisModule_FreeString(ctx, str);
     }
     QueryError_ClearError(&status);
-    AREQ_DecrRef(req);
+    AREQ_Free(req);
 }
 
 // Test data for parameterized tests - includes ranges that create null bytes in binary data
@@ -235,7 +235,7 @@ TEST_F(AREQTest, testBinarySlotRangeParsingSingleRange) {
         RedisModule_FreeString(ctx, str);
     }
     QueryError_ClearError(&status);
-    AREQ_DecrRef(req);
+    AREQ_Free(req);
 }
 
 // Test error handling for insufficient arguments
@@ -263,7 +263,7 @@ TEST_F(AREQTest, testBinarySlotRangeInsufficientArgs) {
         RedisModule_FreeString(ctx, str);
     }
     QueryError_ClearError(&status);
-    AREQ_DecrRef(req);
+    AREQ_Free(req);
 }
 
 // Test complex aggregate query with cursor, scorer, and slot ranges
@@ -310,5 +310,5 @@ TEST_F(AREQTest, testComplexAggregateWithCursorAndSlotRanges) {
         RedisModule_FreeString(ctx, str);
     }
     QueryError_ClearError(&status);
-    AREQ_DecrRef(req);
+    AREQ_Free(req);
 }

--- a/tests/cpptests/test_cpp_cursors.cpp
+++ b/tests/cpptests/test_cpp_cursors.cpp
@@ -10,6 +10,8 @@
 
 #include "gtest/gtest.h"
 #include "cursor.h"
+#include "aggregate/aggregate.h"
+#include "info/info_redis/block_client.h"
 #include <vector>
 #include <algorithm>
 
@@ -164,4 +166,65 @@ TEST_F(CursorsTest, OwnershipAPI) {
   // After the cursors are paused, they should be freed
   ASSERT_EQ(Cursors_GetInfoStats().total_user, 0) << "All cursors should be deleted";
 
+}
+
+// A cursor owns its carried request: every path that frees the cursor must
+// free the request exactly once (leaks and double frees surface under ASAN).
+TEST_F(CursorsTest, CarriedRequestOwnership) {
+  StrongRef dummy = {0};
+  const size_t base = Cursors_GetInfoStats().total_user;
+
+  // Freeing a cursor frees its carried request.
+  AREQ *r = AREQ_New(NULL, 0);
+  Cursor *cur = Cursors_Reserve(&g_CursorsList, dummy, 1000, NULL);
+  ASSERT_TRUE(cur != NULL);
+  cur->query = &r->base;
+  ASSERT_EQ(Cursor_Free(cur), REDISMODULE_OK);
+  ASSERT_EQ(Cursors_GetInfoStats().total_user, base);
+
+  // A delete-marked cursor (CURSOR DEL / list purge mid-cycle) converts its
+  // park into a free, which must also free the carried request.
+  r = AREQ_New(NULL, 0);
+  cur = Cursors_Reserve(&g_CursorsList, dummy, 1000, NULL);
+  ASSERT_TRUE(cur != NULL);
+  cur->query = &r->base;
+  ASSERT_EQ(Cursors_Purge(&g_CursorsList, cur->id), REDISMODULE_OK);
+  ASSERT_TRUE(cur->delete_mark);
+  ASSERT_EQ(Cursor_Pause(cur), REDISMODULE_OK) << "Pause must convert to free";
+  ASSERT_EQ(Cursors_GetInfoStats().total_user, base);
+}
+
+// EndCycle executes the recorded disposition: PAUSE parks the cursor (which
+// keeps owning its carried request); the FREE default tears down cursor and
+// request.
+TEST_F(CursorsTest, EndCycleExecutesRecordedDisposition) {
+  StrongRef dummy = {0};
+  const size_t base = Cursors_GetInfoStats().total_user;
+
+  // PAUSE: the cursor is parked back into the idle list.
+  AREQ *r = AREQ_New(NULL, 0);
+  Cursor *cur = Cursors_Reserve(&g_CursorsList, dummy, 1000, NULL);
+  ASSERT_TRUE(cur != NULL);
+  cur->query = &r->base;
+  r->base.blockedClientCycleActive = true;
+  r->base.cursorInfo.cursor = cur;
+  r->base.cursorInfo.disposition = CURSOR_DISPOSITION_PAUSE;
+  QueryRequest_EndCycle(&r->base);
+  ASSERT_TRUE(is_Idle(cur));
+  ASSERT_EQ(Cursors_GetInfoStats().total_user, base + 1);
+  ASSERT_EQ(Cursor_Free(cur), REDISMODULE_OK) << "Owner free: cursor + request";
+  ASSERT_EQ(Cursors_GetInfoStats().total_user, base);
+
+  // FREE is the per-cycle default: a cycle that recorded no PAUSE (e.g. the
+  // timeout replied without exposing a live cursor id) tears down the
+  // published cursor and its carried request, never parks them.
+  r = AREQ_New(NULL, 0);
+  cur = Cursors_Reserve(&g_CursorsList, dummy, 1000, NULL);
+  ASSERT_TRUE(cur != NULL);
+  cur->query = &r->base;
+  r->base.blockedClientCycleActive = true;
+  r->base.cursorInfo.cursor = cur;
+  ASSERT_EQ(r->base.cursorInfo.disposition, CURSOR_DISPOSITION_FREE);
+  QueryRequest_EndCycle(&r->base);
+  ASSERT_EQ(Cursors_GetInfoStats().total_user, base);
 }

--- a/tests/cpptests/test_cpp_hybrid.cpp
+++ b/tests/cpptests/test_cpp_hybrid.cpp
@@ -38,5 +38,5 @@ TEST_F(HybridRequestBasicTest, testHybridRequestCreationBasic) {
   // Verify the merge pipeline is initialized
   ASSERT_TRUE(hybridReq->tailPipeline->ap.steps.next != nullptr);
   // Clean up
-  HybridRequest_DecrRef(hybridReq);
+  HybridRequest_Free(hybridReq);
 }

--- a/tests/cpptests/test_cpp_hybrid_defaults.cpp
+++ b/tests/cpptests/test_cpp_hybrid_defaults.cpp
@@ -44,7 +44,7 @@ protected:
   void TearDown() override {
     // Free the result if it was set during the test
     if (result) {
-      HybridRequest_DecrRef(result);
+      HybridRequest_Free(result);
     }
     if (hybridParams.scoringCtx) {
       HybridScoringContext_Free(hybridParams.scoringCtx);
@@ -85,7 +85,7 @@ protected:
     HybridRequest_InitArgsCursor(result, &ac, args.size());
     int rc =  parseHybridCommand(ctx, &ac, result->sctx, &cmd, &status, false, EXEC_NO_FLAGS);
     if (rc != REDISMODULE_OK) {
-      HybridRequest_DecrRef(result);
+      HybridRequest_Free(result);
       result = nullptr;
     }
 

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -85,7 +85,7 @@ class ParseHybridTest : public ::testing::Test {
 
   void TearDown() override {
     if (hybridRequest) {
-      HybridRequest_DecrRef(hybridRequest);
+      HybridRequest_Free(hybridRequest);
     }
     if (hybridParams.scoringCtx) {
       HybridScoringContext_Free(hybridParams.scoringCtx);
@@ -134,7 +134,7 @@ class ParseHybridTest : public ::testing::Test {
   // request-scoped config, so tests that mutate RSGlobalConfig call this after.
   void recreateHybridRequest(RMCK::ArgvList &args) {
     if (hybridRequest) {
-      HybridRequest_DecrRef(hybridRequest);
+      HybridRequest_Free(hybridRequest);
     }
     hybridRequest =
         MakeDefaultHybridRequest(NewSearchCtxC(ctx, index_name.c_str(), true), args, args.size());

--- a/tests/cpptests/test_cpp_parse_hybrid_iterators.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid_iterators.cpp
@@ -76,7 +76,7 @@ struct HybridIteratorTestCtx {
 
     ~HybridIteratorTestCtx() {
       if (rootiter) rootiter->Free(rootiter);
-      if (hybridReq) HybridRequest_DecrRef(hybridReq);
+      if (hybridReq) HybridRequest_Free(hybridReq);
       if (hybridParams.scoringCtx) HybridScoringContext_Free(hybridParams.scoringCtx);
       if (spec) Indexes_RemoveSpecFromGlobals(spec->own_ref, false);
     }

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -117,7 +117,7 @@ IndexSpec* CreateStandardTestIndexSpec(RedisModuleCtx *ctx, const char* indexNam
  * 3. Build pipeline
  * 4. Return the built HybridRequest
  *
- * Note: The caller is responsible for calling HybridRequest_DecrRef() and IndexSpec cleanup.
+ * Note: The caller is responsible for calling HybridRequest_Free() and IndexSpec cleanup.
  */
 HybridRequest* ParseAndBuildHybridRequest(RedisModuleCtx *ctx, const char* indexName,
                                           RMCK::ArgvList& args, QueryError *status, IndexSpec **outSpec = nullptr) {
@@ -163,14 +163,14 @@ HybridRequest* ParseAndBuildHybridRequest(RedisModuleCtx *ctx, const char* index
   // Parse the hybrid command - this fills out hybridParams
   int rc = parseHybridCommand(ctx, &ac, test_sctx, &cmd, status, false, EXEC_NO_FLAGS);
   if (rc != REDISMODULE_OK) {
-    HybridRequest_DecrRef(hybridReq);
+    HybridRequest_Free(hybridReq);
     return nullptr;
   }
 
   // Build the pipeline using the parsed hybrid parameters
   rc = HybridRequest_BuildPipeline(hybridReq, cmd.hybridParams, true, status);
   if (rc != REDISMODULE_OK) {
-    HybridRequest_DecrRef(hybridReq);
+    HybridRequest_Free(hybridReq);
     return nullptr;
   }
   return hybridReq;
@@ -194,7 +194,7 @@ HybridRequest* ParseAndBuildHybridRequest(RedisModuleCtx *ctx, const char* index
     HybridRequest* req; \
     IndexSpec* sp; \
     ~HybridTestCleanup() { \
-      if (req) HybridRequest_DecrRef(req); \
+      if (req) HybridRequest_Free(req); \
       if (sp) Indexes_RemoveSpecFromGlobals(sp->own_ref, false); \
     } \
   } cleanup{hybridReq, spec};

--- a/tests/cpptests/test_distagg.cpp
+++ b/tests/cpptests/test_distagg.cpp
@@ -83,7 +83,7 @@ static void testAverage() {
     printf("ERROR!!!: %s\n", QueryError_GetUserError(&status));
     AGPLN_Dump(plan);
   }
-  AREQ_DecrRef(r);
+  AREQ_Free(r);
 }
 
 /**
@@ -129,7 +129,7 @@ static void testCountDistinct() {
   for (size_t ii = 0; ii < array_len(us.serialized); ++ii) {
     printf("Serialized[%lu]: %s\n", ii, us.serialized[ii]);
   }
-  AREQ_DecrRef(r);
+  AREQ_Free(r);
 }
 static void testSplit() {
   RMCK::Context ctx{};
@@ -167,7 +167,7 @@ static void testSplit() {
   for (size_t ii = 0; ii < array_len(us.serialized); ++ii) {
     printf("Serialized[%lu]: %s\n", ii, us.serialized[ii]);
   }
-  AREQ_DecrRef(r);
+  AREQ_Free(r);
 }
 
 int main(int, char **) {

--- a/tests/pytests/test_blocked_client_timeout.py
+++ b/tests/pytests/test_blocked_client_timeout.py
@@ -1343,7 +1343,7 @@ class TestCoordinatorTimeout:
         ``BeforeCursorReadSendChunk`` and fire ``CLIENT UNBLOCK ... TIMEOUT``
         to invoke ``CursorReadTimeoutFailCallback``. Verify the user sees
         ``-TIMEOUT``, the coord error metric bumps, and the coord cursor is
-        reclaimed via ``AREQ_CleanUpStoredCursor``.
+        reclaimed at cycle end (a cycle that records no park frees by default).
         """
         env = self.env
         skipIfNoEnableAssert(env)
@@ -7409,11 +7409,12 @@ class TestShardTimeout:
         after the handshake but before taking the Redis lock. The timeout callback
         loses the claim, observes holding == true, and takes the preempt branch:
         it replies with an exhausted cursor (id 0) and returns immediately. The
-        blocked-client free callback (ShardCursorBlockClient_FreeAREQ) then drains
-        req->storedReplyState.cursor - freeing the cursor (stashed before
-        sendChunk) and dropping its AREQ reference - while the worker is still
-        parked. Releasing the worker makes it resume sendChunk and keep using the
-        freed cursor/AREQ: a use-after-free (caught under SAN, otherwise a crash).
+        original shard free callback then freed the stashed cursor while the
+        worker was still parked; releasing the worker made it resume sendChunk
+        and keep using the freed cursor/AREQ: a use-after-free (caught under
+        SAN, otherwise a crash). Today the free callback runs only after the
+        worker's own unblock, and a cycle the timeout replied for records no
+        park, so cycle end frees the cursor.
 
         Detects the bug: releasing the worker after the cursor was freed must not
         corrupt memory; the cursor-read thread finishes and the server survives.
@@ -7468,9 +7469,9 @@ class TestShardTimeout:
     def test_return_strict_initial_withcursor_preempt_no_cursor_leak(self):
         """Initial RETURN_STRICT FT.AGGREGATE WITHCURSOR must not orphan its cursor.
 
-        The initial WITHCURSOR query reserves a cursor and stashes it in
-        storedReplyState.cursor before sendChunk. The worker wins the claim, marks
-        itself at the GIL gate, and parks at AfterSafeLoaderGILHandshake. The
+        The initial WITHCURSOR query reserves a cursor and publishes it as the
+        cycle's cursor. The worker wins the claim, marks itself at the GIL
+        gate, and parks at AfterSafeLoaderGILHandshake. The
         timeout callback loses the claim, observes holding == true, and preempts:
         it sends an empty cursor-id-0 reply and returns, skipping the normal
         AREQ_ReplyWithStoredResults path that would pause/free the reserved cursor.
@@ -8370,7 +8371,7 @@ class TestNoDeadlockQueryWithConcurrentWriter:
     """MOD-15364: BG query holds the spec read lock; a concurrent writer
     parks on the spec write lock and blocks the main thread. With the fix,
     the BG worker releases the read lock on the BG thread (inside
-    `AREQ_Execute`, before `AREQ_DecrRef`) prior to `RedisModule_UnblockClient`,
+    `AREQ_Execute`) prior to `RedisModule_UnblockClient`,
     so the writer can acquire the write lock and the main thread later runs
     the unblock callback. Without the fix, the unblock callback never runs
     (main thread is parked on wrlock), the read lock is never released, and


### PR DESCRIPTION
**Describe the change**

Completes [MOD-16991]'s acceptance as written: `QueryRequest_IncrRef`/`DecrRef` (and the AREQ/Hybrid wrappers) are deleted, `grep hybrid_ref src/` is empty, and no owner count remains anywhere. A `QueryRequest` now has exactly one owner at any time, documented once on the struct.

The count was already ceremony: the blocked-client API contract (`free_privdata` runs only after the module's own `UnblockClient`, which every flow calls after its last touch) sequences the worker and the reply/timeout callbacks before `OnFree`. The tree had exactly **one** sharing `IncrRef` — `BeginCycle`'s cycle reference; every other "reference" was a transferred count.

The ownership chain: construction → the creating flow; `BeginCycle` → the blocked client (privdata), whose `OnFree` executes the recorded cursor disposition (PAUSE hands ownership to the cursor, FREE frees through it) or frees the request; a parked cursor owns its request (`Cursor.query`); taking it for a read hands it to the new cycle. `Cursor_Free` frees the carried request; the one borrow-free — `EndCycle`'s stashed-cursor drain, where the cycle still owns the request — detaches the handle first.

Consequences swept through:
- `AREQ_Execute` never disposes the request — its old conditional tail free re-derived dynamically what each caller knows statically. The blocked-client worker never frees (the cycle owns; `OnFree` disposes); the inline main-thread path frees right after Execute returns, like its error paths already did. `blockedClientCycleActive` stays: `cursorEndOfCycle` still reads it (`runCursor` serves both inline and cycle flows, so record-vs-execute for the cursor disposition is genuinely dynamic there).
- Every pre-dispatch error path frees as the owner; BCRctx/BCHCtx are documented borrows (the vestigial `setRequest(NULL)` double-free dance is gone).
- The hybrid container `StrongRef` existed to attach a destructor to the count, so it dies with it: `FreeHybridRequest` deleted, signatures take `HybridRequest *`, the handler owns until `BeginCycle` or consumes inline (dialect stats captured before the consuming call).
- Coordinator: every "execution flow reference" release is deleted — the cycle owns, and `OnFree` (right after each flow's unblock) frees, which is also what lets `rpnetFree` drop the MR iterator's reader ref.

**Which issues this PR fixes**

MOD-16991 (completes its acceptance criteria; stacked on #10916 and #10745, which delivered the rest of the ticket).

**Main objects this PR modified**

- `QueryRequest` — refcount deleted; single-owner contract documented; `QueryRequest_Free`
- `QueryRequest_BeginCycle` / `OnFree` / `EndCycle` — ownership hand-off points
- `Cursor_FreeInternal`, `AREQ_CleanUpStoredCursor` — owner-free vs detach-then-free
- `blockedClientHybridCtx` / `blockedClientReqCtx` — borrows
- `dist_aggregate` / `dist_hybrid` — flow-reference releases removed

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

**Release notes**

- [ ] This PR requires release notes
- [x] This PR does not require release notes


[MOD-16991]: https://redislabs.atlassian.net/browse/MOD-16991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ