### PR TITLE
[MOD-14888] query_eval_ctx: add and bind metric requests

### DIFF
--- a/src/redisearch_rs/c_wrappers/query/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/lib.rs
@@ -12,7 +12,7 @@
 mod query_eval_ctx;
 mod query_node_ref;
 
-pub use query_eval_ctx::QueryEvalContext;
+pub use query_eval_ctx::{MetricRequestId, QueryEvalContext};
 pub use query_node_ref::{QueryNode, QueryNodeMut, QueryNodeRef, WildcardMode};
 
 /// Test-only mocks for the query wrapper types, shared with the `query_eval`

--- a/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
@@ -27,6 +27,33 @@ use search_disk::SearchDiskHandle;
 
 use query_types::scorers::{BuiltInScorer, RequestedScorer};
 
+/// A reservation in the query's metric-request array, as
+/// [`QueryEvalContext::add_metric_request`] hands it out.
+///
+/// Reserving and binding are separate steps because the iterator whose key slot
+/// the request points at does not exist yet at reserve time. That split is what
+/// this type guards: it is neither [`Copy`] nor [`Clone`] and its index is
+/// private, so a reservation can only be bound by the one who made it, and only
+/// once. Binding twice would strand the first handle — unreachable from the
+/// array, and so never freed.
+///
+/// Dropping one unbound is legal and expected: a vector node reserves before it
+/// knows whether the search will yield a distance to bind, and leaves the
+/// request unbound when it does not.
+#[derive(Debug)]
+pub struct MetricRequestId(usize);
+
+impl MetricRequestId {
+    /// Where the reservation sits in
+    /// [`metric_requests`](QueryEvalContext::metric_requests).
+    ///
+    /// Reading the index does not spend the reservation, and no
+    /// [`MetricRequestId`] can be rebuilt from one, so this weakens nothing.
+    pub const fn index(&self) -> usize {
+        self.0
+    }
+}
+
 /// Safe wrapper around [`ffi::QueryEvalCtx`].
 ///
 /// The C `QueryEvalCtx` is the shared mutable state threaded through every
@@ -244,13 +271,13 @@ impl QueryEvalContext {
         self.as_ref().status
     }
 
-    /// Reserve a [`MetricRequest`] for `metric_name`, returning its index in
-    /// the query's metric-request array.
+    /// Reserve a [`MetricRequest`] for `metric_name`, returning the
+    /// [`MetricRequestId`] that binds it.
     ///
     /// The reserved entry has a NULL [`key_handle`](MetricRequest::key_handle)
     /// until [`bind_metric_request_key`](Self::bind_metric_request_key) fills
     /// it in; that is the state the pipeline reads as "the iterator was never
-    /// created". An index stays valid for the whole evaluation: appending only
+    /// created". An id stays valid for the whole evaluation: appending only
     /// ever grows the array past the existing entries.
     ///
     /// `is_internal` is recorded as [`MetricRequest::is_internal`], which keeps
