### PR TITLE
Share the text obfuscation wrapper

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -3530,6 +3530,7 @@ dependencies = [
  "redis-module",
  "redis_mock",
  "redisearch_rs",
+ "string_utils",
  "thiserror",
  "tracing",
  "tracing_assert",

--- a/src/redisearch_rs/string_utils/src/lib.rs
+++ b/src/redisearch_rs/string_utils/src/lib.rs
@@ -14,6 +14,7 @@
 //! guards a caller still handing bytes to one of the remaining C helpers needs.
 
 pub mod libnu;
+pub mod obfuscation;
 pub mod runes;
 pub mod tag;
 pub mod unicode;

--- a/src/redisearch_rs/string_utils/src/obfuscation.rs
+++ b/src/redisearch_rs/string_utils/src/obfuscation.rs
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Safe wrappers for C string-obfuscation helpers.
+
+use ffi::{Obfuscate_Number, Obfuscate_Text};
+use std::ffi::CStr;
+
+/// Returns a static string representation of the obfuscated number.
+pub fn obfuscate_number(number: f64) -> &'static str {
+    // SAFETY: `Obfuscate_Number` is a C function that returns a pointer to a
+    // static NUL-terminated string.
+    let obfuscated = unsafe { Obfuscate_Number(number) };
+    // SAFETY: The returned pointer is a valid, NUL-terminated, static C string.
+    unsafe { CStr::from_ptr(obfuscated) }.to_str().unwrap()
+}
+
+/// Returns a static string representation of the obfuscated text.
+pub fn obfuscate_text(text: &[u8]) -> &'static str {
+    // SAFETY: `Obfuscate_Text` expects a `*const c_char` pointer. `text` is a
+    // valid byte slice, and the function returns a pointer to a static
+    // NUL-terminated string.
+    let obfuscated = unsafe { Obfuscate_Text(text.as_ptr().cast()) };
+    // SAFETY: The returned pointer is a valid, NUL-terminated, static C string.
+    unsafe { CStr::from_ptr(obfuscated) }.to_str().unwrap()
+}

--- a/src/redisearch_rs/value/Cargo.toml
+++ b/src/redisearch_rs/value/Cargo.toml
@@ -16,6 +16,7 @@ libc.workspace = true
 query_error.workspace = true
 nul_terminated_bytes.workspace = true
 redis-module.workspace = true
+string_utils.workspace = true
 workspace_hack.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/src/redisearch_rs/value/src/debug.rs
+++ b/src/redisearch_rs/value/src/debug.rs
@@ -13,20 +13,18 @@
 //! with support for obfuscating sensitive data via C-side obfuscation functions.
 
 use crate::Value;
-use ffi::{Obfuscate_Number, Obfuscate_Text};
 use std::{
-    ffi::CStr,
     fmt::{self, Debug},
     str,
 };
+use string_utils::obfuscation::{obfuscate_number, obfuscate_text};
 
 /// A wrapper around a [`Value`] reference that implements [`Debug`] with
 /// optional obfuscation of string and numeric values.
 ///
 /// When `obfuscate` is `true`, string and numeric values are replaced with
-/// obfuscated representations using the C-side `Obfuscate_Text` and
-/// `Obfuscate_Number` functions. Composite types (arrays, maps) recursively
-/// obfuscate their elements.
+/// obfuscated representations using [`obfuscate_text`] and [`obfuscate_number`].
+/// Composite types (arrays, maps) recursively obfuscate their elements.
 pub struct DebugFormatter<'a> {
     pub(crate) value: &'a Value,
     pub(crate) obfuscate: bool,
@@ -78,23 +76,4 @@ impl<'a> Debug for DebugFormatter<'a> {
             Value::Trio(trio) => trio.left().debug_formatter(self.obfuscate).fmt(f),
         }
     }
-}
-
-/// Returns a static string representation of the obfuscated number.
-fn obfuscate_number(number: f64) -> &'static str {
-    // SAFETY: `Obfuscate_Number` is a C function that returns a pointer to a
-    // static null-terminated string.
-    let obfuscated = unsafe { Obfuscate_Number(number) };
-    // SAFETY: The returned pointer is a valid, null-terminated, static C string.
-    unsafe { CStr::from_ptr(obfuscated) }.to_str().unwrap()
-}
-
-/// Returns a static string representation of the obfuscated text.
-fn obfuscate_text(text: &[u8]) -> &'static str {
-    // SAFETY: `Obfuscate_Text` expects a `*const c_char` pointer. `text` is a
-    // valid byte slice, and the function returns a pointer to a static
-    // null-terminated string.
-    let obfuscated = unsafe { Obfuscate_Text(text.as_ptr().cast()) };
-    // SAFETY: The returned pointer is a valid, null-terminated, static C string.
-    unsafe { CStr::from_ptr(obfuscated) }.to_str().unwrap()
 }


### PR DESCRIPTION
## Describe the changes in the pull request

Share the text obfuscation wrappers in `value::debug` to `string_utils`. Needed in the upcoming Rust Fork GC terms scanner. Internal only.

#### Which additional issues this PR fixes

1. N/A

#### Main objects this PR modified

1. `string_utils::obfuscation` — shared text-obfuscation boundary
2. Value debug formatting — reuse of the shared wrapper

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
