### PR TITLE
[MOD-14888] hidden_string: truncate secret_value at the first NUL

### DIFF
--- a/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
@@ -47,6 +47,11 @@ impl HiddenString {
 
     /// Get the secret (aka. "unsafe" in C land) value from the underlying [`ffi::HiddenString`].
     ///
+    /// A name is taken up to its first NUL. Names normally hold none of their
+    /// own, so that is the terminator and the whole name comes back; one that
+    /// does hold an interior NUL is truncated there, as a `%s`-formatted C site
+    /// truncates the same pointer.
+    ///
     /// This is safe **only if** the C function returns a pointer that stays valid
     /// for at least the lifetime of `self`, and the memory contains a NUL at `len`.
     pub fn secret_value(&self) -> &CStr {
@@ -63,7 +68,7 @@ impl HiddenString {
         // Safety: must be ensured by the implementation of `ffi::HiddenString_GetUnsafe` above.
         let bytes = unsafe { core::slice::from_raw_parts(data.cast::<u8>(), n) };
 
-        CStr::from_bytes_with_nul(bytes).expect("malformed C string")
+        CStr::from_bytes_until_nul(bytes).expect("unterminated C string")
     }
 }
 

--- a/src/redisearch_rs/c_wrappers/hidden_string/tests/tests.rs
+++ b/src/redisearch_rs/c_wrappers/hidden_string/tests/tests.rs
@@ -52,6 +52,33 @@ fn get_secret_value() {
     miri,
     ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
 )]
+fn secret_value_truncates_at_an_interior_nul() {
+    // A name holding a NUL of its own. The trailing NUL is the terminator
+    // every hidden string carries; `len` excludes it, as the C side reports it.
+    let input: Vec<u8> = b"v\0hidden\0".to_vec();
+    let len = input.len() - 1;
+    // SAFETY: `input` is a live allocation of `len + 1` bytes terminated by a
+    // NUL, and is neither moved nor mutated while borrowed below.
+    // `takeOwnership = false`, so the wrapper borrows it rather than adopting
+    // it — `input` stays the owner and frees it on drop.
+    let ffi_hs = unsafe { ffi::NewHiddenString(input.as_ptr().cast(), len, false) };
+    // SAFETY: `ffi_hs` is a valid `HiddenString` just returned by
+    // `NewHiddenString`, and `input` outlives every borrow taken from it.
+    let sut = unsafe { HiddenString::from_raw(ffi_hs) };
+
+    assert_eq!(sut.secret_value(), c"v");
+
+    // SAFETY: `ffi_hs` has not been freed yet and no borrow of it is live.
+    // The `false` matches the `takeOwnership` passed to `NewHiddenString`, so
+    // this frees only the wrapper and leaves `input`'s buffer to `input`.
+    unsafe { ffi::HiddenString_Free(ffi_hs, false) };
+}
+
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "extern static `RedisModule_Alloc` is not supported by Miri"
+)]
 fn debug_output() {
     let input = c"Ab#123!";
     let ffi_hs = unsafe { ffi::NewHiddenString(input.as_ptr(), input.count_bytes(), false) };


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `HiddenString::secret_value` requires the name to hold no NUL within its reported length, and panics otherwise. Names are binary-safe, and the C sites being ported format them with `%s`, which truncates at an interior NUL rather than rejecting it.
2. Change: `secret_value` now takes the name up to its first NUL. Names normally hold none of their own, so that NUL is the terminator and the whole name comes back — only the case that previously panicked behaves differently.
3. Outcome: No change for any existing caller, since none passes a name with an interior NUL today. It removes a panic path from a safe accessor and unblocks the Rust QN_VECTOR evaluator (MOD-14888), which must truncate the vector query name the way the C code does.

#### Which additional issues this PR fixes

1. MOD-14888

#### Main objects this PR modified

1. `HiddenString::secret_value` (`hidden_string` crate) — `CStr::from_bytes_until_nul` in place of `from_bytes_with_nul`; the only behavioural change in the PR.
2. `hidden_string` tests — coverage for a name carrying an interior NUL, which previously panicked.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
