### PR TITLE
metrics: upsert a node's own metric instead of dropping it when the key is absent

### DIFF
--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -191,8 +191,12 @@ static inline void updateResultScore(RSIndexResult *res, double score, RLookupKe
     IndexResult_SetNumValue(child, score);
   }
 
-  // Update metrics array entry for downstream $score access.
-  MetricsVec_UpdateValue(&res->metrics, scoreKey, score);
+  // Update metrics array entry for downstream $score access. `ownKey` is only set when
+  // the query asks for the distance as a field, and with no key there is no entry to keep
+  // in step — the same guard `VectorScoreSource::attach_score_metric` applies.
+  if (scoreKey) {
+    MetricsVec_UpsertValue(&res->metrics, scoreKey, score);
+  }
 }
 
 // Cleanup helper for computeDistances_Disk - centralizes resource cleanup.

--- a/src/redisearch_rs/c_entrypoint/metrics_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/metrics_ffi/src/lib.rs
@@ -125,27 +125,31 @@ pub unsafe extern "C" fn MetricsVec_AsSlice(metrics: *const MetricsVec) -> Metri
     vec.as_metrics_slice()
 }
 
-/// Finds the first metric whose key matches `key` (pointer equality) and
-/// replaces its value.
+/// Sets the value carried under `key`, appending a new entry if none carries it yet.
+///
+/// See [`MetricsVec::upsert_with_key`] for which metrics belong here rather than in
+/// [`ResultMetrics_Add`].
 ///
 /// # Safety
 ///
 /// 1. `metrics` must point to a valid `MetricsVec` (e.g. `&result.metrics`).
-/// 2. `key` must point to a valid `RLookupKey`. Compared by pointer identity.
+/// 2. `key` must be non-null and point to a valid `RLookupKey` that outlives the
+///    collection, since a key not already present is stored rather than ignored.
+///    Compared by pointer identity. Unlike [`ResultMetrics_Add`], null is not accepted:
+///    a caller holding an optional key must check it first.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn MetricsVec_UpdateValue(
-    metrics: *mut MetricsVec,
+pub unsafe extern "C" fn MetricsVec_UpsertValue<'a>(
+    metrics: *mut MetricsVec<'a>,
     key: *const RLookupKey,
     new_value: f64,
 ) {
     debug_assert!(!metrics.is_null(), "metrics must not be null");
     debug_assert!(!key.is_null(), "key must not be null");
 
-    // SAFETY: caller guarantees validity (1) and (2).
+    // SAFETY: caller guarantees validity (1).
     let vec = unsafe { &mut *metrics };
-    // SAFETY: caller guarantees `key` is valid and non-null (2); checked by debug_assert above.
+    // SAFETY: caller guarantees `key` is valid, non-null and outlives the collection (2);
+    // non-null is checked by the debug_assert above.
     let key = unsafe { &*key };
-    if let Some(entry) = vec.find_by_key_mut(key) {
-        entry.set_value(new_value);
-    }
+    vec.upsert_with_key(key, new_value);
 }

--- a/src/redisearch_rs/headers/metrics_ffi.h
+++ b/src/redisearch_rs/headers/metrics_ffi.h
@@ -50,15 +50,20 @@ struct MetricsSlice MetricsVec_AsSlice(const MetricsVec *metrics);
 MetricsVec MetricsVec_New(void);
 
 /**
- * Finds the first metric whose key matches `key` (pointer equality) and
- * replaces its value.
+ * Sets the value carried under `key`, appending a new entry if none carries it yet.
+ *
+ * See [`MetricsVec::upsert_with_key`] for which metrics belong here rather than in
+ * [`ResultMetrics_Add`].
  *
  * # Safety
  *
  * 1. `metrics` must point to a valid `MetricsVec` (e.g. `&result.metrics`).
- * 2. `key` must point to a valid `RLookupKey`. Compared by pointer identity.
+ * 2. `key` must be non-null and point to a valid `RLookupKey` that outlives the
+ *    collection, since a key not already present is stored rather than ignored.
+ *    Compared by pointer identity. Unlike [`ResultMetrics_Add`], null is not accepted:
+ *    a caller holding an optional key must check it first.
  */
