### PR TITLE
Fix a yielded vector distance going missing after a mid-query yield

### DIFF
--- a/src/redisearch_rs/c_entrypoint/metrics_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/metrics_ffi/src/lib.rs
@@ -28,29 +28,35 @@ pub const extern "C" fn MetricsVec_New() -> MetricsVec<'static> {
     MetricsVec::new()
 }
 
-/// Moves all metrics from `child` into `parent`, leaving `child` empty.
+/// Drops all entries from a standalone collection, keeping its capacity for reuse.
+///
+/// For the collection embedded in a result, use [`ResultMetrics_Reset`] instead.
 ///
 /// # Safety
 ///
-/// 1. `parent` must point to a valid `MetricsVec` (e.g. `&result.metrics`).
-/// 2. `child` must point to a valid `MetricsVec`, or be null (no-op).
+/// 1. `metrics` must point to a valid `MetricsVec`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn RSYieldableMetric_Concat<'a>(
-    parent: *mut MetricsVec<'a>,
-    child: *mut MetricsVec<'a>,
-) {
-    debug_assert!(!parent.is_null(), "parent must not be null");
-    if child.is_null() {
-        return;
-    }
-    // SAFETY: caller guarantees both pointers are valid.
-    let child = unsafe { &mut *child };
-    if child.is_empty() {
-        return;
-    }
-    // SAFETY: caller guarantees `parent` is a valid, non-null pointer.
-    let parent = unsafe { &mut *parent };
-    parent.concat(child);
+pub unsafe extern "C" fn MetricsVec_Reset(metrics: *mut MetricsVec) {
+    debug_assert!(!metrics.is_null(), "metrics must not be null");
+
+    // SAFETY: caller guarantees validity (1).
+    let metrics = unsafe { &mut *metrics };
+    metrics.reset();
+}
+
+/// Releases the heap allocation behind a collection created by [`MetricsVec_New`].
+///
+/// Only standalone collections need this — one embedded in an [`RSIndexResult`] is freed
+/// with the result.
+///
+/// # Safety
+///
+/// 1. `metrics` must be a collection returned by [`MetricsVec_New`], passed by value. A
+///    zero-initialized value is not a valid empty collection and must not be passed here.
+/// 2. The collection must not be used or freed again afterwards.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn MetricsVec_Free(metrics: MetricsVec) {
+    drop(metrics);
 }
 
 /// Appends a single metric to the result's metrics collection.

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -553,8 +553,7 @@ pub unsafe extern "C" fn AggregateResult_AddChild(
     } else {
         // SAFETY: Caller is to ensure that `child` is a valid, non-null pointer to an `RSIndexResult`
         let child = unsafe { &mut *child };
-        let drained_metrics = std::mem::take(&mut child.metrics);
-        parent.push_borrowed(child, drained_metrics);
+        parent.push_borrowed(child);
     }
 }
 

--- a/src/redisearch_rs/headers/metrics_ffi.h
+++ b/src/redisearch_rs/headers/metrics_ffi.h
@@ -56,6 +56,20 @@ void IndexResult_ResetAggregate(RSIndexResult *r);
 struct MetricsSlice MetricsVec_AsSlice(const MetricsVec *metrics);
 
 /**
+ * Releases the heap allocation behind a collection created by [`MetricsVec_New`].
+ *
+ * Only standalone collections need this — one embedded in an [`RSIndexResult`] is freed
+ * with the result.
+ *
+ * # Safety
+ *
+ * 1. `metrics` must be a collection returned by [`MetricsVec_New`], passed by value. A
+ *    zero-initialized value is not a valid empty collection and must not be passed here.
+ * 2. The collection must not be used or freed again afterwards.
+ */
+void MetricsVec_Free(MetricsVec metrics);
+
+/**
  * Creates an empty metrics collection. Does not allocate.
  *
  * Use this to initialize the `metrics` field when constructing an
@@ -66,6 +80,17 @@ struct MetricsSlice MetricsVec_AsSlice(const MetricsVec *metrics);
  * `NULL`.
  */
 MetricsVec MetricsVec_New(void);
+
+/**
+ * Drops all entries from a standalone collection, keeping its capacity for reuse.
+ *
+ * For the collection embedded in a result, use [`ResultMetrics_Reset`] instead.
+ *
+ * # Safety
+ *
+ * 1. `metrics` must point to a valid `MetricsVec`.
+ */
+void MetricsVec_Reset(MetricsVec *metrics);
 
 /**
  * Sets the value carried under `key`, appending a new entry if none carries it yet.
@@ -82,16 +107,6 @@ MetricsVec MetricsVec_New(void);
  *    a caller holding an optional key must check it first.
  */
 void MetricsVec_UpsertValue(MetricsVec *metrics, const RLookupKey *key, double new_value);
