### PR TITLE
TopK Vector tests: safer abstraction over index creation.

### DIFF
--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -588,7 +588,7 @@ mod tests {
     use super::refine_child_estimated;
     use crate::{
         VectorScoreSource,
-        test_utils::{TestIndex, build_flat_index, make_source, uniform_blob},
+        test_utils::{TestIndex, uniform_blob},
     };
 
     #[test]
@@ -617,7 +617,7 @@ mod tests {
         k: usize,
         child_est: usize,
     ) -> VectorScoreSource<'_, NoOpChecker> {
-        make_source(index, uniform_blob(0.0, 1), 0, k, child_est)
+        index.source(uniform_blob(0.0, 1), 0, k, child_est)
     }
 
     /// Entering adhoc must release the batch iterator before acquiring the adhoc
@@ -627,7 +627,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
     fn begin_adhoc_releases_batch_iterator() {
-        let index = build_flat_index(3, 1);
+        let index = TestIndex::flat(3, 1);
         let mut source = flat_source(&index, 3, 3);
 
         // Consume one batch so the iterator is lazily created and held.
@@ -649,7 +649,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
     fn child_estimate_clamped_to_index_size() {
-        let index = build_flat_index(3, 1);
+        let index = TestIndex::flat(3, 1);
         // Child estimate (100) exceeds the index size (3).
         let mut source = flat_source(&index, 3, 100);
 
@@ -671,7 +671,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
     fn largest_batch_metrics_track_and_survive_rewind() {
-        let index = build_flat_index(20, 1);
+        let index = TestIndex::flat(20, 1);
         let mut source = flat_source(&index, 3, 20);
 
         // drive two batches, shrinking the child estimate between them so
@@ -711,7 +711,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
     fn zero_child_estimate_skips_batch_iterator() {
-        let index = build_flat_index(3, 1);
+        let index = TestIndex::flat(3, 1);
         let mut source = flat_source(&index, 3, 0);
 
         assert!(source.next_batch().unwrap().is_none(), "expected no batch");

--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -582,16 +582,13 @@ fn refine_child_estimated(
 
 #[cfg(test)]
 mod tests {
-    use std::ptr::NonNull;
-
-    use ffi::{VecSimIndex, VecSimIndex_Free};
     use rqe_iterators::NoOpChecker;
     use top_k::ScoreSource;
 
     use super::refine_child_estimated;
     use crate::{
         VectorScoreSource,
-        test_utils::{build_flat_index, make_source, uniform_blob},
+        test_utils::{TestIndex, build_flat_index, make_source, uniform_blob},
     };
 
     #[test]
@@ -615,17 +612,12 @@ mod tests {
     }
 
     /// A dim-1 FLAT source over `n` docs; `0.0` query blob, no pinned policy.
-    ///
-    /// # Safety
-    ///
-    /// `index` must outlive the returned source (freed only after the drop).
-    unsafe fn flat_source(
-        index: NonNull<VecSimIndex>,
+    fn flat_source(
+        index: &TestIndex,
         k: usize,
         child_est: usize,
-    ) -> VectorScoreSource<'static, NoOpChecker> {
-        // SAFETY: caller upholds the `index` lifetime contract.
-        unsafe { make_source(index, uniform_blob(0.0, 1), 0, k, child_est) }
+    ) -> VectorScoreSource<'_, NoOpChecker> {
+        make_source(index, uniform_blob(0.0, 1), 0, k, child_est)
     }
 
     /// Entering adhoc must release the batch iterator before acquiring the adhoc
@@ -636,8 +628,7 @@ mod tests {
     #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
     fn begin_adhoc_releases_batch_iterator() {
         let index = build_flat_index(3, 1);
-        // SAFETY: index is freed after the source is dropped at end of scope.
-        let mut source = unsafe { flat_source(index, 3, 3) };
+        let mut source = flat_source(&index, 3, 3);
 
         // Consume one batch so the iterator is lazily created and held.
         source.next_batch().unwrap();
@@ -649,10 +640,6 @@ mod tests {
             "begin_adhoc must drop the batch iterator before taking adhoc locks"
         );
         source.end_adhoc();
-
-        drop(source);
-        // SAFETY: no live references to the index remain.
-        unsafe { VecSimIndex_Free(index.as_ptr()) };
     }
 
     /// `NumEstimated(child)` is an upper bound that can exceed the index size;
@@ -664,8 +651,7 @@ mod tests {
     fn child_estimate_clamped_to_index_size() {
         let index = build_flat_index(3, 1);
         // Child estimate (100) exceeds the index size (3).
-        // SAFETY: index is freed after the source is dropped at end of scope.
-        let mut source = unsafe { flat_source(index, 3, 100) };
+        let mut source = flat_source(&index, 3, 100);
 
         assert_eq!(source.child_num_estimated, 3, "seed clamped to index size");
         assert_eq!(
@@ -678,10 +664,6 @@ mod tests {
             source.child_num_estimated, 3,
             "rewind restores clamped seed"
         );
-
-        drop(source);
-        // SAFETY: no live references to the index remain.
-        unsafe { VecSimIndex_Free(index.as_ptr()) };
     }
 
     /// The largest-batch profile metrics track each dynamically-computed batch
@@ -690,8 +672,7 @@ mod tests {
     #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
     fn largest_batch_metrics_track_and_survive_rewind() {
         let index = build_flat_index(20, 1);
-        // SAFETY: index is freed after the source is dropped at end of scope.
-        let mut source = unsafe { flat_source(index, 3, 20) };
+        let mut source = flat_source(&index, 3, 20);
 
         // drive two batches, shrinking the child estimate between them so
         // the second computed size is larger, then rewind.
@@ -722,10 +703,6 @@ mod tests {
         source.next_batch().unwrap();
         assert_eq!(source.max_batch_size, grown_size, "re-seed only raises");
         assert_eq!(source.num_iterations, 3, "batches keep accumulating");
-
-        drop(source);
-        // SAFETY: no live references to the index remain.
-        unsafe { VecSimIndex_Free(index.as_ptr()) };
     }
 
     /// A zero seeded child estimate means no doc can match: `next_batch` must
@@ -735,17 +712,12 @@ mod tests {
     #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
     fn zero_child_estimate_skips_batch_iterator() {
         let index = build_flat_index(3, 1);
-        // SAFETY: index is freed after the source is dropped at end of scope.
-        let mut source = unsafe { flat_source(index, 3, 0) };
+        let mut source = flat_source(&index, 3, 0);
 
         assert!(source.next_batch().unwrap().is_none(), "expected no batch");
         assert!(
             source.batch_iter.is_none(),
             "batch iterator must not be created for a zero child estimate"
         );
-
-        drop(source);
-        // SAFETY: no live references to the index remain.
-        unsafe { VecSimIndex_Free(index.as_ptr()) };
     }
 }

--- a/src/redisearch_rs/vector_score_source/src/test_utils.rs
+++ b/src/redisearch_rs/vector_score_source/src/test_utils.rs
@@ -18,8 +18,9 @@ use std::{cmp::Ordering, ffi::c_void, ptr, ptr::NonNull};
 use ffi::{
     AlgoParams, BFParams, HNSWParams, VecSearchMode, VecSearchMode_EMPTY_MODE,
     VecSimAlgo_VecSimAlgo_BF, VecSimAlgo_VecSimAlgo_HNSWLIB, VecSimIndex, VecSimIndex_AddVector,
-    VecSimIndex_New, VecSimMetric, VecSimMetric_VecSimMetric_Cosine, VecSimMetric_VecSimMetric_L2,
-    VecSimParams, VecSimQueryParams, VecSimType_VecSimType_FLOAT32, t_docId,
+    VecSimIndex_Free, VecSimIndex_New, VecSimMetric, VecSimMetric_VecSimMetric_Cosine,
+    VecSimMetric_VecSimMetric_L2, VecSimParams, VecSimQueryParams, VecSimType_VecSimType_FLOAT32,
+    t_docId,
 };
 use rqe_iterators::{ExpirationChecker, IdList, NoOpChecker, RQEIterator};
 
@@ -40,8 +41,31 @@ pub fn uniform_blob(value: f32, dim: usize) -> Vec<u8> {
     blob(&vec![value; dim])
 }
 
+/// Owns a VecSim index, freeing it on drop. Sources built from it borrow it,
+/// so they cannot outlive the index.
+pub struct TestIndex {
+    index: NonNull<VecSimIndex>,
+    /// Dimensionality every query blob for this index must match.
+    dim: usize,
+}
+
+impl TestIndex {
+    /// Byte length [`QueryVector`](vecsim::QueryVector) requires for this index,
+    /// whose fixtures are all `FLOAT32`.
+    fn expected_blob_len(&self) -> usize {
+        self.dim * size_of::<f32>()
+    }
+}
+
+impl Drop for TestIndex {
+    fn drop(&mut self) {
+        // SAFETY: sole owner of an index built by `new_index`, freed once.
+        unsafe { VecSimIndex_Free(self.index.as_ptr()) };
+    }
+}
+
 /// HNSW L2 index of `n` vectors; doc `i` (1..=n) is `[i; dim]`.
-pub fn build_hnsw_index(n: usize, dim: usize) -> NonNull<VecSimIndex> {
+pub fn build_hnsw_index(n: usize, dim: usize) -> TestIndex {
     let params = VecSimParams {
         algo: VecSimAlgo_VecSimAlgo_HNSWLIB,
         algoParams: AlgoParams {
@@ -60,7 +84,7 @@ pub fn build_hnsw_index(n: usize, dim: usize) -> NonNull<VecSimIndex> {
         },
         logCtx: ptr::null_mut(),
     };
-    new_index(&params, |add| {
+    new_index(&params, dim, |add| {
         for i in 1..=n {
             add(i as t_docId, &vec![i as f32; dim]);
         }
@@ -68,19 +92,24 @@ pub fn build_hnsw_index(n: usize, dim: usize) -> NonNull<VecSimIndex> {
 }
 
 /// FLAT (exact brute-force) L2 index of `n` vectors; doc `i` is `[i; dim]`.
-pub fn build_flat_index(n: usize, dim: usize) -> NonNull<VecSimIndex> {
-    new_index(&flat_params(dim, VecSimMetric_VecSimMetric_L2, n), |add| {
-        for i in 1..=n {
-            add(i as t_docId, &vec![i as f32; dim]);
-        }
-    })
+pub fn build_flat_index(n: usize, dim: usize) -> TestIndex {
+    new_index(
+        &flat_params(dim, VecSimMetric_VecSimMetric_L2, n),
+        dim,
+        |add| {
+            for i in 1..=n {
+                add(i as t_docId, &vec![i as f32; dim]);
+            }
+        },
+    )
 }
 
 /// FLAT cosine index; doc `i` is `[i/n, 1, 1, ...]`, approaching the `[1; dim]`
 /// query as `i` grows.
-pub fn build_flat_cosine_index(n: usize, dim: usize) -> NonNull<VecSimIndex> {
+pub fn build_flat_cosine_index(n: usize, dim: usize) -> TestIndex {
     new_index(
         &flat_params(dim, VecSimMetric_VecSimMetric_Cosine, n),
+        dim,
         |add| {
             for i in 1..=n {
                 let mut v = vec![1.0f32; dim];
@@ -108,11 +137,12 @@ fn flat_params(dim: usize, metric: VecSimMetric, n: usize) -> VecSimParams {
     }
 }
 
-/// Create an index from `params` and populate it via `fill(add)`.
+/// Create a `dim`-dimensional index from `params` and populate it via `fill(add)`.
 fn new_index(
     params: &VecSimParams,
+    dim: usize,
     fill: impl FnOnce(&mut dyn FnMut(t_docId, &[f32])),
-) -> NonNull<VecSimIndex> {
+) -> TestIndex {
     // SAFETY: `params` is fully initialised.
     let index = unsafe { VecSimIndex_New(params) };
     let index = NonNull::new(index).expect("VecSimIndex_New returned null");
@@ -125,112 +155,99 @@ fn new_index(
         }
     };
     fill(&mut add);
-    index
+    TestIndex { index, dim }
 }
 
 /// Build a [`VectorScoreSource`] over `index` for the `query` blob, with no
 /// pinned `HYBRID_POLICY`. `ef` seeds HNSW's `efRuntime`; `child_est` seeds the
 /// batch-size heuristic.
 ///
-/// # Safety
+/// # Panics
 ///
-/// 1. `index` must outlive the returned source (and any iterator built from it).
-/// 2. `query` must match `index`'s type and dimension, the layout VecSim reads
-///    in full on every query path; a shorter blob is read out of bounds. Use
-///    [`uniform_blob`]/[`blob`] sized to the index `dim`.
-pub unsafe fn make_source(
-    index: NonNull<VecSimIndex>,
+/// If `query` is not sized for `index`; use [`uniform_blob`]/[`blob`] with the
+/// `dim` the index was built with.
+pub fn make_source<'index>(
+    index: &'index TestIndex,
     query: Vec<u8>,
     ef: usize,
     k: usize,
     child_est: usize,
-) -> VectorScoreSource<'static, NoOpChecker> {
-    // SAFETY: forwarded to `make_source_with_mode`, same contract.
-    unsafe { make_source_with_mode(index, query, ef, VecSearchMode_EMPTY_MODE, k, child_est) }
+) -> VectorScoreSource<'index, NoOpChecker> {
+    make_source_with_mode(index, query, ef, VecSearchMode_EMPTY_MODE, k, child_est)
 }
 
 /// [`make_source`] with the requested `HYBRID_POLICY` pinned to `search_mode`.
 ///
-/// # Safety
+/// # Panics
 ///
-/// 1. `index` must outlive the returned source (and any iterator built from it).
-/// 2. `query` must match `index`'s type and dimension, the layout VecSim reads
-///    in full on every query path; a shorter blob is read out of bounds. Use
-///    [`uniform_blob`]/[`blob`] sized to the index `dim`.
-pub unsafe fn make_source_with_mode(
-    index: NonNull<VecSimIndex>,
+/// If `query` is not sized for `index`, as [`make_source`].
+pub fn make_source_with_mode<'index>(
+    index: &'index TestIndex,
     query: Vec<u8>,
     ef: usize,
     search_mode: VecSearchMode,
     k: usize,
     child_est: usize,
-) -> VectorScoreSource<'static, NoOpChecker> {
-    // SAFETY: forwarded to `make_source_inner`; caller upholds this fn's
-    // `# Safety` 1 and 2.
-    unsafe { make_source_inner(index, query, ef, search_mode, k, child_est, NoOpChecker) }
+) -> VectorScoreSource<'index, NoOpChecker> {
+    make_source_inner(index, query, ef, search_mode, k, child_est, NoOpChecker)
 }
 
-/// [`make_source`] with an optional field-`expiration` filter, consulted at
-/// yield time. `EMPTY_MODE` lets VecSim pick the search strategy.
+/// [`make_source`] with a field-`expiration` filter, consulted at yield time.
+/// `EMPTY_MODE` lets VecSim pick the search strategy.
 ///
-/// # Safety
+/// # Panics
 ///
-/// 1. `index` must outlive the returned source (and any iterator built from it).
-/// 2. `query` must match `index`'s type and dimension, the layout VecSim reads
-///    in full on every query path; a shorter blob is read out of bounds. Use
-///    [`uniform_blob`]/[`blob`] sized to the index `dim`.
-pub unsafe fn make_source_with_expiration<E: ExpirationChecker>(
-    index: NonNull<VecSimIndex>,
+/// If `query` is not sized for `index`, as [`make_source`].
+pub fn make_source_with_expiration<'index, E: ExpirationChecker>(
+    index: &'index TestIndex,
     query: Vec<u8>,
     ef: usize,
     k: usize,
     child_est: usize,
     expiration: E,
-) -> VectorScoreSource<'static, E> {
-    // SAFETY: forwarded to `make_source_inner`; caller upholds this fn's
-    // `# Safety` 1 and 2.
-    unsafe {
-        make_source_inner(
-            index,
-            query,
-            ef,
-            VecSearchMode_EMPTY_MODE,
-            k,
-            child_est,
-            expiration,
-        )
-    }
+) -> VectorScoreSource<'index, E> {
+    make_source_inner(
+        index,
+        query,
+        ef,
+        VecSearchMode_EMPTY_MODE,
+        k,
+        child_est,
+        expiration,
+    )
 }
 
 /// Shared builder behind the `make_source*` fixtures.
 ///
-/// # Safety
+/// # Panics
 ///
-/// 1. `index` must outlive the returned source (and any iterator built from it).
-/// 2. `query` must match `index`'s type and dimension, the layout VecSim reads
-///    in full on every query path; a shorter blob is read out of bounds. Use
-///    [`uniform_blob`]/[`blob`] sized to the index `dim`.
-unsafe fn make_source_inner<E: ExpirationChecker>(
-    index: NonNull<VecSimIndex>,
+/// If `query` is not sized for `index`, as [`make_source`].
+fn make_source_inner<'index, E: ExpirationChecker>(
+    index: &'index TestIndex,
     query: Vec<u8>,
     ef: usize,
     search_mode: VecSearchMode,
     k: usize,
     child_est: usize,
     expiration: E,
-) -> VectorScoreSource<'static, E> {
+) -> VectorScoreSource<'index, E> {
+    assert_eq!(
+        query.len(),
+        index.expected_blob_len(),
+        "query blob does not match the index dimensionality"
+    );
+
     // SAFETY: zeroed is a valid bit pattern for this config; we then set only
     // the fields VecSim reads.
     let mut query_params: VecSimQueryParams = unsafe { std::mem::zeroed() };
     query_params.__bindgen_anon_1.hnswRuntimeParams.efRuntime = ef;
     query_params.searchMode = search_mode;
 
-    // SAFETY: caller-upheld: `index` stays alive and `query` matches its
-    // type/dim (this fn's `# Safety`); null timeout ctx and a RAM (non-disk)
-    // index.
+    // SAFETY: 1. `index` is borrowed for `'index`. 2. `query` is sized for it,
+    // asserted above. Null timeout ctx and a RAM (non-disk) index.
     unsafe {
         VectorScoreSource::new(
-            index,
+            index.index,
             query,
             query_params,
             k,
@@ -244,11 +261,11 @@ unsafe fn make_source_inner<E: ExpirationChecker>(
 }
 
 /// A filter child yielding `ids`, backed by a sorted [`IdList`].
-pub fn make_child(ids: Vec<t_docId>) -> Box<dyn RQEIterator<'static>> {
+pub fn make_child<'index>(ids: Vec<t_docId>) -> Box<dyn RQEIterator<'index> + 'index> {
     Box::new(IdList::<true>::new(ids))
 }
 
 /// Drain an iterator into the doc ids it yields, in read order.
-pub fn collect_ids<I: RQEIterator<'static>>(it: &mut I) -> Vec<t_docId> {
+pub fn collect_ids<'index, I: RQEIterator<'index>>(it: &mut I) -> Vec<t_docId> {
     std::iter::from_fn(|| it.read().unwrap().map(|r| r.doc_id)).collect()
 }

--- a/src/redisearch_rs/vector_score_source/src/test_utils.rs
+++ b/src/redisearch_rs/vector_score_source/src/test_utils.rs
@@ -50,6 +50,28 @@ pub struct TestIndex {
 }
 
 impl TestIndex {
+    /// Create a `dim`-dimensional index from `params` and populate it via
+    /// `fill(add)`.
+    fn new(
+        params: &VecSimParams,
+        dim: usize,
+        fill: impl FnOnce(&mut dyn FnMut(t_docId, &[f32])),
+    ) -> Self {
+        // SAFETY: `params` is fully initialised.
+        let index = unsafe { VecSimIndex_New(params) };
+        let index = NonNull::new(index).expect("VecSimIndex_New returned null");
+
+        let mut add = |id: t_docId, v: &[f32]| {
+            // SAFETY: `v` holds `dim` f32 elements matching the index type/dim;
+            // valid for the duration of the call.
+            unsafe {
+                VecSimIndex_AddVector(index.as_ptr(), v.as_ptr() as *const c_void, id as usize);
+            }
+        };
+        fill(&mut add);
+        Self { index, dim }
+    }
+
     /// HNSW L2 index of `n` vectors; doc `i` (1..=n) is `[i; dim]`.
     pub fn hnsw(n: usize, dim: usize) -> Self {
         let params = VecSimParams {
@@ -104,28 +126,6 @@ impl TestIndex {
                 }
             },
         )
-    }
-
-    /// Create a `dim`-dimensional index from `params` and populate it via
-    /// `fill(add)`.
-    fn new(
-        params: &VecSimParams,
-        dim: usize,
-        fill: impl FnOnce(&mut dyn FnMut(t_docId, &[f32])),
-    ) -> Self {
-        // SAFETY: `params` is fully initialised.
-        let index = unsafe { VecSimIndex_New(params) };
-        let index = NonNull::new(index).expect("VecSimIndex_New returned null");
-
-        let mut add = |id: t_docId, v: &[f32]| {
-            // SAFETY: `v` holds `dim` f32 elements matching the index type/dim;
-            // valid for the duration of the call.
-            unsafe {
-                VecSimIndex_AddVector(index.as_ptr(), v.as_ptr() as *const c_void, id as usize);
-            }
-        };
-        fill(&mut add);
-        Self { index, dim }
     }
 
     /// Byte length [`QueryVector`](vecsim::QueryVector) requires for this index,

--- a/src/redisearch_rs/vector_score_source/src/test_utils.rs
+++ b/src/redisearch_rs/vector_score_source/src/test_utils.rs
@@ -50,74 +50,198 @@ pub struct TestIndex {
 }
 
 impl TestIndex {
+    /// HNSW L2 index of `n` vectors; doc `i` (1..=n) is `[i; dim]`.
+    pub fn hnsw(n: usize, dim: usize) -> Self {
+        let params = VecSimParams {
+            algo: VecSimAlgo_VecSimAlgo_HNSWLIB,
+            algoParams: AlgoParams {
+                hnswParams: HNSWParams {
+                    type_: VecSimType_VecSimType_FLOAT32,
+                    dim,
+                    metric: VecSimMetric_VecSimMetric_L2,
+                    multi: false,
+                    initialCapacity: n,
+                    blockSize: 0,
+                    M: 16,
+                    efConstruction: 100,
+                    efRuntime: 0,
+                    epsilon: 0.0,
+                },
+            },
+            logCtx: ptr::null_mut(),
+        };
+        Self::new(&params, dim, |add| {
+            for i in 1..=n {
+                add(i as t_docId, &vec![i as f32; dim]);
+            }
+        })
+    }
+
+    /// FLAT (exact brute-force) L2 index of `n` vectors; doc `i` is `[i; dim]`.
+    pub fn flat(n: usize, dim: usize) -> Self {
+        Self::new(
+            &flat_params(dim, VecSimMetric_VecSimMetric_L2, n),
+            dim,
+            |add| {
+                for i in 1..=n {
+                    add(i as t_docId, &vec![i as f32; dim]);
+                }
+            },
+        )
+    }
+
+    /// FLAT cosine index; doc `i` is `[i/n, 1, 1, ...]`, approaching the
+    /// `[1; dim]` query as `i` grows.
+    pub fn flat_cosine(n: usize, dim: usize) -> Self {
+        Self::new(
+            &flat_params(dim, VecSimMetric_VecSimMetric_Cosine, n),
+            dim,
+            |add| {
+                for i in 1..=n {
+                    let mut v = vec![1.0f32; dim];
+                    v[0] = i as f32 / n as f32;
+                    add(i as t_docId, &v);
+                }
+            },
+        )
+    }
+
+    /// Create a `dim`-dimensional index from `params` and populate it via
+    /// `fill(add)`.
+    fn new(
+        params: &VecSimParams,
+        dim: usize,
+        fill: impl FnOnce(&mut dyn FnMut(t_docId, &[f32])),
+    ) -> Self {
+        // SAFETY: `params` is fully initialised.
+        let index = unsafe { VecSimIndex_New(params) };
+        let index = NonNull::new(index).expect("VecSimIndex_New returned null");
+
+        let mut add = |id: t_docId, v: &[f32]| {
+            // SAFETY: `v` holds `dim` f32 elements matching the index type/dim;
+            // valid for the duration of the call.
+            unsafe {
+                VecSimIndex_AddVector(index.as_ptr(), v.as_ptr() as *const c_void, id as usize);
+            }
+        };
+        fill(&mut add);
+        Self { index, dim }
+    }
+
     /// Byte length [`QueryVector`](vecsim::QueryVector) requires for this index,
     /// whose fixtures are all `FLOAT32`.
     fn expected_blob_len(&self) -> usize {
         self.dim * size_of::<f32>()
     }
+
+    /// Build a [`VectorScoreSource`] over this index for the `query` blob, with
+    /// no pinned `HYBRID_POLICY`. `ef` seeds HNSW's `efRuntime`; `child_est`
+    /// seeds the batch-size heuristic.
+    ///
+    /// # Panics
+    ///
+    /// If `query` is not sized for this index; use [`uniform_blob`]/[`blob`]
+    /// with the `dim` the index was built with.
+    pub fn source(
+        &self,
+        query: Vec<u8>,
+        ef: usize,
+        k: usize,
+        child_est: usize,
+    ) -> VectorScoreSource<'_, NoOpChecker> {
+        self.source_with_mode(query, ef, VecSearchMode_EMPTY_MODE, k, child_est)
+    }
+
+    /// [`Self::source`] with the requested `HYBRID_POLICY` pinned to
+    /// `search_mode`.
+    ///
+    /// # Panics
+    ///
+    /// If `query` is not sized for this index, as [`Self::source`].
+    pub fn source_with_mode(
+        &self,
+        query: Vec<u8>,
+        ef: usize,
+        search_mode: VecSearchMode,
+        k: usize,
+        child_est: usize,
+    ) -> VectorScoreSource<'_, NoOpChecker> {
+        self.source_inner(query, ef, search_mode, k, child_est, NoOpChecker)
+    }
+
+    /// [`Self::source`] with a field-`expiration` filter, consulted at yield
+    /// time. `EMPTY_MODE` lets VecSim pick the search strategy.
+    ///
+    /// # Panics
+    ///
+    /// If `query` is not sized for this index, as [`Self::source`].
+    pub fn source_with_expiration<E: ExpirationChecker>(
+        &self,
+        query: Vec<u8>,
+        ef: usize,
+        k: usize,
+        child_est: usize,
+        expiration: E,
+    ) -> VectorScoreSource<'_, E> {
+        self.source_inner(
+            query,
+            ef,
+            VecSearchMode_EMPTY_MODE,
+            k,
+            child_est,
+            expiration,
+        )
+    }
+
+    /// Shared builder behind the `source*` fixtures.
+    ///
+    /// # Panics
+    ///
+    /// If `query` is not sized for this index, as [`Self::source`].
+    fn source_inner<E: ExpirationChecker>(
+        &self,
+        query: Vec<u8>,
+        ef: usize,
+        search_mode: VecSearchMode,
+        k: usize,
+        child_est: usize,
+        expiration: E,
+    ) -> VectorScoreSource<'_, E> {
+        assert_eq!(
+            query.len(),
+            self.expected_blob_len(),
+            "query blob does not match the index dimensionality"
+        );
+
+        // SAFETY: zeroed is a valid bit pattern for this config; we then set only
+        // the fields VecSim reads.
+        let mut query_params: VecSimQueryParams = unsafe { std::mem::zeroed() };
+        query_params.__bindgen_anon_1.hnswRuntimeParams.efRuntime = ef;
+        query_params.searchMode = search_mode;
+
+        // SAFETY: 1. `self` is borrowed for the source's lifetime. 2. `query` is
+        // sized for it, asserted above. Null timeout ctx and a RAM (non-disk) index.
+        unsafe {
+            VectorScoreSource::new(
+                self.index,
+                query,
+                query_params,
+                k,
+                std::mem::zeroed(),
+                true,
+                child_est,
+                0,
+                expiration,
+            )
+        }
+    }
 }
 
 impl Drop for TestIndex {
     fn drop(&mut self) {
-        // SAFETY: sole owner of an index built by `new_index`, freed once.
+        // SAFETY: sole owner of the index created in `Self::new`, freed once.
         unsafe { VecSimIndex_Free(self.index.as_ptr()) };
     }
-}
-
-/// HNSW L2 index of `n` vectors; doc `i` (1..=n) is `[i; dim]`.
-pub fn build_hnsw_index(n: usize, dim: usize) -> TestIndex {
-    let params = VecSimParams {
-        algo: VecSimAlgo_VecSimAlgo_HNSWLIB,
-        algoParams: AlgoParams {
-            hnswParams: HNSWParams {
-                type_: VecSimType_VecSimType_FLOAT32,
-                dim,
-                metric: VecSimMetric_VecSimMetric_L2,
-                multi: false,
-                initialCapacity: n,
-                blockSize: 0,
-                M: 16,
-                efConstruction: 100,
-                efRuntime: 0,
-                epsilon: 0.0,
-            },
-        },
-        logCtx: ptr::null_mut(),
-    };
-    new_index(&params, dim, |add| {
-        for i in 1..=n {
-            add(i as t_docId, &vec![i as f32; dim]);
-        }
-    })
-}
-
-/// FLAT (exact brute-force) L2 index of `n` vectors; doc `i` is `[i; dim]`.
-pub fn build_flat_index(n: usize, dim: usize) -> TestIndex {
-    new_index(
-        &flat_params(dim, VecSimMetric_VecSimMetric_L2, n),
-        dim,
-        |add| {
-            for i in 1..=n {
-                add(i as t_docId, &vec![i as f32; dim]);
-            }
-        },
-    )
-}
-
-/// FLAT cosine index; doc `i` is `[i/n, 1, 1, ...]`, approaching the `[1; dim]`
-/// query as `i` grows.
-pub fn build_flat_cosine_index(n: usize, dim: usize) -> TestIndex {
-    new_index(
-        &flat_params(dim, VecSimMetric_VecSimMetric_Cosine, n),
-        dim,
-        |add| {
-            for i in 1..=n {
-                let mut v = vec![1.0f32; dim];
-                v[0] = i as f32 / n as f32;
-                add(i as t_docId, &v);
-            }
-        },
-    )
 }
 
 fn flat_params(dim: usize, metric: VecSimMetric, n: usize) -> VecSimParams {
@@ -134,129 +258,6 @@ fn flat_params(dim: usize, metric: VecSimMetric, n: usize) -> VecSimParams {
             },
         },
         logCtx: ptr::null_mut(),
-    }
-}
-
-/// Create a `dim`-dimensional index from `params` and populate it via `fill(add)`.
-fn new_index(
-    params: &VecSimParams,
-    dim: usize,
-    fill: impl FnOnce(&mut dyn FnMut(t_docId, &[f32])),
-) -> TestIndex {
-    // SAFETY: `params` is fully initialised.
-    let index = unsafe { VecSimIndex_New(params) };
-    let index = NonNull::new(index).expect("VecSimIndex_New returned null");
-
-    let mut add = |id: t_docId, v: &[f32]| {
-        // SAFETY: `v` holds `dim` f32 elements matching the index type/dim;
-        // valid for the duration of the call.
-        unsafe {
-            VecSimIndex_AddVector(index.as_ptr(), v.as_ptr() as *const c_void, id as usize);
-        }
-    };
-    fill(&mut add);
-    TestIndex { index, dim }
-}
-
-/// Build a [`VectorScoreSource`] over `index` for the `query` blob, with no
-/// pinned `HYBRID_POLICY`. `ef` seeds HNSW's `efRuntime`; `child_est` seeds the
-/// batch-size heuristic.
-///
-/// # Panics
-///
-/// If `query` is not sized for `index`; use [`uniform_blob`]/[`blob`] with the
-/// `dim` the index was built with.
-pub fn make_source<'index>(
-    index: &'index TestIndex,
-    query: Vec<u8>,
-    ef: usize,
-    k: usize,
-    child_est: usize,
-) -> VectorScoreSource<'index, NoOpChecker> {
-    make_source_with_mode(index, query, ef, VecSearchMode_EMPTY_MODE, k, child_est)
-}
-
-/// [`make_source`] with the requested `HYBRID_POLICY` pinned to `search_mode`.
-///
-/// # Panics
-///
-/// If `query` is not sized for `index`, as [`make_source`].
-pub fn make_source_with_mode<'index>(
-    index: &'index TestIndex,
-    query: Vec<u8>,
-    ef: usize,
-    search_mode: VecSearchMode,
-    k: usize,
-    child_est: usize,
-) -> VectorScoreSource<'index, NoOpChecker> {
-    make_source_inner(index, query, ef, search_mode, k, child_est, NoOpChecker)
-}
-
-/// [`make_source`] with a field-`expiration` filter, consulted at yield time.
-/// `EMPTY_MODE` lets VecSim pick the search strategy.
-///
-/// # Panics
-///
-/// If `query` is not sized for `index`, as [`make_source`].
-pub fn make_source_with_expiration<'index, E: ExpirationChecker>(
-    index: &'index TestIndex,
-    query: Vec<u8>,
-    ef: usize,
-    k: usize,
-    child_est: usize,
-    expiration: E,
-) -> VectorScoreSource<'index, E> {
-    make_source_inner(
-        index,
-        query,
-        ef,
-        VecSearchMode_EMPTY_MODE,
-        k,
-        child_est,
-        expiration,
-    )
-}
-
-/// Shared builder behind the `make_source*` fixtures.
-///
-/// # Panics
-///
-/// If `query` is not sized for `index`, as [`make_source`].
-fn make_source_inner<'index, E: ExpirationChecker>(
-    index: &'index TestIndex,
-    query: Vec<u8>,
-    ef: usize,
-    search_mode: VecSearchMode,
-    k: usize,
-    child_est: usize,
-    expiration: E,
-) -> VectorScoreSource<'index, E> {
-    assert_eq!(
-        query.len(),
-        index.expected_blob_len(),
-        "query blob does not match the index dimensionality"
-    );
-
-    // SAFETY: zeroed is a valid bit pattern for this config; we then set only
-    // the fields VecSim reads.
-    let mut query_params: VecSimQueryParams = unsafe { std::mem::zeroed() };
-    query_params.__bindgen_anon_1.hnswRuntimeParams.efRuntime = ef;
-    query_params.searchMode = search_mode;
-
-    // SAFETY: 1. `index` is borrowed for `'index`. 2. `query` is sized for it,
-    // asserted above. Null timeout ctx and a RAM (non-disk) index.
-    unsafe {
-        VectorScoreSource::new(
-            index.index,
-            query,
-            query_params,
-            k,
-            std::mem::zeroed(),
-            true,
-            child_est,
-            0,
-            expiration,
-        )
     }
 }
 

--- a/src/redisearch_rs/vector_score_source/tests/integration/policy.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/policy.rs
@@ -12,10 +12,7 @@
 
 use std::num::NonZeroUsize;
 
-use ffi::{
-    VecSearchMode_EMPTY_MODE, VecSearchMode_HYBRID_ADHOC_BF, VecSearchMode_HYBRID_BATCHES,
-    VecSimIndex_Free,
-};
+use ffi::{VecSearchMode_EMPTY_MODE, VecSearchMode_HYBRID_ADHOC_BF, VecSearchMode_HYBRID_BATCHES};
 use top_k::TopKMode;
 use vector_score_source::new_vector_top_k_filtered;
 use vector_score_source::test_utils::{
@@ -27,16 +24,14 @@ use vector_score_source::test_utils::{
 fn explicit_adhoc_policy() {
     let index = build_flat_index(5, 1);
     // SAFETY: index is freed after the iterator is dropped at end of scope.
-    let source = unsafe {
-        make_source_with_mode(
-            index,
-            uniform_blob(0.0, 1),
-            0,
-            VecSearchMode_HYBRID_ADHOC_BF,
-            3,
-            3,
-        )
-    };
+    let source = make_source_with_mode(
+        &index,
+        uniform_blob(0.0, 1),
+        0,
+        VecSearchMode_HYBRID_ADHOC_BF,
+        3,
+        3,
+    );
     let it = new_vector_top_k_filtered(
         source,
         make_child(vec![1, 2, 3]),
@@ -44,10 +39,6 @@ fn explicit_adhoc_policy() {
         false,
     );
     assert_eq!(it.mode(), TopKMode::AdhocBF);
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 #[test]
@@ -55,16 +46,14 @@ fn explicit_adhoc_policy() {
 fn explicit_batches_policy() {
     let index = build_flat_index(5, 1);
     // SAFETY: index is freed after the iterator is dropped at end of scope.
-    let source = unsafe {
-        make_source_with_mode(
-            index,
-            uniform_blob(0.0, 1),
-            0,
-            VecSearchMode_HYBRID_BATCHES,
-            3,
-            3,
-        )
-    };
+    let source = make_source_with_mode(
+        &index,
+        uniform_blob(0.0, 1),
+        0,
+        VecSearchMode_HYBRID_BATCHES,
+        3,
+        3,
+    );
     let it = new_vector_top_k_filtered(
         source,
         make_child(vec![1, 2, 3]),
@@ -72,10 +61,6 @@ fn explicit_batches_policy() {
         false,
     );
     assert_eq!(it.mode(), TopKMode::ForcedBatches);
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 /// With no explicit policy the constructor consults the cost heuristic, which
@@ -85,16 +70,14 @@ fn explicit_batches_policy() {
 fn unset_policy_uses_heuristic() {
     let index = build_flat_index(5, 1);
     // SAFETY: index is freed after the iterator is dropped at end of scope.
-    let source = unsafe {
-        make_source_with_mode(
-            index,
-            uniform_blob(0.0, 1),
-            0,
-            VecSearchMode_EMPTY_MODE,
-            3,
-            3,
-        )
-    };
+    let source = make_source_with_mode(
+        &index,
+        uniform_blob(0.0, 1),
+        0,
+        VecSearchMode_EMPTY_MODE,
+        3,
+        3,
+    );
     let it = new_vector_top_k_filtered(
         source,
         make_child(vec![1, 2, 3]),
@@ -106,8 +89,4 @@ fn unset_policy_uses_heuristic() {
         "heuristic path must not force batches; got {:?}",
         it.mode()
     );
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }

--- a/src/redisearch_rs/vector_score_source/tests/integration/policy.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/policy.rs
@@ -15,23 +15,15 @@ use std::num::NonZeroUsize;
 use ffi::{VecSearchMode_EMPTY_MODE, VecSearchMode_HYBRID_ADHOC_BF, VecSearchMode_HYBRID_BATCHES};
 use top_k::TopKMode;
 use vector_score_source::new_vector_top_k_filtered;
-use vector_score_source::test_utils::{
-    build_flat_index, make_child, make_source_with_mode, uniform_blob,
-};
+use vector_score_source::test_utils::{TestIndex, make_child, uniform_blob};
 
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn explicit_adhoc_policy() {
-    let index = build_flat_index(5, 1);
+    let index = TestIndex::flat(5, 1);
     // SAFETY: index is freed after the iterator is dropped at end of scope.
-    let source = make_source_with_mode(
-        &index,
-        uniform_blob(0.0, 1),
-        0,
-        VecSearchMode_HYBRID_ADHOC_BF,
-        3,
-        3,
-    );
+    let source =
+        index.source_with_mode(uniform_blob(0.0, 1), 0, VecSearchMode_HYBRID_ADHOC_BF, 3, 3);
     let it = new_vector_top_k_filtered(
         source,
         make_child(vec![1, 2, 3]),
@@ -44,16 +36,10 @@ fn explicit_adhoc_policy() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn explicit_batches_policy() {
-    let index = build_flat_index(5, 1);
+    let index = TestIndex::flat(5, 1);
     // SAFETY: index is freed after the iterator is dropped at end of scope.
-    let source = make_source_with_mode(
-        &index,
-        uniform_blob(0.0, 1),
-        0,
-        VecSearchMode_HYBRID_BATCHES,
-        3,
-        3,
-    );
+    let source =
+        index.source_with_mode(uniform_blob(0.0, 1), 0, VecSearchMode_HYBRID_BATCHES, 3, 3);
     let it = new_vector_top_k_filtered(
         source,
         make_child(vec![1, 2, 3]),
@@ -68,16 +54,9 @@ fn explicit_batches_policy() {
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn unset_policy_uses_heuristic() {
-    let index = build_flat_index(5, 1);
+    let index = TestIndex::flat(5, 1);
     // SAFETY: index is freed after the iterator is dropped at end of scope.
-    let source = make_source_with_mode(
-        &index,
-        uniform_blob(0.0, 1),
-        0,
-        VecSearchMode_EMPTY_MODE,
-        3,
-        3,
-    );
+    let source = index.source_with_mode(uniform_blob(0.0, 1), 0, VecSearchMode_EMPTY_MODE, 3, 3);
     let it = new_vector_top_k_filtered(
         source,
         make_child(vec![1, 2, 3]),

--- a/src/redisearch_rs/vector_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source.rs
@@ -16,16 +16,18 @@
 //! neighbours are simply the highest ids — making every expected ordering
 //! trivially predictable.
 
-use std::{num::NonZeroUsize, ptr::NonNull};
+use std::num::NonZeroUsize;
 
 use std::collections::HashSet;
 
-use ffi::{RLookupKey, VecSimIndex, VecSimIndex_Free, t_docId};
+use ffi::{RLookupKey, t_docId};
 use index_result::{RSIndexResult, RSResultKind};
 use rqe_iterators::{ExpirationChecker, IdList, NoOpChecker, RQEIterator};
 use rqe_iterators_test_utils::MockExpirationChecker;
 use top_k::{ScoreSource, TopKIterator, TopKMode};
-use vector_score_source::test_utils::{self, asc, collect_ids, make_child, uniform_blob};
+use vector_score_source::test_utils::{
+    self, TestIndex, asc, collect_ids, make_child, uniform_blob,
+};
 use vector_score_source::{
     VectorScoreSource, new_vector_top_k_filtered, new_vector_top_k_unfiltered,
 };
@@ -33,50 +35,38 @@ use vector_score_source::{
 const DIM: usize = 4;
 
 /// HNSW index of `n` vectors `[i; DIM]` at this suite's fixed dimensionality.
-fn build_hnsw_index(n: usize) -> NonNull<VecSimIndex> {
+fn build_hnsw_index(n: usize) -> TestIndex {
     test_utils::build_hnsw_index(n, DIM)
 }
 
-/// test_utilising the corner `[n; DIM]` with `efRuntime = n`. `child_est` seeds
-/// the batch-size heuristic — production passes `child.num_estimated()`.
-///
-/// # Safety
-///
-/// `index` must outlive the returned source (and any iterator built from it).
-unsafe fn make_source(
-    index: NonNull<VecSimIndex>,
+/// Queries the corner `[n; DIM]` with `efRuntime = n`. `child_est` seeds the
+/// batch-size heuristic — production passes `child.num_estimated()`.
+fn make_source(
+    index: &TestIndex,
     n: usize,
     k: usize,
     child_est: usize,
-) -> VectorScoreSource<'static, NoOpChecker> {
-    // SAFETY: caller-upheld `index` lifetime; no expiration filter.
-    unsafe { make_source_with_expiration(index, n, k, child_est, NoOpChecker) }
+) -> VectorScoreSource<'_, NoOpChecker> {
+    make_source_with_expiration(index, n, k, child_est, NoOpChecker)
 }
 
 /// Same as [`make_source`], but installs a field-expiration filter, consulted
 /// at yield time.
-///
-/// # Safety
-///
-/// `index` must outlive the returned source (and any iterator built from it).
-unsafe fn make_source_with_expiration<E: ExpirationChecker>(
-    index: NonNull<VecSimIndex>,
+fn make_source_with_expiration<E: ExpirationChecker>(
+    index: &TestIndex,
     n: usize,
     k: usize,
     child_est: usize,
     expiration: E,
-) -> VectorScoreSource<'static, E> {
-    // SAFETY: caller upholds the `index` lifetime contract.
-    unsafe {
-        test_utils::make_source_with_expiration(
-            index,
-            uniform_blob(n as f32, DIM),
-            n,
-            k,
-            child_est,
-            expiration,
-        )
-    }
+) -> VectorScoreSource<'_, E> {
+    test_utils::make_source_with_expiration(
+        index,
+        uniform_blob(n as f32, DIM),
+        n,
+        k,
+        child_est,
+        expiration,
+    )
 }
 
 #[test]
@@ -86,8 +76,7 @@ fn unfiltered_returns_top_k_nearest_by_score() {
     let k = 10;
     let index = build_hnsw_index(n);
 
-    // SAFETY: `index` is freed after the iterator is dropped at end of scope.
-    let source = unsafe { make_source(index, n, k, n) };
+    let source = make_source(&index, n, k, n);
     let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
 
     // The unfiltered path streams VecSim's reply ordered by score, so the k
@@ -95,10 +84,6 @@ fn unfiltered_returns_top_k_nearest_by_score() {
     let ids = collect_ids(&mut it);
     assert_eq!(ids, (91..=100).rev().collect::<Vec<_>>());
     assert!(it.at_eof());
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 #[test]
@@ -108,8 +93,7 @@ fn unfiltered_results_are_metric_kind_with_exact_distance() {
     let k = 10;
     let index = build_hnsw_index(n);
 
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, n, k, n) };
+    let source = make_source(&index, n, k, n);
     let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
 
     // Estimate is capped at k (k < index size here).
@@ -132,10 +116,6 @@ fn unfiltered_results_are_metric_kind_with_exact_distance() {
         expected_id -= 1;
     }
     assert_eq!(expected_id, n as t_docId - k as t_docId);
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 #[test]
@@ -145,8 +125,7 @@ fn first_result_after_rewind_is_best() {
     let k = 10;
     let index = build_hnsw_index(n);
 
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, n, k, n) };
+    let source = make_source(&index, n, k, n);
     let child = make_child((1..=n as t_docId).collect());
     // Batches drains the heap best-first, so after a rewind the first read must
     // again be the single best (lowest-distance) doc: the highest id at distance 0.
@@ -164,10 +143,6 @@ fn first_result_after_rewind_is_best() {
     assert_eq!(it.num_estimated(), k);
     let res = it.read().unwrap().expect("a result after rewind");
     assert_eq!(res.doc_id, n as t_docId);
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 #[test]
@@ -177,8 +152,7 @@ fn filtered_full_child_yields_best_first() {
     let k = 10;
     let index = build_hnsw_index(n);
 
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, n, k, n) };
+    let source = make_source(&index, n, k, n);
     let child = make_child((1..=n as t_docId).collect());
     // Public constructor auto-selects batches vs adhoc; either way the heap is
     // drained best-first, so ordering is deterministic.
@@ -187,10 +161,6 @@ fn filtered_full_child_yields_best_first() {
     // Best (lowest distance) first → highest ids first.
     let ids = collect_ids(&mut it);
     assert_eq!(ids, (91..=100).rev().collect::<Vec<_>>());
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 #[test]
@@ -209,8 +179,7 @@ fn filtered_batches_partial_child_intersects() {
     // first (large) batch — mirroring how production sizes batches. Passing a
     // too-large estimate would shrink batches and force many passes, where
     // VecSim's approximate batch iterator can re-surface high-scoring docs.
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, n, k, child_ids.len()) };
+    let source = make_source(&index, n, k, child_ids.len());
     let mut it = TopKIterator::new_with_mode(
         source,
         Some(make_child(child_ids)),
@@ -224,10 +193,6 @@ fn filtered_batches_partial_child_intersects() {
     let ids = collect_ids(&mut it);
     let expected: Vec<t_docId> = (0..k).map(|c| (n - step * c) as t_docId).collect();
     assert_eq!(ids, expected);
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 #[test]
@@ -237,8 +202,7 @@ fn filtered_adhoc_matches_batches() {
     let k = 10;
     let index = build_hnsw_index(n);
 
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, n, k, n) };
+    let source = make_source(&index, n, k, n);
     let child = make_child((1..=n as t_docId).collect());
     // Force the adhoc-BF path (RAM lookups under shared locks) and verify it
     // produces the same ranking as the batches path.
@@ -252,10 +216,6 @@ fn filtered_adhoc_matches_batches() {
 
     let ids = collect_ids(&mut it);
     assert_eq!(ids, (91..=100).rev().collect::<Vec<_>>());
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 #[test]
@@ -275,8 +235,7 @@ fn filtered_adhoc_drops_nan_distance_docs() {
     child_ids.extend(&phantom);
     child_ids.sort_unstable();
 
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, n, k, child_ids.len()) };
+    let source = make_source(&index, n, k, child_ids.len());
     // AdhocBF drives per-id lookups; the NaN drop lives only on this path
     // (Batches intersects against VecSim's real-id stream, so phantom ids
     // never reach the distance lookup).
@@ -296,10 +255,6 @@ fn filtered_adhoc_drops_nan_distance_docs() {
             "phantom id {p} with NaN distance must be filtered"
         );
     }
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 #[test]
@@ -309,8 +264,7 @@ fn rewind_replays_same_results() {
     let k = 10;
     let index = build_hnsw_index(n);
 
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, n, k, n) };
+    let source = make_source(&index, n, k, n);
     let child = make_child((1..=n as t_docId).collect());
     let mut it = TopKIterator::new_with_mode(
         source,
@@ -328,10 +282,6 @@ fn rewind_replays_same_results() {
 
     let second = collect_ids(&mut it);
     assert_eq!(first, second);
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 #[test]
@@ -343,8 +293,7 @@ fn disjoint_child_yields_nothing() {
 
     // No filter id exists in the index, so the intersection is empty.
     let child_ids = vec![1000, 2000, 3000];
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, n, k, child_ids.len()) };
+    let source = make_source(&index, n, k, child_ids.len());
     let child = make_child(child_ids);
     let mut it = TopKIterator::new_with_mode(
         source,
@@ -356,10 +305,6 @@ fn disjoint_child_yields_nothing() {
 
     assert!(it.read().unwrap().is_none());
     assert!(it.at_eof());
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 #[test]
@@ -371,18 +316,13 @@ fn unfiltered_skips_expired_docs() {
 
     // Mark the two nearest neighbours expired.
     let checker = MockExpirationChecker::new(HashSet::from([100, 99]));
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source_with_expiration(index, n, k, n, checker) };
+    let source = make_source_with_expiration(&index, n, k, n, checker);
     let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
 
     // The two expired nearest neighbours are
     // dropped without refill.
     let ids = collect_ids(&mut it);
     assert_eq!(ids, (91..=98).rev().collect::<Vec<_>>());
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 #[test]
@@ -398,8 +338,7 @@ fn filtered_batches_drops_expired_without_refill() {
     // count short, not refilled from the next-best doc.
     let child_ids: Vec<t_docId> = (90..=100).collect();
     let checker = MockExpirationChecker::new(HashSet::from([100]));
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source_with_expiration(index, n, k, child_ids.len(), checker) };
+    let source = make_source_with_expiration(&index, n, k, child_ids.len(), checker);
     let child = make_child(child_ids);
     let mut it = TopKIterator::new_with_mode(
         source,
@@ -411,10 +350,6 @@ fn filtered_batches_drops_expired_without_refill() {
 
     let ids = collect_ids(&mut it);
     assert_eq!(ids, vec![99, 98]);
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 #[test]
@@ -429,8 +364,7 @@ fn filtered_adhoc_drops_expired_without_refill() {
     // count shrinks instead of refilling from the next-best doc.
     let child_ids: Vec<t_docId> = (90..=100).collect();
     let checker = MockExpirationChecker::new(HashSet::from([100]));
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source_with_expiration(index, n, k, child_ids.len(), checker) };
+    let source = make_source_with_expiration(&index, n, k, child_ids.len(), checker);
     let child = make_child(child_ids);
     let mut it = TopKIterator::new_with_mode(
         source,
@@ -442,10 +376,6 @@ fn filtered_adhoc_drops_expired_without_refill() {
 
     let ids = collect_ids(&mut it);
     assert_eq!(ids, vec![99, 98]);
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 #[test]
@@ -454,13 +384,8 @@ fn index_size_reflects_added_vectors() {
     let n = 42;
     let index = build_hnsw_index(n);
 
-    // SAFETY: index outlives the source (freed at end of scope).
-    let source = unsafe { make_source(index, n, 10, n) };
+    let source = make_source(&index, n, 10, n);
     assert_eq!(source.index_size(), n);
-
-    drop(source);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 /// A zero-filled lookup key. The metrics channel only compares the key's
@@ -479,8 +404,7 @@ fn make_key() -> RLookupKey {
 fn attach_score_metric_appends_when_absent() {
     // Arrange: a keyed source and a result holding only the child's own metric.
     let index = build_hnsw_index(3);
-    // SAFETY: index outlives the source (freed at end of scope).
-    let mut source = unsafe { make_source(index, 3, 3, 3) };
+    let mut source = make_source(&index, 3, 3, 3);
     let mut own = make_key();
     *source.own_key = (&mut own as *mut RLookupKey).cast();
 
@@ -498,11 +422,6 @@ fn attach_score_metric_appends_when_absent() {
         result.metrics.find_by_key_mut(&foreign).unwrap().value(),
         7.0
     );
-
-    drop(result);
-    drop(source);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 /// Repeated yields reuse one child storage slot, so the source overwrites its
@@ -514,8 +433,7 @@ fn attach_score_metric_overwrites_in_place() {
     // Arrange: a result already carrying a stale score under our key, as if left
     // by a previous yield on the same storage.
     let index = build_hnsw_index(3);
-    // SAFETY: index outlives the source (freed at end of scope).
-    let mut source = unsafe { make_source(index, 3, 3, 3) };
+    let mut source = make_source(&index, 3, 3, 3);
     let mut own = make_key();
     *source.own_key = (&mut own as *mut RLookupKey).cast();
 
@@ -528,11 +446,6 @@ fn attach_score_metric_overwrites_in_place() {
     // Assert: updated in place, not duplicated.
     assert_eq!(result.metrics.len(), 1);
     assert_eq!(result.metrics.find_by_key_mut(&own).unwrap().value(), 99.0);
-
-    drop(result);
-    drop(source);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 /// With no output key wired up (the metrics loader never ran), attaching a
@@ -541,18 +454,12 @@ fn attach_score_metric_overwrites_in_place() {
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn attach_score_metric_without_key_is_noop() {
     let index = build_hnsw_index(3);
-    // SAFETY: index outlives the source (freed at end of scope).
-    let source = unsafe { make_source(index, 3, 3, 3) };
+    let source = make_source(&index, 3, 3, 3);
     assert!(source.own_key.is_null(), "no key wired by default");
 
     let mut result = RSIndexResult::build_virt().doc_id(1).build();
     source.attach_score_metric(&mut result, 42.0);
     assert_eq!(result.metrics.len(), 0, "no key means no metric attached");
-
-    drop(result);
-    drop(source);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 /// Value the child writes under the shared key, distinct from every distance
@@ -569,8 +476,7 @@ fn trimmed_shared_key_yields(mode: TopKMode) -> Vec<(t_docId, f64, Option<f64>)>
     let index = build_hnsw_index(n);
     let lookup_key = make_key();
 
-    // SAFETY: index outlives the iterator, freed below.
-    let mut source = unsafe { make_source(index, n, k, n) };
+    let mut source = make_source(&index, n, k, n);
     *source.own_key = (&lookup_key as *const RLookupKey).cast_mut().cast();
 
     let mut child_result = RSIndexResult::build_metric(0.0).doc_id(0).build();
@@ -602,9 +508,6 @@ fn trimmed_shared_key_yields(mode: TopKMode) -> Vec<(t_docId, f64, Option<f64>)>
         emitted.push((result.doc_id, value, payload));
     }
 
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
     emitted
 }
 

--- a/src/redisearch_rs/vector_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source.rs
@@ -25,9 +25,7 @@ use index_result::{RSIndexResult, RSResultKind};
 use rqe_iterators::{ExpirationChecker, IdList, NoOpChecker, RQEIterator};
 use rqe_iterators_test_utils::MockExpirationChecker;
 use top_k::{ScoreSource, TopKIterator, TopKMode};
-use vector_score_source::test_utils::{
-    self, TestIndex, asc, collect_ids, make_child, uniform_blob,
-};
+use vector_score_source::test_utils::{TestIndex, asc, collect_ids, make_child, uniform_blob};
 use vector_score_source::{
     VectorScoreSource, new_vector_top_k_filtered, new_vector_top_k_unfiltered,
 };
@@ -36,7 +34,7 @@ const DIM: usize = 4;
 
 /// HNSW index of `n` vectors `[i; DIM]` at this suite's fixed dimensionality.
 fn build_hnsw_index(n: usize) -> TestIndex {
-    test_utils::build_hnsw_index(n, DIM)
+    TestIndex::hnsw(n, DIM)
 }
 
 /// Queries the corner `[n; DIM]` with `efRuntime = n`. `child_est` seeds the
@@ -59,14 +57,7 @@ fn make_source_with_expiration<E: ExpirationChecker>(
     child_est: usize,
     expiration: E,
 ) -> VectorScoreSource<'_, E> {
-    test_utils::make_source_with_expiration(
-        index,
-        uniform_blob(n as f32, DIM),
-        n,
-        k,
-        child_est,
-        expiration,
-    )
+    index.source_with_expiration(uniform_blob(n as f32, DIM), n, k, child_est, expiration)
 }
 
 #[test]

--- a/src/redisearch_rs/vector_score_source/tests/integration/source_pytest_parity.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source_pytest_parity.rs
@@ -24,10 +24,7 @@ use std::num::NonZeroUsize;
 use rqe_core::DocId;
 use rqe_iterators::RQEIterator;
 use top_k::{TopKIterator, TopKMode};
-use vector_score_source::test_utils::{
-    asc, build_flat_cosine_index, build_flat_index, build_hnsw_index, collect_ids, make_child,
-    make_source, uniform_blob,
-};
+use vector_score_source::test_utils::{TestIndex, asc, collect_ids, make_child, uniform_blob};
 use vector_score_source::{new_vector_top_k_filtered, new_vector_top_k_unfiltered};
 
 // FLAT backend coverage (source.rs only exercises HNSW).
@@ -37,9 +34,9 @@ use vector_score_source::{new_vector_top_k_filtered, new_vector_top_k_unfiltered
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn flat_unfiltered_returns_top_k_nearest_by_score() {
     let (n, k, dim) = (100, 10, 4);
-    let index = build_flat_index(n, dim);
+    let index = TestIndex::flat(n, dim);
 
-    let source = make_source(&index, uniform_blob(n as f32, dim), n, k, n);
+    let source = index.source(uniform_blob(n as f32, dim), n, k, n);
     let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
 
     // Streamed by score: nearest first, so id 100 (distance 0) down to 91.
@@ -52,9 +49,9 @@ fn flat_unfiltered_returns_top_k_nearest_by_score() {
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn flat_filtered_full_child_yields_best_first() {
     let (n, k, dim) = (100, 10, 4);
-    let index = build_flat_index(n, dim);
+    let index = TestIndex::flat(n, dim);
 
-    let source = make_source(&index, uniform_blob(n as f32, dim), n, k, n);
+    let source = index.source(uniform_blob(n as f32, dim), n, k, n);
     let child = make_child((1..=n as DocId).collect());
     let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap(), false);
 
@@ -70,9 +67,9 @@ fn flat_filtered_full_child_yields_best_first() {
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn cosine_metric_filtered_top_k_are_highest_ids() {
     let (n, k, dim) = (100, 10, 4);
-    let index = build_flat_cosine_index(n, dim);
+    let index = TestIndex::flat_cosine(n, dim);
 
-    let source = make_source(&index, uniform_blob(1.0, dim), n, k, n);
+    let source = index.source(uniform_blob(1.0, dim), n, k, n);
     let child = make_child((1..=n as DocId).collect());
     let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap(), false);
 
@@ -95,9 +92,9 @@ fn cosine_metric_filtered_top_k_are_highest_ids() {
 fn middle_query_orders_by_distance_then_lower_id() {
     let (n, k, dim) = (100usize, 10usize, 4usize);
     let mid = (n / 2) as DocId;
-    let index = build_flat_index(n, dim);
+    let index = TestIndex::flat(n, dim);
 
-    let source = make_source(&index, uniform_blob(mid as f32, dim), n, k, n);
+    let source = index.source(uniform_blob(mid as f32, dim), n, k, n);
     let child = make_child((1..=n as DocId).collect());
     let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap(), false);
 
@@ -117,9 +114,9 @@ fn middle_query_orders_by_distance_then_lower_id() {
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn dim1_unfiltered_knn_top3() {
     let (n, k, dim) = (10, 3, 1);
-    let index = build_flat_index(n, dim);
+    let index = TestIndex::flat(n, dim);
 
-    let source = make_source(&index, uniform_blob(0.0, dim), n, k, n);
+    let source = index.source(uniform_blob(0.0, dim), n, k, n);
     let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
 
     assert_eq!(collect_ids(&mut it), vec![1, 2, 3]);
@@ -134,10 +131,10 @@ fn dim1_unfiltered_knn_top3() {
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn dim1_filtered_subset_knn_top3() {
     let (n, k, dim) = (10, 3, 1);
-    let index = build_flat_index(n, dim);
+    let index = TestIndex::flat(n, dim);
 
     let child_ids: Vec<DocId> = (6..=10).collect();
-    let source = make_source(&index, uniform_blob(0.0, dim), n, k, child_ids.len());
+    let source = index.source(uniform_blob(0.0, dim), n, k, child_ids.len());
     let child = make_child(child_ids);
     let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap(), false);
 
@@ -153,10 +150,10 @@ fn dim1_filtered_subset_knn_top3() {
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn batches_switch_to_adhoc_yields_no_duplicates() {
     let (n, k, dim) = (10, 3, 1);
-    let index = build_flat_index(n, dim);
+    let index = TestIndex::flat(n, dim);
 
     let child_ids: Vec<DocId> = (6..=10).collect();
-    let source = make_source(&index, uniform_blob(0.0, dim), n, k, child_ids.len());
+    let source = index.source(uniform_blob(0.0, dim), n, k, child_ids.len());
     let mut it = TopKIterator::new_with_mode(
         source,
         Some(make_child(child_ids)),
@@ -182,10 +179,10 @@ fn batches_switch_to_adhoc_yields_no_duplicates() {
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn small_index_prefers_adhoc() {
     let (n, k, dim) = (1000, 10, 4);
-    let index = build_hnsw_index(n, dim);
+    let index = TestIndex::hnsw(n, dim);
 
     let subset = 31;
-    let source = make_source(&index, uniform_blob(n as f32, dim), n, k, subset);
+    let source = index.source(uniform_blob(n as f32, dim), n, k, subset);
     assert!(source.prefer_adhoc(subset, k, true));
 }
 
@@ -199,8 +196,8 @@ fn numeric_like_subset_batches_matches_adhoc() {
     let expected: Vec<DocId> = ((n as DocId - 9)..=n as DocId).rev().collect();
 
     for mode in [TopKMode::Batches, TopKMode::AdhocBF] {
-        let index = build_hnsw_index(n, dim);
-        let source = make_source(&index, uniform_blob(n as f32, dim), n, k, child_ids.len());
+        let index = TestIndex::hnsw(n, dim);
+        let source = index.source(uniform_blob(n as f32, dim), n, k, child_ids.len());
         let mut it = TopKIterator::new_with_mode(
             source,
             Some(make_child(child_ids.clone())),
@@ -220,8 +217,8 @@ fn custom_k_returns_exactly_k() {
     let dim = 4;
     let n = 100;
     for k in [2usize, 5] {
-        let index = build_hnsw_index(n, dim);
-        let source = make_source(&index, uniform_blob(n as f32, dim), n, k, n);
+        let index = TestIndex::hnsw(n, dim);
+        let source = index.source(uniform_blob(n as f32, dim), n, k, n);
         let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
 
         // Streamed by score: nearest (highest id) first.

--- a/src/redisearch_rs/vector_score_source/tests/integration/source_pytest_parity.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source_pytest_parity.rs
@@ -21,7 +21,6 @@
 
 use std::num::NonZeroUsize;
 
-use ffi::VecSimIndex_Free;
 use rqe_core::DocId;
 use rqe_iterators::RQEIterator;
 use top_k::{TopKIterator, TopKMode};
@@ -40,17 +39,12 @@ fn flat_unfiltered_returns_top_k_nearest_by_score() {
     let (n, k, dim) = (100, 10, 4);
     let index = build_flat_index(n, dim);
 
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, uniform_blob(n as f32, dim), n, k, n) };
+    let source = make_source(&index, uniform_blob(n as f32, dim), n, k, n);
     let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
 
     // Streamed by score: nearest first, so id 100 (distance 0) down to 91.
     assert_eq!(collect_ids(&mut it), (91..=100).rev().collect::<Vec<_>>());
     assert!(it.at_eof());
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 /// From `test_hybrid_query_batches_mode_with_text`: filtered KNN on FLAT.
@@ -60,16 +54,11 @@ fn flat_filtered_full_child_yields_best_first() {
     let (n, k, dim) = (100, 10, 4);
     let index = build_flat_index(n, dim);
 
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, uniform_blob(n as f32, dim), n, k, n) };
+    let source = make_source(&index, uniform_blob(n as f32, dim), n, k, n);
     let child = make_child((1..=n as DocId).collect());
     let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap(), false);
 
     assert_eq!(collect_ids(&mut it), (91..=100).rev().collect::<Vec<_>>());
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 // Metric coverage (source.rs only covers L2).
@@ -83,8 +72,7 @@ fn cosine_metric_filtered_top_k_are_highest_ids() {
     let (n, k, dim) = (100, 10, 4);
     let index = build_flat_cosine_index(n, dim);
 
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, uniform_blob(1.0, dim), n, k, n) };
+    let source = make_source(&index, uniform_blob(1.0, dim), n, k, n);
     let child = make_child((1..=n as DocId).collect());
     let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap(), false);
 
@@ -95,10 +83,6 @@ fn cosine_metric_filtered_top_k_are_highest_ids() {
         assert!(window.contains(id), "id {id} outside top-15 cosine window");
     }
     assert_eq!(ids.len(), k);
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 // Non-corner query ordering (source.rs always queries the corner [n; dim]).
@@ -113,8 +97,7 @@ fn middle_query_orders_by_distance_then_lower_id() {
     let mid = (n / 2) as DocId;
     let index = build_flat_index(n, dim);
 
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, uniform_blob(mid as f32, dim), n, k, n) };
+    let source = make_source(&index, uniform_blob(mid as f32, dim), n, k, n);
     let child = make_child((1..=n as DocId).collect());
     let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap(), false);
 
@@ -125,10 +108,6 @@ fn middle_query_orders_by_distance_then_lower_id() {
     }
     expected.push(mid - 5);
     assert_eq!(collect_ids(&mut it), expected);
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 // dim = 1 coverage (test_ft_aggregate_basic).
@@ -140,15 +119,10 @@ fn dim1_unfiltered_knn_top3() {
     let (n, k, dim) = (10, 3, 1);
     let index = build_flat_index(n, dim);
 
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, uniform_blob(0.0, dim), n, k, n) };
+    let source = make_source(&index, uniform_blob(0.0, dim), n, k, n);
     let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
 
     assert_eq!(collect_ids(&mut it), vec![1, 2, 3]);
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 /// From `test_vecsim.py::test_ft_aggregate_basic` (hybrid `(@n:[0 5])` portion):
@@ -163,16 +137,11 @@ fn dim1_filtered_subset_knn_top3() {
     let index = build_flat_index(n, dim);
 
     let child_ids: Vec<DocId> = (6..=10).collect();
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, uniform_blob(0.0, dim), n, k, child_ids.len()) };
+    let source = make_source(&index, uniform_blob(0.0, dim), n, k, child_ids.len());
     let child = make_child(child_ids);
     let mut it = new_vector_top_k_filtered(source, child, NonZeroUsize::new(k).unwrap(), false);
 
     assert_eq!(collect_ids(&mut it), vec![6, 7, 8]);
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 /// Regression: a forced Batches scan that switches to adhoc mid-run must not
@@ -187,8 +156,7 @@ fn batches_switch_to_adhoc_yields_no_duplicates() {
     let index = build_flat_index(n, dim);
 
     let child_ids: Vec<DocId> = (6..=10).collect();
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, uniform_blob(0.0, dim), n, k, child_ids.len()) };
+    let source = make_source(&index, uniform_blob(0.0, dim), n, k, child_ids.len());
     let mut it = TopKIterator::new_with_mode(
         source,
         Some(make_child(child_ids)),
@@ -204,10 +172,6 @@ fn batches_switch_to_adhoc_yields_no_duplicates() {
         "expected mid-run switch to adhoc"
     );
     assert_eq!(ids, vec![6, 7, 8]);
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 // Mode-selection heuristic (PreferAdHocSearch).
@@ -221,13 +185,8 @@ fn small_index_prefers_adhoc() {
     let index = build_hnsw_index(n, dim);
 
     let subset = 31;
-    // SAFETY: index outlives the source (freed at end of scope).
-    let source = unsafe { make_source(index, uniform_blob(n as f32, dim), n, k, subset) };
+    let source = make_source(&index, uniform_blob(n as f32, dim), n, k, subset);
     assert!(source.prefer_adhoc(subset, k, true));
-
-    drop(source);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 /// From `test_vecsim.py::test_hybrid_query_with_numeric`: a contiguous high
@@ -241,9 +200,7 @@ fn numeric_like_subset_batches_matches_adhoc() {
 
     for mode in [TopKMode::Batches, TopKMode::AdhocBF] {
         let index = build_hnsw_index(n, dim);
-        // SAFETY: index outlives the iterator (freed at end of scope).
-        let source =
-            unsafe { make_source(index, uniform_blob(n as f32, dim), n, k, child_ids.len()) };
+        let source = make_source(&index, uniform_blob(n as f32, dim), n, k, child_ids.len());
         let mut it = TopKIterator::new_with_mode(
             source,
             Some(make_child(child_ids.clone())),
@@ -253,10 +210,6 @@ fn numeric_like_subset_batches_matches_adhoc() {
         );
 
         assert_eq!(collect_ids(&mut it), expected, "mode {mode:?}");
-
-        drop(it);
-        // SAFETY: no live references to the index remain.
-        unsafe { VecSimIndex_Free(index.as_ptr()) };
     }
 }
 
@@ -268,16 +221,11 @@ fn custom_k_returns_exactly_k() {
     let n = 100;
     for k in [2usize, 5] {
         let index = build_hnsw_index(n, dim);
-        // SAFETY: index outlives the iterator (freed at end of scope).
-        let source = unsafe { make_source(index, uniform_blob(n as f32, dim), n, k, n) };
+        let source = make_source(&index, uniform_blob(n as f32, dim), n, k, n);
         let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
 
         // Streamed by score: nearest (highest id) first.
         let expected: Vec<DocId> = ((n as DocId - k as DocId + 1)..=n as DocId).rev().collect();
         assert_eq!(collect_ids(&mut it), expected, "k = {k}");
-
-        drop(it);
-        // SAFETY: no live references to the index remain.
-        unsafe { VecSimIndex_Free(index.as_ptr()) };
     }
 }

--- a/src/redisearch_rs/vector_score_source/tests/vecsim_timeout.rs
+++ b/src/redisearch_rs/vector_score_source/tests/vecsim_timeout.rs
@@ -35,9 +35,7 @@ use rqe_core::DocId;
 use rqe_iterators::{RQEIterator, RQEIteratorError};
 use top_k::{ScoreSource as _, TopKIterator, TopKMode};
 use vector_score_source::new_vector_top_k_unfiltered;
-use vector_score_source::test_utils::{
-    asc, build_hnsw_index, make_child, make_source, uniform_blob,
-};
+use vector_score_source::test_utils::{TestIndex, asc, make_child, uniform_blob};
 
 // Provide stubs for C symbols that the linked C archive references but that
 // these tests never exercise (Redis module API surface).
@@ -99,10 +97,10 @@ fn unfiltered_propagates_timeout() {
     // released after `_mock` restores the callback (reverse drop order).
     let _serial = serialize();
     let (n, k, dim) = (100, 10, 4);
-    let index = build_hnsw_index(n, dim);
+    let index = TestIndex::hnsw(n, dim);
     let _mock = MockTimeout::enable();
 
-    let source = make_source(&index, uniform_blob(n as f32, dim), n, k, n);
+    let source = index.source(uniform_blob(n as f32, dim), n, k, n);
     let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
 
     assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
@@ -116,10 +114,10 @@ fn batches_propagates_timeout() {
     // released after `_mock` restores the callback (reverse drop order).
     let _serial = serialize();
     let (n, k, dim) = (100, 10, 4);
-    let index = build_hnsw_index(n, dim);
+    let index = TestIndex::hnsw(n, dim);
     let _mock = MockTimeout::enable();
 
-    let source = make_source(&index, uniform_blob(n as f32, dim), n, k, n);
+    let source = index.source(uniform_blob(n as f32, dim), n, k, n);
     let mut it = TopKIterator::new_with_mode(
         source,
         Some(make_child((1..=n as DocId).collect())),
@@ -141,9 +139,9 @@ fn unfiltered_timeout_does_not_mark_consumed() {
     // released after `_mock` restores the callback (reverse drop order).
     let _serial = serialize();
     let (n, k, dim) = (100, 10, 4);
-    let index = build_hnsw_index(n, dim);
+    let index = TestIndex::hnsw(n, dim);
 
-    let mut source = make_source(&index, uniform_blob(n as f32, dim), n, k, n);
+    let mut source = index.source(uniform_blob(n as f32, dim), n, k, n);
 
     {
         let _mock = MockTimeout::enable();

--- a/src/redisearch_rs/vector_score_source/tests/vecsim_timeout.rs
+++ b/src/redisearch_rs/vector_score_source/tests/vecsim_timeout.rs
@@ -31,7 +31,6 @@ use std::{
     sync::{Mutex, MutexGuard, PoisonError},
 };
 
-use ffi::VecSimIndex_Free;
 use rqe_core::DocId;
 use rqe_iterators::{RQEIterator, RQEIteratorError};
 use top_k::{ScoreSource as _, TopKIterator, TopKMode};
@@ -103,15 +102,10 @@ fn unfiltered_propagates_timeout() {
     let index = build_hnsw_index(n, dim);
     let _mock = MockTimeout::enable();
 
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, uniform_blob(n as f32, dim), n, k, n) };
+    let source = make_source(&index, uniform_blob(n as f32, dim), n, k, n);
     let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
 
     assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 /// From `test_vecsim.py::TestTimeoutReached` (hybrid BATCHES branch).
@@ -125,8 +119,7 @@ fn batches_propagates_timeout() {
     let index = build_hnsw_index(n, dim);
     let _mock = MockTimeout::enable();
 
-    // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, uniform_blob(n as f32, dim), n, k, n) };
+    let source = make_source(&index, uniform_blob(n as f32, dim), n, k, n);
     let mut it = TopKIterator::new_with_mode(
         source,
         Some(make_child((1..=n as DocId).collect())),
@@ -136,10 +129,6 @@ fn batches_propagates_timeout() {
     );
 
     assert!(matches!(it.read(), Err(RQEIteratorError::TimedOut)));
-
-    drop(it);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }
 
 /// A timed-out unfiltered query must not consume the single-shot budget: the
@@ -154,8 +143,7 @@ fn unfiltered_timeout_does_not_mark_consumed() {
     let (n, k, dim) = (100, 10, 4);
     let index = build_hnsw_index(n, dim);
 
-    // SAFETY: index outlives the source (freed at end of scope).
-    let mut source = unsafe { make_source(index, uniform_blob(n as f32, dim), n, k, n) };
+    let mut source = make_source(&index, uniform_blob(n as f32, dim), n, k, n);
 
     {
         let _mock = MockTimeout::enable();
@@ -170,8 +158,4 @@ fn unfiltered_timeout_does_not_mark_consumed() {
         source.all_results_unfiltered_batch().unwrap().is_some(),
         "retry after a timed-out query must re-run it, not short-circuit to EOF"
     );
-
-    drop(source);
-    // SAFETY: no live references to the index remain.
-    unsafe { VecSimIndex_Free(index.as_ptr()) };
 }


### PR DESCRIPTION
Link `VecSimIndex_Free` to a `TestIndex` for Vecsim, removing the need to use unsafe calls over the place in tests.

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
