### PR TITLE
Make the async-disk read pool size and read-ahead queue runtime configs

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -127,6 +127,8 @@ configPair_t __configPairs[] = {
   {"_SIMULATE_IN_FLEX",                "search-_simulate-in-flex"},
   {"search-disk-drop-read-cache",      "search-disk-drop-read-cache"},
   {"search-disk-use-direct-reads",     "search-disk-use-direct-reads"},
+  {"search-_disk-async-read-pool-size",   "search-_disk-async-read-pool-size"},
+  {"search-_disk-async-read-queue-factor", "search-_disk-async-read-queue-factor"},
 };
 
 static const char* FTConfigNameToConfigName(const char *name) {
@@ -2648,7 +2650,7 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
 
   RM_TRY(
     RedisModule_RegisterNumericConfig(
-      ctx, "search-disk-async-read-pool-size", DEFAULT_DISK_ASYNC_READ_POOL_SIZE,
+      ctx, "search-_disk-async-read-pool-size", DEFAULT_DISK_ASYNC_READ_POOL_SIZE,
       REDISMODULE_CONFIG_UNPREFIXED, 1,
       DISK_ASYNC_READ_POOL_SIZE_MAX, get_uint_numeric_config, set_uint_numeric_config, NULL,
       (void *)&(RSGlobalConfig.diskAsyncReadPoolSize)
@@ -2657,7 +2659,7 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
 
   RM_TRY(
     RedisModule_RegisterNumericConfig(
-      ctx, "search-disk-async-read-queue-factor", DEFAULT_DISK_ASYNC_READ_QUEUE_FACTOR,
+      ctx, "search-_disk-async-read-queue-factor", DEFAULT_DISK_ASYNC_READ_QUEUE_FACTOR,
       REDISMODULE_CONFIG_UNPREFIXED, 1,
       DISK_ASYNC_READ_QUEUE_FACTOR_MAX, get_uint_numeric_config, set_uint_numeric_config, NULL,
       (void *)&(RSGlobalConfig.diskAsyncReadQueueFactor)

--- a/src/config.c
+++ b/src/config.c
@@ -2656,6 +2656,15 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
   )
 
   RM_TRY(
+    RedisModule_RegisterNumericConfig(
+      ctx, "search-disk-async-read-queue-factor", DEFAULT_DISK_ASYNC_READ_QUEUE_FACTOR,
+      REDISMODULE_CONFIG_UNPREFIXED, 1,
+      DISK_ASYNC_READ_QUEUE_FACTOR_MAX, get_uint_numeric_config, set_uint_numeric_config, NULL,
+      (void *)&(RSGlobalConfig.diskAsyncReadQueueFactor)
+    )
+  )
+
+  RM_TRY(
     RedisModule_RegisterBoolConfig(
       ctx, "search-disk-drop-read-cache", 0,
       REDISMODULE_CONFIG_IMMUTABLE | REDISMODULE_CONFIG_UNPREFIXED,

--- a/src/config.c
+++ b/src/config.c
@@ -2647,6 +2647,15 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
   )
 
   RM_TRY(
+    RedisModule_RegisterNumericConfig(
+      ctx, "search-disk-async-read-pool-size", DEFAULT_DISK_ASYNC_READ_POOL_SIZE,
+      REDISMODULE_CONFIG_UNPREFIXED, 1,
+      DISK_ASYNC_READ_POOL_SIZE_MAX, get_uint_numeric_config, set_uint_numeric_config, NULL,
+      (void *)&(RSGlobalConfig.diskAsyncReadPoolSize)
+    )
+  )
+
+  RM_TRY(
     RedisModule_RegisterBoolConfig(
       ctx, "search-disk-drop-read-cache", 0,
       REDISMODULE_CONFIG_IMMUTABLE | REDISMODULE_CONFIG_UNPREFIXED,

--- a/src/config.h
+++ b/src/config.h
@@ -8,6 +8,7 @@
 */
 #pragma once
 
+#include <assert.h>
 #include <stdint.h>
 
 #include "redismodule.h"
@@ -231,6 +232,11 @@ typedef struct {
   // Concurrent async document-metadata reads a single query iterator keeps in flight.
   // Read when a query builds its pool, so a change applies from the next query on.
   unsigned int diskAsyncReadPoolSize;
+  // Index results a query queues ahead of submission, as a multiple of
+  // diskAsyncReadPoolSize. A factor rather than an absolute count so that the queue stays
+  // at least as deep as the pool even when a query start races a CONFIG SET and observes a
+  // new pool size paired with the old factor.
+  unsigned int diskAsyncReadQueueFactor;
   // If true, fallback to main thread when BlockClient is unavailable.
   bool fallbackToMainThreadWhenBlockClientUnavailable;
 } RSConfig;
@@ -410,6 +416,13 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
 // value times the number of query threads. Bounded well below what the uint16_t
 // state field allows so a single setting cannot swamp the device.
 #define DISK_ASYNC_READ_POOL_SIZE_MAX 1024
+#define DEFAULT_DISK_ASYNC_READ_QUEUE_FACTOR 1
+// The queue holds deep-copied index results, so its cost is pool size times this factor
+// times the number of concurrently executing queries. Past a small multiple the extra
+// depth buys buffered index results rather than device parallelism.
+#define DISK_ASYNC_READ_QUEUE_FACTOR_MAX 16
+static_assert(DISK_ASYNC_READ_POOL_SIZE_MAX * DISK_ASYNC_READ_QUEUE_FACTOR_MAX <= UINT16_MAX,
+              "queue depth must fit IndexResultAsyncReadState's uint16_t queueSize");
 // Smallest accepted positive cap. Below this the disk backend's open-file cache (cap - 10)
 // underflows to unbounded, so a positive cap must leave at least one cached reader.
 #define DISK_MAX_OPEN_FILES_MIN 11
@@ -478,6 +491,7 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
     .diskUseDirectReads = false,                                               \
     .diskMaxOpenFiles = DEFAULT_DISK_MAX_OPEN_FILES,                           \
     .diskAsyncReadPoolSize = DEFAULT_DISK_ASYNC_READ_POOL_SIZE,                \
+    .diskAsyncReadQueueFactor = DEFAULT_DISK_ASYNC_READ_QUEUE_FACTOR,          \
     .fallbackToMainThreadWhenBlockClientUnavailable = true,                    \
   }
 

--- a/src/config.h
+++ b/src/config.h
@@ -228,6 +228,9 @@ typedef struct {
   // cache — silently disabling the limit — rather than bounding it. Values in that range are
   // rejected (see set_search_disk_max_open_files_config).
   int diskMaxOpenFiles;
+  // Concurrent async document-metadata reads a single query iterator keeps in flight.
+  // Read when a query builds its pool, so a change applies from the next query on.
+  unsigned int diskAsyncReadPoolSize;
   // If true, fallback to main thread when BlockClient is unavailable.
   bool fallbackToMainThreadWhenBlockClientUnavailable;
 } RSConfig;
@@ -401,6 +404,12 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
 #define DEFAULT_TRIMMING_STATE_CHECK_DELAY 100 // 0.1 seconds in milliseconds (We check the trimming state every 0.1 seconds, between MIN_TRIM_DELAY and MAX_TRIM_DELAY)
 #define DEFAULT_DISK_BUFFER_PERCENTAGE 20  // 20% of available memory for disk write buffer
 #define DEFAULT_DISK_MAX_OPEN_FILES 1024   // open-file cap; -1 = unlimited
+#define DEFAULT_DISK_ASYNC_READ_POOL_SIZE 16
+// A query iterator's reads are only one contributor to device queue depth: every
+// concurrently executing query owns a pool, so in-flight reads scale with this
+// value times the number of query threads. Bounded well below what the uint16_t
+// state field allows so a single setting cannot swamp the device.
+#define DISK_ASYNC_READ_POOL_SIZE_MAX 1024
 // Smallest accepted positive cap. Below this the disk backend's open-file cache (cap - 10)
 // underflows to unbounded, so a positive cap must leave at least one cached reader.
 #define DISK_MAX_OPEN_FILES_MIN 11
@@ -468,6 +477,7 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
     .diskDropReadCache = false,                                                \
     .diskUseDirectReads = false,                                               \
     .diskMaxOpenFiles = DEFAULT_DISK_MAX_OPEN_FILES,                           \
+    .diskAsyncReadPoolSize = DEFAULT_DISK_ASYNC_READ_POOL_SIZE,                \
     .fallbackToMainThreadWhenBlockClientUnavailable = true,                    \
   }
 

--- a/src/config.h
+++ b/src/config.h
@@ -230,12 +230,9 @@ typedef struct {
   // rejected (see set_search_disk_max_open_files_config).
   int diskMaxOpenFiles;
   // Concurrent async document-metadata reads a single query iterator keeps in flight.
-  // Read when a query builds its pool, so a change applies from the next query on.
   unsigned int diskAsyncReadPoolSize;
   // Index results a query queues ahead of submission, as a multiple of
-  // diskAsyncReadPoolSize. A factor rather than an absolute count so that the queue stays
-  // at least as deep as the pool even when a query start races a CONFIG SET and observes a
-  // new pool size paired with the old factor.
+  // diskAsyncReadPoolSize. Must be at least 1.
   unsigned int diskAsyncReadQueueFactor;
   // If true, fallback to main thread when BlockClient is unavailable.
   bool fallbackToMainThreadWhenBlockClientUnavailable;
@@ -411,15 +408,8 @@ long long getRedisConfigNumeric(RedisModuleCtx *ctx, const char *confName, long 
 #define DEFAULT_DISK_BUFFER_PERCENTAGE 20  // 20% of available memory for disk write buffer
 #define DEFAULT_DISK_MAX_OPEN_FILES 1024   // open-file cap; -1 = unlimited
 #define DEFAULT_DISK_ASYNC_READ_POOL_SIZE 16
-// A query iterator's reads are only one contributor to device queue depth: every
-// concurrently executing query owns a pool, so in-flight reads scale with this
-// value times the number of query threads. Bounded well below what the uint16_t
-// state field allows so a single setting cannot swamp the device.
 #define DISK_ASYNC_READ_POOL_SIZE_MAX 1024
 #define DEFAULT_DISK_ASYNC_READ_QUEUE_FACTOR 1
-// The queue holds deep-copied index results, so its cost is pool size times this factor
-// times the number of concurrently executing queries. Past a small multiple the extra
-// depth buys buffered index results rather than device parallelism.
 #define DISK_ASYNC_READ_QUEUE_FACTOR_MAX 16
 static_assert(DISK_ASYNC_READ_POOL_SIZE_MAX * DISK_ASYNC_READ_QUEUE_FACTOR_MAX <= UINT16_MAX,
               "queue depth must fit IndexResultAsyncReadState's uint16_t queueSize");

--- a/src/index_result_async_read.c
+++ b/src/index_result_async_read.c
@@ -19,14 +19,14 @@
 #include "rmutil/rm_assert.h"
 
 void IndexResultAsyncRead_Init(IndexResultAsyncReadState *state, uint16_t poolSize,
-                               uint16_t bufferSize) {
-  RS_ASSERT(bufferSize >= poolSize);
+                               uint16_t queueSize) {
+  RS_ASSERT(queueSize >= poolSize);
 
   // Initialize all fields to safe defaults
   dllist_init(&state->iteratorResults);
   dllist_init(&state->pendingResults);
   state->poolSize = poolSize;
-  state->bufferSize = bufferSize;
+  state->queueSize = queueSize;
   state->iteratorResultCount = 0;
   state->readyResults = NULL;
   state->failedUserData = NULL;

--- a/src/index_result_async_read.h
+++ b/src/index_result_async_read.h
@@ -34,7 +34,7 @@ typedef struct IndexResultNode {
  * IndexResultAsyncReadState - State management for async disk reads of index results
  *
  * This structure manages a three-level buffering pipeline for async disk I/O:
- * 1. iteratorResults: Buffered IndexResults from iterator (not yet submitted)
+ * 1. iteratorResults: IndexResults queued from the iterator (not yet submitted)
  * 2. pendingResults: IndexResults with in-flight async disk reads
  * 3. readyResults: Completed disk reads ready for consumption
  *
@@ -47,9 +47,9 @@ typedef struct IndexResultAsyncReadState {
 
   // Configuration
   uint16_t poolSize;                       // Maximum number of concurrent async reads
-  uint16_t bufferSize;                     // Maximum iterator results buffered ahead (>= poolSize)
+  uint16_t queueSize;                      // Maximum iterator results queued ahead (>= poolSize)
 
-  // Level 1: Iterator buffer (not yet submitted to async pool)
+  // Level 1: Iterator queue (not yet submitted to async pool)
   DLLIST iteratorResults;                  // Deep-copied IndexResults from iterator
   uint16_t iteratorResultCount;            // Number of nodes in iteratorResults list
 
@@ -72,11 +72,11 @@ typedef struct IndexResultAsyncReadState {
  *
  * @param state Async read state structure to initialize
  * @param poolSize Maximum number of concurrent async reads
- * @param bufferSize Maximum iterator results buffered ahead of submission. Must be
+ * @param queueSize Maximum iterator results queued ahead of submission. Must be
  *        >= poolSize, so a full pool always has work queued behind it.
  */
 void IndexResultAsyncRead_Init(IndexResultAsyncReadState *state, uint16_t poolSize,
-                               uint16_t bufferSize);
+                               uint16_t queueSize);
 
 /**
  * Setup async pool for disk I/O
@@ -95,7 +95,7 @@ void IndexResultAsyncRead_SetupAsyncPool(IndexResultAsyncReadState *state,
 void IndexResultAsyncRead_Free(IndexResultAsyncReadState *state);
 
 /**
- * Refill the async pool from the iterator buffer
+ * Refill the async pool from the iterator queue
  *
  * Moves IndexResults from iteratorResults to pendingResults by submitting
  * them to the async read pool. Maintains FIFO ordering. Stops when the pool
@@ -103,7 +103,7 @@ void IndexResultAsyncRead_Free(IndexResultAsyncReadState *state);
  *
  * @param state Async read state structure
  * @return Number of reads submitted. Zero means the pool is saturated or the
- *         iterator buffer is empty, so the caller cannot make progress by
+ *         iterator queue is empty, so the caller cannot make progress by
  *         submitting more and should wait on a completion instead of re-polling.
  */
 uint16_t IndexResultAsyncRead_RefillPool(IndexResultAsyncReadState *state);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -137,11 +137,11 @@ static bool getDocumentMetadata(IndexSpec* spec, DocTable* docs, RedisSearchCtx 
 }
 
 /**
- * Refill the IndexResult buffer from the iterator.
- * Fills up to current capacity, doesn't grow the buffer.
+ * Refill the IndexResult queue from the iterator.
+ * Fills up to current capacity, doesn't grow the queue.
  * Returns RS_RESULT_OK on success, RS_RESULT_TIMEDOUT on timeout.
  */
-static int refillBufferUsingIterator(RPQueryIterator *self) {
+static int refillQueueUsingIterator(RPQueryIterator *self) {
   QueryIterator *it = self->iterator;
   RedisSearchCtx *sctx = self->sctx;
   IndexSpec *spec = sctx->spec;
@@ -151,8 +151,8 @@ static int refillBufferUsingIterator(RPQueryIterator *self) {
     return RS_RESULT_OK;
   }
 
-  // Fill buffer up to max capacity
-  while (self->async.iteratorResultCount < self->async.bufferSize && !it->atEOF) {
+  // Fill the queue up to max capacity
+  while (self->async.iteratorResultCount < self->async.queueSize && !it->atEOF) {
     if (TimedOut_WithCounter(&sctx->time.timeout, &self->timeoutLimiter) == TIMED_OUT) {
       return RS_RESULT_TIMEDOUT;
     }
@@ -409,13 +409,13 @@ static int rpQueryItNext_AsyncDisk(ResultProcessor *base, SearchResult *res) {
       self->async.lastReturnedIndexResult = NULL;
     }
 
-    // Step 1: Refill IndexResult buffer if needed (cheap iterator reads)
-    int refillResult = refillBufferUsingIterator(self);
+    // Step 1: Refill the IndexResult queue if needed (cheap iterator reads)
+    int refillResult = refillQueueUsingIterator(self);
     if (refillResult == RS_RESULT_TIMEDOUT) {
       return UnlockSpec_and_ReturnRPResult(sctx, RS_RESULT_TIMEDOUT);
     }
 
-    // Step 1b: Submit any buffered results to async pool (keep pipeline full)
+    // Step 1b: Submit any queued results to async pool (keep pipeline full)
     const uint16_t submitted = IndexResultAsyncRead_RefillPool(&self->async);
 
     // Step 2: Try to serve a ready result if we have one
@@ -490,12 +490,14 @@ ResultProcessor *RPQueryIterator_New(QueryIterator *root, const RedisModuleSlotR
   ret->firstRead = true;
 #endif
 
-  // Read once so the pool and the buffer feeding it cannot disagree if the config
-  // changes mid-query. Bounded by DISK_ASYNC_READ_POOL_SIZE_MAX at registration.
+  // Read both once so the pool and the queue feeding it cannot disagree if the config
+  // changes mid-query. Both bounds are enforced at registration, and the factor's minimum
+  // of 1 is what keeps the queue at least as deep as the pool.
   const uint16_t asyncPoolSize = (uint16_t)RSGlobalConfig.diskAsyncReadPoolSize;
+  const uint16_t asyncQueueSize = asyncPoolSize * (uint16_t)RSGlobalConfig.diskAsyncReadQueueFactor;
 
   // Initialize async read state
-  IndexResultAsyncRead_Init(&ret->async, asyncPoolSize, asyncPoolSize);
+  IndexResultAsyncRead_Init(&ret->async, asyncPoolSize, asyncQueueSize);
 
   // Determine which Next function to use based on disk configuration
   if (sctx->spec->diskSpec &&

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -62,13 +62,6 @@
 #include "util/dict/dict.h"
 #include "util/dllist.h"
 
-// Maximum number of concurrent async disk reads
-#define MAX_ONGOING_READ_SIZE 16
-
-// Iterator results buffered ahead of submission. Separate from the read depth so the
-// two can be tuned independently; must be >= MAX_ONGOING_READ_SIZE.
-#define ITERATOR_BUFFER_SIZE MAX_ONGOING_READ_SIZE
-
 // Timeout for async disk poll when iterator is at EOF (in milliseconds)
 // When the iterator is exhausted, we wait for pending async reads to complete
 #define ASYNC_POLL_TIMEOUT_AT_EOF_MS 1000
@@ -497,8 +490,12 @@ ResultProcessor *RPQueryIterator_New(QueryIterator *root, const RedisModuleSlotR
   ret->firstRead = true;
 #endif
 
+  // Read once so the pool and the buffer feeding it cannot disagree if the config
+  // changes mid-query. Bounded by DISK_ASYNC_READ_POOL_SIZE_MAX at registration.
+  const uint16_t asyncPoolSize = (uint16_t)RSGlobalConfig.diskAsyncReadPoolSize;
+
   // Initialize async read state
-  IndexResultAsyncRead_Init(&ret->async, MAX_ONGOING_READ_SIZE, ITERATOR_BUFFER_SIZE);
+  IndexResultAsyncRead_Init(&ret->async, asyncPoolSize, asyncPoolSize);
 
   // Determine which Next function to use based on disk configuration
   if (sctx->spec->diskSpec &&
@@ -506,7 +503,7 @@ ResultProcessor *RPQueryIterator_New(QueryIterator *root, const RedisModuleSlotR
       SearchDisk_GetAsyncIOEnabled()) {
     // Create async pool and setup async I/O
     RedisSearchDiskAsyncReadPool asyncPool =
-        SearchDisk_CreateAsyncReadPool(sctx->spec->diskSpec, sctx, MAX_ONGOING_READ_SIZE);
+        SearchDisk_CreateAsyncReadPool(sctx->spec->diskSpec, sctx, asyncPoolSize);
 
     if (asyncPool) {
       // Async disk flow with buffering

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -490,11 +490,11 @@ ResultProcessor *RPQueryIterator_New(QueryIterator *root, const RedisModuleSlotR
   ret->firstRead = true;
 #endif
 
-  // Read both once so the pool and the queue feeding it cannot disagree if the config
-  // changes mid-query. Both bounds are enforced at registration, and the factor's minimum
-  // of 1 is what keeps the queue at least as deep as the pool.
+  // Keep one per-query snapshot so the pool and queue sizes stay paired.
   const uint16_t asyncPoolSize = (uint16_t)RSGlobalConfig.diskAsyncReadPoolSize;
-  const uint16_t asyncQueueSize = asyncPoolSize * (uint16_t)RSGlobalConfig.diskAsyncReadQueueFactor;
+  const uint16_t asyncQueueFactor = (uint16_t)RSGlobalConfig.diskAsyncReadQueueFactor;
+  RS_ASSERT(asyncQueueFactor >= 1);
+  const uint16_t asyncQueueSize = asyncPoolSize * asyncQueueFactor;
 
   // Initialize async read state
   IndexResultAsyncRead_Init(&ret->async, asyncPoolSize, asyncQueueSize);

--- a/tests/cpptests/test_cpp_async_state.cpp
+++ b/tests/cpptests/test_cpp_async_state.cpp
@@ -20,13 +20,13 @@
 // Test pool size constant
 #define TEST_ASYNC_POOL_SIZE 16
 // Deliberately larger than the pool, so the fixture exercises the decoupled shape
-#define TEST_ASYNC_BUFFER_SIZE (TEST_ASYNC_POOL_SIZE * 2)
+#define TEST_ASYNC_QUEUE_SIZE (TEST_ASYNC_POOL_SIZE * 2)
 
 class AsyncStateTest : public ::testing::Test {
 protected:
   void SetUp() override {
     // Use the proper Init function - no async pool needed for state machine tests
-    IndexResultAsyncRead_Init(&state, TEST_ASYNC_POOL_SIZE, TEST_ASYNC_BUFFER_SIZE);
+    IndexResultAsyncRead_Init(&state, TEST_ASYNC_POOL_SIZE, TEST_ASYNC_QUEUE_SIZE);
 
     // Manually allocate arrays for testing (normally done by SetupAsyncPool)
     state.readyResults = array_new(AsyncReadResult, TEST_ASYNC_POOL_SIZE);
@@ -84,16 +84,16 @@ protected:
 };
 
 // Test: Initial state is empty
-TEST_F(AsyncStateTest, testBufferAndPoolSizesAreIndependent) {
-  ASSERT_GT(TEST_ASYNC_BUFFER_SIZE, TEST_ASYNC_POOL_SIZE);
+TEST_F(AsyncStateTest, testQueueAndPoolSizesAreIndependent) {
+  ASSERT_GT(TEST_ASYNC_QUEUE_SIZE, TEST_ASYNC_POOL_SIZE);
   ASSERT_EQ(state.poolSize, TEST_ASYNC_POOL_SIZE);
-  ASSERT_EQ(state.bufferSize, TEST_ASYNC_BUFFER_SIZE);
+  ASSERT_EQ(state.queueSize, TEST_ASYNC_QUEUE_SIZE);
 
   // Init allocates nothing, so no Free is needed for this scratch state
   IndexResultAsyncReadState scratch;
   IndexResultAsyncRead_Init(&scratch, 4, 32);
   ASSERT_EQ(scratch.poolSize, 4);
-  ASSERT_EQ(scratch.bufferSize, 32);
+  ASSERT_EQ(scratch.queueSize, 32);
 }
 
 TEST_F(AsyncStateTest, testInitialState) {

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -2295,67 +2295,67 @@ def test_flex_search_disk_buffer_percentage(env):
 
 @skip(cluster=True)
 def test_flex_search_disk_async_read_pool_size(env):
-    """Test search-disk-async-read-pool-size validation in Flex mode"""
-    env.expect('CONFIG', 'GET', 'search-disk-async-read-pool-size')\
-        .equal(['search-disk-async-read-pool-size', '16'])
+    """Test search-_disk-async-read-pool-size validation in Flex mode"""
+    env.expect('CONFIG', 'GET', 'search-_disk-async-read-pool-size')\
+        .equal(['search-_disk-async-read-pool-size', '16'])
 
-    env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '64').ok()
-    env.expect('CONFIG', 'GET', 'search-disk-async-read-pool-size')\
-        .equal(['search-disk-async-read-pool-size', '64'])
+    env.expect('CONFIG', 'SET', 'search-_disk-async-read-pool-size', '64').ok()
+    env.expect('CONFIG', 'GET', 'search-_disk-async-read-pool-size')\
+        .equal(['search-_disk-async-read-pool-size', '64'])
 
     # Boundary values
-    env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '1').ok()
-    env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '1024').ok()
+    env.expect('CONFIG', 'SET', 'search-_disk-async-read-pool-size', '1').ok()
+    env.expect('CONFIG', 'SET', 'search-_disk-async-read-pool-size', '1024').ok()
 
     # A pool of zero would stall the async path outright, so it is rejected
-    env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '0').error()\
+    env.expect('CONFIG', 'SET', 'search-_disk-async-read-pool-size', '0').error()\
         .contains('argument must be between 1 and 1024')
-    env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '1025').error()\
+    env.expect('CONFIG', 'SET', 'search-_disk-async-read-pool-size', '1025').error()\
         .contains('argument must be between 1 and 1024')
 
     # RLTest reuses the server across tests, so hand it back at the default
-    env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '16').ok()
+    env.expect('CONFIG', 'SET', 'search-_disk-async-read-pool-size', '16').ok()
 
 @skip(cluster=True)
 def test_flex_search_disk_async_read_queue_factor(env):
-    """Test search-disk-async-read-queue-factor validation in Flex mode"""
-    env.expect('CONFIG', 'GET', 'search-disk-async-read-queue-factor')\
-        .equal(['search-disk-async-read-queue-factor', '1'])
+    """Test search-_disk-async-read-queue-factor validation in Flex mode"""
+    env.expect('CONFIG', 'GET', 'search-_disk-async-read-queue-factor')\
+        .equal(['search-_disk-async-read-queue-factor', '1'])
 
-    env.expect('CONFIG', 'SET', 'search-disk-async-read-queue-factor', '4').ok()
-    env.expect('CONFIG', 'GET', 'search-disk-async-read-queue-factor')\
-        .equal(['search-disk-async-read-queue-factor', '4'])
+    env.expect('CONFIG', 'SET', 'search-_disk-async-read-queue-factor', '4').ok()
+    env.expect('CONFIG', 'GET', 'search-_disk-async-read-queue-factor')\
+        .equal(['search-_disk-async-read-queue-factor', '4'])
 
     # Boundary values
-    env.expect('CONFIG', 'SET', 'search-disk-async-read-queue-factor', '1').ok()
-    env.expect('CONFIG', 'SET', 'search-disk-async-read-queue-factor', '16').ok()
+    env.expect('CONFIG', 'SET', 'search-_disk-async-read-queue-factor', '1').ok()
+    env.expect('CONFIG', 'SET', 'search-_disk-async-read-queue-factor', '16').ok()
 
     # A factor below 1 would leave the queue shallower than the pool, so it is rejected
-    env.expect('CONFIG', 'SET', 'search-disk-async-read-queue-factor', '0').error()\
+    env.expect('CONFIG', 'SET', 'search-_disk-async-read-queue-factor', '0').error()\
         .contains('argument must be between 1 and 16')
-    env.expect('CONFIG', 'SET', 'search-disk-async-read-queue-factor', '17').error()\
+    env.expect('CONFIG', 'SET', 'search-_disk-async-read-queue-factor', '17').error()\
         .contains('argument must be between 1 and 16')
 
     # RLTest reuses the server across tests, so hand it back at the default
-    env.expect('CONFIG', 'SET', 'search-disk-async-read-queue-factor', '1').ok()
+    env.expect('CONFIG', 'SET', 'search-_disk-async-read-queue-factor', '1').ok()
 
 @skip(cluster=True)
 def test_flex_search_disk_async_read_pool_and_queue_set_together(env):
     """The pool size and the queue factor can be set in one command, in either order"""
-    env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '64',
-               'search-disk-async-read-queue-factor', '2').ok()
-    env.expect('CONFIG', 'GET', 'search-disk-async-read-pool-size')\
-        .equal(['search-disk-async-read-pool-size', '64'])
-    env.expect('CONFIG', 'GET', 'search-disk-async-read-queue-factor')\
-        .equal(['search-disk-async-read-queue-factor', '2'])
+    env.expect('CONFIG', 'SET', 'search-_disk-async-read-pool-size', '64',
+               'search-_disk-async-read-queue-factor', '2').ok()
+    env.expect('CONFIG', 'GET', 'search-_disk-async-read-pool-size')\
+        .equal(['search-_disk-async-read-pool-size', '64'])
+    env.expect('CONFIG', 'GET', 'search-_disk-async-read-queue-factor')\
+        .equal(['search-_disk-async-read-queue-factor', '2'])
 
-    env.expect('CONFIG', 'SET', 'search-disk-async-read-queue-factor', '4',
-               'search-disk-async-read-pool-size', '1024').ok()
-    env.expect('CONFIG', 'GET', 'search-disk-async-read-pool-size')\
-        .equal(['search-disk-async-read-pool-size', '1024'])
-    env.expect('CONFIG', 'GET', 'search-disk-async-read-queue-factor')\
-        .equal(['search-disk-async-read-queue-factor', '4'])
+    env.expect('CONFIG', 'SET', 'search-_disk-async-read-queue-factor', '4',
+               'search-_disk-async-read-pool-size', '1024').ok()
+    env.expect('CONFIG', 'GET', 'search-_disk-async-read-pool-size')\
+        .equal(['search-_disk-async-read-pool-size', '1024'])
+    env.expect('CONFIG', 'GET', 'search-_disk-async-read-queue-factor')\
+        .equal(['search-_disk-async-read-queue-factor', '4'])
 
     # RLTest reuses the server across tests, so hand it back at the defaults
-    env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '16',
-               'search-disk-async-read-queue-factor', '1').ok()
+    env.expect('CONFIG', 'SET', 'search-_disk-async-read-pool-size', '16',
+               'search-_disk-async-read-queue-factor', '1').ok()

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -2312,3 +2312,40 @@ def test_flex_search_disk_async_read_pool_size(env):
         .contains('argument must be between 1 and 1024')
     env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '1025').error()\
         .contains('argument must be between 1 and 1024')
+
+@skip(cluster=True)
+def test_flex_search_disk_async_read_queue_factor(env):
+    """Test search-disk-async-read-queue-factor validation in Flex mode"""
+    env.expect('CONFIG', 'GET', 'search-disk-async-read-queue-factor')\
+        .equal(['search-disk-async-read-queue-factor', '1'])
+
+    env.expect('CONFIG', 'SET', 'search-disk-async-read-queue-factor', '4').ok()
+    env.expect('CONFIG', 'GET', 'search-disk-async-read-queue-factor')\
+        .equal(['search-disk-async-read-queue-factor', '4'])
+
+    # Boundary values
+    env.expect('CONFIG', 'SET', 'search-disk-async-read-queue-factor', '1').ok()
+    env.expect('CONFIG', 'SET', 'search-disk-async-read-queue-factor', '16').ok()
+
+    # A factor below 1 would leave the queue shallower than the pool, so it is rejected
+    env.expect('CONFIG', 'SET', 'search-disk-async-read-queue-factor', '0').error()\
+        .contains('argument must be between 1 and 16')
+    env.expect('CONFIG', 'SET', 'search-disk-async-read-queue-factor', '17').error()\
+        .contains('argument must be between 1 and 16')
+
+@skip(cluster=True)
+def test_flex_search_disk_async_read_pool_and_queue_set_together(env):
+    """The pool size and the queue factor can be set in one command, in either order"""
+    env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '64',
+               'search-disk-async-read-queue-factor', '2').ok()
+    env.expect('CONFIG', 'GET', 'search-disk-async-read-pool-size')\
+        .equal(['search-disk-async-read-pool-size', '64'])
+    env.expect('CONFIG', 'GET', 'search-disk-async-read-queue-factor')\
+        .equal(['search-disk-async-read-queue-factor', '2'])
+
+    env.expect('CONFIG', 'SET', 'search-disk-async-read-queue-factor', '4',
+               'search-disk-async-read-pool-size', '1024').ok()
+    env.expect('CONFIG', 'GET', 'search-disk-async-read-pool-size')\
+        .equal(['search-disk-async-read-pool-size', '1024'])
+    env.expect('CONFIG', 'GET', 'search-disk-async-read-queue-factor')\
+        .equal(['search-disk-async-read-queue-factor', '4'])

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -2313,6 +2313,9 @@ def test_flex_search_disk_async_read_pool_size(env):
     env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '1025').error()\
         .contains('argument must be between 1 and 1024')
 
+    # RLTest reuses the server across tests, so hand it back at the default
+    env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '16').ok()
+
 @skip(cluster=True)
 def test_flex_search_disk_async_read_queue_factor(env):
     """Test search-disk-async-read-queue-factor validation in Flex mode"""
@@ -2333,6 +2336,9 @@ def test_flex_search_disk_async_read_queue_factor(env):
     env.expect('CONFIG', 'SET', 'search-disk-async-read-queue-factor', '17').error()\
         .contains('argument must be between 1 and 16')
 
+    # RLTest reuses the server across tests, so hand it back at the default
+    env.expect('CONFIG', 'SET', 'search-disk-async-read-queue-factor', '1').ok()
+
 @skip(cluster=True)
 def test_flex_search_disk_async_read_pool_and_queue_set_together(env):
     """The pool size and the queue factor can be set in one command, in either order"""
@@ -2349,3 +2355,7 @@ def test_flex_search_disk_async_read_pool_and_queue_set_together(env):
         .equal(['search-disk-async-read-pool-size', '1024'])
     env.expect('CONFIG', 'GET', 'search-disk-async-read-queue-factor')\
         .equal(['search-disk-async-read-queue-factor', '4'])
+
+    # RLTest reuses the server across tests, so hand it back at the defaults
+    env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '16',
+               'search-disk-async-read-queue-factor', '1').ok()

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -2292,3 +2292,23 @@ def test_flex_search_disk_buffer_percentage(env):
     # Values above 100 should be rejected
     env.expect('CONFIG', 'SET', 'search-disk-buffer-percentage', '101').error()\
         .contains('argument must be between 0 and 100')
+
+@skip(cluster=True)
+def test_flex_search_disk_async_read_pool_size(env):
+    """Test search-disk-async-read-pool-size validation in Flex mode"""
+    env.expect('CONFIG', 'GET', 'search-disk-async-read-pool-size')\
+        .equal(['search-disk-async-read-pool-size', '16'])
+
+    env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '64').ok()
+    env.expect('CONFIG', 'GET', 'search-disk-async-read-pool-size')\
+        .equal(['search-disk-async-read-pool-size', '64'])
+
+    # Boundary values
+    env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '1').ok()
+    env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '1024').ok()
+
+    # A pool of zero would stall the async path outright, so it is rejected
+    env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '0').error()\
+        .contains('argument must be between 1 and 1024')
+    env.expect('CONFIG', 'SET', 'search-disk-async-read-pool-size', '1025').error()\
+        .contains('argument must be between 1 and 1024')


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** both the async-disk read depth and the read-ahead queue that feeds it are compile-time constants (`MAX_ONGOING_READ_SIZE`, `ITERATOR_BUFFER_SIZE`), so tuning either takes a rebuild. The right values depend on the device, the query-thread count and the concurrency the shard sees — which differ between a laptop, a benchmark host and a production shard — so no single compiled-in pair serves all three.
2. **Change:** add two internal knobs following the existing `search-_...` internal-config naming — `search-_disk-async-read-pool-size` (metadata reads a query keeps in flight) and `search-_disk-async-read-queue-factor` (read-ahead queue, as a multiple of the pool) — and read both when a query builds its pool.
3. **Outcome:** internal benchmarking and diagnostics can tune async-disk read parallelism and read-ahead depth with `CONFIG SET`, taking effect from the next query. **Defaults are 16 and 1, reproducing the previous constants exactly, so behavior is unchanged.**

Unlike `search-disk-buffer-percentage` and `search-disk-max-open-files`, neither knob needs live-reapply plumbing (no `SearchDisk_Update*` call): the pool is constructed per query, so the next query picks up new values on its own.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `src/config.c` — registers `search-_disk-async-read-pool-size` and `search-_disk-async-read-queue-factor` (both mutable, unprefixed, `get/set_uint_numeric_config`).
2. `src/config.h` — `diskAsyncReadPoolSize` and `diskAsyncReadQueueFactor` fields, their defaults (16, 1) and maxima (1024, 16), the `static_assert` tying those maxima to the `uint16_t` they feed, and the default-initializer entries.
3. `src/result_processor.c` — `RPQueryIterator_New` derives the pool and queue sizes from the configs; the two constants are removed.
4. `src/index_result_async_read.{c,h}` — capacity vocabulary renamed from `buffer` to `queue`, matching the config name.
5. `tests/pytests/test_config.py`, `tests/cpptests/test_cpp_async_state.cpp` — coverage for both internal knobs, each test handing the knobs back at their defaults, and the rename followed through.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

## Design notes

**Why the queue is a factor rather than an absolute count.** `IndexResultAsyncRead_Init` asserts `queueSize >= poolSize` — a queue shallower than the pool cannot keep the pool saturated. Two absolute knobs cannot hold that invariant, for two independent reasons. `CONFIG SET a X b Y` applies its arguments in order, so validation inside a set callback sees a half-applied state and accepts or rejects depending on argument order; moving the check to an apply callback fixes that much. It does not fix the second reason: `RPQueryIterator_New` runs on a query thread and reads two `RSGlobalConfig` fields non-atomically, so raising both 16 → 64 can be observed as pool 64 next to queue 16, tripping the assertion. Deriving the queue as `pool * factor` with `factor >= 1` satisfies the invariant for every interleaving, needs no cross-config validation, and cannot fail a `CONFIG SET`.

**Bounds.** Pool 1..1024: zero would stall the async path outright, and in-flight reads scale with the pool times the number of concurrently executing queries, so on an 8-thread shard 1024 already means up to 8192 outstanding reads. Factor 1..16 bounds memory rather than device depth: the queue holds deep-copied index results, so its cost is pool × factor × concurrent queries, and past a small multiple the extra depth buys buffered index results rather than device parallelism. A `static_assert` fails the build if either cap is raised past what the `uint16_t` queue size can hold.

**Read once per query.** `RPQueryIterator_New` snapshots both values into locals and uses them for the pool and the queue feeding it, so a `CONFIG SET` racing a query start cannot leave the two disagreeing.

**Naming.** The queue knob deliberately avoids `buffer`: `search-disk-buffer-percentage` already exists and means the SpeedB write-buffer budget, so a second `search-disk-*-buffer-*` would read as a relative of an unrelated setting. The internal capacity field was renamed `bufferSize` → `queueSize` to match, and because `result_processor.c` already uses "buffer" for the unrelated `RPSafeLoader` buffering.

**Why the defaults are unchanged.** 16 is shallow for NVMe via io_uring and I expect a deeper default plus a factor above 1 to win, but I have no measurement for it, and the aggregate-depth multiplier above cuts the other way. Changing a default is a behavior change for every existing deployment and deserves its own PR with numbers; bundling it here would mean a revert also takes the knobs away. These internal configs are precisely what makes the measurement cheap — a sweep can now run `CONFIG SET` between phases against a single build instead of rebuilding per value.

## Verification

`tests/pytests/test_config.py` covers, for each knob, the default, a set/get round trip, both boundary values and rejection on either side of the range; plus a case that sets the pool size and the queue factor in a single `CONFIG SET` in both argument orders, which is the ordering trap a validation-based coupling would have had. `tests/cpptests/test_cpp_async_state.cpp` still asserts the pool and queue sizes stay independent.

Every test that changes a knob restores its default on the way out. RLTest reuses one server across all tests whose env parameters match and nothing resets module configs between them, so leaving the pool size at 1024 would have made any later assertion about its default order-dependent for the rest of the run. A trailing `CONFIG SET` is sufficient rather than a `try`/`finally`: `Defaults.exit_on_failure` is false and `--exit-on-failure` is commented out in `tests/pytests/runtests.sh`, so `env.expect` records a failure and execution continues to the end of the test body.

Both source files and both test files compile locally with the flags from a configured build (including the `-Werror=discarded-qualifiers,jump-misses-init,implicit-function-declaration` set), as does a second C++ translation unit that includes `config.h`, confirming the file-scope `static_assert` is valid in both C17 and C++. The `static_assert` was separately checked to fail the build when violated rather than being a silent no-op.

Local targeted verification after making the configs internal:

- `./build.sh RUN_PYTEST TEST=test_config.py:test_flex_search_disk_async_read_pool_size`
- `./build.sh RUN_PYTEST TEST=test_config.py:test_flex_search_disk_async_read_queue_factor`
- `./build.sh RUN_PYTEST TEST=test_config.py:test_flex_search_disk_async_read_pool_and_queue_set_together`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

