### PR TITLE
[MOD-17800] Don't leak a heap byte into RDB and replication

### DIFF
--- a/src/trie/trie_node.c
+++ b/src/trie/trie_node.c
@@ -134,6 +134,9 @@ static inline TriePayload *triePayload_New(const char *payload, uint32_t plen) {
   TriePayload *p = rm_malloc(sizeof(TriePayload) + sizeof(char) * (plen + 1));
   p->len = plen;
   memcpy(p->data, payload, sizeof(char) * plen);
+  // the RDB writer saves `len + 1` bytes, so an unassigned terminator would put
+  // heap contents on the wire and make the saved bytes nondeterministic
+  p->data[plen] = '\0';
   return p;
 }
 

--- a/src/trie/trie_node_internal.h
+++ b/src/trie/trie_node_internal.h
@@ -30,7 +30,7 @@ extern "C" {
 #pragma pack(1)
 struct TriePayload {
   uint32_t len;  // 4G payload is more than enough!!!!
-  char data[];   // this means the data will not take an extra pointer.
+  char data[];   // `len` bytes plus a NUL terminator, inline so it costs no extra pointer.
 };
 #pragma pack()
 

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -1206,29 +1206,44 @@ TEST_F(TrieTest, testSearchTrimDropsTail) {
   TrieType_Free(t);
 }
 
+namespace {
+void *(*savedAlloc)(size_t) = nullptr;
+
+// Hands out allocations pre-filled with a non-zero pattern, so a byte the
+// allocating code never writes reads as garbage instead of an incidental zero.
+void *poisoningAlloc(size_t n) {
+  void *p = savedAlloc(n);
+  if (p) memset(p, 0xAA, n);
+  return p;
+}
+
+// Poisons rm_malloc (but not rm_calloc, whose zeroing is part of its contract)
+// for the enclosing scope.
+struct PoisonedAllocations {
+  PoisonedAllocations() {
+    savedAlloc = RedisModule_Alloc;
+    RedisModule_Alloc = poisoningAlloc;
+  }
+  ~PoisonedAllocations() {
+    RedisModule_Alloc = savedAlloc;
+  }
+};
+}  // namespace
+
 TEST_F(TrieTest, testPayloadTerminatorIsNul) {
   // The saver emits `len + 1` bytes, so the byte past the payload must be written
-  // rather than inherited from the allocator. Dirtying and freeing a block of
-  // exactly the size the payload will request makes an unwritten terminator
-  // observable: the recycled block still reads 0xAA. Both halves of the setup are
-  // load-bearing — macOS scrubs freed blocks below 64K, and a block the allocator
-  // has not seen before arrives zero-filled from the kernel.
-  const size_t plen = 65535;
-  const size_t blockSize = sizeof(TriePayload) + plen + 1;
+  // rather than inherited from the allocator.
+  const size_t plen = 8;
 
   Trie *t = NewTrie(NULL, Trie_Sort_Lex);
   std::unique_ptr<Trie, std::function<void(Trie *)>> tPtr(t, [](Trie *trie) { TrieType_Free(trie); });
   std::string payload(plen, 'z');
   RSPayload p = {.data = (char *)payload.data(), .len = plen};
 
-  // Dirty last: every allocation of a comparable size made after this point and
-  // before the insert would claim the recycled block instead of the payload.
-  void *dirty = rm_malloc(blockSize);
-  ASSERT_TRUE(dirty != nullptr);
-  memset(dirty, 0xAA, blockSize);
-  rm_free(dirty);
-
-  ASSERT_TRUE(Trie_InsertStringBuffer(t, "k", 1, 1.0, 0, &p, 0));
+  {
+    PoisonedAllocations poison;
+    ASSERT_TRUE(Trie_InsertStringBuffer(t, "k", 1, 1.0, 0, &p, 0));
+  }
 
   char *data = (char *)triePayload(t, "k", 1, true);
   ASSERT_TRUE(data != nullptr);

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -13,6 +13,7 @@
 #include "trie/trie_node_internal.h"  // whitebox: subtreeMaxScore invariant checks
 #include "trie/trie.h"
 #include "redismock/redismock.h"
+#include "rmalloc.h"
 
 #include <string>
 #include <memory>
@@ -1203,4 +1204,34 @@ TEST_F(TrieTest, testSearchTrimDropsTail) {
   Vector_Free(res);
 
   TrieType_Free(t);
+}
+
+TEST_F(TrieTest, testPayloadTerminatorIsNul) {
+  // The saver emits `len + 1` bytes, so the byte past the payload must be written
+  // rather than inherited from the allocator. Dirtying and freeing a block of
+  // exactly the size the payload will request makes an unwritten terminator
+  // observable: the recycled block still reads 0xAA. Both halves of the setup are
+  // load-bearing — macOS scrubs freed blocks below 64K, and a block the allocator
+  // has not seen before arrives zero-filled from the kernel.
+  const size_t plen = 65535;
+  const size_t blockSize = sizeof(TriePayload) + plen + 1;
+
+  Trie *t = NewTrie(NULL, Trie_Sort_Lex);
+  std::unique_ptr<Trie, std::function<void(Trie *)>> tPtr(t, [](Trie *trie) { TrieType_Free(trie); });
+  std::string payload(plen, 'z');
+  RSPayload p = {.data = (char *)payload.data(), .len = plen};
+
+  // Dirty last: every allocation of a comparable size made after this point and
+  // before the insert would claim the recycled block instead of the payload.
+  void *dirty = rm_malloc(blockSize);
+  ASSERT_TRUE(dirty != nullptr);
+  memset(dirty, 0xAA, blockSize);
+  rm_free(dirty);
+
+  ASSERT_TRUE(Trie_InsertStringBuffer(t, "k", 1, 1.0, 0, &p, 0));
+
+  char *data = (char *)triePayload(t, "k", 1, true);
+  ASSERT_TRUE(data != nullptr);
+  EXPECT_EQ(0, memcmp(payload.data(), data, plen));
+  EXPECT_EQ('\0', data[plen]);
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `triePayload_New` allocates one byte past the payload as a terminator slot but never assigns it, and `TrieType_GenericSave` writes `payload.len + 1` bytes. Every suggestion payload therefore puts one uninitialized heap byte on the wire.
2. Change: the terminator is assigned. The loader already discarded that byte, so nothing about how payloads are read changes.
3. Outcome: RDB output is byte-identical for identical logical content, and the one byte of process heap that used to accompany every `FT.SUGADD ... PAYLOAD` entry into RDB files and the replication stream no longer leaks. `FT.SUGADD` is the only command reaching this path.

#### Which additional issues this PR fixes

1. [MOD-17800](https://redislabs.atlassian.net/browse/MOD-17800)
2. N/A

#### Main objects this PR modified

1. `triePayload_New` (`src/trie/trie_node.c`) — assigns the trailing NUL the RDB writer has always been saving.
2. `TrieTest.testPayloadTerminatorIsNul` (`tests/cpptests/test_cpp_trie.cpp`) — new test pinning the invariant. It swaps `RedisModule_Alloc` for a wrapper that pre-fills every block with a non-zero pattern for the duration of the insert, so the byte the allocating code fails to write reads as garbage rather than depending on what the heap happens to hold.
3. `struct TriePayload` (`src/trie/trie_node_internal.h`) — the comment on `data[]` now states that it holds a terminator past `len` bytes.

#### Mark if applicable

- [ ] This PR introduces API changes
- [x] This PR introduces serialization changes

The bytes written for a payload change: the terminator is now always `0x00` instead of arbitrary heap contents. Both directions stay loadable — the C loader has always dropped that byte without inspecting it — so no migration or version gate is needed, and RDBs written by older versions load unchanged.

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes


[MOD-17800]: https://redislabs.atlassian.net/browse/MOD-17800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
