### PR TITLE
rqe_iterators: stop skipping 208 tests under miri for an FFI call that does not happen

### DIFF
--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -311,6 +311,7 @@ fn get_correct_value() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Too slow to be run under miri.")]
 fn eof_after_filtering() {
     let mut ii =
         InvertedIndex::<inverted_index::numeric::Numeric>::new(IndexFlags_Index_StoreNumeric);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/profilable.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profilable.rs
@@ -120,7 +120,6 @@ fn optional_wraps_child_and_self() {
 }
 
 /// Wrapping `Intersection` in `Profile` counts reads.
-#[cfg_attr(miri, ignore = "call ffi::RSYieldableMetric_Concat")]
 #[test]
 fn intersection_wraps_children_and_self() {
     let a = Mock::new([1, 3, 5, 7]);
@@ -159,7 +158,6 @@ fn intersection_empty_children() {
 }
 
 /// Wrapping `Union` (full mode) in `Profile` counts reads.
-#[cfg_attr(miri, ignore = "call ffi::RSYieldableMetric_Concat")]
 #[test]
 fn union_full_wraps_children_and_self() {
     let a = Mock::new([1, 3, 5]);
@@ -196,7 +194,6 @@ fn union_full_wraps_children_and_self() {
 }
 
 /// `UnionQuickFlat` wrapped in `Profile` returns after first match per doc.
-#[cfg_attr(miri, ignore = "call ffi::RSYieldableMetric_Concat")]
 #[test]
 fn union_quick_wraps_children_and_self() {
     let a = Mock::new([1, 5]);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -46,7 +46,6 @@ macro_rules! union_common_tests {
         #[case::c10_small(10, &[1u64, 2, 3, 40, 50])]
         #[case::c10_medium(10, &[5u64, 6, 7, 24, 25, 46, 47, 48, 49, 50, 51, 234, 2345])]
         #[case::c10_large(10, &[9u64, 25, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130])]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn read(#[case] num_children: usize, #[case] base_result_set: &[u64]) {
             let (children, expected) = create_union_children(num_children, base_result_set);
 
@@ -100,7 +99,6 @@ macro_rules! union_common_tests {
         #[case::c10_small(10, &[1u64, 2, 3, 40, 50])]
         #[case::c10_medium(10, &[5u64, 6, 7, 24, 25, 46, 47, 48, 49, 50, 51, 234, 2345])]
         #[case::c10_large(10, &[9u64, 25, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130])]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn skip_to(#[case] num_children: usize, #[case] base_result_set: &[u64]) {
             let (children, expected) = create_union_children(num_children, base_result_set);
             let mut union_iter = ContractChecker::new(Union::new(children));
@@ -148,7 +146,6 @@ macro_rules! union_common_tests {
         #[case::c10_small(10, &[1u64, 2, 3, 40, 50])]
         #[case::c10_medium(10, &[5u64, 6, 7, 24, 25, 46, 47, 48, 49, 50, 51, 234, 2345])]
         #[case::c10_large(10, &[9u64, 25, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130])]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn rewind(#[case] num_children: usize, #[case] base_result_set: &[u64]) {
             let (children, expected) = create_union_children(num_children, base_result_set);
             let mut union_iter = ContractChecker::new(Union::new(children));
@@ -180,7 +177,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn rewind_restores_original_order_after_exhaustion() {
             // Child 0: [1]         — exhausts first
             // Child 1: [1, 5]      — exhausts second
@@ -227,7 +223,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn edge_case_single_child() {
             let (child, child_data) = create_mock_1([10, 20, 30, 40, 50]);
             let mut union_iter = ContractChecker::new(Union::new(vec![child]));
@@ -245,7 +240,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn edge_case_disjoint_children() {
             let (children, data) = create_mock_3([1, 2, 3], [10, 20, 30], [100, 200, 300]);
 
@@ -266,7 +260,6 @@ macro_rules! union_common_tests {
             assert_eq!(data[2].read_count(), 4);
         }
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn edge_case_overlapping_children() {
             let (children, data) = create_mock_3(
                 [1, 2, 5, 10, 15, 20],
@@ -290,7 +283,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn edge_case_skip_to_exact_match() {
             let (children, _) = create_mock_2([10, 20, 30, 40, 50], [15, 25, 35, 45, 55]);
             let mut union_iter = ContractChecker::new(Union::new(children));
@@ -306,7 +298,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn edge_case_skip_to_not_found() {
             let (children, _) = create_mock_2([10, 20, 30, 40, 50], [15, 25, 35, 45, 55]);
             let mut union_iter = ContractChecker::new(Union::new(children));
@@ -322,7 +313,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn edge_case_skip_to_past_eof() {
             let (children, _) = create_mock_2([10, 20, 30], [15, 25, 35]);
             let mut union_iter = ContractChecker::new(Union::new(children));
@@ -338,7 +328,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn edge_case_interleaved_read_and_skip_to() {
             let (children, _) = create_mock_2(
                 [10, 20, 30, 40, 50, 60, 70, 80],
@@ -374,7 +363,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn edge_case_empty_children_mixed_with_non_empty() {
             let empty_child: Mock<'static, 0> = Mock::new([]);
             let child1: Mock<'static, 3> = Mock::new([10, 20, 30]);
@@ -395,7 +383,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn edge_case_all_children_empty() {
             let empty1: Mock<'static, 0> = Mock::new([]);
             let empty2: Mock<'static, 0> = Mock::new([]);
@@ -409,7 +396,6 @@ macro_rules! union_common_tests {
             assert_eq!(union_iter.num_estimated(), 0);
         }
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn edge_case_skip_to_child_already_past_target() {
             let (children, _data) = create_mock_2([10, 50, 100], [20, 60, 110]);
             let mut union_iter = ContractChecker::new(Union::new(children));
@@ -423,7 +409,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn edge_case_skip_to_exhausts_some_children() {
             let (children, _data) = create_mock_2([10, 20, 30], [15, 25, 100]);
             let mut union_iter = ContractChecker::new(Union::new(children));
@@ -437,7 +422,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn edge_case_skip_to_exhausts_all_children() {
             let (children, _data) = create_mock_2([10, 20, 30], [15, 25, 35]);
             let mut union_iter = ContractChecker::new(Union::new(children));
@@ -448,7 +432,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn edge_case_initialize_with_empty_children() {
             let empty1: Mock<'static, 0> = Mock::new([]);
             let child1: Mock<'static, 2> = Mock::new([10, 20]);
@@ -476,7 +459,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn edge_case_misbehaving_child_returns_none_during_init() {
             let mock1: Mock<'static, 3> = Mock::new([10, 30, 50]);
             let mock2: Mock<'static, 3> = Mock::new([20, 40, 60]);
@@ -506,7 +488,6 @@ macro_rules! union_common_tests {
         // =============================================================================
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_ok() {
             let child0: Mock<'static, 5> = Mock::new([10, 20, 30, 40, 50]);
             let child1: Mock<'static, 5> = Mock::new([15, 25, 35, 45, 55]);
@@ -537,7 +518,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_moved() {
             let child0: Mock<'static, 5> = Mock::new([10, 20, 30, 40, 50]);
             let child1: Mock<'static, 5> = Mock::new([15, 25, 35, 45, 55]);
@@ -567,7 +547,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_after_eof() {
             let child0: Mock<'static, 2> = Mock::new([10, 20]);
             let child1: Mock<'static, 2> = Mock::new([15, 25]);
@@ -594,7 +573,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_single_child_aborts() {
             let child0: Mock<'static, 5> = Mock::new([10, 20, 30, 40, 50]);
             let child1: Mock<'static, 5> = Mock::new([15, 25, 35, 45, 55]);
@@ -627,7 +605,6 @@ macro_rules! union_common_tests {
             assert!(!union_iter.at_eof());
         }
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_all_children_abort() {
             let child0: Mock<'static, 5> = Mock::new([10, 20, 30, 40, 50]);
             let child1: Mock<'static, 5> = Mock::new([15, 25, 35, 45, 55]);
@@ -656,7 +633,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_child_moves_to_eof() {
             let child0: Mock<'static, 2> = Mock::new([10, 20]);
             let child1: Mock<'static, 5> = Mock::new([15, 25, 35, 45, 55]);
@@ -690,7 +666,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_mixed_ok_moved_abort() {
             let child0: Mock<'static, 5> = Mock::new([10, 20, 30, 40, 50]);
             let child1: Mock<'static, 5> = Mock::new([15, 25, 35, 45, 55]);
@@ -724,7 +699,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_all_children_move_to_eof() {
             let child0: Mock<'static, 2> = Mock::new([10, 20]);
             let child1: Mock<'static, 2> = Mock::new([15, 25]);
@@ -749,7 +723,6 @@ macro_rules! union_common_tests {
             assert!(matches!(status, RQEValidateStatus::Ok));
         }
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_updates_to_new_minimum() {
             let child0: Mock<'static, 5> = Mock::new([10, 20, 30, 40, 50]);
             let child1: Mock<'static, 5> = Mock::new([5, 25, 35, 45, 55]);
@@ -779,7 +752,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_when_already_at_eof() {
             let mock1: Mock<'static, 2> = Mock::new([10, 20]);
             let mock2: Mock<'static, 2> = Mock::new([10, 30]);
@@ -804,7 +776,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_with_children_at_eof() {
             // Test 1: Child moves to EOF during revalidate
             {
@@ -907,7 +878,6 @@ macro_rules! union_common_tests {
         /// contradicts the clamp. [`revalidate_child_behind_union_position_is_kept`]
         /// is the case that does strand a sibling: an exact match on the probe.
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_quick_triggers_quick_exit() {
             let mock1: Mock<'static, 3> = Mock::new([10, 30, 50]);
             let mock2: Mock<'static, 3> = Mock::new([20, 40, 60]);
@@ -964,7 +934,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_keeps_children_at_current_position() {
             let child0: Mock<'static, 3> = Mock::new([10, 20, 30]);
             let child1: Mock<'static, 3> = Mock::new([10, 25, 35]);
@@ -1005,7 +974,6 @@ macro_rules! union_common_tests {
         /// After `read()` returns doc_id 10, revalidate all children with `Ok`.
         /// Because the minimum hasn't moved, the union should return `Ok`.
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_minimum_unchanged_returns_ok() {
             let child0: Mock<'static, 3> = Mock::new([10, 30, 50]);
             let child1: Mock<'static, 3> = Mock::new([10, 40, 60]);
@@ -1050,7 +1018,6 @@ macro_rules! union_common_tests {
         /// asserts on — see
         /// [`revalidate_asserts_when_a_resurrected_child_lands_behind_a_full_union`].
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_child_behind_union_position_is_kept() {
             let child0: Mock<'static, 3> = Mock::new([5, 100, 300]);
             let child1: Mock<'static, 3> = Mock::new([10, 50, 200]);
@@ -1139,7 +1106,6 @@ macro_rules! union_common_tests {
         /// [`revalidate_advance_keeps_a_document_a_lagging_child_still_matches`] —
         /// so the union advances to its next document and reports the move.
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_advances_when_nothing_backs_the_current_position() {
             let child0: Mock<'static, 3> = Mock::new([10, 20, 40]);
             let child1: Mock<'static, 2> = Mock::new([15, 25]);
@@ -1205,7 +1171,6 @@ macro_rules! union_common_tests {
         /// 20 any more, but child1 still matches it, so the union may not step over it
         /// without first asking child1.
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn revalidate_advance_keeps_a_document_a_lagging_child_still_matches() {
             use rqe_iterators::{not::Not, utils::NoTimeoutChecker};
 
@@ -1273,7 +1238,6 @@ macro_rules! union_common_tests {
         /// that on purpose — it is the only way to reach the assertion.
         #[test]
         #[cfg(debug_assertions)]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         #[should_panic(expected = "moved behind the union's position")]
         fn revalidate_asserts_when_a_resurrected_child_lands_behind_a_full_union() {
             let child0: Mock<'static, 2> = Mock::new([10, 30]);
@@ -1313,7 +1277,6 @@ macro_rules! union_common_tests {
         // =============================================================================
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn skip_to_edge_cases() {
             // Quick mode - child already at target doc_id
             {
@@ -1376,7 +1339,6 @@ macro_rules! union_common_tests {
         /// document, so `read()` returns `None` (EOF) during that advancement.
         /// The union should still continue with the remaining child.
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn child_hits_eof_during_advance_matching_children() {
             // child0 has only doc 10, child1 has doc 10 then more.
             let child0: Mock<'static, 1> = Mock::new([10]);
@@ -1406,7 +1368,6 @@ macro_rules! union_common_tests {
         /// Same as above but in Quick mode — only one matching child is consumed,
         /// so the EOF child should be silently dropped.
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn child_hits_eof_during_advance_matching_children_quick() {
             let child0: Mock<'static, 1> = Mock::new([10]);
             let child1: Mock<'static, 3> = Mock::new([10, 20, 30]);
@@ -1430,7 +1391,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn quick_exit_early_match_in_skip_to() {
             let (children, _data) = create_mock_3([1, 30, 200, 1000], [2, 10, 300, 1000], [3, 20, 100, 1000]);
             let mut union = ContractChecker::new($UnionQuick::new(children));
@@ -1477,7 +1437,6 @@ macro_rules! union_common_tests {
         // =============================================================================
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn current_after_operations() {
             let (children, _) = create_mock_2([10, 20, 30, 40, 50], [15, 25, 35, 45, 55]);
             let mut union_iter = ContractChecker::new(Union::new(children));
@@ -1508,7 +1467,6 @@ macro_rules! union_common_tests {
         // =============================================================================
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn mode_quick_variant_produces_same_doc_ids() {
             let (full_children, _) = create_mock_2([10, 20, 30, 40, 50], [15, 25, 35, 45, 55]);
             let mut full_iter = $UnionFull::new(full_children);
@@ -1528,7 +1486,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn mode_full_aggregates_all_matching_children() {
             let (children, _) = create_mock_3([10, 20, 30], [10, 25, 35], [10, 28, 38]);
             let mut full_iter = $UnionFull::new(children);
@@ -1545,7 +1502,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn mode_quick_takes_first_matching_child_only() {
             let (children, _) = create_mock_3([10, 20, 30], [10, 25, 35], [10, 28, 38]);
             let mut quick_iter = $UnionQuick::new(children);
@@ -1562,7 +1518,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn mode_full_aggregates_correct_number_of_children() {
             let (children, _) = create_mock_3([10, 20, 30], [10, 25], [10, 30]);
             let mut full_iter = $UnionFull::new(children);
@@ -1601,7 +1556,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn mode_quick_always_has_one_child() {
             let (children, _) = create_mock_3([10, 20, 30], [10, 25], [10, 30]);
             let mut quick_iter = $UnionQuick::new(children);
@@ -1616,7 +1570,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn mode_quick_vs_full_with_skip_to() {
             let (full_children, _) = create_mock_3([10, 30, 50], [20, 40, 50], [25, 45, 50]);
             let mut full_iter = $UnionFull::new(full_children);
@@ -1649,7 +1602,6 @@ macro_rules! union_common_tests {
         // =============================================================================
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn reuse_results_optimization_full_mode() {
             let (children, data) = create_mock_3([1, 3, 5], [2, 3, 6], [3, 4, 7]);
             let mut union = ContractChecker::new($UnionFull::new(children));
@@ -1745,7 +1697,6 @@ macro_rules! union_common_tests {
         /// Without `reset_aggregate`, the aggregate result's field_mask would
         /// be OR'd across reads, leaking bits from previous documents.
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn full_mode_field_mask_resets_between_reads() {
             let children: Vec<Box<dyn RQEIterator<'static>>> = vec![
                 Box::new(FieldMaskMock::new(vec![10, 20], 0x1)),
@@ -1826,7 +1777,6 @@ macro_rules! union_common_tests {
         // -- Full mode: read propagates timeout ---------------------
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn read_full_propagates_timeout_first_child() {
             let children = make_timeout_children(0);
             let mut union = ContractChecker::new($UnionFull::new(children));
@@ -1834,7 +1784,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn read_full_propagates_timeout_mid_child() {
             let children = make_timeout_children(1);
             let mut union = ContractChecker::new($UnionFull::new(children));
@@ -1842,7 +1791,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn read_full_propagates_timeout_last_child() {
             let children = make_timeout_children(2);
             let mut union = ContractChecker::new($UnionFull::new(children));
@@ -1852,7 +1800,6 @@ macro_rules! union_common_tests {
         // -- Quick mode: read propagates timeout --------------------
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn read_quick_propagates_timeout_first_child() {
             let children = make_timeout_children(0);
             let mut union = ContractChecker::new($UnionQuick::new(children));
@@ -1860,7 +1807,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn read_quick_propagates_timeout_mid_child() {
             let children = make_timeout_children(1);
             let mut union = ContractChecker::new($UnionQuick::new(children));
@@ -1868,7 +1814,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn read_quick_propagates_timeout_last_child() {
             let children = make_timeout_children(2);
             let mut union = ContractChecker::new($UnionQuick::new(children));
@@ -1878,7 +1823,6 @@ macro_rules! union_common_tests {
         // -- Full mode: skip_to propagates timeout ------------------
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn skip_to_full_propagates_timeout_first_child() {
             let children = make_timeout_children(0);
             let mut union = ContractChecker::new($UnionFull::new(children));
@@ -1886,7 +1830,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn skip_to_full_propagates_timeout_mid_child() {
             let children = make_timeout_children(1);
             let mut union = ContractChecker::new($UnionFull::new(children));
@@ -1894,7 +1837,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn skip_to_full_propagates_timeout_last_child() {
             let children = make_timeout_children(2);
             let mut union = ContractChecker::new($UnionFull::new(children));
@@ -1904,7 +1846,6 @@ macro_rules! union_common_tests {
         // -- Quick mode: skip_to propagates timeout -----------------
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn skip_to_quick_propagates_timeout_first_child() {
             let children = make_timeout_children(0);
             let mut union = ContractChecker::new($UnionQuick::new(children));
@@ -1912,7 +1853,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn skip_to_quick_propagates_timeout_mid_child() {
             let children = make_timeout_children(1);
             let mut union = ContractChecker::new($UnionQuick::new(children));
@@ -1920,7 +1860,6 @@ macro_rules! union_common_tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn skip_to_quick_propagates_timeout_last_child() {
             let children = make_timeout_children(2);
             let mut union = ContractChecker::new($UnionQuick::new(children));
@@ -1934,7 +1873,6 @@ macro_rules! union_common_tests {
         /// `into_trimmed` on a Full union produces a working `UnionTrimmed` that
         /// yields all children in reverse order when the limit is large enough.
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn into_trimmed_full_yields_all_children() {
             let (children, _data) = create_mock_3([1, 2], [3, 4], [5, 6]);
             let union = $UnionFull::new(children);
@@ -1946,7 +1884,6 @@ macro_rules! union_common_tests {
 
         /// `into_trimmed` on a Quick union applies ascending trimming correctly.
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn into_trimmed_quick_trims_asc() {
             // 3 children with est [2, 2, 2], limit=1.
             // Asc scan from child[1]: child[1].est=2 > 1 → keep=2.
@@ -1962,7 +1899,6 @@ macro_rules! union_common_tests {
 
         /// `into_trimmed` on a Quick union applies descending trimming correctly.
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn into_trimmed_quick_trims_desc() {
             // 3 children with est [2, 2, 2], limit=1.
             // Desc scan from child[1] backward: child[1].est=2 > 1 → skip=1.
@@ -1996,7 +1932,6 @@ macro_rules! union_common_tests {
 
         /// After reading to EOF, `num_children_active` should be 0.
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn num_children_active_after_eof() {
             let (children, _data) = create_mock_2([1], [2]);
             let mut union = ContractChecker::new(Union::new(children));
@@ -2013,7 +1948,6 @@ macro_rules! union_common_tests {
 
         /// After rewind, `num_children_active` should be restored to the total.
         #[test]
-        #[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
         fn num_children_active_after_rewind() {
             let (children, _data) = create_mock_2([1, 3], [2, 4]);
             let mut union = ContractChecker::new(Union::new(children));

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_flat.rs
@@ -28,7 +28,6 @@ use rqe_iterators_test_utils::ContractChecker;
 // =============================================================================
 
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn reuse_results_optimization_quick_mode() {
     let (children, data) = create_mock_2([3], [2]);
     let mut union = ContractChecker::new(UnionQuickFlat::new(children));
@@ -102,7 +101,6 @@ fn into_children_returns_all_children() {
 /// `into_trimmed` on a `UnionFullFlat` produces a working `UnionTrimmed` that
 /// yields all children in reverse order when the limit is large enough.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn into_trimmed_full_flat_yields_all_children() {
     let (children, _data) = create_mock_3([1, 2], [3, 4], [5, 6]);
     let union = UnionFullFlat::new(children);
@@ -118,7 +116,6 @@ fn into_trimmed_full_flat_yields_all_children() {
 
 /// `into_trimmed` on a `UnionQuickFlat` applies trimming correctly.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn into_trimmed_quick_flat_trims_asc() {
     // 3 children with est [2, 2, 2], limit=1.
     // Asc scan from child[1]: child[1].est=2 > 1 → keep=2.
@@ -157,7 +154,6 @@ fn union_full_flat_upholds_current_contract() {
 /// union would report a document no index holds and move *backwards*, handing a
 /// parent documents it has already been given.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn revalidate_with_an_unread_sibling_does_not_move_the_union_backwards() {
     // child0 holds the probe target, so the early return never reaches child1.
     let matching: Mock<'static, 3> = Mock::new([10, 20, 30]);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_heap.rs
@@ -32,7 +32,6 @@ use rqe_iterators_test_utils::ContractChecker;
 /// read must not inherit those: doc 0 sorts ahead of every real id, so the union
 /// would report an id no document has.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn revalidate_before_first_read_leaves_no_stale_heap_entries() {
     // The empty child has nothing to yield but reports not-at-EOF until something
     // reads it, so the rebuild keeps it.
@@ -58,7 +57,6 @@ fn revalidate_before_first_read_leaves_no_stale_heap_entries() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn reuse_results_optimization_quick_mode() {
     let (children, data) = create_mock_2([3], [2]);
     let mut union = ContractChecker::new(UnionQuickHeap::new(children));
@@ -121,7 +119,6 @@ fn reuse_results_optimization_quick_mode() {
 /// `into_trimmed` on a `UnionFullHeap` produces a working `UnionTrimmed` that
 /// yields all children in reverse order when the limit is large enough.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn into_trimmed_full_heap_yields_all_children() {
     let (children, _data) = create_mock_3([1, 2], [3, 4], [5, 6]);
     let union = UnionFullHeap::new(children);
@@ -152,7 +149,6 @@ fn into_children_returns_all_children() {
 
 /// `into_trimmed` on a `UnionQuickHeap` applies trimming correctly.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn into_trimmed_quick_heap_trims_desc() {
     // 3 children with est [2, 2, 2], limit=1.
     // Desc scan from child[1] backward: child[1].est=2 > 1 → skip=1.
@@ -185,7 +181,6 @@ fn into_trimmed_quick_heap_trims_desc() {
 /// The drain is bounded so a regression fails on the assertion below rather than
 /// spinning until the harness kills it.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn revalidate_before_first_read_keeps_every_document_of_non_empty_children() {
     let moved: Mock<'static, 2> = Mock::new([5, 7]);
     let mut moved_data = moved.data();
@@ -230,7 +225,6 @@ fn revalidate_before_first_read_keeps_every_document_of_non_empty_children() {
 /// over from the smaller heap then runs past zero as children exhaust, which
 /// panics in debug and wraps into a nonsense sort weight in release.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn revalidate_before_first_read_keeps_the_active_count_in_step_with_the_heap() {
     // One document, so `Moved` leaves this child on its last one.
     let moved: Mock<'static, 1> = Mock::new([5]);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_reducer.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_reducer.rs
@@ -180,7 +180,6 @@ fn heap_quick_selected() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[cfg_attr(miri, ignore = "Calls FFI function `RSYieldableMetric_Concat`")]
 fn flat_union_produces_all_docs() {
     let children: Vec<Box<dyn RQEIterator>> = vec![
         Box::new(Mock::new([1, 3, 5])),
@@ -200,7 +199,6 @@ fn flat_union_produces_all_docs() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore = "Calls FFI function `RSYieldableMetric_Concat`")]
 fn heap_union_produces_all_docs() {
     let children: Vec<Box<dyn RQEIterator>> = vec![
         Box::new(Mock::new([1, 4, 7])),

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_trimmed.rs
@@ -54,7 +54,6 @@ fn new_panics_on_two_children() {
 
 /// Three children — verifies full reverse-order drain.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn three_children_reverse_order() {
     let (children, _data) = create_mock_3([1], [2], [3]);
     let mut union = ContractChecker::new_unordered(UnionTrimmed::new(children, usize::MAX, true));
@@ -70,7 +69,6 @@ fn three_children_reverse_order() {
 
 /// Four children with multiple docs each — full reverse drain.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn four_children_reverse_order() {
     let children = make_children(&[&[1, 2], &[3, 4], &[5, 6], &[7, 8]]);
     let mut union = ContractChecker::new_unordered(UnionTrimmed::new(children, usize::MAX, true));
@@ -96,7 +94,6 @@ fn skip_to_panics() {
 // =============================================================================
 
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn rewind_restores_full_iteration() {
     let (children, _data) = create_mock_3([1], [2], [3]);
     let mut union = ContractChecker::new_unordered(UnionTrimmed::new(children, usize::MAX, true));
@@ -132,7 +129,6 @@ fn num_estimated_sums_children() {
 
 /// When the last child is empty, it is skipped and the next child is read.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn skips_exhausted_children() {
     let (children, _data) = create_mock_3([10, 20], [], [30]);
     // children[1] is empty, so it is skipped.
@@ -166,7 +162,6 @@ fn accessors_work() {
 /// Scanning from child[1]: child[1]=3, child[2]=3 → total=6 > 5 → keep=3.
 /// All 5 children stay alive, but only the first 3 are read.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn new_asc_basic() {
     let children = make_children(&[
         &[1, 2, 3],
@@ -195,7 +190,6 @@ fn new_asc_keeps_all_when_limit_large() {
 /// Scanning from child[3] backward: child[3]=3, child[2]=3 → total=6 > 5 → skip=2.
 /// Active window is children[2..5], all 5 stay alive.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn new_desc_basic() {
     let children = make_children(&[
         &[1, 2, 3],
@@ -221,7 +215,6 @@ fn new_desc_keeps_all_when_limit_large() {
 
 /// Ascending: verify the kept children are the correct prefix.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn new_asc_keeps_correct_prefix() {
     // Children: A=[1], B=[2,3], C=[4,5,6], D=[7,8,9,10]
     // Scanning from B: B.est=2, C.est=3 → total=5 > limit=4 → keep=3 (A,B,C).
@@ -239,7 +232,6 @@ fn new_asc_keeps_correct_prefix() {
 
 /// Descending: verify the kept children are the correct suffix.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn new_desc_keeps_correct_suffix() {
     // Children: A=[1], B=[2,3], C=[4,5,6], D=[7,8,9,10]
     // Scanning from C backward: C.est=3, B.est=2 → total=5 > limit=4 → skip=1.
@@ -262,7 +254,6 @@ fn new_desc_keeps_correct_suffix() {
 
 /// `current` returns `Some` after a successful read.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn current_some_after_read() {
     let children = make_children(&[&[1], &[2], &[42]]);
     let mut union = ContractChecker::new_unordered(UnionTrimmed::new(children, usize::MAX, true));
@@ -274,7 +265,6 @@ fn current_some_after_read() {
 
 /// `current` returns `None` after all children are exhausted.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn current_none_after_exhaustion() {
     let (children, _data) = create_mock_3([1], [2], [3]);
     let mut union = ContractChecker::new_unordered(UnionTrimmed::new(children, usize::MAX, true));
@@ -334,7 +324,6 @@ fn child_at_accesses_trimmed_children() {
 /// the last doc from a child doesn't move the cursor until the *next*
 /// read discovers EOF on that child.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn num_children_active_shrinks_as_children_exhaust() {
     // 4 children with 2 docs each, asc trim with large limit → active window [0..4).
     let children = make_children(&[&[1, 2], &[3, 4], &[5, 6], &[7, 8]]);
@@ -430,7 +419,6 @@ fn intersection_sort_weight_with_priority() {
 
 /// Weight shrinks as children exhaust during reads.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn intersection_sort_weight_decreases_after_reads() {
     let children = make_children(&[&[1, 2], &[3, 4], &[5, 6]]);
     let mut union = ContractChecker::new_unordered(UnionTrimmed::new(children, usize::MAX, true));
@@ -445,7 +433,6 @@ fn intersection_sort_weight_decreases_after_reads() {
 
 /// At EOF, weight is 1.0.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn intersection_sort_weight_at_eof() {
     let children = make_children(&[&[1], &[2], &[3]]);
     let mut union = ContractChecker::new_unordered(UnionTrimmed::new(children, usize::MAX, true));
@@ -460,7 +447,6 @@ fn intersection_sort_weight_at_eof() {
 /// `into_trimmed` re-trims with new parameters, preserving all children
 /// including those previously trimmed away.
 #[test]
-#[cfg_attr(miri, ignore = "Calls RSYieldableMetric_Concat FFI in push_borrowed")]
 fn into_trimmed_reuses_all_children() {
     // 5 children, each with est=3. Asc trim with limit=5:
     // scan from child[1]: child[1]=3, child[2]=3 → total=6 > 5 → keep=3.


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** 95 tests in `rqe_iterators` are skipped under miri with the reason *"Calls RSYieldableMetric_Concat FFI in push_borrowed"*. `push_borrowed` does not call that symbol and cannot: it moves the drained metrics with `MetricsVec::concat`, which is a `ThinVec::append`; `index_result` contains no `extern "C"` at all; and `RSYieldableMetric_Concat` is itself a Rust-defined `extern "C"` **entrypoint** in `c_entrypoint/metrics_ffi`, whose only non-test caller is `src/iterators/hybrid_reader.c`. That is C calling into Rust, not the reverse. The reason appears to have outlived the port that made it true.
2. **Change:** Removes those 95 attributes. Adds one guard, on `inverted_index::numeric::eof_after_filtering`, for the reason the kept guards give — it is genuinely slow, ~20s of the run by itself. No production code, no test logic. The 14 pre-existing guards with other reasons (slow tests, `should_panic`, `clock_gettime(CLOCK_MONOTONIC_RAW)`) are untouched.
3. **Outcome:** Internal-only; no user-visible change. It restores miri coverage of the code miri is most useful for — aggregate re-derivation, suspend/resume compaction and teardown, borrowed-entry lifetimes — all of which turn on provenance a normal test run cannot observe.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `tests/integration/union_common.rs` (66), `union_trimmed.rs` (14), `union_heap.rs` (6), `union_flat.rs` (4), `profilable.rs` (3), `union_reducer.rs` (2) — attribute removals.
2. `tests/integration/inverted_index/numeric.rs` — one attribute added, for slowness.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

### Measurements

Locally, `cargo +nightly miri test -p rqe_iterators --test integration`:

| | passed | ignored | wall clock |
|---|---|---|---|
| before | 577 | 253 | 199s |
| after | **785** | 45 | 279s |

**0 failures.** The +208 exceeds the 95 attributes because some sat on parameterized (`rstest`) cases that expand to several tests each. Guarding `eof_after_filtering` accounts for the difference between 299s (measured before adding it) and the 279s above.

**The cost is the ~80s**, spread across miri's three CI shards (~27s each). That is the thing to weigh: this file already carries guards reading *"Takes too long with Miri, causing CI to timeout"*, so if the miri job is near its budget, this is the change that pushes it. I have not measured CI wall clock, only local.
