### PR TITLE
string_utils - add nu_rune_count

### DIFF
--- a/src/redisearch_rs/string_utils/src/lib.rs
+++ b/src/redisearch_rs/string_utils/src/lib.rs
@@ -10,8 +10,9 @@
 //! Shared string utility functions.
 //!
 //! These are pure-Rust replacements for C helpers that were previously
-//! implemented using `libnu` for Unicode operations, plus — in [`libnu`] — the
-//! guards a caller still handing bytes to one of the remaining C helpers needs.
+//! implemented using `libnu` for Unicode operations, plus — in [`libnu`] — a
+//! model of the C decoder's byte walk, including the guards a caller still
+//! handing bytes to one of the remaining C helpers needs.
 
 pub mod libnu;
 pub mod runes;

--- a/src/redisearch_rs/string_utils/src/libnu.rs
+++ b/src/redisearch_rs/string_utils/src/libnu.rs
@@ -16,10 +16,11 @@
 //! string that is not known to be well-formed UTF-8 — a query token, say — has
 //! to keep that read inside its own allocation.
 //!
-//! This module models that read-ahead once, for every caller that needs it:
-//! [`tail_may_overread`] says whether an input can trip it, and
+//! This module models that decoder's walk once, for every caller that needs it:
+//! [`tail_may_overread`] says whether an input can trip the read-ahead,
 //! [`NU_MAX_READAHEAD`] says how many trailing zero bytes a padded copy needs
-//! when it can.
+//! when it can, and [`nu_rune_count`] says how many runes the decoder would
+//! yield.
 
 /// The most bytes the C decoder (`nu_utf8_read`) reads past a multibyte lead
 /// byte. A UTF-8 sequence is at most four bytes, so the decoder touches at most
@@ -64,6 +65,25 @@ pub fn tail_may_overread(bytes: &[u8]) -> bool {
     false
 }
 
+/// How many runes the C decoder (`nu_utf8_read`) would yield for `bytes` —
+/// the count C's `strToRunes` ends up with.
+///
+/// Replays the same walk as [`tail_may_overread`], counting steps instead of
+/// checking for over-read, and so inherits the decoder's lack of validation:
+/// a stray continuation byte in lead position counts as one rune (a two-byte
+/// sequence), and a truncated trailing sequence counts as one rune while the
+/// cursor steps past the end of `bytes`. The point is to predict what C would
+/// count, not what a correct decoder would.
+pub fn nu_rune_count(bytes: &[u8]) -> usize {
+    let mut pos = 0;
+    let mut runes = 0;
+    while pos < bytes.len() {
+        pos += nu_seq_len(bytes[pos]);
+        runes += 1;
+    }
+    runes
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -98,5 +118,27 @@ mod test {
         // The damage is mid-string: the walk resynchronises past it and still
         // lands inside the input, so no over-read is possible.
         assert!(!tail_may_overread(b"\xC3(ab"));
+    }
+
+    #[test]
+    fn rune_count_matches_codepoints_for_well_formed_input() {
+        assert_eq!(nu_rune_count(b""), 0);
+        assert_eq!(nu_rune_count(b"hello"), 5);
+        assert_eq!(nu_rune_count("é".as_bytes()), 1);
+        assert_eq!(nu_rune_count("日本".as_bytes()), 2);
+        // An astral character is one four-byte sequence, hence one rune here —
+        // even though C stores it as a truncated `uint16_t`.
+        assert_eq!(nu_rune_count("ab😀".as_bytes()), 3);
+    }
+
+    #[test]
+    fn rune_count_replays_the_decoder_on_malformed_input() {
+        // A stray continuation byte is read as a two-byte lead, so it swallows
+        // the byte after it rather than counting as one rune of its own.
+        assert_eq!(nu_rune_count(b"\x80a"), 1);
+        // A truncated trailing sequence still counts as one rune, with the
+        // cursor stepping past the end.
+        assert_eq!(nu_rune_count(b"a\xF0"), 2);
+        assert_eq!(nu_rune_count(b"a\xE0\x80"), 2);
     }
 }

--- a/src/redisearch_rs/string_utils/src/libnu.rs
+++ b/src/redisearch_rs/string_utils/src/libnu.rs
@@ -7,7 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Guards for the unbounded read-ahead of the vendored `libnu` UTF-8 decoder.
+//! Models the byte walk of the vendored `libnu` UTF-8 decoder, and the guards
+//! its unbounded read-ahead forces on callers.
 //!
 //! Several C helpers — `strToLowerRunes` and the trie's fuzzy pattern folding
 //! among them — decode their input with `nu_utf8_read` (`deps/libnu/utf8.h`),
