### PR TITLE
[MOD-17730] Accept legacy values for search configuration parameters

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -256,17 +256,6 @@ static int set_max_aggregate_results_config(const char *name, long long val, voi
   return REDISMODULE_OK;
 }
 
-// 0 is legal on the legacy FORK_GC_CLEAN_THRESHOLD path but the native path does not mirror that;
-// it warns and keeps the current value.
-static int set_fork_gc_clean_threshold_config(const char *name, long long val, void *privdata,
-                                               RedisModuleString **err) {
-  if (val == 0) {
-    return warn_or_reject_size_t_config(name, val, (const size_t *)privdata, err);
-  }
-  *(size_t *)privdata = (size_t)val;
-  return REDISMODULE_OK;
-}
-
 // Signed-int getter, for fields that use a negative sentinel (e.g. -1 = "unlimited").
 static long long get_int_numeric_config(const char *name, void *privdata) {
   REDISMODULE_NOT_USED(name);
@@ -2220,7 +2209,7 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
       ctx, "search-fork-gc-clean-threshold",
       SearchDisk_IsEnabledForValidation() ? DEFAULT_DISK_GC_CLEAN_THRESHOLD : DEFAULT_FORK_GC_CLEAN_THRESHOLD,
       REDISMODULE_CONFIG_UNPREFIXED, 0,
-      LLONG_MAX, get_size_t_numeric_config, set_fork_gc_clean_threshold_config, NULL,
+      LLONG_MAX, get_size_t_numeric_config, set_size_t_numeric_config, NULL,
       (void *)&(RSGlobalConfig.gcConfigParams.gcSettings.forkGcCleanThreshold)
     )
   )

--- a/src/config.c
+++ b/src/config.c
@@ -203,6 +203,23 @@ static long long get_uint_numeric_config(const char *name, void *privdata) {
   return (long long)(*(unsigned int *)privdata);
 }
 
