### PR TITLE
build: give cheadergen its own cargo target directory

### DIFF
--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -106,7 +106,12 @@ jobs:
           # `$workspace -> $target`. The `$target` part is treated as a directory
           # relative to the `$workspace` and defaults to "target" if not explicitly given.
           # default: ". -> target"
-          workspaces: "src/redisearch_rs -> ../../bin/redisearch_rs"
+          # `bin/cheadergen` is the separate target directory `regen_headers.sh`
+          # gives the nightly rustdoc run; without it the lint job pays a cold
+          # nightly dependency build on every run.
+          workspaces: |
+            src/redisearch_rs -> ../../bin/redisearch_rs
+            src/redisearch_rs -> ../../bin/cheadergen
       - name: Hakari
         run: cargo install cargo-hakari --locked
       - name: Cargo deny

--- a/src/redisearch_rs/regen_headers.sh
+++ b/src/redisearch_rs/regen_headers.sh
@@ -23,6 +23,16 @@
 # pull in `bindgen` (and therefore libclang/libLLVM/libncursesw/libz) try
 # to link statically and fail because the static versions of those system
 # libraries are not installed in the Alpine CI image.
+#
+# Cargo keeps a single `.rustdoc_fingerprint.json` per target directory and
+# deletes the whole `doc/` tree whenever the rustdoc version recorded there
+# changes.
+# Therefore, pointing `CARGO_TARGET_DIR` cheadergen to own target directory
+# separates the `bin/redisearch_rs` that the rest of the build uses.
+# In this way, `make lint`'s `cargo doc` (pinned stable, HTML) don't evict
+# each other on every run.
+# NB: Compilation artifacts are not the problem — those already coexist,
+# because the rustc version is part of Cargo's unit hash.
 
 set -euo pipefail
 
@@ -67,7 +77,9 @@ RUST_TOOLCHAIN=$(cat "$REPO_ROOT/.rust-nightly")
 # - All crates that use explicit `#[cheadergen::config(export, ..)] annotations
 #   to export types that aren't otherwise reachable from the FFI functions
 #   we expose.
-exec env -u CARGO_BUILD_TARGET RUSTFLAGS="${rustflags}" cheadergen generate \
+exec env -u CARGO_BUILD_TARGET RUSTFLAGS="${rustflags}" \
+    CARGO_TARGET_DIR="$REPO_ROOT/bin/cheadergen" \
+    cheadergen generate \
     --lang c \
     --rust-toolchain="${RUST_TOOLCHAIN}" \
     --prune-orphans \


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `regen_headers.sh` runs the pinned nightly rustdoc in `bin/redisearch_rs`, the same Cargo target directory `make lint`'s pinned-stable `cargo doc` uses. Cargo keeps one `.rustdoc_fingerprint.json` per target directory and deletes the whole `doc/` tree whenever the rustdoc version recorded there changes, so the two evict each other — and because `lint` depends on `generate-rust-headers`, it happens twice on every `make lint`.
2. Change: point the nightly run at `bin/cheadergen` instead, and add that directory to the lint job's `rust-cache` entries.
3. Outcome: internal-only, no user-visible change. Back-to-back `make lint` on an otherwise warm tree drops from 1m49s to 5.8s — 95 crates re-documented every run, now zero (measured locally on macOS/aarch64 by A/B-ing the one-line change on the same tree). That makes the lint loop cheap enough to run before pushing rather than waiting on CI for it.

#### Which additional issues this PR fixes

<!-- Ticket and issue links only. Write "N/A" if there are none. -->

1. MOD-...
2. #...

#### Main objects this PR modified

1. `src/redisearch_rs/regen_headers.sh` — the cheadergen invocation now sets `CARGO_TARGET_DIR`. The reasoning sits in the existing env-scrub comment block, next to the `RUSTFLAGS` and `CARGO_BUILD_TARGET` scrubs it already documents. 
2. Lint CI job — `rust-cache` gains the second target directory, so CI does not trade the local win for a cold nightly dependency build on every run.
3. Worth knowing while reviewing: compilation artifacts were never the problem. The rustc version is part of Cargo's unit hash, so stable and nightly rlibs already coexist in one target directory. `doc/` was the only shared state, which is why isolating it is enough.

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
