### PR TITLE
[MOD-14888] query_node_ref: add take_dist_field

### DIFF
--- a/src/redisearch_rs/c_wrappers/query/src/query_node_ref.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_node_ref.rs
@@ -9,7 +9,7 @@
 
 //! Safe wrapper around [`ffi::RSQueryNode`].
 
-use std::{marker::PhantomData, ops::Deref, ptr::NonNull};
+use std::{ffi::c_char, marker::PhantomData, ops::Deref, ptr::NonNull};
 
 use inverted_index::NumericFilter;
 use query_types::{QueryNodeOptions, QueryNodeType};
@@ -540,6 +540,30 @@ impl QueryNodeMut<'_> {
         // SAFETY: as above — `opts` points to a valid, exclusively-owned
         // `QueryNodeOptions`.
         unsafe { (*opts).field_mask &= mask };
+    }
+
+    /// Take the node's [distance field](QueryNodeOptions::dist_field), leaving
+    /// it null.
+    ///
+    /// Ownership of the string transfers to the caller: the node no longer
+    /// frees it when it is destroyed, so whatever the caller moves it onto must.
+    /// It comes from the module allocator, so releasing it means `rm_free` —
+    /// either directly, or by handing it to a C field whose owner frees it that
+    /// way. Passing it to [`CString::from_raw`](std::ffi::CString::from_raw)
+    /// would release it through Rust's global allocator instead.
+    ///
+    /// Returns null when the node names no distance field.
+    #[must_use = "the node no longer frees the returned string; dropping it here leaks it"]
+    pub fn take_dist_field(&mut self) -> *mut c_char {
+        // SAFETY: the node is valid, so a raw pointer to its `dist_field` is in
+        // bounds; `&mut self` plus the exclusive-access invariant of
+        // [`QueryNodeMut::new`] guarantee nothing else aliases it, so the
+        // read-then-clear below cannot race.
+        let dist_field = unsafe { &raw mut (*self.0.as_ptr()).opts.dist_field };
+        // SAFETY: as above — `dist_field` points to an initialized, exclusively
+        // owned pointer, and the swap goes through the raw pointer without
+        // forming an intermediate reference.
+        unsafe { std::ptr::replace(dist_field, std::ptr::null_mut()) }
     }
 
     /// Reborrow the child at `index` as an exclusive [`QueryNodeMut`].

--- a/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/tests/integration/query_node_ref/mod.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::ffi::CString;
+
 use inverted_index::NumericFilter;
 use query::{
     QueryNode, QueryNodeMut, QueryNodeRef, WildcardMode,
@@ -266,6 +268,40 @@ fn query_node_mut_narrows_child_field_masks() {
 
     // The parent's own mask is untouched.
     assert_eq!(node.opts().field_mask, 0b0110);
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (array_new_sz)")]
+fn query_node_mut_takes_the_dist_field() {
+    // The node is left naming no distance field, which is what stops it freeing
+    // a string the caller now owns. `name` outlives the node and owns the
+    // allocation throughout, so nothing here frees it twice.
+    let name = CString::new("__v_score").unwrap();
+    let mut mock = MockQueryNode::new(QueryNodeType::Vector);
+    mock.opts_mut().dist_field = name.as_ptr().cast_mut();
+
+    // SAFETY: sole wrapper to a valid leaf node; no other wrapper or derived
+    // reference is live.
+    let mut node = unsafe { QueryNodeMut::new(mock.as_non_null()) };
+
+    assert_eq!(node.take_dist_field(), name.as_ptr().cast_mut());
+    assert!(node.opts().dist_field.is_null());
+
+    // Idempotent: the string has already been handed over, so a second call
+    // cannot hand it over again.
+    assert!(node.take_dist_field().is_null());
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (array_new_sz)")]
+fn query_node_mut_takes_an_absent_dist_field_as_null() {
+    let mock = MockQueryNode::new(QueryNodeType::Vector);
+
+    // SAFETY: sole wrapper to a valid leaf node; no other wrapper or derived
+    // reference is live.
+    let mut node = unsafe { QueryNodeMut::new(mock.as_non_null()) };
+
+    assert!(node.take_dist_field().is_null());
 }
 
 #[test]


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `QueryNodeMut` exposes the node's distance field for reading only. A caller that wants to move that string onto another owner has no way to tell the node it no longer owns it, so the string would be freed twice when the node is destroyed.
2. Change: Adds `QueryNodeMut::take_dist_field`, which reads the node's `dist_field` and clears it to NULL in one step, transferring ownership of the string to the caller. Returns NULL when the node names no distance field.
3. Outcome: Internal-only; no user-visible change. It unblocks the Rust QN_VECTOR evaluator (MOD-14888), which moves the distance field onto the `VectorQuery` it builds.

#### Which additional issues this PR fixes

1. MOD-14888

#### Main objects this PR modified

1. `QueryNodeMut` (`query` crate, `query_node_ref.rs`) — new `take_dist_field` accessor; the only ownership-transferring method on the type, so its contract is what a reviewer should check first.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
