### PR TITLE
[MOD-17665] Fix sctx double free in _FT.DEBUG FT.HYBRID error paths

### DIFF
--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -173,11 +173,14 @@ static int applyHybridDebugToBuiltPipelines(HybridRequest_Debug *debug_req, Quer
   return REDISMODULE_OK;
 }
 
+/* Consumes `sctx` on every path: on success the returned request owns it (freed
+ * with the request); on failure it is freed here before returning NULL. */
 static HybridRequest_Debug* HybridRequest_Debug_New(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                                                      RedisSearchCtx *sctx, const char *indexname, QueryError *status) {
   // Parse debug parameters first
   HybridDebugParams debug_params = parseHybridDebugParamsCount(argv, argc, status);
   if (debug_params.debug_params_count == 0) {
+    SearchCtx_Free(sctx);
     return NULL;
   }
 
@@ -261,8 +264,6 @@ int DEBUG_hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, in
   // Create debug hybrid request using the same sctx
   HybridRequest_Debug *debug_req = HybridRequest_Debug_New(ctx, argv, argc, sctx, indexname, &status);
   if (!debug_req) {
-    // parseHybridCommand takes ownership of sctx but doesn't free it on error - we need to clean it up
-    SearchCtx_Free(sctx);
     return QueryError_ReplyAndClear(ctx, &status);
   }
 

--- a/tests/pytests/test_hybrid_timeout.py
+++ b/tests/pytests/test_hybrid_timeout.py
@@ -108,6 +108,25 @@ def test_hybrid_debug_unrecognized_argument():
                'DEBUG_PARAMS_COUNT', '2') \
         .error().contains('Unrecognized argument')
 
+def test_hybrid_debug_malformed_query_no_crash():
+    """A parse failure after the debug request was constructed must not crash
+    the server (MOD-17665).
+
+    A malformed SEARCH expression with a valid DEBUG_PARAMS_COUNT is the only
+    error shape that makes ``HybridRequest_Debug_New`` fail *after* the hybrid
+    request, which owns the search context, was built. Pre-fix the handler
+    freed that context a second time on the NULL return: a double free
+    (deterministic crash under ASAN).
+    """
+    env = Env(enableDebugCommand=True)
+    setup_basic_index(env)
+    env.expect('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', '@bad:[synta',
+               'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
+               'TIMEOUT_AFTER_N_SEARCH', '1',
+               'DEBUG_PARAMS_COUNT', '2').error()
+    # The shard survived the failed command.
+    env.assertTrue(env.cmd('PING'))
+
 @skip(cluster=True)
 def test_hybrid_debug_no_component_timeout_sa():
     """Test error when no component timeout parameter is specified (SA).


### PR DESCRIPTION
**Describe the change**

`_FT.DEBUG FT.HYBRID` double-freed (and used-after-free) the `RedisSearchCtx` when `HybridRequest_Debug_New` failed after the hybrid request was built: the parse- and pipeline-build-failure paths free the sctx through the request (`HybridRequest_Free` frees `hreq->sctx`), and the handler then freed the same pointer again on the NULL return, guided by a comment that wrongly claimed the inner call "doesn't free it on error".

The ownership contract is now uniform — `HybridRequest_Debug_New` consumes `sctx` on every path: the one failure that precedes the container (invalid `DEBUG_PARAMS_COUNT`) frees it directly, the others free it through the request, and on success the request owns it. The handler's NULL branch only replies.

Reachability is gated (admin `_FT.DEBUG`, `enable-debug-command`, single shard), so this is not hit by production deployments with default config — master-only fix, no backports planned.

Adds the missing regression test: a malformed SEARCH expression with a valid `DEBUG_PARAMS_COUNT` is the only error shape that reaches the buggy path (all existing error tests fail either before the container exists or after `Debug_New` succeeded). Deterministic; crashes pre-fix under ASAN.

**Which issues this PR fixes**

MOD-17665

**Main objects this PR modified**

- `HybridRequest_Debug_New` — consumes `sctx` on every path (contract documented)
- `DEBUG_hybridCommandHandler` — no longer frees `sctx` on the NULL return

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

**Release notes**

- [ ] This PR requires release notes
- [x] This PR does not require release notes
