### PR TITLE
Remove dead CMake config and stop double-compiling RMR sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,7 +370,6 @@ set(Boost_NO_WARN_NEW_VERSIONS ON)
 include_directories(
     ${root}/src
     ${root}/src/buffer
-    ${root}/src/dict
     ${root}/src/coord
     ${root}/src/redisearch_rs/headers
     ${root}/deps/libuv/include

--- a/src/coord/CMakeLists.txt
+++ b/src/coord/CMakeLists.txt
@@ -38,7 +38,12 @@ include_directories(
 
 add_subdirectory(rmr)
 
+# rmr/ has its own object library below (added via add_subdirectory), so exclude
+# it here — a bare *.c pattern recurses into every subdirectory, and without this
+# filter rmr's sources would be compiled twice: once into `rmr`, once again into
+# `coordinator-core`, both ending up in redisearch-coord's FINAL_OBJECTS below.
 file(GLOB_RECURSE COORDINATOR_SRC CONFIGURE_DEPENDS *.c *.cpp)
+list(FILTER COORDINATOR_SRC EXCLUDE REGEX "/rmr/")
 add_library(coordinator-core OBJECT ${COORDINATOR_SRC})
 
 

--- a/src/coord/rmr/CMakeLists.txt
+++ b/src/coord/rmr/CMakeLists.txt
@@ -2,8 +2,7 @@ get_filename_component(root ${CMAKE_CURRENT_LIST_DIR}/../../.. ABSOLUTE)
 message("# coord/rmr: root: " ${root})
 
 file(GLOB RMR_SRC
-    *.c
-    redise_parser/*.c)
+    *.c)
 
 include_directories(
 	${root}/src


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current**: The build configuration carries two references to directories that do
   not exist (`${root}/src/dict` in the root `include_directories()`, and a
   `redise_parser/*.c` glob in `src/coord/rmr/CMakeLists.txt`), and `coordinator-core`'s
   unqualified `file(GLOB_RECURSE ... *.c *.cpp)` recurses into `rmr/`, which already has
   its own object library — so every RMR source file gets compiled twice.
2. **Change**: Removes the two dead directory references, and excludes `rmr/` from
   `coordinator-core`'s glob so each RMR file compiles exactly once, via its existing
   `rmr` object library. `redisearch-coord`'s `FINAL_OBJECTS` list is unchanged.
3. **Outcome**: No functional change — verified with full rebuilds before and after each
   commit (`./build.sh DEBUG=1 FORCE`), and by inspecting the resulting archives directly:
   `chan.c.o` (an RMR file) now exists only under `rmr.dir/`, never under
   `coordinator-core.dir/`, and `MR_Fanout` (a real RMR symbol) still appears exactly once
   in the final `libredisearch-coord.a` and in `redisearch.so`'s defined symbols. Fewer
   translation units to compile, no behavior change.

Both issues were surfaced by a dependency-analysis tool developed in a parallel PR
(`eyalr-arch-ctxmap`); this PR does not depend on it and stands on its own.

#### Which additional issues this PR fixes

N/A — no tracked issue; a small build-hygiene fix found via static analysis.

#### Main objects this PR modified

1. `CMakeLists.txt` — removed the nonexistent `${root}/src/dict` include directory.
2. `src/coord/rmr/CMakeLists.txt` — removed the glob over the nonexistent `redise_parser/`.
3. `src/coord/CMakeLists.txt` — excluded `rmr/` from `coordinator-core`'s recursive glob.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
