### PR TITLE
top_k: cap num_estimated by the filter child

### DIFF
--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -609,7 +609,13 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> RQEIterat
 
     #[inline(always)]
     fn num_estimated(&self) -> usize {
-        self.k.get().min(self.source.num_estimated())
+        let estimate = self.k.get().min(self.source.num_estimated());
+        // A filtered query yields the intersection, so the child's own upper
+        // bound caps ours: a selective filter must not be masked by a large `k`.
+        match &self.child {
+            Some(child) => estimate.min(child.num_estimated()),
+            None => estimate,
+        }
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -216,6 +216,24 @@ fn num_estimated_capped_at_k() {
     assert_eq!(it.num_estimated(), 3);
 }
 
+/// A filtered query yields the intersection, so a selective child bounds the
+/// estimate even when `k` and the source estimate are both far larger.
+#[test]
+fn num_estimated_capped_by_child() {
+    let source = MockScoreSource::new(vec![vec![(1, 1.0), (2, 2.0), (3, 3.0)]], vec![], |_, _| {
+        BatchStrategy::Continue
+    })
+    .with_num_estimated(100);
+    let it = TopKIterator::new(
+        source,
+        make_child(vec![2]),
+        NonZeroUsize::new(100).unwrap(),
+        asc,
+    );
+
+    assert_eq!(it.num_estimated(), 1);
+}
+
 // ── Unfiltered path ───────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
A filtered top-k yields the intersection of the score source and the child, so we can return the minimum of those 2 `num_estimated`.

- split from https://github.com/RediSearch/RediSearch/pull/10222

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
