### PR TITLE
build: fix nightly rust-tests by compiling bench C shims with the module's defines

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1572,7 +1572,6 @@ name = "numeric_score_source_bencher"
 version = "0.0.1"
 dependencies = [
  "build_utils",
- "cc",
  "criterion",
  "ffi",
  "index_result",
@@ -3619,7 +3618,6 @@ name = "vector_score_source_bencher"
 version = "0.0.1"
 dependencies = [
  "build_utils",
- "cc",
  "criterion",
  "ffi",
  "redis_mock",

--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -61,6 +61,87 @@ pub fn rerun_if_c_changes(dir: &Path) -> std::io::Result<()> {
     rerun_if_changes(dir, &["c", "h"])
 }
 
+/// Include roots every Rust-side consumer of the RediSearch C headers needs.
+///
+/// Ordering is load-bearing: `src` must precede `src/redisearch_rs/headers`,
+/// which holds generated counterparts of `rlookup.h` and `ttl_table.h`. Swapping
+/// the two silently binds against the generated header instead of the C original.
+/// They are the only colliding header basenames across these roots.
+fn c_include_roots(root: &Path) -> Vec<PathBuf> {
+    vec![
+        root.join("src"),
+        root.join("deps"),
+        root.join("src").join("redisearch_rs").join("headers"),
+        root.join("deps").join("VectorSimilarity").join("src"),
+        root.join("src").join("buffer"),
+        root.join("src").join("ttl_table"),
+    ]
+}
+
+/// Compile a benchmark shim written in C against the RediSearch headers.
+///
+/// Bench crates use a small C shim to drive a production C iterator as the
+/// baseline for its Rust counterpart. Every such shim needs the same include
+/// roots, the same preprocessor defines, and the same warning suppressions, so
+/// they are centralised here: a shim that configures its own [`cc::Build`] from
+/// scratch silently drifts from how CMake compiles the very headers it includes.
+///
+/// `shim` is the path to the C file, relative to the calling crate's manifest
+/// directory. The compiled archive is named after the shim's file stem, and a
+/// `rerun-if-changed` is emitted for it.
+///
+/// # Defines
+///
+/// `_GNU_SOURCE` is required, for the same reason the bindgen path in
+/// `ffi/build.rs` passes it: shims are compiled without `REDIS_MODULE_TARGET`, so
+/// `deps/rmalloc/rmalloc.h` takes its non-module fallback and expands
+/// `rm_asprintf` to bare `asprintf` — which glibc's `<stdio.h>` only declares
+/// under `_GNU_SOURCE`, and the top-level `CMakeLists.txt` promotes implicit
+/// declarations to errors.
+///
+/// `REDIS_MODULE_TARGET` is deliberately *not* set. It would route `rm_malloc`
+/// through `RedisModule_Alloc`, but CMake defines it only when
+/// `USE_REDIS_ALLOCATOR` is on, so forcing it here could disagree with how
+/// `libredisearch_c_bundle.a` was actually built. No shim calls `rm_*` today —
+/// they use `RedisModule_Alloc` directly where the module owns the buffer.
+///
+/// # Panics
+///
+/// Panics if the repository root cannot be located, or if `shim` has no file stem.
+pub fn compile_c_bench_shim(shim: &str) {
+    let root = repository_root().expect("Could not find repository root");
+
+    // Beyond the shared roots, shims reach the iterator API, `rmalloc.h` and the
+    // trie headers directly. Appended, so they cannot shadow a shared root.
+    let mut includes = c_include_roots(&root);
+    includes.extend([
+        root.join("src").join("iterators"),
+        root.join("deps").join("rmalloc"),
+        root.join("src").join("trie"),
+    ]);
+
+    let lib_name = Path::new(shim)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or_else(|| panic!("bench shim path has no file stem: {shim}"));
+
+    cc::Build::new()
+        .file(shim)
+        .define("_GNU_SOURCE", None)
+        // Silence warnings originating from transitively-included RediSearch
+        // headers (static helpers, sign-compare in inline funcs, etc.) — they
+        // are not actionable from a shim and the main CMake build already
+        // suppresses them.
+        .flag_if_supported("-Wno-unused-function")
+        .flag_if_supported("-Wno-unused-variable")
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-sign-compare")
+        .includes(includes)
+        .compile(lib_name);
+
+    println!("cargo:rerun-if-changed={shim}");
+}
+
 /// Link all the relevant C dependencies to allow Rust (testing and benchmarking) code to invoke
 /// RediSearch C symbols.
 ///
@@ -218,15 +299,7 @@ pub fn generate_c_bindings(
     let root =
         repository_root().expect("Could not find repository root for static library linking");
 
-    let includes = vec![
-        root.join("deps").join("RedisModulesSDK"),
-        root.join("src"),
-        root.join("deps"),
-        root.join("src").join("redisearch_rs").join("headers"),
-        root.join("deps").join("VectorSimilarity").join("src"),
-        root.join("src").join("buffer"),
-        root.join("src").join("ttl_table"),
-    ];
+    let includes = c_include_roots(&root);
 
     let headers = headers
         .into_iter()

--- a/src/redisearch_rs/numeric_score_source_bencher/Cargo.toml
+++ b/src/redisearch_rs/numeric_score_source_bencher/Cargo.toml
@@ -19,7 +19,6 @@ harness = false
 
 [build-dependencies]
 build_utils = { path = "../build_utils" }
-cc.workspace = true
 
 [dependencies]
 criterion.workspace = true

--- a/src/redisearch_rs/numeric_score_source_bencher/build.rs
+++ b/src/redisearch_rs/numeric_score_source_bencher/build.rs
@@ -10,42 +10,9 @@
 fn main() {
     // Emit optimizer_shim before redisearch_c_bundle: static archives resolve
     // left-to-right, and the shim's symbols are defined in libredisearch_c_bundle.a.
-    compile_optimizer_shim();
+    //
+    // Drives the real C OptimizerIterator from libredisearch_c_bundle.a, as a
+    // faithful counterpart to the Rust NumericTopKIterator.
+    build_utils::compile_c_bench_shim("benches/optimizer_shim.c");
     build_utils::bind_foreign_c_symbols();
-}
-
-fn compile_optimizer_shim() {
-    use build_utils::repository_root;
-
-    let root = repository_root().expect("Could not find repository root");
-    let src = root.join("src");
-    let deps = root.join("deps");
-
-    cc::Build::new()
-        // Drives the real C OptimizerIterator from libredisearch_c_bundle.a, as a
-        // faithful counterpart to the Rust NumericTopKIterator.
-        .file("benches/optimizer_shim.c")
-        // Silence warnings originating from transitively-included RediSearch
-        // headers (static helpers, sign-compare in inline funcs, etc.) — they
-        // are not actionable from this shim and the main CMake build already
-        // suppresses them.
-        .flag_if_supported("-Wno-unused-function")
-        .flag_if_supported("-Wno-unused-variable")
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-sign-compare")
-        .include(&src)
-        // `deps` (rmutil/*) and RedisModulesSDK (redismodule.h) are pulled in
-        // transitively by spec.h / search_ctx.h for the optimizer shim.
-        .include(&deps)
-        .include(deps.join("RedisModulesSDK"))
-        .include(src.join("iterators"))
-        .include(deps.join("VectorSimilarity").join("src"))
-        .include(deps.join("rmalloc"))
-        .include(src.join("redisearch_rs").join("headers"))
-        .include(src.join("buffer"))
-        .include(src.join("ttl_table"))
-        .include(src.join("trie"))
-        .compile("optimizer_shim");
-
-    println!("cargo:rerun-if-changed=benches/optimizer_shim.c");
 }

--- a/src/redisearch_rs/vector_score_source_bencher/Cargo.toml
+++ b/src/redisearch_rs/vector_score_source_bencher/Cargo.toml
@@ -19,7 +19,6 @@ harness = false
 
 [build-dependencies]
 build_utils = { path = "../build_utils" }
-cc.workspace = true
 
 [dependencies]
 criterion.workspace = true

--- a/src/redisearch_rs/vector_score_source_bencher/build.rs
+++ b/src/redisearch_rs/vector_score_source_bencher/build.rs
@@ -10,42 +10,9 @@
 fn main() {
     // Emit hybrid_shim before redisearch_c_bundle: static archives resolve
     // left-to-right, and the shim's symbols are defined in libredisearch_c_bundle.a.
-    compile_hybrid_shim();
+    //
+    // Drives the real C HybridIterator from libredisearch_c_bundle.a, as a
+    // faithful counterpart to the Rust VectorTopKIterator.
+    build_utils::compile_c_bench_shim("benches/hybrid_shim.c");
     build_utils::bind_foreign_c_symbols();
-}
-
-fn compile_hybrid_shim() {
-    use build_utils::repository_root;
-
-    let root = repository_root().expect("Could not find repository root");
-    let src = root.join("src");
-    let deps = root.join("deps");
-
-    cc::Build::new()
-        // Drives the real C HybridIterator from libredisearch_c_bundle.a, as a
-        // faithful counterpart to the Rust VectorTopKIterator.
-        .file("benches/hybrid_shim.c")
-        // Silence warnings originating from transitively-included RediSearch
-        // headers (static helpers, sign-compare in inline funcs, etc.) — they
-        // are not actionable from this shim and the main CMake build already
-        // suppresses them.
-        .flag_if_supported("-Wno-unused-function")
-        .flag_if_supported("-Wno-unused-variable")
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-sign-compare")
-        .include(&src)
-        // `deps` (rmutil/*) and RedisModulesSDK (redismodule.h) are pulled in
-        // transitively by spec.h / search_ctx.h for the hybrid shim.
-        .include(&deps)
-        .include(deps.join("RedisModulesSDK"))
-        .include(src.join("iterators"))
-        .include(deps.join("VectorSimilarity").join("src"))
-        .include(deps.join("rmalloc"))
-        .include(src.join("redisearch_rs").join("headers"))
-        .include(src.join("buffer"))
-        .include(src.join("ttl_table"))
-        .include(src.join("trie"))
-        .compile("hybrid_shim");
-
-    println!("cargo:rerun-if-changed=benches/hybrid_shim.c");
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** Nightly `make rust-tests` has failed on all 10 `test-all-platforms` jobs since #10724 landed. `optimizer_shim.c` transitively includes `aggregate/reducer.h`, and its `cc::Build` set neither `REDIS_MODULE_TARGET` nor `_GNU_SOURCE`, so `rmalloc.h` took its non-module fallback and expanded `rm_asprintf` to bare `asprintf` — undeclared on glibc without `_GNU_SOURCE`, and the root `CMakeLists.txt` makes implicit declarations an error.
2. **Change:** Bench C shims are now compiled through one `build_utils::compile_c_bench_shim` helper that sets those two defines alongside the include roots and warning suppressions, matching how CMake compiles the same headers.
3. **Outcome:** Internal-only — no user-visible change. Unblocks the nightly matrix, which is red on master right now, and removes the drifted copy of this setup in the second bench crate.

#### Which additional issues this PR fixes

N/A — regression from #10724, no ticket filed. Same bug class as #9210 / #9211, which added `-D_GNU_SOURCE` to `ffi/build.rs` for this exact reason.

#### Main objects this PR modified

1. `build_utils` — new `compile_c_bench_shim`, owning the shim include roots, defines and warning flags.
2. `numeric_score_source_bencher` — `optimizer_shim.c` now builds; this is the shim that was breaking the nightly.
3. `vector_score_source_bencher` — same helper; it shared the missing defines and only escaped the error because `hybrid_shim.c` never reaches `reducer.h`.
4. Both bench manifests — dropped the now-unused `cc` build-dependency.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

---

Worth a reviewer's attention: `REDIS_MODULE_TARGET` is the define that actually removes the `asprintf` reference (`rm_asprintf` resolves to the static inline instead of the macro), and it also aligns each shim's allocator with the `libredisearch_c_bundle.a` it links against. Both shims already call `RedisModule_Alloc` directly, so the module allocator is live in the bench process either way. `_GNU_SOURCE` is kept because `rmalloc.h`'s fallback path still needs it.

Verified locally that both shims compile clean under `-Werror=implicit-function-declaration` with the new defines, and that the `rm_asprintf` call site no longer expands to bare `asprintf`. The original error is glibc-specific, so it does not reproduce on macOS; the nightly matrix is the real check.