+// Legacy MAXSEARCHRESULTS -1 means unlimited; shared with setMaxSearchResults so the legacy and
+// native paths cannot drift.
+static size_t translateOrClampMaxSearchResults(long long val) {
+  if (val < 0) {
+    return MAX_SEARCH_REQUEST_RESULTS;
+  }
+  return (size_t)MIN(val, (long long)MAX_SEARCH_REQUEST_RESULTS);
+}
+
+static int set_max_search_results_config(const char *name, long long val, void *privdata,
+                                          RedisModuleString **err) {
+  REDISMODULE_NOT_USED(name);
+  REDISMODULE_NOT_USED(err);
+  *(size_t *)privdata = translateOrClampMaxSearchResults(val);
+  return REDISMODULE_OK;
+}
+
 // Signed-int getter, for fields that use a negative sentinel (e.g. -1 = "unlimited").
 static long long get_int_numeric_config(const char *name, void *privdata) {
   REDISMODULE_NOT_USED(name);
@@ -523,12 +540,7 @@ CONFIG_SETTER(setMaxSearchResults) {
   long long newSize = 0;
   int acrc = AC_GetLongLong(ac, &newSize, 0);
   CHECK_RETURN_PARSE_ERROR(acrc)
-  if (newSize < 0) {
-    newSize = MAX_SEARCH_REQUEST_RESULTS;
-  } else {
-    newSize = MIN(newSize, MAX_SEARCH_REQUEST_RESULTS);
-  }
-  config->maxSearchResults = newSize;
+  config->maxSearchResults = translateOrClampMaxSearchResults(newSize);
   return REDISMODULE_OK;
 }
 
@@ -2271,8 +2283,8 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
   RM_TRY(
     RedisModule_RegisterNumericConfig(
       ctx, "search-max-search-results", DEFAULT_MAX_SEARCH_REQUEST_RESULTS,
-      REDISMODULE_CONFIG_UNPREFIXED, 0,
-      MAX_SEARCH_REQUEST_RESULTS, get_size_t_numeric_config, set_size_t_numeric_config, NULL,
+      REDISMODULE_CONFIG_UNPREFIXED, LLONG_MIN,
+      MAX_SEARCH_REQUEST_RESULTS, get_size_t_numeric_config, set_max_search_results_config, NULL,
       (void *)&(RSGlobalConfig.maxSearchResults)
     )
   )
@@ -2317,7 +2329,7 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
   RM_TRY(
     RedisModule_RegisterNumericConfig(
       ctx, "search-multi-text-slop", DEFAULT_MULTI_TEXT_SLOP,
-      REDISMODULE_CONFIG_IMMUTABLE | REDISMODULE_CONFIG_UNPREFIXED, 1,
+      REDISMODULE_CONFIG_IMMUTABLE | REDISMODULE_CONFIG_UNPREFIXED, 0,
       UINT32_MAX, get_uint_numeric_config, set_uint_numeric_config, NULL,
       (void *)&(RSGlobalConfig.multiTextOffsetDelta)
     )
@@ -2336,7 +2348,7 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
     RedisModule_RegisterNumericConfig(
       ctx, "search-timeout",
       SearchDisk_IsEnabled() ? DEFAULT_QUERY_TIMEOUT_MS_FLEX : DEFAULT_QUERY_TIMEOUT_MS,
-      REDISMODULE_CONFIG_UNPREFIXED, 1,
+      REDISMODULE_CONFIG_UNPREFIXED, 0,
       LLONG_MAX, get_long_numeric_config, set_long_numeric_config, NULL,
       (void *)&(RSGlobalConfig.requestConfigParams.queryTimeoutMS)
     )

--- a/src/config.c
+++ b/src/config.c
@@ -212,7 +212,7 @@ void RSConfig_SetLoadingStartupConfig(bool loading) {
 
 // Startup must never abort, so an out-of-range value keeps the config's current value with a
 // warning; CONFIG SET stays strict.
-static int warn_or_reject_size_t_config(const char *name, long long val, size_t *privdata,
+static int warn_or_reject_size_t_config(const char *name, long long val, const size_t *privdata,
                                          RedisModuleString **err) {
   if (loadingStartupConfig) {
     RedisModule_Log(RSDummyContext, "warning", "%s: value %lld is out of range, keeping %zu",
@@ -257,7 +257,7 @@ static int set_max_aggregate_results_config(const char *name, long long val, voi
 static int set_fork_gc_clean_threshold_config(const char *name, long long val, void *privdata,
                                                RedisModuleString **err) {
   if (val == 0) {
-    return warn_or_reject_size_t_config(name, val, (size_t *)privdata, err);
+    return warn_or_reject_size_t_config(name, val, (const size_t *)privdata, err);
   }
   *(size_t *)privdata = (size_t)val;
   return REDISMODULE_OK;
@@ -2321,7 +2321,7 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
   RM_TRY(
     RedisModule_RegisterNumericConfig(
       ctx, "search-max-search-results", DEFAULT_MAX_SEARCH_REQUEST_RESULTS,
-      REDISMODULE_CONFIG_UNPREFIXED, LLONG_MIN,
+      REDISMODULE_CONFIG_UNPREFIXED, -1,
       MAX_SEARCH_REQUEST_RESULTS, get_size_t_numeric_config, set_max_search_results_config, NULL,
       (void *)&(RSGlobalConfig.maxSearchResults)
     )

--- a/src/config.c
+++ b/src/config.c
@@ -203,6 +203,27 @@ static long long get_uint_numeric_config(const char *name, void *privdata) {
   return (long long)(*(unsigned int *)privdata);
 }
 
+// True only while RedisModule_LoadConfigs (called from RediSearch_InitModuleConfig) is running.
+static bool loadingStartupConfig = false;
+
+void RSConfig_SetLoadingStartupConfig(bool loading) {
+  loadingStartupConfig = loading;
+}
+
+// Startup must never abort, so an out-of-range value keeps the config's current value with a
+// warning; CONFIG SET stays strict.
+static int warn_or_reject_size_t_config(const char *name, long long val, size_t *privdata,
+                                         RedisModuleString **err) {
+  if (loadingStartupConfig) {
+    RedisModule_Log(RSDummyContext, "warning", "%s: value %lld is out of range, keeping %zu",
+                     name, val, *privdata);
+    return REDISMODULE_OK;
+  }
+  RS_ASSERT(err);
+  *err = RedisModule_CreateStringPrintf(NULL, "%s: value %lld is out of range", name, val);
+  return REDISMODULE_ERR;
+}
+
 // Legacy MAXSEARCHRESULTS -1 means unlimited; shared with setMaxSearchResults so the legacy and
 // native paths cannot drift.
 static size_t translateOrClampMaxSearchResults(long long val) {
@@ -217,6 +238,29 @@ static int set_max_search_results_config(const char *name, long long val, void *
   REDISMODULE_NOT_USED(name);
   REDISMODULE_NOT_USED(err);
   *(size_t *)privdata = translateOrClampMaxSearchResults(val);
+  return REDISMODULE_OK;
+}
+
+// Unlike search-max-search-results, a negative value here does not translate to unlimited on the
+// native path; it warns and keeps the current value. Positive values are still bounded by the
+// registered max (MAX_AGGREGATE_REQUEST_RESULTS), enforced by core before this setter runs.
+static int set_max_aggregate_results_config(const char *name, long long val, void *privdata,
+                                             RedisModuleString **err) {
+  if (val < 0) {
+    return warn_or_reject_size_t_config(name, val, (size_t *)privdata, err);
+  }
+  *(size_t *)privdata = (size_t)val;
+  return REDISMODULE_OK;
+}
+
+// 0 is legal on the legacy FORK_GC_CLEAN_THRESHOLD path but the native path does not mirror that;
+// it warns and keeps the current value.
+static int set_fork_gc_clean_threshold_config(const char *name, long long val, void *privdata,
+                                               RedisModuleString **err) {
+  if (val == 0) {
+    return warn_or_reject_size_t_config(name, val, (size_t *)privdata, err);
+  }
+  *(size_t *)privdata = (size_t)val;
   return REDISMODULE_OK;
 }
 
@@ -2177,8 +2221,8 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
     RedisModule_RegisterNumericConfig (
       ctx, "search-fork-gc-clean-threshold",
       SearchDisk_IsEnabledForValidation() ? DEFAULT_DISK_GC_CLEAN_THRESHOLD : DEFAULT_FORK_GC_CLEAN_THRESHOLD,
-      REDISMODULE_CONFIG_UNPREFIXED, 1,
-      LLONG_MAX, get_size_t_numeric_config, set_size_t_numeric_config, NULL,
+      REDISMODULE_CONFIG_UNPREFIXED, 0,
+      LLONG_MAX, get_size_t_numeric_config, set_fork_gc_clean_threshold_config, NULL,
       (void *)&(RSGlobalConfig.gcConfigParams.gcSettings.forkGcCleanThreshold)
     )
   )
@@ -2237,8 +2281,8 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
       ctx, "search-max-aggregate-results",
       SearchDisk_IsEnabled() ? DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS_FLEX
                              : DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS,
-      REDISMODULE_CONFIG_UNPREFIXED, 0,
-      MAX_AGGREGATE_REQUEST_RESULTS, get_size_t_numeric_config, set_size_t_numeric_config,
+      REDISMODULE_CONFIG_UNPREFIXED, -1,
+      MAX_AGGREGATE_REQUEST_RESULTS, get_size_t_numeric_config, set_max_aggregate_results_config,
       NULL, (void *)&(RSGlobalConfig.maxAggregateResults)
     )
   )

--- a/src/config.c
+++ b/src/config.c
@@ -2269,7 +2269,10 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
       SearchDisk_IsEnabled() ? DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS_FLEX
                              : DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS,
       REDISMODULE_CONFIG_UNPREFIXED, LLONG_MIN,
-      MAX_AGGREGATE_REQUEST_RESULTS, get_size_t_numeric_config, set_max_aggregate_results_config,
+      // Registered max is LLONG_MAX, not MAX_AGGREGATE_REQUEST_RESULTS: an over-cap value must
+      // reach set_max_aggregate_results_config(), which clamps it via translateOrClampMaxResults,
+      // rather than being rejected by core before the setter runs.
+      LLONG_MAX, get_size_t_numeric_config, set_max_aggregate_results_config,
       NULL, (void *)&(RSGlobalConfig.maxAggregateResults)
     )
   )
@@ -2315,7 +2318,9 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
     RedisModule_RegisterNumericConfig(
       ctx, "search-max-search-results", DEFAULT_MAX_SEARCH_REQUEST_RESULTS,
       REDISMODULE_CONFIG_UNPREFIXED, LLONG_MIN,
-      MAX_SEARCH_REQUEST_RESULTS, get_size_t_numeric_config, set_max_search_results_config, NULL,
+      // See the matching comment on search-max-aggregate-results: registered max is LLONG_MAX so
+      // an over-cap value reaches set_max_search_results_config() to be clamped, not rejected.
+      LLONG_MAX, get_size_t_numeric_config, set_max_search_results_config, NULL,
       (void *)&(RSGlobalConfig.maxSearchResults)
     )
   )

--- a/src/config.c
+++ b/src/config.c
@@ -235,19 +235,23 @@ static size_t translateOrClampMaxResults(long long val, size_t max) {
 
 static int set_max_search_results_config(const char *name, long long val, void *privdata,
                                           RedisModuleString **err) {
-  REDISMODULE_NOT_USED(name);
-  REDISMODULE_NOT_USED(err);
+  // Only the -1 sentinel means unlimited; any other negative is out of range.
+  if (val < -1) {
+    return warn_or_reject_size_t_config(name, val, (const size_t *)privdata, err);
+  }
   *(size_t *)privdata = translateOrClampMaxResults(val, MAX_SEARCH_REQUEST_RESULTS);
   return REDISMODULE_OK;
 }
 
-// Like search-max-search-results, a negative value translates to unlimited rather than being
-// rejected: the default on Flex/SearchDisk installs is DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS_FLEX
-// (1,000,000), not the max, so defaulting a legacy -1 would silently impose a 1M cap.
+// Like search-max-search-results, -1 translates to unlimited rather than being rejected: the
+// default on Flex/SearchDisk installs is DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS_FLEX (1,000,000),
+// not the max, so defaulting a legacy -1 would silently impose a 1M cap.
 static int set_max_aggregate_results_config(const char *name, long long val, void *privdata,
                                              RedisModuleString **err) {
-  REDISMODULE_NOT_USED(name);
-  REDISMODULE_NOT_USED(err);
+  // Only the -1 sentinel means unlimited; any other negative is out of range.
+  if (val < -1) {
+    return warn_or_reject_size_t_config(name, val, (const size_t *)privdata, err);
+  }
   *(size_t *)privdata = translateOrClampMaxResults(val, MAX_AGGREGATE_REQUEST_RESULTS);
   return REDISMODULE_OK;
 }
@@ -2275,7 +2279,7 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
       ctx, "search-max-aggregate-results",
       SearchDisk_IsEnabled() ? DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS_FLEX
                              : DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS,
-      REDISMODULE_CONFIG_UNPREFIXED, -1,
+      REDISMODULE_CONFIG_UNPREFIXED, LLONG_MIN,
       MAX_AGGREGATE_REQUEST_RESULTS, get_size_t_numeric_config, set_max_aggregate_results_config,
       NULL, (void *)&(RSGlobalConfig.maxAggregateResults)
     )
@@ -2321,7 +2325,7 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
   RM_TRY(
     RedisModule_RegisterNumericConfig(
       ctx, "search-max-search-results", DEFAULT_MAX_SEARCH_REQUEST_RESULTS,
-      REDISMODULE_CONFIG_UNPREFIXED, -1,
+      REDISMODULE_CONFIG_UNPREFIXED, LLONG_MIN,
       MAX_SEARCH_REQUEST_RESULTS, get_size_t_numeric_config, set_max_search_results_config, NULL,
       (void *)&(RSGlobalConfig.maxSearchResults)
     )

--- a/src/config.c
+++ b/src/config.c
@@ -224,32 +224,31 @@ static int warn_or_reject_size_t_config(const char *name, long long val, size_t 
   return REDISMODULE_ERR;
 }
 
-// Legacy MAXSEARCHRESULTS -1 means unlimited; shared with setMaxSearchResults so the legacy and
-// native paths cannot drift.
-static size_t translateOrClampMaxSearchResults(long long val) {
+// Legacy MAXSEARCHRESULTS/MAXAGGREGATERESULTS -1 means unlimited; shared with setMaxSearchResults
+// and setMaxAggregateResults so the legacy and native paths cannot drift.
+static size_t translateOrClampMaxResults(long long val, size_t max) {
   if (val < 0) {
-    return MAX_SEARCH_REQUEST_RESULTS;
+    return max;
   }
-  return (size_t)MIN(val, (long long)MAX_SEARCH_REQUEST_RESULTS);
+  return (size_t)MIN(val, (long long)max);
 }
 
 static int set_max_search_results_config(const char *name, long long val, void *privdata,
                                           RedisModuleString **err) {
   REDISMODULE_NOT_USED(name);
   REDISMODULE_NOT_USED(err);
-  *(size_t *)privdata = translateOrClampMaxSearchResults(val);
+  *(size_t *)privdata = translateOrClampMaxResults(val, MAX_SEARCH_REQUEST_RESULTS);
   return REDISMODULE_OK;
 }
 
-// Unlike search-max-search-results, a negative value here does not translate to unlimited on the
-// native path; it warns and keeps the current value. Positive values are still bounded by the
-// registered max (MAX_AGGREGATE_REQUEST_RESULTS), enforced by core before this setter runs.
+// Like search-max-search-results, a negative value translates to unlimited rather than being
+// rejected: the default on Flex/SearchDisk installs is DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS_FLEX
+// (1,000,000), not the max, so defaulting a legacy -1 would silently impose a 1M cap.
 static int set_max_aggregate_results_config(const char *name, long long val, void *privdata,
                                              RedisModuleString **err) {
-  if (val < 0) {
-    return warn_or_reject_size_t_config(name, val, (size_t *)privdata, err);
-  }
-  *(size_t *)privdata = (size_t)val;
+  REDISMODULE_NOT_USED(name);
+  REDISMODULE_NOT_USED(err);
+  *(size_t *)privdata = translateOrClampMaxResults(val, MAX_AGGREGATE_REQUEST_RESULTS);
   return REDISMODULE_OK;
 }
 
@@ -584,7 +583,7 @@ CONFIG_SETTER(setMaxSearchResults) {
   long long newSize = 0;
   int acrc = AC_GetLongLong(ac, &newSize, 0);
   CHECK_RETURN_PARSE_ERROR(acrc)
-  config->maxSearchResults = translateOrClampMaxSearchResults(newSize);
+  config->maxSearchResults = translateOrClampMaxResults(newSize, MAX_SEARCH_REQUEST_RESULTS);
   return REDISMODULE_OK;
 }
 
@@ -601,12 +600,7 @@ CONFIG_SETTER(setMaxAggregateResults) {
   long long newSize = 0;
   int acrc = AC_GetLongLong(ac, &newSize, 0);
   CHECK_RETURN_PARSE_ERROR(acrc)
-  if (newSize < 0) {
-    newSize = MAX_AGGREGATE_REQUEST_RESULTS;
-  } else {
-    newSize = MIN(newSize, MAX_AGGREGATE_REQUEST_RESULTS);
-  }
-  config->maxAggregateResults = newSize;
+  config->maxAggregateResults = translateOrClampMaxResults(newSize, MAX_AGGREGATE_REQUEST_RESULTS);
   return REDISMODULE_OK;
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -290,6 +290,11 @@ size_t GetDefaultWorkerThreads(void);
 /* Register module configuration parameters using Module Configuration API */
 int RegisterModuleConfig_Local(RedisModuleCtx *ctx);
 
+/* Marks whether RedisModule_LoadConfigs is currently running. Some numeric config setters
+ * consult this to fall back to their current value with a warning instead of returning
+ * REDISMODULE_ERR, which would abort module init. */
+void RSConfig_SetLoadingStartupConfig(bool loading);
+
 /**
  * Writes the retrieval of the configuration value to the network.
  * isHelp will use a more dict-like pattern, which should be a bit friendlier

--- a/src/module.c
+++ b/src/module.c
@@ -4902,7 +4902,19 @@ static int RediSearch_InitModuleConfig(RedisModuleCtx *ctx, RedisModuleString **
     return REDISMODULE_ERR;
   }
   // Apply configuration redis has loaded from the configuration file
-  RM_TRY_F(RedisModule_LoadConfigs, ctx);
+  // Some numeric config setters check this to fall back instead of erroring, since erroring
+  // here would abort module init. RedisModule_OnLoad also runs for MODULE LOAD/LOADEX against an
+  // already-running server, so gate the fallback on actual server startup rather than on
+  // RedisModule_LoadConfigs running - otherwise a runtime module load would get the same silent
+  // substitution CONFIG SET is meant to reject.
+  const bool atStartup = RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_SERVER_STARTUP;
+  RSConfig_SetLoadingStartupConfig(atStartup);
+  int loadConfigsRC = RedisModule_LoadConfigs(ctx);
+  RSConfig_SetLoadingStartupConfig(false);
+  if (loadConfigsRC == REDISMODULE_ERR) {
+    RedisModule_Log(ctx, "warning", "Could not run RedisModule_LoadConfigs(ctx)");
+    return REDISMODULE_ERR;
+  }
   return REDISMODULE_OK;
 }
 

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -584,7 +584,7 @@ numericConfigs = [
     ('search-bg-index-sleep-gap', 'BG_INDEX_SLEEP_GAP', 100, 1, UINT32_MAX, True, False),
     ('search-cursor-max-idle', 'CURSOR_MAX_IDLE', 300000, 1, LLONG_MAX, False, False),
     ('search-default-dialect', 'DEFAULT_DIALECT', 1, 1, 4, False, False),
-    ('search-fork-gc-clean-threshold', 'FORK_GC_CLEAN_THRESHOLD', 100, 1, LLONG_MAX, False, False),
+    ('search-fork-gc-clean-threshold', 'FORK_GC_CLEAN_THRESHOLD', 100, 0, LLONG_MAX, False, False),
     ('search-fork-gc-retry-interval', 'FORK_GC_RETRY_INTERVAL', 5, 1, LLONG_MAX, False, False),
     ('search-fork-gc-run-interval', 'FORK_GC_RUN_INTERVAL', 30, 1, LLONG_MAX, False, False),
     ('search-fork-gc-sleep-before-exit', 'FORKGC_SLEEP_BEFORE_EXIT', 0, 0, LLONG_MAX, False, False),

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -634,6 +634,7 @@ CLAMPED_CONFIGS = {
 # translated to the listed value on both the legacy and native paths.
 SENTINEL_TRANSLATED_CONFIGS = {
     'search-max-search-results': MAX_SEARCH_REQUEST_RESULTS,
+    'search-max-aggregate-results': MAX_AGGREGATE_REQUEST_RESULTS,
 }
 
 @skip(redis_less_than='7.9.227')

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -628,6 +628,12 @@ CLAMPED_CONFIGS = {
     'search-max-prefix-expansions': UINT32_MAX,
     'search-min-prefix': UINT32_MAX,
     'search-union-iterator-heap': UINT32_MAX,
+    # The registered max is LLONG_MAX (widened so an out-of-range startup value
+    # doesn't abort the server, see MOD-17730), not the values below: an
+    # over-cap CONFIG SET is accepted and clamped to the legacy setter's
+    # maximum, same as the narrowed-type configs above.
+    'search-max-search-results': MAX_SEARCH_REQUEST_RESULTS,
+    'search-max-aggregate-results': MAX_AGGREGATE_REQUEST_RESULTS,
 }
 
 # min - 1 (i.e. -1) is a meaningful "unlimited" sentinel for these configs,

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -852,7 +852,10 @@ _registerModuleLoadexNumericParamTests()
 
 # Skip on ASAN since RedisModule_Unload is not fully implemented (MOD-7161)
 def _testConfigAPILoadTimeNumericParam(configName, maxValue):
-    """Verify MODULE LOADEX rejects values above maxValue for one numeric config."""
+    """Verify MODULE LOADEX rejects values above maxValue for one numeric config,
+    except for a config in CLAMPED_CONFIGS: its registered max is wider than
+    maxValue, so an over-cap value is accepted at load time and clamped down to
+    maxValue rather than rejected."""
     env = Env(noDefaultModuleArgs=True, module='', moduleArgs='')
     redisearch_module_path = os.getenv('MODULE')
     if redisearch_module_path is None:
@@ -862,21 +865,27 @@ def _testConfigAPILoadTimeNumericParam(configName, maxValue):
     env.start()
     res = env.cmd('MODULE', 'LIST')
     env.assertEqual(res, default_module_list)
-    env.expect('MODULE', 'LOADEX', redisearch_module_path,
-                'CONFIG', configName, str(maxValue + 1)).error()\
-                .contains('Error loading the extension')
-    env.assertTrue(env.isUp())
+    if configName in CLAMPED_CONFIGS:
+        res = env.cmd('MODULE', 'LOADEX', redisearch_module_path,
+                       'CONFIG', configName, str(maxValue + 1))
+        env.assertEqual(res, 'OK')
+        env.assertTrue(env.isUp())
+        env.expect('CONFIG', 'GET', configName).equal([configName, str(maxValue)])
+    else:
+        env.expect('MODULE', 'LOADEX', redisearch_module_path,
+                    'CONFIG', configName, str(maxValue + 1)).error()\
+                    .contains('Error loading the extension')
+        env.assertTrue(env.isUp())
     env.stop()
 
 
 def _registerConfigAPILoadTimeNumericParamTests():
-    # Emit one test per non-cluster numeric config (skipping CLAMPED_CONFIGS
-    # whose values are accepted and clamped for backwards compat).
+    # Emit one test per non-cluster numeric config. Configs in CLAMPED_CONFIGS
+    # are included: _testConfigAPILoadTimeNumericParam asserts the clamp
+    # instead of the load-time rejection.
     for cfg in numericConfigs:
         configName, argName, _default, _minValue, maxValue, _immutable, clusterConfig = cfg
         if clusterConfig:
-            continue
-        if configName in CLAMPED_CONFIGS:
             continue
         testName = f'testConfigAPILoadTimeNumericParams_{argName}'
 

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -599,9 +599,11 @@ numericConfigs = [
     ('search-min-phonetic-term-len', 'MIN_PHONETIC_TERM_LEN', 3, 1, LLONG_MAX, False, False),
     ('search-min-prefix', 'MINPREFIX', 2, 1, UINT32_MAX, False, False),
     ('search-min-stem-len', 'MINSTEMLEN', 4, 2, UINT32_MAX, False, False),
-    ('search-multi-text-slop', 'MULTI_TEXT_SLOP', 100, 1, UINT32_MAX, True, False),
+    ('search-multi-text-slop', 'MULTI_TEXT_SLOP', 100, 0, UINT32_MAX, True, False),
     ('search-tiered-hnsw-buffer-limit', 'TIERED_HNSW_BUFFER_LIMIT', 1024, 0, LLONG_MAX, True, False),
-    ('search-timeout', 'TIMEOUT', 500, 1, LLONG_MAX, False, False),
+    # search-timeout 0 is a meaningful "never times out" sentinel on both the
+    # legacy and native paths, not an out-of-range value.
+    ('search-timeout', 'TIMEOUT', 500, 0, LLONG_MAX, False, False),
     ('search-union-iterator-heap', 'UNION_ITERATOR_HEAP', 20, 1, UINT32_MAX, False, False),
     ('search-vss-max-resize', 'VSS_MAX_RESIZE', 0, 0, UINT32_MAX, False, False),
     ('search-workers', 'WORKERS', (0 if RS_TEST_ENTERPRISE else min(MAX_WORKER_THREADS, os.cpu_count())), 0, MAX_WORKER_THREADS, False, False),
@@ -626,6 +628,12 @@ CLAMPED_CONFIGS = {
     'search-max-prefix-expansions': UINT32_MAX,
     'search-min-prefix': UINT32_MAX,
     'search-union-iterator-heap': UINT32_MAX,
+}
+
+# min - 1 (i.e. -1) is a meaningful "unlimited" sentinel for these configs,
+# translated to the listed value on both the legacy and native paths.
+SENTINEL_TRANSLATED_CONFIGS = {
+    'search-max-search-results': MAX_SEARCH_REQUEST_RESULTS,
 }
 
 @skip(redis_less_than='7.9.227')
@@ -670,8 +678,13 @@ def testConfigAPIRunTimeNumericParams():
         # test invalid values
         env.expect('CONFIG', 'SET', configName, 'invalid_numeric').error()\
             .contains('CONFIG SET failed')
-        env.expect('CONFIG', 'SET', configName, str(min - 1)).error()\
-            .contains('CONFIG SET failed')
+        if configName in SENTINEL_TRANSLATED_CONFIGS:
+            env.expect('CONFIG', 'SET', configName, str(min - 1)).equal('OK')
+            env.expect('CONFIG', 'GET', configName)\
+                .equal([configName, str(SENTINEL_TRANSLATED_CONFIGS[configName])])
+        else:
+            env.expect('CONFIG', 'SET', configName, str(min - 1)).error()\
+                .contains('CONFIG SET failed')
         if configName in CLAMPED_CONFIGS:
             # Values above UINT32_MAX are accepted and clamped (backwards compat)
             env.expect('CONFIG', 'SET', configName, str(max + 1)).equal('OK')

--- a/tests/pytests/test_config_native_startup_bounds.py
+++ b/tests/pytests/test_config_native_startup_bounds.py
@@ -122,28 +122,24 @@ def testStartupSearchMaxAggregateResultsNegativeFiveFallsBackToDefault():
 
 
 @skip(cluster=True, redis_less_than='7.9.227')
-def testStartupSearchForkGcCleanThresholdZeroFallsBackToDefault():
-    """search-fork-gc-clean-threshold 0 is not a meaningful sentinel: the
-    server must still start, must log a warning naming the rejected config
-    and value, and the effective value must be left as the config's current
-    value (100 here), not 0."""
+def testStartupSearchForkGcCleanThresholdZeroDoesNotAbort():
+    """search-fork-gc-clean-threshold 0 in the startup config file must not
+    abort the server, and must be stored as 0, exactly like the legacy
+    FORK_GC_CLEAN_THRESHOLD path."""
     confPath = _confPath('test_native_bounds_forkgc.conf')
     _writeConfigFile(confPath, [('search-fork-gc-clean-threshold', 0)])
     env = Env(noDefaultModuleArgs=True, redisConfigFile=confPath)
     env.assertEqual(env.cmd('CONFIG', 'GET', 'search-fork-gc-clean-threshold'),
-                     ['search-fork-gc-clean-threshold', '100'])
-    env.assertGreaterEqual(_grep_file_count(
-        _logFilePath(env),
-        'search-fork-gc-clean-threshold: value 0 is out of range, keeping 100'), 1,
-        message="expected a startup warning naming the rejected config, value and kept value")
+                     ['search-fork-gc-clean-threshold', '0'])
 
 
 @skip(redis_less_than='7.9.227')
-def testRuntimeConfigSetStillRejectsForkGcCleanThresholdZero(env):
-    """Startup tolerance does not relax runtime strictness: CONFIG SET must
-    keep rejecting search-fork-gc-clean-threshold 0."""
-    env.expect('CONFIG', 'SET', 'search-fork-gc-clean-threshold', '0').error()\
-        .contains('CONFIG SET failed').contains('out of range')
+def testRuntimeConfigSetAcceptsForkGcCleanThresholdZero(env):
+    """search-fork-gc-clean-threshold 0 is a legitimate value, matching the
+    legacy path, on the native CONFIG SET path too."""
+    env.expect('CONFIG', 'SET', 'search-fork-gc-clean-threshold', '0').ok()
+    env.assertEqual(env.cmd('CONFIG', 'GET', 'search-fork-gc-clean-threshold'),
+                     ['search-fork-gc-clean-threshold', '0'])
 
 
 @skip(redis_less_than='7.9.227')
@@ -176,11 +172,16 @@ def testRuntimeConfigSetStillRejectsMaxSearchResultsNegativeTwo(env):
 
 # Skip on ASAN since RedisModule_Unload is not fully implemented (MOD-7161)
 @skip(cluster=True, redis_less_than='7.9.227', asan=True)
-def testModuleLoadexRuntimeStillRejectsForkGcCleanThresholdZero():
+def testModuleLoadexRuntimeStillRejectsMaxSearchResultsNegativeTwo():
     """RedisModule_OnLoad also runs for MODULE LOADEX against an
     already-running server, not just at genuine process startup. That path
-    must stay as strict as CONFIG SET: search-fork-gc-clean-threshold 0 must
-    make MODULE LOADEX fail, not silently substitute the default."""
+    must stay as strict as CONFIG SET: search-max-search-results -2 is out
+    of range (only -1 is the unlimited sentinel), so it must make MODULE
+    LOADEX fail rather than silently substitute a default. This is the
+    startup-lenient-vs-runtime-strict asymmetry that the noLoadingStartupConfig
+    flag exists for, now exercised through one of the two results caps
+    instead of search-fork-gc-clean-threshold, which no longer has any
+    out-of-range value to test."""
     env = Env(noDefaultModuleArgs=True, module='', moduleArgs='')
     redisearch_module_path = os.getenv('MODULE')
     if redisearch_module_path is None:
@@ -191,7 +192,7 @@ def testModuleLoadexRuntimeStillRejectsForkGcCleanThresholdZero():
     res = env.cmd('MODULE', 'LIST')
     env.assertEqual(res, default_module_list)
     env.expect('MODULE', 'LOADEX', redisearch_module_path,
-               'CONFIG', 'search-fork-gc-clean-threshold', '0').error()\
+               'CONFIG', 'search-max-search-results', '-2').error()\
         .contains('Error loading the extension')
     env.assertTrue(env.isUp())
     env.stop()

--- a/tests/pytests/test_config_native_startup_bounds.py
+++ b/tests/pytests/test_config_native_startup_bounds.py
@@ -40,7 +40,7 @@ def _logFilePath(env):
     return os.path.join(logDir, logFileName)
 
 
-@skip(cluster=True, redis_less_than='7.9.227')
+@skip(cluster=True, redis_less_than='8.0')
 def testStartupSearchTimeoutZeroDoesNotAbort():
     """search-timeout 0 ("no timeout") in the startup config file must not
     abort the server, and must be stored as 0."""
@@ -50,7 +50,7 @@ def testStartupSearchTimeoutZeroDoesNotAbort():
     env.assertEqual(env.cmd('CONFIG', 'GET', 'search-timeout'), ['search-timeout', '0'])
 
 
-@skip(cluster=True, redis_less_than='7.9.227')
+@skip(cluster=True, redis_less_than='8.0')
 def testStartupSearchMultiTextSlopZeroDoesNotAbort():
     """search-multi-text-slop 0 in the startup config file must not abort
     the server, and must be stored as 0. Public docs document the range as
@@ -62,7 +62,7 @@ def testStartupSearchMultiTextSlopZeroDoesNotAbort():
                      ['search-multi-text-slop', '0'])
 
 
-@skip(cluster=True, redis_less_than='7.9.227')
+@skip(cluster=True, redis_less_than='8.0')
 def testStartupSearchMaxSearchResultsNegativeOneTranslates():
     """search-max-search-results -1 in the startup config file must not
     abort the server, and must translate to MAX_SEARCH_REQUEST_RESULTS,
@@ -74,7 +74,7 @@ def testStartupSearchMaxSearchResultsNegativeOneTranslates():
                      ['search-max-search-results', str(MAX_SEARCH_REQUEST_RESULTS)])
 
 
-@skip(cluster=True, redis_less_than='7.9.227')
+@skip(cluster=True, redis_less_than='8.0')
 def testStartupSearchMaxAggregateResultsNegativeOneTranslates():
     """search-max-aggregate-results -1 in the startup config file must not
     abort the server, and must translate to MAX_AGGREGATE_REQUEST_RESULTS,
@@ -86,7 +86,7 @@ def testStartupSearchMaxAggregateResultsNegativeOneTranslates():
                      ['search-max-aggregate-results', str(MAX_AGGREGATE_REQUEST_RESULTS)])
 
 
-@skip(cluster=True, redis_less_than='7.9.227')
+@skip(cluster=True, redis_less_than='8.0')
 def testStartupSearchMaxSearchResultsOverCapClamps():
     """search-max-search-results 9999999999 (above MAX_SEARCH_REQUEST_RESULTS)
     in the startup config file must not abort the server: the registered max
@@ -99,7 +99,7 @@ def testStartupSearchMaxSearchResultsOverCapClamps():
                      ['search-max-search-results', str(MAX_SEARCH_REQUEST_RESULTS)])
 
 
-@skip(cluster=True, redis_less_than='7.9.227')
+@skip(cluster=True, redis_less_than='8.0')
 def testStartupSearchMaxAggregateResultsOverCapClamps():
     """Same as above for search-max-aggregate-results: a startup value above
     MAX_AGGREGATE_REQUEST_RESULTS must not abort the server and must clamp
@@ -111,7 +111,7 @@ def testStartupSearchMaxAggregateResultsOverCapClamps():
                      ['search-max-aggregate-results', str(MAX_AGGREGATE_REQUEST_RESULTS)])
 
 
-@skip(cluster=True, redis_less_than='7.9.227')
+@skip(cluster=True, redis_less_than='8.0')
 def testStartupSearchMaxSearchResultsNegativeFiveFallsBackToDefault():
     """search-max-search-results -5 is not the -1 sentinel, so it must not
     silently become unlimited: the server must still start, must log a
@@ -129,7 +129,7 @@ def testStartupSearchMaxSearchResultsNegativeFiveFallsBackToDefault():
         message="expected a startup warning naming the rejected config, value and kept value")
 
 
-@skip(cluster=True, redis_less_than='7.9.227')
+@skip(cluster=True, redis_less_than='8.0')
 def testStartupSearchMaxAggregateResultsNegativeFiveFallsBackToDefault():
     """Same as above for search-max-aggregate-results: -5 is not the -1
     sentinel, so the server must still start with the default value and a
@@ -146,7 +146,7 @@ def testStartupSearchMaxAggregateResultsNegativeFiveFallsBackToDefault():
         message="expected a startup warning naming the rejected config, value and kept value")
 
 
-@skip(cluster=True, redis_less_than='7.9.227')
+@skip(cluster=True, redis_less_than='8.0')
 def testStartupSearchForkGcCleanThresholdZeroDoesNotAbort():
     """search-fork-gc-clean-threshold 0 in the startup config file must not
     abort the server, and must be stored as 0, exactly like the legacy
@@ -158,7 +158,7 @@ def testStartupSearchForkGcCleanThresholdZeroDoesNotAbort():
                      ['search-fork-gc-clean-threshold', '0'])
 
 
-@skip(redis_less_than='7.9.227')
+@skip(redis_less_than='8.0')
 def testRuntimeConfigSetAcceptsForkGcCleanThresholdZero(env):
     """search-fork-gc-clean-threshold 0 is a legitimate value, matching the
     legacy path, on the native CONFIG SET path too."""
@@ -167,7 +167,7 @@ def testRuntimeConfigSetAcceptsForkGcCleanThresholdZero(env):
                      ['search-fork-gc-clean-threshold', '0'])
 
 
-@skip(redis_less_than='7.9.227')
+@skip(redis_less_than='8.0')
 def testRuntimeConfigSetTranslatesMaxAggregateResultsNegativeOne(env):
     """search-max-aggregate-results -1 is now a meaningful sentinel on the
     native CONFIG SET path too, mirroring search-max-search-results: it
@@ -177,7 +177,7 @@ def testRuntimeConfigSetTranslatesMaxAggregateResultsNegativeOne(env):
                      ['search-max-aggregate-results', str(MAX_AGGREGATE_REQUEST_RESULTS)])
 
 
-@skip(redis_less_than='7.9.227')
+@skip(redis_less_than='8.0')
 def testRuntimeConfigSetClampsMaxSearchResultsOverCap(env):
     """CONFIG SET search-max-search-results 9999999999 must succeed (the
     registered max is LLONG_MAX) and clamp to MAX_SEARCH_REQUEST_RESULTS,
@@ -187,7 +187,7 @@ def testRuntimeConfigSetClampsMaxSearchResultsOverCap(env):
                      ['search-max-search-results', str(MAX_SEARCH_REQUEST_RESULTS)])
 
 
-@skip(redis_less_than='7.9.227')
+@skip(redis_less_than='8.0')
 def testRuntimeConfigSetClampsMaxAggregateResultsOverCap(env):
     """Same as above for search-max-aggregate-results."""
     env.expect('CONFIG', 'SET', 'search-max-aggregate-results', '9999999999').ok()
@@ -195,7 +195,7 @@ def testRuntimeConfigSetClampsMaxAggregateResultsOverCap(env):
                      ['search-max-aggregate-results', str(MAX_AGGREGATE_REQUEST_RESULTS)])
 
 
-@skip(redis_less_than='7.9.227')
+@skip(redis_less_than='8.0')
 def testRuntimeConfigSetStillRejectsMaxAggregateResultsNegativeTwo(env):
     """Widening the registered min to LLONG_MIN only lets the value reach our
     setter; the setter itself still treats -1 as the only unlimited sentinel,
@@ -204,7 +204,7 @@ def testRuntimeConfigSetStillRejectsMaxAggregateResultsNegativeTwo(env):
         .contains('CONFIG SET failed').contains('out of range')
 
 
-@skip(redis_less_than='7.9.227')
+@skip(redis_less_than='8.0')
 def testRuntimeConfigSetStillRejectsMaxSearchResultsNegativeTwo(env):
     """Same as search-max-aggregate-results: only -1 is the unlimited
     sentinel for search-max-search-results, so CONFIG SET keeps rejecting
@@ -214,7 +214,7 @@ def testRuntimeConfigSetStillRejectsMaxSearchResultsNegativeTwo(env):
 
 
 # Skip on ASAN since RedisModule_Unload is not fully implemented (MOD-7161)
-@skip(cluster=True, redis_less_than='7.9.227', asan=True)
+@skip(cluster=True, redis_less_than='8.0', asan=True)
 def testModuleLoadexRuntimeStillRejectsMaxSearchResultsNegativeTwo():
     """RedisModule_OnLoad also runs for MODULE LOADEX against an
     already-running server, not just at genuine process startup. That path
@@ -241,7 +241,7 @@ def testModuleLoadexRuntimeStillRejectsMaxSearchResultsNegativeTwo():
     env.stop()
 
 
-@skip(cluster=True, redis_less_than='7.9.227')
+@skip(cluster=True, redis_less_than='8.0')
 def testSearchTimeoutZeroMeansNoTimeoutUnderRealSlowQuery():
     """search-timeout 0, set via the native CONFIG SET path, must mean a
     genuinely slow query runs to completion with no timeout warning, while
@@ -277,7 +277,7 @@ def testSearchTimeoutZeroMeansNoTimeoutUnderRealSlowQuery():
     env.assertEqual(int(res['results'][0]['extra_attributes']['count']), 2)
 
 
-@skip(cluster=True, redis_less_than='7.9.227')
+@skip(cluster=True, redis_less_than='8.0')
 def testConfigRewriteRoundTripSearchTimeoutZero():
     """CONFIG SET search-timeout 0, CONFIG REWRITE, restart: the rewritten
     config file must re-apply 0 at genuine startup, not just in the live
@@ -293,7 +293,7 @@ def testConfigRewriteRoundTripSearchTimeoutZero():
     env.assertEqual(env.cmd('CONFIG', 'GET', 'search-timeout'), ['search-timeout', '0'])
 
 
-@skip(cluster=True, redis_less_than='7.9.227')
+@skip(cluster=True, redis_less_than='8.0')
 def testConfigRewriteRoundTripSearchMaxSearchResultsNegativeOne():
     """Same round trip for search-max-search-results -1: the rewritten
     config file must persist the *translated* value (MAX_SEARCH_REQUEST_RESULTS)

--- a/tests/pytests/test_config_native_startup_bounds.py
+++ b/tests/pytests/test_config_native_startup_bounds.py
@@ -1,0 +1,136 @@
+"""
+Coverage for native search-* config startup bounds: values the legacy setter
+accepts must not abort the server when they arrive via the config file, and
+runtime CONFIG SET must keep rejecting the values that startup now tolerates.
+"""
+import os
+import tempfile
+from RLTest import Env
+from includes import *
+from common import *
+from test_config import MAX_SEARCH_REQUEST_RESULTS
+
+
+def _confPath(name):
+    return os.path.join(tempfile.mkdtemp(), name)
+
+
+def _writeConfigFile(path, directives):
+    with open(path, 'w') as f:
+        for name, value in directives:
+            f.write(f'{name} {value}\n')
+
+
+def _stripLoadmoduleLines(path):
+    # CONFIG REWRITE persists `loadmodule` directives into the config file.
+    # RLTest also passes `--loadmodule` on the command line regardless of
+    # noDefaultModuleArgs, so restarting with the rewritten file as-is loads
+    # every module twice and aborts on the second (duplicate command
+    # registration). Strip them; RLTest supplies loadmodule via argv.
+    with open(path) as f:
+        lines = [l for l in f if not l.startswith('loadmodule ')]
+    with open(path, 'w') as f:
+        f.writelines(lines)
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
+def testStartupSearchTimeoutZeroDoesNotAbort():
+    """search-timeout 0 ("no timeout") in the startup config file must not
+    abort the server, and must be stored as 0."""
+    confPath = _confPath('test_native_bounds_timeout.conf')
+    _writeConfigFile(confPath, [('search-timeout', 0)])
+    env = Env(noDefaultModuleArgs=True, redisConfigFile=confPath)
+    env.assertEqual(env.cmd('CONFIG', 'GET', 'search-timeout'), ['search-timeout', '0'])
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
+def testStartupSearchMultiTextSlopZeroDoesNotAbort():
+    """search-multi-text-slop 0 in the startup config file must not abort
+    the server, and must be stored as 0. Public docs document the range as
+    [0 .. 4294967295]."""
+    confPath = _confPath('test_native_bounds_slop.conf')
+    _writeConfigFile(confPath, [('search-multi-text-slop', 0)])
+    env = Env(noDefaultModuleArgs=True, redisConfigFile=confPath)
+    env.assertEqual(env.cmd('CONFIG', 'GET', 'search-multi-text-slop'),
+                     ['search-multi-text-slop', '0'])
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
+def testStartupSearchMaxSearchResultsNegativeOneTranslates():
+    """search-max-search-results -1 in the startup config file must not
+    abort the server, and must translate to MAX_SEARCH_REQUEST_RESULTS,
+    exactly like the legacy setter does for _FT.CONFIG SET MAXSEARCHRESULTS -1."""
+    confPath = _confPath('test_native_bounds_maxsearch.conf')
+    _writeConfigFile(confPath, [('search-max-search-results', -1)])
+    env = Env(noDefaultModuleArgs=True, redisConfigFile=confPath)
+    env.assertEqual(env.cmd('CONFIG', 'GET', 'search-max-search-results'),
+                     ['search-max-search-results', str(MAX_SEARCH_REQUEST_RESULTS)])
+
+
+@skip(cluster=True)
+def testSearchTimeoutZeroMeansNoTimeoutUnderRealSlowQuery():
+    """search-timeout 0, set via the native CONFIG SET path, must mean a
+    genuinely slow query runs to completion with no timeout warning, while
+    the same query trips a tiny nonzero timeout."""
+    env = Env(protocol=3)
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+
+    # doc:0 matches '-common' immediately; the run of 'common' docs after it
+    # forces the NOT iterator to scan past all of them before reaching the
+    # trailing rare doc, giving the query real work to do against a 1ms timeout.
+    skipped = 300_000
+    with conn.pipeline(transaction=False) as p:
+        p.execute_command('HSET', 'doc:0', 't', 'rare')
+        for i in range(1, skipped + 1):
+            p.execute_command('HSET', f'doc:{i}', 't', 'common')
+        p.execute_command('HSET', f'doc:{skipped + 1}', 't', 'rare')
+        p.execute()
+
+    # Sanity control: a tiny nonzero timeout on this scan must time out.
+    env.expect('CONFIG', 'SET', 'search-timeout', '1').ok()
+    res = env.cmd('FT.AGGREGATE', 'idx', '-common', 'GROUPBY', '1', '@t', 'REDUCE', 'COUNT', '0', 'AS', 'count')
+    env.assertTrue(res.get('warning'), message=f"expected a timeout warning as a sanity control, got {res}")
+
+    # search-timeout 0 must mean the identical query runs to completion with
+    # no timeout warning.
+    env.expect('CONFIG', 'SET', 'search-timeout', '0').ok()
+    res = env.cmd('FT.AGGREGATE', 'idx', '-common', 'GROUPBY', '1', '@t', 'REDUCE', 'COUNT', '0', 'AS', 'count')
+    env.assertEqual(res.get('warning', []), [],
+                     message=f"expected no timeout warning with search-timeout 0, got {res}")
+    # '-common' excludes every 'common' doc, leaving only the 2 'rare' docs -
+    # skipped is the scan cost, not the match count.
+    env.assertEqual(int(res['results'][0]['extra_attributes']['count']), 2)
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
+def testConfigRewriteRoundTripSearchTimeoutZero():
+    """CONFIG SET search-timeout 0, CONFIG REWRITE, restart: the rewritten
+    config file must re-apply 0 at genuine startup, not just in the live
+    process."""
+    confPath = _confPath('test_native_bounds_rewrite_timeout.conf')
+    _writeConfigFile(confPath, [])
+    env = Env(noDefaultModuleArgs=True, redisConfigFile=confPath)
+    env.expect('CONFIG', 'SET', 'search-timeout', '0').ok()
+    env.expect('CONFIG', 'REWRITE').ok()
+    env.stop()
+    _stripLoadmoduleLines(confPath)
+    env.start()
+    env.assertEqual(env.cmd('CONFIG', 'GET', 'search-timeout'), ['search-timeout', '0'])
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
+def testConfigRewriteRoundTripSearchMaxSearchResultsNegativeOne():
+    """Same round trip for search-max-search-results -1: the rewritten
+    config file must persist the *translated* value (MAX_SEARCH_REQUEST_RESULTS)
+    and re-apply it at genuine startup."""
+    confPath = _confPath('test_native_bounds_rewrite_maxsearch.conf')
+    _writeConfigFile(confPath, [])
+    env = Env(noDefaultModuleArgs=True, redisConfigFile=confPath)
+    env.expect('CONFIG', 'SET', 'search-max-search-results', '-1').ok()
+    env.expect('CONFIG', 'REWRITE').ok()
+    env.stop()
+    _stripLoadmoduleLines(confPath)
+    env.start()
+    env.assertEqual(env.cmd('CONFIG', 'GET', 'search-max-search-results'),
+                     ['search-max-search-results', str(MAX_SEARCH_REQUEST_RESULTS)])

--- a/tests/pytests/test_config_native_startup_bounds.py
+++ b/tests/pytests/test_config_native_startup_bounds.py
@@ -9,7 +9,7 @@ from RLTest import Env
 from includes import *
 from common import *
 from test_config import _grep_file_count, MAX_SEARCH_REQUEST_RESULTS, \
-    MAX_AGGREGATE_REQUEST_RESULTS, default_module_list
+    MAX_AGGREGATE_REQUEST_RESULTS, DEFAULT_MAX_SEARCH_REQUEST_RESULTS, default_module_list
 
 
 def _confPath(name):
@@ -87,6 +87,41 @@ def testStartupSearchMaxAggregateResultsNegativeOneTranslates():
 
 
 @skip(cluster=True, redis_less_than='7.9.227')
+def testStartupSearchMaxSearchResultsNegativeFiveFallsBackToDefault():
+    """search-max-search-results -5 is not the -1 sentinel, so it must not
+    silently become unlimited: the server must still start, must log a
+    warning naming the rejected config and value, and the effective value
+    must be left at the default (DEFAULT_MAX_SEARCH_REQUEST_RESULTS)."""
+    confPath = _confPath('test_native_bounds_maxsearch_neg5.conf')
+    _writeConfigFile(confPath, [('search-max-search-results', -5)])
+    env = Env(noDefaultModuleArgs=True, redisConfigFile=confPath)
+    env.assertEqual(env.cmd('CONFIG', 'GET', 'search-max-search-results'),
+                     ['search-max-search-results', str(DEFAULT_MAX_SEARCH_REQUEST_RESULTS)])
+    env.assertGreaterEqual(_grep_file_count(
+        _logFilePath(env),
+        f'search-max-search-results: value -5 is out of range, keeping '
+        f'{DEFAULT_MAX_SEARCH_REQUEST_RESULTS}'), 1,
+        message="expected a startup warning naming the rejected config, value and kept value")
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
+def testStartupSearchMaxAggregateResultsNegativeFiveFallsBackToDefault():
+    """Same as above for search-max-aggregate-results: -5 is not the -1
+    sentinel, so the server must still start with the default value and a
+    matching warning, rather than aborting or treating -5 as unlimited."""
+    confPath = _confPath('test_native_bounds_maxagg_neg5.conf')
+    _writeConfigFile(confPath, [('search-max-aggregate-results', -5)])
+    env = Env(noDefaultModuleArgs=True, redisConfigFile=confPath)
+    env.assertEqual(env.cmd('CONFIG', 'GET', 'search-max-aggregate-results'),
+                     ['search-max-aggregate-results', str(MAX_AGGREGATE_REQUEST_RESULTS)])
+    env.assertGreaterEqual(_grep_file_count(
+        _logFilePath(env),
+        f'search-max-aggregate-results: value -5 is out of range, keeping '
+        f'{MAX_AGGREGATE_REQUEST_RESULTS}'), 1,
+        message="expected a startup warning naming the rejected config, value and kept value")
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
 def testStartupSearchForkGcCleanThresholdZeroFallsBackToDefault():
     """search-fork-gc-clean-threshold 0 is not a meaningful sentinel: the
     server must still start, must log a warning naming the rejected config
@@ -123,19 +158,20 @@ def testRuntimeConfigSetTranslatesMaxAggregateResultsNegativeOne(env):
 
 @skip(redis_less_than='7.9.227')
 def testRuntimeConfigSetStillRejectsMaxAggregateResultsNegativeTwo(env):
-    """Widening the sentinel does not widen the bound: core still enforces
-    min = -1, so CONFIG SET must keep rejecting anything below it."""
+    """Widening the registered min to LLONG_MIN only lets the value reach our
+    setter; the setter itself still treats -1 as the only unlimited sentinel,
+    so CONFIG SET must keep rejecting -2 as out of range."""
     env.expect('CONFIG', 'SET', 'search-max-aggregate-results', '-2').error()\
-        .contains('CONFIG SET failed')
+        .contains('CONFIG SET failed').contains('out of range')
 
 
 @skip(redis_less_than='7.9.227')
 def testRuntimeConfigSetStillRejectsMaxSearchResultsNegativeTwo(env):
-    """Registered min = -1 for search-max-search-results (matching
-    search-max-aggregate-results) means CONFIG SET keeps rejecting anything
-    below the sentinel, rather than silently treating it as unlimited."""
+    """Same as search-max-aggregate-results: only -1 is the unlimited
+    sentinel for search-max-search-results, so CONFIG SET keeps rejecting
+    -2 as out of range rather than silently treating it as unlimited."""
     env.expect('CONFIG', 'SET', 'search-max-search-results', '-2').error()\
-        .contains('CONFIG SET failed')
+        .contains('CONFIG SET failed').contains('out of range')
 
 
 # Skip on ASAN since RedisModule_Unload is not fully implemented (MOD-7161)

--- a/tests/pytests/test_config_native_startup_bounds.py
+++ b/tests/pytests/test_config_native_startup_bounds.py
@@ -9,7 +9,7 @@ from RLTest import Env
 from includes import *
 from common import *
 from test_config import _grep_file_count, MAX_SEARCH_REQUEST_RESULTS, \
-    DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS, default_module_list
+    MAX_AGGREGATE_REQUEST_RESULTS, default_module_list
 
 
 def _confPath(name):
@@ -75,22 +75,15 @@ def testStartupSearchMaxSearchResultsNegativeOneTranslates():
 
 
 @skip(cluster=True, redis_less_than='7.9.227')
-def testStartupSearchMaxAggregateResultsNegativeOneFallsBackToDefault():
-    """search-max-aggregate-results -1 is not a meaningful sentinel: the
-    server must still start, must log a warning naming the rejected config
-    and value, and the effective value must be left as the config's current
-    value (DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS here), not -1 taken
-    verbatim."""
+def testStartupSearchMaxAggregateResultsNegativeOneTranslates():
+    """search-max-aggregate-results -1 in the startup config file must not
+    abort the server, and must translate to MAX_AGGREGATE_REQUEST_RESULTS,
+    exactly like the legacy setter does for _FT.CONFIG SET MAXAGGREGATERESULTS -1."""
     confPath = _confPath('test_native_bounds_maxagg.conf')
     _writeConfigFile(confPath, [('search-max-aggregate-results', -1)])
     env = Env(noDefaultModuleArgs=True, redisConfigFile=confPath)
     env.assertEqual(env.cmd('CONFIG', 'GET', 'search-max-aggregate-results'),
-                     ['search-max-aggregate-results', str(DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS)])
-    env.assertGreaterEqual(_grep_file_count(
-        _logFilePath(env),
-        f'search-max-aggregate-results: value -1 is out of range, keeping '
-        f'{DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS}'), 1,
-        message="expected a startup warning naming the rejected config, value and kept value")
+                     ['search-max-aggregate-results', str(MAX_AGGREGATE_REQUEST_RESULTS)])
 
 
 @skip(cluster=True, redis_less_than='7.9.227')
@@ -119,15 +112,25 @@ def testRuntimeConfigSetStillRejectsForkGcCleanThresholdZero(env):
 
 
 @skip(redis_less_than='7.9.227')
-def testRuntimeConfigSetStillRejectsMaxAggregateResultsNegativeOne(env):
-    """Startup tolerance does not relax runtime strictness: CONFIG SET must
-    keep rejecting search-max-aggregate-results -1."""
-    env.expect('CONFIG', 'SET', 'search-max-aggregate-results', '-1').error()\
-        .contains('CONFIG SET failed').contains('out of range')
+def testRuntimeConfigSetTranslatesMaxAggregateResultsNegativeOne(env):
+    """search-max-aggregate-results -1 is now a meaningful sentinel on the
+    native CONFIG SET path too, mirroring search-max-search-results: it
+    translates to MAX_AGGREGATE_REQUEST_RESULTS rather than being rejected."""
+    env.expect('CONFIG', 'SET', 'search-max-aggregate-results', '-1').ok()
+    env.assertEqual(env.cmd('CONFIG', 'GET', 'search-max-aggregate-results'),
+                     ['search-max-aggregate-results', str(MAX_AGGREGATE_REQUEST_RESULTS)])
+
+
+@skip(redis_less_than='7.9.227')
+def testRuntimeConfigSetStillRejectsMaxAggregateResultsNegativeTwo(env):
+    """Widening the sentinel does not widen the bound: core still enforces
+    min = -1, so CONFIG SET must keep rejecting anything below it."""
+    env.expect('CONFIG', 'SET', 'search-max-aggregate-results', '-2').error()\
+        .contains('CONFIG SET failed')
 
 
 # Skip on ASAN since RedisModule_Unload is not fully implemented (MOD-7161)
-@skip(cluster=True, redis_less_than='7.9.227')
+@skip(cluster=True, redis_less_than='7.9.227', asan=True)
 def testModuleLoadexRuntimeStillRejectsForkGcCleanThresholdZero():
     """RedisModule_OnLoad also runs for MODULE LOADEX against an
     already-running server, not just at genuine process startup. That path
@@ -149,7 +152,7 @@ def testModuleLoadexRuntimeStillRejectsForkGcCleanThresholdZero():
     env.stop()
 
 
-@skip(cluster=True)
+@skip(cluster=True, redis_less_than='7.9.227')
 def testSearchTimeoutZeroMeansNoTimeoutUnderRealSlowQuery():
     """search-timeout 0, set via the native CONFIG SET path, must mean a
     genuinely slow query runs to completion with no timeout warning, while

--- a/tests/pytests/test_config_native_startup_bounds.py
+++ b/tests/pytests/test_config_native_startup_bounds.py
@@ -87,6 +87,31 @@ def testStartupSearchMaxAggregateResultsNegativeOneTranslates():
 
 
 @skip(cluster=True, redis_less_than='7.9.227')
+def testStartupSearchMaxSearchResultsOverCapClamps():
+    """search-max-search-results 9999999999 (above MAX_SEARCH_REQUEST_RESULTS)
+    in the startup config file must not abort the server: the registered max
+    is LLONG_MAX so core lets it through to our setter, which clamps it to
+    MAX_SEARCH_REQUEST_RESULTS, matching the legacy setter's silent clamp."""
+    confPath = _confPath('test_native_bounds_maxsearch_overcap.conf')
+    _writeConfigFile(confPath, [('search-max-search-results', 9999999999)])
+    env = Env(noDefaultModuleArgs=True, redisConfigFile=confPath)
+    env.assertEqual(env.cmd('CONFIG', 'GET', 'search-max-search-results'),
+                     ['search-max-search-results', str(MAX_SEARCH_REQUEST_RESULTS)])
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
+def testStartupSearchMaxAggregateResultsOverCapClamps():
+    """Same as above for search-max-aggregate-results: a startup value above
+    MAX_AGGREGATE_REQUEST_RESULTS must not abort the server and must clamp
+    down to MAX_AGGREGATE_REQUEST_RESULTS."""
+    confPath = _confPath('test_native_bounds_maxagg_overcap.conf')
+    _writeConfigFile(confPath, [('search-max-aggregate-results', 9999999999)])
+    env = Env(noDefaultModuleArgs=True, redisConfigFile=confPath)
+    env.assertEqual(env.cmd('CONFIG', 'GET', 'search-max-aggregate-results'),
+                     ['search-max-aggregate-results', str(MAX_AGGREGATE_REQUEST_RESULTS)])
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
 def testStartupSearchMaxSearchResultsNegativeFiveFallsBackToDefault():
     """search-max-search-results -5 is not the -1 sentinel, so it must not
     silently become unlimited: the server must still start, must log a
@@ -148,6 +173,24 @@ def testRuntimeConfigSetTranslatesMaxAggregateResultsNegativeOne(env):
     native CONFIG SET path too, mirroring search-max-search-results: it
     translates to MAX_AGGREGATE_REQUEST_RESULTS rather than being rejected."""
     env.expect('CONFIG', 'SET', 'search-max-aggregate-results', '-1').ok()
+    env.assertEqual(env.cmd('CONFIG', 'GET', 'search-max-aggregate-results'),
+                     ['search-max-aggregate-results', str(MAX_AGGREGATE_REQUEST_RESULTS)])
+
+
+@skip(redis_less_than='7.9.227')
+def testRuntimeConfigSetClampsMaxSearchResultsOverCap(env):
+    """CONFIG SET search-max-search-results 9999999999 must succeed (the
+    registered max is LLONG_MAX) and clamp to MAX_SEARCH_REQUEST_RESULTS,
+    matching the legacy setter's silent clamp on the native path too."""
+    env.expect('CONFIG', 'SET', 'search-max-search-results', '9999999999').ok()
+    env.assertEqual(env.cmd('CONFIG', 'GET', 'search-max-search-results'),
+                     ['search-max-search-results', str(MAX_SEARCH_REQUEST_RESULTS)])
+
+
+@skip(redis_less_than='7.9.227')
+def testRuntimeConfigSetClampsMaxAggregateResultsOverCap(env):
+    """Same as above for search-max-aggregate-results."""
+    env.expect('CONFIG', 'SET', 'search-max-aggregate-results', '9999999999').ok()
     env.assertEqual(env.cmd('CONFIG', 'GET', 'search-max-aggregate-results'),
                      ['search-max-aggregate-results', str(MAX_AGGREGATE_REQUEST_RESULTS)])
 

--- a/tests/pytests/test_config_native_startup_bounds.py
+++ b/tests/pytests/test_config_native_startup_bounds.py
@@ -8,7 +8,8 @@ import tempfile
 from RLTest import Env
 from includes import *
 from common import *
-from test_config import MAX_SEARCH_REQUEST_RESULTS
+from test_config import _grep_file_count, MAX_SEARCH_REQUEST_RESULTS, \
+    DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS, default_module_list
 
 
 def _confPath(name):
@@ -31,6 +32,12 @@ def _stripLoadmoduleLines(path):
         lines = [l for l in f if not l.startswith('loadmodule ')]
     with open(path, 'w') as f:
         f.writelines(lines)
+
+
+def _logFilePath(env):
+    logDir = env.cmd('config', 'get', 'dir')[1]
+    logFileName = env.cmd('CONFIG', 'GET', 'logfile')[1]
+    return os.path.join(logDir, logFileName)
 
 
 @skip(cluster=True, redis_less_than='7.9.227')
@@ -65,6 +72,81 @@ def testStartupSearchMaxSearchResultsNegativeOneTranslates():
     env = Env(noDefaultModuleArgs=True, redisConfigFile=confPath)
     env.assertEqual(env.cmd('CONFIG', 'GET', 'search-max-search-results'),
                      ['search-max-search-results', str(MAX_SEARCH_REQUEST_RESULTS)])
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
+def testStartupSearchMaxAggregateResultsNegativeOneFallsBackToDefault():
+    """search-max-aggregate-results -1 is not a meaningful sentinel: the
+    server must still start, must log a warning naming the rejected config
+    and value, and the effective value must be left as the config's current
+    value (DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS here), not -1 taken
+    verbatim."""
+    confPath = _confPath('test_native_bounds_maxagg.conf')
+    _writeConfigFile(confPath, [('search-max-aggregate-results', -1)])
+    env = Env(noDefaultModuleArgs=True, redisConfigFile=confPath)
+    env.assertEqual(env.cmd('CONFIG', 'GET', 'search-max-aggregate-results'),
+                     ['search-max-aggregate-results', str(DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS)])
+    env.assertGreaterEqual(_grep_file_count(
+        _logFilePath(env),
+        f'search-max-aggregate-results: value -1 is out of range, keeping '
+        f'{DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS}'), 1,
+        message="expected a startup warning naming the rejected config, value and kept value")
+
+
+@skip(cluster=True, redis_less_than='7.9.227')
+def testStartupSearchForkGcCleanThresholdZeroFallsBackToDefault():
+    """search-fork-gc-clean-threshold 0 is not a meaningful sentinel: the
+    server must still start, must log a warning naming the rejected config
+    and value, and the effective value must be left as the config's current
+    value (100 here), not 0."""
+    confPath = _confPath('test_native_bounds_forkgc.conf')
+    _writeConfigFile(confPath, [('search-fork-gc-clean-threshold', 0)])
+    env = Env(noDefaultModuleArgs=True, redisConfigFile=confPath)
+    env.assertEqual(env.cmd('CONFIG', 'GET', 'search-fork-gc-clean-threshold'),
+                     ['search-fork-gc-clean-threshold', '100'])
+    env.assertGreaterEqual(_grep_file_count(
+        _logFilePath(env),
+        'search-fork-gc-clean-threshold: value 0 is out of range, keeping 100'), 1,
+        message="expected a startup warning naming the rejected config, value and kept value")
+
+
+@skip(redis_less_than='7.9.227')
+def testRuntimeConfigSetStillRejectsForkGcCleanThresholdZero(env):
+    """Startup tolerance does not relax runtime strictness: CONFIG SET must
+    keep rejecting search-fork-gc-clean-threshold 0."""
+    env.expect('CONFIG', 'SET', 'search-fork-gc-clean-threshold', '0').error()\
+        .contains('CONFIG SET failed').contains('out of range')
+
+
+@skip(redis_less_than='7.9.227')
+def testRuntimeConfigSetStillRejectsMaxAggregateResultsNegativeOne(env):
+    """Startup tolerance does not relax runtime strictness: CONFIG SET must
+    keep rejecting search-max-aggregate-results -1."""
+    env.expect('CONFIG', 'SET', 'search-max-aggregate-results', '-1').error()\
+        .contains('CONFIG SET failed').contains('out of range')
+
+
+# Skip on ASAN since RedisModule_Unload is not fully implemented (MOD-7161)
+@skip(cluster=True, redis_less_than='7.9.227')
+def testModuleLoadexRuntimeStillRejectsForkGcCleanThresholdZero():
+    """RedisModule_OnLoad also runs for MODULE LOADEX against an
+    already-running server, not just at genuine process startup. That path
+    must stay as strict as CONFIG SET: search-fork-gc-clean-threshold 0 must
+    make MODULE LOADEX fail, not silently substitute the default."""
+    env = Env(noDefaultModuleArgs=True, module='', moduleArgs='')
+    redisearch_module_path = os.getenv('MODULE')
+    if redisearch_module_path is None:
+        env.debugPrint('MODULE environment variable is not set. Skipping test')
+        env.skip()
+
+    env.start()
+    res = env.cmd('MODULE', 'LIST')
+    env.assertEqual(res, default_module_list)
+    env.expect('MODULE', 'LOADEX', redisearch_module_path,
+               'CONFIG', 'search-fork-gc-clean-threshold', '0').error()\
+        .contains('Error loading the extension')
+    env.assertTrue(env.isUp())
+    env.stop()
 
 
 @skip(cluster=True)

--- a/tests/pytests/test_config_native_startup_bounds.py
+++ b/tests/pytests/test_config_native_startup_bounds.py
@@ -129,6 +129,15 @@ def testRuntimeConfigSetStillRejectsMaxAggregateResultsNegativeTwo(env):
         .contains('CONFIG SET failed')
 
 
+@skip(redis_less_than='7.9.227')
+def testRuntimeConfigSetStillRejectsMaxSearchResultsNegativeTwo(env):
+    """Registered min = -1 for search-max-search-results (matching
+    search-max-aggregate-results) means CONFIG SET keeps rejecting anything
+    below the sentinel, rather than silently treating it as unlimited."""
+    env.expect('CONFIG', 'SET', 'search-max-search-results', '-2').error()\
+        .contains('CONFIG SET failed')
+
+
 # Skip on ASAN since RedisModule_Unload is not fully implemented (MOD-7161)
 @skip(cluster=True, redis_less_than='7.9.227', asan=True)
 def testModuleLoadexRuntimeStillRejectsForkGcCleanThresholdZero():

--- a/tests/pytests/test_max_timeout_limit.py
+++ b/tests/pytests/test_max_timeout_limit.py
@@ -57,10 +57,9 @@ class TestMaxForegroundTimeoutLimit:
                                  'v', np.array([float(i), 0.0]).astype(np.float32).tobytes())
 
     def _reset(self, *, workers, timeout, limit):
-        """Pin all three knobs on every shard. timeout=0 routes via legacy
-        _FT.CONFIG SET because native search-timeout is gated at min=1.
-        Propagation is required so any test that previously set a knob via
-        run_command_on_all_shards cannot leak its value into the next test."""
+        """Pin all three knobs on every shard. Propagation is required so any
+        test that previously set a knob via run_command_on_all_shards cannot
+        leak its value into the next test."""
         env = self.env
         # Drop the limit first so intermediate states never violate the
         # cross-knob invariant during the transition.
@@ -68,11 +67,8 @@ class TestMaxForegroundTimeoutLimit:
                                         'search-_max-foreground-timeout-limit', '0')
         verify_command_OK_on_all_shards(env, 'CONFIG', 'SET',
                                         'search-workers', str(workers))
-        if timeout == 0:
-            verify_command_OK_on_all_shards(env, config_cmd(), 'SET', 'TIMEOUT', '0')
-        else:
-            verify_command_OK_on_all_shards(env, 'CONFIG', 'SET',
-                                            'search-timeout', str(timeout))
+        verify_command_OK_on_all_shards(env, 'CONFIG', 'SET',
+                                        'search-timeout', str(timeout))
         verify_command_OK_on_all_shards(env, 'CONFIG', 'SET',
                                         'search-_max-foreground-timeout-limit', str(limit))
 
@@ -104,8 +100,8 @@ class TestMaxForegroundTimeoutLimit:
         self._assert_config('TIMEOUT', '7000')
 
     def test_runtime_accept_unlimited_timeout_when_limit_active_legacy(self):
-        # Native search-timeout is gated at the registered min (1); TIMEOUT 0
-        # is only reachable via the legacy _FT.CONFIG SET path.
+        # search-timeout 0 via the legacy _FT.CONFIG SET path; the native
+        # path equivalent is covered in test_config.py's numericConfigs loop.
         self._reset(workers=0, timeout=100, limit=1000)
         env = self.env
         env.expect(config_cmd(), 'SET', 'TIMEOUT', '0').ok()


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** five native `search-*` numeric configs are registered with a minimum stricter than the value their legacy `_FT.CONFIG SET` / module-arg path accepts. Redis core enforces the registered range inside `RedisModule_LoadConfigs`, before the module's own setter runs, so such a value in a config file fails module init and **aborts the server on startup**. Our own documentation instructs users to set some of these values: `search-timeout` documents that "the timeout can be disabled by setting it to `0`", `search-max-search-results` documents `-1` to remove the limit, and the documented default for `search-max-aggregate-results` is `-1`, which today cannot be set at all.
2. **Change:** the registered floors are widened so these values reach the module, which then either honors them (`search-timeout 0`, `search-multi-text-slop 0`, `search-fork-gc-clean-threshold 0`, negative `search-max-search-results`) or, for a negative value other than `-1` on the two results caps, logs a warning naming the config, the rejected value and the value it keeps, and continues instead of aborting. The registered maximum for `search-max-search-results` and `search-max-aggregate-results` is likewise widened so an over-cap value reaches the module instead of aborting, and is clamped there exactly as the legacy setter always clamped it. Runtime `CONFIG SET` and runtime `MODULE LOAD`/`LOADEX` remain strict and still return an error.
3. **Outcome:** a server no longer refuses to start because of a deprecated-but-documented config value. Affected databases start, load their data and serve queries instead of dying at module load.

| Config | 2.x accepted | 8.x accepted before this PR | 8.x accepted now | Resulting behavior |
| --- | --- | --- | --- | --- |
| `search-timeout` | `>= 0` (`0` = no timeout) | `1 .. LLONG_MAX` | `0 .. LLONG_MAX` | `0` disables the timeout, as documented |
| `search-multi-text-slop` | `>= 0` | `1 .. UINT32_MAX` | `0 .. UINT32_MAX` | `0` is accepted |
| `search-fork-gc-clean-threshold` | `>= 0` | `1 .. LLONG_MAX` | `0 .. LLONG_MAX` | `0` is accepted and stored as `0`, matching 2.x, at startup and via `CONFIG SET` |
| `search-max-search-results` | any value (negative = unlimited, over-cap clamped) | `0 .. 2147483648` | `LLONG_MIN .. LLONG_MAX` | `-1` means unlimited; over-cap values are clamped to `2147483648`; any other negative warns and keeps the current value |
| `search-max-aggregate-results` | any value (negative = unlimited, over-cap clamped) | `0 .. 2147483648` | `LLONG_MIN .. LLONG_MAX` | same shape as `search-max-search-results`, with its own maximum |

#### Which additional issues this PR fixes

1. MOD-17730
2. MOD-17666

#### Main objects this PR modified

1. `RegisterModuleConfig_Local` in `src/config.c` — widened registered minimums for the five affected configs, and widened registered maximums for `search-max-search-results` / `search-max-aggregate-results`.
2. Per-config setters in `src/config.c` for the two results caps — honor `-1`, clamp over-cap values, and warn-and-keep for other negatives at startup while staying strict for `CONFIG SET`. `search-timeout`, `search-multi-text-slop` and `search-fork-gc-clean-threshold` need no custom setter: widening the registered floor is enough.
3. `translateOrClampMaxResults` in `src/config.c` — the negative-means-unlimited translation and the over-cap clamp, taking the cap as a parameter and shared by the native and legacy setters of both results caps, so those paths cannot drift again.
4. `RediSearch_InitModuleConfig` in `src/module.c` — records whether this is genuine server startup, gated on `REDISMODULE_CTX_FLAGS_SERVER_STARTUP`, so a runtime module load is not treated as startup.
5. `tests/pytests/test_config_native_startup_bounds.py` — starts real servers with each value in a config file, which is the path that crashed.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

### Verification

Reproduced and verified on Redis Enterprise 8.2.0-46 with a database upgraded from Redis 7.4 + search 2.10.32 to Redis 8.6 + search 8.6.10, which is how the customer in MOD-17666 hit it: the upgrade translates a legacy `TIMEOUT 0` module arg into a native `search-timeout 0` directive in the generated shard config, and the shard then aborts on start after having saved its final RDB. The same abort reproduces on search 8.0.3, 8.2.15, 8.4.12 and 8.6.10 with identical bounds, so this is not specific to 8.6.

Each of the five values was verified by hand against a fresh build: a config file containing it starts the server on this branch and aborts on `origin/master`. `test_config_native_startup_bounds.py`, `test_config.py` and `test_max_timeout_limit.py` pass at every commit on the branch, and CI was green on the final head.

### Scope

These are all of the configs whose accepted range narrowed between 2.x and 8.x. The full `FT.CONFIG` parameter inventory was compared across `v2.6.37`, `v2.8.38`, `v2.10.32`, `v8.0.3`, `v8.2.15`, `v8.4.12` and `v8.6.8`; see [Legacy Configurations Inventory (2.x->8.x)](https://redislabs.atlassian.net/wiki/spaces/DX/pages/6658195458/Legacy+Configurations+Inventory+2.x-+8.x), whose Class 1 table mirrors the table above.

`search-conn-per-shard` also narrowed, but only at its upper bound: 2.x stored it in a `size_t`, 8.x caps it at `UINT32_MAX`. That cap is not reachable in practice, so it is intentionally out of scope.

### Follow-ups, not in this PR

1. **Docs**: the published range lines contradict their own prose for `search-timeout`, `search-max-search-results` and `search-multi-text-slop`, and `search-topology-validation-timeout` documents `0` as "no timeout" while claiming a range starting at 1. Note also that `0` is implemented as an `INT32_MAX` millisecond deadline, so "disabled" means about 25 days rather than a skipped check.
2. **Startup aborts that remain**: `set_min_trim_delay_numeric_config`, `set_max_trim_delay_numeric_config` and `set_search_disk_max_open_files_config` still return `REDISMODULE_ERR` unconditionally, so a config file can still abort the server through them. The trim-delay pair is also order-sensitive inside `LoadConfigs`, so a file whose final state is valid can abort depending on which setter runs first.
3. **`UPGRADE_INDEX`**: still functional and the only way to feed `legacySpecRules` for RediSearch 1.x RDB upgrades, with no native equivalent and none possible (it is repeatable and multi-token). Worth a comment at its entry so a future cleanup does not delete it.
4. **`_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES`**: the only way to disable fork-GC numeric-empty-node cleanup, reachable solely through a deprecated load-time argument. Candidate for a native name. Its non-underscore sibling is a verified no-op, since the field already defaults to `true`.
5. **Test gating**: 32 remaining uses of `redis_less_than='7.9.227'` elsewhere in the suite. That build number is from the 8.0 pre-release line; `'8.0'` says the same thing readably. The gates guard nothing regardless, since search 8.x cannot load on Redis 7.4 at all.
6. **Flaky test**: `testSearchTimeoutZeroMeansNoTimeoutUnderRealSlowQuery` timed out in CI on a slower runner while building a 300k-document corpus in one pipeline. Removed in #11090.


