### PR TITLE
Fix linking issues

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2117,7 +2117,6 @@ dependencies = [
  "libc",
  "redis-module",
  "tracing",
- "value",
  "workspace_hack",
 ]
 
@@ -3548,6 +3547,7 @@ dependencies = [
  "query_error",
  "redis-module",
  "redis_mock",
+ "redisearch_rs",
  "value",
  "workspace_hack",
 ]

--- a/src/redisearch_rs/c_entrypoint/value_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+test = false
+
 [lints]
 workspace = true
 
@@ -19,3 +22,4 @@ workspace_hack.workspace = true
 
 [dev-dependencies]
 redis_mock.workspace = true
+redisearch_rs = { workspace = true, features = ["mock_allocator"] }

--- a/src/redisearch_rs/c_entrypoint/value_ffi/tests/array.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/tests/array.rs
@@ -12,9 +12,10 @@ use value_ffi::constructors::RSValue_NewNumber;
 use value_ffi::getters::RSValue_Number_Get;
 use value_ffi::shared::RSValue_DecrRef;
 
-#[unsafe(no_mangle)]
-pub static mut RSDummyContext: *mut redis_module::RedisModuleCtx =
-    redis_mock::globals::redis_module_ctx();
+// Keep the Rust FFI exports needed by the linked C bundle from being stripped.
+extern crate redisearch_rs;
+// Mock or stub the C symbols the bundle needs but the line above does not provide.
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
 #[test]
 fn test_array() {

--- a/src/redisearch_rs/c_entrypoint/value_ffi/tests/map.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/tests/map.rs
@@ -13,9 +13,10 @@ use value_ffi::getters::RSValue_Number_Get;
 use value_ffi::map::*;
 use value_ffi::shared::RSValue_DecrRef;
 
-#[unsafe(no_mangle)]
-pub static mut RSDummyContext: *mut redis_module::RedisModuleCtx =
-    redis_mock::globals::redis_module_ctx();
+// Keep the Rust FFI exports needed by the linked C bundle from being stripped.
+extern crate redisearch_rs;
+// Mock or stub the C symbols the bundle needs but the line above does not provide.
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
 #[test]
 fn test_map() {

--- a/src/redisearch_rs/c_entrypoint/value_ffi/tests/string.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/tests/string.rs
@@ -8,7 +8,6 @@
 */
 
 use libc::size_t;
-use redis_mock::mock_or_stub_missing_redis_c_symbols;
 use std::ffi::{CString, c_char};
 use value::{SharedValue, String, Value};
 use value_ffi::RSValue;
@@ -20,12 +19,10 @@ use value_ffi::getters::{RSValue_String_Get, RSValue_StringPtrLen};
 use value_ffi::setters::{RSValue_SetConstString, RSValue_SetString};
 use value_ffi::util::{into_rs_value, into_shared_value};
 
-mock_or_stub_missing_redis_c_symbols!();
-
-#[allow(non_upper_case_globals)]
-#[unsafe(no_mangle)]
-pub static mut RSDummyContext: *mut redis_module::RedisModuleCtx =
-    redis_mock::globals::redis_module_ctx();
+// Keep the Rust FFI exports needed by the linked C bundle from being stripped.
+extern crate redisearch_rs;
+// Mock or stub the C symbols the bundle needs but the line above does not provide.
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
 /// Allocate a null-terminated C string using the mock Redis allocator.
 ///

--- a/src/redisearch_rs/redis_mock/Cargo.toml
+++ b/src/redisearch_rs/redis_mock/Cargo.toml
@@ -14,7 +14,6 @@ bench = false
 ffi.workspace = true
 global_config.workspace = true
 tracing.workspace = true
-value.workspace = true
 redis-module.workspace = true
 workspace_hack.workspace = true
 libc.workspace = true

--- a/src/redisearch_rs/redis_mock/src/lib.rs
+++ b/src/redisearch_rs/redis_mock/src/lib.rs
@@ -277,12 +277,12 @@ macro_rules! mock_or_stub_missing_redis_c_symbols {
     () => {
         #[unsafe(no_mangle)]
         unsafe extern "C" fn rm_alloc_impl(size: usize) -> *mut std::ffi::c_void {
-            redis_mock::allocator::alloc_shim(size)
+            $crate::allocator::alloc_shim(size)
         }
 
         #[unsafe(no_mangle)]
         unsafe extern "C" fn rm_calloc_impl(nmemb: usize, size: usize) -> *mut std::ffi::c_void {
-            redis_mock::allocator::calloc_shim(nmemb, size)
+            $crate::allocator::calloc_shim(nmemb, size)
         }
 
         #[unsafe(no_mangle)]
@@ -290,12 +290,12 @@ macro_rules! mock_or_stub_missing_redis_c_symbols {
             ptr: *mut std::ffi::c_void,
             size: usize,
         ) -> *mut std::ffi::c_void {
-            redis_mock::allocator::realloc_shim(ptr, size)
+            $crate::allocator::realloc_shim(ptr, size)
         }
 
         #[unsafe(no_mangle)]
         unsafe extern "C" fn rm_free_impl(ptr: *mut std::ffi::c_void) {
-            redis_mock::allocator::free_shim(ptr)
+            $crate::allocator::free_shim(ptr)
         }
 
         #[unsafe(no_mangle)]
@@ -324,7 +324,7 @@ macro_rules! mock_or_stub_missing_redis_c_symbols {
         // Those C symbols are required for the C code to link correctly, but they are never invoked in
         // our tests or benchmarks.
         // They are all SSL-related symbols provided by OpenSSL.
-        ::redis_mock::stub_c_fn! {
+        $crate::stub_c_fn! {
             ERR_clear_error,
             ERR_peek_last_error,
             ERR_reason_error_string,

--- a/src/redisearch_rs/value/Cargo.toml
+++ b/src/redisearch_rs/value/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+test = false
+
 [dependencies]
 c_ffi_utils = { workspace = true }
 cheadergen.workspace = true


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** The Rust test-binary link setup carries several latent problems. `redis_mock` declares a `value` dependency it never uses, and since `redis_mock` is a dev-dependency of most of the workspace, that edge propagates whatever `value` pulls in into test binaries that have no use for it. `mock_or_stub_missing_redis_c_symbols!` hard-codes its own crate name in its expansion, so it only works at call sites where a crate named exactly `redis_mock` is in scope. `value_ffi`'s integration tests hand-roll a `no_mangle RSDummyContext` instead of using the workspace's link-guard convention. And `value` / `value_ffi` build lib-test harnesses with no tests in them.
2. **Change:** Dropped the unused dependency, made the macro hygienic with `$crate`, replaced the ad-hoc `RSDummyContext` definitions with the standard `extern crate redisearch_rs` + `mock_or_stub_missing_redis_c_symbols!()` pair, and disabled the two empty lib-test harnesses.
3. **Outcome:** Internal only — no user-visible behavior changes, and no test coverage is lost (the two disabled harnesses contain no tests). Test binaries now link correctly and predictably whether or not `libredisearch_c_bundle.a` ends up in their link line, which unblocks changes that add dependencies to `value` or otherwise widen which crates pull the C bundle into tests.

#### Which additional issues this PR fixes

1. N/A

#### Main objects this PR modified

1. **`redis_mock` — removed the unused `value` dependency.** `reply/mod.rs` declares a local `mod value`, so `use value::ReplyValue` always resolved to that submodule; nothing in the crate ever referenced the `value` crate. Because `redis_mock` is a dev-dependency almost everywhere, this one line silently widened the dependency closure of most test binaries in the workspace.
2. **`redis_mock::mock_or_stub_missing_redis_c_symbols!` — macro hygiene.** The body hard-coded `redis_mock::allocator::…` and `::redis_mock::stub_c_fn!`. `macro_rules!` is not hygienic for paths, so those resolved at the *call site* and the macro only expanded correctly where that exact crate name happened to be in scope. Now uses `$crate::`, so it also works when imported via `use` or through a renamed dependency.
3. **`value_ffi` integration tests (`array`, `map`, `string`) — use the workspace link-guard convention.** They previously defined `RSDummyContext` themselves to satisfy the linker. They now use the same pair as ~30 other test roots: `extern crate redisearch_rs` keeps the umbrella crate's `#[used]` FFI symbol table alive for C objects that call back into Rust, and `mock_or_stub_missing_redis_c_symbols!()` stubs the OpenSSL and `DocIdMeta_*` symbols the C bundle leaves undefined.
4. **`[lib] test = false` on `value` and `value_ffi`.** Neither has `#[cfg(test)]` modules in `src/`, but a lib-test target compiles the crate's own `extern "C"` exports *directly* into the harness binary rather than linking it as an archive, so every export is retained unconditionally and drags the C bundle in behind it — for a harness with nothing to run. Matches the existing precedent on `redisearch_rs`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes