### PR TITLE
index_result: give each aggregate-result variant its own type

### DIFF
--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -427,9 +427,16 @@ pub unsafe extern "C" fn AggregateResult_GetMutUnchecked<'result, 'index>(
     // an `RSAggregateResult`.
     let agg = unsafe { &mut *agg };
 
-    // SAFETY:
-    // 1. Guaranteed by the caller thanks to safety preconditions 1 and 2.
-    // 2. Guaranteed by the caller thanks to safety precondition 3.
+    let Some(agg) = agg.as_owned_mut() else {
+        debug_assert!(
+            false,
+            "Safety violation: trying to get a mutable reference from a borrowed aggregate result"
+        );
+        // SAFETY: Thanks to safety precondition 3., we'll never reach this statement.
+        unsafe { std::hint::unreachable_unchecked() }
+    };
+
+    // SAFETY: Guaranteed by the caller thanks to safety preconditions 1 and 2.
     unsafe { agg.get_mut_unchecked(index) }
 }
 
@@ -501,9 +508,9 @@ pub extern "C" fn AggregateResult_New(cap: usize) -> RSAggregateResult<'static> 
 #[unsafe(no_mangle)]
 pub extern "C" fn AggregateResult_Free(agg: RSAggregateResult) {
     match agg {
-        RSAggregateResult::Borrowed { .. } => {}
-        RSAggregateResult::Owned { records, .. } => {
-            for record in records.into_iter() {
+        RSAggregateResult::Borrowed(_) => {}
+        RSAggregateResult::Owned(agg) => {
+            for record in agg.into_records() {
                 // C still manages this memory so don't free the heap pointers
                 std::mem::forget(record);
             }
@@ -566,13 +573,13 @@ pub unsafe extern "C" fn AggregateResult_GetRecordsSlice(
     // an `RSAggregateResult`.
     let agg = unsafe { &*agg };
     match agg {
-        RSAggregateResult::Borrowed { records, .. } => AggregateRecordsSlice {
-            ptr: records.as_slice().as_ptr() as *const *const RSIndexResult,
-            len: records.len(),
+        RSAggregateResult::Borrowed(agg) => AggregateRecordsSlice {
+            ptr: agg.records().as_ptr() as *const *const RSIndexResult,
+            len: agg.len(),
         },
-        RSAggregateResult::Owned { records, .. } => AggregateRecordsSlice {
-            ptr: records.as_slice().as_ptr() as *const *const RSIndexResult,
-            len: records.len(),
+        RSAggregateResult::Owned(agg) => AggregateRecordsSlice {
+            ptr: agg.records().as_ptr() as *const *const RSIndexResult,
+            len: agg.len(),
         },
     }
 }

--- a/src/redisearch_rs/headers/index_result_rs.h
+++ b/src/redisearch_rs/headers/index_result_rs.h
@@ -368,6 +368,26 @@ typedef struct ThinVec_Box_RawIndexResult_Active__u16 {
 typedef struct ThinVec_Box_RawIndexResult_Active__u16 SmallThinVec_Box_RawIndexResult_Active;
 #endif /* SMALLTHINVEC_BOX_RAWINDEXRESULT_ACTIVE_DEFINED */
 
+#ifndef RAWOWNEDAGGREGATERESULT_ACTIVE_DEFINED
+#define RAWOWNEDAGGREGATERESULT_ACTIVE_DEFINED
+/**
+ * An aggregate result that owns its children, holding each one in its own heap
+ * allocation.
+ *
+ * The [`Owned`](RawAggregateResult::Owned) payload of [`RawAggregateResult`].
+ */
+typedef struct RawOwnedAggregateResult_Active {
+  /**
+   * The records making up this aggregate result, each owned by this aggregate.
+   */
+  SmallThinVec_Box_RawIndexResult_Active records;
+  /**
+   * A map of the aggregate kind of the underlying records
+   */
+  RSResultKindMask kind_mask;
+} RawOwnedAggregateResult_Active;
+#endif /* RAWOWNEDAGGREGATERESULT_ACTIVE_DEFINED */
+
 #ifndef THINVEC_METRICENTRY__U64_DEFINED
 #define THINVEC_METRICENTRY__U64_DEFINED
 /**
@@ -410,10 +430,48 @@ typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u16 {
 typedef struct ThinVec_SharedPtr_Active__RawIndexResult_Active__u16 SmallThinVec_SharedPtr_Active__RawIndexResult_Active;
 #endif /* SMALLTHINVEC_SHAREDPTR_ACTIVE__RAWINDEXRESULT_ACTIVE_DEFINED */
 
+#ifndef RAWBORROWEDAGGREGATERESULT_ACTIVE_DEFINED
+#define RAWBORROWEDAGGREGATERESULT_ACTIVE_DEFINED
+/**
+ * An aggregate result whose children live elsewhere — in the composite iterator
+ * that built it, typically — and are only pointed at from here.
+ *
+ * The [`Borrowed`](RawAggregateResult::Borrowed) payload of
+ * [`RawAggregateResult`].
+ */
+typedef struct RawBorrowedAggregateResult_Active {
+  /**
+   * The records making up this aggregate result.
+   *
+   * Each child is stored as a [`SharedPtr<R, RawIndexResult<R>>`]. In [`Active`] mode this is
+   * equivalent to a `&'a RSIndexResult<'a>`; in [`ref_mode::Suspended`] mode it is
+   * an inert raw pointer that survives lock release/reacquire cycles.
+   */
+  SmallThinVec_SharedPtr_Active__RawIndexResult_Active records;
+  /**
+   * A map of the aggregate kind of the underlying records
+   */
+  RSResultKindMask kind_mask;
+} RawBorrowedAggregateResult_Active;
+#endif /* RAWBORROWEDAGGREGATERESULT_ACTIVE_DEFINED */
+
 #ifndef RAWAGGREGATERESULT_ACTIVE_DEFINED
 #define RAWAGGREGATERESULT_ACTIVE_DEFINED
 /**
  * Represents an aggregate array of values in an index record.
+ *
+ * How the children are held is what separates the two variants, and each one
+ * carries its own type — [`RawBorrowedAggregateResult`] and
+ * [`RawOwnedAggregateResult`]. An operation that only one of them supports
+ * therefore lives on that type: pushing a borrowed child, or handing out a `&mut`
+ * to a child, cannot be attempted on the wrong kind of aggregate. Reach the
+ * payload with [`as_borrowed`](Self::as_borrowed), [`as_owned`](Self::as_owned)
+ * or their `_mut` counterparts.
+ *
+ * `RawAggregateResult` is part of a union in
+ * [`super::result_data::RawResultData`], so it needs to have a known size. That
+ * is why both payloads hold their children in a [`SmallThinVec`] rather than the
+ * std `Vec`, which is not `#[repr(C)]`.
  *
  * The C code should always use `AggregateResult_New` to construct a new instance of this type
  * using Rust since the internals cannot be constructed directly in C. The reason is because of
@@ -432,47 +490,16 @@ enum RawAggregateResult_Active_Tag
 typedef uint8_t RawAggregateResult_Active_Tag;
 #endif // __cplusplus
 
-typedef struct RawAggregateResult_Active_Borrowed_Body {
-  RawAggregateResult_Active_Tag tag;
-  /**
-   * The records making up this aggregate result
-   *
-   * The `RawAggregateResult` is part of a union in [`super::result_data::RawResultData`], so
-   * it needs to have a known size. The std `Vec` won't have this since it is not
-   * `#[repr(C)]`, so we use our own `ThinVec` type which is `#[repr(C)]` and has a known
-   * size instead.
-   *
-   * Each child is stored as a [`SharedPtr<R, RawIndexResult<R>>`]. In [`Active`] mode this is
-   * equivalent to a `&'a RSIndexResult<'a>`; in [`ref_mode::Suspended`] mode it is
-   * an inert raw pointer that survives lock release/reacquire cycles.
-   */
-  SmallThinVec_SharedPtr_Active__RawIndexResult_Active records;
-  /**
-   * A map of the aggregate kind of the underlying records
-   */
-  RSResultKindMask kind_mask;
-} RawAggregateResult_Active_Borrowed_Body;
-
-typedef struct RawAggregateResult_Active_Owned_Body {
-  RawAggregateResult_Active_Tag tag;
-  /**
-   * The records making up this aggregate result
-   *
-   * The `RawAggregateResult` is part of a union in [`super::result_data::RawResultData`], so it needs to have a
-   * known size. The std `Vec` won't have this since it is not `#[repr(C)]`, so we use our
-   * own `ThinVec` type which is `#[repr(C)]` and has a known size instead.
-   */
-  SmallThinVec_Box_RawIndexResult_Active records;
-  /**
-   * A map of the aggregate kind of the underlying records
-   */
-  RSResultKindMask kind_mask;
-} RawAggregateResult_Active_Owned_Body;
-
 typedef union RawAggregateResult_Active {
   RawAggregateResult_Active_Tag tag;
-  struct RawAggregateResult_Active_Borrowed_Body borrowed;
-  struct RawAggregateResult_Active_Owned_Body owned;
+  struct {
+    RawAggregateResult_Active_Tag borrowed_tag;
+    struct RawBorrowedAggregateResult_Active borrowed;
+  };
+  struct {
+    RawAggregateResult_Active_Tag owned_tag;
+    struct RawOwnedAggregateResult_Active owned;
+  };
 } RawAggregateResult_Active;
 #endif /* RAWAGGREGATERESULT_ACTIVE_DEFINED */
 

--- a/src/redisearch_rs/index_result/src/aggregate.rs
+++ b/src/redisearch_rs/index_result/src/aggregate.rs
@@ -15,6 +15,19 @@ use super::kind::RSResultKindMask;
 
 /// Represents an aggregate array of values in an index record.
 ///
+/// How the children are held is what separates the two variants, and each one
+/// carries its own type — [`RawBorrowedAggregateResult`] and
+/// [`RawOwnedAggregateResult`]. An operation that only one of them supports
+/// therefore lives on that type: pushing a borrowed child, or handing out a `&mut`
+/// to a child, cannot be attempted on the wrong kind of aggregate. Reach the
+/// payload with [`as_borrowed`](Self::as_borrowed), [`as_owned`](Self::as_owned)
+/// or their `_mut` counterparts.
+///
+/// `RawAggregateResult` is part of a union in
+/// [`super::result_data::RawResultData`], so it needs to have a known size. That
+/// is why both payloads hold their children in a [`SmallThinVec`] rather than the
+/// std `Vec`, which is not `#[repr(C)]`.
+///
 /// The C code should always use `AggregateResult_New` to construct a new instance of this type
 /// using Rust since the internals cannot be constructed directly in C. The reason is because of
 /// the `ThinVec` which needs to exist in Rust's memory space to ensure its memory is
@@ -23,102 +36,122 @@ use super::kind::RSResultKindMask;
 #[derive(Debug)]
 #[repr(u8)]
 pub enum RawAggregateResult<'query, R: Ref> {
-    Borrowed {
-        /// The records making up this aggregate result
-        ///
-        /// The `RawAggregateResult` is part of a union in [`super::result_data::RawResultData`], so
-        /// it needs to have a known size. The std `Vec` won't have this since it is not
-        /// `#[repr(C)]`, so we use our own `ThinVec` type which is `#[repr(C)]` and has a known
-        /// size instead.
-        ///
-        /// Each child is stored as a [`SharedPtr<R, RawIndexResult<R>>`]. In [`Active`] mode this is
-        /// equivalent to a `&'a RSIndexResult<'a>`; in [`ref_mode::Suspended`] mode it is
-        /// an inert raw pointer that survives lock release/reacquire cycles.
-        records: SmallThinVec<SharedPtr<R, RawIndexResult<'query, R>>>,
-
-        /// A map of the aggregate kind of the underlying records
-        kind_mask: RSResultKindMask,
-    },
-    Owned {
-        /// The records making up this aggregate result
-        ///
-        /// The `RawAggregateResult` is part of a union in [`super::result_data::RawResultData`], so it needs to have a
-        /// known size. The std `Vec` won't have this since it is not `#[repr(C)]`, so we use our
-        /// own `ThinVec` type which is `#[repr(C)]` and has a known size instead.
-        records: SmallThinVec<Box<RawIndexResult<'query, R>>>,
-
-        /// A map of the aggregate kind of the underlying records
-        kind_mask: RSResultKindMask,
-    },
+    Borrowed(RawBorrowedAggregateResult<'query, R>),
+    Owned(RawOwnedAggregateResult<'query, R>),
 }
 
 /// The [`Active`] instantiation of [`RawAggregateResult`].
 #[cheadergen::config(export)]
 pub type RSAggregateResult<'a> = RawAggregateResult<'a, Active<'a>>;
 
-// Compile-time proof that the `Active` and `Suspended` instantiations of
-// `RawAggregateResult` are layout-identical. Only `size_of`/`align_of` are
-// checked: `offset_of!` cannot address `#[repr(u8)]` enum variant fields. Each
-// variant stores its children behind a `SmallThinVec` pointer, so the inline
-// layout is pointer-sized regardless of `R`; the child `RawIndexResult<R>`
-// read through that pointer is guarded by the `core/mod.rs` block. Part of the
-// recursive net backing the conversions on `RawIndexResult`.
+/// An aggregate result whose children live elsewhere — in the composite iterator
+/// that built it, typically — and are only pointed at from here.
+///
+/// The [`Borrowed`](RawAggregateResult::Borrowed) payload of
+/// [`RawAggregateResult`].
+#[derive(Debug)]
+#[repr(C)]
+pub struct RawBorrowedAggregateResult<'query, R: Ref> {
+    /// The records making up this aggregate result.
+    ///
+    /// Each child is stored as a [`SharedPtr<R, RawIndexResult<R>>`]. In [`Active`] mode this is
+    /// equivalent to a `&'a RSIndexResult<'a>`; in [`ref_mode::Suspended`] mode it is
+    /// an inert raw pointer that survives lock release/reacquire cycles.
+    records: SmallThinVec<SharedPtr<R, RawIndexResult<'query, R>>>,
+
+    /// A map of the aggregate kind of the underlying records
+    kind_mask: RSResultKindMask,
+}
+
+/// The [`Active`] instantiation of [`RawBorrowedAggregateResult`].
+pub type RSBorrowedAggregateResult<'a> = RawBorrowedAggregateResult<'a, Active<'a>>;
+
+/// An aggregate result that owns its children, holding each one in its own heap
+/// allocation.
+///
+/// The [`Owned`](RawAggregateResult::Owned) payload of [`RawAggregateResult`].
+#[derive(Debug)]
+#[repr(C)]
+pub struct RawOwnedAggregateResult<'query, R: Ref> {
+    /// The records making up this aggregate result, each owned by this aggregate.
+    records: SmallThinVec<Box<RawIndexResult<'query, R>>>,
+
+    /// A map of the aggregate kind of the underlying records
+    kind_mask: RSResultKindMask,
+}
+
+/// The [`Active`] instantiation of [`RawOwnedAggregateResult`].
+pub type RSOwnedAggregateResult<'a> = RawOwnedAggregateResult<'a, Active<'a>>;
+
+// Compile-time proof that the `Active` and `Suspended` instantiations of the two
+// payloads — and hence of `RawAggregateResult` itself — are layout-identical.
+// Field offsets are checked on the payloads, which `offset_of!` can address;
+// for the enum wrapping them only `size_of`/`align_of` are available, since
+// `offset_of!` cannot reach the fields of a `#[repr(u8)]` enum variant. The
+// child `RawIndexResult<R>` read through a `records` pointer is guarded by the
+// `core/mod.rs` block. Part of the recursive net backing the conversions on
+// `RawIndexResult`.
 const _: () = {
     use ref_mode::Suspended;
-    use std::mem::{align_of, size_of};
-    type A = RawAggregateResult<'static, Active<'static>>;
-    type S = RawAggregateResult<'static, Suspended>;
-    assert!(size_of::<A>() == size_of::<S>());
-    assert!(align_of::<A>() == align_of::<S>());
+    use std::mem::{align_of, offset_of, size_of};
+
+    type ActiveBorrowed = RawBorrowedAggregateResult<'static, Active<'static>>;
+    type SuspendedBorrowed = RawBorrowedAggregateResult<'static, Suspended>;
+    assert!(size_of::<ActiveBorrowed>() == size_of::<SuspendedBorrowed>());
+    assert!(align_of::<ActiveBorrowed>() == align_of::<SuspendedBorrowed>());
+    assert!(offset_of!(ActiveBorrowed, records) == offset_of!(SuspendedBorrowed, records));
+    assert!(offset_of!(ActiveBorrowed, kind_mask) == offset_of!(SuspendedBorrowed, kind_mask));
+
+    type ActiveOwned = RawOwnedAggregateResult<'static, Active<'static>>;
+    type SuspendedOwned = RawOwnedAggregateResult<'static, Suspended>;
+    assert!(size_of::<ActiveOwned>() == size_of::<SuspendedOwned>());
+    assert!(align_of::<ActiveOwned>() == align_of::<SuspendedOwned>());
+    assert!(offset_of!(ActiveOwned, records) == offset_of!(SuspendedOwned, records));
+    assert!(offset_of!(ActiveOwned, kind_mask) == offset_of!(SuspendedOwned, kind_mask));
+
+    type ActiveAggregate = RawAggregateResult<'static, Active<'static>>;
+    type SuspendedAggregate = RawAggregateResult<'static, Suspended>;
+    assert!(size_of::<ActiveAggregate>() == size_of::<SuspendedAggregate>());
+    assert!(align_of::<ActiveAggregate>() == align_of::<SuspendedAggregate>());
 };
 
-// Manual (rather than derived) because the `Borrowed` variant stores
+// Manual (rather than derived) because the records are
 // `SharedPtr<R, RawIndexResult<R>>`, which only implements `PartialEq` in `Active`
 // mode. Restricted to the `Active` alias accordingly.
+impl<'a> PartialEq for RSBorrowedAggregateResult<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind_mask == other.kind_mask
+            && self.records.len() == other.records.len()
+            && self
+                .records
+                .iter()
+                .zip(other.records.iter())
+                .all(|(x, y)| x.get() == y.get())
+    }
+}
+
+// Manual for the same reason as the borrowed payload above: the child
+// `RawIndexResult<R>` is only `PartialEq` in `Active` mode.
+impl<'a> PartialEq for RSOwnedAggregateResult<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind_mask == other.kind_mask && self.records == other.records
+    }
+}
+
 impl<'a> PartialEq for RSAggregateResult<'a> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (
-                Self::Borrowed {
-                    records: a,
-                    kind_mask: ma,
-                },
-                Self::Borrowed {
-                    records: b,
-                    kind_mask: mb,
-                },
-            ) => {
-                ma == mb
-                    && a.len() == b.len()
-                    && a.iter().zip(b.iter()).all(|(x, y)| x.get() == y.get())
-            }
-            (
-                Self::Owned {
-                    records: a,
-                    kind_mask: ma,
-                },
-                Self::Owned {
-                    records: b,
-                    kind_mask: mb,
-                },
-            ) => ma == mb && a == b,
+            (Self::Borrowed(a), Self::Borrowed(b)) => a == b,
+            (Self::Owned(a), Self::Owned(b)) => a == b,
             _ => false,
         }
     }
 }
 
