### PR TITLE
Test Expiry on numeric index

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -3429,6 +3429,39 @@ DEBUG_COMMAND(VecSimMockTimeout) {
 }
 
 /**
+ * FT.DEBUG MOCK_QUERY_TIME <offset-ms|disable|status>
+ * Shift the instant every query evaluates field expiration against, globally
+ * offset-ms - signed millisecond offset added to the wall-clock snapshot each query round takes,
+ *             so a test can move past a TTL without sleeping
+ * disable - restore the unshifted clock
+ * status - report the current offset. Nothing resets it, so a test that dies before disabling it
+ *          leaves every later query evaluating expiration at the shifted instant
+ * The query timeout is derived from the monotonic clock and is unaffected.
+ */
+DEBUG_COMMAND(MockQueryTime) {
+  if (!debugCommandsEnabled(ctx)) {
+    return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
+  }
+  if (argc != 3) {
+    return RedisModule_WrongArity(ctx);
+  }
+  const char *op = RedisModule_StringPtrLen(argv[2], NULL);
+  if (!strcmp("disable", op)) {
+    SearchCtx_SetMockQueryTimeOffsetMS(0);
+  } else if (!strcmp("status", op)) {
+    return RedisModule_ReplyWithLongLong(ctx, SearchCtx_GetMockQueryTimeOffsetMS());
+  } else {
+    long long offsetMS;
+    if (RedisModule_StringToLongLong(argv[2], &offsetMS) != REDISMODULE_OK) {
+      return RedisModule_ReplyWithError(
+          ctx, "Invalid command for 'MOCK_QUERY_TIME'. Use: <offset-ms>, disable, or status");
+    }
+    SearchCtx_SetMockQueryTimeOffsetMS(offsetMS);
+  }
+  return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+/**
  * FT.DEBUG MOCK_REVALIDATE_TIMEOUT <enable|disable|status>
  * Make every iterator revalidation report VALIDATE_TIMEOUT, globally
  * enable - every revalidation reports a timeout, as if the query ran out of time while re-seeking
@@ -3708,6 +3741,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"DUMP_SCHEMA", DumpSchema},
                                {"VECSIM_MOCK_TIMEOUT", VecSimMockTimeout},
                                {"MOCK_REVALIDATE_TIMEOUT", MockRevalidateTimeout},
+                               {"MOCK_QUERY_TIME", MockQueryTime},
                                {"GET_MAX_DOC_ID", GetMaxDocId},
                                {"DUMP_DELETED_IDS", DumpDeletedIds},
                                {"NUMERIC_BUCKET_MAP", NumericBucketMap},

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -37,6 +37,31 @@
 #include "util/references.h"
 #include "util/timeout.h"
 
+/** Debug-only shift applied to `SearchTime::current`. See `SearchCtx_SetMockQueryTimeOffsetMS`. */
+static int64_t mockQueryTimeOffsetMS = 0;
+
+void SearchCtx_SetMockQueryTimeOffsetMS(int64_t offsetMS) {
+  __atomic_store_n(&mockQueryTimeOffsetMS, offsetMS, __ATOMIC_RELAXED);
+}
+
+int64_t SearchCtx_GetMockQueryTimeOffsetMS(void) {
+  return __atomic_load_n(&mockQueryTimeOffsetMS, __ATOMIC_RELAXED);
+}
+
+/** Apply the debug offset to an already-stamped wall-clock instant. */
+static inline void applyMockQueryTimeOffset(struct timespec *current) {
+  const int64_t offsetMS = __atomic_load_n(&mockQueryTimeOffsetMS, __ATOMIC_RELAXED);
+  if (offsetMS == 0) {
+    return;
+  }
+  int64_t ns = (int64_t)current->tv_sec * 1000000000LL + current->tv_nsec + offsetMS * 1000000LL;
+  if (ns < 0) {
+    ns = 0;
+  }
+  current->tv_sec = ns / 1000000000LL;
+  current->tv_nsec = ns % 1000000000LL;
+}
+
 static inline void updateTime(SearchTime *searchTime, int32_t durationNS) {
   if (RS_IsMock) return;
 
@@ -53,6 +78,8 @@ static inline void updateTime(SearchTime *searchTime, int32_t durationNS) {
   // In some mac systems CLOCK_REALTIME_COARSE is not defined, we fallback to CLOCK_REALTIME
   clock_gettime(CLOCK_REALTIME, &searchTime->current);
 #endif
+
+  applyMockQueryTimeOffset(&searchTime->current);
 
   // The timeout mechanism is based on the monotonic clock, so we need another clock_gettime call
   timespec monotoicNow = {.tv_sec = 0, .tv_nsec = 0};

--- a/src/search_ctx.h
+++ b/src/search_ctx.h
@@ -10,6 +10,7 @@
 #define __SEARCH_CTX_H
 
 #include <sched.h>
+#include <stdint.h>
 
 #include "redismodule.h"
 #include "rmutil/rm_assert.h"
@@ -92,6 +93,18 @@ static inline RedisSearchCtx SEARCH_CTX_STATIC(RedisModuleCtx *ctx, IndexSpec *s
 }
 
 void SearchCtx_UpdateTime(RedisSearchCtx *sctx, int32_t durationNS);
+
+/**
+ * Shift the instant queries evaluate field expiration against, by `offsetMS`
+ * milliseconds. Debug-only, process-wide, and applied to every subsequent query
+ * round. A negative offset moves the instant backwards; zero restores the
+ * unshifted clock. The query timeout is derived from the monotonic clock and is
+ * unaffected.
+ */
+void SearchCtx_SetMockQueryTimeOffsetMS(int64_t offsetMS);
+
+/** The offset set by `SearchCtx_SetMockQueryTimeOffsetMS`, in milliseconds. */
+int64_t SearchCtx_GetMockQueryTimeOffsetMS(void);
 
 typedef struct QueryError QueryError;
 

--- a/tests/pytests/test_cursor_concurrent_update.py
+++ b/tests/pytests/test_cursor_concurrent_update.py
@@ -1,0 +1,94 @@
+"""A write during pagination drops *other* documents from the scan.
+
+No field TTLs, no debug commands, no cluster — a report paging with
+`FT.AGGREGATE … WITHCURSOR` while the application serves an ordinary write.
+
+Both the written document and its neighbours go missing, and neither is excused
+by snapshot semantics: `test_document_moved_far_ahead_is_still_returned` writes
+the same document to a distant value, re-indexing it exactly the same way, and it
+comes back. A cursor does reach documents indexed after it started.
+"""
+
+from common import *
+
+DOC_COUNT = 200
+# Small pages: the loss is confined to the first block segment of the index, so
+# a reader that clears it on page one never sees this.
+PAGE_SIZE = 3
+# First document of page two — the write has to land while the reader is still
+# inside that first segment.
+RESAVED = 4
+
+
+def load_inventory(env):
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'inventory', 'ON', 'HASH', 'PREFIX', '1', 'item:',
+               'SCHEMA', 'qty', 'NUMERIC').ok()
+    for i in range(1, DOC_COUNT + 1):
+        conn.execute_command('HSET', f'item:{i}', 'qty', str(i))
+    return conn
+
+
+def page_through(env, resave=None):
+    rows, cursor = env.cmd('FT.AGGREGATE', 'inventory', '@qty:[0 100000]',
+                           'LOAD', 1, '@__key', 'WITHCURSOR', 'COUNT', PAGE_SIZE)
+    seen = [to_dict(row)['__key'] for row in rows[1:]]
+
+    if resave is not None:
+        # A full-object save: every field written back, value unchanged.
+        getConnectionByEnv(env).execute_command('HSET', f'item:{resave}', 'qty', str(resave))
+
+    while cursor:
+        rows, cursor = env.cmd('FT.CURSOR', 'READ', 'inventory', cursor)
+        seen += [to_dict(row)['__key'] for row in rows[1:]]
+    return seen
+
+
+def missing(seen):
+    """Documents absent from the scan. All of them still match the range."""
+    expected = {f'item:{i}' for i in range(1, DOC_COUNT + 1)}
+    return sorted(expected - set(seen), key=lambda key: int(key.split(':')[1]))
+
+
+@skip(cluster=True)
+def test_paginated_scan_is_complete_without_concurrent_writes(env):
+    """Control: nothing is written while the scan runs, so nothing is missing."""
+    load_inventory(env)
+    seen = page_through(env)
+    env.assertEqual(len(seen), DOC_COUNT, message=f'returned {len(seen)}')
+
+
+@skip(cluster=True)
+def test_write_during_scan_does_not_drop_documents(env):
+    """Writing one document must not remove documents from the scan.
+
+    Only `item:4` is written, with the value it already had, so every document
+    still matches the range throughout. Several never come back — including
+    documents nobody touched.
+    """
+    load_inventory(env)
+    seen = page_through(env, resave=RESAVED)
+
+    lost = missing(seen)
+    env.assertEqual(lost, [], message=f'{len(lost)} documents dropped from the scan: {lost}')
+
+
+@skip(cluster=True)
+def test_document_moved_far_ahead_is_still_returned(env):
+    """The control that rules out snapshot semantics as an explanation.
+
+    `item:4` is re-indexed here too — same write, same new version — but to a
+    value far from where the reader is. It comes back, so a cursor plainly does
+    reach documents indexed after it started, and the losses above are not the
+    scan honouring a snapshot.
+    """
+    conn = load_inventory(env)
+    rows, cursor = env.cmd('FT.AGGREGATE', 'inventory', '@qty:[0 100000]',
+                           'LOAD', 1, '@__key', 'WITHCURSOR', 'COUNT', PAGE_SIZE)
+    seen = [to_dict(row)['__key'] for row in rows[1:]]
+    conn.execute_command('HSET', f'item:{RESAVED}', 'qty', '99999')
+    while cursor:
+        rows, cursor = env.cmd('FT.CURSOR', 'READ', 'inventory', cursor)
+        seen += [to_dict(row)['__key'] for row in rows[1:]]
+
+    env.assertContains(f'item:{RESAVED}', seen, message=f'returned {len(seen)}')

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -1211,3 +1211,37 @@ def test_hexpire_on_second_field_is_respected_by_search(env):
     env.expect('FT.SEARCH', 'idx', 'hello', 'NOCONTENT').equal([0])
     # `b` is still valid (long TTL), so a query on `b` still returns the doc.
     env.expect('FT.SEARCH', 'idx', 'world', 'NOCONTENT').equal([1, 'doc:1'])
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_mock_query_time_shifts_expiry_evaluation(env):
+    """`FT.DEBUG MOCK_QUERY_TIME` moves the instant a query evaluates field TTLs
+    against, so a lazily expired field is observable without sleeping past a real
+    TTL. Covers the offset being applied, reported, and cleared."""
+    conn = getConnectionByEnv(env)
+    conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    env.cmd(debug_cmd(), 'SET_MONITOR_EXPIRATION', 'idx', 'fields')
+    conn.execute_command('HSET', 'doc:1', 't', 'hello')
+    conn.execute_command('HSET', 'doc:2', 't', 'hello')
+    conn.execute_command('HPEXPIRE', 'doc:1', '100000', 'FIELDS', '1', 't')
+
+    try:
+        env.expect('FT.SEARCH', 'idx', '@t:hello', 'NOCONTENT') \
+            .apply(sort_document_names).equal([2, 'doc:1', 'doc:2'])
+
+        env.expect(debug_cmd(), 'MOCK_QUERY_TIME', '200000').ok()
+        env.expect(debug_cmd(), 'MOCK_QUERY_TIME', 'status').equal(200000)
+        env.expect('FT.SEARCH', 'idx', '@t:hello', 'NOCONTENT').equal([1, 'doc:2'])
+
+        # A negative offset moves back before the TTL was even set.
+        env.expect(debug_cmd(), 'MOCK_QUERY_TIME', '-200000').ok()
+        env.expect('FT.SEARCH', 'idx', '@t:hello', 'NOCONTENT') \
+            .apply(sort_document_names).equal([2, 'doc:1', 'doc:2'])
+
+        env.expect(debug_cmd(), 'MOCK_QUERY_TIME', 'disable').ok()
+        env.expect(debug_cmd(), 'MOCK_QUERY_TIME', 'status').equal(0)
+        env.expect('FT.SEARCH', 'idx', '@t:hello', 'NOCONTENT') \
+            .apply(sort_document_names).equal([2, 'doc:1', 'doc:2'])
+    finally:
+        env.cmd(debug_cmd(), 'MOCK_QUERY_TIME', 'disable')

--- a/tests/pytests/test_expire_iterators.py
+++ b/tests/pytests/test_expire_iterators.py
@@ -434,9 +434,8 @@ def test_hexpire_on_iterated_numeric_field_mid_cursor(env):
     - `HPEXPIRE` on a field absent from the schema is fine;
     - `HPEXPIRE` on the field under iteration is fine too, if the index already
       held a field TTL when the cursor opened;
-    - only the index acquiring its *first* field TTL mid-cursor is not.
-
-    Written up in `.vscode/docs/expiry_tests/numeric-cursor-abort.md`.
+    - a write landing while the reader is still in the first entries is not —
+      `HPEXPIRE` is one such write, a plain `HSET` is another.
     """
     conn = getConnectionByEnv(env)
     conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
@@ -451,6 +450,7 @@ def test_hexpire_on_iterated_numeric_field_mid_cursor(env):
     conn.execute_command('HPEXPIRE', 'doc:2', str(TTL_MS), 'FIELDS', '1', 'n')
     seen = drain_cursor(env, cursor)
 
+    # Draining is the assertion: today this aborts the server before returning.
     env.assertEqual(seen, ['doc:2'], message=seen)
 
 
@@ -470,10 +470,10 @@ def test_first_field_ttl_mid_cursor_drops_matching_documents(env):
     - a TTL already present when the cursor opens, plus one during.
 
     Only the index going from *no* field TTL to its first one mid-cursor loses
-    documents. Written up in
-    `.vscode/docs/expiry_tests/numeric-cursor-lost-documents.md`.
+    documents.
     """
     n_docs = 200
+    ttl_doc = 'doc:2'
     conn = getConnectionByEnv(env)
     conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
@@ -484,9 +484,13 @@ def test_first_field_ttl_mid_cursor_drops_matching_documents(env):
                            'LOAD', 1, '@__key', 'WITHCURSOR', 'COUNT', 1)
     seen = rows_to_keys(rows)
 
-    conn.execute_command('HPEXPIRE', 'doc:2', str(TTL_MS), 'FIELDS', '1', 'n')
+    conn.execute_command('HPEXPIRE', ttl_doc, str(TTL_MS), 'FIELDS', '1', 'n')
     seen += drain_cursor(env, cursor)
 
-    env.assertEqual(len(seen), n_docs,
-                    message=f'returned {len(seen)} of {n_docs}, '
-                            f'{n_docs - len(seen)} matching documents lost')
+    # Every document still matches: the TTL is far in the future, and re-indexing
+    # is not an excuse — a document moved to a distant value in the same way does
+    # come back (see test_cursor_concurrent_update.py).
+    expected = {f'doc:{i}' for i in range(1, n_docs + 1)}
+    lost = sorted(expected - set(seen), key=lambda key: int(key.split(':')[1]))
+    env.assertEqual(lost, [],
+                    message=f'{len(lost)} documents dropped from the scan: {lost}')

--- a/tests/pytests/test_expire_iterators.py
+++ b/tests/pytests/test_expire_iterators.py
@@ -1,0 +1,230 @@
+"""Field-expiry (`HEXPIRE`) behaviour, per query iterator.
+
+Every iterator that consults the expiration checker is reached here by its own
+query shape, and each one is put through the same assertions. The point is
+comparison: where two iterators treat the same expiry situation differently, the
+matrix reports it as one failing row rather than burying it in an aggregate.
+
+Each case asserts, through `FT.PROFILE`, that the query really did reach the
+iterator the case names — a matrix that silently exercises the wrong iterator is
+worse than no matrix at all.
+
+Expiry is driven by `_FT.DEBUG MOCK_QUERY_TIME`, which shifts the instant a query
+evaluates TTLs against. That keeps the tests off the wall clock: TTLs are set far
+in the future and the clock is moved past them on demand.
+"""
+
+from common import *
+
+# Offsets used to place the query instant either side of the TTLs below. Both are
+# far enough from `TTL_MS` that a coarse clock cannot land between them.
+TTL_MS = 100_000
+BEFORE_EXPIRY_MS = 0
+AFTER_EXPIRY_MS = 200_000
+
+# A vector close to `doc:1`'s, so KNN ordering is by construction rather than by
+# tie-break.
+VEC_QUERY = 'aaaaaaaa'
+
+
+class IteratorCase:
+    """How to reach one iterator, and how to prove the query got there.
+
+    `docs` maps document id to its full field set; `ttl_field` is the field given
+    a TTL on `doc:1`, so the two documents differ only in whether the queried
+    field has lapsed.
+    """
+
+    def __init__(self, name, schema, docs, query, ttl_field, profile_type, params=None,
+                 dialect=None):
+        self.name = name
+        self.schema = schema
+        self.docs = docs
+        self.query = query
+        self.ttl_field = ttl_field
+        self.profile_type = profile_type
+        self.params = params or []
+        self.dialect = dialect
+
+
+TEXT_CASE = IteratorCase(
+    name='text',
+    schema=('t', 'TEXT'),
+    docs={'doc:1': {'t': 'hello'}, 'doc:2': {'t': 'hello'}},
+    query='@t:hello',
+    ttl_field='t',
+    profile_type='TEXT',
+)
+
+TAG_CASE = IteratorCase(
+    name='tag',
+    schema=('tg', 'TAG'),
+    docs={'doc:1': {'tg': 'x'}, 'doc:2': {'tg': 'x'}},
+    query='@tg:{x}',
+    ttl_field='tg',
+    profile_type='TAG',
+)
+
+NUMERIC_CASE = IteratorCase(
+    name='numeric',
+    schema=('n', 'NUMERIC'),
+    docs={'doc:1': {'n': '1'}, 'doc:2': {'n': '2'}},
+    query='@n:[0 100]',
+    ttl_field='n',
+    profile_type='NUMERIC',
+)
+
+GEO_CASE = IteratorCase(
+    name='geo',
+    schema=('g', 'GEO'),
+    docs={'doc:1': {'g': '1,1'}, 'doc:2': {'g': '1.001,1.001'}},
+    query='@g:[1 1 100 km]',
+    ttl_field='g',
+    profile_type='GEO',
+)
+
+GEOSHAPE_CASE = IteratorCase(
+    name='geoshape',
+    schema=('geom', 'GEOSHAPE', 'FLAT'),
+    docs={'doc:1': {'geom': 'POLYGON((1 1, 1 100, 100 100, 100 1, 1 1))'},
+          'doc:2': {'geom': 'POLYGON((1 1, 1 120, 120 120, 120 1, 1 1))'}},
+    query='@geom:[within $poly]',
+    ttl_field='geom',
+    profile_type='GEO-SHAPE',
+    params=['PARAMS', 2, 'poly', 'POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))'],
+    dialect=3,
+)
+
+VECTOR_CASE = IteratorCase(
+    name='vector',
+    schema=('v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2',
+            'DISTANCE_METRIC', 'L2', 't', 'TEXT'),
+    docs={'doc:1': {'v': 'bababaca', 't': 'hello'},
+          'doc:2': {'v': 'babababa', 't': 'hello'}},
+    query='@t:hello=>[KNN 2 @v $vec]',
+    ttl_field='v',
+    profile_type='VECTOR',
+    params=['PARAMS', 2, 'vec', VEC_QUERY],
+    dialect=3,
+)
+
+ALL_CASES = [TEXT_CASE, TAG_CASE, NUMERIC_CASE, GEO_CASE, GEOSHAPE_CASE, VECTOR_CASE]
+
+
+def profile_iterator_types(node):
+    """Every `Type` value in an `FT.PROFILE` reply, in traversal order.
+
+    Walks the reply rather than indexing into it, so nesting (an intersection
+    above a leaf) and the extra `Shard ID` key in enterprise replies do not
+    change what it finds.
+    """
+    found = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == 'Type' and isinstance(value, str):
+                found.append(value)
+            else:
+                found.extend(profile_iterator_types(value))
+    elif isinstance(node, (list, tuple)):
+        for i, value in enumerate(node):
+            if value == 'Type' and i + 1 < len(node) and isinstance(node[i + 1], str):
+                found.append(node[i + 1])
+            else:
+                found.extend(profile_iterator_types(value))
+    return found
+
+
+def setup_case(env, case):
+    """Create the index for `case`, load its documents, and give `doc:1` a TTL."""
+    conn = getConnectionByEnv(env)
+    env.flush()
+    conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', *case.schema).ok()
+    env.cmd(debug_cmd(), 'SET_MONITOR_EXPIRATION', 'idx', 'fields')
+    for doc_id, fields in case.docs.items():
+        conn.execute_command('HSET', doc_id, *chain_fields(fields))
+    conn.execute_command('HPEXPIRE', 'doc:1', str(TTL_MS), 'FIELDS', '1', case.ttl_field)
+    return conn
+
+
+def chain_fields(fields):
+    for key, value in fields.items():
+        yield key
+        yield value
+
+
+def search_args(case, *extra):
+    args = ['idx', case.query, *extra, 'NOCONTENT', *case.params]
+    if case.dialect is not None:
+        args += ['DIALECT', case.dialect]
+    return args
+
+
+def search_ids(env, case):
+    """`(total, sorted ids)` for the case's query. Sorted so score order — which
+    differs between the vector case and the rest — does not enter the assertion."""
+    res = env.cmd('FT.SEARCH', *search_args(case))
+    return res[0], sorted(res[1:])
+
+
+def assert_reaches_iterator(env, case):
+    res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', *search_args(case)[1:])
+    types = profile_iterator_types(res)
+    env.assertContains(case.profile_type, types,
+                       message=f'{case.name}: profile types were {types}')
+
+
+def set_query_time(env, offset_ms):
+    env.cmd(debug_cmd(), 'MOCK_QUERY_TIME', str(offset_ms))
+
+
+def run_baseline(env, case):
+    """A field TTL hides its document from the queried iterator, and only that one.
+
+    Both documents match the query; only `doc:1` carries a TTL on the queried
+    field. Before the query instant reaches it both are returned; after, only
+    `doc:2` is.
+    """
+    setup_case(env, case)
+    try:
+        assert_reaches_iterator(env, case)
+
+        set_query_time(env, BEFORE_EXPIRY_MS)
+        env.assertEqual(search_ids(env, case), (2, ['doc:1', 'doc:2']),
+                        message=f'{case.name}: before expiry')
+
+        set_query_time(env, AFTER_EXPIRY_MS)
+        env.assertEqual(search_ids(env, case), (1, ['doc:2']),
+                        message=f'{case.name}: after expiry')
+    finally:
+        env.cmd(debug_cmd(), 'MOCK_QUERY_TIME', 'disable')
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_expiry_baseline_text(env):
+    run_baseline(env, TEXT_CASE)
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_expiry_baseline_tag(env):
+    run_baseline(env, TAG_CASE)
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_expiry_baseline_numeric(env):
+    run_baseline(env, NUMERIC_CASE)
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_expiry_baseline_geo(env):
+    run_baseline(env, GEO_CASE)
+
+
+@skip(cluster=True, redis_less_than='8.0')
+def test_expiry_baseline_geoshape(env):
+    run_baseline(env, GEOSHAPE_CASE)
+
+
+@skip(cluster=True, redis_less_than='8.0')
+def test_expiry_baseline_vector(env):
+    run_baseline(env, VECTOR_CASE)

--- a/tests/pytests/test_expire_iterators.py
+++ b/tests/pytests/test_expire_iterators.py
@@ -36,7 +36,7 @@ class IteratorCase:
     """
 
     def __init__(self, name, schema, docs, query, ttl_field, profile_type, params=None,
-                 dialect=None):
+                 dialect=None, yield_order=('doc:1', 'doc:2')):
         self.name = name
         self.schema = schema
         self.docs = docs
@@ -45,6 +45,10 @@ class IteratorCase:
         self.profile_type = profile_type
         self.params = params or []
         self.dialect = dialect
+        # The order the iterator yields its two documents in. Ascending doc id for
+        # everything that walks the index; nearest-first for the vector iterator,
+        # which orders by score instead.
+        self.yield_order = yield_order
 
 
 TEXT_CASE = IteratorCase(
@@ -106,6 +110,7 @@ VECTOR_CASE = IteratorCase(
     profile_type='VECTOR',
     params=['PARAMS', 2, 'vec', VEC_QUERY],
     dialect=3,
+    yield_order=('doc:2', 'doc:1'),
 )
 
 ALL_CASES = [TEXT_CASE, TAG_CASE, NUMERIC_CASE, GEO_CASE, GEOSHAPE_CASE, VECTOR_CASE]
@@ -134,8 +139,10 @@ def profile_iterator_types(node):
     return found
 
 
-def setup_case(env, case):
-    """Create the index for `case`, load its documents, and give `doc:1` a TTL."""
+def setup_case(env, case, ttl_doc='doc:1'):
+    """Create the index for `case`, load its documents, and give `ttl_doc` a TTL
+    on the queried field. The two documents then differ only in whether that field
+    has lapsed."""
     conn = getConnectionByEnv(env)
     env.flush()
     conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
@@ -143,7 +150,8 @@ def setup_case(env, case):
     env.cmd(debug_cmd(), 'SET_MONITOR_EXPIRATION', 'idx', 'fields')
     for doc_id, fields in case.docs.items():
         conn.execute_command('HSET', doc_id, *chain_fields(fields))
-    conn.execute_command('HPEXPIRE', 'doc:1', str(TTL_MS), 'FIELDS', '1', case.ttl_field)
+    if ttl_doc is not None:
+        conn.execute_command('HPEXPIRE', ttl_doc, str(TTL_MS), 'FIELDS', '1', case.ttl_field)
     return conn
 
 
@@ -228,3 +236,220 @@ def test_expiry_baseline_geoshape(env):
 @skip(cluster=True, redis_less_than='8.0')
 def test_expiry_baseline_vector(env):
     run_baseline(env, VECTOR_CASE)
+
+
+def aggregate_cursor(env, case, count):
+    """Open a cursor over the case's query, loading each document's key."""
+    args = ['idx', case.query, 'LOAD', 1, '@__key', *case.params]
+    if case.dialect is not None:
+        args += ['DIALECT', case.dialect]
+    args += ['WITHCURSOR', 'COUNT', count]
+    return env.cmd('FT.AGGREGATE', *args)
+
+
+def rows_to_keys(rows):
+    """The document keys in one `FT.AGGREGATE` chunk."""
+    return [to_dict(row)['__key'] for row in rows[1:]]
+
+
+def drain_cursor(env, cursor):
+    """Read a cursor to exhaustion, returning every key it still yields."""
+    keys = []
+    while cursor:
+        rows, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
+        keys += rows_to_keys(rows)
+    return keys
+
+
+def run_liveness_across_cursor_reads(env, case):
+    """A field that lapses between two cursor reads stops being yielded.
+
+    Each `FT.CURSOR READ` re-stamps the instant the round evaluates TTLs against,
+    so a document still live when the cursor opened must disappear once the clock
+    has moved past its TTL — unless the iterator decided its filtering strategy
+    when the cursor was built and never revisited it.
+
+    The TTL goes on the document yielded *second*, so the clock moves while it is
+    still in flight. The first assertion pins that: if it comes out of the opening
+    chunk instead, the shift lands after it was already returned and the rest of
+    the test proves nothing.
+    """
+    early_doc, late_doc = case.yield_order
+    setup_case(env, case, ttl_doc=late_doc)
+    try:
+        set_query_time(env, BEFORE_EXPIRY_MS)
+        rows, cursor = aggregate_cursor(env, case, 1)
+        seen_before = rows_to_keys(rows)
+
+        env.assertEqual(seen_before, [early_doc],
+                        message=f'{case.name}: opening chunk was {seen_before}, so the clock '
+                                f'shift cannot land while the TTL document is in flight')
+
+        set_query_time(env, AFTER_EXPIRY_MS)
+        seen_after = drain_cursor(env, cursor)
+
+        env.assertEqual(late_doc in seen_after, False,
+                        message=f'{case.name}: expired doc yielded after the clock moved, '
+                                f'after={seen_after}')
+    finally:
+        env.cmd(debug_cmd(), 'MOCK_QUERY_TIME', 'disable')
+
+
+def run_ttl_table_emptied_mid_cursor(env, case):
+    """Removing the last document carrying a field TTL mid-cursor is survivable.
+
+    The TTL table is freed when its last entry leaves, while iterators built
+    before that may still hold a decision that assumed it was there. Draining the
+    cursor afterwards must still yield the live document.
+    """
+    conn = setup_case(env, case)
+    try:
+        set_query_time(env, BEFORE_EXPIRY_MS)
+        rows, cursor = aggregate_cursor(env, case, 1)
+        seen = rows_to_keys(rows)
+
+        conn.execute_command('DEL', 'doc:1')
+        seen += drain_cursor(env, cursor)
+
+        env.assertContains('doc:2', seen,
+                           message=f'{case.name}: live doc lost after the TTL table emptied, '
+                                   f'seen={seen}')
+    finally:
+        env.cmd(debug_cmd(), 'MOCK_QUERY_TIME', 'disable')
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_expiry_liveness_text(env):
+    run_liveness_across_cursor_reads(env, TEXT_CASE)
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_expiry_liveness_tag(env):
+    run_liveness_across_cursor_reads(env, TAG_CASE)
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_expiry_liveness_numeric(env):
+    run_liveness_across_cursor_reads(env, NUMERIC_CASE)
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_expiry_liveness_geo(env):
+    run_liveness_across_cursor_reads(env, GEO_CASE)
+
+
+@skip(cluster=True, redis_less_than='8.0')
+def test_expiry_liveness_geoshape(env):
+    run_liveness_across_cursor_reads(env, GEOSHAPE_CASE)
+
+
+@skip(cluster=True, redis_less_than='8.0')
+def test_expiry_liveness_vector(env):
+    run_liveness_across_cursor_reads(env, VECTOR_CASE)
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_ttl_table_emptied_mid_cursor_text(env):
+    run_ttl_table_emptied_mid_cursor(env, TEXT_CASE)
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_ttl_table_emptied_mid_cursor_numeric(env):
+    run_ttl_table_emptied_mid_cursor(env, NUMERIC_CASE)
+
+
+@skip(cluster=True, redis_less_than='8.0')
+def test_ttl_table_emptied_mid_cursor_vector(env):
+    run_ttl_table_emptied_mid_cursor(env, VECTOR_CASE)
+
+
+def run_gate_armed_mid_cursor(env, case):
+    """A field TTL created after the cursor opened is honoured on later reads.
+
+    With no TTL anywhere in the index the expiration gate is off, and an iterator
+    is free to commit to a no-filtering read path when it is built. Arming the
+    gate mid-cursor asks whether that decision is ever revisited: the document is
+    yielded second, so it is still in flight when its TTL appears and lapses.
+    """
+    early_doc, late_doc = case.yield_order
+    conn = setup_case(env, case, ttl_doc=None)
+    try:
+        set_query_time(env, BEFORE_EXPIRY_MS)
+        rows, cursor = aggregate_cursor(env, case, 1)
+        seen_before = rows_to_keys(rows)
+
+        env.assertEqual(seen_before, [early_doc],
+                        message=f'{case.name}: opening chunk was {seen_before}, so the gate '
+                                f'cannot be armed while the TTL document is in flight')
+
+        conn.execute_command('HPEXPIRE', late_doc, str(TTL_MS), 'FIELDS', '1', case.ttl_field)
+        set_query_time(env, AFTER_EXPIRY_MS)
+        seen_after = drain_cursor(env, cursor)
+
+        env.assertEqual(late_doc in seen_after, False,
+                        message=f'{case.name}: document expired by a TTL set after the cursor '
+                                f'opened was still yielded, after={seen_after}')
+    finally:
+        env.cmd(debug_cmd(), 'MOCK_QUERY_TIME', 'disable')
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_gate_armed_mid_cursor_text(env):
+    run_gate_armed_mid_cursor(env, TEXT_CASE)
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_gate_armed_mid_cursor_tag(env):
+    run_gate_armed_mid_cursor(env, TAG_CASE)
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_gate_armed_mid_cursor_numeric(env):
+    run_gate_armed_mid_cursor(env, NUMERIC_CASE)
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_gate_armed_mid_cursor_geo(env):
+    run_gate_armed_mid_cursor(env, GEO_CASE)
+
+
+@skip(cluster=True, redis_less_than='8.0')
+def test_gate_armed_mid_cursor_geoshape(env):
+    run_gate_armed_mid_cursor(env, GEOSHAPE_CASE)
+
+
+@skip(cluster=True, redis_less_than='8.0')
+def test_gate_armed_mid_cursor_vector(env):
+    run_gate_armed_mid_cursor(env, VECTOR_CASE)
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_hexpire_on_iterated_numeric_field_mid_cursor(env):
+    """`HPEXPIRE` on the numeric field a suspended cursor is iterating.
+
+    Reduced from `test_gate_armed_mid_cursor_numeric`, and reached with no debug
+    command in the sequence. Narrowing, for whoever picks this up:
+
+    - a plain `HSET` on the same field mid-cursor is fine;
+    - `HPEXPIRE` on a field absent from the schema is fine;
+    - `HPEXPIRE` on the field under iteration is fine too, if the index already
+      held a field TTL when the cursor opened;
+    - only the index acquiring its *first* field TTL mid-cursor is not.
+
+    Written up, with the production exposure, in
+    `.vscode/docs/expiry_tests/numeric-cursor-crash.md`.
+    """
+    conn = getConnectionByEnv(env)
+    conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
+    conn.execute_command('HSET', 'doc:1', 'n', '1')
+    conn.execute_command('HSET', 'doc:2', 'n', '2')
+
+    rows, cursor = env.cmd('FT.AGGREGATE', 'idx', '@n:[0 100]',
+                           'LOAD', 1, '@__key', 'WITHCURSOR', 'COUNT', 1)
+    env.assertEqual(rows_to_keys(rows), ['doc:1'], message=rows)
+
+    conn.execute_command('HPEXPIRE', 'doc:2', str(TTL_MS), 'FIELDS', '1', 'n')
+    seen = drain_cursor(env, cursor)
+
+    env.assertEqual(seen, ['doc:2'], message=seen)

--- a/tests/pytests/test_expire_iterators.py
+++ b/tests/pytests/test_expire_iterators.py
@@ -436,8 +436,7 @@ def test_hexpire_on_iterated_numeric_field_mid_cursor(env):
       held a field TTL when the cursor opened;
     - only the index acquiring its *first* field TTL mid-cursor is not.
 
-    Written up, with the production exposure, in
-    `.vscode/docs/expiry_tests/numeric-cursor-crash.md`.
+    Written up in `.vscode/docs/expiry_tests/numeric-cursor-abort.md`.
     """
     conn = getConnectionByEnv(env)
     conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
@@ -453,3 +452,41 @@ def test_hexpire_on_iterated_numeric_field_mid_cursor(env):
     seen = drain_cursor(env, cursor)
 
     env.assertEqual(seen, ['doc:2'], message=seen)
+
+
+@skip(cluster=True, redis_less_than='7.4')
+def test_first_field_ttl_mid_cursor_drops_matching_documents(env):
+    """The index acquiring its first field TTL mid-cursor loses matching documents.
+
+    Same trigger as `test_hexpire_on_iterated_numeric_field_mid_cursor`, at an
+    index size where the damaged read lands on an entry boundary instead of
+    mid-entry: no error, no crash, just a short answer. The expired document is
+    given a far-future TTL, so every one of the documents is still live and all
+    of them are expected back.
+
+    Controls, all of which return the full set:
+    - no `HPEXPIRE` at all;
+    - `HPEXPIRE` before the cursor opens, none during;
+    - a TTL already present when the cursor opens, plus one during.
+
+    Only the index going from *no* field TTL to its first one mid-cursor loses
+    documents. Written up in
+    `.vscode/docs/expiry_tests/numeric-cursor-lost-documents.md`.
+    """
+    n_docs = 200
+    conn = getConnectionByEnv(env)
+    conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
+    for i in range(1, n_docs + 1):
+        conn.execute_command('HSET', f'doc:{i}', 'n', str(i))
+
+    rows, cursor = env.cmd('FT.AGGREGATE', 'idx', '@n:[0 100000]',
+                           'LOAD', 1, '@__key', 'WITHCURSOR', 'COUNT', 1)
+    seen = rows_to_keys(rows)
+
+    conn.execute_command('HPEXPIRE', 'doc:2', str(TTL_MS), 'FIELDS', '1', 'n')
+    seen += drain_cursor(env, cursor)
+
+    env.assertEqual(len(seen), n_docs,
+                    message=f'returned {len(seen)} of {n_docs}, '
+                            f'{n_docs - len(seen)} matching documents lost')


### PR DESCRIPTION
Investigating how "live"  ttl expiries are working, I encountered a crash and missing items during concurrent writes:

### Crash

I encountered a panic in https://github.com/RediSearch/RediSearch/blob/712116cff48f3dd92e230513cd3004d196adc153/src/redisearch_rs/rqe_iterators/src/interop.rs#L276-L278

- test `test_gate_armed_mid_cursor_numeric`

```mermaid
sequenceDiagram
    autonumber
    participant A as Client A — paging
    participant B as Client B — TTL writer
    participant S as Redis node
    A->>S: FT.AGGREGATE "@n:[…]" WITHCURSOR
    S-->>A: page 1 + cursor id
    Note over S: no field TTL in this index yet —<br/>iterator built with expiry filtering off
    B->>S: HPEXPIRE doc:… FIELDS 1 n
    S-->>B: OK (looks fine, is the cause)
    A->>S: FT.CURSOR READ idx (cursor id)
    Note over S: panic in the read path → SIGABRT
    S--xA: connection dropped
    S--xB: connection dropped
    Note over S: and every other client on the node with them
``` 

### Missing records on TTL expiry update

- test `test_first_field_ttl_mid_cursor_drops_matching_documents`

```mermaid
sequenceDiagram
    autonumber
    participant A as Client A — paging
    participant B as Client B — TTL writer
    participant S as Redis node
    Note over S: 200 documents, n = 1..200<br/>no field TTL anywhere in this index
    A->>S: FT.AGGREGATE "@n:[0 100000]" WITHCURSOR COUNT 1
    Note over S: the range matches all 200
    S-->>A: page 1 — doc:1
    B->>S: HPEXPIRE doc:2 100000 FIELDS 1 n
    Note right of B: 100 000 ms = 100 s in the future.<br/>Nothing expires during this query —<br/>doc:2 included, it must still come back.
    S-->>B: OK
    A->>S: FT.CURSOR READ … until the cursor is exhausted
    S-->>A: 193 more documents
    Note over A: 194 of 200. doc:2 … doc:8 are missing
```

### Missing records on concurrent writes

- Maybe addressed by https://github.com/RediSearch/RediSearch/pull/11038 ?

Not related to TTL, but related to concurrent updates:

- test `test_write_during_scan_does_not_drop_other_documents`

```mermaid
sequenceDiagram
    autonumber
    participant R as Report — paging
    participant W as App — ordinary write
    participant S as Redis node
    Note over S: 200 items on a numeric field, all matching
    R->>S: FT.AGGREGATE "@qty:[…]" WITHCURSOR COUNT 3
    S-->>R: page 1 — item:1, item:2, item:3
    W->>S: HSET item:4 qty 4
    Note right of W: only item:4 is written
    S-->>W: OK
    R->>S: FT.CURSOR READ … until exhausted
    Note over S: item:7 and item:8 are never written,<br/>never expired, and still match
    S-->>R: the rest — without item:7 or item:8
```

#### Mark if applicable

<!--
Tick these on the observable surface, not the intent: a changed reply shape,
error string, or default is an API change even when the code change is small.
If either box is ticked, the description above must say what breaks, what the
compatibility story is, and whether a migration or version gate is needed.
-->

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

<!--
Exactly one box — CI fails on zero or two. "Requires" for anything a user can
observe: new commands or options, behavior changes, bug fixes, performance
changes. "Does not require" for internal-only work.
-->

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
