### PR TITLE
index_result: add flatten_metrics_into for the paths that discard a subtree

### DIFF
--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -87,7 +87,16 @@ static IteratorStatus HR_ReadInBatch(HybridIterator *hr, RSIndexResult *out) {
 
 static void insertResultToHeap_Metric(HybridIterator *hr, RSIndexResult *child_res, RSIndexResult **vec_res, double *upper_bound) {
 
-  RSYieldableMetric_Concat(&(*vec_res)->metrics, &child_res->metrics); // Pass child metrics, if there are any
+  // Collect the child's whole subtree: none of it is stored beside this bare distance, so
+  // anything a composite child holds deeper would be unreachable later.
+  //
+  // This copies where the previous drain moved, which leaves `child_res` holding its own
+  // entries afterwards. That does not accumulate, because every metric producer clears its
+  // collection before writing the next document's: `set_result_metrics` for a Rust metric
+  // leaf, `reset_aggregate` for a composite, the reset in `HR_ReadKnnUnsortedSingle` here.
+  // A producer that appended without clearing would have depended on someone draining it,
+  // which nothing guarantees.
+  IndexResult_FlattenMetricsInto(child_res, &(*vec_res)->metrics);
   ResultMetrics_Add(*vec_res, hr->ownKey, IndexResult_NumValue(*vec_res));
 
   if (hr->topResults->count < hr->query.k) {

--- a/src/redisearch_rs/c_entrypoint/metrics_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/metrics_ffi/src/lib.rs
@@ -79,6 +79,35 @@ pub unsafe extern "C" fn ResultMetrics_Add(
     }
 }
 
+/// Copies every metric in `source`'s subtree into `dst`, deepest first.
+///
+/// See [`RSIndexResult::flatten_metrics_into`] for the ordering guarantee and for when a
+/// caller needs this rather than reading `source->metrics` directly.
+///
+/// # Safety
+///
+/// 1. `source` must point to a valid [`RSIndexResult`] and cannot be null.
+/// 2. `dst` must point to a valid [`MetricsVec`] (e.g. `&result.metrics`).
+/// 3. `dst` must not alias any collection reachable from `source`, including
+///    `source->metrics` itself: `source` is read while `dst` is written, and appending to
+///    `dst` may reallocate it.
+/// 4. The `RLookupKey`s reachable from `source` must outlive `dst`, since `dst` keeps
+///    borrowing them after this call returns.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn IndexResult_FlattenMetricsInto<'a>(
+    source: *const RSIndexResult<'a>,
+    dst: *mut MetricsVec<'a>,
+) {
+    debug_assert!(!source.is_null(), "source must not be null");
+    debug_assert!(!dst.is_null(), "dst must not be null");
+
+    // SAFETY: caller guarantees validity (1) and (3).
+    let source = unsafe { &*source };
+    // SAFETY: caller guarantees validity (2).
+    let dst = unsafe { &mut *dst };
+    source.flatten_metrics_into(dst);
+}
+
 /// Clears all entries from the result's metrics collection.
 ///
 /// # Safety

--- a/src/redisearch_rs/headers/metrics_ffi.h
+++ b/src/redisearch_rs/headers/metrics_ffi.h
@@ -16,6 +16,24 @@ extern "C" {
 #endif // __cplusplus
 
 /**
+ * Copies every metric in `source`'s subtree into `dst`, deepest first.
+ *
+ * See [`RSIndexResult::flatten_metrics_into`] for the ordering guarantee and for when a
+ * caller needs this rather than reading `source->metrics` directly.
+ *
+ * # Safety
+ *
+ * 1. `source` must point to a valid [`RSIndexResult`] and cannot be null.
+ * 2. `dst` must point to a valid [`MetricsVec`] (e.g. `&result.metrics`).
+ * 3. `dst` must not alias any collection reachable from `source`, including
+ *    `source->metrics` itself: `source` is read while `dst` is written, and appending to
+ *    `dst` may reallocate it.
+ * 4. The `RLookupKey`s reachable from `source` must outlive `dst`, since `dst` keeps
+ *    borrowing them after this call returns.
+ */
+void IndexResult_FlattenMetricsInto(const RSIndexResult *source, MetricsVec *dst);
+
+/**
  * Resets aggregate-specific fields on an `RSIndexResult`: doc_id, freq,
  * field_mask, child records, and metrics.
  *

--- a/src/redisearch_rs/index_result/src/core/mod.rs
+++ b/src/redisearch_rs/index_result/src/core/mod.rs
@@ -1003,6 +1003,36 @@ impl<'a> RSIndexResult<'a> {
         }
     }
 
+    /// Copies every metric in this result's subtree into `dst`, deepest first.
+    ///
+    /// Use this wherever a result's metrics have to outlive the tree that produced them:
+    /// a caller that stores only part of the tree, or none of it, cannot reach the entries
+    /// its children hold. [`metrics_ref`](Self::metrics_ref) alone is not enough, since it
+    /// sees a single node.
+    ///
+    /// Children are collected before the node's own entries, so a metric a node minted for
+    /// itself is appended after the ones it merely carries for its children. Consumers that
+    /// resolve a repeated key by last-write-wins therefore report the outermost value —
+    /// matching [`MetricsVec::upsert_with_key`], which overwrites a child's entry in place
+    /// when it writes at the node instead. Siblings are collected in child order, so among
+    /// entries at the same depth the last child's wins.
+    ///
+    /// The source is left untouched, so a result that is reused from one document to the
+    /// next can be collected from once per document.
+    pub fn flatten_metrics_into(&self, dst: &mut MetricsVec<'a>) {
+        if let Some(agg) = self.as_aggregate() {
+            // Indexed rather than [`RSAggregateResult::iter`], whose `&'a self` receiver
+            // would tie the borrow to the payload's own lifetime and not `&self` here.
+            let mut index = 0;
+            while let Some(child) = agg.get(index) {
+                child.flatten_metrics_into(dst);
+                index += 1;
+            }
+        }
+
+        dst.extend_copied(&self.metrics);
+    }
+
     /// Create an owned copy of this index result, allocating new memory for the contained data.
     ///
     /// The returned result may borrow the term data from the original result.

--- a/src/redisearch_rs/index_result/src/metrics.rs
+++ b/src/redisearch_rs/index_result/src/metrics.rs
@@ -161,6 +161,15 @@ impl<'query> MetricsVec<'query> {
         self.inner.append(&mut other.inner);
     }
 
+    /// Appends a copy of every entry in `other`, leaving `other` untouched.
+    ///
+    /// The copying counterpart to [`concat`](Self::concat), for callers that collect from
+    /// a collection they do not own — or one they will collect from again for the next
+    /// document.
+    pub fn extend_copied(&mut self, other: &Self) {
+        self.inner.extend_from_slice(other.inner.as_slice());
+    }
+
     /// Drops all entries.
     pub fn reset(&mut self) {
         self.inner.clear();

--- a/src/redisearch_rs/inverted_index/tests/integration/index_result.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/index_result.rs
@@ -120,6 +120,137 @@ fn pushing_to_index_result() {
     assert_eq!(ir.field_mask, RS_FIELDMASK_ALL);
 }
 
+/// Children are pushed straight onto the aggregate payload rather than through
+/// `RSIndexResult::push_borrowed`, which drains the child's metrics into the parent and so
+/// cannot produce a tree that holds entries below the root — the very shape
+/// `flatten_metrics_into` exists to collect from.
+#[test]
+fn flatten_metrics_collects_the_whole_subtree_deepest_first() {
+    let leaf_key = crate::metrics::make_key();
+    let mid_key = crate::metrics::make_key();
+    let root_key = crate::metrics::make_key();
+
+    let mut leaf = RSIndexResult::build_numeric(10.0).doc_id(7).build();
+    leaf.metrics.push_with_key(&leaf_key, 1.0);
+
+    let mut mid = RSIndexResult::build_intersect(1).doc_id(7).build();
+    mid.metrics.push_with_key(&mid_key, 2.0);
+    mid.as_aggregate_mut()
+        .and_then(|agg| agg.as_borrowed_mut())
+        .expect("a fresh intersection borrows its children")
+        .push_borrowed(&leaf);
+
+    let mut root = RSIndexResult::build_union(1).doc_id(7).build();
+    root.metrics.push_with_key(&root_key, 3.0);
+    root.as_aggregate_mut()
+        .and_then(|agg| agg.as_borrowed_mut())
+        .expect("a fresh union borrows its children")
+        .push_borrowed(&mid);
+
+    let mut dst = MetricsVec::new();
+    root.flatten_metrics_into(&mut dst);
+
+    assert_eq!(
+        dst.iter().map(|e| e.value()).collect::<Vec<_>>(),
+        vec![1.0, 2.0, 3.0],
+        "deepest first, so the root's own entry is written last",
+    );
+}
+
+/// Siblings are collected in child order, which decides which of two entries at the same
+/// depth a last-write-wins consumer reports.
+#[test]
+fn flatten_metrics_collects_siblings_in_child_order() {
+    let first_key = crate::metrics::make_key();
+    let second_key = crate::metrics::make_key();
+    let root_key = crate::metrics::make_key();
+
+    let mut first = RSIndexResult::build_numeric(10.0).doc_id(7).build();
+    first.metrics.push_with_key(&first_key, 1.0);
+    let mut second = RSIndexResult::build_numeric(20.0).doc_id(7).build();
+    second.metrics.push_with_key(&second_key, 2.0);
+
+    let mut root = RSIndexResult::build_intersect(2).doc_id(7).build();
+    root.metrics.push_with_key(&root_key, 3.0);
+    {
+        let agg = root
+            .as_aggregate_mut()
+            .and_then(|agg| agg.as_borrowed_mut())
+            .expect("a fresh intersection borrows its children");
+        agg.push_borrowed(&first);
+        agg.push_borrowed(&second);
+    }
+
+    let mut dst = MetricsVec::new();
+    root.flatten_metrics_into(&mut dst);
+
+    assert_eq!(
+        dst.iter().map(|e| e.value()).collect::<Vec<_>>(),
+        vec![1.0, 2.0, 3.0],
+        "first child, second child, then the node's own",
+    );
+}
+
+#[test]
+fn flatten_metrics_leaves_the_source_untouched() {
+    // A composite reuses one result per document, so it is flattened once per document;
+    // moving the entries out would empty it for every later read.
+    let child_key = crate::metrics::make_key();
+    let root_key = crate::metrics::make_key();
+
+    let mut child = RSIndexResult::build_numeric(10.0).doc_id(7).build();
+    child.metrics.push_with_key(&child_key, 1.0);
+
+    let mut root = RSIndexResult::build_union(1).doc_id(7).build();
+    root.metrics.push_with_key(&root_key, 2.0);
+    root.as_aggregate_mut()
+        .and_then(|agg| agg.as_borrowed_mut())
+        .expect("a fresh union borrows its children")
+        .push_borrowed(&child);
+
+    let mut first = MetricsVec::new();
+    root.flatten_metrics_into(&mut first);
+    let mut second = MetricsVec::new();
+    root.flatten_metrics_into(&mut second);
+
+    assert_eq!(first, second, "a second collection sees the same entries");
+    assert_eq!(root.metrics.len(), 1, "root keeps only its own entry");
+    assert_eq!(child.metrics.len(), 1, "the child keeps its entry");
+}
+
+#[test]
+fn flatten_metrics_on_a_leaf_collects_its_own_entries() {
+    let key = crate::metrics::make_key();
+    let mut leaf = RSIndexResult::build_numeric(10.0).doc_id(7).build();
+    leaf.metrics.push_with_key(&key, 1.0);
+
+    let mut dst = MetricsVec::new();
+    leaf.flatten_metrics_into(&mut dst);
+
+    assert_eq!(dst.len(), 1);
+    assert_eq!(dst.get(0).unwrap().value(), 1.0);
+}
+
+#[test]
+fn flatten_metrics_appends_to_a_non_empty_destination() {
+    // Appends to whatever the destination already holds rather than replacing it, so one
+    // collection can gather from several results.
+    let key = crate::metrics::make_key();
+    let existing = crate::metrics::make_key();
+
+    let mut leaf = RSIndexResult::build_numeric(10.0).doc_id(7).build();
+    leaf.metrics.push_with_key(&key, 2.0);
+
+    let mut dst = MetricsVec::new();
+    dst.push_with_key(&existing, 1.0);
+    leaf.flatten_metrics_into(&mut dst);
+
+    assert_eq!(
+        dst.iter().map(|e| e.value()).collect::<Vec<_>>(),
+        vec![1.0, 2.0],
+    );
+}
+
 #[test]
 fn to_owned_an_aggregate_index_result() {
     let num_rec = RSIndexResult::build_numeric(5.0).doc_id(10).build();

--- a/src/redisearch_rs/inverted_index/tests/integration/metrics.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/metrics.rs
@@ -23,7 +23,7 @@ use std::ptr;
 ///
 /// The metrics code only stores and compares the borrow's address, so the
 /// field values are intentionally meaningless.
-const fn make_key() -> RLookupKey {
+pub(crate) const fn make_key() -> RLookupKey {
     RLookupKey {
         dstidx: 0,
         svidx: 0,
@@ -346,6 +346,51 @@ fn concat_into_empty_destination() {
     assert_eq!(dst.len(), 2);
     assert_eq!(dst.get(0).unwrap().value(), 1.0);
     assert_eq!(dst.get(1).unwrap().value(), 2.0);
+}
+
+// ── MetricsVec — extend_copied ────────────────────────────────
+
+#[test]
+fn extend_copied_appends_and_leaves_the_source_intact() {
+    let key_a = make_key();
+    let key_b = make_key();
+    let mut dst = MetricsVec::new();
+    dst.push_with_key(&key_a, 1.0);
+    let mut src = MetricsVec::new();
+    src.push_with_key(&key_b, 2.0);
+    src.push_without_key(3.0);
+
+    dst.extend_copied(&src);
+
+    assert_eq!(
+        dst.iter().map(|e| e.value()).collect::<Vec<_>>(),
+        vec![1.0, 2.0, 3.0],
+        "appended in source order after what was already there",
+    );
+    assert_eq!(src.len(), 2, "the source keeps its entries — this copies");
+}
+
+#[test]
+fn extend_copied_from_an_empty_source_is_a_noop() {
+    let key = make_key();
+    let mut dst = MetricsVec::new();
+    dst.push_with_key(&key, 1.0);
+
+    dst.extend_copied(&MetricsVec::new());
+
+    assert_eq!(dst.len(), 1);
+}
+
+#[test]
+fn extend_copied_into_an_empty_destination() {
+    let key = make_key();
+    let mut src = MetricsVec::new();
+    src.push_with_key(&key, 1.0);
+
+    let mut dst = MetricsVec::new();
+    dst.extend_copied(&src);
+
+    assert_eq!(dst, src);
 }
 
 // ── MetricsVec — as_metrics_slice ────────────────────────────────────────

--- a/src/redisearch_rs/top_k/src/iterator.rs
+++ b/src/redisearch_rs/top_k/src/iterator.rs
@@ -679,14 +679,15 @@ fn capture_child_record<'index>(record: &RSIndexResult<'index>) -> RSIndexResult
 ///
 /// Used on the trim path, where the child's deep scoring subtree is skipped but
 /// its yielded metrics remain explicit output/sort fields that must still be
-/// carried. Cloning copies each metric entry by value; the `RLookupKey`s they
-/// reference are owned by the query and stay valid for `'index`, so the copy
-/// outlives subsequent child reads.
+/// carried. The whole subtree is collected, not just the child's own node, since
+/// a composite child holds its entries in its children. Each entry is copied by
+/// value; the `RLookupKey`s they reference are owned by the query and stay valid
+/// for `'index`, so the copy outlives subsequent child reads.
 fn capture_child_metrics<'index>(record: &RSIndexResult<'index>) -> RSIndexResult<'index> {
     let mut owned = RSIndexResult::build_metric(0.0)
         .doc_id(record.doc_id)
         .build();
-    owned.metrics = record.metrics.clone();
+    record.flatten_metrics_into(&mut owned.metrics);
     owned
 }
 

--- a/tests/cpptests/test_cpp_hybrid_reader_disk.cpp
+++ b/tests/cpptests/test_cpp_hybrid_reader_disk.cpp
@@ -297,6 +297,34 @@ TEST_F(HybridReaderDiskTest, RerankingUpdatesScores) {
     ASSERT_EQ(it->Read(it), ITERATOR_EOF);
 }
 
+// A child that yields metrics of its own — a distance yielded by a clause below the filter —
+// has them carried onto every trimmed heap entry, and keeps them: the collection copies out
+// of the child rather than draining it, because the child reuses one result across reads and
+// its own producer is what clears it.
+TEST_F(HybridReaderDiskTest, TrimmedResultsCarryChildMetricsWithoutDrainingTheChild) {
+    constexpr double CHILD_METRIC = 42.0;
+    std::map<labelType, double> sq8 = {{1, 0.5}, {2, 0.1}};
+    auto [index, it] = makeNormalIterator(sq8, {1, 2}, 2);
+
+    ASSERT_NE(it, nullptr);
+
+    // The mock child reuses one result for every read, so planting the entry once covers
+    // every candidate the heap sees.
+    RSIndexResult *childRes = ((HybridIterator *)it)->child->current;
+    ResultMetrics_Add(childRes, nullptr, CHILD_METRIC);
+
+    ASSERT_EQ(it->Read(it), ITERATOR_OK);
+    MetricsSlice carried = MetricsVec_AsSlice(&it->current->metrics);
+    ASSERT_EQ(carried.len, 2u) << "the child's entry plus this reader's distance";
+    EXPECT_DOUBLE_EQ(carried.data[0].value, CHILD_METRIC) << "child's entries come first";
+
+    EXPECT_EQ(MetricsVec_AsSlice(&childRes->metrics).len, 1u)
+        << "the child keeps its own entry; collecting copies rather than moves";
+
+    ASSERT_EQ(it->Read(it), ITERATOR_OK);
+    EXPECT_EQ(MetricsVec_AsSlice(&it->current->metrics).len, 2u);
+}
+
 // Reranking with no score field wired up. `ownKey` is only set when the query asks for the
 // distance as a field, so the rescore must still fix the numeric payload while storing
 // nothing under a key — a null key is not something the metrics collection can carry.


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: two callers keep a result's own metrics and throw its subtree away — the hybrid reader when `canTrimDeepResults` lets it store a bare distance instead of the child's scoring tree, and `TopKIterator` on the same trim path. Both are complete only because building an aggregate drains its children, an invariant neither of them states.
2. Change: adds `RSIndexResult::flatten_metrics_into`, which copies every metric in a subtree into a destination, children before the node itself, and switches both callers onto it.
3. Outcome: internal-only, and no change to what a query reports — with the drain still in place there is nothing below a trimmed child left to collect. One thing does change: the hybrid reader's trim path used to *move* the child's metrics and now copies them, so the child keeps its own entries. That cannot accumulate, because every metric producer clears its collection before writing the next document's; the call site now says so. This is the collection primitive #11006 needs, landed while it is still a no-op so it can be tested on its own.

`RSYieldableMetric_Concat` loses its last caller here but is deleted in #11006, where `MetricsVec::concat` goes with it.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `RSIndexResult::flatten_metrics_into` — copies rather than moves, so a result reused across documents can be collected from once per document; children first, which is what makes a node's own metric outrank the ones it carries for its children.
2. `IndexResult_FlattenMetricsInto` — the C entrypoint for the same.
3. `capture_child_metrics` (`top_k`) and `insertResultToHeap_Metric` (`hybrid_reader.c`) — the two trim paths, now collecting the subtree explicitly instead of relying on it being empty.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
