### PR TITLE
Add display names to IndexSpec

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1096,6 +1096,7 @@ dependencies = [
  "document",
  "ffi",
  "field_spec",
+ "hidden_string",
  "inverted_index",
  "pretty_assertions",
  "redis_mock",

--- a/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
@@ -58,12 +58,13 @@ impl HiddenString {
         let data = unsafe { ffi::HiddenString_GetUnsafe(self.as_ptr(), &mut len) };
         debug_assert!(!data.is_null(), "data must not be null");
 
-        // The length doesn't include the nul terminator so we need to add one.
+        // The length doesn't include the NUL terminator so we need to add one.
         let n = len.checked_add(1).expect("length overflow");
         // Safety: must be ensured by the implementation of `ffi::HiddenString_GetUnsafe` above.
         let bytes = unsafe { core::slice::from_raw_parts(data.cast::<u8>(), n) };
 
-        CStr::from_bytes_with_nul(bytes).expect("malformed C string")
+        // Do explicit truncation here in the rare case the string contains interior NUL bytes.
+        CStr::from_bytes_until_nul(bytes).expect("malformed C string")
     }
 }
 

--- a/src/redisearch_rs/c_wrappers/hidden_string/tests/tests.rs
+++ b/src/redisearch_rs/c_wrappers/hidden_string/tests/tests.rs
@@ -52,6 +52,27 @@ fn get_secret_value() {
     miri,
     ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
 )]
+fn secret_value_truncates_at_interior_nul() {
+    let input = b"idx\0tail\0";
+    // SAFETY: `input` remains live and readable for the provided byte length;
+    // `takeOwnership = false` leaves ownership of the backing buffer with this test.
+    let ffi_hs = unsafe { ffi::NewHiddenString(input.as_ptr().cast(), input.len() - 1, false) };
+    // SAFETY: `ffi_hs` is the non-null, initialized wrapper created above and
+    // neither it nor its backing buffer is mutated while `sut` is used.
+    let sut = unsafe { HiddenString::from_raw(ffi_hs) };
+
+    assert_eq!(sut.secret_value(), c"idx");
+
+    // SAFETY: `ffi_hs` is still the live wrapper created above and is freed
+    // exactly once; `false` matches its non-owning construction.
+    unsafe { ffi::HiddenString_Free(ffi_hs, false) };
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
 fn debug_output() {
     let input = c"Ab#123!";
     let ffi_hs = unsafe { ffi::NewHiddenString(input.as_ptr(), input.count_bytes(), false) };

--- a/src/redisearch_rs/c_wrappers/index_spec/Cargo.toml
+++ b/src/redisearch_rs/c_wrappers/index_spec/Cargo.toml
@@ -13,6 +13,7 @@ c_trie.workspace = true
 dict.workspace = true
 ffi.workspace = true
 field_spec.workspace = true
+hidden_string.workspace = true
 inverted_index.workspace = true
 rqe_core.workspace = true
 schema_rule.workspace = true

--- a/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/src/lib.rs
@@ -10,7 +10,7 @@
 //! Safe wrapper around [`ffi::IndexSpec`].
 
 use std::{
-    ffi::c_char,
+    ffi::{CStr, c_char},
     ops::Deref,
     ptr,
     ptr::NonNull,
@@ -21,6 +21,7 @@ use std::{
 use c_trie::{SuffixTrie, TermsTrie};
 use dict::{Dict, MissingFieldDictType};
 use field_spec::FieldSpec;
+use hidden_string::HiddenString;
 use inverted_index::opaque::InvertedIndex;
 use schema_rule::SchemaRule;
 
@@ -70,6 +71,19 @@ impl IndexSpec {
         let data = self.0.fields.cast::<FieldSpec>();
         // Safety: (1.) due to creation with `IndexSpec::from_raw`
         unsafe { slice::from_raw_parts(data, len) }
+    }
+
+    /// Return the original or obfuscated index name.
+    pub fn display_name(&self, obfuscate: bool) -> &CStr {
+        if obfuscate {
+            // SAFETY: every initialized spec owns a NUL-terminated `obfuscatedName`
+            // that remains immutable for its full lifetime.
+            unsafe { CStr::from_ptr(self.0.obfuscatedName) }
+        } else {
+            // SAFETY: every initialized spec owns an initialized `specName`
+            // whose backing buffer remains immutable for its full lifetime.
+            unsafe { HiddenString::from_raw(self.0.specName) }.secret_value()
+        }
     }
 
     /// Acquire the write lock for this `IndexSpec`. This is required before performing any
@@ -282,6 +296,16 @@ impl<'lock> IndexSpecWriteGuard<'lock> {
         self.0.stats.numRecords -= entries_removed;
         self.0.stats.invertedSize += bytes_allocated;
         self.0.stats.invertedSize -= bytes_freed;
+    }
+}
+
+impl Deref for IndexSpecWriteGuard<'_> {
+    type Target = IndexSpec;
+
+    fn deref(&self) -> &IndexSpec {
+        // SAFETY: `IndexSpec` is transparent over `ffi::IndexSpec`, and the guard's
+        // borrow keeps the spec valid for the returned shared borrow.
+        unsafe { IndexSpec::from_raw(self.0) }
     }
 }
 

--- a/src/redisearch_rs/c_wrappers/index_spec/tests/tests.rs
+++ b/src/redisearch_rs/c_wrappers/index_spec/tests/tests.rs
@@ -63,6 +63,34 @@ fn rule() {
     assert_eq!(rule.type_(), document::DocumentType::Json);
 }
 
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
+fn display_name_truncates_at_interior_nul() {
+    let original = b"idx\0tail\0";
+    let obfuscated = c"Index@123";
+    // SAFETY: a zeroed `ffi::IndexSpec` is valid for this test setup, which
+    // initializes every field subsequently accessed through `IndexSpec`.
+    let mut index_spec = unsafe { mem::zeroed::<ffi::IndexSpec>() };
+    // SAFETY: `original` remains live and readable for the provided byte
+    // length; `takeOwnership = false` leaves its backing buffer with this test.
+    index_spec.specName =
+        unsafe { ffi::NewHiddenString(original.as_ptr().cast(), original.len() - 1, false) };
+    index_spec.obfuscatedName = obfuscated.as_ptr().cast_mut();
+    // SAFETY: `index_spec` and the fields read by `display_name` are initialized
+    // and remain live and immutable while `sut` is used.
+    let sut = unsafe { IndexSpec::from_raw(ptr::from_ref(&index_spec)) };
+
+    assert_eq!(sut.display_name(false), c"idx");
+    assert_eq!(sut.display_name(true), obfuscated);
+
+    // SAFETY: `specName` is still the live wrapper allocated above and is freed
+    // exactly once; `false` matches its non-owning construction.
+    unsafe { ffi::HiddenString_Free(index_spec.specName, false) };
+}
+
 fn field_spec(field_name: &CStr, field_path: &CStr, index: u16) -> ffi::FieldSpec {
     let mut res = unsafe { mem::zeroed::<ffi::FieldSpec>() };
     res.fieldName =


### PR DESCRIPTION
## Describe the changes in the pull request

Add `display_name` to `IndexSpec`. Needed by logging in upcoming Rust terms scanner. Internal only.

#### Which additional issues this PR fixes

1. N/A

#### Main objects this PR modified

1. `IndexSpec` — original or obfuscated display-name access
2. `IndexSpecWriteGuard` — shared access to the guarded index specification
3. `HiddenString` integration — safe access to the original index name

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
