### PR TITLE
build: drop the unused cheadergen dependency from six crates

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1837,7 +1837,6 @@ version = "0.0.1"
 dependencies = [
  "build_utils",
  "c_trie",
- "cheadergen",
  "ffi",
  "field",
  "geo",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1532,7 +1532,6 @@ dependencies = [
 name = "numeric_range_tree_ffi"
 version = "0.0.1"
 dependencies = [
- "cheadergen",
  "ffi",
  "generational_slab",
  "hyperloglog",
@@ -3344,7 +3343,6 @@ dependencies = [
 name = "triemap_ffi"
 version = "0.0.1"
 dependencies = [
- "cheadergen",
  "lending-iterator",
  "libc",
  "redis-module",
@@ -3399,7 +3397,6 @@ dependencies = [
 name = "ttl_table_ffi"
 version = "0.0.1"
 dependencies = [
- "cheadergen",
  "ffi",
  "field",
  "libc",
@@ -3414,7 +3411,6 @@ dependencies = [
 name = "types_ffi"
 version = "0.0.1"
 dependencies = [
- "cheadergen",
  "ffi",
  "field",
  "index_result",
@@ -3581,7 +3577,6 @@ name = "varint_ffi"
 version = "0.0.1"
 dependencies = [
  "buffer",
- "cheadergen",
  "ffi",
  "rqe_core",
  "varint",

--- a/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/numeric_range_tree_ffi/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 
 
 [dependencies]
-cheadergen.workspace = true
 numeric_range_tree.workspace = true
 redis-module.workspace = true
 index_result.workspace = true

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 
 [dependencies]
-cheadergen.workspace = true
 lending-iterator.workspace = true
 libc.workspace = true
 thin_vec.workspace = true

--- a/src/redisearch_rs/c_entrypoint/ttl_table_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/ttl_table_ffi/Cargo.toml
@@ -9,7 +9,6 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-cheadergen.workspace = true
 ffi.workspace = true
 field.workspace = true
 libc.workspace = true

--- a/src/redisearch_rs/c_entrypoint/types_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 
 
 [dependencies]
-cheadergen.workspace = true
 ffi.workspace = true
 field.workspace = true
 index_result.workspace = true

--- a/src/redisearch_rs/c_entrypoint/varint_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/varint_ffi/Cargo.toml
@@ -18,6 +18,5 @@ workspace = true
 ffi = { workspace = true }
 rqe_core.workspace = true
 buffer = { workspace = true }
-cheadergen = { workspace = true }
 varint = { workspace = true }
 workspace_hack.workspace = true

--- a/src/redisearch_rs/query_eval/Cargo.toml
+++ b/src/redisearch_rs/query_eval/Cargo.toml
@@ -15,7 +15,6 @@ build_utils.workspace = true
 
 [dependencies]
 c_trie.workspace = true
-cheadergen.workspace = true
 ffi.workspace = true
 field.workspace = true
 index_result.workspace = true


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: six crates declare `cheadergen` without ever using it. The crate's entire public surface is the `config` attribute macro plus a documentation-only module, so a crate that never writes `#[cheadergen::config(...)]` gains nothing from the dependency — it only carries a proc-macro edge in the build graph.
2. Change: dropped the dependency from `numeric_range_tree_ffi`, `triemap_ffi`, `ttl_table_ffi`, `types_ffi`, `varint_ffi` and `query_eval`. All of them rely on cheadergen's default C lowering and stay on it. No crate in the workspace now declares cheadergen without using it.
3. Outcome: internal-only, with no effect on generated headers — the `cheadergen` CLI selects crates by input directory and an explicit package list, not from the dependency graph, and all 40 headers regenerate byte-identical. It leaves the manifests as an accurate record of which crates actually customize their C surface.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `c_entrypoint/{numeric_range_tree,triemap,ttl_table,types,varint}_ffi` — one dependency line removed from each manifest, no source changes.
2. `query_eval` — same removal; not an FFI crate, and the last remaining dead declaration.
3. `src/redisearch_rs/Cargo.lock` — the six corresponding edges; the `cheadergen` package entry stays, still required by all 24 remaining declarations, each of which really does carry a `#[cheadergen…]` attribute.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
