### PR TITLE
[MOD-14988] Add has_field_expiration setter to index result builders

### DIFF
--- a/src/redisearch_rs/index_result/src/core/mod.rs
+++ b/src/redisearch_rs/index_result/src/core/mod.rs
@@ -34,6 +34,7 @@ pub struct RawIndexResultBuilder<'query, R: Ref> {
     freq: u32,
     data: RawResultData<'query, R>,
     weight: f64,
+    has_field_expiration: bool,
 }
 
 /// Specialized builder for creating [`RawIndexResult`] instances of the
@@ -48,6 +49,7 @@ pub struct RawTermResultBuilder<'query, R: Ref> {
     freq: u32,
     weight: f64,
     record: TermBuilderRecord<'query, R>,
+    has_field_expiration: bool,
 }
 
 /// Internal enum holding the term record data for the builder.
@@ -91,6 +93,12 @@ impl<'query, R: Ref> RawIndexResultBuilder<'query, R> {
         self
     }
 
+    /// Set [`RawIndexResult::has_field_expiration`] for this record
+    pub const fn has_field_expiration(mut self, has_field_expiration: bool) -> Self {
+        self.has_field_expiration = has_field_expiration;
+        self
+    }
+
     /// Create a builder for a virtual index result
     const fn virt() -> Self {
         Self {
@@ -99,6 +107,7 @@ impl<'query, R: Ref> RawIndexResultBuilder<'query, R> {
             freq: 0,
             data: RawResultData::Virtual,
             weight: 0.0,
+            has_field_expiration: false,
         }
     }
 
@@ -110,6 +119,7 @@ impl<'query, R: Ref> RawIndexResultBuilder<'query, R> {
             freq: 1,
             data: RawResultData::Numeric(num),
             weight: 1.0,
+            has_field_expiration: false,
         }
     }
 
@@ -121,6 +131,7 @@ impl<'query, R: Ref> RawIndexResultBuilder<'query, R> {
             freq: 0,
             data: RawResultData::Metric(num),
             weight: 1.0,
+            has_field_expiration: false,
         }
     }
 
@@ -132,6 +143,7 @@ impl<'query, R: Ref> RawIndexResultBuilder<'query, R> {
             freq: 0,
             data: RawResultData::Intersection(RawAggregateResult::borrowed_with_capacity(cap)),
             weight: 0.0,
+            has_field_expiration: false,
         }
     }
 
@@ -143,6 +155,7 @@ impl<'query, R: Ref> RawIndexResultBuilder<'query, R> {
             freq: 0,
             data: RawResultData::Union(RawAggregateResult::borrowed_with_capacity(cap)),
             weight: 0.0,
+            has_field_expiration: false,
         }
     }
 
@@ -154,6 +167,7 @@ impl<'query, R: Ref> RawIndexResultBuilder<'query, R> {
             freq: 0,
             data: RawResultData::HybridMetric(RawAggregateResult::owned_with_capacity(2)),
             weight: 1.0,
+            has_field_expiration: false,
         }
     }
 
@@ -168,7 +182,7 @@ impl<'query, R: Ref> RawIndexResultBuilder<'query, R> {
             data: self.data,
             metrics: MetricsVec::new(),
             weight: self.weight,
-            has_field_expiration: false,
+            has_field_expiration: self.has_field_expiration,
         }
     }
 }
@@ -185,6 +199,7 @@ impl<'query, R: Ref> RawTermResultBuilder<'query, R> {
                 term: None,
                 offsets: RawOffsetSlice::empty(),
             },
+            has_field_expiration: false,
         }
     }
 
@@ -209,6 +224,12 @@ impl<'query, R: Ref> RawTermResultBuilder<'query, R> {
     /// Set the frequency of this record
     pub const fn frequency(mut self, frequency: u32) -> Self {
         self.freq = frequency;
+        self
+    }
+
+    /// Set [`RawIndexResult::has_field_expiration`] for this record
+    pub const fn has_field_expiration(mut self, has_field_expiration: bool) -> Self {
+        self.has_field_expiration = has_field_expiration;
         self
     }
 
@@ -279,7 +300,7 @@ impl<'query, R: Ref> RawTermResultBuilder<'query, R> {
             data,
             metrics: MetricsVec::new(),
             weight: self.weight,
-            has_field_expiration: false,
+            has_field_expiration: self.has_field_expiration,
         }
     }
 }