-impl<'query, R: Ref> RawAggregateResult<'query, R> {
-    /// Create a new empty aggregate result (of the borrowed kind) with the given capacity
-    pub fn borrowed_with_capacity(cap: usize) -> Self {
-        Self::Borrowed {
-            records: SmallThinVec::with_capacity(cap),
-            kind_mask: RSResultKindMask::empty(),
-        }
-    }
-
-    /// Create a new empty aggregate result (of the owned kind) with the given capacity
-    pub fn owned_with_capacity(cap: usize) -> Self {
-        Self::Owned {
+impl<'query, R: Ref> RawBorrowedAggregateResult<'query, R> {
+    /// Create a new empty borrowed aggregate result with the given capacity
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
             records: SmallThinVec::with_capacity(cap),
             kind_mask: RSResultKindMask::empty(),
         }
@@ -126,49 +159,295 @@ impl<'query, R: Ref> RawAggregateResult<'query, R> {
 
     /// The number of results in this aggregate result
     pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    /// Check whether this aggregate result is empty
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    /// The capacity of the aggregate result
+    pub fn capacity(&self) -> usize {
+        self.records.capacity()
+    }
+
+    /// The current type mask of the aggregate result
+    pub const fn kind_mask(&self) -> RSResultKindMask {
+        self.kind_mask
+    }
+
+    /// The pointers to the children of this aggregate result, in order.
+    pub fn records(&self) -> &[SharedPtr<R, RawIndexResult<'query, R>>] {
+        &self.records
+    }
+
+    /// Reset the aggregate result, clearing the children vector and resetting the kind mask.
+    pub fn reset(&mut self) {
+        self.records.clear();
+        self.kind_mask = RSResultKindMask::empty();
+    }
+}
+
+impl<'a> RSBorrowedAggregateResult<'a> {
+    /// Get the child at the given index, if it exists.
+    pub fn get(&self, index: usize) -> Option<&RSIndexResult<'a>> {
+        self.records.get(index).map(|p| p.get())
+    }
+
+    /// Get the child at the given index, if it exists.
+    ///
+    /// # Safety
+    ///
+    /// 1. The index must be within the bounds of the children vector.
+    pub unsafe fn get_unchecked(&self, index: usize) -> &RSIndexResult<'a> {
+        debug_assert!(
+            index < self.records.len(),
+            "Safety violation: trying to access an aggregate result child at an out-of-bounds index, {index}. Length: {}",
+            self.records.len()
+        );
+        // SAFETY:
+        // - Thanks to precondition 1., we know that the index is within bounds.
+        unsafe { self.records.get_unchecked(index) }.get()
+    }
+
+    /// Add a child to the aggregate result and update the kind mask.
+    ///
+    /// `'a` ties the child to this aggregate, so a Rust caller cannot outlive it.
+    /// A caller reaching this across FFI, where `'a` was fabricated from a raw
+    /// pointer, owes the guarantee the borrow checker would otherwise give:
+    /// reading a dead child back out with [`Self::get`] is undefined behaviour.
+    pub fn push_borrowed(&mut self, child: &'a RSIndexResult<'a>) {
+        self.records.push(SharedPtr::from_ref(child));
+
+        self.kind_mask |= child.kind();
+    }
+
+    /// Create an owned copy of this aggregate result, allocating new memory for the records.
+    ///
+    /// The returned aggregate result will have the same lifetime as the original one,
+    /// since it may borrow terms from the original result.
+    pub fn to_owned(&'a self) -> RSOwnedAggregateResult<'a> {
+        let mut records = SmallThinVec::with_capacity(self.records.len());
+
+        records.extend(
+            self.records
+                .iter()
+                .map(|c| RSIndexResult::to_owned(c.get()))
+                .map(Box::new),
+        );
+
+        RSOwnedAggregateResult {
+            records,
+            kind_mask: self.kind_mask,
+        }
+    }
+}
+
+impl<'query, R: Ref> RawOwnedAggregateResult<'query, R> {
+    /// Create a new empty owned aggregate result with the given capacity
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            records: SmallThinVec::with_capacity(cap),
+            kind_mask: RSResultKindMask::empty(),
+        }
+    }
+
+    /// The number of results in this aggregate result
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    /// Check whether this aggregate result is empty
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    /// The capacity of the aggregate result
+    pub fn capacity(&self) -> usize {
+        self.records.capacity()
+    }
+
+    /// The current type mask of the aggregate result
+    pub const fn kind_mask(&self) -> RSResultKindMask {
+        self.kind_mask
+    }
+
+    /// The children owned by this aggregate result, in order.
+    pub fn records(&self) -> &[Box<RawIndexResult<'query, R>>] {
+        &self.records
+    }
+
+    /// Take the children out of this aggregate result, transferring ownership of
+    /// each one to the caller.
+    pub fn into_records(self) -> SmallThinVec<Box<RawIndexResult<'query, R>>> {
+        self.records
+    }
+
+    /// Reset the aggregate result, clearing (and thereby dropping) the children
+    /// and resetting the kind mask.
+    pub fn reset(&mut self) {
+        self.records.clear();
+        self.kind_mask = RSResultKindMask::empty();
+    }
+}
+
+impl<'a> RSOwnedAggregateResult<'a> {
+    /// Get the child at the given index, if it exists.
+    pub fn get(&self, index: usize) -> Option<&RSIndexResult<'a>> {
+        self.records.get(index).map(AsRef::as_ref)
+    }
+
+    /// Get the child at the given index, if it exists.
+    ///
+    /// # Safety
+    ///
+    /// 1. The index must be within the bounds of the children vector.
+    pub unsafe fn get_unchecked(&self, index: usize) -> &RSIndexResult<'a> {
+        debug_assert!(
+            index < self.records.len(),
+            "Safety violation: trying to access an aggregate result child at an out-of-bounds index, {index}. Length: {}",
+            self.records.len()
+        );
+        // SAFETY:
+        // - Thanks to precondition 1., we know that the index is within bounds.
+        unsafe { self.records.get_unchecked(index) }
+    }
+
+    /// Get a mutable reference to the child at the given index, if it exists
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut RSIndexResult<'a>> {
+        self.records.get_mut(index).map(AsMut::as_mut)
+    }
+
+    /// Get a mutable reference to the child at the given index, without checking bounds.
+    ///
+    /// # Safety
+    ///
+    /// 1. The index must be within the bounds of the children vector.
+    pub unsafe fn get_mut_unchecked(&mut self, index: usize) -> &mut RSIndexResult<'a> {
+        debug_assert!(
+            index < self.records.len(),
+            "Safety violation: trying to access an aggregate result child at an out-of-bounds index, {index}. Length: {}",
+            self.records.len()
+        );
+        // SAFETY: Thanks to precondition 1., we know that the index is within bounds.
+        unsafe { self.records.get_unchecked_mut(index) }
+    }
+
+    /// Add a heap owned child to the aggregate result and update the kind mask
+    pub fn push_boxed(&mut self, child: Box<RSIndexResult<'a>>) {
+        self.kind_mask |= child.kind();
+        self.records.push(child);
+    }
+
+    /// Create an owned copy of this aggregate result, allocating new memory for the records.
+    ///
+    /// The returned aggregate result will have the same lifetime as the original one,
+    /// since it may borrow terms from the original result.
+    pub fn to_owned(&'a self) -> RSOwnedAggregateResult<'a> {
+        let mut records = SmallThinVec::with_capacity(self.records.len());
+
+        records.extend(
+            self.records
+                .iter()
+                .map(|c| RSIndexResult::to_owned(c))
+                .map(Box::new),
+        );
+
+        RSOwnedAggregateResult {
+            records,
+            kind_mask: self.kind_mask,
+        }
+    }
+}
+
+impl<'query, R: Ref> RawAggregateResult<'query, R> {
+    /// Create a new empty aggregate result (of the borrowed kind) with the given capacity
+    pub fn borrowed_with_capacity(cap: usize) -> Self {
+        Self::Borrowed(RawBorrowedAggregateResult::with_capacity(cap))
+    }
+
+    /// Create a new empty aggregate result (of the owned kind) with the given capacity
+    pub fn owned_with_capacity(cap: usize) -> Self {
+        Self::Owned(RawOwnedAggregateResult::with_capacity(cap))
+    }
+
+    /// The borrowed payload, if this aggregate result borrows its children.
+    pub const fn as_borrowed(&self) -> Option<&RawBorrowedAggregateResult<'query, R>> {
         match self {
-            Self::Borrowed { records, .. } => records.len(),
-            Self::Owned { records, .. } => records.len(),
+            Self::Borrowed(agg) => Some(agg),
+            Self::Owned(_) => None,
+        }
+    }
+
+    /// The borrowed payload to mutate, if this aggregate result borrows its
+    /// children. The only route to
+    /// [`push_borrowed`](RSBorrowedAggregateResult::push_borrowed).
+    pub const fn as_borrowed_mut(&mut self) -> Option<&mut RawBorrowedAggregateResult<'query, R>> {
+        match self {
+            Self::Borrowed(agg) => Some(agg),
+            Self::Owned(_) => None,
+        }
+    }
+
+    /// The owned payload, if this aggregate result owns its children.
+    pub const fn as_owned(&self) -> Option<&RawOwnedAggregateResult<'query, R>> {
+        match self {
+            Self::Owned(agg) => Some(agg),
+            Self::Borrowed(_) => None,
+        }
+    }
+
+    /// The owned payload to mutate, if this aggregate result owns its children.
+    /// The only route to [`push_boxed`](RSOwnedAggregateResult::push_boxed) and
+    /// [`get_mut`](RSOwnedAggregateResult::get_mut).
+    pub const fn as_owned_mut(&mut self) -> Option<&mut RawOwnedAggregateResult<'query, R>> {
+        match self {
+            Self::Owned(agg) => Some(agg),
+            Self::Borrowed(_) => None,
+        }
+    }
+
+    /// The number of results in this aggregate result
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Borrowed(agg) => agg.len(),
+            Self::Owned(agg) => agg.len(),
         }
     }
 
     /// Check whether this aggregate result is empty
     pub fn is_empty(&self) -> bool {
         match self {
-            Self::Borrowed { records, .. } => records.is_empty(),
-            Self::Owned { records, .. } => records.is_empty(),
+            Self::Borrowed(agg) => agg.is_empty(),
+            Self::Owned(agg) => agg.is_empty(),
         }
     }
 
     /// The capacity of the aggregate result
     pub fn capacity(&self) -> usize {
         match self {
-            Self::Borrowed { records, .. } => records.capacity(),
-            Self::Owned { records, .. } => records.capacity(),
+            Self::Borrowed(agg) => agg.capacity(),
+            Self::Owned(agg) => agg.capacity(),
         }
     }
 
     /// The current type mask of the aggregate result
     pub const fn kind_mask(&self) -> RSResultKindMask {
         match self {
-            Self::Borrowed { kind_mask, .. } => *kind_mask,
-            Self::Owned { kind_mask, .. } => *kind_mask,
+            Self::Borrowed(agg) => agg.kind_mask(),
+            Self::Owned(agg) => agg.kind_mask(),
         }
     }
 
