### PR TITLE
Decouple the async-disk iterator buffer from the read depth

### DIFF
--- a/src/index_result_async_read.c
+++ b/src/index_result_async_read.c
@@ -18,11 +18,15 @@
 #include "inverted_index.h"
 #include "rmutil/rm_assert.h"
 
-void IndexResultAsyncRead_Init(IndexResultAsyncReadState *state, uint16_t poolSize) {
+void IndexResultAsyncRead_Init(IndexResultAsyncReadState *state, uint16_t poolSize,
+                               uint16_t bufferSize) {
+  RS_ASSERT(bufferSize >= poolSize);
+
   // Initialize all fields to safe defaults
   dllist_init(&state->iteratorResults);
   dllist_init(&state->pendingResults);
   state->poolSize = poolSize;
+  state->bufferSize = bufferSize;
   state->iteratorResultCount = 0;
   state->readyResults = NULL;
   state->failedUserData = NULL;

--- a/src/index_result_async_read.h
+++ b/src/index_result_async_read.h
@@ -47,6 +47,7 @@ typedef struct IndexResultAsyncReadState {
 
   // Configuration
   uint16_t poolSize;                       // Maximum number of concurrent async reads
+  uint16_t bufferSize;                     // Maximum iterator results buffered ahead (>= poolSize)
 
   // Level 1: Iterator buffer (not yet submitted to async pool)
   DLLIST iteratorResults;                  // Deep-copied IndexResults from iterator
@@ -71,8 +72,11 @@ typedef struct IndexResultAsyncReadState {
  *
  * @param state Async read state structure to initialize
  * @param poolSize Maximum number of concurrent async reads
+ * @param bufferSize Maximum iterator results buffered ahead of submission. Must be
+ *        >= poolSize, so a full pool always has work queued behind it.
  */
-void IndexResultAsyncRead_Init(IndexResultAsyncReadState *state, uint16_t poolSize);
+void IndexResultAsyncRead_Init(IndexResultAsyncReadState *state, uint16_t poolSize,
+                               uint16_t bufferSize);
 
 /**
  * Setup async pool for disk I/O

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -65,6 +65,10 @@
 // Maximum number of concurrent async disk reads
 #define MAX_ONGOING_READ_SIZE 16
 
+// Iterator results buffered ahead of submission. Separate from the read depth so the
+// two can be tuned independently; must be >= MAX_ONGOING_READ_SIZE.
+#define ITERATOR_BUFFER_SIZE MAX_ONGOING_READ_SIZE
+
 // Timeout for async disk poll when iterator is at EOF (in milliseconds)
 // When the iterator is exhausted, we wait for pending async reads to complete
 #define ASYNC_POLL_TIMEOUT_AT_EOF_MS 1000
@@ -155,7 +159,7 @@ static int refillBufferUsingIterator(RPQueryIterator *self) {
   }
 
   // Fill buffer up to max capacity
-  while (self->async.iteratorResultCount < self->async.poolSize && !it->atEOF) {
+  while (self->async.iteratorResultCount < self->async.bufferSize && !it->atEOF) {
     if (TimedOut_WithCounter(&sctx->time.timeout, &self->timeoutLimiter) == TIMED_OUT) {
       return RS_RESULT_TIMEDOUT;
     }
@@ -494,7 +498,7 @@ ResultProcessor *RPQueryIterator_New(QueryIterator *root, const RedisModuleSlotR
 #endif
 
   // Initialize async read state
-  IndexResultAsyncRead_Init(&ret->async, MAX_ONGOING_READ_SIZE);
+  IndexResultAsyncRead_Init(&ret->async, MAX_ONGOING_READ_SIZE, ITERATOR_BUFFER_SIZE);
 
   // Determine which Next function to use based on disk configuration
   if (sctx->spec->diskSpec &&

--- a/tests/cpptests/test_cpp_async_state.cpp
+++ b/tests/cpptests/test_cpp_async_state.cpp
@@ -19,12 +19,14 @@
 
 // Test pool size constant
 #define TEST_ASYNC_POOL_SIZE 16
+// Deliberately larger than the pool, so the fixture exercises the decoupled shape
+#define TEST_ASYNC_BUFFER_SIZE (TEST_ASYNC_POOL_SIZE * 2)
 
 class AsyncStateTest : public ::testing::Test {
 protected:
   void SetUp() override {
     // Use the proper Init function - no async pool needed for state machine tests
-    IndexResultAsyncRead_Init(&state, TEST_ASYNC_POOL_SIZE);
+    IndexResultAsyncRead_Init(&state, TEST_ASYNC_POOL_SIZE, TEST_ASYNC_BUFFER_SIZE);
 
     // Manually allocate arrays for testing (normally done by SetupAsyncPool)
     state.readyResults = array_new(AsyncReadResult, TEST_ASYNC_POOL_SIZE);
@@ -82,6 +84,18 @@ protected:
 };
 
 // Test: Initial state is empty
+TEST_F(AsyncStateTest, testBufferAndPoolSizesAreIndependent) {
+  ASSERT_GT(TEST_ASYNC_BUFFER_SIZE, TEST_ASYNC_POOL_SIZE);
+  ASSERT_EQ(state.poolSize, TEST_ASYNC_POOL_SIZE);
+  ASSERT_EQ(state.bufferSize, TEST_ASYNC_BUFFER_SIZE);
+
+  // Init allocates nothing, so no Free is needed for this scratch state
+  IndexResultAsyncReadState scratch;
+  IndexResultAsyncRead_Init(&scratch, 4, 32);
+  ASSERT_EQ(scratch.poolSize, 4);
+  ASSERT_EQ(scratch.bufferSize, 32);
+}
+
 TEST_F(AsyncStateTest, testInitialState) {
   ASSERT_EQ(state.iteratorResultCount, 0);
   ASSERT_TRUE(DLLIST_IS_EMPTY(&state.iteratorResults));


### PR DESCRIPTION
> **Stacked on #10958.** Based on that branch rather than `master`, so this PR's commit list also contains #10958's commit — review that one first and read only
> `55cb1c2c2` here. GitHub cannot use a fork branch as a base, which is why it is not set as the base branch.

## Describe the changes in the pull request

1. **Current:** `MAX_ONGOING_READ_SIZE` sizes two unrelated things — how many async reads may be in flight, and how many iterator results are buffered ahead of submission (`refillBufferUsingIterator` caps on `poolSize`). They are equal only because they share a constant, so neither can be tuned without moving the other.
2. **Change:** the async read state gets its own `bufferSize`, set from a separate `ITERATOR_BUFFER_SIZE`. `refillBufferUsingIterator` caps on that instead of `poolSize`.
3. **Outcome:** internal-only, no behavior change. `ITERATOR_BUFFER_SIZE` is defined as `MAX_ONGOING_READ_SIZE`, so both remain 16 and every cap is exactly what it was. This makes the two independently settable, which is a prerequisite for tuning either.

Why they should be separate: the read depth is a statement about how much I/O parallelism a query should use, while the buffer is a statement about how far ahead of that to prefetch from the iterator. The buffer wants to be at least the pool depth so a saturated pool always has work queued behind it — with them equal, a full pool means an empty buffer, so every submission slot that frees up must wait for an iterator read before it can be refilled. `IndexResultAsyncRead_Init` now asserts `bufferSize >= poolSize` so that relationship is stated rather than assumed.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `src/index_result_async_read.h` / `.c` — new `bufferSize` field, `IndexResultAsyncRead_Init` takes it, asserts `bufferSize >= poolSize`.
2. `src/result_processor.c` — `refillBufferUsingIterator` caps on `bufferSize`; adds `ITERATOR_BUFFER_SIZE`.
3. `tests/cpptests/test_cpp_async_state.cpp` — updated for the new `Init` signature.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

## Verification

Both changed translation units syntax-check against the exact flags from a real build's `compile_commands.json` (`cc -fsyntax-only`, exit 0). The only other caller of `IndexResultAsyncRead_Init` is the C++ unit test, updated here; `grep` for `async.poolSize` confirms no remaining out-of-module reader depends on the old coupling.

Behavior is unchanged by construction, so there is nothing to benchmark in this PR — it exists so that the follow-up tuning change has two knobs instead of one.

## Follow-up, not in this PR

`MAX_ONGOING_READ_SIZE` at 16 is shallow for NVMe via io_uring, and per-query depth multiplies by the number of concurrent query threads, so the right value is a measurement rather than a guess. Raising it (and choosing a buffer multiple) wants a sweep over the MS MARCO suite, and plausibly a runtime config in the shape of the existing `search-disk-*` knobs rather than a compile-time constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
