### PR TITLE
[MOD-14988] tag_index: in memory indexing

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3040,6 +3040,7 @@ version = "0.0.1"
 dependencies = [
  "build_utils",
  "ffi",
+ "index_result",
  "inverted_index",
  "redis_mock",
  "redisearch_rs",

--- a/src/redisearch_rs/tag_index/Cargo.toml
+++ b/src/redisearch_rs/tag_index/Cargo.toml
@@ -18,6 +18,7 @@ build_utils.workspace = true
 
 [dependencies]
 ffi.workspace = true
+index_result.workspace = true
 inverted_index.workspace = true
 thin_vec.workspace = true
 trie_rs.workspace = true

--- a/src/redisearch_rs/tag_index/Cargo.toml
+++ b/src/redisearch_rs/tag_index/Cargo.toml
@@ -6,6 +6,8 @@ license-file.workspace = true
 publish.workspace = true
 
 [features]
+# Exposes test-only accessors on `TagIndex` for use by integration tests.
+test-utils = []
 # Enabled when building tests so `build.rs` links the C code (`libredisearch_c_bundle`).
 # See https://github.com/rust-lang/cargo/issues/4789#issuecomment-2308131243
 unittest = []
@@ -25,7 +27,7 @@ trie_rs.workspace = true
 workspace_hack.workspace = true
 
 [dev-dependencies]
-tag_index = { path = ".", features = ["unittest"] }
+tag_index = { path = ".", features = ["unittest", "test-utils"] }
 redis_mock.workspace = true
 
 # Crate required to invoke C symbols: its `#[used]` symbol table keeps the Rust FFI

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -255,10 +255,10 @@ fn write_postings(
 ) -> WritePostingsDelta {
     let mut delta = WritePostingsDelta::default();
 
-    let mut record = RSIndexResult::build_virt().doc_id(doc_id).build();
-    // The builder always clears this, so set it explicitly: `add_record` reads it
-    // off the record to write the posting's expiration bit.
-    record.has_field_expiration = has_field_expiration;
+    let record = RSIndexResult::build_virt()
+        .doc_id(doc_id)
+        .has_field_expiration(has_field_expiration)
+        .build();
     for tag in tags {
         values.insert_with(tag.as_bytes(), |slot| {
             let mut ii = slot.unwrap_or_else(|| {

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -239,9 +239,7 @@ pub struct WritePostingsDelta {
     /// Bytes by which the inverted-index memory grew.
     pub size_delta: usize,
     /// Number of new (tag, doc) postings written by the in-memory path — see
-    /// [`index`](TagIndex::index) for exactly what counts as "new". A future
-    /// on-disk `commit()` will count differently and should not assume this
-    /// field's dedup guarantee.
+    /// [`index`](TagIndex::index) for exactly what counts as "new".
     pub num_records: u32,
     /// Number of inverted-index blocks allocated.
     pub blocks_added: u32,
@@ -307,8 +305,7 @@ impl<M: TagIndexMode> TagIndex<M> {
         self.suffix.is_some()
     }
 
-    /// Register `tags` in the [suffix index](TagSuffixIndex), when enabled: the part
-    /// of `commit` that does not depend on where the postings live.
+    /// Register `tags` in the [suffix index](TagSuffixIndex), when enabled.
     fn add_tags_to_suffix(&mut self, tags: &[Tag<'_>]) {
         let Some(suffix) = &mut self.suffix else {
             return;
@@ -365,17 +362,14 @@ impl TagIndex<InMemoryMode> {
     /// write: register the tags in the [suffix index](TagSuffixIndex), when enabled.
     ///
     /// Returns the number of records to fold into the spec statistics, always `0`:
-    /// the postings were written, and counted, by [`index`](Self::index). Disk mode
-    /// counts them here instead.
+    /// the postings were written, and counted, by [`index`](Self::index).
     pub fn commit(&mut self, tags: &[Tag<'_>]) -> u32 {
         self.add_tags_to_suffix(tags);
         0
     }
 }
 
-// Handles tests reach the index internals through, kept apart from the production
-// methods above and gated behind the `test-utils` feature so they stay out of the
-// public API in release builds.
+// More methods to access internals for test purposes.
 #[cfg(feature = "test-utils")]
 impl TagIndex<InMemoryMode> {
     /// Get the inverted index holding the postings for `tag`, if the tag is
@@ -384,34 +378,13 @@ impl TagIndex<InMemoryMode> {
         self.mode.values.find(tag).map(Box::as_ref)
     }
 
-    /// Get a mutable reference to the inverted index holding the postings for
-    /// `tag`, if the tag is currently indexed.
-    pub fn find_value_mut(&mut self, tag: &[u8]) -> Option<&mut InvertedIndex<DocIdsOnly>> {
-        self.mode.values.find_mut(tag).map(Box::as_mut)
-    }
-
-    /// Get the inverted index for `tag`, registering a new empty one when the
-    /// tag is not indexed yet and `create_if_missing` is set.
-    pub fn open_index(
-        &mut self,
-        tag: &[u8],
-        create_if_missing: bool,
-    ) -> Option<&InvertedIndex<DocIdsOnly>> {
-        let values = &mut self.mode.values;
-
-        if values.find(tag).is_none() {
-            if !create_if_missing {
-                return None;
-            }
-            values.insert(
-                tag,
-                Box::new(InvertedIndex::<DocIdsOnly>::new(
-                    IndexFlags_Index_DocIdsOnly,
-                )),
-            );
-        }
-
-        values.find(tag).map(Box::as_ref)
+    /// Whether `key` is registered in the [suffix index](TagSuffixIndex) — as a
+    /// full tag term or as a suffix of one. `false` when suffix indexing is
+    /// disabled.
+    pub fn suffix_contains(&self, key: &[u8]) -> bool {
+        self.suffix
+            .as_ref()
+            .is_some_and(|suffix| suffix.find(key).is_some())
     }
 }
 

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -141,8 +141,9 @@ redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
 use std::ptr::NonNull;
 
-use ffi::{RedisSearchDiskIndexSpec, t_fieldIndex};
-use inverted_index::{InvertedIndex, doc_ids_only::DocIdsOnly};
+use ffi::{IndexFlags_Index_DocIdsOnly, RedisSearchDiskIndexSpec, t_fieldIndex};
+use index_result::RSIndexResult;
+use inverted_index::{DocId, InvertedIndex, doc_ids_only::DocIdsOnly};
 use suffix::TagSuffixIndex;
 use trie_rs::TrieMap;
 pub use unique_id::TagUniqueId;
@@ -231,6 +232,61 @@ pub struct TagIndex<M: TagIndexMode> {
     mode: M,
 }
 
+/// Deltas produced by writing a document's tag postings, to fold into the
+/// spec statistics.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct WritePostingsDelta {
+    /// Bytes by which the inverted-index memory grew.
+    pub size_delta: usize,
+    /// Number of new (tag, doc) postings written by the in-memory path — see
+    /// [`index`](TagIndex::index) for exactly what counts as "new". A future
+    /// on-disk `commit()` will count differently and should not assume this
+    /// field's dedup guarantee.
+    pub num_records: u32,
+    /// Number of inverted-index blocks allocated.
+    pub blocks_added: u32,
+}
+
+fn write_postings(
+    values: &mut TrieMap<Box<InvertedIndex<DocIdsOnly>>>,
+    tags: &[Tag<'_>],
+    doc_id: DocId,
+    has_field_expiration: bool,
+) -> WritePostingsDelta {
+    let mut delta = WritePostingsDelta::default();
+
+    let mut record = RSIndexResult::build_virt().doc_id(doc_id).build();
+    // The builder always clears this, so set it explicitly: `add_record` reads it
+    // off the record to write the posting's expiration bit.
+    record.has_field_expiration = has_field_expiration;
+    for tag in tags {
+        values.insert_with(tag.as_bytes(), |slot| {
+            let mut ii = slot.unwrap_or_else(|| {
+                let ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+
+                delta.size_delta += ii.memory_usage();
+
+                Box::new(ii)
+            });
+
+            let docs_before = ii.unique_docs();
+            let outcome = ii.add_record(&record).unwrap();
+            // Count a record only when a new unique document was appended; a
+            // duplicate doc id (e.g. a tag repeated in a multi-value field) is
+            // skipped by `add_record` and must not be counted.
+            if ii.unique_docs() > docs_before {
+                delta.num_records += 1;
+            }
+            delta.blocks_added += outcome.blocks_added;
+            delta.size_delta += outcome.mem_growth as usize;
+
+            ii
+        });
+    }
+
+    delta
+}
+
 impl<M: TagIndexMode> TagIndex<M> {
     /// The part of construction every mode's constructor shares.
     fn with_mode(with_suffix: bool, mode: M) -> Self {
@@ -250,6 +306,17 @@ impl<M: TagIndexMode> TagIndex<M> {
     pub const fn has_suffix(&self) -> bool {
         self.suffix.is_some()
     }
+
+    /// Register `tags` in the [suffix index](TagSuffixIndex), when enabled: the part
+    /// of `commit` that does not depend on where the postings live.
+    fn add_tags_to_suffix(&mut self, tags: &[Tag<'_>]) {
+        let Some(suffix) = &mut self.suffix else {
+            return;
+        };
+        for tag in tags {
+            suffix.add(*tag);
+        }
+    }
 }
 
 impl TagIndex<InMemoryMode> {
@@ -265,6 +332,86 @@ impl TagIndex<InMemoryMode> {
                 values: TrieMap::new(),
             },
         )
+    }
+
+    /// How many distinct tags the index holds.
+    pub const fn n_tags(&self) -> usize {
+        self.mode.values.n_unique_keys()
+    }
+
+    /// Index `doc_id` under each tag in `tags`, writing the postings inline into
+    /// the per-tag inverted index.
+    ///
+    /// Returns the [`WritePostingsDelta`] the caller folds into the spec
+    /// statistics (records, memory, blocks). This always succeeds.
+    /// `num_records` counts a (tag, doc) posting as new only when it makes the tag's
+    /// posting list grow by a document, so a value repeated within this document's
+    /// own multi-value tags is counted once.
+    ///
+    /// `has_field_expiration` records whether this document carries a TTL on the
+    /// field being indexed. It is stored per posting as
+    /// [`RSIndexResult::has_field_expiration`] and gates the TTL re-check
+    /// performed on read.
+    pub fn index(
+        &mut self,
+        tags: &[Tag<'_>],
+        doc_id: DocId,
+        has_field_expiration: bool,
+    ) -> WritePostingsDelta {
+        write_postings(&mut self.mode.values, tags, doc_id, has_field_expiration)
+    }
+
+    /// Apply the per-tag metadata updates after the indexing phase of a document
+    /// write: register the tags in the [suffix index](TagSuffixIndex), when enabled.
+    ///
+    /// Returns the number of records to fold into the spec statistics, always `0`:
+    /// the postings were written, and counted, by [`index`](Self::index). Disk mode
+    /// counts them here instead.
+    pub fn commit(&mut self, tags: &[Tag<'_>]) -> u32 {
+        self.add_tags_to_suffix(tags);
+        0
+    }
+}
+
+// Handles tests reach the index internals through, kept apart from the production
+// methods above and gated behind the `test-utils` feature so they stay out of the
+// public API in release builds.
+#[cfg(feature = "test-utils")]
+impl TagIndex<InMemoryMode> {
+    /// Get the inverted index holding the postings for `tag`, if the tag is
+    /// currently indexed.
+    pub fn find_value(&self, tag: &[u8]) -> Option<&InvertedIndex<DocIdsOnly>> {
+        self.mode.values.find(tag).map(Box::as_ref)
+    }
+
+    /// Get a mutable reference to the inverted index holding the postings for
+    /// `tag`, if the tag is currently indexed.
+    pub fn find_value_mut(&mut self, tag: &[u8]) -> Option<&mut InvertedIndex<DocIdsOnly>> {
+        self.mode.values.find_mut(tag).map(Box::as_mut)
+    }
+
+    /// Get the inverted index for `tag`, registering a new empty one when the
+    /// tag is not indexed yet and `create_if_missing` is set.
+    pub fn open_index(
+        &mut self,
+        tag: &[u8],
+        create_if_missing: bool,
+    ) -> Option<&InvertedIndex<DocIdsOnly>> {
+        let values = &mut self.mode.values;
+
+        if values.find(tag).is_none() {
+            if !create_if_missing {
+                return None;
+            }
+            values.insert(
+                tag,
+                Box::new(InvertedIndex::<DocIdsOnly>::new(
+                    IndexFlags_Index_DocIdsOnly,
+                )),
+            );
+        }
+
+        values.find(tag).map(Box::as_ref)
     }
 }
 

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -245,54 +245,6 @@ pub struct WritePostingsDelta {
     pub blocks_added: u32,
 }
 
-fn write_postings(
-    values: &mut TrieMap<Box<InvertedIndex<DocIdsOnly>>>,
-    tags: &[Tag<'_>],
-    doc_id: DocId,
-    has_field_expiration: bool,
-) -> WritePostingsDelta {
-    let mut delta = WritePostingsDelta::default();
-
-    let record = RSIndexResult::build_virt()
-        .doc_id(doc_id)
-        .has_field_expiration(has_field_expiration)
-        .build();
-    for tag in tags {
-        values.insert_with(tag.as_bytes(), |slot| {
-            let mut ii = slot.unwrap_or_else(|| {
-                let ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
-
-                delta.size_delta += ii.memory_usage();
-
-                Box::new(ii)
-            });
-
-            debug_assert!(
-                ii.last_doc_id().is_none_or(|last| last <= doc_id),
-                "TagIndex::index called with a doc_id smaller than one already indexed for \
-                 this tag; see its `Safety` docs for the ordering it requires"
-            );
-
-            let docs_before = ii.unique_docs();
-            let outcome = ii
-                .add_record(&record)
-                .expect("in-memory tag inverted index write cannot fail");
-            // Count a record only when a new unique document was appended; a
-            // duplicate doc id (e.g. a tag repeated in a multi-value field) is
-            // skipped by `add_record` and must not be counted.
-            if ii.unique_docs() > docs_before {
-                delta.num_records += 1;
-            }
-            delta.blocks_added += outcome.blocks_added;
-            delta.size_delta += outcome.mem_growth as usize;
-
-            ii
-        });
-    }
-
-    delta
-}
-
 impl<M: TagIndexMode> TagIndex<M> {
     /// The part of construction every mode's constructor shares.
     fn with_mode(with_suffix: bool, mode: M) -> Self {
@@ -345,7 +297,9 @@ impl TagIndex<InMemoryMode> {
     }
 
     /// Index `doc_id` under each tag in `tags`, writing the postings inline into
-    /// the per-tag inverted index.
+    /// the per-tag inverted index. The caller must follow up with
+    /// [`commit`](Self::commit) on the same `tags` to complete the document
+    /// write (it registers them in the suffix index, when enabled).
     ///
     /// Returns the [`WritePostingsDelta`] the caller folds into the spec
     /// statistics (records, memory, blocks).
@@ -358,17 +312,52 @@ impl TagIndex<InMemoryMode> {
     /// [`RSIndexResult::has_field_expiration`] and gates the TTL re-check
     /// performed on read.
     ///
-    /// # Safety
-    ///
-    /// `doc_id` must be greater than or equal to every `doc_id` already passed to `index` for
-    /// this [`TagIndex`].
-    pub unsafe fn index(
+    /// `doc_id` should be greater than or equal to every `doc_id` already passed to `index` for
+    /// this [`TagIndex`]. See [`InvertedIndex::add_record`] for more information.
+    pub fn index(
         &mut self,
         tags: &[Tag<'_>],
         doc_id: DocId,
         has_field_expiration: bool,
     ) -> WritePostingsDelta {
-        write_postings(&mut self.mode.values, tags, doc_id, has_field_expiration)
+        let mut delta = WritePostingsDelta::default();
+
+        let record = RSIndexResult::build_virt()
+            .doc_id(doc_id)
+            .has_field_expiration(has_field_expiration)
+            .build();
+        for tag in tags {
+            self.mode.values.insert_with(tag.as_bytes(), |slot| {
+                let mut ii = slot.unwrap_or_else(|| {
+                    let ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
+                    delta.size_delta += ii.memory_usage();
+                    Box::new(ii)
+                });
+
+                debug_assert!(
+                    ii.last_doc_id().is_none_or(|last| last <= doc_id),
+                    "TagIndex::index called with a doc_id smaller than one already indexed for \
+                    this tag; see its docs for the ordering it requires"
+                );
+
+                let docs_before = ii.unique_docs();
+                let outcome = ii
+                    .add_record(&record)
+                    .expect("in-memory tag inverted index write cannot fail");
+                // Count a record only when a new unique document was appended; a
+                // duplicate doc id (e.g. a tag repeated in a multi-value field) is
+                // skipped by `add_record` and must not be counted.
+                if ii.unique_docs() > docs_before {
+                    delta.num_records += 1;
+                }
+                delta.blocks_added += outcome.blocks_added;
+                delta.size_delta += outcome.mem_growth as usize;
+
+                ii
+            });
+        }
+
+        delta
     }
 
     /// Apply the per-tag metadata updates after the indexing phase of a document

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -267,6 +267,12 @@ fn write_postings(
                 Box::new(ii)
             });
 
+            debug_assert!(
+                ii.last_doc_id().is_none_or(|last| last <= doc_id),
+                "TagIndex::index called with a doc_id smaller than one already indexed for \
+                 this tag; see its `Safety` docs for the ordering it requires"
+            );
+
             let docs_before = ii.unique_docs();
             let outcome = ii.add_record(&record).unwrap();
             // Count a record only when a new unique document was appended; a
@@ -349,7 +355,12 @@ impl TagIndex<InMemoryMode> {
     /// field being indexed. It is stored per posting as
     /// [`RSIndexResult::has_field_expiration`] and gates the TTL re-check
     /// performed on read.
-    pub fn index(
+    ///
+    /// # Safety
+    ///
+    /// `doc_id` must be greater than or equal to every `doc_id` already passed to `index` for
+    /// this [`TagIndex`].
+    pub unsafe fn index(
         &mut self,
         tags: &[Tag<'_>],
         doc_id: DocId,

--- a/src/redisearch_rs/tag_index/src/lib.rs
+++ b/src/redisearch_rs/tag_index/src/lib.rs
@@ -274,7 +274,9 @@ fn write_postings(
             );
 
             let docs_before = ii.unique_docs();
-            let outcome = ii.add_record(&record).unwrap();
+            let outcome = ii
+                .add_record(&record)
+                .expect("in-memory tag inverted index write cannot fail");
             // Count a record only when a new unique document was appended; a
             // duplicate doc id (e.g. a tag repeated in a multi-value field) is
             // skipped by `add_record` and must not be counted.
@@ -346,7 +348,7 @@ impl TagIndex<InMemoryMode> {
     /// the per-tag inverted index.
     ///
     /// Returns the [`WritePostingsDelta`] the caller folds into the spec
-    /// statistics (records, memory, blocks). This always succeeds.
+    /// statistics (records, memory, blocks).
     /// `num_records` counts a (tag, doc) posting as new only when it makes the tag's
     /// posting list grow by a document, so a value repeated within this document's
     /// own multi-value tags is counted once.

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -95,6 +95,11 @@ impl OwnedTerm {
             .to_bytes_with_nul()
             .len()
     }
+
+    /// Build [`TermPtr`] from the current [`OwnedTerm`]
+    const fn borrowed(&self) -> TermPtr {
+        TermPtr(self.0)
+    }
 }
 
 impl Drop for OwnedTerm {
@@ -111,16 +116,29 @@ impl Drop for OwnedTerm {
 ///
 /// The pointee is owned by the [`OwnedTerm`] of the member's own trie entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct TermPtr(NonNull<u8>);
+pub(crate) struct TermPtr(NonNull<u8>);
 
 /// Payload of one trie entry.
 #[derive(Debug, Default)]
-struct SuffixData {
+pub(crate) struct SuffixData {
     /// `Some` iff this entry's key is itself a member: the owning handle of
     /// that member's tag term allocation.
     full_term: Option<OwnedTerm>,
     /// Every member this entry's key is a suffix of.
-    refs: ThinVec<TermPtr, AlignedU32>,
+    pub(crate) refs: ThinVec<TermPtr, AlignedU32>,
+}
+
+impl SuffixData {
+    /// Every member term this entry's key belongs to: the term itself when the
+    /// key is a full term (stored separately in [`Self::full_term`]) followed by
+    /// every term the key is a *proper* suffix of ([`Self::refs`]).
+    pub fn members(&self) -> impl Iterator<Item = TermPtr> + '_ {
+        self.full_term
+            .as_ref()
+            .map(OwnedTerm::borrowed)
+            .into_iter()
+            .chain(self.refs.iter().copied())
+    }
 }
 
 #[derive(Debug, Default)]
@@ -136,6 +154,58 @@ impl TagSuffixIndex {
             entries: TrieMap::new(),
         }
     }
+
+    /// Index `term` and every one of its suffixes.
+    ///
+    /// `term` is the tag value. The empty tag (`INDEXEMPTY`) is never indexed: it
+    /// has no suffixes to look up.
+    pub fn add(&mut self, term: Tag<'_>) {
+        let bytes = term.as_bytes();
+        if bytes.is_empty() {
+            return;
+        }
+
+        // Don't store duplicates
+        if self
+            .entries
+            .find(bytes)
+            .is_some_and(|data| data.full_term.is_some())
+        {
+            return;
+        }
+
+        let owned = OwnedTerm::new(term);
+        let ptr = owned.borrowed();
+
+        // Store the OwnedTerm into the full tag term
+        self.entries.insert_with(bytes, |slot| {
+            let mut data = slot.unwrap_or_else(|| SuffixData {
+                full_term: None,
+                refs: ThinVec::with_capacity(2),
+            });
+            // Keep "alive" the owned term
+            data.full_term = Some(owned);
+
+            data
+        });
+
+        // Process the suffixes as TermPtr
+        for start in 1..bytes.len() {
+            self.entries.insert_with(&bytes[start..], |slot| {
+                let mut data = slot.unwrap_or_else(|| SuffixData {
+                    full_term: None,
+                    refs: ThinVec::with_capacity(2),
+                });
+                data.refs.push(ptr);
+                data
+            });
+        }
+    }
+
+    /// The entry keyed by exactly `key`, if any.
+    pub fn find(&self, key: &[u8]) -> Option<&SuffixData> {
+        self.entries.find(key)
+    }
 }
 
 #[cfg(test)]
@@ -146,6 +216,11 @@ mod tests {
     /// passes into a [`Tag`].
     fn owned_term(term: &[u8]) -> OwnedTerm {
         OwnedTerm::new(Tag::new(term).expect("test literal is NUL-free"))
+    }
+
+    /// [`TagSuffixIndex::add`], with the same wrapping.
+    fn add(idx: &mut TagSuffixIndex, term: &[u8]) {
+        idx.add(Tag::new(term).expect("test literal is NUL-free"))
     }
 
     /// Read back the bytes stored in an [`OwnedTerm`], terminator included.
@@ -189,5 +264,63 @@ mod tests {
         let term = owned_term(term_bytes.as_bytes());
 
         assert_ne!(term_bytes.as_ptr(), term.0.as_ptr().cast());
+    }
+
+    /// `add` keys the trie on the tag and each of its suffixes, all NUL-free: the
+    /// terminator it stores is part of the value, never of a key, and no stray
+    /// empty entry is created.
+    #[test]
+    fn add_stores_nul_free_keys_without_empty_entry() {
+        let mut idx = TagSuffixIndex::new();
+        add(&mut idx, b"foo");
+
+        assert!(idx.find(b"foo").is_some());
+        assert!(idx.find(b"oo").is_some());
+        assert!(idx.find(b"o").is_some());
+        // The stored terminator is not part of any key, and the empty suffix is
+        // not an entry.
+        assert!(idx.find(b"foo\0").is_none());
+        assert!(idx.find(b"").is_none());
+        assert!(idx.find(b"\0").is_none());
+    }
+
+    /// The empty tag (INDEXEMPTY) is never registered in the suffix trie, not even
+    /// as an empty key.
+    #[test]
+    fn add_ignores_the_empty_tag() {
+        let mut idx = TagSuffixIndex::new();
+        add(&mut idx, b"");
+
+        assert!(idx.find(b"").is_none());
+        assert!(idx.find(b"\0").is_none());
+    }
+
+    /// Re-adding a term already in the trie must be ignored. The second insert
+    /// would otherwise overwrite the entry's [`OwnedTerm`], freeing the
+    /// allocation that every suffix entry's [`TermPtr`] still points at.
+    /// [`TagIndex::commit`](crate::TagIndex::commit) runs once per document, so
+    /// any tag value shared by two documents takes this path.
+    #[test]
+    fn add_of_an_already_indexed_term_is_ignored() {
+        let mut idx = TagSuffixIndex::new();
+        add(&mut idx, b"cat");
+        add(&mut idx, b"cat");
+
+        let term = idx.find(b"cat").expect("`cat` is indexed");
+        assert_eq!(term.members().count(), 1, "one owned term, not two");
+
+        for suffix in [b"at".as_slice(), b"t"] {
+            let data = idx.find(suffix).expect("suffix is indexed");
+            assert_eq!(
+                data.members().count(),
+                1,
+                "`{}` must not gain a second reference to the same term",
+                String::from_utf8_lossy(suffix)
+            );
+            assert!(
+                data.members().eq(term.members()),
+                "the surviving reference must point at the live term allocation"
+            );
+        }
     }
 }

--- a/src/redisearch_rs/tag_index/src/suffix.rs
+++ b/src/redisearch_rs/tag_index/src/suffix.rs
@@ -125,7 +125,7 @@ pub(crate) struct SuffixData {
     /// that member's tag term allocation.
     full_term: Option<OwnedTerm>,
     /// Every member this entry's key is a suffix of.
-    pub(crate) refs: ThinVec<TermPtr, AlignedU32>,
+    refs: ThinVec<TermPtr, AlignedU32>,
 }
 
 impl SuffixData {

--- a/src/redisearch_rs/tag_index/tests/integration/create.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/create.rs
@@ -7,7 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Tests for the `TagIndex` constructors.
+//! Tests for the `TagIndex` constructors and for `TagIndex::open_index`, the
+//! path creating per-tag posting lists.
 //!
 //! Ids come from a counter global to the process, whose starting point these
 //! tests can't pin down, so they assert that ids *differ*, never what they are.
@@ -52,6 +53,43 @@ fn suffix_support_follows_the_creation_flag() {
 fn new_in_memory_means_memory_mode() {
     // Type checked
     let _: TagIndex<InMemoryMode> = TagIndex::<InMemoryMode>::new(false);
+}
+
+/// A newly created index holds no tags: lookups miss, iteration yields
+/// nothing, and a read-only open does not create the posting list.
+#[test]
+fn new_index_holds_no_tags() {
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+
+    assert!(tag_index.find_value(b"missing").is_none());
+
+    assert!(tag_index.open_index(b"missing", false).is_none());
+    // The read-only open must not have registered the tag on the way.
+    assert!(tag_index.find_value(b"missing").is_none());
+}
+
+/// `open_index` with `create_if_missing` registers an empty posting list on
+/// the first call, and later calls return that same posting list instead of
+/// replacing it.
+#[test]
+fn open_index_creates_the_posting_list_once() {
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+
+    let created: *const _ = tag_index
+        .open_index(b"team", true)
+        .expect("first open creates the posting list");
+
+    let found = tag_index.find_value(b"team").expect("tag is registered");
+    assert_eq!(found.unique_docs(), 0, "the posting list starts empty");
+    assert!(std::ptr::eq(created, found));
+
+    let reopened: *const _ = tag_index
+        .open_index(b"team", true)
+        .expect("tag is registered");
+    assert!(
+        std::ptr::eq(created, reopened),
+        "an existing posting list must be returned, not replaced"
+    );
 }
 
 #[test]

--- a/src/redisearch_rs/tag_index/tests/integration/create.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/create.rs
@@ -7,8 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Tests for the `TagIndex` constructors and for `TagIndex::open_index`, the
-//! path creating per-tag posting lists.
+//! Tests for the `TagIndex` constructors.
 //!
 //! Ids come from a counter global to the process, whose starting point these
 //! tests can't pin down, so they assert that ids *differ*, never what they are.
@@ -55,41 +54,12 @@ fn new_in_memory_means_memory_mode() {
     let _: TagIndex<InMemoryMode> = TagIndex::<InMemoryMode>::new(false);
 }
 
-/// A newly created index holds no tags: lookups miss, iteration yields
-/// nothing, and a read-only open does not create the posting list.
+/// A newly created index holds no tags: lookups miss.
 #[test]
 fn new_index_holds_no_tags() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let tag_index = TagIndex::<InMemoryMode>::new(false);
 
     assert!(tag_index.find_value(b"missing").is_none());
-
-    assert!(tag_index.open_index(b"missing", false).is_none());
-    // The read-only open must not have registered the tag on the way.
-    assert!(tag_index.find_value(b"missing").is_none());
-}
-
-/// `open_index` with `create_if_missing` registers an empty posting list on
-/// the first call, and later calls return that same posting list instead of
-/// replacing it.
-#[test]
-fn open_index_creates_the_posting_list_once() {
-    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
-
-    let created: *const _ = tag_index
-        .open_index(b"team", true)
-        .expect("first open creates the posting list");
-
-    let found = tag_index.find_value(b"team").expect("tag is registered");
-    assert_eq!(found.unique_docs(), 0, "the posting list starts empty");
-    assert!(std::ptr::eq(created, found));
-
-    let reopened: *const _ = tag_index
-        .open_index(b"team", true)
-        .expect("tag is registered");
-    assert!(
-        std::ptr::eq(created, reopened),
-        "an existing posting list must be returned, not replaced"
-    );
 }
 
 #[test]

--- a/src/redisearch_rs/tag_index/tests/integration/indexing.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/indexing.rs
@@ -73,8 +73,7 @@ fn field_expiration_flag_round_trips() {
 
     // Doc 1 has no TTL on this field; doc 2 does.
     for (doc_id, has_field_expiration) in [(1, false), (2, true)] {
-        // SAFETY: `doc_id` is non-decreasing across loop iterations.
-        unsafe { tag_index.index(tags, doc_id, has_field_expiration) };
+        tag_index.index(tags, doc_id, has_field_expiration);
     }
 
     let ii = tag_index.find_value(b"team").expect("tag was indexed");

--- a/src/redisearch_rs/tag_index/tests/integration/indexing.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/indexing.rs
@@ -11,7 +11,7 @@
 
 use index_result::RSIndexResult;
 use inverted_index::IndexReader;
-use tag_index::{InMemoryMode, TagIndex, Tag};
+use tag_index::{InMemoryMode, Tag, TagIndex};
 
 use crate::util::{commit_mem, index_mem};
 
@@ -27,6 +27,43 @@ fn indexing_registers_every_tag() {
     for tag in tags {
         assert!(tag_index.find_value(tag).is_some());
     }
+}
+
+/// `commit` forwards tags to the suffix index when suffix indexing is
+/// enabled: every tag and every one of its suffixes becomes a lookup key,
+/// including when a tag is itself a suffix of another indexed tag (`"oo"` is
+/// a suffix of `"foo"` and also indexed as a tag on its own).
+#[test]
+fn commit_registers_tags_in_the_suffix_index_when_enabled() {
+    let mut tag_index = TagIndex::<InMemoryMode>::new(true);
+    let tags: &[&[u8]] = &[b"foo", b"oo"];
+
+    index_mem(&mut tag_index, tags, 1);
+    commit_mem(&mut tag_index, tags);
+
+    for key in [b"foo".as_slice(), b"oo", b"o"] {
+        assert!(
+            tag_index.suffix_contains(key),
+            "`{}` must be registered in the suffix index",
+            String::from_utf8_lossy(key)
+        );
+    }
+    assert!(
+        !tag_index.suffix_contains(b"bar"),
+        "an unrelated key must not be registered"
+    );
+}
+
+/// With suffix indexing disabled, `commit` is a no-op on the suffix index.
+#[test]
+fn commit_does_not_touch_the_suffix_index_when_disabled() {
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let tags: &[&[u8]] = &[b"foo"];
+
+    index_mem(&mut tag_index, tags, 1);
+    commit_mem(&mut tag_index, tags);
+
+    assert!(!tag_index.suffix_contains(b"foo"));
 }
 
 #[test]
@@ -115,9 +152,6 @@ fn intra_document_duplicate_tag_counted_once() {
 /// inverted indexes report, and blocks accumulate (one per tag on the first
 /// write). Asserted against the reported memory rather than absolute byte
 /// constants, which would pin the `InvertedIndex<DocIdsOnly>` layout.
-// Ignored under Miri: the block accounting is only interesting past
-// `DocIdsOnly::RECOMMENDED_BLOCK_ENTRIES`, and interpreting that many writes
-// exceeds `nextest`'s slow-test budget.
 #[test]
 #[cfg_attr(miri, ignore)]
 fn size_and_block_accounting_matches_reported_memory() {

--- a/src/redisearch_rs/tag_index/tests/integration/indexing.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/indexing.rs
@@ -73,7 +73,8 @@ fn field_expiration_flag_round_trips() {
 
     // Doc 1 has no TTL on this field; doc 2 does.
     for (doc_id, has_field_expiration) in [(1, false), (2, true)] {
-        tag_index.index(tags, doc_id, has_field_expiration);
+        // SAFETY: `doc_id` is non-decreasing across loop iterations.
+        unsafe { tag_index.index(tags, doc_id, has_field_expiration) };
     }
 
     let ii = tag_index.find_value(b"team").expect("tag was indexed");

--- a/src/redisearch_rs/tag_index/tests/integration/indexing.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/indexing.rs
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Tests for indexing documents under tags (`TagIndex::index`).
+
+use index_result::RSIndexResult;
+use inverted_index::IndexReader;
+use tag_index::{InMemoryMode, TagIndex, Tag};
+
+use crate::util::{commit_mem, index_mem};
+
+/// Indexing a document registers each of its tags.
+#[test]
+fn indexing_registers_every_tag() {
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+
+    let tags: &[&[u8]] = &[b"tag-1", b"tag-2"];
+
+    index_mem(&mut tag_index, tags, 1);
+
+    for tag in tags {
+        assert!(tag_index.find_value(tag).is_some());
+    }
+}
+
+#[test]
+fn field_expiration_flag_round_trips() {
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let tags = &[Tag::new(b"team").unwrap()];
+
+    // Doc 1 has no TTL on this field; doc 2 does.
+    for (doc_id, has_field_expiration) in [(1, false), (2, true)] {
+        tag_index.index(tags, doc_id, has_field_expiration);
+    }
+
+    let ii = tag_index.find_value(b"team").expect("tag was indexed");
+    let mut reader = ii.reader();
+    let mut record = RSIndexResult::build_virt().doc_id(0).build();
+
+    let mut seen = Vec::new();
+    while reader
+        .next_record(&mut record)
+        .expect("read must not error")
+    {
+        seen.push((record.doc_id, record.has_field_expiration));
+    }
+
+    assert_eq!(seen, [(1, false), (2, true)]);
+}
+
+/// Re-indexing the same document under the same tags is a no-op: the second
+/// write adds no records, allocates no blocks and grows the index by zero
+/// bytes.
+#[test]
+fn reindexing_the_same_document_is_a_no_op() {
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let tags: &[&[u8]] = &[b"hello", b"world", b"foo"];
+
+    let first = index_mem(&mut tag_index, tags, 1);
+    assert!(first.size_delta > 0, "the first insert allocates postings");
+    assert_eq!(first.num_records, tags.len() as u32);
+
+    let second = index_mem(&mut tag_index, tags, 1);
+    assert_eq!(second.size_delta, 0, "re-indexing must not grow the index");
+    assert_eq!(second.num_records, 0, "no new records for a duplicate doc");
+    assert_eq!(second.blocks_added, 0, "no new blocks for a duplicate doc");
+}
+
+/// Indexing N documents over a fixed tag set leaves one posting list per
+/// distinct tag and accumulates one record per (tag, doc) pair.
+#[test]
+fn n_tags_and_record_count_track_the_writes() {
+    // Both counts are linear in N, so the assertions hold at any size; a few hundred
+    // documents just exercises the accumulation over many writes.
+    #[cfg(not(miri))]
+    const N: u64 = 500;
+    // Miri interprets every write, and 500 of them exceed `nextest`'s slow-test budget.
+    #[cfg(miri)]
+    const N: u64 = 20;
+
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let tags: &[&[u8]] = &[b"hello", b"world", b"foo"];
+
+    let mut total_records = 0u32;
+    for doc_id in 1..=N {
+        total_records += index_mem(&mut tag_index, tags, doc_id).num_records;
+    }
+
+    assert_eq!(tag_index.n_tags(), tags.len());
+    assert_eq!(total_records, N as u32 * tags.len() as u32);
+}
+
+/// A tag value repeated within a single document is counted once:
+/// `["foo", "foo", "bar"]` yields two records and two unique values.
+#[test]
+fn intra_document_duplicate_tag_counted_once() {
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let tags: &[&[u8]] = &[b"foo", b"foo", b"bar"];
+
+    let delta = index_mem(&mut tag_index, tags, 1);
+    commit_mem(&mut tag_index, tags);
+
+    assert_eq!(delta.num_records, 2, "the duplicate `foo` is counted once");
+    assert_eq!(tag_index.n_tags(), 2);
+}
+
+/// The accumulated `WritePostingsDelta` accounting matches the crate's own
+/// memory model — the sum of every `size_delta` equals the memory the per-tag
+/// inverted indexes report, and blocks accumulate (one per tag on the first
+/// write). Asserted against the reported memory rather than absolute byte
+/// constants, which would pin the `InvertedIndex<DocIdsOnly>` layout.
+// Ignored under Miri: the block accounting is only interesting past
+// `DocIdsOnly::RECOMMENDED_BLOCK_ENTRIES`, and interpreting that many writes
+// exceeds `nextest`'s slow-test budget.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn size_and_block_accounting_matches_reported_memory() {
+    // A `DocIdsOnly` block holds up to 1000 entries, so index past that to make
+    // each tag's posting list spill into more than one block.
+    const N: u64 = 2500;
+
+    let mut tag_index = TagIndex::<InMemoryMode>::new(false);
+    let tags: &[&[u8]] = &[b"hello", b"world", b"foo"];
+
+    let first = index_mem(&mut tag_index, tags, 1);
+    assert!(
+        first.size_delta > 0,
+        "the first insert allocates the index and its first block"
+    );
+    assert_eq!(
+        first.blocks_added,
+        tags.len() as u32,
+        "each new tag gets exactly one block on its first document"
+    );
+
+    let mut total_size = first.size_delta;
+    let mut total_blocks = first.blocks_added;
+    for doc_id in 2..=N {
+        let delta = index_mem(&mut tag_index, tags, doc_id);
+        total_size += delta.size_delta;
+        total_blocks += delta.blocks_added;
+    }
+
+    let reported: usize = tags
+        .iter()
+        .map(|tag| {
+            tag_index
+                .find_value(tag)
+                .expect("tag is indexed")
+                .memory_usage()
+        })
+        .sum();
+    assert_eq!(
+        total_size, reported,
+        "accumulated size_delta must equal the reported inverted-index memory"
+    );
+    assert!(
+        total_blocks > tags.len() as u32,
+        "blocks accumulate beyond the first per-tag block as postings fill up"
+    );
+}

--- a/src/redisearch_rs/tag_index/tests/integration/main.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/main.rs
@@ -16,4 +16,6 @@ extern crate redisearch_rs;
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
 mod create;
+mod indexing;
 mod tag;
+mod util;

--- a/src/redisearch_rs/tag_index/tests/integration/util.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/util.rs
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Helpers shared by the integration test modules.
+
+use inverted_index::DocId;
+use tag_index::{InMemoryMode, TagIndex, Tag, WritePostingsDelta};
+
+/// Wrap every NUL-free literal `tags` passes as a test fixture into a [`Tag`].
+fn tag_values<'a>(tags: &[&'a [u8]]) -> Vec<Tag<'a>> {
+    tags.iter()
+        .map(|t| Tag::new(t).expect("test literal is NUL-free"))
+        .collect()
+}
+
+/// Index `doc_id` under `tags` in a memory-mode index, with no field expiration.
+///
+/// Tests that care about the expiration flag call
+/// [`TagIndex::index`] directly.
+pub fn index_mem(
+    idx: &mut TagIndex<InMemoryMode>,
+    tags: &[&[u8]],
+    doc_id: DocId,
+) -> WritePostingsDelta {
+    idx.index(&tag_values(tags), doc_id, false)
+}
+
+/// Run the post-indexing commit phase for `tags` on a memory-mode index.
+pub fn commit_mem(idx: &mut TagIndex<InMemoryMode>, tags: &[&[u8]]) -> u32 {
+    idx.commit(&tag_values(tags))
+}

--- a/src/redisearch_rs/tag_index/tests/integration/util.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/util.rs
@@ -28,8 +28,7 @@ pub fn index_mem(
     tags: &[&[u8]],
     doc_id: DocId,
 ) -> WritePostingsDelta {
-    // SAFETY: caller passes `doc_id`s in non-decreasing order, as `TagIndex::index` requires.
-    unsafe { idx.index(&tag_values(tags), doc_id, false) }
+    idx.index(&tag_values(tags), doc_id, false)
 }
 
 /// Run the post-indexing commit phase for `tags` on a memory-mode index.

--- a/src/redisearch_rs/tag_index/tests/integration/util.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/util.rs
@@ -28,7 +28,8 @@ pub fn index_mem(
     tags: &[&[u8]],
     doc_id: DocId,
 ) -> WritePostingsDelta {
-    idx.index(&tag_values(tags), doc_id, false)
+    // SAFETY: caller passes `doc_id`s in non-decreasing order, as `TagIndex::index` requires.
+    unsafe { idx.index(&tag_values(tags), doc_id, false) }
 }
 
 /// Run the post-indexing commit phase for `tags` on a memory-mode index.

--- a/src/redisearch_rs/tag_index/tests/integration/util.rs
+++ b/src/redisearch_rs/tag_index/tests/integration/util.rs
@@ -10,7 +10,7 @@
 //! Helpers shared by the integration test modules.
 
 use inverted_index::DocId;
-use tag_index::{InMemoryMode, TagIndex, Tag, WritePostingsDelta};
+use tag_index::{InMemoryMode, Tag, TagIndex, WritePostingsDelta};
 
 /// Wrap every NUL-free literal `tags` passes as a test fixture into a [`Tag`].
 fn tag_values<'a>(tags: &[&'a [u8]]) -> Vec<Tag<'a>> {


### PR DESCRIPTION
## Describe the changes in the pull request

 1. Current: `TagIndex<InMemoryMode>` only supported construction — the type-state
    foundation from the prior PR in this stack, with no way to write document
    postings into the index yet.
 2. Change: Add `TagIndex<InMemoryMode>::index`, which writes a document's tag
    postings inline into each tag's per-tag inverted index (`DocIdsOnly`), and
    `::commit`, which registers those tags in the suffix index via the new
    `TagSuffixIndex::add`.
 3. Outcome: Internal-only work — no user-visible behavior change yet, since
    nothing outside the crate calls this path.

 #### Which additional issues this PR fixes

 1. MOD-14988

 #### Main objects this PR modified

 1. `TagIndex<InMemoryMode>::index`/`::commit` (`tag_index/src/lib.rs`) — writes
    per-document tag postings and returns a `WritePostingsDelta` (bytes, records,
    blocks) for the caller to fold into spec statistics; a repeated tag within
    the same document's multi-value field is counted once.
 2. `TagSuffixIndex::add` (`tag_index/src/suffix.rs`) — registers a tag term and
    every suffix of it in the suffix trie, for suffix/contains queries; ignores
    the empty tag and re-adds of an already-indexed term (the latter would free
    an `OwnedTerm` allocation still referenced by earlier suffix entries).
 3. Test-only accessors (`find_value`, `find_value_mut`) gated behind a new
    `test-utils` Cargo feature, plus new integration tests in
    `tests/integration/indexing.rs` and shared test helpers in
    `tests/integration/util.rs`.

 #### Mark if applicable

 - [ ] This PR introduces API changes
 - [ ] This PR introduces serialization changes

 #### Release Notes

 - [ ] This PR requires release notes
 - [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