-    /// Reset the aggregate result, clearing the children vector and resetting the kind mask.
+    /// Reset the aggregate result, clearing the children vector and resetting the
+    /// kind mask. Dispatches to
+    /// [`RawBorrowedAggregateResult::reset`] or [`RawOwnedAggregateResult::reset`],
+    /// which differ in what becomes of the children.
     pub fn reset(&mut self) {
         match self {
-            Self::Borrowed {
-                records, kind_mask, ..
-            } => {
-                records.clear();
-                *kind_mask = RSResultKindMask::empty();
-            }
-            Self::Owned { records, kind_mask } => {
-                records.clear();
-                *kind_mask = RSResultKindMask::empty();
-            }
+            Self::Borrowed(agg) => agg.reset(),
+            Self::Owned(agg) => agg.reset(),
         }
     }
 }
@@ -185,8 +464,8 @@ impl<'a> RSAggregateResult<'a> {
     /// Get the child at the given index, if it exists.
     pub fn get(&self, index: usize) -> Option<&RSIndexResult<'a>> {
         match self {
-            Self::Borrowed { records, .. } => records.get(index).map(|p| p.get()),
-            Self::Owned { records, .. } => records.get(index).map(AsRef::as_ref),
+            Self::Borrowed(agg) => agg.get(index),
+            Self::Owned(agg) => agg.get(index),
         }
     }
 
