### PR TITLE
[MOD-17729] Fix memory leak when indexing terms longer than the suffix trie key-length cap

### DIFF
--- a/src/suffix.c
+++ b/src/suffix.c
@@ -88,6 +88,13 @@ void addSuffixTrie(Trie *trie, const char *str, uint32_t len) {
   // Save string copy to all suffixes of it
   // If it exists, move to the next field
   for (size_t j = 1; j < rlen; ++j) {
+    // Trie_InsertRune silently drops keys at or past TRIE_INITIAL_STRING_LEN. Skip
+    // them before building a payload, which the drop would otherwise strand. The
+    // shorter suffixes that follow are still insertable, so this must not bail out.
+    if (rlen - j >= TRIE_INITIAL_STRING_LEN) {
+      continue;
+    }
+
     TrieNode *trienode = Trie_GetNode(trie, runes + j, rlen - j, true, NULL);
 
     data = Suffix_GetData(trienode);

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -88,17 +88,17 @@ void addSuffixTrie(Trie *trie, const char *str, uint32_t len) {
   // Save string copy to all suffixes of it
   // If it exists, move to the next field
   for (size_t j = 1; j < rlen; ++j) {
-    // Trie_InsertRune silently drops keys at or past TRIE_INITIAL_STRING_LEN. Skip
-    // them before building a payload, which the drop would otherwise strand. The
-    // shorter suffixes that follow are still insertable, so this must not bail out.
-    if (rlen - j >= TRIE_INITIAL_STRING_LEN) {
-      continue;
-    }
-
     TrieNode *trienode = Trie_GetNode(trie, runes + j, rlen - j, true, NULL);
 
     data = Suffix_GetData(trienode);
     if (!data) {
+      // Trie_InsertRune silently drops keys at or past TRIE_INITIAL_STRING_LEN, so
+      // building a payload for one strands it. The shorter suffixes that follow are
+      // still insertable, so this must not bail out.
+      if (rlen - j >= TRIE_INITIAL_STRING_LEN) {
+        continue;
+      }
+
       suffixData newdata = createSuffixNode(copyStr, 0);
       RSPayload payload = { .data = (char*)&newdata, .len = sizeof(newdata) };
       int rc = Trie_InsertRune(trie, runes + j, rlen - j, 1, ADD_REPLACE, &payload, 0);

--- a/tests/cpptests/test_cpp_suffix.cpp
+++ b/tests/cpptests/test_cpp_suffix.cpp
@@ -234,3 +234,46 @@ TEST_F(WildcardEmptyPatternTest, trieIterateWildcardEmptyMatchesNothing) {
 
   TrieType_Free(t);
 }
+
+// addSuffixTrie indexes the whole term through an unguarded entry point, but each
+// proper suffix goes through Trie_InsertRune, which drops keys at or past
+// TRIE_INITIAL_STRING_LEN. A term longer than that cap is therefore indexed with a
+// gap: its longest suffixes are missing while the shorter ones are present.
+
+class SuffixTrieLongTermTest : public ::testing::Test {};
+
+// Long enough that suffixes fall on both sides of the cap.
+static constexpr size_t kLongTermLen = TRIE_INITIAL_STRING_LEN + 44;
+
+// Only an inserted suffix carries a payload; a node reached merely as a prefix of
+// a longer key does not.
+static bool suffixIndexed(Trie *t, const rune *runes, size_t rlen, size_t off) {
+  TrieNode *node = Trie_GetNode(t, runes + off, rlen - off, true, NULL);
+  return TrieNode_GetPayloadData(node) != NULL;
+}
+
+TEST_F(SuffixTrieLongTermTest, suffixesPastTheKeyLengthCapAreSkipped) {
+  std::string term;
+  for (size_t i = 0; i < kLongTermLen; ++i) {
+    term += static_cast<char>('a' + (i * 7) % 26);
+  }
+
+  Trie *t = NewTrie(suffixTrie_freeCallback, Trie_Sort_Lex);
+  addSuffixTrie(t, term.data(), term.size());
+
+  runeBuf buf;
+  size_t rlen = 0;
+  rune *runes = runeBufFill(term.data(), term.size(), &buf, &rlen);
+  ASSERT_EQ(rlen, kLongTermLen);
+
+  EXPECT_TRUE(suffixIndexed(t, runes, rlen, 0));
+  // Longest proper suffix, and the last one still over the cap.
+  EXPECT_FALSE(suffixIndexed(t, runes, rlen, 1));
+  EXPECT_FALSE(suffixIndexed(t, runes, rlen, kLongTermLen - TRIE_INITIAL_STRING_LEN));
+  // First suffix under the cap, and the shortest one.
+  EXPECT_TRUE(suffixIndexed(t, runes, rlen, kLongTermLen - TRIE_INITIAL_STRING_LEN + 1));
+  EXPECT_TRUE(suffixIndexed(t, runes, rlen, rlen - 1));
+
+  runeBufFree(&buf);
+  TrieType_Free(t);
+}


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `addSuffixTrie` builds a payload for every proper suffix of a term, but
   `Trie_InsertRune` silently rejects keys at or past `TRIE_INITIAL_STRING_LEN` (256 runes)
   and returns without taking ownership of the payload. Every term longer than that cap
   therefore leaks one array allocation per over-cap suffix on each `WITHSUFFIXTRIE` index
   write.
2. Change: skip payload construction for suffixes the trie will not accept. The suffixes
   below the cap are still indexed, and a suffix that resolves to an existing payload node
   still records the term.
3. Outcome: indexing a 300-character term into a `WITHSUFFIXTRIE` field leaked 44
   allocations that are now never made. Nothing changes about which suffixes are
   searchable — the skipped keys were never inserted in the first place. Any test that
   indexes an over-cap term into a suffix trie fails LSan until this lands: four of the
   `test_suffix_trie_encoding.py` cases in #10965 pass every assertion and still fail
   the `sanitize (Standalone)` lane on `### Sanitizer: leaks detected`.

#### Which additional issues this PR fixes

1. MOD-17729
2. #10965 — its sanitizer lane cannot go green without this fix.

#### Main objects this PR modified

1. `addSuffixTrie` (`src/suffix.c`) — no longer allocates a payload for a suffix that
   exceeds the trie key-length cap.
2. `SuffixTrieLongTermTest` (`tests/cpptests/test_cpp_suffix.cpp`) — pins which suffixes of
   an over-cap term are indexed, and acts as the leak tripwire under ASan.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