-void MetricsVec_UpdateValue(MetricsVec *metrics, const RLookupKey *key, double new_value);
+void MetricsVec_UpsertValue(MetricsVec *metrics, const RLookupKey *key, double new_value);
 
 /**
  * Moves all metrics from `child` into `parent`, leaving `child` empty.

--- a/src/redisearch_rs/index_result/src/metrics.rs
+++ b/src/redisearch_rs/index_result/src/metrics.rs
@@ -223,6 +223,23 @@ impl<'a> MetricsVec<'a> {
     pub fn push_without_key(&mut self, value: f64) {
         self.inner.push(MetricEntry::without_key(value));
     }
+
+    /// Sets the value carried under `key`, appending a new entry if none carries it yet.
+    ///
+    /// This is the operation for a metric a node mints for *itself*, as opposed to one
+    /// it merely carries on behalf of a child:
+    ///
+    /// - The node's storage is typically reused from one document to the next, so a plain
+    ///   [`push_with_key`](Self::push_with_key) would accumulate an entry per document.
+    /// - When a child already contributed an entry under the same key, this overwrites
+    ///   that entry instead of adding a second one, so the node's value is the one
+    ///   reported.
+    pub fn upsert_with_key(&mut self, key: &'a RLookupKey, value: f64) {
+        match self.find_by_key_mut(key) {
+            Some(entry) => entry.set_value(value),
+            None => self.push_with_key(key, value),
+        }
+    }
 }
 
 impl Default for MetricsVec<'_> {

--- a/src/redisearch_rs/inverted_index/tests/integration/metrics.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/metrics.rs
@@ -232,6 +232,67 @@ fn find_by_key_mut_skips_keyless_entries() {
     assert!(v.find_by_key_mut(&key).is_none());
 }
 
+// ── MetricsVec — upsert_with_key ──────────────────────────────
+
+#[test]
+fn upsert_with_key_appends_when_absent() {
+    let key_a = make_key();
+    let key_other = make_key();
+    let mut v = MetricsVec::new();
+    v.push_with_key(&key_a, 1.0);
+
+    v.upsert_with_key(&key_other, 2.0);
+
+    assert_eq!(v.len(), 2);
+    assert_eq!(v.find_by_key_mut(&key_other).unwrap().value(), 2.0);
+    assert_eq!(v.find_by_key_mut(&key_a).unwrap().value(), 1.0, "untouched");
+}
+
+#[test]
+fn upsert_with_key_overwrites_in_place() {
+    let key_a = make_key();
+    let key_b = make_key();
+    let mut v = MetricsVec::new();
+    v.push_with_key(&key_a, 1.0);
+    v.push_with_key(&key_b, 2.0);
+
+    v.upsert_with_key(&key_a, 11.0);
+
+    assert_eq!(v.len(), 2, "overwritten, not appended");
+    assert_eq!(v.get(0).unwrap().value(), 11.0, "in place, order preserved");
+    assert_eq!(v.get(1).unwrap().value(), 2.0);
+}
+
+#[test]
+fn repeated_upserts_under_one_key_keep_a_single_entry() {
+    // The caller's storage is reused across documents, so an upsert per document
+    // must not grow the collection — that is the whole reason to prefer it over
+    // `push_with_key`.
+    let key = make_key();
+    let mut v = MetricsVec::new();
+
+    for value in [1.0, 2.0, 3.0, 4.0] {
+        v.upsert_with_key(&key, value);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.get(0).unwrap().value(), value);
+    }
+}
+
+#[test]
+fn upsert_with_key_ignores_keyless_entries() {
+    // A keyless entry carries no key to match, so it is never the one upserted
+    // into; the keyed entry is appended alongside it.
+    let key = make_key();
+    let mut v = MetricsVec::new();
+    v.push_without_key(1.0);
+
+    v.upsert_with_key(&key, 2.0);
+
+    assert_eq!(v.len(), 2);
+    assert_eq!(v.get(0).unwrap().value(), 1.0);
+    assert_eq!(v.find_by_key_mut(&key).unwrap().value(), 2.0);
+}
+
 // ── MetricsVec — concat ──────────────────────────────────────────────────
 
 #[test]

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -491,9 +491,9 @@ impl<'index, S: ScoreSource + 'index, C: RQEIterator<'index> + 'index> TopKItera
             // and takes the source-built path below.
             if self.child.is_some() && self.source.yields_child_record() {
                 if self.can_trim_deep_results {
-                    // Carry the child's captured metrics and attach our score
-                    // last, so a lookup key shared with the child (e.g. nested
-                    // KNN reusing an `AS` alias) keeps the outer vector score.
+                    // Carry the child's captured metrics and attach our score last, so
+                    // an entry left under our own key by an earlier yield through this
+                    // storage is superseded rather than reported.
                     let mut result = match record {
                         Some(record) => record,
                         None => self.source.build_result(doc_id, score),

--- a/src/redisearch_rs/top_k/src/traits.rs
+++ b/src/redisearch_rs/top_k/src/traits.rs
@@ -224,9 +224,15 @@ pub trait ScoreSource {
     /// vector distance) is exposed via the metrics channel for output fields
     /// like `__v_score`.
     ///
-    /// Implementations that maintain a stable score key should overwrite an
-    /// existing entry with the same key rather than appending, so repeated
-    /// yields of the same child storage don't leak metrics across docs.
+    /// Implementations that maintain a stable score key must
+    /// [upsert](index_result::MetricsVec::upsert_with_key) rather than append: the child's
+    /// storage is reused across yields, so an entry under this key may already be there
+    /// from the previous document, and appending would leak one entry per document.
+    /// Whatever is found under this source's own key is superseded by this score.
+    ///
+    /// Two *different* metric-yielding iterators cannot collide here — `RLookup` refuses a
+    /// duplicate output alias at query-build time — so the entry being overwritten is
+    /// always this source's own from an earlier yield.
     ///
     /// [`TopKIterator`]: crate::TopKIterator
     fn attach_score_metric<'r>(&self, _result: &mut RSIndexResult<'r>, _score: f64)

--- a/src/redisearch_rs/vector_score_source/src/source.rs
+++ b/src/redisearch_rs/vector_score_source/src/source.rs
@@ -489,15 +489,9 @@ impl<'index, E: ExpirationChecker> ScoreSource for VectorScoreSource<'index, E> 
         // at least `'index` (the query lifetime).
         let key: &'r ffi::RLookupKey = unsafe { &*(*self.own_key as *const ffi::RLookupKey) };
 
-        // The child reuses one storage slot across yields, so an entry from a
-        // previous yield may already exist for our key. Update in place when
-        // present; push otherwise. Any non-matching metrics from the child's
-        // own subtree are left untouched.
-        if let Some(entry) = result.metrics.find_by_key_mut(key) {
-            entry.set_value(score);
-        } else {
-            result.metrics.push_with_key(key, score);
-        }
+        // Upsert rather than push, for the reasons on `MetricsVec::upsert_with_key`.
+        // Metrics the child carries under other keys are untouched.
+        result.metrics.upsert_with_key(key, score);
     }
 
     fn yields_child_record(&self) -> bool {

--- a/src/redisearch_rs/vector_score_source/tests/integration/source.rs
+++ b/src/redisearch_rs/vector_score_source/tests/integration/source.rs
@@ -616,9 +616,10 @@ fn trimmed_shared_key_yields(mode: TopKMode) -> Vec<(t_docId, f64, Option<f64>)>
     emitted
 }
 
-/// A nested KNN reusing the outer `AS` alias makes the child yield a metric
-/// under this source's own key: the distance must overwrite that entry and the
-/// numeric payload, leaving nothing of the child's value.
+/// A child arriving with an entry already under this source's own key — seeded here by
+/// hand, as an earlier yield through the same reused storage would leave it — must have
+/// both that entry and the numeric payload superseded by the distance, leaving nothing of
+/// the earlier value.
 #[test]
 #[cfg_attr(miri, ignore = "requires C FFI (VecSim)")]
 fn batches_trimmed_shared_metric_key_carries_vector_score() {

--- a/tests/cpptests/test_cpp_hybrid_reader_disk.cpp
+++ b/tests/cpptests/test_cpp_hybrid_reader_disk.cpp
@@ -19,6 +19,7 @@
 #include "iterators/hybrid_reader.h"
 #include "redisearch.h"
 #include "util/timeout.h"
+#include "metrics_ffi.h"
 #include "types_ffi.h"
 #include "rlookup_ffi.h"
 
@@ -143,7 +144,7 @@ struct TestHybrid {
 
 class HybridReaderDiskTest : public ::testing::Test {
     std::array<float, 4> queryVec = {1.0f, 2.0f, 3.0f, 4.0f};
-    // Stable address used as ownKey sentinel. MetricsVec_UpdateValue compares by
+    // Stable address used as ownKey sentinel. MetricsVec_UpsertValue compares by
     // pointer identity only and never reads the fields, so zero-init is fine.
     RLookupKey scoreKey = {};
 protected:
@@ -213,7 +214,7 @@ protected:
         auto hr = (HybridIterator *)h.iter;
         // Enable reranking before the first Read() triggers prepareResults().
         hr->runtimeParams.hnswDiskRuntimeParams.shouldRerank = VecSimBool_TRUE;
-        // Provide a non-null ownKey so MetricsVec_UpdateValue can find and update
+        // Provide a non-null ownKey so MetricsVec_UpsertValue can find and update
         // the score entry. In production this is set by the metrics loader results
         // processor; in tests we supply a stable fixture-member address instead.
         hr->ownKey = &scoreKey;
@@ -221,6 +222,17 @@ protected:
     }
 
 };
+
+// Reads the single metric entry a trimmed result carries, so a test can assert on the
+// value the pipeline would report rather than only on the heap ordering.
+static double soleMetricValue(const RSIndexResult *res) {
+    MetricsSlice slice = MetricsVec_AsSlice(&res->metrics);
+    EXPECT_EQ(slice.len, 1u);
+    if (slice.len != 1) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    return slice.data[0].value;
+}
 
 // ============================================================================
 // Tests
@@ -272,11 +284,49 @@ TEST_F(HybridReaderDiskTest, RerankingUpdatesScores) {
     ASSERT_NE(it, nullptr);
 
     // After reranking with exact distances, doc 1 (0.1) should come before doc 2 (0.7).
+    // The ordering alone comes from the numeric payload; the metrics entry is what the
+    // pipeline reports as the score field, so assert the exact distance reached it too.
     ASSERT_EQ(it->Read(it), ITERATOR_OK);
     EXPECT_EQ(it->lastDocId, (t_docId)1);
+    EXPECT_DOUBLE_EQ(soleMetricValue(it->current), 0.1);
 
     ASSERT_EQ(it->Read(it), ITERATOR_OK);
     EXPECT_EQ(it->lastDocId, (t_docId)2);
+    EXPECT_DOUBLE_EQ(soleMetricValue(it->current), 0.7);
+
+    ASSERT_EQ(it->Read(it), ITERATOR_EOF);
+}
+
+// Reranking with no score field wired up. `ownKey` is only set when the query asks for the
+// distance as a field, so the rescore must still fix the numeric payload while storing
+// nothing under a key — a null key is not something the metrics collection can carry.
+//
+// One keyless entry is present regardless: `insertResultToHeap_Metric` adds the candidate's
+// distance through `ResultMetrics_Add`, which accepts a null key and pushes an unkeyed
+// entry. Nothing reads it, because a query with no score field has no metrics loader.
+TEST_F(HybridReaderDiskTest, RerankingWithoutScoreFieldStoresNoKeyedMetric) {
+    std::map<labelType, double> sq8 = {{1, 0.9}, {2, 0.8}};
+    std::map<labelType, double> exact = {{1, 0.1}, {2, 0.7}};
+    auto [index, it] = makeRerankingIterator(sq8, exact, {1, 2}, 2);
+
+    ASSERT_NE(it, nullptr);
+    // Undo the fixture's key: this is the shape of a KNN query with no yielded distance.
+    ((HybridIterator *)it)->ownKey = nullptr;
+
+    ASSERT_EQ(it->Read(it), ITERATOR_OK);
+    EXPECT_EQ(it->lastDocId, (t_docId)1);
+    // The rescore reached the payload, which is what orders the heap.
+    EXPECT_DOUBLE_EQ(IndexResult_NumValue(it->current), 0.1);
+    MetricsSlice slice = MetricsVec_AsSlice(&it->current->metrics);
+    ASSERT_EQ(slice.len, 1u);
+    EXPECT_EQ(slice.data[0].key, nullptr) << "no entry may be stored under a null key";
+
+    ASSERT_EQ(it->Read(it), ITERATOR_OK);
+    EXPECT_EQ(it->lastDocId, (t_docId)2);
+    EXPECT_DOUBLE_EQ(IndexResult_NumValue(it->current), 0.7);
+    slice = MetricsVec_AsSlice(&it->current->metrics);
+    ASSERT_EQ(slice.len, 1u);
+    EXPECT_EQ(slice.data[0].key, nullptr);
 
     ASSERT_EQ(it->Read(it), ITERATOR_EOF);
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `MetricsVec_UpdateValue` replaces the value of an entry carrying a given key and does nothing at all when no entry carries it. Its one caller is the hybrid reader's disk path, which rescores heap candidates with exact distances and then rewrites each result's metric to match.
2. Change: it upserts instead, and is renamed `MetricsVec_UpsertValue` so the name stops lying. `VectorScoreSource::attach_score_metric` hand-rolled the same find-or-push, so both now go through one `MetricsVec::upsert_with_key`.
3. Outcome: internal-only, and behavior-unchanged today — building an aggregate currently drains its children, so the key is always already on the result being rescored and the no-op is unreachable. This removes the silent no-op before #11006 makes it reachable, where it would report the stale approximate distance instead of the exact one just computed.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `MetricsVec::upsert_with_key` — one definition of "set this key's value, or add it", built from the existing find and push.
2. `MetricsVec_UpsertValue` (was `MetricsVec_UpdateValue`) — now stores an absent key rather than discarding the write; its safety contract gains the requirement that the key outlive the collection.
3. `ScoreSource::attach_score_metric` (`top_k/src/traits.rs`) — the contract now states the precedence rule both implementations follow: a node's own metric is written last and outranks a child's entry under the same key.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