@@ -271,7 +298,7 @@ impl QueryEvalContext {
         &mut self,
         metric_name: *const c_char,
         is_internal: bool,
-    ) -> usize {
+    ) -> MetricRequestId {
         debug_assert!(!metric_name.is_null(), "a metric request must have a name");
 
         let head = self
@@ -305,10 +332,10 @@ impl QueryEvalContext {
         unsafe { *head = grown.cast() };
         // SAFETY: `grown` is the tracked array the append just returned, so its
         // length header is valid — and non-zero, since it holds `request`.
-        unsafe { ffi::array_len_func(grown) as usize - 1 }
+        MetricRequestId(unsafe { ffi::array_len_func(grown) as usize - 1 })
     }
 
-    /// Allocate the key handle of the request reserved at `idx`, pointing at
+    /// Allocate the key handle of the request `id` reserved, pointing at
     /// `key_ptr` — the owning iterator's [`RLookupKey`] slot — and return it so
     /// the caller can hand it back to that iterator.
     ///
@@ -323,8 +350,10 @@ impl QueryEvalContext {
     ///
     /// # Safety
     ///
-    /// 1. `idx` must come from [`add_metric_request`](Self::add_metric_request)
-    ///    on this same context, and must not already have been bound.
+    /// 1. `id` must come from [`add_metric_request`](Self::add_metric_request)
+    ///    on *this* context. Taking it by value is what rules out binding one
+    ///    reservation twice, but a [`MetricRequestId`] records no context, so
+    ///    which one it came from is still the caller's to get right.
     /// 2. `key_ptr` must be non-null and valid for writes until pipeline
     ///    construction has read the request — *not* merely for as long as the
     ///    owning iterator lives. Pipeline construction writes the resolved key
@@ -346,13 +375,14 @@ impl QueryEvalContext {
     ///    [`is_valid`](RLookupKeyHandle::is_valid) through freed memory.
     pub unsafe fn bind_metric_request_key<'a>(
         &mut self,
-        idx: usize,
+        id: MetricRequestId,
         key_ptr: *mut *mut RLookupKey<'a>,
     ) -> *mut RLookupKeyHandle<'a> {
         debug_assert!(
             !key_ptr.is_null(),
             "a bound metric request must have a key slot"
         );
+        let idx = id.index();
 
         let head_slot = self
             .as_mut()
@@ -361,33 +391,20 @@ impl QueryEvalContext {
         // SAFETY: invariant (2) of `new` guarantees `metricRequestsP` points to
         // a live head slot, and (3) gives us exclusive access to it.
         let head = unsafe { *head_slot };
-        // These checks are debug-only, so neither the length read nor the
-        // already-bound read costs anything in a release build.
+        // An id proves a reservation happened, but not that it happened *here*,
+        // so the bounds check stays. Debug-only, so the length read costs
+        // nothing in a release build. An empty list needs no check of its own:
+        // `array_len` reports a null head as length zero rather than reaching
+        // behind it for a header that is not there.
         #[cfg(debug_assertions)]
         {
-            // Checked first: an empty list is a null head with no length
-            // header behind it, so the read below would fault rather than
-            // report the violated contract.
-            assert!(
-                !head.is_null(),
-                "`idx` must come from `add_metric_request` on this context"
-            );
-            // SAFETY: `head` is the tracked array `add_metric_request` grew, so
-            // its length header is valid.
+            // SAFETY: `head` is either null or the tracked array
+            // `add_metric_request` grew, and the length read accepts both.
             let len = unsafe { ffi::array_len_func(head.cast()) } as usize;
             assert!(
                 idx < len,
-                "`idx` must come from `add_metric_request` on this context"
+                "`id` must come from `add_metric_request` on this context"
             );
-            // SAFETY: the assertion above puts `idx` in bounds, so the offset
-            // is in bounds too.
-            let entry = unsafe { head.add(idx) };
-            // Binding twice would overwrite the first handle, which is then
-            // unreachable from the array and so never freed.
-            //
-            // SAFETY: `entry` points at a live, initialised element.
-            let bound = unsafe { (*entry).key_handle };
-            assert!(bound.is_null(), "metric request {idx} was already bound");
         }
 
         // Allocated only once the checks above have passed, so a violated
@@ -424,7 +441,8 @@ impl QueryEvalContext {
 
     /// The metric requests reserved so far, in the order they were reserved.
     ///
-    /// The read side of [`add_metric_request`](Self::add_metric_request).
+    /// The read side of [`add_metric_request`](Self::add_metric_request), which
+    /// [`MetricRequestId::index`] indexes into.
     /// The slice borrows this context for as long as it is held, and every
     /// append takes it exclusively, so none can run while it is alive.
     pub fn metric_requests(&self) -> &[MetricRequest<'_>] {

--- a/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
+++ b/src/redisearch_rs/c_wrappers/query/src/query_eval_ctx.rs
@@ -9,11 +9,14 @@
 
 //! Safe wrapper around [`ffi::QueryEvalCtx`].
 
-use std::{ffi::CStr, ptr::NonNull};
+use std::{
+    ffi::{CStr, c_char},
+    ptr::NonNull,
+};
 
 use c_trie::TermsTrie;
 use query_flags::QEFlags;
-use rlookup::MetricRequest;
+use rlookup::{MetricRequest, RLookupKey, RLookupKeyHandle};
 use rqe_core::DocId;
 use rqe_iterators::{
     IteratorsConfig,
@@ -241,34 +244,198 @@ impl QueryEvalContext {
         self.as_ref().status
     }
 
-    /// Double pointer to the metric-requests array.
+    /// Reserve a [`MetricRequest`] for `metric_name`, returning its index in
+    /// the query's metric-request array.
     ///
-    /// The C side appends entries via `array_ensure_append_1`. Rust callers
-    /// that create vector iterators use this to register score-field metric
-    /// requests.
+    /// The reserved entry has a NULL [`key_handle`](MetricRequest::key_handle)
+    /// until [`bind_metric_request_key`](Self::bind_metric_request_key) fills
+    /// it in; that is the state the pipeline reads as "the iterator was never
+    /// created". An index stays valid for the whole evaluation: appending only
+    /// ever grows the array past the existing entries.
     ///
-    /// Exclusive because appending reallocates, which invalidates any slice
-    /// [`metric_requests`](Self::metric_requests) handed out: taking the two
-    /// borrows apart is what stops a reader from outliving the array it read.
-    pub const fn metric_requests_ptr(&mut self) -> *mut *mut MetricRequest<'_> {
-        self.as_mut().metricRequestsP.cast()
+    /// `is_internal` is recorded as [`MetricRequest::is_internal`], which keeps
+    /// the metric out of the query response.
+    ///
+    /// # Safety
+    ///
+    /// 1. `metric_name` must be non-null and point to a NUL-terminated C string.
+    ///    Pipeline construction takes its length with `strlen` and looks the
+    ///    name up in the schema, without checking either — so a null or
+    ///    unterminated name is a crash or an out-of-bounds read at
+    ///    `FT.SEARCH` / `FT.AGGREGATE` time, far from this call.
+    /// 2. The request stores `metric_name` as a *borrowed* pointer — nothing
+    ///    ever frees it through the array, and the pipeline reads it back long
+    ///    after this call. Its owner (for a vector query, the `VectorQuery`,
+    ///    hence the AST) must outlive the array.
+    pub unsafe fn add_metric_request(
+        &mut self,
+        metric_name: *const c_char,
+        is_internal: bool,
+    ) -> usize {
+        debug_assert!(!metric_name.is_null(), "a metric request must have a name");
+
+        let head = self
+            .as_mut()
+            .metricRequestsP
+            .cast::<*mut MetricRequest<'_>>();
+        let request = MetricRequest {
+            metric_name,
+            key_handle: std::ptr::null_mut(),
+            is_internal,
+        };
+
+        // SAFETY: invariant (2) of `new` guarantees `metricRequestsP` points to
+        // a live head slot, and (3) gives us exclusive access to it.
+        let current = unsafe { *head };
+        // SAFETY: `current` is a tracked array of `MetricRequest`s (null while
+        // the array is still empty, which the callee treats as "allocate"), and
+        // `request` is one live, correctly sized element to copy from.
+        let grown = unsafe {
+            ffi::array_ensure_append_n_func(
+                current.cast(),
+                (&raw const request).cast_mut().cast(),
+                1,
+                size_of::<MetricRequest<'_>>() as u16,
+            )
+        };
+        // The append may reallocate, so the new head goes back through the
+        // double pointer.
+        //
+        // SAFETY: as for the read above.
+        unsafe { *head = grown.cast() };
+        // SAFETY: `grown` is the tracked array the append just returned, so its
+        // length header is valid — and non-zero, since it holds `request`.
+        unsafe { ffi::array_len_func(grown) as usize - 1 }
+    }
+
+    /// Allocate the key handle of the request reserved at `idx`, pointing at
+    /// `key_ptr` — the owning iterator's [`RLookupKey`] slot — and return it so
+    /// the caller can hand it back to that iterator.
+    ///
+    /// The handle is allocated with the *module* allocator, because C frees it
+    /// with `rm_free` when the AST is destroyed. That allocator does not zero,
+    /// so **both** fields are written:
+    /// [`key_ptr`](RLookupKeyHandle::key_ptr) as given, and
+    /// [`is_valid`](RLookupKeyHandle::is_valid) set. The latter is what
+    /// pipeline construction gates the key write on, and the owning iterator
+    /// clears it when freed — leaving it at whatever the allocator returned
+    /// would drop the metric nondeterministically.
+    ///
+    /// # Safety
+    ///
+    /// 1. `idx` must come from [`add_metric_request`](Self::add_metric_request)
+    ///    on this same context, and must not already have been bound.
+    /// 2. `key_ptr` must be non-null and valid for writes until pipeline
+    ///    construction has read the request — *not* merely for as long as the
+    ///    owning iterator lives. Pipeline construction writes the resolved key
+    ///    through it whenever [`is_valid`](RLookupKeyHandle::is_valid) is still
+    ///    set, without checking either pointer, so a null or dangling slot is a
+    ///    bad write at `FT.SEARCH` / `FT.AGGREGATE` time, far from this call.
+    /// 3. The caller must install the returned handle on the iterator that owns
+    ///    `key_ptr` before that iterator can be freed. Clearing
+    ///    [`is_valid`](RLookupKeyHandle::is_valid) is the iterator's job, and it
+    ///    can only do it through a handle it was given: an uninstalled handle
+    ///    keeps the flag set past the death of the slot it points at, which is
+    ///    precondition (2) violated by omission rather than by a bad argument.
+    ///    Reserving and binding are separate calls because the iterator does not
+    ///    exist yet at reserve time — that split is what makes this one easy to
+    ///    miss, so it is stated rather than left to the shape of the API.
+    /// 4. The metric-request array must outlive every iterator holding one of
+    ///    its handles. The handle is freed with the array when the AST is
+    ///    destroyed, and an iterator freed after that would clear
+    ///    [`is_valid`](RLookupKeyHandle::is_valid) through freed memory.
+    pub unsafe fn bind_metric_request_key<'a>(
+        &mut self,
+        idx: usize,
+        key_ptr: *mut *mut RLookupKey<'a>,
+    ) -> *mut RLookupKeyHandle<'a> {
+        debug_assert!(
+            !key_ptr.is_null(),
+            "a bound metric request must have a key slot"
+        );
+
+        let head_slot = self
+            .as_mut()
+            .metricRequestsP
+            .cast::<*mut MetricRequest<'a>>();
+        // SAFETY: invariant (2) of `new` guarantees `metricRequestsP` points to
+        // a live head slot, and (3) gives us exclusive access to it.
+        let head = unsafe { *head_slot };
+        // These checks are debug-only, so neither the length read nor the
+        // already-bound read costs anything in a release build.
+        #[cfg(debug_assertions)]
+        {
+            // Checked first: an empty list is a null head with no length
+            // header behind it, so the read below would fault rather than
+            // report the violated contract.
+            assert!(
+                !head.is_null(),
+                "`idx` must come from `add_metric_request` on this context"
+            );
+            // SAFETY: `head` is the tracked array `add_metric_request` grew, so
+            // its length header is valid.
+            let len = unsafe { ffi::array_len_func(head.cast()) } as usize;
+            assert!(
+                idx < len,
+                "`idx` must come from `add_metric_request` on this context"
+            );
+            // SAFETY: the assertion above puts `idx` in bounds, so the offset
+            // is in bounds too.
+            let entry = unsafe { head.add(idx) };
+            // Binding twice would overwrite the first handle, which is then
+            // unreachable from the array and so never freed.
+            //
+            // SAFETY: `entry` points at a live, initialised element.
+            let bound = unsafe { (*entry).key_handle };
+            assert!(bound.is_null(), "metric request {idx} was already bound");
+        }
+
+        // Allocated only once the checks above have passed, so a violated
+        // contract reports itself instead of leaking the handle on the way out.
+        //
+        // SAFETY: this Redis API function pointer is set once during module
+        // load and never mutated afterwards, so reading it during query
+        // evaluation cannot race.
+        let alloc = unsafe { redis_module::RedisModule_Alloc }.expect("RedisModule_Alloc unset");
+        // SAFETY: the size is non-zero and well within `isize::MAX`.
+        let handle = NonNull::new(unsafe { alloc(size_of::<RLookupKeyHandle<'a>>()) })
+            .expect("RedisModule_Alloc returned NULL")
+            .cast::<RLookupKeyHandle<'a>>()
+            .as_ptr();
+        // SAFETY: `handle` is a fresh, suitably aligned allocation of the right
+        // size, so writing the whole value initialises it — both fields, since
+        // the allocator does not zero.
+        unsafe {
+            handle.write(RLookupKeyHandle {
+                key_ptr,
+                is_valid: true,
+            });
+        }
+
+        // SAFETY: invariant (1) makes `idx` an index of a live element, so the
+        // offset is in bounds.
+        let request = unsafe { head.add(idx) };
+        // SAFETY: `request` points at that live, initialised element, which
+        // nothing else aliases (invariant (3) of `new`).
+        unsafe { (*request).key_handle = handle };
+
+        handle
     }
 
     /// The metric requests reserved so far, in the order they were reserved.
     ///
-    /// The read side of what
-    /// [`metric_requests_ptr`](Self::metric_requests_ptr) is appended through.
-    /// The slice borrows this context for as long as it is held, so no append
-    /// can run while it is alive.
+    /// The read side of [`add_metric_request`](Self::add_metric_request).
+    /// The slice borrows this context for as long as it is held, and every
+    /// append takes it exclusively, so none can run while it is alive.
     pub fn metric_requests(&self) -> &[MetricRequest<'_>] {
-        // SAFETY: invariant (2) of `new`, which also gives the head the
-        // tracked-array shape the length read below depends on.
-        let head = unsafe {
-            *self
-                .as_ref()
-                .metricRequestsP
-                .cast::<*mut MetricRequest<'_>>()
-        };
+        let head_slot = self
+            .as_ref()
+            .metricRequestsP
+            .cast::<*mut MetricRequest<'_>>();
+        // SAFETY: invariant (2) of `new` guarantees `metricRequestsP` points to
+        // a live head slot, and gives the head itself the tracked-array shape
+        // the length read below depends on.
+        let head = unsafe { *head_slot };
         if head.is_null() {
             // The list is a tracked array, whose empty state is a null head
             // with no length header behind it to read.

--- a/src/redisearch_rs/c_wrappers/query/tests/integration/query_eval_ctx/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/tests/integration/query_eval_ctx/mod.rs
@@ -45,12 +45,220 @@ fn status_mutations_are_visible() {
     assert_eq!(ctx.status().code(), query_error::QueryErrorCode::Syntax);
 }
 
-#[test]
-fn metric_requests_ptr_addresses_the_context_field() {
+/// Run `f` against a context, releasing the metric-request array the appends
+/// grow.
+///
+/// The mock owns the head *slot* but not the array behind it — it hands out an
+/// empty (null) head and never grows one — so whatever the appends allocate is
+/// this function's to free rather than its teardown's.
+fn with_metric_requests(f: impl FnOnce(&mut QueryEvalContext)) {
+    /// Releases the array on the way out, whether `f` returns or panics: an
+    /// assertion failure that skipped the release would leave a non-empty head
+    /// for the mock's teardown to assert on mid-unwind, aborting the process
+    /// instead of reporting which assertion failed.
+    struct FreeOnDrop(*mut *mut rlookup::MetricRequest<'static>);
+
+    impl Drop for FreeOnDrop {
+        fn drop(&mut self) {
+            // SAFETY: the head slot outlives this guard (the mock owning it is
+            // dropped later), and whatever the appends left on it is either
+            // null or a tracked array owned by nothing else.
+            unsafe {
+                let head = *self.0;
+                if head.is_null() {
+                    return;
+                }
+                for request in
+                    std::slice::from_raw_parts(head, ffi::array_len_func(head.cast()) as _)
+                {
+                    if !request.key_handle.is_null() {
+                        // Through the same allocator `bind_metric_request_key`
+                        // took the handle from, rather than the shim that
+                        // happens to back it in this build.
+                        let free = redis_module::RedisModule_Free.expect("RedisModule_Free unset");
+                        free(request.key_handle.cast());
+                    }
+                }
+                ffi::array_free(head.cast());
+                // Back to the empty state the mock handed out, so its teardown
+                // does not outlive the array through a dangling head.
+                *self.0 = std::ptr::null_mut();
+            }
+        }
+    }
+
     let mut mock = MockQueryEvalCtx::new();
+    // Declared after `mock` so it runs first, while the head slot is still live.
+    let _free = FreeOnDrop(mock.metric_requests_p());
+
+    // SAFETY: the mock is a valid, exclusively-owned `QueryEvalCtx`.
     let mut ctx = unsafe { QueryEvalContext::new(mock.as_non_null()) };
-    let ptr = ctx.metric_requests_ptr();
-    assert!(std::ptr::eq(ptr, mock.metric_requests_p().cast()));
+    f(&mut ctx);
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (array_ensure_append_n_func)")]
+fn add_metric_request_appends_and_returns_its_index() {
+    let first = c"__v_score";
+    let second = c"__w_score";
+
+    with_metric_requests(|ctx| {
+        // SAFETY: both are static C string literals — non-null,
+        // NUL-terminated, and outliving the array.
+        let (a, b) = unsafe {
+            (
+                ctx.add_metric_request(first.as_ptr(), false),
+                ctx.add_metric_request(second.as_ptr(), true),
+            )
+        };
+        // Indices are handed out in append order and stay valid as the array
+        // grows — a later request never displaces an earlier one.
+        assert_eq!((a, b), (0, 1));
+
+        let requests = ctx.metric_requests();
+        assert_eq!(requests.len(), 2);
+        assert!(std::ptr::eq(requests[0].metric_name, first.as_ptr()));
+        assert!(!requests[0].is_internal);
+        assert!(std::ptr::eq(requests[1].metric_name, second.as_ptr()));
+        assert!(requests[1].is_internal);
+        assert!(
+            requests.iter().all(|r| r.key_handle.is_null()),
+            "a freshly reserved request carries no key handle"
+        );
+    });
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (array_ensure_append_n_func)")]
+fn bind_metric_request_key_fills_in_a_valid_handle() {
+    with_metric_requests(|ctx| {
+        // SAFETY: a static C string literal — non-null, NUL-terminated,
+        // and outliving the array.
+        let idx = unsafe { ctx.add_metric_request(c"__v_score".as_ptr(), false) };
+
+        // Stands in for the key slot inside an iterator; it outlives the
+        // handle, which this test frees before it goes out of scope.
+        let mut key: *mut rlookup::RLookupKey<'_> = std::ptr::null_mut();
+        // SAFETY: `idx` was just reserved on this context and `key` outlives
+        // the handle.
+        let handle = unsafe { ctx.bind_metric_request_key(idx, &mut key) };
+
+        // SAFETY: `handle` is the freshly allocated, fully initialised handle.
+        let handle_ref = unsafe { &*handle };
+        assert!(std::ptr::eq(handle_ref.key_ptr, &mut key));
+        assert!(
+            handle_ref.is_valid,
+            "the pipeline gates the key write on this flag, so it must be set \
+             explicitly — the module allocator does not zero"
+        );
+        // The two pointers carry unrelated key lifetimes, so compare them by
+        // address rather than making the types line up.
+        assert_eq!(ctx.metric_requests()[idx].key_handle.addr(), handle.addr());
+    });
+}
+
+/// The order a vector node actually produces: reserve, evaluate the child
+/// subtree — which reserves and binds requests of its own, reallocating the
+/// array — and only then bind the outer request. So binds arrive out of order,
+/// at a non-zero index, and across a move of the whole array.
+///
+/// The third reservation is the one that matters: it lands with no spare
+/// capacity, so the array is reallocated between the two binds and the head may
+/// move. That makes this the test that would catch a wrong element stride, an
+/// off-by-one in the index, or a head cached across the append — none of which
+/// a bind at index 0 on a one-element array can distinguish.
+#[test]
+#[cfg_attr(miri, ignore = "requires C FFI (array_ensure_append_n_func)")]
+fn binds_survive_the_array_moving_under_them() {
+    with_metric_requests(|ctx| {
+        let mut outer_key: *mut rlookup::RLookupKey<'_> = std::ptr::null_mut();
+        let mut inner_key: *mut rlookup::RLookupKey<'_> = std::ptr::null_mut();
+
+        // SAFETY: static C string literals — non-null, NUL-terminated, and
+        // outliving the array.
+        let (outer, inner) = unsafe {
+            (
+                ctx.add_metric_request(c"__v_score".as_ptr(), false),
+                ctx.add_metric_request(c"__w_score".as_ptr(), false),
+            )
+        };
+
+        // The inner request binds first, as the child subtree finishes first.
+        // SAFETY: `inner` was just reserved on this context, and `inner_key`
+        // outlives the handle.
+        let inner_handle = unsafe { ctx.bind_metric_request_key(inner, &mut inner_key) };
+
+        // A third reservation moves the array out from under the handle just
+        // stored, which is what the bind below has to tolerate.
+        // SAFETY: as for the reservations above.
+        let third = unsafe { ctx.add_metric_request(c"__x_score".as_ptr(), false) };
+        assert_eq!((outer, inner, third), (0, 1, 2));
+
+        // SAFETY: `outer` was reserved on this context and not yet bound, and
+        // `outer_key` outlives the handle.
+        let outer_handle = unsafe { ctx.bind_metric_request_key(outer, &mut outer_key) };
+
+        let requests = ctx.metric_requests();
+        assert_eq!(requests.len(), 3);
+        // The move did not disturb the earlier binding, and the later one
+        // landed on its own entry rather than overwriting a neighbour.
+        assert_eq!(requests[inner].key_handle.addr(), inner_handle.addr());
+        assert_eq!(requests[outer].key_handle.addr(), outer_handle.addr());
+        assert_ne!(inner_handle.addr(), outer_handle.addr());
+        assert!(
+            requests[third].key_handle.is_null(),
+            "a request reserved but never bound keeps a null handle"
+        );
+
+        // Each handle still points at its own key slot: a wrong stride would
+        // have crossed them over while leaving the assertions above intact.
+        // SAFETY: both handles are freshly allocated and fully initialised.
+        unsafe {
+            assert!(std::ptr::eq((*inner_handle).key_ptr, &mut inner_key));
+            assert!(std::ptr::eq((*outer_handle).key_ptr, &mut outer_key));
+        }
+    });
+}
+
+/// Binding twice orphans the first handle — nothing can reach it through the
+/// array afterwards, so nothing frees it. The debug-only assertion is what
+/// turns that silent leak into a located failure, so it is worth a test of its
+/// own.
+#[test]
+#[cfg(debug_assertions)] // the assertion only exists in debug builds
+#[cfg_attr(miri, ignore = "requires C FFI (array_ensure_append_n_func)")]
+#[should_panic(expected = "was already bound")]
+fn binding_a_metric_request_twice_panics() {
+    with_metric_requests(|ctx| {
+        // SAFETY: a static C string literal — non-null, NUL-terminated,
+        // and outliving the array.
+        let idx = unsafe { ctx.add_metric_request(c"__v_score".as_ptr(), false) };
+
+        let mut key: *mut rlookup::RLookupKey<'_> = std::ptr::null_mut();
+        // SAFETY: `idx` was just reserved on this context and `key` outlives
+        // the handle.
+        unsafe { ctx.bind_metric_request_key(idx, &mut key) };
+        // SAFETY: as above, except for the very precondition under test — the
+        // assertion fires before the second bind reaches the array.
+        unsafe { ctx.bind_metric_request_key(idx, &mut key) };
+    });
+}
+
+/// An index that was never reserved has no entry to bind, and on an empty list
+/// there is no length header to bounds-check it against either — so the
+/// assertion has to come before the length read.
+#[test]
+#[cfg(debug_assertions)] // the assertion only exists in debug builds
+#[should_panic(expected = "must come from `add_metric_request`")]
+fn binding_without_reserving_panics() {
+    let mut mock = MockQueryEvalCtx::new();
+    // SAFETY: the mock is a valid, exclusively-owned `QueryEvalCtx`.
+    let mut ctx = unsafe { QueryEvalContext::new(mock.as_non_null()) };
+
+    let mut key: *mut rlookup::RLookupKey<'_> = std::ptr::null_mut();
+    // SAFETY: none — this violates precondition (1) on purpose, and the
+    // assertion fires before anything reads the null head.
+    unsafe { ctx.bind_metric_request_key(0, &mut key) };
 }
 
 #[test]

--- a/src/redisearch_rs/c_wrappers/query/tests/integration/query_eval_ctx/mod.rs
+++ b/src/redisearch_rs/c_wrappers/query/tests/integration/query_eval_ctx/mod.rs
@@ -113,7 +113,7 @@ fn add_metric_request_appends_and_returns_its_index() {
         };
         // Indices are handed out in append order and stay valid as the array
         // grows — a later request never displaces an earlier one.
-        assert_eq!((a, b), (0, 1));
+        assert_eq!((a.index(), b.index()), (0, 1));
 
         let requests = ctx.metric_requests();
         assert_eq!(requests.len(), 2);
@@ -134,14 +134,16 @@ fn bind_metric_request_key_fills_in_a_valid_handle() {
     with_metric_requests(|ctx| {
         // SAFETY: a static C string literal — non-null, NUL-terminated,
         // and outliving the array.
-        let idx = unsafe { ctx.add_metric_request(c"__v_score".as_ptr(), false) };
+        let id = unsafe { ctx.add_metric_request(c"__v_score".as_ptr(), false) };
+        // Kept because binding spends the id, and the entry is read back below.
+        let idx = id.index();
 
         // Stands in for the key slot inside an iterator; it outlives the
         // handle, which this test frees before it goes out of scope.
         let mut key: *mut rlookup::RLookupKey<'_> = std::ptr::null_mut();
-        // SAFETY: `idx` was just reserved on this context and `key` outlives
+        // SAFETY: `id` was just reserved on this context and `key` outlives
         // the handle.
-        let handle = unsafe { ctx.bind_metric_request_key(idx, &mut key) };
+        let handle = unsafe { ctx.bind_metric_request_key(id, &mut key) };
 
         // SAFETY: `handle` is the freshly allocated, fully initialised handle.
         let handle_ref = unsafe { &*handle };
@@ -176,27 +178,30 @@ fn binds_survive_the_array_moving_under_them() {
 
         // SAFETY: static C string literals — non-null, NUL-terminated, and
         // outliving the array.
-        let (outer, inner) = unsafe {
+        let (outer_id, inner_id) = unsafe {
             (
                 ctx.add_metric_request(c"__v_score".as_ptr(), false),
                 ctx.add_metric_request(c"__w_score".as_ptr(), false),
             )
         };
+        // Kept because binding spends the ids, and both entries are read back
+        // below.
+        let (outer, inner) = (outer_id.index(), inner_id.index());
 
         // The inner request binds first, as the child subtree finishes first.
-        // SAFETY: `inner` was just reserved on this context, and `inner_key`
+        // SAFETY: `inner_id` was just reserved on this context, and `inner_key`
         // outlives the handle.
-        let inner_handle = unsafe { ctx.bind_metric_request_key(inner, &mut inner_key) };
+        let inner_handle = unsafe { ctx.bind_metric_request_key(inner_id, &mut inner_key) };
 
         // A third reservation moves the array out from under the handle just
         // stored, which is what the bind below has to tolerate.
         // SAFETY: as for the reservations above.
-        let third = unsafe { ctx.add_metric_request(c"__x_score".as_ptr(), false) };
+        let third = unsafe { ctx.add_metric_request(c"__x_score".as_ptr(), false) }.index();
         assert_eq!((outer, inner, third), (0, 1, 2));
 
-        // SAFETY: `outer` was reserved on this context and not yet bound, and
-        // `outer_key` outlives the handle.
-        let outer_handle = unsafe { ctx.bind_metric_request_key(outer, &mut outer_key) };
+        // SAFETY: `outer_id` was reserved on this context, and `outer_key`
+        // outlives the handle.
+        let outer_handle = unsafe { ctx.bind_metric_request_key(outer_id, &mut outer_key) };
 
         let requests = ctx.metric_requests();
         assert_eq!(requests.len(), 3);
@@ -220,45 +225,63 @@ fn binds_survive_the_array_moving_under_them() {
     });
 }
 
-/// Binding twice orphans the first handle — nothing can reach it through the
-/// array afterwards, so nothing frees it. The debug-only assertion is what
-/// turns that silent leak into a located failure, so it is worth a test of its
-/// own.
+/// A [`MetricRequestId`](query::MetricRequestId) records no context, so binding one against a context
+/// that never reserved it is the half of precondition (1) the type cannot
+/// discharge — and the reason the bounds check outlived the pair of assertions
+/// that taking the id by value replaced.
+///
+/// The empty case, which the bounds check covers on its own because a null head
+/// reads back as length zero.
 #[test]
 #[cfg(debug_assertions)] // the assertion only exists in debug builds
 #[cfg_attr(miri, ignore = "requires C FFI (array_ensure_append_n_func)")]
-#[should_panic(expected = "was already bound")]
-fn binding_a_metric_request_twice_panics() {
-    with_metric_requests(|ctx| {
+#[should_panic(expected = "must come from `add_metric_request`")]
+fn binding_an_id_against_a_context_that_reserved_nothing_panics() {
+    with_metric_requests(|reserved| {
         // SAFETY: a static C string literal — non-null, NUL-terminated,
         // and outliving the array.
-        let idx = unsafe { ctx.add_metric_request(c"__v_score".as_ptr(), false) };
+        let id = unsafe { reserved.add_metric_request(c"__v_score".as_ptr(), false) };
 
-        let mut key: *mut rlookup::RLookupKey<'_> = std::ptr::null_mut();
-        // SAFETY: `idx` was just reserved on this context and `key` outlives
-        // the handle.
-        unsafe { ctx.bind_metric_request_key(idx, &mut key) };
-        // SAFETY: as above, except for the very precondition under test — the
-        // assertion fires before the second bind reaches the array.
-        unsafe { ctx.bind_metric_request_key(idx, &mut key) };
+        with_metric_requests(|empty| {
+            let mut key: *mut rlookup::RLookupKey<'_> = std::ptr::null_mut();
+            // SAFETY: none — `id` was reserved on the other context, which
+            // violates precondition (1) on purpose. The assertion fires before
+            // the offset onto this context's null head is ever formed.
+            unsafe { empty.bind_metric_request_key(id, &mut key) };
+        });
     });
 }
 
-/// An index that was never reserved has no entry to bind, and on an empty list
-/// there is no length header to bounds-check it against either — so the
-/// assertion has to come before the length read.
+/// The non-empty case: a context that *has* reserved, but fewer times than the
+/// id's index. Unguarded, the bind would write its handle past the end of the
+/// array — which is what makes this the pair's other half rather than a
+/// restatement of it.
 #[test]
 #[cfg(debug_assertions)] // the assertion only exists in debug builds
+#[cfg_attr(miri, ignore = "requires C FFI (array_ensure_append_n_func)")]
 #[should_panic(expected = "must come from `add_metric_request`")]
-fn binding_without_reserving_panics() {
-    let mut mock = MockQueryEvalCtx::new();
-    // SAFETY: the mock is a valid, exclusively-owned `QueryEvalCtx`.
-    let mut ctx = unsafe { QueryEvalContext::new(mock.as_non_null()) };
+fn binding_an_id_past_the_end_of_another_context_panics() {
+    with_metric_requests(|longer| {
+        // SAFETY: static C string literals — non-null, NUL-terminated, and
+        // outliving the array.
+        let id = unsafe {
+            let _ = longer.add_metric_request(c"__v_score".as_ptr(), false);
+            longer.add_metric_request(c"__w_score".as_ptr(), false)
+        };
 
-    let mut key: *mut rlookup::RLookupKey<'_> = std::ptr::null_mut();
-    // SAFETY: none — this violates precondition (1) on purpose, and the
-    // assertion fires before anything reads the null head.
-    unsafe { ctx.bind_metric_request_key(0, &mut key) };
+        with_metric_requests(|shorter| {
+            // One reservation against the other context's two, so the id's
+            // index is one past this array's only element.
+            // SAFETY: as above.
+            let _ = unsafe { shorter.add_metric_request(c"__x_score".as_ptr(), false) };
+            assert_eq!(id.index(), shorter.metric_requests().len());
+
+            let mut key: *mut rlookup::RLookupKey<'_> = std::ptr::null_mut();
+            // SAFETY: none — as above, except that here the head is real and
+            // it is the length that rules the index out.
+            unsafe { shorter.bind_metric_request_key(id, &mut key) };
+        });
+    });
 }
 
 #[test]

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -444,7 +444,12 @@ const HEADERS: &[HeaderAllowlist] = &[
     },
     HeaderAllowlist {
         path: "src/util/arr/arr.h",
-        fns: &["array_free", "array_len_func", "array_new_sz"],
+        fns: &[
+            "array_ensure_append_n_func",
+            "array_free",
+            "array_len_func",
+            "array_new_sz",
+        ],
         types: &[],
         vars: &[],
     },


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `QueryEvalContext` handed the metric-request array out as a raw double pointer (`metric_requests_ptr`), so every Rust caller had to re-derive the C append and the key-handle allocation for itself.
2. Change: two typed operations replace it — `add_metric_request` reserves an entry for a metric name and returns its index, and `bind_metric_request_key` allocates the handle pointing at the owning iterator's `RLookupKey` slot.
3. Outcome: internal-only, no user-visible change. It is the prerequisite for evaluating `QN_VECTOR` nodes in Rust (#10904, stacked on this branch), which is the sole consumer.

#### Which additional issues this PR fixes

1. MOD-14888

#### Main objects this PR modified

1. `QueryEvalContext` (`c_wrappers/query`) — the two new operations, replacing `metric_requests_ptr`. Worth a look: the handle is allocated with the *module* allocator because C frees it with `rm_free` in `QAST_Destroy`, and that allocator does not zero — so `is_valid` is written explicitly rather than inherited, since pipeline construction gates the key write on it.
2. `ffi` bindgen allowlist — exposes `array_ensure_append_n_func`, so the array keeps its `arr.h` tracked-array shape instead of being grown by a hand-rolled equivalent.
3. `query` integration tests — reserve/bind ordering and index stability, handle initialisation, and the debug-only contract assertions (binding twice, binding an unreserved index).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