--- a/src/redisearch_rs/inverted_index/src/tests/expiration_bit.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/expiration_bit.rs
@@ -48,17 +48,15 @@ fn block_bitset_set_and_get() {
 fn assert_sequential_roundtrip<E: crate::Encoder + crate::Decoder>(
     flags: ffi::IndexFlags,
     entries: &[(DocId, bool)],
-    build: impl Fn(DocId) -> RSIndexResult<'static>,
+    build: impl Fn(DocId, bool) -> RSIndexResult<'static>,
 ) {
     let mut ii = InvertedIndex::<E>::new(flags);
     for &(doc_id, has_exp) in entries {
-        let mut rec = build(doc_id);
-        rec.has_field_expiration = has_exp;
-        ii.add_record(&rec).unwrap();
+        ii.add_record(&build(doc_id, has_exp)).unwrap();
     }
 
     let mut reader = ii.reader();
-    let mut result = build(0);
+    let mut result = build(0, false);
     for &(doc_id, has_exp) in entries {
         assert!(reader.next_record(&mut result).unwrap());
         assert_eq!(result.doc_id, doc_id);
@@ -75,7 +73,12 @@ fn doc_ids_only_roundtrips_expiration_bit() {
     assert_sequential_roundtrip::<DocIdsOnly>(
         IndexFlags_Index_DocIdsOnly,
         &[(10, false), (11, true), (20, false), (21, true), (22, true)],
-        |doc_id| RSIndexResult::build_virt().doc_id(doc_id).build(),
+        |doc_id, has_exp| {
+            RSIndexResult::build_virt()
+                .doc_id(doc_id)
+                .has_field_expiration(has_exp)
+                .build()
+        },
     );
 }
 
@@ -84,10 +87,11 @@ fn fields_only_roundtrips_expiration_bit() {
     assert_sequential_roundtrip::<FieldsOnly>(
         IndexFlags_Index_StoreFieldFlags,
         &[(5, true), (6, false), (100, true), (101, false)],
-        |doc_id| {
+        |doc_id, has_exp| {
             RSIndexResult::build_term()
                 .doc_id(doc_id)
                 .field_mask(0b1)
+                .has_field_expiration(has_exp)
                 .build()
         },
     );
@@ -98,7 +102,12 @@ fn numeric_roundtrips_expiration_bit() {
     assert_sequential_roundtrip::<Numeric>(
         IndexFlags_Index_StoreNumeric,
         &[(1, false), (2, true), (3, true), (50, false)],
-        |doc_id| RSIndexResult::build_numeric(1.5).doc_id(doc_id).build(),
+        |doc_id, has_exp| {
+            RSIndexResult::build_numeric(1.5)
+                .doc_id(doc_id)
+                .has_field_expiration(has_exp)
+                .build()
+        },
     );
 }
 
@@ -114,14 +123,23 @@ fn raw_doc_ids_only_roundtrips_and_seeks_with_expiration_bit() {
         (21, true),
         (30, false),
     ];
-    assert_sequential_roundtrip::<RawDocIdsOnly>(IndexFlags_Index_DocIdsOnly, entries, |doc_id| {
-        RSIndexResult::build_virt().doc_id(doc_id).build()
-    });
+    assert_sequential_roundtrip::<RawDocIdsOnly>(
+        IndexFlags_Index_DocIdsOnly,
+        entries,
+        |doc_id, has_exp| {
+            RSIndexResult::build_virt()
+                .doc_id(doc_id)
+                .has_field_expiration(has_exp)
+                .build()
+        },
+    );
 
     let mut ii = InvertedIndex::<RawDocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
     for &(doc_id, has_exp) in entries {
-        let mut rec = RSIndexResult::build_virt().doc_id(doc_id).build();
-        rec.has_field_expiration = has_exp;
+        let rec = RSIndexResult::build_virt()
+            .doc_id(doc_id)
+            .has_field_expiration(has_exp)
+            .build();
         ii.add_record(&rec).unwrap();
     }
     for &(target, expected_doc, expected_exp) in &[
@@ -156,11 +174,11 @@ fn expiration_bit_survives_block_split_on_delta_overflow() {
     .unwrap();
 
     let big_doc_id: DocId = (1u64 << 32) + 5;
-    let mut second = RSIndexResult::build_term()
+    let second = RSIndexResult::build_term()
         .doc_id(big_doc_id)
         .field_mask(0b1)
+        .has_field_expiration(true)
         .build();
-    second.has_field_expiration = true;
     ii.add_record(&second).unwrap();
 
     let mut reader = ii.reader();
@@ -192,8 +210,10 @@ fn expiration_bit_survives_gc() {
         (15, false),
     ];
     for &(doc_id, has_exp) in entries {
-        let mut rec = RSIndexResult::build_virt().doc_id(doc_id).build();
-        rec.has_field_expiration = has_exp;
+        let rec = RSIndexResult::build_virt()
+            .doc_id(doc_id)
+            .has_field_expiration(has_exp)
+            .build();
         ii.add_record(&rec).unwrap();
     }
 

--- a/src/redisearch_rs/inverted_index/src/tests/index.rs
+++ b/src/redisearch_rs/inverted_index/src/tests/index.rs
@@ -657,8 +657,10 @@ fn add_prepared_record_matches_add_record() {
         let doc_id = i as DocId + 1;
 
         let has_field_expiration = i % 2 == 0;
-        let mut record = RSIndexResult::build_numeric(*value).doc_id(doc_id).build();
-        record.has_field_expiration = has_field_expiration;
+        let record = RSIndexResult::build_numeric(*value)
+            .doc_id(doc_id)
+            .has_field_expiration(has_field_expiration)
+            .build();
         let record_outcome = from_records.add_record(&record).unwrap();
         let prepared_outcome = from_prepared
             .add_prepared_record(doc_id, Numeric::prepare(*value), has_field_expiration)

--- a/src/redisearch_rs/inverted_index/tests/integration/index_result.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/index_result.rs
@@ -466,3 +466,44 @@ fn set_offsets_owned_on_borrowed_panics() {
         .unwrap()
         .set_offsets_owned(RSOffsetVector::empty());
 }
+
+/// Nearly every `build_*` call site omits `has_field_expiration` and relies on
+/// the flag being clear, so the default is pinned here for all result kinds.
+#[test]
+fn has_field_expiration_defaults_to_false() {
+    let defaults = [
+        RSIndexResult::build_virt().build(),
+        RSIndexResult::build_numeric(10.0).build(),
+        RSIndexResult::build_metric(10.0).build(),
+        RSIndexResult::build_intersect(1).build(),
+        RSIndexResult::build_union(1).build(),
+        RSIndexResult::build_hybrid_metric().build(),
+        RSIndexResult::build_term().build(),
+    ];
+
+    for result in &defaults {
+        assert!(
+            !result.has_field_expiration,
+            "{:?} must not opt into field-expiration checks by default",
+            result.kind()
+        );
+    }
+}
+
+/// Both builders — the generic one and the term-specific one — must carry the
+/// flag through to the built result.
+#[test]
+fn has_field_expiration_setter() {
+    assert!(
+        RSIndexResult::build_virt()
+            .has_field_expiration(true)
+            .build()
+            .has_field_expiration
+    );
+    assert!(
+        RSIndexResult::build_term()
+            .has_field_expiration(true)
+            .build()
+            .has_field_expiration
+    );
+}

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/range.rs
@@ -300,8 +300,10 @@ fn test_numeric_index_write_paths_agree(#[values(false, true)] compress_floats: 
     for (i, value) in values.iter().enumerate() {
         let doc_id = i as u64 + 1;
         let has_field_expiration = i % 2 == 0;
-        let mut record = RSIndexResult::build_numeric(*value).doc_id(doc_id).build();
-        record.has_field_expiration = has_field_expiration;
+        let record = RSIndexResult::build_numeric(*value)
+            .doc_id(doc_id)
+            .has_field_expiration(has_field_expiration)
+            .build();
 
         let record_outcome = from_records.add_record(&record);
         let prepared_outcome = from_prepared.add_prepared_record(


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `RawIndexResultBuilder` and `RawTermResultBuilder` hard-coded
   `has_field_expiration` to `false` in `build()`, so any caller that needed
   the flag set had to build the result and then mutate the public field
   afterward.
2. Change: Add a `has_field_expiration()` setter to both builders, symmetric
   with the existing `doc_id`/`field_mask`/`weight`/`frequency` setters, and
   thread it through to `build()`. Update tests that previously mutated
   `has_field_expiration` post-build to use the setter instead, and add
   coverage for the default value and the new setter.
3. Outcome: Internal-only cleanup — no user-facing behavior change. Callers
   no longer need to mutate a field on an already-built result.

#### Which additional issues this PR fixes

1. MOD-14988

#### Main objects this PR modified

1. `RawIndexResultBuilder` / `RawTermResultBuilder`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