-
-/**
- * Moves all metrics from `child` into `parent`, leaving `child` empty.
- *
- * # Safety
- *
- * 1. `parent` must point to a valid `MetricsVec` (e.g. `&result.metrics`).
- * 2. `child` must point to a valid `MetricsVec`, or be null (no-op).
- */
-void RSYieldableMetric_Concat(MetricsVec *parent, MetricsVec *child);
 
 /**
  * Appends a single metric to the result's metrics collection.

--- a/src/redisearch_rs/index_result/src/core/mod.rs
+++ b/src/redisearch_rs/index_result/src/core/mod.rs
@@ -943,13 +943,14 @@ impl<'a> RSIndexResult<'a> {
     /// - `doc_id` is set to the child's doc_id (inherits, not accumulated)
     /// - `freq` is accumulated (`+=`) from the child's frequency
     /// - `field_mask` is OR'd with the child's field mask
-    /// - `child_metrics` are concatenated (moved) into this result's metrics
+    ///
+    /// The child's metrics stay with the child; collect a whole tree's worth with
+    /// [`Self::flatten_metrics_into`]. Leaving them in place is what makes pushing the same
+    /// child again — as `revalidate` does when it rebuilds a document it is already on —
+    /// reproduce the same aggregate rather than an aggregate stripped of its metrics.
     ///
     /// If this is not an aggregate result, then nothing happens. Use [`Self::is_aggregate()`] first
     /// to make sure this is an aggregate result.
-    ///
-    /// The caller must drain the child's metrics via `std::mem::take(&mut child.metrics)`
-    /// before calling this method, and pass them as `child_metrics`.
     ///
     /// # Panics
     ///
@@ -961,15 +962,7 @@ impl<'a> RSIndexResult<'a> {
     ///
     /// The given `child` has to stay valid for the lifetime of this index result. Else reading
     /// from this result will cause undefined behaviour.
-    pub fn push_borrowed(
-        &mut self,
-        child: &'a RSIndexResult<'a>,
-        mut child_metrics: MetricsVec<'a>,
-    ) {
-        debug_assert!(
-            child.metrics.is_empty(),
-            "child metrics must be drained by caller via std::mem::take()"
-        );
+    pub fn push_borrowed(&mut self, child: &'a RSIndexResult<'a>) {
         if !self.is_aggregate() {
             return;
         }
@@ -977,10 +970,6 @@ impl<'a> RSIndexResult<'a> {
         self.doc_id = child.doc_id;
         self.freq += child.freq;
         self.field_mask |= child.field_mask;
-
-        if !child_metrics.is_empty() {
-            self.metrics.concat(&mut child_metrics);
-        }
 
         if let Some(agg) = self.as_aggregate_mut() {
             agg.as_borrowed_mut()
@@ -1054,7 +1043,8 @@ impl<'a> RSIndexResult<'a> {
     /// - The document ID will inherit the new child added
     /// - The child's frequency will contribute to this result
     /// - The child's field mask will contribute to this result's field mask
-    /// - If the child has metrics, then they will be concatenated to this result's metrics
+    ///
+    /// As with [`Self::push_borrowed`], the child keeps its own metrics.
     ///
     /// If this is not an aggregate result, then nothing happens. Use [`Self::is_aggregate()`] first
     /// to make sure this is an aggregate result.
@@ -1064,7 +1054,7 @@ impl<'a> RSIndexResult<'a> {
     /// If this is an aggregate result that *borrows* its children, which cannot take
     /// ownership of one. Use [`Self::push_borrowed`] for those, or ask
     /// [`Self::is_copy`] which kind this is.
-    pub fn push_boxed(&mut self, mut child: Box<RSIndexResult<'a>>) {
+    pub fn push_boxed(&mut self, child: Box<RSIndexResult<'a>>) {
         if !self.is_aggregate() {
             return;
         }
@@ -1072,11 +1062,6 @@ impl<'a> RSIndexResult<'a> {
         self.doc_id = child.doc_id;
         self.freq += child.freq;
         self.field_mask |= child.field_mask;
-
-        let mut child_metrics = std::mem::take(&mut child.metrics);
-        if !child_metrics.is_empty() {
-            self.metrics.concat(&mut child_metrics);
-        }
 
         if let Some(agg) = self.as_aggregate_mut() {
             agg.as_owned_mut()

--- a/src/redisearch_rs/index_result/src/metrics.rs
+++ b/src/redisearch_rs/index_result/src/metrics.rs
@@ -156,16 +156,10 @@ impl<'query> MetricsVec<'query> {
         }
     }
 
-    /// Moves all entries from `other` into `self`, leaving `other` empty.
-    pub fn concat(&mut self, other: &mut Self) {
-        self.inner.append(&mut other.inner);
-    }
-
     /// Appends a copy of every entry in `other`, leaving `other` untouched.
     ///
-    /// The copying counterpart to [`concat`](Self::concat), for callers that collect from
-    /// a collection they do not own — or one they will collect from again for the next
-    /// document.
+    /// For callers collecting from a collection they do not own — or one they will collect
+    /// from again for the next document.
     pub fn extend_copied(&mut self, other: &Self) {
         self.inner.extend_from_slice(other.inner.as_slice());
     }

--- a/src/redisearch_rs/inverted_index/tests/integration/index_result.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/index_result.rs
@@ -95,7 +95,7 @@ fn pushing_to_index_result() {
     assert_eq!(ir.freq, 0);
     assert_eq!(ir.field_mask, 0);
 
-    ir.push_borrowed(&result_virt, MetricsVec::new());
+    ir.push_borrowed(&result_virt);
     assert_eq!(ir.doc_id, 2, "should inherit doc id of the child");
     assert_eq!(ir.kind(), RSResultKind::Union);
     assert_eq!(ir.weight, 1.0);
@@ -112,7 +112,7 @@ fn pushing_to_index_result() {
         )
     );
 
-    ir.push_borrowed(&result_with_frequency, MetricsVec::new());
+    ir.push_borrowed(&result_with_frequency);
     assert_eq!(ir.doc_id, 2);
     assert_eq!(ir.kind(), RSResultKind::Union);
     assert_eq!(ir.weight, 1.0);
@@ -120,10 +120,6 @@ fn pushing_to_index_result() {
     assert_eq!(ir.field_mask, RS_FIELDMASK_ALL);
 }
 
-/// Children are pushed straight onto the aggregate payload rather than through
-/// `RSIndexResult::push_borrowed`, which drains the child's metrics into the parent and so
-/// cannot produce a tree that holds entries below the root — the very shape
-/// `flatten_metrics_into` exists to collect from.
 #[test]
 fn flatten_metrics_collects_the_whole_subtree_deepest_first() {
     let leaf_key = crate::metrics::make_key();
@@ -135,17 +131,11 @@ fn flatten_metrics_collects_the_whole_subtree_deepest_first() {
 
     let mut mid = RSIndexResult::build_intersect(1).doc_id(7).build();
     mid.metrics.push_with_key(&mid_key, 2.0);
-    mid.as_aggregate_mut()
-        .and_then(|agg| agg.as_borrowed_mut())
-        .expect("a fresh intersection borrows its children")
-        .push_borrowed(&leaf);
+    mid.push_borrowed(&leaf);
 
     let mut root = RSIndexResult::build_union(1).doc_id(7).build();
     root.metrics.push_with_key(&root_key, 3.0);
-    root.as_aggregate_mut()
-        .and_then(|agg| agg.as_borrowed_mut())
-        .expect("a fresh union borrows its children")
-        .push_borrowed(&mid);
+    root.push_borrowed(&mid);
 
     let mut dst = MetricsVec::new();
     root.flatten_metrics_into(&mut dst);
@@ -172,14 +162,8 @@ fn flatten_metrics_collects_siblings_in_child_order() {
 
     let mut root = RSIndexResult::build_intersect(2).doc_id(7).build();
     root.metrics.push_with_key(&root_key, 3.0);
-    {
-        let agg = root
-            .as_aggregate_mut()
-            .and_then(|agg| agg.as_borrowed_mut())
-            .expect("a fresh intersection borrows its children");
-        agg.push_borrowed(&first);
-        agg.push_borrowed(&second);
-    }
+    root.push_borrowed(&first);
+    root.push_borrowed(&second);
 
     let mut dst = MetricsVec::new();
     root.flatten_metrics_into(&mut dst);
@@ -189,6 +173,63 @@ fn flatten_metrics_collects_siblings_in_child_order() {
         vec![1.0, 2.0, 3.0],
         "first child, second child, then the node's own",
     );
+}
+
+/// Rebuilding an aggregate for a document it has already built must report the same
+/// metrics. A composite rebuilds by resetting and pushing its children again — which is
+/// what `revalidate` does when a child moves without the composite's position changing —
+/// so the rebuild can only re-derive what the children still hold.
+#[test]
+fn rebuilding_an_aggregate_re_derives_its_metrics() {
+    let child_key = crate::metrics::make_key();
+    let mut child = RSIndexResult::build_numeric(10.0).doc_id(7).build();
+    child.metrics.push_with_key(&child_key, 1.0);
+
+    let mut root = RSIndexResult::build_union(1).doc_id(7).build();
+    root.push_borrowed(&child);
+
+    let mut first = MetricsVec::new();
+    root.flatten_metrics_into(&mut first);
+    assert_eq!(first.len(), 1);
+
+    root.reset_aggregate();
+    root.push_borrowed(&child);
+
+    let mut second = MetricsVec::new();
+    root.flatten_metrics_into(&mut second);
+    assert_eq!(second, first, "the rebuild re-derives the child's metric");
+}
+
+/// An aggregate that *owns* its children leaves their metrics with them, so the entries stay
+/// reachable through the child rather than being hoisted into the parent. This is the shape
+/// the hybrid reader builds — `NewHybridResult` owns its children — and the one a metric
+/// below the filter clause rides in.
+#[test]
+fn an_owned_aggregate_keeps_its_childs_metrics() {
+    let child_key = crate::metrics::make_key();
+    let mut child = RSIndexResult::build_numeric(10.0).doc_id(7).build();
+    child.metrics.push_with_key(&child_key, 1.0);
+
+    let mut root = RSIndexResult::build_hybrid_metric().doc_id(7).build();
+    root.push_boxed(Box::new(child));
+
+    assert_eq!(
+        root.metrics_ref().len(),
+        0,
+        "the parent does not take the child's entry",
+    );
+    assert_eq!(
+        root.get(0)
+            .expect("the child was pushed")
+            .metrics_ref()
+            .len(),
+        1,
+        "the child still carries it",
+    );
+
+    let mut collected = MetricsVec::new();
+    root.flatten_metrics_into(&mut collected);
+    assert_eq!(collected.len(), 1, "and collecting the tree finds it");
 }
 
 #[test]
@@ -203,10 +244,7 @@ fn flatten_metrics_leaves_the_source_untouched() {
 
     let mut root = RSIndexResult::build_union(1).doc_id(7).build();
     root.metrics.push_with_key(&root_key, 2.0);
-    root.as_aggregate_mut()
-        .and_then(|agg| agg.as_borrowed_mut())
-        .expect("a fresh union borrows its children")
-        .push_borrowed(&child);
+    root.push_borrowed(&child);
 
     let mut first = MetricsVec::new();
     root.flatten_metrics_into(&mut first);
@@ -259,7 +297,7 @@ fn to_owned_an_aggregate_index_result() {
         .weight(3.0)
         .build();
 
-    ir.push_borrowed(&num_rec, MetricsVec::new());
+    ir.push_borrowed(&num_rec);
 
     let mut ir_copy = ir.to_owned();
 
@@ -362,7 +400,7 @@ fn pushing_a_borrowed_child_to_an_owned_aggregate_panics() {
     let child = RSIndexResult::build_metric(1.0).doc_id(7).build();
     let mut owned = RSIndexResult::build_hybrid_metric().build();
 
-    owned.push_borrowed(&child, MetricsVec::new());
+    owned.push_borrowed(&child);
 }
 
 /// The mirror image: a borrowed aggregate never frees its children, so taking
@@ -383,7 +421,7 @@ fn pushing_an_owned_child_to_a_borrowed_aggregate_panics() {
 fn mutably_reaching_a_borrowed_child_panics() {
     let child = RSIndexResult::build_numeric(1.0).doc_id(7).build();
     let mut borrowed = RSIndexResult::build_union(1).build();
-    borrowed.push_borrowed(&child, MetricsVec::new());
+    borrowed.push_borrowed(&child);
 
     let _ = borrowed.get_mut(0);
 }
@@ -493,7 +531,7 @@ fn single_child_aggregate_always_true() {
     // An intersection with a single numeric child — no proximity check needed.
     let child = RSIndexResult::build_numeric(1.0).doc_id(1).build();
     let mut ir = RSIndexResult::build_intersect(1).build();
-    ir.push_borrowed(&child, MetricsVec::new());
+    ir.push_borrowed(&child);
     assert!(ir.is_within_range(Some(0), false));
     assert!(ir.is_within_range(Some(0), true));
 }
@@ -514,8 +552,8 @@ fn in_order_no_slop_succeeds_when_order_exists() {
         .doc_id(1)
         .build();
     let mut ir = RSIndexResult::build_intersect(2).build();
-    ir.push_borrowed(&t1, MetricsVec::new());
-    ir.push_borrowed(&t2, MetricsVec::new());
+    ir.push_borrowed(&t1);
+    ir.push_borrowed(&t2);
     assert!(ir.is_within_range(None, true));
 }
 
@@ -535,8 +573,8 @@ fn in_order_no_slop_fails_when_order_impossible() {
         .doc_id(1)
         .build();
     let mut ir = RSIndexResult::build_intersect(2).build();
-    ir.push_borrowed(&t1, MetricsVec::new());
-    ir.push_borrowed(&t2, MetricsVec::new());
+    ir.push_borrowed(&t1);
+    ir.push_borrowed(&t2);
     assert!(!ir.is_within_range(None, true));
 }
 
@@ -546,8 +584,8 @@ fn purely_numeric_children_always_true() {
     let child1 = RSIndexResult::build_numeric(1.0).doc_id(1).build();
     let child2 = RSIndexResult::build_numeric(2.0).doc_id(1).build();
     let mut ir = RSIndexResult::build_intersect(2).build();
-    ir.push_borrowed(&child1, MetricsVec::new());
-    ir.push_borrowed(&child2, MetricsVec::new());
+    ir.push_borrowed(&child1);
+    ir.push_borrowed(&child2);
     assert!(ir.is_within_range(Some(0), false));
     assert!(ir.is_within_range(Some(0), true));
 }
@@ -573,8 +611,8 @@ fn full_test_mirrors_cpp_testdistance() {
         .build();
 
     let mut ir = RSIndexResult::build_intersect(2).build();
-    ir.push_borrowed(&t1, MetricsVec::new());
-    ir.push_borrowed(&t2, MetricsVec::new());
+    ir.push_borrowed(&t1);
+    ir.push_borrowed(&t2);
 
     // Unordered: slop=1 is true because (vw1=9, vw2=7) has span=1.
     assert!(!ir.is_within_range(Some(0), false));

--- a/src/redisearch_rs/inverted_index/tests/integration/metrics.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/metrics.rs
@@ -293,61 +293,6 @@ fn upsert_with_key_ignores_keyless_entries() {
     assert_eq!(v.find_by_key_mut(&key).unwrap().value(), 2.0);
 }
 
-// ── MetricsVec — concat ──────────────────────────────────────────────────
-
-#[test]
-fn concat_moves_entries_and_empties_source() {
-    let key_a = make_key();
-    let key_b = make_key();
-
-    let mut dst = MetricsVec::new();
-    dst.push_with_key(&key_a, 1.0);
-
-    let mut src = MetricsVec::new();
-    src.push_with_key(&key_b, 2.0);
-    src.push_without_key(3.0);
-
-    dst.concat(&mut src);
-
-    assert!(src.is_empty(), "source must be drained");
-    assert_eq!(dst.len(), 3);
-    assert_eq!(dst.get(0).unwrap().value(), 1.0);
-    assert_eq!(dst.get(1).unwrap().value(), 2.0);
-    assert!(ptr::eq(dst.get(1).unwrap().key().unwrap(), &key_b));
-    assert!(dst.get(2).unwrap().key().is_none());
-}
-
-#[test]
-fn concat_with_empty_source_is_a_noop() {
-    let key = make_key();
-    let mut dst = MetricsVec::new();
-    dst.push_with_key(&key, 1.0);
-    let snapshot = dst.clone();
-
-    let mut src = MetricsVec::new();
-    dst.concat(&mut src);
-
-    assert_eq!(dst, snapshot);
-    assert!(src.is_empty());
-}
-
-#[test]
-fn concat_into_empty_destination() {
-    let key = make_key();
-    let mut dst = MetricsVec::new();
-
-    let mut src = MetricsVec::new();
-    src.push_with_key(&key, 1.0);
-    src.push_without_key(2.0);
-
-    dst.concat(&mut src);
-
-    assert!(src.is_empty());
-    assert_eq!(dst.len(), 2);
-    assert_eq!(dst.get(0).unwrap().value(), 1.0);
-    assert_eq!(dst.get(1).unwrap().value(), 2.0);
-}
-
 // ── MetricsVec — extend_copied ────────────────────────────────
 
 #[test]

--- a/src/redisearch_rs/rqe_iterators/src/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators/src/intersection.rs
@@ -322,7 +322,6 @@ where
 
         for child in &mut self.children {
             if let Some(child_result) = child.current() {
-                let child_metrics = std::mem::take(&mut child_result.metrics);
                 let child_ptr: *const RSIndexResult<'index> = child_result;
                 // SAFETY:
                 // - `child_ptr` was derived from a valid `&mut RSIndexResult`, so it
@@ -333,7 +332,7 @@ where
                 //   index-backed results; children are owned by `self` and outlive
                 //   this call.
                 let child_ref = unsafe { &*child_ptr };
-                self.result.push_borrowed(child_ref, child_metrics);
+                self.result.push_borrowed(child_ref);
             }
         }
     }

--- a/src/redisearch_rs/rqe_iterators/src/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_flat.rs
@@ -184,14 +184,13 @@ where
     fn add_child_to_result(&mut self, child_idx: usize) {
         let child = &mut self.children[child_idx];
         if let Some(child_result) = child.current() {
-            let drained_metrics = std::mem::take(&mut child_result.metrics);
             let child_ptr: *const RSIndexResult<'index> = child_result;
             // SAFETY: We need a raw pointer to decouple the borrow of the child's
             // result from `&mut self.result`. This is sound because:
             // 1. `self.children[i]` and `self.result` are disjoint fields — no aliasing.
             // 2. The child is owned by `self`, so the 'index data remains valid.
             let child_ref = unsafe { &*child_ptr };
-            self.result.push_borrowed(child_ref, drained_metrics);
+            self.result.push_borrowed(child_ref);
         }
     }
 }
@@ -308,14 +307,13 @@ where
             if child.last_doc_id() == min_id
                 && let Some(child_result) = child.current()
             {
-                let drained_metrics = std::mem::take(&mut child_result.metrics);
                 let child_ptr: *const RSIndexResult<'index> = child_result;
                 // SAFETY: We need a raw pointer to decouple the borrow of the child's
                 // result from `&mut self.result`. This is sound because:
                 // 1. `self.children[i]` and `self.result` are disjoint fields — no aliasing.
                 // 2. The child is owned by `self`, so the 'index data remains valid.
                 let child_ref = unsafe { &*child_ptr };
-                self.result.push_borrowed(child_ref, drained_metrics);
+                self.result.push_borrowed(child_ref);
             }
         }
     }

--- a/src/redisearch_rs/rqe_iterators/src/union_heap.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_heap.rs
@@ -306,14 +306,13 @@ where
             }
 
             if let Some(child_result) = self.children[entry.child_idx].current() {
-                let drained_metrics = std::mem::take(&mut child_result.metrics);
                 let child_ptr: *const RSIndexResult<'index> = child_result;
                 // SAFETY: We need a raw pointer to decouple the borrow of the child's
                 // result from `&mut self.result`. This is sound because:
                 // 1. `self.children[i]` and `self.result` are disjoint fields — no aliasing.
                 // 2. The child is owned by `self`, so the 'index data remains valid.
                 let child_ref = unsafe { &*child_ptr };
-                self.result.push_borrowed(child_ref, drained_metrics);
+                self.result.push_borrowed(child_ref);
             }
             // both children of heap_idx are >= doc_id due to heap property
             let left_heap_idx = 2 * heap_idx + 1;
@@ -417,14 +416,13 @@ where
         self.result.doc_id = child.last_doc_id();
 
         if let Some(child_result) = child.current() {
-            let drained_metrics = std::mem::take(&mut child_result.metrics);
             let child_ptr: *const RSIndexResult<'index> = child_result;
             // SAFETY: We need a raw pointer to decouple the borrow of the child's
             // result from `&mut self.result`. This is sound because:
             // 1. `self.children[i]` and `self.result` are disjoint fields — no aliasing.
             // 2. The child is owned by `self`, so the 'index data remains valid.
             let child_ref = unsafe { &*child_ptr };
-            self.result.push_borrowed(child_ref, drained_metrics);
+            self.result.push_borrowed(child_ref);
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
+++ b/src/redisearch_rs/rqe_iterators/src/union_trimmed.rs
@@ -246,12 +246,11 @@ where
             match child.read()? {
                 Some(child_result) => {
                     self.result.doc_id = child_result.doc_id;
-                    let drained_metrics = std::mem::take(&mut child_result.metrics);
                     let child_ptr: *const RSIndexResult<'index> = child_result;
                     // SAFETY: child_result and self.result are disjoint fields — no aliasing.
                     // The child is owned by self, so the 'index data remains valid.
                     let child_ref = unsafe { &*child_ptr };
-                    self.result.push_borrowed(child_ref, drained_metrics);
+                    self.result.push_borrowed(child_ref);
                     return Ok(Some(&mut self.result));
                 }
                 None => {

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_common.rs
@@ -1993,40 +1993,23 @@ macro_rules! union_common_tests {
             assert_eq!(union.intersection_sort_weight(true), 1.0);
         }
 
-        /// A full union that rebuilds its aggregate for a document it has
-        /// already built loses the metrics it gathered the first time round.
+        /// A full union that rebuilds its aggregate for a document it has already
+        /// built still reports that document's metrics.
         ///
-        /// Metrics are *moved* into the aggregate, not copied:
-        /// `RSIndexResult::push_borrowed` takes them by value and
-        /// `debug_assert!`s that the caller drained the child first. So
-        /// `reset_aggregate` clearing `metrics` is right for every other caller
-        /// — `read`/`skip_to` only ever build a document they have not built
-        /// before — but `revalidate` can rebuild the one it is already on: a
-        /// sibling moves, another child still holds the minimum, and the
-        /// position does not change. The reset then discards the metrics the
-        /// aggregate owns and the re-drain finds the children already empty.
+        /// `revalidate` is the one caller that can rebuild the document it is
+        /// already on: a sibling moves, another child still holds the minimum, and
+        /// the position does not change. The rebuild resets the aggregate and pushes
+        /// each child again, so whatever it cannot re-derive from the children is
+        /// gone. Metrics used to be exactly that: building an aggregate moved them
+        /// out of the children, so the reset destroyed the only copy and the second
+        /// build found nothing left to take.
         ///
-        /// A KNN child in a hybrid query is the case that bites: the union
-        /// answers `Ok`, still on the same document, with `__vector_score` gone
-        /// from the reply.
-        ///
-        /// Ignored because it fails: this is a pre-existing defect, shared with
-        /// the pre-port C `UI_Revalidate`, which reset and rebuilt the same way.
-        /// The fix belongs with `revalidate` re-deriving the aggregate's
-        /// borrowed entries instead of rebuilding it when the position is
-        /// unchanged; this test is the red half of it.
+        /// A KNN child in a hybrid query was the case that bit: the union answered
+        /// `Ok`, still on the same document, with `__vector_score` gone from the
+        /// reply.
         #[test]
-        // No `cfg_attr(miri, ignore)` alongside, for two reasons. It would expand
-        // to a second `#[ignore]` under `cfg(miri)`, and `unused_attributes` is
-        // denied. And it would not be earning its place: the rebuild moves the
-        // metrics through `MetricsVec::concat`, which is a `ThinVec::append` and
-        // nothing else — `index_result` has no FFI at all. The neighbouring
-        // guards in this file blame `RSYieldableMetric_Concat` for the same code
-        // path; that symbol is a Rust *entrypoint* called from
-        // `hybrid_reader.c`, never called by this crate, so those guards skip
-        // tests miri handles fine.
-        #[ignore = "known defect: revalidate drops aggregate metrics when it rebuilds an unchanged document"]
         fn revalidate_on_an_unchanged_document_keeps_its_metrics() {
+            use index_result::MetricsVec;
             use rqe_iterators::metric::MetricSortedById;
 
             let scored = MetricSortedById::new(vec![100], vec![0.5]);
@@ -2041,11 +2024,9 @@ macro_rules! union_common_tests {
 
             let first = union.read().expect("read failed").expect("doc 100");
             assert_eq!(first.doc_id, 100);
-            assert_eq!(
-                first.metrics.len(),
-                1,
-                "the aggregate gathered the scored child's metric",
-            );
+            let mut before = MetricsVec::new();
+            first.flatten_metrics_into(&mut before);
+            assert_eq!(before.len(), 1, "the scored child contributes one metric");
 
             let mock_ctx = rqe_iterators_test_utils::MockContext::new(0, 0);
             let status = union
@@ -2058,10 +2039,11 @@ macro_rules! union_common_tests {
 
             let current = union.current().expect("still on doc 100");
             assert_eq!(current.doc_id, 100);
+            let mut after = MetricsVec::new();
+            current.flatten_metrics_into(&mut after);
             assert_eq!(
-                current.metrics.len(),
-                1,
-                "the metric must survive a rebuild of the document it was gathered for",
+                after, before,
+                "the rebuild must re-derive the metrics of the document it rebuilt",
             );
         }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/union_flat.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/union_flat.rs
@@ -27,6 +27,41 @@ use rqe_iterators_test_utils::ContractChecker;
 // Implementation-specific tests (read_count assertions differ between Flat and Heap)
 // =============================================================================
 
+/// A quick union reports only the matching child's metrics. It rebuilds its aggregate from
+/// that one child, so a sibling sitting on a different document — holding the metric it
+/// yielded there — contributes nothing. Every child keeps its own metrics now, so what
+/// keeps a stale one out of the reply is the aggregate holding exactly the children that
+/// matched.
+#[test]
+fn quick_mode_reports_only_the_matching_childs_metrics() {
+    use index_result::MetricsVec;
+    use rqe_iterators::metric::MetricSortedById;
+
+    let scored = MetricSortedById::new(vec![100, 300], vec![0.5, 0.9]);
+    let sibling = MetricSortedById::new(vec![200], vec![0.7]);
+    let children: Vec<Box<dyn RQEIterator<'static>>> = vec![Box::new(scored), Box::new(sibling)];
+    let mut union = UnionQuickFlat::new(children);
+
+    let at_100 = union.read().expect("read failed").expect("doc 100");
+    assert_eq!(at_100.doc_id, 100);
+    let mut collected = MetricsVec::new();
+    at_100.flatten_metrics_into(&mut collected);
+    assert_eq!(
+        collected.iter().map(|e| e.value()).collect::<Vec<_>>(),
+        vec![0.5],
+    );
+
+    let at_200 = union.read().expect("read failed").expect("doc 200");
+    assert_eq!(at_200.doc_id, 200);
+    let mut collected = MetricsVec::new();
+    at_200.flatten_metrics_into(&mut collected);
+    assert_eq!(
+        collected.iter().map(|e| e.value()).collect::<Vec<_>>(),
+        vec![0.7],
+        "only the child that matched doc 200 contributes",
+    );
+}
+
 #[test]
 fn reuse_results_optimization_quick_mode() {
     let (children, data) = create_mock_2([3], [2]);

--- a/src/redisearch_rs/top_k/tests/integration/iterator.rs
+++ b/src/redisearch_rs/top_k/tests/integration/iterator.rs
@@ -1101,6 +1101,46 @@ fn batches_trim_deep_results_preserves_child_metrics() {
     );
 }
 
+/// The same one level deeper. A composite child keeps its metrics in *its* children, so
+/// carrying only the child's own node would drop them — an `AS`-yielded distance below an
+/// intersection is exactly this shape.
+#[test]
+fn batches_trim_deep_results_preserves_metrics_from_a_composite_child() {
+    use rqe_iterators::metric::MetricSortedById;
+    use rqe_iterators::{IdList, Intersection};
+
+    // The metric is produced by the intersection's child, not by the intersection.
+    let scored = MetricSortedById::new(vec![1, 2], vec![0.25, 0.25]);
+    let plain = IdList::<true>::with_result(vec![1, 2], RSIndexResult::build_virt().build());
+    let children: Vec<Box<dyn RQEIterator<'static>>> = vec![Box::new(scored), Box::new(plain)];
+    let child = Intersection::new(children, 1.0, false);
+
+    let source = MockScoreSource::new(vec![vec![(1, 0.9), (2, 0.5)]], vec![], |_, _| {
+        BatchStrategy::Continue
+    });
+
+    let mut it = TopKIterator::new(
+        source,
+        Box::new(child) as Box<dyn RQEIterator<'_> + '_>,
+        NonZeroUsize::new(10).unwrap(),
+        asc,
+    )
+    .with_trim_deep_results(true);
+
+    let mut emitted = Vec::new();
+    while let Some(r) = it.read().unwrap() {
+        emitted.push((
+            r.doc_id,
+            r.metrics_ref()
+                .iter()
+                .map(|m| m.value())
+                .collect::<Vec<_>>(),
+        ));
+    }
+
+    assert_eq!(emitted, vec![(2, vec![0.25]), (1, vec![0.25])]);
+}
+
 /// A trimmed result stands in for the source's own scored record, so its numeric
 /// payload must hold the source score — not the zero the metric-only carrier is
 /// built with — for consumers that read the record numerically rather than

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -638,9 +638,14 @@ ResultProcessor *RPScorer_New(const ExtScoringFunctionCtx *funcs,
 
 typedef struct {
   ResultProcessor base;
+
+  // Scratch space for the metrics collected from one result tree. Reused across
+  // documents: resetting keeps the allocation, so steady state costs no allocation.
+  MetricsVec collected;
 } RPMetrics;
 
 static int rpMetricsNext(ResultProcessor *base, SearchResult *res) {
+  RPMetrics *self = (RPMetrics *)base;
   int rc;
 
   rc = base->upstream->Next(base->upstream, res);
@@ -648,7 +653,15 @@ static int rpMetricsNext(ResultProcessor *base, SearchResult *res) {
     return rc;
   }
 
-  MetricsSlice slice = MetricsVec_AsSlice(&SearchResult_GetIndexResult(res)->metrics);
+  // Each node of the result tree keeps the metrics produced there, so collecting a
+  // document's metrics means walking the tree rather than reading its root. Safe here
+  // because this RP sits directly above the iterator RP, while every RP that buffers a
+  // result across an iterator advance sits downstream and has already deep-copied the
+  // tree or dropped the borrow.
+  MetricsVec_Reset(&self->collected);
+  IndexResult_FlattenMetricsInto(SearchResult_GetIndexResult(res), &self->collected);
+
+  MetricsSlice slice = MetricsVec_AsSlice(&self->collected);
   for (size_t i = 0; i < slice.len; i++) {
     RLookup_WriteOwnKey(slice.data[i].key, SearchResult_GetRowDataMut(res), RSValue_NewNumber(slice.data[i].value));
   }
@@ -659,11 +672,15 @@ static int rpMetricsNext(ResultProcessor *base, SearchResult *res) {
 /* Free implementation for RPMetrics */
 static void rpMetricsFree(ResultProcessor *rp) {
   RPMetrics *self = (RPMetrics *)rp;
+  MetricsVec_Free(self->collected);
   rm_free(self);
 }
 
 ResultProcessor *RPMetricsLoader_New() {
   RPMetrics *ret = rm_calloc(1, sizeof(*ret));
+  // First, and not later: a zeroed `MetricsVec` is not a valid empty one, so the field must
+  // never be observably zero — `rpMetricsFree` would hand it to `MetricsVec_Free`.
+  ret->collected = MetricsVec_New();
   ret->base.Next = rpMetricsNext;
   ret->base.Free = rpMetricsFree;
   ret->base.type = RP_METRICS;

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -960,6 +960,59 @@ def test_hybrid_query_with_text_vamana():
     execute_hybrid_query(env, '(@t:other text)=>[KNN 10 @v $vec_param HYBRID_POLICY BATCHES BATCH_SIZE 2]', query_data, 't',
                             hybrid_mode='HYBRID_BATCHES').equal([0])
 
+@skip(cluster=True)
+def test_yielded_distance_is_collected_from_below_an_aggregate():
+    """Every result of an intersection whose vector child yields a distance must carry that
+    distance.
+
+    The distance is produced by the child, not by the intersection, so the metrics loader has
+    to collect the whole result tree rather than just the result handed to it. Reading through
+    a cursor one document at a time adds a resume — and so a revalidation of the iterator
+    tree, which rebuilds the aggregate — between every document.
+
+    The `DEL` plus GC cycle gives revalidation real work to do: the iterators re-seek an index
+    whose blocks moved under them, exactly as in production.
+    """
+    env = Env(protocol=3, moduleArgs='DEFAULT_DIALECT 2 FORK_GC_CLEAN_THRESHOLD 1 '
+                                     'FORK_GC_RUN_INTERVAL 99999999999999999')
+    conn = getConnectionByEnv(env)
+    dim = 2
+    index_size = 20
+    data_type = 'FLOAT32'
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'HNSW', '6', 'TYPE', data_type,
+               'DIM', dim, 'DISTANCE_METRIC', 'L2', 't', 'TEXT').ok()
+    load_vectors_with_texts_into_redis(conn, 'v', dim, index_size, data_type)
+    query_data = create_np_array_typed([0] * dim, data_type)
+
+    # Both clauses match every document, so the intersection keeps two live children and the
+    # vector child's distance stays one level below the result the loader is handed. `dist`
+    # is not loaded: the metrics loader writes it into the row itself.
+    query = '@t:(value) @v:[VECTOR_RANGE 1000000 $vec_param]=>{$YIELD_DISTANCE_AS: dist}'
+    res, cursor = env.cmd('FT.AGGREGATE', 'idx', query, 'PARAMS', 2, 'vec_param',
+                          query_data.tobytes(), 'LOAD', 1, '@__key', 'WITHCURSOR', 'COUNT', 1)
+    env.assertEqual(len(res['results']), 1)
+    first = res['results'][0]['extra_attributes']
+    env.assertContains('dist', first)
+    env.assertNotEqual(cursor, 0, message='the cursor must still have results to read')
+
+    # Delete a matching document other than the one already returned, so the number of rows
+    # still to come is exact whatever order the scan uses.
+    doomed = '2' if first['__key'] == '1' else '1'
+    env.assertEqual(conn.execute_command('DEL', doomed), 1)
+    forceInvokeGC(env)
+
+    read = 0
+    while cursor != 0:
+        res, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
+        for row in res['results']:
+            env.assertContains('dist', row['extra_attributes'],
+                               message=f'result {read} after the resume lost its distance')
+            read += 1
+    # One row consumed before the resume, one document deleted.
+    env.assertEqual(read, index_size - 2)
+
+
 def test_hybrid_query_batches_mode_with_text():
     # Set high GC threshold so to eliminate sanitizer warnings from of false leaks from forks (MOD-6229)
     env = Env(moduleArgs='DEFAULT_DIALECT 2 FORK_GC_CLEAN_THRESHOLD 10000')


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: a composite moves its children's metrics into its own aggregate as it builds it, so the aggregate holds the only copy. `revalidate` is the one caller that can rebuild the document it is already on — a sibling moves, another child still holds the minimum, the position does not change — and the rebuild resets that copy, then finds the children already emptied by the first build.
2. Change: children keep the metrics they produced, and the metrics loader collects the whole result tree per document into a scratch collection it reuses across documents.
3. Outcome: a distance yielded by a vector clause survives a mid-query lock yield. `__vector_score`, or an `AS`-aliased distance, no longer goes missing from the results a cursor returns after resuming. Un-ignores the red test from #10952.

#### Which additional issues this PR fixes

1. #10952

#### Main objects this PR modified

1. `RSIndexResult::push_borrowed` / `push_boxed` — no longer take or drain the child's metrics. Assembling an aggregate stops mutating its children; the raw-pointer decoupling in the composites stays, since `current` still hands out `&mut` and the fields are still disjoint.
2. `rpMetricsNext` (`src/result_processor.c`) — walks the tree via `IndexResult_FlattenMetricsInto` into a reused `MetricsVec`. Safe there because it sits directly above the iterator RP, while every RP that buffers a result across an iterator advance is downstream and has already deep-copied the tree or dropped the borrow.
3. `UnionFlat` / `UnionHeap` / `UnionTrimmed` / `Intersection` and `AggregateResult_AddChild` — lose the `mem::take`. A node's own metrics are still reset per document; what changes is that a rebuild can now re-derive from children that were never consumed.
4. `MetricsVec::concat` and `RSYieldableMetric_Concat` — deleted. With no producer moving metrics, copying is the only operation the API offers, so a drain is not something a future caller can reach for by accident.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.
