### PR TITLE
Stop unfiltered KNN queries from re-writing every earlier document's distance

### DIFF
--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -495,6 +495,12 @@ static IteratorStatus HR_ReadKnnUnsortedSingle(HybridIterator *hr) {
     return ITERATOR_EOF;
   }
 
+  // `current` is one result reused for every read, and `ResultMetrics_Add` below only
+  // appends. On this path the hybrid iterator is the query root, so no parent aggregate
+  // ever drains it: without clearing it here the entries would pile up, one per yielded
+  // document, instead of describing the document `current` now holds.
+  ResultMetrics_Reset(hr->base.current);
+
   if (hr->checkFieldExpiration
       && !DocTable_CheckFieldExpirationPredicate(&hr->sctx->spec->docs, hr->base.current->docId,
                                                  hr->filterCtx.field.index,

--- a/src/redisearch_rs/vector_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source.rs
@@ -109,7 +109,9 @@ fn unfiltered_results_are_metric_kind_with_exact_distance() {
     let index = build_hnsw_index(n);
 
     // SAFETY: index outlives the iterator (freed at end of scope).
-    let source = unsafe { make_source(index, n, k, n) };
+    let mut source = unsafe { make_source(index, n, k, n) };
+    let mut own = make_key();
+    *source.own_key = (&mut own as *mut RLookupKey).cast();
     let mut it = new_vector_top_k_unfiltered(source, NonZeroUsize::new(k).unwrap());
 
     // Estimate is capped at k (k < index size here).
@@ -117,10 +119,16 @@ fn unfiltered_results_are_metric_kind_with_exact_distance() {
 
     // Unfiltered streams by score, so results come out best-first. Each result
     // is a Metric carrying the exact squared-L2 distance DIM*(n-id)^2.
+    //
+    // This path builds a fresh result per document rather than reusing one, which is
+    // what keeps its metric from accumulating the way the C reader's reused result did.
+    // Asserting the entry count per read pins that: were the result ever reused, the
+    // count would climb with the number of documents read.
     let mut expected_id = n as t_docId;
     while let Some(res) = it.read().unwrap() {
         assert_eq!(res.kind(), RSResultKind::Metric);
         assert_eq!(res.doc_id, expected_id);
+        assert_eq!(res.metrics.len(), 1, "one entry, for this document only");
         let dist = res
             .as_numeric()
             .expect("metric result carries a numeric value");

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -665,6 +665,9 @@ TEST_F(IndexTest, testHybridVector) {
   while (vecIt->Read(vecIt) != ITERATOR_EOF) {
     ASSERT_EQ(vecIt->current->data.tag, RSResultData_Metric);
     ASSERT_EQ(vecIt->current->docId, max_id - count);
+    // One entry per read, which is what the reset in `HR_ReadKnnUnsortedSingle` buys:
+    // without it this count climbs with the number of documents read.
+    ASSERT_EQ(MetricsVec_AsSlice(&vecIt->current->metrics).len, 1);
     count++;
   }
   ASSERT_EQ(count, k);
@@ -695,6 +698,9 @@ TEST_F(IndexTest, testHybridVector) {
     // since larger ids has lower distance, in every we get lower id (where max id is the final result).
     size_t expected_id = max_id - step*(count++);
     ASSERT_EQ(hybridIt->lastDocId, expected_id);
+    // One entry, because the term child yields no metrics of its own for
+    // `insertResultToHeap_Metric` to carry over: the distance it adds is all there is.
+    ASSERT_EQ(MetricsVec_AsSlice(&hybridIt->current->metrics).len, 1);
   }
   ASSERT_EQ(count, k);
   ASSERT_TRUE(hybridIt->atEOF);


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: on the KNN-only path (`*=>[KNN k @v $b AS dist]`, no filter clause) the hybrid iterator reads every document into one reused result and appends the distance to that result's metrics. Nothing ever drains it — on this path the iterator is the query root — so the collection grows by one entry per document read.
2. Change: clear the result's metrics before adding the distance for the document just read, which is what the Rust `Metric` leaf already does.
3. Outcome: the metrics loader stops re-writing every earlier document's distance. Over n returned documents the row writes and `RSValue` allocations drop from n(n+1)/2 to n, and every deep copy of the result stops copying a collection that grew per document. The reply was already correct, because every entry targets the same lookup key and the newest one is written last.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `HR_ReadKnnUnsortedSingle` (`src/iterators/hybrid_reader.c`) — resets the reused result before adding its metric.
2. `IndexTest.testHybridVector` — asserts one metric entry per read; without the fix the count climbs with the read count.
3. `VectorScoreSource::attach_score_metric` — no fix needed, it already upserts, but a test now pins that across a run of yields so the two implementations cannot drift.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
