### PR TITLE
[MOD-14888] hidden_string: document the name buffer's requirements

### DIFF
--- a/src/obfuscation/hidden.h
+++ b/src/obfuscation/hidden.h
@@ -23,6 +23,16 @@ typedef struct HiddenString HiddenString;
 // This is a security measure to prevent leaking user data
 // The additional takeOwnership determines whether to duplicate the buffer or directly point at the given buffer
 // HiddenString_Free must be called for the object to release it
+//
+// name must be readable for length bytes; length excludes the terminator.
+// With takeOwnership = false the buffer is borrowed, so it must also carry a NUL
+// at name[length] and stay alive and unmodified while the string points at it.
+// With takeOwnership = true rm_strndup copies the bytes and adds its own
+// terminator, so neither applies.
+//
+// Interior NUL bytes are accepted but not honoured: the comparison functions and
+// any %s formatting stop at the first one, so names differing only after it are
+// indistinguishable.
 HiddenString *NewHiddenString(const char *name, size_t length, bool takeOwnership);
 // Frees a hidden string, if takeOwnership is true, the buffer is freed as well
 void HiddenString_Free(const HiddenString *value, bool tookOwnership);
@@ -54,6 +64,12 @@ RedisModuleString *HiddenString_CreateRedisModuleString(const HiddenString* valu
 // 1. Logs
 // 2. Metrics
 // 3. Command responses
+//
+// Returns the name buffer, writing its length to length when that is non-NULL.
+// Its shape is NewHiddenString's contract above.
+//
+// HiddenString_Clone and HiddenString_TakeOwnership point the string at a
+// different buffer, so a pointer retained across either is stale.
 const char *HiddenString_GetUnsafe(const HiddenString* value, size_t* length);
 
 #ifdef __cplusplus

--- a/src/redisearch_rs/c_wrappers/field_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/field_spec/src/lib.rs
@@ -62,10 +62,14 @@ impl FieldSpec {
     ///
     /// 1. `ptr` must be a valid non-null pointer to an `ffi::FieldSpec` that is properly initialized.
     ///    This also applies to any of its subfields.
+    /// 2. The name buffers behind `fieldName` and `fieldPath` must each satisfy
+    ///    clauses (2.) and (3.) of [`HiddenString::from_raw`] for `'a`. They are
+    ///    separate allocations the specs merely borrow, so that does not follow
+    ///    from (1.).
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
     pub const unsafe fn from_raw<'a>(ptr: *const ffi::FieldSpec) -> &'a Self {
-        // Safety: ensured by caller (1.)
+        // Safety: ensured by caller (1., 2.)
         unsafe { ptr.cast::<Self>().as_ref().unwrap() }
     }
 
@@ -77,13 +81,13 @@ impl FieldSpec {
 
     /// Get the underlying field name as a `&HiddenString`.
     pub const fn field_name(&self) -> &HiddenString {
-        // Safety: (1.) due to creation with `FieldSpec::from_raw`
+        // Safety: (1.) and (2.) of `FieldSpec::from_raw`.
         unsafe { HiddenString::from_raw(self.0.fieldName) }
     }
 
     /// Get the underlying field path as a `&HiddenString`.
     pub const fn field_path(&self) -> &HiddenString {
-        // Safety: (1.) due to creation with `FieldSpec::from_raw`
+        // Safety: (1.) and (2.) of `FieldSpec::from_raw`.
         unsafe { HiddenString::from_raw(self.0.fieldPath) }
     }
 

--- a/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/hidden_string/src/lib.rs
@@ -28,11 +28,18 @@ impl HiddenString {
     ///
     /// 1. `ptr` must be a [valid], non-null pointer to a properly initialized
     ///    `ffi::HiddenString`, including its subfields.
-    /// 2. The pointee must not be mutated for the entire lifetime `'a`.
+    /// 2. The name buffer must be [valid] for reads of the length the string
+    ///    reports plus a NUL terminator at that length, as `NewHiddenString`
+    ///    requires. It is a separate allocation the string may merely borrow,
+    ///    so this does not follow from (1.).
+    /// 3. Neither the pointee nor that buffer may be mutated, freed, or swapped
+    ///    out for the entire lifetime `'a` — `HiddenString_Clone` and
+    ///    `HiddenString_TakeOwnership` swap the buffer out, leaving the borrow
+    ///    on the old one.
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
     pub const unsafe fn from_raw<'a>(ptr: *const ffi::HiddenString) -> &'a Self {
-        // SAFETY: Ensured by caller (1., 2.)
+        // SAFETY: Ensured by caller (1., 2., 3.)
         unsafe {
             ptr.cast::<Self>()
                 .as_ref()
@@ -47,13 +54,9 @@ impl HiddenString {
 
     /// Get the secret (aka. "unsafe" in C land) value from the underlying [`ffi::HiddenString`].
     ///
-    /// A name is taken up to its first NUL. Names normally hold none of their
-    /// own, so that is the terminator and the whole name comes back; one that
-    /// does hold an interior NUL is truncated there, as a `%s`-formatted C site
+    /// The name is taken up to its first NUL: normally the terminator, so the
+    /// whole name comes back, but an interior NUL truncates it — as `%s`
     /// truncates the same pointer.
-    ///
-    /// This is safe **only if** the C function returns a pointer that stays valid
-    /// for at least the lifetime of `self`, and the memory contains a NUL at `len`.
     pub fn secret_value(&self) -> &CStr {
         let mut len = 0;
 
@@ -65,7 +68,9 @@ impl HiddenString {
 
         // The length doesn't include the nul terminator so we need to add one.
         let n = len.checked_add(1).expect("length overflow");
-        // Safety: must be ensured by the implementation of `ffi::HiddenString_GetUnsafe` above.
+        // SAFETY: clause (2.) of `from_raw` makes the buffer readable through the
+        // terminator, which is exactly `n`, and clause (3.) keeps it so for
+        // `'a`, which outlives this borrow.
         let bytes = unsafe { core::slice::from_raw_parts(data.cast::<u8>(), n) };
 
         CStr::from_bytes_until_nul(bytes).expect("unterminated C string")


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `HiddenString::from_raw` requires the `ffi::HiddenString` pointee and its subfields to be initialized. The name buffer is a separate allocation the string may merely borrow, and `secret_value` reads it up to and including the terminator one byte past the reported length — none of which the contract grants. `FieldSpec::from_raw` has the same gap for the names it wraps.
2. Change: Both contracts now state what the accessor actually needs: a NUL at the reported length, readability up to and including it, and that neither the string nor its buffer is mutated or freed for the borrow's lifetime.
3. Outcome: Internal-only; no behaviour change. The safety arguments in `hidden_string` and `field_spec` now rest on requirements the constructors publish, rather than on ones their callers were silently assumed to meet.

#### Which additional issues this PR fixes

1. MOD-14888

#### Main objects this PR modified

1. `HiddenString::from_raw` — the terminator, the buffer's extent, and its immutability are now clauses (2.) through (4.); `secret_value` cites them instead of asserting the buffer is valid on its own authority.
2. `FieldSpec::from_raw` — a matching clause covering `fieldName` and `fieldPath`, deferring to `HiddenString::from_raw` rather than restating it.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
