### PR TITLE
top_k: yield captured metric record on trim-deep-results path

### DIFF
--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -115,7 +115,7 @@ pub struct TopKIterator<
     k: NonZeroUsize,
     compare: fn(&f64, &f64) -> Ordering,
     /// When `true`, filtered modes skip deep-copying the child's rich result
-    /// subtree and yield a metric-only result carrying just the source's score.
+    /// subtree and yield its metrics with the source's score attached.
     /// Set when the downstream pipeline needs no rich results (no relevance
     /// scorer or highlighter that reads the child's term records).
     can_trim_deep_results: bool,
@@ -195,9 +195,10 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
 
     /// Set whether filtered modes may yield metric-only results.
     ///
-    /// When `true`, the collection phase skips deep-copying each matching
-    /// child record and the yield phase builds a metric-only result via
-    /// [`ScoreSource::build_result`] instead of carrying the child's subtree.
+    /// When `true`, the collection phase captures only each matching child's
+    /// yielded metrics instead of deep-copying its whole record, and the yield
+    /// phase hands those back with the source's score attached via
+    /// [`ScoreSource::attach_score_metric`].
     /// Leave `false` (the default) whenever a downstream scorer or highlighter
     /// reads the child's term records.
     pub fn with_trim_deep_results(mut self, trim: bool) -> Self {
@@ -490,17 +491,25 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             // and takes the source-built path below.
             if self.child.is_some() && self.source.yields_child_record() {
                 if self.can_trim_deep_results {
-                    // Build a metric-only result, then fold in the child's
-                    // yielded metrics (explicit output/sort fields) captured at
-                    // match time.
-                    let mut result = self.source.build_result(doc_id, score);
+                    // Carry the child's captured metrics and attach our score
+                    // last, so a lookup key shared with the child (e.g. nested
+                    // KNN reusing an `AS` alias) keeps the outer vector score.
+                    let mut result = match record {
+                        Some(record) => record,
+                        None => self.source.build_result(doc_id, score),
+                    };
                     if self.source.is_expired(&result) {
                         continue;
                     }
                     self.last_doc_id = doc_id;
-                    if let Some(mut record) = record {
-                        result.metrics_mut().concat(record.metrics_mut());
+                    // A carried record holds only the child's metrics, with a zeroed
+                    // payload. The score is this record's own value, so it has to reach
+                    // the payload too — that is what `ScoreSource::build_result` puts
+                    // there, and what consumers reading the record numerically expect.
+                    if let Some(value) = result.as_numeric_mut() {
+                        *value = score;
                     }
+                    self.source.attach_score_metric(&mut result, score);
                     *self.current = Some(result);
                     return Ok(self.current.as_mut());
                 }

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -11,7 +11,7 @@
 
 use std::{cmp::Ordering, num::NonZeroUsize};
 
-use rqe_core::DocId;
+use rqe_core::{DocId, RS_FIELDMASK_ALL};
 
 use index_result::RSIndexResult;
 use rqe_iterator_type::IteratorType;
@@ -961,8 +961,8 @@ fn batches_preserves_child_scoring_fields() {
 
 /// The dual of [`batches_preserves_child_scoring_fields`]: when the pipeline can
 /// trim deep results, the child's scoring subtree is never captured, so each
-/// match yields the source's metric-only result (default freq/field_mask) rather
-/// than the child's rich record.
+/// match yields a metric-only result carrying the `build_metric` defaults
+/// (freq 0, [`RS_FIELDMASK_ALL`]) rather than the child's rich record.
 #[test]
 fn batches_trim_deep_results_yields_metric_only() {
     use index_result::RSIndexResult;
@@ -992,9 +992,12 @@ fn batches_trim_deep_results_yields_metric_only() {
     }
 
     // Same doc ids and best-first order as the rich path, but the child's
-    // freq/field_mask are absent — the yielded record is the source's
-    // metric-only result.
-    assert_eq!(emitted, vec![(2, 0, 0), (1, 0, 0)]);
+    // freq/field_mask are dropped — the yielded record carries the metric-only
+    // defaults instead.
+    assert_eq!(
+        emitted,
+        vec![(2, 0, RS_FIELDMASK_ALL), (1, 0, RS_FIELDMASK_ALL)]
+    );
 }
 
 /// Adhoc-BF counterpart of [`batches_trim_deep_results_yields_metric_only`]:
@@ -1029,7 +1032,10 @@ fn adhoc_trim_deep_results_yields_metric_only() {
         emitted.push((r.doc_id, r.freq, r.field_mask));
     }
 
-    assert_eq!(emitted, vec![(2, 0, 0), (1, 0, 0)]);
+    assert_eq!(
+        emitted,
+        vec![(2, 0, RS_FIELDMASK_ALL), (1, 0, RS_FIELDMASK_ALL)]
+    );
 }
 
 /// Trimming skips the child's scoring subtree but must still carry its yielded
@@ -1066,7 +1072,45 @@ fn batches_trim_deep_results_preserves_child_metrics() {
         emitted.push((r.doc_id, r.freq, r.field_mask, metric));
     }
 
-    // Rich subtree is trimmed (freq/field_mask are the source's defaults), but
-    // the child's yielded metric rides along on every result.
-    assert_eq!(emitted, vec![(2, 0, 0, Some(42.0)), (1, 0, 0, Some(42.0))]);
+    // Rich subtree is trimmed (freq/field_mask carry the metric-only defaults),
+    // but the child's yielded metric rides along on every result.
+    assert_eq!(
+        emitted,
+        vec![
+            (2, 0, RS_FIELDMASK_ALL, Some(42.0)),
+            (1, 0, RS_FIELDMASK_ALL, Some(42.0))
+        ]
+    );
+}
+
+/// A trimmed result stands in for the source's own scored record, so its numeric
+/// payload must hold the source score — not the zero the metric-only carrier is
+/// built with — for consumers that read the record numerically rather than
+/// through a lookup key.
+#[test]
+fn batches_trim_deep_results_payload_carries_source_score() {
+    use index_result::RSIndexResult;
+    use rqe_iterators::IdList;
+
+    let child = IdList::<true>::with_result(vec![1, 2], RSIndexResult::build_virt().build());
+
+    let source = MockScoreSource::new(vec![vec![(1, 0.9), (2, 0.5)]], vec![], |_, _| {
+        BatchStrategy::Continue
+    });
+
+    let mut it = TopKIterator::new(
+        source,
+        Box::new(child) as Box<dyn RQEIterator<'_> + '_>,
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    )
+    .with_trim_deep_results(true);
+
+    let mut emitted = Vec::new();
+    while let Some(r) = it.read().unwrap() {
+        emitted.push((r.doc_id, r.as_numeric()));
+    }
+
+    // Best-first ASC order, each payload holding that document's source score.
+    assert_eq!(emitted, vec![(2, Some(0.5)), (1, Some(0.9))]);
 }

--- a/src/redisearch_rs/vector_score_source/src/lib.rs
+++ b/src/redisearch_rs/vector_score_source/src/lib.rs
@@ -108,8 +108,8 @@ pub fn new_vector_top_k_unfiltered<'index, E: ExpirationChecker + 'index>(
 /// Delegates mode selection to source.
 ///
 /// When `can_trim_deep_results` is `true`, the pipeline needs no rich results,
-/// so matches yield a metric-only result carrying just the vector score instead
-/// of the child's deep-copied scoring subtree.
+/// so matches yield the child's metrics with the vector score attached instead
+/// of its deep-copied scoring subtree.
 ///
 /// [`VectorScoreSource::requested_search_mode`]: source::VectorScoreSource::requested_search_mode
 /// [`VecSimIndex_PreferAdHocSearch`]: ffi::VecSimIndex_PreferAdHocSearch

--- a/src/redisearch_rs/vector_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source.rs
@@ -22,7 +22,7 @@ use std::collections::HashSet;
 
 use ffi::{RLookupKey, VecSimIndex, VecSimIndex_Free, t_docId};
 use index_result::{RSIndexResult, RSResultKind};
-use rqe_iterators::{ExpirationChecker, NoOpChecker, RQEIterator};
+use rqe_iterators::{ExpirationChecker, IdList, NoOpChecker, RQEIterator};
 use rqe_iterators_test_utils::MockExpirationChecker;
 use top_k::{ScoreSource, TopKIterator, TopKMode};
 use vector_score_source::test_utils::{self, asc, collect_ids, make_child, uniform_blob};
@@ -37,7 +37,7 @@ fn build_hnsw_index(n: usize) -> NonNull<VecSimIndex> {
     test_utils::build_hnsw_index(n, DIM)
 }
 
-/// test_utilsing the corner `[n; DIM]` with `efRuntime = n`. `child_est` seeds
+/// test_utilising the corner `[n; DIM]` with `efRuntime = n`. `child_est` seeds
 /// the batch-size heuristic — production passes `child.num_estimated()`.
 ///
 /// # Safety
@@ -553,4 +553,90 @@ fn attach_score_metric_without_key_is_noop() {
     drop(source);
     // SAFETY: no live references to the index remain.
     unsafe { VecSimIndex_Free(index.as_ptr()) };
+}
+
+/// Value the child writes under the shared key, distinct from every distance
+/// this suite's index can produce.
+const STALE_CHILD_SCORE: f64 = 777.0;
+
+/// Drives a trimmed filtered query in `mode` whose child yields a metric under
+/// the source's own output key, and returns `(doc id, value under that key,
+/// numeric payload)` per result, asserting along the way that no second entry
+/// appeared for the key.
+fn trimmed_shared_key_yields(mode: TopKMode) -> Vec<(t_docId, f64, Option<f64>)> {
+    let n = 10;
+    let k = 3;
+    let index = build_hnsw_index(n);
+    let lookup_key = make_key();
+
+    // SAFETY: index outlives the iterator, freed below.
+    let mut source = unsafe { make_source(index, n, k, n) };
+    *source.own_key = (&lookup_key as *const RLookupKey).cast_mut().cast();
+
+    let mut child_result = RSIndexResult::build_metric(0.0).doc_id(0).build();
+    child_result
+        .metrics
+        .push_with_key(&lookup_key, STALE_CHILD_SCORE);
+    // Ids below `n` only: doc `n` sits on the query vector, so its distance is 0
+    // and would be indistinguishable from the payload the carrier zeroes.
+    let child = IdList::<true>::with_result(vec![7, 8, 9], child_result);
+
+    let mut it = TopKIterator::new_with_mode(
+        source,
+        Some(child),
+        NonZeroUsize::new(k).unwrap(),
+        asc(),
+        mode,
+    )
+    .with_trim_deep_results(true);
+
+    let mut emitted = Vec::new();
+    while let Some(result) = it.read().unwrap() {
+        assert_eq!(
+            result.metrics.len(),
+            1,
+            "the score must land on the child's entry, not beside it"
+        );
+        let payload = result.as_numeric();
+        let value = result.metrics.find_by_key_mut(&lookup_key).unwrap().value();
+        emitted.push((result.doc_id, value, payload));
+    }
+
+    drop(it);
+    // SAFETY: no live references to the index remain.
+    unsafe { VecSimIndex_Free(index.as_ptr()) };
+    emitted
+}
+
+/// A nested KNN reusing the outer `AS` alias makes the child yield a metric
+/// under this source's own key: the distance must overwrite that entry and the
+/// numeric payload, leaving nothing of the child's value.
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
+fn batches_trimmed_shared_metric_key_carries_vector_score() {
+    // Squared-L2 distance DIM*(n-id)^2 per child id, best-first.
+    assert_eq!(
+        trimmed_shared_key_yields(TopKMode::Batches),
+        vec![
+            (9, 4.0, Some(4.0)),
+            (8, 16.0, Some(16.0)),
+            (7, 36.0, Some(36.0))
+        ]
+    );
+}
+
+/// Adhoc-BF counterpart of
+/// [`batches_trimmed_shared_metric_key_carries_vector_score`]: the child-driven
+/// scan captures the child's metrics on its own path, so it needs its own check.
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
+fn adhoc_trimmed_shared_metric_key_carries_vector_score() {
+    assert_eq!(
+        trimmed_shared_key_yields(TopKMode::AdhocBF),
+        vec![
+            (9, 4.0, Some(4.0)),
+            (8, 16.0, Some(16.0)),
+            (7, 36.0, Some(36.0))
+        ]
+    );
 }


### PR DESCRIPTION
Current: the trim path builds a fresh metric-only result from the source, then
concatenates the child's captured metrics onto it. The child's entry lands after
the source's, so a lookup key shared with the child resolves to the child's value,
and the record's numeric payload is whatever the source built.

Change: carry the child's captured record instead, write the source score into
its numeric payload, and attach the score metric last.

Outcome: a shared lookup key keeps the outer score, and the payload holds it too.
The yielded record now carries the build_metric defaults (field_mask
RS_FIELDMASK_ALL); trim tests are updated to match, plus new coverage for the
payload and the shared-key case on both collection paths.

#### Which additional issues this PR fixes

<!-- Ticket and issue links only. Write "N/A" if there are none. -->

1. MOD-...
2. #...

#### Main objects this PR modified

<!--
3-5 entries. The subsystems, commands, or types a reviewer should look at first,
each with a few words on what changed there. Not a file list — `git diff --stat`
already says which files moved, and it says it more accurately.
-->

1. ...

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