@@ -197,46 +476,10 @@ impl<'a> RSAggregateResult<'a> {
     /// 1. The index must be within the bounds of the children vector.
     pub unsafe fn get_unchecked(&self, index: usize) -> &RSIndexResult<'a> {
         match self {
-            Self::Borrowed { records, .. } => {
-                debug_assert!(
-                    index < records.len(),
-                    "Safety violation: trying to access an aggregate result child at an out-of-bounds index, {index}. Length: {}",
-                    records.len()
-                );
-                // SAFETY:
-                // - Thanks to precondition 1., we know that the index is within bounds.
-                unsafe { records.get_unchecked(index) }.get()
-            }
-            Self::Owned { records, .. } => {
-                debug_assert!(
-                    index < records.len(),
-                    "Safety violation: trying to access an aggregate result child at an out-of-bounds index, {index}. Length: {}",
-                    records.len()
-                );
-                // SAFETY:
-                // - Thanks to precondition 1., we know that the index is within bounds.
-                unsafe { records.get_unchecked(index) }
-            }
-        }
-    }
-
-    /// Add a child to the aggregate result and update the kind mask
-    ///
-    /// # Safety
-    /// The given `child` has to stay valid for the lifetime of this aggregate result. Else reading
-    /// the child with [`Self::get()`] will cause undefined behavior.
-    pub fn push_borrowed(&mut self, child: &'a RSIndexResult<'a>) {
-        match self {
-            Self::Borrowed {
-                records, kind_mask, ..
-            } => {
-                records.push(SharedPtr::from_ref(child));
-
-                *kind_mask |= child.kind();
-            }
-            Self::Owned { .. } => {
-                panic!("Cannot push a borrowed child to an owned aggregate result");
-            }
+            // SAFETY: precondition 1. is forwarded to the payload unchanged.
+            Self::Borrowed(agg) => unsafe { agg.get_unchecked(index) },
+            // SAFETY: precondition 1. is forwarded to the payload unchanged.
+            Self::Owned(agg) => unsafe { agg.get_unchecked(index) },
         }
     }
 
@@ -246,87 +489,8 @@ impl<'a> RSAggregateResult<'a> {
     /// since it may borrow terms from the original result.
     pub fn to_owned(&'a self) -> RSAggregateResult<'a> {
         match self {
-            Self::Borrowed { records, kind_mask } => {
-                let mut new_records = SmallThinVec::with_capacity(records.len());
-
-                new_records.extend(
-                    records
-                        .iter()
-                        .map(|c| RSIndexResult::to_owned(c.get()))
-                        .map(Box::new),
-                );
-
-                Self::Owned {
-                    records: new_records,
-                    kind_mask: *kind_mask,
-                }
-            }
-            Self::Owned { records, kind_mask } => {
-                let mut new_records = SmallThinVec::with_capacity(records.len());
-
-                new_records.extend(
-                    records
-                        .iter()
-                        .map(|c| RSIndexResult::to_owned(c))
-                        .map(Box::new),
-                );
-
-                Self::Owned {
-                    records: new_records,
-                    kind_mask: *kind_mask,
-                }
-            }
-        }
-    }
-
-    /// Add a heap owned child to the aggregate result and update the kind mask
-    pub fn push_boxed(&mut self, child: Box<RSIndexResult<'a>>) {
-        match self {
-            Self::Borrowed { .. } => {
-                panic!("Cannot push a borrowed child to an owned aggregate result");
-            }
-            Self::Owned { records, kind_mask } => {
-                *kind_mask |= child.kind();
-                records.push(child);
-            }
-        }
-    }
-
-    /// Get a mutable reference to the child at the given index, if it exists
-    pub fn get_mut(&mut self, index: usize) -> Option<&mut RSIndexResult<'a>> {
-        match self {
-            Self::Borrowed { .. } => {
-                panic!("Cannot get a mutable reference to a borrowed aggregate result");
-            }
-            Self::Owned { records, .. } => records.get_mut(index).map(AsMut::as_mut),
-        }
-    }
-
-    /// Get a mutable reference to the child at the given index, without checking bounds.
-    ///
-    /// # Safety
-    ///
-    /// 1. The index must be within the bounds of the children vector.
-    /// 2. The aggregate result must be of the `Owned` variant.
-    pub unsafe fn get_mut_unchecked(&mut self, index: usize) -> &mut RSIndexResult<'a> {
-        match self {
-            Self::Borrowed { .. } => {
-                debug_assert!(
-                    false,
-                    "Safety violation: trying to get a mutable reference from a borrowed aggregate result"
-                );
-                // SAFETY: Thanks to precondition 2., we'll never reach this statement.
-                unsafe { std::hint::unreachable_unchecked() }
-            }
-            Self::Owned { records, .. } => {
-                debug_assert!(
-                    index < records.len(),
-                    "Safety violation: trying to access an aggregate result child at an out-of-bounds index, {index}. Length: {}",
-                    records.len()
-                );
-                // SAFETY: Thanks to precondition 1., we know that the index is within bounds.
-                unsafe { records.get_unchecked_mut(index) }
-            }
+            Self::Borrowed(agg) => Self::Owned(agg.to_owned()),
+            Self::Owned(agg) => Self::Owned(agg.to_owned()),
         }
     }
 }

--- a/src/redisearch_rs/index_result/src/core/mod.rs
+++ b/src/redisearch_rs/index_result/src/core/mod.rs
@@ -892,14 +892,14 @@ impl<'query, R: Ref> RawIndexResult<'query, R> {
     /// Is this result some copy type
     pub const fn is_copy(&self) -> bool {
         match self.data {
-            RawResultData::Union(RawAggregateResult::Owned { .. })
-            | RawResultData::Intersection(RawAggregateResult::Owned { .. })
-            | RawResultData::HybridMetric(RawAggregateResult::Owned { .. })
+            RawResultData::Union(RawAggregateResult::Owned(_))
+            | RawResultData::Intersection(RawAggregateResult::Owned(_))
+            | RawResultData::HybridMetric(RawAggregateResult::Owned(_))
             | RawResultData::Term(RawTermRecord::Owned { .. })
             | RawResultData::Term(RawTermRecord::FullyOwned { .. }) => true,
-            RawResultData::Union(RawAggregateResult::Borrowed { .. })
-            | RawResultData::Intersection(RawAggregateResult::Borrowed { .. })
-            | RawResultData::HybridMetric(RawAggregateResult::Borrowed { .. })
+            RawResultData::Union(RawAggregateResult::Borrowed(_))
+            | RawResultData::Intersection(RawAggregateResult::Borrowed(_))
+            | RawResultData::HybridMetric(RawAggregateResult::Borrowed(_))
             | RawResultData::Term(RawTermRecord::Borrowed { .. })
             | RawResultData::Virtual
             | RawResultData::Numeric(_)
@@ -951,6 +951,12 @@ impl<'a> RSIndexResult<'a> {
     /// The caller must drain the child's metrics via `std::mem::take(&mut child.metrics)`
     /// before calling this method, and pass them as `child_metrics`.
     ///
+    /// # Panics
+    ///
+    /// If this is an aggregate result that *owns* its children, which cannot take a
+    /// borrowed one. Use [`Self::push_boxed`] for those, or ask
+    /// [`Self::is_copy`] which kind this is.
+    ///
     /// # Safety
     ///
     /// The given `child` has to stay valid for the lifetime of this index result. Else reading
@@ -977,7 +983,9 @@ impl<'a> RSIndexResult<'a> {
         }
 
         if let Some(agg) = self.as_aggregate_mut() {
-            agg.push_borrowed(child);
+            agg.as_borrowed_mut()
+                .expect("Cannot push a borrowed child to an owned aggregate result")
+                .push_borrowed(child);
         }
     }
 
@@ -1020,6 +1028,12 @@ impl<'a> RSIndexResult<'a> {
     ///
     /// If this is not an aggregate result, then nothing happens. Use [`Self::is_aggregate()`] first
     /// to make sure this is an aggregate result.
+    ///
+    /// # Panics
+    ///
+    /// If this is an aggregate result that *borrows* its children, which cannot take
+    /// ownership of one. Use [`Self::push_borrowed`] for those, or ask
+    /// [`Self::is_copy`] which kind this is.
     pub fn push_boxed(&mut self, mut child: Box<RSIndexResult<'a>>) {
         if !self.is_aggregate() {
             return;
@@ -1035,17 +1049,28 @@ impl<'a> RSIndexResult<'a> {
         }
 
         if let Some(agg) = self.as_aggregate_mut() {
-            agg.push_boxed(child);
+            agg.as_owned_mut()
+                .expect("Cannot push an owned child to a borrowed aggregate result")
+                .push_boxed(child);
         }
     }
 
     /// Get a mutable reference to the child at the given index, if it is an aggregate record.
     /// `None` is returned if this is not an aggregate record or if the index is out-of-bounds.
+    ///
+    /// # Panics
+    ///
+    /// If this is an aggregate record that *borrows* its children: those are shared
+    /// with whoever owns them, so only an
+    /// [`Owned`](RawAggregateResult::Owned) aggregate can hand out a `&mut` to one.
     pub fn get_mut(&mut self, index: usize) -> Option<&mut Self> {
         match &mut self.data {
             RawResultData::Union(agg)
             | RawResultData::Intersection(agg)
-            | RawResultData::HybridMetric(agg) => agg.get_mut(index),
+            | RawResultData::HybridMetric(agg) => agg
+                .as_owned_mut()
+                .expect("Cannot get a mutable reference to a borrowed aggregate result")
+                .get_mut(index),
             RawResultData::Term(_)
             | RawResultData::Virtual
             | RawResultData::Numeric(_)

--- a/src/redisearch_rs/index_result/src/core/proximity.rs
+++ b/src/redisearch_rs/index_result/src/core/proximity.rs
@@ -471,7 +471,7 @@ mod tests {
 
     #[test]
     fn single_child_union_delegates_to_child_iter() {
-        use crate::{RSAggregateResult, RSIndexResult, RSOffsetSlice};
+        use crate::{RSIndexResult, RSOffsetSlice, RSOwnedAggregateResult, RawAggregateResult};
         use std::ptr;
 
         // delta bytes [2, 3, 5] → cumulative positions [2, 5, 10]
@@ -481,7 +481,7 @@ mod tests {
             .borrowed_record(None, RSOffsetSlice::from_slice(&OFFSETS))
             .build();
 
-        let mut agg = RSAggregateResult::owned_with_capacity(1);
+        let mut agg = RSOwnedAggregateResult::with_capacity(1);
         agg.push_boxed(Box::new(term));
 
         // Construct the Union directly; `data` is private to `core` but
@@ -491,7 +491,7 @@ mod tests {
             dmd: ptr::null(),
             field_mask: 0,
             freq: 0,
-            data: RawResultData::Union(agg),
+            data: RawResultData::Union(RawAggregateResult::Owned(agg)),
             metrics: crate::MetricsVec::new(),
             weight: 0.0,
             has_field_expiration: false,

--- a/src/redisearch_rs/index_result/src/lib.rs
+++ b/src/redisearch_rs/index_result/src/lib.rs
@@ -21,7 +21,10 @@ pub use self::core::{
     RSIndexResult, RawIndexResult, RawIndexResultBuilder, RawTermResultBuilder,
     SuspendedIndexResult,
 };
-pub use aggregate::{RSAggregateResult, RSAggregateResultIter, RawAggregateResult};
+pub use aggregate::{
+    RSAggregateResult, RSAggregateResultIter, RSBorrowedAggregateResult, RSOwnedAggregateResult,
+    RawAggregateResult, RawBorrowedAggregateResult, RawOwnedAggregateResult,
+};
 pub use kind::{RSResultKind, RSResultKindMask};
 pub use metrics::{MetricEntry, MetricsSlice, MetricsVec};
 pub use offsets::{RSOffsetSlice, RSOffsetVector, RawOffsetSlice};

--- a/src/redisearch_rs/inverted_index/tests/integration/index_result.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/index_result.rs
@@ -8,8 +8,8 @@
 */
 
 use index_result::{
-    MetricsVec, RSAggregateResult, RSIndexResult, RSOffsetSlice, RSOffsetVector, RSResultKind,
-    RSResultKindMask,
+    MetricsVec, RSBorrowedAggregateResult, RSIndexResult, RSOffsetSlice, RSOffsetVector,
+    RSOwnedAggregateResult, RSResultKind, RSResultKindMask,
 };
 use query_term::RSQueryTerm;
 use rqe_core::RS_FIELDMASK_ALL;
@@ -20,7 +20,7 @@ fn pushing_to_aggregate_result() {
     let num_second = RSIndexResult::build_numeric(100.0).doc_id(3).build();
     let virt_first = RSIndexResult::build_virt().doc_id(4).build();
 
-    let mut agg = RSAggregateResult::borrowed_with_capacity(2);
+    let mut agg = RSBorrowedAggregateResult::with_capacity(2);
 
     assert_eq!(agg.kind_mask(), RSResultKindMask::empty());
 
@@ -170,6 +170,91 @@ fn to_owned_an_aggregate_index_result() {
         5.0,
         "cloned value should not have changed"
     )
+}
+
+/// Which payload an aggregate answers for: the operations only one kind supports
+/// hang off that payload, so this is what decides whether they are reachable at
+/// all.
+#[test]
+fn an_aggregate_answers_for_exactly_one_payload() {
+    let mut borrowed = RSIndexResult::build_union(1).build();
+    let agg = borrowed
+        .as_aggregate_mut()
+        .expect("a union result carries an aggregate");
+    assert!(agg.as_borrowed().is_some());
+    assert!(agg.as_owned().is_none());
+    assert!(agg.as_borrowed_mut().is_some());
+    assert!(agg.as_owned_mut().is_none());
+
+    let mut owned = RSIndexResult::build_hybrid_metric().build();
+    let agg = owned
+        .as_aggregate_mut()
+        .expect("a hybrid metric result carries an aggregate");
+    assert!(agg.as_owned().is_some());
+    assert!(agg.as_borrowed().is_none());
+    assert!(agg.as_owned_mut().is_some());
+    assert!(agg.as_borrowed_mut().is_none());
+}
+
+/// `into_records` hands every child to the caller, so dropping what it returns is
+/// what frees them. Nothing else exercises that: its only production caller
+/// deliberately `mem::forget`s each child to leave the memory with C, so a
+/// double-free or a leak on this path would go unobserved. Run under miri.
+#[test]
+fn into_records_yields_the_children_in_order_and_frees_them_on_drop() {
+    let mut owned = RSOwnedAggregateResult::with_capacity(2);
+    owned.push_boxed(Box::new(
+        RSIndexResult::build_numeric(1.0).doc_id(7).build(),
+    ));
+    owned.push_boxed(Box::new(
+        RSIndexResult::build_numeric(2.0).doc_id(11).build(),
+    ));
+
+    let records = owned.into_records();
+
+    assert_eq!(records.len(), 2);
+    assert_eq!(
+        records.iter().map(|c| c.doc_id).collect::<Vec<_>>(),
+        vec![7, 11],
+        "the children come back in the order they were pushed",
+    );
+
+    // The drop at the end of scope is the point of the test: these boxes are the
+    // aggregate's only owners now, so miri sees either a clean free here or a leak.
+}
+
+/// An owned aggregate frees its children, so taking a borrowed one would hand it a
+/// pointer it must not free.
+#[test]
+#[should_panic = "Cannot push a borrowed child to an owned aggregate result"]
+fn pushing_a_borrowed_child_to_an_owned_aggregate_panics() {
+    let child = RSIndexResult::build_metric(1.0).doc_id(7).build();
+    let mut owned = RSIndexResult::build_hybrid_metric().build();
+
+    owned.push_borrowed(&child, MetricsVec::new());
+}
+
+/// The mirror image: a borrowed aggregate never frees its children, so taking
+/// ownership of one would leak it.
+#[test]
+#[should_panic = "Cannot push an owned child to a borrowed aggregate result"]
+fn pushing_an_owned_child_to_a_borrowed_aggregate_panics() {
+    let mut borrowed = RSIndexResult::build_union(1).build();
+
+    borrowed.push_boxed(Box::new(
+        RSIndexResult::build_numeric(1.0).doc_id(7).build(),
+    ));
+}
+
+/// A borrowed child is shared with whoever owns it, so a `&mut` to it would alias.
+#[test]
+#[should_panic = "Cannot get a mutable reference to a borrowed aggregate result"]
+fn mutably_reaching_a_borrowed_child_panics() {
+    let child = RSIndexResult::build_numeric(1.0).doc_id(7).build();
+    let mut borrowed = RSIndexResult::build_union(1).build();
+    borrowed.push_borrowed(&child, MetricsVec::new());
+
+    let _ = borrowed.get_mut(0);
 }
 
 #[test]


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `RawAggregateResult` is a two-variant enum with struct variants, so the seven operations that only one variant supports have to police themselves at runtime. `push_borrowed`, `push_boxed` and `get_mut` panic on the wrong variant, and `get_mut_unchecked` carries "must be the `Owned` variant" as an unchecked safety precondition backed by `unreachable_unchecked` — a UB footgun on an otherwise safe-looking accessor.
2. Change: each variant now carries its own type, `RawBorrowedAggregateResult` and `RawOwnedAggregateResult`, reached through `as_borrowed` / `as_owned` and their `_mut` counterparts. The partial operations move onto the type that supports them, where they are total; the enum keeps the shared surface (`len`, `capacity`, `kind_mask`, `reset`, `get`, `to_owned`) and the two constructors. No behaviour change, and the C ABI is unchanged.
3. Outcome: internal only — no user-visible change. It removes a class of runtime check from a type on every query path, and unblocks the suspend/resume work in #10892, whose aggregate helpers currently cannot distinguish "owns its children" from "borrows nothing yet".

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `RawBorrowedAggregateResult` / `RawOwnedAggregateResult` — the new payload types; check that each partial operation landed where it is total.
2. The Active/Suspended layout proof — now asserts field offsets with `offset_of!` instead of arguing in prose that `SmallThinVec` is pointer-sized in either mode.
3. `RSIndexResult::{push_borrowed, push_boxed, get_mut}` — same behaviour, but each panic is now raised and documented at the call site; `push_boxed`'s message was previously wrong.
4. `AggregateResult_GetMutUnchecked` — the sole surviving `unreachable_unchecked`, now unreachable from Rust and sitting with the C-caller contract that licenses it.
5. `headers/index_result_rs.h` — ABI-neutral: same size, same `.tag`, same `.borrowed` / `.owned` field paths.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