@@ -19,8 +20,7 @@
 //! This module models that decoder's walk once, for every caller that needs it:
 //! [`tail_may_overread`] says whether an input can trip the read-ahead,
 //! [`NU_MAX_READAHEAD`] says how many trailing zero bytes a padded copy needs
-//! when it can, and [`nu_rune_count`] says how many runes the decoder would
-//! yield.
+//! when it can, and [`nu_rune_count`] says how many steps that walk takes.
 
 /// The most bytes the C decoder (`nu_utf8_read`) reads past a multibyte lead
 /// byte. A UTF-8 sequence is at most four bytes, so the decoder touches at most
@@ -65,15 +65,20 @@ pub fn tail_may_overread(bytes: &[u8]) -> bool {
     false
 }
 
-/// How many runes the C decoder (`nu_utf8_read`) would yield for `bytes` —
-/// the count C's `strToRunes` ends up with.
+/// How many steps the C decoder (`nu_utf8_read`) takes across `bytes` — the
+/// rune count C's `strToRunes` ends up with, as long as no sequence in `bytes`
+/// decodes to codepoint 0.
 ///
 /// Replays the same walk as [`tail_may_overread`], counting steps instead of
-/// checking for over-read, and so inherits the decoder's lack of validation:
-/// a stray continuation byte in lead position counts as one rune (a two-byte
-/// sequence), and a truncated trailing sequence counts as one rune while the
-/// cursor steps past the end of `bytes`. The point is to predict what C would
-/// count, not what a correct decoder would.
+/// checking for over-read, and so inherits [`nu_seq_len`]'s lack of validation:
+/// a truncated trailing sequence counts as one step, with the cursor stepping
+/// past the end of `bytes`.
+///
+/// C has a second stopping condition this walk cannot see: `strToRunes` decodes
+/// a codepoint per step and stops at the first zero one, which an embedded NUL
+/// byte, an overlong sequence such as `C0 80`, and a zero-padded truncated tail
+/// all produce. For those inputs this over-counts. A caller that must not
+/// over-count has to reject them.
 pub fn nu_rune_count(bytes: &[u8]) -> usize {
     let mut pos = 0;
     let mut runes = 0;
@@ -136,9 +141,19 @@ mod test {
         // A stray continuation byte is read as a two-byte lead, so it swallows
         // the byte after it rather than counting as one rune of its own.
         assert_eq!(nu_rune_count(b"\x80a"), 1);
-        // A truncated trailing sequence still counts as one rune, with the
+        // A truncated trailing sequence still counts as one step, with the
         // cursor stepping past the end.
         assert_eq!(nu_rune_count(b"a\xF0"), 2);
         assert_eq!(nu_rune_count(b"a\xE0\x80"), 2);
+    }
+
+    #[test]
+    fn rune_count_overcounts_a_sequence_decoding_to_zero() {
+        // `C0 80` is an overlong encoding of codepoint 0, which libnu decodes
+        // rather than rejects, so C stops there and reports one rune. This walk
+        // has no codepoint to stop on and keeps stepping.
+        assert_eq!(nu_rune_count(b"a\xC0\x80b"), 3);
+        // Same divergence from an embedded NUL, where C reports two runes.
+        assert_eq!(nu_rune_count(b"ab\0cd"), 5);
     }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `string_utils::libnu` models C's `nu_utf8_read` lead-byte stride walk only for
   its over-read guard, so a caller that needs the *rune count* the same decoder would
   produce has to open-code that stride table itself.
2. Change: expose the walk as `nu_rune_count`, next to `tail_may_overread`, which steps
   identically. It deliberately inherits the decoder's lack of validation, so it predicts
   what C counts rather than what a correct decoder would.
3. Outcome: internal-only — no behavior change and no new callers here. It gives the
   trie RDB serializer's key-length gate a shared model to call instead of a second copy
   of the stride table.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `string_utils::libnu` — new `nu_rune_count`; module doc now covers it alongside
   `tail_may_overread` and `NU_MAX_READAHEAD`.
2. `libnu`'s unit tests — cover well-formed input and the two malformed shapes whose
   counts follow from the missing validation (stray continuation byte, truncated
   trailing sequence).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
