### PR TITLE
redis_index: remove unused Redis_OpenReader

### DIFF
--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -21,9 +21,7 @@
 #include "indexes.h"
 #include "doc_table.h"
 #include "redismodule.h"
-#include "iterators_ffi.h"
 #include "inverted_index_ffi.h"
-#include "query_term_ffi.h"
 #include "search_disk.h"
 #include "query_error_ffi.h"
 #include "util/misc.h"
@@ -276,19 +274,6 @@ InvertedIndex *Redis_OpenReaderIndex(const RedisSearchCtx *ctx, const RSToken *t
   }
 
   return idx;
-}
-
-QueryIterator *Redis_OpenReader(const RedisSearchCtx *ctx, RSToken *tok, int tok_id, DocTable *dt,
-                                t_fieldMask fieldMask, double weight) {
-
-  InvertedIndex *idx = Redis_OpenReaderIndex(ctx, tok, fieldMask);
-  if (!idx) {
-    return NULL;
-  }
-
-  FieldMaskOrIndex fieldMaskOrIndex = {.mask_tag = FieldMaskOrIndex_Mask, .mask = fieldMask};
-  RSQueryTerm *term = NewQueryTerm(tok, tok_id);
-  return NewInvIndIterator_TermQuery(idx, ctx, fieldMaskOrIndex, term, weight);
 }
 
 int Redis_LegacyDropScanHandler(RedisModuleCtx *ctx, RedisModuleString *kn, void *opaque) {

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -28,12 +28,6 @@ extern "C" {
 InvertedIndex *Redis_OpenReaderIndex(const RedisSearchCtx *ctx, const RSToken *tok,
                                      t_fieldMask fieldMask);
 
-/* Open an inverted index reader on a redis DMA string, for a specific term.
- * If singleWordMode is set to 1, we do not load the skip index, only the score index
- */
-QueryIterator *Redis_OpenReader(const RedisSearchCtx *ctx, RSToken *tok, int tok_id, DocTable *dt,
-                                 t_fieldMask fieldMask, double weight);
-
 InvertedIndex *Redis_OpenInvertedIndex(IndexSpec *spec, const char *term, size_t len,
                                         bool write, bool *outIsNew);
 


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: `Redis_OpenReader` has no callers left — the term-iterator construction it wrapped is now done by its callers directly.
2. Change: Removes the function and its declaration, plus the two includes it was the last user of in `redis_index.c`.
3. Outcome: Internal-only, no user-visible change. Shrinks the C surface that still has to be carried over as `query.c` is ported to Rust.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

1. `Redis_OpenReader` — the dead term-reader entry point of the `redis_index` surface, removed along with the `iterators_ffi` / `query_term_ffi` declarations it was the last consumer of. `Redis_OpenReaderIndex`, the similarly named function that is still in use, is untouched.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes
