### PR TITLE
[MOD-17308] FT.DEBUG NUMERIC_BUCKET_MAP now accepts GEO fields

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -3573,8 +3573,9 @@ DEBUG_COMMAND(DumpDeletedIds) {
 }
 
 // FT.DEBUG NUMERIC_BUCKET_MAP <index> <field>
-// Dumps the in-memory bucket routing map of a disk numeric field as a JSON
-// string: [{"max_val": ..., "state": "Active"|"BeingCreated", ("source": ...,)
+// Dumps the in-memory bucket routing map of a disk NUMERIC or GEO field (GEO
+// shares the NUMERIC field's bucket map) as a JSON string:
+// [{"max_val": ..., "state": "Active"|"BeingCreated", ("source": ...,)
 // "num_entries": ...}, ...]. Debug/testing only (e.g. asserting a bucket
 // split's routing state on a master and its replica).
 DEBUG_COMMAND(NumericBucketMap) {
@@ -3589,7 +3590,8 @@ DEBUG_COMMAND(NumericBucketMap) {
   if (!sctx->spec->diskSpec) {
     RedisModule_ReplyWithError(sctx->redisCtx, "NUMERIC_BUCKET_MAP is only supported on disk indexes");
   } else {
-    const FieldSpec *fs = getFieldByNameAndType(sctx->spec, argv[3], INDEXFLD_T_NUMERIC);
+    const FieldSpec *fs =
+        getFieldByNameAndType(sctx->spec, argv[3], INDEXFLD_T_NUMERIC | INDEXFLD_T_GEO);
     if (!fs) {
       RedisModule_ReplyWithError(sctx->redisCtx, "Unknown numeric field");
     } else {


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `FT.DEBUG NUMERIC_BUCKET_MAP <index> <field>` filters its field lookup to `INDEXFLD_T_NUMERIC` only, so it errors `"Unknown numeric field"` for a GEO field even though GEO fields are indexed through the same field-index-keyed `NumericInvertedIndex`/`BucketMap` as NUMERIC fields (`geoPreprocessor` converts lat/lon into a numeric score before the shared `numericIndexer` runs).
2. Change: Widen the field-type filter to `INDEXFLD_T_NUMERIC | INDEXFLD_T_GEO`, matching four other disk debug commands in this same file that already accept both types (`GCCleanNumeric` and others).
3. Outcome: `FT.DEBUG NUMERIC_BUCKET_MAP` now returns the real bucket map when called on a GEO field instead of erroring. Debug/test-tooling only — no product-facing command or API is affected.

#### Which additional issues this PR fixes

1. MOD-17308
2. N/A

#### Main objects this PR modified

1. `DEBUG_COMMAND(NumericBucketMap)` in `src/debug_commands.c` — widened the field-type filter passed to `getFieldByNameAndType`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
